### PR TITLE
chore: rename footer label to 'LLM:' and drop Effort field

### DIFF
--- a/.github/scripts/rewrite_create_pr_link.py
+++ b/.github/scripts/rewrite_create_pr_link.py
@@ -6,10 +6,10 @@ Reads the comment body from $BODY_IN and the footer text from $FOOTER_TEXT.
 Prints the rewritten comment body to stdout.
 
 Not idempotent on its own: if a Create-PR link's `body=` already ends with a
-`Generated with: ...` footer (not the default Claude Code attribution), the
+`LLM: ...` footer (not the default Claude Code attribution), the
 else-branch in `rewrite` will append a second footer. The caller in
 .github/workflows/claude.yml guards against re-runs with a
-`grep -q "Generated with:"` check before invoking this script.
+`grep -q "LLM:"` check before invoking this script.
 """
 
 import os

--- a/.github/scripts/test_rewrite_create_pr_link.py
+++ b/.github/scripts/test_rewrite_create_pr_link.py
@@ -14,7 +14,7 @@ import unittest
 import urllib.parse
 
 SCRIPT = os.path.join(os.path.dirname(__file__), "rewrite_create_pr_link.py")
-FOOTER = "---\nGenerated with: Claude Opus 4.7 (1M) | Effort: high"
+FOOTER = "---\nLLM: Claude Opus 4.7 (1M)"
 
 
 def run(body_in, footer=FOOTER):
@@ -61,7 +61,7 @@ class RewriteCreatePRLinkTest(unittest.TestCase):
 
         self.assertTrue(new_body.endswith(FOOTER))
         self.assertIn("## Summary", new_body)
-        self.assertEqual(new_body.count("Generated with:"), 1)
+        self.assertEqual(new_body.count("LLM:"), 1)
 
     def test_no_link_leaves_body_unchanged(self):
         comment = "Just a plain comment with no Create PR link."
@@ -74,13 +74,13 @@ class RewriteCreatePRLinkTest(unittest.TestCase):
         comment = f"first {link} and second {link}"
 
         out = run(comment)
-        # `Generated with:` appears URL-encoded inside the `body=` param —
+        # `LLM:` appears URL-encoded inside the `body=` param —
         # decode the whole output to count occurrences across both links.
-        self.assertEqual(urllib.parse.unquote(out).count("Generated with:"), 2)
+        self.assertEqual(urllib.parse.unquote(out).count("LLM:"), 2)
 
     def test_non_idempotent_without_shell_guard(self):
         """Documents the idempotency caveat: running twice appends twice.
