### PR TITLE
fix: resolve capital_pct on cfg.Strategies instead of value-copy

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -225,6 +225,11 @@ func main() {
 		channelTrades := make(map[string]int)
 		channelTradeDetails := make(map[string][]string)
 
+		// #87: Resolve capital_pct → capital for strategies with dynamic sizing.
+		// Must run on cfg.Strategies (not dueStrategies) so resolved capital persists
+		// across cycles and is picked up by the value-copies in dueStrategies.
+		resolveCapitalPct(cfg.Strategies)
+
 		// Determine which strategies are due this tick
 		dueStrategies := make([]StrategyConfig, 0)
 		for _, sc := range cfg.Strategies {
@@ -293,9 +298,6 @@ func main() {
 			}
 			fmt.Println()
 		}
-
-		// #87: Resolve capital_pct → capital for strategies with dynamic sizing.
-		resolveCapitalPct(dueStrategies)
 
 		// Process only due strategies
 		if saveFailures >= 3 {


### PR DESCRIPTION
## Summary

- `resolveCapitalPct` was called on `dueStrategies` (a `[]StrategyConfig` built by appending value-copies from `cfg.Strategies`), so per-cycle wallet balance updates to `sc.Capital` were silently discarded every cycle — only the startup call on `cfg.Strategies` actually persisted.
- Moved the per-cycle `resolveCapitalPct` call to operate on `cfg.Strategies` **before** `dueStrategies` is built, so resolved capital persists across cycles and the value-copies pick up the updated values.
- This is the intended behavior for `capital_pct`: dynamic sizing based on current wallet balance each cycle.

## Test plan

- [x] `go build` compiles cleanly
- [x] `go test ./...` passes
- [ ] Deploy and verify `[INFO] capital_pct:` log lines show updated balances each cycle (not just at startup)

---
Generated with: Claude Opus 4.6 | Effort: high