### PR TITLE
Make rsi_macd_combo RSI short/long gate configurable

### DIFF
--- a/shared_strategies/futures/strategies.py
+++ b/shared_strategies/futures/strategies.py
@@ -150,11 +150,13 @@ def triple_ema_strategy(df: pd.DataFrame, short_period: int = 8, mid_period: int
     "rsi_macd_combo",
     "RSI+MACD Combo — dual confirmation for higher quality signals",
     {"rsi_period": 14, "rsi_oversold": 35, "rsi_overbought": 65,
-     "macd_fast": 12, "macd_slow": 26, "macd_signal": 9}
+     "macd_fast": 12, "macd_slow": 26, "macd_signal": 9,
+     "rsi_short_min": 50, "rsi_long_max": 50}
 )
 def rsi_macd_combo_strategy(df: pd.DataFrame,
                              rsi_period: int = 14, rsi_oversold: float = 35, rsi_overbought: float = 65,
-                             macd_fast: int = 12, macd_slow: int = 26, macd_signal: int = 9) -> pd.DataFrame:
+                             macd_fast: int = 12, macd_slow: int = 26, macd_signal: int = 9,
+                             rsi_short_min: float = 50, rsi_long_max: float = 50) -> pd.DataFrame:
     result = df.copy()
     # RSI
     delta = result["close"].diff()
@@ -171,13 +173,15 @@ def rsi_macd_combo_strategy(df: pd.DataFrame,
     result["macd_signal_line"] = ema(result["macd_line"], macd_signal)
     # Combined signals
     result["signal"] = 0
-    # Buy: RSI recovering from oversold AND MACD bullish cross
+    # Buy: MACD bullish cross AND RSI below rsi_long_max (default 50 = not already overbought).
+    # Lower rsi_long_max to require a more oversold RSI before longing.
     macd_bull = (result["macd_line"] > result["macd_signal_line"]) & (result["macd_line"].shift(1) <= result["macd_signal_line"].shift(1))
-    rsi_ok = result["rsi"] < 50  # RSI not overbought
+    rsi_ok = result["rsi"] < rsi_long_max
     result.loc[macd_bull & rsi_ok, "signal"] = 1
-    # Sell: RSI dropping from overbought AND MACD bearish cross
+    # Sell: MACD bearish cross AND RSI above rsi_short_min (default 50 = not already oversold).
+    # Lower rsi_short_min to allow shorts deeper into a downtrend.
     macd_bear = (result["macd_line"] < result["macd_signal_line"]) & (result["macd_line"].shift(1) >= result["macd_signal_line"].shift(1))
-    rsi_high = result["rsi"] > 50
+    rsi_high = result["rsi"] > rsi_short_min
     result.loc[macd_bear & rsi_high, "signal"] = -1
     return result
 

--- a/shared_strategies/futures/test_strategies.py
+++ b/shared_strategies/futures/test_strategies.py
@@ -177,6 +177,52 @@ class TestRSIMACDCombo:
         _valid_signals(result)
         assert (result["signal"] == 1).any() or (result["signal"] == -1).any()
 
+    def test_default_gate_preserves_legacy_behavior(self):
+        # The default rsi_short_min / rsi_long_max values (50) must match the
+        # pre-PR hard-coded gates. A straight down-then-up series should still
+        # produce at least one -1 signal with defaults.
+        closes = list(np.linspace(80, 140, 60)) + list(np.linspace(140, 80, 60))
+        result = _run("rsi_macd_combo", closes)
+        _valid_signals(result)
+        assert (result["signal"] == -1).any()
+
+    def test_loosened_short_gate_catches_more_shorts(self):
+        # Series: rally → sharp drop (first MACD bearish cross at high RSI) → small
+        # bounce → extended drop (second bearish cross, now at low RSI). Default
+        # gate (rsi_short_min=50) blocks the second cross; permissive gate catches both.
+        closes = (list(np.linspace(80, 160, 50)) +
+                  list(np.linspace(160, 100, 20)) +
+                  list(np.linspace(100, 115, 15)) +
+                  list(np.linspace(115, 60, 40)))
+        strict = _run("rsi_macd_combo", closes)
+        loose = _run("rsi_macd_combo", closes, params={"rsi_short_min": 0})
+        _valid_signals(strict)
+        _valid_signals(loose)
+        assert (loose["signal"] == -1).sum() > (strict["signal"] == -1).sum(), \
+            "loosening rsi_short_min must allow more short signals"
+
+    def test_loosened_long_gate_catches_more_longs(self):
+        # Symmetric pattern: crash → sharp rally (first cross at low RSI) → dip →
+        # extended rally (second bullish cross at higher RSI). Permissive gate
+        # (rsi_long_max=100) should catch at least as many longs as default.
+        closes = (list(np.linspace(140, 70, 50)) +
+                  list(np.linspace(70, 130, 20)) +
+                  list(np.linspace(130, 115, 15)) +
+                  list(np.linspace(115, 180, 40)))
+        strict = _run("rsi_macd_combo", closes)
+        loose = _run("rsi_macd_combo", closes, params={"rsi_long_max": 100})
+        _valid_signals(strict)
+        _valid_signals(loose)
+        assert (loose["signal"] == 1).sum() >= (strict["signal"] == 1).sum()
+
+    def test_params_forwarded_via_apply_strategy(self):
+        # Sanity: the new params propagate through apply_strategy without error.
+        closes = make_trending_down(80)
+        result = _run("rsi_macd_combo", closes,
+                      params={"rsi_short_min": 30, "rsi_long_max": 70})
+        assert "rsi" in result.columns
+        _valid_signals(result)
+
     def test_flat_no_signal(self):
         result = _run("rsi_macd_combo", make_flat(80))
         assert (result["signal"] == 0).all()

--- a/shared_strategies/spot/strategies.py
+++ b/shared_strategies/spot/strategies.py
@@ -219,11 +219,13 @@ def triple_ema_strategy(df: pd.DataFrame, short_period: int = 8, mid_period: int
     "rsi_macd_combo",
     "RSI+MACD Combo — dual confirmation for higher quality signals",
     {"rsi_period": 14, "rsi_oversold": 35, "rsi_overbought": 65,
-     "macd_fast": 12, "macd_slow": 26, "macd_signal": 9}
+     "macd_fast": 12, "macd_slow": 26, "macd_signal": 9,
+     "rsi_short_min": 50, "rsi_long_max": 50}
 )
 def rsi_macd_combo_strategy(df: pd.DataFrame,
                              rsi_period: int = 14, rsi_oversold: float = 35, rsi_overbought: float = 65,
-                             macd_fast: int = 12, macd_slow: int = 26, macd_signal: int = 9) -> pd.DataFrame:
+                             macd_fast: int = 12, macd_slow: int = 26, macd_signal: int = 9,
+                             rsi_short_min: float = 50, rsi_long_max: float = 50) -> pd.DataFrame:
     result = df.copy()
     # RSI
     delta = result["close"].diff()
