### PR TITLE
feat: add Sharpe ratio calculations to summaries

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -102,6 +102,7 @@ type Config struct {
 	Platforms            map[string]*PlatformConfig `json:"platforms,omitempty"`
 	LeaderboardSummaries []LeaderboardSummaryConfig `json:"leaderboard_summaries,omitempty"` // #308 — configurable per-channel leaderboards
 	SummaryFrequency     map[string]string          `json:"summary_frequency,omitempty"`     // #30 — per-channel summary cadence; keys match Discord/Telegram channel keys (e.g. "spot", "options", "hyperliquid"). Values: Go duration ("30m", "2h"), alias ("hourly", "every"/"per_check"/"always"), or empty for legacy default (continuous: every cycle; spot: hourly)
+	RiskFreeRate         float64                    `json:"risk_free_rate,omitempty"`        // #397 — annualized risk-free rate used in Sharpe-ratio calculations (e.g. 0.02 for 2%). Zero/unset falls back to DefaultAnnualRiskFreeRate.
 }
 
 // ParseSummaryFrequency converts a summary_frequency value to a duration.

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -102,7 +102,7 @@ type Config struct {
 	Platforms            map[string]*PlatformConfig `json:"platforms,omitempty"`
 	LeaderboardSummaries []LeaderboardSummaryConfig `json:"leaderboard_summaries,omitempty"` // #308 — configurable per-channel leaderboards
 	SummaryFrequency     map[string]string          `json:"summary_frequency,omitempty"`     // #30 — per-channel summary cadence; keys match Discord/Telegram channel keys (e.g. "spot", "options", "hyperliquid"). Values: Go duration ("30m", "2h"), alias ("hourly", "every"/"per_check"/"always"), or empty for legacy default (continuous: every cycle; spot: hourly)
-	RiskFreeRate         float64                    `json:"risk_free_rate,omitempty"`        // #397 — annualized risk-free rate used in Sharpe-ratio calculations (e.g. 0.02 for 2%). Zero/unset falls back to DefaultAnnualRiskFreeRate.
+	RiskFreeRate         *float64                   `json:"risk_free_rate,omitempty"`        // #397 — annualized risk-free rate used in Sharpe-ratio calculations (e.g. 0.02 for 2%). Nil/missing falls back to DefaultAnnualRiskFreeRate; an explicit 0 is respected so backtest comparisons can pin to a 0% benchmark.
 }
 
 // ParseSummaryFrequency converts a summary_frequency value to a duration.

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -441,12 +441,12 @@ func FormatCategorySummary(
 		sb.WriteString(tableChunks[0])
 	}
 
