### PR TITLE
fix: make workflow LLM footer authoritative over Claude's self-written footer

### DIFF
--- a/.github/scripts/rewrite_create_pr_link.py
+++ b/.github/scripts/rewrite_create_pr_link.py
@@ -5,17 +5,16 @@ PR body ends with our model/effort footer instead of the default
 Reads the comment body from $BODY_IN and the footer text from $FOOTER_TEXT.
 Prints the rewritten comment body to stdout.
 
-Not idempotent on its own: if a Create-PR link's `body=` already ends with a
-`LLM: ...` footer (not the default Claude Code attribution), the
-else-branch in `rewrite` will append a second footer. The caller in
-.github/workflows/claude.yml guards against re-runs with a
-`grep -q "LLM:"` check before invoking this script.
+Idempotent: any existing LLM footer in the prefilled body= param is stripped
+before the authoritative footer is appended (via strip_llm_footer.strip_llm_footer).
 """
 
 import os
 import re
 import sys
 import urllib.parse
+
+from strip_llm_footer import strip_llm_footer
 
 body = os.environ["BODY_IN"]
 footer = os.environ["FOOTER_TEXT"]
@@ -32,6 +31,7 @@ def rewrite(match):
     new_qs = []
     for k, v in qs:
         if k == "body":
+            v = strip_llm_footer(v)
             if default_attr.search(v):
                 v = default_attr.sub("\n\n" + footer, v)
             else:

--- a/.github/scripts/strip_llm_footer.py
+++ b/.github/scripts/strip_llm_footer.py
@@ -1,0 +1,28 @@
+"""Strip a trailing LLM footer from a comment body.
+
+Reads from stdin, writes the stripped body to stdout.  Idempotent: a body
+with no LLM footer passes through unchanged.
+
+Stripped pattern (anchored to end-of-string):
+    <newlines> [--- <newlines>] LLM: <rest-of-line> <trailing-whitespace>
+
+The pattern is anchored to end-of-string (\\Z) so an "LLM:" token elsewhere in the body
+(e.g. inside a code block) is preserved.
+"""
+
+import re
+import sys
+
+_LLM_FOOTER = re.compile(
+    r"\n+(?:---\n+)?LLM:[^\n]*\s*\Z",
+    re.MULTILINE,
+)
+
+
+def strip_llm_footer(body: str) -> str:
+    return _LLM_FOOTER.sub("", body)
+
+
+if __name__ == "__main__":
+    body = sys.stdin.read()
+    sys.stdout.write(strip_llm_footer(body))

--- a/.github/scripts/test_rewrite_create_pr_link.py
+++ b/.github/scripts/test_rewrite_create_pr_link.py
@@ -91,10 +91,23 @@ class RewriteCreatePRLinkTest(unittest.TestCase):
         # decode the whole output to count occurrences across both links.
         self.assertEqual(urllib.parse.unquote(out).count("LLM:"), 2)
 
-    def test_non_idempotent_without_shell_guard(self):
-        """Documents the idempotency caveat: running twice appends twice.
-        The shell guard in claude.yml (grep -q 'LLM:') is what
-        prevents this in production."""
+    def test_replaces_stale_llm_footer_in_prefilled_body(self):
+        """Simulates Claude having written a wrong effort into the PR body.
+        The rewriter must replace it, not append a second footer."""
+        stale_footer = "---\nLLM: Claude Opus 4.7 (1M) | medium"
+        pr_body = f"## Summary\n- did a thing\n\n{stale_footer}"
+        encoded = urllib.parse.quote(pr_body, safe="")
+        comment = f"[Create PR](https://github.com/owner/repo/compare/main...feat?quick_pull=1&body={encoded})"
+
+        out = run(comment)
+        new_body = extract_body_param(out)
+
+        self.assertTrue(new_body.endswith(FOOTER), msg=f"Body did not end with footer:\n{new_body}")
+        self.assertEqual(new_body.count("LLM:"), 1)
+        self.assertIn("## Summary", new_body)
+
+    def test_idempotent(self):
+        """Running twice produces the same result as running once."""
         pr_body = "## Summary"
         encoded = urllib.parse.quote(pr_body, safe="")
         comment = f"[x](https://github.com/owner/repo/compare/main...feat?quick_pull=1&body={encoded})"
@@ -102,8 +115,10 @@ class RewriteCreatePRLinkTest(unittest.TestCase):
         once = run(comment)
         twice = run(once)
 
-        self.assertEqual(urllib.parse.unquote(once).count("LLM:"), 1)
-        self.assertEqual(urllib.parse.unquote(twice).count("LLM:"), 2)
+        self.assertEqual(
+            extract_body_param(once),
+            extract_body_param(twice),
+        )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_strip_llm_footer.py
+++ b/.github/scripts/test_strip_llm_footer.py
@@ -1,0 +1,49 @@
+"""Unit tests for strip_llm_footer.py.
+
+Run: python3 .github/scripts/test_strip_llm_footer.py
+"""
+
+import sys
+import os
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from strip_llm_footer import strip_llm_footer
+
+
+class StripLLMFooterTest(unittest.TestCase):
+    def test_strips_footer_with_separator(self):
+        body = "## Summary\n- did a thing\n\n---\nLLM: Claude Opus 4.7 (1M) | medium"
+        self.assertEqual(strip_llm_footer(body), "## Summary\n- did a thing")
+
+    def test_strips_footer_without_separator(self):
+        body = "## Summary\n- did a thing\n\nLLM: Claude Opus 4.7 (1M) | high"
+        self.assertEqual(strip_llm_footer(body), "## Summary\n- did a thing")
+
+    def test_strips_footer_with_trailing_whitespace(self):
+        body = "## Summary\n\n---\nLLM: Claude Opus 4.7 (1M) | high\n\n"
+        self.assertEqual(strip_llm_footer(body), "## Summary")
+
+    def test_passthrough_when_no_footer(self):
+        body = "## Summary\n- did a thing"
+        self.assertEqual(strip_llm_footer(body), body)
+
+    def test_passthrough_empty(self):
+        self.assertEqual(strip_llm_footer(""), "")
+
+    def test_does_not_strip_llm_mid_body(self):
+        body = "Use LLM: Claude for this.\n\n## Summary\n- details"
+        self.assertEqual(strip_llm_footer(body), body)
+
+    def test_idempotent(self):
+        body = "## Summary\n\n---\nLLM: Claude Opus 4.7 (1M) | high"
+        stripped = strip_llm_footer(body)
+        self.assertEqual(strip_llm_footer(stripped), stripped)
+
+    def test_multiple_newlines_before_footer(self):
+        body = "## Summary\n\n\n\n---\nLLM: Claude Opus 4.7 (1M) | medium"
+        self.assertEqual(strip_llm_footer(body), "## Summary")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -218,12 +218,12 @@ jobs:
             exit 0
           fi
 
-          if echo "$BODY" | grep -q "LLM:"; then
-            echo "Footer already present"
-            exit 0
-          fi
+          # Strip any stale LLM footer Claude may have written (it doesn't know
+          # the real --effort value, so it guesses). The workflow is authoritative.
+          BODY=$(printf '%s' "$BODY" | python3 .github/scripts/strip_llm_footer.py)
 
           TODAY=$(date -u +%Y%m%d)
+
           USAGE=$(npx --yes ccusage@latest session --json --since "$TODAY" --order desc 2>/tmp/ccusage-err || echo "[]")
           [ -s /tmp/ccusage-err ] && echo "ccusage stderr: $(cat /tmp/ccusage-err)"
           COST=$(printf '%s' "$USAGE" | jq -r 'if .sessions and (.sessions | length) > 0 then .sessions[0] | "Tokens: \(.inputTokens // 0) in / \(.outputTokens // 0) out | Cache: \(.cacheReadTokens // 0) read / \(.cacheCreationTokens // 0) written | Cost: $\(.totalCost // 0 | . * 100 | round / 100)" else "" end' 2>/dev/null || true)


### PR DESCRIPTION
## Summary

- Claude proactively appends an `LLM: <model> | <effort>` footer to its own comments (it learned the convention from `CLAUDE.md`), but it has no access to the `--effort` flag it was invoked with — so it guesses, producing mismatches (e.g. "medium" when the run used "high").
- The previous idempotency guard in the "Append LLM footer" step (`grep -q "LLM:" → exit 0`) preserved Claude's wrong guess instead of overwriting it.

## Changes

- **`strip_llm_footer.py`** (new): stdin→stdout utility that strips any trailing `(---\n)?LLM: …` block. Regex is end-of-string anchored so mid-body `LLM:` tokens (e.g. in code blocks) are preserved.
- **`rewrite_create_pr_link.py`**: calls `strip_llm_footer` on the prefilled `body=` query param before appending the authoritative footer. The Create-PR link's pre-filled PR description is now also corrected.
- **`claude.yml`**: replaced the `grep -q "LLM:" → exit 0` guard with `BODY=$(printf '%s' "$BODY" | python3 .github/scripts/strip_llm_footer.py)`. The workflow is now always authoritative.
- **Tests**: 8 new tests in `test_strip_llm_footer.py`; `test_rewrite_create_pr_link.py` gains a stale-footer regression case and a true idempotency test (replaces the old "documents non-idempotency" caveat test).

## Test plan

- [ ] `python3 .github/scripts/test_strip_llm_footer.py` — 8 tests pass
- [ ] `python3 .github/scripts/test_rewrite_create_pr_link.py` — 7 tests pass (including new stale-footer + idempotency cases)
- [ ] Trigger `@claude` on a PR and confirm the comment ends with the workflow-resolved effort level even when Claude's response body already contains a different `LLM:` footer

---
LLM: Claude Sonnet 4.6 | high