### PR TITLE
fix: _get_swing_indices returns integer positions instead of DatetimeIndex labels

### DIFF
--- a/shared_strategies/chart_patterns.py
+++ b/shared_strategies/chart_patterns.py
@@ -64,8 +64,8 @@ def find_swing_points(
 
 
 def _get_swing_indices(swing_series: pd.Series) -> list:
-    """Return sorted list of integer indices where swing points exist."""
-    return sorted(swing_series.dropna().index.tolist())
+    """Return sorted list of integer positions where swing points exist."""
+    return list(np.where(swing_series.notna())[0])
 
 
 # ─────────────────────────────────────────────
@@ -371,13 +371,12 @@ def _detect_flag(
 
             # Find pole start: the low before the peak
             pole_start = max(0, peak_bar - pole_max_bars)
-            pole_low_bar = pole_start + close.iloc[pole_start:peak_bar].idxmin()
+            segment = close.iloc[pole_start:peak_bar]
+            if len(segment) == 0:
+                continue
+            pole_low_bar = int(segment.values.argmin()) + pole_start
             if not (pole_min_bars <= peak_bar - pole_low_bar <= pole_max_bars):
-                # Try using the actual iloc index
-                segment = close.iloc[pole_start:peak_bar]
-                pole_low_bar = segment.values.argmin() + pole_start
-                if not (pole_min_bars <= peak_bar - pole_low_bar <= pole_max_bars):
-                    continue
+                continue
             pole_move = peak_price - close.iloc[pole_low_bar]
             if atr.iloc[peak_bar] > 0 and pole_move < pole_atr_mult * atr.iloc[peak_bar]:
                 continue

--- a/shared_strategies/chart_patterns.py
+++ b/shared_strategies/chart_patterns.py
@@ -63,9 +63,11 @@ def find_swing_points(
     return swing_highs, swing_lows
 
 
-def _get_swing_indices(swing_series: pd.Series) -> list:
-    """Return sorted list of integer positions where swing points exist."""
-    return list(np.where(swing_series.notna())[0])
+def _get_swing_indices(swing_series: pd.Series) -> list[int]:
+    """Return sorted list of integer positions (not index labels) where swing
+    points exist. Positions are suitable for use with `.iloc[]` regardless of
+    the underlying index type (RangeIndex, DatetimeIndex, etc.)."""
+    return np.where(swing_series.notna())[0].tolist()
 
 
 # ─────────────────────────────────────────────

--- a/shared_strategies/test_chart_patterns.py
+++ b/shared_strategies/test_chart_patterns.py
@@ -308,6 +308,56 @@ class TestCupAndHandle:
         # At least no crash; geometry may or may not trigger
 
 
+# ─── DatetimeIndex regression ────────────────
+
+class TestDatetimeIndex:
+    """Regression tests: _get_swing_indices must return integer positions even
+    when the DataFrame carries a DatetimeIndex (not a RangeIndex)."""
+
+    def _make_datetime_ohlcv(self, closes, volume=None, noise=0.5):
+        df = make_ohlcv(closes, volume=volume, noise=noise)
+        df.index = pd.date_range("2024-01-01", periods=len(df), freq="1h")
+        return df
+
+    def test_get_swing_indices_with_datetime_index(self):
+        prices = list(range(100, 90, -1)) + list(range(90, 101))
+        df = self._make_datetime_ohlcv(prices)
+        sh, sl = find_swing_points(df["high"], df["low"], lookback=3)
+        indices = _get_swing_indices(sl)
+        # All returned values must be plain integers, not Timestamps
+        assert all(isinstance(i, (int, np.integer)) for i in indices), (
+            f"Expected integer positions, got: {[type(i) for i in indices]}"
+        )
+
+    def test_chart_pattern_core_with_datetime_index(self):
+        """chart_pattern_core must not raise TypeError with a DatetimeIndex."""
+        prices = (
+            list(np.linspace(80, 100, 20)) +
+            list(np.linspace(100, 90, 15)) +
+            list(np.linspace(90, 99, 15)) +
+            list(np.linspace(99, 85, 20)) +
+            [85] * 30
+        )
+        df = self._make_datetime_ohlcv(prices, volume=[100] * len(prices))
+        result = chart_pattern_core(df, pivot_lookback=3)
+        assert "signal" in result.columns
+        assert set(result["signal"].unique()).issubset({-1, 0, 1})
+
+    def test_detect_double_top_with_datetime_index(self):
+        prices = (
+            list(np.linspace(80, 100, 20)) +
+            list(np.linspace(100, 90, 15)) +
+            list(np.linspace(90, 99, 15)) +
+            list(np.linspace(99, 85, 20)) +
+            [85] * 30
+        )
+        df = self._make_datetime_ohlcv(prices)
+        sh, sl = find_swing_points(df["high"], df["low"], lookback=3)
+        # Must not raise TypeError
+        matches = detect_double_top(df["high"], df["low"], df["close"], sh, sl, tolerance=0.03)
+        assert isinstance(matches, list)
+
+
 # ─── Orchestrator ────────────────────────────
 
 class TestChartPatternCore:

--- a/shared_strategies/test_chart_patterns.py
+++ b/shared_strategies/test_chart_patterns.py
@@ -357,6 +357,43 @@ class TestDatetimeIndex:
         matches = detect_double_top(df["high"], df["low"], df["close"], sh, sl, tolerance=0.03)
         assert isinstance(matches, list)
 
+    def test_detect_flag_pole_low_bar_with_datetime_index(self):
+        """Regression: `_detect_flag` computes `pole_low_bar` via
+        `segment.values.argmin() + pole_start`. Under a DatetimeIndex the
+        prior `.idxmin()`-based path returned a Timestamp and crashed when
+        the result was used with `.iloc[]`. This test exercises both bull
+        and bear flag paths end-to-end on a DatetimeIndex DataFrame.
+        """
+        # Bull flag: pole then mild pullback then breakout
+        bull_prices = (
+            list(np.linspace(80, 120, 15)) +
+            list(np.linspace(120, 115, 10)) +
+            list(np.linspace(115, 125, 10)) +
+            [125] * 15
+        )
+        vol = [200] * 15 + [100] * (len(bull_prices) - 15)
+        df_bull = self._make_datetime_ohlcv(bull_prices, volume=vol)
+        sh_b, sl_b = find_swing_points(df_bull["high"], df_bull["low"], lookback=3)
+        # Must not raise TypeError on the pole_low_bar calculation
+        bull_matches = detect_bull_flag(
+            df_bull["high"], df_bull["low"], df_bull["close"], df_bull["volume"], sh_b, sl_b,
+        )
+        assert isinstance(bull_matches, list)
+
+        # Bear flag: symmetric drop then mild bounce then breakdown
+        bear_prices = (
+            list(np.linspace(120, 80, 15)) +
+            list(np.linspace(80, 85, 10)) +
+            list(np.linspace(85, 75, 10)) +
+            [75] * 15
+        )
+        df_bear = self._make_datetime_ohlcv(bear_prices, volume=vol)
+        sh_b2, sl_b2 = find_swing_points(df_bear["high"], df_bear["low"], lookback=3)
+        bear_matches = detect_bear_flag(
+            df_bear["high"], df_bear["low"], df_bear["close"], df_bear["volume"], sh_b2, sl_b2,
+        )
+        assert isinstance(bear_matches, list)
+
 
 # ─── Orchestrator ────────────────────────────
 


### PR DESCRIPTION
Fix TypeError in chart_patterns.py when DataFrame has a DatetimeIndex.

`_get_swing_indices` was returning index labels via `.dropna().index.tolist()`, which are Timestamps when the DataFrame has a DatetimeIndex. All pattern detectors pass these values to `.iloc[]`, which requires integer positions, causing `TypeError: Cannot index by location index with a non-integer key`.

Also fixes `_detect_flag`'s pole_low_bar calculation which used `.idxmin()` (returns label) instead of `.values.argmin()` (returns integer position) — same root cause.

Adds 3 regression tests for DatetimeIndex compatibility.

Closes #236

Generated with [Claude Code](https://claude.ai/code)