### PR TITLE
Warn on startup when live strategies run without state DB

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -31,6 +31,16 @@ func main() {
 	}
 	fmt.Printf("Loaded config: %d strategies, interval=%ds\n", len(cfg.Strategies), cfg.IntervalSeconds)
 
+	// #339: Detect a missing state DB on a live deployment *before* OpenStateDB
+	// creates it — a wiped directory (vs. an in-place `git pull`) would otherwise
+	// silently produce a fresh empty DB and desync from exchange positions.
+	// Captured here and replayed to the owner DM once the notifier is wired.
+	var missingStateWarning string
+	if msg := CheckStatePresence(cfg.DBFile, cfg.Strategies); msg != "" && !AllowMissingState() {
+		fmt.Fprintln(os.Stderr, msg)
+		missingStateWarning = msg
+	}
+
 	// Open SQLite state database.
 	stateDB, err := OpenStateDB(cfg.DBFile)
 	if err != nil {
@@ -207,6 +217,13 @@ func main() {
 		for _, msg := range allowShortsWarnings {
 			notifier.SendOwnerDM("[state] " + msg)
 		}
+	}
+
+	// #339: Forward the missing-state-DB warning to the owner. Captured before
+	// OpenStateDB ran (which would have created an empty DB), surfaced here
+	// once the notifier is available.
+	if missingStateWarning != "" && notifier.HasOwner() {
+		notifier.SendOwnerDM("[state] " + missingStateWarning)
 	}
 
 	// -summary mode: post snapshot summary for the specified channel and exit.

--- a/scheduler/state_presence.go
+++ b/scheduler/state_presence.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// HasLiveStrategy reports whether any configured strategy passes --mode=live
+// to its check script. Paper-only deployments don't hold persistent exchange
+// state, so a missing state.db on first startup is expected for them — the
+// wipe-on-update concern from issue #339 only matters when live positions
+// exist.
+func HasLiveStrategy(strategies []StrategyConfig) bool {
+	for _, sc := range strategies {
+		for _, arg := range sc.Args {
+			if arg == "--mode=live" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// CheckStatePresence returns a CRITICAL warning when a live deployment is
+// starting without its persisted state DB — typically a sign that the update
+// process wiped the repo directory instead of running `git pull` in place
+// (issue #339). Returns empty string when no warning is needed.
+//
+// The check runs BEFORE OpenStateDB because that call creates the file if it
+// doesn't exist, erasing the signal.
+func CheckStatePresence(dbPath string, strategies []StrategyConfig) string {
+	if !HasLiveStrategy(strategies) {
+		return ""
+	}
+	if _, err := os.Stat(dbPath); err == nil {
+		return ""
+	} else if !os.IsNotExist(err) {
+		return ""
+	}
+	return fmt.Sprintf(
+		"CRITICAL: state DB %q is missing but live strategies are configured. "+
+			"If you just updated the trader, the directory may have been wiped instead of "+
+			"`git pull`ed in place — open positions and trade history will not be reconciled "+
+			"on this cycle. See issue #339. Set GO_TRADER_ALLOW_MISSING_STATE=1 to silence "+
+			"this warning (e.g. genuine first-run deployments).",
+		dbPath,
+	)
+}
+
+// AllowMissingState returns true when the operator has explicitly opted out
+// of the missing-state warning — used by genuine first-run deployments where
+// no DB is expected yet.
+func AllowMissingState() bool {
+	return os.Getenv("GO_TRADER_ALLOW_MISSING_STATE") == "1"
+}

--- a/scheduler/state_presence.go
+++ b/scheduler/state_presence.go
@@ -12,8 +12,11 @@ import (
 // exist.
 func HasLiveStrategy(strategies []StrategyConfig) bool {
 	for _, sc := range strategies {
-		for _, arg := range sc.Args {
+		for i, arg := range sc.Args {
 			if arg == "--mode=live" {
+				return true
+			}
+			if arg == "--mode" && i+1 < len(sc.Args) && sc.Args[i+1] == "live" {
 				return true
 			}
 		}
@@ -35,6 +38,10 @@ func CheckStatePresence(dbPath string, strategies []StrategyConfig) string {
 	if _, err := os.Stat(dbPath); err == nil {
 		return ""
 	} else if !os.IsNotExist(err) {
+		// Non-IsNotExist errors (permission denied, transient I/O) are
+		// deliberately ignored — the #339 concern is specifically the
+		// wiped-directory case, and warning on transient filesystem hiccups
+		// would generate false positives.
 		return ""
 	}
 	return fmt.Sprintf(

--- a/scheduler/state_presence_test.go
+++ b/scheduler/state_presence_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHasLiveStrategy(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []StrategyConfig
+		want bool
+	}{
+		{"empty", nil, false},
+		{"paper only", []StrategyConfig{{ID: "a", Args: []string{"--mode=paper"}}}, false},
+		{"no mode arg", []StrategyConfig{{ID: "a", Args: []string{"--symbol=BTC"}}}, false},
+		{"one live among many", []StrategyConfig{
+			{ID: "a", Args: []string{"--mode=paper"}},
+			{ID: "b", Args: []string{"foo", "--mode=live"}},
+		}, true},
+		{"mode=live suffix only does not match", []StrategyConfig{
+			{ID: "a", Args: []string{"mode=live"}},
+		}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := HasLiveStrategy(c.in); got != c.want {
+				t.Fatalf("HasLiveStrategy=%v want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestCheckStatePresence(t *testing.T) {
+	dir := t.TempDir()
+	liveCfg := []StrategyConfig{{ID: "hl-x", Args: []string{"--mode=live"}}}
+	paperCfg := []StrategyConfig{{ID: "hl-x", Args: []string{"--mode=paper"}}}
+
+	// Missing DB + live → warns.
+	missing := filepath.Join(dir, "missing.db")
+	if got := CheckStatePresence(missing, liveCfg); !strings.Contains(got, "CRITICAL") {
+		t.Fatalf("expected CRITICAL warning for missing live DB, got %q", got)
+	}
+
+	// Missing DB + paper-only → no warning.
+	if got := CheckStatePresence(missing, paperCfg); got != "" {
+		t.Fatalf("expected no warning for paper-only, got %q", got)
+	}
+
+	// Existing DB + live → no warning.
+	existing := filepath.Join(dir, "state.db")
+	if err := os.WriteFile(existing, nil, 0644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if got := CheckStatePresence(existing, liveCfg); got != "" {
+		t.Fatalf("expected no warning for existing DB, got %q", got)
+	}
+}

--- a/scheduler/state_presence_test.go
+++ b/scheduler/state_presence_test.go
@@ -23,6 +23,15 @@ func TestHasLiveStrategy(t *testing.T) {
 		{"mode=live suffix only does not match", []StrategyConfig{
 			{ID: "a", Args: []string{"mode=live"}},
 		}, false},
+		{"two-token --mode live form", []StrategyConfig{
+			{ID: "a", Args: []string{"--mode", "live"}},
+		}, true},
+		{"two-token --mode paper form", []StrategyConfig{
+			{ID: "a", Args: []string{"--mode", "paper"}},
+		}, false},
+		{"trailing --mode with no value", []StrategyConfig{
+			{ID: "a", Args: []string{"--mode"}},
+		}, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -56,5 +65,33 @@ func TestCheckStatePresence(t *testing.T) {
 	}
 	if got := CheckStatePresence(existing, liveCfg); got != "" {
 		t.Fatalf("expected no warning for existing DB, got %q", got)
+	}
+}
+
+func TestAllowMissingState(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		set  bool
+		want bool
+	}{
+		{"unset", "", false, false},
+		{"empty", "", true, false},
+		{"one", "1", true, true},
+		{"true string not accepted", "true", true, false},
+		{"yes string not accepted", "yes", true, false},
+		{"zero", "0", true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.set {
+				t.Setenv("GO_TRADER_ALLOW_MISSING_STATE", c.val)
+			} else {
+				os.Unsetenv("GO_TRADER_ALLOW_MISSING_STATE")
+			}
+			if got := AllowMissingState(); got != c.want {
+				t.Fatalf("AllowMissingState=%v want %v", got, c.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #339

When the live trader's repo is wiped-and-recloned instead of `git pull`ed in place, `state.db` disappears and `OpenStateDB` silently creates a fresh empty one — open positions and trade history desync from the exchange.

Add a pre-`OpenStateDB` existence check. If any strategy passes `--mode=live` and `cfg.DBFile` is missing, log a CRITICAL warning and DM the owner once the notifier is wired. Operators can set `GO_TRADER_ALLOW_MISSING_STATE=1` to silence the warning on genuine first-run deployments.

Generated with [Claude Code](https://claude.ai/code)