### PR TITLE
Robinhood kill-switch close for live crypto positions

### DIFF
--- a/platforms/robinhood/adapter.py
+++ b/platforms/robinhood/adapter.py
@@ -386,27 +386,50 @@ class RobinhoodExchangeAdapter:
         return result or {}
 
     def get_crypto_positions(self) -> list:
-        """Get current crypto positions from Robinhood."""
+        """Get current crypto positions from Robinhood.
+
+        Best-effort variant: swallows exceptions and returns []. Suitable for
+        signal/strategy paths where a transient Robinhood outage shouldn't
+        crash the cycle. **Do not use for kill-switch flat-confirmation** —
+        a silent [] there would clear virtual state while live exposure
+        remained (see get_crypto_positions_strict, #346 review).
+        """
         if not self._logged_in:
             return []
         try:
-            import robin_stocks.robinhood as rh
-            positions = rh.crypto.get_crypto_positions()
-            result = []
-            for pos in positions:
-                qty = float(pos.get("quantity", 0) or 0)
-                if qty <= 0:
-                    continue
-                currency = pos.get("currency", {})
-                symbol = currency.get("code", "")
-                cost_basis = float(pos.get("cost_bases", [{}])[0].get("direct_cost_basis", 0) or 0)
-                avg_price = cost_basis / qty if qty > 0 else 0
-                result.append({
-                    "symbol": symbol,
-                    "quantity": qty,
-                    "avg_price": avg_price,
-                })
-            return result
+            return self.get_crypto_positions_strict()
         except Exception as e:
             print(f"[robinhood] get_crypto_positions error: {e}", file=sys.stderr)
             return []
+
+    def get_crypto_positions_strict(self) -> list:
+        """Strict variant of get_crypto_positions used by the kill-switch
+        position fetcher (#346). Propagates every error rather than masking
+        it as an empty list — the caller (fetch_robinhood_positions.py)
+        relies on exceptions to emit a JSON error envelope so the Go-side
+        kill switch latches instead of clearing virtual state on a silent
+        empty.
+
+        Raises RuntimeError if the adapter never authenticated.
+        """
+        if not self._logged_in:
+            raise RuntimeError(
+                "Robinhood adapter not logged in — cannot fetch crypto positions"
+            )
+        import robin_stocks.robinhood as rh
+        positions = rh.crypto.get_crypto_positions()
+        result = []
+        for pos in positions:
+            qty = float(pos.get("quantity", 0) or 0)
+            if qty <= 0:
+                continue
+            currency = pos.get("currency", {})
+            symbol = currency.get("code", "")
+            cost_basis = float(pos.get("cost_bases", [{}])[0].get("direct_cost_basis", 0) or 0)
+            avg_price = cost_basis / qty if qty > 0 else 0
+            result.append({
+                "symbol": symbol,
+                "quantity": qty,
+                "avg_price": avg_price,
+            })
+        return result

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -700,6 +700,122 @@ func parseOKXPositionsOutput(stdout []byte, stderrStr string, runErr error) (*OK
 	}
 }
 
+// RobinhoodCloseFill is the parsed fill block from close_robinhood_position.py.
+// Mirrors OKXCloseFill. OID is a string (robin_stocks order IDs are opaque
+// UUIDs), fields are optional — empty {} means the adapter found no position
+// to close (already-flat success).
+type RobinhoodCloseFill struct {
+	AvgPx   float64 `json:"avg_px,omitempty"`
+	TotalSz float64 `json:"total_sz,omitempty"`
+	OID     string  `json:"oid,omitempty"`
+}
+
+// RobinhoodClose is the close block from close_robinhood_position.py.
+type RobinhoodClose struct {
+	Symbol string              `json:"symbol"`
+	Fill   *RobinhoodCloseFill `json:"fill,omitempty"`
+}
+
+// RobinhoodCloseResult is the top-level JSON from close_robinhood_position.py.
+// Used by the portfolio kill switch to liquidate live Robinhood crypto
+// exposure (#346).
+type RobinhoodCloseResult struct {
+	Close     *RobinhoodClose `json:"close"`
+	Platform  string          `json:"platform"`
+	Timestamp string          `json:"timestamp"`
+	Error     string          `json:"error,omitempty"`
+}
+
+// RunRobinhoodClose runs close_robinhood_position.py to submit a market close
+// for a single Robinhood crypto coin (#346). Contract mirrors
+// RunHyperliquidClose / RunOKXClose: any failure path returns a non-nil
+// error so the kill switch stays latched on ambiguous responses.
+func RunRobinhoodClose(script, symbol string) (*RobinhoodCloseResult, string, error) {
+	args := []string{
+		fmt.Sprintf("--symbol=%s", symbol),
+		"--mode=live",
+	}
+	stdout, stderr, runErr := RunPythonScript(script, args)
+	return parseRobinhoodCloseOutput(stdout, string(stderr), runErr)
+}
+
+// parseRobinhoodCloseOutput turns raw subprocess output into
+// (*RobinhoodCloseResult, stderr, error) following the RunRobinhoodClose
+// contract. Extracted so decision logic can be tested without spawning
+// .venv/bin/python3 — same pattern as parseHyperliquidCloseOutput /
+// parseOKXCloseOutput (#341/#342/#345).
+func parseRobinhoodCloseOutput(stdout []byte, stderrStr string, runErr error) (*RobinhoodCloseResult, string, error) {
+	var result RobinhoodCloseResult
+	parseErr := json.Unmarshal(stdout, &result)
+
+	switch {
+	case runErr == nil && parseErr == nil && result.Error == "":
+		return &result, stderrStr, nil
+
+	case runErr == nil && parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("close reported error despite exit 0: %s", result.Error)
+
+	case parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("close failed: %s", result.Error)
+
+	case parseErr == nil && runErr != nil:
+		return &result, stderrStr, fmt.Errorf("close subprocess exit %v with no error field (stderr: %s)", runErr, stderrStr)
+
+	default:
+		return nil, stderrStr, fmt.Errorf("parse close output: %v (run err: %v, stdout: %s)", parseErr, runErr, string(stdout))
+	}
+}
+
+// RobinhoodPositionsResult is the JSON output from fetch_robinhood_positions.py.
+// Size is unsigned — Robinhood crypto is spot, no short positions.
+type RobinhoodPositionsResult struct {
+	Positions []RobinhoodPositionJSON `json:"positions"`
+	Platform  string                  `json:"platform"`
+	Timestamp string                  `json:"timestamp"`
+	Error     string                  `json:"error,omitempty"`
+}
+
+// RobinhoodPositionJSON is the per-position payload from
+// fetch_robinhood_positions.py.
+type RobinhoodPositionJSON struct {
+	Coin     string  `json:"coin"`
+	Size     float64 `json:"size"`
+	AvgPrice float64 `json:"avg_price"`
+}
+
+// RunRobinhoodFetchPositions runs fetch_robinhood_positions.py and returns
+// the parsed result (#346). Like RunRobinhoodClose, any failure path
+// returns a non-nil error so the kill switch can latch and retry.
+func RunRobinhoodFetchPositions(script string) (*RobinhoodPositionsResult, string, error) {
+	stdout, stderr, runErr := RunPythonScript(script, nil)
+	return parseRobinhoodPositionsOutput(stdout, string(stderr), runErr)
+}
+
+// parseRobinhoodPositionsOutput is the pure parser, extracted from
+// RunRobinhoodFetchPositions so the decision logic can be tested without
+// spawning Python. Mirrors parseOKXPositionsOutput's 5-case matrix.
+func parseRobinhoodPositionsOutput(stdout []byte, stderrStr string, runErr error) (*RobinhoodPositionsResult, string, error) {
+	var result RobinhoodPositionsResult
+	parseErr := json.Unmarshal(stdout, &result)
+
+	switch {
+	case runErr == nil && parseErr == nil && result.Error == "":
+		return &result, stderrStr, nil
+
+	case runErr == nil && parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("fetch positions reported error despite exit 0: %s", result.Error)
+
+	case parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("fetch positions failed: %s", result.Error)
+
+	case parseErr == nil && runErr != nil:
+		return &result, stderrStr, fmt.Errorf("fetch positions subprocess exit %v with no error field (stderr: %s)", runErr, stderrStr)
+
+	default:
+		return nil, stderrStr, fmt.Errorf("parse positions output: %v (run err: %v, stdout: %s)", parseErr, runErr, string(stdout))
+	}
+}
+
 // FetchPrices runs check_price.py and returns a map of symbol→price.
 func FetchPrices(symbols []string) (map[string]float64, error) {
 	stdout, stderr, err := RunPythonScript("shared_scripts/check_price.py", symbols)

--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -43,6 +43,22 @@ type KillSwitchCloseInputs struct {
 	OKXCloser      OKXLiveCloser
 	OKXFetcher     OKXPositionsFetcher
 
+	// RHLiveCrypto: every live Robinhood crypto (Type=="spot") strategy
+	// configured. Used to decide which coins to close and to detect
+	// "unconfigured" crypto balances. Robinhood has no public unauthenticated
+	// position endpoint — we always call RHFetcher when there's at least
+	// one live Robinhood crypto strategy, rather than trying to reuse a
+	// pre-fetch. (#346)
+	RHLiveCrypto []StrategyConfig
+	// RHLiveOptions: every live Robinhood options strategy configured.
+	// Surfaced in the Discord message as a known gap — stock options close
+	// semantics (sell-to-close vs buy-to-close per leg) require dispatch
+	// that the kill switch doesn't yet handle (#346 follow-up). Does NOT
+	// block OnChainConfirmedFlat; matches the OKXSpotPresent semantic.
+	RHLiveOptions []StrategyConfig
+	RHCloser      RobinhoodLiveCloser
+	RHFetcher     RobinhoodPositionsFetcher
+
 	PortfolioReason string
 	CloseTimeout    time.Duration
 }
@@ -84,6 +100,22 @@ type KillSwitchClosePlan struct {
 	// whether there is actual spot exposure, and blocking would latch
 	// forever).
 	OKXSpotPresent bool
+
+	// RHCloseReport is the Robinhood per-coin outcome. Zero value when no
+	// Robinhood crypto close was attempted.
+	RHCloseReport RobinhoodLiveCloseReport
+
+	// RHUnconfigured lists live Robinhood crypto balances for coins no
+	// configured live Robinhood crypto strategy trades. Same manual-
+	// intervention semantic as HL Unconfigured / OKX Unconfigured.
+	RHUnconfigured []RobinhoodPosition
+
+	// RHOptionsPresent is true when there is at least one live Robinhood
+	// options strategy configured. Signals an unhandled gap — surfaced in
+	// the Discord message but does NOT block OnChainConfirmedFlat
+	// (hard-latch would freeze the scheduler for any Robinhood options
+	// user with no available close path). Mirrors OKXSpotPresent.
+	RHOptionsPresent bool
 
 	// DiscordMessage is the formatted notification string; empty when no
 	// Discord message should be sent. Caller checks notifier.HasBackends()
@@ -233,6 +265,57 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 		}
 	}
 
