### PR TITLE
feat: add stock options trading to Robinhood platform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
   - `config_migration.go` — `CurrentConfigVersion = 2`; `NewFieldsSince(version)` returns new fields; `MigrateConfig(path, values)` atomic JSON patch + version bump; `runConfigMigrationDM(cfg, discord, configPath)` DMs owner per new field with 10min timeout
 - `shared_scripts/` — Python entry-point scripts called by the scheduler
   - `check_strategy.py` — spot strategy signal checker
-  - `check_options.py` — unified options checker (`--platform=deribit|ibkr`)
+  - `check_options.py` — unified options checker (`--platform=deribit|ibkr|robinhood`)
   - `check_price.py` — price check script
   - `check_hyperliquid.py` — Hyperliquid perps checker (`<strategy> <symbol> <timeframe> [--mode=paper|live]`; `--execute` for live orders)
   - `check_topstep.py` — TopStep futures checker (`<strategy> <symbol> <timeframe> [--mode=paper|live]`; `--execute` for live orders)
@@ -33,7 +33,7 @@
   - `binanceus/adapter.py` — BinanceUSExchangeAdapter (spot only)
   - `hyperliquid/adapter.py` — HyperliquidExchangeAdapter (live perps prices, paper/live trading via `HYPERLIQUID_SECRET_KEY`)
   - `topstep/adapter.py` — TopStepExchangeAdapter (CME futures, paper mode via yfinance, live via TopStepX API)
-  - `robinhood/adapter.py` — RobinhoodExchangeAdapter (crypto spot, paper mode via yfinance, live via robin_stocks + TOTP MFA)
+  - `robinhood/adapter.py` — RobinhoodExchangeAdapter (crypto spot + stock options, paper mode via yfinance/Black-Scholes, live via robin_stocks + TOTP MFA)
 - `shared_tools/` — shared Python utilities (pricing.py, exchange_base.py, data_fetcher, storage)
 - `shared_strategies/` — shared strategy logic (spot/, options/, futures/)
 - `core/` — legacy data utilities used by backtest (data_fetcher, storage)

