### PR TITLE
fix: revalue futures positions at live mark in PortfolioNotional/Value

### DIFF
--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -501,6 +501,13 @@ func FetchPrices(symbols []string) (map[string]float64, error) {
 // REST in live mode) because BinanceUS does not quote ES/NQ/MES/MNQ/CL.
 // See issue #261: without this, PortfolioNotional revalued futures positions
 // at pos.AvgCost, freezing exposure at entry cost.
+//
+// The script embeds a reserved "_mode" metadata key in its JSON output
+// (one of "live", "paper", "paper_fallback"). paper_fallback indicates
+// that live-mode init failed (e.g. missing deps, network init error) and
+// the script silently degraded to yfinance paper quotes — we log a
+// [WARN] so operators aren't blind to the downgrade, since a single
+// stderr line is easy to miss on a long-running scheduler.
 func FetchFuturesMarks(symbols []string) (map[string]float64, error) {
 	if len(symbols) == 0 {
 		return map[string]float64{}, nil
@@ -510,9 +517,29 @@ func FetchFuturesMarks(symbols []string) (map[string]float64, error) {
 		return nil, fmt.Errorf("futures marks fetch error: %w (stderr: %s)", err, string(stderr))
 	}
 
-	var marks map[string]float64
-	if err := json.Unmarshal(stdout, &marks); err != nil {
+	// The script mixes float prices with a string "_mode" metadata key,
+	// so decode into interface{} first, then split into the
+	// float-keyed marks map and the mode string.
+	var raw map[string]interface{}
+	if err := json.Unmarshal(stdout, &raw); err != nil {
 		return nil, fmt.Errorf("parse futures marks: %w (stdout: %s)", err, string(stdout))
+	}
+
+	marks := make(map[string]float64, len(raw))
+	mode := ""
+	for k, v := range raw {
+		if k == "_mode" {
+			if s, ok := v.(string); ok {
+				mode = s
+			}
+			continue
+		}
+		if f, ok := v.(float64); ok {
+			marks[k] = f
+		}
+	}
+	if mode == "paper_fallback" {
+		fmt.Printf("[WARN] fetch_futures_marks: live mode init failed, degraded to paper (yfinance) — check TopStepX creds and network\n")
 	}
 	return marks, nil
 }

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -494,3 +494,25 @@ func FetchPrices(symbols []string) (map[string]float64, error) {
 	}
 	return prices, nil
 }
+
+// FetchFuturesMarks runs fetch_futures_marks.py and returns a map of
+// contract-symbol→mark-price for CME futures (TopStep). Mirrors FetchPrices
+// but routes through the TopStep adapter (yfinance in paper mode, TopStepX
+// REST in live mode) because BinanceUS does not quote ES/NQ/MES/MNQ/CL.
+// See issue #261: without this, PortfolioNotional revalued futures positions
+// at pos.AvgCost, freezing exposure at entry cost.
+func FetchFuturesMarks(symbols []string) (map[string]float64, error) {
+	if len(symbols) == 0 {
+		return map[string]float64{}, nil
+	}
+	stdout, stderr, err := RunPythonScript("shared_scripts/fetch_futures_marks.py", symbols)
+	if err != nil {
+		return nil, fmt.Errorf("futures marks fetch error: %w (stderr: %s)", err, string(stderr))
+	}
+
+	var marks map[string]float64
+	if err := json.Unmarshal(stdout, &marks); err != nil {
+		return nil, fmt.Errorf("parse futures marks: %w (stdout: %s)", err, string(stdout))
+	}
+	return marks, nil
+}

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -495,37 +495,56 @@ func FetchPrices(symbols []string) (map[string]float64, error) {
 	return prices, nil
 }
 
+// FuturesMarkModePaperFallback is the mode string returned by
+// fetch_futures_marks.py when live mode init failed (e.g. missing deps,
+// network error) and the script silently degraded to yfinance paper quotes.
+// Callers that care about surfacing the downgrade compare against this
+// constant. "live" and "paper" are also valid mode strings but represent
+// expected states, so the Go side does not act on them.
+const FuturesMarkModePaperFallback = "paper_fallback"
+
 // FetchFuturesMarks runs fetch_futures_marks.py and returns a map of
-// contract-symbol→mark-price for CME futures (TopStep). Mirrors FetchPrices
-// but routes through the TopStep adapter (yfinance in paper mode, TopStepX
-// REST in live mode) because BinanceUS does not quote ES/NQ/MES/MNQ/CL.
-// See issue #261: without this, PortfolioNotional revalued futures positions
+// contract-symbol→mark-price for CME futures (TopStep), plus the mode
+// string embedded by the Python script. Mirrors FetchPrices but routes
+// through the TopStep adapter (yfinance in paper mode, TopStepX REST in
+// live mode) because BinanceUS does not quote ES/NQ/MES/MNQ/CL. See
+// issue #261: without this, PortfolioNotional revalued futures positions
 // at pos.AvgCost, freezing exposure at entry cost.
 //
 // The script embeds a reserved "_mode" metadata key in its JSON output
-// (one of "live", "paper", "paper_fallback"). paper_fallback indicates
-// that live-mode init failed (e.g. missing deps, network init error) and
-// the script silently degraded to yfinance paper quotes — we log a
-// [WARN] so operators aren't blind to the downgrade, since a single
-// stderr line is easy to miss on a long-running scheduler.
-func FetchFuturesMarks(symbols []string) (map[string]float64, error) {
+// (one of "live", "paper", "paper_fallback"). We strip it from the
+// returned marks map (this is also the *only* filter site for "_mode" —
+// mergeFuturesMarks never sees it) and return it as a separate value so
+// callers can decide how to surface paper_fallback. Logging is NOT done
+// here because this function is called from both the main cycle loop
+// (naturally rate-limited) and /status (polled frequently, needs
+// throttled logging to avoid spam during sustained downgrades).
+func FetchFuturesMarks(symbols []string) (map[string]float64, string, error) {
 	if len(symbols) == 0 {
-		return map[string]float64{}, nil
+		return map[string]float64{}, "", nil
 	}
 	stdout, stderr, err := RunPythonScript("shared_scripts/fetch_futures_marks.py", symbols)
 	if err != nil {
-		return nil, fmt.Errorf("futures marks fetch error: %w (stderr: %s)", err, string(stderr))
+		return nil, "", fmt.Errorf("futures marks fetch error: %w (stderr: %s)", err, string(stderr))
 	}
 
 	// The script mixes float prices with a string "_mode" metadata key,
 	// so decode into interface{} first, then split into the
-	// float-keyed marks map and the mode string.
+	// float-keyed marks map and the mode string. This loop is the only
+	// place "_mode" is filtered out — downstream code (mergeFuturesMarks,
+	// PortfolioNotional) operates on the already-clean map[string]float64
+	// and never has to defend against the string key. If a future refactor
+	// changes this return type, the filter must move with it.
 	var raw map[string]interface{}
 	if err := json.Unmarshal(stdout, &raw); err != nil {
-		return nil, fmt.Errorf("parse futures marks: %w (stdout: %s)", err, string(stdout))
+		return nil, "", fmt.Errorf("parse futures marks: %w (stdout: %s)", err, string(stdout))
 	}
 
 	marks := make(map[string]float64, len(raw))
+	// mode is parsed on every call so callers can detect silent downgrades
+	// (paper_fallback); "live" and "paper" are expected happy-path states
+	// and are intentionally not logged anywhere — see callers in main.go
+	// and server.go which only branch on FuturesMarkModePaperFallback.
 	mode := ""
 	for k, v := range raw {
 		if k == "_mode" {
@@ -538,8 +557,5 @@ func FetchFuturesMarks(symbols []string) (map[string]float64, error) {
 			marks[k] = f
 		}
 	}
-	if mode == "paper_fallback" {
-		fmt.Printf("[WARN] fetch_futures_marks: live mode init failed, degraded to paper (yfinance) — check TopStepX creds and network\n")
-	}
-	return marks, nil
+	return marks, mode, nil
 }

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -316,6 +316,10 @@ func main() {
 		// asset as their position key, so we fetch under a normalized
 		// "<base>/USDT" form and mirror the result back — #245.
 		symbols, perpsMirror := collectPriceSymbols(cfg.Strategies)
+		// Futures (TopStep CME) are on a separate price rail — BinanceUS
+		// doesn't quote ES/NQ/MES/MNQ/CL, so dispatch to the TopStep
+		// adapter via fetch_futures_marks.py — #261.
+		futuresSymbols := collectFuturesMarkSymbols(cfg.Strategies)
 
 		// Fetch current prices for portfolio valuation
 		prices := make(map[string]float64)
@@ -338,6 +342,24 @@ func main() {
 				fmt.Printf("[CRITICAL] All prices are zero/missing — skipping cycle\n")
 				continue
 			}
+		}
+		// Futures marks are best-effort: a failed fetch falls back to
+		// pos.AvgCost in PortfolioNotional/Value (same as pre-#261), it is
+		// NOT a hard cycle skip. Log a [WARN] so stale exposure is visible.
+		if len(futuresSymbols) > 0 {
+			marks, err := FetchFuturesMarks(futuresSymbols)
+			if err != nil {
+				fmt.Printf("[WARN] Futures marks fetch failed for %v: %v — portfolio notional will use entry cost for open futures positions\n", futuresSymbols, err)
+			} else {
+				mergeFuturesMarks(prices, marks)
+				for _, sym := range futuresSymbols {
+					if _, ok := prices[sym]; !ok {
+						fmt.Printf("[WARN] No futures mark for %s — PortfolioNotional/Value will fall back to entry cost\n", sym)
+					}
+				}
+			}
+		}
+		if len(prices) > 0 {
 			fmt.Printf("Prices: ")
 			for sym, price := range prices {
 				fmt.Printf("%s=$%.2f ", sym, price)
@@ -933,6 +955,8 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, notifier
 
 	// Collect symbols that need prices (spot + perps, #245).
 	symbols, perpsMirror := collectPriceSymbols(cfg.Strategies)
+	// Futures marks live on a separate rail (#261).
+	futuresSymbols := collectFuturesMarkSymbols(cfg.Strategies)
 
 	// Fetch current prices.
 	prices := make(map[string]float64)
@@ -948,6 +972,14 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, notifier
 			}
 		}
 		mirrorPerpsPrices(prices, perpsMirror)
+	}
+	if len(futuresSymbols) > 0 {
+		marks, err := FetchFuturesMarks(futuresSymbols)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[WARN] Futures marks fetch failed for %v: %v — summary will use entry cost\n", futuresSymbols, err)
+		} else {
+			mergeFuturesMarks(prices, marks)
+		}
 	}
 
 	// Calculate channel value.

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -347,10 +347,17 @@ func main() {
 		// pos.AvgCost in PortfolioNotional/Value (same as pre-#261), it is
 		// NOT a hard cycle skip. Log a [WARN] so stale exposure is visible.
 		if len(futuresSymbols) > 0 {
-			marks, err := FetchFuturesMarks(futuresSymbols)
+			marks, mode, err := FetchFuturesMarks(futuresSymbols)
 			if err != nil {
 				fmt.Printf("[WARN] Futures marks fetch failed for %v: %v — portfolio notional will use entry cost for open futures positions\n", futuresSymbols, err)
 			} else {
+				// Main cycle loop is naturally rate-limited by the tick
+				// interval, so the paper_fallback warning can fire
+				// unthrottled here — one log per cycle on a sustained
+				// downgrade. /status uses a throttled logger instead.
+				if mode == FuturesMarkModePaperFallback {
+					fmt.Printf("[WARN] fetch_futures_marks: live mode init failed, degraded to paper (yfinance) — check TopStepX creds and network\n")
+				}
 				mergeFuturesMarks(prices, marks)
 				for _, sym := range futuresSymbols {
 					if _, ok := prices[sym]; !ok {
@@ -974,10 +981,14 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, notifier
 		mirrorPerpsPrices(prices, perpsMirror)
 	}
 	if len(futuresSymbols) > 0 {
-		marks, err := FetchFuturesMarks(futuresSymbols)
+		marks, mode, err := FetchFuturesMarks(futuresSymbols)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[WARN] Futures marks fetch failed for %v: %v — summary will use entry cost\n", futuresSymbols, err)
 		} else {
+			// One-shot summary path — not polled, so unthrottled log is fine.
+			if mode == FuturesMarkModePaperFallback {
+				fmt.Fprintf(os.Stderr, "[WARN] fetch_futures_marks: live mode init failed, degraded to paper (yfinance) — check TopStepX creds and network\n")
+			}
 			mergeFuturesMarks(prices, marks)
 		}
 	}

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -80,6 +80,61 @@ func mirrorPerpsPrices(prices map[string]float64, mirror map[string]string) {
 	}
 }
 
+// collectFuturesMarkSymbols returns the list of CME futures contract
+// symbols (e.g. "ES", "NQ", "MES", "MNQ", "CL") that need live marks to
+// revalue open futures positions. Sibling to collectPriceSymbols — kept
+// separate because the price-source rail is different: check_price.py
+// queries BinanceUS which does not list CME futures, so the Go scheduler
+// has to dispatch these symbols to fetch_futures_marks.py (TopStep
+// adapter) instead.
+//
+// Futures strategies store positions under the bare contract symbol
+// (state.Positions["ES"]) with Multiplier > 0; the strategy's Args[1] is
+// the same symbol, so no normalization or alias mirroring is needed.
+// Issue #261: without this, PortfolioNotional / PortfolioValue fell back
+// to pos.AvgCost for futures, freezing exposure at entry cost.
+func collectFuturesMarkSymbols(strategies []StrategyConfig) []string {
+	set := make(map[string]bool)
+	for _, sc := range strategies {
+		if sc.Type != "futures" {
+			continue
+		}
+		if len(sc.Args) < 2 {
+			continue
+		}
+		sym := sc.Args[1]
+		if sym == "" {
+			continue
+		}
+		set[sym] = true
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	symbols := make([]string, 0, len(set))
+	for s := range set {
+		symbols = append(symbols, s)
+	}
+	sort.Strings(symbols)
+	return symbols
+}
+
+// mergeFuturesMarks copies non-zero futures mark prices into the shared
+// prices map. Existing entries win — matches mirrorPerpsPrices semantics
+// so that any live mark a strategy may have already published during the
+// cycle is not overwritten by a (possibly staler) fetch result.
+func mergeFuturesMarks(prices map[string]float64, marks map[string]float64) {
+	for sym, p := range marks {
+		if p <= 0 {
+			continue
+		}
+		if _, exists := prices[sym]; exists {
+			continue
+		}
+		prices[sym] = p
+	}
+}
+
 const maxKillSwitchEvents = 50
 
 // KillSwitchEvent records a kill switch lifecycle event for audit purposes.

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -93,10 +93,22 @@ func mirrorPerpsPrices(prices map[string]float64, mirror map[string]string) {
 // the same symbol, so no normalization or alias mirroring is needed.
 // Issue #261: without this, PortfolioNotional / PortfolioValue fell back
 // to pos.AvgCost for futures, freezing exposure at entry cost.
+//
+// Platform filter: only "topstep" futures strategies are emitted.
+// fetch_futures_marks.py hardcodes TopStepExchangeAdapter, so routing a
+// non-TopStep futures symbol (e.g. a future IBKR futures adapter) through
+// this path would either fail outright or — worse — succeed against a
+// different contract on a different exchange. When a second futures
+// adapter is added, this helper should be generalized to return a
+// platform→symbols map (or similar) and fetch_futures_marks.py should
+// gain platform-aware dispatch.
 func collectFuturesMarkSymbols(strategies []StrategyConfig) []string {
 	set := make(map[string]bool)
 	for _, sc := range strategies {
 		if sc.Type != "futures" {
+			continue
+		}
+		if sc.Platform != "topstep" {
 			continue
 		}
 		if len(sc.Args) < 2 {
@@ -123,6 +135,19 @@ func collectFuturesMarkSymbols(strategies []StrategyConfig) []string {
 // prices map. Existing entries win — matches mirrorPerpsPrices semantics
 // so that any live mark a strategy may have already published during the
 // cycle is not overwritten by a (possibly staler) fetch result.
+//
+// DO NOT "simplify" the skip-if-exists branch. Today the only writer
+// that could pre-populate e.g. prices["ES"] is a hypothetical futures
+// strategy publishing its own live exchange mark via result.Symbol
+// earlier in the cycle — mirrorPerpsPrices runs first but only writes
+// "/USDT"-quoted spot keys, so collisions with bare CME symbols like
+// "ES" or "NQ" are not expected in the current code paths. The guard is
+// still required: a strategy-published mark is ground truth for the
+// cycle (observed during check), whereas fetch_futures_marks is a
+// generic snapshot pulled afterwards and may be slightly stale. When
+// both exist, prefer the former. Preserving this invariant matters for
+// anyone adding strategy-level mark publishing later — removing the
+// skip would silently regress that contract.
 func mergeFuturesMarks(prices map[string]float64, marks map[string]float64) {
 	for sym, p := range marks {
 		if p <= 0 {

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -397,6 +397,152 @@ func TestPortfolioNotional_IncludesPerps(t *testing.T) {
 	}
 }
 
+// TestPortfolioNotional_IncludesFutures verifies that TopStep/CME futures
+// positions (Type="futures", Multiplier > 0, keyed under the bare contract
+// symbol like "ES") are revalued in notional at the live mark rather than
+// frozen at pos.AvgCost. Regression test for issue #261: before the fix,
+// collectPriceSymbols handled only spot + perps, so futures positions had
+// no entry in the prices map and PortfolioNotional fell back to AvgCost —
+// after a rally this understated exposure, after a drawdown it overstated
+// it, breaking the portfolio-notional kill switch for TopStep strategies.
+func TestPortfolioNotional_IncludesFutures(t *testing.T) {
+	strategies := map[string]*StrategyState{
+		"ts-trend-es": {
+			Type: "futures",
+			Positions: map[string]*Position{
+				// TopStep futures: 2 ES contracts long, entry 5000, multiplier 50.
+				"ES": {Symbol: "ES", Quantity: 2, AvgCost: 5000.0, Side: "long", Multiplier: 50},
+			},
+			OptionPositions: make(map[string]*OptionPosition),
+		},
+		"ts-mr-nq": {
+			Type: "futures",
+			Positions: map[string]*Position{
+				// 1 NQ contract short, entry 18000, multiplier 20.
+				"NQ": {Symbol: "NQ", Quantity: 1, AvgCost: 18000.0, Side: "short", Multiplier: 20},
+			},
+			OptionPositions: make(map[string]*OptionPosition),
+		},
+	}
+
+	// Simulate the prices map after fetch_futures_marks.py has merged
+	// live TopStep adapter quotes. Both marks diverge from entry — that
+	// is exactly what the fix unlocks for the notional computation.
+	prices := map[string]float64{
+		"ES": 5100.0,
+		"NQ": 18500.0,
+	}
+
+	notional := PortfolioNotional(strategies, prices)
+
+	// ES long: 2 * 50 * 5100 = 510000
+	// NQ short: 1 * 20 * 18500 = 370000 (absolute notional, sign-agnostic)
+	// Total:    880000
+	expected := 880000.0
+	if notional < expected-0.01 || notional > expected+0.01 {
+		t.Errorf("expected futures notional at live mark=%.2f; got %.2f", expected, notional)
+	}
+
+	// Guard the regression: the buggy pre-fix computation would have used
+	// pos.AvgCost, so assert the result is NOT equal to the frozen-entry
+	// notional (2*50*5000 + 1*20*18000 = 500000 + 360000 = 860000).
+	frozen := 860000.0
+	if notional == frozen {
+		t.Errorf("notional equals frozen-entry value %.2f — mark price was not applied", frozen)
+	}
+}
+
+// TestPortfolioNotional_FuturesMarkMiss verifies graceful degradation
+// when fetch_futures_marks.py returns no price for a symbol: the function
+// must fall back to pos.AvgCost (pre-fix behavior) rather than double-
+// counting or crashing. This is the acceptance-criteria fallback path —
+// the kill switch degrades toward stale exposure, not a cycle skip.
+func TestPortfolioNotional_FuturesMarkMiss(t *testing.T) {
+	strategies := map[string]*StrategyState{
+		"ts-trend-cl": {
+			Type: "futures",
+			Positions: map[string]*Position{
+				"CL": {Symbol: "CL", Quantity: 1, AvgCost: 80.0, Side: "long", Multiplier: 1000},
+			},
+			OptionPositions: make(map[string]*OptionPosition),
+		},
+	}
+	// Empty prices map — simulates fetch_futures_marks.py failing or
+	// omitting this symbol.
+	notional := PortfolioNotional(strategies, map[string]float64{})
+
+	// Fallback: 1 * 1000 * 80 (entry) = 80000
+	expected := 80000.0
+	if notional < expected-0.01 || notional > expected+0.01 {
+		t.Errorf("expected fallback notional=%.2f; got %.2f", expected, notional)
+	}
+}
+
+// TestCollectFuturesMarkSymbols verifies that only futures strategies
+// contribute to the CME mark fetch list and that duplicate symbols are
+// deduplicated. Spot/perps/options must NOT appear — they live on the
+// check_price.py rail, not fetch_futures_marks.py.
+func TestCollectFuturesMarkSymbols(t *testing.T) {
+	strategies := []StrategyConfig{
+		{ID: "ts-trend-es", Type: "futures", Platform: "topstep", Args: []string{"trend", "ES", "1h"}},
+		{ID: "ts-mr-es", Type: "futures", Platform: "topstep", Args: []string{"mean_rev", "ES", "15m"}}, // dup symbol
+		{ID: "ts-trend-nq", Type: "futures", Platform: "topstep", Args: []string{"trend", "NQ", "1h"}},
+		{ID: "ts-trend-mes", Type: "futures", Platform: "topstep", Args: []string{"trend", "MES", "1h"}},
+		// Non-futures strategies must be ignored.
+		{ID: "sma-btc", Type: "spot", Platform: "binanceus", Args: []string{"sma", "BTC/USDT", "1h"}},
+		{ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "ETH", "1h"}},
+		{ID: "deribit-vol-btc", Type: "options", Platform: "deribit", Args: []string{"vol", "BTC"}},
+		// Short-arg strategy should be ignored.
+		{ID: "short", Type: "futures", Args: []string{"trend"}},
+	}
+
+	got := collectFuturesMarkSymbols(strategies)
+	want := []string{"ES", "MES", "NQ"} // sorted
+	if len(got) != len(want) {
+		t.Fatalf("got %d symbols %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i, sym := range want {
+		if got[i] != sym {
+			t.Errorf("got[%d]=%q, want %q (full: %v)", i, got[i], sym, got)
+		}
+	}
+}
+
+// TestMergeFuturesMarks verifies that mergeFuturesMarks copies non-zero
+// marks into the shared prices map, preserves existing entries (so a
+// live mark already published during the cycle wins over a fetcher
+// fallback), and skips zero/negative values.
+func TestMergeFuturesMarks(t *testing.T) {
+	prices := map[string]float64{
+		"BTC/USDT": 50000.0, // unrelated spot, must be untouched
+		"ES":       5120.5,  // strategy already published live mark — must win
+	}
+	marks := map[string]float64{
+		"ES":  5100.0, // stale, must not overwrite
+		"NQ":  18500.0,
+		"MES": 0.0, // missing/failed — must be skipped
+		"CL":  -1,  // bogus — must be skipped
+	}
+
+	mergeFuturesMarks(prices, marks)
+
+	if prices["BTC/USDT"] != 50000.0 {
+		t.Errorf("prices[BTC/USDT] = %v, want 50000 (unrelated entry mutated)", prices["BTC/USDT"])
+	}
+	if prices["ES"] != 5120.5 {
+		t.Errorf("prices[ES] = %v, want 5120.5 (existing live mark must win)", prices["ES"])
+	}
+	if prices["NQ"] != 18500.0 {
+		t.Errorf("prices[NQ] = %v, want 18500 (new mark must be merged)", prices["NQ"])
+	}
+	if _, ok := prices["MES"]; ok {
+		t.Errorf("prices[MES] should not be set when mark is zero (got %v)", prices["MES"])
+	}
+	if _, ok := prices["CL"]; ok {
+		t.Errorf("prices[CL] should not be set when mark is negative (got %v)", prices["CL"])
+	}
+}
+
 // TestPortfolioNotional_IncludesPerpsShort verifies that a perps short
 // also contributes positive exposure to notional (absolute-value
 // interpretation) and is revalued at the live mark rather than frozen at

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -492,8 +492,20 @@ func TestCollectFuturesMarkSymbols(t *testing.T) {
 		{ID: "sma-btc", Type: "spot", Platform: "binanceus", Args: []string{"sma", "BTC/USDT", "1h"}},
 		{ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "ETH", "1h"}},
 		{ID: "deribit-vol-btc", Type: "options", Platform: "deribit", Args: []string{"vol", "BTC"}},
-		// Short-arg strategy should be ignored.
-		{ID: "short", Type: "futures", Args: []string{"trend"}},
+		// Short-arg futures strategy should be ignored (early return
+		// guard at risk.go len(sc.Args) < 2).
+		{ID: "ts-short", Type: "futures", Platform: "topstep", Args: []string{"trend"}},
+		// Empty-symbol futures strategy should be ignored (early return
+		// guard at risk.go sym == "") — explicit coverage of that branch
+		// which the short-arg case above cannot reach.
+		{ID: "ts-empty-sym", Type: "futures", Platform: "topstep", Args: []string{"trend", "", "1h"}},
+		// Non-topstep futures platform must be filtered out:
+		// fetch_futures_marks.py hardcodes TopStepExchangeAdapter, so
+		// routing a hypothetical IBKR futures symbol through it would
+		// either fail outright or resolve against the wrong contract.
+		// Use a symbol distinct from the topstep entries so a filter
+		// bypass would leak "CL" into the result and fail this test.
+		{ID: "ibkr-trend-cl", Type: "futures", Platform: "ibkr", Args: []string{"trend", "CL", "1h"}},
 	}
 
 	got := collectFuturesMarkSymbols(strategies)

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -20,14 +20,17 @@ type StatusServer struct {
 	strategies     []StrategyConfig  // strategy configs for initial capital lookup
 	stateDB        *StateDB          // SQLite DB for /history queries (may be nil)
 
-	// Throttled logging for repeated fetch_futures_marks.py failures on
-	// the /status rail. /status can be polled frequently (oncall dashboard,
-	// monitoring), so we don't want to spam logs on every hit — but
-	// silently discarding the error leaves operators blind to a broken
-	// TopStep rail. Emit the first error immediately, then at most once
-	// per futuresErrLogInterval while the failures continue.
-	futuresErrMu           sync.Mutex
-	lastFuturesErrLoggedAt time.Time
+	// Throttled logging for repeated fetch_futures_marks.py failures and
+	// paper_fallback mode on the /status rail. /status can be polled
+	// frequently (oncall dashboard, monitoring), so we don't want to spam
+	// logs on every hit — but silently discarding the error (or the
+	// silent live→paper downgrade) leaves operators blind to a broken
+	// TopStep rail. For each signal (err / paper_fallback), emit the
+	// first occurrence immediately, then at most once per
+	// futuresErrLogInterval while the condition persists.
+	futuresErrMu            sync.Mutex
+	lastFuturesErrLoggedAt  time.Time
+	lastFuturesModeLoggedAt time.Time
 }
 
 // futuresErrLogInterval caps how often /status logs repeated
@@ -71,6 +74,25 @@ func (ss *StatusServer) logFuturesErrThrottled(err error) {
 	ss.lastFuturesErrLoggedAt = now
 	fmt.Printf("[WARN] /status futures marks fetch failed for %v: %v — PortfolioNotional/Value will fall back to entry cost (throttled, next log in %s)\n",
 		ss.futuresSymbols, err, futuresErrLogInterval)
+}
+
+// logFuturesModeThrottled emits a [WARN] line when fetch_futures_marks
+// silently downgraded from live to paper mode on the /status path. Uses
+// the same 5m window as logFuturesErrThrottled so a sustained outage
+// still produces a reasonable trail without drowning the log on every
+// dashboard poll. Thread-safe. Shares futuresErrMu with the error
+// throttle since the state is a handful of timestamps and contention
+// is negligible.
+func (ss *StatusServer) logFuturesModeThrottled() {
+	ss.futuresErrMu.Lock()
+	defer ss.futuresErrMu.Unlock()
+	now := time.Now()
+	if !ss.lastFuturesModeLoggedAt.IsZero() && now.Sub(ss.lastFuturesModeLoggedAt) < futuresErrLogInterval {
+		return
+	}
+	ss.lastFuturesModeLoggedAt = now
+	fmt.Printf("[WARN] /status fetch_futures_marks: live mode init failed, degraded to paper (yfinance) — check TopStepX creds and network (throttled, next log in %s)\n",
+		futuresErrLogInterval)
 }
 
 func (ss *StatusServer) Start(port int) {
@@ -151,7 +173,10 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 	// on a sustained outage, but the first failure (and periodic
 	// reminders) are still visible.
 	if len(ss.futuresSymbols) > 0 {
-		if marks, err := FetchFuturesMarks(ss.futuresSymbols); err == nil {
+		if marks, mode, err := FetchFuturesMarks(ss.futuresSymbols); err == nil {
+			if mode == FuturesMarkModePaperFallback {
+				ss.logFuturesModeThrottled()
+			}
 			mergeFuturesMarks(prices, marks)
 		} else {
 			ss.logFuturesErrThrottled(err)

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -19,7 +19,22 @@ type StatusServer struct {
 	futuresSymbols []string          // CME futures contracts that need TopStep marks (#261)
 	strategies     []StrategyConfig  // strategy configs for initial capital lookup
 	stateDB        *StateDB          // SQLite DB for /history queries (may be nil)
+
+	// Throttled logging for repeated fetch_futures_marks.py failures on
+	// the /status rail. /status can be polled frequently (oncall dashboard,
+	// monitoring), so we don't want to spam logs on every hit — but
+	// silently discarding the error leaves operators blind to a broken
+	// TopStep rail. Emit the first error immediately, then at most once
+	// per futuresErrLogInterval while the failures continue.
+	futuresErrMu           sync.Mutex
+	lastFuturesErrLoggedAt time.Time
 }
+
+// futuresErrLogInterval caps how often /status logs repeated
+// fetch_futures_marks failures. Kept at 5m so a sustained outage still
+// produces a reasonable trail (every cycle summary) without drowning
+// the log on every dashboard poll.
+const futuresErrLogInterval = 5 * time.Minute
 
 func NewStatusServer(state *AppState, mu *sync.RWMutex, statusToken string, strategies []StrategyConfig, stateDB *StateDB) *StatusServer {
 	// Extract all traded symbols from strategy configs so prices are always
@@ -40,6 +55,22 @@ func NewStatusServer(state *AppState, mu *sync.RWMutex, statusToken string, stra
 		strategies:     strategies,
 		stateDB:        stateDB,
 	}
+}
+
+// logFuturesErrThrottled emits a [WARN] line for a fetch_futures_marks
+// failure on the /status path, skipping emission if we have already
+// logged within futuresErrLogInterval. Thread-safe — /status handlers
+// run concurrently across requests.
+func (ss *StatusServer) logFuturesErrThrottled(err error) {
+	ss.futuresErrMu.Lock()
+	defer ss.futuresErrMu.Unlock()
+	now := time.Now()
+	if !ss.lastFuturesErrLoggedAt.IsZero() && now.Sub(ss.lastFuturesErrLoggedAt) < futuresErrLogInterval {
+		return
+	}
+	ss.lastFuturesErrLoggedAt = now
+	fmt.Printf("[WARN] /status futures marks fetch failed for %v: %v — PortfolioNotional/Value will fall back to entry cost (throttled, next log in %s)\n",
+		ss.futuresSymbols, err, futuresErrLogInterval)
 }
 
 func (ss *StatusServer) Start(port int) {
@@ -115,10 +146,15 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 	mirrorPerpsPrices(prices, ss.priceMirror)
 	// Fetch CME futures marks on their separate rail (#261). Best-effort:
 	// on error, open futures positions fall back to pos.AvgCost — same
-	// degradation behavior as the main cycle loop.
+	// degradation behavior as the main cycle loop. Errors are logged
+	// through a throttle so repeated /status polls don't spam the log
+	// on a sustained outage, but the first failure (and periodic
+	// reminders) are still visible.
 	if len(ss.futuresSymbols) > 0 {
 		if marks, err := FetchFuturesMarks(ss.futuresSymbols); err == nil {
 			mergeFuturesMarks(prices, marks)
+		} else {
+			ss.logFuturesErrThrottled(err)
 		}
 	}
 

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -11,13 +11,14 @@ import (
 
 // StatusServer provides an HTTP endpoint for portfolio status.
 type StatusServer struct {
-	state        *AppState
-	mu           *sync.RWMutex
-	statusToken  string            // if non-empty, /status requires Authorization: Bearer <token>
-	priceSymbols []string          // symbols to always fetch prices for
-	priceMirror  map[string]string // perps position-key → fetch-key aliases (#245)
-	strategies   []StrategyConfig  // strategy configs for initial capital lookup
-	stateDB      *StateDB          // SQLite DB for /history queries (may be nil)
+	state          *AppState
+	mu             *sync.RWMutex
+	statusToken    string            // if non-empty, /status requires Authorization: Bearer <token>
+	priceSymbols   []string          // symbols to always fetch prices for
+	priceMirror    map[string]string // perps position-key → fetch-key aliases (#245)
+	futuresSymbols []string          // CME futures contracts that need TopStep marks (#261)
+	strategies     []StrategyConfig  // strategy configs for initial capital lookup
+	stateDB        *StateDB          // SQLite DB for /history queries (may be nil)
 }
 
 func NewStatusServer(state *AppState, mu *sync.RWMutex, statusToken string, strategies []StrategyConfig, stateDB *StateDB) *StatusServer {
@@ -26,8 +27,19 @@ func NewStatusServer(state *AppState, mu *sync.RWMutex, statusToken string, stra
 	// positions under the base asset (e.g. "BTC"); collectPriceSymbols
 	// normalizes the fetch key to "BTC/USDT" and returns a mirror map so
 	// the handler can back-fill the base-asset alias after FetchPrices.
+	// Futures positions (TopStep CME) are on a separate price rail — #261.
 	symbols, mirror := collectPriceSymbols(strategies)
-	return &StatusServer{state: state, mu: mu, statusToken: statusToken, priceSymbols: symbols, priceMirror: mirror, strategies: strategies, stateDB: stateDB}
+	futuresSymbols := collectFuturesMarkSymbols(strategies)
+	return &StatusServer{
+		state:          state,
+		mu:             mu,
+		statusToken:    statusToken,
+		priceSymbols:   symbols,
+		priceMirror:    mirror,
+		futuresSymbols: futuresSymbols,
+		strategies:     strategies,
+		stateDB:        stateDB,
+	}
 }
 
 func (ss *StatusServer) Start(port int) {
@@ -101,6 +113,14 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	// Back-fill perps position-key aliases (#245).
 	mirrorPerpsPrices(prices, ss.priceMirror)
+	// Fetch CME futures marks on their separate rail (#261). Best-effort:
+	// on error, open futures positions fall back to pos.AvgCost — same
+	// degradation behavior as the main cycle loop.
+	if len(ss.futuresSymbols) > 0 {
+		if marks, err := FetchFuturesMarks(ss.futuresSymbols); err == nil {
+			mergeFuturesMarks(prices, marks)
+		}
+	}
 
 	// Re-acquire read lock to build the response
 	ss.mu.RLock()

--- a/shared_scripts/fetch_futures_marks.py
+++ b/shared_scripts/fetch_futures_marks.py
@@ -37,7 +37,10 @@ def main():
         )
         from adapter import TopStepExchangeAdapter  # type: ignore
     except Exception as e:  # noqa: BLE001
-        print(f"[fetch_futures_marks] adapter import failed: {e}", file=sys.stderr)
+        print(
+            f"[WARN][fetch_futures_marks] adapter import failed: {e}",
+            file=sys.stderr,
+        )
         traceback.print_exc(file=sys.stderr)
         print(json.dumps({}))
         sys.exit(1)
@@ -55,45 +58,61 @@ def main():
     else:
         mode = "paper"
 
+    # Track whether we had to downgrade live→paper so the caller can
+    # surface it in the cycle summary. Emitted as a reserved "_mode" key
+    # in the JSON output, alongside normal symbol→price entries.
+    effective_mode = mode
     try:
         adapter = TopStepExchangeAdapter(mode=mode)
     except Exception as e:  # noqa: BLE001
         # E.g. live mode was requested but requests is missing. Degrade to
         # paper so the scheduler still gets a mark rather than frozen entry
-        # costs on every TopStep position.
+        # costs on every TopStep position. Use [WARN] prefix so the Go
+        # scheduler's log pipeline picks this up as a warning rather than
+        # burying it in generic stderr noise.
         print(
-            f"[fetch_futures_marks] {mode} mode init failed ({e}); "
+            f"[WARN][fetch_futures_marks] {mode} mode init failed ({e}); "
             "falling back to paper",
             file=sys.stderr,
         )
         try:
             adapter = TopStepExchangeAdapter(mode="paper")
+            effective_mode = "paper_fallback"
         except Exception as e2:  # noqa: BLE001
             print(
-                f"[fetch_futures_marks] paper fallback failed: {e2}",
+                f"[WARN][fetch_futures_marks] paper fallback failed: {e2}",
                 file=sys.stderr,
             )
             print(json.dumps({}))
             sys.exit(1)
 
-    marks = {}
+    marks: dict = {}
     for symbol in symbols:
         try:
             price = adapter.get_price(symbol)
             if price and price > 0:
                 marks[symbol] = float(price)
             else:
+                # Omit symbols with no price so Go can detect misses and
+                # fall back to pos.AvgCost with a [WARN] log (same
+                # degradation as get_price exceptions below).
                 print(
-                    f"[fetch_futures_marks] no price for {symbol}",
+                    f"[WARN][fetch_futures_marks] no price for {symbol}",
                     file=sys.stderr,
                 )
         except Exception as e:  # noqa: BLE001
             print(
-                f"[fetch_futures_marks] get_price({symbol}) failed: {e}",
+                f"[WARN][fetch_futures_marks] get_price({symbol}) failed: {e}",
                 file=sys.stderr,
             )
             # Omit failed symbols so Go can detect misses.
 
+    # Attach mode metadata under a reserved "_mode" key so the Go merge
+    # layer can distinguish normal live-mode output from a silent
+    # downgrade. mergeFuturesMarks skips non-positive values, so this
+    # string key will not pollute the prices map even if downstream code
+    # naively iterates without a string-type check.
+    marks["_mode"] = effective_mode
     print(json.dumps(marks))
 
 

--- a/shared_scripts/fetch_futures_marks.py
+++ b/shared_scripts/fetch_futures_marks.py
@@ -86,7 +86,7 @@ def main():
             print(json.dumps({}))
             sys.exit(1)
 
-    marks: dict = {}
+    marks: "dict[str, float | str]" = {}
     for symbol in symbols:
         try:
             price = adapter.get_price(symbol)
@@ -107,11 +107,18 @@ def main():
             )
             # Omit failed symbols so Go can detect misses.
 
-    # Attach mode metadata under a reserved "_mode" key so the Go merge
-    # layer can distinguish normal live-mode output from a silent
-    # downgrade. mergeFuturesMarks skips non-positive values, so this
-    # string key will not pollute the prices map even if downstream code
-    # naively iterates without a string-type check.
+    # Attach mode metadata under a reserved "_mode" key so the Go side can
+    # distinguish normal live/paper output from a silent paper_fallback
+    # downgrade. The type-splitting happens in FetchFuturesMarks
+    # (scheduler/executor.go): that function decodes the JSON into
+    # map[string]interface{}, strips "_mode" into a separate string return
+    # value, and only then populates the float-typed marks map. By the
+    # time mergeFuturesMarks runs, "_mode" has already been filtered out,
+    # so the skip-if-exists / skip-non-positive guards in mergeFuturesMarks
+    # are *separate* safeguards for numeric prices — not defenses against
+    # this metadata key. Do NOT "simplify" by relying on mergeFuturesMarks
+    # to filter "_mode"; if FetchFuturesMarks is ever refactored to return
+    # map[string]interface{} directly, that filter has to move with it.
     marks["_mode"] = effective_mode
     print(json.dumps(marks))
 

--- a/shared_scripts/fetch_futures_marks.py
+++ b/shared_scripts/fetch_futures_marks.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Mark-price fetcher for CME futures symbols (TopStep / issue #261).
+
+Called by the Go scheduler alongside check_price.py to revalue open futures
+positions in PortfolioNotional / PortfolioValue at the live mark rather than
+the frozen entry cost (pos.AvgCost). Cannot reuse check_price.py because
+BinanceUS does not quote CME futures — this script delegates to the TopStep
+adapter, which auto-selects live TopStepX quotes (if TOPSTEP_API_KEY +
+TOPSTEP_API_SECRET + TOPSTEP_ACCOUNT_ID are set) or the yfinance paper
+fallback (ES=F, NQ=F, MES=F, MNQ=F, CL=F, GC=F).
+
+Usage: python3 fetch_futures_marks.py ES NQ MES
+
+Always outputs a JSON object to stdout. Symbols whose price cannot be
+fetched are omitted (matching check_price.py), so the Go caller can detect
+misses and fall back to pos.AvgCost with a [WARN] log — graceful
+degradation, not a hard cycle skip.
+"""
+
+import json
+import os
+import sys
+import traceback
+
+
+def main():
+    symbols = sys.argv[1:]
+    if not symbols:
+        print(json.dumps({}))
+        return
+
+    try:
+        sys.path.insert(
+            0,
+            os.path.join(os.path.dirname(__file__), "..", "platforms", "topstep"),
+        )
+        from adapter import TopStepExchangeAdapter  # type: ignore
+    except Exception as e:  # noqa: BLE001
+        print(f"[fetch_futures_marks] adapter import failed: {e}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        print(json.dumps({}))
+        sys.exit(1)
+
+    # Auto-select live vs paper based on whether TopStepX creds are present.
+    # Live path hits the TopStepX /v1/market/quote endpoint; paper path uses
+    # the yfinance fallback. Both route through adapter.get_price, so the
+    # caller doesn't care which was used.
+    if (
+        os.environ.get("TOPSTEP_API_KEY")
+        and os.environ.get("TOPSTEP_API_SECRET")
+        and os.environ.get("TOPSTEP_ACCOUNT_ID")
+    ):
+        mode = "live"
+    else:
+        mode = "paper"
+
+    try:
+        adapter = TopStepExchangeAdapter(mode=mode)
+    except Exception as e:  # noqa: BLE001
+        # E.g. live mode was requested but requests is missing. Degrade to
+        # paper so the scheduler still gets a mark rather than frozen entry
+        # costs on every TopStep position.
+        print(
+            f"[fetch_futures_marks] {mode} mode init failed ({e}); "
+            "falling back to paper",
+            file=sys.stderr,
+        )
+        try:
+            adapter = TopStepExchangeAdapter(mode="paper")
+        except Exception as e2:  # noqa: BLE001
+            print(
+                f"[fetch_futures_marks] paper fallback failed: {e2}",
+                file=sys.stderr,
+            )
+            print(json.dumps({}))
+            sys.exit(1)
+
+    marks = {}
+    for symbol in symbols:
+        try:
+            price = adapter.get_price(symbol)
+            if price and price > 0:
+                marks[symbol] = float(price)
+            else:
+                print(
+                    f"[fetch_futures_marks] no price for {symbol}",
+                    file=sys.stderr,
+                )
+        except Exception as e:  # noqa: BLE001
+            print(
+                f"[fetch_futures_marks] get_price({symbol}) failed: {e}",
+                file=sys.stderr,
+            )
+            # Omit failed symbols so Go can detect misses.
+
+    print(json.dumps(marks))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #261

## Summary

Fixes the `PortfolioNotional` / `PortfolioValue` stale-price bug for TopStep CME futures positions. Before this change, `collectPriceSymbols` only emitted spot + perps, so futures positions had no entry in the prices map and `PortfolioNotional` fell back to `pos.AvgCost`, freezing exposure at entry cost and breaking the portfolio-notional kill switch for TopStep strategies after a rally / drawdown.

## Changes

- `shared_scripts/fetch_futures_marks.py` — new entry point; delegates to `TopStepExchangeAdapter.get_price` (auto-selects live TopStepX REST if creds are present, yfinance paper fallback otherwise)
- `scheduler/executor.go` — `FetchFuturesMarks([]string) (map[string]float64, error)` mirroring `FetchPrices`
- `scheduler/risk.go` — `collectFuturesMarkSymbols` sibling helper + `mergeFuturesMarks` (preserves existing live marks, skips zero/negative)
- `scheduler/main.go` + `scheduler/server.go` — fetch futures marks alongside `FetchPrices` in all three price-fetch call sites (main cycle loop, `/status`, `-summary=<channel>`)
- Graceful degradation: fetch failures log `[WARN]` and fall back to `pos.AvgCost` — NOT a hard cycle skip

## Tests

Added to `scheduler/risk_test.go`:
- `TestPortfolioNotional_IncludesFutures` — long ES + short NQ, mark diverges from entry; asserts notional matches live mark and explicitly rejects the frozen-entry value
- `TestPortfolioNotional_FuturesMarkMiss` — empty prices map → `AvgCost` fallback preserved
- `TestCollectFuturesMarkSymbols` — dedup + rejects spot/perps/options
- `TestMergeFuturesMarks` — preserves existing live marks, skips zero/negative

## Test plan
- [x] `cd scheduler && go build .`
- [x] `cd scheduler && go test ./...` — all green
- [x] `gofmt -l scheduler/*.go` — clean
- [x] `python3 -m py_compile shared_scripts/fetch_futures_marks.py` — clean
- [ ] Run `./go-trader --once` on a live config with open TopStep positions to verify `[fetch_futures_marks]` stderr and prices output

Generated with [Claude Code](https://claude.ai/code)