### PR TITLE
fix: remove look-ahead bias in Parabolic SAR initialization

### DIFF
--- a/shared_strategies/futures/strategies.py
+++ b/shared_strategies/futures/strategies.py
@@ -547,7 +547,7 @@ def parabolic_sar_strategy(df: pd.DataFrame, iaf: float = 0.02, af_step: float =
         result["signal"] = 0
         return result
 
-    trend[0] = 1 if close[1] >= close[0] else -1
+    trend[0] = 1  # neutral default; avoids look-ahead bias from peeking at close[1] (#104)
     if trend[0] == 1:
         sar[0] = low[0]
         ep[0] = high[0]

--- a/shared_strategies/spot/strategies.py
+++ b/shared_strategies/spot/strategies.py
@@ -676,7 +676,7 @@ def parabolic_sar_strategy(df: pd.DataFrame, iaf: float = 0.02, af_step: float =
         result["signal"] = 0
         return result
 
-    trend[0] = 1 if close[1] >= close[0] else -1
+    trend[0] = 1  # neutral default; avoids look-ahead bias from peeking at close[1] (#104)
     if trend[0] == 1:
         sar[0] = low[0]
         ep[0] = high[0]


### PR DESCRIPTION
## Summary

- Parabolic SAR `trend[0]` initialization peeked at `close[1]` (next bar), introducing look-ahead bias in backtests
- Replaced with neutral `trend[0] = 1` default — same fix in both `spot/strategies.py` and `futures/strategies.py`

Closes #104

## Test plan

- [x] Python syntax check on both files
- [x] 165/166 strategy tests pass (1 pre-existing `vwap_reversion` empty-df failure unrelated)

---
Generated with: Claude Opus 4.6 | Effort: 99