### PR TITLE
Flag perps shorts held under AllowShorts=false at startup (#336)

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -87,6 +87,12 @@ func main() {
 		}
 	}
 
+	// #336: Detect perps shorts held under AllowShorts=false strategies. The
+	// executor can't reconcile this on its own — a fresh-open buy against an
+	// existing short nets on the exchange but flips virtually. Collect here,
+	// forward to owner DM once the notifier is wired below.
+	allowShortsWarnings := ValidatePerpsAllowShortsConfig(state, cfg)
+
 	// #42 / #243: Initialize portfolio peak from sum of capitals on first run.
 	// For strategies that share an exchange wallet (e.g. multiple Hyperliquid
 	// perps strategies on the same account), use the real on-exchange balance
@@ -191,6 +197,14 @@ func main() {
 	// to stderr via the nil-check in state.go.
 	if notifier.HasOwner() {
 		tradePersistWarn = func(msg string) {
+			notifier.SendOwnerDM("[state] " + msg)
+		}
+	}
+
+	// #336: Forward startup AllowShorts warnings to the owner so the desync is
+	// surfaced even when the operator isn't tailing stderr.
+	if len(allowShortsWarnings) > 0 && notifier.HasOwner() {
+		for _, msg := range allowShortsWarnings {
 			notifier.SendOwnerDM("[state] " + msg)
 		}
 	}

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -179,6 +179,41 @@ func ValidateState(state *AppState) {
 	}
 }
 
