### PR TITLE
feat: include go-trader version in Discord summary titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ curl -LsSf https://astral.sh/uv/install.sh | sh   # install uv if needed
 uv sync                                             # creates .venv from lockfile
 
 # 3. Build (requires Go 1.26.2)
-cd scheduler && go build -o ../go-trader . && cd ..
+VER=$(git describe --tags --always --dirty 2>/dev/null || echo dev)
+cd scheduler && go build -ldflags "-X main.Version=$VER" -o ../go-trader . && cd ..
 
 # 4. Generate config
 ./go-trader init                                    # interactive wizard (recommended)
@@ -429,7 +430,7 @@ Closes sold options early based on profit target, stop loss, or approaching expi
 
 | Change | Action |
 |--------|--------|
-| Go code (`scheduler/*.go`) | `cd scheduler && go build -o ../go-trader . && systemctl restart go-trader` |
+| Go code (`scheduler/*.go`) | `VER=$(git describe --tags --always --dirty); cd scheduler && go build -ldflags "-X main.Version=$VER" -o ../go-trader . && systemctl restart go-trader` |
 | Python scripts | `systemctl restart go-trader` (or wait for next cycle) |
 | Config changes | `systemctl restart go-trader` |
 | Service file changes | `systemctl daemon-reload && systemctl restart go-trader` |

--- a/SKILL.md
+++ b/SKILL.md
@@ -95,7 +95,8 @@ No user input needed for this step.
 Before proceeding with Steps 4–7 (manual config), build the binary first so the wizard is available:
 
 ```bash
-cd scheduler && /usr/local/go/bin/go build -o ../go-trader . && cd ..
+VER=$(git describe --tags --always --dirty 2>/dev/null || echo dev)
+cd scheduler && /usr/local/go/bin/go build -ldflags "-X main.Version=$VER" -o ../go-trader . && cd ..
 ```
 
 Then run the interactive wizard:
@@ -450,10 +451,13 @@ If no, ask which part they want to change and loop back to the relevant step.
 ### 8a. Build Go Binary
 ```bash
 cd scheduler
-/usr/local/go/bin/go build -o ../go-trader .
+VER=$(git -C .. describe --tags --always --dirty 2>/dev/null || echo dev)
+/usr/local/go/bin/go build -ldflags "-X main.Version=$VER" -o ../go-trader .
 cd ..
 ```
-If `go` is in PATH, just use `go build`. Check both.
+If `go` is in PATH, just use `go build`. Check both. The `-ldflags` stamp
+surfaces the current revision in Discord summary titles (e.g. `(v1.2.3)`);
+without it the binary reports as `(dev)`.
 
 **Verify:** `./go-trader --help` should print usage.
 
@@ -533,7 +537,8 @@ The scheduler will not re-notify for the same remote version until a newer one a
 **Manual update (always works regardless of setting):**
 ```bash
 cd /path/to/go-trader && git pull --ff-only
-cd scheduler && /usr/local/go/bin/go build -o ../go-trader . && cd ..
+VER=$(git describe --tags --always --dirty 2>/dev/null || echo dev)
+cd scheduler && /usr/local/go/bin/go build -ldflags "-X main.Version=$VER" -o ../go-trader . && cd ..
 sudo systemctl restart go-trader
 ```
 

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -290,10 +290,14 @@ func FormatCategorySummary(
 			assetSuffix = " — " + asset
 		}
 	}
+	verSuffix := ""
+	if Version != "" {
+		verSuffix = " (" + Version + ")"
+	}
 	if totalTrades > 0 {
-		sb.WriteString(fmt.Sprintf("%s **%s TRADES%s** (%s)\n", icon, strings.ToUpper(title), assetSuffix, Version))
+		sb.WriteString(fmt.Sprintf("%s **%s TRADES%s**%s\n", icon, strings.ToUpper(title), assetSuffix, verSuffix))
 	} else {
-		sb.WriteString(fmt.Sprintf("%s **%s Summary%s** (%s)\n", icon, title, assetSuffix, Version))
+		sb.WriteString(fmt.Sprintf("%s **%s Summary%s**%s\n", icon, title, assetSuffix, verSuffix))
 	}
 
 	sb.WriteString(fmt.Sprintf("Cycle #%d | %.1fs\n", cycle, elapsed.Seconds()))

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -291,9 +291,9 @@ func FormatCategorySummary(
 		}
 	}
 	if totalTrades > 0 {
-		sb.WriteString(fmt.Sprintf("%s **%s TRADES%s**\n", icon, strings.ToUpper(title), assetSuffix))
+		sb.WriteString(fmt.Sprintf("%s **%s TRADES%s** (%s)\n", icon, strings.ToUpper(title), assetSuffix, Version))
 	} else {
-		sb.WriteString(fmt.Sprintf("%s **%s Summary%s**\n", icon, title, assetSuffix))
+		sb.WriteString(fmt.Sprintf("%s **%s Summary%s** (%s)\n", icon, title, assetSuffix, Version))
 	}
 
 	sb.WriteString(fmt.Sprintf("Cycle #%d | %.1fs\n", cycle, elapsed.Seconds()))

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -182,6 +182,45 @@ func TestFormatCategorySummary_WithAsset(t *testing.T) {
 	}
 }
 
