### PR TITLE
[#361 phase 3] Per-strategy CB on-chain close: Robinhood crypto (live)

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -769,6 +769,27 @@ func main() {
 						&mu,
 					)
 				}
+				// #361 phase 3: Live Robinhood crypto per-strategy circuit breaker
+				// closes. RH crypto has no reduce-only primitive, so each pending
+				// leg is a full-account market_sell guarded by a sole-ownership
+				// gate (DM the owner when a shared-coin config prevents a safe
+				// close). Lazy fetch — drain only calls the positions fetcher
+				// when pending/stuck-CB work is present, so idle cycles skip the
+				// TOTP login round-trip entirely.
+				if len(rhLiveCrypto) > 0 {
+					runPendingRobinhoodCircuitCloses(
+						context.Background(),
+						state,
+						cfg.Strategies,
+						nil,
+						false,
+						defaultRobinhoodPositionsFetcher,
+						defaultRobinhoodLiveCloser,
+						notifier.SendOwnerDM,
+						150*time.Second,
+						&mu,
+					)
+				}
 				// Pre-phase: sync on-chain positions for due live HL strategies.
 				// Reuses the clearinghouseState already fetched above for the
 				// shared-wallet risk check (#243 review feedback) so we don't

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -552,6 +552,14 @@ type RiskState struct {
 // phase PRs (#360 OKX, #361 RH, #362 TS).
 const PlatformPendingCloseHyperliquid = "hyperliquid"
 
+// PlatformPendingCloseRobinhood is the map key in RiskState.PendingCircuitCloses
+// for Robinhood crypto closes (#361 phase 3). Robinhood crypto has no
+// reduce-only primitive — the drain submits a full market_sell of the coin's
+// on-account balance, gated on sole-ownership (only one live configured RH
+// crypto strategy trading that coin on the account). Shared-coin setups
+// cannot CB-close safely and are surfaced to the owner via DM instead.
+const PlatformPendingCloseRobinhood = "robinhood"
+
 // PendingCircuitClose is a queued request to close one or more positions on a
 // single venue after a per-strategy circuit breaker fired. The drain runner
 // for that venue (platform key in RiskState.PendingCircuitCloses) translates
@@ -575,12 +583,23 @@ type PendingCircuitCloseSymbol struct {
 // drain runner's stuck-CB recovery path then re-enqueues once the fetch
 // succeeds on a later cycle (#356).
 //
-// Only HL fields are populated today (#359 phase 1b generalizes HLRiskAssist).
-// Phases 2-4 will add OKX / TopStep / Robinhood fields as their per-strategy
-// close plumbing lands.
+// HL fields populated since #359 phase 1b; RH fields added in #361 phase 3.
+// OKX / TopStep fields land alongside their phase PRs.
 type PlatformRiskAssist struct {
 	HLPositions []HLPosition
 	HLLiveAll   []StrategyConfig
+	// RHPositions is the full live on-account Robinhood crypto position list
+	// fetched once per cycle (defaultRobinhoodPositionsFetcher). Nil disables
+	// per-strategy RH CB enqueue for the cycle; the drain's stuck-CB recovery
+	// path re-enqueues once the fetch succeeds on a later cycle.
+	RHPositions []RobinhoodPosition
+	// RHLiveAll is every live configured Robinhood crypto (Type=="spot")
+	// strategy — needed for the sole-owner check the drain applies before
+	// submitting a full-account close. An RH crypto strategy that shares a
+	// coin with another live strategy on the same account cannot safely
+	// CB-close (market_sell consumes the shared balance) and is surfaced to
+	// the owner via DM instead.
+	RHLiveAll []StrategyConfig
 }
 
 // MarshalPendingCircuitClosesJSON returns a DB-safe JSON blob for the pending
@@ -732,6 +751,55 @@ func setHyperliquidCircuitBreakerPending(sc *StrategyConfig, s *StrategyState, a
 	s.RiskState.setPendingCircuitClose(PlatformPendingCloseHyperliquid, &PendingCircuitClose{
 		Symbols: []PendingCircuitCloseSymbol{{Symbol: sym, Size: qty}},
 	})
+}
+
+// setRobinhoodCircuitBreakerPending enqueues a pending full-close for a live
+// Robinhood crypto strategy whose per-strategy circuit breaker fired (#361
+// phase 3). Robinhood crypto has no reduce-only primitive: market_sell
+// consumes the entire on-account balance for the coin. We still enqueue
+// unconditionally when an on-account position exists — the sole-ownership
+// gate lives in the drain (runPendingRobinhoodCircuitCloses) so that shared-
+// coin setups DM the owner exactly once per fire cycle rather than silently
+// stalling forever.
+//
+// No-op when assist is nil or lacks the RH snapshot (cycle-local fetch
+// failure — the drain's stuck-CB recovery re-enqueues once the fetch
+// succeeds on a later cycle, mirroring the HL pattern).
+func setRobinhoodCircuitBreakerPending(sc *StrategyConfig, s *StrategyState, assist *PlatformRiskAssist) {
+	if sc == nil || assist == nil || len(assist.RHPositions) == 0 {
+		return
+	}
+	if sc.Platform != "robinhood" || sc.Type != "spot" || !robinhoodIsLive(sc.Args) {
+		return
+	}
+	coin := robinhoodSymbol(sc.Args)
+	if coin == "" {
+		return
+	}
+	if _, ok := s.Positions[coin]; !ok {
+		return
+	}
+	qty := robinhoodOnAccountSize(coin, assist.RHPositions)
+	if qty <= 0 {
+		return
+	}
+	s.RiskState.setPendingCircuitClose(PlatformPendingCloseRobinhood, &PendingCircuitClose{
+		Symbols: []PendingCircuitCloseSymbol{{Symbol: coin, Size: qty}},
+	})
+}
+
+// robinhoodOnAccountSize returns the unsigned on-account size of a coin,
+// or 0 if not found. Robinhood crypto is spot so Size is always >= 0.
+func robinhoodOnAccountSize(coin string, positions []RobinhoodPosition) float64 {
+	for i := range positions {
+		if positions[i].Coin == coin {
+			if positions[i].Size > 0 {
+				return positions[i].Size
+			}
+			return 0
+		}
+	}
+	return 0
 }
 
 // rolloverDailyPnL resets DailyPnL to zero whenever the UTC date has advanced
@@ -951,6 +1019,7 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 			r.CircuitBreaker = true
 			r.CircuitBreakerUntil = now.Add(24 * time.Hour)
 			setHyperliquidCircuitBreakerPending(sc, s, assist)
+			setRobinhoodCircuitBreakerPending(sc, s, assist)
 			forceCloseAllPositions(s, prices, logger)
 			return false, fmt.Sprintf("max drawdown exceeded (%.1f%% > %.1f%%, portfolio=$%.2f peak=$%.2f, denom=%s=$%.2f)",
 				r.CurrentDrawdownPct, r.MaxDrawdownPct, portfolioValue, r.PeakValue, denomLabel, denom)
@@ -962,6 +1031,7 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 		r.CircuitBreaker = true
 		r.CircuitBreakerUntil = now.Add(1 * time.Hour)
 		setHyperliquidCircuitBreakerPending(sc, s, assist)
+		setRobinhoodCircuitBreakerPending(sc, s, assist)
 		forceCloseAllPositions(s, prices, logger)
 		return false, "5 consecutive losses"
 	}

--- a/scheduler/robinhood_pending_close.go
+++ b/scheduler/robinhood_pending_close.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// RobinhoodPendingCloseOwnerDM is the callback the drain uses to notify the
+// operator when a per-strategy CB cannot be closed because the coin is shared
+// by multiple live configured Robinhood crypto strategies on the same account.
+// The function is expected to post a DM and return; nil-safe (drain falls back
+// to log-only when no DM sender is wired — matches test usage).
+type RobinhoodPendingCloseOwnerDM func(message string)
+
+// runPendingRobinhoodCircuitCloses drains the robinhood entry of
+// RiskState.PendingCircuitCloses for every strategy, submitting full-account
+// market_sell closes outside the state mutex. Retries next scheduler cycle on
+// failure.
+//
+// Two correctness gates beyond the HL/OKX drain analogs:
+//
+//  1. Sole-ownership gate: Robinhood crypto has no reduce-only primitive;
+//     a market_sell of BTC consumes the entire on-account BTC balance. When
+//     two live configured RH crypto strategies trade the same coin on the
+//     same account, no strategy-local CB can safely close that coin without
+//     blasting the other strategy's exposure. On detection: emit a CRITICAL
+//     log, DM the owner once per drain cycle, and clear the pending. The
+//     stuck-CB recovery path reapplies the same gate so DMs fire on every
+//     cycle the strategy remains in the shared-and-latched state — operator
+//     intervention is the only resolution.
+//
+//  2. Stuck-CB recovery: mirrors the HL drain. If a CB fires on a cycle
+//     where the RH positions fetch failed, setRobinhoodCircuitBreakerPending
+//     bails (no RHPositions in the assist) and the pending is never set.
+//     Subsequent CheckRisk calls early-return with "circuit breaker active"
+//     without re-enqueuing. The drain detects latched-CB strategies (live RH
+//     crypto, CircuitBreaker=true, no pending, non-zero on-account position)
+//     and reconstructs the pending — gated on sole-ownership.
+//
+// When sendOwnerDM is nil the drain logs the skip and does not DM (tests pass
+// nil to keep the pure-function contract).
+func runPendingRobinhoodCircuitCloses(
+	ctx context.Context,
+	state *AppState,
+	strategies []StrategyConfig,
+	positions []RobinhoodPosition,
+	positionsFetched bool,
+	fetcher RobinhoodPositionsFetcher,
+	closer RobinhoodLiveCloser,
+	sendOwnerDM RobinhoodPendingCloseOwnerDM,
+	totalBudget time.Duration,
+	mu *sync.RWMutex,
+) {
+	if closer == nil || state == nil {
+		return
+	}
+
+	// Roster of live RH crypto strategies from cfg — used for both stuck-CB
+	// recovery and the sole-ownership check.
+	var rhLiveAll []StrategyConfig
+	for _, sc := range strategies {
+		if sc.Platform == "robinhood" && sc.Type == "spot" && robinhoodIsLive(sc.Args) {
+			rhLiveAll = append(rhLiveAll, sc)
+		}
+	}
+	if len(rhLiveAll) == 0 {
+		return
+	}
+
+	// Phase 1: snapshot — detect pending jobs AND stuck-CB strategies needing
+	// pending reconstruction.
+	mu.RLock()
+	hasPending := false
+	hasStuckCB := false
+	for _, ss := range state.Strategies {
+		if ss == nil {
+			continue
+		}
+		if ss.RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood) != nil {
+			hasPending = true
+		}
+	}
+	for _, sc := range rhLiveAll {
+		ss := state.Strategies[sc.ID]
+		if ss == nil {
+			continue
+		}
+		if ss.RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood) == nil && ss.RiskState.CircuitBreaker {
+			hasStuckCB = true
+			break
+		}
+	}
+	mu.RUnlock()
+
+	if !hasPending && !hasStuckCB {
+		return
+	}
+
+	ctxOverall, cancelOverall := context.WithTimeout(ctx, totalBudget)
+	defer cancelOverall()
+
+	// Lazy fetch if we weren't handed positions this cycle — mirrors HL.
+	if !positionsFetched && fetcher != nil {
+		pos, err := fetcher()
+		if err != nil {
+			fmt.Printf("[CRITICAL] rh-circuit-close: cannot fetch RH positions: %v — will retry next cycle\n", err)
+			return
+		}
+		positions = pos
+		positionsFetched = true
+	}
+	if !positionsFetched {
+		fmt.Printf("[CRITICAL] rh-circuit-close: no RH positions snapshot available — will retry next cycle\n")
+		return
+	}
+
+	// Phase 2: reconstruct pending for stuck-CB strategies, applying the
+	// sole-ownership gate BEFORE enqueueing so shared-coin strategies never
+	// latch pending state (avoids silent loop churn).
+	if hasStuckCB {
+		recoverOrder := make([]StrategyConfig, len(rhLiveAll))
+		copy(recoverOrder, rhLiveAll)
+		sort.Slice(recoverOrder, func(i, j int) bool { return recoverOrder[i].ID < recoverOrder[j].ID })
+		mu.Lock()
+		for _, sc := range recoverOrder {
+			ss := state.Strategies[sc.ID]
+			if ss == nil {
+				continue
+			}
+			if ss.RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood) != nil {
+				continue
+			}
+			if !ss.RiskState.CircuitBreaker {
+				continue
+			}
+			coin := robinhoodSymbol(sc.Args)
+			if coin == "" {
+				continue
+			}
+			qty := robinhoodOnAccountSize(coin, positions)
+			if qty <= 0 {
+				continue
+			}
+			peers := rhLiveStrategiesForCoin(coin, rhLiveAll)
+			if len(peers) > 1 {
+				// Shared-owner — don't enqueue; DM from the submit phase below
+				// already-pending strategies. For stuck-CB strategies we also
+				// surface the skip here so the operator hears about it even if
+				// no pending ever made it into state.
+				msg := formatRobinhoodSharedOwnerDM(sc.ID, coin, peers)
+				fmt.Printf("[CRITICAL] rh-circuit-close: %s\n", msg)
+				if sendOwnerDM != nil {
+					sendOwnerDM(msg)
+				}
+				continue
+			}
+			ss.RiskState.setPendingCircuitClose(PlatformPendingCloseRobinhood, &PendingCircuitClose{
+				Symbols: []PendingCircuitCloseSymbol{{Symbol: coin, Size: qty}},
+			})
+			fmt.Printf("[CRITICAL] rh-circuit-close: recovered pending for strategy %s coin %s size=%.8f (CB latched, RH fetch had failed at fire time)\n",
+				sc.ID, coin, qty)
+		}
+		mu.Unlock()
+	}
+
+	// Phase 3: re-snapshot jobs (may now include recovered entries).
+	type job struct {
+		stratID string
+		pending PendingCircuitClose
+	}
+	var jobs []job
+	mu.RLock()
+	for id, ss := range state.Strategies {
+		if ss == nil {
+			continue
+		}
+		p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood)
+		if p == nil || len(p.Symbols) == 0 {
+			continue
+		}
+		jobs = append(jobs, job{id, *p})
+	}
+	mu.RUnlock()
+
+	if len(jobs) == 0 {
+		return
+	}
+
+	// Deterministic drain order for operator-facing logs (#356 review finding 2).
+	sort.Slice(jobs, func(i, j int) bool { return jobs[i].stratID < jobs[j].stratID })
+
+	for _, j := range jobs {
+		if err := ctxOverall.Err(); err != nil {
+			fmt.Printf("[CRITICAL] rh-circuit-close: budget exhausted: %v\n", err)
+			return
+		}
+		sc := lookupStrategyConfig(strategies, j.stratID)
+		if sc == nil || sc.Platform != "robinhood" || sc.Type != "spot" || !robinhoodIsLive(sc.Args) {
+			mu.Lock()
+			if ss := state.Strategies[j.stratID]; ss != nil {
+				ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseRobinhood)
+			}
+			mu.Unlock()
+			continue
+		}
+
+		allOK := true
+		for _, c := range j.pending.Symbols {
+			if err := ctxOverall.Err(); err != nil {
+				allOK = false
+				break
+			}
+			// Defense in depth: re-check the on-account balance right before
+			// submit (it may have drained since enqueue via stuck-CB recovery
+			// or manual intervention). Zero → already flat; skip silently.
+			onAccount := robinhoodOnAccountSize(c.Symbol, positions)
+			if onAccount <= 0 {
+				continue
+			}
+
+			// Sole-ownership gate at submit time — strictly necessary here
+			// because cfg may change between enqueue and drain. Shared-coin
+			// strategies DM the owner and clear the pending for this coin; the
+			// stuck-CB recovery path will re-surface the same DM next cycle
+			// while the CB stays latched.
+			peers := rhLiveStrategiesForCoin(c.Symbol, rhLiveAll)
+			if len(peers) > 1 {
+				msg := formatRobinhoodSharedOwnerDM(j.stratID, c.Symbol, peers)
+				fmt.Printf("[CRITICAL] rh-circuit-close: %s\n", msg)
+				if sendOwnerDM != nil {
+					sendOwnerDM(msg)
+				}
+				// Drop this leg but keep the overall success flag honest:
+				// we did NOT close the position, so don't report success.
+				allOK = false
+				continue
+			}
+
+			result, err := closer(c.Symbol)
+			if err != nil {
+				fmt.Printf("[CRITICAL] rh-circuit-close: strategy %s coin %s failed: %v\n", j.stratID, c.Symbol, err)
+				allOK = false
+				break
+			}
+			if result != nil && result.Close != nil && result.Close.AlreadyFlat {
+				fmt.Printf("[INFO] rh-circuit-close: strategy %s coin %s already flat on-account (no-op)\n", j.stratID, c.Symbol)
+				continue
+			}
+			fmt.Printf("[INFO] rh-circuit-close: strategy %s coin %s submitted market_sell size=%.8f\n",
+				j.stratID, c.Symbol, onAccount)
+		}
+
+		if allOK {
+			mu.Lock()
+			if ss := state.Strategies[j.stratID]; ss != nil {
+				ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseRobinhood)
+			}
+			mu.Unlock()
+			continue
+		}
+
+		// Shared-ownership skip: clear the pending so CheckRisk's stuck-CB
+		// recovery controls whether to re-enqueue next cycle. If the shared
+		// configuration persists, recovery's sole-owner gate will again skip
+		// + DM, giving the operator a steady audit trail until they fix it.
+		// For genuine submit errors we preserve pending so the next cycle's
+		// drain retries (same semantics as HL).
+		mu.Lock()
+		if ss := state.Strategies[j.stratID]; ss != nil {
+			sharedOnly := true
+			for _, c := range j.pending.Symbols {
+				peers := rhLiveStrategiesForCoin(c.Symbol, rhLiveAll)
+				if len(peers) <= 1 {
+					sharedOnly = false
+					break
+				}
+			}
+			if sharedOnly {
+				ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseRobinhood)
+			}
+		}
+		mu.Unlock()
+	}
+}
+
+// rhLiveStrategiesForCoin returns the subset of live configured RH crypto
+// strategies trading the given coin. Used by the drain to detect shared
+// ownership of an on-account balance (see runPendingRobinhoodCircuitCloses).
+func rhLiveStrategiesForCoin(coin string, rhLiveAll []StrategyConfig) []StrategyConfig {
+	var out []StrategyConfig
+	for _, sc := range rhLiveAll {
+		if robinhoodSymbol(sc.Args) == coin {
+			out = append(out, sc)
+		}
+	}
+	return out
+}
+
+// formatRobinhoodSharedOwnerDM formats the DM sent when a per-strategy CB
+// cannot safely close a shared-ownership RH crypto coin. Exported shape in
+// tests: asserts strategy / coin / peer list ordering is deterministic.
+func formatRobinhoodSharedOwnerDM(firingStrategyID, coin string, peers []StrategyConfig) string {
+	ids := make([]string, 0, len(peers))
+	for _, p := range peers {
+		ids = append(ids, p.ID)
+	}
+	sort.Strings(ids)
+	return fmt.Sprintf(
+		"Robinhood CB close skipped: strategy %s tripped on coin %s, but %d live strategies share that coin (%v). Robinhood crypto has no reduce-only primitive, so CB close cannot run safely. Manual intervention required.",
+		firingStrategyID, coin, len(peers), ids,
+	)
+}

