### PR TITLE
fix(okx): initialize best_dte before loop in get_real_expiry

### DIFF
--- a/platforms/okx/adapter.py
+++ b/platforms/okx/adapter.py
@@ -252,6 +252,7 @@ class OKXExchangeAdapter:
 
         best_exp = None
         best_diff = float("inf")
+        best_dte = 0
         for exp_ts in expiries:
             exp_dt = datetime.fromtimestamp(exp_ts / 1000, tz=timezone.utc)
             dte = (exp_dt - now).days


### PR DESCRIPTION
## Summary
- Initialize `best_dte = 0` before the for-loop in `OKXExchangeAdapter.get_real_expiry()` to prevent `UnboundLocalError` when all expiries have negative DTE

Closes #90

## Test plan
- [x] `python3 -m py_compile platforms/okx/adapter.py` passes

---
Generated with: Claude Opus 4.6 | Effort: 55