### PR TITLE
[codex] Add max drawdown to summaries

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -236,8 +236,8 @@ const discordSplitThreshold = 1980
 // catTableMaxRows caps how many strategy rows render per Discord message before
 // the table is continued in a follow-up message. Sized so the rendered table
 // (including header/sep/totals) plus the base summary header and the per-channel
-// position section stays under the 2000-char limit (#381 widened the row to fit
-// the new #T column, so this cap shrank from 20 to 15).
+// position section stays under the 2000-char limit (#381 added #T, #434 added
+// W/L, and #436 added Max DD; 15 rows remains within the Discord limit).
 const catTableMaxRows = 15
 
 // FormatCategorySummary creates Discord messages for a set of strategies sharing a channel.
@@ -410,22 +410,23 @@ func FormatCategorySummary(
 			effectiveInterval = globalIntervalSeconds
 		}
 		tableBots = append(tableBots, botInfo{
-			id:            sc.ID,
-			strategy:      stratName,
-			asset:         botAsset,
-			timeframe:     tf,
-			interval:      formatInterval(effectiveInterval),
-			value:         pv,
-			initialCap:    initCap,
-			pnl:           pnl,
-			pnlPct:        pnlPct,
-			walletPct:     walletPct,
-			trades:        len(ss.TradeHistory),
-			openPositions: openPos,
-			closedTrades:  ss.RiskState.TotalTrades,
-			winningTrades: ss.RiskState.WinningTrades,
-			losingTrades:  ss.RiskState.LosingTrades,
-			tradeHistory:  ss.TradeHistory,
+			id:             sc.ID,
+			strategy:       stratName,
+			asset:          botAsset,
+			timeframe:      tf,
+			interval:       formatInterval(effectiveInterval),
+			value:          pv,
+			initialCap:     initCap,
+			pnl:            pnl,
+			pnlPct:         pnlPct,
+			maxDrawdownPct: sc.MaxDrawdownPct,
+			walletPct:      walletPct,
+			trades:         len(ss.TradeHistory),
+			openPositions:  openPos,
+			closedTrades:   ss.RiskState.TotalTrades,
+			winningTrades:  ss.RiskState.WinningTrades,
+			losingTrades:   ss.RiskState.LosingTrades,
+			tradeHistory:   ss.TradeHistory,
 		})
 	}
 