+	// ── Robinhood ───────────────────────────────────────────────────
+	// Options are surfaced as a known gap (like OKX spot) — stock options
+	// close semantics are complex enough that the kill switch cannot safely
+	// auto-close them. Crypto (spot) is handled below.
+	plan.RHOptionsPresent = len(in.RHLiveOptions) > 0
+	if plan.RHOptionsPresent {
+		plan.LogLines = append(plan.LogLines,
+			fmt.Sprintf("[CRITICAL] rh-close: %d live Robinhood options strategies configured — kill switch cannot auto-close options (sell-to-close vs buy-to-close semantics); operator must verify manually (#346)", len(in.RHLiveOptions)))
+	}
+
+	// Crypto: always attempt fetch when there's a configured crypto strategy
+	// — mirrors the OKX opportunistic-fetch guard. Robinhood has no
+	// pre-fetch to reuse; every cycle requires a subprocess round-trip
+	// (TOTP-authenticated).
+	if len(in.RHLiveCrypto) > 0 && in.RHFetcher != nil {
+		rhPositions, err := in.RHFetcher()
+		if err != nil {
+			plan.LogLines = append(plan.LogLines,
+				fmt.Sprintf("[CRITICAL] rh-close: kill switch unable to fetch Robinhood positions: %v — cannot confirm flat", err))
+			plan.OnChainConfirmedFlat = false
+		} else {
+			ctx, cancel := context.WithTimeout(context.Background(), in.CloseTimeout)
+			plan.RHCloseReport = forceCloseRobinhoodLive(ctx, rhPositions, in.RHLiveCrypto, in.RHCloser)
+			cancel()
+			if !plan.RHCloseReport.ConfirmedFlat() {
+				plan.OnChainConfirmedFlat = false
+			}
+			if len(plan.RHCloseReport.ClosedCoins) > 0 {
+				plan.LogLines = append(plan.LogLines,
+					fmt.Sprintf("[CRITICAL] rh-close: confirmed close for %v", plan.RHCloseReport.ClosedCoins))
+			}
+			if len(plan.RHCloseReport.AlreadyFlat) > 0 {
+				plan.LogLines = append(plan.LogLines,
+					fmt.Sprintf("[INFO] rh-close: already flat: %v", plan.RHCloseReport.AlreadyFlat))
+			}
+			for _, coin := range plan.RHCloseReport.SortedErrorCoins() {
+				plan.LogLines = append(plan.LogLines,
+					fmt.Sprintf("[CRITICAL] rh-close: %s failed: %v (kill switch will retry next cycle)", coin, plan.RHCloseReport.Errors[coin]))
+			}
+
+			plan.RHUnconfigured = plan.RHCloseReport.Unconfigured
+			if len(plan.RHUnconfigured) > 0 {
+				plan.OnChainConfirmedFlat = false
+				for _, p := range plan.RHUnconfigured {
+					plan.LogLines = append(plan.LogLines,
+						fmt.Sprintf("[CRITICAL] rh-close: live balance for unconfigured coin %s (size=%.6f) — manual intervention required, kill switch will retry next cycle", p.Coin, p.Size))
+				}
+			}
+		}
+	}
+
 	plan.DiscordMessage = formatKillSwitchMessage(in.HLAddr, plan, in.PortfolioReason)
 	return plan
 }
@@ -241,9 +324,10 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 // Split out so tests can call it directly and so main.go delivery stays a
 // one-liner. Returns three distinct shapes:
 //   - "PORTFOLIO KILL SWITCH" — confirmed-flat, no spot gap.
-//   - "PORTFOLIO KILL SWITCH (SPOT GAP — VERIFY MANUALLY)" — confirmed-flat
-//     for perps, but OKX spot strategies are configured and the scheduler
-//     has no safe auto-close path (#345). Header is distinct so an
+//   - "PORTFOLIO KILL SWITCH (GAPS — VERIFY MANUALLY)" — confirmed-flat
+//     for closable platforms, but at least one unhandled exposure class
+//     (OKX spot #345, Robinhood options #346) is configured and the
+//     scheduler has no safe auto-close path. Header is distinct so an
 //     operator skimming does not read "Virtual state cleared" as
 //     "everything is closed."
 //   - "PORTFOLIO KILL SWITCH (LATCHED, RETRYING)" — some on-chain
