### PR TITLE
fix(discord): chunk category summary table at 20 rows

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -698,23 +698,10 @@ func formatInterval(seconds int) string {
 	return fmt.Sprintf("%ds", seconds)
 }
 
-// writeCatTable writes a monospace code-block table to sb.
-// When showWalletPct is true, an extra "Wallet%" column is rendered for shared-wallet strategies.
-func writeCatTable(sb *strings.Builder, bots []botInfo, totalValue, totalPnl, totalPnlPct float64, showWalletPct bool) {
-	if len(bots) == 0 {
-		return
-	}
-	var totalInit float64
-	for _, bot := range bots {
-		totalInit += bot.initialCap
-	}
-	writeCatTablePartial(sb, bots, showWalletPct, true, totalInit, totalValue, totalPnl, totalPnlPct)
-}
-
 // writeCatTablePartial writes a single code-block table containing the supplied
 // bots. When includeTotals is true the trailing TOTAL row is appended using the
 // supplied totals (which should be computed from the FULL bot list, not just
-// this chunk). Used by writeCatTable and writeCatTableChunks.
+// this chunk). Used by writeCatTableChunks.
 func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, includeTotals bool, totalInit, totalValue, totalPnl, totalPnlPct float64) {
 	if len(bots) == 0 {
 		return

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -220,6 +220,11 @@ const discordCharLimit = 2000
 // discordSplitThreshold is the soft limit at which we start splitting messages.
 const discordSplitThreshold = 1980
 
+// catTableMaxRows caps how many strategy rows render per Discord message before
+// the table is continued in a follow-up message. With 20 rows the rendered table
+// (including header/sep/totals) stays comfortably under the 2000-char limit.
+const catTableMaxRows = 20
+
 // FormatCategorySummary creates Discord messages for a set of strategies sharing a channel.
 // Returns a slice of messages; when the content exceeds Discord's 2000-char limit,
 // the position list is split across multiple messages.
@@ -399,9 +404,27 @@ func FormatCategorySummary(
 	if totalInitCap > 0 {
 		totalPnlPct = (totalPnl / totalInitCap) * 100
 	}
-	writeCatTable(&sb, tableBots, filteredValue, totalPnl, totalPnlPct, hasSharedWallet)
+
+	// Render the strategy table in chunks of catTableMaxRows. The first chunk
+	// is appended to the in-message header; any extra chunks become standalone
+	// continuation messages so the table never overflows the 2000-char limit.
+	tableChunks := writeCatTableChunks(tableBots, filteredValue, totalPnl, totalPnlPct, hasSharedWallet)
+	if len(tableChunks) > 0 {
+		sb.WriteString(tableChunks[0])
+	}
 
 	header := sb.String()
+
+	var continuationTables []string
+	for i := 1; i < len(tableChunks); i++ {
+		rowStart := i*catTableMaxRows + 1
+		rowEnd := i*catTableMaxRows + catTableMaxRows
+		if rowEnd > len(tableBots) {
+			rowEnd = len(tableBots)
+		}
+		label := fmt.Sprintf("📊 **Strategies (cont'd %d–%d/%d)**", rowStart, rowEnd, len(tableBots))
+		continuationTables = append(continuationTables, label+tableChunks[i])
+	}
 
 	// Collect position lines.
 	totalOpenPos := 0
@@ -425,13 +448,32 @@ func FormatCategorySummary(
 		tradeLines = append(tradeLines, fmt.Sprintf("• %s", td))
 	}
 
-	return splitCategorySummary(header, totalOpenPos, posLines, tradeLines)
+	return splitCategorySummary(header, totalOpenPos, posLines, tradeLines, continuationTables)
 }
 
 // splitCategorySummary assembles the header, position lines, and trade lines into
 // one or more Discord messages, splitting at logical boundaries to stay under the
-// 2000-char Discord limit.
-func splitCategorySummary(header string, totalOpenPos int, posLines []string, tradeLines []string) []string {
+// 2000-char Discord limit. continuationTables are extra strategy-table chunks
+// (already formatted as their own code blocks) that get inserted right after the
+// first message so the rest of the table is the very next thing the user sees.
+func splitCategorySummary(header string, totalOpenPos int, posLines []string, tradeLines []string, continuationTables []string) []string {
+	msgs := splitCategorySummaryCore(header, totalOpenPos, posLines, tradeLines)
+	if len(continuationTables) == 0 {
+		return msgs
+	}
+	// Insert continuation table chunks immediately after the first message so
+	// readers see the rest of the strategy table before any position overflow.
+	out := make([]string, 0, len(msgs)+len(continuationTables))
+	out = append(out, msgs[0])
+	out = append(out, continuationTables...)
+	out = append(out, msgs[1:]...)
+	return out
+}
+
+// splitCategorySummaryCore builds the message list without considering
+// strategy-table continuation chunks. Callers wanting continuation handling
+// should call splitCategorySummary instead.
+func splitCategorySummaryCore(header string, totalOpenPos int, posLines []string, tradeLines []string) []string {
 	var sb strings.Builder
 	sb.WriteString(header)
 
@@ -662,12 +704,26 @@ func writeCatTable(sb *strings.Builder, bots []botInfo, totalValue, totalPnl, to
 	if len(bots) == 0 {
 		return
 	}
+	var totalInit float64
+	for _, bot := range bots {
+		totalInit += bot.initialCap
+	}
+	writeCatTablePartial(sb, bots, showWalletPct, true, totalInit, totalValue, totalPnl, totalPnlPct)
+}
+
+// writeCatTablePartial writes a single code-block table containing the supplied
+// bots. When includeTotals is true the trailing TOTAL row is appended using the
+// supplied totals (which should be computed from the FULL bot list, not just
+// this chunk). Used by writeCatTable and writeCatTableChunks.
+func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, includeTotals bool, totalInit, totalValue, totalPnl, totalPnlPct float64) {
+	if len(bots) == 0 {
+		return
+	}
 	sb.WriteString("\n```\n")
 	if showWalletPct {
 		const sep = "--------------------------------------------------------------------------"
 		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Wallet%", "Tf", "Int"))
 		sb.WriteString(sep + "\n")
-		var totalInit float64
 		for _, bot := range bots {
 			label := bot.id
 			if len(label) > 12 {
@@ -681,20 +737,20 @@ func writeCatTable(sb *strings.Builder, bots []botInfo, totalValue, totalPnl, to
 			if bot.walletPct > 0 {
 				wpStr = fmt.Sprintf("%.1f%%", bot.walletPct)
 			}
-			totalInit += bot.initialCap
 			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s %5s %5s\n", label, initStr, valStr, pnlStr, pctStr, wpStr, bot.timeframe, bot.interval))
 		}
-		sb.WriteString(sep + "\n")
-		totValStr := "$ " + fmtComma(totalValue)
-		totInitStr := "$ " + fmtComma(totalInit)
-		totPnlStr := fmtPnl(totalPnl)
-		totPctStr := fmtPnlPct(totalPnlPct)
-		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s %5s %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "100.0%", "", ""))
+		if includeTotals {
+			sb.WriteString(sep + "\n")
+			totValStr := "$ " + fmtComma(totalValue)
+			totInitStr := "$ " + fmtComma(totalInit)
+			totPnlStr := fmtPnl(totalPnl)
+			totPctStr := fmtPnlPct(totalPnlPct)
+			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s %5s %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "100.0%", "", ""))
+		}
 	} else {
 		const sep = "-----------------------------------------------------------------"
 		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Tf", "Int"))
 		sb.WriteString(sep + "\n")
-		var totalInit float64
 		for _, bot := range bots {
 			label := bot.id
 			if len(label) > 12 {
@@ -704,17 +760,44 @@ func writeCatTable(sb *strings.Builder, bots []botInfo, totalValue, totalPnl, to
 			initStr := "$ " + fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
 			pctStr := fmtPnlPct(bot.pnlPct)
-			totalInit += bot.initialCap
 			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %5s %5s\n", label, initStr, valStr, pnlStr, pctStr, bot.timeframe, bot.interval))
 		}
-		sb.WriteString(sep + "\n")
-		totValStr := "$ " + fmtComma(totalValue)
-		totInitStr := "$ " + fmtComma(totalInit)
-		totPnlStr := fmtPnl(totalPnl)
-		totPctStr := fmtPnlPct(totalPnlPct)
-		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %5s %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", ""))
+		if includeTotals {
+			sb.WriteString(sep + "\n")
+			totValStr := "$ " + fmtComma(totalValue)
+			totInitStr := "$ " + fmtComma(totalInit)
+			totPnlStr := fmtPnl(totalPnl)
+			totPctStr := fmtPnlPct(totalPnlPct)
+			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %5s %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", ""))
+		}
 	}
 	sb.WriteString("```\n")
+}
+
+// writeCatTableChunks splits bots into catTableMaxRows-sized chunks and returns
+// one rendered code-block table per chunk. The TOTAL row appears only in the
+// final chunk so totals always show against the same numbers regardless of how
+// the table was split. Returns nil if bots is empty.
+func writeCatTableChunks(bots []botInfo, totalValue, totalPnl, totalPnlPct float64, showWalletPct bool) []string {
+	if len(bots) == 0 {
+		return nil
+	}
+	var totalInit float64
+	for _, bot := range bots {
+		totalInit += bot.initialCap
+	}
+	var chunks []string
+	for start := 0; start < len(bots); start += catTableMaxRows {
+		end := start + catTableMaxRows
+		if end > len(bots) {
+			end = len(bots)
+		}
+		isLast := end == len(bots)
+		var sb strings.Builder
+		writeCatTablePartial(&sb, bots[start:end], showWalletPct, isLast, totalInit, totalValue, totalPnl, totalPnlPct)
+		chunks = append(chunks, sb.String())
+	}
+	return chunks
 }
 
 func fmtPnl(pnl float64) string {

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -706,7 +706,7 @@ func TestSplitCategorySummary_SingleMessage(t *testing.T) {
 	posLines := []string{"pos1", "pos2"}
 	tradeLines := []string{"• trade1"}
 
-	msgs := splitCategorySummary(header, 2, posLines, tradeLines)
+	msgs := splitCategorySummary(header, 2, posLines, tradeLines, nil)
 	if len(msgs) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(msgs))
 	}
@@ -718,12 +718,102 @@ func TestSplitCategorySummary_SingleMessage(t *testing.T) {
 	}
 }
 
+func TestFormatCategorySummary_LargeTableChunked(t *testing.T) {
+	// Reproduces #249: 28 perps strategies on a single asset produces a table
+	// that, prior to the fix, exceeded Discord's 2000-char limit and was silently
+	// truncated mid-code-block. The fix caps the table at 20 rows per message and
+	// emits the rest as continuation messages, each wrapped in its own code block.
+	const stratCount = 28
+	strats := make([]StrategyConfig, stratCount)
+	strategies := make(map[string]*StrategyState, stratCount)
+	for i := 0; i < stratCount; i++ {
+		id := fmt.Sprintf("hl-strat%02d-btc", i)
+		strats[i] = StrategyConfig{ID: id, Type: "perps", Platform: "hyperliquid", Capital: 500, Args: []string{fmt.Sprintf("strat%02d", i), "BTC", "1h"}}
+		strategies[id] = &StrategyState{Cash: 500}
+	}
+	state := &AppState{Strategies: strategies}
+	prices := map[string]float64{"BTC/USDT": 51000}
+
+	msgs := FormatCategorySummary(1, 0, stratCount, 0, 14000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+
+	if len(msgs) < 2 {
+		t.Fatalf("expected at least 2 messages for %d strategies, got %d", stratCount, len(msgs))
+	}
+	for i, m := range msgs {
+		if len(m) > discordCharLimit {
+			t.Errorf("msg[%d] exceeds Discord limit: %d chars", i, len(m))
+		}
+		// Every message containing table content must have a closed code block.
+		if strings.Count(m, "```")%2 != 0 {
+			t.Errorf("msg[%d] has unbalanced code-block fences:\n%s", i, m)
+		}
+	}
+
+	// First message holds rows 1–20; the totals row stays with the LAST table chunk.
+	if !strings.Contains(msgs[0], "hl-strat00-b") {
+		t.Errorf("first message should contain first strategy row, got:\n%s", msgs[0])
+	}
+	if !strings.Contains(msgs[0], "hl-strat19-b") {
+		t.Errorf("first message should contain 20th strategy row, got:\n%s", msgs[0])
+	}
+	if strings.Contains(msgs[0], "TOTAL") {
+		t.Errorf("first message should NOT contain TOTAL row when table is split, got:\n%s", msgs[0])
+	}
+
+	// Second message is the table continuation: own code block + label + remaining rows + TOTAL.
+	if !strings.Contains(msgs[1], "cont'd") {
+		t.Errorf("second message should be the continuation table label, got:\n%s", msgs[1])
+	}
+	if !strings.Contains(msgs[1], "```") {
+		t.Errorf("continuation table must be wrapped in a code block, got:\n%s", msgs[1])
+	}
+	if !strings.Contains(msgs[1], "hl-strat20-b") {
+		t.Errorf("continuation should contain row 21, got:\n%s", msgs[1])
+	}
+	if !strings.Contains(msgs[1], "hl-strat27-b") {
+		t.Errorf("continuation should contain final row 28, got:\n%s", msgs[1])
+	}
+	if !strings.Contains(msgs[1], "TOTAL") {
+		t.Errorf("final continuation chunk must contain the TOTAL row, got:\n%s", msgs[1])
+	}
+
+	// All 28 strategy rows should appear across the messages.
+	all := strings.Join(msgs, "\n")
+	for i := 0; i < stratCount; i++ {
+		want := fmt.Sprintf("hl-strat%02d-b", i)
+		if !strings.Contains(all, want) {
+			t.Errorf("strategy row %s missing from messages", want)
+		}
+	}
+}
+
+func TestSplitCategorySummary_ContinuationTablesInserted(t *testing.T) {
+	// Continuation tables should be spliced in immediately after the first message.
+	header := "Header line\n"
+	posLines := []string{"pos1", "pos2"}
+	conts := []string{"```\nchunk2\n```\n", "```\nchunk3\n```\n"}
+
+	msgs := splitCategorySummary(header, 2, posLines, nil, conts)
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages (1 main + 2 continuation tables), got %d", len(msgs))
+	}
+	if !strings.Contains(msgs[0], "Header line") {
+		t.Errorf("msg[0] should contain header, got: %s", msgs[0])
+	}
+	if msgs[1] != conts[0] {
+		t.Errorf("msg[1] should be first continuation table, got: %s", msgs[1])
+	}
+	if msgs[2] != conts[1] {
+		t.Errorf("msg[2] should be second continuation table, got: %s", msgs[2])
+	}
+}
+
 func TestSplitCategorySummary_MultiMessage(t *testing.T) {
 	// Create a header that uses ~1900 chars, leaving very little room for positions.
 	header := strings.Repeat("x", 1900) + "\n"
 	posLines := []string{"position-line-1-aaaa", "position-line-2-bbbb", "position-line-3-cccc"}
 
-	msgs := splitCategorySummary(header, 3, posLines, nil)
+	msgs := splitCategorySummary(header, 3, posLines, nil, nil)
 	if len(msgs) < 2 {
 		t.Fatalf("expected multiple messages with large header, got %d", len(msgs))
 	}


### PR DESCRIPTION
Closes #249

## Summary
- Cap the strategy table at 20 rows per Discord message so channels with >20 strategies (e.g. Hyperliquid paper with 28 per asset) no longer exceed Discord's 2000-char limit and get silently truncated.
- Extra rows render as standalone continuation messages, each wrapped in its own code block with a `Strategies (cont'd N–M/total)` label, inserted immediately after the first message.
- The TOTAL row stays with the final table chunk so totals always show against the same numbers regardless of how the table was split.

## Test plan
- [x] `go build .`
- [x] `go test ./...` — all discord tests pass
- [x] New `TestFormatCategorySummary_LargeTableChunked` covers 28-strategy repro
- [x] New `TestSplitCategorySummary_ContinuationTablesInserted` covers splice ordering

🤖 Generated with [Claude Code](https://claude.ai/code)