### PR TITLE
fix(hl-sync): skip reconciliation for shared coins to prevent phantom circuit breakers

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -256,7 +256,8 @@ func syncHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppSt
 		return false
 	}
 
-	return reconcileHyperliquidAccountPositions(hlStrategies, state, mu, logMgr, positions)
+	// Self-contained entry: due and all are the same list.
+	return reconcileHyperliquidAccountPositions(hlStrategies, hlStrategies, state, mu, logMgr, positions)
 }
 
 // reconcileHyperliquidAccountPositions reconciles pre-fetched on-chain positions
@@ -264,35 +265,41 @@ func syncHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppSt
 // clearinghouseState earlier in the cycle (e.g. main.go fetches once for the
 // shared-wallet balance and reuses the positions here to avoid a duplicate
 // HTTP round-trip — see #243 review feedback).
+//
+// dueStrategies are the strategies to reconcile this cycle (subset of allStrategies).
+// allStrategies includes every live HL strategy in the config — needed to detect
+// shared coins (#258) even when only some strategies are due.
+//
 // Must be called WITHOUT holding any lock; acquires Lock internally.
-func reconcileHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager, positions []HLPosition) bool {
+func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager, positions []HLPosition) bool {
 	mu.Lock()
 	defer mu.Unlock()
 
 	changed := false
 
-	// Build ownership index: coin → strategyID from existing state positions.
-	owned := make(map[string]string) // coin → strategy ID
-	for _, sc := range hlStrategies {
-		ss := state.Strategies[sc.ID]
-		if ss == nil {
-			continue
-		}
+	// Build coin → strategy IDs from ALL strategies (not just due) to detect
+	// shared coins. A coin is "shared" when 2+ strategies are configured to
+	// trade it on the same wallet. For shared coins, per-strategy reconciliation
+	// is skipped to prevent the phantom drawdown described in #258: one strategy
+	// selling causes the other's position to be removed by sync, collapsing its
+	// portfolio value and tripping the circuit breaker.
+	coinStrategies := make(map[string][]string)
+	for _, sc := range allStrategies {
 		sym := hyperliquidSymbol(sc.Args)
 		if sym == "" {
 			continue
 		}
-		if pos, ok := ss.Positions[sym]; ok && pos.OwnerStrategyID != "" {
-			if existing, dup := owned[sym]; dup {
-				fmt.Printf("[WARN] hl-sync: coin %s claimed by both %s and %s — skipping duplicate\n", sym, existing, sc.ID)
-				continue
-			}
-			owned[sym] = sc.ID
+		coinStrategies[sym] = append(coinStrategies[sym], sc.ID)
+	}
+	sharedCoins := make(map[string]bool)
+	for coin, ids := range coinStrategies {
+		if len(ids) > 1 {
+			sharedCoins[coin] = true
 		}
 	}
 
-	// Reconcile each strategy's position against on-chain data.
-	for _, sc := range hlStrategies {
+	// Reconcile non-shared coins normally for due strategies.
+	for _, sc := range dueStrategies {
 		ss := state.Strategies[sc.ID]
 		if ss == nil {
 			continue
@@ -300,6 +307,9 @@ func reconcileHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *
 		sym := hyperliquidSymbol(sc.Args)
 		if sym == "" {
 			continue
+		}
+		if sharedCoins[sym] {
+			continue // handled below
 		}
 		logger, err := logMgr.GetStrategyLogger(sc.ID)
 		if err != nil {
@@ -311,9 +321,99 @@ func reconcileHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *
 		}
 	}
 
-	// Warn about unowned on-chain positions.
+	// For shared coins: apply non-destructive updates (multiplier migration,
+	// leverage sync) but do NOT modify quantities or remove positions. Compute
+	// reconciliation gaps so the user can see drift via /status.
+	now := time.Now().UTC()
+	if state.ReconciliationGaps == nil {
+		state.ReconciliationGaps = make(map[string]*ReconciliationGap)
+	}
+	for coin, stratIDs := range coinStrategies {
+		if !sharedCoins[coin] {
+			continue
+		}
+
+		// Find on-chain position for this coin.
+		var onChainPos *HLPosition
+		for i := range positions {
+			if positions[i].Coin == coin {
+				onChainPos = &positions[i]
+				break
+			}
+		}
+
+		virtualQty := 0.0
+		for _, id := range stratIDs {
+			ss := state.Strategies[id]
+			if ss == nil {
+				continue
+			}
+			pos := ss.Positions[coin]
+			if pos == nil {
+				continue
+			}
+			// Sum signed virtual qty.
+			if pos.Side == "long" {
+				virtualQty += pos.Quantity
+			} else {
+				virtualQty -= pos.Quantity
+			}
+			// Non-destructive: migrate multiplier (#254).
+			if pos.Multiplier != 1 {
+				logger, _ := logMgr.GetStrategyLogger(id)
+				if logger != nil {
+					logger.Info("hl-sync: %s migrate multiplier %v → 1 (shared coin) (#254)", coin, pos.Multiplier)
+				}
+				pos.Multiplier = 1
+				changed = true
+			}
+			// Non-destructive: sync leverage from on-chain.
+			if onChainPos != nil && onChainPos.Leverage > 0 && pos.Leverage != onChainPos.Leverage {
+				logger, _ := logMgr.GetStrategyLogger(id)
+				if logger != nil {
+					logger.Info("hl-sync: %s leverage %v → %v (shared coin)", coin, pos.Leverage, onChainPos.Leverage)
+				}
+				pos.Leverage = onChainPos.Leverage
+				changed = true
+			}
+		}
+
+		// Compute reconciliation gap.
+		onChainQty := 0.0
+		if onChainPos != nil {
+			onChainQty = onChainPos.Size
+		}
+		delta := virtualQty - onChainQty
+
+		state.ReconciliationGaps[coin] = &ReconciliationGap{
+			Coin:       coin,
+			OnChainQty: onChainQty,
+			VirtualQty: virtualQty,
+			DeltaQty:   delta,
+			Strategies: stratIDs,
+			UpdatedAt:  now,
+		}
+
+		if math.Abs(delta) > 0.000001 {
+			fmt.Printf("[WARN] hl-sync: shared coin %s reconciliation gap: virtual=%.6f on-chain=%.6f delta=%.6f (strategies: %v)\n",
+				coin, virtualQty, onChainQty, delta, stratIDs)
+		}
+	}
+
+	// Clean up gaps for coins that are no longer shared.
+	for coin := range state.ReconciliationGaps {
+		if !sharedCoins[coin] {
+			delete(state.ReconciliationGaps, coin)
+		}
+	}
+
+	// Warn about unowned on-chain positions (not traded by any strategy).
+	tradedCoins := make(map[string]bool)
+	for coin := range coinStrategies {
+		tradedCoins[coin] = true
+	}
 	for _, p := range positions {
-		if _, ok := owned[p.Coin]; !ok {
+		if !tradedCoins[p.Coin] {
 			qty := math.Abs(p.Size)
 			side := "long"
 			if p.Size < 0 {

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -243,6 +243,9 @@ func reconcileHyperliquidPositions(stratState *StrategyState, sym string, positi
 // scheduler has already fetched clearinghouseState earlier in the cycle (e.g.
 // for shared-wallet balance), use reconcileHyperliquidAccountPositions instead
 // to avoid a second round-trip to the HL API.
+//
+// hlStrategies must include ALL live HL strategies (not a subset) for shared-coin
+// detection to work correctly. It is passed as both dueStrategies and allStrategies.
 func syncHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager) bool {
 	accountAddr := os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS")
 	if accountAddr == "" {
@@ -355,22 +358,29 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 			// Sum signed virtual qty.
 			if pos.Side == "long" {
 				virtualQty += pos.Quantity
-			} else {
+			} else if pos.Side == "short" {
 				virtualQty -= pos.Quantity
+			} else {
+				fmt.Printf("[WARN] hl-sync: strategy %s coin %s has unexpected side=%q, skipping in virtual qty\n", id, coin, pos.Side)
 			}
-			// Non-destructive: migrate multiplier (#254).
+			// Non-destructive updates applied to ALL strategies (not just due) since
+			// multiplier migration and leverage sync are idempotent corrections that
+			// should not wait for the strategy's next scheduled cycle.
 			if pos.Multiplier != 1 {
-				logger, _ := logMgr.GetStrategyLogger(id)
-				if logger != nil {
+				logger, err := logMgr.GetStrategyLogger(id)
+				if err != nil {
+					fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", id, err)
+				} else {
 					logger.Info("hl-sync: %s migrate multiplier %v → 1 (shared coin) (#254)", coin, pos.Multiplier)
 				}
 				pos.Multiplier = 1
 				changed = true
 			}
-			// Non-destructive: sync leverage from on-chain.
 			if onChainPos != nil && onChainPos.Leverage > 0 && pos.Leverage != onChainPos.Leverage {
-				logger, _ := logMgr.GetStrategyLogger(id)
-				if logger != nil {
+				logger, err := logMgr.GetStrategyLogger(id)
+				if err != nil {
+					fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", id, err)
+				} else {
 					logger.Info("hl-sync: %s leverage %v → %v (shared coin)", coin, pos.Leverage, onChainPos.Leverage)
 				}
 				pos.Leverage = onChainPos.Leverage

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -608,6 +608,13 @@ func TestAccountSyncSharedCoinSkipsReconciliation(t *testing.T) {
 	if math.Abs(gap.DeltaQty-expectedDelta) > 0.000001 {
 		t.Errorf("gap DeltaQty = %g, want %g", gap.DeltaQty, expectedDelta)
 	}
+	// Strategies field should list both strategy IDs.
+	if len(gap.Strategies) != 2 {
+		t.Errorf("gap Strategies = %v, want 2 entries", gap.Strategies)
+	}
+	if gap.UpdatedAt.IsZero() {
+		t.Error("gap UpdatedAt should be set")
+	}
 }
 
 // TestAccountSyncSharedCoinNotRemovedWhenOnChainGone verifies the phantom
@@ -667,6 +674,12 @@ func TestAccountSyncSharedCoinNotRemovedWhenOnChainGone(t *testing.T) {
 	}
 	if gap.VirtualQty != 0.212 {
 		t.Errorf("gap VirtualQty = %g, want 0.212", gap.VirtualQty)
+	}
+	if len(gap.Strategies) != 2 {
+		t.Errorf("gap Strategies = %v, want 2 entries", gap.Strategies)
+	}
+	if gap.UpdatedAt.IsZero() {
+		t.Error("gap UpdatedAt should be set")
 	}
 }
 
@@ -814,6 +827,9 @@ func TestAccountSyncMixedSharedAndNonShared(t *testing.T) {
 	if gap.OnChainQty != 0.315 {
 		t.Errorf("ETH gap OnChainQty = %g, want 0.315", gap.OnChainQty)
 	}
+	if len(gap.Strategies) != 2 {
+		t.Errorf("ETH gap Strategies = %v, want 2 entries", gap.Strategies)
+	}
 }
 
 // TestAccountSyncSharedCoinGapClearedWhenNoLongerShared verifies that
@@ -866,5 +882,269 @@ func TestAccountSyncSharedCoinGapClearedWhenNoLongerShared(t *testing.T) {
 	// Stale gap should be cleaned up.
 	if _, ok := state.ReconciliationGaps["ETH"]; ok {
 		t.Error("ETH reconciliation gap should be removed (no longer shared)")
+	}
+}
+
+// TestReconcileDueSubsetOfAllDetectsSharedCoins calls reconcileHyperliquidAccountPositions
+// directly with dueStrategies as a strict subset of allStrategies. This is the production
+// call pattern from main.go where not all strategies are due every cycle.
+func TestReconcileDueSubsetOfAllDetectsSharedCoins(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-rmc-eth": {
+				ID: "hl-rmc-eth", Cash: 500,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2100, Side: "long", Multiplier: 1, Leverage: 20, OwnerStrategyID: "hl-rmc-eth"},
+				},
+			},
+			"hl-tema-eth": {
+				ID: "hl-tema-eth", Cash: 500,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.3, AvgCost: 2200, Side: "long", Multiplier: 1, Leverage: 20, OwnerStrategyID: "hl-tema-eth"},
+				},
+			},
+			"hl-sma-eth": {
+				ID: "hl-sma-eth", Cash: 500,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.2, AvgCost: 2000, Side: "long", Multiplier: 1, Leverage: 20, OwnerStrategyID: "hl-sma-eth"},
+				},
+			},
+		},
+	}
+
+	allStrategies := []StrategyConfig{
+		{ID: "hl-rmc-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-tema-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-sma-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	// Only rmc is due this cycle.
+	dueStrategies := allStrategies[:1]
+
+	positions := []HLPosition{
+		{Coin: "ETH", Size: 0.4, EntryPrice: 2100, Leverage: 20},
+	}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+
+	reconcileHyperliquidAccountPositions(dueStrategies, allStrategies, state, &mu, logMgr, positions)
+
+	// Even though only rmc is due, allStrategies reveals ETH is shared by 3
+	// strategies, so rmc's position must NOT be reconciled to on-chain.
+	rmcPos := state.Strategies["hl-rmc-eth"].Positions["ETH"]
+	if rmcPos == nil {
+		t.Fatal("hl-rmc-eth should still have ETH position")
+	}
+	if rmcPos.Quantity != 0.5 {
+		t.Errorf("rmc ETH quantity = %g, want 0.5 (shared coin, not reconciled)", rmcPos.Quantity)
+	}
+
+	// Non-due strategies should also be untouched.
+	temaPos := state.Strategies["hl-tema-eth"].Positions["ETH"]
+	if temaPos == nil || temaPos.Quantity != 0.3 {
+		t.Errorf("tema ETH = %+v, want quantity 0.3 (not due, not reconciled)", temaPos)
+	}
+	smaPos := state.Strategies["hl-sma-eth"].Positions["ETH"]
+	if smaPos == nil || smaPos.Quantity != 0.2 {
+		t.Errorf("sma ETH = %+v, want quantity 0.2 (not due, not reconciled)", smaPos)
+	}
+
+	// Gap should list all 3 strategies.
+	gap := state.ReconciliationGaps["ETH"]
+	if gap == nil {
+		t.Fatal("expected reconciliation gap for ETH")
+	}
+	if len(gap.Strategies) != 3 {
+		t.Errorf("gap Strategies = %v, want 3 entries", gap.Strategies)
+	}
+	expectedVirtual := 0.5 + 0.3 + 0.2
+	if math.Abs(gap.VirtualQty-expectedVirtual) > 0.000001 {
+		t.Errorf("gap VirtualQty = %g, want %g", gap.VirtualQty, expectedVirtual)
+	}
+}
+
+// TestReconcileSharedCoinShortAndMixedPositions verifies the signed virtual qty
+// computation for shared coins with short and mixed long/short positions.
+func TestReconcileSharedCoinShortAndMixedPositions(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-long-eth": {
+				ID: "hl-long-eth", Cash: 500,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.8, AvgCost: 2100, Side: "long", Multiplier: 1, Leverage: 20, OwnerStrategyID: "hl-long-eth"},
+				},
+			},
+			"hl-short-eth": {
+				ID: "hl-short-eth", Cash: 500,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.3, AvgCost: 2200, Side: "short", Multiplier: 1, Leverage: 20, OwnerStrategyID: "hl-short-eth"},
+				},
+			},
+		},
+	}
+
+	allStrategies := []StrategyConfig{
+		{ID: "hl-long-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-short-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}},
+	}
+
+	// On-chain: net long 0.5 (= 0.8 long - 0.3 short).
+	positions := []HLPosition{
+		{Coin: "ETH", Size: 0.5, EntryPrice: 2150, Leverage: 20},
+	}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions)
+
+	// Positions should be unchanged.
+	longPos := state.Strategies["hl-long-eth"].Positions["ETH"]
+	if longPos == nil || longPos.Quantity != 0.8 || longPos.Side != "long" {
+		t.Errorf("long ETH = %+v, want 0.8 long (unchanged)", longPos)
+	}
+	shortPos := state.Strategies["hl-short-eth"].Positions["ETH"]
+	if shortPos == nil || shortPos.Quantity != 0.3 || shortPos.Side != "short" {
+		t.Errorf("short ETH = %+v, want 0.3 short (unchanged)", shortPos)
+	}
+
+	gap := state.ReconciliationGaps["ETH"]
+	if gap == nil {
+		t.Fatal("expected reconciliation gap for ETH")
+	}
+	// Virtual: +0.8 (long) - 0.3 (short) = 0.5.
+	expectedVirtual := 0.5
+	if math.Abs(gap.VirtualQty-expectedVirtual) > 0.000001 {
+		t.Errorf("gap VirtualQty = %g, want %g (long 0.8 - short 0.3)", gap.VirtualQty, expectedVirtual)
+	}
+	// On-chain is also 0.5, so delta should be ~0.
+	if math.Abs(gap.DeltaQty) > 0.000001 {
+		t.Errorf("gap DeltaQty = %g, want ~0 (virtual matches on-chain)", gap.DeltaQty)
+	}
+	if gap.OnChainQty != 0.5 {
+		t.Errorf("gap OnChainQty = %g, want 0.5", gap.OnChainQty)
+	}
+}
+
+// TestReconcileSharedCoinBothShort verifies virtual qty computation when both
+// strategies are short on a shared coin.
+func TestReconcileSharedCoinBothShort(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-a-eth": {
+				ID: "hl-a-eth", Cash: 500,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.4, AvgCost: 2100, Side: "short", Multiplier: 1, Leverage: 20, OwnerStrategyID: "hl-a-eth"},
+				},
+			},
+			"hl-b-eth": {
+				ID: "hl-b-eth", Cash: 500,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.6, AvgCost: 2200, Side: "short", Multiplier: 1, Leverage: 20, OwnerStrategyID: "hl-b-eth"},
+				},
+			},
+		},
+	}
+
+	allStrategies := []StrategyConfig{
+		{ID: "hl-a-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-b-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}},
+	}
+
+	// On-chain: short 1.0 (negative size).
+	positions := []HLPosition{
+		{Coin: "ETH", Size: -1.0, EntryPrice: 2150, Leverage: 20},
+	}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions)
+
+	gap := state.ReconciliationGaps["ETH"]
+	if gap == nil {
+		t.Fatal("expected reconciliation gap for ETH")
+	}
+	// Virtual: -0.4 + -0.6 = -1.0.
+	expectedVirtual := -1.0
+	if math.Abs(gap.VirtualQty-expectedVirtual) > 0.000001 {
+		t.Errorf("gap VirtualQty = %g, want %g (both short)", gap.VirtualQty, expectedVirtual)
+	}
+	// On-chain is -1.0, so delta should be ~0.
+	if gap.OnChainQty != -1.0 {
+		t.Errorf("gap OnChainQty = %g, want -1.0", gap.OnChainQty)
+	}
+	if math.Abs(gap.DeltaQty) > 0.000001 {
+		t.Errorf("gap DeltaQty = %g, want ~0", gap.DeltaQty)
+	}
+}
+
+// TestReconciliationGapJSONRoundTrip verifies that AppState with ReconciliationGaps
+// survives JSON marshal/unmarshal (catches struct tag typos or type mismatches).
+func TestReconciliationGapJSONRoundTrip(t *testing.T) {
+	original := &AppState{
+		CycleCount: 42,
+		Strategies: map[string]*StrategyState{},
+		ReconciliationGaps: map[string]*ReconciliationGap{
+			"ETH": {
+				Coin:       "ETH",
+				OnChainQty: 0.5,
+				VirtualQty: 0.8,
+				DeltaQty:   0.3,
+				Strategies: []string{"hl-a", "hl-b"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var restored AppState
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	gap := restored.ReconciliationGaps["ETH"]
+	if gap == nil {
+		t.Fatal("ETH gap missing after round-trip")
+	}
+	if gap.Coin != "ETH" {
+		t.Errorf("Coin = %q, want ETH", gap.Coin)
+	}
+	if gap.OnChainQty != 0.5 {
+		t.Errorf("OnChainQty = %g, want 0.5", gap.OnChainQty)
+	}
+	if gap.VirtualQty != 0.8 {
+		t.Errorf("VirtualQty = %g, want 0.8", gap.VirtualQty)
+	}
+	if gap.DeltaQty != 0.3 {
+		t.Errorf("DeltaQty = %g, want 0.3", gap.DeltaQty)
+	}
+	if len(gap.Strategies) != 2 {
+		t.Errorf("Strategies = %v, want 2 entries", gap.Strategies)
+	}
+}
+
+// TestReconciliationGapOmittedWhenEmpty verifies that an empty ReconciliationGaps
+// map is omitted from JSON (omitempty behavior).
+func TestReconciliationGapOmittedWhenEmpty(t *testing.T) {
+	state := &AppState{
+		CycleCount: 1,
+		Strategies: map[string]*StrategyState{},
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	if _, ok := raw["reconciliation_gaps"]; ok {
+		t.Error("reconciliation_gaps should be omitted when nil/empty")
 	}
 }

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -245,13 +246,18 @@ func setupHLTestServer(balance float64, positions []HLPosition) *httptest.Server
 		"assetPositions": func() []interface{} {
 			var out []interface{}
 			for _, p := range positions {
-				out = append(out, map[string]interface{}{
-					"position": map[string]string{
-						"coin":    p.Coin,
-						"szi":     fmt.Sprintf("%.6f", p.Size),
-						"entryPx": fmt.Sprintf("%.2f", p.EntryPrice),
-					},
-				})
+				pos := map[string]interface{}{
+					"coin":    p.Coin,
+					"szi":     fmt.Sprintf("%.6f", p.Size),
+					"entryPx": fmt.Sprintf("%.2f", p.EntryPrice),
+				}
+				if p.Leverage > 0 {
+					pos["leverage"] = map[string]interface{}{
+						"type":  "cross",
+						"value": p.Leverage,
+					}
+				}
+				out = append(out, map[string]interface{}{"position": pos})
 			}
 			return out
 		}(),
@@ -515,5 +521,350 @@ func TestFetchHyperliquidStateParsesLeverage(t *testing.T) {
 	}
 	if positions[0].Leverage != 20 {
 		t.Errorf("Leverage = %v, want 20", positions[0].Leverage)
+	}
+}
+
+// --- #258: shared-coin reconciliation tests ---
+
+// TestAccountSyncSharedCoinSkipsReconciliation verifies that when two strategies
+// trade the same coin on a shared wallet, per-strategy reconciliation is skipped
+// and positions are NOT modified to match on-chain.
+func TestAccountSyncSharedCoinSkipsReconciliation(t *testing.T) {
+	ts := setupHLTestServer(50000, []HLPosition{
+		{Coin: "ETH", Size: 0.315, EntryPrice: 2200},
+	})
+	defer ts.Close()
+
+	origURL := hlMainnetURL
+	hlMainnetURL = ts.URL
+	defer func() { hlMainnetURL = origURL }()
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-rmc-eth-live": {
+				ID: "hl-rmc-eth-live", Cash: 27.15,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.460, AvgCost: 2100, Side: "long", Multiplier: 1, Leverage: 20, OwnerStrategyID: "hl-rmc-eth-live"},
+				},
+			},
+			"hl-tema-eth-live": {
+				ID: "hl-tema-eth-live", Cash: 27.79,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.212, AvgCost: 2150, Side: "long", Multiplier: 1, Leverage: 20, OwnerStrategyID: "hl-tema-eth-live"},
+				},
+			},
+		},
+	}
+
+	strategies := []StrategyConfig{
+		{ID: "hl-rmc-eth-live", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-tema-eth-live", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+	}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+
+	syncHyperliquidAccountPositions(strategies, state, &mu, logMgr)
+
+	// Both virtual positions should be unchanged.
+	rmcPos := state.Strategies["hl-rmc-eth-live"].Positions["ETH"]
+	if rmcPos == nil {
+		t.Fatal("hl-rmc-eth-live should still have ETH position")
+	}
+	if rmcPos.Quantity != 0.460 {
+		t.Errorf("rmc ETH quantity = %g, want 0.460 (should not be reconciled)", rmcPos.Quantity)
+	}
+
+	temaPos := state.Strategies["hl-tema-eth-live"].Positions["ETH"]
+	if temaPos == nil {
+		t.Fatal("hl-tema-eth-live should still have ETH position")
+	}
+	if temaPos.Quantity != 0.212 {
+		t.Errorf("tema ETH quantity = %g, want 0.212 (should not be reconciled)", temaPos.Quantity)
+	}
+
+	// Cash should not change.
+	if state.Strategies["hl-rmc-eth-live"].Cash != 27.15 {
+		t.Errorf("rmc cash = %g, want 27.15", state.Strategies["hl-rmc-eth-live"].Cash)
+	}
+	if state.Strategies["hl-tema-eth-live"].Cash != 27.79 {
+		t.Errorf("tema cash = %g, want 27.79", state.Strategies["hl-tema-eth-live"].Cash)
+	}
+
+	// Reconciliation gap should be recorded.
+	gap := state.ReconciliationGaps["ETH"]
+	if gap == nil {
+		t.Fatal("expected reconciliation gap for ETH")
+	}
+	if gap.OnChainQty != 0.315 {
+		t.Errorf("gap OnChainQty = %g, want 0.315", gap.OnChainQty)
+	}
+	expectedVirtual := 0.460 + 0.212
+	if math.Abs(gap.VirtualQty-expectedVirtual) > 0.000001 {
+		t.Errorf("gap VirtualQty = %g, want %g", gap.VirtualQty, expectedVirtual)
+	}
+	expectedDelta := expectedVirtual - 0.315
+	if math.Abs(gap.DeltaQty-expectedDelta) > 0.000001 {
+		t.Errorf("gap DeltaQty = %g, want %g", gap.DeltaQty, expectedDelta)
+	}
+}
+
+// TestAccountSyncSharedCoinNotRemovedWhenOnChainGone verifies the phantom
+// circuit breaker fix (#258): when one strategy sells the shared position,
+// the other strategy's virtual position is NOT removed by sync.
+func TestAccountSyncSharedCoinNotRemovedWhenOnChainGone(t *testing.T) {
+	// On-chain ETH position is gone (sold by rmc).
+	ts := setupHLTestServer(1336, []HLPosition{})
+	defer ts.Close()
+
+	origURL := hlMainnetURL
+	hlMainnetURL = ts.URL
+	defer func() { hlMainnetURL = origURL }()
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-rmc-eth-live": {
+				ID: "hl-rmc-eth-live", Cash: 1336,
+				Positions: map[string]*Position{}, // rmc already sold via ExecutePerpsSignal
+			},
+			"hl-tema-eth-live": {
+				ID: "hl-tema-eth-live", Cash: 27.79,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.212, AvgCost: 2150, Side: "long", Multiplier: 1, Leverage: 20, OwnerStrategyID: "hl-tema-eth-live"},
+				},
+			},
+		},
+	}
+
+	strategies := []StrategyConfig{
+		{ID: "hl-rmc-eth-live", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-tema-eth-live", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+	}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+
+	syncHyperliquidAccountPositions(strategies, state, &mu, logMgr)
+
+	// tema's position should NOT be removed (phantom circuit breaker fix).
+	temaPos := state.Strategies["hl-tema-eth-live"].Positions["ETH"]
+	if temaPos == nil {
+		t.Fatal("hl-tema-eth-live should still have ETH position (shared coin — not removed by sync)")
+	}
+	if temaPos.Quantity != 0.212 {
+		t.Errorf("tema ETH quantity = %g, want 0.212", temaPos.Quantity)
+	}
+
+	// Reconciliation gap should show the drift.
+	gap := state.ReconciliationGaps["ETH"]
+	if gap == nil {
+		t.Fatal("expected reconciliation gap for ETH")
+	}
+	if gap.OnChainQty != 0 {
+		t.Errorf("gap OnChainQty = %g, want 0", gap.OnChainQty)
+	}
+	if gap.VirtualQty != 0.212 {
+		t.Errorf("gap VirtualQty = %g, want 0.212", gap.VirtualQty)
+	}
+}
+
+// TestAccountSyncSharedCoinMultiplierMigration verifies that non-destructive
+// updates (multiplier migration, leverage sync) still happen for shared coins.
+func TestAccountSyncSharedCoinMultiplierMigration(t *testing.T) {
+	ts := setupHLTestServer(50000, []HLPosition{
+		{Coin: "ETH", Size: 0.5, EntryPrice: 2000, Leverage: 10},
+	})
+	defer ts.Close()
+
+	origURL := hlMainnetURL
+	hlMainnetURL = ts.URL
+	defer func() { hlMainnetURL = origURL }()
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-a-eth": {
+				ID: "hl-a-eth", Cash: 100,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.3, AvgCost: 2000, Side: "long", Multiplier: 0, OwnerStrategyID: "hl-a-eth"},
+				},
+			},
+			"hl-b-eth": {
+				ID: "hl-b-eth", Cash: 100,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.2, AvgCost: 2100, Side: "long", Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-b-eth"},
+				},
+			},
+		},
+	}
+
+	strategies := []StrategyConfig{
+		{ID: "hl-a-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-b-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"ema", "ETH", "1h", "--mode=live"}},
+	}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+
+	changed := syncHyperliquidAccountPositions(strategies, state, &mu, logMgr)
+	if !changed {
+		t.Error("expected changed=true (multiplier migration + leverage sync)")
+	}
+
+	posA := state.Strategies["hl-a-eth"].Positions["ETH"]
+	if posA.Multiplier != 1 {
+		t.Errorf("hl-a-eth ETH multiplier = %v, want 1 (migrated)", posA.Multiplier)
+	}
+	if posA.Leverage != 10 {
+		t.Errorf("hl-a-eth ETH leverage = %v, want 10 (from on-chain)", posA.Leverage)
+	}
+
+	posB := state.Strategies["hl-b-eth"].Positions["ETH"]
+	if posB.Leverage != 10 {
+		t.Errorf("hl-b-eth ETH leverage = %v, want 10 (synced from on-chain)", posB.Leverage)
+	}
+
+	// Quantities must NOT change.
+	if posA.Quantity != 0.3 {
+		t.Errorf("hl-a-eth ETH quantity = %g, want 0.3 (unchanged)", posA.Quantity)
+	}
+	if posB.Quantity != 0.2 {
+		t.Errorf("hl-b-eth ETH quantity = %g, want 0.2 (unchanged)", posB.Quantity)
+	}
+}
+
+// TestAccountSyncMixedSharedAndNonShared verifies that shared and non-shared
+// coins are handled independently: BTC (sole owner) is reconciled normally,
+// while ETH (shared by 2 strategies) skips reconciliation.
+func TestAccountSyncMixedSharedAndNonShared(t *testing.T) {
+	ts := setupHLTestServer(50000, []HLPosition{
+		{Coin: "BTC", Size: 0.5, EntryPrice: 42000, Leverage: 5},
+		{Coin: "ETH", Size: 0.315, EntryPrice: 2200, Leverage: 20},
+	})
+	defer ts.Close()
+
+	origURL := hlMainnetURL
+	hlMainnetURL = ts.URL
+	defer func() { hlMainnetURL = origURL }()
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-btc": {
+				ID: "hl-btc", Cash: 10000,
+				Positions: map[string]*Position{
+					"BTC": {Symbol: "BTC", Quantity: 0.3, AvgCost: 40000, Side: "long", Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-btc"},
+				},
+			},
+			"hl-rmc-eth": {
+				ID: "hl-rmc-eth", Cash: 500,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.46, AvgCost: 2100, Side: "long", Multiplier: 1, Leverage: 20, OwnerStrategyID: "hl-rmc-eth"},
+				},
+			},
+			"hl-tema-eth": {
+				ID: "hl-tema-eth", Cash: 500,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.212, AvgCost: 2150, Side: "long", Multiplier: 1, Leverage: 20, OwnerStrategyID: "hl-tema-eth"},
+				},
+			},
+		},
+	}
+
+	strategies := []StrategyConfig{
+		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+		{ID: "hl-rmc-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-tema-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+	}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+
+	syncHyperliquidAccountPositions(strategies, state, &mu, logMgr)
+
+	// BTC should be reconciled (non-shared): 0.3 → 0.5.
+	btcPos := state.Strategies["hl-btc"].Positions["BTC"]
+	if btcPos == nil {
+		t.Fatal("hl-btc should have BTC position")
+	}
+	if btcPos.Quantity != 0.5 {
+		t.Errorf("BTC quantity = %g, want 0.5 (reconciled)", btcPos.Quantity)
+	}
+
+	// ETH positions should be unchanged (shared).
+	rmcETH := state.Strategies["hl-rmc-eth"].Positions["ETH"]
+	if rmcETH == nil || rmcETH.Quantity != 0.46 {
+		t.Errorf("rmc ETH = %+v, want quantity 0.46 (not reconciled)", rmcETH)
+	}
+	temaETH := state.Strategies["hl-tema-eth"].Positions["ETH"]
+	if temaETH == nil || temaETH.Quantity != 0.212 {
+		t.Errorf("tema ETH = %+v, want quantity 0.212 (not reconciled)", temaETH)
+	}
+
+	// Only ETH should have a reconciliation gap.
+	if _, ok := state.ReconciliationGaps["BTC"]; ok {
+		t.Error("BTC should not have a reconciliation gap (non-shared)")
+	}
+	gap := state.ReconciliationGaps["ETH"]
+	if gap == nil {
+		t.Fatal("ETH should have a reconciliation gap")
+	}
+	if gap.OnChainQty != 0.315 {
+		t.Errorf("ETH gap OnChainQty = %g, want 0.315", gap.OnChainQty)
+	}
+}
+
+// TestAccountSyncSharedCoinGapClearedWhenNoLongerShared verifies that
+// reconciliation gaps are cleaned up when a coin is no longer shared.
+func TestAccountSyncSharedCoinGapClearedWhenNoLongerShared(t *testing.T) {
+	ts := setupHLTestServer(50000, []HLPosition{
+		{Coin: "ETH", Size: 0.3, EntryPrice: 2000, Leverage: 10},
+	})
+	defer ts.Close()
+
+	origURL := hlMainnetURL
+	hlMainnetURL = ts.URL
+	defer func() { hlMainnetURL = origURL }()
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-eth": {
+				ID: "hl-eth", Cash: 100,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.25, AvgCost: 2000, Side: "long", Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-eth"},
+				},
+			},
+		},
+		// Stale gap from when ETH was shared.
+		ReconciliationGaps: map[string]*ReconciliationGap{
+			"ETH": {Coin: "ETH", OnChainQty: 0.5, VirtualQty: 0.7, DeltaQty: 0.2, Strategies: []string{"hl-eth", "hl-old"}},
+		},
+	}
+
+	// Only one strategy trades ETH now (no longer shared).
+	strategies := []StrategyConfig{
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+
+	syncHyperliquidAccountPositions(strategies, state, &mu, logMgr)
+
+	// ETH should be reconciled normally (non-shared).
+	ethPos := state.Strategies["hl-eth"].Positions["ETH"]
+	if ethPos == nil {
+		t.Fatal("hl-eth should have ETH position")
+	}
+	if ethPos.Quantity != 0.3 {
+		t.Errorf("ETH quantity = %g, want 0.3 (reconciled to on-chain)", ethPos.Quantity)
+	}
+
+	// Stale gap should be cleaned up.
+	if _, ok := state.ReconciliationGaps["ETH"]; ok {
+		t.Error("ETH reconciliation gap should be removed (no longer shared)")
 	}
 }

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -530,7 +530,7 @@ func main() {
 				// shared-wallet risk check (#243 review feedback) so we don't
 				// pay two HL API round-trips per cycle.
 				if len(hlLiveDue) > 0 && hlStateFetched {
-					reconcileHyperliquidAccountPositions(hlLiveDue, state, &mu, logMgr, hlPositions)
+					reconcileHyperliquidAccountPositions(hlLiveDue, hlLiveAll, state, &mu, logMgr, hlPositions)
 				}
 
 				for _, sc := range dueStrategies {

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -202,13 +202,14 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type StatusResp struct {
-		CycleCount    int                    `json:"cycle_count"`
-		Prices        map[string]float64     `json:"prices"`
-		Strategies    map[string]StratStatus `json:"strategies"`
-		PortfolioRisk PortfolioRiskState     `json:"portfolio_risk"`
-		TotalValue    float64                `json:"total_value"`
-		TotalNotional float64                `json:"total_notional"`
-		Correlation   *CorrelationSnapshot   `json:"correlation,omitempty"`
+		CycleCount         int                           `json:"cycle_count"`
+		Prices             map[string]float64            `json:"prices"`
+		Strategies         map[string]StratStatus        `json:"strategies"`
+		PortfolioRisk      PortfolioRiskState            `json:"portfolio_risk"`
+		TotalValue         float64                       `json:"total_value"`
+		TotalNotional      float64                       `json:"total_notional"`
+		Correlation        *CorrelationSnapshot          `json:"correlation,omitempty"`
+		ReconciliationGaps map[string]*ReconciliationGap `json:"reconciliation_gaps,omitempty"`
 	}
 
 	totalValue := 0.0
@@ -218,13 +219,14 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 	totalNotional := PortfolioNotional(ss.state.Strategies, prices)
 
 	resp := StatusResp{
-		CycleCount:    ss.state.CycleCount,
-		Prices:        prices,
-		Strategies:    make(map[string]StratStatus),
-		PortfolioRisk: ss.state.PortfolioRisk,
-		TotalValue:    totalValue,
-		TotalNotional: totalNotional,
-		Correlation:   ss.state.CorrelationSnapshot,
+		CycleCount:         ss.state.CycleCount,
+		Prices:             prices,
+		Strategies:         make(map[string]StratStatus),
+		PortfolioRisk:      ss.state.PortfolioRisk,
+		TotalValue:         totalValue,
+		TotalNotional:      totalNotional,
+		Correlation:        ss.state.CorrelationSnapshot,
+		ReconciliationGaps: ss.state.ReconciliationGaps,
 	}
 
 	// Build config lookup for EffectiveInitialCapital.

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -10,15 +10,30 @@ import (
 // maxTradeHistory is the maximum number of trades to retain per strategy.
 const maxTradeHistory = 1000
 
+// ReconciliationGap tracks the drift between virtual per-strategy positions and
+// the actual on-chain position for a coin that is traded by multiple strategies
+// on the same shared wallet (#258). When two strategies trade the same coin,
+// per-strategy reconciliation is skipped (to prevent phantom circuit breakers)
+// and this gap is computed instead.
+type ReconciliationGap struct {
+	Coin       string    `json:"coin"`
+	OnChainQty float64   `json:"on_chain_qty"` // signed: positive = long, negative = short
+	VirtualQty float64   `json:"virtual_qty"`  // sum of all strategies' positions (signed)
+	DeltaQty   float64   `json:"delta_qty"`    // virtual - on_chain
+	Strategies []string  `json:"strategies"`   // strategy IDs configured to trade this coin
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
 // AppState holds all persistent state across restarts.
 type AppState struct {
-	CycleCount              int                       `json:"cycle_count"`
-	LastCycle               time.Time                 `json:"last_cycle"`
-	Strategies              map[string]*StrategyState `json:"strategies"`
-	PortfolioRisk           PortfolioRiskState        `json:"portfolio_risk"`
-	CorrelationSnapshot     *CorrelationSnapshot      `json:"correlation_snapshot,omitempty"`
-	LastTop10Summary        time.Time                 `json:"last_top10_summary,omitempty"`
-	LastLeaderboardPostDate string                    `json:"last_leaderboard_post_date,omitempty"`
+	CycleCount              int                           `json:"cycle_count"`
+	LastCycle               time.Time                     `json:"last_cycle"`
+	Strategies              map[string]*StrategyState     `json:"strategies"`
+	PortfolioRisk           PortfolioRiskState            `json:"portfolio_risk"`
+	CorrelationSnapshot     *CorrelationSnapshot          `json:"correlation_snapshot,omitempty"`
+	ReconciliationGaps      map[string]*ReconciliationGap `json:"reconciliation_gaps,omitempty"`
+	LastTop10Summary        time.Time                     `json:"last_top10_summary,omitempty"`
+	LastLeaderboardPostDate string                        `json:"last_leaderboard_post_date,omitempty"`
 }
 
 // StrategyState is the per-strategy persistent state.

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -19,18 +19,19 @@ type ReconciliationGap struct {
 	Coin       string    `json:"coin"`
 	OnChainQty float64   `json:"on_chain_qty"` // signed: positive = long, negative = short
 	VirtualQty float64   `json:"virtual_qty"`  // sum of all strategies' positions (signed)
-	DeltaQty   float64   `json:"delta_qty"`    // virtual - on_chain
+	DeltaQty   float64   `json:"delta_qty"`    // computed: VirtualQty - OnChainQty
 	Strategies []string  `json:"strategies"`   // strategy IDs configured to trade this coin
 	UpdatedAt  time.Time `json:"updated_at"`
 }
 
 // AppState holds all persistent state across restarts.
 type AppState struct {
-	CycleCount              int                           `json:"cycle_count"`
-	LastCycle               time.Time                     `json:"last_cycle"`
-	Strategies              map[string]*StrategyState     `json:"strategies"`
-	PortfolioRisk           PortfolioRiskState            `json:"portfolio_risk"`
-	CorrelationSnapshot     *CorrelationSnapshot          `json:"correlation_snapshot,omitempty"`
+	CycleCount          int                       `json:"cycle_count"`
+	LastCycle           time.Time                 `json:"last_cycle"`
+	Strategies          map[string]*StrategyState `json:"strategies"`
+	PortfolioRisk       PortfolioRiskState        `json:"portfolio_risk"`
+	CorrelationSnapshot *CorrelationSnapshot      `json:"correlation_snapshot,omitempty"`
+	// ReconciliationGaps is ephemeral — recomputed each sync cycle, not persisted to SQLite.
 	ReconciliationGaps      map[string]*ReconciliationGap `json:"reconciliation_gaps,omitempty"`
 	LastTop10Summary        time.Time                     `json:"last_top10_summary,omitempty"`
 	LastLeaderboardPostDate string                        `json:"last_leaderboard_post_date,omitempty"`
@@ -91,6 +92,9 @@ func LoadState(path string) (*AppState, error) {
 	}
 	if state.Strategies == nil {
 		state.Strategies = make(map[string]*StrategyState)
+	}
+	if state.ReconciliationGaps == nil {
+		state.ReconciliationGaps = make(map[string]*ReconciliationGap)
 	}
 	// Fix nil maps
 	for _, s := range state.Strategies {


### PR DESCRIPTION
## Summary

- Fixes phantom circuit breakers caused by shared-wallet position sync: when 2+ strategies trade the same coin (e.g. `hl-rmc-eth-live` + `hl-tema-eth-live`), one strategy selling previously caused the sync to remove the other strategy's virtual position, collapsing its portfolio value and tripping the drawdown kill switch
- Skips destructive reconciliation (qty changes, position removal) for shared coins; only non-destructive updates (multiplier migration #254, leverage sync) are applied
- Adds per-coin `ReconciliationGap` tracking on `AppState` (on-chain qty, virtual qty, delta, strategies) exposed via `/status` endpoint for drift visibility
- `reconcileHyperliquidAccountPositions` now takes an `allStrategies` param so shared-coin detection uses the full HL config, not just due strategies

## Test plan

- [ ] `TestAccountSyncSharedCoinSkipsReconciliation` — positions unchanged when coin is shared
- [ ] `TestAccountSyncSharedCoinNotRemovedWhenOnChainGone` — phantom circuit breaker scenario: position not deleted when on-chain is gone
- [ ] `TestAccountSyncSharedCoinMultiplierMigration` — multiplier migration and leverage sync still work for shared coins
- [ ] `TestAccountSyncMixedSharedAndNonShared` — BTC (sole owner) reconciles, ETH (shared) skips
- [ ] `TestAccountSyncSharedCoinGapClearedWhenNoLongerShared` — stale gaps cleaned up when coin returns to single owner
- [ ] All existing tests pass (`go test ./...`)

Closes #258

---
Generated with: Claude Opus 4.6 | Effort: high