### PR TITLE
fix: replace --ultrathink with --effort high in Claude GitHub Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model claude-opus-4-6 --ultrathink'
+          claude_args: '--model claude-opus-4-6 --effort high'
 


### PR DESCRIPTION
## Summary
- Replaced `--ultrathink` with `--effort high` in `claude_args` for the Claude Code GitHub Action
- `--ultrathink` is not a supported CLI flag and was causing the action to crash with SDK execution errors
- `--effort high` is the documented flag for increased reasoning quality (per [CLI reference](https://code.claude.com/docs/en/cli-reference))

Closes #78

## Test plan
- [ ] Trigger the Claude Code action via `@claude` mention on an issue/PR
- [ ] Verify the action no longer crashes with SDK execution error
- [ ] Confirm Claude uses Opus 4.6 with high effort reasoning