### PR TITLE
fix: set Discord strategy column width to 16 chars

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -753,7 +753,7 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 	}
 	sb.WriteString("\n```\n")
 	if showWalletPct {
-		const sep = "------------------------------------------------------------------------------------"
+		const sep = "-----------------------------------------------------------------------------------"
 		sb.WriteString(fmt.Sprintf("%-16s %10s %10s %9s %7s %8s %5s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Wallet%", "Tf", "Int", "#T"))
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -753,13 +753,13 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 	}
 	sb.WriteString("\n```\n")
 	if showWalletPct {
-		const sep = "---------------------------------------------------------------------------------------"
-		sb.WriteString(fmt.Sprintf("%-20s %10s %10s %9s %7s %8s %5s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Wallet%", "Tf", "Int", "#T"))
+		const sep = "------------------------------------------------------------------------------------"
+		sb.WriteString(fmt.Sprintf("%-16s %10s %10s %9s %7s %8s %5s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Wallet%", "Tf", "Int", "#T"))
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {
 			label := bot.id
-			if len(label) > 20 {
-				label = label[:20]
+			if len(label) > 16 {
+				label = label[:16]
 			}
 			valStr := fmtComma(bot.value)
 			initStr := fmtComma(bot.initialCap)
@@ -769,7 +769,7 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 			if bot.walletPct > 0 {
 				wpStr = fmt.Sprintf("%.1f%%", bot.walletPct)
 			}
-			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %9s %7s %8s %5s %5s %5d\n", label, initStr, valStr, pnlStr, pctStr, wpStr, bot.timeframe, bot.interval, bot.closedTrades))
+			sb.WriteString(fmt.Sprintf("%-16s %10s %10s %9s %7s %8s %5s %5s %5d\n", label, initStr, valStr, pnlStr, pctStr, wpStr, bot.timeframe, bot.interval, bot.closedTrades))
 		}
 		if includeTotals {
 			sb.WriteString(sep + "\n")
@@ -777,22 +777,22 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 			totInitStr := fmtComma(totalInit)
 			totPnlStr := fmtPnl(totalPnl)
 			totPctStr := fmtPnlPct(totalPnlPct)
-			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %9s %7s %8s %5s %5s %5d\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "100.0%", "", "", totalClosed))
+			sb.WriteString(fmt.Sprintf("%-16s %10s %10s %9s %7s %8s %5s %5s %5d\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "100.0%", "", "", totalClosed))
 		}
 	} else {
-		const sep = "------------------------------------------------------------------------------"
-		sb.WriteString(fmt.Sprintf("%-20s %10s %10s %9s %7s %5s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Tf", "Int", "#T"))
+		const sep = "--------------------------------------------------------------------------"
+		sb.WriteString(fmt.Sprintf("%-16s %10s %10s %9s %7s %5s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Tf", "Int", "#T"))
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {
 			label := bot.id
-			if len(label) > 20 {
-				label = label[:20]
+			if len(label) > 16 {
+				label = label[:16]
 			}
 			valStr := fmtComma(bot.value)
 			initStr := fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
 			pctStr := fmtPnlPct(bot.pnlPct)
-			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %9s %7s %5s %5s %5d\n", label, initStr, valStr, pnlStr, pctStr, bot.timeframe, bot.interval, bot.closedTrades))
+			sb.WriteString(fmt.Sprintf("%-16s %10s %10s %9s %7s %5s %5s %5d\n", label, initStr, valStr, pnlStr, pctStr, bot.timeframe, bot.interval, bot.closedTrades))
 		}
 		if includeTotals {
 			sb.WriteString(sep + "\n")
@@ -800,7 +800,7 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 			totInitStr := fmtComma(totalInit)
 			totPnlStr := fmtPnl(totalPnl)
 			totPctStr := fmtPnlPct(totalPnlPct)
-			sb.WriteString(fmt.Sprintf("%-20s %10s %10s %9s %7s %5s %5s %5d\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", "", totalClosed))
+			sb.WriteString(fmt.Sprintf("%-16s %10s %10s %9s %7s %5s %5s %5d\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", "", totalClosed))
 		}
 	}
 	sb.WriteString("```\n")


### PR DESCRIPTION
Updates the Discord summary table Strategy column from `%-20s` to `%-16s`, adjusting truncation guards and separator lengths to match.

Closes #384

Generated with [Claude Code](https://claude.ai/code)