### PR TITLE
Include perps in notional-exposure price-watch set (#245)

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -311,17 +311,11 @@ func main() {
 			cycle, cycleStart.UTC().Format("2006-01-02 15:04:05 UTC"),
 			len(dueStrategies), len(cfg.Strategies))
 
-		// Collect symbols that need prices
-		symbolSet := make(map[string]bool)
-		for _, sc := range cfg.Strategies {
-			if sc.Type == "spot" && len(sc.Args) >= 2 {
-				symbolSet[sc.Args[1]] = true
-			}
-		}
-		symbols := make([]string, 0, len(symbolSet))
-		for s := range symbolSet {
-			symbols = append(symbols, s)
-		}
+		// Collect symbols that need prices. Spot strategies use the
+		// BinanceUS-formatted symbol directly; perps strategies use the base
+		// asset as their position key, so we fetch under a normalized
+		// "<base>/USDT" form and mirror the result back — #245.
+		symbols, perpsMirror := collectPriceSymbols(cfg.Strategies)
 
 		// Fetch current prices for portfolio valuation
 		prices := make(map[string]float64)
@@ -339,6 +333,7 @@ func main() {
 					fmt.Printf("[WARN] Skipping zero price for %s\n", sym)
 				}
 			}
+			mirrorPerpsPrices(prices, perpsMirror)
 			if len(prices) == 0 {
 				fmt.Printf("[CRITICAL] All prices are zero/missing — skipping cycle\n")
 				continue
@@ -936,17 +931,8 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, notifier
 		os.Exit(1)
 	}
 
-	// Collect symbols that need prices.
-	symbolSet := make(map[string]bool)
-	for _, sc := range cfg.Strategies {
-		if sc.Type == "spot" && len(sc.Args) >= 2 {
-			symbolSet[sc.Args[1]] = true
-		}
-	}
-	symbols := make([]string, 0, len(symbolSet))
-	for s := range symbolSet {
-		symbols = append(symbols, s)
-	}
+	// Collect symbols that need prices (spot + perps, #245).
+	symbols, perpsMirror := collectPriceSymbols(cfg.Strategies)
 
 	// Fetch current prices.
 	prices := make(map[string]float64)
@@ -961,6 +947,7 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, notifier
 				prices[sym] = price
 			}
 		}