--- a/scheduler/robinhood_pending_close_test.go
+++ b/scheduler/robinhood_pending_close_test.go
@@ -1,0 +1,502 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Sole-owner full-close sizing: single live configured RH crypto strategy on
+// the coin → drain submits a market_sell for the entire on-account balance.
+func TestRunPendingRobinhoodCircuitCloses_SoleOwnerFullClose(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"rh-sma-btc": {
+				ID: "rh-sma-btc",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseRobinhood: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "BTC", Size: 0.02}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		calls = append(calls, sym)
+		return &RobinhoodCloseResult{
+			Close:    &RobinhoodClose{Symbol: sym},
+			Platform: "robinhood",
+		}, nil
+	}
+	var dms []string
+	dm := func(msg string) { dms = append(dms, msg) }
+
+	runPendingRobinhoodCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		[]RobinhoodPosition{{Coin: "BTC", Size: 0.02, AvgPrice: 42000}},
+		true,
+		nil,
+		closer,
+		dm,
+		30*time.Second,
+		&mu,
+	)
+
+	if len(calls) != 1 || calls[0] != "BTC" {
+		t.Errorf("closer calls=%v want [BTC]", calls)
+	}
+	if len(dms) != 0 {
+		t.Errorf("unexpected DMs on sole-owner path: %v", dms)
+	}
+	if state.Strategies["rh-sma-btc"].RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood) != nil {
+		t.Error("expected pending cleared after successful close")
+	}
+}
+
+// Stuck-CB recovery: CB active + no pending + on-account position + fetch
+// succeeds this cycle → drain reconstructs pending and closes it.
+func TestRunPendingRobinhoodCircuitCloses_RecoversStuckCB(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"rh-sma-btc": {
+				ID: "rh-sma-btc",
+				RiskState: RiskState{
+					CircuitBreaker:       true,
+					CircuitBreakerUntil:  time.Now().Add(24 * time.Hour),
+					PendingCircuitCloses: nil,
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		calls = append(calls, sym)
+		return &RobinhoodCloseResult{Close: &RobinhoodClose{Symbol: sym}, Platform: "robinhood"}, nil
+	}
+
+	runPendingRobinhoodCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		[]RobinhoodPosition{{Coin: "BTC", Size: 0.02, AvgPrice: 42000}},
+		true,
+		nil,
+		closer,
+		nil,
+		30*time.Second,
+		&mu,
+	)
+
+	if len(calls) != 1 || calls[0] != "BTC" {
+		t.Errorf("expected recovered close for BTC, got %v", calls)
+	}
+	if state.Strategies["rh-sma-btc"].RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood) != nil {
+		t.Error("expected pending cleared after recovered close")
+	}
+}
+
+// Stuck-CB recovery with no on-account position (operator manually closed)
+// must be a no-op rather than submitting a zero-size sell.
+func TestRunPendingRobinhoodCircuitCloses_StuckCBNoOnAccountPositionIsNoOp(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"rh-sma-btc": {
+				ID: "rh-sma-btc",
+				RiskState: RiskState{
+					CircuitBreaker:      true,
+					CircuitBreakerUntil: time.Now().Add(24 * time.Hour),
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		calls = append(calls, sym)
+		return &RobinhoodCloseResult{Close: &RobinhoodClose{Symbol: sym}}, nil
+	}
+
+	runPendingRobinhoodCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		nil,
+		true,
+		nil,
+		closer,
+		nil,
+		30*time.Second,
+		&mu,
+	)
+
+	if len(calls) != 0 {
+		t.Errorf("expected no closer calls when no on-account position, got %v", calls)
+	}
+	if state.Strategies["rh-sma-btc"].RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood) != nil {
+		t.Error("pending should remain nil when recovery has no position to close")
+	}
+}
+
+// Shared-ownership gate: two live RH crypto strategies trade the same coin on
+// the same account → drain must NOT submit a close, must DM the owner, and
+// must clear the pending so stuck-CB recovery controls the next cycle's DM.
+func TestRunPendingRobinhoodCircuitCloses_SharedOwnershipSkipsAndDMs(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"rh-sma-btc": {
+				ID: "rh-sma-btc",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseRobinhood: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "BTC", Size: 0.02}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+		{ID: "rh-ema-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"ema_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		calls = append(calls, sym)
+		return &RobinhoodCloseResult{Close: &RobinhoodClose{Symbol: sym}}, nil
+	}
+	var dms []string
+	dm := func(msg string) { dms = append(dms, msg) }
+
+	runPendingRobinhoodCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		[]RobinhoodPosition{{Coin: "BTC", Size: 0.02, AvgPrice: 42000}},
+		true,
+		nil,
+		closer,
+		dm,
+		30*time.Second,
+		&mu,
+	)
+
+	if len(calls) != 0 {
+		t.Errorf("expected NO closer submissions on shared-ownership, got %v", calls)
+	}
+	if len(dms) != 1 {
+		t.Fatalf("expected exactly one owner DM, got %d: %v", len(dms), dms)
+	}
+	// DM must name firing strategy, coin, and list both peer IDs in sorted order.
+	msg := dms[0]
+	if !strings.Contains(msg, "rh-sma-btc") {
+		t.Errorf("DM missing firing strategy ID: %q", msg)
+	}
+	if !strings.Contains(msg, "BTC") {
+		t.Errorf("DM missing coin: %q", msg)
+	}
+	if !strings.Contains(msg, "rh-ema-btc") {
+		t.Errorf("DM missing peer strategy: %q", msg)
+	}
+	if state.Strategies["rh-sma-btc"].RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood) != nil {
+		t.Error("expected pending cleared on shared-ownership skip so recovery controls next-cycle DMs")
+	}
+}
+
+// Stuck-CB recovery must apply the sole-ownership gate before enqueueing —
+// otherwise shared-coin setups would silently latch pending state that the
+// submit phase would then immediately clear, producing churn without a DM.
+func TestRunPendingRobinhoodCircuitCloses_StuckCBSharedOwnershipSkipDMs(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"rh-sma-btc": {
+				ID: "rh-sma-btc",
+				RiskState: RiskState{
+					CircuitBreaker:      true,
+					CircuitBreakerUntil: time.Now().Add(24 * time.Hour),
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+		{ID: "rh-ema-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"ema_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		calls = append(calls, sym)
+		return &RobinhoodCloseResult{Close: &RobinhoodClose{Symbol: sym}}, nil
+	}
+	var dms []string
+	dm := func(msg string) { dms = append(dms, msg) }
+
+	runPendingRobinhoodCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		[]RobinhoodPosition{{Coin: "BTC", Size: 0.02, AvgPrice: 42000}},
+		true,
+		nil,
+		closer,
+		dm,
+		30*time.Second,
+		&mu,
+	)
+
+	if len(calls) != 0 {
+		t.Errorf("expected NO submissions on shared-ownership stuck CB, got %v", calls)
+	}
+	if len(dms) != 1 {
+		t.Fatalf("expected one DM from recovery-time shared-owner gate, got %d: %v", len(dms), dms)
+	}
+	if state.Strategies["rh-sma-btc"].RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood) != nil {
+		t.Error("shared-ownership recovery must NOT enqueue pending")
+	}
+}
+
+// Submit error preserves pending so the next cycle retries (parity with HL).
+func TestRunPendingRobinhoodCircuitCloses_SubmitErrorRetainsPending(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"rh-sma-btc": {
+				ID: "rh-sma-btc",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseRobinhood: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "BTC", Size: 0.02}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		return nil, fmt.Errorf("robin_stocks 503")
+	}
+
+	runPendingRobinhoodCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		[]RobinhoodPosition{{Coin: "BTC", Size: 0.02}},
+		true,
+		nil,
+		closer,
+		nil,
+		30*time.Second,
+		&mu,
+	)
+
+	pending := state.Strategies["rh-sma-btc"].RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood)
+	if pending == nil {
+		t.Fatal("expected pending preserved on submit error so next cycle retries")
+	}
+	if len(pending.Symbols) != 1 || pending.Symbols[0].Symbol != "BTC" {
+		t.Errorf("pending = %+v, want [BTC]", pending)
+	}
+}
+
+// AlreadyFlat response from the adapter must clear the pending without
+// erroring, mirroring the HL/OKX contract.
+func TestRunPendingRobinhoodCircuitCloses_AlreadyFlatClearsPending(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"rh-sma-btc": {
+				ID: "rh-sma-btc",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseRobinhood: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "BTC", Size: 0.02}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		return &RobinhoodCloseResult{
+			Close:    &RobinhoodClose{Symbol: sym, AlreadyFlat: true},
+			Platform: "robinhood",
+		}, nil
+	}
+
+	runPendingRobinhoodCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		[]RobinhoodPosition{{Coin: "BTC", Size: 0.02}},
+		true,
+		nil,
+		closer,
+		nil,
+		30*time.Second,
+		&mu,
+	)
+
+	if state.Strategies["rh-sma-btc"].RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood) != nil {
+		t.Error("expected pending cleared on already_flat response")
+	}
+}
+
+// setRobinhoodCircuitBreakerPending enqueues on fresh CB fire when assist has
+// the cycle's RH positions. Validates the sc/state preconditions.
+func TestSetRobinhoodCircuitBreakerPending_EnqueuesWhenOnAccountPositionExists(t *testing.T) {
+	sc := &StrategyConfig{
+		ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+		Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"},
+	}
+	s := &StrategyState{
+		ID:        "rh-sma-btc",
+		Positions: map[string]*Position{"BTC": {Quantity: 0.02, Side: "long", AvgCost: 42000}},
+	}
+	assist := &PlatformRiskAssist{
+		RHPositions: []RobinhoodPosition{{Coin: "BTC", Size: 0.02}},
+		RHLiveAll:   []StrategyConfig{*sc},
+	}
+
+	setRobinhoodCircuitBreakerPending(sc, s, assist)
+
+	pending := s.RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood)
+	if pending == nil {
+		t.Fatal("expected pending enqueued")
+	}
+	if len(pending.Symbols) != 1 || pending.Symbols[0].Symbol != "BTC" {
+		t.Errorf("pending = %+v, want [BTC]", pending)
+	}
+	if pending.Symbols[0].Size != 0.02 {
+		t.Errorf("pending size = %v, want 0.02 (full on-account)", pending.Symbols[0].Size)
+	}
+}
+
+// setRobinhoodCircuitBreakerPending is a no-op when assist lacks the RH
+// positions snapshot (cycle-local fetch failure). Stuck-CB recovery picks it
+// up on the next cycle.
+func TestSetRobinhoodCircuitBreakerPending_NoOpWhenAssistMissingPositions(t *testing.T) {
+	sc := &StrategyConfig{
+		ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+		Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"},
+	}
+	s := &StrategyState{
+		ID:        "rh-sma-btc",
+		Positions: map[string]*Position{"BTC": {Quantity: 0.02, Side: "long", AvgCost: 42000}},
+	}
+	assist := &PlatformRiskAssist{}
+
+	setRobinhoodCircuitBreakerPending(sc, s, assist)
+
+	if s.RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood) != nil {
+		t.Error("expected no-op when assist.RHPositions is nil")
+	}
+}
+
+// Paper-mode and cross-platform strategies must never enqueue RH pending.
+func TestSetRobinhoodCircuitBreakerPending_IgnoresNonLiveAndNonRobinhood(t *testing.T) {
+	paper := &StrategyConfig{
+		ID: "rh-paper", Platform: "robinhood", Type: "spot",
+		Args: []string{"sma_crossover", "BTC", "1h"},
+	}
+	hl := &StrategyConfig{
+		ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
+		Args: []string{"sma_crossover", "ETH", "1h", "--mode=live"},
+	}
+	s := &StrategyState{
+		Positions: map[string]*Position{"BTC": {Quantity: 0.02}, "ETH": {Quantity: 0.1}},
+	}
+	assist := &PlatformRiskAssist{
+		RHPositions: []RobinhoodPosition{{Coin: "BTC", Size: 0.02}, {Coin: "ETH", Size: 0.1}},
+	}
+
+	setRobinhoodCircuitBreakerPending(paper, s, assist)
+	setRobinhoodCircuitBreakerPending(hl, s, assist)
+
+	if s.RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood) != nil {
+		t.Error("expected no pending for paper or non-RH strategies")
+	}
+}
+
+// rhLiveStrategiesForCoin basics — used by the drain's sole-owner gate.
+func TestRhLiveStrategiesForCoin(t *testing.T) {
+	roster := []StrategyConfig{
+		{ID: "rh-sma-btc", Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+		{ID: "rh-ema-btc", Args: []string{"ema", "BTC", "1h", "--mode=live"}},
+		{ID: "rh-sma-eth", Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	got := rhLiveStrategiesForCoin("BTC", roster)
+	if len(got) != 2 {
+		t.Fatalf("BTC peers = %d, want 2", len(got))
+	}
+	if rhLiveStrategiesForCoin("ETH", roster)[0].ID != "rh-sma-eth" {
+		t.Error("ETH peer mismatch")
+	}
+	if len(rhLiveStrategiesForCoin("DOGE", roster)) != 0 {
+		t.Error("expected no peers for unconfigured coin")
+	}
+}
+
+// formatRobinhoodSharedOwnerDM must emit sorted peer IDs so repeat fires
+// produce byte-identical output (same contract as the #342 HL review —
+// operator-facing text iterating over strategies must be deterministic).
+func TestFormatRobinhoodSharedOwnerDM_DeterministicPeerOrder(t *testing.T) {
+	peers := []StrategyConfig{
+		{ID: "rh-zeta-btc"},
+		{ID: "rh-alpha-btc"},
+		{ID: "rh-mid-btc"},
+	}
+	msg := formatRobinhoodSharedOwnerDM("rh-zeta-btc", "BTC", peers)
+
+	// The firing strategy ID also appears in the peer list, and strings.Index
+	// would find it in the "strategy X tripped" prefix first. Scope the order
+	// check to the peer-list substring between '[' and ']'.
+	listStart := strings.Index(msg, "[")
+	listEnd := strings.Index(msg, "]")
+	if listStart < 0 || listEnd < 0 || listEnd <= listStart {
+		t.Fatalf("DM missing peer-list brackets: %q", msg)
+	}
+	peerList := msg[listStart+1 : listEnd]
+	alphaIdx := strings.Index(peerList, "rh-alpha-btc")
+	midIdx := strings.Index(peerList, "rh-mid-btc")
+	zetaIdx := strings.Index(peerList, "rh-zeta-btc")
+	if alphaIdx < 0 || midIdx < 0 || zetaIdx < 0 {
+		t.Fatalf("peer list missing expected IDs: %q (full DM: %q)", peerList, msg)
+	}
+	if !(alphaIdx < midIdx && midIdx < zetaIdx) {
+		t.Errorf("peer IDs not in sorted order in peer list: %q", peerList)
+	}
+}


### PR DESCRIPTION
Phase 3 of #357. Per-strategy circuit breaker for live Robinhood crypto now queues a full-account market_sell and submits it outside the state lock, mirroring the HL phase-2 plumbing (#356 / #359).

RH crypto has no reduce-only primitive, so proportional sizing is impossible. The drain gates every submit on sole-ownership of the coin on the account. When two live configured RH crypto strategies trade the same coin, the drain DMs the owner and skips — a full close would blast the peer strategy's balance. Stuck-CB recovery re-applies the DM each cycle the latched-but-shared state persists.

Closes #361

Generated with [Claude Code](https://claude.ai/code)