### PR TITLE
feat(ci): append ccusage token/cost summary to Claude bot comment

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -188,10 +188,15 @@ jobs:
             exit 0
           fi
 
-          NEW_BODY="${BODY}
+          USAGE=$(npx --yes ccusage@latest session --json 2>/dev/null || echo "[]")
+          COST=$(printf '%s' "$USAGE" | jq -r 'if type == "array" and length > 0 then .[0] | "Tokens: \(.inputTokens // 0) in / \(.outputTokens // 0) out | Cost: $\(.totalCost // 0 | . * 100 | round / 100)" else "" end' 2>/dev/null || true)
 
-          ---
-          Generated with: ${MODEL_NAME} | Effort: ${EFFORT}"
+          FOOTER="---"$'\n'"Generated with: ${MODEL_NAME} | Effort: ${EFFORT}"
+          if [ -n "$COST" ]; then
+            FOOTER="${FOOTER} | ${COST}"
+          fi
+
+          NEW_BODY="${BODY}"$'\n\n'"${FOOTER}"
 
           gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
             --method PATCH \

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -189,7 +189,7 @@ jobs:
           fi
 
           USAGE=$(npx --yes ccusage@latest session --json 2>/dev/null || echo "[]")
-          COST=$(printf '%s' "$USAGE" | jq -r 'if type == "array" and length > 0 then .[0] | "Tokens: \(.inputTokens // 0) in / \(.outputTokens // 0) out | Cost: $\(.totalCost // 0 | . * 100 | round / 100)" else "" end' 2>/dev/null || true)
+          COST=$(printf '%s' "$USAGE" | jq -r 'if type == "array" and length > 0 then .[0] | "Tokens: \(.inputTokens // 0) in / \(.outputTokens // 0) out | Cache: \(.cacheReadTokens // 0) read / \(.cacheCreationTokens // 0) written | Cost: $\(.totalCost // 0 | . * 100 | round / 100)" else "" end' 2>/dev/null || true)
 
           FOOTER="---"$'\n'"Generated with: ${MODEL_NAME} | Effort: ${EFFORT}"
           if [ -n "$COST" ]; then


### PR DESCRIPTION
## Summary

- After each `@claude` run, calls `ccusage` to read the session JSONL logs written by Claude Code on the runner
- Parses token counts (input/output) and estimated cost via `--json` flag
- Appends the usage info inline to the existing model/effort footer in the bot's GitHub comment

The footer will look like:
```
---
Generated with: Claude Opus 4.6 | Effort: high | Tokens: 12345 in / 3456 out | Cost: $0.42
```

If `ccusage` finds no data or fails, the footer gracefully falls back to just the model/effort line.

## Test plan

- [ ] Trigger `@claude` on an issue or PR comment and verify the footer includes token/cost info
- [ ] Verify graceful fallback when ccusage returns no data

---
Generated with: Claude Sonnet 4.6 | Effort: 55