### PR TITLE
Close TopStep live futures on portfolio kill-switch fire (#347)

### DIFF
--- a/platforms/topstep/adapter.py
+++ b/platforms/topstep/adapter.py
@@ -155,32 +155,57 @@ class TopStepExchangeAdapter:
     # ─────────────────────────────────────────────
 
     def get_open_positions(self) -> list:
-        """Get open positions for the configured account."""
+        """Get open positions for the configured account.
+
+        Soft-fails on error (returns []) to keep signal-check / paper paths
+        resilient. Callers that must distinguish "no positions" from "fetch
+        failed" (e.g. the portfolio kill switch) should use
+        :meth:`get_open_positions_raise` instead.
+        """
         if not self.is_live:
             return []
         try:
-            resp = self._session.get(
-                f"{API_BASE_URL}/v1/account/positions",
-                params={"accountId": self._account_id},
-                timeout=10,
-            )
-            resp.raise_for_status()
-            positions = []
-            for pos in resp.json().get("positions", []):
-                qty = int(pos.get("quantity", 0))
-                if qty == 0:
-                    continue
-                positions.append({
-                    "symbol": pos.get("symbol", ""),
-                    "quantity": qty,
-                    "avg_price": float(pos.get("avgPrice", 0)),
-                    "side": "long" if qty > 0 else "short",
-                    "unrealized_pnl": float(pos.get("unrealizedPnl", 0)),
-                })
-            return positions
+            return self._fetch_open_positions()
         except Exception as e:
             print(f"[topstep] get_open_positions error: {e}", file=sys.stderr)
             return []
+
+    def get_open_positions_raise(self) -> list:
+        """Same as :meth:`get_open_positions` but re-raises on failure.
+
+        Used by the kill-switch fetch path so auth/network errors propagate
+        into the error envelope instead of being silently swallowed as an
+        empty position list (issue #347 follow-up).
+        """
+        if self._mode != "live":
+            raise RuntimeError("TopStep adapter not in live mode")
+        if self._session is None:
+            raise RuntimeError(
+                "TopStep live session not initialized — missing "
+                "TOPSTEP_API_KEY / TOPSTEP_API_SECRET / TOPSTEP_ACCOUNT_ID"
+            )
+        return self._fetch_open_positions()
+
+    def _fetch_open_positions(self) -> list:
+        resp = self._session.get(
+            f"{API_BASE_URL}/v1/account/positions",
+            params={"accountId": self._account_id},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        positions = []
+        for pos in resp.json().get("positions", []):
+            qty = int(pos.get("quantity", 0))
+            if qty == 0:
+                continue
+            positions.append({
+                "symbol": pos.get("symbol", ""),
+                "quantity": qty,
+                "avg_price": float(pos.get("avgPrice", 0)),
+                "side": "long" if qty > 0 else "short",
+                "unrealized_pnl": float(pos.get("unrealizedPnl", 0)),
+            })
+        return positions
 
     # ─────────────────────────────────────────────
     # Yahoo Finance helpers (paper mode)

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -394,6 +394,128 @@ func RunTopStepExecute(script, symbol, side string, contracts int) (*TopStepExec
 	return &result, stderrStr, nil
 }
 
+// TopStepCloseFill is the parsed fill block from close_topstep_position.py.
+// Mirrors TopStepFill but fields are optional (empty {} means already-flat
+// success) and OID is a string (TopStepX order IDs are opaque).
+type TopStepCloseFill struct {
+	AvgPx          float64 `json:"avg_px,omitempty"`
+	TotalContracts int     `json:"total_contracts,omitempty"`
+	OID            string  `json:"oid,omitempty"`
+}
+
+// TopStepClose is the close block from close_topstep_position.py.
+type TopStepClose struct {
+	Symbol string            `json:"symbol"`
+	Fill   *TopStepCloseFill `json:"fill,omitempty"`
+}
+
+// TopStepCloseResult is the top-level JSON from close_topstep_position.py.
+// Used by the portfolio kill switch to liquidate live TopStep futures
+// exposure (#347).
+type TopStepCloseResult struct {
+	Close     *TopStepClose `json:"close"`
+	Platform  string        `json:"platform"`
+	Timestamp string        `json:"timestamp"`
+	Error     string        `json:"error,omitempty"`
+}
+
+// RunTopStepClose runs close_topstep_position.py to submit a market-flatten
+// for a single TopStep futures symbol (#347). Contract mirrors
+// RunHyperliquidClose / RunOKXClose / RunRobinhoodClose: any failure path
+// returns a non-nil error so the kill switch stays latched on ambiguous
+// responses.
+func RunTopStepClose(script, symbol string) (*TopStepCloseResult, string, error) {
+	args := []string{
+		fmt.Sprintf("--symbol=%s", symbol),
+		"--mode=live",
+	}
+	stdout, stderr, runErr := RunPythonScript(script, args)
+	return parseTopStepCloseOutput(stdout, string(stderr), runErr)
+}
+
+// parseTopStepCloseOutput turns raw subprocess output into
+// (*TopStepCloseResult, stderr, error) following the RunTopStepClose
+// contract. Extracted so decision logic can be tested without spawning
+// .venv/bin/python3 — same pattern as parseHyperliquidCloseOutput /
+// parseOKXCloseOutput / parseRobinhoodCloseOutput (#341/#342/#345/#346).
+func parseTopStepCloseOutput(stdout []byte, stderrStr string, runErr error) (*TopStepCloseResult, string, error) {
+	var result TopStepCloseResult
+	parseErr := json.Unmarshal(stdout, &result)
+
+	switch {
+	case runErr == nil && parseErr == nil && result.Error == "":
+		return &result, stderrStr, nil
+
+	case runErr == nil && parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("close reported error despite exit 0: %s", result.Error)
+
+	case parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("close failed: %s", result.Error)
+
+	case parseErr == nil && runErr != nil:
+		return &result, stderrStr, fmt.Errorf("close subprocess exit %v with no error field (stderr: %s)", runErr, stderrStr)
+
+	default:
+		return nil, stderrStr, fmt.Errorf("parse close output: %v (run err: %v, stdout: %s)", parseErr, runErr, string(stdout))
+	}
+}
+
+// TopStepPositionsResult is the JSON output from fetch_topstep_positions.py.
+// Size is signed (positive = long, negative = short) to mirror OKX/HL so
+// the kill-switch plan builder can treat all platforms symmetrically.
+type TopStepPositionsResult struct {
+	Positions []TopStepPositionJSON `json:"positions"`
+	Platform  string                `json:"platform"`
+	Timestamp string                `json:"timestamp"`
+	Error     string                `json:"error,omitempty"`
+}
+
+// TopStepPositionJSON is the per-position payload from
+// fetch_topstep_positions.py. Size is integer contracts (futures have no
+// fractional sizing).
+type TopStepPositionJSON struct {
+	Coin     string  `json:"coin"`
+	Size     int     `json:"size"`
+	AvgPrice float64 `json:"avg_price"`
+	Side     string  `json:"side"`
+}
+
+// RunTopStepFetchPositions runs fetch_topstep_positions.py and returns the
+// parsed result (#347). Like RunTopStepClose, any failure path returns a
+// non-nil error so the kill switch can latch and retry — a silent parse
+// failure would otherwise look like "no positions" and clear virtual state
+// while live exposure remained.
+func RunTopStepFetchPositions(script string) (*TopStepPositionsResult, string, error) {
+	stdout, stderr, runErr := RunPythonScript(script, nil)
+	return parseTopStepPositionsOutput(stdout, string(stderr), runErr)
+}
+
+// parseTopStepPositionsOutput is the pure parser, extracted from
+// RunTopStepFetchPositions so decision logic can be tested without
+// spawning Python. Mirrors parseOKXPositionsOutput / parseRobinhoodPositionsOutput
+// 5-case matrix.
+func parseTopStepPositionsOutput(stdout []byte, stderrStr string, runErr error) (*TopStepPositionsResult, string, error) {
+	var result TopStepPositionsResult
+	parseErr := json.Unmarshal(stdout, &result)
+
+	switch {
+	case runErr == nil && parseErr == nil && result.Error == "":
+		return &result, stderrStr, nil
+
+	case runErr == nil && parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("fetch positions reported error despite exit 0: %s", result.Error)
+
+	case parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("fetch positions failed: %s", result.Error)
+
+	case parseErr == nil && runErr != nil:
+		return &result, stderrStr, fmt.Errorf("fetch positions subprocess exit %v with no error field (stderr: %s)", runErr, stderrStr)
+
+	default:
+		return nil, stderrStr, fmt.Errorf("parse positions output: %v (run err: %v, stdout: %s)", parseErr, runErr, string(stdout))
+	}
+}
+
 // RobinhoodResult is the JSON output from check_robinhood.py (signal check mode).
 type RobinhoodResult struct {
 	Strategy   string                 `json:"strategy"`

--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -59,6 +59,15 @@ type KillSwitchCloseInputs struct {
 	RHCloser      RobinhoodLiveCloser
 	RHFetcher     RobinhoodPositionsFetcher
 
+	// TSLiveAll: every live TopStep futures strategy configured. Used to
+	// decide which symbols to close and to detect "unconfigured" positions.
+	// TopStep has no public unauthenticated endpoint — we always call
+	// TSFetcher when there's at least one live TopStep futures strategy,
+	// rather than trying to reuse a pre-fetch. (#347)
+	TSLiveAll []StrategyConfig
+	TSCloser  TopStepLiveCloser
+	TSFetcher TopStepPositionsFetcher
+
 	PortfolioReason string
 	CloseTimeout    time.Duration
 }
@@ -116,6 +125,15 @@ type KillSwitchClosePlan struct {
 	// (hard-latch would freeze the scheduler for any Robinhood options
 	// user with no available close path). Mirrors OKXSpotPresent.
 	RHOptionsPresent bool
+
+	// TSCloseReport is the TopStep per-symbol outcome. Zero value when no
+	// TopStep close was attempted.
+	TSCloseReport TopStepLiveCloseReport
+
+	// TSUnconfigured lists live TopStep positions for symbols no configured
+	// live TopStep futures strategy trades. Same manual-intervention
+	// semantic as HL/OKX/Robinhood Unconfigured.
+	TSUnconfigured []TopStepPosition
 
 	// DiscordMessage is the formatted notification string; empty when no
 	// Discord message should be sent. Caller checks notifier.HasBackends()
@@ -316,6 +334,52 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 		}
 	}
 
+	// ── TopStep ─────────────────────────────────────────────────────
+	// Futures: always attempt fetch when there's a configured futures
+	// strategy — mirrors the OKX / Robinhood opportunistic-fetch guard.
+	// TopStep has no pre-fetch to reuse; every cycle requires a subprocess
+	// round-trip (TopStepX REST, authenticated).
+	//
+	// CME trading-hour restriction: fires outside RTH will surface a venue
+	// error here, latching the kill switch until the next in-hours cycle.
+	// This is the correct behavior — do not attempt to bypass the venue.
+	if len(in.TSLiveAll) > 0 && in.TSFetcher != nil {
+		tsPositions, err := in.TSFetcher()
+		if err != nil {
+			plan.LogLines = append(plan.LogLines,
+				fmt.Sprintf("[CRITICAL] ts-close: kill switch unable to fetch TopStep positions: %v — cannot confirm flat", err))
+			plan.OnChainConfirmedFlat = false
+		} else {
+			ctx, cancel := context.WithTimeout(context.Background(), in.CloseTimeout)
+			plan.TSCloseReport = forceCloseTopStepLive(ctx, tsPositions, in.TSLiveAll, in.TSCloser)
+			cancel()
+			if !plan.TSCloseReport.ConfirmedFlat() {
+				plan.OnChainConfirmedFlat = false
+			}
+			if len(plan.TSCloseReport.ClosedCoins) > 0 {
+				plan.LogLines = append(plan.LogLines,
+					fmt.Sprintf("[CRITICAL] ts-close: confirmed close for %v", plan.TSCloseReport.ClosedCoins))
+			}
+			if len(plan.TSCloseReport.AlreadyFlat) > 0 {
+				plan.LogLines = append(plan.LogLines,
+					fmt.Sprintf("[INFO] ts-close: already flat: %v", plan.TSCloseReport.AlreadyFlat))
+			}
+			for _, coin := range plan.TSCloseReport.SortedErrorCoins() {
+				plan.LogLines = append(plan.LogLines,
+					fmt.Sprintf("[CRITICAL] ts-close: %s failed: %v (kill switch will retry next cycle)", coin, plan.TSCloseReport.Errors[coin]))
+			}
+
+			plan.TSUnconfigured = plan.TSCloseReport.Unconfigured
+			if len(plan.TSUnconfigured) > 0 {
+				plan.OnChainConfirmedFlat = false
+				for _, p := range plan.TSUnconfigured {
+					plan.LogLines = append(plan.LogLines,
+						fmt.Sprintf("[CRITICAL] ts-close: live position for unconfigured symbol %s (size=%d) — manual intervention required, kill switch will retry next cycle", p.Coin, p.Size))
+				}
+			}
+		}
+	}
+
 	plan.DiscordMessage = formatKillSwitchMessage(in.HLAddr, plan, in.PortfolioReason)
 	return plan
 }
@@ -347,6 +411,9 @@ func formatKillSwitchMessage(hlAddr string, plan KillSwitchClosePlan, portfolioR
 		}
 		if len(plan.RHCloseReport.ClosedCoins) > 0 {
 			parts = append(parts, fmt.Sprintf("Robinhood closes: %v", plan.RHCloseReport.ClosedCoins))
+		}
+		if len(plan.TSCloseReport.ClosedCoins) > 0 {
+			parts = append(parts, fmt.Sprintf("TopStep closes: %v", plan.TSCloseReport.ClosedCoins))
 		}
 		header := "**PORTFOLIO KILL SWITCH**"
 		gapNotes := []string{}
@@ -410,6 +477,21 @@ func formatKillSwitchMessage(hlAddr string, plan KillSwitchClosePlan, portfolioR
 		}
 		sort.Strings(names)
 		segments = append(segments, "Live Robinhood balances for unconfigured coins (manual intervention required) — "+strings.Join(names, "; "))
+	}
+	if len(plan.TSCloseReport.Errors) > 0 {
+		parts := make([]string, 0, len(plan.TSCloseReport.Errors))
+		for _, coin := range plan.TSCloseReport.SortedErrorCoins() {
+			parts = append(parts, fmt.Sprintf("%s: %v", coin, plan.TSCloseReport.Errors[coin]))
+		}
+		segments = append(segments, "TopStep live close errors — "+strings.Join(parts, "; "))
+	}
+	if len(plan.TSUnconfigured) > 0 {
+		names := make([]string, 0, len(plan.TSUnconfigured))
+		for _, p := range plan.TSUnconfigured {
+			names = append(names, fmt.Sprintf("%s size=%d", p.Coin, p.Size))
+		}
+		sort.Strings(names)
+		segments = append(segments, "Live TopStep positions for unconfigured symbols (manual intervention required) — "+strings.Join(names, "; "))
 	}
 	if plan.OKXSpotPresent {
 		segments = append(segments, "OKX spot strategies present — verify manually (kill switch cannot auto-close spot)")

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -974,3 +974,212 @@ func TestPlanKillSwitchClose_OKXDeterministicErrorOrder(t *testing.T) {
 		t.Errorf("expected alphabetical BTC < ETH < SOL in: %s", prev)
 	}
 }
