### PR TITLE
chore(ci): upgrade default model to claude-opus-4-7[1m]

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -89,10 +89,10 @@ jobs:
           MODEL_SHORT=$(printf '%s' "$STRIPPED" | grep -oE '(^|(\r?\n))[[:space:]]*@claude[[:space:]]+[a-z]+' | head -1 | awk '{print $NF}' || true)
 
           case "$MODEL_SHORT" in
-            opus)    MODEL_ID="claude-opus-4-6[1m]" ;;
+            opus)    MODEL_ID="claude-opus-4-7[1m]" ;;
             sonnet)  MODEL_ID="claude-sonnet-4-6[1m]" ;;
             haiku)   MODEL_ID="claude-haiku-4-5" ;;
-            *)       MODEL_ID="claude-opus-4-6[1m]" ;;  # default (no model specified)
+            *)       MODEL_ID="claude-opus-4-7[1m]" ;;  # default (no model specified)
           esac
 
           echo "model_id=$MODEL_ID" >> "$GITHUB_OUTPUT"
@@ -167,7 +167,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           case "$MODEL_ID" in
-            "claude-opus-4-6[1m]")   MODEL_NAME="Claude Opus 4.6 (1M)" ;;
+            "claude-opus-4-7[1m]")   MODEL_NAME="Claude Opus 4.7 (1M)" ;;
             "claude-sonnet-4-6[1m]") MODEL_NAME="Claude Sonnet 4.6 (1M)" ;;
             claude-haiku-4-5)        MODEL_NAME="Claude Haiku 4.5" ;;
             *)                       MODEL_NAME="$MODEL_ID" ;;


### PR DESCRIPTION
Upgrades the default and `opus` shorthand model in the Claude Code GitHub Actions workflow from `claude-opus-4-6[1m]` to `claude-opus-4-7[1m]`.

---
Generated with: Claude Sonnet 4.6 (1M) | Effort: auto