### PR TITLE
feat: Add Heikin Ashi + EMA strategy

### DIFF
--- a/shared_strategies/futures/strategies.py
+++ b/shared_strategies/futures/strategies.py
@@ -247,6 +247,43 @@ def amd_ifvg_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
     return amd_ifvg_core(df, **params)
 
 
+@register_strategy(
+    "heikin_ashi_ema",
+    "Heikin Ashi + EMA — smoothed candles with EMA trend filter; 2 consecutive HA candles + price side of EMA",
+    {"ema_period": 21, "confirmation": 2}
+)
+def heikin_ashi_ema_strategy(df: pd.DataFrame, ema_period: int = 21, confirmation: int = 2) -> pd.DataFrame:
+    result = df.copy()
+    # Compute Heikin Ashi candles
+    ha_close = (result["open"] + result["high"] + result["low"] + result["close"]) / 4
+    ha_open = ha_close.copy()
+    for i in range(1, len(result)):
+        ha_open.iloc[i] = (ha_open.iloc[i - 1] + ha_close.iloc[i - 1]) / 2
+    ha_high = pd.concat([result["high"], ha_open, ha_close], axis=1).max(axis=1)
+    ha_low = pd.concat([result["low"], ha_open, ha_close], axis=1).min(axis=1)
+    result["ha_open"] = ha_open
+    result["ha_close"] = ha_close
+    result["ha_high"] = ha_high
+    result["ha_low"] = ha_low
+    result["ha_ema"] = ema(ha_close, ema_period)
+    # Bullish HA: green candle (ha_close > ha_open) with no lower wick (ha_low == ha_open)
+    result["ha_bullish"] = (ha_close > ha_open) & (ha_low == ha_open)
+    # Bearish HA: red candle (ha_close < ha_open) with no upper wick (ha_high == ha_open)
+    result["ha_bearish"] = (ha_close < ha_open) & (ha_high == ha_open)
+    # Require `confirmation` consecutive bullish/bearish candles
+    bull_streak = result["ha_bullish"].rolling(window=confirmation).sum() == confirmation
+    bear_streak = result["ha_bearish"].rolling(window=confirmation).sum() == confirmation
+    above_ema = ha_close > result["ha_ema"]
+    below_ema = ha_close < result["ha_ema"]
+    result["signal"] = 0
+    # BUY: confirmation consecutive bullish HA candles + price above EMA
+    buy_cond = bull_streak & above_ema
+    sell_cond = bear_streak & below_ema
+    result.loc[buy_cond & ~buy_cond.shift(1, fill_value=False), "signal"] = 1
+    result.loc[sell_cond & ~sell_cond.shift(1, fill_value=False), "signal"] = -1
+    return result
+
+
 if __name__ == "__main__":
     if "--list-json" in sys.argv:
         print(json.dumps([{"id": name, "description": STRATEGY_REGISTRY[name]["description"]} for name in list_strategies()]))

--- a/shared_strategies/spot/strategies.py
+++ b/shared_strategies/spot/strategies.py
@@ -368,6 +368,43 @@ def amd_ifvg_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
     return amd_ifvg_core(df, **params)
 
 
+@register_strategy(
+    "heikin_ashi_ema",
+    "Heikin Ashi + EMA — smoothed candles with EMA trend filter; 2 consecutive HA candles + price side of EMA",
+    {"ema_period": 21, "confirmation": 2}
+)
+def heikin_ashi_ema_strategy(df: pd.DataFrame, ema_period: int = 21, confirmation: int = 2) -> pd.DataFrame:
+    result = df.copy()
+    # Compute Heikin Ashi candles
+    ha_close = (result["open"] + result["high"] + result["low"] + result["close"]) / 4
+    ha_open = ha_close.copy()
+    for i in range(1, len(result)):
+        ha_open.iloc[i] = (ha_open.iloc[i - 1] + ha_close.iloc[i - 1]) / 2
+    ha_high = pd.concat([result["high"], ha_open, ha_close], axis=1).max(axis=1)
+    ha_low = pd.concat([result["low"], ha_open, ha_close], axis=1).min(axis=1)
+    result["ha_open"] = ha_open
+    result["ha_close"] = ha_close
+    result["ha_high"] = ha_high
+    result["ha_low"] = ha_low
+    result["ha_ema"] = ema(ha_close, ema_period)
+    # Bullish HA: green candle (ha_close > ha_open) with no lower wick (ha_low == ha_open)
+    result["ha_bullish"] = (ha_close > ha_open) & (ha_low == ha_open)
+    # Bearish HA: red candle (ha_close < ha_open) with no upper wick (ha_high == ha_open)
+    result["ha_bearish"] = (ha_close < ha_open) & (ha_high == ha_open)
+    # Require `confirmation` consecutive bullish/bearish candles
+    bull_streak = result["ha_bullish"].rolling(window=confirmation).sum() == confirmation
+    bear_streak = result["ha_bearish"].rolling(window=confirmation).sum() == confirmation
+    above_ema = ha_close > result["ha_ema"]
+    below_ema = ha_close < result["ha_ema"]
+    result["signal"] = 0
+    # BUY: confirmation consecutive bullish HA candles + price above EMA
+    buy_cond = bull_streak & above_ema
+    sell_cond = bear_streak & below_ema
+    result.loc[buy_cond & ~buy_cond.shift(1, fill_value=False), "signal"] = 1
+    result.loc[sell_cond & ~sell_cond.shift(1, fill_value=False), "signal"] = -1
+    return result
+
+
 if __name__ == "__main__":
     import json
     if "--list-json" in sys.argv:


### PR DESCRIPTION
Implements the `heikin_ashi_ema` strategy as described in #49.

Adds `heikin_ashi_ema_strategy()` to both `shared_strategies/spot/strategies.py` and `shared_strategies/futures/strategies.py`, making it available across all platforms (spot, perps, options, futures).

Closes #49

Generated with [Claude Code](https://claude.ai/code)