### PR TITLE
feat: interactive Discord DM auto-upgrade with config migration

### DIFF
--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// CurrentConfigVersion is the version embedded in newly generated configs.
+// When the binary starts and cfg.ConfigVersion < CurrentConfigVersion, migration runs.
+const CurrentConfigVersion = 2
+
+// ConfigField describes a config field introduced in a specific version.
+type ConfigField struct {
+	Version     int    // version this field was added
+	JSONPath    string // dot-separated path in the config JSON (e.g. "discord.owner_id")
+	Description string // human-readable description shown to user in DM
+	Default     string // default value (empty string = no default / user must set manually)
+	FieldType   string // "string", "bool", "int", "float"
+}
+
+// configFieldRegistry lists all fields added since v1.
+var configFieldRegistry = []ConfigField{
+	{
+		Version:     2,
+		JSONPath:    "discord.owner_id",
+		Description: "Your Discord user ID (for upgrade DMs and config prompts). Right-click your username in Discord → Copy User ID.",
+		Default:     "",
+		FieldType:   "string",
+	},
+}
+
+// NewFieldsSince returns all ConfigFields added after the given version number.
+func NewFieldsSince(version int) []ConfigField {
+	var fields []ConfigField
+	for _, f := range configFieldRegistry {
+		if f.Version > version {
+			fields = append(fields, f)
+		}
+	}
+	return fields
+}
+
+// MigrateConfig loads the config as a raw JSON map, applies fieldValues at dot-paths,
+// bumps config_version to CurrentConfigVersion, and writes back atomically.
+func MigrateConfig(configPath string, fieldValues map[string]string) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("read config: %w", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("parse config: %w", err)
+	}
+
+	for path, value := range fieldValues {
+		setNestedField(raw, path, value)
+	}
+	raw["config_version"] = CurrentConfigVersion
+
+	newData, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+
+	tmpPath := configPath + ".tmp"
+	if err := os.WriteFile(tmpPath, newData, 0600); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	return os.Rename(tmpPath, configPath)
+}
+
+// setNestedField sets a value at a dot-path in a nested map[string]interface{}.
+func setNestedField(obj map[string]interface{}, path string, value string) {
+	parts := strings.SplitN(path, ".", 2)
+	if len(parts) == 1 {
+		obj[parts[0]] = value
+		return
+	}
+	nested, ok := obj[parts[0]].(map[string]interface{})
+	if !ok {
+		nested = make(map[string]interface{})
+		obj[parts[0]] = nested
+	}
+	setNestedField(nested, parts[1], value)
+}
+
+// runConfigMigrationDM prompts the owner via DM for any new config fields introduced
+// since cfg.ConfigVersion. Falls back to applying defaults silently when DM is unavailable.
+func runConfigMigrationDM(cfg *Config, discord *DiscordNotifier, configPath string) {
+	fields := NewFieldsSince(cfg.ConfigVersion)
+
+	if len(fields) == 0 {
+		// Already at current version — just bump silently.
+		if err := MigrateConfig(configPath, nil); err != nil {
+			fmt.Printf("[migration] Failed to bump config version: %v\n", err)
+		}
+		return
+	}
+
+	values := make(map[string]string)
+
+	if discord == nil || cfg.Discord.OwnerID == "" {
+		// No DM capability — apply defaults and bump version.
+		fmt.Printf("[migration] %d new config field(s) — applying defaults (no Discord DM configured)\n", len(fields))
+		for _, f := range fields {
+			if f.Default != "" {
+				values[f.JSONPath] = f.Default
+			}
+		}
+		if err := MigrateConfig(configPath, values); err != nil {
+			fmt.Printf("[migration] Failed to migrate config: %v\n", err)
+		}
+		return
+	}
+
+	intro := fmt.Sprintf("**go-trader upgraded!** %d new config field(s) to set.", len(fields))
+	if err := discord.SendDM(cfg.Discord.OwnerID, intro); err != nil {
+		fmt.Printf("[migration] Failed to send intro DM: %v\n", err)
+		return
+	}
+
+	for _, f := range fields {
+		defaultHint := "none"
+		if f.Default != "" {
+			defaultHint = f.Default
+		}
+		prompt := fmt.Sprintf("**%s** — %s\nDefault: `%s`\nReply with a value, or `default` to use the default:", f.JSONPath, f.Description, defaultHint)
+		resp, err := discord.AskDM(cfg.Discord.OwnerID, prompt, 10*time.Minute)
+		if err != nil || strings.EqualFold(strings.TrimSpace(resp), "default") || resp == "" {
+			if f.Default != "" {
+				values[f.JSONPath] = f.Default
+			}
+		} else {
+			values[f.JSONPath] = strings.TrimSpace(resp)
+		}
+	}
+
+	if err := MigrateConfig(configPath, values); err != nil {
+		_ = discord.SendDM(cfg.Discord.OwnerID, fmt.Sprintf("**Migration failed**: %v", err))
+		return
+	}
+
+	_ = discord.SendDM(cfg.Discord.OwnerID, "Config updated. Changes take effect next restart.")
+}

--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -1,3 +1,10 @@
 module trading-scheduler
 
 go 1.26.0
+
+require (
+	github.com/bwmarrin/discordgo v0.29.0 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
+	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b // indirect
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
+)

--- a/scheduler/go.sum
+++ b/scheduler/go.sum
@@ -1,0 +1,12 @@
+github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+EgjDno=
+github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8LoP3mpSgBW8BUoxtEdbXg=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
## Summary

- Replace REST-only Discord client with `discordgo` WebSocket session for two-way communication
- When an update is detected, bot DMs owner asking to auto-upgrade; on "yes" runs `git pull`, rebuilds, and restarts via `systemctl` / `syscall.Exec` fallback
- On restart, any new config fields (v2: `discord.owner_id`) are collected interactively via DM before being written back to config atomically
- Init wizard gains an owner ID prompt; generated configs include `config_version: 2`

## Changes

| File | Change |
|------|--------|
| `scheduler/discord.go` | Replace `http.Client` REST with `discordgo.Session`; add `SendDM`, `AskDM`, `Close`, `messageCreate` handler |
| `scheduler/config.go` | Add `DiscordConfig.OwnerID` (`DISCORD_OWNER_ID` env var), `Config.ConfigVersion` |
| `scheduler/config_migration.go` | New: `CurrentConfigVersion=2`, field registry, `MigrateConfig`, `runConfigMigrationDM` |
| `scheduler/updater.go` | `checkForUpdates` takes `mu`+`state`; add `applyUpgrade`, `restartSelf` |
| `scheduler/init.go` | `DiscordOwnerID` in `InitOptions`; owner ID prompt; `ConfigVersion` in `generateConfig` |
| `scheduler/main.go` | Wire new constructor (returns error), remove channels guard, `defer discord.Close`, migration check |
| `scheduler/go.mod` / `go.sum` | Add `github.com/bwmarrin/discordgo v0.29.0` |
| `CLAUDE.md` | Update discord/updater docs, add config_migration.go, fix `go test` directory note |

## Test plan

- [ ] `cd scheduler && /opt/homebrew/bin/go build .` — compiles clean
- [ ] `cd scheduler && /opt/homebrew/bin/go test ./...` — all tests pass
- [ ] Set `discord.owner_id` + `auto_update: "heartbeat"` in config, run `./go-trader --once` — verify gateway connects and `[update]` log lines appear
- [ ] Set `config_version: 0` in config.json, restart — verify bot DMs about new fields (or applies defaults silently when no owner ID)
- [ ] `printf "...\n" | ./go-trader init` — verify owner ID prompt appears in Discord section