### PR TITLE
feat: rewrite Create PR link body to use model/effort footer

### DIFF
--- a/.github/scripts/rewrite_create_pr_link.py
+++ b/.github/scripts/rewrite_create_pr_link.py
@@ -1,0 +1,46 @@
+"""Rewrite the "Create PR" link inside a claude[bot] comment so the prefilled
+PR body ends with our model/effort footer instead of the default
+"Generated with [Claude Code](...)" attribution.
+
+Reads the comment body from $BODY_IN and the footer text from $FOOTER_TEXT.
+Prints the rewritten comment body to stdout.
+"""
+
+import os
+import re
+import sys
+import urllib.parse
+
+body = os.environ["BODY_IN"]
+footer = os.environ["FOOTER_TEXT"]
+
+default_attr = re.compile(
+    r"\n*Generated with \[Claude Code\]\(https://claude\.com/claude-code\)\s*\Z"
+)
+
+
+def rewrite(match):
+    url = match.group(1)
+    parts = urllib.parse.urlsplit(url)
+    qs = urllib.parse.parse_qsl(parts.query, keep_blank_values=True)
+    new_qs = []
+    for k, v in qs:
+        if k == "body":
+            if default_attr.search(v):
+                v = default_attr.sub("\n\n" + footer, v)
+            else:
+                v = v.rstrip() + "\n\n" + footer
+        new_qs.append((k, v))
+    new_query = urllib.parse.urlencode(new_qs, quote_via=urllib.parse.quote)
+    new_url = urllib.parse.urlunsplit(
+        (parts.scheme, parts.netloc, parts.path, new_query, parts.fragment)
+    )
+    return "(" + new_url + ")"
+
+
+body = re.sub(
+    r"\((https://github\.com/[^)\s]*compare/[^)\s]*[?&]quick_pull=1[^)\s]*)\)",
+    rewrite,
+    body,
+)
+sys.stdout.write(body)

--- a/.github/scripts/rewrite_create_pr_link.py
+++ b/.github/scripts/rewrite_create_pr_link.py
@@ -4,6 +4,12 @@ PR body ends with our model/effort footer instead of the default
 
 Reads the comment body from $BODY_IN and the footer text from $FOOTER_TEXT.
 Prints the rewritten comment body to stdout.
