### PR TITLE
feat: add multi-timeframe (HTF) trend filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,10 @@
 - Spot and futures have independent `STRATEGY_REGISTRY` dicts — a new strategy must be added to both files with `@register_strategy` decorator; perps auto-discovers from spot via `discoverStrategies()`
 - New strategies also need: (1) `knownShortNames` entry in `init.go` for the `"name": "abbrev"` mapping, (2) `defaultSpotStrategies` / `defaultFuturesStrategies` fallback entries in `init.go`
 - Strategy discovery: `shared_strategies/spot/strategies.py --list-json`, `shared_strategies/options/strategies.py --list-json`, and `shared_strategies/futures/strategies.py --list-json` output JSON arrays of `{"id":..., "description":...}`
+- Adding a per-strategy config flag (cross-cutting): (1) add field to `StrategyConfig` in `config.go`, (2) in `main.go` `run*Check` functions append CLI flag to args when enabled, (3) parse flag in each Python check script, (4) add to `InitOptions` + wizard prompt + `generateConfig` in `init.go`
+- `check_strategy.py` uses manual `sys.argv` parsing (not argparse) — when adding flags, filter `--` prefixed args from positional args before indexing; other check scripts (hyperliquid, topstep, robinhood) use `argparse` so just add `parser.add_argument("--flag")`
+- `shared_tools/htf_filter.py` — `htf_trend_filter(symbol, timeframe, fetch_fn)` returns HTF trend via 50 EMA; `apply_htf_filter(signal, htf_trend)` filters counter-trend signals; `fetch_fn` is a callable `(symbol, tf, limit) → DataFrame` so it works across all platforms
+- `StrategyConfig.HTFFilter` — per-strategy bool (`htf_filter` in JSON); Go appends `--htf-filter` to script args; not applied to options strategies
 
 ## Pull Requests
 - PR descriptions must reference the related GitHub issue if one exists, using `Closes #<number>` in the body (e.g. `Closes #46`)
@@ -101,3 +105,4 @@
 - Run with config: `./go-trader --config scheduler/config.json`
 - Smoke test interactive CLI: `printf "answer1\nanswer2\n" | ./go-trader init`
 - Smoke test JSON CLI: `./go-trader init --json '{"assets":["BTC"],"enableSpot":true,"spotStrategies":["sma_crossover"],"spotCapital":1000,"spotDrawdown":10}' --output /tmp/test.json`
