### PR TITLE
docs: sync CLAUDE.md, README.md, SKILL.md for PRs #373–#382

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,10 +20,10 @@
   - `server.go` — HTTP status server (`/status`, `/health` endpoints)
   - `discord.go` — `discordgo.Session` wrapper for two-way Discord communication; `SendMessage`, `SendDM`, `AskDM` (blocking DM with timeout); `FormatCategorySummary` per-asset Discord messages; `fmtComma` — always pass absolute values
   - `init.go` — `go-trader init` interactive wizard + `--json <blob>` non-interactive mode; `generateConfig(InitOptions) *Config` is pure/testable; `runInitFromJSON(jsonStr, outputPath)` for scripted config gen (e.g. from OpenClaw); `runInit` orchestrates I/O
-  - `prompt.go` — `Prompter` struct (String/YesNo/Choice/MultiSelect/Float); inject `NewPrompterFromReader(r,w)` for tests
+  - `prompt.go` — `Prompter` struct (String/YesNo/Choice/MultiSelect/Float/FloatRange); `FloatRange(prompt, default, min, max)` re-prompts on out-of-range input; inject `NewPrompterFromReader(r,w)` for tests
   - `updater.go` — update checker; `checkForUpdates(cfg, discord, &lastNotifiedHash, &mu, state)` — git fetch, channel notify + DM upgrade prompt (goroutine); `applyUpgrade(discord, ownerID, mu, state, cfg)` — git pull + go build + state save + restart; `restartSelf()` — systemctl → syscall.Exec fallback; logs `[update]` prefix
   - `correlation.go` — per-asset directional exposure tracking; `ComputeCorrelation` warns on concentration/same-direction thresholds
-  - `config_migration.go` — `CurrentConfigVersion = 7`; auto-migrates config via Discord DM on startup
+  - `config_migration.go` — `CurrentConfigVersion = 8`; auto-migrates config via Discord DM on startup; v8 migration strips dead `discord.spot_summary_freq` / `discord.options_summary_freq` fields and notifies owner
   - `balance.go` — balance tracking and capital management
   - `hyperliquid_balance.go` — Hyperliquid-specific balance sync (`syncHyperliquidAccountPositions`)
   - `leaderboard.go` — pre-computed strategy leaderboard for Discord summaries
@@ -96,7 +96,8 @@
 - Native Go mark fetchers: `fetchHyperliquidMids` (hyperliquid_marks.go), `fetchOKXPerpsMids` (okx_marks.go), and Deribit ticker fetcher (deribit.go) replace per-cycle Python subprocess calls — pattern: expose base URL as `var xxxMainnetURL` so httptest stubs can redirect in tests
 - `cfg.Discord.Channels` is `map[string]string` (not a struct); keys: "spot", "options", "hyperliquid", etc. — old `.Spot`/`.Options` field access is invalid
 - `cfg.Discord.OwnerID` — Discord user ID for DM upgrade prompts + config migration; loaded from `DISCORD_OWNER_ID` env var (takes priority over config file)
-- `cfg.ConfigVersion` — int, schema version (`0`/missing = v1 baseline); `CurrentConfigVersion = 7` in config_migration.go; startup triggers `runConfigMigrationDM` when below current version
+- `cfg.ConfigVersion` — int, schema version (`0`/missing = v1 baseline); `CurrentConfigVersion = 8` in config_migration.go; startup triggers `runConfigMigrationDM` when below current version
+- `cfg.SummaryFrequency` — `map[string]string` (`"summary_frequency"` in JSON); keys match `discord.channels` keys (e.g. `"spot"`, `"hyperliquid"`); values: Go duration (`"30m"`, `"2h"`), alias (`"hourly"`, `"daily"`, `"every"`/`"per_check"`/`"always"`), or empty for legacy default (continuous channels every cycle; spot hourly). `ParseSummaryFrequency(s)` converts to `time.Duration` (-1 = legacy). `ShouldPostSummary(freq, cycle, intervalSeconds, continuous, hasTrades)` — `hasTrades=true` always forces a post
 - `cfg.Correlation` — `*CorrelationConfig` with `Enabled` (default false), `MaxConcentrationPct` (default 60), `MaxSameDirectionPct` (default 75); computed under RLock, state assigned under Lock; warnings sent to all Discord channels + owner DM
 - `cfg.AutoUpdate` — `"off"` (default), `"daily"` (once/day), `"heartbeat"` (every cycle); handled in main.go loop + startup; uses `dailyCycles = (24*3600)/tickSeconds`
 - Strategy registry imports: `check_strategy.py` imports from `shared_strategies/spot/strategies.py`; `check_hyperliquid.py`, `check_topstep.py`, and `check_okx.py` (swap mode) import from `shared_strategies/futures/strategies.py` — a new strategy must be registered in both if it needs to work across platforms

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Python gets the quant libraries (pandas, numpy, scipy, CCXT). Go gets memory eff
 | `rsi_macd_combo` | RSI and MACD confluence |
 | `pairs_spread` | BTC/ETH, BTC/SOL, ETH/SOL spread z-score stat arb (1d) |
 
