### PR TITLE
feat: add go-trader init interactive config wizard (closes #8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@
   - `executor.go` — Python subprocess runner; max 4 concurrent, 30s timeout per script
   - `server.go` — HTTP status server (`/status`, `/health` endpoints)
   - `discord.go` — Discord alert notifications; `FormatCategorySummary` outputs a monospace code-block table (Strategy/Value/PnL/PnL%) via `writeCatTable`; `fmtComma` handles comma formatting — always pass absolute values (never signed floats)
+  - `init.go` — `go-trader init` interactive wizard; `generateConfig(InitOptions) *Config` is pure/testable; `runInit` orchestrates I/O
+  - `prompt.go` — `Prompter` struct (String/YesNo/Choice/MultiSelect/Float); inject `NewPrompterFromReader(r,w)` for tests
 - `shared_scripts/` — Python entry-point scripts called by the scheduler
   - `check_strategy.py` — spot strategy signal checker
   - `check_options.py` — unified options checker (`--platform=deribit|ibkr`)
@@ -73,3 +75,4 @@
 - Multi-line Go edits with tabs: Edit tool may fail on tab-indented blocks; fallback: `python3 -c "content=open(f).read(); open(f,'w').write(content.replace(old,new,1))"`
 - Smoke test: `./go-trader --once`
 - Run with config: `./go-trader --config scheduler/config.json`
+- Smoke test interactive CLI: `printf "answer1\nanswer2\n" | ./go-trader init`

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -114,6 +114,7 @@ func generateConfig(opts InitOptions) *Config {
 				cfg.Strategies = append(cfg.Strategies, StrategyConfig{
 					ID:              id,
 					Type:            "spot",
+					Platform:        "binanceus",
 					Script:          "shared_scripts/check_strategy.py",
 					Args:            []string{stratID, sym, "1h"},
 					Capital:         opts.SpotCapital,
@@ -131,6 +132,7 @@ func generateConfig(opts InitOptions) *Config {
 				cfg.Strategies = append(cfg.Strategies, StrategyConfig{
 					ID:              id,
 					Type:            "spot",
+					Platform:        "binanceus",
 					Script:          "shared_scripts/check_strategy.py",
 					Args:            []string{"pairs_spread", assetSymbol[a1], "1d", assetSymbol[a2]},
 					Capital:         opts.SpotCapital,
@@ -154,6 +156,7 @@ func generateConfig(opts InitOptions) *Config {
 					cfg.Strategies = append(cfg.Strategies, StrategyConfig{
 						ID:              id,
 						Type:            "options",
+						Platform:        platform,
 						Script:          "shared_scripts/check_options.py",
 						Args:            []string{stratID, assetName, fmt.Sprintf("--platform=%s", platform)},
 						Capital:         opts.OptionsCapital,
@@ -180,6 +183,7 @@ func generateConfig(opts InitOptions) *Config {
 				cfg.Strategies = append(cfg.Strategies, StrategyConfig{
 					ID:              id,
 					Type:            "perps",
+					Platform:        "hyperliquid",
 					Script:          "shared_scripts/check_hyperliquid.py",
 					Args:            []string{strat.ID, assetName, "1h", fmt.Sprintf("--mode=%s", opts.PerpsMode)},
 					Capital:         opts.PerpsCapital,
@@ -411,7 +415,7 @@ func runInit(_ []string) int {
 		fmt.Fprintf(os.Stderr, "Error marshaling config: %v\n", err)
 		return 1
 	}
-	if err := os.WriteFile(outputPath, data, 0644); err != nil {
+	if err := os.WriteFile(outputPath, data, 0600); err != nil {
 		fmt.Fprintf(os.Stderr, "Error writing %s: %v\n", outputPath, err)
 		return 1
 	}

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -1,0 +1,426 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// asset represents a tradeable asset with its exchange symbol.
+type asset struct {
+	Name   string // e.g. "BTC"
+	Symbol string // e.g. "BTC/USDT"
+}
+
+var supportedAssets = []asset{
+	{Name: "BTC", Symbol: "BTC/USDT"},
+	{Name: "ETH", Symbol: "ETH/USDT"},
+	{Name: "SOL", Symbol: "SOL/USDT"},
+}
+
+// stratDef defines a strategy template with its ID, short name for config IDs, and supported assets.
+type stratDef struct {
+	ID        string   // strategy arg used in script invocation
+	ShortName string   // abbreviated name used in config IDs
+	Assets    []string // supported asset names (not currently filtered — handled at generation time)
+}
+
+var spotStrategies = []stratDef{
+	{ID: "sma_crossover", ShortName: "sma", Assets: []string{"BTC", "ETH", "SOL"}},
+	{ID: "ema_crossover", ShortName: "ema", Assets: []string{"BTC", "ETH", "SOL"}},
+	{ID: "momentum", ShortName: "momentum", Assets: []string{"BTC", "ETH", "SOL"}},
+	{ID: "rsi", ShortName: "rsi", Assets: []string{"BTC", "ETH", "SOL"}},
+	{ID: "bollinger_bands", ShortName: "bb", Assets: []string{"BTC", "ETH", "SOL"}},
+	{ID: "macd", ShortName: "macd", Assets: []string{"BTC", "ETH", "SOL"}},
+	{ID: "rsi_sma", ShortName: "rsi-sma", Assets: []string{"BTC", "ETH", "SOL"}},
+	{ID: "rsi_ema", ShortName: "rsi-ema", Assets: []string{"BTC", "ETH", "SOL"}},
+	{ID: "ema_rsi_macd", ShortName: "erm", Assets: []string{"BTC", "ETH", "SOL"}},
+	{ID: "rsi_macd_combo", ShortName: "rmc", Assets: []string{"BTC", "ETH", "SOL"}},
+}
+
+var optionsStrategies = []stratDef{
+	{ID: "vol_mean_reversion", ShortName: "vol", Assets: []string{"BTC", "ETH"}},
+	{ID: "momentum_options", ShortName: "mom", Assets: []string{"BTC", "ETH"}},
+	{ID: "protective_puts", ShortName: "pput", Assets: []string{"BTC", "ETH"}},
+	{ID: "covered_calls", ShortName: "ccall", Assets: []string{"BTC", "ETH"}},
+}
+
+var perpsStrategies = []stratDef{
+	{ID: "momentum", ShortName: "momentum", Assets: []string{"BTC", "ETH", "SOL"}},
+}
+
+// InitOptions captures all user choices from the interactive wizard.
+type InitOptions struct {
+	OutputPath       string
+	Assets           []string // selected asset names, e.g. ["BTC", "ETH"]
+	EnableSpot       bool
+	EnableOptions    bool
+	EnablePerps      bool
+	OptionPlatforms  []string // "deribit", "ibkr", or both
+	PerpsMode        string   // "paper" or "live"
+	SpotStrategies   []string // selected spot strategy IDs
+	IncludePairs     bool
+	OptStrategies    []string // selected options strategy IDs
+	SpotCapital      float64
+	OptionsCapital   float64
+	PerpsCapital     float64
+	SpotDrawdown     float64
+	OptionsDrawdown  float64
+	PerpsDrawdown    float64
+	DiscordEnabled   bool
+	SpotChannelID    string
+	OptionsChannelID string
+}
+
+// generateConfig builds a Config from InitOptions. Pure function, no I/O.
+func generateConfig(opts InitOptions) *Config {
+	cfg := &Config{
+		IntervalSeconds: 3600,
+		LogDir:          "logs",
+		StateFile:       "scheduler/state.json",
+		PortfolioRisk: &PortfolioRiskConfig{
+			MaxDrawdownPct: 25,
+			MaxNotionalUSD: 0,
+		},
+		Discord: DiscordConfig{
+			Enabled: opts.DiscordEnabled,
+			Channels: DiscordChannels{
+				Spot:    opts.SpotChannelID,
+				Options: opts.OptionsChannelID,
+			},
+		},
+		Platforms: make(map[string]*PlatformConfig),
+	}
+
+	// Build asset name → exchange symbol map.
+	assetSymbol := make(map[string]string)
+	for _, a := range supportedAssets {
+		assetSymbol[a.Name] = a.Symbol
+	}
+
+	usesHyperliquid := false
+
+	// Spot strategies.
+	if opts.EnableSpot {
+		for _, stratID := range opts.SpotStrategies {
+			shortName := stratShortName(spotStrategies, stratID)
+			for _, assetName := range opts.Assets {
+				sym := assetSymbol[assetName]
+				if sym == "" {
+					continue
+				}
+				id := shortName + "-" + strings.ToLower(assetName)
+				cfg.Strategies = append(cfg.Strategies, StrategyConfig{
+					ID:              id,
+					Type:            "spot",
+					Script:          "shared_scripts/check_strategy.py",
+					Args:            []string{stratID, sym, "1h"},
+					Capital:         opts.SpotCapital,
+					MaxDrawdownPct:  opts.SpotDrawdown,
+					IntervalSeconds: 3600,
+				})
+			}
+		}
+
+		// Pairs spread — only available with 2+ assets.
+		if opts.IncludePairs && len(opts.Assets) >= 2 {
+			for _, pair := range makePairs(opts.Assets) {
+				a1, a2 := pair[0], pair[1]
+				id := fmt.Sprintf("pairs-%s-%s", strings.ToLower(a1), strings.ToLower(a2))
+				cfg.Strategies = append(cfg.Strategies, StrategyConfig{
+					ID:              id,
+					Type:            "spot",
+					Script:          "shared_scripts/check_strategy.py",
+					Args:            []string{"pairs_spread", assetSymbol[a1], "1d", assetSymbol[a2]},
+					Capital:         opts.SpotCapital,
+					MaxDrawdownPct:  opts.SpotDrawdown,
+					IntervalSeconds: 86400,
+				})
+			}
+		}
+	}
+
+	// Options strategies.
+	if opts.EnableOptions {
+		for _, stratID := range opts.OptStrategies {
+			shortName := stratShortName(optionsStrategies, stratID)
+			for _, platform := range opts.OptionPlatforms {
+				for _, assetName := range opts.Assets {
+					if assetName == "SOL" {
+						continue // options don't support SOL
+					}
+					id := fmt.Sprintf("%s-%s-%s", platform, shortName, strings.ToLower(assetName))
+					cfg.Strategies = append(cfg.Strategies, StrategyConfig{
+						ID:              id,
+						Type:            "options",
+						Script:          "shared_scripts/check_options.py",
+						Args:            []string{stratID, assetName, fmt.Sprintf("--platform=%s", platform)},
+						Capital:         opts.OptionsCapital,
+						MaxDrawdownPct:  opts.OptionsDrawdown,
+						IntervalSeconds: 14400,
+						ThetaHarvest: &ThetaHarvestConfig{
+							Enabled:         true,
+							ProfitTargetPct: 60,
+							StopLossPct:     200,
+							MinDTEClose:     3,
+						},
+					})
+				}
+			}
+		}
+	}
+
+	// Perps strategies (Hyperliquid only).
+	if opts.EnablePerps {
+		usesHyperliquid = true
+		for _, strat := range perpsStrategies {
+			for _, assetName := range opts.Assets {
+				id := fmt.Sprintf("hl-%s-%s", strat.ID, strings.ToLower(assetName))
+				cfg.Strategies = append(cfg.Strategies, StrategyConfig{
+					ID:              id,
+					Type:            "perps",
+					Script:          "shared_scripts/check_hyperliquid.py",
+					Args:            []string{strat.ID, assetName, "1h", fmt.Sprintf("--mode=%s", opts.PerpsMode)},
+					Capital:         opts.PerpsCapital,
+					MaxDrawdownPct:  opts.PerpsDrawdown,
+					IntervalSeconds: 3600,
+				})
+			}
+		}
+	}
+
+	if usesHyperliquid {
+		cfg.Platforms["hyperliquid"] = &PlatformConfig{
+			StateFile: "platforms/hyperliquid/state.json",
+		}
+	}
+
+	return cfg
+}
+
+// stratShortName returns the ShortName for a strategy ID, falling back to the ID itself.
+func stratShortName(strats []stratDef, stratID string) string {
+	for _, s := range strats {
+		if s.ID == stratID {
+			return s.ShortName
+		}
+	}
+	return stratID
+}
+
+// makePairs returns all ordered 2-combinations of the given asset names.
+func makePairs(assets []string) [][2]string {
+	var pairs [][2]string
+	for i := 0; i < len(assets); i++ {
+		for j := i + 1; j < len(assets); j++ {
+			pairs = append(pairs, [2]string{assets[i], assets[j]})
+		}
+	}
+	return pairs
+}
+
+// runInit executes the interactive init wizard. Returns exit code.
+func runInit(_ []string) int {
+	p := NewPrompter()
+
+	fmt.Println()
+	fmt.Println("=== go-trader init ===")
+	fmt.Println("Interactive config setup. Press Enter to accept defaults.")
+	fmt.Println()
+
+	// Step 1: Output path.
+	outputPath := p.String("Output config path", "scheduler/config.json")
+	if _, err := os.Stat(outputPath); err == nil {
+		if !p.YesNo(fmt.Sprintf("  %s already exists. Overwrite?", outputPath), false) {
+			fmt.Println("Aborted.")
+			return 0
+		}
+	}
+
+	// Step 2: Asset selection.
+	assetNames := make([]string, len(supportedAssets))
+	for i, a := range supportedAssets {
+		assetNames[i] = a.Name
+	}
+	assetIdxs := p.MultiSelect("\nSelect assets to trade:", assetNames, true)
+	if len(assetIdxs) == 0 {
+		fmt.Println("No assets selected. Aborted.")
+		return 1
+	}
+	selectedAssets := make([]string, len(assetIdxs))
+	for i, idx := range assetIdxs {
+		selectedAssets[i] = supportedAssets[idx].Name
+	}
+
+	// Step 3: Strategy types.
+	stratTypeNames := []string{"spot", "options", "perps"}
+	stratTypeIdxs := p.MultiSelect("\nSelect strategy types:", stratTypeNames, false)
+	enableSpot, enableOptions, enablePerps := false, false, false
+	for _, idx := range stratTypeIdxs {
+		switch stratTypeNames[idx] {
+		case "spot":
+			enableSpot = true
+		case "options":
+			enableOptions = true
+		case "perps":
+			enablePerps = true
+		}
+	}
+	if !enableSpot && !enableOptions && !enablePerps {
+		fmt.Println("No strategy types selected. Aborted.")
+		return 1
+	}
+
+	// Step 4: Options platform.
+	var optionPlatforms []string
+	if enableOptions {
+		platOptions := []string{"deribit", "ibkr", "both"}
+		platIdx := p.Choice("\nOptions platform:", platOptions, 0)
+		switch platOptions[platIdx] {
+		case "deribit":
+			optionPlatforms = []string{"deribit"}
+		case "ibkr":
+			optionPlatforms = []string{"ibkr"}
+		case "both":
+			optionPlatforms = []string{"deribit", "ibkr"}
+		}
+	}
+
+	// Step 5: Perps mode.
+	perpsMode := "paper"
+	if enablePerps {
+		modeOptions := []string{"paper (safe default)", "live (requires HYPERLIQUID_SECRET_KEY)"}
+		if p.Choice("\nPerps trading mode:", modeOptions, 0) == 1 {
+			perpsMode = "live"
+		}
+	}
+
+	// Step 6: Spot strategy selection.
+	var selectedSpotStrats []string
+	includePairs := false
+	if enableSpot {
+		spotNames := make([]string, len(spotStrategies))
+		for i, s := range spotStrategies {
+			spotNames[i] = s.ID
+		}
+		hasPairsOption := len(selectedAssets) >= 2
+		if hasPairsOption {
+			spotNames = append(spotNames, "pairs_spread")
+		}
+		spotIdxs := p.MultiSelect("\nSelect spot strategies:", spotNames, false)
+		for _, idx := range spotIdxs {
+			if hasPairsOption && idx == len(spotStrategies) {
+				includePairs = true
+			} else if idx < len(spotStrategies) {
+				selectedSpotStrats = append(selectedSpotStrats, spotStrategies[idx].ID)
+			}
+		}
+	}
+
+	// Step 7: Options strategy selection.
+	var selectedOptStrats []string
+	if enableOptions {
+		optNames := make([]string, len(optionsStrategies))
+		for i, s := range optionsStrategies {
+			optNames[i] = s.ID
+		}
+		optIdxs := p.MultiSelect("\nSelect options strategies:", optNames, false)
+		for _, idx := range optIdxs {
+			selectedOptStrats = append(selectedOptStrats, optionsStrategies[idx].ID)
+		}
+	}
+
+	if len(selectedSpotStrats) == 0 && !includePairs && len(selectedOptStrats) == 0 && !enablePerps {
+		fmt.Println("No strategies selected. Aborted.")
+		return 1
+	}
+
+	// Step 8: Capital & risk.
+	fmt.Println("\n--- Capital & Risk ---")
+	spotCapital := 1000.0
+	optionsCapital := 5000.0
+	perpsCapital := 1000.0
+	spotDrawdown := 5.0
+	optionsDrawdown := 10.0
+	perpsDrawdown := 5.0
+
+	if enableSpot || includePairs {
+		spotCapital = p.Float("Spot/pairs capital per strategy ($)", 1000)
+		spotDrawdown = p.Float("Spot max drawdown (%)", 5)
+	}
+	if enableOptions {
+		optionsCapital = p.Float("Options capital per strategy ($)", 5000)
+		optionsDrawdown = p.Float("Options max drawdown (%)", 10)
+	}
+	if enablePerps {
+		perpsCapital = p.Float("Perps capital per strategy ($)", 1000)
+		perpsDrawdown = p.Float("Perps max drawdown (%)", 5)
+	}
+
+	// Step 9: Discord.
+	fmt.Println("\n--- Discord Notifications ---")
+	discordEnabled := p.YesNo("Enable Discord notifications?", false)
+	spotChannelID := ""
+	optionsChannelID := ""
+	if discordEnabled {
+		spotChannelID = p.String("Spot channel ID (leave blank to skip)", "")
+		optionsChannelID = p.String("Options channel ID (leave blank to skip)", "")
+	}
+
+	opts := InitOptions{
+		OutputPath:       outputPath,
+		Assets:           selectedAssets,
+		EnableSpot:       enableSpot,
+		EnableOptions:    enableOptions,
+		EnablePerps:      enablePerps,
+		OptionPlatforms:  optionPlatforms,
+		PerpsMode:        perpsMode,
+		SpotStrategies:   selectedSpotStrats,
+		IncludePairs:     includePairs,
+		OptStrategies:    selectedOptStrats,
+		SpotCapital:      spotCapital,
+		OptionsCapital:   optionsCapital,
+		PerpsCapital:     perpsCapital,
+		SpotDrawdown:     spotDrawdown,
+		OptionsDrawdown:  optionsDrawdown,
+		PerpsDrawdown:    perpsDrawdown,
+		DiscordEnabled:   discordEnabled,
+		SpotChannelID:    spotChannelID,
+		OptionsChannelID: optionsChannelID,
+	}
+
+	cfg := generateConfig(opts)
+
+	// Step 10: Summary + confirm.
+	fmt.Println("\n--- Summary ---")
+	fmt.Printf("Output:     %s\n", outputPath)
+	fmt.Printf("Assets:     %s\n", strings.Join(selectedAssets, ", "))
+	fmt.Printf("Strategies: %d\n", len(cfg.Strategies))
+	for _, s := range cfg.Strategies {
+		fmt.Printf("  - %-35s (%s, $%.0f)\n", s.ID, s.Type, s.Capital)
+	}
+
+	if !p.YesNo("\nWrite config?", true) {
+		fmt.Println("Aborted.")
+		return 0
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling config: %v\n", err)
+		return 1
+	}
+	if err := os.WriteFile(outputPath, data, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing %s: %v\n", outputPath, err)
+		return 1
+	}
+
+	fmt.Printf("\nConfig written to %s\n", outputPath)
+	fmt.Println("Next steps:")
+	if discordEnabled {
+		fmt.Println("  export DISCORD_BOT_TOKEN=<your-token>")
+	}
+	fmt.Printf("  ./go-trader --config %s --once\n", outputPath)
+	return 0
+}

--- a/scheduler/init_test.go
+++ b/scheduler/init_test.go
@@ -1,0 +1,467 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// baseOpts returns an InitOptions suitable as a starting point for tests.
+func baseOpts() InitOptions {
+	return InitOptions{
+		Assets:          []string{"BTC", "ETH"},
+		EnableSpot:      true,
+		EnableOptions:   false,
+		EnablePerps:     false,
+		OptionPlatforms: []string{"deribit"},
+		PerpsMode:       "paper",
+		SpotStrategies:  []string{"momentum"},
+		IncludePairs:    false,
+		OptStrategies:   []string{},
+		SpotCapital:     1000,
+		OptionsCapital:  5000,
+		PerpsCapital:    1000,
+		SpotDrawdown:    5,
+		OptionsDrawdown: 10,
+		PerpsDrawdown:   5,
+	}
+}
+
+func TestGenerateConfig_AllTypes(t *testing.T) {
+	opts := InitOptions{
+		Assets:          []string{"BTC", "ETH", "SOL"},
+		EnableSpot:      true,
+		EnableOptions:   true,
+		EnablePerps:     true,
+		OptionPlatforms: []string{"deribit"},
+		PerpsMode:       "paper",
+		SpotStrategies:  []string{"momentum"},
+		IncludePairs:    true,
+		OptStrategies:   []string{"vol_mean_reversion"},
+		SpotCapital:     1000,
+		OptionsCapital:  5000,
+		PerpsCapital:    1000,
+		SpotDrawdown:    5,
+		OptionsDrawdown: 10,
+		PerpsDrawdown:   5,
+	}
+	cfg := generateConfig(opts)
+
+	// momentum × 3 assets = 3 spot
+	// pairs: (BTC,ETH),(BTC,SOL),(ETH,SOL) = 3 pairs
+	// options deribit × vol × (BTC,ETH) = 2  (SOL skipped)
+	// perps momentum × 3 assets = 3
+	// total = 11
+	if len(cfg.Strategies) != 11 {
+		t.Errorf("expected 11 strategies, got %d", len(cfg.Strategies))
+		for _, s := range cfg.Strategies {
+			t.Logf("  %s (%s)", s.ID, s.Type)
+		}
+	}
+}
+
+func TestGenerateConfig_SingleAsset_NoPairs(t *testing.T) {
+	opts := baseOpts()
+	opts.Assets = []string{"BTC"}
+	opts.IncludePairs = true // should be ignored: < 2 assets
+
+	cfg := generateConfig(opts)
+
+	// momentum × BTC = 1, no pairs
+	if len(cfg.Strategies) != 1 {
+		t.Errorf("expected 1 strategy for single asset, got %d", len(cfg.Strategies))
+	}
+	if cfg.Strategies[0].ID != "momentum-btc" {
+		t.Errorf("expected id momentum-btc, got %s", cfg.Strategies[0].ID)
+	}
+}
+
+func TestGenerateConfig_SpotOnly(t *testing.T) {
+	opts := baseOpts()
+	cfg := generateConfig(opts)
+
+	for _, s := range cfg.Strategies {
+		if s.Type != "spot" {
+			t.Errorf("expected only spot strategies, got %s (%s)", s.ID, s.Type)
+		}
+	}
+}
+
+func TestGenerateConfig_OptionsSinglePlatformDeribit(t *testing.T) {
+	opts := baseOpts()
+	opts.EnableSpot = false
+	opts.EnableOptions = true
+	opts.OptStrategies = []string{"vol_mean_reversion"}
+	opts.OptionPlatforms = []string{"deribit"}
+
+	cfg := generateConfig(opts)
+
+	// deribit × vol × (BTC, ETH) = 2
+	if len(cfg.Strategies) != 2 {
+		t.Errorf("expected 2 options strategies, got %d", len(cfg.Strategies))
+	}
+	for _, s := range cfg.Strategies {
+		if s.Type != "options" {
+			t.Errorf("expected options type, got %s", s.Type)
+		}
+		if s.Script != "shared_scripts/check_options.py" {
+			t.Errorf("expected check_options.py script, got %s", s.Script)
+		}
+		if !strings.HasPrefix(s.ID, "deribit-") {
+			t.Errorf("expected deribit- prefix, got %s", s.ID)
+		}
+	}
+}
+
+func TestGenerateConfig_OptionsBothPlatforms(t *testing.T) {
+	opts := baseOpts()
+	opts.EnableSpot = false
+	opts.EnableOptions = true
+	opts.OptStrategies = []string{"vol_mean_reversion"}
+	opts.OptionPlatforms = []string{"deribit", "ibkr"}
+
+	cfg := generateConfig(opts)
+
+	// 2 platforms × vol × (BTC, ETH) = 4
+	if len(cfg.Strategies) != 4 {
+		t.Errorf("expected 4 options strategies (both platforms), got %d", len(cfg.Strategies))
+	}
+}
+
+func TestGenerateConfig_PerpsLiveMode(t *testing.T) {
+	opts := baseOpts()
+	opts.EnableSpot = false
+	opts.EnablePerps = true
+	opts.PerpsMode = "live"
+
+	cfg := generateConfig(opts)
+
+	for _, s := range cfg.Strategies {
+		if s.Type != "perps" {
+			continue
+		}
+		found := false
+		for _, arg := range s.Args {
+			if arg == "--mode=live" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected --mode=live in args for %s, got %v", s.ID, s.Args)
+		}
+	}
+}
+
+func TestGenerateConfig_PerpsDefaultPaperMode(t *testing.T) {
+	opts := baseOpts()
+	opts.EnableSpot = false
+	opts.EnablePerps = true
+	opts.PerpsMode = "paper"
+
+	cfg := generateConfig(opts)
+
+	for _, s := range cfg.Strategies {
+		if s.Type != "perps" {
+			continue
+		}
+		found := false
+		for _, arg := range s.Args {
+			if arg == "--mode=paper" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected --mode=paper in args for %s, got %v", s.ID, s.Args)
+		}
+	}
+}
+
+func TestGenerateConfig_ThreeAssets_ThreePairs(t *testing.T) {
+	opts := baseOpts()
+	opts.Assets = []string{"BTC", "ETH", "SOL"}
+	opts.SpotStrategies = []string{} // no regular spot
+	opts.IncludePairs = true
+
+	cfg := generateConfig(opts)
+
+	// pairs: (BTC,ETH),(BTC,SOL),(ETH,SOL) = 3
+	if len(cfg.Strategies) != 3 {
+		t.Errorf("expected 3 pairs for 3 assets, got %d", len(cfg.Strategies))
+	}
+	for _, s := range cfg.Strategies {
+		if s.IntervalSeconds != 86400 {
+			t.Errorf("expected pairs interval 86400, got %d for %s", s.IntervalSeconds, s.ID)
+		}
+	}
+}
+
+func TestGenerateConfig_TwoAssets_OnePair(t *testing.T) {
+	opts := baseOpts()
+	opts.SpotStrategies = []string{}
+	opts.IncludePairs = true
+
+	cfg := generateConfig(opts)
+
+	// pairs: (BTC,ETH) = 1
+	if len(cfg.Strategies) != 1 {
+		t.Errorf("expected 1 pair for 2 assets, got %d", len(cfg.Strategies))
+	}
+	if cfg.Strategies[0].ID != "pairs-btc-eth" {
+		t.Errorf("expected pairs-btc-eth, got %s", cfg.Strategies[0].ID)
+	}
+	if cfg.Strategies[0].Args[0] != "pairs_spread" {
+		t.Errorf("expected pairs_spread arg, got %s", cfg.Strategies[0].Args[0])
+	}
+}
+
+func TestGenerateConfig_CustomCapital(t *testing.T) {
+	opts := baseOpts()
+	opts.SpotCapital = 2500
+	opts.SpotDrawdown = 15
+
+	cfg := generateConfig(opts)
+
+	for _, s := range cfg.Strategies {
+		if s.Capital != 2500 {
+			t.Errorf("expected capital=2500 for %s, got %.0f", s.ID, s.Capital)
+		}
+		if s.MaxDrawdownPct != 15 {
+			t.Errorf("expected max_drawdown_pct=15 for %s, got %.0f", s.ID, s.MaxDrawdownPct)
+		}
+	}
+}
+
+func TestGenerateConfig_IDFormat(t *testing.T) {
+	opts := baseOpts()
+	opts.Assets = []string{"BTC"}
+
+	cfg := generateConfig(opts)
+
+	if cfg.Strategies[0].ID != "momentum-btc" {
+		t.Errorf("expected momentum-btc, got %s", cfg.Strategies[0].ID)
+	}
+}
+
+func TestGenerateConfig_SpotScriptAndArgs(t *testing.T) {
+	opts := baseOpts()
+	opts.Assets = []string{"BTC"}
+
+	cfg := generateConfig(opts)
+
+	s := cfg.Strategies[0]
+	if s.Script != "shared_scripts/check_strategy.py" {
+		t.Errorf("expected check_strategy.py, got %s", s.Script)
+	}
+	if len(s.Args) != 3 || s.Args[0] != "momentum" || s.Args[1] != "BTC/USDT" || s.Args[2] != "1h" {
+		t.Errorf("unexpected spot args: %v", s.Args)
+	}
+}
+
+func TestGenerateConfig_HyperliquidPlatformAdded(t *testing.T) {
+	opts := baseOpts()
+	opts.EnablePerps = true
+
+	cfg := generateConfig(opts)
+
+	if _, ok := cfg.Platforms["hyperliquid"]; !ok {
+		t.Error("expected hyperliquid platform config when perps enabled")
+	}
+}
+
+func TestGenerateConfig_NoHyperliquidWithoutPerps(t *testing.T) {
+	opts := baseOpts()
+	opts.EnablePerps = false
+
+	cfg := generateConfig(opts)
+
+	if _, ok := cfg.Platforms["hyperliquid"]; ok {
+		t.Error("expected no hyperliquid platform config when perps disabled")
+	}
+}
+
+func TestGenerateConfig_SOLSkippedForOptions(t *testing.T) {
+	opts := baseOpts()
+	opts.Assets = []string{"BTC", "ETH", "SOL"}
+	opts.EnableSpot = false
+	opts.EnableOptions = true
+	opts.OptStrategies = []string{"vol_mean_reversion"}
+	opts.OptionPlatforms = []string{"deribit"}
+
+	cfg := generateConfig(opts)
+
+	// Only BTC and ETH — SOL skipped
+	if len(cfg.Strategies) != 2 {
+		t.Errorf("expected 2 options strategies (SOL skipped), got %d", len(cfg.Strategies))
+	}
+	for _, s := range cfg.Strategies {
+		if strings.Contains(s.ID, "sol") {
+			t.Errorf("SOL should be skipped for options, got %s", s.ID)
+		}
+		for _, arg := range s.Args {
+			if arg == "SOL" {
+				t.Errorf("SOL should not appear in options args: %v", s.Args)
+			}
+		}
+	}
+}
+
+func TestGenerateConfig_OptionsThetaHarvest(t *testing.T) {
+	opts := baseOpts()
+	opts.EnableSpot = false
+	opts.EnableOptions = true
+	opts.OptStrategies = []string{"vol_mean_reversion"}
+
+	cfg := generateConfig(opts)
+
+	for _, s := range cfg.Strategies {
+		if s.Type != "options" {
+			continue
+		}
+		if s.ThetaHarvest == nil {
+			t.Errorf("expected ThetaHarvest to be set for %s", s.ID)
+			continue
+		}
+		if !s.ThetaHarvest.Enabled {
+			t.Errorf("expected ThetaHarvest.Enabled=true for %s", s.ID)
+		}
+		if s.ThetaHarvest.ProfitTargetPct != 60 {
+			t.Errorf("expected ProfitTargetPct=60 for %s, got %.0f", s.ID, s.ThetaHarvest.ProfitTargetPct)
+		}
+	}
+}
+
+func TestGenerateConfig_PerpsScriptAndArgs(t *testing.T) {
+	opts := baseOpts()
+	opts.EnableSpot = false
+	opts.EnablePerps = true
+	opts.Assets = []string{"BTC"}
+	opts.PerpsMode = "paper"
+
+	cfg := generateConfig(opts)
+
+	if len(cfg.Strategies) != 1 {
+		t.Fatalf("expected 1 perps strategy, got %d", len(cfg.Strategies))
+	}
+	s := cfg.Strategies[0]
+	if s.ID != "hl-momentum-btc" {
+		t.Errorf("expected hl-momentum-btc, got %s", s.ID)
+	}
+	if s.Script != "shared_scripts/check_hyperliquid.py" {
+		t.Errorf("expected check_hyperliquid.py, got %s", s.Script)
+	}
+	if len(s.Args) != 4 || s.Args[0] != "momentum" || s.Args[1] != "BTC" || s.Args[2] != "1h" || s.Args[3] != "--mode=paper" {
+		t.Errorf("unexpected perps args: %v", s.Args)
+	}
+}
+
+func TestGenerateConfig_IntervalDefaults(t *testing.T) {
+	opts := InitOptions{
+		Assets:          []string{"BTC", "ETH"},
+		EnableSpot:      true,
+		EnableOptions:   true,
+		EnablePerps:     true,
+		OptionPlatforms: []string{"deribit"},
+		PerpsMode:       "paper",
+		SpotStrategies:  []string{"momentum"},
+		IncludePairs:    true,
+		OptStrategies:   []string{"vol_mean_reversion"},
+		SpotCapital:     1000,
+		OptionsCapital:  5000,
+		PerpsCapital:    1000,
+		SpotDrawdown:    5,
+		OptionsDrawdown: 10,
+		PerpsDrawdown:   5,
+	}
+	cfg := generateConfig(opts)
+
+	for _, s := range cfg.Strategies {
+		switch s.Type {
+		case "spot":
+			if strings.HasPrefix(s.ID, "pairs-") {
+				if s.IntervalSeconds != 86400 {
+					t.Errorf("expected pairs interval 86400, got %d for %s", s.IntervalSeconds, s.ID)
+				}
+			} else {
+				if s.IntervalSeconds != 3600 {
+					t.Errorf("expected spot interval 3600, got %d for %s", s.IntervalSeconds, s.ID)
+				}
+			}
+		case "options":
+			if s.IntervalSeconds != 14400 {
+				t.Errorf("expected options interval 14400, got %d for %s", s.IntervalSeconds, s.ID)
+			}
+		case "perps":
+			if s.IntervalSeconds != 3600 {
+				t.Errorf("expected perps interval 3600, got %d for %s", s.IntervalSeconds, s.ID)
+			}
+		}
+	}
+}
+
+func TestGenerateConfig_PortfolioRiskDefaults(t *testing.T) {
+	cfg := generateConfig(baseOpts())
+
+	if cfg.PortfolioRisk == nil {
+		t.Fatal("expected PortfolioRisk to be set")
+	}
+	if cfg.PortfolioRisk.MaxDrawdownPct != 25 {
+		t.Errorf("expected MaxDrawdownPct=25, got %.0f", cfg.PortfolioRisk.MaxDrawdownPct)
+	}
+}
+
+func TestGenerateConfig_DiscordEnabled(t *testing.T) {
+	opts := baseOpts()
+	opts.DiscordEnabled = true
+	opts.SpotChannelID = "111222333"
+	opts.OptionsChannelID = "444555666"
+
+	cfg := generateConfig(opts)
+
+	if !cfg.Discord.Enabled {
+		t.Error("expected Discord.Enabled=true")
+	}
+	if cfg.Discord.Channels.Spot != "111222333" {
+		t.Errorf("expected spot channel 111222333, got %s", cfg.Discord.Channels.Spot)
+	}
+	if cfg.Discord.Channels.Options != "444555666" {
+		t.Errorf("expected options channel 444555666, got %s", cfg.Discord.Channels.Options)
+	}
+}
+
+func TestMakePairs(t *testing.T) {
+	pairs := makePairs([]string{"BTC", "ETH", "SOL"})
+	if len(pairs) != 3 {
+		t.Errorf("expected 3 pairs, got %d", len(pairs))
+	}
+	// Verify ordering: (BTC,ETH), (BTC,SOL), (ETH,SOL)
+	expected := [][2]string{{"BTC", "ETH"}, {"BTC", "SOL"}, {"ETH", "SOL"}}
+	for i, pair := range pairs {
+		if pair != expected[i] {
+			t.Errorf("pair[%d]: expected %v, got %v", i, expected[i], pair)
+		}
+	}
+}
+
+func TestMakePairs_TwoAssets(t *testing.T) {
+	pairs := makePairs([]string{"BTC", "ETH"})
+	if len(pairs) != 1 {
+		t.Errorf("expected 1 pair, got %d", len(pairs))
+	}
+}
+
+func TestStratShortName(t *testing.T) {
+	if got := stratShortName(spotStrategies, "momentum"); got != "momentum" {
+		t.Errorf("expected momentum, got %s", got)
+	}
+	if got := stratShortName(spotStrategies, "sma_crossover"); got != "sma" {
+		t.Errorf("expected sma, got %s", got)
+	}
+	if got := stratShortName(optionsStrategies, "vol_mean_reversion"); got != "vol" {
+		t.Errorf("expected vol, got %s", got)
+	}
+	// Unknown strategy falls back to the ID itself.
+	if got := stratShortName(spotStrategies, "unknown_strat"); got != "unknown_strat" {
+		t.Errorf("expected unknown_strat, got %s", got)
+	}
+}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -11,6 +11,10 @@ import (
 )
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "init" {
+		os.Exit(runInit(os.Args[2:]))
+	}
+
 	configPath := flag.String("config", "scheduler/config.json", "Path to config file")
 	once := flag.Bool("once", false, "Run one cycle and exit")
 	flag.Parse()

--- a/scheduler/prompt.go
+++ b/scheduler/prompt.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Prompter wraps an input scanner and output writer for interactive prompts.
+// Inject a custom reader/writer for tests.
+type Prompter struct {
+	scanner *bufio.Scanner
+	out     io.Writer
+}
+
+// NewPrompter creates a Prompter using stdin/stdout.
+func NewPrompter() *Prompter {
+	return &Prompter{
+		scanner: bufio.NewScanner(os.Stdin),
+		out:     os.Stdout,
+	}
+}
+
+// NewPrompterFromReader creates a Prompter with custom reader/writer (for tests).
+func NewPrompterFromReader(r io.Reader, w io.Writer) *Prompter {
+	return &Prompter{
+		scanner: bufio.NewScanner(r),
+		out:     w,
+	}
+}
+
+// String prompts for a string value. Returns defaultVal on empty input.
+func (p *Prompter) String(prompt, defaultVal string) string {
+	if defaultVal != "" {
+		fmt.Fprintf(p.out, "%s [%s]: ", prompt, defaultVal)
+	} else {
+		fmt.Fprintf(p.out, "%s: ", prompt)
+	}
+	if !p.scanner.Scan() {
+		return defaultVal
+	}
+	input := strings.TrimSpace(p.scanner.Text())
+	if input == "" {
+		return defaultVal
+	}
+	return input
+}
+
+// YesNo prompts for a yes/no answer. Returns defaultYes on empty input.
+func (p *Prompter) YesNo(prompt string, defaultYes bool) bool {
+	def := "y/N"
+	if defaultYes {
+		def = "Y/n"
+	}
+	fmt.Fprintf(p.out, "%s [%s]: ", prompt, def)
+	if !p.scanner.Scan() {
+		return defaultYes
+	}
+	input := strings.TrimSpace(strings.ToLower(p.scanner.Text()))
+	if input == "" {
+		return defaultYes
+	}
+	return input == "y" || input == "yes"
+}
+
+// Choice prompts the user to pick one option from a numbered list.
+// Returns the 0-based index of the selection.
+func (p *Prompter) Choice(prompt string, options []string, defaultIdx int) int {
+	fmt.Fprintln(p.out, prompt)
+	for i, opt := range options {
+		marker := " "
+		if i == defaultIdx {
+			marker = "*"
+		}
+		fmt.Fprintf(p.out, "  %s%d) %s\n", marker, i+1, opt)
+	}
+	for {
+		fmt.Fprintf(p.out, "Enter choice [%d]: ", defaultIdx+1)
+		if !p.scanner.Scan() {
+			return defaultIdx
+		}
+		input := strings.TrimSpace(p.scanner.Text())
+		if input == "" {
+			return defaultIdx
+		}
+		n, err := strconv.Atoi(input)
+		if err == nil && n >= 1 && n <= len(options) {
+			return n - 1
+		}
+		fmt.Fprintln(p.out, "  Invalid choice, try again.")
+	}
+}
+
+// MultiSelect prompts the user to pick multiple options from a numbered list.
+// Accepts comma-separated numbers (e.g. "1,3"), "all", or "none".
+// Returns a slice of 0-based indices.
+func (p *Prompter) MultiSelect(prompt string, options []string, defaultAll bool) []int {
+	fmt.Fprintln(p.out, prompt)
+	for i, opt := range options {
+		fmt.Fprintf(p.out, "  %d) %s\n", i+1, opt)
+	}
+	def := "none"
+	if defaultAll {
+		def = "all"
+	}
+	for {
+		fmt.Fprintf(p.out, "Enter comma-separated numbers, \"all\", or \"none\" [%s]: ", def)
+		if !p.scanner.Scan() {
+			return multiSelectDefault(options, defaultAll)
+		}
+		input := strings.TrimSpace(strings.ToLower(p.scanner.Text()))
+		if input == "" {
+			return multiSelectDefault(options, defaultAll)
+		}
+		if input == "all" {
+			all := make([]int, len(options))
+			for i := range options {
+				all[i] = i
+			}
+			return all
+		}
+		if input == "none" {
+			return []int{}
+		}
+		parts := strings.Split(input, ",")
+		var result []int
+		valid := true
+		for _, part := range parts {
+			n, err := strconv.Atoi(strings.TrimSpace(part))
+			if err != nil || n < 1 || n > len(options) {
+				fmt.Fprintf(p.out, "  Invalid selection %q, try again.\n", strings.TrimSpace(part))
+				valid = false
+				break
+			}
+			result = append(result, n-1)
+		}
+		if valid && len(result) > 0 {
+			return result
+		}
+		if valid {
+			fmt.Fprintln(p.out, "  No items selected, try again.")
+		}
+	}
+}
+
+// Float prompts for a float64 value. Returns defaultVal on empty input or parse error.
+func (p *Prompter) Float(prompt string, defaultVal float64) float64 {
+	fmt.Fprintf(p.out, "%s [%.0f]: ", prompt, defaultVal)
+	if !p.scanner.Scan() {
+		return defaultVal
+	}
+	input := strings.TrimSpace(p.scanner.Text())
+	if input == "" {
+		return defaultVal
+	}
+	v, err := strconv.ParseFloat(input, 64)
+	if err != nil {
+		return defaultVal
+	}
+	return v
+}
+
+func multiSelectDefault(options []string, defaultAll bool) []int {
+	if defaultAll {
+		all := make([]int, len(options))
+		for i := range options {
+			all[i] = i
+		}
+		return all
+	}
+	return []int{}
+}


### PR DESCRIPTION
## Summary

- Adds `go-trader init` subcommand: menu-driven wizard that generates a complete `config.json` from user selections (assets, strategy types, platforms, capital/risk, Discord)
- `generateConfig(InitOptions) *Config` is a pure function — no stdin — making it fully unit-testable
- `Prompter` struct in `prompt.go` wraps `bufio.Scanner` with injectable reader/writer for test isolation
- 17 unit tests covering all combinations: single/multi-asset, spot/options/perps, platform selection, live mode, pairs combinatorics, custom capital, ID format, script paths, interval defaults

## New files

| File | Purpose |
|---|---|
| `scheduler/prompt.go` | `Prompter` with String/YesNo/Choice/MultiSelect/Float |
| `scheduler/init.go` | `generateConfig()` + `runInit()` 10-step wizard |
| `scheduler/init_test.go` | 17 tests for `generateConfig` |

## Test plan

- [x] `cd scheduler && go build .` — compiles
- [x] `cd scheduler && go test ./...` — all tests pass
- [ ] `./go-trader init` — run interactively, verify generated config.json
- [ ] `./go-trader --config <generated> --once` — smoke test generated config