### PR TITLE
docs(claude): avoid #N notation in GitHub comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@
 
 ## Pull Requests
 - PR descriptions must reference the related GitHub issue if one exists, using `Closes #<number>` in the body (e.g. `Closes #46`)
+- In GitHub comments and PR reviews, avoid using `#N` notation for numbered list items or steps (e.g. "step #1", "point #2") — GitHub auto-links these to issues/PRs. Use `(1)`, `1.`, or `step 1` instead. Only use `#N` when intentionally linking to a specific issue or PR.
 
 ## Build & Deploy
 - Build: `cd scheduler && /opt/homebrew/bin/go build -o ../go-trader .` — always rebuild before smoke-testing `./go-trader`; stale binary gives misleading results

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@
 
 ## Pull Requests
 - PR descriptions must reference the related GitHub issue if one exists, using `Closes #<number>` in the body (e.g. `Closes #46`)
-- In GitHub comments and PR reviews, avoid using `#N` notation for numbered list items or steps (e.g. "step #1", "point #2") — GitHub auto-links these to issues/PRs. Use `(1)`, `1.`, or `step 1` instead. Only use `#N` when intentionally linking to a specific issue or PR.
+- In GitHub comments and PR reviews, avoid using `#N` notation for numbered list items or steps (e.g. "step #1", "point #2") — GitHub auto-links these to issues/PRs. Use `1.` instead. Only use `#N` when intentionally linking to a specific issue or PR.
 
 ## Build & Deploy
 - Build: `cd scheduler && /opt/homebrew/bin/go build -o ../go-trader .` — always rebuild before smoke-testing `./go-trader`; stale binary gives misleading results


### PR DESCRIPTION
## Summary

- Adds a CLAUDE.md instruction to avoid `#N` notation for numbered list items or steps in GitHub comments and PR reviews
- GitHub auto-links `#N` to issues/PRs, causing unintended references when Claude uses it for list items like "step #1" or "point #2"
- Instructs Claude to use `(1)`, `1.`, or `step 1` alternatives, reserving `#N` only for intentional issue/PR links

## Test plan

- [ ] Trigger `@claude` on a PR comment and verify its response uses `1.` / `(1)` style instead of `#1` / `#2` for numbered items

---
Generated with: Claude Sonnet 4.6 | Effort: 55