### PR TITLE
[codex] support SIGHUP config reload

### DIFF
--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// applyHotReloadConfig applies the subset of config fields that are safe to
+// mutate while the scheduler keeps running. The caller must hold mu.Lock when
+// invoking this from the main loop.
+func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNotifier, server *StatusServer) ([]string, error) {
+	if cfg == nil || next == nil {
+		return nil, fmt.Errorf("config reload requires current and next config")
+	}
+	if err := validateHotReloadCompatible(cfg, next); err != nil {
+		return nil, err
+	}
+
+	var changes []string
+	addChange := func(format string, args ...interface{}) {
+		changes = append(changes, fmt.Sprintf(format, args...))
+	}
+
+	if cfg.IntervalSeconds != next.IntervalSeconds {
+		addChange("interval_seconds: %d -> %d", cfg.IntervalSeconds, next.IntervalSeconds)
+		cfg.IntervalSeconds = next.IntervalSeconds
+	}
+
+	nextByID := strategyConfigByID(next.Strategies)
+	for i := range cfg.Strategies {
+		sc := &cfg.Strategies[i]
+		ns := nextByID[sc.ID]
+		oldCapital := sc.Capital
+
+		if sc.MaxDrawdownPct != ns.MaxDrawdownPct {
+			addChange("strategy[%s].max_drawdown_pct: %.2f%% -> %.2f%%", sc.ID, sc.MaxDrawdownPct, ns.MaxDrawdownPct)
+			sc.MaxDrawdownPct = ns.MaxDrawdownPct
+			if ss := stateStrategy(state, sc.ID); ss != nil {
+				ss.RiskState.MaxDrawdownPct = ns.MaxDrawdownPct
+			}
+		}
+		if sc.CapitalPct == 0 && sc.Capital != ns.Capital {
+			addChange("strategy[%s].capital: $%.2f -> $%.2f", sc.ID, sc.Capital, ns.Capital)
+			sc.Capital = ns.Capital
+			if ss := stateStrategy(state, sc.ID); ss != nil {
+				ss.Cash += ns.Capital - oldCapital
+			}
+		}
+		if sc.Leverage != ns.Leverage {
+			addChange("strategy[%s].leverage: %.2fx -> %.2fx", sc.ID, sc.Leverage, ns.Leverage)
+			sc.Leverage = ns.Leverage
+			if ss := stateStrategy(state, sc.ID); ss != nil && sc.Type == "perps" && ns.Leverage > 0 {
+				for _, pos := range ss.Positions {
+					if pos != nil {
+						pos.Leverage = ns.Leverage
+					}
+				}
+			}
+		}
+		if sc.IntervalSeconds != ns.IntervalSeconds {
+			addChange("strategy[%s].interval_seconds: %d -> %d", sc.ID, sc.IntervalSeconds, ns.IntervalSeconds)
+			sc.IntervalSeconds = ns.IntervalSeconds
+		}
+	}
+
+	if portfolioRiskMaxDrawdown(cfg.PortfolioRisk) != portfolioRiskMaxDrawdown(next.PortfolioRisk) {
+		addChange("portfolio_risk.max_drawdown_pct: %.2f%% -> %.2f%%",
+			portfolioRiskMaxDrawdown(cfg.PortfolioRisk), portfolioRiskMaxDrawdown(next.PortfolioRisk))
+	}
+	if portfolioRiskWarnThreshold(cfg.PortfolioRisk) != portfolioRiskWarnThreshold(next.PortfolioRisk) {
+		addChange("portfolio_risk.warn_threshold_pct: %.2f%% -> %.2f%%",
+			portfolioRiskWarnThreshold(cfg.PortfolioRisk), portfolioRiskWarnThreshold(next.PortfolioRisk))
+	}
+	cfg.PortfolioRisk = clonePortfolioRiskConfig(next.PortfolioRisk)
+
+	if !reflect.DeepEqual(cfg.Discord.Channels, next.Discord.Channels) {
+		addChange("discord.channels: %s -> %s", formatStringMap(cfg.Discord.Channels), formatStringMap(next.Discord.Channels))
+	}
+	if !reflect.DeepEqual(cfg.Discord.DMChannels, next.Discord.DMChannels) {
+		addChange("discord.dm_channels: %s -> %s", formatStringMap(cfg.Discord.DMChannels), formatStringMap(next.Discord.DMChannels))
+	}
+	if cfg.Discord.LeaderboardTopN != next.Discord.LeaderboardTopN {
+		addChange("discord.leaderboard_top_n: %d -> %d", cfg.Discord.LeaderboardTopN, next.Discord.LeaderboardTopN)
+	}
+	if cfg.Discord.LeaderboardChannel != next.Discord.LeaderboardChannel {
+		addChange("discord.leaderboard_channel: %q -> %q", cfg.Discord.LeaderboardChannel, next.Discord.LeaderboardChannel)
+	}
+	cfg.Discord.Channels = cloneStringMap(next.Discord.Channels)
+	cfg.Discord.DMChannels = cloneStringMap(next.Discord.DMChannels)
+	cfg.Discord.LeaderboardTopN = next.Discord.LeaderboardTopN
+	cfg.Discord.LeaderboardChannel = next.Discord.LeaderboardChannel
+
+	if !reflect.DeepEqual(cfg.Telegram.Channels, next.Telegram.Channels) {
+		addChange("telegram.channels: %s -> %s", formatStringMap(cfg.Telegram.Channels), formatStringMap(next.Telegram.Channels))
+	}
+	if !reflect.DeepEqual(cfg.Telegram.DMChannels, next.Telegram.DMChannels) {
+		addChange("telegram.dm_channels: %s -> %s", formatStringMap(cfg.Telegram.DMChannels), formatStringMap(next.Telegram.DMChannels))
+	}
+	cfg.Telegram.Channels = cloneStringMap(next.Telegram.Channels)
+	cfg.Telegram.DMChannels = cloneStringMap(next.Telegram.DMChannels)
+
+	if !reflect.DeepEqual(cfg.SummaryFrequency, next.SummaryFrequency) {
+		addChange("summary_frequency: %s -> %s", formatStringMap(cfg.SummaryFrequency), formatStringMap(next.SummaryFrequency))
+	}
+	cfg.SummaryFrequency = cloneStringMap(next.SummaryFrequency)
+
+	cfg.ConfigVersion = next.ConfigVersion
+	cfg.Platforms = next.Platforms
+
+	if notifier != nil {
+		notifier.ReloadConfig(cfg)
+	}
+	if server != nil {
+		server.UpdateStrategies(cfg.Strategies)
+	}
+
+	sort.Strings(changes)
+	return changes, nil
+}
+
+func validateHotReloadCompatible(cfg, next *Config) error {
+	var errs []string
+	if cfg.DBFile != next.DBFile {
+		errs = append(errs, fmt.Sprintf("db_file changed (%q -> %q; restart required)", cfg.DBFile, next.DBFile))
+	}
+	if cfg.LogDir != next.LogDir {
+		errs = append(errs, fmt.Sprintf("log_dir changed (%q -> %q; restart required)", cfg.LogDir, next.LogDir))
+	}
+	if cfg.StatusPort != next.StatusPort {
+		errs = append(errs, fmt.Sprintf("status_port changed (%d -> %d; restart required)", cfg.StatusPort, next.StatusPort))
+	}
+	if cfg.StatusToken != next.StatusToken {
+		errs = append(errs, "status token changed (restart required)")
+	}
+	if cfg.AutoUpdate != next.AutoUpdate {
+		errs = append(errs, fmt.Sprintf("auto_update changed (%q -> %q; restart required)", cfg.AutoUpdate, next.AutoUpdate))
+	}
+	if cfg.LeaderboardPostTime != next.LeaderboardPostTime {
+		errs = append(errs, fmt.Sprintf("leaderboard_post_time changed (%q -> %q; restart required)", cfg.LeaderboardPostTime, next.LeaderboardPostTime))
+	}
+	if !reflect.DeepEqual(cfg.Correlation, next.Correlation) {
+		errs = append(errs, "correlation changed (restart required)")
+	}
+	if !reflect.DeepEqual(cfg.LeaderboardSummaries, next.LeaderboardSummaries) {
+		errs = append(errs, "leaderboard_summaries changed (restart required)")
+	}
+	if !reflect.DeepEqual(cfg.RiskFreeRate, next.RiskFreeRate) {
+		errs = append(errs, "risk_free_rate changed (restart required)")
+	}
+	if !reflect.DeepEqual(cfg.TradingViewExport, next.TradingViewExport) {
+		errs = append(errs, "tradingview_export changed (restart required)")
+	}
+	if portfolioRiskMaxNotional(cfg.PortfolioRisk) != portfolioRiskMaxNotional(next.PortfolioRisk) {
+		errs = append(errs, fmt.Sprintf("portfolio_risk.max_notional_usd changed (%.2f -> %.2f; restart required)",
+			portfolioRiskMaxNotional(cfg.PortfolioRisk), portfolioRiskMaxNotional(next.PortfolioRisk)))
+	}
+	if cfg.Discord.Enabled != next.Discord.Enabled {
+		errs = append(errs, "discord.enabled changed (restart required)")
+	}
+	if cfg.Discord.Token != next.Discord.Token {
+		errs = append(errs, "discord.token changed (restart required)")
+	}
+	if cfg.Discord.OwnerID != next.Discord.OwnerID {
+		errs = append(errs, "discord.owner_id changed (restart required)")
+	}
+	if cfg.Telegram.Enabled != next.Telegram.Enabled {
+		errs = append(errs, "telegram.enabled changed (restart required)")
+	}
+	if cfg.Telegram.BotToken != next.Telegram.BotToken {
+		errs = append(errs, "telegram.bot_token changed (restart required)")
+	}
+	if cfg.Telegram.OwnerChatID != next.Telegram.OwnerChatID {
+		errs = append(errs, "telegram.owner_chat_id changed (restart required)")
+	}
+	if !sameStrategyIDSet(cfg.Strategies, next.Strategies) {
+		errs = append(errs, fmt.Sprintf("strategy set changed (current=%v next=%v; restart required)",
+			sortedStrategyIDs(cfg.Strategies), sortedStrategyIDs(next.Strategies)))
+	}
+
+	nextByID := strategyConfigByID(next.Strategies)
+	for _, sc := range cfg.Strategies {
+		ns, ok := nextByID[sc.ID]
+		if !ok {
+			continue
+		}
+		oldShape := strategyRestartShape(sc)
+		newShape := strategyRestartShape(ns)
+		if !reflect.DeepEqual(oldShape, newShape) {
+			errs = append(errs, fmt.Sprintf("strategy[%s] changed non-hot-reloadable fields (restart required)", sc.ID))
+		}
+	}
+
+	if len(errs) > 0 {
+		sort.Strings(errs)
+		return fmt.Errorf("config reload rejected:\n  %s", strings.Join(errs, "\n  "))
+	}
+	return nil
+}
+
+func strategyRestartShape(sc StrategyConfig) StrategyConfig {
+	sc.MaxDrawdownPct = 0
+	sc.Capital = 0
+	sc.Leverage = 0
+	sc.IntervalSeconds = 0
+	return sc
+}
+
+func strategyConfigByID(strategies []StrategyConfig) map[string]StrategyConfig {
+	out := make(map[string]StrategyConfig, len(strategies))
+	for _, sc := range strategies {
+		out[sc.ID] = sc
+	}
+	return out
+}
+
+func sameStrategyIDSet(a, b []StrategyConfig) bool {
+	aa := sortedStrategyIDs(a)
+	bb := sortedStrategyIDs(b)
+	return reflect.DeepEqual(aa, bb)
+}
+
+func sortedStrategyIDs(strategies []StrategyConfig) []string {
+	ids := make([]string, 0, len(strategies))
+	for _, sc := range strategies {
+		ids = append(ids, sc.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func stateStrategy(state *AppState, id string) *StrategyState {
+	if state == nil || state.Strategies == nil {
+		return nil
+	}
+	return state.Strategies[id]
+}
+
+func portfolioRiskMaxDrawdown(pr *PortfolioRiskConfig) float64 {
+	if pr == nil {
+		return 0
+	}
+	return pr.MaxDrawdownPct
+}
+
+func portfolioRiskWarnThreshold(pr *PortfolioRiskConfig) float64 {
+	if pr == nil {
+		return 0
+	}
+	return pr.WarnThresholdPct
+}
+
+func portfolioRiskMaxNotional(pr *PortfolioRiskConfig) float64 {
+	if pr == nil {
+		return 0
+	}
+	return pr.MaxNotionalUSD
+}
+
+func clonePortfolioRiskConfig(pr *PortfolioRiskConfig) *PortfolioRiskConfig {
+	if pr == nil {
+		return nil
+	}
+	cp := *pr
+	return &cp
+}
+
+func cloneStringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func formatStringMap(m map[string]string) string {
+	if len(m) == 0 {
+		return "{}"
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	ordered := make(map[string]string, len(m))
+	for _, k := range keys {
+		ordered[k] = m[k]
+	}
+	b, err := json.Marshal(ordered)
+	if err != nil {
+		return fmt.Sprintf("%v", m)
+	}
+	return string(b)
+}
+
+func schedulerTickSeconds(cfg *Config) int {
+	if cfg == nil {
+		return 60
+	}
+	tickSeconds := cfg.IntervalSeconds
+	for _, sc := range cfg.Strategies {
+		si := sc.IntervalSeconds
+		if si <= 0 {
+			si = cfg.IntervalSeconds
+		}
+		if si < tickSeconds {
+			tickSeconds = si
+		}
+	}
+	if tickSeconds < 60 {
+		tickSeconds = 60
+	}
+	return tickSeconds
+}

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -18,6 +18,9 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 	if err := validateHotReloadCompatible(cfg, next); err != nil {
 		return nil, err
 	}
+	if err := validateHotReloadStateCompatible(cfg, next, state); err != nil {
+		return nil, err
+	}
 
 	var changes []string
 	addChange := func(format string, args ...interface{}) {
@@ -200,6 +203,26 @@ func validateHotReloadCompatible(cfg, next *Config) error {
 	return nil
 }
 
+func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error {
+	var errs []string
+	nextByID := strategyConfigByID(next.Strategies)
+	for _, sc := range cfg.Strategies {
+		ns, ok := nextByID[sc.ID]
+		if !ok {
+			continue
+		}
+		if sc.Type == "perps" && sc.Leverage != ns.Leverage && strategyHasOpenPositions(stateStrategy(state, sc.ID)) {
+			errs = append(errs, fmt.Sprintf("strategy[%s] leverage changed with open positions (%.2fx -> %.2fx; flatten first or restart after close)",
+				sc.ID, sc.Leverage, ns.Leverage))
+		}
+	}
+	if len(errs) > 0 {
+		sort.Strings(errs)
+		return fmt.Errorf("config reload rejected:\n  %s", strings.Join(errs, "\n  "))
+	}
+	return nil
+}
+
 func strategyRestartShape(sc StrategyConfig) StrategyConfig {
 	sc.MaxDrawdownPct = 0
 	sc.Capital = 0
@@ -236,6 +259,23 @@ func stateStrategy(state *AppState, id string) *StrategyState {
 		return nil
 	}
 	return state.Strategies[id]
+}
+
+func strategyHasOpenPositions(s *StrategyState) bool {
+	if s == nil {
+		return false
+	}
+	for _, pos := range s.Positions {
+		if pos != nil && pos.Quantity > 0 {
+			return true
+		}
+	}
+	for _, pos := range s.OptionPositions {
+		if pos != nil && pos.Quantity != 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func portfolioRiskMaxDrawdown(pr *PortfolioRiskConfig) float64 {

--- a/scheduler/config_reload_test.go
+++ b/scheduler/config_reload_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestApplyHotReloadConfigAppliesAllowedFields(t *testing.T) {
+	cfg := &Config{
+		IntervalSeconds: 600,
+		DBFile:          "scheduler/state.db",
+		Discord: DiscordConfig{
+			Enabled:            true,
+			Channels:           map[string]string{"spot": "old-spot"},
+			DMChannels:         map[string]string{"binanceus-paper": "old-dm"},
+			LeaderboardTopN:    5,
+			LeaderboardChannel: "old-lb",
+		},
+		Telegram: TelegramConfig{
+			Enabled:    true,
+			Channels:   map[string]string{"spot": "old-tg"},
+			DMChannels: map[string]string{"binanceus-paper": "old-tg-dm"},
+		},
+		SummaryFrequency: map[string]string{"spot": "hourly"},
+		Strategies: []StrategyConfig{{
+			ID:              "spot-btc",
+			Type:            "spot",
+			Platform:        "binanceus",
+			Script:          "shared_scripts/check_strategy.py",
+			Args:            []string{"sma_crossover", "BTC/USDT", "1h"},
+			Capital:         1000,
+			MaxDrawdownPct:  20,
+			IntervalSeconds: 600,
+		}, {
+			ID:              "hl-eth",
+			Type:            "perps",
+			Platform:        "hyperliquid",
+			Script:          "shared_scripts/check_hyperliquid.py",
+			Args:            []string{"triple_ema_bidir", "ETH", "1h", "--mode=paper"},
+			Capital:         500,
+			MaxDrawdownPct:  50,
+			IntervalSeconds: 600,
+			Leverage:        2,
+		}},
+		PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 60},
+	}
+	next := &Config{
+		IntervalSeconds: 300,
+		DBFile:          "scheduler/state.db",
+		Discord: DiscordConfig{
+			Enabled:            true,
+			Channels:           map[string]string{"spot": "new-spot"},
+			DMChannels:         map[string]string{"binanceus-paper": "new-dm"},
+			LeaderboardTopN:    7,
+			LeaderboardChannel: "new-lb",
+		},
+		Telegram: TelegramConfig{
+			Enabled:    true,
+			Channels:   map[string]string{"spot": "new-tg"},
+			DMChannels: map[string]string{"binanceus-paper": "new-tg-dm"},
+		},
+		SummaryFrequency: map[string]string{"spot": "30m"},
+		Strategies: []StrategyConfig{{
+			ID:              "spot-btc",
+			Type:            "spot",
+			Platform:        "binanceus",
+			Script:          "shared_scripts/check_strategy.py",
+			Args:            []string{"sma_crossover", "BTC/USDT", "1h"},
+			Capital:         1200,
+			MaxDrawdownPct:  15,
+			IntervalSeconds: 300,
+		}, {
+			ID:              "hl-eth",
+			Type:            "perps",
+			Platform:        "hyperliquid",
+			Script:          "shared_scripts/check_hyperliquid.py",
+			Args:            []string{"triple_ema_bidir", "ETH", "1h", "--mode=paper"},
+			Capital:         700,
+			MaxDrawdownPct:  45,
+			IntervalSeconds: 900,
+			Leverage:        5,
+		}},
+		PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 30, WarnThresholdPct: 70},
+	}
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"spot-btc": {
+			ID: "spot-btc", Cash: 900,
+			RiskState: RiskState{MaxDrawdownPct: 20},
+		},
+		"hl-eth": {
+			ID: "hl-eth", Cash: 450,
+			RiskState: RiskState{MaxDrawdownPct: 50},
+			Positions: map[string]*Position{
+				"ETH": {Symbol: "ETH", Quantity: 1, Side: "long", AvgCost: 3000, Leverage: 2},
+			},
+		},
+	}}
+	mock := &mockNotifier{}
+	tgMock := &mockNotifier{}
+	notifier := NewMultiNotifier(
+		notifierBackend{notifier: mock, channels: cfg.Discord.Channels, dmChannels: cfg.Discord.DMChannels, leaderboardChannel: cfg.Discord.LeaderboardChannel},
+		notifierBackend{notifier: tgMock, channels: cfg.Telegram.Channels, dmChannels: cfg.Telegram.DMChannels, plainText: true},
+	)
+	server := NewStatusServer(state, nil, "", cfg.Strategies, nil)
+
+	changes, err := applyHotReloadConfig(cfg, next, state, notifier, server)
+	if err != nil {
+		t.Fatalf("applyHotReloadConfig returned error: %v", err)
+	}
+	if len(changes) == 0 {
+		t.Fatal("expected reload changes")
+	}
+	joined := strings.Join(changes, "\n")
+	for _, want := range []string{
+		"interval_seconds: 600 -> 300",
+		"strategy[spot-btc].capital: $1000.00 -> $1200.00",
+		"strategy[spot-btc].max_drawdown_pct: 20.00% -> 15.00%",
+		"strategy[hl-eth].leverage: 2.00x -> 5.00x",
+		"portfolio_risk.max_drawdown_pct: 25.00% -> 30.00%",
+		"discord.channels:",
+		"telegram.channels:",
+		"summary_frequency:",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("changes missing %q:\n%s", want, joined)
+		}
+	}
+	if cfg.IntervalSeconds != 300 {
+		t.Errorf("IntervalSeconds = %d, want 300", cfg.IntervalSeconds)
+	}
+	if cfg.Strategies[0].Capital != 1200 || cfg.Strategies[0].MaxDrawdownPct != 15 || cfg.Strategies[0].IntervalSeconds != 300 {
+		t.Errorf("spot config not reloaded: %+v", cfg.Strategies[0])
+	}
+	if cfg.Strategies[1].Leverage != 5 || cfg.Strategies[1].IntervalSeconds != 900 {
+		t.Errorf("perps config not reloaded: %+v", cfg.Strategies[1])
+	}
+	if got := state.Strategies["spot-btc"].Cash; got != 1100 {
+		t.Errorf("spot cash = %g, want 1100 (capital delta applied)", got)
+	}
+	if got := state.Strategies["spot-btc"].RiskState.MaxDrawdownPct; got != 15 {
+		t.Errorf("spot risk max drawdown = %g, want 15", got)
+	}
+	if got := state.Strategies["hl-eth"].Positions["ETH"].Leverage; got != 5 {
+		t.Errorf("position leverage = %g, want 5", got)
+	}
+
+	notifier.SendToChannel("binanceus", "spot", "hello")
+	if len(mock.messages) != 1 || mock.messages[0].channelID != "new-spot" {
+		t.Fatalf("discord channel not reloaded, messages=%#v", mock.messages)
+	}
+	if len(tgMock.messages) != 1 || tgMock.messages[0].channelID != "new-tg" {
+		t.Fatalf("telegram channel not reloaded, messages=%#v", tgMock.messages)
+	}
+	if server.strategies[0].Capital != 1200 {
+		t.Errorf("status server strategies not updated: %+v", server.strategies[0])
+	}
+}
+
+func TestApplyHotReloadConfigRejectsStrategySetChange(t *testing.T) {
+	cfg := minimalReloadConfig([]StrategyConfig{{
+		ID: "s1", Type: "spot", Platform: "binanceus", Script: "x.py", Capital: 100, MaxDrawdownPct: 10,
+	}})
+	next := minimalReloadConfig([]StrategyConfig{{
+		ID: "s1", Type: "spot", Platform: "binanceus", Script: "x.py", Capital: 200, MaxDrawdownPct: 10,
+	}, {
+		ID: "s2", Type: "spot", Platform: "binanceus", Script: "x.py", Capital: 100, MaxDrawdownPct: 10,
+	}})
+
+	_, err := applyHotReloadConfig(cfg, next, NewAppState(), nil, nil)
+	if err == nil {
+		t.Fatal("expected strategy set change to be rejected")
+	}
+	if !strings.Contains(err.Error(), "strategy set changed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Strategies[0].Capital != 100 {
+		t.Errorf("current config mutated after rejected reload: %+v", cfg.Strategies[0])
+	}
+}
+
+func TestApplyHotReloadConfigRejectsNonReloadableStrategyField(t *testing.T) {
+	cfg := minimalReloadConfig([]StrategyConfig{{
+		ID: "s1", Type: "spot", Platform: "binanceus", Script: "x.py", Args: []string{"a"}, Capital: 100, MaxDrawdownPct: 10,
+	}})
+	next := minimalReloadConfig([]StrategyConfig{{
+		ID: "s1", Type: "spot", Platform: "binanceus", Script: "y.py", Args: []string{"a"}, Capital: 200, MaxDrawdownPct: 10,
+	}})
+
+	_, err := applyHotReloadConfig(cfg, next, NewAppState(), nil, nil)
+	if err == nil {
+		t.Fatal("expected script change to be rejected")
+	}
+	if !strings.Contains(err.Error(), "non-hot-reloadable") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Strategies[0].Capital != 100 {
+		t.Errorf("current config mutated after rejected reload: %+v", cfg.Strategies[0])
+	}
+}
+
+func TestApplyHotReloadConfigPreservesRuntimeCapitalPctCapital(t *testing.T) {
+	cfg := minimalReloadConfig([]StrategyConfig{{
+		ID: "s1", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "BTC", "1h"}, Capital: 2500, CapitalPct: 0.5, MaxDrawdownPct: 10, Leverage: 2,
+	}})
+	next := minimalReloadConfig([]StrategyConfig{{
+		ID: "s1", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "BTC", "1h"}, Capital: 100, CapitalPct: 0.5, MaxDrawdownPct: 12, Leverage: 2,
+	}})
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"s1": {ID: "s1", Cash: 2400, RiskState: RiskState{MaxDrawdownPct: 10}},
+	}}
+
+	changes, err := applyHotReloadConfig(cfg, next, state, nil, nil)
+	if err != nil {
+		t.Fatalf("applyHotReloadConfig returned error: %v", err)
+	}
+	if cfg.Strategies[0].Capital != 2500 {
+		t.Errorf("runtime capital_pct capital = %g, want preserved 2500", cfg.Strategies[0].Capital)
+	}
+	if state.Strategies["s1"].Cash != 2400 {
+		t.Errorf("cash = %g, want preserved 2400", state.Strategies["s1"].Cash)
+	}
+	joined := strings.Join(changes, "\n")
+	if strings.Contains(joined, ".capital:") {
+		t.Fatalf("capital_pct fallback capital should not be hot-applied, changes:\n%s", joined)
+	}
+	if cfg.Strategies[0].MaxDrawdownPct != 12 || state.Strategies["s1"].RiskState.MaxDrawdownPct != 12 {
+		t.Fatalf("other hot-reloadable fields should still apply, cfg=%+v state=%+v", cfg.Strategies[0], state.Strategies["s1"].RiskState)
+	}
+}
+
+func minimalReloadConfig(strategies []StrategyConfig) *Config {
+	return &Config{
+		IntervalSeconds: 600,
+		DBFile:          "scheduler/state.db",
+		Discord:         DiscordConfig{Channels: map[string]string{}},
+		Telegram:        TelegramConfig{Channels: map[string]string{}},
+		Strategies:      strategies,
+		PortfolioRisk:   &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 60},
+	}
+}

