### PR TITLE
fix: value perps positions as margin + PnL (#254)

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -102,6 +102,7 @@ type StrategyConfig struct {
 	MaxDrawdownPct  float64                `json:"max_drawdown_pct"`
 	IntervalSeconds int                    `json:"interval_seconds,omitempty"` // per-strategy override (0 = use global)
 	HTFFilter       bool                   `json:"htf_filter,omitempty"`       // higher-timeframe trend filter
+	Leverage        float64                `json:"leverage,omitempty"`         // perps leverage multiplier (default 1 = no leverage); used for notional sizing and margin-based valuation (#254)
 	Params          map[string]interface{} `json:"params,omitempty"`           // custom strategy parameters passed to Python
 	ThetaHarvest    *ThetaHarvestConfig    `json:"theta_harvest,omitempty"`
 	FuturesConfig   *FuturesConfig         `json:"futures,omitempty"`
@@ -233,6 +234,13 @@ func LoadConfig(path string) (*Config, error) {
 			} else {
 				cfg.Strategies[i].MaxDrawdownPct = 60
 			}
+		}
+
+		// #254: Default leverage for perps strategies is 1x (no leverage)
+		// when unset. Spot/options/futures ignore Leverage; only perps uses it
+		// for notional sizing and setting Position.Multiplier.
+		if cfg.Strategies[i].Type == "perps" && cfg.Strategies[i].Leverage <= 0 {
+			cfg.Strategies[i].Leverage = 1
 		}
 
 		// #56: Default theta harvest for options strategies — sold options
@@ -433,6 +441,16 @@ func ValidateConfig(cfg *Config) error {
 		// #36: IntervalSeconds must be >= 0 (0 means use global).
 		if sc.IntervalSeconds < 0 {
 			errs = append(errs, fmt.Sprintf("%s: interval_seconds must be >= 0, got %d", prefix, sc.IntervalSeconds))
+		}
+
+		// #254: Leverage must be >= 1 when set. Only applicable to perps.
+		if sc.Leverage != 0 {
+			if sc.Type != "perps" {
+				errs = append(errs, fmt.Sprintf("%s: leverage is only supported for perps strategies (got type %q)", prefix, sc.Type))
+			}
+			if sc.Leverage < 1 || sc.Leverage > 100 {
+				errs = append(errs, fmt.Sprintf("%s: leverage must be in [1, 100], got %g", prefix, sc.Leverage))
+			}
 		}
 
 		// #36: ThetaHarvest fields must be non-negative when present.

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -685,3 +685,98 @@ func TestLoadConfigInitialCapital(t *testing.T) {
 		t.Errorf("Capital = %g, want 600 (should not be overwritten)", sc.Capital)
 	}
 }
+
+// #254: perps strategies get default Leverage=1 when unset.
+func TestLoadConfigPerpsLeverageDefault(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [{
+			"id": "hl-test-eth",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000
+		}]
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	sc := cfg.Strategies[0]
+	if sc.Leverage != 1 {
+		t.Errorf("Leverage = %g, want 1 (default)", sc.Leverage)
+	}
+}
+
+// #254: explicit perps Leverage is preserved.
+func TestLoadConfigPerpsLeverageExplicit(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [{
+			"id": "hl-test-eth",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000,
+			"leverage": 10
+		}]
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	if cfg.Strategies[0].Leverage != 10 {
+		t.Errorf("Leverage = %g, want 10", cfg.Strategies[0].Leverage)
+	}
+}
+
+// #254: Leverage must be rejected on non-perps types.
+func TestLoadConfigLeverageRejectsSpot(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [{
+			"id": "test-spot",
+			"type": "spot",
+			"script": "shared_scripts/check_strategy.py",
+			"args": ["sma_crossover", "BTC/USDT", "1h"],
+			"capital": 1000,
+			"leverage": 5
+		}]
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected validation error for leverage on spot strategy")
+	}
+	if !strings.Contains(err.Error(), "leverage is only supported for perps") {
+		t.Errorf("error = %v, want 'leverage is only supported for perps'", err)
+	}
+}
+
+// #254: Leverage must be in [1, 100].
+func TestLoadConfigLeverageRejectsOutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [{
+			"id": "hl-test-eth",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000,
+			"leverage": 150
+		}]
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected validation error for leverage=150")
+	}
+	if !strings.Contains(err.Error(), "leverage must be in") {
+		t.Errorf("error = %v, want 'leverage must be in'", err)
+	}
+}

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -18,6 +18,7 @@ type HLPosition struct {
 	Coin       string
 	Size       float64 // signed: positive = long, negative = short
 	EntryPrice float64
+	Leverage   float64 // on-chain leverage value (#254)
 }
 
 var hlMainnetURL = "https://api.hyperliquid.xyz"
