### PR TITLE
feat: per-channel summary_frequency config (#30)

### DIFF
--- a/scheduler/config.example.json
+++ b/scheduler/config.example.json
@@ -1,5 +1,5 @@
 {
-  "config_version": 7,
+  "config_version": 8,
   "interval_seconds": 300,
   "db_file": "scheduler/state.db",
   "portfolio_risk": {
@@ -73,10 +73,14 @@
       "hyperliquid": "PASTE_DISCORD_USER_OR_CHANNEL_ID",
       "hyperliquid-paper": "PASTE_DISCORD_USER_OR_CHANNEL_ID"
     },
-    "spot_summary_freq": "hourly",
-    "options_summary_freq": "per_check",
     "leaderboard_top_n": 5,
     "leaderboard_channel": ""
+  },
+  "summary_frequency": {
+    "spot": "hourly",
+    "options": "every",
+    "hyperliquid": "every",
+    "topstep": "every"
   },
   "leaderboard_summaries": [
     {

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -100,6 +100,91 @@ type Config struct {
 	Correlation          *CorrelationConfig         `json:"correlation,omitempty"`
 	Platforms            map[string]*PlatformConfig `json:"platforms,omitempty"`
 	LeaderboardSummaries []LeaderboardSummaryConfig `json:"leaderboard_summaries,omitempty"` // #308 — configurable per-channel leaderboards
+	SummaryFrequency     map[string]string          `json:"summary_frequency,omitempty"`     // #30 — per-channel summary cadence; keys match Discord/Telegram channel keys (e.g. "spot", "options", "hyperliquid"). Values: Go duration ("30m", "2h"), alias ("hourly", "every"/"per_check"/"always"), or empty for legacy default (continuous: every cycle; spot: hourly)
+}
+
+// ParseSummaryFrequency converts a summary_frequency value to a duration.
+// Returns -1 to mean "use legacy default", 0 to mean "every cycle", or a
+// positive duration when caller should post every duration. An unrecognized
+// value returns a non-nil error.
+func ParseSummaryFrequency(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return -1, nil
+	}
+	switch strings.ToLower(s) {
+	case "every", "per_check", "always":
+		return 0, nil
+	case "hourly":
+		return time.Hour, nil
+	case "daily":
+		return 24 * time.Hour, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("duration must be non-negative, got %s", s)
+	}
+	return d, nil
+}
+
+// ShouldPostSummary reports whether a channel summary should be posted on the
+// given cycle. hasTrades unconditionally forces a post (users want immediate
+// trade visibility). Otherwise the cadence is derived from freq:
+//   - freq empty → legacy default: continuous channels post every cycle;
+//     non-continuous channels post hourly.
+//   - freq "every"/"per_check"/"always" (or a duration shorter than the
+//     scheduler interval) → every cycle.
+//   - freq parseable as Go duration or alias → post every N cycles where
+//     N = max(1, duration/intervalSeconds).
+//
+// continuous is true for channel types (options/perps/futures) that legacy
+// posted every cycle.
+func ShouldPostSummary(freq string, cycle, intervalSeconds int, continuous, hasTrades bool) bool {
+	if hasTrades {
+		return true
+	}
+	cyclesBetween := summaryCyclesBetween(freq, intervalSeconds, continuous)
+	if cycle < 1 {
+		cycle = 1
+	}
+	return (cycle-1)%cyclesBetween == 0
+}
+
+// summaryCyclesBetween returns N such that a summary posts every N cycles.
+// Always >= 1.
+func summaryCyclesBetween(freq string, intervalSeconds int, continuous bool) int {
+	dur, err := ParseSummaryFrequency(freq)
+	if err != nil {
+		dur = -1
+	}
+	switch {
+	case dur < 0: // legacy default
+		if continuous {
+			return 1
+		}
+		if intervalSeconds > 0 {
+			n := 3600 / intervalSeconds
+			if n < 1 {
+				n = 1
+			}
+			return n
+		}
+		return 12
+	case dur == 0:
+		return 1
+	default:
+		if intervalSeconds <= 0 {
+			return 1
+		}
+		n := int(dur.Seconds()) / intervalSeconds
+		if n < 1 {
+			n = 1
+		}
+		return n
+	}
 }
 
 // ThetaHarvestConfig controls early exit on sold options.
@@ -555,6 +640,19 @@ func ValidateConfig(cfg *Config) error {
 	}
 	validateDMChannelsMap(cfg.Discord.DMChannels, "discord", knownPlatforms, &errs)
 	validateDMChannelsMap(cfg.Telegram.DMChannels, "telegram", knownPlatforms, &errs)
+
+	// Validate summary_frequency values (#30). Keys are free-form channel
+	// keys (matching DiscordConfig.Channels), so we don't validate them
+	// against a fixed allow-list — only the cadence values.
+	for k, v := range cfg.SummaryFrequency {
+		if strings.TrimSpace(k) == "" {
+			errs = append(errs, "summary_frequency: empty key")
+			continue
+		}
+		if _, err := ParseSummaryFrequency(v); err != nil {
+			errs = append(errs, fmt.Sprintf("summary_frequency[%q]: %v", k, err))
+		}
+	}
 
 	if len(errs) > 0 {
 		return fmt.Errorf("config validation errors:\n  %s", strings.Join(errs, "\n  "))

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -10,7 +10,7 @@ import (
 
 // CurrentConfigVersion is the version embedded in newly generated configs.
 // When the binary starts and cfg.ConfigVersion < CurrentConfigVersion, migration runs.
-const CurrentConfigVersion = 7
+const CurrentConfigVersion = 8
 
 // ConfigField describes a config field introduced in a specific version.
 type ConfigField struct {
@@ -59,6 +59,19 @@ var v7DeprecatedFields = []string{
 	"telegram.dm_paper_trades",
 	"telegram.dm_live_trades",
 }
+
+// v8DeprecatedFields lists fields removed in v8 (replaced by top-level
+// summary_frequency map, #30). The old spot_summary_freq / options_summary_freq
+// fields under discord were never wired to the main loop.
+var v8DeprecatedFields = []string{
+	"discord.spot_summary_freq",
+	"discord.options_summary_freq",
+}
+
+const v8DeprecationNotice = "**Note:** `discord.spot_summary_freq` and `discord.options_summary_freq` have been replaced by " +
+	"a top-level `summary_frequency` map keyed by channel (e.g. `\"spot\": \"hourly\"`, `\"options\": \"every\"`). " +
+	"Values may be `\"every\"`/`\"per_check\"`/`\"always\"` (every cycle), `\"hourly\"` (1h), `\"daily\"` (24h), or any Go duration like `\"30m\"`. " +
+	"Empty/missing falls back to legacy defaults (options/perps/futures every cycle, spot hourly). See issue #30."
 
 const v7DeprecationNotice = "**Note:** `dm_paper_trades` and `dm_live_trades` have been replaced by a `dm_channels` map. " +
 	"Paper trades use `dm_channels[\"<platform>-paper\"]`; live trades use `dm_channels[\"<platform>\"]`. " +
@@ -112,6 +125,16 @@ func MigrateConfig(configPath string, fieldValues map[string]string, cfg *Config
 	if oldVer < 7 {
 		translateV7DMChannels(raw, cfg)
 		for _, path := range v7DeprecatedFields {
+			removeNestedField(raw, path)
+		}
+	}
+
+	// v8: remove dead discord.spot_summary_freq / options_summary_freq (#30).
+	// No translation — the old fields were never wired to the main loop, so
+	// silently dropping them changes no runtime behavior. Users opting in to
+	// per-channel cadence populate the top-level summary_frequency map.
+	if oldVer < 8 {
+		for _, path := range v8DeprecatedFields {
 			removeNestedField(raw, path)
 		}
 	}
@@ -279,6 +302,14 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 				fmt.Printf("[migration] %s\n", v7DeprecationNotice)
 			}
 		}
+		// v8: notify about summary_frequency migration (#30).
+		if cfg.ConfigVersion < 8 {
+			if notifier != nil && notifier.HasOwner() {
+				notifier.SendOwnerDM(v8DeprecationNotice)
+			} else {
+				fmt.Printf("[migration] %s\n", v8DeprecationNotice)
+			}
+		}
 		return
 	}
 
@@ -300,6 +331,9 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 		}
 		if cfg.ConfigVersion < 7 {
 			fmt.Printf("[migration] %s\n", v7DeprecationNotice)
+		}
+		if cfg.ConfigVersion < 8 {
+			fmt.Printf("[migration] %s\n", v8DeprecationNotice)
 		}
 		return
 	}
@@ -337,5 +371,9 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 	// v7: notify about dm_channels migration (#248).
 	if cfg.ConfigVersion < 7 {
 		notifier.SendOwnerDM(v7DeprecationNotice)
+	}
+	// v8: notify about summary_frequency migration (#30).
+	if cfg.ConfigVersion < 8 {
+		notifier.SendOwnerDM(v8DeprecationNotice)
 	}
 }

