### PR TITLE
feat: show positions count in strategy summary

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -335,6 +335,17 @@ func FormatCategorySummary(
 	}
 	writeCatTable(&sb, tableBots, filteredValue, totalPnl, totalPnlPct)
 
+	// Positions summary (#145)
+	totalOpenPos := 0
+	for _, bot := range tableBots {
+		totalOpenPos += bot.openPositions
+	}
+	if totalOpenPos == 0 {
+		sb.WriteString("Positions: no open positions\n")
+	} else {
+		sb.WriteString(fmt.Sprintf("Positions: %d open\n", totalOpenPos))
+	}
+
 	// Trade details (always shown)
 	if len(tradeDetails) > 0 {
 		sb.WriteString("\n**Trades:**\n")


### PR DESCRIPTION
## Summary

- Adds a positions line after the strategy table in Discord summaries
- Shows "Positions: no open positions" when all strategies have zero positions
- Shows "Positions: N open" when there are active positions
- Helps users distinguish between "no positions" and "data missing/error"

Closes #145

## Test plan

- [x] `go build` compiles
- [x] `go test ./...` passes (existing discord_test.go covers FormatCategorySummary)
- [x] `gofmt` clean

---
Generated with: Claude Opus 4.6 | Effort: 99