### PR TITLE
feat: complete portfolio kill switch (#25)

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -18,8 +18,9 @@ type DiscordConfig struct {
 
 // PortfolioRiskConfig controls aggregate portfolio-level risk (#42).
 type PortfolioRiskConfig struct {
-	MaxDrawdownPct float64 `json:"max_drawdown_pct"` // kill switch threshold (default 25)
-	MaxNotionalUSD float64 `json:"max_notional_usd"` // 0 = disabled
+	MaxDrawdownPct   float64 `json:"max_drawdown_pct"`             // kill switch threshold (default 25)
+	MaxNotionalUSD   float64 `json:"max_notional_usd"`             // 0 = disabled
+	WarnThresholdPct float64 `json:"warn_threshold_pct,omitempty"` // % of MaxDrawdownPct to warn (default 80)
 }
 
 // PlatformConfig holds per-platform settings (state file path and optional risk overrides).
@@ -166,6 +167,9 @@ func LoadConfig(path string) (*Config, error) {
 	if cfg.PortfolioRisk == nil {
 		cfg.PortfolioRisk = &PortfolioRiskConfig{MaxDrawdownPct: 25}
 	}
+	if cfg.PortfolioRisk.WarnThresholdPct == 0 {
+		cfg.PortfolioRisk.WarnThresholdPct = 80
+	}
 
 	if err := ValidateConfig(&cfg); err != nil {
 		return nil, err
@@ -260,6 +264,9 @@ func ValidateConfig(cfg *Config) error {
 		}
 		if cfg.PortfolioRisk.MaxNotionalUSD < 0 {
 			errs = append(errs, fmt.Sprintf("portfolio_risk.max_notional_usd must be >= 0, got %g", cfg.PortfolioRisk.MaxNotionalUSD))
+		}
+		if cfg.PortfolioRisk.WarnThresholdPct <= 0 || cfg.PortfolioRisk.WarnThresholdPct > 100 {
+			errs = append(errs, fmt.Sprintf("portfolio_risk.warn_threshold_pct must be in (0, 100], got %g", cfg.PortfolioRisk.WarnThresholdPct))
 		}
 	}
 

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -10,7 +10,7 @@ import (
 
 // CurrentConfigVersion is the version embedded in newly generated configs.
 // When the binary starts and cfg.ConfigVersion < CurrentConfigVersion, migration runs.
-const CurrentConfigVersion = 2
+const CurrentConfigVersion = 3
 
 // ConfigField describes a config field introduced in a specific version.
 type ConfigField struct {
@@ -29,6 +29,13 @@ var configFieldRegistry = []ConfigField{
 		Description: "Your Discord user ID (for upgrade DMs and config prompts). Right-click your username in Discord → Copy User ID.",
 		Default:     "",
 		FieldType:   "string",
+	},
+	{
+		Version:     3,
+		JSONPath:    "portfolio_risk.warn_threshold_pct",
+		Description: "Percentage of max_drawdown_pct at which to send a warning alert (e.g. 80 means warn at 80% of the kill switch threshold).",
+		Default:     "80",
+		FieldType:   "float",
 	},
 }
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -165,6 +165,7 @@ func main() {
 	}
 
 	saveFailures := 0
+	resetGoroutineRunning := false
 
 	// Main loop
 	for {
@@ -264,7 +265,7 @@ func main() {
 			mu.RUnlock()
 
 			mu.Lock()
-			portfolioAllowed, nb, portfolioReason := CheckPortfolioRisk(&state.PortfolioRisk, cfg.PortfolioRisk, totalPV, totalNotional)
+			portfolioAllowed, nb, portfolioWarning, portfolioReason := CheckPortfolioRisk(&state.PortfolioRisk, cfg.PortfolioRisk, totalPV, totalNotional)
 			if !portfolioAllowed {
 				killSwitchFired = true
 				fmt.Printf("[CRITICAL] Portfolio kill switch: %s\n", portfolioReason)
@@ -291,6 +292,56 @@ func main() {
 						}
 					}
 				}
+			}
+
+			// Warning alert: drawdown approaching kill switch threshold.
+			if portfolioWarning && discord != nil {
+				mu.Lock()
+				addKillSwitchEvent(&state.PortfolioRisk, "warning", state.PortfolioRisk.CurrentDrawdownPct, totalPV, state.PortfolioRisk.PeakValue, portfolioReason)
+				mu.Unlock()
+				warnMsg := fmt.Sprintf("**PORTFOLIO WARNING**\n%s", portfolioReason)
+				seen := make(map[string]bool)
+				for _, ch := range cfg.Discord.Channels {
+					if ch != "" && !seen[ch] {
+						seen[ch] = true
+						if err := discord.SendMessage(ch, warnMsg); err != nil {
+							fmt.Printf("[WARN] Discord warning alert failed: %v\n", err)
+						}
+					}
+				}
+				ownerID := cfg.Discord.OwnerID
+				if ownerID != "" {
+					_ = discord.SendDM(ownerID, warnMsg)
+				}
+				fmt.Printf("[WARN] %s\n", portfolioReason)
+			}
+
+			// Kill switch reset goroutine: prompt owner to reset via DM.
+			if killSwitchFired && discord != nil && cfg.Discord.OwnerID != "" && !resetGoroutineRunning {
+				resetGoroutineRunning = true
+				go func() {
+					defer func() { resetGoroutineRunning = false }()
+					ownerID := cfg.Discord.OwnerID
+					resp, err := discord.AskDM(ownerID, "Kill switch active. Reply 'reset' to resume trading.", 30*time.Minute)
+					if err != nil {
+						fmt.Printf("[update] Kill switch reset DM timed out or failed: %v\n", err)
+						return
+					}
+					if resp != "reset" {
+						fmt.Printf("[update] Kill switch reset DM got unexpected reply: %q\n", resp)
+						return
+					}
+					mu.Lock()
+					state.PortfolioRisk.KillSwitchActive = false
+					state.PortfolioRisk.KillSwitchAt = time.Time{}
+					addKillSwitchEvent(&state.PortfolioRisk, "reset", state.PortfolioRisk.CurrentDrawdownPct, 0, state.PortfolioRisk.PeakValue, "manual reset via Discord DM")
+					if err := SavePlatformStates(state, cfg); err != nil {
+						fmt.Printf("[CRITICAL] Failed to save state after kill switch reset: %v\n", err)
+					}
+					mu.Unlock()
+					_ = discord.SendDM(ownerID, "Kill switch reset. Trading will resume next cycle.")
+					fmt.Println("[update] Kill switch reset by owner via Discord DM")
+				}()
 			}
 
 			if !killSwitchFired {

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -5,21 +5,51 @@ import (
 	"time"
 )
 
+const maxKillSwitchEvents = 50
+
+// KillSwitchEvent records a kill switch lifecycle event for audit purposes.
+type KillSwitchEvent struct {
+	Timestamp      time.Time `json:"timestamp"`
+	Type           string    `json:"type"` // "triggered", "reset", "warning"
+	DrawdownPct    float64   `json:"drawdown_pct"`
+	PortfolioValue float64   `json:"portfolio_value"`
+	PeakValue      float64   `json:"peak_value"`
+	Details        string    `json:"details"`
+}
+
 // PortfolioRiskState tracks aggregate portfolio-level risk (#42).
 type PortfolioRiskState struct {
-	PeakValue          float64   `json:"peak_value"`
-	CurrentDrawdownPct float64   `json:"current_drawdown_pct"`
-	KillSwitchActive   bool      `json:"kill_switch_active"`
-	KillSwitchAt       time.Time `json:"kill_switch_at,omitempty"`
+	PeakValue          float64           `json:"peak_value"`
+	CurrentDrawdownPct float64           `json:"current_drawdown_pct"`
+	KillSwitchActive   bool              `json:"kill_switch_active"`
+	KillSwitchAt       time.Time         `json:"kill_switch_at,omitempty"`
+	WarningSent        bool              `json:"warning_sent,omitempty"`
+	Events             []KillSwitchEvent `json:"events,omitempty"`
+}
+
+// addKillSwitchEvent appends an event and trims to maxKillSwitchEvents.
+func addKillSwitchEvent(prs *PortfolioRiskState, eventType string, drawdownPct, portfolioValue, peakValue float64, details string) {
+	prs.Events = append(prs.Events, KillSwitchEvent{
+		Timestamp:      time.Now().UTC(),
+		Type:           eventType,
+		DrawdownPct:    drawdownPct,
+		PortfolioValue: portfolioValue,
+		PeakValue:      peakValue,
+		Details:        details,
+	})
+	if len(prs.Events) > maxKillSwitchEvents {
+		prs.Events = prs.Events[len(prs.Events)-maxKillSwitchEvents:]
+	}
 }
 
 // CheckPortfolioRisk evaluates aggregate portfolio risk.
-// Returns (allowed, notionalBlocked, reason).
+// Returns (allowed, notionalBlocked, warning, reason).
 // allowed=false means the kill switch has fired or is latched; notionalBlocked=true
-// means new trades should be skipped but existing positions kept.
-func CheckPortfolioRisk(prs *PortfolioRiskState, cfg *PortfolioRiskConfig, totalValue, totalNotional float64) (allowed, notionalBlocked bool, reason string) {
+// means new trades should be skipped but existing positions kept; warning=true
+// means drawdown is approaching the kill switch threshold.
+func CheckPortfolioRisk(prs *PortfolioRiskState, cfg *PortfolioRiskConfig, totalValue, totalNotional float64) (allowed, notionalBlocked, warning bool, reason string) {
 	if prs.KillSwitchActive {
-		return false, false, fmt.Sprintf("portfolio kill switch is latched (triggered at %s, manual reset required)",
+		return false, false, false, fmt.Sprintf("portfolio kill switch is latched (triggered at %s, manual reset required)",
 			prs.KillSwitchAt.Format("2006-01-02 15:04:05 UTC"))
 	}
 
@@ -31,21 +61,39 @@ func CheckPortfolioRisk(prs *PortfolioRiskState, cfg *PortfolioRiskConfig, total
 	// Check drawdown kill switch.
 	if prs.PeakValue > 0 {
 		prs.CurrentDrawdownPct = (prs.PeakValue - totalValue) / prs.PeakValue * 100
+
+		// Kill switch fires if drawdown exceeds limit.
 		if prs.CurrentDrawdownPct > cfg.MaxDrawdownPct {
 			prs.KillSwitchActive = true
 			prs.KillSwitchAt = time.Now().UTC()
-			return false, false, fmt.Sprintf("portfolio drawdown %.1f%% exceeds limit %.1f%% (value=$%.2f, peak=$%.2f)",
+			r := fmt.Sprintf("portfolio drawdown %.1f%% exceeds limit %.1f%% (value=$%.2f, peak=$%.2f)",
 				prs.CurrentDrawdownPct, cfg.MaxDrawdownPct, totalValue, prs.PeakValue)
+			addKillSwitchEvent(prs, "triggered", prs.CurrentDrawdownPct, totalValue, prs.PeakValue, r)
+			return false, false, false, r
+		}
+
+		// Warning check: approaching kill switch threshold.
+		warnDrawdownPct := cfg.MaxDrawdownPct * cfg.WarnThresholdPct / 100
+		if prs.CurrentDrawdownPct > warnDrawdownPct {
+			if !prs.WarningSent {
+				prs.WarningSent = true
+				warning = true
+				reason = fmt.Sprintf("portfolio drawdown %.1f%% approaching kill switch limit %.1f%% (warn at %.1f%%, value=$%.2f, peak=$%.2f)",
+					prs.CurrentDrawdownPct, cfg.MaxDrawdownPct, warnDrawdownPct, totalValue, prs.PeakValue)
+			}
+		} else {
+			// Recovered below warning threshold — reset so it can fire again.
+			prs.WarningSent = false
 		}
 	}
 
 	// Check notional cap — blocks new trades but does not force-close.
 	if cfg.MaxNotionalUSD > 0 && totalNotional > cfg.MaxNotionalUSD {
-		return true, true, fmt.Sprintf("portfolio notional $%.2f exceeds cap $%.2f — new trades blocked",
+		return true, true, warning, fmt.Sprintf("portfolio notional $%.2f exceeds cap $%.2f — new trades blocked",
 			totalNotional, cfg.MaxNotionalUSD)
 	}
 
-	return true, false, ""
+	return true, false, warning, reason
 }
 
 // PortfolioNotional computes gross market exposure across all strategies.

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -203,11 +203,11 @@ func TestCheckRisk_ForceCloseOnDrawdown(t *testing.T) {
 // TestCheckPortfolioRisk_DrawdownKillSwitch verifies the kill switch fires at the
 // drawdown threshold and latches on subsequent calls.
 func TestCheckPortfolioRisk_DrawdownKillSwitch(t *testing.T) {
-	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, MaxNotionalUSD: 0}
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, MaxNotionalUSD: 0, WarnThresholdPct: 80}
 	prs := &PortfolioRiskState{PeakValue: 10000.0}
 
 	// Just under threshold — should be allowed.
-	allowed, nb, reason := CheckPortfolioRisk(prs, cfg, 7600.0, 0)
+	allowed, nb, _, reason := CheckPortfolioRisk(prs, cfg, 7600.0, 0)
 	if !allowed {
 		t.Errorf("expected allowed below threshold; got reason=%s", reason)
 	}
@@ -221,7 +221,7 @@ func TestCheckPortfolioRisk_DrawdownKillSwitch(t *testing.T) {
 	}
 
 	// Drawdown = (10000-7400)/10000 = 26% > 25% — kill switch fires.
-	allowed, nb, reason = CheckPortfolioRisk(prs, cfg, 7400.0, 0)
+	allowed, nb, _, reason = CheckPortfolioRisk(prs, cfg, 7400.0, 0)
 	if allowed {
 		t.Error("expected kill switch to fire at 26% drawdown")
 	}
@@ -239,7 +239,7 @@ func TestCheckPortfolioRisk_DrawdownKillSwitch(t *testing.T) {
 	}
 
 	// Subsequent call — still latched even with recovered value.
-	allowed, _, _ = CheckPortfolioRisk(prs, cfg, 10000.0, 0)
+	allowed, _, _, _ = CheckPortfolioRisk(prs, cfg, 10000.0, 0)
 	if allowed {
 		t.Error("expected kill switch to remain latched on subsequent call")
 	}
@@ -248,11 +248,11 @@ func TestCheckPortfolioRisk_DrawdownKillSwitch(t *testing.T) {
 // TestCheckPortfolioRisk_NotionalCap verifies the notional cap blocks new trades
 // without triggering the kill switch.
 func TestCheckPortfolioRisk_NotionalCap(t *testing.T) {
-	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, MaxNotionalUSD: 50000}
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, MaxNotionalUSD: 50000, WarnThresholdPct: 80}
 	prs := &PortfolioRiskState{PeakValue: 10000.0}
 
 	// Under cap — allowed, not notional-blocked.
-	allowed, nb, _ := CheckPortfolioRisk(prs, cfg, 10000.0, 30000.0)
+	allowed, nb, _, _ := CheckPortfolioRisk(prs, cfg, 10000.0, 30000.0)
 	if !allowed {
 		t.Error("expected allowed under notional cap")
 	}
@@ -261,7 +261,7 @@ func TestCheckPortfolioRisk_NotionalCap(t *testing.T) {
 	}
 
 	// Over cap — allowed=true, notionalBlocked=true, kill switch NOT active.
-	allowed, nb, reason := CheckPortfolioRisk(prs, cfg, 10000.0, 60000.0)
+	allowed, nb, _, reason := CheckPortfolioRisk(prs, cfg, 10000.0, 60000.0)
 	if !allowed {
 		t.Error("expected allowed=true (notional cap doesn't kill switch)")
 	}
@@ -276,7 +276,7 @@ func TestCheckPortfolioRisk_NotionalCap(t *testing.T) {
 // TestCheckPortfolioRisk_PeakTracking verifies the peak high-water mark only
 // ratchets upward, never down.
 func TestCheckPortfolioRisk_PeakTracking(t *testing.T) {
-	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 50, MaxNotionalUSD: 0}
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 50, MaxNotionalUSD: 0, WarnThresholdPct: 80}
 	prs := &PortfolioRiskState{PeakValue: 5000.0}
 
 	// Value rises — peak should update.
@@ -392,5 +392,107 @@ func TestCheckRisk_ConsecutiveLossesForceClose(t *testing.T) {
 	expectedCash := 10000.0
 	if s.Cash != expectedCash {
 		t.Errorf("expected Cash=%.2f after force-close; got %.2f", expectedCash, s.Cash)
+	}
+}
+
+// TestCheckPortfolioRisk_WarningFires verifies that drawdown at 80% of limit
+// triggers a warning once but not again on second call.
+func TestCheckPortfolioRisk_WarningFires(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 10000.0}
+
+	// Warn threshold = 25 * 80/100 = 20%. Drawdown = (10000-7900)/10000 = 21% > 20%.
+	_, _, warning, reason := CheckPortfolioRisk(prs, cfg, 7900.0, 0)
+	if !warning {
+		t.Error("expected warning=true at 21% drawdown (warn threshold=20%)")
+	}
+	if reason == "" {
+		t.Error("expected non-empty reason for warning")
+	}
+	if !prs.WarningSent {
+		t.Error("expected WarningSent=true after warning fires")
+	}
+
+	// Second call at same drawdown — warning should NOT fire again.
+	_, _, warning, _ = CheckPortfolioRisk(prs, cfg, 7900.0, 0)
+	if warning {
+		t.Error("expected warning=false on second call (already sent)")
+	}
+}
+
+// TestCheckPortfolioRisk_WarningResetOnRecovery verifies that recovery below
+// the warning threshold resets WarningSent so it can fire again.
+func TestCheckPortfolioRisk_WarningResetOnRecovery(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 10000.0}
+
+	// Trigger warning at 21% drawdown.
+	CheckPortfolioRisk(prs, cfg, 7900.0, 0)
+	if !prs.WarningSent {
+		t.Fatal("expected WarningSent=true after first warning")
+	}
+
+	// Recover to 15% drawdown (below 20% warn threshold).
+	CheckPortfolioRisk(prs, cfg, 8500.0, 0)
+	if prs.WarningSent {
+		t.Error("expected WarningSent=false after recovery below warn threshold")
+	}
+
+	// Cross warning threshold again — should warn again.
+	_, _, warning, _ := CheckPortfolioRisk(prs, cfg, 7900.0, 0)
+	if !warning {
+		t.Error("expected warning=true after recovery and re-crossing threshold")
+	}
+}
+
+// TestCheckPortfolioRisk_WarningNotAfterKillSwitch verifies that past the kill
+// threshold the kill switch fires and no warning is returned.
+func TestCheckPortfolioRisk_WarningNotAfterKillSwitch(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 10000.0}
+
+	// 26% drawdown > 25% kill switch threshold.
+	allowed, _, warning, _ := CheckPortfolioRisk(prs, cfg, 7400.0, 0)
+	if allowed {
+		t.Error("expected kill switch to fire")
+	}
+	if warning {
+		t.Error("expected warning=false when kill switch fires (kill takes precedence)")
+	}
+}
+
+// TestAddKillSwitchEvent_MaxCap verifies that events are capped at maxKillSwitchEvents.
+func TestAddKillSwitchEvent_MaxCap(t *testing.T) {
+	prs := &PortfolioRiskState{}
+
+	for i := 0; i < 60; i++ {
+		addKillSwitchEvent(prs, "warning", float64(i), 1000, 2000, "test")
+	}
+
+	if len(prs.Events) != maxKillSwitchEvents {
+		t.Errorf("expected %d events; got %d", maxKillSwitchEvents, len(prs.Events))
+	}
+	// Oldest event should be the 11th one added (index 10).
+	if prs.Events[0].DrawdownPct != 10 {
+		t.Errorf("expected oldest event drawdown=10; got %.0f", prs.Events[0].DrawdownPct)
+	}
+}
+
+// TestCheckPortfolioRisk_EventLoggedOnTrigger verifies that a "triggered" event
+// is appended when the kill switch fires.
+func TestCheckPortfolioRisk_EventLoggedOnTrigger(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 10000.0}
+
+	CheckPortfolioRisk(prs, cfg, 7400.0, 0)
+
+	if len(prs.Events) != 1 {
+		t.Fatalf("expected 1 event; got %d", len(prs.Events))
+	}
+	if prs.Events[0].Type != "triggered" {
+		t.Errorf("expected event type='triggered'; got %q", prs.Events[0].Type)
+	}
+	if prs.Events[0].PortfolioValue != 7400.0 {
+		t.Errorf("expected portfolio_value=7400; got %.2f", prs.Events[0].PortfolioValue)
 	}
 }


### PR DESCRIPTION
## Summary
- Add warning alerts when portfolio drawdown approaches the kill switch threshold (configurable `warn_threshold_pct`, default 80% of `max_drawdown_pct`)
- Add manual kill switch reset via Discord DM (owner replies "reset" to resume trading)
- Add kill switch event audit log (`triggered`, `reset`, `warning` events, capped at 50, exposed via `/status`)
- Bump config version to 3 with migration support for `portfolio_risk.warn_threshold_pct`

## Files Changed
- `scheduler/risk.go` — `KillSwitchEvent` type, `addKillSwitchEvent()`, extended `PortfolioRiskState`, 4-return `CheckPortfolioRisk` with warning logic
- `scheduler/config.go` — `WarnThresholdPct` field, default, validation
- `scheduler/config_migration.go` — `CurrentConfigVersion` 2→3, registry entry
- `scheduler/main.go` — warning Discord alerts + owner DM, reset goroutine
- `scheduler/risk_test.go` — updated 3 existing tests, added 5 new tests

## Test plan
- [x] `go build .` passes
- [x] `go test ./...` passes (12 tests including 5 new)
- [x] `gofmt -l *.go` clean
- [ ] Smoke test with `--once` flag
- [ ] Verify warning fires at 80% of kill switch threshold
- [ ] Verify kill switch reset via DM clears state and resumes trading
- [ ] Verify `/status` endpoint includes events in portfolio risk JSON