### PR TITLE
fix: include version ldflag in manual update notification message

### DIFF
--- a/scheduler/updater.go
+++ b/scheduler/updater.go
@@ -227,7 +227,7 @@ func formatUpdateMessage(localHash, remoteHash, commitLog, newTag string, goChan
 	sb.WriteString("To update:\n```\n")
 	sb.WriteString("cd /path/to/go-trader && git pull --ff-only\n")
 	if goChanged {
-		sb.WriteString("cd scheduler && go build -o ../go-trader . && cd ..\n")
+		sb.WriteString("cd scheduler && go build -ldflags \"-X main.Version=$(git describe --tags --always)\" -o ../go-trader . && cd ..\n")
 	}
 	sb.WriteString("systemctl restart go-trader\n```")
 


### PR DESCRIPTION
The Discord notification for available updates showed a build command without the -ldflags stamp, so users following the manual instructions would produce a (dev) binary.

The `applyUpgrade` function already correctly stamped the version when performing the automated upgrade — this fixes the human-readable instructions in the Discord notification message.

Closes #419

---
LLM: Claude Sonnet 4.6 | high

---
LLM: Claude Sonnet 4.6 (1M) | high | Tokens: 31 in / 7554 out | Cache: 840184 read / 58607 written | Cost: $0.59