### PR TITLE
test: replace brittle mock chains with real DataFrames in TopStep tests

### DIFF
--- a/platforms/topstep/test_adapter.py
+++ b/platforms/topstep/test_adapter.py
@@ -64,16 +64,13 @@ class TestContractSpecs:
 
 class TestMarketDataPaper:
     def test_get_price_paper_yahoo(self):
+        import pandas as pd
         adapter = TopStepExchangeAdapter(mode="paper")
-        mock_hist = MagicMock()
-        mock_hist.empty = False
-        mock_close = MagicMock()
-        mock_close.iloc.__getitem__ = MagicMock(return_value=5500.0)
-        mock_hist.__getitem__ = MagicMock(return_value=mock_close)
+        hist = pd.DataFrame({"Close": [5400.0, 5450.0, 5500.0]})
 
         mock_yf = MagicMock()
         mock_ticker = MagicMock()
-        mock_ticker.history.return_value = mock_hist
+        mock_ticker.history.return_value = hist
         mock_yf.Ticker.return_value = mock_ticker
         with patch.dict(sys.modules, {"yfinance": mock_yf}):
             price = adapter.get_price("ES")


### PR DESCRIPTION
## Summary
- Replaced brittle `MagicMock` chain (`__getitem__`, `iloc.__getitem__`) for yfinance DataFrame access in `test_get_price_paper_yahoo` with a real `pd.DataFrame({"Close": [5400.0, 5450.0, 5500.0]})`.
- This ensures the test exercises the actual pandas `hist["Close"].iloc[-1]` code path in the adapter rather than silently returning a `MagicMock` if production code changes how it accesses the DataFrame.

## Test plan
- [x] All 15 tests in `platforms/topstep/test_adapter.py` pass

---
Generated with: Claude Opus 4.6 | Effort: high