### PR TITLE
Add margin-aware drawdown to portfolio kill switch (#296)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -157,6 +157,18 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: --model ${{ steps.resolve_model.outputs.model_id }} --effort ${{ steps.resolve_model.outputs.effort }} --allowedTools "Bash(go *),Bash(cd scheduler && go *),Bash(uv run *),Bash(python3 *),Bash(.venv/bin/python3 *),Bash(gofmt *),Bash(cd scheduler && gofmt *),Bash(git *)"
 
+      - name: Revise CLAUDE.md with session learnings
+        if: steps.verify_invocation.outputs.invoked == 'true' && steps.claude.outcome == 'success'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: "Use the Skill tool to invoke the 'claude-md-management:revise-claude-md' skill. Review the changes made in this session (use git log and git diff to inspect them) and update CLAUDE.md with any new patterns, conventions, or important context learned."
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: |
+            code-review@claude-code-plugins
+            claude-md-management@claude-code-plugins
+          claude_args: --model ${{ steps.resolve_model.outputs.model_id }} --allowedTools "Bash(git *),Edit,Read,Grep,Glob,Write"
+
       - name: Append model/effort footer to Claude comment
         if: steps.verify_invocation.outputs.invoked == 'true'
         env:

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -139,6 +139,7 @@ CREATE TABLE IF NOT EXISTS portfolio_risk (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     peak_value REAL NOT NULL DEFAULT 0,
     current_drawdown_pct REAL NOT NULL DEFAULT 0,
+    current_margin_drawdown_pct REAL NOT NULL DEFAULT 0,
     kill_switch_active INTEGER NOT NULL DEFAULT 0,
     kill_switch_at TEXT NOT NULL DEFAULT '',
     warning_sent INTEGER NOT NULL DEFAULT 0
@@ -148,6 +149,7 @@ CREATE TABLE IF NOT EXISTS kill_switch_events (
     rowid INTEGER PRIMARY KEY AUTOINCREMENT,
     timestamp TEXT NOT NULL,
     type TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT '',
     drawdown_pct REAL NOT NULL DEFAULT 0,
     portfolio_value REAL NOT NULL DEFAULT 0,
     peak_value REAL NOT NULL DEFAULT 0,
@@ -209,6 +211,9 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE trades ADD COLUMN exchange_fee REAL NOT NULL DEFAULT 0",
 		// Position lifecycle tracking (#288).
 		"ALTER TABLE positions ADD COLUMN opened_at TEXT NOT NULL DEFAULT ''",
+		// Portfolio margin drawdown + kill-switch source tracking (#296 review).
+		"ALTER TABLE portfolio_risk ADD COLUMN current_margin_drawdown_pct REAL NOT NULL DEFAULT 0",
+		"ALTER TABLE kill_switch_events ADD COLUMN source TEXT NOT NULL DEFAULT ''",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -439,9 +444,9 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	if state.PortfolioRisk.WarningSent {
 		warnSent = 1
 	}
-	if _, err := tx.Exec(`INSERT OR REPLACE INTO portfolio_risk (id, peak_value, current_drawdown_pct, kill_switch_active, kill_switch_at, warning_sent)
-		VALUES (1, ?, ?, ?, ?, ?)`,
-		state.PortfolioRisk.PeakValue, state.PortfolioRisk.CurrentDrawdownPct,
+	if _, err := tx.Exec(`INSERT OR REPLACE INTO portfolio_risk (id, peak_value, current_drawdown_pct, current_margin_drawdown_pct, kill_switch_active, kill_switch_at, warning_sent)
+		VALUES (1, ?, ?, ?, ?, ?, ?)`,
+		state.PortfolioRisk.PeakValue, state.PortfolioRisk.CurrentDrawdownPct, state.PortfolioRisk.CurrentMarginDrawdownPct,
 		ksActive, formatTime(state.PortfolioRisk.KillSwitchAt), warnSent,
 	); err != nil {
 		return fmt.Errorf("upsert portfolio_risk: %w", err)
@@ -452,14 +457,14 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		return fmt.Errorf("delete kill_switch_events: %w", err)
 	}
 	if len(state.PortfolioRisk.Events) > 0 {
-		stmtEvt, err := tx.Prepare(`INSERT INTO kill_switch_events (timestamp, type, drawdown_pct, portfolio_value, peak_value, details)
-			VALUES (?, ?, ?, ?, ?, ?)`)
+		stmtEvt, err := tx.Prepare(`INSERT INTO kill_switch_events (timestamp, type, source, drawdown_pct, portfolio_value, peak_value, details)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`)
 		if err != nil {
 			return fmt.Errorf("prepare kill_switch_event insert: %w", err)
 		}
 		defer stmtEvt.Close()
 		for _, evt := range state.PortfolioRisk.Events {
-			if _, err := stmtEvt.Exec(formatTime(evt.Timestamp), evt.Type, evt.DrawdownPct, evt.PortfolioValue, evt.PeakValue, evt.Details); err != nil {
+			if _, err := stmtEvt.Exec(formatTime(evt.Timestamp), evt.Type, evt.Source, evt.DrawdownPct, evt.PortfolioValue, evt.PeakValue, evt.Details); err != nil {
 				return fmt.Errorf("insert kill_switch_event: %w", err)
 			}
 		}
@@ -789,8 +794,8 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	// 6. Load portfolio_risk.
 	var ksActiveInt, warnSentInt int
 	var ksAtStr string
-	err = sdb.db.QueryRow("SELECT peak_value, current_drawdown_pct, kill_switch_active, kill_switch_at, warning_sent FROM portfolio_risk WHERE id = 1").
-		Scan(&state.PortfolioRisk.PeakValue, &state.PortfolioRisk.CurrentDrawdownPct,
+	err = sdb.db.QueryRow("SELECT peak_value, current_drawdown_pct, current_margin_drawdown_pct, kill_switch_active, kill_switch_at, warning_sent FROM portfolio_risk WHERE id = 1").
+		Scan(&state.PortfolioRisk.PeakValue, &state.PortfolioRisk.CurrentDrawdownPct, &state.PortfolioRisk.CurrentMarginDrawdownPct,
 			&ksActiveInt, &ksAtStr, &warnSentInt)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, fmt.Errorf("load portfolio_risk: %w", err)
@@ -800,7 +805,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	state.PortfolioRisk.WarningSent = warnSentInt != 0
 
 	// 7. Load kill switch events.
-	evtRows, err := sdb.db.Query("SELECT timestamp, type, drawdown_pct, portfolio_value, peak_value, details FROM kill_switch_events ORDER BY rowid ASC")
+	evtRows, err := sdb.db.Query("SELECT timestamp, type, source, drawdown_pct, portfolio_value, peak_value, details FROM kill_switch_events ORDER BY rowid ASC")
 	if err != nil {
 		return nil, fmt.Errorf("load kill_switch_events: %w", err)
 	}
@@ -808,7 +813,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	for evtRows.Next() {
 		var evt KillSwitchEvent
 		var tsStr string
-		if err := evtRows.Scan(&tsStr, &evt.Type, &evt.DrawdownPct, &evt.PortfolioValue, &evt.PeakValue, &evt.Details); err != nil {
+		if err := evtRows.Scan(&tsStr, &evt.Type, &evt.Source, &evt.DrawdownPct, &evt.PortfolioValue, &evt.PeakValue, &evt.Details); err != nil {
 			return nil, fmt.Errorf("scan kill_switch_event: %w", err)
 		}
 		evt.Timestamp = parseTime(tsStr)

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -122,11 +122,11 @@ func makeTestState() *AppState {
 			},
 		},
 		PortfolioRisk: PortfolioRiskState{
-			PeakValue: 2050, CurrentDrawdownPct: 1.5,
+			PeakValue: 2050, CurrentDrawdownPct: 1.5, CurrentMarginDrawdownPct: 18.7,
 			KillSwitchActive: false,
 			WarningSent:      true,
 			Events: []KillSwitchEvent{
-				{Timestamp: now.Add(-3 * time.Hour), Type: "warning", DrawdownPct: 5, PortfolioValue: 1950, PeakValue: 2050, Details: "approaching threshold"},
+				{Timestamp: now.Add(-3 * time.Hour), Type: "warning", Source: "margin", DrawdownPct: 18.7, PortfolioValue: 1950, PeakValue: 2050, Details: "approaching threshold"},
 			},
 		},
 		CorrelationSnapshot: &CorrelationSnapshot{
@@ -236,6 +236,12 @@ func TestSaveAndLoadDBRoundTrip(t *testing.T) {
 	if loaded.PortfolioRisk.PeakValue != 2050 {
 		t.Errorf("PortfolioRisk.PeakValue = %f, want 2050", loaded.PortfolioRisk.PeakValue)
 	}
+	if loaded.PortfolioRisk.CurrentDrawdownPct != 1.5 {
+		t.Errorf("PortfolioRisk.CurrentDrawdownPct = %f, want 1.5", loaded.PortfolioRisk.CurrentDrawdownPct)
+	}
+	if loaded.PortfolioRisk.CurrentMarginDrawdownPct != 18.7 {
+		t.Errorf("PortfolioRisk.CurrentMarginDrawdownPct = %f, want 18.7", loaded.PortfolioRisk.CurrentMarginDrawdownPct)
+	}
 	if !loaded.PortfolioRisk.WarningSent {
 		t.Error("PortfolioRisk.WarningSent should be true")
 	}
@@ -244,6 +250,9 @@ func TestSaveAndLoadDBRoundTrip(t *testing.T) {
 	}
 	if loaded.PortfolioRisk.Events[0].Type != "warning" {
 		t.Errorf("event type = %q, want %q", loaded.PortfolioRisk.Events[0].Type, "warning")
+	}
+	if loaded.PortfolioRisk.Events[0].Source != "margin" {
+		t.Errorf("event source = %q, want %q", loaded.PortfolioRisk.Events[0].Source, "margin")
 	}
 
 	// Correlation snapshot round-trip.

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -475,7 +475,7 @@ func main() {
 			// equity total so the portfolio kill switch can fire on a
 			// leveraged margin blow-up that would otherwise hide inside
 			// equity-only drawdown for all-perps accounts.
-			perpsLoss, perpsMargin := AggregatePerpsMarginDrawdown(state.Strategies, prices)
+			perpsLoss, perpsMargin := AggregatePerpsMarginInputs(state.Strategies, prices)
 			mu.RUnlock()
 
 			mu.Lock()
@@ -513,7 +513,15 @@ func main() {
 			// Warning alert: drawdown approaching kill switch threshold.
 			if portfolioWarning && notifier.HasBackends() {
 				mu.Lock()
-				addKillSwitchEvent(&state.PortfolioRisk, "warning", state.PortfolioRisk.CurrentDrawdownPct, totalPV, state.PortfolioRisk.PeakValue, portfolioReason)
+				// Source mirrors CheckPortfolioRisk's tie-break: margin wins
+				// ties so the newer #296 signal is surfaced preferentially.
+				source := "equity"
+				warnDD := state.PortfolioRisk.CurrentDrawdownPct
+				if state.PortfolioRisk.CurrentMarginDrawdownPct >= warnDD {
+					source = "margin"
+					warnDD = state.PortfolioRisk.CurrentMarginDrawdownPct
+				}
+				addKillSwitchEvent(&state.PortfolioRisk, "warning", source, warnDD, totalPV, state.PortfolioRisk.PeakValue, portfolioReason)
 				mu.Unlock()
 				warnMsg := fmt.Sprintf("**PORTFOLIO WARNING**\n%s", portfolioReason)
 				notifier.SendToAllChannels(warnMsg)
@@ -557,7 +565,7 @@ func main() {
 					mu.Lock()
 					state.PortfolioRisk.KillSwitchActive = false
 					state.PortfolioRisk.KillSwitchAt = time.Time{}
-					addKillSwitchEvent(&state.PortfolioRisk, "reset", state.PortfolioRisk.CurrentDrawdownPct, 0, state.PortfolioRisk.PeakValue, "manual reset via DM")
+					addKillSwitchEvent(&state.PortfolioRisk, "reset", "", state.PortfolioRisk.CurrentDrawdownPct, 0, state.PortfolioRisk.PeakValue, "manual reset via DM")
 					if err := SaveStateWithDB(state, cfg, stateDB); err != nil {
 						fmt.Printf("[CRITICAL] Failed to save state after kill switch reset: %v\n", err)
 					}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -471,6 +471,11 @@ func main() {
 			mu.RLock()
 			totalPV, usedPVFallback := computeTotalPortfolioValue(cfg.Strategies, state, prices, walletBalances, sharedWallets)
 			totalNotional := PortfolioNotional(state.Strategies, prices)
+			// #296: aggregate perps margin drawdown inputs alongside the
+			// equity total so the portfolio kill switch can fire on a
+			// leveraged margin blow-up that would otherwise hide inside
+			// equity-only drawdown for all-perps accounts.
+			perpsLoss, perpsMargin := AggregatePerpsMarginDrawdown(state.Strategies, prices)
 			mu.RUnlock()
 
 			mu.Lock()
@@ -481,7 +486,7 @@ func main() {
 			// we snapshot before the call and restore if we're on a fallback
 			// cycle. Drawdown detection still runs against the frozen peak.
 			origPeak := state.PortfolioRisk.PeakValue
-			portfolioAllowed, nb, portfolioWarning, portfolioReason := CheckPortfolioRisk(&state.PortfolioRisk, cfg.PortfolioRisk, totalPV, totalNotional)
+			portfolioAllowed, nb, portfolioWarning, portfolioReason := CheckPortfolioRisk(&state.PortfolioRisk, cfg.PortfolioRisk, totalPV, totalNotional, perpsLoss, perpsMargin)
 			if usedPVFallback && state.PortfolioRisk.PeakValue > origPeak {
 				state.PortfolioRisk.PeakValue = origPeak
 			}

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -186,9 +186,17 @@ func mergeFuturesMarks(prices map[string]float64, marks map[string]float64) {
 const maxKillSwitchEvents = 50
 
 // KillSwitchEvent records a kill switch lifecycle event for audit purposes.
+//
+// Source identifies which drawdown signal drove a "triggered" or "warning"
+// event: "equity" (classic peak-relative equity drawdown) or "margin" (perps
+// unrealized loss vs. deployed margin, #296). Empty for events that predate
+// #296 or are signal-agnostic (e.g. "reset", "auto_reset"). DrawdownPct is the
+// percentage of the signal named by Source, so tailing the event log for a
+// post-incident review gives an arithmetically consistent record.
 type KillSwitchEvent struct {
 	Timestamp      time.Time `json:"timestamp"`
 	Type           string    `json:"type"` // "triggered", "reset", "warning"
+	Source         string    `json:"source,omitempty"`
 	DrawdownPct    float64   `json:"drawdown_pct"`
 	PortfolioValue float64   `json:"portfolio_value"`
 	PeakValue      float64   `json:"peak_value"`
@@ -196,13 +204,21 @@ type KillSwitchEvent struct {
 }
 
 // PortfolioRiskState tracks aggregate portfolio-level risk (#42).
+//
+// CurrentDrawdownPct is pure equity drawdown ((PeakValue - totalValue) /
+// PeakValue). CurrentMarginDrawdownPct is the #296 perps-margin drawdown
+// (perps unrealized loss / deployed margin). Keeping them as separate fields
+// preserves the arithmetic invariant that (PeakValue, CurrentDrawdownPct) is
+// reconstructable, while still exposing the margin signal for operators and
+// the kill switch. The kill switch fires on whichever signal breaches first.
 type PortfolioRiskState struct {
-	PeakValue          float64           `json:"peak_value"`
-	CurrentDrawdownPct float64           `json:"current_drawdown_pct"`
-	KillSwitchActive   bool              `json:"kill_switch_active"`
-	KillSwitchAt       time.Time         `json:"kill_switch_at,omitempty"`
-	WarningSent        bool              `json:"warning_sent,omitempty"`
-	Events             []KillSwitchEvent `json:"events,omitempty"`
+	PeakValue                float64           `json:"peak_value"`
+	CurrentDrawdownPct       float64           `json:"current_drawdown_pct"`
+	CurrentMarginDrawdownPct float64           `json:"current_margin_drawdown_pct,omitempty"`
+	KillSwitchActive         bool              `json:"kill_switch_active"`
+	KillSwitchAt             time.Time         `json:"kill_switch_at,omitempty"`
+	WarningSent              bool              `json:"warning_sent,omitempty"`
+	Events                   []KillSwitchEvent `json:"events,omitempty"`
 }
 
 // SharedWalletBalanceFetcher returns the real on-chain balance for a given
@@ -293,7 +309,7 @@ func ClearLatchedKillSwitchSharedWallet(state *AppState, strategies []StrategyCo
 	// (potentially double-counted) peak.
 	state.PortfolioRisk.PeakValue = totalBalance
 	state.PortfolioRisk.CurrentDrawdownPct = 0
-	addKillSwitchEvent(&state.PortfolioRisk, "auto_reset",
+	addKillSwitchEvent(&state.PortfolioRisk, "auto_reset", "",
 		0, totalBalance, totalBalance,
 		fmt.Sprintf("startup auto-clear: shared wallets %v reachable, total balance=$%.2f (peak re-baselined)",
 			sharedPlatforms, totalBalance))
@@ -301,10 +317,18 @@ func ClearLatchedKillSwitchSharedWallet(state *AppState, strategies []StrategyCo
 }
 
 // addKillSwitchEvent appends an event and trims to maxKillSwitchEvents.
-func addKillSwitchEvent(prs *PortfolioRiskState, eventType string, drawdownPct, portfolioValue, peakValue float64, details string) {
+//
+// source identifies which drawdown signal drove the event: "equity", "margin",
+// or "" (unknown / signal-agnostic). For "triggered" and "warning" events it
+// must be set; for "reset" / "auto_reset" it is typically empty. DrawdownPct
+// is interpreted as a pct of the signal named by source — do not pass
+// max(equity, margin) here; pass the value for the specific source, otherwise
+// the event log becomes arithmetically inconsistent.
+func addKillSwitchEvent(prs *PortfolioRiskState, eventType, source string, drawdownPct, portfolioValue, peakValue float64, details string) {
 	prs.Events = append(prs.Events, KillSwitchEvent{
 		Timestamp:      time.Now().UTC(),
 		Type:           eventType,
+		Source:         source,
 		DrawdownPct:    drawdownPct,
 		PortfolioValue: portfolioValue,
 		PeakValue:      peakValue,
@@ -315,10 +339,11 @@ func addKillSwitchEvent(prs *PortfolioRiskState, eventType string, drawdownPct, 
 	}
 }
 
-// AggregatePerpsMarginDrawdown sums unrealized loss and deployed margin across
-// every perps strategy in the portfolio. Mirrors perpsMarginDrawdownInputs from
-// the per-strategy path (#292) but aggregates to the portfolio level for the
-// kill switch (#296).
+// AggregatePerpsMarginInputs sums unrealized loss and deployed margin across
+// every perps strategy in the portfolio. It returns the numerator and
+// denominator inputs of the drawdown ratio (not a ratio itself) — matches the
+// per-strategy counterpart perpsMarginDrawdownInputs (#292), aggregated to the
+// portfolio level for the kill switch (#296).
 //
 // Only strategies with Type == "perps" contribute; the inner filter (Multiplier
 // > 0 && Leverage > 0) inside perpsMarginDrawdownInputs is the second guard
@@ -328,7 +353,7 @@ func addKillSwitchEvent(prs *PortfolioRiskState, eventType string, drawdownPct, 
 // margin as "no perps signal this cycle" and falls back to pure equity
 // drawdown. This preserves existing behavior for all-spot / all-options
 // portfolios.
-func AggregatePerpsMarginDrawdown(strategies map[string]*StrategyState, prices map[string]float64) (unrealizedLoss, margin float64) {
+func AggregatePerpsMarginInputs(strategies map[string]*StrategyState, prices map[string]float64) (unrealizedLoss, margin float64) {
 	for _, s := range strategies {
 		if s.Type != "perps" {
 			continue
@@ -349,21 +374,23 @@ func AggregatePerpsMarginDrawdown(strategies map[string]*StrategyState, prices m
 // Two independent drawdown signals feed the kill switch:
 //
 //  1. Equity drawdown — (peak - totalValue) / peak. Captures spot/options
-//     PnL and overall cash erosion.
+//     PnL and overall cash erosion. Persisted as CurrentDrawdownPct.
 //  2. Perps margin drawdown (#296) — perpsUnrealizedLoss / perpsMargin.
 //     Captures leveraged-position losses against deployed margin, which a
 //     pure equity view understates dramatically for all-perps accounts: a
 //     50% loss on 10x margin shows up as ~5% of total account value, so the
 //     equity-only kill switch fires far too late (or not at all before
-//     liquidation).
+//     liquidation). Persisted as CurrentMarginDrawdownPct.
 //
+// The two signals live on separate fields so (PeakValue, CurrentDrawdownPct)
+// remains an arithmetically consistent equity tuple for post-incident review.
 // The kill switch fires on whichever signal breaches cfg.MaxDrawdownPct
 // first, so a mixed portfolio is guarded on both fronts. For all-perps
 // accounts, the margin signal dominates; for all-spot/options, the margin
 // inputs are zero and behavior is identical to the pre-#296 baseline.
 //
-// CurrentDrawdownPct is set to the max of the two signals so operators can
-// see the worse number at a glance in status output.
+// The emitted KillSwitchEvent.Source records whether equity or margin drove
+// the fire/warning so operators can tell at a glance which lever tripped.
 func CheckPortfolioRisk(prs *PortfolioRiskState, cfg *PortfolioRiskConfig, totalValue, totalNotional, perpsUnrealizedLoss, perpsMargin float64) (allowed, notionalBlocked, warning bool, reason string) {
 	if prs.KillSwitchActive {
 		return false, false, false, fmt.Sprintf("portfolio kill switch is latched (triggered at %s, manual reset required)",
@@ -375,60 +402,73 @@ func CheckPortfolioRisk(prs *PortfolioRiskState, cfg *PortfolioRiskConfig, total
 		prs.PeakValue = totalValue
 	}
 
-	// Compute both drawdown signals independently.
+	// Compute both drawdown signals independently. Each is persisted to its
+	// own field so (PeakValue, CurrentDrawdownPct) stays internally consistent
+	// and operators can see both lenses at once.
 	var equityDD, marginDD float64
 	if prs.PeakValue > 0 {
 		equityDD = (prs.PeakValue - totalValue) / prs.PeakValue * 100
 		if equityDD < 0 {
 			equityDD = 0
 		}
+		prs.CurrentDrawdownPct = equityDD
 	}
 	if perpsMargin > 0 && perpsUnrealizedLoss > 0 {
 		marginDD = perpsUnrealizedLoss / perpsMargin * 100
 	}
+	prs.CurrentMarginDrawdownPct = marginDD
 
-	// CurrentDrawdownPct reflects the worse of the two signals for operator
-	// visibility. When perps margin is not deployed this reduces to the
-	// classic equity drawdown — existing tests and telemetry are unaffected.
-	currentDD := equityDD
-	if marginDD > currentDD {
-		currentDD = marginDD
-	}
-	// Only overwrite CurrentDrawdownPct when we have a peak (preserves prior
-	// behavior of leaving it zero before the first valuation).
-	if prs.PeakValue > 0 {
-		prs.CurrentDrawdownPct = currentDD
-	}
-
-	// Kill switch: fire if either signal breaches the limit. The reason
-	// names the breaching signal so operators know whether to investigate
-	// spot/options equity or perps margin.
+	// Kill switch: fire if either signal breaches the limit. The reason names
+	// the breaching signal so operators know whether to investigate spot /
+	// options equity or perps margin.
+	//
+	// Note: this branch runs even when PeakValue == 0, so a cold-start
+	// account that blows up margin on bar 1 (before any equity snapshot) is
+	// still protected — equityDD is zero in that case and only the margin
+	// signal can fire.
 	if equityDD > cfg.MaxDrawdownPct || marginDD > cfg.MaxDrawdownPct {
 		prs.KillSwitchActive = true
 		prs.KillSwitchAt = time.Now().UTC()
-		var r string
+		var r, source string
+		var dd float64
+		// Tie-break to margin when the two signals are equal: the margin
+		// signal is the newer, more sensitive lens (#296) and surfacing it
+		// preferentially helps operators notice leveraged blow-ups.
 		if marginDD >= equityDD {
+			source = "margin"
+			dd = marginDD
 			r = fmt.Sprintf("portfolio perps margin drawdown %.1f%% exceeds limit %.1f%% (unrealized loss=$%.2f, margin=$%.2f, value=$%.2f, peak=$%.2f)",
 				marginDD, cfg.MaxDrawdownPct, perpsUnrealizedLoss, perpsMargin, totalValue, prs.PeakValue)
 		} else {
+			source = "equity"
+			dd = equityDD
 			r = fmt.Sprintf("portfolio drawdown %.1f%% exceeds limit %.1f%% (value=$%.2f, peak=$%.2f)",
 				equityDD, cfg.MaxDrawdownPct, totalValue, prs.PeakValue)
 		}
-		addKillSwitchEvent(prs, "triggered", currentDD, totalValue, prs.PeakValue, r)
+		addKillSwitchEvent(prs, "triggered", source, dd, totalValue, prs.PeakValue, r)
 		return false, false, false, r
 	}
 
 	// Warning check: approaching kill switch threshold on either signal.
 	if cfg.MaxDrawdownPct > 0 {
 		warnDrawdownPct := cfg.MaxDrawdownPct * cfg.WarnThresholdPct / 100
-		if currentDD > warnDrawdownPct {
+		equityWarn := equityDD > warnDrawdownPct
+		marginWarn := marginDD > warnDrawdownPct
+		if equityWarn || marginWarn {
 			if !prs.WarningSent {
 				prs.WarningSent = true
 				warning = true
-				if marginDD >= equityDD {
+				switch {
+				case equityWarn && marginWarn:
+					// Both breached — surface both in the reason so a
+					// correlated move is visible to the operator. Ties go
+					// to margin (see kill-switch branch above).
+					reason = fmt.Sprintf("portfolio drawdown approaching kill switch limit %.1f%% (warn at %.1f%%): equity=%.1f%% (value=$%.2f, peak=$%.2f); perps margin=%.1f%% (unrealized loss=$%.2f, margin=$%.2f)",
+						cfg.MaxDrawdownPct, warnDrawdownPct, equityDD, totalValue, prs.PeakValue, marginDD, perpsUnrealizedLoss, perpsMargin)
+				case marginWarn:
 					reason = fmt.Sprintf("portfolio perps margin drawdown %.1f%% approaching kill switch limit %.1f%% (warn at %.1f%%, unrealized loss=$%.2f, margin=$%.2f)",
 						marginDD, cfg.MaxDrawdownPct, warnDrawdownPct, perpsUnrealizedLoss, perpsMargin)
-				} else {
+				default:
 					reason = fmt.Sprintf("portfolio drawdown %.1f%% approaching kill switch limit %.1f%% (warn at %.1f%%, value=$%.2f, peak=$%.2f)",
 						equityDD, cfg.MaxDrawdownPct, warnDrawdownPct, totalValue, prs.PeakValue)
 				}

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -315,12 +315,56 @@ func addKillSwitchEvent(prs *PortfolioRiskState, eventType string, drawdownPct, 
 	}
 }
 
+// AggregatePerpsMarginDrawdown sums unrealized loss and deployed margin across
+// every perps strategy in the portfolio. Mirrors perpsMarginDrawdownInputs from
+// the per-strategy path (#292) but aggregates to the portfolio level for the
+// kill switch (#296).
+//
+// Only strategies with Type == "perps" contribute; the inner filter (Multiplier
+// > 0 && Leverage > 0) inside perpsMarginDrawdownInputs is the second guard
+// against any hypothetical non-perps leveraged position leaking through.
+//
+// Returns (0, 0) when no perps margin is deployed — the caller treats a zero
+// margin as "no perps signal this cycle" and falls back to pure equity
+// drawdown. This preserves existing behavior for all-spot / all-options
+// portfolios.
+func AggregatePerpsMarginDrawdown(strategies map[string]*StrategyState, prices map[string]float64) (unrealizedLoss, margin float64) {
+	for _, s := range strategies {
+		if s.Type != "perps" {
+			continue
+		}
+		loss, m := perpsMarginDrawdownInputs(s, prices)
+		unrealizedLoss += loss
+		margin += m
+	}
+	return unrealizedLoss, margin
+}
+
 // CheckPortfolioRisk evaluates aggregate portfolio risk.
 // Returns (allowed, notionalBlocked, warning, reason).
 // allowed=false means the kill switch has fired or is latched; notionalBlocked=true
 // means new trades should be skipped but existing positions kept; warning=true
 // means drawdown is approaching the kill switch threshold.
-func CheckPortfolioRisk(prs *PortfolioRiskState, cfg *PortfolioRiskConfig, totalValue, totalNotional float64) (allowed, notionalBlocked, warning bool, reason string) {
+//
+// Two independent drawdown signals feed the kill switch:
+//
+//  1. Equity drawdown — (peak - totalValue) / peak. Captures spot/options
+//     PnL and overall cash erosion.
+//  2. Perps margin drawdown (#296) — perpsUnrealizedLoss / perpsMargin.
+//     Captures leveraged-position losses against deployed margin, which a
+//     pure equity view understates dramatically for all-perps accounts: a
+//     50% loss on 10x margin shows up as ~5% of total account value, so the
+//     equity-only kill switch fires far too late (or not at all before
+//     liquidation).
+//
+// The kill switch fires on whichever signal breaches cfg.MaxDrawdownPct
+// first, so a mixed portfolio is guarded on both fronts. For all-perps
+// accounts, the margin signal dominates; for all-spot/options, the margin
+// inputs are zero and behavior is identical to the pre-#296 baseline.
+//
+// CurrentDrawdownPct is set to the max of the two signals so operators can
+// see the worse number at a glance in status output.
+func CheckPortfolioRisk(prs *PortfolioRiskState, cfg *PortfolioRiskConfig, totalValue, totalNotional, perpsUnrealizedLoss, perpsMargin float64) (allowed, notionalBlocked, warning bool, reason string) {
 	if prs.KillSwitchActive {
 		return false, false, false, fmt.Sprintf("portfolio kill switch is latched (triggered at %s, manual reset required)",
 			prs.KillSwitchAt.Format("2006-01-02 15:04:05 UTC"))
@@ -331,28 +375,63 @@ func CheckPortfolioRisk(prs *PortfolioRiskState, cfg *PortfolioRiskConfig, total
 		prs.PeakValue = totalValue
 	}
 
-	// Check drawdown kill switch.
+	// Compute both drawdown signals independently.
+	var equityDD, marginDD float64
 	if prs.PeakValue > 0 {
-		prs.CurrentDrawdownPct = (prs.PeakValue - totalValue) / prs.PeakValue * 100
-
-		// Kill switch fires if drawdown exceeds limit.
-		if prs.CurrentDrawdownPct > cfg.MaxDrawdownPct {
-			prs.KillSwitchActive = true
-			prs.KillSwitchAt = time.Now().UTC()
-			r := fmt.Sprintf("portfolio drawdown %.1f%% exceeds limit %.1f%% (value=$%.2f, peak=$%.2f)",
-				prs.CurrentDrawdownPct, cfg.MaxDrawdownPct, totalValue, prs.PeakValue)
-			addKillSwitchEvent(prs, "triggered", prs.CurrentDrawdownPct, totalValue, prs.PeakValue, r)
-			return false, false, false, r
+		equityDD = (prs.PeakValue - totalValue) / prs.PeakValue * 100
+		if equityDD < 0 {
+			equityDD = 0
 		}
+	}
+	if perpsMargin > 0 && perpsUnrealizedLoss > 0 {
+		marginDD = perpsUnrealizedLoss / perpsMargin * 100
+	}
 
-		// Warning check: approaching kill switch threshold.
+	// CurrentDrawdownPct reflects the worse of the two signals for operator
+	// visibility. When perps margin is not deployed this reduces to the
+	// classic equity drawdown — existing tests and telemetry are unaffected.
+	currentDD := equityDD
+	if marginDD > currentDD {
+		currentDD = marginDD
+	}
+	// Only overwrite CurrentDrawdownPct when we have a peak (preserves prior
+	// behavior of leaving it zero before the first valuation).
+	if prs.PeakValue > 0 {
+		prs.CurrentDrawdownPct = currentDD
+	}
+
+	// Kill switch: fire if either signal breaches the limit. The reason
+	// names the breaching signal so operators know whether to investigate
+	// spot/options equity or perps margin.
+	if equityDD > cfg.MaxDrawdownPct || marginDD > cfg.MaxDrawdownPct {
+		prs.KillSwitchActive = true
+		prs.KillSwitchAt = time.Now().UTC()
+		var r string
+		if marginDD >= equityDD {
+			r = fmt.Sprintf("portfolio perps margin drawdown %.1f%% exceeds limit %.1f%% (unrealized loss=$%.2f, margin=$%.2f, value=$%.2f, peak=$%.2f)",
+				marginDD, cfg.MaxDrawdownPct, perpsUnrealizedLoss, perpsMargin, totalValue, prs.PeakValue)
+		} else {
+			r = fmt.Sprintf("portfolio drawdown %.1f%% exceeds limit %.1f%% (value=$%.2f, peak=$%.2f)",
+				equityDD, cfg.MaxDrawdownPct, totalValue, prs.PeakValue)
+		}
+		addKillSwitchEvent(prs, "triggered", currentDD, totalValue, prs.PeakValue, r)
+		return false, false, false, r
+	}
+
+	// Warning check: approaching kill switch threshold on either signal.
+	if cfg.MaxDrawdownPct > 0 {
 		warnDrawdownPct := cfg.MaxDrawdownPct * cfg.WarnThresholdPct / 100
-		if prs.CurrentDrawdownPct > warnDrawdownPct {
+		if currentDD > warnDrawdownPct {
 			if !prs.WarningSent {
 				prs.WarningSent = true
 				warning = true
-				reason = fmt.Sprintf("portfolio drawdown %.1f%% approaching kill switch limit %.1f%% (warn at %.1f%%, value=$%.2f, peak=$%.2f)",
-					prs.CurrentDrawdownPct, cfg.MaxDrawdownPct, warnDrawdownPct, totalValue, prs.PeakValue)
+				if marginDD >= equityDD {
+					reason = fmt.Sprintf("portfolio perps margin drawdown %.1f%% approaching kill switch limit %.1f%% (warn at %.1f%%, unrealized loss=$%.2f, margin=$%.2f)",
+						marginDD, cfg.MaxDrawdownPct, warnDrawdownPct, perpsUnrealizedLoss, perpsMargin)
+				} else {
+					reason = fmt.Sprintf("portfolio drawdown %.1f%% approaching kill switch limit %.1f%% (warn at %.1f%%, value=$%.2f, peak=$%.2f)",
+						equityDD, cfg.MaxDrawdownPct, warnDrawdownPct, totalValue, prs.PeakValue)
+				}
 			}
 		} else {
 			// Recovered below warning threshold — reset so it can fire again.

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -208,7 +209,7 @@ func TestCheckPortfolioRisk_DrawdownKillSwitch(t *testing.T) {
 	prs := &PortfolioRiskState{PeakValue: 10000.0}
 
 	// Just under threshold — should be allowed.
-	allowed, nb, _, reason := CheckPortfolioRisk(prs, cfg, 7600.0, 0)
+	allowed, nb, _, reason := CheckPortfolioRisk(prs, cfg, 7600.0, 0, 0, 0)
 	if !allowed {
 		t.Errorf("expected allowed below threshold; got reason=%s", reason)
 	}
@@ -222,7 +223,7 @@ func TestCheckPortfolioRisk_DrawdownKillSwitch(t *testing.T) {
 	}
 
 	// Drawdown = (10000-7400)/10000 = 26% > 25% — kill switch fires.
-	allowed, nb, _, reason = CheckPortfolioRisk(prs, cfg, 7400.0, 0)
+	allowed, nb, _, reason = CheckPortfolioRisk(prs, cfg, 7400.0, 0, 0, 0)
 	if allowed {
 		t.Error("expected kill switch to fire at 26% drawdown")
 	}
@@ -240,7 +241,7 @@ func TestCheckPortfolioRisk_DrawdownKillSwitch(t *testing.T) {
 	}
 
 	// Subsequent call — still latched even with recovered value.
-	allowed, _, _, _ = CheckPortfolioRisk(prs, cfg, 10000.0, 0)
+	allowed, _, _, _ = CheckPortfolioRisk(prs, cfg, 10000.0, 0, 0, 0)
 	if allowed {
 		t.Error("expected kill switch to remain latched on subsequent call")
 	}
@@ -253,7 +254,7 @@ func TestCheckPortfolioRisk_NotionalCap(t *testing.T) {
 	prs := &PortfolioRiskState{PeakValue: 10000.0}
 
 	// Under cap — allowed, not notional-blocked.
-	allowed, nb, _, _ := CheckPortfolioRisk(prs, cfg, 10000.0, 30000.0)
+	allowed, nb, _, _ := CheckPortfolioRisk(prs, cfg, 10000.0, 30000.0, 0, 0)
 	if !allowed {
 		t.Error("expected allowed under notional cap")
 	}
@@ -262,7 +263,7 @@ func TestCheckPortfolioRisk_NotionalCap(t *testing.T) {
 	}
 
 	// Over cap — allowed=true, notionalBlocked=true, kill switch NOT active.
-	allowed, nb, _, reason := CheckPortfolioRisk(prs, cfg, 10000.0, 60000.0)
+	allowed, nb, _, reason := CheckPortfolioRisk(prs, cfg, 10000.0, 60000.0, 0, 0)
 	if !allowed {
 		t.Error("expected allowed=true (notional cap doesn't kill switch)")
 	}
@@ -281,25 +282,25 @@ func TestCheckPortfolioRisk_PeakTracking(t *testing.T) {
 	prs := &PortfolioRiskState{PeakValue: 5000.0}
 
 	// Value rises — peak should update.
-	CheckPortfolioRisk(prs, cfg, 8000.0, 0)
+	CheckPortfolioRisk(prs, cfg, 8000.0, 0, 0, 0)
 	if prs.PeakValue != 8000.0 {
 		t.Errorf("expected peak=8000 after rise; got %.2f", prs.PeakValue)
 	}
 
 	// Value drops — peak should NOT update.
-	CheckPortfolioRisk(prs, cfg, 6000.0, 0)
+	CheckPortfolioRisk(prs, cfg, 6000.0, 0, 0, 0)
 	if prs.PeakValue != 8000.0 {
 		t.Errorf("expected peak=8000 unchanged after drop; got %.2f", prs.PeakValue)
 	}
 
 	// Value rises again — peak updates.
-	CheckPortfolioRisk(prs, cfg, 9000.0, 0)
+	CheckPortfolioRisk(prs, cfg, 9000.0, 0, 0, 0)
 	if prs.PeakValue != 9000.0 {
 		t.Errorf("expected peak=9000 after new high; got %.2f", prs.PeakValue)
 	}
 
 	// Drawdown tracked correctly: (9000-6000)/9000 ≈ 33.3%.
-	CheckPortfolioRisk(prs, cfg, 6000.0, 0)
+	CheckPortfolioRisk(prs, cfg, 6000.0, 0, 0, 0)
 	expectedDD := (9000.0 - 6000.0) / 9000.0 * 100
 	if prs.CurrentDrawdownPct < expectedDD-0.01 || prs.CurrentDrawdownPct > expectedDD+0.01 {
 		t.Errorf("expected drawdown≈%.2f%%; got %.2f%%", expectedDD, prs.CurrentDrawdownPct)
@@ -777,7 +778,7 @@ func TestCheckPortfolioRisk_WarningFires(t *testing.T) {
 	prs := &PortfolioRiskState{PeakValue: 10000.0}
 
 	// Warn threshold = 25 * 80/100 = 20%. Drawdown = (10000-7900)/10000 = 21% > 20%.
-	_, _, warning, reason := CheckPortfolioRisk(prs, cfg, 7900.0, 0)
+	_, _, warning, reason := CheckPortfolioRisk(prs, cfg, 7900.0, 0, 0, 0)
 	if !warning {
 		t.Error("expected warning=true at 21% drawdown (warn threshold=20%)")
 	}
@@ -789,7 +790,7 @@ func TestCheckPortfolioRisk_WarningFires(t *testing.T) {
 	}
 
 	// Second call at same drawdown — warning should NOT fire again.
-	_, _, warning, _ = CheckPortfolioRisk(prs, cfg, 7900.0, 0)
+	_, _, warning, _ = CheckPortfolioRisk(prs, cfg, 7900.0, 0, 0, 0)
 	if warning {
 		t.Error("expected warning=false on second call (already sent)")
 	}
@@ -802,19 +803,19 @@ func TestCheckPortfolioRisk_WarningResetOnRecovery(t *testing.T) {
 	prs := &PortfolioRiskState{PeakValue: 10000.0}
 
 	// Trigger warning at 21% drawdown.
-	CheckPortfolioRisk(prs, cfg, 7900.0, 0)
+	CheckPortfolioRisk(prs, cfg, 7900.0, 0, 0, 0)
 	if !prs.WarningSent {
 		t.Fatal("expected WarningSent=true after first warning")
 	}
 
 	// Recover to 15% drawdown (below 20% warn threshold).
-	CheckPortfolioRisk(prs, cfg, 8500.0, 0)
+	CheckPortfolioRisk(prs, cfg, 8500.0, 0, 0, 0)
 	if prs.WarningSent {
 		t.Error("expected WarningSent=false after recovery below warn threshold")
 	}
 
 	// Cross warning threshold again — should warn again.
-	_, _, warning, _ := CheckPortfolioRisk(prs, cfg, 7900.0, 0)
+	_, _, warning, _ := CheckPortfolioRisk(prs, cfg, 7900.0, 0, 0, 0)
 	if !warning {
 		t.Error("expected warning=true after recovery and re-crossing threshold")
 	}
@@ -827,7 +828,7 @@ func TestCheckPortfolioRisk_WarningNotAfterKillSwitch(t *testing.T) {
 	prs := &PortfolioRiskState{PeakValue: 10000.0}
 
 	// 26% drawdown > 25% kill switch threshold.
-	allowed, _, warning, _ := CheckPortfolioRisk(prs, cfg, 7400.0, 0)
+	allowed, _, warning, _ := CheckPortfolioRisk(prs, cfg, 7400.0, 0, 0, 0)
 	if allowed {
 		t.Error("expected kill switch to fire")
 	}
@@ -859,7 +860,7 @@ func TestCheckPortfolioRisk_EventLoggedOnTrigger(t *testing.T) {
 	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
 	prs := &PortfolioRiskState{PeakValue: 10000.0}
 
-	CheckPortfolioRisk(prs, cfg, 7400.0, 0)
+	CheckPortfolioRisk(prs, cfg, 7400.0, 0, 0, 0)
 
 	if len(prs.Events) != 1 {
 		t.Fatalf("expected 1 event; got %d", len(prs.Events))
@@ -981,7 +982,7 @@ func TestClearLatchedKillSwitchSharedWallet_NoRelatchOnNextTick(t *testing.T) {
 	// stays cleared. With the old buggy behavior (peak still $20K), drawdown
 	// would be 75% and the kill switch would re-latch immediately.
 	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
-	allowed, _, _, reason := CheckPortfolioRisk(&state.PortfolioRisk, cfg, 5000, 0)
+	allowed, _, _, reason := CheckPortfolioRisk(&state.PortfolioRisk, cfg, 5000, 0, 0, 0)
 	if !allowed {
 		t.Fatalf("expected kill switch to stay cleared after auto-clear; got reason=%s", reason)
 	}
@@ -1445,5 +1446,224 @@ func TestDetectSharedWalletPlatforms(t *testing.T) {
 	got := detectSharedWalletPlatforms(strategies)
 	if len(got) != 1 || got[0] != "hyperliquid" {
 		t.Errorf("expected [hyperliquid]; got %v", got)
+	}
+}
+
+// --- #296: portfolio-level perps margin drawdown ---
+
+// TestCheckPortfolioRisk_AllPerps_MarginDrawdownFires is the core acceptance-
+// criteria test for issue #296. An all-perps portfolio where deployed margin
+// has lost 50% of its value must fire the kill switch at the configured
+// drawdown limit, even though the equity-based drawdown looks small because
+// leveraged PnL is only a small fraction of total account value.
+//
+// Scenario: $10K equity, $1K of margin deployed on a 10x leveraged position
+// (notional ~$10K). A 5% adverse price move = $500 unrealized loss = 50% of
+// deployed margin, but only 5% of total equity. Pre-#296 the portfolio kill
+// switch would not fire until equity drawdown breached 25%, long after the
+// position would have been liquidated. Post-#296 the margin signal trips at
+// 25%.
+func TestCheckPortfolioRisk_AllPerps_MarginDrawdownFires(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 10000}
+
+	// Equity has barely moved — 5% nominal drawdown — so the pre-#296
+	// equity-only check would allow. Margin drawdown is 50%, well above
+	// the 25% limit, so the kill switch must fire.
+	totalValue := 9500.0
+	perpsLoss := 500.0
+	perpsMargin := 1000.0
+
+	allowed, _, _, reason := CheckPortfolioRisk(prs, cfg, totalValue, 0, perpsLoss, perpsMargin)
+	if allowed {
+		t.Errorf("expected kill switch to fire on 50%% perps margin drawdown; got allowed=true, reason=%s", reason)
+	}
+	if !prs.KillSwitchActive {
+		t.Error("expected KillSwitchActive=true")
+	}
+	if reason == "" {
+		t.Error("expected non-empty reason for kill switch")
+	}
+	// Reason should name the margin signal, not equity.
+	if !strings.Contains(reason, "margin") {
+		t.Errorf("expected reason to reference perps margin drawdown; got %q", reason)
+	}
+	// CurrentDrawdownPct should reflect the worse of the two signals (50%).
+	if prs.CurrentDrawdownPct < 49.9 || prs.CurrentDrawdownPct > 50.1 {
+		t.Errorf("expected CurrentDrawdownPct≈50%%; got %.2f", prs.CurrentDrawdownPct)
+	}
+}
+
+// TestCheckPortfolioRisk_MixedAccount_SpotEquityStillHonored verifies that a
+// mixed spot+perps portfolio does not regress on the equity signal when perps
+// margin is healthy. Acceptance criterion 2: "Mixed spot+perps portfolios
+// don't regress (spot equity drawdown still honored)."
+func TestCheckPortfolioRisk_MixedAccount_SpotEquityStillHonored(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 10000}
+
+	// Equity drawdown 30% (spot leg tanked). Perps has margin deployed but
+	// no unrealized loss — margin signal does not fire.
+	totalValue := 7000.0
+	perpsLoss := 0.0
+	perpsMargin := 500.0
+
+	allowed, _, _, reason := CheckPortfolioRisk(prs, cfg, totalValue, 0, perpsLoss, perpsMargin)
+	if allowed {
+		t.Errorf("expected equity-drawdown kill switch to fire at 30%%; got allowed=true")
+	}
+	if !prs.KillSwitchActive {
+		t.Error("expected KillSwitchActive=true")
+	}
+	// Reason should NOT reference margin — this was an equity event.
+	if strings.Contains(reason, "margin") {
+		t.Errorf("expected reason to reference equity drawdown, not margin; got %q", reason)
+	}
+}
+
+// TestCheckPortfolioRisk_MixedAccount_MarginFiresFirst verifies that when both
+// equity and margin drawdowns breach the limit simultaneously, the reason
+// names the larger (margin) signal — so operators see the headline number.
+func TestCheckPortfolioRisk_MixedAccount_MarginFiresFirst(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 10000}
+
+	// Equity: 30% drawdown (> 25%). Margin: 60% drawdown (way bigger).
+	totalValue := 7000.0
+	perpsLoss := 600.0
+	perpsMargin := 1000.0
+
+	allowed, _, _, reason := CheckPortfolioRisk(prs, cfg, totalValue, 0, perpsLoss, perpsMargin)
+	if allowed {
+		t.Error("expected kill switch to fire")
+	}
+	if !strings.Contains(reason, "margin") {
+		t.Errorf("expected reason to reference margin (worse signal); got %q", reason)
+	}
+	// CurrentDrawdownPct reflects the worse signal (60%).
+	if prs.CurrentDrawdownPct < 59.9 || prs.CurrentDrawdownPct > 60.1 {
+		t.Errorf("expected CurrentDrawdownPct≈60%%; got %.2f", prs.CurrentDrawdownPct)
+	}
+}
+
+// TestCheckPortfolioRisk_NoPerps_EquityBehaviorUnchanged verifies that
+// passing zero perps inputs reproduces the pre-#296 equity-only behavior
+// exactly. Guard against regressions for all-spot/all-options portfolios.
+func TestCheckPortfolioRisk_NoPerps_EquityBehaviorUnchanged(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 10000}
+
+	// 20% equity drawdown, no perps — below the 25% limit, should allow.
+	allowed, _, _, _ := CheckPortfolioRisk(prs, cfg, 8000, 0, 0, 0)
+	if !allowed {
+		t.Error("expected allowed=true at 20%% equity drawdown with no perps")
+	}
+
+	// 26% equity drawdown — fires.
+	allowed, _, _, reason := CheckPortfolioRisk(prs, cfg, 7400, 0, 0, 0)
+	if allowed {
+		t.Error("expected kill switch at 26%% equity drawdown")
+	}
+	if strings.Contains(reason, "margin") {
+		t.Errorf("expected equity-drawdown reason (no perps deployed); got %q", reason)
+	}
+}
+
+// TestCheckPortfolioRisk_MarginWarning verifies the warning signal also
+// respects the perps margin drawdown, not just equity — so a leveraged
+// position approaching the kill switch threshold alerts operators early.
+func TestCheckPortfolioRisk_MarginWarning(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 10000}
+
+	// Equity flat. Margin drawdown 21% — between warn threshold (20%) and
+	// kill switch (25%). Warning must fire.
+	_, _, warning, reason := CheckPortfolioRisk(prs, cfg, 10000, 0, 210, 1000)
+	if !warning {
+		t.Errorf("expected warning=true at 21%% margin drawdown; reason=%q", reason)
+	}
+	if !strings.Contains(reason, "margin") {
+		t.Errorf("expected warning reason to reference margin; got %q", reason)
+	}
+	if prs.KillSwitchActive {
+		t.Error("expected kill switch NOT active (warning, not fire)")
+	}
+}
+
+// TestAggregatePerpsMarginDrawdown verifies the helper sums across multiple
+// perps strategies and ignores non-perps (spot/options/futures). This is the
+// inputs side of the #296 portfolio kill switch — a regression here would
+// silently under-count deployed margin and hide leveraged losses.
+func TestAggregatePerpsMarginDrawdown(t *testing.T) {
+	strategies := map[string]*StrategyState{
+		"hl-btc": {
+			Type: "perps",
+			Positions: map[string]*Position{
+				// 1 BTC short @ 40K, now 42K, 10x leverage, multiplier 1.
+				// notional = 1 * 42000 = 42000, margin = 42000/10 = 4200.
+				// pnl = 1 * 1 * (40000 - 42000) = -2000 (short loses when price rises).
+				"BTC": {Symbol: "BTC", Quantity: 1, AvgCost: 40000, Side: "short", Multiplier: 1, Leverage: 10},
+			},
+		},
+		"hl-eth": {
+			Type: "perps",
+			Positions: map[string]*Position{
+				// 10 ETH long @ 3000, now 3100, 5x leverage.
+				// notional = 10 * 3100 = 31000, margin = 31000/5 = 6200.
+				// pnl = 10 * 1 * (3100 - 3000) = +1000 (winner, clamps to 0 loss).
+				"ETH": {Symbol: "ETH", Quantity: 10, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 5},
+			},
+		},
+		"spot-sol": {
+			Type: "spot",
+			Positions: map[string]*Position{
+				// Spot position must be ignored — no leverage, no margin.
+				"SOL/USDT": {Symbol: "SOL/USDT", Quantity: 100, AvgCost: 150, Side: "long"},
+			},
+		},
+		"ts-es": {
+			Type: "futures",
+			Positions: map[string]*Position{
+				// Futures position must be ignored — Type != perps.
+				"ES": {Symbol: "ES", Quantity: 1, AvgCost: 5000, Side: "long", Multiplier: 50},
+			},
+		},
+	}
+	prices := map[string]float64{
+		"BTC":      42000,
+		"ETH":      3100,
+		"SOL/USDT": 200,
+		"ES":       5100,
+	}
+
+	loss, margin := AggregatePerpsMarginDrawdown(strategies, prices)
+
+	// Only the losing BTC short contributes to loss: 2000.
+	// Margin includes both perps positions: 4200 + 6200 = 10400.
+	expectedLoss := 2000.0
+	expectedMargin := 10400.0
+	if loss < expectedLoss-0.01 || loss > expectedLoss+0.01 {
+		t.Errorf("expected loss=%.2f; got %.2f", expectedLoss, loss)
+	}
+	if margin < expectedMargin-0.01 || margin > expectedMargin+0.01 {
+		t.Errorf("expected margin=%.2f; got %.2f", expectedMargin, margin)
+	}
+}
+
+// TestAggregatePerpsMarginDrawdown_NoPerpsReturnsZero verifies the helper
+// returns (0, 0) when no perps strategies exist. The caller treats zero
+// margin as the signal to fall back to pure equity drawdown.
+func TestAggregatePerpsMarginDrawdown_NoPerpsReturnsZero(t *testing.T) {
+	strategies := map[string]*StrategyState{
+		"spot-btc": {
+			Type: "spot",
+			Positions: map[string]*Position{
+				"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.5, AvgCost: 40000, Side: "long"},
+			},
+		},
+	}
+	loss, margin := AggregatePerpsMarginDrawdown(strategies, map[string]float64{"BTC/USDT": 50000})
+	if loss != 0 || margin != 0 {
+		t.Errorf("expected (0, 0) for no perps; got (%.2f, %.2f)", loss, margin)
 	}
 }

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -842,7 +842,7 @@ func TestAddKillSwitchEvent_MaxCap(t *testing.T) {
 	prs := &PortfolioRiskState{}
 
 	for i := 0; i < 60; i++ {
-		addKillSwitchEvent(prs, "warning", float64(i), 1000, 2000, "test")
+		addKillSwitchEvent(prs, "warning", "equity", float64(i), 1000, 2000, "test")
 	}
 
 	if len(prs.Events) != maxKillSwitchEvents {
@@ -1488,9 +1488,31 @@ func TestCheckPortfolioRisk_AllPerps_MarginDrawdownFires(t *testing.T) {
 	if !strings.Contains(reason, "margin") {
 		t.Errorf("expected reason to reference perps margin drawdown; got %q", reason)
 	}
-	// CurrentDrawdownPct should reflect the worse of the two signals (50%).
-	if prs.CurrentDrawdownPct < 49.9 || prs.CurrentDrawdownPct > 50.1 {
-		t.Errorf("expected CurrentDrawdownPct≈50%%; got %.2f", prs.CurrentDrawdownPct)
+	// Equity drawdown was only 5% — field stays on the equity signal.
+	if prs.CurrentDrawdownPct < 4.9 || prs.CurrentDrawdownPct > 5.1 {
+		t.Errorf("expected CurrentDrawdownPct (equity)≈5%%; got %.2f", prs.CurrentDrawdownPct)
+	}
+	// Margin drawdown is 50% — recorded on the dedicated field so persistence
+	// stays arithmetically consistent (peak_value / current_drawdown_pct).
+	if prs.CurrentMarginDrawdownPct < 49.9 || prs.CurrentMarginDrawdownPct > 50.1 {
+		t.Errorf("expected CurrentMarginDrawdownPct≈50%%; got %.2f", prs.CurrentMarginDrawdownPct)
+	}
+	// Event must be recorded with source="margin" so auditors can tell which
+	// signal drove the fire without re-parsing the reason string.
+	if len(prs.Events) != 1 {
+		t.Fatalf("expected exactly one event; got %d", len(prs.Events))
+	}
+	evt := prs.Events[0]
+	if evt.Type != "triggered" {
+		t.Errorf("expected event Type=triggered; got %q", evt.Type)
+	}
+	if evt.Source != "margin" {
+		t.Errorf("expected event Source=margin; got %q", evt.Source)
+	}
+	// Event's DrawdownPct records the signal value (margin=50%), not a
+	// mixed "worse of" number.
+	if evt.DrawdownPct < 49.9 || evt.DrawdownPct > 50.1 {
+		t.Errorf("expected event DrawdownPct≈50%% (margin signal); got %.2f", evt.DrawdownPct)
 	}
 }
 
@@ -1519,6 +1541,9 @@ func TestCheckPortfolioRisk_MixedAccount_SpotEquityStillHonored(t *testing.T) {
 	if strings.Contains(reason, "margin") {
 		t.Errorf("expected reason to reference equity drawdown, not margin; got %q", reason)
 	}
+	if len(prs.Events) != 1 || prs.Events[0].Source != "equity" {
+		t.Errorf("expected one triggered event with Source=equity; got %+v", prs.Events)
+	}
 }
 
 // TestCheckPortfolioRisk_MixedAccount_MarginFiresFirst verifies that when both
@@ -1540,9 +1565,15 @@ func TestCheckPortfolioRisk_MixedAccount_MarginFiresFirst(t *testing.T) {
 	if !strings.Contains(reason, "margin") {
 		t.Errorf("expected reason to reference margin (worse signal); got %q", reason)
 	}
-	// CurrentDrawdownPct reflects the worse signal (60%).
-	if prs.CurrentDrawdownPct < 59.9 || prs.CurrentDrawdownPct > 60.1 {
-		t.Errorf("expected CurrentDrawdownPct≈60%%; got %.2f", prs.CurrentDrawdownPct)
+	// Equity and margin are persisted separately: equity=30%, margin=60%.
+	if prs.CurrentDrawdownPct < 29.9 || prs.CurrentDrawdownPct > 30.1 {
+		t.Errorf("expected CurrentDrawdownPct (equity)≈30%%; got %.2f", prs.CurrentDrawdownPct)
+	}
+	if prs.CurrentMarginDrawdownPct < 59.9 || prs.CurrentMarginDrawdownPct > 60.1 {
+		t.Errorf("expected CurrentMarginDrawdownPct≈60%%; got %.2f", prs.CurrentMarginDrawdownPct)
+	}
+	if len(prs.Events) != 1 || prs.Events[0].Source != "margin" {
+		t.Errorf("expected one triggered event with Source=margin; got %+v", prs.Events)
 	}
 }
 
@@ -1590,11 +1621,11 @@ func TestCheckPortfolioRisk_MarginWarning(t *testing.T) {
 	}
 }
 
-// TestAggregatePerpsMarginDrawdown verifies the helper sums across multiple
+// TestAggregatePerpsMarginInputs verifies the helper sums across multiple
 // perps strategies and ignores non-perps (spot/options/futures). This is the
 // inputs side of the #296 portfolio kill switch — a regression here would
 // silently under-count deployed margin and hide leveraged losses.
-func TestAggregatePerpsMarginDrawdown(t *testing.T) {
+func TestAggregatePerpsMarginInputs(t *testing.T) {
 	strategies := map[string]*StrategyState{
 		"hl-btc": {
 			Type: "perps",
@@ -1636,7 +1667,7 @@ func TestAggregatePerpsMarginDrawdown(t *testing.T) {
 		"ES":       5100,
 	}
 
-	loss, margin := AggregatePerpsMarginDrawdown(strategies, prices)
+	loss, margin := AggregatePerpsMarginInputs(strategies, prices)
 
 	// Only the losing BTC short contributes to loss: 2000.
 	// Margin includes both perps positions: 4200 + 6200 = 10400.
@@ -1650,10 +1681,10 @@ func TestAggregatePerpsMarginDrawdown(t *testing.T) {
 	}
 }
 
-// TestAggregatePerpsMarginDrawdown_NoPerpsReturnsZero verifies the helper
+// TestAggregatePerpsMarginInputs_NoPerpsReturnsZero verifies the helper
 // returns (0, 0) when no perps strategies exist. The caller treats zero
 // margin as the signal to fall back to pure equity drawdown.
-func TestAggregatePerpsMarginDrawdown_NoPerpsReturnsZero(t *testing.T) {
+func TestAggregatePerpsMarginInputs_NoPerpsReturnsZero(t *testing.T) {
 	strategies := map[string]*StrategyState{
 		"spot-btc": {
 			Type: "spot",
@@ -1662,8 +1693,74 @@ func TestAggregatePerpsMarginDrawdown_NoPerpsReturnsZero(t *testing.T) {
 			},
 		},
 	}
-	loss, margin := AggregatePerpsMarginDrawdown(strategies, map[string]float64{"BTC/USDT": 50000})
+	loss, margin := AggregatePerpsMarginInputs(strategies, map[string]float64{"BTC/USDT": 50000})
 	if loss != 0 || margin != 0 {
 		t.Errorf("expected (0, 0) for no perps; got (%.2f, %.2f)", loss, margin)
+	}
+}
+
+// TestCheckPortfolioRisk_PeakZero_MarginCanStillFire guards against the
+// subtle gating change introduced in #296: a cold-start account (no prior
+// valuation, PeakValue==0) that opens a leveraged perps position and
+// immediately blows up its margin must still kill-switch. Pre-#296 the
+// entire kill-switch branch sat inside `if prs.PeakValue > 0`, so a fresh
+// account firing on bar 1 was impossible; the margin signal has to work
+// independent of the equity high-water mark.
+func TestCheckPortfolioRisk_PeakZero_MarginCanStillFire(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 0} // cold start: no prior valuation
+
+	// Cold account opens a 10x perps position, immediately down 50% on
+	// margin. totalValue is zero (we have no valuation yet) so equityDD is
+	// zero; margin signal is 50%, well above the 25% limit.
+	allowed, _, _, reason := CheckPortfolioRisk(prs, cfg, 0, 0, 500, 1000)
+	if allowed {
+		t.Errorf("expected cold-start margin drawdown to fire kill switch; got allowed=true, reason=%s", reason)
+	}
+	if !prs.KillSwitchActive {
+		t.Error("expected KillSwitchActive=true on cold-start margin blowup")
+	}
+	if !strings.Contains(reason, "margin") {
+		t.Errorf("expected margin-driven reason; got %q", reason)
+	}
+	if len(prs.Events) != 1 || prs.Events[0].Source != "margin" {
+		t.Errorf("expected one triggered event with Source=margin; got %+v", prs.Events)
+	}
+}
+
+// TestCheckPortfolioRisk_BothSignalsBreachWarn_ReasonIncludesBoth verifies
+// that when both equity and margin cross the warning threshold in the same
+// cycle, the reason string surfaces both — so a correlated move is visible
+// to the operator at a glance rather than hidden behind the larger signal.
+func TestCheckPortfolioRisk_BothSignalsBreachWarn_ReasonIncludesBoth(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 10000}
+
+	// Equity drawdown 22%, margin drawdown 23% — both above the 20% warn
+	// threshold, both below the 25% kill switch.
+	_, _, warning, reason := CheckPortfolioRisk(prs, cfg, 7800, 0, 230, 1000)
+	if !warning {
+		t.Fatalf("expected warning=true; reason=%q", reason)
+	}
+	if !strings.Contains(reason, "equity=") || !strings.Contains(reason, "margin=") {
+		t.Errorf("expected reason to mention both equity= and margin=; got %q", reason)
+	}
+}
+
+// TestCheckPortfolioRisk_MarginWarning_FieldsPopulated makes sure the
+// dedicated CurrentMarginDrawdownPct field is kept current even when the
+// warning does not fire (so /status surfaces the live margin signal). This
+// mirrors CurrentDrawdownPct's always-updated contract.
+func TestCheckPortfolioRisk_MarginWarning_FieldsPopulated(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 10000}
+
+	// Equity flat. Margin drawdown 10% — below warn. Field still updates.
+	_, _, warning, _ := CheckPortfolioRisk(prs, cfg, 10000, 0, 100, 1000)
+	if warning {
+		t.Error("expected warning=false at 10%% margin drawdown")
+	}
+	if prs.CurrentMarginDrawdownPct < 9.9 || prs.CurrentMarginDrawdownPct > 10.1 {
+		t.Errorf("expected CurrentMarginDrawdownPct≈10%%; got %.2f", prs.CurrentMarginDrawdownPct)
 	}
 }


### PR DESCRIPTION
Closes #296

## Summary

Mirrors the per-strategy fix from #292 at the portfolio level. The portfolio kill switch previously only tracked equity drawdown, which dramatically understates risk for all-perps accounts: a 50% loss on 10x margin shows up as ~5% of total account value, so the kill switch fired far too late (or not at all before liquidation).

`CheckPortfolioRisk` now runs two independent drawdown signals:
- Equity drawdown (spot/options)
- Perps margin drawdown (aggregate unrealized loss / deployed margin)

Kill switch fires on whichever breaches the limit first, so mixed portfolios are guarded on both fronts and all-spot/options behavior is unchanged (margin inputs are zero).

## Test plan
- [x] `go test ./...` passes (new and existing tests)
- [x] `go build .` passes
- [ ] Smoke test against a live all-perps config

🤖 Generated with [Claude Code](https://claude.ai/code)