### PR TITLE
feat(scheduler): dm_channels map for trade alerts (#248)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
   - `prompt.go` — `Prompter` struct (String/YesNo/Choice/MultiSelect/Float); inject `NewPrompterFromReader(r,w)` for tests
   - `updater.go` — update checker; `checkForUpdates(cfg, discord, &lastNotifiedHash, &mu, state)` — git fetch, channel notify + DM upgrade prompt (goroutine); `applyUpgrade(discord, ownerID, mu, state, cfg)` — git pull + go build + state save + restart; `restartSelf()` — systemctl → syscall.Exec fallback; logs `[update]` prefix
   - `correlation.go` — per-asset directional exposure tracking; `ComputeCorrelation` warns on concentration/same-direction thresholds
-  - `config_migration.go` — `CurrentConfigVersion = 5`; auto-migrates config via Discord DM on startup
+  - `config_migration.go` — `CurrentConfigVersion = 7`; auto-migrates config via Discord DM on startup
   - `balance.go` — balance tracking and capital management
   - `hyperliquid_balance.go` — Hyperliquid-specific balance sync (`syncHyperliquidAccountPositions`)
   - `leaderboard.go` — pre-computed strategy leaderboard for Discord summaries
@@ -82,7 +82,7 @@
 - State persisted to `scheduler/state.json` (path set in config); per-platform files at `platforms/<name>/state.json`
 - `cfg.Discord.Channels` is `map[string]string` (not a struct); keys: "spot", "options", "hyperliquid", etc. — old `.Spot`/`.Options` field access is invalid
 - `cfg.Discord.OwnerID` — Discord user ID for DM upgrade prompts + config migration; loaded from `DISCORD_OWNER_ID` env var (takes priority over config file)
-- `cfg.ConfigVersion` — int, schema version (`0`/missing = v1 baseline); `CurrentConfigVersion = 5` in config_migration.go; startup triggers `runConfigMigrationDM` when below current version
+- `cfg.ConfigVersion` — int, schema version (`0`/missing = v1 baseline); `CurrentConfigVersion = 7` in config_migration.go; startup triggers `runConfigMigrationDM` when below current version
 - `cfg.Correlation` — `*CorrelationConfig` with `Enabled` (default false), `MaxConcentrationPct` (default 60), `MaxSameDirectionPct` (default 75); computed under RLock, state assigned under Lock; warnings sent to all Discord channels + owner DM
 - `cfg.AutoUpdate` — `"off"` (default), `"daily"` (once/day), `"heartbeat"` (every cycle); handled in main.go loop + startup; uses `dailyCycles = (24*3600)/tickSeconds`
 - Strategy registry imports: `check_strategy.py` imports from `shared_strategies/spot/strategies.py`; `check_hyperliquid.py`, `check_topstep.py`, and `check_okx.py` (swap mode) import from `shared_strategies/futures/strategies.py` — a new strategy must be registered in both if it needs to work across platforms

--- a/scheduler/config.example.json
+++ b/scheduler/config.example.json
@@ -1,4 +1,5 @@
 {
+  "config_version": 7,
   "interval_seconds": 300,
   "state_file": "scheduler/state.json",
   "portfolio_risk": {
@@ -72,6 +73,10 @@
       "options": "",
       "hyperliquid": "",
       "hyperliquid-paper": ""
+    },
+    "dm_channels": {
+      "hyperliquid": "PASTE_DISCORD_USER_OR_CHANNEL_ID",
+      "hyperliquid-paper": "PASTE_DISCORD_USER_OR_CHANNEL_ID"
     },
     "spot_summary_freq": "hourly",
     "options_summary_freq": "per_check",

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -495,8 +495,14 @@ func ValidateConfig(cfg *Config) error {
 		}
 	}
 
-	validateDMChannelsMap(cfg.Discord.DMChannels, "discord", &errs)
-	validateDMChannelsMap(cfg.Telegram.DMChannels, "telegram", &errs)
+	knownPlatforms := make(map[string]bool)
+	for _, sc := range cfg.Strategies {
+		if p := strings.TrimSpace(sc.Platform); p != "" {
+			knownPlatforms[p] = true
+		}
+	}
+	validateDMChannelsMap(cfg.Discord.DMChannels, "discord", knownPlatforms, &errs)
+	validateDMChannelsMap(cfg.Telegram.DMChannels, "telegram", knownPlatforms, &errs)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("config validation errors:\n  %s", strings.Join(errs, "\n  "))
@@ -505,7 +511,9 @@ func ValidateConfig(cfg *Config) error {
 }
 
 // validateDMChannelsMap checks dm_channels keys and values (#248).
-func validateDMChannelsMap(m map[string]string, label string, errs *[]string) {
+// Keys must be "<platform>" or "<platform>-paper" with a non-empty platform prefix.
+// Unknown platforms (not present in cfg.Strategies) produce a warning log but not a validation error.
+func validateDMChannelsMap(m map[string]string, label string, knownPlatforms map[string]bool, errs *[]string) {
 	if m == nil {
 		return
 	}
@@ -518,8 +526,17 @@ func validateDMChannelsMap(m map[string]string, label string, errs *[]string) {
 			*errs = append(*errs, fmt.Sprintf("%s: dm_channels key %q is invalid (only optional suffix is \"-paper\")", label, k))
 			continue
 		}
+		platform := strings.TrimSuffix(k, "-paper")
+		if platform == "" {
+			*errs = append(*errs, fmt.Sprintf("%s: dm_channels key %q is invalid (platform prefix is empty)", label, k))
+			continue
+		}
 		if strings.TrimSpace(v) == "" {
 			*errs = append(*errs, fmt.Sprintf("%s: dm_channels[%q] must be non-empty", label, k))
+			continue
+		}
+		if len(knownPlatforms) > 0 && !knownPlatforms[platform] {
+			fmt.Printf("[WARN] %s: dm_channels[%q] references platform %q with no configured strategies — possible typo\n", label, k, platform)
 		}
 	}
 }

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -15,8 +15,7 @@ type DiscordConfig struct {
 	Enabled            bool              `json:"enabled"`
 	Token              string            `json:"token"`
 	OwnerID            string            `json:"owner_id,omitempty"`            // Discord user ID for DM features (upgrade prompts, config migration)
-	DMPaperTrades      bool              `json:"dm_paper_trades,omitempty"`     // DM owner on paper trade execution
-	DMLiveTrades       bool              `json:"dm_live_trades,omitempty"`      // DM owner on live trade execution
+	DMChannels         map[string]string `json:"dm_channels,omitempty"`         // per-platform DM-style trade alerts: "<platform>" (live), "<platform>-paper" (paper); value = user ID or channel ID
 	Channels           map[string]string `json:"channels"`                      // keyed by platform or type; "<platform>-paper" for paper-specific channels
 	LeaderboardTopN    int               `json:"leaderboard_top_n,omitempty"`   // number of entries shown in leaderboard messages (default 5)
 	LeaderboardChannel string            `json:"leaderboard_channel,omitempty"` // dedicated Discord channel ID for leaderboard posts; when set, all leaderboards route here instead of being broadcast across platform channels
@@ -24,12 +23,11 @@ type DiscordConfig struct {
 
 // TelegramConfig holds Telegram notification settings.
 type TelegramConfig struct {
-	Enabled       bool              `json:"enabled"`
-	BotToken      string            `json:"bot_token"`
-	OwnerChatID   string            `json:"owner_chat_id,omitempty"`   // Owner's Telegram chat ID for DMs/upgrade prompts
-	DMPaperTrades bool              `json:"dm_paper_trades,omitempty"` // send message on paper trade execution
-	DMLiveTrades  bool              `json:"dm_live_trades,omitempty"`  // send message on live trade execution
-	Channels      map[string]string `json:"channels"`                  // keyed by platform or type; "<platform>-paper" for paper-specific channels
+	Enabled     bool              `json:"enabled"`
+	BotToken    string            `json:"bot_token"`
+	OwnerChatID string            `json:"owner_chat_id,omitempty"` // Owner's Telegram chat ID for DMs/upgrade prompts
+	DMChannels  map[string]string `json:"dm_channels,omitempty"`   // per-platform trade alerts: "<platform>" (live), "<platform>-paper" (paper); value = chat ID
+	Channels    map[string]string `json:"channels"`                // keyed by platform or type; "<platform>-paper" for paper-specific channels
 }
 
 // PortfolioRiskConfig controls aggregate portfolio-level risk (#42).
@@ -497,8 +495,31 @@ func ValidateConfig(cfg *Config) error {
 		}
 	}
 
+	validateDMChannelsMap(cfg.Discord.DMChannels, "discord", &errs)
+	validateDMChannelsMap(cfg.Telegram.DMChannels, "telegram", &errs)
+
 	if len(errs) > 0 {
 		return fmt.Errorf("config validation errors:\n  %s", strings.Join(errs, "\n  "))
 	}
 	return nil
+}
+
+// validateDMChannelsMap checks dm_channels keys and values (#248).
+func validateDMChannelsMap(m map[string]string, label string, errs *[]string) {
+	if m == nil {
+		return
+	}
+	for k, v := range m {
+		if k == "" {
+			*errs = append(*errs, fmt.Sprintf("%s: dm_channels has empty key", label))
+			continue
+		}
+		if strings.Contains(k, "-paper") && !strings.HasSuffix(k, "-paper") {
+			*errs = append(*errs, fmt.Sprintf("%s: dm_channels key %q is invalid (only optional suffix is \"-paper\")", label, k))
+			continue
+		}
+		if strings.TrimSpace(v) == "" {
+			*errs = append(*errs, fmt.Sprintf("%s: dm_channels[%q] must be non-empty", label, k))
+		}
+	}
 }

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -62,7 +62,10 @@ var v7DeprecatedFields = []string{
 
 const v7DeprecationNotice = "**Note:** `dm_paper_trades` and `dm_live_trades` have been replaced by a `dm_channels` map. " +
 	"Paper trades use `dm_channels[\"<platform>-paper\"]`; live trades use `dm_channels[\"<platform>\"]`. " +
-	"Absent keys disable DM-style trade alerts for that platform. See issue #248."
+	"Absent keys disable DM-style trade alerts for that platform. Values may be a user ID (delivered as a DM) " +
+	"or a channel/chat ID (delivered as a channel message) — the name \"dm_channels\" reflects the fallback behavior, " +
+	"not a restriction. Migration populates `dm_channels` only for platforms currently configured; new platforms " +
+	"added later will not auto-enroll — add an entry manually. See issue #248."
 
 // NewFieldsSince returns all ConfigFields added after the given version number.
 func NewFieldsSince(version int) []ConfigField {
@@ -181,7 +184,7 @@ func translateV7DMChannels(raw map[string]interface{}, cfg *Config) {
 			fmt.Printf("[migration] %s: dm trade booleans set but no strategies found — add dm_channels manually\n", section)
 			return
 		}
-		dm := cloneOrNewStringMap(sec["dm_channels"])
+		dm := cloneOrNewJSONMap(sec["dm_channels"])
 		for _, p := range platforms {
 			if paperB {
 				k := p + "-paper"
@@ -238,7 +241,9 @@ func stringFromJSON(v interface{}) string {
 	return strings.TrimSpace(fmt.Sprint(v))
 }
 
-func cloneOrNewStringMap(v interface{}) map[string]interface{} {
+// cloneOrNewJSONMap returns a shallow copy of v if it is a JSON object (map[string]interface{}),
+// or a fresh empty map otherwise. Values remain interface{} — this is not a string-keyed string map.
+func cloneOrNewJSONMap(v interface{}) map[string]interface{} {
 	out := make(map[string]interface{})
 	if m, ok := v.(map[string]interface{}); ok {
 		for k, val := range m {

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -10,7 +10,7 @@ import (
 
 // CurrentConfigVersion is the version embedded in newly generated configs.
 // When the binary starts and cfg.ConfigVersion < CurrentConfigVersion, migration runs.
-const CurrentConfigVersion = 6
+const CurrentConfigVersion = 7
 
 // ConfigField describes a config field introduced in a specific version.
 type ConfigField struct {
@@ -37,34 +37,6 @@ var configFieldRegistry = []ConfigField{
 		Default:     "80",
 		FieldType:   "float",
 	},
-	{
-		Version:     4,
-		JSONPath:    "discord.dm_live_trades",
-		Description: "Send a DM to the bot owner on every live trade execution (true/false).",
-		Default:     "false",
-		FieldType:   "bool",
-	},
-	{
-		Version:     4,
-		JSONPath:    "discord.dm_paper_trades",
-		Description: "Send a DM to the bot owner on every paper trade execution (true/false).",
-		Default:     "false",
-		FieldType:   "bool",
-	},
-	{
-		Version:     4,
-		JSONPath:    "telegram.dm_live_trades",
-		Description: "Send a Telegram message on every live trade execution (true/false).",
-		Default:     "false",
-		FieldType:   "bool",
-	},
-	{
-		Version:     4,
-		JSONPath:    "telegram.dm_paper_trades",
-		Description: "Send a Telegram message on every paper trade execution (true/false).",
-		Default:     "false",
-		FieldType:   "bool",
-	},
 }
 
 // v6DeprecatedFields lists fields removed in v6 (channel boolean routing replaced by
@@ -80,6 +52,18 @@ const v6DeprecationNotice = "**Note:** `channel_paper_trades` and `channel_live_
 	"Channel trade alerts are now controlled by channel presence: add `\"<platform>-paper\"` keys to " +
 	"your channels map for paper-specific routing. See issue #247."
 
+// v7DeprecatedFields lists fields removed in v7 (replaced by dm_channels map). Cleaned during migration.
+var v7DeprecatedFields = []string{
+	"discord.dm_paper_trades",
+	"discord.dm_live_trades",
+	"telegram.dm_paper_trades",
+	"telegram.dm_live_trades",
+}
+
+const v7DeprecationNotice = "**Note:** `dm_paper_trades` and `dm_live_trades` have been replaced by a `dm_channels` map. " +
+	"Paper trades use `dm_channels[\"<platform>-paper\"]`; live trades use `dm_channels[\"<platform>\"]`. " +
+	"Absent keys disable DM-style trade alerts for that platform. See issue #248."
+
 // NewFieldsSince returns all ConfigFields added after the given version number.
 func NewFieldsSince(version int) []ConfigField {
 	var fields []ConfigField
@@ -93,7 +77,8 @@ func NewFieldsSince(version int) []ConfigField {
 
 // MigrateConfig loads the config as a raw JSON map, applies fieldValues at dot-paths,
 // removes deprecated fields, bumps config_version to CurrentConfigVersion, and writes back atomically.
-func MigrateConfig(configPath string, fieldValues map[string]string) error {
+// cfg is optional; when non-nil it is used to translate pre-v7 dm_* booleans into dm_channels per strategy platform.
+func MigrateConfig(configPath string, fieldValues map[string]string, cfg *Config) error {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		return fmt.Errorf("read config: %w", err)
@@ -104,13 +89,26 @@ func MigrateConfig(configPath string, fieldValues map[string]string) error {
 		return fmt.Errorf("parse config: %w", err)
 	}
 
+	oldVer := 0
+	if v, ok := raw["config_version"].(float64); ok {
+		oldVer = int(v)
+	}
+
 	for path, value := range fieldValues {
 		setNestedField(raw, path, value)
 	}
 
 	// v6: remove deprecated channel boolean fields (replaced by <platform>-paper convention).
-	if version, ok := raw["config_version"].(float64); !ok || int(version) < 6 {
+	if oldVer < 6 {
 		for _, path := range v6DeprecatedFields {
+			removeNestedField(raw, path)
+		}
+	}
+
+	// v7: translate dm_paper_trades / dm_live_trades into dm_channels, then remove deprecated booleans.
+	if oldVer < 7 {
+		translateV7DMChannels(raw, cfg)
+		for _, path := range v7DeprecatedFields {
 			removeNestedField(raw, path)
 		}
 	}
@@ -158,6 +156,98 @@ func removeNestedField(obj map[string]interface{}, path string) {
 	removeNestedField(nested, parts[1])
 }
 
+// translateV7DMChannels merges legacy dm_paper_trades / dm_live_trades booleans into dm_channels (#248).
+func translateV7DMChannels(raw map[string]interface{}, cfg *Config) {
+	if cfg == nil {
+		return
+	}
+	platforms := collectUniquePlatforms(cfg)
+	translateSection := func(section, ownerKey string) {
+		sec, ok := raw[section].(map[string]interface{})
+		if !ok {
+			return
+		}
+		liveB := jsonBoolish(sec["dm_live_trades"])
+		paperB := jsonBoolish(sec["dm_paper_trades"])
+		if !liveB && !paperB {
+			return
+		}
+		owner := stringFromJSON(sec[ownerKey])
+		if owner == "" {
+			fmt.Printf("[migration] %s: dm_paper_trades/dm_live_trades enabled but %s is empty — cannot populate dm_channels\n", section, ownerKey)
+			return
+		}
+		if len(platforms) == 0 {
+			fmt.Printf("[migration] %s: dm trade booleans set but no strategies found — add dm_channels manually\n", section)
+			return
+		}
+		dm := cloneOrNewStringMap(sec["dm_channels"])
+		for _, p := range platforms {
+			if paperB {
+				k := p + "-paper"
+				if _, exists := dm[k]; !exists {
+					dm[k] = owner
+				}
+			}
+			if liveB {
+				if _, exists := dm[p]; !exists {
+					dm[p] = owner
+				}
+			}
+		}
+		sec["dm_channels"] = dm
+	}
+	translateSection("discord", "owner_id")
+	translateSection("telegram", "owner_chat_id")
+}
+
+func collectUniquePlatforms(cfg *Config) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, sc := range cfg.Strategies {
+		p := strings.TrimSpace(sc.Platform)
+		if p == "" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	return out
+}
+
+func jsonBoolish(v interface{}) bool {
+	switch t := v.(type) {
+	case bool:
+		return t
+	case string:
+		return strings.EqualFold(strings.TrimSpace(t), "true") || strings.TrimSpace(t) == "1"
+	case float64:
+		return t != 0
+	default:
+		return false
+	}
+}
+
+func stringFromJSON(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return strings.TrimSpace(s)
+	}
+	return strings.TrimSpace(fmt.Sprint(v))
+}
+
+func cloneOrNewStringMap(v interface{}) map[string]interface{} {
+	out := make(map[string]interface{})
+	if m, ok := v.(map[string]interface{}); ok {
+		for k, val := range m {
+			out[k] = val
+		}
+	}
+	return out
+}
+
 // runConfigMigrationDM prompts the owner via DM for any new config fields introduced
 // since cfg.ConfigVersion. Falls back to applying defaults silently when DM is unavailable.
 func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath string) {
@@ -165,7 +255,7 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 
 	if len(fields) == 0 {
 		// Already at current version — just bump silently.
-		if err := MigrateConfig(configPath, nil); err != nil {
+		if err := MigrateConfig(configPath, nil, cfg); err != nil {
 			fmt.Printf("[migration] Failed to bump config version: %v\n", err)
 		}
 		// v6: notify about deprecated channel boolean removal.
@@ -174,6 +264,14 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 				notifier.SendOwnerDM(v6DeprecationNotice)
 			} else {
 				fmt.Printf("[migration] %s\n", v6DeprecationNotice)
+			}
+		}
+		// v7: notify about dm_channels migration (#248).
+		if cfg.ConfigVersion < 7 {
+			if notifier != nil && notifier.HasOwner() {
+				notifier.SendOwnerDM(v7DeprecationNotice)
+			} else {
+				fmt.Printf("[migration] %s\n", v7DeprecationNotice)
 			}
 		}
 		return
@@ -189,11 +287,14 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 				values[f.JSONPath] = f.Default
 			}
 		}
-		if err := MigrateConfig(configPath, values); err != nil {
+		if err := MigrateConfig(configPath, values, cfg); err != nil {
 			fmt.Printf("[migration] Failed to migrate config: %v\n", err)
 		}
 		if cfg.ConfigVersion < 6 {
 			fmt.Printf("[migration] %s\n", v6DeprecationNotice)
+		}
+		if cfg.ConfigVersion < 7 {
+			fmt.Printf("[migration] %s\n", v7DeprecationNotice)
 		}
 		return
 	}
@@ -217,7 +318,7 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 		}
 	}
 
-	if err := MigrateConfig(configPath, values); err != nil {
+	if err := MigrateConfig(configPath, values, cfg); err != nil {
 		notifier.SendOwnerDM(fmt.Sprintf("**Migration failed**: %v", err))
 		return
 	}
@@ -227,5 +328,9 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 	// v6: notify about deprecated channel boolean removal.
 	if cfg.ConfigVersion < 6 {
 		notifier.SendOwnerDM(v6DeprecationNotice)
+	}
+	// v7: notify about dm_channels migration (#248).
+	if cfg.ConfigVersion < 7 {
+		notifier.SendOwnerDM(v7DeprecationNotice)
 	}
 }

--- a/scheduler/config_migration_test.go
+++ b/scheduler/config_migration_test.go
@@ -12,11 +12,11 @@ func TestNewFieldsSince(t *testing.T) {
 		version  int
 		minCount int // at least this many fields
 	}{
-		{0, 6},                    // all fields; v5 channel booleans removed in v6
-		{1, 6},                    // v1 baseline, should get all v2+ fields
-		{2, 4},                    // should get v3+ fields
-		{3, 4},                    // should get v4+ fields
-		{4, 0},                    // v5 channel booleans removed — no new fields since v4
+		{0, 2}, // v2 owner_id + v3 warn_threshold (v4 dm booleans removed in v7)
+		{1, 2}, // v1 baseline → v2+ fields
+		{2, 1}, // v3+ only
+		{3, 0}, // nothing after v3 in registry
+		{4, 0},
 		{CurrentConfigVersion, 0}, // no new fields
 		{999, 0},                  // future version
 	}
@@ -73,7 +73,7 @@ func TestMigrateConfigBasic(t *testing.T) {
 	values := map[string]string{
 		"discord.owner_id": "12345",
 	}
-	if err := MigrateConfig(path, values); err != nil {
+	if err := MigrateConfig(path, values, nil); err != nil {
 		t.Fatalf("MigrateConfig failed: %v", err)
 	}
 
@@ -122,9 +122,9 @@ func TestMigrateConfigCreatesNestedPaths(t *testing.T) {
 	}
 
 	values := map[string]string{
-		"discord.dm_live_trades": "true",
+		"discord.dm_channels.hyperliquid": "999888777",
 	}
-	if err := MigrateConfig(path, values); err != nil {
+	if err := MigrateConfig(path, values, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -138,8 +138,9 @@ func TestMigrateConfigCreatesNestedPaths(t *testing.T) {
 	}
 
 	discord := updated["discord"].(map[string]interface{})
-	if discord["dm_live_trades"] != "true" {
-		t.Errorf("discord.dm_live_trades = %v, want %q", discord["dm_live_trades"], "true")
+	dmCh := discord["dm_channels"].(map[string]interface{})
+	if dmCh["hyperliquid"] != "999888777" {
+		t.Errorf("discord.dm_channels.hyperliquid = %v, want %q", dmCh["hyperliquid"], "999888777")
 	}
 }
 
@@ -157,7 +158,7 @@ func TestMigrateConfigNilValues(t *testing.T) {
 	}
 
 	// nil values — just bump version
-	if err := MigrateConfig(path, nil); err != nil {
+	if err := MigrateConfig(path, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -189,7 +190,7 @@ func TestMigrateConfigAtomicWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := MigrateConfig(path, nil); err != nil {
+	if err := MigrateConfig(path, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -200,7 +201,7 @@ func TestMigrateConfigAtomicWrite(t *testing.T) {
 }
 
 func TestMigrateConfigMissingFile(t *testing.T) {
-	err := MigrateConfig("/nonexistent/config.json", nil)
+	err := MigrateConfig("/nonexistent/config.json", nil, nil)
 	if err == nil {
 		t.Error("expected error for missing file")
 	}
@@ -213,7 +214,7 @@ func TestMigrateConfigInvalidJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := MigrateConfig(path, nil)
+	err := MigrateConfig(path, nil, nil)
 	if err == nil {
 		t.Error("expected error for invalid JSON")
 	}
@@ -289,7 +290,7 @@ func TestMigrateConfigV6SkipsRemovalForCurrentVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := MigrateConfig(path, nil); err != nil {
+	if err := MigrateConfig(path, nil, nil); err != nil {
 		t.Fatalf("MigrateConfig failed: %v", err)
 	}
 
@@ -339,7 +340,7 @@ func TestMigrateConfigV6RemovesChannelBooleans(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := MigrateConfig(path, nil); err != nil {
+	if err := MigrateConfig(path, nil, nil); err != nil {
 		t.Fatalf("MigrateConfig failed: %v", err)
 	}
 
@@ -352,7 +353,7 @@ func TestMigrateConfigV6RemovesChannelBooleans(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Version should be bumped to 6.
+	// Version should be bumped to CurrentConfigVersion.
 	version := int(updated["config_version"].(float64))
 	if version != CurrentConfigVersion {
 		t.Errorf("config_version = %d, want %d", version, CurrentConfigVersion)
@@ -382,5 +383,119 @@ func TestMigrateConfigV6RemovesChannelBooleans(t *testing.T) {
 	channels := discord["channels"].(map[string]interface{})
 	if channels["hyperliquid"] != "ch-123" {
 		t.Error("discord.channels.hyperliquid should be preserved")
+	}
+}
+
+func TestMigrateConfigV7TranslatesDMBooleans(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	original := map[string]interface{}{
+		"config_version": 6,
+		"discord": map[string]interface{}{
+			"owner_id":        "disc-owner",
+			"dm_paper_trades": true,
+			"dm_live_trades":  false,
+		},
+		"telegram": map[string]interface{}{
+			"owner_chat_id":   "tg-owner",
+			"dm_paper_trades": false,
+			"dm_live_trades":  true,
+		},
+	}
+	data, err := json.MarshalIndent(original, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{
+		Strategies: []StrategyConfig{
+			{Platform: "hyperliquid"},
+			{Platform: "deribit"},
+		},
+	}
+	if err := MigrateConfig(path, nil, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var updated map[string]interface{}
+	if err := json.Unmarshal(result, &updated); err != nil {
+		t.Fatal(err)
+	}
+
+	discord := updated["discord"].(map[string]interface{})
+	if _, ok := discord["dm_paper_trades"]; ok {
+		t.Error("discord.dm_paper_trades should be removed")
+	}
+	if _, ok := discord["dm_live_trades"]; ok {
+		t.Error("discord.dm_live_trades should be removed")
+	}
+	dmD := discord["dm_channels"].(map[string]interface{})
+	if dmD["hyperliquid-paper"] != "disc-owner" || dmD["deribit-paper"] != "disc-owner" {
+		t.Errorf("discord dm_channels (paper) = %#v", dmD)
+	}
+	if _, ok := dmD["hyperliquid"]; ok {
+		t.Error("discord live hyperliquid should not be set when dm_live_trades is false")
+	}
+
+	tg := updated["telegram"].(map[string]interface{})
+	if _, ok := tg["dm_live_trades"]; ok {
+		t.Error("telegram.dm_live_trades should be removed")
+	}
+	dmT := tg["dm_channels"].(map[string]interface{})
+	if dmT["hyperliquid"] != "tg-owner" || dmT["deribit"] != "tg-owner" {
+		t.Errorf("telegram dm_channels (live) = %#v", dmT)
+	}
+	if _, ok := dmT["hyperliquid-paper"]; ok {
+		t.Error("telegram paper key should not exist when dm_paper_trades is false")
+	}
+}
+
+func TestMigrateConfigV7RemovesDMBooleansWhenUnset(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	original := map[string]interface{}{
+		"config_version": 6,
+		"discord": map[string]interface{}{
+			"owner_id":        "o1",
+			"dm_paper_trades": false,
+			"dm_live_trades":  false,
+		},
+	}
+	data, err := json.MarshalIndent(original, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{Strategies: []StrategyConfig{{Platform: "hyperliquid"}}}
+	if err := MigrateConfig(path, nil, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var updated map[string]interface{}
+	if err := json.Unmarshal(result, &updated); err != nil {
+		t.Fatal(err)
+	}
+	discord := updated["discord"].(map[string]interface{})
+	if _, ok := discord["dm_paper_trades"]; ok {
+		t.Error("dm_paper_trades should be removed")
+	}
+	if _, ok := discord["dm_channels"]; ok {
+		t.Error("dm_channels should not be added when both dm booleans are false")
 	}
 }

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -874,3 +874,30 @@ func TestValidateConfigDMChannelsValidKeys(t *testing.T) {
 		t.Errorf("telegram dm_channels mismatch: %#v", loaded.Telegram.DMChannels)
 	}
 }
+
+func TestValidateConfigDMChannelsOrphanSuffix(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [{
+			"id": "t-spot",
+			"type": "spot",
+			"script": "shared_scripts/check_strategy.py",
+			"args": ["sma_crossover", "BTC/USDT", "1h"],
+			"capital": 1000,
+			"max_drawdown_pct": 60
+		}],
+		"discord": {
+			"enabled": false,
+			"channels": {},
+			"dm_channels": { "-paper": "123" }
+		}
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected validation error for orphan -paper key")
+	}
+	if !strings.Contains(err.Error(), "platform prefix is empty") {
+		t.Errorf("error = %v, want mention of empty platform prefix", err)
+	}
+}

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -780,3 +780,97 @@ func TestLoadConfigLeverageRejectsOutOfRange(t *testing.T) {
 		t.Errorf("error = %v, want 'leverage must be in'", err)
 	}
 }
+
+func TestValidateConfigDMChannelsInvalidKey(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [{
+			"id": "t-spot",
+			"type": "spot",
+			"script": "shared_scripts/check_strategy.py",
+			"args": ["sma_crossover", "BTC/USDT", "1h"],
+			"capital": 1000,
+			"max_drawdown_pct": 60
+		}],
+		"discord": {
+			"enabled": false,
+			"channels": {},
+			"dm_channels": { "hyperliquid-paper-extra": "123456789" }
+		}
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected validation error for invalid dm_channels key")
+	}
+	if !strings.Contains(err.Error(), "dm_channels key") {
+		t.Errorf("error = %v, want mention of dm_channels key", err)
+	}
+}
+
+func TestValidateConfigDMChannelsEmptyValue(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [{
+			"id": "t-spot",
+			"type": "spot",
+			"script": "shared_scripts/check_strategy.py",
+			"args": ["sma_crossover", "BTC/USDT", "1h"],
+			"capital": 1000,
+			"max_drawdown_pct": 60
+		}],
+		"discord": {
+			"enabled": false,
+			"channels": {},
+			"dm_channels": { "hyperliquid-paper": "" }
+		}
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected validation error for empty dm_channels value")
+	}
+	if !strings.Contains(err.Error(), "dm_channels[\"hyperliquid-paper\"]") {
+		t.Errorf("error = %v", err)
+	}
+}
+
+func TestValidateConfigDMChannelsValidKeys(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [{
+			"id": "hl-test",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "BTC", "1h", "--mode=paper"],
+			"capital": 1000,
+			"max_drawdown_pct": 50
+		}],
+		"discord": {
+			"enabled": false,
+			"channels": {},
+			"dm_channels": {
+				"hyperliquid": "111",
+				"hyperliquid-paper": "222",
+				"deribit": "333"
+			}
+		},
+		"telegram": {
+			"enabled": false,
+			"channels": {},
+			"dm_channels": { "okx-paper": "444" }
+		}
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	loaded, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if loaded.Discord.DMChannels["hyperliquid"] != "111" || loaded.Discord.DMChannels["hyperliquid-paper"] != "222" {
+		t.Errorf("discord dm_channels mismatch: %#v", loaded.Discord.DMChannels)
+	}
+	if loaded.Telegram.DMChannels["okx-paper"] != "444" {
+		t.Errorf("telegram dm_channels mismatch: %#v", loaded.Telegram.DMChannels)
+	}
+}

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -267,10 +267,6 @@ type InitOptions struct {
 	TelegramOwnerChatID     string            // Telegram chat ID for owner DMs
 	TelegramChannelMap      map[string]string // keyed by platform/type ("spot", "hyperliquid", etc.)
 	AutoUpdate              string            // "off", "daily", "heartbeat" (default: "off")
-	DMPaperTrades           bool              // DM owner on paper trade execution
-	DMLiveTrades            bool              // DM owner on live trade execution
-	TelegramDMPaper         bool              // Telegram: send on paper trade
-	TelegramDMLive          bool              // Telegram: send on live trade
 }
 
 // generateConfig builds a Config from InitOptions. Pure function, no I/O.
@@ -285,18 +281,14 @@ func generateConfig(opts InitOptions) *Config {
 			MaxNotionalUSD: 0,
 		},
 		Discord: DiscordConfig{
-			Enabled:       opts.DiscordEnabled,
-			OwnerID:       opts.DiscordOwnerID,
-			DMPaperTrades: opts.DMPaperTrades,
-			DMLiveTrades:  opts.DMLiveTrades,
-			Channels:      opts.ChannelMap,
+			Enabled:  opts.DiscordEnabled,
+			OwnerID:  opts.DiscordOwnerID,
+			Channels: opts.ChannelMap,
 		},
 		Telegram: TelegramConfig{
-			Enabled:       opts.TelegramEnabled,
-			OwnerChatID:   opts.TelegramOwnerChatID,
-			DMPaperTrades: opts.TelegramDMPaper,
-			DMLiveTrades:  opts.TelegramDMLive,
-			Channels:      opts.TelegramChannelMap,
+			Enabled:     opts.TelegramEnabled,
+			OwnerChatID: opts.TelegramOwnerChatID,
+			Channels:    opts.TelegramChannelMap,
 		},
 		AutoUpdate: opts.AutoUpdate,
 		Platforms:  make(map[string]*PlatformConfig),
@@ -1049,13 +1041,9 @@ func runInit(args []string) int {
 	discordEnabled := false
 	channelMap := make(map[string]string)
 	discordOwnerID := ""
-	dmLiveTrades := false
-	dmPaperTrades := false
 	telegramEnabled := false
 	telegramChannelMap := make(map[string]string)
 	telegramOwnerChatID := ""
-	telegramDMLive := false
-	telegramDMPaper := false
 
 	// Auto-update defaults to off; HTF filter defaults to enabled.
 	autoUpdate := "off"
@@ -1155,10 +1143,6 @@ func runInit(args []string) int {
 		TelegramOwnerChatID:     telegramOwnerChatID,
 		TelegramChannelMap:      telegramChannelMap,
 		AutoUpdate:              autoUpdate,
-		DMPaperTrades:           dmPaperTrades,
-		DMLiveTrades:            dmLiveTrades,
-		TelegramDMPaper:         telegramDMPaper,
-		TelegramDMLive:          telegramDMLive,
 	}
 
 	cfg := generateConfig(opts)

--- a/scheduler/init_test.go
+++ b/scheduler/init_test.go
@@ -885,17 +885,11 @@ func TestGenerateConfig_DefaultsForOptionalFields(t *testing.T) {
 	if cfg.Telegram.Enabled {
 		t.Error("expected Telegram.Enabled=false by default")
 	}
-	if cfg.Discord.DMPaperTrades {
-		t.Error("expected Discord.DMPaperTrades=false by default")
+	if cfg.Discord.DMChannels != nil {
+		t.Errorf("expected Discord.DMChannels=nil by default, got %v", cfg.Discord.DMChannels)
 	}
-	if cfg.Discord.DMLiveTrades {
-		t.Error("expected Discord.DMLiveTrades=false by default")
-	}
-	if cfg.Telegram.DMPaperTrades {
-		t.Error("expected Telegram.DMPaperTrades=false by default")
-	}
-	if cfg.Telegram.DMLiveTrades {
-		t.Error("expected Telegram.DMLiveTrades=false by default")
+	if cfg.Telegram.DMChannels != nil {
+		t.Errorf("expected Telegram.DMChannels=nil by default, got %v", cfg.Telegram.DMChannels)
 	}
 
 	// Auto-update should default to empty (off).

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -150,8 +150,7 @@ func main() {
 				channels:           cfg.Discord.Channels,
 				ownerID:            cfg.Discord.OwnerID,
 				leaderboardChannel: cfg.Discord.LeaderboardChannel,
-				dmPaperTrades:      cfg.Discord.DMPaperTrades,
-				dmLiveTrades:       cfg.Discord.DMLiveTrades,
+				dmChannels:         cfg.Discord.DMChannels,
 			})
 			defer discord.Close()
 		}
@@ -168,12 +167,11 @@ func main() {
 			}
 			fmt.Println(")")
 			backends = append(backends, notifierBackend{
-				notifier:      tg,
-				channels:      cfg.Telegram.Channels,
-				ownerID:       cfg.Telegram.OwnerChatID,
-				dmPaperTrades: cfg.Telegram.DMPaperTrades,
-				dmLiveTrades:  cfg.Telegram.DMLiveTrades,
-				plainText:     true,
+				notifier:   tg,
+				channels:   cfg.Telegram.Channels,
+				ownerID:    cfg.Telegram.OwnerChatID,
+				dmChannels: cfg.Telegram.DMChannels,
+				plainText:  true,
 			})
 			defer tg.Close()
 		}
@@ -1199,7 +1197,14 @@ func sendTradeAlerts(sc StrategyConfig, stratState *StrategyState, trades int, m
 	mu.RUnlock()
 
 	for _, b := range notifier.backends {
-		dmEnabled := b.ownerID != "" && ((isLive && b.dmLiveTrades) || (!isLive && b.dmPaperTrades))
+		dmKey := sc.Platform
+		if !isLive {
+			dmKey = sc.Platform + "-paper"
+		}
+		dmDest := ""
+		if b.dmChannels != nil {
+			dmDest = b.dmChannels[dmKey]
+		}
 
 		// Channel routing: presence of a channel ID means enabled, absence means disabled.
 		// Paper trades use "<platform>-paper" key with fallback to base platform key.
@@ -1215,7 +1220,7 @@ func sendTradeAlerts(sc StrategyConfig, stratState *StrategyState, trades int, m
 			}
 		}
 
-		if !dmEnabled && ch == "" && liveCh == "" {
+		if dmDest == "" && ch == "" && liveCh == "" {
 			continue
 		}
 
@@ -1226,8 +1231,8 @@ func sendTradeAlerts(sc StrategyConfig, stratState *StrategyState, trades int, m
 			} else {
 				msg = FormatTradeDM(sc, t, mode)
 			}
-			if dmEnabled {
-				if err := b.notifier.SendDM(b.ownerID, msg); err != nil {
+			if dmDest != "" {
+				if err := sendTradeDestination(b.notifier, dmDest, msg); err != nil {
 					fmt.Printf("[notify] DM trade alert failed: %v\n", err)
 				}
 			}

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -227,10 +227,10 @@ func TestSendTradeAlerts_DMAndChannel(t *testing.T) {
 	notifier := &MultiNotifier{
 		backends: []notifierBackend{
 			{
-				notifier:      mock,
-				ownerID:       "owner123",
-				channels:      map[string]string{"spot": "ch-spot-123"},
-				dmPaperTrades: true,
+				notifier:   mock,
+				ownerID:    "owner123",
+				channels:   map[string]string{"spot": "ch-spot-123"},
+				dmChannels: map[string]string{"binanceus-paper": "owner123"},
 			},
 		},
 	}
@@ -264,10 +264,10 @@ func TestSendTradeAlerts_DMOnly(t *testing.T) {
 	notifier := &MultiNotifier{
 		backends: []notifierBackend{
 			{
-				notifier:      mock,
-				ownerID:       "owner123",
-				channels:      map[string]string{}, // no channels configured
-				dmPaperTrades: true,
+				notifier:   mock,
+				ownerID:    "owner123",
+				channels:   map[string]string{}, // no channels configured
+				dmChannels: map[string]string{"binanceus-paper": "owner123"},
 			},
 		},
 	}
@@ -397,10 +397,10 @@ func TestSendTradeAlerts_LiveChannelRouting(t *testing.T) {
 	notifier := &MultiNotifier{
 		backends: []notifierBackend{
 			{
-				notifier:     mock,
-				ownerID:      "owner123",
-				channels:     map[string]string{"hyperliquid": "ch-hl", "hyperliquid-live": "ch-hl-live"},
-				dmLiveTrades: true,
+				notifier:   mock,
+				ownerID:    "owner123",
+				channels:   map[string]string{"hyperliquid": "ch-hl", "hyperliquid-live": "ch-hl-live"},
+				dmChannels: map[string]string{"hyperliquid": "owner123"},
 			},
 		},
 	}
@@ -556,6 +556,107 @@ func TestSendTradeAlerts_PaperFallbackToBase(t *testing.T) {
 	}
 	if len(mock.messages) > 0 && mock.messages[0].channelID != "ch-hl" {
 		t.Errorf("expected message to base channel ch-hl, got %s", mock.messages[0].channelID)
+	}
+}
+
+func TestSendTradeAlerts_DMChannelPaper(t *testing.T) {
+	mock := &mockNotifier{}
+	sc := StrategyConfig{
+		ID:       "hl-sma-btc",
+		Type:     "perps",
+		Platform: "hyperliquid",
+		Args:     []string{"sma", "BTC", "1h", "--mode=paper"},
+	}
+	state := &StrategyState{TradeHistory: []Trade{testTrade()}}
+	var mu sync.RWMutex
+	notifier := &MultiNotifier{
+		backends: []notifierBackend{
+			{
+				notifier:   mock,
+				dmChannels: map[string]string{"hyperliquid-paper": "user-paper-dm"},
+			},
+		},
+	}
+	sendTradeAlerts(sc, state, 1, &mu, notifier)
+	if len(mock.dms) != 1 || mock.dms[0].userID != "user-paper-dm" {
+		t.Errorf("expected 1 DM to user-paper-dm, got %#v", mock.dms)
+	}
+}
+
+func TestSendTradeAlerts_DMChannelLive(t *testing.T) {
+	mock := &mockNotifier{}
+	sc := StrategyConfig{
+		ID:       "hl-sma-btc",
+		Type:     "perps",
+		Platform: "hyperliquid",
+		Args:     []string{"sma", "BTC", "1h", "--mode=live"},
+	}
+	state := &StrategyState{TradeHistory: []Trade{testTrade()}}
+	var mu sync.RWMutex
+	notifier := &MultiNotifier{
+		backends: []notifierBackend{
+			{
+				notifier:   mock,
+				dmChannels: map[string]string{"hyperliquid": "user-live-dm"},
+			},
+		},
+	}
+	sendTradeAlerts(sc, state, 1, &mu, notifier)
+	if len(mock.dms) != 1 || mock.dms[0].userID != "user-live-dm" {
+		t.Errorf("expected 1 DM to user-live-dm, got %#v", mock.dms)
+	}
+}
+
+func TestSendTradeAlerts_DMMissingKey(t *testing.T) {
+	// Paper trade but only live key in dm_channels — no DM, no channel.
+	mock := &mockNotifier{}
+	sc := StrategyConfig{
+		ID:       "hl-sma-btc",
+		Type:     "perps",
+		Platform: "hyperliquid",
+		Args:     []string{"sma", "BTC", "1h", "--mode=paper"},
+	}
+	state := &StrategyState{TradeHistory: []Trade{testTrade()}}
+	var mu sync.RWMutex
+	notifier := &MultiNotifier{
+		backends: []notifierBackend{
+			{
+				notifier:   mock,
+				dmChannels: map[string]string{"hyperliquid": "only-live"},
+				channels:   map[string]string{},
+			},
+		},
+	}
+	sendTradeAlerts(sc, state, 1, &mu, notifier)
+	if len(mock.dms) != 0 || len(mock.messages) != 0 {
+		t.Errorf("expected no messages, dms=%d messages=%d", len(mock.dms), len(mock.messages))
+	}
+}
+
+func TestSendTradeAlerts_DMChannelFallback(t *testing.T) {
+	mock := &mockNotifier{failSendDM: true}
+	sc := StrategyConfig{
+		ID:       "hl-sma-btc",
+		Type:     "perps",
+		Platform: "hyperliquid",
+		Args:     []string{"sma", "BTC", "1h", "--mode=paper"},
+	}
+	state := &StrategyState{TradeHistory: []Trade{testTrade()}}
+	var mu sync.RWMutex
+	notifier := &MultiNotifier{
+		backends: []notifierBackend{
+			{
+				notifier:   mock,
+				dmChannels: map[string]string{"hyperliquid-paper": "private-log-channel"},
+			},
+		},
+	}
+	sendTradeAlerts(sc, state, 1, &mu, notifier)
+	if len(mock.dms) != 0 {
+		t.Errorf("expected SendDM to fail without recording DM, got %d dms", len(mock.dms))
+	}
+	if len(mock.messages) != 1 || mock.messages[0].channelID != "private-log-channel" {
+		t.Errorf("expected 1 channel message to private-log-channel, got %#v", mock.messages)
 	}
 }
 

--- a/scheduler/notifier.go
+++ b/scheduler/notifier.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -19,10 +20,9 @@ type notifierBackend struct {
 	notifier           Notifier
 	channels           map[string]string // channel map from config (keyed by platform/type; "<platform>-paper" for paper-specific)
 	ownerID            string
-	leaderboardChannel string // dedicated leaderboard channel ID (optional); when set, leaderboard posts route here
-	dmPaperTrades      bool   // send DM on paper trade execution
-	dmLiveTrades       bool   // send DM on live trade execution
-	plainText          bool   // use plain-text formatting (no markdown)
+	leaderboardChannel string            // dedicated leaderboard channel ID (optional); when set, leaderboard posts route here
+	dmChannels         map[string]string // per-platform DM-style trade alerts (#248)
+	plainText          bool              // use plain-text formatting (no markdown)
 }
 
 // MultiNotifier fans out calls to all configured notification providers.
@@ -265,4 +265,17 @@ func (m *MultiNotifier) AllChannelKeys() map[string]bool {
 		}
 	}
 	return keys
+}
+
+// sendTradeDestination delivers a trade alert to a user ID (DM) or channel ID.
+// Discord requires UserChannelCreate for DMs, so we try SendDM first and fall back to SendMessage.
+func sendTradeDestination(n Notifier, id, content string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil
+	}
+	if err := n.SendDM(id, content); err == nil {
+		return nil
+	}
+	return n.SendMessage(id, content)
 }

--- a/scheduler/notifier.go
+++ b/scheduler/notifier.go
@@ -269,6 +269,8 @@ func (m *MultiNotifier) AllChannelKeys() map[string]bool {
 
 // sendTradeDestination delivers a trade alert to a user ID (DM) or channel ID.
 // Discord requires UserChannelCreate for DMs, so we try SendDM first and fall back to SendMessage.
+// Logs the original SendDM error before falling back so transient DM failures on valid user IDs
+// are visible instead of being masked by a misleading "Unknown Channel" from the fallback.
 func sendTradeDestination(n Notifier, id, content string) error {
 	id = strings.TrimSpace(id)
 	if id == "" {
@@ -276,6 +278,8 @@ func sendTradeDestination(n Notifier, id, content string) error {
 	}
 	if err := n.SendDM(id, content); err == nil {
 		return nil
+	} else {
+		fmt.Printf("[notify] SendDM(%s) failed, falling back to SendMessage: %v\n", id, err)
 	}
 	return n.SendMessage(id, content)
 }

--- a/scheduler/notifier_test.go
+++ b/scheduler/notifier_test.go
@@ -9,12 +9,13 @@ import (
 
 // mockNotifier is a test double that records all calls.
 type mockNotifier struct {
-	mu       sync.Mutex
-	messages []mockMessage
-	dms      []mockDM
-	askResp  string
-	askErr   error
-	closed   bool
+	mu         sync.Mutex
+	messages   []mockMessage
+	dms        []mockDM
+	askResp    string
+	askErr     error
+	closed     bool
+	failSendDM bool // when true, SendDM errors (exercises SendMessage fallback in sendTradeDestination)
 }
 
 type mockMessage struct {
@@ -37,6 +38,9 @@ func (m *mockNotifier) SendMessage(channelID string, content string) error {
 func (m *mockNotifier) SendDM(userID, content string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.failSendDM {
+		return fmt.Errorf("mock SendDM failed")
+	}
 	m.dms = append(m.dms, mockDM{userID, content})
 	return nil
 }
@@ -52,6 +56,32 @@ func (m *mockNotifier) Close() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.closed = true
+}
+
+func TestSendTradeDestination_PrefersSendDM(t *testing.T) {
+	m := &mockNotifier{}
+	if err := sendTradeDestination(m, "user-1", "hello"); err != nil {
+		t.Fatal(err)
+	}
+	if len(m.dms) != 1 || m.dms[0].userID != "user-1" {
+		t.Fatalf("expected 1 DM, got %#v", m.dms)
+	}
+	if len(m.messages) != 0 {
+		t.Fatalf("expected no channel messages, got %#v", m.messages)
+	}
+}
+
+func TestSendTradeDestination_FallsBackToSendMessage(t *testing.T) {
+	m := &mockNotifier{failSendDM: true}
+	if err := sendTradeDestination(m, "channel-99", "hello"); err != nil {
+		t.Fatal(err)
+	}
+	if len(m.dms) != 0 {
+		t.Fatalf("expected no DMs when SendDM fails, got %#v", m.dms)
+	}
+	if len(m.messages) != 1 || m.messages[0].channelID != "channel-99" {
+		t.Fatalf("expected 1 channel message, got %#v", m.messages)
+	}
 }
 
 func TestMultiNotifier_NoBackends(t *testing.T) {


### PR DESCRIPTION
Closes #248

## Summary
- Replace `dm_paper_trades` / `dm_live_trades` booleans with `dm_channels` on Discord and Telegram (`<platform>` for live, `<platform>-paper` for paper).
- `sendTradeAlerts` resolves the destination per backend; `sendTradeDestination` tries `SendDM` then `SendMessage` for user vs channel IDs.
- Config version **7**: migration translates legacy booleans using unique strategy platforms and `owner_id` / `owner_chat_id`; removes deprecated keys; deprecation notice aligned with v6 pattern.
- Init wizard drops DM-trade boolean fields; example config documents `dm_channels`.
- Tests updated/added for routing, migration, and validation.

## Verification
- `cd scheduler && go test ./...`
- `go-trader init --json ...` and smoke with example config.