### PR TITLE
Close OKX live positions on portfolio kill switch (#345)

### DIFF
--- a/platforms/okx/adapter.py
+++ b/platforms/okx/adapter.py
@@ -159,6 +159,19 @@ class OKXExchangeAdapter:
     # Order execution (live mode only)
     # ─────────────────────────────────────────────
 
+    def fetch_open_positions(self) -> list:
+        """Return every open perpetual swap position on the account.
+
+        Thin wrapper around ccxt's ``fetch_positions`` — exists so shared
+        scripts can stay off the private ``_exchange`` attribute (CLAUDE.md
+        rule). Raises in paper mode: position queries require auth.
+        """
+        if not self._is_live:
+            raise RuntimeError(
+                "fetch_open_positions requires live mode (set OKX_API_KEY, OKX_API_SECRET, OKX_PASSPHRASE)"
+            )
+        return self._exchange.fetch_positions() or []
+
     def market_open(self, symbol: str, is_buy: bool, size: float, inst_type: str = "spot") -> dict:
         """
         Place a market order.

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -562,6 +562,128 @@ func RunOKXExecute(script, symbol, side string, size float64, instType string) (
 	return &result, stderrStr, nil
 }
 
+// OKXCloseFill is the parsed fill block from close_okx_position.py.
+// Mirrors HyperliquidCloseFill so kill-switch accounting is symmetric
+// across platforms. OID is a string (ccxt order IDs are opaque strings,
+// unlike HL's int64) and all fields are optional — empty {} means the
+// adapter found no position to close (already-flat success).
+type OKXCloseFill struct {
+	AvgPx   float64 `json:"avg_px,omitempty"`
+	TotalSz float64 `json:"total_sz,omitempty"`
+	OID     string  `json:"oid,omitempty"`
+	Fee     float64 `json:"fee,omitempty"`
+}
+
+// OKXClose is the close block from close_okx_position.py.
+type OKXClose struct {
+	Symbol string        `json:"symbol"`
+	Fill   *OKXCloseFill `json:"fill,omitempty"`
+}
+
+// OKXCloseResult is the top-level JSON from close_okx_position.py.
+// Used by the portfolio kill switch to liquidate on-chain OKX perps
+// positions (#345).
+type OKXCloseResult struct {
+	Close     *OKXClose `json:"close"`
+	Platform  string    `json:"platform"`
+	Timestamp string    `json:"timestamp"`
+	Error     string    `json:"error,omitempty"`
+}
+
+// RunOKXClose runs close_okx_position.py to submit a reduce-only market
+// close for a single OKX swap coin (#345).
+//
+// Contract mirrors RunHyperliquidClose: a non-nil error is returned for
+// ANY failure — non-zero subprocess exit, malformed JSON, or a JSON
+// envelope with `error` populated. Callers that see (result, nil) can
+// treat the close as confirmed by the adapter. Kill-switch correctness
+// depends on this: any ambiguous response must surface as error so the
+// switch stays latched and retries next cycle.
+func RunOKXClose(script, symbol string) (*OKXCloseResult, string, error) {
+	args := []string{
+		fmt.Sprintf("--symbol=%s", symbol),
+		"--mode=live",
+	}
+	stdout, stderr, runErr := RunPythonScript(script, args)
+	return parseOKXCloseOutput(stdout, string(stderr), runErr)
+}
+
+// parseOKXCloseOutput turns raw subprocess output into
+// (*OKXCloseResult, stderr, error) following the RunOKXClose contract.
+// Extracted so the decision logic can be tested without spawning
+// .venv/bin/python3 (absent in the Go CI job — same reason as
+// parseHyperliquidCloseOutput, #341/#342).
+func parseOKXCloseOutput(stdout []byte, stderrStr string, runErr error) (*OKXCloseResult, string, error) {
+	var result OKXCloseResult
+	parseErr := json.Unmarshal(stdout, &result)
+
+	switch {
+	case runErr == nil && parseErr == nil && result.Error == "":
+		return &result, stderrStr, nil
+
+	case runErr == nil && parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("close reported error despite exit 0: %s", result.Error)
+
+	case parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("close failed: %s", result.Error)
+
+	case parseErr == nil && runErr != nil:
+		return &result, stderrStr, fmt.Errorf("close subprocess exit %v with no error field (stderr: %s)", runErr, stderrStr)
+
+	default:
+		return nil, stderrStr, fmt.Errorf("parse close output: %v (run err: %v, stdout: %s)", parseErr, runErr, string(stdout))
+	}
+}
+
+// OKXPositionsResult is the JSON output from fetch_okx_positions.py.
+// Size is signed (positive = long, negative = short) to mirror HLPosition.
+type OKXPositionsResult struct {
+	Positions []OKXPositionJSON `json:"positions"`
+	Platform  string            `json:"platform"`
+	Timestamp string            `json:"timestamp"`
+	Error     string            `json:"error,omitempty"`
+}
+
+// OKXPositionJSON is the per-position payload from fetch_okx_positions.py.
+type OKXPositionJSON struct {
+	Coin       string  `json:"coin"`
+	Size       float64 `json:"size"`
+	EntryPrice float64 `json:"entry_price"`
+	Side       string  `json:"side"`
+}
+
+// RunOKXFetchPositions runs fetch_okx_positions.py and returns the parsed
+// result (#345). Like RunOKXClose, any failure path returns a non-nil
+// error so the kill switch can latch and retry — a silent parse failure
+// would otherwise look like "no positions" and clear virtual state while
+// on-chain exposure remained.
+func RunOKXFetchPositions(script string) (*OKXPositionsResult, string, error) {
+	stdout, stderr, runErr := RunPythonScript(script, nil)
+	return parseOKXPositionsOutput(stdout, string(stderr), runErr)
+}
+
+// parseOKXPositionsOutput is the pure parser, extracted from
+// RunOKXFetchPositions so the decision logic can be tested without
+// spawning Python (mirrors parseOKXCloseOutput / parseHyperliquidCloseOutput).
+func parseOKXPositionsOutput(stdout []byte, stderrStr string, runErr error) (*OKXPositionsResult, string, error) {
+	var result OKXPositionsResult
+	parseErr := json.Unmarshal(stdout, &result)
+
+	switch {
+	case runErr == nil && parseErr == nil && result.Error == "":
+		return &result, stderrStr, nil
+
+	case parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("fetch positions failed: %s", result.Error)
+
+	case parseErr == nil && runErr != nil:
+		return &result, stderrStr, fmt.Errorf("fetch positions subprocess exit %v with no error field (stderr: %s)", runErr, stderrStr)
+
+	default:
+		return nil, stderrStr, fmt.Errorf("parse positions output: %v (run err: %v, stdout: %s)", parseErr, runErr, string(stdout))
+	}
+}
+
 // FetchPrices runs check_price.py and returns a map of symbol→price.
 func FetchPrices(symbols []string) (map[string]float64, error) {
 	stdout, stderr, err := RunPythonScript("shared_scripts/check_price.py", symbols)

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -664,19 +664,35 @@ func RunOKXFetchPositions(script string) (*OKXPositionsResult, string, error) {
 
 // parseOKXPositionsOutput is the pure parser, extracted from
 // RunOKXFetchPositions so the decision logic can be tested without
-// spawning Python (mirrors parseOKXCloseOutput / parseHyperliquidCloseOutput).
+// spawning Python. Mirrors parseOKXCloseOutput / parseHyperliquidCloseOutput
+// 5-case matrix (contract drift here would be bad — the kill switch reads
+// every parser result the same way).
 func parseOKXPositionsOutput(stdout []byte, stderrStr string, runErr error) (*OKXPositionsResult, string, error) {
 	var result OKXPositionsResult
 	parseErr := json.Unmarshal(stdout, &result)
 
 	switch {
 	case runErr == nil && parseErr == nil && result.Error == "":
+		// Clean success: exit 0, valid JSON, no error field.
 		return &result, stderrStr, nil
 
+	case runErr == nil && parseErr == nil && result.Error != "":
+		// Exit 0 but the script reported an error — shouldn't happen with
+		// the current Python contract (every error path exits 1) but we
+		// honor the JSON envelope as authoritative and surface it as a
+		// contract-drift diagnostic.
+		return &result, stderrStr, fmt.Errorf("fetch positions reported error despite exit 0: %s", result.Error)
+
 	case parseErr == nil && result.Error != "":
+		// Expected error path: exit non-zero, valid JSON envelope. Surface
+		// as a non-nil error so callers don't need to double-check.
 		return &result, stderrStr, fmt.Errorf("fetch positions failed: %s", result.Error)
 
 	case parseErr == nil && runErr != nil:
+		// Exit non-zero with valid JSON but no error field — unexpected.
+		// Treat as failure to avoid silently reporting "no positions" on a
+		// non-zero exit (kill switch would clear virtual state while
+		// on-chain exposure remained — the #345 bug class).
 		return &result, stderrStr, fmt.Errorf("fetch positions subprocess exit %v with no error field (stderr: %s)", runErr, stderrStr)
 
 	default:

--- a/scheduler/executor_test.go
+++ b/scheduler/executor_test.go
@@ -412,3 +412,125 @@ func TestParseHyperliquidCloseOutput_MalformedJSON(t *testing.T) {
 		t.Errorf("result should be nil for unparseable output, got %+v", result)
 	}
 }
+
+// ── OKX close parser tests (#345) ──────────────────────────────────────
+// Same 5-case matrix as parseHyperliquidCloseOutput — mirrors the HL tests
+// one-to-one because the two parsers implement the same contract. Any
+// relaxation of the contract on one side must fail a test on that side so
+// kill-switch correctness parity is mechanically enforced.
+
+func TestParseOKXCloseOutput_CleanSuccess(t *testing.T) {
+	stdout := []byte(`{"close":{"symbol":"BTC","fill":{"avg_px":42000,"total_sz":0.01,"oid":"abc123","fee":0.02}},"platform":"okx","timestamp":"2026-04-19T00:00:00Z"}`)
+	result, _, err := parseOKXCloseOutput(stdout, "", nil)
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if result == nil || result.Close == nil || result.Close.Fill == nil {
+		t.Fatalf("expected populated result, got %+v", result)
+	}
+	if result.Close.Fill.TotalSz != 0.01 {
+		t.Errorf("TotalSz = %g, want 0.01", result.Close.Fill.TotalSz)
+	}
+	if result.Close.Fill.OID != "abc123" {
+		t.Errorf("OID = %q, want abc123 (ccxt IDs are strings, unlike HL ints)", result.Close.Fill.OID)
+	}
+	if result.Close.Fill.Fee != 0.02 {
+		t.Errorf("Fee = %g, want 0.02 — fee parsing is load-bearing for post-kill accounting", result.Close.Fill.Fee)
+	}
+}
+
+func TestParseOKXCloseOutput_Exit0WithError(t *testing.T) {
+	stdout := []byte(`{"close":{"symbol":"BTC","fill":{}},"platform":"okx","timestamp":"x","error":"okx auth failed"}`)
+	_, _, err := parseOKXCloseOutput(stdout, "", nil)
+	if err == nil {
+		t.Fatal("expected non-nil err for exit 0 with error envelope")
+	}
+	if !strings.Contains(err.Error(), "okx auth failed") {
+		t.Errorf("err must surface envelope error, got %v", err)
+	}
+}
+
+func TestParseOKXCloseOutput_Exit1WithError(t *testing.T) {
+	stdout := []byte(`{"close":{"symbol":"BTC","fill":{}},"platform":"okx","timestamp":"x","error":"okx rate limited"}`)
+	runErr := fmt.Errorf("exit status 1")
+	_, _, err := parseOKXCloseOutput(stdout, "", runErr)
+	if err == nil {
+		t.Fatal("expected non-nil err for exit 1 — kill switch must latch")
+	}
+	if !strings.Contains(err.Error(), "okx rate limited") {
+		t.Errorf("err must include underlying error, got %v", err)
+	}
+}
+
+func TestParseOKXCloseOutput_Exit1WithoutErrorField(t *testing.T) {
+	stdout := []byte(`{"close":{"symbol":"BTC","fill":{}},"platform":"okx","timestamp":"x"}`)
+	runErr := fmt.Errorf("exit status 1")
+	_, _, err := parseOKXCloseOutput(stdout, "", runErr)
+	if err == nil {
+		t.Fatal("expected non-nil err for exit 1 even without error field — silent crash must not clear virtual state")
+	}
+	if !strings.Contains(err.Error(), "no error field") {
+		t.Errorf("err message should mention missing error field, got %v", err)
+	}
+}
+
+func TestParseOKXCloseOutput_MalformedJSON(t *testing.T) {
+	result, _, err := parseOKXCloseOutput([]byte("not json"), "", nil)
+	if err == nil {
+		t.Fatal("expected non-nil err for malformed JSON")
+	}
+	if result != nil {
+		t.Errorf("result should be nil for unparseable output, got %+v", result)
+	}
+}
+
+// ── OKX positions fetcher parser tests (#345) ───────────────────────────
+
+func TestParseOKXPositionsOutput_Success(t *testing.T) {
+	stdout := []byte(`{"positions":[{"coin":"BTC","size":0.01,"entry_price":42000,"side":"long"},{"coin":"ETH","size":-0.5,"entry_price":3000,"side":"short"}],"platform":"okx","timestamp":"x"}`)
+	result, _, err := parseOKXPositionsOutput(stdout, "", nil)
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if len(result.Positions) != 2 {
+		t.Fatalf("expected 2 positions, got %d", len(result.Positions))
+	}
+	if result.Positions[0].Coin != "BTC" || result.Positions[0].Size != 0.01 {
+		t.Errorf("position[0] = %+v", result.Positions[0])
+	}
+	// Short size must be negative — load-bearing for on-chain direction
+	// classification in forceCloseOKXLive.
+	if result.Positions[1].Size != -0.5 {
+		t.Errorf("short size must be signed negative, got %g", result.Positions[1].Size)
+	}
+}
+
+func TestParseOKXPositionsOutput_EmptyIsSuccess(t *testing.T) {
+	stdout := []byte(`{"positions":[],"platform":"okx","timestamp":"x"}`)
+	result, _, err := parseOKXPositionsOutput(stdout, "", nil)
+	if err != nil {
+		t.Fatalf("empty positions must be success, got err=%v", err)
+	}
+	if len(result.Positions) != 0 {
+		t.Errorf("expected 0 positions, got %d", len(result.Positions))
+	}
+}
+
+func TestParseOKXPositionsOutput_ErrorEnvelope(t *testing.T) {
+	stdout := []byte(`{"positions":[],"platform":"okx","timestamp":"x","error":"OKX auth failed"}`)
+	runErr := fmt.Errorf("exit status 1")
+	_, _, err := parseOKXPositionsOutput(stdout, "", runErr)
+	if err == nil {
+		t.Fatal("expected non-nil err when envelope has error field — kill switch must latch")
+	}
+	if !strings.Contains(err.Error(), "OKX auth failed") {
+		t.Errorf("err must include envelope error, got %v", err)
+	}
+}
+
+func TestParseOKXPositionsOutput_MalformedJSON(t *testing.T) {
+	_, _, err := parseOKXPositionsOutput([]byte("garbage"), "", nil)
+	if err == nil {
+		t.Fatal("expected non-nil err for malformed JSON — cannot infer positions from garbage")
+	}
+}

--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -8,6 +8,45 @@ import (
 	"time"
 )
 
+// KillSwitchCloseInputs bundles every platform-specific bit the kill-switch
+// plan builder needs. Grouped into a struct so that adding a new platform
+// (Robinhood, TopStep, etc.) is an additive change rather than a signature
+// widening that cascades through every call site and test.
+//
+// HLStateFetched / HLPositions capture whether main.go already fetched HL
+// clearinghouseState earlier in the cycle (for shared-wallet balance or
+// due reconcile). When HLStateFetched is false but HLAddr is set, the
+// plan builder does an opportunistic fetch via HLFetcher so a configured
+// account with no due strategies still gets verified (false-reassurance
+// guard from #341 review).
+//
+// OKX has no equivalent public position endpoint — we always call
+// OKXFetcher when there's at least one live OKX perps strategy, rather
+// than trying to reuse a pre-fetch. Spot OKX strategies are surfaced via
+// OKXSpotLive so the plan builder can warn in the Discord message without
+// attempting an unsafe automated close (see forceCloseOKXLive doc).
+type KillSwitchCloseInputs struct {
+	HLAddr         string
+	HLStateFetched bool
+	HLPositions    []HLPosition
+	HLLiveAll      []StrategyConfig
+	HLCloser       HyperliquidLiveCloser
+	HLFetcher      HLStateFetcher
+
+	// OKXLiveAllPerps: every live OKX perps strategy configured (used to
+	// decide which coins to close and to detect "unconfigured" positions).
+	OKXLiveAllPerps []StrategyConfig
+	// OKXLiveAllSpot: every live OKX spot strategy configured. The kill
+	// switch cannot close spot positions safely (#345) — these are surfaced
+	// in the Discord message as a known gap so the operator intervenes.
+	OKXLiveAllSpot []StrategyConfig
+	OKXCloser      OKXLiveCloser
+	OKXFetcher     OKXPositionsFetcher
+
+	PortfolioReason string
+	CloseTimeout    time.Duration
+}
+
 // KillSwitchClosePlan is the output of planKillSwitchClose — everything the
 // main loop needs to apply virtual-state mutation and send notifications.
 // The plan is pure data (no goroutines, no I/O callbacks), so the main loop
@@ -15,22 +54,36 @@ import (
 // mutex without re-running any logic.
 type KillSwitchClosePlan struct {
 	// OnChainConfirmedFlat is the load-bearing correctness signal. True means
-	// the caller MAY clear virtual state. False means at least one live HL
-	// exposure could not be confirmed closed — caller MUST leave virtual
-	// state intact and let the next cycle retry.
+	// the caller MAY clear virtual state. False means at least one live
+	// exposure (on any platform) could not be confirmed closed — caller
+	// MUST leave virtual state intact and let the next cycle retry.
 	OnChainConfirmedFlat bool
 
-	// CloseReport is the per-coin outcome of the close attempt. Zero value
-	// when no close was attempted (HL not configured, HL configured but no
-	// live strategies, fetch failure).
+	// CloseReport is the HL per-coin outcome. Zero value when no HL close
+	// was attempted.
 	CloseReport HyperliquidLiveCloseReport
 
-	// Unconfigured lists on-chain positions for coins no configured live HL
-	// strategy trades. Non-empty when HYPERLIQUID_ACCOUNT_ADDRESS is set but
-	// len(hlLiveAll) == 0 and the wallet holds positions. The kill switch
-	// refuses to unilaterally liquidate unconfigured positions (could be a
-	// manual hedge or another bot's inventory); it surfaces them instead.
+	// OKXCloseReport is the OKX per-coin outcome. Zero value when no OKX
+	// close was attempted.
+	OKXCloseReport OKXLiveCloseReport
+
+	// Unconfigured lists HL on-chain positions for coins no configured live
+	// HL strategy trades. Kept as HLPosition for backward compat with #341
+	// tests; OKX equivalent is in OKXUnconfigured.
 	Unconfigured []HLPosition
+
+	// OKXUnconfigured lists OKX on-chain positions for coins no configured
+	// live OKX strategy trades. Same manual-intervention semantic as
+	// Unconfigured.
+	OKXUnconfigured []OKXPosition
+
+	// OKXSpotPresent is true when there is at least one live OKX spot
+	// strategy configured. Signals that the kill switch left an unhandled
+	// gap — surfaced in the Discord message but does NOT block
+	// OnChainConfirmedFlat (the scheduler has no reliable way to check
+	// whether there is actual spot exposure, and blocking would latch
+	// forever).
+	OKXSpotPresent bool
 
 	// DiscordMessage is the formatted notification string; empty when no
 	// Discord message should be sent. Caller checks notifier.HasBackends()
@@ -59,41 +112,27 @@ func defaultHLStateFetcher(addr string) ([]HLPosition, error) {
 // The caller applies mutations based on the returned plan.
 //
 // Extracted from main.go so the latch-until-flat flow (the actual #341 fix)
-// can be unit-tested with fake closer + fake fetcher. Without this seam, the
-// load-bearing `if killSwitchFired && OnChainConfirmedFlat` gate around
+// can be unit-tested with fake closers + fake fetchers. Without this seam,
+// the load-bearing `if killSwitchFired && OnChainConfirmedFlat` gate around
 // forceCloseAllPositions would regress silently — exactly the kind of bug
 // #341 was.
 //
-// Inputs capture the cycle's state at the point of the kill-switch firing:
-//   - hlAddr: HYPERLIQUID_ACCOUNT_ADDRESS value ("" means HL not configured)
-//   - hlStateFetched / hlPositions: whether main.go already fetched state
-//     earlier in the cycle (for shared-wallet balance or due reconcile)
-//   - hlLiveAll: every configured live HL strategy
-//   - portfolioReason: CheckPortfolioRisk's reason string
-//   - closeTimeout: overall budget for the whole close loop (caller passes
-//     ~90s in production; tests pass context.Background deadline via 0)
-//   - closer: submits the actual HL close (defaultHyperliquidLiveCloser or
-//     a fake)
-//   - fetcher: performs the opportunistic re-fetch when main.go didn't fetch
-//     but HL is configured (defaultHLStateFetcher or a fake)
-func planKillSwitchClose(
-	hlAddr string,
-	hlStateFetched bool,
-	hlPositions []HLPosition,
-	hlLiveAll []StrategyConfig,
-	portfolioReason string,
-	closeTimeout time.Duration,
-	closer HyperliquidLiveCloser,
-	fetcher HLStateFetcher,
-) KillSwitchClosePlan {
+// Platform handling is independent: either platform (HL or OKX) being
+// un-confirmed-flat flips OnChainConfirmedFlat to false and latches the
+// switch. Messages combine both platforms' status.
+func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 	plan := KillSwitchClosePlan{OnChainConfirmedFlat: true}
 
-	// Opportunistic fetch: operator could have removed all HL strategies
+	// ── Hyperliquid ─────────────────────────────────────────────────
+	hlPositions := in.HLPositions
+	hlStateFetched := in.HLStateFetched
+
+	// Opportunistic HL fetch: operator could have removed all HL strategies
 	// from config while the wallet still holds positions from a previous
 	// deploy or manual trade. Kill switch must not report "no exposure"
 	// without actually checking (#341 review, false-reassurance case).
-	if !hlStateFetched && hlAddr != "" {
-		pos, err := fetcher(hlAddr)
+	if !hlStateFetched && in.HLAddr != "" && in.HLFetcher != nil {
+		pos, err := in.HLFetcher(in.HLAddr)
 		if err != nil {
 			plan.LogLines = append(plan.LogLines,
 				fmt.Sprintf("[CRITICAL] hl-close: kill switch unable to fetch HL state: %v — cannot confirm on-chain flat", err))
@@ -105,10 +144,10 @@ func planKillSwitchClose(
 	}
 
 	switch {
-	case hlStateFetched && len(hlLiveAll) > 0:
-		ctx, cancel := context.WithTimeout(context.Background(), closeTimeout)
-		defer cancel()
-		plan.CloseReport = forceCloseHyperliquidLive(ctx, hlPositions, hlLiveAll, closer)
+	case hlStateFetched && len(in.HLLiveAll) > 0:
+		ctx, cancel := context.WithTimeout(context.Background(), in.CloseTimeout)
+		plan.CloseReport = forceCloseHyperliquidLive(ctx, hlPositions, in.HLLiveAll, in.HLCloser)
+		cancel()
 		if !plan.CloseReport.ConfirmedFlat() {
 			plan.OnChainConfirmedFlat = false
 		}
@@ -125,7 +164,7 @@ func planKillSwitchClose(
 				fmt.Sprintf("[CRITICAL] hl-close: %s failed: %v (kill switch will retry next cycle)", coin, plan.CloseReport.Errors[coin]))
 		}
 
-	case hlStateFetched && len(hlLiveAll) == 0:
+	case hlStateFetched && len(in.HLLiveAll) == 0:
 		for _, p := range hlPositions {
 			if p.Size != 0 {
 				plan.Unconfigured = append(plan.Unconfigured, p)
@@ -140,7 +179,72 @@ func planKillSwitchClose(
 		}
 	}
 
-	plan.DiscordMessage = formatKillSwitchMessage(hlAddr, plan, portfolioReason)
+	// ── OKX ─────────────────────────────────────────────────────────
+	// OKX spot is surfaced as a known gap but does not block flat — we
+	// cannot fetch nor safely auto-close spot balances (#345).
+	plan.OKXSpotPresent = len(in.OKXLiveAllSpot) > 0
+	if plan.OKXSpotPresent {
+		plan.LogLines = append(plan.LogLines,
+			fmt.Sprintf("[CRITICAL] okx-close: %d live OKX spot strategies configured — kill switch cannot auto-close spot (no reduce-only); operator must verify manually (#345)", len(in.OKXLiveAllSpot)))
+	}
+
+	// Perps: always attempt fetch when there's a perps strategy or fetcher
+	// — mirrors the HL opportunistic-fetch guard. Unlike HL there is no
+	// pre-fetch to reuse; OKX always requires a subprocess round-trip.
+	if len(in.OKXLiveAllPerps) > 0 && in.OKXFetcher != nil {
+		okxPositions, err := in.OKXFetcher()
+		if err != nil {
+			plan.LogLines = append(plan.LogLines,
+				fmt.Sprintf("[CRITICAL] okx-close: kill switch unable to fetch OKX positions: %v — cannot confirm on-chain flat", err))
+			plan.OnChainConfirmedFlat = false
+		} else {
+			ctx, cancel := context.WithTimeout(context.Background(), in.CloseTimeout)
+			plan.OKXCloseReport = forceCloseOKXLive(ctx, okxPositions, in.OKXLiveAllPerps, in.OKXCloser)
+			cancel()
+			if !plan.OKXCloseReport.ConfirmedFlat() {
+				plan.OnChainConfirmedFlat = false
+			}
+			if len(plan.OKXCloseReport.ClosedCoins) > 0 {
+				plan.LogLines = append(plan.LogLines,
+					fmt.Sprintf("[CRITICAL] okx-close: confirmed close for %v", plan.OKXCloseReport.ClosedCoins))
+			}
+			if len(plan.OKXCloseReport.AlreadyFlat) > 0 {
+				plan.LogLines = append(plan.LogLines,
+					fmt.Sprintf("[INFO] okx-close: already flat on-chain: %v", plan.OKXCloseReport.AlreadyFlat))
+			}
+			for _, coin := range plan.OKXCloseReport.SortedErrorCoins() {
+				plan.LogLines = append(plan.LogLines,
+					fmt.Sprintf("[CRITICAL] okx-close: %s failed: %v (kill switch will retry next cycle)", coin, plan.OKXCloseReport.Errors[coin]))
+			}
+
+			// Unconfigured OKX positions: traded coins vs. on-chain. Same
+			// semantic as HL: kill switch refuses to unilaterally liquidate
+			// positions for coins it isn't configured to trade.
+			tradedCoins := make(map[string]bool)
+			for _, sc := range in.OKXLiveAllPerps {
+				if sc.Type != "perps" {
+					continue
+				}
+				if sym := okxSymbol(sc.Args); sym != "" {
+					tradedCoins[sym] = true
+				}
+			}
+			for _, p := range okxPositions {
+				if !tradedCoins[p.Coin] && p.Size != 0 {
+					plan.OKXUnconfigured = append(plan.OKXUnconfigured, p)
+				}
+			}
+			if len(plan.OKXUnconfigured) > 0 {
+				plan.OnChainConfirmedFlat = false
+				for _, p := range plan.OKXUnconfigured {
+					plan.LogLines = append(plan.LogLines,
+						fmt.Sprintf("[CRITICAL] okx-close: on-chain position for unconfigured coin %s (size=%.6f) — manual intervention required, kill switch will retry next cycle", p.Coin, p.Size))
+				}
+			}
+		}
+	}
+
+	plan.DiscordMessage = formatKillSwitchMessage(in.HLAddr, plan, in.PortfolioReason)
 	return plan
 }
 
@@ -150,32 +254,63 @@ func planKillSwitchClose(
 // confirmed-flat, "PORTFOLIO KILL SWITCH (LATCHED, RETRYING)" otherwise.
 func formatKillSwitchMessage(hlAddr string, plan KillSwitchClosePlan, portfolioReason string) string {
 	if plan.OnChainConfirmedFlat {
-		summary := "no live HL exposure"
+		var parts []string
 		if len(plan.CloseReport.ClosedCoins) > 0 {
-			summary = fmt.Sprintf("HL closes: %v", plan.CloseReport.ClosedCoins)
+			parts = append(parts, fmt.Sprintf("HL closes: %v", plan.CloseReport.ClosedCoins))
 		} else if hlAddr == "" {
-			summary = "HL not configured"
+			parts = append(parts, "HL not configured")
+		} else {
+			parts = append(parts, "no live HL exposure")
 		}
+		if len(plan.OKXCloseReport.ClosedCoins) > 0 {
+			parts = append(parts, fmt.Sprintf("OKX closes: %v", plan.OKXCloseReport.ClosedCoins))
+		}
+		if plan.OKXSpotPresent {
+			parts = append(parts, "OKX spot strategies present — verify manually (kill switch cannot auto-close spot)")
+		}
+		summary := strings.Join(parts, "; ")
 		return fmt.Sprintf("**PORTFOLIO KILL SWITCH**\n%s\n%s. Virtual state cleared. Manual reset required.", portfolioReason, summary)
 	}
 
-	var errSummary string
-	switch {
-	case len(plan.CloseReport.Errors) > 0:
+	var segments []string
+
+	if len(plan.CloseReport.Errors) > 0 {
 		parts := make([]string, 0, len(plan.CloseReport.Errors))
 		for _, coin := range plan.CloseReport.SortedErrorCoins() {
 			parts = append(parts, fmt.Sprintf("%s: %v", coin, plan.CloseReport.Errors[coin]))
 		}
-		errSummary = "Live close errors — " + strings.Join(parts, "; ")
-	case len(plan.Unconfigured) > 0:
+		segments = append(segments, "HL live close errors — "+strings.Join(parts, "; "))
+	}
+	if len(plan.OKXCloseReport.Errors) > 0 {
+		parts := make([]string, 0, len(plan.OKXCloseReport.Errors))
+		for _, coin := range plan.OKXCloseReport.SortedErrorCoins() {
+			parts = append(parts, fmt.Sprintf("%s: %v", coin, plan.OKXCloseReport.Errors[coin]))
+		}
+		segments = append(segments, "OKX live close errors — "+strings.Join(parts, "; "))
+	}
+	if len(plan.Unconfigured) > 0 {
 		names := make([]string, 0, len(plan.Unconfigured))
 		for _, p := range plan.Unconfigured {
 			names = append(names, fmt.Sprintf("%s szi=%.6f", p.Coin, p.Size))
 		}
 		sort.Strings(names)
-		errSummary = "On-chain HL positions for unconfigured coins (manual intervention required) — " + strings.Join(names, "; ")
-	default:
-		errSummary = "Could not fetch HL on-chain state to confirm flat"
+		segments = append(segments, "On-chain HL positions for unconfigured coins (manual intervention required) — "+strings.Join(names, "; "))
 	}
-	return fmt.Sprintf("**PORTFOLIO KILL SWITCH (LATCHED, RETRYING)**\n%s\n%s. Virtual state preserved. Next cycle will retry.", portfolioReason, errSummary)
+	if len(plan.OKXUnconfigured) > 0 {
+		names := make([]string, 0, len(plan.OKXUnconfigured))
+		for _, p := range plan.OKXUnconfigured {
+			names = append(names, fmt.Sprintf("%s size=%.6f", p.Coin, p.Size))
+		}
+		sort.Strings(names)
+		segments = append(segments, "On-chain OKX positions for unconfigured coins (manual intervention required) — "+strings.Join(names, "; "))
+	}
+	if plan.OKXSpotPresent {
+		segments = append(segments, "OKX spot strategies present — verify manually (kill switch cannot auto-close spot)")
+	}
+	if len(segments) == 0 {
+		// Fallback: HL fetch failure path doesn't populate Errors/Unconfigured.
+		segments = append(segments, "Could not fetch on-chain state to confirm flat")
+	}
+
+	return fmt.Sprintf("**PORTFOLIO KILL SWITCH (LATCHED, RETRYING)**\n%s\n%s. Virtual state preserved. Next cycle will retry.", portfolioReason, strings.Join(segments, " | "))
 }

--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -217,23 +217,12 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 					fmt.Sprintf("[CRITICAL] okx-close: %s failed: %v (kill switch will retry next cycle)", coin, plan.OKXCloseReport.Errors[coin]))
 			}
 
-			// Unconfigured OKX positions: traded coins vs. on-chain. Same
-			// semantic as HL: kill switch refuses to unilaterally liquidate
-			// positions for coins it isn't configured to trade.
-			tradedCoins := make(map[string]bool)
-			for _, sc := range in.OKXLiveAllPerps {
-				if sc.Type != "perps" {
-					continue
-				}
-				if sym := okxSymbol(sc.Args); sym != "" {
-					tradedCoins[sym] = true
-				}
-			}
-			for _, p := range okxPositions {
-				if !tradedCoins[p.Coin] && p.Size != 0 {
-					plan.OKXUnconfigured = append(plan.OKXUnconfigured, p)
-				}
-			}
+			// Unconfigured OKX positions are detected in forceCloseOKXLive
+			// so the traded-coins partition has a single source of truth.
+			// Semantic matches HL Unconfigured: kill switch refuses to
+			// unilaterally liquidate positions for coins it isn't
+			// configured to trade.
+			plan.OKXUnconfigured = plan.OKXCloseReport.Unconfigured
 			if len(plan.OKXUnconfigured) > 0 {
 				plan.OnChainConfirmedFlat = false
 				for _, p := range plan.OKXUnconfigured {
@@ -250,8 +239,15 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 
 // formatKillSwitchMessage builds the Discord notification string from a plan.
 // Split out so tests can call it directly and so main.go delivery stays a
-// one-liner. Returns two distinct shapes: "PORTFOLIO KILL SWITCH" on
-// confirmed-flat, "PORTFOLIO KILL SWITCH (LATCHED, RETRYING)" otherwise.
+// one-liner. Returns three distinct shapes:
+//   - "PORTFOLIO KILL SWITCH" — confirmed-flat, no spot gap.
+//   - "PORTFOLIO KILL SWITCH (SPOT GAP — VERIFY MANUALLY)" — confirmed-flat
+//     for perps, but OKX spot strategies are configured and the scheduler
+//     has no safe auto-close path (#345). Header is distinct so an
+//     operator skimming does not read "Virtual state cleared" as
+//     "everything is closed."
+//   - "PORTFOLIO KILL SWITCH (LATCHED, RETRYING)" — some on-chain
+//     exposure could not be confirmed closed; retry next cycle.
 func formatKillSwitchMessage(hlAddr string, plan KillSwitchClosePlan, portfolioReason string) string {
 	if plan.OnChainConfirmedFlat {
 		var parts []string
@@ -265,11 +261,13 @@ func formatKillSwitchMessage(hlAddr string, plan KillSwitchClosePlan, portfolioR
 		if len(plan.OKXCloseReport.ClosedCoins) > 0 {
 			parts = append(parts, fmt.Sprintf("OKX closes: %v", plan.OKXCloseReport.ClosedCoins))
 		}
+		header := "**PORTFOLIO KILL SWITCH**"
 		if plan.OKXSpotPresent {
-			parts = append(parts, "OKX spot strategies present — verify manually (kill switch cannot auto-close spot)")
+			header = "**PORTFOLIO KILL SWITCH (SPOT GAP — VERIFY MANUALLY)**"
+			parts = append(parts, "OKX spot strategies present — kill switch cannot auto-close spot, verify balances manually")
 		}
 		summary := strings.Join(parts, "; ")
-		return fmt.Sprintf("**PORTFOLIO KILL SWITCH**\n%s\n%s. Virtual state cleared. Manual reset required.", portfolioReason, summary)
+		return fmt.Sprintf("%s\n%s\n%s. Virtual state cleared. Manual reset required.", header, portfolioReason, summary)
 	}
 
 	var segments []string

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -7,14 +7,12 @@ import (
 	"time"
 )
 
-// Tests for planKillSwitchClose — the orchestration seam for #341. The 7
-// tests in hyperliquid_balance_test.go cover forceCloseHyperliquidLive in
-// isolation; these cover the "latch until flat" wiring that is the actual
-// fix. Without them, the load-bearing
-// `killSwitchFired && plan.OnChainConfirmedFlat` guard around
-// forceCloseAllPositions could regress silently — exactly the shape of the
-// original #341 bug (virtual state mutated without confirming on-chain
-// closure).
+// Tests for planKillSwitchClose — the orchestration seam for #341 / #345.
+// Covers the "latch until flat" wiring that is the actual fix. Without
+// them, the load-bearing `killSwitchFired && plan.OnChainConfirmedFlat`
+// guard around forceCloseAllPositions could regress silently — exactly
+// the shape of the original #341 bug (virtual state mutated without
+// confirming on-chain closure).
 
 // stubHLLiveCloser returns a HyperliquidLiveCloser that records every invocation
 // and maps coin → canned error. Missing keys yield a synthetic success.
@@ -47,6 +45,56 @@ func stubHLStateFetcher(positions []HLPosition, err error) (HLStateFetcher, *int
 	return fetcher, &calls
 }
 
+// stubOKXLiveCloser mirrors stubHLLiveCloser for OKX. Used in tests that
+// want to ensure the OKX path isn't invoked — the default (empty errs) is
+// a synthetic success that should never be triggered in HL-only tests.
+func stubOKXLiveCloser(errs map[string]error) (OKXLiveCloser, *[]string) {
+	var calls []string
+	closer := func(symbol string) (*OKXCloseResult, error) {
+		calls = append(calls, symbol)
+		if err, ok := errs[symbol]; ok && err != nil {
+			return nil, err
+		}
+		return &OKXCloseResult{
+			Close:    &OKXClose{Symbol: symbol, Fill: &OKXCloseFill{TotalSz: 1.0, AvgPx: 100}},
+			Platform: "okx",
+		}, nil
+	}
+	return closer, &calls
+}
+
+// stubOKXPositionsFetcher returns an OKXPositionsFetcher that replays a
+// fixed response and records invocation count.
+func stubOKXPositionsFetcher(positions []OKXPosition, err error) (OKXPositionsFetcher, *int) {
+	var calls int
+	fetcher := func() ([]OKXPosition, error) {
+		calls++
+		if err != nil {
+			return nil, err
+		}
+		return positions, nil
+	}
+	return fetcher, &calls
+}
+
+// defaultHLInputs builds a KillSwitchCloseInputs for an HL-only test. Any
+// OKX fields are zeroed — the OKX plan branch only fires when
+// OKXLiveAllPerps is non-empty, so these tests stay HL-exclusive.
+func defaultHLInputs(hlAddr string, fetched bool, positions []HLPosition,
+	hlLive []StrategyConfig, reason string, timeout time.Duration,
+	closer HyperliquidLiveCloser, fetcher HLStateFetcher) KillSwitchCloseInputs {
+	return KillSwitchCloseInputs{
+		HLAddr:          hlAddr,
+		HLStateFetched:  fetched,
+		HLPositions:     positions,
+		HLLiveAll:       hlLive,
+		HLCloser:        closer,
+		HLFetcher:       fetcher,
+		PortfolioReason: reason,
+		CloseTimeout:    timeout,
+	}
+}
+
 // Happy path: HL configured, on-chain state already fetched, one live strategy
 // with an open position. Plan reports ConfirmedFlat, closer called once,
 // Discord message is the success shape. This is the test that locks in the
@@ -62,9 +110,9 @@ func TestPlanKillSwitchClose_HappyPath(t *testing.T) {
 	closer, calls := stubHLLiveCloser(nil)
 	fetcher, fetchCalls := stubHLStateFetcher(nil, nil)
 
-	plan := planKillSwitchClose("0xaddr", true, positions, hlLive,
+	plan := planKillSwitchClose(defaultHLInputs("0xaddr", true, positions, hlLive,
 		"portfolio drawdown 25.0% exceeds limit 20.0%",
-		time.Second, closer, fetcher)
+		time.Second, closer, fetcher))
 
 	if !plan.OnChainConfirmedFlat {
 		t.Fatalf("expected ConfirmedFlat, got plan=%+v", plan)
@@ -88,10 +136,7 @@ func TestPlanKillSwitchClose_HappyPath(t *testing.T) {
 }
 
 // Close failure: closer errors for one coin. Plan must NOT be ConfirmedFlat
-// — caller must keep virtual state intact and retry next cycle. Discord
-// message must be the "LATCHED, RETRYING" shape with the specific error
-// surfaced. This is the test that prevents regression of the retry loop
-// (the whole point of latch-until-flat).
+// — caller must keep virtual state intact and retry next cycle.
 func TestPlanKillSwitchClose_CloseError(t *testing.T) {
 	hlLive := []StrategyConfig{
 		{ID: "hl-ema-eth", Platform: "hyperliquid", Type: "perps",
@@ -101,9 +146,9 @@ func TestPlanKillSwitchClose_CloseError(t *testing.T) {
 	closer, _ := stubHLLiveCloser(map[string]error{"ETH": fmt.Errorf("hl rate limited")})
 	fetcher, _ := stubHLStateFetcher(nil, nil)
 
-	plan := planKillSwitchClose("0xaddr", true, positions, hlLive,
+	plan := planKillSwitchClose(defaultHLInputs("0xaddr", true, positions, hlLive,
 		"portfolio drawdown 25.0% exceeds limit 20.0%",
-		time.Second, closer, fetcher)
+		time.Second, closer, fetcher))
 
 	if plan.OnChainConfirmedFlat {
 		t.Fatal("expected NOT ConfirmedFlat on close error — kill switch would clear virtual state while on-chain is still live")
@@ -123,9 +168,8 @@ func TestPlanKillSwitchClose_CloseError(t *testing.T) {
 }
 
 // Opportunistic fetch: HL configured but main.go didn't fetch state this
-// cycle (no due strategies, no shared wallet). planKillSwitchClose must
-// re-fetch — otherwise the kill switch reports "no live HL exposure" without
-// checking, which is the false-reassurance case the PR review flagged.
+// cycle. planKillSwitchClose must re-fetch — otherwise the kill switch
+// reports "no live HL exposure" without checking.
 func TestPlanKillSwitchClose_OpportunisticFetch(t *testing.T) {
 	hlLive := []StrategyConfig{
 		{ID: "hl-ema-eth", Platform: "hyperliquid", Type: "perps",
@@ -135,8 +179,8 @@ func TestPlanKillSwitchClose_OpportunisticFetch(t *testing.T) {
 	closer, calls := stubHLLiveCloser(nil)
 	fetcher, fetchCalls := stubHLStateFetcher(positions, nil)
 
-	plan := planKillSwitchClose("0xaddr", false, nil, hlLive,
-		"drawdown reason", time.Second, closer, fetcher)
+	plan := planKillSwitchClose(defaultHLInputs("0xaddr", false, nil, hlLive,
+		"drawdown reason", time.Second, closer, fetcher))
 
 	if *fetchCalls != 1 {
 		t.Fatalf("fetcher should be called once, got %d", *fetchCalls)
@@ -151,8 +195,7 @@ func TestPlanKillSwitchClose_OpportunisticFetch(t *testing.T) {
 
 // Opportunistic fetch failure: HL configured, fetch errors. Plan must NOT be
 // ConfirmedFlat — we cannot verify on-chain state, so caller must not clear
-// virtual state. This is the test that guards against silent desync when HL
-// API is flaky.
+// virtual state.
 func TestPlanKillSwitchClose_FetchFailure(t *testing.T) {
 	hlLive := []StrategyConfig{
 		{ID: "hl-ema-eth", Platform: "hyperliquid", Type: "perps",
@@ -161,8 +204,8 @@ func TestPlanKillSwitchClose_FetchFailure(t *testing.T) {
 	closer, calls := stubHLLiveCloser(nil)
 	fetcher, fetchCalls := stubHLStateFetcher(nil, fmt.Errorf("hl 503"))
 
-	plan := planKillSwitchClose("0xaddr", false, nil, hlLive,
-		"drawdown reason", time.Second, closer, fetcher)
+	plan := planKillSwitchClose(defaultHLInputs("0xaddr", false, nil, hlLive,
+		"drawdown reason", time.Second, closer, fetcher))
 
 	if *fetchCalls != 1 {
 		t.Fatalf("fetcher should be called once on fetch failure, got %d", *fetchCalls)
@@ -182,19 +225,17 @@ func TestPlanKillSwitchClose_FetchFailure(t *testing.T) {
 }
 
 // False-reassurance case: HL configured but no live HL strategies are
-// configured, yet the wallet still has on-chain positions (previous deploy,
-// manual trade). planKillSwitchClose must fetch state, detect the positions,
-// block virtual state mutation, and surface them in the Discord message so
-// the operator manually intervenes. Before the fix, the plan would report
-// "no live HL exposure" — the original #341 review's HIGH finding.
+// configured, yet the wallet still has on-chain positions. planKillSwitchClose
+// must fetch state, detect the positions, block virtual state mutation, and
+// surface them in the Discord message.
 func TestPlanKillSwitchClose_UnconfiguredPositionBlocksReset(t *testing.T) {
 	positions := []HLPosition{{Coin: "ETH", Size: 0.517}}
 	closer, calls := stubHLLiveCloser(nil)
 	fetcher, _ := stubHLStateFetcher(positions, nil)
 
-	plan := planKillSwitchClose("0xaddr", false, nil,
+	plan := planKillSwitchClose(defaultHLInputs("0xaddr", false, nil,
 		[]StrategyConfig{}, // NO live HL strategies configured
-		"drawdown reason", time.Second, closer, fetcher)
+		"drawdown reason", time.Second, closer, fetcher))
 
 	if plan.OnChainConfirmedFlat {
 		t.Fatal("expected NOT ConfirmedFlat — on-chain position exists for unconfigured coin")
@@ -215,13 +256,13 @@ func TestPlanKillSwitchClose_UnconfiguredPositionBlocksReset(t *testing.T) {
 
 // No HL at all: hlAddr="" and no live HL strategies. Kill switch should
 // proceed normally (ConfirmedFlat=true) so spot/options/futures-only users
-// don't regress. Message must not imply HL was checked.
+// don't regress.
 func TestPlanKillSwitchClose_NoHLConfigured(t *testing.T) {
 	closer, calls := stubHLLiveCloser(nil)
 	fetcher, fetchCalls := stubHLStateFetcher(nil, nil)
 
-	plan := planKillSwitchClose("", false, nil, nil,
-		"drawdown reason", time.Second, closer, fetcher)
+	plan := planKillSwitchClose(defaultHLInputs("", false, nil, nil,
+		"drawdown reason", time.Second, closer, fetcher))
 
 	if !plan.OnChainConfirmedFlat {
 		t.Fatal("expected ConfirmedFlat when HL is not configured at all")
@@ -239,8 +280,6 @@ func TestPlanKillSwitchClose_NoHLConfigured(t *testing.T) {
 
 // Stable error ordering (bot review #3): when multiple coins fail with the
 // same errors, the Discord message must be byte-identical across calls.
-// Without sort, Go map iteration randomization produces different messages
-// for identical failures — confusing for operator triage.
 func TestPlanKillSwitchClose_DeterministicErrorOrder(t *testing.T) {
 	hlLive := []StrategyConfig{
 		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps",
@@ -264,14 +303,13 @@ func TestPlanKillSwitchClose_DeterministicErrorOrder(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		closer, _ := stubHLLiveCloser(errs)
 		fetcher, _ := stubHLStateFetcher(nil, nil)
-		plan := planKillSwitchClose("0xaddr", true, positions, hlLive,
-			"reason", time.Second, closer, fetcher)
+		plan := planKillSwitchClose(defaultHLInputs("0xaddr", true, positions, hlLive,
+			"reason", time.Second, closer, fetcher))
 		if prev != "" && plan.DiscordMessage != prev {
 			t.Fatalf("message should be deterministic across calls\niter %d: %s\nprev: %s", i, plan.DiscordMessage, prev)
 		}
 		prev = plan.DiscordMessage
 	}
-	// Also verify coins are alphabetically sorted in the output.
 	btcPos := strings.Index(prev, "BTC:")
 	dogePos := strings.Index(prev, "DOGE:")
 	ethPos := strings.Index(prev, "ETH:")
@@ -290,8 +328,312 @@ func TestPlanKillSwitchClose_DeterministicErrorOrder(t *testing.T) {
 func TestPlanKillSwitchClose_ZeroInputsAreSafe(t *testing.T) {
 	closer, _ := stubHLLiveCloser(nil)
 	fetcher, _ := stubHLStateFetcher(nil, nil)
-	plan := planKillSwitchClose("", false, nil, nil, "", time.Second, closer, fetcher)
+	plan := planKillSwitchClose(defaultHLInputs("", false, nil, nil, "", time.Second, closer, fetcher))
 	if !plan.OnChainConfirmedFlat {
 		t.Errorf("zero inputs should yield ConfirmedFlat=true, got %+v", plan)
+	}
+}
+
+// ── OKX tests (#345) ───────────────────────────────────────────────────
+
+// OKX happy path: one live OKX perps strategy with an open position. Plan
+// reports ConfirmedFlat, closer called once, Discord message mentions OKX
+// closes. This is the #345 analog of TestPlanKillSwitchClose_HappyPath.
+func TestPlanKillSwitchClose_OKXHappyPath(t *testing.T) {
+	okxLive := []StrategyConfig{
+		{ID: "okx-sma-btc", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []OKXPosition{{Coin: "BTC", Size: 0.01, EntryPrice: 42000, Side: "long"}}
+	closer, calls := stubOKXLiveCloser(nil)
+	fetcher, fetchCalls := stubOKXPositionsFetcher(positions, nil)
+
+	in := KillSwitchCloseInputs{
+		OKXLiveAllPerps: okxLive,
+		OKXCloser:       closer,
+		OKXFetcher:      fetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	}
+	plan := planKillSwitchClose(in)
+
+	if !plan.OnChainConfirmedFlat {
+		t.Fatalf("expected ConfirmedFlat, got plan=%+v", plan)
+	}
+	if *fetchCalls != 1 {
+		t.Errorf("OKX fetcher should be called exactly once, got %d", *fetchCalls)
+	}
+	if len(*calls) != 1 || (*calls)[0] != "BTC" {
+		t.Errorf("closer calls = %v, want [BTC]", *calls)
+	}
+	if !strings.Contains(plan.DiscordMessage, "OKX closes: [BTC]") {
+		t.Errorf("expected OKX closes in message, got: %s", plan.DiscordMessage)
+	}
+}
+
+// OKX close failure: closer errors, plan must latch. Mirrors the HL close-
+// error test — this is the load-bearing #345 correctness case. Without
+// this, a silent OKX close failure would clear virtual state while on-chain
+// exposure remained (the exact #341/#345 bug class).
+func TestPlanKillSwitchClose_OKXCloseError(t *testing.T) {
+	okxLive := []StrategyConfig{
+		{ID: "okx-sma-btc", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
+	closer, _ := stubOKXLiveCloser(map[string]error{"BTC": fmt.Errorf("okx rate limited")})
+	fetcher, _ := stubOKXPositionsFetcher(positions, nil)
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		OKXLiveAllPerps: okxLive,
+		OKXCloser:       closer,
+		OKXFetcher:      fetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("expected NOT ConfirmedFlat on OKX close error — would clear virtual state while on-chain is live")
+	}
+	if got, ok := plan.OKXCloseReport.Errors["BTC"]; !ok || got == nil {
+		t.Errorf("expected BTC error in OKX report, got %v", plan.OKXCloseReport.Errors)
+	}
+	if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
+		t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
+	}
+	if !strings.Contains(plan.DiscordMessage, "okx rate limited") {
+		t.Errorf("expected OKX error detail in message, got: %s", plan.DiscordMessage)
+	}
+}
+
+// OKX fetch failure: fetcher errors → kill switch must latch, closer
+// must NOT be invoked (we don't know which coins to close). Same guard
+// semantic as TestPlanKillSwitchClose_FetchFailure.
+func TestPlanKillSwitchClose_OKXFetchFailure(t *testing.T) {
+	okxLive := []StrategyConfig{
+		{ID: "okx-sma-btc", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	closer, calls := stubOKXLiveCloser(nil)
+	fetcher, _ := stubOKXPositionsFetcher(nil, fmt.Errorf("okx auth failed"))
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		OKXLiveAllPerps: okxLive,
+		OKXCloser:       closer,
+		OKXFetcher:      fetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("expected NOT ConfirmedFlat on OKX fetch failure")
+	}
+	if len(*calls) != 0 {
+		t.Errorf("closer must not be invoked when fetch failed, got %v", *calls)
+	}
+	if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
+		t.Errorf("expected LATCHED message on fetch failure, got: %s", plan.DiscordMessage)
+	}
+}
+
+// OKX spot strategy present: surface as unhandled gap. Does NOT block
+// ConfirmedFlat (we have no reliable way to check spot balances — a hard
+// latch would freeze the scheduler forever for any OKX spot user).
+func TestPlanKillSwitchClose_OKXSpotSurfacesGap(t *testing.T) {
+	okxSpot := []StrategyConfig{
+		{ID: "okx-sma-btc-spot", Platform: "okx", Type: "spot",
+			Args: []string{"sma", "BTC", "1h", "--mode=live", "--inst-type=spot"}},
+	}
+	closer, _ := stubOKXLiveCloser(nil)
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		OKXLiveAllSpot:  okxSpot,
+		OKXCloser:       closer,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	// Spot gap alone does NOT latch — the Discord message surfaces it.
+	if !plan.OnChainConfirmedFlat {
+		t.Errorf("spot-only presence must not block ConfirmedFlat, got plan=%+v", plan)
+	}
+	if !plan.OKXSpotPresent {
+		t.Error("expected OKXSpotPresent=true")
+	}
+	if !strings.Contains(plan.DiscordMessage, "OKX spot") {
+		t.Errorf("expected spot gap note in message, got: %s", plan.DiscordMessage)
+	}
+}
+
+// HL + OKX combined: both platforms have successful closes. Plan is
+// ConfirmedFlat, message lists both. Verifies the two platforms compose
+// rather than clobber each other's report.
+func TestPlanKillSwitchClose_HLAndOKXHappyPath(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	okxLive := []StrategyConfig{
+		{ID: "okx-btc", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	hlPos := []HLPosition{{Coin: "ETH", Size: 0.5}}
+	okxPos := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
+	hlCloser, hlCalls := stubHLLiveCloser(nil)
+	hlFetcher, _ := stubHLStateFetcher(nil, nil)
+	okxCloser, okxCalls := stubOKXLiveCloser(nil)
+	okxFetcher, _ := stubOKXPositionsFetcher(okxPos, nil)
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		HLAddr:          "0xaddr",
+		HLStateFetched:  true,
+		HLPositions:     hlPos,
+		HLLiveAll:       hlLive,
+		HLCloser:        hlCloser,
+		HLFetcher:       hlFetcher,
+		OKXLiveAllPerps: okxLive,
+		OKXCloser:       okxCloser,
+		OKXFetcher:      okxFetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if !plan.OnChainConfirmedFlat {
+		t.Fatalf("expected ConfirmedFlat when both platforms succeed, got plan=%+v", plan)
+	}
+	if len(*hlCalls) != 1 || (*hlCalls)[0] != "ETH" {
+		t.Errorf("HL closer calls = %v, want [ETH]", *hlCalls)
+	}
+	if len(*okxCalls) != 1 || (*okxCalls)[0] != "BTC" {
+		t.Errorf("OKX closer calls = %v, want [BTC]", *okxCalls)
+	}
+	if !strings.Contains(plan.DiscordMessage, "HL closes: [ETH]") {
+		t.Errorf("expected HL closes in message, got: %s", plan.DiscordMessage)
+	}
+	if !strings.Contains(plan.DiscordMessage, "OKX closes: [BTC]") {
+		t.Errorf("expected OKX closes in message, got: %s", plan.DiscordMessage)
+	}
+}
+
+// Either platform failing latches the switch: HL succeeds, OKX fails.
+// Critical correctness test — without it, OKX-side failures would be
+// hidden behind an HL-side success (exactly the #345 bug class).
+func TestPlanKillSwitchClose_HLSuccessOKXFailureStillLatches(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	okxLive := []StrategyConfig{
+		{ID: "okx-btc", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	hlPos := []HLPosition{{Coin: "ETH", Size: 0.5}}
+	okxPos := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
+	hlCloser, _ := stubHLLiveCloser(nil)
+	hlFetcher, _ := stubHLStateFetcher(nil, nil)
+	okxCloser, _ := stubOKXLiveCloser(map[string]error{"BTC": fmt.Errorf("okx err")})
+	okxFetcher, _ := stubOKXPositionsFetcher(okxPos, nil)
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		HLAddr:          "0xaddr",
+		HLStateFetched:  true,
+		HLPositions:     hlPos,
+		HLLiveAll:       hlLive,
+		HLCloser:        hlCloser,
+		HLFetcher:       hlFetcher,
+		OKXLiveAllPerps: okxLive,
+		OKXCloser:       okxCloser,
+		OKXFetcher:      okxFetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("OKX failure must latch the switch even when HL succeeded")
+	}
+	if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
+		t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
+	}
+	if !strings.Contains(plan.DiscordMessage, "okx err") {
+		t.Errorf("OKX error missing from message, got: %s", plan.DiscordMessage)
+	}
+}
+
+// OKX unconfigured: fetcher reports a position for a coin no live perps
+// strategy trades. Kill switch refuses to liquidate and latches.
+func TestPlanKillSwitchClose_OKXUnconfiguredBlocksReset(t *testing.T) {
+	okxLive := []StrategyConfig{
+		{ID: "okx-btc", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []OKXPosition{
+		{Coin: "BTC", Size: 0.01, Side: "long"},
+		{Coin: "SOL", Size: 100, Side: "long"}, // not configured
+	}
+	closer, calls := stubOKXLiveCloser(nil)
+	fetcher, _ := stubOKXPositionsFetcher(positions, nil)
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		OKXLiveAllPerps: okxLive,
+		OKXCloser:       closer,
+		OKXFetcher:      fetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("expected NOT ConfirmedFlat — unconfigured SOL position is still on-chain")
+	}
+	if len(plan.OKXUnconfigured) != 1 || plan.OKXUnconfigured[0].Coin != "SOL" {
+		t.Errorf("expected OKXUnconfigured=[SOL], got %v", plan.OKXUnconfigured)
+	}
+	// BTC should still be closed (it's configured).
+	if len(*calls) != 1 || (*calls)[0] != "BTC" {
+		t.Errorf("closer calls = %v, want [BTC]", *calls)
+	}
+	if !strings.Contains(plan.DiscordMessage, "manual intervention required") {
+		t.Errorf("expected manual intervention note, got: %s", plan.DiscordMessage)
+	}
+}
+
+// OKX deterministic error ordering: multiple failing coins produce a stable
+// message. Mirrors TestPlanKillSwitchClose_DeterministicErrorOrder for the
+// OKX path — Go map iteration randomization would otherwise produce
+// flaky messages for identical failures.
+func TestPlanKillSwitchClose_OKXDeterministicErrorOrder(t *testing.T) {
+	okxLive := []StrategyConfig{
+		{ID: "okx-btc", Platform: "okx", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+		{ID: "okx-eth", Platform: "okx", Type: "perps", Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "okx-sol", Platform: "okx", Type: "perps", Args: []string{"sma", "SOL", "1h", "--mode=live"}},
+	}
+	positions := []OKXPosition{
+		{Coin: "BTC", Size: 0.01, Side: "long"},
+		{Coin: "ETH", Size: 0.1, Side: "long"},
+		{Coin: "SOL", Size: 1.0, Side: "long"},
+	}
+	errs := map[string]error{
+		"BTC": fmt.Errorf("err"), "ETH": fmt.Errorf("err"), "SOL": fmt.Errorf("err"),
+	}
+	var prev string
+	for i := 0; i < 10; i++ {
+		closer, _ := stubOKXLiveCloser(errs)
+		fetcher, _ := stubOKXPositionsFetcher(positions, nil)
+		plan := planKillSwitchClose(KillSwitchCloseInputs{
+			OKXLiveAllPerps: okxLive,
+			OKXCloser:       closer,
+			OKXFetcher:      fetcher,
+			PortfolioReason: "reason",
+			CloseTimeout:    time.Second,
+		})
+		if prev != "" && plan.DiscordMessage != prev {
+			t.Fatalf("message should be deterministic, iter %d:\n%s\nprev:\n%s", i, plan.DiscordMessage, prev)
+		}
+		prev = plan.DiscordMessage
+	}
+	btcPos := strings.Index(prev, "BTC:")
+	ethPos := strings.Index(prev, "ETH:")
+	solPos := strings.Index(prev, "SOL:")
+	if !(btcPos < ethPos && ethPos < solPos) {
+		t.Errorf("expected alphabetical BTC < ETH < SOL in: %s", prev)
 	}
 }

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -503,6 +503,23 @@ func main() {
 				}
 			}
 
+			// #345: Partition live OKX strategies for the kill-switch close
+			// path. Perps and spot are separated because only perps support
+			// a reduce-only close; spot is surfaced as a manual-intervention
+			// gap in the Discord message (see planKillSwitchClose).
+			var okxLivePerps []StrategyConfig
+			var okxLiveSpot []StrategyConfig
+			for _, sc := range cfg.Strategies {
+				if sc.Platform != "okx" || !okxIsLive(sc.Args) {
+					continue
+				}
+				if sc.Type == "perps" {
+					okxLivePerps = append(okxLivePerps, sc)
+				} else if sc.Type == "spot" {
+					okxLiveSpot = append(okxLiveSpot, sc)
+				}
+			}
+
 			sharedWallets := detectSharedWallets(cfg.Strategies)
 			hlAddr := os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS")
 			hlKey := SharedWalletKey{Platform: "hyperliquid", Account: hlAddr}
@@ -564,31 +581,37 @@ func main() {
 			}
 			mu.Unlock()
 
-			// #341: Submit reduce-only market closes to Hyperliquid for every
-			// non-zero on-chain position belonging to a configured live HL
-			// strategy. The planning step (planKillSwitchClose) runs OUTSIDE
-			// the lock — close_hyperliquid_position.py is a subprocess that
-			// can take seconds. HL-only this PR; OKX/Robinhood/TopStep have
-			// the same underlying bug but route orders through subprocesses
-			// without a native Go on-chain fetcher (tracked separately).
+			// #341 / #345: Submit reduce-only market closes to Hyperliquid
+			// AND OKX for every non-zero on-chain position belonging to a
+			// configured live perps strategy. The planning step
+			// (planKillSwitchClose) runs OUTSIDE the lock — the close
+			// scripts are subprocesses that can take seconds. OKX spot is
+			// surfaced as a known gap (no reduce-only equivalent for spot).
+			// Robinhood/TopStep have the same underlying bug but are
+			// tracked separately.
 			//
 			// Latch semantics: virtual state is mutated only when
-			// plan.OnChainConfirmedFlat is true. Otherwise the kill switch
-			// stays latched and the next cycle re-enters this branch
-			// (CheckPortfolioRisk early-returns false while KillSwitchActive
-			// is true) and retries.
+			// plan.OnChainConfirmedFlat is true (either platform failing
+			// flips the flag). Otherwise the kill switch stays latched and
+			// the next cycle re-enters this branch (CheckPortfolioRisk
+			// early-returns false while KillSwitchActive is true) and retries.
 			var plan KillSwitchClosePlan
 			if killSwitchFired {
-				plan = planKillSwitchClose(
-					hlAddr,
-					hlStateFetched,
-					hlPositions,
-					hlLiveAll,
-					portfolioReason,
-					90*time.Second,
-					defaultHyperliquidLiveCloser,
-					defaultHLStateFetcher,
-				)
+				inputs := KillSwitchCloseInputs{
+					HLAddr:          hlAddr,
+					HLStateFetched:  hlStateFetched,
+					HLPositions:     hlPositions,
+					HLLiveAll:       hlLiveAll,
+					HLCloser:        defaultHyperliquidLiveCloser,
+					HLFetcher:       defaultHLStateFetcher,
+					OKXLiveAllPerps: okxLivePerps,
+					OKXLiveAllSpot:  okxLiveSpot,
+					OKXCloser:       defaultOKXLiveCloser,
+					OKXFetcher:      defaultOKXPositionsFetcher,
+					PortfolioReason: portfolioReason,
+					CloseTimeout:    90 * time.Second,
+				}
+				plan = planKillSwitchClose(inputs)
 				for _, line := range plan.LogLines {
 					fmt.Println(line)
 				}

--- a/scheduler/okx_close.go
+++ b/scheduler/okx_close.go
@@ -49,7 +49,9 @@ type OKXPositionsFetcher func() ([]OKXPosition, error)
 
 // defaultOKXPositionsFetcher wraps fetch_okx_positions.py for production
 // use. Returns a typed slice so callers don't have to decode the JSON
-// envelope themselves.
+// envelope themselves. Python-side filters stale zero-size entries
+// upstream (fetch_okx_positions.py), and forceCloseOKXLive has its own
+// size==0 defense-in-depth — no need for a third filtering layer here.
 func defaultOKXPositionsFetcher() ([]OKXPosition, error) {
 	result, stderr, err := RunOKXFetchPositions(okxFetchPositionsScript)
 	if stderr != "" {
@@ -60,9 +62,6 @@ func defaultOKXPositionsFetcher() ([]OKXPosition, error) {
 	}
 	positions := make([]OKXPosition, 0, len(result.Positions))
 	for _, p := range result.Positions {
-		if p.Size == 0 {
-			continue
-		}
 		positions = append(positions, OKXPosition{
 			Coin:       p.Coin,
 			Size:       p.Size,
@@ -76,16 +75,27 @@ func defaultOKXPositionsFetcher() ([]OKXPosition, error) {
 // OKXLiveCloseReport summarizes a forceCloseOKXLive run. Mirrors
 // HyperliquidLiveCloseReport so the kill-switch plan can treat both
 // platforms symmetrically. Errors is the load-bearing correctness signal —
-// only when it's empty does the caller mutate virtual state. See
+// ConfirmedFlat() returns true only when it's empty. See
 // HyperliquidLiveCloseReport doc for the rationale.
+//
+// Unconfigured lists on-chain positions for coins no configured live perps
+// strategy trades. Computed here (rather than in the plan builder) so the
+// "which coins is this scheduler authorized to touch" partition has a
+// single source of truth — if the perps-vs-spot partition rule ever
+// changes, only this function needs to be updated. The plan builder
+// consumes Unconfigured separately from ConfirmedFlat to decide whether
+// to latch the kill switch for manual intervention.
 type OKXLiveCloseReport struct {
-	ClosedCoins []string
-	AlreadyFlat []string
-	Errors      map[string]error
+	ClosedCoins  []string
+	AlreadyFlat  []string
+	Unconfigured []OKXPosition
+	Errors       map[string]error
 }
 
 // ConfirmedFlat reports whether every configured live OKX coin reached a
-// terminal closed/flat state without errors.
+// terminal closed/flat state without errors. Mirrors HL shape
+// (Errors-only); Unconfigured is a separate signal the plan builder
+// consumes to decide whether to latch the switch for manual intervention.
 func (r OKXLiveCloseReport) ConfirmedFlat() bool {
 	return len(r.Errors) == 0
 }
@@ -141,7 +151,12 @@ func forceCloseOKXLive(ctx context.Context, positions []OKXPosition, okxLiveAll 
 	for _, p := range positions {
 		if !tradedCoins[p.Coin] {
 			// Unowned position — kill switch only acts on coins this
-			// scheduler is configured to trade.
+			// scheduler is configured to trade. Non-zero sizes are surfaced
+			// to the caller via Unconfigured so the plan can latch the
+			// switch and prompt manual intervention.
+			if p.Size != 0 {
+				report.Unconfigured = append(report.Unconfigured, p)
+			}
 			continue
 		}
 		if p.Size == 0 {

--- a/scheduler/okx_close.go
+++ b/scheduler/okx_close.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+)
+
+// OKXPosition represents an on-chain OKX perpetual swap position. Size is
+// signed (positive = long, negative = short) to mirror HLPosition so the
+// kill-switch plan builder can treat both platforms symmetrically.
+type OKXPosition struct {
+	Coin       string
+	Size       float64
+	EntryPrice float64
+	Side       string // "long" or "short"; empty when szi==0 (filtered)
+}
+
+// okxLiveCloseScript is the path to the Python close helper. Exposed as a
+// var so tests can substitute — same pattern as hyperliquidLiveCloseScript.
+var okxLiveCloseScript = "shared_scripts/close_okx_position.py"
+
+// okxFetchPositionsScript is the path to the Python position fetcher.
+var okxFetchPositionsScript = "shared_scripts/fetch_okx_positions.py"
+
+// OKXLiveCloser submits a reduce-only market close for a single OKX swap
+// coin and returns the parsed result. Exposed as a function variable so
+// tests can inject a fake without spawning Python. Production implementation
+// is defaultOKXLiveCloser, which shells out to close_okx_position.py via
+// RunOKXClose.
+type OKXLiveCloser func(symbol string) (*OKXCloseResult, error)
+
+// defaultOKXLiveCloser is the production close implementation. Matches the
+// HL shape: stderr goes to os.Stderr (kill switch is a system-level event,
+// not strategy-scoped) and any non-nil err means the close was NOT confirmed
+// by the adapter so the kill switch must stay latched.
+func defaultOKXLiveCloser(symbol string) (*OKXCloseResult, error) {
+	result, stderr, err := RunOKXClose(okxLiveCloseScript, symbol)
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, "[okx-close] %s stderr: %s\n", symbol, stderr)
+	}
+	return result, err
+}
+
+// OKXPositionsFetcher fetches every open OKX swap position on the account.
+// Exposed as a function type so tests can stub — mirrors HLStateFetcher.
+type OKXPositionsFetcher func() ([]OKXPosition, error)
+
+// defaultOKXPositionsFetcher wraps fetch_okx_positions.py for production
+// use. Returns a typed slice so callers don't have to decode the JSON
+// envelope themselves.
+func defaultOKXPositionsFetcher() ([]OKXPosition, error) {
+	result, stderr, err := RunOKXFetchPositions(okxFetchPositionsScript)
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, "[okx-close] fetch_positions stderr: %s\n", stderr)
+	}
+	if err != nil {
+		return nil, err
+	}
+	positions := make([]OKXPosition, 0, len(result.Positions))
+	for _, p := range result.Positions {
+		if p.Size == 0 {
+			continue
+		}
+		positions = append(positions, OKXPosition{
+			Coin:       p.Coin,
+			Size:       p.Size,
+			EntryPrice: p.EntryPrice,
+			Side:       p.Side,
+		})
+	}
+	return positions, nil
+}
+
+// OKXLiveCloseReport summarizes a forceCloseOKXLive run. Mirrors
+// HyperliquidLiveCloseReport so the kill-switch plan can treat both
+// platforms symmetrically. Errors is the load-bearing correctness signal —
+// only when it's empty does the caller mutate virtual state. See
+// HyperliquidLiveCloseReport doc for the rationale.
+type OKXLiveCloseReport struct {
+	ClosedCoins []string
+	AlreadyFlat []string
+	Errors      map[string]error
+}
+
+// ConfirmedFlat reports whether every configured live OKX coin reached a
+// terminal closed/flat state without errors.
+func (r OKXLiveCloseReport) ConfirmedFlat() bool {
+	return len(r.Errors) == 0
+}
+
+// SortedErrorCoins returns Errors keys in deterministic order for stable
+// log/Discord output. Same reason as HyperliquidLiveCloseReport — map
+// iteration is randomized in Go, so identical kill-switch fires would
+// otherwise produce different messages (caught in #342 review).
+func (r OKXLiveCloseReport) SortedErrorCoins() []string {
+	coins := make([]string, 0, len(r.Errors))
+	for c := range r.Errors {
+		coins = append(coins, c)
+	}
+	sort.Strings(coins)
+	return coins
+}
+
+// forceCloseOKXLive submits reduce-only market closes for every non-zero
+// on-chain OKX swap position belonging to a coin a configured live OKX
+// perps strategy trades on this account. Mirrors forceCloseHyperliquidLive:
+// closes the on-chain quantity directly, regardless of which strategy
+// "owns" it — required because account-level positions can diverge from
+// per-strategy virtual state (#341/#345). The OKX adapter's market_close
+// passes reduceOnly=True, so overshooting cannot flip the position.
+//
+// Pure / no state mutation. Caller mutates virtual state only when
+// report.ConfirmedFlat() is true.
+//
+// The ctx argument bounds the OVERALL close loop. Each individual closer
+// call has its own subprocess timeout (see RunPythonScript). Once ctx
+// expires, remaining unprocessed coins are added to Errors so the kill
+// switch stays latched and retries next cycle.
+//
+// Note: only perps strategies are considered. OKX spot strategies (sc.Type
+// == "spot") are deliberately NOT closed here — there is no reduce-only
+// spot close, and a blind sell-all would trash unrelated holdings. The
+// plan surfaces spot strategies via SpotUnclosable so the operator sees
+// the gap in the Discord message.
+func forceCloseOKXLive(ctx context.Context, positions []OKXPosition, okxLiveAll []StrategyConfig, closer OKXLiveCloser) OKXLiveCloseReport {
+	report := OKXLiveCloseReport{Errors: make(map[string]error)}
+
+	tradedCoins := make(map[string]bool)
+	for _, sc := range okxLiveAll {
+		if sc.Type != "perps" {
+			continue
+		}
+		sym := okxSymbol(sc.Args)
+		if sym != "" {
+			tradedCoins[sym] = true
+		}
+	}
+
+	for _, p := range positions {
+		if !tradedCoins[p.Coin] {
+			// Unowned position — kill switch only acts on coins this
+			// scheduler is configured to trade.
+			continue
+		}
+		if p.Size == 0 {
+			report.AlreadyFlat = append(report.AlreadyFlat, p.Coin)
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			report.Errors[p.Coin] = fmt.Errorf("close budget exhausted before submit: %w", err)
+			continue
+		}
+		if _, err := closer(p.Coin); err != nil {
+			report.Errors[p.Coin] = err
+			continue
+		}
+		report.ClosedCoins = append(report.ClosedCoins, p.Coin)
+	}
+
+	return report
+}

--- a/scheduler/okx_close_test.go
+++ b/scheduler/okx_close_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// forceCloseOKXLive unit tests — mirror the HL tests in
+// hyperliquid_balance_test.go (TestForceCloseHyperliquidLive_*). Each
+// test asserts a single branch of the decision logic so a regression
+// produces a targeted failure rather than a conflated ambiguous signal.
+
+func TestForceCloseOKXLive_ClosesOwnedCoinsOnly(t *testing.T) {
+	okxLive := []StrategyConfig{
+		{ID: "okx-btc", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []OKXPosition{
+		{Coin: "BTC", Size: 0.01, Side: "long"},
+		{Coin: "SOL", Size: 50, Side: "long"}, // unowned: no configured strategy
+	}
+	var calls []string
+	closer := func(sym string) (*OKXCloseResult, error) {
+		calls = append(calls, sym)
+		return &OKXCloseResult{Close: &OKXClose{Symbol: sym}}, nil
+	}
+
+	report := forceCloseOKXLive(context.Background(), positions, okxLive, closer)
+
+	if !report.ConfirmedFlat() {
+		t.Errorf("expected ConfirmedFlat, got errors=%v", report.Errors)
+	}
+	if len(calls) != 1 || calls[0] != "BTC" {
+		t.Errorf("expected closer to be called only for owned coin BTC, got %v", calls)
+	}
+	if len(report.ClosedCoins) != 1 || report.ClosedCoins[0] != "BTC" {
+		t.Errorf("ClosedCoins = %v, want [BTC]", report.ClosedCoins)
+	}
+}
+
+func TestForceCloseOKXLive_CloseErrorLatches(t *testing.T) {
+	okxLive := []StrategyConfig{
+		{ID: "okx-btc", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
+	closer := func(sym string) (*OKXCloseResult, error) {
+		return nil, fmt.Errorf("okx 503")
+	}
+
+	report := forceCloseOKXLive(context.Background(), positions, okxLive, closer)
+
+	if report.ConfirmedFlat() {
+		t.Fatal("expected NOT ConfirmedFlat on close error")
+	}
+	if _, ok := report.Errors["BTC"]; !ok {
+		t.Errorf("expected BTC in errors, got %v", report.Errors)
+	}
+}
+
+func TestForceCloseOKXLive_ZeroSizeMarkedAlreadyFlat(t *testing.T) {
+	// Defense-in-depth: fetcher filters size==0 upstream, but if it ever
+	// loosens we must not submit a zero-size order (OKX would reject it
+	// and the kill switch would latch on a false failure).
+	okxLive := []StrategyConfig{
+		{ID: "okx-btc", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []OKXPosition{{Coin: "BTC", Size: 0, Side: ""}}
+	var calls []string
+	closer := func(sym string) (*OKXCloseResult, error) {
+		calls = append(calls, sym)
+		return &OKXCloseResult{}, nil
+	}
+
+	report := forceCloseOKXLive(context.Background(), positions, okxLive, closer)
+
+	if len(calls) != 0 {
+		t.Errorf("zero-size position must short-circuit before closer, got calls=%v", calls)
+	}
+	if len(report.AlreadyFlat) != 1 || report.AlreadyFlat[0] != "BTC" {
+		t.Errorf("AlreadyFlat = %v, want [BTC]", report.AlreadyFlat)
+	}
+	if !report.ConfirmedFlat() {
+		t.Errorf("zero-size short-circuit must be ConfirmedFlat, got errors=%v", report.Errors)
+	}
+}
+
+func TestForceCloseOKXLive_CtxExpiredBeforeSubmit(t *testing.T) {
+	// When the overall budget expires, remaining coins must be flagged as
+	// errors so the kill switch latches and retries next cycle — rather
+	// than silently skipping them and clearing virtual state.
+	okxLive := []StrategyConfig{
+		{ID: "okx-btc", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	cancel()
+	time.Sleep(time.Millisecond) // ensure Err() is non-nil
+	var calls []string
+	closer := func(sym string) (*OKXCloseResult, error) {
+		calls = append(calls, sym)
+		return &OKXCloseResult{}, nil
+	}
+
+	report := forceCloseOKXLive(ctx, positions, okxLive, closer)
+
+	if len(calls) != 0 {
+		t.Errorf("closer must not be called after ctx expires, got %v", calls)
+	}
+	if _, ok := report.Errors["BTC"]; !ok {
+		t.Errorf("expected BTC to be marked as error on ctx expiry, got %v", report.Errors)
+	}
+}
+
+func TestForceCloseOKXLive_SpotStrategiesIgnored(t *testing.T) {
+	// Spot strategies live in OKXLiveAllSpot and must NOT appear in the
+	// perps close loop — forceCloseOKXLive should not attempt to "close"
+	// spot coins. Guards against a future refactor that flattens the
+	// perps/spot partition and triggers unsafe sell-all behavior.
+	mixed := []StrategyConfig{
+		{ID: "okx-btc-spot", Platform: "okx", Type: "spot",
+			Args: []string{"sma", "BTC", "1h", "--mode=live", "--inst-type=spot"}},
+	}
+	positions := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
+	var calls []string
+	closer := func(sym string) (*OKXCloseResult, error) {
+		calls = append(calls, sym)
+		return &OKXCloseResult{}, nil
+	}
+
+	report := forceCloseOKXLive(context.Background(), positions, mixed, closer)
+
+	if len(calls) != 0 {
+		t.Errorf("spot strategy must not drive perps close, got calls=%v", calls)
+	}
+	if !report.ConfirmedFlat() {
+		t.Errorf("spot-only config with non-traded perps position is ConfirmedFlat for the OKX perps branch, got errors=%v", report.Errors)
+	}
+}
+
+// SortedErrorCoins determinism — same rationale as HL
+// (HyperliquidLiveCloseReport.SortedErrorCoins): Go map iteration is
+// randomized and the Discord output must be byte-stable across calls for
+// operator triage.
+func TestOKXLiveCloseReport_SortedErrorCoins(t *testing.T) {
+	r := OKXLiveCloseReport{Errors: map[string]error{
+		"SOL": fmt.Errorf("e"), "BTC": fmt.Errorf("e"), "ETH": fmt.Errorf("e"),
+	}}
+	coins := r.SortedErrorCoins()
+	want := []string{"BTC", "ETH", "SOL"}
+	if len(coins) != len(want) {
+		t.Fatalf("len = %d, want %d", len(coins), len(want))
+	}
+	for i, c := range coins {
+		if c != want[i] {
+			t.Errorf("coins[%d] = %q, want %q", i, c, want[i])
+		}
+	}
+}

--- a/scheduler/okx_close_test.go
+++ b/scheduler/okx_close_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 )
 
 // forceCloseOKXLive unit tests — mirror the HL tests in
@@ -37,6 +36,13 @@ func TestForceCloseOKXLive_ClosesOwnedCoinsOnly(t *testing.T) {
 	}
 	if len(report.ClosedCoins) != 1 || report.ClosedCoins[0] != "BTC" {
 		t.Errorf("ClosedCoins = %v, want [BTC]", report.ClosedCoins)
+	}
+	// Unowned positions must be surfaced via Unconfigured so the kill-switch
+	// plan can latch for manual intervention (dedup: single source of truth
+	// for the traded-coins partition lives in forceCloseOKXLive, not the
+	// plan builder).
+	if len(report.Unconfigured) != 1 || report.Unconfigured[0].Coin != "SOL" {
+		t.Errorf("Unconfigured = %v, want [SOL]", report.Unconfigured)
 	}
 }
 
@@ -99,7 +105,6 @@ func TestForceCloseOKXLive_CtxExpiredBeforeSubmit(t *testing.T) {
 	positions := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
 	ctx, cancel := context.WithTimeout(context.Background(), 0)
 	cancel()
-	time.Sleep(time.Millisecond) // ensure Err() is non-nil
 	var calls []string
 	closer := func(sym string) (*OKXCloseResult, error) {
 		calls = append(calls, sym)

--- a/shared_scripts/close_okx_position.py
+++ b/shared_scripts/close_okx_position.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+OKX emergency position close script (issue #345).
+
+Submits a reduce-only market close for a single coin via the OKX adapter's
+``market_close``. Used by the portfolio kill switch in the Go scheduler to
+liquidate on-chain swap (perps) exposure regardless of which strategy
+"owns" the position.
+
+Scope: swap (perps) only. OKX spot strategies are NOT closed by this script
+— spot "positions" are just balances, have no reduce-only semantics, and a
+blind sell-all would trash unrelated holdings on the same account. See #345
+for the spot follow-up.
+
+Usage:
+    close_okx_position.py --symbol=BTC --mode=live
+
+Live mode is required (kill switch is meaningful only against real
+positions). Stdout is always a single JSON envelope matching the shape of
+``close_hyperliquid_position.py`` so the Go caller's parser contract is
+symmetric across platforms:
+``{"close": {"symbol": ..., "fill": {...}}, "platform": "okx",
+  "timestamp": ..., "error": "..."}``
+
+The kill switch must NEVER report success unless the on-chain exposure is
+actually reduced. Credential errors, network failures, and unexpected SDK
+responses all exit 1 with a populated ``error`` field so the Go caller
+latches the kill switch and retries next cycle.
+"""
+
+import argparse
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "platforms", "okx"))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--symbol", required=True)
+    parser.add_argument("--mode", default="live")
+    args = parser.parse_args()
+
+    if args.mode != "live":
+        print(json.dumps({
+            "close": None,
+            "platform": "okx",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "error": "--mode=live required for emergency close",
+        }))
+        sys.exit(1)
+
+    try:
+        from adapter import OKXExchangeAdapter
+        adapter = OKXExchangeAdapter()
+        if not adapter.is_live:
+            _emit_error(args.symbol, "OKX adapter not live — set OKX_API_KEY / OKX_API_SECRET / OKX_PASSPHRASE")
+            return
+        result = adapter.market_close(args.symbol)
+    except Exception as e:
+        traceback.print_exc(file=sys.stderr)
+        _emit_error(args.symbol, str(e))
+        return
+
+    # adapter.market_close returns:
+    #   - {} when fetch_positions returned no open position (already flat)
+    #   - the ccxt order dict from the first reduce-only close submit
+    # Any other shape is unexpected and must be treated as failure so the
+    # kill switch latches for a retry rather than clearing virtual state.
+    if not isinstance(result, dict):
+        _emit_error(args.symbol, f"unexpected adapter response type {type(result).__name__}: {result!r}")
+        return
+
+    if not result:
+        # Empty dict — adapter found no open position to close. Treat as
+        # already-flat success so the kill switch can release the latch when
+        # on-chain is genuinely flat (eventual-consistency window between the
+        # Go-side fetch and this submit).
+        _emit_success(args.symbol, fill={})
+        return
+
+    # ccxt unified order response: extract best-effort fill telemetry. Missing
+    # fields are OK — the Go caller only treats non-nil error as failure.
+    fill = {}
+    avg = result.get("average") or result.get("price")
+    filled = result.get("filled") or result.get("amount")
+    try:
+        if avg is not None:
+            fill["avg_px"] = float(avg or 0)
+        if filled is not None:
+            fill["total_sz"] = float(filled or 0)
+    except (TypeError, ValueError):
+        pass
+    oid = result.get("id")
+    if oid is not None:
+        fill["oid"] = str(oid)
+    fee_info = result.get("fee") or {}
+    if isinstance(fee_info, dict) and fee_info.get("cost") is not None:
+        try:
+            fill["fee"] = float(fee_info["cost"])
+        except (TypeError, ValueError):
+            pass
+
+    _emit_success(args.symbol, fill)
+
+
+def _emit_success(symbol, fill):
+    print(json.dumps({
+        "close": {"symbol": symbol, "fill": fill},
+        "platform": "okx",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }))
+
+
+def _emit_error(symbol, message):
+    print(json.dumps({
+        "close": {"symbol": symbol, "fill": {}},
+        "platform": "okx",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "error": message,
+    }))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/shared_scripts/fetch_okx_positions.py
+++ b/shared_scripts/fetch_okx_positions.py
@@ -37,7 +37,7 @@ def main():
         if not adapter.is_live:
             _emit_error("OKX adapter not live — set OKX_API_KEY / OKX_API_SECRET / OKX_PASSPHRASE")
             return
