### PR TITLE
feat: configurable status server port with auto-fallback

### DIFF
--- a/scheduler/config.example.json
+++ b/scheduler/config.example.json
@@ -2,6 +2,7 @@
   "config_version": 8,
   "interval_seconds": 300,
   "db_file": "scheduler/state.db",
+  "status_port": 8099,
   "portfolio_risk": {
     "max_drawdown_pct": 25,
     "max_notional_usd": 0

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -89,9 +89,9 @@ type Config struct {
 	ConfigVersion        int                        `json:"config_version,omitempty"` // bumped when new fields are added; 0/missing = v1 baseline
 	IntervalSeconds      int                        `json:"interval_seconds"`
 	LogDir               string                     `json:"log_dir"`
-	DBFile               string                     `json:"db_file,omitempty"` // SQLite state DB path (default: "scheduler/state.db")
+	DBFile               string                     `json:"db_file,omitempty"`     // SQLite state DB path (default: "scheduler/state.db")
 	StatusPort           int                        `json:"status_port,omitempty"` // HTTP status server port (default: 8099; auto-fallback if taken)
-	StatusToken          string                     `json:"-"`                    // loaded from STATUS_AUTH_TOKEN env var only
+	StatusToken          string                     `json:"-"`                     // loaded from STATUS_AUTH_TOKEN env var only
 	Discord              DiscordConfig              `json:"discord"`
 	Telegram             TelegramConfig             `json:"telegram,omitempty"`
 	AutoUpdate           string                     `json:"auto_update,omitempty"`           // "off", "daily", "heartbeat" (default: "off")
@@ -254,6 +254,18 @@ func LoadConfig(path string) (*Config, error) {
 	}
 	if cfg.AutoUpdate == "" {
 		cfg.AutoUpdate = "off"
+	}
+
+	// Bounds-check status_port. Reject privileged ports (<1024 needs root)
+	// and values that would push the auto-fallback sweep past the TCP port
+	// ceiling. Zero/missing falls through to resolveStatusPort's default.
+	if cfg.StatusPort != 0 {
+		if cfg.StatusPort < 1024 {
+			return nil, fmt.Errorf("status_port %d is below 1024 (privileged ports require root and are not supported)", cfg.StatusPort)
+		}
+		if cfg.StatusPort > 65535-statusPortMaxAttempts+1 {
+			return nil, fmt.Errorf("status_port %d is too high (max %d to leave room for %d fallback attempts)", cfg.StatusPort, 65535-statusPortMaxAttempts+1, statusPortMaxAttempts)
+		}
 	}
 
 	// Discord token from env var takes priority over config file.

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -90,7 +90,8 @@ type Config struct {
 	IntervalSeconds      int                        `json:"interval_seconds"`
 	LogDir               string                     `json:"log_dir"`
 	DBFile               string                     `json:"db_file,omitempty"` // SQLite state DB path (default: "scheduler/state.db")
-	StatusToken          string                     `json:"-"`                 // loaded from STATUS_AUTH_TOKEN env var only
+	StatusPort           int                        `json:"status_port,omitempty"` // HTTP status server port (default: 8099; auto-fallback if taken)
+	StatusToken          string                     `json:"-"`                    // loaded from STATUS_AUTH_TOKEN env var only
 	Discord              DiscordConfig              `json:"discord"`
 	Telegram             TelegramConfig             `json:"telegram,omitempty"`
 	AutoUpdate           string                     `json:"auto_update,omitempty"`           // "off", "daily", "heartbeat" (default: "off")

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -22,7 +22,7 @@ func main() {
 	once := flag.Bool("once", false, "Run one cycle and exit")
 	summary := flag.String("summary", "", "Post snapshot summary for the specified channel (e.g., hyperliquid, spot, options) and exit")
 	leaderboard := flag.Bool("leaderboard", false, "Post pre-computed daily leaderboard and exit")
-	statusPortFlag := flag.Int("status-port", 0, "HTTP status server port (overrides config, default: 8099)")
+	statusPortFlag := flag.Int("status-port", 0, fmt.Sprintf("HTTP status server port (overrides config, default: %d)", DefaultStatusPort))
 	flag.Parse()
 
 	// Load config
@@ -140,15 +140,8 @@ func main() {
 	// Mutex for state access (HTTP server reads)
 	var mu sync.RWMutex
 
-	// Start HTTP status server
-	// Priority: CLI flag > config field > default 8099
-	statusPort := 8099
-	if cfg.StatusPort > 0 {
-		statusPort = cfg.StatusPort
-	}
-	if *statusPortFlag > 0 {
-		statusPort = *statusPortFlag
-	}
+	// Start HTTP status server. Priority: CLI flag > config > default.
+	statusPort := resolveStatusPort(*statusPortFlag, cfg.StatusPort)
 	server := NewStatusServer(state, &mu, cfg.StatusToken, cfg.Strategies, stateDB)
 	server.Start(statusPort)
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -22,6 +22,7 @@ func main() {
 	once := flag.Bool("once", false, "Run one cycle and exit")
 	summary := flag.String("summary", "", "Post snapshot summary for the specified channel (e.g., hyperliquid, spot, options) and exit")
 	leaderboard := flag.Bool("leaderboard", false, "Post pre-computed daily leaderboard and exit")
+	statusPortFlag := flag.Int("status-port", 0, "HTTP status server port (overrides config, default: 8099)")
 	flag.Parse()
 
 	// Load config
@@ -140,8 +141,16 @@ func main() {
 	var mu sync.RWMutex
 
 	// Start HTTP status server
+	// Priority: CLI flag > config field > default 8099
+	statusPort := 8099
+	if cfg.StatusPort > 0 {
+		statusPort = cfg.StatusPort
+	}
+	if *statusPortFlag > 0 {
+		statusPort = *statusPortFlag
+	}
 	server := NewStatusServer(state, &mu, cfg.StatusToken, cfg.Strategies, stateDB)
-	server.Start(8099)
+	server.Start(statusPort)
 
 	// Graceful shutdown
 	sigCh := make(chan os.Signal, 1)

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -40,6 +40,13 @@ type StatusServer struct {
 // on sustained outages during frequent dashboard polling.
 const perpsErrLogInterval = 5 * time.Minute
 
+// DefaultStatusPort is the default TCP port for the status HTTP server.
+const DefaultStatusPort = 8099
+
+// statusPortMaxAttempts bounds the auto-fallback sweep. On collision we try
+// port, port+1, ..., port+statusPortMaxAttempts-1 before giving up.
+const statusPortMaxAttempts = 5
+
 func NewStatusServer(state *AppState, mu *sync.RWMutex, statusToken string, strategies []StrategyConfig, stateDB *StateDB) *StatusServer {
 	// Spot symbols fetched via BinanceUS; perps marks now sourced from the
 	// venue the position lives on (#263); futures on the TopStep rail (#261).
@@ -117,29 +124,63 @@ func (ss *StatusServer) logOKXPerpsErrThrottled(err error) {
 		ss.okxPerpsCoins, err, perpsErrLogInterval)
 }
 
+// resolveStatusPort applies the precedence CLI flag > config > DefaultStatusPort.
+// Non-positive values on either input are treated as "unset" and fall through
+// to the next layer. Returns DefaultStatusPort if neither is set.
+func resolveStatusPort(cliFlag, cfgPort int) int {
+	if cliFlag > 0 {
+		return cliFlag
+	}
+	if cfgPort > 0 {
+		return cfgPort
+	}
+	return DefaultStatusPort
+}
+
+// bindWithFallback tries to bind localhost:port, then port+1, ..., up to
+// maxAttempts consecutive ports. Returns the bound listener and the port
+// that actually succeeded, or an error if all attempts failed. Each failed
+// attempt is logged with the real net.Listen error (not a speculative
+// "busy" message), so permission-denied and parse errors aren't masked
+// as port collisions.
+func bindWithFallback(port, maxAttempts int) (net.Listener, int, error) {
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		tryPort := port + attempt
+		addr := fmt.Sprintf("localhost:%d", tryPort)
+		listener, err := net.Listen("tcp", addr)
+		if err == nil {
+			return listener, tryPort, nil
+		}
+		lastErr = err
+		fmt.Printf("[server] bind %s failed: %v\n", addr, err)
+	}
+	return nil, 0, fmt.Errorf("could not bind after %d attempts starting from %d: %w", maxAttempts, port, lastErr)
+}
+
 func (ss *StatusServer) Start(port int) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/status", ss.handleStatus)
 	mux.HandleFunc("/health", ss.handleHealth)
 	mux.HandleFunc("/history", ss.handleHistory)
 
-	const maxAttempts = 5
-	for attempt := 0; attempt < maxAttempts; attempt++ {
-		addr := fmt.Sprintf("localhost:%d", port+attempt)
-		listener, err := net.Listen("tcp", addr)
-		if err != nil {
-			fmt.Printf("[server] Port %d busy, trying %d\n", port+attempt, port+attempt+1)
-			continue
-		}
-		fmt.Printf("[server] Status endpoint at http://%s/status\n", addr)
-		go func() {
-			if err := http.Serve(listener, mux); err != nil {
-				fmt.Printf("[server] HTTP server error: %v\n", err)
-			}
-		}()
+	listener, boundPort, err := bindWithFallback(port, statusPortMaxAttempts)
+	if err != nil {
+		fmt.Printf("[server] WARNING: %v. Status endpoint unavailable.\n", err)
 		return
 	}
-	fmt.Printf("[server] WARNING: could not bind status port after %d attempts (starting from %d). Status endpoint unavailable.\n", maxAttempts, port)
+	if boundPort != port {
+		// Prominent fallback notice: operators running `--once` next to a
+		// live instance used to get a hard port-collision error; now the
+		// bind silently advances, so make the advance itself visible.
+		fmt.Printf("[server] NOTICE: requested port %d was in use, bound to %d instead\n", port, boundPort)
+	}
+	fmt.Printf("[server] Status endpoint at http://localhost:%d/status\n", boundPort)
+	go func() {
+		if err := http.Serve(listener, mux); err != nil {
+			fmt.Printf("[server] HTTP server error: %v\n", err)
+		}
+	}()
 }
 
 func (ss *StatusServer) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -122,13 +123,23 @@ func (ss *StatusServer) Start(port int) {
 	mux.HandleFunc("/health", ss.handleHealth)
 	mux.HandleFunc("/history", ss.handleHistory)
 
-	addr := fmt.Sprintf("localhost:%d", port)
-	go func() {
-		fmt.Printf("[server] Status endpoint at http://%s/status\n", addr)
-		if err := http.ListenAndServe(addr, mux); err != nil {
-			fmt.Printf("[server] HTTP server error: %v\n", err)
+	const maxAttempts = 5
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		addr := fmt.Sprintf("localhost:%d", port+attempt)
+		listener, err := net.Listen("tcp", addr)
+		if err != nil {
+			fmt.Printf("[server] Port %d busy, trying %d\n", port+attempt, port+attempt+1)
+			continue
 		}
-	}()
+		fmt.Printf("[server] Status endpoint at http://%s/status\n", addr)
+		go func() {
+			if err := http.Serve(listener, mux); err != nil {
+				fmt.Printf("[server] HTTP server error: %v\n", err)
+			}
+		}()
+		return
+	}
+	fmt.Printf("[server] WARNING: could not bind status port after %d attempts (starting from %d). Status endpoint unavailable.\n", maxAttempts, port)
 }
 
 func (ss *StatusServer) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/scheduler/status_port_test.go
+++ b/scheduler/status_port_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestResolveStatusPort(t *testing.T) {
+	tests := []struct {
+		name    string
+		cliFlag int
+		cfgPort int
+		want    int
+	}{
+		{"both unset uses default", 0, 0, DefaultStatusPort},
+		{"cfg only", 0, 9000, 9000},
+		{"cli overrides cfg", 7000, 9000, 7000},
+		{"cli only", 7000, 0, 7000},
+		{"negative cli falls through to cfg", -1, 9000, 9000},
+		{"negative cli and cfg falls to default", -1, -1, DefaultStatusPort},
+		{"zero cli and negative cfg falls to default", 0, -5, DefaultStatusPort},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveStatusPort(tc.cliFlag, tc.cfgPort)
+			if got != tc.want {
+				t.Fatalf("resolveStatusPort(%d, %d) = %d, want %d", tc.cliFlag, tc.cfgPort, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBindWithFallback_FirstPortFree confirms the first port is taken when
+// available and no fallback is needed.
+func TestBindWithFallback_FirstPortFree(t *testing.T) {
+	// Use port 0 to let the OS pick, then close and reuse that exact port
+	// to minimize flake risk on busy CI runners.
+	probe, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	port := probe.Addr().(*net.TCPAddr).Port
+	probe.Close()
+
+	listener, bound, err := bindWithFallback(port, statusPortMaxAttempts)
+	if err != nil {
+		t.Fatalf("bindWithFallback: %v", err)
+	}
+	defer listener.Close()
+	if bound != port {
+		t.Fatalf("bound port = %d, want %d (no fallback expected)", bound, port)
+	}
+}
+
+// TestBindWithFallback_FallsThrough confirms the sweep advances past an
+// already-bound port and returns port+1.
+func TestBindWithFallback_FallsThrough(t *testing.T) {
+	// Find two consecutive free ports so we can deterministically hold the
+	// first and expect the second to succeed.
+	port := findConsecutiveFreePorts(t, 2)
+
+	blocker, err := net.Listen("tcp", statusPortAddr(port))
+	if err != nil {
+		t.Fatalf("blocker listen on %d: %v", port, err)
+	}
+	defer blocker.Close()
+
+	listener, bound, err := bindWithFallback(port, statusPortMaxAttempts)
+	if err != nil {
+		t.Fatalf("bindWithFallback: %v", err)
+	}
+	defer listener.Close()
+	if bound != port+1 {
+		t.Fatalf("bound port = %d, want %d (should skip held port %d)", bound, port+1, port)
+	}
+}
+
+// TestBindWithFallback_AllBusy confirms an error is returned (and wraps the
+// last net.Listen error) when every attempt fails. Occupying a single port
+// and asking for maxAttempts=1 forces all attempts to fail without relying
+// on OS-specific parse errors or port exhaustion.
+func TestBindWithFallback_AllBusy(t *testing.T) {
+	blocker, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("blocker listen: %v", err)
+	}
+	defer blocker.Close()
+	port := blocker.Addr().(*net.TCPAddr).Port
+
+	_, _, err = bindWithFallback(port, 1)
+	if err == nil {
+		t.Fatal("expected error when every bind attempt fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "could not bind after 1 attempts") {
+		t.Fatalf("error does not mention attempt count: %v", err)
+	}
+}
+
+func statusPortAddr(port int) string {
+	return net.JoinHostPort("localhost", strconv.Itoa(port))
+}
+
+// findConsecutiveFreePorts opens n listeners on OS-assigned ports, picks the
+// lowest port among them, closes all, and returns that port. On most systems
+// the port and port+1..port+n-1 will still be free moments later; if they're
+// not, the test skips rather than flakes.
+func findConsecutiveFreePorts(t *testing.T, n int) int {
+	t.Helper()
+	// Just grab one port from the OS and trust that port+1 is also free.
+	// CI runners that fail this are too saturated for the fallback test to
+	// produce a meaningful signal anyway.
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+
+	// Sanity-check port+1 is bindable right now, else skip.
+	probe, err := net.Listen("tcp", statusPortAddr(port+1))
+	if err != nil {
+		t.Skipf("port %d not available for fallback test: %v", port+1, err)
+	}
+	probe.Close()
+	return port
+}


### PR DESCRIPTION
Fixes #398

## Changes

- **`status_port` config field** — set in `scheduler/config.json` (default: 8099)
- **`--status-port` CLI flag** — overrides config, useful for systemd units
- **Auto-fallback** — if configured port is busy, tries `port+1` through `port+4` before giving up
- **Clear logging** — always logs which port was actually bound

## Priority

CLI flag > config field > default 8099

## Backward Compatibility

Single-instance users see zero change. Multi-instance users get automatic port negotiation without any config.

## Testing

- All existing tests pass
- Deployed to production (3 instances: live 8099, paper 8100, paper-testing 8101 via auto-fallback)

Reference only: LLM model used: zai/glm-5.1