--- a/scheduler/config_reload_test.go
+++ b/scheduler/config_reload_test.go
@@ -88,11 +88,9 @@ func TestApplyHotReloadConfigAppliesAllowedFields(t *testing.T) {
 			RiskState: RiskState{MaxDrawdownPct: 20},
 		},
 		"hl-eth": {
-			ID: "hl-eth", Cash: 450,
+			ID:        "hl-eth",
+			Cash:      450,
 			RiskState: RiskState{MaxDrawdownPct: 50},
-			Positions: map[string]*Position{
-				"ETH": {Symbol: "ETH", Quantity: 1, Side: "long", AvgCost: 3000, Leverage: 2},
-			},
 		},
 	}}
 	mock := &mockNotifier{}
@@ -140,10 +138,6 @@ func TestApplyHotReloadConfigAppliesAllowedFields(t *testing.T) {
 	if got := state.Strategies["spot-btc"].RiskState.MaxDrawdownPct; got != 15 {
 		t.Errorf("spot risk max drawdown = %g, want 15", got)
 	}
-	if got := state.Strategies["hl-eth"].Positions["ETH"].Leverage; got != 5 {
-		t.Errorf("position leverage = %g, want 5", got)
-	}
-
 	notifier.SendToChannel("binanceus", "spot", "hello")
 	if len(mock.messages) != 1 || mock.messages[0].channelID != "new-spot" {
 		t.Fatalf("discord channel not reloaded, messages=%#v", mock.messages)
@@ -195,6 +189,41 @@ func TestApplyHotReloadConfigRejectsNonReloadableStrategyField(t *testing.T) {
 	}
 	if cfg.Strategies[0].Capital != 100 {
 		t.Errorf("current config mutated after rejected reload: %+v", cfg.Strategies[0])
+	}
+}
+
+func TestApplyHotReloadConfigRejectsLeverageChangeWithOpenPerpsPosition(t *testing.T) {
+	cfg := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 2,
+	}})
+	next := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1200, MaxDrawdownPct: 12, Leverage: 5,
+	}})
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-eth": {
+			ID: "hl-eth", Cash: 900,
+			RiskState: RiskState{MaxDrawdownPct: 10},
+			Positions: map[string]*Position{
+				"ETH": {Symbol: "ETH", Quantity: 1, Side: "long", AvgCost: 3000, Leverage: 2},
+			},
+		},
+	}}
+
+	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
+	if err == nil {
+		t.Fatal("expected open perps leverage change to be rejected")
+	}
+	if !strings.Contains(err.Error(), "leverage changed with open positions") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Strategies[0].Capital != 1000 || cfg.Strategies[0].MaxDrawdownPct != 10 || cfg.Strategies[0].Leverage != 2 {
+		t.Fatalf("current config mutated after rejected reload: %+v", cfg.Strategies[0])
+	}
+	if state.Strategies["hl-eth"].Cash != 900 || state.Strategies["hl-eth"].RiskState.MaxDrawdownPct != 10 {
+		t.Fatalf("state mutated after rejected reload: %+v", state.Strategies["hl-eth"])
+	}
+	if state.Strategies["hl-eth"].Positions["ETH"].Leverage != 2 {
+		t.Fatalf("position leverage mutated after rejected reload: %+v", state.Strategies["hl-eth"].Positions["ETH"])
 	}
 }
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -310,6 +310,20 @@ func main() {
 		os.Exit(0)
 	}
 