+### Futures-only (additional strategies, available on TopStep/perps)
+
+| Strategy | Description |
+|----------|-------------|
+| `session_breakout` | Break of prior session (Asian/US open/US close) high/low with volume confirmation |
+
 ### Options (4 strategies, 4h interval, BTC/ETH)
 
 Same 4 strategies on both Deribit and IBKR/CME for comparison:
@@ -159,13 +165,13 @@ New options trades are scored against existing positions for strike distance, ex
 
 ### Perps (1h interval, any HL-listed asset)
 
-Full spot strategy suite on Hyperliquid perpetual futures. Strategies are auto-discovered at `go-trader init` time: `momentum`, `sma_crossover`, `ema_crossover`, `rsi`, `bollinger_bands`, `macd`, `mean_reversion`, `volume_weighted`, `triple_ema`, `rsi_macd_combo`, `triple_ema_bidir`.
+Full spot strategy suite on Hyperliquid perpetual futures. Strategies are auto-discovered at `go-trader init` time: `momentum`, `sma_crossover`, `ema_crossover`, `rsi`, `bollinger_bands`, `macd`, `mean_reversion`, `volume_weighted`, `triple_ema`, `rsi_macd_combo`, `triple_ema_bidir`, `session_breakout`.
 
 Most strategies are long-only; `triple_ema_bidir` is the first bidirectional strategy (long on bullish EMA stack, short on bearish) and runs with `allow_shorts: true` so the scheduler opens shorts from flat and flips long↔short on reversals. New bidirectional strategies opt in per-strategy via the same flag — existing long-only strategies keep their semantics.
 
 Live mode requires `HYPERLIQUID_SECRET_KEY` env var. Paper mode simulates trades without a key.
 
-### Futures (5 strategies, 1h interval, ES/NQ/MES/MNQ/CL/GC)
+### Futures (6 strategies, 1h interval, ES/NQ/MES/MNQ/CL/GC)
 
 | Strategy | Description |
 |----------|-------------|
@@ -174,6 +180,7 @@ Live mode requires `HYPERLIQUID_SECRET_KEY` env var. Paper mode simulates trades
 | `rsi` | Buy oversold, sell overbought |
 | `macd` | MACD/signal line crossovers |
 | `breakout` | Price breakout detection |
+| `session_breakout` | Break of prior session (Asian/US open/US close) high/low with volume confirmation |
 
 CME futures on TopStep. Live mode requires `TOPSTEP_API_KEY`, `TOPSTEP_API_SECRET`, `TOPSTEP_ACCOUNT_ID` env vars. Paper mode uses Yahoo Finance for price data.
 
