### PR TITLE
Show entry price in position lines, simplify header prices

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -318,14 +318,15 @@ func FormatCategorySummary(
 		parts := make([]string, 0, len(syms))
 		for _, sym := range syms {
 			short := strings.TrimSuffix(sym, "/USDT")
+			priceStr := fmtComma2(displayPrices[sym])
 			if isFutures {
 				if fullName, ok := futuresFullNames[strings.ToUpper(short)]; ok {
-					parts = append(parts, fmt.Sprintf("%s (%s) $%.0f", short, fullName, displayPrices[sym]))
+					parts = append(parts, fmt.Sprintf("%s (%s): $%s", short, fullName, priceStr))
 				} else {
-					parts = append(parts, fmt.Sprintf("%s $%.0f", short, displayPrices[sym]))
+					parts = append(parts, fmt.Sprintf("%s: $%s", short, priceStr))
 				}
 			} else {
-				parts = append(parts, fmt.Sprintf("%s $%.0f", short, displayPrices[sym]))
+				parts = append(parts, fmt.Sprintf("%s: $%s", short, priceStr))
 			}
 		}
 		sb.WriteString(strings.Join(parts, " | "))
@@ -680,6 +681,30 @@ func fmtComma(v float64) string {
 	return string(out)
 }
 
+// fmtComma2 formats a float with thousands separators and two decimal places,
+// e.g. 2240.5 → "2,240.50". Negative values get a leading minus sign.
+func fmtComma2(v float64) string {
+	neg := v < 0
+	if neg {
+		v = -v
+	}
+	s := fmt.Sprintf("%.2f", v)
+	dot := strings.Index(s, ".")
+	intStr, fracStr := s[:dot], s[dot:]
+	var out []byte
+	for i := 0; i < len(intStr); i++ {
+		if i > 0 && (len(intStr)-i)%3 == 0 {
+			out = append(out, ',')
+		}
+		out = append(out, intStr[i])
+	}
+	result := string(out) + fracStr
+	if neg {
+		return "-" + result
+	}
+	return result
+}
+
 // formatInterval converts a duration in seconds to a short human-readable string.
 // Examples: 60 → "1m", 600 → "10m", 3600 → "1h", 86400 → "1d".
 func formatInterval(seconds int) string {
@@ -818,14 +843,16 @@ func collectPositions(stratID string, ss *StrategyState, prices map[string]float
 			pnl = pos.Quantity * (pos.AvgCost - currentPrice)
 		}
 		sign := "+"
+		absPnl := pnl
 		if pnl < 0 {
-			sign = ""
+			sign = "-"
+			absPnl = -pnl
 		}
 		dateStr := ""
 		if !pos.OpenedAt.IsZero() {
 			dateStr = fmt.Sprintf(" [%s]", pos.OpenedAt.Format("Jan 02 15:04"))
 		}
-		lines = append(lines, fmt.Sprintf("%s %s %s x%g (%s$%.0f)%s", stratID, pos.Side, sym, pos.Quantity, sign, pnl, dateStr))
+		lines = append(lines, fmt.Sprintf("%s %s %s x%g @ $%s (%s$%s)%s", stratID, pos.Side, sym, pos.Quantity, fmtComma2(pos.AvgCost), sign, fmtComma2(absPnl), dateStr))
 	}
 	for key, opt := range ss.OptionPositions {
 		dateStr := ""

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -661,24 +661,29 @@ func groupByAsset(strats []StrategyConfig) (map[string][]StrategyConfig, []strin
 	return groups, keys
 }
 
+// insertCommas inserts thousands separators into a non-negative integer string.
+// e.g. "1234567" -> "1,234,567". Input must contain only digits.
+func insertCommas(intStr string) string {
+	if len(intStr) <= 3 {
+		return intStr
+	}
+	var out []byte
+	for i := 0; i < len(intStr); i++ {
+		if i > 0 && (len(intStr)-i)%3 == 0 {
+			out = append(out, ',')
+		}
+		out = append(out, intStr[i])
+	}
+	return string(out)
+}
+
 // fmtComma formats a float as a comma-separated integer string (e.g. 1234567 -> "1,234,567").
 func fmtComma(v float64) string {
 	n := int(v)
 	if n < 0 {
-		return "-" + fmtComma(-v)
+		return "-" + insertCommas(fmt.Sprintf("%d", -n))
 	}
-	s := fmt.Sprintf("%d", n)
-	if len(s) <= 3 {
-		return s
-	}
-	var out []byte
-	for i, c := range s {
-		if i > 0 && (len(s)-i)%3 == 0 {
-			out = append(out, ',')
-		}
-		out = append(out, byte(c))
-	}
-	return string(out)
+	return insertCommas(fmt.Sprintf("%d", n))
 }
 
 // fmtComma2 formats a float with thousands separators and two decimal places,
@@ -690,15 +695,7 @@ func fmtComma2(v float64) string {
 	}
 	s := fmt.Sprintf("%.2f", v)
 	dot := strings.Index(s, ".")
-	intStr, fracStr := s[:dot], s[dot:]
-	var out []byte
-	for i := 0; i < len(intStr); i++ {
-		if i > 0 && (len(intStr)-i)%3 == 0 {
-			out = append(out, ',')
-		}
-		out = append(out, intStr[i])
-	}
-	result := string(out) + fracStr
+	result := insertCommas(s[:dot]) + s[dot:]
 	if neg {
 		return "-" + result
 	}
@@ -859,7 +856,7 @@ func collectPositions(stratID string, ss *StrategyState, prices map[string]float
 		if !opt.OpenedAt.IsZero() {
 			dateStr = fmt.Sprintf(" [%s]", opt.OpenedAt.Format("Jan 02 15:04"))
 		}
-		lines = append(lines, fmt.Sprintf("%s OPT %s ($%.0f)%s", stratID, key, opt.CurrentValueUSD, dateStr))
+		lines = append(lines, fmt.Sprintf("%s OPT %s ($%s)%s", stratID, key, fmtComma2(opt.CurrentValueUSD), dateStr))
 	}
 	return lines
 }

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -701,6 +701,24 @@ func TestCollectPositions_OptionTimestamp(t *testing.T) {
 	}
 }
 
