### PR TITLE
[codex] Use exchange-reported fees on live opens

### DIFF
--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -384,6 +384,7 @@ type TopStepResult struct {
 type TopStepFill struct {
 	AvgPx          float64 `json:"avg_px"`
 	TotalContracts int     `json:"total_contracts"`
+	Fee            float64 `json:"fee,omitempty"`
 }
 
 // TopStepExecution is the execution block from check_topstep.py --execute output.
@@ -587,6 +588,7 @@ type RobinhoodResult struct {
 type RobinhoodFill struct {
 	AvgPx    float64 `json:"avg_px"`
 	Quantity float64 `json:"quantity"`
+	Fee      float64 `json:"fee,omitempty"`
 }
 
 // RobinhoodExecution is the execution block from check_robinhood.py --execute output.
@@ -673,6 +675,7 @@ type OKXResult struct {
 type OKXFill struct {
 	AvgPx   float64 `json:"avg_px"`
 	TotalSz float64 `json:"total_sz"`
+	Fee     float64 `json:"fee,omitempty"`
 }
 
 // OKXExecution is the execution block from check_okx.py --execute output.

--- a/scheduler/executor_test.go
+++ b/scheduler/executor_test.go
@@ -193,7 +193,7 @@ func TestTopStepExecuteResultJSON(t *testing.T) {
 			"action": "buy",
 			"symbol": "ES",
 			"contracts": 2,
-			"fill": {"avg_px": 5200.25, "total_contracts": 2}
+			"fill": {"avg_px": 5200.25, "total_contracts": 2, "fee": 4.12}
 		},
 		"platform": "topstep"
 	}`
@@ -207,6 +207,9 @@ func TestTopStepExecuteResultJSON(t *testing.T) {
 	}
 	if result.Execution.Fill.TotalContracts != 2 {
 		t.Errorf("TotalContracts = %d, want 2", result.Execution.Fill.TotalContracts)
+	}
+	if result.Execution.Fill.Fee != 4.12 {
+		t.Errorf("Fee = %g, want 4.12", result.Execution.Fill.Fee)
 	}
 }
 
@@ -235,7 +238,7 @@ func TestRobinhoodExecuteResultJSON(t *testing.T) {
 			"action": "buy",
 			"symbol": "BTC",
 			"amount_usd": 500,
-			"fill": {"avg_px": 60000.5, "quantity": 0.00833}
+			"fill": {"avg_px": 60000.5, "quantity": 0.00833, "fee": 0.07}
 		},
 		"platform": "robinhood"
 	}`
@@ -246,6 +249,9 @@ func TestRobinhoodExecuteResultJSON(t *testing.T) {
 	}
 	if result.Execution.AmountUSD != 500 {
 		t.Errorf("AmountUSD = %g, want 500", result.Execution.AmountUSD)
+	}
+	if result.Execution.Fill.Fee != 0.07 {
+		t.Errorf("Fee = %g, want 0.07", result.Execution.Fill.Fee)
 	}
 }
 
@@ -277,7 +283,7 @@ func TestOKXExecuteResultJSON(t *testing.T) {
 			"action": "sell",
 			"symbol": "BTC",
 			"size": 0.05,
-			"fill": {"avg_px": 55000, "total_sz": 0.05}
+			"fill": {"avg_px": 55000, "total_sz": 0.05, "fee": 1.25}
 		},
 		"platform": "okx"
 	}`
@@ -288,6 +294,9 @@ func TestOKXExecuteResultJSON(t *testing.T) {
 	}
 	if result.Execution.Size != 0.05 {
 		t.Errorf("Size = %g, want 0.05", result.Execution.Size)
+	}
+	if result.Execution.Fill.Fee != 1.25 {
+		t.Errorf("Fee = %g, want 1.25", result.Execution.Fill.Fee)
 	}
 }
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2281,9 +2281,11 @@ func runTopStepExecuteOrder(sc StrategyConfig, result *TopStepResult, price, cas
 func executeTopStepResult(sc StrategyConfig, s *StrategyState, result *TopStepResult, execResult *TopStepExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
 	fillPrice := price
 	var fillContracts int
+	var fillFee float64
 	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.AvgPx > 0 {
 		fillPrice = execResult.Execution.Fill.AvgPx
 		fillContracts = execResult.Execution.Fill.TotalContracts
+		fillFee = execResult.Execution.Fill.Fee
 		logger.Info("Live fill at $%.2f contracts=%d (signal was $%.2f)", fillPrice, fillContracts, price)
 	}
 
@@ -2294,7 +2296,7 @@ func executeTopStepResult(sc StrategyConfig, s *StrategyState, result *TopStepRe
 		maxContracts = sc.FuturesConfig.MaxContracts
 	}
 
-	trades, err := ExecuteFuturesSignal(s, result.Signal, result.Symbol, fillPrice, result.ContractSpec, feePerContract, maxContracts, fillContracts, logger)
+	trades, err := ExecuteFuturesSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, result.ContractSpec, feePerContract, maxContracts, fillContracts, fillFee, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -2437,13 +2439,15 @@ func runRobinhoodExecuteOrder(sc StrategyConfig, result *RobinhoodResult, price,
 func executeRobinhoodResult(sc StrategyConfig, s *StrategyState, result *RobinhoodResult, execResult *RobinhoodExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
 	fillPrice := price
 	var fillQty float64
+	var fillFee float64
 	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.AvgPx > 0 {
 		fillPrice = execResult.Execution.Fill.AvgPx
 		fillQty = execResult.Execution.Fill.Quantity
+		fillFee = execResult.Execution.Fill.Fee
 		logger.Info("Live fill at $%.2f qty=%.6f (mid was $%.2f)", fillPrice, fillQty, price)
 	}
 
-	trades, err := ExecuteSpotSignal(s, result.Signal, result.Symbol, fillPrice, fillQty, logger)
+	trades, err := ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -2624,9 +2628,11 @@ func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQt
 func executeOKXResult(sc StrategyConfig, s *StrategyState, result *OKXResult, execResult *OKXExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
 	fillPrice := price
 	var fillQty float64
+	var fillFee float64
 	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.AvgPx > 0 {
 		fillPrice = execResult.Execution.Fill.AvgPx
 		fillQty = execResult.Execution.Fill.TotalSz
+		fillFee = execResult.Execution.Fill.Fee
 		logger.Info("Live fill at $%.2f qty=%.6f (mid was $%.2f)", fillPrice, fillQty, price)
 	}
 
@@ -2637,11 +2643,9 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, result *OKXResult, ex
 		if leverage <= 0 {
 			leverage = 1
 		}
-		// OKXFill does not carry OID/fee today; pass empties and let SaveState
-		// backfill from any future adapter extension via the usual path.
-		trades, err = ExecutePerpsSignal(s, result.Signal, result.Symbol, fillPrice, leverage, fillQty, "", 0, sc.AllowShorts, logger)
+		trades, err = ExecutePerpsSignal(s, result.Signal, result.Symbol, fillPrice, leverage, fillQty, "", fillFee, sc.AllowShorts, logger)
 	} else {
-		trades, err = ExecuteSpotSignal(s, result.Signal, result.Symbol, fillPrice, fillQty, logger)
+		trades, err = ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, logger)
 	}
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -208,6 +208,20 @@ type Trade struct {
 	persisted bool
 }
 
+func executionFee(modeledFee, fillFee float64, useFillFee bool) float64 {
+	if useFillFee && fillFee > 0 {
+		return fillFee
+	}
+	return modeledFee
+}
+
+func exchangeFeeForTrade(fillFee float64, useFillFee bool) float64 {
+	if useFillFee && fillFee > 0 {
+		return fillFee
+	}
+	return 0
+}
+
 // PortfolioValue calculates total value of a strategy's portfolio.
 func PortfolioValue(s *StrategyState, prices map[string]float64) float64 {
 	total := s.Cash
@@ -423,13 +437,10 @@ func FuturesOrderSkipReason(signal int, posSide string) string {
 // leveraged budget with slippage applied.
 //
 // fillOID/fillFee carry exchange metadata for live fills (empty/zero for
-// paper). One live fill = one exchange fee; if a signal encounters an
-// opposite-side position, ExecutePerpsSignal synthesizes a close+open
-// pair for in-memory accounting, but the real exchange action was the
-// single fill that opened the new side. Stamping the same fee on both
-// synthetic legs would double-count it in analytics — so only the
-// opening trade carries fillOID/fillFee; the close leg carries empty
-// exchange metadata. See #289.
+// paper). One live fill = one exchange fee; if a bidirectional signal flips an
+// opposite-side position, ExecutePerpsSignal synthesizes a close+open pair.
+// The close leg owns the exchange-reported fill fee; the open leg uses modeled
+// fee cash math so the real fee is not counted twice. See #451.
 //
 // allowShorts toggles bidirectional semantics (#328). When true, signal=-1
 // from flat opens a short, and signal=-1 on an existing long flips to a
@@ -477,24 +488,27 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 				execPrice = ApplySlippage(price)
 			}
 			pnl := pos.Quantity * (pos.AvgCost - execPrice)
-			fee := CalculatePlatformSpotFee(feePlatform, pos.Quantity*execPrice)
+			useFillFee := flipCloseQty > 0
+			fee := executionFee(CalculatePlatformSpotFee(feePlatform, pos.Quantity*execPrice), fillFee, useFillFee)
 			pnl -= fee
 			s.Cash += pnl
 			now := time.Now().UTC()
-			// Synthetic close — no exchange metadata stamped; the real fill
-			// (if any) is attributed to the open-long trade below. Prevents
-			// fee double-count when a flip produces two in-memory trades
-			// from a single exchange fill.
+			var closeOID string
+			if useFillFee {
+				closeOID = fillOID
+			}
 			trade := Trade{
-				Timestamp:  now,
-				StrategyID: s.ID,
-				Symbol:     symbol,
-				Side:       "buy",
-				Quantity:   pos.Quantity,
-				Price:      execPrice,
-				Value:      pos.Quantity * execPrice,
-				TradeType:  "perps",
-				Details:    fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				Timestamp:       now,
+				StrategyID:      s.ID,
+				Symbol:          symbol,
+				Side:            "buy",
+				Quantity:        pos.Quantity,
+				Price:           execPrice,
+				Value:           pos.Quantity * execPrice,
+				TradeType:       "perps",
+				Details:         fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				ExchangeOrderID: closeOID,
+				ExchangeFee:     exchangeFeeForTrade(fillFee, useFillFee),
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -529,9 +543,14 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 			qty = budget / execPrice
 		}
 		notional := qty * execPrice
-		fee := CalculatePlatformSpotFee(feePlatform, notional)
+		useFillFee := flipCloseQty == 0
+		fee := executionFee(CalculatePlatformSpotFee(feePlatform, notional), fillFee, useFillFee)
 		s.Cash -= fee // margin-based: only fee leaves cash, notional stays virtual
 		now := time.Now().UTC()
+		var openOID string
+		if useFillFee {
+			openOID = fillOID
+		}
 		s.Positions[symbol] = &Position{
 			Symbol:          symbol,
 			Quantity:        qty,
@@ -552,8 +571,8 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 			Value:           notional,
 			TradeType:       "perps",
 			Details:         fmt.Sprintf("Open long %.6f @ $%.2f (%.1fx, fee $%.2f)", qty, execPrice, leverage, fee),
-			ExchangeOrderID: fillOID,
-			ExchangeFee:     fillFee,
+			ExchangeOrderID: openOID,
+			ExchangeFee:     exchangeFeeForTrade(fillFee, useFillFee),
 		}
 		RecordTrade(s, trade)
 		logger.Info("BUY %s: %.6f @ $%.2f (%.1fx, notional $%.2f, fee $%.2f)", symbol, qty, execPrice, leverage, notional, fee)
@@ -579,19 +598,14 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 				execPrice = ApplySlippage(price)
 			}
 			pnl := pos.Quantity * (execPrice - pos.AvgCost)
-			fee := CalculatePlatformSpotFee(feePlatform, pos.Quantity*execPrice)
+			useFillFee := flipCloseQty > 0 || !allowShorts
+			fee := executionFee(CalculatePlatformSpotFee(feePlatform, pos.Quantity*execPrice), fillFee, useFillFee)
 			pnl -= fee
 			s.Cash += pnl
 			now := time.Now().UTC()
-			// When flipping to short, the close-long leg is the synthetic half of
-			// a single real exchange fill — same rationale as the close-short leg
-			// in the signal=1 branch. Stamp exchange metadata only on the new
-			// opener so the fee is not double-counted.
 			var closeOID string
-			var closeFee float64
-			if !allowShorts {
+			if useFillFee {
 				closeOID = fillOID
-				closeFee = fillFee
 			}
 			trade := Trade{
 				Timestamp:       now,
@@ -604,7 +618,7 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 				TradeType:       "perps",
 				Details:         fmt.Sprintf("Close long, PnL: $%.2f (fee $%.2f)", pnl, fee),
 				ExchangeOrderID: closeOID,
-				ExchangeFee:     closeFee,
+				ExchangeFee:     exchangeFeeForTrade(fillFee, useFillFee),
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -644,9 +658,14 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 			qty = budget / execPrice
 		}
 		notional := qty * execPrice
-		fee := CalculatePlatformSpotFee(feePlatform, notional)
+		useFillFee := flipCloseQty == 0
+		fee := executionFee(CalculatePlatformSpotFee(feePlatform, notional), fillFee, useFillFee)
 		s.Cash -= fee // margin-based: only fee leaves cash
 		now := time.Now().UTC()
+		var openOID string
+		if useFillFee {
+			openOID = fillOID
+		}
 		s.Positions[symbol] = &Position{
 			Symbol:          symbol,
 			Quantity:        qty,
@@ -667,8 +686,8 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 			Value:           notional,
 			TradeType:       "perps",
 			Details:         fmt.Sprintf("Open short %.6f @ $%.2f (%.1fx, fee $%.2f)", qty, execPrice, leverage, fee),
-			ExchangeOrderID: fillOID,
-			ExchangeFee:     fillFee,
+			ExchangeOrderID: openOID,
+			ExchangeFee:     exchangeFeeForTrade(fillFee, useFillFee),
 		}
 		RecordTrade(s, trade)
 		logger.Info("SELL %s: %.6f @ $%.2f (%.1fx, notional $%.2f, fee $%.2f) [open short]", symbol, qty, execPrice, leverage, notional, fee)
@@ -681,6 +700,10 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 // fillQty > 0 means a live fill: use price as-is (no slippage) and fillQty as position quantity for buys.
 // fillQty == 0 means paper mode: apply ApplySlippage and compute qty from state budget.
 func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float64, fillQty float64, logger *StrategyLogger) (int, error) {
+	return ExecuteSpotSignalWithFillFee(s, signal, symbol, price, fillQty, 0, logger)
+}
+
+func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, fillQty float64, fillFee float64, logger *StrategyLogger) (int, error) {
 	if signal == 0 {
 		return 0, nil
 	}
@@ -689,6 +712,7 @@ func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float6
 	if s.Platform == "okx" && s.Type == "perps" {
 		feePlatform = "okx-perps"
 	}
+	fillFeeUsed := false
 
 	if signal == 1 { // Buy
 		// Check if already long
@@ -705,21 +729,26 @@ func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float6
 				execPrice = ApplySlippage(price)
 			}
 			buyCost := pos.Quantity * execPrice
-			fee := CalculatePlatformSpotFee(feePlatform, buyCost)
+			useFillFee := fillQty > 0 && !fillFeeUsed
+			fee := executionFee(CalculatePlatformSpotFee(feePlatform, buyCost), fillFee, useFillFee)
+			if useFillFee && fillFee > 0 {
+				fillFeeUsed = true
+			}
 			totalCost := buyCost + fee
 			pnl := pos.Quantity*pos.AvgCost - totalCost
 			s.Cash += pos.Quantity*pos.AvgCost - totalCost
 			now := time.Now().UTC()
 			trade := Trade{
-				Timestamp:  now,
-				StrategyID: s.ID,
-				Symbol:     symbol,
-				Side:       "buy",
-				Quantity:   pos.Quantity,
-				Price:      execPrice,
-				Value:      totalCost,
-				TradeType:  "spot",
-				Details:    fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				Timestamp:   now,
+				StrategyID:  s.ID,
+				Symbol:      symbol,
+				Side:        "buy",
+				Quantity:    pos.Quantity,
+				Price:       execPrice,
+				Value:       totalCost,
+				TradeType:   "spot",
+				Details:     fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				ExchangeFee: exchangeFeeForTrade(fillFee, useFillFee),
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -746,7 +775,11 @@ func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float6
 			qty = budget / execPrice
 		}
 		tradeCost := qty * execPrice
-		fee := CalculatePlatformSpotFee(feePlatform, tradeCost)
+		useFillFee := fillQty > 0 && !fillFeeUsed
+		fee := executionFee(CalculatePlatformSpotFee(feePlatform, tradeCost), fillFee, useFillFee)
+		if useFillFee && fillFee > 0 {
+			fillFeeUsed = true
+		}
 		s.Cash -= tradeCost + fee
 		now := time.Now().UTC()
 		s.Positions[symbol] = &Position{
@@ -758,15 +791,16 @@ func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float6
 			OpenedAt:        now,
 		}
 		trade := Trade{
-			Timestamp:  now,
-			StrategyID: s.ID,
-			Symbol:     symbol,
-			Side:       "buy",
-			Quantity:   qty,
-			Price:      execPrice,
-			Value:      tradeCost + fee,
-			TradeType:  "spot",
-			Details:    fmt.Sprintf("Open long %.6f @ $%.2f (fee $%.2f)", qty, execPrice, fee),
+			Timestamp:   now,
+			StrategyID:  s.ID,
+			Symbol:      symbol,
+			Side:        "buy",
+			Quantity:    qty,
+			Price:       execPrice,
+			Value:       tradeCost + fee,
+			TradeType:   "spot",
+			Details:     fmt.Sprintf("Open long %.6f @ $%.2f (fee $%.2f)", qty, execPrice, fee),
+			ExchangeFee: exchangeFeeForTrade(fillFee, useFillFee),
 		}
 		RecordTrade(s, trade)
 		logger.Info("BUY %s: %.6f @ $%.2f (fee $%.2f, total $%.2f)", symbol, qty, execPrice, fee, tradeCost+fee)
@@ -782,21 +816,26 @@ func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float6
 				execPrice = ApplySlippage(price)
 			}
 			saleValue := pos.Quantity * execPrice
-			fee := CalculatePlatformSpotFee(feePlatform, saleValue)
+			useFillFee := fillQty > 0 && !fillFeeUsed
+			fee := executionFee(CalculatePlatformSpotFee(feePlatform, saleValue), fillFee, useFillFee)
+			if useFillFee && fillFee > 0 {
+				fillFeeUsed = true
+			}
 			netProceeds := saleValue - fee
 			pnl := netProceeds - (pos.Quantity * pos.AvgCost)
 			s.Cash += netProceeds
 			now := time.Now().UTC()
 			trade := Trade{
-				Timestamp:  now,
-				StrategyID: s.ID,
-				Symbol:     symbol,
-				Side:       "sell",
-				Quantity:   pos.Quantity,
-				Price:      execPrice,
-				Value:      netProceeds,
-				TradeType:  "spot",
-				Details:    fmt.Sprintf("Close long, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				Timestamp:   now,
+				StrategyID:  s.ID,
+				Symbol:      symbol,
+				Side:        "sell",
+				Quantity:    pos.Quantity,
+				Price:       execPrice,
+				Value:       netProceeds,
+				TradeType:   "spot",
+				Details:     fmt.Sprintf("Close long, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				ExchangeFee: exchangeFeeForTrade(fillFee, useFillFee),
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -815,11 +854,16 @@ func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float6
 // fillContracts > 0 means a live fill: use price as-is (no slippage) and fillContracts as contract count for opens.
 // fillContracts == 0 means paper mode: apply ApplySlippage and compute contracts from state budget.
 func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price float64, spec ContractSpec, feePerContract float64, maxContracts int, fillContracts int, logger *StrategyLogger) (int, error) {
+	return ExecuteFuturesSignalWithFillFee(s, signal, symbol, price, spec, feePerContract, maxContracts, fillContracts, 0, logger)
+}
+
+func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, spec ContractSpec, feePerContract float64, maxContracts int, fillContracts int, fillFee float64, logger *StrategyLogger) (int, error) {
 	if signal == 0 {
 		return 0, nil
 	}
 	tradesExecuted := 0
 	multiplier := spec.Multiplier
+	fillFeeUsed := false
 
 	if signal == 1 { // Buy
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
@@ -836,20 +880,25 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 			}
 			contracts := int(pos.Quantity)
 			pnl := float64(contracts) * multiplier * (pos.AvgCost - execPrice)
-			fee := CalculateFuturesFee(contracts, feePerContract)
+			useFillFee := fillContracts > 0 && !fillFeeUsed
+			fee := executionFee(CalculateFuturesFee(contracts, feePerContract), fillFee, useFillFee)
+			if useFillFee && fillFee > 0 {
+				fillFeeUsed = true
+			}
 			pnl -= fee
 			s.Cash += pnl
 			now := time.Now().UTC()
 			trade := Trade{
-				Timestamp:  now,
-				StrategyID: s.ID,
-				Symbol:     symbol,
-				Side:       "buy",
-				Quantity:   pos.Quantity,
-				Price:      execPrice,
-				Value:      float64(contracts) * multiplier * execPrice,
-				TradeType:  "futures",
-				Details:    fmt.Sprintf("Close short %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee),
+				Timestamp:   now,
+				StrategyID:  s.ID,
+				Symbol:      symbol,
+				Side:        "buy",
+				Quantity:    pos.Quantity,
+				Price:       execPrice,
+				Value:       float64(contracts) * multiplier * execPrice,
+				TradeType:   "futures",
+				Details:     fmt.Sprintf("Close short %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee),
+				ExchangeFee: exchangeFeeForTrade(fillFee, useFillFee),
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -887,7 +936,11 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 			logger.Info("Insufficient cash ($%.2f) for even 1 %s contract (margin=$%.2f)", s.Cash, symbol, marginPerContract)
 			return tradesExecuted, nil
 		}
-		fee := CalculateFuturesFee(contracts, feePerContract)
+		useFillFee := fillContracts > 0 && !fillFeeUsed
+		fee := executionFee(CalculateFuturesFee(contracts, feePerContract), fillFee, useFillFee)
+		if useFillFee && fillFee > 0 {
+			fillFeeUsed = true
+		}
 		s.Cash -= fee // futures use margin, not full notional; deduct fee only
 		now := time.Now().UTC()
 		s.Positions[symbol] = &Position{
@@ -900,15 +953,16 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 			OpenedAt:        now,
 		}
 		trade := Trade{
-			Timestamp:  now,
-			StrategyID: s.ID,
-			Symbol:     symbol,
-			Side:       "buy",
-			Quantity:   float64(contracts),
-			Price:      execPrice,
-			Value:      float64(contracts) * marginPerContract,
-			TradeType:  "futures",
-			Details:    fmt.Sprintf("Open long %d contracts @ $%.2f (fee $%.2f)", contracts, execPrice, fee),
+			Timestamp:   now,
+			StrategyID:  s.ID,
+			Symbol:      symbol,
+			Side:        "buy",
+			Quantity:    float64(contracts),
+			Price:       execPrice,
+			Value:       float64(contracts) * marginPerContract,
+			TradeType:   "futures",
+			Details:     fmt.Sprintf("Open long %d contracts @ $%.2f (fee $%.2f)", contracts, execPrice, fee),
+			ExchangeFee: exchangeFeeForTrade(fillFee, useFillFee),
 		}
 		RecordTrade(s, trade)
 		logger.Info("BUY %s: %d contracts @ $%.2f (fee $%.2f)", symbol, contracts, execPrice, fee)
@@ -925,20 +979,25 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 			}
 			contracts := int(pos.Quantity)
 			pnl := float64(contracts) * multiplier * (execPrice - pos.AvgCost)
-			fee := CalculateFuturesFee(contracts, feePerContract)
+			useFillFee := fillContracts > 0 && !fillFeeUsed
+			fee := executionFee(CalculateFuturesFee(contracts, feePerContract), fillFee, useFillFee)
+			if useFillFee && fillFee > 0 {
+				fillFeeUsed = true
+			}
 			pnl -= fee
 			s.Cash += pnl
 			now := time.Now().UTC()
 			trade := Trade{
-				Timestamp:  now,
-				StrategyID: s.ID,
-				Symbol:     symbol,
-				Side:       "sell",
-				Quantity:   pos.Quantity,
-				Price:      execPrice,
-				Value:      float64(contracts) * multiplier * execPrice,
-				TradeType:  "futures",
-				Details:    fmt.Sprintf("Close long %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee),
+				Timestamp:   now,
+				StrategyID:  s.ID,
+				Symbol:      symbol,
+				Side:        "sell",
+				Quantity:    pos.Quantity,
+				Price:       execPrice,
+				Value:       float64(contracts) * multiplier * execPrice,
+				TradeType:   "futures",
+				Details:     fmt.Sprintf("Close long %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee),
+				ExchangeFee: exchangeFeeForTrade(fillFee, useFillFee),
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -977,7 +1036,11 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 				logger.Info("Insufficient cash ($%.2f) for even 1 %s short contract (margin=$%.2f)", s.Cash, symbol, marginPerContract)
 				return tradesExecuted, nil
 			}
-			fee := CalculateFuturesFee(contracts, feePerContract)
+			useFillFee := fillContracts > 0 && !fillFeeUsed
+			fee := executionFee(CalculateFuturesFee(contracts, feePerContract), fillFee, useFillFee)
+			if useFillFee && fillFee > 0 {
+				fillFeeUsed = true
+			}
 			s.Cash -= fee
 			now := time.Now().UTC()
 			s.Positions[symbol] = &Position{
@@ -990,15 +1053,16 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 				OpenedAt:        now,
 			}
 			trade := Trade{
-				Timestamp:  now,
-				StrategyID: s.ID,
-				Symbol:     symbol,
-				Side:       "sell",
-				Quantity:   float64(contracts),
-				Price:      execPrice,
-				Value:      float64(contracts) * marginPerContract,
-				TradeType:  "futures",
-				Details:    fmt.Sprintf("Open short %d contracts @ $%.2f (fee $%.2f)", contracts, execPrice, fee),
+				Timestamp:   now,
+				StrategyID:  s.ID,
+				Symbol:      symbol,
+				Side:        "sell",
+				Quantity:    float64(contracts),
+				Price:       execPrice,
+				Value:       float64(contracts) * marginPerContract,
+				TradeType:   "futures",
+				Details:     fmt.Sprintf("Open short %d contracts @ $%.2f (fee $%.2f)", contracts, execPrice, fee),
+				ExchangeFee: exchangeFeeForTrade(fillFee, useFillFee),
 			}
 			RecordTrade(s, trade)
 			logger.Info("SHORT %s: %d contracts @ $%.2f (fee $%.2f)", symbol, contracts, execPrice, fee)

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -466,9 +466,11 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 
 	// flipCloseQty lets the open leg subtract the close-leg qty from a live
 	// fill when the exchange executes a single net-flip order of
-	// (posQty + newSize). Only set when AllowShorts=true — legacy paths (e.g.
-	// a migrated short being closed by a long-only strategy) keep fillQty as
-	// the open-side-only qty to preserve #289's single-fee-per-fill invariant.
+	// (posQty + newSize). Only set when AllowShorts=true so #451 can charge
+	// the real fill fee to the close leg and modeled fee to the open leg on
+	// bidirectional flips. Legacy paths (e.g. a migrated short closed by a
+	// long-only strategy) keep fillQty as the open-side-only qty, so the open
+	// leg carries the single live fill fee.
 	var flipCloseQty float64
 
 	if signal == 1 { // Buy — go long (close short first if any)

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -1117,6 +1117,56 @@ func TestExecutePerpsSignalLegacyFlatNoShort(t *testing.T) {
 	}
 }
 
+func TestExecutePerpsSignalLegacyCloseShortThenOpenLongUsesOpenFillFee(t *testing.T) {
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	s := &StrategyState{
+		ID:       "hl-legacy-eth",
+		Cash:     1000,
+		Platform: "hyperliquid",
+		Type:     "perps",
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2100, Side: "short", Multiplier: 1, Leverage: 1, OwnerStrategyID: "hl-legacy-eth"},
+		},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{},
+	}
+
+	trades, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 1, 0.3, "legacy-open-oid", 0.42, false, logger)
+	if err != nil {
+		t.Fatalf("ExecutePerpsSignal: %v", err)
+	}
+	if trades != 2 {
+		t.Fatalf("trades = %d, want 2 (legacy close short + open long)", trades)
+	}
+	if len(s.TradeHistory) != 2 {
+		t.Fatalf("TradeHistory len = %d, want 2", len(s.TradeHistory))
+	}
+
+	closeLeg, openLeg := s.TradeHistory[0], s.TradeHistory[1]
+	if closeLeg.ExchangeOrderID != "" || closeLeg.ExchangeFee != 0 {
+		t.Errorf("legacy close leg exchange metadata = oid %q fee %g, want empty modeled-fee leg",
+			closeLeg.ExchangeOrderID, closeLeg.ExchangeFee)
+	}
+	if openLeg.ExchangeOrderID != "legacy-open-oid" || openLeg.ExchangeFee != 0.42 {
+		t.Errorf("legacy open leg exchange metadata = oid %q fee %g, want oid legacy-open-oid fee 0.42",
+			openLeg.ExchangeOrderID, openLeg.ExchangeFee)
+	}
+	pos := s.Positions["ETH"]
+	if pos == nil || pos.Side != "long" || pos.Quantity != 0.3 {
+		t.Fatalf("position after legacy close/open = %+v, want long qty 0.3", pos)
+	}
+
+	modeledCloseFee := CalculatePlatformSpotFee("hyperliquid", 0.5*2000)
+	wantCash := 1000.0 + (0.5*(2100-2000) - modeledCloseFee) - 0.42
+	if math.Abs(s.Cash-wantCash) > 1e-9 {
+		t.Errorf("cash = %.9f, want %.9f (close modeled fee + open real fill fee)", s.Cash, wantCash)
+	}
+}
+
 // #328 — long + signal=-1 + AllowShorts closes the long AND opens a short.
 // Mirrors the existing signal=1+short close-and-flip branch. Produces exactly
 // two Trade rows; the close leg carries the real fill fee while the open leg

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -540,6 +540,63 @@ func TestExecuteSpotSignalLiveFill(t *testing.T) {
 	}
 }
 
+func TestExecutionFeeSelection(t *testing.T) {
+	cases := []struct {
+		name       string
+		modeledFee float64
+		fillFee    float64
+		useFillFee bool
+		want       float64
+	}{
+		{"zero_fill_fee_falls_back", 0.35, 0, true, 0.35},
+		{"non_zero_fill_fee_uses_real", 0.35, 0.12, true, 0.12},
+		{"flip_open_leg_uses_modeled", 0.35, 0.12, false, 0.35},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := executionFee(tc.modeledFee, tc.fillFee, tc.useFillFee)
+			if got != tc.want {
+				t.Errorf("executionFee(%g, %g, %v) = %g, want %g",
+					tc.modeledFee, tc.fillFee, tc.useFillFee, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExecuteSpotSignalLiveFillUsesExchangeFee(t *testing.T) {
+	s := &StrategyState{
+		ID:              "rh-momentum-btc",
+		Cash:            1000,
+		Platform:        "robinhood",
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	fillQty := 0.015
+	fillPrice := 50000.0
+	fillFee := 0.17
+	trades, err := ExecuteSpotSignalWithFillFee(s, 1, "BTC", fillPrice, fillQty, fillFee, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trades != 1 {
+		t.Errorf("trades = %d, want 1", trades)
+	}
+	wantCash := 1000.0 - fillQty*fillPrice - fillFee
+	if math.Abs(s.Cash-wantCash) > 1e-9 {
+		t.Errorf("cash = %.9f, want %.9f (live fill fee)", s.Cash, wantCash)
+	}
+	if len(s.TradeHistory) != 1 || s.TradeHistory[0].ExchangeFee != fillFee {
+		t.Fatalf("ExchangeFee = %v, want %v", s.TradeHistory, fillFee)
+	}
+}
+
 // #254: ExecutePerpsSignal — margin-based accounting. Paper buy should NOT
 // deplete cash by the full notional (unlike spot). Only the fee leaves cash,
 // and the opened position is stamped with Multiplier=1 so PortfolioValue
@@ -592,6 +649,38 @@ func TestExecutePerpsSignalPaperBuyNoNotionalDeduction(t *testing.T) {
 	}
 	if s.Cash >= 1000 {
 		t.Errorf("cash = %v, should have some fee deducted", s.Cash)
+	}
+}
+
+func TestExecutePerpsSignalLiveOpenUsesExchangeFee(t *testing.T) {
+	s := &StrategyState{
+		ID:              "hl-test-eth",
+		Cash:            1000,
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	fillFee := 0.42
+	trades, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 1, 0.5, "oid-1", fillFee, false, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	wantCash := 1000.0 - fillFee
+	if math.Abs(s.Cash-wantCash) > 1e-9 {
+		t.Errorf("cash = %.9f, want %.9f (real fill fee)", s.Cash, wantCash)
+	}
+	if s.TradeHistory[0].ExchangeFee != fillFee {
+		t.Errorf("ExchangeFee = %g, want %g", s.TradeHistory[0].ExchangeFee, fillFee)
 	}
 }
 
@@ -901,6 +990,39 @@ func TestExecuteFuturesSignalLiveFill(t *testing.T) {
 	}
 }
 
+func TestExecuteFuturesSignalLiveFillUsesExchangeFee(t *testing.T) {
+	s := &StrategyState{
+		ID:              "ts-momentum-es",
+		Cash:            10000,
+		Platform:        "topstep",
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	spec := ContractSpec{TickSize: 0.25, TickValue: 12.5, Multiplier: 50, Margin: 500}
+	fillFee := 4.12
+	trades, err := ExecuteFuturesSignalWithFillFee(s, 1, "ES", 5000, spec, 2.5, 5, 2, fillFee, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	wantCash := 10000.0 - fillFee
+	if math.Abs(s.Cash-wantCash) > 1e-9 {
+		t.Errorf("cash = %.9f, want %.9f (real fill fee)", s.Cash, wantCash)
+	}
+	if s.TradeHistory[0].ExchangeFee != fillFee {
+		t.Errorf("ExchangeFee = %g, want %g", s.TradeHistory[0].ExchangeFee, fillFee)
+	}
+}
+
 // #328 — AllowShorts=true lets signal=-1 from flat open a short perp position.
 // Without AllowShorts the same call returns 0 trades (legacy close-long-only).
 func TestExecutePerpsSignalOpenShortFromFlat(t *testing.T) {
@@ -997,8 +1119,8 @@ func TestExecutePerpsSignalLegacyFlatNoShort(t *testing.T) {
 
 // #328 — long + signal=-1 + AllowShorts closes the long AND opens a short.
 // Mirrors the existing signal=1+short close-and-flip branch. Produces exactly
-// two Trade rows; only the opening trade carries live exchange metadata so a
-// single fill's fee isn't double-counted (#289).
+// two Trade rows; the close leg carries the real fill fee while the open leg
+// uses modeled fee cash math so a single fill's fee isn't double-counted (#451).
 func TestExecutePerpsSignalFlipLongToShort(t *testing.T) {
 	lm, _ := NewLogManager("")
 	logger, _ := lm.GetStrategyLogger("test")
@@ -1038,12 +1160,19 @@ func TestExecutePerpsSignalFlipLongToShort(t *testing.T) {
 		t.Fatalf("TradeHistory len = %d, want 2", len(s.TradeHistory))
 	}
 	closeLeg, openLeg := s.TradeHistory[0], s.TradeHistory[1]
-	if closeLeg.ExchangeOrderID != "" || closeLeg.ExchangeFee != 0 {
-		t.Errorf("close leg carries exchange metadata (oid=%q fee=%g); must stay empty",
+	if closeLeg.ExchangeOrderID != "live-flip-oid" || closeLeg.ExchangeFee != 0.5 {
+		t.Errorf("close leg exchange metadata = oid %q fee %g, want oid live-flip-oid fee 0.5",
 			closeLeg.ExchangeOrderID, closeLeg.ExchangeFee)
 	}
-	if openLeg.ExchangeOrderID != "live-flip-oid" || openLeg.ExchangeFee != 0.5 {
-		t.Errorf("open leg missing exchange metadata: oid=%q fee=%g", openLeg.ExchangeOrderID, openLeg.ExchangeFee)
+	if openLeg.ExchangeOrderID != "" || openLeg.ExchangeFee != 0 {
+		t.Errorf("open leg exchange metadata = oid %q fee %g, want empty modeled-fee leg",
+			openLeg.ExchangeOrderID, openLeg.ExchangeFee)
+	}
+	// Close PnL: +$50 - $0.50 real fill fee. Open notional: 0.5 * $2000
+	// with Hyperliquid modeled taker fee 0.035% = $0.35.
+	wantCash := 1000.0 + 49.5 - 0.35
+	if math.Abs(s.Cash-wantCash) > 1e-9 {
+		t.Errorf("cash = %.9f, want %.9f (flip close real fee + open modeled fee)", s.Cash, wantCash)
 	}
 }
 

--- a/scheduler/trade_persist_test.go
+++ b/scheduler/trade_persist_test.go
@@ -343,11 +343,11 @@ func TestRecordTrade_PersistFailureTriggersWarnHook(t *testing.T) {
 
 // TestExecutePerpsSignal_FlipDoesNotDoubleCountFee pins the policy that when
 // a buy signal encounters an existing short — producing a close-short +
-// open-long pair in memory — only the opening trade carries the exchange
+// open-long pair in memory — only one synthetic leg carries the exchange
 // fee. A single live fill represents one exchange fee; stamping it on both
 // synthetic legs would 2× it in analytics. Summed ExchangeFee across the
 // two persisted rows must equal the one real fee, and the OID must appear
-// on exactly one row (the opener — the trade that reflects the real fill).
+// on exactly one row.
 func TestExecutePerpsSignal_FlipDoesNotDoubleCountFee(t *testing.T) {
 	db := openTestDB(t)
 	prev := tradeRecorder
@@ -381,9 +381,9 @@ func TestExecutePerpsSignal_FlipDoesNotDoubleCountFee(t *testing.T) {
 	logger := newTestLogger(t)
 	s := state.Strategies["hl-flip"]
 
-	// Live buy @ $2000 qty=0.3 → closes the full 0.5 short + opens new 0.3
-	// long = 2 in-memory trades, 1 real exchange fill worth $0.42.
-	trades, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 1, 0.3, "99999", 0.42, false, logger)
+	// Live flip buy @ $2000 qty=0.8 → closes the full 0.5 short + opens new
+	// 0.3 long = 2 in-memory trades, 1 real exchange fill worth $0.42.
+	trades, err := ExecutePerpsSignal(s, 1, "ETH", 2000, 1, 0.8, "99999", 0.42, true, logger)
 	if err != nil {
 		t.Fatalf("ExecutePerpsSignal: %v", err)
 	}
@@ -402,11 +402,15 @@ func TestExecutePerpsSignal_FlipDoesNotDoubleCountFee(t *testing.T) {
 
 	var totalFee float64
 	oidHits := 0
+	var closeFee float64
 	var openerFee float64
 	for _, tr := range ss.TradeHistory {
 		totalFee += tr.ExchangeFee
 		if tr.ExchangeOrderID == "99999" {
 			oidHits++
+			closeFee = tr.ExchangeFee
+		}
+		if strings.Contains(tr.Details, "Open long") {
 			openerFee = tr.ExchangeFee
 		}
 	}
@@ -414,10 +418,13 @@ func TestExecutePerpsSignal_FlipDoesNotDoubleCountFee(t *testing.T) {
 		t.Errorf("sum(ExchangeFee) = %v, want 0.42 (fee double-counted across flip legs)", totalFee)
 	}
 	if oidHits != 1 {
-		t.Errorf("rows with OID=99999 = %d, want 1 (only the opener should carry the real fill's OID)", oidHits)
+		t.Errorf("rows with OID=99999 = %d, want 1", oidHits)
 	}
-	if openerFee != 0.42 {
-		t.Errorf("opener ExchangeFee = %v, want 0.42", openerFee)
+	if closeFee != 0.42 {
+		t.Errorf("close ExchangeFee = %v, want 0.42", closeFee)
+	}
+	if openerFee != 0 {
+		t.Errorf("opener ExchangeFee = %v, want 0 (open leg uses modeled cash fee)", openerFee)
 	}
 }
 

--- a/shared_scripts/check_okx.py
+++ b/shared_scripts/check_okx.py
@@ -44,6 +44,25 @@ def _make_dataframe(candles):
     return df
 
 
+def _float_or_none(value):
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_fee(response):
+    """Extract ccxt unified order fee.cost when present."""
+    if not isinstance(response, dict):
+        return None
+    fee_info = response.get("fee")
+    if isinstance(fee_info, dict):
+        return _float_or_none(fee_info.get("cost"))
+    return _float_or_none(fee_info)
+
+
 def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=False, inst_type="swap", strategy_params_override=None):
     """Run strategy signal check using OKX OHLCV data."""
     try:
@@ -209,6 +228,9 @@ def run_execute(symbol, side, size, mode, inst_type="swap"):
                 "avg_px": float(result.get("average", 0) or 0),
                 "total_sz": float(result.get("filled", 0) or 0),
             }
+            fee = _extract_fee(result)
+            if fee is not None:
+                fill["fee"] = fee
         except Exception:
             pass
 

--- a/shared_scripts/check_robinhood.py
+++ b/shared_scripts/check_robinhood.py
@@ -44,10 +44,25 @@ def _float_or_none(value):
         return None
 
 
-def _extract_fee_value(value):
+_FEE_CONTAINER_KEYS = (
+    "fee",
+    "fees",
+    "commission",
+    "commission_paid",
+    "total_fee",
+    "totalFee",
+    "estimated_fee",
+    "regulatory_fee",
+)
+
+_FEE_VALUE_KEYS = ("cost", "amount", "total", "value")
+
+
+def _extract_fee_value(value, fee_context=False):
     if isinstance(value, dict):
-        for key in ("cost", "amount", "fee", "fees", "commission", "total", "value"):
-            fee = _extract_fee_value(value.get(key))
+        keys = _FEE_VALUE_KEYS if fee_context else _FEE_CONTAINER_KEYS
+        for key in keys:
+            fee = _extract_fee_value(value.get(key), fee_context=True)
             if fee is not None:
                 return fee
         return None
@@ -55,20 +70,22 @@ def _extract_fee_value(value):
         total = 0.0
         found = False
         for item in value:
-            fee = _extract_fee_value(item)
+            fee = _extract_fee_value(item, fee_context=fee_context)
             if fee is not None:
                 total += fee
                 found = True
         return total if found else None
-    return _float_or_none(value)
+    if fee_context:
+        return _float_or_none(value)
+    return None
 
 
 def _extract_fee(response):
     """Best-effort Robinhood order fee extraction; absent fees fall back in Go."""
     if not isinstance(response, dict):
         return None
-    for key in ("fee", "fees", "commission", "total_fee", "totalFee", "estimated_fee", "regulatory_fee"):
-        fee = _extract_fee_value(response.get(key))
+    for key in _FEE_CONTAINER_KEYS:
+        fee = _extract_fee_value(response.get(key), fee_context=True)
         if fee is not None:
             return fee
     return _extract_fee_value(response.get("executions"))

--- a/shared_scripts/check_robinhood.py
+++ b/shared_scripts/check_robinhood.py
@@ -35,6 +35,45 @@ def _make_dataframe(candles):
     return df
 
 
+def _float_or_none(value):
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_fee_value(value):
+    if isinstance(value, dict):
+        for key in ("cost", "amount", "fee", "fees", "commission", "total", "value"):
+            fee = _extract_fee_value(value.get(key))
+            if fee is not None:
+                return fee
+        return None
+    if isinstance(value, list):
+        total = 0.0
+        found = False
+        for item in value:
+            fee = _extract_fee_value(item)
+            if fee is not None:
+                total += fee
+                found = True
+        return total if found else None
+    return _float_or_none(value)
+
+
+def _extract_fee(response):
+    """Best-effort Robinhood order fee extraction; absent fees fall back in Go."""
+    if not isinstance(response, dict):
+        return None
+    for key in ("fee", "fees", "commission", "total_fee", "totalFee", "estimated_fee", "regulatory_fee"):
+        fee = _extract_fee_value(response.get(key))
+        if fee is not None:
+            return fee
+    return _extract_fee_value(response.get("executions"))
+
+
 def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=False, strategy_params=None):
     """Run strategy signal check using yfinance OHLCV data."""
     try:
@@ -178,6 +217,9 @@ def run_execute(symbol, side, amount_usd, quantity, mode):
                 filled_qty = float(result.get("cumulative_quantity", 0) or 0)
                 if avg_px > 0:
                     fill = {"avg_px": avg_px, "quantity": filled_qty}
+                    fee = _extract_fee(result)
+                    if fee is not None:
+                        fill["fee"] = fee
         except Exception:
             pass
 

--- a/shared_scripts/check_topstep.py
+++ b/shared_scripts/check_topstep.py
@@ -42,10 +42,15 @@ def _float_or_none(value):
         return None
 
 
-def _extract_fee_value(value):
+_FEE_CONTAINER_KEYS = ("fee", "fees", "commission", "commission_paid", "totalFee", "totalFees", "commissionAndFees")
+_FEE_VALUE_KEYS = ("cost", "amount", "total", "value")
+
+
+def _extract_fee_value(value, fee_context=False):
     if isinstance(value, dict):
-        for key in ("cost", "amount", "fee", "fees", "commission", "total", "value"):
-            fee = _extract_fee_value(value.get(key))
+        keys = _FEE_VALUE_KEYS if fee_context else _FEE_CONTAINER_KEYS
+        for key in keys:
+            fee = _extract_fee_value(value.get(key), fee_context=True)
             if fee is not None:
                 return fee
         return None
@@ -53,20 +58,22 @@ def _extract_fee_value(value):
         total = 0.0
         found = False
         for item in value:
-            fee = _extract_fee_value(item)
+            fee = _extract_fee_value(item, fee_context=fee_context)
             if fee is not None:
                 total += fee
                 found = True
         return total if found else None
-    return _float_or_none(value)
+    if fee_context:
+        return _float_or_none(value)
+    return None
 
 
 def _extract_fee(response):
     """Best-effort TopStep fill fee extraction; absent fees fall back in Go."""
     if not isinstance(response, dict):
         return None
-    for key in ("fee", "fees", "commission", "totalFee", "totalFees", "commissionAndFees"):
-        fee = _extract_fee_value(response.get(key))
+    for key in _FEE_CONTAINER_KEYS:
+        fee = _extract_fee_value(response.get(key), fee_context=True)
         if fee is not None:
             return fee
     return None

--- a/shared_scripts/check_topstep.py
+++ b/shared_scripts/check_topstep.py
@@ -33,6 +33,45 @@ def _make_dataframe(candles):
     return df
 
 
+def _float_or_none(value):
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_fee_value(value):
+    if isinstance(value, dict):
+        for key in ("cost", "amount", "fee", "fees", "commission", "total", "value"):
+            fee = _extract_fee_value(value.get(key))
+            if fee is not None:
+                return fee
+        return None
+    if isinstance(value, list):
+        total = 0.0
+        found = False
+        for item in value:
+            fee = _extract_fee_value(item)
+            if fee is not None:
+                total += fee
+                found = True
+        return total if found else None
+    return _float_or_none(value)
+
+
+def _extract_fee(response):
+    """Best-effort TopStep fill fee extraction; absent fees fall back in Go."""
+    if not isinstance(response, dict):
+        return None
+    for key in ("fee", "fees", "commission", "totalFee", "totalFees", "commissionAndFees"):
+        fee = _extract_fee_value(response.get(key))
+        if fee is not None:
+            return fee
+    return None
+
+
 def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=False, strategy_params=None):
     """Run strategy signal check using TopStep market data."""
     try:
@@ -195,6 +234,9 @@ def run_execute(symbol, side, contracts, mode):
                 "avg_px": float(result.get("avgPrice", 0) or 0),
                 "total_contracts": int(result.get("filledQuantity", contracts) or contracts),
             }
+            fee = _extract_fee(result)
+            if fee is not None:
+                fill["fee"] = fee
         except Exception as e:
             print(f"[topstep] fill parse error: {e}", file=sys.stderr)
 

--- a/shared_scripts/test_check_execute_fees.py
+++ b/shared_scripts/test_check_execute_fees.py
@@ -1,0 +1,33 @@
+"""Tests for live execute fee extraction in platform check scripts."""
+
+import importlib.util
+import os
+
+
+def _load_script(filename):
+    script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), filename)
+    module_name = filename.replace(".py", "").replace("-", "_") + "_fee_test"
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_okx_extracts_ccxt_fee_cost():
+    mod = _load_script("check_okx.py")
+    assert mod._extract_fee({"fee": {"cost": "0.25", "currency": "USDT"}}) == 0.25
+
+
+def test_robinhood_extracts_nested_execution_fee():
+    mod = _load_script("check_robinhood.py")
+    response = {
+        "average_price": "50000",
+        "cumulative_quantity": "0.01",
+        "executions": [{"fees": [{"amount": "0.03"}, {"amount": "0.02"}]}],
+    }
+    assert abs(mod._extract_fee(response) - 0.05) < 1e-12
+
+
+def test_topstep_extracts_nested_fee_total():
+    mod = _load_script("check_topstep.py")
+    assert abs(mod._extract_fee({"totalFees": [{"amount": "1.50"}, {"amount": "2.62"}]}) - 4.12) < 1e-12

--- a/shared_scripts/test_check_execute_fees.py
+++ b/shared_scripts/test_check_execute_fees.py
@@ -28,6 +28,21 @@ def test_robinhood_extracts_nested_execution_fee():
     assert abs(mod._extract_fee(response) - 0.05) < 1e-12
 
 
+def test_robinhood_ignores_execution_notional_without_fee_keys():
+    mod = _load_script("check_robinhood.py")
+    response = {
+        "average_price": "50000",
+        "cumulative_quantity": "0.015",
+        "executions": [{"total": "750.00", "value": "0.015", "amount": "0.015"}],
+    }
+    assert mod._extract_fee(response) is None
+
+
 def test_topstep_extracts_nested_fee_total():
     mod = _load_script("check_topstep.py")
     assert abs(mod._extract_fee({"totalFees": [{"amount": "1.50"}, {"amount": "2.62"}]}) - 4.12) < 1e-12
+
+
+def test_topstep_ignores_generic_nested_totals_without_fee_context():
+    mod = _load_script("check_topstep.py")
+    assert mod._extract_fee_value([{"total": "750.00", "value": "0.015"}]) is None


### PR DESCRIPTION
## Summary

- Use exchange-reported live fill fees for open-path cash math when present, with modeled fees as the fallback for paper or missing fee data.
- Thread fill fees through OKX, Robinhood, and TopStep execute results, matching the existing Hyperliquid fill metadata path.
- Apply the flip policy from issue #451: the real fill fee belongs to the close leg, while the synthetic open leg uses modeled fee cash math.
- Add focused Go and Python regression coverage for fee selection, JSON parsing, and script-level fee extraction.

## Validation

- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...`
- `/Users/richardkuo/Work/openclaw/go-trader/.venv/bin/python3 -m py_compile shared_scripts/check_okx.py shared_scripts/check_robinhood.py shared_scripts/check_topstep.py shared_scripts/test_check_execute_fees.py`
- `/Users/richardkuo/Work/openclaw/go-trader/.venv/bin/python3 -m pytest shared_scripts/test_check_execute_fees.py -q`
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler build -o /tmp/go-trader-build-check .`
- `git diff --check`

Closes #451

LLM: GPT-5.5 | extra high effort