### PR TITLE
fix: grant write permission so Claude Code Review can post PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary

- Changed `pull-requests: read` to `pull-requests: write` in the Claude Code Review workflow so review comments are actually posted to PRs.
- All PRs since the workflow was added (2026-04-01) received no review feedback because comments were silently dropped.

Closes #113

## Test plan

- [ ] Merge this PR and open a new test PR to verify the workflow posts a review comment

---
Generated with: Claude Opus 4.6 | Effort: 85