### PR TITLE
feat: split Discord summaries per asset (#19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@
 - `scheduler/` — Go scheduler (single `package main`); all .go files compile together
   - `executor.go` — Python subprocess runner; max 4 concurrent, 30s timeout per script
   - `server.go` — HTTP status server (`/status`, `/health` endpoints)
-  - `discord.go` — `discordgo.Session` wrapper for two-way Discord communication; `NewDiscordNotifier(token, ownerID string) (*DiscordNotifier, error)` — opens WebSocket gateway; `SendMessage(channelID, content)` — channel posts; `SendDM(userID, content)` — DM send; `AskDM(userID, question, timeout)` — send + block on reply (returns `ErrDMTimeout`); intents: `discordgo.IntentsDirectMessages`; DM detection: `m.GuildID == ""`; `FormatCategorySummary(...)` outputs monospace code-block table; `fmtComma` — always pass absolute values
+  - `discord.go` — `discordgo.Session` wrapper for two-way Discord communication; `NewDiscordNotifier(token, ownerID string) (*DiscordNotifier, error)` — opens WebSocket gateway; `SendMessage(channelID, content)` — channel posts; `SendDM(userID, content)` — DM send; `AskDM(userID, question, timeout)` — send + block on reply (returns `ErrDMTimeout`); intents: `discordgo.IntentsDirectMessages`; DM detection: `m.GuildID == ""`; `FormatCategorySummary(..., channelKey, asset string)` — `asset` non-empty adds " — BTC" suffix + filters prices line; `extractAsset(sc)` uses `Args[1]` as canonical asset source (strips `/USDT` for spot); `groupByAsset(strats)` groups by asset with BTC/ETH/SOL/BNB-first sort; `channelTradeDetails` keyed as `ch+"|"+asset`; `fmtComma` — always pass absolute values
   - `init.go` — `go-trader init` interactive wizard + `--json <blob>` non-interactive mode; `generateConfig(InitOptions) *Config` is pure/testable; `runInitFromJSON(jsonStr, outputPath)` for scripted config gen (e.g. from OpenClaw); `runInit` orchestrates I/O
   - `prompt.go` — `Prompter` struct (String/YesNo/Choice/MultiSelect/Float); inject `NewPrompterFromReader(r,w)` for tests
   - `updater.go` — update checker; `checkForUpdates(cfg, discord, &lastNotifiedHash, &mu, state)` — git fetch, channel notify + DM upgrade prompt (goroutine); `applyUpgrade(discord, ownerID, mu, state, cfg)` — git pull + go build + state save + restart; `restartSelf()` — systemctl → syscall.Exec fallback; logs `[update]` prefix
@@ -79,7 +79,7 @@
 - `cd scheduler && /opt/homebrew/bin/go build .` — compile check
 - `cd scheduler && /opt/homebrew/bin/go test ./...` — run all unit tests (must run from scheduler/ where go.mod lives; repo root has no go.mod)
 - `cd scheduler && /opt/homebrew/bin/gofmt -w <file>.go` — format after editing Go files (`-l *.go` lists all files needing formatting)
-- Multi-line Go edits with tabs: Edit tool may fail on tab-indented blocks; fallback: `python3 -c "content=open(f).read(); open(f,'w').write(content.replace(old,new,1))"`
+- Multi-line Go edits with tabs: Edit tool may fail on tab-indented blocks; use heredoc form (one-liner fails on multi-line strings with quotes): `python3 << 'PYEOF'` / `content=open(f).read()` / `open(f,'w').write(content.replace(old,new,1))` / `PYEOF`
 - Smoke test: `./go-trader --once`
 - Run with config: `./go-trader --config scheduler/config.json`
 - Smoke test interactive CLI: `printf "answer1\nanswer2\n" | ./go-trader init`

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -180,6 +180,7 @@ func isOptionsType(strats []StrategyConfig) bool {
 
 // FormatCategorySummary creates a Discord message for a set of strategies sharing a channel.
 // channelStrategies is pre-filtered by the caller; channelKey is the display label.
+// asset, when non-empty, appends " — <ASSET>" to the title and filters the prices line.
 func FormatCategorySummary(
 	cycle int,
 	elapsed time.Duration,
@@ -191,6 +192,7 @@ func FormatCategorySummary(
 	channelStrategies []StrategyConfig,
 	state *AppState,
 	channelKey string,
+	asset string,
 ) string {
 	var sb strings.Builder
 
@@ -202,25 +204,39 @@ func FormatCategorySummary(
 		icon = "📈"
 	}
 	title := strings.ToUpper(channelKey[:1]) + channelKey[1:]
+	assetSuffix := ""
+	if asset != "" {
+		assetSuffix = " — " + asset
+	}
 	if totalTrades > 0 {
-		sb.WriteString(fmt.Sprintf("%s **%s TRADES**\n", icon, strings.ToUpper(title)))
+		sb.WriteString(fmt.Sprintf("%s **%s TRADES%s**\n", icon, strings.ToUpper(title), assetSuffix))
 	} else {
-		sb.WriteString(fmt.Sprintf("%s **%s Summary**\n", icon, title))
+		sb.WriteString(fmt.Sprintf("%s **%s Summary%s**\n", icon, title, assetSuffix))
 	}
 
 	sb.WriteString(fmt.Sprintf("Cycle #%d | %.1fs\n", cycle, elapsed.Seconds()))
 
-	// Prices inline
-	if len(prices) > 0 {
-		syms := make([]string, 0, len(prices))
-		for s := range prices {
+	// Prices inline — filter to just this asset when asset is specified.
+	displayPrices := prices
+	if asset != "" {
+		displayPrices = make(map[string]float64)
+		for sym, price := range prices {
+			base := strings.ToUpper(strings.SplitN(sym, "/", 2)[0])
+			if base == asset {
+				displayPrices[sym] = price
+			}
+		}
+	}
+	if len(displayPrices) > 0 {
+		syms := make([]string, 0, len(displayPrices))
+		for s := range displayPrices {
 			syms = append(syms, s)
 		}
 		sort.Strings(syms)
 		parts := make([]string, 0, len(syms))
 		for _, sym := range syms {
 			short := strings.TrimSuffix(sym, "/USDT")
-			parts = append(parts, fmt.Sprintf("%s $%.0f", short, prices[sym]))
+			parts = append(parts, fmt.Sprintf("%s $%.0f", short, displayPrices[sym]))
 		}
 		sb.WriteString(strings.Join(parts, " | "))
 		sb.WriteString("\n")
@@ -303,21 +319,47 @@ func extractStrategyName(sc StrategyConfig) string {
 }
 
 func extractAsset(sc StrategyConfig) string {
-	// Extract asset from strategy ID
-	// Examples: "momentum-btc" -> "BTC", "deribit-vol-eth" -> "ETH", "ibkr-wheel-btc" -> "BTC"
-	parts := strings.Split(sc.ID, "-")
-	if len(parts) > 0 {
-		lastPart := strings.ToUpper(parts[len(parts)-1])
-		// Check if it's a known asset
-		if lastPart == "BTC" || lastPart == "ETH" || lastPart == "SOL" {
-			return lastPart
-		}
-	}
-	// For options, try args
-	if sc.Type == "options" && len(sc.Args) > 1 {
-		return strings.ToUpper(sc.Args[1])
+	// Args[1] is the canonical asset source for all strategy types.
+	// Spot uses "BTC/USDT" style symbols; strip the quote currency.
+	if len(sc.Args) > 1 {
+		asset := strings.ToUpper(sc.Args[1])
+		return strings.TrimSuffix(asset, "/USDT")
 	}
 	return ""
+}
+
+// assetSortKey returns a stable sort key so BTC/ETH/SOL/BNB appear first.
+func assetSortKey(asset string) string {
+	switch asset {
+	case "BTC":
+		return "0"
+	case "ETH":
+		return "1"
+	case "SOL":
+		return "2"
+	case "BNB":
+		return "3"
+	default:
+		return "4" + asset
+	}
+}
+
+// groupByAsset groups strategies by asset and returns sorted asset keys.
+// Strategies with no extractable asset are grouped under "".
+func groupByAsset(strats []StrategyConfig) (map[string][]StrategyConfig, []string) {
+	groups := make(map[string][]StrategyConfig)
+	for _, sc := range strats {
+		asset := extractAsset(sc)
+		groups[asset] = append(groups[asset], sc)
+	}
+	keys := make([]string, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return assetSortKey(keys[i]) < assetSortKey(keys[j])
+	})
+	return groups, keys
 }
 
 // fmtComma formats a float as a comma-separated integer string (e.g. 1234567 -> "1,234,567").

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -55,6 +56,92 @@ func TestIsOptionsType(t *testing.T) {
 	}
 	if !isOptionsType(opts) {
 		t.Error("expected true when options present")
+	}
+}
+
+func TestExtractAsset(t *testing.T) {
+	cases := []struct {
+		sc   StrategyConfig
+		want string
+	}{
+		// spot: Args[1] is "BTC/USDT" → strip suffix → "BTC"
+		{StrategyConfig{Type: "spot", Args: []string{"sma_crossover", "BTC/USDT"}}, "BTC"},
+		// options: Args[1] is the underlying symbol
+		{StrategyConfig{Type: "options", Args: []string{"wheel", "ETH", "--platform=deribit"}}, "ETH"},
+		// perps: Args[1] is coin name
+		{StrategyConfig{Type: "perps", Args: []string{"momentum", "SOL", "1h"}}, "SOL"},
+		// perps BNB
+		{StrategyConfig{Type: "perps", Args: []string{"rsi", "BNB", "1h"}}, "BNB"},
+		// empty args → ""
+		{StrategyConfig{Type: "spot", Args: []string{}}, ""},
+		// only one arg → ""
+		{StrategyConfig{Type: "perps", Args: []string{"strategy"}}, ""},
+	}
+	for _, c := range cases {
+		got := extractAsset(c.sc)
+		if got != c.want {
+			t.Errorf("extractAsset(%v) = %q, want %q", c.sc.Args, got, c.want)
+		}
+	}
+}
+
+func TestGroupByAsset(t *testing.T) {
+	strats := []StrategyConfig{
+		{ID: "hl-rsi-eth", Type: "perps", Args: []string{"rsi", "ETH", "1h"}},
+		{ID: "hl-mom-btc", Type: "perps", Args: []string{"momentum", "BTC", "1h"}},
+		{ID: "hl-ema-sol", Type: "perps", Args: []string{"ema", "SOL", "1h"}},
+		{ID: "hl-rsi-bnb", Type: "perps", Args: []string{"rsi", "BNB", "1h"}},
+		{ID: "hl-sma-btc", Type: "perps", Args: []string{"sma", "BTC", "1h"}},
+	}
+	groups, keys := groupByAsset(strats)
+
+	// 4 distinct assets
+	if len(keys) != 4 {
+		t.Fatalf("expected 4 asset keys, got %d: %v", len(keys), keys)
+	}
+	// BTC first, ETH second, SOL third, BNB fourth
+	if keys[0] != "BTC" || keys[1] != "ETH" || keys[2] != "SOL" || keys[3] != "BNB" {
+		t.Errorf("unexpected key order: %v", keys)
+	}
+	// BTC group has 2 strategies
+	if len(groups["BTC"]) != 2 {
+		t.Errorf("expected 2 BTC strategies, got %d", len(groups["BTC"]))
+	}
+
+	// Single asset case
+	single := []StrategyConfig{
+		{ID: "hl-rsi-eth", Type: "perps", Args: []string{"rsi", "ETH", "1h"}},
+	}
+	_, keys2 := groupByAsset(single)
+	if len(keys2) != 1 || keys2[0] != "ETH" {
+		t.Errorf("single asset: expected [ETH], got %v", keys2)
+	}
+}
+
+func TestFormatCategorySummary_WithAsset(t *testing.T) {
+	strats := []StrategyConfig{
+		{ID: "hl-rsi-btc", Type: "perps", Args: []string{"rsi", "BTC", "1h"}, Capital: 1000},
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-rsi-btc": {Cash: 1000},
+		},
+	}
+	prices := map[string]float64{"BTC/USDT": 50000, "ETH/USDT": 3000}
+
+	// With asset — title should contain " — BTC" and only BTC price shown
+	msg := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC")
+	if !strings.Contains(msg, "— BTC") {
+		t.Errorf("expected '— BTC' in title, got:\n%s", msg)
+	}
+	if strings.Contains(msg, "ETH") {
+		t.Errorf("ETH price should be filtered out for asset=BTC, got:\n%s", msg)
+	}
+
+	// Without asset — no suffix in title
+	msg2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "")
+	if strings.Contains(msg2, "— ") {
+		t.Errorf("expected no asset suffix when asset='', got:\n%s", msg2)
 	}
 }
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -361,7 +361,8 @@ func main() {
 							trades, detail, harvestDetails = executeOptionsResult(sc, stratState, result, signalStr, logger)
 							mu.Unlock()
 							if ch := resolveChannel(cfg.Discord.Channels, sc.Platform, sc.Type); ch != "" {
-								channelTradeDetails[ch] = append(channelTradeDetails[ch], harvestDetails...)
+								key := ch + "|" + extractAsset(sc)
+								channelTradeDetails[key] = append(channelTradeDetails[key], harvestDetails...)
 							}
 						}
 					case "perps":
@@ -383,7 +384,8 @@ func main() {
 					if trades > 0 && detail != "" {
 						if ch := resolveChannel(cfg.Discord.Channels, sc.Platform, sc.Type); ch != "" {
 							channelTrades[ch] += trades
-							channelTradeDetails[ch] = append(channelTradeDetails[ch], detail)
+							key := ch + "|" + extractAsset(sc)
+							channelTradeDetails[key] = append(channelTradeDetails[key], detail)
 						}
 					}
 
@@ -442,7 +444,7 @@ func main() {
 		elapsed := time.Since(cycleStart)
 		logMgr.LogSummary(cycle, elapsed, len(dueStrategies), totalTrades, totalValue)
 
-		// Discord notification — one message per channel, dynamic platform support.
+		// Discord notification — one message per channel per asset, dynamic platform support.
 		if discord != nil {
 			mu.RLock()
 			for ch, chStrats := range channelStrats {
@@ -458,15 +460,41 @@ func main() {
 					continue
 				}
 				chTrades := channelTrades[ch]
-				chDetails := channelTradeDetails[ch]
-				chValue := channelValue[ch]
 				// Options: post every run. Others: hourly or on trade.
 				// (cycle-1)%12==0 fires at cycles 1,13,25... so first summary posts on startup.
-				if isOptionsType(chStrats) || chTrades > 0 || (cycle-1)%12 == 0 {
-					chKey := channelKeyFromID(cfg.Discord.Channels, ch)
-					msg := FormatCategorySummary(cycle, elapsed, len(dueStrategies), chTrades, chValue, prices, chDetails, chStrats, state, chKey)
+				if !isOptionsType(chStrats) && chTrades == 0 && (cycle-1)%12 != 0 {
+					continue
+				}
+				chKey := channelKeyFromID(cfg.Discord.Channels, ch)
+				assetGroups, assetKeys := groupByAsset(chStrats)
+				if len(assetKeys) <= 1 {
+					// Single asset (or none) → backwards-compatible single message without asset label.
+					detailKey := ch + "|"
+					if len(assetKeys) == 1 {
+						detailKey = ch + "|" + assetKeys[0]
+					}
+					chDetails := channelTradeDetails[detailKey]
+					chValue := channelValue[ch]
+					msg := FormatCategorySummary(cycle, elapsed, len(dueStrategies), chTrades, chValue, prices, chDetails, chStrats, state, chKey, "")
 					if err := discord.SendMessage(ch, msg); err != nil {
 						fmt.Printf("[WARN] Discord %s summary failed: %v\n", chKey, err)
+					}
+				} else {
+					// Multiple assets → one message per asset.
+					for _, asset := range assetKeys {
+						assetStrats := assetGroups[asset]
+						assetDetails := channelTradeDetails[ch+"|"+asset]
+						assetValue := 0.0
+						for _, sc := range assetStrats {
+							if s, ok := state.Strategies[sc.ID]; ok {
+								assetValue += PortfolioValue(s, prices)
+							}
+						}
+						assetTrades := len(assetDetails)
+						msg := FormatCategorySummary(cycle, elapsed, len(dueStrategies), assetTrades, assetValue, prices, assetDetails, assetStrats, state, chKey, asset)
+						if err := discord.SendMessage(ch, msg); err != nil {
+							fmt.Printf("[WARN] Discord %s/%s summary failed: %v\n", chKey, asset, err)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

- **Problem:** With 40+ Hyperliquid strategies across BTC/ETH/SOL/BNB, a single summary message per Discord channel hits the 2000-char limit and gets truncated.
- **Solution:** Send one message per asset per channel when multiple assets are present; single-asset channels remain backwards-compatible (no label).

## Changes

- `extractAsset`: rewritten to use `Args[1]` as canonical source for all strategy types; strips `/USDT` suffix for spot symbols; removes hardcoded BTC/ETH/SOL allowlist
- New `assetSortKey` + `groupByAsset` helpers — BTC → ETH → SOL → BNB → others sort order
- `FormatCategorySummary`: new `asset string` param — appends `" — BTC"` to title and filters the prices line to the relevant asset when non-empty
- `channelTradeDetails` key changed from bare channel ID to `ch+"|"+asset` composite (consistent across options harvest and spot/perps trades)
- Discord sending loop: single-asset channels send one message without label (backwards-compatible); multi-asset channels loop over sorted asset groups and send one message each

## Test Plan

- [x] `cd scheduler && /opt/homebrew/bin/go build .` — compiles clean
- [x] `cd scheduler && /opt/homebrew/bin/go test ./...` — all 50 tests pass
- [x] `TestExtractAsset` — spot BTC/USDT→BTC, options ETH→ETH, perps SOL/BNB, empty args→""
- [x] `TestGroupByAsset` — 4 assets return in BTC/ETH/SOL/BNB order; BTC group has correct count
- [x] `TestFormatCategorySummary_WithAsset` — asset suffix in title; ETH price filtered out for asset=BTC; empty asset has no suffix

Closes #19