+// TestFormatCategorySummary_VersionSuffix guards that summary and trade titles
+// include the package-level Version so /upgrade can surface which revision is
+// running. Also covers the empty-Version edge case where the suffix should be
+// omitted entirely (no trailing "()").
+func TestFormatCategorySummary_VersionSuffix(t *testing.T) {
+	strats := []StrategyConfig{
+		{ID: "hl-rsi-btc", Type: "perps", Args: []string{"rsi", "BTC", "1h"}, Capital: 1000},
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-rsi-btc": {Cash: 1000},
+		},
+	}
+	prices := map[string]float64{"BTC/USDT": 50000}
+
+	orig := Version
+	defer func() { Version = orig }()
+
+	Version = "v9.9.9-test"
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+	summary := strings.Join(msgs, "\n")
+	if !strings.Contains(summary, "("+Version+")") {
+		t.Errorf("expected version %q in summary title, got:\n%s", Version, summary)
+	}
+
+	msgs = FormatCategorySummary(1, 0, 1, 3, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+	trades := strings.Join(msgs, "\n")
+	if !strings.Contains(trades, "("+Version+")") {
+		t.Errorf("expected version %q in trades title, got:\n%s", Version, trades)
+	}
+
+	Version = ""
+	msgs = FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+	empty := strings.Join(msgs, "\n")
+	if strings.Contains(empty, "()") {
+		t.Errorf("empty Version should omit the suffix, got:\n%s", empty)
+	}
+}
+
 func TestFormatCategorySummary_CircuitBreakerActive(t *testing.T) {
 	strats := []StrategyConfig{
 		{ID: "hl-rsi-btc", Type: "perps", Args: []string{"rsi", "BTC", "1h"}, Capital: 1000},

--- a/scheduler/updater.go
+++ b/scheduler/updater.go
@@ -105,7 +105,9 @@ func applyUpgrade(notifier *MultiNotifier, mu *sync.RWMutex, state *AppState, cf
 	}
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel2()
-	buildCmd := exec.CommandContext(ctx2, goBinary, "build", "-o", "../go-trader", ".")
+	ver := resolveBuildVersion()
+	buildArgs := []string{"build", "-ldflags", "-X main.Version=" + ver, "-o", "../go-trader", "."}
+	buildCmd := exec.CommandContext(ctx2, goBinary, buildArgs...)
 	buildCmd.Dir = "scheduler"
 	buildOut, buildErr := buildCmd.CombinedOutput()
 	if buildErr != nil {

--- a/scheduler/version.go
+++ b/scheduler/version.go
@@ -1,5 +1,27 @@
 package main
 
+import (
+	"os/exec"
+	"strings"
+)
+
 // Version is set at build time via -ldflags "-X main.Version=vX.Y.Z".
 // Falls back to "dev" for local builds.
 var Version = "dev"
+
+// resolveBuildVersion returns a version string for stamping a rebuilt binary
+// during in-app upgrade. Uses `git describe --tags --always --dirty` so the
+// auto-upgrade path preserves the version label it was meant to surface
+// (otherwise every /upgrade reverts Version to "dev"). Falls back to "dev"
+// when git is unavailable or the repo has no reachable commits.
+func resolveBuildVersion() string {
+	out, err := exec.Command("git", "describe", "--tags", "--always", "--dirty").Output()
+	if err != nil {
+		return "dev"
+	}
+	v := strings.TrimSpace(string(out))
+	if v == "" {
+		return "dev"
+	}
+	return v
+}

--- a/scheduler/version.go
+++ b/scheduler/version.go
@@ -1,0 +1,5 @@
+package main
+
+// Version is set at build time via -ldflags "-X main.Version=vX.Y.Z".
+// Falls back to "dev" for local builds.
+var Version = "dev"


### PR DESCRIPTION
Adds a `Version` variable (defaulting to "dev") settable at build time via `-ldflags "-X main.Version=vX.Y.Z"`. All summary titles now append the version in parentheses after the channel name and optional asset suffix, covering spot, options, hyperliquid, and futures summaries.

Closes #400

Generated with [Claude Code](https://claude.ai/code)