### PR TITLE
fix: match claude.ai/code attribution in PR link rewrite + document LLM footer rule

### DIFF
--- a/.github/scripts/rewrite_create_pr_link.py
+++ b/.github/scripts/rewrite_create_pr_link.py
@@ -21,7 +21,7 @@ body = os.environ["BODY_IN"]
 footer = os.environ["FOOTER_TEXT"]
 
 default_attr = re.compile(
-    r"\n*Generated with \[Claude Code\]\(https://claude\.com/claude-code\)\s*\Z"
+    r"\n*Generated with \[Claude Code\]\(https://claude\.(?:com/claude-code|ai/code)\)\s*\Z"
 )
 
 

--- a/.github/scripts/test_rewrite_create_pr_link.py
+++ b/.github/scripts/test_rewrite_create_pr_link.py
@@ -51,6 +51,19 @@ class RewriteCreatePRLinkTest(unittest.TestCase):
         self.assertTrue(new_body.endswith(FOOTER))
         self.assertIn("## Summary", new_body)
 
+    def test_replaces_claude_ai_code_attribution(self):
+        default_attr = "Generated with [Claude Code](https://claude.ai/code)"
+        pr_body = f"## Summary\n- did a thing\n\n{default_attr}"
+        encoded = urllib.parse.quote(pr_body, safe="")
+        comment = f"[Create PR](https://github.com/owner/repo/compare/main...feat?quick_pull=1&body={encoded})"
+
+        out = run(comment)
+        new_body = extract_body_param(out)
+
+        self.assertNotIn("claude.ai/code", new_body)
+        self.assertTrue(new_body.endswith(FOOTER))
+        self.assertIn("## Summary", new_body)
+
     def test_appends_when_no_default_attribution(self):
         pr_body = "## Summary\n- did a thing"
         encoded = urllib.parse.quote(pr_body, safe="")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,12 @@
 - In GitHub comments and PR reviews, avoid using `#N` notation for numbered list items or steps (e.g. "step #1", "point #2") — GitHub auto-links these to issues/PRs. Use `1.` instead. Only use `#N` when intentionally linking to a specific issue or PR.
 - Fetch latest bot review on a PR: `gh api repos/richkuo/go-trader/issues/<N>/comments --jq '[.[] | select(.user.login=="codex[bot]" or .user.login=="claude[bot]")] | last | .body'` (top-level review summary lives on the **issues** endpoint, not pulls; inline review comments via `/pulls/<N>/comments`, review-object summaries via `/pulls/<N>/reviews`)
 - Before merging a long-running PR, `git fetch origin main && git diff origin/main..HEAD -- <paths>` to catch silent reverts from unrelated merges that landed on main while the PR was open. Rebase onto main if the diff shows unexpected deletions.
+- Replace the default `🤖 Generated with [Claude Code](https://claude.com/claude-code)` footer with a metadata footer, e.g.:
+  ```
+  ---
+  LLM: Claude Sonnet 4.6 | high
+  ```
+  Model name must match the model in use (Opus 4.7, Sonnet 4.6, Haiku 4.5, etc.). Effort is one of: low / medium / high. No `Co-Authored-By` trailer.
 
 ## Build & Deploy
 - Build: `cd scheduler && /opt/homebrew/bin/go build -o ../go-trader .` — always rebuild before smoke-testing `./go-trader`; stale binary gives misleading results


### PR DESCRIPTION
## Summary
- The default Claude Code attribution URL is now `claude.ai/code`, but `rewrite_create_pr_link.py` only matched the legacy `claude.com/claude-code`, so the default \"Generated with Claude Code\" line survived into shipped PR descriptions (e.g. #413).
- Broaden the regex to match both URL forms and add a regression test covering the `claude.ai/code` variant.
- Add the LLM/effort footer rule to the project CLAUDE.md Pull Requests section so it is enforced at the project level (mirrors the global `~/.claude/CLAUDE.md`).

## Test plan
- [x] `python3 .github/scripts/test_rewrite_create_pr_link.py` — 6/6 pass (new `test_replaces_claude_ai_code_attribution` included)
- [ ] Next claude-authored PR no longer carries the default attribution line

---
LLM: Claude Sonnet 4.6 | low