### PR TITLE
test: assert error message in TestPostLeaderboard_NoStrategies

### DIFF
--- a/scheduler/leaderboard_test.go
+++ b/scheduler/leaderboard_test.go
@@ -372,8 +372,12 @@ func TestPostLeaderboard_NoStrategies(t *testing.T) {
 	mock := &mockNotifier{}
 	notifier := NewMultiNotifier(notifierBackend{notifier: mock, channels: map[string]string{"spot": "spot-ch"}})
 
-	if err := PostLeaderboard(cfg, state, nil, notifier); err == nil {
+	err := PostLeaderboard(cfg, state, nil, notifier)
+	if err == nil {
 		t.Error("expected error when no strategies configured")
+	}
+	if err != nil && !strings.Contains(err.Error(), "no strategies to leaderboard") {
+		t.Errorf("unexpected error message: %q", err.Error())
 	}
 	if len(mock.messages) != 0 {
 		t.Errorf("expected no messages sent, got %d", len(mock.messages))


### PR DESCRIPTION
Adds a `strings.Contains` check on the error message returned by `PostLeaderboard` when no strategies are configured, so that rewording "no strategies to leaderboard" will be caught by the test.

Closes #320

Generated with [Claude Code](https://claude.ai/code)