### PR TITLE
ci: add Discord release notifications

### DIFF
--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post to Discord
-        uses: SethCohen/github-releases-to-discord@v1.15.1
+        uses: SethCohen/github-releases-to-discord@v1.20.0
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           color: "2105893"


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to post release notes to Discord when a release is published
- Uses [github-releases-to-discord](https://github.com/marketplace/actions/github-releases-to-discord) action
- Webhook URL stored as `DISCORD_WEBHOOK_URL` GitHub secret

## Test plan
- [ ] Publish a test release and verify Discord notification appears

---
Generated with: Claude Opus 4.6 | Effort: 85