### PR TITLE
fix: round Hyperliquid order size to asset tick precision

### DIFF
--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -201,6 +201,11 @@ class HyperliquidExchangeAdapter:
             raise RuntimeError(
                 "market_open requires live mode (set HYPERLIQUID_SECRET_KEY)"
             )
+        # Round to asset's tick precision to avoid float_to_wire rounding error
+        sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3)
+        size = round(size, sz_decimals)
+        if size <= 0:
+            raise ValueError(f"Size rounded to zero for {symbol} (sz_decimals={sz_decimals})")
         return self._exchange.market_open(symbol, is_buy, size, None, 0.01)
 
     def market_close(self, symbol: str) -> dict:


### PR DESCRIPTION
## Summary
- Round order size to the asset's `szDecimals` before passing to the SDK's `market_open()`, preventing `float_to_wire()` `ValueError` when sizes have too many decimal places
- Uses `self._info.asset_to_sz_decimals` (already available from exchange metadata) with a default of 3 decimals
- Adds a guard against size rounding to zero

Closes #105

## Test plan
- [ ] `python3 -m py_compile platforms/hyperliquid/adapter.py` passes
- [ ] Verify live HL order placement no longer triggers `float_to_wire` rounding error
- [ ] Confirm small-size assets (e.g. BTC with szDecimals=5) still place correctly

---
Generated with: Claude Opus 4.6 | Effort: 85