### PR TITLE
feat: make leaderboard top-N configurable via discord.leaderboard_top_n

### DIFF
--- a/scheduler/config.example.json
+++ b/scheduler/config.example.json
@@ -73,6 +73,7 @@
       "hyperliquid": ""
     },
     "spot_summary_freq": "hourly",
-    "options_summary_freq": "per_check"
+    "options_summary_freq": "per_check",
+    "leaderboard_top_n": 5
   }
 }

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -20,6 +20,7 @@ type DiscordConfig struct {
 	ChannelPaperTrades bool              `json:"channel_paper_trades,omitempty"` // post paper trade alerts to platform channel
 	ChannelLiveTrades  bool              `json:"channel_live_trades,omitempty"`  // post live trade alerts to platform channel
 	Channels           map[string]string `json:"channels"`                       // keyed by platform or type ("spot", "hyperliquid", "deribit", etc.)
+	LeaderboardTopN    int               `json:"leaderboard_top_n,omitempty"`    // number of entries shown in leaderboard messages (default 5)
 }
 
 // TelegramConfig holds Telegram notification settings.

--- a/scheduler/leaderboard.go
+++ b/scheduler/leaderboard.go
@@ -23,8 +23,12 @@ type LeaderboardEntry struct {
 
 // LeaderboardData is the pre-computed leaderboard written to disk each cycle.
 type LeaderboardData struct {
-	Timestamp time.Time         `json:"timestamp"`
-	Messages  map[string]string `json:"messages"` // keyed by category: "spot", "perps", "options", "futures", "top10", "bottom10"
+	Timestamp time.Time `json:"timestamp"`
+	// Messages is keyed by category: "spot", "perps", "options", "futures",
+	// "top10", "bottom10". The "top10"/"bottom10" keys are retained for
+	// backwards compatibility with the on-disk leaderboard.json schema; the
+	// entry count is actually controlled by Discord.LeaderboardTopN.
+	Messages map[string]string `json:"messages"`
 }
 
 // leaderboardPath returns the path for the pre-computed leaderboard file,
@@ -128,16 +132,12 @@ func PrecomputeLeaderboard(cfg *Config, state *AppState, prices map[string]float
 }
 
 // formatLeaderboardMessage formats a single category leaderboard message.
-// topN controls how many entries appear in the table (default 5 when <= 0).
+// Callers are responsible for passing a positive topN (see leaderboardTopN).
 func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, showType bool, topN int) string {
 	// Sort by PnL% descending.
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].PnLPct > entries[j].PnLPct
 	})
-
-	if topN <= 0 {
-		topN = 5
-	}
 
 	dateStr := time.Now().Format("January 2, 2006")
 
@@ -234,9 +234,6 @@ func formatAllTimeMessage(icon, title string, entries []LeaderboardEntry, isTop 
 		})
 	}
 
