### PR TITLE
feat: add Init column to Discord cycle summary tables

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -347,6 +347,7 @@ func FormatCategorySummary(
 			strategy:      stratName,
 			asset:         asset,
 			value:         pv,
+			initialCap:    ss.InitialCapital,
 			pnl:           pnl,
 			pnlPct:        pnlPct,
 			walletPct:     walletPct,
@@ -400,6 +401,7 @@ type botInfo struct {
 	strategy      string
 	asset         string
 	value         float64
+	initialCap    float64
 	pnl           float64
 	pnlPct        float64
 	walletPct     float64 // 0 = not a shared wallet; >0 = strategy's share of the wallet
@@ -497,47 +499,55 @@ func writeCatTable(sb *strings.Builder, bots []botInfo, totalValue, totalPnl, to
 	}
 	sb.WriteString("\n```\n")
 	if showWalletPct {
-		const sep = "-------------------------------------------------"
-		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %7s %8s\n", "Strategy", "Value", "PnL", "PnL%", "Wallet%"))
+		const sep = "------------------------------------------------------------"
+		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s\n", "Strategy", "Value", "Init", "PnL", "PnL%", "Wallet%"))
 		sb.WriteString(sep + "\n")
+		var totalInit float64
 		for _, bot := range bots {
 			label := bot.id
 			if len(label) > 12 {
 				label = label[:12]
 			}
 			valStr := "$ " + fmtComma(bot.value)
+			initStr := "$ " + fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
 			pctStr := fmtPnlPct(bot.pnlPct)
 			wpStr := ""
 			if bot.walletPct > 0 {
 				wpStr = fmt.Sprintf("%.1f%%", bot.walletPct)
 			}
-			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %7s %8s\n", label, valStr, pnlStr, pctStr, wpStr))
+			totalInit += bot.initialCap
+			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s\n", label, valStr, initStr, pnlStr, pctStr, wpStr))
 		}
 		sb.WriteString(sep + "\n")
 		totValStr := "$ " + fmtComma(totalValue)
+		totInitStr := "$ " + fmtComma(totalInit)
 		totPnlStr := fmtPnl(totalPnl)
 		totPctStr := fmtPnlPct(totalPnlPct)
-		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %7s %8s\n", "TOTAL", totValStr, totPnlStr, totPctStr, "100.0%"))
+		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s\n", "TOTAL", totValStr, totInitStr, totPnlStr, totPctStr, "100.0%"))
 	} else {
-		const sep = "---------------------------------------"
-		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %7s\n", "Strategy", "Value", "PnL", "PnL%"))
+		const sep = "--------------------------------------------------"
+		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s\n", "Strategy", "Value", "Init", "PnL", "PnL%"))
 		sb.WriteString(sep + "\n")
+		var totalInit float64
 		for _, bot := range bots {
 			label := bot.id
 			if len(label) > 12 {
 				label = label[:12]
 			}
 			valStr := "$ " + fmtComma(bot.value)
+			initStr := "$ " + fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
 			pctStr := fmtPnlPct(bot.pnlPct)
-			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %7s\n", label, valStr, pnlStr, pctStr))
+			totalInit += bot.initialCap
+			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s\n", label, valStr, initStr, pnlStr, pctStr))
 		}
 		sb.WriteString(sep + "\n")
 		totValStr := "$ " + fmtComma(totalValue)
+		totInitStr := "$ " + fmtComma(totalInit)
 		totPnlStr := fmtPnl(totalPnl)
 		totPctStr := fmtPnlPct(totalPnlPct)
-		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %7s\n", "TOTAL", totValStr, totPnlStr, totPctStr))
+		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s\n", "TOTAL", totValStr, totInitStr, totPnlStr, totPctStr))
 	}
 	sb.WriteString("```\n")
 }

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -301,8 +301,8 @@ func TestFormatCategorySummary_SharedWallet(t *testing.T) {
 	}
 	state := &AppState{
 		Strategies: map[string]*StrategyState{
-			"hl-rmc-eth":  {Cash: 1085}, // full wallet value
-			"hl-tema-eth": {Cash: 1085}, // full wallet value
+			"hl-rmc-eth":  {Cash: 1085, InitialCapital: 500}, // full wallet value
+			"hl-tema-eth": {Cash: 1085, InitialCapital: 500}, // full wallet value
 		},
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
@@ -312,6 +312,10 @@ func TestFormatCategorySummary_SharedWallet(t *testing.T) {
 	// Should contain Wallet% column
 	if !strings.Contains(msg, "Wallet%") {
 		t.Errorf("expected 'Wallet%%' column header, got:\n%s", msg)
+	}
+	// Should contain Init column
+	if !strings.Contains(msg, "Init") {
+		t.Errorf("expected 'Init' column header, got:\n%s", msg)
 	}
 	// Should contain 50.0% for each strategy
 	if !strings.Contains(msg, "50.0%") {
@@ -329,6 +333,10 @@ func TestFormatCategorySummary_SharedWallet(t *testing.T) {
 	if !strings.Contains(msg, "$ 542") {
 		t.Errorf("expected individual value ~$542, got:\n%s", msg)
 	}
+	// Initial capital should show $500 for each strategy
+	if !strings.Contains(msg, "$ 500") {
+		t.Errorf("expected initial capital '$ 500', got:\n%s", msg)
+	}
 }
 
 func TestFormatCategorySummary_NoSharedWallet(t *testing.T) {
@@ -339,8 +347,8 @@ func TestFormatCategorySummary_NoSharedWallet(t *testing.T) {
 	}
 	state := &AppState{
 		Strategies: map[string]*StrategyState{
-			"hl-rmc-eth":  {Cash: 500},
-			"hl-tema-eth": {Cash: 600},
+			"hl-rmc-eth":  {Cash: 500, InitialCapital: 500},
+			"hl-tema-eth": {Cash: 600, InitialCapital: 500},
 		},
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
@@ -349,5 +357,9 @@ func TestFormatCategorySummary_NoSharedWallet(t *testing.T) {
 
 	if strings.Contains(msg, "Wallet%") {
 		t.Errorf("should not show Wallet%% column without shared wallet, got:\n%s", msg)
+	}
+	// Should still show Init column even without shared wallet
+	if !strings.Contains(msg, "Init") {
+		t.Errorf("expected 'Init' column header, got:\n%s", msg)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds an `Init` column to Discord cycle summary tables showing each strategy's `initial_capital`
- Provides immediate performance context (e.g. $100 PnL on $1,000 vs $100,000 initial)
- Column appears in both shared-wallet and non-shared-wallet table formats

Closes #190

## Test plan
- [x] `TestFormatCategorySummary_SharedWallet` — verifies Init column with initial capital values
- [x] `TestFormatCategorySummary_NoSharedWallet` — verifies Init column without shared wallet
- [x] `TestFormatCategorySummary_WithAsset` — existing test still passes

---
Generated with: Claude Opus 4.6 | Effort: auto