### PR TITLE
[codex] Add TradingView CSV export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@
 - Fees: `CalculatePlatformSpotFee(platform, value)` (HL 0.035%, RH 0%, BinanceUS 0.1%); `CalculatePlatformFuturesFee(sc, contracts)`.
 - Position ownership: `Position.OwnerStrategyID`; `syncHyperliquidAccountPositions` reconciles with owner only.
 - **State is SQLite-only** (`scheduler/state.db`, `cfg.DBFile`). Legacy JSON paths removed. Trades persist immediately via `RecordTrade` → `StateDB.InsertTrade`. `ClosedPositions` flushed atomically by `SaveState`. Leaderboard built on-demand (`BuildLeaderboardMessages`).
+- **TradingView export:** if the user says "export data to TradingView", first ask which strategy IDs to export or whether to export all strategies. Use `./go-trader export tradingview --strategy <id> --output <file>` for one or more selected strategies, or `./go-trader export tradingview --all --output <file>`. Exports are sourced from SQLite trades and may require `tradingview_export.symbol_overrides` for platforms/symbols without a safe built-in TradingView mapping.
 - **Map iteration:** ALWAYS `sort.Strings(keys)` before formatting any operator-facing or test-asserted output. Go map iteration is randomized.
 - `cfg.Discord.Channels` / `Telegram.Channels` / `DMChannels` are `map[string]string`; keys: `spot`, `options`, `<platform>`, `<platform>-paper`. `cfg.Discord.OwnerID` from `DISCORD_OWNER_ID` env var (priority over config).
 - `cfg.SummaryFrequency map[string]string`: Go duration / alias (`hourly`, `daily`, `every`/`per_check`/`always`) / empty (legacy). `ShouldPostSummary(..., hasTrades)` — `hasTrades=true` always forces a post.