@@ -611,22 +612,23 @@ func splitCategorySummaryCore(header string, totalOpenPos int, posLines []string
 }
 
 type botInfo struct {
-	id            string
-	strategy      string
-	asset         string
-	timeframe     string // e.g. "1h" or "—" for spot/options
-	interval      string // e.g. "10m", formatted from effective interval seconds
-	value         float64
-	initialCap    float64
-	pnl           float64
-	pnlPct        float64
-	walletPct     float64 // 0 = not a shared wallet; >0 = strategy's share of the wallet
-	trades        int
-	openPositions int
-	closedTrades  int
-	winningTrades int
-	losingTrades  int
-	tradeHistory  []Trade
+	id             string
+	strategy       string
+	asset          string
+	timeframe      string // e.g. "1h" or "—" for spot/options
+	interval       string // e.g. "10m", formatted from effective interval seconds
+	value          float64
+	initialCap     float64
+	pnl            float64
+	pnlPct         float64
+	maxDrawdownPct float64
+	walletPct      float64 // 0 = not a shared wallet; >0 = strategy's share of the wallet
+	trades         int
+	openPositions  int
+	closedTrades   int
+	winningTrades  int
+	losingTrades   int
+	tradeHistory   []Trade
 }
 
 func extractStrategyName(sc StrategyConfig) string {
@@ -771,8 +773,8 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 	}
 	sb.WriteString("\n```\n")
 	if showWalletPct {
-		const sep = "------------------------------------------------------------------------------------"
-		sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %8s %5s %5s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Wallet%", "Tf", "Int", "#T", "W/L"))
+		sep := strings.Repeat("-", 92)
+		sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %6s %8s %5s %5s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Max DD", "Wallet%", "Tf", "Int", "#T", "W/L"))
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {
 			label := bot.id
@@ -783,12 +785,13 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 			initStr := fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
 			pctStr := fmtPnlPct(bot.pnlPct)
+			maxDDStr := fmtDrawdownPct(bot.maxDrawdownPct)
 			wpStr := ""
 			if bot.walletPct > 0 {
 				wpStr = fmt.Sprintf("%.1f%%", bot.walletPct)
 			}
 			wlStr := fmtWinLossRatio(bot.winningTrades, bot.losingTrades)
-			sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %8s %5s %5s %5d %5s\n", label, initStr, valStr, pnlStr, pctStr, wpStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
+			sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %6s %8s %5s %5s %5d %5s\n", label, initStr, valStr, pnlStr, pctStr, maxDDStr, wpStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
 		}
 		if includeTotals {
 			sb.WriteString(sep + "\n")
@@ -797,11 +800,11 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 			totPnlStr := fmtPnl(totalPnl)
 			totPctStr := fmtPnlPct(totalPnlPct)
 			totWlStr := fmtWinLossRatio(totalWins, totalLosses)
-			sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %8s %5s %5s %5d %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "100.0%", "", "", totalClosed, totWlStr))
+			sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %6s %8s %5s %5s %5d %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", "100.0%", "", "", totalClosed, totWlStr))
 		}
 	} else {
-		const sep = "-----------------------------------------------------------------------------"
-		sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %5s %5s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Tf", "Int", "#T", "W/L"))
+		sep := strings.Repeat("-", 83)
+		sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %6s %5s %5s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Max DD", "Tf", "Int", "#T", "W/L"))
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {
 			label := bot.id
@@ -813,7 +816,8 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 			pnlStr := fmtPnl(bot.pnl)
 			pctStr := fmtPnlPct(bot.pnlPct)
 			wlStr := fmtWinLossRatio(bot.winningTrades, bot.losingTrades)
-			sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %5s %5s %5d %5s\n", label, initStr, valStr, pnlStr, pctStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
+			maxDDStr := fmtDrawdownPct(bot.maxDrawdownPct)
+			sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %6s %5s %5s %5d %5s\n", label, initStr, valStr, pnlStr, pctStr, maxDDStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
 		}
 		if includeTotals {
 			sb.WriteString(sep + "\n")
@@ -822,7 +826,7 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 			totPnlStr := fmtPnl(totalPnl)
 			totPctStr := fmtPnlPct(totalPnlPct)
 			totWlStr := fmtWinLossRatio(totalWins, totalLosses)
-			sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %5s %5s %5d %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", "", totalClosed, totWlStr))
+			sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %6s %5s %5s %5d %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", "", "", totalClosed, totWlStr))
 		}
 	}
 	sb.WriteString("```\n")
@@ -887,6 +891,13 @@ func fmtPnlPct(pct float64) string {
 		sign = ""
 	}
 	return fmt.Sprintf("%s%.1f%%", sign, pct)
+}
+
+func fmtDrawdownPct(pct float64) string {
+	if pct <= 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.1f%%", pct)
 }
 
 // collectPositions returns human-readable position lines for a strategy.

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -625,6 +625,82 @@ func TestFormatCategorySummary_TfIntGlobalFallback(t *testing.T) {
 	}
 }
 
