### PR TITLE
feat: add per-trade stop-loss via HL trigger orders

### DIFF
--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -253,6 +253,16 @@ class HyperliquidExchangeAdapter:
             )
         return self._exchange.market_close(symbol, sz)
 
+    def round_perps_trigger_px(self, symbol: str, px: float) -> float:
+        """Public wrapper around HL's per-asset price-tick rounding.
+
+        Callers that need to record the post-rounding trigger price (for PnL
+        bookkeeping when the SL fills) can pre-round before calling
+        ``place_stop_loss``; rounding is idempotent.
+        """
+        sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3) if self._info else 3
+        return _round_perps_px(px, sz_decimals)
+
     def place_stop_loss(
         self,
         symbol: str,

--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -228,3 +228,56 @@ class HyperliquidExchangeAdapter:
                 "market_close requires live mode (set HYPERLIQUID_SECRET_KEY)"
             )
         return self._exchange.market_close(symbol, sz)
+
+    def place_stop_loss(
+        self,
+        symbol: str,
+        sz: float,
+        trigger_px: float,
+        is_buy: bool,
+        limit_slippage_pct: float = 5.0,
+    ) -> dict:
+        """Place a reduce-only stop-loss trigger order (#412).
+
+        ``is_buy`` is the direction of the triggered order itself — a long
+        position's stop-loss is a SELL (is_buy=False); a short's is a BUY
+        (is_buy=True). HL requires a ``limit_px`` as the worst acceptable
+        fill price; a market-trigger uses a wide band off the trigger
+        (default 5%) so slippage around the stop doesn't reject the fill.
+
+        HL enforces a 10 trigger-orders-per-day cap per account (resets 00:00
+        UTC). Callers should track + warn upstream.
+        """
+        if not self._exchange:
+            raise RuntimeError(
+                "place_stop_loss requires live mode (set HYPERLIQUID_SECRET_KEY)"
+            )
+        if symbol not in self._info.asset_to_sz_decimals:
+            print(f"[WARN] sz_decimals not found for {symbol}, defaulting to 3", file=sys.stderr)
+        sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3)
+        sz = round(sz, sz_decimals)
+        if sz <= 0:
+            raise ValueError(f"Size rounded to zero for {symbol} (sz_decimals={sz_decimals})")
+        if trigger_px <= 0:
+            raise ValueError(f"trigger_px must be > 0, got {trigger_px}")
+
+        slip = max(limit_slippage_pct, 0.0) / 100.0
+        if is_buy:
+            limit_px = trigger_px * (1.0 + slip)
+        else:
+            limit_px = trigger_px * (1.0 - slip)
+        limit_px = round(limit_px, 6)
+        trigger_px = round(trigger_px, 6)
+
+        order_type = {"trigger": {"triggerPx": trigger_px, "isMarket": True, "tpsl": "sl"}}
+        return self._exchange.order(
+            symbol, is_buy, sz, limit_px, order_type, reduce_only=True
+        )
+
+    def cancel_trigger_order(self, symbol: str, oid: int) -> dict:
+        """Cancel a resting trigger order by OID (#412)."""
+        if not self._exchange:
+            raise RuntimeError(
+                "cancel_trigger_order requires live mode (set HYPERLIQUID_SECRET_KEY)"
+            )
+        return self._exchange.cancel(symbol, int(oid))

--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -10,6 +10,7 @@ Environment variables:
     HYPERLIQUID_TESTNET=1        — use testnet instead of mainnet
 """
 
+import math
 import os
 import sys
 import time
@@ -29,6 +30,29 @@ except ImportError:
     _HLInfo = None
     _HLExchange = None
     _SDK_AVAILABLE = False
+
+
+def _round_perps_px(px: float, sz_decimals: int) -> float:
+    """Round a perps price to HL's tick rules.
+
+    Two constraints apply simultaneously:
+      - At most (MAX_DECIMALS - sz_decimals) decimal places, where
+        MAX_DECIMALS=6 for perps. Higher-priced assets (BTC sz_decimals=5)
+        therefore allow only 1 decimal of price precision.
+      - At most 5 significant figures.
+
+    The earlier fixed-6-decimal round was fine for tiny-priced coins but
+    routinely produced HL "price has too many decimals" rejections on
+    majors, leaving the position unprotected with the SL slot consumed
+    (#421 review point 5).
+    """
+    if px <= 0:
+        return px
+    px_decimals = max(0, 6 - sz_decimals)
+    log = math.floor(math.log10(abs(px)))
+    sig_decimals = max(0, 5 - 1 - int(log))
+    decimals = min(px_decimals, sig_decimals)
+    return round(px, decimals)
 
 
 class HyperliquidExchangeAdapter:
@@ -246,7 +270,10 @@ class HyperliquidExchangeAdapter:
         (default 5%) so slippage around the stop doesn't reject the fill.
 
         HL enforces a 10 trigger-orders-per-day cap per account (resets 00:00
-        UTC). Callers should track + warn upstream.
+        UTC). Cap exhaustion surfaces as an order-status error string (e.g.
+        "Too many open trigger orders") in the SDK response; the scheduler
+        detects it via isHLTriggerCapRejection and escalates to CRITICAL +
+        notifier — no proactive client-side counter is required.
         """
         if not self._exchange:
             raise RuntimeError(
@@ -266,8 +293,13 @@ class HyperliquidExchangeAdapter:
             limit_px = trigger_px * (1.0 + slip)
         else:
             limit_px = trigger_px * (1.0 - slip)
-        limit_px = round(limit_px, 6)
-        trigger_px = round(trigger_px, 6)
+        # HL perps: prices use at most (MAX_DECIMALS - sz_decimals) decimals
+        # AND at most 5 significant figures. Fixed-6-decimal rounding here
+        # was rejected by HL on high-priced assets like BTC (sz_decimals=5,
+        # so px_decimals=1) — the trigger sat resting only because the order
+        # got rejected (#421 review point 5).
+        limit_px = _round_perps_px(limit_px, sz_decimals)
+        trigger_px = _round_perps_px(trigger_px, sz_decimals)
 
         order_type = {"trigger": {"triggerPx": trigger_px, "isMarket": True, "tpsl": "sl"}}
         return self._exchange.order(

--- a/platforms/hyperliquid/test_adapter.py
+++ b/platforms/hyperliquid/test_adapter.py
@@ -355,6 +355,15 @@ class TestStopLossPlacement:
         assert mod._round_perps_px(0, sz_decimals=5) == 0
         assert mod._round_perps_px(-1.5, sz_decimals=5) == -1.5
 
+    def test_round_perps_trigger_px_matches_internal_helper(self):
+        # Public wrapper must produce the same value place_stop_loss would
+        # submit, so callers can record the post-rounding price for PnL.
+        adapter, _, mod = self._live_adapter(sz_decimals={"BTC": 5})
+        assert adapter.round_perps_trigger_px("BTC", 63123.456) == mod._round_perps_px(63123.456, 5)
+        # Idempotent — rounding a rounded value returns the same value.
+        rounded = adapter.round_perps_trigger_px("BTC", 63123.456)
+        assert adapter.round_perps_trigger_px("BTC", rounded) == rounded
+
     def test_cancel_trigger_order_paper_mode_raises(self):
         mock_info = MagicMock()
         mock_info_cls = MagicMock(return_value=mock_info)

--- a/platforms/hyperliquid/test_adapter.py
+++ b/platforms/hyperliquid/test_adapter.py
@@ -265,3 +265,106 @@ class TestOrderExecution:
 
         adapter.market_close("ETH", 0.25)
         mock_exchange.market_close.assert_called_once_with("ETH", 0.25)
+
+
+# ─── Stop Loss / Trigger Orders (#412 / #421) ──────
+
+class TestStopLossPlacement:
+    """Coverage for place_stop_loss + cancel_trigger_order added in #412 and
+    refined for tick-size rules in #421 review point 5."""
+
+    def _live_adapter(self, sz_decimals=None):
+        mock_info = MagicMock()
+        mock_info.asset_to_sz_decimals = sz_decimals or {"BTC": 5, "ETH": 4}
+        mock_info_cls = MagicMock(return_value=mock_info)
+        mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
+        adapter = mod.HyperliquidExchangeAdapter()
+        mock_exchange = MagicMock()
+        adapter._exchange = mock_exchange
+        adapter._info = mock_info
+        return adapter, mock_exchange, mod
+
+    def test_place_stop_loss_paper_mode_raises(self):
+        mock_info = MagicMock()
+        mock_info_cls = MagicMock(return_value=mock_info)
+        mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
+        adapter = mod.HyperliquidExchangeAdapter()
+        with pytest.raises(RuntimeError, match="live mode"):
+            adapter.place_stop_loss("BTC", 0.01, 60000, False)
+
+    def test_place_stop_loss_long_uses_sell_with_lower_limit(self):
+        adapter, ex, _ = self._live_adapter()
+        ex.order.return_value = {"status": "ok"}
+        adapter.place_stop_loss("ETH", 0.5, 3000.0, is_buy=False, limit_slippage_pct=5.0)
+        args, kwargs = ex.order.call_args
+        sym, is_buy, sz, limit_px, order_type = args
+        assert sym == "ETH"
+        assert is_buy is False
+        # limit_px is below trigger_px for a sell-stop
+        assert limit_px < 3000.0
+        assert kwargs == {"reduce_only": True}
+        assert order_type["trigger"]["tpsl"] == "sl"
+        assert order_type["trigger"]["isMarket"] is True
+
+    def test_place_stop_loss_short_uses_buy_with_higher_limit(self):
+        adapter, ex, _ = self._live_adapter()
+        ex.order.return_value = {"status": "ok"}
+        adapter.place_stop_loss("ETH", 0.5, 3000.0, is_buy=True, limit_slippage_pct=5.0)
+        _, _, _, limit_px, _ = ex.order.call_args.args
+        # limit_px is above trigger_px for a buy-stop
+        assert limit_px > 3000.0
+
+    def test_place_stop_loss_size_rounds_to_zero_raises(self):
+        adapter, _, _ = self._live_adapter(sz_decimals={"BTC": 0})
+        with pytest.raises(ValueError, match="rounded to zero"):
+            adapter.place_stop_loss("BTC", 0.4, 60000, False)
+
+    def test_place_stop_loss_invalid_trigger_px_raises(self):
+        adapter, _, _ = self._live_adapter()
+        with pytest.raises(ValueError, match="trigger_px must be > 0"):
+            adapter.place_stop_loss("BTC", 0.01, 0, False)
+
+    def test_place_stop_loss_high_priced_asset_uses_per_asset_px_decimals(self):
+        # BTC has sz_decimals=5 → px_decimals = 6 - 5 = 1. Fixed-6-decimal
+        # rounding (the pre-#421 behavior) would produce e.g. 60000.000000;
+        # the new logic must round to ≤1 decimal, capped at 5 sig figs.
+        adapter, ex, mod = self._live_adapter(sz_decimals={"BTC": 5})
+        ex.order.return_value = {"status": "ok"}
+        # Use a trigger_px that would produce extra decimals after the
+        # slip-band multiplication. trigger_px = 63123.456 → after rounding
+        # to px_decimals=1 we expect 63123.5 (but capped at 5 sig figs to 63120).
+        adapter.place_stop_loss("BTC", 0.001, 63123.456, is_buy=False)
+        _, _, _, limit_px, order_type = ex.order.call_args.args
+        # 5-sig-fig rounding for ~63000 → tens place (63120 or 63130).
+        assert limit_px == round(limit_px, 0) or limit_px == round(limit_px, -1)
+        assert order_type["trigger"]["triggerPx"] == round(order_type["trigger"]["triggerPx"], 0) or \
+               order_type["trigger"]["triggerPx"] == round(order_type["trigger"]["triggerPx"], -1)
+
+    def test_round_perps_px_high_price(self):
+        # Direct unit test of the helper. BTC at $63500 with sz_decimals=5
+        # → px_decimals=1, but 5 sig fig cap takes priority and rounds to
+        # tens place.
+        from importlib import reload  # noqa: F401
+        mod = _load_hl_adapter(mock_info_cls=MagicMock(return_value=MagicMock()))
+        # 63123.456 with 5 sig figs → 63123 (decimals=0)
+        assert mod._round_perps_px(63123.456, sz_decimals=5) == 63123
+        # 0.123456 with 5 sig figs and sz_decimals=2 → px_decimals=4, sig_decimals=5
+        # → use min(4, 5) = 4 decimals → 0.1235
+        assert mod._round_perps_px(0.123456, sz_decimals=2) == 0.1235
+        # Edge case: zero / negative passes through unchanged.
+        assert mod._round_perps_px(0, sz_decimals=5) == 0
+        assert mod._round_perps_px(-1.5, sz_decimals=5) == -1.5
+
+    def test_cancel_trigger_order_paper_mode_raises(self):
+        mock_info = MagicMock()
+        mock_info_cls = MagicMock(return_value=mock_info)
+        mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
+        adapter = mod.HyperliquidExchangeAdapter()
+        with pytest.raises(RuntimeError, match="live mode"):
+            adapter.cancel_trigger_order("BTC", 12345)
+
+    def test_cancel_trigger_order_passes_int_oid(self):
+        adapter, ex, _ = self._live_adapter()
+        ex.cancel.return_value = {"status": "ok"}
+        adapter.cancel_trigger_order("BTC", "12345")
+        ex.cancel.assert_called_once_with("BTC", 12345)

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -218,6 +218,7 @@ type StrategyConfig struct {
 	HTFFilter       bool                   `json:"htf_filter,omitempty"`       // higher-timeframe trend filter
 	AllowShorts     bool                   `json:"allow_shorts,omitempty"`     // perps only: opt-in to bidirectional execution — signal=-1 from flat opens a short, long+(-1) closes-and-flips. Default false preserves close-long-only behavior for strategies like triple_ema that emit -1 only as a long-exit (#328)
 	Leverage        float64                `json:"leverage,omitempty"`         // perps leverage multiplier (default 1 = no leverage); used for notional sizing and margin-based valuation (#254)
+	StopLossPct     float64                `json:"stop_loss_pct,omitempty"`    // HL perps only: % from entry to place a reduce-only stop-loss trigger (0 = disabled) (#412)
 	Params          map[string]interface{} `json:"params,omitempty"`           // custom strategy parameters passed to Python
 	ThetaHarvest    *ThetaHarvestConfig    `json:"theta_harvest,omitempty"`
 	FuturesConfig   *FuturesConfig         `json:"futures,omitempty"`

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -613,6 +613,19 @@ func ValidateConfig(cfg *Config) error {
 			}
 		}
 
+		// #421: bound-check stop_loss_pct to mirror the init wizard's range.
+		// A hand-edited config with stop_loss_pct=200 would otherwise silently
+		// place an SL at $0 (long) or 3× entry (short) — both never trigger,
+		// breaking the safety feature without any warning.
+		if sc.StopLossPct != 0 {
+			if sc.StopLossPct < 0 || sc.StopLossPct > 50 {
+				errs = append(errs, fmt.Sprintf("%s: stop_loss_pct must be in [0, 50], got %g", prefix, sc.StopLossPct))
+			}
+			if sc.Type != "perps" || sc.Platform != "hyperliquid" {
+				errs = append(errs, fmt.Sprintf("%s: stop_loss_pct is only supported for HL perps strategies (got platform=%q type=%q)", prefix, sc.Platform, sc.Type))
+			}
+		}
+
 		// #36: ThetaHarvest fields must be non-negative when present.
 		if sc.ThetaHarvest != nil {
 			th := sc.ThetaHarvest

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -67,6 +67,7 @@ CREATE TABLE IF NOT EXISTS positions (
     multiplier REAL NOT NULL DEFAULT 0,
     owner_strategy_id TEXT NOT NULL DEFAULT '',
     opened_at TEXT NOT NULL DEFAULT '',
+    stop_loss_oid INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (strategy_id, symbol)
 );
 
@@ -234,6 +235,8 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE kill_switch_events ADD COLUMN source TEXT NOT NULL DEFAULT ''",
 		// Per-leaderboard-summary last-post timestamps stored as JSON (#308).
 		"ALTER TABLE app_state ADD COLUMN last_leaderboard_summaries TEXT NOT NULL DEFAULT ''",
+		// Per-trade HL stop-loss trigger OID (#412).
+		"ALTER TABLE positions ADD COLUMN stop_loss_oid INTEGER NOT NULL DEFAULT 0",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -461,8 +464,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	}
 	defer stmtStrat.Close()
 
-	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, quantity, avg_cost, side, multiplier, owner_strategy_id, opened_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, quantity, avg_cost, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare position insert: %w", err)
 	}
@@ -512,7 +515,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		}
 
 		for _, pos := range s.Positions {
-			if _, err := stmtPos.Exec(s.ID, pos.Symbol, pos.Quantity, pos.AvgCost, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt)); err != nil {
+			if _, err := stmtPos.Exec(s.ID, pos.Symbol, pos.Quantity, pos.AvgCost, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID); err != nil {
 				return fmt.Errorf("insert position %s/%s: %w", s.ID, pos.Symbol, err)
 			}
 		}
@@ -909,7 +912,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	}
 
 	// 3. Load positions for each strategy.
-	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, quantity, avg_cost, side, multiplier, owner_strategy_id, opened_at FROM positions")
+	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, quantity, avg_cost, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid FROM positions")
 	if err != nil {
 		return nil, fmt.Errorf("load positions: %w", err)
 	}
@@ -918,7 +921,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		var stratID string
 		var pos Position
 		var openedAtStr string
-		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.Quantity, &pos.AvgCost, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr); err != nil {
+		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.Quantity, &pos.AvgCost, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID); err != nil {
 			return nil, fmt.Errorf("scan position: %w", err)
 		}
 		pos.OpenedAt = parseTime(openedAtStr)

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -68,6 +68,7 @@ CREATE TABLE IF NOT EXISTS positions (
     owner_strategy_id TEXT NOT NULL DEFAULT '',
     opened_at TEXT NOT NULL DEFAULT '',
     stop_loss_oid INTEGER NOT NULL DEFAULT 0,
+    stop_loss_trigger_px REAL NOT NULL DEFAULT 0,
     PRIMARY KEY (strategy_id, symbol)
 );
 
@@ -237,6 +238,8 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE app_state ADD COLUMN last_leaderboard_summaries TEXT NOT NULL DEFAULT ''",
 		// Per-trade HL stop-loss trigger OID (#412).
 		"ALTER TABLE positions ADD COLUMN stop_loss_oid INTEGER NOT NULL DEFAULT 0",
+		// Per-trade HL stop-loss trigger price for later-fill reconciliation (#421).
+		"ALTER TABLE positions ADD COLUMN stop_loss_trigger_px REAL NOT NULL DEFAULT 0",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -464,8 +467,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	}
 	defer stmtStrat.Close()
 
-	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, quantity, avg_cost, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, quantity, avg_cost, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare position insert: %w", err)
 	}
@@ -515,7 +518,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		}
 
 		for _, pos := range s.Positions {
-			if _, err := stmtPos.Exec(s.ID, pos.Symbol, pos.Quantity, pos.AvgCost, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID); err != nil {
+			if _, err := stmtPos.Exec(s.ID, pos.Symbol, pos.Quantity, pos.AvgCost, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx); err != nil {
 				return fmt.Errorf("insert position %s/%s: %w", s.ID, pos.Symbol, err)
 			}
 		}
@@ -912,7 +915,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	}
 
 	// 3. Load positions for each strategy.