+
+// ── TopStep tests (#347) ───────────────────────────────────────────────
+
+// stubTSLiveCloser mirrors stubHLLiveCloser / stubOKXLiveCloser / stubRHLiveCloser
+// for TopStep. Missing-symbol entries yield a synthetic success.
+func stubTSLiveCloser(errs map[string]error) (TopStepLiveCloser, *[]string) {
+	var calls []string
+	closer := func(symbol string) (*TopStepCloseResult, error) {
+		calls = append(calls, symbol)
+		if err, ok := errs[symbol]; ok && err != nil {
+			return nil, err
+		}
+		return &TopStepCloseResult{
+			Close:    &TopStepClose{Symbol: symbol, Fill: &TopStepCloseFill{TotalContracts: 1, AvgPx: 5000}},
+			Platform: "topstep",
+		}, nil
+	}
+	return closer, &calls
+}
+
+// stubTSPositionsFetcher returns a TopStepPositionsFetcher that replays a
+// fixed response and records invocation count.
+func stubTSPositionsFetcher(positions []TopStepPosition, err error) (TopStepPositionsFetcher, *int) {
+	var calls int
+	fetcher := func() ([]TopStepPosition, error) {
+		calls++
+		if err != nil {
+			return nil, err
+		}
+		return positions, nil
+	}
+	return fetcher, &calls
+}
+
+// TopStep happy path: one live futures strategy with an open ES position.
+// Plan reports ConfirmedFlat, closer called once, Discord message mentions
+// TopStep closes. The #347 analog of HL/OKX/Robinhood happy-path.
+func TestPlanKillSwitchClose_TopStepHappyPath(t *testing.T) {
+	tsLive := []StrategyConfig{
+		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
+			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
+	}
+	positions := []TopStepPosition{{Coin: "ES", Size: 2, AvgPrice: 5000, Side: "long"}}
+	closer, calls := stubTSLiveCloser(nil)
+	fetcher, fetchCalls := stubTSPositionsFetcher(positions, nil)
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		TSLiveAll:       tsLive,
+		TSCloser:        closer,
+		TSFetcher:       fetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if !plan.OnChainConfirmedFlat {
+		t.Fatalf("expected ConfirmedFlat, got plan=%+v", plan)
+	}
+	if *fetchCalls != 1 {
+		t.Errorf("TopStep fetcher should be called exactly once, got %d", *fetchCalls)
+	}
+	if len(*calls) != 1 || (*calls)[0] != "ES" {
+		t.Errorf("closer calls = %v, want [ES]", *calls)
+	}
+	if !strings.Contains(plan.DiscordMessage, "TopStep closes: [ES]") {
+		t.Errorf("expected TopStep closes in message, got: %s", plan.DiscordMessage)
+	}
+}
+
+// TopStep close failure: the load-bearing #347 correctness case. Without
+// latching on a failed close, virtual state would clear while CME exposure
+// remained — exactly the #341 bug shape.
+func TestPlanKillSwitchClose_TopStepCloseError(t *testing.T) {
+	tsLive := []StrategyConfig{
+		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
+			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
+	}
+	positions := []TopStepPosition{{Coin: "ES", Size: 2}}
+	closer, _ := stubTSLiveCloser(map[string]error{"ES": fmt.Errorf("market closed")})
+	fetcher, _ := stubTSPositionsFetcher(positions, nil)
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		TSLiveAll:       tsLive,
+		TSCloser:        closer,
+		TSFetcher:       fetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("expected NOT ConfirmedFlat on TopStep close error — would clear virtual state while CME is still active")
+	}
+	if got, ok := plan.TSCloseReport.Errors["ES"]; !ok || got == nil {
+		t.Errorf("expected ES error in TopStep report, got %v", plan.TSCloseReport.Errors)
+	}
+	if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
+		t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
+	}
+	if !strings.Contains(plan.DiscordMessage, "market closed") {
+		t.Errorf("expected TopStep error detail in message, got: %s", plan.DiscordMessage)
+	}
+}
+
+// TopStep fetch failure: fetcher errors → kill switch must latch, closer
+// must NOT be invoked. Same guard as HL/OKX/Robinhood fetch failure. This
+// branch also covers the CME-closed-hours case when the fetch itself can't
+// reach TopStepX (credentials, auth token expired, etc).
+func TestPlanKillSwitchClose_TopStepFetchFailure(t *testing.T) {
+	tsLive := []StrategyConfig{
+		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
+			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
+	}
+	closer, calls := stubTSLiveCloser(nil)
+	fetcher, _ := stubTSPositionsFetcher(nil, fmt.Errorf("topstepx 401"))
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		TSLiveAll:       tsLive,
+		TSCloser:        closer,
+		TSFetcher:       fetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("expected NOT ConfirmedFlat on TopStep fetch failure")
+	}
+	if len(*calls) != 0 {
+		t.Errorf("closer must not be invoked when fetch failed, got %v", *calls)
+	}
+	if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
+		t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
+	}
+}
+
+// TopStep unconfigured: fetcher reports a position for a symbol no live
+// futures strategy trades. Kill switch refuses to liquidate and latches.
+func TestPlanKillSwitchClose_TopStepUnconfiguredBlocksReset(t *testing.T) {
+	tsLive := []StrategyConfig{
+		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
+			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
+	}
+	positions := []TopStepPosition{
+		{Coin: "ES", Size: 2},
+		{Coin: "NQ", Size: 1},
+	}
+	closer, calls := stubTSLiveCloser(nil)
+	fetcher, _ := stubTSPositionsFetcher(positions, nil)
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		TSLiveAll:       tsLive,
+		TSCloser:        closer,
+		TSFetcher:       fetcher,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("expected NOT ConfirmedFlat — unconfigured NQ position is still live")
+	}
+	if len(plan.TSUnconfigured) != 1 || plan.TSUnconfigured[0].Coin != "NQ" {
+		t.Errorf("expected TSUnconfigured=[NQ], got %v", plan.TSUnconfigured)
+	}
+	if len(*calls) != 1 || (*calls)[0] != "ES" {
+		t.Errorf("closer calls = %v, want [ES]", *calls)
+	}
+	if !strings.Contains(plan.DiscordMessage, "manual intervention required") {
+		t.Errorf("expected manual intervention note, got: %s", plan.DiscordMessage)
+	}
+}
+
+// Cross-platform latch: HL happy but TopStep fails — plan must still
+// latch across the board. Mirrors the existing
+// RobinhoodFailureStillLatchesAcrossPlatforms test. Proves either
+// platform flipping ConfirmedFlat=false cascades correctly.
+func TestPlanKillSwitchClose_TopStepFailureStillLatchesAcrossPlatforms(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-mom-btc", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"momentum", "BTC", "1h", "--mode=live"}},
+	}
+	hlPositions := []HLPosition{{Coin: "BTC", Size: 0.5}}
+	hlCloser, _ := stubHLLiveCloser(nil)
+
+	tsLive := []StrategyConfig{
+		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
+			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
+	}
+	tsPositions := []TopStepPosition{{Coin: "ES", Size: 2}}
+	tsCloser, _ := stubTSLiveCloser(map[string]error{"ES": fmt.Errorf("venue down")})
+	tsFetcher, _ := stubTSPositionsFetcher(tsPositions, nil)
+
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		HLAddr:          "0xabc",
+		HLStateFetched:  true,
+		HLPositions:     hlPositions,
+		HLLiveAll:       hlLive,
+		HLCloser:        hlCloser,
+		TSLiveAll:       tsLive,
+		TSCloser:        tsCloser,
+		TSFetcher:       tsFetcher,
+		PortfolioReason: "reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("expected NOT ConfirmedFlat when TopStep fails even though HL succeeded")
+	}
+	if len(plan.CloseReport.ClosedCoins) != 1 || plan.CloseReport.ClosedCoins[0] != "BTC" {
+		t.Errorf("HL close should still run: got %v", plan.CloseReport.ClosedCoins)
+	}
+}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -537,6 +537,18 @@ func main() {
 				}
 			}
 