+
+Not idempotent on its own: if a Create-PR link's `body=` already ends with a
+`Generated with: ...` footer (not the default Claude Code attribution), the
+else-branch in `rewrite` will append a second footer. The caller in
+.github/workflows/claude.yml guards against re-runs with a
+`grep -q "Generated with:"` check before invoking this script.
 """
 
 import os
@@ -31,7 +37,7 @@ def rewrite(match):
             else:
                 v = v.rstrip() + "\n\n" + footer
         new_qs.append((k, v))
-    new_query = urllib.parse.urlencode(new_qs, quote_via=urllib.parse.quote)
+    new_query = urllib.parse.urlencode(new_qs, safe="", quote_via=urllib.parse.quote)
     new_url = urllib.parse.urlunsplit(
         (parts.scheme, parts.netloc, parts.path, new_query, parts.fragment)
     )
@@ -44,3 +50,4 @@ body = re.sub(
     body,
 )
 sys.stdout.write(body)
+sys.stdout.write("\n")

--- a/.github/scripts/test_rewrite_create_pr_link.py
+++ b/.github/scripts/test_rewrite_create_pr_link.py
@@ -1,0 +1,97 @@
+"""Unit tests for rewrite_create_pr_link.py.
+
+Invokes the script as a subprocess with BODY_IN/FOOTER_TEXT env vars and
+asserts the rewritten stdout — covers the default-attribution replacement,
+fallback append, no-link no-op, and multi-link cases.
+
+Run: python3 .github/scripts/test_rewrite_create_pr_link.py
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+import urllib.parse
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "rewrite_create_pr_link.py")
+FOOTER = "---\nGenerated with: Claude Opus 4.7 (1M) | Effort: high"
+
+
+def run(body_in, footer=FOOTER):
+    result = subprocess.run(
+        [sys.executable, SCRIPT],
+        env={**os.environ, "BODY_IN": body_in, "FOOTER_TEXT": footer},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.rstrip("\n")
+
+
+def extract_body_param(markdown):
+    """Pull the `body=` query param out of the first Create-PR link."""
+    start = markdown.index("(https://github.com/")
+    end = markdown.index(")", start)
+    url = markdown[start + 1 : end]
+    qs = urllib.parse.parse_qs(urllib.parse.urlsplit(url).query, keep_blank_values=True)
+    return qs["body"][0]
+
+
+class RewriteCreatePRLinkTest(unittest.TestCase):
+    def test_replaces_default_attribution(self):
+        default_attr = "Generated with [Claude Code](https://claude.com/claude-code)"
+        pr_body = f"## Summary\n- did a thing\n\n{default_attr}"
+        encoded = urllib.parse.quote(pr_body, safe="")
+        comment = f"See [Create PR ➔](https://github.com/owner/repo/compare/main...feat?quick_pull=1&title=x&body={encoded})"
+
+        out = run(comment)
+        new_body = extract_body_param(out)
+
+        self.assertNotIn("claude.com/claude-code", new_body)
+        self.assertTrue(new_body.endswith(FOOTER))
+        self.assertIn("## Summary", new_body)
+
+    def test_appends_when_no_default_attribution(self):
+        pr_body = "## Summary\n- did a thing"
+        encoded = urllib.parse.quote(pr_body, safe="")
+        comment = f"[Create PR](https://github.com/owner/repo/compare/main...feat?quick_pull=1&body={encoded})"
+
+        out = run(comment)
+        new_body = extract_body_param(out)
+
+        self.assertTrue(new_body.endswith(FOOTER))
+        self.assertIn("## Summary", new_body)
+        self.assertEqual(new_body.count("Generated with:"), 1)
+
+    def test_no_link_leaves_body_unchanged(self):
+        comment = "Just a plain comment with no Create PR link."
+        self.assertEqual(run(comment), comment)
+
+    def test_rewrites_multiple_links(self):
+        pr_body = "## Summary"
+        encoded = urllib.parse.quote(pr_body, safe="")
+        link = f"(https://github.com/owner/repo/compare/main...feat?quick_pull=1&body={encoded})"
+        comment = f"first {link} and second {link}"
+
+        out = run(comment)
+        # `Generated with:` appears URL-encoded inside the `body=` param —
+        # decode the whole output to count occurrences across both links.
+        self.assertEqual(urllib.parse.unquote(out).count("Generated with:"), 2)
+
+    def test_non_idempotent_without_shell_guard(self):
+        """Documents the idempotency caveat: running twice appends twice.
+        The shell guard in claude.yml (grep -q 'Generated with:') is what
+        prevents this in production."""
+        pr_body = "## Summary"
+        encoded = urllib.parse.quote(pr_body, safe="")
+        comment = f"[x](https://github.com/owner/repo/compare/main...feat?quick_pull=1&body={encoded})"
+
+        once = run(comment)
+        twice = run(once)
+
+        self.assertEqual(urllib.parse.unquote(once).count("Generated with:"), 1)
+        self.assertEqual(urllib.parse.unquote(twice).count("Generated with:"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -235,6 +235,11 @@ jobs:
 
           NEW_BODY="${BODY}"$'\n\n'"${FOOTER}"
 
+          # Rewrite the "Create PR" link's prefilled `body=` query param so the PR
+          # description ends with our model/effort footer instead of the default
+          # "Generated with [Claude Code](https://claude.com/claude-code)" line.
+          NEW_BODY=$(BODY_IN="$NEW_BODY" FOOTER_TEXT="$FOOTER" python3 .github/scripts/rewrite_create_pr_link.py)
+
           gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
             --method PATCH \
             --field body="$NEW_BODY"


### PR DESCRIPTION
## Summary
- When the claude[bot] comment footer step patches the issue comment, it now also rewrites the prefilled `body=` query param of any "Create PR ➔" link in that comment
- The PR description that prefills when clicking "Create PR" will end with `Generated with: Claude Opus 4.7 (1M) | Effort: high` (or whichever model/effort was used) instead of the default `Generated with [Claude Code](https://claude.com/claude-code)` line
- Rewrite logic extracted to `.github/scripts/rewrite_create_pr_link.py` (stdlib only, no deps) — keeps the workflow YAML clean and the heredoc-in-subshell YAML indentation problem avoided

## Test plan
- Trigger `@claude` on an issue and wait for the bot to complete
- Inspect the comment — the "Create PR ➔" link URL's `body=` param should end with the model/effort footer when URL-decoded
- Click "Create PR" and confirm the prefilled PR description ends with `Generated with: ...` footer, not the default Claude Code attribution

---
Generated with: Claude Opus 4.7 (1M) | Effort: high