### PR TITLE
ci: allow Go/Python commands in Claude Code Action sandbox

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,5 +57,8 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model claude-opus-4-6 --effort high'
+          claude_args: |
+            --model claude-opus-4-6
+            --effort high
+            --allowedTools "Bash(go *),Bash(cd scheduler && go *),Bash(uv run *),Bash(python3 *),Bash(.venv/bin/python3 *),Bash(gofmt *),Bash(cd scheduler && gofmt *)"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@
 - When marking an issue fixed: update the row (`NO` → `YES`) **and** the Summary table at the bottom (`Fixed` count +1, `Unfixed` count -1 for that category and Total)
 
 ## Testing
+- **New functionality must include tests** — Go changes need `_test.go` coverage; Python changes need `test_*.py` coverage. Bug fixes should include a regression test when feasible.
 - `python3 -m py_compile <file>` — syntax check Python files; run from repo root (`python3 -m py_compile shared_scripts/check_*.py`) — paths are relative to cwd
 - `cd scheduler && /opt/homebrew/bin/go build .` — compile check
 - `cd scheduler && /opt/homebrew/bin/go test ./...` — run all unit tests (must run from scheduler/ where go.mod lives; repo root has no go.mod)


### PR DESCRIPTION
## Summary
- Add `--allowedTools` to `claude_args` in the Claude Code Action workflow so Claude can run `go build`, `go test`, `uv run pytest`, `python3 -m py_compile`, and `gofmt` in CI
- The toolchains were already installed (commit 6317288) but Claude couldn't execute them because the sandbox blocks Bash commands by default
- Also adds test coverage requirement to CLAUDE.md

Closes #175 (unblocks Claude from verifying its own changes)

## Test plan
- [ ] Tag `@claude` on a test issue asking it to run `cd scheduler && go build .` and `cd scheduler && go test ./...`
- [ ] Confirm commands execute successfully without sandbox errors

---
Generated with: Claude Opus 4.6 | Effort: 85