-	if topN <= 0 {
-		topN = 5
-	}
 	n := topN
 	if len(sorted) < n {
 		n = len(sorted)
@@ -296,9 +293,10 @@ func PostLeaderboard(cfg *Config, notifier *MultiNotifier) error {
 	return nil
 }
 
-// FormatPlatformTop10 builds a top-10 summary message for strategies on a given platform,
-// sorted by PnL% descending. Returns "" if no strategies exist for that platform.
-func FormatPlatformTop10(platform, icon, title string, cfg *Config, state *AppState, prices map[string]float64) string {
+// FormatPlatformTopN builds a top-N summary message for strategies on a given platform,
+// sorted by PnL% descending. N is controlled by Discord.LeaderboardTopN (default 5).
+// Returns "" if no strategies exist for that platform.
+func FormatPlatformTopN(platform, icon, title string, cfg *Config, state *AppState, prices map[string]float64) string {
 	var entries []LeaderboardEntry
 	for _, sc := range cfg.Strategies {
 		if sc.Platform != platform {
@@ -343,10 +341,12 @@ func FormatPlatformTop10(platform, icon, title string, cfg *Config, state *AppSt
 	return formatLeaderboardMessage(icon, title, entries[:n], false, n)
 }
 
-// FormatHyperliquidTop10 builds a top-10 summary message for hyperliquid strategies,
-// sorted by PnL% descending. Returns "" if no hyperliquid strategies exist.
-func FormatHyperliquidTop10(cfg *Config, state *AppState, prices map[string]float64) string {
-	return FormatPlatformTop10("hyperliquid", "⚡", "Hyperliquid Top 10", cfg, state, prices)
+// FormatHyperliquidTopN builds a top-N summary message for hyperliquid strategies,
+// sorted by PnL% descending. N is controlled by Discord.LeaderboardTopN (default 5).
+// Returns "" if no hyperliquid strategies exist.
+func FormatHyperliquidTopN(cfg *Config, state *AppState, prices map[string]float64) string {
+	title := fmt.Sprintf("Hyperliquid Top %d", leaderboardTopN(cfg))
+	return FormatPlatformTopN("hyperliquid", "⚡", title, cfg, state, prices)
 }
 
 // fmtSignedDollar formats a dollar value with +/- prefix.

--- a/scheduler/leaderboard.go
+++ b/scheduler/leaderboard.go
@@ -34,6 +34,14 @@ func leaderboardPath(cfg *Config) string {
 	return filepath.Join(dir, "leaderboard.json")
 }
 
+// leaderboardTopN returns the configured top-N count, defaulting to 5 when unset.
+func leaderboardTopN(cfg *Config) int {
+	if cfg.Discord.LeaderboardTopN > 0 {
+		return cfg.Discord.LeaderboardTopN
+	}
+	return 5
+}
+
 // PrecomputeLeaderboard builds leaderboard messages from current state and writes
 // them to leaderboard.json. Called after each cycle's state save so the data is
 // always fresh. The cron job just reads and posts this file.
@@ -69,6 +77,7 @@ func PrecomputeLeaderboard(cfg *Config, state *AppState, prices map[string]float
 	}
 
 	messages := make(map[string]string)
+	topN := leaderboardTopN(cfg)
 
 	// Per-category leaderboards.
 	categories := []struct {
@@ -87,13 +96,13 @@ func PrecomputeLeaderboard(cfg *Config, state *AppState, prices map[string]float
 		if len(entries) == 0 {
 			continue
 		}
-		messages[cat.key] = formatLeaderboardMessage(cat.icon, cat.title, entries, false)
+		messages[cat.key] = formatLeaderboardMessage(cat.icon, cat.title, entries, false, topN)
 	}
 
-	// All-time top 10 and bottom 10 across all categories.
+	// All-time top-N and bottom-N across all categories.
 	if len(allEntries) > 0 {
-		messages["top10"] = formatAllTimeMessage("🏆", "Top 10 All-Time Performers", allEntries, true)
-		messages["bottom10"] = formatAllTimeMessage("💀", "Bottom 10 All-Time Performers", allEntries, false)
+		messages["top10"] = formatAllTimeMessage("🏆", "Top All-Time Performers", allEntries, true, topN)
+		messages["bottom10"] = formatAllTimeMessage("💀", "Bottom All-Time Performers", allEntries, false, topN)
 	}
 
 	data := LeaderboardData{
@@ -119,11 +128,16 @@ func PrecomputeLeaderboard(cfg *Config, state *AppState, prices map[string]float
 }
 
 // formatLeaderboardMessage formats a single category leaderboard message.
-func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, showType bool) string {
+// topN controls how many entries appear in the table (default 5 when <= 0).
+func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, showType bool, topN int) string {
 	// Sort by PnL% descending.
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].PnLPct > entries[j].PnLPct
 	})
+
+	if topN <= 0 {
+		topN = 5
+	}
 
 	dateStr := time.Now().Format("January 2, 2006")
 
@@ -153,10 +167,10 @@ func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, sh
 		totalPnlPct = (totalPnl / totalCapital) * 100
 	}
 
-	// Show top 5.
+	// Show top N entries.
 	top := entries
-	if len(top) > 5 {
-		top = top[:5]
+	if len(top) > topN {
+		top = top[:topN]
 	}
 
 	const sep = "--------------------------------------------------------------------"
@@ -205,11 +219,12 @@ func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, sh
 }
 
 // formatAllTimeMessage formats the top/bottom all-time leaderboard.
-func formatAllTimeMessage(icon, title string, entries []LeaderboardEntry, topN bool) string {
+// isTop controls sort direction; topN controls how many entries to show.
+func formatAllTimeMessage(icon, title string, entries []LeaderboardEntry, isTop bool, topN int) string {
 	// Sort: top = descending PnL%, bottom = ascending PnL%.
 	sorted := make([]LeaderboardEntry, len(entries))
 	copy(sorted, entries)
-	if topN {
+	if isTop {
 		sort.Slice(sorted, func(i, j int) bool {
 			return sorted[i].PnLPct > sorted[j].PnLPct
 		})
@@ -219,13 +234,16 @@ func formatAllTimeMessage(icon, title string, entries []LeaderboardEntry, topN b
 		})
 	}
 
-	n := 10
+	if topN <= 0 {
+		topN = 5
+	}
+	n := topN
 	if len(sorted) < n {
 		n = len(sorted)
 	}
 	top := sorted[:n]
 
-	return formatLeaderboardMessage(icon, title, top, true)
+	return formatLeaderboardMessage(icon, title, top, true, n)
 }
 
 // LoadLeaderboard reads the pre-computed leaderboard from disk.
@@ -312,16 +330,17 @@ func FormatPlatformTop10(platform, icon, title string, cfg *Config, state *AppSt
 		return ""
 	}
 
-	// Sort by PnL% descending, take top 10.
+	// Sort by PnL% descending, take top N.
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].PnLPct > entries[j].PnLPct
 	})
-	n := 10
+	topN := leaderboardTopN(cfg)
+	n := topN
 	if len(entries) < n {
 		n = len(entries)
 	}
 
-	return formatLeaderboardMessage(icon, title, entries[:n], false)
+	return formatLeaderboardMessage(icon, title, entries[:n], false, n)
 }
 
 // FormatHyperliquidTop10 builds a top-10 summary message for hyperliquid strategies,

--- a/scheduler/leaderboard_test.go
+++ b/scheduler/leaderboard_test.go
@@ -188,7 +188,7 @@ func TestFmtSignedPct(t *testing.T) {
 	}
 }
 
