### PR TITLE
feat: add go-trader init --json flag for non-interactive config generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@
   - `executor.go` — Python subprocess runner; max 4 concurrent, 30s timeout per script
   - `server.go` — HTTP status server (`/status`, `/health` endpoints)
   - `discord.go` — Discord alert notifications; `FormatCategorySummary` outputs a monospace code-block table (Strategy/Value/PnL/PnL%) via `writeCatTable`; `fmtComma` handles comma formatting — always pass absolute values (never signed floats)
-  - `init.go` — `go-trader init` interactive wizard; `generateConfig(InitOptions) *Config` is pure/testable; `runInit` orchestrates I/O
+  - `init.go` — `go-trader init` interactive wizard + `--json <blob>` non-interactive mode; `generateConfig(InitOptions) *Config` is pure/testable; `runInitFromJSON(jsonStr, outputPath)` for scripted config gen (e.g. from OpenClaw); `runInit` orchestrates I/O
   - `prompt.go` — `Prompter` struct (String/YesNo/Choice/MultiSelect/Float); inject `NewPrompterFromReader(r,w)` for tests
 - `shared_scripts/` — Python entry-point scripts called by the scheduler
   - `check_strategy.py` — spot strategy signal checker
@@ -76,3 +76,4 @@
 - Smoke test: `./go-trader --once`
 - Run with config: `./go-trader --config scheduler/config.json`
 - Smoke test interactive CLI: `printf "answer1\nanswer2\n" | ./go-trader init`
+- Smoke test JSON CLI: `./go-trader init --json '{"assets":["BTC"],"enableSpot":true,"spotStrategies":["sma_crossover"],"spotCapital":1000,"spotDrawdown":10}' --output /tmp/test.json`


### PR DESCRIPTION
## Summary

- Adds `--json <blob>` and `--output <path>` flags to `go-trader init`, enabling non-interactive config generation from OpenClaw (Discord/Telegram) without a TTY
- New `runInitFromJSON` validates required fields, defaults perps mode to `paper`, and writes the config with `0600` permissions
- Interactive wizard (`runInit`) is unchanged — `--json` only activates the new code path
- Closes #11

## Test plan

- [ ] `cd scheduler && /opt/homebrew/bin/go test ./...` passes (5 new tests for `runInitFromJSON`)
- [ ] Smoke test: `./go-trader init --json '{"assets":["BTC"],"enableSpot":true,"spotStrategies":["sma_crossover"],"spotCapital":1000,"spotDrawdown":10}' --output /tmp/test.json && cat /tmp/test.json`
- [ ] Error cases: missing assets, no strategy types, spot with no strategies all return exit code 1
- [ ] Interactive flow still works: `printf "1\n1\n1\n..." | ./go-trader init`