### PR TITLE
feat: add capital_pct for dynamic strategy capital as % of wallet balance

### DIFF
--- a/scheduler/balance.go
+++ b/scheduler/balance.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// balanceResult is the JSON output from check_balance.py.
+type balanceResult struct {
+	Balance float64 `json:"balance"`
+	Error   string  `json:"error,omitempty"`
+}
+
+// FetchPlatformBalance returns the account balance for the given platform.
+// Uses Go-native API calls where available, falls back to check_balance.py.
+func FetchPlatformBalance(platform string) (float64, error) {
+	switch platform {
+	case "hyperliquid":
+		addr := os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS")
+		if addr == "" {
+			return 0, fmt.Errorf("HYPERLIQUID_ACCOUNT_ADDRESS env var not set")
+		}
+		return fetchHyperliquidBalance(addr)
+	default:
+		return fetchPythonBalance(platform)
+	}
+}
+
+// fetchPythonBalance calls check_balance.py for platforms without Go-native balance fetching.
+func fetchPythonBalance(platform string) (float64, error) {
+	args := []string{fmt.Sprintf("--platform=%s", platform)}
+	stdout, stderr, err := RunPythonScript("shared_scripts/check_balance.py", args)
+	if err != nil {
+		return 0, fmt.Errorf("check_balance.py %s: %w (stderr: %s)", platform, err, string(stderr))
+	}
+
+	var result balanceResult
+	if err := json.Unmarshal(stdout, &result); err != nil {
+		return 0, fmt.Errorf("parse balance output for %s: %w (stdout: %s)", platform, err, string(stdout))
+	}
+	if result.Error != "" {
+		return 0, fmt.Errorf("balance check %s: %s", platform, result.Error)
+	}
+	return result.Balance, nil
+}
+
+// resolveCapitalPct fetches wallet balances and updates Capital for strategies
+// that have CapitalPct set. Caches balance per platform to avoid redundant API calls.
+func resolveCapitalPct(strategies []StrategyConfig) {
+	// Find platforms that need balance queries.
+	needsBalance := make(map[string]bool)
+	for _, sc := range strategies {
+		if sc.CapitalPct > 0 {
+			needsBalance[sc.Platform] = true
+		}
+	}
+	if len(needsBalance) == 0 {
+		return
+	}
+
+	// Fetch balance per platform (cached).
+	balances := make(map[string]float64)
+	for platform := range needsBalance {
+		balance, err := FetchPlatformBalance(platform)
+		if err != nil {
+			fmt.Printf("[WARN] capital_pct: failed to fetch %s balance: %v\n", platform, err)
+			continue
+		}
+		if balance <= 0 {
+			fmt.Printf("[WARN] capital_pct: %s balance is $%.2f — wallet may be unfunded\n", platform, balance)
+			continue
+		}
+		balances[platform] = balance
+	}
+
+	// Update Capital for strategies with CapitalPct.
+	for i := range strategies {
+		sc := &strategies[i]
+		if sc.CapitalPct <= 0 {
+			continue
+		}
+		balance, ok := balances[sc.Platform]
+		if !ok {
+			if sc.Capital > 0 {
+				fmt.Printf("[WARN] capital_pct: no balance for %s, using fallback capital=$%.2f\n", sc.ID, sc.Capital)
+			} else {
+				fmt.Printf("[WARN] capital_pct: no balance for %s and no fallback capital — skipping\n", sc.ID)
+			}
+			continue
+		}
+		newCapital := balance * sc.CapitalPct
+		fmt.Printf("[INFO] capital_pct: %s → $%.2f (%.0f%% of $%.2f %s balance)\n",
+			sc.ID, newCapital, sc.CapitalPct*100, balance, sc.Platform)
+		sc.Capital = newCapital
+	}
+}

