### PR TITLE
Kill-switch cross-platform hardening (#350)

### DIFF
--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -234,9 +234,15 @@ type HyperliquidCloseFill struct {
 }
 
 // HyperliquidClose is the close block from close_hyperliquid_position.py.
+// AlreadyFlat is set by the Python script when the SDK reports an empty
+// statuses list (no position to close at submit time, eventual-consistency
+// window after the Go-side fetch). The Go side reads this to route the
+// outcome through AlreadyFlat instead of ClosedCoins so operator messaging
+// distinguishes "we sent a close order" from "nothing to close" (#350).
 type HyperliquidClose struct {
-	Symbol string                `json:"symbol"`
-	Fill   *HyperliquidCloseFill `json:"fill,omitempty"`
+	Symbol      string                `json:"symbol"`
+	Fill        *HyperliquidCloseFill `json:"fill,omitempty"`
+	AlreadyFlat bool                  `json:"already_flat,omitempty"`
 }
 
 // HyperliquidCloseResult is the top-level JSON from close_hyperliquid_position.py.
@@ -696,10 +702,14 @@ type OKXCloseFill struct {
 	Fee     float64 `json:"fee,omitempty"`
 }
 
-// OKXClose is the close block from close_okx_position.py.
+// OKXClose is the close block from close_okx_position.py. AlreadyFlat is
+// set by the Python script when adapter.market_close returns {} (adapter
+// found no open position at submit time, eventual-consistency window
+// after the Go-side fetch). See HyperliquidClose for the reasoning (#350).
 type OKXClose struct {
-	Symbol string        `json:"symbol"`
-	Fill   *OKXCloseFill `json:"fill,omitempty"`
+	Symbol      string        `json:"symbol"`
+	Fill        *OKXCloseFill `json:"fill,omitempty"`
+	AlreadyFlat bool          `json:"already_flat,omitempty"`
 }
 
 // OKXCloseResult is the top-level JSON from close_okx_position.py.
@@ -833,9 +843,13 @@ type RobinhoodCloseFill struct {
 }
 
 // RobinhoodClose is the close block from close_robinhood_position.py.
+// AlreadyFlat is set by the Python script when adapter.get_crypto_positions
+// returns qty<=0 at submit time (eventual-consistency window after the
+// Go-side fetch). See HyperliquidClose for the reasoning (#350).
 type RobinhoodClose struct {
-	Symbol string              `json:"symbol"`
-	Fill   *RobinhoodCloseFill `json:"fill,omitempty"`
+	Symbol      string              `json:"symbol"`
+	Fill        *RobinhoodCloseFill `json:"fill,omitempty"`
+	AlreadyFlat bool                `json:"already_flat,omitempty"`
 }
 
 // RobinhoodCloseResult is the top-level JSON from close_robinhood_position.py.

--- a/scheduler/executor_test.go
+++ b/scheduler/executor_test.go
@@ -413,6 +413,24 @@ func TestParseHyperliquidCloseOutput_MalformedJSON(t *testing.T) {
 	}
 }
 
+// already_flat field round-trips through the parser so the Go-side
+// AlreadyFlat routing has the signal it needs (#350). Without this, a
+// silent struct-tag regression would make every adapter-side already-flat
+// case fall back to ClosedCoins.
+func TestParseHyperliquidCloseOutput_AlreadyFlatFieldParsed(t *testing.T) {
+	stdout := []byte(`{"close":{"symbol":"ETH","fill":{},"already_flat":true},"platform":"hyperliquid","timestamp":"x"}`)
+	result, _, err := parseHyperliquidCloseOutput(stdout, "", nil)
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if result == nil || result.Close == nil {
+		t.Fatalf("expected populated result.Close, got %+v", result)
+	}
+	if !result.Close.AlreadyFlat {
+		t.Errorf("AlreadyFlat = false, want true — Go side cannot route to AlreadyFlat slice without this field")
+	}
+}
+
 // ── OKX close parser tests (#345) ──────────────────────────────────────
 // Same 5-case matrix as parseHyperliquidCloseOutput — mirrors the HL tests
 // one-to-one because the two parsers implement the same contract. Any
@@ -471,6 +489,20 @@ func TestParseOKXCloseOutput_Exit1WithoutErrorField(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no error field") {
 		t.Errorf("err message should mention missing error field, got %v", err)
+	}
+}
+
+func TestParseOKXCloseOutput_AlreadyFlatFieldParsed(t *testing.T) {
+	stdout := []byte(`{"close":{"symbol":"BTC","fill":{},"already_flat":true},"platform":"okx","timestamp":"x"}`)
+	result, _, err := parseOKXCloseOutput(stdout, "", nil)
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if result == nil || result.Close == nil {
+		t.Fatalf("expected populated result.Close, got %+v", result)
+	}
+	if !result.Close.AlreadyFlat {
+		t.Errorf("AlreadyFlat = false, want true (#350)")
 	}
 }
 

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -563,8 +563,18 @@ func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLi
 			report.Errors[p.Coin] = fmt.Errorf("close budget exhausted before submit: %w", err)
 			continue
 		}
