### PR TITLE
fix: send DM alerts for all trades in a cycle

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -585,7 +585,7 @@ func main() {
 							channelTradeDetails[key] = append(channelTradeDetails[key], detail)
 						}
 						// DM trade alerts (Discord + Telegram)
-						sendTradeAlerts(sc, stratState, &mu, notifier)
+						sendTradeAlerts(sc, stratState, trades, &mu, notifier)
 					}
 
 					totalTrades += trades
@@ -953,21 +953,26 @@ func isLiveArgs(args []string) bool {
 }
 
 // sendTradeAlerts sends DM trade alerts to the owner via all configured backends.
-func sendTradeAlerts(sc StrategyConfig, stratState *StrategyState, mu *sync.RWMutex, notifier *MultiNotifier) {
+// trades is the number of new trades appended during this cycle.
+func sendTradeAlerts(sc StrategyConfig, stratState *StrategyState, trades int, mu *sync.RWMutex, notifier *MultiNotifier) {
 	isLive := isLiveArgs(sc.Args)
 	mode := "paper"
 	if isLive {
 		mode = "live"
 	}
 
-	var lastTrade Trade
 	mu.RLock()
-	if n := len(stratState.TradeHistory); n > 0 {
-		lastTrade = stratState.TradeHistory[n-1]
-	} else {
+	n := len(stratState.TradeHistory)
+	if n == 0 || trades <= 0 {
 		mu.RUnlock()
 		return
 	}
+	start := n - trades
+	if start < 0 {
+		start = 0
+	}
+	newTrades := make([]Trade, trades)
+	copy(newTrades, stratState.TradeHistory[start:n])
 	mu.RUnlock()
 
 	for _, b := range notifier.backends {
@@ -978,14 +983,16 @@ func sendTradeAlerts(sc StrategyConfig, stratState *StrategyState, mu *sync.RWMu
 		if !dmEnabled {
 			continue
 		}
-		var msg string
-		if b.plainText {
-			msg = FormatTradeDMPlain(sc, lastTrade, mode)
-		} else {
-			msg = FormatTradeDM(sc, lastTrade, mode)
-		}
-		if err := b.notifier.SendDM(b.ownerID, msg); err != nil {
-			fmt.Printf("[notify] DM trade alert failed: %v\n", err)
+		for _, t := range newTrades {
+			var msg string
+			if b.plainText {
+				msg = FormatTradeDMPlain(sc, t, mode)
+			} else {
+				msg = FormatTradeDM(sc, t, mode)
+			}
+			if err := b.notifier.SendDM(b.ownerID, msg); err != nil {
+				fmt.Printf("[notify] DM trade alert failed: %v\n", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- `sendTradeAlerts` previously only sent a DM for `TradeHistory[n-1]`, missing earlier trades when a single cycle produces multiple trades (e.g. close + re-open)
- Now accepts a `trades` count parameter and loops over the last N entries in `TradeHistory`, sending a DM for each
- Copies the trade slice under RLock to minimize lock hold time

## Test plan
- [x] `go build` compiles successfully
- [x] `go test ./...` passes
- [x] `gofmt` clean

---
Generated with: Claude Opus 4.6 | Effort: high