### PR TITLE
feat: replace channel booleans with <platform>-paper convention (#247)

### DIFF
--- a/scheduler/config.example.json
+++ b/scheduler/config.example.json
@@ -70,7 +70,8 @@
     "channels": {
       "spot": "",
       "options": "",
-      "hyperliquid": ""
+      "hyperliquid": "",
+      "hyperliquid-paper": ""
     },
     "spot_summary_freq": "hourly",
     "options_summary_freq": "per_check",

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -14,26 +14,22 @@ import (
 type DiscordConfig struct {
 	Enabled            bool              `json:"enabled"`
 	Token              string            `json:"token"`
-	OwnerID            string            `json:"owner_id,omitempty"`             // Discord user ID for DM features (upgrade prompts, config migration)
-	DMPaperTrades      bool              `json:"dm_paper_trades,omitempty"`      // DM owner on paper trade execution
-	DMLiveTrades       bool              `json:"dm_live_trades,omitempty"`       // DM owner on live trade execution
-	ChannelPaperTrades bool              `json:"channel_paper_trades,omitempty"` // post paper trade alerts to platform channel
-	ChannelLiveTrades  bool              `json:"channel_live_trades,omitempty"`  // post live trade alerts to platform channel
-	Channels           map[string]string `json:"channels"`                       // keyed by platform or type ("spot", "hyperliquid", "deribit", etc.)
-	LeaderboardTopN    int               `json:"leaderboard_top_n,omitempty"`    // number of entries shown in leaderboard messages (default 5)
-	LeaderboardChannel string            `json:"leaderboard_channel,omitempty"`  // dedicated Discord channel ID for leaderboard posts; when set, all leaderboards route here instead of being broadcast across platform channels
+	OwnerID            string            `json:"owner_id,omitempty"`            // Discord user ID for DM features (upgrade prompts, config migration)
+	DMPaperTrades      bool              `json:"dm_paper_trades,omitempty"`     // DM owner on paper trade execution
+	DMLiveTrades       bool              `json:"dm_live_trades,omitempty"`      // DM owner on live trade execution
+	Channels           map[string]string `json:"channels"`                      // keyed by platform or type; "<platform>-paper" for paper-specific channels
+	LeaderboardTopN    int               `json:"leaderboard_top_n,omitempty"`   // number of entries shown in leaderboard messages (default 5)
+	LeaderboardChannel string            `json:"leaderboard_channel,omitempty"` // dedicated Discord channel ID for leaderboard posts; when set, all leaderboards route here instead of being broadcast across platform channels
 }
 
 // TelegramConfig holds Telegram notification settings.
 type TelegramConfig struct {
-	Enabled            bool              `json:"enabled"`
-	BotToken           string            `json:"bot_token"`
-	OwnerChatID        string            `json:"owner_chat_id,omitempty"`        // Owner's Telegram chat ID for DMs/upgrade prompts
-	DMPaperTrades      bool              `json:"dm_paper_trades,omitempty"`      // send message on paper trade execution
-	DMLiveTrades       bool              `json:"dm_live_trades,omitempty"`       // send message on live trade execution
-	ChannelPaperTrades bool              `json:"channel_paper_trades,omitempty"` // post paper trade alerts to platform channel
-	ChannelLiveTrades  bool              `json:"channel_live_trades,omitempty"`  // post live trade alerts to platform channel
-	Channels           map[string]string `json:"channels"`                       // keyed by platform or type ("spot", "hyperliquid", etc.)
+	Enabled       bool              `json:"enabled"`
+	BotToken      string            `json:"bot_token"`
+	OwnerChatID   string            `json:"owner_chat_id,omitempty"`   // Owner's Telegram chat ID for DMs/upgrade prompts
+	DMPaperTrades bool              `json:"dm_paper_trades,omitempty"` // send message on paper trade execution
+	DMLiveTrades  bool              `json:"dm_live_trades,omitempty"`  // send message on live trade execution
+	Channels      map[string]string `json:"channels"`                  // keyed by platform or type; "<platform>-paper" for paper-specific channels
 }
 
 // PortfolioRiskConfig controls aggregate portfolio-level risk (#42).

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -76,6 +76,10 @@ var v6DeprecatedFields = []string{
 	"telegram.channel_paper_trades",
 }
 
+const v6DeprecationNotice = "**Note:** `channel_paper_trades` and `channel_live_trades` have been removed. " +
+	"Channel trade alerts are now controlled by channel presence: add `\"<platform>-paper\"` keys to " +
+	"your channels map for paper-specific routing. See issue #247."
+
 // NewFieldsSince returns all ConfigFields added after the given version number.
 func NewFieldsSince(version int) []ConfigField {
 	var fields []ConfigField
@@ -105,8 +109,10 @@ func MigrateConfig(configPath string, fieldValues map[string]string) error {
 	}
 
 	// v6: remove deprecated channel boolean fields (replaced by <platform>-paper convention).
-	for _, path := range v6DeprecatedFields {
-		removeNestedField(raw, path)
+	if version, ok := raw["config_version"].(float64); !ok || int(version) < 6 {
+		for _, path := range v6DeprecatedFields {
+			removeNestedField(raw, path)
+		}
 	}
 
 	raw["config_version"] = CurrentConfigVersion
@@ -162,6 +168,14 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 		if err := MigrateConfig(configPath, nil); err != nil {
 			fmt.Printf("[migration] Failed to bump config version: %v\n", err)
 		}
+		// v6: notify about deprecated channel boolean removal.
+		if cfg.ConfigVersion < 6 {
+			if notifier != nil && notifier.HasOwner() {
+				notifier.SendOwnerDM(v6DeprecationNotice)
+			} else {
+				fmt.Printf("[migration] %s\n", v6DeprecationNotice)
+			}
+		}
 		return
 	}
 
@@ -177,6 +191,9 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 		}
 		if err := MigrateConfig(configPath, values); err != nil {
 			fmt.Printf("[migration] Failed to migrate config: %v\n", err)
+		}
+		if cfg.ConfigVersion < 6 {
+			fmt.Printf("[migration] %s\n", v6DeprecationNotice)
 		}
 		return
 	}
@@ -209,8 +226,6 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 
 	// v6: notify about deprecated channel boolean removal.
 	if cfg.ConfigVersion < 6 {
-		notifier.SendOwnerDM("**Note:** `channel_paper_trades` and `channel_live_trades` have been removed. " +
-			"Channel trade alerts are now controlled by channel presence: add `\"<platform>-paper\"` keys to " +
-			"your channels map for paper-specific routing. See issue #247.")
+		notifier.SendOwnerDM(v6DeprecationNotice)
 	}
 }

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -10,7 +10,7 @@ import (
 
 // CurrentConfigVersion is the version embedded in newly generated configs.
 // When the binary starts and cfg.ConfigVersion < CurrentConfigVersion, migration runs.
-const CurrentConfigVersion = 5
+const CurrentConfigVersion = 6
 
 // ConfigField describes a config field introduced in a specific version.
 type ConfigField struct {
@@ -65,34 +65,15 @@ var configFieldRegistry = []ConfigField{
 		Default:     "false",
 		FieldType:   "bool",
 	},
-	{
-		Version:     5,
-		JSONPath:    "discord.channel_live_trades",
-		Description: "Post individual trade alerts to the platform's Discord channel on every live trade execution (true/false).",
-		Default:     "false",
-		FieldType:   "bool",
-	},
-	{
-		Version:     5,
-		JSONPath:    "discord.channel_paper_trades",
-		Description: "Post individual trade alerts to the platform's Discord channel on every paper trade execution (true/false).",
-		Default:     "false",
-		FieldType:   "bool",
-	},
-	{
-		Version:     5,
-		JSONPath:    "telegram.channel_live_trades",
-		Description: "Post individual trade alerts to the platform's Telegram channel on every live trade execution (true/false).",
-		Default:     "false",
-		FieldType:   "bool",
-	},
-	{
-		Version:     5,
-		JSONPath:    "telegram.channel_paper_trades",
-		Description: "Post individual trade alerts to the platform's Telegram channel on every paper trade execution (true/false).",
-		Default:     "false",
-		FieldType:   "bool",
-	},
+}
+
+// v6DeprecatedFields lists fields removed in v6 (channel boolean routing replaced by
+// <platform>-paper channel key convention). These are cleaned up during migration.
+var v6DeprecatedFields = []string{
+	"discord.channel_live_trades",
+	"discord.channel_paper_trades",
+	"telegram.channel_live_trades",
+	"telegram.channel_paper_trades",
 }
 
 // NewFieldsSince returns all ConfigFields added after the given version number.
@@ -107,7 +88,7 @@ func NewFieldsSince(version int) []ConfigField {
 }
 
 // MigrateConfig loads the config as a raw JSON map, applies fieldValues at dot-paths,
-// bumps config_version to CurrentConfigVersion, and writes back atomically.
+// removes deprecated fields, bumps config_version to CurrentConfigVersion, and writes back atomically.
 func MigrateConfig(configPath string, fieldValues map[string]string) error {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
@@ -122,6 +103,12 @@ func MigrateConfig(configPath string, fieldValues map[string]string) error {
 	for path, value := range fieldValues {
 		setNestedField(raw, path, value)
 	}
+
+	// v6: remove deprecated channel boolean fields (replaced by <platform>-paper convention).
+	for _, path := range v6DeprecatedFields {
+		removeNestedField(raw, path)
+	}
+
 	raw["config_version"] = CurrentConfigVersion
 
 	newData, err := json.MarshalIndent(raw, "", "  ")
@@ -149,6 +136,20 @@ func setNestedField(obj map[string]interface{}, path string, value string) {
 		obj[parts[0]] = nested
 	}
 	setNestedField(nested, parts[1], value)
+}
+
+// removeNestedField removes a field at a dot-path from a nested map[string]interface{}.
+func removeNestedField(obj map[string]interface{}, path string) {
+	parts := strings.SplitN(path, ".", 2)
+	if len(parts) == 1 {
+		delete(obj, parts[0])
+		return
+	}
+	nested, ok := obj[parts[0]].(map[string]interface{})
+	if !ok {
+		return
+	}
+	removeNestedField(nested, parts[1])
 }
 
 // runConfigMigrationDM prompts the owner via DM for any new config fields introduced
@@ -205,4 +206,11 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 	}
 
 	notifier.SendOwnerDM("Config updated. Changes take effect next restart.")
+
+	// v6: notify about deprecated channel boolean removal.
+	if cfg.ConfigVersion < 6 {
+		notifier.SendOwnerDM("**Note:** `channel_paper_trades` and `channel_live_trades` have been removed. " +
+			"Channel trade alerts are now controlled by channel presence: add `\"<platform>-paper\"` keys to " +
+			"your channels map for paper-specific routing. See issue #247.")
+	}
 }

