### PR TITLE
feat: show candle timeframe and check interval per strategy in Discord summaries

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -225,6 +225,7 @@ const discordSplitThreshold = 1980
 // the position list is split across multiple messages.
 // channelStrategies is pre-filtered by the caller; channelKey is the display label.
 // asset, when non-empty, appends " — <ASSET>" to the title and filters the prices line.
+// globalIntervalSeconds is the config-level default interval used when a strategy has no per-strategy override.
 func FormatCategorySummary(
 	cycle int,
 	elapsed time.Duration,
@@ -237,6 +238,7 @@ func FormatCategorySummary(
 	state *AppState,
 	channelKey string,
 	asset string,
+	globalIntervalSeconds int,
 ) []string {
 	var sb strings.Builder
 
@@ -368,11 +370,18 @@ func FormatCategorySummary(
 		if initCap > 0 {
 			pnlPct = (pnl / initCap) * 100
 		}
-		asset := extractAsset(sc)
+		botAsset := extractAsset(sc)
+		tf := extractTimeframe(sc)
+		effectiveInterval := sc.IntervalSeconds
+		if effectiveInterval <= 0 {
+			effectiveInterval = globalIntervalSeconds
+		}
 		tableBots = append(tableBots, botInfo{
 			id:            sc.ID,
 			strategy:      stratName,
-			asset:         asset,
+			asset:         botAsset,
+			timeframe:     tf,
+			interval:      formatInterval(effectiveInterval),
 			value:         pv,
 			initialCap:    initCap,
 			pnl:           pnl,
@@ -525,6 +534,8 @@ type botInfo struct {
 	id            string
 	strategy      string
 	asset         string
+	timeframe     string // e.g. "1h" or "—" for spot/options
+	interval      string // e.g. "10m", formatted from effective interval seconds
 	value         float64
 	initialCap    float64
 	pnl           float64
@@ -560,6 +571,17 @@ func extractAsset(sc StrategyConfig) string {
 		return strings.TrimSuffix(asset, "/USDT")
 	}
 	return ""
+}
+
+// extractTimeframe returns the candle timeframe for a strategy, or "—" if none.
+// Perps and futures scripts (check_hyperliquid.py, check_topstep.py, check_robinhood.py,
+// check_okx.py) use args[2] as the timeframe (e.g. "1h").
+// Spot (check_strategy.py) and options scripts have no timeframe argument.
+func extractTimeframe(sc StrategyConfig) string {
+	if len(sc.Args) > 2 && !strings.HasPrefix(sc.Args[2], "--") {
+		return sc.Args[2]
+	}
+	return "—"
 }
 
 // assetSortKey returns a stable sort key so BTC/ETH/SOL/BNB appear first.
@@ -616,6 +638,24 @@ func fmtComma(v float64) string {
 	return string(out)
 }
 
+// formatInterval converts a duration in seconds to a short human-readable string.
+// Examples: 60 → "1m", 600 → "10m", 3600 → "1h", 86400 → "1d".
+func formatInterval(seconds int) string {
+	if seconds <= 0 {
+		return "—"
+	}
+	if seconds%86400 == 0 {
+		return fmt.Sprintf("%dd", seconds/86400)
+	}
+	if seconds%3600 == 0 {
+		return fmt.Sprintf("%dh", seconds/3600)
+	}
+	if seconds%60 == 0 {
+		return fmt.Sprintf("%dm", seconds/60)
+	}
+	return fmt.Sprintf("%ds", seconds)
+}
+
 // writeCatTable writes a monospace code-block table to sb.
 // When showWalletPct is true, an extra "Wallet%" column is rendered for shared-wallet strategies.
 func writeCatTable(sb *strings.Builder, bots []botInfo, totalValue, totalPnl, totalPnlPct float64, showWalletPct bool) {
@@ -624,8 +664,8 @@ func writeCatTable(sb *strings.Builder, bots []botInfo, totalValue, totalPnl, to
 	}
 	sb.WriteString("\n```\n")
 	if showWalletPct {
-		const sep = "------------------------------------------------------------"
-		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Wallet%"))
+		const sep = "-----------------------------------------------------------------------"
+		sb.WriteString(fmt.Sprintf("%-12s %-8s %10s %10s %10s %7s %8s\n", "Strategy", "Tf/Int", "Init", "Value", "PnL", "PnL%", "Wallet%"))
 		sb.WriteString(sep + "\n")
 		var totalInit float64
 		for _, bot := range bots {
@@ -633,6 +673,7 @@ func writeCatTable(sb *strings.Builder, bots []botInfo, totalValue, totalPnl, to
 			if len(label) > 12 {
 				label = label[:12]
 			}
+			tfInt := bot.timeframe + "/" + bot.interval
 			valStr := "$ " + fmtComma(bot.value)
 			initStr := "$ " + fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
@@ -642,17 +683,17 @@ func writeCatTable(sb *strings.Builder, bots []botInfo, totalValue, totalPnl, to
 				wpStr = fmt.Sprintf("%.1f%%", bot.walletPct)
 			}
 			totalInit += bot.initialCap
-			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s\n", label, initStr, valStr, pnlStr, pctStr, wpStr))
+			sb.WriteString(fmt.Sprintf("%-12s %-8s %10s %10s %10s %7s %8s\n", label, tfInt, initStr, valStr, pnlStr, pctStr, wpStr))
 		}
 		sb.WriteString(sep + "\n")
 		totValStr := "$ " + fmtComma(totalValue)
 		totInitStr := "$ " + fmtComma(totalInit)
 		totPnlStr := fmtPnl(totalPnl)
 		totPctStr := fmtPnlPct(totalPnlPct)
-		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "100.0%"))
+		sb.WriteString(fmt.Sprintf("%-12s %-8s %10s %10s %10s %7s %8s\n", "TOTAL", "", totInitStr, totValStr, totPnlStr, totPctStr, "100.0%"))
 	} else {
-		const sep = "--------------------------------------------------"
-		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s\n", "Strategy", "Init", "Value", "PnL", "PnL%"))
+		const sep = "--------------------------------------------------------------"
+		sb.WriteString(fmt.Sprintf("%-12s %-8s %10s %10s %10s %7s\n", "Strategy", "Tf/Int", "Init", "Value", "PnL", "PnL%"))
 		sb.WriteString(sep + "\n")
 		var totalInit float64
 		for _, bot := range bots {
@@ -660,19 +701,20 @@ func writeCatTable(sb *strings.Builder, bots []botInfo, totalValue, totalPnl, to
 			if len(label) > 12 {
 				label = label[:12]
 			}
+			tfInt := bot.timeframe + "/" + bot.interval
 			valStr := "$ " + fmtComma(bot.value)
 			initStr := "$ " + fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
 			pctStr := fmtPnlPct(bot.pnlPct)
 			totalInit += bot.initialCap
-			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s\n", label, initStr, valStr, pnlStr, pctStr))
+			sb.WriteString(fmt.Sprintf("%-12s %-8s %10s %10s %10s %7s\n", label, tfInt, initStr, valStr, pnlStr, pctStr))
 		}
 		sb.WriteString(sep + "\n")
 		totValStr := "$ " + fmtComma(totalValue)
 		totInitStr := "$ " + fmtComma(totalInit)
 		totPnlStr := fmtPnl(totalPnl)
 		totPctStr := fmtPnlPct(totalPnlPct)
-		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr))
+		sb.WriteString(fmt.Sprintf("%-12s %-8s %10s %10s %10s %7s\n", "TOTAL", "", totInitStr, totValStr, totPnlStr, totPctStr))
 	}
 	sb.WriteString("```\n")
 }

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -664,8 +664,8 @@ func writeCatTable(sb *strings.Builder, bots []botInfo, totalValue, totalPnl, to
 	}
 	sb.WriteString("\n```\n")
 	if showWalletPct {
-		const sep = "-----------------------------------------------------------------------"
-		sb.WriteString(fmt.Sprintf("%-12s %-8s %10s %10s %10s %7s %8s\n", "Strategy", "Tf/Int", "Init", "Value", "PnL", "PnL%", "Wallet%"))
+		const sep = "--------------------------------------------------------------------------"
+		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Wallet%", "Tf", "Int"))
 		sb.WriteString(sep + "\n")
 		var totalInit float64
 		for _, bot := range bots {
@@ -673,7 +673,6 @@ func writeCatTable(sb *strings.Builder, bots []botInfo, totalValue, totalPnl, to
 			if len(label) > 12 {
 				label = label[:12]
 			}
-			tfInt := bot.timeframe + "/" + bot.interval
 			valStr := "$ " + fmtComma(bot.value)
 			initStr := "$ " + fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
@@ -683,17 +682,17 @@ func writeCatTable(sb *strings.Builder, bots []botInfo, totalValue, totalPnl, to
 				wpStr = fmt.Sprintf("%.1f%%", bot.walletPct)
 			}
 			totalInit += bot.initialCap
-			sb.WriteString(fmt.Sprintf("%-12s %-8s %10s %10s %10s %7s %8s\n", label, tfInt, initStr, valStr, pnlStr, pctStr, wpStr))
+			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s %5s %5s\n", label, initStr, valStr, pnlStr, pctStr, wpStr, bot.timeframe, bot.interval))
 		}
 		sb.WriteString(sep + "\n")
 		totValStr := "$ " + fmtComma(totalValue)
 		totInitStr := "$ " + fmtComma(totalInit)
 		totPnlStr := fmtPnl(totalPnl)
 		totPctStr := fmtPnlPct(totalPnlPct)
-		sb.WriteString(fmt.Sprintf("%-12s %-8s %10s %10s %10s %7s %8s\n", "TOTAL", "", totInitStr, totValStr, totPnlStr, totPctStr, "100.0%"))
+		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s %5s %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "100.0%", "", ""))
 	} else {
-		const sep = "--------------------------------------------------------------"
-		sb.WriteString(fmt.Sprintf("%-12s %-8s %10s %10s %10s %7s\n", "Strategy", "Tf/Int", "Init", "Value", "PnL", "PnL%"))
+		const sep = "-----------------------------------------------------------------"
+		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Tf", "Int"))
 		sb.WriteString(sep + "\n")
 		var totalInit float64
 		for _, bot := range bots {
@@ -701,20 +700,19 @@ func writeCatTable(sb *strings.Builder, bots []botInfo, totalValue, totalPnl, to
 			if len(label) > 12 {
 				label = label[:12]
 			}
-			tfInt := bot.timeframe + "/" + bot.interval
 			valStr := "$ " + fmtComma(bot.value)
 			initStr := "$ " + fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
 			pctStr := fmtPnlPct(bot.pnlPct)
 			totalInit += bot.initialCap
-			sb.WriteString(fmt.Sprintf("%-12s %-8s %10s %10s %10s %7s\n", label, tfInt, initStr, valStr, pnlStr, pctStr))
+			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %5s %5s\n", label, initStr, valStr, pnlStr, pctStr, bot.timeframe, bot.interval))
 		}
 		sb.WriteString(sep + "\n")
 		totValStr := "$ " + fmtComma(totalValue)
 		totInitStr := "$ " + fmtComma(totalInit)
 		totPnlStr := fmtPnl(totalPnl)
 		totPctStr := fmtPnlPct(totalPnlPct)
-		sb.WriteString(fmt.Sprintf("%-12s %-8s %10s %10s %10s %7s\n", "TOTAL", "", totInitStr, totValStr, totPnlStr, totPctStr))
+		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %5s %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", ""))
 	}
 	sb.WriteString("```\n")
 }

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -430,13 +430,13 @@ func TestFormatCategorySummary_TfIntColumn(t *testing.T) {
 	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 3600)
 	msg := strings.Join(msgs, "\n")
 
-	// Tf/Int column header should be present.
-	if !strings.Contains(msg, "Tf/Int") {
-		t.Errorf("expected 'Tf/Int' column header, got:\n%s", msg)
+	// Separate Tf and Int column headers should be present (at end of table).
+	if !strings.Contains(msg, "Tf") || !strings.Contains(msg, "Int") {
+		t.Errorf("expected 'Tf' and 'Int' column headers, got:\n%s", msg)
 	}
-	// Strategy timeframe "1h" and per-strategy interval 600s → "10m".
-	if !strings.Contains(msg, "1h/10m") {
-		t.Errorf("expected '1h/10m' for perps with 1h timeframe and 600s interval, got:\n%s", msg)
+	// Row should render timeframe "1h" and interval "10m" as separate values.
+	if !strings.Contains(msg, "1h") || !strings.Contains(msg, "10m") {
+		t.Errorf("expected '1h' and '10m' for perps with 1h timeframe and 600s interval, got:\n%s", msg)
 	}
 }
 
@@ -455,9 +455,9 @@ func TestFormatCategorySummary_TfIntGlobalFallback(t *testing.T) {
 	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "spot", "", 3600)
 	msg := strings.Join(msgs, "\n")
 
-	// No timeframe for spot → "—", global interval 3600s → "1h".
-	if !strings.Contains(msg, "—/1h") {
-		t.Errorf("expected '—/1h' for spot with global 3600s interval, got:\n%s", msg)
+	// No timeframe for spot → "—"; global interval 3600s → "1h". Separate columns now.
+	if !strings.Contains(msg, "—") || !strings.Contains(msg, "1h") {
+		t.Errorf("expected '—' and '1h' for spot with global 3600s interval, got:\n%s", msg)
 	}
 }
 

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -132,7 +132,7 @@ func TestFormatCategorySummary_WithAsset(t *testing.T) {
 	prices := map[string]float64{"BTC/USDT": 50000, "ETH/USDT": 3000}
 
 	// With asset — title should contain " — BTC" and only BTC price shown
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC")
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
 	msg := strings.Join(msgs, "\n")
 	if !strings.Contains(msg, "— BTC") {
 		t.Errorf("expected '— BTC' in title, got:\n%s", msg)
@@ -142,7 +142,7 @@ func TestFormatCategorySummary_WithAsset(t *testing.T) {
 	}
 
 	// Without asset — no suffix in title
-	msgs2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "")
+	msgs2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "", 600)
 	msg2 := strings.Join(msgs2, "\n")
 	if strings.Contains(msg2, "— ") {
 		t.Errorf("expected no asset suffix when asset='', got:\n%s", msg2)
@@ -168,7 +168,7 @@ func TestFormatCategorySummary_CircuitBreakerActive(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC")
+	msgs := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "Circuit breaker active") {
@@ -200,7 +200,7 @@ func TestFormatCategorySummary_NoCircuitBreaker(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC")
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
 	msg := strings.Join(msgs, "\n")
 
 	if strings.Contains(msg, "Circuit breaker") {
@@ -356,6 +356,111 @@ func TestFormatTradeDM_EmptyPlatform(t *testing.T) {
 	}
 }
 
+func TestFormatInterval(t *testing.T) {
+	cases := []struct {
+		seconds int
+		want    string
+	}{
+		{60, "1m"},
+		{300, "5m"},
+		{600, "10m"},
+		{900, "15m"},
+		{1800, "30m"},
+		{3600, "1h"},
+		{7200, "2h"},
+		{14400, "4h"},
+		{21600, "6h"},
+		{43200, "12h"},
+		{86400, "1d"},
+		{172800, "2d"},
+		{90, "90s"}, // not divisible by 60 → falls through to seconds
+		{45, "45s"}, // non-round seconds
+		{0, "—"},
+		{-1, "—"},
+	}
+	for _, c := range cases {
+		got := formatInterval(c.seconds)
+		if got != c.want {
+			t.Errorf("formatInterval(%d) = %q, want %q", c.seconds, got, c.want)
+		}
+	}
+}
+
+func TestExtractTimeframe(t *testing.T) {
+	cases := []struct {
+		sc   StrategyConfig
+		want string
+	}{
+		// Perps: args[2] is timeframe
+		{StrategyConfig{Type: "perps", Args: []string{"rsi", "BTC", "1h"}}, "1h"},
+		{StrategyConfig{Type: "perps", Args: []string{"sma", "ETH", "4h"}}, "4h"},
+		// Futures: args[2] is timeframe
+		{StrategyConfig{Type: "futures", Args: []string{"sma", "ES", "15m"}}, "15m"},
+		// OKX spot with timeframe
+		{StrategyConfig{Type: "spot", Args: []string{"sma", "BTC", "1h"}}, "1h"},
+		// Spot via check_strategy.py: only 2 args → no timeframe
+		{StrategyConfig{Type: "spot", Args: []string{"sma_crossover", "BTC/USDT"}}, "—"},
+		// Options: args[2] starts with "--"
+		{StrategyConfig{Type: "options", Args: []string{"wheel", "ETH", "--platform=deribit"}}, "—"},
+		// Only 1 arg
+		{StrategyConfig{Type: "perps", Args: []string{"rsi"}}, "—"},
+		// Empty args
+		{StrategyConfig{Type: "spot", Args: []string{}}, "—"},
+	}
+	for _, c := range cases {
+		got := extractTimeframe(c.sc)
+		if got != c.want {
+			t.Errorf("extractTimeframe(%v, %v) = %q, want %q", c.sc.Type, c.sc.Args, got, c.want)
+		}
+	}
+}
+
+func TestFormatCategorySummary_TfIntColumn(t *testing.T) {
+	// Perps strategy with timeframe "1h" and per-strategy interval 600s.
+	strats := []StrategyConfig{
+		{ID: "hl-rsi-btc", Type: "perps", Args: []string{"rsi", "BTC", "1h"}, Capital: 1000, IntervalSeconds: 600},
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-rsi-btc": {Cash: 1000},
+		},
+	}
+	prices := map[string]float64{"BTC/USDT": 50000}
+
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 3600)
+	msg := strings.Join(msgs, "\n")
+
+	// Tf/Int column header should be present.
+	if !strings.Contains(msg, "Tf/Int") {
+		t.Errorf("expected 'Tf/Int' column header, got:\n%s", msg)
+	}
+	// Strategy timeframe "1h" and per-strategy interval 600s → "10m".
+	if !strings.Contains(msg, "1h/10m") {
+		t.Errorf("expected '1h/10m' for perps with 1h timeframe and 600s interval, got:\n%s", msg)
+	}
+}
+
+func TestFormatCategorySummary_TfIntGlobalFallback(t *testing.T) {
+	// Spot strategy — no timeframe in args, falls back to global interval.
+	strats := []StrategyConfig{
+		{ID: "sma-btc", Type: "spot", Args: []string{"sma_crossover", "BTC/USDT"}, Capital: 1000},
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"sma-btc": {Cash: 1000},
+		},
+	}
+	prices := map[string]float64{"BTC/USDT": 50000}
+
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "spot", "", 3600)
+	msg := strings.Join(msgs, "\n")
+
+	// No timeframe for spot → "—", global interval 3600s → "1h".
+	if !strings.Contains(msg, "—/1h") {
+		t.Errorf("expected '—/1h' for spot with global 3600s interval, got:\n%s", msg)
+	}
+}
+
 func TestFormatCategorySummary_SharedWallet(t *testing.T) {
 	// Two strategies share a Hyperliquid wallet via capital_pct=0.5 each.
 	// Wallet balance = $1085, so each strategy's Capital = $542.50.
@@ -372,7 +477,7 @@ func TestFormatCategorySummary_SharedWallet(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH")
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600)
 	msg := strings.Join(msgs, "\n")
 
 	// Should contain Wallet% column
@@ -428,7 +533,7 @@ func TestFormatCategorySummary_WalletPctFromConfig(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH")
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "30.0%") {
@@ -453,7 +558,7 @@ func TestFormatCategorySummary_NoSharedWallet(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH")
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600)
 	msg := strings.Join(msgs, "\n")
 
 	if strings.Contains(msg, "Wallet%") {
@@ -482,7 +587,7 @@ func TestFormatCategorySummary_MessageSplitting(t *testing.T) {
 	state := &AppState{Strategies: strategies}
 	prices := map[string]float64{"BTC/USDT": 51000}
 
-	msgs := FormatCategorySummary(1, 0, 20, 0, 10000, prices, nil, strats, state, "hyperliquid", "BTC")
+	msgs := FormatCategorySummary(1, 0, 20, 0, 10000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
 
 	// Should produce multiple messages.
 	if len(msgs) < 2 {
@@ -532,7 +637,7 @@ func TestFormatCategorySummary_NoSplitWhenShort(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 51000}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC")
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
 
 	if len(msgs) != 1 {
 		t.Errorf("expected single message for 1 position, got %d", len(msgs))

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -750,7 +750,7 @@ func main() {
 					}
 					chDetails := channelTradeDetails[detailKey]
 					chValue := channelValue[chKey]
-					msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), chTrades, chValue, prices, chDetails, chStrats, state, chKey, "")
+					msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), chTrades, chValue, prices, chDetails, chStrats, state, chKey, "", cfg.IntervalSeconds)
 					for _, msg := range msgs {
 						notifier.SendToChannel(chKey, chKey, msg)
 					}
@@ -766,7 +766,7 @@ func main() {
 							}
 						}
 						assetTrades := len(assetDetails)
-						msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), assetTrades, assetValue, prices, assetDetails, assetStrats, state, chKey, asset)
+						msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), assetTrades, assetValue, prices, assetDetails, assetStrats, state, chKey, asset, cfg.IntervalSeconds)
 						for _, msg := range msgs {
 							notifier.SendToChannel(chKey, chKey, msg)
 						}
