### PR TITLE
Enable plan mode for Claude GitHub Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,4 +47,5 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: '--model claude-opus-4-6 --ultrathink'
+          use_plan_mode: true
 


### PR DESCRIPTION
## Summary
- Add `use_plan_mode: true` to the Claude Code GitHub Action workflow
- Claude will now plan before acting on `@claude` mentions in issues and PRs, allowing reviewers to approve the approach before implementation

## Test plan
- [ ] Verify the workflow YAML is valid
- [ ] Tag `@claude` on a test issue and confirm it enters plan mode before making changes