### PR TITLE
Add /menu command to SKILL.md; sync CLAUDE.md to current repo structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,13 +15,14 @@
   - `executor.go` — Python subprocess runner; max 4 concurrent, 30s timeout per script
   - `server.go` — HTTP status server (`/status`, `/health` endpoints)
   - `discord.go` — Discord alert notifications
-- `scripts/` — Python strategy scripts called as subprocesses by the scheduler
+- `shared_scripts/` — Python entry-point scripts called by the scheduler
   - `check_strategy.py` — spot strategy signal checker
-  - `check_options.py` / `check_options_ibkr.py` — options signal checkers (Deribit / IBKR)
+  - `check_options.py` — unified options checker (`--platform=deribit|ibkr`)
   - `check_price.py` — price check script
-- `core/` — shared Python data utilities (data_fetcher, storage)
-- `strategies/` — strategy logic imported by check_strategy.py
-- `options/` — IBKR options adapter (`ibkr_adapter.py`, `options_adapter.py`, etc.)
+- `platforms/` — platform-specific adapters (deribit, ibkr, binanceus)
+- `shared_tools/` — shared Python utilities (pricing.py, exchange_base.py, data_fetcher, storage)
+- `shared_strategies/` — shared strategy logic (spot/, options/)
+- `core/`, `strategies/` — legacy; used by backtest via `PYTHONPATH=core:strategies`
 - `backtest/` — backtesting and paper trading scripts; `run_backtest.py` needs `PYTHONPATH=core:strategies`
 - `archive/` — retired/unused modules
 - `SKILL.md` — agent operations guide (setup, deploy, backtest commands)
@@ -33,7 +34,7 @@
 - Mutex `mu sync.RWMutex` guards `state`; RLock for reads, Lock for all mutations
 - Per-strategy loop uses 6 fine-grained lock phases: RLock(read inputs) → Lock(CheckRisk) → no lock(subprocess) → Lock(execute signal) → RLock/no lock/Lock(mark prices) → RLock(status log)
 - Audit lock balance: `grep -n "mu\.\(R\)\?Lock\(\)\|mu\.\(R\)\?Unlock\(\)" scheduler/main.go`
-- `deribit_utils.py` is imported by `check_options.py` — both must be updated together for Deribit API changes
+- Platform adapters loaded via importlib; class discovered by `endswith("ExchangeAdapter")` — all adapter classes must use that suffix
 - State persisted to `scheduler/state.json` (path set in config); survives restarts
 
 ## Build & Deploy

--- a/SKILL.md
+++ b/SKILL.md
@@ -663,6 +663,70 @@ Present the output to the user in a readable format. Highlight any circuit break
 
 ---
 
+## `/menu` Command
+
+When the user says `/menu`, "show menu", "what can I configure", "what's available", or "help me get started", output the following overview directly (no bash command needed):
+
+```
+=== GO-TRADER MENU ===
+
+1. TRADING PLATFORMS
+   • Binance US  — spot trading: BTC, ETH, SOL
+   • Deribit     — options trading: BTC, ETH
+   • IBKR / CME  — options trading: BTC, ETH (CME Micro contracts, Black-Scholes pricing)
+
+2. AVAILABLE STRATEGIES  (30 total)
+   Spot (14):
+     momentum (BTC,ETH,SOL), rsi (BTC,ETH,SOL), macd (BTC,ETH,SOL),
+     volume_weighted (BTC), pairs_spread (BTC/ETH)
+   Deribit Options (8):
+     vol_mean_reversion, momentum_options, protective_puts, covered_calls,
+     wheel, butterfly  — BTC + ETH each
+   IBKR Options (8):
+     same 6 strategies as Deribit — BTC + ETH each
+
+3. ADJUSTABLE SETTINGS  (edit scheduler/config.json, then: sudo systemctl restart go-trader)
+   Global:
+     interval_seconds  — default cycle interval (seconds)
+     state_file        — path to position/trade history file
+     max_drawdown_pct  — portfolio-level circuit breaker
+     notional_cap_usd  — max total notional exposure
+   Per-strategy:
+     capital           — starting capital (USD)
+     max_drawdown_pct  — strategy-level circuit breaker
+     interval_seconds  — per-strategy check frequency (0 = use global)
+     theta_harvest.*   — profit_target_pct, stop_loss_pct, min_dte_close
+   Discord:
+     enabled           — true/false
+     channel_id        — channel for alerts
+     summary_interval  — how often to post summaries
+   Environment (sudo systemctl edit go-trader):
+     DISCORD_BOT_TOKEN, STATUS_AUTH_TOKEN
+     BINANCE_API_KEY, BINANCE_API_SECRET
+
+4. COMMANDS
+   /menu       — this overview
+   /go-trader  — live status dashboard (cycle, prices, PnL, circuit breakers)
+   System:
+     sudo systemctl start|stop|restart go-trader
+     sudo systemctl status go-trader
+     journalctl -u go-trader -n 50 --no-pager
+     curl -s localhost:8099/status | python3 -m json.tool
+
+5. BACKTESTING
+   Spot:
+     PYTHONPATH=core:strategies .venv/bin/python3 backtest/run_backtest.py \
+       --strategy <n> --symbol BTC/USDT --timeframe 1h \
+       --mode single|compare|multi|optimize
+   Options:
+     .venv/bin/python3 backtest/backtest_options.py --underlying BTC --since YYYY-MM-DD --capital 10000
+     .venv/bin/python3 backtest/backtest_theta.py   --underlying BTC --since YYYY-MM-DD --capital 10000
+
+For full details on any section, ask about it or see the relevant section in SKILL.md.
+```
+
+---
+
 ## Adjustable Settings Reference
 
 All settings live in `scheduler/config.json`. After any change, restart the service:


### PR DESCRIPTION
## Summary

- **SKILL.md**: Adds a `/menu` command section that outputs a structured overview of all platforms, strategies, configurable settings, commands, and backtesting options. Triggered when user says `/menu`, "show menu", "what can I configure", "what's available", or "help me get started".
- **CLAUDE.md**: Syncs repo structure to the completed multi-platform restructure — replaces stale `scripts/`/`options/` paths with `shared_scripts/`, `platforms/`, `shared_tools/`, `shared_strategies/`; replaces dead `deribit_utils.py` note with the importlib adapter-suffix pattern.

## Test plan

- [ ] Verify `/menu` section appears between `/go-trader` command and `## Adjustable Settings Reference` in SKILL.md
- [ ] Confirm menu covers all 5 sections: platforms, strategies, settings, commands, backtesting
- [ ] Confirm CLAUDE.md no longer references `scripts/`, `options/`, or `check_options_ibkr.py`