### PR TITLE
[codex] Auto-reset confirmed-flat kill switch

### DIFF
--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -178,6 +178,17 @@ type KillSwitchClosePlan struct {
 	LogLines []string
 }
 
+func (p KillSwitchClosePlan) CanAutoResetWithoutOwner() bool {
+	return p.OnChainConfirmedFlat && !p.OKXSpotPresent && !p.RHOptionsPresent
+}
+
+const killSwitchManualResetLine = "Virtual state cleared. Manual reset required."
+const killSwitchAutoResetLine = "Virtual state cleared. Kill switch auto-reset; trading will resume next cycle."
+
+func formatKillSwitchAutoResetMessage(msg string) string {
+	return strings.Replace(msg, killSwitchManualResetLine, killSwitchAutoResetLine, 1)
+}
+
 // HLStateFetcher re-fetches Hyperliquid on-chain positions for the kill-switch
 // opportunistic-fetch path. Exposed as a function type so tests can stub the
 // HTTP call. The default wraps fetchHyperliquidState.
@@ -496,7 +507,7 @@ func formatKillSwitchMessage(hlAddr string, plan KillSwitchClosePlan, portfolioR
 			parts = append(parts, gapNotes...)
 		}
 		summary := strings.Join(parts, "; ")
-		return fmt.Sprintf("%s\n%s\n%s. Virtual state cleared. Manual reset required.", header, portfolioReason, summary)
+		return fmt.Sprintf("%s\n%s\n%s. %s", header, portfolioReason, summary, killSwitchManualResetLine)
 	}
 
 	var segments []string

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -129,6 +129,9 @@ func TestPlanKillSwitchClose_HappyPath(t *testing.T) {
 	if !plan.OnChainConfirmedFlat {
 		t.Fatalf("expected ConfirmedFlat, got plan=%+v", plan)
 	}
+	if !plan.CanAutoResetWithoutOwner() {
+		t.Fatal("expected happy-path confirmed-flat plan to allow no-owner auto-reset")
+	}
 	if len(plan.CloseReport.ClosedCoins) != 1 || plan.CloseReport.ClosedCoins[0] != "ETH" {
 		t.Errorf("ClosedCoins = %v, want [ETH]", plan.CloseReport.ClosedCoins)
 	}
@@ -144,6 +147,10 @@ func TestPlanKillSwitchClose_HappyPath(t *testing.T) {
 	}
 	if !strings.Contains(plan.DiscordMessage, "Virtual state cleared") {
 		t.Errorf("expected 'Virtual state cleared' in message, got: %s", plan.DiscordMessage)
+	}
+	if got := formatKillSwitchAutoResetMessage(plan.DiscordMessage); !strings.Contains(got, "Kill switch auto-reset; trading will resume next cycle") ||
+		strings.Contains(got, "Manual reset required") {
+		t.Errorf("expected auto-reset message to replace manual-reset instruction, got: %s", got)
 	}
 }
 
