### PR TITLE
Guard initial_capital against silent overwrite in SaveState

### DIFF
--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -368,6 +368,14 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		}
 		existingInitCaps[id] = existing
 	}
+	// rows.Next() returns false on both exhaustion and mid-iteration error;
+	// without this Err() check a transient SQLite failure would yield a
+	// silently-incomplete snapshot and leave un-snapshotted strategies
+	// unprotected by the baseline guard for this save cycle.
+	if err := existingRows.Err(); err != nil {
+		existingRows.Close()
+		return fmt.Errorf("iterate existing initial_capital: %w", err)
+	}
 	existingRows.Close()
 
 	// 3. Delete all strategies (CASCADE deletes positions + option_positions).

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -253,6 +253,33 @@ func (sdb *StateDB) InsertTrade(strategyID string, trade Trade) error {
 	return nil
 }
 
+// SetInitialCapital is the ONLY sanctioned way to change a strategy's
+// initial_capital baseline (#343). All other write paths go through SaveState,
+// which preserves the existing baseline. Callers are expected to be an
+// explicit user command (CLI flag, admin script, migration), not normal
+// runtime state persistence.
+func (sdb *StateDB) SetInitialCapital(strategyID string, value float64) error {
+	if sdb == nil || sdb.db == nil {
+		return fmt.Errorf("state db unavailable")
+	}
+	if value <= 0 {
+		return fmt.Errorf("initial_capital must be > 0, got %g", value)
+	}
+	res, err := sdb.db.Exec("UPDATE strategies SET initial_capital = ? WHERE id = ?", value, strategyID)
+	if err != nil {
+		return fmt.Errorf("update initial_capital for %s: %w", strategyID, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("no strategy row for id=%q", strategyID)
+	}
+	fmt.Printf("[state] initial_capital override for %s set to $%.2f (#343)\n", strategyID, value)
+	return nil
+}
+
 // SaveState writes the full AppState to SQLite within a single transaction.
 func (sdb *StateDB) SaveState(state *AppState) error {
 	tx, err := sdb.db.Begin()
@@ -280,12 +307,31 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		return fmt.Errorf("upsert app_state: %w", err)
 	}
 
-	// 2. Delete all strategies (CASCADE deletes positions + option_positions).
+	// 2. Snapshot existing initial_capital per strategy so the save path can
+	// never silently rewrite a PnL baseline (#343). Captured before DELETE so
+	// the CASCADE doesn't erase the prior values first.
+	existingInitCaps := make(map[string]float64)
+	existingRows, err := tx.Query("SELECT id, initial_capital FROM strategies")
+	if err != nil {
+		return fmt.Errorf("read existing initial_capital: %w", err)
+	}
+	for existingRows.Next() {
+		var id string
+		var cap float64
+		if err := existingRows.Scan(&id, &cap); err != nil {
+			existingRows.Close()
+			return fmt.Errorf("scan existing initial_capital: %w", err)
+		}
+		existingInitCaps[id] = cap
+	}
+	existingRows.Close()
+
+	// 3. Delete all strategies (CASCADE deletes positions + option_positions).
 	if _, err := tx.Exec("DELETE FROM strategies"); err != nil {
 		return fmt.Errorf("delete strategies: %w", err)
 	}
 
-	// 3. Insert strategies with flattened risk state.
+	// 4. Insert strategies with flattened risk state.
 	stmtStrat, err := tx.Prepare(`INSERT OR REPLACE INTO strategies (id, type, platform, cash, initial_capital,
 		risk_peak_value, risk_max_drawdown_pct, risk_current_drawdown_pct,
 		risk_daily_pnl, risk_daily_pnl_date, risk_consecutive_losses,
@@ -314,6 +360,17 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	defer stmtOpt.Close()
 
 	for _, s := range state.Strategies {
+		// Immutable baseline guard (#343): if a prior initial_capital exists
+		// and the incoming value disagrees, keep the prior value so PnL
+		// history stays comparable across restarts, state restores, and
+		// position closes. A baseline change requires an explicit override
+		// via StateDB.SetInitialCapital.
+		if prev, ok := existingInitCaps[s.ID]; ok && prev > 0 && s.InitialCapital != prev {
+			fmt.Printf("[WARN] state: blocking initial_capital change for %s ($%.2f → $%.2f); baseline preserved (#343)\n",
+				s.ID, prev, s.InitialCapital)
+			s.InitialCapital = prev
+		}
+
 		cbInt := 0
 		if s.RiskState.CircuitBreaker {
 			cbInt = 1
@@ -346,7 +403,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		}
 	}
 
-	// 4. Append-only trades: insert any TradeHistory rows that have not yet been
+	// 5. Append-only trades: insert any TradeHistory rows that have not yet been
 	//    persisted (t.persisted == false). LoadState and successful RecordTrade
 	//    both flip the flag to true, so SaveState only flushes the backlog —
 	//    including any rows whose eager InsertTrade earlier in the cycle
@@ -445,7 +502,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		}
 	}
 
-	// 5. Upsert portfolio_risk singleton.
+	// 6. Upsert portfolio_risk singleton.
 	ksActive := 0
 	if state.PortfolioRisk.KillSwitchActive {
 		ksActive = 1
@@ -462,7 +519,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		return fmt.Errorf("upsert portfolio_risk: %w", err)
 	}
 
-	// 6. Kill switch events: replace all (capped at maxKillSwitchEvents).
+	// 7. Kill switch events: replace all (capped at maxKillSwitchEvents).
 	if _, err := tx.Exec("DELETE FROM kill_switch_events"); err != nil {
 		return fmt.Errorf("delete kill_switch_events: %w", err)
 	}
@@ -480,7 +537,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		}
 	}
 
-	// 7. Upsert correlation_snapshot singleton as JSON.
+	// 8. Upsert correlation_snapshot singleton as JSON.
 	snapJSON := "{}"
 	if state.CorrelationSnapshot != nil {
 		data, err := json.Marshal(state.CorrelationSnapshot)

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -7,10 +7,23 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	_ "modernc.org/sqlite"
 )
+
+// initialCapitalGuardWarn is the operator-visible hook for #343 baseline-guard
+// warnings. main.go wires it to the owner DM after MultiNotifier is built so
+// silent overwrites surface beyond stderr. Nil-safe: SaveState falls back to
+// stderr-only when the hook isn't set (early boot, tests).
+var initialCapitalGuardWarn func(msg string)
+
+// initialCapitalGuardWarned dedups baseline-guard warnings to one per strategy
+// per process lifetime. Without this the per-cycle SaveState would re-emit the
+// same warning forever once config drifts from the persisted baseline. Cleared
+// on restart so a still-broken caller is re-flagged after redeploy.
+var initialCapitalGuardWarned sync.Map // map[string]struct{}, key = strategy ID
 
 const schemaDDL = `
 CREATE TABLE IF NOT EXISTS app_state (
@@ -256,8 +269,20 @@ func (sdb *StateDB) InsertTrade(strategyID string, trade Trade) error {
 // SetInitialCapital is the ONLY sanctioned way to change a strategy's
 // initial_capital baseline (#343). All other write paths go through SaveState,
 // which preserves the existing baseline. Callers are expected to be an
-// explicit user command (CLI flag, admin script, migration), not normal
-// runtime state persistence.
+// explicit user command (CLI flag, admin script, config-drift reconciler at
+// startup), not normal runtime state persistence.
+//
+// Concurrency: runs inside a transaction so a concurrent SaveState observes
+// either the pre- or post-override value, never an interleaved snapshot. With
+// SQLite's single-writer model and SetMaxOpenConns(1), a SaveState already in
+// progress will serialize behind this update.
+//
+// In-memory caveat: this only updates the persisted row. Any AppState already
+// in memory still holds the stale value until reloaded — risk/PnL calculations
+// that fire before the next process restart (or in-place reload of state) will
+// continue to use the pre-override baseline. The startup config-drift path in
+// main.go handles this by mutating in-memory state alongside the DB write;
+// callers invoking this directly mid-run must do the same or accept the gap.
 func (sdb *StateDB) SetInitialCapital(strategyID string, value float64) error {
 	if sdb == nil || sdb.db == nil {
 		return fmt.Errorf("state db unavailable")
@@ -265,7 +290,12 @@ func (sdb *StateDB) SetInitialCapital(strategyID string, value float64) error {
 	if value <= 0 {
 		return fmt.Errorf("initial_capital must be > 0, got %g", value)
 	}
-	res, err := sdb.db.Exec("UPDATE strategies SET initial_capital = ? WHERE id = ?", value, strategyID)
+	tx, err := sdb.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	res, err := tx.Exec("UPDATE strategies SET initial_capital = ? WHERE id = ?", value, strategyID)
 	if err != nil {
 		return fmt.Errorf("update initial_capital for %s: %w", strategyID, err)
 	}
@@ -276,11 +306,25 @@ func (sdb *StateDB) SetInitialCapital(strategyID string, value float64) error {
 	if n == 0 {
 		return fmt.Errorf("no strategy row for id=%q", strategyID)
 	}
-	fmt.Printf("[state] initial_capital override for %s set to $%.2f (#343)\n", strategyID, value)
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	// Allow the guard to fire again for this strategy if a future SaveState
+	// still tries to revert the new baseline — the override is a fresh state
+	// of the world.
+	initialCapitalGuardWarned.Delete(strategyID)
+	fmt.Fprintf(os.Stderr, "[state] initial_capital override for %s set to $%.2f (#343)\n", strategyID, value)
 	return nil
 }
 
 // SaveState writes the full AppState to SQLite within a single transaction.
+//
+// Side effect (#343): when the in-memory StrategyState carries an
+// initial_capital that disagrees with the persisted baseline, SaveState
+// rewrites the in-memory field to match the persisted value. Callers should
+// not rely on the post-save struct holding their original value — the
+// persisted baseline is treated as the source of truth. Use
+// StateDB.SetInitialCapital to change a baseline.
 func (sdb *StateDB) SaveState(state *AppState) error {
 	tx, err := sdb.db.Begin()
 	if err != nil {
@@ -317,12 +361,12 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	}
 	for existingRows.Next() {
 		var id string
-		var cap float64
-		if err := existingRows.Scan(&id, &cap); err != nil {
+		var existing float64
+		if err := existingRows.Scan(&id, &existing); err != nil {
 			existingRows.Close()
 			return fmt.Errorf("scan existing initial_capital: %w", err)
 		}
-		existingInitCaps[id] = cap
+		existingInitCaps[id] = existing
 	}
 	existingRows.Close()
 
@@ -366,9 +410,16 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		// position closes. A baseline change requires an explicit override
 		// via StateDB.SetInitialCapital.
 		if prev, ok := existingInitCaps[s.ID]; ok && prev > 0 && s.InitialCapital != prev {
-			fmt.Printf("[WARN] state: blocking initial_capital change for %s ($%.2f → $%.2f); baseline preserved (#343)\n",
-				s.ID, prev, s.InitialCapital)
+			attempted := s.InitialCapital
 			s.InitialCapital = prev
+			if _, alreadyWarned := initialCapitalGuardWarned.LoadOrStore(s.ID, struct{}{}); !alreadyWarned {
+				msg := fmt.Sprintf("blocking initial_capital change for %s ($%.2f → $%.2f); baseline preserved. Use StateDB.SetInitialCapital or set initial_capital in config to change the baseline (#343)",
+					s.ID, prev, attempted)
+				fmt.Fprintf(os.Stderr, "[state] WARN: %s\n", msg)
+				if initialCapitalGuardWarn != nil {
+					initialCapitalGuardWarn(msg)
+				}
+			}
 		}
 
 		cbInt := 0

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -19,7 +19,18 @@ func openTestDB(t *testing.T) *StateDB {
 		t.Fatalf("OpenStateDB: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
+	resetInitialCapitalGuardDedup(t)
 	return db
+}
+
+// resetInitialCapitalGuardDedup wipes the package-level dedup map so a test
+// that asserts on warn counts (or simply triggers the guard repeatedly) is
+// not influenced by prior tests in the same package run. Registers a Cleanup
+// so the next test also starts from a clean slate even if this one panics.
+func resetInitialCapitalGuardDedup(t *testing.T) {
+	t.Helper()
+	initialCapitalGuardWarned = sync.Map{}
+	t.Cleanup(func() { initialCapitalGuardWarned = sync.Map{} })
 }
 
 func TestOpenStateDB(t *testing.T) {
@@ -1610,9 +1621,8 @@ func TestSetInitialCapital_RejectsInvalid(t *testing.T) {
 // per-cycle SaveState calls don't spam the operator DM.
 func TestSaveState_GuardWarnIsOneShot(t *testing.T) {
 	db := openTestDB(t)
-
-	// Reset the dedup map so prior tests don't leak.
-	initialCapitalGuardWarned = sync.Map{}
+	// Dedup map is reset by openTestDB → resetInitialCapitalGuardDedup so
+	// prior tests don't leak warn counts into this assertion.
 
 	var warns int
 	prev := initialCapitalGuardWarn

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -1355,3 +1355,206 @@ func TestSaveLoadState_LeaderboardSummaries(t *testing.T) {
 		}
 	}
 }
+
+// TestSaveState_PreservesInitialCapital verifies the #343 guard: once an
+// initial_capital baseline has been persisted, subsequent SaveState calls can
+// never silently overwrite it, even if the in-memory StrategyState has a
+// different value. Normal state persistence (cycle saves, position closes,
+// restarts) must leave the baseline untouched.
+func TestSaveState_PreservesInitialCapital(t *testing.T) {
+	db := openTestDB(t)
+
+	initial := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-tema-eth": {
+				ID:              "hl-tema-eth",
+				Type:            "perps",
+				Platform:        "hyperliquid",
+				Cash:            505,
+				InitialCapital:  505,
+				Positions:       map[string]*Position{},
+				OptionPositions: map[string]*OptionPosition{},
+			},
+		},
+	}
+	if err := db.SaveState(initial); err != nil {
+		t.Fatalf("first SaveState: %v", err)
+	}
+
+	// Simulate the incident: something (operator agent, buggy code path) tries
+	// to rewrite initial_capital alongside a normal state save.
+	mutated := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-tema-eth": {
+				ID:              "hl-tema-eth",
+				Type:            "perps",
+				Platform:        "hyperliquid",
+				Cash:            632,
+				InitialCapital:  632,
+				Positions:       map[string]*Position{},
+				OptionPositions: map[string]*OptionPosition{},
+			},
+		},
+	}
+	if err := db.SaveState(mutated); err != nil {
+		t.Fatalf("second SaveState: %v", err)
+	}
+
+	// Guard should preserve the baseline and mutate the in-memory state so
+	// subsequent reads stay consistent with the DB.
+	if got := mutated.Strategies["hl-tema-eth"].InitialCapital; got != 505 {
+		t.Errorf("in-memory InitialCapital = %g, want 505 (guard should have restored it)", got)
+	}
+
+	// Cash is a normal runtime field — guard must not touch it.
+	if got := mutated.Strategies["hl-tema-eth"].Cash; got != 632 {
+		t.Errorf("Cash = %g, want 632 (guard must only protect initial_capital)", got)
+	}
+
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got := loaded.Strategies["hl-tema-eth"].InitialCapital; got != 505 {
+		t.Errorf("persisted initial_capital = %g, want 505", got)
+	}
+	if got := loaded.Strategies["hl-tema-eth"].Cash; got != 632 {
+		t.Errorf("persisted cash = %g, want 632", got)
+	}
+}
+
+// TestSaveState_AllowsFirstInitialCapitalWrite confirms the guard only protects
+// an *existing* baseline — the very first save (DB empty, or prior row had 0)
+// must establish the baseline normally.
+func TestSaveState_AllowsFirstInitialCapitalWrite(t *testing.T) {
+	db := openTestDB(t)
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"new-strat": {
+				ID: "new-strat", Type: "spot", Cash: 1000, InitialCapital: 1000,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+			},
+		},
+	}
+	if err := db.SaveState(state); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got := loaded.Strategies["new-strat"].InitialCapital; got != 1000 {
+		t.Errorf("initial_capital = %g, want 1000 (first write must land)", got)
+	}
+}
+
+// TestSaveState_AllowsNewStrategies confirms the guard does not block strategy
+// rows that don't yet exist in the DB (new strategies added to config between
+// restarts).
+func TestSaveState_AllowsNewStrategies(t *testing.T) {
+	db := openTestDB(t)
+
+	first := &AppState{
+		Strategies: map[string]*StrategyState{
+			"old": {
+				ID: "old", Type: "spot", Cash: 1000, InitialCapital: 1000,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+			},
+		},
+	}
+	if err := db.SaveState(first); err != nil {
+		t.Fatalf("first SaveState: %v", err)
+	}
+
+	second := &AppState{
+		Strategies: map[string]*StrategyState{
+			"old": {
+				ID: "old", Type: "spot", Cash: 1000, InitialCapital: 1000,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+			},
+			"brand-new": {
+				ID: "brand-new", Type: "spot", Cash: 2000, InitialCapital: 2000,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+			},
+		},
+	}
+	if err := db.SaveState(second); err != nil {
+		t.Fatalf("second SaveState: %v", err)
+	}
+
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got := loaded.Strategies["brand-new"].InitialCapital; got != 2000 {
+		t.Errorf("new strategy initial_capital = %g, want 2000", got)
+	}
+	if got := loaded.Strategies["old"].InitialCapital; got != 1000 {
+		t.Errorf("old strategy initial_capital = %g, want 1000", got)
+	}
+}
+
+// TestSetInitialCapital_ExplicitOverride is the sanctioned escape hatch —
+// admin/CLI code can permanently change the baseline through this path.
+func TestSetInitialCapital_ExplicitOverride(t *testing.T) {
+	db := openTestDB(t)
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"s": {
+				ID: "s", Type: "spot", Cash: 505, InitialCapital: 505,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+			},
+		},
+	}
+	if err := db.SaveState(state); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	if err := db.SetInitialCapital("s", 750); err != nil {
+		t.Fatalf("SetInitialCapital: %v", err)
+	}
+
+	// A subsequent SaveState must carry the new baseline forward, not revert
+	// to the in-memory (stale) value.
+	state.Strategies["s"].InitialCapital = 505 // stale in-memory value
+	if err := db.SaveState(state); err != nil {
+		t.Fatalf("SaveState after override: %v", err)
+	}
+
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got := loaded.Strategies["s"].InitialCapital; got != 750 {
+		t.Errorf("initial_capital = %g, want 750 (override must stick)", got)
+	}
+}
+
+func TestSetInitialCapital_RejectsInvalid(t *testing.T) {
+	db := openTestDB(t)
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"s": {
+				ID: "s", Type: "spot", Cash: 1000, InitialCapital: 1000,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+			},
+		},
+	}
+	if err := db.SaveState(state); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	if err := db.SetInitialCapital("s", 0); err == nil {
+		t.Error("expected error for zero initial_capital")
+	}
+	if err := db.SetInitialCapital("s", -100); err == nil {
+		t.Error("expected error for negative initial_capital")
+	}
+	if err := db.SetInitialCapital("unknown-id", 1000); err == nil {
+		t.Error("expected error for unknown strategy id")
+	}
+}

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -1496,6 +1497,51 @@ func TestSaveState_AllowsNewStrategies(t *testing.T) {
 	}
 }
 
