### PR TITLE
feat: change default warn_threshold_pct from 80 to 60

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -34,7 +34,7 @@ type TelegramConfig struct {
 type PortfolioRiskConfig struct {
 	MaxDrawdownPct   float64 `json:"max_drawdown_pct"`             // kill switch threshold (default 25)
 	MaxNotionalUSD   float64 `json:"max_notional_usd"`             // 0 = disabled
-	WarnThresholdPct float64 `json:"warn_threshold_pct,omitempty"` // % of MaxDrawdownPct to warn (default 80)
+	WarnThresholdPct float64 `json:"warn_threshold_pct,omitempty"` // % of MaxDrawdownPct to warn (default 60)
 }
 
 // PlatformConfig holds per-platform optional risk overrides.
@@ -379,7 +379,7 @@ func LoadConfig(path string) (*Config, error) {
 		cfg.PortfolioRisk = &PortfolioRiskConfig{MaxDrawdownPct: 25}
 	}
 	if cfg.PortfolioRisk.WarnThresholdPct == 0 {
-		cfg.PortfolioRisk.WarnThresholdPct = 80
+		cfg.PortfolioRisk.WarnThresholdPct = 60
 	}
 
 	// Correlation tracking defaults.

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -33,8 +33,8 @@ var configFieldRegistry = []ConfigField{
 	{
 		Version:     3,
 		JSONPath:    "portfolio_risk.warn_threshold_pct",
-		Description: "Percentage of max_drawdown_pct at which to send a warning alert (e.g. 80 means warn at 80% of the kill switch threshold).",
-		Default:     "80",
+		Description: "Percentage of max_drawdown_pct at which to send a warning alert (e.g. 60 means warn at 60% of the kill switch threshold).",
+		Default:     "60",
 		FieldType:   "float",
 	},
 }

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -184,8 +184,8 @@ func TestLoadConfigPortfolioRiskDefaults(t *testing.T) {
 	if loaded.PortfolioRisk.MaxDrawdownPct != 25 {
 		t.Errorf("MaxDrawdownPct = %g, want 25", loaded.PortfolioRisk.MaxDrawdownPct)
 	}
-	if loaded.PortfolioRisk.WarnThresholdPct != 80 {
-		t.Errorf("WarnThresholdPct = %g, want 80", loaded.PortfolioRisk.WarnThresholdPct)
+	if loaded.PortfolioRisk.WarnThresholdPct != 60 {
+		t.Errorf("WarnThresholdPct = %g, want 60", loaded.PortfolioRisk.WarnThresholdPct)
 	}
 }
 

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -334,7 +334,7 @@ type InitOptions struct {
 	// Risk settings — prompted explicitly during live-mode setup (#85) so operators
 	// don't hit the post-launch migration DM for portfolio_risk fields.
 	PortfolioMaxDrawdownPct   float64 `json:"portfolioMaxDrawdownPct,omitempty"`   // kill switch threshold; 0 → default 25
-	PortfolioWarnThresholdPct float64 `json:"portfolioWarnThresholdPct,omitempty"` // % of kill switch that triggers warnings; 0 → default 80
+	PortfolioWarnThresholdPct float64 `json:"portfolioWarnThresholdPct,omitempty"` // % of kill switch that triggers warnings; 0 → default 60
 	DiscordEnabled            bool
 	DiscordOwnerID            string            // Discord user ID for DM features (upgrade prompts, config migration)
 	SpotChannelID             string            // deprecated: use ChannelMap
@@ -1123,7 +1123,7 @@ func runInit(args []string) int {
 		// (config.go:492,498); re-prompt on out-of-range so the wizard can't
 		// produce a file that fails validateConfig on the next startup.
 		portfolioMaxDD = p.FloatRange("Portfolio kill-switch max drawdown %", 25, 0, 100)
-		portfolioWarnPct = p.FloatRange("Portfolio warn threshold % (of kill switch)", 80, 0, 100)
+		portfolioWarnPct = p.FloatRange("Portfolio warn threshold % (of kill switch)", 60, 0, 100)
 	}
 
 	// Notifications default to disabled.

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -354,7 +354,7 @@ func generateConfig(opts InitOptions) *Config {
 	}
 	portfolioWarn := opts.PortfolioWarnThresholdPct
 	if portfolioWarn <= 0 {
-		portfolioWarn = 80
+		portfolioWarn = 60
 	}
 	cfg := &Config{
 		ConfigVersion:   CurrentConfigVersion,
@@ -1092,7 +1092,7 @@ func runInit(args []string) int {
 
 	// Portfolio risk defaults (#85); overridden below if any live mode is enabled.
 	portfolioMaxDD := 25.0
-	portfolioWarnPct := 80.0
+	portfolioWarnPct := 60.0
 
 	// #85: Live trading setup must prompt for risk parameters explicitly so
 	// operators don't hit the post-launch DM migration wizard. These fields

--- a/scheduler/init_test.go
+++ b/scheduler/init_test.go
@@ -409,8 +409,8 @@ func TestGenerateConfig_PortfolioRiskDefaults(t *testing.T) {
 	if cfg.PortfolioRisk.MaxDrawdownPct != 25 {
 		t.Errorf("expected MaxDrawdownPct=25, got %.0f", cfg.PortfolioRisk.MaxDrawdownPct)
 	}
-	if cfg.PortfolioRisk.WarnThresholdPct != 80 {
-		t.Errorf("expected WarnThresholdPct=80, got %.0f", cfg.PortfolioRisk.WarnThresholdPct)
+	if cfg.PortfolioRisk.WarnThresholdPct != 60 {
+		t.Errorf("expected WarnThresholdPct=60, got %.0f", cfg.PortfolioRisk.WarnThresholdPct)
 	}
 }
 
@@ -443,8 +443,8 @@ func TestGenerateConfig_PortfolioRiskZeroKeepsDefaults(t *testing.T) {
 
 	cfg := generateConfig(opts)
 
-	if cfg.PortfolioRisk.MaxDrawdownPct != 25 || cfg.PortfolioRisk.WarnThresholdPct != 80 {
-		t.Errorf("expected defaults 25/80, got %.0f/%.0f",
+	if cfg.PortfolioRisk.MaxDrawdownPct != 25 || cfg.PortfolioRisk.WarnThresholdPct != 60 {
+		t.Errorf("expected defaults 25/60, got %.0f/%.0f",
 			cfg.PortfolioRisk.MaxDrawdownPct, cfg.PortfolioRisk.WarnThresholdPct)
 	}
 }


### PR DESCRIPTION
Change the default `warn_threshold_pct` from 80% to 60% of the kill switch threshold. For a 20% limit this gives 8% headroom before the kill switch fires (vs 4% previously

---
LLM: Claude Sonnet 4.6 (1M) | high | Tokens: 46 in / 11509 out | Cache: 1498466 read / 78144 written | Cost: $0.92