### PR TITLE
fix: add isPerpsType to Discord summary gate so perps post every cycle

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -188,6 +188,16 @@ func isFuturesType(strats []StrategyConfig) bool {
 	return false
 }
 
+// isPerpsType returns true if any strategy in the list is a perps strategy.
+func isPerpsType(strats []StrategyConfig) bool {
+	for _, sc := range strats {
+		if sc.Type == "perps" {
+			return true
+		}
+	}
+	return false
+}
+
 // futuresFullNames maps ticker symbols to their full contract names.
 var futuresFullNames = map[string]string{
 	"MES": "Micro E-mini S&P 500",

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -656,7 +656,7 @@ func main() {
 				chTrades := channelTrades[chKey]
 				// Options: post every run. Others: hourly or on trade.
 				// (cycle-1)%12==0 fires at cycles 1,13,25... so first summary posts on startup.
-				if !isOptionsType(chStrats) && !isFuturesType(chStrats) && chTrades == 0 && (cycle-1)%12 != 0 {
+				if !isOptionsType(chStrats) && !isFuturesType(chStrats) && !isPerpsType(chStrats) && chTrades == 0 && (cycle-1)%12 != 0 {
 					continue
 				}
 				assetGroups, assetKeys := groupByAsset(chStrats)


### PR DESCRIPTION
Perps strategies were never posting Discord summaries unless a trade occurred because the summary gate only recognized options and futures as derivative types. Add isPerpsType helper and include it in the gate condition so perps are treated as first-class derivatives.

Closes #121

Generated with [Claude Code](https://claude.ai/code)