### PR TITLE
Add triple_ema_bidir strategy for bidirectional perps trend trading

### DIFF
--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -328,6 +328,11 @@ DEFAULT_PARAM_RANGES = {
         "mid_period": [15, 21, 30],
         "long_period": [40, 55, 80],
     },
+    "triple_ema_bidir": {
+        "short_period": [5, 8, 13],
+        "mid_period": [15, 21, 30],
+        "long_period": [40, 55, 80],
+    },
     "rsi_macd_combo": {
         "rsi_period": [10, 14],
         "rsi_oversold": [30, 35, 40],

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -129,6 +129,7 @@ type StrategyConfig struct {
 	MaxDrawdownPct  float64                `json:"max_drawdown_pct"`
 	IntervalSeconds int                    `json:"interval_seconds,omitempty"` // per-strategy override (0 = use global)
 	HTFFilter       bool                   `json:"htf_filter,omitempty"`       // higher-timeframe trend filter
+	AllowShorts     bool                   `json:"allow_shorts,omitempty"`     // perps only: opt-in to bidirectional execution — signal=-1 from flat opens a short, long+(-1) closes-and-flips. Default false preserves close-long-only behavior for strategies like triple_ema that emit -1 only as a long-exit (#328)
 	Leverage        float64                `json:"leverage,omitempty"`         // perps leverage multiplier (default 1 = no leverage); used for notional sizing and margin-based valuation (#254)
 	Params          map[string]interface{} `json:"params,omitempty"`           // custom strategy parameters passed to Python
 	ThetaHarvest    *ThetaHarvestConfig    `json:"theta_harvest,omitempty"`

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -37,6 +37,7 @@ var knownShortNames = map[string]string{
 	"mean_reversion":        "mr",
 	"volume_weighted":       "vw",
 	"triple_ema":            "tema",
+	"triple_ema_bidir":      "temab",
 	"rsi_macd_combo":        "rmc",
 	"vol_mean_reversion":    "vol",
 	"momentum_options":      "mom",
@@ -111,6 +112,7 @@ var defaultOptionsStrategies = []stratDef{
 
 var defaultPerpsStrategies = []stratDef{
 	{ID: "momentum", ShortName: "momentum"},
+	{ID: "triple_ema_bidir", ShortName: "temab"},
 	{ID: "chart_pattern", ShortName: "cpat"},
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 	{ID: "delta_neutral_funding", ShortName: "dnf"},
@@ -126,6 +128,7 @@ var defaultFuturesStrategies = []stratDef{
 	{ID: "rsi", ShortName: "rsi"},
 	{ID: "macd", ShortName: "macd"},
 	{ID: "breakout", ShortName: "bo"},
+	{ID: "triple_ema_bidir", ShortName: "temab"},
 	{ID: "stoch_rsi", ShortName: "stochrsi"},
 	{ID: "ichimoku_cloud", ShortName: "ichi"},
 	{ID: "order_blocks", ShortName: "ob"},

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -62,6 +62,18 @@ var knownShortNames = map[string]string{
 	"donchian_breakout":     "dbo",
 }
 
+// bidirectionalPerpsStrategies lists strategy IDs that emit signal=-1 as a
+// short-entry (not just a long-exit). Configs generated for these strategies
+// set AllowShorts=true so ExecutePerpsSignal opens shorts from flat instead
+// of skipping the signal (#328).
+var bidirectionalPerpsStrategies = map[string]bool{
+	"triple_ema_bidir": true,
+}
+
+func isBidirectionalPerpsStrategy(id string) bool {
+	return bidirectionalPerpsStrategies[id]
+}
+
 // deriveShortName returns a short abbreviation for a strategy ID.
 // Uses knownShortNames override map; falls back to first letter of each word.
 func deriveShortName(id string) string {
@@ -398,6 +410,11 @@ func generateConfig(opts InitOptions) *Config {
 		}
 		for _, stratID := range opts.PerpsStrategies {
 			shortName := deriveShortName(stratID)
+			// Strategies that emit bidirectional signals must opt in to
+			// short-opening execution, otherwise ExecutePerpsSignal drops
+			// their signal=-1 from flat and the strategy becomes effectively
+			// long-only at the executor layer (#328 review feedback).
+			allowShorts := isBidirectionalPerpsStrategy(stratID)
 			for _, assetName := range opts.Assets {
 				id := fmt.Sprintf("hl-%s-%s", shortName, strings.ToLower(assetName))
 				cfg.Strategies = append(cfg.Strategies, StrategyConfig{
@@ -410,6 +427,7 @@ func generateConfig(opts InitOptions) *Config {
 					MaxDrawdownPct:  opts.PerpsDrawdown,
 					IntervalSeconds: 3600,
 					Leverage:        perpsLeverage,
+					AllowShorts:     allowShorts,
 				})
 			}
 		}

--- a/scheduler/init_test.go
+++ b/scheduler/init_test.go
@@ -571,6 +571,42 @@ func TestDeriveShortName(t *testing.T) {
 	}
 }
 
+// #328 — triple_ema_bidir must generate AllowShorts=true in perps configs so
+// ExecutePerpsSignal opens shorts from flat. Long-only strategies must keep
+// AllowShorts=false so they can't silently flip into short positions.
+func TestGenerateConfig_PerpsAllowShortsWiring(t *testing.T) {
+	opts := baseOpts()
+	opts.EnableSpot = false
+	opts.EnablePerps = true
+	opts.Assets = []string{"ETH"}
+	opts.PerpsMode = "paper"
+	opts.PerpsStrategies = []string{"triple_ema_bidir", "triple_ema", "rsi_macd_combo"}
+
+	cfg := generateConfig(opts)
+
+	want := map[string]bool{
+		"hl-temab-eth": true,  // bidirectional — must allow shorts
+		"hl-tema-eth":  false, // long-only — must NOT allow shorts
+		"hl-rmc-eth":   false, // long-only — must NOT allow shorts
+	}
+	seen := map[string]bool{}
+	for _, s := range cfg.Strategies {
+		expected, ok := want[s.ID]
+		if !ok {
+			continue
+		}
+		seen[s.ID] = true
+		if s.AllowShorts != expected {
+			t.Errorf("%s AllowShorts = %v, want %v", s.ID, s.AllowShorts, expected)
+		}
+	}
+	for id := range want {
+		if !seen[id] {
+			t.Errorf("expected generated config for %s, not found", id)
+		}
+	}
+}
+
 func TestGenerateConfig_PerpsMultipleStrategies(t *testing.T) {
 	opts := baseOpts()
 	opts.EnableSpot = false

--- a/scheduler/init_test.go
+++ b/scheduler/init_test.go
@@ -556,6 +556,7 @@ func TestDeriveShortName(t *testing.T) {
 		{"mean_reversion", "mr"},
 		{"volume_weighted", "vw"},
 		{"triple_ema", "tema"},
+		{"triple_ema_bidir", "temab"},
 		{"rsi_macd_combo", "rmc"},
 		{"vol_mean_reversion", "vol"},
 		{"momentum_options", "mom"},

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1418,7 +1418,7 @@ func runHyperliquidCheck(sc StrategyConfig, prices map[string]float64, logger *S
 // issue #298 — 0.716 ETH of live fills were lost this way because the
 // "already long, skipping buy" branch sat AFTER RunHyperliquidExecute.
 func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, price, cash, posQty float64, posSide string, logger *StrategyLogger) (*HyperliquidExecuteResult, bool) {
-	if reason := PerpsOrderSkipReason(result.Signal, posSide); reason != "" {
+	if reason := PerpsOrderSkipReason(result.Signal, posSide, sc.AllowShorts); reason != "" {
 		logger.Info("Skipping live order for %s: %s", result.Symbol, reason)
 		return nil, false
 	}
@@ -1429,13 +1429,16 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	if sc.Type == "perps" && sc.Leverage > 0 {
 		sizingLeverage = sc.Leverage
 	}
+	// sell-from-flat path: AllowShorts lets signal=-1 open a short sized from
+	// the leveraged cash budget, mirroring the buy path. Without AllowShorts
+	// the skip-reason above already returned for flat+(-1), so we only reach
+	// this else-block with an existing long to close.
+	openingShort := !isBuy && sc.AllowShorts && posQty <= 0
 	var size float64
-	if isBuy {
-		// #254: sizing uses leveraged notional = cash * leverage * 0.95.
-		// The actual margin locked on-chain will be notional/leverage.
+	if isBuy || openingShort {
 		budget := cash * sizingLeverage * 0.95
 		if budget < 1 || price <= 0 {
-			logger.Info("Insufficient cash ($%.2f) for live buy", cash)
+			logger.Info("Insufficient cash ($%.2f) for live %s", cash, map[bool]string{true: "buy", false: "sell (short-open)"}[isBuy])
 			return nil, false
 		}
 		size = budget / price
@@ -1499,7 +1502,7 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 		fillFee = fill.Fee
 	}
 
-	trades, err := ExecutePerpsSignal(s, result.Signal, result.Symbol, fillPrice, leverage, fillQty, fillOID, fillFee, logger)
+	trades, err := ExecutePerpsSignal(s, result.Signal, result.Symbol, fillPrice, leverage, fillQty, fillOID, fillFee, sc.AllowShorts, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -1931,7 +1934,7 @@ func runOKXCheck(sc StrategyConfig, prices map[string]float64, logger *StrategyL
 func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQty float64, posSide string, logger *StrategyLogger) (*OKXExecuteResult, bool) {
 	var skip string
 	if sc.Type == "perps" {
-		skip = PerpsOrderSkipReason(result.Signal, posSide)
+		skip = PerpsOrderSkipReason(result.Signal, posSide, sc.AllowShorts)
 	} else {
 		skip = SpotOrderSkipReason(result.Signal, posSide)
 	}
@@ -1945,11 +1948,14 @@ func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQt
 	if sc.Type == "perps" && sc.Leverage > 0 {
 		sizingLeverage = sc.Leverage
 	}
+	// Mirror hyperliquid: AllowShorts on perps lets signal=-1 open a short
+	// sized from leveraged cash budget (#328).
+	openingShort := !isBuy && sc.Type == "perps" && sc.AllowShorts && posQty <= 0
 	var size float64
-	if isBuy {
+	if isBuy || openingShort {
 		budget := cash * sizingLeverage * 0.95
 		if budget < 1 || price <= 0 {
-			logger.Info("Insufficient cash ($%.2f) for live buy", cash)
+			logger.Info("Insufficient cash ($%.2f) for live %s", cash, map[bool]string{true: "buy", false: "sell (short-open)"}[isBuy])
 			return nil, false
 		}
 		size = budget / price
@@ -2002,7 +2008,7 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, result *OKXResult, ex
 		}
 		// OKXFill does not carry OID/fee today; pass empties and let SaveState
 		// backfill from any future adapter extension via the usual path.
-		trades, err = ExecutePerpsSignal(s, result.Signal, result.Symbol, fillPrice, leverage, fillQty, "", 0, logger)
+		trades, err = ExecutePerpsSignal(s, result.Signal, result.Symbol, fillPrice, leverage, fillQty, "", 0, sc.AllowShorts, logger)
 	} else {
 		trades, err = ExecuteSpotSignal(s, result.Signal, result.Symbol, fillPrice, fillQty, logger)
 	}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1429,25 +1429,10 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	if sc.Type == "perps" && sc.Leverage > 0 {
 		sizingLeverage = sc.Leverage
 	}
-	// sell-from-flat path: AllowShorts lets signal=-1 open a short sized from
-	// the leveraged cash budget, mirroring the buy path. Without AllowShorts
-	// the skip-reason above already returned for flat+(-1), so we only reach
-	// this else-block with an existing long to close.
-	openingShort := !isBuy && sc.AllowShorts && posQty <= 0
-	var size float64
-	if isBuy || openingShort {
-		budget := cash * sizingLeverage * 0.95
-		if budget < 1 || price <= 0 {
-			logger.Info("Insufficient cash ($%.2f) for live %s", cash, map[bool]string{true: "buy", false: "sell (short-open)"}[isBuy])
-			return nil, false
-		}
-		size = budget / price
-	} else {
-		if posQty <= 0 {
-			logger.Info("No position to close for %s", result.Symbol)
-			return nil, false
-		}
-		size = posQty
+	size, ok, reason := perpsLiveOrderSize(result.Signal, price, cash, posQty, sizingLeverage, posSide, sc.AllowShorts)
+	if !ok {
+		logger.Info("%s for %s", reason, result.Symbol)
+		return nil, false
 	}
 
 	side := "buy"
@@ -1948,23 +1933,33 @@ func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQt
 	if sc.Type == "perps" && sc.Leverage > 0 {
 		sizingLeverage = sc.Leverage
 	}
-	// Mirror hyperliquid: AllowShorts on perps lets signal=-1 open a short
-	// sized from leveraged cash budget (#328).
-	openingShort := !isBuy && sc.Type == "perps" && sc.AllowShorts && posQty <= 0
 	var size float64
-	if isBuy || openingShort {
-		budget := cash * sizingLeverage * 0.95
-		if budget < 1 || price <= 0 {
-			logger.Info("Insufficient cash ($%.2f) for live %s", cash, map[bool]string{true: "buy", false: "sell (short-open)"}[isBuy])
+	if sc.Type == "perps" {
+		var ok bool
+		var reason string
+		size, ok, reason = perpsLiveOrderSize(result.Signal, price, cash, posQty, sizingLeverage, posSide, sc.AllowShorts)
+		if !ok {
+			logger.Info("%s for %s", reason, result.Symbol)
 			return nil, false
 		}
-		size = budget / price
 	} else {
-		if posQty <= 0 {
-			logger.Info("No position to close for %s", result.Symbol)
-			return nil, false
+		// Spot sizing: buy opens from cash, sell closes posQty. AllowShorts
+		// does not apply to spot — SpotOrderSkipReason already blocked any
+		// signal=-1 without a long above.
+		if isBuy {
+			budget := cash * sizingLeverage * 0.95
+			if budget < 1 || price <= 0 {
+				logger.Info("Insufficient cash ($%.2f) for live buy %s", cash, result.Symbol)
+				return nil, false
+			}
+			size = budget / price
+		} else {
+			if posQty <= 0 {
+				logger.Info("No position to close for %s", result.Symbol)
+				return nil, false
+			}
+			size = posQty
 		}
-		size = posQty
 	}
 
 	side := "buy"

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -608,24 +608,28 @@ func main() {
 					var hlCash float64
 					var hlPosQty float64
 					var hlPosSide string
+					var hlAvgCost float64
 					if sc.Type == "perps" && hyperliquidIsLive(sc.Args) {
 						hlCash = stratState.Cash
 						if sym := hyperliquidSymbol(sc.Args); sym != "" {
 							if pos, ok := stratState.Positions[sym]; ok {
 								hlPosQty = pos.Quantity
 								hlPosSide = pos.Side
+								hlAvgCost = pos.AvgCost
 							}
 						}
 					}
 					var okxCash float64
 					var okxPosQty float64
 					var okxPosSide string
+					var okxAvgCost float64
 					if sc.Platform == "okx" && okxIsLive(sc.Args) {
 						okxCash = stratState.Cash
 						if sym := okxSymbol(sc.Args); sym != "" {
 							if pos, ok := stratState.Positions[sym]; ok {
 								okxPosQty = pos.Quantity
 								okxPosSide = pos.Side
+								okxAvgCost = pos.AvgCost
 							}
 						}
 					}
@@ -685,7 +689,7 @@ func main() {
 								var execResult *OKXExecuteResult
 								liveExecFailed := false
 								if okxIsLive(sc.Args) && result.Signal != 0 {
-									if er, ok2 := runOKXExecuteOrder(sc, result, price, okxCash, okxPosQty, okxPosSide, logger); ok2 {
+									if er, ok2 := runOKXExecuteOrder(sc, result, price, okxCash, okxPosQty, okxPosSide, okxAvgCost, logger); ok2 {
 										execResult = er
 									} else {
 										liveExecFailed = true
@@ -738,7 +742,7 @@ func main() {
 								var execResult *OKXExecuteResult
 								liveExecFailed := false
 								if okxIsLive(sc.Args) && result.Signal != 0 {
-									if er, ok2 := runOKXExecuteOrder(sc, result, price, okxCash, okxPosQty, okxPosSide, logger); ok2 {
+									if er, ok2 := runOKXExecuteOrder(sc, result, price, okxCash, okxPosQty, okxPosSide, okxAvgCost, logger); ok2 {
 										execResult = er
 									} else {
 										liveExecFailed = true
@@ -755,7 +759,7 @@ func main() {
 							var execResult *HyperliquidExecuteResult
 							liveExecFailed := false
 							if hyperliquidIsLive(sc.Args) && result.Signal != 0 {
-								if er, ok2 := runHyperliquidExecuteOrder(sc, result, price, hlCash, hlPosQty, hlPosSide, logger); ok2 {
+								if er, ok2 := runHyperliquidExecuteOrder(sc, result, price, hlCash, hlPosQty, hlPosSide, hlAvgCost, logger); ok2 {
 									execResult = er
 								} else {
 									liveExecFailed = true
@@ -1417,7 +1421,7 @@ func runHyperliquidCheck(sc StrategyConfig, prices map[string]float64, logger *S
 // Trade record, leaving state silently behind actual exchange holdings. See
 // issue #298 — 0.716 ETH of live fills were lost this way because the
 // "already long, skipping buy" branch sat AFTER RunHyperliquidExecute.
-func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, price, cash, posQty float64, posSide string, logger *StrategyLogger) (*HyperliquidExecuteResult, bool) {
+func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, price, cash, posQty float64, posSide string, avgCost float64, logger *StrategyLogger) (*HyperliquidExecuteResult, bool) {
 	if reason := PerpsOrderSkipReason(result.Signal, posSide, sc.AllowShorts); reason != "" {
 		logger.Info("Skipping live order for %s: %s", result.Symbol, reason)
 		return nil, false
@@ -1429,7 +1433,7 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	if sc.Type == "perps" && sc.Leverage > 0 {
 		sizingLeverage = sc.Leverage
 	}
-	size, ok, reason := perpsLiveOrderSize(result.Signal, price, cash, posQty, sizingLeverage, posSide, sc.AllowShorts)
+	size, ok, reason := perpsLiveOrderSize(result.Signal, price, cash, posQty, avgCost, sizingLeverage, posSide, sc.AllowShorts)
 	if !ok {
 		logger.Info("%s for %s", reason, result.Symbol)
 		return nil, false
@@ -1916,7 +1920,7 @@ func runOKXCheck(sc StrategyConfig, prices map[string]float64, logger *StrategyL
 // ExecutePerpsSignal that must be mirrored to avoid the #298 bug class
 // (live fill placed but no Trade recorded because the in-memory execution
 // returned 0). See #300.
-func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQty float64, posSide string, logger *StrategyLogger) (*OKXExecuteResult, bool) {
+func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQty float64, posSide string, avgCost float64, logger *StrategyLogger) (*OKXExecuteResult, bool) {
 	var skip string
 	if sc.Type == "perps" {
 		skip = PerpsOrderSkipReason(result.Signal, posSide, sc.AllowShorts)
@@ -1937,7 +1941,7 @@ func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQt
 	if sc.Type == "perps" {
 		var ok bool
 		var reason string
-		size, ok, reason = perpsLiveOrderSize(result.Signal, price, cash, posQty, sizingLeverage, posSide, sc.AllowShorts)
+		size, ok, reason = perpsLiveOrderSize(result.Signal, price, cash, posQty, avgCost, sizingLeverage, posSide, sc.AllowShorts)
 		if !ok {
 			logger.Info("%s for %s", reason, result.Symbol)
 			return nil, false

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -442,7 +442,10 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 			execPrice = price
 			qty = fillQty - flipCloseQty
 			if qty <= 0 {
-				logger.Info("Flip fill qty (%.6f) did not cover new long after closing short (%.6f); leaving flat", fillQty, flipCloseQty)
+				// Partial-fill on a flip order — the scheduler intended to flip
+				// but the exchange only closed. Warn so regressions are visible
+				// in the strategy log (matching risk.go's Warn-level signals).
+				logger.Warn("Flip fill qty (%.6f) did not cover new long after closing short (%.6f); leaving flat", fillQty, flipCloseQty)
 				return tradesExecuted, nil
 			}
 		} else {
@@ -557,7 +560,7 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 			execPrice = price
 			qty = fillQty - flipCloseQty
 			if qty <= 0 {
-				logger.Info("Flip fill qty (%.6f) did not cover new short after closing long (%.6f); leaving flat", fillQty, flipCloseQty)
+				logger.Warn("Flip fill qty (%.6f) did not cover new short after closing long (%.6f); leaving flat", fillQty, flipCloseQty)
 				return tradesExecuted, nil
 			}
 		} else {

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -187,22 +187,30 @@ func PortfolioValue(s *StrategyState, prices map[string]float64) float64 {
 // in-memory execution path returns 0 and no Trade is recorded, leaving
 // virtual state permanently behind actual exchange positions (#298).
 //
-// posSide is "" when no position exists; "long" or "short" otherwise. The
-// conditions here mirror the SIDE-BASED skip conditions in
-// ExecutePerpsSignal (the "already long, skipping buy" and "no long position
-// to sell" branches). The `s.Cash < 1` branch inside the open-long path is
-// NOT mirrored here because cash after a flip-close leg cannot be derived
-// from (signal, posSide) alone — live callers already guard cash upstream
-// before placing the order (see runHyperliquidExecuteOrder). If a new
-// side-based no-op branch is added to ExecutePerpsSignal, add it here too.
-func PerpsOrderSkipReason(signal int, posSide string) string {
+// posSide is "" when no position exists; "long" or "short" otherwise.
+// allowShorts toggles the branches that ExecutePerpsSignal exposes when
+// bidirectional execution is enabled (#328):
+//   - allowShorts=false (legacy): signal=-1 with no long is a skip (close-long-only).
+//   - allowShorts=true: signal=-1 with no position opens a short; signal=-1
+//     while already short is a skip (mirrors "already long, skipping buy").
+//
+// The `s.Cash < 1` branch inside the open paths is NOT mirrored here because
+// cash after a flip-close leg cannot be derived from (signal, posSide) alone —
+// live callers guard cash upstream before placing the order (see
+// runHyperliquidExecuteOrder). If a new side-based no-op branch is added to
+// ExecutePerpsSignal, add it here too.
+func PerpsOrderSkipReason(signal int, posSide string, allowShorts bool) string {
 	switch signal {
 	case 1:
 		if posSide == "long" {
 			return "already long, skipping buy"
 		}
 	case -1:
-		if posSide != "long" {
+		if allowShorts {
+			if posSide == "short" {
+				return "already short, skipping sell"
+			}
+		} else if posSide != "long" {
 			return "no long position to sell, skipping"
 		}
 	}
@@ -288,15 +296,21 @@ func FuturesOrderSkipReason(signal int, posSide string) string {
 // row therefore carries empty exchange metadata — accurate, since no
 // distinct exchange order closed it. See #289.
 //
-// In current live mode the flip branch is unreachable: signal=-1 does not
-// open shorts, and runHyperliquidExecuteOrder sizes buys as a fresh open,
-// not close+open. The policy above exists so the invariant survives any
-// future adapter that does model flips as two fills or adds short-open.
-// The same policy is correct if an adapter ever reports a single atomic
-// net-flip fill (one OID, one fee, exchange reduces short and opens long
-// in one shot) — the single real fee lands on the opener, which is the
-// trade that represents the one exchange action.
-func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float64, leverage float64, fillQty float64, fillOID string, fillFee float64, logger *StrategyLogger) (int, error) {
+// allowShorts toggles bidirectional semantics (#328). When true, signal=-1
+// from flat opens a short, and signal=-1 on an existing long flips to a
+// short after closing (mirrored to the existing signal=1 + short branch
+// which already closes-and-flips). When false (default), signal=-1 only
+// closes a long and never opens a short — the legacy long-only behavior
+// that strategies like triple_ema and rsi_macd_combo depend on.
+//
+// Fill metadata rationale: one live fill = one exchange fee; if a signal
+// encounters an opposite-side position, ExecutePerpsSignal synthesizes a
+// close+open pair for in-memory accounting, but the real exchange action
+// was the single fill that opened the new side. Stamping the same fee on
+// both legs would double-count it in analytics. The close leg therefore
+// carries empty exchange metadata — accurate, since no distinct exchange
+// order closed it. See #289.
+func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float64, leverage float64, fillQty float64, fillOID string, fillFee float64, allowShorts bool, logger *StrategyLogger) (int, error) {
 	if signal == 0 {
 		return 0, nil
 	}
@@ -401,7 +415,14 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 		logger.Info("BUY %s: %.6f @ $%.2f (%.1fx, notional $%.2f, fee $%.2f)", symbol, qty, execPrice, leverage, notional, fee)
 		tradesExecuted++
 
-	} else if signal == -1 { // Sell — close long (no auto-open-short; matches current spot wrapper)
+	} else if signal == -1 { // Sell
+		// Dedupe: already short and allowShorts means nothing new to do (mirrors
+		// the "already long, skipping buy" branch above).
+		if pos, exists := s.Positions[symbol]; exists && pos.Side == "short" && allowShorts {
+			logger.Info("Already short %s (qty=%.6f), skipping sell", symbol, pos.Quantity)
+			return 0, nil
+		}
+		// Close long if exists — realize PnL.
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
 			var execPrice float64
 			if fillQty > 0 {
@@ -414,6 +435,16 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 			pnl -= fee
 			s.Cash += pnl
 			now := time.Now().UTC()
+			// When flipping to short, the close-long leg is the synthetic half of
+			// a single real exchange fill — same rationale as the close-short leg
+			// in the signal=1 branch. Stamp exchange metadata only on the new
+			// opener so the fee is not double-counted.
+			var closeOID string
+			var closeFee float64
+			if !allowShorts {
+				closeOID = fillOID
+				closeFee = fillFee
+			}
 			trade := Trade{
 				Timestamp:       now,
 				StrategyID:      s.ID,
@@ -424,8 +455,8 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 				Value:           pos.Quantity * execPrice,
 				TradeType:       "perps",
 				Details:         fmt.Sprintf("Close long, PnL: $%.2f (fee $%.2f)", pnl, fee),
-				ExchangeOrderID: fillOID,
-				ExchangeFee:     fillFee,
+				ExchangeOrderID: closeOID,
+				ExchangeFee:     closeFee,
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -433,9 +464,60 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 			delete(s.Positions, symbol)
 			logger.Info("SELL %s: %.6f @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, pos.Quantity, execPrice, fee, pnl)
 			tradesExecuted++
-		} else {
+		} else if !allowShorts {
 			logger.Info("No long position in %s to sell, skipping", symbol)
+			return tradesExecuted, nil
 		}
+		// Open short when bidirectional execution is enabled.
+		if !allowShorts {
+			return tradesExecuted, nil
+		}
+		if s.Cash < 1 {
+			logger.Info("Insufficient cash ($%.2f) to open short %s perp", s.Cash, symbol)
+			return tradesExecuted, nil
+		}
+		var execPrice, qty float64
+		if fillQty > 0 {
+			execPrice = price
+			qty = fillQty
+		} else {
+			execPrice = ApplySlippage(price)
+			if execPrice <= 0 {
+				return tradesExecuted, nil
+			}
+			budget := s.Cash * leverage * 0.95
+			qty = budget / execPrice
+		}
+		notional := qty * execPrice
+		fee := CalculatePlatformSpotFee(feePlatform, notional)
+		s.Cash -= fee // margin-based: only fee leaves cash
+		now := time.Now().UTC()
+		s.Positions[symbol] = &Position{
+			Symbol:          symbol,
+			Quantity:        qty,
+			AvgCost:         execPrice,
+			Side:            "short",
+			Multiplier:      1,
+			Leverage:        leverage,
+			OwnerStrategyID: s.ID,
+			OpenedAt:        now,
+		}
+		trade := Trade{
+			Timestamp:       now,
+			StrategyID:      s.ID,
+			Symbol:          symbol,
+			Side:            "sell",
+			Quantity:        qty,
+			Price:           execPrice,
+			Value:           notional,
+			TradeType:       "perps",
+			Details:         fmt.Sprintf("Open short %.6f @ $%.2f (%.1fx, fee $%.2f)", qty, execPrice, leverage, fee),
+			ExchangeOrderID: fillOID,
+			ExchangeFee:     fillFee,
+		}
+		RecordTrade(s, trade)
+		logger.Info("SELL %s: %.6f @ $%.2f (%.1fx, notional $%.2f, fee $%.2f) [open short]", symbol, qty, execPrice, leverage, notional, fee)
+		tradesExecuted++
 	}
 	return tradesExecuted, nil
 }

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -270,12 +270,16 @@ func perpsLiveOrderSize(signal int, price, cash, posQty, avgCost, sizingLeverage
 		}
 		budget := effectiveCash * sizingLeverage * 0.95
 		if budget < 1 || price <= 0 {
+			// Flip + catastrophic drawdown (realized loss wipes out post-close
+			// margin): the new side can't be sized, but the close leg still
+			// must fire — otherwise a deep-underwater bidirectional strategy
+			// would be worse at exiting than a legacy long-only one. Degrade
+			// to close-only sizing as the docstring promises.
+			if flipping {
+				return posQty, true, ""
+			}
 			label := "buy"
-			if flipping && isBuy {
-				label = "buy (flip)"
-			} else if flipping {
-				label = "sell (flip)"
-			} else if !isBuy {
+			if !isBuy {
 				label = "sell (short-open)"
 			}
 			return 0, false, fmt.Sprintf("insufficient cash ($%.2f effective) for live %s", effectiveCash, label)
@@ -362,15 +366,13 @@ func FuturesOrderSkipReason(signal int, posSide string) string {
 // leveraged budget with slippage applied.
 //
 // fillOID/fillFee carry exchange metadata for live fills (empty/zero for
-// paper). They are stamped ONLY on the trade that represents the new
-// position — the opening trade on signal=1, the closing trade on
-// signal=-1. The rationale: one live fill = one exchange fee; if a buy
-// signal encounters an existing short, ExecutePerpsSignal synthesizes a
-// close-short + open-long pair for in-memory accounting, but the real
-// exchange action was the single fill that opened the long. Stamping the
-// same fee on both legs would double-count it in analytics. The close-leg
-// row therefore carries empty exchange metadata — accurate, since no
-// distinct exchange order closed it. See #289.
+// paper). One live fill = one exchange fee; if a signal encounters an
+// opposite-side position, ExecutePerpsSignal synthesizes a close+open
+// pair for in-memory accounting, but the real exchange action was the
+// single fill that opened the new side. Stamping the same fee on both
+// synthetic legs would double-count it in analytics — so only the
+// opening trade carries fillOID/fillFee; the close leg carries empty
+// exchange metadata. See #289.
 //
 // allowShorts toggles bidirectional semantics (#328). When true, signal=-1
 // from flat opens a short, and signal=-1 on an existing long flips to a
@@ -378,14 +380,6 @@ func FuturesOrderSkipReason(signal int, posSide string) string {
 // which already closes-and-flips). When false (default), signal=-1 only
 // closes a long and never opens a short — the legacy long-only behavior
 // that strategies like triple_ema and rsi_macd_combo depend on.
-//
-// Fill metadata rationale: one live fill = one exchange fee; if a signal
-// encounters an opposite-side position, ExecutePerpsSignal synthesizes a
-// close+open pair for in-memory accounting, but the real exchange action
-// was the single fill that opened the new side. Stamping the same fee on
-// both legs would double-count it in analytics. The close leg therefore
-// carries empty exchange metadata — accurate, since no distinct exchange
-// order closed it. See #289.
 func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float64, leverage float64, fillQty float64, fillOID string, fillFee float64, allowShorts bool, logger *StrategyLogger) (int, error) {
 	if signal == 0 {
 		return 0, nil
@@ -509,8 +503,9 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 		tradesExecuted++
 
 	} else if signal == -1 { // Sell
-		// Dedupe: already short and allowShorts means nothing new to do (mirrors
-		// the "already long, skipping buy" branch above).
+		// Dedupe: already short and allowShorts means nothing new to do —
+		// symmetric mirror of the "Already long ... skipping buy" branch at
+		// portfolio.go:408 in the signal==1 block above.
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "short" && allowShorts {
 			logger.Info("Already short %s (qty=%.6f), skipping sell", symbol, pos.Quantity)
 			return 0, nil

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -227,8 +227,8 @@ func PerpsOrderSkipReason(signal int, posSide string, allowShorts bool) string {
 //   - Close-only (legacy, !AllowShorts):
 //   - signal=-1 + long   → size = posQty
 //   - Flip (AllowShorts + opposite-side position):
-//   - signal=1 + short   → size = posQty + cash*lev*0.95/price
-//   - signal=-1 + long   → size = posQty + cash*lev*0.95/price
+//   - signal=1 + short   → size = posQty + (cash+expectedClosePnL)*lev*0.95/price
+//   - signal=-1 + long   → size = posQty + (cash+expectedClosePnL)*lev*0.95/price
 //
 // The flip branch is what this helper exists for: without `posQty + newSize`
 // a bidirectional scheduler tells ExecutePerpsSignal to virtually close+open
@@ -237,8 +237,15 @@ func PerpsOrderSkipReason(signal int, posSide string, allowShorts bool) string {
 // `posQty + newSize` settles to the new side at the intended notional and
 // matches the virtual-state transition exactly — see PR #330 review.
 //
+// avgCost is the entry price of the existing position (0 when flat). For a
+// flip, the new-side budget uses `cash + expectedClosePnL` rather than raw
+// `cash` so a losing long→short flip at higher leverage doesn't over-size
+// past post-close exchange margin. expectedClosePnL can be negative; if it
+// zeroes out the post-close budget the flip degrades to close-only sizing
+// (reported as insufficient cash rather than silently undersizing).
+//
 // Returns (size, ok); when ok is false `reason` is a log-ready string.
-func perpsLiveOrderSize(signal int, price, cash, posQty, sizingLeverage float64, posSide string, allowShorts bool) (size float64, ok bool, reason string) {
+func perpsLiveOrderSize(signal int, price, cash, posQty, avgCost, sizingLeverage float64, posSide string, allowShorts bool) (size float64, ok bool, reason string) {
 	isBuy := signal == 1
 	flipping := allowShorts && posQty > 0 && ((isBuy && posSide == "short") || (!isBuy && posSide == "long"))
 	// Fresh open: buy always fresh-sizes (legacy buy-vs-migrated-short kept
@@ -248,7 +255,20 @@ func perpsLiveOrderSize(signal int, price, cash, posQty, sizingLeverage float64,
 	openingFresh := isBuy || (!isBuy && allowShorts && posQty <= 0)
 
 	if openingFresh || flipping {
-		budget := cash * sizingLeverage * 0.95
+		effectiveCash := cash
+		if flipping {
+			// Close leg realizes PnL before the new side opens on-chain;
+			// size the new side against post-close margin so a losing flip
+			// at higher leverage doesn't exceed exchange capacity.
+			var closePnL float64
+			if isBuy { // short → long: profit when price < avgCost
+				closePnL = posQty * (avgCost - price)
+			} else { // long → short: profit when price > avgCost
+				closePnL = posQty * (price - avgCost)
+			}
+			effectiveCash = cash + closePnL
+		}
+		budget := effectiveCash * sizingLeverage * 0.95
 		if budget < 1 || price <= 0 {
 			label := "buy"
 			if flipping && isBuy {
@@ -258,7 +278,7 @@ func perpsLiveOrderSize(signal int, price, cash, posQty, sizingLeverage float64,
 			} else if !isBuy {
 				label = "sell (short-open)"
 			}
-			return 0, false, fmt.Sprintf("insufficient cash ($%.2f) for live %s", cash, label)
+			return 0, false, fmt.Sprintf("insufficient cash ($%.2f effective) for live %s", effectiveCash, label)
 		}
 		newSize := budget / price
 		if flipping {

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -217,6 +217,62 @@ func PerpsOrderSkipReason(signal int, posSide string, allowShorts bool) string {
 	return ""
 }
 
+// perpsLiveOrderSize returns the market-order size to place for a live perps
+// execution. PerpsOrderSkipReason must already have passed (no skip). The
+// four cases:
+//
+//   - Fresh open (posQty <= 0):
+//   - signal=1           → size = cash*lev*0.95/price (long from flat)
+//   - signal=-1 + AllowShorts → size = cash*lev*0.95/price (short from flat)
+//   - Close-only (legacy, !AllowShorts):
+//   - signal=-1 + long   → size = posQty
+//   - Flip (AllowShorts + opposite-side position):
+//   - signal=1 + short   → size = posQty + cash*lev*0.95/price
+//   - signal=-1 + long   → size = posQty + cash*lev*0.95/price
+//
+// The flip branch is what this helper exists for: without `posQty + newSize`
+// a bidirectional scheduler tells ExecutePerpsSignal to virtually close+open
+// in one step, but the exchange only closes (size = newSize or size = posQty
+// picked either way would desync). A single net-flip order of
+// `posQty + newSize` settles to the new side at the intended notional and
+// matches the virtual-state transition exactly — see PR #330 review.
+//
+// Returns (size, ok); when ok is false `reason` is a log-ready string.
+func perpsLiveOrderSize(signal int, price, cash, posQty, sizingLeverage float64, posSide string, allowShorts bool) (size float64, ok bool, reason string) {
+	isBuy := signal == 1
+	flipping := allowShorts && posQty > 0 && ((isBuy && posSide == "short") || (!isBuy && posSide == "long"))
+	// Fresh open: buy always fresh-sizes (legacy buy-vs-migrated-short kept
+	// the pre-#330 fresh-open sizing for that edge case), or AllowShorts
+	// short-from-flat. Sell + !AllowShorts + no long is unreachable —
+	// PerpsOrderSkipReason handled it.
+	openingFresh := isBuy || (!isBuy && allowShorts && posQty <= 0)
+
+	if openingFresh || flipping {
+		budget := cash * sizingLeverage * 0.95
+		if budget < 1 || price <= 0 {
+			label := "buy"
+			if flipping && isBuy {
+				label = "buy (flip)"
+			} else if flipping {
+				label = "sell (flip)"
+			} else if !isBuy {
+				label = "sell (short-open)"
+			}
+			return 0, false, fmt.Sprintf("insufficient cash ($%.2f) for live %s", cash, label)
+		}
+		newSize := budget / price
+		if flipping {
+			return posQty + newSize, true, ""
+		}
+		return newSize, true, ""
+	}
+	// close-only: signal=-1 + long + !allowShorts
+	if posQty <= 0 {
+		return 0, false, "no position to close"
+	}
+	return posQty, true, ""
+}
+
 // SpotOrderSkipReason mirrors PerpsOrderSkipReason for spot. ExecuteSpotSignal's
 // side-based skip branches ("already long, skipping buy" at signal=1,
 // "No long position to sell, skipping" at signal=-1) must be consulted BEFORE
@@ -326,6 +382,13 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 		feePlatform = "okx-perps"
 	}
 
+	// flipCloseQty lets the open leg subtract the close-leg qty from a live
+	// fill when the exchange executes a single net-flip order of
+	// (posQty + newSize). Only set when AllowShorts=true — legacy paths (e.g.
+	// a migrated short being closed by a long-only strategy) keep fillQty as
+	// the open-side-only qty to preserve #289's single-fee-per-fill invariant.
+	var flipCloseQty float64
+
 	if signal == 1 { // Buy — go long (close short first if any)
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
 			logger.Info("Already long %s (qty=%.6f), skipping buy", symbol, pos.Quantity)
@@ -333,6 +396,9 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 		}
 		// Close short if exists — realize PnL only (no notional swing).
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "short" {
+			if allowShorts {
+				flipCloseQty = pos.Quantity
+			}
 			var execPrice float64
 			if fillQty > 0 {
 				execPrice = price
@@ -374,7 +440,11 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 		var execPrice, qty float64
 		if fillQty > 0 {
 			execPrice = price
-			qty = fillQty
+			qty = fillQty - flipCloseQty
+			if qty <= 0 {
+				logger.Info("Flip fill qty (%.6f) did not cover new long after closing short (%.6f); leaving flat", fillQty, flipCloseQty)
+				return tradesExecuted, nil
+			}
 		} else {
 			execPrice = ApplySlippage(price)
 			if execPrice <= 0 {
@@ -424,6 +494,9 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 		}
 		// Close long if exists — realize PnL.
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
+			if allowShorts {
+				flipCloseQty = pos.Quantity
+			}
 			var execPrice float64
 			if fillQty > 0 {
 				execPrice = price
@@ -464,14 +537,17 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 			delete(s.Positions, symbol)
 			logger.Info("SELL %s: %.6f @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, pos.Quantity, execPrice, fee, pnl)
 			tradesExecuted++
-		} else if !allowShorts {
-			logger.Info("No long position in %s to sell, skipping", symbol)
-			return tradesExecuted, nil
 		}
-		// Open short when bidirectional execution is enabled.
+		// Legacy long-only path: whether we closed a long or had nothing to
+		// close, AllowShorts=false never opens a short. Log only when we did
+		// nothing (close-path already logged).
 		if !allowShorts {
+			if tradesExecuted == 0 {
+				logger.Info("No long position in %s to sell, skipping", symbol)
+			}
 			return tradesExecuted, nil
 		}
+		// Open short (AllowShorts=true).
 		if s.Cash < 1 {
 			logger.Info("Insufficient cash ($%.2f) to open short %s perp", s.Cash, symbol)
 			return tradesExecuted, nil
@@ -479,7 +555,11 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 		var execPrice, qty float64
 		if fillQty > 0 {
 			execPrice = price
-			qty = fillQty
+			qty = fillQty - flipCloseQty
+			if qty <= 0 {
+				logger.Info("Flip fill qty (%.6f) did not cover new short after closing long (%.6f); leaving flat", fillQty, flipCloseQty)
+				return tradesExecuted, nil
+			}
 		} else {
 			execPrice = ApplySlippage(price)
 			if execPrice <= 0 {

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -1088,31 +1088,33 @@ func TestExecutePerpsSignalAlreadyShortIsInertNoOp(t *testing.T) {
 // virtual close+open lands against an exchange fill that only closed,
 // leaving virtual state ahead of the exchange (same class of desync as #298).
 func TestPerpsLiveOrderSize_FlipIncludesCloseLeg(t *testing.T) {
-	// cash=1000, leverage=1, price=2000 → newSize = 1000*0.95/2000 = 0.475
+	// cash=1000, leverage=1, price=2000, avgCost=2000 (no PnL on close) →
+	// newSize = 1000*0.95/2000 = 0.475
 	cases := []struct {
 		name       string
 		signal     int
 		posQty     float64
+		avgCost    float64
 		posSide    string
 		allowShort bool
 		wantSize   float64
 		wantOK     bool
 	}{
-		// Fresh opens
-		{"long_from_flat", 1, 0, "", false, 0.475, true},
-		{"short_from_flat_allowed", -1, 0, "", true, 0.475, true},
+		// Fresh opens — avgCost is 0 (no position)
+		{"long_from_flat", 1, 0, 0, "", false, 0.475, true},
+		{"short_from_flat_allowed", -1, 0, 0, "", true, 0.475, true},
 		// Close-only (legacy)
-		{"close_long_legacy", -1, 0.3, "long", false, 0.3, true},
-		// Flips (the reviewer's blocker)
-		{"flip_long_to_short", -1, 0.5, "long", true, 0.975, true}, // 0.5 + 0.475
-		{"flip_short_to_long", 1, 0.5, "short", true, 0.975, true}, // 0.5 + 0.475
+		{"close_long_legacy", -1, 0.3, 2000, "long", false, 0.3, true},
+		// Flat-PnL flips: avgCost == price so effectiveCash == cash.
+		{"flip_long_to_short_flat_pnl", -1, 0.5, 2000, "long", true, 0.975, true}, // 0.5 + 0.475
+		{"flip_short_to_long_flat_pnl", 1, 0.5, 2000, "short", true, 0.975, true}, // 0.5 + 0.475
 		// Legacy buy against migrated short is NOT a flip (AllowShorts=false):
 		// sizing stays at newSize — the legacy behavior pre-dating #328.
-		{"buy_vs_short_legacy_not_flip", 1, 0.5, "short", false, 0.475, true},
+		{"buy_vs_short_legacy_not_flip", 1, 0.5, 2000, "short", false, 0.475, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			size, ok, reason := perpsLiveOrderSize(tc.signal, 2000, 1000, tc.posQty, 1.0, tc.posSide, tc.allowShort)
+			size, ok, reason := perpsLiveOrderSize(tc.signal, 2000, 1000, tc.posQty, tc.avgCost, 1.0, tc.posSide, tc.allowShort)
 			if ok != tc.wantOK {
 				t.Fatalf("ok = %v (reason=%q), want %v", ok, reason, tc.wantOK)
 			}
@@ -1128,11 +1130,57 @@ func TestPerpsLiveOrderSize_FlipIncludesCloseLeg(t *testing.T) {
 // (the old close-only behavior that silently broke bidirectional execution).
 func TestPerpsLiveOrderSize_FlipLongToShortExceedsCloseOnly(t *testing.T) {
 	posQty := 0.5
-	size, ok, _ := perpsLiveOrderSize(-1, 2000, 1000, posQty, 1.0, "long", true)
+	size, ok, _ := perpsLiveOrderSize(-1, 2000, 1000, posQty, 2000, 1.0, "long", true)
 	if !ok {
 		t.Fatal("expected ok")
 	}
 	if size <= posQty {
 		t.Errorf("flip size = %g, must exceed close-only posQty (%g) for a net-flip", size, posQty)
+	}
+}
+
+// #335 — a losing long→short flip must size against post-close margin, not
+// pre-close cash. Without the expectedClosePnL adjustment, the new-side
+// budget overstates available margin and a leveraged flip can exceed what
+// the exchange will fill, yielding a partial-fill / rejection and the same
+// class of virtual-vs-exchange desync as #298.
+func TestPerpsLiveOrderSize_FlipSizesAgainstPostCloseMargin(t *testing.T) {
+	// long 0.5 ETH @ 2000, price drops to 1900, 5x leverage, cash=1000.
+	// Close leg realizes: 0.5 * (1900 - 2000) = -50 → post-close cash = 950.
+	// New-side budget: 950 * 5 * 0.95 / 1900 = 2.375 → flip size = 0.5 + 2.375 = 2.875.
+	// Pre-close sizing (bug) would yield: 1000 * 5 * 0.95 / 1900 = 2.5 → 3.0, over-sized.
+	size, ok, reason := perpsLiveOrderSize(-1, 1900, 1000, 0.5, 2000, 5.0, "long", true)
+	if !ok {
+		t.Fatalf("expected ok, got reason=%q", reason)
+	}
+	wantSize := 0.5 + (1000-50)*5*0.95/1900
+	if diff := size - wantSize; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("size = %g, want %g (post-close margin sizing)", size, wantSize)
+	}
+	// Regression guard: must be strictly LESS than the buggy pre-close sizing.
+	preCloseSize := 0.5 + 1000*5*0.95/1900
+	if size >= preCloseSize {
+		t.Errorf("size = %g must be < pre-close-sized %g to avoid over-sizing on a losing flip", size, preCloseSize)
+	}
+}
+
+// #335 — profitable flips should size LARGER than pre-close sizing: the
+// close leg adds realized gains to available margin, letting the new side
+// take a proportionally bigger position. Mirror of the losing-flip case.
+func TestPerpsLiveOrderSize_FlipProfitableFlipUsesRealizedGain(t *testing.T) {
+	// short 0.5 ETH @ 2000, price drops to 1900 (profit on short), 5x leverage.
+	// Close leg realizes: 0.5 * (2000 - 1900) = +50 → post-close cash = 1050.
+	// New-side budget: 1050 * 5 * 0.95 / 1900 = 2.625 → flip size = 0.5 + 2.625 = 3.125.
+	size, ok, _ := perpsLiveOrderSize(1, 1900, 1000, 0.5, 2000, 5.0, "short", true)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	wantSize := 0.5 + (1000+50)*5*0.95/1900
+	if diff := size - wantSize; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("size = %g, want %g (post-close margin sizing, profit added)", size, wantSize)
+	}
+	preCloseSize := 0.5 + 1000*5*0.95/1900
+	if size <= preCloseSize {
+		t.Errorf("profitable flip size = %g must exceed pre-close-sized %g", size, preCloseSize)
 	}
 }

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -939,6 +939,9 @@ func TestExecutePerpsSignalOpenShortFromFlat(t *testing.T) {
 	if pos.Multiplier != 1 {
 		t.Errorf("Multiplier = %g, want 1 (perps PnL branch)", pos.Multiplier)
 	}
+	if pos.Leverage != 1 {
+		t.Errorf("Leverage = %g, want 1 (matches leverage arg; risk.go reads this)", pos.Leverage)
+	}
 	if pos.OwnerStrategyID != s.ID {
 		t.Errorf("OwnerStrategyID = %q, want %q", pos.OwnerStrategyID, s.ID)
 	}
@@ -1014,7 +1017,10 @@ func TestExecutePerpsSignalFlipLongToShort(t *testing.T) {
 		RiskState:       RiskState{},
 	}
 
-	trades, err := ExecutePerpsSignal(s, -1, "ETH", 2000, 1, 0.5, "live-flip-oid", 0.5, true, logger)
+	// Live flip: exchange executes a single net-flip sell of size
+	// (closeLongQty + newShortQty) = 0.5 + 0.5 = 1.0. ExecutePerpsSignal
+	// subtracts the close leg when sizing the new short side.
+	trades, err := ExecutePerpsSignal(s, -1, "ETH", 2000, 1, 1.0, "live-flip-oid", 0.5, true, logger)
 	if err != nil {
 		t.Fatalf("ExecutePerpsSignal: %v", err)
 	}
@@ -1024,6 +1030,9 @@ func TestExecutePerpsSignalFlipLongToShort(t *testing.T) {
 	pos := s.Positions["ETH"]
 	if pos == nil || pos.Side != "short" {
 		t.Fatalf("expected ETH short after flip, got %+v", pos)
+	}
+	if pos.Quantity != 0.5 {
+		t.Errorf("new short Quantity = %g, want 0.5 (fillQty=1.0 minus closed long 0.5)", pos.Quantity)
 	}
 	if len(s.TradeHistory) != 2 {
 		t.Fatalf("TradeHistory len = %d, want 2", len(s.TradeHistory))
@@ -1070,5 +1079,60 @@ func TestExecutePerpsSignalAlreadyShortIsInertNoOp(t *testing.T) {
 	}
 	if len(s.TradeHistory) != 0 {
 		t.Error("no Trade should be recorded on dedupe")
+	}
+}
+
+// #330 (follow-up review) — regression: the live perps order size MUST include
+// the close-leg quantity when AllowShorts + opposite-side position, so a
+// single exchange order net-flips the position. Without this, the scheduler's
+// virtual close+open lands against an exchange fill that only closed,
+// leaving virtual state ahead of the exchange (same class of desync as #298).
+func TestPerpsLiveOrderSize_FlipIncludesCloseLeg(t *testing.T) {
+	// cash=1000, leverage=1, price=2000 → newSize = 1000*0.95/2000 = 0.475
+	cases := []struct {
+		name       string
+		signal     int
+		posQty     float64
+		posSide    string
+		allowShort bool
+		wantSize   float64
+		wantOK     bool
+	}{
+		// Fresh opens
+		{"long_from_flat", 1, 0, "", false, 0.475, true},
+		{"short_from_flat_allowed", -1, 0, "", true, 0.475, true},
+		// Close-only (legacy)
+		{"close_long_legacy", -1, 0.3, "long", false, 0.3, true},
+		// Flips (the reviewer's blocker)
+		{"flip_long_to_short", -1, 0.5, "long", true, 0.975, true}, // 0.5 + 0.475
+		{"flip_short_to_long", 1, 0.5, "short", true, 0.975, true}, // 0.5 + 0.475
+		// Legacy buy against migrated short is NOT a flip (AllowShorts=false):
+		// sizing stays at newSize — the legacy behavior pre-dating #328.
+		{"buy_vs_short_legacy_not_flip", 1, 0.5, "short", false, 0.475, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			size, ok, reason := perpsLiveOrderSize(tc.signal, 2000, 1000, tc.posQty, 1.0, tc.posSide, tc.allowShort)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v (reason=%q), want %v", ok, reason, tc.wantOK)
+			}
+			if ok && size != tc.wantSize {
+				t.Errorf("size = %g, want %g", size, tc.wantSize)
+			}
+		})
+	}
+}
+
+// #330 (follow-up) — pin the sizing contract at the boundary where it
+// matters: a long-to-short flip must size to posQty + newSize, NOT posQty
+// (the old close-only behavior that silently broke bidirectional execution).
+func TestPerpsLiveOrderSize_FlipLongToShortExceedsCloseOnly(t *testing.T) {
+	posQty := 0.5
+	size, ok, _ := perpsLiveOrderSize(-1, 2000, 1000, posQty, 1.0, "long", true)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if size <= posQty {
+		t.Errorf("flip size = %g, must exceed close-only posQty (%g) for a net-flip", size, posQty)
 	}
 }

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -1164,6 +1164,24 @@ func TestPerpsLiveOrderSize_FlipSizesAgainstPostCloseMargin(t *testing.T) {
 	}
 }
 
+// #330 (final review) — a catastrophically-losing flip must still close the
+// position even when post-close margin can't fund the new side. Without
+// this fallback, a deep-underwater bidirectional strategy would be worse
+// at exiting than a legacy long-only one: both the close AND open legs
+// would be dropped.
+func TestPerpsLiveOrderSize_CatastrophicFlipDegradesToCloseOnly(t *testing.T) {
+	// long 1.0 ETH @ 2000, price crashes to 500, 1x leverage, cash=100.
+	// closePnL = 1.0 * (500 - 2000) = -1500 → effectiveCash = 100 - 1500 = -1400.
+	// Budget would be -1400 * 1 * 0.95 = -1330 (< 1) → fallback to close-only.
+	size, ok, reason := perpsLiveOrderSize(-1, 500, 100, 1.0, 2000, 1.0, "long", true)
+	if !ok {
+		t.Fatalf("expected ok (should degrade to close-only, not abort); reason=%q", reason)
+	}
+	if size != 1.0 {
+		t.Errorf("size = %g, want 1.0 (close-only fallback when post-close margin is negative)", size)
+	}
+}
+
 // #335 — profitable flips should size LARGER than pre-close sizing: the
 // close leg adds realized gains to available margin, letting the new side
 // take a proportionally bigger position. Mirror of the losing-flip case.

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -559,7 +559,7 @@ func TestExecutePerpsSignalPaperBuyNoNotionalDeduction(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 5, 0, "", 0, logger)
+	trades, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 5, 0, "", 0, false, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -614,7 +614,7 @@ func TestExecutePerpsSignalPortfolioValueAfterMove(t *testing.T) {
 	defer logger.Close()
 
 	// Open at exactly 2000 via live fill (no slippage).
-	_, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 1, 0.5, "", 0, logger)
+	_, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 1, 0.5, "", 0, false, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -659,7 +659,7 @@ func TestExecutePerpsSignalNotInflatedByNotional(t *testing.T) {
 	defer logger.Close()
 
 	// Live fill 0.279 ETH @ 2210.71 (matching the issue example).
-	_, err := ExecutePerpsSignal(s, 1, "ETH", 2210.71, 1, 0.279, "", 0, logger)
+	_, err := ExecutePerpsSignal(s, 1, "ETH", 2210.71, 1, 0.279, "", 0, false, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -702,7 +702,7 @@ func TestExecutePerpsSignalCloseLong(t *testing.T) {
 	defer logger.Close()
 
 	// Close at 2100 — PnL = 0.5 * (2100 - 2000) = $50 gross.
-	_, err := ExecutePerpsSignal(s, -1, "ETH", 2100, 1, 0.5, "", 0, logger)
+	_, err := ExecutePerpsSignal(s, -1, "ETH", 2100, 1, 0.5, "", 0, false, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -721,25 +721,34 @@ func TestExecutePerpsSignalCloseLong(t *testing.T) {
 // recorded" gap that lost 0.716 ETH on Hyperliquid.
 func TestPerpsOrderSkipReason(t *testing.T) {
 	cases := []struct {
-		name    string
-		signal  int
-		posSide string
-		wantSet bool
+		name        string
+		signal      int
+		posSide     string
+		allowShorts bool
+		wantSet     bool
 	}{
-		{"buy_flat_allowed", 1, "", false},
-		{"buy_short_allowed_flip", 1, "short", false},
-		{"buy_long_skipped", 1, "long", true},
-		{"sell_long_allowed", -1, "long", false},
-		{"sell_flat_skipped", -1, "", true},
-		{"sell_short_skipped", -1, "short", true},
-		{"signal_zero_flat", 0, "", false},
-		{"signal_zero_long", 0, "long", false},
+		// Legacy (allowShorts=false) — long-only execution
+		{"buy_flat_allowed", 1, "", false, false},
+		{"buy_short_allowed_flip", 1, "short", false, false},
+		{"buy_long_skipped", 1, "long", false, true},
+		{"sell_long_allowed", -1, "long", false, false},
+		{"sell_flat_skipped", -1, "", false, true},
+		{"sell_short_skipped_legacy", -1, "short", false, true},
+		{"signal_zero_flat", 0, "", false, false},
+		{"signal_zero_long", 0, "long", false, false},
+		// #328 — AllowShorts opens short from flat and dedupes already-short
+		{"sell_flat_allowed_bidir", -1, "", true, false},
+		{"sell_short_deduped_bidir", -1, "short", true, true},
+		{"sell_long_allowed_bidir", -1, "long", true, false},
+		{"buy_long_still_skipped_bidir", 1, "long", true, true},
+		{"buy_short_flip_bidir", 1, "short", true, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := PerpsOrderSkipReason(tc.signal, tc.posSide)
+			got := PerpsOrderSkipReason(tc.signal, tc.posSide, tc.allowShorts)
 			if (got != "") != tc.wantSet {
-				t.Errorf("PerpsOrderSkipReason(%d, %q) = %q, wantSet=%v", tc.signal, tc.posSide, got, tc.wantSet)
+				t.Errorf("PerpsOrderSkipReason(%d, %q, allowShorts=%v) = %q, wantSet=%v",
+					tc.signal, tc.posSide, tc.allowShorts, got, tc.wantSet)
 			}
 		})
 	}
@@ -834,7 +843,7 @@ func TestExecutePerpsSignalAlreadyLongIsInertNoOp(t *testing.T) {
 	qtyBefore := s.Positions["ETH"].Quantity
 	tradesBefore := len(s.TradeHistory)
 
-	trades, err := ExecutePerpsSignal(s, 1, "ETH", 2334, 1, 0.238, "oid-123", 0.42, logger)
+	trades, err := ExecutePerpsSignal(s, 1, "ETH", 2334, 1, 0.238, "oid-123", 0.42, false, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -889,5 +898,177 @@ func TestExecuteFuturesSignalLiveFill(t *testing.T) {
 	// AvgCost must be exactly the fill price — no slippage
 	if math.Abs(pos.AvgCost-fillPrice) > 1e-6 {
 		t.Errorf("AvgCost = %.6f, want %.6f (exact fill price)", pos.AvgCost, fillPrice)
+	}
+}
+
+// #328 — AllowShorts=true lets signal=-1 from flat open a short perp position.
+// Without AllowShorts the same call returns 0 trades (legacy close-long-only).
+func TestExecutePerpsSignalOpenShortFromFlat(t *testing.T) {
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	s := &StrategyState{
+		ID:              "hl-temab-eth",
+		Cash:            1000,
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{},
+	}
+
+	trades, err := ExecutePerpsSignal(s, -1, "ETH", 2000, 1, 0, "", 0, true, logger)
+	if err != nil {
+		t.Fatalf("ExecutePerpsSignal: %v", err)
+	}
+	if trades != 1 {
+		t.Errorf("trades = %d, want 1 (short open)", trades)
+	}
+	pos := s.Positions["ETH"]
+	if pos == nil {
+		t.Fatal("expected ETH short position to be opened")
+	}
+	if pos.Side != "short" {
+		t.Errorf("side = %q, want \"short\"", pos.Side)
+	}
+	if pos.Quantity <= 0 {
+		t.Errorf("quantity = %g, want > 0", pos.Quantity)
+	}
+	if pos.Multiplier != 1 {
+		t.Errorf("Multiplier = %g, want 1 (perps PnL branch)", pos.Multiplier)
+	}
+	if pos.OwnerStrategyID != s.ID {
+		t.Errorf("OwnerStrategyID = %q, want %q", pos.OwnerStrategyID, s.ID)
+	}
+	// Margin-based accounting: cash should drop by fee only, not full notional.
+	feeOnly := 1000.0 - s.Cash
+	notional := pos.Quantity * pos.AvgCost
+	if feeOnly >= notional*0.1 {
+		t.Errorf("cash drop = %.4f, want ~fee only (notional=$%.2f)", feeOnly, notional)
+	}
+	if len(s.TradeHistory) != 1 {
+		t.Fatalf("TradeHistory len = %d, want 1", len(s.TradeHistory))
+	}
+	if s.TradeHistory[0].Side != "sell" {
+		t.Errorf("Trade.Side = %q, want \"sell\"", s.TradeHistory[0].Side)
+	}
+}
+
+// #328 — legacy behavior regression: without AllowShorts, signal=-1 on flat
+// must not open a short (otherwise triple_ema / rsi_macd_combo et al. would
+// silently start trading shorts they never intended).
+func TestExecutePerpsSignalLegacyFlatNoShort(t *testing.T) {
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	s := &StrategyState{
+		ID:              "hl-tema-eth",
+		Cash:            1000,
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+	}
+
+	trades, err := ExecutePerpsSignal(s, -1, "ETH", 2000, 1, 0, "", 0, false, logger)
+	if err != nil {
+		t.Fatalf("ExecutePerpsSignal: %v", err)
+	}
+	if trades != 0 {
+		t.Errorf("trades = %d, want 0 (legacy no-op)", trades)
+	}
+	if len(s.Positions) != 0 {
+		t.Error("no position should be opened without AllowShorts")
+	}
+	if len(s.TradeHistory) != 0 {
+		t.Error("no Trade should be recorded")
+	}
+	if s.Cash != 1000 {
+		t.Errorf("cash = %g, want unchanged 1000", s.Cash)
+	}
+}
+
+// #328 — long + signal=-1 + AllowShorts closes the long AND opens a short.
+// Mirrors the existing signal=1+short close-and-flip branch. Produces exactly
+// two Trade rows; only the opening trade carries live exchange metadata so a
+// single fill's fee isn't double-counted (#289).
+func TestExecutePerpsSignalFlipLongToShort(t *testing.T) {
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	s := &StrategyState{
+		ID:       "hl-temab-eth",
+		Cash:     1000,
+		Platform: "hyperliquid",
+		Type:     "perps",
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 1900, Side: "long", Multiplier: 1, Leverage: 1, OwnerStrategyID: "hl-temab-eth"},
+		},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{},
+	}
+
+	trades, err := ExecutePerpsSignal(s, -1, "ETH", 2000, 1, 0.5, "live-flip-oid", 0.5, true, logger)
+	if err != nil {
+		t.Fatalf("ExecutePerpsSignal: %v", err)
+	}
+	if trades != 2 {
+		t.Errorf("trades = %d, want 2 (close long + open short)", trades)
+	}
+	pos := s.Positions["ETH"]
+	if pos == nil || pos.Side != "short" {
+		t.Fatalf("expected ETH short after flip, got %+v", pos)
+	}
+	if len(s.TradeHistory) != 2 {
+		t.Fatalf("TradeHistory len = %d, want 2", len(s.TradeHistory))
+	}
+	closeLeg, openLeg := s.TradeHistory[0], s.TradeHistory[1]
+	if closeLeg.ExchangeOrderID != "" || closeLeg.ExchangeFee != 0 {
+		t.Errorf("close leg carries exchange metadata (oid=%q fee=%g); must stay empty",
+			closeLeg.ExchangeOrderID, closeLeg.ExchangeFee)
+	}
+	if openLeg.ExchangeOrderID != "live-flip-oid" || openLeg.ExchangeFee != 0.5 {
+		t.Errorf("open leg missing exchange metadata: oid=%q fee=%g", openLeg.ExchangeOrderID, openLeg.ExchangeFee)
+	}
+}
+
+// #328 — symmetric dedupe: already-short + signal=-1 + AllowShorts is a no-op,
+// just like already-long + signal=1.
+func TestExecutePerpsSignalAlreadyShortIsInertNoOp(t *testing.T) {
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	s := &StrategyState{
+		ID:       "hl-temab-eth",
+		Cash:     999.50,
+		Platform: "hyperliquid",
+		Type:     "perps",
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2000, Side: "short", Multiplier: 1, Leverage: 1},
+		},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+	}
+	cashBefore := s.Cash
+
+	trades, err := ExecutePerpsSignal(s, -1, "ETH", 1950, 1, 0, "", 0, true, logger)
+	if err != nil {
+		t.Fatalf("ExecutePerpsSignal: %v", err)
+	}
+	if trades != 0 {
+		t.Errorf("trades = %d, want 0 (already short dedupe)", trades)
+	}
+	if s.Cash != cashBefore {
+		t.Errorf("cash changed on no-op: before=%.4f after=%.4f", cashBefore, s.Cash)
+	}
+	if len(s.TradeHistory) != 0 {
+		t.Error("no Trade should be recorded on dedupe")
 	}
 }

--- a/scheduler/trade_persist_test.go
+++ b/scheduler/trade_persist_test.go
@@ -216,7 +216,7 @@ func TestExecutePerpsSignal_PersistsExchangeMetadata(t *testing.T) {
 	s := state.Strategies["hl-live"]
 
 	// Live open-long @ $2000, qty=0.5, OID=12345, fee=$0.42.
-	trades, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 1, 0.5, "12345", 0.42, logger)
+	trades, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 1, 0.5, "12345", 0.42, false, logger)
 	if err != nil {
 		t.Fatalf("ExecutePerpsSignal: %v", err)
 	}
@@ -383,7 +383,7 @@ func TestExecutePerpsSignal_FlipDoesNotDoubleCountFee(t *testing.T) {
 
 	// Live buy @ $2000 qty=0.3 → closes the full 0.5 short + opens new 0.3
 	// long = 2 in-memory trades, 1 real exchange fill worth $0.42.
-	trades, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 1, 0.3, "99999", 0.42, logger)
+	trades, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 1, 0.3, "99999", 0.42, false, logger)
 	if err != nil {
 		t.Fatalf("ExecutePerpsSignal: %v", err)
 	}

--- a/shared_strategies/futures/strategies.py
+++ b/shared_strategies/futures/strategies.py
@@ -147,6 +147,24 @@ def triple_ema_strategy(df: pd.DataFrame, short_period: int = 8, mid_period: int
 
 
 @register_strategy(
+    "triple_ema_bidir",
+    "Triple EMA Bidirectional — long on bullish stack, short on bearish stack",
+    {"short_period": 8, "mid_period": 21, "long_period": 55}
+)
+def triple_ema_bidir_strategy(df: pd.DataFrame, short_period: int = 8, mid_period: int = 21, long_period: int = 55) -> pd.DataFrame:
+    result = df.copy()
+    result["ema_short"] = ema(result["close"], short_period)
+    result["ema_mid"] = ema(result["close"], mid_period)
+    result["ema_long"] = ema(result["close"], long_period)
+    bullish = (result["ema_short"] > result["ema_mid"]) & (result["ema_mid"] > result["ema_long"])
+    bearish = (result["ema_short"] < result["ema_mid"]) & (result["ema_mid"] < result["ema_long"])
+    result["position"] = np.where(bullish, 1, np.where(bearish, -1, 0))
+    # A direct bullish→bearish flip yields diff == -2; clamp so downstream sees {-1, 0, 1}.
+    result["signal"] = result["position"].diff().clip(-1, 1)
+    return result
+
+
+@register_strategy(
     "rsi_macd_combo",
     "RSI+MACD Combo — dual confirmation for higher quality signals",
     {"rsi_period": 14, "rsi_oversold": 35, "rsi_overbought": 65,

--- a/shared_strategies/futures/test_strategies.py
+++ b/shared_strategies/futures/test_strategies.py
@@ -45,9 +45,10 @@ make_volatile = _conftest_mod.make_volatile
 class TestFuturesRegistry:
     def test_strategies_registered(self):
         names = list_strategies()
-        assert len(names) >= 21
+        assert len(names) >= 22
         for expected in ["sma_crossover", "ema_crossover", "bollinger_bands",
-                         "volume_weighted", "triple_ema", "rsi_macd_combo",
+                         "volume_weighted", "triple_ema", "triple_ema_bidir",
+                         "rsi_macd_combo",
                          "momentum", "mean_reversion", "rsi", "macd", "breakout",
                          "stoch_rsi", "supertrend", "squeeze_momentum",
                          "ichimoku_cloud", "atr_breakout", "heikin_ashi_ema",
@@ -163,6 +164,49 @@ class TestTripleEMA:
     def test_flat_no_signal(self):
         result = _run("triple_ema", make_flat(80))
         assert (result["signal"].dropna() == 0).all()
+
+
+# ─── Triple EMA Bidirectional ─────────────
+
+class TestTripleEMABidir:
+    def test_uptrend_enters_long(self):
+        result = _run("triple_ema_bidir", make_trending_up(120))
+        assert "ema_short" in result.columns
+        _valid_signals(result)
+        assert (result["position"] == 1).any()
+        assert (result["signal"] == 1).any()
+
+    def test_downtrend_enters_short(self):
+        result = _run("triple_ema_bidir", make_trending_down(120))
+        _valid_signals(result)
+        assert (result["position"] == -1).any(), "bearish stack must emit position=-1"
+        assert (result["signal"] == -1).any(), "bearish stack must emit short-entry signal"
+
+    def test_flat_no_signal(self):
+        result = _run("triple_ema_bidir", make_flat(80))
+        assert (result["position"].dropna() == 0).all()
+        assert (result["signal"].dropna() == 0).all()
+
+    def test_direct_flip_signal_clamped(self):
+        # Strong uptrend then strong downtrend — EMAs should flip from bullish to bearish
+        # stack with no flat-stack bars in between. The raw diff would be -2 on the flip
+        # bar; the strategy must clamp it to -1.
+        closes = list(make_trending_up(80, start=100, step=1.0)) + list(
+            make_trending_down(80, start=180, step=1.0)
+        )
+        result = _run("triple_ema_bidir", closes)
+        _valid_signals(result)
+        assert result["signal"].min() >= -1
+        assert result["signal"].max() <= 1
+
+    def test_custom_params_applied(self):
+        # Override periods — strategy must accept and use them (checked indirectly via
+        # ema columns differing from defaults on same input).
+        closes = make_trending_up(60)
+        default = _run("triple_ema_bidir", closes)
+        custom = _run("triple_ema_bidir", closes,
+                      params={"short_period": 3, "mid_period": 10, "long_period": 30})
+        assert not default["ema_short"].equals(custom["ema_short"])
 
 
 # ─── RSI MACD Combo ──────────────────────
@@ -518,7 +562,7 @@ class TestAMDIFVG:
 class TestEdgeCases:
     @pytest.mark.parametrize("name", [
         "sma_crossover", "ema_crossover", "bollinger_bands",
-        "volume_weighted", "triple_ema", "rsi_macd_combo",
+        "volume_weighted", "triple_ema", "triple_ema_bidir", "rsi_macd_combo",
         "momentum", "mean_reversion", "rsi", "macd", "breakout",
         "stoch_rsi", "supertrend", "squeeze_momentum",
         "atr_breakout", "heikin_ashi_ema", "parabolic_sar",
@@ -532,7 +576,7 @@ class TestEdgeCases:
 
     @pytest.mark.parametrize("name", [
         "sma_crossover", "ema_crossover", "bollinger_bands",
-        "volume_weighted", "triple_ema", "rsi_macd_combo",
+        "volume_weighted", "triple_ema", "triple_ema_bidir", "rsi_macd_combo",
         "momentum", "mean_reversion", "rsi", "macd", "breakout",
         "stoch_rsi", "atr_breakout", "heikin_ashi_ema",
         "supertrend", "squeeze_momentum", "ichimoku_cloud",


### PR DESCRIPTION
## Summary
- Add `triple_ema_bidir` in `shared_strategies/futures/strategies.py` — long on bullish stack, short on bearish stack, signal clamped to `{-1, 0, 1}`.
- Register `temab` short name and add to `defaultFuturesStrategies` + `defaultPerpsStrategies` in `scheduler/init.go`.
- Tests cover uptrend/downtrend/flat, direct flip clamping, custom params, registry, and edge cases.

## Why

The existing `triple_ema` is structurally long-only — `position ∈ {0, 1}` so `signal.diff()` emits `-1` only as a long-exit, never a short entry. `hl-tema-eth` sat at position=0 through ETH's 30m dump on 2026-04-18 even with `ema_short 2376 < ema_mid 2393 < ema_long 2394` fully bearish.

Live verification against Hyperliquid public `candles_snapshot` confirms the new strategy entered short at 2026-04-18 10:59 UTC (position=-1, signal=-1) and held through the latest bar — exactly the short `hl-tema-eth` would have missed.

## Test plan
- [x] `uv run pytest shared_strategies/` — 301 passed
- [x] `cd scheduler && go test ./...` — passed (`ok trading-scheduler 4.013s`)
- [x] `cd scheduler && go build .` — clean
- [x] `gofmt -l` — clean
- [x] Strategy discovery: `shared_strategies/futures/strategies.py --list-json` includes `triple_ema_bidir`
- [x] Live ETH 30m replay on Hyperliquid: position=-1 in last 2 bars, signal=-1 on entry bar, all signals ⊆ `{-1, 0, 1}`
- [x] End-to-end: `.venv/bin/python3 shared_scripts/check_hyperliquid.py triple_ema_bidir ETH 30m --mode=paper` returns valid JSON
- [x] Init wizard: `./go-trader init --json '{..."perpsStrategies":["triple_ema_bidir"]...}'` generates `hl-temab-eth` config correctly

## Config migration

Users wanting bidirectional behavior swap their strategy entry:

```json
{ "id": "hl-temab-eth", "strategy": "triple_ema_bidir", ... }
```

Existing `hl-tema-eth` (long-only `triple_ema`) keeps working unchanged — no breaking change.

Closes #328

---
Generated with: Claude Opus 4.7 | Effort: high