### PR TITLE
ci: use Opus 4.6 with ultrathink for Claude GitHub Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--model claude-opus-4-6 --ultrathink'
 


### PR DESCRIPTION
## Summary
- Configure Claude Code GitHub Action to use `claude-opus-4-6` model instead of the default Sonnet
- Enable `--ultrathink` flag for higher quality reasoning on issues and PRs

## Test plan
- [ ] Verify workflow file syntax is valid
- [ ] Tag @claude in a test issue to confirm Opus model is used