### PR TITLE
feat: warn when strategy interval_seconds exceeds top-level interval

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -420,6 +420,41 @@ func ParseLeaderboardPostTime(s string) (int, int, bool) {
 	return h, m, true
 }
 
+// strategyIntervalExceedsGlobalWarning returns a [WARN] message when the
+// per-strategy interval exceeds the top-level interval (#409), or "" otherwise.
+func strategyIntervalExceedsGlobalWarning(sc StrategyConfig, globalInterval int) string {
+	if sc.IntervalSeconds <= 0 || globalInterval <= 0 || sc.IntervalSeconds <= globalInterval {
+		return ""
+	}
+	ratio := sc.IntervalSeconds / globalInterval
+	if sc.IntervalSeconds%globalInterval != 0 {
+		ratio++
+	}
+	return fmt.Sprintf("[WARN] strategy %q interval_seconds=%d exceeds top-level interval_seconds=%d. Strategy will only run every %s portfolio cycle.",
+		sc.ID, sc.IntervalSeconds, globalInterval, ordinal(ratio))
+}
+
+// ordinal returns the English ordinal suffix form of n (e.g. 1 → "1st", 3 → "3rd", 11 → "11th").
+func ordinal(n int) string {
+	if n < 0 {
+		n = -n
+	}
+	mod100 := n % 100
+	if mod100 >= 11 && mod100 <= 13 {
+		return fmt.Sprintf("%dth", n)
+	}
+	switch n % 10 {
+	case 1:
+		return fmt.Sprintf("%dst", n)
+	case 2:
+		return fmt.Sprintf("%dnd", n)
+	case 3:
+		return fmt.Sprintf("%drd", n)
+	default:
+		return fmt.Sprintf("%dth", n)
+	}
+}
+
 // ValidateConfig checks script paths and strategy fields (#34, #36).
 func ValidateConfig(cfg *Config) error {
 	var errs []string
@@ -559,6 +594,12 @@ func ValidateConfig(cfg *Config) error {
 		// #36: IntervalSeconds must be >= 0 (0 means use global).
 		if sc.IntervalSeconds < 0 {
 			errs = append(errs, fmt.Sprintf("%s: interval_seconds must be >= 0, got %d", prefix, sc.IntervalSeconds))
+		}
+
+		// #409: warn when per-strategy interval exceeds the top-level interval;
+		// the strategy will only run every Nth portfolio cycle.
+		if msg := strategyIntervalExceedsGlobalWarning(sc, cfg.IntervalSeconds); msg != "" {
+			fmt.Println(msg)
 		}
 
 		// #254: Leverage must be >= 1 when set. Only applicable to perps.

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -955,3 +955,118 @@ func TestLoadConfigLeaderboardSummaries(t *testing.T) {
 		t.Errorf("second summary ticker: got %q, want 'eth'", loaded.LeaderboardSummaries[1].Ticker)
 	}
 }
+
+// TestStrategyIntervalExceedsGlobalWarning covers #409: per-strategy
+// interval_seconds greater than the top-level interval should emit a warning
+// describing the "every Nth portfolio cycle" cadence.
+func TestStrategyIntervalExceedsGlobalWarning(t *testing.T) {
+	cases := []struct {
+		name           string
+		strategyID     string
+		strategyInt    int
+		globalInt      int
+		wantWarn       bool
+		wantSubstrings []string
+	}{
+		{
+			name:        "strategy interval matches global",
+			strategyID:  "hl-tema-eth",
+			strategyInt: 300,
+			globalInt:   300,
+			wantWarn:    false,
+		},
+		{
+			name:        "strategy interval below global",
+			strategyID:  "hl-tema-eth",
+			strategyInt: 120,
+			globalInt:   300,
+			wantWarn:    false,
+		},
+		{
+			name:        "strategy interval zero uses global",
+			strategyID:  "hl-tema-eth",
+			strategyInt: 0,
+			globalInt:   300,
+			wantWarn:    false,
+		},
+		{
+			name:           "exact triple — every 3rd cycle",
+			strategyID:     "hl-tema-eth-live",
+			strategyInt:    900,
+			globalInt:      300,
+			wantWarn:       true,
+			wantSubstrings: []string{`"hl-tema-eth-live"`, "interval_seconds=900", "interval_seconds=300", "every 3rd portfolio cycle"},
+		},
+		{
+			name:           "non-multiple rounds up — every 2nd cycle",
+			strategyID:     "s1",
+			strategyInt:    400,
+			globalInt:      300,
+			wantWarn:       true,
+			wantSubstrings: []string{"every 2nd portfolio cycle"},
+		},
+		{
+			name:           "11x uses 'th' suffix",
+			strategyID:     "s1",
+			strategyInt:    3300,
+			globalInt:      300,
+			wantWarn:       true,
+			wantSubstrings: []string{"every 11th portfolio cycle"},
+		},
+		{
+			name:           "21x uses 'st' suffix",
+			strategyID:     "s1",
+			strategyInt:    6300,
+			globalInt:      300,
+			wantWarn:       true,
+			wantSubstrings: []string{"every 21st portfolio cycle"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := StrategyConfig{ID: tc.strategyID, IntervalSeconds: tc.strategyInt}
+			got := strategyIntervalExceedsGlobalWarning(sc, tc.globalInt)
+			if tc.wantWarn {
+				if got == "" {
+					t.Fatalf("expected warning, got empty string")
+				}
+				if !strings.HasPrefix(got, "[WARN] strategy ") {
+					t.Errorf("warning should start with '[WARN] strategy ', got %q", got)
+				}
+				for _, sub := range tc.wantSubstrings {
+					if !strings.Contains(got, sub) {
+						t.Errorf("warning %q missing substring %q", got, sub)
+					}
+				}
+			} else if got != "" {
+				t.Errorf("expected no warning, got %q", got)
+			}
+		})
+	}
+}
+
+// TestOrdinal spot-checks the ordinal suffix helper used by the #409 warning.
+func TestOrdinal(t *testing.T) {
+	cases := map[int]string{
+		1:   "1st",
+		2:   "2nd",
+		3:   "3rd",
+		4:   "4th",
+		11:  "11th",
+		12:  "12th",
+		13:  "13th",
+		21:  "21st",
+		22:  "22nd",
+		23:  "23rd",
+		101: "101st",
+		111: "111th",
+		112: "112th",
+		113: "113th",
+	}
+	for n, want := range cases {
+		if got := ordinal(n); got != want {
+			t.Errorf("ordinal(%d) = %q, want %q", n, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #409

Adds a non-fatal [WARN] during ValidateConfig when a per-strategy interval_seconds is greater than cfg.IntervalSeconds, reporting the effective "every Nth portfolio cycle" cadence.

---
LLM: Claude Opus 4.7 (1M) | high | Tokens: 53 in / 14055 out | Cache: 2069627 read / 163371 written | Cost: $2.41