### PR TITLE
feat: persist Hyperliquid exchange transaction IDs with each trade

### DIFF
--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -82,7 +82,9 @@ CREATE TABLE IF NOT EXISTS trades (
     price REAL NOT NULL,
     value REAL NOT NULL,
     trade_type TEXT NOT NULL DEFAULT '',
-    details TEXT NOT NULL DEFAULT ''
+    details TEXT NOT NULL DEFAULT '',
+    exchange_order_id TEXT NOT NULL DEFAULT '',
+    exchange_fee REAL NOT NULL DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS idx_trades_strategy ON trades(strategy_id);
@@ -146,7 +148,32 @@ func OpenStateDB(path string) (*StateDB, error) {
 		db.Close()
 		return nil, fmt.Errorf("create schema: %w", err)
 	}
-	return &StateDB{db: db}, nil
+
+	sdb := &StateDB{db: db}
+	if err := sdb.migrateSchema(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migrate schema: %w", err)
+	}
+	return sdb, nil
+}
+
+// migrateSchema adds columns that may be missing from older databases.
+func (sdb *StateDB) migrateSchema() error {
+	// Add exchange_order_id and exchange_fee to trades table (added in #219).
+	migrations := []string{
+		"ALTER TABLE trades ADD COLUMN exchange_order_id TEXT NOT NULL DEFAULT ''",
+		"ALTER TABLE trades ADD COLUMN exchange_fee REAL NOT NULL DEFAULT 0",
+	}
+	for _, ddl := range migrations {
+		if _, err := sdb.db.Exec(ddl); err != nil {
+			// "duplicate column name" means the column already exists — skip.
+			if strings.Contains(err.Error(), "duplicate column") {
+				continue
+			}
+			return err
+		}
+	}
+	return nil
 }
 
 // Close closes the database connection.
@@ -241,8 +268,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 
 	// 4. Append-only trades: find the latest timestamp per strategy already in DB,
 	//    insert only newer trades.
