### PR TITLE
feat: notify on failed trade executions and stuck CB close drains

### DIFF
--- a/scheduler/failure_alerts.go
+++ b/scheduler/failure_alerts.go
@@ -4,6 +4,15 @@ import (
 	"fmt"
 	"sync"
 	"time"
+	"unicode/utf8"
+)
+
+// Direction labels for live-exec failure throttle keys and alert messages.
+// Use these constants at every call site to avoid typos that would silently
+// fragment the per-(strategy, platform, symbol, direction) throttle key.
+const (
+	directionOpen  = "open"
+	directionClose = "close"
 )
 
 // shouldNotifyDrainFailure decides whether a circuit-breaker close drain
@@ -60,13 +69,19 @@ func liveExecKey(strategyID, platform, symbol, direction string) string {
 	return strategyID + "|" + platform + "|" + symbol + "|" + direction
 }
 
-// truncErrSig returns the first 120 characters of an error message to use as
-// an error signature for detecting "same error vs. new error".
+// truncErrSig returns the first ~120 bytes of an error message to use as an
+// error signature for detecting "same error vs. new error". Walks back to a
+// rune boundary so the signature never splits a multi-byte UTF-8 codepoint.
 func truncErrSig(errMsg string) string {
-	if len(errMsg) <= 120 {
+	const limit = 120
+	if len(errMsg) <= limit {
 		return errMsg
 	}
-	return errMsg[:120]
+	cut := limit
+	for cut > 0 && !utf8.RuneStart(errMsg[cut]) {
+		cut--
+	}
+	return errMsg[:cut]
 }
 
 // Record increments the failure counter for the given key. Returns
@@ -126,7 +141,7 @@ func formatLiveExecFailureAlert(strategyID, platform, direction, symbol, errMsg 
 }
 
 // notifyLiveExecFailure fires a throttled Discord+DM alert when a live order
-// wrapper returns ok=false. direction is "open" or "close".
+// wrapper returns ok=false. direction must be directionOpen or directionClose.
 // Uses the package-level liveExecThrottle; nil-safe (returns immediately if
 // notifier has no backends).
 func notifyLiveExecFailure(notifier *MultiNotifier, sc StrategyConfig, direction, symbol, errMsg string) {
@@ -134,7 +149,7 @@ func notifyLiveExecFailure(notifier *MultiNotifier, sc StrategyConfig, direction
 		return
 	}
 	key := liveExecKey(sc.ID, sc.Platform, symbol, direction)
-	shouldNotify, count := liveExecThrottle.Record(key, errMsg, time.Now())
+	shouldNotify, count := liveExecThrottle.Record(key, errMsg, time.Now().UTC())
 	if !shouldNotify {
 		return
 	}

--- a/scheduler/failure_alerts.go
+++ b/scheduler/failure_alerts.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// shouldNotifyDrainFailure decides whether a circuit-breaker close drain
+// should fire a Discord/DM alert for the current failure. Notifies on the
+// first failure, every 10th failure, or when at least one hour has elapsed
+// since the last notification — whichever fires first. This keeps operator
+// alerts actionable without spamming every retry cycle (#427).
+//
+// failureCount is the count AFTER incrementing (i.e. 1 = first failure).
+// lastNotifiedAt is the zero Time if no notification has been sent yet.
+func shouldNotifyDrainFailure(failureCount int, lastNotifiedAt, now time.Time) bool {
+	if failureCount <= 1 {
+		return true
+	}
+	if failureCount%10 == 0 {
+		return true
+	}
+	if !lastNotifiedAt.IsZero() && now.Sub(lastNotifiedAt) >= time.Hour {
+		return true
+	}
+	return false
+}
+
+// formatDrainFailureAlert builds the operator message for a failed CB close
+// attempt on the given platform drain. count is the failure count after
+// incrementing (1 = first failure).
+func formatDrainFailureAlert(platform, strategyID, symbol string, size float64, errMsg string, count int) string {
+	countNote := ""
+	if count > 1 {
+		countNote = fmt.Sprintf(" (failure #%d, still retrying)", count)
+	}
+	return fmt.Sprintf("**CIRCUIT CLOSE FAILED** [%s] %s %s sz=%.6f: %s%s",
+		strategyID, platform, symbol, size, errMsg, countNote)
+}
+
+// liveExecFailureEntry is one slot in the in-memory live-exec throttle.
+type liveExecFailureEntry struct {
+	count          int
+	lastNotifiedAt time.Time
+	lastErrSig     string // first 120 chars of the error message
+}
+
+// LiveExecFailureThrottle tracks per-(strategyID, platform, symbol, direction)
+// consecutive live-order failures so the main loop can throttle operator alerts.
+// All state is in-memory; restarting the scheduler naturally resets the counts
+// so the first failure after a restart always notifies.
+type LiveExecFailureThrottle struct {
+	mu      sync.Mutex
+	entries map[string]*liveExecFailureEntry
+}
+
+// liveExecKey builds the map key for a live execution failure entry.
+func liveExecKey(strategyID, platform, symbol, direction string) string {
+	return strategyID + "|" + platform + "|" + symbol + "|" + direction
+}
+
+// truncErrSig returns the first 120 characters of an error message to use as
+// an error signature for detecting "same error vs. new error".
+func truncErrSig(errMsg string) string {
+	if len(errMsg) <= 120 {
+		return errMsg
+	}
+	return errMsg[:120]
+}
+
+// Record increments the failure counter for the given key. Returns
+// (shouldNotify bool, failureCount int). Same-signature errors apply the
+// standard throttle cadence (1st, 10th, hourly). A change in error signature
+// resets the count and notifies immediately — the operator needs to know when
+// the error character changes.
+func (t *LiveExecFailureThrottle) Record(key, errSig string, now time.Time) (bool, int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.entries == nil {
+		t.entries = make(map[string]*liveExecFailureEntry)
+	}
+	e := t.entries[key]
+	if e == nil {
+		e = &liveExecFailureEntry{}
+		t.entries[key] = e
+	}
+	sig := truncErrSig(errSig)
+	if sig != e.lastErrSig {
+		// New error type — treat as a fresh first failure.
+		e.count = 1
+		e.lastErrSig = sig
+		e.lastNotifiedAt = now
+		return true, 1
+	}
+	e.count++
+	if shouldNotifyDrainFailure(e.count, e.lastNotifiedAt, now) {
+		e.lastNotifiedAt = now
+		return true, e.count
+	}
+	return false, e.count
+}
+
+// Clear removes the throttle entry for the given key. Called when a live
+// order succeeds so that the next failure re-notifies as a fresh first hit.
+func (t *LiveExecFailureThrottle) Clear(key string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.entries != nil {
+		delete(t.entries, key)
+	}
+}
+
+// liveExecThrottle is the package-level singleton; resets on process restart.
+var liveExecThrottle = &LiveExecFailureThrottle{}
+
+// formatLiveExecFailureAlert builds the operator message for a failed live
+// order attempt (open or close). count is the failure count after incrementing.
+func formatLiveExecFailureAlert(strategyID, platform, direction, symbol, errMsg string, count int) string {
+	countNote := ""
+	if count > 1 {
+		countNote = fmt.Sprintf(" (failure #%d)", count)
+	}
+	return fmt.Sprintf("**LIVE ORDER FAILED** [%s] %s %s %s: %s%s",
+		strategyID, platform, direction, symbol, errMsg, countNote)
+}
+
+// notifyLiveExecFailure fires a throttled Discord+DM alert when a live order
+// wrapper returns ok=false. direction is "open" or "close".
+// Uses the package-level liveExecThrottle; nil-safe (returns immediately if
+// notifier has no backends).
+func notifyLiveExecFailure(notifier *MultiNotifier, sc StrategyConfig, direction, symbol, errMsg string) {
+	if notifier == nil || !notifier.HasBackends() {
+		return
+	}
+	key := liveExecKey(sc.ID, sc.Platform, symbol, direction)
+	shouldNotify, count := liveExecThrottle.Record(key, errMsg, time.Now())
+	if !shouldNotify {
+		return
+	}
+	msg := formatLiveExecFailureAlert(sc.ID, sc.Platform, direction, symbol, errMsg, count)
+	notifier.SendToAllChannels(msg)
+	notifier.SendOwnerDM(msg)
+}
+
+// clearLiveExecThrottle removes the throttle entry for a successful live order.
+// Calling this on success means the next failure for the same key notifies fresh.
+func clearLiveExecThrottle(sc StrategyConfig, direction, symbol string) {
+	key := liveExecKey(sc.ID, sc.Platform, symbol, direction)
+	liveExecThrottle.Clear(key)
+}

--- a/scheduler/failure_alerts_test.go
+++ b/scheduler/failure_alerts_test.go
@@ -40,16 +40,18 @@ func TestShouldNotifyDrainFailure_HourlyEvenIfNotMod10(t *testing.T) {
 	}
 }
 
-func TestShouldNotifyDrainFailure_ZeroLastNotifiedAt_NeverSuppressed(t *testing.T) {
-	// zero LastNotifiedAt means no notification has ever fired; first failure
-	// path (count==1) already notifies, but even count==5 with zero LastNotifiedAt
-	// should notify because lastNotifiedAt.IsZero() implies first alert.
-	// shouldNotifyDrainFailure only checks !lastNotifiedAt.IsZero(), so count==5
-	// with zero time returns false (not mod 10, IsZero check fails). This is by
-	// design: FailureCount==1 is the only guaranteed path; the zero-time case only
-	// matters practically because count is always 1 when LastNotifiedAt is zero.
+func TestShouldNotifyDrainFailure_ZeroLastNotifiedAt_FirstNotifiesMidSuppressed(t *testing.T) {
+	// zero LastNotifiedAt means no notification has ever fired. count==1 must
+	// always notify (first-failure path). The hourly path explicitly skips
+	// IsZero so count==5 with zero time is suppressed — by design, since in
+	// practice count > 1 implies a previous notification already set the
+	// timestamp; a stale zero-time at count > 1 would mean some other path
+	// reset the count without notifying, so we keep the throttle quiet.
 	if !shouldNotifyDrainFailure(1, time.Time{}, time.Now()) {
 		t.Error("count==1 with zero LastNotifiedAt must notify")
+	}
+	if shouldNotifyDrainFailure(5, time.Time{}, time.Now()) {
+		t.Error("count==5 with zero LastNotifiedAt must be suppressed (not mod 10, IsZero blocks hourly)")
 	}
 }
 

--- a/scheduler/failure_alerts_test.go
+++ b/scheduler/failure_alerts_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- shouldNotifyDrainFailure ---
+
+func TestShouldNotifyDrainFailure_FirstFailure_Notifies(t *testing.T) {
+	if !shouldNotifyDrainFailure(1, time.Time{}, time.Now()) {
+		t.Error("expected notify on first failure")
+	}
+}
+
+func TestShouldNotifyDrainFailure_2ndThrough9thSuppressed(t *testing.T) {
+	notifiedAt := time.Now()
+	for i := 2; i <= 9; i++ {
+		if shouldNotifyDrainFailure(i, notifiedAt, notifiedAt.Add(time.Minute)) {
+			t.Errorf("expected suppress on failure #%d (within hour, not mod 10)", i)
+		}
+	}
+}
+
+func TestShouldNotifyDrainFailure_EveryTenthNotifies(t *testing.T) {
+	notifiedAt := time.Now()
+	for _, count := range []int{10, 20, 30} {
+		if !shouldNotifyDrainFailure(count, notifiedAt, notifiedAt.Add(time.Minute)) {
+			t.Errorf("expected notify at count=%d (mod 10)", count)
+		}
+	}
+}
+
+func TestShouldNotifyDrainFailure_HourlyEvenIfNotMod10(t *testing.T) {
+	notifiedAt := time.Now()
+	// count=5, not mod 10, but >1 hour since last notify
+	if !shouldNotifyDrainFailure(5, notifiedAt, notifiedAt.Add(61*time.Minute)) {
+		t.Error("expected notify when >1 hour since last notify")
+	}
+}
+
+func TestShouldNotifyDrainFailure_ZeroLastNotifiedAt_NeverSuppressed(t *testing.T) {
+	// zero LastNotifiedAt means no notification has ever fired; first failure
+	// path (count==1) already notifies, but even count==5 with zero LastNotifiedAt
+	// should notify because lastNotifiedAt.IsZero() implies first alert.
+	// shouldNotifyDrainFailure only checks !lastNotifiedAt.IsZero(), so count==5
+	// with zero time returns false (not mod 10, IsZero check fails). This is by
+	// design: FailureCount==1 is the only guaranteed path; the zero-time case only
+	// matters practically because count is always 1 when LastNotifiedAt is zero.
+	if !shouldNotifyDrainFailure(1, time.Time{}, time.Now()) {
+		t.Error("count==1 with zero LastNotifiedAt must notify")
+	}
+}
+
+// --- LiveExecFailureThrottle ---
+
+func TestLiveExecFailureThrottle_FirstFailureNotifies(t *testing.T) {
+	th := &LiveExecFailureThrottle{}
+	notify, count := th.Record("k1", "some error", time.Now())
+	if !notify {
+		t.Error("expected notify on first failure")
+	}
+	if count != 1 {
+		t.Errorf("expected count=1, got %d", count)
+	}
+}
+
+func TestLiveExecFailureThrottle_RepeatsThrottled(t *testing.T) {
+	th := &LiveExecFailureThrottle{}
+	now := time.Now()
+	// First call notifies.
+	notify, _ := th.Record("k1", "err", now)
+	if !notify {
+		t.Fatal("first call must notify")
+	}
+	// Second through ninth — should suppress.
+	for i := 2; i <= 9; i++ {
+		notify, count := th.Record("k1", "err", now.Add(time.Minute))
+		if notify {
+			t.Errorf("call #%d should be suppressed, got notify=true count=%d", i, count)
+		}
+	}
+}
+
+func TestLiveExecFailureThrottle_TenthNotifies(t *testing.T) {
+	th := &LiveExecFailureThrottle{}
+	now := time.Now()
+	for i := 1; i <= 10; i++ {
+		notify, count := th.Record("k1", "err", now.Add(time.Minute))
+		if i == 1 && !notify {
+			t.Error("first call must notify")
+		}
+		if i == 10 && !notify {
+			t.Errorf("10th call must notify, count=%d", count)
+		}
+	}
+}
+
+func TestLiveExecFailureThrottle_DifferentErrorSigReNotifies(t *testing.T) {
+	th := &LiveExecFailureThrottle{}
+	now := time.Now()
+	th.Record("k1", "error-type-A", now)
+	th.Record("k1", "error-type-A", now.Add(time.Minute)) // suppressed
+	// New error type — must re-notify regardless of count.
+	notify, count := th.Record("k1", "error-type-B", now.Add(2*time.Minute))
+	if !notify {
+		t.Error("new error signature must re-notify fresh")
+	}
+	if count != 1 {
+		t.Errorf("count must reset to 1 on new error sig, got %d", count)
+	}
+}
+
+func TestLiveExecFailureThrottle_ClearResetsCount(t *testing.T) {
+	th := &LiveExecFailureThrottle{}
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		th.Record("k1", "err", now)
+	}
+	th.Clear("k1")
+	notify, count := th.Record("k1", "err", now.Add(time.Minute))
+	if !notify {
+		t.Error("after Clear, first failure must notify again")
+	}
+	if count != 1 {
+		t.Errorf("after Clear count must be 1, got %d", count)
+	}
+}
+
+func TestLiveExecFailureThrottle_HourlyAlert(t *testing.T) {
+	th := &LiveExecFailureThrottle{}
+	now := time.Now()
+	th.Record("k1", "err", now)                                  // notified
+	th.Record("k1", "err", now.Add(30*time.Minute))              // suppressed
+	notify, _ := th.Record("k1", "err", now.Add(65*time.Minute)) // hourly fire
+	if !notify {
+		t.Error("expected hourly alert after 65 minutes")
+	}
+}
+
+// --- formatters ---
+
+func TestFormatLiveExecFailureAlert_IncludesAllFields(t *testing.T) {
+	msg := formatLiveExecFailureAlert("hl-tema-btc", "hyperliquid", "open", "BTC", "float_to_wire", 1)
+	for _, want := range []string{"hl-tema-btc", "hyperliquid", "open", "BTC", "float_to_wire"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message missing %q: %s", want, msg)
+		}
+	}
+}
+
+func TestFormatLiveExecFailureAlert_RepeatIncludesCount(t *testing.T) {
+	msg := formatLiveExecFailureAlert("hl-a", "hyperliquid", "close", "ETH", "timeout", 10)
+	if !strings.Contains(msg, "failure #10") {
+		t.Errorf("expected 'failure #10' in repeat message: %s", msg)
+	}
+}
+
+func TestFormatLiveExecFailureAlert_FirstOmitsCount(t *testing.T) {
+	msg := formatLiveExecFailureAlert("hl-a", "hyperliquid", "close", "ETH", "timeout", 1)
+	if strings.Contains(msg, "failure #") {
+		t.Errorf("first-failure message should omit count: %s", msg)
+	}
+}
+
+func TestFormatDrainFailureAlert_IncludesAllFields(t *testing.T) {
+	msg := formatDrainFailureAlert("hyperliquid", "hl-tema-eth", "ETH", 0.25, "float_to_wire", 1)
+	for _, want := range []string{"hl-tema-eth", "hyperliquid", "ETH", "float_to_wire"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message missing %q: %s", want, msg)
+		}
+	}
+}
+
+func TestFormatDrainFailureAlert_RepeatIncludesCount(t *testing.T) {
+	msg := formatDrainFailureAlert("okx", "okx-a", "ETH", 0.1, "503", 5)
+	if !strings.Contains(msg, "failure #5") {
+		t.Errorf("expected 'failure #5' in message: %s", msg)
+	}
+}

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -1043,8 +1043,10 @@ func runPendingHyperliquidCircuitCloses(
 
 		// Post-loop: update ConsecutiveFailures counter and fire owner DM.
 		// drainError = true only on a hard closer() error; under-fills are
-		// partial progress and reset the counter so the next hard error re-fires
-		// the first-failure alert.
+		// partial progress that reset the counter to 0 — but ONLY when the
+		// cycle had no hard error at all. In a multi-symbol pending list where
+		// one leg under-fills and another hard-errors, drainError wins (we
+		// still increment) so the operator is alerted to the failed leg.
 		var failCount int
 		var shouldAlert bool
 		now := time.Now().UTC()

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -769,7 +769,7 @@ func runPendingHyperliquidCircuitCloses(
 	closer HyperliquidLiveCloser,
 	totalBudget time.Duration,
 	mu *sync.RWMutex,
-	notifier operatorRequiredNotifier,
+	ownerDM func(string),
 ) {
 	if hlAddr == "" || closer == nil || state == nil {
 		return
@@ -919,6 +919,10 @@ func runPendingHyperliquidCircuitCloses(
 		}
 
 		allOK := true
+		drainError := false // set on closer() error; not set for under-fills (partial progress)
+		var drainErrSym string
+		var drainErrSz float64
+		var drainErrMsg string
 		for _, c := range j.pending.Symbols {
 			if err := ctxOverall.Err(); err != nil {
 				allOK = false
@@ -948,27 +952,12 @@ func runPendingHyperliquidCircuitCloses(
 			cancelOIDs := j.slOIDs[c.Symbol]
 			result, err := closer(c.Symbol, &partial, cancelOIDs)
 			if err != nil {
-				errMsg := err.Error()
 				fmt.Printf("[CRITICAL] hl-circuit-close: strategy %s coin %s sz=%.6f failed: %v\n", j.stratID, c.Symbol, sz, err)
 				allOK = false
-				now := time.Now().UTC()
-				mu.Lock()
-				if ss := state.Strategies[j.stratID]; ss != nil {
-					if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid); p != nil {
-						p.FailureCount++
-						if shouldNotifyDrainFailure(p.FailureCount, p.LastNotifiedAt, now) {
-							p.LastNotifiedAt = now
-							mu.Unlock()
-							if notifier != nil && notifier.HasBackends() {
-								msg := formatDrainFailureAlert("hyperliquid", j.stratID, c.Symbol, sz, errMsg, p.FailureCount)
-								notifier.SendToAllChannels(msg)
-								notifier.SendOwnerDM(msg)
-							}
-							mu.Lock()
-						}
-					}
-				}
-				mu.Unlock()
+				drainError = true
+				drainErrSym = c.Symbol
+				drainErrSz = sz
+				drainErrMsg = err.Error()
 				break
 			}
 
@@ -1024,26 +1013,6 @@ func runPendingHyperliquidCircuitCloses(
 				fmt.Printf("[CRITICAL] hl-circuit-close: strategy %s coin %s PARTIAL fill %.6f/%.6f — leaving pending for retry%s\n",
 					j.stratID, c.Symbol, fillSz, sz, slNote)
 				allOK = false
-				now := time.Now().UTC()
-				mu.Lock()
-				if ss := state.Strategies[j.stratID]; ss != nil {
-					if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid); p != nil {
-						p.FailureCount++
-						if shouldNotifyDrainFailure(p.FailureCount, p.LastNotifiedAt, now) {
-							p.LastNotifiedAt = now
-							mu.Unlock()
-							if notifier != nil && notifier.HasBackends() {
-								residual := sz - fillSz
-								errMsg := fmt.Sprintf("partial fill %.6f/%.6f — residual %.6f pending%s", fillSz, sz, residual, slNote)
-								msg := formatDrainFailureAlert("hyperliquid", j.stratID, c.Symbol, residual, errMsg, p.FailureCount)
-								notifier.SendToAllChannels(msg)
-								notifier.SendOwnerDM(msg)
-							}
-							mu.Lock()
-						}
-					}
-				}
-				mu.Unlock()
 			} else {
 				fmt.Printf("[INFO] hl-circuit-close: strategy %s coin %s closed sz=%.6f (filled %.6f)\n", j.stratID, c.Symbol, sz, fillSz)
 			}
@@ -1072,12 +1041,36 @@ func runPendingHyperliquidCircuitCloses(
 			}
 		}
 
-		if allOK {
-			mu.Lock()
-			if ss := state.Strategies[j.stratID]; ss != nil {
+		// Post-loop: update ConsecutiveFailures counter and fire owner DM.
+		// drainError = true only on a hard closer() error; under-fills are
+		// partial progress and reset the counter so the next hard error re-fires
+		// the first-failure alert.
+		var failCount int
+		var shouldAlert bool
+		now := time.Now().UTC()
+		mu.Lock()
+		if ss := state.Strategies[j.stratID]; ss != nil {
+			if allOK {
 				ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseHyperliquid)
+			} else if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid); p != nil {
+				if drainError {
+					p.ConsecutiveFailures++
+					failCount = p.ConsecutiveFailures
+					if shouldNotifyDrainFailure(p.ConsecutiveFailures, p.LastNotifiedAt, now) {
+						p.LastNotifiedAt = now
+						shouldAlert = true
+					}
+				} else {
+					// Under-fill only — partial progress. Reset so the next
+					// hard error re-notifies as a fresh first failure.
+					p.ConsecutiveFailures = 0
+				}
 			}
-			mu.Unlock()
+		}
+		mu.Unlock()
+
+		if shouldAlert && ownerDM != nil {
+			ownerDM(formatDrainFailureAlert("hyperliquid", j.stratID, drainErrSym, drainErrSz, drainErrMsg, failCount))
 		}
 	}
 }

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -769,6 +769,7 @@ func runPendingHyperliquidCircuitCloses(
 	closer HyperliquidLiveCloser,
 	totalBudget time.Duration,
 	mu *sync.RWMutex,
+	notifier operatorRequiredNotifier,
 ) {
 	if hlAddr == "" || closer == nil || state == nil {
 		return
@@ -947,8 +948,27 @@ func runPendingHyperliquidCircuitCloses(
 			cancelOIDs := j.slOIDs[c.Symbol]
 			result, err := closer(c.Symbol, &partial, cancelOIDs)
 			if err != nil {
+				errMsg := err.Error()
 				fmt.Printf("[CRITICAL] hl-circuit-close: strategy %s coin %s sz=%.6f failed: %v\n", j.stratID, c.Symbol, sz, err)
 				allOK = false
+				now := time.Now().UTC()
+				mu.Lock()
+				if ss := state.Strategies[j.stratID]; ss != nil {
+					if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid); p != nil {
+						p.FailureCount++
+						if shouldNotifyDrainFailure(p.FailureCount, p.LastNotifiedAt, now) {
+							p.LastNotifiedAt = now
+							mu.Unlock()
+							if notifier != nil && notifier.HasBackends() {
+								msg := formatDrainFailureAlert("hyperliquid", j.stratID, c.Symbol, sz, errMsg, p.FailureCount)
+								notifier.SendToAllChannels(msg)
+								notifier.SendOwnerDM(msg)
+							}
+							mu.Lock()
+						}
+					}
+				}
+				mu.Unlock()
 				break
 			}
 
@@ -1004,6 +1024,26 @@ func runPendingHyperliquidCircuitCloses(
 				fmt.Printf("[CRITICAL] hl-circuit-close: strategy %s coin %s PARTIAL fill %.6f/%.6f — leaving pending for retry%s\n",
 					j.stratID, c.Symbol, fillSz, sz, slNote)
 				allOK = false
+				now := time.Now().UTC()
+				mu.Lock()
+				if ss := state.Strategies[j.stratID]; ss != nil {
+					if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid); p != nil {
+						p.FailureCount++
+						if shouldNotifyDrainFailure(p.FailureCount, p.LastNotifiedAt, now) {
+							p.LastNotifiedAt = now
+							mu.Unlock()
+							if notifier != nil && notifier.HasBackends() {
+								residual := sz - fillSz
+								errMsg := fmt.Sprintf("partial fill %.6f/%.6f — residual %.6f pending%s", fillSz, sz, residual, slNote)
+								msg := formatDrainFailureAlert("hyperliquid", j.stratID, c.Symbol, residual, errMsg, p.FailureCount)
+								notifier.SendToAllChannels(msg)
+								notifier.SendOwnerDM(msg)
+							}
+							mu.Lock()
+						}
+					}
+				}
+				mu.Unlock()
 			} else {
 				fmt.Printf("[INFO] hl-circuit-close: strategy %s coin %s closed sz=%.6f (filled %.6f)\n", j.stratID, c.Symbol, sz, fillSz)
 			}

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -2106,18 +2106,8 @@ func TestApplyHyperliquidCircuitCloseFill_NoPositionLongCloseRecordsSell(t *test
 	}
 }
 
-// captureHLNotifier implements operatorRequiredNotifier for tests.
-type captureHLNotifier struct {
-	channels []string
-	dms      []string
-}
-
-func (n *captureHLNotifier) HasBackends() bool          { return true }
-func (n *captureHLNotifier) SendToAllChannels(c string) { n.channels = append(n.channels, c) }
-func (n *captureHLNotifier) SendOwnerDM(c string)       { n.dms = append(n.dms, c) }
-
 // TestRunPendingHyperliquidCircuitCloses_FailureIncrementsCountAndNotifies
-// verifies that a close error increments FailureCount to 1 and fires the
+// verifies that a close error increments ConsecutiveFailures to 1 and fires the
 // notifier exactly once (#427).
 func TestRunPendingHyperliquidCircuitCloses_FailureIncrementsCountAndNotifies(t *testing.T) {
 	state := &AppState{
@@ -2142,7 +2132,8 @@ func TestRunPendingHyperliquidCircuitCloses_FailureIncrementsCountAndNotifies(t 
 	closer := func(symbol string, sz *float64, cancelOIDs []int64) (*HyperliquidCloseResult, error) {
 		return nil, fmt.Errorf("float_to_wire causes rounding")
 	}
-	notifier := &captureHLNotifier{}
+	var dmMsgs []string
+	ownerDM := func(msg string) { dmMsgs = append(dmMsgs, msg) }
 	runPendingHyperliquidCircuitCloses(
 		context.Background(),
 		state,
@@ -2154,20 +2145,17 @@ func TestRunPendingHyperliquidCircuitCloses_FailureIncrementsCountAndNotifies(t 
 		closer,
 		30*time.Second,
 		&mu,
-		notifier,
+		ownerDM,
 	)
 	p := state.Strategies["hl-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
 	if p == nil {
 		t.Fatal("pending should be preserved on close failure")
 	}
-	if p.FailureCount != 1 {
-		t.Errorf("FailureCount: got %d, want 1", p.FailureCount)
+	if p.ConsecutiveFailures != 1 {
+		t.Errorf("ConsecutiveFailures: got %d, want 1", p.ConsecutiveFailures)
 	}
-	if len(notifier.dms) != 1 {
-		t.Errorf("expected 1 DM on first failure, got %d", len(notifier.dms))
-	}
-	if len(notifier.channels) != 1 {
-		t.Errorf("expected 1 channel message on first failure, got %d", len(notifier.channels))
+	if len(dmMsgs) != 1 {
+		t.Errorf("expected 1 DM on first failure, got %d", len(dmMsgs))
 	}
 }
 
@@ -2181,9 +2169,9 @@ func TestRunPendingHyperliquidCircuitCloses_RepeatedFailureThrottlesNotifier(t *
 				RiskState: RiskState{
 					PendingCircuitCloses: map[string]*PendingCircuitClose{
 						PlatformPendingCloseHyperliquid: {
-							Symbols:        []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.25}},
-							FailureCount:   1,
-							LastNotifiedAt: time.Now(),
+							Symbols:             []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.25}},
+							ConsecutiveFailures: 1,
+							LastNotifiedAt:      time.Now(),
 						},
 					},
 				},
@@ -2198,7 +2186,8 @@ func TestRunPendingHyperliquidCircuitCloses_RepeatedFailureThrottlesNotifier(t *
 	closer := func(symbol string, sz *float64, cancelOIDs []int64) (*HyperliquidCloseResult, error) {
 		return nil, fmt.Errorf("float_to_wire causes rounding")
 	}
-	notifier := &captureHLNotifier{}
+	var dmMsgs []string
+	ownerDM := func(msg string) { dmMsgs = append(dmMsgs, msg) }
 	runPendingHyperliquidCircuitCloses(
 		context.Background(),
 		state,
@@ -2210,10 +2199,10 @@ func TestRunPendingHyperliquidCircuitCloses_RepeatedFailureThrottlesNotifier(t *
 		closer,
 		30*time.Second,
 		&mu,
-		notifier,
+		ownerDM,
 	)
-	if len(notifier.dms) != 0 {
-		t.Errorf("expected 0 DMs on failure #2 (suppressed), got %d", len(notifier.dms))
+	if len(dmMsgs) != 0 {
+		t.Errorf("expected 0 DMs on failure #2 (suppressed), got %d", len(dmMsgs))
 	}
 }
 
@@ -2227,9 +2216,9 @@ func TestRunPendingHyperliquidCircuitCloses_TenthFailureNotifies(t *testing.T) {
 				RiskState: RiskState{
 					PendingCircuitCloses: map[string]*PendingCircuitClose{
 						PlatformPendingCloseHyperliquid: {
-							Symbols:        []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.25}},
-							FailureCount:   9,
-							LastNotifiedAt: time.Now(),
+							Symbols:             []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.25}},
+							ConsecutiveFailures: 9,
+							LastNotifiedAt:      time.Now(),
 						},
 					},
 				},
@@ -2244,7 +2233,8 @@ func TestRunPendingHyperliquidCircuitCloses_TenthFailureNotifies(t *testing.T) {
 	closer := func(symbol string, sz *float64, cancelOIDs []int64) (*HyperliquidCloseResult, error) {
 		return nil, fmt.Errorf("float_to_wire causes rounding")
 	}
-	notifier := &captureHLNotifier{}
+	var dmMsgs []string
+	ownerDM := func(msg string) { dmMsgs = append(dmMsgs, msg) }
 	runPendingHyperliquidCircuitCloses(
 		context.Background(),
 		state,
@@ -2256,13 +2246,13 @@ func TestRunPendingHyperliquidCircuitCloses_TenthFailureNotifies(t *testing.T) {
 		closer,
 		30*time.Second,
 		&mu,
-		notifier,
+		ownerDM,
 	)
 	p := state.Strategies["hl-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
-	if p == nil || p.FailureCount != 10 {
-		t.Fatalf("expected FailureCount=10, got %v", p)
+	if p == nil || p.ConsecutiveFailures != 10 {
+		t.Fatalf("expected ConsecutiveFailures=10, got %v", p)
 	}
-	if len(notifier.dms) != 1 {
-		t.Errorf("expected 1 DM on failure #10 (every-10th cadence), got %d", len(notifier.dms))
+	if len(dmMsgs) != 1 {
+		t.Errorf("expected 1 DM on failure #10 (every-10th cadence), got %d", len(dmMsgs))
 	}
 }

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1572,6 +1572,7 @@ func TestRunPendingHyperliquidCircuitCloses_RecoversStuckCB(t *testing.T) {
 		closer,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 	if len(calls) != 1 || calls[0] != "ETH:0.4" {
 		t.Errorf("closer calls=%v want [ETH:0.4] (recovered pending should drain full szi as sole owner)", calls)
@@ -1617,6 +1618,7 @@ func TestRunPendingHyperliquidCircuitCloses_StuckCBNoOnChainPositionIsNoOp(t *te
 		closer,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 	if len(calls) != 0 {
 		t.Errorf("expected no closer calls when no on-chain position, got %v", calls)
@@ -1669,6 +1671,7 @@ func TestRunPendingHyperliquidCircuitCloses_ClearsOnSuccess(t *testing.T) {
 		closer,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 	if state.Strategies["hl-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid) != nil {
 		t.Error("expected pending cleared after successful close")
@@ -1718,6 +1721,7 @@ func TestRunPendingHyperliquidCircuitCloses_PartialFillKeepsPendingAndDecrements
 		context.Background(), state, cfg, "0xabc",
 		[]HLPosition{{Coin: "ETH", Size: 1.0, EntryPrice: 3000}}, true,
 		nil, closer, 30*time.Second, &mu,
+		nil,
 	)
 
 	// Pending must NOT be cleared — residual 0.5 must retry next cycle.
@@ -1789,6 +1793,7 @@ func TestRunPendingHyperliquidCircuitCloses_FullFillDecrementsAndClears(t *testi
 		context.Background(), state, cfg, "0xabc",
 		[]HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 3000}}, true,
 		nil, closer, 30*time.Second, &mu,
+		nil,
 	)
 
 	if state.Strategies["hl-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid) != nil {
@@ -1865,6 +1870,7 @@ func TestRunPendingHyperliquidCircuitCloses_SharedCoinDecrementsFiringStrategy(t
 		context.Background(), state, cfg, "0xabc",
 		[]HLPosition{{Coin: "ETH", Size: 1.0, EntryPrice: 3000}}, true,
 		nil, closer, 30*time.Second, &mu,
+		nil,
 	)
 
 	// Firing strategy's virtual position should be fully closed.
@@ -1945,6 +1951,7 @@ func TestRunPendingHyperliquidCircuitCloses_ZeroFillKeepsPending(t *testing.T) {
 		context.Background(), state, cfg, "0xabc",
 		[]HLPosition{{Coin: "ETH", Size: 1.0, EntryPrice: 3000}}, true,
 		nil, closer, 30*time.Second, &mu,
+		nil,
 	)
 
 	// Pending must NOT be cleared — nothing on-chain has actually been flattened.
@@ -2005,6 +2012,7 @@ func TestRunPendingHyperliquidCircuitCloses_PartialThenFullPreservesAvgCost(t *t
 		context.Background(), state, cfg, "0xabc",
 		[]HLPosition{{Coin: "ETH", Size: 1.0, EntryPrice: 3000}}, true,
 		nil, cycle1, 30*time.Second, &mu,
+		nil,
 	)
 
 	// After cycle 1: pending preserved, position decremented to 0.6, AvgCost untouched.
@@ -2036,6 +2044,7 @@ func TestRunPendingHyperliquidCircuitCloses_PartialThenFullPreservesAvgCost(t *t
 		context.Background(), state, cfg, "0xabc",
 		[]HLPosition{{Coin: "ETH", Size: 0.6, EntryPrice: 3000}}, true,
 		nil, cycle2, 30*time.Second, &mu,
+		nil,
 	)
 
 	// Position fully closed; pending cleared.
@@ -2094,5 +2103,166 @@ func TestApplyHyperliquidCircuitCloseFill_NoPositionLongCloseRecordsSell(t *test
 	}
 	if s.TradeHistory[0].Side != "sell" {
 		t.Errorf("Side = %q; want sell (closing a long)", s.TradeHistory[0].Side)
+	}
+}
+
+// captureHLNotifier implements operatorRequiredNotifier for tests.
+type captureHLNotifier struct {
+	channels []string
+	dms      []string
+}
+
+func (n *captureHLNotifier) HasBackends() bool          { return true }
+func (n *captureHLNotifier) SendToAllChannels(c string) { n.channels = append(n.channels, c) }
+func (n *captureHLNotifier) SendOwnerDM(c string)       { n.dms = append(n.dms, c) }
+
+// TestRunPendingHyperliquidCircuitCloses_FailureIncrementsCountAndNotifies
+// verifies that a close error increments FailureCount to 1 and fires the
+// notifier exactly once (#427).
+func TestRunPendingHyperliquidCircuitCloses_FailureIncrementsCountAndNotifies(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-a": {
+				ID: "hl-a",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseHyperliquid: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.25}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "hl-a", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	closer := func(symbol string, sz *float64, cancelOIDs []int64) (*HyperliquidCloseResult, error) {
+		return nil, fmt.Errorf("float_to_wire causes rounding")
+	}
+	notifier := &captureHLNotifier{}
+	runPendingHyperliquidCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		"0xabc",
+		[]HLPosition{{Coin: "ETH", Size: 0.25}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+		notifier,
+	)
+	p := state.Strategies["hl-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
+	if p == nil {
+		t.Fatal("pending should be preserved on close failure")
+	}
+	if p.FailureCount != 1 {
+		t.Errorf("FailureCount: got %d, want 1", p.FailureCount)
+	}
+	if len(notifier.dms) != 1 {
+		t.Errorf("expected 1 DM on first failure, got %d", len(notifier.dms))
+	}
+	if len(notifier.channels) != 1 {
+		t.Errorf("expected 1 channel message on first failure, got %d", len(notifier.channels))
+	}
+}
+
+// TestRunPendingHyperliquidCircuitCloses_RepeatedFailureThrottlesNotifier
+// verifies that failure #2 is suppressed when LastNotifiedAt was just set.
+func TestRunPendingHyperliquidCircuitCloses_RepeatedFailureThrottlesNotifier(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-a": {
+				ID: "hl-a",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseHyperliquid: {
+							Symbols:        []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.25}},
+							FailureCount:   1,
+							LastNotifiedAt: time.Now(),
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "hl-a", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	closer := func(symbol string, sz *float64, cancelOIDs []int64) (*HyperliquidCloseResult, error) {
+		return nil, fmt.Errorf("float_to_wire causes rounding")
+	}
+	notifier := &captureHLNotifier{}
+	runPendingHyperliquidCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		"0xabc",
+		[]HLPosition{{Coin: "ETH", Size: 0.25}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+		notifier,
+	)
+	if len(notifier.dms) != 0 {
+		t.Errorf("expected 0 DMs on failure #2 (suppressed), got %d", len(notifier.dms))
+	}
+}
+
+// TestRunPendingHyperliquidCircuitCloses_TenthFailureNotifies verifies that
+// failure #10 fires the notifier (every-10th cadence).
+func TestRunPendingHyperliquidCircuitCloses_TenthFailureNotifies(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-a": {
+				ID: "hl-a",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseHyperliquid: {
+							Symbols:        []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.25}},
+							FailureCount:   9,
+							LastNotifiedAt: time.Now(),
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "hl-a", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	closer := func(symbol string, sz *float64, cancelOIDs []int64) (*HyperliquidCloseResult, error) {
+		return nil, fmt.Errorf("float_to_wire causes rounding")
+	}
+	notifier := &captureHLNotifier{}
+	runPendingHyperliquidCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		"0xabc",
+		[]HLPosition{{Coin: "ETH", Size: 0.25}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+		notifier,
+	)
+	p := state.Strategies["hl-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
+	if p == nil || p.FailureCount != 10 {
+		t.Fatalf("expected FailureCount=10, got %v", p)
+	}
+	if len(notifier.dms) != 1 {
+		t.Errorf("expected 1 DM on failure #10 (every-10th cadence), got %d", len(notifier.dms))
 	}
 }

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -477,6 +477,7 @@ func TestRunPendingHyperliquidCircuitCloses_CancelsStopLossOID(t *testing.T) {
 		context.Background(), state, cfg, "0xabc",
 		[]HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 3000}}, true,
 		nil, closer, 30*time.Second, &mu,
+		nil,
 	)
 
 	if seenCancelOID != 99887766 {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -896,6 +896,7 @@ func main() {
 						defaultHyperliquidLiveCloser,
 						90*time.Second,
 						&mu,
+						notifier,
 					)
 				}
 				// #360: Live OKX per-strategy circuit breaker closes. Same shape
@@ -912,6 +913,7 @@ func main() {
 						defaultOKXLiveCloser,
 						90*time.Second,
 						&mu,
+						notifier,
 					)
 				}
 				// #362: Live TopStep per-strategy circuit breaker closes
@@ -930,6 +932,7 @@ func main() {
 						defaultTopStepLiveCloser,
 						90*time.Second,
 						&mu,
+						notifier,
 					)
 				}
 				// #361 phase 3: Live Robinhood crypto per-strategy circuit breaker
@@ -951,6 +954,7 @@ func main() {
 						notifier.SendOwnerDM,
 						150*time.Second,
 						&mu,
+						notifier,
 					)
 				}
 				// #363 phase 5: operator-gap per-strategy CB pending closes.
@@ -1092,7 +1096,7 @@ func main() {
 								var execResult *OKXExecuteResult
 								liveExecFailed := false
 								if okxIsLive(sc.Args) && result.Signal != 0 {
-									if er, ok2 := runOKXExecuteOrder(sc, result, price, okxCash, okxPosQty, okxPosSide, okxAvgCost, logger); ok2 {
+									if er, ok2 := runOKXExecuteOrder(sc, result, price, okxCash, okxPosQty, okxPosSide, okxAvgCost, notifier, logger); ok2 {
 										execResult = er
 									} else {
 										liveExecFailed = true
@@ -1110,7 +1114,7 @@ func main() {
 								var execResult *RobinhoodExecuteResult
 								liveExecFailed := false
 								if robinhoodIsLive(sc.Args) && result.Signal != 0 {
-									if er, ok2 := runRobinhoodExecuteOrder(sc, result, price, rhCash, rhPosQty, rhPosSide, logger); ok2 {
+									if er, ok2 := runRobinhoodExecuteOrder(sc, result, price, rhCash, rhPosQty, rhPosSide, notifier, logger); ok2 {
 										execResult = er
 									} else {
 										liveExecFailed = true
@@ -1145,7 +1149,7 @@ func main() {
 								var execResult *OKXExecuteResult
 								liveExecFailed := false
 								if okxIsLive(sc.Args) && result.Signal != 0 {
-									if er, ok2 := runOKXExecuteOrder(sc, result, price, okxCash, okxPosQty, okxPosSide, okxAvgCost, logger); ok2 {
+									if er, ok2 := runOKXExecuteOrder(sc, result, price, okxCash, okxPosQty, okxPosSide, okxAvgCost, notifier, logger); ok2 {
 										execResult = er
 									} else {
 										liveExecFailed = true
@@ -1196,7 +1200,7 @@ func main() {
 							var execResult *TopStepExecuteResult
 							liveExecFailed := false
 							if topstepIsLive(sc.Args) && result.Signal != 0 {
-								if er, ok2 := runTopStepExecuteOrder(sc, result, price, tsCash, tsContracts, tsPosSide, logger); ok2 {
+								if er, ok2 := runTopStepExecuteOrder(sc, result, price, tsCash, tsContracts, tsPosSide, notifier, logger); ok2 {
 									execResult = er
 								} else {
 									liveExecFailed = true
@@ -1950,14 +1954,21 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	// even when the open leg fails (#421). Caller treats ok=false as "do not
 	// apply state mutations" but inspects execResult.CancelStopLossSucceeded
 	// before discarding it.
+	direction := "open"
+	if side == "sell" {
+		direction = "close"
+	}
 	if err != nil {
 		logger.Error("Live execute failed: %v", err)
+		notifyLiveExecFailure(notifier, sc, direction, result.Symbol, err.Error())
 		return execResult, false
 	}
 	if execResult.Error != "" {
 		logger.Error("Live execute returned error: %s", execResult.Error)
+		notifyLiveExecFailure(notifier, sc, direction, result.Symbol, execResult.Error)
 		return execResult, false
 	}
+	clearLiveExecThrottle(sc, direction, result.Symbol)
 	if execResult.CancelStopLossError != "" {
 		logger.Warn("SL cancel failed (non-fatal): %s", execResult.CancelStopLossError)
 	}
@@ -2160,7 +2171,7 @@ func runTopStepCheck(sc StrategyConfig, prices map[string]float64, logger *Strat
 // posSide=="short" (Quantity is always positive so posQty<=0 cannot
 // distinguish short from flat) but ExecuteFuturesSignal is a no-op in that
 // state — producing a silent state drift identical in shape to #298/#300.
-func runTopStepExecuteOrder(sc StrategyConfig, result *TopStepResult, price, cash, posQty float64, posSide string, logger *StrategyLogger) (*TopStepExecuteResult, bool) {
+func runTopStepExecuteOrder(sc StrategyConfig, result *TopStepResult, price, cash, posQty float64, posSide string, notifier *MultiNotifier, logger *StrategyLogger) (*TopStepExecuteResult, bool) {
 	if reason := FuturesOrderSkipReason(result.Signal, posSide); reason != "" {
 		logger.Info("Skipping live order for %s: %s", result.Symbol, reason)
 		return nil, false
@@ -2203,14 +2214,21 @@ func runTopStepExecuteOrder(sc StrategyConfig, result *TopStepResult, price, cas
 	if stderr != "" {
 		logger.Info("execute stderr: %s", stderr)
 	}
+	direction := "open"
+	if side == "sell" {
+		direction = "close"
+	}
 	if err != nil {
 		logger.Error("Live execute failed: %v", err)
+		notifyLiveExecFailure(notifier, sc, direction, result.Symbol, err.Error())
 		return nil, false
 	}
 	if execResult.Error != "" {
 		logger.Error("Live execute returned error: %s", execResult.Error)
+		notifyLiveExecFailure(notifier, sc, direction, result.Symbol, execResult.Error)
 		return nil, false
 	}
+	clearLiveExecThrottle(sc, direction, result.Symbol)
 	return execResult, true
 }
 
@@ -2321,7 +2339,7 @@ func runRobinhoodCheck(sc StrategyConfig, prices map[string]float64, logger *Str
 // calling the Python executor: otherwise a no-op ExecuteSpotSignal (e.g.
 // already-long with signal=1) would not record the live fill — the same bug
 // class as #298. See #300.
-func runRobinhoodExecuteOrder(sc StrategyConfig, result *RobinhoodResult, price, cash, posQty float64, posSide string, logger *StrategyLogger) (*RobinhoodExecuteResult, bool) {
+func runRobinhoodExecuteOrder(sc StrategyConfig, result *RobinhoodResult, price, cash, posQty float64, posSide string, notifier *MultiNotifier, logger *StrategyLogger) (*RobinhoodExecuteResult, bool) {
 	if reason := SpotOrderSkipReason(result.Signal, posSide); reason != "" {
 		logger.Info("Skipping live order for %s: %s", result.Symbol, reason)
 		return nil, false
@@ -2352,14 +2370,21 @@ func runRobinhoodExecuteOrder(sc StrategyConfig, result *RobinhoodResult, price,
 	if stderr != "" {
 		logger.Info("execute stderr: %s", stderr)
 	}
+	direction := "open"
+	if side == "sell" {
+		direction = "close"
+	}
 	if err != nil {
 		logger.Error("Live execute failed: %v", err)
+		notifyLiveExecFailure(notifier, sc, direction, result.Symbol, err.Error())
 		return nil, false
 	}
 	if execResult.Error != "" {
 		logger.Error("Live execute returned error: %s", execResult.Error)
+		notifyLiveExecFailure(notifier, sc, direction, result.Symbol, execResult.Error)
 		return nil, false
 	}
+	clearLiveExecThrottle(sc, direction, result.Symbol)
 	return execResult, true
 }
 
@@ -2475,7 +2500,7 @@ func runOKXCheck(sc StrategyConfig, prices map[string]float64, logger *StrategyL
 // ExecutePerpsSignal that must be mirrored to avoid the #298 bug class
 // (live fill placed but no Trade recorded because the in-memory execution
 // returned 0). See #300.
-func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQty float64, posSide string, avgCost float64, logger *StrategyLogger) (*OKXExecuteResult, bool) {
+func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQty float64, posSide string, avgCost float64, notifier *MultiNotifier, logger *StrategyLogger) (*OKXExecuteResult, bool) {
 	var skip string
 	if sc.Type == "perps" {
 		skip = PerpsOrderSkipReason(result.Signal, posSide, sc.AllowShorts)
@@ -2532,14 +2557,21 @@ func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQt
 	if stderr != "" {
 		logger.Info("execute stderr: %s", stderr)
 	}
+	direction := "open"
+	if side == "sell" {
+		direction = "close"
+	}
 	if err != nil {
 		logger.Error("Live execute failed: %v", err)
+		notifyLiveExecFailure(notifier, sc, direction, result.Symbol, err.Error())
 		return nil, false
 	}
 	if execResult.Error != "" {
 		logger.Error("Live execute returned error: %s", execResult.Error)
+		notifyLiveExecFailure(notifier, sc, direction, result.Symbol, execResult.Error)
 		return nil, false
 	}
+	clearLiveExecThrottle(sc, direction, result.Symbol)
 	return execResult, true
 }
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1953,9 +1953,9 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	// even when the open leg fails (#421). Caller treats ok=false as "do not
 	// apply state mutations" but inspects execResult.CancelStopLossSucceeded
 	// before discarding it.
-	direction := "open"
+	direction := directionOpen
 	if side == "sell" {
-		direction = "close"
+		direction = directionClose
 	}
 	if err != nil {
 		logger.Error("Live execute failed: %v", err)
@@ -2213,9 +2213,9 @@ func runTopStepExecuteOrder(sc StrategyConfig, result *TopStepResult, price, cas
 	if stderr != "" {
 		logger.Info("execute stderr: %s", stderr)
 	}
-	direction := "open"
+	direction := directionOpen
 	if side == "sell" {
-		direction = "close"
+		direction = directionClose
 	}
 	if err != nil {
 		logger.Error("Live execute failed: %v", err)
@@ -2369,9 +2369,9 @@ func runRobinhoodExecuteOrder(sc StrategyConfig, result *RobinhoodResult, price,
 	if stderr != "" {
 		logger.Info("execute stderr: %s", stderr)
 	}
-	direction := "open"
+	direction := directionOpen
 	if side == "sell" {
-		direction = "close"
+		direction = directionClose
 	}
 	if err != nil {
 		logger.Error("Live execute failed: %v", err)
@@ -2556,9 +2556,9 @@ func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQt
 	if stderr != "" {
 		logger.Info("execute stderr: %s", stderr)
 	}
-	direction := "open"
+	direction := directionOpen
 	if side == "sell" {
-		direction = "close"
+		direction = directionClose
 	}
 	if err != nil {
 		logger.Error("Live execute failed: %v", err)

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -896,7 +896,7 @@ func main() {
 						defaultHyperliquidLiveCloser,
 						90*time.Second,
 						&mu,
-						notifier,
+						notifier.SendOwnerDM,
 					)
 				}
 				// #360: Live OKX per-strategy circuit breaker closes. Same shape
@@ -913,7 +913,7 @@ func main() {
 						defaultOKXLiveCloser,
 						90*time.Second,
 						&mu,
-						notifier,
+						notifier.SendOwnerDM,
 					)
 				}
 				// #362: Live TopStep per-strategy circuit breaker closes
@@ -932,7 +932,7 @@ func main() {
 						defaultTopStepLiveCloser,
 						90*time.Second,
 						&mu,
-						notifier,
+						notifier.SendOwnerDM,
 					)
 				}
 				// #361 phase 3: Live Robinhood crypto per-strategy circuit breaker
@@ -954,7 +954,6 @@ func main() {
 						notifier.SendOwnerDM,
 						150*time.Second,
 						&mu,
-						notifier,
 					)
 				}
 				// #363 phase 5: operator-gap per-strategy CB pending closes.

--- a/scheduler/okx_close.go
+++ b/scheduler/okx_close.go
@@ -327,6 +327,7 @@ func runPendingOKXCircuitCloses(
 	closer OKXLiveCloser,
 	totalBudget time.Duration,
 	mu *sync.RWMutex,
+	notifier operatorRequiredNotifier,
 ) {
 	if !okxHasCreds || closer == nil || state == nil {
 		return
@@ -483,8 +484,27 @@ func runPendingOKXCircuitCloses(
 			partial := sz
 			_, err := closer(c.Symbol, &partial)
 			if err != nil {
+				errMsg := err.Error()
 				fmt.Printf("[CRITICAL] okx-circuit-close: strategy %s coin %s sz=%.6f failed: %v\n", j.stratID, c.Symbol, sz, err)
 				allOK = false
+				now := time.Now().UTC()
+				mu.Lock()
+				if ss := state.Strategies[j.stratID]; ss != nil {
+					if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseOKX); p != nil {
+						p.FailureCount++
+						if shouldNotifyDrainFailure(p.FailureCount, p.LastNotifiedAt, now) {
+							p.LastNotifiedAt = now
+							mu.Unlock()
+							if notifier != nil && notifier.HasBackends() {
+								msg := formatDrainFailureAlert("okx", j.stratID, c.Symbol, sz, errMsg, p.FailureCount)
+								notifier.SendToAllChannels(msg)
+								notifier.SendOwnerDM(msg)
+							}
+							mu.Lock()
+						}
+					}
+				}
+				mu.Unlock()
 				break
 			}
 			fmt.Printf("[INFO] okx-circuit-close: strategy %s coin %s submitted reduce-only close sz=%.6f\n", j.stratID, c.Symbol, sz)

--- a/scheduler/okx_close.go
+++ b/scheduler/okx_close.go
@@ -504,18 +504,24 @@ func runPendingOKXCircuitCloses(
 		if ss := state.Strategies[j.stratID]; ss != nil {
 			if allOK {
 				ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseOKX)
-			} else if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseOKX); p != nil {
-				p.ConsecutiveFailures++
-				failCount = p.ConsecutiveFailures
-				if shouldNotifyDrainFailure(p.ConsecutiveFailures, p.LastNotifiedAt, now) {
-					p.LastNotifiedAt = now
-					shouldAlert = true
+			} else if failedErr != nil {
+				// Only count as a drain failure when a closer() actually errored.
+				// allOK can also be set false by a mid-loop ctxOverall expiry
+				// where failedErr stays nil — counting that would inflate the
+				// counter and dereferencing failedErr.Error() below would panic.
+				if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseOKX); p != nil {
+					p.ConsecutiveFailures++
+					failCount = p.ConsecutiveFailures
+					if shouldNotifyDrainFailure(p.ConsecutiveFailures, p.LastNotifiedAt, now) {
+						p.LastNotifiedAt = now
+						shouldAlert = true
+					}
 				}
 			}
 		}
 		mu.Unlock()
 
-		if shouldAlert && ownerDM != nil {
+		if shouldAlert && ownerDM != nil && failedErr != nil {
 			ownerDM(formatDrainFailureAlert("okx", j.stratID, failedSym, failedSz, failedErr.Error(), failCount))
 		}
 	}

--- a/scheduler/okx_close.go
+++ b/scheduler/okx_close.go
@@ -327,7 +327,7 @@ func runPendingOKXCircuitCloses(
 	closer OKXLiveCloser,
 	totalBudget time.Duration,
 	mu *sync.RWMutex,
-	notifier operatorRequiredNotifier,
+	ownerDM func(string),
 ) {
 	if !okxHasCreds || closer == nil || state == nil {
 		return
@@ -458,6 +458,9 @@ func runPendingOKXCircuitCloses(
 		}
 
 		allOK := true
+		var failedSym string
+		var failedSz float64
+		var failedErr error
 		for _, c := range j.pending.Symbols {
 			if err := ctxOverall.Err(); err != nil {
 				allOK = false
@@ -484,38 +487,36 @@ func runPendingOKXCircuitCloses(
 			partial := sz
 			_, err := closer(c.Symbol, &partial)
 			if err != nil {
-				errMsg := err.Error()
 				fmt.Printf("[CRITICAL] okx-circuit-close: strategy %s coin %s sz=%.6f failed: %v\n", j.stratID, c.Symbol, sz, err)
 				allOK = false
-				now := time.Now().UTC()
-				mu.Lock()
-				if ss := state.Strategies[j.stratID]; ss != nil {
-					if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseOKX); p != nil {
-						p.FailureCount++
-						if shouldNotifyDrainFailure(p.FailureCount, p.LastNotifiedAt, now) {
-							p.LastNotifiedAt = now
-							mu.Unlock()
-							if notifier != nil && notifier.HasBackends() {
-								msg := formatDrainFailureAlert("okx", j.stratID, c.Symbol, sz, errMsg, p.FailureCount)
-								notifier.SendToAllChannels(msg)
-								notifier.SendOwnerDM(msg)
-							}
-							mu.Lock()
-						}
-					}
-				}
-				mu.Unlock()
+				failedSym = c.Symbol
+				failedSz = sz
+				failedErr = err
 				break
 			}
 			fmt.Printf("[INFO] okx-circuit-close: strategy %s coin %s submitted reduce-only close sz=%.6f\n", j.stratID, c.Symbol, sz)
 		}
 
-		if allOK {
-			mu.Lock()
-			if ss := state.Strategies[j.stratID]; ss != nil {
+		var failCount int
+		var shouldAlert bool
+		now := time.Now().UTC()
+		mu.Lock()
+		if ss := state.Strategies[j.stratID]; ss != nil {
+			if allOK {
 				ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseOKX)
+			} else if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseOKX); p != nil {
+				p.ConsecutiveFailures++
+				failCount = p.ConsecutiveFailures
+				if shouldNotifyDrainFailure(p.ConsecutiveFailures, p.LastNotifiedAt, now) {
+					p.LastNotifiedAt = now
+					shouldAlert = true
+				}
 			}
-			mu.Unlock()
+		}
+		mu.Unlock()
+
+		if shouldAlert && ownerDM != nil {
+			ownerDM(formatDrainFailureAlert("okx", j.stratID, failedSym, failedSz, failedErr.Error(), failCount))
 		}
 	}
 }

--- a/scheduler/okx_close_test.go
+++ b/scheduler/okx_close_test.go
@@ -329,6 +329,7 @@ func TestRunPendingOKXCircuitCloses_RecoversStuckCB(t *testing.T) {
 		closer,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 	if len(calls) != 1 || calls[0] != "ETH:0.4" {
 		t.Errorf("closer calls=%v want [ETH:0.4] (recovered pending should drain full abs size as sole owner)", calls)
@@ -374,6 +375,7 @@ func TestRunPendingOKXCircuitCloses_StuckCBNoOnChainPositionIsNoOp(t *testing.T)
 		closer,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 	if len(calls) != 0 {
 		t.Errorf("expected no closer calls when no on-chain position, got %v", calls)
@@ -426,6 +428,7 @@ func TestRunPendingOKXCircuitCloses_ClearsOnSuccess(t *testing.T) {
 		closer,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 	if state.Strategies["okx-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseOKX) != nil {
 		t.Error("expected pending cleared after successful close")
@@ -471,6 +474,7 @@ func TestRunPendingOKXCircuitCloses_PendingPreservedOnFailure(t *testing.T) {
 		closer,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 	if state.Strategies["okx-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseOKX) == nil {
 		t.Error("expected pending preserved after closer failure (latch semantic)")
@@ -513,6 +517,7 @@ func TestRunPendingOKXCircuitCloses_StaleStrategyClearsPending(t *testing.T) {
 		closer,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 	if len(calls) != 0 {
 		t.Errorf("closer must not be called for stale strategy, got %v", calls)
@@ -600,5 +605,169 @@ func TestParseOKXBalanceOutput_ErrorEnvelopeSurfacesAsErr(t *testing.T) {
 	_, _, err := parseOKXBalanceOutput(stdout, "", fmt.Errorf("exit 1"))
 	if err == nil {
 		t.Fatal("expected non-nil err for error envelope")
+	}
+}
+
+// captureOKXNotifier implements operatorRequiredNotifier for tests, recording
+// all messages sent to channels and DMs.
+type captureOKXNotifier struct {
+	channels []string
+	dms      []string
+}
+
+func (n *captureOKXNotifier) HasBackends() bool          { return true }
+func (n *captureOKXNotifier) SendToAllChannels(c string) { n.channels = append(n.channels, c) }
+func (n *captureOKXNotifier) SendOwnerDM(c string)       { n.dms = append(n.dms, c) }
+
+// TestRunPendingOKXCircuitCloses_FailureIncrementsCountAndNotifies verifies that
+// a single failed close attempt increments FailureCount to 1 and fires the
+// notifier exactly once (#427).
+func TestRunPendingOKXCircuitCloses_FailureIncrementsCountAndNotifies(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"okx-a": {
+				ID: "okx-a",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseOKX: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.1}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "okx-a", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
+		return nil, fmt.Errorf("okx 503")
+	}
+	notifier := &captureOKXNotifier{}
+	runPendingOKXCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		true,
+		[]OKXPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 1, Side: "long"}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+		notifier,
+	)
+	p := state.Strategies["okx-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseOKX)
+	if p == nil {
+		t.Fatal("pending should be preserved on failure")
+	}
+	if p.FailureCount != 1 {
+		t.Errorf("FailureCount: got %d, want 1", p.FailureCount)
+	}
+	if len(notifier.dms) != 1 {
+		t.Errorf("expected 1 DM on first failure, got %d", len(notifier.dms))
+	}
+	if len(notifier.channels) != 1 {
+		t.Errorf("expected 1 channel message on first failure, got %d", len(notifier.channels))
+	}
+}
+
+// TestRunPendingOKXCircuitCloses_RepeatedFailureThrottlesNotifier verifies that
+// failures 2–9 do not fire the notifier (throttle suppresses repeats).
+func TestRunPendingOKXCircuitCloses_RepeatedFailureThrottlesNotifier(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"okx-a": {
+				ID: "okx-a",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseOKX: {
+							Symbols:      []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.1}},
+							FailureCount: 1, // first failure already recorded
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "okx-a", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
+		return nil, fmt.Errorf("okx 503")
+	}
+	notifier := &captureOKXNotifier{}
+	// Force LastNotifiedAt to just now so hourly gate doesn't fire.
+	state.Strategies["okx-a"].RiskState.PendingCircuitCloses[PlatformPendingCloseOKX].LastNotifiedAt = time.Now()
+
+	runPendingOKXCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		true,
+		[]OKXPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 1, Side: "long"}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+		notifier,
+	)
+	if len(notifier.dms) != 0 {
+		t.Errorf("expected 0 DMs on failure #2 (suppressed), got %d", len(notifier.dms))
+	}
+}
+
+// TestRunPendingOKXCircuitCloses_TenthFailureNotifies verifies that failure #10
+// fires the notifier (every-10th cadence).
+func TestRunPendingOKXCircuitCloses_TenthFailureNotifies(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"okx-a": {
+				ID: "okx-a",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseOKX: {
+							Symbols:        []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.1}},
+							FailureCount:   9,
+							LastNotifiedAt: time.Now(),
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "okx-a", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
+		return nil, fmt.Errorf("okx 503")
+	}
+	notifier := &captureOKXNotifier{}
+	runPendingOKXCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		true,
+		[]OKXPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 1, Side: "long"}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+		notifier,
+	)
+	p := state.Strategies["okx-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseOKX)
+	if p == nil || p.FailureCount != 10 {
+		t.Fatalf("expected FailureCount=10, got %v", p)
+	}
+	if len(notifier.dms) != 1 {
+		t.Errorf("expected 1 DM on failure #10 (every-10th cadence), got %d", len(notifier.dms))
 	}
 }

--- a/scheduler/okx_close_test.go
+++ b/scheduler/okx_close_test.go
@@ -760,3 +760,79 @@ func TestRunPendingOKXCircuitCloses_TenthFailureNotifies(t *testing.T) {
 		t.Errorf("expected 1 DM on failure #10 (every-10th cadence), got %d", len(dmMsgs))
 	}
 }
+
+// Regression: when ctxOverall trips mid-symbol-loop (e.g. previous symbol's
+// closer consumed the budget), the inner per-symbol ctx check sets
+// allOK=false but failedErr stays nil. The post-loop block must NOT
+// increment ConsecutiveFailures and must NOT dereference failedErr (that
+// would panic). Mirrors the HL drain's `drainError` flag semantic and the
+// RH drain's `else if failedErr != nil` guard. See PR #435 review.
+func TestRunPendingOKXCircuitCloses_CtxExpiryMidLoopDoesNotCountAsFailure(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"okx-a": {
+				ID: "okx-a",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseOKX: {
+							Symbols: []PendingCircuitCloseSymbol{
+								{Symbol: "BTC", Size: 0.01},
+								{Symbol: "ETH", Size: 0.1},
+							},
+							ConsecutiveFailures: 3,
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "okx-a", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var calls []string
+	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
+		calls = append(calls, sym)
+		// First closer call succeeds AND cancels the budget so the inner
+		// ctx check fires before the second symbol runs — exactly the
+		// nil-failedErr-with-allOK=false branch the bug reproduces.
+		cancel()
+		return &OKXCloseResult{Close: &OKXClose{Symbol: sym}}, nil
+	}
+	var dmMsgs []string
+	ownerDM := func(msg string) { dmMsgs = append(dmMsgs, msg) }
+
+	runPendingOKXCircuitCloses(
+		ctx,
+		state,
+		cfg,
+		true,
+		[]OKXPosition{
+			{Coin: "BTC", Size: 0.01, EntryPrice: 1, Side: "long"},
+			{Coin: "ETH", Size: 0.5, EntryPrice: 1, Side: "long"},
+		},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+		ownerDM,
+	)
+
+	if len(calls) != 1 {
+		t.Errorf("expected exactly 1 closer call before ctx expiry, got %d (%v)", len(calls), calls)
+	}
+	if len(dmMsgs) != 0 {
+		t.Errorf("expected 0 DMs on mid-loop ctx expiry (no real failure), got %d (%v)", len(dmMsgs), dmMsgs)
+	}
+	p := state.Strategies["okx-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseOKX)
+	if p == nil {
+		t.Fatal("pending must be preserved on ctx expiry")
+	}
+	if p.ConsecutiveFailures != 3 {
+		t.Errorf("ConsecutiveFailures must not increment on ctx expiry: got %d, want 3", p.ConsecutiveFailures)
+	}
+}

--- a/scheduler/okx_close_test.go
+++ b/scheduler/okx_close_test.go
@@ -608,19 +608,8 @@ func TestParseOKXBalanceOutput_ErrorEnvelopeSurfacesAsErr(t *testing.T) {
 	}
 }
 
-// captureOKXNotifier implements operatorRequiredNotifier for tests, recording
-// all messages sent to channels and DMs.
-type captureOKXNotifier struct {
-	channels []string
-	dms      []string
-}
-
-func (n *captureOKXNotifier) HasBackends() bool          { return true }
-func (n *captureOKXNotifier) SendToAllChannels(c string) { n.channels = append(n.channels, c) }
-func (n *captureOKXNotifier) SendOwnerDM(c string)       { n.dms = append(n.dms, c) }
-
 // TestRunPendingOKXCircuitCloses_FailureIncrementsCountAndNotifies verifies that
-// a single failed close attempt increments FailureCount to 1 and fires the
+// a single failed close attempt increments ConsecutiveFailures to 1 and fires the
 // notifier exactly once (#427).
 func TestRunPendingOKXCircuitCloses_FailureIncrementsCountAndNotifies(t *testing.T) {
 	state := &AppState{
@@ -645,7 +634,8 @@ func TestRunPendingOKXCircuitCloses_FailureIncrementsCountAndNotifies(t *testing
 	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
 		return nil, fmt.Errorf("okx 503")
 	}
-	notifier := &captureOKXNotifier{}
+	var dmMsgs []string
+	ownerDM := func(msg string) { dmMsgs = append(dmMsgs, msg) }
 	runPendingOKXCircuitCloses(
 		context.Background(),
 		state,
@@ -657,20 +647,17 @@ func TestRunPendingOKXCircuitCloses_FailureIncrementsCountAndNotifies(t *testing
 		closer,
 		30*time.Second,
 		&mu,
-		notifier,
+		ownerDM,
 	)
 	p := state.Strategies["okx-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseOKX)
 	if p == nil {
 		t.Fatal("pending should be preserved on failure")
 	}
-	if p.FailureCount != 1 {
-		t.Errorf("FailureCount: got %d, want 1", p.FailureCount)
+	if p.ConsecutiveFailures != 1 {
+		t.Errorf("ConsecutiveFailures: got %d, want 1", p.ConsecutiveFailures)
 	}
-	if len(notifier.dms) != 1 {
-		t.Errorf("expected 1 DM on first failure, got %d", len(notifier.dms))
-	}
-	if len(notifier.channels) != 1 {
-		t.Errorf("expected 1 channel message on first failure, got %d", len(notifier.channels))
+	if len(dmMsgs) != 1 {
+		t.Errorf("expected 1 DM on first failure, got %d", len(dmMsgs))
 	}
 }
 
@@ -684,8 +671,8 @@ func TestRunPendingOKXCircuitCloses_RepeatedFailureThrottlesNotifier(t *testing.
 				RiskState: RiskState{
 					PendingCircuitCloses: map[string]*PendingCircuitClose{
 						PlatformPendingCloseOKX: {
-							Symbols:      []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.1}},
-							FailureCount: 1, // first failure already recorded
+							Symbols:             []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.1}},
+							ConsecutiveFailures: 1, // first failure already recorded
 						},
 					},
 				},
@@ -700,7 +687,8 @@ func TestRunPendingOKXCircuitCloses_RepeatedFailureThrottlesNotifier(t *testing.
 	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
 		return nil, fmt.Errorf("okx 503")
 	}
-	notifier := &captureOKXNotifier{}
+	var dmMsgs []string
+	ownerDM := func(msg string) { dmMsgs = append(dmMsgs, msg) }
 	// Force LastNotifiedAt to just now so hourly gate doesn't fire.
 	state.Strategies["okx-a"].RiskState.PendingCircuitCloses[PlatformPendingCloseOKX].LastNotifiedAt = time.Now()
 
@@ -715,10 +703,10 @@ func TestRunPendingOKXCircuitCloses_RepeatedFailureThrottlesNotifier(t *testing.
 		closer,
 		30*time.Second,
 		&mu,
-		notifier,
+		ownerDM,
 	)
-	if len(notifier.dms) != 0 {
-		t.Errorf("expected 0 DMs on failure #2 (suppressed), got %d", len(notifier.dms))
+	if len(dmMsgs) != 0 {
+		t.Errorf("expected 0 DMs on failure #2 (suppressed), got %d", len(dmMsgs))
 	}
 }
 
@@ -732,9 +720,9 @@ func TestRunPendingOKXCircuitCloses_TenthFailureNotifies(t *testing.T) {
 				RiskState: RiskState{
 					PendingCircuitCloses: map[string]*PendingCircuitClose{
 						PlatformPendingCloseOKX: {
-							Symbols:        []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.1}},
-							FailureCount:   9,
-							LastNotifiedAt: time.Now(),
+							Symbols:             []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.1}},
+							ConsecutiveFailures: 9,
+							LastNotifiedAt:      time.Now(),
 						},
 					},
 				},
@@ -749,7 +737,8 @@ func TestRunPendingOKXCircuitCloses_TenthFailureNotifies(t *testing.T) {
 	closer := func(sym string, partialSz *float64) (*OKXCloseResult, error) {
 		return nil, fmt.Errorf("okx 503")
 	}
-	notifier := &captureOKXNotifier{}
+	var dmMsgs []string
+	ownerDM := func(msg string) { dmMsgs = append(dmMsgs, msg) }
 	runPendingOKXCircuitCloses(
 		context.Background(),
 		state,
@@ -761,13 +750,13 @@ func TestRunPendingOKXCircuitCloses_TenthFailureNotifies(t *testing.T) {
 		closer,
 		30*time.Second,
 		&mu,
-		notifier,
+		ownerDM,
 	)
 	p := state.Strategies["okx-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseOKX)
-	if p == nil || p.FailureCount != 10 {
-		t.Fatalf("expected FailureCount=10, got %v", p)
+	if p == nil || p.ConsecutiveFailures != 10 {
+		t.Fatalf("expected ConsecutiveFailures=10, got %v", p)
 	}
-	if len(notifier.dms) != 1 {
-		t.Errorf("expected 1 DM on failure #10 (every-10th cadence), got %d", len(notifier.dms))
+	if len(dmMsgs) != 1 {
+		t.Errorf("expected 1 DM on failure #10 (every-10th cadence), got %d", len(dmMsgs))
 	}
 }

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -615,9 +615,17 @@ const (
 // #363). The drain emits a CRITICAL warning each cycle instead and leaves the
 // pending populated so /status, Discord, and Telegram all surface the gap
 // continuously until the operator clears it manually.
+//
+// FailureCount and LastNotifiedAt track consecutive close-attempt failures for
+// the throttled operator alert added in #427. The drain increments FailureCount
+// on each failure and only fires the Discord/DM alert on the first failure,
+// every 10th failure, or once per hour — whichever fires first. Cleared when
+// the pending close succeeds (the entire entry is removed).
 type PendingCircuitClose struct {
 	Symbols          []PendingCircuitCloseSymbol `json:"symbols"`
 	OperatorRequired bool                        `json:"operator_required,omitempty"`
+	FailureCount     int                         `json:"failure_count,omitempty"`
+	LastNotifiedAt   time.Time                   `json:"last_notified_at,omitempty"`
 }
 
 // PendingCircuitCloseSymbol is one position leg of a pending close. Symbol is

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -616,16 +616,18 @@ const (
 // pending populated so /status, Discord, and Telegram all surface the gap
 // continuously until the operator clears it manually.
 //
-// FailureCount and LastNotifiedAt track consecutive close-attempt failures for
-// the throttled operator alert added in #427. The drain increments FailureCount
-// on each failure and only fires the Discord/DM alert on the first failure,
-// every 10th failure, or once per hour — whichever fires first. Cleared when
-// the pending close succeeds (the entire entry is removed).
+// ConsecutiveFailures and LastNotifiedAt track consecutive close-attempt
+// failures (without any partial progress) for the throttled owner-DM alert
+// added in #427. The drain increments ConsecutiveFailures on each hard error
+// and resets it to 0 on any partial fill progress. The DM fires on the first
+// failure, every 10th consecutive failure, or once per hour — whichever fires
+// first. The counter is discarded together with the entry when the close
+// fully succeeds.
 type PendingCircuitClose struct {
-	Symbols          []PendingCircuitCloseSymbol `json:"symbols"`
-	OperatorRequired bool                        `json:"operator_required,omitempty"`
-	FailureCount     int                         `json:"failure_count,omitempty"`
-	LastNotifiedAt   time.Time                   `json:"last_notified_at,omitempty"`
+	Symbols             []PendingCircuitCloseSymbol `json:"symbols"`
+	OperatorRequired    bool                        `json:"operator_required,omitempty"`
+	ConsecutiveFailures int                         `json:"consecutive_failures,omitempty"`
+	LastNotifiedAt      time.Time                   `json:"last_notified_at,omitempty"`
 }
 
 // PendingCircuitCloseSymbol is one position leg of a pending close. Symbol is

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -2250,3 +2250,53 @@ func TestRiskState_PendingCircuitClose_MultiPlatformRoundTrip(t *testing.T) {
 		t.Error("okx entry lost in round-trip")
 	}
 }
+
+// TestRiskState_PendingCircuitClose_FailureCounterRoundTrip verifies that
+// FailureCount and LastNotifiedAt survive Marshal/Unmarshal so a stuck CB close
+// loop remembers how many attempts have fired across restarts and throttles
+// notifications correctly (#427).
+func TestRiskState_PendingCircuitClose_FailureCounterRoundTrip(t *testing.T) {
+	notifiedAt := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	src := &RiskState{PendingCircuitCloses: map[string]*PendingCircuitClose{
+		PlatformPendingCloseHyperliquid: {
+			Symbols:        []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.25}},
+			FailureCount:   7,
+			LastNotifiedAt: notifiedAt,
+		},
+	}}
+	blob := src.MarshalPendingCircuitClosesJSON()
+	if blob == "" {
+		t.Fatal("expected non-empty JSON blob")
+	}
+	var dst RiskState
+	dst.UnmarshalPendingCircuitClosesJSON(blob)
+	got := dst.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
+	if got == nil {
+		t.Fatal("entry lost in round-trip")
+	}
+	if got.FailureCount != 7 {
+		t.Errorf("FailureCount: got %d, want 7", got.FailureCount)
+	}
+	if !got.LastNotifiedAt.Equal(notifiedAt) {
+		t.Errorf("LastNotifiedAt: got %v, want %v", got.LastNotifiedAt, notifiedAt)
+	}
+}
+
+// TestRiskState_PendingCircuitClose_LegacyShapeDefaultsZeroFailureCount verifies
+// that pre-#427 DB rows (which have no failure_count field) load with
+// FailureCount=0 so the first new-code failure increments to 1 and notifies.
+func TestRiskState_PendingCircuitClose_LegacyShapeDefaultsZeroFailureCount(t *testing.T) {
+	var r RiskState
+	// Legacy DB row has no failure_count or last_notified_at fields.
+	r.UnmarshalPendingCircuitClosesJSON(`{"hyperliquid":{"symbols":[{"symbol":"ETH","size":0.25}]}}`)
+	got := r.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
+	if got == nil {
+		t.Fatal("entry not loaded")
+	}
+	if got.FailureCount != 0 {
+		t.Errorf("legacy row must default FailureCount=0, got %d", got.FailureCount)
+	}
+	if !got.LastNotifiedAt.IsZero() {
+		t.Errorf("legacy row must default LastNotifiedAt=zero, got %v", got.LastNotifiedAt)
+	}
+}

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -2251,17 +2251,17 @@ func TestRiskState_PendingCircuitClose_MultiPlatformRoundTrip(t *testing.T) {
 	}
 }
 
-// TestRiskState_PendingCircuitClose_FailureCounterRoundTrip verifies that
-// FailureCount and LastNotifiedAt survive Marshal/Unmarshal so a stuck CB close
+// TestRiskState_PendingCircuitClose_ConsecutiveFailureserRoundTrip verifies that
+// ConsecutiveFailures and LastNotifiedAt survive Marshal/Unmarshal so a stuck CB close
 // loop remembers how many attempts have fired across restarts and throttles
 // notifications correctly (#427).
-func TestRiskState_PendingCircuitClose_FailureCounterRoundTrip(t *testing.T) {
+func TestRiskState_PendingCircuitClose_ConsecutiveFailureserRoundTrip(t *testing.T) {
 	notifiedAt := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
 	src := &RiskState{PendingCircuitCloses: map[string]*PendingCircuitClose{
 		PlatformPendingCloseHyperliquid: {
-			Symbols:        []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.25}},
-			FailureCount:   7,
-			LastNotifiedAt: notifiedAt,
+			Symbols:             []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.25}},
+			ConsecutiveFailures: 7,
+			LastNotifiedAt:      notifiedAt,
 		},
 	}}
 	blob := src.MarshalPendingCircuitClosesJSON()
@@ -2274,18 +2274,18 @@ func TestRiskState_PendingCircuitClose_FailureCounterRoundTrip(t *testing.T) {
 	if got == nil {
 		t.Fatal("entry lost in round-trip")
 	}
-	if got.FailureCount != 7 {
-		t.Errorf("FailureCount: got %d, want 7", got.FailureCount)
+	if got.ConsecutiveFailures != 7 {
+		t.Errorf("ConsecutiveFailures: got %d, want 7", got.ConsecutiveFailures)
 	}
 	if !got.LastNotifiedAt.Equal(notifiedAt) {
 		t.Errorf("LastNotifiedAt: got %v, want %v", got.LastNotifiedAt, notifiedAt)
 	}
 }
 
-// TestRiskState_PendingCircuitClose_LegacyShapeDefaultsZeroFailureCount verifies
+// TestRiskState_PendingCircuitClose_LegacyShapeDefaultsZeroConsecutiveFailures verifies
 // that pre-#427 DB rows (which have no failure_count field) load with
-// FailureCount=0 so the first new-code failure increments to 1 and notifies.
-func TestRiskState_PendingCircuitClose_LegacyShapeDefaultsZeroFailureCount(t *testing.T) {
+// ConsecutiveFailures=0 so the first new-code failure increments to 1 and notifies.
+func TestRiskState_PendingCircuitClose_LegacyShapeDefaultsZeroConsecutiveFailures(t *testing.T) {
 	var r RiskState
 	// Legacy DB row has no failure_count or last_notified_at fields.
 	r.UnmarshalPendingCircuitClosesJSON(`{"hyperliquid":{"symbols":[{"symbol":"ETH","size":0.25}]}}`)
@@ -2293,8 +2293,8 @@ func TestRiskState_PendingCircuitClose_LegacyShapeDefaultsZeroFailureCount(t *te
 	if got == nil {
 		t.Fatal("entry not loaded")
 	}
-	if got.FailureCount != 0 {
-		t.Errorf("legacy row must default FailureCount=0, got %d", got.FailureCount)
+	if got.ConsecutiveFailures != 0 {
+		t.Errorf("legacy row must default ConsecutiveFailures=0, got %d", got.ConsecutiveFailures)
 	}
 	if !got.LastNotifiedAt.IsZero() {
 		t.Errorf("legacy row must default LastNotifiedAt=zero, got %v", got.LastNotifiedAt)

--- a/scheduler/robinhood_pending_close.go
+++ b/scheduler/robinhood_pending_close.go
@@ -53,6 +53,7 @@ func runPendingRobinhoodCircuitCloses(
 	sendOwnerDM RobinhoodPendingCloseOwnerDM,
 	totalBudget time.Duration,
 	mu *sync.RWMutex,
+	notifier operatorRequiredNotifier,
 ) {
 	if closer == nil || state == nil {
 		return
@@ -251,8 +252,27 @@ func runPendingRobinhoodCircuitCloses(
 
 			result, err := closer(c.Symbol)
 			if err != nil {
+				errMsg := err.Error()
 				fmt.Printf("[CRITICAL] rh-circuit-close: strategy %s coin %s failed: %v\n", j.stratID, c.Symbol, err)
 				allOK = false
+				now := time.Now().UTC()
+				mu.Lock()
+				if ss := state.Strategies[j.stratID]; ss != nil {
+					if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood); p != nil {
+						p.FailureCount++
+						if shouldNotifyDrainFailure(p.FailureCount, p.LastNotifiedAt, now) {
+							p.LastNotifiedAt = now
+							mu.Unlock()
+							if notifier != nil && notifier.HasBackends() {
+								msg := formatDrainFailureAlert("robinhood", j.stratID, c.Symbol, c.Size, errMsg, p.FailureCount)
+								notifier.SendToAllChannels(msg)
+								notifier.SendOwnerDM(msg)
+							}
+							mu.Lock()
+						}
+					}
+				}
+				mu.Unlock()
 				break
 			}
 			if result != nil && result.Close != nil && result.Close.AlreadyFlat {

--- a/scheduler/robinhood_pending_close.go
+++ b/scheduler/robinhood_pending_close.go
@@ -53,7 +53,6 @@ func runPendingRobinhoodCircuitCloses(
 	sendOwnerDM RobinhoodPendingCloseOwnerDM,
 	totalBudget time.Duration,
 	mu *sync.RWMutex,
-	notifier operatorRequiredNotifier,
 ) {
 	if closer == nil || state == nil {
 		return
@@ -213,6 +212,9 @@ func runPendingRobinhoodCircuitCloses(
 		}
 
 		allOK := true
+		var failedCoin string
+		var failedSize float64
+		var failedErr error
 		for _, c := range j.pending.Symbols {
 			// Defense in depth: re-check the on-account balance right before
 			// submit (it may have drained since enqueue via stuck-CB recovery
@@ -252,27 +254,11 @@ func runPendingRobinhoodCircuitCloses(
 
 			result, err := closer(c.Symbol)
 			if err != nil {
-				errMsg := err.Error()
 				fmt.Printf("[CRITICAL] rh-circuit-close: strategy %s coin %s failed: %v\n", j.stratID, c.Symbol, err)
 				allOK = false
-				now := time.Now().UTC()
-				mu.Lock()
-				if ss := state.Strategies[j.stratID]; ss != nil {
-					if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood); p != nil {
-						p.FailureCount++
-						if shouldNotifyDrainFailure(p.FailureCount, p.LastNotifiedAt, now) {
-							p.LastNotifiedAt = now
-							mu.Unlock()
-							if notifier != nil && notifier.HasBackends() {
-								msg := formatDrainFailureAlert("robinhood", j.stratID, c.Symbol, c.Size, errMsg, p.FailureCount)
-								notifier.SendToAllChannels(msg)
-								notifier.SendOwnerDM(msg)
-							}
-							mu.Lock()
-						}
-					}
-				}
-				mu.Unlock()
+				failedCoin = c.Symbol
+				failedSize = c.Size
+				failedErr = err
 				break
 			}
 			if result != nil && result.Close != nil && result.Close.AlreadyFlat {
@@ -296,8 +282,11 @@ func runPendingRobinhoodCircuitCloses(
 		// recovery controls whether to re-enqueue next cycle. If the shared
 		// configuration persists, recovery's sole-owner gate will again skip
 		// + DM, giving the operator a steady audit trail until they fix it.
-		// For genuine submit errors we preserve pending so the next cycle's
-		// drain retries (same semantics as HL).
+		// For genuine submit errors we preserve pending and increment the
+		// consecutive-failure counter for throttled owner-DM alerts (#427).
+		var failCount int
+		var shouldAlert bool
+		now := time.Now().UTC()
 		mu.Lock()
 		if ss := state.Strategies[j.stratID]; ss != nil {
 			sharedOnly := true
@@ -310,9 +299,22 @@ func runPendingRobinhoodCircuitCloses(
 			}
 			if sharedOnly {
 				ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseRobinhood)
+			} else if failedErr != nil {
+				if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood); p != nil {
+					p.ConsecutiveFailures++
+					failCount = p.ConsecutiveFailures
+					if shouldNotifyDrainFailure(p.ConsecutiveFailures, p.LastNotifiedAt, now) {
+						p.LastNotifiedAt = now
+						shouldAlert = true
+					}
+				}
 			}
 		}
 		mu.Unlock()
+
+		if shouldAlert && sendOwnerDM != nil {
+			sendOwnerDM(formatDrainFailureAlert("robinhood", j.stratID, failedCoin, failedSize, failedErr.Error(), failCount))
+		}
 	}
 }
 

--- a/scheduler/robinhood_pending_close_test.go
+++ b/scheduler/robinhood_pending_close_test.go
@@ -53,6 +53,7 @@ func TestRunPendingRobinhoodCircuitCloses_SoleOwnerFullClose(t *testing.T) {
 		dm,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 
 	if len(calls) != 1 || calls[0] != "BTC" {
@@ -103,6 +104,7 @@ func TestRunPendingRobinhoodCircuitCloses_RecoversStuckCB(t *testing.T) {
 		nil,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 
 	if len(calls) != 1 || calls[0] != "BTC" {
@@ -149,6 +151,7 @@ func TestRunPendingRobinhoodCircuitCloses_StuckCBNoOnAccountPositionIsNoOp(t *te
 		nil,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 
 	if len(calls) != 0 {
@@ -203,6 +206,7 @@ func TestRunPendingRobinhoodCircuitCloses_SharedOwnershipSkipsAndDMs(t *testing.
 		dm,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 
 	if len(calls) != 0 {
@@ -268,6 +272,7 @@ func TestRunPendingRobinhoodCircuitCloses_StuckCBSharedOwnershipSkipDMs(t *testi
 		dm,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 
 	if len(calls) != 0 {
@@ -317,6 +322,7 @@ func TestRunPendingRobinhoodCircuitCloses_SubmitErrorRetainsPending(t *testing.T
 		nil,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 
 	pending := state.Strategies["rh-sma-btc"].RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood)
@@ -368,6 +374,7 @@ func TestRunPendingRobinhoodCircuitCloses_AlreadyFlatClearsPending(t *testing.T)
 		nil,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 
 	if state.Strategies["rh-sma-btc"].RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood) != nil {
@@ -498,5 +505,108 @@ func TestFormatRobinhoodSharedOwnerDM_DeterministicPeerOrder(t *testing.T) {
 	}
 	if !(alphaIdx < midIdx && midIdx < zetaIdx) {
 		t.Errorf("peer IDs not in sorted order in peer list: %q", peerList)
+	}
+}
+
+// captureRHNotifier implements operatorRequiredNotifier for tests.
+type captureRHNotifier struct {
+	channels []string
+	dms      []string
+}
+
+func (n *captureRHNotifier) HasBackends() bool          { return true }
+func (n *captureRHNotifier) SendToAllChannels(c string) { n.channels = append(n.channels, c) }
+func (n *captureRHNotifier) SendOwnerDM(c string)       { n.dms = append(n.dms, c) }
+
+func TestRunPendingRobinhoodCircuitCloses_FailureIncrementsCountAndNotifies(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"rh-a": {
+				ID: "rh-a",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseRobinhood: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "BTC", Size: 0.01}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "rh-a", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		return nil, fmt.Errorf("rh timeout")
+	}
+	notifier := &captureRHNotifier{}
+	runPendingRobinhoodCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		[]RobinhoodPosition{{Coin: "BTC", Size: 0.01}},
+		true,
+		nil,
+		closer,
+		nil,
+		30*time.Second,
+		&mu,
+		notifier,
+	)
+	p := state.Strategies["rh-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood)
+	if p == nil {
+		t.Fatal("pending should be preserved on failure")
+	}
+	if p.FailureCount != 1 {
+		t.Errorf("FailureCount: got %d, want 1", p.FailureCount)
+	}
+	if len(notifier.dms) != 1 {
+		t.Errorf("expected 1 DM on first failure, got %d", len(notifier.dms))
+	}
+}
+
+func TestRunPendingRobinhoodCircuitCloses_RepeatedFailureThrottlesNotifier(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"rh-a": {
+				ID: "rh-a",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseRobinhood: {
+							Symbols:        []PendingCircuitCloseSymbol{{Symbol: "BTC", Size: 0.01}},
+							FailureCount:   1,
+							LastNotifiedAt: time.Now(),
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "rh-a", Platform: "robinhood", Type: "spot",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	closer := func(sym string) (*RobinhoodCloseResult, error) {
+		return nil, fmt.Errorf("rh timeout")
+	}
+	notifier := &captureRHNotifier{}
+	runPendingRobinhoodCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		[]RobinhoodPosition{{Coin: "BTC", Size: 0.01}},
+		true,
+		nil,
+		closer,
+		nil,
+		30*time.Second,
+		&mu,
+		notifier,
+	)
+	if len(notifier.dms) != 0 {
+		t.Errorf("expected 0 DMs on failure #2 (suppressed), got %d", len(notifier.dms))
 	}
 }

--- a/scheduler/robinhood_pending_close_test.go
+++ b/scheduler/robinhood_pending_close_test.go
@@ -53,7 +53,6 @@ func TestRunPendingRobinhoodCircuitCloses_SoleOwnerFullClose(t *testing.T) {
 		dm,
 		30*time.Second,
 		&mu,
-		nil,
 	)
 
 	if len(calls) != 1 || calls[0] != "BTC" {
@@ -104,7 +103,6 @@ func TestRunPendingRobinhoodCircuitCloses_RecoversStuckCB(t *testing.T) {
 		nil,
 		30*time.Second,
 		&mu,
-		nil,
 	)
 
 	if len(calls) != 1 || calls[0] != "BTC" {
@@ -151,7 +149,6 @@ func TestRunPendingRobinhoodCircuitCloses_StuckCBNoOnAccountPositionIsNoOp(t *te
 		nil,
 		30*time.Second,
 		&mu,
-		nil,
 	)
 
 	if len(calls) != 0 {
@@ -206,7 +203,6 @@ func TestRunPendingRobinhoodCircuitCloses_SharedOwnershipSkipsAndDMs(t *testing.
 		dm,
 		30*time.Second,
 		&mu,
-		nil,
 	)
 
 	if len(calls) != 0 {
@@ -272,7 +268,6 @@ func TestRunPendingRobinhoodCircuitCloses_StuckCBSharedOwnershipSkipDMs(t *testi
 		dm,
 		30*time.Second,
 		&mu,
-		nil,
 	)
 
 	if len(calls) != 0 {
@@ -322,7 +317,6 @@ func TestRunPendingRobinhoodCircuitCloses_SubmitErrorRetainsPending(t *testing.T
 		nil,
 		30*time.Second,
 		&mu,
-		nil,
 	)
 
 	pending := state.Strategies["rh-sma-btc"].RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood)
@@ -374,7 +368,6 @@ func TestRunPendingRobinhoodCircuitCloses_AlreadyFlatClearsPending(t *testing.T)
 		nil,
 		30*time.Second,
 		&mu,
-		nil,
 	)
 
 	if state.Strategies["rh-sma-btc"].RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood) != nil {
@@ -508,16 +501,6 @@ func TestFormatRobinhoodSharedOwnerDM_DeterministicPeerOrder(t *testing.T) {
 	}
 }
 
-// captureRHNotifier implements operatorRequiredNotifier for tests.
-type captureRHNotifier struct {
-	channels []string
-	dms      []string
-}
-
-func (n *captureRHNotifier) HasBackends() bool          { return true }
-func (n *captureRHNotifier) SendToAllChannels(c string) { n.channels = append(n.channels, c) }
-func (n *captureRHNotifier) SendOwnerDM(c string)       { n.dms = append(n.dms, c) }
-
 func TestRunPendingRobinhoodCircuitCloses_FailureIncrementsCountAndNotifies(t *testing.T) {
 	state := &AppState{
 		Strategies: map[string]*StrategyState{
@@ -541,7 +524,8 @@ func TestRunPendingRobinhoodCircuitCloses_FailureIncrementsCountAndNotifies(t *t
 	closer := func(sym string) (*RobinhoodCloseResult, error) {
 		return nil, fmt.Errorf("rh timeout")
 	}
-	notifier := &captureRHNotifier{}
+	var dmMsgs []string
+	ownerDM := func(msg string) { dmMsgs = append(dmMsgs, msg) }
 	runPendingRobinhoodCircuitCloses(
 		context.Background(),
 		state,
@@ -550,20 +534,19 @@ func TestRunPendingRobinhoodCircuitCloses_FailureIncrementsCountAndNotifies(t *t
 		true,
 		nil,
 		closer,
-		nil,
+		ownerDM,
 		30*time.Second,
 		&mu,
-		notifier,
 	)
 	p := state.Strategies["rh-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseRobinhood)
 	if p == nil {
 		t.Fatal("pending should be preserved on failure")
 	}
-	if p.FailureCount != 1 {
-		t.Errorf("FailureCount: got %d, want 1", p.FailureCount)
+	if p.ConsecutiveFailures != 1 {
+		t.Errorf("ConsecutiveFailures: got %d, want 1", p.ConsecutiveFailures)
 	}
-	if len(notifier.dms) != 1 {
-		t.Errorf("expected 1 DM on first failure, got %d", len(notifier.dms))
+	if len(dmMsgs) != 1 {
+		t.Errorf("expected 1 DM on first failure, got %d", len(dmMsgs))
 	}
 }
 
@@ -575,9 +558,9 @@ func TestRunPendingRobinhoodCircuitCloses_RepeatedFailureThrottlesNotifier(t *te
 				RiskState: RiskState{
 					PendingCircuitCloses: map[string]*PendingCircuitClose{
 						PlatformPendingCloseRobinhood: {
-							Symbols:        []PendingCircuitCloseSymbol{{Symbol: "BTC", Size: 0.01}},
-							FailureCount:   1,
-							LastNotifiedAt: time.Now(),
+							Symbols:             []PendingCircuitCloseSymbol{{Symbol: "BTC", Size: 0.01}},
+							ConsecutiveFailures: 1,
+							LastNotifiedAt:      time.Now(),
 						},
 					},
 				},
@@ -592,7 +575,8 @@ func TestRunPendingRobinhoodCircuitCloses_RepeatedFailureThrottlesNotifier(t *te
 	closer := func(sym string) (*RobinhoodCloseResult, error) {
 		return nil, fmt.Errorf("rh timeout")
 	}
-	notifier := &captureRHNotifier{}
+	var dmMsgs []string
+	ownerDM := func(msg string) { dmMsgs = append(dmMsgs, msg) }
 	runPendingRobinhoodCircuitCloses(
 		context.Background(),
 		state,
@@ -601,12 +585,11 @@ func TestRunPendingRobinhoodCircuitCloses_RepeatedFailureThrottlesNotifier(t *te
 		true,
 		nil,
 		closer,
-		nil,
+		ownerDM,
 		30*time.Second,
 		&mu,
-		notifier,
 	)
-	if len(notifier.dms) != 0 {
-		t.Errorf("expected 0 DMs on failure #2 (suppressed), got %d", len(notifier.dms))
+	if len(dmMsgs) != 0 {
+		t.Errorf("expected 0 DMs on failure #2 (suppressed), got %d", len(dmMsgs))
 	}
 }

--- a/scheduler/topstep_close.go
+++ b/scheduler/topstep_close.go
@@ -207,6 +207,7 @@ func runPendingTopStepCircuitCloses(
 	closer TopStepLiveCloser,
 	totalBudget time.Duration,
 	mu *sync.RWMutex,
+	notifier operatorRequiredNotifier,
 ) {
 	if closer == nil || state == nil {
 		return
@@ -369,9 +370,28 @@ func runPendingTopStepCircuitCloses(
 				// any other close failure land here — we log and latch. The
 				// next cycle re-enters this drain and retries; virtual state
 				// stays untouched (CheckRisk already force-closed locally).
+				errMsg := err.Error()
 				fmt.Printf("[CRITICAL] ts-circuit-close: strategy %s contract %s sz=%d failed: %v (will retry next cycle)\n",
 					j.stratID, c.Symbol, absOC, err)
 				allOK = false
+				now := time.Now().UTC()
+				mu.Lock()
+				if ss := state.Strategies[j.stratID]; ss != nil {
+					if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep); p != nil {
+						p.FailureCount++
+						if shouldNotifyDrainFailure(p.FailureCount, p.LastNotifiedAt, now) {
+							p.LastNotifiedAt = now
+							mu.Unlock()
+							if notifier != nil && notifier.HasBackends() {
+								msg := formatDrainFailureAlert("topstep", j.stratID, c.Symbol, float64(absOC), errMsg, p.FailureCount)
+								notifier.SendToAllChannels(msg)
+								notifier.SendOwnerDM(msg)
+							}
+							mu.Lock()
+						}
+					}
+				}
+				mu.Unlock()
 				break
 			}
 			fmt.Printf("[INFO] ts-circuit-close: strategy %s contract %s submitted market_close sz=%d\n",

--- a/scheduler/topstep_close.go
+++ b/scheduler/topstep_close.go
@@ -392,18 +392,24 @@ func runPendingTopStepCircuitCloses(
 		if ss := state.Strategies[j.stratID]; ss != nil {
 			if allOK {
 				ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseTopStep)
-			} else if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep); p != nil {
-				p.ConsecutiveFailures++
-				failCount = p.ConsecutiveFailures
-				if shouldNotifyDrainFailure(p.ConsecutiveFailures, p.LastNotifiedAt, now) {
-					p.LastNotifiedAt = now
-					shouldAlert = true
+			} else if failedErr != nil {
+				// Only count as a drain failure when a closer() actually errored.
+				// allOK can also be set false by a mid-loop ctxOverall expiry
+				// where failedErr stays nil — counting that would inflate the
+				// counter and dereferencing failedErr.Error() below would panic.
+				if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep); p != nil {
+					p.ConsecutiveFailures++
+					failCount = p.ConsecutiveFailures
+					if shouldNotifyDrainFailure(p.ConsecutiveFailures, p.LastNotifiedAt, now) {
+						p.LastNotifiedAt = now
+						shouldAlert = true
+					}
 				}
 			}
 		}
 		mu.Unlock()
 
-		if shouldAlert && ownerDM != nil {
+		if shouldAlert && ownerDM != nil && failedErr != nil {
 			ownerDM(formatDrainFailureAlert("topstep", j.stratID, failedSym, float64(failedAbsOC), failedErr.Error(), failCount))
 		}
 	}

--- a/scheduler/topstep_close.go
+++ b/scheduler/topstep_close.go
@@ -207,7 +207,7 @@ func runPendingTopStepCircuitCloses(
 	closer TopStepLiveCloser,
 	totalBudget time.Duration,
 	mu *sync.RWMutex,
-	notifier operatorRequiredNotifier,
+	ownerDM func(string),
 ) {
 	if closer == nil || state == nil {
 		return
@@ -336,6 +336,9 @@ func runPendingTopStepCircuitCloses(
 		}
 
 		allOK := true
+		var failedSym string
+		var failedAbsOC int
+		var failedErr error
 		for _, c := range j.pending.Symbols {
 			if err := ctxOverall.Err(); err != nil {
 				allOK = false
@@ -370,40 +373,38 @@ func runPendingTopStepCircuitCloses(
 				// any other close failure land here — we log and latch. The
 				// next cycle re-enters this drain and retries; virtual state
 				// stays untouched (CheckRisk already force-closed locally).
-				errMsg := err.Error()
 				fmt.Printf("[CRITICAL] ts-circuit-close: strategy %s contract %s sz=%d failed: %v (will retry next cycle)\n",
 					j.stratID, c.Symbol, absOC, err)
 				allOK = false
-				now := time.Now().UTC()
-				mu.Lock()
-				if ss := state.Strategies[j.stratID]; ss != nil {
-					if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep); p != nil {
-						p.FailureCount++
-						if shouldNotifyDrainFailure(p.FailureCount, p.LastNotifiedAt, now) {
-							p.LastNotifiedAt = now
-							mu.Unlock()
-							if notifier != nil && notifier.HasBackends() {
-								msg := formatDrainFailureAlert("topstep", j.stratID, c.Symbol, float64(absOC), errMsg, p.FailureCount)
-								notifier.SendToAllChannels(msg)
-								notifier.SendOwnerDM(msg)
-							}
-							mu.Lock()
-						}
-					}
-				}
-				mu.Unlock()
+				failedSym = c.Symbol
+				failedAbsOC = absOC
+				failedErr = err
 				break
 			}
 			fmt.Printf("[INFO] ts-circuit-close: strategy %s contract %s submitted market_close sz=%d\n",
 				j.stratID, c.Symbol, absOC)
 		}
 
-		if allOK {
-			mu.Lock()
-			if ss := state.Strategies[j.stratID]; ss != nil {
+		var failCount int
+		var shouldAlert bool
+		now := time.Now().UTC()
+		mu.Lock()
+		if ss := state.Strategies[j.stratID]; ss != nil {
+			if allOK {
 				ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseTopStep)
+			} else if p := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep); p != nil {
+				p.ConsecutiveFailures++
+				failCount = p.ConsecutiveFailures
+				if shouldNotifyDrainFailure(p.ConsecutiveFailures, p.LastNotifiedAt, now) {
+					p.LastNotifiedAt = now
+					shouldAlert = true
+				}
 			}
-			mu.Unlock()
+		}
+		mu.Unlock()
+
+		if shouldAlert && ownerDM != nil {
+			ownerDM(formatDrainFailureAlert("topstep", j.stratID, failedSym, float64(failedAbsOC), failedErr.Error(), failCount))
 		}
 	}
 }

--- a/scheduler/topstep_close_test.go
+++ b/scheduler/topstep_close_test.go
@@ -775,3 +775,76 @@ func TestRunPendingTopStepCircuitCloses_RepeatedFailureThrottlesNotifier(t *test
 		t.Errorf("expected 0 DMs on failure #2 (suppressed), got %d", len(dmMsgs))
 	}
 }
+
+// Regression: when ctxOverall trips mid-symbol-loop, the inner per-symbol
+// ctx check sets allOK=false but failedErr stays nil. The post-loop block
+// must NOT increment ConsecutiveFailures and must NOT dereference failedErr
+// (that would panic). See PR #435 review.
+func TestRunPendingTopStepCircuitCloses_CtxExpiryMidLoopDoesNotCountAsFailure(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"ts-es": {
+				ID: "ts-es",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseTopStep: {
+							Symbols: []PendingCircuitCloseSymbol{
+								{Symbol: "ES", Size: 1},
+								{Symbol: "NQ", Size: 1},
+							},
+							ConsecutiveFailures: 4,
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "ts-es", Platform: "topstep", Type: "futures",
+			Args: []string{"ts-es", "ES", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var calls []string
+	closer := func(sym string) (*TopStepCloseResult, error) {
+		calls = append(calls, sym)
+		// Cancel the budget after the first symbol succeeds so the inner
+		// ctx check fires before the second symbol — exactly the
+		// nil-failedErr-with-allOK=false branch the bug reproduces.
+		cancel()
+		return &TopStepCloseResult{Close: &TopStepClose{Symbol: sym}}, nil
+	}
+	var dmMsgs []string
+	ownerDM := func(msg string) { dmMsgs = append(dmMsgs, msg) }
+
+	runPendingTopStepCircuitCloses(
+		ctx,
+		state,
+		cfg,
+		[]TopStepPosition{
+			{Coin: "ES", Size: 1},
+			{Coin: "NQ", Size: 1},
+		},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+		ownerDM,
+	)
+
+	if len(calls) != 1 {
+		t.Errorf("expected exactly 1 closer call before ctx expiry, got %d (%v)", len(calls), calls)
+	}
+	if len(dmMsgs) != 0 {
+		t.Errorf("expected 0 DMs on mid-loop ctx expiry (no real failure), got %d (%v)", len(dmMsgs), dmMsgs)
+	}
+	p := state.Strategies["ts-es"].RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep)
+	if p == nil {
+		t.Fatal("pending must be preserved on ctx expiry")
+	}
+	if p.ConsecutiveFailures != 4 {
+		t.Errorf("ConsecutiveFailures must not increment on ctx expiry: got %d, want 4", p.ConsecutiveFailures)
+	}
+}

--- a/scheduler/topstep_close_test.go
+++ b/scheduler/topstep_close_test.go
@@ -435,6 +435,7 @@ func TestRunPendingTopStepCircuitCloses_DrainsAndClearsPending(t *testing.T) {
 		closer,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 	if len(calls) != 1 || calls[0] != "ES" {
 		t.Errorf("closer calls=%v want [ES]", calls)
@@ -480,6 +481,7 @@ func TestRunPendingTopStepCircuitCloses_RecoversStuckCB(t *testing.T) {
 		closer,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 	if len(calls) != 1 || calls[0] != "ES" {
 		t.Errorf("closer calls=%v want [ES] (recovered pending should flatten full size)", calls)
@@ -524,6 +526,7 @@ func TestRunPendingTopStepCircuitCloses_CloseErrorLatchesPending(t *testing.T) {
 		closer,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 	pending := state.Strategies["ts-es"].RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep)
 	if pending == nil {
@@ -573,6 +576,7 @@ func TestRunPendingTopStepCircuitCloses_AlreadyFlatSkipsCloserAndClears(t *testi
 		closer,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 	if len(calls) != 0 {
 		t.Errorf("closer should not be called when position is already flat, got %v", calls)
@@ -618,6 +622,7 @@ func TestRunPendingTopStepCircuitCloses_StuckCBMultiPeerSkipped(t *testing.T) {
 		closer,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 	if len(calls) != 0 {
 		t.Errorf("closer should not be called for multi-peer contract, got %v", calls)
@@ -667,6 +672,7 @@ func TestRunPendingTopStepCircuitCloses_FetcherErrorBails(t *testing.T) {
 		closer,
 		30*time.Second,
 		&mu,
+		nil,
 	)
 	if len(calls) != 0 {
 		t.Errorf("closer should not be called when fetcher errors, got %v", calls)
@@ -674,5 +680,106 @@ func TestRunPendingTopStepCircuitCloses_FetcherErrorBails(t *testing.T) {
 	// Pending must remain so the next cycle retries.
 	if state.Strategies["ts-es"].RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep) == nil {
 		t.Error("expected pending to remain latched when fetcher errors")
+	}
+}
+
+// captureTSNotifier implements operatorRequiredNotifier for tests.
+type captureTSNotifier struct {
+	channels []string
+	dms      []string
+}
+
+func (n *captureTSNotifier) HasBackends() bool          { return true }
+func (n *captureTSNotifier) SendToAllChannels(c string) { n.channels = append(n.channels, c) }
+func (n *captureTSNotifier) SendOwnerDM(c string)       { n.dms = append(n.dms, c) }
+
+func TestRunPendingTopStepCircuitCloses_FailureIncrementsCountAndNotifies(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"ts-es": {
+				ID: "ts-es",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseTopStep: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "ES", Size: 1}},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "ts-es", Platform: "topstep", Type: "futures",
+			Args: []string{"ts-es", "ES", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	closer := func(sym string) (*TopStepCloseResult, error) {
+		return nil, fmt.Errorf("topstep API 503")
+	}
+	notifier := &captureTSNotifier{}
+	runPendingTopStepCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		[]TopStepPosition{{Coin: "ES", Size: 1}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+		notifier,
+	)
+	p := state.Strategies["ts-es"].RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep)
+	if p == nil {
+		t.Fatal("pending should be preserved on failure")
+	}
+	if p.FailureCount != 1 {
+		t.Errorf("FailureCount: got %d, want 1", p.FailureCount)
+	}
+	if len(notifier.dms) != 1 {
+		t.Errorf("expected 1 DM on first failure, got %d", len(notifier.dms))
+	}
+}
+
+func TestRunPendingTopStepCircuitCloses_RepeatedFailureThrottlesNotifier(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"ts-es": {
+				ID: "ts-es",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseTopStep: {
+							Symbols:        []PendingCircuitCloseSymbol{{Symbol: "ES", Size: 1}},
+							FailureCount:   1,
+							LastNotifiedAt: time.Now(),
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "ts-es", Platform: "topstep", Type: "futures",
+			Args: []string{"ts-es", "ES", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	closer := func(sym string) (*TopStepCloseResult, error) {
+		return nil, fmt.Errorf("topstep API 503")
+	}
+	notifier := &captureTSNotifier{}
+	runPendingTopStepCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		[]TopStepPosition{{Coin: "ES", Size: 1}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+		notifier,
+	)
+	if len(notifier.dms) != 0 {
+		t.Errorf("expected 0 DMs on failure #2 (suppressed), got %d", len(notifier.dms))
 	}
 }

--- a/scheduler/topstep_close_test.go
+++ b/scheduler/topstep_close_test.go
@@ -683,16 +683,6 @@ func TestRunPendingTopStepCircuitCloses_FetcherErrorBails(t *testing.T) {
 	}
 }
 
-// captureTSNotifier implements operatorRequiredNotifier for tests.
-type captureTSNotifier struct {
-	channels []string
-	dms      []string
-}
-
-func (n *captureTSNotifier) HasBackends() bool          { return true }
-func (n *captureTSNotifier) SendToAllChannels(c string) { n.channels = append(n.channels, c) }
-func (n *captureTSNotifier) SendOwnerDM(c string)       { n.dms = append(n.dms, c) }
-
 func TestRunPendingTopStepCircuitCloses_FailureIncrementsCountAndNotifies(t *testing.T) {
 	state := &AppState{
 		Strategies: map[string]*StrategyState{
@@ -716,7 +706,8 @@ func TestRunPendingTopStepCircuitCloses_FailureIncrementsCountAndNotifies(t *tes
 	closer := func(sym string) (*TopStepCloseResult, error) {
 		return nil, fmt.Errorf("topstep API 503")
 	}
-	notifier := &captureTSNotifier{}
+	var dmMsgs []string
+	ownerDM := func(msg string) { dmMsgs = append(dmMsgs, msg) }
 	runPendingTopStepCircuitCloses(
 		context.Background(),
 		state,
@@ -727,17 +718,17 @@ func TestRunPendingTopStepCircuitCloses_FailureIncrementsCountAndNotifies(t *tes
 		closer,
 		30*time.Second,
 		&mu,
-		notifier,
+		ownerDM,
 	)
 	p := state.Strategies["ts-es"].RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep)
 	if p == nil {
 		t.Fatal("pending should be preserved on failure")
 	}
-	if p.FailureCount != 1 {
-		t.Errorf("FailureCount: got %d, want 1", p.FailureCount)
+	if p.ConsecutiveFailures != 1 {
+		t.Errorf("ConsecutiveFailures: got %d, want 1", p.ConsecutiveFailures)
 	}
-	if len(notifier.dms) != 1 {
-		t.Errorf("expected 1 DM on first failure, got %d", len(notifier.dms))
+	if len(dmMsgs) != 1 {
+		t.Errorf("expected 1 DM on first failure, got %d", len(dmMsgs))
 	}
 }
 
@@ -749,9 +740,9 @@ func TestRunPendingTopStepCircuitCloses_RepeatedFailureThrottlesNotifier(t *test
 				RiskState: RiskState{
 					PendingCircuitCloses: map[string]*PendingCircuitClose{
 						PlatformPendingCloseTopStep: {
-							Symbols:        []PendingCircuitCloseSymbol{{Symbol: "ES", Size: 1}},
-							FailureCount:   1,
-							LastNotifiedAt: time.Now(),
+							Symbols:             []PendingCircuitCloseSymbol{{Symbol: "ES", Size: 1}},
+							ConsecutiveFailures: 1,
+							LastNotifiedAt:      time.Now(),
 						},
 					},
 				},
@@ -766,7 +757,8 @@ func TestRunPendingTopStepCircuitCloses_RepeatedFailureThrottlesNotifier(t *test
 	closer := func(sym string) (*TopStepCloseResult, error) {
 		return nil, fmt.Errorf("topstep API 503")
 	}
-	notifier := &captureTSNotifier{}
+	var dmMsgs []string
+	ownerDM := func(msg string) { dmMsgs = append(dmMsgs, msg) }
 	runPendingTopStepCircuitCloses(
 		context.Background(),
 		state,
@@ -777,9 +769,9 @@ func TestRunPendingTopStepCircuitCloses_RepeatedFailureThrottlesNotifier(t *test
 		closer,
 		30*time.Second,
 		&mu,
-		notifier,
+		ownerDM,
 	)
-	if len(notifier.dms) != 0 {
-		t.Errorf("expected 0 DMs on failure #2 (suppressed), got %d", len(notifier.dms))
+	if len(dmMsgs) != 0 {
+		t.Errorf("expected 0 DMs on failure #2 (suppressed), got %d", len(dmMsgs))
 	}
 }


### PR DESCRIPTION
## Summary

- **CB drain failures go completely silent**: when `runPendingHyperliquidCircuitCloses` / OKX / TopStep / Robinhood drains hit a closer error, only a `[CRITICAL]` log line fired. The drain retries every cycle forever with no operator alert — the `float_to_wire` bug in #425 left `hl-tema-eth-live` stuck for hours unnoticed.
- **Live order failures go silent too**: when `runHyperliquidExecuteOrder` / OKX / Robinhood / TopStep wrappers return `ok=false`, `liveExecFailed=true` correctly prevents virtual state mutation, but no Discord/Telegram notification fired.

## Changes

1. **`scheduler/risk.go`** — add `ConsecutiveFailures int` and `LastNotifiedAt time.Time` to `PendingCircuitClose`, persisted via the existing `risk_pending_circuit_closes_json` column.

2. **`scheduler/failure_alerts.go`** (new) — pure helpers:
   - `shouldNotifyDrainFailure`: notify on 1st failure, every 10th, or once per hour — whichever fires first.
   - `LiveExecFailureThrottle`: in-memory per-`(stratID, platform, symbol, direction)` throttle for live-exec failures; restart-clears naturally.
   - `formatDrainFailureAlert` / `formatLiveExecFailureAlert`: message formatters.
   - `notifyLiveExecFailure` / `clearLiveExecThrottle`: helpers wired into the live-exec wrappers.

3. **CB drain functions** — add `ownerDM func(string)` parameter to all four drains (HL, OKX, TopStep, Robinhood reuses existing `sendOwnerDM`); fire owner DM on close failure, throttled via `ConsecutiveFailures` / `LastNotifiedAt`. Counter resets to 0 on partial-fill progress so the next hard error re-notifies as a fresh first failure.

4. **`scheduler/main.go`** — pass `notifier.SendOwnerDM` to all four drain call sites; add `notifier *MultiNotifier` parameter to `runOKXExecuteOrder`, `runRobinhoodExecuteOrder`, `runTopStepExecuteOrder` (HL already had it); call `notifyLiveExecFailure` on both `err != nil` and `execResult.Error` paths; call `clearLiveExecThrottle` on success.

5. **Tests** — 36 new tests: `failure_alerts_test.go` (pure throttle/formatter coverage), `risk_test.go` (DB round-trip for new fields + legacy-row compat), and per-platform drain failure-alert tests in HL/OKX/TopStep/Robinhood test files.

Closes #427

---
LLM: Claude Opus 4.7 (1M) | high