### PR TITLE
fix: invert delta_neutral_funding signals and remove from spot registry

### DIFF
--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -89,7 +89,6 @@ var defaultSpotStrategies = []stratDef{
 	{ID: "chart_pattern", ShortName: "cpat"},
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 	{ID: "parabolic_sar", ShortName: "psar"},
-	{ID: "delta_neutral_funding", ShortName: "dnf"},
 }
 
 var defaultOptionsStrategies = []stratDef{
@@ -103,6 +102,7 @@ var defaultPerpsStrategies = []stratDef{
 	{ID: "momentum", ShortName: "momentum"},
 	{ID: "chart_pattern", ShortName: "cpat"},
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
+	{ID: "delta_neutral_funding", ShortName: "dnf"},
 }
 
 var defaultFuturesStrategies = []stratDef{
@@ -179,7 +179,8 @@ func discoverStrategies() {
 		}
 		if len(filtered) > 0 {
 			spotStrategies = filtered
-			perpsStrategies = filtered // perps supports the same set as spot
+			// perps supports the same set as spot + delta_neutral_funding (perps-only, #102)
+			perpsStrategies = append(filtered, stratDef{ID: "delta_neutral_funding", ShortName: "dnf"})
 		}
 	}
 	if discovered := discoverPythonStrategies("shared_strategies/options/strategies.py"); len(discovered) > 0 {

--- a/shared_strategies/futures/strategies.py
+++ b/shared_strategies/futures/strategies.py
@@ -627,10 +627,11 @@ def delta_neutral_funding_strategy(df: pd.DataFrame,
     result["signal"] = 0
     if avg == 0.0:
         return result
+    # Positive avg funding = longs pay shorts → SHORT perp to collect (#102)
     if avg > entry_threshold:
-        result.iloc[-1, result.columns.get_loc("signal")] = 1
+        result.iloc[-1, result.columns.get_loc("signal")] = -1  # enter short
     elif avg < exit_threshold:
-        result.iloc[-1, result.columns.get_loc("signal")] = -1
+        result.iloc[-1, result.columns.get_loc("signal")] = 1   # exit short
     return result
 
 

--- a/shared_strategies/futures/test_strategies.py
+++ b/shared_strategies/futures/test_strategies.py
@@ -288,12 +288,13 @@ class TestDeltaNeutralFunding:
     def test_entry_on_high_funding(self):
         result = _run("delta_neutral_funding", make_flat(20),
                        {"avg_funding_rate_7d": 0.0005, "entry_threshold": 0.0001})
-        assert result["signal"].iloc[-1] == 1
+        # Positive funding → SHORT perp to collect (#102)
+        assert result["signal"].iloc[-1] == -1
 
     def test_exit_on_low_funding(self):
         result = _run("delta_neutral_funding", make_flat(20),
                        {"avg_funding_rate_7d": 0.00003, "exit_threshold": 0.00005})
-        assert result["signal"].iloc[-1] == -1
+        assert result["signal"].iloc[-1] == 1
 
     def test_zero_funding_no_signal(self):
         result = _run("delta_neutral_funding", make_flat(20),

--- a/shared_strategies/spot/strategies.py
+++ b/shared_strategies/spot/strategies.py
@@ -739,12 +739,7 @@ def parabolic_sar_strategy(df: pd.DataFrame, iaf: float = 0.02, af_step: float =
     return result
 
 
-@register_strategy(
-    "delta_neutral_funding",
-    "Delta-Neutral Funding — enter when 7d avg funding rate exceeds threshold, exit when below",
-    {"entry_threshold": 0.0001, "exit_threshold": 0.00005, "drift_threshold": 2.0,
-     "current_funding_rate": 0.0, "avg_funding_rate_7d": 0.0}
-)
+# Not registered in spot — funding rates are perps-only; check_strategy.py never injects params (#102).
 def delta_neutral_funding_strategy(df: pd.DataFrame,
                                    entry_threshold: float = 0.0001,
                                    exit_threshold: float = 0.00005,
@@ -761,11 +756,11 @@ def delta_neutral_funding_strategy(df: pd.DataFrame,
     result["signal"] = 0
     if avg == 0.0:
         return result
-    # Positive avg funding = longs pay shorts → short perp collects funding
+    # Positive avg funding = longs pay shorts → SHORT perp to collect (#102)
     if avg > entry_threshold:
-        result.iloc[-1, result.columns.get_loc("signal")] = 1
+        result.iloc[-1, result.columns.get_loc("signal")] = -1  # enter short
     elif avg < exit_threshold:
-        result.iloc[-1, result.columns.get_loc("signal")] = -1
+        result.iloc[-1, result.columns.get_loc("signal")] = 1   # exit short
     return result
 
 

--- a/shared_strategies/spot/test_strategies.py
+++ b/shared_strategies/spot/test_strategies.py
@@ -500,25 +500,7 @@ class TestParabolicSAR:
 
 # ─── Delta Neutral Funding ──────────────────
 
-class TestDeltaNeutralFunding:
-    def test_entry_signal_on_high_avg(self):
-        closes = make_flat(20)
-        result = _run_strategy("delta_neutral_funding", closes,
-                               {"avg_funding_rate_7d": 0.0005, "entry_threshold": 0.0001})
-        # Last row should have buy signal (avg > entry_threshold → enter delta-neutral)
-        assert result["signal"].iloc[-1] == 1
-
-    def test_exit_signal_on_low_avg(self):
-        closes = make_flat(20)
-        result = _run_strategy("delta_neutral_funding", closes,
-                               {"avg_funding_rate_7d": 0.00003, "exit_threshold": 0.00005})
-        assert result["signal"].iloc[-1] == -1
-
-    def test_no_signal_on_zero_avg(self):
-        closes = make_flat(20)
-        result = _run_strategy("delta_neutral_funding", closes,
-                               {"avg_funding_rate_7d": 0.0})
-        assert (result["signal"] == 0).all()
+# delta_neutral_funding removed from spot registry — perps-only (#102)
 
 
 # ─── Squeeze Momentum ──────────────────────


### PR DESCRIPTION
## Summary

- **Signal inversion**: `signal=1` (BUY) was emitted when positive funding should trigger a SHORT perp (`signal=-1`) to collect funding from longs; flipped in both `spot/strategies.py` and `futures/strategies.py`
- **Spot registry removal**: Removed `@register_strategy` from spot — `check_strategy.py` never injects funding rate params, so the strategy silently no-ops on spot platforms
- **init.go**: Removed from `defaultSpotStrategies`, added to `defaultPerpsStrategies`; `discoverStrategies` now appends `delta_neutral_funding` to perps after filtering from spot discovery
- **Tests**: Removed spot test class, updated futures test expectations to match corrected signal semantics

Closes #102

## Test plan

- [x] `go build` + `go test ./...` pass
- [x] `pytest` — 162 passed (1 pre-existing vwap_reversion failure)
- [x] `strategies.py --list-json` confirms `delta_neutral_funding` absent from spot registry
- [x] Smoke test: `go-trader init --json` with perps — `delta_neutral_funding` present
- [x] Smoke test: `go-trader init --json` with spot only — `delta_neutral_funding` absent

---
Generated with: Claude Opus 4.6 | Effort: 99