@@ -240,13 +242,15 @@ def rsi_macd_combo_strategy(df: pd.DataFrame,
     result["macd_signal_line"] = ema(result["macd_line"], macd_signal)
     # Combined signals
     result["signal"] = 0
-    # Buy: RSI recovering from oversold AND MACD bullish cross
+    # Buy: MACD bullish cross AND RSI below rsi_long_max (default 50 = not already overbought).
+    # Lower rsi_long_max to require a more oversold RSI before longing.
     macd_bull = (result["macd_line"] > result["macd_signal_line"]) & (result["macd_line"].shift(1) <= result["macd_signal_line"].shift(1))
-    rsi_ok = result["rsi"] < 50  # RSI not overbought
+    rsi_ok = result["rsi"] < rsi_long_max
     result.loc[macd_bull & rsi_ok, "signal"] = 1
-    # Sell: RSI dropping from overbought AND MACD bearish cross
+    # Sell: MACD bearish cross AND RSI above rsi_short_min (default 50 = not already oversold).
+    # Lower rsi_short_min to allow shorts deeper into a downtrend.
     macd_bear = (result["macd_line"] < result["macd_signal_line"]) & (result["macd_line"].shift(1) >= result["macd_signal_line"].shift(1))
-    rsi_high = result["rsi"] > 50
+    rsi_high = result["rsi"] > rsi_short_min
     result.loc[macd_bear & rsi_high, "signal"] = -1
     return result
 

--- a/shared_strategies/spot/test_strategies.py
+++ b/shared_strategies/spot/test_strategies.py
@@ -318,6 +318,37 @@ class TestRSIMACDCombo:
         # MACD bearish cross with RSI > 50 during decline
         assert (result["signal"] == -1).any(), "Expected sell signal on MACD bearish cross with RSI > 50"
 
+    def test_loosened_short_gate_catches_more_shorts(self):
+        # Rally → drop (cross at high RSI) → bounce → extended drop (cross at low RSI).
+        # Default rsi_short_min=50 blocks the second cross; permissive catches both.
+        closes = (list(np.linspace(80, 160, 50)) +
+                  list(np.linspace(160, 100, 20)) +
+                  list(np.linspace(100, 115, 15)) +
+                  list(np.linspace(115, 60, 40)))
+        strict = _run_strategy("rsi_macd_combo", closes)
+        loose = _run_strategy("rsi_macd_combo", closes, params={"rsi_short_min": 0})
+        _assert_valid_signals(strict)
+        _assert_valid_signals(loose)
+        assert (loose["signal"] == -1).sum() > (strict["signal"] == -1).sum()
+
+    def test_loosened_long_gate_catches_more_longs(self):
+        closes = (list(np.linspace(140, 70, 50)) +
+                  list(np.linspace(70, 130, 20)) +
+                  list(np.linspace(130, 115, 15)) +
+                  list(np.linspace(115, 180, 40)))
+        strict = _run_strategy("rsi_macd_combo", closes)
+        loose = _run_strategy("rsi_macd_combo", closes, params={"rsi_long_max": 100})
+        _assert_valid_signals(strict)
+        _assert_valid_signals(loose)
+        assert (loose["signal"] == 1).sum() >= (strict["signal"] == 1).sum()
+
+    def test_params_forwarded_via_apply_strategy(self):
+        closes = list(np.linspace(140, 70, 80))
+        result = _run_strategy("rsi_macd_combo", closes,
+                               params={"rsi_short_min": 30, "rsi_long_max": 70})
+        assert "rsi" in result.columns
+        _assert_valid_signals(result)
+
 
 # ─── Stochastic RSI ─────────────────────────
 


### PR DESCRIPTION
## Summary
- Add `rsi_short_min` (default 50) and `rsi_long_max` (default 50) params to `rsi_macd_combo` in both `shared_strategies/futures/strategies.py` and `shared_strategies/spot/strategies.py`.
- Replace hard-coded `rsi > 50` / `rsi < 50` gates with the new params.
- Defaults preserve existing production behavior exactly.
- Tests cover default regression, loosened-gate behavior, symmetric long-side, and `--params` forwarding.

## Why

The short gate was `rsi > 50` hard-coded — meaning shorts only fire on *fresh reversals*. When ETH dumped on 2026-04-18 and RSI fell to 23-35 during the flush, every subsequent MACD bearish cross was blocked, so `hl-rmc-eth` couldn't short the trend continuation. The existing `rsi_overbought=65` / `rsi_oversold=35` params were declared but never actually referenced in the gate logic.

With this change, loosening becomes a pure config edit — no code change needed:

```json
{
  "id": "hl-rmc-eth",
  "strategy": "rsi_macd_combo",
  "params": {"rsi_short_min": 30, "rsi_long_max": 70}
}
```

Go already plumbs `StrategyConfig.Params` → `--params '<json>'` → Python `apply_strategy(name, df, params)`, verified end-to-end.

Kept `rsi_overbought` / `rsi_oversold` untouched (they remain unused but available for future work — semantic mismatch means overloading them for the gate reads badly at low thresholds).

## Test plan
- [x] `uv run pytest shared_strategies/` — 301 passed
- [x] `go test ./...` from scheduler/ — clean
- [x] `go build .` — clean
- [x] `python3 -m py_compile` both strategy modules — clean
- [x] Strategy discovery: `rsi_macd_combo` in both `futures/` and `spot/` `--list-json`
- [x] Live ETH 48h replay: defaults produce same 2 shorts as pre-PR behavior (RSI at 50.1, 58.6 — both already > 50)
- [x] End-to-end: `.venv/bin/python3 shared_scripts/check_hyperliquid.py rsi_macd_combo ETH 30m --mode=paper --params='{"rsi_short_min":30,"rsi_long_max":70}'` returns valid JSON
- [x] Differential test on synthetic rally→drop→bounce→drop pattern: default catches 1 short, permissive catches 2

## Config migration

Zero-risk — defaults match old behavior. Users can opt in to looser gates per-strategy when they need trend-continuation shorts:

```json
{"params": {"rsi_short_min": 30}}
```

Closes #329

---
Generated with: Claude Opus 4.7 | Effort: high