### PR TITLE
feat: add VWAP Reversion strategy

### DIFF
--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -46,6 +46,7 @@ var knownShortNames = map[string]string{
 	"atr_breakout":       "atrbo",
 	"stoch_rsi":          "stochrsi",
 	"ichimoku_cloud":     "ichi",
+	"vwap_reversion":     "vwap",
 }
 
 // deriveShortName returns a short abbreviation for a strategy ID.
@@ -78,6 +79,7 @@ var defaultSpotStrategies = []stratDef{
 	{ID: "rsi_macd_combo", ShortName: "rmc"},
 	{ID: "stoch_rsi", ShortName: "stochrsi"},
 	{ID: "ichimoku_cloud", ShortName: "ichi"},
+	{ID: "vwap_reversion", ShortName: "vwap"},
 }
 
 var defaultOptionsStrategies = []stratDef{
@@ -99,6 +101,7 @@ var defaultFuturesStrategies = []stratDef{
 	{ID: "breakout", ShortName: "bo"},
 	{ID: "stoch_rsi", ShortName: "stochrsi"},
 	{ID: "ichimoku_cloud", ShortName: "ichi"},
+	{ID: "vwap_reversion", ShortName: "vwap"},
 }
 
 // Supported CME futures symbols for the init wizard.

--- a/shared_strategies/futures/strategies.py
+++ b/shared_strategies/futures/strategies.py
@@ -392,6 +392,43 @@ def heikin_ashi_ema_strategy(df: pd.DataFrame, ema_period: int = 21, confirmatio
     return result
 
 
+@register_strategy(
+    "vwap_reversion",
+    "VWAP Reversion — buy when price drops below VWAP by N std devs, sell when above",
+    {"entry_std": 1.5, "exit_std": 0.2}
+)
+def vwap_reversion_strategy(df: pd.DataFrame, entry_std: float = 1.5, exit_std: float = 0.2) -> pd.DataFrame:
+    result = df.copy()
+    # Detect daily boundaries for VWAP reset
+    if isinstance(result.index, pd.DatetimeIndex):
+        day = result.index.date
+    else:
+        day = pd.to_datetime(result.index).date
+    result["_day"] = day
+    typical_price = (result["high"] + result["low"] + result["close"]) / 3
+    result["_tp_vol"] = typical_price * result["volume"]
+    # Cumulative sums reset each day
+    result["_cum_tp_vol"] = result.groupby("_day")["_tp_vol"].cumsum()
+    result["_cum_vol"] = result.groupby("_day")["volume"].cumsum()
+    result["vwap"] = result["_cum_tp_vol"] / result["_cum_vol"]
+    # Rolling std of price deviation from VWAP (use intraday window)
+    result["vwap_std"] = result.groupby("_day")["close"].transform(
+        lambda x: (x - result.loc[x.index, "vwap"]).expanding().std()
+    )
+    result["vwap_std"] = result["vwap_std"].fillna(0)
+    result["signal"] = 0
+    # BUY: price crosses below VWAP - entry_std * std
+    lower = result["vwap"] - entry_std * result["vwap_std"]
+    upper = result["vwap"] + entry_std * result["vwap_std"]
+    buy_cross = (result["close"] < lower) & (result["close"].shift(1) >= lower.shift(1))
+    sell_cross = (result["close"] > upper) & (result["close"].shift(1) <= upper.shift(1))
+    result.loc[buy_cross, "signal"] = 1
+    result.loc[sell_cross, "signal"] = -1
+    # Clean up temp columns
+    result.drop(columns=["_day", "_tp_vol", "_cum_tp_vol", "_cum_vol"], inplace=True)
+    return result
+
+
 if __name__ == "__main__":
     if "--list-json" in sys.argv:
         print(json.dumps([{"id": name, "description": STRATEGY_REGISTRY[name]["description"]} for name in list_strategies()]))

--- a/shared_strategies/spot/strategies.py
+++ b/shared_strategies/spot/strategies.py
@@ -513,6 +513,43 @@ def heikin_ashi_ema_strategy(df: pd.DataFrame, ema_period: int = 21, confirmatio
     return result
 
 
+@register_strategy(
+    "vwap_reversion",
+    "VWAP Reversion — buy when price drops below VWAP by N std devs, sell when above",
+    {"entry_std": 1.5, "exit_std": 0.2}
+)
+def vwap_reversion_strategy(df: pd.DataFrame, entry_std: float = 1.5, exit_std: float = 0.2) -> pd.DataFrame:
+    result = df.copy()
+    # Detect daily boundaries for VWAP reset
+    if isinstance(result.index, pd.DatetimeIndex):
+        day = result.index.date
+    else:
+        day = pd.to_datetime(result.index).date
+    result["_day"] = day
+    typical_price = (result["high"] + result["low"] + result["close"]) / 3
+    result["_tp_vol"] = typical_price * result["volume"]
+    # Cumulative sums reset each day
+    result["_cum_tp_vol"] = result.groupby("_day")["_tp_vol"].cumsum()
+    result["_cum_vol"] = result.groupby("_day")["volume"].cumsum()
+    result["vwap"] = result["_cum_tp_vol"] / result["_cum_vol"]
+    # Rolling std of price deviation from VWAP (use intraday window)
+    result["vwap_std"] = result.groupby("_day")["close"].transform(
+        lambda x: (x - result.loc[x.index, "vwap"]).expanding().std()
+    )
+    result["vwap_std"] = result["vwap_std"].fillna(0)
+    result["signal"] = 0
+    # BUY: price crosses below VWAP - entry_std * std
+    lower = result["vwap"] - entry_std * result["vwap_std"]
+    upper = result["vwap"] + entry_std * result["vwap_std"]
+    buy_cross = (result["close"] < lower) & (result["close"].shift(1) >= lower.shift(1))
+    sell_cross = (result["close"] > upper) & (result["close"].shift(1) <= upper.shift(1))
+    result.loc[buy_cross, "signal"] = 1
+    result.loc[sell_cross, "signal"] = -1
+    # Clean up temp columns
+    result.drop(columns=["_day", "_tp_vol", "_cum_tp_vol", "_cum_vol"], inplace=True)
+    return result
+
+
 if __name__ == "__main__":
     import json
     if "--list-json" in sys.argv:


### PR DESCRIPTION
## Summary
- Add `vwap_reversion` strategy to spot and futures registries with daily-reset VWAP, expanding std dev bands, and crossover signals at ±1.5 std devs
- Register in Go `knownShortNames`, `defaultSpotStrategies`, and `defaultFuturesStrategies`

Closes #48

## Test plan
- [x] `strategies.py --list-json` confirms `vwap_reversion` in both spot and futures
- [x] `go build` passes
- [x] `go test ./...` passes
- [x] `py_compile` passes for both strategy files
- [ ] Paper trading on all platforms