--- a/scheduler/balance_test.go
+++ b/scheduler/balance_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestResolveCapitalPct_NoCapitalPct(t *testing.T) {
+	strategies := []StrategyConfig{
+		{ID: "test-1", Capital: 1000, Platform: "binanceus"},
+		{ID: "test-2", Capital: 2000, Platform: "hyperliquid"},
+	}
+	// Should be a no-op when no strategies have CapitalPct.
+	resolveCapitalPct(strategies)
+	if strategies[0].Capital != 1000 {
+		t.Errorf("expected capital=1000, got %g", strategies[0].Capital)
+	}
+	if strategies[1].Capital != 2000 {
+		t.Errorf("expected capital=2000, got %g", strategies[1].Capital)
+	}
+}
+
+func TestResolveCapitalPct_FallbackCapital(t *testing.T) {
+	// When balance fetch fails (unsupported platform without Python), should keep fallback capital.
+	strategies := []StrategyConfig{
+		{ID: "test-pct", Capital: 500, CapitalPct: 0.5, Platform: "binanceus"},
+	}
+	// binanceus doesn't have a Go-native balance fetch and check_balance.py won't work in tests,
+	// so it should fall back to the existing capital value.
+	resolveCapitalPct(strategies)
+	if strategies[0].Capital != 500 {
+		t.Errorf("expected fallback capital=500, got %g", strategies[0].Capital)
+	}
+}
+
+func TestResolveCapitalPct_NoFallbackCapital(t *testing.T) {
+	// When balance fetch fails and no fallback capital, should remain 0.
+	strategies := []StrategyConfig{
+		{ID: "test-no-fallback", Capital: 0, CapitalPct: 0.5, Platform: "binanceus"},
+	}
+	resolveCapitalPct(strategies)
+	if strategies[0].Capital != 0 {
+		t.Errorf("expected capital=0 (no fallback), got %g", strategies[0].Capital)
+	}
+}

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -73,6 +73,7 @@ type StrategyConfig struct {
 	Script          string              `json:"script"`
 	Args            []string            `json:"args"`
 	Capital         float64             `json:"capital"`
+	CapitalPct      float64             `json:"capital_pct,omitempty"` // 0-1; dynamic capital = wallet_balance * capital_pct (overrides capital)
 	MaxDrawdownPct  float64             `json:"max_drawdown_pct"`
 	IntervalSeconds int                 `json:"interval_seconds,omitempty"` // per-strategy override (0 = use global)
 	HTFFilter       bool                `json:"htf_filter,omitempty"`       // higher-timeframe trend filter
@@ -313,9 +314,19 @@ func ValidateConfig(cfg *Config) error {
 			}
 		}
 
-		// #36: Capital must be > 0.
-		if sc.Capital <= 0 {
-			errs = append(errs, fmt.Sprintf("%s: capital must be > 0, got %g", prefix, sc.Capital))
+		// #87: capital_pct validation.
+		if sc.CapitalPct != 0 {
+			if sc.CapitalPct < 0 || sc.CapitalPct > 1 {
+				errs = append(errs, fmt.Sprintf("%s: capital_pct must be in (0, 1], got %g", prefix, sc.CapitalPct))
+			}
+			if sc.Capital > 0 {
+				fmt.Printf("[WARN] %s: both capital ($%.0f) and capital_pct (%.0f%%) set — capital_pct takes priority\n", sc.ID, sc.Capital, sc.CapitalPct*100)
+			}
+		}
+
+		// #36: Capital must be > 0 (unless capital_pct is set).
+		if sc.Capital <= 0 && sc.CapitalPct == 0 {
+			errs = append(errs, fmt.Sprintf("%s: capital must be > 0 (or set capital_pct), got %g", prefix, sc.Capital))
 		}
 
 		// #36: MaxDrawdownPct must be in (0, 100].

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -233,7 +233,8 @@ type InitOptions struct {
 	OKXPerpsStrategies      []string // selected perps strategy IDs for OKX
 	OKXCapital              float64
 	OKXDrawdown             float64
-	HTFFilter               bool // higher-timeframe trend filter for all strategies
+	CapitalPct              float64 `json:"capitalPct,omitempty"` // 0-1; global capital_pct applied to all strategies
+	HTFFilter               bool    // higher-timeframe trend filter for all strategies
 	DiscordEnabled          bool
 	DiscordOwnerID          string            // Discord user ID for DM features (upgrade prompts, config migration)
 	SpotChannelID           string            // deprecated: use ChannelMap
@@ -532,6 +533,13 @@ func generateConfig(opts InitOptions) *Config {
 			if cfg.Strategies[i].Type != "options" {
 				cfg.Strategies[i].HTFFilter = true
 			}
+		}
+	}
+
+	// #87: Apply capital_pct to all strategies if set globally.
+	if opts.CapitalPct > 0 {
+		for i := range cfg.Strategies {
+			cfg.Strategies[i].CapitalPct = opts.CapitalPct
 		}
 	}
 

--- a/scheduler/init_test.go
+++ b/scheduler/init_test.go
@@ -749,3 +749,117 @@ func TestRunInitFromJSON_FuturesEnabled(t *testing.T) {
 		t.Errorf("expected 2 futures strategies, got %d", futuresCount)
 	}
 }
