### PR TITLE
feat: add AMD+IFVG strategy for session-aware trading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,8 @@
 - `cfg.ConfigVersion` — int, schema version (`0`/missing = v1 baseline); `CurrentConfigVersion = 2` in config_migration.go; startup triggers `runConfigMigrationDM` when below current version
 - `cfg.Correlation` — `*CorrelationConfig` with `Enabled` (default false), `MaxConcentrationPct` (default 60), `MaxSameDirectionPct` (default 75); computed under RLock, state assigned under Lock; warnings sent to all Discord channels + owner DM
 - `cfg.AutoUpdate` — `"off"` (default), `"daily"` (once/day), `"heartbeat"` (every cycle); handled in main.go loop + startup; uses `dailyCycles = (24*3600)/tickSeconds`
+- Strategy registry imports: `check_hyperliquid.py` and `check_strategy.py` import from `shared_strategies/spot/strategies.py`; `check_topstep.py` imports from `shared_strategies/futures/strategies.py` — a new strategy must be registered in both if it needs to work across platforms
+- Adding a cross-platform strategy: create core logic in `shared_strategies/<name>.py`, then import+register in both `spot/strategies.py` and `futures/strategies.py` (same pattern as indicators.py)
 - Strategy discovery: `shared_strategies/spot/strategies.py --list-json`, `shared_strategies/options/strategies.py --list-json`, and `shared_strategies/futures/strategies.py --list-json` output JSON arrays of `{"id":..., "description":...}`
 
 ## Build & Deploy
@@ -87,6 +89,7 @@
 - `cd scheduler && /opt/homebrew/bin/go test ./...` — run all unit tests (must run from scheduler/ where go.mod lives; repo root has no go.mod)
 - `cd scheduler && /opt/homebrew/bin/gofmt -w <file>.go` — format after editing Go files (`-l *.go` lists all files needing formatting)
 - Multi-line Go edits with tabs: Edit tool may fail on tab-indented blocks; use heredoc form (one-liner fails on multi-line strings with quotes): `python3 << 'PYEOF'` / `content=open(f).read()` / `open(f,'w').write(content.replace(old,new,1))` / `PYEOF`
+- Strategy listing: `cd shared_strategies/spot && ../../.venv/bin/python3 strategies.py --list-json` (must use venv for numpy/pandas)
 - Smoke test: `./go-trader --once`
 - Run with config: `./go-trader --config scheduler/config.json`
 - Smoke test interactive CLI: `printf "answer1\nanswer2\n" | ./go-trader init`

--- a/scheduler/config.example.json
+++ b/scheduler/config.example.json
@@ -47,6 +47,15 @@
       "capital": 1000,
       "max_drawdown_pct": 50,
       "interval_seconds": 300
