### PR TITLE
fix: split Discord messages exceeding 2000 char limit and add position timestamps

### DIFF
--- a/scheduler/deribit.go
+++ b/scheduler/deribit.go
@@ -438,6 +438,7 @@ func applyAssignment(s *StrategyState, r markResult, logger *StrategyLogger) {
 				Quantity: r.AssignQuantity,
 				AvgCost:  r.AssignStrike,
 				Side:     "long",
+				OpenedAt: time.Now().UTC(),
 			}
 		}
 		s.TradeHistory = append(s.TradeHistory, Trade{

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -486,8 +486,15 @@ func splitCategorySummary(header string, totalOpenPos int, posLines []string, tr
 		}
 		contMsg += candidate
 	}
-	contMsg += tradeSuffix
-	msgs = append(msgs, contMsg)
+	if len(contMsg)+len(tradeSuffix) > discordSplitThreshold {
+		msgs = append(msgs, contMsg)
+		if tradeSuffix != "" {
+			msgs = append(msgs, tradeSuffix)
+		}
+	} else {
+		contMsg += tradeSuffix
+		msgs = append(msgs, contMsg)
+	}
 
 	return msgs
 }

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -214,7 +214,15 @@ func futuresDisplayName(ticker string) string {
 	return strings.ToUpper(ticker)
 }
 