-	// Category-level Sharpe ratio (#397). Treated as portfolio Sharpe across the
-	// strategies in this category, computed from realized daily returns. Zero is
-	// rendered as "—" so operators can distinguish "no data yet" from a genuine
-	// zero Sharpe.
+	// Book Sharpe ratio (#397). "Book" meaning the pooled portfolio of every
+	// strategy in this channel/asset, not any one strategy's figure — per-strategy
+	// Sharpes are rendered in the leaderboard column. Computed from realized
+	// daily returns with zero-fill on flat days (see sharpe.go).
 	if categorySharpe != 0 {
-		sb.WriteString(fmt.Sprintf("📐 Sharpe (realized, annualized): %s\n", fmtSharpe(categorySharpe)))
+		sb.WriteString(fmt.Sprintf("📐 Book Sharpe (realized, annualized): %s\n", fmtSharpe(categorySharpe)))
 	}
 
 	header := sb.String()

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -259,6 +259,7 @@ func FormatCategorySummary(
 	channelKey string,
 	asset string,
 	globalIntervalSeconds int,
+	categorySharpe float64,
 ) []string {
 	var sb strings.Builder
 
@@ -438,6 +439,14 @@ func FormatCategorySummary(
 	tableChunks := writeCatTableChunks(tableBots, filteredValue, totalPnl, totalPnlPct, hasSharedWallet)
 	if len(tableChunks) > 0 {
 		sb.WriteString(tableChunks[0])
+	}
+
+	// Category-level Sharpe ratio (#397). Treated as portfolio Sharpe across the
+	// strategies in this category, computed from realized daily returns. Zero is
+	// rendered as "—" so operators can distinguish "no data yet" from a genuine
+	// zero Sharpe.
+	if categorySharpe != 0 {
+		sb.WriteString(fmt.Sprintf("📐 Sharpe (realized, annualized): %s\n", fmtSharpe(categorySharpe)))
 	}
 
 	header := sb.String()

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -165,7 +165,7 @@ func TestFormatCategorySummary_WithAsset(t *testing.T) {
 	prices := map[string]float64{"BTC/USDT": 50000, "ETH/USDT": 3000}
 
 	// With asset — title should contain " — BTC" and only BTC price shown
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
 	msg := strings.Join(msgs, "\n")
 	if !strings.Contains(msg, "— BTC") {
 		t.Errorf("expected '— BTC' in title, got:\n%s", msg)
@@ -175,7 +175,7 @@ func TestFormatCategorySummary_WithAsset(t *testing.T) {
 	}
 
 	// Without asset — no suffix in title
-	msgs2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "", 600)
+	msgs2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "", 600, 0)
 	msg2 := strings.Join(msgs2, "\n")
 	if strings.Contains(msg2, "— ") {
 		t.Errorf("expected no asset suffix when asset='', got:\n%s", msg2)
@@ -201,20 +201,20 @@ func TestFormatCategorySummary_VersionSuffix(t *testing.T) {
 	defer func() { Version = orig }()
 
 	Version = "v9.9.9-test"
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
 	summary := strings.Join(msgs, "\n")
 	if !strings.Contains(summary, "("+Version+")") {
 		t.Errorf("expected version %q in summary title, got:\n%s", Version, summary)
 	}
 
-	msgs = FormatCategorySummary(1, 0, 1, 3, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+	msgs = FormatCategorySummary(1, 0, 1, 3, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
 	trades := strings.Join(msgs, "\n")
 	if !strings.Contains(trades, "("+Version+")") {
 		t.Errorf("expected version %q in trades title, got:\n%s", Version, trades)
 	}
 
 	Version = ""
-	msgs = FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+	msgs = FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
 	empty := strings.Join(msgs, "\n")
 	if strings.Contains(empty, "()") {
 		t.Errorf("empty Version should omit the suffix, got:\n%s", empty)
@@ -240,7 +240,7 @@ func TestFormatCategorySummary_CircuitBreakerActive(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "Circuit breaker active") {
@@ -274,7 +274,7 @@ func TestFormatCategorySummary_StrategiesSortedByID(t *testing.T) {
 		},
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
-	msgs := FormatCategorySummary(1, 0, 1, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
 	msg := strings.Join(msgs, "\n")
 	idxAdx := strings.Index(msg, "hl-adx-btc")
 	idxZebra := strings.Index(msg, "hl-zebra-btc")
@@ -297,7 +297,7 @@ func TestFormatCategorySummary_NoCircuitBreaker(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
 	msg := strings.Join(msgs, "\n")
 
 	if strings.Contains(msg, "Circuit breaker") {
@@ -591,7 +591,7 @@ func TestFormatCategorySummary_TfIntColumn(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 3600)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 3600, 0)
 	msg := strings.Join(msgs, "\n")
 
 	// Separate Tf and Int column headers should be present (at end of table).
@@ -616,7 +616,7 @@ func TestFormatCategorySummary_TfIntGlobalFallback(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "spot", "", 3600)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "spot", "", 3600, 0)
 	msg := strings.Join(msgs, "\n")
 
 	// No timeframe for spot → "—"; global interval 3600s → "1h". Separate columns now.
@@ -642,7 +642,7 @@ func TestFormatCategorySummary_ClosedTradesColumn(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
 	msg := strings.Join(msgs, "\n")
 
 	// Header should include #T column.
@@ -695,7 +695,7 @@ func TestFormatCategorySummary_ClosedTradesColumn_SharedWallet(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "#T") {
@@ -744,7 +744,7 @@ func TestFormatCategorySummary_SharedWallet(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0)
 	msg := strings.Join(msgs, "\n")
 
 	// Should contain Wallet% column
@@ -800,7 +800,7 @@ func TestFormatCategorySummary_WalletPctFromConfig(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "30.0%") {
@@ -825,7 +825,7 @@ func TestFormatCategorySummary_NoSharedWallet(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0)
 	msg := strings.Join(msgs, "\n")
 
 	if strings.Contains(msg, "Wallet%") {
@@ -854,7 +854,7 @@ func TestFormatCategorySummary_MessageSplitting(t *testing.T) {
 	state := &AppState{Strategies: strategies}
 	prices := map[string]float64{"BTC/USDT": 51000}
 
-	msgs := FormatCategorySummary(1, 0, 20, 0, 10000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+	msgs := FormatCategorySummary(1, 0, 20, 0, 10000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
 
 	// Should produce multiple messages.
 	if len(msgs) < 2 {
@@ -904,7 +904,7 @@ func TestFormatCategorySummary_NoSplitWhenShort(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 51000}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
 
 	if len(msgs) != 1 {
 		t.Errorf("expected single message for 1 position, got %d", len(msgs))
@@ -1058,7 +1058,7 @@ func TestFormatCategorySummary_HeaderPriceFormat(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 2240.5}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0)
 	msg := strings.Join(msgs, "\n")
 	if !strings.Contains(msg, "ETH: $2,240.50") {
 		t.Errorf("expected header price 'ETH: $2,240.50', got:\n%s", msg)
@@ -1126,7 +1126,7 @@ func TestFormatCategorySummary_LargeTableChunked(t *testing.T) {
 	state := &AppState{Strategies: strategies}
 	prices := map[string]float64{"BTC/USDT": 51000}
 
-	msgs := FormatCategorySummary(1, 0, stratCount, 0, 14000, prices, nil, strats, state, "hyperliquid", "BTC", 600)
+	msgs := FormatCategorySummary(1, 0, stratCount, 0, 14000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
 
 	if len(msgs) < 2 {
 		t.Fatalf("expected at least 2 messages for %d strategies, got %d", stratCount, len(msgs))

--- a/scheduler/leaderboard.go
+++ b/scheduler/leaderboard.go
@@ -18,6 +18,7 @@ type LeaderboardEntry struct {
 	PnL     float64 `json:"pnl"`
 	PnLPct  float64 `json:"pnl_pct"`
 	Trades  int     `json:"trades"`
+	Sharpe  float64 `json:"sharpe,omitempty"` // #397 — annualized Sharpe; 0 = undefined/no data
 }
 
 // leaderboardTopN returns the configured top-N count, defaulting to 5 when unset.
@@ -33,7 +34,7 @@ func leaderboardTopN(cfg *Config) int {
 // the actual entry count is controlled by Discord.LeaderboardTopN. Returns nil
 // if no strategies have state. Issue #313 moved this to an on-demand compute
 // (previously written to leaderboard.json every cycle).
-func BuildLeaderboardMessages(cfg *Config, state *AppState, prices map[string]float64) map[string]string {
+func BuildLeaderboardMessages(cfg *Config, state *AppState, prices map[string]float64, sharpeByStrategy map[string]float64) map[string]string {
 	var allEntries []LeaderboardEntry
 
 	for _, sc := range cfg.Strategies {
@@ -57,6 +58,7 @@ func BuildLeaderboardMessages(cfg *Config, state *AppState, prices map[string]fl
 			PnL:     pnl,
 			PnLPct:  pnlPct,
 			Trades:  len(ss.TradeHistory),
+			Sharpe:  sharpeByStrategy[sc.ID],
 		})
 	}
 
@@ -114,12 +116,12 @@ func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, sh
 		top = top[:topN]
 	}
 
-	const sep = "--------------------------------------------------------------------"
+	const sep = "--------------------------------------------------------------------------------"
 	sb.WriteString("\n```\n")
 	if showType {
-		sb.WriteString(fmt.Sprintf("%-22s %-6s %10s %10s %7s %8s\n", "Strategy", "Type", "Value", "PnL", "PnL%", "Trades"))
+		sb.WriteString(fmt.Sprintf("%-22s %-6s %10s %10s %7s %8s %7s\n", "Strategy", "Type", "Value", "PnL", "PnL%", "Trades", "Sharpe"))
 	} else {
-		sb.WriteString(fmt.Sprintf("%-26s %10s %10s %7s %8s\n", "Strategy", "Value", "PnL", "PnL%", "Trades"))
+		sb.WriteString(fmt.Sprintf("%-26s %10s %10s %7s %8s %7s\n", "Strategy", "Value", "PnL", "PnL%", "Trades", "Sharpe"))
 	}
 	sb.WriteString(sep + "\n")
 
@@ -129,16 +131,17 @@ func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, sh
 		pnlStr := fmtSignedDollar(e.PnL)
 		pctStr := fmtSignedPct(e.PnLPct)
 		tradesStr := fmt.Sprintf("%d", e.Trades)
+		sharpeStr := fmtSharpe(e.Sharpe)
 		if showType {
 			if len(label) > 22 {
 				label = label[:22]
 			}
-			sb.WriteString(fmt.Sprintf("%-22s %-6s %10s %10s %7s %8s\n", label, e.Type, valStr, pnlStr, pctStr, tradesStr))
+			sb.WriteString(fmt.Sprintf("%-22s %-6s %10s %10s %7s %8s %7s\n", label, e.Type, valStr, pnlStr, pctStr, tradesStr, sharpeStr))
 		} else {
 			if len(label) > 26 {
 				label = label[:26]
 			}
-			sb.WriteString(fmt.Sprintf("%-26s %10s %10s %7s %8s\n", label, valStr, pnlStr, pctStr, tradesStr))
+			sb.WriteString(fmt.Sprintf("%-26s %10s %10s %7s %8s %7s\n", label, valStr, pnlStr, pctStr, tradesStr, sharpeStr))
 		}
 	}
 	sb.WriteString(sep + "\n")
@@ -149,9 +152,9 @@ func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, sh
 	totPctStr := fmtSignedPct(totalPnlPct)
 	totTradesStr := fmt.Sprintf("%d", totalTrades)
 	if showType {
-		sb.WriteString(fmt.Sprintf("%-22s %-6s %10s %10s %7s %8s\n", totalLabel, "", totValStr, totPnlStr, totPctStr, totTradesStr))
+		sb.WriteString(fmt.Sprintf("%-22s %-6s %10s %10s %7s %8s %7s\n", totalLabel, "", totValStr, totPnlStr, totPctStr, totTradesStr, ""))
 	} else {
-		sb.WriteString(fmt.Sprintf("%-26s %10s %10s %7s %8s\n", totalLabel, totValStr, totPnlStr, totPctStr, totTradesStr))
+		sb.WriteString(fmt.Sprintf("%-26s %10s %10s %7s %8s %7s\n", totalLabel, totValStr, totPnlStr, totPctStr, totTradesStr, ""))
 	}
 	sb.WriteString("```\n")
 	sb.WriteString(fmt.Sprintf("🟢 %d winning · 🔴 %d losing · ⚪ %d flat\n", winning, losing, flat))
@@ -189,8 +192,8 @@ func formatAllTimeMessage(icon, title string, entries []LeaderboardEntry, isTop 
 // pre-computed leaderboard.json (which was rewritten every cycle) to computing
 // fresh data at post time — the data is only used by the daily cron post and
 // the --leaderboard flag, so there is no benefit to pre-computation.
-func PostLeaderboard(cfg *Config, state *AppState, prices map[string]float64, notifier *MultiNotifier) error {
-	return postLeaderboardMessages(BuildLeaderboardMessages(cfg, state, prices), notifier)
+func PostLeaderboard(cfg *Config, state *AppState, prices map[string]float64, sharpeByStrategy map[string]float64, notifier *MultiNotifier) error {
+	return postLeaderboardMessages(BuildLeaderboardMessages(cfg, state, prices, sharpeByStrategy), notifier)
 }
 
 // postLeaderboardMessages posts pre-built leaderboard messages. Separated from
@@ -257,7 +260,7 @@ func platformIcon(platform string) string {
 // optionally ticker) sorted by PnL% descending, truncated to TopN. Returns ""
 // if no strategies match — caller should skip posting in that case.
 // Issue #308.
-func BuildLeaderboardSummary(lc LeaderboardSummaryConfig, cfg *Config, state *AppState, prices map[string]float64) string {
+func BuildLeaderboardSummary(lc LeaderboardSummaryConfig, cfg *Config, state *AppState, prices map[string]float64, sharpeByStrategy map[string]float64) string {
 	topN := lc.TopN
 	if topN <= 0 {
 		topN = 5
@@ -291,6 +294,7 @@ func BuildLeaderboardSummary(lc LeaderboardSummaryConfig, cfg *Config, state *Ap
 			PnL:     pnl,
 			PnLPct:  pnlPct,
 			Trades:  len(ss.TradeHistory),
+			Sharpe:  sharpeByStrategy[sc.ID],
 		})
 	}
 

--- a/scheduler/leaderboard.go
+++ b/scheduler/leaderboard.go
@@ -18,7 +18,7 @@ type LeaderboardEntry struct {
 	PnL     float64 `json:"pnl"`
 	PnLPct  float64 `json:"pnl_pct"`
 	Trades  int     `json:"trades"`
-	Sharpe  float64 `json:"sharpe,omitempty"` // #397 — annualized Sharpe; 0 = undefined/no data
+	Sharpe  float64 `json:"sharpe"` // #397 — annualized Sharpe; 0 = undefined/no data. Kept in the serialized form (no omitempty) so consumers can distinguish "present but zero" from "omitted".
 }
 
 // leaderboardTopN returns the configured top-N count, defaulting to 5 when unset.

--- a/scheduler/leaderboard_test.go
+++ b/scheduler/leaderboard_test.go
@@ -89,6 +89,46 @@ func TestBuildLeaderboardMessages(t *testing.T) {
 	}
 }
 
+// TestBuildLeaderboardMessages_SharpeColumn verifies that a populated
+// sharpeByStrategy map surfaces the Sharpe column header and at least one
+// non-N/A value in the rendered message. Regression for the review nit that
+// every leaderboard test previously passed nil and the column was exercised
+// only by fmtSharpe unit tests.
+func TestBuildLeaderboardMessages_SharpeColumn(t *testing.T) {
+	cfg := &Config{
+		Strategies: []StrategyConfig{
+			{ID: "sma-btc", Type: "spot", Capital: 1000, Platform: "binanceus", Args: []string{"sma_crossover", "BTC/USDT", "1h"}},
+			{ID: "rsi-eth", Type: "spot", Capital: 500, Platform: "binanceus", Args: []string{"rsi_divergence", "ETH/USDT", "1h"}},
+		},
+	}
+	state := NewAppState()
+	for _, sc := range cfg.Strategies {
+		ss := NewStrategyState(sc)
+		ss.Cash = sc.Capital + 100
+		state.Strategies[sc.ID] = ss
+	}
+	sharpe := map[string]float64{
+		"sma-btc": 1.42,
+		"rsi-eth": -0.33,
+	}
+
+	messages := BuildLeaderboardMessages(cfg, state, map[string]float64{"BTC/USDT": 50000, "ETH/USDT": 3000}, sharpe)
+	if messages == nil {
+		t.Fatal("BuildLeaderboardMessages returned nil")
+	}
+	topMsg := messages["top"]
+	if !containsStr(topMsg, "Sharpe") {
+		t.Errorf("top message should contain Sharpe column header, got:\n%s", topMsg)
+	}
+	if !containsStr(topMsg, "+1.42") {
+		t.Errorf("top message should render sma-btc Sharpe +1.42, got:\n%s", topMsg)
+	}
+	bottomMsg := messages["bottom"]
+	if !containsStr(bottomMsg, "-0.33") {
+		t.Errorf("bottom message should render rsi-eth Sharpe -0.33, got:\n%s", bottomMsg)
+	}
+}
+
 // TestBuildLeaderboardMessages_Empty verifies BuildLeaderboardMessages returns
 // nil when no strategies have state. PostLeaderboard relies on this to surface
 // the "no strategies" error instead of posting empty messages.

--- a/scheduler/leaderboard_test.go
+++ b/scheduler/leaderboard_test.go
@@ -49,7 +49,7 @@ func TestBuildLeaderboardMessages(t *testing.T) {
 		"ETH/USDT": 3000,
 	}
 
-	messages := BuildLeaderboardMessages(cfg, state, prices)
+	messages := BuildLeaderboardMessages(cfg, state, prices, nil)
 	if messages == nil {
 		t.Fatal("BuildLeaderboardMessages returned nil")
 	}
@@ -96,7 +96,7 @@ func TestBuildLeaderboardMessages_Empty(t *testing.T) {
 	cfg := &Config{DBFile: filepath.Join(t.TempDir(), "state.db")}
 	state := NewAppState()
 
-	if messages := BuildLeaderboardMessages(cfg, state, nil); messages != nil {
+	if messages := BuildLeaderboardMessages(cfg, state, nil, nil); messages != nil {
 		t.Errorf("Expected nil messages for empty state, got %v", messages)
 	}
 }
@@ -186,7 +186,7 @@ func TestBuildLeaderboardMessages_TopN(t *testing.T) {
 		state.Strategies[sc.ID] = ss
 	}
 
-	messages := BuildLeaderboardMessages(cfg, state, map[string]float64{"BTC/USDT": 50000})
+	messages := BuildLeaderboardMessages(cfg, state, map[string]float64{"BTC/USDT": 50000}, nil)
 	if messages == nil {
 		t.Fatal("BuildLeaderboardMessages returned nil")
 	}
@@ -252,7 +252,7 @@ func TestPostLeaderboard_DedicatedChannel(t *testing.T) {
 		leaderboardChannel: "lb-ch",
 	})
 
-	if err := PostLeaderboard(cfg, state, prices, notifier); err != nil {
+	if err := PostLeaderboard(cfg, state, prices, nil, notifier); err != nil {
 		t.Fatalf("PostLeaderboard: %v", err)
 	}
 
@@ -278,7 +278,7 @@ func TestPostLeaderboard_FallbackRouting(t *testing.T) {
 		channels: map[string]string{"spot": "spot-ch", "perps": "perps-ch"},
 	})
 
-	if err := PostLeaderboard(cfg, state, prices, notifier); err != nil {
+	if err := PostLeaderboard(cfg, state, prices, nil, notifier); err != nil {
 		t.Fatalf("PostLeaderboard: %v", err)
 	}
 
@@ -331,7 +331,7 @@ func TestPostLeaderboard_MixedBackends(t *testing.T) {
 		},
 	)
 
-	if err := PostLeaderboard(cfg, state, prices, notifier); err != nil {
+	if err := PostLeaderboard(cfg, state, prices, nil, notifier); err != nil {
 		t.Fatalf("PostLeaderboard: %v", err)
 	}
 
@@ -372,7 +372,7 @@ func TestPostLeaderboard_NoStrategies(t *testing.T) {
 	mock := &mockNotifier{}
 	notifier := NewMultiNotifier(notifierBackend{notifier: mock, channels: map[string]string{"spot": "spot-ch"}})
 
-	err := PostLeaderboard(cfg, state, nil, notifier)
+	err := PostLeaderboard(cfg, state, nil, nil, notifier)
 	if err == nil {
 		t.Error("expected error when no strategies configured")
 	}
@@ -423,7 +423,7 @@ func TestBuildLeaderboardSummary_PlatformOnly(t *testing.T) {
 	}
 
 	lc := LeaderboardSummaryConfig{Platform: "hyperliquid", TopN: 10, Channel: "chan-1"}
-	msg := BuildLeaderboardSummary(lc, cfg, state, nil)
+	msg := BuildLeaderboardSummary(lc, cfg, state, nil, nil)
 	if msg == "" {
 		t.Fatal("Expected non-empty message")
 	}
@@ -455,7 +455,7 @@ func TestBuildLeaderboardSummary_TickerFilter(t *testing.T) {
 	}
 
 	lc := LeaderboardSummaryConfig{Platform: "hyperliquid", Ticker: "eth", TopN: 5, Channel: "chan-1"}
-	msg := BuildLeaderboardSummary(lc, cfg, state, nil)
+	msg := BuildLeaderboardSummary(lc, cfg, state, nil, nil)
 	if msg == "" {
 		t.Fatal("Expected non-empty message")
 	}
@@ -498,7 +498,7 @@ func TestBuildLeaderboardSummary_DefaultTopN(t *testing.T) {
 
 	// TopN=0 means default (5).
 	lc := LeaderboardSummaryConfig{Platform: "hyperliquid", Channel: "c1"}
-	msg := BuildLeaderboardSummary(lc, cfg, state, nil)
+	msg := BuildLeaderboardSummary(lc, cfg, state, nil, nil)
 	if !containsStr(msg, "Hyperliquid Top 5") {
 		t.Errorf("Expected default TopN=5 in title, got:\n%s", msg)
 	}
@@ -514,7 +514,7 @@ func TestBuildLeaderboardSummary_NoMatches(t *testing.T) {
 	state.Strategies["sma-btc"] = NewStrategyState(cfg.Strategies[0])
 
 	lc := LeaderboardSummaryConfig{Platform: "hyperliquid", Channel: "c1"}
-	if msg := BuildLeaderboardSummary(lc, cfg, state, nil); msg != "" {
+	if msg := BuildLeaderboardSummary(lc, cfg, state, nil, nil); msg != "" {
 		t.Errorf("Expected empty message when no strategies match, got:\n%s", msg)
 	}
 }

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -278,7 +278,7 @@ func main() {
 			os.Exit(0)
 		}
 		prices := fetchPricesForSummary(cfg)
-		sharpeByStrategy := ComputeSharpeByStrategy(stateDB, cfg, state)
+		sharpeByStrategy := ComputeSharpeByStrategy(LoadClosedPositionsByStrategy(stateDB, cfg), cfg, state)
 		if err := PostLeaderboard(cfg, state, prices, sharpeByStrategy, notifier); err != nil {
 			fmt.Fprintf(os.Stderr, "Leaderboard post failed: %v\n", err)
 			os.Exit(1)
@@ -1191,6 +1191,13 @@ func main() {
 		elapsed := time.Since(cycleStart)
 		logMgr.LogSummary(cycle, elapsed, len(dueStrategies), totalTrades, totalValue)
 
+		// Pre-compute closed-position history once per cycle so per-channel /
+		// per-asset Sharpe calls (and the later ComputeSharpeByStrategy for
+		// leaderboard summaries) don't each re-query the DB. Nil when stateDB
+		// is nil — downstream callers treat that as "Sharpe unavailable".
+		closedByStrategy := LoadClosedPositionsByStrategy(stateDB, cfg)
+		rfr := RiskFreeRateOrDefault(cfg)
+
 		// Notification — one message per channel per asset, sent to all backends.
 		if notifier.HasBackends() {
 			mu.RLock()
@@ -1225,7 +1232,7 @@ func main() {
 					}
 					chDetails := channelTradeDetails[detailKey]
 					chValue := channelValue[chKey]
-					chSharpe := aggregateSharpe(stateDB, chStrats, state, RiskFreeRateOrDefault(cfg))
+					chSharpe := aggregateSharpe(closedByStrategy, chStrats, state, rfr)
 					msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), chTrades, chValue, prices, chDetails, chStrats, state, chKey, "", cfg.IntervalSeconds, chSharpe)
 					for _, msg := range msgs {
 						notifier.SendToChannel(chKey, chKey, msg)
@@ -1242,7 +1249,7 @@ func main() {
 							}
 						}
 						assetTrades := len(assetDetails)
-						assetSharpe := aggregateSharpe(stateDB, assetStrats, state, RiskFreeRateOrDefault(cfg))
+						assetSharpe := aggregateSharpe(closedByStrategy, assetStrats, state, rfr)
 						msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), assetTrades, assetValue, prices, assetDetails, assetStrats, state, chKey, asset, cfg.IntervalSeconds, assetSharpe)
 						for _, msg := range msgs {
 							notifier.SendToChannel(chKey, chKey, msg)
@@ -1262,7 +1269,7 @@ func main() {
 		// HTTPS latency can't stall the scheduler cycle.
 		var duePending []pendingLeaderboardSummary
 		if notifier.HasBackends() {
-			duePending = collectDueLeaderboardSummaries(cfg, state, prices, ComputeSharpeByStrategy(stateDB, cfg, state))
+			duePending = collectDueLeaderboardSummaries(cfg, state, prices, ComputeSharpeByStrategy(closedByStrategy, cfg, state))
 		}
 
 		if err := SaveStateWithDB(state, cfg, stateDB); err != nil {
@@ -1316,7 +1323,7 @@ func main() {
 				fmt.Println("[leaderboard] Auto-post skipped: no strategies configured")
 				stampDate()
 			} else {
-				sharpeByStrategy := ComputeSharpeByStrategy(stateDB, cfg, state)
+				sharpeByStrategy := ComputeSharpeByStrategy(closedByStrategy, cfg, state)
 				mu.RLock()
 				lbMessages := BuildLeaderboardMessages(cfg, state, prices, sharpeByStrategy)
 				mu.RUnlock()
@@ -1426,9 +1433,11 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, sdb *Sta
 	}
 
 	// Format and send summary using the same asset-grouping logic as the main loop.
+	closedByStrategy := LoadClosedPositionsByStrategy(sdb, cfg)
+	rfr := RiskFreeRateOrDefault(cfg)
 	assetGroups, assetKeys := groupByAsset(chStrats)
 	if len(assetKeys) <= 1 {
-		chSharpe := aggregateSharpe(sdb, chStrats, state, RiskFreeRateOrDefault(cfg))
+		chSharpe := aggregateSharpe(closedByStrategy, chStrats, state, rfr)
 		msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, chValue, prices, nil, chStrats, state, channelKey, "", cfg.IntervalSeconds, chSharpe)
 		for _, msg := range msgs {
 			notifier.SendToChannel(channelKey, channelKey, msg)
@@ -1443,7 +1452,7 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, sdb *Sta
 					assetValue += PortfolioValue(s, prices)
 				}
 			}
-			assetSharpe := aggregateSharpe(sdb, assetStrats, state, RiskFreeRateOrDefault(cfg))
+			assetSharpe := aggregateSharpe(closedByStrategy, assetStrats, state, rfr)
 			msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, assetValue, prices, nil, assetStrats, state, channelKey, asset, cfg.IntervalSeconds, assetSharpe)
 			for _, msg := range msgs {
 				notifier.SendToChannel(channelKey, channelKey, msg)
@@ -2416,7 +2425,7 @@ func fetchPricesForSummary(cfg *Config) map[string]float64 {
 // 1 only if every entry produced no message. (#308, review item 3 on #309)
 func runLeaderboardSummariesAndExit(lcs []LeaderboardSummaryConfig, cfg *Config, state *AppState, sdb *StateDB, notifier *MultiNotifier) {
 	prices := fetchPricesForSummary(cfg)
-	sharpeByStrategy := ComputeSharpeByStrategy(sdb, cfg, state)
+	sharpeByStrategy := ComputeSharpeByStrategy(LoadClosedPositionsByStrategy(sdb, cfg), cfg, state)
 	posted := 0
 	for _, lc := range lcs {
 		msg := BuildLeaderboardSummary(lc, cfg, state, prices, sharpeByStrategy)

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -260,7 +260,7 @@ func main() {
 	// launching the config-migration goroutine, update checks, and pricers
 	// that would be hard-killed by os.Exit.
 	if *summary != "" {
-		runSummaryAndExit(*summary, cfg, state, notifier)
+		runSummaryAndExit(*summary, cfg, state, stateDB, notifier)
 	}
 
 	// -leaderboard mode: compute leaderboard on-demand and exit. Issue #313
@@ -278,7 +278,8 @@ func main() {
 			os.Exit(0)
 		}
 		prices := fetchPricesForSummary(cfg)
-		if err := PostLeaderboard(cfg, state, prices, notifier); err != nil {
+		sharpeByStrategy := ComputeSharpeByStrategy(stateDB, cfg, state)
+		if err := PostLeaderboard(cfg, state, prices, sharpeByStrategy, notifier); err != nil {
 			fmt.Fprintf(os.Stderr, "Leaderboard post failed: %v\n", err)
 			os.Exit(1)
 		}
@@ -1224,7 +1225,8 @@ func main() {
 					}
 					chDetails := channelTradeDetails[detailKey]
 					chValue := channelValue[chKey]
-					msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), chTrades, chValue, prices, chDetails, chStrats, state, chKey, "", cfg.IntervalSeconds)
+					chSharpe := aggregateSharpe(stateDB, chStrats, state, RiskFreeRateOrDefault(cfg))
+					msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), chTrades, chValue, prices, chDetails, chStrats, state, chKey, "", cfg.IntervalSeconds, chSharpe)
 					for _, msg := range msgs {
 						notifier.SendToChannel(chKey, chKey, msg)
 					}
@@ -1240,7 +1242,8 @@ func main() {
 							}
 						}
 						assetTrades := len(assetDetails)
-						msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), assetTrades, assetValue, prices, assetDetails, assetStrats, state, chKey, asset, cfg.IntervalSeconds)
+						assetSharpe := aggregateSharpe(stateDB, assetStrats, state, RiskFreeRateOrDefault(cfg))
+						msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), assetTrades, assetValue, prices, assetDetails, assetStrats, state, chKey, asset, cfg.IntervalSeconds, assetSharpe)
 						for _, msg := range msgs {
 							notifier.SendToChannel(chKey, chKey, msg)
 						}
@@ -1259,7 +1262,7 @@ func main() {
 		// HTTPS latency can't stall the scheduler cycle.
 		var duePending []pendingLeaderboardSummary
 		if notifier.HasBackends() {
-			duePending = collectDueLeaderboardSummaries(cfg, state, prices)
+			duePending = collectDueLeaderboardSummaries(cfg, state, prices, ComputeSharpeByStrategy(stateDB, cfg, state))
 		}
 
 		if err := SaveStateWithDB(state, cfg, stateDB); err != nil {
@@ -1313,8 +1316,9 @@ func main() {
 				fmt.Println("[leaderboard] Auto-post skipped: no strategies configured")
 				stampDate()
 			} else {
+				sharpeByStrategy := ComputeSharpeByStrategy(stateDB, cfg, state)
 				mu.RLock()
-				lbMessages := BuildLeaderboardMessages(cfg, state, prices)
+				lbMessages := BuildLeaderboardMessages(cfg, state, prices, sharpeByStrategy)
 				mu.RUnlock()
 				if len(lbMessages) == 0 {
 					fmt.Println("[leaderboard] Auto-post skipped: no strategy state to leaderboard yet")
@@ -1365,7 +1369,7 @@ func main() {
 //
 // It fetches current prices, formats the summary, posts to all notification
 // backends, and exits immediately.
-func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, notifier *MultiNotifier) {
+func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, sdb *StateDB, notifier *MultiNotifier) {
 	if !notifier.HasBackends() {
 		fmt.Fprintf(os.Stderr, "No notification backends configured\n")
 		os.Exit(1)
@@ -1373,7 +1377,7 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, notifier
 
 	// #308: Manual trigger for configured leaderboard summaries.
 	if lcs := findLeaderboardSummariesByChannel(cfg, channelKey); len(lcs) > 0 {
-		runLeaderboardSummariesAndExit(lcs, cfg, state, notifier)
+		runLeaderboardSummariesAndExit(lcs, cfg, state, sdb, notifier)
 		return
 	}
 
@@ -1424,7 +1428,8 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, notifier
 	// Format and send summary using the same asset-grouping logic as the main loop.
 	assetGroups, assetKeys := groupByAsset(chStrats)
 	if len(assetKeys) <= 1 {
-		msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, chValue, prices, nil, chStrats, state, channelKey, "", cfg.IntervalSeconds)
+		chSharpe := aggregateSharpe(sdb, chStrats, state, RiskFreeRateOrDefault(cfg))
+		msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, chValue, prices, nil, chStrats, state, channelKey, "", cfg.IntervalSeconds, chSharpe)
 		for _, msg := range msgs {
 			notifier.SendToChannel(channelKey, channelKey, msg)
 			fmt.Println(msg)
@@ -1438,7 +1443,8 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, notifier
 					assetValue += PortfolioValue(s, prices)
 				}
 			}
-			msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, assetValue, prices, nil, assetStrats, state, channelKey, asset, cfg.IntervalSeconds)
+			assetSharpe := aggregateSharpe(sdb, assetStrats, state, RiskFreeRateOrDefault(cfg))
+			msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, assetValue, prices, nil, assetStrats, state, channelKey, asset, cfg.IntervalSeconds, assetSharpe)
 			for _, msg := range msgs {
 				notifier.SendToChannel(channelKey, channelKey, msg)
 				fmt.Println(msg)
@@ -2408,11 +2414,12 @@ func fetchPricesForSummary(cfg *Config) map[string]float64 {
 // and exits. Prices are fetched once and shared across all entries. Each
 // empty-result entry is reported to stderr but does not abort siblings; exits
 // 1 only if every entry produced no message. (#308, review item 3 on #309)
-func runLeaderboardSummariesAndExit(lcs []LeaderboardSummaryConfig, cfg *Config, state *AppState, notifier *MultiNotifier) {
+func runLeaderboardSummariesAndExit(lcs []LeaderboardSummaryConfig, cfg *Config, state *AppState, sdb *StateDB, notifier *MultiNotifier) {
 	prices := fetchPricesForSummary(cfg)
+	sharpeByStrategy := ComputeSharpeByStrategy(sdb, cfg, state)
 	posted := 0
 	for _, lc := range lcs {
-		msg := BuildLeaderboardSummary(lc, cfg, state, prices)
+		msg := BuildLeaderboardSummary(lc, cfg, state, prices, sharpeByStrategy)
 		if msg == "" {
 			fmt.Fprintf(os.Stderr, "No strategies match leaderboard summary platform=%s ticker=%s\n", lc.Platform, lc.Ticker)
 			continue
@@ -2445,7 +2452,7 @@ type pendingLeaderboardSummary struct {
 // optimistically so duplicate posts are avoided if the caller's Discord send
 // fails; same semantics as the previous in-lock implementation. Caller must
 // hold the write lock on state. (#308)
-func collectDueLeaderboardSummaries(cfg *Config, state *AppState, prices map[string]float64) []pendingLeaderboardSummary {
+func collectDueLeaderboardSummaries(cfg *Config, state *AppState, prices map[string]float64, sharpeByStrategy map[string]float64) []pendingLeaderboardSummary {
 	if len(cfg.LeaderboardSummaries) == 0 {
 		return nil
 	}
@@ -2464,7 +2471,7 @@ func collectDueLeaderboardSummaries(cfg *Config, state *AppState, prices map[str
 		if !last.IsZero() && now.Sub(last) < freq {
 			continue
 		}
-		msg := BuildLeaderboardSummary(lc, cfg, state, prices)
+		msg := BuildLeaderboardSummary(lc, cfg, state, prices, sharpeByStrategy)
 		if msg == "" {
 			continue
 		}

--- a/scheduler/sharpe.go
+++ b/scheduler/sharpe.go
@@ -12,61 +12,92 @@ import (
 const TradingDaysPerYear = 252
 
 // DefaultAnnualRiskFreeRate is the Sharpe risk-free rate used when the operator
-// has not set Config.RiskFreeRate (0 is treated as "not set"). 2% ≈ short-term
+// has not set Config.RiskFreeRate (nil pointer = not set). 2% ≈ short-term
 // treasury yield commonly used in retail strategy reports.
 const DefaultAnnualRiskFreeRate = 0.02
 
 // minSharpeDays is the minimum number of distinct trading days required to
-// report a Sharpe ratio. A single day gives zero variance; two is the smallest
-// sample where stdev is defined.
-const minSharpeDays = 2
+// report a Sharpe ratio. Set to 20 so the displayed number reflects a
+// meaningful sample — with fewer days the sample variance is dominated by
+// noise and the annualized figure swings wildly (#397 review). Operators see
+// "N/A" instead of a misleading early value.
+const minSharpeDays = 20
 
 // sharpeLookbackLimit caps how many closed-position rows are pulled per
 // strategy. Sharpe is computed from realized PnL, so a cap here just bounds the
 // DB scan — the underlying day-bucketing still reflects the full rolling
-// window covered by the returned rows. 2000 covers a year of heavy activity.
-const sharpeLookbackLimit = 2000
+// window covered by the returned rows. StateDB.QueryClosedPositions clamps the
+// per-call limit to 500 internally, so this is a documented ceiling rather
+// than a true maximum.
+const sharpeLookbackLimit = 500
 
-// RiskFreeRateOrDefault returns cfg.RiskFreeRate, falling back to
-// DefaultAnnualRiskFreeRate when unset. Treats zero and negative values as
-// unset to keep the config forgiving — operators who truly want a 0% rate can
-// set a trivially small positive value if needed.
+// RiskFreeRateOrDefault returns *cfg.RiskFreeRate, falling back to
+// DefaultAnnualRiskFreeRate when unset (nil pointer). A genuinely 0% rate is
+// expressible as an explicit 0 in the config — the pointer distinguishes
+// "missing" from "zero" so operators running backtest comparisons against a
+// 0% benchmark are not silently overridden.
 func RiskFreeRateOrDefault(cfg *Config) float64 {
-	if cfg == nil || cfg.RiskFreeRate <= 0 {
+	if cfg == nil || cfg.RiskFreeRate == nil {
 		return DefaultAnnualRiskFreeRate
 	}
-	return cfg.RiskFreeRate
+	if *cfg.RiskFreeRate < 0 {
+		return DefaultAnnualRiskFreeRate
+	}
+	return *cfg.RiskFreeRate
 }
 
-// ComputeSharpeRatio returns the annualized Sharpe ratio of a strategy based
-// on realized daily returns, computed as:
+// dailyReturnsContinuous buckets realized PnL by UTC day and fills zeros for
+// every day between the earliest and latest close. The Sharpe annualization
+// (√252) assumes the sample represents a continuously-running book's daily
+// return distribution; skipping flat days would inflate the mean and deflate
+// the stdev, overstating the metric. Returns (returns, numDistinctDays) —
+// caller uses the day count to gate minSharpeDays.
 //
-//	sharpe = sqrt(252) * (meanDailyReturn - dailyRiskFreeRate) / stdevDailyReturn
-//
-// Daily return = sum(realized_pnl for positions closed on day D) / initialCapital.
-// The annual risk-free rate is converted to a daily simple rate by dividing by
-// TradingDaysPerYear.
-//
-// Returns 0 when the metric is undefined: < minSharpeDays of realized data,
-// initialCapital <= 0, or zero standard deviation (all daily returns equal).
-func ComputeSharpeRatio(closed []ClosedPosition, initialCapital, annualRiskFreeRate float64) float64 {
+// Day bucketing is UTC. Operators trading NY-session equity futures may expect
+// exchange-close buckets, but a consistent zone across platforms is more
+// important than per-platform accuracy for a high-level summary metric.
+func dailyReturnsContinuous(closed []ClosedPosition, initialCapital float64) ([]float64, int) {
 	if initialCapital <= 0 || len(closed) == 0 {
-		return 0
+		return nil, 0
 	}
 	dailyPnL := make(map[string]float64)
+	var minDay, maxDay time.Time
+	first := true
 	for _, cp := range closed {
 		if cp.ClosedAt.IsZero() {
 			continue
 		}
-		day := cp.ClosedAt.UTC().Format("2006-01-02")
+		d := cp.ClosedAt.UTC().Truncate(24 * time.Hour)
+		day := d.Format("2006-01-02")
 		dailyPnL[day] += cp.RealizedPnL
+		if first || d.Before(minDay) {
+			minDay = d
+		}
+		if first || d.After(maxDay) {
+			maxDay = d
+		}
+		first = false
 	}
-	if len(dailyPnL) < minSharpeDays {
+	if first {
+		return nil, 0
+	}
+	distinct := len(dailyPnL)
+	var returns []float64
+	for d := minDay; !d.After(maxDay); d = d.Add(24 * time.Hour) {
+		key := d.Format("2006-01-02")
+		returns = append(returns, dailyPnL[key]/initialCapital)
+	}
+	return returns, distinct
+}
+
+// annualizedSharpeFromDaily computes sqrt(252)*(mean-dailyRfr)/stdev for a
+// slice of daily return values. Returns 0 when the metric is undefined (too
+// few samples or zero stdev). Single source of truth for the Sharpe math;
+// shared by per-strategy and aggregate code paths so formula changes stay in
+// one place (#397 review item 6).
+func annualizedSharpeFromDaily(returns []float64, annualRiskFreeRate float64) float64 {
+	if len(returns) < 2 {
 		return 0
-	}
-	returns := make([]float64, 0, len(dailyPnL))
-	for _, pnl := range dailyPnL {
-		returns = append(returns, pnl/initialCapital)
 	}
 	var sum float64
 	for _, r := range returns {
@@ -78,22 +109,65 @@ func ComputeSharpeRatio(closed []ClosedPosition, initialCapital, annualRiskFreeR
 		d := r - mean
 		sqSum += d * d
 	}
-	// Sample standard deviation (Bessel-corrected).
+	// Sample standard deviation (Bessel-corrected). The epsilon floor treats
+	// near-zero stdev as "effectively no variance" — without it, summing 20+
+	// identical daily returns accumulates tiny IEEE-754 drift (e.g. 0.01 is
+	// not exactly representable), which would otherwise divide a near-zero
+	// mean-excess by a near-zero stdev and fabricate a Sharpe in the 1e16 range.
 	variance := sqSum / float64(len(returns)-1)
 	stdev := math.Sqrt(variance)
-	if stdev == 0 {
+	if stdev < 1e-12 {
 		return 0
 	}
 	dailyRfr := annualRiskFreeRate / float64(TradingDaysPerYear)
 	return math.Sqrt(float64(TradingDaysPerYear)) * (mean - dailyRfr) / stdev
 }
 
-// ComputeSharpeByStrategy builds a map of strategy ID → Sharpe ratio by
-// pulling closed-position history from sdb for every configured strategy.
-// Returns nil if sdb is nil (callers treat nil as "Sharpe unavailable").
-// Strategies with no realized data are omitted from the map.
-func ComputeSharpeByStrategy(sdb *StateDB, cfg *Config, state *AppState) map[string]float64 {
-	if sdb == nil || cfg == nil || state == nil {
+// ComputeSharpeRatio returns the annualized Sharpe ratio of a strategy based
+// on realized daily returns:
+//
+//	sharpe = sqrt(252) * (meanDailyReturn - dailyRiskFreeRate) / stdevDailyReturn
+//
+// Daily return = sum(realized_pnl for positions closed on day D) / initialCapital.
+// Days with no closures between the first and last close are filled with zero
+// so the sample reflects a continuously-running book.
+//
+// Returns 0 when the metric is undefined: < minSharpeDays of distinct-close
+// data, initialCapital <= 0, or zero standard deviation.
+func ComputeSharpeRatio(closed []ClosedPosition, initialCapital, annualRiskFreeRate float64) float64 {
+	returns, distinct := dailyReturnsContinuous(closed, initialCapital)
+	if distinct < minSharpeDays {
+		return 0
+	}
+	return annualizedSharpeFromDaily(returns, annualRiskFreeRate)
+}
+
+// LoadClosedPositionsByStrategy pulls closed-position history for every
+// configured strategy once, so per-cycle consumers (per-strategy Sharpe,
+// per-channel book Sharpe, per-asset book Sharpe) don't each re-query the DB.
+// Returns nil when sdb is nil; strategies with empty history map to an empty
+// slice so callers can distinguish "queried, no data" from "not queried".
+func LoadClosedPositionsByStrategy(sdb *StateDB, cfg *Config) map[string][]ClosedPosition {
+	if sdb == nil || cfg == nil {
+		return nil
+	}
+	out := make(map[string][]ClosedPosition, len(cfg.Strategies))
+	for _, sc := range cfg.Strategies {
+		closed, _, err := sdb.QueryClosedPositions(sc.ID, "", time.Time{}, time.Time{}, sharpeLookbackLimit, 0)
+		if err != nil {
+			continue
+		}
+		out[sc.ID] = closed
+	}
+	return out
+}
+
+// ComputeSharpeByStrategy builds a map of strategy ID → Sharpe ratio from a
+// pre-loaded closed-positions map. Callers that still need the DB-query
+// variant can call LoadClosedPositionsByStrategy first. Strategies with no
+// realized data or undefined Sharpe are omitted.
+func ComputeSharpeByStrategy(closedByStrategy map[string][]ClosedPosition, cfg *Config, state *AppState) map[string]float64 {
+	if closedByStrategy == nil || cfg == nil || state == nil {
 		return nil
 	}
 	rfr := RiskFreeRateOrDefault(cfg)
@@ -107,11 +181,7 @@ func ComputeSharpeByStrategy(sdb *StateDB, cfg *Config, state *AppState) map[str
 		if initCap <= 0 {
 			continue
 		}
-		closed, _, err := sdb.QueryClosedPositions(sc.ID, "", time.Time{}, time.Time{}, sharpeLookbackLimit, 0)
-		if err != nil {
-			continue
-		}
-		s := ComputeSharpeRatio(closed, initCap, rfr)
+		s := ComputeSharpeRatio(closedByStrategy[sc.ID], initCap, rfr)
 		if s != 0 {
 			out[sc.ID] = s
 		}
@@ -119,71 +189,67 @@ func ComputeSharpeByStrategy(sdb *StateDB, cfg *Config, state *AppState) map[str
 	return out
 }
 
-// aggregateSharpe returns the Sharpe ratio of a portfolio of strategies,
-// computed by summing per-day realized PnL across all strategies and dividing
-// by the total initial capital — i.e. treating the group as one book. This is
-// more faithful than averaging per-strategy Sharpes, which would weight small
-// strategies equally with large ones.
-func aggregateSharpe(sdb *StateDB, strategies []StrategyConfig, state *AppState, annualRiskFreeRate float64) float64 {
-	if sdb == nil || len(strategies) == 0 {
+// aggregateSharpe returns the Sharpe ratio of a portfolio of strategies —
+// i.e. "book Sharpe" — computed by summing per-day realized PnL across all
+// strategies and dividing by the total initial capital. This is more faithful
+// than averaging per-strategy Sharpes, which would weight small strategies
+// equally with large ones. Uses the pre-loaded closed-positions map so the
+// per-cycle caller queries the DB exactly once per strategy.
+func aggregateSharpe(closedByStrategy map[string][]ClosedPosition, strategies []StrategyConfig, state *AppState, annualRiskFreeRate float64) float64 {
+	if len(strategies) == 0 || state == nil {
 		return 0
 	}
 	var totalCap float64
 	dailyPnL := make(map[string]float64)
+	var minDay, maxDay time.Time
+	first := true
 	for _, sc := range strategies {
 		ss := state.Strategies[sc.ID]
 		if ss == nil {
 			continue
 		}
 		totalCap += EffectiveInitialCapital(sc, ss)
-		closed, _, err := sdb.QueryClosedPositions(sc.ID, "", time.Time{}, time.Time{}, sharpeLookbackLimit, 0)
-		if err != nil {
-			continue
-		}
-		for _, cp := range closed {
+		for _, cp := range closedByStrategy[sc.ID] {
 			if cp.ClosedAt.IsZero() {
 				continue
 			}
-			day := cp.ClosedAt.UTC().Format("2006-01-02")
+			d := cp.ClosedAt.UTC().Truncate(24 * time.Hour)
+			day := d.Format("2006-01-02")
 			dailyPnL[day] += cp.RealizedPnL
+			if first || d.Before(minDay) {
+				minDay = d
+			}
+			if first || d.After(maxDay) {
+				maxDay = d
+			}
+			first = false
 		}
 	}
 	if totalCap <= 0 || len(dailyPnL) < minSharpeDays {
 		return 0
 	}
+	// Fill zero-return days between first and last close so the distribution
+	// reflects a continuously-running book (see dailyReturnsContinuous).
 	days := make([]string, 0, len(dailyPnL))
-	for d := range dailyPnL {
-		days = append(days, d)
+	for d := minDay; !d.After(maxDay); d = d.Add(24 * time.Hour) {
+		days = append(days, d.Format("2006-01-02"))
 	}
 	sort.Strings(days)
 	returns := make([]float64, len(days))
 	for i, d := range days {
 		returns[i] = dailyPnL[d] / totalCap
 	}
-	var sum float64
-	for _, r := range returns {
-		sum += r
-	}
-	mean := sum / float64(len(returns))
-	var sqSum float64
-	for _, r := range returns {
-		d := r - mean
-		sqSum += d * d
-	}
-	variance := sqSum / float64(len(returns)-1)
-	stdev := math.Sqrt(variance)
-	if stdev == 0 {
-		return 0
-	}
-	dailyRfr := annualRiskFreeRate / float64(TradingDaysPerYear)
-	return math.Sqrt(float64(TradingDaysPerYear)) * (mean - dailyRfr) / stdev
+	return annualizedSharpeFromDaily(returns, annualRiskFreeRate)
 }
 
-// fmtSharpe renders a Sharpe ratio for summary tables. "—" for zero (undefined)
-// so operators can distinguish "no data yet" from a genuine 0.00 Sharpe.
+// fmtSharpe renders a Sharpe ratio for summary tables. "N/A" for zero
+// (undefined) so operators can distinguish "no data yet" from a genuine 0.00
+// Sharpe. Returns plain ASCII to keep fixed-width byte padding (%Ns) aligned
+// in Discord monospace code blocks — a UTF-8 em-dash is 3 bytes but 1 rune,
+// which misaligns the column by 2 spaces (#397 review item 2).
 func fmtSharpe(s float64) string {
 	if s == 0 {
-		return "—"
+		return "N/A"
 	}
 	if s > 0 {
 		return fmt.Sprintf("+%.2f", s)

--- a/scheduler/sharpe.go
+++ b/scheduler/sharpe.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"time"
+)
+
+// TradingDaysPerYear is the standard trading-days convention used to annualize
+// daily Sharpe ratios. Matches most broker/industry reports (252 sessions/year).
+const TradingDaysPerYear = 252
+
+// DefaultAnnualRiskFreeRate is the Sharpe risk-free rate used when the operator
+// has not set Config.RiskFreeRate (0 is treated as "not set"). 2% ≈ short-term
+// treasury yield commonly used in retail strategy reports.
+const DefaultAnnualRiskFreeRate = 0.02
+
+// minSharpeDays is the minimum number of distinct trading days required to
+// report a Sharpe ratio. A single day gives zero variance; two is the smallest
+// sample where stdev is defined.
+const minSharpeDays = 2
+
+// sharpeLookbackLimit caps how many closed-position rows are pulled per
+// strategy. Sharpe is computed from realized PnL, so a cap here just bounds the
+// DB scan — the underlying day-bucketing still reflects the full rolling
+// window covered by the returned rows. 2000 covers a year of heavy activity.
+const sharpeLookbackLimit = 2000
+
+// RiskFreeRateOrDefault returns cfg.RiskFreeRate, falling back to
+// DefaultAnnualRiskFreeRate when unset. Treats zero and negative values as
+// unset to keep the config forgiving — operators who truly want a 0% rate can
+// set a trivially small positive value if needed.
+func RiskFreeRateOrDefault(cfg *Config) float64 {
+	if cfg == nil || cfg.RiskFreeRate <= 0 {
+		return DefaultAnnualRiskFreeRate
+	}
+	return cfg.RiskFreeRate
+}
+
+// ComputeSharpeRatio returns the annualized Sharpe ratio of a strategy based
+// on realized daily returns, computed as:
+//
+//	sharpe = sqrt(252) * (meanDailyReturn - dailyRiskFreeRate) / stdevDailyReturn
+//
+// Daily return = sum(realized_pnl for positions closed on day D) / initialCapital.
+// The annual risk-free rate is converted to a daily simple rate by dividing by
+// TradingDaysPerYear.
+//
+// Returns 0 when the metric is undefined: < minSharpeDays of realized data,
+// initialCapital <= 0, or zero standard deviation (all daily returns equal).
+func ComputeSharpeRatio(closed []ClosedPosition, initialCapital, annualRiskFreeRate float64) float64 {
+	if initialCapital <= 0 || len(closed) == 0 {
+		return 0
+	}
+	dailyPnL := make(map[string]float64)
+	for _, cp := range closed {
+		if cp.ClosedAt.IsZero() {
+			continue
+		}
+		day := cp.ClosedAt.UTC().Format("2006-01-02")
+		dailyPnL[day] += cp.RealizedPnL
+	}
+	if len(dailyPnL) < minSharpeDays {
+		return 0
+	}
+	returns := make([]float64, 0, len(dailyPnL))
+	for _, pnl := range dailyPnL {
+		returns = append(returns, pnl/initialCapital)
+	}
+	var sum float64
+	for _, r := range returns {
+		sum += r
+	}
+	mean := sum / float64(len(returns))
+	var sqSum float64
+	for _, r := range returns {
+		d := r - mean
+		sqSum += d * d
+	}
+	// Sample standard deviation (Bessel-corrected).
+	variance := sqSum / float64(len(returns)-1)
+	stdev := math.Sqrt(variance)
+	if stdev == 0 {
+		return 0
+	}
+	dailyRfr := annualRiskFreeRate / float64(TradingDaysPerYear)
+	return math.Sqrt(float64(TradingDaysPerYear)) * (mean - dailyRfr) / stdev
+}
+
+// ComputeSharpeByStrategy builds a map of strategy ID → Sharpe ratio by
+// pulling closed-position history from sdb for every configured strategy.
+// Returns nil if sdb is nil (callers treat nil as "Sharpe unavailable").
+// Strategies with no realized data are omitted from the map.
+func ComputeSharpeByStrategy(sdb *StateDB, cfg *Config, state *AppState) map[string]float64 {
+	if sdb == nil || cfg == nil || state == nil {
+		return nil
+	}
+	rfr := RiskFreeRateOrDefault(cfg)
+	out := make(map[string]float64)
+	for _, sc := range cfg.Strategies {
+		ss := state.Strategies[sc.ID]
+		if ss == nil {
+			continue
+		}
+		initCap := EffectiveInitialCapital(sc, ss)
+		if initCap <= 0 {
+			continue
+		}
+		closed, _, err := sdb.QueryClosedPositions(sc.ID, "", time.Time{}, time.Time{}, sharpeLookbackLimit, 0)
+		if err != nil {
+			continue
+		}
+		s := ComputeSharpeRatio(closed, initCap, rfr)
+		if s != 0 {
+			out[sc.ID] = s
+		}
+	}
+	return out
+}
+
+// aggregateSharpe returns the Sharpe ratio of a portfolio of strategies,
+// computed by summing per-day realized PnL across all strategies and dividing
+// by the total initial capital — i.e. treating the group as one book. This is
+// more faithful than averaging per-strategy Sharpes, which would weight small
+// strategies equally with large ones.
+func aggregateSharpe(sdb *StateDB, strategies []StrategyConfig, state *AppState, annualRiskFreeRate float64) float64 {
+	if sdb == nil || len(strategies) == 0 {
+		return 0
+	}
+	var totalCap float64
+	dailyPnL := make(map[string]float64)
+	for _, sc := range strategies {
+		ss := state.Strategies[sc.ID]
+		if ss == nil {
+			continue
+		}
+		totalCap += EffectiveInitialCapital(sc, ss)
+		closed, _, err := sdb.QueryClosedPositions(sc.ID, "", time.Time{}, time.Time{}, sharpeLookbackLimit, 0)
+		if err != nil {
+			continue
+		}
+		for _, cp := range closed {
+			if cp.ClosedAt.IsZero() {
+				continue
+			}
+			day := cp.ClosedAt.UTC().Format("2006-01-02")
+			dailyPnL[day] += cp.RealizedPnL
+		}
+	}
+	if totalCap <= 0 || len(dailyPnL) < minSharpeDays {
+		return 0
+	}
+	days := make([]string, 0, len(dailyPnL))
+	for d := range dailyPnL {
+		days = append(days, d)
+	}
+	sort.Strings(days)
+	returns := make([]float64, len(days))
+	for i, d := range days {
+		returns[i] = dailyPnL[d] / totalCap
+	}
+	var sum float64
+	for _, r := range returns {
+		sum += r
+	}
+	mean := sum / float64(len(returns))
+	var sqSum float64
+	for _, r := range returns {
+		d := r - mean
+		sqSum += d * d
+	}
+	variance := sqSum / float64(len(returns)-1)
+	stdev := math.Sqrt(variance)
+	if stdev == 0 {
+		return 0
+	}
+	dailyRfr := annualRiskFreeRate / float64(TradingDaysPerYear)
+	return math.Sqrt(float64(TradingDaysPerYear)) * (mean - dailyRfr) / stdev
+}
+
+// fmtSharpe renders a Sharpe ratio for summary tables. "—" for zero (undefined)
+// so operators can distinguish "no data yet" from a genuine 0.00 Sharpe.
+func fmtSharpe(s float64) string {
+	if s == 0 {
+		return "—"
+	}
+	if s > 0 {
+		return fmt.Sprintf("+%.2f", s)
+	}
+	return fmt.Sprintf("%.2f", s)
+}

--- a/scheduler/sharpe_test.go
+++ b/scheduler/sharpe_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func day(s string) time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func TestComputeSharpeRatioInsufficientData(t *testing.T) {
+	if got := ComputeSharpeRatio(nil, 1000, 0.02); got != 0 {
+		t.Fatalf("empty input should yield 0, got %v", got)
+	}
+	// Single day = only one sample, variance undefined.
+	one := []ClosedPosition{{ClosedAt: day("2026-01-01"), RealizedPnL: 10}}
+	if got := ComputeSharpeRatio(one, 1000, 0.02); got != 0 {
+		t.Fatalf("single-day input should yield 0, got %v", got)
+	}
+	// Rows with a zero ClosedAt are skipped.
+	skipped := []ClosedPosition{
+		{ClosedAt: time.Time{}, RealizedPnL: 10},
+		{ClosedAt: time.Time{}, RealizedPnL: -5},
+	}
+	if got := ComputeSharpeRatio(skipped, 1000, 0.02); got != 0 {
+		t.Fatalf("zero-timestamp rows should be skipped, got %v", got)
+	}
+}
+
+func TestComputeSharpeRatioZeroStdev(t *testing.T) {
+	// Two days, identical daily PnL → stdev 0 → Sharpe undefined (0).
+	same := []ClosedPosition{
+		{ClosedAt: day("2026-01-01"), RealizedPnL: 10},
+		{ClosedAt: day("2026-01-02"), RealizedPnL: 10},
+	}
+	if got := ComputeSharpeRatio(same, 1000, 0); got != 0 {
+		t.Fatalf("zero-stdev should yield 0, got %v", got)
+	}
+}
+
+func TestComputeSharpeRatioInvalidCapital(t *testing.T) {
+	closed := []ClosedPosition{
+		{ClosedAt: day("2026-01-01"), RealizedPnL: 10},
+		{ClosedAt: day("2026-01-02"), RealizedPnL: -5},
+	}
+	if got := ComputeSharpeRatio(closed, 0, 0.02); got != 0 {
+		t.Fatalf("zero capital should yield 0, got %v", got)
+	}
+	if got := ComputeSharpeRatio(closed, -100, 0.02); got != 0 {
+		t.Fatalf("negative capital should yield 0, got %v", got)
+	}
+}
+
+func TestComputeSharpeRatioKnownValue(t *testing.T) {
+	// Three daily returns of 1%, -0.5%, 0.75% on $10k initial capital with a 0%
+	// risk-free rate. Returns: 0.01, -0.005, 0.0075 → mean 0.004167,
+	// sample stdev 0.00763763. Annualized Sharpe = sqrt(252) * mean / stdev.
+	closed := []ClosedPosition{
+		{ClosedAt: day("2026-01-01"), RealizedPnL: 100},
+		{ClosedAt: day("2026-01-02"), RealizedPnL: -50},
+		{ClosedAt: day("2026-01-03"), RealizedPnL: 75},
+	}
+	got := ComputeSharpeRatio(closed, 10000, 0)
+	// Daily returns: 0.01, -0.005, 0.0075
+	// mean = 0.0041666667
+	// sample variance = ((0.01-m)^2 + (-0.005-m)^2 + (0.0075-m)^2) / 2 = 6.4583e-5
+	// stdev = sqrt(6.4583e-5) ≈ 0.008036
+	// Sharpe = sqrt(252) * mean / stdev ≈ 8.2305
+	want := math.Sqrt(252) * 0.0041666667 / math.Sqrt(6.4583e-5)
+	if math.Abs(got-want) > 1e-2 {
+		t.Fatalf("Sharpe = %v, want %v", got, want)
+	}
+	if got < 7.5 || got > 9.0 {
+		t.Fatalf("Sharpe = %v outside sanity range", got)
+	}
+}
+
+func TestComputeSharpeRatioBucketsByDay(t *testing.T) {
+	// Two rows on the same UTC day should collapse into one daily return.
+	// With only one distinct day of data we should get 0 (insufficient data).
+	sameDay := []ClosedPosition{
+		{ClosedAt: time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC), RealizedPnL: 30},
+		{ClosedAt: time.Date(2026, 1, 1, 18, 0, 0, 0, time.UTC), RealizedPnL: 20},
+	}
+	if got := ComputeSharpeRatio(sameDay, 1000, 0); got != 0 {
+		t.Fatalf("multiple rows same day should produce one bucket (insufficient), got %v", got)
+	}
+
+	// Positive drift with low noise → positive Sharpe.
+	var closed []ClosedPosition
+	for i := 0; i < 10; i++ {
+		closed = append(closed, ClosedPosition{
+			ClosedAt:    day("2026-01-01").Add(time.Duration(i) * 24 * time.Hour),
+			RealizedPnL: 10 + float64(i%2), // alternating 10, 11
+		})
+	}
+	got := ComputeSharpeRatio(closed, 1000, 0)
+	if got <= 0 {
+		t.Fatalf("positive drift should yield positive Sharpe, got %v", got)
+	}
+}
+
+func TestComputeSharpeRatioRiskFreeLowersSharpe(t *testing.T) {
+	closed := []ClosedPosition{
+		{ClosedAt: day("2026-01-01"), RealizedPnL: 100},
+		{ClosedAt: day("2026-01-02"), RealizedPnL: -50},
+		{ClosedAt: day("2026-01-03"), RealizedPnL: 75},
+	}
+	withZero := ComputeSharpeRatio(closed, 10000, 0)
+	withRfr := ComputeSharpeRatio(closed, 10000, 0.02)
+	if !(withZero > withRfr) {
+		t.Fatalf("risk-free rate should lower Sharpe: withZero=%v withRfr=%v", withZero, withRfr)
+	}
+}
+
+func TestRiskFreeRateOrDefault(t *testing.T) {
+	if got := RiskFreeRateOrDefault(nil); got != DefaultAnnualRiskFreeRate {
+		t.Fatalf("nil cfg should yield default, got %v", got)
+	}
+	if got := RiskFreeRateOrDefault(&Config{}); got != DefaultAnnualRiskFreeRate {
+		t.Fatalf("zero field should yield default, got %v", got)
+	}
+	if got := RiskFreeRateOrDefault(&Config{RiskFreeRate: 0.05}); got != 0.05 {
+		t.Fatalf("custom rate should pass through, got %v", got)
+	}
+	if got := RiskFreeRateOrDefault(&Config{RiskFreeRate: -0.01}); got != DefaultAnnualRiskFreeRate {
+		t.Fatalf("negative rate should fall back to default, got %v", got)
+	}
+}
+
+func TestFmtSharpe(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{0, "—"},
+		{1.23, "+1.23"},
+		{-0.75, "-0.75"},
+		{2.0, "+2.00"},
+	}
+	for _, c := range cases {
+		if got := fmtSharpe(c.in); got != c.want {
+			t.Fatalf("fmtSharpe(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestComputeSharpeByStrategyNilDB(t *testing.T) {
+	if got := ComputeSharpeByStrategy(nil, &Config{}, &AppState{}); got != nil {
+		t.Fatalf("nil sdb should yield nil map, got %v", got)
+	}
+}
+
+func TestAggregateSharpeEmpty(t *testing.T) {
+	if got := aggregateSharpe(nil, nil, nil, 0.02); got != 0 {
+		t.Fatalf("nil inputs should yield 0, got %v", got)
+	}
+}

--- a/scheduler/sharpe_test.go
+++ b/scheduler/sharpe_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"math"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -12,6 +13,20 @@ func day(s string) time.Time {
 		panic(err)
 	}
 	return t
+}
+
+// manyDays builds a canned N-day slice of ClosedPositions starting from start.
+// Useful for tests that need >= minSharpeDays of data without spelling out
+// every entry.
+func manyDays(start time.Time, n int, pnl func(i int) float64) []ClosedPosition {
+	out := make([]ClosedPosition, n)
+	for i := 0; i < n; i++ {
+		out[i] = ClosedPosition{
+			ClosedAt:    start.Add(time.Duration(i) * 24 * time.Hour),
+			RealizedPnL: pnl(i),
+		}
+	}
+	return out
 }
 
 func TestComputeSharpeRatioInsufficientData(t *testing.T) {
@@ -31,24 +46,35 @@ func TestComputeSharpeRatioInsufficientData(t *testing.T) {
 	if got := ComputeSharpeRatio(skipped, 1000, 0.02); got != 0 {
 		t.Fatalf("zero-timestamp rows should be skipped, got %v", got)
 	}
+	// Fewer than minSharpeDays (20) distinct close days → undefined.
+	short := manyDays(day("2026-01-01"), minSharpeDays-1, func(i int) float64 {
+		if i%2 == 0 {
+			return 10
+		}
+		return -5
+	})
+	if got := ComputeSharpeRatio(short, 1000, 0); got != 0 {
+		t.Fatalf("fewer than minSharpeDays distinct days should yield 0, got %v", got)
+	}
 }
 
 func TestComputeSharpeRatioZeroStdev(t *testing.T) {
-	// Two days, identical daily PnL → stdev 0 → Sharpe undefined (0).
-	same := []ClosedPosition{
-		{ClosedAt: day("2026-01-01"), RealizedPnL: 10},
-		{ClosedAt: day("2026-01-02"), RealizedPnL: 10},
-	}
+	// All days have identical daily PnL → stdev 0 → Sharpe undefined.
+	// Must be at least minSharpeDays to exercise the stdev branch (not the
+	// insufficient-days branch).
+	same := manyDays(day("2026-01-01"), minSharpeDays, func(int) float64 { return 10 })
 	if got := ComputeSharpeRatio(same, 1000, 0); got != 0 {
 		t.Fatalf("zero-stdev should yield 0, got %v", got)
 	}
 }
 
 func TestComputeSharpeRatioInvalidCapital(t *testing.T) {
-	closed := []ClosedPosition{
-		{ClosedAt: day("2026-01-01"), RealizedPnL: 10},
-		{ClosedAt: day("2026-01-02"), RealizedPnL: -5},
-	}
+	closed := manyDays(day("2026-01-01"), minSharpeDays, func(i int) float64 {
+		if i%2 == 0 {
+			return 10
+		}
+		return -5
+	})
 	if got := ComputeSharpeRatio(closed, 0, 0.02); got != 0 {
 		t.Fatalf("zero capital should yield 0, got %v", got)
 	}
@@ -58,32 +84,58 @@ func TestComputeSharpeRatioInvalidCapital(t *testing.T) {
 }
 
 func TestComputeSharpeRatioKnownValue(t *testing.T) {
-	// Three daily returns of 1%, -0.5%, 0.75% on $10k initial capital with a 0%
-	// risk-free rate. Returns: 0.01, -0.005, 0.0075 → mean 0.004167,
-	// sample stdev 0.00763763. Annualized Sharpe = sqrt(252) * mean / stdev.
-	closed := []ClosedPosition{
-		{ClosedAt: day("2026-01-01"), RealizedPnL: 100},
-		{ClosedAt: day("2026-01-02"), RealizedPnL: -50},
-		{ClosedAt: day("2026-01-03"), RealizedPnL: 75},
-	}
+	// A contiguous minSharpeDays-day series with consistent +$100/-$50/+$75
+	// rotation. Because every day has a close, the zero-fill path is a no-op
+	// here and we can compare against the closed-form daily-return Sharpe.
+	pattern := []float64{100, -50, 75}
+	closed := manyDays(day("2026-01-01"), minSharpeDays, func(i int) float64 {
+		return pattern[i%len(pattern)]
+	})
 	got := ComputeSharpeRatio(closed, 10000, 0)
-	// Daily returns: 0.01, -0.005, 0.0075
-	// mean = 0.0041666667
-	// sample variance = ((0.01-m)^2 + (-0.005-m)^2 + (0.0075-m)^2) / 2 = 6.4583e-5
-	// stdev = sqrt(6.4583e-5) ≈ 0.008036
-	// Sharpe = sqrt(252) * mean / stdev ≈ 8.2305
-	want := math.Sqrt(252) * 0.0041666667 / math.Sqrt(6.4583e-5)
-	if math.Abs(got-want) > 1e-2 {
+
+	// Build the expected value from the same series.
+	returns := make([]float64, minSharpeDays)
+	for i := 0; i < minSharpeDays; i++ {
+		returns[i] = pattern[i%len(pattern)] / 10000
+	}
+	var sum float64
+	for _, r := range returns {
+		sum += r
+	}
+	mean := sum / float64(minSharpeDays)
+	var sqSum float64
+	for _, r := range returns {
+		d := r - mean
+		sqSum += d * d
+	}
+	variance := sqSum / float64(minSharpeDays-1)
+	want := math.Sqrt(252) * mean / math.Sqrt(variance)
+	if math.Abs(got-want) > 1e-6 {
 		t.Fatalf("Sharpe = %v, want %v", got, want)
 	}
-	if got < 7.5 || got > 9.0 {
-		t.Fatalf("Sharpe = %v outside sanity range", got)
+	if got <= 0 {
+		t.Fatalf("positive-drift series should yield positive Sharpe, got %v", got)
+	}
+}
+
+func TestComputeSharpeRatioZeroFillBetweenCloses(t *testing.T) {
+	// Two closes, 30 days apart. The zero-fill path should produce 31 daily
+	// returns (mostly zero), bringing the distinct-close count to 2 — which is
+	// still below minSharpeDays, so the result is 0. This asserts the
+	// gating is on *distinct close days*, not zero-filled days, so sparse
+	// trading can't fabricate a usable sample.
+	sparse := []ClosedPosition{
+		{ClosedAt: day("2026-01-01"), RealizedPnL: 100},
+		{ClosedAt: day("2026-01-31"), RealizedPnL: -50},
+	}
+	if got := ComputeSharpeRatio(sparse, 10000, 0); got != 0 {
+		t.Fatalf("sparse series with 2 distinct closes should yield 0 (gated by minSharpeDays), got %v", got)
 	}
 }
 
 func TestComputeSharpeRatioBucketsByDay(t *testing.T) {
-	// Two rows on the same UTC day should collapse into one daily return.
-	// With only one distinct day of data we should get 0 (insufficient data).
+	// Two rows on the same UTC day collapse into one daily return; with only
+	// one distinct close day we should get 0 (insufficient data).
 	sameDay := []ClosedPosition{
 		{ClosedAt: time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC), RealizedPnL: 30},
 		{ClosedAt: time.Date(2026, 1, 1, 18, 0, 0, 0, time.UTC), RealizedPnL: 20},
@@ -92,14 +144,11 @@ func TestComputeSharpeRatioBucketsByDay(t *testing.T) {
 		t.Fatalf("multiple rows same day should produce one bucket (insufficient), got %v", got)
 	}
 
-	// Positive drift with low noise → positive Sharpe.
-	var closed []ClosedPosition
-	for i := 0; i < 10; i++ {
-		closed = append(closed, ClosedPosition{
-			ClosedAt:    day("2026-01-01").Add(time.Duration(i) * 24 * time.Hour),
-			RealizedPnL: 10 + float64(i%2), // alternating 10, 11
-		})
-	}
+	// Positive drift with low noise → positive Sharpe. Needs minSharpeDays
+	// contiguous days to satisfy the new sampling floor.
+	closed := manyDays(day("2026-01-01"), minSharpeDays, func(i int) float64 {
+		return 10 + float64(i%2) // alternating 10, 11
+	})
 	got := ComputeSharpeRatio(closed, 1000, 0)
 	if got <= 0 {
 		t.Fatalf("positive drift should yield positive Sharpe, got %v", got)
@@ -107,11 +156,10 @@ func TestComputeSharpeRatioBucketsByDay(t *testing.T) {
 }
 
 func TestComputeSharpeRatioRiskFreeLowersSharpe(t *testing.T) {
-	closed := []ClosedPosition{
-		{ClosedAt: day("2026-01-01"), RealizedPnL: 100},
-		{ClosedAt: day("2026-01-02"), RealizedPnL: -50},
-		{ClosedAt: day("2026-01-03"), RealizedPnL: 75},
-	}
+	closed := manyDays(day("2026-01-01"), minSharpeDays, func(i int) float64 {
+		pattern := []float64{100, -50, 75}
+		return pattern[i%3]
+	})
 	withZero := ComputeSharpeRatio(closed, 10000, 0)
 	withRfr := ComputeSharpeRatio(closed, 10000, 0.02)
 	if !(withZero > withRfr) {
@@ -120,26 +168,39 @@ func TestComputeSharpeRatioRiskFreeLowersSharpe(t *testing.T) {
 }
 
 func TestRiskFreeRateOrDefault(t *testing.T) {
+	// A nil pointer — whether because cfg itself is nil or the field was
+	// omitted — falls back to the default.
 	if got := RiskFreeRateOrDefault(nil); got != DefaultAnnualRiskFreeRate {
 		t.Fatalf("nil cfg should yield default, got %v", got)
 	}
 	if got := RiskFreeRateOrDefault(&Config{}); got != DefaultAnnualRiskFreeRate {
-		t.Fatalf("zero field should yield default, got %v", got)
+		t.Fatalf("nil field should yield default, got %v", got)
 	}
-	if got := RiskFreeRateOrDefault(&Config{RiskFreeRate: 0.05}); got != 0.05 {
+	// A genuine zero is respected — a user pinning to a 0% rate for backtest
+	// comparisons should not be silently overridden.
+	zero := 0.0
+	if got := RiskFreeRateOrDefault(&Config{RiskFreeRate: &zero}); got != 0 {
+		t.Fatalf("explicit zero should be respected, got %v", got)
+	}
+	custom := 0.05
+	if got := RiskFreeRateOrDefault(&Config{RiskFreeRate: &custom}); got != 0.05 {
 		t.Fatalf("custom rate should pass through, got %v", got)
 	}
-	if got := RiskFreeRateOrDefault(&Config{RiskFreeRate: -0.01}); got != DefaultAnnualRiskFreeRate {
+	negative := -0.01
+	if got := RiskFreeRateOrDefault(&Config{RiskFreeRate: &negative}); got != DefaultAnnualRiskFreeRate {
 		t.Fatalf("negative rate should fall back to default, got %v", got)
 	}
 }
 
 func TestFmtSharpe(t *testing.T) {
+	// "N/A" is plain ASCII — 3 bytes, 3 runes — so fmt.Sprintf("%7s", ...)
+	// padding aligns correctly in Discord monospace code blocks. A UTF-8
+	// em-dash would be 3 bytes but 1 rune and misalign the column.
 	cases := []struct {
 		in   float64
 		want string
 	}{
-		{0, "—"},
+		{0, "N/A"},
 		{1.23, "+1.23"},
 		{-0.75, "-0.75"},
 		{2.0, "+2.00"},
@@ -151,14 +212,152 @@ func TestFmtSharpe(t *testing.T) {
 	}
 }
 
-func TestComputeSharpeByStrategyNilDB(t *testing.T) {
+func TestComputeSharpeByStrategyNilMap(t *testing.T) {
 	if got := ComputeSharpeByStrategy(nil, &Config{}, &AppState{}); got != nil {
-		t.Fatalf("nil sdb should yield nil map, got %v", got)
+		t.Fatalf("nil map should yield nil, got %v", got)
 	}
 }
 
 func TestAggregateSharpeEmpty(t *testing.T) {
 	if got := aggregateSharpe(nil, nil, nil, 0.02); got != 0 {
 		t.Fatalf("nil inputs should yield 0, got %v", got)
+	}
+	if got := aggregateSharpe(nil, []StrategyConfig{}, &AppState{}, 0.02); got != 0 {
+		t.Fatalf("empty strategies should yield 0, got %v", got)
+	}
+}
+
+// TestAggregateSharpePositivePath is the positive-path coverage for the
+// book-Sharpe aggregator that the review flagged as missing. Two strategies
+// share the same time window; we assert the pooled Sharpe is real (non-zero)
+// and differs from the mean of per-strategy Sharpes — the whole point of
+// pooling on capital rather than averaging.
+func TestAggregateSharpePositivePath(t *testing.T) {
+	base := day("2026-01-01")
+	closedByStrategy := map[string][]ClosedPosition{
+		"a": manyDays(base, minSharpeDays, func(i int) float64 {
+			pattern := []float64{100, -50, 75, 25}
+			return pattern[i%len(pattern)]
+		}),
+		"b": manyDays(base, minSharpeDays, func(i int) float64 {
+			pattern := []float64{20, 30, -10, 40}
+			return pattern[i%len(pattern)]
+		}),
+	}
+	strategies := []StrategyConfig{
+		{ID: "a", Capital: 10000},
+		{ID: "b", Capital: 5000},
+	}
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"a": {InitialCapital: 10000},
+		"b": {InitialCapital: 5000},
+	}}
+
+	pooled := aggregateSharpe(closedByStrategy, strategies, state, 0)
+	if pooled == 0 {
+		t.Fatalf("pooled Sharpe should be non-zero for profitable mixed strategies")
+	}
+
+	// The per-strategy Sharpes should not trivially average to the pooled one
+	// — that is the whole reason we aggregate on capital.
+	sharpeA := ComputeSharpeRatio(closedByStrategy["a"], 10000, 0)
+	sharpeB := ComputeSharpeRatio(closedByStrategy["b"], 5000, 0)
+	mean := (sharpeA + sharpeB) / 2
+	if math.Abs(pooled-mean) < 1e-9 {
+		t.Fatalf("pooled Sharpe (%v) should differ from mean of per-strategy Sharpes (%v)", pooled, mean)
+	}
+}
+
+// TestAggregateSharpeFillsFlatDays covers the continuous-book fix: a strategy
+// whose closes span 30 days but only touch the first and last day should be
+// gated by minSharpeDays (distinct close days = 2), not produce a Sharpe off
+// the two raw samples. This is the regression test for review item 1.
+func TestAggregateSharpeFillsFlatDays(t *testing.T) {
+	closedByStrategy := map[string][]ClosedPosition{
+		"a": {
+			{ClosedAt: day("2026-01-01"), RealizedPnL: 100},
+			{ClosedAt: day("2026-01-31"), RealizedPnL: -50},
+		},
+	}
+	strategies := []StrategyConfig{{ID: "a", Capital: 10000}}
+	state := &AppState{Strategies: map[string]*StrategyState{"a": {InitialCapital: 10000}}}
+	if got := aggregateSharpe(closedByStrategy, strategies, state, 0); got != 0 {
+		t.Fatalf("sparse series (2 distinct closes, 30 calendar days) should yield 0, got %v", got)
+	}
+}
+
+// TestComputeSharpeByStrategyFromMap covers the positive path for the
+// per-strategy wrapper that feeds leaderboard rows.
+func TestComputeSharpeByStrategyFromMap(t *testing.T) {
+	base := day("2026-01-01")
+	closedByStrategy := map[string][]ClosedPosition{
+		"a": manyDays(base, minSharpeDays, func(i int) float64 {
+			if i%2 == 0 {
+				return 50
+			}
+			return -20
+		}),
+		"b": nil, // no history → should be omitted
+	}
+	cfg := &Config{Strategies: []StrategyConfig{
+		{ID: "a", Capital: 10000},
+		{ID: "b", Capital: 5000},
+	}}
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"a": {InitialCapital: 10000},
+		"b": {InitialCapital: 5000},
+	}}
+	got := ComputeSharpeByStrategy(closedByStrategy, cfg, state)
+	if _, ok := got["a"]; !ok {
+		t.Fatalf("expected Sharpe entry for 'a', got %v", got)
+	}
+	if _, ok := got["b"]; ok {
+		t.Fatalf("no-history strategy should be omitted, got %v", got)
+	}
+}
+
+// TestLoadClosedPositionsByStrategyNilDB guards the nil-sdb branch that keeps
+// the downstream callers tolerant of a DB that failed to open.
+func TestLoadClosedPositionsByStrategyNilDB(t *testing.T) {
+	if got := LoadClosedPositionsByStrategy(nil, &Config{}); got != nil {
+		t.Fatalf("nil sdb should yield nil, got %v", got)
+	}
+}
+
+// TestLoadClosedPositionsByStrategy wires through a real StateDB so the full
+// DB round-trip (insertion via SaveStateWithDB → query via
+// QueryClosedPositions) is exercised.
+func TestLoadClosedPositionsByStrategy(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "state.db")
+	sdb, err := OpenStateDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenStateDB: %v", err)
+	}
+	defer sdb.Close()
+
+	sc := StrategyConfig{ID: "a", Capital: 10000, Type: "spot"}
+	cfg := &Config{DBFile: dbPath, Strategies: []StrategyConfig{sc}}
+	state := NewAppState()
+	ss := NewStrategyState(sc)
+	ss.ClosedPositions = []ClosedPosition{
+		{StrategyID: "a", Symbol: "BTC/USDT", Quantity: 1, AvgCost: 50000, Side: "long",
+			Multiplier: 1, OpenedAt: day("2026-01-01"), ClosedAt: day("2026-01-02"),
+			ClosePrice: 51000, RealizedPnL: 100, CloseReason: "test", DurationSeconds: 86400},
+	}
+	state.Strategies["a"] = ss
+	if err := SaveStateWithDB(state, cfg, sdb); err != nil {
+		t.Fatalf("SaveStateWithDB: %v", err)
+	}
+
+	got := LoadClosedPositionsByStrategy(sdb, cfg)
+	if got == nil {
+		t.Fatal("LoadClosedPositionsByStrategy returned nil")
+	}
+	if len(got["a"]) != 1 {
+		t.Fatalf("expected 1 closed position for 'a', got %d", len(got["a"]))
+	}
+	if got["a"][0].RealizedPnL != 100 {
+		t.Fatalf("expected realized pnl 100, got %v", got["a"][0].RealizedPnL)
 	}
 }


### PR DESCRIPTION
Adds annualized Sharpe ratio to Discord summaries and leaderboards, computed from realized daily returns on closed positions. Risk-free rate is configurable via a new `risk_free_rate` field in the top-level Config (default 2%).

Closes #397

Generated with [Claude Code](https://claude.ai/code)

---
Generated with: Claude Opus 4.7 (1M) | Effort: high | Tokens: 115 in / 44486 out | Cache: 9172599 read / 186643 written | Cost: $6.87