### PR TITLE
fix: skip workflow when @claude appears only in code blocks or examples

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,26 +25,64 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      - name: Verify @claude is an actual invocation (not in a code block or example)
+        id: verify_invocation
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          REVIEW_BODY: ${{ github.event.review.body }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          # Select body based on event type
+          case "$EVENT_NAME" in
+            issue_comment|pull_request_review_comment)
+              BODY="$COMMENT_BODY"
+              ;;
+            pull_request_review)
+              BODY="$REVIEW_BODY"
+              ;;
+            issues)
+              BODY="$ISSUE_BODY"
+              ;;
+          esac
+
+          # Strip fenced code blocks (``` ... ```) and inline code spans (` ... `)
+          STRIPPED=$(printf '%s' "$BODY" | perl -0777 -pe 's/```.*?```//gs' | sed 's/`[^`]*`//g')
+
+          # @claude is a real invocation only when it appears at the start of a line
+          if printf '%s' "$STRIPPED" | grep -qE '(^|(\r?\n))[[:space:]]*@claude([[:space:]]|$)'; then
+            echo "invoked=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "invoked=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::@claude found but only inside code blocks or examples — skipping."
+          fi
+
       - name: Checkout repository
+        if: steps.verify_invocation.outputs.invoked == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Set up Go
+        if: steps.verify_invocation.outputs.invoked == 'true'
         uses: actions/setup-go@v5
         with:
           go-version: '1.26'
 
       - name: Set up Python (uv)
+        if: steps.verify_invocation.outputs.invoked == 'true'
         uses: astral-sh/setup-uv@v6
 
       - name: Install Python dependencies
+        if: steps.verify_invocation.outputs.invoked == 'true'
         run: uv sync --frozen --extra test
 
       - name: Clean up lockfile changes before Claude checkout
+        if: steps.verify_invocation.outputs.invoked == 'true'
         run: git checkout -- uv.lock
 
       - name: Run Claude Code
+        if: steps.verify_invocation.outputs.invoked == 'true'
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
@@ -64,4 +102,3 @@ jobs:
             --model claude-opus-4-6
             --effort high
             --allowedTools "Bash(go *),Bash(cd scheduler && go *),Bash(uv run *),Bash(python3 *),Bash(.venv/bin/python3 *),Bash(gofmt *),Bash(cd scheduler && gofmt *)"
-


### PR DESCRIPTION
## Summary

- Adds a `verify_invocation` step that strips code blocks/inline code spans from the trigger body, then checks `@claude` only appears at the start of a line (an actual invocation)
- Gates all subsequent job steps on `invoked == 'true'` so nothing runs on false positives
- Passes untrusted event bodies via `env:` variables (not inline `${{ }}` interpolation) to avoid command injection

## Root cause

The workflow's `contains(github.event.issue.body, '@claude')` condition fires whenever `@claude` appears anywhere in a body — including inside fenced code blocks or inline examples — causing unintended workflow runs.

---
Generated with: Claude Sonnet 4.6 | Effort: auto