### PR TITLE
[#363 phase 5] Per-strategy CB: OKX spot + Robinhood options operator-warning gaps

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -932,6 +932,53 @@ Present the output to the user in a readable format. Highlight any circuit break
 
 ---
 
+## Operator-Required Circuit Breakers (OKX spot / Robinhood options)
+
+Some live venues have no safe automated-close primitive. When a per-strategy circuit breaker fires on one of these, the scheduler cannot flatten on its own — it enqueues a pending close with `operator_required: true` and emits a CRITICAL warning on every cycle (stderr, Discord, Telegram) until the operator intervenes.
+
+### Affected venues
+
+| Platform | Type | Why no auto-close | Pending-close key |
+| --- | --- | --- | --- |
+| OKX | spot | No reduce-only semantic on asset balances; net-close could wipe other holdings | `okx_spot` |
+| Robinhood | options | Leg-aware close semantics (sell-to-close vs buy-to-close, multi-leg spreads) are high-risk to automate | `robinhood_options` |
+
+These gaps are documented separately from the portfolio kill-switch equivalents in #345 (OKX spot) and #346 (Robinhood options); the per-strategy path (#363) reuses the same operator-intervention framing.
+
+### Detecting the condition
+
+**Via `/status`:** look under `strategies.<id>.risk_state.pending_circuit_closes` for entries with `operator_required: true`. Ignore HL / OKX-perps / TopStep / Robinhood-crypto pending entries — those drain automatically.
+
+```bash
+curl -s localhost:8080/status | .venv/bin/python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for sid, s in d['strategies'].items():
+    pc = s['risk_state'].get('pending_circuit_closes') or {}
+    for platform, p in pc.items():
+        if p.get('operator_required'):
+            legs = ', '.join(f\"{x['symbol']} size={x['size']}\" for x in p['symbols'])
+            print(f'{sid} [{platform}]: {legs}')
+"
+```
+
+**Via notifications:** Discord and Telegram receive a message titled `CIRCUIT BREAKER — OPERATOR INTERVENTION REQUIRED` listing each affected strategy, its legs, drawdown %, and CB-until timestamp.
+
+**Via logs:** every cycle prints one `[CRITICAL] operator-required-close: strategy <id> platform <key> — <legs> (circuit breaker fired, venue lacks safe auto-close; operator must flatten manually)` line per entry.
+
+### Response
+
+1. Open the venue UI (OKX web / mobile, Robinhood app).
+2. Flatten the listed positions manually.
+3. Confirm via `/status` that the underlying positions are gone.
+4. Do NOT manually clear the pending — the scheduler clears it automatically on the next natural circuit-breaker reset (24h default for max-drawdown, 1h for 5-consecutive-losses). If you need to resume trading sooner, reset the portfolio kill switch via owner DM (which also clears per-strategy operator-required pendings) or restart the scheduler after flattening.
+
+### Do not confuse with portfolio kill switch
+
+The portfolio kill switch (`KILL_SWITCH` in state, `PORTFOLIO KILL SWITCH` message header) is a higher-severity event that fires on total-portfolio drawdown and runs the platform-specific automated close paths. Operator-required warnings are the PER-STRATEGY equivalent: only the strategy hitting its own `max_drawdown_pct` is paused, not the whole portfolio. If both fire the portfolio kill takes over and clears per-strategy operator-required pendings to avoid double-notifying.
+
+---
+
 ## `/menu` Command
 
 When the user says `/menu`, "show menu", "what can I configure", "what's available", or "help me get started", output the following overview directly (no bash command needed):

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -608,9 +608,16 @@ func main() {
 				// the reduce-only order left on-chain positions live, and once
 				// virtual was empty no future cycle could detect the leak.
 				// Portfolio kill owns all HL closes — drop per-strategy pending.
+				// Operator-required pendings (OKX spot / RH options, #363) are
+				// also cleared: the portfolio kill path surfaces those same
+				// gaps via formatKillSwitchMessage OKXSpotPresent /
+				// RHOptionsPresent, so leaving both sets of warnings in place
+				// would double-notify the operator.
 				for _, ss := range state.Strategies {
 					if ss != nil {
 						ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseHyperliquid)
+						ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseOKXSpot)
+						ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseRobinhoodOptions)
 					}
 				}
 			}
@@ -769,6 +776,12 @@ func main() {
 						&mu,
 					)
 				}
+				// #363 phase 5: operator-gap per-strategy CB pending closes.
+				// OKX spot and Robinhood options have no safe automated close
+				// primitive — the drain emits a CRITICAL warning each cycle
+				// instead of submitting orders. Pending stays set until the
+				// operator flattens manually.
+				drainOperatorRequiredPendingCloses(state, notifier, &mu)
 				// Pre-phase: sync on-chain positions for due live HL strategies.
 				// Reuses the clearinghouseState already fetched above for the
 				// shared-wallet risk check (#243 review feedback) so we don't

