### PR TITLE
ci: skip CLAUDE.md revision when no code changes

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -128,6 +128,11 @@ jobs:
         if: steps.verify_invocation.outputs.invoked == 'true'
         run: git checkout -- uv.lock
 
+      - name: Record HEAD sha before Claude runs
+        if: steps.verify_invocation.outputs.invoked == 'true'
+        id: pre_claude
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code
         if: steps.verify_invocation.outputs.invoked == 'true'
         id: claude
@@ -157,8 +162,23 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: --model ${{ steps.resolve_model.outputs.model_id }} --effort ${{ steps.resolve_model.outputs.effort }} --allowedTools "Bash(go *),Bash(cd scheduler && go *),Bash(uv run *),Bash(python3 *),Bash(.venv/bin/python3 *),Bash(gofmt *),Bash(cd scheduler && gofmt *),Bash(git *)"
 
-      - name: Revise CLAUDE.md with session learnings
+      - name: Detect if Claude made commits
         if: steps.verify_invocation.outputs.invoked == 'true' && steps.claude.outcome == 'success'
+        id: claude_changes
+        env:
+          PRE_SHA: ${{ steps.pre_claude.outputs.sha }}
+        run: |
+          git fetch --quiet origin "$GITHUB_REF_NAME" 2>/dev/null || true
+          CURRENT_SHA=$(git rev-parse HEAD)
+          if [ "$PRE_SHA" != "$CURRENT_SHA" ] || ! git diff --quiet || [ -n "$(git status --porcelain)" ]; then
+            echo "made_commits=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "made_commits=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Claude made no code changes — skipping CLAUDE.md revision."
+          fi
+
+      - name: Revise CLAUDE.md with session learnings
+        if: steps.verify_invocation.outputs.invoked == 'true' && steps.claude.outcome == 'success' && steps.claude_changes.outputs.made_commits == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Record HEAD sha before the main Claude step and compare after to detect whether Claude actually made changes
- Skip the `Revise CLAUDE.md with session learnings` step when HEAD didn't move and the worktree is clean (i.e. pure PR review / Q&A invocations)
- Emits a `::notice::` in the GH Actions log when skipping, so the reason is visible

## Test plan

- [ ] Comment `@claude review` on a PR and confirm the Revise step is skipped with the notice
- [ ] Comment `@claude fix ...` that actually changes code and confirm the Revise step runs

---
Generated with: Claude Opus 4.7 (1M) | Effort: medium