### PR TITLE
fix: default init to a minimal BTC spot starter

### DIFF
--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -20,6 +20,13 @@ var supportedAssets = []asset{
 	{Name: "SOL", Symbol: "SOL/USDT"},
 }
 
+const (
+	starterAssetName      = "BTC"
+	starterSpotStrategyID = "momentum"
+	starterSpotCapital    = 1000.0
+	starterSpotDrawdown   = 5.0
+)
+
 // stratDef defines a strategy template with its ID and short name for config IDs.
 type stratDef struct {
 	ID        string // strategy arg used in script invocation
@@ -230,6 +237,50 @@ func discoverStrategies() {
 		// shared_strategies/futures/, so perps must match that registry.
 		perpsStrategies = discovered
 	}
+}
+
+func hasAnyEnabledStrategyType(opts InitOptions) bool {
+	return opts.EnableSpot || opts.EnableOptions || opts.EnablePerps || opts.EnableFutures || opts.EnableRobinhood || opts.EnableLuno || opts.EnableOKX
+}
+
+// applyMinimalStarterDefaults turns the empty/default init path into one safe,
+// easy-to-understand starter strategy: BTC spot momentum on BinanceUS.
+func applyMinimalStarterDefaults(opts *InitOptions) {
+	if !opts.EnableSpot && hasAnyEnabledStrategyType(*opts) {
+		return
+	}
+	if !opts.EnableSpot {
+		opts.EnableSpot = true
+	}
+	if len(opts.Assets) == 0 {
+		opts.Assets = []string{starterAssetName}
+	}
+	if len(opts.SpotStrategies) == 0 && (!opts.IncludePairs || len(opts.Assets) < 2) {
+		opts.SpotStrategies = []string{starterSpotStrategyID}
+	}
+	if opts.SpotCapital <= 0 {
+		opts.SpotCapital = starterSpotCapital
+	}
+	if opts.SpotDrawdown <= 0 {
+		opts.SpotDrawdown = starterSpotDrawdown
+	}
+}
+
+func selectionDefaults(options []string, preferred []string, fallbackFirst bool) []int {
+	indexByValue := make(map[string]int, len(options))
+	for i, option := range options {
+		indexByValue[option] = i
+	}
+	result := make([]int, 0, len(preferred))
+	for _, want := range preferred {
+		if idx, ok := indexByValue[want]; ok {
+			result = append(result, idx)
+		}
+	}
+	if len(result) == 0 && fallbackFirst && len(options) > 0 {
+		return []int{0}
+	}
+	return result
 }
 
 // InitOptions captures all user choices from the interactive wizard.
@@ -624,11 +675,13 @@ func runInitFromJSON(jsonStr string, outputPath string) int {
 		}
 	}
 
+	applyMinimalStarterDefaults(&opts)
+
 	if len(opts.Assets) == 0 {
 		fmt.Fprintln(os.Stderr, "Error: at least one asset required")
 		return 1
 	}