@@ -472,6 +479,9 @@ func TestPlanKillSwitchClose_OKXSpotSurfacesGap(t *testing.T) {
 	if !plan.OKXSpotPresent {
 		t.Error("expected OKXSpotPresent=true")
 	}
+	if plan.CanAutoResetWithoutOwner() {
+		t.Error("OKX spot operator-required gap must suppress no-owner auto-reset")
+	}
 	if !strings.Contains(plan.DiscordMessage, "OKX spot") {
 		t.Errorf("expected spot gap note in message, got: %s", plan.DiscordMessage)
 	}
@@ -762,6 +772,9 @@ func TestPlanKillSwitchClose_RobinhoodOptionsSurfacesGap(t *testing.T) {
 	}
 	if !plan.RHOptionsPresent {
 		t.Error("expected RHOptionsPresent=true")
+	}
+	if plan.CanAutoResetWithoutOwner() {
+		t.Error("Robinhood options operator-required gap must suppress no-owner auto-reset")
 	}
 	if !strings.Contains(plan.DiscordMessage, "Robinhood options") {
 		t.Errorf("expected options gap note in message, got: %s", plan.DiscordMessage)

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -791,6 +791,7 @@ func main() {
 				}
 			}
 
+			killSwitchAutoReset := false
 			if killSwitchFired && plan.OnChainConfirmedFlat {
 				mu.Lock()
 				for _, sc := range cfg.Strategies {
@@ -803,16 +804,25 @@ func main() {
 					}
 				}
 				if !notifier.HasOwner() {
-					if AutoResetConfirmedFlatKillSwitch(&state.PortfolioRisk, totalPV,
-						"confirmed flat after portfolio kill-switch close; no DM owner configured, latch auto-cleared") {
-						fmt.Printf("[CRITICAL] Portfolio kill switch auto-reset after confirmed flat close (no owner configured, peak re-baselined to $%.2f)\n", totalPV)
+					if plan.CanAutoResetWithoutOwner() {
+						killSwitchAutoReset = AutoResetConfirmedFlatKillSwitch(&state.PortfolioRisk, totalPV,
+							"confirmed flat after portfolio kill-switch close; no DM owner configured, latch auto-cleared")
+						if killSwitchAutoReset {
+							fmt.Printf("[CRITICAL] Portfolio kill switch auto-reset after confirmed flat close (no owner configured, peak re-baselined to $%.2f)\n", totalPV)
+						}
+					} else {
+						fmt.Println("[CRITICAL] Portfolio kill switch auto-reset suppressed: operator-required close gaps remain")
 					}
 				}
 				mu.Unlock()
 			}
 
 			if killSwitchFired && notifier.HasBackends() && plan.DiscordMessage != "" {
-				notifier.SendToAllChannels(plan.DiscordMessage)
+				killSwitchMsg := plan.DiscordMessage
+				if killSwitchAutoReset {
+					killSwitchMsg = formatKillSwitchAutoResetMessage(killSwitchMsg)
+				}
+				notifier.SendToAllChannels(killSwitchMsg)
 			}
 
 			// Warning alert: drawdown approaching kill switch threshold.

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -802,6 +802,12 @@ func main() {
 						// portfolio kill path once it takes over flattening.
 					}
 				}
+				if !notifier.HasOwner() {
+					if AutoResetConfirmedFlatKillSwitch(&state.PortfolioRisk, totalPV,
+						"confirmed flat after portfolio kill-switch close; no DM owner configured, latch auto-cleared") {
+						fmt.Printf("[CRITICAL] Portfolio kill switch auto-reset after confirmed flat close (no owner configured, peak re-baselined to $%.2f)\n", totalPV)
+					}
+				}
 				mu.Unlock()
 			}
 

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -325,18 +325,34 @@ func ClearLatchedKillSwitchSharedWallet(state *AppState, strategies []StrategyCo
 // live close planning has confirmed all automated venues are flat. This is used
 // only when no DM-capable owner is configured; owner-backed deployments keep the
 // existing human-in-the-loop reset path.
-func AutoResetConfirmedFlatKillSwitch(prs *PortfolioRiskState, postClosePortfolioValue float64, details string) bool {
+//
+// rebaselineValue is the best available estimate for post-close portfolio
+// value. The hot loop typically passes the pre-close mark-to-market totalPV,
+// which closely approximates post-close cash apart from fees and slippage.
+//
+// Note: callers should suppress this auto-reset when the close plan has
+// operator-required gaps such as OKX spot or Robinhood options. Those venues do
+// not block OnChainConfirmedFlat because there is no safe automated close path,
+// but resuming trading without a human reset would hide remaining live exposure.
+func AutoResetConfirmedFlatKillSwitch(prs *PortfolioRiskState, rebaselineValue float64, details string) bool {
 	if prs == nil || !prs.KillSwitchActive {
 		return false
+	}
+
+	prevEquityDrawdownPct := prs.CurrentDrawdownPct
+	prevMarginDrawdownPct := prs.CurrentMarginDrawdownPct
+	if details != "" {
+		details = fmt.Sprintf("%s (previous equity drawdown=%.2f%%, previous margin drawdown=%.2f%%)",
+			details, prevEquityDrawdownPct, prevMarginDrawdownPct)
 	}
 
 	prs.KillSwitchActive = false
 	prs.KillSwitchAt = time.Time{}
 	prs.WarningSent = false
-	prs.PeakValue = postClosePortfolioValue
+	prs.PeakValue = rebaselineValue
 	prs.CurrentDrawdownPct = 0
 	prs.CurrentMarginDrawdownPct = 0
-	addKillSwitchEvent(prs, "auto_reset", "", 0, postClosePortfolioValue, postClosePortfolioValue, details)
+	addKillSwitchEvent(prs, "auto_reset", "", 0, rebaselineValue, rebaselineValue, details)
 	return true
 }
 

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -270,7 +270,7 @@ func detectSharedWalletPlatforms(strategies []StrategyConfig) []string {
 //     partial slice that would under-baseline PeakValue
 //
 // On success, PortfolioRisk.PeakValue is re-baselined to the verified total
-// balance (and CurrentDrawdownPct zeroed) so the very next CheckPortfolioRisk
+// balance (and drawdown fields zeroed) so the very next CheckPortfolioRisk
 // call cannot immediately re-latch the kill switch using a stale inflated
 // peak — the original root cause from #244.
 //
@@ -313,10 +313,30 @@ func ClearLatchedKillSwitchSharedWallet(state *AppState, strategies []StrategyCo
 	// (potentially double-counted) peak.
 	state.PortfolioRisk.PeakValue = totalBalance
 	state.PortfolioRisk.CurrentDrawdownPct = 0
+	state.PortfolioRisk.CurrentMarginDrawdownPct = 0
 	addKillSwitchEvent(&state.PortfolioRisk, "auto_reset", "",
 		0, totalBalance, totalBalance,
 		fmt.Sprintf("startup auto-clear: shared wallets %v reachable, total balance=$%.2f (peak re-baselined)",
 			sharedPlatforms, totalBalance))
+	return true
+}
+
+// AutoResetConfirmedFlatKillSwitch clears a portfolio kill-switch latch after
+// live close planning has confirmed all automated venues are flat. This is used
+// only when no DM-capable owner is configured; owner-backed deployments keep the
+// existing human-in-the-loop reset path.
+func AutoResetConfirmedFlatKillSwitch(prs *PortfolioRiskState, postClosePortfolioValue float64, details string) bool {
+	if prs == nil || !prs.KillSwitchActive {
+		return false
+	}
+
+	prs.KillSwitchActive = false
+	prs.KillSwitchAt = time.Time{}
+	prs.WarningSent = false
+	prs.PeakValue = postClosePortfolioValue
+	prs.CurrentDrawdownPct = 0
+	prs.CurrentMarginDrawdownPct = 0
+	addKillSwitchEvent(prs, "auto_reset", "", 0, postClosePortfolioValue, postClosePortfolioValue, details)
 	return true
 }
 

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -945,10 +945,11 @@ func latchedSharedWalletState() *AppState {
 	return &AppState{
 		Strategies: map[string]*StrategyState{},
 		PortfolioRisk: PortfolioRiskState{
-			PeakValue:          10000,
-			CurrentDrawdownPct: 50,
-			KillSwitchActive:   true,
-			KillSwitchAt:       time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+			PeakValue:                10000,
+			CurrentDrawdownPct:       50,
+			CurrentMarginDrawdownPct: 26.84,
+			KillSwitchActive:         true,
+			KillSwitchAt:             time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
 		},
 	}
 }
@@ -999,6 +1000,9 @@ func TestClearLatchedKillSwitchSharedWallet_Success(t *testing.T) {
 	}
 	if state.PortfolioRisk.CurrentDrawdownPct != 0 {
 		t.Errorf("expected CurrentDrawdownPct reset to 0; got %.2f", state.PortfolioRisk.CurrentDrawdownPct)
+	}
+	if state.PortfolioRisk.CurrentMarginDrawdownPct != 0 {
+		t.Errorf("expected CurrentMarginDrawdownPct reset to 0; got %.2f", state.PortfolioRisk.CurrentMarginDrawdownPct)
 	}
 	if len(state.PortfolioRisk.Events) != 1 {
 		t.Fatalf("expected 1 audit event; got %d", len(state.PortfolioRisk.Events))
@@ -1217,6 +1221,96 @@ func TestClearLatchedKillSwitchSharedWallet_MultiPlatformAnyFailPreservesLatch(t
 	}
 	if len(state.PortfolioRisk.Events) != 0 {
 		t.Errorf("expected no audit event on partial failure; got %d", len(state.PortfolioRisk.Events))
+	}
+}
+
+func TestAutoResetConfirmedFlatKillSwitch_Success(t *testing.T) {
+	latchedAt := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	prs := &PortfolioRiskState{
+		PeakValue:                1261.87,
+		CurrentDrawdownPct:       3.63,
+		CurrentMarginDrawdownPct: 26.84,
+		KillSwitchActive:         true,
+		KillSwitchAt:             latchedAt,
+		WarningSent:              true,
+	}
+
+	if ok := AutoResetConfirmedFlatKillSwitch(prs, 1216.07, "confirmed flat; no owner configured"); !ok {
+		t.Fatal("expected auto-reset to return true")
+	}
+	if prs.KillSwitchActive {
+		t.Error("expected KillSwitchActive=false after confirmed-flat auto-reset")
+	}
+	if !prs.KillSwitchAt.IsZero() {
+		t.Errorf("expected KillSwitchAt zeroed; got %v", prs.KillSwitchAt)
+	}
+	if prs.WarningSent {
+		t.Error("expected WarningSent=false after confirmed-flat auto-reset")
+	}
+	if prs.PeakValue != 1216.07 {
+		t.Errorf("expected PeakValue re-baselined to post-close value 1216.07; got %.2f", prs.PeakValue)
+	}
+	if prs.CurrentDrawdownPct != 0 {
+		t.Errorf("expected CurrentDrawdownPct=0; got %.2f", prs.CurrentDrawdownPct)
+	}
+	if prs.CurrentMarginDrawdownPct != 0 {
+		t.Errorf("expected CurrentMarginDrawdownPct=0; got %.2f", prs.CurrentMarginDrawdownPct)
+	}
+	if len(prs.Events) != 1 {
+		t.Fatalf("expected 1 audit event; got %d", len(prs.Events))
+	}
+	evt := prs.Events[0]
+	if evt.Type != "auto_reset" {
+		t.Errorf("expected event type auto_reset; got %q", evt.Type)
+	}
+	if evt.DrawdownPct != 0 {
+		t.Errorf("expected event drawdown 0; got %.2f", evt.DrawdownPct)
+	}
+	if evt.PortfolioValue != 1216.07 || evt.PeakValue != 1216.07 {
+		t.Errorf("expected event portfolio/peak re-baselined to 1216.07; got portfolio=%.2f peak=%.2f",
+			evt.PortfolioValue, evt.PeakValue)
+	}
+}
+
+func TestAutoResetConfirmedFlatKillSwitch_NoOpWhenInactive(t *testing.T) {
+	prs := &PortfolioRiskState{
+		PeakValue:                5000,
+		CurrentDrawdownPct:       4,
+		CurrentMarginDrawdownPct: 8,
+	}
+
+	if ok := AutoResetConfirmedFlatKillSwitch(prs, 4500, "no-op"); ok {
+		t.Fatal("expected inactive kill switch to be a no-op")
+	}
+	if prs.PeakValue != 5000 {
+		t.Errorf("expected PeakValue unchanged; got %.2f", prs.PeakValue)
+	}
+	if prs.CurrentDrawdownPct != 4 || prs.CurrentMarginDrawdownPct != 8 {
+		t.Errorf("expected drawdown fields unchanged; got equity=%.2f margin=%.2f",
+			prs.CurrentDrawdownPct, prs.CurrentMarginDrawdownPct)
+	}
+	if len(prs.Events) != 0 {
+		t.Errorf("expected no event on no-op; got %d", len(prs.Events))
+	}
+}
+
+func TestAutoResetConfirmedFlatKillSwitch_NoRelatchOnNextTick(t *testing.T) {
+	prs := &PortfolioRiskState{
+		PeakValue:          10000,
+		CurrentDrawdownPct: 30,
+		KillSwitchActive:   true,
+		KillSwitchAt:       time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC),
+	}
+
+	AutoResetConfirmedFlatKillSwitch(prs, 7000, "confirmed flat; no owner configured")
+
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	allowed, _, _, reason := CheckPortfolioRisk(prs, cfg, 7000, 0, 0, 0)
+	if !allowed {
+		t.Fatalf("expected next tick to resume trading after auto-reset; got reason=%s", reason)
+	}
+	if prs.KillSwitchActive {
+		t.Error("expected kill switch to remain inactive on next tick")
 	}
 }
 

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -1270,6 +1270,10 @@ func TestAutoResetConfirmedFlatKillSwitch_Success(t *testing.T) {
 		t.Errorf("expected event portfolio/peak re-baselined to 1216.07; got portfolio=%.2f peak=%.2f",
 			evt.PortfolioValue, evt.PeakValue)
 	}
+	if !strings.Contains(evt.Details, "previous equity drawdown=3.63%") ||
+		!strings.Contains(evt.Details, "previous margin drawdown=26.84%") {
+		t.Errorf("expected previous drawdowns in event details; got %q", evt.Details)
+	}
 }
 
 func TestAutoResetConfirmedFlatKillSwitch_NoOpWhenInactive(t *testing.T) {
@@ -1311,6 +1315,9 @@ func TestAutoResetConfirmedFlatKillSwitch_NoRelatchOnNextTick(t *testing.T) {
 	}
 	if prs.KillSwitchActive {
 		t.Error("expected kill switch to remain inactive on next tick")
+	}
+	if prs.PeakValue != 7000 {
+		t.Errorf("expected PeakValue to remain at re-baselined value 7000; got %.2f", prs.PeakValue)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #431 by adding a non-Discord recovery path for the portfolio kill switch after automated force-close confirms all managed live venues are flat.

## What changed

- Auto-clear the portfolio kill-switch latch when `plan.OnChainConfirmedFlat == true` and no DM-capable owner is configured.
- Re-baseline `PortfolioRisk.PeakValue` to the post-close portfolio value, zero both drawdown fields, clear warning state, and append an `auto_reset` audit event.
- Preserve the existing owner DM reset flow when an owner is configured.
- Also zero `CurrentMarginDrawdownPct` in the existing shared-wallet startup auto-clear helper so direct DB inspection stays clean.

## Validation

- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...`