### PR TITLE
ci: add sandbox permissions for code-review plugin

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,6 +28,7 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           claude_args: '--model claude-opus-4-6 --effort high'
+          allowed_tools: 'Bash(gh api *),Bash(gh pr *),Write'
           allowed_bots: 'claude'
           show_full_output: true
 


### PR DESCRIPTION
## Summary

- The code-review plugin agent was looping ~80 times in CI ([run #24083595626](https://github.com/richkuo/go-trader/actions/runs/24083595626/job/70250308498?pr=180)) trying to write `review_payload.json` and post reviews via `gh api`, both denied by the Claude Code Action sandbox
- Adds `allowed_tools: 'Bash(gh api *),Bash(gh pr *),Write'` so the plugin can post PR reviews

## Test plan

- [ ] Open a test PR and verify the code-review workflow completes without permission loops

---
Generated with: Claude Opus 4.6 | Effort: 85