### PR TITLE
Remove entry price from position summary lines

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -755,7 +755,7 @@ func collectPositions(stratID string, ss *StrategyState, prices map[string]float
 		if !pos.OpenedAt.IsZero() {
 			dateStr = fmt.Sprintf(" [%s]", pos.OpenedAt.Format("Jan 02 15:04"))
 		}
-		lines = append(lines, fmt.Sprintf("%s %s %s x%g @ $%.2f (%s$%.0f)%s", stratID, pos.Side, sym, pos.Quantity, pos.AvgCost, sign, pnl, dateStr))
+		lines = append(lines, fmt.Sprintf("%s %s %s x%g (%s$%.0f)%s", stratID, pos.Side, sym, pos.Quantity, sign, pnl, dateStr))
 	}
 	for key, opt := range ss.OptionPositions {
 		dateStr := ""


### PR DESCRIPTION
Remove `@ $AvgCost` from position line format in `collectPositions()` in `scheduler/discord.go`.

The entry price is redundant since the summary header already shows the current market price.

Closes #251

Generated with [Claude Code](https://claude.ai/code)