-	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, quantity, avg_cost, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid FROM positions")
+	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, quantity, avg_cost, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px FROM positions")
 	if err != nil {
 		return nil, fmt.Errorf("load positions: %w", err)
 	}
@@ -921,7 +924,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		var stratID string
 		var pos Position
 		var openedAtStr string
-		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.Quantity, &pos.AvgCost, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID); err != nil {
+		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.Quantity, &pos.AvgCost, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx); err != nil {
 			return nil, fmt.Errorf("scan position: %w", err)
 		}
 		pos.OpenedAt = parseTime(openedAtStr)

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -44,10 +44,12 @@ type HyperliquidResult struct {
 
 // HyperliquidFill holds fill details from a live Hyperliquid order.
 type HyperliquidFill struct {
-	AvgPx   float64 `json:"avg_px"`
-	TotalSz float64 `json:"total_sz"`
-	OID     int64   `json:"oid,omitempty"` // exchange order ID
-	Fee     float64 `json:"fee,omitempty"` // exchange fee (if available)
+	AvgPx             float64 `json:"avg_px"`
+	TotalSz           float64 `json:"total_sz"`
+	OID               int64   `json:"oid,omitempty"`                  // exchange order ID
+	Fee               float64 `json:"fee,omitempty"`                  // exchange fee (if available)
+	StopLossOID       int64   `json:"stop_loss_oid,omitempty"`        // resting trigger OID for the per-trade SL placed alongside the fill (#412)
+	StopLossTriggerPx float64 `json:"stop_loss_trigger_px,omitempty"` // SL trigger price (for logs/audit) (#412)
 }
 
 // HyperliquidExecution is the execution block from check_hyperliquid.py --execute output.
@@ -60,10 +62,12 @@ type HyperliquidExecution struct {
 
 // HyperliquidExecuteResult is the top-level JSON from check_hyperliquid.py --execute.
 type HyperliquidExecuteResult struct {
-	Execution *HyperliquidExecution `json:"execution"`
-	Platform  string                `json:"platform"`
-	Timestamp string                `json:"timestamp"`
-	Error     string                `json:"error,omitempty"`
+	Execution           *HyperliquidExecution `json:"execution"`
+	Platform            string                `json:"platform"`
+	Timestamp           string                `json:"timestamp"`
+	Error               string                `json:"error,omitempty"`
+	CancelStopLossError string                `json:"cancel_stop_loss_error,omitempty"` // non-fatal: SL cancel before order failed (#412)
+	StopLossError       string                `json:"stop_loss_error,omitempty"`        // non-fatal: SL placement after fill failed (#412)
 }
 
 // RunPythonScript executes a Python script and returns stdout/stderr.
@@ -198,7 +202,10 @@ func RunHyperliquidCheck(script string, args []string) (*HyperliquidResult, stri
 }
 
 // RunHyperliquidExecute runs check_hyperliquid.py in execute mode (live orders).
-func RunHyperliquidExecute(script, symbol, side string, size float64) (*HyperliquidExecuteResult, string, error) {
+// stopLossPct > 0 requests a reduce-only SL trigger after a successful open.
+// cancelStopLossOID > 0 cancels an existing trigger before placing the new order
+// (used on signal-based closes so the stale SL doesn't race the close fill).
+func RunHyperliquidExecute(script, symbol, side string, size, stopLossPct float64, cancelStopLossOID int64) (*HyperliquidExecuteResult, string, error) {
 	args := []string{
 		"--execute",
 		fmt.Sprintf("--symbol=%s", symbol),
@@ -206,14 +213,27 @@ func RunHyperliquidExecute(script, symbol, side string, size float64) (*Hyperliq
 		fmt.Sprintf("--size=%g", size),
 		"--mode=live",
 	}
+	if stopLossPct > 0 {
+		args = append(args, fmt.Sprintf("--stop-loss-pct=%g", stopLossPct))
+	}
+	if cancelStopLossOID > 0 {
+		args = append(args, fmt.Sprintf("--cancel-stop-loss-oid=%d", cancelStopLossOID))
+	}
 	stdout, stderr, err := RunPythonScript(script, args)
-	stderrStr := string(stderr)
-	if err != nil {
+	return parseHyperliquidExecuteOutput(stdout, string(stderr), err)
+}
+
+// parseHyperliquidExecuteOutput turns subprocess output into
+// (*HyperliquidExecuteResult, stderr, error). Extracted from RunHyperliquidExecute
+// so Go CI (no .venv) can test the parsing contract without spawning Python
+// — same pattern as parseHyperliquidCloseOutput (#341).
+func parseHyperliquidExecuteOutput(stdout []byte, stderrStr string, runErr error) (*HyperliquidExecuteResult, string, error) {
+	if runErr != nil {
 		var result HyperliquidExecuteResult
 		if jsonErr := json.Unmarshal(stdout, &result); jsonErr == nil && result.Error != "" {
 			return &result, stderrStr, nil
 		}
-		return nil, stderrStr, fmt.Errorf("execute error: %w (stderr: %s)", err, stderrStr)
+		return nil, stderrStr, fmt.Errorf("execute error: %w (stderr: %s)", runErr, stderrStr)
 	}
 
 	var result HyperliquidExecuteResult

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -292,8 +292,8 @@ type HyperliquidCloseResult struct {
 // RunHyperliquidClose runs close_hyperliquid_position.py to submit a reduce-only
 // market close for a single coin (#341). When partialSz is non-nil, submits a
 // partial close for that coin quantity (#356 shared-wallet circuit breakers).
-// When cancelStopLossOID > 0, the script first cancels that resting trigger
-// order so per-strategy CB / kill-switch closes don't leave orphaned SLs
+// When cancelStopLossOIDs is non-empty, the script first cancels those resting
+// trigger orders so per-strategy CB / kill-switch closes don't leave orphaned SLs
 // burning HL's 10/day account-wide trigger-order cap (#421).
 //
 // Contract (load-bearing for kill-switch correctness): a non-nil error is
@@ -303,7 +303,7 @@ type HyperliquidCloseResult struct {
 // (result, nil) for "exit 1 + parseable JSON with error" which forced every
 // caller to also inspect result.Error and conflated subprocess success with
 // JSON-error success.
-func RunHyperliquidClose(script, symbol string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, string, error) {
+func RunHyperliquidClose(script, symbol string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, string, error) {
 	args := []string{
 		fmt.Sprintf("--symbol=%s", symbol),
 		"--mode=live",
@@ -311,8 +311,10 @@ func RunHyperliquidClose(script, symbol string, partialSz *float64, cancelStopLo
 	if partialSz != nil {
 		args = append(args, fmt.Sprintf("--sz=%s", strconv.FormatFloat(*partialSz, 'f', -1, 64)))
 	}
-	if cancelStopLossOID > 0 {
-		args = append(args, fmt.Sprintf("--cancel-stop-loss-oid=%d", cancelStopLossOID))
+	for _, oid := range cancelStopLossOIDs {
+		if oid > 0 {
+			args = append(args, fmt.Sprintf("--cancel-stop-loss-oid=%d", oid))
+		}
 	}
 	stdout, stderr, runErr := RunPythonScript(script, args)
 	return parseHyperliquidCloseOutput(stdout, string(stderr), runErr)

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -62,12 +62,14 @@ type HyperliquidExecution struct {
 
 // HyperliquidExecuteResult is the top-level JSON from check_hyperliquid.py --execute.
 type HyperliquidExecuteResult struct {
-	Execution           *HyperliquidExecution `json:"execution"`
-	Platform            string                `json:"platform"`
-	Timestamp           string                `json:"timestamp"`
-	Error               string                `json:"error,omitempty"`
-	CancelStopLossError string                `json:"cancel_stop_loss_error,omitempty"` // non-fatal: SL cancel before order failed (#412)
-	StopLossError       string                `json:"stop_loss_error,omitempty"`        // non-fatal: SL placement after fill failed (#412)
+	Execution                 *HyperliquidExecution `json:"execution"`
+	Platform                  string                `json:"platform"`
+	Timestamp                 string                `json:"timestamp"`
+	Error                     string                `json:"error,omitempty"`
+	CancelStopLossError       string                `json:"cancel_stop_loss_error,omitempty"`       // non-fatal: SL cancel before order failed (#412)
+	CancelStopLossSucceeded   bool                  `json:"cancel_stop_loss_succeeded,omitempty"`   // SL cancel went through (set even if subsequent open failed) so caller can clear stale pos.StopLossOID (#421)
+	StopLossError             string                `json:"stop_loss_error,omitempty"`              // non-fatal: SL placement after fill failed (#412)
+	StopLossFilledImmediately bool                  `json:"stop_loss_filled_immediately,omitempty"` // SL trigger filled at submit (price already through the level) — position is flat on-chain (#421)
 }
 
 // RunPythonScript executes a Python script and returns stdout/stderr.
@@ -205,7 +207,11 @@ func RunHyperliquidCheck(script string, args []string) (*HyperliquidResult, stri
 // stopLossPct > 0 requests a reduce-only SL trigger after a successful open.
 // cancelStopLossOID > 0 cancels an existing trigger before placing the new order
 // (used on signal-based closes so the stale SL doesn't race the close fill).
-func RunHyperliquidExecute(script, symbol, side string, size, stopLossPct float64, cancelStopLossOID int64) (*HyperliquidExecuteResult, string, error) {
+// prevPosQty > 0 indicates a flip is in progress: total_sz from the fill is
+// closeQty + newQty, and the SL must be sized against (total_sz - prevPosQty)
+// or HL will reject the oversized reduce-only trigger (#421). These trailing
+// args are HL-specific: OKX/TopStep have their own execute helpers and signatures.
+func RunHyperliquidExecute(script, symbol, side string, size, stopLossPct float64, cancelStopLossOID int64, prevPosQty float64) (*HyperliquidExecuteResult, string, error) {
 	args := []string{
 		"--execute",
 		fmt.Sprintf("--symbol=%s", symbol),
@@ -218,6 +224,9 @@ func RunHyperliquidExecute(script, symbol, side string, size, stopLossPct float6
 	}
 	if cancelStopLossOID > 0 {
 		args = append(args, fmt.Sprintf("--cancel-stop-loss-oid=%d", cancelStopLossOID))
+	}
+	if prevPosQty > 0 {
+		args = append(args, fmt.Sprintf("--prev-pos-qty=%g", prevPosQty))
 	}
 	stdout, stderr, err := RunPythonScript(script, args)
 	return parseHyperliquidExecuteOutput(stdout, string(stderr), err)

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -277,16 +277,24 @@ type HyperliquidClose struct {
 
 // HyperliquidCloseResult is the top-level JSON from close_hyperliquid_position.py.
 // Used by the portfolio kill switch to liquidate on-chain positions (#341).
+// CancelStopLossSucceeded / CancelStopLossError surface the optional
+// pre-close trigger-cancel that frees `Position.StopLossOID` when a CB or
+// kill switch flattens a strategy carrying a resting SL (#421).
 type HyperliquidCloseResult struct {
-	Close     *HyperliquidClose `json:"close"`
-	Platform  string            `json:"platform"`
-	Timestamp string            `json:"timestamp"`
-	Error     string            `json:"error,omitempty"`
+	Close                   *HyperliquidClose `json:"close"`
+	Platform                string            `json:"platform"`
+	Timestamp               string            `json:"timestamp"`
+	Error                   string            `json:"error,omitempty"`
+	CancelStopLossError     string            `json:"cancel_stop_loss_error,omitempty"`
+	CancelStopLossSucceeded bool              `json:"cancel_stop_loss_succeeded,omitempty"`
 }
 
 // RunHyperliquidClose runs close_hyperliquid_position.py to submit a reduce-only
 // market close for a single coin (#341). When partialSz is non-nil, submits a
 // partial close for that coin quantity (#356 shared-wallet circuit breakers).
+// When cancelStopLossOID > 0, the script first cancels that resting trigger
+// order so per-strategy CB / kill-switch closes don't leave orphaned SLs
+// burning HL's 10/day account-wide trigger-order cap (#421).
 //
 // Contract (load-bearing for kill-switch correctness): a non-nil error is
 // returned for ANY failure path — non-zero subprocess exit, malformed JSON,
@@ -295,13 +303,16 @@ type HyperliquidCloseResult struct {
 // (result, nil) for "exit 1 + parseable JSON with error" which forced every
 // caller to also inspect result.Error and conflated subprocess success with
 // JSON-error success.
-func RunHyperliquidClose(script, symbol string, partialSz *float64) (*HyperliquidCloseResult, string, error) {
+func RunHyperliquidClose(script, symbol string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, string, error) {
 	args := []string{
 		fmt.Sprintf("--symbol=%s", symbol),
 		"--mode=live",
 	}
 	if partialSz != nil {
 		args = append(args, fmt.Sprintf("--sz=%s", strconv.FormatFloat(*partialSz, 'f', -1, 64)))
+	}
+	if cancelStopLossOID > 0 {
+		args = append(args, fmt.Sprintf("--cancel-stop-loss-oid=%d", cancelStopLossOID))
 	}
 	stdout, stderr, runErr := RunPythonScript(script, args)
 	return parseHyperliquidCloseOutput(stdout, string(stderr), runErr)

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -274,6 +274,11 @@ func reconcileHyperliquidPositions(stratState *StrategyState, sym string, positi
 		// Position in state but not on-chain — closed externally.
 		logger.Info("hl-sync: %s position (%.6f %s) no longer on-chain, removing",
 			sym, statePos.Quantity, statePos.Side)
+		if statePos.StopLossOID > 0 && statePos.StopLossTriggerPx > 0 {
+			if recordPerpsStopLossClose(stratState, sym, statePos.StopLossTriggerPx, "stop_loss", logger) {
+				return true
+			}
+		}
 		// Close price is unknown — the fill happened off-scheduler between
 		// reconcile cycles. Record 0 in both fields; downstream analytics
 		// that compute avg close price / slippage must filter

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -36,16 +36,18 @@ var hyperliquidLiveCloseScript = "shared_scripts/close_hyperliquid_position.py"
 // implementation is defaultHyperliquidLiveCloser, which shells out to
 // close_hyperliquid_position.py via RunHyperliquidClose.
 // When partialSz is nil, the full on-chain position is closed (#341). When
-// non-nil, submits a partial close for that coin quantity (#356).
-type HyperliquidLiveCloser func(symbol string, partialSz *float64) (*HyperliquidCloseResult, error)
+// non-nil, submits a partial close for that coin quantity (#356). When
+// cancelStopLossOID > 0, the script also cancels that resting trigger order
+// before the close so the per-strategy SL slot is freed (#421).
+type HyperliquidLiveCloser func(symbol string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error)
 
 // defaultHyperliquidLiveCloser is the production close implementation. Writes
 // stderr to os.Stderr rather than a per-strategy logger — kill switch is a
 // system-level event, not strategy-scoped. Relies on RunHyperliquidClose's
 // uniform error contract: any non-nil err means the close was not confirmed
 // by the SDK and the kill switch must stay latched.
-func defaultHyperliquidLiveCloser(symbol string, partialSz *float64) (*HyperliquidCloseResult, error) {
-	result, stderr, err := RunHyperliquidClose(hyperliquidLiveCloseScript, symbol, partialSz)
+func defaultHyperliquidLiveCloser(symbol string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
+	result, stderr, err := RunHyperliquidClose(hyperliquidLiveCloseScript, symbol, partialSz, cancelStopLossOID)
 	if stderr != "" {
 		fmt.Fprintf(os.Stderr, "[hl-close] %s stderr: %s\n", symbol, stderr)
 	}
@@ -560,7 +562,12 @@ func (r HyperliquidLiveCloseReport) SortedErrorCoins() []string {
 // remaining unprocessed coins are added to Errors so the kill switch stays
 // latched and retries next cycle. Pass context.Background() to disable the
 // overall bound.
-func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLiveAll []StrategyConfig, closer HyperliquidLiveCloser) HyperliquidLiveCloseReport {
+//
+// stopLossOIDsByCoin carries any resting per-trade SL trigger OIDs that
+// should be cancelled before the close fires, so kill-switch flattening
+// doesn't leave orphan triggers consuming HL's 10/day account-wide cap
+// (#421). nil/empty disables the cancel; the closer is otherwise unchanged.
+func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLiveAll []StrategyConfig, closer HyperliquidLiveCloser, stopLossOIDsByCoin map[string]int64) HyperliquidLiveCloseReport {
 	report := HyperliquidLiveCloseReport{Errors: make(map[string]error)}
 
 	tradedCoins := make(map[string]bool)
@@ -590,7 +597,11 @@ func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLi
 			report.Errors[p.Coin] = fmt.Errorf("close budget exhausted before submit: %w", err)
 			continue
 		}
-		result, err := closer(p.Coin, nil)
+		var slOID int64
+		if stopLossOIDsByCoin != nil {
+			slOID = stopLossOIDsByCoin[p.Coin]
+		}
+		result, err := closer(p.Coin, nil, slOID)
 		if err != nil {
 			report.Errors[p.Coin] = err
 			continue
@@ -834,9 +845,15 @@ func runPendingHyperliquidCircuitCloses(
 	}
 
 	// Phase 3: re-snapshot jobs (may now include recovered entries).
+	// Also snapshot per-symbol StopLossOID so the closer can cancel any
+	// resting SL trigger before flattening — leaving them orphaned would
+	// burn one of HL's 10/day account-wide trigger slots per CB fire and
+	// silently degrade the safety feature for every other strategy on the
+	// same wallet (#421 review point 1).
 	type job struct {
 		stratID string
 		pending PendingCircuitClose
+		slOIDs  map[string]int64
 	}
 	var jobs []job
 	mu.RLock()
@@ -848,7 +865,13 @@ func runPendingHyperliquidCircuitCloses(
 		if p == nil || len(p.Symbols) == 0 {
 			continue
 		}
-		jobs = append(jobs, job{id, *p})
+		slOIDs := make(map[string]int64, len(p.Symbols))
+		for _, c := range p.Symbols {
+			if pos, ok := ss.Positions[c.Symbol]; ok && pos != nil && pos.StopLossOID > 0 {
+				slOIDs[c.Symbol] = pos.StopLossOID
+			}
+		}
+		jobs = append(jobs, job{id, *p, slOIDs})
 	}
 	mu.RUnlock()
 
@@ -903,13 +926,26 @@ func runPendingHyperliquidCircuitCloses(
 				continue
 			}
 			partial := sz
-			_, err := closer(c.Symbol, &partial)
+			cancelOID := j.slOIDs[c.Symbol]
+			result, err := closer(c.Symbol, &partial, cancelOID)
 			if err != nil {
 				fmt.Printf("[CRITICAL] hl-circuit-close: strategy %s coin %s sz=%.6f failed: %v\n", j.stratID, c.Symbol, sz, err)
 				allOK = false
 				break
 			}
 			fmt.Printf("[INFO] hl-circuit-close: strategy %s coin %s submitted reduce-only close sz=%.6f\n", j.stratID, c.Symbol, sz)
+			// Clear the StopLossOID under Lock when the cancel went
+			// through, so a follow-up cycle doesn't try to cancel the
+			// already-cancelled trigger.
+			if cancelOID > 0 && result != nil && result.CancelStopLossSucceeded {
+				mu.Lock()
+				if ss := state.Strategies[j.stratID]; ss != nil {
+					if pos, ok := ss.Positions[c.Symbol]; ok && pos != nil && pos.StopLossOID == cancelOID {
+						pos.StopLossOID = 0
+					}
+				}
+				mu.Unlock()
+			}
 		}
 
 		if allOK {

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -37,17 +37,17 @@ var hyperliquidLiveCloseScript = "shared_scripts/close_hyperliquid_position.py"
 // close_hyperliquid_position.py via RunHyperliquidClose.
 // When partialSz is nil, the full on-chain position is closed (#341). When
 // non-nil, submits a partial close for that coin quantity (#356). When
-// cancelStopLossOID > 0, the script also cancels that resting trigger order
-// before the close so the per-strategy SL slot is freed (#421).
-type HyperliquidLiveCloser func(symbol string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error)
+// cancelStopLossOIDs is non-empty, the script also cancels those resting
+// trigger orders before the close so per-strategy SL slots are freed (#421).
+type HyperliquidLiveCloser func(symbol string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error)
 
 // defaultHyperliquidLiveCloser is the production close implementation. Writes
 // stderr to os.Stderr rather than a per-strategy logger — kill switch is a
 // system-level event, not strategy-scoped. Relies on RunHyperliquidClose's
 // uniform error contract: any non-nil err means the close was not confirmed
 // by the SDK and the kill switch must stay latched.
-func defaultHyperliquidLiveCloser(symbol string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
-	result, stderr, err := RunHyperliquidClose(hyperliquidLiveCloseScript, symbol, partialSz, cancelStopLossOID)
+func defaultHyperliquidLiveCloser(symbol string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
+	result, stderr, err := RunHyperliquidClose(hyperliquidLiveCloseScript, symbol, partialSz, cancelStopLossOIDs)
 	if stderr != "" {
 		fmt.Fprintf(os.Stderr, "[hl-close] %s stderr: %s\n", symbol, stderr)
 	}
@@ -572,7 +572,7 @@ func (r HyperliquidLiveCloseReport) SortedErrorCoins() []string {
 // should be cancelled before the close fires, so kill-switch flattening
 // doesn't leave orphan triggers consuming HL's 10/day account-wide cap
 // (#421). nil/empty disables the cancel; the closer is otherwise unchanged.
-func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLiveAll []StrategyConfig, closer HyperliquidLiveCloser, stopLossOIDsByCoin map[string]int64) HyperliquidLiveCloseReport {
+func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLiveAll []StrategyConfig, closer HyperliquidLiveCloser, stopLossOIDsByCoin map[string][]int64) HyperliquidLiveCloseReport {
 	report := HyperliquidLiveCloseReport{Errors: make(map[string]error)}
 
 	tradedCoins := make(map[string]bool)
@@ -602,11 +602,11 @@ func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLi
 			report.Errors[p.Coin] = fmt.Errorf("close budget exhausted before submit: %w", err)
 			continue
 		}
-		var slOID int64
+		var slOIDs []int64
 		if stopLossOIDsByCoin != nil {
-			slOID = stopLossOIDsByCoin[p.Coin]
+			slOIDs = stopLossOIDsByCoin[p.Coin]
 		}
-		result, err := closer(p.Coin, nil, slOID)
+		result, err := closer(p.Coin, nil, slOIDs)
 		if err != nil {
 			report.Errors[p.Coin] = err
 			continue
@@ -858,7 +858,7 @@ func runPendingHyperliquidCircuitCloses(
 	type job struct {
 		stratID string
 		pending PendingCircuitClose
-		slOIDs  map[string]int64
+		slOIDs  map[string][]int64
 	}
 	var jobs []job
 	mu.RLock()
@@ -870,10 +870,10 @@ func runPendingHyperliquidCircuitCloses(
 		if p == nil || len(p.Symbols) == 0 {
 			continue
 		}
-		slOIDs := make(map[string]int64, len(p.Symbols))
+		slOIDs := make(map[string][]int64, len(p.Symbols))
 		for _, c := range p.Symbols {
 			if pos, ok := ss.Positions[c.Symbol]; ok && pos != nil && pos.StopLossOID > 0 {
-				slOIDs[c.Symbol] = pos.StopLossOID
+				slOIDs[c.Symbol] = []int64{pos.StopLossOID}
 			}
 		}
 		jobs = append(jobs, job{id, *p, slOIDs})
@@ -931,8 +931,8 @@ func runPendingHyperliquidCircuitCloses(
 				continue
 			}
 			partial := sz
-			cancelOID := j.slOIDs[c.Symbol]
-			result, err := closer(c.Symbol, &partial, cancelOID)
+			cancelOIDs := j.slOIDs[c.Symbol]
+			result, err := closer(c.Symbol, &partial, cancelOIDs)
 			if err != nil {
 				fmt.Printf("[CRITICAL] hl-circuit-close: strategy %s coin %s sz=%.6f failed: %v\n", j.stratID, c.Symbol, sz, err)
 				allOK = false
@@ -942,6 +942,7 @@ func runPendingHyperliquidCircuitCloses(
 			// Clear the StopLossOID under Lock when the cancel went
 			// through, so a follow-up cycle doesn't try to cancel the
 			// already-cancelled trigger.
+			cancelOID := firstPositiveStopLossOID(cancelOIDs)
 			if cancelOID > 0 && result != nil && result.CancelStopLossSucceeded {
 				mu.Lock()
 				if ss := state.Strategies[j.stratID]; ss != nil {
@@ -961,4 +962,25 @@ func runPendingHyperliquidCircuitCloses(
 			mu.Unlock()
 		}
 	}
+}
+
+func firstPositiveStopLossOID(oids []int64) int64 {
+	for _, oid := range oids {
+		if oid > 0 {
+			return oid
+		}
+	}
+	return 0
+}
+
+func appendUniquePositiveStopLossOID(oids []int64, oid int64) []int64 {
+	if oid <= 0 {
+		return oids
+	}
+	for _, existing := range oids {
+		if existing == oid {
+			return oids
+		}
+	}
+	return append(oids, oid)
 }

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1163,7 +1163,7 @@ func TestReconciliationGapOmittedWhenEmpty(t *testing.T) {
 // invocation and returns either a canned success or an error per coin.
 func fakeCloser(errs map[string]error) (HyperliquidLiveCloser, *[]string) {
 	var calls []string
-	closer := func(symbol string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
+	closer := func(symbol string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
 		if partialSz != nil {
 			calls = append(calls, fmt.Sprintf("%s:%g", symbol, *partialSz))
 		} else {
@@ -1175,7 +1175,7 @@ func fakeCloser(errs map[string]error) (HyperliquidLiveCloser, *[]string) {
 		return &HyperliquidCloseResult{
 			Close:                   &HyperliquidClose{Symbol: symbol, Fill: &HyperliquidCloseFill{TotalSz: 1.0, AvgPx: 100}},
 			Platform:                "hyperliquid",
-			CancelStopLossSucceeded: cancelStopLossOID > 0,
+			CancelStopLossSucceeded: firstPositiveStopLossOID(cancelStopLossOIDs) > 0,
 		}, nil
 	}
 	return closer, &calls
@@ -1365,7 +1365,7 @@ func TestForceCloseHyperliquidLive_UnownedPositionIgnored(t *testing.T) {
 // no-op. The caller's onChainConfirmedFlat check then proceeds straight to
 // virtual state mutation, matching pre-#341 behavior for non-HL deployments.
 func TestForceCloseHyperliquidLive_EmptyInputs(t *testing.T) {
-	report := forceCloseHyperliquidLive(context.Background(), nil, nil, func(string, *float64, int64) (*HyperliquidCloseResult, error) {
+	report := forceCloseHyperliquidLive(context.Background(), nil, nil, func(string, *float64, []int64) (*HyperliquidCloseResult, error) {
 		t.Fatalf("closer should not be called with empty inputs")
 		return nil, nil
 	}, nil)
@@ -1387,7 +1387,7 @@ func TestForceCloseHyperliquidLive_AdapterAlreadyFlatRoutedCorrectly(t *testing.
 	positions := []HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 3000}}
 
 	var calls []string
-	closer := func(symbol string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
+	closer := func(symbol string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
 		calls = append(calls, symbol)
 		return &HyperliquidCloseResult{
 			Close:    &HyperliquidClose{Symbol: symbol, AlreadyFlat: true},
@@ -1495,7 +1495,7 @@ func TestRunPendingHyperliquidCircuitCloses_RecoversStuckCB(t *testing.T) {
 	}
 	var mu sync.RWMutex
 	var calls []string
-	closer := func(sym string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
+	closer := func(sym string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
 		if partialSz != nil {
 			calls = append(calls, fmt.Sprintf("%s:%g", sym, *partialSz))
 		} else {
@@ -1547,7 +1547,7 @@ func TestRunPendingHyperliquidCircuitCloses_StuckCBNoOnChainPositionIsNoOp(t *te
 	}
 	var mu sync.RWMutex
 	var calls []string
-	closer := func(sym string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
+	closer := func(sym string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
 		calls = append(calls, sym)
 		return &HyperliquidCloseResult{Close: &HyperliquidClose{Symbol: sym}, Platform: "hyperliquid"}, nil
 	}
@@ -1592,7 +1592,7 @@ func TestRunPendingHyperliquidCircuitCloses_ClearsOnSuccess(t *testing.T) {
 	}
 	var mu sync.RWMutex
 	var calls []string
-	closer := func(sym string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
+	closer := func(sym string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
 		if partialSz != nil {
 			calls = append(calls, fmt.Sprintf("%s:%g", sym, *partialSz))
 		} else {

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1163,7 +1163,7 @@ func TestReconciliationGapOmittedWhenEmpty(t *testing.T) {
 // invocation and returns either a canned success or an error per coin.
 func fakeCloser(errs map[string]error) (HyperliquidLiveCloser, *[]string) {
 	var calls []string
-	closer := func(symbol string, partialSz *float64) (*HyperliquidCloseResult, error) {
+	closer := func(symbol string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
 		if partialSz != nil {
 			calls = append(calls, fmt.Sprintf("%s:%g", symbol, *partialSz))
 		} else {
@@ -1173,8 +1173,9 @@ func fakeCloser(errs map[string]error) (HyperliquidLiveCloser, *[]string) {
 			return nil, err
 		}
 		return &HyperliquidCloseResult{
-			Close:    &HyperliquidClose{Symbol: symbol, Fill: &HyperliquidCloseFill{TotalSz: 1.0, AvgPx: 100}},
-			Platform: "hyperliquid",
+			Close:                   &HyperliquidClose{Symbol: symbol, Fill: &HyperliquidCloseFill{TotalSz: 1.0, AvgPx: 100}},
+			Platform:                "hyperliquid",
+			CancelStopLossSucceeded: cancelStopLossOID > 0,
 		}, nil
 	}
 	return closer, &calls
@@ -1193,7 +1194,7 @@ func TestForceCloseHyperliquidLive_NonSharedCoin(t *testing.T) {
 	}
 
 	closer, calls := fakeCloser(nil)
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
 
 	if len(report.Errors) != 0 {
 		t.Errorf("expected no errors, got %v", report.Errors)
@@ -1222,7 +1223,7 @@ func TestForceCloseHyperliquidLive_SharedCoinEmptyVirtual(t *testing.T) {
 	}
 
 	closer, calls := fakeCloser(nil)
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
 
 	if len(report.Errors) != 0 {
 		t.Errorf("expected no errors, got %v", report.Errors)
@@ -1253,7 +1254,7 @@ func TestForceCloseHyperliquidLive_NetZeroSziAlreadyFlat(t *testing.T) {
 	}
 
 	closer, calls := fakeCloser(nil)
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
 
 	if len(report.Errors) != 0 {
 		t.Errorf("expected no errors for net-zero coin, got %v", report.Errors)
@@ -1286,7 +1287,7 @@ func TestForceCloseHyperliquidLive_ShortPosition(t *testing.T) {
 	}
 
 	closer, calls := fakeCloser(nil)
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
 
 	if len(report.Errors) != 0 {
 		t.Errorf("expected no errors, got %v", report.Errors)
@@ -1318,7 +1319,7 @@ func TestForceCloseHyperliquidLive_ClosePartialFailure(t *testing.T) {
 	closeErr := fmt.Errorf("hl rate limited")
 	closer, _ := fakeCloser(map[string]error{"BTC": closeErr})
 
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
 
 	if len(report.ClosedCoins) != 1 || report.ClosedCoins[0] != "ETH" {
 		t.Errorf("ClosedCoins = %v, want [ETH]", report.ClosedCoins)
@@ -1347,7 +1348,7 @@ func TestForceCloseHyperliquidLive_UnownedPositionIgnored(t *testing.T) {
 	}
 
 	closer, calls := fakeCloser(nil)
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
 
 	if len(report.ClosedCoins) != 1 || report.ClosedCoins[0] != "ETH" {
 		t.Errorf("ClosedCoins = %v, want [ETH]", report.ClosedCoins)
@@ -1364,10 +1365,10 @@ func TestForceCloseHyperliquidLive_UnownedPositionIgnored(t *testing.T) {
 // no-op. The caller's onChainConfirmedFlat check then proceeds straight to
 // virtual state mutation, matching pre-#341 behavior for non-HL deployments.
 func TestForceCloseHyperliquidLive_EmptyInputs(t *testing.T) {
-	report := forceCloseHyperliquidLive(context.Background(), nil, nil, func(string, *float64) (*HyperliquidCloseResult, error) {
+	report := forceCloseHyperliquidLive(context.Background(), nil, nil, func(string, *float64, int64) (*HyperliquidCloseResult, error) {
 		t.Fatalf("closer should not be called with empty inputs")
 		return nil, nil
-	})
+	}, nil)
 	if len(report.ClosedCoins) != 0 || len(report.AlreadyFlat) != 0 || len(report.Errors) != 0 {
 		t.Errorf("expected empty report, got %+v", report)
 	}
@@ -1386,7 +1387,7 @@ func TestForceCloseHyperliquidLive_AdapterAlreadyFlatRoutedCorrectly(t *testing.
 	positions := []HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 3000}}
 
 	var calls []string
-	closer := func(symbol string, partialSz *float64) (*HyperliquidCloseResult, error) {
+	closer := func(symbol string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
 		calls = append(calls, symbol)
 		return &HyperliquidCloseResult{
 			Close:    &HyperliquidClose{Symbol: symbol, AlreadyFlat: true},
@@ -1394,7 +1395,7 @@ func TestForceCloseHyperliquidLive_AdapterAlreadyFlatRoutedCorrectly(t *testing.
 		}, nil
 	}
 
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
 
 	if len(report.Errors) != 0 {
 		t.Errorf("expected no errors, got %v", report.Errors)
@@ -1494,7 +1495,7 @@ func TestRunPendingHyperliquidCircuitCloses_RecoversStuckCB(t *testing.T) {
 	}
 	var mu sync.RWMutex
 	var calls []string
-	closer := func(sym string, partialSz *float64) (*HyperliquidCloseResult, error) {
+	closer := func(sym string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
 		if partialSz != nil {
 			calls = append(calls, fmt.Sprintf("%s:%g", sym, *partialSz))
 		} else {
@@ -1546,7 +1547,7 @@ func TestRunPendingHyperliquidCircuitCloses_StuckCBNoOnChainPositionIsNoOp(t *te
 	}
 	var mu sync.RWMutex
 	var calls []string
-	closer := func(sym string, partialSz *float64) (*HyperliquidCloseResult, error) {
+	closer := func(sym string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
 		calls = append(calls, sym)
 		return &HyperliquidCloseResult{Close: &HyperliquidClose{Symbol: sym}, Platform: "hyperliquid"}, nil
 	}
@@ -1591,7 +1592,7 @@ func TestRunPendingHyperliquidCircuitCloses_ClearsOnSuccess(t *testing.T) {
 	}
 	var mu sync.RWMutex
 	var calls []string
-	closer := func(sym string, partialSz *float64) (*HyperliquidCloseResult, error) {
+	closer := func(sym string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
 		if partialSz != nil {
 			calls = append(calls, fmt.Sprintf("%s:%g", sym, *partialSz))
 		} else {

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// Tests for the stop-loss plumbing added in #412. We exercise the pure
+// output parser (which Go CI can run without .venv/bin/python3) plus
+// StrategyConfig/Position serialization round-trips so struct-tag
+// regressions on the new fields surface here.
+
+func TestParseHyperliquidExecuteOutput_StopLossFields(t *testing.T) {
+	stdout := []byte(`{
+		"execution": {
+			"action": "buy",
+			"symbol": "ETH",
+			"size": 0.25,
+			"fill": {
+				"avg_px": 3200.5,
+				"total_sz": 0.25,
+				"oid": 987654,
+				"fee": 0.40,
+				"stop_loss_oid": 12345678,
+				"stop_loss_trigger_px": 3104.485
+			}
+		},
+		"platform": "hyperliquid",
+		"timestamp": "2026-04-23T12:00:00+00:00"
+	}`)
+
+	result, stderr, err := parseHyperliquidExecuteOutput(stdout, "", nil)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if stderr != "" {
+		t.Errorf("expected empty stderr, got %q", stderr)
+	}
+	if result.Execution == nil || result.Execution.Fill == nil {
+		t.Fatalf("missing execution/fill: %+v", result)
+	}
+	fill := result.Execution.Fill
+	if fill.OID != 987654 {
+		t.Errorf("OID: got %d, want 987654", fill.OID)
+	}
+	if fill.StopLossOID != 12345678 {
+		t.Errorf("StopLossOID: got %d, want 12345678", fill.StopLossOID)
+	}
+	if fill.StopLossTriggerPx != 3104.485 {
+		t.Errorf("StopLossTriggerPx: got %v, want 3104.485", fill.StopLossTriggerPx)
+	}
+}
+
+func TestParseHyperliquidExecuteOutput_NonFatalSLErrors(t *testing.T) {
+	// When SL placement fails but the main fill succeeds, the Python side
+	// emits top-level stop_loss_error / cancel_stop_loss_error strings and
+	// keeps the execution block intact. Parser must surface both so the
+	// scheduler can log them without aborting state updates.
+	stdout := []byte(`{
+		"execution": {
+			"action": "sell",
+			"symbol": "BTC",
+			"size": 0.01,
+			"fill": {"avg_px": 67000, "total_sz": 0.01, "oid": 42}
+		},
+		"platform": "hyperliquid",
+		"timestamp": "2026-04-23T12:00:00+00:00",
+		"cancel_stop_loss_error": "trigger already cancelled",
+		"stop_loss_error": "placement rejected: max triggers reached"
+	}`)
+
+	result, _, err := parseHyperliquidExecuteOutput(stdout, "warn: something", nil)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if result.CancelStopLossError != "trigger already cancelled" {
+		t.Errorf("CancelStopLossError: got %q", result.CancelStopLossError)
+	}
+	if result.StopLossError != "placement rejected: max triggers reached" {
+		t.Errorf("StopLossError: got %q", result.StopLossError)
+	}
+	if result.Execution == nil || result.Execution.Fill.OID != 42 {
+		t.Errorf("main fill should still parse: %+v", result)
+	}
+}
+
+func TestParseHyperliquidExecuteOutput_ErrorJSONPreserved(t *testing.T) {
+	// Python script exits 1 with an {"error": "..."} payload; runErr is
+	// non-nil but parser should return the decoded result so the scheduler
+	// can log the reason without treating it as an unparseable failure.
+	stdout := []byte(`{"execution": null, "platform": "hyperliquid", "timestamp": "2026-04-23T12:00:00+00:00", "error": "--execute requires --mode=live"}`)
+	runErr := errors.New("exit status 1")
+	result, _, err := parseHyperliquidExecuteOutput(stdout, "", runErr)
+	if err != nil {
+		t.Fatalf("parse should swallow runErr when JSON carries .error: %v", err)
+	}
+	if result == nil || result.Error == "" {
+		t.Fatalf("expected error payload, got %+v", result)
+	}
+}
+
+func TestStrategyConfig_StopLossPctJSON(t *testing.T) {
+	sc := StrategyConfig{
+		ID:          "hl-donch-btc",
+		Platform:    "hyperliquid",
+		Type:        "perps",
+		StopLossPct: 3.5,
+	}
+	b, err := json.Marshal(sc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round StrategyConfig
+	if err := json.Unmarshal(b, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if round.StopLossPct != 3.5 {
+		t.Errorf("round-trip StopLossPct: got %v, want 3.5", round.StopLossPct)
+	}
+	// omitempty check: default-value config must not emit the field.
+	b2, _ := json.Marshal(StrategyConfig{ID: "x", Platform: "hyperliquid", Type: "perps"})
+	if containsKey(b2, "stop_loss_pct") {
+		t.Errorf("zero StopLossPct should be omitted; got %s", b2)
+	}
+}
+
+func TestPosition_StopLossOIDJSON(t *testing.T) {
+	p := Position{Symbol: "ETH", Quantity: 1, AvgCost: 3000, Side: "long", StopLossOID: 42}
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round Position
+	if err := json.Unmarshal(b, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if round.StopLossOID != 42 {
+		t.Errorf("round-trip StopLossOID: got %v", round.StopLossOID)
+	}
+	// omitempty: zero should drop from JSON.
+	b2, _ := json.Marshal(Position{Symbol: "ETH", Quantity: 1, AvgCost: 3000, Side: "long"})
+	if containsKey(b2, "stop_loss_oid") {
+		t.Errorf("zero StopLossOID should be omitted; got %s", b2)
+	}
+}
+
+func containsKey(b []byte, key string) bool {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		return false
+	}
+	_, ok := m[key]
+	return ok
+}

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -152,4 +153,122 @@ func containsKey(b []byte, key string) bool {
 	}
 	_, ok := m[key]
 	return ok
+}
+
+func TestParseHyperliquidExecuteOutput_StopLossFilledImmediately(t *testing.T) {
+	// Issue 421: when price is already through the trigger at submit, HL
+	// fills the SL immediately. The Python side surfaces this as
+	// stop_loss_filled_immediately=true (no OID) so the scheduler can
+	// reconcile virtual state instead of treating it as a placement error.
+	stdout := []byte(`{
+		"execution": {"action": "buy", "symbol": "ETH", "size": 0.1, "fill": {"avg_px": 3200, "total_sz": 0.1, "oid": 1}},
+		"platform": "hyperliquid",
+		"timestamp": "2026-04-25T00:00:00+00:00",
+		"stop_loss_filled_immediately": true
+	}`)
+	result, _, err := parseHyperliquidExecuteOutput(stdout, "", nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !result.StopLossFilledImmediately {
+		t.Errorf("expected StopLossFilledImmediately=true, got %+v", result)
+	}
+	if result.Execution.Fill.StopLossOID != 0 {
+		t.Errorf("instant-fill should have no resting OID; got %d", result.Execution.Fill.StopLossOID)
+	}
+}
+
+func TestParseHyperliquidExecuteOutput_CancelSucceededOnFailure(t *testing.T) {
+	// Issue 421 (review point 3): when the cancel succeeds but the subsequent
+	// open fails, the Python error path still emits cancel_stop_loss_succeeded
+	// so the scheduler can drop the dead OID from pos.StopLossOID.
+	stdout := []byte(`{
+		"execution": null,
+		"platform": "hyperliquid",
+		"timestamp": "2026-04-25T00:00:00+00:00",
+		"error": "market_open: insufficient balance",
+		"cancel_stop_loss_succeeded": true
+	}`)
+	runErr := errors.New("exit status 1")
+	result, _, err := parseHyperliquidExecuteOutput(stdout, "", runErr)
+	if err != nil {
+		t.Fatalf("parse should swallow runErr when JSON carries .error: %v", err)
+	}
+	if !result.CancelStopLossSucceeded {
+		t.Errorf("CancelStopLossSucceeded should be true, got %+v", result)
+	}
+	if result.Error == "" {
+		t.Errorf("error payload should be preserved")
+	}
+}
+
+func TestIsHLTriggerCapRejection(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"too many", "Too many open trigger orders", true},
+		{"rate limit", "trigger order rate limit exceeded", true},
+		{"max", "max trigger orders per day reached", true},
+		{"unrelated", "insufficient margin", false},
+		{"empty", "", false},
+		{"trigger only", "trigger price out of range", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isHLTriggerCapRejection(c.in); got != c.want {
+				t.Errorf("isHLTriggerCapRejection(%q)=%v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestValidateConfig_StopLossPctBounds(t *testing.T) {
+	// Issue 421 (review point 4): hand-edited configs with out-of-range
+	// stop_loss_pct must fail validation rather than silently break the
+	// safety feature.
+	cases := []struct {
+		name      string
+		pct       float64
+		platform  string
+		typ       string
+		wantError bool
+	}{
+		{"zero ok", 0, "hyperliquid", "perps", false},
+		{"in range", 5, "hyperliquid", "perps", false},
+		{"max boundary", 50, "hyperliquid", "perps", false},
+		{"too high", 200, "hyperliquid", "perps", true},
+		{"negative", -1, "hyperliquid", "perps", true},
+		{"non-HL platform", 5, "okx", "perps", true},
+		{"non-perps type", 5, "hyperliquid", "spot", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := &Config{
+				IntervalSeconds: 60,
+				Strategies: []StrategyConfig{
+					{
+						ID:             "test",
+						Type:           c.typ,
+						Platform:       c.platform,
+						Script:         "shared_scripts/check_hyperliquid.py",
+						Capital:        1000,
+						MaxDrawdownPct: 10,
+						StopLossPct:    c.pct,
+					},
+				},
+				PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 60},
+			}
+			err := ValidateConfig(cfg)
+			gotErr := err != nil && containsStopLossErr(err.Error())
+			if gotErr != c.wantError {
+				t.Errorf("got err=%v wantStopLossErr=%v (full err: %v)", gotErr, c.wantError, err)
+			}
+		})
+	}
+}
+
+func containsStopLossErr(s string) bool {
+	return strings.Contains(s, "stop_loss_pct")
 }

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -464,12 +464,12 @@ func TestRunPendingHyperliquidCircuitCloses_CancelsStopLossOID(t *testing.T) {
 	var mu sync.RWMutex
 
 	var seenCancelOID int64
-	closer := func(sym string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
-		seenCancelOID = cancelStopLossOID
+	closer := func(sym string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
+		seenCancelOID = firstPositiveStopLossOID(cancelStopLossOIDs)
 		return &HyperliquidCloseResult{
 			Close:                   &HyperliquidClose{Symbol: sym, Fill: &HyperliquidCloseFill{TotalSz: *partialSz, AvgPx: 3000}},
 			Platform:                "hyperliquid",
-			CancelStopLossSucceeded: cancelStopLossOID > 0,
+			CancelStopLossSucceeded: seenCancelOID > 0,
 		}, nil
 	}
 
@@ -502,11 +502,11 @@ func TestForceCloseHyperliquidLive_ThreadsStopLossOIDs(t *testing.T) {
 		{Coin: "ETH", Size: 0.5, EntryPrice: 3000},
 		{Coin: "BTC", Size: 0.01, EntryPrice: 60000},
 	}
-	slOIDs := map[string]int64{"ETH": 1111, "BTC": 0} // BTC has no resting SL
+	slOIDs := map[string][]int64{"ETH": {1111}, "BTC": nil} // BTC has no resting SL
 
-	seen := map[string]int64{}
-	closer := func(sym string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
-		seen[sym] = cancelStopLossOID
+	seen := map[string][]int64{}
+	closer := func(sym string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
+		seen[sym] = append([]int64(nil), cancelStopLossOIDs...)
 		return &HyperliquidCloseResult{
 			Close:    &HyperliquidClose{Symbol: sym, Fill: &HyperliquidCloseFill{TotalSz: 1, AvgPx: 1}},
 			Platform: "hyperliquid",
@@ -517,10 +517,44 @@ func TestForceCloseHyperliquidLive_ThreadsStopLossOIDs(t *testing.T) {
 	if len(report.Errors) != 0 {
 		t.Fatalf("expected no errors, got %v", report.Errors)
 	}
-	if seen["ETH"] != 1111 {
-		t.Errorf("ETH closer got cancelStopLossOID=%d, want 1111", seen["ETH"])
+	if got := seen["ETH"]; len(got) != 1 || got[0] != 1111 {
+		t.Errorf("ETH closer got cancelStopLossOIDs=%v, want [1111]", got)
 	}
-	if seen["BTC"] != 0 {
-		t.Errorf("BTC closer got cancelStopLossOID=%d, want 0 (no SL)", seen["BTC"])
+	if got := seen["BTC"]; len(got) != 0 {
+		t.Errorf("BTC closer got cancelStopLossOIDs=%v, want [] (no SL)", got)
+	}
+}
+
+func TestForceCloseHyperliquidLive_CancelsAllSharedCoinStopLossOIDs(t *testing.T) {
+	hlLiveAll := []StrategyConfig{
+		{ID: "hl-a-eth", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-b-eth", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"ema", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 3000}}
+	slOIDs := map[string][]int64{"ETH": {1111, 2222}}
+
+	var calls int
+	var seen []int64
+	closer := func(sym string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
+		calls++
+		seen = append([]int64(nil), cancelStopLossOIDs...)
+		return &HyperliquidCloseResult{
+			Close:                   &HyperliquidClose{Symbol: sym, Fill: &HyperliquidCloseFill{TotalSz: 1, AvgPx: 1}},
+			Platform:                "hyperliquid",
+			CancelStopLossSucceeded: len(cancelStopLossOIDs) > 0,
+		}, nil
+	}
+
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, slOIDs)
+	if len(report.Errors) != 0 {
+		t.Fatalf("expected no errors, got %v", report.Errors)
+	}
+	if calls != 1 {
+		t.Fatalf("closer calls=%d, want 1 market close for shared ETH", calls)
+	}
+	if len(seen) != 2 || seen[0] != 1111 || seen[1] != 2222 {
+		t.Errorf("closer saw cancel OIDs=%v, want [1111 2222]", seen)
 	}
 }

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -1,11 +1,22 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
+
+// silentStrategyLogger returns a StrategyLogger that writes to io.Discard
+// so tests don't pollute test output. The constructor name follows the
+// project convention of platform/feature-prefixed test helpers (CLAUDE.md).
+func silentStrategyLogger(id string) *StrategyLogger {
+	return &StrategyLogger{stratID: id, writer: io.Discard}
+}
 
 // Tests for the stop-loss plumbing added in #412. We exercise the pure
 // output parser (which Go CI can run without .venv/bin/python3) plus
@@ -271,4 +282,184 @@ func TestValidateConfig_StopLossPctBounds(t *testing.T) {
 
 func containsStopLossErr(s string) bool {
 	return strings.Contains(s, "stop_loss_pct")
+}
+
+// #421 review point 2: when StopLossFilledImmediately is true, the on-chain
+// position is flat (the trigger fired at submit). executeHyperliquidResult
+// must reconcile virtual state by synthesizing a close at trigger_px,
+// otherwise the next reconcile cycle silently delete()s the phantom
+// position with PnL=0 and the realized loss is dropped from history.
+func TestExecuteHyperliquidResult_StopLossFilledImmediately_ReconcilesState(t *testing.T) {
+	sc := StrategyConfig{
+		ID:       "hl-test-eth",
+		Platform: "hyperliquid",
+		Type:     "perps",
+		Capital:  1000,
+		Leverage: 5,
+	}
+	state := &StrategyState{
+		ID:        "hl-test-eth",
+		Platform:  "hyperliquid",
+		Type:      "perps",
+		Cash:      1000,
+		Positions: map[string]*Position{},
+	}
+	result := &HyperliquidResult{Symbol: "ETH", Signal: 1, Price: 3200}
+	execResult := &HyperliquidExecuteResult{
+		Execution: &HyperliquidExecution{
+			Action: "buy",
+			Symbol: "ETH",
+			Size:   0.1,
+			Fill: &HyperliquidFill{
+				AvgPx:             3200,
+				TotalSz:           0.1,
+				OID:               1,
+				StopLossTriggerPx: 3104.0,
+				// note: no StopLossOID — instant fill leaves no resting OID
+			},
+		},
+		StopLossFilledImmediately: true,
+	}
+
+	logger := silentStrategyLogger("hl-test-eth")
+	defer logger.Close()
+	trades, _ := executeHyperliquidResult(sc, state, result, execResult, "BUY", 3200, logger)
+
+	// Open + synthetic close = 2 trades.
+	if trades != 2 {
+		t.Errorf("trades=%d, want 2 (open + synthetic close)", trades)
+	}
+	// On-chain is flat → virtual state must also be flat.
+	if _, exists := state.Positions["ETH"]; exists {
+		t.Errorf("Position should have been deleted; got %+v", state.Positions["ETH"])
+	}
+	// One ClosedPosition entry recorded with the trigger price as ClosePrice
+	// and the realized PnL on the books (not zero).
+	if len(state.ClosedPositions) != 1 {
+		t.Fatalf("ClosedPositions=%d, want 1", len(state.ClosedPositions))
+	}
+	cp := state.ClosedPositions[0]
+	if cp.CloseReason != "stop_loss_immediate" {
+		t.Errorf("CloseReason=%q, want stop_loss_immediate", cp.CloseReason)
+	}
+	if cp.ClosePrice != 3104.0 {
+		t.Errorf("ClosePrice=%v, want 3104", cp.ClosePrice)
+	}
+	if cp.RealizedPnL >= 0 {
+		t.Errorf("RealizedPnL=%v should be negative for a long stopped out below entry", cp.RealizedPnL)
+	}
+}
+
+// Defensive: when the instant-fill flag is set but trigger_px is missing
+// (shouldn't happen with the current Python contract), the reconcile is
+// skipped and the position is left as opened — better than crashing on a
+// divide-by-zero or producing nonsense PnL.
+func TestExecuteHyperliquidResult_StopLossFilledImmediately_NoTriggerPxIsNoOp(t *testing.T) {
+	sc := StrategyConfig{ID: "hl", Platform: "hyperliquid", Type: "perps", Leverage: 1}
+	state := &StrategyState{ID: "hl", Platform: "hyperliquid", Type: "perps", Cash: 1000, Positions: map[string]*Position{}}
+	result := &HyperliquidResult{Symbol: "ETH", Signal: 1, Price: 3200}
+	execResult := &HyperliquidExecuteResult{
+		Execution:                 &HyperliquidExecution{Action: "buy", Symbol: "ETH", Size: 0.1, Fill: &HyperliquidFill{AvgPx: 3200, TotalSz: 0.1}},
+		StopLossFilledImmediately: true,
+	}
+	logger := silentStrategyLogger("hl")
+	defer logger.Close()
+	trades, _ := executeHyperliquidResult(sc, state, result, execResult, "BUY", 3200, logger)
+	if trades != 1 {
+		t.Errorf("trades=%d, want 1 (only open recorded; reconcile skipped)", trades)
+	}
+	if _, ok := state.Positions["ETH"]; !ok {
+		t.Errorf("Position should still exist when trigger_px is missing")
+	}
+}
+
+// #421 review point 1: per-strategy circuit-breaker drain must thread
+// pos.StopLossOID through to the closer so the resting trigger is
+// cancelled before the close fires. Otherwise it sits orphaned on HL's
+// book consuming one of the 10/day account-wide trigger slots.
+func TestRunPendingHyperliquidCircuitCloses_CancelsStopLossOID(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-a": {
+				ID: "hl-a",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 5, StopLossOID: 99887766},
+				},
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseHyperliquid: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.5}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "hl-a", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+
+	var seenCancelOID int64
+	closer := func(sym string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
+		seenCancelOID = cancelStopLossOID
+		return &HyperliquidCloseResult{
+			Close:                   &HyperliquidClose{Symbol: sym, Fill: &HyperliquidCloseFill{TotalSz: *partialSz, AvgPx: 3000}},
+			Platform:                "hyperliquid",
+			CancelStopLossSucceeded: cancelStopLossOID > 0,
+		}, nil
+	}
+
+	runPendingHyperliquidCircuitCloses(
+		context.Background(), state, cfg, "0xabc",
+		[]HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 3000}}, true,
+		nil, closer, 30*time.Second, &mu,
+	)
+
+	if seenCancelOID != 99887766 {
+		t.Errorf("closer received cancelStopLossOID=%d, want 99887766", seenCancelOID)
+	}
+	// And the StopLossOID was cleared in state since the cancel succeeded.
+	if got := state.Strategies["hl-a"].Positions["ETH"].StopLossOID; got != 0 {
+		t.Errorf("StopLossOID should be cleared after cancel succeeded, got %d", got)
+	}
+}
+
+// #421 review point 1: kill-switch close must thread the per-coin
+// StopLossOID map through forceCloseHyperliquidLive so resting SL triggers
+// are cancelled along with the close.
+func TestForceCloseHyperliquidLive_ThreadsStopLossOIDs(t *testing.T) {
+	hlLiveAll := []StrategyConfig{
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{
+		{Coin: "ETH", Size: 0.5, EntryPrice: 3000},
+		{Coin: "BTC", Size: 0.01, EntryPrice: 60000},
+	}
+	slOIDs := map[string]int64{"ETH": 1111, "BTC": 0} // BTC has no resting SL
+
+	seen := map[string]int64{}
+	closer := func(sym string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
+		seen[sym] = cancelStopLossOID
+		return &HyperliquidCloseResult{
+			Close:    &HyperliquidClose{Symbol: sym, Fill: &HyperliquidCloseFill{TotalSz: 1, AvgPx: 1}},
+			Platform: "hyperliquid",
+		}, nil
+	}
+
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, slOIDs)
+	if len(report.Errors) != 0 {
+		t.Fatalf("expected no errors, got %v", report.Errors)
+	}
+	if seen["ETH"] != 1111 {
+		t.Errorf("ETH closer got cancelStopLossOID=%d, want 1111", seen["ETH"])
+	}
+	if seen["BTC"] != 0 {
+		t.Errorf("BTC closer got cancelStopLossOID=%d, want 0 (no SL)", seen["BTC"])
+	}
 }

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -138,7 +138,7 @@ func TestStrategyConfig_StopLossPctJSON(t *testing.T) {
 }
 
 func TestPosition_StopLossOIDJSON(t *testing.T) {
-	p := Position{Symbol: "ETH", Quantity: 1, AvgCost: 3000, Side: "long", StopLossOID: 42}
+	p := Position{Symbol: "ETH", Quantity: 1, AvgCost: 3000, Side: "long", StopLossOID: 42, StopLossTriggerPx: 2900}
 	b, err := json.Marshal(p)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -150,10 +150,16 @@ func TestPosition_StopLossOIDJSON(t *testing.T) {
 	if round.StopLossOID != 42 {
 		t.Errorf("round-trip StopLossOID: got %v", round.StopLossOID)
 	}
+	if round.StopLossTriggerPx != 2900 {
+		t.Errorf("round-trip StopLossTriggerPx: got %v", round.StopLossTriggerPx)
+	}
 	// omitempty: zero should drop from JSON.
 	b2, _ := json.Marshal(Position{Symbol: "ETH", Quantity: 1, AvgCost: 3000, Side: "long"})
 	if containsKey(b2, "stop_loss_oid") {
 		t.Errorf("zero StopLossOID should be omitted; got %s", b2)
+	}
+	if containsKey(b2, "stop_loss_trigger_px") {
+		t.Errorf("zero StopLossTriggerPx should be omitted; got %s", b2)
 	}
 }
 
@@ -370,6 +376,61 @@ func TestExecuteHyperliquidResult_StopLossFilledImmediately_NoTriggerPxIsNoOp(t 
 	}
 	if _, ok := state.Positions["ETH"]; !ok {
 		t.Errorf("Position should still exist when trigger_px is missing")
+	}
+}
+
+func TestReconcileHyperliquidPositions_RestingStopLossFillBooksPnL(t *testing.T) {
+	state := &StrategyState{
+		ID:       "hl-test-eth",
+		Platform: "hyperliquid",
+		Type:     "perps",
+		Cash:     1000,
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol:            "ETH",
+				Quantity:          0.1,
+				AvgCost:           3200,
+				Side:              "long",
+				Multiplier:        1,
+				Leverage:          5,
+				OwnerStrategyID:   "hl-test-eth",
+				OpenedAt:          time.Now().UTC().Add(-time.Hour),
+				StopLossOID:       12345,
+				StopLossTriggerPx: 3104,
+			},
+		},
+	}
+	logger := silentStrategyLogger("hl-test-eth")
+	defer logger.Close()
+
+	changed := reconcileHyperliquidPositions(state, "ETH", nil, logger)
+	if !changed {
+		t.Fatalf("expected reconcile to report a state change")
+	}
+	if _, ok := state.Positions["ETH"]; ok {
+		t.Fatalf("position should be removed after tracked SL fill: %+v", state.Positions["ETH"])
+	}
+	if len(state.ClosedPositions) != 1 {
+		t.Fatalf("ClosedPositions=%d, want 1", len(state.ClosedPositions))
+	}
+	cp := state.ClosedPositions[0]
+	if cp.CloseReason != "stop_loss" {
+		t.Errorf("CloseReason=%q, want stop_loss", cp.CloseReason)
+	}
+	if cp.ClosePrice != 3104 {
+		t.Errorf("ClosePrice=%v, want 3104", cp.ClosePrice)
+	}
+	if cp.RealizedPnL >= 0 {
+		t.Errorf("RealizedPnL=%v should be negative for stopped long", cp.RealizedPnL)
+	}
+	if state.Cash >= 1000 {
+		t.Errorf("Cash=%v should decrease by the realized stop loss", state.Cash)
+	}
+	if len(state.TradeHistory) != 1 || state.TradeHistory[0].Side != "sell" {
+		t.Errorf("expected one synthetic sell trade, got %+v", state.TradeHistory)
+	}
+	if state.RiskState.TotalTrades != 1 || state.RiskState.LosingTrades != 1 {
+		t.Errorf("risk stats not updated for SL fill: %+v", state.RiskState)
 	}
 }
 

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -303,6 +303,7 @@ type InitOptions struct {
 	OptionsCapital          float64
 	PerpsCapital            float64
 	PerpsLeverage           float64 // perps leverage multiplier (default 1 = no leverage) (#254)
+	HLStopLossPct           float64 // HL perps only: per-trade stop-loss % from entry (0 = disabled) (#412)
 	SpotDrawdown            float64
 	OptionsDrawdown         float64
 	PerpsDrawdown           float64
@@ -499,6 +500,7 @@ func generateConfig(opts InitOptions) *Config {
 					IntervalSeconds: 3600,
 					Leverage:        perpsLeverage,
 					AllowShorts:     allowShorts,
+					StopLossPct:     opts.HLStopLossPct,
 				})
 			}
 		}
@@ -1080,6 +1082,7 @@ func runInit(args []string) int {
 	optionsDrawdown := 10.0
 	perpsDrawdown := 5.0
 	perpsLeverage := 1.0 // #254 default: 1x (no leverage); user can edit config
+	hlStopLossPct := 0.0 // #412 default: disabled; prompted below when HL perps goes live
 	robinhoodCapital := 500.0
 	robinhoodDrawdown := 5.0
 	lunoCapital := 500.0
@@ -1124,6 +1127,13 @@ func runInit(args []string) int {
 		// produce a file that fails validateConfig on the next startup.
 		portfolioMaxDD = p.FloatRange("Portfolio kill-switch max drawdown %", 25, 0, 100)
 		portfolioWarnPct = p.FloatRange("Portfolio warn threshold % (of kill switch)", 60, 0, 100)
+
+		// #412: per-trade stop-loss is HL-only today and only makes sense when
+		// perps are running live. Default 0 disables it; HL caps trigger orders
+		// at 10/day/account so starting disabled avoids burning slots by accident.
+		if enablePerps && perpsMode == "live" {
+			hlStopLossPct = p.FloatRange("HL perps per-trade stop-loss % from entry (0 = disabled)", 0, 0, 50)
+		}
 	}
 
 	// Notifications default to disabled.
@@ -1198,6 +1208,7 @@ func runInit(args []string) int {
 		OptionsCapital:            optionsCapital,
 		PerpsCapital:              perpsCapital,
 		PerpsLeverage:             perpsLeverage,
+		HLStopLossPct:             hlStopLossPct,
 		SpotDrawdown:              spotDrawdown,
 		OptionsDrawdown:           optionsDrawdown,
 		PerpsDrawdown:             perpsDrawdown,

--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -32,6 +32,12 @@ type KillSwitchCloseInputs struct {
 	HLLiveAll      []StrategyConfig
 	HLCloser       HyperliquidLiveCloser
 	HLFetcher      HLStateFetcher
+	// HLStopLossOIDs maps coin → resting per-trade SL trigger OID so the
+	// kill-switch close path can cancel them before flattening. Without
+	// this, kill-switch wipes virtual state but the on-chain triggers sit
+	// resting and burn HL's 10/day account-wide cap (#421 review point 1).
+	// nil/empty disables; coins with no resting SL are simply absent.
+	HLStopLossOIDs map[string]int64
 
 	// OKXLiveAllPerps: every live OKX perps strategy configured (used to
 	// decide which coins to close and to detect "unconfigured" positions).
@@ -234,7 +240,7 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 	switch {
 	case hlStateFetched && len(in.HLLiveAll) > 0:
 		ctx, cancel := context.WithTimeout(context.Background(), in.platformCloseBudget(in.HLCloseTimeout))
-		plan.CloseReport = forceCloseHyperliquidLive(ctx, hlPositions, in.HLLiveAll, in.HLCloser)
+		plan.CloseReport = forceCloseHyperliquidLive(ctx, hlPositions, in.HLLiveAll, in.HLCloser, in.HLStopLossOIDs)
 		cancel()
 		if !plan.CloseReport.ConfirmedFlat() {
 			plan.OnChainConfirmedFlat = false

--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -32,12 +32,12 @@ type KillSwitchCloseInputs struct {
 	HLLiveAll      []StrategyConfig
 	HLCloser       HyperliquidLiveCloser
 	HLFetcher      HLStateFetcher
-	// HLStopLossOIDs maps coin → resting per-trade SL trigger OID so the
+	// HLStopLossOIDs maps coin → resting per-trade SL trigger OIDs so the
 	// kill-switch close path can cancel them before flattening. Without
 	// this, kill-switch wipes virtual state but the on-chain triggers sit
 	// resting and burn HL's 10/day account-wide cap (#421 review point 1).
 	// nil/empty disables; coins with no resting SL are simply absent.
-	HLStopLossOIDs map[string]int64
+	HLStopLossOIDs map[string][]int64
 
 	// OKXLiveAllPerps: every live OKX perps strategy configured (used to
 	// decide which coins to close and to detect "unconfigured" positions).

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -17,18 +17,30 @@ import (
 // stubHLLiveCloser returns a HyperliquidLiveCloser that records every invocation
 // and maps coin → canned error. Missing keys yield a synthetic success.
 func stubHLLiveCloser(errs map[string]error) (HyperliquidLiveCloser, *[]string) {
+	closer, calls, _ := stubHLLiveCloserWithCancel(errs)
+	return closer, calls
+}
+
+// stubHLLiveCloserWithCancel mirrors stubHLLiveCloser but also surfaces the
+// per-call cancelStopLossOID so #421 tests can assert the kill-switch /
+// CB-drain plumbing actually threads the OID through. cancels[symbol]
+// holds the most recent OID seen for that coin (0 = no cancel attempted).
+func stubHLLiveCloserWithCancel(errs map[string]error) (HyperliquidLiveCloser, *[]string, *map[string]int64) {
 	var calls []string
-	closer := func(symbol string, partialSz *float64) (*HyperliquidCloseResult, error) {
+	cancels := make(map[string]int64)
+	closer := func(symbol string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
 		calls = append(calls, symbol)
+		cancels[symbol] = cancelStopLossOID
 		if err, ok := errs[symbol]; ok && err != nil {
 			return nil, err
 		}
 		return &HyperliquidCloseResult{
-			Close:    &HyperliquidClose{Symbol: symbol, Fill: &HyperliquidCloseFill{TotalSz: 1.0, AvgPx: 100}},
-			Platform: "hyperliquid",
+			Close:                   &HyperliquidClose{Symbol: symbol, Fill: &HyperliquidCloseFill{TotalSz: 1.0, AvgPx: 100}},
+			Platform:                "hyperliquid",
+			CancelStopLossSucceeded: cancelStopLossOID > 0,
 		}, nil
 	}
-	return closer, &calls
+	return closer, &calls, &cancels
 }
 
 // stubHLStateFetcher returns an HLStateFetcher that replays a fixed response list

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -22,22 +22,22 @@ func stubHLLiveCloser(errs map[string]error) (HyperliquidLiveCloser, *[]string) 
 }
 
 // stubHLLiveCloserWithCancel mirrors stubHLLiveCloser but also surfaces the
-// per-call cancelStopLossOID so #421 tests can assert the kill-switch /
+// per-call cancelStopLossOIDs so #421 tests can assert the kill-switch /
 // CB-drain plumbing actually threads the OID through. cancels[symbol]
-// holds the most recent OID seen for that coin (0 = no cancel attempted).
-func stubHLLiveCloserWithCancel(errs map[string]error) (HyperliquidLiveCloser, *[]string, *map[string]int64) {
+// holds the OIDs seen for that coin.
+func stubHLLiveCloserWithCancel(errs map[string]error) (HyperliquidLiveCloser, *[]string, *map[string][]int64) {
 	var calls []string
-	cancels := make(map[string]int64)
-	closer := func(symbol string, partialSz *float64, cancelStopLossOID int64) (*HyperliquidCloseResult, error) {
+	cancels := make(map[string][]int64)
+	closer := func(symbol string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
 		calls = append(calls, symbol)
-		cancels[symbol] = cancelStopLossOID
+		cancels[symbol] = append([]int64(nil), cancelStopLossOIDs...)
 		if err, ok := errs[symbol]; ok && err != nil {
 			return nil, err
 		}
 		return &HyperliquidCloseResult{
 			Close:                   &HyperliquidClose{Symbol: symbol, Fill: &HyperliquidCloseFill{TotalSz: 1.0, AvgPx: 100}},
 			Platform:                "hyperliquid",
-			CancelStopLossSucceeded: cancelStopLossOID > 0,
+			CancelStopLossSucceeded: firstPositiveStopLossOID(cancelStopLossOIDs) > 0,
 		}, nil
 	}
 	return closer, &calls, &cancels

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -938,6 +938,7 @@ func main() {
 					var hlPosQty float64
 					var hlPosSide string
 					var hlAvgCost float64
+					var hlStopLossOID int64
 					if sc.Type == "perps" && hyperliquidIsLive(sc.Args) {
 						hlCash = stratState.Cash
 						if sym := hyperliquidSymbol(sc.Args); sym != "" {
@@ -945,6 +946,7 @@ func main() {
 								hlPosQty = pos.Quantity
 								hlPosSide = pos.Side
 								hlAvgCost = pos.AvgCost
+								hlStopLossOID = pos.StopLossOID
 							}
 						}
 					}
@@ -1108,7 +1110,7 @@ func main() {
 							var execResult *HyperliquidExecuteResult
 							liveExecFailed := false
 							if hyperliquidIsLive(sc.Args) && result.Signal != 0 {
-								if er, ok2 := runHyperliquidExecuteOrder(sc, result, price, hlCash, hlPosQty, hlPosSide, hlAvgCost, logger); ok2 {
+								if er, ok2 := runHyperliquidExecuteOrder(sc, result, price, hlCash, hlPosQty, hlPosSide, hlAvgCost, hlStopLossOID, logger); ok2 {
 									execResult = er
 								} else {
 									liveExecFailed = true
@@ -1809,7 +1811,7 @@ func runHyperliquidCheck(sc StrategyConfig, prices map[string]float64, logger *S
 // Trade record, leaving state silently behind actual exchange holdings. See
 // issue #298 — 0.716 ETH of live fills were lost this way because the
 // "already long, skipping buy" branch sat AFTER RunHyperliquidExecute.
-func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, price, cash, posQty float64, posSide string, avgCost float64, logger *StrategyLogger) (*HyperliquidExecuteResult, bool) {
+func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, price, cash, posQty float64, posSide string, avgCost float64, existingStopLossOID int64, logger *StrategyLogger) (*HyperliquidExecuteResult, bool) {
 	if reason := PerpsOrderSkipReason(result.Signal, posSide, sc.AllowShorts); reason != "" {
 		logger.Info("Skipping live order for %s: %s", result.Symbol, reason)
 		return nil, false
@@ -1831,9 +1833,27 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	if !isBuy {
 		side = "sell"
 	}
-	logger.Info("Placing live %s %s size=%.6f", side, result.Symbol, size)
 
-	execResult, stderr, err := RunHyperliquidExecute(sc.Script, result.Symbol, side, size)
+	// Stop-loss wiring (#412):
+	//   - cancel stale SL whenever a position exists with a known OID
+	//     (close path must free the trigger slot; flip path too, since the
+	//     new side gets a fresh SL below).
+	//   - place a new SL after the open leg unless the action is a pure close
+	//     (signal=-1 on a long without AllowShorts → no new position to
+	//     protect). Skip for non-HL platforms or when pct<=0.
+	pureClose := result.Signal == -1 && posSide == "long" && !sc.AllowShorts
+	var cancelOID int64
+	if existingStopLossOID > 0 && posQty > 0 {
+		cancelOID = existingStopLossOID
+	}
+	var slPct float64
+	if !pureClose && sc.StopLossPct > 0 && sc.Platform == "hyperliquid" {
+		slPct = sc.StopLossPct
+	}
+
+	logger.Info("Placing live %s %s size=%.6f (sl_pct=%.2f cancel_oid=%d)", side, result.Symbol, size, slPct, cancelOID)
+
+	execResult, stderr, err := RunHyperliquidExecute(sc.Script, result.Symbol, side, size, slPct, cancelOID)
 	if stderr != "" {
 		logger.Info("execute stderr: %s", stderr)
 	}
@@ -1844,6 +1864,12 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	if execResult.Error != "" {
 		logger.Error("Live execute returned error: %s", execResult.Error)
 		return nil, false
+	}
+	if execResult.CancelStopLossError != "" {
+		logger.Warn("SL cancel failed (non-fatal): %s", execResult.CancelStopLossError)
+	}
+	if execResult.StopLossError != "" {
+		logger.Warn("SL placement failed (non-fatal): %s", execResult.StopLossError)
 	}
 	return execResult, true
 }
@@ -1886,6 +1912,20 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 	}
 	if trades > 0 && fillOID != "" {
 		logger.Info("Exchange order ID: %s", fillOID)
+	}
+
+	// Stamp the SL trigger OID onto the freshly-opened Position so the next
+	// signal-based close can cancel it (#412). Only the open side of a flip
+	// carries a new SL — the close leg deleted its Position before the open
+	// leg created the new one, so we attach to whatever Position sits at the
+	// symbol now.
+	if trades > 0 && execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil {
+		if slOID := execResult.Execution.Fill.StopLossOID; slOID > 0 {
+			if pos, ok := s.Positions[result.Symbol]; ok {
+				pos.StopLossOID = slOID
+				logger.Info("SL trigger placed oid=%d @ $%.4f", slOID, execResult.Execution.Fill.StopLossTriggerPx)
+			}
+		}
 	}
 
 	detail := ""

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2019,6 +2019,7 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 		if slOID := execResult.Execution.Fill.StopLossOID; slOID > 0 {
 			if pos, ok := s.Positions[result.Symbol]; ok {
 				pos.StopLossOID = slOID
+				pos.StopLossTriggerPx = execResult.Execution.Fill.StopLossTriggerPx
 				logger.Info("SL trigger placed oid=%d @ $%.4f", slOID, execResult.Execution.Fill.StopLossTriggerPx)
 			}
 		}
@@ -2035,43 +2036,8 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 	if trades > 0 && execResult != nil && execResult.StopLossFilledImmediately &&
 		execResult.Execution != nil && execResult.Execution.Fill != nil {
 		triggerPx := execResult.Execution.Fill.StopLossTriggerPx
-		if triggerPx > 0 {
-			if pos, ok := s.Positions[result.Symbol]; ok {
-				now := time.Now().UTC()
-				qty := pos.Quantity
-				avgCost := pos.AvgCost
-				side := pos.Side
-				var pnl float64
-				if side == "long" {
-					pnl = qty * (triggerPx - avgCost)
-				} else {
-					pnl = qty * (avgCost - triggerPx)
-				}
-				fee := CalculatePlatformSpotFee(sc.Platform, qty*triggerPx)
-				pnl -= fee
-				s.Cash += pnl
-				closeSide := "sell"
-				if side == "short" {
-					closeSide = "buy"
-				}
-				trade := Trade{
-					Timestamp:  now,
-					StrategyID: s.ID,
-					Symbol:     result.Symbol,
-					Side:       closeSide,
-					Quantity:   qty,
-					Price:      triggerPx,
-					Value:      qty * triggerPx,
-					TradeType:  "perps",
-					Details:    fmt.Sprintf("SL filled at submit, PnL: $%.2f (fee $%.2f)", pnl, fee),
-				}
-				RecordTrade(s, trade)
-				RecordTradeResult(&s.RiskState, pnl)
-				recordClosedPosition(s, pos, triggerPx, pnl, "stop_loss_immediate", now)
-				delete(s.Positions, result.Symbol)
-				trades++
-				logger.Warn("SL filled at submit @ $%.4f, PnL: $%.2f (fee $%.2f) — virtual state reconciled", triggerPx, pnl, fee)
-			}
+		if recordPerpsStopLossClose(s, result.Symbol, triggerPx, "stop_loss_immediate", logger) {
+			trades++
 		}
 	}
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -712,6 +712,28 @@ func main() {
 			// early-returns false while KillSwitchActive is true) and retries.
 			var plan KillSwitchClosePlan
 			if killSwitchFired {
+				// Snapshot per-coin StopLossOID so the kill-switch close
+				// path can cancel resting SLs before flattening, freeing
+				// HL's 10/day account-wide trigger-order cap (#421 review
+				// point 1). Sole-source: every live HL strategy's Position
+				// for the coin it trades. Last-write-wins on shared coins
+				// is fine — any one strategy's OID is enough to free the
+				// slot, and shared coins are rare in practice.
+				hlSLOIDs := map[string]int64{}
+				mu.RLock()
+				for _, sc := range hlLiveAll {
+					sym := hyperliquidSymbol(sc.Args)
+					if sym == "" {
+						continue
+					}
+					if ss, ok := state.Strategies[sc.ID]; ok && ss != nil {
+						if pos, pok := ss.Positions[sym]; pok && pos != nil && pos.StopLossOID > 0 {
+							hlSLOIDs[sym] = pos.StopLossOID
+						}
+					}
+				}
+				mu.RUnlock()
+
 				inputs := KillSwitchCloseInputs{
 					HLAddr:          hlAddr,
 					HLStateFetched:  hlStateFetched,
@@ -719,6 +741,7 @@ func main() {
 					HLLiveAll:       hlLiveAll,
 					HLCloser:        defaultHyperliquidLiveCloser,
 					HLFetcher:       defaultHLStateFetcher,
+					HLStopLossOIDs:  hlSLOIDs,
 					OKXLiveAllPerps: okxLivePerps,
 					OKXLiveAllSpot:  okxLiveSpot,
 					OKXCloser:       defaultOKXLiveCloser,
@@ -1110,7 +1133,7 @@ func main() {
 							var execResult *HyperliquidExecuteResult
 							liveExecFailed := false
 							if hyperliquidIsLive(sc.Args) && result.Signal != 0 {
-								er, ok2 := runHyperliquidExecuteOrder(sc, result, price, hlCash, hlPosQty, hlPosSide, hlAvgCost, hlStopLossOID, logger)
+								er, ok2 := runHyperliquidExecuteOrder(sc, result, price, hlCash, hlPosQty, hlPosSide, hlAvgCost, hlStopLossOID, notifier, logger)
 								if ok2 {
 									execResult = er
 								} else {
@@ -1827,7 +1850,7 @@ func runHyperliquidCheck(sc StrategyConfig, prices map[string]float64, logger *S
 // Trade record, leaving state silently behind actual exchange holdings. See
 // issue #298 — 0.716 ETH of live fills were lost this way because the
 // "already long, skipping buy" branch sat AFTER RunHyperliquidExecute.
-func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, price, cash, posQty float64, posSide string, avgCost float64, existingStopLossOID int64, logger *StrategyLogger) (*HyperliquidExecuteResult, bool) {
+func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, price, cash, posQty float64, posSide string, avgCost float64, existingStopLossOID int64, notifier *MultiNotifier, logger *StrategyLogger) (*HyperliquidExecuteResult, bool) {
 	if reason := PerpsOrderSkipReason(result.Signal, posSide, sc.AllowShorts); reason != "" {
 		logger.Info("Skipping live order for %s: %s", result.Symbol, reason)
 		return nil, false
@@ -1860,7 +1883,13 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	//   - on a flip, pass prev_pos_qty so the SL is sized against the new
 	//     net position (#421) — total_sz alone is closeQty+newQty.
 	pureClose := result.Signal == -1 && posSide == "long" && !sc.AllowShorts
-	flipping := posQty > 0 && ((result.Signal == 1 && posSide == "short") || (result.Signal == -1 && posSide == "long" && sc.AllowShorts))
+	// flipping predicate must mirror perpsLiveOrderSize exactly — both branches
+	// require sc.AllowShorts. A long-only strategy that inherited a short
+	// position (e.g. AllowShorts toggled true→false between restarts) would
+	// otherwise see prevPosQty=posQty here while perpsLiveOrderSize sized it
+	// as a fresh open without that offset, leaving net_new_sz negative and
+	// the SL silently undersized (#421 review point 6).
+	flipping := sc.AllowShorts && posQty > 0 && ((result.Signal == 1 && posSide == "short") || (result.Signal == -1 && posSide == "long"))
 	var cancelOID int64
 	if existingStopLossOID > 0 && posQty > 0 {
 		cancelOID = existingStopLossOID
@@ -1907,9 +1936,18 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 		// Surface HL trigger-cap exhaustion as CRITICAL — the position is
 		// live without protection, and one noisy strategy can deplete the
 		// 10/day account-wide pool for everything else (#421 review #5).
+		// Also route to notifier so operators see the unprotected-position
+		// state in chat, not just in stderr logs (#421 review point 7,
+		// mirrors the per-strategy CB notifier precedent in #415).
 		if isHLTriggerCapRejection(execResult.StopLossError) {
 			logger.Error("CRITICAL: HL trigger-cap rejected SL placement for %s — position is unprotected: %s",
 				result.Symbol, execResult.StopLossError)
+			if notifier != nil && notifier.HasBackends() {
+				msg := fmt.Sprintf("**HL TRIGGER-CAP EXHAUSTED** [%s] %s position is UNPROTECTED — SL placement rejected: %s",
+					sc.ID, result.Symbol, execResult.StopLossError)
+				notifier.SendToAllChannels(msg)
+				notifier.SendOwnerDM(msg)
+			}
 		} else {
 			logger.Warn("SL placement failed (non-fatal): %s", execResult.StopLossError)
 		}
@@ -1982,6 +2020,61 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 			if pos, ok := s.Positions[result.Symbol]; ok {
 				pos.StopLossOID = slOID
 				logger.Info("SL trigger placed oid=%d @ $%.4f", slOID, execResult.Execution.Fill.StopLossTriggerPx)
+			}
+		}
+	}
+
+	// Reconcile instant-fill stop-loss: when price was already through the
+	// trigger at submit, HL fills the SL immediately and the on-chain
+	// position is flat. Without this branch, virtual state would carry a
+	// phantom open position with StopLossOID=0 until the next reconcile
+	// cycle silently delete()s it via recordClosedPosition with PnL=0,
+	// losing the actual stop-loss in trade history (#421 review point 2).
+	// We synthesize the close at trigger_px so virtual state matches and
+	// the realized loss is booked correctly.
+	if trades > 0 && execResult != nil && execResult.StopLossFilledImmediately &&
+		execResult.Execution != nil && execResult.Execution.Fill != nil {
+		triggerPx := execResult.Execution.Fill.StopLossTriggerPx
+		if triggerPx > 0 {
+			if pos, ok := s.Positions[result.Symbol]; ok {
+				now := time.Now().UTC()
+				qty := pos.Quantity
+				avgCost := pos.AvgCost
+				side := pos.Side
+				var pnl float64
+				if side == "long" {
+					pnl = qty * (triggerPx - avgCost)
+				} else {
+					pnl = qty * (avgCost - triggerPx)
+				}
+				feePlatform := sc.Platform
+				if sc.Platform == "okx" && sc.Type == "perps" {
+					feePlatform = "okx-perps"
+				}
+				fee := CalculatePlatformSpotFee(feePlatform, qty*triggerPx)
+				pnl -= fee
+				s.Cash += pnl
+				closeSide := "sell"
+				if side == "short" {
+					closeSide = "buy"
+				}
+				trade := Trade{
+					Timestamp:  now,
+					StrategyID: s.ID,
+					Symbol:     result.Symbol,
+					Side:       closeSide,
+					Quantity:   qty,
+					Price:      triggerPx,
+					Value:      qty * triggerPx,
+					TradeType:  "perps",
+					Details:    fmt.Sprintf("SL filled at submit, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				}
+				RecordTrade(s, trade)
+				RecordTradeResult(&s.RiskState, pnl)
+				recordClosedPosition(s, pos, triggerPx, pnl, "stop_loss_immediate", now)
+				delete(s.Positions, result.Symbol)
+				trades++
+				logger.Warn("SL filled at submit @ $%.4f, PnL: $%.2f (fee $%.2f) — virtual state reconciled", triggerPx, pnl, fee)
 			}
 		}
 	}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1110,10 +1110,26 @@ func main() {
 							var execResult *HyperliquidExecuteResult
 							liveExecFailed := false
 							if hyperliquidIsLive(sc.Args) && result.Signal != 0 {
-								if er, ok2 := runHyperliquidExecuteOrder(sc, result, price, hlCash, hlPosQty, hlPosSide, hlAvgCost, hlStopLossOID, logger); ok2 {
+								er, ok2 := runHyperliquidExecuteOrder(sc, result, price, hlCash, hlPosQty, hlPosSide, hlAvgCost, hlStopLossOID, logger)
+								if ok2 {
 									execResult = er
 								} else {
 									liveExecFailed = true
+									// Even on failure, if the Python side
+									// confirmed the stale-SL cancel went
+									// through, drop the dead OID so the next
+									// cycle doesn't try to cancel it again.
+									if er != nil && er.CancelStopLossSucceeded && hlStopLossOID > 0 {
+										sym := hyperliquidSymbol(sc.Args)
+										if sym != "" {
+											mu.Lock()
+											if pos, ok3 := stratState.Positions[sym]; ok3 && pos.StopLossOID == hlStopLossOID {
+												pos.StopLossOID = 0
+												logger.Info("cleared stale SL OID=%d after open failed but cancel succeeded", hlStopLossOID)
+											}
+											mu.Unlock()
+										}
+									}
 								}
 							}
 							if !liveExecFailed {
@@ -1841,7 +1857,10 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	//   - place a new SL after the open leg unless the action is a pure close
 	//     (signal=-1 on a long without AllowShorts → no new position to
 	//     protect). Skip for non-HL platforms or when pct<=0.
+	//   - on a flip, pass prev_pos_qty so the SL is sized against the new
+	//     net position (#421) — total_sz alone is closeQty+newQty.
 	pureClose := result.Signal == -1 && posSide == "long" && !sc.AllowShorts
+	flipping := posQty > 0 && ((result.Signal == 1 && posSide == "short") || (result.Signal == -1 && posSide == "long" && sc.AllowShorts))
 	var cancelOID int64
 	if existingStopLossOID > 0 && posQty > 0 {
 		cancelOID = existingStopLossOID
@@ -1850,28 +1869,67 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	if !pureClose && sc.StopLossPct > 0 && sc.Platform == "hyperliquid" {
 		slPct = sc.StopLossPct
 	}
+	var prevPosQty float64
+	if flipping {
+		prevPosQty = posQty
+	}
 
-	logger.Info("Placing live %s %s size=%.6f (sl_pct=%.2f cancel_oid=%d)", side, result.Symbol, size, slPct, cancelOID)
+	// Only log SL fields when at least one is set, to keep the common
+	// no-stop-loss case quiet.
+	if slPct > 0 || cancelOID > 0 || prevPosQty > 0 {
+		logger.Info("Placing live %s %s size=%.6f (sl_pct=%.2f cancel_oid=%d prev_pos_qty=%.6f)",
+			side, result.Symbol, size, slPct, cancelOID, prevPosQty)
+	} else {
+		logger.Info("Placing live %s %s size=%.6f", side, result.Symbol, size)
+	}
 
-	execResult, stderr, err := RunHyperliquidExecute(sc.Script, result.Symbol, side, size, slPct, cancelOID)
+	execResult, stderr, err := RunHyperliquidExecute(sc.Script, result.Symbol, side, size, slPct, cancelOID, prevPosQty)
 	if stderr != "" {
 		logger.Info("execute stderr: %s", stderr)
 	}
+	// On failure, the Python script may still report cancel_stop_loss_succeeded
+	// — propagate execResult to the caller so the stale OID can be cleared
+	// even when the open leg fails (#421). Caller treats ok=false as "do not
+	// apply state mutations" but inspects execResult.CancelStopLossSucceeded
+	// before discarding it.
 	if err != nil {
 		logger.Error("Live execute failed: %v", err)
-		return nil, false
+		return execResult, false
 	}
 	if execResult.Error != "" {
 		logger.Error("Live execute returned error: %s", execResult.Error)
-		return nil, false
+		return execResult, false
 	}
 	if execResult.CancelStopLossError != "" {
 		logger.Warn("SL cancel failed (non-fatal): %s", execResult.CancelStopLossError)
 	}
 	if execResult.StopLossError != "" {
-		logger.Warn("SL placement failed (non-fatal): %s", execResult.StopLossError)
+		// Surface HL trigger-cap exhaustion as CRITICAL — the position is
+		// live without protection, and one noisy strategy can deplete the
+		// 10/day account-wide pool for everything else (#421 review #5).
+		if isHLTriggerCapRejection(execResult.StopLossError) {
+			logger.Error("CRITICAL: HL trigger-cap rejected SL placement for %s — position is unprotected: %s",
+				result.Symbol, execResult.StopLossError)
+		} else {
+			logger.Warn("SL placement failed (non-fatal): %s", execResult.StopLossError)
+		}
+	}
+	if execResult.StopLossFilledImmediately {
+		logger.Warn("SL trigger filled at submit (price was already through the level) for %s — position is flat on-chain", result.Symbol)
 	}
 	return execResult, true
+}
+
+// isHLTriggerCapRejection detects HL's "10 trigger-orders-per-day" rejection
+// strings so the scheduler can escalate them above WARN. The exact wording
+// has historically been one of "Too many open trigger orders" or "trigger
+// order rate limit"; we match either substring case-insensitively. Conservative
+// rather than exhaustive — false negatives (logged as WARN) are acceptable;
+// we only escalate on confirmed cap-rejection language to avoid CRITICAL
+// noise on unrelated failures.
+func isHLTriggerCapRejection(errStr string) bool {
+	lower := strings.ToLower(errStr)
+	return strings.Contains(lower, "trigger order") && (strings.Contains(lower, "too many") || strings.Contains(lower, "rate limit") || strings.Contains(lower, "max"))
 }
 
 // executeHyperliquidResult applies a hyperliquid result to state. Must be called under Lock.

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2047,11 +2047,7 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 				} else {
 					pnl = qty * (avgCost - triggerPx)
 				}
-				feePlatform := sc.Platform
-				if sc.Platform == "okx" && sc.Type == "perps" {
-					feePlatform = "okx-perps"
-				}
-				fee := CalculatePlatformSpotFee(feePlatform, qty*triggerPx)
+				fee := CalculatePlatformSpotFee(sc.Platform, qty*triggerPx)
 				pnl -= fee
 				s.Cash += pnl
 				closeSide := "sell"

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -712,14 +712,13 @@ func main() {
 			// early-returns false while KillSwitchActive is true) and retries.
 			var plan KillSwitchClosePlan
 			if killSwitchFired {
-				// Snapshot per-coin StopLossOID so the kill-switch close
+				// Snapshot per-coin StopLossOIDs so the kill-switch close
 				// path can cancel resting SLs before flattening, freeing
 				// HL's 10/day account-wide trigger-order cap (#421 review
 				// point 1). Sole-source: every live HL strategy's Position
-				// for the coin it trades. Last-write-wins on shared coins
-				// is fine — any one strategy's OID is enough to free the
-				// slot, and shared coins are rare in practice.
-				hlSLOIDs := map[string]int64{}
+				// for the coin it trades. Shared coins may have multiple
+				// per-strategy SL triggers, so preserve every OID.
+				hlSLOIDs := map[string][]int64{}
 				mu.RLock()
 				for _, sc := range hlLiveAll {
 					sym := hyperliquidSymbol(sc.Args)
@@ -728,7 +727,7 @@ func main() {
 					}
 					if ss, ok := state.Strategies[sc.ID]; ok && ss != nil {
 						if pos, pok := ss.Positions[sym]; pok && pos != nil && pos.StopLossOID > 0 {
-							hlSLOIDs[sym] = pos.StopLossOID
+							hlSLOIDs[sym] = appendUniquePositiveStopLossOID(hlSLOIDs[sym], pos.StopLossOID)
 						}
 					}
 				}

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -15,6 +15,7 @@ type Position struct {
 	Leverage        float64   `json:"leverage,omitempty"`          // perps leverage (informational; PnL is not scaled by leverage) (#254)
 	OwnerStrategyID string    `json:"owner_strategy_id,omitempty"` // strategy that opened this position
 	OpenedAt        time.Time `json:"opened_at,omitempty"`         // when the position was opened
+	StopLossOID     int64     `json:"stop_loss_oid,omitempty"`     // HL perps: resting trigger-order OID for the per-trade stop-loss (0 = none) (#412)
 }
 
 // ClosedPosition is a historical record of a position after it closed (#288).

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -7,15 +7,16 @@ import (
 
 // Position represents a spot, futures, or perps position.
 type Position struct {
-	Symbol          string    `json:"symbol"`
-	Quantity        float64   `json:"quantity"`
-	AvgCost         float64   `json:"avg_cost"`
-	Side            string    `json:"side"`                        // "long" or "short"
-	Multiplier      float64   `json:"multiplier,omitempty"`        // contract multiplier (0 = spot, >0 = futures/perps PnL branch; canonical perps value is 1 — do NOT set to leverage)
-	Leverage        float64   `json:"leverage,omitempty"`          // perps leverage (informational; PnL is not scaled by leverage) (#254)
-	OwnerStrategyID string    `json:"owner_strategy_id,omitempty"` // strategy that opened this position
-	OpenedAt        time.Time `json:"opened_at,omitempty"`         // when the position was opened
-	StopLossOID     int64     `json:"stop_loss_oid,omitempty"`     // HL perps: resting trigger-order OID for the per-trade stop-loss (0 = none) (#412)
+	Symbol            string    `json:"symbol"`
+	Quantity          float64   `json:"quantity"`
+	AvgCost           float64   `json:"avg_cost"`
+	Side              string    `json:"side"`                           // "long" or "short"
+	Multiplier        float64   `json:"multiplier,omitempty"`           // contract multiplier (0 = spot, >0 = futures/perps PnL branch; canonical perps value is 1 — do NOT set to leverage)
+	Leverage          float64   `json:"leverage,omitempty"`             // perps leverage (informational; PnL is not scaled by leverage) (#254)
+	OwnerStrategyID   string    `json:"owner_strategy_id,omitempty"`    // strategy that opened this position
+	OpenedAt          time.Time `json:"opened_at,omitempty"`            // when the position was opened
+	StopLossOID       int64     `json:"stop_loss_oid,omitempty"`        // HL perps: resting trigger-order OID for the per-trade stop-loss (0 = none) (#412)
+	StopLossTriggerPx float64   `json:"stop_loss_trigger_px,omitempty"` // HL perps: trigger price for the resting stop-loss (0 = unknown) (#421)
 }
 
 // ClosedPosition is a historical record of a position after it closed (#288).
@@ -100,6 +101,61 @@ func recordClosedPosition(s *StrategyState, pos *Position, closePrice, realizedP
 		CloseReason:     reason,
 		DurationSeconds: duration,
 	})
+}
+
+// recordPerpsStopLossClose books a tracked perps stop-loss fill and removes the
+// virtual position. Used both when HL reports an immediate trigger fill at
+// submit time and when a previously-resting trigger has fired between cycles.
+func recordPerpsStopLossClose(s *StrategyState, symbol string, triggerPx float64, reason string, logger *StrategyLogger) bool {
+	if triggerPx <= 0 {
+		return false
+	}
+	pos, ok := s.Positions[symbol]
+	if !ok || pos == nil {
+		return false
+	}
+
+	now := time.Now().UTC()
+	qty := pos.Quantity
+	avgCost := pos.AvgCost
+	side := pos.Side
+	var pnl float64
+	if side == "long" {
+		pnl = qty * (triggerPx - avgCost)
+	} else {
+		pnl = qty * (avgCost - triggerPx)
+	}
+	feePlatform := s.Platform
+	if s.Platform == "okx" && s.Type == "perps" {
+		feePlatform = "okx-perps"
+	}
+	fee := CalculatePlatformSpotFee(feePlatform, qty*triggerPx)
+	pnl -= fee
+	s.Cash += pnl
+
+	closeSide := "sell"
+	if side == "short" {
+		closeSide = "buy"
+	}
+	trade := Trade{
+		Timestamp:  now,
+		StrategyID: s.ID,
+		Symbol:     symbol,
+		Side:       closeSide,
+		Quantity:   qty,
+		Price:      triggerPx,
+		Value:      qty * triggerPx,
+		TradeType:  "perps",
+		Details:    fmt.Sprintf("Stop loss close, PnL: $%.2f (fee $%.2f)", pnl, fee),
+	}
+	RecordTrade(s, trade)
+	RecordTradeResult(&s.RiskState, pnl)
+	recordClosedPosition(s, pos, triggerPx, pnl, reason, now)
+	delete(s.Positions, symbol)
+	if logger != nil {
+		logger.Warn("SL close reconciled @ $%.4f, PnL: $%.2f (fee $%.2f)", triggerPx, pnl, fee)
+	}
+	return true
 }
 
 // recordClosedOptionPosition appends a ClosedOptionPosition entry to the

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -8,6 +8,8 @@ Signal check mode (paper or live):
 
 Execution mode (live only, called by Go as phase 2):
     check_hyperliquid.py --execute --symbol=BTC --side=buy|sell --size=0.01 [--mode=live]
+        [--stop-loss-pct=3.0]         # optional: place a reduce-only SL trigger after fill (#412)
+        [--cancel-stop-loss-oid=OID]  # optional: cancel this trigger OID before the order
 """
 
 import sys
@@ -191,8 +193,31 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
         sys.exit(1)
 
 
-def run_execute(symbol, side, size, mode):
-    """Place a live market order on Hyperliquid."""
+def _extract_resting_oid(sdk_response: dict):
+    """Return the resting OID from a trigger-order SDK response, or None.
+
+    HL returns resting orders as:
+      {"status":"ok","response":{"type":"order","data":{"statuses":[{"resting":{"oid":N}}]}}}
+
+    If the trigger was instantly filled (price already through the level),
+    the status dict is `{"filled": {...}}` with an oid — treat that as a no-op
+    (no resting SL to cancel later) and return None to surface the skip upstream.
+    """
+    try:
+        statuses = sdk_response.get("response", {}).get("data", {}).get("statuses", [])
+        if not statuses:
+            return None
+        resting = statuses[0].get("resting") if isinstance(statuses[0], dict) else None
+        if resting and resting.get("oid") is not None:
+            return int(resting["oid"])
+    except Exception:
+        pass
+    return None
+
+
+def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0):
+    """Place a live market order on Hyperliquid, optionally wrapping it with
+    a stop-loss trigger (open) or cancelling a stale SL trigger (close)."""
     if mode != "live":
         print(json.dumps({"error": "--execute requires --mode=live"}, cls=SafeEncoder))
         sys.exit(1)
@@ -202,6 +227,20 @@ def run_execute(symbol, side, size, mode):
         adapter = HyperliquidExchangeAdapter()
 
         is_buy = side.lower() == "buy"
+
+        # Cancel stale SL first: we want to free the trigger slot before
+        # possibly spending another one on the new entry. A cancel failure is
+        # non-fatal (SL may have already triggered on-chain, in which case the
+        # position sync will detect the close on the next cycle) but is
+        # surfaced in the JSON so the scheduler can log it.
+        cancel_err = ""
+        if cancel_oid > 0:
+            try:
+                adapter.cancel_trigger_order(symbol, cancel_oid)
+            except Exception as ce:
+                cancel_err = str(ce)
+                print(f"[WARN] cancel_trigger_order({symbol}, {cancel_oid}) failed: {ce}", file=sys.stderr)
+
         result = adapter.market_open(symbol, is_buy, size)
 
         # Extract fill info from SDK response structure:
@@ -226,7 +265,36 @@ def run_execute(symbol, side, size, mode):
         except Exception:
             pass
 
-        print(json.dumps({
+        # Place the stop-loss trigger on successful opens only. We only try to
+        # place an SL when the main order actually filled; a zero-size fill
+        # usually means the order was rejected and there's nothing to protect.
+        sl_err = ""
+        if stop_loss_pct > 0 and fill.get("avg_px", 0) > 0 and fill.get("total_sz", 0) > 0:
+            entry_px = fill["avg_px"]
+            filled_sz = fill["total_sz"]
+            # Stop-loss fires against the opposite direction of the open:
+            # long open (is_buy=True)  → SL sells when price drops below entry*(1-pct).
+            # short open (is_buy=False) → SL buys when price rises above entry*(1+pct).
+            if is_buy:
+                trigger_px = entry_px * (1.0 - stop_loss_pct / 100.0)
+                sl_is_buy = False
+            else:
+                trigger_px = entry_px * (1.0 + stop_loss_pct / 100.0)
+                sl_is_buy = True
+            try:
+                sl_resp = adapter.place_stop_loss(symbol, filled_sz, trigger_px, sl_is_buy)
+                sl_oid = _extract_resting_oid(sl_resp)
+                if sl_oid is not None:
+                    fill["stop_loss_oid"] = sl_oid
+                    fill["stop_loss_trigger_px"] = round(trigger_px, 6)
+                else:
+                    sl_err = f"place_stop_loss returned no resting OID: {sl_resp}"
+                    print(f"[WARN] {sl_err}", file=sys.stderr)
+            except Exception as se:
+                sl_err = str(se)
+                print(f"[WARN] place_stop_loss({symbol}, {filled_sz}, {trigger_px}) failed: {se}", file=sys.stderr)
+
+        out = {
             "execution": {
                 "action": "buy" if is_buy else "sell",
                 "symbol": symbol,
@@ -235,7 +303,12 @@ def run_execute(symbol, side, size, mode):
             },
             "platform": "hyperliquid",
             "timestamp": datetime.now(timezone.utc).isoformat(),
-        }, cls=SafeEncoder))
+        }
+        if cancel_err:
+            out["cancel_stop_loss_error"] = cancel_err
+        if sl_err:
+            out["stop_loss_error"] = sl_err
+        print(json.dumps(out, cls=SafeEncoder))
 
     except Exception as e:
         traceback.print_exc(file=sys.stderr)
@@ -258,8 +331,13 @@ def main():
         parser.add_argument("--side", required=True, choices=["buy", "sell"])
         parser.add_argument("--size", type=float, required=True)
         parser.add_argument("--mode", default="live")
+        parser.add_argument("--stop-loss-pct", type=float, default=0.0,
+                            help="place a reduce-only SL trigger this pct away from fill (#412)")
+        parser.add_argument("--cancel-stop-loss-oid", type=int, default=0,
+                            help="cancel this trigger OID before placing the new order (#412)")
         args = parser.parse_args()
-        run_execute(args.symbol, args.side, args.size, args.mode)
+        run_execute(args.symbol, args.side, args.size, args.mode,
+                    stop_loss_pct=args.stop_loss_pct, cancel_oid=args.cancel_stop_loss_oid)
     else:
         # Signal check mode: <strategy> <symbol> <timeframe> [--mode=paper|live] [--htf-filter]
         import argparse

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -10,6 +10,8 @@ Execution mode (live only, called by Go as phase 2):
     check_hyperliquid.py --execute --symbol=BTC --side=buy|sell --size=0.01 [--mode=live]
         [--stop-loss-pct=3.0]         # optional: place a reduce-only SL trigger after fill (#412)
         [--cancel-stop-loss-oid=OID]  # optional: cancel this trigger OID before the order
+        [--prev-pos-qty=0.5]          # optional: existing position qty being flipped, so the SL
+                                      # is sized against the *new* net position (total_sz - prev) (#421)
 """
 
 import sys
@@ -193,34 +195,62 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
         sys.exit(1)
 
 
-def _extract_resting_oid(sdk_response: dict):
-    """Return the resting OID from a trigger-order SDK response, or None.
+def _classify_sl_response(sdk_response: dict):
+    """Classify a trigger-order SDK response into one of:
 
-    HL returns resting orders as:
-      {"status":"ok","response":{"type":"order","data":{"statuses":[{"resting":{"oid":N}}]}}}
+      ("resting", oid)        — order is now resting on the book (happy path)
+      ("filled",  oid_or_0)   — order filled at submit (price was already through the trigger)
+      ("error",   reason_str) — SDK reported an error in the status payload
+      ("missing", None)       — couldn't find a status entry (malformed response)
 
-    If the trigger was instantly filled (price already through the level),
-    the status dict is `{"filled": {...}}` with an oid — treat that as a no-op
-    (no resting SL to cancel later) and return None to surface the skip upstream.
+    HL responses look like:
+      {"status":"ok","response":{"type":"order","data":{"statuses":[ <status> ]}}}
+
+    where <status> is one of `{"resting":{"oid":N}}`, `{"filled":{...,"oid":N}}`,
+    or `{"error":"..."}`. Distinguishing these matters because an instant-fill
+    means the position is already closed on-chain — surfacing it as "no resting
+    OID" the way the previous _extract_resting_oid did made the scheduler log
+    a placement error and leave virtual state thinking the position is open. (#421)
     """
     try:
         statuses = sdk_response.get("response", {}).get("data", {}).get("statuses", [])
         if not statuses:
-            return None
-        resting = statuses[0].get("resting") if isinstance(statuses[0], dict) else None
-        if resting and resting.get("oid") is not None:
-            return int(resting["oid"])
-    except Exception:
-        pass
-    return None
+            return ("missing", None)
+        status = statuses[0] if isinstance(statuses[0], dict) else {}
+        if "resting" in status and isinstance(status["resting"], dict):
+            oid = status["resting"].get("oid")
+            return ("resting", int(oid) if oid is not None else 0)
+        if "filled" in status and isinstance(status["filled"], dict):
+            oid = status["filled"].get("oid")
+            return ("filled", int(oid) if oid is not None else 0)
+        if "error" in status:
+            return ("error", str(status["error"]))
+    except Exception as e:
+        return ("error", f"_classify_sl_response: {e}")
+    return ("missing", None)
 
 
-def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0):
+def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_pos_qty=0.0):
     """Place a live market order on Hyperliquid, optionally wrapping it with
-    a stop-loss trigger (open) or cancelling a stale SL trigger (close)."""
+    a stop-loss trigger (open) or cancelling a stale SL trigger (close).
+
+    ``prev_pos_qty`` is the absolute quantity of any existing position being
+    flipped through (e.g. long→short). On a flip, total_sz from the fill is
+    closeQty + newQty, so the SL must be sized against ``total_sz - prev_pos_qty``
+    to avoid placing an oversized reduce-only trigger that HL may reject (#421).
+    For pure opens from flat (no flip), pass 0 — full total_sz is the new
+    position size."""
     if mode != "live":
         print(json.dumps({"error": "--execute requires --mode=live"}, cls=SafeEncoder))
         sys.exit(1)
+
+    # Track cancel state outside the main try/except so the scheduler still
+    # learns whether the stale SL was freed even if the subsequent market_open
+    # raises. Otherwise pos.StopLossOID points at a dead OID for another cycle
+    # and the next signal tries to cancel a non-existent order. (#421)
+    cancel_err = ""
+    cancel_attempted = cancel_oid > 0
+    cancel_succeeded = False
 
     try:
         from adapter import HyperliquidExchangeAdapter
@@ -233,10 +263,10 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0):
         # non-fatal (SL may have already triggered on-chain, in which case the
         # position sync will detect the close on the next cycle) but is
         # surfaced in the JSON so the scheduler can log it.
-        cancel_err = ""
-        if cancel_oid > 0:
+        if cancel_attempted:
             try:
                 adapter.cancel_trigger_order(symbol, cancel_oid)
+                cancel_succeeded = True
             except Exception as ce:
                 cancel_err = str(ce)
                 print(f"[WARN] cancel_trigger_order({symbol}, {cancel_oid}) failed: {ce}", file=sys.stderr)
@@ -269,9 +299,14 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0):
         # place an SL when the main order actually filled; a zero-size fill
         # usually means the order was rejected and there's nothing to protect.
         sl_err = ""
-        if stop_loss_pct > 0 and fill.get("avg_px", 0) > 0 and fill.get("total_sz", 0) > 0:
+        sl_filled_immediately = False
+        # Net new-position size: on a flip (long→short or vice versa) total_sz
+        # is closeQty + newQty, but reduce-only triggers must be sized against
+        # the resulting net position (#421).
+        net_new_sz = max(fill.get("total_sz", 0) - max(prev_pos_qty, 0.0), 0.0)
+        if stop_loss_pct > 0 and fill.get("avg_px", 0) > 0 and net_new_sz > 0:
             entry_px = fill["avg_px"]
-            filled_sz = fill["total_sz"]
+            sl_size = net_new_sz
             # Stop-loss fires against the opposite direction of the open:
             # long open (is_buy=True)  → SL sells when price drops below entry*(1-pct).
             # short open (is_buy=False) → SL buys when price rises above entry*(1+pct).
@@ -282,17 +317,29 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0):
                 trigger_px = entry_px * (1.0 + stop_loss_pct / 100.0)
                 sl_is_buy = True
             try:
-                sl_resp = adapter.place_stop_loss(symbol, filled_sz, trigger_px, sl_is_buy)
-                sl_oid = _extract_resting_oid(sl_resp)
-                if sl_oid is not None:
-                    fill["stop_loss_oid"] = sl_oid
+                sl_resp = adapter.place_stop_loss(symbol, sl_size, trigger_px, sl_is_buy)
+                kind, payload = _classify_sl_response(sl_resp)
+                if kind == "resting":
+                    fill["stop_loss_oid"] = payload
                     fill["stop_loss_trigger_px"] = round(trigger_px, 6)
+                elif kind == "filled":
+                    # Price was already through the trigger — the SL filled at
+                    # submit time, so the position just got stopped out. No OID
+                    # to track. Surface as a distinct field so the scheduler
+                    # can reconcile virtual state instead of treating it as a
+                    # placement error and leaving the position recorded as open.
+                    sl_filled_immediately = True
+                    fill["stop_loss_trigger_px"] = round(trigger_px, 6)
+                    print(f"[WARN] stop-loss filled immediately at submit (price already through {trigger_px})", file=sys.stderr)
+                elif kind == "error":
+                    sl_err = f"place_stop_loss SDK error: {payload}"
+                    print(f"[WARN] {sl_err}", file=sys.stderr)
                 else:
-                    sl_err = f"place_stop_loss returned no resting OID: {sl_resp}"
+                    sl_err = f"place_stop_loss returned no usable status: {sl_resp}"
                     print(f"[WARN] {sl_err}", file=sys.stderr)
             except Exception as se:
                 sl_err = str(se)
-                print(f"[WARN] place_stop_loss({symbol}, {filled_sz}, {trigger_px}) failed: {se}", file=sys.stderr)
+                print(f"[WARN] place_stop_loss({symbol}, {sl_size}, {trigger_px}) failed: {se}", file=sys.stderr)
 
         out = {
             "execution": {
@@ -306,18 +353,29 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0):
         }
         if cancel_err:
             out["cancel_stop_loss_error"] = cancel_err
+        if cancel_succeeded:
+            out["cancel_stop_loss_succeeded"] = True
         if sl_err:
             out["stop_loss_error"] = sl_err
+        if sl_filled_immediately:
+            out["stop_loss_filled_immediately"] = True
         print(json.dumps(out, cls=SafeEncoder))
 
     except Exception as e:
         traceback.print_exc(file=sys.stderr)
-        print(json.dumps({
+        err_payload = {
             "execution": None,
             "platform": "hyperliquid",
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "error": str(e),
-        }, cls=SafeEncoder))
+        }
+        # Always surface cancel state on failure paths too so the scheduler
+        # can clear pos.StopLossOID even when the subsequent open raises (#421).
+        if cancel_err:
+            err_payload["cancel_stop_loss_error"] = cancel_err
+        if cancel_succeeded:
+            err_payload["cancel_stop_loss_succeeded"] = True
+        print(json.dumps(err_payload, cls=SafeEncoder))
         sys.exit(1)
 
 
@@ -335,9 +393,12 @@ def main():
                             help="place a reduce-only SL trigger this pct away from fill (#412)")
         parser.add_argument("--cancel-stop-loss-oid", type=int, default=0,
                             help="cancel this trigger OID before placing the new order (#412)")
+        parser.add_argument("--prev-pos-qty", type=float, default=0.0,
+                            help="abs qty of existing position being flipped, so SL is sized against the new net position (#421)")
         args = parser.parse_args()
         run_execute(args.symbol, args.side, args.size, args.mode,
-                    stop_loss_pct=args.stop_loss_pct, cancel_oid=args.cancel_stop_loss_oid)
+                    stop_loss_pct=args.stop_loss_pct, cancel_oid=args.cancel_stop_loss_oid,
+                    prev_pos_qty=args.prev_pos_qty)
     else:
         # Signal check mode: <strategy> <symbol> <timeframe> [--mode=paper|live] [--htf-filter]
         import argparse

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -316,12 +316,16 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
             else:
                 trigger_px = entry_px * (1.0 + stop_loss_pct / 100.0)
                 sl_is_buy = True
+            # Pre-round to HL's per-asset px tick so the recorded value matches
+            # the price the order actually rests at — the scheduler books PnL
+            # off this field on StopLossFilledImmediately (#421 review).
+            trigger_px = adapter.round_perps_trigger_px(symbol, trigger_px)
             try:
                 sl_resp = adapter.place_stop_loss(symbol, sl_size, trigger_px, sl_is_buy)
                 kind, payload = _classify_sl_response(sl_resp)
                 if kind == "resting":
                     fill["stop_loss_oid"] = payload
-                    fill["stop_loss_trigger_px"] = round(trigger_px, 6)
+                    fill["stop_loss_trigger_px"] = trigger_px
                 elif kind == "filled":
                     # Price was already through the trigger — the SL filled at
                     # submit time, so the position just got stopped out. No OID
@@ -329,7 +333,7 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
                     # can reconcile virtual state instead of treating it as a
                     # placement error and leaving the position recorded as open.
                     sl_filled_immediately = True
-                    fill["stop_loss_trigger_px"] = round(trigger_px, 6)
+                    fill["stop_loss_trigger_px"] = trigger_px
                     print(f"[WARN] stop-loss filled immediately at submit (price already through {trigger_px})", file=sys.stderr)
                 elif kind == "error":
                     sl_err = f"place_stop_loss SDK error: {payload}"

--- a/shared_scripts/close_hyperliquid_position.py
+++ b/shared_scripts/close_hyperliquid_position.py
@@ -13,15 +13,16 @@ Usage:
     close_hyperliquid_position.py --symbol=ETH --mode=live
     close_hyperliquid_position.py --symbol=ETH --mode=live --sz=0.25
     close_hyperliquid_position.py --symbol=ETH --mode=live --cancel-stop-loss-oid=123
+    close_hyperliquid_position.py --symbol=ETH --mode=live --cancel-stop-loss-oid=123 --cancel-stop-loss-oid=456
 
 Optional ``--sz`` submits a partial reduce-only close (coin units). Omit for
 full position close (portfolio kill switch and sole-owner circuit breakers).
 
-Optional ``--cancel-stop-loss-oid`` cancels a resting trigger order BEFORE
+Optional ``--cancel-stop-loss-oid`` (repeatable) cancels resting trigger orders BEFORE
 the close fires. Used by per-strategy circuit breakers and the portfolio
 kill switch to free the trigger slot from `Position.StopLossOID` so the
 SL doesn't sit orphaned on HL's book consuming one of the 10/day account
-trigger-order slots (#421 review point 1). Cancel failure is non-fatal
+trigger-order slots (#421 review point 1). Cancel failures are non-fatal
 (SL may have already triggered on-chain) and is surfaced as
 ``cancel_stop_loss_error`` in the JSON envelope.
 
@@ -56,8 +57,9 @@ def main():
     parser.add_argument(
         "--cancel-stop-loss-oid",
         type=int,
-        default=0,
-        help="cancel this trigger OID before the close (frees HL's 10/day cap; #421)",
+        action="append",
+        default=[],
+        help="cancel this trigger OID before the close; repeat for shared-coin triggers (#421)",
     )
     args = parser.parse_args()
 
@@ -82,13 +84,18 @@ def main():
         # which case the close itself will hit "no position" and route
         # through already_flat. Cancel state is surfaced in the JSON
         # envelope so the Go side can clear pos.StopLossOID either way.
-        if args.cancel_stop_loss_oid > 0:
+        cancel_errors = []
+        for oid in args.cancel_stop_loss_oid:
+            if oid <= 0:
+                continue
             try:
-                adapter.cancel_trigger_order(args.symbol, args.cancel_stop_loss_oid)
+                adapter.cancel_trigger_order(args.symbol, oid)
                 cancel_succeeded = True
             except Exception as ce:
-                cancel_err = str(ce)
-                print(f"[WARN] cancel_trigger_order({args.symbol}, {args.cancel_stop_loss_oid}) failed: {ce}", file=sys.stderr)
+                cancel_errors.append(f"{oid}: {ce}")
+                print(f"[WARN] cancel_trigger_order({args.symbol}, {oid}) failed: {ce}", file=sys.stderr)
+        if cancel_errors:
+            cancel_err = "; ".join(cancel_errors)
         result = adapter.market_close(args.symbol, args.sz)
     except Exception as e:
         traceback.print_exc(file=sys.stderr)

--- a/shared_scripts/close_hyperliquid_position.py
+++ b/shared_scripts/close_hyperliquid_position.py
@@ -12,9 +12,18 @@ state can diverge from the on-chain net.
 Usage:
     close_hyperliquid_position.py --symbol=ETH --mode=live
     close_hyperliquid_position.py --symbol=ETH --mode=live --sz=0.25
+    close_hyperliquid_position.py --symbol=ETH --mode=live --cancel-stop-loss-oid=123
 
 Optional ``--sz`` submits a partial reduce-only close (coin units). Omit for
 full position close (portfolio kill switch and sole-owner circuit breakers).
+
+Optional ``--cancel-stop-loss-oid`` cancels a resting trigger order BEFORE
+the close fires. Used by per-strategy circuit breakers and the portfolio
+kill switch to free the trigger slot from `Position.StopLossOID` so the
+SL doesn't sit orphaned on HL's book consuming one of the 10/day account
+trigger-order slots (#421 review point 1). Cancel failure is non-fatal
+(SL may have already triggered on-chain) and is surfaced as
+``cancel_stop_loss_error`` in the JSON envelope.
 
 Live mode is required (kill switch is meaningful only against real
 positions). Stdout is always a single JSON envelope: `{"close": ..., "platform": ...,
@@ -44,6 +53,12 @@ def main():
         default=None,
         help="partial close size in coin units (omit for full position)",
     )
+    parser.add_argument(
+        "--cancel-stop-loss-oid",
+        type=int,
+        default=0,
+        help="cancel this trigger OID before the close (frees HL's 10/day cap; #421)",
+    )
     args = parser.parse_args()
 
     if args.mode != "live":
@@ -55,13 +70,29 @@ def main():
         }))
         sys.exit(1)
 
+    cancel_err = ""
+    cancel_succeeded = False
+
     try:
         from adapter import HyperliquidExchangeAdapter
         adapter = HyperliquidExchangeAdapter()
+        # Cancel stale SL trigger first so it doesn't sit orphaned on HL's
+        # book after the close completes (#421 review point 1). A cancel
+        # failure is non-fatal — the SL may have already triggered, in
+        # which case the close itself will hit "no position" and route
+        # through already_flat. Cancel state is surfaced in the JSON
+        # envelope so the Go side can clear pos.StopLossOID either way.
+        if args.cancel_stop_loss_oid > 0:
+            try:
+                adapter.cancel_trigger_order(args.symbol, args.cancel_stop_loss_oid)
+                cancel_succeeded = True
+            except Exception as ce:
+                cancel_err = str(ce)
+                print(f"[WARN] cancel_trigger_order({args.symbol}, {args.cancel_stop_loss_oid}) failed: {ce}", file=sys.stderr)
         result = adapter.market_close(args.symbol, args.sz)
     except Exception as e:
         traceback.print_exc(file=sys.stderr)
-        _emit_error(args.symbol, str(e))
+        _emit_error(args.symbol, str(e), cancel_err=cancel_err, cancel_succeeded=cancel_succeeded)
         return
 
     # SDK reduce-only close response shape mirrors market_open:
@@ -72,13 +103,15 @@ def main():
     # (the original #341 failure mode shifted into the Python layer).
 
     if not isinstance(result, dict):
-        _emit_error(args.symbol, f"unexpected SDK response type {type(result).__name__}: {result!r}")
+        _emit_error(args.symbol, f"unexpected SDK response type {type(result).__name__}: {result!r}",
+                    cancel_err=cancel_err, cancel_succeeded=cancel_succeeded)
         return
 
     # Outer status must be "ok" or absent — anything else is an SDK rejection.
     outer_status = result.get("status")
     if outer_status not in (None, "ok"):
-        _emit_error(args.symbol, f"sdk status={outer_status!r}: {result}")
+        _emit_error(args.symbol, f"sdk status={outer_status!r}: {result}",
+                    cancel_err=cancel_err, cancel_succeeded=cancel_succeeded)
         return
 
     statuses = result.get("response", {}).get("data", {}).get("statuses", [])
@@ -93,7 +126,8 @@ def main():
         # AlreadyFlat report slice rather than ClosedCoins — operator
         # messaging must distinguish "we sent a close order" from
         # "nothing to close" (#350).
-        _emit_success(args.symbol, fill={}, already_flat=True)
+        _emit_success(args.symbol, fill={}, already_flat=True,
+                      cancel_err=cancel_err, cancel_succeeded=cancel_succeeded)
         return
 
     first = statuses[0]
@@ -101,14 +135,16 @@ def main():
     # Per-status error (e.g. "order has zero size", "no position", rate limit).
     # Surface so the kill switch latches and retries next cycle.
     if "error" in first:
-        _emit_error(args.symbol, f"per-status error: {first['error']}")
+        _emit_error(args.symbol, f"per-status error: {first['error']}",
+                    cancel_err=cancel_err, cancel_succeeded=cancel_succeeded)
         return
 
     # "resting" means a limit order is sitting on the book — for market_close
     # this should never happen (market orders fill or fail), but guard anyway.
     # Not "filled" => not closed => kill switch must NOT release the latch.
     if "filled" not in first:
-        _emit_error(args.symbol, f"close not filled (status keys={list(first.keys())}): {first}")
+        _emit_error(args.symbol, f"close not filled (status keys={list(first.keys())}): {first}",
+                    cancel_err=cancel_err, cancel_succeeded=cancel_succeeded)
         return
 
     filled = first["filled"]
@@ -122,27 +158,37 @@ def main():
     fee = filled.get("fee")
     if fee is not None:
         fill["fee"] = float(fee)
-    _emit_success(args.symbol, fill)
+    _emit_success(args.symbol, fill, cancel_err=cancel_err, cancel_succeeded=cancel_succeeded)
 
 
-def _emit_success(symbol, fill, already_flat=False):
+def _emit_success(symbol, fill, already_flat=False, cancel_err="", cancel_succeeded=False):
     close = {"symbol": symbol, "fill": fill}
     if already_flat:
         close["already_flat"] = True
-    print(json.dumps({
+    out = {
         "close": close,
         "platform": "hyperliquid",
         "timestamp": datetime.now(timezone.utc).isoformat(),
-    }))
+    }
+    if cancel_err:
+        out["cancel_stop_loss_error"] = cancel_err
+    if cancel_succeeded:
+        out["cancel_stop_loss_succeeded"] = True
+    print(json.dumps(out))
 
 
-def _emit_error(symbol, message):
-    print(json.dumps({
+def _emit_error(symbol, message, cancel_err="", cancel_succeeded=False):
+    out = {
         "close": {"symbol": symbol, "fill": {}},
         "platform": "hyperliquid",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "error": message,
-    }))
+    }
+    if cancel_err:
+        out["cancel_stop_loss_error"] = cancel_err
+    if cancel_succeeded:
+        out["cancel_stop_loss_succeeded"] = True
+    print(json.dumps(out))
     sys.exit(1)
 
 

--- a/shared_scripts/test_check_hyperliquid.py
+++ b/shared_scripts/test_check_hyperliquid.py
@@ -136,3 +136,80 @@ class TestFillExtraction:
         }
         result = self._run_execute_with_mock_response(sdk_response)
         assert result["execution"]["fill"] == {}
+
+
+class TestClassifySLResponse:
+    """Unit coverage for _classify_sl_response added in #421. The classifier
+    is the load-bearing piece that distinguishes a resting SL from an instant
+    fill or rejection — getting it wrong means either virtual state thinks
+    the position is open when it's flat, or the scheduler treats a happy
+    instant fill as a placement error."""
+
+    def _classify(self, response):
+        mod, spec = _load_check_module()
+        spec.loader.exec_module(mod)
+        return mod._classify_sl_response(response)
+
+    def test_resting(self):
+        kind, oid = self._classify({
+            "response": {"type": "order", "data": {"statuses": [
+                {"resting": {"oid": 12345}}
+            ]}}
+        })
+        assert kind == "resting"
+        assert oid == 12345
+
+    def test_resting_missing_oid_returns_zero(self):
+        kind, oid = self._classify({
+            "response": {"type": "order", "data": {"statuses": [
+                {"resting": {}}
+            ]}}
+        })
+        assert kind == "resting"
+        assert oid == 0
+
+    def test_filled_immediate_with_oid(self):
+        kind, oid = self._classify({
+            "response": {"type": "order", "data": {"statuses": [
+                {"filled": {"oid": 67890, "avgPx": "3000"}}
+            ]}}
+        })
+        assert kind == "filled"
+        assert oid == 67890
+
+    def test_filled_immediate_without_oid(self):
+        kind, oid = self._classify({
+            "response": {"type": "order", "data": {"statuses": [
+                {"filled": {}}
+            ]}}
+        })
+        assert kind == "filled"
+        assert oid == 0
+
+    def test_per_status_error(self):
+        kind, payload = self._classify({
+            "response": {"type": "order", "data": {"statuses": [
+                {"error": "Too many open trigger orders"}
+            ]}}
+        })
+        assert kind == "error"
+        assert "Too many" in payload
+
+    def test_missing_when_no_statuses(self):
+        kind, payload = self._classify({
+            "response": {"type": "order", "data": {"statuses": []}}
+        })
+        assert kind == "missing"
+        assert payload is None
+
+    def test_missing_when_completely_malformed(self):
+        kind, payload = self._classify({})
+        assert kind == "missing"
+        assert payload is None
+
+    def test_missing_when_status_is_not_dict(self):
+        kind, payload = self._classify({
+            "response": {"type": "order", "data": {"statuses": ["not a dict"]}}
+        })
+        assert kind == "missing"
+        assert payload is None

--- a/shared_scripts/test_close_hyperliquid_position.py
+++ b/shared_scripts/test_close_hyperliquid_position.py
@@ -225,5 +225,114 @@ class TestFailurePaths:
         assert "unexpected SDK response type" in out["error"]
 
 
+def _run_script_with_cancel(sdk_response, cancel_response, argv):
+    """Variant of _run_script that also stubs adapter.cancel_trigger_order.
+    cancel_response is either a dict (returned) or an Exception (raised)."""
+    script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               "close_hyperliquid_position.py")
+    spec = importlib.util.spec_from_file_location("close_hyperliquid_position", script_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    mock_adapter_cls = MagicMock()
+    mock_adapter = MagicMock()
+    mock_adapter_cls.return_value = mock_adapter
+    mock_adapter.market_close.return_value = sdk_response
+    if isinstance(cancel_response, Exception):
+        mock_adapter.cancel_trigger_order.side_effect = cancel_response
+    else:
+        mock_adapter.cancel_trigger_order.return_value = cancel_response
+
+    captured = StringIO()
+    exit_code = {"value": 0}
+
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "adapter":
+            fake_mod = MagicMock()
+            fake_mod.HyperliquidExchangeAdapter = mock_adapter_cls
+            return fake_mod
+        return original_import(name, *args, **kwargs)
+
+    def mock_exit(code=0):
+        exit_code["value"] = code
+        raise SystemExit(code)
+
+    with patch("builtins.__import__", side_effect=mock_import), \
+         patch("sys.stdout", captured), \
+         patch("sys.argv", ["close_hyperliquid_position.py"] + argv), \
+         patch.object(mod.sys, "exit", side_effect=mock_exit):
+        try:
+            mod.main()
+        except SystemExit:
+            pass
+
+    raw = captured.getvalue().strip()
+    parsed = json.loads(raw) if raw else {}
+    return parsed, exit_code["value"], mock_adapter
+
+
+class TestCancelStopLossOID:
+    """#421 review point 1: per-strategy CB / portfolio-kill close paths must
+    cancel the resting SL trigger before flattening so HL's 10/day account-wide
+    trigger-order cap doesn't fill up with orphans."""
+
+    def _filled_response(self, sym="ETH"):
+        return {
+            "status": "ok",
+            "response": {"type": "order", "data": {"statuses": [
+                {"filled": {"avgPx": "3000", "totalSz": "1.0", "oid": 999}}
+            ]}},
+        }
+
+    def test_no_cancel_when_oid_zero(self):
+        """Default behavior preserved: omitting --cancel-stop-loss-oid (or
+        passing 0) must not call cancel_trigger_order."""
+        out, code, adapter = _run_script_with_cancel(
+            self._filled_response(), {"status": "ok"},
+            ["--symbol=ETH", "--mode=live"])
+        assert code == 0
+        adapter.cancel_trigger_order.assert_not_called()
+        assert "cancel_stop_loss_succeeded" not in out
+        assert "cancel_stop_loss_error" not in out
+
+    def test_cancel_succeeded_surfaces_in_envelope(self):
+        out, code, adapter = _run_script_with_cancel(
+            self._filled_response(), {"status": "ok"},
+            ["--symbol=ETH", "--mode=live", "--cancel-stop-loss-oid=12345"])
+        assert code == 0
+        adapter.cancel_trigger_order.assert_called_once_with("ETH", 12345)
+        assert out.get("cancel_stop_loss_succeeded") is True
+
+    def test_cancel_failure_is_non_fatal(self):
+        """Cancel may fail because the SL already triggered — close should
+        still proceed and the failure is surfaced for the Go side to log."""
+        out, code, adapter = _run_script_with_cancel(
+            self._filled_response(), RuntimeError("order not found"),
+            ["--symbol=ETH", "--mode=live", "--cancel-stop-loss-oid=999"])
+        assert code == 0  # close still succeeded
+        assert "order not found" in out.get("cancel_stop_loss_error", "")
+        assert "cancel_stop_loss_succeeded" not in out
+
+    def test_cancel_state_propagates_through_close_failure(self):
+        """If close fails after cancel succeeds, the envelope must still
+        report cancel_stop_loss_succeeded so the Go side can clear the
+        dead OID from pos.StopLossOID — same contract as the execute path
+        from #421's CancelStopLossSucceeded field."""
+        sdk_response = {
+            "status": "ok",
+            "response": {"type": "order", "data": {"statuses": [
+                {"error": "no position to close"}
+            ]}},
+        }
+        out, code, adapter = _run_script_with_cancel(
+            sdk_response, {"status": "ok"},
+            ["--symbol=ETH", "--mode=live", "--cancel-stop-loss-oid=12345"])
+        assert code == 1
+        assert "per-status error" in out["error"]
+        assert out.get("cancel_stop_loss_succeeded") is True
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))

--- a/shared_scripts/test_close_hyperliquid_position.py
+++ b/shared_scripts/test_close_hyperliquid_position.py
@@ -305,6 +305,17 @@ class TestCancelStopLossOID:
         adapter.cancel_trigger_order.assert_called_once_with("ETH", 12345)
         assert out.get("cancel_stop_loss_succeeded") is True
 
+    def test_multiple_cancel_oids_are_all_attempted(self):
+        out, code, adapter = _run_script_with_cancel(
+            self._filled_response(), {"status": "ok"},
+            ["--symbol=ETH", "--mode=live",
+             "--cancel-stop-loss-oid=12345", "--cancel-stop-loss-oid=67890"])
+        assert code == 0
+        adapter.cancel_trigger_order.assert_any_call("ETH", 12345)
+        adapter.cancel_trigger_order.assert_any_call("ETH", 67890)
+        assert adapter.cancel_trigger_order.call_count == 2
+        assert out.get("cancel_stop_loss_succeeded") is True
+
     def test_cancel_failure_is_non_fatal(self):
         """Cancel may fail because the SL already triggered — close should
         still proceed and the failure is surfaced for the Go side to log."""


### PR DESCRIPTION
Closes #412

## Summary

- Places a reduce-only Hyperliquid trigger order alongside every live perps open (`tpsl: sl`)
- Tracks the resting OID on `Position.StopLossOID` (SQLite migration included) so signal-based closes and flips cancel the stale SL before placing their own fill
- Per-strategy `stop_loss_pct` gates the feature (default 0 = disabled); init wizard prompts for it only when HL perps runs live
- Non-fatal SL cancel/placement errors surface as JSON fields so the scheduler logs them without aborting the main fill's state update

## Test plan

- [x] `go test ./...` passes (incl. new `hyperliquid_stop_loss_test.go` covering parser + JSON round-trip)
- [x] `gofmt -l` clean
- [x] Python AST parse clean on both edited files
- [ ] Smoke test `init --json` emits `stop_loss_pct` on HL perps configs
- [ ] Paper-mode HL perps cycle with `stop_loss_pct=3` (verify flag is threaded but ignored in paper mode)
- [ ] Live-mode HL perps smoke (requires HL creds): open → confirm SL appears in `frontendOpenOrders` → close → confirm SL cancelled

🤖 Generated with [Claude Code](https://claude.ai/code)

---
LLM: Claude Opus 4.7 (1M) | high | Tokens: 122 in / 50915 out | Cache: 12682616 read / 270274 written | Cost: $9.3