-	if !opts.EnableSpot && !opts.EnableOptions && !opts.EnablePerps && !opts.EnableFutures && !opts.EnableRobinhood && !opts.EnableLuno && !opts.EnableOKX {
+	if !hasAnyEnabledStrategyType(opts) {
 		fmt.Fprintln(os.Stderr, "Error: at least one strategy type must be enabled")
 		return 1
 	}
@@ -809,7 +862,7 @@ func runInit(args []string) int {
 	for i, a := range supportedAssets {
 		assetNames[i] = a.Name
 	}
-	assetIdxs := p.MultiSelect("\nSelect assets to trade:", assetNames, true)
+	assetIdxs := p.MultiSelectWithDefaults("\nSelect assets to trade:", assetNames, selectionDefaults(assetNames, []string{starterAssetName}, true))
 	if len(assetIdxs) == 0 {
 		fmt.Println("No assets selected. Aborted.")
 		return 1
@@ -821,7 +874,7 @@ func runInit(args []string) int {
 
 	// Step 3: Strategy types.
 	stratTypeNames := []string{"spot", "options", "perps", "futures", "robinhood", "luno", "okx"}
-	stratTypeIdxs := p.MultiSelect("\nSelect strategy types:", stratTypeNames, false)
+	stratTypeIdxs := p.MultiSelectWithDefaults("\nSelect strategy types:", stratTypeNames, selectionDefaults(stratTypeNames, []string{"spot"}, true))
 	enableSpot, enableOptions, enablePerps, enableFutures, enableRobinhood, enableLuno, enableOKX := false, false, false, false, false, false, false
 	for _, idx := range stratTypeIdxs {
 		switch stratTypeNames[idx] {
@@ -936,7 +989,7 @@ func runInit(args []string) int {
 		if hasPairsOption {
 			spotNames = append(spotNames, "pairs_spread")
 		}
-		spotIdxs := p.MultiSelect("\nSelect spot strategies:", spotNames, false)
+		spotIdxs := p.MultiSelectWithDefaults("\nSelect spot strategies:", spotNames, selectionDefaults(spotNames, []string{starterSpotStrategyID}, true))
 		for _, idx := range spotIdxs {
 			if hasPairsOption && idx == len(spotStrategies) {
 				includePairs = true

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -254,6 +254,9 @@ func applyMinimalStarterDefaults(opts *InitOptions) {
 	}
 	if len(opts.Assets) == 0 {
 		opts.Assets = []string{starterAssetName}
+		// pairs_spread needs ≥2 assets; clear IncludePairs rather than silently
+		// generating a 1-asset config with an inert pairs flag.
+		opts.IncludePairs = false
 	}
 	if len(opts.SpotStrategies) == 0 && (!opts.IncludePairs || len(opts.Assets) < 2) {
 		opts.SpotStrategies = []string{starterSpotStrategyID}

--- a/scheduler/init_test.go
+++ b/scheduler/init_test.go
@@ -613,6 +613,64 @@ func TestRunInitFromJSON_SpotEnabledNoStrategiesUsesStarterStrategy(t *testing.T
 	}
 }
 
+// When the user passes includePairs=true but no assets, the starter defaulter
+// populates Assets with the single starter asset. pairs_spread needs ≥2 assets,
+// so IncludePairs must be cleared rather than leaving an inert flag that would
+// silently generate a 1-asset config with no pair strategies.
+func TestApplyMinimalStarterDefaults_IncludePairsWithoutAssetsDrops(t *testing.T) {
+	opts := InitOptions{IncludePairs: true}
+	applyMinimalStarterDefaults(&opts)
+	if opts.IncludePairs {
+		t.Errorf("expected IncludePairs cleared when assets were defaulted, still true")
+	}
+	if len(opts.Assets) != 1 || opts.Assets[0] != starterAssetName {
+		t.Errorf("expected Assets=[%s], got %v", starterAssetName, opts.Assets)
+	}
+	if len(opts.SpotStrategies) != 1 || opts.SpotStrategies[0] != starterSpotStrategyID {
+		t.Errorf("expected SpotStrategies=[%s], got %v", starterSpotStrategyID, opts.SpotStrategies)
+	}
+}
+
+// If the user explicitly passes assets=["BTC","ETH"] and includePairs=true,
+// the defaulter must leave IncludePairs alone (pairs are valid with 2+ assets).
+func TestApplyMinimalStarterDefaults_IncludePairsWithMultipleAssetsPreserved(t *testing.T) {
+	opts := InitOptions{Assets: []string{"BTC", "ETH"}, IncludePairs: true}
+	applyMinimalStarterDefaults(&opts)
+	if !opts.IncludePairs {
+		t.Errorf("expected IncludePairs preserved when caller supplied 2+ assets")
+	}
+}
+
+// Guard against drift between the starter constants and the option lists the
+// interactive wizard uses: if `starterAssetName` is ever removed from
+// `supportedAssets` or `starterSpotStrategyID` disappears from the spot
+// registry, `selectionDefaults` silently falls back to index 0 — a first-run
+// user would end up with some other asset/strategy without warning. Pin them
+// here so the test fails loudly instead.
+func TestStarterConstants_PinnedToOptionLists(t *testing.T) {
+	found := false
+	for _, a := range supportedAssets {
+		if a.Name == starterAssetName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("starterAssetName %q not in supportedAssets — interactive wizard would silently fall back to index 0", starterAssetName)
+	}
+
+	found = false
+	for _, s := range spotStrategies {
+		if s.ID == starterSpotStrategyID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("starterSpotStrategyID %q not in spotStrategies — interactive wizard would silently fall back to index 0", starterSpotStrategyID)
+	}
+}
+
 func TestRunInitFromJSON_PerpsNoModeDefaultsPaper(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "config.json")
 	jsonStr := `{"assets":["BTC"],"enablePerps":true}`

--- a/scheduler/init_test.go
+++ b/scheduler/init_test.go
@@ -543,30 +543,73 @@ func TestRunInitFromJSON_Valid(t *testing.T) {
 	}
 }
 
-func TestRunInitFromJSON_MissingAssets(t *testing.T) {
+func TestRunInitFromJSON_EmptyUsesStarterSpotDefaults(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "config.json")
-	jsonStr := `{"enableSpot":true,"spotStrategies":["sma_crossover"]}`
+	jsonStr := `{}`
 	code := runInitFromJSON(jsonStr, out)
-	if code != 1 {
-		t.Fatalf("expected exit 1 for missing assets, got %d", code)
+	if code != 0 {
+		t.Fatalf("expected exit 0 for starter defaults, got %d", code)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("expected output file to exist: %v", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if len(cfg.Strategies) != 1 {
+		t.Fatalf("expected 1 starter strategy, got %d", len(cfg.Strategies))
+	}
+	s := cfg.Strategies[0]
+	if s.ID != "momentum-btc" {
+		t.Errorf("expected starter ID momentum-btc, got %s", s.ID)
+	}
+	if s.Type != "spot" || s.Platform != "binanceus" {
+		t.Errorf("expected starter spot strategy on binanceus, got %s/%s", s.Type, s.Platform)
+	}
+	if s.Capital != 1000 || s.MaxDrawdownPct != 5 {
+		t.Errorf("expected starter capital/drawdown 1000/5, got %.0f/%.0f", s.Capital, s.MaxDrawdownPct)
 	}
 }
 
-func TestRunInitFromJSON_NoStrategyTypes(t *testing.T) {
+func TestRunInitFromJSON_AssetsOnlyDefaultsToStarterSpot(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "config.json")
 	jsonStr := `{"assets":["BTC"]}`
 	code := runInitFromJSON(jsonStr, out)
-	if code != 1 {
-		t.Fatalf("expected exit 1 for no strategy types, got %d", code)
+	if code != 0 {
+		t.Fatalf("expected exit 0 for starter defaults, got %d", code)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("expected output file to exist: %v", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if len(cfg.Strategies) != 1 || cfg.Strategies[0].ID != "momentum-btc" {
+		t.Fatalf("expected starter momentum-btc config, got %+v", cfg.Strategies)
 	}
 }
 
-func TestRunInitFromJSON_SpotEnabledNoStrategies(t *testing.T) {
+func TestRunInitFromJSON_SpotEnabledNoStrategiesUsesStarterStrategy(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "config.json")
 	jsonStr := `{"assets":["BTC"],"enableSpot":true}`
 	code := runInitFromJSON(jsonStr, out)
-	if code != 1 {
-		t.Fatalf("expected exit 1 for spot enabled with no strategies, got %d", code)
+	if code != 0 {
+		t.Fatalf("expected exit 0 for starter defaults, got %d", code)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("expected output file to exist: %v", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if len(cfg.Strategies) != 1 || cfg.Strategies[0].ID != "momentum-btc" {
+		t.Fatalf("expected starter momentum-btc config, got %+v", cfg.Strategies)
 	}
 }
 

--- a/scheduler/prompt.go
+++ b/scheduler/prompt.go
@@ -98,22 +98,26 @@ func (p *Prompter) Choice(prompt string, options []string, defaultIdx int) int {
 // Accepts comma-separated numbers (e.g. "1,3"), "all", or "none".
 // Returns a slice of 0-based indices.
 func (p *Prompter) MultiSelect(prompt string, options []string, defaultAll bool) []int {
+	return p.MultiSelectWithDefaults(prompt, options, multiSelectDefault(options, defaultAll))
+}
+
+// MultiSelectWithDefaults prompts the user to pick multiple options from a
+// numbered list, using defaultIdxs when the input is empty.
+func (p *Prompter) MultiSelectWithDefaults(prompt string, options []string, defaultIdxs []int) []int {
 	fmt.Fprintln(p.out, prompt)
 	for i, opt := range options {
 		fmt.Fprintf(p.out, "  %d) %s\n", i+1, opt)
 	}
-	def := "none"
-	if defaultAll {
-		def = "all"
-	}
+	defaultIdxs = normalizeMultiSelectIndices(defaultIdxs, len(options))
+	def := multiSelectPromptDefault(options, defaultIdxs)
 	for {
 		fmt.Fprintf(p.out, "Enter comma-separated numbers, \"all\", or \"none\" [%s]: ", def)
 		if !p.scanner.Scan() {
-			return multiSelectDefault(options, defaultAll)
+			return append([]int(nil), defaultIdxs...)
 		}
 		input := strings.TrimSpace(strings.ToLower(p.scanner.Text()))
 		if input == "" {
-			return multiSelectDefault(options, defaultAll)
+			return append([]int(nil), defaultIdxs...)
 		}
 		if input == "all" {
 			all := make([]int, len(options))
@@ -199,4 +203,40 @@ func multiSelectDefault(options []string, defaultAll bool) []int {
 		return all
 	}
 	return []int{}
+}
+
+func normalizeMultiSelectIndices(indices []int, optionCount int) []int {
+	seen := make(map[int]bool, len(indices))
+	result := make([]int, 0, len(indices))
+	for _, idx := range indices {
+		if idx < 0 || idx >= optionCount || seen[idx] {
+			continue
+		}
+		seen[idx] = true
+		result = append(result, idx)
+	}
+	return result
+}
+
+func multiSelectPromptDefault(options []string, defaultIdxs []int) string {
+	if len(defaultIdxs) == 0 {
+		return "none"
+	}
+	if len(defaultIdxs) == len(options) {
+		all := true
+		for i, idx := range defaultIdxs {
+			if idx != i {
+				all = false
+				break
+			}
+		}
+		if all {
+			return "all"
+		}
+	}
+	parts := make([]string, len(defaultIdxs))
+	for i, idx := range defaultIdxs {
+		parts[i] = strconv.Itoa(idx + 1)
+	}
+	return strings.Join(parts, ",")
 }

--- a/scheduler/prompt_test.go
+++ b/scheduler/prompt_test.go
@@ -131,6 +131,38 @@ func TestPrompterMultiSelect(t *testing.T) {
 	}
 }
 
+func TestPrompterMultiSelectWithDefaults(t *testing.T) {
+	options := []string{"A", "B", "C", "D"}
+
+	cases := []struct {
+		name        string
+		input       string
+		defaultIdxs []int
+		want        []int
+	}{
+		{"empty uses custom defaults", "\n", []int{1, 3}, []int{1, 3}},
+		{"eof uses custom defaults", "", []int{2}, []int{2}},
+		{"none overrides defaults", "none\n", []int{1}, []int{}},
+		{"explicit selection overrides defaults", "1,4\n", []int{1}, []int{0, 3}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, _ := newTestPrompter(tc.input)
+			got := p.MultiSelectWithDefaults("Pick items:", options, tc.defaultIdxs)
+			if len(got) != len(tc.want) {
+				t.Errorf("MultiSelectWithDefaults() len = %d, want %d", len(got), len(tc.want))
+				return
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("MultiSelectWithDefaults()[%d] = %d, want %d", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestPrompterFloat(t *testing.T) {
 	cases := []struct {
 		name       string


### PR DESCRIPTION
## Summary
- default `go-trader init` to a minimal starter config for BTC spot with the `momentum` strategy
- make the interactive wizard use starter defaults when the user presses Enter on the asset, strategy-type, and spot-strategy prompts
- add regression coverage for the new prompt defaulting and JSON init fallback behavior

## Testing
- `/opt/homebrew/bin/go build .`
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go test ./...`

## Metadata
- model: `gpt-5.4`
- effort: `high`

Closes #393