+    },
+    {
+      "id": "hl-amd-btc",
+      "type": "perps",
+      "script": "shared_scripts/check_hyperliquid.py",
+      "args": ["amd_ifvg", "BTC", "15m", "--mode=paper"],
+      "capital": 1000,
+      "max_drawdown_pct": 50,
+      "interval_seconds": 900
     }
   ],
   "platforms": {

--- a/shared_strategies/amd_ifvg.py
+++ b/shared_strategies/amd_ifvg.py
@@ -1,0 +1,188 @@
+"""
+AMD+IFVG — ICT Accumulation-Manipulation-Distribution with Implied Fair Value Gap.
+
+Session-aware price action strategy on 15m candles:
+1. Accumulation: Identify Asian session range (high/low)
+2. Manipulation: Detect London open sweep beyond Asian range (stop hunt)
+3. IFVG Detection: Find 3-candle imbalance gap created during manipulation
+4. Entry: Price retraces into the IFVG -> fire signal in direction of reversal
+
+Signal: 1 = BUY, -1 = SELL, 0 = FLAT
+"""
+
+import numpy as np
+import pandas as pd
+
+
+def amd_ifvg_core(
+    df: pd.DataFrame,
+    asian_start_hour: int = 0,
+    asian_end_hour: int = 8,
+    london_start_hour: int = 8,
+    london_end_hour: int = 12,
+    min_ifvg_pct: float = 0.05,
+    sweep_threshold_pct: float = 0.01,
+) -> pd.DataFrame:
+    """
+    AMD+IFVG strategy core logic.
+
+    Parameters:
+        df: OHLCV DataFrame with UTC datetime index
+        asian_start_hour: UTC hour Asian session begins (inclusive)
+        asian_end_hour: UTC hour Asian session ends (exclusive)
+        london_start_hour: UTC hour London kill zone begins (inclusive)
+        london_end_hour: UTC hour London kill zone ends (exclusive)
+        min_ifvg_pct: Minimum IFVG gap as percentage of price (0.05 = 0.05%)
+        sweep_threshold_pct: Penetration beyond Asian range as fraction of range size
+
+    Returns:
+        DataFrame with signal column and indicator columns added.
+    """
+    result = df.copy()
+    n = len(result)
+
+    # Initialize output columns
+    result["signal"] = 0
+    result["asian_high"] = np.nan
+    result["asian_low"] = np.nan
+    result["ifvg_high"] = np.nan
+    result["ifvg_low"] = np.nan
+    result["sweep_dir"] = 0  # 1=above, -1=below, 0=none
+
+    if n < 3:
+        return result
+
+    hours = result.index.hour
+    dates = result.index.date
+
+    # Process each trading day
+    for day in pd.unique(dates):
+        day_mask = dates == day
+
+        # --- Phase 1: Accumulation — Asian session range ---
+        asian_mask = day_mask & (hours >= asian_start_hour) & (hours < asian_end_hour)
+        asian_candles = result.loc[asian_mask]
+
+        if len(asian_candles) < 2:
+            continue
+
+        asian_high = asian_candles["high"].max()
+        asian_low = asian_candles["low"].min()
+        asian_range = asian_high - asian_low
+
+        if asian_range <= 0:
+            continue
+
+        # Write Asian range to all candles for the day
+        result.loc[day_mask, "asian_high"] = asian_high
+        result.loc[day_mask, "asian_low"] = asian_low
+
+        # --- Phase 2: Manipulation — London session sweep detection ---
+        london_mask = day_mask & (hours >= london_start_hour) & (hours < london_end_hour)
+        london_candles = result.loc[london_mask]
+
+        if len(london_candles) < 3:
+            continue
+
+        sweep_threshold = asian_range * sweep_threshold_pct
+
+        # Find first sweep in each direction
+        swept_below_idx = None
+        swept_above_idx = None
+
+        for idx in london_candles.index:
+            row = london_candles.loc[idx]
+            if swept_below_idx is None and row["low"] < (asian_low - sweep_threshold):
+                swept_below_idx = idx
+            if swept_above_idx is None and row["high"] > (asian_high + sweep_threshold):
+                swept_above_idx = idx
+
+        # Determine bias from first sweep
+        if swept_below_idx is not None and swept_above_idx is not None:
+            # Both swept — use whichever happened first
+            if swept_below_idx <= swept_above_idx:
+                bias = -1  # swept below first → bullish reversal
+            else:
+                bias = 1  # swept above first → bearish reversal
+        elif swept_below_idx is not None:
+            bias = -1  # swept below → bullish reversal
+        elif swept_above_idx is not None:
+            bias = 1  # swept above → bearish reversal
+        else:
+            continue  # no sweep — no setup
+
+        result.loc[london_mask, "sweep_dir"] = bias
+        sweep_idx = swept_below_idx if bias == -1 else swept_above_idx
+
+        # --- Phase 3: IFVG Detection — 3-candle imbalance gap ---
+        # Scan candles from the sweep onward for fair value gaps
+        post_sweep_mask = day_mask & (result.index >= sweep_idx)
+        post_sweep = result.loc[post_sweep_mask]
+
+        if len(post_sweep) < 3:
+            continue
+
+        best_ifvg = None
+        best_ifvg_idx = None
+        latest_close = post_sweep["close"].iloc[-1]
+
+        ps_indices = post_sweep.index.tolist()
+        for i in range(2, len(ps_indices)):
+            c0 = post_sweep.loc[ps_indices[i - 2]]  # candle before displacement
+            c2 = post_sweep.loc[ps_indices[i]]       # candle after displacement
+
+            if bias == -1:
+                # Bullish IFVG: gap up (c0 high < c2 low)
+                if c0["high"] < c2["low"]:
+                    gap_low = c0["high"]
+                    gap_high = c2["low"]
+                    gap_size = gap_high - gap_low
+                    mid_price = (gap_high + gap_low) / 2
+                    if mid_price > 0 and (gap_size / mid_price * 100) >= min_ifvg_pct:
+                        dist = abs(latest_close - (gap_high + gap_low) / 2)
+                        if best_ifvg is None or dist < best_ifvg[2]:
+                            best_ifvg = (gap_low, gap_high, dist)
+                            best_ifvg_idx = ps_indices[i]
+            else:
+                # Bearish IFVG: gap down (c0 low > c2 high)
+                if c0["low"] > c2["high"]:
+                    gap_high = c0["low"]
+                    gap_low = c2["high"]
+                    gap_size = gap_high - gap_low
+                    mid_price = (gap_high + gap_low) / 2
+                    if mid_price > 0 and (gap_size / mid_price * 100) >= min_ifvg_pct:
+                        dist = abs(latest_close - (gap_high + gap_low) / 2)
+                        if best_ifvg is None or dist < best_ifvg[2]:
+                            best_ifvg = (gap_low, gap_high, dist)
+                            best_ifvg_idx = ps_indices[i]
+
+        if best_ifvg is None:
+            continue
+
+        ifvg_low, ifvg_high = best_ifvg[0], best_ifvg[1]
+        result.loc[day_mask, "ifvg_high"] = ifvg_high
+        result.loc[day_mask, "ifvg_low"] = ifvg_low
+
+        # --- Phase 4: Entry — Retracement into IFVG ---
+        # Look for price entering the IFVG zone after it forms
+        entry_mask = day_mask & (result.index > best_ifvg_idx)
+        entry_candles = result.loc[entry_mask]
+
+        signal_fired = False
+        for idx in entry_candles.index:
+            if signal_fired:
+                break
+            row = entry_candles.loc[idx]
+
+            if bias == -1:
+                # Bullish entry: price dips into bullish IFVG
+                if row["low"] <= ifvg_high and row["close"] >= ifvg_low:
+                    result.loc[idx, "signal"] = 1
+                    signal_fired = True
+            else:
+                # Bearish entry: price rallies into bearish IFVG
+                if row["high"] >= ifvg_low and row["close"] <= ifvg_high:
+                    result.loc[idx, "signal"] = -1
+                    signal_fired = True
+
+    return result

--- a/shared_strategies/futures/strategies.py
+++ b/shared_strategies/futures/strategies.py
@@ -14,8 +14,11 @@ from typing import Dict, List, Optional
 
 # Add shared_strategies/spot/ to path for indicator functions (sma, ema)
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'spot'))
+# Add shared_strategies/ for amd_ifvg
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from indicators import sma, ema
+from amd_ifvg import amd_ifvg_core
 
 # ─────────────────────────────────────────────
 # Strategy registry
