### PR TITLE
docs: scrub personal artifacts and add OpenClaw quick-flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,10 @@
 - In git worktrees, `.venv` is NOT copied — use the main repo's venv: `<main-repo>/.venv/bin/python3`
 - Python deps managed with `uv` (see `pyproject.toml` / `uv.lock`)
 
+## Quick Flow
+- **New server:** tell OpenClaw `install https://github.com/richkuo/go-trader and init`.
+
 ## Setup
-- **Quick flow for a new server:** tell OpenClaw `install https://github.com/richkuo/go-trader and init`.
 - `uv sync` — install Python deps into `.venv`
 - Copy `scheduler/config.example.json` → `scheduler/config.json` and fill in API keys
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,11 @@
 - Requires Go 1.26.2 — install via Homebrew (macOS): `brew install go@1.26` or Linux tarball: `curl -sL https://go.dev/dl/go1.26.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -`
 - Go is not in PATH via shell; use `/opt/homebrew/bin/go` directly (e.g. `cd scheduler && /opt/homebrew/bin/go build .`)
 - Python venv at `.venv/bin/python3` (used by executor.go at runtime)
-- In git worktrees, `.venv` is NOT copied — use the main repo's venv: `/Users/richardkuo/Work/openclaw/go-trader/.venv/bin/python3`
+- In git worktrees, `.venv` is NOT copied — use the main repo's venv: `<main-repo>/.venv/bin/python3`
 - Python deps managed with `uv` (see `pyproject.toml` / `uv.lock`)
 
 ## Setup
+- **Quick flow for a new server:** tell OpenClaw `install https://github.com/richkuo/go-trader and init`.
 - `uv sync` — install Python deps into `.venv`
 - Copy `scheduler/config.example.json` → `scheduler/config.json` and fill in API keys
 
@@ -137,7 +138,7 @@
 - `cd scheduler && /opt/homebrew/bin/go test ./...` — run all unit tests (must run from scheduler/ where go.mod lives; repo root has no go.mod)
 - `cd scheduler && /opt/homebrew/bin/gofmt -w <file>.go` — format after editing Go files (`-l *.go` lists all files needing formatting)
 - Multi-line Go edits with tabs: Edit tool may fail on tab-indented blocks; use heredoc form (one-liner fails on multi-line strings with quotes): `python3 << 'PYEOF'` / `content=open(f).read()` / `open(f,'w').write(content.replace(old,new,1))` / `PYEOF`
-- Strategy listing: `cd shared_strategies/spot && ../../.venv/bin/python3 strategies.py --list-json` (must use venv for numpy/pandas; in worktrees use absolute path: `/Users/richardkuo/Work/openclaw/go-trader/.venv/bin/python3`)
+- Strategy listing: `cd shared_strategies/spot && ../../.venv/bin/python3 strategies.py --list-json` (must use venv for numpy/pandas; in worktrees use absolute path: `<main-repo>/.venv/bin/python3`)
 - Smoke test: `./go-trader --once`
 - Run with config: `./go-trader --config scheduler/config.json`
 - Smoke test interactive CLI: `printf "answer1\nanswer2\n" | ./go-trader init`

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Join the Discord: [https://discord.gg/46d7Fa2dXz](https://discord.gg/46d7Fa2dXz)
 
 ## Getting Started
 
+**Quick flow for a new server:** tell OpenClaw `install https://github.com/richkuo/go-trader and init`.
+
 ### AI Agent Setup (Recommended)
 
 The fastest way to get running. Give your AI agent the [Agent Setup Guide](SKILL.md) — it's fully self-contained with the repo URL, step-by-step instructions, and exact prompts. The agent will clone the repo, install dependencies, walk you through configuration (Discord channels, strategy selection, risk settings), build the binary, and start the service.

--- a/SKILL.md
+++ b/SKILL.md
@@ -4,6 +4,8 @@
 
 This is a self-contained setup guide for AI agents. Give this file to any AI coding agent and it will handle the full installation — cloning the repo, installing dependencies, configuring Discord/strategies/risk, building, and starting the service.
 
+**Quick flow for a new server:** tell OpenClaw `install https://github.com/richkuo/go-trader and init`.
+
 **For OpenClaw agents:** This is the skill entry point. Read it when a user says "set up go-trader", "install go trading bot", or "configure go-trader".
 
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -419,8 +419,8 @@ If the agent is running inside OpenClaw and Discord was configured, add the chan
 
 Or via CLI:
 ```bash
-openclaw config set "channels.discord.guilds.${GUILD_ID}.channels.${SPOT_CHANNEL}.requireMention" false
-openclaw config set "channels.discord.guilds.${GUILD_ID}.channels.${OPTIONS_CHANNEL}.requireMention" false
+openclaw config set "channels.discord.guilds.<GUILD_ID>.channels.<SPOT_CHANNEL>.requireMention" false
+openclaw config set "channels.discord.guilds.<GUILD_ID>.channels.<OPTIONS_CHANNEL>.requireMention" false
 ```
 
 ### 7c. Confirm with User

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -934,8 +934,8 @@ func TestLoadConfigLeaderboardSummaries(t *testing.T) {
 			{"id": "hl-sma-btc", "type": "perps", "platform": "hyperliquid", "script": "x.py", "capital": 1000, "max_drawdown_pct": 10}
 		],
 		"leaderboard_summaries": [
-			{"platform": "hyperliquid", "ticker": null, "top_n": 10, "channel": "1490924126712365115", "frequency": "6h"},
-			{"platform": "hyperliquid", "ticker": "eth", "top_n": 5, "channel": "1477762393181523981", "frequency": "12h"}
+			{"platform": "hyperliquid", "ticker": null, "top_n": 10, "channel": "11111111111111111", "frequency": "6h"},
+			{"platform": "hyperliquid", "ticker": "eth", "top_n": 5, "channel": "22222222222222222", "frequency": "12h"}
 		]
 	}`
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {


### PR DESCRIPTION
## Summary

- Replace hardcoded `/Users/richardkuo/...` venv paths in `CLAUDE.md` with portable `<main-repo>` placeholder so the doc works on any machine
- Replace real-looking Discord channel IDs in `scheduler/config_test.go` test fixture with obvious placeholders (`11111...`/`22222...`) — the test never asserts on the `channel` field so behaviour is unchanged
- Add **Quick flow for a new server** one-liner to `README.md`, `SKILL.md`, and `CLAUDE.md`: *tell OpenClaw `install https://github.com/richkuo/go-trader and init`*

## Test plan

- [ ] `go test ./...` passes (CI)
- [ ] Verify no `richkuo`-specific paths remain in tracked doc files

---
Generated with: Claude Opus 4.7 | Effort: 20