@@ -217,7 +224,7 @@ Use `./go-trader init` (interactive) or `./go-trader init --json '...'` (scripte
 
 ```json
 {
-  "config_version": 7,
+  "config_version": 8,
   "interval_seconds": 3600,
   "db_file": "scheduler/state.db",
   "log_dir": "logs",
@@ -300,6 +307,29 @@ To get your Discord user ID: right-click your username in Discord → **Copy Use
 | `discord.owner_id` | Your Discord user ID — enables DM upgrade prompts and post-upgrade config migration. Use `DISCORD_OWNER_ID` env var. |
 | `discord.channels` | Map of channel IDs keyed by platform/type — `"spot"`, `"options"`, `"hyperliquid"`, `"topstep"`, `"robinhood"`, `"okx"`, etc. Options post per-check; others post hourly + on trades. |
 | `config_version` | Schema version (set automatically by `go-trader init`; migration runs on startup when behind current version) |
+
+### Summary Frequency
+
+Control how often each channel posts a summary via the top-level `summary_frequency` map. Keys match the `discord.channels` keys (e.g. `"spot"`, `"hyperliquid"`). Trades always force an immediate post regardless of the configured cadence.
+
+```json
+{
+  "summary_frequency": {
+    "spot": "hourly",
+    "options": "every",
+    "hyperliquid": "every",
+    "topstep": "30m"
+  }
+}
+```
+
+| Value | Behavior |
+|-------|----------|
+| `"every"` / `"per_check"` / `"always"` | Post every scheduler cycle |
+| `"hourly"` | Post once per hour |
+| `"daily"` | Post once per day |
+| `"30m"`, `"2h"`, etc. | Post every N minutes/hours (Go duration syntax) |
+| `""` (omitted) | Legacy default — options/perps/futures post every cycle; spot posts hourly |
 
 ### Strategy Entry
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -109,10 +109,11 @@ The wizard walks through:
 2. **Spot strategies** — momentum, mean reversion, pairs spread (BinanceUS)
 3. **Options strategies** — covered call, cash-secured put; Deribit and/or IBKR
 4. **Perps strategies** — full spot strategy suite on Hyperliquid (paper or live mode)
-5. **Futures strategies** — momentum, mean_reversion, rsi, macd, breakout on CME futures (TopStep, paper or live mode)
+5. **Futures strategies** — momentum, mean_reversion, rsi, macd, breakout, session_breakout on CME futures (TopStep, paper or live mode)
 6. **Capital & max drawdown** per strategy type
-7. **Discord** — per-platform channel IDs (spot, options, hyperliquid if perps enabled, topstep if futures enabled, okx if OKX enabled)
-8. **Auto-update** — off / daily / heartbeat (default: off)
+7. **Risk settings** (live mode only) — per-strategy max drawdown %, portfolio kill-switch threshold %, and warn threshold %; these are prompted explicitly when any live platform is selected so the generated config is complete before first startup (#378)
+8. **Discord** — per-platform channel IDs (spot, options, hyperliquid if perps enabled, topstep if futures enabled, okx if OKX enabled)
+9. **Auto-update** — off / daily / heartbeat (default: off)
 
 A summary is shown before writing. If `scheduler/config.json` already exists, you'll be prompted to confirm overwrite.
 
@@ -226,7 +227,7 @@ Ask:
 
 If provided, store as `DISCORD_OWNER_ID` for the systemd service (Step 8c). Do NOT write it to config.json.
 
-> **Note:** Summary frequency is automatic — spot and hyperliquid summaries post hourly (plus immediate trade alerts), options summaries post every check cycle. No configuration needed.
+> **Note:** Summary cadence is configurable via the top-level `summary_frequency` map in `config.json`. Keys match channel names (e.g. `"spot"`, `"hyperliquid"`). Values: `"hourly"`, `"daily"`, `"every"`/`"per_check"`, or Go durations like `"30m"`. Omit a key for the legacy default (options/perps/futures: every cycle; spot: hourly). Trades always force an immediate post.
 
 ---
 
@@ -405,7 +406,7 @@ Discord config:
 - `discord.enabled`: true/false based on Step 4
 - `discord.token`: Always `""` (token comes from env var)
 - `discord.channels`: Map of channel IDs for enabled platform types, e.g. `{"spot": "ID_FROM_4b", "options": "ID_FROM_4c", "hyperliquid": "ID_FROM_4d", "topstep": "ID_FROM_4e", "okx": "ID_FROM_4f", "luno": "ID_FROM_4g"}` — omit keys for platforms not in use
-- Summary frequency is automatic: options post per-check, spot/hyperliquid/okx post hourly + on trades (no config field needed)
+- `summary_frequency`: Optional map controlling post cadence per channel. Keys match `discord.channels` keys. Values: `"hourly"`, `"daily"`, `"every"`/`"per_check"`, or Go durations like `"30m"`. Omit for legacy default (options/perps/futures every cycle; spot hourly). Example: `{"spot": "hourly", "options": "every", "hyperliquid": "every"}`. Trades always force an immediate post regardless of cadence.
 
 ### 7b. OpenClaw Discord Allowlist (if applicable)
 
@@ -1000,24 +1001,27 @@ When the user says `/menu`, "show menu", "what can I configure", "what's availab
    Spot (10 strategies):
      sma_crossover, ema_crossover, momentum, rsi, bollinger_bands, macd,
      mean_reversion, volume_weighted, triple_ema, rsi_macd_combo, pairs_spread
+   Futures-only (TopStep/perps only):
+     session_breakout
    Deribit Options (8):
      vol_mean_reversion, momentum_options, protective_puts, covered_calls,
      wheel, butterfly  — BTC + ETH each
    IBKR Options (8):
      same 6 strategies as Deribit — BTC + ETH each
-   Futures (5 strategies, TopStep/CME):
-     momentum, mean_reversion, rsi, macd, breakout
+   Futures (6 strategies, TopStep/CME):
+     momentum, mean_reversion, rsi, macd, breakout, session_breakout
    Robinhood Crypto (same 10 spot strategies):
      sma_crossover, ema_crossover, momentum, rsi, bollinger_bands, macd,
      mean_reversion, volume_weighted, triple_ema, rsi_macd_combo
 
 3. ADJUSTABLE SETTINGS  (edit scheduler/config.json, then: sudo systemctl restart go-trader)
    Global:
-     interval_seconds  — default cycle interval (seconds)
-     db_file           — SQLite path for positions/trades/risk state
-     max_drawdown_pct  — portfolio-level circuit breaker (triggers live-close on HL/OKX/Robinhood/TopStep)
-     notional_cap_usd  — max total notional exposure
-     correlation.*     — per-asset directional exposure tracking (enabled, max_concentration_pct, max_same_direction_pct)
+     interval_seconds   — default cycle interval (seconds)
+     db_file            — SQLite path for positions/trades/risk state
+     max_drawdown_pct   — portfolio-level circuit breaker (triggers live-close on HL/OKX/Robinhood/TopStep)
+     notional_cap_usd   — max total notional exposure
+     correlation.*      — per-asset directional exposure tracking (enabled, max_concentration_pct, max_same_direction_pct)
+     summary_frequency  — per-channel cadence map (hourly/daily/every/30m/2h); keys match discord.channels keys
    Per-strategy:
      capital           — starting capital (USD)
      max_drawdown_pct  — strategy-level circuit breaker
@@ -1202,6 +1206,7 @@ Each spot strategy needs entries for each asset it supports:
 - `sma_crossover`, `ema_crossover`, `momentum`, `rsi`, `bollinger_bands`, `macd`, `mean_reversion`, `volume_weighted`, `triple_ema`, `rsi_macd_combo`: BTC, ETH, SOL
 - `pairs_spread`: Requires two assets — `args: ["pairs_spread", "BTC/USDT", "1d", "ETH/USDT"]`
 - `triple_ema_bidir`: futures/perps only (not registered for spot); bidirectional — set `"allow_shorts": true` on the strategy entry so the scheduler opens shorts from flat and flips on reversal.
+- `session_breakout`: futures/perps only; short name `sbo`; ID convention `ts-sbo-es` (TopStep), `hl-sbo-btc` (Hyperliquid perps). Default params: `session=asian`, `lookback=1`, `volume_threshold=1.5`.
 
 **Pairs strategy IDs and args:**
 ```json


### PR DESCRIPTION
Brings all three docs into sync with `main` as of commit 57849c6 (the most recent commit at time of writing).

## Changes

**config_version 7 → 8** (#377 `summary_frequency` migration)
- Update `config_version` in README.md JSON example
- Update `CurrentConfigVersion` references in CLAUDE.md
- Add v8 migration note: strips dead `discord.spot_summary_freq` / `discord.options_summary_freq` fields

**`summary_frequency` config map** (#377)
- New top-level config key documented in README.md (new subsection with JSON snippet + cadence values table)
- Documented in CLAUDE.md key-patterns (`cfg.SummaryFrequency`, `ParseSummaryFrequency`, `ShouldPostSummary`)
- SKILL.md Step 4g note: replaced stale "Summary frequency is automatic" with configurable map description
- SKILL.md Step 7a: `summary_frequency` added to config generation bullet
- SKILL.md `/menu`: `summary_frequency` added under Global adjustable settings

**`session_breakout` strategy** (#373, futures-only)
- README.md: new "Futures-only" strategies table; added to Futures table and perps auto-discovery list
- SKILL.md Step 3b: added to futures wizard bullet; strategy reference entry with short name `sbo` and ID conventions
- SKILL.md `/menu`: futures count 5 → 6, new Futures-only section

**`go-trader init` live-mode risk prompts** (#378)
- SKILL.md Step 3b: added bullet 7 noting per-strategy DD %, kill-switch threshold %, and warn threshold % are now prompted when any live platform is selected
- CLAUDE.md: added `FloatRange` to Prompter methods list

---
Generated with: Claude Sonnet 4.6 | Effort: 30