### PR TITLE
docs: note margin-based drawdown for perps strategies (#292)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,8 @@
 - `shared_tools/htf_filter.py` — `htf_trend_filter(symbol, timeframe, fetch_fn)` returns HTF trend via 50 EMA; `apply_htf_filter(signal, htf_trend)` filters counter-trend signals; `fetch_fn` is a callable `(symbol, tf, limit) → DataFrame` so it works across all platforms
 - `StrategyConfig.HTFFilter` — per-strategy bool (`htf_filter` in JSON); Go appends `--htf-filter` to script args; not applied to options strategies or `delta_neutral_funding` (funding-rate harvest is direction-agnostic); guard in both `generateConfig` and all Python check scripts
 - `delta_neutral_funding` is perps-only (not in spot registry); function lives in `spot/strategies.py` but without `@register_strategy`; registered only in `futures/strategies.py`
+- Perps vs futures at Position level: both set `Multiplier > 0`; only perps sets `Leverage > 0`. Use the two-field check (`Multiplier > 0 && Leverage > 0`) when iterating positions for leverage-aware metrics — see `perpsMarginDeployed` in `risk.go` (#292)
+- Per-strategy drawdown denominator: spot/options/futures use peak portfolio value; perps uses deployed margin (`Σ qty*price/leverage`) when positions are open, falling back to peak when no margin is deployed — see `CheckRisk` in `risk.go` (#292)
 
 ## Pull Requests
 - PR descriptions must reference the related GitHub issue if one exists, using `Closes #<number>` in the body (e.g. `Closes #46`)

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ To get your Discord user ID: right-click your username in Discord → **Copy Use
 | `script` | Python script path (relative) | Required |
 | `args` | Arguments passed to script | Required |
 | `capital` | Starting capital in USD | 1000 |
-| `max_drawdown_pct` | Circuit breaker threshold (from peak) | Spot: 5%, Options: 10%, Perps: 5% |
+| `max_drawdown_pct` | Circuit breaker threshold — peak-relative for spot/options/futures; margin-relative for perps (#292) | Spot: 5%, Options: 10%, Perps: 5% |
 | `interval_seconds` | Check interval (0 = use global) | 0 |
 | `htf_filter` | Enable higher-timeframe trend filter | false |
 | `params` | Custom strategy parameters (e.g. `{"multiplier": 2.0}`) | null |
@@ -383,7 +383,7 @@ journalctl -u go-trader -n 50           # recent logs
 - **Portfolio kill switch** — halt all trading if portfolio drawdown exceeds threshold (default: 25%)
 - **Notional cap** — optional hard limit on total notional exposure
 - **Correlation tracking** — per-asset directional exposure monitoring; warns when a single asset exceeds concentration threshold (default: 60%) or too many strategies share the same direction (default: 75%); opt-in via `correlation.enabled`
-- **Per-strategy circuit breakers** — pause trading when max drawdown exceeded (24h cooldown)
+- **Per-strategy circuit breakers** — pause trading when max drawdown exceeded (24h cooldown); spot/options/futures measure drawdown peak-relative, perps measure it relative to deployed margin so leveraged margin wipes fire the breaker in time (#292)
 - **Consecutive loss tracking** — 5 losses in a row → 1h pause
 - **Spot**: max 95% capital per position
 - **Options**: max 4 positions per strategy, portfolio-aware scoring

--- a/SKILL.md
+++ b/SKILL.md
@@ -263,7 +263,7 @@ Ask:
 
 #### 5c. Risk Tolerance — Max Drawdown
 Ask:
-> What's your maximum drawdown tolerance? When a strategy's losses exceed this percentage, a circuit breaker pauses trading for 24 hours.
+> What's your maximum drawdown tolerance? When a strategy's losses exceed this percentage, a circuit breaker pauses trading for 24 hours. Spot/options/futures measure drawdown from peak portfolio value; perps measure it relative to deployed margin (capital at risk) so leveraged positions fire the breaker before margin is wiped.
 >
 > - **Spot strategies** default: 60%
 > - **Options strategies** default: 40% (measured from peak value)


### PR DESCRIPTION
## Summary

Docs-only companion to #294 (the code change that switched perps strategies to a margin-based drawdown denominator).

- **CLAUDE.md** — two key-pattern lines: how to distinguish perps from futures at the Position level (`Multiplier > 0 && Leverage > 0`), and the new per-strategy drawdown denominator rule.
- **README.md** — clarified `max_drawdown_pct` table entry and the per-strategy circuit breaker bullet to note that perps use margin-relative drawdown.
- **SKILL.md** — init wizard drawdown prompt spells out the perps-specific denominator so operators pick a sensible value.

No code changes.

## Test plan

- [x] Diff is strictly docs (3 files, 5 insertions, 3 deletions) — verified via `git diff --stat`
- [x] Branch based on latest `origin/main` (not on top of the #294 code branch)

Related: #292, #294

---
Generated with: Claude Opus 4.7 | Effort: high