### PR TITLE
fix: close alerts show position side not execution side

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -906,7 +906,7 @@ func FormatTradeDM(sc StrategyConfig, trade Trade, mode string) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%s **%s**\n", icon, header))
 	sb.WriteString(fmt.Sprintf("Strategy: %s (%s %s)\n", sc.ID, platformLabel, typeLabel))
-	sb.WriteString(fmt.Sprintf("%s — %s %.6g @ $%s\n", trade.Symbol, tradeSideToDirection(trade.Side), trade.Quantity, fmtComma(trade.Price)))
+	sb.WriteString(fmt.Sprintf("%s — %s %.6g @ $%s\n", trade.Symbol, tradeDirectionLabel(trade), trade.Quantity, fmtComma(trade.Price)))
 
 	valueLine := fmt.Sprintf("Value: $%s", fmtComma(trade.Value))
 	if isClose {
@@ -930,6 +930,26 @@ func tradeSideToDirection(side string) string {
 	default:
 		return strings.ToUpper(side)
 	}
+}
+
+// tradeDirectionLabel returns the LONG/SHORT label describing the *position*
+// the trade opens or closes. Details carries "Open long" / "Close long" /
+// "Open short" / "Close short" — authoritative for spot/perps/futures. Falls
+// back to mapping the execution Side (buy/sell) when Details has no such
+// marker (e.g. options wheel fills, circuit-breaker force-close).
+//
+// Why: close trades invert execution side vs position side — selling to close
+// a long execution Side="sell" would render as SHORT, but the position being
+// exited was LONG. See #386.
+func tradeDirectionLabel(trade Trade) string {
+	d := strings.ToLower(trade.Details)
+	switch {
+	case strings.Contains(d, "open long"), strings.Contains(d, "close long"):
+		return "LONG"
+	case strings.Contains(d, "open short"), strings.Contains(d, "close short"):
+		return "SHORT"
+	}
+	return tradeSideToDirection(trade.Side)
 }
 
 // extractPnL parses the PnL value from a trade Details string.

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -337,14 +337,38 @@ func TestFormatTradeDM_CloseTrade(t *testing.T) {
 	if !strings.Contains(msg, "TRADE CLOSED") {
 		t.Errorf("expected 'TRADE CLOSED', got:\n%s", msg)
 	}
-	if !strings.Contains(msg, "SHORT") {
-		t.Errorf("expected SHORT, got:\n%s", msg)
+	// Regression for #386: close alert must report the *position* side, not
+	// the execution side. Selling to close a long must render LONG, not SHORT.
+	if !strings.Contains(msg, "LONG") {
+		t.Errorf("expected LONG (position side), got:\n%s", msg)
+	}
+	if strings.Contains(msg, "SHORT") {
+		t.Errorf("close-long trade must not render SHORT, got:\n%s", msg)
 	}
 	if !strings.Contains(msg, "PnL: $34.35") {
 		t.Errorf("expected PnL in close trade, got:\n%s", msg)
 	}
 	if !strings.Contains(msg, "Mode: live") {
 		t.Errorf("expected 'Mode: live', got:\n%s", msg)
+	}
+}
+
+func TestFormatTradeDM_CloseShort(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-bidir-eth", Platform: "hyperliquid", Type: "perps"}
+	trade := Trade{
+		Symbol:   "ETH",
+		Side:     "buy",
+		Quantity: 0.47,
+		Price:    3077.70,
+		Value:    1446.52,
+		Details:  "Close short, PnL: $12.50 (fee $1.23)",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	if !strings.Contains(msg, "SHORT") {
+		t.Errorf("expected SHORT (position side), got:\n%s", msg)
+	}
+	if strings.Contains(msg, "LONG") {
+		t.Errorf("close-short trade must not render LONG, got:\n%s", msg)
 	}
 }
 
@@ -427,6 +451,33 @@ func TestTradeSideToDirection(t *testing.T) {
 		if got != c.want {
 			t.Errorf("tradeSideToDirection(%q) = %q, want %q", c.side, got, c.want)
 		}
+	}
+}
+
+func TestTradeDirectionLabel(t *testing.T) {
+	cases := []struct {
+		name    string
+		side    string
+		details string
+		want    string
+	}{
+		{"close_long_from_sell", "sell", "Close long, PnL: $34.35 (fee $1.23)", "LONG"},
+		{"close_short_from_buy", "buy", "Close short, PnL: $12.50 (fee $1.23)", "SHORT"},
+		{"open_long", "buy", "Open long 0.15 @ $67845.00 (fee $10.18)", "LONG"},
+		{"open_short", "sell", "Open short 0.15 @ $67845.00 (fee $10.18)", "SHORT"},
+		{"futures_close_long", "sell", "Close long 2 contracts, PnL: $50.00 (fee $4.12)", "LONG"},
+		{"futures_close_short", "buy", "Close short 2 contracts, PnL: $50.00 (fee $4.12)", "SHORT"},
+		{"circuit_breaker_fallback", "close", "Circuit breaker force-close, PnL: $-12.00", "CLOSE"},
+		{"options_close_falls_back_to_side", "sell", "Close BTC-call-50000 PnL=$123.45", "SHORT"},
+		{"empty_details_falls_back", "buy", "", "LONG"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := tradeDirectionLabel(Trade{Side: c.side, Details: c.details})
+			if got != c.want {
+				t.Errorf("tradeDirectionLabel(side=%q, details=%q) = %q, want %q", c.side, c.details, got, c.want)
+			}
+		})
 	}
 }
 
