### PR TITLE
ci: fix uv.lock conflict in Claude Code Action checkout

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install Python dependencies
         run: uv sync --frozen --extra test
 
+      - name: Clean up lockfile changes before Claude checkout
+        run: git checkout -- uv.lock
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary

- Fixes Claude Code Action CI failure where `uv sync` modifies `uv.lock` on the `main` checkout, then the action's internal `git checkout <pr-branch>` fails due to uncommitted changes
- Adds a `git checkout -- uv.lock` step after dependency installation to reset the lockfile before branch checkout
- Resolves the error seen in [run #24116328885](https://github.com/richkuo/go-trader/actions/runs/24116328885/job/70361077099)

## Test plan

- [ ] Trigger `@claude` on PR #194 and verify the CI job completes past the checkout step

---
Generated with: Claude Opus 4.6 | Effort: auto