@@ -146,6 +149,19 @@ def breakout_strategy(df: pd.DataFrame, lookback: int = 20, atr_period: int = 14
     breakout_down = (result["close"] < result["low_roll"].shift(1)) & (tr > result["atr"] * atr_multiplier)
     result.loc[breakout_down & ~breakout_down.shift(1, fill_value=False), "signal"] = -1
     return result
+
+
+@register_strategy(
+    "amd_ifvg",
+    "AMD+IFVG — ICT Accumulation-Manipulation-Distribution with Implied Fair Value Gap (15m, session-aware)",
+    {
+        "asian_start_hour": 0, "asian_end_hour": 8,
+        "london_start_hour": 8, "london_end_hour": 12,
+        "min_ifvg_pct": 0.05, "sweep_threshold_pct": 0.01,
+    }
+)
+def amd_ifvg_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return amd_ifvg_core(df, **params)
 
 
 if __name__ == "__main__":

--- a/shared_strategies/spot/strategies.py
+++ b/shared_strategies/spot/strategies.py
@@ -4,10 +4,15 @@ Each strategy takes a DataFrame with OHLCV data and returns it with a 'signal' c
 signal: 1 = buy, -1 = sell, 0 = hold
 """
 
+import os
+import sys
 import numpy as np
 import pandas as pd
 from typing import Dict, Any, List, Optional, Callable
 from indicators import sma, ema
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from amd_ifvg import amd_ifvg_core
 
 
 # ─────────────────────────────────────────────
@@ -267,8 +272,20 @@ def pairs_spread_strategy(df: pd.DataFrame, lookback: int = 30, entry_z: float =
     return result
 
 
+@register_strategy(
+    "amd_ifvg",
+    "AMD+IFVG — ICT Accumulation-Manipulation-Distribution with Implied Fair Value Gap (15m, session-aware)",
+    {
+        "asian_start_hour": 0, "asian_end_hour": 8,
+        "london_start_hour": 8, "london_end_hour": 12,
+        "min_ifvg_pct": 0.05, "sweep_threshold_pct": 0.01,
+    }
+)
+def amd_ifvg_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return amd_ifvg_core(df, **params)
+
+
 if __name__ == "__main__":
-    import sys
     import json
     if "--list-json" in sys.argv:
         print(json.dumps([{"id": name, "description": STRATEGY_REGISTRY[name]["description"]} for name in list_strategies()]))


### PR DESCRIPTION
## Summary
- Implements ICT AMD+IFVG strategy as a new cross-platform strategy (closes #42)
- Session-aware logic on 15m candles: Asian range detection → London sweep → IFVG entry
- Registered in both spot and futures strategy registries for HL perps + TopStep futures support
- Core algorithm in `shared_strategies/amd_ifvg.py`, registered via thin wrappers in both registries

## Strategy Logic
1. **Accumulation** — Asian session (00:00–08:00 UTC) high/low range
2. **Manipulation** — London session (08:00–12:00 UTC) sweep beyond Asian range
3. **IFVG Detection** — 3-candle imbalance gap during manipulation
4. **Entry** — Price retraces into IFVG → signal fires (1 signal/day max)

## Files Changed
- `shared_strategies/amd_ifvg.py` — new core algorithm
- `shared_strategies/spot/strategies.py` — register `amd_ifvg`
- `shared_strategies/futures/strategies.py` — register `amd_ifvg`
- `scheduler/config.example.json` — add `hl-amd-btc` example
- `CLAUDE.md` — document cross-platform strategy pattern

## Test plan
- [x] `python3 -m py_compile` passes on all 3 Python files
- [x] `--list-json` shows `amd_ifvg` in both spot and futures registries
- [x] Functional test with synthetic data fires correct bullish signal
- [x] Go build + unit tests pass (no Go changes needed)
- [ ] Paper trade on Hyperliquid with BTC 15m