-		if _, err := closer(p.Coin); err != nil {
+		result, err := closer(p.Coin)
+		if err != nil {
 			report.Errors[p.Coin] = err
+			continue
+		}
+		// Adapter may report already_flat when its own pre-submit position
+		// check finds nothing to close (eventual-consistency window between
+		// the Go-side fetch and the close submit). Route through AlreadyFlat
+		// so operator messaging accurately distinguishes "we sent a close
+		// order" from "nothing to close" (#350).
+		if result != nil && result.Close != nil && result.Close.AlreadyFlat {
+			report.AlreadyFlat = append(report.AlreadyFlat, p.Coin)
 			continue
 		}
 		report.ClosedCoins = append(report.ClosedCoins, p.Coin)

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -483,7 +483,13 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 // so future readers see the predicate spelled out.
 type HyperliquidLiveCloseReport struct {
 	ClosedCoins []string
-	AlreadyFlat []string // unreachable in production (see forceCloseHyperliquidLive); kept as defense-in-depth
+	// AlreadyFlat is set from two sources: the pre-submit szi==0 short-circuit
+	// in forceCloseHyperliquidLive (defense-in-depth — FetchHyperliquidPositions
+	// pre-filters szi≠0, so this branch should not fire in production) AND the
+	// adapter-side already_flat envelope flag, which IS production-reachable
+	// when the eventual-consistency window between the Go-side fetch and the
+	// SDK submit lets a position close out from under us (#350).
+	AlreadyFlat []string
 	// Errors is non-nil so coin-keyed writes don't panic; len() works on nil maps too.
 	Errors map[string]error
 }

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1367,3 +1367,40 @@ func TestForceCloseHyperliquidLive_EmptyInputs(t *testing.T) {
 		t.Errorf("expected empty report, got %+v", report)
 	}
 }
+
+// Adapter-side AlreadyFlat: closer returns success with already_flat=true
+// (eventual-consistency window — Go-side fetch saw non-zero szi, but by
+// the time the SDK submitted, the position was already flat). The coin
+// must land in AlreadyFlat, NOT ClosedCoins, so operator messaging
+// distinguishes "we sent a close order" from "nothing to close" (#350).
+func TestForceCloseHyperliquidLive_AdapterAlreadyFlatRoutedCorrectly(t *testing.T) {
+	hlLiveAll := []StrategyConfig{
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 3000}}
+
+	var calls []string
+	closer := func(symbol string) (*HyperliquidCloseResult, error) {
+		calls = append(calls, symbol)
+		return &HyperliquidCloseResult{
+			Close:    &HyperliquidClose{Symbol: symbol, AlreadyFlat: true},
+			Platform: "hyperliquid",
+		}, nil
+	}
+
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer)
+
+	if len(report.Errors) != 0 {
+		t.Errorf("expected no errors, got %v", report.Errors)
+	}
+	if len(report.ClosedCoins) != 0 {
+		t.Errorf("ClosedCoins should be empty when adapter reports already_flat, got %v", report.ClosedCoins)
+	}
+	if len(report.AlreadyFlat) != 1 || report.AlreadyFlat[0] != "ETH" {
+		t.Errorf("AlreadyFlat = %v, want [ETH]", report.AlreadyFlat)
+	}
+	if len(calls) != 1 || calls[0] != "ETH" {
+		t.Errorf("closer should still be called once (Go side saw non-zero szi), got %v", calls)
+	}
+}

