### PR TITLE
feat: add Liquidity Sweeps (ICT) strategy across all platforms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,10 +65,10 @@
 - `cfg.Correlation` — `*CorrelationConfig` with `Enabled` (default false), `MaxConcentrationPct` (default 60), `MaxSameDirectionPct` (default 75); computed under RLock, state assigned under Lock; warnings sent to all Discord channels + owner DM
 - `cfg.AutoUpdate` — `"off"` (default), `"daily"` (once/day), `"heartbeat"` (every cycle); handled in main.go loop + startup; uses `dailyCycles = (24*3600)/tickSeconds`
 - Strategy registry imports: `check_hyperliquid.py` and `check_strategy.py` import from `shared_strategies/spot/strategies.py`; `check_topstep.py` imports from `shared_strategies/futures/strategies.py` — a new strategy must be registered in both if it needs to work across platforms
-- Adding a cross-platform strategy: create core logic in `shared_strategies/<name>.py`, then import+register in both `spot/strategies.py` and `futures/strategies.py` (same pattern as indicators.py)
+- Adding a cross-platform strategy: create core logic in `shared_strategies/<name>.py` (see `chart_patterns.py`, `liquidity_sweeps.py`), then import+register in both `spot/strategies.py` and `futures/strategies.py`; thin wrapper: `@register_strategy(...)` + `def x(df, **params): return x_core(df, **params)`
 - Adding a new spot/futures strategy (no new platform): (1) add `@register_strategy` function to `shared_strategies/spot/strategies.py`, (2) add same to `shared_strategies/futures/strategies.py`, (3) add short name to `knownShortNames` in `scheduler/init.go` — auto-discovery handles all platform configs
 - Spot and futures have independent `STRATEGY_REGISTRY` dicts — a new strategy must be added to both files with `@register_strategy` decorator; perps auto-discovers from spot via `discoverStrategies()`
-- New strategies also need: (1) `knownShortNames` entry in `init.go` for the `"name": "abbrev"` mapping, (2) `defaultSpotStrategies` / `defaultFuturesStrategies` fallback entries in `init.go`
+- New strategies also need: (1) `knownShortNames` entry in `init.go` for the `"name": "abbrev"` mapping, (2) `defaultSpotStrategies` / `defaultPerpsStrategies` / `defaultFuturesStrategies` fallback entries in `init.go`
 - Strategy discovery: `shared_strategies/spot/strategies.py --list-json`, `shared_strategies/options/strategies.py --list-json`, and `shared_strategies/futures/strategies.py --list-json` output JSON arrays of `{"id":..., "description":...}`
 
 ## Pull Requests

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -48,6 +48,7 @@ var knownShortNames = map[string]string{
 	"ichimoku_cloud":     "ichi",
 	"vwap_reversion":     "vwap",
 	"chart_pattern":      "cpat",
+	"liquidity_sweeps":   "liqsw",
 }
 
 // deriveShortName returns a short abbreviation for a strategy ID.
