### PR TITLE
feat: restore code-review plugin settings to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -128,6 +128,16 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # Allow Claude's own bot user to trigger reviews on its own PRs
+          allowed_bots: 'claude'
+
+          # Show full output in the job summary (important for code review results)
+          show_full_output: true
+
+          # Load the code-review plugin so @claude review uses structured review skill
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## Summary

- Restores `allowed_bots: 'claude'` — allows Claude's bot user to trigger reviews on its own PRs
- Restores `show_full_output: true` — surfaces full review output in the job summary
- Restores `plugin_marketplaces` + `plugins: 'code-review@claude-code-plugins'` — loads the structured code-review skill so `@claude review` invokes it properly

These settings were present in the removed `claude-code-review.yml` workflow but were not carried over to `claude.yml` when the dedicated review workflow was deleted.

## Test plan

- [ ] Comment `@claude review` on a PR and verify the structured code-review skill is invoked
- [ ] Verify review output appears in the GitHub Actions job summary
- [ ] Open a PR from a Claude-created branch and confirm `@claude review` can be triggered by the Claude bot user

---
Generated with: Claude Sonnet 4.6 | Effort: 20