--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -79,9 +79,9 @@ type KillSwitchCloseInputs struct {
 	// extra headroom.
 	CloseTimeout time.Duration
 
-	// Per-platform overrides. Zero means "use CloseTimeout". A minimum
-	// guarantee ensures one slow platform's budget cannot starve the others
-	// — each platform's context is independent.
+	// Per-platform overrides. Zero means "use CloseTimeout". Each platform's
+	// context is independent so one slow platform's budget cannot starve
+	// the others.
 	HLCloseTimeout  time.Duration
 	OKXCloseTimeout time.Duration
 	RHCloseTimeout  time.Duration

--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -69,7 +69,34 @@ type KillSwitchCloseInputs struct {
 	TSFetcher TopStepPositionsFetcher
 
 	PortfolioReason string
-	CloseTimeout    time.Duration
+
+	// CloseTimeout is the default per-platform close-budget when a
+	// platform-specific override is unset (zero). Each platform gets its
+	// OWN context.WithTimeout — they do not share a single budget — but a
+	// single tunable here was insufficient for platforms with very different
+	// per-call costs (Robinhood adds TOTP login overhead per submit). The
+	// per-platform fields below let the caller widen RH without giving HL
+	// extra headroom.
+	CloseTimeout time.Duration
+
+	// Per-platform overrides. Zero means "use CloseTimeout". A minimum
+	// guarantee ensures one slow platform's budget cannot starve the others
+	// — each platform's context is independent.
+	HLCloseTimeout  time.Duration
+	OKXCloseTimeout time.Duration
+	RHCloseTimeout  time.Duration
+	TSCloseTimeout  time.Duration
+}
+
+// platformCloseBudget returns the effective close-budget for a platform,
+// preferring the per-platform override and falling back to CloseTimeout.
+// Centralized so a future "minimum 30s per platform" floor lives in one
+// place rather than four switch arms.
+func (in KillSwitchCloseInputs) platformCloseBudget(override time.Duration) time.Duration {
+	if override > 0 {
+		return override
+	}
+	return in.CloseTimeout
 }
 
 // KillSwitchClosePlan is the output of planKillSwitchClose — everything the
@@ -181,21 +208,32 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 	// from config while the wallet still holds positions from a previous
 	// deploy or manual trade. Kill switch must not report "no exposure"
 	// without actually checking (#341 review, false-reassurance case).
-	if !hlStateFetched && in.HLAddr != "" && in.HLFetcher != nil {
-		pos, err := in.HLFetcher(in.HLAddr)
-		if err != nil {
+	if !hlStateFetched && in.HLAddr != "" {
+		switch {
+		case in.HLFetcher != nil:
+			pos, err := in.HLFetcher(in.HLAddr)
+			if err != nil {
+				plan.LogLines = append(plan.LogLines,
+					fmt.Sprintf("[CRITICAL] hl-close: kill switch unable to fetch HL state: %v — cannot confirm on-chain flat", err))
+				plan.OnChainConfirmedFlat = false
+			} else {
+				hlPositions = pos
+				hlStateFetched = true
+			}
+		default:
+			// Defense-in-depth: production wires HLFetcher in main.go, but a
+			// future regression that drops the assignment would otherwise
+			// silently bypass the kill switch (false-reassurance, latch
+			// stays clear). Latch and log instead. (#350)
 			plan.LogLines = append(plan.LogLines,
-				fmt.Sprintf("[CRITICAL] hl-close: kill switch unable to fetch HL state: %v — cannot confirm on-chain flat", err))
+				"[CRITICAL] hl-close: HLAddr configured but HLFetcher unwired — cannot confirm on-chain flat (kill switch will retry next cycle)")
 			plan.OnChainConfirmedFlat = false
-		} else {
-			hlPositions = pos
-			hlStateFetched = true
 		}
 	}
 
 	switch {
 	case hlStateFetched && len(in.HLLiveAll) > 0:
-		ctx, cancel := context.WithTimeout(context.Background(), in.CloseTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), in.platformCloseBudget(in.HLCloseTimeout))
 		plan.CloseReport = forceCloseHyperliquidLive(ctx, hlPositions, in.HLLiveAll, in.HLCloser)
 		cancel()
 		if !plan.CloseReport.ConfirmedFlat() {
@@ -241,14 +279,22 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 	// Perps: always attempt fetch when there's a perps strategy or fetcher
 	// — mirrors the HL opportunistic-fetch guard. Unlike HL there is no
 	// pre-fetch to reuse; OKX always requires a subprocess round-trip.
-	if len(in.OKXLiveAllPerps) > 0 && in.OKXFetcher != nil {
+	switch {
+	case len(in.OKXLiveAllPerps) > 0 && in.OKXFetcher == nil:
+		// Defense-in-depth (#350): a future main.go regression that drops
+		// OKXFetcher would otherwise silently skip OKX and clear virtual
+		// state with on-chain exposure live. Latch and log.
+		plan.LogLines = append(plan.LogLines,
+			"[CRITICAL] okx-close: OKX live perps strategies configured but OKXFetcher unwired — cannot confirm on-chain flat (kill switch will retry next cycle)")
+		plan.OnChainConfirmedFlat = false
+	case len(in.OKXLiveAllPerps) > 0:
 		okxPositions, err := in.OKXFetcher()
 		if err != nil {
 			plan.LogLines = append(plan.LogLines,
 				fmt.Sprintf("[CRITICAL] okx-close: kill switch unable to fetch OKX positions: %v — cannot confirm on-chain flat", err))
 			plan.OnChainConfirmedFlat = false
 		} else {
-			ctx, cancel := context.WithTimeout(context.Background(), in.CloseTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), in.platformCloseBudget(in.OKXCloseTimeout))
 			plan.OKXCloseReport = forceCloseOKXLive(ctx, okxPositions, in.OKXLiveAllPerps, in.OKXCloser)
 			cancel()
 			if !plan.OKXCloseReport.ConfirmedFlat() {
@@ -297,14 +343,22 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 	// — mirrors the OKX opportunistic-fetch guard. Robinhood has no
 	// pre-fetch to reuse; every cycle requires a subprocess round-trip
 	// (TOTP-authenticated).
-	if len(in.RHLiveCrypto) > 0 && in.RHFetcher != nil {
+	switch {
+	case len(in.RHLiveCrypto) > 0 && in.RHFetcher == nil:
+		// Defense-in-depth (#350): a future main.go regression that drops
+		// RHFetcher would otherwise silently skip Robinhood and clear
+		// virtual state with on-account exposure live. Latch and log.
+		plan.LogLines = append(plan.LogLines,
+			"[CRITICAL] rh-close: Robinhood live crypto strategies configured but RHFetcher unwired — cannot confirm flat (kill switch will retry next cycle)")
+		plan.OnChainConfirmedFlat = false
+	case len(in.RHLiveCrypto) > 0:
 		rhPositions, err := in.RHFetcher()
 		if err != nil {
 			plan.LogLines = append(plan.LogLines,
 				fmt.Sprintf("[CRITICAL] rh-close: kill switch unable to fetch Robinhood positions: %v — cannot confirm flat", err))
 			plan.OnChainConfirmedFlat = false
 		} else {
-			ctx, cancel := context.WithTimeout(context.Background(), in.CloseTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), in.platformCloseBudget(in.RHCloseTimeout))
 			plan.RHCloseReport = forceCloseRobinhoodLive(ctx, rhPositions, in.RHLiveCrypto, in.RHCloser)
 			cancel()
 			if !plan.RHCloseReport.ConfirmedFlat() {
@@ -343,14 +397,22 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 	// CME trading-hour restriction: fires outside RTH will surface a venue
 	// error here, latching the kill switch until the next in-hours cycle.
 	// This is the correct behavior — do not attempt to bypass the venue.
-	if len(in.TSLiveAll) > 0 && in.TSFetcher != nil {
+	switch {
+	case len(in.TSLiveAll) > 0 && in.TSFetcher == nil:
+		// Defense-in-depth (#350): a future main.go regression that drops
+		// TSFetcher would otherwise silently skip TopStep and clear virtual
+		// state with on-account exposure live. Latch and log.
+		plan.LogLines = append(plan.LogLines,
+			"[CRITICAL] ts-close: TopStep live futures strategies configured but TSFetcher unwired — cannot confirm flat (kill switch will retry next cycle)")
+		plan.OnChainConfirmedFlat = false
+	case len(in.TSLiveAll) > 0:
 		tsPositions, err := in.TSFetcher()
 		if err != nil {
 			plan.LogLines = append(plan.LogLines,
 				fmt.Sprintf("[CRITICAL] ts-close: kill switch unable to fetch TopStep positions: %v — cannot confirm flat", err))
 			plan.OnChainConfirmedFlat = false
 		} else {
-			ctx, cancel := context.WithTimeout(context.Background(), in.CloseTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), in.platformCloseBudget(in.TSCloseTimeout))
 			plan.TSCloseReport = forceCloseTopStepLive(ctx, tsPositions, in.TSLiveAll, in.TSCloser)
 			cancel()
 			if !plan.TSCloseReport.ConfirmedFlat() {

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -1183,3 +1183,142 @@ func TestPlanKillSwitchClose_TopStepFailureStillLatchesAcrossPlatforms(t *testin
 		t.Errorf("HL close should still run: got %v", plan.CloseReport.ClosedCoins)
 	}
 }
+
+// Per-platform CloseTimeout overrides take precedence over the
+// CloseTimeout fallback. Without this, RH (TOTP-slow) and HL (fast) would
+// share a single budget that could not be tuned independently. (#350)
+func TestPlanKillSwitchClose_PlatformBudgetOverrides(t *testing.T) {
+	in := KillSwitchCloseInputs{
+		CloseTimeout:    90 * time.Second,
+		HLCloseTimeout:  10 * time.Second,
+		OKXCloseTimeout: 0,
+		RHCloseTimeout:  150 * time.Second,
+		TSCloseTimeout:  0,
+	}
+	if got := in.platformCloseBudget(in.HLCloseTimeout); got != 10*time.Second {
+		t.Errorf("HL budget = %v, want 10s override", got)
+	}
+	if got := in.platformCloseBudget(in.OKXCloseTimeout); got != 90*time.Second {
+		t.Errorf("OKX budget = %v, want 90s fallback", got)
+	}
+	if got := in.platformCloseBudget(in.RHCloseTimeout); got != 150*time.Second {
+		t.Errorf("RH budget = %v, want 150s override", got)
+	}
+	if got := in.platformCloseBudget(in.TSCloseTimeout); got != 90*time.Second {
+		t.Errorf("TS budget = %v, want 90s fallback", got)
+	}
+}
+
+// HL fetcher unwired while HLAddr configured: must latch with a CRITICAL
+// log line. Defense-in-depth against a future main.go regression that
+// drops HLFetcher; without this, the kill switch would silently bypass
+// HL exposure. (#350)
+func TestPlanKillSwitchClose_HLFetcherUnwiredLatches(t *testing.T) {
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		HLAddr:          "0xabc",
+		HLStateFetched:  false,
+		HLFetcher:       nil,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("expected NOT ConfirmedFlat when HLFetcher unwired with HLAddr set")
+	}
+	found := false
+	for _, line := range plan.LogLines {
+		if strings.Contains(line, "HLFetcher unwired") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected log line mentioning HLFetcher unwired, got: %v", plan.LogLines)
+	}
+}
+
+// OKX fetcher unwired while strategies configured: must latch. Without
+// the else branch, len(strategies)>0 && fetcher==nil silently skipped
+// OKX and cleared OnChainConfirmedFlat=true. (#350)
+func TestPlanKillSwitchClose_OKXFetcherUnwiredLatches(t *testing.T) {
+	okxLive := []StrategyConfig{
+		{ID: "okx-sma-btc", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		OKXLiveAllPerps: okxLive,
+		OKXFetcher:      nil,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("expected NOT ConfirmedFlat when OKXFetcher unwired with strategies configured")
+	}
+	found := false
+	for _, line := range plan.LogLines {
+		if strings.Contains(line, "OKXFetcher unwired") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected log line mentioning OKXFetcher unwired, got: %v", plan.LogLines)
+	}
+}
+
+// RH fetcher unwired while strategies configured: must latch. (#350)
+func TestPlanKillSwitchClose_RHFetcherUnwiredLatches(t *testing.T) {
+	rhLive := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		RHLiveCrypto:    rhLive,
+		RHFetcher:       nil,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("expected NOT ConfirmedFlat when RHFetcher unwired with strategies configured")
+	}
+	found := false
+	for _, line := range plan.LogLines {
+		if strings.Contains(line, "RHFetcher unwired") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected log line mentioning RHFetcher unwired, got: %v", plan.LogLines)
+	}
+}
+
+// TS fetcher unwired while strategies configured: must latch. (#350)
+func TestPlanKillSwitchClose_TSFetcherUnwiredLatches(t *testing.T) {
+	tsLive := []StrategyConfig{
+		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
+			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
+	}
+	plan := planKillSwitchClose(KillSwitchCloseInputs{
+		TSLiveAll:       tsLive,
+		TSFetcher:       nil,
+		PortfolioReason: "drawdown reason",
+		CloseTimeout:    time.Second,
+	})
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("expected NOT ConfirmedFlat when TSFetcher unwired with strategies configured")
+	}
+	found := false
+	for _, line := range plan.LogLines {
+		if strings.Contains(line, "TSFetcher unwired") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected log line mentioning TSFetcher unwired, got: %v", plan.LogLines)
+	}
+}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -645,6 +645,12 @@ func main() {
 					TSFetcher:       defaultTopStepPositionsFetcher,
 					PortfolioReason: portfolioReason,
 					CloseTimeout:    90 * time.Second,
+					// Per-platform overrides: each platform gets its own
+					// independent context.WithTimeout so a slow platform
+					// cannot starve the others. Robinhood adds TOTP login
+					// overhead to every submit, so it gets a wider budget;
+					// the rest stay at the 90s default. (#350)
+					RHCloseTimeout: 150 * time.Second,
 				}
 				plan = planKillSwitchClose(inputs)
 				for _, line := range plan.LogLines {

--- a/scheduler/okx_close.go
+++ b/scheduler/okx_close.go
@@ -167,8 +167,17 @@ func forceCloseOKXLive(ctx context.Context, positions []OKXPosition, okxLiveAll 
 			report.Errors[p.Coin] = fmt.Errorf("close budget exhausted before submit: %w", err)
 			continue
 		}
-		if _, err := closer(p.Coin); err != nil {
+		result, err := closer(p.Coin)
+		if err != nil {
 			report.Errors[p.Coin] = err
+			continue
+		}
+		// Adapter may report already_flat when its own pre-submit position
+		// check finds nothing to close (eventual-consistency window). Route
+		// through AlreadyFlat so operator messaging distinguishes "we sent a
+		// close order" from "nothing to close" (#350).
+		if result != nil && result.Close != nil && result.Close.AlreadyFlat {
+			report.AlreadyFlat = append(report.AlreadyFlat, p.Coin)
 			continue
 		}
 		report.ClosedCoins = append(report.ClosedCoins, p.Coin)

--- a/scheduler/okx_close_test.go
+++ b/scheduler/okx_close_test.go
@@ -147,6 +147,41 @@ func TestForceCloseOKXLive_SpotStrategiesIgnored(t *testing.T) {
 	}
 }
 
+// Adapter-side AlreadyFlat: closer returns success with already_flat=true
+// (eventual-consistency window between Go-side fetch and adapter submit).
+// The coin must land in AlreadyFlat, NOT ClosedCoins, so operator messaging
+// distinguishes "we sent a close order" from "nothing to close" (#350).
+func TestForceCloseOKXLive_AdapterAlreadyFlatRoutedCorrectly(t *testing.T) {
+	okxLive := []StrategyConfig{
+		{ID: "okx-btc", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
+	var calls []string
+	closer := func(sym string) (*OKXCloseResult, error) {
+		calls = append(calls, sym)
+		return &OKXCloseResult{
+			Close:    &OKXClose{Symbol: sym, AlreadyFlat: true},
+			Platform: "okx",
+		}, nil
+	}
+
+	report := forceCloseOKXLive(context.Background(), positions, okxLive, closer)
+
+	if !report.ConfirmedFlat() {
+		t.Errorf("expected ConfirmedFlat, got errors=%v", report.Errors)
+	}
+	if len(report.ClosedCoins) != 0 {
+		t.Errorf("ClosedCoins should be empty when adapter reports already_flat, got %v", report.ClosedCoins)
+	}
+	if len(report.AlreadyFlat) != 1 || report.AlreadyFlat[0] != "BTC" {
+		t.Errorf("AlreadyFlat = %v, want [BTC]", report.AlreadyFlat)
+	}
+	if len(calls) != 1 || calls[0] != "BTC" {
+		t.Errorf("closer should be called once (Go side saw non-zero size), got %v", calls)
+	}
+}
+
 // SortedErrorCoins determinism — same rationale as HL
 // (HyperliquidLiveCloseReport.SortedErrorCoins): Go map iteration is
 // randomized and the Discord output must be byte-stable across calls for

--- a/scheduler/robinhood_close.go
+++ b/scheduler/robinhood_close.go
@@ -165,8 +165,17 @@ func forceCloseRobinhoodLive(ctx context.Context, positions []RobinhoodPosition,
 			report.Errors[p.Coin] = fmt.Errorf("close budget exhausted before submit: %w", err)
 			continue
 		}
-		if _, err := closer(p.Coin); err != nil {
+		result, err := closer(p.Coin)
+		if err != nil {
 			report.Errors[p.Coin] = err
+			continue
+		}
+		// Adapter may report already_flat when its own pre-submit position
+		// check finds qty<=0 (eventual-consistency window). Route through
+		// AlreadyFlat so operator messaging distinguishes "we sent a close
+		// order" from "nothing to close" (#350).
+		if result != nil && result.Close != nil && result.Close.AlreadyFlat {
+			report.AlreadyFlat = append(report.AlreadyFlat, p.Coin)
 			continue
 		}
 		report.ClosedCoins = append(report.ClosedCoins, p.Coin)

--- a/scheduler/robinhood_close_test.go
+++ b/scheduler/robinhood_close_test.go
@@ -173,6 +173,42 @@ func TestForceCloseRobinhoodLive_OptionsStrategiesIgnored(t *testing.T) {
 	}
 }
 
+// Adapter-side AlreadyFlat: closer returns success with already_flat=true
+// (eventual-consistency window — Go-side fetch saw qty>0, but by the time
+// the adapter ran get_crypto_positions it returned qty<=0). The coin must
+// land in AlreadyFlat, NOT ClosedCoins, so operator messaging
+// distinguishes "we sent a close order" from "nothing to close" (#350).
+func TestForceCloseRobinhoodLive_AdapterAlreadyFlatRoutedCorrectly(t *testing.T) {
+	rhLive := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []RobinhoodPosition{{Coin: "BTC", Size: 0.01, AvgPrice: 42000}}
+	var calls []string
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		calls = append(calls, sym)
+		return &RobinhoodCloseResult{
+			Close:    &RobinhoodClose{Symbol: sym, AlreadyFlat: true},
+			Platform: "robinhood",
+		}, nil
+	}
+
+	report := forceCloseRobinhoodLive(context.Background(), positions, rhLive, closer)
+
+	if !report.ConfirmedFlat() {
+		t.Errorf("expected ConfirmedFlat, got errors=%v", report.Errors)
+	}
+	if len(report.ClosedCoins) != 0 {
+		t.Errorf("ClosedCoins should be empty when adapter reports already_flat, got %v", report.ClosedCoins)
+	}
+	if len(report.AlreadyFlat) != 1 || report.AlreadyFlat[0] != "BTC" {
+		t.Errorf("AlreadyFlat = %v, want [BTC]", report.AlreadyFlat)
+	}
+	if len(calls) != 1 || calls[0] != "BTC" {
+		t.Errorf("closer should be called once (Go side saw qty>0), got %v", calls)
+	}
+}
+
 // SortedErrorCoins determinism — same rationale as HL / OKX: Go map
 // iteration is randomized and Discord output must be byte-stable across
 // calls for operator triage.
@@ -233,6 +269,20 @@ func TestParseRobinhoodCloseOutput_ExitNonZeroNoErrorField(t *testing.T) {
 	_, _, err := parseRobinhoodCloseOutput(stdout, "stderr msg", fmt.Errorf("exit 2"))
 	if err == nil {
 		t.Fatal("expected non-nil err on non-zero exit with no error field")
+	}
+}
+
+func TestParseRobinhoodCloseOutput_AlreadyFlatFieldParsed(t *testing.T) {
+	stdout := []byte(`{"close":{"symbol":"BTC","fill":{},"already_flat":true},"platform":"robinhood","timestamp":"x"}`)
+	result, _, err := parseRobinhoodCloseOutput(stdout, "", nil)
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if result == nil || result.Close == nil {
+		t.Fatalf("expected populated result.Close, got %+v", result)
+	}
+	if !result.Close.AlreadyFlat {
+		t.Errorf("AlreadyFlat = false, want true (#350)")
 	}
 }
 

--- a/scheduler/topstep_close.go
+++ b/scheduler/topstep_close.go
@@ -168,6 +168,11 @@ func forceCloseTopStepLive(ctx context.Context, positions []TopStepPosition, tsL
 			report.Errors[p.Coin] = fmt.Errorf("close budget exhausted before submit: %w", err)
 			continue
 		}
+		// No adapter-side already_flat branch (unlike HL/OKX/RH in #350):
+		// TopStepX's market_close endpoint rejects close-on-flat with an
+		// error rather than returning a no-op envelope, so any close after
+		// an eventual-consistency flat surfaces here as report.Errors and
+		// keeps the kill switch latched until the next cycle re-fetches.
 		if _, err := closer(p.Coin); err != nil {
 			report.Errors[p.Coin] = err
 			continue

--- a/shared_scripts/close_hyperliquid_position.py
+++ b/shared_scripts/close_hyperliquid_position.py
@@ -79,7 +79,11 @@ def main():
     # for the eventual-consistency window where on-chain just-flattened between
     # the Go-side fetch and our submit.
     if not statuses:
-        _emit_success(args.symbol, fill={})
+        # Set already_flat=True so the Go side routes this through the
+        # AlreadyFlat report slice rather than ClosedCoins — operator
+        # messaging must distinguish "we sent a close order" from
+        # "nothing to close" (#350).
+        _emit_success(args.symbol, fill={}, already_flat=True)
         return
 
     first = statuses[0]
@@ -111,9 +115,12 @@ def main():
     _emit_success(args.symbol, fill)
 
 
-def _emit_success(symbol, fill):
+def _emit_success(symbol, fill, already_flat=False):
+    close = {"symbol": symbol, "fill": fill}
+    if already_flat:
+        close["already_flat"] = True
     print(json.dumps({
-        "close": {"symbol": symbol, "fill": fill},
+        "close": close,
         "platform": "hyperliquid",
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }))

--- a/shared_scripts/close_okx_position.py
+++ b/shared_scripts/close_okx_position.py
@@ -79,8 +79,11 @@ def main():
         # Empty dict — adapter found no open position to close. Treat as
         # already-flat success so the kill switch can release the latch when
         # on-chain is genuinely flat (eventual-consistency window between the
-        # Go-side fetch and this submit).
-        _emit_success(args.symbol, fill={})
+        # Go-side fetch and this submit). Set already_flat=True so the Go
+        # side routes this through the AlreadyFlat report slice rather than
+        # ClosedCoins — operator messaging must distinguish "we sent a
+        # close order" from "nothing to close" (#350).
+        _emit_success(args.symbol, fill={}, already_flat=True)
         return
 
     # ccxt unified order response: extract best-effort fill telemetry. Missing
@@ -108,9 +111,12 @@ def main():
     _emit_success(args.symbol, fill)
 
 
-def _emit_success(symbol, fill):
+def _emit_success(symbol, fill, already_flat=False):
+    close = {"symbol": symbol, "fill": fill}
+    if already_flat:
+        close["already_flat"] = True
     print(json.dumps({
-        "close": {"symbol": symbol, "fill": fill},
+        "close": close,
         "platform": "okx",
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }))

--- a/shared_scripts/close_robinhood_position.py
+++ b/shared_scripts/close_robinhood_position.py
@@ -78,8 +78,12 @@ def main():
         if qty <= 0:
             # Already flat — treat as success so the kill switch can release
             # the latch when on-chain is genuinely empty (eventual-consistency
-            # window between the Go-side fetch and this submit).
-            _emit_success(args.symbol, fill={})
+            # window between the Go-side fetch and this submit). Set
+            # already_flat=True so the Go side routes this through the
+            # AlreadyFlat report slice rather than ClosedCoins — operator
+            # messaging must distinguish "we sent a close order" from
+            # "nothing to close" (#350).
+            _emit_success(args.symbol, fill={}, already_flat=True)
             return
 
         result = adapter.market_sell(args.symbol, qty)
@@ -120,9 +124,12 @@ def main():
     _emit_success(args.symbol, fill)
 
 
-def _emit_success(symbol, fill):
+def _emit_success(symbol, fill, already_flat=False):
+    close = {"symbol": symbol, "fill": fill}
+    if already_flat:
+        close["already_flat"] = True
     print(json.dumps({
-        "close": {"symbol": symbol, "fill": fill},
+        "close": close,
         "platform": "robinhood",
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }))

--- a/shared_scripts/test_close_hyperliquid_position.py
+++ b/shared_scripts/test_close_hyperliquid_position.py
@@ -154,6 +154,10 @@ class TestAlreadyFlat:
         assert out["close"]["symbol"] == "ETH"
         assert out["close"]["fill"] == {}
         assert "error" not in out
+        # already_flat must be set so the Go side routes this through
+        # AlreadyFlat instead of ClosedCoins (#350) — operator messaging
+        # must distinguish "we sent a close order" from "nothing to close".
+        assert out["close"]["already_flat"] is True
 
     def test_no_response_field(self):
         """Some SDK paths omit response entirely for a flat account — handled
@@ -161,6 +165,7 @@ class TestAlreadyFlat:
         sdk_response = {"status": "ok"}
         out, code = _run_script(sdk_response, ["--symbol=ETH", "--mode=live"])
         assert code == 0
+        assert out["close"]["already_flat"] is True
 
 
 class TestFailurePaths:

--- a/shared_scripts/test_close_okx_position.py
+++ b/shared_scripts/test_close_okx_position.py
@@ -152,6 +152,10 @@ class TestAlreadyFlat:
         assert out["close"]["symbol"] == "BTC"
         assert out["close"]["fill"] == {}
         assert "error" not in out
+        # already_flat must be set so the Go side routes this through
+        # AlreadyFlat instead of ClosedCoins (#350) — operator messaging
+        # must distinguish "we sent a close order" from "nothing to close".
+        assert out["close"]["already_flat"] is True
 
 
 class TestFailurePaths:


### PR DESCRIPTION
Closes #350

#1 Per-platform `CloseTimeout` budgets on `KillSwitchCloseInputs` (HL/OKX/RH/TS) with `CloseTimeout` fallback. Wire `RHCloseTimeout: 150s` in `main.go` to absorb Robinhood TOTP overhead.

#2 Fetcher nil-guard else branches for HL/OKX/RH/TS — latch + `[CRITICAL]` log instead of silently skipping when a `Fetcher` is nil while live strategies are configured.

#3 `already_flat:true` envelope flag for adapter qty==0 case (HL/OKX/RH), wired through `HyperliquidClose`/`OKXClose`/`RobinhoodClose` Go types. `forceClose*Live` routes those through `AlreadyFlat` instead of `ClosedCoins` so operator messaging accurately distinguishes "we sent a close order" from "nothing to close".

Generated with [Claude Code](https://claude.ai/code)