### PR TITLE
fix: align CI Go version with go.mod (1.22 → 1.26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.26'
 
       - name: Build
         run: cd scheduler && go build .


### PR DESCRIPTION
## Summary

- CI workflow (`.github/workflows/ci.yml`) was pinned to `go-version: '1.22'`, but `scheduler/go.mod` requires `go 1.26.0`.
- This mismatch means CI builds and tests run with Go 1.22, potentially missing compile errors or behavior changes specific to Go 1.26.
- Updated `go-version` to `'1.26'` to match `go.mod`.

## Test plan

- [ ] CI workflow triggers on this PR and installs Go 1.26.x
- [ ] `go build .` and `go test ./...` pass under Go 1.26
- [ ] `gofmt` check passes

---
Generated with: Claude Opus 4.6 | Effort: high