### PR TITLE
[#362 phase 4] Per-strategy CB on-chain close: TopStep futures (live)

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -606,6 +606,24 @@ func main() {
 					walletBalances[okxKey] = bal
 				}
 			}
+			// #362: Fetch TopStep positions once per cycle when any live TS
+			// futures strategy exists, so per-strategy CB enqueue
+			// (setTopStepCircuitBreakerPending) has a sizing source. The
+			// kill-switch plan builder has its own fetch path; we let it do
+			// its own call rather than plumb a pre-fetched TS slice through
+			// KillSwitchCloseInputs — the fetch is cheap (one HTTPS call)
+			// and keeps the kill-switch plumbing untouched.
+			var tsPositions []TopStepPosition
+			var tsStateFetched bool
+			if len(tsLiveAll) > 0 {
+				pos, err := defaultTopStepPositionsFetcher()
+				if err != nil {
+					fmt.Printf("[WARN] topstep positions fetch failed: %v — per-strategy CB will use stuck-CB recovery on next cycle\n", err)
+				} else {
+					tsStateFetched = true
+					tsPositions = pos
+				}
+			}
 
 			mu.RLock()
 			totalPV, usedPVFallback := computeTotalPortfolioValue(cfg.Strategies, state, prices, walletBalances, sharedWallets)
@@ -637,12 +655,15 @@ func main() {
 				// from the exchange (#341): closing virtually but never sending
 				// the reduce-only order left on-chain positions live, and once
 				// virtual was empty no future cycle could detect the leak.
-				// Portfolio kill owns all platform closes — drop per-strategy pending.
+				// Portfolio kill owns all live closes — drop per-strategy pending
+				// so the per-strategy drains don't double-submit against an
+				// already-flattening venue.
 				for _, ss := range state.Strategies {
 					if ss != nil {
 						ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseHyperliquid)
 						ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseOKX)
 						ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseRobinhood)
+						ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseTopStep)
 					}
 				}
 			}
@@ -817,6 +838,24 @@ func main() {
 						&mu,
 					)
 				}
+				// #362: Live TopStep per-strategy circuit breaker closes
+				// (market_close full-flatten, sole-peer only — whole-contract
+				// futures have no partial-close primitive). Outside-RTH
+				// rejections and other TopStepX errors keep the pending
+				// latched; the drain retries on the next cycle.
+				if len(tsLiveAll) > 0 {
+					runPendingTopStepCircuitCloses(
+						context.Background(),
+						state,
+						cfg.Strategies,
+						tsPositions,
+						tsStateFetched,
+						defaultTopStepPositionsFetcher,
+						defaultTopStepLiveCloser,
+						90*time.Second,
+						&mu,
+					)
+				}
 				// #361 phase 3: Live Robinhood crypto per-strategy circuit breaker
 				// closes. RH crypto has no reduce-only primitive, so each pending
 				// leg is a full-account market_sell guarded by a sole-ownership
