### PR TITLE
fix: move -summary check before unnecessary startup work

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -164,6 +164,14 @@ func main() {
 	notifier := NewMultiNotifier(backends...)
 	fmt.Printf("Notification backends: %d active\n", notifier.BackendCount())
 
+	// -summary mode: post snapshot summary for the specified channel and exit.
+	// Checked early since it only needs config, state, and notifier — avoids
+	// launching the config-migration goroutine, update checks, and pricers
+	// that would be hard-killed by os.Exit.
+	if *summary != "" {
+		runSummaryAndExit(*summary, cfg, state, notifier)
+	}
+
 	// Config migration: DM owner about new fields if config is behind current version.
 	if cfg.ConfigVersion < CurrentConfigVersion {
 		go runConfigMigrationDM(cfg, notifier, *configPath)
@@ -204,11 +212,6 @@ func main() {
 	dailyCycles := (24 * 3600) / tickSeconds
 	if dailyCycles < 1 {
 		dailyCycles = 1
-	}
-
-	// -summary mode: post snapshot summary for the specified channel and exit.
-	if *summary != "" {
-		runSummaryAndExit(*summary, cfg, state, notifier)
 	}
 
 	saveFailures := 0


### PR DESCRIPTION
## Summary

- Moved the `-summary` flag check to immediately after `MultiNotifier` initialization, before config migration goroutine, update checks, DeribitPricer init, and tick interval calculation
- The `-summary` path is a one-shot exit (calls `os.Exit`) that only needs `cfg`, `state`, and `notifier` — everything else was wasted work
- Prevents the config migration goroutine from being spawned and then hard-killed by `os.Exit`

## Test plan

- [x] `go build .` compiles successfully
- [x] `go test ./...` passes
- [x] `gofmt` applied
- [ ] Manual: `./go-trader --config scheduler/config.json -summary spot` still posts the snapshot and exits

---
Generated with: Claude Opus 4.6 | Effort: high