### PR TITLE
feat: add session_breakout strategy with volume confirmation

### DIFF
--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -426,6 +426,11 @@ DEFAULT_PARAM_RANGES = {
         "atr_period": [10, 14, 20],
         "atr_multiplier": [1.0, 1.5, 2.0],
     },
+    "session_breakout": {
+        "session": ["asian", "us_open", "us_close"],
+        "lookback": [1, 2, 3],
+        "volume_threshold": [1.2, 1.5, 2.0],
+    },
     "delta_neutral_funding": {
         "entry_threshold": [0.00005, 0.0001, 0.00015],
         "exit_threshold": [0.0, 0.00002, 0.00005],

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -430,6 +430,7 @@ DEFAULT_PARAM_RANGES = {
         "session": ["asian", "us_open", "us_close"],
         "lookback": [1, 2, 3],
         "volume_threshold": [1.2, 1.5, 2.0],
+        "atr_multiplier": [0.0, 0.5, 1.0],
     },
     "delta_neutral_funding": {
         "entry_threshold": [0.00005, 0.0001, 0.00015],

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -60,6 +60,7 @@ var knownShortNames = map[string]string{
 	"sweep_squeeze_combo":   "ssc",
 	"adx_trend":             "adxt",
 	"donchian_breakout":     "dbo",
+	"session_breakout":      "sbo",
 }
 
 // bidirectionalPerpsStrategies lists strategy IDs that emit signal=-1 as a
@@ -68,6 +69,7 @@ var knownShortNames = map[string]string{
 // of skipping the signal (#328).
 var bidirectionalPerpsStrategies = map[string]bool{
 	"triple_ema_bidir": true,
+	"session_breakout": true,
 }
 
 func isBidirectionalPerpsStrategy(id string) bool {
@@ -132,6 +134,7 @@ var defaultPerpsStrategies = []stratDef{
 	{ID: "sweep_squeeze_combo", ShortName: "ssc"},
 	{ID: "adx_trend", ShortName: "adxt"},
 	{ID: "donchian_breakout", ShortName: "dbo"},
+	{ID: "session_breakout", ShortName: "sbo"},
 }
 
 var defaultFuturesStrategies = []stratDef{
@@ -153,6 +156,7 @@ var defaultFuturesStrategies = []stratDef{
 	{ID: "sweep_squeeze_combo", ShortName: "ssc"},
 	{ID: "adx_trend", ShortName: "adxt"},
 	{ID: "donchian_breakout", ShortName: "dbo"},
+	{ID: "session_breakout", ShortName: "sbo"},
 }
 
 // Supported CME futures symbols for the init wizard.

--- a/scheduler/init_test.go
+++ b/scheduler/init_test.go
@@ -580,7 +580,7 @@ func TestGenerateConfig_PerpsAllowShortsWiring(t *testing.T) {
 	opts.EnablePerps = true
 	opts.Assets = []string{"ETH"}
 	opts.PerpsMode = "paper"
-	opts.PerpsStrategies = []string{"triple_ema_bidir", "triple_ema", "rsi_macd_combo"}
+	opts.PerpsStrategies = []string{"triple_ema_bidir", "triple_ema", "rsi_macd_combo", "session_breakout"}
 
 	cfg := generateConfig(opts)
 
@@ -588,6 +588,7 @@ func TestGenerateConfig_PerpsAllowShortsWiring(t *testing.T) {
 		"hl-temab-eth": true,  // bidirectional — must allow shorts
 		"hl-tema-eth":  false, // long-only — must NOT allow shorts
 		"hl-rmc-eth":   false, // long-only — must NOT allow shorts
+		"hl-sbo-eth":   true,  // bidirectional — must allow shorts (#371)
 	}
 	seen := map[string]bool{}
 	for _, s := range cfg.Strategies {

--- a/shared_strategies/registry.py
+++ b/shared_strategies/registry.py
@@ -40,6 +40,7 @@ from range_scalper import range_scalper_core
 from sweep_squeeze_combo import sweep_squeeze_combo_core
 from adx_trend import adx_trend_core
 from donchian_breakout import donchian_breakout_core
+from session_breakout import session_breakout_core
 
 
 VALID_PLATFORMS: Tuple[str, ...] = ("spot", "futures")
@@ -903,6 +904,19 @@ def donchian_breakout_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
     return donchian_breakout_core(df, **params)
 
 
+@register(
+    "session_breakout",
+    "Session Breakout — break of prior session (Asian/US open/US close) high/low with volume confirmation",
+    {
+        "session": "asian", "lookback": 1, "volume_threshold": 1.5,
+        "vol_period": 20, "atr_period": 14, "atr_multiplier": 0.0,
+    },
+    platforms=("futures",),
+)
+def session_breakout_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return session_breakout_core(df, **params)
+
+
 # ─────────────────────────────────────────────
 # Per-platform display order.
 # These lists MUST match the legacy registration order in each shim so
@@ -927,6 +941,6 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "heikin_ashi_ema", "order_blocks", "vwap_reversion", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
         "sweep_squeeze_combo", "adx_trend", "delta_neutral_funding",
-        "donchian_breakout",
+        "donchian_breakout", "session_breakout",
     ],
 }

--- a/shared_strategies/session_breakout.py
+++ b/shared_strategies/session_breakout.py
@@ -20,7 +20,7 @@ import pandas as pd
 # UTC hour windows [start, end). ``end`` is exclusive.
 SESSION_WINDOWS = {
     "asian":    (0, 8),     # Asian range
-    "us_open":  (13, 14),   # first hour after NYSE open (13:30 UTC → 13:xx bars)
+    "us_open":  (13, 15),   # NYSE open window: covers 13:30–15:00 UTC (DST) / 14:30–15:30 UTC (standard)
     "us_close": (20, 21),   # final hour before NYSE close
 }
 
@@ -70,7 +70,11 @@ def session_breakout_core(
     if not isinstance(result.index, pd.DatetimeIndex) or result.empty:
         return result
 
-    start_hour, end_hour = SESSION_WINDOWS.get(session, SESSION_WINDOWS["asian"])
+    if session not in SESSION_WINDOWS:
+        raise ValueError(
+            f"Unknown session {session!r}. Valid values: {list(SESSION_WINDOWS)}"
+        )
+    start_hour, end_hour = SESSION_WINDOWS[session]
     hours = result.index.hour
     in_session = (hours >= start_hour) & (hours < end_hour)
     dates = result.index.normalize()
@@ -85,20 +89,21 @@ def session_breakout_core(
         return result
 
     sess_df["level_high"] = (
-        sess_df["s_high"].rolling(window=lookback, min_periods=1).max().shift(1)
+        sess_df["s_high"].rolling(window=lookback, min_periods=1).max()
     )
     sess_df["level_low"] = (
-        sess_df["s_low"].rolling(window=lookback, min_periods=1).min().shift(1)
+        sess_df["s_low"].rolling(window=lookback, min_periods=1).min()
     )
 
-    # Forward-fill levels across days so a bar on day N uses the level built
-    # from the last ``lookback`` sessions ending on day N-1.
+    # Map each bar to its day's level (most-recently-completed session).
+    # ``after_session`` below prevents look-ahead: breakout bars can only fire
+    # once the session has closed, so the level is already fixed.
     level_high_by_day = sess_df["level_high"]
     level_low_by_day = sess_df["level_low"]
     result["session_high"] = dates.to_series(index=result.index).map(level_high_by_day)
     result["session_low"] = dates.to_series(index=result.index).map(level_low_by_day)
 
-    result["vol_sma"] = result["volume"].rolling(window=vol_period, min_periods=1).mean()
+    result["vol_sma"] = result["volume"].rolling(window=vol_period, min_periods=vol_period).mean()
     high_volume = result["volume"] > result["vol_sma"] * volume_threshold
 
     if atr_multiplier > 0:
@@ -110,7 +115,7 @@ def session_breakout_core(
             ],
             axis=1,
         ).max(axis=1)
-        atr = tr.rolling(window=atr_period, min_periods=1).mean()
+        atr = tr.rolling(window=atr_period, min_periods=atr_period).mean()
         atr_ok = tr > atr * atr_multiplier
     else:
         atr_ok = pd.Series(True, index=result.index)

--- a/shared_strategies/session_breakout.py
+++ b/shared_strategies/session_breakout.py
@@ -1,0 +1,136 @@
+"""
+Session Breakout — trade breakouts from session-specific highs/lows with volume
+confirmation.
+
+Differs from the ``breakout`` strategy (rolling N-bar high/low + ATR filter):
+
+* Levels come from the most recently-completed *session* (e.g. Asian range,
+  US open first hour) rather than a rolling window.
+* A volume spike is mandatory for entry, filtering out low-conviction wicks.
+
+Sessions are UTC-based. A bar is considered *after* the session once its hour
+is past the session end — that guarantees the level is fixed before any
+breakout can fire, avoiding look-ahead.
+"""
+
+import numpy as np
+import pandas as pd
+
+
+# UTC hour windows [start, end). ``end`` is exclusive.
+SESSION_WINDOWS = {
+    "asian":    (0, 8),     # Asian range
+    "us_open":  (13, 14),   # first hour after NYSE open (13:30 UTC → 13:xx bars)
+    "us_close": (20, 21),   # final hour before NYSE close
+}
+
+
+def session_breakout_core(
+    df: pd.DataFrame,
+    session: str = "asian",
+    lookback: int = 1,
+    volume_threshold: float = 1.5,
+    vol_period: int = 20,
+    atr_period: int = 14,
+    atr_multiplier: float = 0.0,
+) -> pd.DataFrame:
+    """
+    Generate session breakout signals with volume confirmation.
+
+    Parameters
+    ----------
+    df : DataFrame with open/high/low/close/volume columns. A DatetimeIndex
+         is required — without it, signals are all zero (session detection
+         needs wall-clock hours).
+    session : one of ``"asian"``, ``"us_open"``, ``"us_close"``.
+    lookback : number of prior sessions to aggregate for the key level
+               (rolling max of session highs / min of session lows).
+    volume_threshold : multiplier vs ``vol_period`` SMA the breakout bar's
+                       volume must exceed (default 1.5 = 150% of average).
+    vol_period : window for the volume SMA.
+    atr_period : window for the optional ATR filter.
+    atr_multiplier : if > 0, the breakout bar's true range must exceed
+                     ``atr * atr_multiplier`` (filters low-volatility chop).
+                     Default 0 disables the filter.
+
+    Returns
+    -------
+    DataFrame with added columns:
+        signal        : 1 (bullish breakout), -1 (bearish breakout), 0 (hold)
+        session_high  : prior lookback sessions' high (key level)
+        session_low   : prior lookback sessions' low (key level)
+        vol_sma       : rolling volume SMA
+    """
+    result = df.copy()
+    result["signal"] = 0
+    result["session_high"] = np.nan
+    result["session_low"] = np.nan
+    result["vol_sma"] = np.nan
+
+    if not isinstance(result.index, pd.DatetimeIndex) or result.empty:
+        return result
+
+    start_hour, end_hour = SESSION_WINDOWS.get(session, SESSION_WINDOWS["asian"])
+    hours = result.index.hour
+    in_session = (hours >= start_hour) & (hours < end_hour)
+    dates = result.index.normalize()
+
+    # Per-day session high/low. Days with no in-session bars don't contribute
+    # a row so a gappy series doesn't blank the levels.
+    session_bars = result[in_session]
+    sess_df = session_bars.groupby(session_bars.index.normalize()).agg(
+        s_high=("high", "max"), s_low=("low", "min")
+    )
+    if sess_df.empty:
+        return result
+
+    sess_df["level_high"] = (
+        sess_df["s_high"].rolling(window=lookback, min_periods=1).max().shift(1)
+    )
+    sess_df["level_low"] = (
+        sess_df["s_low"].rolling(window=lookback, min_periods=1).min().shift(1)
+    )
+
+    # Forward-fill levels across days so a bar on day N uses the level built
+    # from the last ``lookback`` sessions ending on day N-1.
+    level_high_by_day = sess_df["level_high"]
+    level_low_by_day = sess_df["level_low"]
+    result["session_high"] = dates.to_series(index=result.index).map(level_high_by_day)
+    result["session_low"] = dates.to_series(index=result.index).map(level_low_by_day)
+
+    result["vol_sma"] = result["volume"].rolling(window=vol_period, min_periods=1).mean()
+    high_volume = result["volume"] > result["vol_sma"] * volume_threshold
+
+    if atr_multiplier > 0:
+        tr = pd.concat(
+            [
+                result["high"] - result["low"],
+                (result["high"] - result["close"].shift(1)).abs(),
+                (result["low"] - result["close"].shift(1)).abs(),
+            ],
+            axis=1,
+        ).max(axis=1)
+        atr = tr.rolling(window=atr_period, min_periods=1).mean()
+        atr_ok = tr > atr * atr_multiplier
+    else:
+        atr_ok = pd.Series(True, index=result.index)
+
+    # Only fire after the session has closed for the day — an intra-session
+    # "breakout" against its own forming level is meaningless.
+    after_session = hours >= end_hour
+
+    level_high = result["session_high"]
+    level_low = result["session_low"]
+
+    break_up = (
+        (result["close"] > level_high) & high_volume & atr_ok & after_session
+    )
+    break_down = (
+        (result["close"] < level_low) & high_volume & atr_ok & after_session
+    )
+
+    # First bar of a breakout only — stay-above doesn't repeat.
+    result.loc[break_up & ~break_up.shift(1, fill_value=False), "signal"] = 1
+    result.loc[break_down & ~break_down.shift(1, fill_value=False), "signal"] = -1
+
+    return result

--- a/shared_strategies/test_session_breakout.py
+++ b/shared_strategies/test_session_breakout.py
@@ -138,15 +138,14 @@ def test_signal_not_repeated_across_consecutive_breakout_bars():
     assert signals == [1, 0]
 
 
-def test_unknown_session_falls_back_to_asian_defaults():
-    # Must not crash; defaults to asian window.
+def test_unknown_session_raises():
     rng = np.random.RandomState(0)
-    n = 96  # 4 days of hourly bars
+    n = 96
     idx = pd.date_range("2024-01-01", periods=n, freq="h")
     closes = 100 + rng.randn(n).cumsum() * 0.1
     df = pd.DataFrame({
         "open": closes, "high": closes + 0.5, "low": closes - 0.5,
         "close": closes, "volume": np.full(n, 100.0),
     }, index=idx)
-    result = session_breakout_core(df, session="not_a_real_session")
-    assert "signal" in result.columns
+    with pytest.raises(ValueError, match="Unknown session"):
+        session_breakout_core(df, session="not_a_real_session")

--- a/shared_strategies/test_session_breakout.py
+++ b/shared_strategies/test_session_breakout.py
@@ -1,0 +1,152 @@
+"""Tests for session_breakout strategy."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from session_breakout import session_breakout_core
+
+
+def _make_df(bars):
+    """Build a DataFrame from a list of (timestamp, o, h, l, c, v) tuples."""
+    idx = pd.DatetimeIndex([b[0] for b in bars])
+    return pd.DataFrame(
+        {
+            "open":   [b[1] for b in bars],
+            "high":   [b[2] for b in bars],
+            "low":    [b[3] for b in bars],
+            "close":  [b[4] for b in bars],
+            "volume": [b[5] for b in bars],
+        },
+        index=idx,
+    )
+
+
+def test_no_datetime_index_returns_zero_signal():
+    df = pd.DataFrame({
+        "open": [100.0] * 10, "high": [101.0] * 10, "low": [99.0] * 10,
+        "close": [100.0] * 10, "volume": [100.0] * 10,
+    })
+    result = session_breakout_core(df)
+    assert (result["signal"] == 0).all()
+
+
+def test_empty_df_returns_empty():
+    df = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+    result = session_breakout_core(df)
+    assert "signal" in result.columns
+    assert len(result) == 0
+
+
+def test_bullish_breakout_requires_volume_spike():
+    # Day 1: Asian session 00-08 UTC with range 100-105.
+    # Day 2: after session end, price breaks above 105 with heavy volume.
+    bars = []
+    base = pd.Timestamp("2024-01-01 00:00:00", tz=None)
+    # Day 1 asian session (9 hourly bars within 00-08)
+    for h in range(8):
+        bars.append((base + pd.Timedelta(hours=h), 100, 105, 99, 102, 100.0))
+    # Day 1 after session (fill bars to keep vol SMA populated)
+    for h in range(8, 24):
+        bars.append((base + pd.Timedelta(hours=h), 102, 103, 101, 102, 100.0))
+    # Day 2 asian session
+    day2 = base + pd.Timedelta(days=1)
+    for h in range(8):
+        bars.append((day2 + pd.Timedelta(hours=h), 102, 104, 101, 103, 100.0))
+    # Day 2 breakout bar — close > 105 with high volume
+    bars.append((day2 + pd.Timedelta(hours=9), 103, 108, 103, 107, 500.0))
+
+    df = _make_df(bars)
+    result = session_breakout_core(df, session="asian", lookback=1, volume_threshold=1.5)
+    # The breakout bar is the last one
+    assert result["signal"].iloc[-1] == 1
+
+
+def test_breakout_suppressed_without_volume():
+    # Same setup as above, but last bar has normal volume.
+    bars = []
+    base = pd.Timestamp("2024-01-01 00:00:00")
+    for h in range(8):
+        bars.append((base + pd.Timedelta(hours=h), 100, 105, 99, 102, 100.0))
+    for h in range(8, 24):
+        bars.append((base + pd.Timedelta(hours=h), 102, 103, 101, 102, 100.0))
+    day2 = base + pd.Timedelta(days=1)
+    for h in range(8):
+        bars.append((day2 + pd.Timedelta(hours=h), 102, 104, 101, 103, 100.0))
+    bars.append((day2 + pd.Timedelta(hours=9), 103, 108, 103, 107, 100.0))  # no volume spike
+
+    df = _make_df(bars)
+    result = session_breakout_core(df, session="asian", lookback=1, volume_threshold=1.5)
+    assert result["signal"].iloc[-1] == 0
+
+
+def test_bearish_breakout_emits_short_signal():
+    bars = []
+    base = pd.Timestamp("2024-01-01 00:00:00")
+    # Day 1 asian session: range 100-105
+    for h in range(8):
+        bars.append((base + pd.Timedelta(hours=h), 102, 105, 100, 103, 100.0))
+    for h in range(8, 24):
+        bars.append((base + pd.Timedelta(hours=h), 102, 103, 101, 102, 100.0))
+    # Day 2 asian session
+    day2 = base + pd.Timedelta(days=1)
+    for h in range(8):
+        bars.append((day2 + pd.Timedelta(hours=h), 101, 103, 100, 101, 100.0))
+    # Break below 100 with volume
+    bars.append((day2 + pd.Timedelta(hours=9), 100, 100, 95, 96, 500.0))
+
+    df = _make_df(bars)
+    result = session_breakout_core(df, session="asian", lookback=1, volume_threshold=1.5)
+    assert result["signal"].iloc[-1] == -1
+
+
+def test_intra_session_bar_does_not_signal():
+    # Bar within the session must not fire (level isn't fixed yet).
+    bars = []
+    base = pd.Timestamp("2024-01-01 00:00:00")
+    for h in range(8):
+        bars.append((base + pd.Timedelta(hours=h), 100, 105, 99, 102, 100.0))
+    for h in range(8, 24):
+        bars.append((base + pd.Timedelta(hours=h), 102, 103, 101, 102, 100.0))
+    # Day 2 inside asian session — volume spike, price above prior high.
+    day2 = base + pd.Timedelta(days=1)
+    bars.append((day2 + pd.Timedelta(hours=3), 103, 108, 103, 107, 500.0))
+
+    df = _make_df(bars)
+    result = session_breakout_core(df, session="asian", lookback=1, volume_threshold=1.5)
+    # The spike bar is at hour 3, within session -> no signal.
+    assert result["signal"].iloc[-1] == 0
+
+
+def test_signal_not_repeated_across_consecutive_breakout_bars():
+    # Two bars in a row above the level with high volume -> only first fires.
+    bars = []
+    base = pd.Timestamp("2024-01-01 00:00:00")
+    for h in range(8):
+        bars.append((base + pd.Timedelta(hours=h), 100, 105, 99, 102, 100.0))
+    for h in range(8, 24):
+        bars.append((base + pd.Timedelta(hours=h), 102, 103, 101, 102, 100.0))
+    day2 = base + pd.Timedelta(days=1)
+    for h in range(8):
+        bars.append((day2 + pd.Timedelta(hours=h), 102, 104, 101, 103, 100.0))
+    bars.append((day2 + pd.Timedelta(hours=9),  103, 108, 103, 107, 500.0))
+    bars.append((day2 + pd.Timedelta(hours=10), 107, 109, 106, 108, 500.0))
+
+    df = _make_df(bars)
+    result = session_breakout_core(df, session="asian", lookback=1, volume_threshold=1.5)
+    signals = result["signal"].iloc[-2:].tolist()
+    assert signals == [1, 0]
+
+
+def test_unknown_session_falls_back_to_asian_defaults():
+    # Must not crash; defaults to asian window.
+    rng = np.random.RandomState(0)
+    n = 96  # 4 days of hourly bars
+    idx = pd.date_range("2024-01-01", periods=n, freq="h")
+    closes = 100 + rng.randn(n).cumsum() * 0.1
+    df = pd.DataFrame({
+        "open": closes, "high": closes + 0.5, "low": closes - 0.5,
+        "close": closes, "volume": np.full(n, 100.0),
+    }, index=idx)
+    result = session_breakout_core(df, session="not_a_real_session")
+    assert "signal" in result.columns


### PR DESCRIPTION
Closes #371

## Summary

- New bidirectional futures strategy `session_breakout`: trades breakouts of prior session (Asian/US open/US close) high/low gated by a volume spike.
- Differs from `breakout` (rolling N-bar high/low + ATR): session-aware levels + mandatory volume confirmation filters low-conviction wicks.
- Registered futures-only; perps picks it up via shared futures registry.
- Wired as bidirectional (`AllowShorts=true`) so short signals aren't silently dropped (#328 contract).

## Test plan

- [x] `uv run pytest shared_strategies/ backtest/tests shared_tools/` — 438 passed
- [x] `go -C scheduler test ./...` — pass
- [x] `gofmt -l` clean
- [x] `test_param_ranges_cover_every_registered_strategy` covers new entry
- [x] `TestGenerateConfig_PerpsAllowShortsWiring` covers `hl-sbo-eth` → `AllowShorts=true`

🤖 Generated with [Claude Code](https://claude.ai/code)