### PR TITLE
fix: route SendMessage/SendDM per-backend instead of broadcasting to all

### DIFF
--- a/scheduler/notifier.go
+++ b/scheduler/notifier.go
@@ -41,24 +41,38 @@ func NewMultiNotifier(backends ...notifierBackend) *MultiNotifier {
 	return &MultiNotifier{backends: valid}
 }
 
-// SendMessage sends content to the given channel/chat ID on all backends.
-// Used when the caller already has a resolved channel ID.
+// SendMessage sends content to backends that own the given channel/chat ID.
+// A backend receives the message only if channelID appears in its channel map.
+// Returns the first error encountered; all per-backend errors are logged.
 func (m *MultiNotifier) SendMessage(channelID string, content string) error {
 	var firstErr error
 	for _, b := range m.backends {
-		if err := b.notifier.SendMessage(channelID, content); err != nil && firstErr == nil {
-			firstErr = err
+		if !backendOwnsChannel(b, channelID) {
+			continue
+		}
+		if err := b.notifier.SendMessage(channelID, content); err != nil {
+			fmt.Printf("[WARN] SendMessage to channel %s failed: %v\n", channelID, err)
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
 	return firstErr
 }
 
-// SendDM sends content as a direct message on all backends using each backend's owner ID.
+// SendDM sends content as a direct message to backends whose ownerID matches userID.
+// Returns the first error encountered; all per-backend errors are logged.
 func (m *MultiNotifier) SendDM(userID, content string) error {
 	var firstErr error
 	for _, b := range m.backends {
-		if err := b.notifier.SendDM(userID, content); err != nil && firstErr == nil {
-			firstErr = err
+		if b.ownerID != userID {
+			continue
+		}
+		if err := b.notifier.SendDM(userID, content); err != nil {
+			fmt.Printf("[WARN] SendDM to user %s failed: %v\n", userID, err)
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
 	return firstErr
@@ -107,6 +121,16 @@ func (m *MultiNotifier) OwnerID() string {
 // HasOwner returns true if any backend has an owner configured.
 func (m *MultiNotifier) HasOwner() bool {
 	return m.OwnerID() != ""
+}
+
+// backendOwnsChannel returns true if channelID is one of the backend's configured channel values.
+func backendOwnsChannel(b notifierBackend, channelID string) bool {
+	for _, ch := range b.channels {
+		if ch == channelID {
+			return true
+		}
+	}
+	return false
 }
 
 // SendToChannel sends content to all backends that have a channel configured

--- a/scheduler/notifier_test.go
+++ b/scheduler/notifier_test.go
@@ -308,12 +308,96 @@ func (e *errNotifier) Close() {}
 
 func TestMultiNotifier_SendMessage_ReturnsFirstError(t *testing.T) {
 	mn := NewMultiNotifier(
-		notifierBackend{notifier: &errNotifier{}},
-		notifierBackend{notifier: &mockNotifier{}},
+		notifierBackend{notifier: &errNotifier{}, channels: map[string]string{"spot": "ch1"}},
+		notifierBackend{notifier: &mockNotifier{}, channels: map[string]string{"spot": "ch1"}},
 	)
 
 	err := mn.SendMessage("ch1", "test")
 	if err == nil {
 		t.Error("expected error from first backend")
+	}
+}
+
+func TestMultiNotifier_SendMessage_RoutesPerBackend(t *testing.T) {
+	discord := &mockNotifier{}
+	telegram := &mockNotifier{}
+
+	mn := NewMultiNotifier(
+		notifierBackend{
+			notifier: discord,
+			channels: map[string]string{"spot": "discord-ch1"},
+		},
+		notifierBackend{
+			notifier: telegram,
+			channels: map[string]string{"spot": "telegram-ch1"},
+		},
+	)
+
+	// Sending to a Discord channel should NOT reach Telegram.
+	mn.SendMessage("discord-ch1", "hello discord")
+	if len(discord.messages) != 1 {
+		t.Errorf("expected 1 discord message, got %d", len(discord.messages))
+	}
+	if len(telegram.messages) != 0 {
+		t.Errorf("expected 0 telegram messages, got %d", len(telegram.messages))
+	}
+
+	// Sending to a Telegram channel should NOT reach Discord.
+	mn.SendMessage("telegram-ch1", "hello telegram")
+	if len(discord.messages) != 1 {
+		t.Errorf("expected still 1 discord message, got %d", len(discord.messages))
+	}
+	if len(telegram.messages) != 1 {
+		t.Errorf("expected 1 telegram message, got %d", len(telegram.messages))
+	}
+}
+
+func TestMultiNotifier_SendDM_RoutesPerBackend(t *testing.T) {
+	discord := &mockNotifier{}
+	telegram := &mockNotifier{}
+
+	mn := NewMultiNotifier(
+		notifierBackend{
+			notifier: discord,
+			ownerID:  "discord-owner",
+		},
+		notifierBackend{
+			notifier: telegram,
+			ownerID:  "telegram-owner",
+		},
+	)
+
+	// DM to Discord owner should NOT reach Telegram.
+	mn.SendDM("discord-owner", "hello discord")
+	if len(discord.dms) != 1 {
+		t.Errorf("expected 1 discord DM, got %d", len(discord.dms))
+	}
+	if len(telegram.dms) != 0 {
+		t.Errorf("expected 0 telegram DMs, got %d", len(telegram.dms))
+	}
+
+	// DM to Telegram owner should NOT reach Discord.
+	mn.SendDM("telegram-owner", "hello telegram")
+	if len(discord.dms) != 1 {
+		t.Errorf("expected still 1 discord DM, got %d", len(discord.dms))
+	}
+	if len(telegram.dms) != 1 {
+		t.Errorf("expected 1 telegram DM, got %d", len(telegram.dms))
+	}
+}
+
+func TestMultiNotifier_SendMessage_UnknownChannel(t *testing.T) {
+	mock := &mockNotifier{}
+	mn := NewMultiNotifier(
+		notifierBackend{notifier: mock, channels: map[string]string{"spot": "ch1"}},
+	)
+
+	// Unknown channel ID should not be sent anywhere.
+	err := mn.SendMessage("unknown-channel", "test")
+	if err != nil {
+		t.Errorf("expected nil error for unmatched channel, got %v", err)
+	}
+	if len(mock.messages) != 0 {
+		t.Errorf("expected 0 messages for unknown channel, got %d", len(mock.messages))
 	}
 }


### PR DESCRIPTION
MultiNotifier.SendMessage now only forwards to backends whose channel map contains the given channelID. SendDM only forwards to backends whose ownerID matches the given userID. Per-backend errors are logged instead of silently swallowed.

Closes #99

Generated with [Claude Code](https://claude.ai/claude-code)