### PR TITLE
fix: add Telegram token-in-config warning consistent with Discord

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -135,8 +135,16 @@ func LoadConfig(path string) (*Config, error) {
 	}
 
 	// Telegram bot token from env var takes priority over config file.
-	if telegramToken := os.Getenv("TELEGRAM_BOT_TOKEN"); telegramToken != "" {
-		cfg.Telegram.BotToken = telegramToken
+	// Warn if token is present in config file (env var is preferred).
+	configHasTelegramToken := cfg.Telegram.BotToken != ""
+	envTelegramToken := os.Getenv("TELEGRAM_BOT_TOKEN")
+	if envTelegramToken != "" {
+		if configHasTelegramToken {
+			fmt.Println("[WARN] Telegram bot token found in both config file and TELEGRAM_BOT_TOKEN env var. Remove it from config.json to avoid accidental exposure.")
+		}
+		cfg.Telegram.BotToken = envTelegramToken
+	} else if configHasTelegramToken {
+		fmt.Println("[WARN] Telegram bot token found in config file. Prefer setting TELEGRAM_BOT_TOKEN env var instead.")
 	}
 	// Telegram owner chat ID from env var takes priority over config file.
 	if telegramOwner := os.Getenv("TELEGRAM_OWNER_CHAT_ID"); telegramOwner != "" {


### PR DESCRIPTION
## Summary
- Discord already warns when the bot token is found in `config.json` instead of an env var, but Telegram had no equivalent warning
- Added the same warning pattern for Telegram bot token in `LoadConfig`, mirroring the Discord approach:
  - If token is in both config file and `TELEGRAM_BOT_TOKEN` env var: warns about both sources, env var takes priority
  - If token is only in config file: warns to prefer `TELEGRAM_BOT_TOKEN` env var

## Test plan
- [x] `go build .` compiles successfully
- [x] `go test ./...` passes
- [x] `gofmt` applied

---
Generated with: Claude Opus 4.6 | Effort: high