--- a/scheduler/operator_required_close.go
+++ b/scheduler/operator_required_close.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// OperatorRequiredEntry is one strategy-platform pair whose per-strategy
+// circuit breaker fired but which the scheduler cannot auto-close (OKX spot,
+// Robinhood options). Surfaced as a record so tests and /status can inspect
+// the set directly without scanning PendingCircuitCloses in two places.
+type OperatorRequiredEntry struct {
+	StrategyID  string
+	Platform    string // PlatformPendingCloseOKXSpot / PlatformPendingCloseRobinhoodOptions
+	Symbols     []PendingCircuitCloseSymbol
+	CBUntil     string // ISO timestamp — empty when CB not latched (defensive)
+	DrawdownPct float64
+}
+
+// OperatorRequiredWarningPlan is the output of planOperatorRequiredWarning.
+// Callers deliver LogLines to stderr and, when HasEntries() is true, send
+// Message through every configured notifier backend.
+//
+// Pure data — no goroutines, no notifier side effects. Separated from the
+// delivery wrapper so the formatting is unit-testable against a static input
+// (#363 phase 5; mirrors the planKillSwitchClose pattern from #341).
+type OperatorRequiredWarningPlan struct {
+	Entries  []OperatorRequiredEntry
+	Message  string
+	LogLines []string
+}
+
+// HasEntries reports whether any operator-required pending close is present.
+// Caller uses this as the gate for notifier delivery so an empty cycle stays
+// silent.
+func (p OperatorRequiredWarningPlan) HasEntries() bool { return len(p.Entries) > 0 }
+
+// planOperatorRequiredWarning scans every strategy's PendingCircuitCloses map
+// for entries with OperatorRequired=true and builds the per-cycle warning.
+// Runs under the caller's RLock (read-only access to state).
+//
+// Ordering is deterministic: entries are sorted by (StrategyID, Platform) so
+// the operator-facing log line, /status serialization, and Discord message all
+// produce byte-identical output across runs — required by the CLAUDE.md rule
+// against map-iteration randomness in operator-facing output.
+func planOperatorRequiredWarning(state *AppState) OperatorRequiredWarningPlan {
+	var plan OperatorRequiredWarningPlan
+	if state == nil {
+		return plan
+	}
+
+	for _, s := range state.Strategies {
+		if s == nil || len(s.RiskState.PendingCircuitCloses) == 0 {
+			continue
+		}
+		for platform, pending := range s.RiskState.PendingCircuitCloses {
+			if pending == nil || !pending.OperatorRequired {
+				continue
+			}
+			legs := make([]PendingCircuitCloseSymbol, len(pending.Symbols))
+			copy(legs, pending.Symbols)
+			sort.Slice(legs, func(i, j int) bool { return legs[i].Symbol < legs[j].Symbol })
+
+			entry := OperatorRequiredEntry{
+				StrategyID:  s.ID,
+				Platform:    platform,
+				Symbols:     legs,
+				DrawdownPct: s.RiskState.CurrentDrawdownPct,
+			}
+			if !s.RiskState.CircuitBreakerUntil.IsZero() {
+				entry.CBUntil = s.RiskState.CircuitBreakerUntil.UTC().Format("2006-01-02T15:04:05Z")
+			}
+			plan.Entries = append(plan.Entries, entry)
+		}
+	}
+
+	sort.Slice(plan.Entries, func(i, j int) bool {
+		if plan.Entries[i].StrategyID != plan.Entries[j].StrategyID {
+			return plan.Entries[i].StrategyID < plan.Entries[j].StrategyID
+		}
+		return plan.Entries[i].Platform < plan.Entries[j].Platform
+	})
+
+	if len(plan.Entries) == 0 {
+		return plan
+	}
+
+	for _, e := range plan.Entries {
+		plan.LogLines = append(plan.LogLines, fmt.Sprintf(
+			"[CRITICAL] operator-required-close: strategy %s platform %s — %s (circuit breaker fired, venue lacks safe auto-close; operator must flatten manually)",
+			e.StrategyID, e.Platform, formatOperatorRequiredLegs(e.Symbols),
+		))
+	}
+	plan.Message = formatOperatorRequiredWarningMessage(plan.Entries)
+	return plan
+}
+
+// formatOperatorRequiredLegs renders a pending-close symbol list as
+// "SYM1 (size=N), SYM2 (size=N)" with deterministic order.
+func formatOperatorRequiredLegs(legs []PendingCircuitCloseSymbol) string {
+	if len(legs) == 0 {
+		return "no open legs (marker entry)"
+	}
+	parts := make([]string, 0, len(legs))
+	for _, l := range legs {
+		parts = append(parts, fmt.Sprintf("%s (size=%.6f)", l.Symbol, l.Size))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// operatorRequiredPlatformLabel maps an internal pending-close platform key to
+// its operator-facing label. Keeps the message self-describing — "okx_spot"
+// and "robinhood_options" are internal identifiers; the formatted message
+// should say "OKX spot" and "Robinhood options" to match runbook language.
+func operatorRequiredPlatformLabel(platform string) string {
+	switch platform {
+	case PlatformPendingCloseOKXSpot:
+		return "OKX spot"
+	case PlatformPendingCloseRobinhoodOptions:
+		return "Robinhood options"
+	default:
+		return platform
+	}
+}
+
+// formatOperatorRequiredWarningMessage builds the Discord/Telegram message
+// from the sorted entries. Header mirrors FormatKillSwitchMessage's
+// "GAPS — VERIFY MANUALLY" language so operators skimming notifications see
+// the same severity marker they already recognize from portfolio kill events
+// (#345 / #346).
+func formatOperatorRequiredWarningMessage(entries []OperatorRequiredEntry) string {
+	if len(entries) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("**CIRCUIT BREAKER — OPERATOR INTERVENTION REQUIRED**\n")
+	b.WriteString(fmt.Sprintf("%d strategy-platform pair%s hit a per-strategy circuit breaker on a venue the scheduler cannot auto-close. Flatten manually.\n",
+		len(entries), pluralS(len(entries))))
+	for _, e := range entries {
+		cbSuffix := ""
+		if e.CBUntil != "" {
+			cbSuffix = fmt.Sprintf(" (CB until %s)", e.CBUntil)
+		}
+		b.WriteString(fmt.Sprintf("• %s [%s]: %s — drawdown %.1f%%%s\n",
+			e.StrategyID, operatorRequiredPlatformLabel(e.Platform),
+			formatOperatorRequiredLegs(e.Symbols), e.DrawdownPct, cbSuffix))
+	}
+	b.WriteString("No automated close will be attempted. Pending remains set until operator clears positions.")
+	return b.String()
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// operatorRequiredNotifier is the narrow notifier surface drainOperator-
+// RequiredPendingCloses needs. *MultiNotifier satisfies it in production; tests
+// supply a capturing stub so the drain can be exercised without a live
+// Discord/Telegram connection.
+type operatorRequiredNotifier interface {
+	HasBackends() bool
+	SendToAllChannels(content string)
+	SendOwnerDM(content string)
+}
+
+// drainOperatorRequiredPendingCloses emits a CRITICAL warning for every
+// strategy with an OperatorRequired=true pending close, once per cycle. Does
+// NOT attempt any automated close — the pending entry stays populated in
+// RiskState and surfaces through /status, Discord, and Telegram on every
+// cycle until the operator flattens manually and the CB resets.
+//
+// Called from the main loop alongside runPendingHyperliquidCircuitCloses
+// (#363 phase 5). Takes the state mutex as an RWMutex; only a read lock is
+// ever held (state is not mutated here — the drain's job is to surface the
+// condition, not clear it).
+func drainOperatorRequiredPendingCloses(state *AppState, notifier operatorRequiredNotifier, mu *sync.RWMutex) {
+	if state == nil {
+		return
+	}
+	mu.RLock()
+	plan := planOperatorRequiredWarning(state)
+	mu.RUnlock()
+
+	if !plan.HasEntries() {
+		return
+	}
+	for _, line := range plan.LogLines {
+		fmt.Println(line)
+	}
+	if notifier != nil && notifier.HasBackends() && plan.Message != "" {
+		notifier.SendToAllChannels(plan.Message)
+		notifier.SendOwnerDM(plan.Message)
+	}
+}

--- a/scheduler/operator_required_close_test.go
+++ b/scheduler/operator_required_close_test.go
@@ -1,0 +1,432 @@
+package main
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSetOperatorRequiredCircuitBreakerPending_OKXSpot verifies #363 phase 5:
+// a live OKX spot strategy tripping its circuit breaker enqueues a pending
+// close with OperatorRequired=true under the PlatformPendingCloseOKXSpot key
+// — NOT under the auto-close "okx" key, so the portfolio-kill OKX perps drain
+// never dequeues and auto-closes it.
+func TestSetOperatorRequiredCircuitBreakerPending_OKXSpot(t *testing.T) {
+	sc := &StrategyConfig{
+		ID: "okx-sma-btc", Platform: "okx", Type: "spot",
+		Args: []string{"sma_crossover", "BTC-USDT", "1h", "--mode=live"},
+	}
+	s := &StrategyState{
+		ID: sc.ID, Type: "spot", Platform: "okx",
+		Positions: map[string]*Position{
+			"BTC-USDT": {Symbol: "BTC-USDT", Quantity: 0.0125, AvgCost: 80000, Side: "long"},
+		},
+		OptionPositions: map[string]*OptionPosition{},
+	}
+
+	setOperatorRequiredCircuitBreakerPending(sc, s)
+
+	p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseOKXSpot)
+	if p == nil {
+		t.Fatal("expected PendingCircuitCloses[okx_spot] after CB fire")
+	}
+	if !p.OperatorRequired {
+		t.Error("OperatorRequired=false; want true")
+	}
+	if len(p.Symbols) != 1 || p.Symbols[0].Symbol != "BTC-USDT" || p.Symbols[0].Size != 0.0125 {
+		t.Errorf("unexpected pending symbols: %+v", p.Symbols)
+	}
+	// Defensive: must NOT land under the auto-close "okx" key.
+	if s.RiskState.getPendingCircuitClose("okx") != nil {
+		t.Error("enqueue leaked into the auto-close okx key — portfolio-kill drain would auto-close this")
+	}
+}
+
+// TestSetOperatorRequiredCircuitBreakerPending_RobinhoodOptions verifies each
+// open option leg is captured as a separate PendingCircuitCloseSymbol (not the
+// underlier) so the operator sees which specific positions need manual close.
+func TestSetOperatorRequiredCircuitBreakerPending_RobinhoodOptions(t *testing.T) {
+	sc := &StrategyConfig{
+		ID: "rh-ccall-spy", Platform: "robinhood", Type: "options",
+		Args: []string{"covered_call", "SPY", "1d", "--mode=live"},
+	}
+	s := &StrategyState{
+		ID: sc.ID, Type: "options", Platform: "robinhood",
+		Positions: map[string]*Position{},
+		OptionPositions: map[string]*OptionPosition{
+			"SPY-2026-05-15-450-C": {Quantity: 2},
+			"SPY-2026-06-19-460-C": {Quantity: 1},
+		},
+	}
+
+	setOperatorRequiredCircuitBreakerPending(sc, s)
+
+	p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhoodOptions)
+	if p == nil {
+		t.Fatal("expected PendingCircuitCloses[robinhood_options] after CB fire")
+	}
+	if !p.OperatorRequired {
+		t.Error("OperatorRequired=false; want true")
+	}
+	if len(p.Symbols) != 2 {
+		t.Fatalf("expected 2 option legs, got %d: %+v", len(p.Symbols), p.Symbols)
+	}
+	// Deterministic sort guarantees alphabetic order.
+	if p.Symbols[0].Symbol != "SPY-2026-05-15-450-C" || p.Symbols[1].Symbol != "SPY-2026-06-19-460-C" {
+		t.Errorf("legs not sorted alphabetically: %+v", p.Symbols)
+	}
+	if s.RiskState.getPendingCircuitClose("robinhood") != nil {
+		t.Error("enqueue leaked into the auto-close robinhood key")
+	}
+}
+
+// TestSetOperatorRequiredCircuitBreakerPending_RobinhoodOptions_NoOpenLegs
+// locks in the marker-entry fallback: when options CB fires before any leg is
+// opened, we still enqueue a single underlier marker so /status and
+// notifications surface the fire.
+func TestSetOperatorRequiredCircuitBreakerPending_RobinhoodOptions_NoOpenLegs(t *testing.T) {
+	sc := &StrategyConfig{
+		ID: "rh-vol-qqq", Platform: "robinhood", Type: "options",
+		Args: []string{"vol_scalp", "QQQ", "1d", "--mode=live"},
+	}
+	s := &StrategyState{
+		ID: sc.ID, Type: "options", Platform: "robinhood",
+		Positions:       map[string]*Position{},
+		OptionPositions: map[string]*OptionPosition{},
+	}
+
+	setOperatorRequiredCircuitBreakerPending(sc, s)
+
+	p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhoodOptions)
+	if p == nil || len(p.Symbols) != 1 {
+		t.Fatalf("expected 1 marker symbol when no legs open; got %+v", p)
+	}
+	if p.Symbols[0].Symbol != "QQQ" || p.Symbols[0].Size != 0 {
+		t.Errorf("marker entry wrong: %+v", p.Symbols[0])
+	}
+}
+
+// TestSetOperatorRequiredCircuitBreakerPending_PaperMode_NoEnqueue verifies
+// paper-mode strategies do NOT enqueue — there is no real venue exposure and
+// surfacing a warning would be noise.
+func TestSetOperatorRequiredCircuitBreakerPending_PaperMode_NoEnqueue(t *testing.T) {
+	// OKX spot, paper mode (no --mode=live).
+	sc := &StrategyConfig{
+		ID: "okx-paper", Platform: "okx", Type: "spot",
+		Args: []string{"sma_crossover", "BTC-USDT", "1h", "--mode=paper"},
+	}
+	s := &StrategyState{
+		ID: sc.ID, Positions: map[string]*Position{"BTC-USDT": {Quantity: 0.01}},
+	}
+	setOperatorRequiredCircuitBreakerPending(sc, s)
+	if s.RiskState.getPendingCircuitClose(PlatformPendingCloseOKXSpot) != nil {
+		t.Error("paper-mode OKX spot enqueued operator-required pending; want nil")
+	}
+
+	// RH options, paper mode.
+	sc2 := &StrategyConfig{
+		ID: "rh-paper", Platform: "robinhood", Type: "options",
+		Args: []string{"covered_call", "SPY", "1d", "--mode=paper"},
+	}
+	s2 := &StrategyState{
+		ID: sc2.ID, OptionPositions: map[string]*OptionPosition{"SPY-leg": {Quantity: 1}},
+	}
+	setOperatorRequiredCircuitBreakerPending(sc2, s2)
+	if s2.RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhoodOptions) != nil {
+		t.Error("paper-mode RH options enqueued operator-required pending; want nil")
+	}
+}
+
+// TestSetOperatorRequiredCircuitBreakerPending_IgnoresOtherPlatforms verifies
+// the helper is a no-op for HL / TopStep / BinanceUS / OKX perps / RH crypto
+// — those either have an automated close path or fall under a different
+// helper.
+func TestSetOperatorRequiredCircuitBreakerPending_IgnoresOtherPlatforms(t *testing.T) {
+	for _, sc := range []*StrategyConfig{
+		{ID: "hl-1", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"triple_ema", "ETH", "1h", "--mode=live"}},
+		{ID: "ts-1", Platform: "topstep", Type: "futures",
+			Args: []string{"breakout", "ESM25", "15m", "--mode=live"}},
+		{ID: "bu-1", Platform: "binanceus", Type: "spot",
+			Args: []string{"sma_crossover", "BTC/USDT", "1h"}},
+		{ID: "okx-perps", Platform: "okx", Type: "perps",
+			Args: []string{"triple_ema", "BTC-USDT-SWAP", "1h", "--mode=live"}},
+		{ID: "rh-crypto", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
+	} {
+		s := &StrategyState{ID: sc.ID, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}}
+		setOperatorRequiredCircuitBreakerPending(sc, s)
+		if len(s.RiskState.PendingCircuitCloses) != 0 {
+			t.Errorf("%s: unexpected enqueue %+v", sc.ID, s.RiskState.PendingCircuitCloses)
+		}
+	}
+}
+
+// TestCheckRisk_LiveOKXSpot_SetsOperatorRequiredPending verifies the full
+// CheckRisk → setOperatorRequiredCircuitBreakerPending wiring for OKX spot.
+// Drawdown is intentionally above the max threshold so the CB fires.
+func TestCheckRisk_LiveOKXSpot_SetsOperatorRequiredPending(t *testing.T) {
+	sc := StrategyConfig{
+		ID: "okx-sma-btc", Platform: "okx", Type: "spot",
+		Args: []string{"sma_crossover", "BTC-USDT", "1h", "--mode=live"},
+	}
+	s := &StrategyState{
+		ID: sc.ID, Type: "spot", Platform: "okx",
+		Cash: 0,
+		RiskState: RiskState{
+			PeakValue: 1000, MaxDrawdownPct: 10, TotalTrades: 1, DailyPnLDate: todayUTC(),
+		},
+		Positions: map[string]*Position{
+			"BTC-USDT": {Symbol: "BTC-USDT", Quantity: 0.01, AvgCost: 80000, Side: "long"},
+		},
+		OptionPositions: map[string]*OptionPosition{},
+	}
+	// Price drop sends PV to $500 (50% drawdown from peak 1000 — well past max 10%).
+	prices := map[string]float64{"BTC-USDT": 50000}
+
+	allowed, reason := CheckRisk(&sc, s, PortfolioValue(s, prices), prices, nil, nil)
+	if allowed {
+		t.Fatalf("CheckRisk allowed=true; want false after drawdown breach (reason=%q)", reason)
+	}
+	p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseOKXSpot)
+	if p == nil {
+		t.Fatal("expected PendingCircuitCloses[okx_spot] after CheckRisk CB fire")
+	}
+	if !p.OperatorRequired {
+		t.Error("OperatorRequired=false; want true")
+	}
+}
+
+// --- Drain + formatter tests ---
+
+type captureNotifier struct {
+	hasBackends bool
+	channels    []string
+	dms         []string
+}
+
+func (n *captureNotifier) HasBackends() bool          { return n.hasBackends }
+func (n *captureNotifier) SendToAllChannels(c string) { n.channels = append(n.channels, c) }
+func (n *captureNotifier) SendOwnerDM(c string)       { n.dms = append(n.dms, c) }
+
+// TestPlanOperatorRequiredWarning_EmptyStateNoEntries confirms the formatter
+// is silent when no operator-required pending is present.
+func TestPlanOperatorRequiredWarning_EmptyStateNoEntries(t *testing.T) {
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-1": {ID: "hl-1", RiskState: RiskState{}},
+	}}
+	plan := planOperatorRequiredWarning(state)
+	if plan.HasEntries() {
+		t.Errorf("expected no entries; got %+v", plan.Entries)
+	}
+	if plan.Message != "" {
+		t.Errorf("expected empty message; got %q", plan.Message)
+	}
+}
+
+// TestPlanOperatorRequiredWarning_IgnoresAutomatedPlatforms verifies that
+// PendingCircuitCloses entries WITHOUT OperatorRequired=true (i.e. HL auto-close
+// pending) do not produce operator warnings — the HL drain owns those.
+func TestPlanOperatorRequiredWarning_IgnoresAutomatedPlatforms(t *testing.T) {
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-1": {
+			ID: "hl-1",
+			RiskState: RiskState{PendingCircuitCloses: map[string]*PendingCircuitClose{
+				PlatformPendingCloseHyperliquid: {
+					Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.1}},
+				},
+			}},
+		},
+	}}
+	plan := planOperatorRequiredWarning(state)
+	if plan.HasEntries() {
+		t.Errorf("HL auto-close pending leaked into operator warning: %+v", plan.Entries)
+	}
+}
+
+// TestPlanOperatorRequiredWarning_FormatsOKXAndRH locks in the message
+// structure: sorted by strategy ID then platform, leg list, CB-until suffix,
+// explicit "No automated close" footer.
+func TestPlanOperatorRequiredWarning_FormatsOKXAndRH(t *testing.T) {
+	cbUntil := time.Date(2026, 4, 21, 3, 30, 0, 0, time.UTC)
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"okx-sma-btc": {
+			ID: "okx-sma-btc",
+			RiskState: RiskState{
+				CurrentDrawdownPct:  12.5,
+				CircuitBreaker:      true,
+				CircuitBreakerUntil: cbUntil,
+				PendingCircuitCloses: map[string]*PendingCircuitClose{
+					PlatformPendingCloseOKXSpot: {
+						Symbols:          []PendingCircuitCloseSymbol{{Symbol: "BTC-USDT", Size: 0.0125}},
+						OperatorRequired: true,
+					},
+				},
+			},
+		},
+		"rh-ccall-spy": {
+			ID: "rh-ccall-spy",
+			RiskState: RiskState{
+				CurrentDrawdownPct:  8.0,
+				CircuitBreaker:      true,
+				CircuitBreakerUntil: cbUntil,
+				PendingCircuitCloses: map[string]*PendingCircuitClose{
+					PlatformPendingCloseRobinhoodOptions: {
+						Symbols: []PendingCircuitCloseSymbol{
+							{Symbol: "SPY-2026-06-19-460-C", Size: 1},
+							{Symbol: "SPY-2026-05-15-450-C", Size: 2},
+						},
+						OperatorRequired: true,
+					},
+				},
+			},
+		},
+	}}
+
+	plan := planOperatorRequiredWarning(state)
+	if !plan.HasEntries() || len(plan.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %+v", len(plan.Entries), plan.Entries)
+	}
+	// Deterministic ordering: strategy ID alphabetical.
+	if plan.Entries[0].StrategyID != "okx-sma-btc" || plan.Entries[1].StrategyID != "rh-ccall-spy" {
+		t.Errorf("entries not sorted by StrategyID: got %s, %s", plan.Entries[0].StrategyID, plan.Entries[1].StrategyID)
+	}
+	// Legs within an entry sorted alphabetically.
+	rhLegs := plan.Entries[1].Symbols
+	if rhLegs[0].Symbol != "SPY-2026-05-15-450-C" || rhLegs[1].Symbol != "SPY-2026-06-19-460-C" {
+		t.Errorf("RH legs not sorted: %+v", rhLegs)
+	}
+
+	msg := plan.Message
+	for _, want := range []string{
+		"CIRCUIT BREAKER — OPERATOR INTERVENTION REQUIRED",
+		"2 strategy-platform pairs",
+		"okx-sma-btc [OKX spot]",
+		"rh-ccall-spy [Robinhood options]",
+		"BTC-USDT (size=0.012500)",
+		"SPY-2026-05-15-450-C",
+		"drawdown 12.5%",
+		"CB until 2026-04-21T03:30:00Z",
+		"No automated close will be attempted",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message missing %q; got:\n%s", want, msg)
+		}
+	}
+
+	// LogLines: one CRITICAL per entry, containing strategy ID + platform key.
+	if len(plan.LogLines) != 2 {
+		t.Fatalf("expected 2 log lines, got %d", len(plan.LogLines))
+	}
+	for _, line := range plan.LogLines {
+		if !strings.HasPrefix(line, "[CRITICAL] operator-required-close:") {
+			t.Errorf("log line missing CRITICAL prefix: %q", line)
+		}
+	}
+}
+
+// TestDrainOperatorRequired_DeliversToNotifier confirms the drain wrapper
+// forwards to SendToAllChannels and SendOwnerDM exactly once per cycle when
+// entries are present.
+func TestDrainOperatorRequired_DeliversToNotifier(t *testing.T) {
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"okx-s": {
+			ID: "okx-s",
+			RiskState: RiskState{PendingCircuitCloses: map[string]*PendingCircuitClose{
+				PlatformPendingCloseOKXSpot: {
+					Symbols:          []PendingCircuitCloseSymbol{{Symbol: "BTC-USDT", Size: 0.01}},
+					OperatorRequired: true,
+				},
+			}},
+		},
+	}}
+	n := &captureNotifier{hasBackends: true}
+	var mu sync.RWMutex
+
+	drainOperatorRequiredPendingCloses(state, n, &mu)
+
+	if len(n.channels) != 1 || len(n.dms) != 1 {
+		t.Fatalf("expected 1 channel send + 1 owner DM; got channels=%d dms=%d", len(n.channels), len(n.dms))
+	}
+	if !strings.Contains(n.channels[0], "OPERATOR INTERVENTION REQUIRED") {
+		t.Errorf("channel message missing header: %s", n.channels[0])
+	}
+
+	// Pending must remain after drain — auto-clearing would hide the gap.
+	if state.Strategies["okx-s"].RiskState.getPendingCircuitClose(PlatformPendingCloseOKXSpot) == nil {
+		t.Error("drain cleared the pending; it should persist until operator intervenes")
+	}
+}
+
+// TestDrainOperatorRequired_NoBackendsSafe confirms the drain tolerates a
+// notifier with no backends (Discord + Telegram disabled) without panicking
+// and without producing output.
+func TestDrainOperatorRequired_NoBackendsSafe(t *testing.T) {
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"okx-s": {
+			ID: "okx-s",
+			RiskState: RiskState{PendingCircuitCloses: map[string]*PendingCircuitClose{
+				PlatformPendingCloseOKXSpot: {
+					Symbols:          []PendingCircuitCloseSymbol{{Symbol: "BTC-USDT", Size: 0.01}},
+					OperatorRequired: true,
+				},
+			}},
+		},
+	}}
+	n := &captureNotifier{hasBackends: false}
+	var mu sync.RWMutex
+	drainOperatorRequiredPendingCloses(state, n, &mu) // must not panic
+	if len(n.channels)+len(n.dms) != 0 {
+		t.Errorf("expected no sends when HasBackends()=false; got %d/%d", len(n.channels), len(n.dms))
+	}
+}
+
+// TestDrainOperatorRequired_NilNotifierSafe locks in the nil-notifier guard.
+func TestDrainOperatorRequired_NilNotifierSafe(t *testing.T) {
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"okx-s": {
+			ID: "okx-s",
+			RiskState: RiskState{PendingCircuitCloses: map[string]*PendingCircuitClose{
+				PlatformPendingCloseOKXSpot: {
+					Symbols:          []PendingCircuitCloseSymbol{{Symbol: "BTC-USDT", Size: 0.01}},
+					OperatorRequired: true,
+				},
+			}},
+		},
+	}}
+	var mu sync.RWMutex
+	drainOperatorRequiredPendingCloses(state, nil, &mu) // must not panic
+}
+
+// TestPendingCircuitClose_OperatorRequired_JSONRoundTrip locks in that the
+// OperatorRequired flag round-trips through Marshal/Unmarshal (serialized to
+// SQLite as part of risk_pending_circuit_closes_json). A bug where the flag
+// gets dropped would silently re-promote the entry to auto-close on reload.
+func TestPendingCircuitClose_OperatorRequired_JSONRoundTrip(t *testing.T) {
+	src := &RiskState{PendingCircuitCloses: map[string]*PendingCircuitClose{
+		PlatformPendingCloseOKXSpot: {
+			Symbols:          []PendingCircuitCloseSymbol{{Symbol: "BTC-USDT", Size: 0.01}},
+			OperatorRequired: true,
+		},
+		PlatformPendingCloseHyperliquid: {
+			Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.1}},
+			// OperatorRequired omitted — expect false after roundtrip.
+		},
+	}}
+	blob := src.MarshalPendingCircuitClosesJSON()
+	if blob == "" {
+		t.Fatal("empty blob; expected marshaled JSON")
+	}
+	dst := &RiskState{}
+	dst.UnmarshalPendingCircuitClosesJSON(blob)
+
+	okx := dst.getPendingCircuitClose(PlatformPendingCloseOKXSpot)
+	if okx == nil || !okx.OperatorRequired {
+		t.Errorf("OperatorRequired flag lost on reload: %+v", okx)
+	}
+	hl := dst.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
+	if hl == nil || hl.OperatorRequired {
+		t.Errorf("HL entry OperatorRequired flipped true unexpectedly: %+v", hl)
+	}
+}

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -552,12 +552,41 @@ type RiskState struct {
 // phase PRs (#360 OKX, #361 RH, #362 TS).
 const PlatformPendingCloseHyperliquid = "hyperliquid"
 
+// PlatformPendingCloseOKXSpot and PlatformPendingCloseRobinhoodOptions are map
+// keys for per-strategy circuit-breaker closes the scheduler CANNOT auto-close
+// safely (#363 phase 5, mirrors the portfolio-kill gaps from #345 / #346).
+//
+// OKX spot: no reduce-only semantic for asset balances; a net-close would wipe
+// holdings that other strategies or the operator's manual positions rely on.
+//
+// Robinhood options: stock options close semantics (sell-to-close vs
+// buy-to-close per leg, multi-leg spreads) are non-trivial to automate and the
+// failure mode is high-risk.
+//
+// Pending entries under these keys carry OperatorRequired=true. The drain does
+// NOT submit orders — it emits a CRITICAL warning once per cycle and leaves
+// the pending intact until the operator intervenes (or the CB naturally
+// resets). Deliberately distinct from "okx" / "robinhood" portfolio-kill keys
+// so the auto-close drains never dequeue an operator-required entry.
+const (
+	PlatformPendingCloseOKXSpot          = "okx_spot"
+	PlatformPendingCloseRobinhoodOptions = "robinhood_options"
+)
+
 // PendingCircuitClose is a queued request to close one or more positions on a
 // single venue after a per-strategy circuit breaker fired. The drain runner
 // for that venue (platform key in RiskState.PendingCircuitCloses) translates
 // the symbol/size legs into venue-specific orders.
+//
+// When OperatorRequired is true the scheduler will not attempt an automated
+// close — the venue lacks a safe reduce-only primitive or the close semantics
+// are leg-aware enough that automation is unsafe (OKX spot, Robinhood options;
+// #363). The drain emits a CRITICAL warning each cycle instead and leaves the
+// pending populated so /status, Discord, and Telegram all surface the gap
+// continuously until the operator clears it manually.
 type PendingCircuitClose struct {
-	Symbols []PendingCircuitCloseSymbol `json:"symbols"`
+	Symbols          []PendingCircuitCloseSymbol `json:"symbols"`
+	OperatorRequired bool                        `json:"operator_required,omitempty"`
 }
 
 // PendingCircuitCloseSymbol is one position leg of a pending close. Symbol is
@@ -732,6 +761,67 @@ func setHyperliquidCircuitBreakerPending(sc *StrategyConfig, s *StrategyState, a
 	s.RiskState.setPendingCircuitClose(PlatformPendingCloseHyperliquid, &PendingCircuitClose{
 		Symbols: []PendingCircuitCloseSymbol{{Symbol: sym, Size: qty}},
 	})
+}
+
+// setOperatorRequiredCircuitBreakerPending enqueues an OperatorRequired=true
+// pending close for OKX spot and Robinhood options strategies, the two live
+// venues the scheduler has no safe auto-close path for (#345 / #346 / #363).
+//
+// Unlike setHyperliquidCircuitBreakerPending, this helper does not size the
+// close — no subprocess round-trip is ever attempted, so a notional size is
+// unnecessary. Size is set to the strategy's virtual position quantity (or 0
+// when no virtual position exists, e.g. options strategies whose positions
+// live in OptionPositions rather than Positions) purely for operator-facing
+// context in the warning message.
+//
+// No-op when the strategy is not live, or when the strategy is not one of the
+// two covered operator-gap configurations (call sites can invoke it broadly;
+// the guard keeps it cheap).
+func setOperatorRequiredCircuitBreakerPending(sc *StrategyConfig, s *StrategyState) {
+	if sc == nil || s == nil {
+		return
+	}
+	switch {
+	case sc.Platform == "okx" && sc.Type == "spot" && okxIsLive(sc.Args):
+		sym := okxSymbol(sc.Args)
+		if sym == "" {
+			return
+		}
+		var size float64
+		if pos, ok := s.Positions[sym]; ok {
+			size = pos.Quantity
+		}
+		s.RiskState.setPendingCircuitClose(PlatformPendingCloseOKXSpot, &PendingCircuitClose{
+			Symbols:          []PendingCircuitCloseSymbol{{Symbol: sym, Size: size}},
+			OperatorRequired: true,
+		})
+	case sc.Platform == "robinhood" && sc.Type == "options" && robinhoodIsLive(sc.Args):
+		// Options positions live in s.OptionPositions keyed by option ID, not
+		// a single underlier. Collect every open leg's ID so the operator sees
+		// exactly which positions need manual close (not just the underlier).
+		symbols := make([]PendingCircuitCloseSymbol, 0, len(s.OptionPositions))
+		for id, op := range s.OptionPositions {
+			if op == nil {
+				continue
+			}
+			symbols = append(symbols, PendingCircuitCloseSymbol{Symbol: id, Size: op.Quantity})
+		}
+		if len(symbols) == 0 {
+			// No open option legs — emit a single marker entry with the
+			// underlier so the operator still sees the strategy-level CB fire
+			// on /status and in notifications.
+			sym := robinhoodSymbol(sc.Args)
+			if sym == "" {
+				return
+			}
+			symbols = append(symbols, PendingCircuitCloseSymbol{Symbol: sym, Size: 0})
+		}
+		sort.Slice(symbols, func(i, j int) bool { return symbols[i].Symbol < symbols[j].Symbol })
+		s.RiskState.setPendingCircuitClose(PlatformPendingCloseRobinhoodOptions, &PendingCircuitClose{
+			Symbols:          symbols,
+			OperatorRequired: true,
+		})
+	}
 }
 
 // rolloverDailyPnL resets DailyPnL to zero whenever the UTC date has advanced
@@ -951,6 +1041,7 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 			r.CircuitBreaker = true
 			r.CircuitBreakerUntil = now.Add(24 * time.Hour)
 			setHyperliquidCircuitBreakerPending(sc, s, assist)
+			setOperatorRequiredCircuitBreakerPending(sc, s)
 			forceCloseAllPositions(s, prices, logger)
 			return false, fmt.Sprintf("max drawdown exceeded (%.1f%% > %.1f%%, portfolio=$%.2f peak=$%.2f, denom=%s=$%.2f)",
 				r.CurrentDrawdownPct, r.MaxDrawdownPct, portfolioValue, r.PeakValue, denomLabel, denom)


### PR DESCRIPTION
Closes #363.

Phase 5 of #357. When a per-strategy circuit breaker fires on OKX spot or Robinhood options — two live venues with no safe automated-close primitive (#345 / #346) — the scheduler now enqueues a pending close with `OperatorRequired=true` under distinct `okx_spot` / `robinhood_options` keys. A per-cycle drain emits a CRITICAL warning to stderr, all Discord channels, and the owner DM without attempting any order submission. The pending stays populated so /status, Discord, and Telegram continuously surface the gap until the operator flattens manually and the CB naturally resets.

When the portfolio kill switch fires, per-strategy operator-required pendings are cleared alongside the HL pending to avoid double-notification (`formatKillSwitchMessage` already surfaces `OKXSpotPresent` / `RHOptionsPresent`).

Tests: 13 new unit tests covering enqueue for both venues, paper-mode no-op, other-platform no-op, `CheckRisk` end-to-end wiring, formatter output, drain delivery, nil/no-backends safety, JSON round-trip of the `operator_required` flag.

Runbook: new "Operator-Required Circuit Breakers" section in SKILL.md with /status query snippet and response steps.

🤖 Generated with [Claude Code](https://claude.ai/code)