### PR TITLE
test: check json.Unmarshal errors in executor tests

### DIFF
--- a/scheduler/executor_test.go
+++ b/scheduler/executor_test.go
@@ -41,7 +41,9 @@ func TestSpotResultJSON(t *testing.T) {
 func TestSpotResultErrorJSON(t *testing.T) {
 	raw := `{"strategy": "sma", "error": "API timeout"}`
 	var result SpotResult
-	json.Unmarshal([]byte(raw), &result)
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatal(err)
+	}
 	if result.Error != "API timeout" {
 		t.Errorf("Error = %q, want %q", result.Error, "API timeout")
 	}


### PR DESCRIPTION
## Summary
- Fix silently discarded `json.Unmarshal` return value in `TestSpotResultErrorJSON` (`scheduler/executor_test.go` line 44)
- All other test files in `scheduler/` already check unmarshal errors; this was the only instance

## Context
Flagged in PR #120 review. If struct tags or types change, the discarded error would cause test assertions to fail with confusing zero-value mismatches instead of a clear unmarshal error.

## Test plan
- [x] `go build .` passes
- [x] `go test ./...` passes
- [x] `gofmt` clean

---
Generated with: Claude Opus 4.6 | Effort: high