### PR TITLE
fix(ci): debug ccusage session lookup

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -191,7 +191,7 @@ jobs:
           TODAY=$(date -u +%Y%m%d)
           USAGE=$(npx --yes ccusage@latest session --json --since "$TODAY" --order desc 2>/tmp/ccusage-err || echo "[]")
           [ -s /tmp/ccusage-err ] && echo "ccusage stderr: $(cat /tmp/ccusage-err)"
-          echo "ccusage session count: $(printf '%s' "$USAGE" | jq 'length' 2>/dev/null || echo 'parse error')"
+          echo "ccusage raw: $USAGE"
           COST=$(printf '%s' "$USAGE" | jq -r 'if type == "array" and length > 0 then .[0] | "Tokens: \(.inputTokens // 0) in / \(.outputTokens // 0) out | Cache: \(.cacheReadTokens // 0) read / \(.cacheCreationTokens // 0) written | Cost: $\(.totalCost // 0 | . * 100 | round / 100)" else "" end' 2>/dev/null || true)
 
           FOOTER="---"$'\n'"Generated with: ${MODEL_NAME} | Effort: ${EFFORT}"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -188,7 +188,10 @@ jobs:
             exit 0
           fi
 
-          USAGE=$(npx --yes ccusage@latest session --json 2>/dev/null || echo "[]")
+          TODAY=$(date -u +%Y%m%d)
+          USAGE=$(npx --yes ccusage@latest session --json --since "$TODAY" --order desc 2>/tmp/ccusage-err || echo "[]")
+          [ -s /tmp/ccusage-err ] && echo "ccusage stderr: $(cat /tmp/ccusage-err)"
+          echo "ccusage session count: $(printf '%s' "$USAGE" | jq 'length' 2>/dev/null || echo 'parse error')"
           COST=$(printf '%s' "$USAGE" | jq -r 'if type == "array" and length > 0 then .[0] | "Tokens: \(.inputTokens // 0) in / \(.outputTokens // 0) out | Cache: \(.cacheReadTokens // 0) read / \(.cacheCreationTokens // 0) written | Cost: $\(.totalCost // 0 | . * 100 | round / 100)" else "" end' 2>/dev/null || true)
 
           FOOTER="---"$'\n'"Generated with: ${MODEL_NAME} | Effort: ${EFFORT}"


### PR DESCRIPTION
## Summary

- Adds `--since <today>` and `--order desc` to `ccusage session --json` so the most recent session is `.[0]` and stale data is excluded
- Captures ccusage stderr to `/tmp/ccusage-err` and prints it in the workflow log (instead of silently swallowing with `2>/dev/null`)
- Prints session count so we can tell if ccusage finds data at all in the Actions runner

## Why

The ccusage token/cost footer wasn't appearing — `USAGE` returned `[]`. The `2>/dev/null` was hiding the reason. This change surfaces the error so we can diagnose whether it's a missing data path, install failure, or something else.

## Test plan

- [ ] Trigger `@claude` on any issue, then check "Append model/effort footer" step logs for `ccusage session count` and any `ccusage stderr` output

---
Generated with: Claude Sonnet 4.6 | Effort: 55