@@ -921,15 +960,22 @@ func main() {
 
 					// Phase 2: Lock — CheckRisk (fast, no I/O)
 					var riskAssist *PlatformRiskAssist
-					if (hlStateFetched && len(hlLiveAll) > 0) || (okxStateFetched && len(okxLivePerps) > 0) {
+					needHL := hlStateFetched && len(hlLiveAll) > 0
+					needOKX := okxStateFetched && len(okxLivePerps) > 0
+					needTS := tsStateFetched && len(tsLiveAll) > 0
+					if needHL || needOKX || needTS {
 						riskAssist = &PlatformRiskAssist{}
-						if hlStateFetched && len(hlLiveAll) > 0 {
+						if needHL {
 							riskAssist.HLPositions = hlPositions
 							riskAssist.HLLiveAll = hlLiveAll
 						}
-						if okxStateFetched && len(okxLivePerps) > 0 {
+						if needOKX {
 							riskAssist.OKXPositions = okxPositions
 							riskAssist.OKXLiveAll = okxLivePerps
+						}
+						if needTS {
+							riskAssist.TSPositions = tsPositions
+							riskAssist.TSLiveAll = tsLiveAll
 						}
 					}
 					mu.Lock()

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -564,6 +564,13 @@ const PlatformPendingCloseOKX = "okx"
 // cannot CB-close safely and are surfaced to the owner via DM instead.
 const PlatformPendingCloseRobinhood = "robinhood"
 
+// PlatformPendingCloseTopStep is the map key in RiskState.PendingCircuitCloses
+// for TopStep futures closes. Size entries are integer contract counts encoded
+// as float64 (PendingCircuitCloseSymbol.Size is float64 across all venues for
+// storage uniformity; market_close has no size argument and flattens the full
+// position — Size is informational only for TopStep).
+const PlatformPendingCloseTopStep = "topstep"
+
 // PendingCircuitClose is a queued request to close one or more positions on a
 // single venue after a per-strategy circuit breaker fired. The drain runner
 // for that venue (platform key in RiskState.PendingCircuitCloses) translates
@@ -587,11 +594,10 @@ type PendingCircuitCloseSymbol struct {
 // drain runner's stuck-CB recovery path then re-enqueues once the fetch
 // succeeds on a later cycle (#356).
 //
-// HL and OKX fields are populated today (#356, #360). RH fields are defined
-// here for phase 3 (#361) but left unpopulated at the CheckRisk call site in
-// main.go — see setRobinhoodCircuitBreakerPending for why the RH enqueue is
-// driven exclusively by the drain's stuck-CB recovery path rather than at
-// CB-fire time. TopStep fields land in phase 4.
+// HL (#356), OKX (#360), Robinhood (#361), and TopStep (#362) fields are all
+// populated today. RH fields are left unpopulated at the CheckRisk call site —
+// see setRobinhoodCircuitBreakerPending for why the RH enqueue is driven
+// exclusively by the drain's stuck-CB recovery path rather than at CB-fire time.
 type PlatformRiskAssist struct {
 	HLPositions  []HLPosition
 	HLLiveAll    []StrategyConfig
@@ -604,10 +610,19 @@ type PlatformRiskAssist struct {
 	// even when no CB fires).
 	RHPositions []RobinhoodPosition
 	// RHLiveAll mirrors HLLiveAll/OKXLiveAll: every live configured Robinhood
-	// crypto (Type=="spot") strategy. Consumed by the sole-owner check in the
-	// drain before submitting a full-account market_sell. Left nil at the
-	// CheckRisk call site today — see setRobinhoodCircuitBreakerPending.
+	// crypto (Type=="spot") strategy. Left nil at the CheckRisk call site today
+	// — see setRobinhoodCircuitBreakerPending.
 	RHLiveAll []StrategyConfig
+	// TSPositions is the pre-fetched live TopStep futures position snapshot
+	// for the configured account. Populated in main.go from a once-per-cycle
+	// fetch_topstep_positions.py call (#362). Empty slice with TSLiveAll set
+	// is a successful fetch that found no open positions; nil slice signals
+	// a fetch failure (stuck-CB path will retry).
+	TSPositions []TopStepPosition
+	// TSLiveAll mirrors HLLiveAll — every configured live TopStep futures
+	// strategy on this scheduler. Needed by the sole-vs-shared-peer branch
+	// in computeTopStepCircuitCloseQty.
+	TSLiveAll []StrategyConfig
 }
 
 // MarshalPendingCircuitClosesJSON returns a DB-safe JSON blob for the pending
@@ -736,6 +751,41 @@ func (r *RiskState) getPendingCircuitClose(platform string) *PendingCircuitClose
 		return nil
 	}
 	return r.PendingCircuitCloses[platform]
+}
+
+// setTopStepCircuitBreakerPending enqueues a reduce-only flatten request for
+// the firing strategy's TopStep futures contract (#362). Sole-peer strategies
+// enqueue the full on-account contract count; multi-peer shared contracts are
+// skipped because TopStepX's market_close only flattens the entire on-account
+// size — no safe partial-close primitive exists for whole-contract futures.
+// The operator is notified via the virtual force-close (CheckRisk still calls
+// forceCloseAllPositions), and manual intervention is required to split a
+// shared contract.
+//
+// A nil or empty assist bails — same stuck-CB semantics as the HL helper:
+// a fetch failure at CB fire time leaves pending nil, and the drain's
+// stuck-CB recovery phase reconstructs the pending once TS is reachable.
+func setTopStepCircuitBreakerPending(sc *StrategyConfig, s *StrategyState, assist *PlatformRiskAssist) {
+	if sc == nil || assist == nil || len(assist.TSPositions) == 0 {
+		return
+	}
+	if sc.Platform != "topstep" || sc.Type != "futures" || !topstepIsLive(sc.Args) {
+		return
+	}
+	sym := topstepSymbol(sc.Args)
+	if sym == "" {
+		return
+	}
+	if _, ok := s.Positions[sym]; !ok {
+		return
+	}
+	qty, ok := computeTopStepCircuitCloseQty(sym, s.ID, assist.TSPositions, assist.TSLiveAll)
+	if !ok || qty <= 0 {
+		return
+	}
+	s.RiskState.setPendingCircuitClose(PlatformPendingCloseTopStep, &PendingCircuitClose{
+		Symbols: []PendingCircuitCloseSymbol{{Symbol: sym, Size: float64(qty)}},
+	})
 }
 
 func setHyperliquidCircuitBreakerPending(sc *StrategyConfig, s *StrategyState, assist *PlatformRiskAssist) {
@@ -1070,6 +1120,7 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 			setHyperliquidCircuitBreakerPending(sc, s, assist)
 			setOKXCircuitBreakerPending(sc, s, assist)
 			setRobinhoodCircuitBreakerPending(sc, s, assist)
+			setTopStepCircuitBreakerPending(sc, s, assist)
 			forceCloseAllPositions(s, prices, logger)
 			return false, fmt.Sprintf("max drawdown exceeded (%.1f%% > %.1f%%, portfolio=$%.2f peak=$%.2f, denom=%s=$%.2f)",
 				r.CurrentDrawdownPct, r.MaxDrawdownPct, portfolioValue, r.PeakValue, denomLabel, denom)

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -567,8 +567,8 @@ const PlatformPendingCloseRobinhood = "robinhood"
 // PlatformPendingCloseTopStep is the map key in RiskState.PendingCircuitCloses
 // for TopStep futures closes. Size entries are integer contract counts encoded
 // as float64 (PendingCircuitCloseSymbol.Size is float64 across all venues for
-// storage uniformity; market_close has no size argument and flattens the full
-// position — Size is informational only for TopStep).
+// storage uniformity; the TopStep drain logs the live on-account count at
+// drain time — market_close has no size argument and flattens the full position).
 const PlatformPendingCloseTopStep = "topstep"
 
 // PendingCircuitClose is a queued request to close one or more positions on a

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -1359,6 +1359,110 @@ func TestCheckRisk_LiveHLSharedCoin_SetsPendingPartialClose(t *testing.T) {
 	}
 }
 
+// TestCheckRisk_LiveTopStepCB_SetsPendingFullFlatten verifies #362: a live
+// TopStep futures strategy with a sole-peer contract gets a full-flatten
+// pending close enqueued when its per-strategy circuit breaker fires.
+func TestCheckRisk_LiveTopStepCB_SetsPendingFullFlatten(t *testing.T) {
+	sc := StrategyConfig{
+		ID: "ts-es", Platform: "topstep", Type: "futures",
+		Capital: 5000,
+		Args:    []string{"sma", "ES", "15m", "--mode=live"},
+	}
+	tsLiveAll := []StrategyConfig{sc}
+	assist := &PlatformRiskAssist{
+		TSPositions: []TopStepPosition{{Coin: "ES", Size: 3, Side: "long"}},
+		TSLiveAll:   tsLiveAll,
+	}
+
+	// Rig a max-drawdown breach so CheckRisk fires the CB.
+	s := &StrategyState{
+		ID:   sc.ID,
+		Type: "futures",
+		Cash: 3000.0,
+		RiskState: RiskState{
+			PeakValue:      5000.0,
+			MaxDrawdownPct: 25.0,
+			TotalTrades:    1,
+			DailyPnLDate:   todayUTC(),
+		},
+		Positions: map[string]*Position{
+			// Futures position with Multiplier > 0; no Leverage (TS isn't perps).
+			"ES": {Symbol: "ES", Quantity: 3, AvgCost: 5000, Side: "long", Multiplier: 50},
+		},
+		OptionPositions: make(map[string]*OptionPosition),
+	}
+	prices := map[string]float64{"ES": 4995}
+	pv := PortfolioValue(s, prices)
+
+	allowed, _ := CheckRisk(&sc, s, pv, prices, nil, assist)
+	if allowed {
+		t.Fatal("expected CB fire (drawdown exceeds 25%)")
+	}
+
+	p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep)
+	if p == nil {
+		t.Fatal("expected PendingCircuitCloses[topstep] after CB fire")
+	}
+	if len(p.Symbols) != 1 {
+		t.Fatalf("expected 1 pending symbol, got %d", len(p.Symbols))
+	}
+	c0 := p.Symbols[0]
+	if c0.Symbol != "ES" {
+		t.Errorf("symbol=%q want ES", c0.Symbol)
+	}
+	if c0.Size != 3 {
+		t.Errorf("pending size=%.0f want 3 (full flatten for sole peer)", c0.Size)
+	}
+}
+
+// Multi-peer: CheckRisk still fires CB and force-closes virtual state, but
+// setTopStepCircuitBreakerPending does NOT enqueue because market_close has
+// no partial-size variant — operator handles the shared contract manually.
+func TestCheckRisk_LiveTopStepCB_MultiPeerNoPending(t *testing.T) {
+	sc := StrategyConfig{
+		ID: "ts-a", Platform: "topstep", Type: "futures",
+		Capital: 5000,
+		Args:    []string{"sma", "ES", "15m", "--mode=live"},
+	}
+	tsLiveAll := []StrategyConfig{
+		sc,
+		{ID: "ts-b", Platform: "topstep", Type: "futures",
+			Capital: 5000,
+			Args:    []string{"rsi", "ES", "15m", "--mode=live"}},
+	}
+	assist := &PlatformRiskAssist{
+		TSPositions: []TopStepPosition{{Coin: "ES", Size: 5, Side: "long"}},
+		TSLiveAll:   tsLiveAll,
+	}
+
+	s := &StrategyState{
+		ID:   sc.ID,
+		Type: "futures",
+		Cash: 3000.0,
+		RiskState: RiskState{
+			PeakValue:      5000.0,
+			MaxDrawdownPct: 25.0,
+			TotalTrades:    1,
+			DailyPnLDate:   todayUTC(),
+		},
+		Positions: map[string]*Position{
+			"ES": {Symbol: "ES", Quantity: 2, AvgCost: 5000, Side: "long", Multiplier: 50},
+		},
+		OptionPositions: make(map[string]*OptionPosition),
+	}
+	prices := map[string]float64{"ES": 4995}
+	pv := PortfolioValue(s, prices)
+
+	allowed, _ := CheckRisk(&sc, s, pv, prices, nil, assist)
+	if allowed {
+		t.Fatal("expected CB fire")
+	}
+
+	if s.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep) != nil {
+		t.Error("expected no pending TS entry for multi-peer contract")
+	}
+}
+
 // TestCheckRisk_PerpsMarginDrawdown_BelowThreshold verifies the perps
 // strategy is allowed to continue when margin-based drawdown is under the
 // circuit-breaker limit.

--- a/scheduler/topstep_close.go
+++ b/scheduler/topstep_close.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"sync"
+	"time"
 )
 
 // TopStepPosition represents a live TopStep futures position. Size is
@@ -113,6 +115,276 @@ func (r TopStepLiveCloseReport) SortedErrorCoins() []string {
 	}
 	sort.Strings(coins)
 	return coins
+}
+
+// tsLiveStrategiesForContract returns every configured live TopStep futures
+// strategy that trades the given contract symbol. Used by the per-strategy
+// circuit-breaker sizing code to decide whether the firing strategy is the
+// sole peer (full flatten safe) or one of several peers sharing the contract
+// (partial flatten required but not supported by market_close).
+func tsLiveStrategiesForContract(symbol string, tsLiveAll []StrategyConfig) []StrategyConfig {
+	var out []StrategyConfig
+	for _, sc := range tsLiveAll {
+		if topstepSymbol(sc.Args) == symbol {
+			out = append(out, sc)
+		}
+	}
+	return out
+}
+
+// computeTopStepCircuitCloseQty returns the unsigned contract count to flatten
+// when strategyID's per-strategy circuit breaker fires (#362). Futures are
+// whole-contract only, so qty is an integer magnitude.
+//
+// Sole-peer (one live strategy configured for the contract): returns the full
+// on-account absolute contract count so market_close flattens the position.
+//
+// Multi-peer (two+ live strategies sharing the contract): returns (0, false).
+// TopStepX's market_close has no partial-size variant; issuing a full flatten
+// on behalf of one strategy would close the peer's share too. A proportional
+// partial close would require a regular market order in the opposite
+// direction, which is a different code path and outside phase 4's scope. The
+// virtual force-close in CheckRisk still runs, and the operator is warned to
+// intervene manually for the shared contract.
+//
+// ok is false when no non-zero on-account position exists for the symbol.
+func computeTopStepCircuitCloseQty(symbol, strategyID string, tsPositions []TopStepPosition, tsLiveAll []StrategyConfig) (qty int, ok bool) {
+	var onAccount int
+	found := false
+	for _, p := range tsPositions {
+		if p.Coin == symbol {
+			onAccount = p.Size
+			found = true
+			break
+		}
+	}
+	if !found || onAccount == 0 {
+		return 0, false
+	}
+	abs := onAccount
+	if abs < 0 {
+		abs = -abs
+	}
+	peers := tsLiveStrategiesForContract(symbol, tsLiveAll)
+	if len(peers) <= 1 {
+		return abs, true
+	}
+	// Multi-peer: skip. Logged by the caller when the skip is visible (#362
+	// review). Enqueuing nothing means virtual force-close still mutates local
+	// state and the kill switch for the firing strategy is latched, but the
+	// live contracts are left for operator review.
+	fmt.Printf("[WARN] ts-circuit-close: strategy %s shares contract %s with %d peers; skipping enqueue (market_close has no partial-size variant — manual intervention required)\n",
+		strategyID, symbol, len(peers))
+	return 0, false
+}
+
+// runPendingTopStepCircuitCloses drains the topstep entry of
+// RiskState.PendingCircuitCloses for every strategy, submitting market-flatten
+// orders outside the state mutex. Retries next scheduler cycle on failure,
+// which handles CME outside-RTH rejections naturally: the close errors, the
+// pending stays queued, and the drain re-attempts on the next tick (#362).
+//
+// Also recovers "stuck CB" strategies: if a per-strategy circuit breaker fired
+// on a cycle where the TopStep positions fetch failed,
+// setTopStepCircuitBreakerPending bails on the nil assist and the pending
+// close is never set. Subsequent CheckRisk calls early-return with "circuit
+// breaker active" without re-enqueuing. This drain detects the case (live TS
+// futures strategy with CircuitBreaker=true but no pending TS entry AND a
+// matching non-zero on-account position) and reconstructs the pending so the
+// market_close eventually fires once TS is reachable again.
+//
+// Mirrors runPendingHyperliquidCircuitCloses (#356) exactly; differences are:
+//   - closer signature has no partial-size argument (TopStep has none)
+//   - stuck-CB recovery only reconstructs for sole-peer contracts (the
+//     computeTopStepCircuitCloseQty guard)
+func runPendingTopStepCircuitCloses(
+	ctx context.Context,
+	state *AppState,
+	strategies []StrategyConfig,
+	tsPositions []TopStepPosition,
+	tsStateFetched bool,
+	tsFetcher TopStepPositionsFetcher,
+	closer TopStepLiveCloser,
+	totalBudget time.Duration,
+	mu *sync.RWMutex,
+) {
+	if closer == nil || state == nil {
+		return
+	}
+
+	var tsLiveAll []StrategyConfig
+	for _, sc := range strategies {
+		if sc.Platform == "topstep" && sc.Type == "futures" && topstepIsLive(sc.Args) {
+			tsLiveAll = append(tsLiveAll, sc)
+		}
+	}
+	if len(tsLiveAll) == 0 {
+		return
+	}
+
+	mu.RLock()
+	hasPending := false
+	hasStuckCB := false
+	for _, ss := range state.Strategies {
+		if ss == nil {
+			continue
+		}
+		if ss.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep) != nil {
+			hasPending = true
+		}
+	}
+	for _, sc := range tsLiveAll {
+		ss := state.Strategies[sc.ID]
+		if ss == nil {
+			continue
+		}
+		if ss.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep) == nil && ss.RiskState.CircuitBreaker {
+			hasStuckCB = true
+			break
+		}
+	}
+	mu.RUnlock()
+
+	if !hasPending && !hasStuckCB {
+		return
+	}
+
+	ctxOverall, cancelOverall := context.WithTimeout(ctx, totalBudget)
+	defer cancelOverall()
+
+	positions := tsPositions
+	if !tsStateFetched && tsFetcher != nil {
+		pos, err := tsFetcher()
+		if err != nil {
+			fmt.Printf("[CRITICAL] ts-circuit-close: cannot fetch TopStep positions: %v — will retry next cycle\n", err)
+			return
+		}
+		positions = pos
+	}
+
+	if hasStuckCB {
+		recoverOrder := make([]StrategyConfig, len(tsLiveAll))
+		copy(recoverOrder, tsLiveAll)
+		sort.Slice(recoverOrder, func(i, j int) bool { return recoverOrder[i].ID < recoverOrder[j].ID })
+		mu.Lock()
+		for _, sc := range recoverOrder {
+			ss := state.Strategies[sc.ID]
+			if ss == nil {
+				continue
+			}
+			if ss.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep) != nil {
+				continue
+			}
+			if !ss.RiskState.CircuitBreaker {
+				continue
+			}
+			sym := topstepSymbol(sc.Args)
+			if sym == "" {
+				continue
+			}
+			qty, ok := computeTopStepCircuitCloseQty(sym, sc.ID, positions, tsLiveAll)
+			if !ok || qty <= 0 {
+				continue
+			}
+			ss.RiskState.setPendingCircuitClose(PlatformPendingCloseTopStep, &PendingCircuitClose{
+				Symbols: []PendingCircuitCloseSymbol{{Symbol: sym, Size: float64(qty)}},
+			})
+			fmt.Printf("[CRITICAL] ts-circuit-close: recovered pending for strategy %s contract %s sz=%d (CB latched, TS fetch had failed at fire time)\n",
+				sc.ID, sym, qty)
+		}
+		mu.Unlock()
+	}
+
+	type job struct {
+		stratID string
+		pending PendingCircuitClose
+	}
+	var jobs []job
+	mu.RLock()
+	for id, ss := range state.Strategies {
+		if ss == nil {
+			continue
+		}
+		p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep)
+		if p == nil || len(p.Symbols) == 0 {
+			continue
+		}
+		jobs = append(jobs, job{id, *p})
+	}
+	mu.RUnlock()
+
+	if len(jobs) == 0 {
+		return
+	}
+
+	sort.Slice(jobs, func(i, j int) bool { return jobs[i].stratID < jobs[j].stratID })
+
+	for _, j := range jobs {
+		if err := ctxOverall.Err(); err != nil {
+			fmt.Printf("[CRITICAL] ts-circuit-close: budget exhausted: %v\n", err)
+			return
+		}
+		sc := lookupStrategyConfig(strategies, j.stratID)
+		if sc == nil || sc.Platform != "topstep" || sc.Type != "futures" || !topstepIsLive(sc.Args) {
+			mu.Lock()
+			if ss := state.Strategies[j.stratID]; ss != nil {
+				ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseTopStep)
+			}
+			mu.Unlock()
+			continue
+		}
+
+		allOK := true
+		for _, c := range j.pending.Symbols {
+			if err := ctxOverall.Err(); err != nil {
+				allOK = false
+				break
+			}
+			// Defense-in-depth: skip legs whose on-account position already
+			// went flat between enqueue and drain (e.g. operator manual close,
+			// eventual consistency after a prior successful submit). Without
+			// this guard, calling market_close on a flat position would error
+			// and keep the pending latched forever.
+			stillOpen := false
+			for _, p := range positions {
+				if p.Coin == c.Symbol {
+					absOC := p.Size
+					if absOC < 0 {
+						absOC = -absOC
+					}
+					if absOC > 0 {
+						stillOpen = true
+					}
+					break
+				}
+			}
+			if !stillOpen {
+				fmt.Printf("[INFO] ts-circuit-close: strategy %s contract %s already flat on-account; clearing pending without submit\n",
+					j.stratID, c.Symbol)
+				continue
+			}
+			if _, err := closer(c.Symbol); err != nil {
+				// Outside-RTH rejections, transient TopStepX API errors, and
+				// any other close failure land here — we log and latch. The
+				// next cycle re-enters this drain and retries; virtual state
+				// stays untouched (CheckRisk already force-closed locally).
+				fmt.Printf("[CRITICAL] ts-circuit-close: strategy %s contract %s sz=%.0f failed: %v (will retry next cycle)\n",
+					j.stratID, c.Symbol, c.Size, err)
+				allOK = false
+				break
+			}
+			fmt.Printf("[INFO] ts-circuit-close: strategy %s contract %s submitted market_close sz=%.0f\n",
+				j.stratID, c.Symbol, c.Size)
+		}
+
+		if allOK {
+			mu.Lock()
+			if ss := state.Strategies[j.stratID]; ss != nil {
+				ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseTopStep)
+			}
+			mu.Unlock()
+		}
+	}
 }
 
 // forceCloseTopStepLive submits market-flatten orders for every non-zero

