### PR TITLE
[codex] fix shared-wallet fallback kill switch

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -527,7 +527,9 @@ type HyperliquidLiveCloseReport struct {
 	// pre-filters szi≠0, so this branch should not fire in production) AND the
 	// adapter-side already_flat envelope flag, which IS production-reachable
 	// when the eventual-consistency window between the Go-side fetch and the
-	// SDK submit lets a position close out from under us (#350).
+	// SDK submit lets a position close out from under us (#350), or when a
+	// post-close verification fetch proves a coin is flat after the close
+	// subprocess returned an error (#452).
 	AlreadyFlat []string
 	// Errors is non-nil so coin-keyed writes don't panic; len() works on nil maps too.
 	Errors map[string]error

--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -201,6 +201,34 @@ func defaultHLStateFetcher(addr string) ([]HLPosition, error) {
 	return pos, err
 }
 
+// clearVerifiedFlatHLErrors removes close errors for coins that a follow-up
+// clearinghouseState fetch proves are now flat. This handles the post-submit
+// failure window where the reduce-only close filled on-chain, but the Python
+// subprocess still returned an error before Go saw a confirmed result (#452).
+func clearVerifiedFlatHLErrors(report *HyperliquidLiveCloseReport, positions []HLPosition) []string {
+	if report == nil || len(report.Errors) == 0 {
+		return nil
+	}
+
+	open := make(map[string]bool)
+	for _, p := range positions {
+		if p.Size != 0 {
+			open[p.Coin] = true
+		}
+	}
+
+	var verified []string
+	for _, coin := range report.SortedErrorCoins() {
+		if open[coin] {
+			continue
+		}
+		delete(report.Errors, coin)
+		report.AlreadyFlat = append(report.AlreadyFlat, coin)
+		verified = append(verified, coin)
+	}
+	return verified
+}
+
 // planKillSwitchClose runs the kill-switch close logic without touching any
 // mutable state — no locks, no virtual state mutation, no Discord delivery.
 // The caller applies mutations based on the returned plan.
@@ -253,6 +281,18 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 		ctx, cancel := context.WithTimeout(context.Background(), in.platformCloseBudget(in.HLCloseTimeout))
 		plan.CloseReport = forceCloseHyperliquidLive(ctx, hlPositions, in.HLLiveAll, in.HLCloser, in.HLStopLossOIDs)
 		cancel()
+		if !plan.CloseReport.ConfirmedFlat() {
+			if in.HLAddr != "" && in.HLFetcher != nil {
+				postClosePositions, err := in.HLFetcher(in.HLAddr)
+				if err != nil {
+					plan.LogLines = append(plan.LogLines,
+						fmt.Sprintf("[CRITICAL] hl-close: unable to verify HL state after close error: %v", err))
+				} else if verified := clearVerifiedFlatHLErrors(&plan.CloseReport, postClosePositions); len(verified) > 0 {
+					plan.LogLines = append(plan.LogLines,
+						fmt.Sprintf("[INFO] hl-close: verified flat after close error: %v", verified))
+				}
+			}
+		}
 		if !plan.CloseReport.ConfirmedFlat() {
 			plan.OnChainConfirmedFlat = false
 		}

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -163,12 +163,15 @@ func TestPlanKillSwitchClose_CloseError(t *testing.T) {
 	}
 	positions := []HLPosition{{Coin: "ETH", Size: 0.5}}
 	closer, _ := stubHLLiveCloser(map[string]error{"ETH": fmt.Errorf("hl rate limited")})
-	fetcher, _ := stubHLStateFetcher(nil, nil)
+	fetcher, fetchCalls := stubHLStateFetcher(positions, nil)
 
 	plan := planKillSwitchClose(defaultHLInputs("0xaddr", true, positions, hlLive,
 		"portfolio drawdown 25.0% exceeds limit 20.0%",
 		time.Second, closer, fetcher))
 
+	if *fetchCalls != 1 {
+		t.Fatalf("fetcher should be called once to verify the close error, got %d", *fetchCalls)
+	}
 	if plan.OnChainConfirmedFlat {
 		t.Fatal("expected NOT ConfirmedFlat on close error — kill switch would clear virtual state while on-chain is still live")
 	}
@@ -183,6 +186,69 @@ func TestPlanKillSwitchClose_CloseError(t *testing.T) {
 	}
 	if !strings.Contains(plan.DiscordMessage, "hl rate limited") {
 		t.Errorf("error detail missing from message, got: %s", plan.DiscordMessage)
+	}
+}
+
+// Close error followed by a flat verification fetch: the close may have filled
+// on-chain before the subprocess returned an error. In that case the kill switch
+// may clear virtual state instead of staying latched forever (#452).
+func TestPlanKillSwitchClose_CloseErrorVerifiedFlat(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-ema-eth", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"ema_crossover", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 0.5}}
+	closer, _ := stubHLLiveCloser(map[string]error{"ETH": fmt.Errorf("post-submit disconnect")})
+	fetcher, fetchCalls := stubHLStateFetcher(nil, nil)
+
+	plan := planKillSwitchClose(defaultHLInputs("0xaddr", true, positions, hlLive,
+		"portfolio drawdown 25.0% exceeds limit 20.0%",
+		time.Second, closer, fetcher))
+
+	if *fetchCalls != 1 {
+		t.Fatalf("fetcher should be called once to verify the close error, got %d", *fetchCalls)
+	}
+	if !plan.OnChainConfirmedFlat {
+		t.Fatalf("expected ConfirmedFlat after verification fetch proved ETH flat, got plan=%+v", plan)
+	}
+	if len(plan.CloseReport.Errors) != 0 {
+		t.Fatalf("expected verified-flat close error to be cleared, got %v", plan.CloseReport.Errors)
+	}
+	if len(plan.CloseReport.AlreadyFlat) != 1 || plan.CloseReport.AlreadyFlat[0] != "ETH" {
+		t.Errorf("AlreadyFlat = %v, want [ETH]", plan.CloseReport.AlreadyFlat)
+	}
+	if !strings.Contains(strings.Join(plan.LogLines, "\n"), "verified flat after close error: [ETH]") {
+		t.Errorf("expected verification log line, got %v", plan.LogLines)
+	}
+	if strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
+		t.Errorf("expected success-shaped message after verified-flat close error, got: %s", plan.DiscordMessage)
+	}
+}
+
+func TestPlanKillSwitchClose_CloseErrorVerificationFetchFailure(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-ema-eth", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"ema_crossover", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 0.5}}
+	closer, _ := stubHLLiveCloser(map[string]error{"ETH": fmt.Errorf("post-submit disconnect")})
+	fetcher, fetchCalls := stubHLStateFetcher(nil, fmt.Errorf("hl 503"))
+
+	plan := planKillSwitchClose(defaultHLInputs("0xaddr", true, positions, hlLive,
+		"portfolio drawdown 25.0% exceeds limit 20.0%",
+		time.Second, closer, fetcher))
+
+	if *fetchCalls != 1 {
+		t.Fatalf("fetcher should be called once to verify the close error, got %d", *fetchCalls)
+	}
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("expected NOT ConfirmedFlat when the verification fetch also fails")
+	}
+	if got, ok := plan.CloseReport.Errors["ETH"]; !ok || got == nil {
+		t.Errorf("expected ETH error to remain in report, got %v", plan.CloseReport.Errors)
+	}
+	if !strings.Contains(strings.Join(plan.LogLines, "\n"), "unable to verify HL state after close error: hl 503") {
+		t.Errorf("expected verification fetch error log line, got %v", plan.LogLines)
 	}
 }
 