+			// #347: Partition live TopStep futures strategies for the
+			// kill-switch close path. TopStepX supports reduce-all via
+			// market_close; CME trading-hour restrictions are handled by
+			// the latch-until-flat semantic (fires outside RTH stay
+			// latched until the venue reopens).
+			var tsLiveAll []StrategyConfig
+			for _, sc := range cfg.Strategies {
+				if sc.Platform == "topstep" && sc.Type == "futures" && topstepIsLive(sc.Args) {
+					tsLiveAll = append(tsLiveAll, sc)
+				}
+			}
+
 			sharedWallets := detectSharedWallets(cfg.Strategies)
 			hlAddr := os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS")
 			hlKey := SharedWalletKey{Platform: "hyperliquid", Account: hlAddr}
@@ -598,14 +610,13 @@ func main() {
 			}
 			mu.Unlock()
 
-			// #341 / #345 / #346: Submit market closes to Hyperliquid,
-			// OKX, AND Robinhood for every non-zero on-chain position
-			// belonging to a configured live strategy. The planning step
-			// (planKillSwitchClose) runs OUTSIDE the lock — the close
-			// scripts are subprocesses that can take seconds. OKX spot
-			// and Robinhood options are surfaced as known gaps (no
-			// unified close primitive). TopStep has the same underlying
-			// bug but is tracked separately.
+			// #341 / #345 / #346 / #347: Submit market closes to
+			// Hyperliquid, OKX, Robinhood, AND TopStep for every non-zero
+			// on-chain / on-account position belonging to a configured
+			// live strategy. The planning step (planKillSwitchClose)
+			// runs OUTSIDE the lock — the close scripts are subprocesses
+			// that can take seconds. OKX spot and Robinhood options are
+			// surfaced as known gaps (no unified close primitive).
 			//
 			// Latch semantics: virtual state is mutated only when
 			// plan.OnChainConfirmedFlat is true (either platform failing
