### PR TITLE
fix: grant Claude workflow write permissions for contents, PRs, issues, and workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,12 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
+      workflows: write # Required for Claude to modify workflow files
     steps:
       - name: Verify @claude is an actual invocation (not in a code block or example)
         id: verify_invocation


### PR DESCRIPTION
## Summary

- Upgrades `contents`, `pull-requests`, and `issues` permissions from `read` → `write` so the Claude Code Action can push changes and comment
- Adds `workflows: write` so Claude can modify `.github/workflows/` files (previously blocked, causing PR #231 to stall)

## Test plan
- [ ] Trigger `@claude` on a new issue or PR comment
- [ ] Verify Claude can push a branch that includes workflow file changes

---
Generated with: Claude Sonnet 4.6 | Effort: 20