--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ CME futures on TopStep. Live mode requires `TOPSTEP_API_KEY`, `TOPSTEP_API_SECRE
 
 Same spot strategy suite as Binance US, running on Robinhood crypto. Paper mode uses Yahoo Finance for OHLCV data (no credentials needed). Live mode requires `ROBINHOOD_USERNAME`, `ROBINHOOD_PASSWORD`, `ROBINHOOD_TOTP_SECRET` env vars.
 
+### Robinhood Stock Options (6 strategies, 4h interval)
+
+US equity options on SPY, QQQ, AAPL, etc. using the same options strategies as Deribit/IBKR (covered_calls, protective_puts, momentum_options, vol_mean_reversion, wheel, butterfly). Paper mode uses Black-Scholes pricing. Live mode uses robin_stocks for real options chains and greeks.
+
 ---
 
 ## Platforms
@@ -186,6 +190,7 @@ Same spot strategy suite as Binance US, running on Robinhood crypto. Paper mode 
 | Hyperliquid | Perps | BTC, ETH, SOL | Paper + live trading via SDK |
 | TopStep | Futures | ES, NQ, MES, MNQ, CL, GC | Paper (yfinance) + live trading via TopStepX API |
 | Robinhood | Crypto | BTC, ETH, SOL, DOGE, etc. | Paper (yfinance) + live trading via robin_stocks |
+| Robinhood | Options | SPY, QQQ, AAPL, MSFT, etc. | Paper (Black-Scholes) + live chains via robin_stocks |
 
 ---
 
@@ -371,6 +376,7 @@ journalctl -u go-trader -n 50           # recent logs
 | Hyperliquid Perps | 0.035% taker | ±0.05% |
 | TopStep Futures | Per-contract (configurable) | ±0.05% |
 | Robinhood Crypto | No commission (spread embedded) | ±0.05% |
+| Robinhood Options | $0.03/contract (regulatory fee) | — |
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -942,6 +942,7 @@ When the user says `/menu`, "show menu", "what can I configure", "what's availab
    • Hyperliquid — perps trading: any HL-listed asset (paper + live)
    • TopStep     — futures trading: ES, NQ, MES, MNQ, CL, GC (paper + live)
    • Robinhood   — crypto trading: BTC, ETH, SOL, DOGE, etc. (paper via yfinance + live via robin_stocks)
+   • Robinhood   — stock options: SPY, QQQ, AAPL, etc. (paper via Black-Scholes + live via robin_stocks)
    • Custom      — add your own exchange via Step 9 (guided setup)
 
 2. AVAILABLE STRATEGIES
@@ -1182,3 +1183,16 @@ Each Robinhood strategy runs the spot strategy suite on crypto assets (BTC, ETH,
 **ID convention:** `rh-{strategy_short}-{asset}` (e.g. `rh-sma-btc`, `rh-rsi-eth`)
 
 Paper mode uses Yahoo Finance for OHLCV data (no credentials needed). For live trading, change `--mode=paper` to `--mode=live`. Requires `ROBINHOOD_USERNAME`, `ROBINHOOD_PASSWORD`, `ROBINHOOD_TOTP_SECRET` env vars.
+
+### Robinhood Stock Options Entries
+
+Each Robinhood options strategy runs on US equity symbols (SPY, QQQ, AAPL, etc.):
+
+```json
+{"id": "rh-ccall-spy", "type": "options", "platform": "robinhood", "script": "shared_scripts/check_options.py", "args": ["covered_calls", "SPY", "--platform=robinhood"], "capital": 5000, "max_drawdown_pct": 10, "interval_seconds": 14400, "theta_harvest": {"enabled": true, "profit_target_pct": 60, "stop_loss_pct": 200, "min_dte_close": 3}}
+{"id": "rh-pput-qqq", "type": "options", "platform": "robinhood", "script": "shared_scripts/check_options.py", "args": ["protective_puts", "QQQ", "--platform=robinhood"], "capital": 5000, "max_drawdown_pct": 10, "interval_seconds": 14400, "theta_harvest": {"enabled": true, "profit_target_pct": 60, "stop_loss_pct": 200, "min_dte_close": 3}}
+```
+
+**ID convention:** `rh-{strategy_short}-{symbol}` (e.g. `rh-ccall-spy`, `rh-vol-qqq`)
+
+Paper mode uses Black-Scholes pricing (no credentials needed). Live mode uses robin_stocks for real options chains and greeks. Requires `ROBINHOOD_USERNAME`, `ROBINHOOD_PASSWORD`, `ROBINHOOD_TOTP_SECRET` env vars.

--- a/platforms/robinhood/adapter.py
+++ b/platforms/robinhood/adapter.py
@@ -1,8 +1,9 @@
 """
-Robinhood Crypto Exchange Adapter.
+Robinhood Exchange Adapter.
 
-Supports paper (signal-only using yfinance for OHLCV, no credentials needed) and
-live (real orders via robin_stocks, credentials required) modes.
+Supports crypto spot trading and US stock options.
+Paper mode: yfinance for OHLCV/prices, Black-Scholes for options pricing.
+Live mode: robin_stocks for prices/chains/orders, TOTP MFA authentication.
 
 Environment variables:
     ROBINHOOD_USERNAME     — Robinhood account email/username
@@ -12,6 +13,11 @@ Environment variables:
 
 import os
 import sys
+import math
+from datetime import datetime, timezone, timedelta
+from typing import Tuple
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'shared_tools'))
 
 # Yahoo Finance crypto symbol mapping (paper mode OHLCV + fallback prices)
 YAHOO_CRYPTO_MAP = {
@@ -27,14 +33,30 @@ YAHOO_CRYPTO_MAP = {
     "SHIB": "SHIB-USD",
 }
 
+# Standard equity options strike intervals
+STRIKE_INTERVALS = [
+    (100, 1),    # under $100: $1 increments
+    (500, 5),    # $100-$500: $5 increments
+    (float('inf'), 10),  # over $500: $10 increments
+]
+
+
+def _get_strike_interval(price: float) -> float:
+    """Return standard equity options strike interval for given price."""
+    for threshold, interval in STRIKE_INTERVALS:
+        if price < threshold:
+            return interval
+    return 10
+
 
 class RobinhoodExchangeAdapter:
     """
-    Exchange adapter for Robinhood crypto trading.
+    Exchange adapter for Robinhood crypto + stock options trading.
 
-    Paper mode:  no credentials needed; uses yfinance for OHLCV and price data.
+    Paper mode:  no credentials needed; uses yfinance for OHLCV and price data,
+                 Black-Scholes for options pricing.
     Live mode:   requires ROBINHOOD_USERNAME, ROBINHOOD_PASSWORD, ROBINHOOD_TOTP_SECRET;
-                 uses robin_stocks for live prices and order execution.
+                 uses robin_stocks for live prices, options chains, and order execution.
     """
 
     def __init__(self, mode="paper"):
@@ -84,17 +106,28 @@ class RobinhoodExchangeAdapter:
         return "robinhood"
 
     # ─────────────────────────────────────────────
-    # Market data
+    # Market data (crypto + stocks)
     # ─────────────────────────────────────────────
 
+    def _resolve_yahoo_symbol(self, symbol: str) -> str:
+        """Resolve symbol to yfinance ticker. Crypto uses map, stocks pass through."""
+        return YAHOO_CRYPTO_MAP.get(symbol.upper(), symbol.upper())
+
     def get_price(self, symbol: str) -> float:
-        """Get current crypto price. Uses robin_stocks if logged in, else yfinance."""
+        """Get current price. Uses robin_stocks if logged in, else yfinance."""
         if self._logged_in:
             try:
                 import robin_stocks.robinhood as rh
-                quote = rh.crypto.get_crypto_quote(symbol)
-                if quote and quote.get("mark_price"):
-                    return float(quote["mark_price"])
+                # Try crypto first
+                if symbol.upper() in YAHOO_CRYPTO_MAP:
+                    quote = rh.crypto.get_crypto_quote(symbol)
+                    if quote and quote.get("mark_price"):
+                        return float(quote["mark_price"])
+                else:
+                    # Stock quote
+                    prices = rh.stocks.get_latest_price(symbol)
+                    if prices and prices[0]:
+                        return float(prices[0])
             except Exception as e:
                 print(f"[robinhood] robin_stocks price error for {symbol}: {e}", file=sys.stderr)
         return self._get_yahoo_price(symbol)
@@ -105,21 +138,178 @@ class RobinhoodExchangeAdapter:
 
     def get_ohlcv(self, symbol: str, interval: str = "1h", limit: int = 200) -> list:
         """
-        Fetch OHLCV candles via yfinance (robin_stocks has no OHLCV endpoint).
+        Fetch OHLCV candles via yfinance.
 
         Returns list of [timestamp_ms, open, high, low, close, volume].
         """
         return self._get_yahoo_ohlcv(symbol, interval, limit)
+
+    def get_ohlcv_closes(self, symbol: str, timeframe: str = "4h", limit: int = 100, min_len: int = 30) -> list:
+        """Fetch closing prices via yfinance. Used by check_options.py momentum strategy."""
+        candles = self._get_yahoo_ohlcv(symbol, timeframe, limit)
+        if not candles or len(candles) < min_len:
+            return None
+        return [c[4] for c in candles]
+
+    # ─────────────────────────────────────────────
+    # Options Protocol methods
+    # ─────────────────────────────────────────────
+
+    def get_vol_metrics(self, underlying: str) -> Tuple[float, float]:
+        """Compute 14-day historical vol and IV rank from yfinance OHLCV data."""
+        try:
+            import yfinance as yf
+            yahoo_sym = self._resolve_yahoo_symbol(underlying)
+            ticker = yf.Ticker(yahoo_sym)
+            hist = ticker.history(period="90d", interval="1d")
+            if hist.empty or len(hist) < 15:
+                return 0.30, 50.0
+            closes = hist["Close"].tolist()
+            returns = [math.log(closes[i] / closes[i - 1]) for i in range(1, len(closes)) if closes[i - 1] > 0]
+            if len(returns) < 14:
+                return 0.30, 50.0
+
+            w = 14
+            mean = sum(returns[-w:]) / w
+            variance = sum((r - mean) ** 2 for r in returns[-w:]) / w
+            vol = math.sqrt(variance) * math.sqrt(252)  # 252 trading days for stocks
+
+            # IV rank (rolling HV comparison)
+            hvs = []
+            for i in range(len(returns) - w + 1):
+                chunk = returns[i:i + w]
+                m = sum(chunk) / w
+                v = sum((r - m) ** 2 for r in chunk) / w
+                hvs.append(math.sqrt(v) * math.sqrt(252) * 100)
+            current_hv = vol * 100
+            hv_min, hv_max = min(hvs), max(hvs)
+            if hv_max > hv_min:
+                iv_rank = (current_hv - hv_min) / (hv_max - hv_min) * 100
+                iv_rank = round(min(max(iv_rank, 0.0), 100.0), 1)
+            else:
+                iv_rank = 50.0
+
+            return round(vol, 4), iv_rank
+        except Exception as e:
+            print(f"[robinhood] vol_metrics error for {underlying}: {e}", file=sys.stderr)
+            return 0.30, 50.0
+
+    def get_real_expiry(self, underlying: str, target_dte: int) -> Tuple[str, int]:
+        """Return options expiry closest to target_dte.
+
+        Live mode: fetches real expiry dates from Robinhood.
+        Paper mode: synthetic expiry (today + target_dte).
+        """
+        if self._logged_in:
+            try:
+                import robin_stocks.robinhood as rh
+                chain = rh.options.get_chains(underlying)
+                if chain and chain.get("expiration_dates"):
+                    today = datetime.now(timezone.utc).date()
+                    target_date = today + timedelta(days=target_dte)
+                    best_expiry = None
+                    best_diff = float('inf')
+                    for exp_str in chain["expiration_dates"]:
+                        exp_date = datetime.strptime(exp_str, "%Y-%m-%d").date()
+                        diff = abs((exp_date - target_date).days)
+                        if diff < best_diff:
+                            best_diff = diff
+                            best_expiry = exp_str
+                    if best_expiry:
+                        actual_dte = (datetime.strptime(best_expiry, "%Y-%m-%d").date() - today).days
+                        return best_expiry, max(actual_dte, 1)
+            except Exception as e:
+                print(f"[robinhood] get_real_expiry error: {e}", file=sys.stderr)
+
+        # Paper mode fallback: synthetic expiry
+        expiry_dt = datetime.now(timezone.utc) + timedelta(days=target_dte)
+        return expiry_dt.strftime("%Y-%m-%d"), target_dte
+
+    def get_real_strike(self, underlying: str, expiry: str,
+                        option_type: str, target_strike: float) -> float:
+        """Return strike closest to target.
+
+        Live mode: fetches real strikes from Robinhood.
+        Paper mode: rounds to standard equity options interval.
+        """
+        if self._logged_in:
+            try:
+                import robin_stocks.robinhood as rh
+                options = rh.options.find_tradable_options(
+                    underlying, expirationDate=expiry,
+                    optionType=option_type
+                )
+                if options:
+                    best_strike = None
+                    best_diff = float('inf')
+                    for opt in options:
+                        strike = float(opt.get("strike_price", 0))
+                        if strike > 0:
+                            diff = abs(strike - target_strike)
+                            if diff < best_diff:
+                                best_diff = diff
+                                best_strike = strike
+                    if best_strike is not None:
+                        return best_strike
+            except Exception as e:
+                print(f"[robinhood] get_real_strike error: {e}", file=sys.stderr)
+
+        # Paper mode fallback: round to standard interval
+        interval = _get_strike_interval(target_strike)
+        return round(target_strike / interval) * interval
+
+    def get_premium_and_greeks(self, underlying: str, option_type: str,
+                                strike: float, expiry: str, dte: float,
+                                spot: float, vol: float) -> Tuple[float, float, dict]:
+        """Estimate premium and greeks.
+
+        Live mode: fetches real market data from Robinhood.
+        Paper mode: Black-Scholes via shared_tools/pricing.py.
+        """
+        if self._logged_in:
+            try:
+                import robin_stocks.robinhood as rh
+                options = rh.options.find_tradable_options(
+                    underlying, expirationDate=expiry,
+                    strikePrice=str(strike), optionType=option_type
+                )
+                if options:
+                    opt_id = options[0].get("id") or options[0].get("url", "").split("/")[-2]
+                    if opt_id:
+                        market_data = rh.options.get_option_market_data_by_id(opt_id)
+                        if market_data and isinstance(market_data, list) and market_data[0]:
+                            md = market_data[0]
+                            mark = float(md.get("adjusted_mark_price", 0) or 0)
+                            greeks = {
+                                "delta": float(md.get("delta", 0) or 0),
+                                "gamma": float(md.get("gamma", 0) or 0),
+                                "theta": float(md.get("theta", 0) or 0),
+                                "vega": float(md.get("vega", 0) or 0),
+                            }
+                            # mark is per-share price, multiply by 100 for per-contract
+                            premium_usd = mark * 100
+                            mark_pct = (mark / spot) if spot > 0 else 0.0
+                            return round(mark_pct, 6), round(premium_usd, 2), greeks
+            except Exception as e:
+                print(f"[robinhood] get_premium_and_greeks error: {e}", file=sys.stderr)
+
+        # Paper mode fallback: Black-Scholes
+        from pricing import bs_price_and_greeks
+        if vol <= 0:
+            vol = 0.30  # stock default
+        price_usd, greeks = bs_price_and_greeks(spot, strike, dte, vol, option_type=option_type)
+        # price_usd is per-share; multiply by 100 for per-contract
+        premium_usd = price_usd * 100
+        mark_pct = (price_usd / spot) if spot > 0 else 0.0
+        return round(mark_pct, 6), round(premium_usd, 2), greeks
 
     # ─────────────────────────────────────────────
     # Yahoo Finance helpers
     # ─────────────────────────────────────────────
 
     def _get_yahoo_price(self, symbol: str) -> float:
-        """Fetch current price via yfinance."""
-        yahoo_sym = YAHOO_CRYPTO_MAP.get(symbol)
-        if not yahoo_sym:
-            return 0.0
+        """Fetch current price via yfinance. Works for both crypto and stocks."""
+        yahoo_sym = self._resolve_yahoo_symbol(symbol)
         try:
             import yfinance as yf
             ticker = yf.Ticker(yahoo_sym)
@@ -135,10 +325,8 @@ class RobinhoodExchangeAdapter:
             return 0.0
 
     def _get_yahoo_ohlcv(self, symbol: str, interval: str = "1h", limit: int = 200) -> list:
-        """Fetch OHLCV via yfinance for crypto symbols."""
-        yahoo_sym = YAHOO_CRYPTO_MAP.get(symbol)
-        if not yahoo_sym:
-            return []
+        """Fetch OHLCV via yfinance. Works for both crypto and stocks."""
+        yahoo_sym = self._resolve_yahoo_symbol(symbol)
         try:
             import yfinance as yf
             yf_interval = interval

--- a/scheduler/fees.go
+++ b/scheduler/fees.go
@@ -16,6 +16,9 @@ const (
 	// Hyperliquid perps taker fee
 	HyperliquidTakerFeePct = 0.00035 // 0.035% taker fee
 
+	// Robinhood options regulatory fee (per contract)
+	RobinhoodOptionFeeFixed = 0.03 // $0.03/contract (SEC/FINRA regulatory fee)
+
 	// Slippage simulation (random +/- this pct)
 	SlippagePct = 0.0005 // 0.05% (5 basis points)
 )
@@ -59,12 +62,21 @@ func CalculateIBKROptionFee(quantity float64) float64 {
 	return quantity * IBKROptionFeeFixed
 }
 
+// CalculateRobinhoodOptionFee calculates trading fee for Robinhood options.
+func CalculateRobinhoodOptionFee(quantity float64) float64 {
+	return quantity * RobinhoodOptionFeeFixed
+}
+
 // CalculateOptionFee dispatches to the appropriate fee calculator based on platform.
 func CalculateOptionFee(platform string, premiumUSD, quantity float64) float64 {
-	if platform == "ibkr" {
+	switch platform {
+	case "ibkr":
 		return CalculateIBKROptionFee(quantity)
+	case "robinhood":
+		return CalculateRobinhoodOptionFee(quantity)
+	default:
+		return CalculateDeribitOptionFee(premiumUSD)
 	}
-	return CalculateDeribitOptionFee(premiumUSD)
 }
 
 // CalculateFuturesFee calculates per-contract fee for futures trades.

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -97,6 +97,9 @@ var defaultFuturesStrategies = []stratDef{
 // Supported CME futures symbols for the init wizard.
 var supportedFuturesSymbols = []string{"ES", "NQ", "MES", "MNQ", "CL", "GC"}
 
+// Supported stock symbols for Robinhood options.
+var supportedStockSymbols = []string{"SPY", "QQQ", "AAPL", "MSFT", "AMZN", "GOOGL", "TSLA", "META"}
+
 // Live strategy lists — populated by discoverStrategies() at startup.
 // Tests set these via init() to avoid Python dependency.
 var (
@@ -163,41 +166,42 @@ func discoverStrategies() {
 
 // InitOptions captures all user choices from the interactive wizard.
 type InitOptions struct {
-	OutputPath            string
-	Assets                []string // selected asset names, e.g. ["BTC", "ETH"]
-	EnableSpot            bool
-	EnableOptions         bool
-	EnablePerps           bool
-	OptionPlatforms       []string // "deribit", "ibkr", or both
-	PerpsMode             string   // "paper" or "live"
-	SpotStrategies        []string // selected spot strategy IDs
-	IncludePairs          bool
-	OptStrategies         []string // selected options strategy IDs
-	PerpsStrategies       []string // selected perps strategy IDs (auto-populated if empty)
-	SpotCapital           float64
-	OptionsCapital        float64
-	PerpsCapital          float64
-	SpotDrawdown          float64
-	OptionsDrawdown       float64
-	PerpsDrawdown         float64
-	EnableFutures         bool
-	FuturesMode           string   // "paper" or "live"
-	FuturesStrategies     []string // selected futures strategy IDs
-	FuturesSymbols        []string // selected CME symbols (e.g. ["ES", "MES"])
-	FuturesCapital        float64
-	FuturesDrawdown       float64
-	FuturesFeePerContract float64
-	EnableRobinhood       bool
-	RobinhoodMode         string   // "paper" or "live"
-	RobinhoodStrategies   []string // selected crypto strategy IDs
-	RobinhoodCapital      float64
-	RobinhoodDrawdown     float64
-	DiscordEnabled        bool
-	DiscordOwnerID        string            // Discord user ID for DM features (upgrade prompts, config migration)
-	SpotChannelID         string            // deprecated: use ChannelMap
-	OptionsChannelID      string            // deprecated: use ChannelMap
-	ChannelMap            map[string]string // keyed by platform/type ("spot", "hyperliquid", "deribit", etc.)
-	AutoUpdate            string            // "off", "daily", "heartbeat" (default: "off")
+	OutputPath              string
+	Assets                  []string // selected asset names, e.g. ["BTC", "ETH"]
+	EnableSpot              bool
+	EnableOptions           bool
+	EnablePerps             bool
+	OptionPlatforms         []string // "deribit", "ibkr", or both
+	PerpsMode               string   // "paper" or "live"
+	SpotStrategies          []string // selected spot strategy IDs
+	IncludePairs            bool
+	OptStrategies           []string // selected options strategy IDs
+	PerpsStrategies         []string // selected perps strategy IDs (auto-populated if empty)
+	SpotCapital             float64
+	OptionsCapital          float64
+	PerpsCapital            float64
+	SpotDrawdown            float64
+	OptionsDrawdown         float64
+	PerpsDrawdown           float64
+	EnableFutures           bool
+	FuturesMode             string   // "paper" or "live"
+	FuturesStrategies       []string // selected futures strategy IDs
+	FuturesSymbols          []string // selected CME symbols (e.g. ["ES", "MES"])
+	FuturesCapital          float64
+	FuturesDrawdown         float64
+	FuturesFeePerContract   float64
+	EnableRobinhood         bool
+	RobinhoodMode           string   // "paper" or "live"
+	RobinhoodStrategies     []string // selected crypto strategy IDs
+	RobinhoodCapital        float64
+	RobinhoodDrawdown       float64
+	RobinhoodOptionsSymbols []string // stock tickers for Robinhood options (e.g. ["SPY", "QQQ"])
+	DiscordEnabled          bool
+	DiscordOwnerID          string            // Discord user ID for DM features (upgrade prompts, config migration)
+	SpotChannelID           string            // deprecated: use ChannelMap
+	OptionsChannelID        string            // deprecated: use ChannelMap
+	ChannelMap              map[string]string // keyed by platform/type ("spot", "hyperliquid", "deribit", etc.)
+	AutoUpdate              string            // "off", "daily", "heartbeat" (default: "off")
 }
 
 // generateConfig builds a Config from InitOptions. Pure function, no I/O.
@@ -275,11 +279,26 @@ func generateConfig(opts InitOptions) *Config {
 		for _, stratID := range opts.OptStrategies {
 			shortName := deriveShortName(stratID)
 			for _, platform := range opts.OptionPlatforms {
-				for _, assetName := range opts.Assets {
-					if assetName == "SOL" {
-						continue // options don't support SOL
+				// Robinhood options use stock symbols; others use crypto assets
+				var symbols []string
+				if platform == "robinhood" {
+					symbols = opts.RobinhoodOptionsSymbols
+					if len(symbols) == 0 {
+						symbols = []string{"SPY", "QQQ"}
 					}
-					id := fmt.Sprintf("%s-%s-%s", platform, shortName, strings.ToLower(assetName))
+				} else {
+					for _, a := range opts.Assets {
+						if a != "SOL" { // options don't support SOL
+							symbols = append(symbols, a)
+						}
+					}
+				}
+				for _, assetName := range symbols {
+					prefix := platform
+					if platform == "robinhood" {
+						prefix = "rh"
+					}
+					id := fmt.Sprintf("%s-%s-%s", prefix, shortName, strings.ToLower(assetName))
 					cfg.Strategies = append(cfg.Strategies, StrategyConfig{
 						ID:              id,
 						Type:            "options",
@@ -482,6 +501,15 @@ func runInitFromJSON(jsonStr string, outputPath string) int {
 		}
 	}
 
+	// Auto-populate Robinhood options symbols.
+	if opts.EnableOptions {
+		for _, plt := range opts.OptionPlatforms {
+			if plt == "robinhood" && len(opts.RobinhoodOptionsSymbols) == 0 {
+				opts.RobinhoodOptionsSymbols = []string{"SPY", "QQQ"}
+			}
+		}
+	}
+
 	// Auto-populate Robinhood defaults.
 	if opts.EnableRobinhood {
 		if opts.RobinhoodMode == "" {
@@ -600,15 +628,32 @@ func runInit(args []string) int {
 	// Step 4: Options platform.
 	var optionPlatforms []string
 	if enableOptions {
-		platOptions := []string{"deribit", "ibkr", "both"}
+		platOptions := []string{"deribit", "ibkr", "robinhood", "all"}
 		platIdx := p.Choice("\nOptions platform:", platOptions, 0)
 		switch platOptions[platIdx] {
 		case "deribit":
 			optionPlatforms = []string{"deribit"}
 		case "ibkr":
 			optionPlatforms = []string{"ibkr"}
-		case "both":
-			optionPlatforms = []string{"deribit", "ibkr"}
+		case "robinhood":
+			optionPlatforms = []string{"robinhood"}
+		case "all":
+			optionPlatforms = []string{"deribit", "ibkr", "robinhood"}
+		}
+	}
+
+	// Step 4b: Robinhood options stock symbols.
+	var robinhoodOptionsSymbols []string
+	for _, plt := range optionPlatforms {
+		if plt == "robinhood" {
+			symIdxs := p.MultiSelect("\nSelect stock symbols for Robinhood options:", supportedStockSymbols, false)
+			for _, idx := range symIdxs {
+				robinhoodOptionsSymbols = append(robinhoodOptionsSymbols, supportedStockSymbols[idx])
+			}
+			if len(robinhoodOptionsSymbols) == 0 {
+				robinhoodOptionsSymbols = []string{"SPY", "QQQ"} // defaults
+			}
+			break
 		}
 	}
 
@@ -808,39 +853,40 @@ func runInit(args []string) int {
 	}
 
 	opts := InitOptions{
-		OutputPath:            outputPath,
-		Assets:                selectedAssets,
-		EnableSpot:            enableSpot,
-		EnableOptions:         enableOptions,
-		EnablePerps:           enablePerps,
-		OptionPlatforms:       optionPlatforms,
-		PerpsMode:             perpsMode,
-		SpotStrategies:        selectedSpotStrats,
-		IncludePairs:          includePairs,
-		OptStrategies:         selectedOptStrats,
-		PerpsStrategies:       perpsStratIDs,
-		SpotCapital:           spotCapital,
-		OptionsCapital:        optionsCapital,
-		PerpsCapital:          perpsCapital,
-		SpotDrawdown:          spotDrawdown,
-		OptionsDrawdown:       optionsDrawdown,
-		PerpsDrawdown:         perpsDrawdown,
-		EnableRobinhood:       enableRobinhood,
-		RobinhoodMode:         robinhoodMode,
-		RobinhoodStrategies:   robinhoodStratIDs,
-		RobinhoodCapital:      robinhoodCapital,
-		RobinhoodDrawdown:     robinhoodDrawdown,
-		EnableFutures:         enableFutures,
-		FuturesMode:           futuresMode,
-		FuturesStrategies:     futuresStratIDs,
-		FuturesSymbols:        futuresSymbols,
-		FuturesCapital:        futuresCapital,
-		FuturesDrawdown:       futuresDrawdown,
-		FuturesFeePerContract: futuresFeePerContract,
-		DiscordEnabled:        discordEnabled,
-		DiscordOwnerID:        discordOwnerID,
-		ChannelMap:            channelMap,
-		AutoUpdate:            autoUpdate,
+		OutputPath:              outputPath,
+		Assets:                  selectedAssets,
+		EnableSpot:              enableSpot,
+		EnableOptions:           enableOptions,
+		EnablePerps:             enablePerps,
+		OptionPlatforms:         optionPlatforms,
+		PerpsMode:               perpsMode,
+		SpotStrategies:          selectedSpotStrats,
+		IncludePairs:            includePairs,
+		OptStrategies:           selectedOptStrats,
+		PerpsStrategies:         perpsStratIDs,
+		SpotCapital:             spotCapital,
+		OptionsCapital:          optionsCapital,
+		PerpsCapital:            perpsCapital,
+		SpotDrawdown:            spotDrawdown,
+		OptionsDrawdown:         optionsDrawdown,
+		PerpsDrawdown:           perpsDrawdown,
+		RobinhoodOptionsSymbols: robinhoodOptionsSymbols,
+		EnableRobinhood:         enableRobinhood,
+		RobinhoodMode:           robinhoodMode,
+		RobinhoodStrategies:     robinhoodStratIDs,
+		RobinhoodCapital:        robinhoodCapital,
+		RobinhoodDrawdown:       robinhoodDrawdown,
+		EnableFutures:           enableFutures,
+		FuturesMode:             futuresMode,
+		FuturesStrategies:       futuresStratIDs,
+		FuturesSymbols:          futuresSymbols,
+		FuturesCapital:          futuresCapital,
+		FuturesDrawdown:         futuresDrawdown,
+		FuturesFeePerContract:   futuresFeePerContract,
+		DiscordEnabled:          discordEnabled,
+		DiscordOwnerID:          discordOwnerID,
+		ChannelMap:              channelMap,
+		AutoUpdate:              autoUpdate,
 	}
 
 	cfg := generateConfig(opts)

--- a/shared_scripts/check_options.py
+++ b/shared_scripts/check_options.py
@@ -3,7 +3,7 @@
 Unified options strategy check script.
 Evaluates options strategies using a platform adapter.
 
-Usage: python3 check_options.py <strategy> <underlying> [--platform=deribit|ibkr]
+Usage: python3 check_options.py <strategy> <underlying> [--platform=deribit|ibkr|robinhood]
 """
 
 import sys
@@ -44,14 +44,22 @@ def _load_adapter(platform: str):
 
 # ── shared helpers ────────────────────────────────────────────────────────────
 
-def _fetch_ohlcv_closes(underlying, timeframe, limit, min_len):
-    """Fetch OHLCV from BinanceUS and return closing prices, or None if insufficient data."""
-    import ccxt
-    exchange = ccxt.binanceus({"enableRateLimit": True})
-    ohlcv = exchange.fetch_ohlcv(f"{underlying}/USDT", timeframe, limit=limit)
-    if not ohlcv or len(ohlcv) < min_len:
+def _fetch_ohlcv_closes(underlying, timeframe, limit, min_len, adapter=None):
+    """Fetch OHLCV closing prices. Uses adapter if available, else BinanceUS."""
+    # Try adapter's get_ohlcv_closes if available (e.g., Robinhood stocks)
+    if adapter is not None:
+        ohlcv_closes_fn = getattr(adapter, 'get_ohlcv_closes', None)
+        if ohlcv_closes_fn is not None:
+            return ohlcv_closes_fn(underlying, timeframe, limit, min_len)
+    try:
+        import ccxt
+        exchange = ccxt.binanceus({"enableRateLimit": True})
+        ohlcv = exchange.fetch_ohlcv(f"{underlying}/USDT", timeframe, limit=limit)
+        if not ohlcv or len(ohlcv) < min_len:
+            return None
+        return [c[4] for c in ohlcv]
+    except Exception:
         return None
-    return [c[4] for c in ohlcv]
 
 
 def _platform_extra(adapter, underlying: str) -> dict:
@@ -162,7 +170,7 @@ def score_new_trade(proposed_action, existing_positions, spot_price):
 def evaluate_momentum_options(underlying, spot_price, vol_annual, iv_rank,
                                existing_positions, spot_positions, adapter):
     try:
-        closes = _fetch_ohlcv_closes(underlying, "4h", 100, 30)
+        closes = _fetch_ohlcv_closes(underlying, "4h", 100, 30, adapter=adapter)
         if closes is None:
             return 0, [], iv_rank
 


### PR DESCRIPTION
## Summary

- Extends the Robinhood adapter to support US stock options trading (closes #36)
- Paper mode uses Black-Scholes pricing from `shared_tools/pricing.py` — no credentials needed
- Live mode fetches real options chains, strikes, expiries, and greeks from robin_stocks
- Reuses all 6 existing options strategies: covered_calls, protective_puts, momentum_options, vol_mean_reversion, wheel, butterfly
- Supports equity symbols: SPY, QQQ, AAPL, MSFT, AMZN, GOOGL, TSLA, META
- Fee: $0.03/contract regulatory fee (Robinhood charges no commission)

## Changes

### Python
- `platforms/robinhood/adapter.py` — add options Protocol methods (`get_vol_metrics`, `get_real_expiry`, `get_real_strike`, `get_premium_and_greeks`, `get_ohlcv_closes`); extend `get_spot_price` for stock tickers via yfinance/robin_stocks
- `shared_scripts/check_options.py` — adapter-aware `_fetch_ohlcv_closes` fallback for stock symbols (was hardcoded to BinanceUS/CCXT)

### Go
- `scheduler/fees.go` — `RobinhoodOptionFeeFixed = 0.03`, `CalculateRobinhoodOptionFee()`, updated `CalculateOptionFee()` dispatch
- `scheduler/init.go` — add `"robinhood"` to options platform selection, stock symbol prompts, `generateConfig` support with `rh-` prefix

### Documentation
- `CLAUDE.md`, `README.md`, `SKILL.md` — updated with Robinhood options info

## Test plan

- [x] `python3 -m py_compile platforms/robinhood/adapter.py` — passes
- [x] `python3 -m py_compile shared_scripts/check_options.py` — passes
- [x] `cd scheduler && go build .` — compiles cleanly
- [x] `cd scheduler && go test ./...` — all tests pass
- [x] `gofmt` — no formatting issues
- [ ] Smoke test init: `./go-trader init --json '{"assets":["BTC"],"enableOptions":true,"optionPlatforms":["robinhood"],"optStrategies":["covered_calls"],"robinhoodOptionsSymbols":["SPY"],"optionsCapital":5000,"optionsDrawdown":10}' --output /tmp/test_rh_opts.json`