### PR TITLE
leaderboard: skip price fetch when no strategies configured

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -213,6 +213,10 @@ func main() {
 			fmt.Fprintf(os.Stderr, "No notification backends configured\n")
 			os.Exit(1)
 		}
+		if len(state.Strategies) == 0 {
+			fmt.Fprintln(os.Stderr, "No strategies configured; nothing to post")
+			os.Exit(0)
+		}
 		prices := fetchPricesForSummary(cfg)
 		if err := PostLeaderboard(cfg, state, prices, notifier); err != nil {
 			fmt.Fprintf(os.Stderr, "Leaderboard post failed: %v\n", err)


### PR DESCRIPTION
Add early return before `fetchPricesForSummary` in the `--leaderboard` CLI path when `state.Strategies` is empty, skipping wasteful price fetches for operators running with zero configured strategies.

Closes #317

Generated with [Claude Code](https://claude.ai/code)