### PR TITLE
docs: sync project docs with recent architectural changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,11 @@
   - `risk.go` — per-strategy risk checks (drawdown limits, position sizing)
   - `telegram.go` — Telegram notification backend
   - `pricer.go` — `OptionPricer` interface; `ibkr_pricer.go` — IBKRPricer with Black-Scholes
+  - `db.go` — SQLite state persistence (`modernc.org/sqlite` pure-Go driver); `OpenStateDB(path)`, `SaveStateWithDB`, `LoadStateWithDB`; tables: `app_state`, `strategies`, `positions`, `option_positions`, `trades`, `portfolio_risk`, `kill_switch_events`, `correlation_snapshot`
+  - `hyperliquid_marks.go` — `fetchHyperliquidMids(coins)` native Go HL `/info allMids` fetcher; correct oracle for HL perps PnL (replaces BinanceUS spot basis spoofing, issue #263)
+  - `okx_marks.go` — `fetchOKXPerpsMids(coins)` native Go OKX `/api/v5/market/tickers?instType=SWAP` fetcher; USDT-margined swaps only (PR #280, issue #279); test stub via `okxMainnetURL` var
+  - `deribit.go` — native Go Deribit `/public/ticker` fetcher (mark/underlying price + greeks)
+  - `shared_wallet.go` — `SharedWalletKey{Platform, Account}` + `walletKeyFor(sc)`; prevents double-counting capital when multiple strategies trade from the same on-exchange wallet (currently HL live perps all share `HYPERLIQUID_ACCOUNT_ADDRESS`)
 - `shared_scripts/` — Python entry-point scripts called by the scheduler
   - `check_strategy.py` — spot strategy signal checker
   - `check_options.py` — unified options checker (`--platform=deribit|ibkr|robinhood|okx`)
@@ -40,6 +45,7 @@
   - `check_robinhood.py` — Robinhood crypto checker (`<strategy> <symbol> <timeframe> [--mode=paper|live]`; `--execute` for live orders; OHLCV via yfinance)
   - `check_okx.py` — OKX spot/perps checker (`<strategy> <symbol> <timeframe> [--mode=paper|live] [--inst-type=spot|swap]`; `--execute` for live orders; CCXT)
   - `check_balance.py` — balance/position checker for live account reconciliation
+  - `fetch_futures_marks.py` — CME futures mark-price fetcher; revalues open TopStep positions at live marks (issue #261); TopStep adapter auto-selects TopStepX live quotes vs yfinance paper
 - `platforms/` — platform-specific adapters (deribit, ibkr, binanceus, hyperliquid, topstep, robinhood, okx, luno)
   - `deribit/adapter.py` — DeribitExchangeAdapter (live quotes, real expiries/strikes)
   - `ibkr/adapter.py` — IBKRExchangeAdapter (CME strikes, Black-Scholes pricing)
@@ -79,7 +85,8 @@
 - Hyperliquid SDK funding rates: `info.meta_and_asset_ctxs()` returns current predicted funding rate per asset (NOT `info.meta()` which only returns universe metadata); `info.funding_history(coin, startTime)` for historical rates; response uses parallel arrays — universe[i] matches asset_ctxs[i]
 - Fee dispatch: `CalculatePlatformSpotFee(platform, value)` — 0.035% hyperliquid, 0% robinhood, 0.1% binanceus (replaces bare `CalculateSpotFee` for platform-aware spot/perps trades); `CalculateFuturesFee(contracts, feePerContract)` and `CalculatePlatformFuturesFee(sc, contracts)` for futures per-contract fees
 - Position ownership: `Position.OwnerStrategyID` tracks which strategy opened a position; `syncHyperliquidAccountPositions` syncs on-chain positions once per cycle (not per-strategy) and only reconciles positions with their owner; `syncHyperliquidLiveCapital` is a no-op — capital is set from config or `capital_pct`
-- State persisted to `scheduler/state.json` (path set in config); per-platform files at `platforms/<name>/state.json`
+- State persisted exclusively to SQLite at runtime: `scheduler/state.db` (`cfg.DBFile`, default `scheduler/state.db`) via `SaveStateWithDB`/`LoadStateWithDB`; `cfg.StateFile` (`scheduler/state.json`) is a one-time migration source — `loadJSONPlatformStates` only runs on first boot when SQLite is empty, then the JSON files are never read again; `init.go` still emits a default `state_file` into new configs (cosmetic) and `leaderboard.go` uses `filepath.Dir(cfg.StateFile)` as a directory anchor
+- Native Go mark fetchers: `fetchHyperliquidMids` (hyperliquid_marks.go), `fetchOKXPerpsMids` (okx_marks.go), and Deribit ticker fetcher (deribit.go) replace per-cycle Python subprocess calls — pattern: expose base URL as `var xxxMainnetURL` so httptest stubs can redirect in tests
 - `cfg.Discord.Channels` is `map[string]string` (not a struct); keys: "spot", "options", "hyperliquid", etc. — old `.Spot`/`.Options` field access is invalid
 - `cfg.Discord.OwnerID` — Discord user ID for DM upgrade prompts + config migration; loaded from `DISCORD_OWNER_ID` env var (takes priority over config file)
 - `cfg.ConfigVersion` — int, schema version (`0`/missing = v1 baseline); `CurrentConfigVersion = 7` in config_migration.go; startup triggers `runConfigMigrationDM` when below current version

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A Go + Python hybrid trading system. A single Go binary (~8MB RAM) orchestrates 
 
 **Discord alerts**: Per-platform channels for spot, options, hyperliquid, topstep, robinhood, and okx summaries, with immediate trade notifications. When a new release is detected, the bot DMs you directly — reply **yes** and it upgrades, rebuilds, and restarts itself automatically.
 
-Supported platforms: Binance US, Deribit, IBKR/CME, Hyperliquid, TopStep, Robinhood.
+Supported platforms: Binance US, Deribit, IBKR/CME, Hyperliquid, TopStep, Robinhood, OKX, Luno.
 
 ## Community
 
@@ -105,9 +105,9 @@ Go scheduler (always running, ~8MB idle)
     .venv/bin/python3 shared_scripts/check_price.py       → live prices
   ↓ processes signals, executes paper trades, manages risk
   ↓ marks options to market via Deribit REST API (live prices every cycle)
-  ↓ saves state → scheduler/state.json (atomic writes, survives restarts)
+  ↓ saves state → scheduler/state.db (SQLite, survives restarts)
   ↓ HTTP status → localhost:8099/status
-  ↓ Discord → per-platform channels (spot, options, hyperliquid, topstep, robinhood, okx)
+  ↓ Discord → per-platform channels (spot, options, hyperliquid, topstep, robinhood, okx, luno)
 
 Platform adapters (Python):
   platforms/binanceus/adapter.py   — spot (CCXT)
@@ -117,6 +117,7 @@ Platform adapters (Python):
   platforms/topstep/adapter.py     — futures (CME, paper via yfinance + live via TopStepX)
   platforms/robinhood/adapter.py   — crypto (paper via yfinance + live via robin_stocks)
   platforms/okx/adapter.py         — spot + perps + options (CCXT, paper + live)
+  platforms/luno/adapter.py        — spot (South African crypto exchange)
 ```
 
 Python gets the quant libraries (pandas, numpy, scipy, CCXT). Go gets memory efficiency. 50+ strategies cost ~220MB peak for ~30 seconds, then ~8MB idle.
@@ -200,6 +201,7 @@ US equity options on SPY, QQQ, AAPL, etc. using the same options strategies as D
 | Robinhood | Crypto | BTC, ETH, SOL, DOGE, etc. | Paper (yfinance) + live trading via robin_stocks |
 | Robinhood | Options | SPY, QQQ, AAPL, MSFT, etc. | Paper (Black-Scholes) + live chains via robin_stocks |
 | OKX | Spot + Perps + Options | BTC, ETH, SOL | CCXT, paper + live, MiCA/EU licensed |
+| Luno | Spot | BTC, ETH, etc. | South African crypto exchange |
 
 ---
 
@@ -211,9 +213,10 @@ Use `./go-trader init` (interactive) or `./go-trader init --json '...'` (scripte
 
 ```json
 {
-  "config_version": 2,
+  "config_version": 7,
   "interval_seconds": 3600,
   "state_file": "scheduler/state.json",
+  "db_file": "scheduler/state.db",
   "log_dir": "logs",
   "auto_update": "daily",
   "portfolio_risk": {
@@ -224,7 +227,7 @@ Use `./go-trader init` (interactive) or `./go-trader init --json '...'` (scripte
     "enabled": true,
     "token": "",
     "owner_id": "",
-    "channels": { "spot": "CHANNEL_ID", "options": "CHANNEL_ID", "hyperliquid": "CHANNEL_ID", "topstep": "CHANNEL_ID", "robinhood": "CHANNEL_ID", "okx": "CHANNEL_ID" }
+    "channels": { "spot": "CHANNEL_ID", "options": "CHANNEL_ID", "hyperliquid": "CHANNEL_ID", "topstep": "CHANNEL_ID", "robinhood": "CHANNEL_ID", "okx": "CHANNEL_ID", "luno": "CHANNEL_ID" }
   },
   "platforms": {
     "hyperliquid": {
@@ -421,16 +424,25 @@ go-trader/
 ├── scheduler/              # Go scheduler source + config
 │   ├── main.go             # Main loop, strategy orchestration
 │   ├── config.go           # Config parsing + validation
+│   ├── config_migration.go # Config version registry, MigrateConfig, DM-based migration
 │   ├── executor.go         # Python subprocess runner
-│   ├── state.go            # State persistence (atomic writes)
+│   ├── db.go               # SQLite state persistence (modernc.org/sqlite)
+│   ├── state.go            # In-memory state loading wrapper
 │   ├── portfolio.go        # Spot position tracking
 │   ├── options.go          # Options positions, Greeks, theta harvest
+│   ├── balance.go          # Balance tracking and capital management
+│   ├── hyperliquid_balance.go # Hyperliquid account position sync
+│   ├── hyperliquid_marks.go   # Native Go HL /info allMids fetcher
+│   ├── okx_marks.go        # Native Go OKX perps tickers fetcher
+│   ├── shared_wallet.go    # Shared-wallet key (prevents double-counting HL capital)
 │   ├── risk.go             # Drawdown, circuit breakers
 │   ├── deribit.go          # Deribit REST API for live pricing
 │   ├── discord.go          # Discord gateway (discordgo), SendMessage/SendDM/AskDM
+│   ├── notifier.go         # MultiNotifier (Discord + Telegram)
+│   ├── telegram.go         # Telegram backend
 │   ├── updater.go          # Update checker, DM upgrade flow, applyUpgrade/restartSelf
 │   ├── correlation.go      # Per-asset directional exposure tracking
-│   ├── config_migration.go # Config version registry, MigrateConfig, DM-based migration
+│   ├── leaderboard.go      # Pre-computed strategy leaderboard
 │   ├── server.go           # HTTP status endpoint
 │   ├── fees.go             # Trading fee calculations
 │   ├── pricer.go           # OptionPricer interface
@@ -442,24 +454,25 @@ go-trader/
 │   └── state.example.json  # State template
 ├── shared_scripts/         # Stateless Python entry-point scripts
 │   ├── check_strategy.py   # Spot checker (Binance US via CCXT)
-│   ├── check_options.py    # Options checker (--platform=deribit|ibkr)
+│   ├── check_options.py    # Options checker (--platform=deribit|ibkr|robinhood|okx)
 │   ├── check_hyperliquid.py # Hyperliquid perps checker
 │   ├── check_okx.py         # OKX spot/perps checker
 │   ├── check_topstep.py    # TopStep futures checker
 │   ├── check_robinhood.py  # Robinhood crypto checker
-│   └── check_price.py      # Multi-symbol price fetcher
+│   ├── check_balance.py    # Live account reconciliation
+│   ├── check_price.py      # Multi-symbol price fetcher
+│   └── fetch_futures_marks.py # CME futures mark-price fetcher (TopStep)
 ├── platforms/              # Platform-specific adapters
 │   ├── binanceus/          # BinanceUS spot adapter
 │   ├── deribit/            # Deribit options adapter
 │   ├── ibkr/               # IBKR/CME options adapter
 │   ├── hyperliquid/        # Hyperliquid perps adapter
 │   ├── topstep/            # TopStep futures adapter
-│   ├── robinhood/          # Robinhood crypto adapter
-│   └── okx/                # OKX spot/perps/options adapter (CCXT)
-├── shared_tools/           # Shared Python utilities (pricing, exchange_base, storage)
+│   ├── robinhood/          # Robinhood crypto + stock options adapter
+│   ├── okx/                # OKX spot/perps/options adapter (CCXT)
+│   └── luno/               # Luno spot adapter
+├── shared_tools/           # Shared Python utilities (pricing, exchange_base, storage, htf_filter)
 ├── shared_strategies/      # Shared strategy logic (spot/, options/, futures/)
-├── core/                   # Legacy data utilities (used by backtest)
-├── strategies/             # Legacy spot strategy logic (used by backtest)
 ├── backtest/               # Backtesting tools
 ├── archive/                # Retired/unused modules
 ├── SKILL.md                # AI agent setup guide

--- a/SKILL.md
+++ b/SKILL.md
@@ -28,18 +28,21 @@ If missing, install:
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-### 1c. Go runtime (1.23+)
+### 1c. Go runtime (1.26.0)
 ```bash
-go version 2>/dev/null || /usr/local/go/bin/go version 2>/dev/null || echo "NOT_INSTALLED"
+go version 2>/dev/null || /usr/local/go/bin/go version 2>/dev/null || /opt/homebrew/bin/go version 2>/dev/null || echo "NOT_INSTALLED"
 ```
 If missing, ask:
-> Go 1.23+ is required to build the scheduler. Want me to install it?
+> Go 1.26.0 is required to build the scheduler. Want me to install it?
 
 Install with:
 ```bash
-curl -sL https://go.dev/dl/go1.23.6.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+# Linux
+curl -sL https://go.dev/dl/go1.26.0.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+# macOS (Homebrew)
+brew install go@1.26
 ```
-Note: Go may not be in PATH. Use `/usr/local/go/bin/go` if `go` doesn't resolve.
+Note: Go may not be in PATH. Use `/usr/local/go/bin/go` (Linux) or `/opt/homebrew/bin/go` (macOS) if `go` doesn't resolve.
 
 ### 1d. Git
 ```bash
@@ -315,7 +318,7 @@ Ask for each group:
 ### If 3 (individual):
 Present each strategy and ask yes/no. Group them for readability:
 
-> **Spot Strategies** (5-minute checks):
+> **Spot Strategies** (1h checks):
 >
 > | # | Strategy | Assets | Description | Enable? |
 > |---|----------|--------|-------------|---------|
@@ -399,7 +402,7 @@ Start from `scheduler/config.example.json` as a template. For each enabled strat
 Discord config:
 - `discord.enabled`: true/false based on Step 4
 - `discord.token`: Always `""` (token comes from env var)
-- `discord.channels`: Map of channel IDs for enabled platform types, e.g. `{"spot": "ID_FROM_4b", "options": "ID_FROM_4c", "hyperliquid": "ID_FROM_4d", "topstep": "ID_FROM_4e", "okx": "ID_FROM_4f"}` — omit keys for platforms not in use
+- `discord.channels`: Map of channel IDs for enabled platform types, e.g. `{"spot": "ID_FROM_4b", "options": "ID_FROM_4c", "hyperliquid": "ID_FROM_4d", "topstep": "ID_FROM_4e", "okx": "ID_FROM_4f", "luno": "ID_FROM_4g"}` — omit keys for platforms not in use
 - Summary frequency is automatic: options post per-check, spot/hyperliquid/okx post hourly + on trades (no config field needed)
 
 ### 7b. OpenClaw Discord Allowlist (if applicable)
@@ -738,8 +741,8 @@ If Discord is enabled, wait for the first cycle to complete (~5 minutes) and ver
 > **Status:** `curl localhost:8099/status`
 > **Logs:** `journalctl -u go-trader -f`
 >
-> Spot strategies check every 5 minutes (summaries {freq}).
-> Options strategies check every 20 minutes (summaries per check).
+> Spot/perps strategies check every 1h (summaries hourly).
+> Options strategies check every 4h (summaries per check).
 > Trades post immediately to Discord.
 >
 > **Useful commands:**
@@ -973,13 +976,15 @@ When the user says `/menu`, "show menu", "what can I configure", "what's availab
      theta_harvest.*   — profit_target_pct, stop_loss_pct, min_dte_close
    Discord:
      enabled           — true/false
-     channels          — map: "spot", "options", "hyperliquid", "topstep", "robinhood", "okx"
-     summary_interval  — how often to post summaries
+     channels          — map: "spot", "options", "hyperliquid", "topstep", "robinhood", "okx", "luno"
    Environment (sudo systemctl edit go-trader):
-     DISCORD_BOT_TOKEN, STATUS_AUTH_TOKEN
+     DISCORD_BOT_TOKEN, DISCORD_OWNER_ID, STATUS_AUTH_TOKEN
      BINANCE_API_KEY, BINANCE_API_SECRET
+     HYPERLIQUID_SECRET_KEY, HYPERLIQUID_ACCOUNT_ADDRESS
      TOPSTEP_API_KEY, TOPSTEP_API_SECRET, TOPSTEP_ACCOUNT_ID
      ROBINHOOD_USERNAME, ROBINHOOD_PASSWORD, ROBINHOOD_TOTP_SECRET
+     OKX_API_KEY, OKX_API_SECRET, OKX_PASSPHRASE, OKX_SANDBOX
+     LUNO_API_KEY_ID, LUNO_API_KEY_SECRET
 
 4. COMMANDS
    /menu       — this overview
@@ -1022,7 +1027,8 @@ Config changes are synced to state on startup — no need to reset positions.
 | Setting | Key | Default | Description |
 |---------|-----|---------|-------------|
 | Check interval | `interval_seconds` | 300 (5 min) | Global default cycle interval in seconds |
-| State file path | `state_file` | `scheduler/state.json` | Where positions and trade history are stored |
+| State DB path | `db_file` | `scheduler/state.db` | SQLite DB — sole store for positions, trades, and risk state at runtime |
+| Legacy state file | `state_file` | `scheduler/state.json` | One-time migration source only: read on first boot when SQLite is empty, then ignored. Safe to omit from new configs. |
 | Auto-update | `auto_update` | `"off"` | Update check mode: `"off"`, `"daily"`, `"heartbeat"` |
 
 ### Correlation Tracking
@@ -1056,7 +1062,7 @@ Each entry in the `strategies` array supports:
 | Setting | Key | Default | Description |
 |---------|-----|---------|-------------|
 | Enable Discord | `discord.enabled` | true | Turn Discord notifications on/off |
-| Channels | `discord.channels` | — | Map of channel IDs keyed by platform/type: `"spot"`, `"options"`, `"hyperliquid"`, `"topstep"`, `"okx"`, etc. |
+| Channels | `discord.channels` | — | Map of channel IDs keyed by platform/type: `"spot"`, `"options"`, `"hyperliquid"`, `"topstep"`, `"robinhood"`, `"okx"`, `"luno"`, etc. |
 | Owner ID | `discord.owner_id` | — | Your Discord user ID — enables DM upgrade prompts and post-upgrade config migration. Use `DISCORD_OWNER_ID` env var (preferred). |
 
 ### Environment Variables
@@ -1070,12 +1076,20 @@ Set via systemd override (`sudo systemctl edit go-trader`):
 | `STATUS_AUTH_TOKEN` | Optional: require Bearer token for /status endpoint |
 | `BINANCE_API_KEY` | Binance API key (live trading only) |
 | `BINANCE_API_SECRET` | Binance API secret (live trading only) |
+| `HYPERLIQUID_SECRET_KEY` | Hyperliquid signing key (perps live trading only) |
+| `HYPERLIQUID_ACCOUNT_ADDRESS` | Hyperliquid account address (shared-wallet tracking) |
 | `TOPSTEP_API_KEY` | TopStep API key (futures live trading only) |
 | `TOPSTEP_API_SECRET` | TopStep API secret (futures live trading only) |
 | `TOPSTEP_ACCOUNT_ID` | TopStep account ID (futures live trading only) |
-| `ROBINHOOD_USERNAME` | Robinhood account email (crypto live trading only) |
-| `ROBINHOOD_PASSWORD` | Robinhood account password (crypto live trading only) |
+| `ROBINHOOD_USERNAME` | Robinhood account email (crypto/options live trading only) |
+| `ROBINHOOD_PASSWORD` | Robinhood account password (crypto/options live trading only) |
 | `ROBINHOOD_TOTP_SECRET` | TOTP secret for Robinhood MFA (base32 string from authenticator setup) |
+| `OKX_API_KEY` | OKX API key (live trading only) |
+| `OKX_API_SECRET` | OKX API secret (live trading only) |
+| `OKX_PASSPHRASE` | OKX API passphrase (live trading only) |
+| `OKX_SANDBOX` | Set to `1` to target OKX demo trading environment |
+| `LUNO_API_KEY_ID` | Luno API key ID (live trading only) |
+| `LUNO_API_KEY_SECRET` | Luno API secret (live trading only) |
 
 ### Example: Adjusting a Strategy
 


### PR DESCRIPTION
## Summary

- **SQLite state persistence**: Document `db.go` and `state.db` as the primary runtime store; clarify `state_file` is a one-time JSON migration source only
- **Missing Go files**: Add `hyperliquid_marks.go`, `okx_marks.go`, `deribit.go`, `shared_wallet.go` to CLAUDE.md and README file structure
- **Luno platform**: Add to supported platforms list, architecture diagram, platforms table, Discord channel examples, and env var tables in all three files
- **SKILL.md accuracy**: Fix Go version (1.23 → 1.26.0), fix interval claims (5-min/20-min → 1h/4h), add OKX/HL/Luno env vars, remove fictitious `summary_interval` config key
- **README cleanup**: Fix `config_version` example (2 → 7), add `db_file` field, remove deleted `core/` and `strategies/` legacy dirs from file structure
- **`fetch_futures_marks.py`**: Add to `shared_scripts/` list in both CLAUDE.md and README

---
Generated with: Claude Opus 4.7 | Effort: 35