### PR TITLE
fix: expand strategy column width from 12 to 20 chars in Discord summary

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -750,13 +750,13 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 	}
 	sb.WriteString("\n```\n")
 	if showWalletPct {
-		const sep = "--------------------------------------------------------------------------"
-		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Wallet%", "Tf", "Int"))
+		const sep = "------------------------------------------------------------------------------------------"
+		sb.WriteString(fmt.Sprintf("%-20s %10s %10s %10s %7s %8s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Wallet%", "Tf", "Int"))
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {
 			label := bot.id
-			if len(label) > 12 {
-				label = label[:12]
+			if len(label) > 20 {
+				label = label[:20]
 			}
 			valStr := "$ " + fmtComma(bot.value)
 			initStr := "$ " + fmtComma(bot.initialCap)
@@ -766,7 +766,7 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 			if bot.walletPct > 0 {
 				wpStr = fmt.Sprintf("%.1f%%", bot.walletPct)
 			}
-			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s %5s %5s\n", label, initStr, valStr, pnlStr, pctStr, wpStr, bot.timeframe, bot.interval))
+			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %10s %7s %8s %5s %5s\n", label, initStr, valStr, pnlStr, pctStr, wpStr, bot.timeframe, bot.interval))
 		}
 		if includeTotals {
 			sb.WriteString(sep + "\n")
@@ -774,22 +774,22 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 			totInitStr := "$ " + fmtComma(totalInit)
 			totPnlStr := fmtPnl(totalPnl)
 			totPctStr := fmtPnlPct(totalPnlPct)
-			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %8s %5s %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "100.0%", "", ""))
+			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %10s %7s %8s %5s %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "100.0%", "", ""))
 		}
 	} else {
-		const sep = "-----------------------------------------------------------------"
-		sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Tf", "Int"))
+		const sep = "-------------------------------------------------------------------------"
+		sb.WriteString(fmt.Sprintf("%-20s %10s %10s %10s %7s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Tf", "Int"))
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {
 			label := bot.id
-			if len(label) > 12 {
-				label = label[:12]
+			if len(label) > 20 {
+				label = label[:20]
 			}
 			valStr := "$ " + fmtComma(bot.value)
 			initStr := "$ " + fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
 			pctStr := fmtPnlPct(bot.pnlPct)
-			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %5s %5s\n", label, initStr, valStr, pnlStr, pctStr, bot.timeframe, bot.interval))
+			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %10s %7s %5s %5s\n", label, initStr, valStr, pnlStr, pctStr, bot.timeframe, bot.interval))
 		}
 		if includeTotals {
 			sb.WriteString(sep + "\n")
@@ -797,7 +797,7 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 			totInitStr := "$ " + fmtComma(totalInit)
 			totPnlStr := fmtPnl(totalPnl)
 			totPctStr := fmtPnlPct(totalPnlPct)
-			sb.WriteString(fmt.Sprintf("%-12s %10s %10s %10s %7s %5s %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", ""))
+			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %10s %7s %5s %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", ""))
 		}
 	}
 	sb.WriteString("```\n")

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -750,7 +750,7 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 	}
 	sb.WriteString("\n```\n")
 	if showWalletPct {
-		const sep = "------------------------------------------------------------------------------------------"
+		const sep = "----------------------------------------------------------------------------------"
 		sb.WriteString(fmt.Sprintf("%-20s %10s %10s %10s %7s %8s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Wallet%", "Tf", "Int"))
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {


### PR DESCRIPTION
Expands the strategy ID column in Discord category summary tables from 12 to 20 characters, preventing truncation of longer strategy names.

Changes in `scheduler/discord.go`:
- All 6 `%-12s` format specifiers updated to `%-20s`
- Label truncation guards updated from 12 to 20
- Separator line widths adjusted to match

Closes #372

Generated with [Claude Code](https://claude.ai/code)