@@ -261,10 +345,20 @@ func formatKillSwitchMessage(hlAddr string, plan KillSwitchClosePlan, portfolioR
 		if len(plan.OKXCloseReport.ClosedCoins) > 0 {
 			parts = append(parts, fmt.Sprintf("OKX closes: %v", plan.OKXCloseReport.ClosedCoins))
 		}
+		if len(plan.RHCloseReport.ClosedCoins) > 0 {
+			parts = append(parts, fmt.Sprintf("Robinhood closes: %v", plan.RHCloseReport.ClosedCoins))
+		}
 		header := "**PORTFOLIO KILL SWITCH**"
+		gapNotes := []string{}
 		if plan.OKXSpotPresent {
-			header = "**PORTFOLIO KILL SWITCH (SPOT GAP — VERIFY MANUALLY)**"
-			parts = append(parts, "OKX spot strategies present — kill switch cannot auto-close spot, verify balances manually")
+			gapNotes = append(gapNotes, "OKX spot strategies present — kill switch cannot auto-close spot, verify balances manually")
+		}
+		if plan.RHOptionsPresent {
+			gapNotes = append(gapNotes, "Robinhood options strategies present — kill switch cannot auto-close options, verify manually")
+		}
+		if len(gapNotes) > 0 {
+			header = "**PORTFOLIO KILL SWITCH (GAPS — VERIFY MANUALLY)**"
+			parts = append(parts, gapNotes...)
 		}
 		summary := strings.Join(parts, "; ")
 		return fmt.Sprintf("%s\n%s\n%s. Virtual state cleared. Manual reset required.", header, portfolioReason, summary)
@@ -302,8 +396,26 @@ func formatKillSwitchMessage(hlAddr string, plan KillSwitchClosePlan, portfolioR
 		sort.Strings(names)
 		segments = append(segments, "On-chain OKX positions for unconfigured coins (manual intervention required) — "+strings.Join(names, "; "))
 	}
+	if len(plan.RHCloseReport.Errors) > 0 {
+		parts := make([]string, 0, len(plan.RHCloseReport.Errors))
+		for _, coin := range plan.RHCloseReport.SortedErrorCoins() {
+			parts = append(parts, fmt.Sprintf("%s: %v", coin, plan.RHCloseReport.Errors[coin]))
+		}
+		segments = append(segments, "Robinhood live close errors — "+strings.Join(parts, "; "))
+	}
+	if len(plan.RHUnconfigured) > 0 {
+		names := make([]string, 0, len(plan.RHUnconfigured))
+		for _, p := range plan.RHUnconfigured {
+			names = append(names, fmt.Sprintf("%s size=%.6f", p.Coin, p.Size))
+		}
+		sort.Strings(names)
+		segments = append(segments, "Live Robinhood balances for unconfigured coins (manual intervention required) — "+strings.Join(names, "; "))
+	}
 	if plan.OKXSpotPresent {
 		segments = append(segments, "OKX spot strategies present — verify manually (kill switch cannot auto-close spot)")
+	}
+	if plan.RHOptionsPresent {
+		segments = append(segments, "Robinhood options strategies present — verify manually (kill switch cannot auto-close options)")
 	}
 	if len(segments) == 0 {
 		// Fallback: HL fetch failure path doesn't populate Errors/Unconfigured.

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -596,6 +596,343 @@ func TestPlanKillSwitchClose_OKXUnconfiguredBlocksReset(t *testing.T) {
 	}
 }
 
+// ── Robinhood tests (#346) ─────────────────────────────────────────────
+
+// stubRHLiveCloser mirrors stubHLLiveCloser / stubOKXLiveCloser for
+// Robinhood. Missing-coin entries yield a synthetic success.
+func stubRHLiveCloser(errs map[string]error) (RobinhoodLiveCloser, *[]string) {
+	var calls []string
+	closer := func(symbol string) (*RobinhoodCloseResult, error) {
+		calls = append(calls, symbol)
+		if err, ok := errs[symbol]; ok && err != nil {
+			return nil, err
+		}
+		return &RobinhoodCloseResult{
+			Close:    &RobinhoodClose{Symbol: symbol, Fill: &RobinhoodCloseFill{TotalSz: 1.0, AvgPx: 100}},
+			Platform: "robinhood",
+		}, nil
+	}
+	return closer, &calls
+}
+
+// stubRHPositionsFetcher returns a RobinhoodPositionsFetcher that replays a
+// fixed response and records invocation count.
+func stubRHPositionsFetcher(positions []RobinhoodPosition, err error) (RobinhoodPositionsFetcher, *int) {
+	var calls int
+	fetcher := func() ([]RobinhoodPosition, error) {
+		calls++
+		if err != nil {
+			return nil, err
+		}
+		return positions, nil
+	}
+	return fetcher, &calls
+}
+
+// Robinhood happy path: one live Robinhood crypto strategy with an open
+// position. Plan reports ConfirmedFlat, closer called once, Discord
+// message mentions Robinhood closes. The #346 analog of HL/OKX happy-path.
+func TestPlanKillSwitchClose_RobinhoodHappyPath(t *testing.T) {
+	rhLive := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []RobinhoodPosition{{Coin: "BTC", Size: 0.01, AvgPrice: 42000}}
+	closer, calls := stubRHLiveCloser(nil)
+	fetcher, fetchCalls := stubRHPositionsFetcher(positions, nil)
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		RHLiveCrypto:    rhLive,
+		RHCloser:        closer,
+		RHFetcher:       fetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if !plan.OnChainConfirmedFlat {
+		t.Fatalf("expected ConfirmedFlat, got plan=%+v", plan)
+	}
+	if *fetchCalls != 1 {
+		t.Errorf("Robinhood fetcher should be called exactly once, got %d", *fetchCalls)
+	}
+	if len(*calls) != 1 || (*calls)[0] != "BTC" {
+		t.Errorf("closer calls = %v, want [BTC]", *calls)
+	}
+	if !strings.Contains(plan.DiscordMessage, "Robinhood closes: [BTC]") {
+		t.Errorf("expected Robinhood closes in message, got: %s", plan.DiscordMessage)
+	}
+}
+
+// Robinhood close failure: closer errors, plan must latch. Mirrors the
+// HL/OKX close-error tests — this is the load-bearing #346 correctness
+// case. Without it, a silent Robinhood close failure would clear virtual
+// state while on-account exposure remained.
+func TestPlanKillSwitchClose_RobinhoodCloseError(t *testing.T) {
+	rhLive := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []RobinhoodPosition{{Coin: "BTC", Size: 0.01}}
+	closer, _ := stubRHLiveCloser(map[string]error{"BTC": fmt.Errorf("rh rate limited")})
+	fetcher, _ := stubRHPositionsFetcher(positions, nil)
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		RHLiveCrypto:    rhLive,
+		RHCloser:        closer,
+		RHFetcher:       fetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("expected NOT ConfirmedFlat on Robinhood close error — would clear virtual state while live is still active")
+	}
+	if got, ok := plan.RHCloseReport.Errors["BTC"]; !ok || got == nil {
+		t.Errorf("expected BTC error in Robinhood report, got %v", plan.RHCloseReport.Errors)
+	}
+	if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
+		t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
+	}
+	if !strings.Contains(plan.DiscordMessage, "rh rate limited") {
+		t.Errorf("expected Robinhood error detail in message, got: %s", plan.DiscordMessage)
+	}
+}
+
+// Robinhood fetch failure: fetcher errors → kill switch must latch,
+// closer must NOT be invoked (we don't know which coins to close). Same
+// guard semantic as HL/OKX fetch failure.
+func TestPlanKillSwitchClose_RobinhoodFetchFailure(t *testing.T) {
+	rhLive := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	closer, calls := stubRHLiveCloser(nil)
+	fetcher, _ := stubRHPositionsFetcher(nil, fmt.Errorf("rh auth failed"))
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		RHLiveCrypto:    rhLive,
+		RHCloser:        closer,
+		RHFetcher:       fetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("expected NOT ConfirmedFlat on Robinhood fetch failure")
+	}
+	if len(*calls) != 0 {
+		t.Errorf("closer must not be invoked when fetch failed, got %v", *calls)
+	}
+	if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
+		t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
+	}
+}
+
+// Robinhood options strategy present: surface as unhandled gap. Does NOT
+// block ConfirmedFlat (hard-latch would freeze the scheduler forever for
+// any Robinhood options user). Mirrors OKX spot semantic.
+func TestPlanKillSwitchClose_RobinhoodOptionsSurfacesGap(t *testing.T) {
+	rhOptions := []StrategyConfig{
+		{ID: "rh-ccall-spy", Platform: "robinhood", Type: "options",
+			Args: []string{"covered_call", "SPY", "1d", "--mode=live"}},
+	}
+	closer, _ := stubRHLiveCloser(nil)
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		RHLiveOptions:   rhOptions,
+		RHCloser:        closer,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if !plan.OnChainConfirmedFlat {
+		t.Errorf("options-only presence must not block ConfirmedFlat, got plan=%+v", plan)
+	}
+	if !plan.RHOptionsPresent {
+		t.Error("expected RHOptionsPresent=true")
+	}
+	if !strings.Contains(plan.DiscordMessage, "Robinhood options") {
+		t.Errorf("expected options gap note in message, got: %s", plan.DiscordMessage)
+	}
+}
+
+// Robinhood unconfigured: fetcher reports a balance for a coin no live
+// crypto strategy trades. Kill switch refuses to liquidate and latches.
+func TestPlanKillSwitchClose_RobinhoodUnconfiguredBlocksReset(t *testing.T) {
+	rhLive := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []RobinhoodPosition{
+		{Coin: "BTC", Size: 0.01},
+		{Coin: "DOGE", Size: 100}, // unconfigured
+	}
+	closer, calls := stubRHLiveCloser(nil)
+	fetcher, _ := stubRHPositionsFetcher(positions, nil)
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		RHLiveCrypto:    rhLive,
+		RHCloser:        closer,
+		RHFetcher:       fetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("expected NOT ConfirmedFlat — unconfigured DOGE balance is still live")
+	}
+	if len(plan.RHUnconfigured) != 1 || plan.RHUnconfigured[0].Coin != "DOGE" {
+		t.Errorf("expected RHUnconfigured=[DOGE], got %v", plan.RHUnconfigured)
+	}
+	// BTC should still be closed (it's configured).
+	if len(*calls) != 1 || (*calls)[0] != "BTC" {
+		t.Errorf("closer calls = %v, want [BTC]", *calls)
+	}
+	if !strings.Contains(plan.DiscordMessage, "manual intervention required") {
+		t.Errorf("expected manual intervention note, got: %s", plan.DiscordMessage)
+	}
+}
+
+// Combined: HL + OKX + Robinhood all succeeding. Plan ConfirmedFlat,
+// message lists all three.
+func TestPlanKillSwitchClose_HLAndOKXAndRobinhoodHappyPath(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	okxLive := []StrategyConfig{
+		{ID: "okx-btc", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	rhLive := []StrategyConfig{
+		{ID: "rh-sma-sol", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "SOL", "1h", "--mode=live"}},
+	}
+	hlPos := []HLPosition{{Coin: "ETH", Size: 0.5}}
+	okxPos := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
+	rhPos := []RobinhoodPosition{{Coin: "SOL", Size: 2.5}}
+
+	hlCloser, _ := stubHLLiveCloser(nil)
+	hlFetcher, _ := stubHLStateFetcher(nil, nil)
+	okxCloser, _ := stubOKXLiveCloser(nil)
+	okxFetcher, _ := stubOKXPositionsFetcher(okxPos, nil)
+	rhCloser, rhCalls := stubRHLiveCloser(nil)
+	rhFetcher, _ := stubRHPositionsFetcher(rhPos, nil)
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		HLAddr:          "0xaddr",
+		HLStateFetched:  true,
+		HLPositions:     hlPos,
+		HLLiveAll:       hlLive,
+		HLCloser:        hlCloser,
+		HLFetcher:       hlFetcher,
+		OKXLiveAllPerps: okxLive,
+		OKXCloser:       okxCloser,
+		OKXFetcher:      okxFetcher,
+		RHLiveCrypto:    rhLive,
+		RHCloser:        rhCloser,
+		RHFetcher:       rhFetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if !plan.OnChainConfirmedFlat {
+		t.Fatalf("expected ConfirmedFlat, got plan=%+v", plan)
+	}
+	if len(*rhCalls) != 1 || (*rhCalls)[0] != "SOL" {
+		t.Errorf("Robinhood closer calls = %v, want [SOL]", *rhCalls)
+	}
+	if !strings.Contains(plan.DiscordMessage, "HL closes: [ETH]") {
+		t.Errorf("expected HL closes in message, got: %s", plan.DiscordMessage)
+	}
+	if !strings.Contains(plan.DiscordMessage, "OKX closes: [BTC]") {
+		t.Errorf("expected OKX closes in message, got: %s", plan.DiscordMessage)
+	}
+	if !strings.Contains(plan.DiscordMessage, "Robinhood closes: [SOL]") {
+		t.Errorf("expected Robinhood closes in message, got: %s", plan.DiscordMessage)
+	}
+}
+
+// Any platform failing latches the switch: HL + OKX succeed, Robinhood
+// fails. Without this test a silent Robinhood failure could be hidden
+// behind the other platforms' successes (the #346 bug class).
+func TestPlanKillSwitchClose_RobinhoodFailureStillLatchesAcrossPlatforms(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	rhLive := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	hlPos := []HLPosition{{Coin: "ETH", Size: 0.5}}
+	rhPos := []RobinhoodPosition{{Coin: "BTC", Size: 0.01}}
+
+	hlCloser, _ := stubHLLiveCloser(nil)
+	hlFetcher, _ := stubHLStateFetcher(nil, nil)
+	rhCloser, _ := stubRHLiveCloser(map[string]error{"BTC": fmt.Errorf("rh err")})
+	rhFetcher, _ := stubRHPositionsFetcher(rhPos, nil)
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		HLAddr:          "0xaddr",
+		HLStateFetched:  true,
+		HLPositions:     hlPos,
+		HLLiveAll:       hlLive,
+		HLCloser:        hlCloser,
+		HLFetcher:       hlFetcher,
+		RHLiveCrypto:    rhLive,
+		RHCloser:        rhCloser,
+		RHFetcher:       rhFetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("Robinhood failure must latch the switch even when HL succeeded")
+	}
+	if !strings.Contains(plan.DiscordMessage, "rh err") {
+		t.Errorf("Robinhood error missing from message, got: %s", plan.DiscordMessage)
+	}
+}
+
+// Robinhood deterministic error ordering: multiple failing coins produce
+// a stable message. Mirrors HL/OKX determinism tests.
+func TestPlanKillSwitchClose_RobinhoodDeterministicErrorOrder(t *testing.T) {
+	rhLive := []StrategyConfig{
+		{ID: "rh-btc", Platform: "robinhood", Type: "spot", Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+		{ID: "rh-eth", Platform: "robinhood", Type: "spot", Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "rh-doge", Platform: "robinhood", Type: "spot", Args: []string{"sma", "DOGE", "1h", "--mode=live"}},
+	}
+	positions := []RobinhoodPosition{
+		{Coin: "BTC", Size: 0.01}, {Coin: "ETH", Size: 0.1}, {Coin: "DOGE", Size: 100},
+	}
+	errs := map[string]error{
+		"BTC": fmt.Errorf("err"), "ETH": fmt.Errorf("err"), "DOGE": fmt.Errorf("err"),
+	}
+	var prev string
+	for i := 0; i < 10; i++ {
+		closer, _ := stubRHLiveCloser(errs)
+		fetcher, _ := stubRHPositionsFetcher(positions, nil)
+		plan := planKillSwitchClose(KillSwitchCloseInputs{
+			RHLiveCrypto:    rhLive,
+			RHCloser:        closer,
+			RHFetcher:       fetcher,
+			PortfolioReason: "reason",
+			CloseTimeout:    time.Second,
+		})
+		if prev != "" && plan.DiscordMessage != prev {
+			t.Fatalf("message should be deterministic, iter %d:\n%s\nprev:\n%s", i, plan.DiscordMessage, prev)
+		}
+		prev = plan.DiscordMessage
+	}
+	btcPos := strings.Index(prev, "BTC:")
+	dogePos := strings.Index(prev, "DOGE:")
+	ethPos := strings.Index(prev, "ETH:")
+	if !(btcPos < dogePos && dogePos < ethPos) {
+		t.Errorf("expected alphabetical BTC < DOGE < ETH in: %s", prev)
+	}
+}
+
 // OKX deterministic error ordering: multiple failing coins produce a stable
 // message. Mirrors TestPlanKillSwitchClose_DeterministicErrorOrder for the
 // OKX path — Go map iteration randomization would otherwise produce

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -520,6 +520,23 @@ func main() {
 				}
 			}
 
