### PR TITLE
test: assert actual DESC ordering in test_multiple_results_ordered_desc

### DIFF
--- a/shared_tools/storage.py
+++ b/shared_tools/storage.py
@@ -160,7 +160,7 @@ def get_backtest_results(strategy_name: Optional[str] = None,
     if strategy_name:
         query += " WHERE strategy_name = ?"
         params.append(strategy_name)
-    query += " ORDER BY created_at DESC"
+    query += " ORDER BY created_at DESC, id DESC"
     df = pd.read_sql_query(query, conn, params=params)
     conn.close()
     return df

--- a/shared_tools/test_storage.py
+++ b/shared_tools/test_storage.py
@@ -301,4 +301,4 @@ class TestBacktestRoundTrip:
 
         df = get_backtest_results(db_path=db_path)
         assert len(df) == 3
-        assert set(df["strategy_name"]) == {"strategy_0", "strategy_1", "strategy_2"}
+        assert list(df["strategy_name"]) == ["strategy_2", "strategy_1", "strategy_0"]


### PR DESCRIPTION
## Summary
- `test_multiple_results_ordered_desc` used `set()` which discards ordering, so it never actually verified DESC sort. Replaced with a `list` assertion checking `["strategy_2", "strategy_1", "strategy_0"]`.
- Added `id DESC` as a tiebreaker in `get_backtest_results`'s `ORDER BY` clause to guarantee deterministic ordering when rows share the same `created_at` timestamp (which has only second-level precision in SQLite).

## Test plan
- [x] `test_multiple_results_ordered_desc` passes with the new list assertion
- [x] All 25 tests in `shared_tools/test_storage.py` pass with no regressions

---
Generated with: Claude Opus 4.6 | Effort: high