-// FormatCategorySummary creates a Discord message for a set of strategies sharing a channel.
+// discordCharLimit is the maximum characters per Discord message.
+const discordCharLimit = 2000
+
+// discordSplitThreshold is the soft limit at which we start splitting messages.
+const discordSplitThreshold = 1980
+
+// FormatCategorySummary creates Discord messages for a set of strategies sharing a channel.
+// Returns a slice of messages; when the content exceeds Discord's 2000-char limit,
+// the position list is split across multiple messages.
 // channelStrategies is pre-filtered by the caller; channelKey is the display label.
 // asset, when non-empty, appends " — <ASSET>" to the title and filters the prices line.
 func FormatCategorySummary(
@@ -229,7 +237,7 @@ func FormatCategorySummary(
 	state *AppState,
 	channelKey string,
 	asset string,
-) string {
+) []string {
 	var sb strings.Builder
 
 	// Icon and title based on strategy types and channel key.
@@ -362,35 +370,126 @@ func FormatCategorySummary(
 	}
 	writeCatTable(&sb, tableBots, filteredValue, totalPnl, totalPnlPct, hasSharedWallet)
 
-	// Positions summary (#145, #162)
+	header := sb.String()
+
+	// Collect position lines.
 	totalOpenPos := 0
 	for _, bot := range tableBots {
 		totalOpenPos += bot.openPositions
 	}
-	if totalOpenPos == 0 {
-		sb.WriteString("Positions: no open positions\n")
-	} else {
-		sb.WriteString(fmt.Sprintf("Positions: %d open\n", totalOpenPos))
+	var posLines []string
+	if totalOpenPos > 0 {
 		for _, sc := range channelStrategies {
 			ss := state.Strategies[sc.ID]
 			if ss == nil {
 				continue
 			}
-			for _, line := range collectPositions(sc.ID, ss, prices) {
-				sb.WriteString(fmt.Sprintf("  • %s\n", line))
-			}
+			posLines = append(posLines, collectPositions(sc.ID, ss, prices)...)
 		}
 	}
 
-	// Trade details (always shown)
-	if len(tradeDetails) > 0 {
-		sb.WriteString("\n**Trades:**\n")
-		for _, td := range tradeDetails {
-			sb.WriteString(fmt.Sprintf("• %s\n", td))
-		}
+	// Collect trade detail lines.
+	var tradeLines []string
+	for _, td := range tradeDetails {
+		tradeLines = append(tradeLines, fmt.Sprintf("• %s", td))
 	}
 
-	return sb.String()
+	return splitCategorySummary(header, totalOpenPos, posLines, tradeLines)
+}
+
+// splitCategorySummary assembles the header, position lines, and trade lines into
+// one or more Discord messages, splitting at logical boundaries to stay under the
+// 2000-char Discord limit.
+func splitCategorySummary(header string, totalOpenPos int, posLines []string, tradeLines []string) []string {
+	var sb strings.Builder
+	sb.WriteString(header)
+
+	// Position header
+	if totalOpenPos == 0 {
+		sb.WriteString("Positions: no open positions\n")
+	} else {
+		sb.WriteString(fmt.Sprintf("Positions: %d open\n", totalOpenPos))
+	}
+
+	// Trade details section
+	var tradeSuffix string
+	if len(tradeLines) > 0 {
+		var tsb strings.Builder
+		tsb.WriteString("\n**Trades:**\n")
+		for _, tl := range tradeLines {
+			tsb.WriteString(tl + "\n")
+		}
+		tradeSuffix = tsb.String()
+	}
+
+	// If no positions, just append trades and return.
+	if totalOpenPos == 0 || len(posLines) == 0 {
+		sb.WriteString(tradeSuffix)
+		return []string{sb.String()}
+	}
+
+	// Try fitting everything in one message.
+	fullMsg := sb.String()
+	for _, line := range posLines {
+		fullMsg += fmt.Sprintf("  • %s\n", line)
+	}
+	fullMsg += tradeSuffix
+	if len(fullMsg) <= discordSplitThreshold {
+		return []string{fullMsg}
+	}
+
+	// Need to split: add positions until we approach the limit.
+	firstMsg := sb.String() // header + "Positions: N open\n"
+	included := 0
+	for _, line := range posLines {
+		candidate := fmt.Sprintf("  • %s\n", line)
+		// Reserve room for the "... and N more" indicator.
+		remaining := len(posLines) - included - 1
+		moreIndicator := ""
+		if remaining > 0 {
+			moreIndicator = fmt.Sprintf("  ... and %d more\n", remaining)
+		}
+		if len(firstMsg)+len(candidate)+len(moreIndicator) > discordSplitThreshold {
+			break
+		}
+		firstMsg += candidate
+		included++
+	}
+
+	if included < len(posLines) {
+		firstMsg += fmt.Sprintf("  ... and %d more\n", len(posLines)-included)
+	}
+
+	// If all positions fit (edge case where trades push us over), include trades in second message.
+	if included >= len(posLines) {
+		// Trades caused the overflow. Put all positions in first message, trades in second.
+		firstMsg = sb.String()
+		for _, line := range posLines {
+			firstMsg += fmt.Sprintf("  • %s\n", line)
+		}
+		if len(tradeSuffix) > 0 {
+			return []string{firstMsg, tradeSuffix}
+		}
+		return []string{firstMsg}
+	}
+
+	// Build continuation message(s) with remaining positions + trades.
+	var msgs []string
+	msgs = append(msgs, firstMsg)
+
+	contMsg := fmt.Sprintf("Positions (cont'd %d/%d):\n", included+1, len(posLines))
+	for _, line := range posLines[included:] {
+		candidate := fmt.Sprintf("  • %s\n", line)
+		if len(contMsg)+len(candidate) > discordSplitThreshold {
+			msgs = append(msgs, contMsg)
+			contMsg = fmt.Sprintf("Positions (cont'd):\n")
+		}
+		contMsg += candidate
+	}
+	contMsg += tradeSuffix
+	msgs = append(msgs, contMsg)
+
+	return msgs
 }
 
 type botInfo struct {
@@ -583,10 +682,18 @@ func collectPositions(stratID string, ss *StrategyState, prices map[string]float
 		if pnl < 0 {
 			sign = ""
 		}
-		lines = append(lines, fmt.Sprintf("%s %s %s x%g @ $%.2f (%s$%.0f)", stratID, pos.Side, sym, pos.Quantity, pos.AvgCost, sign, pnl))
+		dateStr := ""
+		if !pos.OpenedAt.IsZero() {
+			dateStr = fmt.Sprintf(" [%s]", pos.OpenedAt.Format("Jan 02 15:04"))
+		}
+		lines = append(lines, fmt.Sprintf("%s %s %s x%g @ $%.2f (%s$%.0f)%s", stratID, pos.Side, sym, pos.Quantity, pos.AvgCost, sign, pnl, dateStr))
 	}
 	for key, opt := range ss.OptionPositions {
-		lines = append(lines, fmt.Sprintf("%s OPT %s ($%.0f)", stratID, key, opt.CurrentValueUSD))
+		dateStr := ""
+		if !opt.OpenedAt.IsZero() {
+			dateStr = fmt.Sprintf(" [%s]", opt.OpenedAt.Format("Jan 02 15:04"))
+		}
+		lines = append(lines, fmt.Sprintf("%s OPT %s ($%.0f)%s", stratID, key, opt.CurrentValueUSD, dateStr))
 	}
 	return lines
 }

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestResolveChannel(t *testing.T) {
@@ -130,7 +132,8 @@ func TestFormatCategorySummary_WithAsset(t *testing.T) {
 	prices := map[string]float64{"BTC/USDT": 50000, "ETH/USDT": 3000}
 
 	// With asset — title should contain " — BTC" and only BTC price shown
-	msg := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC")
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC")
+	msg := strings.Join(msgs, "\n")
 	if !strings.Contains(msg, "— BTC") {
 		t.Errorf("expected '— BTC' in title, got:\n%s", msg)
 	}
@@ -139,7 +142,8 @@ func TestFormatCategorySummary_WithAsset(t *testing.T) {
 	}
 
 	// Without asset — no suffix in title
-	msg2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "")
+	msgs2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "")
+	msg2 := strings.Join(msgs2, "\n")
 	if strings.Contains(msg2, "— ") {
 		t.Errorf("expected no asset suffix when asset='', got:\n%s", msg2)
 	}
@@ -306,7 +310,8 @@ func TestFormatCategorySummary_SharedWallet(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msg := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH")
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH")
+	msg := strings.Join(msgs, "\n")
 
 	// Should contain Wallet% column
 	if !strings.Contains(msg, "Wallet%") {
@@ -361,7 +366,8 @@ func TestFormatCategorySummary_WalletPctFromConfig(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msg := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH")
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH")
+	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "30.0%") {
 		t.Errorf("expected '30.0%%' from capital_pct=0.3, got:\n%s", msg)
@@ -385,7 +391,8 @@ func TestFormatCategorySummary_NoSharedWallet(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msg := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH")
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH")
+	msg := strings.Join(msgs, "\n")
 
 	if strings.Contains(msg, "Wallet%") {
 		t.Errorf("should not show Wallet%% column without shared wallet, got:\n%s", msg)
@@ -393,5 +400,175 @@ func TestFormatCategorySummary_NoSharedWallet(t *testing.T) {
 	// Should still show Init column even without shared wallet
 	if !strings.Contains(msg, "Init") {
 		t.Errorf("expected 'Init' column header, got:\n%s", msg)
+	}
+}
+
+func TestFormatCategorySummary_MessageSplitting(t *testing.T) {
+	// Create enough positions to exceed Discord's 2000-char limit.
+	strats := make([]StrategyConfig, 20)
+	strategies := make(map[string]*StrategyState, 20)
+	for i := 0; i < 20; i++ {
+		id := fmt.Sprintf("hl-strat%02d-btc", i)
+		strats[i] = StrategyConfig{ID: id, Type: "perps", Platform: "hyperliquid", Capital: 500, Args: []string{fmt.Sprintf("strat%02d", i), "BTC", "1h"}}
+		strategies[id] = &StrategyState{
+			Cash: 450,
+			Positions: map[string]*Position{
+				"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.01, AvgCost: 50000, Side: "long", OpenedAt: time.Date(2026, 3, 15, 10, 30, 0, 0, time.UTC)},
+			},
+		}
+	}
+	state := &AppState{Strategies: strategies}
+	prices := map[string]float64{"BTC/USDT": 51000}
+
+	msgs := FormatCategorySummary(1, 0, 20, 0, 10000, prices, nil, strats, state, "hyperliquid", "BTC")
+
+	// Should produce multiple messages.
+	if len(msgs) < 2 {
+		totalLen := 0
+		for _, m := range msgs {
+			totalLen += len(m)
+		}
+		t.Errorf("expected multiple messages for 20 positions, got %d (total chars: %d)", len(msgs), totalLen)
+	}
+
+	// First message should contain "... and N more".
+	if !strings.Contains(msgs[0], "... and") {
+		t.Errorf("first message should contain '... and N more' indicator, got:\n%s", msgs[0])
+	}
+
+	// First message should not exceed the split threshold.
+	if len(msgs[0]) > discordCharLimit {
+		t.Errorf("first message exceeds %d chars: %d", discordCharLimit, len(msgs[0]))
+	}
+
+	// Second message should contain continuation header.
+	if !strings.Contains(msgs[1], "cont'd") {
+		t.Errorf("second message should contain continuation header, got:\n%s", msgs[1])
+	}
+
+	// All position lines should appear across all messages.
+	allMsgs := strings.Join(msgs, "\n")
+	if !strings.Contains(allMsgs, "Positions: 20 open") {
+		t.Errorf("expected 'Positions: 20 open' header, got:\n%s", allMsgs)
+	}
+}
+
+func TestFormatCategorySummary_NoSplitWhenShort(t *testing.T) {
+	// A small number of positions should produce a single message.
+	strats := []StrategyConfig{
+		{ID: "hl-rsi-btc", Type: "perps", Platform: "hyperliquid", Capital: 1000, Args: []string{"rsi", "BTC", "1h"}},
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-rsi-btc": {
+				Cash: 900,
+				Positions: map[string]*Position{
+					"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.01, AvgCost: 50000, Side: "long"},
+				},
+			},
+		},
+	}
+	prices := map[string]float64{"BTC/USDT": 51000}
+
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC")
+
+	if len(msgs) != 1 {
+		t.Errorf("expected single message for 1 position, got %d", len(msgs))
+	}
+	if !strings.Contains(msgs[0], "Positions: 1 open") {
+		t.Errorf("expected 'Positions: 1 open', got:\n%s", msgs[0])
+	}
+}
+
+func TestCollectPositions_WithTimestamp(t *testing.T) {
+	opened := time.Date(2026, 3, 15, 10, 30, 0, 0, time.UTC)
+	ss := &StrategyState{
+		Positions: map[string]*Position{
+			"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.5, AvgCost: 50000, Side: "long", OpenedAt: opened},
+		},
+	}
+	prices := map[string]float64{"BTC/USDT": 51000}
+
+	lines := collectPositions("hl-rsi-btc", ss, prices)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	if !strings.Contains(lines[0], "[Mar 15 10:30]") {
+		t.Errorf("expected timestamp '[Mar 15 10:30]', got: %s", lines[0])
+	}
+}
+
+func TestCollectPositions_WithoutTimestamp(t *testing.T) {
+	// Legacy positions without OpenedAt should not show a date.
+	ss := &StrategyState{
+		Positions: map[string]*Position{
+			"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.5, AvgCost: 50000, Side: "long"},
+		},
+	}
+	prices := map[string]float64{"BTC/USDT": 51000}
+
+	lines := collectPositions("hl-rsi-btc", ss, prices)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	if strings.Contains(lines[0], "[") {
+		t.Errorf("legacy position without OpenedAt should not show date, got: %s", lines[0])
+	}
+}
+
+func TestCollectPositions_OptionTimestamp(t *testing.T) {
+	opened := time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC)
+	ss := &StrategyState{
+		OptionPositions: map[string]*OptionPosition{
+			"BTC-call-50000": {ID: "BTC-call-50000", CurrentValueUSD: 500, OpenedAt: opened},
+		},
+	}
+	prices := map[string]float64{}
+
+	lines := collectPositions("deribit-wheel-btc", ss, prices)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	if !strings.Contains(lines[0], "[Apr 01 08:00]") {
+		t.Errorf("expected option timestamp '[Apr 01 08:00]', got: %s", lines[0])
+	}
+}
+
+func TestSplitCategorySummary_SingleMessage(t *testing.T) {
+	header := "Header line\n"
+	posLines := []string{"pos1", "pos2"}
+	tradeLines := []string{"• trade1"}
+
+	msgs := splitCategorySummary(header, 2, posLines, tradeLines)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if !strings.Contains(msgs[0], "pos1") || !strings.Contains(msgs[0], "pos2") {
+		t.Errorf("single message should contain all positions, got:\n%s", msgs[0])
+	}
+	if !strings.Contains(msgs[0], "trade1") {
+		t.Errorf("single message should contain trades, got:\n%s", msgs[0])
+	}
+}
+
+func TestSplitCategorySummary_MultiMessage(t *testing.T) {
+	// Create a header that uses ~1900 chars, leaving very little room for positions.
+	header := strings.Repeat("x", 1900) + "\n"
+	posLines := []string{"position-line-1-aaaa", "position-line-2-bbbb", "position-line-3-cccc"}
+
+	msgs := splitCategorySummary(header, 3, posLines, nil)
+	if len(msgs) < 2 {
+		t.Fatalf("expected multiple messages with large header, got %d", len(msgs))
+	}
+	// First message should have "... and N more"
+	if !strings.Contains(msgs[0], "... and") {
+		t.Errorf("expected '... and N more' in first message, got:\n%s", msgs[0][:100])
+	}
+	// All positions should appear across messages
+	all := strings.Join(msgs, "\n")
+	for _, pl := range posLines {
+		if !strings.Contains(all, pl) {
+			t.Errorf("position %q missing from messages", pl)
+		}
 	}
 }

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -750,8 +750,10 @@ func main() {
 					}
 					chDetails := channelTradeDetails[detailKey]
 					chValue := channelValue[chKey]
-					msg := FormatCategorySummary(cycle, elapsed, len(dueStrategies), chTrades, chValue, prices, chDetails, chStrats, state, chKey, "")
-					notifier.SendToChannel(chKey, chKey, msg)
+					msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), chTrades, chValue, prices, chDetails, chStrats, state, chKey, "")
+					for _, msg := range msgs {
+						notifier.SendToChannel(chKey, chKey, msg)
+					}
 				} else {
 					// Multiple assets → one message per asset.
 					for _, asset := range assetKeys {
@@ -764,8 +766,10 @@ func main() {
 							}
 						}
 						assetTrades := len(assetDetails)
-						msg := FormatCategorySummary(cycle, elapsed, len(dueStrategies), assetTrades, assetValue, prices, assetDetails, assetStrats, state, chKey, asset)
-						notifier.SendToChannel(chKey, chKey, msg)
+						msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), assetTrades, assetValue, prices, assetDetails, assetStrats, state, chKey, asset)
+						for _, msg := range msgs {
+							notifier.SendToChannel(chKey, chKey, msg)
+						}
 					}
 				}
 			}
