### PR TITLE
[#360 phase 2] OKX perps per-strategy circuit-breaker on-chain close

### DIFF
--- a/platforms/okx/adapter.py
+++ b/platforms/okx/adapter.py
@@ -192,9 +192,18 @@ class OKXExchangeAdapter:
             params = {"tdMode": "cash"}
         return self._exchange.create_market_order(pair, side, size, params=params)
 
-    def market_close(self, symbol: str) -> dict:
+    def market_close(self, symbol: str, sz: float | None = None) -> dict:
         """
-        Close all open perpetual swap positions for a symbol.
+        Close an open perpetual swap position for a symbol (reduce-only).
+
+        When ``sz`` is None, closes the full on-chain contracts for the
+        position (portfolio kill switch / sole-owner circuit breakers).
+        When ``sz`` is set, submits a reduce-only market order for that
+        contract quantity only — used for shared-wallet per-strategy
+        circuit breakers (#360). The caller is responsible for sizing;
+        OKX enforces reduceOnly=True on the order itself so an oversized
+        request cannot flip the position.
+
         Only available in live mode; raises RuntimeError in paper mode.
         """
         if not self._is_live:
@@ -209,11 +218,37 @@ class OKXExchangeAdapter:
             if contracts > 0:
                 pos_side = pos.get("side", "")
                 close_side = "sell" if pos_side == "long" else "buy"
+                close_sz = contracts
+                if sz is not None:
+                    if sz <= 0:
+                        continue
+                    close_sz = min(float(sz), contracts)
+                    if close_sz <= 0:
+                        continue
                 results.append(self._exchange.create_market_order(
-                    pair, close_side, contracts,
+                    pair, close_side, close_sz,
                     params={"tdMode": "cross", "reduceOnly": True}
                 ))
         return results[0] if results else {}
+
+    def get_account_balance(self) -> float:
+        """Return total USDT-denominated account value for shared-wallet
+        aggregation (#360 phase 2 — unlocks multi-strategy OKX portfolio
+        value correctness). Sums free + used USDT; callers that need to
+        include open-position PnL should rely on ccxt's total field.
+
+        Only available in live mode; raises RuntimeError in paper mode.
+        """
+        if not self._is_live:
+            raise RuntimeError(
+                "get_account_balance requires live mode (set OKX_API_KEY, OKX_API_SECRET, OKX_PASSPHRASE)"
+            )
+        bal = self._exchange.fetch_balance()
+        total = bal.get("total") or {}
+        try:
+            return float(total.get("USDT") or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
 
     # ─────────────────────────────────────────────
     # Options Protocol methods

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -728,7 +728,9 @@ type OKXCloseResult struct {
 }
 
 // RunOKXClose runs close_okx_position.py to submit a reduce-only market
-// close for a single OKX swap coin (#345).
+// close for a single OKX swap coin (#345). When partialSz is non-nil, submits
+// a partial reduce-only close for that coin quantity (#360 shared-wallet
+// per-strategy circuit breakers).
 //
 // Contract mirrors RunHyperliquidClose: a non-nil error is returned for
 // ANY failure — non-zero subprocess exit, malformed JSON, or a JSON
@@ -736,10 +738,13 @@ type OKXCloseResult struct {
 // treat the close as confirmed by the adapter. Kill-switch correctness
 // depends on this: any ambiguous response must surface as error so the
 // switch stays latched and retries next cycle.
-func RunOKXClose(script, symbol string) (*OKXCloseResult, string, error) {
+func RunOKXClose(script, symbol string, partialSz *float64) (*OKXCloseResult, string, error) {
 	args := []string{
 		fmt.Sprintf("--symbol=%s", symbol),
 		"--mode=live",
+	}
+	if partialSz != nil {
+		args = append(args, fmt.Sprintf("--sz=%s", strconv.FormatFloat(*partialSz, 'f', -1, 64)))
 	}
 	stdout, stderr, runErr := RunPythonScript(script, args)
 	return parseOKXCloseOutput(stdout, string(stderr), runErr)
@@ -834,6 +839,50 @@ func parseOKXPositionsOutput(stdout []byte, stderrStr string, runErr error) (*OK
 
 	default:
 		return nil, stderrStr, fmt.Errorf("parse positions output: %v (run err: %v, stdout: %s)", parseErr, runErr, string(stdout))
+	}
+}
+
+// OKXBalanceResult is the JSON output from fetch_okx_balance.py (#360).
+type OKXBalanceResult struct {
+	Balance   float64 `json:"balance"`
+	Platform  string  `json:"platform"`
+	Timestamp string  `json:"timestamp"`
+	Error     string  `json:"error,omitempty"`
+}
+
+// RunOKXFetchBalance runs fetch_okx_balance.py and returns the parsed result
+// (#360 phase 2 of #357). Used by defaultSharedWalletBalance to unlock
+// multi-strategy OKX portfolio value correctness. Follows the same
+// contract as RunOKXClose / RunOKXFetchPositions: non-nil error on ANY
+// failure path so callers preserve the kill switch on uncertainty.
+func RunOKXFetchBalance(script string) (*OKXBalanceResult, string, error) {
+	stdout, stderr, runErr := RunPythonScript(script, nil)
+	return parseOKXBalanceOutput(stdout, string(stderr), runErr)
+}
+
+// parseOKXBalanceOutput is the pure parser for RunOKXFetchBalance. Extracted
+// so the decision logic can be tested without spawning .venv/bin/python3
+// (absent in the Go CI job). Mirrors parseOKXPositionsOutput's 5-case
+// matrix — contract drift across fetch parsers would be bad.
+func parseOKXBalanceOutput(stdout []byte, stderrStr string, runErr error) (*OKXBalanceResult, string, error) {
+	var result OKXBalanceResult
+	parseErr := json.Unmarshal(stdout, &result)
+
+	switch {
+	case runErr == nil && parseErr == nil && result.Error == "":
+		return &result, stderrStr, nil
+
+	case runErr == nil && parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("fetch balance reported error despite exit 0: %s", result.Error)
+
+	case parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("fetch balance failed: %s", result.Error)
+
+	case parseErr == nil && runErr != nil:
+		return &result, stderrStr, fmt.Errorf("fetch balance subprocess exit %v with no error field (stderr: %s)", runErr, stderrStr)
+
+	default:
+		return nil, stderrStr, fmt.Errorf("parse balance output: %v (run err: %v, stdout: %s)", parseErr, runErr, string(stdout))
 	}
 }
 

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -97,6 +97,10 @@ func fetchHyperliquidBalance(accountAddress string) (float64, error) {
 	return val, nil
 }
 
+// okxBalanceScript is the path to the Python balance fetcher. Exposed as a
+// var so tests can substitute.
+var okxBalanceScript = "shared_scripts/fetch_okx_balance.py"
+
 // defaultSharedWalletBalance dispatches a real on-chain balance lookup by
 // platform name for use with ClearLatchedKillSwitchSharedWallet (#244).
 // Returns an error for any platform that does not (yet) expose a real
@@ -109,6 +113,21 @@ func defaultSharedWalletBalance(platform string) (float64, error) {
 			return 0, fmt.Errorf("HYPERLIQUID_ACCOUNT_ADDRESS not set")
 		}
 		return fetchHyperliquidBalance(addr)
+	case "okx":
+		// #360 phase 2 of #357: unlocks multi-strategy OKX portfolio value
+		// correctness. fetch_okx_balance.py reads the CCXT-unified USDT
+		// total for the configured API key account.
+		if os.Getenv("OKX_API_KEY") == "" {
+			return 0, fmt.Errorf("OKX_API_KEY not set")
+		}
+		result, stderr, err := RunOKXFetchBalance(okxBalanceScript)
+		if stderr != "" {
+			fmt.Fprintf(os.Stderr, "[okx-balance] stderr: %s\n", stderr)
+		}
+		if err != nil {
+			return 0, err
+		}
+		return result.Balance, nil
 	}
 	return 0, fmt.Errorf("no shared-wallet balance fetcher for platform %q", platform)
 }

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -50,7 +50,7 @@ func stubHLStateFetcher(positions []HLPosition, err error) (HLStateFetcher, *int
 // a synthetic success that should never be triggered in HL-only tests.
 func stubOKXLiveCloser(errs map[string]error) (OKXLiveCloser, *[]string) {
 	var calls []string
-	closer := func(symbol string) (*OKXCloseResult, error) {
+	closer := func(symbol string, partialSz *float64) (*OKXCloseResult, error) {
 		calls = append(calls, symbol)
 		if err, ok := errs[symbol]; ok && err != nil {
 			return nil, err

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -577,6 +577,36 @@ func main() {
 				}
 			}
 
+			// #360: Fetch OKX positions once if any live OKX perps strategy
+			// exists. Drives per-strategy circuit-breaker pending closes
+			// (PlatformRiskAssist.OKXPositions). Gated on OKX_API_KEY so
+			// paper-only configs skip the subprocess entirely.
+			okxHasCreds := os.Getenv("OKX_API_KEY") != ""
+			okxKey := SharedWalletKey{Platform: "okx", Account: os.Getenv("OKX_API_KEY")}
+			_, okxShared := sharedWallets[okxKey]
+			var okxPositions []OKXPosition
+			var okxStateFetched bool
+			if okxHasCreds && len(okxLivePerps) > 0 {
+				pos, err := defaultOKXPositionsFetcher()
+				if err != nil {
+					fmt.Printf("[WARN] okx fetch_positions failed: %v — skipping per-strategy OKX circuit enqueue this cycle\n", err)
+				} else {
+					okxStateFetched = true
+					okxPositions = pos
+				}
+			}
+			// #360 phase 2 of #357: fetch the unified USDT balance for the
+			// shared-wallet risk check when 2+ live OKX perps strategies share
+			// an API key. Independent subprocess so a fetch_positions outage
+			// doesn't starve the balance read.
+			if okxHasCreds && okxShared {
+				if bal, err := defaultSharedWalletBalance("okx"); err != nil {
+					fmt.Printf("[WARN] okx balance fetch failed: %v — falling back to per-wallet max this cycle\n", err)
+				} else {
+					walletBalances[okxKey] = bal
+				}
+			}
+
 			mu.RLock()
 			totalPV, usedPVFallback := computeTotalPortfolioValue(cfg.Strategies, state, prices, walletBalances, sharedWallets)
 			totalNotional := PortfolioNotional(state.Strategies, prices)
@@ -607,10 +637,11 @@ func main() {
 				// from the exchange (#341): closing virtually but never sending
 				// the reduce-only order left on-chain positions live, and once
 				// virtual was empty no future cycle could detect the leak.
-				// Portfolio kill owns all HL closes — drop per-strategy pending.
+				// Portfolio kill owns all platform closes — drop per-strategy pending.
 				for _, ss := range state.Strategies {
 					if ss != nil {
 						ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseHyperliquid)
+						ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseOKX)
 					}
 				}
 			}
@@ -769,6 +800,22 @@ func main() {
 						&mu,
 					)
 				}
+				// #360: Live OKX per-strategy circuit breaker closes. Same shape
+				// as the HL drain — the pending map is keyed per platform.
+				if len(okxLivePerps) > 0 && okxHasCreds {
+					runPendingOKXCircuitCloses(
+						context.Background(),
+						state,
+						cfg.Strategies,
+						okxHasCreds,
+						okxPositions,
+						okxStateFetched,
+						defaultOKXPositionsFetcher,
+						defaultOKXLiveCloser,
+						90*time.Second,
+						&mu,
+					)
+				}
 				// Pre-phase: sync on-chain positions for due live HL strategies.
 				// Reuses the clearinghouseState already fetched above for the
 				// shared-wallet risk check (#243 review feedback) so we don't
@@ -852,8 +899,16 @@ func main() {
 
 					// Phase 2: Lock — CheckRisk (fast, no I/O)
 					var riskAssist *PlatformRiskAssist
-					if hlStateFetched && len(hlLiveAll) > 0 {
-						riskAssist = &PlatformRiskAssist{HLPositions: hlPositions, HLLiveAll: hlLiveAll}
+					if (hlStateFetched && len(hlLiveAll) > 0) || (okxStateFetched && len(okxLivePerps) > 0) {
+						riskAssist = &PlatformRiskAssist{}
+						if hlStateFetched && len(hlLiveAll) > 0 {
+							riskAssist.HLPositions = hlPositions
+							riskAssist.HLLiveAll = hlLiveAll
+						}
+						if okxStateFetched && len(okxLivePerps) > 0 {
+							riskAssist.OKXPositions = okxPositions
+							riskAssist.OKXLiveAll = okxLivePerps
+						}
 					}
 					mu.Lock()
 					allowed, reason := CheckRisk(&sc, stratState, pv, prices, logger, riskAssist)

--- a/scheduler/okx_close.go
+++ b/scheduler/okx_close.go
@@ -3,8 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"sort"
+	"sync"
+	"time"
 )
 
 // OKXPosition represents an on-chain OKX perpetual swap position. Size is
@@ -29,14 +32,18 @@ var okxFetchPositionsScript = "shared_scripts/fetch_okx_positions.py"
 // tests can inject a fake without spawning Python. Production implementation
 // is defaultOKXLiveCloser, which shells out to close_okx_position.py via
 // RunOKXClose.
-type OKXLiveCloser func(symbol string) (*OKXCloseResult, error)
+// When partialSz is nil, the full on-chain position is closed (portfolio
+// kill switch and sole-owner circuit breakers). When non-nil, submits a
+// reduce-only partial close for that coin quantity — used by per-strategy
+// circuit breakers on shared OKX wallets (#360 / phase 2 of #357).
+type OKXLiveCloser func(symbol string, partialSz *float64) (*OKXCloseResult, error)
 
 // defaultOKXLiveCloser is the production close implementation. Matches the
 // HL shape: stderr goes to os.Stderr (kill switch is a system-level event,
 // not strategy-scoped) and any non-nil err means the close was NOT confirmed
 // by the adapter so the kill switch must stay latched.
-func defaultOKXLiveCloser(symbol string) (*OKXCloseResult, error) {
-	result, stderr, err := RunOKXClose(okxLiveCloseScript, symbol)
+func defaultOKXLiveCloser(symbol string, partialSz *float64) (*OKXCloseResult, error) {
+	result, stderr, err := RunOKXClose(okxLiveCloseScript, symbol, partialSz)
 	if stderr != "" {
 		fmt.Fprintf(os.Stderr, "[okx-close] %s stderr: %s\n", symbol, stderr)
 	}
@@ -167,7 +174,7 @@ func forceCloseOKXLive(ctx context.Context, positions []OKXPosition, okxLiveAll 
 			report.Errors[p.Coin] = fmt.Errorf("close budget exhausted before submit: %w", err)
 			continue
 		}
-		result, err := closer(p.Coin)
+		result, err := closer(p.Coin, nil)
 		if err != nil {
 			report.Errors[p.Coin] = err
 			continue
@@ -184,4 +191,311 @@ func forceCloseOKXLive(ctx context.Context, positions []OKXPosition, okxLiveAll 
 	}
 
 	return report
+}
+
+// okxLiveStrategiesForCoin returns every live OKX perps strategy configured to
+// trade the given coin. Mirrors hlLiveStrategiesForCoin.
+func okxLiveStrategiesForCoin(coin string, okxLiveAll []StrategyConfig) []StrategyConfig {
+	var out []StrategyConfig
+	for _, sc := range okxLiveAll {
+		if sc.Platform != "okx" || sc.Type != "perps" {
+			continue
+		}
+		if okxSymbol(sc.Args) == coin {
+			out = append(out, sc)
+		}
+	}
+	return out
+}
+
+// okxStrategyCapitalWeight returns a single strategy's proportional weight for
+// shared-coin close sizing. Matches hlStrategyCapitalWeight.
+func okxStrategyCapitalWeight(sc StrategyConfig) float64 {
+	if sc.CapitalPct > 0 {
+		return sc.CapitalPct
+	}
+	if sc.Capital > 0 {
+		return sc.Capital
+	}
+	return 1.0
+}
+
+// okxStrategyCapitalWeights returns per-peer weights for proportional close
+// sizing on a shared coin. Mixed-units guard matches hlStrategyCapitalWeights:
+// when peers declare CapitalPct (fractional) alongside raw Capital (dollars)
+// their sum is nonsensical and the CapitalPct-only peer's share collapses to
+// near-zero, producing a no-op close. Detect the mismatch and fall back to
+// equal weights so the firing strategy still gets a meaningful share.
+func okxStrategyCapitalWeights(peers []StrategyConfig) []float64 {
+	hasPct := false
+	hasAbs := false
+	for _, p := range peers {
+		switch {
+		case p.CapitalPct > 0:
+			hasPct = true
+		case p.Capital > 0:
+			hasAbs = true
+		}
+	}
+	mixed := hasPct && hasAbs
+	out := make([]float64, len(peers))
+	for i, p := range peers {
+		if mixed {
+			out[i] = 1.0
+			continue
+		}
+		out[i] = okxStrategyCapitalWeight(p)
+	}
+	return out
+}
+
+// computeOKXCircuitCloseQty returns the unsigned contract quantity for a
+// reduce-only market_close when strategyID's per-strategy circuit breaker
+// fires on OKX perps. For a coin traded by multiple live OKX strategies on the
+// same wallet, the close size is proportional to capital_pct (or capital)
+// weights. For a sole configured trader of that coin, the full on-chain
+// absolute size is used. ok is false when there is no non-zero on-chain
+// position for the coin. Mirrors computeHyperliquidCircuitCloseQty.
+func computeOKXCircuitCloseQty(coin, strategyID string, okxPositions []OKXPosition, okxLiveAll []StrategyConfig) (qty float64, ok bool) {
+	var onChain float64
+	found := false
+	for i := range okxPositions {
+		if okxPositions[i].Coin == coin {
+			onChain = okxPositions[i].Size
+			found = true
+			break
+		}
+	}
+	if !found || onChain == 0 {
+		return 0, false
+	}
+	absSzi := math.Abs(onChain)
+	peers := okxLiveStrategiesForCoin(coin, okxLiveAll)
+	if len(peers) <= 1 {
+		return absSzi, true
+	}
+	weights := okxStrategyCapitalWeights(peers)
+	sumW := 0.0
+	var wFiring float64
+	foundFiring := false
+	for i, p := range peers {
+		sumW += weights[i]
+		if p.ID == strategyID {
+			wFiring = weights[i]
+			foundFiring = true
+		}
+	}
+	if !foundFiring || sumW <= 0 {
+		return absSzi, true
+	}
+	q := absSzi * (wFiring / sumW)
+	if q > absSzi {
+		q = absSzi
+	}
+	if q < 1e-12 {
+		return 0, false
+	}
+	return q, true
+}
+
+// runPendingOKXCircuitCloses drains the "okx" entry of
+// RiskState.PendingCircuitCloses for every strategy, submitting reduce-only
+// OKX swap closes outside the state mutex. Retries next scheduler cycle on
+// failure. Mirrors runPendingHyperliquidCircuitCloses (#360).
+//
+// Also recovers "stuck CB" strategies: if a per-strategy circuit breaker fires
+// on a cycle where the OKX position fetch failed, setOKXCircuitBreakerPending
+// bails on the nil assist and the pending close is never set. Subsequent
+// CheckRisk calls early-return with "circuit breaker active" without
+// re-enqueueing. This drain detects the case (live OKX perps strategy with
+// CircuitBreaker=true but no pending OKX entry AND a matching non-zero
+// on-chain position) and reconstructs the pending so the reduce-only close
+// eventually fires once OKX is reachable again.
+//
+// okxHasCreds is used to decide whether fetching is worth attempting on a
+// cycle where the main loop did not already pre-fetch; it is the same gate as
+// the env-var check in defaultOKXPositionsFetcher. When false, this function
+// is a no-op.
+func runPendingOKXCircuitCloses(
+	ctx context.Context,
+	state *AppState,
+	strategies []StrategyConfig,
+	okxHasCreds bool,
+	okxPositions []OKXPosition,
+	okxStateFetched bool,
+	okxFetcher OKXPositionsFetcher,
+	closer OKXLiveCloser,
+	totalBudget time.Duration,
+	mu *sync.RWMutex,
+) {
+	if !okxHasCreds || closer == nil || state == nil {
+		return
+	}
+
+	// Build the live OKX perps roster from strategies — needed for both the
+	// stuck-CB recovery path and the shared-coin weight computation.
+	var okxLiveAll []StrategyConfig
+	for _, sc := range strategies {
+		if sc.Platform == "okx" && sc.Type == "perps" && okxIsLive(sc.Args) {
+			okxLiveAll = append(okxLiveAll, sc)
+		}
+	}
+
+	// Phase 1: snapshot — detect pending jobs AND stuck-CB strategies.
+	mu.RLock()
+	hasPending := false
+	hasStuckCB := false
+	for _, ss := range state.Strategies {
+		if ss == nil {
+			continue
+		}
+		if ss.RiskState.getPendingCircuitClose(PlatformPendingCloseOKX) != nil {
+			hasPending = true
+		}
+	}
+	for _, sc := range okxLiveAll {
+		ss := state.Strategies[sc.ID]
+		if ss == nil {
+			continue
+		}
+		if ss.RiskState.getPendingCircuitClose(PlatformPendingCloseOKX) == nil && ss.RiskState.CircuitBreaker {
+			hasStuckCB = true
+			break
+		}
+	}
+	mu.RUnlock()
+
+	if !hasPending && !hasStuckCB {
+		return
+	}
+
+	ctxOverall, cancelOverall := context.WithTimeout(ctx, totalBudget)
+	defer cancelOverall()
+
+	positions := okxPositions
+	if !okxStateFetched && okxFetcher != nil {
+		pos, err := okxFetcher()
+		if err != nil {
+			fmt.Printf("[CRITICAL] okx-circuit-close: cannot fetch OKX positions: %v — will retry next cycle\n", err)
+			return
+		}
+		positions = pos
+	}
+
+	// Phase 2: reconstruct pending for stuck-CB strategies.
+	if hasStuckCB {
+		recoverOrder := make([]StrategyConfig, len(okxLiveAll))
+		copy(recoverOrder, okxLiveAll)
+		sort.Slice(recoverOrder, func(i, j int) bool { return recoverOrder[i].ID < recoverOrder[j].ID })
+		mu.Lock()
+		for _, sc := range recoverOrder {
+			ss := state.Strategies[sc.ID]
+			if ss == nil {
+				continue
+			}
+			if ss.RiskState.getPendingCircuitClose(PlatformPendingCloseOKX) != nil {
+				continue
+			}
+			if !ss.RiskState.CircuitBreaker {
+				continue
+			}
+			sym := okxSymbol(sc.Args)
+			if sym == "" {
+				continue
+			}
+			qty, ok := computeOKXCircuitCloseQty(sym, sc.ID, positions, okxLiveAll)
+			if !ok || qty <= 0 {
+				continue
+			}
+			ss.RiskState.setPendingCircuitClose(PlatformPendingCloseOKX, &PendingCircuitClose{
+				Symbols: []PendingCircuitCloseSymbol{{Symbol: sym, Size: qty}},
+			})
+			fmt.Printf("[CRITICAL] okx-circuit-close: recovered pending for strategy %s coin %s sz=%.6f (CB latched, OKX fetch had failed at fire time)\n",
+				sc.ID, sym, qty)
+		}
+		mu.Unlock()
+	}
+
+	// Phase 3: re-snapshot jobs (may now include recovered entries).
+	type job struct {
+		stratID string
+		pending PendingCircuitClose
+	}
+	var jobs []job
+	mu.RLock()
+	for id, ss := range state.Strategies {
+		if ss == nil {
+			continue
+		}
+		p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseOKX)
+		if p == nil || len(p.Symbols) == 0 {
+			continue
+		}
+		jobs = append(jobs, job{id, *p})
+	}
+	mu.RUnlock()
+
+	if len(jobs) == 0 {
+		return
+	}
+
+	sort.Slice(jobs, func(i, j int) bool { return jobs[i].stratID < jobs[j].stratID })
+
+	for _, j := range jobs {
+		if err := ctxOverall.Err(); err != nil {
+			fmt.Printf("[CRITICAL] okx-circuit-close: budget exhausted: %v\n", err)
+			return
+		}
+		sc := lookupStrategyConfig(strategies, j.stratID)
+		if sc == nil || sc.Platform != "okx" || sc.Type != "perps" || !okxIsLive(sc.Args) {
+			mu.Lock()
+			if ss := state.Strategies[j.stratID]; ss != nil {
+				ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseOKX)
+			}
+			mu.Unlock()
+			continue
+		}
+
+		allOK := true
+		for _, c := range j.pending.Symbols {
+			if err := ctxOverall.Err(); err != nil {
+				allOK = false
+				break
+			}
+			sz := c.Size
+			for _, p := range positions {
+				if p.Coin != c.Symbol {
+					continue
+				}
+				absOC := math.Abs(p.Size)
+				if absOC <= 1e-15 {
+					sz = 0
+					break
+				}
+				if sz > absOC {
+					sz = absOC
+				}
+				break
+			}
+			if sz <= 1e-15 {
+				continue
+			}
+			partial := sz
+			_, err := closer(c.Symbol, &partial)
+			if err != nil {
+				fmt.Printf("[CRITICAL] okx-circuit-close: strategy %s coin %s sz=%.6f failed: %v\n", j.stratID, c.Symbol, sz, err)
+				allOK = false
+				break
+			}
+			fmt.Printf("[INFO] okx-circuit-close: strategy %s coin %s submitted reduce-only close sz=%.6f\n", j.stratID, c.Symbol, sz)
+		}
+
+		if allOK {
+			mu.Lock()
+			if ss := state.Strategies[j.stratID]; ss != nil {
+				ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseOKX)
+			}
+			mu.Unlock()
+		}
+	}
 }

--- a/scheduler/okx_close_test.go
+++ b/scheduler/okx_close_test.go
@@ -3,7 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"math"
+	"sync"
 	"testing"
+	"time"
 )
 
 // forceCloseOKXLive unit tests — mirror the HL tests in
@@ -21,7 +24,7 @@ func TestForceCloseOKXLive_ClosesOwnedCoinsOnly(t *testing.T) {
 		{Coin: "SOL", Size: 50, Side: "long"}, // unowned: no configured strategy
 	}
 	var calls []string
-	closer := func(sym string) (*OKXCloseResult, error) {
+	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
 		calls = append(calls, sym)
 		return &OKXCloseResult{Close: &OKXClose{Symbol: sym}}, nil
 	}
@@ -52,7 +55,7 @@ func TestForceCloseOKXLive_CloseErrorLatches(t *testing.T) {
 			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
 	}
 	positions := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
-	closer := func(sym string) (*OKXCloseResult, error) {
+	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
 		return nil, fmt.Errorf("okx 503")
 	}
 
@@ -76,7 +79,7 @@ func TestForceCloseOKXLive_ZeroSizeMarkedAlreadyFlat(t *testing.T) {
 	}
 	positions := []OKXPosition{{Coin: "BTC", Size: 0, Side: ""}}
 	var calls []string
-	closer := func(sym string) (*OKXCloseResult, error) {
+	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
 		calls = append(calls, sym)
 		return &OKXCloseResult{}, nil
 	}
@@ -106,7 +109,7 @@ func TestForceCloseOKXLive_CtxExpiredBeforeSubmit(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 0)
 	cancel()
 	var calls []string
-	closer := func(sym string) (*OKXCloseResult, error) {
+	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
 		calls = append(calls, sym)
 		return &OKXCloseResult{}, nil
 	}
@@ -132,7 +135,7 @@ func TestForceCloseOKXLive_SpotStrategiesIgnored(t *testing.T) {
 	}
 	positions := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
 	var calls []string
-	closer := func(sym string) (*OKXCloseResult, error) {
+	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
 		calls = append(calls, sym)
 		return &OKXCloseResult{}, nil
 	}
@@ -158,7 +161,7 @@ func TestForceCloseOKXLive_AdapterAlreadyFlatRoutedCorrectly(t *testing.T) {
 	}
 	positions := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
 	var calls []string
-	closer := func(sym string) (*OKXCloseResult, error) {
+	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
 		calls = append(calls, sym)
 		return &OKXCloseResult{
 			Close:    &OKXClose{Symbol: sym, AlreadyFlat: true},
@@ -199,5 +202,403 @@ func TestOKXLiveCloseReport_SortedErrorCoins(t *testing.T) {
 		if c != want[i] {
 			t.Errorf("coins[%d] = %q, want %q", i, c, want[i])
 		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Per-strategy circuit-breaker close (phase 2 of #357, issue #360).
+// Mirrors the HL coverage in hyperliquid_balance_test.go — sizing math,
+// stuck-CB recovery, and clear-on-success are the three load-bearing
+// invariants for per-strategy CB on shared OKX wallets.
+// ─────────────────────────────────────────────────────────────────────
+
+func TestComputeOKXCircuitCloseQty_SoleOwnerFullSzi(t *testing.T) {
+	okxLive := []StrategyConfig{
+		{ID: "okx-eth", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	pos := []OKXPosition{{Coin: "ETH", Size: -0.4, EntryPrice: 3000, Side: "short"}}
+	q, ok := computeOKXCircuitCloseQty("ETH", "okx-eth", pos, okxLive)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if math.Abs(q-0.4) > 1e-9 {
+		t.Errorf("qty=%.6f want 0.4 (full abs size for sole owner)", q)
+	}
+}
+
+func TestComputeOKXCircuitCloseQty_Shared50_50(t *testing.T) {
+	okxLive := []StrategyConfig{
+		{ID: "okx-a", Platform: "okx", Type: "perps", CapitalPct: 0.5, Capital: 1000,
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "okx-b", Platform: "okx", Type: "perps", CapitalPct: 0.5, Capital: 1000,
+			Args: []string{"ema", "ETH", "1h", "--mode=live"}},
+	}
+	pos := []OKXPosition{{Coin: "ETH", Size: 0.517, EntryPrice: 3000, Side: "long"}}
+	q, ok := computeOKXCircuitCloseQty("ETH", "okx-a", pos, okxLive)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	want := 0.517 * 0.5
+	if math.Abs(q-want) > 1e-9 {
+		t.Errorf("qty=%.6f want %.6f", q, want)
+	}
+}
+
+// Mixed-units weight normalization: when peers on a shared coin declare
+// weights in different fields (fractional CapitalPct vs absolute Capital),
+// the sum is nonsensical. Fall back to equal weights so the firing strategy
+// still gets a meaningful share. Mirrors the HL invariant (#356 review
+// finding 3) — regression here would silently collapse OKX shared-coin
+// closes to near-zero reduce-only orders.
+func TestComputeOKXCircuitCloseQty_MixedUnitsFallsBackToEqualWeights(t *testing.T) {
+	okxLive := []StrategyConfig{
+		{ID: "okx-a", Platform: "okx", Type: "perps", CapitalPct: 0.5,
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "okx-b", Platform: "okx", Type: "perps", Capital: 1000,
+			Args: []string{"ema", "ETH", "1h", "--mode=live"}},
+	}
+	pos := []OKXPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 3000, Side: "long"}}
+	q, ok := computeOKXCircuitCloseQty("ETH", "okx-a", pos, okxLive)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	// With equal 1.0/1.0 fallback, okx-a gets half of |size| = 0.25.
+	want := 0.25
+	if math.Abs(q-want) > 1e-9 {
+		t.Errorf("qty=%.6f want %.6f (equal-weight fallback on mixed units)", q, want)
+	}
+}
+
+func TestComputeOKXCircuitCloseQty_NoPositionReturnsFalse(t *testing.T) {
+	okxLive := []StrategyConfig{
+		{ID: "okx-eth", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	pos := []OKXPosition{{Coin: "BTC", Size: 0.1, EntryPrice: 42000, Side: "long"}}
+	q, ok := computeOKXCircuitCloseQty("ETH", "okx-eth", pos, okxLive)
+	if ok {
+		t.Errorf("expected ok=false when no on-chain position for coin, got qty=%v", q)
+	}
+}
+
+// Recovery after OKX-fetch-fail at CB fire time. When the position fetch
+// fails on the cycle a CB first fires, setOKXCircuitBreakerPending bails on
+// the nil assist and the pending close is never set. Subsequent cycles must
+// detect the stuck state (CB active, pending nil, live OKX perps, non-zero
+// on-chain position) and reconstruct the pending so the reduce-only close
+// eventually fires. Mirror of the HL recovery test.
+func TestRunPendingOKXCircuitCloses_RecoversStuckCB(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"okx-a": {
+				ID: "okx-a",
+				RiskState: RiskState{
+					CircuitBreaker:       true,
+					CircuitBreakerUntil:  time.Now().Add(24 * time.Hour),
+					PendingCircuitCloses: nil,
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "okx-a", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
+		if partialSz != nil {
+			calls = append(calls, fmt.Sprintf("%s:%g", sym, *partialSz))
+		} else {
+			calls = append(calls, sym)
+		}
+		return &OKXCloseResult{
+			Close:    &OKXClose{Symbol: sym, Fill: &OKXCloseFill{TotalSz: 0.4, AvgPx: 1}},
+			Platform: "okx",
+		}, nil
+	}
+	runPendingOKXCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		true,
+		[]OKXPosition{{Coin: "ETH", Size: 0.4, EntryPrice: 1, Side: "long"}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+	)
+	if len(calls) != 1 || calls[0] != "ETH:0.4" {
+		t.Errorf("closer calls=%v want [ETH:0.4] (recovered pending should drain full abs size as sole owner)", calls)
+	}
+	if state.Strategies["okx-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseOKX) != nil {
+		t.Error("expected pending cleared after successful recovery close")
+	}
+}
+
+// If the stuck-CB strategy has no on-chain position (e.g. operator already
+// closed it manually), recovery must be a no-op rather than submitting a
+// zero-size order.
+func TestRunPendingOKXCircuitCloses_StuckCBNoOnChainPositionIsNoOp(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"okx-a": {
+				ID: "okx-a",
+				RiskState: RiskState{
+					CircuitBreaker:      true,
+					CircuitBreakerUntil: time.Now().Add(24 * time.Hour),
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "okx-a", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
+		calls = append(calls, sym)
+		return &OKXCloseResult{Close: &OKXClose{Symbol: sym}, Platform: "okx"}, nil
+	}
+	runPendingOKXCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		true,
+		nil,
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+	)
+	if len(calls) != 0 {
+		t.Errorf("expected no closer calls when no on-chain position, got %v", calls)
+	}
+	if state.Strategies["okx-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseOKX) != nil {
+		t.Error("pending should remain nil when recovery has no on-chain position to close")
+	}
+}
+
+func TestRunPendingOKXCircuitCloses_ClearsOnSuccess(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"okx-a": {
+				ID: "okx-a",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseOKX: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.1}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "okx-a", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
+		if partialSz != nil {
+			calls = append(calls, fmt.Sprintf("%s:%g", sym, *partialSz))
+		} else {
+			calls = append(calls, sym)
+		}
+		return &OKXCloseResult{
+			Close:    &OKXClose{Symbol: sym, Fill: &OKXCloseFill{TotalSz: 0.1, AvgPx: 1}},
+			Platform: "okx",
+		}, nil
+	}
+	runPendingOKXCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		true,
+		[]OKXPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 1, Side: "long"}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+	)
+	if state.Strategies["okx-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseOKX) != nil {
+		t.Error("expected pending cleared after successful close")
+	}
+	if len(calls) != 1 || calls[0] != "ETH:0.1" {
+		t.Errorf("closer calls=%v want [ETH:0.1]", calls)
+	}
+}
+
+// On closer failure, pending must NOT be cleared — the kill switch latches
+// and retries next cycle. Same contract as the HL drain.
+func TestRunPendingOKXCircuitCloses_PendingPreservedOnFailure(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"okx-a": {
+				ID: "okx-a",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseOKX: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.1}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "okx-a", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
+		return nil, fmt.Errorf("okx 503")
+	}
+	runPendingOKXCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		true,
+		[]OKXPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 1, Side: "long"}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+	)
+	if state.Strategies["okx-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseOKX) == nil {
+		t.Error("expected pending preserved after closer failure (latch semantic)")
+	}
+}
+
+// When a pending entry references a strategy that is no longer configured as
+// live OKX perps (e.g. operator removed it from config between cycles), drain
+// must silently clear the stale entry and not submit any close.
+func TestRunPendingOKXCircuitCloses_StaleStrategyClearsPending(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"okx-gone": {
+				ID: "okx-gone",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseOKX: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.1}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
+		calls = append(calls, sym)
+		return &OKXCloseResult{Close: &OKXClose{Symbol: sym}}, nil
+	}
+	runPendingOKXCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		true,
+		[]OKXPosition{{Coin: "ETH", Size: 0.5, Side: "long"}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+	)
+	if len(calls) != 0 {
+		t.Errorf("closer must not be called for stale strategy, got %v", calls)
+	}
+	if state.Strategies["okx-gone"].RiskState.getPendingCircuitClose(PlatformPendingCloseOKX) != nil {
+		t.Error("stale pending should be cleared")
+	}
+}
+
+// setOKXCircuitBreakerPending enqueues for a live OKX perps strategy with
+// an open virtual position and non-zero on-chain position.
+func TestSetOKXCircuitBreakerPending_EnqueuesForLivePerps(t *testing.T) {
+	sc := StrategyConfig{ID: "okx-a", Platform: "okx", Type: "perps",
+		Args: []string{"sma", "ETH", "1h", "--mode=live"}}
+	s := &StrategyState{
+		ID: "okx-a",
+		Positions: map[string]*Position{
+			"ETH": {Quantity: 0.25, Side: "long"},
+		},
+	}
+	assist := &PlatformRiskAssist{
+		OKXPositions: []OKXPosition{{Coin: "ETH", Size: 0.25, Side: "long"}},
+		OKXLiveAll:   []StrategyConfig{sc},
+	}
+	setOKXCircuitBreakerPending(&sc, s, assist)
+	p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseOKX)
+	if p == nil {
+		t.Fatal("expected pending entry to be enqueued")
+	}
+	if len(p.Symbols) != 1 || p.Symbols[0].Symbol != "ETH" || math.Abs(p.Symbols[0].Size-0.25) > 1e-9 {
+		t.Errorf("pending=%+v, want [ETH:0.25]", p.Symbols)
+	}
+}
+
+// Paper-mode OKX strategies must NOT enqueue a pending close — kill switch
+// is meaningful only against live exposure.
+func TestSetOKXCircuitBreakerPending_SkipsPaperMode(t *testing.T) {
+	sc := StrategyConfig{ID: "okx-paper", Platform: "okx", Type: "perps",
+		Args: []string{"sma", "ETH", "1h"}}
+	s := &StrategyState{
+		ID: "okx-paper",
+		Positions: map[string]*Position{
+			"ETH": {Quantity: 0.25, Side: "long"},
+		},
+	}
+	assist := &PlatformRiskAssist{
+		OKXPositions: []OKXPosition{{Coin: "ETH", Size: 0.25, Side: "long"}},
+		OKXLiveAll:   []StrategyConfig{sc},
+	}
+	setOKXCircuitBreakerPending(&sc, s, assist)
+	if s.RiskState.getPendingCircuitClose(PlatformPendingCloseOKX) != nil {
+		t.Error("paper-mode OKX strategy must not enqueue pending")
+	}
+}
+
+// Nil assist (e.g. OKX fetch failed this cycle) must no-op so the stuck-CB
+// recovery path in runPendingOKXCircuitCloses can reconstruct later.
+func TestSetOKXCircuitBreakerPending_NilAssistIsNoOp(t *testing.T) {
+	sc := StrategyConfig{ID: "okx-a", Platform: "okx", Type: "perps",
+		Args: []string{"sma", "ETH", "1h", "--mode=live"}}
+	s := &StrategyState{ID: "okx-a",
+		Positions: map[string]*Position{"ETH": {Quantity: 0.25, Side: "long"}}}
+	setOKXCircuitBreakerPending(&sc, s, nil)
+	if s.RiskState.getPendingCircuitClose(PlatformPendingCloseOKX) != nil {
+		t.Error("nil assist must no-op")
+	}
+}
+
+// Parser for fetch_okx_balance.py must surface any error (exit nonzero,
+// populated error field, or unparseable) as non-nil error so the
+// shared-wallet auto-clear path preserves the kill switch on uncertainty.
+func TestParseOKXBalanceOutput_CleanSuccess(t *testing.T) {
+	stdout := []byte(`{"balance":1234.56,"platform":"okx","timestamp":"2026-04-20T00:00:00Z"}`)
+	r, _, err := parseOKXBalanceOutput(stdout, "", nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if math.Abs(r.Balance-1234.56) > 1e-9 {
+		t.Errorf("balance=%v want 1234.56", r.Balance)
+	}
+}
+
+func TestParseOKXBalanceOutput_ErrorEnvelopeSurfacesAsErr(t *testing.T) {
+	stdout := []byte(`{"balance":0,"platform":"okx","timestamp":"x","error":"auth failed"}`)
+	_, _, err := parseOKXBalanceOutput(stdout, "", fmt.Errorf("exit 1"))
+	if err == nil {
+		t.Fatal("expected non-nil err for error envelope")
 	}
 }

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -552,6 +552,10 @@ type RiskState struct {
 // phase PRs (#360 OKX, #361 RH, #362 TS).
 const PlatformPendingCloseHyperliquid = "hyperliquid"
 
+// PlatformPendingCloseOKX is the map key in RiskState.PendingCircuitCloses for
+// OKX perpetual swap reduce-only closes (#360 phase 2 of #357).
+const PlatformPendingCloseOKX = "okx"
+
 // PendingCircuitClose is a queued request to close one or more positions on a
 // single venue after a per-strategy circuit breaker fired. The drain runner
 // for that venue (platform key in RiskState.PendingCircuitCloses) translates
@@ -575,12 +579,13 @@ type PendingCircuitCloseSymbol struct {
 // drain runner's stuck-CB recovery path then re-enqueues once the fetch
 // succeeds on a later cycle (#356).
 //
-// Only HL fields are populated today (#359 phase 1b generalizes HLRiskAssist).
-// Phases 2-4 will add OKX / TopStep / Robinhood fields as their per-strategy
-// close plumbing lands.
+// HL and OKX fields are populated today (#356, #360). TopStep / Robinhood
+// fields land in phases 3-4 as their per-strategy close plumbing ships.
 type PlatformRiskAssist struct {
-	HLPositions []HLPosition
-	HLLiveAll   []StrategyConfig
+	HLPositions  []HLPosition
+	HLLiveAll    []StrategyConfig
+	OKXPositions []OKXPosition
+	OKXLiveAll   []StrategyConfig
 }
 
 // MarshalPendingCircuitClosesJSON returns a DB-safe JSON blob for the pending
@@ -730,6 +735,33 @@ func setHyperliquidCircuitBreakerPending(sc *StrategyConfig, s *StrategyState, a
 		return
 	}
 	s.RiskState.setPendingCircuitClose(PlatformPendingCloseHyperliquid, &PendingCircuitClose{
+		Symbols: []PendingCircuitCloseSymbol{{Symbol: sym, Size: qty}},
+	})
+}
+
+// setOKXCircuitBreakerPending mirrors setHyperliquidCircuitBreakerPending for
+// OKX perps (#360 phase 2 of #357). Bails on any nil dependency or missing
+// fetched assist so the stuck-CB recovery path in runPendingOKXCircuitCloses
+// can reconstruct the pending on a later cycle once OKX is reachable again.
+func setOKXCircuitBreakerPending(sc *StrategyConfig, s *StrategyState, assist *PlatformRiskAssist) {
+	if sc == nil || assist == nil || len(assist.OKXPositions) == 0 {
+		return
+	}
+	if sc.Platform != "okx" || sc.Type != "perps" || !okxIsLive(sc.Args) {
+		return
+	}
+	sym := okxSymbol(sc.Args)
+	if sym == "" {
+		return
+	}
+	if _, ok := s.Positions[sym]; !ok {
+		return
+	}
+	qty, ok := computeOKXCircuitCloseQty(sym, s.ID, assist.OKXPositions, assist.OKXLiveAll)
+	if !ok || qty <= 0 {
+		return
+	}
+	s.RiskState.setPendingCircuitClose(PlatformPendingCloseOKX, &PendingCircuitClose{
 		Symbols: []PendingCircuitCloseSymbol{{Symbol: sym, Size: qty}},
 	})
 }
@@ -951,6 +983,7 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 			r.CircuitBreaker = true
 			r.CircuitBreakerUntil = now.Add(24 * time.Hour)
 			setHyperliquidCircuitBreakerPending(sc, s, assist)
+			setOKXCircuitBreakerPending(sc, s, assist)
 			forceCloseAllPositions(s, prices, logger)
 			return false, fmt.Sprintf("max drawdown exceeded (%.1f%% > %.1f%%, portfolio=$%.2f peak=$%.2f, denom=%s=$%.2f)",
 				r.CurrentDrawdownPct, r.MaxDrawdownPct, portfolioValue, r.PeakValue, denomLabel, denom)

--- a/scheduler/shared_wallet.go
+++ b/scheduler/shared_wallet.go
@@ -95,6 +95,7 @@ func walletKeyFor(sc StrategyConfig) (SharedWalletKey, bool) {
 // registered instrument for the platform before flipping it on.
 var platformsWithSharedWalletBalanceFetcher = map[string]bool{
 	"hyperliquid": true,
+	"okx":         true, // #360 phase 2 of #357 — fetch_okx_balance.py
 }
 
 // hasSharedWalletBalanceFetcher reports whether defaultSharedWalletFetcher can

--- a/scheduler/shared_wallet_test.go
+++ b/scheduler/shared_wallet_test.go
@@ -212,12 +212,13 @@ func TestWalletKeyFor_Robinhood_OptionsNoKey(t *testing.T) {
 	}
 }
 
-// TestDetectSharedWallets_OKXExcludedNoFetcher is the critical regression test
-// for #357 phase 1a: two live OKX perps strategies on the same API key must NOT
-// be returned by detectSharedWallets because OKX has no registered balance
-// fetcher yet. Including them would cause computeTotalPortfolioValue to freeze
-// the portfolio peak every cycle via the max-of-members fallback.
-func TestDetectSharedWallets_OKXExcludedNoFetcher(t *testing.T) {
+// TestDetectSharedWallets_OKXIncludedAfterFetcher locks in #360 phase 2
+// of #357: two live OKX perps strategies on the same API key are now grouped
+// as a shared wallet because fetch_okx_balance.py provides real-balance
+// lookup via defaultSharedWalletBalance. Before #360, OKX was deliberately
+// excluded to avoid freezing the portfolio peak via max-of-members fallback
+// in computeTotalPortfolioValue.
+func TestDetectSharedWallets_OKXIncludedAfterFetcher(t *testing.T) {
 	t.Setenv("OKX_API_KEY", "okx-key-abc")
 
 	strategies := []StrategyConfig{
@@ -226,15 +227,12 @@ func TestDetectSharedWallets_OKXExcludedNoFetcher(t *testing.T) {
 	}
 
 	shared := detectSharedWallets(strategies)
-	if len(shared) != 0 {
-		t.Errorf("expected OKX to be excluded from detectSharedWallets until a balance fetcher exists; got %d entries", len(shared))
+	if len(shared) != 1 {
+		t.Fatalf("expected OKX to be grouped as one shared wallet (phase 2 #360), got %d entries", len(shared))
 	}
-
-	// walletKeyFor itself SHOULD recognize them — the exclusion is only at the
-	// detection layer. Future CB code relies on direct walletKeyFor calls.
 	for _, sc := range strategies {
 		if _, ok := walletKeyFor(sc); !ok {
-			t.Errorf("walletKeyFor should recognize %s even though detectSharedWallets filters it", sc.ID)
+			t.Errorf("walletKeyFor should recognize %s", sc.ID)
 		}
 	}
 }
@@ -269,13 +267,14 @@ func TestDetectSharedWallets_RobinhoodExcludedNoFetcher(t *testing.T) {
 	}
 }
 
-// TestHasSharedWalletBalanceFetcher_HLOnly locks in the contract that only HL
-// has a balance fetcher today. When phases 2-4 add fetchers for OKX / TS / RH,
-// this test should be updated in the same PR as the fetcher wiring.
-func TestHasSharedWalletBalanceFetcher_HLOnly(t *testing.T) {
+// TestHasSharedWalletBalanceFetcher_HLAndOKX locks in the contract that HL
+// and OKX have balance fetchers today (#360 phase 2 of #357). When phases
+// 3-4 add fetchers for TS / RH, this test should be updated in the same PR
+// as the fetcher wiring.
+func TestHasSharedWalletBalanceFetcher_HLAndOKX(t *testing.T) {
 	cases := map[string]bool{
 		"hyperliquid": true,
-		"okx":         false,
+		"okx":         true,
 		"topstep":     false,
 		"robinhood":   false,
 		"binanceus":   false,
@@ -289,10 +288,9 @@ func TestHasSharedWalletBalanceFetcher_HLOnly(t *testing.T) {
 }
 
 // TestDetectSharedWallets_MixedHLAndOKX verifies that when HL and OKX live
-// strategies are configured together, HL is still grouped (fetcher exists) and
-// OKX is still filtered out (no fetcher yet) in the SAME detection pass. Guards
-// against future refactors accidentally cross-contaminating the platform
-// filter.
+// strategies are configured together, BOTH are grouped as shared wallets
+// after #360 phase 2 of #357 (OKX gained a balance fetcher). Guards against
+// future refactors accidentally cross-contaminating the platform filter.
 func TestDetectSharedWallets_MixedHLAndOKX(t *testing.T) {
 	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xhl")
 	t.Setenv("OKX_API_KEY", "okx-key-abc")
@@ -305,25 +303,16 @@ func TestDetectSharedWallets_MixedHLAndOKX(t *testing.T) {
 	}
 
 	shared := detectSharedWallets(strategies)
-	if len(shared) != 1 {
-		t.Fatalf("expected exactly 1 shared wallet (HL); got %d entries %+v", len(shared), shared)
+	if len(shared) != 2 {
+		t.Fatalf("expected 2 shared wallets (HL + OKX); got %d entries %+v", len(shared), shared)
 	}
 	hlKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xhl"}
-	ids, ok := shared[hlKey]
-	if !ok {
-		t.Fatalf("expected HL wallet in shared set; got %+v", shared)
+	if ids, ok := shared[hlKey]; !ok || len(ids) != 2 {
+		t.Errorf("expected HL wallet with 2 strategies; got ok=%v ids=%v", ok, ids)
 	}
-	if len(ids) != 2 {
-		t.Errorf("expected 2 HL strategies grouped; got %d (%v)", len(ids), ids)
-	}
-	// Confirm OKX was filtered at detection, not at walletKeyFor.
-	for _, sc := range strategies {
-		if sc.Platform != "okx" {
-			continue
-		}
-		if _, ok := walletKeyFor(sc); !ok {
-			t.Errorf("walletKeyFor should still recognize OKX strategy %s", sc.ID)
-		}
+	okxKey := SharedWalletKey{Platform: "okx", Account: "okx-key-abc"}
+	if ids, ok := shared[okxKey]; !ok || len(ids) != 2 {
+		t.Errorf("expected OKX wallet with 2 strategies; got ok=%v ids=%v", ok, ids)
 	}
 }
 

--- a/shared_scripts/close_okx_position.py
+++ b/shared_scripts/close_okx_position.py
@@ -14,6 +14,11 @@ for the spot follow-up.
 
 Usage:
     close_okx_position.py --symbol=BTC --mode=live
+    close_okx_position.py --symbol=BTC --mode=live --sz=0.25
+
+Optional ``--sz`` submits a partial reduce-only close (contract units). Omit
+for full position close (portfolio kill switch and sole-owner circuit
+breakers). Used by shared-wallet per-strategy circuit breakers (#360).
 
 Live mode is required (kill switch is meaningful only against real
 positions). Stdout is always a single JSON envelope matching the shape of
@@ -43,6 +48,12 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--symbol", required=True)
     parser.add_argument("--mode", default="live")
+    parser.add_argument(
+        "--sz",
+        type=float,
+        default=None,
+        help="partial close size in contract units (omit for full position)",
+    )
     args = parser.parse_args()
 
     if args.mode != "live":
@@ -60,7 +71,7 @@ def main():
         if not adapter.is_live:
             _emit_error(args.symbol, "OKX adapter not live — set OKX_API_KEY / OKX_API_SECRET / OKX_PASSPHRASE")
             return
-        result = adapter.market_close(args.symbol)
+        result = adapter.market_close(args.symbol, args.sz)
     except Exception as e:
         traceback.print_exc(file=sys.stderr)
         _emit_error(args.symbol, str(e))

--- a/shared_scripts/fetch_okx_balance.py
+++ b/shared_scripts/fetch_okx_balance.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+OKX live account-balance fetcher (issue #360 phase 2 of #357).
+
+Emits the total USDT-denominated account value for shared-wallet portfolio
+aggregation. Used by ``defaultSharedWalletBalance`` in the Go scheduler so
+multi-strategy OKX deployments don't double-count capital.
+
+Scope: unified USDT total balance (free + used) via the adapter. Callers
+that need open-position PnL should upgrade the adapter's aggregation — for
+now, unrealized PnL is reflected via ``fetch_positions`` and revalued at
+mark prices upstream in the scheduler.
+
+Requires OKX_API_KEY / OKX_API_SECRET / OKX_PASSPHRASE. Output:
+``{"balance": 1234.56, "platform": "okx", "timestamp": ..., "error": "..."}``
+"""
+
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "platforms", "okx"))
+
+
+def main():
+    try:
+        from adapter import OKXExchangeAdapter
+        adapter = OKXExchangeAdapter()
+        if not adapter.is_live:
+            _emit_error("OKX adapter not live — set OKX_API_KEY / OKX_API_SECRET / OKX_PASSPHRASE")
+            return
+        balance = float(adapter.get_account_balance() or 0.0)
+    except Exception as e:
+        traceback.print_exc(file=sys.stderr)
+        _emit_error(str(e))
+        return
+
+    print(json.dumps({
+        "balance": balance,
+        "platform": "okx",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }))
+
+
+def _emit_error(message):
+    print(json.dumps({
+        "balance": 0.0,
+        "platform": "okx",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "error": message,
+    }))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Phase 2 of #357 — OKX reduce-only per-strategy CB close using the generic PendingCircuitCloses plumbing from phase 1b (#359). Before this, a live OKX perps CB fire only mutated virtual state; the real on-chain swap position stayed open until the portfolio kill switch fired.

## Summary
- `OKXLiveCloser` gains `partialSz`; OKX adapter `market_close` accepts `sz` to submit a reduce-only partial.
- `computeOKXCircuitCloseQty` — sole-owner full-size, shared proportional, mixed-units equal-weight fallback.
- `setOKXCircuitBreakerPending` wired from `CheckRisk`; `PlatformRiskAssist` gains OKX fields.
- `runPendingOKXCircuitCloses` drain with stuck-CB recovery.
- `fetch_okx_balance.py` + `defaultSharedWalletBalance` case "okx" unlocks multi-strategy OKX portfolio-value correctness.

## Tests
Sole-owner, shared 50/50, mixed-units fallback, stuck-CB recovery, clear-on-success, failure-latch, stale-strategy-clear, balance parser.

Closes #360

Generated with [Claude Code](https://claude.ai/code)