### PR TITLE
feat: add Opus 4.6 with high effort to Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,4 +41,5 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+          claude_args: '--model claude-opus-4-6 --effort high'
 


### PR DESCRIPTION
## Summary
- Add `claude_args: '--model claude-opus-4-6 --effort high'` to the code review workflow
- Uses Opus 4.6 with high effort reasoning for higher quality automated code reviews

## Test plan
- [ ] Open a PR and verify the Claude Code Review action triggers with Opus model
- [ ] Note: requires valid API authentication (OAuth token or API key) with Opus access