@@ -921,9 +925,11 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, notifier
 	// Format and send summary using the same asset-grouping logic as the main loop.
 	assetGroups, assetKeys := groupByAsset(chStrats)
 	if len(assetKeys) <= 1 {
-		msg := FormatCategorySummary(state.CycleCount, 0, 0, 0, chValue, prices, nil, chStrats, state, channelKey, "")
-		notifier.SendToChannel(channelKey, channelKey, msg)
-		fmt.Println(msg)
+		msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, chValue, prices, nil, chStrats, state, channelKey, "")
+		for _, msg := range msgs {
+			notifier.SendToChannel(channelKey, channelKey, msg)
+			fmt.Println(msg)
+		}
 	} else {
 		for _, asset := range assetKeys {
 			assetStrats := assetGroups[asset]
@@ -933,9 +939,11 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, notifier
 					assetValue += PortfolioValue(s, prices)
 				}
 			}
-			msg := FormatCategorySummary(state.CycleCount, 0, 0, 0, assetValue, prices, nil, assetStrats, state, channelKey, asset)
-			notifier.SendToChannel(channelKey, channelKey, msg)
-			fmt.Println(msg)
+			msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, assetValue, prices, nil, assetStrats, state, channelKey, asset)
+			for _, msg := range msgs {
+				notifier.SendToChannel(channelKey, channelKey, msg)
+				fmt.Println(msg)
+			}
 		}
 	}
 

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -7,12 +7,13 @@ import (
 
 // Position represents a spot or futures position.
 type Position struct {
-	Symbol          string  `json:"symbol"`
-	Quantity        float64 `json:"quantity"`
-	AvgCost         float64 `json:"avg_cost"`
-	Side            string  `json:"side"`                        // "long" or "short"
-	Multiplier      float64 `json:"multiplier,omitempty"`        // futures contract multiplier (0 = spot)
-	OwnerStrategyID string  `json:"owner_strategy_id,omitempty"` // strategy that opened this position
+	Symbol          string    `json:"symbol"`
+	Quantity        float64   `json:"quantity"`
+	AvgCost         float64   `json:"avg_cost"`
+	Side            string    `json:"side"`                        // "long" or "short"
+	Multiplier      float64   `json:"multiplier,omitempty"`        // futures contract multiplier (0 = spot)
+	OwnerStrategyID string    `json:"owner_strategy_id,omitempty"` // strategy that opened this position
+	OpenedAt        time.Time `json:"opened_at,omitempty"`         // when the position was opened
 }
 
 // Trade represents a completed trade.
@@ -114,15 +115,17 @@ func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float6
 		tradeCost := qty * execPrice
 		fee := CalculatePlatformSpotFee(feePlatform, tradeCost)
 		s.Cash -= tradeCost + fee
+		now := time.Now().UTC()
 		s.Positions[symbol] = &Position{
 			Symbol:          symbol,
 			Quantity:        qty,
 			AvgCost:         execPrice,
 			Side:            "long",
 			OwnerStrategyID: s.ID,
+			OpenedAt:        now,
 		}
 		trade := Trade{
-			Timestamp:  time.Now().UTC(),
+			Timestamp:  now,
 			StrategyID: s.ID,
 			Symbol:     symbol,
 			Side:       "buy",
@@ -227,6 +230,7 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 		}
 		fee := CalculateFuturesFee(contracts, feePerContract)
 		s.Cash -= fee // futures use margin, not full notional; deduct fee only
+		now := time.Now().UTC()
 		s.Positions[symbol] = &Position{
 			Symbol:          symbol,
 			Quantity:        float64(contracts),
@@ -234,9 +238,10 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 			Side:            "long",
 			Multiplier:      multiplier,
 			OwnerStrategyID: s.ID,
+			OpenedAt:        now,
 		}
 		trade := Trade{
-			Timestamp:  time.Now().UTC(),
+			Timestamp:  now,
 			StrategyID: s.ID,
 			Symbol:     symbol,
 			Side:       "buy",
@@ -298,6 +303,7 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 			}
 			fee := CalculateFuturesFee(contracts, feePerContract)
 			s.Cash -= fee
+			now := time.Now().UTC()
 			s.Positions[symbol] = &Position{
 				Symbol:          symbol,
 				Quantity:        float64(contracts),
@@ -305,9 +311,10 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 				Side:            "short",
 				Multiplier:      multiplier,
 				OwnerStrategyID: s.ID,
+				OpenedAt:        now,
 			}
 			trade := Trade{
-				Timestamp:  time.Now().UTC(),
+				Timestamp:  now,
 				StrategyID: s.ID,
 				Symbol:     symbol,
 				Side:       "sell",


### PR DESCRIPTION
Closes #210

FormatCategorySummary now returns []string, splitting position lists across multiple messages when the content would exceed Discord's 2000-char limit. The first message shows as many positions as fit with a "... and N more" indicator; continuation messages carry the remaining positions.

Also adds OpenedAt timestamp to Position struct and displays the open date on each position line.

Generated with [Claude Code](https://claude.ai/code)