+- Smoke test HTF filter: `./go-trader init --json '{"assets":["BTC"],"enableSpot":true,"spotStrategies":["sma_crossover"],"spotCapital":1000,"spotDrawdown":10,"htfFilter":true}' --output /tmp/test.json` — verify `htf_filter: true` in output

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -75,6 +75,7 @@ type StrategyConfig struct {
 	Capital         float64             `json:"capital"`
 	MaxDrawdownPct  float64             `json:"max_drawdown_pct"`
 	IntervalSeconds int                 `json:"interval_seconds,omitempty"` // per-strategy override (0 = use global)
+	HTFFilter       bool                `json:"htf_filter,omitempty"`       // higher-timeframe trend filter
 	ThetaHarvest    *ThetaHarvestConfig `json:"theta_harvest,omitempty"`
 	FuturesConfig   *FuturesConfig      `json:"futures,omitempty"`
 }

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -210,6 +210,7 @@ type InitOptions struct {
 	RobinhoodCapital        float64
 	RobinhoodDrawdown       float64
 	RobinhoodOptionsSymbols []string // stock tickers for Robinhood options (e.g. ["SPY", "QQQ"])
+	HTFFilter               bool     // higher-timeframe trend filter for all strategies
 	DiscordEnabled          bool
 	DiscordOwnerID          string            // Discord user ID for DM features (upgrade prompts, config migration)
 	SpotChannelID           string            // deprecated: use ChannelMap
@@ -450,6 +451,15 @@ func generateConfig(opts InitOptions) *Config {
 	if usesLuno {
 		cfg.Platforms["luno"] = &PlatformConfig{
 			StateFile: "platforms/luno/state.json",
+		}
+	}
+
+	// Apply HTF filter to all non-options strategies if enabled.
+	if opts.HTFFilter {
+		for i := range cfg.Strategies {
+			if cfg.Strategies[i].Type != "options" {
+				cfg.Strategies[i].HTFFilter = true
+			}
 		}
 	}
 
@@ -918,6 +928,10 @@ func runInit(args []string) int {
 	autoUpdateModes := []string{"off", "daily", "heartbeat"}
 	autoUpdate := autoUpdateModes[autoUpdateIdx]
 
+	// HTF trend filter.
+	fmt.Println("\n--- HTF Trend Filter ---")
+	htfFilter := p.YesNo("Enable higher-timeframe trend filter? (filters counter-trend signals)", true)
+
 	// Collect all perps strategy IDs (auto-selected, no user prompt).
 	perpsStratIDs := make([]string, len(perpsStrategies))
 	for i, s := range perpsStrategies {
@@ -983,6 +997,7 @@ func runInit(args []string) int {
 		FuturesCapital:          futuresCapital,
 		FuturesDrawdown:         futuresDrawdown,
 		FuturesFeePerContract:   futuresFeePerContract,
+		HTFFilter:               htfFilter,
 		DiscordEnabled:          discordEnabled,
 		DiscordOwnerID:          discordOwnerID,
 		ChannelMap:              channelMap,

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -671,9 +671,13 @@ func main() {
 // runSpotCheck runs the spot check subprocess and returns the parsed result.
 // No state access. Returns (result, signalStr, price, ok); ok=false means skip execution.
 func runSpotCheck(sc StrategyConfig, prices map[string]float64, logger *StrategyLogger) (*SpotResult, string, float64, bool) {
-	logger.Info("Running: python3 %s %v", sc.Script, sc.Args)
+	args := sc.Args
+	if sc.HTFFilter {
+		args = append(append([]string{}, args...), "--htf-filter")
+	}
+	logger.Info("Running: python3 %s %v", sc.Script, args)
 
-	result, stderr, err := RunSpotCheck(sc.Script, sc.Args)
+	result, stderr, err := RunSpotCheck(sc.Script, args)
 	if err != nil {
 		logger.Error("Script failed: %v", err)
 		if stderr != "" {
@@ -807,9 +811,13 @@ func hyperliquidSymbol(args []string) string {
 
 // runHyperliquidCheck runs check_hyperliquid.py signal-check mode (Phase 3, no lock).
 func runHyperliquidCheck(sc StrategyConfig, prices map[string]float64, logger *StrategyLogger) (*HyperliquidResult, string, float64, bool) {
-	logger.Info("Running: python3 %s %v", sc.Script, sc.Args)
+	args := sc.Args
+	if sc.HTFFilter {
+		args = append(append([]string{}, args...), "--htf-filter")
+	}
+	logger.Info("Running: python3 %s %v", sc.Script, args)
 
-	result, stderr, err := RunHyperliquidCheck(sc.Script, sc.Args)
+	result, stderr, err := RunHyperliquidCheck(sc.Script, args)
 	if err != nil {
 		logger.Error("Script failed: %v", err)
 		if stderr != "" {
@@ -933,9 +941,13 @@ func topstepSymbol(args []string) string {
 
 // runTopStepCheck runs check_topstep.py signal-check mode (Phase 3, no lock).
 func runTopStepCheck(sc StrategyConfig, prices map[string]float64, logger *StrategyLogger) (*TopStepResult, string, float64, bool) {
-	logger.Info("Running: python3 %s %v", sc.Script, sc.Args)
+	args := sc.Args
+	if sc.HTFFilter {
+		args = append(append([]string{}, args...), "--htf-filter")
+	}
+	logger.Info("Running: python3 %s %v", sc.Script, args)
 
-	result, stderr, err := RunTopStepCheck(sc.Script, sc.Args)
+	result, stderr, err := RunTopStepCheck(sc.Script, args)
 	if err != nil {
 		logger.Error("Script failed: %v", err)
 		if stderr != "" {
@@ -1080,9 +1092,13 @@ func robinhoodSymbol(args []string) string {
 
 // runRobinhoodCheck runs check_robinhood.py signal-check mode (Phase 3, no lock).
 func runRobinhoodCheck(sc StrategyConfig, prices map[string]float64, logger *StrategyLogger) (*RobinhoodResult, string, float64, bool) {
-	logger.Info("Running: python3 %s %v", sc.Script, sc.Args)
+	args := sc.Args
+	if sc.HTFFilter {
+		args = append(append([]string{}, args...), "--htf-filter")
+	}
+	logger.Info("Running: python3 %s %v", sc.Script, args)
 
-	result, stderr, err := RunRobinhoodCheck(sc.Script, sc.Args)
+	result, stderr, err := RunRobinhoodCheck(sc.Script, args)
 	if err != nil {
 		logger.Error("Script failed: %v", err)
 		if stderr != "" {

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -33,7 +33,7 @@ def _make_dataframe(candles):
     return df
 
 
-def run_signal_check(strategy_name, symbol, timeframe, mode):
+def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=False):
     """Run strategy signal check using Hyperliquid OHLCV data."""
     try:
         from adapter import HyperliquidExchangeAdapter
@@ -76,6 +76,21 @@ def run_signal_check(strategy_name, symbol, timeframe, mode):
 
         price = float(last["close"])
 
+        # Apply HTF trend filter if enabled
+        htf_info = {}
+        if htf_filter_enabled:
+            from htf_filter import htf_trend_filter, apply_htf_filter
+
+            def _fetch_htf(sym, tf, limit):
+                candles = adapter.get_ohlcv(sym, interval=tf, limit=limit)
+                return _make_dataframe(candles) if candles else None
+
+            htf_info = htf_trend_filter(symbol, timeframe, _fetch_htf)
+            original_signal = signal
+            signal = apply_htf_filter(signal, htf_info.get("htf_trend", 0))
+            if signal != original_signal:
+                print(f"HTF filter: {original_signal} → {signal} (HTF trend={htf_info.get('htf_trend')})", file=sys.stderr)
+
         # Freshen price with live mid if available
         try:
             mid = adapter.get_spot_price(symbol)
@@ -98,6 +113,12 @@ def run_signal_check(strategy_name, symbol, timeframe, mode):
                     indicators[col] = round(float(val), 6)
                 except (ValueError, TypeError):
                     pass
+
+        # Merge HTF indicators
+        if htf_info:
+            for k, v in htf_info.items():
+                if isinstance(v, (int, float)):
+                    indicators[k] = v
 
         print(json.dumps({
             "strategy": strategy_name,
@@ -190,15 +211,16 @@ def main():
         args = parser.parse_args()
         run_execute(args.symbol, args.side, args.size, args.mode)
     else:
-        # Signal check mode: <strategy> <symbol> <timeframe> [--mode=paper|live]
+        # Signal check mode: <strategy> <symbol> <timeframe> [--mode=paper|live] [--htf-filter]
         import argparse
         parser = argparse.ArgumentParser()
         parser.add_argument("strategy")
         parser.add_argument("symbol")
         parser.add_argument("timeframe")
         parser.add_argument("--mode", default="paper")
+        parser.add_argument("--htf-filter", action="store_true", default=False)
         args = parser.parse_args()
-        run_signal_check(args.strategy, args.symbol, args.timeframe, args.mode)
+        run_signal_check(args.strategy, args.symbol, args.timeframe, args.mode, args.htf_filter)
 
 
 if __name__ == "__main__":

--- a/shared_scripts/check_robinhood.py
+++ b/shared_scripts/check_robinhood.py
@@ -34,7 +34,7 @@ def _make_dataframe(candles):
     return df
 
 
-def run_signal_check(strategy_name, symbol, timeframe, mode):
+def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=False):
     """Run strategy signal check using yfinance OHLCV data."""
     try:
         from adapter import RobinhoodExchangeAdapter
@@ -77,6 +77,21 @@ def run_signal_check(strategy_name, symbol, timeframe, mode):
 
         price = float(last["close"])
 
+        # Apply HTF trend filter if enabled
+        htf_info = {}
+        if htf_filter_enabled:
+            from htf_filter import htf_trend_filter, apply_htf_filter
+
+            def _fetch_htf(sym, tf, limit):
+                candles = adapter.get_ohlcv(sym, interval=tf, limit=limit)
+                return _make_dataframe(candles) if candles else None
+
+            htf_info = htf_trend_filter(symbol, timeframe, _fetch_htf)
+            original_signal = signal
+            signal = apply_htf_filter(signal, htf_info.get("htf_trend", 0))
+            if signal != original_signal:
+                print(f"HTF filter: {original_signal} → {signal} (HTF trend={htf_info.get('htf_trend')})", file=sys.stderr)
+
         # Freshen price with live quote if available
         try:
             live_price = adapter.get_price(symbol)
@@ -99,6 +114,12 @@ def run_signal_check(strategy_name, symbol, timeframe, mode):
                     indicators[col] = round(float(val), 6)
                 except (ValueError, TypeError):
                     pass
+
+        # Merge HTF indicators
+        if htf_info:
+            for k, v in htf_info.items():
+                if isinstance(v, (int, float)):
+                    indicators[k] = v
 
         print(json.dumps({
             "strategy": strategy_name,
@@ -203,8 +224,9 @@ def main():
         parser.add_argument("symbol")
         parser.add_argument("timeframe")
         parser.add_argument("--mode", default="paper")
+        parser.add_argument("--htf-filter", action="store_true", default=False)
         args = parser.parse_args()
-        run_signal_check(args.strategy, args.symbol, args.timeframe, args.mode)
+        run_signal_check(args.strategy, args.symbol, args.timeframe, args.mode, args.htf_filter)
 
 
 if __name__ == "__main__":

--- a/shared_scripts/check_strategy.py
+++ b/shared_scripts/check_strategy.py
@@ -23,16 +23,20 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools')
 
 
 def main():
-    if len(sys.argv) < 4:
+    # Parse optional flags from argv before positional args
+    htf_filter_enabled = "--htf-filter" in sys.argv
+    positional_args = [a for a in sys.argv[1:] if not a.startswith("--")]
+
+    if len(positional_args) < 3:
         print(json.dumps({
-            "error": f"Usage: {sys.argv[0]} <strategy> <symbol> <timeframe> [symbol_b]"
+            "error": f"Usage: {sys.argv[0]} <strategy> <symbol> <timeframe> [symbol_b] [--htf-filter]"
         }))
         sys.exit(1)
 
-    strategy_name = sys.argv[1]
-    symbol = sys.argv[2]
-    timeframe = sys.argv[3]
-    symbol_b = sys.argv[4] if len(sys.argv) >= 5 else None
+    strategy_name = positional_args[0]
+    symbol = positional_args[1]
+    timeframe = positional_args[2]
+    symbol_b = positional_args[3] if len(positional_args) >= 4 else None
 
     try:
         from strategies import apply_strategy, get_strategy
@@ -103,6 +107,20 @@ def main():
 
         price = float(last["close"])
 
+        # Apply HTF trend filter if enabled
+        htf_info = {}
+        if htf_filter_enabled:
+            from htf_filter import htf_trend_filter, apply_htf_filter
+
+            def _fetch_htf(sym, tf, limit):
+                return fetch_ohlcv(symbol=sym, timeframe=tf, limit=limit, store=False)
+
+            htf_info = htf_trend_filter(symbol, timeframe, _fetch_htf)
+            original_signal = signal
+            signal = apply_htf_filter(signal, htf_info.get("htf_trend", 0))
+            if signal != original_signal:
+                print(f"HTF filter: {original_signal} → {signal} (HTF trend={htf_info.get('htf_trend')})", file=sys.stderr)
+
         # Collect relevant indicators
         indicators = {}
         indicator_cols = [c for c in result_df.columns
@@ -115,6 +133,12 @@ def main():
                     indicators[col] = round(float(val), 6)
                 except (ValueError, TypeError):
                     pass
+
+        # Merge HTF indicators
+        if htf_info:
+            for k, v in htf_info.items():
+                if isinstance(v, (int, float)):
+                    indicators[k] = v
 
         output = {
             "strategy": strategy_name,

--- a/shared_scripts/check_topstep.py
+++ b/shared_scripts/check_topstep.py
@@ -32,7 +32,7 @@ def _make_dataframe(candles):
     return df
 
 
-def run_signal_check(strategy_name, symbol, timeframe, mode):
+def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=False):
     """Run strategy signal check using TopStep market data."""
     try:
         from adapter import TopStepExchangeAdapter
@@ -95,6 +95,21 @@ def run_signal_check(strategy_name, symbol, timeframe, mode):
 
         price = float(last["close"])
 
+        # Apply HTF trend filter if enabled
+        htf_info = {}
+        if htf_filter_enabled:
+            from htf_filter import htf_trend_filter, apply_htf_filter
+
+            def _fetch_htf(sym, tf, limit):
+                candles = adapter.get_ohlcv(sym, interval=tf, limit=limit)
+                return _make_dataframe(candles) if candles else None
+
+            htf_info = htf_trend_filter(symbol, timeframe, _fetch_htf)
+            original_signal = signal
+            signal = apply_htf_filter(signal, htf_info.get("htf_trend", 0))
+            if signal != original_signal:
+                print(f"HTF filter: {original_signal} → {signal} (HTF trend={htf_info.get('htf_trend')})", file=sys.stderr)
+
         # Freshen price with live quote if available
         try:
             live = adapter.get_price(symbol)
@@ -117,6 +132,12 @@ def run_signal_check(strategy_name, symbol, timeframe, mode):
                     indicators[col] = round(float(val), 6)
                 except (ValueError, TypeError):
                     pass
+
+        # Merge HTF indicators
+        if htf_info:
+            for k, v in htf_info.items():
+                if isinstance(v, (int, float)):
+                    indicators[k] = v
 
         print(json.dumps({
             "strategy": strategy_name,
@@ -214,8 +235,9 @@ def main():
         parser.add_argument("symbol")
         parser.add_argument("timeframe")
         parser.add_argument("--mode", default="paper")
+        parser.add_argument("--htf-filter", action="store_true", default=False)
         args = parser.parse_args()
-        run_signal_check(args.strategy, args.symbol, args.timeframe, args.mode)
+        run_signal_check(args.strategy, args.symbol, args.timeframe, args.mode, args.htf_filter)
 
 
 if __name__ == "__main__":

--- a/shared_tools/htf_filter.py
+++ b/shared_tools/htf_filter.py
@@ -1,0 +1,110 @@
+"""
+Higher-timeframe (HTF) trend filter utility.
+
+Determines trend direction on a higher timeframe using a 50 EMA.
+Used as a pre-filter: only pass BUY when HTF is bullish, SELL when bearish.
+"""
+
+import numpy as np
+
+
+# Default LTF → HTF mapping
+_HTF_MAP = {
+    "1m": "15m",
+    "5m": "1h",
+    "15m": "1h",
+    "30m": "4h",
+    "1h": "4h",
+    "4h": "1d",
+}
+
+
+def get_default_htf(timeframe: str) -> str:
+    """Map a lower timeframe to its default higher timeframe."""
+    return _HTF_MAP.get(timeframe, "4h")
+
+
+def htf_trend_filter(symbol, timeframe, fetch_fn, htf=None, ema_period=50):
+    """
+    Fetch HTF data, compute EMA, return trend direction.
+
+    Args:
+        symbol: Trading pair (e.g. "BTC/USDT" or "BTC")
+        timeframe: The strategy's (lower) timeframe
+        fetch_fn: Callable(symbol, timeframe, limit) → DataFrame with 'close' column
+        htf: Override HTF timeframe (default: auto from LTF)
+        ema_period: EMA lookback period (default 50)
+
+    Returns:
+        dict with keys:
+            htf_timeframe: str — the HTF used
+            htf_trend: int — 1 (bull), -1 (bear), 0 (neutral/error)
+            htf_ema: float — current HTF EMA value
+            htf_close: float — current HTF close price
+    """
+    htf = htf or get_default_htf(timeframe)
+    result = {"htf_timeframe": htf, "htf_trend": 0, "htf_ema": 0.0, "htf_close": 0.0}
+
+    try:
+        df = fetch_fn(symbol, htf, ema_period + 10)
+        if df is None or len(df) < ema_period:
+            return result
+
+        closes = df["close"].astype(float).values
+        ema = _compute_ema(closes, ema_period)
+
+        current_close = float(closes[-1])
+        current_ema = float(ema[-1])
+
+        result["htf_close"] = round(current_close, 6)
+        result["htf_ema"] = round(current_ema, 6)
+
+        if current_close > current_ema:
+            result["htf_trend"] = 1
+        elif current_close < current_ema:
+            result["htf_trend"] = -1
+        else:
+            result["htf_trend"] = 0
+
+    except Exception:
+        # On any error, return neutral (don't block signals)
+        pass
+
+    return result
+
+
+def apply_htf_filter(signal, htf_trend):
+    """
+    Filter a strategy signal based on HTF trend.
+
+    Rules:
+        BUY  + HTF bull  → BUY   (aligned)
+        BUY  + HTF bear  → HOLD  (counter-trend, filtered)
+        SELL + HTF bear  → SELL  (aligned)
+        SELL + HTF bull  → HOLD  (counter-trend, filtered)
+        HTF neutral      → pass signal through
+        signal == 0      → HOLD  (no signal to filter)
+
+    Returns:
+        Filtered signal (1, -1, or 0)
+    """
+    if signal == 0 or htf_trend == 0:
+        return signal
+
+    if signal == 1 and htf_trend == 1:
+        return 1
+    if signal == -1 and htf_trend == -1:
+        return -1
+
+    # Counter-trend: filter to HOLD
+    return 0
+
+
+def _compute_ema(values, period):
+    """Compute EMA over a numpy array."""
+    alpha = 2.0 / (period + 1)
+    ema = np.empty_like(values, dtype=float)
+    ema[0] = values[0]
+    for i in range(1, len(values)):
+        ema[i] = alpha * values[i] + (1 - alpha) * ema[i - 1]
+    return ema


### PR DESCRIPTION
## Summary
- Add `shared_tools/htf_filter.py` — utility that fetches HTF candle data, computes 50 EMA, and determines trend direction (bull/bear/neutral)
- Add per-strategy `htf_filter` config flag to `StrategyConfig` — Go appends `--htf-filter` to Python script args when enabled
- Update all 4 check scripts (spot, hyperliquid, topstep, robinhood) to parse `--htf-filter` flag and apply trend filtering before outputting signals
- Add HTF filter toggle to `go-trader init` wizard and `--json` mode
- HTF filter is not applied to options strategies (trend filtering doesn't apply to options signal logic)

Closes #67

## Test plan
- [x] All Python files pass `py_compile` syntax check
- [x] `go build` succeeds
- [x] `go test ./...` passes
- [x] `gofmt` clean
- [x] Smoke test: `go-trader init --json` with `htfFilter: true` produces config with `htf_filter: true` on strategies
- [x] Smoke test: `go-trader init --json` without `htfFilter` produces config without `htf_filter` field