+		mirrorPerpsPrices(prices, perpsMirror)
 	}
 
 	// Calculate channel value.

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -3,8 +3,68 @@ package main
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 )
+
+// collectPriceSymbols returns the list of symbols to fetch for portfolio
+// valuation/notional and a mirror map (position-key → fetch-key) used to
+// back-fill prices for perps positions.
+//
+// Spot positions are stored under the same key the price fetcher uses
+// (e.g. "BTC/USDT"), so they need no mirroring. Perps positions are stored
+// under the base asset only (e.g. "BTC" for Hyperliquid/OKX perps), but
+// check_price.py queries BinanceUS which requires "BTC/USDT" format. The
+// caller fetches under the normalized key and then invokes
+// mirrorPerpsPrices to populate the base-asset alias so that both
+// PortfolioNotional and PortfolioValue can resolve prices for open perps
+// positions — fixes issue #245 where perps exposure was silently dropped
+// from portfolio-notional risk checks.
+func collectPriceSymbols(strategies []StrategyConfig) (symbols []string, mirror map[string]string) {
+	set := make(map[string]bool)
+	mirror = make(map[string]string)
+	for _, sc := range strategies {
+		if len(sc.Args) < 2 {
+			continue
+		}
+		switch sc.Type {
+		case "spot":
+			set[sc.Args[1]] = true
+		case "perps":
+			baseSym := sc.Args[1]
+			fetchSym := baseSym
+			if !strings.Contains(baseSym, "/") {
+				fetchSym = baseSym + "/USDT"
+			}
+			set[fetchSym] = true
+			if fetchSym != baseSym {
+				mirror[baseSym] = fetchSym
+			}
+		}
+	}
+	symbols = make([]string, 0, len(set))
+	for s := range set {
+		symbols = append(symbols, s)
+	}
+	return symbols, mirror
+}
+
+// mirrorPerpsPrices back-fills price aliases so that fetched quotes keyed
+// under a normalized fetch symbol (e.g. "BTC/USDT") are also available
+// under the position-storage key (e.g. "BTC") used by perps state. An
+// existing price under the position key is preserved — if a strategy has
+// already published a live exchange mid via result.Symbol during the same
+// cycle, that value wins over the (possibly stale) BinanceUS spot quote.
+func mirrorPerpsPrices(prices map[string]float64, mirror map[string]string) {
+	for posKey, fetchKey := range mirror {
+		if _, exists := prices[posKey]; exists {
+			continue
+		}
+		if p, ok := prices[fetchKey]; ok && p > 0 {
+			prices[posKey] = p
+		}
+	}
+}
 
 const maxKillSwitchEvents = 50
 

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -18,11 +18,24 @@ import (
 // caller fetches under the normalized key and then invokes
 // mirrorPerpsPrices to populate the base-asset alias so that both
 // PortfolioNotional and PortfolioValue can resolve prices for open perps
-// positions — fixes issue #245 where perps exposure was silently dropped
-// from portfolio-notional risk checks.
-func collectPriceSymbols(strategies []StrategyConfig) (symbols []string, mirror map[string]string) {
+// positions — fixes issue #245 where perps exposure in portfolio-notional
+// risk checks was frozen at entry cost (pos.AvgCost) instead of being
+// revalued at the live mark, causing notional to drift away from true
+// exposure after price moved.
+//
+// Assumptions and limits:
+//   - The fetch-key quote is hardcoded to "/USDT". HL and OKX perps today
+//     both settle vs. USDT and BinanceUS quotes BTC/USDT, so this holds.
+//     A future USDC- or BTC-settled perps platform would need a
+//     per-platform fetch-key derivation (likely pushed into the adapter
+//     layer).
+//   - BinanceUS coverage is best-effort. HL lists many coins BinanceUS
+//     doesn't (HYPE, kPEPE, kSHIB, PURR, …); for those, FetchPrices will
+//     return 0 → mirrorPerpsPrices skips → PortfolioNotional/Value fall
+//     back to pos.AvgCost, same as before this fix (not a regression).
+func collectPriceSymbols(strategies []StrategyConfig) ([]string, map[string]string) {
 	set := make(map[string]bool)
-	mirror = make(map[string]string)
+	mirror := make(map[string]string)
 	for _, sc := range strategies {
 		if len(sc.Args) < 2 {
 			continue
@@ -34,6 +47,7 @@ func collectPriceSymbols(strategies []StrategyConfig) (symbols []string, mirror 
 			baseSym := sc.Args[1]
 			fetchSym := baseSym
 			if !strings.Contains(baseSym, "/") {
+				// HL/OKX perps quote vs. USDT — see "Assumptions" above.
 				fetchSym = baseSym + "/USDT"
 			}
 			set[fetchSym] = true
@@ -42,7 +56,7 @@ func collectPriceSymbols(strategies []StrategyConfig) (symbols []string, mirror 
 			}
 		}
 	}
-	symbols = make([]string, 0, len(set))
+	symbols := make([]string, 0, len(set))
 	for s := range set {
 		symbols = append(symbols, s)
 	}

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -353,6 +353,153 @@ func TestPortfolioNotional(t *testing.T) {
 	}
 }
 
+// TestPortfolioNotional_IncludesPerps verifies that perps positions (keyed
+// by base asset, e.g. "BTC" for Hyperliquid/OKX) are included in notional
+// exposure once their fetch price has been mirrored into the position key.
+// Regression test for issue #245: perps were silently dropped from
+// PortfolioNotional because the symbolSet builder only picked up spot.
+func TestPortfolioNotional_IncludesPerps(t *testing.T) {
+	strategies := map[string]*StrategyState{
+		"hl-momentum-btc": {
+			Type: "perps",
+			Positions: map[string]*Position{
+				// Hyperliquid perps store positions under the base asset.
+				"BTC": {Symbol: "BTC", Quantity: 0.4, AvgCost: 40000.0, Side: "long"},
+			},
+			OptionPositions: make(map[string]*OptionPosition),
+		},
+		"spot-btc": {
+			Type: "spot",
+			Positions: map[string]*Position{
+				"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.1, AvgCost: 45000.0, Side: "long"},
+			},
+			OptionPositions: make(map[string]*OptionPosition),
+		},
+	}
+
+	// Simulate the mirrored prices map after collectPriceSymbols +
+	// mirrorPerpsPrices: "BTC/USDT" is the fetch key, "BTC" the alias.
+	prices := map[string]float64{
+		"BTC/USDT": 50000.0,
+		"BTC":      50000.0,
+	}
+
+	notional := PortfolioNotional(strategies, prices)
+
+	// Perps: 0.4 * 50000 = 20000
+	// Spot:  0.1 * 50000 =  5000
+	// Total: 25000
+	expected := 25000.0
+	if notional < expected-0.01 || notional > expected+0.01 {
+		t.Errorf("expected notional=%.2f; got %.2f", expected, notional)
+	}
+}
+
+// TestCollectPriceSymbols verifies that spot and perps strategies both
+// contribute to the fetch list, that perps base-asset symbols are
+// normalized to "<base>/USDT", and that the mirror map captures the
+// position-key alias for each normalized perps symbol.
+func TestCollectPriceSymbols(t *testing.T) {
+	strategies := []StrategyConfig{
+		{ID: "sma-btc", Type: "spot", Platform: "binanceus", Args: []string{"sma", "BTC/USDT", "1h"}},
+		{ID: "sma-eth", Type: "spot", Platform: "binanceus", Args: []string{"sma", "ETH/USDT", "1h"}},
+		{ID: "hl-momentum-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}},
+		{ID: "okx-ema-sol-perp", Type: "perps", Platform: "okx", Args: []string{"ema", "SOL", "1h"}},
+		// Options should be ignored by the collector.
+		{ID: "deribit-vol-btc", Type: "options", Platform: "deribit", Args: []string{"vol", "BTC"}},
+		// Short-arg strategies should be ignored (no symbol to fetch).
+		{ID: "short", Type: "spot", Args: []string{"sma"}},
+	}
+
+	symbols, mirror := collectPriceSymbols(strategies)
+
+	got := make(map[string]bool, len(symbols))
+	for _, s := range symbols {
+		got[s] = true
+	}
+
+	wantSymbols := []string{"BTC/USDT", "ETH/USDT", "SOL/USDT"}
+	for _, sym := range wantSymbols {
+		if !got[sym] {
+			t.Errorf("symbols missing %q; got %v", sym, symbols)
+		}
+	}
+	if len(symbols) != len(wantSymbols) {
+		t.Errorf("symbols len = %d (%v), want %d (%v)", len(symbols), symbols, len(wantSymbols), wantSymbols)
+	}
+
+	// Perps mirror: base-asset → fetch key.
+	if mirror["BTC"] != "BTC/USDT" {
+		t.Errorf("mirror[BTC] = %q, want %q", mirror["BTC"], "BTC/USDT")
+	}
+	if mirror["SOL"] != "SOL/USDT" {
+		t.Errorf("mirror[SOL] = %q, want %q", mirror["SOL"], "SOL/USDT")
+	}
+	// Spot symbols must not appear in the mirror — the fetch key is
+	// already the position key.
+	if _, ok := mirror["BTC/USDT"]; ok {
+		t.Errorf("mirror should not contain spot symbol %q", "BTC/USDT")
+	}
+	if len(mirror) != 2 {
+		t.Errorf("mirror len = %d, want 2 (got %v)", len(mirror), mirror)
+	}
+}
+
+// TestCollectPriceSymbols_PerpsAlreadyNormalized verifies that a perps
+// strategy whose args already use a slash-form symbol (hypothetical OKX
+// swap "BTC/USDT:USDT" or similar) is passed through unchanged and not
+// double-suffixed, and that no mirror entry is created (fetch key == pos
+// key).
+func TestCollectPriceSymbols_PerpsAlreadyNormalized(t *testing.T) {
+	strategies := []StrategyConfig{
+		{ID: "okx-btc-swap", Type: "perps", Platform: "okx", Args: []string{"sma", "BTC/USDT", "1h"}},
+	}
+
+	symbols, mirror := collectPriceSymbols(strategies)
+
+	if len(symbols) != 1 || symbols[0] != "BTC/USDT" {
+		t.Errorf("symbols = %v, want [BTC/USDT]", symbols)
+	}
+	if len(mirror) != 0 {
+		t.Errorf("mirror = %v, want empty (fetch key already matches pos key)", mirror)
+	}
+}
+
+// TestMirrorPerpsPrices verifies that mirrorPerpsPrices back-fills the
+// position-key alias from its fetch key, preserves an existing position-key
+// entry (so a live exchange mid published by the strategy run wins over a
+// stale BinanceUS quote), and skips missing/zero fetch prices.
+func TestMirrorPerpsPrices(t *testing.T) {
+	mirror := map[string]string{
+		"BTC":  "BTC/USDT",
+		"ETH":  "ETH/USDT",
+		"SOL":  "SOL/USDT",
+		"DOGE": "DOGE/USDT",
+	}
+	prices := map[string]float64{
+		"BTC/USDT":  50000.0,
+		"ETH/USDT":  3000.0,
+		"ETH":       2999.5, // live mid already published — must be preserved
+		"SOL/USDT":  0,      // zero must not be mirrored
+		"DOGE/USDT": 0.08,
+	}
+
+	mirrorPerpsPrices(prices, mirror)
+
+	if prices["BTC"] != 50000.0 {
+		t.Errorf("prices[BTC] = %v, want 50000", prices["BTC"])
+	}
+	if prices["ETH"] != 2999.5 {
+		t.Errorf("prices[ETH] = %v, want 2999.5 (existing live mid), mirror must not overwrite", prices["ETH"])
+	}
+	if _, ok := prices["SOL"]; ok {
+		t.Errorf("prices[SOL] should not be set when fetch price is zero (got %v)", prices["SOL"])
+	}
+	if prices["DOGE"] != 0.08 {
+		t.Errorf("prices[DOGE] = %v, want 0.08", prices["DOGE"])
+	}
+}
+
 // TestCheckRisk_ConsecutiveLossesForceClose verifies that the consecutive-losses
 // circuit breaker force-closes all open positions.
 func TestCheckRisk_ConsecutiveLossesForceClose(t *testing.T) {

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -356,8 +356,10 @@ func TestPortfolioNotional(t *testing.T) {
 // TestPortfolioNotional_IncludesPerps verifies that perps positions (keyed
 // by base asset, e.g. "BTC" for Hyperliquid/OKX) are included in notional
 // exposure once their fetch price has been mirrored into the position key.
-// Regression test for issue #245: perps were silently dropped from
-// PortfolioNotional because the symbolSet builder only picked up spot.
+// Regression test for issue #245: before the fix, perps notional was
+// frozen at pos.AvgCost because the symbolSet builder only picked up spot
+// strategies, so prices[sym] missed for perps and the function fell back
+// to entry cost.
 func TestPortfolioNotional_IncludesPerps(t *testing.T) {
 	strategies := map[string]*StrategyState{
 		"hl-momentum-btc": {
@@ -392,6 +394,39 @@ func TestPortfolioNotional_IncludesPerps(t *testing.T) {
 	expected := 25000.0
 	if notional < expected-0.01 || notional > expected+0.01 {
 		t.Errorf("expected notional=%.2f; got %.2f", expected, notional)
+	}
+}
+
+// TestPortfolioNotional_IncludesPerpsShort verifies that a perps short
+// also contributes positive exposure to notional (absolute-value
+// interpretation) and is revalued at the live mark rather than frozen at
+// entry cost. HL shorts are stored with positive Quantity + Side:"short"
+// (see hyperliquid_balance.go syncs the on-chain |Size|), so the
+// pre-fix fallback to AvgCost would have understated notional after a
+// price rally and overstated it after a drawdown — this pins the fix
+// against the sign path, not just longs.
+func TestPortfolioNotional_IncludesPerpsShort(t *testing.T) {
+	strategies := map[string]*StrategyState{
+		"hl-mean-rev-eth": {
+			Type: "perps",
+			Positions: map[string]*Position{
+				"ETH": {Symbol: "ETH", Quantity: 2.0, AvgCost: 3000.0, Side: "short"},
+			},
+			OptionPositions: make(map[string]*OptionPosition),
+		},
+	}
+	// Live mark diverges from entry — this is what the fix unlocks.
+	prices := map[string]float64{
+		"ETH/USDT": 3200.0,
+		"ETH":      3200.0,
+	}
+
+	notional := PortfolioNotional(strategies, prices)
+
+	// Short notional at live mark: 2.0 * 3200 = 6400 (not 2.0 * 3000 = 6000).
+	expected := 6400.0
+	if notional < expected-0.01 || notional > expected+0.01 {
+		t.Errorf("expected short notional at live mark=%.2f; got %.2f", expected, notional)
 	}
 }
 
@@ -445,11 +480,11 @@ func TestCollectPriceSymbols(t *testing.T) {
 	}
 }
 
-// TestCollectPriceSymbols_PerpsAlreadyNormalized verifies that a perps
-// strategy whose args already use a slash-form symbol (hypothetical OKX
-// swap "BTC/USDT:USDT" or similar) is passed through unchanged and not
-// double-suffixed, and that no mirror entry is created (fetch key == pos
-// key).
+// TestCollectPriceSymbols_PerpsAlreadyNormalized is a defensive guardrail:
+// today neither hyperliquidSymbol nor okxSymbol ever returns a slash-form
+// string (both return args[1] = base coin), but should a caller ever pass
+// a slash-form symbol through, the normalizer must not double-suffix it
+// and must not create a mirror entry (fetch key already == pos key).
 func TestCollectPriceSymbols_PerpsAlreadyNormalized(t *testing.T) {
 	strategies := []StrategyConfig{
 		{ID: "okx-btc-swap", Type: "perps", Platform: "okx", Args: []string{"sma", "BTC/USDT", "1h"}},

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -13,26 +13,21 @@ import (
 type StatusServer struct {
 	state        *AppState
 	mu           *sync.RWMutex
-	statusToken  string           // if non-empty, /status requires Authorization: Bearer <token>
-	priceSymbols []string         // symbols to always fetch prices for
-	strategies   []StrategyConfig // strategy configs for initial capital lookup
-	stateDB      *StateDB         // SQLite DB for /history queries (may be nil)
+	statusToken  string            // if non-empty, /status requires Authorization: Bearer <token>
+	priceSymbols []string          // symbols to always fetch prices for
+	priceMirror  map[string]string // perps position-key → fetch-key aliases (#245)
+	strategies   []StrategyConfig  // strategy configs for initial capital lookup
+	stateDB      *StateDB          // SQLite DB for /history queries (may be nil)
 }
 
 func NewStatusServer(state *AppState, mu *sync.RWMutex, statusToken string, strategies []StrategyConfig, stateDB *StateDB) *StatusServer {
-	// Extract all traded symbols from strategy configs so prices are always fetched,
-	// even when no positions are open.
-	symbolSet := make(map[string]bool)
-	for _, sc := range strategies {
-		if sc.Type == "spot" && len(sc.Args) >= 2 {
-			symbolSet[sc.Args[1]] = true // e.g., "BTC/USDT"
-		}
-	}
-	symbols := make([]string, 0, len(symbolSet))
-	for s := range symbolSet {
-		symbols = append(symbols, s)
-	}
-	return &StatusServer{state: state, mu: mu, statusToken: statusToken, priceSymbols: symbols, strategies: strategies, stateDB: stateDB}
+	// Extract all traded symbols from strategy configs so prices are always
+	// fetched, even when no positions are open. Perps strategies key their
+	// positions under the base asset (e.g. "BTC"); collectPriceSymbols
+	// normalizes the fetch key to "BTC/USDT" and returns a mirror map so
+	// the handler can back-fill the base-asset alias after FetchPrices.
+	symbols, mirror := collectPriceSymbols(strategies)
+	return &StatusServer{state: state, mu: mu, statusToken: statusToken, priceSymbols: symbols, priceMirror: mirror, strategies: strategies, stateDB: stateDB}
 }
 
 func (ss *StatusServer) Start(port int) {
@@ -104,6 +99,8 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 			prices = p
 		}
 	}
+	// Back-fill perps position-key aliases (#245).
+	mirrorPerpsPrices(prices, ss.priceMirror)
 
 	// Re-acquire read lock to build the response
 	ss.mu.RLock()

--- a/scheduler/server_test.go
+++ b/scheduler/server_test.go
@@ -158,7 +158,11 @@ func TestNewStatusServerExtractsSymbols(t *testing.T) {
 	strategies := []StrategyConfig{
 		{Type: "spot", Args: []string{"sma", "BTC/USDT", "1h"}},
 		{Type: "spot", Args: []string{"rsi", "ETH/USDT", "1h"}},
-		{Type: "options", Args: []string{"vol", "BTC"}}, // not spot, skipped
+		{Type: "options", Args: []string{"vol", "BTC"}}, // options skipped
+		// #245: perps must also populate priceSymbols, normalized to "<base>/USDT",
+		// and register a mirror entry so the handler can back-fill the base-asset
+		// alias after FetchPrices returns.
+		{Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "SOL", "1h"}},
 	}
 	state := NewAppState()
 	var mu sync.RWMutex
@@ -176,8 +180,14 @@ func TestNewStatusServerExtractsSymbols(t *testing.T) {
 	if !symbolSet["ETH/USDT"] {
 		t.Error("ETH/USDT should be in priceSymbols")
 	}
-	if len(ss.priceSymbols) != 2 {
-		t.Errorf("priceSymbols len = %d, want 2", len(ss.priceSymbols))
+	if !symbolSet["SOL/USDT"] {
+		t.Error("SOL/USDT should be in priceSymbols (perps must be fetched — #245)")
+	}
+	if len(ss.priceSymbols) != 3 {
+		t.Errorf("priceSymbols len = %d, want 3", len(ss.priceSymbols))
+	}
+	if ss.priceMirror["SOL"] != "SOL/USDT" {
+		t.Errorf("priceMirror[SOL] = %q, want %q", ss.priceMirror["SOL"], "SOL/USDT")
 	}
 }
 


### PR DESCRIPTION
Closes #245

## Summary

`PortfolioNotional` was silently dropping perps exposure because all three `symbolSet` builders (main loop, `--summary` handler, `/status` endpoint) only picked up `sc.Type == "spot"`. Naively adding the perps base asset (`"BTC"`) wouldn't work either -- `check_price.py` queries BinanceUS which requires the `"BTC/USDT"` form.

## Fix

- `collectPriceSymbols(strategies)` in `risk.go` returns the set of symbols to fetch (normalizing perps `"BTC"` → `"BTC/USDT"`) plus a mirror map from position-key → fetch-key.
- `mirrorPerpsPrices` back-fills the base-asset alias after `FetchPrices` returns. An existing price under the position key is preserved so a live exchange mid published by a strategy run still wins over a stale BinanceUS quote.
- Three call sites updated: `main.go:315` (main loop pre-fetch), `main.go:940` (`--summary`), and `server.go` (`StatusServer` gains a `priceMirror` field).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` -- all existing tests + new: `TestPortfolioNotional_IncludesPerps`, `TestCollectPriceSymbols`, `TestCollectPriceSymbols_PerpsAlreadyNormalized`, `TestMirrorPerpsPrices`, `TestNewStatusServerExtractsSymbols` (extended).

🤖 Generated with [Claude Code](https://claude.ai/code)