@@ -82,6 +83,7 @@ var defaultSpotStrategies = []stratDef{
 	{ID: "ichimoku_cloud", ShortName: "ichi"},
 	{ID: "vwap_reversion", ShortName: "vwap"},
 	{ID: "chart_pattern", ShortName: "cpat"},
+	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 }
 
 var defaultOptionsStrategies = []stratDef{
@@ -94,6 +96,7 @@ var defaultOptionsStrategies = []stratDef{
 var defaultPerpsStrategies = []stratDef{
 	{ID: "momentum", ShortName: "momentum"},
 	{ID: "chart_pattern", ShortName: "cpat"},
+	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 }
 
 var defaultFuturesStrategies = []stratDef{
@@ -106,6 +109,7 @@ var defaultFuturesStrategies = []stratDef{
 	{ID: "ichimoku_cloud", ShortName: "ichi"},
 	{ID: "vwap_reversion", ShortName: "vwap"},
 	{ID: "chart_pattern", ShortName: "cpat"},
+	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 }
 
 // Supported CME futures symbols for the init wizard.

--- a/shared_strategies/futures/strategies.py
+++ b/shared_strategies/futures/strategies.py
@@ -20,6 +20,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from indicators import sma, ema
 from amd_ifvg import amd_ifvg_core
 from chart_patterns import chart_pattern_core
+from liquidity_sweeps import liquidity_sweep_core
 
 # ─────────────────────────────────────────────
 # Strategy registry
@@ -437,6 +438,15 @@ def vwap_reversion_strategy(df: pd.DataFrame, entry_std: float = 1.5, exit_std: 
 )
 def chart_pattern_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
     return chart_pattern_core(df, **params)
+
+
+@register_strategy(
+    "liquidity_sweeps",
+    "Liquidity Sweeps (ICT) — fades stop-hunt wicks beyond swing highs/lows after price closes back inside range",
+    {"swing_lookback": 20, "confirmation": 1}
+)
+def liquidity_sweeps_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return liquidity_sweep_core(df, **params)
 
 
 if __name__ == "__main__":

--- a/shared_strategies/liquidity_sweeps.py
+++ b/shared_strategies/liquidity_sweeps.py
@@ -1,0 +1,95 @@
+"""
+Liquidity Sweeps (ICT/SMC) — core strategy logic.
+
+Price frequently sweeps beyond key swing highs/lows to hunt stop losses before
+reversing. This strategy fades the sweep after confirmation: the candle's wick
+pierces the liquidity pool but the body closes back inside the prior range.
+
+Bullish sweep: low dips below recent swing low, close finishes above it → BUY
+Bearish sweep: high spikes above recent swing high, close finishes below it → SELL
+"""
+
+import numpy as np
+import pandas as pd
+
+
+def _find_swing_highs(highs: pd.Series, lookback: int) -> pd.Series:
+    """Mark swing highs — local maxima where high[i] is the max over ±lookback window."""
+    swing = pd.Series(np.nan, index=highs.index)
+    for i in range(lookback, len(highs) - lookback):
+        window = highs.iloc[i - lookback : i + lookback + 1]
+        if highs.iloc[i] == window.max():
+            swing.iloc[i] = highs.iloc[i]
+    return swing
+
+
+def _find_swing_lows(lows: pd.Series, lookback: int) -> pd.Series:
+    """Mark swing lows — local minima where low[i] is the min over ±lookback window."""
+    swing = pd.Series(np.nan, index=lows.index)
+    for i in range(lookback, len(lows) - lookback):
+        window = lows.iloc[i - lookback : i + lookback + 1]
+        if lows.iloc[i] == window.min():
+            swing.iloc[i] = lows.iloc[i]
+    return swing
+
+
+def liquidity_sweep_core(
+    df: pd.DataFrame,
+    swing_lookback: int = 20,
+    confirmation: int = 1,
+) -> pd.DataFrame:
+    """
+    Detect liquidity sweeps and generate fade signals.
+
+    Parameters
+    ----------
+    df : DataFrame with open, high, low, close columns
+    swing_lookback : number of candles on each side to identify swing points
+    confirmation : reserved for future multi-candle confirmation (currently 1)
+
+    Returns
+    -------
+    DataFrame with added 'signal' column: 1 (buy), -1 (sell), 0 (hold)
+    """
+    result = df.copy()
+    result["signal"] = 0
+
+    if len(result) < swing_lookback * 2 + 1:
+        return result
+
+    swing_highs = _find_swing_highs(result["high"], swing_lookback)
+    swing_lows = _find_swing_lows(result["low"], swing_lookback)
+
+    # Track the most recent confirmed swing high/low as liquidity pools
+    recent_swing_high = np.nan
+    recent_swing_low = np.nan
+
+    for i in range(len(result)):
+        high_i = result["high"].iloc[i]
+        low_i = result["low"].iloc[i]
+        close_i = result["close"].iloc[i]
+
+        # Check for sweeps against current liquidity pools
+        if not np.isnan(recent_swing_high):
+            # Bearish sweep: wick above swing high but close below it
+            if high_i > recent_swing_high and close_i < recent_swing_high:
+                if i == 0 or result["signal"].iloc[i - 1] != -1:
+                    result.iloc[i, result.columns.get_loc("signal")] = -1
+                    recent_swing_high = np.nan  # consumed
+
+        if not np.isnan(recent_swing_low):
+            # Bullish sweep: wick below swing low but close above it
+            if low_i < recent_swing_low and close_i > recent_swing_low:
+                if i == 0 or result["signal"].iloc[i - 1] != 1:
+                    result.iloc[i, result.columns.get_loc("signal")] = 1
+                    recent_swing_low = np.nan  # consumed
+
+        # Update liquidity pools from confirmed swing points
+        # Only use swing points from candles before the current one to avoid lookahead
+        if i > 0:
+            if not np.isnan(swing_highs.iloc[i - 1]):
+                recent_swing_high = swing_highs.iloc[i - 1]
+            if not np.isnan(swing_lows.iloc[i - 1]):
+                recent_swing_low = swing_lows.iloc[i - 1]
+
+    return result

--- a/shared_strategies/spot/strategies.py
+++ b/shared_strategies/spot/strategies.py
@@ -14,6 +14,7 @@ from indicators import sma, ema
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from amd_ifvg import amd_ifvg_core
 from chart_patterns import chart_pattern_core
+from liquidity_sweeps import liquidity_sweep_core
 
 
 # ─────────────────────────────────────────────
@@ -558,6 +559,15 @@ def vwap_reversion_strategy(df: pd.DataFrame, entry_std: float = 1.5, exit_std: 
 )
 def chart_pattern_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
     return chart_pattern_core(df, **params)
+
+
+@register_strategy(
+    "liquidity_sweeps",
+    "Liquidity Sweeps (ICT) — fades stop-hunt wicks beyond swing highs/lows after price closes back inside range",
+    {"swing_lookback": 20, "confirmation": 1}
+)
+def liquidity_sweeps_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return liquidity_sweep_core(df, **params)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add ICT Liquidity Sweeps strategy that fades stop-hunt wicks beyond swing highs/lows
- Core logic in `shared_strategies/liquidity_sweeps.py`, registered in both spot and futures strategy engines
- Added to `knownShortNames`, `defaultSpotStrategies`, `defaultPerpsStrategies`, and `defaultFuturesStrategies` in `init.go`
- Updated CLAUDE.md with improved cross-platform strategy addition docs

Closes #64

## Test plan
- [ ] `shared_strategies/spot/strategies.py --list-json` includes `liquidity_sweeps`
- [ ] `shared_strategies/futures/strategies.py --list-json` includes `liquidity_sweeps`
- [ ] `python3 -m py_compile shared_strategies/liquidity_sweeps.py` passes
- [ ] `cd scheduler && go build .` succeeds
- [ ] `cd scheduler && go test ./...` passes
- [ ] Paper trading on all platforms produces valid signals