### PR TITLE
discord: derive #T and W/L from lifetime trades, not RiskState counters

### DIFF
--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -148,12 +150,16 @@ CREATE TABLE IF NOT EXISTS trades (
     trade_type TEXT NOT NULL DEFAULT '',
     details TEXT NOT NULL DEFAULT '',
     exchange_order_id TEXT NOT NULL DEFAULT '',
-    exchange_fee REAL NOT NULL DEFAULT 0
+    exchange_fee REAL NOT NULL DEFAULT 0,
+    is_close INTEGER NOT NULL DEFAULT 0,
+    realized_pnl REAL NOT NULL DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS idx_trades_strategy ON trades(strategy_id);
 CREATE INDEX IF NOT EXISTS idx_trades_symbol ON trades(symbol);
 CREATE INDEX IF NOT EXISTS idx_trades_timestamp ON trades(timestamp DESC);
+-- idx_trades_close (#455) is created in migrateSchema, not here, so legacy
+-- DBs add the is_close column before the index references it.
 
 CREATE TABLE IF NOT EXISTS portfolio_risk (
     id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -240,6 +246,11 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE positions ADD COLUMN stop_loss_oid INTEGER NOT NULL DEFAULT 0",
 		// Per-trade HL stop-loss trigger price for later-fill reconciliation (#421).
 		"ALTER TABLE positions ADD COLUMN stop_loss_trigger_px REAL NOT NULL DEFAULT 0",
+		// Lifetime round-trip / win-loss tracking (#455). is_close marks closing
+		// legs; realized_pnl carries the per-trade realized PnL.
+		"ALTER TABLE trades ADD COLUMN is_close INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE trades ADD COLUMN realized_pnl REAL NOT NULL DEFAULT 0",
+		"CREATE INDEX IF NOT EXISTS idx_trades_close ON trades(strategy_id, is_close)",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -252,7 +263,106 @@ func (sdb *StateDB) migrateSchema() error {
 			return err
 		}
 	}
-	return sdb.migratePendingCircuitClosesColumn()
+	if err := sdb.migratePendingCircuitClosesColumn(); err != nil {
+		return err
+	}
+	return sdb.backfillTradeCloseFlags()
+}
+
+// backfillTradeCloseFlags is a one-time best-effort backfill (#455) for
+// pre-existing rows in the trades table that lack is_close/realized_pnl.
+// New rows always insert with explicit values, so this only runs against
+// rows where is_close=0 AND realized_pnl=0 — rows already populated by a
+// fresh insert won't be touched.
+//
+// The heuristic looks at the Details string (the only structured signal
+// available on legacy rows): close legs always include "PnL" (some sites
+// use "PnL: $X.XX", others "PnL=$X.XX"), and "expired ITM" identifies
+// option assignments / call-aways. We extract the realized PnL via the
+// shared regex and flip is_close=1 for matched rows. Best-effort: a row
+// whose Details was truncated or never carried a PnL substring stays at
+// is_close=0 (and undercounts by the same margin as the legacy in-memory
+// counters did pre-#455).
+func (sdb *StateDB) backfillTradeCloseFlags() error {
+	// Only flag rows that haven't been touched. Detect close trades by
+	// the "PnL" substring (covers "PnL: $X" and "PnL=$X" forms) — this
+	// matches every Details string emitted by a close-leg RecordTrade
+	// call site at the time of #455.
+	_, err := sdb.db.Exec(`UPDATE trades SET is_close = 1
+		WHERE is_close = 0 AND realized_pnl = 0 AND details LIKE '%PnL%'`)
+	if err != nil {
+		return fmt.Errorf("backfill is_close: %w", err)
+	}
+	// Parse the realized PnL out of the Details string. SQLite lacks
+	// regexp by default, so we walk the rows in Go. Only touch rows that
+	// were just flagged is_close=1 by the previous statement and still
+	// carry realized_pnl=0 (skip rows where future code already wrote a
+	// non-zero PnL — defensive against re-runs).
+	rows, err := sdb.db.Query(`SELECT rowid, details FROM trades
+		WHERE is_close = 1 AND realized_pnl = 0`)
+	if err != nil {
+		return fmt.Errorf("scan backfill candidates: %w", err)
+	}
+	type pnlRow struct {
+		id  int64
+		pnl float64
+	}
+	var updates []pnlRow
+	for rows.Next() {
+		var id int64
+		var details string
+		if err := rows.Scan(&id, &details); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan backfill row: %w", err)
+		}
+		if pnl, ok := parseDetailsPnL(details); ok {
+			updates = append(updates, pnlRow{id: id, pnl: pnl})
+		}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate backfill rows: %w", err)
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+	tx, err := sdb.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin backfill tx: %w", err)
+	}
+	defer tx.Rollback()
+	stmt, err := tx.Prepare("UPDATE trades SET realized_pnl = ? WHERE rowid = ?")
+	if err != nil {
+		return fmt.Errorf("prepare backfill update: %w", err)
+	}
+	defer stmt.Close()
+	for _, u := range updates {
+		if _, err := stmt.Exec(u.pnl, u.id); err != nil {
+			return fmt.Errorf("backfill realized_pnl: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+// pnlPattern matches the realized-PnL substring emitted by close-leg
+// RecordTrade Details strings: "PnL: $-1.23", "PnL=$4.56", "PnL: 7.89".
+// Both colon and equals are accepted; the dollar sign and sign are
+// optional. Whitespace between "PnL" and the value is tolerated.
+var pnlPattern = regexp.MustCompile(`PnL\s*[:=]\s*\$?(-?\d+(?:\.\d+)?)`)
+
+// parseDetailsPnL extracts the realized PnL value from a trade Details
+// string. Returns (0, false) when no PnL token is present. Used by the
+// #455 backfill to populate realized_pnl on legacy rows.
+func parseDetailsPnL(details string) (float64, bool) {
+	m := pnlPattern.FindStringSubmatch(details)
+	if len(m) < 2 {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
 }
 
 // migratePendingCircuitClosesColumn handles the #356/#359 pending-close column
@@ -326,12 +436,16 @@ func (sdb *StateDB) InsertTrade(strategyID string, trade Trade) error {
 	if sdb == nil || sdb.db == nil {
 		return fmt.Errorf("state db unavailable")
 	}
+	isClose := 0
+	if trade.IsClose {
+		isClose = 1
+	}
 	_, err := sdb.db.Exec(`INSERT INTO trades
-		(strategy_id, timestamp, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		(strategy_id, timestamp, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		strategyID, formatTime(trade.Timestamp), trade.Symbol, trade.Side,
 		trade.Quantity, trade.Price, trade.Value, trade.TradeType, trade.Details,
-		trade.ExchangeOrderID, trade.ExchangeFee)
+		trade.ExchangeOrderID, trade.ExchangeFee, isClose, trade.RealizedPnL)
 	if err != nil {
 		return fmt.Errorf("insert trade for %s: %w", strategyID, err)
 	}
@@ -542,8 +656,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	//    failed, even if later-timestamped rows were persisted successfully
 	//    (fixes the MAX(timestamp) dedup gap that would silently drop
 	//    out-of-order retries).
-	stmtTrade, err := tx.Prepare(`INSERT INTO trades (strategy_id, timestamp, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtTrade, err := tx.Prepare(`INSERT INTO trades (strategy_id, timestamp, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare trade insert: %w", err)
 	}
@@ -563,7 +677,11 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 				continue
 			}
 			t := s.TradeHistory[i]
-			if _, err := stmtTrade.Exec(s.ID, formatTime(t.Timestamp), t.Symbol, t.Side, t.Quantity, t.Price, t.Value, t.TradeType, t.Details, t.ExchangeOrderID, t.ExchangeFee); err != nil {
+			isClose := 0
+			if t.IsClose {
+				isClose = 1
+			}
+			if _, err := stmtTrade.Exec(s.ID, formatTime(t.Timestamp), t.Symbol, t.Side, t.Quantity, t.Price, t.Value, t.TradeType, t.Details, t.ExchangeOrderID, t.ExchangeFee, isClose, t.RealizedPnL); err != nil {
 				return fmt.Errorf("insert trade for %s: %w", s.ID, err)
 			}
 			flushed = append(flushed, trackedFlush{strat: s, index: i})
@@ -967,7 +1085,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 
 	// 5. Load most recent 1000 trades per strategy (full history stays in SQLite).
 	for id, s := range state.Strategies {
-		tradeRows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee
+		tradeRows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl
 			FROM trades WHERE strategy_id = ? ORDER BY timestamp ASC`, id)
 		if err != nil {
 			return nil, fmt.Errorf("load trades for %s: %w", id, err)
@@ -976,11 +1094,13 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		for tradeRows.Next() {
 			var t Trade
 			var tsStr string
-			if err := tradeRows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee); err != nil {
+			var isCloseInt int
+			if err := tradeRows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL); err != nil {
 				tradeRows.Close()
 				return nil, fmt.Errorf("scan trade: %w", err)
 			}
 			t.Timestamp = parseTime(tsStr)
+			t.IsClose = isCloseInt != 0
 			t.persisted = true // loaded from DB → already persisted; SaveState will skip.
 			allTrades = append(allTrades, t)
 		}
@@ -1046,6 +1166,58 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	return state, nil
 }
 
+// LifetimeTradeStats holds the per-strategy round-trip totals derived from
+// the trades table (#455). RoundTrips is the lifetime count of close legs
+// (1 trade = 1 round-trip per the issue spec); Wins and Losses partition
+// that count by realized PnL sign (PnL ≥ 0 → win, PnL < 0 → loss). Open
+// positions without a recorded close do not count.
+type LifetimeTradeStats struct {
+	RoundTrips int
+	Wins       int
+	Losses     int
+}
+
+// LifetimeTradeStatsAll returns lifetime round-trip stats for every strategy
+// that has at least one close trade in the trades table. Strategies with no
+// closes are absent from the result; callers should treat a missing key as
+// an all-zero struct. Used by FormatCategorySummary (#455) to render lifetime
+// #T / W/L columns that are immune to kill-switch / circuit-breaker resets
+// of the in-memory RiskState counters.
+func (sdb *StateDB) LifetimeTradeStatsAll() (map[string]LifetimeTradeStats, error) {
+	if sdb == nil || sdb.db == nil {
+		return nil, fmt.Errorf("state db unavailable")
+	}
+	rows, err := sdb.db.Query(`SELECT
+			strategy_id,
+			COUNT(*),
+			SUM(CASE WHEN realized_pnl >= 0 THEN 1 ELSE 0 END),
+			SUM(CASE WHEN realized_pnl < 0 THEN 1 ELSE 0 END)
+		FROM trades
+		WHERE is_close = 1
+		GROUP BY strategy_id`)
+	if err != nil {
+		return nil, fmt.Errorf("query lifetime trade stats: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string]LifetimeTradeStats)
+	for rows.Next() {
+		var id string
+		var total, wins, losses sql.NullInt64
+		if err := rows.Scan(&id, &total, &wins, &losses); err != nil {
+			return nil, fmt.Errorf("scan lifetime trade stats: %w", err)
+		}
+		out[id] = LifetimeTradeStats{
+			RoundTrips: int(total.Int64),
+			Wins:       int(wins.Int64),
+			Losses:     int(losses.Int64),
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate lifetime trade stats: %w", err)
+	}
+	return out, nil
+}
+
 // QueryTradeHistory returns trades filtered by optional strategy/symbol/time bounds,
 // ordered by timestamp desc, with limit/offset pagination.
 func (sdb *StateDB) QueryTradeHistory(strategyID, symbol string, since, until time.Time, limit, offset int) ([]Trade, int, error) {
@@ -1086,7 +1258,7 @@ func (sdb *StateDB) QueryTradeHistory(strategyID, symbol string, since, until ti
 		limit = 500
 	}
 
-	query := fmt.Sprintf("SELECT timestamp, strategy_id, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee FROM trades %s ORDER BY timestamp DESC LIMIT ? OFFSET ?", whereClause)
+	query := fmt.Sprintf("SELECT timestamp, strategy_id, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl FROM trades %s ORDER BY timestamp DESC LIMIT ? OFFSET ?", whereClause)
 	queryArgs := append(args, limit, offset)
 	rows, err := sdb.db.Query(query, queryArgs...)
 	if err != nil {
@@ -1098,10 +1270,12 @@ func (sdb *StateDB) QueryTradeHistory(strategyID, symbol string, since, until ti
 	for rows.Next() {
 		var t Trade
 		var tsStr string
-		if err := rows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee); err != nil {
+		var isCloseInt int
+		if err := rows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL); err != nil {
 			return nil, 0, fmt.Errorf("scan trade: %w", err)
 		}
 		t.Timestamp = parseTime(tsStr)
+		t.IsClose = isCloseInt != 0
 		trades = append(trades, t)
 	}
 	if err := rows.Err(); err != nil {

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -283,6 +283,12 @@ func (sdb *StateDB) migrateSchema() error {
 // whose Details was truncated or never carried a PnL substring stays at
 // is_close=0 (and undercounts by the same margin as the legacy in-memory
 // counters did pre-#455).
+//
+// Known asymmetry: the HL on-chain "no virtual position" branch emitted
+// "Circuit breaker on-chain close (no virtual position), fill=… fee=$…"
+// in its Details — no PnL token. Pre-#455 rows from that branch therefore
+// stay is_close=0 here, while post-#455 rows from the same branch land
+// is_close=1, realized_pnl=0 (written directly by hyperliquid_balance.go).
 func (sdb *StateDB) backfillTradeCloseFlags() error {
 	// Only flag rows that haven't been touched. Detect close trades by
 	// the "PnL" substring (covers "PnL: $X" and "PnL=$X" forms) — this
@@ -294,12 +300,13 @@ func (sdb *StateDB) backfillTradeCloseFlags() error {
 		return fmt.Errorf("backfill is_close: %w", err)
 	}
 	// Parse the realized PnL out of the Details string. SQLite lacks
-	// regexp by default, so we walk the rows in Go. Only touch rows that
-	// were just flagged is_close=1 by the previous statement and still
-	// carry realized_pnl=0 (skip rows where future code already wrote a
-	// non-zero PnL — defensive against re-runs).
+	// regexp by default, so we walk the rows in Go. Restrict to rows that
+	// have both is_close=1 and a "PnL" token: realized_pnl=0 rows without
+	// a PnL substring (e.g. the HL-fallback "no virtual position" branch)
+	// can never match parseDetailsPnL and would be re-scanned every boot
+	// otherwise.
 	rows, err := sdb.db.Query(`SELECT rowid, details FROM trades
-		WHERE is_close = 1 AND realized_pnl = 0`)
+		WHERE is_close = 1 AND realized_pnl = 0 AND details LIKE '%PnL%'`)
 	if err != nil {
 		return fmt.Errorf("scan backfill candidates: %w", err)
 	}
@@ -1169,8 +1176,10 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 // LifetimeTradeStats holds the per-strategy round-trip totals derived from
 // the trades table (#455). RoundTrips is the lifetime count of close legs
 // (1 trade = 1 round-trip per the issue spec); Wins and Losses partition
-// that count by realized PnL sign (PnL ≥ 0 → win, PnL < 0 → loss). Open
-// positions without a recorded close do not count.
+// that count by strict realized PnL sign (PnL > 0 → win, PnL < 0 → loss).
+// Breakeven closes (PnL = 0) are excluded from both buckets so that the
+// on-chain "no virtual position" fallback (which records realized_pnl=0)
+// does not inflate W. Open positions without a recorded close do not count.
 type LifetimeTradeStats struct {
 	RoundTrips int
 	Wins       int
@@ -1190,7 +1199,7 @@ func (sdb *StateDB) LifetimeTradeStatsAll() (map[string]LifetimeTradeStats, erro
 	rows, err := sdb.db.Query(`SELECT
 			strategy_id,
 			COUNT(*),
-			SUM(CASE WHEN realized_pnl >= 0 THEN 1 ELSE 0 END),
+			SUM(CASE WHEN realized_pnl > 0 THEN 1 ELSE 0 END),
 			SUM(CASE WHEN realized_pnl < 0 THEN 1 ELSE 0 END)
 		FROM trades
 		WHERE is_close = 1

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -1863,3 +1863,171 @@ func TestMigrateSchema_PendingCircuitClosesColumn_FromLegacyDB(t *testing.T) {
 		t.Errorf("row data lost in rename; got %q", raw)
 	}
 }
+
+// TestParseDetailsPnL verifies the regex used to backfill realized_pnl from
+// pre-#455 trade Details strings. Covers each of the formatter variants emitted
+// by close-leg RecordTrade call sites at the time of #455.
+func TestParseDetailsPnL(t *testing.T) {
+	cases := []struct {
+		name    string
+		details string
+		want    float64
+		ok      bool
+	}{
+		{"close_long_perps", "Close long, PnL: $42.50 (fee $0.21)", 42.50, true},
+		{"close_short_spot", "Close short, PnL: $-1.23 (fee $0.10)", -1.23, true},
+		{"options_close", "Close BTC-call-50000-2026-05-01 PnL=$7.89", 7.89, true},
+		{"theta_harvest", "Theta harvest close ETH-put-3000-2026-05-15 PnL=$-4.20", -4.20, true},
+		{"circuit_breaker", "Circuit breaker close long, PnL: $0.00", 0.0, true},
+		{"wheel_callaway", "Wheel call-away: sold call expired ITM (spot=$50000.00), sold 0.1 BTC @ $51000 PnL=$100.00", 100.0, true},
+		{"open_long_no_pnl", "Open long 0.500000 @ $2000.00 (1.0x, fee $0.35)", 0, false},
+		{"buy_option_no_pnl", "Buy BTC call strike=50000 exp=2026-05-01 premium=$1.23 fee=$0.05", 0, false},
+		{"empty", "", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseDetailsPnL(tc.details)
+			if ok != tc.ok {
+				t.Fatalf("ok=%v, want %v (details=%q)", ok, tc.ok, tc.details)
+			}
+			if ok && got != tc.want {
+				t.Errorf("got %v, want %v (details=%q)", got, tc.want, tc.details)
+			}
+		})
+	}
+}
+
+// TestBackfillTradeCloseFlags exercises the one-time legacy backfill: rows
+// whose Details contain "PnL:" or "PnL=" should flip is_close=1 and have
+// realized_pnl populated. Open-leg rows must stay is_close=0.
+func TestBackfillTradeCloseFlags(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	const oldSchema = `
+CREATE TABLE app_state (id INTEGER PRIMARY KEY, cycle_count INTEGER NOT NULL DEFAULT 0);
+CREATE TABLE strategies (id TEXT PRIMARY KEY, type TEXT NOT NULL DEFAULT '');
+CREATE TABLE trades (
+    rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+    strategy_id TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    symbol TEXT NOT NULL,
+    side TEXT NOT NULL,
+    quantity REAL NOT NULL,
+    price REAL NOT NULL,
+    value REAL NOT NULL,
+    trade_type TEXT NOT NULL DEFAULT '',
+    details TEXT NOT NULL DEFAULT ''
+);`
+	if _, err := db.Exec(oldSchema); err != nil {
+		t.Fatalf("create old schema: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO strategies (id, type) VALUES ('s1', 'perps')`); err != nil {
+		t.Fatalf("seed strategy: %v", err)
+	}
+	rows := []struct{ side, details string }{
+		{"buy", "Open long 0.5 @ $2000.00 (1.0x, fee $0.35)"},
+		{"sell", "Close long, PnL: $42.50 (fee $0.21)"},
+		{"buy", "Open long 0.4 @ $2010.00 (1.0x, fee $0.30)"},
+		{"sell", "Close long, PnL: $-7.10 (fee $0.20)"},
+		{"close", "Theta harvest close opt-1 PnL=$3.14"},
+	}
+	for i, r := range rows {
+		ts := time.Now().UTC().Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano)
+		if _, err := db.Exec(`INSERT INTO trades (strategy_id, timestamp, symbol, side, quantity, price, value, trade_type, details) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			"s1", ts, "BTC", r.side, 0.1, 2000.0, 200.0, "perps", r.details); err != nil {
+			t.Fatalf("seed trade %d: %v", i, err)
+		}
+	}
+	db.Close()
+
+	sdb, err := OpenStateDB(path)
+	if err != nil {
+		t.Fatalf("OpenStateDB (with migration): %v", err)
+	}
+	defer sdb.Close()
+
+	stats, err := sdb.LifetimeTradeStatsAll()
+	if err != nil {
+		t.Fatalf("LifetimeTradeStatsAll: %v", err)
+	}
+	got := stats["s1"]
+	if got.RoundTrips != 3 {
+		t.Errorf("RoundTrips = %d, want 3 (3 close legs of 5 rows)", got.RoundTrips)
+	}
+	if got.Wins != 2 {
+		t.Errorf("Wins = %d, want 2 (PnL >= 0: $42.50, $3.14)", got.Wins)
+	}
+	if got.Losses != 1 {
+		t.Errorf("Losses = %d, want 1 (PnL < 0: $-7.10)", got.Losses)
+	}
+}
+
+// TestLifetimeTradeStatsAll_FreshInsert verifies that new InsertTrade calls
+// land with is_close/realized_pnl set so LifetimeTradeStatsAll reports them
+// without depending on the legacy backfill.
+func TestLifetimeTradeStatsAll_FreshInsert(t *testing.T) {
+	sdb := openTestDB(t)
+	now := time.Now().UTC()
+	trades := []Trade{
+		{StrategyID: "s1", Timestamp: now, Symbol: "BTC", Side: "buy", Quantity: 0.1, Price: 50000, Value: 5000, TradeType: "perps", Details: "Open long"},
+		{StrategyID: "s1", Timestamp: now.Add(time.Second), Symbol: "BTC", Side: "sell", Quantity: 0.1, Price: 51000, Value: 5100, TradeType: "perps", Details: "Close long, PnL: $100.00", IsClose: true, RealizedPnL: 100},
+		{StrategyID: "s1", Timestamp: now.Add(2 * time.Second), Symbol: "BTC", Side: "buy", Quantity: 0.1, Price: 51000, Value: 5100, TradeType: "perps", Details: "Open long"},
+		{StrategyID: "s1", Timestamp: now.Add(3 * time.Second), Symbol: "BTC", Side: "sell", Quantity: 0.1, Price: 50500, Value: 5050, TradeType: "perps", Details: "Close long, PnL: $-50.00", IsClose: true, RealizedPnL: -50},
+		{StrategyID: "s2", Timestamp: now, Symbol: "ETH", Side: "buy", Quantity: 0.5, Price: 2000, Value: 1000, TradeType: "perps", Details: "Open long"},
+		{StrategyID: "s2", Timestamp: now.Add(time.Second), Symbol: "ETH", Side: "sell", Quantity: 0.5, Price: 2100, Value: 1050, TradeType: "perps", Details: "Close long, PnL: $50.00", IsClose: true, RealizedPnL: 50},
+	}
+	for _, tr := range trades {
+		if err := sdb.InsertTrade(tr.StrategyID, tr); err != nil {
+			t.Fatalf("InsertTrade: %v", err)
+		}
+	}
+
+	stats, err := sdb.LifetimeTradeStatsAll()
+	if err != nil {
+		t.Fatalf("LifetimeTradeStatsAll: %v", err)
+	}
+	if got := stats["s1"]; got.RoundTrips != 2 || got.Wins != 1 || got.Losses != 1 {
+		t.Errorf("s1 stats = %+v, want RoundTrips=2 Wins=1 Losses=1", got)
+	}
+	if got := stats["s2"]; got.RoundTrips != 1 || got.Wins != 1 || got.Losses != 0 {
+		t.Errorf("s2 stats = %+v, want RoundTrips=1 Wins=1 Losses=0", got)
+	}
+	if _, ok := stats["s3"]; ok {
+		t.Errorf("unexpected entry for s3 with no closes: %+v", stats["s3"])
+	}
+}
+
+// TestLifetimeTradeStats_SurvivesRiskStateReset is the core regression test
+// for #455: kill-switch / circuit-breaker resets of the in-memory RiskState
+// counters MUST NOT change the lifetime stats query. The query reads from
+// trades, which is append-only, so simulating a counter reset leaves the DB
+// result intact.
+func TestLifetimeTradeStats_SurvivesRiskStateReset(t *testing.T) {
+	sdb := openTestDB(t)
+	now := time.Now().UTC()
+	closes := []Trade{
+		{StrategyID: "s1", Timestamp: now, Symbol: "BTC", Side: "sell", Quantity: 0.1, Price: 51000, Value: 5100, TradeType: "perps", Details: "Close long, PnL: $100", IsClose: true, RealizedPnL: 100},
+		{StrategyID: "s1", Timestamp: now.Add(time.Second), Symbol: "BTC", Side: "sell", Quantity: 0.1, Price: 50500, Value: 5050, TradeType: "perps", Details: "Close long, PnL: $-25", IsClose: true, RealizedPnL: -25},
+	}
+	for _, tr := range closes {
+		if err := sdb.InsertTrade(tr.StrategyID, tr); err != nil {
+			t.Fatalf("InsertTrade: %v", err)
+		}
+	}
+
+	// Simulate a kill-switch reset of in-memory RiskState. The trades table
+	// is append-only, so the lifetime query is unaffected.
+	_ = RiskState{}
+
+	stats, err := sdb.LifetimeTradeStatsAll()
+	if err != nil {
+		t.Fatalf("LifetimeTradeStatsAll: %v", err)
+	}
+	got := stats["s1"]
+	if got.RoundTrips != 2 || got.Wins != 1 || got.Losses != 1 {
+		t.Errorf("post-reset stats = %+v, want RoundTrips=2 Wins=1 Losses=1", got)
+	}
+}

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -1958,7 +1958,7 @@ CREATE TABLE trades (
 		t.Errorf("RoundTrips = %d, want 3 (3 close legs of 5 rows)", got.RoundTrips)
 	}
 	if got.Wins != 2 {
-		t.Errorf("Wins = %d, want 2 (PnL >= 0: $42.50, $3.14)", got.Wins)
+		t.Errorf("Wins = %d, want 2 (PnL > 0: $42.50, $3.14)", got.Wins)
 	}
 	if got.Losses != 1 {
 		t.Errorf("Losses = %d, want 1 (PnL < 0: $-7.10)", got.Losses)

--- a/scheduler/deribit.go
+++ b/scheduler/deribit.go
@@ -503,6 +503,8 @@ func applyAssignment(s *StrategyState, r markResult, logger *StrategyLogger) {
 			TradeType:  "assignment",
 			Details: fmt.Sprintf("Wheel call-away: sold call expired ITM (spot=$%.2f), sold %.4f %s @ $%.0f PnL=$%.2f",
 				r.AssignSpotPrice, r.AssignQuantity, symbol, r.AssignStrike, pnl),
+			IsClose:     true,
+			RealizedPnL: pnl,
 		})
 		logger.Info("CALL-AWAY: sold call %s-%.0f expired ITM (spot=$%.2f), sold %.4f %s @ $%.0f (proceeds=$%.2f, PnL=$%.2f)",
 			r.AssignUnderlying, r.AssignStrike, r.AssignSpotPrice, r.AssignQuantity, symbol, r.AssignStrike, proceeds, pnl)

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -246,6 +246,9 @@ const catTableMaxRows = 15
 // channelStrategies is pre-filtered by the caller; channelKey is the display label.
 // asset, when non-empty, appends " — <ASSET>" to the title and filters the prices line.
 // globalIntervalSeconds is the config-level default interval used when a strategy has no per-strategy override.
+// lifetimeStats is keyed by strategy ID; missing keys fall back to the
+// in-memory RiskState counters (#455). When nil, all rows fall back —
+// preserves existing test call sites that pre-date this parameter.
 func FormatCategorySummary(
 	cycle int,
 	elapsed time.Duration,
@@ -260,6 +263,7 @@ func FormatCategorySummary(
 	asset string,
 	globalIntervalSeconds int,
 	categorySharpe float64,
+	lifetimeStats map[string]LifetimeTradeStats,
 ) []string {
 	var sb strings.Builder
 
@@ -409,6 +413,22 @@ func FormatCategorySummary(
 		if effectiveInterval <= 0 {
 			effectiveInterval = globalIntervalSeconds
 		}
+		// Lifetime round-trip stats from the trades table (#455). Survives
+		// kill-switch and circuit-breaker resets; counts each open+close
+		// pair as a single trade. Falls back to the in-memory RiskState
+		// counters when the DB hasn't reported a stat for this strategy
+		// (e.g. tests that don't wire a DB, or first-run before any
+		// trade has been recorded).
+		closedT := ss.RiskState.TotalTrades
+		winT := ss.RiskState.WinningTrades
+		lossT := ss.RiskState.LosingTrades
+		if lifetimeStats != nil {
+			if lt, ok := lifetimeStats[sc.ID]; ok {
+				closedT = lt.RoundTrips
+				winT = lt.Wins
+				lossT = lt.Losses
+			}
+		}
 		tableBots = append(tableBots, botInfo{
 			id:             sc.ID,
 			strategy:       stratName,
@@ -423,9 +443,9 @@ func FormatCategorySummary(
 			walletPct:      walletPct,
 			trades:         len(ss.TradeHistory),
 			openPositions:  openPos,
-			closedTrades:   ss.RiskState.TotalTrades,
-			winningTrades:  ss.RiskState.WinningTrades,
-			losingTrades:   ss.RiskState.LosingTrades,
+			closedTrades:   closedT,
+			winningTrades:  winT,
+			losingTrades:   lossT,
 			tradeHistory:   ss.TradeHistory,
 		})
 	}

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -427,6 +428,13 @@ func FormatCategorySummary(
 				closedT = lt.RoundTrips
 				winT = lt.Wins
 				lossT = lt.Losses
+			} else if ss.RiskState.TotalTrades > 0 {
+				// DB was queried (non-nil map) but this strategy has no close
+				// trades recorded — RiskState counters may be stale (e.g. from
+				// a run before #455 landed). Log once per summary cycle so the
+				// discrepancy is visible without spamming the operator.
+				fmt.Fprintf(os.Stderr, "[discord] WARN: strategy %s has RiskState.TotalTrades=%d but no lifetime trades in DB; using in-memory fallback\n",
+					sc.ID, ss.RiskState.TotalTrades)
 			}
 		}
 		tableBots = append(tableBots, botInfo{

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -165,7 +165,7 @@ func TestFormatCategorySummary_WithAsset(t *testing.T) {
 	prices := map[string]float64{"BTC/USDT": 50000, "ETH/USDT": 3000}
 
 	// With asset — title should contain " — BTC" and only BTC price shown
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
 	msg := strings.Join(msgs, "\n")
 	if !strings.Contains(msg, "— BTC") {
 		t.Errorf("expected '— BTC' in title, got:\n%s", msg)
@@ -175,7 +175,7 @@ func TestFormatCategorySummary_WithAsset(t *testing.T) {
 	}
 
 	// Without asset — no suffix in title
-	msgs2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "", 600, 0)
+	msgs2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "", 600, 0, nil)
 	msg2 := strings.Join(msgs2, "\n")
 	if strings.Contains(msg2, "— ") {
 		t.Errorf("expected no asset suffix when asset='', got:\n%s", msg2)
@@ -201,20 +201,20 @@ func TestFormatCategorySummary_VersionSuffix(t *testing.T) {
 	defer func() { Version = orig }()
 
 	Version = "v9.9.9-test"
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
 	summary := strings.Join(msgs, "\n")
 	if !strings.Contains(summary, "("+Version+")") {
 		t.Errorf("expected version %q in summary title, got:\n%s", Version, summary)
 	}
 
-	msgs = FormatCategorySummary(1, 0, 1, 3, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
+	msgs = FormatCategorySummary(1, 0, 1, 3, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
 	trades := strings.Join(msgs, "\n")
 	if !strings.Contains(trades, "("+Version+")") {
 		t.Errorf("expected version %q in trades title, got:\n%s", Version, trades)
 	}
 
 	Version = ""
-	msgs = FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
+	msgs = FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
 	empty := strings.Join(msgs, "\n")
 	if strings.Contains(empty, "()") {
 		t.Errorf("empty Version should omit the suffix, got:\n%s", empty)
@@ -240,7 +240,7 @@ func TestFormatCategorySummary_CircuitBreakerActive(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "Circuit breaker active") {
@@ -274,7 +274,7 @@ func TestFormatCategorySummary_StrategiesSortedByID(t *testing.T) {
 		},
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
-	msgs := FormatCategorySummary(1, 0, 1, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
 	msg := strings.Join(msgs, "\n")
 	idxAdx := strings.Index(msg, "hl-adx-btc")
 	idxZebra := strings.Index(msg, "hl-zebra-btc")
@@ -297,7 +297,7 @@ func TestFormatCategorySummary_NoCircuitBreaker(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
 	msg := strings.Join(msgs, "\n")
 
 	if strings.Contains(msg, "Circuit breaker") {
@@ -591,7 +591,7 @@ func TestFormatCategorySummary_TfIntColumn(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 3600, 0)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 3600, 0, nil)
 	msg := strings.Join(msgs, "\n")
 
 	// Separate Tf and Int column headers should be present (at end of table).
@@ -616,7 +616,7 @@ func TestFormatCategorySummary_TfIntGlobalFallback(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "spot", "", 3600, 0)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "spot", "", 3600, 0, nil)
 	msg := strings.Join(msgs, "\n")
 
 	// No timeframe for spot → "—"; global interval 3600s → "1h". Separate columns now.
@@ -640,7 +640,7 @@ func TestFormatCategorySummary_MaxDrawdownColumn(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, " DD ") {
@@ -672,7 +672,7 @@ func TestFormatCategorySummary_MaxDrawdownColumn_SharedWallet(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil)
 	msg := strings.Join(msgs, "\n")
 	lines := strings.Split(msg, "\n")
 	var headerLine, totalLine string
@@ -718,7 +718,7 @@ func TestFormatCategorySummary_ClosedTradesColumn(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
 	msg := strings.Join(msgs, "\n")
 
 	// Header should include #T column.
@@ -773,7 +773,7 @@ func TestFormatCategorySummary_ClosedTradesColumn_SharedWallet(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "#T") {
@@ -846,7 +846,7 @@ func TestFormatCategorySummary_WinLossColumn(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "W/L") {
@@ -900,7 +900,7 @@ func TestFormatCategorySummary_SharedWallet(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil)
 	msg := strings.Join(msgs, "\n")
 
 	// Should contain Wallet% column
@@ -956,7 +956,7 @@ func TestFormatCategorySummary_WalletPctFromConfig(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "30.0%") {
@@ -981,7 +981,7 @@ func TestFormatCategorySummary_NoSharedWallet(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil)
 	msg := strings.Join(msgs, "\n")
 
 	if strings.Contains(msg, "Wallet%") {
@@ -1010,7 +1010,7 @@ func TestFormatCategorySummary_MessageSplitting(t *testing.T) {
 	state := &AppState{Strategies: strategies}
 	prices := map[string]float64{"BTC/USDT": 51000}
 
-	msgs := FormatCategorySummary(1, 0, 20, 0, 10000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 20, 0, 10000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
 
 	// Should produce multiple messages.
 	if len(msgs) < 2 {
@@ -1060,7 +1060,7 @@ func TestFormatCategorySummary_NoSplitWhenShort(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 51000}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
 
 	if len(msgs) != 1 {
 		t.Errorf("expected single message for 1 position, got %d", len(msgs))
@@ -1214,7 +1214,7 @@ func TestFormatCategorySummary_HeaderPriceFormat(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 2240.5}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil)
 	msg := strings.Join(msgs, "\n")
 	if !strings.Contains(msg, "ETH: $2,240.50") {
 		t.Errorf("expected header price 'ETH: $2,240.50', got:\n%s", msg)
@@ -1282,7 +1282,7 @@ func TestFormatCategorySummary_LargeTableChunked(t *testing.T) {
 	state := &AppState{Strategies: strategies}
 	prices := map[string]float64{"BTC/USDT": 51000}
 
-	msgs := FormatCategorySummary(1, 0, stratCount, 0, 14000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0)
+	msgs := FormatCategorySummary(1, 0, stratCount, 0, 14000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
 
 	if len(msgs) < 2 {
 		t.Fatalf("expected at least 2 messages for %d strategies, got %d", stratCount, len(msgs))
@@ -1456,5 +1456,77 @@ func TestSplitCategorySummary_MultiMessage(t *testing.T) {
 		if !strings.Contains(all, pl) {
 			t.Errorf("position %q missing from messages", pl)
 		}
+	}
+}
+
+// TestFormatCategorySummary_LifetimeStatsOverride verifies that
+// FormatCategorySummary prefers the lifetime stats map over the in-memory
+// RiskState counters (#455). Simulates a strategy whose RiskState was
+// reset by a kill switch (showing 2 trades) but whose trades-table
+// lifetime stats show 17 round-trips — the table must render the lifetime
+// figure.
+func TestFormatCategorySummary_LifetimeStatsOverride(t *testing.T) {
+	prices := map[string]float64{"ETH/USDT": 2000.0}
+	strats := []StrategyConfig{
+		{ID: "hl-rmc-eth-live", Type: "perps", Platform: "hyperliquid", Args: []string{"rmc", "ETH/USDT", "1h"}},
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-rmc-eth-live": {
+				Cash: 1000,
+				// Post-kill-switch reset: in-memory counters are stale.
+				RiskState: RiskState{TotalTrades: 2, WinningTrades: 1, LosingTrades: 1},
+			},
+		},
+	}
+	lifetime := map[string]LifetimeTradeStats{
+		"hl-rmc-eth-live": {RoundTrips: 17, Wins: 10, Losses: 7},
+	}
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, lifetime)
+	if len(msgs) == 0 {
+		t.Fatal("expected at least one message")
+	}
+	msg := msgs[0]
+	// Lifetime #T should appear (17), not the stale RiskState count (2).
+	if !strings.Contains(msg, " 17 ") {
+		t.Errorf("expected lifetime #T=17 in summary, got:\n%s", msg)
+	}
+	// W/L renders as wins/losses ratio (10/7 ≈ 1.43). The stale 1/1
+	// fallback would have rendered "1.00", so its absence confirms the
+	// override took effect.
+	if !strings.Contains(msg, "1.43") {
+		t.Errorf("expected lifetime W/L ratio (10/7=1.43) in summary, got:\n%s", msg)
+	}
+}
+
+// TestFormatCategorySummary_LifetimeStatsFallback verifies the legacy
+// fallback: when lifetimeStats is nil OR has no entry for a strategy, the
+// summary uses RiskState counters so existing test fixtures keep working.
+func TestFormatCategorySummary_LifetimeStatsFallback(t *testing.T) {
+	prices := map[string]float64{"ETH/USDT": 2000.0}
+	strats := []StrategyConfig{
+		{ID: "hl-rmc-eth-live", Type: "perps", Platform: "hyperliquid", Args: []string{"rmc", "ETH/USDT", "1h"}},
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-rmc-eth-live": {
+				Cash:      1000,
+				RiskState: RiskState{TotalTrades: 5, WinningTrades: 3, LosingTrades: 2},
+			},
+		},
+	}
+	// Nil map → fallback.
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil)
+	if !strings.Contains(msgs[0], " 5 ") {
+		t.Errorf("expected fallback #T=5 in summary, got:\n%s", msgs[0])
+	}
+	// W/L from RiskState wins=3 losses=2 → ratio 1.50.
+	if !strings.Contains(msgs[0], "1.50") {
+		t.Errorf("expected fallback W/L ratio (3/2=1.50) in summary, got:\n%s", msgs[0])
+	}
+	// Empty map (DB returned no rows for this strategy) → also fallback.
+	msgs2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, map[string]LifetimeTradeStats{})
+	if !strings.Contains(msgs2[0], " 5 ") {
+		t.Errorf("expected fallback #T=5 from empty map, got:\n%s", msgs2[0])
 	}
 }

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -1124,6 +1124,13 @@ func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, f
 			Value:      fillSz * fillPx,
 			TradeType:  "perps",
 			Details:    fmt.Sprintf("Circuit breaker on-chain close (no virtual position), fill=%.6f fee=$%.4f", fillSz, fillFee),
+			// No virtual position to derive PnL from. Still mark as a close
+			// leg so the lifetime round-trip count (#455) reflects that the
+			// exchange-side position was reduced, but leave RealizedPnL=0
+			// (no AvgCost basis available). Counts as a "win" by the
+			// pnl >= 0 partition — acceptable since this branch is a
+			// defensive fallback for already-flat virtual state.
+			IsClose: true,
 		})
 		return
 	}
@@ -1148,15 +1155,17 @@ func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, f
 	s.Cash += pnl
 
 	RecordTrade(s, Trade{
-		Timestamp:  now,
-		StrategyID: s.ID,
-		Symbol:     symbol,
-		Side:       closeSide,
-		Quantity:   qtyClosed,
-		Price:      fillPx,
-		Value:      qtyClosed * fillPx,
-		TradeType:  "perps",
-		Details:    fmt.Sprintf("Circuit breaker on-chain close, PnL: $%.2f (fee $%.4f)", pnl, fillFee),
+		Timestamp:   now,
+		StrategyID:  s.ID,
+		Symbol:      symbol,
+		Side:        closeSide,
+		Quantity:    qtyClosed,
+		Price:       fillPx,
+		Value:       qtyClosed * fillPx,
+		TradeType:   "perps",
+		Details:     fmt.Sprintf("Circuit breaker on-chain close, PnL: $%.2f (fee $%.4f)", pnl, fillFee),
+		IsClose:     true,
+		RealizedPnL: pnl,
 	})
 	RecordTradeResult(&s.RiskState, pnl)
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1356,6 +1356,19 @@ func main() {
 		closedByStrategy := LoadClosedPositionsByStrategy(stateDB, cfg)
 		rfr := RiskFreeRateOrDefault(cfg)
 
+		// Lifetime round-trip / W-L stats sourced from the trades table (#455).
+		// One DB round-trip per cycle; missing keys fall back to RiskState
+		// counters inside FormatCategorySummary. Errors are downgraded to a
+		// nil map so the summary still posts using the in-memory fallback.
+		var lifetimeStats map[string]LifetimeTradeStats
+		if stateDB != nil {
+			if ls, err := stateDB.LifetimeTradeStatsAll(); err != nil {
+				fmt.Printf("[summary] lifetime trade stats unavailable: %v\n", err)
+			} else {
+				lifetimeStats = ls
+			}
+		}
+
 		// Notification — one message per channel per asset, sent to all backends.
 		if notifier.HasBackends() {
 			mu.RLock()
@@ -1391,7 +1404,7 @@ func main() {
 					chDetails := channelTradeDetails[detailKey]
 					chValue := channelValue[chKey]
 					chSharpe := aggregateSharpe(closedByStrategy, chStrats, state, rfr)
-					msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), chTrades, chValue, prices, chDetails, chStrats, state, chKey, "", cfg.IntervalSeconds, chSharpe)
+					msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), chTrades, chValue, prices, chDetails, chStrats, state, chKey, "", cfg.IntervalSeconds, chSharpe, lifetimeStats)
 					for _, msg := range msgs {
 						notifier.SendToChannel(chKey, chKey, msg)
 					}
@@ -1408,7 +1421,7 @@ func main() {
 						}
 						assetTrades := len(assetDetails)
 						assetSharpe := aggregateSharpe(closedByStrategy, assetStrats, state, rfr)
-						msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), assetTrades, assetValue, prices, assetDetails, assetStrats, state, chKey, asset, cfg.IntervalSeconds, assetSharpe)
+						msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), assetTrades, assetValue, prices, assetDetails, assetStrats, state, chKey, asset, cfg.IntervalSeconds, assetSharpe, lifetimeStats)
 						for _, msg := range msgs {
 							notifier.SendToChannel(chKey, chKey, msg)
 						}
@@ -1607,10 +1620,18 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, sdb *Sta
 	// Format and send summary using the same asset-grouping logic as the main loop.
 	closedByStrategy := LoadClosedPositionsByStrategy(sdb, cfg)
 	rfr := RiskFreeRateOrDefault(cfg)
+	var lifetimeStats map[string]LifetimeTradeStats
+	if sdb != nil {
+		if ls, err := sdb.LifetimeTradeStatsAll(); err != nil {
+			fmt.Printf("[summary] lifetime trade stats unavailable: %v\n", err)
+		} else {
+			lifetimeStats = ls
+		}
+	}
 	assetGroups, assetKeys := groupByAsset(chStrats)
 	if len(assetKeys) <= 1 {
 		chSharpe := aggregateSharpe(closedByStrategy, chStrats, state, rfr)
-		msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, chValue, prices, nil, chStrats, state, channelKey, "", cfg.IntervalSeconds, chSharpe)
+		msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, chValue, prices, nil, chStrats, state, channelKey, "", cfg.IntervalSeconds, chSharpe, lifetimeStats)
 		for _, msg := range msgs {
 			notifier.SendToChannel(channelKey, channelKey, msg)
 			fmt.Println(msg)
@@ -1625,7 +1646,7 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, sdb *Sta
 				}
 			}
 			assetSharpe := aggregateSharpe(closedByStrategy, assetStrats, state, rfr)
-			msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, assetValue, prices, nil, assetStrats, state, channelKey, asset, cfg.IntervalSeconds, assetSharpe)
+			msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, assetValue, prices, nil, assetStrats, state, channelKey, asset, cfg.IntervalSeconds, assetSharpe, lifetimeStats)
 			for _, msg := range msgs {
 				notifier.SendToChannel(channelKey, channelKey, msg)
 				fmt.Println(msg)

--- a/scheduler/options.go
+++ b/scheduler/options.go
@@ -239,15 +239,17 @@ func executeOptionClose(s *StrategyState, result *OptionsResult, action *Options
 			}
 			now := time.Now().UTC()
 			trade := Trade{
-				Timestamp:  now,
-				StrategyID: s.ID,
-				Symbol:     pos.ID,
-				Side:       "close",
-				Quantity:   pos.Quantity,
-				Price:      action.PremiumUSD,
-				Value:      action.PremiumUSD,
-				TradeType:  "options",
-				Details:    fmt.Sprintf("Close %s PnL=$%.2f", pos.ID, pnl),
+				Timestamp:   now,
+				StrategyID:  s.ID,
+				Symbol:      pos.ID,
+				Side:        "close",
+				Quantity:    pos.Quantity,
+				Price:       action.PremiumUSD,
+				Value:       action.PremiumUSD,
+				TradeType:   "options",
+				Details:     fmt.Sprintf("Close %s PnL=$%.2f", pos.ID, pnl),
+				IsClose:     true,
+				RealizedPnL: pnl,
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -439,15 +441,17 @@ func CheckThetaHarvest(s *StrategyState, cfg *ThetaHarvestConfig, logger *Strate
 
 		now := time.Now().UTC()
 		trade := Trade{
-			Timestamp:  now,
-			StrategyID: s.ID,
-			Symbol:     pos.ID,
-			Side:       "close",
-			Quantity:   pos.Quantity,
-			Price:      buybackCost,
-			Value:      buybackCost,
-			TradeType:  "options",
-			Details:    fmt.Sprintf("Theta harvest close %s PnL=$%.2f", pos.ID, pnl),
+			Timestamp:   now,
+			StrategyID:  s.ID,
+			Symbol:      pos.ID,
+			Side:        "close",
+			Quantity:    pos.Quantity,
+			Price:       buybackCost,
+			Value:       buybackCost,
+			TradeType:   "options",
+			Details:     fmt.Sprintf("Theta harvest close %s PnL=$%.2f", pos.ID, pnl),
+			IsClose:     true,
+			RealizedPnL: pnl,
 		}
 		RecordTrade(s, trade)
 		RecordTradeResult(&s.RiskState, pnl)

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -138,15 +138,17 @@ func recordPerpsStopLossClose(s *StrategyState, symbol string, triggerPx float64
 		closeSide = "buy"
 	}
 	trade := Trade{
-		Timestamp:  now,
-		StrategyID: s.ID,
-		Symbol:     symbol,
-		Side:       closeSide,
-		Quantity:   qty,
-		Price:      triggerPx,
-		Value:      qty * triggerPx,
-		TradeType:  "perps",
-		Details:    fmt.Sprintf("Stop loss close, PnL: $%.2f (fee $%.2f)", pnl, fee),
+		Timestamp:   now,
+		StrategyID:  s.ID,
+		Symbol:      symbol,
+		Side:        closeSide,
+		Quantity:    qty,
+		Price:       triggerPx,
+		Value:       qty * triggerPx,
+		TradeType:   "perps",
+		Details:     fmt.Sprintf("Stop loss close, PnL: $%.2f (fee $%.2f)", pnl, fee),
+		IsClose:     true,
+		RealizedPnL: pnl,
 	}
 	RecordTrade(s, trade)
 	RecordTradeResult(&s.RiskState, pnl)
@@ -198,6 +200,15 @@ type Trade struct {
 	Details         string    `json:"details"`
 	ExchangeOrderID string    `json:"exchange_order_id,omitempty"` // exchange-provided order ID (e.g. Hyperliquid oid)
 	ExchangeFee     float64   `json:"exchange_fee,omitempty"`      // fee charged by exchange (if available)
+
+	// IsClose marks closing legs of a round-trip (close, stop-loss, circuit-breaker
+	// liquidation, theta harvest, wheel call-away). Used by lifetime-stats queries
+	// (#455) to count round-trips and W/L without resetting on kill switch /
+	// circuit breaker. Opens leave it false. RealizedPnL is the per-trade realized
+	// PnL on close legs (0 on opens). Both columns are append-only metadata: once
+	// inserted on a close, they identify the round-trip in the trades table.
+	IsClose     bool    `json:"is_close,omitempty"`
+	RealizedPnL float64 `json:"realized_pnl,omitempty"`
 
 	// persisted tracks whether this Trade has been written to SQLite — set by
 	// RecordTrade on successful InsertTrade and by LoadState for DB-loaded
@@ -486,15 +497,17 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 			// fee double-count when a flip produces two in-memory trades
 			// from a single exchange fill.
 			trade := Trade{
-				Timestamp:  now,
-				StrategyID: s.ID,
-				Symbol:     symbol,
-				Side:       "buy",
-				Quantity:   pos.Quantity,
-				Price:      execPrice,
-				Value:      pos.Quantity * execPrice,
-				TradeType:  "perps",
-				Details:    fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				Timestamp:   now,
+				StrategyID:  s.ID,
+				Symbol:      symbol,
+				Side:        "buy",
+				Quantity:    pos.Quantity,
+				Price:       execPrice,
+				Value:       pos.Quantity * execPrice,
+				TradeType:   "perps",
+				Details:     fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				IsClose:     true,
+				RealizedPnL: pnl,
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -605,6 +618,8 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 				Details:         fmt.Sprintf("Close long, PnL: $%.2f (fee $%.2f)", pnl, fee),
 				ExchangeOrderID: closeOID,
 				ExchangeFee:     closeFee,
+				IsClose:         true,
+				RealizedPnL:     pnl,
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -711,15 +726,17 @@ func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float6
 			s.Cash += pos.Quantity*pos.AvgCost - totalCost
 			now := time.Now().UTC()
 			trade := Trade{
-				Timestamp:  now,
-				StrategyID: s.ID,
-				Symbol:     symbol,
-				Side:       "buy",
-				Quantity:   pos.Quantity,
-				Price:      execPrice,
-				Value:      totalCost,
-				TradeType:  "spot",
-				Details:    fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				Timestamp:   now,
+				StrategyID:  s.ID,
+				Symbol:      symbol,
+				Side:        "buy",
+				Quantity:    pos.Quantity,
+				Price:       execPrice,
+				Value:       totalCost,
+				TradeType:   "spot",
+				Details:     fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				IsClose:     true,
+				RealizedPnL: pnl,
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -788,15 +805,17 @@ func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float6
 			s.Cash += netProceeds
 			now := time.Now().UTC()
 			trade := Trade{
-				Timestamp:  now,
-				StrategyID: s.ID,
-				Symbol:     symbol,
-				Side:       "sell",
-				Quantity:   pos.Quantity,
-				Price:      execPrice,
-				Value:      netProceeds,
-				TradeType:  "spot",
-				Details:    fmt.Sprintf("Close long, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				Timestamp:   now,
+				StrategyID:  s.ID,
+				Symbol:      symbol,
+				Side:        "sell",
+				Quantity:    pos.Quantity,
+				Price:       execPrice,
+				Value:       netProceeds,
+				TradeType:   "spot",
+				Details:     fmt.Sprintf("Close long, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				IsClose:     true,
+				RealizedPnL: pnl,
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -841,15 +860,17 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 			s.Cash += pnl
 			now := time.Now().UTC()
 			trade := Trade{
-				Timestamp:  now,
-				StrategyID: s.ID,
-				Symbol:     symbol,
-				Side:       "buy",
-				Quantity:   pos.Quantity,
-				Price:      execPrice,
-				Value:      float64(contracts) * multiplier * execPrice,
-				TradeType:  "futures",
-				Details:    fmt.Sprintf("Close short %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee),
+				Timestamp:   now,
+				StrategyID:  s.ID,
+				Symbol:      symbol,
+				Side:        "buy",
+				Quantity:    pos.Quantity,
+				Price:       execPrice,
+				Value:       float64(contracts) * multiplier * execPrice,
+				TradeType:   "futures",
+				Details:     fmt.Sprintf("Close short %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee),
+				IsClose:     true,
+				RealizedPnL: pnl,
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -930,15 +951,17 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 			s.Cash += pnl
 			now := time.Now().UTC()
 			trade := Trade{
-				Timestamp:  now,
-				StrategyID: s.ID,
-				Symbol:     symbol,
-				Side:       "sell",
-				Quantity:   pos.Quantity,
-				Price:      execPrice,
-				Value:      float64(contracts) * multiplier * execPrice,
-				TradeType:  "futures",
-				Details:    fmt.Sprintf("Close long %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee),
+				Timestamp:   now,
+				StrategyID:  s.ID,
+				Symbol:      symbol,
+				Side:        "sell",
+				Quantity:    pos.Quantity,
+				Price:       execPrice,
+				Value:       float64(contracts) * multiplier * execPrice,
+				TradeType:   "futures",
+				Details:     fmt.Sprintf("Close long %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee),
+				IsClose:     true,
+				RealizedPnL: pnl,
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1098,15 +1098,17 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 			logger.Warn("Circuit breaker: force-closing %s %s @ $%.2f (PnL: $%.2f)", pos.Side, symbol, price, pnl)
 		}
 		trade := Trade{
-			Timestamp:  now,
-			StrategyID: s.ID,
-			Symbol:     symbol,
-			Side:       "close",
-			Quantity:   pos.Quantity,
-			Price:      price,
-			Value:      value,
-			TradeType:  tradeType,
-			Details:    fmt.Sprintf("Circuit breaker close %s, PnL: $%.2f", pos.Side, pnl),
+			Timestamp:   now,
+			StrategyID:  s.ID,
+			Symbol:      symbol,
+			Side:        "close",
+			Quantity:    pos.Quantity,
+			Price:       price,
+			Value:       value,
+			TradeType:   tradeType,
+			Details:     fmt.Sprintf("Circuit breaker close %s, PnL: $%.2f", pos.Side, pnl),
+			IsClose:     true,
+			RealizedPnL: pnl,
 		}
 		RecordTrade(s, trade)
 		RecordTradeResult(&s.RiskState, pnl)
@@ -1130,15 +1132,17 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 			logger.Warn("Circuit breaker: force-closing %s %s @ $%.2f (PnL: $%.2f)", pos.Action, id, closePrice, pnl)
 		}
 		trade := Trade{
-			Timestamp:  now,
-			StrategyID: s.ID,
-			Symbol:     id,
-			Side:       "close",
-			Quantity:   pos.Quantity,
-			Price:      closePrice,
-			Value:      closePrice,
-			TradeType:  "options",
-			Details:    fmt.Sprintf("Circuit breaker force-close, PnL: $%.2f", pnl),
+			Timestamp:   now,
+			StrategyID:  s.ID,
+			Symbol:      id,
+			Side:        "close",
+			Quantity:    pos.Quantity,
+			Price:       closePrice,
+			Value:       closePrice,
+			TradeType:   "options",
+			Details:     fmt.Sprintf("Circuit breaker force-close, PnL: $%.2f", pnl),
+			IsClose:     true,
+			RealizedPnL: pnl,
 		}
 		RecordTrade(s, trade)
 		RecordTradeResult(&s.RiskState, pnl)


### PR DESCRIPTION
Closes #455

## Summary
- Adds `is_close` + `realized_pnl` columns to the `trades` table (idempotent migration + best-effort legacy backfill via `parseDetailsPnL`).
- Sets `IsClose`/`RealizedPnL` on every close-leg `RecordTrade` call site (perps/spot/futures/options + stop loss/circuit breaker/hyperliquid on-chain/wheel call-away).
- `StateDB.LifetimeTradeStatsAll` groups round-trips/wins/losses per strategy; pre-computed once per cycle and threaded into `FormatCategorySummary`.
- Falls back to `RiskState` counters when no DB entry exists (preserves existing test fixtures).

## Why
The pre-existing `#T` / `W/L` columns read from `RiskState`, which is incremented only when `RecordTradeResult` fires. Close paths that bypass it (`hl_sync_external` reconciliation, partial fills, mid-cycle crashes) silently undercount. Operators reported `#T=2` against 17 rows in the trades table.

## Test plan
- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [ ] Smoke-test on a live deployment: kill switch fires, confirm `#T` does not reset.

LLM: Claude Opus 4.7 (1M context) | high
) · [View job run](https://github.com/richkuo/go-trader/actions/runs/25069219512

---
LLM: Claude Opus 4.7 (1M) | high | Tokens: 154 in / 69984 out | Cache: 17812860 read / 281479 written | Cost: $12.42