-        The shell guard in claude.yml (grep -q 'Generated with:') is what
+        The shell guard in claude.yml (grep -q 'LLM:') is what
         prevents this in production."""
         pr_body = "## Summary"
         encoded = urllib.parse.quote(pr_body, safe="")
@@ -89,8 +89,8 @@ class RewriteCreatePRLinkTest(unittest.TestCase):
         once = run(comment)
         twice = run(once)
 
-        self.assertEqual(urllib.parse.unquote(once).count("Generated with:"), 1)
-        self.assertEqual(urllib.parse.unquote(twice).count("Generated with:"), 2)
+        self.assertEqual(urllib.parse.unquote(once).count("LLM:"), 1)
+        self.assertEqual(urllib.parse.unquote(twice).count("LLM:"), 2)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_rewrite_create_pr_link.py
+++ b/.github/scripts/test_rewrite_create_pr_link.py
@@ -14,7 +14,7 @@ import unittest
 import urllib.parse
 
 SCRIPT = os.path.join(os.path.dirname(__file__), "rewrite_create_pr_link.py")
-FOOTER = "---\nLLM: Claude Opus 4.7 (1M)"
+FOOTER = "---\nLLM: Claude Opus 4.7 (1M) | high"
 
 
 def run(body_in, footer=FOOTER):

--- a/.github/workflows/Codex.yml
+++ b/.github/workflows/Codex.yml
@@ -293,7 +293,7 @@ jobs:
               return;
             }
 
-            const footer = ["---", "Generated with: GPT-5.4 | Effort: high"];
+            const footer = ["---", "LLM: GPT-5.4"];
             if (process.env.PUSHED === "true" && process.env.PUSH_BRANCH) {
               footer.push(`Pushed changes to \`${process.env.PUSH_BRANCH}\`.`);
             }

--- a/.github/workflows/Codex.yml
+++ b/.github/workflows/Codex.yml
@@ -293,7 +293,7 @@ jobs:
               return;
             }
 
-            const footer = ["---", "LLM: GPT-5.4"];
+            const footer = ["---", "LLM: GPT-5.4 | high"];
             if (process.env.PUSHED === "true" && process.env.PUSH_BRANCH) {
               footer.push(`Pushed changes to \`${process.env.PUSH_BRANCH}\`.`);
             }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -191,12 +191,11 @@ jobs:
             claude-md-management@claude-plugins-official
           claude_args: --model ${{ steps.resolve_model.outputs.model_id }} --allowedTools "Bash(git *),Edit,Read,Grep,Glob,Write"
 
-      - name: Append model/effort footer to Claude comment
+      - name: Append LLM footer to Claude comment
         if: steps.verify_invocation.outputs.invoked == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           MODEL_ID: ${{ steps.resolve_model.outputs.model_id }}
-          EFFORT: ${{ steps.resolve_model.outputs.effort }}
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
@@ -218,7 +217,7 @@ jobs:
             exit 0
           fi
 
-          if echo "$BODY" | grep -q "Generated with:"; then
+          if echo "$BODY" | grep -q "LLM:"; then
             echo "Footer already present"
             exit 0
           fi
@@ -228,7 +227,7 @@ jobs:
           [ -s /tmp/ccusage-err ] && echo "ccusage stderr: $(cat /tmp/ccusage-err)"
           COST=$(printf '%s' "$USAGE" | jq -r 'if .sessions and (.sessions | length) > 0 then .sessions[0] | "Tokens: \(.inputTokens // 0) in / \(.outputTokens // 0) out | Cache: \(.cacheReadTokens // 0) read / \(.cacheCreationTokens // 0) written | Cost: $\(.totalCost // 0 | . * 100 | round / 100)" else "" end' 2>/dev/null || true)
 
-          FOOTER="---"$'\n'"Generated with: ${MODEL_NAME} | Effort: ${EFFORT}"
+          FOOTER="---"$'\n'"LLM: ${MODEL_NAME}"
           if [ -n "$COST" ]; then
             FOOTER="${FOOTER} | ${COST}"
           fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -196,6 +196,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           MODEL_ID: ${{ steps.resolve_model.outputs.model_id }}
+          EFFORT: ${{ steps.resolve_model.outputs.effort }}
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
@@ -227,7 +228,7 @@ jobs:
           [ -s /tmp/ccusage-err ] && echo "ccusage stderr: $(cat /tmp/ccusage-err)"
           COST=$(printf '%s' "$USAGE" | jq -r 'if .sessions and (.sessions | length) > 0 then .sessions[0] | "Tokens: \(.inputTokens // 0) in / \(.outputTokens // 0) out | Cache: \(.cacheReadTokens // 0) read / \(.cacheCreationTokens // 0) written | Cost: $\(.totalCost // 0 | . * 100 | round / 100)" else "" end' 2>/dev/null || true)
 
-          FOOTER="---"$'\n'"LLM: ${MODEL_NAME}"
+          FOOTER="---"$'\n'"LLM: ${MODEL_NAME} | ${EFFORT}"
           if [ -n "$COST" ]; then
             FOOTER="${FOOTER} | ${COST}"
           fi


### PR DESCRIPTION
## Summary

- Replace `Generated with:` with `LLM:` in the claude[bot] and Codex comment footers
- Drop the `Effort:` label but keep the effort value — footer is now `LLM: <model name> | <effort>` (e.g. `LLM: Claude Opus 4.7 (1M) | high`)
- Rename the claude.yml step to "Append LLM footer to Claude comment"
- Update the idempotency grep guard in claude.yml (`grep -q "LLM:"`)
- Update rewrite_create_pr_link.py docstring and all test assertions

## Test plan

- [ ] Run `python3 .github/scripts/test_rewrite_create_pr_link.py` — all 5 tests pass
- [ ] Trigger the claude GitHub Action and verify the footer reads `LLM: Claude Opus 4.7 (1M) | high` (plus cost if ccusage data available)

---
LLM: Claude Opus 4.7 (1M) | high