--- a/scheduler/config_migration_test.go
+++ b/scheduler/config_migration_test.go
@@ -499,3 +499,79 @@ func TestMigrateConfigV7RemovesDMBooleansWhenUnset(t *testing.T) {
 		t.Error("dm_channels should not be added when both dm booleans are false")
 	}
 }
+
+// TestMigrateConfigV8RemovesDeadSummaryFreqFields verifies that the dead
+// discord.spot_summary_freq / discord.options_summary_freq fields (replaced by
+// the top-level summary_frequency map in #30) are stripped when upgrading
+// from v7.
+func TestMigrateConfigV8RemovesDeadSummaryFreqFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	original := map[string]interface{}{
+		"config_version": 7,
+		"discord": map[string]interface{}{
+			"enabled":              true,
+			"spot_summary_freq":    "hourly",
+			"options_summary_freq": "per_check",
+		},
+	}
+	data, err := json.MarshalIndent(original, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateConfig(path, nil, nil); err != nil {
+		t.Fatalf("MigrateConfig failed: %v", err)
+	}
+	result, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var updated map[string]interface{}
+	if err := json.Unmarshal(result, &updated); err != nil {
+		t.Fatal(err)
+	}
+	if v := int(updated["config_version"].(float64)); v != CurrentConfigVersion {
+		t.Errorf("config_version = %d, want %d", v, CurrentConfigVersion)
+	}
+	discord := updated["discord"].(map[string]interface{})
+	if _, ok := discord["spot_summary_freq"]; ok {
+		t.Error("discord.spot_summary_freq should have been removed")
+	}
+	if _, ok := discord["options_summary_freq"]; ok {
+		t.Error("discord.options_summary_freq should have been removed")
+	}
+}
+
+// TestMigrateConfigV8PreservesFieldsAtCurrentVersion verifies the version
+// guard — a config already at the current version must not have the v8
+// deprecated fields stripped if a user intentionally reintroduced them.
+func TestMigrateConfigV8PreservesFieldsAtCurrentVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	original := map[string]interface{}{
+		"config_version": CurrentConfigVersion,
+		"discord": map[string]interface{}{
+			"spot_summary_freq": "hourly",
+		},
+	}
+	data, err := json.MarshalIndent(original, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateConfig(path, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	result, _ := os.ReadFile(path)
+	var updated map[string]interface{}
+	_ = json.Unmarshal(result, &updated)
+	discord := updated["discord"].(map[string]interface{})
+	if _, ok := discord["spot_summary_freq"]; !ok {
+		t.Error("discord.spot_summary_freq should NOT be removed when already at CurrentConfigVersion")
+	}
+}

--- a/scheduler/config_migration_test.go
+++ b/scheduler/config_migration_test.go
@@ -567,9 +567,14 @@ func TestMigrateConfigV8PreservesFieldsAtCurrentVersion(t *testing.T) {
 	if err := MigrateConfig(path, nil, nil); err != nil {
 		t.Fatal(err)
 	}
-	result, _ := os.ReadFile(path)
+	result, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
 	var updated map[string]interface{}
-	_ = json.Unmarshal(result, &updated)
+	if err := json.Unmarshal(result, &updated); err != nil {
+		t.Fatal(err)
+	}
 	discord := updated["discord"].(map[string]interface{})
 	if _, ok := discord["spot_summary_freq"]; !ok {
 		t.Error("discord.spot_summary_freq should NOT be removed when already at CurrentConfigVersion")

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1204,9 +1204,13 @@ func main() {
 					continue
 				}
 				chTrades := channelTrades[chKey]
-				// Options/perps/futures: post every run. Spot: hourly or on trade.
-				// (cycle-1)%12==0 fires at cycles 1,13,25... so first summary posts on startup.
-				if !isOptionsType(chStrats) && !isFuturesType(chStrats) && !isPerpsType(chStrats) && chTrades == 0 && (cycle-1)%12 != 0 {
+				// Per-channel summary cadence (#30). Legacy default: continuous
+				// channel types (options/perps/futures) post every cycle; spot
+				// posts hourly. Override per channel via cfg.SummaryFrequency.
+				// Trades always force a post so operators see executions
+				// immediately regardless of cadence.
+				continuous := isOptionsType(chStrats) || isFuturesType(chStrats) || isPerpsType(chStrats)
+				if !ShouldPostSummary(cfg.SummaryFrequency[chKey], cycle, cfg.IntervalSeconds, continuous, chTrades > 0) {
 					continue
 				}
 				assetGroups, assetKeys := groupByAsset(chStrats)

--- a/scheduler/summary_frequency_test.go
+++ b/scheduler/summary_frequency_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseSummaryFrequency(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"empty means legacy default", "", -1, false},
+		{"whitespace means legacy default", "   ", -1, false},
+		{"every alias", "every", 0, false},
+		{"per_check alias", "per_check", 0, false},
+		{"always alias", "always", 0, false},
+		{"case-insensitive alias", "Every", 0, false},
+		{"hourly alias", "hourly", time.Hour, false},
+		{"daily alias", "daily", 24 * time.Hour, false},
+		{"go duration minutes", "30m", 30 * time.Minute, false},
+		{"go duration hours", "2h", 2 * time.Hour, false},
+		{"go duration combined", "1h30m", 90 * time.Minute, false},
+		{"invalid string", "sometimes", 0, true},
+		{"negative duration rejected", "-5m", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSummaryFrequency(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil (value=%v)", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseSummaryFrequency(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldPostSummary_TradesForcePost(t *testing.T) {
+	// Trades always post, regardless of cadence setting or cycle position.
+	if !ShouldPostSummary("hourly", 5, 300, false, true) {
+		t.Error("trades should force a post even mid-window")
+	}
+	if !ShouldPostSummary("daily", 2, 300, false, true) {
+		t.Error("trades should force a post even with daily cadence")
+	}
+}
+
+func TestShouldPostSummary_LegacyContinuousPostsEveryCycle(t *testing.T) {
+	// Empty freq + continuous (options/perps/futures) = every cycle.
+	for c := 1; c <= 5; c++ {
+		if !ShouldPostSummary("", c, 300, true, false) {
+			t.Errorf("continuous legacy default should post every cycle; cycle %d did not", c)
+		}
+	}
+}
+
+func TestShouldPostSummary_LegacySpotPostsHourly(t *testing.T) {
+	// Empty freq + non-continuous + interval=300s (5m) → 12 cycles between posts.
+	// Cycles 1, 13, 25 post; 2..12 and 14..24 don't.
+	cases := []struct {
+		cycle int
+		want  bool
+	}{
+		{1, true}, {2, false}, {6, false}, {12, false}, {13, true}, {24, false}, {25, true},
+	}
+	for _, tc := range cases {
+		got := ShouldPostSummary("", tc.cycle, 300, false, false)
+		if got != tc.want {
+			t.Errorf("spot legacy cycle %d: got %v, want %v", tc.cycle, got, tc.want)
+		}
+	}
+}
+
+func TestShouldPostSummary_EveryAliasOverridesSpotDefault(t *testing.T) {
+	// User sets spot to "every" — should post every cycle.
+	for c := 1; c <= 10; c++ {
+		if !ShouldPostSummary("every", c, 300, false, false) {
+			t.Errorf(`freq="every" should post every cycle; cycle %d did not`, c)
+		}
+	}
+}
+
+func TestShouldPostSummary_HourlyAliasThrottlesContinuous(t *testing.T) {
+	// User sets options (continuous) to "hourly" — should throttle to 1/hour.
+	// interval=300s → 12 cycles between posts.
+	if !ShouldPostSummary("hourly", 1, 300, true, false) {
+		t.Error("cycle 1 should post")
+	}
+	if ShouldPostSummary("hourly", 2, 300, true, false) {
+		t.Error("cycle 2 should be throttled")
+	}
+	if !ShouldPostSummary("hourly", 13, 300, true, false) {
+		t.Error("cycle 13 should post (12 cycles after cycle 1)")
+	}
+}
+
+func TestShouldPostSummary_CustomDuration(t *testing.T) {
+	// 30m with 5m interval → every 6 cycles.
+	want := map[int]bool{1: true, 2: false, 6: false, 7: true, 12: false, 13: true}
+	for c, expect := range want {
+		got := ShouldPostSummary("30m", c, 300, false, false)
+		if got != expect {
+			t.Errorf("30m cadence cycle %d: got %v, want %v", c, got, expect)
+		}
+	}
+}
+
+func TestShouldPostSummary_DurationShorterThanInterval(t *testing.T) {
+	// 1m cadence with 5m interval — clamp to every cycle.
+	for c := 1; c <= 5; c++ {
+		if !ShouldPostSummary("1m", c, 300, false, false) {
+			t.Errorf("sub-interval cadence should clamp to every cycle; cycle %d did not", c)
+		}
+	}
+}
+
+func TestShouldPostSummary_InvalidValueFallsBackToLegacy(t *testing.T) {
+	// Invalid freq should fall back to the legacy default rather than crashing.
+	// Continuous legacy = every cycle.
+	if !ShouldPostSummary("nonsense", 3, 300, true, false) {
+		t.Error("invalid freq + continuous should fall back to legacy every-cycle")
+	}
+	// Non-continuous legacy = hourly (12 cycles at 300s interval).
+	if ShouldPostSummary("nonsense", 2, 300, false, false) {
+		t.Error("invalid freq + spot should fall back to legacy hourly (cycle 2 suppressed)")
+	}
+}
+
+func TestValidateConfig_SummaryFrequency(t *testing.T) {
+	base := &Config{
+		IntervalSeconds: 60,
+		Strategies: []StrategyConfig{
+			{ID: "s1", Type: "spot", Platform: "binanceus", Capital: 100, MaxDrawdownPct: 10, Script: "x.py"},
+		},
+	}
+
+	t.Run("valid values pass", func(t *testing.T) {
+		cfg := *base
+		cfg.SummaryFrequency = map[string]string{
+			"spot":        "hourly",
+			"options":     "every",
+			"hyperliquid": "30m",
+		}
+		if err := ValidateConfig(&cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid value rejected", func(t *testing.T) {
+		cfg := *base
+		cfg.SummaryFrequency = map[string]string{"spot": "sometimes"}
+		err := ValidateConfig(&cfg)
+		if err == nil {
+			t.Fatal("expected validation error for invalid value")
+		}
+		if !strings.Contains(err.Error(), "summary_frequency") {
+			t.Errorf("expected error to mention summary_frequency, got: %v", err)
+		}
+	})
+
+	t.Run("empty key rejected", func(t *testing.T) {
+		cfg := *base
+		cfg.SummaryFrequency = map[string]string{"": "hourly"}
+		err := ValidateConfig(&cfg)
+		if err == nil {
+			t.Fatal("expected validation error for empty key")
+		}
+	})
+}


### PR DESCRIPTION
Replaces the hardcoded summary cadence in the scheduler main loop with a top-level `summary_frequency` map keyed by channel. Values accept Go durations (`30m`, `2h`), aliases (`every`, `per_check`, `always`, `hourly`, `daily`), or empty for legacy defaults (continuous channels every cycle; spot hourly). Trades still force a post so operators see executions immediately.

The dead `discord.spot_summary_freq` / `discord.options_summary_freq` fields (which the main loop never read) are stripped during v8 config migration with an owner DM notice.

Closes #30

Generated with [Claude Code](https://claude.ai/code)