### PR TITLE
leaderboard: skip auto-post silently when no strategies configured

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -958,19 +958,28 @@ func main() {
 		// post without the lock held so Discord HTTPS latency can't stall
 		// other goroutines.
 		if postLeaderboard {
+			stampDate := func() {
+				mu.Lock()
+				state.LastLeaderboardPostDate = time.Now().UTC().Format("2006-01-02")
+				mu.Unlock()
+			}
 			if len(cfg.Strategies) == 0 {
 				fmt.Println("[leaderboard] Auto-post skipped: no strategies configured")
+				stampDate()
 			} else {
-				fmt.Printf("[leaderboard] Auto-posting daily leaderboard (configured time: %s UTC)\n", cfg.LeaderboardPostTime)
 				mu.RLock()
 				lbMessages := BuildLeaderboardMessages(cfg, state, prices)
 				mu.RUnlock()
-				if err := postLeaderboardMessages(lbMessages, notifier); err != nil {
-					fmt.Printf("[WARN] Leaderboard auto-post failed: %v\n", err)
+				if len(lbMessages) == 0 {
+					fmt.Println("[leaderboard] Auto-post skipped: no strategy state to leaderboard yet")
+					stampDate()
 				} else {
-					mu.Lock()
-					state.LastLeaderboardPostDate = time.Now().UTC().Format("2006-01-02")
-					mu.Unlock()
+					fmt.Printf("[leaderboard] Auto-posting daily leaderboard (configured time: %s UTC)\n", cfg.LeaderboardPostTime)
+					if err := postLeaderboardMessages(lbMessages, notifier); err != nil {
+						fmt.Printf("[WARN] Leaderboard auto-post failed: %v\n", err)
+					} else {
+						stampDate()
+					}
 				}
 			}
 		}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -958,16 +958,20 @@ func main() {
 		// post without the lock held so Discord HTTPS latency can't stall
 		// other goroutines.
 		if postLeaderboard {
-			fmt.Printf("[leaderboard] Auto-posting daily leaderboard (configured time: %s UTC)\n", cfg.LeaderboardPostTime)
-			mu.RLock()
-			lbMessages := BuildLeaderboardMessages(cfg, state, prices)
-			mu.RUnlock()
-			if err := postLeaderboardMessages(lbMessages, notifier); err != nil {
-				fmt.Printf("[WARN] Leaderboard auto-post failed: %v\n", err)
+			if len(cfg.Strategies) == 0 {
+				fmt.Println("[leaderboard] Auto-post skipped: no strategies configured")
 			} else {
-				mu.Lock()
-				state.LastLeaderboardPostDate = time.Now().UTC().Format("2006-01-02")
-				mu.Unlock()
+				fmt.Printf("[leaderboard] Auto-posting daily leaderboard (configured time: %s UTC)\n", cfg.LeaderboardPostTime)
+				mu.RLock()
+				lbMessages := BuildLeaderboardMessages(cfg, state, prices)
+				mu.RUnlock()
+				if err := postLeaderboardMessages(lbMessages, notifier); err != nil {
+					fmt.Printf("[WARN] Leaderboard auto-post failed: %v\n", err)
+				} else {
+					mu.Lock()
+					state.LastLeaderboardPostDate = time.Now().UTC().Format("2006-01-02")
+					mu.Unlock()
+				}
 			}
 		}
 


### PR DESCRIPTION
When the daily leaderboard auto-post fires but no strategies are configured, log at INFO level instead of surfacing a WARN. Previously `PostLeaderboard` returned an error ("no strategies to leaderboard") which the auto-post path logged as [WARN] every day.

Closes #318

Generated with [Claude Code](https://claude.ai/code)