### PR TITLE
feat: Donchian Channel Breakout strategy

### DIFF
--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -57,6 +57,7 @@ var knownShortNames = map[string]string{
 	"heikin_ashi_ema":       "hae",
 	"range_scalper":         "rs",
 	"sweep_squeeze_combo":   "ssc",
+	"donchian_breakout":     "dbo",
 }
 
 // deriveShortName returns a short abbreviation for a strategy ID.
@@ -96,6 +97,7 @@ var defaultSpotStrategies = []stratDef{
 	{ID: "parabolic_sar", ShortName: "psar"},
 	{ID: "range_scalper", ShortName: "rs"},
 	{ID: "sweep_squeeze_combo", ShortName: "ssc"},
+	{ID: "donchian_breakout", ShortName: "dbo"},
 }
 
 var defaultOptionsStrategies = []stratDef{
@@ -112,6 +114,7 @@ var defaultPerpsStrategies = []stratDef{
 	{ID: "delta_neutral_funding", ShortName: "dnf"},
 	{ID: "range_scalper", ShortName: "rs"},
 	{ID: "sweep_squeeze_combo", ShortName: "ssc"},
+	{ID: "donchian_breakout", ShortName: "dbo"},
 }
 
 var defaultFuturesStrategies = []stratDef{
@@ -130,6 +133,7 @@ var defaultFuturesStrategies = []stratDef{
 	{ID: "delta_neutral_funding", ShortName: "dnf"},
 	{ID: "range_scalper", ShortName: "rs"},
 	{ID: "sweep_squeeze_combo", ShortName: "ssc"},
+	{ID: "donchian_breakout", ShortName: "dbo"},
 }
 
 // Supported CME futures symbols for the init wizard.

--- a/shared_strategies/donchian_breakout.py
+++ b/shared_strategies/donchian_breakout.py
@@ -27,14 +27,17 @@ def donchian_breakout_core(
     ----------
     df : DataFrame with open, high, low, close columns
     entry_period : lookback for upper/lower channel (highest high / lowest low)
-    exit_period : tighter channel for exits (columns exposed, not used for signals)
+    exit_period : tighter channel for exits (columns exposed for downstream use,
+                  not used for signal generation)
 
     Returns
     -------
     DataFrame with added columns:
-        signal         : 1 (buy), -1 (sell), 0 (hold)
-        donchian_upper : upper channel (shifted to avoid lookahead)
-        donchian_lower : lower channel (shifted to avoid lookahead)
+        signal              : 1 (buy), -1 (sell), 0 (hold)
+        donchian_upper      : entry upper channel (shifted to avoid lookahead)
+        donchian_lower      : entry lower channel (shifted to avoid lookahead)
+        donchian_exit_upper : exit upper channel (shifted to avoid lookahead)
+        donchian_exit_lower : exit lower channel (shifted to avoid lookahead)
     """
     result = df.copy()
     result["signal"] = 0
@@ -42,11 +45,17 @@ def donchian_breakout_core(
     if len(result) < entry_period + 1:
         result["donchian_upper"] = np.nan
         result["donchian_lower"] = np.nan
+        result["donchian_exit_upper"] = np.nan
+        result["donchian_exit_lower"] = np.nan
         return result
 
     # Shift by 1 so the channel at bar i is computed from bars [i-entry_period, i-1]
     result["donchian_upper"] = result["high"].rolling(window=entry_period).max().shift(1)
     result["donchian_lower"] = result["low"].rolling(window=entry_period).min().shift(1)
+
+    # Exit channel (tighter, exposed for downstream use)
+    result["donchian_exit_upper"] = result["high"].rolling(window=exit_period).max().shift(1)
+    result["donchian_exit_lower"] = result["low"].rolling(window=exit_period).min().shift(1)
 
     close = result["close"]
     upper = result["donchian_upper"]

--- a/shared_strategies/donchian_breakout.py
+++ b/shared_strategies/donchian_breakout.py
@@ -1,0 +1,67 @@
+"""
+Donchian Channel Breakout — turtle-trading-inspired trend-following strategy.
+
+The Donchian Channel is defined by the highest high and lowest low over a
+lookback period.  A breakout occurs when the close crosses above the upper
+channel (buy) or below the lower channel (sell).  Only the *crossover* bar
+fires a signal — staying above/below the channel does not repeat the signal.
+
+Default parameters follow the classic Turtle system: 20-bar entry channel
+and 10-bar exit channel (the exit channel is exposed for downstream use but
+the core signal generation uses only the entry channel).
+"""
+
+import numpy as np
+import pandas as pd
+
+
+def donchian_breakout_core(
+    df: pd.DataFrame,
+    entry_period: int = 20,
+    exit_period: int = 10,
+) -> pd.DataFrame:
+    """
+    Generate Donchian Channel breakout signals.
+
+    Parameters
+    ----------
+    df : DataFrame with open, high, low, close columns
+    entry_period : lookback for upper/lower channel (highest high / lowest low)
+    exit_period : tighter channel for exits (columns exposed, not used for signals)
+
+    Returns
+    -------
+    DataFrame with added columns:
+        signal         : 1 (buy), -1 (sell), 0 (hold)
+        donchian_upper : upper channel (shifted to avoid lookahead)
+        donchian_lower : lower channel (shifted to avoid lookahead)
+    """
+    result = df.copy()
+    result["signal"] = 0
+
+    if len(result) < entry_period + 1:
+        result["donchian_upper"] = np.nan
+        result["donchian_lower"] = np.nan
+        return result
+
+    # Shift by 1 so the channel at bar i is computed from bars [i-entry_period, i-1]
+    result["donchian_upper"] = result["high"].rolling(window=entry_period).max().shift(1)
+    result["donchian_lower"] = result["low"].rolling(window=entry_period).min().shift(1)
+
+    close = result["close"]
+    upper = result["donchian_upper"]
+    lower = result["donchian_lower"]
+
+    prev_close = close.shift(1)
+    prev_upper = upper.shift(1)
+    prev_lower = lower.shift(1)
+
+    # BUY crossover: close breaks above upper channel
+    buy_mask = (close > upper) & (prev_close <= prev_upper)
+    # SELL crossover: close breaks below lower channel
+    sell_mask = (close < lower) & (prev_close >= prev_lower)
+
+    result.loc[buy_mask, "signal"] = 1
+    result.loc[sell_mask, "signal"] = -1
+
+    return result

--- a/shared_strategies/futures/strategies.py
+++ b/shared_strategies/futures/strategies.py
@@ -23,6 +23,7 @@ from chart_patterns import chart_pattern_core
 from liquidity_sweeps import liquidity_sweep_core
 from range_scalper import range_scalper_core
 from sweep_squeeze_combo import sweep_squeeze_combo_core
+from donchian_breakout import donchian_breakout_core
 
 # ─────────────────────────────────────────────
 # Strategy registry
@@ -653,6 +654,15 @@ def delta_neutral_funding_strategy(df: pd.DataFrame,
     elif avg < exit_threshold:
         result.iloc[-1, result.columns.get_loc("signal")] = 1   # exit short
     return result
+
+
+@register_strategy(
+    "donchian_breakout",
+    "Donchian Channel Breakout — turtle-trading style entry on new high/low channel breakouts",
+    {"entry_period": 20, "exit_period": 10}
+)
+def donchian_breakout_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return donchian_breakout_core(df, **params)
 
 
 if __name__ == "__main__":

--- a/shared_strategies/spot/strategies.py
+++ b/shared_strategies/spot/strategies.py
@@ -17,6 +17,7 @@ from chart_patterns import chart_pattern_core
 from liquidity_sweeps import liquidity_sweep_core
 from range_scalper import range_scalper_core
 from sweep_squeeze_combo import sweep_squeeze_combo_core
+from donchian_breakout import donchian_breakout_core
 
 
 # ─────────────────────────────────────────────
@@ -782,6 +783,15 @@ def delta_neutral_funding_strategy(df: pd.DataFrame,
     elif avg < exit_threshold:
         result.iloc[-1, result.columns.get_loc("signal")] = 1   # exit short
     return result
+
+
+@register_strategy(
+    "donchian_breakout",
+    "Donchian Channel Breakout — turtle-trading style entry on new high/low channel breakouts",
+    {"entry_period": 20, "exit_period": 10}
+)
+def donchian_breakout_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return donchian_breakout_core(df, **params)
 
 
 if __name__ == "__main__":

--- a/shared_strategies/test_donchian_breakout.py
+++ b/shared_strategies/test_donchian_breakout.py
@@ -59,6 +59,7 @@ def test_short_data_no_crash():
     result = donchian_breakout_core(df)
     assert "signal" in result.columns
     assert len(result) == 5
+    assert (result["signal"] == 0).all(), "Short data should produce no signals"
 
 
 def test_signal_values_valid():
@@ -91,8 +92,11 @@ def test_no_lookahead_bias():
 
 
 def test_channels_exposed():
-    """Output should include donchian_upper and donchian_lower columns."""
+    """Output should include donchian_upper, donchian_lower, and exit channel columns."""
     df = make_ohlcv([100] * 30)
     result = donchian_breakout_core(df)
     assert "donchian_upper" in result.columns
     assert "donchian_lower" in result.columns
+    assert "donchian_exit_upper" in result.columns
+    assert "donchian_exit_lower" in result.columns
+    assert (result["signal"] == 0).all(), "Flat data should produce no breakout signals"

--- a/shared_strategies/test_donchian_breakout.py
+++ b/shared_strategies/test_donchian_breakout.py
@@ -1,0 +1,98 @@
+"""Tests for donchian_breakout.py — Donchian Channel Breakout strategy."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from donchian_breakout import donchian_breakout_core
+
+
+# ─── Helpers ────────────────────────────────
+
+def make_ohlcv(closes, volume=None, noise=0.5):
+    """Build an OHLCV DataFrame from a close price array."""
+    closes = np.array(closes, dtype=float)
+    n = len(closes)
+    if volume is None:
+        volume = np.full(n, 100.0)
+    highs = closes + noise
+    lows = closes - noise
+    opens = closes - noise * 0.3
+    return pd.DataFrame({
+        "open": opens,
+        "high": highs,
+        "low": lows,
+        "close": closes,
+        "volume": np.array(volume, dtype=float),
+    })
+
+
+# ─── Tests ──────────────────────────────────
+
+def test_breakout_above_channel_generates_buy():
+    """Range-bound data then breakout upward should produce a buy signal."""
+    prices = [100] * 30 + list(np.linspace(100, 120, 20))
+    df = make_ohlcv(prices)
+    result = donchian_breakout_core(df)
+    assert (result["signal"] == 1).any(), "Expected at least one buy signal on upward breakout"
+
+
+def test_breakdown_below_channel_generates_sell():
+    """Range-bound data then breakdown downward should produce a sell signal."""
+    prices = [100] * 30 + list(np.linspace(100, 80, 20))
+    df = make_ohlcv(prices)
+    result = donchian_breakout_core(df)
+    assert (result["signal"] == -1).any(), "Expected at least one sell signal on downward breakdown"
+
+
+def test_flat_market_no_signals():
+    """Flat data with no noise should produce no signals."""
+    prices = [100.0] * 50
+    df = make_ohlcv(prices, noise=0)
+    result = donchian_breakout_core(df)
+    assert (result["signal"] == 0).all(), "Flat market should produce no breakout signals"
+
+
+def test_short_data_no_crash():
+    """Very short data should return a signal column without crashing."""
+    df = make_ohlcv([100, 101, 102, 103, 104])
+    result = donchian_breakout_core(df)
+    assert "signal" in result.columns
+    assert len(result) == 5
+
+
+def test_signal_values_valid():
+    """All signal values should be in {-1, 0, 1}."""
+    prices = list(np.linspace(80, 120, 30)) + list(np.linspace(120, 80, 30))
+    df = make_ohlcv(prices)
+    result = donchian_breakout_core(df)
+    assert set(result["signal"].unique()).issubset({-1, 0, 1})
+
+
+def test_no_lookahead_bias():
+    """Channel at bar i must be based on bars before i, not including i.
+
+    With 25 bars of flat data at 100 followed by a breakout candle at 110,
+    the breakout candle (index 25) should fire a buy signal because it breaks
+    above the channel computed from the prior 20 bars (all at 100).
+    """
+    prices = [100] * 25 + [110]
+    df = make_ohlcv(prices)
+    result = donchian_breakout_core(df)
+    # The channel upper at index 25 is max(high[5:25]) shifted by 1 = 100 + noise = 100.5
+    # Close at index 25 is 110 > 100.5, so signal should be 1
+    assert result["signal"].iloc[25] == 1, (
+        "Breakout candle should fire buy signal (channel based on prior bars)"
+    )
+    # Bars in the flat region should NOT have signals
+    assert (result["signal"].iloc[:25] == 0).all(), (
+        "No signals expected in the flat region before breakout"
+    )
+
+
+def test_channels_exposed():
+    """Output should include donchian_upper and donchian_lower columns."""
+    df = make_ohlcv([100] * 30)
+    result = donchian_breakout_core(df)
+    assert "donchian_upper" in result.columns
+    assert "donchian_lower" in result.columns


### PR DESCRIPTION
## Summary
- Add Donchian Channel Breakout strategy -- a turtle-trading-inspired trend-following strategy that enters on new high/low channel breakouts, designed for catching sustained trends
- Upper channel = rolling max of high, lower channel = rolling min of low over configurable `entry_period` (default 20 bars), shifted to avoid lookahead bias
- BUY on close crossing above upper channel, SELL on close crossing below lower channel (crossover only, not sustained)
- Registered in both spot and futures strategy registries with short name `dbo`
- Added to `knownShortNames` and all default strategy fallback lists in `init.go`
- Includes 7 pytest tests covering buy/sell signals, flat markets, short data, valid signal values, no-lookahead-bias verification, and channel column exposure

## Test plan
- [x] `python3 -m py_compile` passes for all modified/new Python files
- [x] `go build` passes in scheduler/
- [x] `go test ./...` passes in scheduler/
- [x] All 7 pytest tests pass for `test_donchian_breakout.py`

---
Generated with: Claude Opus 4.6 | Effort: auto