### PR TITLE
ci: fix claude-md-management plugin marketplace reference

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -163,10 +163,12 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: "Use the Skill tool to invoke the 'claude-md-management:revise-claude-md' skill. Review the changes made in this session (use git log and git diff to inspect them) and update CLAUDE.md with any new patterns, conventions, or important context learned."
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugin_marketplaces: |
+            https://github.com/anthropics/claude-code.git
+            https://github.com/anthropics/claude-plugins-official.git
           plugins: |
             code-review@claude-code-plugins
-            claude-md-management@claude-code-plugins
+            claude-md-management@claude-plugins-official
           claude_args: --model ${{ steps.resolve_model.outputs.model_id }} --allowedTools "Bash(git *),Edit,Read,Grep,Glob,Write"
 
       - name: Append model/effort footer to Claude comment


### PR DESCRIPTION
## Summary

- `claude-md-management` lives in `anthropics/claude-plugins-official` (marketplace name `claude-plugins-official`), not in `claude-code-plugins`
- Adds `https://github.com/anthropics/claude-plugins-official.git` to `plugin_marketplaces`
- Corrects plugin reference from `claude-md-management@claude-code-plugins` → `claude-md-management@claude-plugins-official`
- Restores original prompt that explicitly invokes the skill (so marketplace failures stay loud/visible)

Fixes the failure seen in https://github.com/richkuo/go-trader/actions/runs/24601632018

## Test plan

- [ ] Trigger `@claude review` on a PR and confirm the `Revise CLAUDE.md with session learnings` step installs both plugins without error
- [ ] Confirm the sub-agent announces `Using claude-md-management:revise-claude-md` in its output

---
Generated with: Claude Opus 4.7 (1M) | Effort: medium