+			// #346: Partition live Robinhood strategies for the kill-switch
+			// close path. Crypto (Type=="spot") is closable via market_sell;
+			// options is surfaced as a manual-intervention gap (sell-to-
+			// close vs buy-to-close semantics not yet handled).
+			var rhLiveCrypto []StrategyConfig
+			var rhLiveOptions []StrategyConfig
+			for _, sc := range cfg.Strategies {
+				if sc.Platform != "robinhood" || !robinhoodIsLive(sc.Args) {
+					continue
+				}
+				if sc.Type == "spot" {
+					rhLiveCrypto = append(rhLiveCrypto, sc)
+				} else if sc.Type == "options" {
+					rhLiveOptions = append(rhLiveOptions, sc)
+				}
+			}
+
 			sharedWallets := detectSharedWallets(cfg.Strategies)
 			hlAddr := os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS")
 			hlKey := SharedWalletKey{Platform: "hyperliquid", Account: hlAddr}
@@ -581,14 +598,14 @@ func main() {
 			}
 			mu.Unlock()
 
-			// #341 / #345: Submit reduce-only market closes to Hyperliquid
-			// AND OKX for every non-zero on-chain position belonging to a
-			// configured live perps strategy. The planning step
+			// #341 / #345 / #346: Submit market closes to Hyperliquid,
+			// OKX, AND Robinhood for every non-zero on-chain position
+			// belonging to a configured live strategy. The planning step
 			// (planKillSwitchClose) runs OUTSIDE the lock — the close
-			// scripts are subprocesses that can take seconds. OKX spot is
-			// surfaced as a known gap (no reduce-only equivalent for spot).
-			// Robinhood/TopStep have the same underlying bug but are
-			// tracked separately.
+			// scripts are subprocesses that can take seconds. OKX spot
+			// and Robinhood options are surfaced as known gaps (no
+			// unified close primitive). TopStep has the same underlying
+			// bug but is tracked separately.
 			//
 			// Latch semantics: virtual state is mutated only when
 			// plan.OnChainConfirmedFlat is true (either platform failing
@@ -608,6 +625,10 @@ func main() {
 					OKXLiveAllSpot:  okxLiveSpot,
 					OKXCloser:       defaultOKXLiveCloser,
 					OKXFetcher:      defaultOKXPositionsFetcher,
+					RHLiveCrypto:    rhLiveCrypto,
+					RHLiveOptions:   rhLiveOptions,
+					RHCloser:        defaultRobinhoodLiveCloser,
+					RHFetcher:       defaultRobinhoodPositionsFetcher,
 					PortfolioReason: portfolioReason,
 					CloseTimeout:    90 * time.Second,
 				}

