### PR TITLE
fix: skip HTF filter for delta_neutral_funding strategy

### DIFF
--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -544,9 +544,10 @@ func generateConfig(opts InitOptions) *Config {
 	}
 
 	// Apply HTF filter to all non-options strategies if enabled.
+	// Skip delta_neutral_funding — trend direction is irrelevant to funding-rate harvesting (#103).
 	if opts.HTFFilter {
 		for i := range cfg.Strategies {
-			if cfg.Strategies[i].Type != "options" {
+			if cfg.Strategies[i].Type != "options" && (len(cfg.Strategies[i].Args) == 0 || cfg.Strategies[i].Args[0] != "delta_neutral_funding") {
 				cfg.Strategies[i].HTFFilter = true
 			}
 		}

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -91,9 +91,9 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
 
         price = float(last["close"])
 
-        # Apply HTF trend filter if enabled
+        # Apply HTF trend filter if enabled (skip for funding-rate strategies — #103)
         htf_info = {}
-        if htf_filter_enabled:
+        if htf_filter_enabled and strategy_name != "delta_neutral_funding":
             from htf_filter import htf_trend_filter, apply_htf_filter
 
             def _fetch_htf(sym, tf, limit):

--- a/shared_scripts/check_okx.py
+++ b/shared_scripts/check_okx.py
@@ -94,9 +94,9 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
 
         price = float(last["close"])
 
-        # Apply HTF trend filter if enabled
+        # Apply HTF trend filter if enabled (skip for funding-rate strategies — #103)
         htf_info = {}
-        if htf_filter_enabled:
+        if htf_filter_enabled and strategy_name != "delta_neutral_funding":
             from htf_filter import htf_trend_filter, apply_htf_filter
 
             def _fetch_htf(sym, tf, limit):

--- a/shared_scripts/check_robinhood.py
+++ b/shared_scripts/check_robinhood.py
@@ -77,9 +77,9 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
 
         price = float(last["close"])
 
-        # Apply HTF trend filter if enabled
+        # Apply HTF trend filter if enabled (skip for funding-rate strategies — #103)
         htf_info = {}
-        if htf_filter_enabled:
+        if htf_filter_enabled and strategy_name != "delta_neutral_funding":
             from htf_filter import htf_trend_filter, apply_htf_filter
 
             def _fetch_htf(sym, tf, limit):

--- a/shared_scripts/check_strategy.py
+++ b/shared_scripts/check_strategy.py
@@ -107,9 +107,9 @@ def main():
 
         price = float(last["close"])
 
-        # Apply HTF trend filter if enabled
+        # Apply HTF trend filter if enabled (skip for funding-rate strategies — #103)
         htf_info = {}
-        if htf_filter_enabled:
+        if htf_filter_enabled and strategy_name != "delta_neutral_funding":
             from htf_filter import htf_trend_filter, apply_htf_filter
 
             def _fetch_htf(sym, tf, limit):

--- a/shared_scripts/check_topstep.py
+++ b/shared_scripts/check_topstep.py
@@ -95,9 +95,9 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
 
         price = float(last["close"])
 
-        # Apply HTF trend filter if enabled
+        # Apply HTF trend filter if enabled (skip for funding-rate strategies — #103)
         htf_info = {}
-        if htf_filter_enabled:
+        if htf_filter_enabled and strategy_name != "delta_neutral_funding":
             from htf_filter import htf_trend_filter, apply_htf_filter
 
             def _fetch_htf(sym, tf, limit):


### PR DESCRIPTION
## Summary

- `delta_neutral_funding` is a funding-rate harvest strategy — trend direction is irrelevant, so the HTF trend filter incorrectly suppresses valid entries (especially during downtrends when funding is most profitable)
- Excludes `delta_neutral_funding` from HTF filter assignment in `generateConfig` (`init.go`)
- Adds runtime guard in all 5 Python check scripts to skip HTF filter when `strategy_name == "delta_neutral_funding"` (protects existing configs)

Closes #103

## Test plan

- [x] `go build` compiles
- [x] `go test ./...` passes
- [x] Python syntax check on all 5 modified check scripts
- [x] Smoke test: `go-trader init --json` with `htfFilter:true` and both `delta_neutral_funding` + `sma_crossover` — confirms DNF gets `htf_filter=false`, SMA gets `htf_filter=true`

---
Generated with: Claude Opus 4.6 | Effort: 99