### PR TITLE
feat: support @claude <model> syntax to override model per invocation

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,6 +25,43 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      - name: Resolve model from @claude invocation
+        id: resolve_model
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          REVIEW_BODY: ${{ github.event.review.body }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          # Select body based on event type
+          case "$EVENT_NAME" in
+            issue_comment|pull_request_review_comment)
+              BODY="$COMMENT_BODY"
+              ;;
+            pull_request_review)
+              BODY="$REVIEW_BODY"
+              ;;
+            issues)
+              BODY="$ISSUE_BODY"
+              ;;
+          esac
+
+          # Strip fenced code blocks (``` ... ```) and inline code spans (` ... `)
+          STRIPPED=$(printf '%s' "$BODY" | perl -0777 -pe 's/```.*?```//gs' | sed 's/`[^`]*`//g')
+
+          # Extract optional model shorthand after @claude on a line boundary
+          # e.g. "@claude sonnet fix this" → "sonnet"
+          MODEL_SHORT=$(printf '%s' "$STRIPPED" | grep -oE '(^|(\r?\n))[[:space:]]*@claude[[:space:]]+[a-z]+' | head -1 | awk '{print $NF}' || true)
+
+          case "$MODEL_SHORT" in
+            sonnet) MODEL_ID="claude-sonnet-4-6" ;;
+            haiku)  MODEL_ID="claude-haiku-4-5" ;;
+            *)      MODEL_ID="claude-opus-4-6" ;;  # default (covers "opus" and no model)
+          esac
+
+          echo "model_id=$MODEL_ID" >> "$GITHUB_OUTPUT"
+          echo "::notice::Using model: $MODEL_ID"
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -61,7 +98,6 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: |
-            --model claude-opus-4-6
+            --model ${{ steps.resolve_model.outputs.model_id }}
             --effort high
             --allowedTools "Bash(go *),Bash(cd scheduler && go *),Bash(uv run *),Bash(python3 *),Bash(.venv/bin/python3 *),Bash(gofmt *),Bash(cd scheduler && gofmt *)"
-


### PR DESCRIPTION
## Summary

- Adds a `resolve_model` step that parses the trigger body for a model shorthand immediately after `@claude`
- Maps shorthands to full model IDs: `sonnet` → `claude-sonnet-4-6`, `haiku` → `claude-haiku-4-5`, `opus`/none → `claude-opus-4-6`
- Passes the resolved model to `--model` in `claude_args`
- Untrusted event bodies passed via `env:` variables (not inline `${{ }}` interpolation) to prevent command injection

## Usage

| Invocation | Model used |
|---|---|
| `@claude sonnet <task>` | `claude-sonnet-4-6` |
| `@claude haiku <task>` | `claude-haiku-4-5` |
| `@claude opus <task>` | `claude-opus-4-6` |
| `@claude <task>` | `claude-opus-4-6` (default) |

Closes #229

---
Generated with: Claude Sonnet 4.6 | Effort: auto