### PR TITLE
fix: add missing liveExecFailed guards for Robinhood and OKX perps

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -501,14 +501,19 @@ func main() {
 							if result, signalStr, price, ok := runRobinhoodCheck(sc, prices, logger); ok {
 								prices[result.Symbol] = price
 								var execResult *RobinhoodExecuteResult
+								liveExecFailed := false
 								if robinhoodIsLive(sc.Args) && result.Signal != 0 {
 									if er, ok2 := runRobinhoodExecuteOrder(sc, result, price, rhCash, rhPosQty, logger); ok2 {
 										execResult = er
+									} else {
+										liveExecFailed = true
 									}
 								}
-								mu.Lock()
-								trades, detail = executeRobinhoodResult(sc, stratState, result, execResult, signalStr, price, logger)
-								mu.Unlock()
+								if !liveExecFailed {
+									mu.Lock()
+									trades, detail = executeRobinhoodResult(sc, stratState, result, execResult, signalStr, price, logger)
+									mu.Unlock()
+								}
 							}
 						} else if result, signalStr, price, ok := runSpotCheck(sc, prices, logger); ok {
 							mu.Lock()
@@ -531,14 +536,19 @@ func main() {
 							if result, signalStr, price, ok := runOKXCheck(sc, prices, logger); ok {
 								prices[result.Symbol] = price
 								var execResult *OKXExecuteResult
+								liveExecFailed := false
 								if okxIsLive(sc.Args) && result.Signal != 0 {
 									if er, ok2 := runOKXExecuteOrder(sc, result, price, okxCash, okxPosQty, logger); ok2 {
 										execResult = er
+									} else {
+										liveExecFailed = true
 									}
 								}
-								mu.Lock()
-								trades, detail = executeOKXResult(sc, stratState, result, execResult, signalStr, price, logger)
-								mu.Unlock()
+								if !liveExecFailed {
+									mu.Lock()
+									trades, detail = executeOKXResult(sc, stratState, result, execResult, signalStr, price, logger)
+									mu.Unlock()
+								}
 							}
 						} else if result, signalStr, price, ok := runHyperliquidCheck(sc, prices, logger); ok {
 							prices[result.Symbol] = price


### PR DESCRIPTION
## Summary

- PR #112 added `liveExecFailed` guards to 3 live execution paths (OKX spot, Hyperliquid perps, TopStep futures) but missed **Robinhood spot** and **OKX perps**.
- When `runRobinhoodExecuteOrder` or `runOKXExecuteOrder` (perps case) returned `ok2=false`, the code still proceeded to `mu.Lock()` and updated paper state via `executeRobinhoodResult` / `executeOKXResult` — causing state/exchange divergence.
- This PR adds the same `liveExecFailed` pattern to both missing paths: set `liveExecFailed = true` on `ok2=false`, then wrap the state update in `if !liveExecFailed { ... }`.

## What changed

**`scheduler/main.go`** — two blocks modified:

1. **Robinhood spot path** (~line 500): added `liveExecFailed` variable, `else { liveExecFailed = true }` branch, and `if !liveExecFailed` guard around state update.
2. **OKX perps path** (~line 535): same pattern applied.

All 5 live execution paths now have consistent guards:
- OKX spot (already had it)
- Robinhood spot (fixed)
- OKX perps (fixed)
- Hyperliquid perps (already had it)
- TopStep futures (already had it)

## Test plan

- [x] `go build .` compiles successfully
- [x] `go test ./...` passes
- [x] `gofmt -w main.go` produces no changes
- [ ] Manual: verify Robinhood live mode skips state update on execution failure
- [ ] Manual: verify OKX perps live mode skips state update on execution failure

---
Generated with: Claude Opus 4.6 | Effort: high