### PR TITLE
fix(ci): add --comment flag to code-review plugin

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,7 +26,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           claude_args: '--model claude-opus-4-6 --effort high'
           allowed_bots: 'claude'
           show_full_output: true


### PR DESCRIPTION
## Summary
- Add `--comment` flag to the `/code-review:code-review` prompt in the Claude Code Review workflow
- Without this flag, the plugin runs the review but doesn't post results to the PR — the "Post review results" step was always skipped because `outputs.result` was empty

## Test plan
- [ ] Open a test PR and verify the code-review workflow posts findings as a PR comment
- [ ] Confirm the workflow still succeeds on PRs with no issues found

---
Generated with: Claude Opus 4.6 | Effort: auto