+// ValidatePerpsAllowShortsConfig flags short positions that belong to a perps
+// strategy currently configured with AllowShorts=false (#336). The desync can
+// arise from state migration, paper→live handoff, operator edits of state.db,
+// or a config toggle from true→false without first closing the short. When the
+// strategy next emits a buy signal, the executor's fresh-open sizing will
+// collide with the pre-existing short and leave virtual state out of sync with
+// the exchange. We warn-and-continue (matching ValidateState's precedent)
+// rather than force-closing — marks may be unavailable at startup and silent
+// auto-close of an operator-seeded position is worse than a loud warning.
+//
+// Returns human-readable warnings so the caller can both log them and forward
+// to the operator via DM once the notifier is ready.
+func ValidatePerpsAllowShortsConfig(state *AppState, cfg *Config) []string {
+	var warnings []string
+	for i := range cfg.Strategies {
+		sc := &cfg.Strategies[i]
+		if sc.Type != "perps" || sc.AllowShorts {
+			continue
+		}
+		s, ok := state.Strategies[sc.ID]
+		if !ok {
+			continue
+		}
+		for sym, pos := range s.Positions {
+			if pos.Side != "short" {
+				continue
+			}
+			msg := fmt.Sprintf("perps state-vs-config gap: strategy %s has short %s qty=%g (AllowShorts=false). Position was likely seeded by migration, paper→live handoff, or a prior AllowShorts=true config. Close manually before the next buy signal — the executor's fresh-open sizing will otherwise desync virtual state from the exchange.", sc.ID, sym, pos.Quantity)
+			fmt.Printf("[WARN] %s\n", msg)
+			warnings = append(warnings, msg)
+		}
+	}
+	return warnings
+}
+
 // LoadStateWithDB loads state from SQLite. Returns a fresh AppState when the DB is empty.
 func LoadStateWithDB(cfg *Config, sdb *StateDB) (*AppState, error) {
 	state, err := sdb.LoadState()

--- a/scheduler/state_test.go
+++ b/scheduler/state_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -108,6 +109,101 @@ func TestValidateState(t *testing.T) {
 	}
 	if _, ok := s.OptionPositions["badqty"]; ok {
 		t.Error("zero-quantity option should be removed")
+	}
+}
+
+// TestValidatePerpsAllowShortsConfig exercises the #336 startup check: a short
+// position seeded into SQLite (via migration, paper→live handoff, or operator
+// edit) under a perps strategy whose config has AllowShorts=false must be
+// flagged so the operator sees it before the executor's flip path quietly
+// desyncs virtual state from the exchange on the next buy signal.
+func TestValidatePerpsAllowShortsConfig(t *testing.T) {
+	state := NewAppState()
+	state.Strategies["hl-triple-ema-eth"] = &StrategyState{
+		ID:   "hl-triple-ema-eth",
+		Type: "perps",
+		Positions: map[string]*Position{
+			// The gap case: short under AllowShorts=false.
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2000, Side: "short", Multiplier: 1, Leverage: 1},
+		},
+	}
+	state.Strategies["hl-bidir-btc"] = &StrategyState{
+		ID:   "hl-bidir-btc",
+		Type: "perps",
+		Positions: map[string]*Position{
+			// Allowed short: AllowShorts=true in config below, must not warn.
+			"BTC": {Symbol: "BTC", Quantity: 0.1, AvgCost: 60000, Side: "short", Multiplier: 1, Leverage: 1},
+		},
+	}
+	state.Strategies["bn-sma-btc"] = &StrategyState{
+		ID:   "bn-sma-btc",
+		Type: "spot",
+		Positions: map[string]*Position{
+			// Non-perps: AllowShorts is meaningless, must not warn.
+			"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.01, AvgCost: 60000, Side: "long"},
+		},
+	}
+
+	cfg := &Config{
+		Strategies: []StrategyConfig{
+			{ID: "hl-triple-ema-eth", Type: "perps", Platform: "hyperliquid", AllowShorts: false},
+			{ID: "hl-bidir-btc", Type: "perps", Platform: "hyperliquid", AllowShorts: true},
+			{ID: "bn-sma-btc", Type: "spot", Platform: "binanceus", AllowShorts: false},
+		},
+	}
+
+	warnings := ValidatePerpsAllowShortsConfig(state, cfg)
+	if len(warnings) != 1 {
+		t.Fatalf("want 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	w := warnings[0]
+	if !strings.Contains(w, "hl-triple-ema-eth") {
+		t.Errorf("warning should name the offending strategy, got: %s", w)
+	}
+	if !strings.Contains(w, "ETH") {
+		t.Errorf("warning should name the symbol, got: %s", w)
+	}
+	if !strings.Contains(w, "AllowShorts=false") {
+		t.Errorf("warning should cite the config gap, got: %s", w)
+	}
+}
+
+// TestValidatePerpsAllowShortsConfig_NoShorts confirms the validator is silent
+// when all perps positions match their strategy's AllowShorts setting.
+func TestValidatePerpsAllowShortsConfig_NoShorts(t *testing.T) {
+	state := NewAppState()
+	state.Strategies["hl-triple-ema-eth"] = &StrategyState{
+		ID:   "hl-triple-ema-eth",
+		Type: "perps",
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2000, Side: "long", Multiplier: 1, Leverage: 1},
+		},
+	}
+	cfg := &Config{
+		Strategies: []StrategyConfig{
+			{ID: "hl-triple-ema-eth", Type: "perps", Platform: "hyperliquid", AllowShorts: false},
+		},
+	}
+	if warnings := ValidatePerpsAllowShortsConfig(state, cfg); len(warnings) != 0 {
+		t.Errorf("want no warnings for a long-only state, got: %v", warnings)
+	}
+}
+
+// TestValidatePerpsAllowShortsConfig_OrphanState verifies we don't crash when
+// state has a strategy that's been removed from config (pruning happens
+// separately in main.go but validators must tolerate the intermediate state).
+func TestValidatePerpsAllowShortsConfig_OrphanState(t *testing.T) {
+	state := NewAppState()
+	state.Strategies["gone"] = &StrategyState{
+		ID:   "gone",
+		Type: "perps",
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, Side: "short", Multiplier: 1, Leverage: 1},
+		},
+	}
+	cfg := &Config{Strategies: []StrategyConfig{}}
+	if warnings := ValidatePerpsAllowShortsConfig(state, cfg); len(warnings) != 0 {
+		t.Errorf("orphan state should not produce warnings, got: %v", warnings)
 	}
 }
 


### PR DESCRIPTION
Adds `ValidatePerpsAllowShortsConfig` startup check for the state-vs-config gap described in #336: a short position in state under a perps strategy configured with AllowShorts=false. The executor's fresh-open sizing path cannot reconcile this — a buy nets against the short on-exchange but flips virtually, leaving virtual state desynced. Policy is warn-and-continue with stderr log + owner DM, matching `ValidateState`. Includes regression tests for the gap case, the long-only baseline, and orphan state.

Close #336

Generated with [Claude Code](https://claude.ai/code)