### PR TITLE
fix: update stale comment on Discord summary gate condition

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -660,7 +660,7 @@ func main() {
 					continue
 				}
 				chTrades := channelTrades[chKey]
-				// Options: post every run. Others: hourly or on trade.
+				// Options/perps/futures: post every run. Spot: hourly or on trade.
 				// (cycle-1)%12==0 fires at cycles 1,13,25... so first summary posts on startup.
 				if !isOptionsType(chStrats) && !isFuturesType(chStrats) && !isPerpsType(chStrats) && chTrades == 0 && (cycle-1)%12 != 0 {
 					continue


### PR DESCRIPTION
## Summary
- Updated comment in `scheduler/main.go` (line 663) that said "Options: post every run. Others: hourly or on trade." to "Options/perps/futures: post every run. Spot: hourly or on trade."
- The comment was left over from when only options posted every cycle, but PR #123 added perps and futures to the gate condition (`!isPerpsType(chStrats) && !isFuturesType(chStrats)`), making the old comment inaccurate.

## Test plan
- [x] `gofmt` passes
- [x] `go build` compiles successfully
- Comment-only change; no behavioral impact

---
Generated with: Claude Opus 4.6 | Effort: high