+
+func TestGenerateConfig_CapitalPct(t *testing.T) {
+	opts := baseOpts()
+	opts.CapitalPct = 0.45
+
+	cfg := generateConfig(opts)
+
+	for _, s := range cfg.Strategies {
+		if s.CapitalPct != 0.45 {
+			t.Errorf("expected capital_pct=0.45 for %s, got %g", s.ID, s.CapitalPct)
+		}
+	}
+}
+
+func TestGenerateConfig_NoCapitalPct(t *testing.T) {
+	opts := baseOpts()
+	// CapitalPct defaults to 0 (not set)
+
+	cfg := generateConfig(opts)
+
+	for _, s := range cfg.Strategies {
+		if s.CapitalPct != 0 {
+			t.Errorf("expected capital_pct=0 for %s, got %g", s.ID, s.CapitalPct)
+		}
+	}
+}
+
+func TestValidateConfig_CapitalPctValid(t *testing.T) {
+	cfg := &Config{
+		IntervalSeconds: 600,
+		StateFile:       "state.json",
+		Strategies: []StrategyConfig{
+			{
+				ID:             "test-pct",
+				Type:           "spot",
+				Platform:       "hyperliquid",
+				Script:         "shared_scripts/check_strategy.py",
+				Capital:        0,
+				CapitalPct:     0.45,
+				MaxDrawdownPct: 10,
+			},
+		},
+		PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Errorf("expected valid config with capital_pct, got error: %v", err)
+	}
+}
+
+func TestValidateConfig_CapitalPctInvalid(t *testing.T) {
+	cfg := &Config{
+		IntervalSeconds: 600,
+		StateFile:       "state.json",
+		Strategies: []StrategyConfig{
+			{
+				ID:             "test-bad-pct",
+				Type:           "spot",
+				Platform:       "hyperliquid",
+				Script:         "shared_scripts/check_strategy.py",
+				Capital:        0,
+				CapitalPct:     1.5, // invalid: > 1
+				MaxDrawdownPct: 10,
+			},
+		},
+		PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+	}
+	if err := ValidateConfig(cfg); err == nil {
+		t.Error("expected validation error for capital_pct > 1")
+	}
+}
+
+func TestValidateConfig_CapitalPctNegative(t *testing.T) {
+	cfg := &Config{
+		IntervalSeconds: 600,
+		StateFile:       "state.json",
+		Strategies: []StrategyConfig{
+			{
+				ID:             "test-neg-pct",
+				Type:           "spot",
+				Platform:       "hyperliquid",
+				Script:         "shared_scripts/check_strategy.py",
+				Capital:        0,
+				CapitalPct:     -0.5, // invalid: < 0
+				MaxDrawdownPct: 10,
+			},
+		},
+		PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+	}
+	if err := ValidateConfig(cfg); err == nil {
+		t.Error("expected validation error for negative capital_pct")
+	}
+}
+
+func TestValidateConfig_NoCapitalNoCapitalPct(t *testing.T) {
+	cfg := &Config{
+		IntervalSeconds: 600,
+		StateFile:       "state.json",
+		Strategies: []StrategyConfig{
+			{
+				ID:             "test-no-cap",
+				Type:           "spot",
+				Platform:       "hyperliquid",
+				Script:         "shared_scripts/check_strategy.py",
+				Capital:        0,
+				CapitalPct:     0,
+				MaxDrawdownPct: 10,
+			},
+		},
+		PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+	}
+	if err := ValidateConfig(cfg); err == nil {
+		t.Error("expected validation error when neither capital nor capital_pct is set")
+	}
+}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -36,11 +36,16 @@ func main() {
 	}
 	ValidateState(state)
 