@@ -125,9 +126,13 @@ func fetchHyperliquidState(accountAddress string) (float64, []HLPosition, error)
 		} `json:"marginSummary"`
 		AssetPositions []struct {
 			Position struct {
-				Coin    string `json:"coin"`
-				Szi     string `json:"szi"`
-				EntryPx string `json:"entryPx"`
+				Coin     string `json:"coin"`
+				Szi      string `json:"szi"`
+				EntryPx  string `json:"entryPx"`
+				Leverage struct {
+					Type  string      `json:"type"`
+					Value json.Number `json:"value"`
+				} `json:"leverage"`
 			} `json:"position"`
 		} `json:"assetPositions"`
 	}
@@ -150,10 +155,19 @@ func fetchHyperliquidState(accountAddress string) (float64, []HLPosition, error)
 		if err != nil {
 			fmt.Printf("[WARN] hl-sync: failed to parse entryPx %q for %s: %v\n", ap.Position.EntryPx, ap.Position.Coin, err)
 		}
+		// #254: HL per-position leverage from clearinghouseState. Value is a
+		// number in the API but tolerated as string; default 1 on parse error.
+		lev := 1.0
+		if lvStr := ap.Position.Leverage.Value.String(); lvStr != "" {
+			if parsed, lerr := strconv.ParseFloat(lvStr, 64); lerr == nil && parsed > 0 {
+				lev = parsed
+			}
+		}
 		positions = append(positions, HLPosition{
 			Coin:       ap.Position.Coin,
 			Size:       szi,
 			EntryPrice: entryPx,
+			Leverage:   lev,
 		})
 	}
 
