### PR TITLE
fix(ci): fix ccusage token/cost footer in Claude bot comment

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -191,7 +191,6 @@ jobs:
           TODAY=$(date -u +%Y%m%d)
           USAGE=$(npx --yes ccusage@latest session --json --since "$TODAY" --order desc 2>/tmp/ccusage-err || echo "[]")
           [ -s /tmp/ccusage-err ] && echo "ccusage stderr: $(cat /tmp/ccusage-err)"
-          echo "ccusage raw: $USAGE"
           COST=$(printf '%s' "$USAGE" | jq -r 'if .sessions and (.sessions | length) > 0 then .sessions[0] | "Tokens: \(.inputTokens // 0) in / \(.outputTokens // 0) out | Cache: \(.cacheReadTokens // 0) read / \(.cacheCreationTokens // 0) written | Cost: $\(.totalCost // 0 | . * 100 | round / 100)" else "" end' 2>/dev/null || true)
 
           FOOTER="---"$'\n'"Generated with: ${MODEL_NAME} | Effort: ${EFFORT}"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -192,7 +192,7 @@ jobs:
           USAGE=$(npx --yes ccusage@latest session --json --since "$TODAY" --order desc 2>/tmp/ccusage-err || echo "[]")
           [ -s /tmp/ccusage-err ] && echo "ccusage stderr: $(cat /tmp/ccusage-err)"
           echo "ccusage raw: $USAGE"
-          COST=$(printf '%s' "$USAGE" | jq -r 'if type == "array" and length > 0 then .[0] | "Tokens: \(.inputTokens // 0) in / \(.outputTokens // 0) out | Cache: \(.cacheReadTokens // 0) read / \(.cacheCreationTokens // 0) written | Cost: $\(.totalCost // 0 | . * 100 | round / 100)" else "" end' 2>/dev/null || true)
+          COST=$(printf '%s' "$USAGE" | jq -r 'if .sessions and (.sessions | length) > 0 then .sessions[0] | "Tokens: \(.inputTokens // 0) in / \(.outputTokens // 0) out | Cache: \(.cacheReadTokens // 0) read / \(.cacheCreationTokens // 0) written | Cost: $\(.totalCost // 0 | . * 100 | round / 100)" else "" end' 2>/dev/null || true)
 
           FOOTER="---"$'\n'"Generated with: ${MODEL_NAME} | Effort: ${EFFORT}"
           if [ -n "$COST" ]; then


### PR DESCRIPTION
Fixes the ccusage token/cost summary not appearing in the Claude bot comment footer.

## Root cause

`ccusage session --json` returns an object `{"sessions": [...], "totals": {...}}` — not a plain array. The original jq filter checked `type == "array"` and accessed `.[0]`, both of which fail against an object.

## Changes

- Fix jq filter to use `.sessions[0]` instead of `.[0]`
- Add `--since <today>` and `--order desc` so the most recent session is always first
- Capture ccusage stderr (logged only if non-empty) instead of silently discarding with `2>/dev/null`

Closes #266

---
Generated with: Claude Sonnet 4.6 | Effort: 55