### PR TITLE
fix: normalize trade direction to LONG/SHORT in notifications

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -869,7 +869,7 @@ func collectPositions(stratID string, ss *StrategyState, prices map[string]float
 		if !pos.OpenedAt.IsZero() {
 			dateStr = fmt.Sprintf(" [%s]", pos.OpenedAt.Format("Jan 02 15:04"))
 		}
-		lines = append(lines, fmt.Sprintf("%s %s %s x%g @ $%s (%s$%s)%s", stratID, pos.Side, sym, pos.Quantity, fmtComma2(pos.AvgCost), sign, fmtComma2(absPnl), dateStr))
+		lines = append(lines, fmt.Sprintf("%s %s %s x%g @ $%s (%s$%s)%s", stratID, strings.ToUpper(pos.Side), sym, pos.Quantity, fmtComma2(pos.AvgCost), sign, fmtComma2(absPnl), dateStr))
 	}
 	for key, opt := range ss.OptionPositions {
 		dateStr := ""
@@ -901,7 +901,7 @@ func FormatTradeDM(sc StrategyConfig, trade Trade, mode string) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%s **%s**\n", icon, header))
 	sb.WriteString(fmt.Sprintf("Strategy: %s (%s %s)\n", sc.ID, platformLabel, typeLabel))
-	sb.WriteString(fmt.Sprintf("%s — %s %.6g @ $%s\n", trade.Symbol, strings.ToUpper(trade.Side), trade.Quantity, fmtComma(trade.Price)))
+	sb.WriteString(fmt.Sprintf("%s — %s %.6g @ $%s\n", trade.Symbol, tradeSideToDirection(trade.Side), trade.Quantity, fmtComma(trade.Price)))
 
 	valueLine := fmt.Sprintf("Value: $%s", fmtComma(trade.Value))
 	if isClose {
@@ -913,6 +913,18 @@ func FormatTradeDM(sc StrategyConfig, trade Trade, mode string) string {
 	sb.WriteString(valueLine)
 
 	return sb.String()
+}
+
+// tradeSideToDirection converts buy/sell trade sides to LONG/SHORT direction labels.
+func tradeSideToDirection(side string) string {
+	switch strings.ToLower(side) {
+	case "buy":
+		return "LONG"
+	case "sell":
+		return "SHORT"
+	default:
+		return strings.ToUpper(side)
+	}
 }
 
 // extractPnL parses the PnL value from a trade Details string.

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -737,6 +737,9 @@ func TestCollectPositions_WithTimestamp(t *testing.T) {
 	if !strings.Contains(lines[0], "[Mar 15 10:30]") {
 		t.Errorf("expected timestamp '[Mar 15 10:30]', got: %s", lines[0])
 	}
+	if !strings.Contains(lines[0], "LONG") {
+		t.Errorf("expected 'LONG' direction label, got: %s", lines[0])
+	}
 }
 
 func TestCollectPositions_WithoutTimestamp(t *testing.T) {
@@ -816,6 +819,9 @@ func TestCollectPositions_EntryPrice(t *testing.T) {
 	if !strings.Contains(lines[0], "(+$2.70)") {
 		t.Errorf("expected PnL '(+$2.70)' in line, got: %s", lines[0])
 	}
+	if !strings.Contains(lines[0], "LONG") {
+		t.Errorf("expected 'LONG' direction label, got: %s", lines[0])
+	}
 }
 
 // TestCollectPositions_ShortEntryPrice verifies entry price + PnL rendering for
@@ -839,6 +845,9 @@ func TestCollectPositions_ShortEntryPrice(t *testing.T) {
 	// Short at 50k, price up to 51k → loss of 0.1 * 1000 = 100.
 	if !strings.Contains(lines[0], "(-$100.00)") {
 		t.Errorf("expected PnL '(-$100.00)' in line, got: %s", lines[0])
+	}
+	if !strings.Contains(lines[0], "SHORT") {
+		t.Errorf("expected 'SHORT' direction label, got: %s", lines[0])
 	}
 }
 
@@ -993,6 +1002,69 @@ func TestSplitCategorySummary_ContinuationTablesInserted(t *testing.T) {
 	}
 	if msgs[2] != conts[1] {
 		t.Errorf("msg[2] should be second continuation table, got: %s", msgs[2])
+	}
+}
+
+func TestFormatTradeDMPlain_OpenTrade(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps"}
+	trade := Trade{
+		Symbol:   "BTC",
+		Side:     "buy",
+		Quantity: 0.15,
+		Price:    67845.00,
+		Value:    10176.75,
+		Details:  "Open long 0.150000 @ $67845.00 (fee $10.18)",
+	}
+	msg := FormatTradeDMPlain(sc, trade, "paper")
+
+	if !strings.Contains(msg, "TRADE EXECUTED") {
+		t.Errorf("expected 'TRADE EXECUTED', got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "hl-sma-btc") {
+		t.Errorf("expected strategy ID, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "LONG") {
+		t.Errorf("expected LONG, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "Mode: paper") {
+		t.Errorf("expected 'Mode: paper', got:\n%s", msg)
+	}
+	if strings.Contains(msg, "PnL") {
+		t.Errorf("open trade should not contain PnL, got:\n%s", msg)
+	}
+	// Plain format: no Discord bold markdown (**).
+	if strings.Contains(msg, "**") {
+		t.Errorf("plain format should not contain Discord markdown '**', got:\n%s", msg)
+	}
+}
+
+func TestFormatTradeDMPlain_CloseTrade(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-rmc-eth", Platform: "hyperliquid", Type: "perps"}
+	trade := Trade{
+		Symbol:   "ETH",
+		Side:     "sell",
+		Quantity: 0.47,
+		Price:    3077.70,
+		Value:    1446.52,
+		Details:  "Close long, PnL: $34.35 (fee $1.23)",
+	}
+	msg := FormatTradeDMPlain(sc, trade, "live")
+
+	if !strings.Contains(msg, "TRADE CLOSED") {
+		t.Errorf("expected 'TRADE CLOSED', got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "SHORT") {
+		t.Errorf("expected SHORT, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "PnL: $34.35") {
+		t.Errorf("expected PnL in close trade, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "Mode: live") {
+		t.Errorf("expected 'Mode: live', got:\n%s", msg)
+	}
+	// Plain format: no Discord bold markdown (**).
+	if strings.Contains(msg, "**") {
+		t.Errorf("plain format should not contain Discord markdown '**', got:\n%s", msg)
 	}
 }
 

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -311,8 +311,8 @@ func TestFormatTradeDM_OpenTrade(t *testing.T) {
 	if !strings.Contains(msg, "hl-sma-btc") {
 		t.Errorf("expected strategy ID, got:\n%s", msg)
 	}
-	if !strings.Contains(msg, "BUY") {
-		t.Errorf("expected BUY, got:\n%s", msg)
+	if !strings.Contains(msg, "LONG") {
+		t.Errorf("expected LONG, got:\n%s", msg)
 	}
 	if !strings.Contains(msg, "Mode: paper") {
 		t.Errorf("expected 'Mode: paper', got:\n%s", msg)
@@ -337,8 +337,8 @@ func TestFormatTradeDM_CloseTrade(t *testing.T) {
 	if !strings.Contains(msg, "TRADE CLOSED") {
 		t.Errorf("expected 'TRADE CLOSED', got:\n%s", msg)
 	}
-	if !strings.Contains(msg, "SELL") {
-		t.Errorf("expected SELL, got:\n%s", msg)
+	if !strings.Contains(msg, "SHORT") {
+		t.Errorf("expected SHORT, got:\n%s", msg)
 	}
 	if !strings.Contains(msg, "PnL: $34.35") {
 		t.Errorf("expected PnL in close trade, got:\n%s", msg)
@@ -411,6 +411,22 @@ func TestFormatTradeDM_EmptyPlatform(t *testing.T) {
 	msg := FormatTradeDM(sc, trade, "paper")
 	if !strings.Contains(msg, "TRADE EXECUTED") {
 		t.Errorf("expected message, got:\n%s", msg)
+	}
+}
+
+func TestTradeSideToDirection(t *testing.T) {
+	cases := []struct{ side, want string }{
+		{"buy", "LONG"},
+		{"BUY", "LONG"},
+		{"sell", "SHORT"},
+		{"SELL", "SHORT"},
+		{"other", "OTHER"},
+	}
+	for _, c := range cases {
+		got := tradeSideToDirection(c.side)
+		if got != c.want {
+			t.Errorf("tradeSideToDirection(%q) = %q, want %q", c.side, got, c.want)
+		}
 	}
 }
 

--- a/scheduler/telegram.go
+++ b/scheduler/telegram.go
@@ -254,7 +254,7 @@ func FormatTradeDMPlain(sc StrategyConfig, trade Trade, mode string) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%s %s\n", icon, header))
 	sb.WriteString(fmt.Sprintf("Strategy: %s (%s %s)\n", sc.ID, platformLabel, typeLabel))
-	sb.WriteString(fmt.Sprintf("%s — %s %.6g @ $%s\n", trade.Symbol, strings.ToUpper(trade.Side), trade.Quantity, fmtComma(trade.Price)))
+	sb.WriteString(fmt.Sprintf("%s — %s %.6g @ $%s\n", trade.Symbol, tradeSideToDirection(trade.Side), trade.Quantity, fmtComma(trade.Price)))
 
 	valueLine := fmt.Sprintf("Value: $%s", fmtComma(trade.Value))
 	if isClose {


### PR DESCRIPTION
Normalize all direction indicators to LONG/SHORT across trade notifications.

**Changes:**
- Added `tradeSideToDirection` helper in `discord.go`: `buy`→`LONG`, `sell`→`SHORT`
- `FormatTradeDM` and `FormatTradeDMPlain` now use this helper instead of `strings.ToUpper(trade.Side)`
- `collectPositions` now renders `pos.Side` as `LONG`/`SHORT` instead of lowercase
- Updated tests and added `TestTradeSideToDirection`

Closes #374

Generated with [Claude Code](https://claude.ai/code)