### PR TITLE
fix(backtest): critical correctness bugs — look-ahead, IV math (#302)

### DIFF
--- a/backtest/THETA_HARVEST_RESULTS.md
+++ b/backtest/THETA_HARVEST_RESULTS.md
@@ -1,12 +1,9 @@
 # Theta Harvesting Backtest Results
 
-> ⚠️ **SUPERSEDED — 2026-04-17.** These results were produced with the
-> pre-fix volatility and IV-rank math (issue #302). The old `calc_historical_vol`
-> used simple returns and `sum(r**2)/n` (not variance around the mean), and
-> `calc_iv_rank` returned an IV *ratio* rather than a percentile rank. Both
-> inflated Black-Scholes premiums and skewed entry timing, so the numbers
-> below should not be treated as live-comparable. Rerun after the #302 C2/C3
-> fixes ship before using any figure in this document.
+> ⚠️ **SUPERSEDED — 2026-04-17.** These figures were produced against a
+> pre-issue-#302 version of `calc_historical_vol` and `calc_iv_rank` that
+> inflated premiums and skewed entry timing. Rerun `backtest_theta.py`
+> against the current implementations before citing any number below.
 
 **Date:** 2026-02-11
 **Data:** Binance US, 2023-01-01 to 2026-02-11 (1,048 days)

--- a/backtest/THETA_HARVEST_RESULTS.md
+++ b/backtest/THETA_HARVEST_RESULTS.md
@@ -1,5 +1,13 @@
 # Theta Harvesting Backtest Results
 
+> ⚠️ **SUPERSEDED — 2026-04-17.** These results were produced with the
+> pre-fix volatility and IV-rank math (issue #302). The old `calc_historical_vol`
+> used simple returns and `sum(r**2)/n` (not variance around the mean), and
+> `calc_iv_rank` returned an IV *ratio* rather than a percentile rank. Both
+> inflated Black-Scholes premiums and skewed entry timing, so the numbers
+> below should not be treated as live-comparable. Rerun after the #302 C2/C3
+> fixes ship before using any figure in this document.
+
 **Date:** 2026-02-11
 **Data:** Binance US, 2023-01-01 to 2026-02-11 (1,048 days)
 **Strategy:** Vol Mean Reversion (sell strangles on high IV, buy straddles on low IV)

--- a/backtest/backtest_options.py
+++ b/backtest/backtest_options.py
@@ -98,7 +98,6 @@ def calc_iv_rank(closes: list, recent_window: int = 14,
     merely 2× historical vol rather than at a true lookback high. That
     triggered strangles at entirely different moments than live.
     """
-    # Need enough bars for a full rolling window plus lookback.
     if len(closes) < recent_window + lookback_days + 1:
         return 50.0
 
@@ -107,18 +106,12 @@ def calc_iv_rank(closes: list, recent_window: int = 14,
     ]
 
     def _rolling_vol(end_idx: int) -> float:
-        # Annualised realised vol of the ``recent_window`` log returns ending
-        # at index ``end_idx`` (inclusive). Uses variance around the sample
-        # mean — same formula family as calc_historical_vol.
         window = log_returns[end_idx - recent_window + 1: end_idx + 1]
         mean = sum(window) / len(window)
         variance = sum((r - mean) ** 2 for r in window) / len(window)
         return math.sqrt(variance * 365)
 
-    # Current realised vol — most recent full window.
     current = _rolling_vol(len(log_returns) - 1)
-
-    # Trailing rolling-vol distribution over the lookback window.
     history = [
         _rolling_vol(end)
         for end in range(
@@ -129,7 +122,7 @@ def calc_iv_rank(closes: list, recent_window: int = 14,
 
     lo, hi = min(history), max(history)
     if hi - lo <= 1e-12:
-        # Vol has been constant across the lookback — rank is ill-defined.
+        # Degenerate range — rank is ill-defined, return neutral.
         return 50.0
 
     rank = (current - lo) / (hi - lo) * 100.0

--- a/backtest/backtest_options.py
+++ b/backtest/backtest_options.py
@@ -64,12 +64,23 @@ def black_scholes_price(spot: float, strike: float, dte_days: float, vol: float,
 
 
 def calc_historical_vol(closes: list, window: int = 14) -> float:
-    """Calculate annualized historical volatility from daily closes."""
+    """Annualized historical volatility from daily closes.
+
+    Uses log returns (correct for multiplicative price processes) and
+    population variance around the sample mean. The previous implementation
+    used simple returns with ``sum(r**2) / n`` — the latter is the mean of
+    squared returns, which equals variance only when the mean return is
+    exactly zero. For crypto over short windows that assumption is false,
+    inflating vol and overpricing every Black-Scholes premium.
+    """
     if len(closes) < window + 1:
         return 0.5  # default 50%
-    
-    returns = [(closes[i] - closes[i-1]) / closes[i-1] for i in range(-window, 0)]
-    variance = sum(r**2 for r in returns) / len(returns)
+
+    log_returns = [
+        math.log(closes[i] / closes[i - 1]) for i in range(-window, 0)
+    ]
+    mean = sum(log_returns) / len(log_returns)
+    variance = sum((r - mean) ** 2 for r in log_returns) / len(log_returns)
     return math.sqrt(variance * 365)
 
 

--- a/backtest/backtest_options.py
+++ b/backtest/backtest_options.py
@@ -84,16 +84,56 @@ def calc_historical_vol(closes: list, window: int = 14) -> float:
     return math.sqrt(variance * 365)
 
 
-def calc_iv_rank(closes: list, recent_window: int = 14) -> float:
-    """Calculate IV rank (simplified: recent vol vs historical vol)."""
-    if len(closes) < 30:
+def calc_iv_rank(closes: list, recent_window: int = 14,
+                  lookback_days: int = 60) -> float:
+    """IV rank — percentile of current realised vol within a trailing window.
+
+    Defined as ``(current - min) / (max - min) * 100`` over the past
+    ``lookback_days`` days of rolling ``recent_window``-day realised vol,
+    matching the shape of ``adapter.get_iv_rank()`` in the live
+    ``VolMeanReversionStrategy``.
+
+    The previous implementation returned ``(recent / hist) * 50`` — an IV
+    *ratio* halved and clipped, which reached 100 whenever recent vol was
+    merely 2× historical vol rather than at a true lookback high. That
+    triggered strangles at entirely different moments than live.
+    """
+    # Need enough bars for a full rolling window plus lookback.
+    if len(closes) < recent_window + lookback_days + 1:
         return 50.0
-    
-    returns = [(closes[i] - closes[i-1]) / closes[i-1] for i in range(1, len(closes))]
-    recent_vol = math.sqrt(sum(r**2 for r in returns[-recent_window:]) / recent_window) * math.sqrt(365) * 100
-    hist_vol = math.sqrt(sum(r**2 for r in returns) / len(returns)) * math.sqrt(365) * 100
-    
-    return min(max((recent_vol / max(hist_vol, 0.001)) * 50, 0), 100)
+
+    log_returns = [
+        math.log(closes[i] / closes[i - 1]) for i in range(1, len(closes))
+    ]
+
+    def _rolling_vol(end_idx: int) -> float:
+        # Annualised realised vol of the ``recent_window`` log returns ending
+        # at index ``end_idx`` (inclusive). Uses variance around the sample
+        # mean — same formula family as calc_historical_vol.
+        window = log_returns[end_idx - recent_window + 1: end_idx + 1]
+        mean = sum(window) / len(window)
+        variance = sum((r - mean) ** 2 for r in window) / len(window)
+        return math.sqrt(variance * 365)
+
+    # Current realised vol — most recent full window.
+    current = _rolling_vol(len(log_returns) - 1)
+
+    # Trailing rolling-vol distribution over the lookback window.
+    history = [
+        _rolling_vol(end)
+        for end in range(
+            len(log_returns) - 1 - lookback_days,
+            len(log_returns),
+        )
+    ]
+
+    lo, hi = min(history), max(history)
+    if hi - lo <= 1e-12:
+        # Vol has been constant across the lookback — rank is ill-defined.
+        return 50.0
+
+    rank = (current - lo) / (hi - lo) * 100.0
+    return min(max(rank, 0.0), 100.0)
 
 
 class OptionPosition:

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -84,16 +84,14 @@ class Backtester:
 
         Execution model matches the live scheduler: a signal produced by the
         close of bar t is read after the bar finishes and filled at bar t+1's
-        open. The backtester therefore shifts the signal column forward by one
-        bar and fills at ``row['open']`` when available (fallback: close).
+        open (no look-ahead bias). Falls back to close when an ``open`` column
+        is not present.
 
         Returns dict with all performance metrics.
         """
         if "signal" not in df.columns:
             raise ValueError("DataFrame must have a 'signal' column")
 
-        # Shift signals forward 1 bar so a signal at bar t executes on bar t+1
-        # (no look-ahead bias). Fill resulting NaN at bar 0 with 0 = hold.
         df = df.copy()
         df["signal"] = df["signal"].shift(1).fillna(0)
 
@@ -110,11 +108,9 @@ class Backtester:
             mark_price = row["close"]
             signal = row["signal"]
 
-            # Calculate current equity (mark-to-close for the equity curve)
             equity = cash + position * mark_price
             equity_curve.append({"date": idx, "equity": equity})
 
-            # Process signals — fill at bar open (or close if open missing)
             if signal == 1 and position == 0:
                 # BUY — go long with all available cash
                 effective_price = fill_price * (1 + self.slippage_pct)

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -82,10 +82,22 @@ class Backtester:
         Run backtest on a DataFrame that already has a 'signal' column.
         signal: 1 = buy, -1 = sell, 0 = hold
 
+        Execution model matches the live scheduler: a signal produced by the
+        close of bar t is read after the bar finishes and filled at bar t+1's
+        open. The backtester therefore shifts the signal column forward by one
+        bar and fills at ``row['open']`` when available (fallback: close).
+
         Returns dict with all performance metrics.
         """
         if "signal" not in df.columns:
             raise ValueError("DataFrame must have a 'signal' column")
+
+        # Shift signals forward 1 bar so a signal at bar t executes on bar t+1
+        # (no look-ahead bias). Fill resulting NaN at bar 0 with 0 = hold.
+        df = df.copy()
+        df["signal"] = df["signal"].shift(1).fillna(0)
+
+        has_open = "open" in df.columns
 
         cash = self.initial_capital
         position = 0.0  # shares held
@@ -94,17 +106,18 @@ class Backtester:
         equity_curve = []
 
         for i, (idx, row) in enumerate(df.iterrows()):
-            price = row["close"]
+            fill_price = row["open"] if has_open else row["close"]
+            mark_price = row["close"]
             signal = row["signal"]
 
-            # Calculate current equity
-            equity = cash + position * price
+            # Calculate current equity (mark-to-close for the equity curve)
+            equity = cash + position * mark_price
             equity_curve.append({"date": idx, "equity": equity})
 
-            # Process signals
+            # Process signals — fill at bar open (or close if open missing)
             if signal == 1 and position == 0:
                 # BUY — go long with all available cash
-                effective_price = price * (1 + self.slippage_pct)
+                effective_price = fill_price * (1 + self.slippage_pct)
                 commission = cash * self.commission_pct
                 available = cash - commission
                 shares = available / effective_price
@@ -116,7 +129,7 @@ class Backtester:
 
             elif signal == -1 and position > 0:
                 # SELL — close long position
-                effective_price = price * (1 - self.slippage_pct)
+                effective_price = fill_price * (1 - self.slippage_pct)
                 proceeds = position * effective_price
                 commission = proceeds * self.commission_pct
                 cash = proceeds - commission

--- a/backtest/tests/conftest.py
+++ b/backtest/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Make backtest/ modules importable from backtest/tests/."""
+import os
+import sys
+
+BACKTEST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if BACKTEST_DIR not in sys.path:
+    sys.path.insert(0, BACKTEST_DIR)

--- a/backtest/tests/test_backtester_end_to_end.py
+++ b/backtest/tests/test_backtester_end_to_end.py
@@ -1,0 +1,61 @@
+"""
+End-to-end golden-file regression for issue #302.
+
+Runs the Backtester on a deterministic synthetic OHLC series with an
+SMA-crossover signal stream and pins the summary stats. The unit tests
+cover each fix in isolation; this locks in their combined behavior —
+a regression that fixes each piece individually but drifts the integrated
+P&L will fail here.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from backtester import Backtester
+
+
+def _synthetic_ohlc(seed: int = 42, n: int = 200) -> pd.DataFrame:
+    """Generate a deterministic OHLC path with intrabar open/close spread."""
+    rng = np.random.default_rng(seed)
+    log_returns = rng.normal(loc=0.0003, scale=0.02, size=n)
+    closes = [100.0]
+    for r in log_returns:
+        closes.append(closes[-1] * np.exp(r))
+    closes = np.array(closes[1:])
+    # Opens deterministically offset from close so fills at open != close.
+    opens = closes * (1.0 + rng.normal(loc=0.0, scale=0.003, size=n))
+    highs = np.maximum(opens, closes) * 1.002
+    lows = np.minimum(opens, closes) * 0.998
+
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    return pd.DataFrame(
+        {"open": opens, "high": highs, "low": lows, "close": closes},
+        index=idx,
+    )
+
+
+def _sma_crossover_signals(df: pd.DataFrame, fast: int = 10, slow: int = 30) -> pd.Series:
+    fast_ma = df["close"].rolling(fast).mean()
+    slow_ma = df["close"].rolling(slow).mean()
+    position = (fast_ma > slow_ma).astype(int)
+    # position.diff() → 1 on buy crossover, -1 on sell crossover, 0 otherwise.
+    return position.diff().fillna(0).astype(int)
+
+
+def test_end_to_end_golden_file():
+    df = _synthetic_ohlc()
+    df["signal"] = _sma_crossover_signals(df)
+
+    bt = Backtester(
+        initial_capital=1000.0, commission_pct=0.001, slippage_pct=0.0005
+    )
+    results = bt.run(df, strategy_name="e2e-golden", save=False)
+
+    # Golden values — update intentionally if (and only if) the execution
+    # model changes. A regression that drifts signal-shift alignment,
+    # fill-at-next-open, or the metrics pipeline will break at least one.
+    assert results["total_trades"] == 6
+    assert results["final_capital"] == pytest.approx(923.53, abs=0.01)
+    assert results["total_return_pct"] == pytest.approx(-7.51, abs=0.01)
+    assert results["sharpe_ratio"] == pytest.approx(-0.686, abs=0.001)
+    assert results["max_drawdown_pct"] == pytest.approx(-17.66, abs=0.01)

--- a/backtest/tests/test_backtester_fills.py
+++ b/backtest/tests/test_backtester_fills.py
@@ -1,10 +1,9 @@
 """
-Regression tests for #302 C1: look-ahead bias in the backtester.
+Regression tests for issue #302 — Backtester fill alignment.
 
-Live scheduler behavior: a signal computed on the close of bar t is read after
-the bar closes and filled as a market order that lands at ~bar t+1's open.
-The backtester must match this — filling at bar t's close on the same bar the
-signal was produced creates a free look-ahead.
+Live scheduler reads a completed bar's close-signal and market-orders that
+lands at the next bar's open. Backtests must match — filling at the signal
+bar's close is free look-ahead.
 """
 import pandas as pd
 import pytest
@@ -28,10 +27,7 @@ def _make_df(opens, highs, lows, closes, signals):
 
 
 def test_fill_uses_next_bar_open_not_signal_bar_close():
-    """A buy signal on bar 2 must fill at bar 3's open, not bar 2's close."""
-    # Crafted prices: bar 2 close (=100) is distinct from bar 3 open (=110).
-    # If the backtester incorrectly fills at close, the entry price is 100.
-    # Correct behavior (fill at next bar's open) puts the entry at 110.
+    """Buy signal on bar 2 must fill at bar 3's open, not bar 2's close."""
     opens = [100, 100, 100, 110, 110, 110]
     highs = [101, 101, 101, 111, 111, 111]
     lows = [99, 99, 99, 109, 109, 109]
@@ -45,8 +41,12 @@ def test_fill_uses_next_bar_open_not_signal_bar_close():
     assert len(results["trades"]) == 1
     trade = results["trades"][0]
     assert trade["entry_price"] == pytest.approx(110.0, rel=1e-9), (
-        "Entry price must come from the bar *after* the signal bar's open "
-        "(110), not the signal bar's close (100). A 100 here is look-ahead bias."
+        "Entry must fill at the bar after the signal bar's open (110), "
+        "not the signal bar's close (100) — that would be look-ahead bias."
+    )
+    assert trade["shares"] == pytest.approx(1000.0 / 110.0, rel=1e-9), (
+        "Share count must divide available cash by the actual fill price "
+        "(110), not the signal-bar close (100)."
     )
 
 
@@ -64,19 +64,19 @@ def test_exit_uses_next_bar_open_not_signal_bar_close():
 
     assert len(results["trades"]) == 1
     trade = results["trades"][0]
-    # Entry is buy at bar 2's open (next bar after signal bar 1) → 100.
     assert trade["entry_price"] == pytest.approx(100.0, rel=1e-9)
-    # Exit is sell at bar 4's open (next bar after signal bar 3) → 200,
-    # NOT bar 3's close (= 100, which would show a 0% trade — look-ahead-free
-    # exit sees the big gap up).
     assert trade["exit_price"] == pytest.approx(200.0, rel=1e-9), (
-        "Exit must fill at the bar following the sell-signal bar's open (200), "
+        "Exit must fill at the bar after the sell-signal bar's open (200), "
         "not the signal bar's close (100)."
+    )
+    expected_final_cash = 1000.0 * (200.0 / 100.0)
+    assert results["final_capital"] == pytest.approx(expected_final_cash, rel=1e-9), (
+        "Final cash should double with the 2x gap-up fill, not stay flat."
     )
 
 
 def test_falls_back_to_close_when_open_column_missing():
-    """Legacy demos/tests feed only a 'close' column — preserve that path."""
+    """Legacy demos feed only 'close' — preserve that path (shift still applies)."""
     closes = [100, 100, 100, 110, 110, 110]
     signals = [0, 0, 1, 0, 0, -1]
     idx = pd.date_range("2024-01-01", periods=len(closes), freq="D")
@@ -86,13 +86,11 @@ def test_falls_back_to_close_when_open_column_missing():
     results = bt.run(df, strategy_name="legacy-close-only", save=False)
 
     assert len(results["trades"]) == 1
-    # With no open column we fall back to close — signal shifted by 1 bar means
-    # entry is at bar 3's close (=110), not bar 2's close (=100).
     assert results["trades"][0]["entry_price"] == pytest.approx(110.0, rel=1e-9)
 
 
 def test_signal_on_final_bar_never_fills():
-    """A signal emitted on the last bar has no following bar to fill on."""
+    """Signal on the last bar has no following bar to fill on."""
     opens = [100, 100, 100]
     closes = [100, 100, 100]
     signals = [0, 0, 1]
@@ -104,6 +102,57 @@ def test_signal_on_final_bar_never_fills():
     bt = Backtester(initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0)
     results = bt.run(df, strategy_name="last-bar-signal", save=False)
 
-    assert results["total_trades"] == 0, (
-        "Signal on the last bar has no next bar to fill on — must not trade."
+    assert results["total_trades"] == 0
+
+
+def test_signal_on_bar_zero_fills_on_bar_one():
+    """A buy at raw bar 0 is shifted to bar 1 and fills at bar 1's open."""
+    opens = [100, 200, 200, 200, 200]
+    closes = [100, 200, 200, 200, 200]
+    signals = [1, 0, 0, 0, -1]
+    idx = pd.date_range("2024-01-01", periods=5, freq="D")
+    df = pd.DataFrame(
+        {"open": opens, "close": closes, "signal": signals}, index=idx
     )
+
+    bt = Backtester(initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0)
+    results = bt.run(df, strategy_name="bar-zero-signal", save=False)
+
+    assert len(results["trades"]) == 1
+    # Buy signal on raw bar 0 → shifted to bar 1 → fills at bar 1's open = 200.
+    # A bug that drops the bar-0 signal (e.g. starts the loop at i=1) would
+    # produce 0 trades.
+    assert results["trades"][0]["entry_price"] == pytest.approx(200.0, rel=1e-9)
+
+
+def test_buy_signal_while_long_is_ignored():
+    """Repeat buy must not double-up an existing long position."""
+    opens = [100, 100, 100, 100, 100, 100]
+    closes = [100, 100, 100, 100, 100, 100]
+    signals = [0, 1, 1, 0, 0, -1]
+    idx = pd.date_range("2024-01-01", periods=6, freq="D")
+    df = pd.DataFrame(
+        {"open": opens, "close": closes, "signal": signals}, index=idx
+    )
+
+    bt = Backtester(initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0)
+    results = bt.run(df, strategy_name="repeat-buy", save=False)
+
+    assert results["total_trades"] == 1
+
+
+def test_sell_signal_while_flat_is_ignored():
+    """Sell signal with no open position must not create a phantom trade."""
+    opens = [100, 100, 100, 100]
+    closes = [100, 100, 100, 100]
+    signals = [0, -1, 0, 0]
+    idx = pd.date_range("2024-01-01", periods=4, freq="D")
+    df = pd.DataFrame(
+        {"open": opens, "close": closes, "signal": signals}, index=idx
+    )
+
+    bt = Backtester(initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0)
+    results = bt.run(df, strategy_name="sell-while-flat", save=False)
+
+    assert results["total_trades"] == 0
+    assert results["final_capital"] == pytest.approx(1000.0, rel=1e-9)

--- a/backtest/tests/test_backtester_fills.py
+++ b/backtest/tests/test_backtester_fills.py
@@ -1,0 +1,109 @@
+"""
+Regression tests for #302 C1: look-ahead bias in the backtester.
+
+Live scheduler behavior: a signal computed on the close of bar t is read after
+the bar closes and filled as a market order that lands at ~bar t+1's open.
+The backtester must match this — filling at bar t's close on the same bar the
+signal was produced creates a free look-ahead.
+"""
+import pandas as pd
+import pytest
+
+from backtester import Backtester
+
+
+def _make_df(opens, highs, lows, closes, signals):
+    n = len(closes)
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    return pd.DataFrame(
+        {
+            "open": opens,
+            "high": highs,
+            "low": lows,
+            "close": closes,
+            "signal": signals,
+        },
+        index=idx,
+    )
+
+
+def test_fill_uses_next_bar_open_not_signal_bar_close():
+    """A buy signal on bar 2 must fill at bar 3's open, not bar 2's close."""
+    # Crafted prices: bar 2 close (=100) is distinct from bar 3 open (=110).
+    # If the backtester incorrectly fills at close, the entry price is 100.
+    # Correct behavior (fill at next bar's open) puts the entry at 110.
+    opens = [100, 100, 100, 110, 110, 110]
+    highs = [101, 101, 101, 111, 111, 111]
+    lows = [99, 99, 99, 109, 109, 109]
+    closes = [100, 100, 100, 110, 110, 110]
+    signals = [0, 0, 1, 0, 0, -1]
+
+    df = _make_df(opens, highs, lows, closes, signals)
+    bt = Backtester(initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0)
+    results = bt.run(df, strategy_name="lookahead-check", save=False)
+
+    assert len(results["trades"]) == 1
+    trade = results["trades"][0]
+    assert trade["entry_price"] == pytest.approx(110.0, rel=1e-9), (
+        "Entry price must come from the bar *after* the signal bar's open "
+        "(110), not the signal bar's close (100). A 100 here is look-ahead bias."
+    )
+
+
+def test_exit_uses_next_bar_open_not_signal_bar_close():
+    """Exit on sell signal must fill at the following bar's open."""
+    opens = [100, 100, 100, 100, 200, 300]
+    highs = [101, 101, 101, 101, 201, 301]
+    lows = [99, 99, 99, 99, 199, 299]
+    closes = [100, 100, 100, 100, 200, 300]
+    signals = [0, 1, 0, -1, 0, 0]
+
+    df = _make_df(opens, highs, lows, closes, signals)
+    bt = Backtester(initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0)
+    results = bt.run(df, strategy_name="lookahead-exit", save=False)
+
+    assert len(results["trades"]) == 1
+    trade = results["trades"][0]
+    # Entry is buy at bar 2's open (next bar after signal bar 1) → 100.
+    assert trade["entry_price"] == pytest.approx(100.0, rel=1e-9)
+    # Exit is sell at bar 4's open (next bar after signal bar 3) → 200,
+    # NOT bar 3's close (= 100, which would show a 0% trade — look-ahead-free
+    # exit sees the big gap up).
+    assert trade["exit_price"] == pytest.approx(200.0, rel=1e-9), (
+        "Exit must fill at the bar following the sell-signal bar's open (200), "
+        "not the signal bar's close (100)."
+    )
+
+
+def test_falls_back_to_close_when_open_column_missing():
+    """Legacy demos/tests feed only a 'close' column — preserve that path."""
+    closes = [100, 100, 100, 110, 110, 110]
+    signals = [0, 0, 1, 0, 0, -1]
+    idx = pd.date_range("2024-01-01", periods=len(closes), freq="D")
+    df = pd.DataFrame({"close": closes, "signal": signals}, index=idx)
+
+    bt = Backtester(initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0)
+    results = bt.run(df, strategy_name="legacy-close-only", save=False)
+
+    assert len(results["trades"]) == 1
+    # With no open column we fall back to close — signal shifted by 1 bar means
+    # entry is at bar 3's close (=110), not bar 2's close (=100).
+    assert results["trades"][0]["entry_price"] == pytest.approx(110.0, rel=1e-9)
+
+
+def test_signal_on_final_bar_never_fills():
+    """A signal emitted on the last bar has no following bar to fill on."""
+    opens = [100, 100, 100]
+    closes = [100, 100, 100]
+    signals = [0, 0, 1]
+    idx = pd.date_range("2024-01-01", periods=3, freq="D")
+    df = pd.DataFrame(
+        {"open": opens, "close": closes, "signal": signals}, index=idx
+    )
+
+    bt = Backtester(initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0)
+    results = bt.run(df, strategy_name="last-bar-signal", save=False)
+
+    assert results["total_trades"] == 0, (
+        "Signal on the last bar has no next bar to fill on — must not trade."
+    )

--- a/backtest/tests/test_options_iv_rank.py
+++ b/backtest/tests/test_options_iv_rank.py
@@ -1,10 +1,16 @@
 """
-Regression tests for #302 C3: calc_iv_rank must be a percentile rank of
-current realised vol inside a trailing lookback — matching the shape of
-adapter.get_iv_rank() in the live VolMeanReversionStrategy — not the
-``(recent / hist) * 50`` ratio the old implementation returned.
+Regression tests for issue #302 — calc_iv_rank must be a percentile rank of
+current realised vol inside a trailing lookback, not the ``(recent / hist) * 50``
+ratio the old implementation returned.
+
+Includes a parity test against the live OKX adapter's ``get_vol_metrics``
+(``platforms/okx/adapter.py``), which computes IV rank via the same
+``(current - min) / (max - min) * 100`` shape on a rolling 14-day realised-vol
+distribution.
 """
 import math
+import os
+import sys
 
 import numpy as np
 import pytest
@@ -18,8 +24,8 @@ LOOKBACK = 60
 
 def _path_from_vol_schedule(vol_per_day: list, seed: int = 0) -> list:
     """Build a close-price path where each day's log return has the given
-    (day-specific) volatility. Used to control where realised vol lands in
-    the lookback distribution.
+    (day-specific) volatility — controls where realised vol lands in the
+    lookback distribution.
     """
     rng = np.random.default_rng(seed)
     closes = [100.0]
@@ -30,21 +36,34 @@ def _path_from_vol_schedule(vol_per_day: list, seed: int = 0) -> list:
 
 
 def test_returns_default_when_history_too_short():
-    closes = [100.0 + i for i in range(50)]  # only 50 bars
+    closes = [100.0 + i for i in range(50)]
     assert calc_iv_rank(closes, recent_window=RECENT, lookback_days=LOOKBACK) == 50.0
 
 
+def test_boundary_one_below_minimum_returns_default():
+    """Need recent_window + lookback_days + 1 = 75 bars — 74 is one short."""
+    closes = [100.0 + i for i in range(74)]
+    assert calc_iv_rank(closes, recent_window=RECENT, lookback_days=LOOKBACK) == 50.0
+
+
+def test_boundary_exact_minimum_computes_rank():
+    """At exactly 75 bars the function must compute a real percentile, not default."""
+    closes = _path_from_vol_schedule([0.02] * 74, seed=11)
+    assert len(closes) == 75
+    rank = calc_iv_rank(closes, recent_window=RECENT, lookback_days=LOOKBACK)
+    assert 0.0 <= rank <= 100.0
+    # 50.0 could occur organically, but the flat-vol branch is the only way to
+    # hit *exactly* 50.0 — our noisy schedule will not.
+    assert rank != 50.0
+
+
 def test_flat_lookback_returns_neutral_50():
-    """If every day is dead flat vol is 0 everywhere → degenerate range → 50."""
+    """Flat prices → vol is 0 everywhere → degenerate range → 50."""
     closes = [100.0] * (RECENT + LOOKBACK + 5)
     assert calc_iv_rank(closes, recent_window=RECENT, lookback_days=LOOKBACK) == 50.0
 
 
 def test_recent_spike_ranks_near_100():
-    """Vol is low for the lookback then spikes in the most recent window.
-    Current realised vol should sit at the top of the distribution → rank ≈ 100.
-    """
-    # 90 total bars: first 76 at low vol, last 14 at high vol.
     sched = [0.005] * 76 + [0.08] * 14
     closes = _path_from_vol_schedule(sched, seed=1)
     rank = calc_iv_rank(closes, recent_window=RECENT, lookback_days=LOOKBACK)
@@ -52,7 +71,6 @@ def test_recent_spike_ranks_near_100():
 
 
 def test_recent_calm_ranks_near_0():
-    """Inverse: lookback is volatile then the recent window calms down → rank ≈ 0."""
     sched = [0.08] * 76 + [0.001] * 14
     closes = _path_from_vol_schedule(sched, seed=2)
     rank = calc_iv_rank(closes, recent_window=RECENT, lookback_days=LOOKBACK)
@@ -60,9 +78,8 @@ def test_recent_calm_ranks_near_0():
 
 
 def test_rank_is_clamped_to_0_100():
-    """Values outside the historical window should clamp, not go negative."""
-    # 2× ratio between recent and historical that used to produce rank=100
-    # in the old formula — verify the new one returns a legal percentile.
+    """2× recent/historical ratio returned rank=100 under the old formula —
+    verify the new percentile stays in bounds regardless."""
     sched = [0.02] * 76 + [0.04] * 14
     closes = _path_from_vol_schedule(sched, seed=3)
     rank = calc_iv_rank(closes, recent_window=RECENT, lookback_days=LOOKBACK)
@@ -70,13 +87,63 @@ def test_rank_is_clamped_to_0_100():
 
 
 def test_middle_of_distribution_ranks_around_50():
-    """Current realised vol sitting mid-range of the lookback → rank near 50."""
-    # Deterministic schedule: vol linearly walks up then current hits the midpoint.
-    # First 76 bars span 0.01 → 0.05 linearly; last 14 bars are ~0.03.
     lookback_vols = np.linspace(0.01, 0.05, 76).tolist()
     recent_vols = [0.03] * 14
     closes = _path_from_vol_schedule(lookback_vols + recent_vols, seed=4)
     rank = calc_iv_rank(closes, recent_window=RECENT, lookback_days=LOOKBACK)
-    # Wide tolerance — exact rank depends on the realised path. We only assert
-    # we're nowhere near the extremes the old broken formula hit.
+    # Wide tolerance — exact rank depends on the realised path.
     assert 20 < rank < 80, f"expected a middle value, got {rank}"
+
+
+def _live_okx_iv_rank(closes: list, window: int = 14) -> float:
+    """Inline reproduction of OKX adapter.get_vol_metrics IV-rank logic.
+
+    See platforms/okx/adapter.py:225-236. Uses every rolling window in the
+    series (no explicit lookback_days cap) because the live adapter pulls a
+    90-bar window and uses all rolling vols within it.
+    """
+    if len(closes) < window + 1:
+        return 50.0
+    returns = [math.log(closes[i] / closes[i - 1]) for i in range(1, len(closes))]
+    if len(returns) < window:
+        return 50.0
+    mean = sum(returns[-window:]) / window
+    variance = sum((r - mean) ** 2 for r in returns[-window:]) / window
+    current = math.sqrt(variance * 365) * 100
+    hvs = []
+    for i in range(len(returns) - window + 1):
+        chunk = returns[i:i + window]
+        m = sum(chunk) / window
+        v = sum((r - m) ** 2 for r in chunk) / window
+        hvs.append(math.sqrt(v * 365) * 100)
+    lo, hi = min(hvs), max(hvs)
+    if hi <= lo:
+        return 50.0
+    rank = (current - lo) / (hi - lo) * 100
+    return min(max(rank, 0.0), 100.0)
+
+
+def test_matches_live_okx_adapter_shape():
+    """Run both implementations on the same series with aligned lookback and
+    assert they agree. ``lookback_days`` is set so the rolling-vol distribution
+    spans every rolling window in the series, matching the OKX adapter's
+    behavior exactly.
+    """
+    rng = np.random.default_rng(99)
+    log_returns = rng.normal(loc=0.0, scale=0.03, size=120)
+    closes = [100.0]
+    for r in log_returns:
+        closes.append(closes[-1] * math.exp(r))
+
+    # OKX uses every rolling window in the input series. To match, set
+    # lookback_days = (total rolling windows) - 1 = len(log_returns) - window.
+    total_returns = len(closes) - 1
+    lookback = total_returns - RECENT
+
+    got = calc_iv_rank(closes, recent_window=RECENT, lookback_days=lookback)
+    expected = _live_okx_iv_rank(closes, window=RECENT)
+
+    assert got == pytest.approx(expected, abs=1e-9), (
+        f"backtest calc_iv_rank must produce the same percentile as the live "
+        f"OKX adapter on identical inputs — got {got}, expected {expected}"
+    )

--- a/backtest/tests/test_options_iv_rank.py
+++ b/backtest/tests/test_options_iv_rank.py
@@ -1,0 +1,82 @@
+"""
+Regression tests for #302 C3: calc_iv_rank must be a percentile rank of
+current realised vol inside a trailing lookback — matching the shape of
+adapter.get_iv_rank() in the live VolMeanReversionStrategy — not the
+``(recent / hist) * 50`` ratio the old implementation returned.
+"""
+import math
+
+import numpy as np
+import pytest
+
+from backtest_options import calc_iv_rank
+
+
+RECENT = 14
+LOOKBACK = 60
+
+
+def _path_from_vol_schedule(vol_per_day: list, seed: int = 0) -> list:
+    """Build a close-price path where each day's log return has the given
+    (day-specific) volatility. Used to control where realised vol lands in
+    the lookback distribution.
+    """
+    rng = np.random.default_rng(seed)
+    closes = [100.0]
+    for sigma in vol_per_day:
+        r = rng.normal(loc=0.0, scale=sigma)
+        closes.append(closes[-1] * math.exp(r))
+    return closes
+
+
+def test_returns_default_when_history_too_short():
+    closes = [100.0 + i for i in range(50)]  # only 50 bars
+    assert calc_iv_rank(closes, recent_window=RECENT, lookback_days=LOOKBACK) == 50.0
+
+
+def test_flat_lookback_returns_neutral_50():
+    """If every day is dead flat vol is 0 everywhere → degenerate range → 50."""
+    closes = [100.0] * (RECENT + LOOKBACK + 5)
+    assert calc_iv_rank(closes, recent_window=RECENT, lookback_days=LOOKBACK) == 50.0
+
+
+def test_recent_spike_ranks_near_100():
+    """Vol is low for the lookback then spikes in the most recent window.
+    Current realised vol should sit at the top of the distribution → rank ≈ 100.
+    """
+    # 90 total bars: first 76 at low vol, last 14 at high vol.
+    sched = [0.005] * 76 + [0.08] * 14
+    closes = _path_from_vol_schedule(sched, seed=1)
+    rank = calc_iv_rank(closes, recent_window=RECENT, lookback_days=LOOKBACK)
+    assert rank > 90, f"expected near-100, got {rank}"
+
+
+def test_recent_calm_ranks_near_0():
+    """Inverse: lookback is volatile then the recent window calms down → rank ≈ 0."""
+    sched = [0.08] * 76 + [0.001] * 14
+    closes = _path_from_vol_schedule(sched, seed=2)
+    rank = calc_iv_rank(closes, recent_window=RECENT, lookback_days=LOOKBACK)
+    assert rank < 10, f"expected near-0, got {rank}"
+
+
+def test_rank_is_clamped_to_0_100():
+    """Values outside the historical window should clamp, not go negative."""
+    # 2× ratio between recent and historical that used to produce rank=100
+    # in the old formula — verify the new one returns a legal percentile.
+    sched = [0.02] * 76 + [0.04] * 14
+    closes = _path_from_vol_schedule(sched, seed=3)
+    rank = calc_iv_rank(closes, recent_window=RECENT, lookback_days=LOOKBACK)
+    assert 0.0 <= rank <= 100.0
+
+
+def test_middle_of_distribution_ranks_around_50():
+    """Current realised vol sitting mid-range of the lookback → rank near 50."""
+    # Deterministic schedule: vol linearly walks up then current hits the midpoint.
+    # First 76 bars span 0.01 → 0.05 linearly; last 14 bars are ~0.03.
+    lookback_vols = np.linspace(0.01, 0.05, 76).tolist()
+    recent_vols = [0.03] * 14
+    closes = _path_from_vol_schedule(lookback_vols + recent_vols, seed=4)
+    rank = calc_iv_rank(closes, recent_window=RECENT, lookback_days=LOOKBACK)
+    # Wide tolerance — exact rank depends on the realised path. We only assert
+    # we're nowhere near the extremes the old broken formula hit.
+    assert 20 < rank < 80, f"expected a middle value, got {rank}"

--- a/backtest/tests/test_options_vol_math.py
+++ b/backtest/tests/test_options_vol_math.py
@@ -1,0 +1,58 @@
+"""
+Regression tests for #302 C2: historical volatility must use log returns and
+variance around the sample mean, matching ``numpy.std(log_returns, ddof=0)``
+annualized by ``sqrt(365)``.
+"""
+import math
+
+import numpy as np
+import pytest
+
+from backtest_options import calc_historical_vol
+
+
+def _numpy_vol(closes, window):
+    closes = np.asarray(closes[-(window + 1):], dtype=float)
+    log_returns = np.log(closes[1:] / closes[:-1])
+    return float(np.std(log_returns, ddof=0) * math.sqrt(365))
+
+
+def test_matches_numpy_for_random_walk():
+    rng = np.random.default_rng(42)
+    # 120 days of a lognormal random walk — realistic-ish price path.
+    log_returns = rng.normal(loc=0.0005, scale=0.03, size=120)
+    closes = [100.0]
+    for r in log_returns:
+        closes.append(closes[-1] * math.exp(r))
+
+    window = 30
+    got = calc_historical_vol(closes, window=window)
+    expected = _numpy_vol(closes, window=window)
+    assert got == pytest.approx(expected, rel=1e-9), (
+        "calc_historical_vol must match numpy.std(log_returns, ddof=0) * sqrt(365)."
+    )
+
+
+def test_trending_window_vol_matches_reference():
+    """A strongly trending window has non-zero mean return — this is where the
+    old ``sum(r**2)/n`` formula overstates vol. Verify the new formula matches
+    the numpy reference (variance around the sample mean) within float tolerance.
+    """
+    # Monotonic 1%/day rally — mean log return is clearly non-zero.
+    closes = [100.0 * (1.01 ** i) for i in range(60)]
+    got = calc_historical_vol(closes, window=30)
+    expected = _numpy_vol(closes, window=30)
+    assert got == pytest.approx(expected, rel=1e-9)
+
+    # Realised vol of a perfectly trending series is ~0 around the mean.
+    # (Exactly 0 would fail downstream Black-Scholes; accept < 1%.)
+    assert got < 0.01
+
+
+def test_short_history_returns_default():
+    assert calc_historical_vol([100.0, 101.0, 102.0], window=14) == 0.5
+
+
+def test_flat_prices_give_zero_vol():
+    closes = [100.0] * 50
+    assert calc_historical_vol(closes, window=14) == pytest.approx(0.0)

--- a/backtest/tests/test_options_vol_math.py
+++ b/backtest/tests/test_options_vol_math.py
@@ -1,7 +1,7 @@
 """
-Regression tests for #302 C2: historical volatility must use log returns and
-variance around the sample mean, matching ``numpy.std(log_returns, ddof=0)``
-annualized by ``sqrt(365)``.
+Regression tests for issue #302 — historical volatility must use log returns
+and variance around the sample mean, matching
+``numpy.std(log_returns, ddof=0) * sqrt(365)``.
 """
 import math
 
@@ -19,7 +19,6 @@ def _numpy_vol(closes, window):
 
 def test_matches_numpy_for_random_walk():
     rng = np.random.default_rng(42)
-    # 120 days of a lognormal random walk — realistic-ish price path.
     log_returns = rng.normal(loc=0.0005, scale=0.03, size=120)
     closes = [100.0]
     for r in log_returns:
@@ -28,29 +27,44 @@ def test_matches_numpy_for_random_walk():
     window = 30
     got = calc_historical_vol(closes, window=window)
     expected = _numpy_vol(closes, window=window)
-    assert got == pytest.approx(expected, rel=1e-9), (
-        "calc_historical_vol must match numpy.std(log_returns, ddof=0) * sqrt(365)."
-    )
+    assert got == pytest.approx(expected, rel=1e-9)
 
 
 def test_trending_window_vol_matches_reference():
-    """A strongly trending window has non-zero mean return — this is where the
-    old ``sum(r**2)/n`` formula overstates vol. Verify the new formula matches
-    the numpy reference (variance around the sample mean) within float tolerance.
-    """
-    # Monotonic 1%/day rally — mean log return is clearly non-zero.
+    """Non-zero mean return is where the old ``sum(r**2)/n`` overstated vol."""
     closes = [100.0 * (1.01 ** i) for i in range(60)]
     got = calc_historical_vol(closes, window=30)
     expected = _numpy_vol(closes, window=30)
     assert got == pytest.approx(expected, rel=1e-9)
-
-    # Realised vol of a perfectly trending series is ~0 around the mean.
-    # (Exactly 0 would fail downstream Black-Scholes; accept < 1%.)
+    # Pure trend has ~zero realised vol around the mean.
     assert got < 0.01
 
 
 def test_short_history_returns_default():
     assert calc_historical_vol([100.0, 101.0, 102.0], window=14) == 0.5
+
+
+def test_exact_minimum_length_computes_vol():
+    """len(closes) == window + 1 is the minimum valid input."""
+    window = 14
+    rng = np.random.default_rng(7)
+    log_returns = rng.normal(loc=0.0, scale=0.02, size=window)
+    closes = [100.0]
+    for r in log_returns:
+        closes.append(closes[-1] * math.exp(r))
+
+    assert len(closes) == window + 1
+    got = calc_historical_vol(closes, window=window)
+    expected = _numpy_vol(closes, window=window)
+    assert got == pytest.approx(expected, rel=1e-9)
+    assert got != 0.5  # guard: not the short-history default
+
+
+def test_one_below_minimum_returns_default():
+    """len(closes) == window — one short of the minimum valid length."""
+    window = 14
+    closes = [100.0 + i for i in range(window)]
+    assert calc_historical_vol(closes, window=window) == 0.5
 
 
 def test_flat_prices_give_zero_vol():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,4 @@ test = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["shared_tools", "platforms"]
+testpaths = ["shared_tools", "platforms", "backtest/tests"]


### PR DESCRIPTION
Closes #302.

Three critical backtest correctness bugs identified in the comprehensive backtest review. One commit per item for reviewability.

## Summary

- **C1 — Look-ahead bias** (0f09cd6): `Backtester.run` filled trades at the same bar's close that produced the signal, leaking future info into crossover strategies (sma/ema/triple_ema/macd/volume_weighted). Now shifts the signal column by +1 and fills at the next bar's open; falls back to close when only `close` is present. 4 regression tests in `backtest/tests/test_backtester_fills.py`.
- **C2 — Historical vol math** (eb47b3f): `calc_historical_vol` used simple returns and `sum(r**2)/n` (mean of squared returns, not variance). Replaced with log returns + population variance around the sample mean, matching `numpy.std(log_returns, ddof=0) * sqrt(365)`. `backtest_theta.py` inherits via its import. `THETA_HARVEST_RESULTS.md` annotated as superseded. 4 tests in `backtest/tests/test_options_vol_math.py`.
- **C3 — IV rank formula** (30acd53): `calc_iv_rank` returned `(recent/hist) * 50` — an IV ratio halved and clipped, not a percentile rank. Replaced with a true percentile: `(current - min) / (max - min) * 100` over a trailing 60-day distribution of rolling 14-day realised vol, matching `adapter.get_iv_rank()` shape used by the live `VolMeanReversionStrategy`. 6 tests in `backtest/tests/test_options_iv_rank.py`.

## Test plan

- [x] `uv run pytest` passes (326 tests; +14 new).
- [x] `python3 -m py_compile backtest/backtest_options.py backtest/backtest_theta.py backtest/backtester.py`.
- [x] Added `backtest/tests` to `testpaths` in `pyproject.toml`.
- [ ] Rerun `backtest_theta.py` against real data once this lands and update `THETA_HARVEST_RESULTS.md` with corrected figures (tracked in #304).

## Notes

- This PR is restricted to the three critical items in #302. Parity gaps (H-series) are in #303, reporting & cleanup (M/L-series) in #304.
- Acceptance criteria from #302 all addressed: shifted-signal regression test ✔, vol parity with numpy ✔, IV-rank percentile endpoints covered ✔, THETA_HARVEST_RESULTS annotated ✔.

---
Generated with: Claude Sonnet 4.6 | Effort: high