### PR TITLE
[codex] Repeat portfolio drawdown warnings

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -661,7 +661,12 @@ func main() {
 			// we snapshot before the call and restore if we're on a fallback
 			// cycle. Drawdown detection still runs against the frozen peak.
 			origPeak := state.PortfolioRisk.PeakValue
+			prevWarningSent := state.PortfolioRisk.WarningSent
 			portfolioAllowed, nb, portfolioWarning, portfolioReason := CheckPortfolioRisk(&state.PortfolioRisk, cfg.PortfolioRisk, totalPV, totalNotional, perpsLoss, perpsMargin)
+			// True only on the cycle that first enters the warn band; false on
+			// repeat cycles while still in band. Used to gate kill-switch event
+			// log appends — notifications still fire every cycle via portfolioWarning.
+			portfolioWarnBandEntered := portfolioWarning && !prevWarningSent
 			if usedPVFallback && state.PortfolioRisk.PeakValue > origPeak {
 				state.PortfolioRisk.PeakValue = origPeak
 			}
@@ -774,7 +779,13 @@ func main() {
 					source = "margin"
 					warnDD = state.PortfolioRisk.CurrentMarginDrawdownPct
 				}
-				addKillSwitchEvent(&state.PortfolioRisk, "warning", source, warnDD, totalPV, state.PortfolioRisk.PeakValue, portfolioReason)
+				// Only append a kill-switch event on the transition INTO the
+				// warn band. Notifications repeat every cycle (portfolioWarning)
+				// but the 50-entry ring buffer must not be evicted by repeating
+				// "warning" entries that drown out triggered/reset transitions.
+				if portfolioWarnBandEntered {
+					addKillSwitchEvent(&state.PortfolioRisk, "warning", source, warnDD, totalPV, state.PortfolioRisk.PeakValue, portfolioReason)
+				}
 				mu.Unlock()
 				warnMsg := fmt.Sprintf("**PORTFOLIO WARNING**\n%s", portfolioReason)
 				notifier.SendToAllChannels(warnMsg)

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -212,6 +212,9 @@ type KillSwitchEvent struct {
 // preserves the arithmetic invariant that (PeakValue, CurrentDrawdownPct) is
 // reconstructable, while still exposing the margin signal for operators and
 // the kill switch. The kill switch fires on whichever signal breaches first.
+// WarningSent is retained for persisted status visibility and is true while
+// either drawdown signal is in the warning band; notifications are emitted on
+// every cycle in that band.
 type PortfolioRiskState struct {
 	PeakValue                float64           `json:"peak_value"`
 	CurrentDrawdownPct       float64           `json:"current_drawdown_pct"`
@@ -456,26 +459,24 @@ func CheckPortfolioRisk(prs *PortfolioRiskState, cfg *PortfolioRiskConfig, total
 		equityWarn := equityDD > warnDrawdownPct
 		marginWarn := marginDD > warnDrawdownPct
 		if equityWarn || marginWarn {
-			if !prs.WarningSent {
-				prs.WarningSent = true
-				warning = true
-				switch {
-				case equityWarn && marginWarn:
-					// Both breached — surface both in the reason so a
-					// correlated move is visible to the operator. Ties go
-					// to margin (see kill-switch branch above).
-					reason = fmt.Sprintf("portfolio drawdown approaching kill switch limit %.1f%% (warn at %.1f%%): equity=%.1f%% (value=$%.2f, peak=$%.2f); perps margin=%.1f%% (unrealized loss=$%.2f, margin=$%.2f)",
-						cfg.MaxDrawdownPct, warnDrawdownPct, equityDD, totalValue, prs.PeakValue, marginDD, perpsUnrealizedLoss, perpsMargin)
-				case marginWarn:
-					reason = fmt.Sprintf("portfolio perps margin drawdown %.1f%% approaching kill switch limit %.1f%% (warn at %.1f%%, unrealized loss=$%.2f, margin=$%.2f)",
-						marginDD, cfg.MaxDrawdownPct, warnDrawdownPct, perpsUnrealizedLoss, perpsMargin)
-				default:
-					reason = fmt.Sprintf("portfolio drawdown %.1f%% approaching kill switch limit %.1f%% (warn at %.1f%%, value=$%.2f, peak=$%.2f)",
-						equityDD, cfg.MaxDrawdownPct, warnDrawdownPct, totalValue, prs.PeakValue)
-				}
+			prs.WarningSent = true
+			warning = true
+			switch {
+			case equityWarn && marginWarn:
+				// Both breached — surface both in the reason so a
+				// correlated move is visible to the operator. Ties go
+				// to margin (see kill-switch branch above).
+				reason = fmt.Sprintf("portfolio drawdown approaching kill switch limit %.1f%% (warn at %.1f%%): equity=%.1f%% (value=$%.2f, peak=$%.2f); perps margin=%.1f%% (unrealized loss=$%.2f, margin=$%.2f)",
+					cfg.MaxDrawdownPct, warnDrawdownPct, equityDD, totalValue, prs.PeakValue, marginDD, perpsUnrealizedLoss, perpsMargin)
+			case marginWarn:
+				reason = fmt.Sprintf("portfolio perps margin drawdown %.1f%% approaching kill switch limit %.1f%% (warn at %.1f%%, unrealized loss=$%.2f, margin=$%.2f)",
+					marginDD, cfg.MaxDrawdownPct, warnDrawdownPct, perpsUnrealizedLoss, perpsMargin)
+			default:
+				reason = fmt.Sprintf("portfolio drawdown %.1f%% approaching kill switch limit %.1f%% (warn at %.1f%%, value=$%.2f, peak=$%.2f)",
+					equityDD, cfg.MaxDrawdownPct, warnDrawdownPct, totalValue, prs.PeakValue)
 			}
 		} else {
-			// Recovered below warning threshold — reset so it can fire again.
+			// Recovered below warning threshold — no active warning band.
 			prs.WarningSent = false
 		}
 	}

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -824,6 +824,42 @@ func TestCheckPortfolioRisk_WarningRepeatsAcrossCycles(t *testing.T) {
 	}
 }
 
+// TestCheckPortfolioRisk_WarnBandEnteredTransition verifies that the
+// prevWarningSent snapshot pattern used by main.go correctly identifies only
+// the first cycle as a warn-band entry. This prevents the kill-switch event
+// log from being flooded by repeat "warning" entries while drawdown stays in
+// the warn band.
+func TestCheckPortfolioRisk_WarnBandEnteredTransition(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 10000.0}
+
+	for i := 0; i < 5; i++ {
+		prevWarningSent := prs.WarningSent
+		_, _, warning, _ := CheckPortfolioRisk(prs, cfg, 7900.0, 0, 0, 0)
+		enteredWarnBand := warning && !prevWarningSent
+		if i == 0 {
+			if !enteredWarnBand {
+				t.Error("cycle 0: expected enteredWarnBand=true on first entry")
+			}
+		} else {
+			if enteredWarnBand {
+				t.Errorf("cycle %d: expected enteredWarnBand=false while already in warn band", i)
+			}
+		}
+	}
+
+	// After recovery, re-entering the band should produce enteredWarnBand=true again.
+	CheckPortfolioRisk(prs, cfg, 8500.0, 0, 0, 0) // recover below warn threshold
+	prevWarningSent := prs.WarningSent
+	_, _, warning, _ := CheckPortfolioRisk(prs, cfg, 7900.0, 0, 0, 0)
+	if !warning {
+		t.Error("expected warning=true after re-crossing warn threshold")
+	}
+	if !warning || prevWarningSent {
+		t.Error("expected enteredWarnBand=true on re-entry after recovery")
+	}
+}
+
 // TestCheckPortfolioRisk_WarningResetOnRecovery verifies that recovery below
 // the warning threshold resets WarningSent.
 func TestCheckPortfolioRisk_WarningResetOnRecovery(t *testing.T) {

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -802,6 +802,28 @@ func TestCheckPortfolioRisk_WarningFires(t *testing.T) {
 	}
 }
 
+// TestCheckPortfolioRisk_WarningRepeatsAcrossCycles verifies that warning
+// fires on every cycle while drawdown remains in the warn band, even with no
+// recovery in between.
+func TestCheckPortfolioRisk_WarningRepeatsAcrossCycles(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 10000.0}
+
+	// Warn threshold = 20%. Hold portfolio at 21% drawdown across many cycles.
+	for i := 0; i < 5; i++ {
+		_, _, warning, reason := CheckPortfolioRisk(prs, cfg, 7900.0, 0, 0, 0)
+		if !warning {
+			t.Errorf("cycle %d: expected warning=true while in warn band", i)
+		}
+		if reason == "" {
+			t.Errorf("cycle %d: expected non-empty reason", i)
+		}
+		if !prs.WarningSent {
+			t.Errorf("cycle %d: expected WarningSent=true while in warn band", i)
+		}
+	}
+}
+
 // TestCheckPortfolioRisk_WarningResetOnRecovery verifies that recovery below
 // the warning threshold resets WarningSent.
 func TestCheckPortfolioRisk_WarningResetOnRecovery(t *testing.T) {

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -773,7 +773,8 @@ func TestCheckRisk_ConsecutiveLossesForceClose(t *testing.T) {
 }
 
 // TestCheckPortfolioRisk_WarningFires verifies that drawdown at 80% of limit
-// triggers a warning once but not again on second call.
+// triggers a warning on every call while the portfolio remains in the warning
+// band.
 func TestCheckPortfolioRisk_WarningFires(t *testing.T) {
 	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
 	prs := &PortfolioRiskState{PeakValue: 10000.0}
@@ -790,15 +791,19 @@ func TestCheckPortfolioRisk_WarningFires(t *testing.T) {
 		t.Error("expected WarningSent=true after warning fires")
 	}
 
-	// Second call at same drawdown — warning should NOT fire again.
-	_, _, warning, _ = CheckPortfolioRisk(prs, cfg, 7900.0, 0, 0, 0)
-	if warning {
-		t.Error("expected warning=false on second call (already sent)")
+	// Second call at same drawdown — warning should fire again so operators get
+	// a reminder each cycle while the account remains in the warning band.
+	_, _, warning, reason = CheckPortfolioRisk(prs, cfg, 7900.0, 0, 0, 0)
+	if !warning {
+		t.Error("expected warning=true on second call while still in warning band")
+	}
+	if reason == "" {
+		t.Error("expected non-empty reason for repeated warning")
 	}
 }
 
 // TestCheckPortfolioRisk_WarningResetOnRecovery verifies that recovery below
-// the warning threshold resets WarningSent so it can fire again.
+// the warning threshold resets WarningSent.
 func TestCheckPortfolioRisk_WarningResetOnRecovery(t *testing.T) {
 	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
 	prs := &PortfolioRiskState{PeakValue: 10000.0}
@@ -1783,6 +1788,14 @@ func TestCheckPortfolioRisk_MarginWarning(t *testing.T) {
 	}
 	if prs.KillSwitchActive {
 		t.Error("expected kill switch NOT active (warning, not fire)")
+	}
+
+	_, _, warning, reason = CheckPortfolioRisk(prs, cfg, 10000, 0, 210, 1000)
+	if !warning {
+		t.Errorf("expected repeated warning=true while margin drawdown remains above threshold; reason=%q", reason)
+	}
+	if !strings.Contains(reason, "margin") {
+		t.Errorf("expected repeated warning reason to reference margin; got %q", reason)
 	}
 }
 


### PR DESCRIPTION
## Summary

Portfolio drawdown warnings now repeat on every scheduler cycle while the portfolio remains in the warning band, instead of only notifying once per breach. This applies to both portfolio equity drawdown and the perps-margin drawdown signal introduced for leveraged positions.

The change keeps `PortfolioRiskState.WarningSent` because it is persisted in SQLite and exposed through status/state surfaces, but narrows its meaning to current warning-band visibility: `true` while either drawdown signal is above the warning threshold, `false` again after recovery below that threshold.

## Root Cause

`CheckPortfolioRisk` set `warning=true` only inside an `if !prs.WarningSent` guard. After the first warning, later cycles with the same ongoing warning-band drawdown updated the drawdown fields but returned `warning=false`, so `main.go` did not send Discord/Telegram reminders.

## Behavior

- Emits the existing warning reason every cycle while equity drawdown is above `max_drawdown_pct * warn_threshold_pct / 100`.
- Emits the existing warning reason every cycle while perps-margin drawdown is above the same warning threshold.
- Stops warning once both signals recover below the warning threshold.
- Leaves the hard portfolio kill-switch path unchanged.
- Does not add a config flag or notification interval for this first version.

## Tests

- Updated `TestCheckPortfolioRisk_WarningFires` to assert consecutive equity drawdown warning returns without recovery.
- Updated `TestCheckPortfolioRisk_MarginWarning` to assert consecutive perps-margin warning returns without recovery.
- Kept recovery coverage for `WarningSent` resetting below the warn threshold.

## Validation

- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go test ./...` from `scheduler/`

Closes #420

---
LLM: GPT-5 | medium