### PR TITLE
feat: remove dollar sign prefixes from Discord summary table cells

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Run Claude Code
         if: steps.verify_invocation.outputs.invoked == 'true'
         id: claude
-        uses: richkuo/claude-code-action@fix/bun-tsconfig-realpath
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -179,7 +179,7 @@ jobs:
 
       - name: Revise CLAUDE.md with session learnings
         if: steps.verify_invocation.outputs.invoked == 'true' && steps.claude.outcome == 'success' && steps.claude_changes.outputs.made_commits == 'true'
-        uses: richkuo/claude-code-action@fix/bun-tsconfig-realpath
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: "Use the Skill tool to invoke the 'claude-md-management:revise-claude-md' skill. Review the changes made in this session (use git log and git diff to inspect them) and update CLAUDE.md with any new patterns, conventions, or important context learned."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Run Claude Code
         if: steps.verify_invocation.outputs.invoked == 'true'
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: richkuo/claude-code-action@fix/bun-tsconfig-realpath
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -179,7 +179,7 @@ jobs:
 
       - name: Revise CLAUDE.md with session learnings
         if: steps.verify_invocation.outputs.invoked == 'true' && steps.claude.outcome == 'success' && steps.claude_changes.outputs.made_commits == 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: richkuo/claude-code-action@fix/bun-tsconfig-realpath
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: "Use the Skill tool to invoke the 'claude-md-management:revise-claude-md' skill. Review the changes made in this session (use git log and git diff to inspect them) and update CLAUDE.md with any new patterns, conventions, or important context learned."

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -750,54 +750,54 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 	}
 	sb.WriteString("\n```\n")
 	if showWalletPct {
-		const sep = "----------------------------------------------------------------------------------"
-		sb.WriteString(fmt.Sprintf("%-20s %10s %10s %10s %7s %8s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Wallet%", "Tf", "Int"))
+		const sep = "---------------------------------------------------------------------------------"
+		sb.WriteString(fmt.Sprintf("%-20s %10s %10s %9s %7s %8s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Wallet%", "Tf", "Int"))
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {
 			label := bot.id
 			if len(label) > 20 {
 				label = label[:20]
 			}
-			valStr := "$ " + fmtComma(bot.value)
-			initStr := "$ " + fmtComma(bot.initialCap)
+			valStr := fmtComma(bot.value)
+			initStr := fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
 			pctStr := fmtPnlPct(bot.pnlPct)
 			wpStr := ""
 			if bot.walletPct > 0 {
 				wpStr = fmt.Sprintf("%.1f%%", bot.walletPct)
 			}
-			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %10s %7s %8s %5s %5s\n", label, initStr, valStr, pnlStr, pctStr, wpStr, bot.timeframe, bot.interval))
+			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %9s %7s %8s %5s %5s\n", label, initStr, valStr, pnlStr, pctStr, wpStr, bot.timeframe, bot.interval))
 		}
 		if includeTotals {
 			sb.WriteString(sep + "\n")
-			totValStr := "$ " + fmtComma(totalValue)
-			totInitStr := "$ " + fmtComma(totalInit)
+			totValStr := fmtComma(totalValue)
+			totInitStr := fmtComma(totalInit)
 			totPnlStr := fmtPnl(totalPnl)
 			totPctStr := fmtPnlPct(totalPnlPct)
-			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %10s %7s %8s %5s %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "100.0%", "", ""))
+			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %9s %7s %8s %5s %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "100.0%", "", ""))
 		}
 	} else {
-		const sep = "-------------------------------------------------------------------------"
-		sb.WriteString(fmt.Sprintf("%-20s %10s %10s %10s %7s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Tf", "Int"))
+		const sep = "------------------------------------------------------------------------"
+		sb.WriteString(fmt.Sprintf("%-20s %10s %10s %9s %7s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Tf", "Int"))
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {
 			label := bot.id
 			if len(label) > 20 {
 				label = label[:20]
 			}
-			valStr := "$ " + fmtComma(bot.value)
-			initStr := "$ " + fmtComma(bot.initialCap)
+			valStr := fmtComma(bot.value)
+			initStr := fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
 			pctStr := fmtPnlPct(bot.pnlPct)
-			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %10s %7s %5s %5s\n", label, initStr, valStr, pnlStr, pctStr, bot.timeframe, bot.interval))
+			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %9s %7s %5s %5s\n", label, initStr, valStr, pnlStr, pctStr, bot.timeframe, bot.interval))
 		}
 		if includeTotals {
 			sb.WriteString(sep + "\n")
-			totValStr := "$ " + fmtComma(totalValue)
-			totInitStr := "$ " + fmtComma(totalInit)
+			totValStr := fmtComma(totalValue)
+			totInitStr := fmtComma(totalInit)
 			totPnlStr := fmtPnl(totalPnl)
 			totPctStr := fmtPnlPct(totalPnlPct)
-			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %10s %7s %5s %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", ""))
+			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %9s %7s %5s %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", ""))
 		}
 	}
 	sb.WriteString("```\n")
@@ -836,7 +836,7 @@ func fmtPnl(pnl float64) string {
 		sign = "-"
 		abs = -pnl
 	}
-	return "$ " + sign + fmtComma(abs)
+	return sign + fmtComma(abs)
 }
 
 func fmtPnlPct(pct float64) string {

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -571,16 +571,16 @@ func TestFormatCategorySummary_SharedWallet(t *testing.T) {
 		t.Errorf("expected '100.0%%' total wallet share, got:\n%s", msg)
 	}
 	// TOTAL value should be ~$1,085 (sum of both strategy values)
-	if !strings.Contains(msg, "$ 1,085") {
-		t.Errorf("expected total value ~$1,085, got:\n%s", msg)
+	if !strings.Contains(msg, "1,085") {
+		t.Errorf("expected total value ~1,085, got:\n%s", msg)
 	}
 	// Individual values should be ~$542
-	if !strings.Contains(msg, "$ 542") {
-		t.Errorf("expected individual value ~$542, got:\n%s", msg)
+	if !strings.Contains(msg, "542") {
+		t.Errorf("expected individual value ~542, got:\n%s", msg)
 	}
 	// PnL should use InitialCapital ($500), not runtime Capital ($542.50)
-	if !strings.Contains(msg, "$ 500") {
-		t.Errorf("expected initial capital '$ 500', got:\n%s", msg)
+	if !strings.Contains(msg, "500") {
+		t.Errorf("expected initial capital '500', got:\n%s", msg)
 	}
 	// Column order should be Init | Value (not Value | Init)
 	initIdx := strings.Index(msg, "Init")


### PR DESCRIPTION
Remove the `$ ` prefix from Init, Value, and PnL cells in the Discord category summary table. This recovers 2 chars per column and reduces the chance of hitting Discord's 2000-char limit on large portfolios. Also shrinks the PnL column width by 1 char and adjusts separator lengths accordingly.

Closes #379

Generated with [Claude Code](https://claude.ai/code)