+	reloadCh := make(chan struct{}, 1)
+	hupCh := make(chan os.Signal, 1)
+	signal.Notify(hupCh, syscall.SIGHUP)
+	defer signal.Stop(hupCh)
+	go func() {
+		for range hupCh {
+			select {
+			case reloadCh <- struct{}{}:
+			default:
+				fmt.Println("[reload] SIGHUP received while reload is pending; coalescing")
+			}
+		}
+	}()
+
 	// Config migration: DM owner about new fields if config is behind current version.
 	if cfg.ConfigVersion < CurrentConfigVersion {
 		go runConfigMigrationDM(cfg, notifier, *configPath)
@@ -336,22 +350,49 @@ func main() {
 	// the existing `mu` lock guards `state`, not `lastRun`.
 	lastRun := make(map[string]time.Time)
 
-	// Determine tick interval: GCD of all strategy intervals, min 60s
-	tickSeconds := cfg.IntervalSeconds
-	for _, sc := range cfg.Strategies {
-		si := sc.IntervalSeconds
-		if si <= 0 {
-			si = cfg.IntervalSeconds
-		}
-		if si < tickSeconds {
-			tickSeconds = si
-		}
-	}
-	if tickSeconds < 60 {
-		tickSeconds = 60
-	}
+	// Determine tick interval from configured strategy intervals, min 60s.
+	tickSeconds := schedulerTickSeconds(cfg)
 	fmt.Printf("Tick interval: %ds (strategies have individual intervals)\n", tickSeconds)
 	drawdownWarnThresholdPct := configuredDrawdownWarnThresholdPct(cfg)
+
+	reloadConfig := func() {
+		fmt.Printf("[reload] SIGHUP received; reloading config from %s\n", *configPath)
+		nextCfg, err := LoadConfig(*configPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[reload] ERROR: reload failed; keeping previous config: %v\n", err)
+			return
+		}
+		mu.Lock()
+		changes, err := applyHotReloadConfig(cfg, nextCfg, state, notifier, server)
+		if err != nil {
+			mu.Unlock()
+			fmt.Fprintf(os.Stderr, "[reload] ERROR: reload rejected; keeping previous config: %v\n", err)
+			return
+		}
+		tickSeconds = schedulerTickSeconds(cfg)
+		drawdownWarnThresholdPct = configuredDrawdownWarnThresholdPct(cfg)
+		mu.Unlock()
+
+		if len(changes) == 0 {
+			fmt.Println("[reload] Config reload applied: no hot-reloadable changes")
+		} else {
+			fmt.Printf("[reload] Config reload applied (%d changes):\n", len(changes))
+			for _, change := range changes {
+				fmt.Printf("[reload]   %s\n", change)
+			}
+		}
+		fmt.Printf("[reload] Tick interval now %ds\n", tickSeconds)
+	}
+	processConfigReloads := func() {
+		for {
+			select {
+			case <-reloadCh:
+				reloadConfig()
+			default:
+				return
+			}
+		}
+	}
 
 	// Wall-clock tracker for cfg.AutoUpdate == "daily". Initialized to now so
 	// the first daily check fires after 24h (matching the previous
@@ -367,6 +408,8 @@ func main() {
 
 	// Main loop
 	for {
+		processConfigReloads()
+
 		cycleStart := time.Now()
 		mu.Lock()
 		state.CycleCount++
@@ -410,6 +453,11 @@ func main() {
 			timer := time.NewTimer(delay)
 			select {
 			case <-timer.C:
+				continue
+			case <-reloadCh:
+				timer.Stop()
+				reloadConfig()
+				processConfigReloads()
 				continue
 			case <-stopCh:
 				timer.Stop()
@@ -1478,6 +1526,10 @@ func main() {
 		select {
 		case <-timer.C:
 			// Next tick
+		case <-reloadCh:
+			timer.Stop()
+			reloadConfig()
+			processConfigReloads()
 		case <-stopCh:
 			timer.Stop()
 			fmt.Println("Shutdown complete.")

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1825,53 +1825,26 @@ func sendTradeAlerts(sc StrategyConfig, stratState *StrategyState, trades int, m
 	copy(newTrades, stratState.TradeHistory[start:n])
 	mu.RUnlock()
 
-	for _, b := range notifier.backends {
-		dmKey := sc.Platform
-		if !isLive {
-			dmKey = sc.Platform + "-paper"
-		}
-		dmDest := ""
-		if b.dmChannels != nil {
-			dmDest = b.dmChannels[dmKey]
-		}
-
-		// Channel routing: presence of a channel ID means enabled, absence means disabled.
-		// Paper trades use "<platform>-paper" key with fallback to base platform key.
-		// Live trades use the base platform key.
-		ch := resolveTradeChannel(b.channels, sc.Platform, sc.Type, isLive)
-
-		// Also post live trades to a dedicated "<platform>-live" channel if configured.
-		var liveCh string
-		if isLive {
-			liveCh = resolveChannel(b.channels, sc.Platform+"-live", "")
-			if liveCh == ch {
-				liveCh = "" // avoid double-posting to the same channel
-			}
-		}
-
-		if dmDest == "" && ch == "" && liveCh == "" {
-			continue
-		}
-
+	for _, route := range notifier.tradeAlertRoutes(sc.Platform, sc.Type, isLive) {
 		for _, t := range newTrades {
 			var msg string
-			if b.plainText {
+			if route.plainText {
 				msg = FormatTradeDMPlain(sc, t, mode)
 			} else {
 				msg = FormatTradeDM(sc, t, mode)
 			}
-			if dmDest != "" {
-				if err := sendTradeDestination(b.notifier, dmDest, msg); err != nil {
+			if route.dmDest != "" {
+				if err := sendTradeDestination(route.notifier, route.dmDest, msg); err != nil {
 					fmt.Printf("[notify] DM trade alert failed: %v\n", err)
 				}
 			}
-			if ch != "" {
-				if err := b.notifier.SendMessage(ch, msg); err != nil {
+			if route.channel != "" {
+				if err := route.notifier.SendMessage(route.channel, msg); err != nil {
 					fmt.Printf("[notify] Channel trade alert failed: %v\n", err)
 				}
 			}
-			if liveCh != "" {
-				if err := b.notifier.SendMessage(liveCh, msg); err != nil {
+			if route.liveChan != "" {
+				if err := route.notifier.SendMessage(route.liveChan, msg); err != nil {
 					fmt.Printf("[notify] Live channel trade alert failed: %v\n", err)
 				}
 			}

--- a/scheduler/notifier.go
+++ b/scheduler/notifier.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -28,6 +29,7 @@ type notifierBackend struct {
 // MultiNotifier fans out calls to all configured notification providers.
 // It is aware of each provider's channel config and owner ID for proper routing.
 type MultiNotifier struct {
+	mu       sync.RWMutex
 	backends []notifierBackend
 }
 
@@ -36,10 +38,28 @@ func NewMultiNotifier(backends ...notifierBackend) *MultiNotifier {
 	var valid []notifierBackend
 	for _, b := range backends {
 		if b.notifier != nil {
+			b.channels = cloneStringMap(b.channels)
+			b.dmChannels = cloneStringMap(b.dmChannels)
 			valid = append(valid, b)
 		}
 	}
 	return &MultiNotifier{backends: valid}
+}
+
+func (m *MultiNotifier) snapshotBackends() []notifierBackend {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	out := make([]notifierBackend, len(m.backends))
+	for i, b := range m.backends {
+		b.channels = cloneStringMap(b.channels)
+		b.dmChannels = cloneStringMap(b.dmChannels)
+		out[i] = b
+	}
+	return out
 }
 
 // SendMessage sends content to backends that own the given channel/chat ID.
@@ -47,7 +67,7 @@ func NewMultiNotifier(backends ...notifierBackend) *MultiNotifier {
 // Returns the first error encountered; all per-backend errors are logged.
 func (m *MultiNotifier) SendMessage(channelID string, content string) error {
 	var firstErr error
-	for _, b := range m.backends {
+	for _, b := range m.snapshotBackends() {
 		if !backendOwnsChannel(b, channelID) {
 			continue
 		}
@@ -65,7 +85,7 @@ func (m *MultiNotifier) SendMessage(channelID string, content string) error {
 // Returns the first error encountered; all per-backend errors are logged.
 func (m *MultiNotifier) SendDM(userID, content string) error {
 	var firstErr error
-	for _, b := range m.backends {
+	for _, b := range m.snapshotBackends() {
 		if b.ownerID != userID {
 			continue
 		}
@@ -81,31 +101,42 @@ func (m *MultiNotifier) SendDM(userID, content string) error {
 
 // AskDM sends a question and waits for a reply. Uses the first backend with a matching owner.
 func (m *MultiNotifier) AskDM(userID, question string, timeout time.Duration) (string, error) {
-	for _, b := range m.backends {
+	backends := m.snapshotBackends()
+	for _, b := range backends {
 		if b.ownerID == userID {
 			return b.notifier.AskDM(userID, question, timeout)
 		}
 	}
-	if len(m.backends) > 0 {
-		return m.backends[0].notifier.AskDM(userID, question, timeout)
+	if len(backends) > 0 {
+		return backends[0].notifier.AskDM(userID, question, timeout)
 	}
 	return "", fmt.Errorf("no notification backends configured")
 }
 
 // Close shuts down all backends.
 func (m *MultiNotifier) Close() {
-	for _, b := range m.backends {
+	for _, b := range m.snapshotBackends() {
 		b.notifier.Close()
 	}
 }
 
 // HasBackends returns true if at least one backend is configured.
 func (m *MultiNotifier) HasBackends() bool {
+	if m == nil {
+		return false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return len(m.backends) > 0
 }
 
 // BackendCount returns the number of active backends.
 func (m *MultiNotifier) BackendCount() int {
+	if m == nil {
+		return 0
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return len(m.backends)
 }
 
@@ -116,22 +147,24 @@ func (m *MultiNotifier) ReloadConfig(cfg *Config) {
 	if m == nil || cfg == nil {
 		return
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	for i := range m.backends {
 		b := &m.backends[i]
 		if b.plainText {
-			b.channels = cfg.Telegram.Channels
-			b.dmChannels = cfg.Telegram.DMChannels
+			b.channels = cloneStringMap(cfg.Telegram.Channels)
+			b.dmChannels = cloneStringMap(cfg.Telegram.DMChannels)
 			continue
 		}
-		b.channels = cfg.Discord.Channels
-		b.dmChannels = cfg.Discord.DMChannels
+		b.channels = cloneStringMap(cfg.Discord.Channels)
+		b.dmChannels = cloneStringMap(cfg.Discord.DMChannels)
 		b.leaderboardChannel = cfg.Discord.LeaderboardChannel
 	}
 }
 
 // OwnerID returns the first configured owner ID across all backends.
 func (m *MultiNotifier) OwnerID() string {
-	for _, b := range m.backends {
+	for _, b := range m.snapshotBackends() {
 		if b.ownerID != "" {
 			return b.ownerID
 		}
@@ -157,7 +190,7 @@ func backendOwnsChannel(b notifierBackend, channelID string) bool {
 // SendToChannel sends content to all backends that have a channel configured
 // for the given platform and strategy type.
 func (m *MultiNotifier) SendToChannel(platform, stratType, content string) {
-	for _, b := range m.backends {
+	for _, b := range m.snapshotBackends() {
 		if ch := resolveChannel(b.channels, platform, stratType); ch != "" {
 			if err := b.notifier.SendMessage(ch, content); err != nil {
 				fmt.Printf("[WARN] Notifier send to channel failed: %v\n", err)
@@ -171,7 +204,7 @@ func (m *MultiNotifier) SendToChannel(platform, stratType, content string) {
 // leaderboardChannel is configured, the message is sent there once; otherwise
 // it broadcasts to all unique channels on that backend.
 func (m *MultiNotifier) PostLeaderboardBroadcast(content string) {
-	for _, b := range m.backends {
+	for _, b := range m.snapshotBackends() {
 		if b.leaderboardChannel != "" {
 			if err := b.notifier.SendMessage(b.leaderboardChannel, content); err != nil {
 				fmt.Printf("[WARN] Notifier send to leaderboard channel %s failed: %v\n", b.leaderboardChannel, err)
@@ -193,7 +226,7 @@ func (m *MultiNotifier) PostLeaderboardBroadcast(content string) {
 // SendToAllChannels sends content to all unique channels across all backends.
 // Used for broadcast messages (kill switch, correlation warnings).
 func (m *MultiNotifier) SendToAllChannels(content string) {
-	for _, b := range m.backends {
+	for _, b := range m.snapshotBackends() {
 		seen := make(map[string]bool)
 		for _, ch := range b.channels {
 			if ch != "" && !seen[ch] {
@@ -208,7 +241,7 @@ func (m *MultiNotifier) SendToAllChannels(content string) {
 
 // SendOwnerDM sends a DM to the owner on all backends that have an owner configured.
 func (m *MultiNotifier) SendOwnerDM(content string) {
-	for _, b := range m.backends {
+	for _, b := range m.snapshotBackends() {
 		if b.ownerID != "" {
 			if err := b.notifier.SendDM(b.ownerID, content); err != nil {
 				fmt.Printf("[WARN] Owner DM failed: %v\n", err)
@@ -220,7 +253,7 @@ func (m *MultiNotifier) SendOwnerDM(content string) {
 // AskOwnerDM sends a question to the owner and waits for a reply.
 // Uses the first backend that has an owner configured.
 func (m *MultiNotifier) AskOwnerDM(question string, timeout time.Duration) (string, error) {
-	for _, b := range m.backends {
+	for _, b := range m.snapshotBackends() {
 		if b.ownerID != "" {
 			return b.notifier.AskDM(b.ownerID, question, timeout)
 		}
@@ -230,7 +263,7 @@ func (m *MultiNotifier) AskOwnerDM(question string, timeout time.Duration) (stri
 
 // HasChannel returns true if any backend has a channel configured for the given platform/type.
 func (m *MultiNotifier) HasChannel(platform, stratType string) bool {
-	for _, b := range m.backends {
+	for _, b := range m.snapshotBackends() {
 		if resolveChannel(b.channels, platform, stratType) != "" {
 			return true
 		}
@@ -242,7 +275,7 @@ func (m *MultiNotifier) HasChannel(platform, stratType string) bool {
 // Uses the same lookup order as resolveChannel: platform first, then stratType.
 // Returns "" if no channel is configured on any backend.
 func (m *MultiNotifier) resolveChannelKey(platform, stratType string) string {
-	for _, b := range m.backends {
+	for _, b := range m.snapshotBackends() {
 		if _, ok := b.channels[platform]; ok {
 			return platform
 		}
@@ -256,12 +289,55 @@ func (m *MultiNotifier) resolveChannelKey(platform, stratType string) string {
 // AllChannelKeys returns all unique channel keys across all backends.
 func (m *MultiNotifier) AllChannelKeys() map[string]bool {
 	keys := make(map[string]bool)
-	for _, b := range m.backends {
+	for _, b := range m.snapshotBackends() {
 		for k := range b.channels {
 			keys[k] = true
 		}
 	}
 	return keys
+}
+
+type tradeAlertRoute struct {
+	notifier  Notifier
+	plainText bool
+	dmDest    string
+	channel   string
+	liveChan  string
+}
+
+func (m *MultiNotifier) tradeAlertRoutes(platform, stratType string, isLive bool) []tradeAlertRoute {
+	var routes []tradeAlertRoute
+	dmKey := platform
+	if !isLive {
+		dmKey = platform + "-paper"
+	}
+	for _, b := range m.snapshotBackends() {
+		dmDest := ""
+		if b.dmChannels != nil {
+			dmDest = b.dmChannels[dmKey]
+		}
+		ch := resolveTradeChannel(b.channels, platform, stratType, isLive)
+
+		var liveCh string
+		if isLive {
+			liveCh = resolveChannel(b.channels, platform+"-live", "")
+			if liveCh == ch {
+				liveCh = ""
+			}
+		}
+
+		if dmDest == "" && ch == "" && liveCh == "" {
+			continue
+		}
+		routes = append(routes, tradeAlertRoute{
+			notifier:  b.notifier,
+			plainText: b.plainText,
+			dmDest:    dmDest,
+			channel:   ch,
+			liveChan:  liveCh,
+		})
+	}
+	return routes
 }
 
 // sendTradeDestination delivers a trade alert to a user ID (DM) or channel ID.

--- a/scheduler/notifier.go
+++ b/scheduler/notifier.go
@@ -109,6 +109,26 @@ func (m *MultiNotifier) BackendCount() int {
 	return len(m.backends)
 }
 
+// ReloadConfig refreshes per-provider routing maps after a hot config reload.
+// Backend construction (tokens, gateway sessions, owner identity) is intentionally
+// restart-only; this updates only the channel settings that can be changed safely.
+func (m *MultiNotifier) ReloadConfig(cfg *Config) {
+	if m == nil || cfg == nil {
+		return
+	}
+	for i := range m.backends {
+		b := &m.backends[i]
+		if b.plainText {
+			b.channels = cfg.Telegram.Channels
+			b.dmChannels = cfg.Telegram.DMChannels
+			continue
+		}
+		b.channels = cfg.Discord.Channels
+		b.dmChannels = cfg.Discord.DMChannels
+		b.leaderboardChannel = cfg.Discord.LeaderboardChannel
+	}
+}
+
 // OwnerID returns the first configured owner ID across all backends.
 func (m *MultiNotifier) OwnerID() string {
 	for _, b := range m.backends {

--- a/scheduler/notifier_test.go
+++ b/scheduler/notifier_test.go
@@ -509,3 +509,81 @@ func TestMultiNotifier_SendMessage_UnknownChannel(t *testing.T) {
 		t.Errorf("expected 0 messages for unknown channel, got %d", len(mock.messages))
 	}
 }
+
+func TestMultiNotifier_ReloadConfigConcurrentRoutingReads(t *testing.T) {
+	mock := &mockNotifier{}
+	cfgA := &Config{
+		Discord: DiscordConfig{
+			Channels:           map[string]string{"spot": "spot-a", "hyperliquid": "hl-a", "hyperliquid-live": "hl-live-a"},
+			DMChannels:         map[string]string{"hyperliquid": "dm-a"},
+			LeaderboardChannel: "lb-a",
+		},
+	}
+	cfgB := &Config{
+		Discord: DiscordConfig{
+			Channels:           map[string]string{"spot": "spot-b", "hyperliquid": "hl-b", "hyperliquid-live": "hl-live-b"},
+			DMChannels:         map[string]string{"hyperliquid": "dm-b"},
+			LeaderboardChannel: "lb-b",
+		},
+	}
+	mn := NewMultiNotifier(notifierBackend{
+		notifier:           mock,
+		channels:           cfgA.Discord.Channels,
+		dmChannels:         cfgA.Discord.DMChannels,
+		leaderboardChannel: cfgA.Discord.LeaderboardChannel,
+		ownerID:            "owner-1",
+	})
+
+	sc := StrategyConfig{
+		ID:       "hl-btc",
+		Platform: "hyperliquid",
+		Type:     "perps",
+		Args:     []string{"--live"},
+	}
+	stratState := &StrategyState{
+		TradeHistory: []Trade{{
+			Timestamp:  time.Now(),
+			StrategyID: "hl-btc",
+			Symbol:     "BTC",
+			Side:       "buy",
+			Quantity:   1,
+			Price:      100,
+			Value:      100,
+			TradeType:  "perps",
+		}},
+	}
+
+	var stateMu sync.RWMutex
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 250; i++ {
+			if i%2 == 0 {
+				mn.ReloadConfig(cfgA)
+			} else {
+				mn.ReloadConfig(cfgB)
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 250; i++ {
+			_ = mn.SendMessage("hl-a", "direct")
+			mn.SendDM("owner-1", "dm")
+			mn.SendToChannel("hyperliquid", "perps", "platform")
+			mn.PostLeaderboardBroadcast("leaderboard")
+			mn.SendToAllChannels("broadcast")
+			mn.SendOwnerDM("owner")
+			_ = mn.HasChannel("hyperliquid", "perps")
+			_ = mn.resolveChannelKey("hyperliquid", "perps")
+			_ = mn.AllChannelKeys()
+			sendTradeAlerts(sc, stratState, 1, &stateMu, mn)
+		}
+	}()
+	close(start)
+	wg.Wait()
+}

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -66,6 +66,16 @@ func NewStatusServer(state *AppState, mu *sync.RWMutex, statusToken string, stra
 	}
 }
 
+// UpdateStrategies refreshes config-derived status metadata after a hot reload.
+// The caller must coordinate with ss.mu so /status does not build responses from
+// a half-applied config update.
+func (ss *StatusServer) UpdateStrategies(strategies []StrategyConfig) {
+	if ss == nil {
+		return
+	}
+	ss.strategies = append([]StrategyConfig(nil), strategies...)
+}
+
 // logFuturesErrThrottled emits a [WARN] line for a fetch_futures_marks
 // failure on the /status path, skipping emission if we have already
 // logged within perpsErrLogInterval. Thread-safe — /status handlers


### PR DESCRIPTION
## Summary

- handle SIGHUP in the scheduler and re-read config without restarting
- hot-apply safe config fields: strategy drawdown/capital/leverage/intervals, portfolio drawdown/warn thresholds, notification routing, summary frequency, and scheduler interval
- reject restart-required changes and keep the previous config on invalid reloads
- add regression coverage for allowed reloads, rejected structural changes, and capital_pct runtime capital preservation

Closes #442

## Validation

- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...`
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler build .`

LLM: GPT-5 Codex | medium