@@ -629,6 +640,9 @@ func main() {
 					RHLiveOptions:   rhLiveOptions,
 					RHCloser:        defaultRobinhoodLiveCloser,
 					RHFetcher:       defaultRobinhoodPositionsFetcher,
+					TSLiveAll:       tsLiveAll,
+					TSCloser:        defaultTopStepLiveCloser,
+					TSFetcher:       defaultTopStepPositionsFetcher,
 					PortfolioReason: portfolioReason,
 					CloseTimeout:    90 * time.Second,
 				}

--- a/scheduler/robinhood_close_test.go
+++ b/scheduler/robinhood_close_test.go
@@ -122,8 +122,8 @@ func TestForceCloseRobinhoodLive_NegativeSizeNotTraded(t *testing.T) {
 			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
 	}
 	positions := []RobinhoodPosition{
-		{Coin: "BTC", Size: -0.01},  // owned coin, hypothetical negative
-		{Coin: "DOGE", Size: -100},  // unowned coin, hypothetical negative
+		{Coin: "BTC", Size: -0.01}, // owned coin, hypothetical negative
+		{Coin: "DOGE", Size: -100}, // unowned coin, hypothetical negative
 	}
 	var calls []string
 	closer := func(sym string) (*RobinhoodCloseResult, error) {

--- a/scheduler/topstep_close.go
+++ b/scheduler/topstep_close.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+)
+
+// TopStepPosition represents a live TopStep futures position. Size is
+// signed (positive = long, negative = short) and integer-valued (futures
+// contracts have no fractional sizing). Mirrors HLPosition / OKXPosition /
+// RobinhoodPosition so the kill-switch plan builder can treat all
+// platforms symmetrically.
+type TopStepPosition struct {
+	Coin     string
+	Size     int
+	AvgPrice float64
+	Side     string // "long" or "short"
+}
+
+// topstepLiveCloseScript is the path to the Python close helper. Exposed
+// as a var so tests can substitute — same pattern as hyperliquidLiveCloseScript /
+// okxLiveCloseScript / robinhoodLiveCloseScript.
+var topstepLiveCloseScript = "shared_scripts/close_topstep_position.py"
+
+// topstepFetchPositionsScript is the path to the Python position fetcher.
+var topstepFetchPositionsScript = "shared_scripts/fetch_topstep_positions.py"
+
+// TopStepLiveCloser submits a market-flatten for the full on-account
+// contract count of a single TopStep futures symbol and returns the parsed
+// result. Exposed as a function variable so tests can inject a fake
+// without spawning Python. Production implementation is
+// defaultTopStepLiveCloser, which shells out to close_topstep_position.py
+// via RunTopStepClose.
+type TopStepLiveCloser func(symbol string) (*TopStepCloseResult, error)
+
+// defaultTopStepLiveCloser is the production close implementation. Matches
+// the HL/OKX/Robinhood shape: stderr goes to os.Stderr (kill switch is a
+// system-level event, not strategy-scoped) and any non-nil err means the
+// close was NOT confirmed by the adapter so the kill switch must stay
+// latched.
+func defaultTopStepLiveCloser(symbol string) (*TopStepCloseResult, error) {
+	result, stderr, err := RunTopStepClose(topstepLiveCloseScript, symbol)
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, "[ts-close] %s stderr: %s\n", symbol, stderr)
+	}
+	return result, err
+}
+
+// TopStepPositionsFetcher fetches every open TopStep futures position on
+// the configured account. Exposed as a function type so tests can stub —
+// mirrors HLStateFetcher / OKXPositionsFetcher / RobinhoodPositionsFetcher.
+type TopStepPositionsFetcher func() ([]TopStepPosition, error)
+
+// defaultTopStepPositionsFetcher wraps fetch_topstep_positions.py for
+// production use. Python-side filters zero-size entries; forceCloseTopStepLive
+// also has a size==0 defense-in-depth layer.
+func defaultTopStepPositionsFetcher() ([]TopStepPosition, error) {
+	result, stderr, err := RunTopStepFetchPositions(topstepFetchPositionsScript)
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, "[ts-close] fetch_positions stderr: %s\n", stderr)
+	}
+	if err != nil {
+		return nil, err
+	}
+	positions := make([]TopStepPosition, 0, len(result.Positions))
+	for _, p := range result.Positions {
+		positions = append(positions, TopStepPosition{
+			Coin:     p.Coin,
+			Size:     p.Size,
+			AvgPrice: p.AvgPrice,
+			Side:     p.Side,
+		})
+	}
+	return positions, nil
+}
+
+// TopStepLiveCloseReport summarizes a forceCloseTopStepLive run. Mirrors
+// HyperliquidLiveCloseReport / OKXLiveCloseReport / RobinhoodLiveCloseReport
+// so the kill-switch plan can treat all platforms symmetrically. Errors is
+// the load-bearing correctness signal — ConfirmedFlat() returns true only
+// when it's empty.
+//
+// Unconfigured lists live positions for symbols no configured live TopStep
+// futures strategy trades. Computed here (rather than in the plan builder)
+// so the "which symbols is this scheduler authorized to touch" partition
+// has a single source of truth. The plan builder consumes Unconfigured
+// separately from ConfirmedFlat to decide whether to latch the kill
+// switch for manual intervention.
+type TopStepLiveCloseReport struct {
+	ClosedCoins  []string
+	AlreadyFlat  []string
+	Unconfigured []TopStepPosition
+	Errors       map[string]error
+}
+
+// ConfirmedFlat reports whether every configured live TopStep futures
+// symbol reached a terminal closed/flat state without errors. Mirrors
+// HL/OKX/Robinhood shape.
+func (r TopStepLiveCloseReport) ConfirmedFlat() bool {
+	return len(r.Errors) == 0
+}
+
+// SortedErrorCoins returns Errors keys in deterministic order for stable
+// log/Discord output. Go map iteration is randomized, so identical
+// kill-switch fires would otherwise produce different messages (caught in
+// #342 review for the HL report).
+func (r TopStepLiveCloseReport) SortedErrorCoins() []string {
+	coins := make([]string, 0, len(r.Errors))
+	for c := range r.Errors {
+		coins = append(coins, c)
+	}
+	sort.Strings(coins)
+	return coins
+}
+
+// forceCloseTopStepLive submits market-flatten orders for every non-zero
+// live TopStep futures position belonging to a symbol a configured live
+// TopStep strategy trades on this account. Mirrors forceCloseHyperliquidLive /
+// forceCloseOKXLive. TopStep's market_close endpoint flattens the full
+// contract count for the symbol — futures are whole-contract only, so no
+// client-side rounding is required.
+//
+// Pure / no state mutation. Caller mutates virtual state only when
+// report.ConfirmedFlat() is true.
+//
+// The ctx argument bounds the OVERALL close loop. Each individual closer
+// call has its own subprocess timeout (see RunPythonScript). Once ctx
+// expires, remaining unprocessed symbols are added to Errors so the kill
+// switch stays latched and retries next cycle.
+//
+// CME trading-hour restriction: fires outside RTH may fail with a venue
+// error (market closed). The latch-until-flat semantic handles this
+// naturally — the kill switch stays latched, logs the error, and the
+// next cycle retries. The operator sees the restriction in the Discord
+// message so there is no false-reassurance window.
+func forceCloseTopStepLive(ctx context.Context, positions []TopStepPosition, tsLiveAll []StrategyConfig, closer TopStepLiveCloser) TopStepLiveCloseReport {
+	report := TopStepLiveCloseReport{Errors: make(map[string]error)}
+
+	tradedCoins := make(map[string]bool)
+	for _, sc := range tsLiveAll {
+		if sc.Type != "futures" {
+			continue
+		}
+		sym := topstepSymbol(sc.Args)
+		if sym != "" {
+			tradedCoins[sym] = true
+		}
+	}
+
+	for _, p := range positions {
+		if !tradedCoins[p.Coin] {
+			// Unowned position — kill switch only acts on symbols this
+			// scheduler is configured to trade. Non-zero sizes are surfaced
+			// to the caller via Unconfigured so the plan can latch the
+			// switch and prompt manual intervention.
+			if p.Size != 0 {
+				report.Unconfigured = append(report.Unconfigured, p)
+			}
+			continue
+		}
+		if p.Size == 0 {
+			report.AlreadyFlat = append(report.AlreadyFlat, p.Coin)
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			report.Errors[p.Coin] = fmt.Errorf("close budget exhausted before submit: %w", err)
+			continue
+		}
+		if _, err := closer(p.Coin); err != nil {
+			report.Errors[p.Coin] = err
+			continue
+		}
+		report.ClosedCoins = append(report.ClosedCoins, p.Coin)
+	}
+
+	return report
+}

