### PR TITLE
fix: wire test server into TelegramNotifier tests and add assertions

### DIFF
--- a/scheduler/telegram.go
+++ b/scheduler/telegram.go
@@ -19,7 +19,8 @@ type TelegramNotifier struct {
 	botToken    string
 	ownerChatID string
 	client      *http.Client
-	lastUpdate  int64 // offset for getUpdates polling
+	baseURL     string // API base URL (defaults to telegramAPIBase)
+	lastUpdate  int64  // offset for getUpdates polling
 	mu          sync.Mutex
 	closed      bool
 }
@@ -30,6 +31,7 @@ func NewTelegramNotifier(botToken, ownerChatID string) (*TelegramNotifier, error
 		botToken:    botToken,
 		ownerChatID: ownerChatID,
 		client:      &http.Client{Timeout: 35 * time.Second},
+		baseURL:     telegramAPIBase,
 	}
 
 	// Verify the bot token with a getMe call.
@@ -83,7 +85,7 @@ type telegramCBData struct {
 
 // apiCall makes a POST request to the Telegram Bot API.
 func (t *TelegramNotifier) apiCall(method string, payload interface{}) (*telegramResponse, error) {
-	url := telegramAPIBase + t.botToken + "/" + method
+	url := t.baseURL + t.botToken + "/" + method
 
 	var body io.Reader
 	if payload != nil {

--- a/scheduler/telegram_test.go
+++ b/scheduler/telegram_test.go
@@ -16,6 +16,7 @@ func newTestTelegramNotifier(serverURL string) *TelegramNotifier {
 		botToken:    "test-token",
 		ownerChatID: "12345",
 		client:      &http.Client{Timeout: 5 * time.Second},
+		baseURL:     serverURL + "/bot",
 	}
 }
 
@@ -37,25 +38,17 @@ func TestTelegramNotifier_SendMessage(t *testing.T) {
 	defer server.Close()
 
 	tg := newTestTelegramNotifier(server.URL)
-	// Override the apiCall to use our test server
-	tg.botToken = "test-token"
 
-	// Test the message truncation logic directly
-	longMsg := strings.Repeat("a", telegramMaxMessageLen+100)
-	if len(longMsg) <= telegramMaxMessageLen {
-		t.Fatal("test setup error: message should exceed max length")
+	err := tg.SendMessage("67890", "hello world")
+	if err != nil {
+		t.Fatalf("SendMessage returned error: %v", err)
 	}
-
-	// Test that SendMessage truncates (we can't test the actual API call without more setup,
-	// but we can test the interface compliance)
-	var n Notifier = tg
-	_ = n // Verify TelegramNotifier implements Notifier
-
-	// Use the test server to verify sends
-	origBase := telegramAPIBase
-	_ = origBase
-	_ = receivedChatID
-	_ = receivedText
+	if receivedChatID != "67890" {
+		t.Errorf("expected chat_id '67890', got %q", receivedChatID)
+	}
+	if receivedText != "hello world" {
+		t.Errorf("expected text 'hello world', got %q", receivedText)
+	}
 }
 
 func TestTelegramNotifier_ImplementsNotifier(t *testing.T) {
@@ -91,26 +84,40 @@ func TestTelegramNotifier_SendDM_IsSendMessage(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// We can verify the interface at compile time
-	tg := &TelegramNotifier{
-		botToken: "test",
-		client:   &http.Client{Timeout: 5 * time.Second},
+	tg := newTestTelegramNotifier(server.URL)
+
+	err := tg.SendDM("99999", "dm content")
+	if err != nil {
+		t.Fatalf("SendDM returned error: %v", err)
 	}
-	_ = tg
-	_ = sentChatID
+	if sentChatID != "99999" {
+		t.Errorf("expected chat_id '99999', got %q", sentChatID)
+	}
 }
 
 func TestTelegramNotifier_MessageTruncation(t *testing.T) {
-	// Verify that messages exceeding 4096 chars are truncated
+	var receivedText string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&body)
+		receivedText, _ = body["text"].(string)
+		json.NewEncoder(w).Encode(telegramResponse{OK: true})
+	}))
+	defer server.Close()
+
+	tg := newTestTelegramNotifier(server.URL)
+
 	longContent := strings.Repeat("x", 5000)
-	if len(longContent) > telegramMaxMessageLen {
-		truncated := longContent[:telegramMaxMessageLen-3] + "..."
-		if len(truncated) != telegramMaxMessageLen {
-			t.Errorf("expected truncated length %d, got %d", telegramMaxMessageLen, len(truncated))
-		}
-		if !strings.HasSuffix(truncated, "...") {
-			t.Error("expected truncated message to end with '...'")
-		}
+	err := tg.SendMessage("123", longContent)
+	if err != nil {
+		t.Fatalf("SendMessage returned error: %v", err)
+	}
+	if len(receivedText) != telegramMaxMessageLen {
+		t.Errorf("expected truncated length %d, got %d", telegramMaxMessageLen, len(receivedText))
+	}
+	if !strings.HasSuffix(receivedText, "...") {
+		t.Error("expected truncated message to end with '...'")
 	}
 }
 
@@ -182,6 +189,7 @@ func TestApiCallDoesNotLeakToken(t *testing.T) {
 	tn := &TelegramNotifier{
 		botToken: "secret-test-token-12345",
 		client:   &http.Client{Timeout: 50 * time.Millisecond},
+		baseURL:  telegramAPIBase,
 	}
 	// Call with no server running — will fail with connection error
 	_, err := tn.apiCall("getMe", nil)


### PR DESCRIPTION
Add `baseURL` field to `TelegramNotifier` so tests can redirect API calls to `httptest.NewServer`. Fix SendMessage, SendDM, and truncation tests to actually call the methods under test and assert on captured values.

Closes #98

Generated with [Claude Code](https://claude.ai/code)