### PR TITLE
feat: always show trading status in summary

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -287,6 +287,8 @@ func FormatCategorySummary(
 		for _, cb := range cbActive {
 			sb.WriteString(fmt.Sprintf("  • %s\n", cb))
 		}
+	} else {
+		sb.WriteString("✅ **Trading active**\n")
 	}
 
 	// Prices inline — filter to just this asset when asset is specified.

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -184,6 +184,9 @@ func TestFormatCategorySummary_CircuitBreakerActive(t *testing.T) {
 	if strings.Contains(msg, "hl-sma-btc") && strings.Contains(msg, "hl-sma-btc (resumes") {
 		t.Errorf("hl-sma-btc should not have circuit breaker warning, got:\n%s", msg)
 	}
+	if strings.Contains(msg, "Trading active") {
+		t.Errorf("should not show 'Trading active' when circuit breaker is active, got:\n%s", msg)
+	}
 }
 
 func TestFormatCategorySummary_NoCircuitBreaker(t *testing.T) {
@@ -202,6 +205,9 @@ func TestFormatCategorySummary_NoCircuitBreaker(t *testing.T) {
 
 	if strings.Contains(msg, "Circuit breaker") {
 		t.Errorf("should not show circuit breaker when none active, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "Trading active") {
+		t.Errorf("expected 'Trading active' status when no circuit breaker, got:\n%s", msg)
 	}
 }
 


### PR DESCRIPTION
Always show a trading status line in the Discord summary:

- ✅ *Trading active* when circuit breaker is off
- 🚫 *Circuit breaker active — trading disabled* when on

Closes #228

Generated with [Claude Code](https://claude.ai/code)