### PR TITLE
discord: compact strategy summary column widths

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -237,7 +237,7 @@ const discordSplitThreshold = 1980
 // the table is continued in a follow-up message. Sized so the rendered table
 // (including header/sep/totals) plus the base summary header and the per-channel
 // position section stays under the 2000-char limit (#381 added #T, #434 added
-// W/L, and #436 added Max DD; 15 rows remains within the Discord limit).
+// W/L, and #436 added DD; 15 rows remains within the Discord limit).
 const catTableMaxRows = 15
 
 // FormatCategorySummary creates Discord messages for a set of strategies sharing a channel.
@@ -773,13 +773,13 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 	}
 	sb.WriteString("\n```\n")
 	if showWalletPct {
-		sep := strings.Repeat("-", 92)
-		sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %6s %8s %5s %5s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Max DD", "Wallet%", "Tf", "Int", "#T", "W/L"))
+		sep := strings.Repeat("-", 84)
+		sb.WriteString(fmt.Sprintf("%-14s %9s %6s %6s %7s %6s %8s %5s %4s %4s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "DD", "Wallet%", "Tf", "Int", "#T", "W/L"))
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {
 			label := bot.id
-			if len(label) > 16 {
-				label = label[:16]
+			if len(label) > 14 {
+				label = label[:14]
 			}
 			valStr := fmtComma(bot.value)
 			initStr := fmtComma(bot.initialCap)
@@ -791,7 +791,7 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 				wpStr = fmt.Sprintf("%.1f%%", bot.walletPct)
 			}
 			wlStr := fmtWinLossRatio(bot.winningTrades, bot.losingTrades)
-			sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %6s %8s %5s %5s %5d %5s\n", label, initStr, valStr, pnlStr, pctStr, maxDDStr, wpStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
+			sb.WriteString(fmt.Sprintf("%-14s %9s %6s %6s %7s %6s %8s %5s %4s %4d %5s\n", label, initStr, valStr, pnlStr, pctStr, maxDDStr, wpStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
 		}
 		if includeTotals {
 			sb.WriteString(sep + "\n")
@@ -800,16 +800,16 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 			totPnlStr := fmtPnl(totalPnl)
 			totPctStr := fmtPnlPct(totalPnlPct)
 			totWlStr := fmtWinLossRatio(totalWins, totalLosses)
-			sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %6s %8s %5s %5s %5d %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", "100.0%", "", "", totalClosed, totWlStr))
+			sb.WriteString(fmt.Sprintf("%-14s %9s %6s %6s %7s %6s %8s %5s %4s %4d %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", "100.0%", "", "", totalClosed, totWlStr))
 		}
 	} else {
-		sep := strings.Repeat("-", 83)
-		sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %6s %5s %5s %5s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "Max DD", "Tf", "Int", "#T", "W/L"))
+		sep := strings.Repeat("-", 75)
+		sb.WriteString(fmt.Sprintf("%-14s %9s %6s %6s %7s %6s %5s %4s %4s %5s\n", "Strategy", "Init", "Value", "PnL", "PnL%", "DD", "Tf", "Int", "#T", "W/L"))
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {
 			label := bot.id
-			if len(label) > 16 {
-				label = label[:16]
+			if len(label) > 14 {
+				label = label[:14]
 			}
 			valStr := fmtComma(bot.value)
 			initStr := fmtComma(bot.initialCap)
@@ -817,7 +817,7 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 			pctStr := fmtPnlPct(bot.pnlPct)
 			wlStr := fmtWinLossRatio(bot.winningTrades, bot.losingTrades)
 			maxDDStr := fmtDrawdownPct(bot.maxDrawdownPct)
-			sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %6s %5s %5s %5d %5s\n", label, initStr, valStr, pnlStr, pctStr, maxDDStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
+			sb.WriteString(fmt.Sprintf("%-14s %9s %6s %6s %7s %6s %5s %4s %4d %5s\n", label, initStr, valStr, pnlStr, pctStr, maxDDStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
 		}
 		if includeTotals {
 			sb.WriteString(sep + "\n")
@@ -826,7 +826,7 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 			totPnlStr := fmtPnl(totalPnl)
 			totPctStr := fmtPnlPct(totalPnlPct)
 			totWlStr := fmtWinLossRatio(totalWins, totalLosses)
-			sb.WriteString(fmt.Sprintf("%-16s %9s %9s %7s %7s %6s %5s %5s %5d %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", "", "", totalClosed, totWlStr))
+			sb.WriteString(fmt.Sprintf("%-14s %9s %6s %6s %7s %6s %5s %4s %4d %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", "", "", totalClosed, totWlStr))
 		}
 	}
 	sb.WriteString("```\n")
@@ -897,7 +897,7 @@ func fmtDrawdownPct(pct float64) string {
 	if pct <= 0 {
 		return "n/a"
 	}
-	return fmt.Sprintf("%.1f%%", pct)
+	return fmt.Sprintf("%.0f%%", pct)
 }
 
 // collectPositions returns human-readable position lines for a strategy.

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -643,22 +643,22 @@ func TestFormatCategorySummary_MaxDrawdownColumn(t *testing.T) {
 	msgs := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
 	msg := strings.Join(msgs, "\n")
 
-	if !strings.Contains(msg, "Max DD") {
-		t.Errorf("expected Max DD column header, got:\n%s", msg)
+	if !strings.Contains(msg, " DD ") {
+		t.Errorf("expected DD column header, got:\n%s", msg)
 	}
 	pnlIdx := strings.Index(msg, "PnL%")
-	maxDDIdx := strings.Index(msg, "Max DD")
+	ddIdx := strings.Index(msg, " DD ")
 	tfIdx := strings.Index(msg, "Tf")
-	if pnlIdx < 0 || maxDDIdx < pnlIdx || tfIdx < maxDDIdx {
-		t.Errorf("expected Max DD column between PnL%% and Tf, got PnL%%@%d MaxDD@%d Tf@%d:\n%s", pnlIdx, maxDDIdx, tfIdx, msg)
+	if pnlIdx < 0 || ddIdx < pnlIdx || tfIdx < ddIdx {
+		t.Errorf("expected DD column between PnL%% and Tf, got PnL%%@%d DD@%d Tf@%d:\n%s", pnlIdx, ddIdx, tfIdx, msg)
 	}
-	if !strings.Contains(msg, "12.5%") || !strings.Contains(msg, "50.0%") {
-		t.Errorf("expected resolved max drawdown values 12.5%% and 50.0%%, got:\n%s", msg)
+	if !strings.Contains(msg, "12%") || !strings.Contains(msg, "50%") {
+		t.Errorf("expected resolved max drawdown values 12%% and 50%%, got:\n%s", msg)
 	}
 }
 
 func TestFormatCategorySummary_MaxDrawdownColumn_SharedWallet(t *testing.T) {
-	// Shared-wallet tables have a Wallet% column, so keep Max DD anchored before
+	// Shared-wallet tables have a Wallet% column, so keep DD anchored before
 	// it and keep the TOTAL wallet percentage from shifting.
 	strats := []StrategyConfig{
 		{ID: "hl-rmc-eth", Type: "perps", Platform: "hyperliquid", Capital: 500, CapitalPct: 0.5, Args: []string{"rmc", "ETH", "1h"}, MaxDrawdownPct: 25},
@@ -677,7 +677,7 @@ func TestFormatCategorySummary_MaxDrawdownColumn_SharedWallet(t *testing.T) {
 	lines := strings.Split(msg, "\n")
 	var headerLine, totalLine string
 	for _, line := range lines {
-		if strings.Contains(line, "Max DD") && strings.Contains(line, "Wallet%") {
+		if strings.Contains(line, " DD ") && strings.Contains(line, "Wallet%") {
 			headerLine = line
 		}
 		if strings.HasPrefix(line, "TOTAL") {
@@ -688,13 +688,13 @@ func TestFormatCategorySummary_MaxDrawdownColumn_SharedWallet(t *testing.T) {
 		t.Fatalf("expected shared-wallet header and TOTAL row, got:\n%s", msg)
 	}
 	pnlIdx := strings.Index(headerLine, "PnL%")
-	maxDDIdx := strings.Index(headerLine, "Max DD")
+	ddIdx := strings.Index(headerLine, " DD ")
 	walletIdx := strings.Index(headerLine, "Wallet%")
-	if pnlIdx < 0 || maxDDIdx < pnlIdx || walletIdx < maxDDIdx {
-		t.Errorf("expected Max DD column between PnL%% and Wallet%%, got PnL%%@%d MaxDD@%d Wallet%%@%d:\n%s", pnlIdx, maxDDIdx, walletIdx, msg)
+	if pnlIdx < 0 || ddIdx < pnlIdx || walletIdx < ddIdx {
+		t.Errorf("expected DD column between PnL%% and Wallet%%, got PnL%%@%d DD@%d Wallet%%@%d:\n%s", pnlIdx, ddIdx, walletIdx, msg)
 	}
-	if !strings.Contains(msg, "25.0%") || !strings.Contains(msg, "35.0%") {
-		t.Errorf("expected resolved max drawdown values 25.0%% and 35.0%%, got:\n%s", msg)
+	if !strings.Contains(msg, "25%") || !strings.Contains(msg, "35%") {
+		t.Errorf("expected resolved max drawdown values 25%% and 35%%, got:\n%s", msg)
 	}
 	if len(totalLine) <= walletIdx || !strings.Contains(totalLine[walletIdx:], "100.0%") {
 		t.Errorf("expected TOTAL row to keep 100.0%% under Wallet%% column, got header=%q total=%q", headerLine, totalLine)


### PR DESCRIPTION
Closes #444

### Summary
- Strategy column width 16→14
- Reduce Init→Value, Value→PnL, Tf→Int, Int→#T gaps
- Rename `Max DD` → `DD` + whole-number format (`25.0%` → `25%`

---
LLM: Claude Opus 4.7 (1M) | high | Tokens: 49 in / 28422 out | Cache: 2007283 read / 117511 written | Cost: $2.45