### PR TITLE
fix: remove wildcard allowed_bots from Claude review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,5 +27,4 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          allowed_bots: '*'
           claude_args: '--model claude-opus-4-6 --effort high'


### PR DESCRIPTION
## Summary
- Removes `allowed_bots: '*'` from `.github/workflows/claude-code-review.yml`, which previously permitted any bot account to interact with the Claude code review action
- Without this setting, the `anthropics/claude-code-action` uses its default behavior, which is more restrictive and only allows expected bot accounts
- The other workflow (`claude.yml`) already omits this setting and works correctly with defaults

## Test plan
- [ ] Verify the Claude Code Review workflow still triggers on PRs opened by human contributors
- [ ] Verify dependabot PRs are handled correctly (the action's defaults should allow standard GitHub bots)
- [ ] Confirm no regressions in the review workflow behavior

---
Generated with: Claude Opus 4.6 | Effort: high