### PR TITLE
[codex] Notify on per-strategy circuit breakers

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1614,16 +1614,20 @@ func notifyPerStrategyCircuitBreaker(sc StrategyConfig, reason string, portfolio
 }
 
 func isFreshPerStrategyCircuitBreaker(reason string) bool {
-	r := strings.ToLower(reason)
-	if r == "" || strings.Contains(r, "circuit breaker active") {
+	if reason == "" || reason == RiskReasonCircuitBreakerActive {
 		return false
 	}
-	return strings.Contains(r, "max drawdown exceeded") ||
-		strings.Contains(r, "consecutive losses") ||
-		strings.Contains(r, "circuit breaker")
+	return strings.HasPrefix(reason, RiskReasonMaxDrawdownExceeded) ||
+		strings.HasPrefix(reason, RiskReasonConsecutiveLosses)
 }
 
 func formatPerStrategyCircuitBreakerMessage(strategyID, reason string, portfolioValue float64) string {
+	// The max-drawdown reason already embeds a portfolio=$... token, so don't
+	// append a duplicate trailing value. Consecutive-losses reasons carry no
+	// portfolio context, so include it there.
+	if strings.Contains(reason, "portfolio=$") {
+		return fmt.Sprintf("**CIRCUIT BREAKER** [%s] %s", strategyID, reason)
+	}
 	return fmt.Sprintf("**CIRCUIT BREAKER** [%s] %s (portfolio=$%.2f)", strategyID, reason, portfolioValue)
 }
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -997,6 +997,7 @@ func main() {
 					allowed, reason := CheckRisk(&sc, stratState, pv, prices, logger, riskAssist)
 					mu.Unlock()
 					if !allowed {
+						notifyPerStrategyCircuitBreaker(sc, reason, pv, notifier, killSwitchFired)
 						logger.Warn("Risk block: %s (portfolio=$%.2f)", reason, pv)
 						logger.Close()
 						lastRun[sc.ID] = time.Now()
@@ -1601,6 +1602,29 @@ func executeOptionsResult(sc StrategyConfig, s *StrategyState, result *OptionsRe
 // no fallback capital configured).
 func shouldSkipZeroCapital(sc StrategyConfig) bool {
 	return sc.CapitalPct > 0 && sc.Capital <= 0
+}
+
+func notifyPerStrategyCircuitBreaker(sc StrategyConfig, reason string, portfolioValue float64, notifier *MultiNotifier, portfolioKillSwitchFired bool) {
+	if notifier == nil || !notifier.HasBackends() || portfolioKillSwitchFired || !isFreshPerStrategyCircuitBreaker(reason) {
+		return
+	}
+	msg := formatPerStrategyCircuitBreakerMessage(sc.ID, reason, portfolioValue)
+	notifier.SendToAllChannels(msg)
+	notifier.SendOwnerDM(msg)
+}
+
+func isFreshPerStrategyCircuitBreaker(reason string) bool {
+	r := strings.ToLower(reason)
+	if r == "" || strings.Contains(r, "circuit breaker active") {
+		return false
+	}
+	return strings.Contains(r, "max drawdown exceeded") ||
+		strings.Contains(r, "consecutive losses") ||
+		strings.Contains(r, "circuit breaker")
+}
+
+func formatPerStrategyCircuitBreakerMessage(strategyID, reason string, portfolioValue float64) string {
+	return fmt.Sprintf("**CIRCUIT BREAKER** [%s] %s (portfolio=$%.2f)", strategyID, reason, portfolioValue)
 }
 
 // sendTradeAlerts sends trade alerts via DM and/or channel for all configured backends.

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -38,16 +38,22 @@ func TestShouldSkipZeroCapital(t *testing.T) {
 
 func TestNotifyPerStrategyCircuitBreaker_BroadcastsFreshTriggers(t *testing.T) {
 	cases := []struct {
-		name   string
-		reason string
+		name                string
+		reason              string
+		wantTrailingPortVal bool
 	}{
 		{
-			name:   "max drawdown",
-			reason: "max drawdown exceeded (30.0% > 25.0%, portfolio=$700.00 peak=$1000.00, denom=peak=$1000.00)",
+			name: "max drawdown",
+			reason: RiskReasonMaxDrawdownExceeded +
+				" (30.0% > 25.0%, portfolio=$700.00 peak=$1000.00, denom=peak=$1000.00)",
+			// Reason already embeds portfolio=$700.00 — formatter must not
+			// duplicate the value with a trailing (portfolio=$1234.56).
+			wantTrailingPortVal: false,
 		},
 		{
-			name:   "consecutive losses",
-			reason: "5 consecutive losses",
+			name:                "consecutive losses",
+			reason:              RiskReasonConsecutiveLosses,
+			wantTrailingPortVal: true,
 		},
 	}
 
@@ -79,9 +85,15 @@ func TestNotifyPerStrategyCircuitBreaker_BroadcastsFreshTriggers(t *testing.T) {
 			for _, msg := range []string{mock.messages[0].content, mock.messages[1].content, mock.dms[0].content} {
 				if !strings.Contains(msg, "**CIRCUIT BREAKER**") ||
 					!strings.Contains(msg, "[test-strategy]") ||
-					!strings.Contains(msg, tc.reason) ||
-					!strings.Contains(msg, "portfolio=$1234.56") {
+					!strings.Contains(msg, tc.reason) {
 					t.Fatalf("notification missing required context: %q", msg)
+				}
+				hasTrailing := strings.Contains(msg, "(portfolio=$1234.56)")
+				if tc.wantTrailingPortVal && !hasTrailing {
+					t.Fatalf("expected trailing (portfolio=$1234.56) in %q", msg)
+				}
+				if !tc.wantTrailingPortVal && hasTrailing {
+					t.Fatalf("portfolio value duplicated when reason already embeds one: %q", msg)
 				}
 			}
 		})
@@ -94,43 +106,52 @@ func TestNotifyPerStrategyCircuitBreaker_SuppressesNonFreshAndPortfolioKill(t *t
 		reason              string
 		portfolioKillFired  bool
 		notifierHasBackends bool
+		nilNotifier         bool
 		wantChannelMessages int
 		wantOwnerDMs        int
 	}{
 		{
 			name:                "latched circuit breaker no spam",
-			reason:              "circuit breaker active",
+			reason:              RiskReasonCircuitBreakerActive,
 			notifierHasBackends: true,
 		},
 		{
-			name:                "ordinary risk block",
+			name:                "unknown reason strings are dropped",
 			reason:              "daily loss limit exceeded",
 			notifierHasBackends: true,
 		},
 		{
 			name:                "portfolio kill owns notification",
-			reason:              "max drawdown exceeded (30.0% > 25.0%)",
+			reason:              RiskReasonMaxDrawdownExceeded + " (30.0% > 25.0%)",
 			portfolioKillFired:  true,
 			notifierHasBackends: true,
 		},
 		{
 			name:                "no backends",
-			reason:              "5 consecutive losses",
+			reason:              RiskReasonConsecutiveLosses,
 			notifierHasBackends: false,
+		},
+		{
+			name:        "nil notifier",
+			reason:      RiskReasonConsecutiveLosses,
+			nilNotifier: true,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mock := &mockNotifier{}
-			notifier := &MultiNotifier{}
-			if tc.notifierHasBackends {
-				notifier.backends = []notifierBackend{
-					{
-						notifier: mock,
-						ownerID:  "owner123",
-						channels: map[string]string{"spot": "ch-spot"},
-					},
+			var notifier *MultiNotifier
+			if !tc.nilNotifier {
+				notifier = &MultiNotifier{}
+				if tc.notifierHasBackends {
+					notifier.backends = []notifierBackend{
+						{
+							notifier: mock,
+							ownerID:  "owner123",
+							channels: map[string]string{"spot": "ch-spot"},
+						},
+					}
 				}
 			}
 			sc := StrategyConfig{ID: "test-strategy", Platform: "binanceus", Type: "spot"}

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -30,6 +31,117 @@ func TestShouldSkipZeroCapital(t *testing.T) {
 			if got := shouldSkipZeroCapital(sc); got != tc.want {
 				t.Errorf("shouldSkipZeroCapital(pct=%g, cap=%g) = %v, want %v",
 					tc.capitalPct, tc.capital, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNotifyPerStrategyCircuitBreaker_BroadcastsFreshTriggers(t *testing.T) {
+	cases := []struct {
+		name   string
+		reason string
+	}{
+		{
+			name:   "max drawdown",
+			reason: "max drawdown exceeded (30.0% > 25.0%, portfolio=$700.00 peak=$1000.00, denom=peak=$1000.00)",
+		},
+		{
+			name:   "consecutive losses",
+			reason: "5 consecutive losses",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &mockNotifier{}
+			notifier := &MultiNotifier{
+				backends: []notifierBackend{
+					{
+						notifier: mock,
+						ownerID:  "owner123",
+						channels: map[string]string{
+							"spot":        "ch-spot",
+							"hyperliquid": "ch-hl",
+						},
+					},
+				},
+			}
+			sc := StrategyConfig{ID: "test-strategy", Platform: "binanceus", Type: "spot"}
+
+			notifyPerStrategyCircuitBreaker(sc, tc.reason, 1234.56, notifier, false)
+
+			if len(mock.messages) != 2 {
+				t.Fatalf("expected 2 channel messages, got %d", len(mock.messages))
+			}
+			if len(mock.dms) != 1 {
+				t.Fatalf("expected 1 owner DM, got %d", len(mock.dms))
+			}
+			for _, msg := range []string{mock.messages[0].content, mock.messages[1].content, mock.dms[0].content} {
+				if !strings.Contains(msg, "**CIRCUIT BREAKER**") ||
+					!strings.Contains(msg, "[test-strategy]") ||
+					!strings.Contains(msg, tc.reason) ||
+					!strings.Contains(msg, "portfolio=$1234.56") {
+					t.Fatalf("notification missing required context: %q", msg)
+				}
+			}
+		})
+	}
+}
+
+func TestNotifyPerStrategyCircuitBreaker_SuppressesNonFreshAndPortfolioKill(t *testing.T) {
+	cases := []struct {
+		name                string
+		reason              string
+		portfolioKillFired  bool
+		notifierHasBackends bool
+		wantChannelMessages int
+		wantOwnerDMs        int
+	}{
+		{
+			name:                "latched circuit breaker no spam",
+			reason:              "circuit breaker active",
+			notifierHasBackends: true,
+		},
+		{
+			name:                "ordinary risk block",
+			reason:              "daily loss limit exceeded",
+			notifierHasBackends: true,
+		},
+		{
+			name:                "portfolio kill owns notification",
+			reason:              "max drawdown exceeded (30.0% > 25.0%)",
+			portfolioKillFired:  true,
+			notifierHasBackends: true,
+		},
+		{
+			name:                "no backends",
+			reason:              "5 consecutive losses",
+			notifierHasBackends: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &mockNotifier{}
+			notifier := &MultiNotifier{}
+			if tc.notifierHasBackends {
+				notifier.backends = []notifierBackend{
+					{
+						notifier: mock,
+						ownerID:  "owner123",
+						channels: map[string]string{"spot": "ch-spot"},
+					},
+				}
+			}
+			sc := StrategyConfig{ID: "test-strategy", Platform: "binanceus", Type: "spot"}
+
+			notifyPerStrategyCircuitBreaker(sc, tc.reason, 1234.56, notifier, tc.portfolioKillFired)
+
+			if len(mock.messages) != tc.wantChannelMessages {
+				t.Fatalf("channel messages = %d, want %d", len(mock.messages), tc.wantChannelMessages)
+			}
+			if len(mock.dms) != tc.wantOwnerDMs {
+				t.Fatalf("owner DMs = %d, want %d", len(mock.dms), tc.wantOwnerDMs)
 			}
 		})
 	}

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1140,6 +1140,16 @@ func perpsMarginDrawdownInputs(s *StrategyState, prices map[string]float64) (unr
 	return unrealizedLoss, margin
 }
 
+// Shared reason-string prefixes for CheckRisk return values. Consumers
+// (main.go notification dispatch, tests) must reference these constants
+// rather than re-typing literals so reason-string tweaks stay safe under
+// refactor.
+const (
+	RiskReasonCircuitBreakerActive = "circuit breaker active"
+	RiskReasonMaxDrawdownExceeded  = "max drawdown exceeded"
+	RiskReasonConsecutiveLosses    = "5 consecutive losses"
+)
+
 // CheckRisk evaluates risk state and returns whether trading is allowed.
 // sc is the strategy config for this state (nil in some tests — platform
 // pending logic is skipped). assist carries pre-fetched per-platform state
@@ -1154,7 +1164,7 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 	// Check circuit breaker
 	if r.CircuitBreaker {
 		if now.Before(r.CircuitBreakerUntil) {
-			return false, "circuit breaker active"
+			return false, RiskReasonCircuitBreakerActive
 		}
 		r.CircuitBreaker = false
 		r.ConsecutiveLosses = 0
@@ -1213,8 +1223,8 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 			setTopStepCircuitBreakerPending(sc, s, assist)
 			setOperatorRequiredCircuitBreakerPending(sc, s)
 			forceCloseAllPositions(s, prices, logger)
-			return false, fmt.Sprintf("max drawdown exceeded (%.1f%% > %.1f%%, portfolio=$%.2f peak=$%.2f, denom=%s=$%.2f)",
-				r.CurrentDrawdownPct, r.MaxDrawdownPct, portfolioValue, r.PeakValue, denomLabel, denom)
+			return false, fmt.Sprintf("%s (%.1f%% > %.1f%%, portfolio=$%.2f peak=$%.2f, denom=%s=$%.2f)",
+				RiskReasonMaxDrawdownExceeded, r.CurrentDrawdownPct, r.MaxDrawdownPct, portfolioValue, r.PeakValue, denomLabel, denom)
 		}
 	}
 
@@ -1228,7 +1238,7 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 		setTopStepCircuitBreakerPending(sc, s, assist)
 		setOperatorRequiredCircuitBreakerPending(sc, s)
 		forceCloseAllPositions(s, prices, logger)
-		return false, "5 consecutive losses"
+		return false, RiskReasonConsecutiveLosses
 	}
 
 	return true, ""


### PR DESCRIPTION
## Summary

Closes #411 by sending operator notifications when a per-strategy circuit breaker freshly fires.

## What changed

- Broadcast per-strategy circuit breaker notifications to all configured channels.
- Send the same notification to the owner DM.
- Include the strategy ID, risk-block reason, and current portfolio value in the message.
- Suppress repeated notifications for already-latched `circuit breaker active` cycles.
- Suppress per-strategy notifications when the portfolio kill switch has already fired in the same cycle, so the portfolio path owns that alert.

## Root cause

`CheckRisk` could latch a per-strategy circuit breaker and force-close positions, but the main risk-block path only logged the reason before skipping the strategy. Unlike portfolio kill switch warnings, it never called the notifier.

## Validation

- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go test ./...` from `scheduler/`

---
LLM: GPT-5.4 | high