### PR TITLE
feat: sync HL live strategy capital from real wallet balance at startup

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+const hlMainnetURL = "https://api.hyperliquid.xyz"
+
+// fetchHyperliquidBalance fetches the live USDC balance (accountValue) from
+// the Hyperliquid clearinghouseState endpoint for a given address.
+// Returns 0 and a non-nil error if the request fails or the response is unexpected.
+func fetchHyperliquidBalance(accountAddress string) (float64, error) {
+	payload := map[string]string{
+		"type": "clearinghouseState",
+		"user": accountAddress,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return 0, fmt.Errorf("marshal request: %w", err)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Post(hlMainnetURL+"/info", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("http %d from %s", resp.StatusCode, hlMainnetURL)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, fmt.Errorf("read response: %w", err)
+	}
+
+	var result struct {
+		MarginSummary struct {
+			AccountValue string `json:"accountValue"`
+		} `json:"marginSummary"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return 0, fmt.Errorf("parse response: %w", err)
+	}
+
+	val, err := strconv.ParseFloat(result.MarginSummary.AccountValue, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse accountValue %q: %w", result.MarginSummary.AccountValue, err)
+	}
+	return val, nil
+}
+
+// syncHyperliquidLiveCapital checks if a strategy is a live Hyperliquid strategy
+// and if so, fetches the real account balance and updates the strategy config's Capital
+// to match. Logs a warning and falls back to the configured capital on any error.
+//
+// This ensures the bot trades 95% of the actual wallet balance rather than a
+// stale config value.
+func syncHyperliquidLiveCapital(sc *StrategyConfig) {
+	if sc.Platform != "hyperliquid" {
+		return
+	}
+
+	// Only sync in live mode (--mode=live arg present)
+	isLive := false
+	for _, arg := range sc.Args {
+		if arg == "--mode=live" {
+			isLive = true
+			break
+		}
+	}
+	if !isLive {
+		return
+	}
+
+	// HYPERLIQUID_ACCOUNT_ADDRESS must be set explicitly; address derivation
+	// from HYPERLIQUID_SECRET_KEY requires go-ethereum which is not in scope.
+	accountAddr := os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS")
+	if accountAddr == "" {
+		fmt.Printf("[WARN] hl-live-balance: no account address for %s, using config capital=$%.2f\n",
+			sc.ID, sc.Capital)
+		return
+	}
+
+	balance, err := fetchHyperliquidBalance(accountAddr)
+	if err != nil {
+		fmt.Printf("[WARN] hl-live-balance: failed to fetch balance for %s (%s): %v — using config capital=$%.2f\n",
+			sc.ID, accountAddr, err, sc.Capital)
+		return
+	}
+
+	if balance <= 0 {
+		fmt.Printf("[WARN] hl-live-balance: live balance is $%.2f for %s — wallet may be unfunded, using config capital=$%.2f\n",
+			balance, sc.ID, sc.Capital)
+		return
+	}
+
+	fmt.Printf("[INFO] hl-live-balance: synced %s capital from config $%.2f → live balance $%.2f\n",
+		sc.ID, sc.Capital, balance)
+	sc.Capital = balance
+}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -37,9 +37,12 @@ func main() {
 	ValidateState(state)
 
 	// Initialize new strategies and sync config values for existing ones
-	for _, sc := range cfg.Strategies {
+	for i := range cfg.Strategies {
+		sc := &cfg.Strategies[i]
+		// For live Hyperliquid strategies, override capital with the real wallet balance.
+		syncHyperliquidLiveCapital(sc)
 		if s, exists := state.Strategies[sc.ID]; !exists {
-			state.Strategies[sc.ID] = NewStrategyState(sc)
+			state.Strategies[sc.ID] = NewStrategyState(*sc)
 			fmt.Printf("  Initialized strategy: %s (type=%s, capital=$%.0f)\n", sc.ID, sc.Type, sc.Capital)
 		} else {
 			// Sync config → state (config is source of truth).


### PR DESCRIPTION
## Summary
- On startup, for any Hyperliquid strategy running in `--mode=live`, fetch the actual account balance via the HL `clearinghouseState` API and override the configured `capital_usd` with the real wallet value
- Ensures position sizing (95% of capital) is always based on the true wallet balance rather than a potentially stale config value
- Graceful fallback to config value on any error — bot always starts

## Changes
- **New file: `scheduler/hyperliquid_balance.go`**
  - `fetchHyperliquidBalance(addr)` — HTTP POST to `/info` endpoint with status code check, parses `marginSummary.accountValue`
  - `syncHyperliquidLiveCapital(sc)` — detects live HL strategies via `--mode=live` arg, fetches live balance, updates `sc.Capital` in-place
- **`scheduler/main.go`** — iterate strategies by pointer, call `syncHyperliquidLiveCapital` before `NewStrategyState`

## Test plan
- [ ] `go build .` compiles cleanly
- [ ] `go test ./...` passes
- [ ] Paper mode: no behavior change (sync is a no-op without `--mode=live`)
- [ ] Live mode with `HYPERLIQUID_ACCOUNT_ADDRESS` set: logs `[INFO] hl-live-balance: synced ...`
- [ ] Live mode without env var: logs `[WARN]` and falls back to config capital