--- a/scheduler/topstep_close_test.go
+++ b/scheduler/topstep_close_test.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// forceCloseTopStepLive unit tests — mirror the Robinhood/OKX tests. Each
+// test asserts a single branch of the decision logic so a regression
+// produces a targeted failure rather than a conflated signal (#347).
+
+func TestForceCloseTopStepLive_ClosesOwnedSymbolsOnly(t *testing.T) {
+	tsLive := []StrategyConfig{
+		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
+			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
+	}
+	positions := []TopStepPosition{
+		{Coin: "ES", Size: 2, AvgPrice: 5000, Side: "long"},
+		{Coin: "NQ", Size: 1, AvgPrice: 17000, Side: "long"}, // unowned
+	}
+	var calls []string
+	closer := func(sym string) (*TopStepCloseResult, error) {
+		calls = append(calls, sym)
+		return &TopStepCloseResult{Close: &TopStepClose{Symbol: sym}}, nil
+	}
+
+	report := forceCloseTopStepLive(context.Background(), positions, tsLive, closer)
+
+	if !report.ConfirmedFlat() {
+		t.Errorf("expected ConfirmedFlat, got errors=%v", report.Errors)
+	}
+	if len(calls) != 1 || calls[0] != "ES" {
+		t.Errorf("expected closer to be called only for owned symbol ES, got %v", calls)
+	}
+	if len(report.ClosedCoins) != 1 || report.ClosedCoins[0] != "ES" {
+		t.Errorf("ClosedCoins = %v, want [ES]", report.ClosedCoins)
+	}
+	if len(report.Unconfigured) != 1 || report.Unconfigured[0].Coin != "NQ" {
+		t.Errorf("Unconfigured = %v, want [NQ]", report.Unconfigured)
+	}
+}
+
+func TestForceCloseTopStepLive_CloseErrorLatches(t *testing.T) {
+	tsLive := []StrategyConfig{
+		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
+			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
+	}
+	positions := []TopStepPosition{{Coin: "ES", Size: 2}}
+	closer := func(sym string) (*TopStepCloseResult, error) {
+		return nil, fmt.Errorf("topstepx 503")
+	}
+
+	report := forceCloseTopStepLive(context.Background(), positions, tsLive, closer)
+
+	if report.ConfirmedFlat() {
+		t.Fatal("expected NOT ConfirmedFlat on close error")
+	}
+	if _, ok := report.Errors["ES"]; !ok {
+		t.Errorf("expected ES in errors, got %v", report.Errors)
+	}
+}
+
+func TestForceCloseTopStepLive_ZeroSizeMarkedAlreadyFlat(t *testing.T) {
+	tsLive := []StrategyConfig{
+		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
+			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
+	}
+	positions := []TopStepPosition{{Coin: "ES", Size: 0}}
+	var calls []string
+	closer := func(sym string) (*TopStepCloseResult, error) {
+		calls = append(calls, sym)
+		return &TopStepCloseResult{}, nil
+	}
+
+	report := forceCloseTopStepLive(context.Background(), positions, tsLive, closer)
+
+	if len(calls) != 0 {
+		t.Errorf("zero-size position must short-circuit before closer, got calls=%v", calls)
+	}
+	if len(report.AlreadyFlat) != 1 || report.AlreadyFlat[0] != "ES" {
+		t.Errorf("AlreadyFlat = %v, want [ES]", report.AlreadyFlat)
+	}
+	if !report.ConfirmedFlat() {
+		t.Errorf("zero-size short-circuit must be ConfirmedFlat, got errors=%v", report.Errors)
+	}
+}
+
+func TestForceCloseTopStepLive_CtxExpiredBeforeSubmit(t *testing.T) {
+	tsLive := []StrategyConfig{
+		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
+			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
+	}
+	positions := []TopStepPosition{{Coin: "ES", Size: 2}}
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	cancel()
+	var calls []string
+	closer := func(sym string) (*TopStepCloseResult, error) {
+		calls = append(calls, sym)
+		return &TopStepCloseResult{}, nil
+	}
+
+	report := forceCloseTopStepLive(ctx, positions, tsLive, closer)
+
+	if len(calls) != 0 {
+		t.Errorf("closer must not be called after ctx expires, got %v", calls)
+	}
+	if _, ok := report.Errors["ES"]; !ok {
+		t.Errorf("expected ES to be marked as error on ctx expiry, got %v", report.Errors)
+	}
+}
+
+func TestForceCloseTopStepLive_ShortPositionClosed(t *testing.T) {
+	// Futures support bidirectional positions (unlike Robinhood crypto).
+	// A negative size (short) for an owned symbol must trigger a close —
+	// market_close flattens regardless of direction. Guards against a
+	// future refactor that copies Robinhood's Size > 0 check, which would
+	// leave shorts open on kill-switch fire.
+	tsLive := []StrategyConfig{
+		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
+			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
+	}
+	positions := []TopStepPosition{{Coin: "ES", Size: -2, Side: "short"}}
+	var calls []string
+	closer := func(sym string) (*TopStepCloseResult, error) {
+		calls = append(calls, sym)
+		return &TopStepCloseResult{Close: &TopStepClose{Symbol: sym}}, nil
+	}
+
+	report := forceCloseTopStepLive(context.Background(), positions, tsLive, closer)
+
+	if len(calls) != 1 || calls[0] != "ES" {
+		t.Errorf("short must trigger close, got calls=%v", calls)
+	}
+	if !report.ConfirmedFlat() {
+		t.Errorf("successful short close must be ConfirmedFlat, got errors=%v", report.Errors)
+	}
+}
+
+func TestForceCloseTopStepLive_NonFuturesStrategiesIgnored(t *testing.T) {
+	// Non-futures entries in TSLiveAll must not drive closes (type partition
+	// guard). Mirrors the options-ignored test on the Robinhood close path.
+	mixed := []StrategyConfig{
+		{ID: "hl-mom-btc", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"momentum", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []TopStepPosition{{Coin: "ES", Size: 2}}
+	var calls []string
+	closer := func(sym string) (*TopStepCloseResult, error) {
+		calls = append(calls, sym)
+		return &TopStepCloseResult{}, nil
+	}
+
+	report := forceCloseTopStepLive(context.Background(), positions, mixed, closer)
+
+	if len(calls) != 0 {
+		t.Errorf("non-futures strategy must not drive TopStep close, got calls=%v", calls)
+	}
+	if len(report.Unconfigured) != 1 || report.Unconfigured[0].Coin != "ES" {
+		t.Errorf("unowned ES must be Unconfigured, got %+v", report.Unconfigured)
+	}
+}
+
+// SortedErrorCoins determinism — same rationale as HL / OKX / Robinhood.
+func TestTopStepLiveCloseReport_SortedErrorCoins(t *testing.T) {
+	r := TopStepLiveCloseReport{Errors: map[string]error{
+		"NQ": fmt.Errorf("e"), "ES": fmt.Errorf("e"), "CL": fmt.Errorf("e"),
+	}}
+	coins := r.SortedErrorCoins()
+	want := []string{"CL", "ES", "NQ"}
+	if len(coins) != len(want) {
+		t.Fatalf("len = %d, want %d", len(coins), len(want))
+	}
+	for i, c := range coins {
+		if c != want[i] {
+			t.Errorf("coins[%d] = %q, want %q", i, c, want[i])
+		}
+	}
+}
+
+// parseTopStepCloseOutput tests — 5-case matrix mirroring HL / OKX / Robinhood.
+
+func TestParseTopStepCloseOutput_CleanSuccess(t *testing.T) {
+	stdout := []byte(`{"close":{"symbol":"ES","fill":{"avg_px":5000,"total_contracts":2,"oid":"ord-1"}},"platform":"topstep","timestamp":"2026-04-19T10:00:00Z"}`)
+	result, _, err := parseTopStepCloseOutput(stdout, "", nil)
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if result == nil || result.Close == nil || result.Close.Symbol != "ES" {
+		t.Errorf("unexpected result: %+v", result)
+	}
+	if result.Close.Fill == nil || result.Close.Fill.TotalContracts != 2 {
+		t.Errorf("Fill = %+v, want TotalContracts=2", result.Close.Fill)
+	}
+}
+
+func TestParseTopStepCloseOutput_Exit0WithErrorField(t *testing.T) {
+	stdout := []byte(`{"close":{"symbol":"ES","fill":{}},"platform":"topstep","timestamp":"x","error":"venue down"}`)
+	_, _, err := parseTopStepCloseOutput(stdout, "", nil)
+	if err == nil {
+		t.Fatal("expected non-nil err when error field populated, even on exit 0")
+	}
+}
+
+func TestParseTopStepCloseOutput_ExitNonZeroWithErrorEnvelope(t *testing.T) {
+	stdout := []byte(`{"close":{"symbol":"ES","fill":{}},"platform":"topstep","timestamp":"x","error":"market closed"}`)
+	_, _, err := parseTopStepCloseOutput(stdout, "", fmt.Errorf("exit 1"))
+	if err == nil {
+		t.Fatal("expected non-nil err on error envelope")
+	}
+}
+
+func TestParseTopStepCloseOutput_ExitNonZeroNoErrorField(t *testing.T) {
+	stdout := []byte(`{"close":{"symbol":"ES","fill":{}},"platform":"topstep","timestamp":"x"}`)
+	_, _, err := parseTopStepCloseOutput(stdout, "stderr msg", fmt.Errorf("exit 2"))
+	if err == nil {
+		t.Fatal("expected non-nil err on non-zero exit with no error field")
+	}
+}
+
+func TestParseTopStepCloseOutput_MalformedJSON(t *testing.T) {
+	result, _, err := parseTopStepCloseOutput([]byte(`not json`), "", nil)
+	if err == nil {
+		t.Fatal("expected non-nil err on malformed JSON")
+	}
+	if result != nil {
+		t.Errorf("expected nil result on parse failure, got %+v", result)
+	}
+}
+
+// parseTopStepPositionsOutput tests.
+
+func TestParseTopStepPositionsOutput_CleanSuccess(t *testing.T) {
+	stdout := []byte(`{"positions":[{"coin":"ES","size":2,"avg_price":5000,"side":"long"}],"platform":"topstep","timestamp":"x"}`)
+	result, _, err := parseTopStepPositionsOutput(stdout, "", nil)
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if len(result.Positions) != 1 || result.Positions[0].Coin != "ES" {
+		t.Errorf("unexpected positions: %+v", result.Positions)
+	}
+	if result.Positions[0].Size != 2 {
+		t.Errorf("Size = %d, want 2", result.Positions[0].Size)
+	}
+}
+
+func TestParseTopStepPositionsOutput_ErrorEnvelopeLatchesSwitch(t *testing.T) {
+	// Load-bearing contract: a failed fetch must surface as err so the kill
+	// switch latches. A silent parse that returned {Positions: nil, err: nil}
+	// would look like "no positions" and clear virtual state while live
+	// exposure remained (the #341/#345/#346 bug class, now #347).
+	stdout := []byte(`{"positions":[],"platform":"topstep","timestamp":"x","error":"credentials missing"}`)
+	_, _, err := parseTopStepPositionsOutput(stdout, "", fmt.Errorf("exit 1"))
+	if err == nil {
+		t.Fatal("expected non-nil err when error envelope populated")
+	}
+}
+
+func TestParseTopStepPositionsOutput_MalformedJSON(t *testing.T) {
+	_, _, err := parseTopStepPositionsOutput([]byte(`garbage`), "", nil)
+	if err == nil {
+		t.Fatal("expected non-nil err on malformed JSON")
+	}
+}

--- a/shared_scripts/close_topstep_position.py
+++ b/shared_scripts/close_topstep_position.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+TopStep emergency position close script (issue #347).
+
+Submits a market-flatten order for a single futures symbol via the TopStep
+adapter's ``market_close`` REST endpoint. Used by the portfolio kill switch
+in the Go scheduler to liquidate live futures exposure regardless of which
+strategy "owns" the position. Mirrors ``close_hyperliquid_position.py`` /
+``close_okx_position.py`` / ``close_robinhood_position.py`` so the Go
+caller's parser contract is symmetric across platforms.
+
+TopStep-specific notes:
+  * CME futures use whole-contract sizing — the adapter's ``market_close``
+    endpoint flattens the full contract count for the symbol, no client-side
+    rounding required.
+  * CME trading-hour restrictions apply. Kill-switch fires outside RTH may
+    fail with a venue error; the latch-until-flat semantic handles this
+    naturally (retries until in-hours).
+
+Usage:
+    close_topstep_position.py --symbol=ES --mode=live
+
+Live mode is required (kill switch is meaningful only against real
+positions). Stdout is always a single JSON envelope matching the shape of
+the other close scripts:
+``{"close": {"symbol": ..., "fill": {...}}, "platform": "topstep",
+  "timestamp": ..., "error": "..."}``
+
+The kill switch must NEVER report success unless the position is actually
+flattened. Credential errors, HTTP failures, and unexpected REST responses
+all exit 1 with a populated ``error`` field so the Go caller latches the
+kill switch and retries next cycle.
+"""
+
+import argparse
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "platforms", "topstep"))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--symbol", required=True)
+    parser.add_argument("--mode", default="live")
+    args = parser.parse_args()
+
+    if args.mode != "live":
+        print(json.dumps({
+            "close": None,
+            "platform": "topstep",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "error": "--mode=live required for emergency close",
+        }))
+        sys.exit(1)
+
+    try:
+        from adapter import TopStepExchangeAdapter
+        adapter = TopStepExchangeAdapter(mode="live")
+        if not adapter.is_live:
+            _emit_error(args.symbol, "TopStep adapter not live — set TOPSTEP_API_KEY / TOPSTEP_API_SECRET / TOPSTEP_ACCOUNT_ID")
+            return
+
+        result = adapter.market_close(args.symbol)
+    except Exception as e:
+        traceback.print_exc(file=sys.stderr)
+        _emit_error(args.symbol, str(e))
+        return
+
+    if not isinstance(result, dict):
+        _emit_error(args.symbol, f"unexpected adapter response type {type(result).__name__}: {result!r}")
+        return
+
+    # TopStepX order/close endpoints surface an explicit status. Anything
+    # other than "ok"/"filled"/absent is a venue rejection — must not be
+    # read as confirmation. An empty dict is likewise ambiguous (#346
+    # pattern: never map "no signal" to success).
+    status = (result.get("status") or "").lower()
+    if status and status not in ("ok", "filled", "accepted"):
+        _emit_error(args.symbol, f"venue status={result.get('status')!r}: {result}")
+        return
+    if not result and status == "":
+        _emit_error(args.symbol, "empty order response from TopStepX market_close")
+        return
+
+    # Best-effort fill telemetry. TopStepX fields mirror the execute path.
+    fill = {}
+    try:
+        filled_qty = result.get("filledQuantity") or result.get("quantity")
+        if filled_qty is not None:
+            fill["total_contracts"] = int(filled_qty)
+    except (TypeError, ValueError):
+        pass
+    try:
+        avg = result.get("avgPrice") or result.get("averagePrice")
+        if avg is not None:
+            fill["avg_px"] = float(avg)
+    except (TypeError, ValueError):
+        pass
+    oid = result.get("orderId") or result.get("id")
+    if oid is not None:
+        fill["oid"] = str(oid)
+
+    _emit_success(args.symbol, fill)
+
+
+def _emit_success(symbol, fill):
+    print(json.dumps({
+        "close": {"symbol": symbol, "fill": fill},
+        "platform": "topstep",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }))
+
+
+def _emit_error(symbol, message):
+    print(json.dumps({
+        "close": {"symbol": symbol, "fill": {}},
+        "platform": "topstep",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "error": message,
+    }))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/shared_scripts/fetch_topstep_positions.py
+++ b/shared_scripts/fetch_topstep_positions.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+TopStep live positions fetcher (issue #347).
+
+Fetches every open TopStep futures position on the configured account and
+emits a JSON list to stdout. Used by the portfolio kill switch in the Go
+scheduler to decide which symbols need market-flattens — mirrors
+``fetch_okx_positions.py`` / ``fetch_robinhood_positions.py``. Requires
+live credentials (TopStepX REST API); there is no public unauthenticated
+endpoint.
+
+Usage:
+    fetch_topstep_positions.py
+
+Requires TOPSTEP_API_KEY / TOPSTEP_API_SECRET / TOPSTEP_ACCOUNT_ID.
+Output:
+``{"positions": [{"coin": "ES", "size": 2, "avg_price": 5000.0, "side": "long"}, ...],
+  "platform": "topstep", "timestamp": ...}``
+Size is signed (positive=long, negative=short) — mirrors OKX/HL so the
+Go-side kill-switch parser contract stays symmetric. Zero-size entries
+are filtered upstream, but forceCloseTopStepLive has its own size==0
+defense-in-depth.
+"""
+
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "platforms", "topstep"))
+
+
+def main():
+    try:
+        from adapter import TopStepExchangeAdapter
+        adapter = TopStepExchangeAdapter(mode="live")
+        if not adapter.is_live:
+            _emit_error("TopStep adapter not live — set TOPSTEP_API_KEY / TOPSTEP_API_SECRET / TOPSTEP_ACCOUNT_ID")
+            return
+        raw = adapter.get_open_positions()
+    except Exception as e:
+        traceback.print_exc(file=sys.stderr)
+        _emit_error(str(e))
+        return
+
+    positions = []
+    for p in raw or []:
+        symbol = (p.get("symbol") or "").upper()
+        if not symbol:
+            continue
+        try:
+            qty = int(p.get("quantity") or 0)
+        except (TypeError, ValueError):
+            continue
+        if qty == 0:
+            continue
+        try:
+            avg_price = float(p.get("avg_price") or 0)
+        except (TypeError, ValueError):
+            avg_price = 0.0
+        side = (p.get("side") or ("long" if qty > 0 else "short")).lower()
+        positions.append({
+            "coin": symbol,
+            "size": qty,
+            "avg_price": avg_price,
+            "side": side,
+        })
+
+    print(json.dumps({
+        "positions": positions,
+        "platform": "topstep",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }))
+
+
+def _emit_error(message):
+    print(json.dumps({
+        "positions": [],
+        "platform": "topstep",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "error": message,
+    }))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/shared_scripts/fetch_topstep_positions.py
+++ b/shared_scripts/fetch_topstep_positions.py
@@ -39,7 +39,7 @@ def main():
         if not adapter.is_live:
             _emit_error("TopStep adapter not live — set TOPSTEP_API_KEY / TOPSTEP_API_SECRET / TOPSTEP_ACCOUNT_ID")
             return
-        raw = adapter.get_open_positions()
+        raw = adapter.get_open_positions_raise()
     except Exception as e:
         traceback.print_exc(file=sys.stderr)
         _emit_error(str(e))

--- a/shared_scripts/test_fetch_topstep_positions.py
+++ b/shared_scripts/test_fetch_topstep_positions.py
@@ -1,0 +1,182 @@
+"""Tests for fetch_topstep_positions.py — live-account position fetcher
+used by the portfolio kill switch (#347).
+
+Critical invariant: auth / network failures on TopStepX MUST produce an
+error envelope (exit 1, "error" key populated, positions empty). If the
+script silently reports an empty position list on a transient 5xx or an
+expired token, the kill switch would clear virtual state while live CME
+exposure survived — the exact #341/#342 bug class this feature is meant
+to close, just shifted into the fetch path.
+"""
+
+import builtins
+import importlib.util
+import json
+import os
+import sys
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _run_script(positions_or_exc, is_live=True, use_raise=True):
+    """Invoke fetch_topstep_positions.main() with a mocked adapter.
+
+    positions_or_exc may be either a list (returned by
+    adapter.get_open_positions_raise) or an Exception. Returns
+    (parsed_stdout_json, exit_code).
+    """
+    script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               "fetch_topstep_positions.py")
+    spec = importlib.util.spec_from_file_location("fetch_topstep_positions", script_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    mock_adapter_cls = MagicMock()
+    mock_adapter = MagicMock()
+    mock_adapter.is_live = is_live
+    mock_adapter_cls.return_value = mock_adapter
+    target = mock_adapter.get_open_positions_raise if use_raise else mock_adapter.get_open_positions
+    if isinstance(positions_or_exc, Exception):
+        target.side_effect = positions_or_exc
+    else:
+        target.return_value = positions_or_exc
+
+    captured = StringIO()
+    exit_code = {"value": 0}
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "adapter":
+            fake_mod = MagicMock()
+            fake_mod.TopStepExchangeAdapter = mock_adapter_cls
+            return fake_mod
+        return original_import(name, *args, **kwargs)
+
+    def mock_exit(code=0):
+        exit_code["value"] = code
+        raise SystemExit(code)
+
+    with patch("builtins.__import__", side_effect=mock_import), \
+         patch("sys.stdout", captured), \
+         patch("sys.argv", ["fetch_topstep_positions.py"]), \
+         patch.object(mod.sys, "exit", side_effect=mock_exit):
+        try:
+            mod.main()
+        except SystemExit:
+            pass
+
+    raw = captured.getvalue().strip()
+    parsed = json.loads(raw) if raw else {}
+    return parsed, exit_code["value"]
+
+
+class TestSuccess:
+    def test_long_position(self):
+        out, code = _run_script([
+            {"symbol": "ES", "quantity": 2, "avg_price": 5000.0, "side": "long"},
+        ])
+        assert code == 0
+        assert len(out["positions"]) == 1
+        p = out["positions"][0]
+        assert p["coin"] == "ES"
+        assert p["size"] == 2
+        assert p["avg_price"] == 5000.0
+        assert p["side"] == "long"
+        assert "error" not in out
+
+    def test_short_position_size_is_negative(self):
+        """Short positions must carry a negative signed size so the Go
+        kill switch parser can infer direction identically to HL/OKX."""
+        out, code = _run_script([
+            {"symbol": "NQ", "quantity": -1, "avg_price": 18000.0, "side": "short"},
+        ])
+        assert code == 0
+        assert out["positions"][0]["size"] == -1
+        assert out["positions"][0]["side"] == "short"
+
+    def test_zero_size_filtered(self):
+        out, code = _run_script([
+            {"symbol": "ES", "quantity": 0, "avg_price": 5000.0, "side": "long"},
+        ])
+        assert code == 0
+        assert out["positions"] == []
+
+    def test_empty_positions(self):
+        out, code = _run_script([])
+        assert code == 0
+        assert out["positions"] == []
+        assert "error" not in out
+
+
+class TestFailurePaths:
+    def test_non_live_adapter(self):
+        out, code = _run_script([], is_live=False)
+        assert code == 1
+        assert "TOPSTEP_API_KEY" in out["error"]
+
+    def test_exchange_raises_401(self):
+        """Auth failure (rotated/revoked token) must surface as an error
+        envelope, not an empty success. Regression guard for the review
+        comment on PR #351: the old code called the soft-fail
+        get_open_positions() which swallowed every exception."""
+        out, code = _run_script(RuntimeError("401 Unauthorized"))
+        assert code == 1
+        assert "401" in out["error"]
+        assert out["positions"] == []
+
+    def test_exchange_raises_5xx(self):
+        out, code = _run_script(RuntimeError("TopStepX 503 Service Unavailable"))
+        assert code == 1
+        assert "503" in out["error"]
+        assert out["positions"] == []
+
+    def test_network_error(self):
+        out, code = _run_script(ConnectionError("DNS resolution failed"))
+        assert code == 1
+        assert "DNS" in out["error"]
+        assert out["positions"] == []
+
+    def test_uses_raise_variant_not_soft_fail(self):
+        """The script MUST call get_open_positions_raise (re-raises on
+        failure) rather than get_open_positions (returns []). If a future
+        refactor switches back to the soft-fail method, this test will
+        catch it because the raise-variant mock will be untouched and
+        the exception never fires."""
+        script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                   "fetch_topstep_positions.py")
+        spec = importlib.util.spec_from_file_location("fetch_topstep_positions", script_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        mock_adapter_cls = MagicMock()
+        mock_adapter = MagicMock()
+        mock_adapter.is_live = True
+        mock_adapter_cls.return_value = mock_adapter
+        mock_adapter.get_open_positions_raise.return_value = []
+        mock_adapter.get_open_positions.side_effect = AssertionError(
+            "fetch_topstep_positions must use get_open_positions_raise, not get_open_positions"
+        )
+
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "adapter":
+                fake_mod = MagicMock()
+                fake_mod.TopStepExchangeAdapter = mock_adapter_cls
+                return fake_mod
+            return original_import(name, *args, **kwargs)
+
+        captured = StringIO()
+        with patch("builtins.__import__", side_effect=mock_import), \
+             patch("sys.stdout", captured), \
+             patch("sys.argv", ["fetch_topstep_positions.py"]):
+            mod.main()
+
+        assert mock_adapter.get_open_positions_raise.called
+        assert not mock_adapter.get_open_positions.called
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes #347

Mirrors the #342 Hyperliquid fix and #345/#346 OKX/Robinhood fixes: the portfolio kill switch now fetches live TopStep positions, submits market-flatten orders via the TopStepX adapter, and only clears virtual state when every configured live symbol is confirmed flat. Previously `forceCloseAllPositions` mutated virtual state while CME exposure survived untouched until an operator manually intervened.

## Test plan
- [ ] `go test ./...` passes locally (done)
- [ ] `python3 -m py_compile` passes for new scripts (done)
- [ ] Manual: fire kill switch with live TopStep ES position → confirm flatten submitted and Discord message lists "TopStep closes: [ES]"
- [ ] Manual: fire kill switch outside RTH → confirm latch-until-flat retries next cycle with clear error message

🤖 Generated with [Claude Code](https://claude.ai/code)