### PR TITLE
test: add unit tests for zero-capital strategy skip guard

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -255,7 +255,7 @@ func main() {
 		for _, sc := range cfg.Strategies {
 			// #100: Skip strategies where capital_pct is set but capital resolved to $0
 			// (balance fetch failed and no fallback capital configured).
-			if sc.CapitalPct > 0 && sc.Capital <= 0 {
+			if shouldSkipZeroCapital(sc) {
 				fmt.Printf("[ERROR] %s: capital_pct set but capital resolved to $0 — skipping\n", sc.ID)
 				continue
 			}
@@ -989,6 +989,13 @@ func executeOptionsResult(sc StrategyConfig, s *StrategyState, result *OptionsRe
 	}
 
 	return trades, detail, harvestDetails
+}
+
+// shouldSkipZeroCapital reports whether a strategy should be skipped because
+// capital_pct is set but capital resolved to $0 (balance fetch failed and
+// no fallback capital configured).
+func shouldSkipZeroCapital(sc StrategyConfig) bool {
+	return sc.CapitalPct > 0 && sc.Capital <= 0
 }
 
 // hyperliquidIsLive reports whether --mode=live appears in strategy args.

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -4,6 +4,35 @@ import (
 	"testing"
 )
 
+func TestShouldSkipZeroCapital(t *testing.T) {
+	cases := []struct {
+		name       string
+		capitalPct float64
+		capital    float64
+		want       bool
+	}{
+		{"capital_pct set and capital is zero", 0.5, 0, true},
+		{"capital_pct set and capital is negative", 0.25, -100, true},
+		{"capital_pct set and capital resolved", 0.5, 500, false},
+		{"no capital_pct (fixed capital)", 0, 1000, false},
+		{"no capital_pct and no capital", 0, 0, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := StrategyConfig{
+				ID:         "test-strategy",
+				CapitalPct: tc.capitalPct,
+				Capital:    tc.capital,
+			}
+			if got := shouldSkipZeroCapital(sc); got != tc.want {
+				t.Errorf("shouldSkipZeroCapital(pct=%g, cap=%g) = %v, want %v",
+					tc.capitalPct, tc.capital, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsLiveArgs(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
Add unit tests for the `shouldSkipZeroCapital` guard introduced in PR #160.

Extracts the inline check into a testable helper and adds 5 table-driven test cases.

Follows up on #160.

Generated with [Claude Code](https://claude.ai/code)