### PR TITLE
[codex] fix perps drawdown circuit breaker

### DIFF
--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1288,7 +1288,7 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 		} else {
 			r.CurrentDrawdownPct = 0
 		}
-		if r.TotalTrades > 0 && r.CurrentDrawdownPct > r.MaxDrawdownPct {
+		if r.CurrentDrawdownPct > r.MaxDrawdownPct {
 			r.CircuitBreaker = true
 			r.CircuitBreakerUntil = now.Add(24 * time.Hour)
 			setHyperliquidCircuitBreakerPending(sc, s, assist)

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -1558,6 +1558,43 @@ func TestCheckRisk_PerpsMarginDrawdown_FiresEarly(t *testing.T) {
 	}
 }
 
+func TestCheckRisk_PerpsDrawdownFiresBeforeAnyClosedTrades(t *testing.T) {
+	s := &StrategyState{
+		ID:   "hl-first-trade",
+		Type: "perps",
+		Cash: 500,
+		RiskState: RiskState{
+			PeakValue:      500,
+			MaxDrawdownPct: 10,
+			TotalTrades:    0,
+			DailyPnLDate:   todayUTC(),
+		},
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 1, AvgCost: 100, Side: "long", Multiplier: 1, Leverage: 20},
+		},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+	}
+	prices := map[string]float64{"ETH": 80}
+	pv := PortfolioValue(s, prices)
+	sc := &StrategyConfig{ID: "hl-first-trade", Platform: "hyperliquid", Type: "perps", Leverage: 20}
+
+	allowed, reason := CheckRisk(sc, s, pv, prices, nil, nil)
+
+	if allowed {
+		t.Fatalf("expected first open position to trip drawdown circuit breaker; reason=%s", reason)
+	}
+	if !strings.HasPrefix(reason, RiskReasonMaxDrawdownExceeded) {
+		t.Fatalf("reason = %q, want %q prefix", reason, RiskReasonMaxDrawdownExceeded)
+	}
+	if !s.RiskState.CircuitBreaker {
+		t.Fatal("expected circuit breaker to be active")
+	}
+	if len(s.Positions) != 0 {
+		t.Errorf("expected positions force-closed; got %d", len(s.Positions))
+	}
+}
+
 // TestCheckRisk_LiveHLSharedCoin_SetsPendingPartialClose verifies #356: a live
 // HL strategy that shares a coin with another configured live HL strategy gets
 // a proportional pending on-chain close (capital_pct weights), not the full

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -179,6 +179,34 @@ func ValidateState(state *AppState) {
 	}
 }
 
+func migrateLegacyPerpsPositionMultipliers(state *AppState, cfg *Config) int {
+	if state == nil {
+		return 0
+	}
+	perpsIDs := make(map[string]bool)
+	if cfg != nil {
+		for _, sc := range cfg.Strategies {
+			if sc.Type == "perps" {
+				perpsIDs[sc.ID] = true
+			}
+		}
+	}
+	migrated := 0
+	for id, s := range state.Strategies {
+		if s == nil || (s.Type != "perps" && !perpsIDs[id]) {
+			continue
+		}
+		for _, pos := range s.Positions {
+			if pos == nil || pos.Multiplier > 0 {
+				continue
+			}
+			pos.Multiplier = 1
+			migrated++
+		}
+	}
+	return migrated
+}
+
 // ValidatePerpsAllowShortsConfig flags short positions that belong to a perps
 // strategy currently configured with AllowShorts=false (#336). The desync can
 // arise from state migration, paper→live handoff, operator edits of state.db,
@@ -272,6 +300,9 @@ func LoadStateWithDB(cfg *Config, sdb *StateDB) (*AppState, error) {
 		return nil, fmt.Errorf("sqlite load: %w", err)
 	}
 	if state != nil {
+		if migrated := migrateLegacyPerpsPositionMultipliers(state, cfg); migrated > 0 {
+			fmt.Printf("[state] Migrated %d legacy perps position multiplier(s) to 1\n", migrated)
+		}
 		fmt.Println("[state] Loaded from SQLite")
 		return state, nil
 	}

--- a/scheduler/state_test.go
+++ b/scheduler/state_test.go
@@ -261,6 +261,62 @@ func TestLoadStateWithDB_EmptyDB(t *testing.T) {
 	}
 }
 
+func TestLoadStateWithDB_MigratesLegacyPerpsMultiplier(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "state.db")
+
+	db, err := OpenStateDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	original := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-eth": {
+				ID:             "hl-eth",
+				Type:           "perps",
+				Platform:       "hyperliquid",
+				Cash:           500,
+				InitialCapital: 500,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.25, AvgCost: 2200, Side: "long", Multiplier: 0},
+				},
+				OptionPositions: make(map[string]*OptionPosition),
+				TradeHistory:    []Trade{},
+			},
+			"spot-btc": {
+				ID:             "spot-btc",
+				Type:           "spot",
+				Platform:       "binanceus",
+				Cash:           500,
+				InitialCapital: 500,
+				Positions: map[string]*Position{
+					"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.01, AvgCost: 50000, Side: "long", Multiplier: 0},
+				},
+				OptionPositions: make(map[string]*OptionPosition),
+				TradeHistory:    []Trade{},
+			},
+		},
+	}
+	if err := db.SaveState(original); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{DBFile: dbPath}
+	loaded, err := LoadStateWithDB(cfg, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := loaded.Strategies["hl-eth"].Positions["ETH"].Multiplier; got != 1 {
+		t.Errorf("perps multiplier = %g, want 1 after legacy migration", got)
+	}
+	if got := loaded.Strategies["spot-btc"].Positions["BTC/USDT"].Multiplier; got != 0 {
+		t.Errorf("spot multiplier = %g, want 0 (spot position must not migrate)", got)
+	}
+}
+
 func TestSaveStateWithDB(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "state.db")


### PR DESCRIPTION
## Summary

- migrate legacy perps positions with `Multiplier <= 0` to `Multiplier = 1` during SQLite state load
- allow max-drawdown circuit breakers to fire before the first closed trade
- add focused regressions for the state-load migration and first-open-position drawdown CB behavior

## Root Cause

Legacy/paper perps positions could retain `Multiplier = 0`, causing perps margin drawdown to fall back to peak-relative drawdown. Separately, the max-drawdown check required `TotalTrades > 0`, so a first open position could breach its configured drawdown threshold without tripping the per-strategy circuit breaker.

Closes #447

## Validation

- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test -run 'TestLoadStateWithDB_MigratesLegacyPerpsMultiplier|TestCheckRisk_PerpsDrawdownFiresBeforeAnyClosedTrades' .`
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...`
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler build .`
- `git diff --check`

LLM: GPT-5 Codex | extra high