--- a/scheduler/robinhood_close.go
+++ b/scheduler/robinhood_close.go
@@ -148,13 +148,16 @@ func forceCloseRobinhoodLive(ctx context.Context, positions []RobinhoodPosition,
 			// Unowned position — kill switch only acts on coins this
 			// scheduler is configured to trade. Non-zero sizes are surfaced
 			// to the caller via Unconfigured so the plan can latch the
-			// switch and prompt manual intervention.
-			if p.Size != 0 {
+			// switch and prompt manual intervention. Robinhood crypto is
+			// spot-only so Size should never be < 0; guard with > 0 so a
+			// future change that mistakenly populates a negative balance
+			// (e.g. lent / staked) doesn't trigger a market sell for |size|.
+			if p.Size > 0 {
 				report.Unconfigured = append(report.Unconfigured, p)
 			}
 			continue
 		}
-		if p.Size == 0 {
+		if p.Size <= 0 {
 			report.AlreadyFlat = append(report.AlreadyFlat, p.Coin)
 			continue
 		}

--- a/scheduler/robinhood_close.go
+++ b/scheduler/robinhood_close.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+)
+
+// RobinhoodPosition represents a live Robinhood crypto position. Size is
+// unsigned — Robinhood crypto is spot, so no short exposure exists.
+// Mirrors HLPosition / OKXPosition so the kill-switch plan builder can
+// treat all platforms symmetrically.
+type RobinhoodPosition struct {
+	Coin     string
+	Size     float64
+	AvgPrice float64
+}
+
+// robinhoodLiveCloseScript is the path to the Python close helper. Exposed as
+// a var so tests can substitute — same pattern as hyperliquidLiveCloseScript /
+// okxLiveCloseScript.
+var robinhoodLiveCloseScript = "shared_scripts/close_robinhood_position.py"
+
+// robinhoodFetchPositionsScript is the path to the Python position fetcher.
+var robinhoodFetchPositionsScript = "shared_scripts/fetch_robinhood_positions.py"
+
+// RobinhoodLiveCloser submits a market sell for the full on-account quantity
+// of a single Robinhood crypto coin and returns the parsed result. Exposed
+// as a function variable so tests can inject a fake without spawning Python.
+// Production implementation is defaultRobinhoodLiveCloser, which shells out
+// to close_robinhood_position.py via RunRobinhoodClose.
+type RobinhoodLiveCloser func(symbol string) (*RobinhoodCloseResult, error)
+
+// defaultRobinhoodLiveCloser is the production close implementation. Matches
+// the HL/OKX shape: stderr goes to os.Stderr (kill switch is a system-level
+// event, not strategy-scoped) and any non-nil err means the close was NOT
+// confirmed by the adapter so the kill switch must stay latched.
+func defaultRobinhoodLiveCloser(symbol string) (*RobinhoodCloseResult, error) {
+	result, stderr, err := RunRobinhoodClose(robinhoodLiveCloseScript, symbol)
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, "[rh-close] %s stderr: %s\n", symbol, stderr)
+	}
+	return result, err
+}
+
+// RobinhoodPositionsFetcher fetches every open Robinhood crypto position on
+// the account. Exposed as a function type so tests can stub — mirrors
+// HLStateFetcher / OKXPositionsFetcher.
+type RobinhoodPositionsFetcher func() ([]RobinhoodPosition, error)
+
+// defaultRobinhoodPositionsFetcher wraps fetch_robinhood_positions.py for
+// production use. Python-side filters stale zero-size entries; forceCloseRobinhoodLive
+// also has a size==0 defense-in-depth layer.
+func defaultRobinhoodPositionsFetcher() ([]RobinhoodPosition, error) {
+	result, stderr, err := RunRobinhoodFetchPositions(robinhoodFetchPositionsScript)
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, "[rh-close] fetch_positions stderr: %s\n", stderr)
+	}
+	if err != nil {
+		return nil, err
+	}
+	positions := make([]RobinhoodPosition, 0, len(result.Positions))
+	for _, p := range result.Positions {
+		positions = append(positions, RobinhoodPosition{
+			Coin:     p.Coin,
+			Size:     p.Size,
+			AvgPrice: p.AvgPrice,
+		})
+	}
+	return positions, nil
+}
+
+// RobinhoodLiveCloseReport summarizes a forceCloseRobinhoodLive run. Mirrors
+// HyperliquidLiveCloseReport / OKXLiveCloseReport so the kill-switch plan
+// can treat all platforms symmetrically. Errors is the load-bearing
+// correctness signal — ConfirmedFlat() returns true only when it's empty.
+//
+// Unconfigured lists on-chain positions for coins no configured live
+// Robinhood crypto strategy trades. Computed here (rather than in the plan
+// builder) so the "which coins is this scheduler authorized to touch"
+// partition has a single source of truth. The plan builder consumes
+// Unconfigured separately from ConfirmedFlat to decide whether to latch
+// the kill switch for manual intervention.
+type RobinhoodLiveCloseReport struct {
+	ClosedCoins  []string
+	AlreadyFlat  []string
+	Unconfigured []RobinhoodPosition
+	Errors       map[string]error
+}
+
+// ConfirmedFlat reports whether every configured live Robinhood crypto coin
+// reached a terminal closed/flat state without errors. Mirrors HL/OKX shape.
+func (r RobinhoodLiveCloseReport) ConfirmedFlat() bool {
+	return len(r.Errors) == 0
+}
+
+// SortedErrorCoins returns Errors keys in deterministic order for stable
+// log/Discord output. Go map iteration is randomized, so identical
+// kill-switch fires would otherwise produce different messages (caught in
+// #342 review for the HL report).
+func (r RobinhoodLiveCloseReport) SortedErrorCoins() []string {
+	coins := make([]string, 0, len(r.Errors))
+	for c := range r.Errors {
+		coins = append(coins, c)
+	}
+	sort.Strings(coins)
+	return coins
+}
+
+// forceCloseRobinhoodLive submits market closes for every non-zero live
+// Robinhood crypto position belonging to a coin a configured live Robinhood
+// crypto strategy trades on this account. Mirrors forceCloseHyperliquidLive /
+// forceCloseOKXLive. Robinhood crypto is spot with no reduce-only primitive,
+// so this sells the full on-account balance for each configured coin —
+// acceptable because kill switch only acts on coins the scheduler is
+// authorized to trade (the operator's configuration opts in).
+//
+// Pure / no state mutation. Caller mutates virtual state only when
+// report.ConfirmedFlat() is true.
+//
+// The ctx argument bounds the OVERALL close loop. Each individual closer
+// call has its own subprocess timeout (see RunPythonScript). Once ctx
+// expires, remaining unprocessed coins are added to Errors so the kill
+// switch stays latched and retries next cycle.
+//
+// Only crypto (Type == "spot") strategies are considered. Robinhood stock
+// options (Type == "options") are NOT closed here — their close semantics
+// (sell-to-close vs buy-to-close per leg) and multi-leg instrument IDs
+// require separate handling. The plan surfaces options strategies as a
+// known gap in the Discord message (#346 follow-up).
+func forceCloseRobinhoodLive(ctx context.Context, positions []RobinhoodPosition, rhLiveCrypto []StrategyConfig, closer RobinhoodLiveCloser) RobinhoodLiveCloseReport {
+	report := RobinhoodLiveCloseReport{Errors: make(map[string]error)}
+
+	tradedCoins := make(map[string]bool)
+	for _, sc := range rhLiveCrypto {
+		if sc.Type != "spot" {
+			continue
+		}
+		sym := robinhoodSymbol(sc.Args)
+		if sym != "" {
+			tradedCoins[sym] = true
+		}
+	}
+
+	for _, p := range positions {
+		if !tradedCoins[p.Coin] {
+			// Unowned position — kill switch only acts on coins this
+			// scheduler is configured to trade. Non-zero sizes are surfaced
+			// to the caller via Unconfigured so the plan can latch the
+			// switch and prompt manual intervention.
+			if p.Size != 0 {
+				report.Unconfigured = append(report.Unconfigured, p)
+			}
+			continue
+		}
+		if p.Size == 0 {
+			report.AlreadyFlat = append(report.AlreadyFlat, p.Coin)
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			report.Errors[p.Coin] = fmt.Errorf("close budget exhausted before submit: %w", err)
+			continue
+		}
+		if _, err := closer(p.Coin); err != nil {
+			report.Errors[p.Coin] = err
+			continue
+		}
+		report.ClosedCoins = append(report.ClosedCoins, p.Coin)
+	}
+
+	return report
+}

--- a/scheduler/robinhood_close_test.go
+++ b/scheduler/robinhood_close_test.go
@@ -111,6 +111,42 @@ func TestForceCloseRobinhoodLive_CtxExpiredBeforeSubmit(t *testing.T) {
 	}
 }
 
