### PR TITLE
fix: show model and effort in Claude workflow job summary

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -127,6 +127,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          model: ${{ steps.resolve_model.outputs.model_id }}
+          effort: high
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
@@ -138,7 +140,4 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: |
-            --model ${{ steps.resolve_model.outputs.model_id }}
-            --effort high
-            --allowedTools "Bash(go *),Bash(cd scheduler && go *),Bash(uv run *),Bash(python3 *),Bash(.venv/bin/python3 *),Bash(gofmt *),Bash(cd scheduler && gofmt *)"
+          claude_args: --allowedTools "Bash(go *),Bash(cd scheduler && go *),Bash(uv run *),Bash(python3 *),Bash(.venv/bin/python3 *),Bash(gofmt *),Bash(cd scheduler && gofmt *)"


### PR DESCRIPTION
## Summary

- Move `--model` and `--effort` out of `claude_args` and into dedicated `model:` / `effort:` action inputs
- The `claude-code-action` reads these fields directly to populate the job summary; passing them via `claude_args` bypasses that display logic, causing the blank model/effort shown in #228

Closes #228

---
Generated with: Claude Sonnet 4.6 | Effort: 5