-        raw = adapter._exchange.fetch_positions()
+        raw = adapter.fetch_open_positions()
     except Exception as e:
         traceback.print_exc(file=sys.stderr)
         _emit_error(str(e))

--- a/shared_scripts/fetch_okx_positions.py
+++ b/shared_scripts/fetch_okx_positions.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+OKX live positions fetcher (issue #345).
+
+Fetches every open OKX perpetual swap position on the account and emits a
+JSON list to stdout. Used by the portfolio kill switch in the Go scheduler
+to decide which coins need reduce-only closes — mirrors
+``fetchHyperliquidState`` but via Python subprocess since OKX position
+queries require authenticated API access (no public endpoint equivalent).
+
+Scope: swap (perps) only. OKX spot balances are NOT surfaced — the kill
+switch has no automated spot close path (see ``close_okx_position.py``).
+
+Usage:
+    fetch_okx_positions.py
+
+Requires OKX_API_KEY / OKX_API_SECRET / OKX_PASSPHRASE. Output:
+``{"positions": [{"coin": "BTC", "size": 0.334, "entry_price": 42000.5,
+  "side": "long"}, ...], "platform": "okx", "timestamp": ...}``
+Size is signed (positive = long, negative = short) to mirror HLPosition.
+"""
+
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "platforms", "okx"))
+
+
+def main():
+    try:
+        from adapter import OKXExchangeAdapter
+        adapter = OKXExchangeAdapter()
+        if not adapter.is_live:
+            _emit_error("OKX adapter not live — set OKX_API_KEY / OKX_API_SECRET / OKX_PASSPHRASE")
+            return
+        raw = adapter._exchange.fetch_positions()
+    except Exception as e:
+        traceback.print_exc(file=sys.stderr)
+        _emit_error(str(e))
+        return
+
+    positions = []
+    for p in raw or []:
+        # ccxt unified position shape: {symbol, contracts, side, entryPrice, ...}
+        try:
+            contracts = float(p.get("contracts") or 0)
+        except (TypeError, ValueError):
+            continue
+        if contracts == 0:
+            continue
+        symbol = p.get("symbol") or ""
+        # OKX swap symbols look like "BTC/USDT:USDT" — strip to coin.
+        coin = symbol.split("/", 1)[0] if "/" in symbol else symbol
+        if not coin:
+            continue
+        side = (p.get("side") or "").lower()
+        # Encode side into signed size so Go side can mirror HLPosition semantics.
+        signed_size = -contracts if side == "short" else contracts
+        entry_price = 0.0
+        try:
+            entry_price = float(p.get("entryPrice") or 0)
+        except (TypeError, ValueError):
+            pass
+        positions.append({
+            "coin": coin,
+            "size": signed_size,
+            "entry_price": entry_price,
+            "side": side,
+        })
+
+    print(json.dumps({
+        "positions": positions,
+        "platform": "okx",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }))
+
+
+def _emit_error(message):
+    print(json.dumps({
+        "positions": [],
+        "platform": "okx",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "error": message,
+    }))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/shared_scripts/test_close_okx_position.py
+++ b/shared_scripts/test_close_okx_position.py
@@ -1,0 +1,177 @@
+"""Tests for close_okx_position.py — adapter response parsing for the
+portfolio kill switch (#345).
+
+Pattern mirrors test_close_hyperliquid_position.py: load the script as a
+module, mock the `adapter` import, run main() with --symbol=... --mode=live,
+capture stdout + exit code.
+
+These tests pin the contract for every branch of the adapter response
+parser. A regression that treats an ambiguous response as success would
+silently clear virtual state while on-chain exposure remained — the
+exact #345 failure mode. Every path that means "close was NOT confirmed"
+must exit 1 with a populated error field so the Go caller latches the
+kill switch.
+"""
+
+import builtins
+import importlib.util
+import json
+import os
+import sys
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _run_script(adapter_response_or_exc, argv, is_live=True):
+    """Helper: invoke close_okx_position.main() with a mocked adapter.
+
+    adapter_response_or_exc may be either a dict/value (returned by
+    adapter.market_close) or an Exception subclass (raised by
+    market_close). argv is the list passed to main() as sys.argv
+    (excluding the program name).
+
+    is_live controls the mocked adapter's is_live property — False
+    verifies the script rejects paper/unauthenticated adapters.
+
+    Returns (parsed_stdout_json, exit_code).
+    """
+    script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               "close_okx_position.py")
+    spec = importlib.util.spec_from_file_location("close_okx_position", script_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    mock_adapter_cls = MagicMock()
+    mock_adapter = MagicMock()
+    mock_adapter.is_live = is_live
+    mock_adapter_cls.return_value = mock_adapter
+    if isinstance(adapter_response_or_exc, Exception):
+        mock_adapter.market_close.side_effect = adapter_response_or_exc
+    else:
+        mock_adapter.market_close.return_value = adapter_response_or_exc
+
+    captured = StringIO()
+    exit_code = {"value": 0}
+
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "adapter":
+            fake_mod = MagicMock()
+            fake_mod.OKXExchangeAdapter = mock_adapter_cls
+            return fake_mod
+        return original_import(name, *args, **kwargs)
+
+    def mock_exit(code=0):
+        exit_code["value"] = code
+        raise SystemExit(code)
+
+    with patch("builtins.__import__", side_effect=mock_import), \
+         patch("sys.stdout", captured), \
+         patch("sys.argv", ["close_okx_position.py"] + argv), \
+         patch.object(mod.sys, "exit", side_effect=mock_exit):
+        try:
+            mod.main()
+        except SystemExit:
+            pass
+
+    raw = captured.getvalue().strip()
+    parsed = json.loads(raw) if raw else {}
+    return parsed, exit_code["value"]
+
+
+class TestPaperModeRejected:
+    """--mode=live is required for kill-switch invocation."""
+
+    def test_paper_mode_exits_nonzero(self):
+        out, code = _run_script({"id": "xx"}, ["--symbol=BTC", "--mode=paper"])
+        assert code == 1
+        assert "--mode=live required" in out["error"]
+        assert out["close"] is None
+
+    def test_default_mode_is_live(self):
+        """No --mode flag → default live. Must go through to the adapter."""
+        out, code = _run_script({"id": "abc", "average": 42000, "filled": 0.01},
+                                ["--symbol=BTC"])
+        assert code == 0, out
+        assert "error" not in out
+
+
+class TestNonLiveAdapterRejected:
+    """Adapter reporting is_live=False (missing credentials) must fail fast —
+    silently calling market_close on a paper adapter would raise
+    RuntimeError but the script's try/except would surface it as a generic
+    error. The explicit is_live check produces a clearer operator message."""
+
+    def test_non_live_adapter_exits_nonzero(self):
+        out, code = _run_script({}, ["--symbol=BTC", "--mode=live"], is_live=False)
+        assert code == 1
+        assert "OKX_API_KEY" in out["error"]
+        assert out["close"]["fill"] == {}
+
+
+class TestSuccessFill:
+    """Normal close response → success path with fill telemetry."""
+
+    def test_full_fill_fields(self):
+        response = {
+            "id": "12345abc",
+            "average": 42000.5,
+            "filled": 0.01,
+            "fee": {"cost": 0.25, "currency": "USDT"},
+        }
+        out, code = _run_script(response, ["--symbol=BTC", "--mode=live"])
+        assert code == 0
+        assert out["close"]["symbol"] == "BTC"
+        fill = out["close"]["fill"]
+        assert fill["avg_px"] == 42000.5
+        assert fill["total_sz"] == 0.01
+        assert fill["oid"] == "12345abc"
+        assert fill["fee"] == 0.25
+
+    def test_minimal_fill_fields(self):
+        """Older/degenerate ccxt responses may omit optional fields. Must
+        still succeed — we don't have a way to re-fetch telemetry, and the
+        kill switch only cares about the binary close-submitted signal."""
+        out, code = _run_script({"id": "x"}, ["--symbol=BTC", "--mode=live"])
+        assert code == 0
+        assert out["close"]["symbol"] == "BTC"
+        assert out["close"]["fill"].get("oid") == "x"
+
+
+class TestAlreadyFlat:
+    """Empty dict == adapter found no position. Must be success with empty
+    fill so the kill switch can release the latch during the eventual-
+    consistency window between Go-side fetch and this submit."""
+
+    def test_empty_response_is_success(self):
+        out, code = _run_script({}, ["--symbol=BTC", "--mode=live"])
+        assert code == 0, out
+        assert out["close"]["symbol"] == "BTC"
+        assert out["close"]["fill"] == {}
+        assert "error" not in out
+
+
+class TestFailurePaths:
+    """Every path that means "close was NOT confirmed" must emit error +
+    exit 1 so the Go caller latches the kill switch for retry."""
+
+    def test_adapter_raises(self):
+        out, code = _run_script(RuntimeError("OKX auth failed"),
+                                ["--symbol=BTC", "--mode=live"])
+        assert code == 1
+        assert "OKX auth" in out["error"]
+        assert out["close"]["fill"] == {}
+
+    def test_non_dict_response(self):
+        """Defensive: unexpected ccxt response shape (list, None, string)
+        must not be treated as success — we don't know what it means."""
+        out, code = _run_script("unexpected string", ["--symbol=BTC", "--mode=live"])
+        assert code == 1
+        assert "unexpected adapter response type" in out["error"]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/shared_scripts/test_fetch_okx_positions.py
+++ b/shared_scripts/test_fetch_okx_positions.py
@@ -1,0 +1,133 @@
+"""Tests for fetch_okx_positions.py — live-account position fetcher used
+by the portfolio kill switch (#345).
+
+The kill switch's flat-confirmation depends on this script reporting every
+open perps position truthfully. A regression that drops a position from
+the output would cause the switch to release its latch while on-chain
+exposure remained — the exact #345 failure mode shifted into the Python
+layer.
+"""
+
+import builtins
+import importlib.util
+import json
+import os
+import sys
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _run_script(positions_or_exc, is_live=True):
+    """Invoke fetch_okx_positions.main() with a mocked adapter.
+
+    positions_or_exc may be either a list (returned by
+    adapter._exchange.fetch_positions) or an Exception. Returns
+    (parsed_stdout_json, exit_code).
+    """
+    script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               "fetch_okx_positions.py")
+    spec = importlib.util.spec_from_file_location("fetch_okx_positions", script_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    mock_adapter_cls = MagicMock()
+    mock_adapter = MagicMock()
+    mock_adapter.is_live = is_live
+    mock_exchange = MagicMock()
+    mock_adapter._exchange = mock_exchange
+    mock_adapter_cls.return_value = mock_adapter
+    if isinstance(positions_or_exc, Exception):
+        mock_exchange.fetch_positions.side_effect = positions_or_exc
+    else:
+        mock_exchange.fetch_positions.return_value = positions_or_exc
+
+    captured = StringIO()
+    exit_code = {"value": 0}
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "adapter":
+            fake_mod = MagicMock()
+            fake_mod.OKXExchangeAdapter = mock_adapter_cls
+            return fake_mod
+        return original_import(name, *args, **kwargs)
+
+    def mock_exit(code=0):
+        exit_code["value"] = code
+        raise SystemExit(code)
+
+    with patch("builtins.__import__", side_effect=mock_import), \
+         patch("sys.stdout", captured), \
+         patch("sys.argv", ["fetch_okx_positions.py"]), \
+         patch.object(mod.sys, "exit", side_effect=mock_exit):
+        try:
+            mod.main()
+        except SystemExit:
+            pass
+
+    raw = captured.getvalue().strip()
+    parsed = json.loads(raw) if raw else {}
+    return parsed, exit_code["value"]
+
+
+class TestSuccess:
+    def test_long_position(self):
+        out, code = _run_script([
+            {"symbol": "BTC/USDT:USDT", "contracts": "0.01", "side": "long",
+             "entryPrice": "42000.5"},
+        ])
+        assert code == 0
+        assert len(out["positions"]) == 1
+        p = out["positions"][0]
+        assert p["coin"] == "BTC"
+        assert p["size"] == 0.01
+        assert p["side"] == "long"
+        assert p["entry_price"] == 42000.5
+
+    def test_short_position_size_is_negative(self):
+        """Short positions must be encoded with a negative signed size to
+        mirror HLPosition — the Go-side forceCloseOKXLive treats size==0
+        as already-flat and size!=0 as something to close."""
+        out, code = _run_script([
+            {"symbol": "ETH/USDT:USDT", "contracts": "0.5", "side": "short",
+             "entryPrice": "3000"},
+        ])
+        assert code == 0
+        assert out["positions"][0]["size"] == -0.5
+        assert out["positions"][0]["side"] == "short"
+
+    def test_zero_size_filtered(self):
+        """ccxt sometimes returns stale zero-contract entries. They must
+        be filtered — passing a zero-size position to the Go side would
+        trigger the AlreadyFlat defense-in-depth branch but also pollute
+        the report's coin list."""
+        out, code = _run_script([
+            {"symbol": "BTC/USDT:USDT", "contracts": "0", "side": "long"},
+        ])
+        assert code == 0
+        assert out["positions"] == []
+
+    def test_empty_positions(self):
+        out, code = _run_script([])
+        assert code == 0
+        assert out["positions"] == []
+        assert "error" not in out
+
+
+class TestFailurePaths:
+    def test_non_live_adapter(self):
+        out, code = _run_script([], is_live=False)
+        assert code == 1
+        assert "OKX_API_KEY" in out["error"]
+
+    def test_exchange_raises(self):
+        out, code = _run_script(RuntimeError("OKX 503 Service Unavailable"))
+        assert code == 1
+        assert "OKX 503" in out["error"]
+        assert out["positions"] == []
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/shared_scripts/test_fetch_okx_positions.py
+++ b/shared_scripts/test_fetch_okx_positions.py
@@ -35,13 +35,11 @@ def _run_script(positions_or_exc, is_live=True):
     mock_adapter_cls = MagicMock()
     mock_adapter = MagicMock()
     mock_adapter.is_live = is_live
-    mock_exchange = MagicMock()
-    mock_adapter._exchange = mock_exchange
     mock_adapter_cls.return_value = mock_adapter
     if isinstance(positions_or_exc, Exception):
-        mock_exchange.fetch_positions.side_effect = positions_or_exc
+        mock_adapter.fetch_open_positions.side_effect = positions_or_exc
     else:
-        mock_exchange.fetch_positions.return_value = positions_or_exc
+        mock_adapter.fetch_open_positions.return_value = positions_or_exc
 
     captured = StringIO()
     exit_code = {"value": 0}


### PR DESCRIPTION
Closes #345

Extends the #341 kill-switch latch-until-flat pattern from Hyperliquid to OKX perps. Previously the portfolio kill switch cleared virtual state without sending any close order to OKX, leaving on-chain exposure live until manual intervention.

## Summary
- `shared_scripts/close_okx_position.py` + `fetch_okx_positions.py` mirror the HL Python helpers.
- `scheduler/okx_close.go` adds `OKXPosition`, `OKXLiveCloser`, `OKXLiveCloseReport`, `forceCloseOKXLive`.
- `scheduler/executor.go` adds `OKXCloseResult`/Runners with the same "any ambiguous response is an error" parser contract as the HL side.
- `scheduler/kill_switch_close.go` refactored to take `KillSwitchCloseInputs` struct; either platform failing flips `OnChainConfirmedFlat`.
- Spot is surfaced as a known gap in the Discord message (no reduce-only primitive for OKX spot) but does not block `ConfirmedFlat`.

## Test plan
- [x] `go test ./...` (all green, including 8 new kill-switch tests + 5 parser tests + `okx_close_test.go`)
- [x] `uv run pytest shared_scripts/test_close_okx_position.py shared_scripts/test_fetch_okx_positions.py -v` (14 passed)
- [x] `gofmt -l scheduler/*.go` clean
- [ ] Smoke test `./go-trader --once` on an account with `OKX_API_KEY` configured and a drawdown triggering the kill switch

Generated with [Claude Code](https://claude.ai/code)