+func TestForceCloseRobinhoodLive_NegativeSizeNotTraded(t *testing.T) {
+	// Robinhood crypto is spot-only — negative sizes shouldn't appear in
+	// practice. If a future change ever populates a negative balance (e.g.
+	// lent / staked), the close gate must NOT fire a market sell for |size|.
+	// Forward-compat guard against the Size > 0 vs Size != 0 ambiguity
+	// flagged in the #346 review.
+	rhLive := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []RobinhoodPosition{
+		{Coin: "BTC", Size: -0.01},  // owned coin, hypothetical negative
+		{Coin: "DOGE", Size: -100},  // unowned coin, hypothetical negative
+	}
+	var calls []string
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		calls = append(calls, sym)
+		return &RobinhoodCloseResult{}, nil
+	}
+
+	report := forceCloseRobinhoodLive(context.Background(), positions, rhLive, closer)
+
+	if len(calls) != 0 {
+		t.Errorf("negative-size position must NOT trigger close, got calls=%v", calls)
+	}
+	if len(report.Unconfigured) != 0 {
+		t.Errorf("negative-size unowned position must NOT be Unconfigured, got %+v", report.Unconfigured)
+	}
+	if len(report.AlreadyFlat) != 1 || report.AlreadyFlat[0] != "BTC" {
+		t.Errorf("negative-size owned position should be treated as already-flat, got %v", report.AlreadyFlat)
+	}
+	if !report.ConfirmedFlat() {
+		t.Errorf("negative-size positions must not block ConfirmedFlat, got errors=%v", report.Errors)
+	}
+}
+
 func TestForceCloseRobinhoodLive_OptionsStrategiesIgnored(t *testing.T) {
 	// Options strategies live in RHLiveOptions and must NOT appear in the
 	// crypto close loop — forceCloseRobinhoodLive should not attempt to

--- a/scheduler/robinhood_close_test.go
+++ b/scheduler/robinhood_close_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// forceCloseRobinhoodLive unit tests — mirror the OKX tests in
+// okx_close_test.go. Each test asserts a single branch of the decision
+// logic so a regression produces a targeted failure rather than a
+// conflated ambiguous signal (#346).
+
+func TestForceCloseRobinhoodLive_ClosesOwnedCoinsOnly(t *testing.T) {
+	rhLive := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []RobinhoodPosition{
+		{Coin: "BTC", Size: 0.01, AvgPrice: 42000},
+		{Coin: "DOGE", Size: 100, AvgPrice: 0.08}, // unowned
+	}
+	var calls []string
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		calls = append(calls, sym)
+		return &RobinhoodCloseResult{Close: &RobinhoodClose{Symbol: sym}}, nil
+	}
+
+	report := forceCloseRobinhoodLive(context.Background(), positions, rhLive, closer)
+
+	if !report.ConfirmedFlat() {
+		t.Errorf("expected ConfirmedFlat, got errors=%v", report.Errors)
+	}
+	if len(calls) != 1 || calls[0] != "BTC" {
+		t.Errorf("expected closer to be called only for owned coin BTC, got %v", calls)
+	}
+	if len(report.ClosedCoins) != 1 || report.ClosedCoins[0] != "BTC" {
+		t.Errorf("ClosedCoins = %v, want [BTC]", report.ClosedCoins)
+	}
+	if len(report.Unconfigured) != 1 || report.Unconfigured[0].Coin != "DOGE" {
+		t.Errorf("Unconfigured = %v, want [DOGE]", report.Unconfigured)
+	}
+}
+
+func TestForceCloseRobinhoodLive_CloseErrorLatches(t *testing.T) {
+	rhLive := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []RobinhoodPosition{{Coin: "BTC", Size: 0.01}}
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		return nil, fmt.Errorf("robin_stocks 503")
+	}
+
+	report := forceCloseRobinhoodLive(context.Background(), positions, rhLive, closer)
+
+	if report.ConfirmedFlat() {
+		t.Fatal("expected NOT ConfirmedFlat on close error")
+	}
+	if _, ok := report.Errors["BTC"]; !ok {
+		t.Errorf("expected BTC in errors, got %v", report.Errors)
+	}
+}
+
+func TestForceCloseRobinhoodLive_ZeroSizeMarkedAlreadyFlat(t *testing.T) {
+	rhLive := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []RobinhoodPosition{{Coin: "BTC", Size: 0}}
+	var calls []string
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		calls = append(calls, sym)
+		return &RobinhoodCloseResult{}, nil
+	}
+
+	report := forceCloseRobinhoodLive(context.Background(), positions, rhLive, closer)
+
+	if len(calls) != 0 {
+		t.Errorf("zero-size position must short-circuit before closer, got calls=%v", calls)
+	}
+	if len(report.AlreadyFlat) != 1 || report.AlreadyFlat[0] != "BTC" {
+		t.Errorf("AlreadyFlat = %v, want [BTC]", report.AlreadyFlat)
+	}
+	if !report.ConfirmedFlat() {
+		t.Errorf("zero-size short-circuit must be ConfirmedFlat, got errors=%v", report.Errors)
+	}
+}
+
+func TestForceCloseRobinhoodLive_CtxExpiredBeforeSubmit(t *testing.T) {
+	rhLive := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []RobinhoodPosition{{Coin: "BTC", Size: 0.01}}
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	cancel()
+	var calls []string
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		calls = append(calls, sym)
+		return &RobinhoodCloseResult{}, nil
+	}
+
+	report := forceCloseRobinhoodLive(ctx, positions, rhLive, closer)
+
+	if len(calls) != 0 {
+		t.Errorf("closer must not be called after ctx expires, got %v", calls)
+	}
+	if _, ok := report.Errors["BTC"]; !ok {
+		t.Errorf("expected BTC to be marked as error on ctx expiry, got %v", report.Errors)
+	}
+}
+
+func TestForceCloseRobinhoodLive_OptionsStrategiesIgnored(t *testing.T) {
+	// Options strategies live in RHLiveOptions and must NOT appear in the
+	// crypto close loop — forceCloseRobinhoodLive should not attempt to
+	// "close" options as crypto. Guards against a future refactor that
+	// flattens the crypto/options partition.
+	mixed := []StrategyConfig{
+		{ID: "rh-ccall-spy", Platform: "robinhood", Type: "options",
+			Args: []string{"covered_call", "SPY", "1d", "--mode=live"}},
+	}
+	positions := []RobinhoodPosition{{Coin: "BTC", Size: 0.01}}
+	var calls []string
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		calls = append(calls, sym)
+		return &RobinhoodCloseResult{}, nil
+	}
+
+	report := forceCloseRobinhoodLive(context.Background(), positions, mixed, closer)
+
+	if len(calls) != 0 {
+		t.Errorf("options strategy must not drive crypto close, got calls=%v", calls)
+	}
+	if !report.ConfirmedFlat() {
+		t.Errorf("options-only config with non-traded crypto is ConfirmedFlat for the crypto branch, got errors=%v", report.Errors)
+	}
+}
+
+// SortedErrorCoins determinism — same rationale as HL / OKX: Go map
+// iteration is randomized and Discord output must be byte-stable across
+// calls for operator triage.
+func TestRobinhoodLiveCloseReport_SortedErrorCoins(t *testing.T) {
+	r := RobinhoodLiveCloseReport{Errors: map[string]error{
+		"SOL": fmt.Errorf("e"), "BTC": fmt.Errorf("e"), "ETH": fmt.Errorf("e"),
+	}}
+	coins := r.SortedErrorCoins()
+	want := []string{"BTC", "ETH", "SOL"}
+	if len(coins) != len(want) {
+		t.Fatalf("len = %d, want %d", len(coins), len(want))
+	}
+	for i, c := range coins {
+		if c != want[i] {
+			t.Errorf("coins[%d] = %q, want %q", i, c, want[i])
+		}
+	}
+}
+
+// parseRobinhoodCloseOutput tests — mirror the 5-case matrix established
+// by parseHyperliquidCloseOutput / parseOKXCloseOutput. These test the
+// load-bearing kill-switch contract that any ambiguous subprocess
+// response must surface as a non-nil error so the switch stays latched.
+
+func TestParseRobinhoodCloseOutput_CleanSuccess(t *testing.T) {
+	stdout := []byte(`{"close":{"symbol":"BTC","fill":{"avg_px":42000,"total_sz":0.01,"oid":"abc-123"}},"platform":"robinhood","timestamp":"2026-04-19T10:00:00Z"}`)
+	result, _, err := parseRobinhoodCloseOutput(stdout, "", nil)
+	if err != nil {
+		t.Fatalf("expected nil err on clean success, got %v", err)
+	}
+	if result == nil || result.Close == nil || result.Close.Symbol != "BTC" {
+		t.Errorf("unexpected result: %+v", result)
+	}
+}
+
+func TestParseRobinhoodCloseOutput_Exit0WithErrorField(t *testing.T) {
+	// Contract drift guard: Python shouldn't exit 0 with error populated,
+	// but if it happens the envelope is authoritative.
+	stdout := []byte(`{"close":{"symbol":"BTC","fill":{}},"platform":"robinhood","timestamp":"x","error":"bad thing"}`)
+	_, _, err := parseRobinhoodCloseOutput(stdout, "", nil)
+	if err == nil {
+		t.Fatal("expected non-nil err when error field populated, even on exit 0")
+	}
+}
+
+func TestParseRobinhoodCloseOutput_ExitNonZeroWithErrorEnvelope(t *testing.T) {
+	stdout := []byte(`{"close":{"symbol":"BTC","fill":{}},"platform":"robinhood","timestamp":"x","error":"auth failed"}`)
+	_, _, err := parseRobinhoodCloseOutput(stdout, "", fmt.Errorf("exit 1"))
+	if err == nil {
+		t.Fatal("expected non-nil err on error envelope")
+	}
+}
+
+func TestParseRobinhoodCloseOutput_ExitNonZeroNoErrorField(t *testing.T) {
+	// Unexpected: must surface as failure so kill switch latches rather than
+	// silently report success on non-zero exit.
+	stdout := []byte(`{"close":{"symbol":"BTC","fill":{}},"platform":"robinhood","timestamp":"x"}`)
+	_, _, err := parseRobinhoodCloseOutput(stdout, "stderr msg", fmt.Errorf("exit 2"))
+	if err == nil {
+		t.Fatal("expected non-nil err on non-zero exit with no error field")
+	}
+}
+
+func TestParseRobinhoodCloseOutput_MalformedJSON(t *testing.T) {
+	stdout := []byte(`not json`)
+	result, _, err := parseRobinhoodCloseOutput(stdout, "", nil)
+	if err == nil {
+		t.Fatal("expected non-nil err on malformed JSON")
+	}
+	if result != nil {
+		t.Errorf("expected nil result on parse failure, got %+v", result)
+	}
+}
+
+// parseRobinhoodPositionsOutput tests — mirror parseOKXPositionsOutput.
+
+func TestParseRobinhoodPositionsOutput_CleanSuccess(t *testing.T) {
+	stdout := []byte(`{"positions":[{"coin":"BTC","size":0.01,"avg_price":42000}],"platform":"robinhood","timestamp":"x"}`)
+	result, _, err := parseRobinhoodPositionsOutput(stdout, "", nil)
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if len(result.Positions) != 1 || result.Positions[0].Coin != "BTC" {
+		t.Errorf("unexpected positions: %+v", result.Positions)
+	}
+}
+
+func TestParseRobinhoodPositionsOutput_ErrorEnvelope(t *testing.T) {
+	stdout := []byte(`{"positions":[],"platform":"robinhood","timestamp":"x","error":"not live"}`)
+	_, _, err := parseRobinhoodPositionsOutput(stdout, "", fmt.Errorf("exit 1"))
+	if err == nil {
+		t.Fatal("expected non-nil err when error envelope populated — silent parse would make kill switch misread as 'no positions' and clear virtual state while on-chain remained live (#346/#345 bug class)")
+	}
+}
+
+func TestParseRobinhoodPositionsOutput_MalformedJSON(t *testing.T) {
+	_, _, err := parseRobinhoodPositionsOutput([]byte(`garbage`), "", nil)
+	if err == nil {
+		t.Fatal("expected non-nil err on malformed JSON")
+	}
+}