+// TestCollectPositions_OptionValueFormat verifies option position lines format
+// CurrentValueUSD with thousands separators and two decimal places (matching the
+// spot/perps line format), so small values like $12.34 render precisely.
+func TestCollectPositions_OptionValueFormat(t *testing.T) {
+	ss := &StrategyState{
+		OptionPositions: map[string]*OptionPosition{
+			"BTC-call-50000": {ID: "BTC-call-50000", CurrentValueUSD: 12345.67},
+		},
+	}
+	lines := collectPositions("deribit-wheel-btc", ss, nil)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	if !strings.Contains(lines[0], "($12,345.67)") {
+		t.Errorf("expected option value '($12,345.67)' in line, got: %s", lines[0])
+	}
+}
+
 // TestCollectPositions_EntryPrice verifies issue #259: position lines include
 // the entry price (`@ $AvgCost`) alongside PnL so users can compare entry vs
 // current price at a glance.
@@ -787,6 +805,8 @@ func TestFmtComma2(t *testing.T) {
 		{1234567.89, "1,234,567.89"},
 		{-2213.08, "-2,213.08"},
 		{2240.5, "2,240.50"},
+		{-12345.67, "-12,345.67"},
+		{-1234567.89, "-1,234,567.89"},
 	}
 	for _, c := range cases {
 		if got := fmtComma2(c.in); got != c.want {

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -701,6 +701,100 @@ func TestCollectPositions_OptionTimestamp(t *testing.T) {
 	}
 }
 
+// TestCollectPositions_EntryPrice verifies issue #259: position lines include
+// the entry price (`@ $AvgCost`) alongside PnL so users can compare entry vs
+// current price at a glance.
+func TestCollectPositions_EntryPrice(t *testing.T) {
+	ss := &StrategyState{
+		Positions: map[string]*Position{
+			"ETH/USDT": {Symbol: "ETH/USDT", Quantity: 1.5, AvgCost: 2213.08, Side: "long"},
+		},
+	}
+	prices := map[string]float64{"ETH/USDT": 2214.88}
+
+	lines := collectPositions("hl-rsi-eth", ss, prices)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	// Entry price: 2213.08 with comma/decimal formatting.
+	if !strings.Contains(lines[0], "@ $2,213.08") {
+		t.Errorf("expected entry price '@ $2,213.08' in line, got: %s", lines[0])
+	}
+	// PnL: 1.5 * (2214.88 - 2213.08) = 2.70
+	if !strings.Contains(lines[0], "(+$2.70)") {
+		t.Errorf("expected PnL '(+$2.70)' in line, got: %s", lines[0])
+	}
+}
+
+// TestCollectPositions_ShortEntryPrice verifies entry price + PnL rendering for
+// short positions (PnL flips sign).
+func TestCollectPositions_ShortEntryPrice(t *testing.T) {
+	ss := &StrategyState{
+		Positions: map[string]*Position{
+			"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.1, AvgCost: 50000, Side: "short"},
+		},
+	}
+	prices := map[string]float64{"BTC/USDT": 51000}
+
+	lines := collectPositions("hl-rsi-btc", ss, prices)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	// Entry price formatted with comma.
+	if !strings.Contains(lines[0], "@ $50,000.00") {
+		t.Errorf("expected entry price '@ $50,000.00' in line, got: %s", lines[0])
+	}
+	// Short at 50k, price up to 51k → loss of 0.1 * 1000 = 100.
+	if !strings.Contains(lines[0], "(-$100.00)") {
+		t.Errorf("expected PnL '(-$100.00)' in line, got: %s", lines[0])
+	}
+}
+
+// TestFormatCategorySummary_HeaderPriceFormat verifies issue #259: the header
+// prices line uses `SYMBOL: $X,XXX.XX` format — colon separator, thousands
+// comma, two decimal places.
+func TestFormatCategorySummary_HeaderPriceFormat(t *testing.T) {
+	strats := []StrategyConfig{
+		{ID: "hl-rsi-eth", Type: "perps", Args: []string{"rsi", "ETH", "1h"}, Capital: 1000},
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-rsi-eth": {Cash: 1000},
+		},
+	}
+	prices := map[string]float64{"ETH/USDT": 2240.5}
+
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600)
+	msg := strings.Join(msgs, "\n")
+	if !strings.Contains(msg, "ETH: $2,240.50") {
+		t.Errorf("expected header price 'ETH: $2,240.50', got:\n%s", msg)
+	}
+	// Old format `ETH $2240` (no colon) must be gone.
+	if strings.Contains(msg, "ETH $2240") {
+		t.Errorf("old header format 'ETH $2240' should be removed, got:\n%s", msg)
+	}
+}
+
+func TestFmtComma2(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{0, "0.00"},
+		{1.5, "1.50"},
+		{123.456, "123.46"},
+		{1234.5, "1,234.50"},
+		{1234567.89, "1,234,567.89"},
+		{-2213.08, "-2,213.08"},
+		{2240.5, "2,240.50"},
+	}
+	for _, c := range cases {
+		if got := fmtComma2(c.in); got != c.want {
+			t.Errorf("fmtComma2(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 func TestSplitCategorySummary_SingleMessage(t *testing.T) {
 	header := "Header line\n"
 	posLines := []string{"pos1", "pos2"}


### PR DESCRIPTION
## Summary

- Restore entry price (`@ $AvgCost`) in position lines so users can compare entry vs current at a glance
- Simplify the header prices format from `ETH $2240` to `ETH: $2,240.50` (colon separator, thousands comma, two decimals)
- Raise PnL precision from `%.0f` to two decimals so small moves are visible
- New `fmtComma2` helper shared between the header and position lines

Partially reverts #251 (the entry price removal) while fixing the actual underlying problem (redundant header price display).

Closes #259

## Test plan
- [x] `go build .`
- [x] `go test ./...`
- [x] New unit tests: `TestCollectPositions_EntryPrice`, `TestCollectPositions_ShortEntryPrice`, `TestFormatCategorySummary_HeaderPriceFormat`, `TestFmtComma2`

🤖 Generated with [Claude Code](https://claude.ai/code)