### PR TITLE
Sort category summary strategies by ID (#354)

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -263,14 +263,14 @@ func FormatCategorySummary(
 	// Summaries scan better with strategies ordered A→Z by ID (#354). Callers often
 	// pass config file order, which is not necessarily alphabetical.
 	strategies := append([]StrategyConfig(nil), channelStrategies...)
-	sort.Slice(strategies, func(i, j int) bool {
+	sort.SliceStable(strategies, func(i, j int) bool {
 		return strategies[i].ID < strategies[j].ID
 	})
 
 	// Icon and title based on strategy types and channel key.
-	isFutures := isFuturesType(channelStrategies) || channelKey == "futures" || channelKey == "ibkr"
+	isFutures := isFuturesType(strategies) || channelKey == "futures" || channelKey == "ibkr"
 	icon := "📊"
-	if isOptionsType(channelStrategies) {
+	if isOptionsType(strategies) {
 		icon = "🎯"
 	} else if channelKey == "spot" {
 		icon = "📈"
@@ -356,7 +356,7 @@ func FormatCategorySummary(
 	// Detect shared wallet groups: strategies on same platform with CapitalPct > 0.
 	walletCapital := make(map[string]float64) // platform -> sum of capitals
 	walletCount := make(map[string]int)       // platform -> count of strategies
-	for _, sc := range channelStrategies {
+	for _, sc := range strategies {
 		if sc.CapitalPct > 0 {
 			walletCapital[sc.Platform] += sc.Capital
 			walletCount[sc.Platform]++

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -260,6 +260,13 @@ func FormatCategorySummary(
 ) []string {
 	var sb strings.Builder
 
+	// Summaries scan better with strategies ordered A→Z by ID (#354). Callers often
+	// pass config file order, which is not necessarily alphabetical.
+	strategies := append([]StrategyConfig(nil), channelStrategies...)
+	sort.Slice(strategies, func(i, j int) bool {
+		return strategies[i].ID < strategies[j].ID
+	})
+
 	// Icon and title based on strategy types and channel key.
 	isFutures := isFuturesType(channelStrategies) || channelKey == "futures" || channelKey == "ibkr"
 	icon := "📊"
@@ -292,7 +299,7 @@ func FormatCategorySummary(
 	// Circuit breaker status — show warning for any strategy with active breaker.
 	var cbActive []string
 	now := time.Now().UTC()
-	for _, sc := range channelStrategies {
+	for _, sc := range strategies {
 		ss := state.Strategies[sc.ID]
 		if ss == nil {
 			continue
@@ -366,7 +373,7 @@ func FormatCategorySummary(
 	// Build flat bot list from the provided channel strategies.
 	var tableBots []botInfo
 	var totalInitCap, filteredValue float64
-	for _, sc := range channelStrategies {
+	for _, sc := range strategies {
 		ss := state.Strategies[sc.ID]
 		if ss == nil {
 			continue
@@ -447,7 +454,7 @@ func FormatCategorySummary(
 	}
 	var posLines []string
 	if totalOpenPos > 0 {
-		for _, sc := range channelStrategies {
+		for _, sc := range strategies {
 			ss := state.Strategies[sc.ID]
 			if ss == nil {
 				continue

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -222,6 +222,31 @@ func TestFormatCategorySummary_CircuitBreakerActive(t *testing.T) {
 	}
 }
 
+func TestFormatCategorySummary_StrategiesSortedByID(t *testing.T) {
+	// Issue #354: table rows should follow strategy ID order, not config order.
+	strats := []StrategyConfig{
+		{ID: "hl-zebra-btc", Type: "perps", Args: []string{"zebra", "BTC", "1h"}, Capital: 1000},
+		{ID: "hl-adx-btc", Type: "perps", Args: []string{"adx", "BTC", "1h"}, Capital: 1000},
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-zebra-btc": {Cash: 1000},
+			"hl-adx-btc":   {Cash: 1000},
+		},
+	}
+	prices := map[string]float64{"BTC/USDT": 50000}
+	msgs := FormatCategorySummary(1, 0, 1, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+	msg := strings.Join(msgs, "\n")
+	idxAdx := strings.Index(msg, "hl-adx-btc")
+	idxZebra := strings.Index(msg, "hl-zebra-btc")
+	if idxAdx < 0 || idxZebra < 0 {
+		t.Fatalf("expected both strategy IDs in output:\n%s", msg)
+	}
+	if idxAdx >= idxZebra {
+		t.Errorf("expected hl-adx-btc before hl-zebra-btc (sorted by ID), got adx@%d zebra@%d", idxAdx, idxZebra)
+	}
+}
+
 func TestFormatCategorySummary_NoCircuitBreaker(t *testing.T) {
 	strats := []StrategyConfig{
 		{ID: "hl-rsi-btc", Type: "perps", Args: []string{"rsi", "BTC", "1h"}, Capital: 1000},


### PR DESCRIPTION
## Summary

- Copy `channelStrategies` in `FormatCategorySummary` and sort by `ID` before rendering the summary table, circuit-breaker bullets, and position lines so Discord summaries are scannable A→Z regardless of config order.

## Test plan

- [x] `go test ./...` in `scheduler/`

Closes #354

Made with [Cursor](https://cursor.com)