### PR TITLE
fix(okx): use perp ticker for swap position sizing

### DIFF
--- a/platforms/okx/adapter.py
+++ b/platforms/okx/adapter.py
@@ -88,6 +88,17 @@ class OKXExchangeAdapter:
                 continue
         return 0.0
 
+    def get_perp_price(self, symbol: str) -> float:
+        """Get current last price for a perpetual swap (e.g. 'BTC')."""
+        try:
+            ticker = self._exchange.fetch_ticker(f"{symbol}/USDT:USDT")
+            price = ticker.get("last") or 0
+            if price and price > 0:
+                return float(price)
+        except Exception:
+            pass
+        return 0.0
+
     def get_ohlcv(self, symbol: str, interval: str = "1h", limit: int = 200) -> list:
         """
         Fetch OHLCV candles from OKX.

--- a/shared_scripts/check_okx.py
+++ b/shared_scripts/check_okx.py
@@ -118,7 +118,13 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
 
         # Freshen price with live mid if available
         try:
-            mid = adapter.get_spot_price(symbol)
+            if inst_type == "swap":
+                # Use perp ticker to avoid spot/perp price divergence
+                pair = f"{symbol}/USDT:USDT"
+                ticker = adapter._exchange.fetch_ticker(pair)
+                mid = float(ticker.get("last") or 0)
+            else:
+                mid = adapter.get_spot_price(symbol)
             if mid > 0:
                 price = mid
         except Exception:

--- a/shared_scripts/check_okx.py
+++ b/shared_scripts/check_okx.py
@@ -119,10 +119,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
         # Freshen price with live mid if available
         try:
             if inst_type == "swap":
-                # Use perp ticker to avoid spot/perp price divergence
-                pair = f"{symbol}/USDT:USDT"
-                ticker = adapter._exchange.fetch_ticker(pair)
-                mid = float(ticker.get("last") or 0)
+                mid = adapter.get_perp_price(symbol)
             else:
                 mid = adapter.get_spot_price(symbol)
             if mid > 0:


### PR DESCRIPTION
## Summary
- When `inst_type == "swap"`, the "freshen price" step in `check_okx.py` was calling `adapter.get_spot_price(symbol)`, which returns the spot price — not the perpetual contract price. This caused incorrect position sizing when spot and perp prices diverge.
- Changed to fetch the perp ticker (`{symbol}/USDT:USDT`) via `fetch_ticker` when in swap mode, falling back to `get_spot_price` only for spot orders.

Closes #91

## Test plan
- [ ] Verify syntax: `python3 -m py_compile shared_scripts/check_okx.py`
- [ ] Run OKX perps strategy in paper mode and confirm the price used for sizing matches the perp ticker, not spot
- [ ] Run OKX spot strategy and confirm spot price is still used

---
Generated with: Claude Opus 4.6 | Effort: 55