### PR TITLE
fix: warn on Hyperliquid sz_decimals fallback for unknown symbols

### DIFF
--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -11,6 +11,7 @@ Environment variables:
 """
 
 import os
+import sys
 import time
 
 MAINNET_URL = "https://api.hyperliquid.xyz"
@@ -202,6 +203,8 @@ class HyperliquidExchangeAdapter:
                 "market_open requires live mode (set HYPERLIQUID_SECRET_KEY)"
             )
         # Round to asset's tick precision to avoid float_to_wire rounding error
+        if symbol not in self._info.asset_to_sz_decimals:
+            print(f"[WARN] sz_decimals not found for {symbol}, defaulting to 3", file=sys.stderr)
         sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3)
         size = round(size, sz_decimals)
         if size <= 0:


### PR DESCRIPTION
## Summary
- The `sz_decimals` lookup in `HyperliquidExchangeAdapter.market_open()` silently fell back to `3` when a symbol wasn't found in `asset_to_sz_decimals`, which could cause incorrect order size rounding for newly listed assets.
- Added a `[WARN]` log to stderr when the fallback is triggered, making it visible in scheduler logs without changing the existing behavior.

## Test plan
- [ ] Verify `py_compile` passes on the modified file
- [ ] Confirm warning appears in stderr when trading a symbol not in the sz_decimals map
- [ ] Confirm no warning for known symbols (BTC, ETH, SOL, etc.)

---
Generated with: Claude Opus 4.6 | Effort: high