### PR TITLE
leaderboard: persist LastLeaderboardPostDate immediately after post

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -965,8 +965,14 @@ func main() {
 			if err := postLeaderboardMessages(lbMessages, notifier); err != nil {
 				fmt.Printf("[WARN] Leaderboard auto-post failed: %v\n", err)
 			} else {
+				// Issue #319: persist LastLeaderboardPostDate immediately so a
+				// crash before the next cycle's SaveState cannot cause a duplicate
+				// daily post on restart.
 				mu.Lock()
 				state.LastLeaderboardPostDate = time.Now().UTC().Format("2006-01-02")
+				if err := SaveStateWithDB(state, cfg, stateDB); err != nil {
+					fmt.Printf("[WARN] Leaderboard post-date save failed: %v\n", err)
+				}
 				mu.Unlock()
 			}
 		}


### PR DESCRIPTION
Previously `LastLeaderboardPostDate` was set in memory but only flushed to SQLite on the next cycle's `SaveStateWithDB`. A crash between the post and the next save could cause the daily leaderboard to post again on restart.

Fix: save state immediately inside the same `mu.Lock()` that sets the field.

Closes #319

Generated with [Claude Code](https://claude.ai/code)