### PR TITLE
ci: fix Claude workflow uv.lock checkout conflict

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,7 +39,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Install Python dependencies
-        run: uv sync --extra test
+        run: uv sync --frozen --extra test
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Summary
- Adds `--frozen` flag to `uv sync` in the Claude Code workflow
- `uv sync` was modifying `uv.lock`, causing the subsequent PR branch checkout to fail with "Your local changes would be overwritten"
- `--frozen` installs from the existing lockfile without updating it

## Test plan
- [x] Verified `uv sync --frozen --extra test` works locally
- [ ] Re-trigger Claude on PR #194 to confirm the workflow succeeds

---
Generated with: Claude Opus 4.6 | Effort: auto