--- a/SKILL.md
+++ b/SKILL.md
@@ -18,6 +18,7 @@ Quick flow for a new server: tell OpenClaw `install https://github.com/richkuo/g
 - State is SQLite only: default `scheduler/state.db`.
 - Never store secrets in config files. Put Discord and exchange credentials in systemd environment variables.
 - Prefer `./go-trader init` for humans and `./go-trader init --json ... --output scheduler/config.json` for agents/scripts.
+- When a user asks to export data to TradingView, ask which strategy IDs to export or whether to export all strategies before running the export.
 
 ---
 
@@ -212,6 +213,28 @@ curl -s localhost:8099/history
 If Discord is enabled, wait for the first cycle and verify messages in configured channels.
 
 Report success to the user with mode, number of strategies, status URL, and log command.
+
+---
+
+## TradingView Export
+
+Export recorded SQLite trades to a TradingView portfolio transaction-import CSV:
+
+```bash
+./go-trader export tradingview --strategy hl-btc-momentum --output tradingview-hl-btc-momentum.csv
+./go-trader export tradingview --strategy hl-btc-momentum --strategy okx-eth-breakout --output tradingview-selected.csv
+./go-trader export tradingview --all --output tradingview-all.csv
+```
+
+The CSV contains TradingView's import header: `Symbol,Side,Qty,Status,Fill Price,Commission,Closing Time`. Built-in mappings cover known OKX and BinanceUS crypto pairs. Add `tradingview_export.symbol_overrides` when a platform/symbol cannot be safely mapped:
+
+```json
+"tradingview_export": {
+  "symbol_overrides": {
+    "hl:BTC": "BYBIT:BTCUSDT"
+  }
+}
+```
 
 ---
 

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -61,6 +61,12 @@ type LeaderboardSummaryConfig struct {
 	Frequency string `json:"frequency,omitempty"` // optional: Go duration like "6h"; empty = on-demand only
 }
 
+// TradingViewExportConfig controls optional symbol mappings for TradingView
+// portfolio CSV exports.
+type TradingViewExportConfig struct {
+	SymbolOverrides map[string]string `json:"symbol_overrides,omitempty"` // keys may be strategy:symbol, platform:symbol, or symbol
+}
+
 // ParsedFrequency returns the parsed duration of Frequency, or 0 if empty/invalid.
 // Validation catches invalid values at startup; callers can treat 0 as "disabled".
 func (lc LeaderboardSummaryConfig) ParsedFrequency() time.Duration {
@@ -103,6 +109,7 @@ type Config struct {
 	LeaderboardSummaries []LeaderboardSummaryConfig `json:"leaderboard_summaries,omitempty"` // #308 — configurable per-channel leaderboards
 	SummaryFrequency     map[string]string          `json:"summary_frequency,omitempty"`     // #30 — per-channel summary cadence; keys match Discord/Telegram channel keys (e.g. "spot", "options", "hyperliquid"). Values: Go duration ("30m", "2h"), alias ("hourly", "every"/"per_check"/"always"), or empty for legacy default (continuous: every cycle; spot: hourly)
 	RiskFreeRate         *float64                   `json:"risk_free_rate,omitempty"`        // #397 — annualized risk-free rate used in Sharpe-ratio calculations (e.g. 0.02 for 2%). Nil/missing falls back to DefaultAnnualRiskFreeRate; an explicit 0 is respected so backtest comparisons can pin to a 0% benchmark.
+	TradingViewExport    TradingViewExportConfig    `json:"tradingview_export,omitempty"`    // #3 — optional symbol overrides for TradingView portfolio CSV exports
 }
 
 // ParseSummaryFrequency converts a summary_frequency value to a duration.
@@ -720,6 +727,16 @@ func ValidateConfig(cfg *Config) error {
 		}
 		if _, err := ParseSummaryFrequency(v); err != nil {
 			errs = append(errs, fmt.Sprintf("summary_frequency[%q]: %v", k, err))
+		}
+	}
+
+	for k, v := range cfg.TradingViewExport.SymbolOverrides {
+		if strings.TrimSpace(k) == "" {
+			errs = append(errs, "tradingview_export.symbol_overrides: empty key")
+			continue
+		}
+		if !strings.Contains(strings.TrimSpace(v), ":") {
+			errs = append(errs, fmt.Sprintf("tradingview_export.symbol_overrides[%q]: value must be in EXCHANGE:TICKER format, got %q", k, v))
 		}
 	}
 

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -1155,15 +1154,6 @@ func (sdb *StateDB) QueryTradingViewExportTrades(strategyIDs []string) ([]Trade,
 	if trades == nil {
 		trades = []Trade{}
 	}
-	sort.SliceStable(trades, func(i, j int) bool {
-		if !trades[i].Timestamp.Equal(trades[j].Timestamp) {
-			return trades[i].Timestamp.Before(trades[j].Timestamp)
-		}
-		if trades[i].StrategyID != trades[j].StrategyID {
-			return trades[i].StrategyID < trades[j].StrategyID
-		}
-		return trades[i].Symbol < trades[j].Symbol
-	})
 	return trades, nil
 }
 

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -1111,6 +1112,59 @@ func (sdb *StateDB) QueryTradeHistory(strategyID, symbol string, since, until ti
 		trades = []Trade{}
 	}
 	return trades, total, nil
+}
+
+// QueryTradingViewExportTrades returns all trades for the given strategies in
+// chronological order for deterministic CSV export.
+func (sdb *StateDB) QueryTradingViewExportTrades(strategyIDs []string) ([]Trade, error) {
+	if sdb == nil || sdb.db == nil {
+		return nil, fmt.Errorf("state db unavailable")
+	}
+	if len(strategyIDs) == 0 {
+		return nil, fmt.Errorf("at least one strategy id is required")
+	}
+	placeholders := make([]string, len(strategyIDs))
+	args := make([]interface{}, 0, len(strategyIDs))
+	for i, id := range strategyIDs {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	query := fmt.Sprintf(`SELECT timestamp, strategy_id, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee
+		FROM trades
+		WHERE strategy_id IN (%s)
+		ORDER BY timestamp ASC, strategy_id ASC, symbol ASC, rowid ASC`, strings.Join(placeholders, ","))
+	rows, err := sdb.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query TradingView export trades: %w", err)
+	}
+	defer rows.Close()
+
+	var trades []Trade
+	for rows.Next() {
+		var t Trade
+		var tsStr string
+		if err := rows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee); err != nil {
+			return nil, fmt.Errorf("scan TradingView export trade: %w", err)
+		}
+		t.Timestamp = parseTime(tsStr)
+		trades = append(trades, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate TradingView export trades: %w", err)
+	}
+	if trades == nil {
+		trades = []Trade{}
+	}
+	sort.SliceStable(trades, func(i, j int) bool {
+		if !trades[i].Timestamp.Equal(trades[j].Timestamp) {
+			return trades[i].Timestamp.Before(trades[j].Timestamp)
+		}
+		if trades[i].StrategyID != trades[j].StrategyID {
+			return trades[i].StrategyID < trades[j].StrategyID
+		}
+		return trades[i].Symbol < trades[j].Symbol
+	})
+	return trades, nil
 }
 
 // formatTime converts a time.Time to RFC 3339 string, or "" for zero time.

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -14,8 +14,13 @@ import (
 )
 
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "init" {
-		os.Exit(runInit(os.Args[2:]))
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "init":
+			os.Exit(runInit(os.Args[2:]))
+		case "export":
+			os.Exit(runExport(os.Args[2:]))
+		}
 	}
 
 	configPath := flag.String("config", "scheduler/config.json", "Path to config file")

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1106,7 +1106,7 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 			Price:      price,
 			Value:      value,
 			TradeType:  tradeType,
-			Details:    fmt.Sprintf("Circuit breaker force-close, PnL: $%.2f", pnl),
+			Details:    fmt.Sprintf("Circuit breaker close %s, PnL: $%.2f", pos.Side, pnl),
 		}
 		RecordTrade(s, trade)
 		RecordTradeResult(&s.RiskState, pnl)

--- a/scheduler/tradingview_export.go
+++ b/scheduler/tradingview_export.go
@@ -1,0 +1,381 @@
+package main
+
+import (
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var tradingViewCSVHeader = []string{"Symbol", "Side", "Qty", "Status", "Fill Price", "Commission", "Closing Time"}
+
+type repeatedStringFlag []string
+
+func (f *repeatedStringFlag) String() string {
+	return strings.Join(*f, ",")
+}
+
+func (f *repeatedStringFlag) Set(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("strategy id cannot be empty")
+	}
+	*f = append(*f, value)
+	return nil
+}
+
+type tradingViewExportOptions struct {
+	All         bool
+	StrategyIDs []string
+	OutputPath  string
+}
+
+func runExport(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "Usage: go-trader export tradingview [--config scheduler/config.json] (--all | --strategy <id>...) --output <file>")
+		return 2
+	}
+	switch args[0] {
+	case "tradingview":
+		return runTradingViewExport(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown export target %q\n", args[0])
+		return 2
+	}
+}
+
+func runTradingViewExport(args []string) int {
+	fs := flag.NewFlagSet("export tradingview", flag.ContinueOnError)
+	configPath := fs.String("config", "scheduler/config.json", "Path to config file")
+	outputPath := fs.String("output", "", "Output CSV path")
+	all := fs.Bool("all", false, "Export all configured strategies with trade data")
+	var strategyIDs repeatedStringFlag
+	fs.Var(&strategyIDs, "strategy", "Strategy ID to export; may be specified multiple times")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintf(os.Stderr, "Unexpected arguments: %s\n", strings.Join(fs.Args(), " "))
+		return 2
+	}
+
+	cfg, err := LoadConfig(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load config: %v\n", err)
+		return 1
+	}
+	stateDB, err := OpenStateDB(cfg.DBFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to open state DB: %v\n", err)
+		return 1
+	}
+	defer stateDB.Close()
+
+	n, err := exportTradingViewCSVFile(stateDB, cfg, tradingViewExportOptions{
+		All:         *all,
+		StrategyIDs: []string(strategyIDs),
+		OutputPath:  *outputPath,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "TradingView export failed: %v\n", err)
+		return 1
+	}
+	fmt.Printf("Exported %d TradingView transaction rows to %s\n", n, *outputPath)
+	return 0
+}
+
+func exportTradingViewCSVFile(stateDB *StateDB, cfg *Config, opts tradingViewExportOptions) (int, error) {
+	if strings.TrimSpace(opts.OutputPath) == "" {
+		return 0, fmt.Errorf("--output is required")
+	}
+	strategies, err := selectTradingViewExportStrategies(cfg, opts)
+	if err != nil {
+		return 0, err
+	}
+	ids := make([]string, 0, len(strategies))
+	for _, sc := range strategies {
+		ids = append(ids, sc.ID)
+	}
+	trades, err := stateDB.QueryTradingViewExportTrades(ids)
+	if err != nil {
+		return 0, err
+	}
+	rows, err := buildTradingViewCSVRows(strategies, trades, cfg.TradingViewExport.SymbolOverrides, !opts.All)
+	if err != nil {
+		return 0, err
+	}
+	f, err := os.Create(opts.OutputPath)
+	if err != nil {
+		return 0, fmt.Errorf("create output CSV: %w", err)
+	}
+	defer f.Close()
+	if err := writeTradingViewCSV(f, rows); err != nil {
+		return 0, err
+	}
+	return len(rows), nil
+}
+
+func selectTradingViewExportStrategies(cfg *Config, opts tradingViewExportOptions) ([]StrategyConfig, error) {
+	if opts.All && len(opts.StrategyIDs) > 0 {
+		return nil, fmt.Errorf("use either --all or --strategy, not both")
+	}
+	if !opts.All && len(opts.StrategyIDs) == 0 {
+		return nil, fmt.Errorf("choose --all or at least one --strategy")
+	}
+
+	byID := make(map[string]StrategyConfig, len(cfg.Strategies))
+	for _, sc := range cfg.Strategies {
+		byID[sc.ID] = sc
+	}
+	if opts.All {
+		ids := make([]string, 0, len(byID))
+		for id := range byID {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		out := make([]StrategyConfig, 0, len(ids))
+		for _, id := range ids {
+			out = append(out, byID[id])
+		}
+		if len(out) == 0 {
+			return nil, fmt.Errorf("no configured strategies to export")
+		}
+		return out, nil
+	}
+
+	seen := make(map[string]bool, len(opts.StrategyIDs))
+	out := make([]StrategyConfig, 0, len(opts.StrategyIDs))
+	for _, id := range opts.StrategyIDs {
+		id = strings.TrimSpace(id)
+		if seen[id] {
+			continue
+		}
+		sc, ok := byID[id]
+		if !ok {
+			return nil, fmt.Errorf("strategy %q is not in config", id)
+		}
+		seen[id] = true
+		out = append(out, sc)
+	}
+	return out, nil
+}
+
+func buildTradingViewCSVRows(strategies []StrategyConfig, trades []Trade, overrides map[string]string, requireEachStrategy bool) ([][]string, error) {
+	byID := make(map[string]StrategyConfig, len(strategies))
+	required := make(map[string]bool, len(strategies))
+	for _, sc := range strategies {
+		byID[sc.ID] = sc
+		required[sc.ID] = true
+	}
+
+	var rows [][]string
+	seenTrades := make(map[string]int, len(strategies))
+	for _, trade := range trades {
+		sc, ok := byID[trade.StrategyID]
+		if !ok {
+			continue
+		}
+		row, err := tradingViewCSVRow(sc, trade, overrides)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, row)
+		seenTrades[trade.StrategyID]++
+	}
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("no trade data found for selected strategies")
+	}
+	if requireEachStrategy {
+		var missing []string
+		for id := range required {
+			if seenTrades[id] == 0 {
+				missing = append(missing, id)
+			}
+		}
+		sort.Strings(missing)
+		if len(missing) > 0 {
+			return nil, fmt.Errorf("no trade data found for strategy %s", strings.Join(missing, ", "))
+		}
+	}
+	return rows, nil
+}
+
+func tradingViewCSVRow(sc StrategyConfig, trade Trade, overrides map[string]string) ([]string, error) {
+	side := strings.ToLower(strings.TrimSpace(trade.Side))
+	if side != "buy" && side != "sell" {
+		return nil, fmt.Errorf("strategy %s trade at %s has unsupported side %q", trade.StrategyID, formatTime(trade.Timestamp), trade.Side)
+	}
+	if trade.Quantity <= 0 {
+		return nil, fmt.Errorf("strategy %s trade at %s has non-positive quantity %g", trade.StrategyID, formatTime(trade.Timestamp), trade.Quantity)
+	}
+	if trade.Price <= 0 {
+		return nil, fmt.Errorf("strategy %s trade at %s has non-positive price %g", trade.StrategyID, formatTime(trade.Timestamp), trade.Price)
+	}
+	tvSymbol, err := tradingViewSymbol(sc, trade, overrides)
+	if err != nil {
+		return nil, err
+	}
+	commission := trade.ExchangeFee
+	if commission < 0 {
+		commission = -commission
+	}
+	return []string{
+		tvSymbol,
+		side,
+		formatTradingViewFloat(trade.Quantity),
+		"Filled",
+		formatTradingViewFloat(trade.Price),
+		formatTradingViewFloat(commission),
+		formatTradingViewTime(trade.Timestamp),
+	}, nil
+}
+
+func writeTradingViewCSV(w io.Writer, rows [][]string) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write(tradingViewCSVHeader); err != nil {
+		return fmt.Errorf("write CSV header: %w", err)
+	}
+	for _, row := range rows {
+		if err := cw.Write(row); err != nil {
+			return fmt.Errorf("write CSV row: %w", err)
+		}
+	}
+	cw.Flush()
+	if err := cw.Error(); err != nil {
+		return fmt.Errorf("flush CSV: %w", err)
+	}
+	return nil
+}
+
+func tradingViewSymbol(sc StrategyConfig, trade Trade, overrides map[string]string) (string, error) {
+	if symbol := findTradingViewSymbolOverride(sc, trade, overrides); symbol != "" {
+		return symbol, nil
+	}
+	raw := strings.TrimSpace(trade.Symbol)
+	if raw == "" {
+		return "", fmt.Errorf("strategy %s trade has empty symbol", trade.StrategyID)
+	}
+	if strings.Contains(raw, ":") {
+		return strings.ToUpper(raw), nil
+	}
+	ticker := normalizeTradingViewTicker(raw)
+	if ticker == "" {
+		return "", fmt.Errorf("strategy %s trade has invalid symbol %q", trade.StrategyID, trade.Symbol)
+	}
+
+	platform := strings.ToLower(strings.TrimSpace(sc.Platform))
+	tradeType := strings.ToLower(strings.TrimSpace(trade.TradeType))
+	if tradeType == "" {
+		tradeType = strings.ToLower(strings.TrimSpace(sc.Type))
+	}
+	switch platform {
+	case "binanceus":
+		if isLikelyCryptoPair(ticker) {
+			return "BINANCEUS:" + ticker, nil
+		}
+	case "okx":
+		if strings.Contains(strings.ToUpper(raw), "SWAP") || tradeType == "perps" {
+			if base, quote, ok := splitCryptoPair(raw); ok {
+				return "OKX:" + base + quote + ".P", nil
+			}
+		}
+		if isLikelyCryptoPair(ticker) {
+			return "OKX:" + ticker, nil
+		}
+	}
+	return "", fmt.Errorf("no TradingView symbol mapping for strategy %s platform=%q symbol=%q; add tradingview_export.symbol_overrides", sc.ID, sc.Platform, trade.Symbol)
+}
+
+func findTradingViewSymbolOverride(sc StrategyConfig, trade Trade, overrides map[string]string) string {
+	if len(overrides) == 0 {
+		return ""
+	}
+	raw := strings.TrimSpace(trade.Symbol)
+	normalized := normalizeTradingViewTicker(raw)
+	platforms := platformOverrideAliases(sc.Platform)
+	candidates := []string{
+		sc.ID + ":" + raw,
+		sc.ID + ":" + normalized,
+	}
+	for _, platform := range platforms {
+		candidates = append(candidates,
+			platform+":"+raw,
+			platform+":"+normalized,
+		)
+	}
+	candidates = append(candidates, raw, normalized)
+	for _, key := range candidates {
+		if value := strings.TrimSpace(overrides[key]); value != "" {
+			return strings.ToUpper(value)
+		}
+	}
+	return ""
+}
+
+func platformOverrideAliases(platform string) []string {
+	p := strings.ToLower(strings.TrimSpace(platform))
+	switch p {
+	case "hyperliquid":
+		return []string{"hyperliquid", "hl"}
+	case "binanceus":
+		return []string{"binanceus", "bus"}
+	default:
+		if p == "" {
+			return nil
+		}
+		return []string{p}
+	}
+}
+
+func normalizeTradingViewTicker(symbol string) string {
+	s := strings.ToUpper(strings.TrimSpace(symbol))
+	replacer := strings.NewReplacer("/", "", "-", "", "_", "", " ", "")
+	return replacer.Replace(s)
+}
+
+func isLikelyCryptoPair(ticker string) bool {
+	for _, quote := range []string{"USDT", "USD", "USDC", "BTC", "ETH"} {
+		if strings.HasSuffix(ticker, quote) && len(ticker) > len(quote) {
+			return true
+		}
+	}
+	return false
+}
+
+func splitCryptoPair(symbol string) (string, string, bool) {
+	parts := strings.FieldsFunc(strings.ToUpper(strings.TrimSpace(symbol)), func(r rune) bool {
+		return r == '/' || r == '-' || r == '_' || r == ' '
+	})
+	filtered := parts[:0]
+	for _, part := range parts {
+		if part != "" && part != "SWAP" && part != "PERP" && part != "PERPS" {
+			filtered = append(filtered, part)
+		}
+	}
+	if len(filtered) >= 2 {
+		return filtered[0], filtered[1], true
+	}
+	ticker := normalizeTradingViewTicker(symbol)
+	for _, quote := range []string{"USDT", "USDC", "USD"} {
+		if strings.HasSuffix(ticker, quote) && len(ticker) > len(quote) {
+			return strings.TrimSuffix(ticker, quote), quote, true
+		}
+	}
+	return "", "", false
+}
+
+func formatTradingViewFloat(v float64) string {
+	return strconv.FormatFloat(v, 'f', -1, 64)
+}
+
+func formatTradingViewTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format("2006-01-02 15:04:05")
+}

--- a/scheduler/tradingview_export.go
+++ b/scheduler/tradingview_export.go
@@ -137,6 +137,9 @@ func selectTradingViewExportStrategies(cfg *Config, opts tradingViewExportOption
 
 	byID := make(map[string]StrategyConfig, len(cfg.Strategies))
 	for _, sc := range cfg.Strategies {
+		if _, dup := byID[sc.ID]; dup {
+			return nil, fmt.Errorf("config has duplicate strategy id %q", sc.ID)
+		}
 		byID[sc.ID] = sc
 	}
 	if opts.All {
@@ -218,10 +221,10 @@ func tradingViewCSVRow(sc StrategyConfig, trade Trade, overrides map[string]stri
 		return nil, err
 	}
 	if trade.Quantity <= 0 {
-		return nil, fmt.Errorf("strategy %s trade at %s has non-positive quantity %g", trade.StrategyID, formatTime(trade.Timestamp), trade.Quantity)
+		return nil, fmt.Errorf("strategy %s trade %s at %s has non-positive quantity %g", trade.StrategyID, tradingViewTradeRef(trade), formatTime(trade.Timestamp), trade.Quantity)
 	}
 	if trade.Price <= 0 {
-		return nil, fmt.Errorf("strategy %s trade at %s has non-positive price %g", trade.StrategyID, formatTime(trade.Timestamp), trade.Price)
+		return nil, fmt.Errorf("strategy %s trade %s at %s has non-positive price %g", trade.StrategyID, tradingViewTradeRef(trade), formatTime(trade.Timestamp), trade.Price)
 	}
 	tvSymbol, err := tradingViewSymbol(sc, trade, overrides)
 	if err != nil {
@@ -248,10 +251,29 @@ func tradingViewSide(sc StrategyConfig, trade Trade) (string, error) {
 		if strings.EqualFold(trade.TradeType, "options") || strings.EqualFold(sc.Type, "options") {
 			return tradingViewOptionCloseSide(trade)
 		}
-		return "", fmt.Errorf("strategy %s trade at %s has close side without persisted position direction; cannot map to TradingView buy/sell", trade.StrategyID, formatTime(trade.Timestamp))
+		// Close trades from circuit-breaker / portfolio paths encode the
+		// position direction in Details ("Close long" / "Close short"); see
+		// risk.go and portfolio.go. Closing a long → sell, closing a short → buy.
+		details := strings.ToLower(trade.Details)
+		switch {
+		case strings.Contains(details, "close long"):
+			return "sell", nil
+		case strings.Contains(details, "close short"):
+			return "buy", nil
+		}
+		return "", fmt.Errorf("strategy %s trade %s at %s has close side without persisted position direction; cannot map to TradingView buy/sell", trade.StrategyID, tradingViewTradeRef(trade), formatTime(trade.Timestamp))
 	default:
-		return "", fmt.Errorf("strategy %s trade at %s has unsupported side %q", trade.StrategyID, formatTime(trade.Timestamp), trade.Side)
+		return "", fmt.Errorf("strategy %s trade %s at %s has unsupported side %q", trade.StrategyID, tradingViewTradeRef(trade), formatTime(trade.Timestamp), trade.Side)
 	}
+}
+
+// tradingViewTradeRef returns a short reference (exchange order id when set,
+// otherwise the symbol) to make export-error logs traceable.
+func tradingViewTradeRef(trade Trade) string {
+	if id := strings.TrimSpace(trade.ExchangeOrderID); id != "" {
+		return "order=" + id
+	}
+	return "symbol=" + strings.TrimSpace(trade.Symbol)
 }
 
 func tradingViewOptionCloseSide(trade Trade) (string, error) {

--- a/scheduler/tradingview_export.go
+++ b/scheduler/tradingview_export.go
@@ -14,6 +14,8 @@ import (
 
 var tradingViewCSVHeader = []string{"Symbol", "Side", "Qty", "Status", "Fill Price", "Commission", "Closing Time"}
 
+var tradingViewCryptoQuotes = []string{"USDT", "USDC", "USD", "BTC", "ETH"}
+
 type repeatedStringFlag []string
 
 func (f *repeatedStringFlag) String() string {
@@ -85,7 +87,7 @@ func runTradingViewExport(args []string) int {
 		fmt.Fprintf(os.Stderr, "TradingView export failed: %v\n", err)
 		return 1
 	}
-	fmt.Printf("Exported %d TradingView transaction rows to %s\n", n, *outputPath)
+	fmt.Fprintf(os.Stderr, "Exported %d TradingView transaction rows to %s\n", n, *outputPath)
 	return 0
 }
 
@@ -108,6 +110,11 @@ func exportTradingViewCSVFile(stateDB *StateDB, cfg *Config, opts tradingViewExp
 	rows, err := buildTradingViewCSVRows(strategies, trades, cfg.TradingViewExport.SymbolOverrides, !opts.All)
 	if err != nil {
 		return 0, err
+	}
+	if _, err := os.Stat(opts.OutputPath); err == nil {
+		fmt.Fprintf(os.Stderr, "[WARN] overwriting existing TradingView CSV: %s\n", opts.OutputPath)
+	} else if !os.IsNotExist(err) {
+		return 0, fmt.Errorf("check output CSV: %w", err)
 	}
 	f, err := os.Create(opts.OutputPath)
 	if err != nil {
@@ -206,9 +213,9 @@ func buildTradingViewCSVRows(strategies []StrategyConfig, trades []Trade, overri
 }
 
 func tradingViewCSVRow(sc StrategyConfig, trade Trade, overrides map[string]string) ([]string, error) {
-	side := strings.ToLower(strings.TrimSpace(trade.Side))
-	if side != "buy" && side != "sell" {
-		return nil, fmt.Errorf("strategy %s trade at %s has unsupported side %q", trade.StrategyID, formatTime(trade.Timestamp), trade.Side)
+	side, err := tradingViewSide(sc, trade)
+	if err != nil {
+		return nil, err
 	}
 	if trade.Quantity <= 0 {
 		return nil, fmt.Errorf("strategy %s trade at %s has non-positive quantity %g", trade.StrategyID, formatTime(trade.Timestamp), trade.Quantity)
@@ -221,9 +228,6 @@ func tradingViewCSVRow(sc StrategyConfig, trade Trade, overrides map[string]stri
 		return nil, err
 	}
 	commission := trade.ExchangeFee
-	if commission < 0 {
-		commission = -commission
-	}
 	return []string{
 		tvSymbol,
 		side,
@@ -233,6 +237,38 @@ func tradingViewCSVRow(sc StrategyConfig, trade Trade, overrides map[string]stri
 		formatTradingViewFloat(commission),
 		formatTradingViewTime(trade.Timestamp),
 	}, nil
+}
+
+func tradingViewSide(sc StrategyConfig, trade Trade) (string, error) {
+	side := strings.ToLower(strings.TrimSpace(trade.Side))
+	switch side {
+	case "buy", "sell":
+		return side, nil
+	case "close":
+		if strings.EqualFold(trade.TradeType, "options") || strings.EqualFold(sc.Type, "options") {
+			return tradingViewOptionCloseSide(trade)
+		}
+		return "", fmt.Errorf("strategy %s trade at %s has close side without persisted position direction; cannot map to TradingView buy/sell", trade.StrategyID, formatTime(trade.Timestamp))
+	default:
+		return "", fmt.Errorf("strategy %s trade at %s has unsupported side %q", trade.StrategyID, formatTime(trade.Timestamp), trade.Side)
+	}
+}
+
+func tradingViewOptionCloseSide(trade Trade) (string, error) {
+	parts := strings.FieldsFunc(strings.ToLower(strings.TrimSpace(trade.Symbol)), func(r rune) bool {
+		return r == '-' || r == '_' || r == ' '
+	})
+	for _, part := range parts {
+		switch part {
+		case "sell", "short", "sold":
+			return "buy", nil
+		case "buy", "long", "bought":
+			return "sell", nil
+		}
+	}
+	// Legacy long-option position IDs do not include action; closing a bought
+	// option is a sell transaction in TradingView.
+	return "sell", nil
 }
 
 func writeTradingViewCSV(w io.Writer, rows [][]string) error {
@@ -324,6 +360,18 @@ func platformOverrideAliases(platform string) []string {
 		return []string{"hyperliquid", "hl"}
 	case "binanceus":
 		return []string{"binanceus", "bus"}
+	case "robinhood":
+		return []string{"robinhood", "rh"}
+	case "topstep":
+		return []string{"topstep", "ts"}
+	case "deribit":
+		return []string{"deribit"}
+	case "ibkr":
+		return []string{"ibkr"}
+	case "okx":
+		return []string{"okx"}
+	case "luno":
+		return []string{"luno"}
 	default:
 		if p == "" {
 			return nil
@@ -339,7 +387,7 @@ func normalizeTradingViewTicker(symbol string) string {
 }
 
 func isLikelyCryptoPair(ticker string) bool {
-	for _, quote := range []string{"USDT", "USD", "USDC", "BTC", "ETH"} {
+	for _, quote := range tradingViewCryptoQuotes {
 		if strings.HasSuffix(ticker, quote) && len(ticker) > len(quote) {
 			return true
 		}
@@ -351,6 +399,7 @@ func splitCryptoPair(symbol string) (string, string, bool) {
 	parts := strings.FieldsFunc(strings.ToUpper(strings.TrimSpace(symbol)), func(r rune) bool {
 		return r == '/' || r == '-' || r == '_' || r == ' '
 	})
+	// Filter instrument suffixes so BTC-USDT-SWAP becomes BTC/USDT.
 	filtered := parts[:0]
 	for _, part := range parts {
 		if part != "" && part != "SWAP" && part != "PERP" && part != "PERPS" {
@@ -361,7 +410,7 @@ func splitCryptoPair(symbol string) (string, string, bool) {
 		return filtered[0], filtered[1], true
 	}
 	ticker := normalizeTradingViewTicker(symbol)
-	for _, quote := range []string{"USDT", "USDC", "USD"} {
+	for _, quote := range tradingViewCryptoQuotes {
 		if strings.HasSuffix(ticker, quote) && len(ticker) > len(quote) {
 			return strings.TrimSuffix(ticker, quote), quote, true
 		}

--- a/scheduler/tradingview_export_test.go
+++ b/scheduler/tradingview_export_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTradingViewExportRowsSelectedStrategies(t *testing.T) {
+	ts := time.Date(2026, 4, 28, 12, 34, 56, 0, time.UTC)
+	strategies := []StrategyConfig{
+		{ID: "okx-btc", Platform: "okx", Type: "spot"},
+		{ID: "bus-eth", Platform: "binanceus", Type: "spot"},
+	}
+	trades := []Trade{
+		{Timestamp: ts, StrategyID: "okx-btc", Symbol: "BTC/USDT", Side: "buy", Quantity: 0.25, Price: 60000, ExchangeFee: 1.5},
+		{Timestamp: ts.Add(time.Minute), StrategyID: "bus-eth", Symbol: "ETH/USDT", Side: "sell", Quantity: 2, Price: 3200},
+	}
+
+	rows, err := buildTradingViewCSVRows(strategies, trades, nil, true)
+	if err != nil {
+		t.Fatalf("buildTradingViewCSVRows: %v", err)
+	}
+	want := [][]string{
+		{"OKX:BTCUSDT", "buy", "0.25", "Filled", "60000", "1.5", "2026-04-28 12:34:56"},
+		{"BINANCEUS:ETHUSDT", "sell", "2", "Filled", "3200", "0", "2026-04-28 12:35:56"},
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("rows len = %d, want %d", len(rows), len(want))
+	}
+	for i := range want {
+		for j := range want[i] {
+			if rows[i][j] != want[i][j] {
+				t.Fatalf("rows[%d][%d] = %q, want %q (rows=%v)", i, j, rows[i][j], want[i][j], rows)
+			}
+		}
+	}
+}
+
+func TestTradingViewExportRowsExplicitStrategyRequiresData(t *testing.T) {
+	strategies := []StrategyConfig{
+		{ID: "okx-btc", Platform: "okx", Type: "spot"},
+		{ID: "bus-eth", Platform: "binanceus", Type: "spot"},
+	}
+	trades := []Trade{
+		{Timestamp: time.Now().UTC(), StrategyID: "okx-btc", Symbol: "BTC/USDT", Side: "buy", Quantity: 1, Price: 60000},
+	}
+
+	_, err := buildTradingViewCSVRows(strategies, trades, nil, true)
+	if err == nil || !strings.Contains(err.Error(), "bus-eth") {
+		t.Fatalf("expected missing strategy data error for bus-eth, got %v", err)
+	}
+}
+
+func TestTradingViewSymbolOverridesAndUnsupported(t *testing.T) {
+	trade := Trade{StrategyID: "hl-btc", Symbol: "BTC"}
+	symbol, err := tradingViewSymbol(
+		StrategyConfig{ID: "hl-btc", Platform: "hyperliquid", Type: "perps"},
+		trade,
+		map[string]string{"hl:BTC": "BYBIT:BTCUSDT"},
+	)
+	if err != nil {
+		t.Fatalf("tradingViewSymbol override: %v", err)
+	}
+	if symbol != "BYBIT:BTCUSDT" {
+		t.Fatalf("symbol = %q, want BYBIT:BTCUSDT", symbol)
+	}
+
+	_, err = tradingViewSymbol(StrategyConfig{ID: "rh-aapl", Platform: "robinhood", Type: "spot"}, Trade{StrategyID: "rh-aapl", Symbol: "AAPL"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "symbol_overrides") {
+		t.Fatalf("expected unsupported mapping error, got %v", err)
+	}
+}
+
+func TestQueryTradingViewExportTradesChronological(t *testing.T) {
+	db := openTestDB(t)
+	t1 := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	t2 := t1.Add(time.Minute)
+	if err := db.InsertTrade("s1", Trade{Timestamp: t2, Symbol: "ETH/USDT", Side: "buy", Quantity: 1, Price: 3000}); err != nil {
+		t.Fatalf("InsertTrade t2: %v", err)
+	}
+	if err := db.InsertTrade("s1", Trade{Timestamp: t1, Symbol: "BTC/USDT", Side: "buy", Quantity: 1, Price: 60000}); err != nil {
+		t.Fatalf("InsertTrade t1: %v", err)
+	}
+	if err := db.InsertTrade("s2", Trade{Timestamp: t1, Symbol: "SOL/USDT", Side: "buy", Quantity: 1, Price: 150}); err != nil {
+		t.Fatalf("InsertTrade s2: %v", err)
+	}
+
+	trades, err := db.QueryTradingViewExportTrades([]string{"s1"})
+	if err != nil {
+		t.Fatalf("QueryTradingViewExportTrades: %v", err)
+	}
+	if len(trades) != 2 {
+		t.Fatalf("trades len = %d, want 2", len(trades))
+	}
+	if trades[0].Symbol != "BTC/USDT" || trades[1].Symbol != "ETH/USDT" {
+		t.Fatalf("trades not chronological or filtered: %+v", trades)
+	}
+}
+
+func TestWriteTradingViewCSV(t *testing.T) {
+	var buf bytes.Buffer
+	rows := [][]string{{"OKX:BTCUSDT", "buy", "1", "Filled", "60000", "0", "2026-04-28 12:00:00"}}
+	if err := writeTradingViewCSV(&buf, rows); err != nil {
+		t.Fatalf("writeTradingViewCSV: %v", err)
+	}
+	got := buf.String()
+	if !strings.HasPrefix(got, "Symbol,Side,Qty,Status,Fill Price,Commission,Closing Time\n") {
+		t.Fatalf("missing TradingView header, got:\n%s", got)
+	}
+	if !strings.Contains(got, "OKX:BTCUSDT,buy,1,Filled,60000,0,2026-04-28 12:00:00\n") {
+		t.Fatalf("missing row, got:\n%s", got)
+	}
+}
+
+func TestExportTradingViewCSVFileEndToEnd(t *testing.T) {
+	db := openTestDB(t)
+	ts := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	if err := db.InsertTrade("okx-btc", Trade{Timestamp: ts, Symbol: "BTC/USDT", Side: "buy", Quantity: 1, Price: 60000}); err != nil {
+		t.Fatalf("InsertTrade: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "tradingview.csv")
+	cfg := &Config{
+		Strategies: []StrategyConfig{{ID: "okx-btc", Platform: "okx", Type: "spot"}},
+	}
+
+	n, err := exportTradingViewCSVFile(db, cfg, tradingViewExportOptions{All: true, OutputPath: out})
+	if err != nil {
+		t.Fatalf("exportTradingViewCSVFile: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("exported rows = %d, want 1", n)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(data), "OKX:BTCUSDT,buy,1,Filled,60000,0,2026-04-28 12:00:00") {
+		t.Fatalf("unexpected CSV:\n%s", data)
+	}
+}

--- a/scheduler/tradingview_export_test.go
+++ b/scheduler/tradingview_export_test.go
@@ -156,6 +156,52 @@ func TestTradingViewCloseSideUnsupportedWithoutDirection(t *testing.T) {
 	}
 }
 
+func TestTradingViewCloseSideFromDetailsDirection(t *testing.T) {
+	ts := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	closeLong, err := tradingViewCSVRow(
+		StrategyConfig{ID: "okx-btc", Platform: "okx", Type: "spot"},
+		Trade{
+			Timestamp: ts, StrategyID: "okx-btc", Symbol: "BTC/USDT", Side: "close",
+			Quantity: 1, Price: 60000, TradeType: "spot",
+			Details: "Circuit breaker close long, PnL: $-50.00",
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("close-long row: %v", err)
+	}
+	if closeLong[1] != "sell" {
+		t.Fatalf("close-long side = %q, want sell", closeLong[1])
+	}
+
+	closeShort, err := tradingViewCSVRow(
+		StrategyConfig{ID: "hl-btc", Platform: "hyperliquid", Type: "perps"},
+		Trade{
+			Timestamp: ts, StrategyID: "hl-btc", Symbol: "BTC", Side: "close",
+			Quantity: 1, Price: 60000, TradeType: "perps",
+			Details: "Circuit breaker close short, PnL: $-50.00",
+		},
+		map[string]string{"hl:BTC": "OKX:BTCUSDT.P"},
+	)
+	if err != nil {
+		t.Fatalf("close-short row: %v", err)
+	}
+	if closeShort[1] != "buy" {
+		t.Fatalf("close-short side = %q, want buy", closeShort[1])
+	}
+}
+
+func TestTradingViewExportRejectsDuplicateStrategyID(t *testing.T) {
+	cfg := &Config{Strategies: []StrategyConfig{
+		{ID: "okx-btc", Platform: "okx", Type: "spot"},
+		{ID: "okx-btc", Platform: "okx", Type: "spot"},
+	}}
+	_, err := selectTradingViewExportStrategies(cfg, tradingViewExportOptions{All: true, OutputPath: "/tmp/out.csv"})
+	if err == nil || !strings.Contains(err.Error(), "duplicate strategy id") {
+		t.Fatalf("expected duplicate strategy id error, got %v", err)
+	}
+}
+
 func TestTradingViewCSVRowPreservesNegativeCommission(t *testing.T) {
 	row, err := tradingViewCSVRow(
 		StrategyConfig{ID: "okx-btc", Platform: "okx", Type: "spot"},

--- a/scheduler/tradingview_export_test.go
+++ b/scheduler/tradingview_export_test.go
@@ -75,6 +75,119 @@ func TestTradingViewSymbolOverridesAndUnsupported(t *testing.T) {
 	}
 }
 
+func TestTradingViewSymbolOverridePriorityAndAliases(t *testing.T) {
+	trade := Trade{StrategyID: "rh-aapl", Symbol: "AAPL"}
+	overrides := map[string]string{
+		"AAPL":         "NASDAQ:AAPL",
+		"rh:AAPL":      "NYSE:AAPL",
+		"rh-aapl:AAPL": "AMEX:AAPL",
+	}
+	symbol, err := tradingViewSymbol(StrategyConfig{ID: "rh-aapl", Platform: "robinhood", Type: "spot"}, trade, overrides)
+	if err != nil {
+		t.Fatalf("tradingViewSymbol: %v", err)
+	}
+	if symbol != "AMEX:AAPL" {
+		t.Fatalf("symbol = %q, want strategy-specific override AMEX:AAPL", symbol)
+	}
+
+	delete(overrides, "rh-aapl:AAPL")
+	symbol, err = tradingViewSymbol(StrategyConfig{ID: "rh-aapl", Platform: "robinhood", Type: "spot"}, trade, overrides)
+	if err != nil {
+		t.Fatalf("tradingViewSymbol alias: %v", err)
+	}
+	if symbol != "NYSE:AAPL" {
+		t.Fatalf("symbol = %q, want rh alias override NYSE:AAPL", symbol)
+	}
+}
+
+func TestTradingViewPerpsSymbol(t *testing.T) {
+	symbol, err := tradingViewSymbol(
+		StrategyConfig{ID: "okx-btc-perp", Platform: "okx", Type: "perps"},
+		Trade{StrategyID: "okx-btc-perp", Symbol: "BTC-USDT-SWAP", TradeType: "perps"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("tradingViewSymbol perps: %v", err)
+	}
+	if symbol != "OKX:BTCUSDT.P" {
+		t.Fatalf("symbol = %q, want OKX:BTCUSDT.P", symbol)
+	}
+}
+
+func TestTradingViewOptionCloseSide(t *testing.T) {
+	ts := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	sc := StrategyConfig{ID: "opt", Platform: "deribit", Type: "options"}
+	overrides := map[string]string{
+		"BTC-call-50000-2026-05-01":      "DERIBIT:BTC-1MAY26-50000-C",
+		"BTC-call-sell-50000-2026-05-01": "DERIBIT:BTC-1MAY26-50000-C",
+	}
+
+	longClose, err := tradingViewCSVRow(sc, Trade{
+		Timestamp: ts, StrategyID: "opt", Symbol: "BTC-call-50000-2026-05-01", Side: "close",
+		Quantity: 1, Price: 100, TradeType: "options",
+	}, overrides)
+	if err != nil {
+		t.Fatalf("long option close row: %v", err)
+	}
+	if longClose[1] != "sell" {
+		t.Fatalf("long option close side = %q, want sell", longClose[1])
+	}
+
+	shortClose, err := tradingViewCSVRow(sc, Trade{
+		Timestamp: ts, StrategyID: "opt", Symbol: "BTC-call-sell-50000-2026-05-01", Side: "close",
+		Quantity: 1, Price: 100, TradeType: "options",
+	}, overrides)
+	if err != nil {
+		t.Fatalf("short option close row: %v", err)
+	}
+	if shortClose[1] != "buy" {
+		t.Fatalf("short option close side = %q, want buy", shortClose[1])
+	}
+}
+
+func TestTradingViewCloseSideUnsupportedWithoutDirection(t *testing.T) {
+	_, err := tradingViewCSVRow(
+		StrategyConfig{ID: "spot", Platform: "okx", Type: "spot"},
+		Trade{Timestamp: time.Now().UTC(), StrategyID: "spot", Symbol: "BTC/USDT", Side: "close", Quantity: 1, Price: 60000, TradeType: "spot"},
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "persisted position direction") {
+		t.Fatalf("expected close-side direction error, got %v", err)
+	}
+}
+
+func TestTradingViewCSVRowPreservesNegativeCommission(t *testing.T) {
+	row, err := tradingViewCSVRow(
+		StrategyConfig{ID: "okx-btc", Platform: "okx", Type: "spot"},
+		Trade{Timestamp: time.Now().UTC(), StrategyID: "okx-btc", Symbol: "BTC/USDT", Side: "buy", Quantity: 1, Price: 60000, ExchangeFee: -0.25},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("tradingViewCSVRow: %v", err)
+	}
+	if row[5] != "-0.25" {
+		t.Fatalf("commission = %q, want -0.25", row[5])
+	}
+}
+
+func TestTradingViewExportAllAllowsZeroTradeStrategies(t *testing.T) {
+	strategies := []StrategyConfig{
+		{ID: "okx-btc", Platform: "okx", Type: "spot"},
+		{ID: "bus-eth", Platform: "binanceus", Type: "spot"},
+	}
+	trades := []Trade{
+		{Timestamp: time.Now().UTC(), StrategyID: "okx-btc", Symbol: "BTC/USDT", Side: "buy", Quantity: 1, Price: 60000},
+	}
+
+	rows, err := buildTradingViewCSVRows(strategies, trades, nil, false)
+	if err != nil {
+		t.Fatalf("buildTradingViewCSVRows all: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows len = %d, want 1", len(rows))
+	}
+}
+
 func TestQueryTradingViewExportTradesChronological(t *testing.T) {
 	db := openTestDB(t)
 	t1 := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary

- add `go-trader export tradingview` for selected-strategy and all-strategy CSV exports
- source export rows from SQLite trade history with deterministic chronological ordering
- add TradingView CSV formatting, built-in OKX/BinanceUS crypto symbol mapping, and configurable symbol overrides for unsupported mappings
- document the agent workflow for asking which strategies to export before producing TradingView data

Closes #3

## Validation

```bash
env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test -run 'TestTradingView|TestQueryTradingViewExport'
env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...
env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler build .
```

LLM: Codex GPT-5 | medium