@@ -191,6 +205,19 @@ func reconcileHyperliquidPositions(stratState *StrategyState, sym string, positi
 			statePos.Quantity = qty
 			statePos.Side = side
 			statePos.AvgCost = onChainPos.EntryPrice
+			changed = true
+		}
+		// #254: always pull the current on-chain leverage and ensure Multiplier=1
+		// so PortfolioValue uses the PnL branch. Also migrates legacy positions
+		// that were stored with Multiplier=0 (treated as spot/full-notional).
+		if statePos.Multiplier != 1 {
+			logger.Info("hl-sync: %s migrate multiplier %v → 1 (perps PnL valuation) (#254)", sym, statePos.Multiplier)
+			statePos.Multiplier = 1
+			changed = true
+		}
+		if onChainPos.Leverage > 0 && statePos.Leverage != onChainPos.Leverage {
+			logger.Info("hl-sync: %s leverage %v → %v", sym, statePos.Leverage, onChainPos.Leverage)
+			statePos.Leverage = onChainPos.Leverage
 			changed = true
 		}
 	} else if onChainPos == nil && statePos != nil {

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -183,11 +183,13 @@ func TestReconcileNoChange(t *testing.T) {
 		ID:   "hl-btc",
 		Cash: 5000,
 		Positions: map[string]*Position{
-			"BTC": {Symbol: "BTC", Quantity: 0.5, AvgCost: 40000, Side: "long", OwnerStrategyID: "hl-btc"},
+			// #254: Multiplier=1 + Leverage=2 so reconcile sees a fully
+			// up-to-date perps position and doesn't flip any fields.
+			"BTC": {Symbol: "BTC", Quantity: 0.5, AvgCost: 40000, Side: "long", Multiplier: 1, Leverage: 2, OwnerStrategyID: "hl-btc"},
 		},
 	}
 	logger := newTestLogger(t)
-	positions := []HLPosition{{Coin: "BTC", Size: 0.5, EntryPrice: 40000}}
+	positions := []HLPosition{{Coin: "BTC", Size: 0.5, EntryPrice: 40000, Leverage: 2}}
 
 	changed := reconcileHyperliquidPositions(s, "BTC", positions, logger)
 
@@ -419,5 +421,99 @@ func TestValidateStateMigratesOwnership(t *testing.T) {
 	pos := state.Strategies["hl-btc"].Positions["BTC"]
 	if pos.OwnerStrategyID != "hl-btc" {
 		t.Errorf("OwnerStrategyID = %q, want %q", pos.OwnerStrategyID, "hl-btc")
+	}
+}
+
+// #254: reconcile migrates a legacy position stored with Multiplier=0 up to
+// Multiplier=1 so PortfolioValue uses the perps PnL branch. It also copies
+// the on-chain leverage into the Position.
+func TestReconcileMigratesLegacyMultiplierAndSyncsLeverage(t *testing.T) {
+	s := &StrategyState{
+		ID:   "hl-eth",
+		Cash: 27.15,
+		Positions: map[string]*Position{
+			// Legacy perps position as stored before #254: Multiplier=0.
+			"ETH": {Symbol: "ETH", Quantity: 0.279, AvgCost: 2210.71, Side: "long", OwnerStrategyID: "hl-eth"},
+		},
+	}
+	logger := newTestLogger(t)
+	positions := []HLPosition{{Coin: "ETH", Size: 0.279, EntryPrice: 2210.71, Leverage: 20}}
+
+	changed := reconcileHyperliquidPositions(s, "ETH", positions, logger)
+
+	if !changed {
+		t.Fatal("expected changed=true (migration)")
+	}
+	pos := s.Positions["ETH"]
+	if pos.Multiplier != 1 {
+		t.Errorf("Multiplier = %v, want 1 after migration", pos.Multiplier)
+	}
+	if pos.Leverage != 20 {
+		t.Errorf("Leverage = %v, want 20 (from on-chain)", pos.Leverage)
+	}
+	if pos.Quantity != 0.279 || pos.AvgCost != 2210.71 {
+		t.Errorf("qty/avgCost changed unexpectedly: %v @ %v", pos.Quantity, pos.AvgCost)
+	}
+}
+
+// #254: after migration, PortfolioValue reflects margin + PnL, not inflated
+// notional. This is the direct regression for the issue.
+func TestReconcileLegacyPositionPortfolioValueAfterMigration(t *testing.T) {
+	s := &StrategyState{
+		ID:              "hl-eth",
+		Cash:            27.15,
+		OptionPositions: make(map[string]*OptionPosition),
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.279, AvgCost: 2210.71, Side: "long", OwnerStrategyID: "hl-eth"},
+		},
+	}
+	// Pre-fix value (spot branch): 27.15 + 0.279 * 2201.10 = 641.23 — inflated.
+	preFix := PortfolioValue(s, map[string]float64{"ETH": 2201.10})
+	if preFix < 600 || preFix > 700 {
+		t.Logf("pre-migration value = %v (spot branch)", preFix)
+	}
+
+	logger := newTestLogger(t)
+	reconcileHyperliquidPositions(s, "ETH",
+		[]HLPosition{{Coin: "ETH", Size: 0.279, EntryPrice: 2210.71, Leverage: 20}}, logger)
+
+	// Post-migration value: cash + qty*(price-entry) = 27.15 + 0.279*(2201.10-2210.71) = ~24.47
+	postFix := PortfolioValue(s, map[string]float64{"ETH": 2201.10})
+	expected := 27.15 + 0.279*(2201.10-2210.71)
+	if postFix-expected > 0.01 || expected-postFix > 0.01 {
+		t.Errorf("post-migration value = %v, want %v (cash + PnL)", postFix, expected)
+	}
+	if postFix >= preFix-1 {
+		t.Errorf("post-migration value (%v) should be much lower than pre-fix (%v)", postFix, preFix)
+	}
+}
+
+// #254: parse leverage out of clearinghouseState JSON.
+func TestFetchHyperliquidStateParsesLeverage(t *testing.T) {
+	body := `{
+		"marginSummary": {"accountValue": "1000.0"},
+		"assetPositions": [
+			{"position": {"coin": "ETH", "szi": "0.5", "entryPx": "2000.0", "leverage": {"type": "cross", "value": 20}}}
+		]
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	savedURL := hlMainnetURL
+	hlMainnetURL = srv.URL
+	defer func() { hlMainnetURL = savedURL }()
+
+	_, positions, err := fetchHyperliquidState("0xdeadbeef")
+	if err != nil {
+		t.Fatalf("fetchHyperliquidState: %v", err)
+	}
+	if len(positions) != 1 {
+		t.Fatalf("positions = %d, want 1", len(positions))
+	}
+	if positions[0].Leverage != 20 {
+		t.Errorf("Leverage = %v, want 20", positions[0].Leverage)
 	}
 }

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -229,6 +229,7 @@ type InitOptions struct {
 	SpotCapital             float64
 	OptionsCapital          float64
 	PerpsCapital            float64
+	PerpsLeverage           float64 // perps leverage multiplier (default 1 = no leverage) (#254)
 	SpotDrawdown            float64
 	OptionsDrawdown         float64
 	PerpsDrawdown           float64
@@ -408,6 +409,10 @@ func generateConfig(opts InitOptions) *Config {
 	// Perps strategies (Hyperliquid only).
 	if opts.EnablePerps {
 		usesHyperliquid = true
+		perpsLeverage := opts.PerpsLeverage
+		if perpsLeverage <= 0 {
+			perpsLeverage = 1
+		}
 		for _, stratID := range opts.PerpsStrategies {
 			shortName := deriveShortName(stratID)
 			for _, assetName := range opts.Assets {
@@ -421,6 +426,7 @@ func generateConfig(opts InitOptions) *Config {
 					Capital:         opts.PerpsCapital,
 					MaxDrawdownPct:  opts.PerpsDrawdown,
 					IntervalSeconds: 3600,
+					Leverage:        perpsLeverage,
 				})
 			}
 		}
@@ -537,6 +543,10 @@ func generateConfig(opts InitOptions) *Config {
 			}
 		}
 		// OKX perps strategies
+		okxPerpsLeverage := opts.PerpsLeverage
+		if okxPerpsLeverage <= 0 {
+			okxPerpsLeverage = 1
+		}
 		for _, stratID := range opts.OKXPerpsStrategies {
 			shortName := deriveShortName(stratID)
 			for _, assetName := range opts.Assets {
@@ -550,6 +560,7 @@ func generateConfig(opts InitOptions) *Config {
 					Capital:         opts.OKXCapital,
 					MaxDrawdownPct:  opts.OKXDrawdown,
 					IntervalSeconds: 3600,
+					Leverage:        okxPerpsLeverage,
 				})
 			}
 		}
@@ -654,6 +665,10 @@ func runInitFromJSON(jsonStr string, outputPath string) int {
 	}
 	if opts.EnablePerps && opts.PerpsMode == "" {
 		opts.PerpsMode = "paper"
+	}
+	// #254: perps leverage defaults to 1x if not specified.
+	if opts.EnablePerps && opts.PerpsLeverage <= 0 {
+		opts.PerpsLeverage = 1
 	}
 
 	// Auto-populate PerpsStrategies from discovered list if not specified.
@@ -1027,6 +1042,7 @@ func runInit(args []string) int {
 	spotDrawdown := 5.0
 	optionsDrawdown := 10.0
 	perpsDrawdown := 5.0
+	perpsLeverage := 1.0 // #254 default: 1x (no leverage); user can edit config
 	robinhoodCapital := 500.0
 	robinhoodDrawdown := 5.0
 	lunoCapital := 500.0
@@ -1116,6 +1132,7 @@ func runInit(args []string) int {
 		SpotCapital:             spotCapital,
 		OptionsCapital:          optionsCapital,
 		PerpsCapital:            perpsCapital,
+		PerpsLeverage:           perpsLeverage,
 		SpotDrawdown:            spotDrawdown,
 		OptionsDrawdown:         optionsDrawdown,
 		PerpsDrawdown:           perpsDrawdown,

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1283,15 +1283,17 @@ func runHyperliquidCheck(sc StrategyConfig, prices map[string]float64, logger *S
 // Returns (execResult, ok); ok=false means order failed, skip state update.
 func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, price, cash, posQty float64, logger *StrategyLogger) (*HyperliquidExecuteResult, bool) {
 	isBuy := result.Signal == 1
-	leverage := sc.Leverage
-	if leverage <= 0 {
-		leverage = 1
+	// #254: perps use leverage to size notional; mirror OKX's guard so any
+	// future HL spot mode can't accidentally over-size.
+	sizingLeverage := 1.0
+	if sc.Type == "perps" && sc.Leverage > 0 {
+		sizingLeverage = sc.Leverage
 	}
 	var size float64
 	if isBuy {
 		// #254: sizing uses leveraged notional = cash * leverage * 0.95.
 		// The actual margin locked on-chain will be notional/leverage.
-		budget := cash * leverage * 0.95
+		budget := cash * sizingLeverage * 0.95
 		if budget < 1 || price <= 0 {
 			logger.Info("Insufficient cash ($%.2f) for live buy", cash)
 			return nil, false
@@ -1342,7 +1344,7 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 	if leverage <= 0 {
 		leverage = 1
 	}
-	trades, err := ExecutePerpsSignal(s, result.Signal, result.Symbol, fillPrice, leverage, fillQty, 0, logger)
+	trades, err := ExecutePerpsSignal(s, result.Signal, result.Symbol, fillPrice, leverage, fillQty, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -1817,7 +1819,7 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, result *OKXResult, ex
 		if leverage <= 0 {
 			leverage = 1
 		}
-		trades, err = ExecutePerpsSignal(s, result.Signal, result.Symbol, fillPrice, leverage, fillQty, 0, logger)
+		trades, err = ExecutePerpsSignal(s, result.Signal, result.Symbol, fillPrice, leverage, fillQty, logger)
 	} else {
 		trades, err = ExecuteSpotSignal(s, result.Signal, result.Symbol, fillPrice, fillQty, logger)
 	}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1283,9 +1283,15 @@ func runHyperliquidCheck(sc StrategyConfig, prices map[string]float64, logger *S
 // Returns (execResult, ok); ok=false means order failed, skip state update.
 func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, price, cash, posQty float64, logger *StrategyLogger) (*HyperliquidExecuteResult, bool) {
 	isBuy := result.Signal == 1
+	leverage := sc.Leverage
+	if leverage <= 0 {
+		leverage = 1
+	}
 	var size float64
 	if isBuy {
-		budget := cash * 0.95
+		// #254: sizing uses leveraged notional = cash * leverage * 0.95.
+		// The actual margin locked on-chain will be notional/leverage.
+		budget := cash * leverage * 0.95
 		if budget < 1 || price <= 0 {
 			logger.Info("Insufficient cash ($%.2f) for live buy", cash)
 			return nil, false
@@ -1332,7 +1338,11 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 	}
 
 	prevTradeCount := len(s.TradeHistory)
-	trades, err := ExecuteSpotSignal(s, result.Signal, result.Symbol, fillPrice, fillQty, logger)
+	leverage := sc.Leverage
+	if leverage <= 0 {
+		leverage = 1
+	}
+	trades, err := ExecutePerpsSignal(s, result.Signal, result.Symbol, fillPrice, leverage, fillQty, 0, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -1747,9 +1757,14 @@ func runOKXCheck(sc StrategyConfig, prices map[string]float64, logger *StrategyL
 // runOKXExecuteOrder places a live market order on OKX (Phase 3, no lock).
 func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQty float64, logger *StrategyLogger) (*OKXExecuteResult, bool) {
 	isBuy := result.Signal == 1
+	// #254: perps use leverage to size notional; spot is unaffected.
+	sizingLeverage := 1.0
+	if sc.Type == "perps" && sc.Leverage > 0 {
+		sizingLeverage = sc.Leverage
+	}
 	var size float64
 	if isBuy {
-		budget := cash * 0.95
+		budget := cash * sizingLeverage * 0.95
 		if budget < 1 || price <= 0 {
 			logger.Info("Insufficient cash ($%.2f) for live buy", cash)
 			return nil, false
@@ -1795,7 +1810,17 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, result *OKXResult, ex
 		logger.Info("Live fill at $%.2f qty=%.6f (mid was $%.2f)", fillPrice, fillQty, price)
 	}
 
-	trades, err := ExecuteSpotSignal(s, result.Signal, result.Symbol, fillPrice, fillQty, logger)
+	var trades int
+	var err error
+	if sc.Type == "perps" {
+		leverage := sc.Leverage
+		if leverage <= 0 {
+			leverage = 1
+		}
+		trades, err = ExecutePerpsSignal(s, result.Signal, result.Symbol, fillPrice, leverage, fillQty, 0, logger)
+	} else {
+		trades, err = ExecuteSpotSignal(s, result.Signal, result.Symbol, fillPrice, fillQty, logger)
+	}
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -11,7 +11,7 @@ type Position struct {
 	Quantity        float64   `json:"quantity"`
 	AvgCost         float64   `json:"avg_cost"`
 	Side            string    `json:"side"`                        // "long" or "short"
-	Multiplier      float64   `json:"multiplier,omitempty"`        // contract multiplier (0 = spot, >0 = futures/perps PnL branch)
+	Multiplier      float64   `json:"multiplier,omitempty"`        // contract multiplier (0 = spot, >0 = futures/perps PnL branch; canonical perps value is 1 — do NOT set to leverage)
 	Leverage        float64   `json:"leverage,omitempty"`          // perps leverage (informational; PnL is not scaled by leverage) (#254)
 	OwnerStrategyID string    `json:"owner_strategy_id,omitempty"` // strategy that opened this position
 	OpenedAt        time.Time `json:"opened_at,omitempty"`         // when the position was opened
@@ -74,7 +74,7 @@ func PortfolioValue(s *StrategyState, prices map[string]float64) float64 {
 // fillQty > 0 means a live fill: use price and fillQty as-is (no slippage,
 // no notional recalc). fillQty == 0 means paper mode: compute qty from
 // leveraged budget with slippage applied.
-func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float64, leverage float64, fillQty float64, feePerContract float64, logger *StrategyLogger) (int, error) {
+func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float64, leverage float64, fillQty float64, logger *StrategyLogger) (int, error) {
 	if signal == 0 {
 		return 0, nil
 	}
@@ -83,11 +83,8 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 	}
 	tradesExecuted := 0
 
-	// perPlatformFee picks the right fee dispatch for a given strategy
-	// platform. For Hyperliquid spot+perps and OKX perps the existing
-	// CalculatePlatformSpotFee table already encodes the correct taker fee;
-	// feePerContract is reserved for future expansion (unused for now).
-	_ = feePerContract
+	// Fee dispatch: for Hyperliquid spot+perps and OKX perps the existing
+	// CalculatePlatformSpotFee table already encodes the correct taker fee.
 	feePlatform := s.Platform
 	if s.Platform == "okx" && s.Type == "perps" {
 		feePlatform = "okx-perps"

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -5,13 +5,14 @@ import (
 	"time"
 )
 
-// Position represents a spot or futures position.
+// Position represents a spot, futures, or perps position.
 type Position struct {
 	Symbol          string    `json:"symbol"`
 	Quantity        float64   `json:"quantity"`
 	AvgCost         float64   `json:"avg_cost"`
 	Side            string    `json:"side"`                        // "long" or "short"
-	Multiplier      float64   `json:"multiplier,omitempty"`        // futures contract multiplier (0 = spot)
+	Multiplier      float64   `json:"multiplier,omitempty"`        // contract multiplier (0 = spot, >0 = futures/perps PnL branch)
+	Leverage        float64   `json:"leverage,omitempty"`          // perps leverage (informational; PnL is not scaled by leverage) (#254)
 	OwnerStrategyID string    `json:"owner_strategy_id,omitempty"` // strategy that opened this position
 	OpenedAt        time.Time `json:"opened_at,omitempty"`         // when the position was opened
 }
@@ -58,6 +59,154 @@ func PortfolioValue(s *StrategyState, prices map[string]float64) float64 {
 		total += opt.CurrentValueUSD
 	}
 	return total
+}
+
+// ExecutePerpsSignal processes a perps (perpetual futures) signal with
+// margin-based accounting (#254). Unlike spot, perps positions do NOT consume
+// the full notional from cash — only the fee is deducted, matching the
+// futures model. The resulting Position is stamped with Multiplier=1 so
+// PortfolioValue takes the PnL branch (cash + qty*(price-entry)).
+//
+// leverage determines notional sizing in paper mode: quantity =
+// cash * leverage * 0.95 / price. With leverage=1 (default) the sizing
+// matches 1x spot notional, but without depleting cash.
+//
+// fillQty > 0 means a live fill: use price and fillQty as-is (no slippage,
+// no notional recalc). fillQty == 0 means paper mode: compute qty from
+// leveraged budget with slippage applied.
+func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float64, leverage float64, fillQty float64, feePerContract float64, logger *StrategyLogger) (int, error) {
+	if signal == 0 {
+		return 0, nil
+	}
+	if leverage <= 0 {
+		leverage = 1
+	}
+	tradesExecuted := 0
+
+	// perPlatformFee picks the right fee dispatch for a given strategy
+	// platform. For Hyperliquid spot+perps and OKX perps the existing
+	// CalculatePlatformSpotFee table already encodes the correct taker fee;
+	// feePerContract is reserved for future expansion (unused for now).
+	_ = feePerContract
+	feePlatform := s.Platform
+	if s.Platform == "okx" && s.Type == "perps" {
+		feePlatform = "okx-perps"
+	}
+
+	if signal == 1 { // Buy — go long (close short first if any)
+		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
+			logger.Info("Already long %s (qty=%.6f), skipping buy", symbol, pos.Quantity)
+			return 0, nil
+		}
+		// Close short if exists — realize PnL only (no notional swing).
+		if pos, exists := s.Positions[symbol]; exists && pos.Side == "short" {
+			var execPrice float64
+			if fillQty > 0 {
+				execPrice = price
+			} else {
+				execPrice = ApplySlippage(price)
+			}
+			pnl := pos.Quantity * (pos.AvgCost - execPrice)
+			fee := CalculatePlatformSpotFee(feePlatform, pos.Quantity*execPrice)
+			pnl -= fee
+			s.Cash += pnl
+			trade := Trade{
+				Timestamp:  time.Now().UTC(),
+				StrategyID: s.ID,
+				Symbol:     symbol,
+				Side:       "buy",
+				Quantity:   pos.Quantity,
+				Price:      execPrice,
+				Value:      pos.Quantity * execPrice,
+				TradeType:  "perps",
+				Details:    fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee),
+			}
+			s.TradeHistory = append(s.TradeHistory, trade)
+			RecordTradeResult(&s.RiskState, pnl)
+			delete(s.Positions, symbol)
+			logger.Info("Closed short %s @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, execPrice, fee, pnl)
+			tradesExecuted++
+		}
+		// Open long
+		if s.Cash < 1 {
+			logger.Info("Insufficient cash ($%.2f) to open long %s perp", s.Cash, symbol)
+			return tradesExecuted, nil
+		}
+		var execPrice, qty float64
+		if fillQty > 0 {
+			execPrice = price
+			qty = fillQty
+		} else {
+			execPrice = ApplySlippage(price)
+			if execPrice <= 0 {
+				return tradesExecuted, nil
+			}
+			// Leveraged notional: cash * leverage * 0.95
+			budget := s.Cash * leverage * 0.95
+			qty = budget / execPrice
+		}
+		notional := qty * execPrice
+		fee := CalculatePlatformSpotFee(feePlatform, notional)
+		s.Cash -= fee // margin-based: only fee leaves cash, notional stays virtual
+		now := time.Now().UTC()
+		s.Positions[symbol] = &Position{
+			Symbol:          symbol,
+			Quantity:        qty,
+			AvgCost:         execPrice,
+			Side:            "long",
+			Multiplier:      1, // perps use 1:1 contract size; PnL-branch in PortfolioValue
+			Leverage:        leverage,
+			OwnerStrategyID: s.ID,
+			OpenedAt:        now,
+		}
+		trade := Trade{
+			Timestamp:  now,
+			StrategyID: s.ID,
+			Symbol:     symbol,
+			Side:       "buy",
+			Quantity:   qty,
+			Price:      execPrice,
+			Value:      notional,
+			TradeType:  "perps",
+			Details:    fmt.Sprintf("Open long %.6f @ $%.2f (%.1fx, fee $%.2f)", qty, execPrice, leverage, fee),
+		}
+		s.TradeHistory = append(s.TradeHistory, trade)
+		logger.Info("BUY %s: %.6f @ $%.2f (%.1fx, notional $%.2f, fee $%.2f)", symbol, qty, execPrice, leverage, notional, fee)
+		tradesExecuted++
+
+	} else if signal == -1 { // Sell — close long (no auto-open-short; matches current spot wrapper)
+		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
+			var execPrice float64
+			if fillQty > 0 {
+				execPrice = price
+			} else {
+				execPrice = ApplySlippage(price)
+			}
+			pnl := pos.Quantity * (execPrice - pos.AvgCost)
+			fee := CalculatePlatformSpotFee(feePlatform, pos.Quantity*execPrice)
+			pnl -= fee
+			s.Cash += pnl
+			trade := Trade{
+				Timestamp:  time.Now().UTC(),
+				StrategyID: s.ID,
+				Symbol:     symbol,
+				Side:       "sell",
+				Quantity:   pos.Quantity,
+				Price:      execPrice,
+				Value:      pos.Quantity * execPrice,
+				TradeType:  "perps",
+				Details:    fmt.Sprintf("Close long, PnL: $%.2f (fee $%.2f)", pnl, fee),
+			}
+			s.TradeHistory = append(s.TradeHistory, trade)
+			RecordTradeResult(&s.RiskState, pnl)
+			delete(s.Positions, symbol)
+			logger.Info("SELL %s: %.6f @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, pos.Quantity, execPrice, fee, pnl)
+			tradesExecuted++
+		} else {
+			logger.Info("No long position in %s to sell, skipping", symbol)
+		}
+	}
+	return tradesExecuted, nil
 }
 
 // ExecuteSpotSignal processes a spot signal and executes paper or live trades.

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -501,7 +501,7 @@ func TestExecutePerpsSignalPaperBuyNoNotionalDeduction(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 5, 0, 0, logger)
+	trades, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 5, 0, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -556,7 +556,7 @@ func TestExecutePerpsSignalPortfolioValueAfterMove(t *testing.T) {
 	defer logger.Close()
 
 	// Open at exactly 2000 via live fill (no slippage).
-	_, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 1, 0.5, 0, logger)
+	_, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 1, 0.5, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -601,7 +601,7 @@ func TestExecutePerpsSignalNotInflatedByNotional(t *testing.T) {
 	defer logger.Close()
 
 	// Live fill 0.279 ETH @ 2210.71 (matching the issue example).
-	_, err := ExecutePerpsSignal(s, 1, "ETH", 2210.71, 1, 0.279, 0, logger)
+	_, err := ExecutePerpsSignal(s, 1, "ETH", 2210.71, 1, 0.279, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -644,7 +644,7 @@ func TestExecutePerpsSignalCloseLong(t *testing.T) {
 	defer logger.Close()
 
 	// Close at 2100 — PnL = 0.5 * (2100 - 2000) = $50 gross.
-	_, err := ExecutePerpsSignal(s, -1, "ETH", 2100, 1, 0.5, 0, logger)
+	_, err := ExecutePerpsSignal(s, -1, "ETH", 2100, 1, 0.5, logger)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -482,6 +482,181 @@ func TestExecuteSpotSignalLiveFill(t *testing.T) {
 	}
 }
 
+// #254: ExecutePerpsSignal — margin-based accounting. Paper buy should NOT
+// deplete cash by the full notional (unlike spot). Only the fee leaves cash,
+// and the opened position is stamped with Multiplier=1 so PortfolioValue
+// routes through the PnL branch.
+func TestExecutePerpsSignalPaperBuyNoNotionalDeduction(t *testing.T) {
+	s := &StrategyState{
+		ID:              "hl-test-eth",
+		Cash:            1000,
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	trades, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 5, 0, 0, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+
+	pos := s.Positions["ETH"]
+	if pos == nil {
+		t.Fatal("should have ETH position")
+	}
+	if pos.Side != "long" {
+		t.Errorf("side = %q, want long", pos.Side)
+	}
+	if pos.Multiplier != 1 {
+		t.Errorf("multiplier = %v, want 1 (for PnL branch in PortfolioValue)", pos.Multiplier)
+	}
+	if pos.Leverage != 5 {
+		t.Errorf("leverage = %v, want 5", pos.Leverage)
+	}
+	// With leverage=5, budget = 1000 * 5 * 0.95 = 4750 notional
+	// qty ≈ 4750 / 2000 = 2.375 (modulo slippage on execPrice)
+	if pos.Quantity < 2.0 || pos.Quantity > 2.8 {
+		t.Errorf("quantity = %v, want ~2.375 (5x leverage)", pos.Quantity)
+	}
+	// Cash must be untouched except for fee. fee ≈ notional * 0.00035
+	// (hyperliquid fee), so cash should remain > 990.
+	if s.Cash < 990 {
+		t.Errorf("cash = %v, want ~1000 (only fee deducted, not notional)", s.Cash)
+	}
+	if s.Cash >= 1000 {
+		t.Errorf("cash = %v, should have some fee deducted", s.Cash)
+	}
+}
+
+// #254: verify PortfolioValue handles the perps position correctly using the
+// futures branch (qty * multiplier * (price - avgCost)). Cash is preserved,
+// and a favorable price move shows up as PnL on top of cash.
+func TestExecutePerpsSignalPortfolioValueAfterMove(t *testing.T) {
+	s := &StrategyState{
+		ID:              "hl-test-eth",
+		Cash:            1000,
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	// Open at exactly 2000 via live fill (no slippage).
+	_, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 1, 0.5, 0, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cashAfterOpen := s.Cash
+	valueAtEntry := PortfolioValue(s, map[string]float64{"ETH": 2000})
+	// At entry, PnL=0, value = cashAfterOpen.
+	if math.Abs(valueAtEntry-cashAfterOpen) > 1e-6 {
+		t.Errorf("at entry value = %v, cash = %v, want equal (PnL=0)", valueAtEntry, cashAfterOpen)
+	}
+	// Price moves +$10: PnL = 0.5 * (2010 - 2000) = $5.
+	valueAfterMove := PortfolioValue(s, map[string]float64{"ETH": 2010})
+	expected := cashAfterOpen + 5.0
+	if math.Abs(valueAfterMove-expected) > 1e-6 {
+		t.Errorf("value after +$10 move = %v, want %v (cash + PnL)", valueAfterMove, expected)
+	}
+	// Price moves -$10: PnL = -$5.
+	valueAfterDrop := PortfolioValue(s, map[string]float64{"ETH": 1990})
+	expectedDrop := cashAfterOpen - 5.0
+	if math.Abs(valueAfterDrop-expectedDrop) > 1e-6 {
+		t.Errorf("value after -$10 move = %v, want %v (cash + PnL)", valueAfterDrop, expectedDrop)
+	}
+}
+
+// #254: regression — before the fix, perps positions stored with
+// Multiplier=0 hit the spot branch (qty * price) which inflated portfolio
+// value by the full notional. After the fix, ExecutePerpsSignal stamps
+// Multiplier=1 so valuation uses the PnL branch. This test pins the wrong
+// "spot-like" valuation vs the correct "perps" valuation to prevent drift.
+func TestExecutePerpsSignalNotInflatedByNotional(t *testing.T) {
+	s := &StrategyState{
+		ID:              "hl-rmc-eth-live",
+		Cash:            644,
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	// Live fill 0.279 ETH @ 2210.71 (matching the issue example).
+	_, err := ExecutePerpsSignal(s, 1, "ETH", 2210.71, 1, 0.279, 0, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	value := PortfolioValue(s, map[string]float64{"ETH": 2201.10})
+	// At $2201.10 vs entry $2210.71: PnL = 0.279 * (2201.10 - 2210.71) ≈ -$2.68
+	// Expected value ≈ 644 - fee - 2.68 ≈ ~641.3 — NOT inflated.
+	// The buggy spot-branch valuation would be cash (~644) + 0.279*2201 ≈ 1258.
+	if value > 700 {
+		t.Errorf("value = %v, leaking into spot-branch (>$700 means notional not stripped)", value)
+	}
+	if value < 600 || value > 650 {
+		t.Errorf("value = %v, want ~641 (initial capital + unrealized PnL)", value)
+	}
+}
+
+// #254: closing a perps long realizes PnL directly (not notional swing).
+func TestExecutePerpsSignalCloseLong(t *testing.T) {
+	s := &StrategyState{
+		ID:       "hl-test-eth",
+		Cash:     990,
+		Platform: "hyperliquid",
+		Type:     "perps",
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol:     "ETH",
+				Quantity:   0.5,
+				AvgCost:    2000,
+				Side:       "long",
+				Multiplier: 1,
+				Leverage:   2,
+			},
+		},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 1000},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	// Close at 2100 — PnL = 0.5 * (2100 - 2000) = $50 gross.
+	_, err := ExecutePerpsSignal(s, -1, "ETH", 2100, 1, 0.5, 0, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.Positions["ETH"]; ok {
+		t.Error("position should be closed")
+	}
+	// Expected: 990 + 50 - fee(0.5*2100=1050). HL fee ≈ 1050 * 0.00035 ≈ 0.37.
+	if s.Cash < 1039 || s.Cash > 1040.5 {
+		t.Errorf("cash = %v, want ~1039.6 (990 + 50 - fee)", s.Cash)
+	}
+}
+
 func TestExecuteFuturesSignalLiveFill(t *testing.T) {
 	s := &StrategyState{
 		ID:              "ts-momentum-es",


### PR DESCRIPTION
Closes #254

## Summary

- All Hyperliquid perps positions were stored with `Multiplier=0`, so `PortfolioValue` hit the spot branch (`qty * price`) and reported inflated strategy values.
- New `ExecutePerpsSignal` with margin-based accounting: cash is only reduced by the fee, position is stamped `Multiplier=1` so valuation uses the PnL branch, and paper/live sizing uses a leveraged notional budget.
- New `StrategyConfig.Leverage` field (perps-only, [1,100], default 1) flows through HL + OKX perps dispatch and the init wizard.
- `fetchHyperliquidState` parses per-position leverage; `reconcileHyperliquidPositions` copies it into stored positions and migrates legacy `Multiplier=0` positions to `Multiplier=1`.

## Test plan

- [x] `go test ./...` passes
- [x] New unit tests cover `ExecutePerpsSignal` paper/live/close paths, the regression from the issue example, leverage validation, legacy position migration, and leverage parsing from `clearinghouseState`.
- [ ] Smoke test on a running scheduler with a real HL strategy

🤖 Generated with [Claude Code](https://claude.ai/code)