### PR TITLE
feat(init): prompt for risk settings during live trading setup

### DIFF
--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -1047,8 +1047,16 @@ func runInit(args []string) int {
 	if anyLive {
 		fmt.Println("\n--- Risk settings (live trading) ---")
 		fmt.Println("These guard real capital. Press Enter to accept defaults.")
-		perStrategyDD := p.Float("Per-strategy max drawdown % (applied to all strategies)", 20)
+		// Default 5 matches the existing per-platform default for every live-capable
+		// platform (spot/perps/robinhood/luno/futures/okx), so pressing Enter is a
+		// no-op for those. Options default is 10, so Enter tightens options to 5 —
+		// intentional: if real capital is at stake on any platform, apply the
+		// tighter bound uniformly. Operator can type a different value to widen.
+		perStrategyDD := p.FloatRange("Per-strategy max drawdown % (applied to all strategies)", 5, 0, 100)
 		if perStrategyDD > 0 {
+			// Override applies to every strategy type including spot/options/luno
+			// even when those are paper-mode: the operator has asked for a uniform
+			// per-strategy DD across the whole account.
 			spotDrawdown = perStrategyDD
 			optionsDrawdown = perStrategyDD
 			perpsDrawdown = perStrategyDD
@@ -1057,8 +1065,11 @@ func runInit(args []string) int {
 			futuresDrawdown = perStrategyDD
 			okxDrawdown = perStrategyDD
 		}
-		portfolioMaxDD = p.Float("Portfolio kill-switch max drawdown %", 25)
-		portfolioWarnPct = p.Float("Portfolio warn threshold % (of kill switch)", 80)
+		// Both portfolio fields are validated (0, 100] at config load time
+		// (config.go:492,498); re-prompt on out-of-range so the wizard can't
+		// produce a file that fails validateConfig on the next startup.
+		portfolioMaxDD = p.FloatRange("Portfolio kill-switch max drawdown %", 25, 0, 100)
+		portfolioWarnPct = p.FloatRange("Portfolio warn threshold % (of kill switch)", 80, 0, 100)
 	}
 
 	// Notifications default to disabled.

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -1053,18 +1053,16 @@ func runInit(args []string) int {
 		// intentional: if real capital is at stake on any platform, apply the
 		// tighter bound uniformly. Operator can type a different value to widen.
 		perStrategyDD := p.FloatRange("Per-strategy max drawdown % (applied to all strategies)", 5, 0, 100)
-		if perStrategyDD > 0 {
-			// Override applies to every strategy type including spot/options/luno
-			// even when those are paper-mode: the operator has asked for a uniform
-			// per-strategy DD across the whole account.
-			spotDrawdown = perStrategyDD
-			optionsDrawdown = perStrategyDD
-			perpsDrawdown = perStrategyDD
-			robinhoodDrawdown = perStrategyDD
-			lunoDrawdown = perStrategyDD
-			futuresDrawdown = perStrategyDD
-			okxDrawdown = perStrategyDD
-		}
+		// Override applies to every strategy type including spot/options/luno
+		// even when those are paper-mode: the operator has asked for a uniform
+		// per-strategy DD across the whole account.
+		spotDrawdown = perStrategyDD
+		optionsDrawdown = perStrategyDD
+		perpsDrawdown = perStrategyDD
+		robinhoodDrawdown = perStrategyDD
+		lunoDrawdown = perStrategyDD
+		futuresDrawdown = perStrategyDD
+		okxDrawdown = perStrategyDD
 		// Both portfolio fields are validated (0, 100] at config load time
 		// (config.go:492,498); re-prompt on out-of-range so the wizard can't
 		// produce a file that fails validateConfig on the next startup.

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -277,27 +277,40 @@ type InitOptions struct {
 	OKXDrawdown             float64
 	CapitalPct              float64 `json:"capitalPct,omitempty"` // 0-1; global capital_pct applied to all strategies
 	HTFFilter               bool    // higher-timeframe trend filter for all strategies
-	DiscordEnabled          bool
-	DiscordOwnerID          string            // Discord user ID for DM features (upgrade prompts, config migration)
-	SpotChannelID           string            // deprecated: use ChannelMap
-	OptionsChannelID        string            // deprecated: use ChannelMap
-	ChannelMap              map[string]string // keyed by platform/type ("spot", "hyperliquid", "deribit", etc.)
-	TelegramEnabled         bool
-	TelegramOwnerChatID     string            // Telegram chat ID for owner DMs
-	TelegramChannelMap      map[string]string // keyed by platform/type ("spot", "hyperliquid", etc.)
-	AutoUpdate              string            // "off", "daily", "heartbeat" (default: "off")
+	// Risk settings — prompted explicitly during live-mode setup (#85) so operators
+	// don't hit the post-launch migration DM for portfolio_risk fields.
+	PortfolioMaxDrawdownPct   float64 `json:"portfolioMaxDrawdownPct,omitempty"`   // kill switch threshold; 0 → default 25
+	PortfolioWarnThresholdPct float64 `json:"portfolioWarnThresholdPct,omitempty"` // % of kill switch that triggers warnings; 0 → default 80
+	DiscordEnabled            bool
+	DiscordOwnerID            string            // Discord user ID for DM features (upgrade prompts, config migration)
+	SpotChannelID             string            // deprecated: use ChannelMap
+	OptionsChannelID          string            // deprecated: use ChannelMap
+	ChannelMap                map[string]string // keyed by platform/type ("spot", "hyperliquid", "deribit", etc.)
+	TelegramEnabled           bool
+	TelegramOwnerChatID       string            // Telegram chat ID for owner DMs
+	TelegramChannelMap        map[string]string // keyed by platform/type ("spot", "hyperliquid", etc.)
+	AutoUpdate                string            // "off", "daily", "heartbeat" (default: "off")
 }
 
 // generateConfig builds a Config from InitOptions. Pure function, no I/O.
 func generateConfig(opts InitOptions) *Config {
+	portfolioMaxDD := opts.PortfolioMaxDrawdownPct
+	if portfolioMaxDD <= 0 {
+		portfolioMaxDD = 25
+	}
+	portfolioWarn := opts.PortfolioWarnThresholdPct
+	if portfolioWarn <= 0 {
+		portfolioWarn = 80
+	}
 	cfg := &Config{
 		ConfigVersion:   CurrentConfigVersion,
 		IntervalSeconds: 3600,
 		LogDir:          "logs",
 		DBFile:          "scheduler/state.db",
 		PortfolioRisk: &PortfolioRiskConfig{
-			MaxDrawdownPct: 25,
-			MaxNotionalUSD: 0,
+			MaxDrawdownPct:   portfolioMaxDD,
+			MaxNotionalUSD:   0,
+			WarnThresholdPct: portfolioWarn,
 		},
 		Discord: DiscordConfig{
 			Enabled:  opts.DiscordEnabled,
@@ -1021,6 +1034,33 @@ func runInit(args []string) int {
 	okxCapital := 1000.0
 	okxDrawdown := 5.0
 
+	// Portfolio risk defaults (#85); overridden below if any live mode is enabled.
+	portfolioMaxDD := 25.0
+	portfolioWarnPct := 80.0
+
+	// #85: Live trading setup must prompt for risk parameters explicitly so
+	// operators don't hit the post-launch DM migration wizard. These fields
+	// gate the portfolio kill switch (portfolio_risk.max_drawdown_pct) and
+	// early-warning alert (portfolio_risk.warn_threshold_pct) that protect
+	// the whole account, so we ask up-front when real capital is at stake.
+	anyLive := perpsMode == "live" || futuresMode == "live" || robinhoodMode == "live" || okxMode == "live"
+	if anyLive {
+		fmt.Println("\n--- Risk settings (live trading) ---")
+		fmt.Println("These guard real capital. Press Enter to accept defaults.")
+		perStrategyDD := p.Float("Per-strategy max drawdown % (applied to all strategies)", 20)
+		if perStrategyDD > 0 {
+			spotDrawdown = perStrategyDD
+			optionsDrawdown = perStrategyDD
+			perpsDrawdown = perStrategyDD
+			robinhoodDrawdown = perStrategyDD
+			lunoDrawdown = perStrategyDD
+			futuresDrawdown = perStrategyDD
+			okxDrawdown = perStrategyDD
+		}
+		portfolioMaxDD = p.Float("Portfolio kill-switch max drawdown %", 25)
+		portfolioWarnPct = p.Float("Portfolio warn threshold % (of kill switch)", 80)
+	}
+
 	// Notifications default to disabled.
 	discordEnabled := false
 	channelMap := make(map[string]string)
@@ -1078,55 +1118,57 @@ func runInit(args []string) int {
 	}
 
 	opts := InitOptions{
-		OutputPath:              outputPath,
-		Assets:                  selectedAssets,
-		EnableSpot:              enableSpot,
-		EnableOptions:           enableOptions,
-		EnablePerps:             enablePerps,
-		OptionPlatforms:         optionPlatforms,
-		PerpsMode:               perpsMode,
-		SpotStrategies:          selectedSpotStrats,
-		IncludePairs:            includePairs,
-		OptStrategies:           selectedOptStrats,
-		PerpsStrategies:         perpsStratIDs,
-		SpotCapital:             spotCapital,
-		OptionsCapital:          optionsCapital,
-		PerpsCapital:            perpsCapital,
-		PerpsLeverage:           perpsLeverage,
-		SpotDrawdown:            spotDrawdown,
-		OptionsDrawdown:         optionsDrawdown,
-		PerpsDrawdown:           perpsDrawdown,
-		RobinhoodOptionsSymbols: robinhoodOptionsSymbols,
-		EnableRobinhood:         enableRobinhood,
-		RobinhoodMode:           robinhoodMode,
-		RobinhoodStrategies:     robinhoodStratIDs,
-		RobinhoodCapital:        robinhoodCapital,
-		RobinhoodDrawdown:       robinhoodDrawdown,
-		EnableLuno:              enableLuno,
-		LunoStrategies:          lunoStratIDs,
-		LunoCapital:             lunoCapital,
-		LunoDrawdown:            lunoDrawdown,
-		EnableFutures:           enableFutures,
-		FuturesMode:             futuresMode,
-		FuturesStrategies:       futuresStratIDs,
-		FuturesSymbols:          futuresSymbols,
-		FuturesCapital:          futuresCapital,
-		FuturesDrawdown:         futuresDrawdown,
-		FuturesFeePerContract:   futuresFeePerContract,
-		EnableOKX:               enableOKX,
-		OKXMode:                 okxMode,
-		OKXSpotStrategies:       okxSpotStratIDs,
-		OKXPerpsStrategies:      okxPerpsStratIDs,
-		OKXCapital:              okxCapital,
-		OKXDrawdown:             okxDrawdown,
-		HTFFilter:               htfFilter,
-		DiscordEnabled:          discordEnabled,
-		DiscordOwnerID:          discordOwnerID,
-		ChannelMap:              channelMap,
-		TelegramEnabled:         telegramEnabled,
-		TelegramOwnerChatID:     telegramOwnerChatID,
-		TelegramChannelMap:      telegramChannelMap,
-		AutoUpdate:              autoUpdate,
+		OutputPath:                outputPath,
+		Assets:                    selectedAssets,
+		EnableSpot:                enableSpot,
+		EnableOptions:             enableOptions,
+		EnablePerps:               enablePerps,
+		OptionPlatforms:           optionPlatforms,
+		PerpsMode:                 perpsMode,
+		SpotStrategies:            selectedSpotStrats,
+		IncludePairs:              includePairs,
+		OptStrategies:             selectedOptStrats,
+		PerpsStrategies:           perpsStratIDs,
+		SpotCapital:               spotCapital,
+		OptionsCapital:            optionsCapital,
+		PerpsCapital:              perpsCapital,
+		PerpsLeverage:             perpsLeverage,
+		SpotDrawdown:              spotDrawdown,
+		OptionsDrawdown:           optionsDrawdown,
+		PerpsDrawdown:             perpsDrawdown,
+		RobinhoodOptionsSymbols:   robinhoodOptionsSymbols,
+		EnableRobinhood:           enableRobinhood,
+		RobinhoodMode:             robinhoodMode,
+		RobinhoodStrategies:       robinhoodStratIDs,
+		RobinhoodCapital:          robinhoodCapital,
+		RobinhoodDrawdown:         robinhoodDrawdown,
+		EnableLuno:                enableLuno,
+		LunoStrategies:            lunoStratIDs,
+		LunoCapital:               lunoCapital,
+		LunoDrawdown:              lunoDrawdown,
+		EnableFutures:             enableFutures,
+		FuturesMode:               futuresMode,
+		FuturesStrategies:         futuresStratIDs,
+		FuturesSymbols:            futuresSymbols,
+		FuturesCapital:            futuresCapital,
+		FuturesDrawdown:           futuresDrawdown,
+		FuturesFeePerContract:     futuresFeePerContract,
+		EnableOKX:                 enableOKX,
+		OKXMode:                   okxMode,
+		OKXSpotStrategies:         okxSpotStratIDs,
+		OKXPerpsStrategies:        okxPerpsStratIDs,
+		OKXCapital:                okxCapital,
+		OKXDrawdown:               okxDrawdown,
+		HTFFilter:                 htfFilter,
+		PortfolioMaxDrawdownPct:   portfolioMaxDD,
+		PortfolioWarnThresholdPct: portfolioWarnPct,
+		DiscordEnabled:            discordEnabled,
+		DiscordOwnerID:            discordOwnerID,
+		ChannelMap:                channelMap,
+		TelegramEnabled:           telegramEnabled,
+		TelegramOwnerChatID:       telegramOwnerChatID,
+		TelegramChannelMap:        telegramChannelMap,
+		AutoUpdate:                autoUpdate,
 	}
 
 	cfg := generateConfig(opts)

--- a/scheduler/init_test.go
+++ b/scheduler/init_test.go
@@ -409,6 +409,60 @@ func TestGenerateConfig_PortfolioRiskDefaults(t *testing.T) {
 	if cfg.PortfolioRisk.MaxDrawdownPct != 25 {
 		t.Errorf("expected MaxDrawdownPct=25, got %.0f", cfg.PortfolioRisk.MaxDrawdownPct)
 	}
+	if cfg.PortfolioRisk.WarnThresholdPct != 80 {
+		t.Errorf("expected WarnThresholdPct=80, got %.0f", cfg.PortfolioRisk.WarnThresholdPct)
+	}
+}
+
+// #85: live-setup risk prompts feed into PortfolioRisk.* via InitOptions.
+func TestGenerateConfig_PortfolioRiskOverride(t *testing.T) {
+	opts := baseOpts()
+	opts.PortfolioMaxDrawdownPct = 15
+	opts.PortfolioWarnThresholdPct = 70
+
+	cfg := generateConfig(opts)
+
+	if cfg.PortfolioRisk == nil {
+		t.Fatal("expected PortfolioRisk to be set")
+	}
+	if cfg.PortfolioRisk.MaxDrawdownPct != 15 {
+		t.Errorf("expected MaxDrawdownPct=15, got %.0f", cfg.PortfolioRisk.MaxDrawdownPct)
+	}
+	if cfg.PortfolioRisk.WarnThresholdPct != 70 {
+		t.Errorf("expected WarnThresholdPct=70, got %.0f", cfg.PortfolioRisk.WarnThresholdPct)
+	}
+}
+
+// Zero values must not overwrite the safe defaults — the interactive wizard
+// only prompts when a live mode is enabled, so JSON configs that omit the
+// fields should still produce a valid portfolio_risk block.
+func TestGenerateConfig_PortfolioRiskZeroKeepsDefaults(t *testing.T) {
+	opts := baseOpts()
+	opts.PortfolioMaxDrawdownPct = 0
+	opts.PortfolioWarnThresholdPct = 0
+
+	cfg := generateConfig(opts)
+
+	if cfg.PortfolioRisk.MaxDrawdownPct != 25 || cfg.PortfolioRisk.WarnThresholdPct != 80 {
+		t.Errorf("expected defaults 25/80, got %.0f/%.0f",
+			cfg.PortfolioRisk.MaxDrawdownPct, cfg.PortfolioRisk.WarnThresholdPct)
+	}
+}
+
+// JSON-mode consumers (OpenClaw, scripted setup) pass risk values under the
+// camelCase tags; verify the unmarshal path wires them into generateConfig.
+func TestInitOptions_PortfolioRiskJSONTags(t *testing.T) {
+	blob := `{"portfolioMaxDrawdownPct": 18, "portfolioWarnThresholdPct": 65}`
+	var opts InitOptions
+	if err := json.Unmarshal([]byte(blob), &opts); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if opts.PortfolioMaxDrawdownPct != 18 {
+		t.Errorf("expected 18, got %.0f", opts.PortfolioMaxDrawdownPct)
+	}
+	if opts.PortfolioWarnThresholdPct != 65 {
+		t.Errorf("expected 65, got %.0f", opts.PortfolioWarnThresholdPct)
+	}
 }
 
 func TestGenerateConfig_DiscordEnabled(t *testing.T) {

--- a/scheduler/prompt.go
+++ b/scheduler/prompt.go
@@ -163,6 +163,33 @@ func (p *Prompter) Float(prompt string, defaultVal float64) float64 {
 	return v
 }
 
+// FloatRange prompts for a float64 value in the half-open range (min, max].
+// Re-prompts on out-of-range input so the wizard can only emit a value that
+// passes downstream validation. Empty input returns defaultVal without
+// re-prompting (the caller is responsible for picking a default inside range).
+func (p *Prompter) FloatRange(prompt string, defaultVal, min, max float64) float64 {
+	for {
+		fmt.Fprintf(p.out, "%s [%.0f]: ", prompt, defaultVal)
+		if !p.scanner.Scan() {
+			return defaultVal
+		}
+		input := strings.TrimSpace(p.scanner.Text())
+		if input == "" {
+			return defaultVal
+		}
+		v, err := strconv.ParseFloat(input, 64)
+		if err != nil {
+			fmt.Fprintln(p.out, "  Invalid number, try again.")
+			continue
+		}
+		if v <= min || v > max {
+			fmt.Fprintf(p.out, "  Must be in (%.0f, %.0f], try again.\n", min, max)
+			continue
+		}
+		return v
+	}
+}
+
 func multiSelectDefault(options []string, defaultAll bool) []int {
 	if defaultAll {
 		all := make([]int, len(options))

--- a/scheduler/prompt_test.go
+++ b/scheduler/prompt_test.go
@@ -156,6 +156,35 @@ func TestPrompterFloat(t *testing.T) {
 	}
 }
 
+func TestPrompterFloatRange(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		defaultVal float64
+		min, max   float64
+		want       float64
+	}{
+		{"in range", "50\n", 25, 0, 100, 50},
+		{"upper bound ok", "100\n", 25, 0, 100, 100},
+		{"empty uses default", "\n", 25, 0, 100, 25},
+		{"eof uses default", "", 25, 0, 100, 25},
+		{"zero rejected then valid", "0\n40\n", 25, 0, 100, 40},
+		{"over-max rejected then valid", "150\n80\n", 25, 0, 100, 80},
+		{"negative rejected then valid", "-5\n30\n", 25, 0, 100, 30},
+		{"invalid rejected then valid", "abc\n20\n", 25, 0, 100, 20},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, _ := newTestPrompter(tc.input)
+			got := p.FloatRange("Enter pct:", tc.defaultVal, tc.min, tc.max)
+			if got != tc.want {
+				t.Errorf("FloatRange() = %g, want %g", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestMultiSelectDefault(t *testing.T) {
 	options := []string{"A", "B", "C"}
 


### PR DESCRIPTION
Closes #85

## Summary
When the interactive `go-trader init` wizard detects that any live mode (perps, futures, Robinhood, OKX) was selected, it now explicitly prompts for:
- Per-strategy max drawdown % (default 20)
- Portfolio kill-switch max drawdown % (default 25)
- Portfolio warn threshold % (default 80)

Values flow through new `InitOptions.PortfolioMaxDrawdownPct` / `PortfolioWarnThresholdPct` fields into `PortfolioRisk`, so the config is complete at write time and the post-launch config-migration DM does not fire for these fields.

## Test plan
- [x] `go test ./...` passes
- [x] New tests cover override, zero-keeps-defaults, and JSON tag unmarshal paths
- [ ] Manual smoke of interactive wizard with `perps + live` confirms prompts appear and are written to `portfolio_risk`

Generated with [Claude Code](https://claude.ai/code)