### PR TITLE
Fix systemd log directory setup under ProtectSystem=strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ curl -s localhost:8099/status | python3 -m json.tool
 `scripts/install-service.sh` copies the unit into `/etc/systemd/system/`, runs
 `daemon-reload`, and **enables** the unit so it auto-starts on boot. Always
 install services this way (or pass `systemctl enable --now`) — a service that
-is only `start`ed will silently stay down after the next reboot.
+is only `start`ed will silently stay down after the next reboot. It also
+pre-creates `<WorkingDirectory>/logs` with the unit's configured user/group, so
+`ProtectSystem=strict` still lets the scheduler create log files on first boot.
 
 ### Running multiple instances (paper / live / testing)
 

--- a/go-trader.service
+++ b/go-trader.service
@@ -25,8 +25,8 @@ EnvironmentFile=-/opt/go-trader/.env
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
-# Allow writes only to the data directory
-ReadWritePaths=/opt/go-trader/scheduler
+# Allow writes only to the data and logs directories
+ReadWritePaths=/opt/go-trader/scheduler /opt/go-trader/logs
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -40,6 +40,25 @@ fi
 UNIT_FILENAME="$(basename "$SRC")"
 DEST="/etc/systemd/system/$UNIT_FILENAME"
 
+resolve_unit_value() {
+  local value="$1"
+  if [[ "$UNIT_FILENAME" == *@.service ]]; then
+    value="${value//%i/$INSTANCE}"
+    value="${value//%I/$INSTANCE}"
+  fi
+  printf '%s\n' "$value"
+}
+
+read_unit_field() {
+  local key="$1"
+  local raw
+  raw="$(sed -n "s/^${key}=//p" "$SRC" | head -n 1)"
+  if [[ -z "$raw" ]]; then
+    return 0
+  fi
+  resolve_unit_value "$raw"
+}
+
 # For a template unit (go-trader@.service), the instance name is what gets
 # enabled/started (e.g. go-trader@live). For a plain unit, ignore $INSTANCE.
 if [[ "$UNIT_FILENAME" == *@.service ]]; then
@@ -53,8 +72,28 @@ else
   SERVICE_NAME="$UNIT_FILENAME"
 fi
 
+WORKING_DIR="$(read_unit_field WorkingDirectory)"
+SERVICE_USER="$(read_unit_field User)"
+SERVICE_GROUP="$(read_unit_field Group)"
+LOG_DIR=""
+if [[ -n "$WORKING_DIR" ]]; then
+  LOG_DIR="$WORKING_DIR/logs"
+fi
+
 echo "Installing $SRC -> $DEST"
 install -m 0644 "$SRC" "$DEST"
+
+if [[ -n "$LOG_DIR" ]]; then
+  echo "Ensuring log directory exists: $LOG_DIR"
+  install -d -m 0755 "$LOG_DIR"
+  if [[ -n "$SERVICE_USER" ]]; then
+    OWNER="$SERVICE_USER"
+    if [[ -n "$SERVICE_GROUP" ]]; then
+      OWNER="${SERVICE_USER}:${SERVICE_GROUP}"
+    fi
+    chown "$OWNER" "$LOG_DIR"
+  fi
+fi
 
 echo "Reloading systemd"
 systemctl daemon-reload

--- a/systemd/go-trader@.service
+++ b/systemd/go-trader@.service
@@ -25,8 +25,8 @@ EnvironmentFile=-/opt/go-trader-%i/.env
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
-# Allow writes only to the data directory
-ReadWritePaths=/opt/go-trader-%i/scheduler
+# Allow writes only to the data and logs directories
+ReadWritePaths=/opt/go-trader-%i/scheduler /opt/go-trader-%i/logs
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add the logs directory to ReadWritePaths for the canonical and templated systemd units
- create the resolved WorkingDirectory/logs path during service installation and chown it to the unit user/group
- document that the installer now pre-creates the logs directory for strict systemd hardening

## Testing
- bash -n scripts/install-service.sh
- git diff --check -- go-trader.service systemd/go-trader@.service scripts/install-service.sh README.md

## Agent Details
- model: GPT-5.4
- effort: high

Closes #392