### PR TITLE
feat: ADX Trend Rider strategy

### DIFF
--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -57,6 +57,7 @@ var knownShortNames = map[string]string{
 	"heikin_ashi_ema":       "hae",
 	"range_scalper":         "rs",
 	"sweep_squeeze_combo":   "ssc",
+	"adx_trend":             "adxt",
 }
 
 // deriveShortName returns a short abbreviation for a strategy ID.
@@ -96,6 +97,7 @@ var defaultSpotStrategies = []stratDef{
 	{ID: "parabolic_sar", ShortName: "psar"},
 	{ID: "range_scalper", ShortName: "rs"},
 	{ID: "sweep_squeeze_combo", ShortName: "ssc"},
+	{ID: "adx_trend", ShortName: "adxt"},
 }
 
 var defaultOptionsStrategies = []stratDef{
@@ -112,6 +114,7 @@ var defaultPerpsStrategies = []stratDef{
 	{ID: "delta_neutral_funding", ShortName: "dnf"},
 	{ID: "range_scalper", ShortName: "rs"},
 	{ID: "sweep_squeeze_combo", ShortName: "ssc"},
+	{ID: "adx_trend", ShortName: "adxt"},
 }
 
 var defaultFuturesStrategies = []stratDef{
@@ -130,6 +133,7 @@ var defaultFuturesStrategies = []stratDef{
 	{ID: "delta_neutral_funding", ShortName: "dnf"},
 	{ID: "range_scalper", ShortName: "rs"},
 	{ID: "sweep_squeeze_combo", ShortName: "ssc"},
+	{ID: "adx_trend", ShortName: "adxt"},
 }
 
 // Supported CME futures symbols for the init wizard.

--- a/shared_strategies/adx_trend.py
+++ b/shared_strategies/adx_trend.py
@@ -1,0 +1,130 @@
+"""
+ADX Trend Rider — core strategy logic.
+
+Uses the Average Directional Index (ADX) to measure trend strength and
++DI/-DI crossovers for directional entry signals.
+
+Entry BUY:  ADX > threshold AND +DI crosses above -DI
+Entry SELL: ADX > threshold AND -DI crosses above +DI
+No signal:  ADX below threshold (weak/no trend)
+
+ADX and directional indicators are computed using Wilder's smoothing method.
+"""
+
+import numpy as np
+import pandas as pd
+
+
+def adx_trend_core(
+    df: pd.DataFrame,
+    adx_period: int = 14,
+    adx_threshold: float = 25.0,
+) -> pd.DataFrame:
+    """
+    Detect trend-following signals via ADX + DI crossovers.
+
+    Parameters
+    ----------
+    df : DataFrame with open, high, low, close columns
+    adx_period : lookback period for ADX / DI calculation (Wilder's smoothing)
+    adx_threshold : minimum ADX value to confirm a strong trend
+
+    Returns
+    -------
+    DataFrame with added 'signal' column: 1 (buy), -1 (sell), 0 (hold)
+    """
+    result = df.copy()
+    result["signal"] = 0
+
+    n = len(result)
+    if n < adx_period * 2 + 1:
+        return result
+
+    high = result["high"].values
+    low = result["low"].values
+    close = result["close"].values
+    period = adx_period
+
+    # --- True Range, +DM, -DM ---
+    tr = np.zeros(n)
+    plus_dm = np.zeros(n)
+    minus_dm = np.zeros(n)
+
+    for i in range(1, n):
+        h_l = high[i] - low[i]
+        h_pc = abs(high[i] - close[i - 1])
+        l_pc = abs(low[i] - close[i - 1])
+        tr[i] = max(h_l, h_pc, l_pc)
+
+        up_move = high[i] - high[i - 1]
+        down_move = low[i - 1] - low[i]
+
+        if up_move > down_move and up_move > 0:
+            plus_dm[i] = up_move
+        else:
+            plus_dm[i] = 0.0
+
+        if down_move > up_move and down_move > 0:
+            minus_dm[i] = down_move
+        else:
+            minus_dm[i] = 0.0
+
+    # --- Wilder's smoothing for TR, +DM, -DM ---
+    smooth_tr = np.zeros(n)
+    smooth_plus_dm = np.zeros(n)
+    smooth_minus_dm = np.zeros(n)
+
+    # First smoothed value = sum of first `period` values (starting from index 1)
+    smooth_tr[period] = np.sum(tr[1 : period + 1])
+    smooth_plus_dm[period] = np.sum(plus_dm[1 : period + 1])
+    smooth_minus_dm[period] = np.sum(minus_dm[1 : period + 1])
+
+    for i in range(period + 1, n):
+        smooth_tr[i] = smooth_tr[i - 1] - smooth_tr[i - 1] / period + tr[i]
+        smooth_plus_dm[i] = smooth_plus_dm[i - 1] - smooth_plus_dm[i - 1] / period + plus_dm[i]
+        smooth_minus_dm[i] = smooth_minus_dm[i - 1] - smooth_minus_dm[i - 1] / period + minus_dm[i]
+
+    # --- +DI, -DI ---
+    plus_di = np.zeros(n)
+    minus_di = np.zeros(n)
+
+    for i in range(period, n):
+        if smooth_tr[i] != 0:
+            plus_di[i] = 100.0 * smooth_plus_dm[i] / smooth_tr[i]
+            minus_di[i] = 100.0 * smooth_minus_dm[i] / smooth_tr[i]
+
+    # --- DX ---
+    dx = np.zeros(n)
+    for i in range(period, n):
+        di_sum = plus_di[i] + minus_di[i]
+        if di_sum != 0:
+            dx[i] = 100.0 * abs(plus_di[i] - minus_di[i]) / di_sum
+
+    # --- ADX (Wilder's smooth of DX) ---
+    adx = np.zeros(n)
+    # First ADX = average of first `period` DX values (starting at index `period`)
+    adx_start = period * 2
+    if adx_start >= n:
+        return result
+
+    adx[adx_start] = np.mean(dx[period : adx_start + 1])
+
+    for i in range(adx_start + 1, n):
+        adx[i] = (adx[i - 1] * (period - 1) + dx[i]) / period
+
+    # --- Crossover signals ---
+    sig_col = result.columns.get_loc("signal")
+    for i in range(adx_start + 1, n):
+        if adx[i] <= adx_threshold:
+            continue
+
+        # +DI crosses above -DI
+        prev_bull = plus_di[i - 1] > minus_di[i - 1]
+        curr_bull = plus_di[i] > minus_di[i]
+
+        if curr_bull and not prev_bull:
+            result.iloc[i, sig_col] = 1
+        elif not curr_bull and prev_bull:
+            result.iloc[i, sig_col] = -1
+
+    return result

--- a/shared_strategies/adx_trend.py
+++ b/shared_strategies/adx_trend.py
@@ -107,6 +107,10 @@ def adx_trend_core(
     if adx_start >= n:
         return result
 
+    adx_start = period * 2 - 1
+    if adx_start >= n:
+        return result
+
     adx[adx_start] = np.mean(dx[period : adx_start + 1])
 
     for i in range(adx_start + 1, n):

--- a/shared_strategies/futures/strategies.py
+++ b/shared_strategies/futures/strategies.py
@@ -23,6 +23,7 @@ from chart_patterns import chart_pattern_core
 from liquidity_sweeps import liquidity_sweep_core
 from range_scalper import range_scalper_core
 from sweep_squeeze_combo import sweep_squeeze_combo_core
+from adx_trend import adx_trend_core
 
 # ─────────────────────────────────────────────
 # Strategy registry
@@ -623,6 +624,15 @@ def range_scalper_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
 )
 def sweep_squeeze_combo_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
     return sweep_squeeze_combo_core(df, **params)
+
+
+@register_strategy(
+    "adx_trend",
+    "ADX Trend Rider — enters on DI crossovers when ADX confirms strong trend (>25)",
+    {"adx_period": 14, "adx_threshold": 25}
+)
+def adx_trend_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return adx_trend_core(df, **params)
 
 
 @register_strategy(

--- a/shared_strategies/spot/strategies.py
+++ b/shared_strategies/spot/strategies.py
@@ -17,6 +17,7 @@ from chart_patterns import chart_pattern_core
 from liquidity_sweeps import liquidity_sweep_core
 from range_scalper import range_scalper_core
 from sweep_squeeze_combo import sweep_squeeze_combo_core
+from adx_trend import adx_trend_core
 
 
 # ─────────────────────────────────────────────
@@ -757,6 +758,15 @@ def range_scalper_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
 )
 def sweep_squeeze_combo_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
     return sweep_squeeze_combo_core(df, **params)
+
+
+@register_strategy(
+    "adx_trend",
+    "ADX Trend Rider — enters on DI crossovers when ADX confirms strong trend (>25)",
+    {"adx_period": 14, "adx_threshold": 25}
+)
+def adx_trend_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return adx_trend_core(df, **params)
 
 
 # Not registered in spot — funding rates are perps-only; check_strategy.py never injects params (#102).

--- a/shared_strategies/test_adx_trend.py
+++ b/shared_strategies/test_adx_trend.py
@@ -1,0 +1,82 @@
+"""Tests for adx_trend.py — ADX Trend Rider strategy."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from adx_trend import adx_trend_core
+
+
+# ─── Helpers ────────────────────────────────
+
+def make_ohlcv(closes, volume=None, noise=0.5):
+    """Build an OHLCV DataFrame from a close price array."""
+    closes = np.array(closes, dtype=float)
+    n = len(closes)
+    if volume is None:
+        volume = np.full(n, 100.0)
+    highs = closes + noise
+    lows = closes - noise
+    opens = closes - noise * 0.3
+    return pd.DataFrame({
+        "open": opens,
+        "high": highs,
+        "low": lows,
+        "close": closes,
+        "volume": np.array(volume, dtype=float),
+    })
+
+
+# ─── Tests ──────────────────────────────────
+
+def test_strong_uptrend_generates_buy():
+    """A downtrend followed by a strong uptrend should produce a buy on the DI crossover."""
+    # Start with a downtrend so -DI dominates, then reverse into uptrend for +DI crossover
+    prices = list(np.linspace(150, 100, 50)) + list(np.linspace(100, 200, 100))
+    df = make_ohlcv(prices, noise=1.0)
+    result = adx_trend_core(df)
+    assert (result["signal"] == 1).any(), "Expected at least one buy signal on DI crossover into uptrend"
+
+
+def test_strong_downtrend_generates_sell():
+    """An uptrend followed by a strong downtrend should produce a sell on the DI crossover."""
+    # Start with an uptrend so +DI dominates, then reverse into downtrend for -DI crossover
+    prices = list(np.linspace(100, 200, 50)) + list(np.linspace(200, 100, 100))
+    df = make_ohlcv(prices, noise=1.0)
+    result = adx_trend_core(df)
+    assert (result["signal"] == -1).any(), "Expected at least one sell signal on DI crossover into downtrend"
+
+
+def test_flat_market_no_signals():
+    """Flat data with minimal noise should produce no signals (ADX stays low)."""
+    prices = [100.0] * 100
+    df = make_ohlcv(prices, noise=0.1)
+    result = adx_trend_core(df)
+    assert (result["signal"] == 0).all(), "Expected no signals in flat market"
+
+
+def test_short_data_no_crash():
+    """Very short data should return signal column with all zeros, no crash."""
+    prices = [100, 101, 102, 101, 100]
+    df = make_ohlcv(prices)
+    result = adx_trend_core(df)
+    assert "signal" in result.columns
+    assert (result["signal"] == 0).all()
+    assert len(result) == 5
+
+
+def test_signal_values_valid():
+    """All signal values must be in {-1, 0, 1}."""
+    prices = list(np.linspace(100, 150, 50)) + list(np.linspace(150, 90, 50))
+    df = make_ohlcv(prices)
+    result = adx_trend_core(df)
+    assert set(result["signal"].unique()).issubset({-1, 0, 1})
+
+
+def test_crossover_with_weak_adx_no_signal():
+    """Choppy sideways data: DI crossovers may happen but ADX stays low -> no signals."""
+    # Alternating up/down creates crossovers but weak trend
+    prices = [100, 102, 100, 102, 100, 102, 100, 102] * 25
+    df = make_ohlcv(prices, noise=0.1)
+    result = adx_trend_core(df)
+    assert (result["signal"] == 0).all(), "Expected no signals when ADX is weak despite DI crossovers"


### PR DESCRIPTION
## Summary
- Add ADX Trend Rider strategy that catches sustained trends by measuring trend strength via ADX and entering on +DI/-DI crossovers only when ADX confirms a strong trend (>25)
- Core logic in `shared_strategies/adx_trend.py` using Wilder's smoothing for ADX/DI computation
- Registered in both spot and futures strategy registries with short name `adxt`

## Changes
- `shared_strategies/adx_trend.py` — core strategy logic with Wilder's smoothing
- `shared_strategies/spot/strategies.py` — import + `@register_strategy` registration
- `shared_strategies/futures/strategies.py` — import + `@register_strategy` registration
- `scheduler/init.go` — `knownShortNames` + default fallback lists (spot, perps, futures)
- `shared_strategies/test_adx_trend.py` — 6 tests covering uptrend buy, downtrend sell, flat market, short data, valid signals, weak ADX filtering

## Test plan
- [x] `python3 -m py_compile` passes for all modified Python files
- [x] `go build` passes in scheduler/
- [x] `go test ./...` passes in scheduler/
- [x] All 6 pytest tests pass for test_adx_trend.py

---
Generated with: Claude Opus 4.6 | Effort: auto