### PR TITLE
fix: round sz to sz_decimals in HL market_close

### DIFF
--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -251,6 +251,14 @@ class HyperliquidExchangeAdapter:
             raise RuntimeError(
                 "market_close requires live mode (set HYPERLIQUID_SECRET_KEY)"
             )
+        if sz is not None:
+            # Round to asset's tick precision to avoid float_to_wire rounding error (#425)
+            if symbol not in self._info.asset_to_sz_decimals:
+                print(f"[WARN] sz_decimals not found for {symbol}, defaulting to 3", file=sys.stderr)
+            sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3)
+            sz = round(sz, sz_decimals)
+            if sz <= 0:
+                raise ValueError(f"Size rounded to zero for {symbol} (sz_decimals={sz_decimals})")
         return self._exchange.market_close(symbol, sz)
 
     def round_perps_trigger_px(self, symbol: str, px: float) -> float:

--- a/platforms/hyperliquid/test_adapter.py
+++ b/platforms/hyperliquid/test_adapter.py
@@ -254,17 +254,53 @@ class TestOrderExecution:
         assert result == {"status": "closed"}
         mock_exchange.market_close.assert_called_once_with("BTC", None)
 
-    def test_market_close_partial_size_passes_sz(self):
+    def test_market_close_partial_size_rounds_to_sz_decimals(self):
+        # Issue #425: unrounded sz (e.g. 0.250965 from per-strategy CB sizing
+        # of a shared-wallet position) must be rounded to the asset's
+        # sz_decimals before reaching the SDK or HL rejects with
+        # `float_to_wire causes rounding`. Mirrors market_open / place_stop_loss.
         mock_info = MagicMock()
+        mock_info.asset_to_sz_decimals = {"ETH": 4}
         mock_info_cls = MagicMock(return_value=mock_info)
         mock_exchange = MagicMock()
         mock_exchange.market_close.return_value = {"status": "closed"}
         mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
         adapter = mod.HyperliquidExchangeAdapter()
         adapter._exchange = mock_exchange
+        adapter._info = mock_info
 
-        adapter.market_close("ETH", 0.25)
-        mock_exchange.market_close.assert_called_once_with("ETH", 0.25)
+        adapter.market_close("ETH", 0.2509645272613055)
+        mock_exchange.market_close.assert_called_once_with("ETH", 0.251)
+
+    def test_market_close_full_close_passes_none_unchanged(self):
+        # sz=None must bypass rounding (SDK closes the full on-chain position
+        # internally). A naive round(None, ...) would raise TypeError.
+        mock_info = MagicMock()
+        mock_info.asset_to_sz_decimals = {"BTC": 5}
+        mock_info_cls = MagicMock(return_value=mock_info)
+        mock_exchange = MagicMock()
+        mock_exchange.market_close.return_value = {"status": "closed"}
+        mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
+        adapter = mod.HyperliquidExchangeAdapter()
+        adapter._exchange = mock_exchange
+        adapter._info = mock_info
+
+        adapter.market_close("BTC")
+        mock_exchange.market_close.assert_called_once_with("BTC", None)
+
+    def test_market_close_partial_size_rounded_to_zero_raises(self):
+        mock_info = MagicMock()
+        mock_info.asset_to_sz_decimals = {"BTC": 0}
+        mock_info_cls = MagicMock(return_value=mock_info)
+        mock_exchange = MagicMock()
+        mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
+        adapter = mod.HyperliquidExchangeAdapter()
+        adapter._exchange = mock_exchange
+        adapter._info = mock_info
+
+        with pytest.raises(ValueError, match="Size rounded to zero"):
+            adapter.market_close("BTC", 0.4)
+        mock_exchange.market_close.assert_not_called()
 
 
 # ─── Stop Loss / Trigger Orders (#412 / #421) ──────


### PR DESCRIPTION
## Summary

- `market_close` in the Hyperliquid adapter was passing `sz` directly to the SDK without rounding to the asset's `sz_decimals`, causing `float_to_wire causes rounding` rejections for per-strategy circuit-breaker closes
- Per-strategy CB sizing of a shared-wallet position produces fractional coin quantities with more precision than HL accepts (e.g. ETH `0.2509645272613055` with `sz_decimals=4`)
- The fix applies the same `sz_decimals` rounding already used by `market_open` and `place_stop_loss`, plus the `sz=None` full-close passthrough guard and zero-size `ValueError`

## Test plan

- [ ] `uv run pytest platforms/hyperliquid/test_adapter.py -v` — all 34 tests pass, including 3 new regression tests:
  - `test_market_close_partial_size_rounds_to_sz_decimals` (ETH `0.2509645272613055` → `0.251` at sz_decimals=4)
  - `test_market_close_full_close_passes_none_unchanged`
  - `test_market_close_partial_size_rounded_to_zero_raises`

Closes #425

---
LLM: Claude Sonnet 4.6 (1M) | medium