@@ -1172,8 +1223,12 @@ func TestFormatTradeDMPlain_CloseTrade(t *testing.T) {
 	if !strings.Contains(msg, "TRADE CLOSED") {
 		t.Errorf("expected 'TRADE CLOSED', got:\n%s", msg)
 	}
-	if !strings.Contains(msg, "SHORT") {
-		t.Errorf("expected SHORT, got:\n%s", msg)
+	// Regression for #386: close alert must report the *position* side.
+	if !strings.Contains(msg, "LONG") {
+		t.Errorf("expected LONG (position side), got:\n%s", msg)
+	}
+	if strings.Contains(msg, "SHORT") {
+		t.Errorf("close-long trade must not render SHORT, got:\n%s", msg)
 	}
 	if !strings.Contains(msg, "PnL: $34.35") {
 		t.Errorf("expected PnL in close trade, got:\n%s", msg)

--- a/scheduler/telegram.go
+++ b/scheduler/telegram.go
@@ -254,7 +254,7 @@ func FormatTradeDMPlain(sc StrategyConfig, trade Trade, mode string) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%s %s\n", icon, header))
 	sb.WriteString(fmt.Sprintf("Strategy: %s (%s %s)\n", sc.ID, platformLabel, typeLabel))
-	sb.WriteString(fmt.Sprintf("%s — %s %.6g @ $%s\n", trade.Symbol, tradeSideToDirection(trade.Side), trade.Quantity, fmtComma(trade.Price)))
+	sb.WriteString(fmt.Sprintf("%s — %s %.6g @ $%s\n", trade.Symbol, tradeDirectionLabel(trade), trade.Quantity, fmtComma(trade.Price)))
 
 	valueLine := fmt.Sprintf("Value: $%s", fmtComma(trade.Value))
 	if isClose {


### PR DESCRIPTION
Closes #386

## Summary

Closes #386. Close trade alerts were rendering the execution `Side` (buy/sell) through `tradeSideToDirection`, so selling to close a long printed `SHORT` even though the position exited was LONG.

New `tradeDirectionLabel(trade)` parses `Open/Close long|short` from `Trade.Details` first and falls back to the execution-side mapping when Details has no marker (options wheel fills, circuit-breaker force-close). Wired into both `FormatTradeDM` (Discord) and `FormatTradeDMPlain` (Telegram).

## Test plan

- [x] `go test ./...` passes
- [x] Regression tests for close-long and close-short (both Discord and plain-text formatters)
- [x] Table-driven `TestTradeDirectionLabel` covers spot/perps/futures open+close + fallbacks

Generated with [Claude Code](https://claude.ai/code)