### PR TITLE
fix: use actual exchange fill price/qty in live trade state updates

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1011,7 +1011,7 @@ func runSpotCheck(sc StrategyConfig, prices map[string]float64, logger *Strategy
 
 // executeSpotResult applies a spot signal to state. Must be called under Lock.
 func executeSpotResult(sc StrategyConfig, s *StrategyState, result *SpotResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
-	trades, err := ExecuteSpotSignal(s, result.Signal, result.Symbol, price, logger)
+	trades, err := ExecuteSpotSignal(s, result.Signal, result.Symbol, price, 0, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -1288,12 +1288,14 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 // execResult is non-nil for successful live orders; nil for paper mode.
 func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *HyperliquidResult, execResult *HyperliquidExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
 	fillPrice := price
+	var fillQty float64
 	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.AvgPx > 0 {
 		fillPrice = execResult.Execution.Fill.AvgPx
-		logger.Info("Live fill at $%.2f (mid was $%.2f)", fillPrice, price)
+		fillQty = execResult.Execution.Fill.TotalSz
+		logger.Info("Live fill at $%.2f qty=%.6f (mid was $%.2f)", fillPrice, fillQty, price)
 	}
 
-	trades, err := ExecuteSpotSignal(s, result.Signal, result.Symbol, fillPrice, logger)
+	trades, err := ExecuteSpotSignal(s, result.Signal, result.Symbol, fillPrice, fillQty, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -1440,9 +1442,11 @@ func runTopStepExecuteOrder(sc StrategyConfig, result *TopStepResult, price, cas
 // executeTopStepResult applies a TopStep futures result to state. Must be called under Lock.
 func executeTopStepResult(sc StrategyConfig, s *StrategyState, result *TopStepResult, execResult *TopStepExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
 	fillPrice := price
+	var fillContracts int
 	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.AvgPx > 0 {
 		fillPrice = execResult.Execution.Fill.AvgPx
-		logger.Info("Live fill at $%.2f (signal was $%.2f)", fillPrice, price)
+		fillContracts = execResult.Execution.Fill.TotalContracts
+		logger.Info("Live fill at $%.2f contracts=%d (signal was $%.2f)", fillPrice, fillContracts, price)
 	}
 
 	var feePerContract float64
@@ -1452,7 +1456,7 @@ func executeTopStepResult(sc StrategyConfig, s *StrategyState, result *TopStepRe
 		maxContracts = sc.FuturesConfig.MaxContracts
 	}
 
-	trades, err := ExecuteFuturesSignal(s, result.Signal, result.Symbol, fillPrice, result.ContractSpec, feePerContract, maxContracts, logger)
+	trades, err := ExecuteFuturesSignal(s, result.Signal, result.Symbol, fillPrice, result.ContractSpec, feePerContract, maxContracts, fillContracts, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -1582,12 +1586,14 @@ func runRobinhoodExecuteOrder(sc StrategyConfig, result *RobinhoodResult, price,
 // executeRobinhoodResult applies a Robinhood result to state. Must be called under Lock.
 func executeRobinhoodResult(sc StrategyConfig, s *StrategyState, result *RobinhoodResult, execResult *RobinhoodExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
 	fillPrice := price
+	var fillQty float64
 	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.AvgPx > 0 {
 		fillPrice = execResult.Execution.Fill.AvgPx
-		logger.Info("Live fill at $%.2f (mid was $%.2f)", fillPrice, price)
+		fillQty = execResult.Execution.Fill.Quantity
+		logger.Info("Live fill at $%.2f qty=%.6f (mid was $%.2f)", fillPrice, fillQty, price)
 	}
 
-	trades, err := ExecuteSpotSignal(s, result.Signal, result.Symbol, fillPrice, logger)
+	trades, err := ExecuteSpotSignal(s, result.Signal, result.Symbol, fillPrice, fillQty, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -1729,12 +1735,14 @@ func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQt
 // executeOKXResult applies an OKX result to state. Must be called under Lock.
 func executeOKXResult(sc StrategyConfig, s *StrategyState, result *OKXResult, execResult *OKXExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
 	fillPrice := price
+	var fillQty float64
 	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.AvgPx > 0 {
 		fillPrice = execResult.Execution.Fill.AvgPx
-		logger.Info("Live fill at $%.2f (mid was $%.2f)", fillPrice, price)
+		fillQty = execResult.Execution.Fill.TotalSz
+		logger.Info("Live fill at $%.2f qty=%.6f (mid was $%.2f)", fillPrice, fillQty, price)
 	}
 
-	trades, err := ExecuteSpotSignal(s, result.Signal, result.Symbol, fillPrice, logger)
+	trades, err := ExecuteSpotSignal(s, result.Signal, result.Symbol, fillPrice, fillQty, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -242,12 +242,12 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 		var execPrice float64
 		var contracts int
 		marginPerContract := spec.Margin
-		if marginPerContract <= 0 {
-			marginPerContract = price * multiplier // fallback if margin not set
-		}
 		if fillContracts > 0 {
 			execPrice = price
 			contracts = fillContracts
+			if marginPerContract <= 0 {
+				marginPerContract = price * multiplier
+			}
 		} else {
 			execPrice = ApplySlippage(price)
 			if marginPerContract <= 0 {
@@ -330,12 +330,12 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 			var execPrice float64
 			var contracts int
 			marginPerContract := spec.Margin
-			if marginPerContract <= 0 {
-				marginPerContract = price * multiplier
-			}
 			if fillContracts > 0 {
 				execPrice = price
 				contracts = fillContracts
+				if marginPerContract <= 0 {
+					marginPerContract = price * multiplier
+				}
 			} else {
 				execPrice = ApplySlippage(price)
 				if marginPerContract <= 0 {

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -58,8 +58,10 @@ func PortfolioValue(s *StrategyState, prices map[string]float64) float64 {
 	return total
 }
 
-// ExecuteSpotSignal processes a spot signal and executes paper trades.
-func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float64, logger *StrategyLogger) (int, error) {
+// ExecuteSpotSignal processes a spot signal and executes paper or live trades.
+// fillQty > 0 means a live fill: use price as-is (no slippage) and fillQty as position quantity for buys.
+// fillQty == 0 means paper mode: apply ApplySlippage and compute qty from state budget.
+func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float64, fillQty float64, logger *StrategyLogger) (int, error) {
 	if signal == 0 {
 		return 0, nil
 	}
@@ -77,7 +79,12 @@ func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float6
 		}
 		// Close short if exists
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "short" {
-			execPrice := ApplySlippage(price)
+			var execPrice float64
+			if fillQty > 0 {
+				execPrice = price
+			} else {
+				execPrice = ApplySlippage(price)
+			}
 			buyCost := pos.Quantity * execPrice
 			fee := CalculatePlatformSpotFee(feePlatform, buyCost)
 			totalCost := buyCost + fee
@@ -100,18 +107,23 @@ func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float6
 			logger.Info("Closed short %s @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, execPrice, fee, pnl)
 			tradesExecuted++
 		}
-		// Open long — use 95% of cash
+		// Open long — use 95% of cash (paper) or exact fill qty (live)
 		budget := s.Cash * 0.95
 		if budget < 1 {
 			logger.Info("Insufficient cash ($%.2f) to buy %s", s.Cash, symbol)
 			return tradesExecuted, nil
 		}
-		// Apply slippage
-		execPrice := ApplySlippage(price)
-		if execPrice <= 0 {
-			return tradesExecuted, nil
+		var execPrice, qty float64
+		if fillQty > 0 {
+			execPrice = price
+			qty = fillQty
+		} else {
+			execPrice = ApplySlippage(price)
+			if execPrice <= 0 {
+				return tradesExecuted, nil
+			}
+			qty = budget / execPrice
 		}
-		qty := budget / execPrice
 		tradeCost := qty * execPrice
 		fee := CalculatePlatformSpotFee(feePlatform, tradeCost)
 		s.Cash -= tradeCost + fee
@@ -142,7 +154,12 @@ func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float6
 	} else if signal == -1 { // Sell
 		// Close long if exists
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
-			execPrice := ApplySlippage(price)
+			var execPrice float64
+			if fillQty > 0 {
+				execPrice = price
+			} else {
+				execPrice = ApplySlippage(price)
+			}
 			saleValue := pos.Quantity * execPrice
 			fee := CalculatePlatformSpotFee(feePlatform, saleValue)
 			netProceeds := saleValue - fee
@@ -172,7 +189,9 @@ func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float6
 }
 
 // ExecuteFuturesSignal processes a futures signal with whole-contract sizing.
-func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price float64, spec ContractSpec, feePerContract float64, maxContracts int, logger *StrategyLogger) (int, error) {
+// fillContracts > 0 means a live fill: use price as-is (no slippage) and fillContracts as contract count for opens.
+// fillContracts == 0 means paper mode: apply ApplySlippage and compute contracts from state budget.
+func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price float64, spec ContractSpec, feePerContract float64, maxContracts int, fillContracts int, logger *StrategyLogger) (int, error) {
 	if signal == 0 {
 		return 0, nil
 	}
@@ -186,7 +205,12 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 		}
 		// Close short if exists
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "short" {
-			execPrice := ApplySlippage(price)
+			var execPrice float64
+			if fillContracts > 0 {
+				execPrice = price
+			} else {
+				execPrice = ApplySlippage(price)
+			}
 			contracts := int(pos.Quantity)
 			pnl := float64(contracts) * multiplier * (pos.AvgCost - execPrice)
 			fee := CalculateFuturesFee(contracts, feePerContract)
@@ -215,14 +239,24 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 			logger.Info("Insufficient cash ($%.2f) to buy %s futures", s.Cash, symbol)
 			return tradesExecuted, nil
 		}
-		execPrice := ApplySlippage(price)
+		var execPrice float64
+		var contracts int
 		marginPerContract := spec.Margin
 		if marginPerContract <= 0 {
-			marginPerContract = execPrice * multiplier // fallback if margin not set
+			marginPerContract = price * multiplier // fallback if margin not set
 		}
-		contracts := int(budget / marginPerContract)
-		if maxContracts > 0 && contracts > maxContracts {
-			contracts = maxContracts
+		if fillContracts > 0 {
+			execPrice = price
+			contracts = fillContracts
+		} else {
+			execPrice = ApplySlippage(price)
+			if marginPerContract <= 0 {
+				marginPerContract = execPrice * multiplier
+			}
+			contracts = int(budget / marginPerContract)
+			if maxContracts > 0 && contracts > maxContracts {
+				contracts = maxContracts
+			}
 		}
 		if contracts < 1 {
 			logger.Info("Insufficient cash ($%.2f) for even 1 %s contract (margin=$%.2f)", s.Cash, symbol, marginPerContract)
@@ -258,7 +292,12 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 	} else if signal == -1 { // Sell
 		// Close long if exists
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
-			execPrice := ApplySlippage(price)
+			var execPrice float64
+			if fillContracts > 0 {
+				execPrice = price
+			} else {
+				execPrice = ApplySlippage(price)
+			}
 			contracts := int(pos.Quantity)
 			pnl := float64(contracts) * multiplier * (execPrice - pos.AvgCost)
 			fee := CalculateFuturesFee(contracts, feePerContract)
@@ -288,14 +327,24 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 				logger.Info("Insufficient cash ($%.2f) to short %s futures", s.Cash, symbol)
 				return tradesExecuted, nil
 			}
-			execPrice := ApplySlippage(price)
+			var execPrice float64
+			var contracts int
 			marginPerContract := spec.Margin
 			if marginPerContract <= 0 {
-				marginPerContract = execPrice * multiplier
+				marginPerContract = price * multiplier
 			}
-			contracts := int(budget / marginPerContract)
-			if maxContracts > 0 && contracts > maxContracts {
-				contracts = maxContracts
+			if fillContracts > 0 {
+				execPrice = price
+				contracts = fillContracts
+			} else {
+				execPrice = ApplySlippage(price)
+				if marginPerContract <= 0 {
+					marginPerContract = execPrice * multiplier
+				}
+				contracts = int(budget / marginPerContract)
+				if maxContracts > 0 && contracts > maxContracts {
+					contracts = maxContracts
+				}
 			}
 			if contracts < 1 {
 				logger.Info("Insufficient cash ($%.2f) for even 1 %s short contract (margin=$%.2f)", s.Cash, symbol, marginPerContract)

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -112,7 +112,7 @@ func TestExecuteSpotSignalHold(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, err := ExecuteSpotSignal(s, 0, "BTC/USDT", 60000, logger)
+	trades, err := ExecuteSpotSignal(s, 0, "BTC/USDT", 60000, 0, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func TestExecuteSpotSignalBuy(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, err := ExecuteSpotSignal(s, 1, "BTC/USDT", 50000, logger)
+	trades, err := ExecuteSpotSignal(s, 1, "BTC/USDT", 50000, 0, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +182,7 @@ func TestExecuteSpotSignalSell(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, err := ExecuteSpotSignal(s, -1, "BTC/USDT", 55000, logger)
+	trades, err := ExecuteSpotSignal(s, -1, "BTC/USDT", 55000, 0, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +222,7 @@ func TestExecuteSpotSignalBuyAlreadyLong(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, _ := ExecuteSpotSignal(s, 1, "BTC/USDT", 60000, logger)
+	trades, _ := ExecuteSpotSignal(s, 1, "BTC/USDT", 60000, 0, logger)
 	if trades != 0 {
 		t.Error("should not buy when already long")
 	}
@@ -240,7 +240,7 @@ func TestExecuteSpotSignalSellNoPosition(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, _ := ExecuteSpotSignal(s, -1, "BTC/USDT", 60000, logger)
+	trades, _ := ExecuteSpotSignal(s, -1, "BTC/USDT", 60000, 0, logger)
 	if trades != 0 {
 		t.Error("should not sell when no position")
 	}
@@ -258,7 +258,7 @@ func TestExecuteSpotSignalInsufficientCash(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, _ := ExecuteSpotSignal(s, 1, "BTC/USDT", 60000, logger)
+	trades, _ := ExecuteSpotSignal(s, 1, "BTC/USDT", 60000, 0, logger)
 	if trades != 0 {
 		t.Error("should not buy with insufficient cash")
 	}
@@ -276,7 +276,7 @@ func TestExecuteSpotSignalOKXPerpsFee(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	_, err := ExecuteSpotSignal(s, 1, "BTC", 50000.0, logger)
+	_, err := ExecuteSpotSignal(s, 1, "BTC", 50000.0, 0, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -315,7 +315,7 @@ func TestExecuteFuturesSignalBuy(t *testing.T) {
 	defer logger.Close()
 
 	spec := ContractSpec{TickSize: 0.25, TickValue: 12.5, Multiplier: 50, Margin: 500}
-	trades, err := ExecuteFuturesSignal(s, 1, "ES", 5000, spec, 2.5, 5, logger)
+	trades, err := ExecuteFuturesSignal(s, 1, "ES", 5000, spec, 2.5, 5, 0, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,7 +347,7 @@ func TestExecuteFuturesSignalHold(t *testing.T) {
 	defer logger.Close()
 
 	spec := ContractSpec{Multiplier: 50, Margin: 500}
-	trades, _ := ExecuteFuturesSignal(s, 0, "ES", 5000, spec, 2.5, 5, logger)
+	trades, _ := ExecuteFuturesSignal(s, 0, "ES", 5000, spec, 2.5, 5, 0, logger)
 	if trades != 0 {
 		t.Error("should not trade on hold signal")
 	}
@@ -367,7 +367,7 @@ func TestExecuteSpotSignalSetsOwnerStrategyID(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	_, err := ExecuteSpotSignal(s, 1, "BTC", 50000, logger)
+	_, err := ExecuteSpotSignal(s, 1, "BTC", 50000, 0, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -396,7 +396,7 @@ func TestExecuteFuturesSignalSetsOwnerStrategyID(t *testing.T) {
 	defer logger.Close()
 
 	spec := ContractSpec{TickSize: 0.25, TickValue: 12.5, Multiplier: 50, Margin: 500}
-	_, err := ExecuteFuturesSignal(s, 1, "ES", 5000, spec, 2.5, 5, logger)
+	_, err := ExecuteFuturesSignal(s, 1, "ES", 5000, spec, 2.5, 5, 0, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -425,7 +425,7 @@ func TestExecuteFuturesSignalShortSetsOwnerStrategyID(t *testing.T) {
 	defer logger.Close()
 
 	spec := ContractSpec{TickSize: 0.25, TickValue: 12.5, Multiplier: 50, Margin: 500}
-	_, err := ExecuteFuturesSignal(s, -1, "ES", 5000, spec, 2.5, 5, logger)
+	_, err := ExecuteFuturesSignal(s, -1, "ES", 5000, spec, 2.5, 5, 0, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -439,5 +439,85 @@ func TestExecuteFuturesSignalShortSetsOwnerStrategyID(t *testing.T) {
 	}
 	if pos.OwnerStrategyID != "ts-trend-es" {
 		t.Errorf("OwnerStrategyID = %q, want %q", pos.OwnerStrategyID, "ts-trend-es")
+	}
+}
+
+func TestExecuteSpotSignalLiveFill(t *testing.T) {
+	s := &StrategyState{
+		ID:              "hl-momentum-btc",
+		Cash:            1000,
+		Platform:        "hyperliquid",
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	// Live fill: exchange filled 0.015 BTC at exact price 50000
+	fillQty := 0.015
+	fillPrice := 50000.0
+	trades, err := ExecuteSpotSignal(s, 1, "BTC", fillPrice, fillQty, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trades != 1 {
+		t.Errorf("trades = %d, want 1", trades)
+	}
+
+	pos := s.Positions["BTC"]
+	if pos == nil {
+		t.Fatal("should have BTC position")
+	}
+	// Quantity must be exactly the fill qty — no slippage distortion
+	if math.Abs(pos.Quantity-fillQty) > 1e-9 {
+		t.Errorf("Quantity = %.9f, want %.9f (exact fill qty)", pos.Quantity, fillQty)
+	}
+	// AvgCost must be exactly the fill price — no slippage
+	if math.Abs(pos.AvgCost-fillPrice) > 1e-6 {
+		t.Errorf("AvgCost = %.6f, want %.6f (exact fill price)", pos.AvgCost, fillPrice)
+	}
+}
+
+func TestExecuteFuturesSignalLiveFill(t *testing.T) {
+	s := &StrategyState{
+		ID:              "ts-momentum-es",
+		Cash:            10000,
+		Platform:        "topstep",
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	spec := ContractSpec{TickSize: 0.25, TickValue: 12.5, Multiplier: 50, Margin: 500}
+	fillContracts := 2
+	fillPrice := 5000.0
+	trades, err := ExecuteFuturesSignal(s, 1, "ES", fillPrice, spec, 2.5, 5, fillContracts, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trades != 1 {
+		t.Errorf("trades = %d, want 1", trades)
+	}
+
+	pos := s.Positions["ES"]
+	if pos == nil {
+		t.Fatal("should have ES position")
+	}
+	// Contract count must be exactly the fill contracts — no slippage distortion
+	if int(pos.Quantity) != fillContracts {
+		t.Errorf("Quantity = %g, want %d (exact fill contracts)", pos.Quantity, fillContracts)
+	}
+	// AvgCost must be exactly the fill price — no slippage
+	if math.Abs(pos.AvgCost-fillPrice) > 1e-6 {
+		t.Errorf("AvgCost = %.6f, want %.6f (exact fill price)", pos.AvgCost, fillPrice)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `fillQty float64` parameter to `ExecuteSpotSignal` and `fillContracts int` to `ExecuteFuturesSignal`
- When `> 0` (live mode): use exact exchange fill price/qty, no simulated slippage applied
- When `== 0` (paper mode): existing `ApplySlippage` + budget-based sizing behavior unchanged
- All four live platforms (Hyperliquid, TopStep, Robinhood, OKX) now pass actual fill data from exchange responses

Fixes the state drift caused by applying `ApplySlippage` on top of already-accurate exchange fill prices, and by computing buy quantity from state cash rather than using the exchange-reported fill size.

## Test plan

- [ ] All existing unit tests pass (`go test ./...`)
- [ ] `TestExecuteSpotSignalLiveFill`: verifies `fillQty=0.015` stored as exact position qty, `fillPrice=50000` as exact avg cost
- [ ] `TestExecuteFuturesSignalLiveFill`: verifies `fillContracts=2` stored as exact contract count, fill price as exact avg cost
- [ ] Paper-mode tests unchanged — slippage still applied when `fillQty/fillContracts == 0`

Closes #215

---
Generated with: Claude Sonnet 4.6 | Effort: 45