### PR TITLE
chore: update Go toolchain to 1.26.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # go-trader Project Context
 
 ## Environment
-- Requires Go 1.26.0 — install via Homebrew: `brew install go@1.26`
+- Requires Go 1.26.2 — install via Homebrew (macOS): `brew install go@1.26` or Linux tarball: `curl -sL https://go.dev/dl/go1.26.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -`
 - Go is not in PATH via shell; use `/opt/homebrew/bin/go` directly (e.g. `cd scheduler && /opt/homebrew/bin/go build .`)
 - Python venv at `.venv/bin/python3` (used by executor.go at runtime)
 - In git worktrees, `.venv` is NOT copied — use the main repo's venv: `/Users/richardkuo/Work/openclaw/go-trader/.venv/bin/python3`

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ cd go-trader
 curl -LsSf https://astral.sh/uv/install.sh | sh   # install uv if needed
 uv sync                                             # creates .venv from lockfile
 
-# 3. Build (requires Go 1.26.0)
+# 3. Build (requires Go 1.26.2)
 cd scheduler && go build -o ../go-trader . && cd ..
 
 # 4. Generate config
@@ -486,7 +486,7 @@ go-trader/
 ## Dependencies
 
 - **Python 3.12+** — managed by [uv](https://github.com/astral-sh/uv) (ccxt, pandas, numpy, scipy, hyperliquid-python-sdk)
-- **Go 1.26.0** — [`github.com/bwmarrin/discordgo`](https://github.com/bwmarrin/discordgo) for WebSocket gateway (DM support)
+- **Go 1.26.2** — [`github.com/bwmarrin/discordgo`](https://github.com/bwmarrin/discordgo) for WebSocket gateway (DM support)
 - **systemd** — service management
 
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -28,17 +28,17 @@ If missing, install:
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-### 1c. Go runtime (1.26.0)
+### 1c. Go runtime (1.26.2)
 ```bash
 go version 2>/dev/null || /usr/local/go/bin/go version 2>/dev/null || /opt/homebrew/bin/go version 2>/dev/null || echo "NOT_INSTALLED"
 ```
 If missing, ask:
-> Go 1.26.0 is required to build the scheduler. Want me to install it?
+> Go 1.26.2 is required to build the scheduler. Want me to install it?
 
 Install with:
 ```bash
 # Linux
-curl -sL https://go.dev/dl/go1.26.0.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+curl -sL https://go.dev/dl/go1.26.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 # macOS (Homebrew)
 brew install go@1.26
 ```

--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -1,6 +1,6 @@
 module trading-scheduler
 
-go 1.26.0
+go 1.26.2
 
 require github.com/bwmarrin/discordgo v0.29.0
 


### PR DESCRIPTION
Update the `go` directive in `scheduler/go.mod` from `go 1.26.0` to `go 1.26.2` to track the latest patch release.

The CI workflow already uses `go-version: '1.26'` which picks up the latest 1.26.x automatically.

Closes #282

Generated with [Claude Code](https://claude.ai/code)