+func TestFormatCategorySummary_MaxDrawdownColumn(t *testing.T) {
+	// Issue #436: summary tables surface the effective max_drawdown_pct already
+	// resolved onto StrategyConfig by LoadConfig (strategy → platform → type).
+	strats := []StrategyConfig{
+		{ID: "hl-rsi-btc", Type: "perps", Args: []string{"rsi", "BTC", "1h"}, Capital: 1000, MaxDrawdownPct: 12.5},
+		{ID: "hl-sma-btc", Type: "perps", Args: []string{"sma", "BTC", "1h"}, Capital: 1000, MaxDrawdownPct: 50},
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-rsi-btc": {Cash: 1000},
+			"hl-sma-btc": {Cash: 1000},
+		},
+	}
+	prices := map[string]float64{"BTC/USDT": 50000}
+
+	msgs := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
+	msg := strings.Join(msgs, "\n")
+
+	if !strings.Contains(msg, "Max DD") {
+		t.Errorf("expected Max DD column header, got:\n%s", msg)
+	}
+	pnlIdx := strings.Index(msg, "PnL%")
+	maxDDIdx := strings.Index(msg, "Max DD")
+	tfIdx := strings.Index(msg, "Tf")
+	if pnlIdx < 0 || maxDDIdx < pnlIdx || tfIdx < maxDDIdx {
+		t.Errorf("expected Max DD column between PnL%% and Tf, got PnL%%@%d MaxDD@%d Tf@%d:\n%s", pnlIdx, maxDDIdx, tfIdx, msg)
+	}
+	if !strings.Contains(msg, "12.5%") || !strings.Contains(msg, "50.0%") {
+		t.Errorf("expected resolved max drawdown values 12.5%% and 50.0%%, got:\n%s", msg)
+	}
+}
+
+func TestFormatCategorySummary_MaxDrawdownColumn_SharedWallet(t *testing.T) {
+	// Shared-wallet tables have a Wallet% column, so keep Max DD anchored before
+	// it and keep the TOTAL wallet percentage from shifting.
+	strats := []StrategyConfig{
+		{ID: "hl-rmc-eth", Type: "perps", Platform: "hyperliquid", Capital: 500, CapitalPct: 0.5, Args: []string{"rmc", "ETH", "1h"}, MaxDrawdownPct: 25},
+		{ID: "hl-tema-eth", Type: "perps", Platform: "hyperliquid", Capital: 500, CapitalPct: 0.5, Args: []string{"tema", "ETH", "1h"}, MaxDrawdownPct: 35},
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-rmc-eth":  {Cash: 500, InitialCapital: 500},
+			"hl-tema-eth": {Cash: 500, InitialCapital: 500},
+		},
+	}
+	prices := map[string]float64{"ETH/USDT": 3000}
+
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0)
+	msg := strings.Join(msgs, "\n")
+	lines := strings.Split(msg, "\n")
+	var headerLine, totalLine string
+	for _, line := range lines {
+		if strings.Contains(line, "Max DD") && strings.Contains(line, "Wallet%") {
+			headerLine = line
+		}
+		if strings.HasPrefix(line, "TOTAL") {
+			totalLine = line
+		}
+	}
+	if headerLine == "" || totalLine == "" {
+		t.Fatalf("expected shared-wallet header and TOTAL row, got:\n%s", msg)
+	}
+	pnlIdx := strings.Index(headerLine, "PnL%")
+	maxDDIdx := strings.Index(headerLine, "Max DD")
+	walletIdx := strings.Index(headerLine, "Wallet%")
+	if pnlIdx < 0 || maxDDIdx < pnlIdx || walletIdx < maxDDIdx {
+		t.Errorf("expected Max DD column between PnL%% and Wallet%%, got PnL%%@%d MaxDD@%d Wallet%%@%d:\n%s", pnlIdx, maxDDIdx, walletIdx, msg)
+	}
+	if !strings.Contains(msg, "25.0%") || !strings.Contains(msg, "35.0%") {
+		t.Errorf("expected resolved max drawdown values 25.0%% and 35.0%%, got:\n%s", msg)
+	}
+	if len(totalLine) <= walletIdx || !strings.Contains(totalLine[walletIdx:], "100.0%") {
+		t.Errorf("expected TOTAL row to keep 100.0%% under Wallet%% column, got header=%q total=%q", headerLine, totalLine)
+	}
+}
+
 func TestFormatCategorySummary_ClosedTradesColumn(t *testing.T) {
 	// Issue #381: strategy table should show closed-trade count per strategy.
 	// Standard variant (no shared wallet).


### PR DESCRIPTION
## Summary

- Add a `Max DD` column to Discord/Telegram strategy summary tables.
- Render the effective `StrategyConfig.MaxDrawdownPct` value already resolved by config loading.
- Preserve the W/L column from `main` and cover both standard and shared-wallet summary table layouts.

## Validation

- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test -count=1 ./...`

Closes #436.