--- a/scheduler/topstep_close.go
+++ b/scheduler/topstep_close.go
@@ -345,10 +345,11 @@ func runPendingTopStepCircuitCloses(
 			// eventual consistency after a prior successful submit). Without
 			// this guard, calling market_close on a flat position would error
 			// and keep the pending latched forever.
+			var absOC int
 			stillOpen := false
 			for _, p := range positions {
 				if p.Coin == c.Symbol {
-					absOC := p.Size
+					absOC = p.Size
 					if absOC < 0 {
 						absOC = -absOC
 					}
@@ -368,13 +369,13 @@ func runPendingTopStepCircuitCloses(
 				// any other close failure land here — we log and latch. The
 				// next cycle re-enters this drain and retries; virtual state
 				// stays untouched (CheckRisk already force-closed locally).
-				fmt.Printf("[CRITICAL] ts-circuit-close: strategy %s contract %s sz=%.0f failed: %v (will retry next cycle)\n",
-					j.stratID, c.Symbol, c.Size, err)
+				fmt.Printf("[CRITICAL] ts-circuit-close: strategy %s contract %s sz=%d failed: %v (will retry next cycle)\n",
+					j.stratID, c.Symbol, absOC, err)
 				allOK = false
 				break
 			}
-			fmt.Printf("[INFO] ts-circuit-close: strategy %s contract %s submitted market_close sz=%.0f\n",
-				j.stratID, c.Symbol, c.Size)
+			fmt.Printf("[INFO] ts-circuit-close: strategy %s contract %s submitted market_close sz=%d\n",
+				j.stratID, c.Symbol, absOC)
 		}
 
 		if allOK {

--- a/scheduler/topstep_close_test.go
+++ b/scheduler/topstep_close_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 )
 
 // forceCloseTopStepLive unit tests — mirror the Robinhood/OKX tests. Each
@@ -260,5 +262,417 @@ func TestParseTopStepPositionsOutput_MalformedJSON(t *testing.T) {
 	_, _, err := parseTopStepPositionsOutput([]byte(`garbage`), "", nil)
 	if err == nil {
 		t.Fatal("expected non-nil err on malformed JSON")
+	}
+}
+
+// --- #362 phase 4: per-strategy circuit-breaker close tests ---
+
+func TestComputeTopStepCircuitCloseQty_SolePeerFullFlatten(t *testing.T) {
+	tsLive := []StrategyConfig{
+		{ID: "ts-es", Platform: "topstep", Type: "futures",
+			Args: []string{"sma", "ES", "15m", "--mode=live"}},
+	}
+	pos := []TopStepPosition{{Coin: "ES", Size: 3, AvgPrice: 5000, Side: "long"}}
+	q, ok := computeTopStepCircuitCloseQty("ES", "ts-es", pos, tsLive)
+	if !ok {
+		t.Fatal("expected ok for sole peer")
+	}
+	if q != 3 {
+		t.Errorf("qty=%d want 3 (full abs size for sole peer)", q)
+	}
+}
+
+func TestComputeTopStepCircuitCloseQty_SolePeerShortFullFlatten(t *testing.T) {
+	tsLive := []StrategyConfig{
+		{ID: "ts-es", Platform: "topstep", Type: "futures",
+			Args: []string{"sma", "ES", "15m", "--mode=live"}},
+	}
+	// Short position reported as negative size.
+	pos := []TopStepPosition{{Coin: "ES", Size: -2, AvgPrice: 5000, Side: "short"}}
+	q, ok := computeTopStepCircuitCloseQty("ES", "ts-es", pos, tsLive)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if q != 2 {
+		t.Errorf("qty=%d want 2 (abs of -2)", q)
+	}
+}
+
+// TopStep has no partial-size market_close. When two live strategies share a
+// contract, we skip the enqueue so market_close doesn't flatten the peer's
+// share on behalf of the firing strategy. Operator intervenes manually.
+func TestComputeTopStepCircuitCloseQty_MultiPeerSkipped(t *testing.T) {
+	tsLive := []StrategyConfig{
+		{ID: "ts-a", Platform: "topstep", Type: "futures",
+			Args: []string{"sma", "ES", "15m", "--mode=live"}},
+		{ID: "ts-b", Platform: "topstep", Type: "futures",
+			Args: []string{"rsi", "ES", "15m", "--mode=live"}},
+	}
+	pos := []TopStepPosition{{Coin: "ES", Size: 5, Side: "long"}}
+	q, ok := computeTopStepCircuitCloseQty("ES", "ts-a", pos, tsLive)
+	if ok {
+		t.Fatalf("expected ok=false when multiple peers share contract, got qty=%d", q)
+	}
+	if q != 0 {
+		t.Errorf("qty=%d want 0 for multi-peer skip", q)
+	}
+}
+
+func TestComputeTopStepCircuitCloseQty_NoOnAccountPosition(t *testing.T) {
+	tsLive := []StrategyConfig{
+		{ID: "ts-es", Platform: "topstep", Type: "futures",
+			Args: []string{"sma", "ES", "15m", "--mode=live"}},
+	}
+	q, ok := computeTopStepCircuitCloseQty("ES", "ts-es", nil, tsLive)
+	if ok {
+		t.Errorf("expected ok=false when no position found, got qty=%d", q)
+	}
+}
+
+func TestComputeTopStepCircuitCloseQty_ZeroSizePosition(t *testing.T) {
+	tsLive := []StrategyConfig{
+		{ID: "ts-es", Platform: "topstep", Type: "futures",
+			Args: []string{"sma", "ES", "15m", "--mode=live"}},
+	}
+	pos := []TopStepPosition{{Coin: "ES", Size: 0, Side: "long"}}
+	q, ok := computeTopStepCircuitCloseQty("ES", "ts-es", pos, tsLive)
+	if ok {
+		t.Errorf("expected ok=false for zero-size position, got qty=%d", q)
+	}
+}
+
+func TestSetTopStepCircuitBreakerPending_SolePeerEnqueues(t *testing.T) {
+	sc := &StrategyConfig{
+		ID: "ts-es", Platform: "topstep", Type: "futures",
+		Args: []string{"sma", "ES", "15m", "--mode=live"},
+	}
+	s := &StrategyState{
+		ID:        "ts-es",
+		Positions: map[string]*Position{"ES": {Side: "long", Quantity: 3}},
+	}
+	assist := &PlatformRiskAssist{
+		TSPositions: []TopStepPosition{{Coin: "ES", Size: 3, Side: "long"}},
+		TSLiveAll:   []StrategyConfig{*sc},
+	}
+	setTopStepCircuitBreakerPending(sc, s, assist)
+
+	pending := s.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep)
+	if pending == nil {
+		t.Fatal("expected pending entry enqueued")
+	}
+	if len(pending.Symbols) != 1 || pending.Symbols[0].Symbol != "ES" || pending.Symbols[0].Size != 3 {
+		t.Errorf("pending=%+v want one ES sz=3", pending.Symbols)
+	}
+}
+
+func TestSetTopStepCircuitBreakerPending_NilAssistBails(t *testing.T) {
+	sc := &StrategyConfig{
+		ID: "ts-es", Platform: "topstep", Type: "futures",
+		Args: []string{"sma", "ES", "15m", "--mode=live"},
+	}
+	s := &StrategyState{
+		ID:        "ts-es",
+		Positions: map[string]*Position{"ES": {Side: "long", Quantity: 3}},
+	}
+	// Nil assist — simulates a TS-fetch failure at CB fire time.
+	setTopStepCircuitBreakerPending(sc, s, nil)
+	if s.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep) != nil {
+		t.Error("expected no enqueue when assist is nil (stuck-CB path will recover)")
+	}
+}
+
+func TestSetTopStepCircuitBreakerPending_PaperModeSkipped(t *testing.T) {
+	sc := &StrategyConfig{
+		ID: "ts-es", Platform: "topstep", Type: "futures",
+		Args: []string{"sma", "ES", "15m", "--mode=paper"},
+	}
+	s := &StrategyState{
+		ID:        "ts-es",
+		Positions: map[string]*Position{"ES": {Side: "long", Quantity: 3}},
+	}
+	assist := &PlatformRiskAssist{
+		TSPositions: []TopStepPosition{{Coin: "ES", Size: 3, Side: "long"}},
+		TSLiveAll:   []StrategyConfig{},
+	}
+	setTopStepCircuitBreakerPending(sc, s, assist)
+	if s.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep) != nil {
+		t.Error("expected no enqueue for paper-mode strategy")
+	}
+}
+
+func TestRunPendingTopStepCircuitCloses_DrainsAndClearsPending(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"ts-es": {
+				ID: "ts-es",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseTopStep: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "ES", Size: 3}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "ts-es", Platform: "topstep", Type: "futures",
+			Args: []string{"sma", "ES", "15m", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string) (*TopStepCloseResult, error) {
+		calls = append(calls, sym)
+		return &TopStepCloseResult{Close: &TopStepClose{Symbol: sym}}, nil
+	}
+	runPendingTopStepCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		[]TopStepPosition{{Coin: "ES", Size: 3, Side: "long"}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+	)
+	if len(calls) != 1 || calls[0] != "ES" {
+		t.Errorf("closer calls=%v want [ES]", calls)
+	}
+	if state.Strategies["ts-es"].RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep) != nil {
+		t.Error("expected pending cleared after successful close")
+	}
+}
+
+// Stuck-CB recovery (mirrors HL #356 finding 1): if TS fetch failed at CB
+// fire time, pending is nil; the drain must detect CircuitBreaker=true +
+// pending==nil + on-account position and enqueue on a later cycle.
+func TestRunPendingTopStepCircuitCloses_RecoversStuckCB(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"ts-es": {
+				ID: "ts-es",
+				RiskState: RiskState{
+					CircuitBreaker:       true,
+					CircuitBreakerUntil:  time.Now().Add(24 * time.Hour),
+					PendingCircuitCloses: nil,
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "ts-es", Platform: "topstep", Type: "futures",
+			Args: []string{"sma", "ES", "15m", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string) (*TopStepCloseResult, error) {
+		calls = append(calls, sym)
+		return &TopStepCloseResult{Close: &TopStepClose{Symbol: sym}}, nil
+	}
+	runPendingTopStepCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		[]TopStepPosition{{Coin: "ES", Size: 3, Side: "long"}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+	)
+	if len(calls) != 1 || calls[0] != "ES" {
+		t.Errorf("closer calls=%v want [ES] (recovered pending should flatten full size)", calls)
+	}
+	if state.Strategies["ts-es"].RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep) != nil {
+		t.Error("expected pending cleared after successful recovery close")
+	}
+}
+
+// Session-gate defer: a TopStepX close that fails (outside RTH, venue error)
+// must keep the pending latched so the next cycle retries.
+func TestRunPendingTopStepCircuitCloses_CloseErrorLatchesPending(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"ts-es": {
+				ID: "ts-es",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseTopStep: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "ES", Size: 3}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "ts-es", Platform: "topstep", Type: "futures",
+			Args: []string{"sma", "ES", "15m", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	closer := func(sym string) (*TopStepCloseResult, error) {
+		return nil, fmt.Errorf("market closed — outside RTH")
+	}
+	runPendingTopStepCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		[]TopStepPosition{{Coin: "ES", Size: 3, Side: "long"}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+	)
+	pending := state.Strategies["ts-es"].RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep)
+	if pending == nil {
+		t.Fatal("expected pending to remain latched after close error (session-gate / venue error)")
+	}
+	if len(pending.Symbols) != 1 || pending.Symbols[0].Symbol != "ES" {
+		t.Errorf("pending.Symbols=%v want [{ES,3}]", pending.Symbols)
+	}
+}
+
+// If the drain runs but the on-account position already went flat between
+// enqueue and drain (operator manual close, eventual consistency), the
+// closer must NOT be called — otherwise market_close on a flat position
+// would error and latch the pending forever.
+func TestRunPendingTopStepCircuitCloses_AlreadyFlatSkipsCloserAndClears(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"ts-es": {
+				ID: "ts-es",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseTopStep: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "ES", Size: 3}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "ts-es", Platform: "topstep", Type: "futures",
+			Args: []string{"sma", "ES", "15m", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string) (*TopStepCloseResult, error) {
+		calls = append(calls, sym)
+		return &TopStepCloseResult{Close: &TopStepClose{Symbol: sym}}, nil
+	}
+	runPendingTopStepCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		nil, // no positions on account
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+	)
+	if len(calls) != 0 {
+		t.Errorf("closer should not be called when position is already flat, got %v", calls)
+	}
+	if state.Strategies["ts-es"].RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep) != nil {
+		t.Error("expected pending cleared after already-flat skip")
+	}
+}
+
+func TestRunPendingTopStepCircuitCloses_StuckCBMultiPeerSkipped(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"ts-a": {
+				ID: "ts-a",
+				RiskState: RiskState{
+					CircuitBreaker:      true,
+					CircuitBreakerUntil: time.Now().Add(24 * time.Hour),
+				},
+			},
+		},
+	}
+	// Two live peers on contract ES — computeTopStepCircuitCloseQty returns
+	// (0, false), so stuck-CB recovery must NOT reconstruct a pending.
+	cfg := []StrategyConfig{
+		{ID: "ts-a", Platform: "topstep", Type: "futures",
+			Args: []string{"sma", "ES", "15m", "--mode=live"}},
+		{ID: "ts-b", Platform: "topstep", Type: "futures",
+			Args: []string{"rsi", "ES", "15m", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string) (*TopStepCloseResult, error) {
+		calls = append(calls, sym)
+		return &TopStepCloseResult{Close: &TopStepClose{Symbol: sym}}, nil
+	}
+	runPendingTopStepCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		[]TopStepPosition{{Coin: "ES", Size: 5}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+	)
+	if len(calls) != 0 {
+		t.Errorf("closer should not be called for multi-peer contract, got %v", calls)
+	}
+	if state.Strategies["ts-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep) != nil {
+		t.Error("expected no pending reconstruction for multi-peer contract")
+	}
+}
+
+// When the fetcher is needed (tsStateFetched=false) and it returns an error,
+// the drain must bail without mutating pending entries.
+func TestRunPendingTopStepCircuitCloses_FetcherErrorBails(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"ts-es": {
+				ID: "ts-es",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseTopStep: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "ES", Size: 3}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "ts-es", Platform: "topstep", Type: "futures",
+			Args: []string{"sma", "ES", "15m", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string) (*TopStepCloseResult, error) {
+		calls = append(calls, sym)
+		return &TopStepCloseResult{Close: &TopStepClose{Symbol: sym}}, nil
+	}
+	fetcher := func() ([]TopStepPosition, error) {
+		return nil, fmt.Errorf("topstep api 500")
+	}
+	runPendingTopStepCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		nil,
+		false,
+		fetcher,
+		closer,
+		30*time.Second,
+		&mu,
+	)
+	if len(calls) != 0 {
+		t.Errorf("closer should not be called when fetcher errors, got %v", calls)
+	}
+	// Pending must remain so the next cycle retries.
+	if state.Strategies["ts-es"].RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep) == nil {
+		t.Error("expected pending to remain latched when fetcher errors")
 	}
 }


### PR DESCRIPTION
Closes #362

Phase 4 of #357: TopStep futures per-strategy circuit breaker close.

## Summary
- `setTopStepCircuitBreakerPending` enqueues `PendingCircuitCloses["topstep"]` via `PlatformRiskAssist.TSPositions/TSLiveAll`
- `runPendingTopStepCircuitCloses` drains outside the state lock, with stuck-CB recovery mirroring the HL drain (#356 finding 1)
- Sole-peer contracts full-flatten via `market_close`; multi-peer shared contracts skip enqueue (no partial-size primitive)
- Outside-RTH and other close errors keep pending latched; drain retries next cycle
- Portfolio kill switch clears TS pending entries alongside HL

## Test plan
- [x] `go build .`
- [x] `go test ./...` passes
- [x] New unit tests cover sizing, multi-peer skip, stuck-CB, close-error latch, already-flat skip, fetcher-error bail, CheckRisk integration

Generated with [Claude Code](https://claude.ai/code)