-func TestFormatHyperliquidTop10(t *testing.T) {
+func TestFormatHyperliquidTopN(t *testing.T) {
 	cfg := &Config{
 		Strategies: []StrategyConfig{
 			{ID: "hl-sma-btc", Type: "perps", Capital: 1000, Platform: "hyperliquid", Args: []string{"sma_crossover", "BTC/USDT", "1h"}},
@@ -218,13 +218,14 @@ func TestFormatHyperliquidTop10(t *testing.T) {
 	}
 
 	prices := map[string]float64{"BTC/USDT": 50000, "ETH/USDT": 3000, "SOL/USDT": 150}
-	msg := FormatHyperliquidTop10(cfg, state, prices)
+	msg := FormatHyperliquidTopN(cfg, state, prices)
 
 	if msg == "" {
 		t.Fatal("Expected non-empty message")
 	}
-	if !containsStr(msg, "Hyperliquid Top 10") {
-		t.Error("Message should contain title")
+	// Default LeaderboardTopN is 5, so title should be "Hyperliquid Top 5".
+	if !containsStr(msg, "Hyperliquid Top 5") {
+		t.Error("Message should contain dynamic title reflecting default topN=5")
 	}
 	if !containsStr(msg, "hl-sma-btc") {
 		t.Error("Message should contain hl-sma-btc")
@@ -245,7 +246,7 @@ func TestFormatHyperliquidTop10(t *testing.T) {
 	}
 }
 
-func TestFormatHyperliquidTop10_NoHLStrategies(t *testing.T) {
+func TestFormatHyperliquidTopN_NoHLStrategies(t *testing.T) {
 	cfg := &Config{
 		Strategies: []StrategyConfig{
 			{ID: "sma-btc", Type: "spot", Capital: 1000, Platform: "binanceus"},
@@ -254,14 +255,14 @@ func TestFormatHyperliquidTop10_NoHLStrategies(t *testing.T) {
 	state := NewAppState()
 	state.Strategies["sma-btc"] = &StrategyState{Cash: 1100, InitialCapital: 1000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}, TradeHistory: []Trade{}}
 
-	msg := FormatHyperliquidTop10(cfg, state, nil)
+	msg := FormatHyperliquidTopN(cfg, state, nil)
 	if msg != "" {
 		t.Errorf("Expected empty message when no HL strategies, got %q", msg)
 	}
 }
 
-func TestFormatHyperliquidTop10_SortOrder(t *testing.T) {
-	// Create 12 hyperliquid strategies to verify only top 10 are included.
+func TestFormatHyperliquidTopN_SortOrder(t *testing.T) {
+	// Create 12 hyperliquid strategies to verify only topN are included.
 	var strats []StrategyConfig
 	for i := 0; i < 12; i++ {
 		strats = append(strats, StrategyConfig{
@@ -272,7 +273,11 @@ func TestFormatHyperliquidTop10_SortOrder(t *testing.T) {
 			Args:     []string{"sma", "BTC/USDT", "1h"},
 		})
 	}
-	cfg := &Config{Strategies: strats}
+	// Explicitly set LeaderboardTopN=10 to preserve original test intent.
+	cfg := &Config{
+		Strategies: strats,
+		Discord:    DiscordConfig{LeaderboardTopN: 10},
+	}
 
 	state := NewAppState()
 	for i, sc := range cfg.Strategies {
@@ -282,11 +287,15 @@ func TestFormatHyperliquidTop10_SortOrder(t *testing.T) {
 		state.Strategies[sc.ID] = ss
 	}
 
-	msg := FormatHyperliquidTop10(cfg, state, nil)
+	msg := FormatHyperliquidTopN(cfg, state, nil)
 	if msg == "" {
 		t.Fatal("Expected non-empty message")
 	}
 
+	// Dynamic title should reflect configured topN=10.
+	if !containsStr(msg, "Hyperliquid Top 10") {
+		t.Error("Message should contain dynamic title reflecting configured topN=10")
+	}
 	// The worst strategy (hl-s00-btc at -10%) should NOT appear (only top 10 of 12).
 	if containsStr(msg, "hl-s00-btc") {
 		t.Error("Worst strategy should be excluded from top 10")
@@ -300,7 +309,7 @@ func TestFormatHyperliquidTop10_SortOrder(t *testing.T) {
 	}
 }
 
-func TestFormatPlatformTop10(t *testing.T) {
+func TestFormatPlatformTopN(t *testing.T) {
 	cfg := &Config{
 		Strategies: []StrategyConfig{
 			{ID: "hl-sma-btc", Type: "perps", Capital: 1000, Platform: "hyperliquid", Args: []string{"sma_crossover", "BTC/USDT", "1h"}},
@@ -332,7 +341,7 @@ func TestFormatPlatformTop10(t *testing.T) {
 	prices := map[string]float64{"BTC/USDT": 50000, "ETH/USDT": 3000}
 
 	// Test Deribit platform leaderboard.
-	msg := FormatPlatformTop10("deribit", "🎯", "Deribit Top 10", cfg, state, prices)
+	msg := FormatPlatformTopN("deribit", "🎯", "Deribit Top 10", cfg, state, prices)
 	if msg == "" {
 		t.Fatal("Expected non-empty message for deribit")
 	}
@@ -357,18 +366,19 @@ func TestFormatPlatformTop10(t *testing.T) {
 	}
 
 	// Test platform with no strategies returns empty.
-	msg = FormatPlatformTop10("okx", "🔶", "OKX Top 10", cfg, state, prices)
+	msg = FormatPlatformTopN("okx", "🔶", "OKX Top 10", cfg, state, prices)
 	if msg != "" {
 		t.Errorf("Expected empty message for platform with no strategies, got %q", msg)
 	}
 
-	// Test that FormatHyperliquidTop10 still works via the wrapper.
-	hlMsg := FormatHyperliquidTop10(cfg, state, prices)
+	// Test that FormatHyperliquidTopN still works via the wrapper.
+	hlMsg := FormatHyperliquidTopN(cfg, state, prices)
 	if hlMsg == "" {
-		t.Fatal("Expected non-empty message from FormatHyperliquidTop10 wrapper")
+		t.Fatal("Expected non-empty message from FormatHyperliquidTopN wrapper")
 	}
-	if !containsStr(hlMsg, "Hyperliquid Top 10") {
-		t.Error("Wrapper message should contain Hyperliquid title")
+	// Default topN is 5, so wrapper title should reflect "Hyperliquid Top 5".
+	if !containsStr(hlMsg, "Hyperliquid Top 5") {
+		t.Error("Wrapper message should contain Hyperliquid Top 5 title")
 	}
 	if !containsStr(hlMsg, "hl-sma-btc") {
 		t.Error("Wrapper message should contain hl-sma-btc")
@@ -457,6 +467,40 @@ func TestPrecomputeLeaderboardTopN(t *testing.T) {
 	// sma-s04 is 4th — should NOT appear in top 3.
 	if containsStr(spotMsg, "sma-s04") {
 		t.Error("4th strategy sma-s04 should not appear when top_n=3")
+	}
+
+	// All-time top/bottom messages use a different code path
+	// (formatAllTimeMessage) and must also respect LeaderboardTopN.
+	top10Msg := lb.Messages["top10"]
+	if top10Msg == "" {
+		t.Fatal("Expected non-empty top10 all-time message")
+	}
+	// Top 3 by PnL%: sma-s07, sma-s06, sma-s05.
+	if !containsStr(top10Msg, "sma-s07") {
+		t.Error("top10 all-time should contain sma-s07 when top_n=3")
+	}
+	if !containsStr(top10Msg, "sma-s05") {
+		t.Error("top10 all-time should contain sma-s05 when top_n=3")
+	}
+	// sma-s04 is 4th — should NOT appear.
+	if containsStr(top10Msg, "sma-s04") {
+		t.Error("top10 all-time should not contain sma-s04 when top_n=3")
+	}
+
+	bottom10Msg := lb.Messages["bottom10"]
+	if bottom10Msg == "" {
+		t.Fatal("Expected non-empty bottom10 all-time message")
+	}
+	// Bottom 3 by PnL%: sma-s00, sma-s01, sma-s02.
+	if !containsStr(bottom10Msg, "sma-s00") {
+		t.Error("bottom10 all-time should contain sma-s00 when top_n=3")
+	}
+	if !containsStr(bottom10Msg, "sma-s02") {
+		t.Error("bottom10 all-time should contain sma-s02 when top_n=3")
+	}
+	// sma-s03 is 4th-worst — should NOT appear.
+	if containsStr(bottom10Msg, "sma-s03") {
+		t.Error("bottom10 all-time should not contain sma-s03 when top_n=3")
 	}
 }
 

--- a/scheduler/leaderboard_test.go
+++ b/scheduler/leaderboard_test.go
@@ -375,6 +375,91 @@ func TestFormatPlatformTop10(t *testing.T) {
 	}
 }
 
+// TestLeaderboardTopNDefault verifies that leaderboardTopN returns 5 when unset.
+func TestLeaderboardTopNDefault(t *testing.T) {
+	cfg := &Config{}
+	if got := leaderboardTopN(cfg); got != 5 {
+		t.Errorf("leaderboardTopN with zero value = %d, want 5", got)
+	}
+}
+
+// TestLeaderboardTopNConfigured verifies that leaderboardTopN respects the configured value.
+func TestLeaderboardTopNConfigured(t *testing.T) {
+	cfg := &Config{Discord: DiscordConfig{LeaderboardTopN: 10}}
+	if got := leaderboardTopN(cfg); got != 10 {
+		t.Errorf("leaderboardTopN with configured value = %d, want 10", got)
+	}
+}
+
+// TestLeaderboardTopNNegative verifies that leaderboardTopN ignores negative values.
+func TestLeaderboardTopNNegative(t *testing.T) {
+	cfg := &Config{Discord: DiscordConfig{LeaderboardTopN: -1}}
+	if got := leaderboardTopN(cfg); got != 5 {
+		t.Errorf("leaderboardTopN with negative value = %d, want 5", got)
+	}
+}
+
+// TestPrecomputeLeaderboardTopN verifies that LeaderboardTopN limits the entries shown.
+func TestPrecomputeLeaderboardTopN(t *testing.T) {
+	dir := t.TempDir()
+	stateFile := fmt.Sprintf("%s/state.json", dir)
+
+	// Create 8 spot strategies.
+	var strats []StrategyConfig
+	for i := 0; i < 8; i++ {
+		strats = append(strats, StrategyConfig{
+			ID:       fmt.Sprintf("sma-s%02d", i),
+			Type:     "spot",
+			Capital:  1000,
+			Platform: "binanceus",
+			Args:     []string{"sma_crossover", "BTC/USDT", "1h"},
+		})
+	}
+
+	cfg := &Config{
+		StateFile:  stateFile,
+		Strategies: strats,
+		Discord:    DiscordConfig{LeaderboardTopN: 3},
+	}
+
+	state := NewAppState()
+	for i, sc := range cfg.Strategies {
+		ss := NewStrategyState(sc)
+		ss.Cash = 1000 + float64(i)*10 // different PnL for each
+		state.Strategies[sc.ID] = ss
+	}
+
+	prices := map[string]float64{"BTC/USDT": 50000}
+	if err := PrecomputeLeaderboard(cfg, state, prices); err != nil {
+		t.Fatalf("PrecomputeLeaderboard failed: %v", err)
+	}
+
+	lb, err := LoadLeaderboard(cfg)
+	if err != nil {
+		t.Fatalf("LoadLeaderboard failed: %v", err)
+	}
+
+	spotMsg := lb.Messages["spot"]
+	if spotMsg == "" {
+		t.Fatal("Expected non-empty spot message")
+	}
+
+	// The best strategy (sma-s07) should appear (top 3).
+	if !containsStr(spotMsg, "sma-s07") {
+		t.Error("Best strategy sma-s07 should appear in top 3")
+	}
+	if !containsStr(spotMsg, "sma-s06") {
+		t.Error("Second-best strategy sma-s06 should appear in top 3")
+	}
+	if !containsStr(spotMsg, "sma-s05") {
+		t.Error("Third-best strategy sma-s05 should appear in top 3")
+	}
+	// sma-s04 is 4th — should NOT appear in top 3.
+	if containsStr(spotMsg, "sma-s04") {
+		t.Error("4th strategy sma-s04 should not appear when top_n=3")
+	}
+}
+
 func containsStr(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && findSubstring(s, substr))
 }

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -787,7 +787,7 @@ func main() {
 		// Periodic hyperliquid top-10 summary (#176).
 		var top10Msg string
 		if top10Freq > 0 && time.Since(state.LastTop10Summary) >= top10Freq {
-			top10Msg = FormatHyperliquidTop10(cfg, state, prices)
+			top10Msg = FormatHyperliquidTopN(cfg, state, prices)
 			if top10Msg != "" {
 				state.LastTop10Summary = time.Now().UTC()
 			}


### PR DESCRIPTION
Add `leaderboard_top_n` to `DiscordConfig` so users can control how many entries appear in leaderboard messages without editing code. Defaults to 5 when omitted.

Both per-category leaderboards and all-time top/bottom tables respect the setting.

Closes #246

Generated with [Claude Code](https://claude.ai/code)