@@ -925,7 +925,7 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, notifier
 	// Format and send summary using the same asset-grouping logic as the main loop.
 	assetGroups, assetKeys := groupByAsset(chStrats)
 	if len(assetKeys) <= 1 {
-		msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, chValue, prices, nil, chStrats, state, channelKey, "")
+		msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, chValue, prices, nil, chStrats, state, channelKey, "", cfg.IntervalSeconds)
 		for _, msg := range msgs {
 			notifier.SendToChannel(channelKey, channelKey, msg)
 			fmt.Println(msg)
@@ -939,7 +939,7 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, notifier
 					assetValue += PortfolioValue(s, prices)
 				}
 			}
-			msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, assetValue, prices, nil, assetStrats, state, channelKey, asset)
+			msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, assetValue, prices, nil, assetStrats, state, channelKey, asset, cfg.IntervalSeconds)
 			for _, msg := range msgs {
 				notifier.SendToChannel(channelKey, channelKey, msg)
 				fmt.Println(msg)


### PR DESCRIPTION
## Summary

Adds two new columns at the end of the category summary table — `Tf` (candle timeframe, e.g. `1h`, `4h`, or `—` for spot/options) and `Int` (effective check interval, e.g. `10m`, `1h`). This lets users see from the Discord summary how often each strategy checks and what candle length it uses, without cross-referencing the config file.

### Rendered output

```
Strategy           Init      Value        PnL    PnL%    Tf   Int
-----------------------------------------------------------------
hl-rsi-btc      $ 1,000    $ 1,050      $ +50   +5.0%    1h   10m
hl-sma-eth      $ 5,000    $ 4,800     $ -200   -4.0%    4h    1h
spot-mom-btc    $ 2,000    $ 2,100     $ +100   +5.0%     —    1h
-----------------------------------------------------------------
TOTAL           $ 8,000    $ 7,950      $ -50   -0.6%
```

### Changes

- `discord.go` — `formatInterval(seconds int) string` helper (`60→1m`, `600→10m`, `3600→1h`, `86400→1d`, `≤0→—`); `extractTimeframe(sc StrategyConfig) string` returns `Args[2]` for perps/futures/OKX-swap (skipping `--` flags) or `—` for spot/options; `botInfo` gains `timeframe` and `interval` fields; `FormatCategorySummary` takes a new `globalIntervalSeconds int` parameter used when a strategy has no per-strategy `IntervalSeconds` override; `writeCatTable` renders `Tf` and `Int` as separate right-aligned columns at the end of both the wallet and non-wallet variants.
- `main.go` — all four `FormatCategorySummary` call sites pass `cfg.IntervalSeconds`.
- `discord_test.go` — existing calls updated with the new `globalIntervalSeconds` arg; `TestFormatInterval` (seconds → short string), `TestExtractTimeframe` (perps/futures/spot/options/flag-skipping), `TestFormatCategorySummary_TfIntColumn` (per-strategy override), `TestFormatCategorySummary_TfIntGlobalFallback` (global fallback for spot).

Closes #237

## Test plan
- [x] `go build .` in `scheduler/`
- [x] `go test ./...` — all tests pass
- [x] Rendered sample table verified column-aligned at 65 chars (non-wallet) and 74 chars (wallet variant)

---
Generated with: Claude Opus 4.6 | Effort: medium