--- a/scheduler/config_migration_test.go
+++ b/scheduler/config_migration_test.go
@@ -12,11 +12,11 @@ func TestNewFieldsSince(t *testing.T) {
 		version  int
 		minCount int // at least this many fields
 	}{
-		{0, 10},                   // all fields; update counts when adding new config versions
-		{1, 10},                   // v1 baseline, should get all v2+ fields
-		{2, 8},                    // should get v3+ fields
-		{3, 8},                    // should get v4+ fields
-		{4, 4},                    // should get v5 fields
+		{0, 6},                    // all fields; v5 channel booleans removed in v6
+		{1, 6},                    // v1 baseline, should get all v2+ fields
+		{2, 4},                    // should get v3+ fields
+		{3, 4},                    // should get v4+ fields
+		{4, 0},                    // v5 channel booleans removed — no new fields since v4
 		{CurrentConfigVersion, 0}, // no new fields
 		{999, 0},                  // future version
 	}
@@ -238,5 +238,105 @@ func TestSetNestedField(t *testing.T) {
 	deepNested := deep["nested"].(map[string]interface{})
 	if deepNested["field"] != "value3" {
 		t.Errorf("deep.nested.field = %v, want %q", deepNested["field"], "value3")
+	}
+}
+
+func TestRemoveNestedField(t *testing.T) {
+	obj := map[string]interface{}{
+		"top_level": "value1",
+		"nested": map[string]interface{}{
+			"field": "value2",
+			"keep":  "preserved",
+		},
+	}
+
+	removeNestedField(obj, "top_level")
+	if _, ok := obj["top_level"]; ok {
+		t.Error("top_level should have been removed")
+	}
+
+	removeNestedField(obj, "nested.field")
+	nested := obj["nested"].(map[string]interface{})
+	if _, ok := nested["field"]; ok {
+		t.Error("nested.field should have been removed")
+	}
+	if nested["keep"] != "preserved" {
+		t.Error("nested.keep should be preserved")
+	}
+
+	// Removing a non-existent field should be a no-op.
+	removeNestedField(obj, "nonexistent.path")
+}
+
+func TestMigrateConfigV6RemovesChannelBooleans(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	original := map[string]interface{}{
+		"config_version": 5,
+		"discord": map[string]interface{}{
+			"enabled":              true,
+			"channel_paper_trades": true,
+			"channel_live_trades":  true,
+			"channels": map[string]interface{}{
+				"hyperliquid": "ch-123",
+			},
+		},
+		"telegram": map[string]interface{}{
+			"channel_paper_trades": false,
+			"channel_live_trades":  true,
+		},
+	}
+	data, err := json.MarshalIndent(original, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MigrateConfig(path, nil); err != nil {
+		t.Fatalf("MigrateConfig failed: %v", err)
+	}
+
+	result, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var updated map[string]interface{}
+	if err := json.Unmarshal(result, &updated); err != nil {
+		t.Fatal(err)
+	}
+
+	// Version should be bumped to 6.
+	version := int(updated["config_version"].(float64))
+	if version != CurrentConfigVersion {
+		t.Errorf("config_version = %d, want %d", version, CurrentConfigVersion)
+	}
+
+	// Channel booleans should be removed from both discord and telegram.
+	discord := updated["discord"].(map[string]interface{})
+	if _, ok := discord["channel_paper_trades"]; ok {
+		t.Error("discord.channel_paper_trades should have been removed")
+	}
+	if _, ok := discord["channel_live_trades"]; ok {
+		t.Error("discord.channel_live_trades should have been removed")
+	}
+
+	telegram := updated["telegram"].(map[string]interface{})
+	if _, ok := telegram["channel_paper_trades"]; ok {
+		t.Error("telegram.channel_paper_trades should have been removed")
+	}
+	if _, ok := telegram["channel_live_trades"]; ok {
+		t.Error("telegram.channel_live_trades should have been removed")
+	}
+
+	// Other fields should be preserved.
+	if discord["enabled"] != true {
+		t.Error("discord.enabled should be preserved")
+	}
+	channels := discord["channels"].(map[string]interface{})
+	if channels["hyperliquid"] != "ch-123" {
+		t.Error("discord.channels.hyperliquid should be preserved")
 	}
 }

--- a/scheduler/config_migration_test.go
+++ b/scheduler/config_migration_test.go
@@ -268,6 +268,50 @@ func TestRemoveNestedField(t *testing.T) {
 	removeNestedField(obj, "nonexistent.path")
 }
 
+func TestMigrateConfigV6SkipsRemovalForCurrentVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	// Config already at v6 with fields that happen to match deprecated names
+	// should NOT have them removed (version guard).
+	original := map[string]interface{}{
+		"config_version": 6,
+		"discord": map[string]interface{}{
+			"channel_paper_trades": true,
+			"channel_live_trades":  true,
+		},
+	}
+	data, err := json.MarshalIndent(original, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MigrateConfig(path, nil); err != nil {
+		t.Fatalf("MigrateConfig failed: %v", err)
+	}
+
+	result, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var updated map[string]interface{}
+	if err := json.Unmarshal(result, &updated); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fields should still be present since config was already at v6.
+	discord := updated["discord"].(map[string]interface{})
+	if _, ok := discord["channel_paper_trades"]; !ok {
+		t.Error("discord.channel_paper_trades should NOT have been removed for v6+ config")
+	}
+	if _, ok := discord["channel_live_trades"]; !ok {
+		t.Error("discord.channel_live_trades should NOT have been removed for v6+ config")
+	}
+}
+
 func TestMigrateConfigV6RemovesChannelBooleans(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -158,6 +158,19 @@ func resolveChannel(channels map[string]string, platform, stratType string) stri
 	return ""
 }
 
+// resolveTradeChannel resolves the channel ID for a trade alert.
+// For paper trades: tries "<platform>-paper" first, then falls back to resolveChannel.
+// For live trades: uses resolveChannel directly (platform -> stratType).
+// Presence of a channel ID means alerts are enabled; absence means disabled.
+func resolveTradeChannel(channels map[string]string, platform, stratType string, isLive bool) string {
+	if !isLive {
+		if ch, ok := channels[platform+"-paper"]; ok && ch != "" {
+			return ch
+		}
+	}
+	return resolveChannel(channels, platform, stratType)
+}
+
 // channelKeyFromID returns the map key for a given channel ID (reverse lookup for display labels).
 func channelKeyFromID(channels map[string]string, chID string) string {
 	for k, v := range channels {

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -33,6 +33,39 @@ func TestResolveChannel(t *testing.T) {
 	}
 }
 
+func TestResolveTradeChannel(t *testing.T) {
+	channels := map[string]string{
+		"hyperliquid":       "ch-hl",
+		"hyperliquid-paper": "ch-hl-paper",
+		"spot":              "ch-spot",
+	}
+
+	// Paper trade: uses <platform>-paper when present.
+	if got := resolveTradeChannel(channels, "hyperliquid", "perps", false); got != "ch-hl-paper" {
+		t.Errorf("paper with -paper key: expected ch-hl-paper, got %s", got)
+	}
+
+	// Live trade: uses base platform key (ignores -paper).
+	if got := resolveTradeChannel(channels, "hyperliquid", "perps", true); got != "ch-hl" {
+		t.Errorf("live trade: expected ch-hl, got %s", got)
+	}
+
+	// Paper trade with no -paper key: falls back to base platform.
+	if got := resolveTradeChannel(channels, "binanceus", "spot", false); got != "ch-spot" {
+		t.Errorf("paper fallback to stratType: expected ch-spot, got %s", got)
+	}
+
+	// Paper trade with no channel at all.
+	if got := resolveTradeChannel(channels, "unknown", "unknown", false); got != "" {
+		t.Errorf("paper no channel: expected empty, got %s", got)
+	}
+
+	// Live trade falls back to stratType.
+	if got := resolveTradeChannel(channels, "binanceus", "spot", true); got != "ch-spot" {
+		t.Errorf("live fallback to stratType: expected ch-spot, got %s", got)
+	}
+}
+
 func TestChannelKeyFromID(t *testing.T) {
 	channels := map[string]string{
 		"spot":        "111",

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -269,12 +269,8 @@ type InitOptions struct {
 	AutoUpdate              string            // "off", "daily", "heartbeat" (default: "off")
 	DMPaperTrades           bool              // DM owner on paper trade execution
 	DMLiveTrades            bool              // DM owner on live trade execution
-	ChannelPaperTrades      bool              // post paper trade alerts to Discord channel
-	ChannelLiveTrades       bool              // post live trade alerts to Discord channel
 	TelegramDMPaper         bool              // Telegram: send on paper trade
 	TelegramDMLive          bool              // Telegram: send on live trade
-	TelegramChannelPaper    bool              // Telegram: post paper trade alerts to channel
-	TelegramChannelLive     bool              // Telegram: post live trade alerts to channel
 }
 
 // generateConfig builds a Config from InitOptions. Pure function, no I/O.
@@ -289,22 +285,18 @@ func generateConfig(opts InitOptions) *Config {
 			MaxNotionalUSD: 0,
 		},
 		Discord: DiscordConfig{
-			Enabled:            opts.DiscordEnabled,
-			OwnerID:            opts.DiscordOwnerID,
-			DMPaperTrades:      opts.DMPaperTrades,
-			DMLiveTrades:       opts.DMLiveTrades,
-			ChannelPaperTrades: opts.ChannelPaperTrades,
-			ChannelLiveTrades:  opts.ChannelLiveTrades,
-			Channels:           opts.ChannelMap,
+			Enabled:       opts.DiscordEnabled,
+			OwnerID:       opts.DiscordOwnerID,
+			DMPaperTrades: opts.DMPaperTrades,
+			DMLiveTrades:  opts.DMLiveTrades,
+			Channels:      opts.ChannelMap,
 		},
 		Telegram: TelegramConfig{
-			Enabled:            opts.TelegramEnabled,
-			OwnerChatID:        opts.TelegramOwnerChatID,
-			DMPaperTrades:      opts.TelegramDMPaper,
-			DMLiveTrades:       opts.TelegramDMLive,
-			ChannelPaperTrades: opts.TelegramChannelPaper,
-			ChannelLiveTrades:  opts.TelegramChannelLive,
-			Channels:           opts.TelegramChannelMap,
+			Enabled:       opts.TelegramEnabled,
+			OwnerChatID:   opts.TelegramOwnerChatID,
+			DMPaperTrades: opts.TelegramDMPaper,
+			DMLiveTrades:  opts.TelegramDMLive,
+			Channels:      opts.TelegramChannelMap,
 		},
 		AutoUpdate: opts.AutoUpdate,
 		Platforms:  make(map[string]*PlatformConfig),
@@ -1059,15 +1051,11 @@ func runInit(args []string) int {
 	discordOwnerID := ""
 	dmLiveTrades := false
 	dmPaperTrades := false
-	channelLiveTrades := false
-	channelPaperTrades := false
 	telegramEnabled := false
 	telegramChannelMap := make(map[string]string)
 	telegramOwnerChatID := ""
 	telegramDMLive := false
 	telegramDMPaper := false
-	telegramChannelLive := false
-	telegramChannelPaper := false
 
 	// Auto-update defaults to off; HTF filter defaults to enabled.
 	autoUpdate := "off"
@@ -1169,12 +1157,8 @@ func runInit(args []string) int {
 		AutoUpdate:              autoUpdate,
 		DMPaperTrades:           dmPaperTrades,
 		DMLiveTrades:            dmLiveTrades,
-		ChannelPaperTrades:      channelPaperTrades,
-		ChannelLiveTrades:       channelLiveTrades,
 		TelegramDMPaper:         telegramDMPaper,
 		TelegramDMLive:          telegramDMLive,
-		TelegramChannelPaper:    telegramChannelPaper,
-		TelegramChannelLive:     telegramChannelLive,
 	}
 
 	cfg := generateConfig(opts)

--- a/scheduler/init_test.go
+++ b/scheduler/init_test.go
@@ -891,12 +891,6 @@ func TestGenerateConfig_DefaultsForOptionalFields(t *testing.T) {
 	if cfg.Discord.DMLiveTrades {
 		t.Error("expected Discord.DMLiveTrades=false by default")
 	}
-	if cfg.Discord.ChannelPaperTrades {
-		t.Error("expected Discord.ChannelPaperTrades=false by default")
-	}
-	if cfg.Discord.ChannelLiveTrades {
-		t.Error("expected Discord.ChannelLiveTrades=false by default")
-	}
 	if cfg.Telegram.DMPaperTrades {
 		t.Error("expected Telegram.DMPaperTrades=false by default")
 	}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -152,8 +152,6 @@ func main() {
 				leaderboardChannel: cfg.Discord.LeaderboardChannel,
 				dmPaperTrades:      cfg.Discord.DMPaperTrades,
 				dmLiveTrades:       cfg.Discord.DMLiveTrades,
-				channelPaperTrades: cfg.Discord.ChannelPaperTrades,
-				channelLiveTrades:  cfg.Discord.ChannelLiveTrades,
 			})
 			defer discord.Close()
 		}
@@ -170,14 +168,12 @@ func main() {
 			}
 			fmt.Println(")")
 			backends = append(backends, notifierBackend{
-				notifier:           tg,
-				channels:           cfg.Telegram.Channels,
-				ownerID:            cfg.Telegram.OwnerChatID,
-				dmPaperTrades:      cfg.Telegram.DMPaperTrades,
-				dmLiveTrades:       cfg.Telegram.DMLiveTrades,
-				channelPaperTrades: cfg.Telegram.ChannelPaperTrades,
-				channelLiveTrades:  cfg.Telegram.ChannelLiveTrades,
-				plainText:          true,
+				notifier:      tg,
+				channels:      cfg.Telegram.Channels,
+				ownerID:       cfg.Telegram.OwnerChatID,
+				dmPaperTrades: cfg.Telegram.DMPaperTrades,
+				dmLiveTrades:  cfg.Telegram.DMLiveTrades,
+				plainText:     true,
 			})
 			defer tg.Close()
 		}
@@ -1204,26 +1200,23 @@ func sendTradeAlerts(sc StrategyConfig, stratState *StrategyState, trades int, m
 
 	for _, b := range notifier.backends {
 		dmEnabled := b.ownerID != "" && ((isLive && b.dmLiveTrades) || (!isLive && b.dmPaperTrades))
-		channelEnabled := (isLive && b.channelLiveTrades) || (!isLive && b.channelPaperTrades)
-		if !dmEnabled && !channelEnabled {
-			continue
-		}
 
-		ch := ""
-		if channelEnabled {
-			ch = resolveChannel(b.channels, sc.Platform, sc.Type)
-			if ch == "" {
-				fmt.Printf("[notify] channel trade alerts enabled but no channel configured for platform=%q type=%q\n", sc.Platform, sc.Type)
-			}
-		}
+		// Channel routing: presence of a channel ID means enabled, absence means disabled.
+		// Paper trades use "<platform>-paper" key with fallback to base platform key.
+		// Live trades use the base platform key.
+		ch := resolveTradeChannel(b.channels, sc.Platform, sc.Type, isLive)
 
 		// Also post live trades to a dedicated "<platform>-live" channel if configured.
 		var liveCh string
-		if isLive && channelEnabled {
+		if isLive {
 			liveCh = resolveChannel(b.channels, sc.Platform+"-live", "")
 			if liveCh == ch {
 				liveCh = "" // avoid double-posting to the same channel
 			}
+		}
+
+		if !dmEnabled && ch == "" && liveCh == "" {
+			continue
 		}
 
 		for _, t := range newTrades {

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -227,11 +227,10 @@ func TestSendTradeAlerts_DMAndChannel(t *testing.T) {
 	notifier := &MultiNotifier{
 		backends: []notifierBackend{
 			{
-				notifier:           mock,
-				ownerID:            "owner123",
-				channels:           map[string]string{"spot": "ch-spot-123"},
-				dmPaperTrades:      true,
-				channelPaperTrades: true,
+				notifier:      mock,
+				ownerID:       "owner123",
+				channels:      map[string]string{"spot": "ch-spot-123"},
+				dmPaperTrades: true,
 			},
 		},
 	}
@@ -250,6 +249,7 @@ func TestSendTradeAlerts_DMAndChannel(t *testing.T) {
 }
 
 func TestSendTradeAlerts_DMOnly(t *testing.T) {
+	// DM enabled but no channel configured for platform — only DM sent.
 	mock := &mockNotifier{}
 	sc := StrategyConfig{
 		ID:       "test-spot-sma",
@@ -264,11 +264,10 @@ func TestSendTradeAlerts_DMOnly(t *testing.T) {
 	notifier := &MultiNotifier{
 		backends: []notifierBackend{
 			{
-				notifier:           mock,
-				ownerID:            "owner123",
-				channels:           map[string]string{"spot": "ch-spot-123"},
-				dmPaperTrades:      true,
-				channelPaperTrades: false,
+				notifier:      mock,
+				ownerID:       "owner123",
+				channels:      map[string]string{}, // no channels configured
+				dmPaperTrades: true,
 			},
 		},
 	}
@@ -284,6 +283,7 @@ func TestSendTradeAlerts_DMOnly(t *testing.T) {
 }
 
 func TestSendTradeAlerts_ChannelOnly(t *testing.T) {
+	// Channel configured but DM disabled — only channel message sent.
 	mock := &mockNotifier{}
 	sc := StrategyConfig{
 		ID:       "test-spot-sma",
@@ -298,11 +298,9 @@ func TestSendTradeAlerts_ChannelOnly(t *testing.T) {
 	notifier := &MultiNotifier{
 		backends: []notifierBackend{
 			{
-				notifier:           mock,
-				ownerID:            "owner123",
-				channels:           map[string]string{"spot": "ch-spot-123"},
-				dmPaperTrades:      false,
-				channelPaperTrades: true,
+				notifier: mock,
+				ownerID:  "owner123",
+				channels: map[string]string{"spot": "ch-spot-123"},
 			},
 		},
 	}
@@ -318,6 +316,7 @@ func TestSendTradeAlerts_ChannelOnly(t *testing.T) {
 }
 
 func TestSendTradeAlerts_NeitherEnabled(t *testing.T) {
+	// No DM enabled, no channel configured — nothing sent.
 	mock := &mockNotifier{}
 	sc := StrategyConfig{
 		ID:       "test-spot-sma",
@@ -332,11 +331,9 @@ func TestSendTradeAlerts_NeitherEnabled(t *testing.T) {
 	notifier := &MultiNotifier{
 		backends: []notifierBackend{
 			{
-				notifier:           mock,
-				ownerID:            "owner123",
-				channels:           map[string]string{"spot": "ch-spot-123"},
-				dmPaperTrades:      false,
-				channelPaperTrades: false,
+				notifier: mock,
+				ownerID:  "owner123",
+				channels: map[string]string{}, // no channels configured
 			},
 		},
 	}
@@ -351,7 +348,8 @@ func TestSendTradeAlerts_NeitherEnabled(t *testing.T) {
 	}
 }
 
-func TestSendTradeAlerts_ChannelEnabledButNotConfigured(t *testing.T) {
+func TestSendTradeAlerts_NoChannelForPlatform(t *testing.T) {
+	// Channel map has "spot" but not "hyperliquid" or "perps" — no messages.
 	mock := &mockNotifier{}
 	sc := StrategyConfig{
 		ID:       "hl-perps-sma",
@@ -363,22 +361,18 @@ func TestSendTradeAlerts_ChannelEnabledButNotConfigured(t *testing.T) {
 		TradeHistory: []Trade{testTrade()},
 	}
 	var mu sync.RWMutex
-	// Channel map has "spot" but not "hyperliquid" or "perps"
 	notifier := &MultiNotifier{
 		backends: []notifierBackend{
 			{
-				notifier:           mock,
-				ownerID:            "owner123",
-				channels:           map[string]string{"spot": "ch-spot-123"},
-				dmPaperTrades:      false,
-				channelPaperTrades: true,
+				notifier: mock,
+				ownerID:  "owner123",
+				channels: map[string]string{"spot": "ch-spot-123"},
 			},
 		},
 	}
 
 	sendTradeAlerts(sc, state, 1, &mu, notifier)
 
-	// Channel enabled but no channel for platform=hyperliquid type=perps, so no messages sent
 	if len(mock.dms) != 0 {
 		t.Errorf("expected no DM messages, got %d", len(mock.dms))
 	}
@@ -403,11 +397,10 @@ func TestSendTradeAlerts_LiveChannelRouting(t *testing.T) {
 	notifier := &MultiNotifier{
 		backends: []notifierBackend{
 			{
-				notifier:          mock,
-				ownerID:           "owner123",
-				channels:          map[string]string{"hyperliquid": "ch-hl", "hyperliquid-live": "ch-hl-live"},
-				dmLiveTrades:      true,
-				channelLiveTrades: true,
+				notifier:     mock,
+				ownerID:      "owner123",
+				channels:     map[string]string{"hyperliquid": "ch-hl", "hyperliquid-live": "ch-hl-live"},
+				dmLiveTrades: true,
 			},
 		},
 	}
@@ -449,10 +442,9 @@ func TestSendTradeAlerts_LiveChannelDedup(t *testing.T) {
 	notifier := &MultiNotifier{
 		backends: []notifierBackend{
 			{
-				notifier:          mock,
-				ownerID:           "",
-				channels:          map[string]string{"hyperliquid": "ch-hl", "hyperliquid-live": "ch-hl"}, // same channel
-				channelLiveTrades: true,
+				notifier: mock,
+				ownerID:  "",
+				channels: map[string]string{"hyperliquid": "ch-hl", "hyperliquid-live": "ch-hl"}, // same channel
 			},
 		},
 	}
@@ -465,7 +457,8 @@ func TestSendTradeAlerts_LiveChannelDedup(t *testing.T) {
 }
 
 func TestSendTradeAlerts_PaperNoLiveChannel(t *testing.T) {
-	// Paper trades should NOT post to the <platform>-live channel.
+	// Paper trades should NOT post to the <platform>-live channel; they use
+	// <platform>-paper (or fall back to base platform channel).
 	mock := &mockNotifier{}
 	sc := StrategyConfig{
 		ID:       "hl-sma-btc",
@@ -480,10 +473,9 @@ func TestSendTradeAlerts_PaperNoLiveChannel(t *testing.T) {
 	notifier := &MultiNotifier{
 		backends: []notifierBackend{
 			{
-				notifier:           mock,
-				ownerID:            "",
-				channels:           map[string]string{"hyperliquid": "ch-hl", "hyperliquid-live": "ch-hl-live"},
-				channelPaperTrades: true,
+				notifier: mock,
+				ownerID:  "",
+				channels: map[string]string{"hyperliquid": "ch-hl", "hyperliquid-live": "ch-hl-live"},
 			},
 		},
 	}
@@ -495,6 +487,75 @@ func TestSendTradeAlerts_PaperNoLiveChannel(t *testing.T) {
 	}
 	if len(mock.messages) > 0 && mock.messages[0].channelID != "ch-hl" {
 		t.Errorf("expected message to primary channel ch-hl, got %s", mock.messages[0].channelID)
+	}
+}
+
+func TestSendTradeAlerts_PaperChannelRouting(t *testing.T) {
+	// Paper trades should route to <platform>-paper channel when configured.
+	mock := &mockNotifier{}
+	sc := StrategyConfig{
+		ID:       "hl-sma-btc",
+		Type:     "perps",
+		Platform: "hyperliquid",
+		Args:     []string{"sma", "BTC", "1h", "--mode=paper"},
+	}
+	state := &StrategyState{
+		TradeHistory: []Trade{testTrade()},
+	}
+	var mu sync.RWMutex
+	notifier := &MultiNotifier{
+		backends: []notifierBackend{
+			{
+				notifier: mock,
+				ownerID:  "",
+				channels: map[string]string{
+					"hyperliquid":       "ch-hl-live",
+					"hyperliquid-paper": "ch-hl-paper",
+				},
+			},
+		},
+	}
+
+	sendTradeAlerts(sc, state, 1, &mu, notifier)
+
+	if len(mock.messages) != 1 {
+		t.Errorf("expected 1 channel message, got %d", len(mock.messages))
+	}
+	if len(mock.messages) > 0 && mock.messages[0].channelID != "ch-hl-paper" {
+		t.Errorf("expected message to paper channel ch-hl-paper, got %s", mock.messages[0].channelID)
+	}
+}
+
+func TestSendTradeAlerts_PaperFallbackToBase(t *testing.T) {
+	// Paper trades fall back to base platform channel when no <platform>-paper key exists.
+	mock := &mockNotifier{}
+	sc := StrategyConfig{
+		ID:       "hl-sma-btc",
+		Type:     "perps",
+		Platform: "hyperliquid",
+		Args:     []string{"sma", "BTC", "1h", "--mode=paper"},
+	}
+	state := &StrategyState{
+		TradeHistory: []Trade{testTrade()},
+	}
+	var mu sync.RWMutex
+	notifier := &MultiNotifier{
+		backends: []notifierBackend{
+			{
+				notifier: mock,
+				ownerID:  "",
+				channels: map[string]string{"hyperliquid": "ch-hl"},
+			},
+		},
+	}
+
+	sendTradeAlerts(sc, state, 1, &mu, notifier)
+
+	if len(mock.messages) != 1 {
+		t.Errorf("expected 1 channel message, got %d", len(mock.messages))
+	}
+	if len(mock.messages) > 0 && mock.messages[0].channelID != "ch-hl" {
+		t.Errorf("expected message to base channel ch-hl, got %s", mock.messages[0].channelID)
 	}
 }
 

--- a/scheduler/notifier.go
+++ b/scheduler/notifier.go
@@ -17,13 +17,11 @@ type Notifier interface {
 // notifierBackend pairs a Notifier with its provider-specific config.
 type notifierBackend struct {
 	notifier           Notifier
-	channels           map[string]string // channel map from config (keyed by platform/type)
+	channels           map[string]string // channel map from config (keyed by platform/type; "<platform>-paper" for paper-specific)
 	ownerID            string
 	leaderboardChannel string // dedicated leaderboard channel ID (optional); when set, leaderboard posts route here
 	dmPaperTrades      bool   // send DM on paper trade execution
 	dmLiveTrades       bool   // send DM on live trade execution
-	channelPaperTrades bool   // post paper trade alerts to platform channel
-	channelLiveTrades  bool   // post live trade alerts to platform channel
 	plainText          bool   // use plain-text formatting (no markdown)
 }
 


### PR DESCRIPTION
Replace `channel_paper_trades` and `channel_live_trades` booleans with a `<platform>-paper` suffix convention in the channels map. Paper trade alerts now use `<platform>-paper` channel keys with fallback to the base platform key. Presence of a channel ID means enabled; absence means disabled.

Closes #247

Generated with [Claude Code](https://claude.ai/code)