### PR TITLE
fix: repeat portfolio drawdown warning every cycle while in warn band

### DIFF
--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -213,13 +213,18 @@ type KillSwitchEvent struct {
 // reconstructable, while still exposing the margin signal for operators and
 // the kill switch. The kill switch fires on whichever signal breaches first.
 type PortfolioRiskState struct {
-	PeakValue                float64           `json:"peak_value"`
-	CurrentDrawdownPct       float64           `json:"current_drawdown_pct"`
-	CurrentMarginDrawdownPct float64           `json:"current_margin_drawdown_pct,omitempty"`
-	KillSwitchActive         bool              `json:"kill_switch_active"`
-	KillSwitchAt             time.Time         `json:"kill_switch_at,omitempty"`
-	WarningSent              bool              `json:"warning_sent,omitempty"`
-	Events                   []KillSwitchEvent `json:"events,omitempty"`
+	PeakValue                float64   `json:"peak_value"`
+	CurrentDrawdownPct       float64   `json:"current_drawdown_pct"`
+	CurrentMarginDrawdownPct float64   `json:"current_margin_drawdown_pct,omitempty"`
+	KillSwitchActive         bool      `json:"kill_switch_active"`
+	KillSwitchAt             time.Time `json:"kill_switch_at,omitempty"`
+	// WarningSent is true while drawdown is currently in the warn band
+	// (between warn threshold and kill-switch limit). It is set every cycle
+	// the band is breached and cleared when drawdown recovers below the warn
+	// threshold. The warning notification fires on every cycle the band is
+	// breached, not just on the rising edge (#420).
+	WarningSent bool              `json:"warning_sent,omitempty"`
+	Events      []KillSwitchEvent `json:"events,omitempty"`
 }
 
 // SharedWalletBalanceFetcher returns the real on-chain balance for a given
@@ -456,26 +461,28 @@ func CheckPortfolioRisk(prs *PortfolioRiskState, cfg *PortfolioRiskConfig, total
 		equityWarn := equityDD > warnDrawdownPct
 		marginWarn := marginDD > warnDrawdownPct
 		if equityWarn || marginWarn {
-			if !prs.WarningSent {
-				prs.WarningSent = true
-				warning = true
-				switch {
-				case equityWarn && marginWarn:
-					// Both breached — surface both in the reason so a
-					// correlated move is visible to the operator. Ties go
-					// to margin (see kill-switch branch above).
-					reason = fmt.Sprintf("portfolio drawdown approaching kill switch limit %.1f%% (warn at %.1f%%): equity=%.1f%% (value=$%.2f, peak=$%.2f); perps margin=%.1f%% (unrealized loss=$%.2f, margin=$%.2f)",
-						cfg.MaxDrawdownPct, warnDrawdownPct, equityDD, totalValue, prs.PeakValue, marginDD, perpsUnrealizedLoss, perpsMargin)
-				case marginWarn:
-					reason = fmt.Sprintf("portfolio perps margin drawdown %.1f%% approaching kill switch limit %.1f%% (warn at %.1f%%, unrealized loss=$%.2f, margin=$%.2f)",
-						marginDD, cfg.MaxDrawdownPct, warnDrawdownPct, perpsUnrealizedLoss, perpsMargin)
-				default:
-					reason = fmt.Sprintf("portfolio drawdown %.1f%% approaching kill switch limit %.1f%% (warn at %.1f%%, value=$%.2f, peak=$%.2f)",
-						equityDD, cfg.MaxDrawdownPct, warnDrawdownPct, totalValue, prs.PeakValue)
-				}
+			// Fire on every cycle the band is breached so the operator
+			// keeps seeing the alert during a slow bleed (#420). Recovery
+			// below the threshold clears WarningSent in the else branch.
+			prs.WarningSent = true
+			warning = true
+			switch {
+			case equityWarn && marginWarn:
+				// Both breached — surface both in the reason so a
+				// correlated move is visible to the operator. Ties go
+				// to margin (see kill-switch branch above).
+				reason = fmt.Sprintf("portfolio drawdown approaching kill switch limit %.1f%% (warn at %.1f%%): equity=%.1f%% (value=$%.2f, peak=$%.2f); perps margin=%.1f%% (unrealized loss=$%.2f, margin=$%.2f)",
+					cfg.MaxDrawdownPct, warnDrawdownPct, equityDD, totalValue, prs.PeakValue, marginDD, perpsUnrealizedLoss, perpsMargin)
+			case marginWarn:
+				reason = fmt.Sprintf("portfolio perps margin drawdown %.1f%% approaching kill switch limit %.1f%% (warn at %.1f%%, unrealized loss=$%.2f, margin=$%.2f)",
+					marginDD, cfg.MaxDrawdownPct, warnDrawdownPct, perpsUnrealizedLoss, perpsMargin)
+			default:
+				reason = fmt.Sprintf("portfolio drawdown %.1f%% approaching kill switch limit %.1f%% (warn at %.1f%%, value=$%.2f, peak=$%.2f)",
+					equityDD, cfg.MaxDrawdownPct, warnDrawdownPct, totalValue, prs.PeakValue)
 			}
 		} else {
-			// Recovered below warning threshold — reset so it can fire again.
+			// Recovered below warning threshold — clear so the next breach
+			// records a fresh rising edge in state.
 			prs.WarningSent = false
 		}
 	}

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -772,8 +772,8 @@ func TestCheckRisk_ConsecutiveLossesForceClose(t *testing.T) {
 	}
 }
 
-// TestCheckPortfolioRisk_WarningFires verifies that drawdown at 80% of limit
-// triggers a warning once but not again on second call.
+// TestCheckPortfolioRisk_WarningFires verifies that drawdown in the warn band
+// triggers a warning on every cycle until recovery (#420).
 func TestCheckPortfolioRisk_WarningFires(t *testing.T) {
 	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
 	prs := &PortfolioRiskState{PeakValue: 10000.0}
@@ -790,10 +790,35 @@ func TestCheckPortfolioRisk_WarningFires(t *testing.T) {
 		t.Error("expected WarningSent=true after warning fires")
 	}
 
-	// Second call at same drawdown — warning should NOT fire again.
-	_, _, warning, _ = CheckPortfolioRisk(prs, cfg, 7900.0, 0, 0, 0)
-	if warning {
-		t.Error("expected warning=false on second call (already sent)")
+	// Second call at same drawdown — warning fires again every cycle (#420).
+	_, _, warning, reason2 := CheckPortfolioRisk(prs, cfg, 7900.0, 0, 0, 0)
+	if !warning {
+		t.Error("expected warning=true on second call (warn band still breached)")
+	}
+	if reason2 == "" {
+		t.Error("expected non-empty reason on second call")
+	}
+}
+
+// TestCheckPortfolioRisk_WarningRepeatsAcrossCycles verifies that warning
+// fires on every cycle while drawdown remains in the warn band, even with no
+// recovery in between (#420).
+func TestCheckPortfolioRisk_WarningRepeatsAcrossCycles(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 10000.0}
+
+	// Warn threshold = 20%. Hold portfolio at 21% drawdown across many cycles.
+	for i := 0; i < 5; i++ {
+		_, _, warning, reason := CheckPortfolioRisk(prs, cfg, 7900.0, 0, 0, 0)
+		if !warning {
+			t.Errorf("cycle %d: expected warning=true while in warn band", i)
+		}
+		if reason == "" {
+			t.Errorf("cycle %d: expected non-empty reason", i)
+		}
+		if !prs.WarningSent {
+			t.Errorf("cycle %d: expected WarningSent=true while in warn band", i)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove the `!WarningSent` rising-edge gate in `CheckPortfolioRisk` so the warn-band notification fires on every cycle until drawdown recovers (#420).
- Repurpose `WarningSent` as a "currently in warn band" state flag (kept for `/status` visibility, persisted in DB) — set every cycle the band is breached, cleared on recovery.
- Update existing test to assert warning fires on the second call; add `TestCheckPortfolioRisk_WarningRepeatsAcrossCycles` covering 5 consecutive in-band cycles.

## Test plan
- [x] `go test ./...` (full scheduler suite passes)
- [x] `go test -run 'CheckPortfolioRisk|Warning' ./...` (targeted)
- [x] `gofmt -l scheduler/risk.go scheduler/risk_test.go` clean
- [x] Recovery test (`TestCheckPortfolioRisk_WarningResetOnRecovery`) still passes — `WarningSent` clears below threshold and re-fires on re-cross
- [x] Kill-switch precedence test (`TestCheckPortfolioRisk_WarningNotAfterKillSwitch`) still passes — warning is suppressed when kill switch fires

Closes #420

---
LLM: Claude Opus 4.7 (1M) | medium