-	stmtTrade, err := tx.Prepare(`INSERT INTO trades (strategy_id, timestamp, symbol, side, quantity, price, value, trade_type, details)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtTrade, err := tx.Prepare(`INSERT INTO trades (strategy_id, timestamp, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare trade insert: %w", err)
 	}
@@ -260,7 +287,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		for _, t := range s.TradeHistory {
 			ts := formatTime(t.Timestamp)
 			if ts > latestTS {
-				if _, err := stmtTrade.Exec(s.ID, ts, t.Symbol, t.Side, t.Quantity, t.Price, t.Value, t.TradeType, t.Details); err != nil {
+				if _, err := stmtTrade.Exec(s.ID, ts, t.Symbol, t.Side, t.Quantity, t.Price, t.Value, t.TradeType, t.Details, t.ExchangeOrderID, t.ExchangeFee); err != nil {
 					return fmt.Errorf("insert trade for %s: %w", s.ID, err)
 				}
 			}
@@ -428,7 +455,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 
 	// 5. Load most recent 1000 trades per strategy (full history stays in SQLite).
 	for id, s := range state.Strategies {
-		tradeRows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, side, quantity, price, value, trade_type, details
+		tradeRows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee
 			FROM trades WHERE strategy_id = ? ORDER BY timestamp ASC`, id)
 		if err != nil {
 			return nil, fmt.Errorf("load trades for %s: %w", id, err)
@@ -437,7 +464,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		for tradeRows.Next() {
 			var t Trade
 			var tsStr string
-			if err := tradeRows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details); err != nil {
+			if err := tradeRows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee); err != nil {
 				tradeRows.Close()
 				return nil, fmt.Errorf("scan trade: %w", err)
 			}
@@ -546,7 +573,7 @@ func (sdb *StateDB) QueryTradeHistory(strategyID, symbol string, since, until ti
 		limit = 500
 	}
 
-	query := fmt.Sprintf("SELECT timestamp, strategy_id, symbol, side, quantity, price, value, trade_type, details FROM trades %s ORDER BY timestamp DESC LIMIT ? OFFSET ?", whereClause)
+	query := fmt.Sprintf("SELECT timestamp, strategy_id, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee FROM trades %s ORDER BY timestamp DESC LIMIT ? OFFSET ?", whereClause)
 	queryArgs := append(args, limit, offset)
 	rows, err := sdb.db.Query(query, queryArgs...)
 	if err != nil {
@@ -558,7 +585,7 @@ func (sdb *StateDB) QueryTradeHistory(strategyID, symbol string, since, until ti
 	for rows.Next() {
 		var t Trade
 		var tsStr string
-		if err := rows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details); err != nil {
+		if err := rows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee); err != nil {
 			return nil, 0, fmt.Errorf("scan trade: %w", err)
 		}
 		t.Timestamp = parseTime(tsStr)

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"database/sql"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	_ "modernc.org/sqlite"
 )
 
 func openTestDB(t *testing.T) *StateDB {
@@ -675,5 +678,306 @@ func TestSaveState_EmptyStrategies(t *testing.T) {
 	}
 	if len(loaded.Strategies) != 0 {
 		t.Errorf("strategies count = %d, want 0", len(loaded.Strategies))
+	}
+}
+
+func TestTradeExchangeFieldsRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+	now := time.Now().UTC().Truncate(time.Nanosecond)
+
+	state := &AppState{
+		CycleCount: 1,
+		Strategies: map[string]*StrategyState{
+			"hl-test": {
+				ID: "hl-test", Type: "perps", Platform: "hyperliquid",
+				Cash: 1000, InitialCapital: 1000,
+				Positions: make(map[string]*Position), OptionPositions: make(map[string]*OptionPosition),
+				TradeHistory: []Trade{
+					{
+						Timestamp: now.Add(-1 * time.Hour), StrategyID: "hl-test", Symbol: "BTC",
+						Side: "buy", Quantity: 0.1, Price: 50000, Value: 5000, TradeType: "perps",
+						Details: "live buy", ExchangeOrderID: "1234567890", ExchangeFee: 1.75,
+					},
+					{
+						Timestamp: now, StrategyID: "hl-test", Symbol: "BTC",
+						Side: "sell", Quantity: 0.1, Price: 51000, Value: 5100, TradeType: "perps",
+						Details: "live sell", ExchangeOrderID: "1234567891", ExchangeFee: 1.79,
+					},
+				},
+			},
+		},
+	}
+
+	if err := db.SaveState(state); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+
+	hlStrat := loaded.Strategies["hl-test"]
+	if hlStrat == nil {
+		t.Fatal("missing strategy hl-test")
+	}
+	if len(hlStrat.TradeHistory) != 2 {
+		t.Fatalf("trade count = %d, want 2", len(hlStrat.TradeHistory))
+	}
+
+	// Verify exchange fields persisted on first trade.
+	t1 := hlStrat.TradeHistory[0]
+	if t1.ExchangeOrderID != "1234567890" {
+		t.Errorf("trade[0].ExchangeOrderID = %q, want %q", t1.ExchangeOrderID, "1234567890")
+	}
+	if t1.ExchangeFee != 1.75 {
+		t.Errorf("trade[0].ExchangeFee = %g, want 1.75", t1.ExchangeFee)
+	}
+
+	// Verify exchange fields persisted on second trade.
+	t2 := hlStrat.TradeHistory[1]
+	if t2.ExchangeOrderID != "1234567891" {
+		t.Errorf("trade[1].ExchangeOrderID = %q, want %q", t2.ExchangeOrderID, "1234567891")
+	}
+	if t2.ExchangeFee != 1.79 {
+		t.Errorf("trade[1].ExchangeFee = %g, want 1.79", t2.ExchangeFee)
+	}
+}
+
+func TestTradeExchangeFields_EmptyByDefault(t *testing.T) {
+	db := openTestDB(t)
+	now := time.Now().UTC().Truncate(time.Nanosecond)
+
+	// Trades without exchange fields should default to empty/zero.
+	state := &AppState{
+		CycleCount: 1,
+		Strategies: map[string]*StrategyState{
+			"spot-test": {
+				ID: "spot-test", Type: "spot", Platform: "binanceus",
+				Cash: 1000, InitialCapital: 1000,
+				Positions: make(map[string]*Position), OptionPositions: make(map[string]*OptionPosition),
+				TradeHistory: []Trade{
+					{Timestamp: now, StrategyID: "spot-test", Symbol: "BTC/USDT", Side: "buy",
+						Quantity: 0.01, Price: 50000, Value: 500, TradeType: "spot", Details: "paper trade"},
+				},
+			},
+		},
+	}
+
+	if err := db.SaveState(state); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+
+	tr := loaded.Strategies["spot-test"].TradeHistory[0]
+	if tr.ExchangeOrderID != "" {
+		t.Errorf("ExchangeOrderID should be empty for paper trade, got %q", tr.ExchangeOrderID)
+	}
+	if tr.ExchangeFee != 0 {
+		t.Errorf("ExchangeFee should be 0 for paper trade, got %g", tr.ExchangeFee)
+	}
+}
+
+func TestQueryTradeHistory_ExchangeFields(t *testing.T) {
+	db := openTestDB(t)
+	now := time.Now().UTC().Truncate(time.Nanosecond)
+
+	state := &AppState{
+		CycleCount: 1,
+		Strategies: map[string]*StrategyState{
+			"hl-test": {
+				ID: "hl-test", Type: "perps", Platform: "hyperliquid",
+				Cash: 1000, InitialCapital: 1000,
+				Positions: make(map[string]*Position), OptionPositions: make(map[string]*OptionPosition),
+				TradeHistory: []Trade{
+					{Timestamp: now, StrategyID: "hl-test", Symbol: "BTC", Side: "buy",
+						Quantity: 0.1, Price: 50000, Value: 5000, TradeType: "perps",
+						Details: "live", ExchangeOrderID: "9876543210", ExchangeFee: 2.50},
+				},
+			},
+		},
+	}
+
+	if err := db.SaveState(state); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	trades, total, err := db.QueryTradeHistory("hl-test", "", time.Time{}, time.Time{}, 50, 0)
+	if err != nil {
+		t.Fatalf("QueryTradeHistory: %v", err)
+	}
+	if total != 1 {
+		t.Fatalf("total = %d, want 1", total)
+	}
+	if trades[0].ExchangeOrderID != "9876543210" {
+		t.Errorf("ExchangeOrderID = %q, want %q", trades[0].ExchangeOrderID, "9876543210")
+	}
+	if trades[0].ExchangeFee != 2.50 {
+		t.Errorf("ExchangeFee = %g, want 2.50", trades[0].ExchangeFee)
+	}
+}
+
+func TestMigrateSchema_AddsExchangeColumns(t *testing.T) {
+	// Create a DB with the old schema (no exchange columns), then verify migration adds them.
+	path := filepath.Join(t.TempDir(), "state.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	// Create old-schema trades table without exchange columns.
+	oldSchema := `
+	CREATE TABLE IF NOT EXISTS app_state (
+	    id INTEGER PRIMARY KEY CHECK (id = 1),
+	    cycle_count INTEGER NOT NULL DEFAULT 0,
+	    last_cycle TEXT NOT NULL DEFAULT '',
+	    last_top10_summary TEXT NOT NULL DEFAULT '',
+	    last_leaderboard_post_date TEXT NOT NULL DEFAULT ''
+	);
+	CREATE TABLE IF NOT EXISTS strategies (
+	    id TEXT PRIMARY KEY,
+	    type TEXT NOT NULL,
+	    platform TEXT NOT NULL DEFAULT '',
+	    cash REAL NOT NULL DEFAULT 0,
+	    initial_capital REAL NOT NULL DEFAULT 0,
+	    risk_peak_value REAL NOT NULL DEFAULT 0,
+	    risk_max_drawdown_pct REAL NOT NULL DEFAULT 0,
+	    risk_current_drawdown_pct REAL NOT NULL DEFAULT 0,
+	    risk_daily_pnl REAL NOT NULL DEFAULT 0,
+	    risk_daily_pnl_date TEXT NOT NULL DEFAULT '',
+	    risk_consecutive_losses INTEGER NOT NULL DEFAULT 0,
+	    risk_circuit_breaker INTEGER NOT NULL DEFAULT 0,
+	    risk_circuit_breaker_until TEXT NOT NULL DEFAULT '',
+	    risk_total_trades INTEGER NOT NULL DEFAULT 0,
+	    risk_winning_trades INTEGER NOT NULL DEFAULT 0,
+	    risk_losing_trades INTEGER NOT NULL DEFAULT 0
+	);
+	CREATE TABLE IF NOT EXISTS positions (
+	    strategy_id TEXT NOT NULL REFERENCES strategies(id) ON DELETE CASCADE,
+	    symbol TEXT NOT NULL,
+	    quantity REAL NOT NULL,
+	    avg_cost REAL NOT NULL,
+	    side TEXT NOT NULL,
+	    multiplier REAL NOT NULL DEFAULT 0,
+	    owner_strategy_id TEXT NOT NULL DEFAULT '',
+	    PRIMARY KEY (strategy_id, symbol)
+	);
+	CREATE TABLE IF NOT EXISTS option_positions (
+	    strategy_id TEXT NOT NULL, id TEXT NOT NULL, underlying TEXT NOT NULL,
+	    option_type TEXT NOT NULL, strike REAL NOT NULL, expiry TEXT NOT NULL,
+	    dte REAL NOT NULL DEFAULT 0, action TEXT NOT NULL, quantity REAL NOT NULL,
+	    entry_premium REAL NOT NULL DEFAULT 0, entry_premium_usd REAL NOT NULL DEFAULT 0,
+	    current_value_usd REAL NOT NULL DEFAULT 0, delta REAL NOT NULL DEFAULT 0,
+	    gamma REAL NOT NULL DEFAULT 0, theta REAL NOT NULL DEFAULT 0,
+	    vega REAL NOT NULL DEFAULT 0, opened_at TEXT NOT NULL DEFAULT '',
+	    PRIMARY KEY (strategy_id, id)
+	);
+	CREATE TABLE IF NOT EXISTS trades (
+	    rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+	    strategy_id TEXT NOT NULL,
+	    timestamp TEXT NOT NULL,
+	    symbol TEXT NOT NULL,
+	    side TEXT NOT NULL,
+	    quantity REAL NOT NULL,
+	    price REAL NOT NULL,
+	    value REAL NOT NULL,
+	    trade_type TEXT NOT NULL DEFAULT '',
+	    details TEXT NOT NULL DEFAULT ''
+	);
+	CREATE TABLE IF NOT EXISTS portfolio_risk (
+	    id INTEGER PRIMARY KEY CHECK (id = 1),
+	    peak_value REAL NOT NULL DEFAULT 0,
+	    current_drawdown_pct REAL NOT NULL DEFAULT 0,
+	    kill_switch_active INTEGER NOT NULL DEFAULT 0,
+	    kill_switch_at TEXT NOT NULL DEFAULT '',
+	    warning_sent INTEGER NOT NULL DEFAULT 0
+	);
+	CREATE TABLE IF NOT EXISTS kill_switch_events (
+	    rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+	    timestamp TEXT NOT NULL,
+	    type TEXT NOT NULL,
+	    drawdown_pct REAL NOT NULL DEFAULT 0,
+	    portfolio_value REAL NOT NULL DEFAULT 0,
+	    peak_value REAL NOT NULL DEFAULT 0,
+	    details TEXT NOT NULL DEFAULT ''
+	);
+	CREATE TABLE IF NOT EXISTS correlation_snapshot (
+	    id INTEGER PRIMARY KEY CHECK (id = 1),
+	    snapshot_json TEXT NOT NULL DEFAULT '{}'
+	);`
+
+	if _, err := db.Exec(oldSchema); err != nil {
+		t.Fatalf("create old schema: %v", err)
+	}
+
+	// Insert a trade without exchange columns.
+	if _, err := db.Exec(`INSERT INTO app_state (id, cycle_count) VALUES (1, 1)`); err != nil {
+		t.Fatalf("insert app_state: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO strategies (id, type) VALUES ('test', 'perps')`); err != nil {
+		t.Fatalf("insert strategy: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO trades (strategy_id, timestamp, symbol, side, quantity, price, value, trade_type, details)
+		VALUES ('test', '2026-01-01T00:00:00Z', 'BTC', 'buy', 0.1, 50000, 5000, 'perps', 'old trade')`); err != nil {
+		t.Fatalf("insert old trade: %v", err)
+	}
+	db.Close()
+
+	// Re-open via OpenStateDB which runs migration.
+	sdb, err := OpenStateDB(path)
+	if err != nil {
+		t.Fatalf("OpenStateDB after migration: %v", err)
+	}
+	defer sdb.Close()
+
+	// Verify old trade can be loaded with new columns defaulting to empty/zero.
+	loaded, err := sdb.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState after migration: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("loaded state is nil")
+	}
+	strat := loaded.Strategies["test"]
+	if strat == nil {
+		t.Fatal("missing strategy 'test'")
+	}
+	if len(strat.TradeHistory) != 1 {
+		t.Fatalf("trade count = %d, want 1", len(strat.TradeHistory))
+	}
+	tr := strat.TradeHistory[0]
+	if tr.ExchangeOrderID != "" {
+		t.Errorf("migrated trade ExchangeOrderID = %q, want empty", tr.ExchangeOrderID)
+	}
+	if tr.ExchangeFee != 0 {
+		t.Errorf("migrated trade ExchangeFee = %g, want 0", tr.ExchangeFee)
+	}
+
+	// Verify new trades with exchange fields can be saved and loaded.
+	strat.TradeHistory = append(strat.TradeHistory, Trade{
+		Timestamp: time.Now().UTC(), StrategyID: "test", Symbol: "BTC", Side: "sell",
+		Quantity: 0.1, Price: 51000, Value: 5100, TradeType: "perps",
+		Details: "new live trade", ExchangeOrderID: "999888777", ExchangeFee: 1.50,
+	})
+	if err := sdb.SaveState(loaded); err != nil {
+		t.Fatalf("SaveState with new trade: %v", err)
+	}
+
+	loaded2, err := sdb.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState after new trade: %v", err)
+	}
+	trades := loaded2.Strategies["test"].TradeHistory
+	if len(trades) != 2 {
+		t.Fatalf("trade count = %d, want 2", len(trades))
+	}
+	if trades[1].ExchangeOrderID != "999888777" {
+		t.Errorf("new trade ExchangeOrderID = %q, want %q", trades[1].ExchangeOrderID, "999888777")
+	}
+	if trades[1].ExchangeFee != 1.50 {
+		t.Errorf("new trade ExchangeFee = %g, want 1.50", trades[1].ExchangeFee)
 	}
 }

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -45,6 +45,8 @@ type HyperliquidResult struct {
 type HyperliquidFill struct {
 	AvgPx   float64 `json:"avg_px"`
 	TotalSz float64 `json:"total_sz"`
+	OID     int64   `json:"oid,omitempty"` // exchange order ID
+	Fee     float64 `json:"fee,omitempty"` // exchange fee (if available)
 }
 
 // HyperliquidExecution is the execution block from check_hyperliquid.py --execute output.

--- a/scheduler/executor_test.go
+++ b/scheduler/executor_test.go
@@ -106,6 +106,57 @@ func TestHyperliquidExecuteResultJSON(t *testing.T) {
 	}
 }
 
+func TestHyperliquidExecuteResultJSON_WithOID(t *testing.T) {
+	raw := `{
+		"execution": {
+			"action": "buy",
+			"symbol": "BTC",
+			"size": 0.01,
+			"fill": {"avg_px": 55000.5, "total_sz": 0.01, "oid": 1234567890, "fee": 0.35}
+		},
+		"platform": "hyperliquid",
+		"timestamp": "2026-01-01T00:00:00Z"
+	}`
+
+	var result HyperliquidExecuteResult
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Execution == nil || result.Execution.Fill == nil {
+		t.Fatal("Execution and Fill should not be nil")
+	}
+	if result.Execution.Fill.OID != 1234567890 {
+		t.Errorf("OID = %d, want 1234567890", result.Execution.Fill.OID)
+	}
+	if result.Execution.Fill.Fee != 0.35 {
+		t.Errorf("Fee = %g, want 0.35", result.Execution.Fill.Fee)
+	}
+}
+
+func TestHyperliquidExecuteResultJSON_NoOID(t *testing.T) {
+	// Backwards compatibility: fill without oid/fee should still parse
+	raw := `{
+		"execution": {
+			"action": "sell",
+			"symbol": "ETH",
+			"size": 0.5,
+			"fill": {"avg_px": 2100, "total_sz": 0.5}
+		},
+		"platform": "hyperliquid"
+	}`
+
+	var result HyperliquidExecuteResult
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Execution.Fill.OID != 0 {
+		t.Errorf("OID should be 0 when absent, got %d", result.Execution.Fill.OID)
+	}
+	if result.Execution.Fill.Fee != 0 {
+		t.Errorf("Fee should be 0 when absent, got %g", result.Execution.Fill.Fee)
+	}
+}
+
 func TestTopStepResultJSON(t *testing.T) {
 	raw := `{
 		"strategy": "sma",

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1295,10 +1295,27 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 		logger.Info("Live fill at $%.2f qty=%.6f (mid was $%.2f)", fillPrice, fillQty, price)
 	}
 
+	prevTradeCount := len(s.TradeHistory)
 	trades, err := ExecuteSpotSignal(s, result.Signal, result.Symbol, fillPrice, fillQty, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
+	}
+
+	// Stamp exchange metadata on newly created trades from live fills.
+	if trades > 0 && execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil {
+		fill := execResult.Execution.Fill
+		orderID := ""
+		if fill.OID != 0 {
+			orderID = fmt.Sprintf("%d", fill.OID)
+		}
+		for i := prevTradeCount; i < len(s.TradeHistory); i++ {
+			s.TradeHistory[i].ExchangeOrderID = orderID
+			s.TradeHistory[i].ExchangeFee = fill.Fee
+		}
+		if orderID != "" {
+			logger.Info("Exchange order ID: %s", orderID)
+		}
 	}
 
 	detail := ""

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -497,3 +497,80 @@ func TestSendTradeAlerts_PaperNoLiveChannel(t *testing.T) {
 		t.Errorf("expected message to primary channel ch-hl, got %s", mock.messages[0].channelID)
 	}
 }
+
+func TestExecuteHyperliquidResult_StampsExchangeData(t *testing.T) {
+	s := &StrategyState{
+		ID:              "hl-test-btc",
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		Cash:            1000,
+		InitialCapital:  1000,
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 1000},
+	}
+	sc := StrategyConfig{ID: "hl-test-btc", Type: "perps", Platform: "hyperliquid"}
+	result := &HyperliquidResult{Signal: 1, Symbol: "BTC", Price: 50000}
+	execResult := &HyperliquidExecuteResult{
+		Execution: &HyperliquidExecution{
+			Action: "buy", Symbol: "BTC", Size: 0.015,
+			Fill: &HyperliquidFill{AvgPx: 50000.5, TotalSz: 0.015, OID: 1234567890, Fee: 1.75},
+		},
+		Platform: "hyperliquid",
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	trades, _ := executeHyperliquidResult(sc, s, result, execResult, "BUY", 50000, logger)
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	if len(s.TradeHistory) != 1 {
+		t.Fatalf("TradeHistory len = %d, want 1", len(s.TradeHistory))
+	}
+
+	tr := s.TradeHistory[0]
+	if tr.ExchangeOrderID != "1234567890" {
+		t.Errorf("ExchangeOrderID = %q, want %q", tr.ExchangeOrderID, "1234567890")
+	}
+	if tr.ExchangeFee != 1.75 {
+		t.Errorf("ExchangeFee = %g, want 1.75", tr.ExchangeFee)
+	}
+}
+
+func TestExecuteHyperliquidResult_PaperModeNoExchangeData(t *testing.T) {
+	s := &StrategyState{
+		ID:              "hl-paper-btc",
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		Cash:            1000,
+		InitialCapital:  1000,
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 1000},
+	}
+	sc := StrategyConfig{ID: "hl-paper-btc", Type: "perps", Platform: "hyperliquid"}
+	result := &HyperliquidResult{Signal: 1, Symbol: "BTC", Price: 50000}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	// Paper mode: execResult is nil
+	trades, _ := executeHyperliquidResult(sc, s, result, nil, "BUY", 50000, logger)
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+
+	tr := s.TradeHistory[0]
+	if tr.ExchangeOrderID != "" {
+		t.Errorf("ExchangeOrderID should be empty in paper mode, got %q", tr.ExchangeOrderID)
+	}
+	if tr.ExchangeFee != 0 {
+		t.Errorf("ExchangeFee should be 0 in paper mode, got %g", tr.ExchangeFee)
+	}
+}

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -18,15 +18,17 @@ type Position struct {
 
 // Trade represents a completed trade.
 type Trade struct {
-	Timestamp  time.Time `json:"timestamp"`
-	StrategyID string    `json:"strategy_id"`
-	Symbol     string    `json:"symbol"`
-	Side       string    `json:"side"` // "buy" or "sell"
-	Quantity   float64   `json:"quantity"`
-	Price      float64   `json:"price"`
-	Value      float64   `json:"value"`
-	TradeType  string    `json:"trade_type"` // "spot", "options", or "futures"
-	Details    string    `json:"details"`
+	Timestamp       time.Time `json:"timestamp"`
+	StrategyID      string    `json:"strategy_id"`
+	Symbol          string    `json:"symbol"`
+	Side            string    `json:"side"` // "buy" or "sell"
+	Quantity        float64   `json:"quantity"`
+	Price           float64   `json:"price"`
+	Value           float64   `json:"value"`
+	TradeType       string    `json:"trade_type"` // "spot", "options", or "futures"
+	Details         string    `json:"details"`
+	ExchangeOrderID string    `json:"exchange_order_id,omitempty"` // exchange-provided order ID (e.g. Hyperliquid oid)
+	ExchangeFee     float64   `json:"exchange_fee,omitempty"`      // fee charged by exchange (if available)
 }
 
 // PortfolioValue calculates total value of a strategy's portfolio.

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -215,6 +215,14 @@ def run_execute(symbol, side, size, mode):
                     "avg_px": float(filled.get("avgPx", 0) or 0),
                     "total_sz": float(filled.get("totalSz", 0) or 0),
                 }
+                # Extract exchange order ID if present
+                oid = filled.get("oid")
+                if oid is not None:
+                    fill["oid"] = int(oid)
+                # Extract fee if present in response
+                fee = filled.get("fee")
+                if fee is not None:
+                    fill["fee"] = float(fee)
         except Exception:
             pass
 

--- a/shared_scripts/test_check_hyperliquid.py
+++ b/shared_scripts/test_check_hyperliquid.py
@@ -1,0 +1,138 @@
+"""Tests for check_hyperliquid.py — specifically the fill extraction logic."""
+
+import sys
+import os
+import json
+import importlib.util
+from unittest.mock import MagicMock, patch
+from io import StringIO
+
+import pytest
+
+
+def _load_check_module():
+    """Load check_hyperliquid.py as a module."""
+    script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "check_hyperliquid.py")
+    spec = importlib.util.spec_from_file_location("check_hyperliquid", script_path)
+    mod = importlib.util.module_from_spec(spec)
+    # Don't execute top-level code that sets up sys.path — we'll mock the adapter
+    return mod, spec
+
+
+class TestFillExtraction:
+    """Test that run_execute extracts oid and fee from Hyperliquid SDK responses."""
+
+    def _run_execute_with_mock_response(self, sdk_response):
+        """Helper: mock the adapter and capture JSON output from run_execute."""
+        mod, spec = _load_check_module()
+        spec.loader.exec_module(mod)
+
+        mock_adapter_cls = MagicMock()
+        mock_adapter = MagicMock()
+        mock_adapter_cls.return_value = mock_adapter
+        mock_adapter.market_open.return_value = sdk_response
+
+        captured = StringIO()
+        with patch.dict(sys.modules, {}):
+            with patch.object(mod, "__builtins__", mod.__builtins__):
+                # Patch the import inside run_execute
+                import builtins
+                original_import = builtins.__import__
+
+                def mock_import(name, *args, **kwargs):
+                    if name == "adapter":
+                        fake_mod = MagicMock()
+                        fake_mod.HyperliquidExchangeAdapter = mock_adapter_cls
+                        return fake_mod
+                    return original_import(name, *args, **kwargs)
+
+                with patch("builtins.__import__", side_effect=mock_import):
+                    with patch("sys.stdout", captured):
+                        mod.run_execute("BTC", "buy", 0.01, "live")
+
+        return json.loads(captured.getvalue())
+
+    def test_fill_with_oid_and_fee(self):
+        """SDK response includes oid and fee — both should appear in output."""
+        sdk_response = {
+            "status": "ok",
+            "response": {
+                "type": "order",
+                "data": {
+                    "statuses": [
+                        {
+                            "filled": {
+                                "avgPx": "55000.5",
+                                "totalSz": "0.01",
+                                "oid": 1234567890,
+                                "fee": "0.35",
+                            }
+                        }
+                    ]
+                },
+            },
+        }
+        result = self._run_execute_with_mock_response(sdk_response)
+        fill = result["execution"]["fill"]
+        assert fill["avg_px"] == 55000.5
+        assert fill["total_sz"] == 0.01
+        assert fill["oid"] == 1234567890
+        assert fill["fee"] == 0.35
+
+    def test_fill_with_oid_no_fee(self):
+        """SDK response has oid but no fee — fee should be absent."""
+        sdk_response = {
+            "status": "ok",
+            "response": {
+                "type": "order",
+                "data": {
+                    "statuses": [
+                        {
+                            "filled": {
+                                "avgPx": "2100.0",
+                                "totalSz": "0.5",
+                                "oid": 9876543210,
+                            }
+                        }
+                    ]
+                },
+            },
+        }
+        result = self._run_execute_with_mock_response(sdk_response)
+        fill = result["execution"]["fill"]
+        assert fill["oid"] == 9876543210
+        assert "fee" not in fill
+
+    def test_fill_without_oid(self):
+        """SDK response has no oid — backwards compatible with old responses."""
+        sdk_response = {
+            "status": "ok",
+            "response": {
+                "type": "order",
+                "data": {
+                    "statuses": [
+                        {
+                            "filled": {
+                                "avgPx": "50000",
+                                "totalSz": "0.1",
+                            }
+                        }
+                    ]
+                },
+            },
+        }
+        result = self._run_execute_with_mock_response(sdk_response)
+        fill = result["execution"]["fill"]
+        assert fill["avg_px"] == 50000.0
+        assert fill["total_sz"] == 0.1
+        assert "oid" not in fill
+        assert "fee" not in fill
+
+    def test_fill_empty_statuses(self):
+        """SDK response with empty statuses — fill should be empty dict."""
+        sdk_response = {
+            "status": "ok",
+            "response": {"type": "order", "data": {"statuses": []}},
+        }
+        result = self._run_execute_with_mock_response(sdk_response)
+        assert result["execution"]["fill"] == {}


### PR DESCRIPTION
Closes #219

Add `exchange_order_id` and `exchange_fee` fields to trade records so that live Hyperliquid fills include the actual exchange order ID and fee.

Generated with [Claude Code](https://claude.ai/code)