### PR TITLE
fix(okx): cast strike to float before comparison

### DIFF
--- a/platforms/okx/adapter.py
+++ b/platforms/okx/adapter.py
@@ -323,7 +323,7 @@ class OKXExchangeAdapter:
                 if (market.get("type") == "option"
                         and market.get("base", "").upper() == underlying.upper()
                         and market.get("optionType") == option_type
-                        and market.get("strike") == strike
+                        and float(market.get("strike") or 0) == strike
                         and market.get("active", True)):
                     mkt_exp = market.get("expiry")
                     if mkt_exp and exp_start <= int(mkt_exp) < exp_end:


### PR DESCRIPTION
## Summary
- Cast `market.get("strike")` to `float` before comparing with the `strike` parameter in `get_premium_and_greeks`, since CCXT may return OKX strikes as strings (e.g. `"50000"` vs `50000.0`), causing silent match failure.

Closes #94

## Test plan
- [ ] Verify `python3 -m py_compile platforms/okx/adapter.py` passes
- [ ] Confirm strike matching works when CCXT returns string strikes

---
Generated with: Claude Opus 4.6 | Effort: 55