### PR TITLE
Use --permission-mode plan instead of use_plan_mode

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,6 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model claude-opus-4-6 --ultrathink'
-          use_plan_mode: true
+          claude_args: '--model claude-opus-4-6 --ultrathink --permission-mode plan'
 


### PR DESCRIPTION
## Summary
- Consolidate plan mode configuration into `claude_args` using the native `--permission-mode plan` CLI flag
- Remove the separate `use_plan_mode` action parameter, which is redundant with the CLI flag

## Test plan
- [ ] Verify Claude GitHub Action triggers correctly on issues/PRs
- [ ] Confirm Claude operates in plan mode when invoked