### PR TITLE
Per-strategy HL circuit breaker: live reduce-only closes (#356)

### DIFF
--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -211,9 +211,15 @@ class HyperliquidExchangeAdapter:
             raise ValueError(f"Size rounded to zero for {symbol} (sz_decimals={sz_decimals})")
         return self._exchange.market_open(symbol, is_buy, size, None, 0.01)
 
-    def market_close(self, symbol: str) -> dict:
+    def market_close(self, symbol: str, sz: float | None = None) -> dict:
         """
-        Close all open positions for a symbol.
+        Close an open perp position for a symbol (reduce-only).
+
+        When ``sz`` is None, closes the full on-chain position (SDK default).
+        When ``sz`` is set, submits a reduce-only market order for that coin
+        quantity only — used for shared-wallet per-strategy circuit breakers
+        (#356).
+
         Only available in live mode; raises RuntimeError in paper mode.
         Returns raw SDK response dict.
         """
@@ -221,4 +227,4 @@ class HyperliquidExchangeAdapter:
             raise RuntimeError(
                 "market_close requires live mode (set HYPERLIQUID_SECRET_KEY)"
             )
-        return self._exchange.market_close(symbol)
+        return self._exchange.market_close(symbol, sz)

--- a/platforms/hyperliquid/test_adapter.py
+++ b/platforms/hyperliquid/test_adapter.py
@@ -252,4 +252,16 @@ class TestOrderExecution:
 
         result = adapter.market_close("BTC")
         assert result == {"status": "closed"}
-        mock_exchange.market_close.assert_called_once_with("BTC")
+        mock_exchange.market_close.assert_called_once_with("BTC", None)
+
+    def test_market_close_partial_size_passes_sz(self):
+        mock_info = MagicMock()
+        mock_info_cls = MagicMock(return_value=mock_info)
+        mock_exchange = MagicMock()
+        mock_exchange.market_close.return_value = {"status": "closed"}
+        mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
+        adapter = mod.HyperliquidExchangeAdapter()
+        adapter._exchange = mock_exchange
+
+        adapter.market_close("ETH", 0.25)
+        mock_exchange.market_close.assert_called_once_with("ETH", 0.25)

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -48,6 +48,7 @@ CREATE TABLE IF NOT EXISTS strategies (
     risk_consecutive_losses INTEGER NOT NULL DEFAULT 0,
     risk_circuit_breaker INTEGER NOT NULL DEFAULT 0,
     risk_circuit_breaker_until TEXT NOT NULL DEFAULT '',
+    risk_pending_hl_close_json TEXT NOT NULL DEFAULT '',
     risk_total_trades INTEGER NOT NULL DEFAULT 0,
     risk_winning_trades INTEGER NOT NULL DEFAULT 0,
     risk_losing_trades INTEGER NOT NULL DEFAULT 0
@@ -229,6 +230,8 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE kill_switch_events ADD COLUMN source TEXT NOT NULL DEFAULT ''",
 		// Per-leaderboard-summary last-post timestamps stored as JSON (#308).
 		"ALTER TABLE app_state ADD COLUMN last_leaderboard_summaries TEXT NOT NULL DEFAULT ''",
+		// Per-strategy HL circuit-breaker pending closes (#356).
+		"ALTER TABLE strategies ADD COLUMN risk_pending_hl_close_json TEXT NOT NULL DEFAULT ''",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -387,9 +390,9 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	stmtStrat, err := tx.Prepare(`INSERT OR REPLACE INTO strategies (id, type, platform, cash, initial_capital,
 		risk_peak_value, risk_max_drawdown_pct, risk_current_drawdown_pct,
 		risk_daily_pnl, risk_daily_pnl_date, risk_consecutive_losses,
-		risk_circuit_breaker, risk_circuit_breaker_until,
+		risk_circuit_breaker, risk_circuit_breaker_until, risk_pending_hl_close_json,
 		risk_total_trades, risk_winning_trades, risk_losing_trades)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare strategy insert: %w", err)
 	}
@@ -439,6 +442,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 			s.RiskState.PeakValue, s.RiskState.MaxDrawdownPct, s.RiskState.CurrentDrawdownPct,
 			s.RiskState.DailyPnL, s.RiskState.DailyPnLDate, s.RiskState.ConsecutiveLosses,
 			cbInt, formatTime(s.RiskState.CircuitBreakerUntil),
+			s.RiskState.MarshalPendingHLCloseJSON(),
 			s.RiskState.TotalTrades, s.RiskState.WinningTrades, s.RiskState.LosingTrades,
 		); err != nil {
 			return fmt.Errorf("insert strategy %s: %w", s.ID, err)
@@ -808,7 +812,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	rows, err := sdb.db.Query(`SELECT id, type, platform, cash, initial_capital,
 		risk_peak_value, risk_max_drawdown_pct, risk_current_drawdown_pct,
 		risk_daily_pnl, risk_daily_pnl_date, risk_consecutive_losses,
-		risk_circuit_breaker, risk_circuit_breaker_until,
+		risk_circuit_breaker, risk_circuit_breaker_until, risk_pending_hl_close_json,
 		risk_total_trades, risk_winning_trades, risk_losing_trades
 		FROM strategies`)
 	if err != nil {
@@ -819,18 +823,19 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	for rows.Next() {
 		var s StrategyState
 		var cbInt int
-		var cbUntilStr string
+		var cbUntilStr, pendingHLJSON string
 		if err := rows.Scan(
 			&s.ID, &s.Type, &s.Platform, &s.Cash, &s.InitialCapital,
 			&s.RiskState.PeakValue, &s.RiskState.MaxDrawdownPct, &s.RiskState.CurrentDrawdownPct,
 			&s.RiskState.DailyPnL, &s.RiskState.DailyPnLDate, &s.RiskState.ConsecutiveLosses,
-			&cbInt, &cbUntilStr,
+			&cbInt, &cbUntilStr, &pendingHLJSON,
 			&s.RiskState.TotalTrades, &s.RiskState.WinningTrades, &s.RiskState.LosingTrades,
 		); err != nil {
 			return nil, fmt.Errorf("scan strategy: %w", err)
 		}
 		s.RiskState.CircuitBreaker = cbInt != 0
 		s.RiskState.CircuitBreakerUntil = parseTime(cbUntilStr)
+		s.RiskState.UnmarshalPendingHLCloseJSON(pendingHLJSON)
 		s.Positions = make(map[string]*Position)
 		s.OptionPositions = make(map[string]*OptionPosition)
 		s.TradeHistory = []Trade{}

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -1678,3 +1678,38 @@ func TestSaveState_GuardWarnIsOneShot(t *testing.T) {
 		t.Errorf("warn fired %d times after override, want 2 (dedup must reset)", warns)
 	}
 }
+
+func TestSaveAndLoadDB_PendingHLCloseRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	state := &AppState{
+		CycleCount: 1,
+		LastCycle:  now,
+		Strategies: map[string]*StrategyState{
+			"hl-a": {
+				ID: "hl-a", Type: "perps", Platform: "hyperliquid", Cash: 100, InitialCapital: 100,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+				RiskState: RiskState{
+					PeakValue: 100, MaxDrawdownPct: 25,
+					PendingHyperliquidCircuitClose: &HyperliquidCircuitClosePending{
+						Coins: []HyperliquidCircuitCloseCoin{{Coin: "ETH", Sz: 0.2585}},
+					},
+				},
+			},
+		},
+	}
+	if err := db.SaveState(state); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	p := loaded.Strategies["hl-a"].RiskState.PendingHyperliquidCircuitClose
+	if p == nil || len(p.Coins) != 1 {
+		t.Fatalf("pending missing: %+v", p)
+	}
+	if p.Coins[0].Coin != "ETH" || p.Coins[0].Sz != 0.2585 {
+		t.Errorf("pending coin=%q sz=%g want ETH 0.2585", p.Coins[0].Coin, p.Coins[0].Sz)
+	}
+}

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"syscall"
 	"time"
 )
@@ -255,7 +256,8 @@ type HyperliquidCloseResult struct {
 }
 
 // RunHyperliquidClose runs close_hyperliquid_position.py to submit a reduce-only
-// market close for a single coin (#341).
+// market close for a single coin (#341). When partialSz is non-nil, submits a
+// partial close for that coin quantity (#356 shared-wallet circuit breakers).
 //
 // Contract (load-bearing for kill-switch correctness): a non-nil error is
 // returned for ANY failure path — non-zero subprocess exit, malformed JSON,
@@ -264,10 +266,13 @@ type HyperliquidCloseResult struct {
 // (result, nil) for "exit 1 + parseable JSON with error" which forced every
 // caller to also inspect result.Error and conflated subprocess success with
 // JSON-error success.
-func RunHyperliquidClose(script, symbol string) (*HyperliquidCloseResult, string, error) {
+func RunHyperliquidClose(script, symbol string, partialSz *float64) (*HyperliquidCloseResult, string, error) {
 	args := []string{
 		fmt.Sprintf("--symbol=%s", symbol),
 		"--mode=live",
+	}
+	if partialSz != nil {
+		args = append(args, fmt.Sprintf("--sz=%s", strconv.FormatFloat(*partialSz, 'f', -1, 64)))
 	}
 	stdout, stderr, runErr := RunPythonScript(script, args)
 	return parseHyperliquidCloseOutput(stdout, string(stderr), runErr)

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -611,6 +611,37 @@ func hlStrategyCapitalWeight(sc StrategyConfig) float64 {
 	return 1.0
 }
 
+// hlStrategyCapitalWeights returns per-peer weights for proportional close
+// sizing on a shared coin. When peers mix units (one declares CapitalPct as a
+// fraction, another declares raw Capital in dollars), their sum is nonsensical
+// (e.g. 0.5 + 1000 ≈ 1000.5) and the CapitalPct-only peer's share collapses to
+// ~0, producing a no-op close. Detect the mismatch and fall back to equal
+// weights (1.0 each) so the firing strategy still gets a meaningful share.
+// When all peers use the same field, behavior matches hlStrategyCapitalWeight
+// (#356 review).
+func hlStrategyCapitalWeights(peers []StrategyConfig) []float64 {
+	hasPct := false
+	hasAbs := false
+	for _, p := range peers {
+		switch {
+		case p.CapitalPct > 0:
+			hasPct = true
+		case p.Capital > 0:
+			hasAbs = true
+		}
+	}
+	mixed := hasPct && hasAbs
+	out := make([]float64, len(peers))
+	for i, p := range peers {
+		if mixed {
+			out[i] = 1.0
+			continue
+		}
+		out[i] = hlStrategyCapitalWeight(p)
+	}
+	return out
+}
+
 // computeHyperliquidCircuitCloseQty returns the unsigned coin quantity for a
 // reduce-only market_close when strategyID's per-strategy circuit breaker fires
 // (#356). For a coin traded by multiple live HL strategies on the same wallet,
@@ -635,14 +666,14 @@ func computeHyperliquidCircuitCloseQty(coin, strategyID string, hlPositions []HL
 	if len(peers) <= 1 {
 		return absSzi, true
 	}
+	weights := hlStrategyCapitalWeights(peers)
 	sumW := 0.0
 	var wFiring float64
 	foundFiring := false
-	for _, p := range peers {
-		w := hlStrategyCapitalWeight(p)
-		sumW += w
+	for i, p := range peers {
+		sumW += weights[i]
 		if p.ID == strategyID {
-			wFiring = w
+			wFiring = weights[i]
 			foundFiring = true
 		}
 	}
@@ -671,6 +702,15 @@ func lookupStrategyConfig(strategies []StrategyConfig, id string) *StrategyConfi
 // runPendingHyperliquidCircuitCloses drains PendingHyperliquidCircuitClose for
 // every strategy, submitting reduce-only HL closes outside the state mutex.
 // Retries next scheduler cycle on failure (#356).
+//
+// Also recovers "stuck CB" strategies: if a per-strategy circuit breaker fires
+// on a cycle where the HL clearinghouse fetch failed, setHyperliquidCircuitBreakerPending
+// bails on the nil hlAssist and the pending close is never set. Subsequent
+// CheckRisk calls early-return with "circuit breaker active" without re-enqueuing.
+// This drain detects the case (live HL perps strategy with CircuitBreaker=true
+// but pending=nil AND a matching non-zero on-chain position) and reconstructs
+// the pending so the reduce-only close eventually fires once HL is reachable
+// again (#356 review finding 1).
 func runPendingHyperliquidCircuitCloses(
 	ctx context.Context,
 	state *AppState,
@@ -687,11 +727,97 @@ func runPendingHyperliquidCircuitCloses(
 		return
 	}
 
+	// Build the live HL perps roster from strategies — needed for both the
+	// stuck-CB recovery path and the shared-coin weight computation.
+	var hlLiveAll []StrategyConfig
+	for _, sc := range strategies {
+		if sc.Platform == "hyperliquid" && sc.Type == "perps" && hyperliquidIsLive(sc.Args) {
+			hlLiveAll = append(hlLiveAll, sc)
+		}
+	}
+
+	// Phase 1: snapshot — detect pending jobs AND stuck-CB strategies that
+	// need their pending reconstructed.
+	mu.RLock()
+	hasPending := false
+	hasStuckCB := false
+	for _, ss := range state.Strategies {
+		if ss == nil {
+			continue
+		}
+		if ss.RiskState.PendingHyperliquidCircuitClose != nil {
+			hasPending = true
+		}
+	}
+	for _, sc := range hlLiveAll {
+		ss := state.Strategies[sc.ID]
+		if ss == nil {
+			continue
+		}
+		if ss.RiskState.PendingHyperliquidCircuitClose == nil && ss.RiskState.CircuitBreaker {
+			hasStuckCB = true
+			break
+		}
+	}
+	mu.RUnlock()
+
+	if !hasPending && !hasStuckCB {
+		return
+	}
+
+	ctxOverall, cancelOverall := context.WithTimeout(ctx, totalBudget)
+	defer cancelOverall()
+
+	positions := hlPositions
+	if !hlStateFetched && hlFetcher != nil {
+		pos, err := hlFetcher(hlAddr)
+		if err != nil {
+			fmt.Printf("[CRITICAL] hl-circuit-close: cannot fetch HL positions: %v — will retry next cycle\n", err)
+			return
+		}
+		positions = pos
+	}
+
+	// Phase 2: reconstruct pending for stuck-CB strategies.
+	if hasStuckCB {
+		// Sort hlLiveAll for deterministic recovery-log order.
+		recoverOrder := make([]StrategyConfig, len(hlLiveAll))
+		copy(recoverOrder, hlLiveAll)
+		sort.Slice(recoverOrder, func(i, j int) bool { return recoverOrder[i].ID < recoverOrder[j].ID })
+		mu.Lock()
+		for _, sc := range recoverOrder {
+			ss := state.Strategies[sc.ID]
+			if ss == nil {
+				continue
+			}
+			if ss.RiskState.PendingHyperliquidCircuitClose != nil {
+				continue
+			}
+			if !ss.RiskState.CircuitBreaker {
+				continue
+			}
+			sym := hyperliquidSymbol(sc.Args)
+			if sym == "" {
+				continue
+			}
+			qty, ok := computeHyperliquidCircuitCloseQty(sym, sc.ID, positions, hlLiveAll)
+			if !ok || qty <= 0 {
+				continue
+			}
+			ss.RiskState.PendingHyperliquidCircuitClose = &HyperliquidCircuitClosePending{
+				Coins: []HyperliquidCircuitCloseCoin{{Coin: sym, Sz: qty}},
+			}
+			fmt.Printf("[CRITICAL] hl-circuit-close: recovered pending for strategy %s coin %s sz=%.6f (CB latched, HL fetch had failed at fire time)\n",
+				sc.ID, sym, qty)
+		}
+		mu.Unlock()
+	}
+
+	// Phase 3: re-snapshot jobs (may now include recovered entries).
 	type job struct {
 		stratID string
 		pending HyperliquidCircuitClosePending
 	}
-
 	var jobs []job
 	mu.RLock()
 	for id, ss := range state.Strategies {
@@ -710,18 +836,12 @@ func runPendingHyperliquidCircuitCloses(
 		return
 	}
 
-	ctxOverall, cancelOverall := context.WithTimeout(ctx, totalBudget)
-	defer cancelOverall()
-
-	positions := hlPositions
-	if !hlStateFetched && hlFetcher != nil {
-		pos, err := hlFetcher(hlAddr)
-		if err != nil {
-			fmt.Printf("[CRITICAL] hl-circuit-close: cannot fetch HL positions: %v — will retry next cycle\n", err)
-			return
-		}
-		positions = pos
-	}
+	// Deterministic drain order — operator-facing logs at lines below iterate
+	// this slice, and map iteration above would otherwise randomize which
+	// subset of strategies get serviced when the budget is partially exhausted
+	// (#356 review finding 2; CLAUDE.md "Sort map keys before formatting any
+	// operator-facing output").
+	sort.Slice(jobs, func(i, j int) bool { return jobs[i].stratID < jobs[j].stratID })
 
 	for _, j := range jobs {
 		if err := ctxOverall.Err(); err != nil {

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -35,15 +35,17 @@ var hyperliquidLiveCloseScript = "shared_scripts/close_hyperliquid_position.py"
 // inject a fake without spawning a real Python subprocess. Production
 // implementation is defaultHyperliquidLiveCloser, which shells out to
 // close_hyperliquid_position.py via RunHyperliquidClose.
-type HyperliquidLiveCloser func(symbol string) (*HyperliquidCloseResult, error)
+// When partialSz is nil, the full on-chain position is closed (#341). When
+// non-nil, submits a partial close for that coin quantity (#356).
+type HyperliquidLiveCloser func(symbol string, partialSz *float64) (*HyperliquidCloseResult, error)
 
 // defaultHyperliquidLiveCloser is the production close implementation. Writes
 // stderr to os.Stderr rather than a per-strategy logger — kill switch is a
 // system-level event, not strategy-scoped. Relies on RunHyperliquidClose's
 // uniform error contract: any non-nil err means the close was not confirmed
 // by the SDK and the kill switch must stay latched.
-func defaultHyperliquidLiveCloser(symbol string) (*HyperliquidCloseResult, error) {
-	result, stderr, err := RunHyperliquidClose(hyperliquidLiveCloseScript, symbol)
+func defaultHyperliquidLiveCloser(symbol string, partialSz *float64) (*HyperliquidCloseResult, error) {
+	result, stderr, err := RunHyperliquidClose(hyperliquidLiveCloseScript, symbol, partialSz)
 	if stderr != "" {
 		fmt.Fprintf(os.Stderr, "[hl-close] %s stderr: %s\n", symbol, stderr)
 	}
@@ -569,7 +571,7 @@ func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLi
 			report.Errors[p.Coin] = fmt.Errorf("close budget exhausted before submit: %w", err)
 			continue
 		}
-		result, err := closer(p.Coin)
+		result, err := closer(p.Coin, nil)
 		if err != nil {
 			report.Errors[p.Coin] = err
 			continue
@@ -587,4 +589,195 @@ func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLi
 	}
 
 	return report
+}
+
+func hlLiveStrategiesForCoin(coin string, hlLiveAll []StrategyConfig) []StrategyConfig {
+	var out []StrategyConfig
+	for _, sc := range hlLiveAll {
+		if hyperliquidSymbol(sc.Args) == coin {
+			out = append(out, sc)
+		}
+	}
+	return out
+}
+
+func hlStrategyCapitalWeight(sc StrategyConfig) float64 {
+	if sc.CapitalPct > 0 {
+		return sc.CapitalPct
+	}
+	if sc.Capital > 0 {
+		return sc.Capital
+	}
+	return 1.0
+}
+
+// computeHyperliquidCircuitCloseQty returns the unsigned coin quantity for a
+// reduce-only market_close when strategyID's per-strategy circuit breaker fires
+// (#356). For a coin traded by multiple live HL strategies on the same wallet,
+// the close size is proportional to capital_pct (or capital) weights. For a
+// sole configured trader of that coin, the full on-chain absolute size is used.
+// ok is false when there is no non-zero on-chain position for the coin.
+func computeHyperliquidCircuitCloseQty(coin, strategyID string, hlPositions []HLPosition, hlLiveAll []StrategyConfig) (qty float64, ok bool) {
+	var onChain float64
+	found := false
+	for i := range hlPositions {
+		if hlPositions[i].Coin == coin {
+			onChain = hlPositions[i].Size
+			found = true
+			break
+		}
+	}
+	if !found || onChain == 0 {
+		return 0, false
+	}
+	absSzi := math.Abs(onChain)
+	peers := hlLiveStrategiesForCoin(coin, hlLiveAll)
+	if len(peers) <= 1 {
+		return absSzi, true
+	}
+	sumW := 0.0
+	var wFiring float64
+	foundFiring := false
+	for _, p := range peers {
+		w := hlStrategyCapitalWeight(p)
+		sumW += w
+		if p.ID == strategyID {
+			wFiring = w
+			foundFiring = true
+		}
+	}
+	if !foundFiring || sumW <= 0 {
+		return absSzi, true
+	}
+	q := absSzi * (wFiring / sumW)
+	if q > absSzi {
+		q = absSzi
+	}
+	if q < 1e-12 {
+		return 0, false
+	}
+	return q, true
+}
+
+func lookupStrategyConfig(strategies []StrategyConfig, id string) *StrategyConfig {
+	for i := range strategies {
+		if strategies[i].ID == id {
+			return &strategies[i]
+		}
+	}
+	return nil
+}
+
+// runPendingHyperliquidCircuitCloses drains PendingHyperliquidCircuitClose for
+// every strategy, submitting reduce-only HL closes outside the state mutex.
+// Retries next scheduler cycle on failure (#356).
+func runPendingHyperliquidCircuitCloses(
+	ctx context.Context,
+	state *AppState,
+	strategies []StrategyConfig,
+	hlAddr string,
+	hlPositions []HLPosition,
+	hlStateFetched bool,
+	hlFetcher HLStateFetcher,
+	closer HyperliquidLiveCloser,
+	totalBudget time.Duration,
+	mu *sync.RWMutex,
+) {
+	if hlAddr == "" || closer == nil || state == nil {
+		return
+	}
+
+	type job struct {
+		stratID string
+		pending HyperliquidCircuitClosePending
+	}
+
+	var jobs []job
+	mu.RLock()
+	for id, ss := range state.Strategies {
+		if ss == nil || ss.RiskState.PendingHyperliquidCircuitClose == nil {
+			continue
+		}
+		p := ss.RiskState.PendingHyperliquidCircuitClose
+		if len(p.Coins) == 0 {
+			continue
+		}
+		jobs = append(jobs, job{id, *p})
+	}
+	mu.RUnlock()
+
+	if len(jobs) == 0 {
+		return
+	}
+
+	ctxOverall, cancelOverall := context.WithTimeout(ctx, totalBudget)
+	defer cancelOverall()
+
+	positions := hlPositions
+	if !hlStateFetched && hlFetcher != nil {
+		pos, err := hlFetcher(hlAddr)
+		if err != nil {
+			fmt.Printf("[CRITICAL] hl-circuit-close: cannot fetch HL positions: %v — will retry next cycle\n", err)
+			return
+		}
+		positions = pos
+	}
+
+	for _, j := range jobs {
+		if err := ctxOverall.Err(); err != nil {
+			fmt.Printf("[CRITICAL] hl-circuit-close: budget exhausted: %v\n", err)
+			return
+		}
+		sc := lookupStrategyConfig(strategies, j.stratID)
+		if sc == nil || sc.Platform != "hyperliquid" || sc.Type != "perps" || !hyperliquidIsLive(sc.Args) {
+			mu.Lock()
+			if ss := state.Strategies[j.stratID]; ss != nil {
+				ss.RiskState.PendingHyperliquidCircuitClose = nil
+			}
+			mu.Unlock()
+			continue
+		}
+
+		allOK := true
+		for _, c := range j.pending.Coins {
+			if err := ctxOverall.Err(); err != nil {
+				allOK = false
+				break
+			}
+			sz := c.Sz
+			for _, p := range positions {
+				if p.Coin != c.Coin {
+					continue
+				}
+				absOC := math.Abs(p.Size)
+				if absOC <= 1e-15 {
+					sz = 0
+					break
+				}
+				if sz > absOC {
+					sz = absOC
+				}
+				break
+			}
+			if sz <= 1e-15 {
+				continue
+			}
+			partial := sz
+			_, err := closer(c.Coin, &partial)
+			if err != nil {
+				fmt.Printf("[CRITICAL] hl-circuit-close: strategy %s coin %s sz=%.6f failed: %v\n", j.stratID, c.Coin, sz, err)
+				allOK = false
+				break
+			}
+			fmt.Printf("[INFO] hl-circuit-close: strategy %s coin %s submitted reduce-only close sz=%.6f\n", j.stratID, c.Coin, sz)
+		}
+
+		if allOK {
+			mu.Lock()
+			if ss := state.Strategies[j.stratID]; ss != nil && ss.RiskState.PendingHyperliquidCircuitClose != nil {
+				ss.RiskState.PendingHyperliquidCircuitClose = nil
+			}
+			mu.Unlock()
+		}
+	}
 }

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1443,6 +1443,133 @@ func TestComputeHyperliquidCircuitCloseQty_Shared50_50(t *testing.T) {
 	}
 }
 
+// Mixed-units weight normalization (#356 review finding 3): when peers on a
+// shared coin declare weights in different fields (fractional CapitalPct vs
+// absolute Capital), their sum is nonsensical. Detect the mismatch and fall
+// back to equal weights so the firing strategy still gets a meaningful share.
+func TestComputeHyperliquidCircuitCloseQty_MixedUnitsFallsBackToEqualWeights(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-a", Platform: "hyperliquid", Type: "perps", CapitalPct: 0.5,
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-b", Platform: "hyperliquid", Type: "perps", Capital: 1000,
+			Args: []string{"ema", "ETH", "1h", "--mode=live"}},
+	}
+	pos := []HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 3000}}
+	q, ok := computeHyperliquidCircuitCloseQty("ETH", "hl-a", pos, hlLive)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	// With equal 1.0/1.0 fallback, hl-a gets half of |szi| = 0.25. Without the
+	// fallback, the old logic would compute 0.5/(0.5+1000) ≈ 0.00025 — a no-op.
+	want := 0.25
+	if math.Abs(q-want) > 1e-9 {
+		t.Errorf("qty=%.6f want %.6f (equal-weight fallback on mixed units)", q, want)
+	}
+}
+
+// Recovery after HL-fetch-fail at CB fire time (#356 review finding 1).
+// When the clearinghouse fetch fails on the cycle a CB first fires, the
+// pending close is never enqueued (setHyperliquidCircuitBreakerPending bails
+// on nil hlAssist). Subsequent cycles must detect the stuck state (CB active,
+// pending nil, live HL perps, on-chain position still open) and reconstruct
+// the pending so the reduce-only close eventually fires.
+func TestRunPendingHyperliquidCircuitCloses_RecoversStuckCB(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-a": {
+				ID: "hl-a",
+				RiskState: RiskState{
+					// CB was fired on a prior cycle, but pending was never set
+					// because the HL fetch had failed at that time.
+					CircuitBreaker:                 true,
+					CircuitBreakerUntil:            time.Now().Add(24 * time.Hour),
+					PendingHyperliquidCircuitClose: nil,
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "hl-a", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string, partialSz *float64) (*HyperliquidCloseResult, error) {
+		if partialSz != nil {
+			calls = append(calls, fmt.Sprintf("%s:%g", sym, *partialSz))
+		} else {
+			calls = append(calls, sym)
+		}
+		return &HyperliquidCloseResult{
+			Close:    &HyperliquidClose{Symbol: sym, Fill: &HyperliquidCloseFill{TotalSz: 0.4, AvgPx: 1}},
+			Platform: "hyperliquid",
+		}, nil
+	}
+	runPendingHyperliquidCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		"0xabc",
+		[]HLPosition{{Coin: "ETH", Size: 0.4, EntryPrice: 1}},
+		true, // hl state already fetched this cycle
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+	)
+	if len(calls) != 1 || calls[0] != "ETH:0.4" {
+		t.Errorf("closer calls=%v want [ETH:0.4] (recovered pending should drain full szi as sole owner)", calls)
+	}
+	if state.Strategies["hl-a"].RiskState.PendingHyperliquidCircuitClose != nil {
+		t.Error("expected pending cleared after successful recovery close")
+	}
+}
+
+// If the stuck-CB strategy has no on-chain position (e.g. operator already
+// closed it manually), recovery must be a no-op rather than submitting a
+// zero-size order.
+func TestRunPendingHyperliquidCircuitCloses_StuckCBNoOnChainPositionIsNoOp(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-a": {
+				ID: "hl-a",
+				RiskState: RiskState{
+					CircuitBreaker:      true,
+					CircuitBreakerUntil: time.Now().Add(24 * time.Hour),
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "hl-a", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string, partialSz *float64) (*HyperliquidCloseResult, error) {
+		calls = append(calls, sym)
+		return &HyperliquidCloseResult{Close: &HyperliquidClose{Symbol: sym}, Platform: "hyperliquid"}, nil
+	}
+	runPendingHyperliquidCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		"0xabc",
+		nil, // no on-chain positions
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+	)
+	if len(calls) != 0 {
+		t.Errorf("expected no closer calls when no on-chain position, got %v", calls)
+	}
+	if state.Strategies["hl-a"].RiskState.PendingHyperliquidCircuitClose != nil {
+		t.Error("pending should remain nil when recovery has no on-chain position to close")
+	}
+}
+
 func TestRunPendingHyperliquidCircuitCloses_ClearsOnSuccess(t *testing.T) {
 	state := &AppState{
 		Strategies: map[string]*StrategyState{

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 )
 
 // Tests in this file mutate package-level hlMainnetURL and must NOT use t.Parallel().
@@ -1162,8 +1163,12 @@ func TestReconciliationGapOmittedWhenEmpty(t *testing.T) {
 // invocation and returns either a canned success or an error per coin.
 func fakeCloser(errs map[string]error) (HyperliquidLiveCloser, *[]string) {
 	var calls []string
-	closer := func(symbol string) (*HyperliquidCloseResult, error) {
-		calls = append(calls, symbol)
+	closer := func(symbol string, partialSz *float64) (*HyperliquidCloseResult, error) {
+		if partialSz != nil {
+			calls = append(calls, fmt.Sprintf("%s:%g", symbol, *partialSz))
+		} else {
+			calls = append(calls, symbol)
+		}
 		if err, ok := errs[symbol]; ok {
 			return nil, err
 		}
@@ -1359,7 +1364,7 @@ func TestForceCloseHyperliquidLive_UnownedPositionIgnored(t *testing.T) {
 // no-op. The caller's onChainConfirmedFlat check then proceeds straight to
 // virtual state mutation, matching pre-#341 behavior for non-HL deployments.
 func TestForceCloseHyperliquidLive_EmptyInputs(t *testing.T) {
-	report := forceCloseHyperliquidLive(context.Background(), nil, nil, func(string) (*HyperliquidCloseResult, error) {
+	report := forceCloseHyperliquidLive(context.Background(), nil, nil, func(string, *float64) (*HyperliquidCloseResult, error) {
 		t.Fatalf("closer should not be called with empty inputs")
 		return nil, nil
 	})
@@ -1381,7 +1386,7 @@ func TestForceCloseHyperliquidLive_AdapterAlreadyFlatRoutedCorrectly(t *testing.
 	positions := []HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 3000}}
 
 	var calls []string
-	closer := func(symbol string) (*HyperliquidCloseResult, error) {
+	closer := func(symbol string, partialSz *float64) (*HyperliquidCloseResult, error) {
 		calls = append(calls, symbol)
 		return &HyperliquidCloseResult{
 			Close:    &HyperliquidClose{Symbol: symbol, AlreadyFlat: true},
@@ -1402,5 +1407,88 @@ func TestForceCloseHyperliquidLive_AdapterAlreadyFlatRoutedCorrectly(t *testing.
 	}
 	if len(calls) != 1 || calls[0] != "ETH" {
 		t.Errorf("closer should still be called once (Go side saw non-zero szi), got %v", calls)
+	}
+}
+
+func TestComputeHyperliquidCircuitCloseQty_SoleOwnerFullSzi(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	pos := []HLPosition{{Coin: "ETH", Size: -0.4, EntryPrice: 3000}}
+	q, ok := computeHyperliquidCircuitCloseQty("ETH", "hl-eth", pos, hlLive)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if math.Abs(q-0.4) > 1e-9 {
+		t.Errorf("qty=%.6f want 0.4 (full abs szi for sole owner)", q)
+	}
+}
+
+func TestComputeHyperliquidCircuitCloseQty_Shared50_50(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-a", Platform: "hyperliquid", Type: "perps", CapitalPct: 0.5, Capital: 1000,
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-b", Platform: "hyperliquid", Type: "perps", CapitalPct: 0.5, Capital: 1000,
+			Args: []string{"ema", "ETH", "1h", "--mode=live"}},
+	}
+	pos := []HLPosition{{Coin: "ETH", Size: 0.517, EntryPrice: 3000}}
+	q, ok := computeHyperliquidCircuitCloseQty("ETH", "hl-a", pos, hlLive)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	want := 0.517 * 0.5
+	if math.Abs(q-want) > 1e-9 {
+		t.Errorf("qty=%.6f want %.6f", q, want)
+	}
+}
+
+func TestRunPendingHyperliquidCircuitCloses_ClearsOnSuccess(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-a": {
+				ID: "hl-a",
+				RiskState: RiskState{
+					PendingHyperliquidCircuitClose: &HyperliquidCircuitClosePending{
+						Coins: []HyperliquidCircuitCloseCoin{{Coin: "ETH", Sz: 0.1}},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "hl-a", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string, partialSz *float64) (*HyperliquidCloseResult, error) {
+		if partialSz != nil {
+			calls = append(calls, fmt.Sprintf("%s:%g", sym, *partialSz))
+		} else {
+			calls = append(calls, sym)
+		}
+		return &HyperliquidCloseResult{
+			Close:    &HyperliquidClose{Symbol: sym, Fill: &HyperliquidCloseFill{TotalSz: 0.1, AvgPx: 1}},
+			Platform: "hyperliquid",
+		}, nil
+	}
+	runPendingHyperliquidCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		"0xabc",
+		[]HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 1}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+	)
+	if state.Strategies["hl-a"].RiskState.PendingHyperliquidCircuitClose != nil {
+		t.Error("expected pending cleared after successful close")
+	}
+	if len(calls) != 1 || calls[0] != "ETH:0.1" {
+		t.Errorf("closer calls=%v want [ETH:0.1]", calls)
 	}
 }

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -18,7 +18,7 @@ import (
 // and maps coin → canned error. Missing keys yield a synthetic success.
 func stubHLLiveCloser(errs map[string]error) (HyperliquidLiveCloser, *[]string) {
 	var calls []string
-	closer := func(symbol string) (*HyperliquidCloseResult, error) {
+	closer := func(symbol string, partialSz *float64) (*HyperliquidCloseResult, error) {
 		calls = append(calls, symbol)
 		if err, ok := errs[symbol]; ok && err != nil {
 			return nil, err

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -560,7 +561,10 @@ func main() {
 			walletBalances := make(map[SharedWalletKey]float64)
 			var hlPositions []HLPosition
 			var hlStateFetched bool
-			if hlAddr != "" && (hlShared || len(hlLiveDue) > 0) {
+			// Fetch clearinghouseState whenever any live HL strategy exists (#356
+			// per-strategy circuit closes need fresh positions even if no HL
+			// strategy is due this cycle).
+			if hlAddr != "" && len(hlLiveAll) > 0 {
 				bal, pos, err := fetchHyperliquidState(hlAddr)
 				if err != nil {
 					fmt.Printf("[WARN] hyperliquid clearinghouseState fetch failed: %v — falling back to per-wallet max and skipping position sync this cycle\n", err)
@@ -603,6 +607,12 @@ func main() {
 				// from the exchange (#341): closing virtually but never sending
 				// the reduce-only order left on-chain positions live, and once
 				// virtual was empty no future cycle could detect the leak.
+				// Portfolio kill owns all HL closes — drop per-strategy pending.
+				for _, ss := range state.Strategies {
+					if ss != nil {
+						ss.RiskState.PendingHyperliquidCircuitClose = nil
+					}
+				}
 			}
 			notionalBlocked = nb
 			if notionalBlocked {
@@ -663,6 +673,7 @@ func main() {
 				for _, sc := range cfg.Strategies {
 					if s, ok := state.Strategies[sc.ID]; ok {
 						forceCloseAllPositions(s, prices, nil)
+						s.RiskState.PendingHyperliquidCircuitClose = nil
 					}
 				}
 				mu.Unlock()
@@ -738,6 +749,23 @@ func main() {
 			}
 
 			if !killSwitchFired {
+				// #356: Live HL per-strategy circuit breaker closes (reduce-only,
+				// proportional on shared coins). Runs before reconcile so the next
+				// sync sees updated on-chain sizes.
+				if len(hlLiveAll) > 0 {
+					runPendingHyperliquidCircuitCloses(
+						context.Background(),
+						state,
+						cfg.Strategies,
+						hlAddr,
+						hlPositions,
+						hlStateFetched,
+						defaultHLStateFetcher,
+						defaultHyperliquidLiveCloser,
+						90*time.Second,
+						&mu,
+					)
+				}
 				// Pre-phase: sync on-chain positions for due live HL strategies.
 				// Reuses the clearinghouseState already fetched above for the
 				// shared-wallet risk check (#243 review feedback) so we don't
@@ -820,8 +848,12 @@ func main() {
 					mu.RUnlock()
 
 					// Phase 2: Lock — CheckRisk (fast, no I/O)
+					var hlRiskAssist *HLRiskAssist
+					if hlStateFetched && len(hlLiveAll) > 0 {
+						hlRiskAssist = &HLRiskAssist{HLPositions: hlPositions, HLLiveAll: hlLiveAll}
+					}
 					mu.Lock()
-					allowed, reason := CheckRisk(stratState, pv, prices, logger)
+					allowed, reason := CheckRisk(&sc, stratState, pv, prices, logger, hlRiskAssist)
 					mu.Unlock()
 					if !allowed {
 						logger.Warn("Risk block: %s (portfolio=$%.2f)", reason, pv)

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -673,7 +673,10 @@ func main() {
 				for _, sc := range cfg.Strategies {
 					if s, ok := state.Strategies[sc.ID]; ok {
 						forceCloseAllPositions(s, prices, nil)
-						s.RiskState.PendingHyperliquidCircuitClose = nil
+						// Pending HL circuit close was already cleared above
+						// when portfolio kill fired (line ~611); nothing to do
+						// here. The per-strategy pending field is owned by the
+						// portfolio kill path once it takes over flattening.
 					}
 				}
 				mu.Unlock()

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -557,12 +557,19 @@ type HLRiskAssist struct {
 }
 
 // MarshalPendingHLCloseJSON returns a DB-safe JSON blob for the pending field.
+// A marshal error is logged loudly rather than silently swallowed — on a
+// simple {string, float64} struct this branch is essentially unreachable,
+// but silently returning "" would persist a blank column that wipes the
+// pending close on reload. Logging gives operators a chance to notice if
+// this ever fires (#356 review).
 func (r *RiskState) MarshalPendingHLCloseJSON() string {
 	if r == nil || r.PendingHyperliquidCircuitClose == nil {
 		return ""
 	}
 	b, err := json.Marshal(r.PendingHyperliquidCircuitClose)
 	if err != nil {
+		fmt.Printf("[CRITICAL] MarshalPendingHLCloseJSON: refusing to persist pending HL circuit close — json.Marshal failed: %v (pending=%+v)\n",
+			err, r.PendingHyperliquidCircuitClose)
 		return ""
 	}
 	return string(b)

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -570,7 +570,10 @@ func (r *RiskState) MarshalPendingHLCloseJSON() string {
 
 // UnmarshalPendingHLCloseJSON restores PendingHyperliquidCircuitClose from DB.
 func (r *RiskState) UnmarshalPendingHLCloseJSON(raw string) {
-	if r == nil || raw == "" {
+	if r == nil {
+		return
+	}
+	if raw == "" {
 		r.PendingHyperliquidCircuitClose = nil
 		return
 	}

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"time"
@@ -529,6 +530,79 @@ type RiskState struct {
 	TotalTrades         int       `json:"total_trades"`
 	WinningTrades       int       `json:"winning_trades"`
 	LosingTrades        int       `json:"losing_trades"`
+	// PendingHyperliquidCircuitClose is set when a live HL perps strategy trips
+	// a per-strategy circuit breaker (#356). The main loop drains this with
+	// reduce-only closes (full or proportional for shared coins) before
+	// clearing the field. Serialized to SQLite as risk_pending_hl_close_json.
+	PendingHyperliquidCircuitClose *HyperliquidCircuitClosePending `json:"pending_hl_circuit_close,omitempty"`
+}
+
+// HyperliquidCircuitClosePending requests on-chain reduce-only closes after a
+// per-strategy circuit breaker fired on a live Hyperliquid wallet (#356).
+type HyperliquidCircuitClosePending struct {
+	Coins []HyperliquidCircuitCloseCoin `json:"coins"`
+}
+
+// HyperliquidCircuitCloseCoin is one coin leg of a pending HL circuit close.
+type HyperliquidCircuitCloseCoin struct {
+	Coin string  `json:"coin"`
+	Sz   float64 `json:"sz"` // positive magnitude in coin units
+}
+
+// HLRiskAssist carries pre-fetched Hyperliquid clearinghouse positions for
+// per-strategy circuit-breaker close sizing (#356). Nil disables HL pending.
+type HLRiskAssist struct {
+	HLPositions []HLPosition
+	HLLiveAll   []StrategyConfig
+}
+
+// MarshalPendingHLCloseJSON returns a DB-safe JSON blob for the pending field.
+func (r *RiskState) MarshalPendingHLCloseJSON() string {
+	if r == nil || r.PendingHyperliquidCircuitClose == nil {
+		return ""
+	}
+	b, err := json.Marshal(r.PendingHyperliquidCircuitClose)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// UnmarshalPendingHLCloseJSON restores PendingHyperliquidCircuitClose from DB.
+func (r *RiskState) UnmarshalPendingHLCloseJSON(raw string) {
+	if r == nil || raw == "" {
+		r.PendingHyperliquidCircuitClose = nil
+		return
+	}
+	var p HyperliquidCircuitClosePending
+	if err := json.Unmarshal([]byte(raw), &p); err != nil || len(p.Coins) == 0 {
+		r.PendingHyperliquidCircuitClose = nil
+		return
+	}
+	r.PendingHyperliquidCircuitClose = &p
+}
+
+func setHyperliquidCircuitBreakerPending(sc *StrategyConfig, s *StrategyState, hlAssist *HLRiskAssist) {
+	if sc == nil || hlAssist == nil || len(hlAssist.HLPositions) == 0 {
+		return
+	}
+	if sc.Platform != "hyperliquid" || sc.Type != "perps" || !hyperliquidIsLive(sc.Args) {
+		return
+	}
+	sym := hyperliquidSymbol(sc.Args)
+	if sym == "" {
+		return
+	}
+	if _, ok := s.Positions[sym]; !ok {
+		return
+	}
+	qty, ok := computeHyperliquidCircuitCloseQty(sym, s.ID, hlAssist.HLPositions, hlAssist.HLLiveAll)
+	if !ok || qty <= 0 {
+		return
+	}
+	s.RiskState.PendingHyperliquidCircuitClose = &HyperliquidCircuitClosePending{
+		Coins: []HyperliquidCircuitCloseCoin{{Coin: sym, Sz: qty}},
+	}
 }
 
 // rolloverDailyPnL resets DailyPnL to zero whenever the UTC date has advanced
@@ -681,7 +755,10 @@ func perpsMarginDrawdownInputs(s *StrategyState, prices map[string]float64) (unr
 }
 
 // CheckRisk evaluates risk state and returns whether trading is allowed.
-func CheckRisk(s *StrategyState, portfolioValue float64, prices map[string]float64, logger *StrategyLogger) (bool, string) {
+// sc is the strategy config for this state (nil in some tests — HL pending
+// logic is skipped). hlAssist carries HL clearinghouse positions when fetched
+// this cycle so live perps can enqueue on-chain closes on circuit breaker (#356).
+func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, prices map[string]float64, logger *StrategyLogger, hlAssist *HLRiskAssist) (bool, string) {
 	r := &s.RiskState
 	now := time.Now().UTC()
 
@@ -743,6 +820,7 @@ func CheckRisk(s *StrategyState, portfolioValue float64, prices map[string]float
 		if r.TotalTrades > 0 && r.CurrentDrawdownPct > r.MaxDrawdownPct {
 			r.CircuitBreaker = true
 			r.CircuitBreakerUntil = now.Add(24 * time.Hour)
+			setHyperliquidCircuitBreakerPending(sc, s, hlAssist)
 			forceCloseAllPositions(s, prices, logger)
 			return false, fmt.Sprintf("max drawdown exceeded (%.1f%% > %.1f%%, portfolio=$%.2f peak=$%.2f, denom=%s=$%.2f)",
 				r.CurrentDrawdownPct, r.MaxDrawdownPct, portfolioValue, r.PeakValue, denomLabel, denom)
@@ -753,6 +831,7 @@ func CheckRisk(s *StrategyState, portfolioValue float64, prices map[string]float
 	if r.ConsecutiveLosses >= 5 {
 		r.CircuitBreaker = true
 		r.CircuitBreakerUntil = now.Add(1 * time.Hour)
+		setHyperliquidCircuitBreakerPending(sc, s, hlAssist)
 		forceCloseAllPositions(s, prices, logger)
 		return false, "5 consecutive losses"
 	}

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -111,7 +112,7 @@ func TestCheckRisk_RollsOverDailyPnL(t *testing.T) {
 	s.RiskState.PeakValue = 1000.0
 	s.RiskState.MaxDrawdownPct = 50.0
 
-	CheckRisk(s, 1000.0, nil, nil)
+	CheckRisk(nil, s, 1000.0, nil, nil, nil)
 
 	if s.RiskState.DailyPnL != 0 {
 		t.Errorf("expected DailyPnL reset to 0 by CheckRisk; got %.2f", s.RiskState.DailyPnL)
@@ -164,7 +165,7 @@ func TestCheckRisk_ForceCloseOnDrawdown(t *testing.T) {
 	prices := map[string]float64{"BTC": 30000.0}
 	pv := PortfolioValue(s, prices)
 
-	allowed, reason := CheckRisk(s, pv, prices, nil)
+	allowed, reason := CheckRisk(nil, s, pv, prices, nil, nil)
 
 	if allowed {
 		t.Error("expected CheckRisk to return false on drawdown breach")
@@ -751,7 +752,7 @@ func TestCheckRisk_ConsecutiveLossesForceClose(t *testing.T) {
 	prices := map[string]float64{"BTC": 50000.0}
 	pv := PortfolioValue(s, prices)
 
-	allowed, reason := CheckRisk(s, pv, prices, nil)
+	allowed, reason := CheckRisk(nil, s, pv, prices, nil, nil)
 
 	if allowed {
 		t.Errorf("expected circuit breaker to fire; reason=%s", reason)
@@ -1281,7 +1282,7 @@ func TestCheckRisk_PerpsMarginDrawdown_FiresEarly(t *testing.T) {
 	prices := map[string]float64{"ETH": 2307.5}
 	pv := PortfolioValue(s, prices)
 
-	allowed, reason := CheckRisk(s, pv, prices, nil)
+	allowed, reason := CheckRisk(nil, s, pv, prices, nil, nil)
 
 	if allowed {
 		t.Errorf("expected circuit breaker to fire on margin-based drawdown; reason=%s", reason)
@@ -1295,6 +1296,65 @@ func TestCheckRisk_PerpsMarginDrawdown_FiresEarly(t *testing.T) {
 	// Positions liquidated on circuit-breaker fire.
 	if len(s.Positions) != 0 {
 		t.Errorf("expected positions force-closed; got %d", len(s.Positions))
+	}
+}
+
+// TestCheckRisk_LiveHLSharedCoin_SetsPendingPartialClose verifies #356: a live
+// HL strategy that shares a coin with another configured live HL strategy gets
+// a proportional pending on-chain close (capital_pct weights), not the full
+// wallet szi.
+func TestCheckRisk_LiveHLSharedCoin_SetsPendingPartialClose(t *testing.T) {
+	sc := StrategyConfig{
+		ID: "hl-tema", Platform: "hyperliquid", Type: "perps",
+		CapitalPct: 0.5, Capital: 500,
+		Args: []string{"triple_ema", "ETH", "1h", "--mode=live"},
+	}
+	hlLiveAll := []StrategyConfig{
+		sc,
+		{ID: "hl-rmc", Platform: "hyperliquid", Type: "perps",
+			CapitalPct: 0.5, Capital: 500,
+			Args: []string{"rsi_macd", "ETH", "1h", "--mode=live"}},
+	}
+	assist := &HLRiskAssist{
+		HLPositions: []HLPosition{{Coin: "ETH", Size: 0.517, EntryPrice: 3000}},
+		HLLiveAll:   hlLiveAll,
+	}
+
+	s := &StrategyState{
+		ID:       sc.ID,
+		Type:     "perps",
+		Platform: "hyperliquid",
+		Cash:     584.0,
+		RiskState: RiskState{
+			PeakValue:      589.0,
+			MaxDrawdownPct: 25.0,
+			TotalTrades:    1,
+			DailyPnLDate:   todayUTC(),
+		},
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.236, AvgCost: 2357.0, Side: "long", Multiplier: 1, Leverage: 20},
+		},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+	}
+	prices := map[string]float64{"ETH": 2307.5}
+	pv := PortfolioValue(s, prices)
+
+	_, _ = CheckRisk(&sc, s, pv, prices, nil, assist)
+
+	if s.RiskState.PendingHyperliquidCircuitClose == nil {
+		t.Fatal("expected PendingHyperliquidCircuitClose after CB fire")
+	}
+	if len(s.RiskState.PendingHyperliquidCircuitClose.Coins) != 1 {
+		t.Fatalf("expected 1 pending coin, got %d", len(s.RiskState.PendingHyperliquidCircuitClose.Coins))
+	}
+	c0 := s.RiskState.PendingHyperliquidCircuitClose.Coins[0]
+	if c0.Coin != "ETH" {
+		t.Errorf("coin=%q want ETH", c0.Coin)
+	}
+	want := 0.517 * 0.5
+	if math.Abs(c0.Sz-want) > 1e-6 {
+		t.Errorf("pending sz=%.6f want %.6f (half of shared on-chain 0.517)", c0.Sz, want)
 	}
 }
 
@@ -1322,7 +1382,7 @@ func TestCheckRisk_PerpsMarginDrawdown_BelowThreshold(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH": 2355.0}
 	pv := PortfolioValue(s, prices)
-	allowed, reason := CheckRisk(s, pv, prices, nil)
+	allowed, reason := CheckRisk(nil, s, pv, prices, nil, nil)
 	if !allowed {
 		t.Errorf("expected allowed below margin drawdown threshold; reason=%s dd=%.2f",
 			reason, s.RiskState.CurrentDrawdownPct)
@@ -1357,7 +1417,7 @@ func TestCheckRisk_PerpsPriorRealizedLossesDoNotInflateDrawdown(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH": 3000}
 	pv := PortfolioValue(s, prices)
-	allowed, reason := CheckRisk(s, pv, prices, nil)
+	allowed, reason := CheckRisk(nil, s, pv, prices, nil, nil)
 	if !allowed {
 		t.Errorf("expected fresh position with no unrealized PnL to NOT fire; reason=%s dd=%.2f",
 			reason, s.RiskState.CurrentDrawdownPct)
@@ -1390,7 +1450,7 @@ func TestCheckRisk_PerpsNoOpenPositions_FallsBackToPeak(t *testing.T) {
 	}
 	// Portfolio = cash only = $700. Peak-relative drawdown = 30% → fires.
 	pv := PortfolioValue(s, nil)
-	allowed, _ := CheckRisk(s, pv, nil, nil)
+	allowed, _ := CheckRisk(nil, s, pv, nil, nil, nil)
 	if allowed {
 		t.Error("expected peak-relative drawdown to fire when no perps margin deployed")
 	}
@@ -1421,7 +1481,7 @@ func TestCheckRisk_SpotUnchanged(t *testing.T) {
 	// Portfolio = 500 + 300 = $800. Peak drawdown = 20% < 25% → allowed.
 	prices := map[string]float64{"BTC/USDT": 30000}
 	pv := PortfolioValue(s, prices)
-	allowed, _ := CheckRisk(s, pv, prices, nil)
+	allowed, _ := CheckRisk(nil, s, pv, prices, nil, nil)
 	if !allowed {
 		t.Errorf("expected spot strategy to stay within 25%% peak drawdown; dd=%.2f",
 			s.RiskState.CurrentDrawdownPct)

--- a/shared_scripts/close_hyperliquid_position.py
+++ b/shared_scripts/close_hyperliquid_position.py
@@ -11,6 +11,10 @@ state can diverge from the on-chain net.
 
 Usage:
     close_hyperliquid_position.py --symbol=ETH --mode=live
+    close_hyperliquid_position.py --symbol=ETH --mode=live --sz=0.25
+
+Optional ``--sz`` submits a partial reduce-only close (coin units). Omit for
+full position close (portfolio kill switch and sole-owner circuit breakers).
 
 Live mode is required (kill switch is meaningful only against real
 positions). Stdout is always a single JSON envelope: `{"close": ..., "platform": ...,
@@ -34,6 +38,12 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--symbol", required=True)
     parser.add_argument("--mode", default="live")
+    parser.add_argument(
+        "--sz",
+        type=float,
+        default=None,
+        help="partial close size in coin units (omit for full position)",
+    )
     args = parser.parse_args()
 
     if args.mode != "live":
@@ -48,7 +58,7 @@ def main():
     try:
         from adapter import HyperliquidExchangeAdapter
         adapter = HyperliquidExchangeAdapter()
-        result = adapter.market_close(args.symbol)
+        result = adapter.market_close(args.symbol, args.sz)
     except Exception as e:
         traceback.print_exc(file=sys.stderr)
         _emit_error(args.symbol, str(e))


### PR DESCRIPTION
## Summary

Implements [#356](https://github.com/richkuo/go-trader/issues/356): when a **live Hyperliquid perps** strategy trips a per-strategy circuit breaker (max drawdown or consecutive losses), the scheduler now enqueues **real** reduce-only on-chain closes instead of only clearing virtual state via `forceCloseAllPositions`.

- **Shared coin** (multiple live HL strategies on the same wallet): close size is proportional to `capital_pct` / `capital` weights vs the on-chain `|szi|`.
- **Sole owner** of the coin: full `|szi|` close (same as kill-switch semantics for that leg).
- **Persistence**: `risk_pending_hl_close_json` on `strategies` so pending closes survive restarts; drained each cycle before HL reconcile.
- **Portfolio kill switch** clears per-strategy HL pending when aggregate risk owns flattening.

## Test plan

- [x] `go test -C scheduler ./...`
- [x] `pytest platforms/hyperliquid/test_adapter.py`


Made with [Cursor](https://cursor.com)