--- a/shared_scripts/close_robinhood_position.py
+++ b/shared_scripts/close_robinhood_position.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Robinhood emergency position close script (issue #346).
+
+Submits a market sell for the full on-account quantity of a single crypto
+coin via the Robinhood adapter's ``market_sell``. Used by the portfolio
+kill switch in the Go scheduler to liquidate live exposure regardless of
+which strategy "owns" the position. Mirrors ``close_hyperliquid_position.py``
+and ``close_okx_position.py`` so the Go caller's parser contract is
+symmetric across platforms.
+
+Scope: crypto only. Robinhood stock options positions have different close
+semantics (sell-to-close vs buy-to-close per leg) and no unified adapter
+method — they are surfaced as a known gap by the Go kill-switch plan
+rather than auto-closed here (see #346 follow-up).
+
+Usage:
+    close_robinhood_position.py --symbol=BTC --mode=live
+
+Live mode is required (kill switch is meaningful only against real
+positions). Stdout is always a single JSON envelope matching the shape of
+``close_hyperliquid_position.py``:
+``{"close": {"symbol": ..., "fill": {...}}, "platform": "robinhood",
+  "timestamp": ..., "error": "..."}``
+
+The kill switch must NEVER report success unless the on-chain exposure is
+actually reduced. Credential errors, missing positions that should exist,
+and unexpected SDK responses all exit 1 with a populated ``error`` field
+so the Go caller latches the kill switch and retries next cycle.
+"""
+
+import argparse
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "platforms", "robinhood"))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--symbol", required=True)
+    parser.add_argument("--mode", default="live")
+    args = parser.parse_args()
+
+    if args.mode != "live":
+        print(json.dumps({
+            "close": None,
+            "platform": "robinhood",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "error": "--mode=live required for emergency close",
+        }))
+        sys.exit(1)
+
+    try:
+        from adapter import RobinhoodExchangeAdapter
+        adapter = RobinhoodExchangeAdapter(mode="live")
+        if not adapter.is_live:
+            _emit_error(args.symbol, "Robinhood adapter not live — set ROBINHOOD_USERNAME / ROBINHOOD_PASSWORD / ROBINHOOD_TOTP_SECRET")
+            return
+
+        # Find the on-chain quantity so we can market-sell the full balance.
+        # Robinhood crypto is spot (no reduce-only), so the kill switch is
+        # explicit: sell everything this account holds for this coin.
+        positions = adapter.get_crypto_positions()
+        qty = 0.0
+        for pos in positions or []:
+            if (pos.get("symbol") or "").upper() == args.symbol.upper():
+                try:
+                    qty = float(pos.get("quantity") or 0)
+                except (TypeError, ValueError):
+                    qty = 0.0
+                break
+
+        if qty <= 0:
+            # Already flat — treat as success so the kill switch can release
+            # the latch when on-chain is genuinely empty (eventual-consistency
+            # window between the Go-side fetch and this submit).
+            _emit_success(args.symbol, fill={})
+            return
+
+        result = adapter.market_sell(args.symbol, qty)
+    except Exception as e:
+        traceback.print_exc(file=sys.stderr)
+        _emit_error(args.symbol, str(e))
+        return
+
+    if not isinstance(result, dict):
+        _emit_error(args.symbol, f"unexpected adapter response type {type(result).__name__}: {result!r}")
+        return
+
+    if not result:
+        # Adapter returned empty dict — order submit returned nothing. Treat
+        # as failure so the kill switch latches; an empty response from a
+        # live sell is ambiguous and must not be read as confirmation.
+        _emit_error(args.symbol, "empty order response from robin_stocks sell submit")
+        return
+
+    # robin_stocks order response: surface best-effort fill telemetry.
+    fill = {}
+    try:
+        filled_qty = result.get("quantity") or result.get("cumulative_quantity")
+        if filled_qty is not None:
+            fill["total_sz"] = float(filled_qty)
+    except (TypeError, ValueError):
+        pass
+    try:
+        avg = result.get("average_price") or result.get("price")
+        if avg is not None:
+            fill["avg_px"] = float(avg)
+    except (TypeError, ValueError):
+        pass
+    oid = result.get("id")
+    if oid is not None:
+        fill["oid"] = str(oid)
+
+    _emit_success(args.symbol, fill)
+
+
+def _emit_success(symbol, fill):
+    print(json.dumps({
+        "close": {"symbol": symbol, "fill": fill},
+        "platform": "robinhood",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }))
+
+
+def _emit_error(symbol, message):
+    print(json.dumps({
+        "close": {"symbol": symbol, "fill": {}},
+        "platform": "robinhood",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "error": message,
+    }))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/shared_scripts/fetch_robinhood_positions.py
+++ b/shared_scripts/fetch_robinhood_positions.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Robinhood live positions fetcher (issue #346).
+
+Fetches every open Robinhood crypto position on the account and emits a
+JSON list to stdout. Used by the portfolio kill switch in the Go scheduler
+to decide which coins need market closes — mirrors
+``fetch_okx_positions.py``. Requires authenticated session
+(robin_stocks + TOTP MFA); there is no public unauthenticated endpoint.
+
+Scope: crypto only. Stock options are NOT surfaced — the kill switch has
+no automated options close path (different buy-to-close / sell-to-close
+semantics, see ``close_robinhood_position.py``).
+
+Usage:
+    fetch_robinhood_positions.py
+
+Requires ROBINHOOD_USERNAME / ROBINHOOD_PASSWORD / ROBINHOOD_TOTP_SECRET.
+Output:
+``{"positions": [{"coin": "BTC", "size": 0.01, "avg_price": 42000.0}, ...],
+  "platform": "robinhood", "timestamp": ...}``
+Size is unsigned (Robinhood crypto is spot — no short positions).
+"""
+
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "platforms", "robinhood"))
+
+
+def main():
+    try:
+        from adapter import RobinhoodExchangeAdapter
+        adapter = RobinhoodExchangeAdapter(mode="live")
+        if not adapter.is_live:
+            _emit_error("Robinhood adapter not live — set ROBINHOOD_USERNAME / ROBINHOOD_PASSWORD / ROBINHOOD_TOTP_SECRET")
+            return
+        raw = adapter.get_crypto_positions()
+    except Exception as e:
+        traceback.print_exc(file=sys.stderr)
+        _emit_error(str(e))
+        return
+
+    positions = []
+    for p in raw or []:
+        symbol = (p.get("symbol") or "").upper()
+        if not symbol:
+            continue
+        try:
+            qty = float(p.get("quantity") or 0)
+        except (TypeError, ValueError):
+            continue
+        if qty <= 0:
+            continue
+        try:
+            avg_price = float(p.get("avg_price") or 0)
+        except (TypeError, ValueError):
+            avg_price = 0.0
+        positions.append({
+            "coin": symbol,
+            "size": qty,
+            "avg_price": avg_price,
+        })
+
+    print(json.dumps({
+        "positions": positions,
+        "platform": "robinhood",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }))
+
+
+def _emit_error(message):
+    print(json.dumps({
+        "positions": [],
+        "platform": "robinhood",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "error": message,
+    }))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/shared_scripts/fetch_robinhood_positions.py
+++ b/shared_scripts/fetch_robinhood_positions.py
@@ -39,7 +39,11 @@ def main():
         if not adapter.is_live:
             _emit_error("Robinhood adapter not live — set ROBINHOOD_USERNAME / ROBINHOOD_PASSWORD / ROBINHOOD_TOTP_SECRET")
             return
