### PR TITLE
feat: add auto-update notifications via Discord

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@
   - `discord.go` — Discord alert notifications; `FormatCategorySummary(cycle, elapsed, strategiesRun, trades, value, prices, tradeDetails, channelStrategies []StrategyConfig, state, channelKey string)` outputs a monospace code-block table via `writeCatTable`; `resolveChannel(channels, platform, stratType)` maps strategy to channel ID; `fmtComma` — always pass absolute values (never signed floats)
   - `init.go` — `go-trader init` interactive wizard + `--json <blob>` non-interactive mode; `generateConfig(InitOptions) *Config` is pure/testable; `runInitFromJSON(jsonStr, outputPath)` for scripted config gen (e.g. from OpenClaw); `runInit` orchestrates I/O
   - `prompt.go` — `Prompter` struct (String/YesNo/Choice/MultiSelect/Float); inject `NewPrompterFromReader(r,w)` for tests
+  - `updater.go` — update checker; `checkForUpdates(cfg, discord, &lastNotifiedHash)` — git fetch, Discord notify, dedup by remote hash; logs `[update]` prefix
 - `shared_scripts/` — Python entry-point scripts called by the scheduler
   - `check_strategy.py` — spot strategy signal checker
   - `check_options.py` — unified options checker (`--platform=deribit|ibkr`)
@@ -51,6 +52,7 @@
 - Fee dispatch: `CalculatePlatformSpotFee(platform, value)` — 0.035% hyperliquid, 0.1% binanceus (replaces bare `CalculateSpotFee` for platform-aware spot/perps trades)
 - State persisted to `scheduler/state.json` (path set in config); per-platform files at `platforms/<name>/state.json`
 - `cfg.Discord.Channels` is `map[string]string` (not a struct); keys: "spot", "options", "hyperliquid", etc. — old `.Spot`/`.Options` field access is invalid
+- `cfg.AutoUpdate` — `"off"` (default), `"daily"` (once/day), `"heartbeat"` (every cycle); handled in main.go loop + startup; uses `dailyCycles = (24*3600)/tickSeconds`
 - Strategy discovery: `shared_strategies/spot/strategies.py --list-json` and `shared_strategies/options/strategies.py --list-json` output JSON arrays of `{"id":..., "description":...}`
 
 ## Build & Deploy

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	StateFile       string                     `json:"state_file"`
 	StatusToken     string                     `json:"-"` // loaded from STATUS_AUTH_TOKEN env var only
 	Discord         DiscordConfig              `json:"discord"`
+	AutoUpdate      string                     `json:"auto_update,omitempty"` // "off", "daily", "heartbeat" (default: "off")
 	Strategies      []StrategyConfig           `json:"strategies"`
 	PortfolioRisk   *PortfolioRiskConfig       `json:"portfolio_risk,omitempty"`
 	Platforms       map[string]*PlatformConfig `json:"platforms,omitempty"`
@@ -77,6 +78,9 @@ func LoadConfig(path string) (*Config, error) {
 	}
 	if cfg.StateFile == "" {
 		cfg.StateFile = "scheduler/state.json"
+	}
+	if cfg.AutoUpdate == "" {
+		cfg.AutoUpdate = "off"
 	}
 
 	// Discord token from env var takes priority over config file.