+	// #87: Resolve capital_pct at startup so initial state gets the right capital.
+	resolveCapitalPct(cfg.Strategies)
+
 	// Initialize new strategies and sync config values for existing ones
 	for i := range cfg.Strategies {
 		sc := &cfg.Strategies[i]
-		// For live Hyperliquid strategies, override capital with the real wallet balance.
-		syncHyperliquidLiveCapital(sc)
+		// For live Hyperliquid strategies without capital_pct, override capital with the real wallet balance.
+		if sc.CapitalPct == 0 {
+			syncHyperliquidLiveCapital(sc)
+		}
 		if s, exists := state.Strategies[sc.ID]; !exists {
 			state.Strategies[sc.ID] = NewStrategyState(*sc)
 			fmt.Printf("  Initialized strategy: %s (type=%s, capital=$%.0f)\n", sc.ID, sc.Type, sc.Capital)
@@ -250,6 +255,9 @@ func main() {
 			}
 			fmt.Println()
 		}
+
+		// #87: Resolve capital_pct → capital for strategies with dynamic sizing.
+		resolveCapitalPct(dueStrategies)
 
 		// Process only due strategies
 		if saveFailures >= 3 {

--- a/shared_scripts/check_balance.py
+++ b/shared_scripts/check_balance.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+check_balance.py — Query wallet balance for supported platforms.
+
+Usage:
+    python3 check_balance.py --platform=okx
+
+Outputs JSON: {"balance": 1234.56}
+On error: {"balance": 0, "error": "message"}
+
+Supported platforms:
+    okx         — via CCXT (requires OKX_API_KEY, OKX_API_SECRET, OKX_PASSPHRASE)
+    robinhood   — via robin_stocks (requires ROBINHOOD_USERNAME, ROBINHOOD_PASSWORD, ROBINHOOD_TOTP_SECRET)
+"""
+
+import json
+import os
+import sys
+
+
+def fetch_okx_balance():
+    """Fetch total account equity from OKX via CCXT."""
+    import ccxt
+
+    api_key = os.environ.get("OKX_API_KEY", "")
+    api_secret = os.environ.get("OKX_API_SECRET", "")
+    passphrase = os.environ.get("OKX_PASSPHRASE", "")
+    sandbox = os.environ.get("OKX_SANDBOX", "") == "1"
+
+    if not (api_key and api_secret and passphrase):
+        raise ValueError("OKX_API_KEY, OKX_API_SECRET, and OKX_PASSPHRASE env vars required")
+
+    config = {
+        "apiKey": api_key,
+        "secret": api_secret,
+        "password": passphrase,
+        "enableRateLimit": True,
+    }
+    if sandbox:
+        config["sandbox"] = True
+
+    exchange = ccxt.okx(config)
+    balance = exchange.fetch_balance({"type": "trading"})
+    # CCXT returns balance['total']['USDT'] for USDT equity
+    total = balance.get("total", {})
+    usdt = float(total.get("USDT", 0))
+    if usdt > 0:
+        return usdt
+    # Fallback: check info.totalEq (OKX-specific total equity across all currencies)
+    info = balance.get("info", {})
+    if isinstance(info, dict):
+        details = info.get("data", [{}])
+        if details:
+            total_eq = float(details[0].get("totalEq", 0))
+            if total_eq > 0:
+                return total_eq
+    return usdt
+
+
+def fetch_robinhood_balance():
+    """Fetch crypto buying power from Robinhood."""
+    import robin_stocks.robinhood as rh
+    import pyotp
+
+    username = os.environ.get("ROBINHOOD_USERNAME", "")
+    password = os.environ.get("ROBINHOOD_PASSWORD", "")
+    totp_secret = os.environ.get("ROBINHOOD_TOTP_SECRET", "")
+
+    if not (username and password and totp_secret):
+        raise ValueError("ROBINHOOD_USERNAME, ROBINHOOD_PASSWORD, and ROBINHOOD_TOTP_SECRET env vars required")
+
+    totp = pyotp.TOTP(totp_secret).now()
+    rh.login(username, password, mfa_code=totp)
+    try:
+        profile = rh.profiles.load_account_profile()
+        # Crypto buying power
+        buying_power = float(profile.get("crypto_buying_power", 0))
+        if buying_power > 0:
+            return buying_power
+        # Fallback: portfolio cash
+        return float(profile.get("portfolio_cash", 0))
+    finally:
+        rh.logout()
+
+
+PLATFORM_FETCHERS = {
+    "okx": fetch_okx_balance,
+    "robinhood": fetch_robinhood_balance,
+}
+
+
+def main():
+    platform = None
+    for arg in sys.argv[1:]:
+        if arg.startswith("--platform="):
+            platform = arg.split("=", 1)[1]
+
+    if not platform:
+        print(json.dumps({"balance": 0, "error": "usage: check_balance.py --platform=<name>"}))
+        sys.exit(1)
+
+    fetcher = PLATFORM_FETCHERS.get(platform)
+    if not fetcher:
+        print(json.dumps({"balance": 0, "error": f"unsupported platform: {platform}"}))
+        sys.exit(1)
+
+    try:
+        balance = fetcher()
+        print(json.dumps({"balance": balance}))
+    except Exception as e:
+        print(json.dumps({"balance": 0, "error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #87

Allow strategies to specify `capital_pct` (0-1) instead of a fixed `capital` dollar amount. When set, the scheduler queries the live wallet balance each cycle and computes `capital = balance * capital_pct`.

- Add `CapitalPct` field to `StrategyConfig` with validation
- Add `balance.go` with `FetchPlatformBalance` (Hyperliquid Go-native, others via Python)
- Add `check_balance.py` for OKX/Robinhood balance queries
- Resolve `capital_pct` at startup and per-cycle in main loop
- Support `capitalPct` in `init --json` mode
- Add unit tests

Generated with [Claude Code](https://claude.ai/code)