### PR TITLE
fix: remove invalid permission-mode plan from Claude GitHub Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model claude-opus-4-6 --ultrathink --permission-mode plan'
+          claude_args: '--model claude-opus-4-6 --ultrathink'
 


### PR DESCRIPTION
## Summary
- Removed `--permission-mode plan` from `claude_args` in the Claude Code GitHub Action workflow
- Plan mode requires interactive approval which is incompatible with CI — the action's default `acceptEdits` mode is the correct choice for non-interactive usage
- Also removed the previously invalid `use_plan_mode` input (not a recognized action input)

Closes #78

## Test plan
- [ ] Trigger the Claude Code action via `@claude` mention on an issue/PR and verify it no longer crashes with `SDK execution error`
- [ ] Note: the `CLAUDE_CODE_OAUTH_TOKEN` secret must also be configured for the action to fully succeed