### PR TITLE
[codex] Speed up drawdown warning checks

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -321,6 +321,7 @@ func main() {
 		tickSeconds = 60
 	}
 	fmt.Printf("Tick interval: %ds (strategies have individual intervals)\n", tickSeconds)
+	drawdownWarnThresholdPct := configuredDrawdownWarnThresholdPct(cfg)
 
 	// Cycles per day, used for "daily" update check mode.
 	dailyCycles := (24 * 3600) / tickSeconds
@@ -356,19 +357,21 @@ func main() {
 				fmt.Printf("[ERROR] %s: capital_pct set but capital resolved to $0 — skipping\n", sc.ID)
 				continue
 			}
-			interval := sc.IntervalSeconds
-			if interval <= 0 {
-				interval = cfg.IntervalSeconds
-			}
+			mu.RLock()
+			interval := effectiveStrategyIntervalSeconds(sc, state.Strategies[sc.ID], cfg.IntervalSeconds, drawdownWarnThresholdPct)
+			mu.RUnlock()
 			last, exists := lastRun[sc.ID]
-			if !exists || time.Since(last) >= time.Duration(interval)*time.Second {
+			if !exists || cycleStart.Sub(last) >= time.Duration(interval)*time.Second {
 				dueStrategies = append(dueStrategies, sc)
 			}
 		}
 
 		if len(dueStrategies) == 0 {
 			// Nothing due, wait for next tick
-			timer := time.NewTimer(time.Duration(tickSeconds) * time.Second)
+			mu.RLock()
+			delay := schedulerDelay(cfg.Strategies, state.Strategies, lastRun, cfg.IntervalSeconds, drawdownWarnThresholdPct, time.Now(), tickSeconds)
+			mu.RUnlock()
+			timer := time.NewTimer(delay)
 			select {
 			case <-timer.C:
 				continue
@@ -1354,7 +1357,10 @@ func main() {
 		}
 
 		// Wait for next tick or shutdown
-		timer := time.NewTimer(time.Duration(tickSeconds) * time.Second)
+		mu.RLock()
+		delay := schedulerDelay(cfg.Strategies, state.Strategies, lastRun, cfg.IntervalSeconds, drawdownWarnThresholdPct, time.Now(), tickSeconds)
+		mu.RUnlock()
+		timer := time.NewTimer(delay)
 		select {
 		case <-timer.C:
 			// Next tick

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -303,7 +303,13 @@ func main() {
 	deribitPricer := NewDeribitPricer()
 	fmt.Println("Option pricers ready (deribit: live API, ibkr: Black-Scholes)")
 
-	// Track last-run time per strategy for per-strategy intervals
+	// Track last-run time per strategy for per-strategy intervals.
+	// Single-writer invariant: lastRun is only mutated from the scheduler
+	// goroutine (this for-loop and the per-strategy continuations below).
+	// Reads from the same goroutine (the dueStrategies loop and the
+	// schedulerDelay calls) are safe without additional synchronization.
+	// If you ever split writes across goroutines, add explicit locking —
+	// the existing `mu` lock guards `state`, not `lastRun`.
 	lastRun := make(map[string]time.Time)
 
 	// Determine tick interval: GCD of all strategy intervals, min 60s
@@ -323,11 +329,14 @@ func main() {
 	fmt.Printf("Tick interval: %ds (strategies have individual intervals)\n", tickSeconds)
 	drawdownWarnThresholdPct := configuredDrawdownWarnThresholdPct(cfg)
 
-	// Cycles per day, used for "daily" update check mode.
-	dailyCycles := (24 * 3600) / tickSeconds
-	if dailyCycles < 1 {
-		dailyCycles = 1
-	}
+	// Wall-clock tracker for cfg.AutoUpdate == "daily". Initialized to now so
+	// the first daily check fires after 24h (matching the previous
+	// cycle-based behavior). We can't use cycle counts anymore because the
+	// scheduler no longer sleeps a fixed tick — schedulerDelay returns a
+	// variable delay (1s when due, up to the longest strategy interval
+	// otherwise), so cycle increments no longer correspond to wall-clock
+	// time.
+	lastAutoUpdateCheck := time.Now()
 
 	saveFailures := 0
 	resetGoroutineRunning := false
@@ -348,6 +357,13 @@ func main() {
 		// across cycles and is picked up by the value-copies in dueStrategies.
 		resolveCapitalPct(cfg.Strategies)
 
+		// Compute effective per-strategy intervals once per cycle under
+		// RLock; reuse the same map for due-detection and schedulerDelay
+		// below to avoid re-entering the lock and recomputing per strategy.
+		mu.RLock()
+		intervals := effectiveStrategyIntervals(cfg.Strategies, state.Strategies, cfg.IntervalSeconds, drawdownWarnThresholdPct)
+		mu.RUnlock()
+
 		// Determine which strategies are due this tick
 		dueStrategies := make([]StrategyConfig, 0)
 		for _, sc := range cfg.Strategies {
@@ -357,9 +373,7 @@ func main() {
 				fmt.Printf("[ERROR] %s: capital_pct set but capital resolved to $0 — skipping\n", sc.ID)
 				continue
 			}
-			mu.RLock()
-			interval := effectiveStrategyIntervalSeconds(sc, state.Strategies[sc.ID], cfg.IntervalSeconds, drawdownWarnThresholdPct)
-			mu.RUnlock()
+			interval := intervals[sc.ID]
 			last, exists := lastRun[sc.ID]
 			if !exists || cycleStart.Sub(last) >= time.Duration(interval)*time.Second {
 				dueStrategies = append(dueStrategies, sc)
@@ -368,9 +382,7 @@ func main() {
 
 		if len(dueStrategies) == 0 {
 			// Nothing due, wait for next tick
-			mu.RLock()
-			delay := schedulerDelay(cfg.Strategies, state.Strategies, lastRun, cfg.IntervalSeconds, drawdownWarnThresholdPct, time.Now(), tickSeconds)
-			mu.RUnlock()
+			delay := schedulerDelay(cfg.Strategies, intervals, lastRun, cfg.IntervalSeconds, time.Now(), tickSeconds)
 			timer := time.NewTimer(delay)
 			select {
 			case <-timer.C:
@@ -1344,11 +1356,14 @@ func main() {
 			}
 		}
 
-		// Periodic update check (heartbeat: every cycle; daily: once per day).
+		// Periodic update check (heartbeat: every cycle; daily: once per
+		// 24h wall-clock — was cycle-based, broke when schedulerDelay
+		// became variable, see lastAutoUpdateCheck above).
 		if cfg.AutoUpdate == "heartbeat" {
 			checkForUpdates(cfg, notifier, &lastNotifiedHash, &mu, state, stateDB)
-		} else if cfg.AutoUpdate == "daily" && cycle%dailyCycles == 0 {
+		} else if cfg.AutoUpdate == "daily" && time.Since(lastAutoUpdateCheck) >= 24*time.Hour {
 			checkForUpdates(cfg, notifier, &lastNotifiedHash, &mu, state, stateDB)
+			lastAutoUpdateCheck = time.Now()
 		}
 
 		if *once {
@@ -1356,10 +1371,14 @@ func main() {
 			return
 		}
 
-		// Wait for next tick or shutdown
+		// Wait for next tick or shutdown. Recompute intervals here under
+		// RLock — drawdown state may have changed during the cycle, so
+		// re-evaluating ensures a strategy that just entered (or exited)
+		// the warning band gets the fast (or slow) cadence immediately.
 		mu.RLock()
-		delay := schedulerDelay(cfg.Strategies, state.Strategies, lastRun, cfg.IntervalSeconds, drawdownWarnThresholdPct, time.Now(), tickSeconds)
+		endIntervals := effectiveStrategyIntervals(cfg.Strategies, state.Strategies, cfg.IntervalSeconds, drawdownWarnThresholdPct)
 		mu.RUnlock()
+		delay := schedulerDelay(cfg.Strategies, endIntervals, lastRun, cfg.IntervalSeconds, time.Now(), tickSeconds)
 		timer := time.NewTimer(delay)
 		select {
 		case <-timer.C:

--- a/scheduler/strategy_interval.go
+++ b/scheduler/strategy_interval.go
@@ -1,0 +1,89 @@
+package main
+
+import "time"
+
+const (
+	strategyDrawdownFastIntervalSeconds = 90
+	defaultDrawdownWarnThresholdPct     = 80
+)
+
+func configuredDrawdownWarnThresholdPct(cfg *Config) float64 {
+	if cfg != nil && cfg.PortfolioRisk != nil && cfg.PortfolioRisk.WarnThresholdPct > 0 {
+		return cfg.PortfolioRisk.WarnThresholdPct
+	}
+	return defaultDrawdownWarnThresholdPct
+}
+
+func configuredStrategyIntervalSeconds(sc StrategyConfig, globalIntervalSeconds int) int {
+	if sc.IntervalSeconds > 0 {
+		return sc.IntervalSeconds
+	}
+	return globalIntervalSeconds
+}
+
+func strategyDrawdownWarningActive(s *StrategyState, warnThresholdPct float64) bool {
+	if s == nil || s.RiskState.CircuitBreaker {
+		return false
+	}
+	r := s.RiskState
+	if r.TotalTrades <= 0 || r.MaxDrawdownPct <= 0 || warnThresholdPct <= 0 {
+		return false
+	}
+	warnDrawdownPct := r.MaxDrawdownPct * warnThresholdPct / 100
+	return r.CurrentDrawdownPct > warnDrawdownPct && r.CurrentDrawdownPct <= r.MaxDrawdownPct
+}
+
+func effectiveStrategyIntervalSeconds(sc StrategyConfig, s *StrategyState, globalIntervalSeconds int, warnThresholdPct float64) int {
+	interval := configuredStrategyIntervalSeconds(sc, globalIntervalSeconds)
+	if strategyDrawdownWarningActive(s, warnThresholdPct) && (interval <= 0 || interval > strategyDrawdownFastIntervalSeconds) {
+		return strategyDrawdownFastIntervalSeconds
+	}
+	return interval
+}
+
+func nextStrategyCheckDelay(strategies []StrategyConfig, states map[string]*StrategyState, lastRun map[string]time.Time, globalIntervalSeconds int, warnThresholdPct float64, now time.Time) time.Duration {
+	var minDelay time.Duration
+	hasCandidate := false
+	for _, sc := range strategies {
+		if shouldSkipZeroCapital(sc) {
+			continue
+		}
+		interval := effectiveStrategyIntervalSeconds(sc, states[sc.ID], globalIntervalSeconds, warnThresholdPct)
+		if interval <= 0 {
+			continue
+		}
+		hasCandidate = true
+		last, ok := lastRun[sc.ID]
+		if !ok {
+			return 0
+		}
+		delay := last.Add(time.Duration(interval) * time.Second).Sub(now)
+		if delay <= 0 {
+			return 0
+		}
+		if minDelay == 0 || delay < minDelay {
+			minDelay = delay
+		}
+	}
+	if !hasCandidate {
+		return -1
+	}
+	return minDelay
+}
+
+func schedulerDelay(strategies []StrategyConfig, states map[string]*StrategyState, lastRun map[string]time.Time, globalIntervalSeconds int, warnThresholdPct float64, now time.Time, fallbackSeconds int) time.Duration {
+	delay := nextStrategyCheckDelay(strategies, states, lastRun, globalIntervalSeconds, warnThresholdPct, now)
+	if delay > 0 {
+		return delay
+	}
+	if delay == 0 {
+		return time.Second
+	}
+	if fallbackSeconds <= 0 {
+		fallbackSeconds = globalIntervalSeconds
+	}
+	if fallbackSeconds <= 0 {
+		fallbackSeconds = 60
+	}
+	return time.Duration(fallbackSeconds) * time.Second
+}

--- a/scheduler/strategy_interval.go
+++ b/scheduler/strategy_interval.go
@@ -7,6 +7,15 @@ const (
 	defaultDrawdownWarnThresholdPct     = 80
 )
 
+// configuredDrawdownWarnThresholdPct returns the percent-of-max threshold at
+// which a strategy enters per-strategy "drawdown warning" mode (and switches to
+// the fast 90s check interval).
+//
+// Note: this currently reuses cfg.PortfolioRisk.WarnThresholdPct, which was
+// originally designed for portfolio-level (PeakValue vs total equity) warnings.
+// Per-strategy drawdown warning shares the same knob today; if the two ever
+// need to diverge, add an optional StrategyConfig.DrawdownWarnThresholdPct
+// override and prefer it over the portfolio-level value here.
 func configuredDrawdownWarnThresholdPct(cfg *Config) float64 {
 	if cfg != nil && cfg.PortfolioRisk != nil && cfg.PortfolioRisk.WarnThresholdPct > 0 {
 		return cfg.PortfolioRisk.WarnThresholdPct
@@ -21,6 +30,13 @@ func configuredStrategyIntervalSeconds(sc StrategyConfig, globalIntervalSeconds 
 	return globalIntervalSeconds
 }
 
+// strategyDrawdownWarningActive reports whether a strategy should switch to
+// the fast check cadence because its current drawdown has crossed the warn
+// threshold (warnThresholdPct % of MaxDrawdownPct). The check intentionally
+// has no upper bound: if drawdown has exceeded MaxDrawdownPct but the circuit
+// breaker hasn't flipped yet (CB is set inside CheckRisk during a real cycle),
+// we still want the fast cadence so the next cycle can fire CB ASAP. The
+// CircuitBreaker guard above handles the post-CB case.
 func strategyDrawdownWarningActive(s *StrategyState, warnThresholdPct float64) bool {
 	if s == nil || s.RiskState.CircuitBreaker {
 		return false
@@ -30,7 +46,7 @@ func strategyDrawdownWarningActive(s *StrategyState, warnThresholdPct float64) b
 		return false
 	}
 	warnDrawdownPct := r.MaxDrawdownPct * warnThresholdPct / 100
-	return r.CurrentDrawdownPct > warnDrawdownPct && r.CurrentDrawdownPct <= r.MaxDrawdownPct
+	return r.CurrentDrawdownPct > warnDrawdownPct
 }
 
 func effectiveStrategyIntervalSeconds(sc StrategyConfig, s *StrategyState, globalIntervalSeconds int, warnThresholdPct float64) int {
@@ -41,18 +57,37 @@ func effectiveStrategyIntervalSeconds(sc StrategyConfig, s *StrategyState, globa
 	return interval
 }
 
-func nextStrategyCheckDelay(strategies []StrategyConfig, states map[string]*StrategyState, lastRun map[string]time.Time, globalIntervalSeconds int, warnThresholdPct float64, now time.Time) time.Duration {
+// effectiveStrategyIntervals computes the effective per-strategy check
+// interval for every strategy in one pass. Callers that need the same
+// intervals for both due-detection and the scheduler delay calculation should
+// compute this map once per cycle (under mu.RLock) and pass it to both
+// strategyIsDue and nextStrategyCheckDelay, instead of recomputing per call.
+func effectiveStrategyIntervals(strategies []StrategyConfig, states map[string]*StrategyState, globalIntervalSeconds int, warnThresholdPct float64) map[string]int {
+	out := make(map[string]int, len(strategies))
+	for _, sc := range strategies {
+		out[sc.ID] = effectiveStrategyIntervalSeconds(sc, states[sc.ID], globalIntervalSeconds, warnThresholdPct)
+	}
+	return out
+}
+
+// nextStrategyCheckDelay returns the time until the next strategy is due, or
+// 0 if any strategy is due now (including a first-run strategy with no
+// lastRun entry), or -1 if no strategy is a delay candidate at all (all
+// skipped by zero-capital or non-positive interval). The -1 sentinel lets
+// schedulerDelay distinguish "fire ASAP" from "nothing scheduled — fall back."
+//
+// `intervals` must be the precomputed map from effectiveStrategyIntervals.
+func nextStrategyCheckDelay(strategies []StrategyConfig, intervals map[string]int, lastRun map[string]time.Time, now time.Time) time.Duration {
 	var minDelay time.Duration
 	hasCandidate := false
 	for _, sc := range strategies {
 		if shouldSkipZeroCapital(sc) {
 			continue
 		}
-		interval := effectiveStrategyIntervalSeconds(sc, states[sc.ID], globalIntervalSeconds, warnThresholdPct)
+		interval := intervals[sc.ID]
 		if interval <= 0 {
 			continue
 		}
-		hasCandidate = true
 		last, ok := lastRun[sc.ID]
 		if !ok {
 			return 0
@@ -61,8 +96,9 @@ func nextStrategyCheckDelay(strategies []StrategyConfig, states map[string]*Stra
 		if delay <= 0 {
 			return 0
 		}
-		if minDelay == 0 || delay < minDelay {
+		if !hasCandidate || delay < minDelay {
 			minDelay = delay
+			hasCandidate = true
 		}
 	}
 	if !hasCandidate {
@@ -71,8 +107,11 @@ func nextStrategyCheckDelay(strategies []StrategyConfig, states map[string]*Stra
 	return minDelay
 }
 
-func schedulerDelay(strategies []StrategyConfig, states map[string]*StrategyState, lastRun map[string]time.Time, globalIntervalSeconds int, warnThresholdPct float64, now time.Time, fallbackSeconds int) time.Duration {
-	delay := nextStrategyCheckDelay(strategies, states, lastRun, globalIntervalSeconds, warnThresholdPct, now)
+// schedulerDelay turns the next-due time into a sleep duration: a positive
+// next-due wins; "due now" sleeps 1s to yield; "no candidates" falls back to
+// fallbackSeconds (then globalIntervalSeconds, then 60s).
+func schedulerDelay(strategies []StrategyConfig, intervals map[string]int, lastRun map[string]time.Time, globalIntervalSeconds int, now time.Time, fallbackSeconds int) time.Duration {
+	delay := nextStrategyCheckDelay(strategies, intervals, lastRun, now)
 	if delay > 0 {
 		return delay
 	}

--- a/scheduler/strategy_interval_test.go
+++ b/scheduler/strategy_interval_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEffectiveStrategyIntervalSeconds_DrawdownWarningUsesFastInterval(t *testing.T) {
+	sc := StrategyConfig{ID: "s1", IntervalSeconds: 3600}
+	state := &StrategyState{
+		RiskState: RiskState{
+			MaxDrawdownPct:     10,
+			CurrentDrawdownPct: 8.5,
+			TotalTrades:        1,
+		},
+	}
+
+	got := effectiveStrategyIntervalSeconds(sc, state, 600, 80)
+	if got != strategyDrawdownFastIntervalSeconds {
+		t.Errorf("effective interval = %d, want %d", got, strategyDrawdownFastIntervalSeconds)
+	}
+}
+
+func TestEffectiveStrategyIntervalSeconds_DrawdownRecoveryReverts(t *testing.T) {
+	sc := StrategyConfig{ID: "s1", IntervalSeconds: 3600}
+	state := &StrategyState{
+		RiskState: RiskState{
+			MaxDrawdownPct:     10,
+			CurrentDrawdownPct: 7.5,
+			TotalTrades:        1,
+		},
+	}
+
+	got := effectiveStrategyIntervalSeconds(sc, state, 600, 80)
+	if got != 3600 {
+		t.Errorf("effective interval = %d, want normal interval 3600", got)
+	}
+}
+
+func TestEffectiveStrategyIntervalSeconds_OnlyWarningStrategySpeedsUp(t *testing.T) {
+	strategies := []StrategyConfig{
+		{ID: "warning", IntervalSeconds: 3600, Capital: 1000},
+		{ID: "normal", IntervalSeconds: 3600, Capital: 1000},
+	}
+	states := map[string]*StrategyState{
+		"warning": {
+			RiskState: RiskState{MaxDrawdownPct: 10, CurrentDrawdownPct: 8.1, TotalTrades: 1},
+		},
+		"normal": {
+			RiskState: RiskState{MaxDrawdownPct: 10, CurrentDrawdownPct: 2.0, TotalTrades: 1},
+		},
+	}
+
+	if got := effectiveStrategyIntervalSeconds(strategies[0], states["warning"], 600, 80); got != strategyDrawdownFastIntervalSeconds {
+		t.Errorf("warning strategy interval = %d, want %d", got, strategyDrawdownFastIntervalSeconds)
+	}
+	if got := effectiveStrategyIntervalSeconds(strategies[1], states["normal"], 600, 80); got != 3600 {
+		t.Errorf("normal strategy interval = %d, want 3600", got)
+	}
+}
+
+func TestEffectiveStrategyIntervalSeconds_DoesNotSlowAlreadyFastStrategy(t *testing.T) {
+	sc := StrategyConfig{ID: "s1", IntervalSeconds: 60}
+	state := &StrategyState{
+		RiskState: RiskState{
+			MaxDrawdownPct:     10,
+			CurrentDrawdownPct: 8.5,
+			TotalTrades:        1,
+		},
+	}
+
+	got := effectiveStrategyIntervalSeconds(sc, state, 600, 80)
+	if got != 60 {
+		t.Errorf("effective interval = %d, want existing faster interval 60", got)
+	}
+}
+
+func TestEffectiveStrategyIntervalSeconds_CircuitBreakerIsNotWarningMode(t *testing.T) {
+	sc := StrategyConfig{ID: "s1", IntervalSeconds: 3600}
+	state := &StrategyState{
+		RiskState: RiskState{
+			MaxDrawdownPct:     10,
+			CurrentDrawdownPct: 12,
+			TotalTrades:        1,
+			CircuitBreaker:     true,
+		},
+	}
+
+	got := effectiveStrategyIntervalSeconds(sc, state, 600, 80)
+	if got != 3600 {
+		t.Errorf("effective interval = %d, want normal interval 3600 while circuit breaker is active", got)
+	}
+}
+
+func TestNextStrategyCheckDelay_UsesWarningInterval(t *testing.T) {
+	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	strategies := []StrategyConfig{
+		{ID: "warning", IntervalSeconds: 3600, Capital: 1000},
+		{ID: "normal", IntervalSeconds: 3600, Capital: 1000},
+	}
+	states := map[string]*StrategyState{
+		"warning": {
+			RiskState: RiskState{MaxDrawdownPct: 10, CurrentDrawdownPct: 8.5, TotalTrades: 1},
+		},
+		"normal": {
+			RiskState: RiskState{MaxDrawdownPct: 10, CurrentDrawdownPct: 1.0, TotalTrades: 1},
+		},
+	}
+	lastRun := map[string]time.Time{
+		"warning": now.Add(-30 * time.Second),
+		"normal":  now.Add(-30 * time.Second),
+	}
+
+	got := nextStrategyCheckDelay(strategies, states, lastRun, 600, 80, now)
+	if got != time.Minute {
+		t.Errorf("next delay = %s, want 1m", got)
+	}
+}

--- a/scheduler/strategy_interval_test.go
+++ b/scheduler/strategy_interval_test.go
@@ -92,6 +92,28 @@ func TestEffectiveStrategyIntervalSeconds_CircuitBreakerIsNotWarningMode(t *test
 	}
 }
 
+// Drawdown that has already exceeded MaxDrawdownPct (but circuit breaker
+// hasn't flipped yet — CB only sets inside CheckRisk during a real cycle)
+// must still use the fast cadence so the next cycle can trip CB ASAP.
+// Regression test for #417 review: the previous implementation had an upper
+// bound `<= MaxDrawdownPct` that incorrectly fell back to the slow interval
+// in this most-urgent case.
+func TestEffectiveStrategyIntervalSeconds_OverMaxDrawdownStillFast(t *testing.T) {
+	sc := StrategyConfig{ID: "s1", IntervalSeconds: 3600}
+	state := &StrategyState{
+		RiskState: RiskState{
+			MaxDrawdownPct:     10,
+			CurrentDrawdownPct: 12, // already over max; CB not yet set
+			TotalTrades:        1,
+		},
+	}
+
+	got := effectiveStrategyIntervalSeconds(sc, state, 600, 80)
+	if got != strategyDrawdownFastIntervalSeconds {
+		t.Errorf("effective interval = %d, want fast %d when drawdown exceeds max but CB not yet set", got, strategyDrawdownFastIntervalSeconds)
+	}
+}
+
 func TestNextStrategyCheckDelay_UsesWarningInterval(t *testing.T) {
 	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
 	strategies := []StrategyConfig{
@@ -111,8 +133,67 @@ func TestNextStrategyCheckDelay_UsesWarningInterval(t *testing.T) {
 		"normal":  now.Add(-30 * time.Second),
 	}
 
-	got := nextStrategyCheckDelay(strategies, states, lastRun, 600, 80, now)
+	intervals := effectiveStrategyIntervals(strategies, states, 600, 80)
+	got := nextStrategyCheckDelay(strategies, intervals, lastRun, now)
 	if got != time.Minute {
 		t.Errorf("next delay = %s, want 1m", got)
+	}
+}
+
+// First-run path: a strategy with no lastRun entry must short-circuit to 0
+// so schedulerDelay yields immediately (1s) and the dueStrategies loop picks
+// it up next cycle.
+func TestNextStrategyCheckDelay_FirstRunReturnsZero(t *testing.T) {
+	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	strategies := []StrategyConfig{
+		{ID: "fresh", IntervalSeconds: 3600, Capital: 1000},
+	}
+	intervals := effectiveStrategyIntervals(strategies, nil, 600, 80)
+
+	got := nextStrategyCheckDelay(strategies, intervals, map[string]time.Time{}, now)
+	if got != 0 {
+		t.Errorf("first-run delay = %s, want 0", got)
+	}
+
+	// schedulerDelay should turn that into a 1s yield.
+	sd := schedulerDelay(strategies, intervals, map[string]time.Time{}, 600, now, 60)
+	if sd != time.Second {
+		t.Errorf("schedulerDelay first-run = %s, want 1s", sd)
+	}
+}
+
+// No-candidate path: every strategy is skipped (zero capital with capital_pct
+// set, or non-positive interval). nextStrategyCheckDelay must return -1 so
+// schedulerDelay falls back to the configured fallback interval rather than
+// busy-looping.
+func TestNextStrategyCheckDelay_NoCandidatesReturnsNegative(t *testing.T) {
+	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	strategies := []StrategyConfig{
+		// shouldSkipZeroCapital: capital_pct set (0-1) + capital == 0
+		{ID: "skipped-zero-cap", IntervalSeconds: 3600, CapitalPct: 0.5, Capital: 0},
+	}
+	intervals := effectiveStrategyIntervals(strategies, nil, 600, 80)
+
+	got := nextStrategyCheckDelay(strategies, intervals, map[string]time.Time{}, now)
+	if got != -1 {
+		t.Errorf("no-candidates delay = %s, want -1", got)
+	}
+
+	// schedulerDelay should fall back to the configured fallbackSeconds.
+	sd := schedulerDelay(strategies, intervals, map[string]time.Time{}, 600, now, 120)
+	if sd != 120*time.Second {
+		t.Errorf("schedulerDelay no-candidates = %s, want 120s fallback", sd)
+	}
+
+	// fallbackSeconds <= 0 → use globalIntervalSeconds.
+	sd = schedulerDelay(strategies, intervals, map[string]time.Time{}, 600, now, 0)
+	if sd != 600*time.Second {
+		t.Errorf("schedulerDelay fallback->global = %s, want 600s", sd)
+	}
+
+	// Both <= 0 → 60s ultimate fallback.
+	sd = schedulerDelay(strategies, intervals, map[string]time.Time{}, 0, now, 0)
+	if sd != 60*time.Second {
+		t.Errorf("schedulerDelay ultimate fallback = %s, want 60s", sd)
 	}
 }


### PR DESCRIPTION
## Summary
- Add scheduler helpers that detect per-strategy drawdown warning state and temporarily use a 90s effective interval.
- Wire the main scheduling loop to use the fast interval only for strategies currently in that warning band, then revert automatically when drawdown recovers.
- Add unit coverage for warning activation, recovery, per-strategy isolation, already-fast strategies, circuit-breaker exclusion, and next-delay calculation.

## Validation
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go test ./...`
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go build .`
- `git diff --check`

Closes #414

---
LLM: GPT-5.4 | high