-        raw = adapter.get_crypto_positions()
+        # Strict variant propagates exceptions instead of silently returning
+        # [] — required by the kill switch so a Robinhood outage latches
+        # rather than clears virtual state while live exposure remains
+        # (#346 review).
+        raw = adapter.get_crypto_positions_strict()
     except Exception as e:
         traceback.print_exc(file=sys.stderr)
         _emit_error(str(e))

--- a/shared_scripts/test_fetch_robinhood_positions.py
+++ b/shared_scripts/test_fetch_robinhood_positions.py
@@ -1,0 +1,128 @@
+"""Tests for fetch_robinhood_positions.py — live-account position fetcher
+used by the portfolio kill switch (#346).
+
+Regression target: the #346 review caught that the adapter's
+``get_crypto_positions()`` swallowed exceptions and returned [], which
+the Go-side parser would then read as "no positions" → ConfirmedFlat=True
+→ virtual state cleared while live exposure remained. The script now
+calls ``get_crypto_positions_strict()`` so any adapter failure surfaces
+as a JSON error envelope and the kill switch latches.
+"""
+
+import builtins
+import importlib.util
+import json
+import os
+import sys
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _run_script(positions_or_exc, is_live=True):
+    """Invoke fetch_robinhood_positions.main() with a mocked adapter.
+
+    positions_or_exc may be a list (returned by
+    adapter.get_crypto_positions_strict) or an Exception. Returns
+    (parsed_stdout_json, exit_code).
+    """
+    script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               "fetch_robinhood_positions.py")
+    spec = importlib.util.spec_from_file_location("fetch_robinhood_positions", script_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    mock_adapter_cls = MagicMock()
+    mock_adapter = MagicMock()
+    mock_adapter.is_live = is_live
+    mock_adapter_cls.return_value = mock_adapter
+    if isinstance(positions_or_exc, Exception):
+        mock_adapter.get_crypto_positions_strict.side_effect = positions_or_exc
+    else:
+        mock_adapter.get_crypto_positions_strict.return_value = positions_or_exc
+
+    captured = StringIO()
+    exit_code = {"value": 0}
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "adapter":
+            fake_mod = MagicMock()
+            fake_mod.RobinhoodExchangeAdapter = mock_adapter_cls
+            return fake_mod
+        return original_import(name, *args, **kwargs)
+
+    def mock_exit(code=0):
+        exit_code["value"] = code
+        raise SystemExit(code)
+
+    with patch("builtins.__import__", side_effect=mock_import), \
+         patch("sys.stdout", captured), \
+         patch("sys.argv", ["fetch_robinhood_positions.py"]), \
+         patch.object(mod.sys, "exit", side_effect=mock_exit):
+        try:
+            mod.main()
+        except SystemExit:
+            pass
+
+    raw = captured.getvalue().strip()
+    parsed = json.loads(raw) if raw else {}
+    return parsed, exit_code["value"]
+
+
+class TestSuccess:
+    def test_single_position(self):
+        out, code = _run_script([
+            {"symbol": "BTC", "quantity": 0.01, "avg_price": 42000.0},
+        ])
+        assert code == 0
+        assert len(out["positions"]) == 1
+        p = out["positions"][0]
+        assert p["coin"] == "BTC"
+        assert p["size"] == 0.01
+        assert p["avg_price"] == 42000.0
+        assert "error" not in out
+
+    def test_zero_quantity_filtered(self):
+        out, code = _run_script([
+            {"symbol": "BTC", "quantity": 0, "avg_price": 0},
+        ])
+        assert code == 0
+        assert out["positions"] == []
+
+    def test_empty_positions(self):
+        out, code = _run_script([])
+        assert code == 0
+        assert out["positions"] == []
+        assert "error" not in out
+
+
+class TestFailurePaths:
+    def test_non_live_adapter(self):
+        out, code = _run_script([], is_live=False)
+        assert code == 1
+        assert "ROBINHOOD" in out["error"]
+
+    def test_strict_raises_propagates_as_error_envelope(self):
+        """Regression for #346 review: if the adapter call fails, the
+        script MUST emit error envelope + exit 1 — NOT a clean
+        {positions: []}. Otherwise the Go-side kill switch reads no
+        positions, sets ConfirmedFlat=true, and clears virtual state
+        while live exposure remains.
+        """
+        out, code = _run_script(RuntimeError("Robinhood 503 Service Unavailable"))
+        assert code == 1
+        assert "503" in out["error"]
+        assert out["positions"] == []
+
+    def test_not_logged_in_raises(self):
+        out, code = _run_script(
+            RuntimeError("Robinhood adapter not logged in — cannot fetch crypto positions")
+        )
+        assert code == 1
+        assert "not logged in" in out["error"]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes #346

## Summary

Mirrors the HL (#341/#342) and OKX (#345) kill-switch design for Robinhood. On portfolio kill switch, the scheduler now:

- Fetches live Robinhood crypto balances via a TOTP-authenticated subprocess.
- Submits full-quantity market sells for coins a configured live crypto strategy trades.
- Latches the switch until the exchange confirms flat (any error or unconfigured balance blocks virtual-state reset).
- Surfaces Robinhood stock options as a known gap (sell-to-close vs buy-to-close per leg requires follow-up) without blocking `OnChainConfirmedFlat` — same semantic as OKX spot (#345).

## Changes

- `scheduler/robinhood_close.go` + test — `forceCloseRobinhoodLive`, `RobinhoodLiveCloseReport`, default closer/fetcher wrappers.
- `scheduler/executor.go` — `RunRobinhoodClose`, `RunRobinhoodFetchPositions`, and pure parsers testable without `.venv`.
- `scheduler/kill_switch_close.go` — Robinhood dispatch in `planKillSwitchClose`; success/LATCHED message formatting.
- `scheduler/main.go` — partition live Robinhood strategies by type and thread into plan inputs.
- `shared_scripts/close_robinhood_position.py` + `fetch_robinhood_positions.py` — subprocess helpers using the existing adapter.

## Test plan
- [x] `cd scheduler && go build .` passes.
- [x] `cd scheduler && go vet ./...` clean.
- [x] `cd scheduler && go test ./...` passes (includes 7 new plan tests, 6 new `forceCloseRobinhoodLive`/report tests, 8 new parser tests).
- [x] `python3 -m py_compile shared_scripts/close_robinhood_position.py shared_scripts/fetch_robinhood_positions.py` passes.
- [ ] Manual smoke test of the kill switch against a live Robinhood account (requires TOTP creds; not part of CI).

Generated with [Claude Code](https://claude.ai/code)