--- a/scheduler/updater.go
+++ b/scheduler/updater.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// checkForUpdates uses git fetch to check for upstream changes. If new commits are found
+// (and the remote hash differs from lastNotifiedHash), it sends a Discord notification with
+// release notes asking the user to update, then sets *lastNotifiedHash to the new remote hash.
+// Best-effort: errors are logged but never block startup or the main loop.
+// Returns true if updates are available.
+func checkForUpdates(cfg *Config, discord *DiscordNotifier, lastNotifiedHash *string) bool {
+	// Must be a git repo.
+	if err := gitCheck(); err != nil {
+		fmt.Printf("[update] Not a git repo or git unavailable: %v\n", err)
+		return false
+	}
+
+	localHash, err := gitRevParse("HEAD")
+	if err != nil {
+		fmt.Printf("[update] Failed to get local HEAD: %v\n", err)
+		return false
+	}
+
+	if err := runGitFetch(); err != nil {
+		fmt.Printf("[update] git fetch failed: %v\n", err)
+		return false
+	}
+
+	remoteHash, err := gitRevParse("origin/main")
+	if err != nil {
+		fmt.Printf("[update] Failed to get origin/main: %v\n", err)
+		return false
+	}
+
+	if localHash == remoteHash {
+		fmt.Println("[update] Already up to date")
+		return false
+	}
+
+	// Skip notification if we already notified about this exact remote hash.
+	if lastNotifiedHash != nil && *lastNotifiedHash == remoteHash {
+		fmt.Printf("[update] Update available (%s), already notified\n", remoteHash[:8])
+		return true
+	}
+
+	fmt.Printf("[update] Update available: %s → %s\n", localHash[:8], remoteHash[:8])
+
+	commitLog, _ := gitLog("HEAD", "origin/main")
+	newTag, _ := gitDescribeExact("origin/main")
+	goChanged, _ := gitDiffHasFiles("HEAD", "origin/main", "scheduler/")
+
+	msg := formatUpdateMessage(localHash, remoteHash, commitLog, newTag, goChanged)
+
+	if discord != nil && len(cfg.Discord.Channels) > 0 {
+		seen := make(map[string]bool)
+		for _, ch := range cfg.Discord.Channels {
+			if ch != "" && !seen[ch] {
+				seen[ch] = true
+				if err := discord.SendMessage(ch, msg); err != nil {
+					fmt.Printf("[update] Discord notify failed: %v\n", err)
+				}
+			}
+		}
+	}
+
+	if lastNotifiedHash != nil {
+		*lastNotifiedHash = remoteHash
+	}
+
+	return true
+}
+
+// gitCheck verifies that git is available and the working directory is a git repo.
+func gitCheck() error {
+	_, err := exec.Command("git", "rev-parse", "--git-dir").Output()
+	return err
+}
+
+// gitRevParse returns the full commit hash for the given ref.
+func gitRevParse(ref string) (string, error) {
+	out, err := exec.Command("git", "rev-parse", ref).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// runGitFetch fetches from origin with a 15-second timeout.
+func runGitFetch() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	_, err := exec.CommandContext(ctx, "git", "fetch", "origin").CombinedOutput()
+	return err
+}
+
+// gitLog returns a short one-line log of commits in the range from..to.
+func gitLog(from, to string) (string, error) {
+	out, err := exec.Command("git", "log", "--oneline", from+".."+to).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// gitDescribeExact returns the tag name if the given ref is exactly tagged, empty string otherwise.
+func gitDescribeExact(ref string) (string, error) {
+	out, err := exec.Command("git", "describe", "--tags", "--exact-match", ref).Output()
+	if err != nil {
+		return "", nil // not tagged — normal, not an error
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// gitDiffHasFiles returns true if any files under the given path prefix changed between from and to.
+func gitDiffHasFiles(from, to, prefix string) (bool, error) {
+	out, err := exec.Command("git", "diff", "--name-only", from, to, "--", prefix).Output()
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(out)) != "", nil
+}
+
+// formatUpdateMessage builds the Discord notification message for an available update.
+func formatUpdateMessage(localHash, remoteHash, commitLog, newTag string, goChanged bool) string {
+	var sb strings.Builder
+
+	if newTag != "" {
+		sb.WriteString(fmt.Sprintf("**New Release: %s**\n", newTag))
+	} else {
+		sb.WriteString("**go-trader Update Available**\n")
+	}
+
+	sb.WriteString(fmt.Sprintf("`%s` → `%s`\n", localHash[:8], remoteHash[:8]))
+
+	if commitLog != "" {
+		lines := strings.Split(commitLog, "\n")
+		if len(lines) > 10 {
+			extra := len(lines) - 10
+			lines = lines[:10]
+			lines = append(lines, fmt.Sprintf("... and %d more", extra))
+		}
+		sb.WriteString("```\n")
+		sb.WriteString(strings.Join(lines, "\n"))
+		sb.WriteString("\n```\n")
+	}
+
+	sb.WriteString("To update:\n```\n")
+	sb.WriteString("cd /path/to/go-trader && git pull --ff-only\n")
+	if goChanged {
+		sb.WriteString("cd scheduler && go build -o ../go-trader . && cd ..\n")
+	}
+	sb.WriteString("systemctl restart go-trader\n```")
+
+	return sb.String()
+}


### PR DESCRIPTION
## Summary

- Adds optional update checking (`auto_update`: `off` / `daily` / `heartbeat`) to the scheduler
- On startup and each qualifying cycle, runs `git fetch` and compares local HEAD to `origin/main`
- When new commits are found, posts a Discord message to all active channels with commit log and update instructions — notify only, does **not** auto-apply changes
- Deduplicates notifications: won't re-notify for the same remote hash until a newer one appears
- New `go-trader init` Step 10 prompts for auto-update preference

## Files changed

- `scheduler/updater.go` — `checkForUpdates()`, git helpers, `formatUpdateMessage()`
- `scheduler/config.go` — `AutoUpdate` field with `"off"` default
- `scheduler/main.go` — startup check + periodic check in main loop
- `scheduler/init.go` — Step 10 wizard prompt + `InitOptions.AutoUpdate`
- `SKILL.md` — rewritten Step 8d; replace cron/heartbeat instructions with new built-in feature
- `CLAUDE.md` — document `updater.go` and `cfg.AutoUpdate` pattern

## Test plan

- [ ] Build: `cd scheduler && /opt/homebrew/bin/go build .`
- [ ] Smoke test with `--once`: `./go-trader --once` — verify `[update]` log line appears on startup when `auto_update != "off"`
- [ ] Verify `journalctl -u go-trader -f | grep -i "\[update\]"` shows output
- [ ] Init wizard: `printf "\n\n\n\n\n\n\n\n\n\n1\n" | ./go-trader init` — confirm Step 10 auto-update prompt appears and summary shows `Auto-update: daily`
- [ ] Init `--json`: ensure existing JSON blobs without `auto_update` still parse (defaults to `"off"`)