### PR TITLE
leaderboard: rename top10/bottom10 map keys to top/bottom

### DIFF
--- a/scheduler/leaderboard.go
+++ b/scheduler/leaderboard.go
@@ -29,10 +29,9 @@ func leaderboardTopN(cfg *Config) int {
 }
 
 // BuildLeaderboardMessages computes the aggregate top-N / bottom-N leaderboard
-// messages from the current state. Returned map keys are "top10" and "bottom10"
-// (names retained for continuity with the Discord channel routing keys — the
-// actual entry count is controlled by Discord.LeaderboardTopN). Returns nil if
-// no strategies have state. Issue #313 moved this to an on-demand compute
+// messages from the current state. Returned map keys are "top" and "bottom";
+// the actual entry count is controlled by Discord.LeaderboardTopN. Returns nil
+// if no strategies have state. Issue #313 moved this to an on-demand compute
 // (previously written to leaderboard.json every cycle).
 func BuildLeaderboardMessages(cfg *Config, state *AppState, prices map[string]float64) map[string]string {
 	var allEntries []LeaderboardEntry
@@ -67,13 +66,13 @@ func BuildLeaderboardMessages(cfg *Config, state *AppState, prices map[string]fl
 
 	topN := leaderboardTopN(cfg)
 	return map[string]string{
-		"top10":    formatAllTimeMessage("🏆", "Top All-Time Performers", allEntries, true, topN),
-		"bottom10": formatAllTimeMessage("💀", "Bottom All-Time Performers", allEntries, false, topN),
+		"top":    formatAllTimeMessage("🏆", "Top All-Time Performers", allEntries, true, topN),
+		"bottom": formatAllTimeMessage("💀", "Bottom All-Time Performers", allEntries, false, topN),
 	}
 }
 
 // formatLeaderboardMessage formats a leaderboard message for a sorted slice of entries.
-// Used by formatAllTimeMessage (top10/bottom10) and BuildLeaderboardSummary (per-platform summaries).
+// Used by formatAllTimeMessage (top/bottom) and BuildLeaderboardSummary (per-platform summaries).
 // Callers are responsible for passing a positive topN (see leaderboardTopN).
 func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, showType bool, topN int) string {
 	// Sort by PnL% descending.
@@ -206,7 +205,7 @@ func postLeaderboardMessages(messages map[string]string, notifier *MultiNotifier
 	// Routing is decided per-backend inside the notifier: backends with a
 	// dedicated leaderboard channel route there, others fall back to broadcast
 	// across all configured channels. Issue #310.
-	order := []string{"top10", "bottom10"}
+	order := []string{"top", "bottom"}
 	first := true
 	for _, key := range order {
 		msg, ok := messages[key]

--- a/scheduler/leaderboard_test.go
+++ b/scheduler/leaderboard_test.go
@@ -54,13 +54,13 @@ func TestBuildLeaderboardMessages(t *testing.T) {
 		t.Fatal("BuildLeaderboardMessages returned nil")
 	}
 
-	// Only aggregate top10/bottom10 messages are produced; per-product sections
+	// Only aggregate top/bottom messages are produced; per-product sections
 	// were removed in issue #310.
-	if _, ok := messages["top10"]; !ok {
-		t.Error("Missing top10 leaderboard message")
+	if _, ok := messages["top"]; !ok {
+		t.Error("Missing top leaderboard message")
 	}
-	if _, ok := messages["bottom10"]; !ok {
-		t.Error("Missing bottom10 leaderboard message")
+	if _, ok := messages["bottom"]; !ok {
+		t.Error("Missing bottom leaderboard message")
 	}
 	for _, key := range []string{"spot", "perps", "options", "futures"} {
 		if _, ok := messages[key]; ok {
@@ -68,24 +68,24 @@ func TestBuildLeaderboardMessages(t *testing.T) {
 		}
 	}
 
-	top10Msg := messages["top10"]
-	if top10Msg == "" {
-		t.Fatal("top10 message is empty")
+	topMsg := messages["top"]
+	if topMsg == "" {
+		t.Fatal("top message is empty")
 	}
-	if !containsStr(top10Msg, "sma-btc") {
-		t.Error("top10 message should contain sma-btc")
+	if !containsStr(topMsg, "sma-btc") {
+		t.Error("top message should contain sma-btc")
 	}
-	if !containsStr(top10Msg, "Top All-Time Performers") {
-		t.Error("top10 message should contain title")
+	if !containsStr(topMsg, "Top All-Time Performers") {
+		t.Error("top message should contain title")
 	}
-	if !containsStr(top10Msg, "TOTAL") {
-		t.Error("top10 message should contain TOTAL row")
+	if !containsStr(topMsg, "TOTAL") {
+		t.Error("top message should contain TOTAL row")
 	}
-	if !containsStr(top10Msg, "winning") {
-		t.Error("top10 message should contain winning/losing/flat counts")
+	if !containsStr(topMsg, "winning") {
+		t.Error("top message should contain winning/losing/flat counts")
 	}
-	if !containsStr(top10Msg, "Trades") {
-		t.Error("top10 message should contain Trades column header")
+	if !containsStr(topMsg, "Trades") {
+		t.Error("top message should contain Trades column header")
 	}
 }
 
@@ -191,33 +191,33 @@ func TestBuildLeaderboardMessages_TopN(t *testing.T) {
 		t.Fatal("BuildLeaderboardMessages returned nil")
 	}
 
-	top10Msg := messages["top10"]
-	if top10Msg == "" {
-		t.Fatal("Expected non-empty top10 all-time message")
+	topMsg := messages["top"]
+	if topMsg == "" {
+		t.Fatal("Expected non-empty top all-time message")
 	}
 	// Top 3 by PnL%: sma-s07, sma-s06, sma-s05.
-	if !containsStr(top10Msg, "sma-s07") {
-		t.Error("top10 all-time should contain sma-s07 when top_n=3")
+	if !containsStr(topMsg, "sma-s07") {
+		t.Error("top all-time should contain sma-s07 when top_n=3")
 	}
-	if !containsStr(top10Msg, "sma-s05") {
-		t.Error("top10 all-time should contain sma-s05 when top_n=3")
+	if !containsStr(topMsg, "sma-s05") {
+		t.Error("top all-time should contain sma-s05 when top_n=3")
 	}
-	if containsStr(top10Msg, "sma-s04") {
-		t.Error("top10 all-time should not contain sma-s04 when top_n=3")
+	if containsStr(topMsg, "sma-s04") {
+		t.Error("top all-time should not contain sma-s04 when top_n=3")
 	}
 
-	bottom10Msg := messages["bottom10"]
-	if bottom10Msg == "" {
-		t.Fatal("Expected non-empty bottom10 all-time message")
+	bottomMsg := messages["bottom"]
+	if bottomMsg == "" {
+		t.Fatal("Expected non-empty bottom all-time message")
 	}
-	if !containsStr(bottom10Msg, "sma-s00") {
-		t.Error("bottom10 all-time should contain sma-s00 when top_n=3")
+	if !containsStr(bottomMsg, "sma-s00") {
+		t.Error("bottom all-time should contain sma-s00 when top_n=3")
 	}
-	if !containsStr(bottom10Msg, "sma-s02") {
-		t.Error("bottom10 all-time should contain sma-s02 when top_n=3")
+	if !containsStr(bottomMsg, "sma-s02") {
+		t.Error("bottom all-time should contain sma-s02 when top_n=3")
 	}
-	if containsStr(bottom10Msg, "sma-s03") {
-		t.Error("bottom10 all-time should not contain sma-s03 when top_n=3")
+	if containsStr(bottomMsg, "sma-s03") {
+		t.Error("bottom all-time should not contain sma-s03 when top_n=3")
 	}
 }
 
@@ -241,7 +241,7 @@ func leaderboardTestFixture() (*Config, *AppState, map[string]float64) {
 
 // TestPostLeaderboard_DedicatedChannel verifies that when DiscordConfig.LeaderboardChannel
 // is set (wired into notifierBackend.leaderboardChannel), PostLeaderboard routes
-// the top10/bottom10 messages to the dedicated channel instead of broadcasting.
+// the top/bottom messages to the dedicated channel instead of broadcasting.
 func TestPostLeaderboard_DedicatedChannel(t *testing.T) {
 	cfg, state, prices := leaderboardTestFixture()
 
@@ -256,7 +256,7 @@ func TestPostLeaderboard_DedicatedChannel(t *testing.T) {
 		t.Fatalf("PostLeaderboard: %v", err)
 	}
 
-	// Only top10 + bottom10 should land on the dedicated channel.
+	// Only top + bottom should land on the dedicated channel.
 	if len(mock.messages) != 2 {
 		t.Fatalf("expected 2 messages on dedicated channel, got %d: %v", len(mock.messages), mock.messages)
 	}
@@ -268,7 +268,7 @@ func TestPostLeaderboard_DedicatedChannel(t *testing.T) {
 }
 
 // TestPostLeaderboard_FallbackRouting verifies that when no LeaderboardChannel
-// is configured, top10/bottom10 broadcast to all configured channels.
+// is configured, top/bottom broadcast to all configured channels.
 func TestPostLeaderboard_FallbackRouting(t *testing.T) {
 	cfg, state, prices := leaderboardTestFixture()
 
@@ -282,12 +282,12 @@ func TestPostLeaderboard_FallbackRouting(t *testing.T) {
 		t.Fatalf("PostLeaderboard: %v", err)
 	}
 
-	// top10 → broadcast to 2 channels; bottom10 → broadcast to 2 channels = 4.
+	// top → broadcast to 2 channels; bottom → broadcast to 2 channels = 4.
 	if len(mock.messages) != 4 {
 		t.Fatalf("expected 4 messages from fallback routing, got %d: %v", len(mock.messages), mock.messages)
 	}
 
-	// Each channel should receive both top10 and bottom10 content.
+	// Each channel should receive both top and bottom content.
 	for _, ch := range []string{"spot-ch", "perps-ch"} {
 		seen := 0
 		for _, m := range mock.messages {
@@ -296,7 +296,7 @@ func TestPostLeaderboard_FallbackRouting(t *testing.T) {
 			}
 		}
 		if seen != 2 {
-			t.Errorf("channel %s: expected 2 messages (top10+bottom10), got %d", ch, seen)
+			t.Errorf("channel %s: expected 2 messages (top+bottom), got %d", ch, seen)
 		}
 	}
 }
@@ -335,7 +335,7 @@ func TestPostLeaderboard_MixedBackends(t *testing.T) {
 		t.Fatalf("PostLeaderboard: %v", err)
 	}
 
-	// Discord: top10 + bottom10 should land on discord-lb.
+	// Discord: top + bottom should land on discord-lb.
 	if len(discord.messages) != 2 {
 		t.Fatalf("expected 2 discord messages on discord-lb, got %d: %v", len(discord.messages), discord.messages)
 	}
@@ -345,7 +345,7 @@ func TestPostLeaderboard_MixedBackends(t *testing.T) {
 		}
 	}
 
-	// Telegram: top10 and bottom10 each broadcast to all 4 channels = 8 total.
+	// Telegram: top and bottom each broadcast to all 4 channels = 8 total.
 	if len(telegram.messages) != 8 {
 		t.Fatalf("expected 8 telegram messages from broadcast routing, got %d: %v", len(telegram.messages), telegram.messages)
 	}
@@ -358,7 +358,7 @@ func TestPostLeaderboard_MixedBackends(t *testing.T) {
 			}
 		}
 		if seen != 2 {
-			t.Errorf("telegram channel %s: expected 2 messages (top10+bottom10), got %d", ch, seen)
+			t.Errorf("telegram channel %s: expected 2 messages (top+bottom), got %d", ch, seen)
 		}
 	}
 }

--- a/scheduler/notifier.go
+++ b/scheduler/notifier.go
@@ -147,7 +147,7 @@ func (m *MultiNotifier) SendToChannel(platform, stratType, content string) {
 }
 
 // PostLeaderboardBroadcast routes an all-time leaderboard message
-// (top10/bottom10) on a per-backend basis. For each backend: if a dedicated
+// (top/bottom) on a per-backend basis. For each backend: if a dedicated
 // leaderboardChannel is configured, the message is sent there once; otherwise
 // it broadcasts to all unique channels on that backend.
 func (m *MultiNotifier) PostLeaderboardBroadcast(content string) {


### PR DESCRIPTION
Drop the misleading `10` suffix from `BuildLeaderboardMessages` return keys now that the map is in-memory only (leaderboard.json removed in #313).

Updates all call sites in leaderboard.go, leaderboard_test.go, and notifier.go.

Closes #321

Generated with [Claude Code](https://claude.ai/code)