+// TestSaveState_AllowsBaselineWhenPrevZero confirms the legacy/reset path
+// (#343 review item 7): if a prior row exists with initial_capital = 0
+// (e.g. after ValidateState clamped a malformed value at state.go:144), the
+// next SaveState carrying a real positive baseline must establish it — the
+// guard's `prev > 0` precondition is what makes this work.
+func TestSaveState_AllowsBaselineWhenPrevZero(t *testing.T) {
+	db := openTestDB(t)
+
+	// Seed a strategy row with initial_capital = 0 (mimics the post-ValidateState
+	// reset path).
+	zeroState := &AppState{
+		Strategies: map[string]*StrategyState{
+			"legacy": {
+				ID: "legacy", Type: "spot", Cash: 0, InitialCapital: 0,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+			},
+		},
+	}
+	if err := db.SaveState(zeroState); err != nil {
+		t.Fatalf("seed SaveState: %v", err)
+	}
+
+	// Now save with a real baseline. Guard must let it through (prev == 0
+	// means "no real baseline yet").
+	bumped := &AppState{
+		Strategies: map[string]*StrategyState{
+			"legacy": {
+				ID: "legacy", Type: "spot", Cash: 1000, InitialCapital: 1000,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+			},
+		},
+	}
+	if err := db.SaveState(bumped); err != nil {
+		t.Fatalf("bumped SaveState: %v", err)
+	}
+
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got := loaded.Strategies["legacy"].InitialCapital; got != 1000 {
+		t.Errorf("initial_capital = %g, want 1000 (prev==0 must allow baseline establishment)", got)
+	}
+}
+
 // TestSetInitialCapital_ExplicitOverride is the sanctioned escape hatch —
 // admin/CLI code can permanently change the baseline through this path.
 func TestSetInitialCapital_ExplicitOverride(t *testing.T) {
@@ -1556,5 +1602,69 @@ func TestSetInitialCapital_RejectsInvalid(t *testing.T) {
 	}
 	if err := db.SetInitialCapital("unknown-id", 1000); err == nil {
 		t.Error("expected error for unknown strategy id")
+	}
+}
+
+// TestSaveState_GuardWarnIsOneShot covers the #343 review item 3 follow-up:
+// the baseline-guard warning must fire only once per strategy per process so
+// per-cycle SaveState calls don't spam the operator DM.
+func TestSaveState_GuardWarnIsOneShot(t *testing.T) {
+	db := openTestDB(t)
+
+	// Reset the dedup map so prior tests don't leak.
+	initialCapitalGuardWarned = sync.Map{}
+
+	var warns int
+	prev := initialCapitalGuardWarn
+	initialCapitalGuardWarn = func(string) { warns++ }
+	t.Cleanup(func() { initialCapitalGuardWarn = prev })
+
+	seed := &AppState{
+		Strategies: map[string]*StrategyState{
+			"s": {
+				ID: "s", Type: "spot", Cash: 100, InitialCapital: 100,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+			},
+		},
+	}
+	if err := db.SaveState(seed); err != nil {
+		t.Fatalf("seed SaveState: %v", err)
+	}
+
+	bad := &AppState{
+		Strategies: map[string]*StrategyState{
+			"s": {
+				ID: "s", Type: "spot", Cash: 100, InitialCapital: 200,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+			},
+		},
+	}
+	for i := 0; i < 5; i++ {
+		if err := db.SaveState(bad); err != nil {
+			t.Fatalf("save %d: %v", i, err)
+		}
+	}
+	if warns != 1 {
+		t.Errorf("warn fired %d times, want 1 (one-shot per strategy)", warns)
+	}
+
+	// SetInitialCapital clears the dedup so a subsequent guard violation
+	// against the new baseline fires again.
+	if err := db.SetInitialCapital("s", 200); err != nil {
+		t.Fatalf("SetInitialCapital: %v", err)
+	}
+	stillBad := &AppState{
+		Strategies: map[string]*StrategyState{
+			"s": {
+				ID: "s", Type: "spot", Cash: 100, InitialCapital: 50,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+			},
+		},
+	}
+	if err := db.SaveState(stillBad); err != nil {
+		t.Fatalf("stillBad save: %v", err)
+	}
+	if warns != 2 {
+		t.Errorf("warn fired %d times after override, want 2 (dedup must reset)", warns)
 	}
 }

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -65,6 +65,13 @@ func main() {
 	// #87: Resolve capital_pct at startup so initial state gets the right capital.
 	resolveCapitalPct(cfg.Strategies)
 
+	// #343: Reconcile any operator-driven initial_capital changes from config
+	// against the persisted baseline. Without this, the SaveState guard would
+	// silently revert a legitimate "bump initial_capital in config.json" edit
+	// on the next cycle. Captured here, surfaced to the owner DM once the
+	// notifier is wired below.
+	initialCapitalChangeWarnings := ReconcileConfigInitialCapital(cfg, state, stateDB)
+
 	// Initialize new strategies and sync config values for existing ones
 	for i := range cfg.Strategies {
 		sc := &cfg.Strategies[i]
@@ -207,6 +214,21 @@ func main() {
 	// to stderr via the nil-check in state.go.
 	if notifier.HasOwner() {
 		tradePersistWarn = func(msg string) {
+			notifier.SendOwnerDM("[state] " + msg)
+		}
+		// #343: Forward baseline-guard warnings (a SaveState caller tried to
+		// rewrite initial_capital) to the owner DM. Dedup is handled inside
+		// SaveState — this only fires once per strategy per process lifetime.
+		initialCapitalGuardWarn = func(msg string) {
+			notifier.SendOwnerDM("[state] " + msg)
+		}
+	}
+
+	// #343: Forward startup config-driven baseline changes to the owner. These
+	// are routine when the operator intentionally bumps initial_capital in
+	// config, but worth surfacing so the change is visible in DMs.
+	if len(initialCapitalChangeWarnings) > 0 && notifier.HasOwner() {
+		for _, msg := range initialCapitalChangeWarnings {
 			notifier.SendOwnerDM("[state] " + msg)
 		}
 	}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -70,7 +70,7 @@ func main() {
 	// silently revert a legitimate "bump initial_capital in config.json" edit
 	// on the next cycle. Captured here, surfaced to the owner DM once the
 	// notifier is wired below.
-	initialCapitalChangeWarnings := ReconcileConfigInitialCapital(cfg, state, stateDB)
+	initialCapitalChangeInfos, initialCapitalChangeErrors := ReconcileConfigInitialCapital(cfg, state, stateDB)
 
 	// Initialize new strategies and sync config values for existing ones
 	for i := range cfg.Strategies {
@@ -224,12 +224,16 @@ func main() {
 		}
 	}
 
-	// #343: Forward startup config-driven baseline changes to the owner. These
-	// are routine when the operator intentionally bumps initial_capital in
-	// config, but worth surfacing so the change is visible in DMs.
-	if len(initialCapitalChangeWarnings) > 0 && notifier.HasOwner() {
-		for _, msg := range initialCapitalChangeWarnings {
+	// #343: Forward startup config-driven baseline changes to the owner. Info
+	// DMs confirm a deliberate bump; ERROR DMs surface a persist failure where
+	// the DB still holds the prior baseline. Both are routine but worth
+	// surfacing so the change (or its failure) is visible.
+	if notifier.HasOwner() {
+		for _, msg := range initialCapitalChangeInfos {
 			notifier.SendOwnerDM("[state] " + msg)
+		}
+		for _, msg := range initialCapitalChangeErrors {
+			notifier.SendOwnerDM("[state] ERROR: " + msg)
 		}
 	}
 

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -226,17 +226,19 @@ func ValidatePerpsAllowShortsConfig(state *AppState, cfg *Config) []string {
 //     path so the guard's snapshot picks it up next cycle.
 //   - Mutate the in-memory StrategyState so any startup-time PnL/risk
 //     calculation in the same process sees the new value immediately.
-//   - Return human-readable warnings so main.go can DM the owner — a
-//     baseline change is rare and worth surfacing.
+//   - Return separate info messages (successful applies) and error messages
+//     (persist failures) so main.go can DM the owner with a clear distinction
+//     — a baseline change is rare and worth surfacing either way, but the
+//     caller should be able to tell success from failure without parsing the
+//     string.
 //
 // Strategies that omit initial_capital from config are ignored: Capital is a
 // runtime field that drifts with PnL and capital_pct rebases, so it is not a
 // reliable signal of "operator wants to change the baseline." The explicit
 // path is `initial_capital` in config or a direct SetInitialCapital call.
-func ReconcileConfigInitialCapital(cfg *Config, state *AppState, sdb *StateDB) []string {
-	var warnings []string
+func ReconcileConfigInitialCapital(cfg *Config, state *AppState, sdb *StateDB) (infos []string, errors []string) {
 	if state == nil || sdb == nil {
-		return warnings
+		return nil, nil
 	}
 	for _, sc := range cfg.Strategies {
 		if sc.InitialCapital <= 0 {
@@ -251,16 +253,16 @@ func ReconcileConfigInitialCapital(cfg *Config, state *AppState, sdb *StateDB) [
 			msg := fmt.Sprintf("config-driven initial_capital change for %s ($%.2f → $%.2f) failed to persist: %v — DB still holds $%.2f",
 				sc.ID, prev, sc.InitialCapital, err, prev)
 			fmt.Fprintf(os.Stderr, "[state] WARN: %s\n", msg)
-			warnings = append(warnings, msg)
+			errors = append(errors, msg)
 			continue
 		}
 		s.InitialCapital = sc.InitialCapital
 		msg := fmt.Sprintf("config-driven initial_capital change applied for %s: $%.2f → $%.2f (#343)",
 			sc.ID, prev, sc.InitialCapital)
 		fmt.Fprintf(os.Stderr, "[state] %s\n", msg)
-		warnings = append(warnings, msg)
+		infos = append(infos, msg)
 	}
-	return warnings
+	return infos, errors
 }
 
 // LoadStateWithDB loads state from SQLite. Returns a fresh AppState when the DB is empty.

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -214,6 +214,55 @@ func ValidatePerpsAllowShortsConfig(state *AppState, cfg *Config) []string {
 	return warnings
 }
 
+// ReconcileConfigInitialCapital bridges the #343 baseline guard with operator
+// intent expressed via config. The SaveState guard treats initial_capital as
+// immutable, so a legitimate change ("bump $505 → $1000") would otherwise be
+// silently reverted on every cycle. This function runs once at startup:
+//
+//   - For each strategy where config explicitly sets initial_capital
+//     (sc.InitialCapital > 0) and the persisted state baseline disagrees,
+//     treat the config field as the explicit override signal.
+//   - Persist the new baseline via the sanctioned StateDB.SetInitialCapital
+//     path so the guard's snapshot picks it up next cycle.
+//   - Mutate the in-memory StrategyState so any startup-time PnL/risk
+//     calculation in the same process sees the new value immediately.
+//   - Return human-readable warnings so main.go can DM the owner — a
+//     baseline change is rare and worth surfacing.
+//
+// Strategies that omit initial_capital from config are ignored: Capital is a
+// runtime field that drifts with PnL and capital_pct rebases, so it is not a
+// reliable signal of "operator wants to change the baseline." The explicit
+// path is `initial_capital` in config or a direct SetInitialCapital call.
+func ReconcileConfigInitialCapital(cfg *Config, state *AppState, sdb *StateDB) []string {
+	var warnings []string
+	if state == nil || sdb == nil {
+		return warnings
+	}
+	for _, sc := range cfg.Strategies {
+		if sc.InitialCapital <= 0 {
+			continue
+		}
+		s, ok := state.Strategies[sc.ID]
+		if !ok || s.InitialCapital <= 0 || s.InitialCapital == sc.InitialCapital {
+			continue
+		}
+		prev := s.InitialCapital
+		if err := sdb.SetInitialCapital(sc.ID, sc.InitialCapital); err != nil {
+			msg := fmt.Sprintf("config-driven initial_capital change for %s ($%.2f → $%.2f) failed to persist: %v — DB still holds $%.2f",
+				sc.ID, prev, sc.InitialCapital, err, prev)
+			fmt.Fprintf(os.Stderr, "[state] WARN: %s\n", msg)
+			warnings = append(warnings, msg)
+			continue
+		}
+		s.InitialCapital = sc.InitialCapital
+		msg := fmt.Sprintf("config-driven initial_capital change applied for %s: $%.2f → $%.2f (#343)",
+			sc.ID, prev, sc.InitialCapital)
+		fmt.Fprintf(os.Stderr, "[state] %s\n", msg)
+		warnings = append(warnings, msg)
+	}
+	return warnings
+}
+
 // LoadStateWithDB loads state from SQLite. Returns a fresh AppState when the DB is empty.
 func LoadStateWithDB(cfg *Config, sdb *StateDB) (*AppState, error) {
 	state, err := sdb.LoadState()

--- a/scheduler/state_test.go
+++ b/scheduler/state_test.go
@@ -355,6 +355,7 @@ func TestReconcileConfigInitialCapital(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
+	resetInitialCapitalGuardDedup(t)
 
 	// Seed DB with a $505 baseline.
 	state := &AppState{
@@ -382,9 +383,12 @@ func TestReconcileConfigInitialCapital(t *testing.T) {
 		},
 	}
 
-	warnings := ReconcileConfigInitialCapital(cfg, state, db)
-	if len(warnings) != 1 {
-		t.Fatalf("warnings = %d, want 1 (only hl-tema-eth changed)", len(warnings))
+	infos, errs := ReconcileConfigInitialCapital(cfg, state, db)
+	if len(infos) != 1 {
+		t.Fatalf("infos = %d, want 1 (only hl-tema-eth changed)", len(infos))
+	}
+	if len(errs) != 0 {
+		t.Fatalf("errs = %v, want none", errs)
 	}
 
 	// In-memory mutation must happen so same-process risk calcs see the new value.
@@ -416,6 +420,7 @@ func TestReconcileConfigInitialCapital_NoOpWhenAligned(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
+	resetInitialCapitalGuardDedup(t)
 
 	state := &AppState{
 		Strategies: map[string]*StrategyState{
@@ -429,7 +434,7 @@ func TestReconcileConfigInitialCapital_NoOpWhenAligned(t *testing.T) {
 	cfg := &Config{Strategies: []StrategyConfig{
 		{ID: "s", Type: "spot", Capital: 1000, InitialCapital: 1000},
 	}}
-	if w := ReconcileConfigInitialCapital(cfg, state, db); len(w) != 0 {
-		t.Errorf("warnings = %v, want none when config matches DB", w)
+	if infos, errs := ReconcileConfigInitialCapital(cfg, state, db); len(infos) != 0 || len(errs) != 0 {
+		t.Errorf("infos=%v errs=%v, want none when config matches DB", infos, errs)
 	}
 }

--- a/scheduler/state_test.go
+++ b/scheduler/state_test.go
@@ -345,3 +345,91 @@ func TestNewStrategyState_NoConfigInitialCapital(t *testing.T) {
 		t.Errorf("InitialCapital = %g, want 600 (from Capital fallback)", s.InitialCapital)
 	}
 }
+
+// TestReconcileConfigInitialCapital covers the #343 startup bridge between
+// operator-driven config bumps and the SaveState baseline guard.
+func TestReconcileConfigInitialCapital(t *testing.T) {
+	dir := t.TempDir()
+	db, err := OpenStateDB(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Seed DB with a $505 baseline.
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-tema-eth": {
+				ID: "hl-tema-eth", Type: "perps", Platform: "hyperliquid",
+				Cash: 505, InitialCapital: 505,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+			},
+			"silent": {
+				ID: "silent", Type: "spot", Cash: 200, InitialCapital: 200,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+			},
+		},
+	}
+	if err := db.SaveState(state); err != nil {
+		t.Fatal(err)
+	}
+
+	// Config bumps the explicit field for one strategy, leaves the other alone.
+	cfg := &Config{
+		Strategies: []StrategyConfig{
+			{ID: "hl-tema-eth", Type: "perps", Platform: "hyperliquid", Capital: 1000, InitialCapital: 1000},
+			{ID: "silent", Type: "spot", Capital: 200}, // no InitialCapital → no reconciliation
+		},
+	}
+
+	warnings := ReconcileConfigInitialCapital(cfg, state, db)
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %d, want 1 (only hl-tema-eth changed)", len(warnings))
+	}
+
+	// In-memory mutation must happen so same-process risk calcs see the new value.
+	if got := state.Strategies["hl-tema-eth"].InitialCapital; got != 1000 {
+		t.Errorf("in-memory InitialCapital = %g, want 1000", got)
+	}
+	if got := state.Strategies["silent"].InitialCapital; got != 200 {
+		t.Errorf("untouched strategy InitialCapital = %g, want 200", got)
+	}
+
+	// Persist must stick across a SaveState (the baseline guard would have
+	// reverted it if SetInitialCapital didn't run).
+	if err := db.SaveState(state); err != nil {
+		t.Fatalf("SaveState after reconcile: %v", err)
+	}
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := loaded.Strategies["hl-tema-eth"].InitialCapital; got != 1000 {
+		t.Errorf("persisted InitialCapital = %g, want 1000", got)
+	}
+}
+
+func TestReconcileConfigInitialCapital_NoOpWhenAligned(t *testing.T) {
+	dir := t.TempDir()
+	db, err := OpenStateDB(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"s": {ID: "s", Type: "spot", Cash: 1000, InitialCapital: 1000,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
+		},
+	}
+	if err := db.SaveState(state); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &Config{Strategies: []StrategyConfig{
+		{ID: "s", Type: "spot", Capital: 1000, InitialCapital: 1000},
+	}}
+	if w := ReconcileConfigInitialCapital(cfg, state, db); len(w) != 0 {
+		t.Errorf("warnings = %v, want none when config matches DB", w)
+	}
+}


### PR DESCRIPTION
Closes #343

Treats `initial_capital` as an immutable PnL baseline. `SaveState` now snapshots the existing per-strategy value before the DELETE+INSERT cycle and preserves it when the incoming value disagrees, logging a warning. The sanctioned way to change a baseline is the new `StateDB.SetInitialCapital` explicit-override method.

Generated with [Claude Code](https://claude.ai/code)