@@ -321,7 +387,7 @@ func TestPlanKillSwitchClose_DeterministicErrorOrder(t *testing.T) {
 	var prev string
 	for i := 0; i < 10; i++ {
 		closer, _ := stubHLLiveCloser(errs)
-		fetcher, _ := stubHLStateFetcher(nil, nil)
+		fetcher, _ := stubHLStateFetcher(positions, nil)
 		plan := planKillSwitchClose(defaultHLInputs("0xaddr", true, positions, hlLive,
 			"reason", time.Second, closer, fetcher))
 		if prev != "" && plan.DiscordMessage != prev {

--- a/scheduler/shared_wallet.go
+++ b/scheduler/shared_wallet.go
@@ -102,8 +102,8 @@ var platformsWithSharedWalletBalanceFetcher = map[string]bool{
 // return a live balance for the given platform. Platforms recognized by
 // walletKeyFor but without a fetcher are EXCLUDED from detectSharedWallets so
 // multi-strategy setups on those platforms don't cause computeTotalPortfolioValue
-// to freeze the portfolio peak on every cycle via the max-of-members fallback
-// (#357 phase 1a preserves HL-only portfolio-value behavior).
+// to enter fallback and freeze the portfolio peak on every cycle (#357 phase 1a
+// preserves HL-only portfolio-value behavior).
 //
 // As phase 2-4 land real balance fetchers for OKX / TopStep / Robinhood, add
 // their platform strings to platformsWithSharedWalletBalanceFetcher to enable
@@ -119,8 +119,8 @@ func hasSharedWalletBalanceFetcher(platform string) bool {
 //
 // Wallets on platforms without a registered balance fetcher (see
 // hasSharedWalletBalanceFetcher) are also excluded: without a real-balance
-// fetch, computeTotalPortfolioValue would fall back to max(member PV) every
-// cycle and freeze the peak (#357 phase 1a preserves HL-only behavior).
+// fetch, computeTotalPortfolioValue would use fallback every cycle and freeze
+// the peak (#357 phase 1a preserves HL-only behavior).
 // As phase 2-4 land balance fetchers for OKX / TS / RH, those platforms
 // become eligible for double-count protection automatically.
 func detectSharedWallets(strategies []StrategyConfig) map[SharedWalletKey][]string {
@@ -192,13 +192,12 @@ func fetchSharedWalletBalances(
 // balance per wallet.
 //
 // Fallback: when a shared-wallet balance is missing from walletBalances (e.g.
-// transient API failure), the function uses the MAX of member strategies'
-// PortfolioValue — NOT the sum. Summing members would re-introduce the exact
-// #243 double-count bug and can permanently inflate PortfolioRisk.PeakValue
-// (peak is sticky). Max is a lower-bound approximation that never exceeds a
-// single strategy's slice of the wallet. The returned usedFallback flag tells
-// the caller to skip peak ratcheting for that cycle so a network blip cannot
-// move the high-water mark.
+// transient API failure), the function sums member strategies' PortfolioValue.
+// The real-balance path still contributes the wallet once (#243); fallback has
+// no real wallet balance to de-duplicate, and each strategy carries its own
+// virtual cash/position slice. The returned usedFallback flag tells the caller
+// to skip peak ratcheting for that cycle so a network blip cannot move the
+// high-water mark.
 //
 // This function only reads state and does NOT perform network I/O — call
 // fetchSharedWalletBalances (or fetch clearinghouseState directly) first
@@ -238,7 +237,7 @@ func computeTotalPortfolioValue(
 	}
 
 	// One real-balance contribution per shared wallet. On fetch failure,
-	// use MAX of member strategies' PVs (never the sum — that's #243).
+	// sum member strategy PVs; usedFallback still freezes peak ratcheting.
 	usedFallback := false
 	for key, ids := range sharedWallets {
 		if bal, ok := walletBalances[key]; ok {
@@ -246,19 +245,17 @@ func computeTotalPortfolioValue(
 			continue
 		}
 		usedFallback = true
-		maxPV := 0.0
+		sumPV := 0.0
 		for _, id := range ids {
 			s, ok := state.Strategies[id]
 			if !ok {
 				continue
 			}
-			if pv := PortfolioValue(s, prices); pv > maxPV {
-				maxPV = pv
-			}
+			sumPV += PortfolioValue(s, prices)
 		}
-		fmt.Printf("[WARN] shared-wallet %s/%s: balance fetch missing, falling back to max(member PV)=$%.2f (peak will NOT be updated this cycle)\n",
-			key.Platform, key.Account, maxPV)
-		total += maxPV
+		fmt.Printf("[WARN] shared-wallet %s/%s: balance fetch missing, falling back to sum(member PV)=$%.2f (peak will NOT be updated this cycle)\n",
+			key.Platform, key.Account, sumPV)
+		total += sumPV
 	}
 
 	return total, usedFallback

--- a/scheduler/shared_wallet_test.go
+++ b/scheduler/shared_wallet_test.go
@@ -216,8 +216,8 @@ func TestWalletKeyFor_Robinhood_OptionsNoKey(t *testing.T) {
 // of #357: two live OKX perps strategies on the same API key are now grouped
 // as a shared wallet because fetch_okx_balance.py provides real-balance
 // lookup via defaultSharedWalletBalance. Before #360, OKX was deliberately
-// excluded to avoid freezing the portfolio peak via max-of-members fallback
-// in computeTotalPortfolioValue.
+// excluded to avoid freezing the portfolio peak via fallback every cycle in
+// computeTotalPortfolioValue.
 func TestDetectSharedWallets_OKXIncludedAfterFetcher(t *testing.T) {
 	t.Setenv("OKX_API_KEY", "okx-key-abc")
 
@@ -382,12 +382,11 @@ func TestComputeTotalPortfolioValue_SharedWalletUsesRealBalance(t *testing.T) {
 	}
 }
 
-// TestComputeTotalPortfolioValue_FallbackUsesMaxNotSum verifies that when the
-// real-balance fetch fails for a shared wallet, the function falls back to the
-// MAX of member strategies' PVs — NOT the sum. Summing members would
-// re-introduce the exact #243 double-count bug during transient fetch failures
-// and could permanently inflate PortfolioRisk.PeakValue.
-func TestComputeTotalPortfolioValue_FallbackUsesMaxNotSum(t *testing.T) {
+// TestComputeTotalPortfolioValue_FallbackSumsMemberPVs verifies issue #452:
+// when the real-balance fetch fails for a shared wallet, fallback must sum the
+// member strategy PVs. The real-balance path above still prevents #243
+// double-counting; fallback has no fetched wallet value to de-duplicate.
+func TestComputeTotalPortfolioValue_FallbackSumsMemberPVs(t *testing.T) {
 	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
 
 	strategies := []StrategyConfig{
@@ -402,22 +401,21 @@ func TestComputeTotalPortfolioValue_FallbackUsesMaxNotSum(t *testing.T) {
 	}
 
 	// Empty walletBalances (simulates fetch failure) — should fall back to
-	// MAX(4000, 6000) = 6000, NOT 4000 + 6000 = 10000 (which would be the
-	// #243 double-count bug in disguise).
+	// 4000 + 6000 = 10000, not max(4000, 6000) = 6000.
 	got, usedFallback := computeTotalPortfolioValue(strategies, state, nil, nil, nil)
-	want := 6000.0
+	want := 10000.0
 	if got != want {
-		t.Errorf("expected fallback total=%v (max of members); got %v — sum of members would re-introduce #243", want, got)
+		t.Errorf("expected fallback total=%v (sum of members); got %v", want, got)
 	}
 	if !usedFallback {
 		t.Errorf("expected usedFallback=true on fetch failure so caller can freeze peak")
 	}
 }
 
-// TestComputeTotalPortfolioValue_FallbackPreventsPeakInflation is a tabletop
-// verification of the peak-protection contract: two members with PVs that
-// summed would exceed PeakValue must NOT produce a total above the max member.
-func TestComputeTotalPortfolioValue_FallbackPreventsPeakInflation(t *testing.T) {
+// TestComputeTotalPortfolioValue_FallbackKeepsPeakFreezeSignal verifies that
+// the #452 sum fallback still tells main.go not to ratchet PeakValue upward
+// during a balance-fetch failure.
+func TestComputeTotalPortfolioValue_FallbackKeepsPeakFreezeSignal(t *testing.T) {
 	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
 
 	strategies := []StrategyConfig{
@@ -433,12 +431,8 @@ func TestComputeTotalPortfolioValue_FallbackPreventsPeakInflation(t *testing.T) 
 	}
 
 	got, usedFallback := computeTotalPortfolioValue(strategies, state, nil, nil, nil)
-	// Must NOT be 7000 (sum) — that's the #243 bug. Should be 3500 (max).
-	if got == 7000 {
-		t.Errorf("fallback total=%v matches sum-of-members — #243 double-count bug returned!", got)
-	}
-	if got != 3500 {
-		t.Errorf("expected fallback total=3500 (max of members); got %v", got)
+	if got != 7000 {
+		t.Errorf("expected fallback total=7000 (sum of members); got %v", got)
 	}
 	if !usedFallback {
 		t.Errorf("usedFallback must be true so main.go can freeze peak")


### PR DESCRIPTION
## Summary

- Change shared-wallet portfolio fallback from `max(member PV)` to `sum(member PV)` when the real wallet balance fetch is missing.
- Keep the fallback flag so portfolio peaks are still not ratcheted upward during balance-fetch failure cycles.
- Add Hyperliquid post-close verification after close subprocess errors, clearing the close error when a follow-up state fetch proves the coin is flat on-chain.

## Root Cause

The real-balance shared-wallet path correctly contributes one fetched account value to avoid double-counting, but the fetch-failure fallback reused a `max(member PV)` approximation. In shared-wallet HL setups, each strategy carries its own virtual cash/position slice, so fallback should sum those slices; using the max could understate equity and trigger a false portfolio kill switch.

A related kill-switch close path could also stay latched after an HL close actually filled on-chain if the close subprocess returned an error after submission. The planner now verifies HL state after such errors before deciding whether virtual state must remain preserved.

Closes #452

## Validation

- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...`
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler build .`

LLM: GPT-5 Codex | medium