### PR TITLE
feat: add sweep_squeeze_combo strategy

### DIFF
--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -56,6 +56,7 @@ var knownShortNames = map[string]string{
 	"squeeze_momentum":      "sqm",
 	"heikin_ashi_ema":       "hae",
 	"range_scalper":         "rs",
+	"sweep_squeeze_combo":   "ssc",
 }
 
 // deriveShortName returns a short abbreviation for a strategy ID.

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -95,6 +95,7 @@ var defaultSpotStrategies = []stratDef{
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 	{ID: "parabolic_sar", ShortName: "psar"},
 	{ID: "range_scalper", ShortName: "rs"},
+	{ID: "sweep_squeeze_combo", ShortName: "ssc"},
 }
 
 var defaultOptionsStrategies = []stratDef{
@@ -110,6 +111,7 @@ var defaultPerpsStrategies = []stratDef{
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 	{ID: "delta_neutral_funding", ShortName: "dnf"},
 	{ID: "range_scalper", ShortName: "rs"},
+	{ID: "sweep_squeeze_combo", ShortName: "ssc"},
 }
 
 var defaultFuturesStrategies = []stratDef{
@@ -127,6 +129,7 @@ var defaultFuturesStrategies = []stratDef{
 	{ID: "parabolic_sar", ShortName: "psar"},
 	{ID: "delta_neutral_funding", ShortName: "dnf"},
 	{ID: "range_scalper", ShortName: "rs"},
+	{ID: "sweep_squeeze_combo", ShortName: "ssc"},
 }
 
 // Supported CME futures symbols for the init wizard.

--- a/shared_strategies/futures/strategies.py
+++ b/shared_strategies/futures/strategies.py
@@ -22,6 +22,7 @@ from amd_ifvg import amd_ifvg_core
 from chart_patterns import chart_pattern_core
 from liquidity_sweeps import liquidity_sweep_core
 from range_scalper import range_scalper_core
+from sweep_squeeze_combo import sweep_squeeze_combo_core
 
 # ─────────────────────────────────────────────
 # Strategy registry
@@ -613,6 +614,15 @@ def parabolic_sar_strategy(df: pd.DataFrame, iaf: float = 0.02, af_step: float =
 )
 def range_scalper_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
     return range_scalper_core(df, **params)
+
+
+@register_strategy(
+    "sweep_squeeze_combo",
+    "Sweep Squeeze Combo — 2-of-3 consensus (liquidity sweeps + squeeze momentum + stochastic RSI) for high-conviction reversals",
+    {"swing_lookback": 10, "min_agree": 2}
+)
+def sweep_squeeze_combo_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return sweep_squeeze_combo_core(df, **params)
 
 
 @register_strategy(

--- a/shared_strategies/spot/strategies.py
+++ b/shared_strategies/spot/strategies.py
@@ -16,6 +16,7 @@ from amd_ifvg import amd_ifvg_core
 from chart_patterns import chart_pattern_core
 from liquidity_sweeps import liquidity_sweep_core
 from range_scalper import range_scalper_core
+from sweep_squeeze_combo import sweep_squeeze_combo_core
 
 
 # ─────────────────────────────────────────────
@@ -747,6 +748,15 @@ def parabolic_sar_strategy(df: pd.DataFrame, iaf: float = 0.02, af_step: float =
 )
 def range_scalper_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
     return range_scalper_core(df, **params)
+
+
+@register_strategy(
+    "sweep_squeeze_combo",
+    "Sweep Squeeze Combo — 2-of-3 consensus (liquidity sweeps + squeeze momentum + stochastic RSI) for high-conviction reversals",
+    {"swing_lookback": 10, "min_agree": 2}
+)
+def sweep_squeeze_combo_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return sweep_squeeze_combo_core(df, **params)
 
 
 # Not registered in spot — funding rates are perps-only; check_strategy.py never injects params (#102).

--- a/shared_strategies/spot/test_strategies.py
+++ b/shared_strategies/spot/test_strategies.py
@@ -665,6 +665,7 @@ class TestEdgeCases:
         "mean_reversion", "momentum", "volume_weighted", "triple_ema",
         "rsi_macd_combo", "stoch_rsi", "atr_breakout",
         "heikin_ashi_ema", "amd_ifvg", "range_scalper",
+        "sweep_squeeze_combo",
     ])
     def test_single_row(self, name):
         """All strategies should handle a single-row DataFrame."""
@@ -672,3 +673,59 @@ class TestEdgeCases:
         result = apply_strategy(name, df)
         assert len(result) == 1
         assert "signal" in result.columns
+
+
+class TestSweepSqueezeCombo:
+    """Tests for sweep_squeeze_combo strategy."""
+
+    def test_registered(self):
+        assert "sweep_squeeze_combo" in STRATEGY_REGISTRY
+
+    def test_output_columns(self):
+        """Should produce signal + sub-signal diagnostic columns."""
+        df = make_ohlcv(make_trending_up(80))
+        result = apply_strategy("sweep_squeeze_combo", df)
+        for col in ["signal", "ls_signal", "sq_signal", "sr_signal", "buy_votes", "sell_votes"]:
+            assert col in result.columns, f"Missing column: {col}"
+
+    def test_no_signal_on_flat(self):
+        """Flat data should produce no consensus signals."""
+        df = make_ohlcv(make_flat(80))
+        result = apply_strategy("sweep_squeeze_combo", df)
+        assert (result["signal"] == 0).all()
+
+    def test_sweep_with_recovery_produces_buy(self):
+        """Simulate a liquidity sweep: wick below swing low, close above it."""
+        n = 80
+        # Downtrend to establish a swing low, then range, then sweep candle
+        prices = list(np.linspace(110, 95, 25))   # downtrend
+        prices += list(np.linspace(96, 105, 15))   # recovery (swing low at ~95)
+        prices += list(np.linspace(105, 100, 15))  # drift back down
+        # Sweep candle: close above swing low but wick below
+        prices += [96.0]  # close above 95 (swing low)
+        prices += list(np.linspace(98, 108, n - len(prices)))  # rally
+        df = make_ohlcv(prices, noise=0.3)
+        # Make the sweep candle (index 55) wick below the swing low
+        df.loc[df.index[55], "low"] = 93.0   # wick below 95 swing low
+        df.loc[df.index[55], "close"] = 96.0  # close above 95
+        result = apply_strategy("sweep_squeeze_combo", df, {"swing_lookback": 5})
+        # Liquidity sweep sub-signal should fire on the sweep candle
+        assert (result["ls_signal"] == 1).any(), \
+            "Expected liquidity sweep buy signal on sweep candle"
+
+    def test_short_data_no_crash(self):
+        """Should handle very short data without crashing."""
+        df = make_ohlcv([100.0, 101.0, 99.0])
+        result = apply_strategy("sweep_squeeze_combo", df)
+        assert "signal" in result.columns
+        assert len(result) == 3
+
+    def test_default_swing_lookback_is_10(self):
+        """Default params should have swing_lookback=10."""
+        defaults = STRATEGY_REGISTRY["sweep_squeeze_combo"]["default_params"]
+        assert defaults["swing_lookback"] == 10
+
+    def test_min_agree_default_is_2(self):
+        """Default params should require 2-of-3 agreement."""
+        defaults = STRATEGY_REGISTRY["sweep_squeeze_combo"]["default_params"]
+        assert defaults["min_agree"] == 2

--- a/shared_strategies/spot/test_strategies.py
+++ b/shared_strategies/spot/test_strategies.py
@@ -729,3 +729,69 @@ class TestSweepSqueezeCombo:
         """Default params should require 2-of-3 agreement."""
         defaults = STRATEGY_REGISTRY["sweep_squeeze_combo"]["default_params"]
         assert defaults["min_agree"] == 2
+
+    def test_consensus_signal_with_two_agreeing(self):
+        """Verify consensus signal fires when 2 of 3 sub-signals agree."""
+        from unittest.mock import patch
+
+        n = 50
+        df = make_ohlcv(make_flat(n))
+
+        # Fake sub-signals: liquidity sweep + stochastic RSI agree on buy at bar 25
+        fake_ls_df = df.copy()
+        fake_ls_df["signal"] = 0
+        fake_ls_df.iloc[25, fake_ls_df.columns.get_loc("signal")] = 1
+        fake_sq = pd.Series(0, index=df.index)
+        fake_sr = pd.Series(0, index=df.index)
+        fake_sr.iloc[25] = 1  # 2-of-3 agree on buy
+
+        with patch("sweep_squeeze_combo.liquidity_sweep_core", return_value=fake_ls_df), \
+             patch("sweep_squeeze_combo._squeeze_signals", return_value=fake_sq), \
+             patch("sweep_squeeze_combo._stoch_rsi_signals", return_value=fake_sr):
+            result = apply_strategy("sweep_squeeze_combo", df, {"min_agree": 2})
+
+        assert result.loc[result.index[25], "signal"] == 1, \
+            "Expected consensus buy signal=1 when 2 of 3 sub-signals agree"
+        assert result.loc[result.index[25], "buy_votes"] == 2
+
+    def test_consensus_sell_signal_with_two_agreeing(self):
+        """Verify consensus sell signal fires when 2 of 3 sub-signals agree."""
+        from unittest.mock import patch
+
+        n = 50
+        df = make_ohlcv(make_flat(n))
+
+        # Fake sub-signals: squeeze + stochastic RSI agree on sell at bar 30
+        fake_ls_df = df.copy()
+        fake_ls_df["signal"] = 0
+        fake_sq = pd.Series(0, index=df.index)
+        fake_sq.iloc[30] = -1
+        fake_sr = pd.Series(0, index=df.index)
+        fake_sr.iloc[30] = -1  # 2-of-3 agree on sell
+
+        with patch("sweep_squeeze_combo.liquidity_sweep_core", return_value=fake_ls_df), \
+             patch("sweep_squeeze_combo._squeeze_signals", return_value=fake_sq), \
+             patch("sweep_squeeze_combo._stoch_rsi_signals", return_value=fake_sr):
+            result = apply_strategy("sweep_squeeze_combo", df, {"min_agree": 2})
+
+        assert (result["signal"] == -1).any(), \
+            "Expected consensus sell signal=-1 when 2 of 3 sub-signals agree"
+        assert result.loc[result.index[30], "sell_votes"] == 2
+
+    def test_consensus_buy_signal_with_sweep(self):
+        """Consensus buy signal=1 fires when liquidity sweep sub-signal is counted."""
+        n = 80
+        prices = list(np.linspace(110, 95, 25))
+        prices += list(np.linspace(96, 105, 15))
+        prices += list(np.linspace(105, 100, 15))
+        prices += [96.0]
+        prices += list(np.linspace(98, 108, n - len(prices)))
+        df = make_ohlcv(prices, noise=0.3)
+        df.loc[df.index[55], "low"] = 93.0
+        df.loc[df.index[55], "close"] = 96.0
+        result = apply_strategy("sweep_squeeze_combo", df, {
+            "swing_lookback": 5,
+            "min_agree": 1,
+        })
+        assert (result["signal"] == 1).any(), \
+            "Expected consensus buy signal=1 with min_agree=1 and ls_signal firing"

--- a/shared_strategies/sweep_squeeze_combo.py
+++ b/shared_strategies/sweep_squeeze_combo.py
@@ -1,0 +1,171 @@
+"""
+Sweep Squeeze Combo — 2-of-3 consensus strategy.
+
+Combines liquidity sweeps, squeeze momentum, and stochastic RSI into a single
+strategy that fires only when at least 2 of 3 sub-signals agree on direction.
+
+Designed for 10-minute candles where liquidity sweeps catch stop hunts,
+squeeze momentum detects volatility breakouts, and stochastic RSI confirms
+oversold/overbought reversals.
+
+Buy:  2+ sub-strategies signal buy on the same candle
+Sell: 2+ sub-strategies signal sell on the same candle
+"""
+
+import numpy as np
+import pandas as pd
+
+from liquidity_sweeps import liquidity_sweep_core
+
+
+def _sma(series: pd.Series, period: int) -> pd.Series:
+    return series.rolling(window=period).mean()
+
+
+def _ema(series: pd.Series, period: int) -> pd.Series:
+    return series.ewm(span=period, adjust=False).mean()
+
+
+def _squeeze_signals(
+    df: pd.DataFrame,
+    bb_period: int = 20,
+    bb_std: float = 2.0,
+    kc_period: int = 20,
+    kc_mult: float = 1.5,
+    mom_lookback: int = 12,
+) -> pd.Series:
+    """Return squeeze momentum signal series: 1 (buy), -1 (sell), 0 (hold)."""
+    result = df.copy()
+    bb_mid = _sma(result["close"], bb_period)
+    bb_stddev = result["close"].rolling(window=bb_period).std()
+    bb_upper = bb_mid + (bb_std * bb_stddev)
+    bb_lower = bb_mid - (bb_std * bb_stddev)
+
+    kc_mid = _ema(result["close"], kc_period)
+    tr = pd.concat([
+        result["high"] - result["low"],
+        (result["high"] - result["close"].shift(1)).abs(),
+        (result["low"] - result["close"].shift(1)).abs(),
+    ], axis=1).max(axis=1)
+    atr = tr.rolling(window=kc_period).mean()
+    kc_upper = kc_mid + (kc_mult * atr)
+    kc_lower = kc_mid - (kc_mult * atr)
+
+    squeeze_on = (bb_lower > kc_lower) & (bb_upper < kc_upper)
+
+    highest_high = result["high"].rolling(window=kc_period).max()
+    lowest_low = result["low"].rolling(window=kc_period).min()
+    midline = ((highest_high + lowest_low) / 2 + bb_mid) / 2
+    delta = result["close"] - midline
+
+    x = np.arange(mom_lookback, dtype=float)
+    x_mean = x.mean()
+    x_var = ((x - x_mean) ** 2).sum()
+
+    def _linreg_last(window):
+        if len(window) < mom_lookback or np.isnan(window).any():
+            return np.nan
+        slope = ((x - x_mean) * (window - window.mean())).sum() / x_var
+        return slope * (mom_lookback - 1 - x_mean) + window.mean()
+
+    squeeze_mom = delta.rolling(window=mom_lookback).apply(_linreg_last, raw=True)
+
+    squeeze_fired = (~squeeze_on) & (squeeze_on.shift(1) == True)  # noqa: E712
+    mom_pos_rising = (squeeze_mom > 0) & (squeeze_mom > squeeze_mom.shift(1))
+    mom_neg_falling = (squeeze_mom < 0) & (squeeze_mom < squeeze_mom.shift(1))
+
+    signal = pd.Series(0, index=df.index)
+    signal.loc[squeeze_fired & mom_pos_rising] = 1
+    signal.loc[squeeze_fired & mom_neg_falling] = -1
+    return signal
+
+
+def _stoch_rsi_signals(
+    df: pd.DataFrame,
+    rsi_period: int = 14,
+    stoch_period: int = 14,
+    k_smooth: int = 3,
+    d_smooth: int = 3,
+    overbought: float = 80,
+    oversold: float = 20,
+) -> pd.Series:
+    """Return stochastic RSI signal series: 1 (buy), -1 (sell), 0 (hold)."""
+    close = df["close"]
+    delta = close.diff()
+    gain = delta.clip(lower=0)
+    loss = (-delta).clip(lower=0)
+    avg_gain = gain.ewm(alpha=1 / rsi_period, min_periods=rsi_period, adjust=False).mean()
+    avg_loss = loss.ewm(alpha=1 / rsi_period, min_periods=rsi_period, adjust=False).mean()
+    rs = avg_gain / avg_loss
+    rsi = 100 - (100 / (1 + rs))
+
+    rsi_min = rsi.rolling(window=stoch_period).min()
+    rsi_max = rsi.rolling(window=stoch_period).max()
+    stoch_rsi = (rsi - rsi_min) / (rsi_max - rsi_min) * 100
+    stoch_k = stoch_rsi.rolling(window=k_smooth).mean()
+    stoch_d = stoch_k.rolling(window=d_smooth).mean()
+
+    k_cross_up = (stoch_k > stoch_d) & (stoch_k.shift(1) <= stoch_d.shift(1))
+    k_cross_down = (stoch_k < stoch_d) & (stoch_k.shift(1) >= stoch_d.shift(1))
+
+    signal = pd.Series(0, index=df.index)
+    signal.loc[k_cross_up & (stoch_k < oversold)] = 1
+    signal.loc[k_cross_down & (stoch_k > overbought)] = -1
+    return signal
+
+
+def sweep_squeeze_combo_core(
+    df: pd.DataFrame,
+    swing_lookback: int = 10,
+    confirmation: int = 1,
+    bb_period: int = 20,
+    bb_std: float = 2.0,
+    kc_period: int = 20,
+    kc_mult: float = 1.5,
+    mom_lookback: int = 12,
+    rsi_period: int = 14,
+    stoch_period: int = 14,
+    k_smooth: int = 3,
+    d_smooth: int = 3,
+    overbought: float = 80,
+    oversold: float = 20,
+    min_agree: int = 2,
+) -> pd.DataFrame:
+    """
+    Consensus strategy: fires when at least `min_agree` of 3 sub-strategies
+    (liquidity sweeps, squeeze momentum, stochastic RSI) agree on direction.
+
+    Parameters
+    ----------
+    swing_lookback : lookback for liquidity sweep swing detection (default 10)
+    min_agree : minimum sub-signals that must agree (default 2)
+    Other params : forwarded to respective sub-strategies
+    """
+    result = df.copy()
+
+    # Sub-strategy 1: liquidity sweeps
+    ls_result = liquidity_sweep_core(df, swing_lookback=swing_lookback, confirmation=confirmation)
+    ls_signal = ls_result["signal"]
+
+    # Sub-strategy 2: squeeze momentum
+    sq_signal = _squeeze_signals(df, bb_period, bb_std, kc_period, kc_mult, mom_lookback)
+
+    # Sub-strategy 3: stochastic RSI
+    sr_signal = _stoch_rsi_signals(df, rsi_period, stoch_period, k_smooth, d_smooth, overbought, oversold)
+
+    # Count agreements
+    buy_votes = (ls_signal == 1).astype(int) + (sq_signal == 1).astype(int) + (sr_signal == 1).astype(int)
+    sell_votes = (ls_signal == -1).astype(int) + (sq_signal == -1).astype(int) + (sr_signal == -1).astype(int)
+
+    result["signal"] = 0
+    result.loc[buy_votes >= min_agree, "signal"] = 1
+    result.loc[sell_votes >= min_agree, "signal"] = -1
+
+    # Expose sub-signals as indicators for debugging
+    result["ls_signal"] = ls_signal.values
+    result["sq_signal"] = sq_signal.values
+    result["sr_signal"] = sr_signal.values
+    result["buy_votes"] = buy_votes.values
+    result["sell_votes"] = sell_votes.values
+
+    return result


### PR DESCRIPTION
## Summary

- Adds `sweep_squeeze_combo` strategy — a 2-of-3 consensus strategy combining liquidity sweeps, squeeze momentum, and stochastic RSI
- Fires only when at least 2 sub-strategies agree on direction, reducing false signals
- Default `swing_lookback=10` (tuned for 10-minute candles) and `min_agree=2`
- Exposes diagnostic columns (`ls_signal`, `sq_signal`, `sr_signal`, `buy_votes`, `sell_votes`) for debugging
- Registered in both spot and futures strategy registries with short name `ssc`

## Test plan

- [x] Python syntax check passes for all modified files
- [x] Go build passes
- [x] 7 new tests in `TestSweepSqueezeCombo` all pass
- [x] Full strategy test suite passes (245 passed, 5 pre-existing failures unrelated)
- [x] Go test suite passes
- [x] Strategy registers in `--list-json` output

---
Generated with: Claude Opus 4.6 | Effort: 85