### PR TITLE
Plumb exchange order IDs through live fills

### DIFF
--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -384,6 +384,7 @@ type TopStepResult struct {
 type TopStepFill struct {
 	AvgPx          float64 `json:"avg_px"`
 	TotalContracts int     `json:"total_contracts"`
+	OID            string  `json:"oid,omitempty"`
 	Fee            float64 `json:"fee,omitempty"`
 }
 
@@ -588,6 +589,7 @@ type RobinhoodResult struct {
 type RobinhoodFill struct {
 	AvgPx    float64 `json:"avg_px"`
 	Quantity float64 `json:"quantity"`
+	OID      string  `json:"oid,omitempty"`
 	Fee      float64 `json:"fee,omitempty"`
 }
 
@@ -675,6 +677,7 @@ type OKXResult struct {
 type OKXFill struct {
 	AvgPx   float64 `json:"avg_px"`
 	TotalSz float64 `json:"total_sz"`
+	OID     string  `json:"oid,omitempty"`
 	Fee     float64 `json:"fee,omitempty"`
 }
 

--- a/scheduler/executor_test.go
+++ b/scheduler/executor_test.go
@@ -193,7 +193,7 @@ func TestTopStepExecuteResultJSON(t *testing.T) {
 			"action": "buy",
 			"symbol": "ES",
 			"contracts": 2,
-			"fill": {"avg_px": 5200.25, "total_contracts": 2, "fee": 4.12}
+			"fill": {"avg_px": 5200.25, "total_contracts": 2, "oid": "ts-order-123", "fee": 4.12}
 		},
 		"platform": "topstep"
 	}`
@@ -207,6 +207,9 @@ func TestTopStepExecuteResultJSON(t *testing.T) {
 	}
 	if result.Execution.Fill.TotalContracts != 2 {
 		t.Errorf("TotalContracts = %d, want 2", result.Execution.Fill.TotalContracts)
+	}
+	if result.Execution.Fill.OID != "ts-order-123" {
+		t.Errorf("OID = %q, want ts-order-123", result.Execution.Fill.OID)
 	}
 	if result.Execution.Fill.Fee != 4.12 {
 		t.Errorf("Fee = %g, want 4.12", result.Execution.Fill.Fee)
@@ -238,7 +241,7 @@ func TestRobinhoodExecuteResultJSON(t *testing.T) {
 			"action": "buy",
 			"symbol": "BTC",
 			"amount_usd": 500,
-			"fill": {"avg_px": 60000.5, "quantity": 0.00833, "fee": 0.07}
+			"fill": {"avg_px": 60000.5, "quantity": 0.00833, "oid": "rh-order-456", "fee": 0.07}
 		},
 		"platform": "robinhood"
 	}`
@@ -249,6 +252,9 @@ func TestRobinhoodExecuteResultJSON(t *testing.T) {
 	}
 	if result.Execution.AmountUSD != 500 {
 		t.Errorf("AmountUSD = %g, want 500", result.Execution.AmountUSD)
+	}
+	if result.Execution.Fill.OID != "rh-order-456" {
+		t.Errorf("OID = %q, want rh-order-456", result.Execution.Fill.OID)
 	}
 	if result.Execution.Fill.Fee != 0.07 {
 		t.Errorf("Fee = %g, want 0.07", result.Execution.Fill.Fee)
@@ -283,7 +289,7 @@ func TestOKXExecuteResultJSON(t *testing.T) {
 			"action": "sell",
 			"symbol": "BTC",
 			"size": 0.05,
-			"fill": {"avg_px": 55000, "total_sz": 0.05, "fee": 1.25}
+			"fill": {"avg_px": 55000, "total_sz": 0.05, "oid": "okx-order-789", "fee": 1.25}
 		},
 		"platform": "okx"
 	}`
@@ -294,6 +300,9 @@ func TestOKXExecuteResultJSON(t *testing.T) {
 	}
 	if result.Execution.Size != 0.05 {
 		t.Errorf("Size = %g, want 0.05", result.Execution.Size)
+	}
+	if result.Execution.Fill.OID != "okx-order-789" {
+		t.Errorf("OID = %q, want okx-order-789", result.Execution.Fill.OID)
 	}
 	if result.Execution.Fill.Fee != 1.25 {
 		t.Errorf("Fee = %g, want 1.25", result.Execution.Fill.Fee)

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2663,6 +2663,11 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, result *OKXResult, ex
 		logger.Info("Live fill at $%.2f qty=%.6f (mid was $%.2f)", fillPrice, fillQty, price)
 	}
 
+	// Thread fillOID/fillFee into the signal handlers so each Trade is built
+	// with the OID and fee before RecordTrade persists it (#456). Stamping the
+	// fields onto s.TradeHistory after the fact would never reach SQLite — the
+	// eager INSERT has already happened and SaveState's timestamp dedup skips
+	// re-inserts for the same trade.
 	var trades int
 	var err error
 	if sc.Type == "perps" {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2303,10 +2303,12 @@ func executeTopStepResult(sc StrategyConfig, s *StrategyState, result *TopStepRe
 	fillPrice := price
 	var fillContracts int
 	var fillFee float64
+	var fillOID string
 	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.AvgPx > 0 {
 		fillPrice = execResult.Execution.Fill.AvgPx
 		fillContracts = execResult.Execution.Fill.TotalContracts
 		fillFee = execResult.Execution.Fill.Fee
+		fillOID = execResult.Execution.Fill.OID
 		logger.Info("Live fill at $%.2f contracts=%d (signal was $%.2f)", fillPrice, fillContracts, price)
 	}
 
@@ -2317,7 +2319,7 @@ func executeTopStepResult(sc StrategyConfig, s *StrategyState, result *TopStepRe
 		maxContracts = sc.FuturesConfig.MaxContracts
 	}
 
-	trades, err := ExecuteFuturesSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, result.ContractSpec, feePerContract, maxContracts, fillContracts, fillFee, logger)
+	trades, err := ExecuteFuturesSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, result.ContractSpec, feePerContract, maxContracts, fillContracts, fillFee, fillOID, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -2461,14 +2463,16 @@ func executeRobinhoodResult(sc StrategyConfig, s *StrategyState, result *Robinho
 	fillPrice := price
 	var fillQty float64
 	var fillFee float64
+	var fillOID string
 	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.AvgPx > 0 {
 		fillPrice = execResult.Execution.Fill.AvgPx
 		fillQty = execResult.Execution.Fill.Quantity
 		fillFee = execResult.Execution.Fill.Fee
+		fillOID = execResult.Execution.Fill.OID
 		logger.Info("Live fill at $%.2f qty=%.6f (mid was $%.2f)", fillPrice, fillQty, price)
 	}
 
-	trades, err := ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, logger)
+	trades, err := ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, fillOID, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -2650,10 +2654,12 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, result *OKXResult, ex
 	fillPrice := price
 	var fillQty float64
 	var fillFee float64
+	var fillOID string
 	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.AvgPx > 0 {
 		fillPrice = execResult.Execution.Fill.AvgPx
 		fillQty = execResult.Execution.Fill.TotalSz
 		fillFee = execResult.Execution.Fill.Fee
+		fillOID = execResult.Execution.Fill.OID
 		logger.Info("Live fill at $%.2f qty=%.6f (mid was $%.2f)", fillPrice, fillQty, price)
 	}
 
@@ -2664,9 +2670,9 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, result *OKXResult, ex
 		if leverage <= 0 {
 			leverage = 1
 		}
-		trades, err = ExecutePerpsSignal(s, result.Signal, result.Symbol, fillPrice, leverage, fillQty, "", fillFee, sc.AllowShorts, logger)
+		trades, err = ExecutePerpsSignal(s, result.Signal, result.Symbol, fillPrice, leverage, fillQty, fillOID, fillFee, sc.AllowShorts, logger)
 	} else {
-		trades, err = ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, logger)
+		trades, err = ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, fillOID, logger)
 	}
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -869,3 +869,168 @@ func TestExecuteHyperliquidResult_PaperModeNoExchangeData(t *testing.T) {
 		t.Errorf("ExchangeFee should be 0 in paper mode, got %g", tr.ExchangeFee)
 	}
 }
+
+func TestExecuteOKXResult_PerpsStampsExchangeData(t *testing.T) {
+	s := &StrategyState{
+		ID:              "okx-perps-btc",
+		Type:            "perps",
+		Platform:        "okx",
+		Cash:            1000,
+		InitialCapital:  1000,
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 1000},
+	}
+	sc := StrategyConfig{ID: "okx-perps-btc", Type: "perps", Platform: "okx", Leverage: 2}
+	result := &OKXResult{Signal: 1, Symbol: "BTC", Price: 50000}
+	execResult := &OKXExecuteResult{
+		Execution: &OKXExecution{
+			Action: "buy", Symbol: "BTC", Size: 0.02,
+			Fill: &OKXFill{AvgPx: 50000.5, TotalSz: 0.02, OID: "okx-perps-oid", Fee: 1.25},
+		},
+		Platform: "okx",
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	trades, _ := executeOKXResult(sc, s, result, execResult, "BUY", 50000, logger)
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	tr := s.TradeHistory[0]
+	if tr.ExchangeOrderID != "okx-perps-oid" {
+		t.Errorf("ExchangeOrderID = %q, want okx-perps-oid", tr.ExchangeOrderID)
+	}
+	if tr.ExchangeFee != 1.25 {
+		t.Errorf("ExchangeFee = %g, want 1.25", tr.ExchangeFee)
+	}
+}
+
+func TestExecuteOKXResult_SpotStampsExchangeData(t *testing.T) {
+	s := &StrategyState{
+		ID:              "okx-spot-btc",
+		Type:            "spot",
+		Platform:        "okx",
+		Cash:            1000,
+		InitialCapital:  1000,
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 1000},
+	}
+	sc := StrategyConfig{ID: "okx-spot-btc", Type: "spot", Platform: "okx"}
+	result := &OKXResult{Signal: 1, Symbol: "BTC", Price: 50000}
+	execResult := &OKXExecuteResult{
+		Execution: &OKXExecution{
+			Action: "buy", Symbol: "BTC", Size: 0.01,
+			Fill: &OKXFill{AvgPx: 50000.5, TotalSz: 0.01, OID: "okx-spot-oid", Fee: 0.18},
+		},
+		Platform: "okx",
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	trades, _ := executeOKXResult(sc, s, result, execResult, "BUY", 50000, logger)
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	tr := s.TradeHistory[0]
+	if tr.ExchangeOrderID != "okx-spot-oid" {
+		t.Errorf("ExchangeOrderID = %q, want okx-spot-oid", tr.ExchangeOrderID)
+	}
+	if tr.ExchangeFee != 0.18 {
+		t.Errorf("ExchangeFee = %g, want 0.18", tr.ExchangeFee)
+	}
+}
+
+func TestExecuteRobinhoodResult_StampsExchangeData(t *testing.T) {
+	s := &StrategyState{
+		ID:              "rh-momentum-btc",
+		Type:            "spot",
+		Platform:        "robinhood",
+		Cash:            1000,
+		InitialCapital:  1000,
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 1000},
+	}
+	sc := StrategyConfig{ID: "rh-momentum-btc", Type: "spot", Platform: "robinhood"}
+	result := &RobinhoodResult{Signal: 1, Symbol: "BTC", Price: 50000}
+	execResult := &RobinhoodExecuteResult{
+		Execution: &RobinhoodExecution{
+			Action: "buy", Symbol: "BTC", AmountUSD: 500,
+			Fill: &RobinhoodFill{AvgPx: 50000.5, Quantity: 0.01, OID: "rh-live-oid", Fee: 0.07},
+		},
+		Platform: "robinhood",
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	trades, _ := executeRobinhoodResult(sc, s, result, execResult, "BUY", 50000, logger)
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	tr := s.TradeHistory[0]
+	if tr.ExchangeOrderID != "rh-live-oid" {
+		t.Errorf("ExchangeOrderID = %q, want rh-live-oid", tr.ExchangeOrderID)
+	}
+	if tr.ExchangeFee != 0.07 {
+		t.Errorf("ExchangeFee = %g, want 0.07", tr.ExchangeFee)
+	}
+}
+
+func TestExecuteTopStepResult_StampsExchangeData(t *testing.T) {
+	s := &StrategyState{
+		ID:              "ts-momentum-es",
+		Type:            "futures",
+		Platform:        "topstep",
+		Cash:            10000,
+		InitialCapital:  10000,
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 10000},
+	}
+	sc := StrategyConfig{
+		ID:       "ts-momentum-es",
+		Type:     "futures",
+		Platform: "topstep",
+		FuturesConfig: &FuturesConfig{
+			FeePerContract: 2.5,
+			MaxContracts:   5,
+		},
+	}
+	spec := ContractSpec{TickSize: 0.25, TickValue: 12.5, Multiplier: 50, Margin: 500}
+	result := &TopStepResult{Signal: 1, Symbol: "ES", Price: 5000, ContractSpec: spec}
+	execResult := &TopStepExecuteResult{
+		Execution: &TopStepExecution{
+			Action: "buy", Symbol: "ES", Contracts: 2,
+			Fill: &TopStepFill{AvgPx: 5000.25, TotalContracts: 2, OID: "ts-live-oid", Fee: 4.12},
+		},
+		Platform: "topstep",
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	trades, _ := executeTopStepResult(sc, s, result, execResult, "BUY", 5000, logger)
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	tr := s.TradeHistory[0]
+	if tr.ExchangeOrderID != "ts-live-oid" {
+		t.Errorf("ExchangeOrderID = %q, want ts-live-oid", tr.ExchangeOrderID)
+	}
+	if tr.ExchangeFee != 4.12 {
+		t.Errorf("ExchangeFee = %g, want 4.12", tr.ExchangeFee)
+	}
+}

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -233,6 +233,13 @@ func exchangeFeeForTrade(fillFee float64, useFillFee bool) float64 {
 	return 0
 }
 
+func exchangeOrderIDForTrade(fillOID string, useFillMetadata bool) string {
+	if useFillMetadata {
+		return fillOID
+	}
+	return ""
+}
+
 // PortfolioValue calculates total value of a strategy's portfolio.
 func PortfolioValue(s *StrategyState, prices map[string]float64) float64 {
 	total := s.Cash
@@ -717,10 +724,10 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 // fillQty > 0 means a live fill: use price as-is (no slippage) and fillQty as position quantity for buys.
 // fillQty == 0 means paper mode: apply ApplySlippage and compute qty from state budget.
 func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float64, fillQty float64, logger *StrategyLogger) (int, error) {
-	return ExecuteSpotSignalWithFillFee(s, signal, symbol, price, fillQty, 0, logger)
+	return ExecuteSpotSignalWithFillFee(s, signal, symbol, price, fillQty, 0, "", logger)
 }
 
-func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, fillQty float64, fillFee float64, logger *StrategyLogger) (int, error) {
+func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, fillQty float64, fillFee float64, fillOID string, logger *StrategyLogger) (int, error) {
 	if signal == 0 {
 		return 0, nil
 	}
@@ -729,7 +736,7 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 	if s.Platform == "okx" && s.Type == "perps" {
 		feePlatform = "okx-perps"
 	}
-	fillFeeUsed := false
+	fillMetadataUsed := false
 
 	if signal == 1 { // Buy
 		// Check if already long
@@ -746,28 +753,29 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 				execPrice = ApplySlippage(price)
 			}
 			buyCost := pos.Quantity * execPrice
-			useFillFee := fillQty > 0 && !fillFeeUsed
-			fee := executionFee(CalculatePlatformSpotFee(feePlatform, buyCost), fillFee, useFillFee)
-			if useFillFee && fillFee > 0 {
-				fillFeeUsed = true
+			useFillMetadata := fillQty > 0 && !fillMetadataUsed
+			fee := executionFee(CalculatePlatformSpotFee(feePlatform, buyCost), fillFee, useFillMetadata)
+			if useFillMetadata {
+				fillMetadataUsed = true
 			}
 			totalCost := buyCost + fee
 			pnl := pos.Quantity*pos.AvgCost - totalCost
 			s.Cash += pos.Quantity*pos.AvgCost - totalCost
 			now := time.Now().UTC()
 			trade := Trade{
-				Timestamp:   now,
-				StrategyID:  s.ID,
-				Symbol:      symbol,
-				Side:        "buy",
-				Quantity:    pos.Quantity,
-				Price:       execPrice,
-				Value:       totalCost,
-				TradeType:   "spot",
-				Details:     fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee),
-				ExchangeFee: exchangeFeeForTrade(fillFee, useFillFee),
-				IsClose:     true,
-				RealizedPnL: pnl,
+			Timestamp:       now,
+				StrategyID:      s.ID,
+				Symbol:          symbol,
+				Side:            "buy",
+				Quantity:        pos.Quantity,
+				Price:           execPrice,
+				Value:           totalCost,
+				TradeType:       "spot",
+				Details:         fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				ExchangeOrderID: exchangeOrderIDForTrade(fillOID, useFillMetadata),
+				ExchangeFee:     exchangeFeeForTrade(fillFee, useFillMetadata),
+				IsClose:         true,
+				RealizedPnL:     pnl,
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -794,10 +802,10 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			qty = budget / execPrice
 		}
 		tradeCost := qty * execPrice
-		useFillFee := fillQty > 0 && !fillFeeUsed
-		fee := executionFee(CalculatePlatformSpotFee(feePlatform, tradeCost), fillFee, useFillFee)
-		if useFillFee && fillFee > 0 {
-			fillFeeUsed = true
+		useFillMetadata := fillQty > 0 && !fillMetadataUsed
+		fee := executionFee(CalculatePlatformSpotFee(feePlatform, tradeCost), fillFee, useFillMetadata)
+		if useFillMetadata {
+			fillMetadataUsed = true
 		}
 		s.Cash -= tradeCost + fee
 		now := time.Now().UTC()
@@ -810,16 +818,17 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			OpenedAt:        now,
 		}
 		trade := Trade{
-			Timestamp:   now,
-			StrategyID:  s.ID,
-			Symbol:      symbol,
-			Side:        "buy",
-			Quantity:    qty,
-			Price:       execPrice,
-			Value:       tradeCost + fee,
-			TradeType:   "spot",
-			Details:     fmt.Sprintf("Open long %.6f @ $%.2f (fee $%.2f)", qty, execPrice, fee),
-			ExchangeFee: exchangeFeeForTrade(fillFee, useFillFee),
+			Timestamp:       now,
+			StrategyID:      s.ID,
+			Symbol:          symbol,
+			Side:            "buy",
+			Quantity:        qty,
+			Price:           execPrice,
+			Value:           tradeCost + fee,
+			TradeType:       "spot",
+			Details:         fmt.Sprintf("Open long %.6f @ $%.2f (fee $%.2f)", qty, execPrice, fee),
+			ExchangeOrderID: exchangeOrderIDForTrade(fillOID, useFillMetadata),
+			ExchangeFee:     exchangeFeeForTrade(fillFee, useFillMetadata),
 		}
 		RecordTrade(s, trade)
 		logger.Info("BUY %s: %.6f @ $%.2f (fee $%.2f, total $%.2f)", symbol, qty, execPrice, fee, tradeCost+fee)
@@ -835,28 +844,29 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 				execPrice = ApplySlippage(price)
 			}
 			saleValue := pos.Quantity * execPrice
-			useFillFee := fillQty > 0 && !fillFeeUsed
-			fee := executionFee(CalculatePlatformSpotFee(feePlatform, saleValue), fillFee, useFillFee)
-			if useFillFee && fillFee > 0 {
-				fillFeeUsed = true
+			useFillMetadata := fillQty > 0 && !fillMetadataUsed
+			fee := executionFee(CalculatePlatformSpotFee(feePlatform, saleValue), fillFee, useFillMetadata)
+			if useFillMetadata {
+				fillMetadataUsed = true
 			}
 			netProceeds := saleValue - fee
 			pnl := netProceeds - (pos.Quantity * pos.AvgCost)
 			s.Cash += netProceeds
 			now := time.Now().UTC()
 			trade := Trade{
-				Timestamp:   now,
-				StrategyID:  s.ID,
-				Symbol:      symbol,
-				Side:        "sell",
-				Quantity:    pos.Quantity,
-				Price:       execPrice,
-				Value:       netProceeds,
-				TradeType:   "spot",
-				Details:     fmt.Sprintf("Close long, PnL: $%.2f (fee $%.2f)", pnl, fee),
-				ExchangeFee: exchangeFeeForTrade(fillFee, useFillFee),
-				IsClose:     true,
-				RealizedPnL: pnl,
+			Timestamp:       now,
+				StrategyID:      s.ID,
+				Symbol:          symbol,
+				Side:            "sell",
+				Quantity:        pos.Quantity,
+				Price:           execPrice,
+				Value:           netProceeds,
+				TradeType:       "spot",
+				Details:         fmt.Sprintf("Close long, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				ExchangeOrderID: exchangeOrderIDForTrade(fillOID, useFillMetadata),
+				ExchangeFee:     exchangeFeeForTrade(fillFee, useFillMetadata),
+				IsClose:         true,
+				RealizedPnL:     pnl,
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -875,16 +885,16 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 // fillContracts > 0 means a live fill: use price as-is (no slippage) and fillContracts as contract count for opens.
 // fillContracts == 0 means paper mode: apply ApplySlippage and compute contracts from state budget.
 func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price float64, spec ContractSpec, feePerContract float64, maxContracts int, fillContracts int, logger *StrategyLogger) (int, error) {
-	return ExecuteFuturesSignalWithFillFee(s, signal, symbol, price, spec, feePerContract, maxContracts, fillContracts, 0, logger)
+	return ExecuteFuturesSignalWithFillFee(s, signal, symbol, price, spec, feePerContract, maxContracts, fillContracts, 0, "", logger)
 }
 
-func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, spec ContractSpec, feePerContract float64, maxContracts int, fillContracts int, fillFee float64, logger *StrategyLogger) (int, error) {
+func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, spec ContractSpec, feePerContract float64, maxContracts int, fillContracts int, fillFee float64, fillOID string, logger *StrategyLogger) (int, error) {
 	if signal == 0 {
 		return 0, nil
 	}
 	tradesExecuted := 0
 	multiplier := spec.Multiplier
-	fillFeeUsed := false
+	fillMetadataUsed := false
 
 	if signal == 1 { // Buy
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
@@ -901,27 +911,28 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			}
 			contracts := int(pos.Quantity)
 			pnl := float64(contracts) * multiplier * (pos.AvgCost - execPrice)
-			useFillFee := fillContracts > 0 && !fillFeeUsed
-			fee := executionFee(CalculateFuturesFee(contracts, feePerContract), fillFee, useFillFee)
-			if useFillFee && fillFee > 0 {
-				fillFeeUsed = true
+			useFillMetadata := fillContracts > 0 && !fillMetadataUsed
+			fee := executionFee(CalculateFuturesFee(contracts, feePerContract), fillFee, useFillMetadata)
+			if useFillMetadata {
+				fillMetadataUsed = true
 			}
 			pnl -= fee
 			s.Cash += pnl
 			now := time.Now().UTC()
 			trade := Trade{
-				Timestamp:   now,
-				StrategyID:  s.ID,
-				Symbol:      symbol,
-				Side:        "buy",
-				Quantity:    pos.Quantity,
-				Price:       execPrice,
-				Value:       float64(contracts) * multiplier * execPrice,
-				TradeType:   "futures",
-				Details:     fmt.Sprintf("Close short %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee),
-				ExchangeFee: exchangeFeeForTrade(fillFee, useFillFee),
-				IsClose:     true,
-				RealizedPnL: pnl,
+			Timestamp:       now,
+				StrategyID:      s.ID,
+				Symbol:          symbol,
+				Side:            "buy",
+				Quantity:        pos.Quantity,
+				Price:           execPrice,
+				Value:           float64(contracts) * multiplier * execPrice,
+				TradeType:       "futures",
+				Details:         fmt.Sprintf("Close short %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee),
+				ExchangeOrderID: exchangeOrderIDForTrade(fillOID, useFillMetadata),
+				ExchangeFee:     exchangeFeeForTrade(fillFee, useFillMetadata),
+				IsClose:         true,
+				RealizedPnL:     pnl,
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -959,10 +970,10 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			logger.Info("Insufficient cash ($%.2f) for even 1 %s contract (margin=$%.2f)", s.Cash, symbol, marginPerContract)
 			return tradesExecuted, nil
 		}
-		useFillFee := fillContracts > 0 && !fillFeeUsed
-		fee := executionFee(CalculateFuturesFee(contracts, feePerContract), fillFee, useFillFee)
-		if useFillFee && fillFee > 0 {
-			fillFeeUsed = true
+		useFillMetadata := fillContracts > 0 && !fillMetadataUsed
+		fee := executionFee(CalculateFuturesFee(contracts, feePerContract), fillFee, useFillMetadata)
+		if useFillMetadata {
+			fillMetadataUsed = true
 		}
 		s.Cash -= fee // futures use margin, not full notional; deduct fee only
 		now := time.Now().UTC()
@@ -976,16 +987,17 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			OpenedAt:        now,
 		}
 		trade := Trade{
-			Timestamp:   now,
-			StrategyID:  s.ID,
-			Symbol:      symbol,
-			Side:        "buy",
-			Quantity:    float64(contracts),
-			Price:       execPrice,
-			Value:       float64(contracts) * marginPerContract,
-			TradeType:   "futures",
-			Details:     fmt.Sprintf("Open long %d contracts @ $%.2f (fee $%.2f)", contracts, execPrice, fee),
-			ExchangeFee: exchangeFeeForTrade(fillFee, useFillFee),
+			Timestamp:       now,
+			StrategyID:      s.ID,
+			Symbol:          symbol,
+			Side:            "buy",
+			Quantity:        float64(contracts),
+			Price:           execPrice,
+			Value:           float64(contracts) * marginPerContract,
+			TradeType:       "futures",
+			Details:         fmt.Sprintf("Open long %d contracts @ $%.2f (fee $%.2f)", contracts, execPrice, fee),
+			ExchangeOrderID: exchangeOrderIDForTrade(fillOID, useFillMetadata),
+			ExchangeFee:     exchangeFeeForTrade(fillFee, useFillMetadata),
 		}
 		RecordTrade(s, trade)
 		logger.Info("BUY %s: %d contracts @ $%.2f (fee $%.2f)", symbol, contracts, execPrice, fee)
@@ -1002,27 +1014,28 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			}
 			contracts := int(pos.Quantity)
 			pnl := float64(contracts) * multiplier * (execPrice - pos.AvgCost)
-			useFillFee := fillContracts > 0 && !fillFeeUsed
-			fee := executionFee(CalculateFuturesFee(contracts, feePerContract), fillFee, useFillFee)
-			if useFillFee && fillFee > 0 {
-				fillFeeUsed = true
+			useFillMetadata := fillContracts > 0 && !fillMetadataUsed
+			fee := executionFee(CalculateFuturesFee(contracts, feePerContract), fillFee, useFillMetadata)
+			if useFillMetadata {
+				fillMetadataUsed = true
 			}
 			pnl -= fee
 			s.Cash += pnl
 			now := time.Now().UTC()
 			trade := Trade{
-				Timestamp:   now,
-				StrategyID:  s.ID,
-				Symbol:      symbol,
-				Side:        "sell",
-				Quantity:    pos.Quantity,
-				Price:       execPrice,
-				Value:       float64(contracts) * multiplier * execPrice,
-				TradeType:   "futures",
-				Details:     fmt.Sprintf("Close long %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee),
-				ExchangeFee: exchangeFeeForTrade(fillFee, useFillFee),
-				IsClose:     true,
-				RealizedPnL: pnl,
+			Timestamp:       now,
+				StrategyID:      s.ID,
+				Symbol:          symbol,
+				Side:            "sell",
+				Quantity:        pos.Quantity,
+				Price:           execPrice,
+				Value:           float64(contracts) * multiplier * execPrice,
+				TradeType:       "futures",
+				Details:         fmt.Sprintf("Close long %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee),
+				ExchangeOrderID: exchangeOrderIDForTrade(fillOID, useFillMetadata),
+				ExchangeFee:     exchangeFeeForTrade(fillFee, useFillMetadata),
+				IsClose:         true,
+				RealizedPnL:     pnl,
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
@@ -1061,10 +1074,10 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 				logger.Info("Insufficient cash ($%.2f) for even 1 %s short contract (margin=$%.2f)", s.Cash, symbol, marginPerContract)
 				return tradesExecuted, nil
 			}
-			useFillFee := fillContracts > 0 && !fillFeeUsed
-			fee := executionFee(CalculateFuturesFee(contracts, feePerContract), fillFee, useFillFee)
-			if useFillFee && fillFee > 0 {
-				fillFeeUsed = true
+			useFillMetadata := fillContracts > 0 && !fillMetadataUsed
+			fee := executionFee(CalculateFuturesFee(contracts, feePerContract), fillFee, useFillMetadata)
+			if useFillMetadata {
+				fillMetadataUsed = true
 			}
 			s.Cash -= fee
 			now := time.Now().UTC()
@@ -1078,16 +1091,17 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 				OpenedAt:        now,
 			}
 			trade := Trade{
-				Timestamp:   now,
-				StrategyID:  s.ID,
-				Symbol:      symbol,
-				Side:        "sell",
-				Quantity:    float64(contracts),
-				Price:       execPrice,
-				Value:       float64(contracts) * marginPerContract,
-				TradeType:   "futures",
-				Details:     fmt.Sprintf("Open short %d contracts @ $%.2f (fee $%.2f)", contracts, execPrice, fee),
-				ExchangeFee: exchangeFeeForTrade(fillFee, useFillFee),
+				Timestamp:       now,
+				StrategyID:      s.ID,
+				Symbol:          symbol,
+				Side:            "sell",
+				Quantity:        float64(contracts),
+				Price:           execPrice,
+				Value:           float64(contracts) * marginPerContract,
+				TradeType:       "futures",
+				Details:         fmt.Sprintf("Open short %d contracts @ $%.2f (fee $%.2f)", contracts, execPrice, fee),
+				ExchangeOrderID: exchangeOrderIDForTrade(fillOID, useFillMetadata),
+				ExchangeFee:     exchangeFeeForTrade(fillFee, useFillMetadata),
 			}
 			RecordTrade(s, trade)
 			logger.Info("SHORT %s: %d contracts @ $%.2f (fee $%.2f)", symbol, contracts, execPrice, fee)

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -763,7 +763,7 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			s.Cash += pos.Quantity*pos.AvgCost - totalCost
 			now := time.Now().UTC()
 			trade := Trade{
-			Timestamp:       now,
+				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
 				Side:            "buy",
@@ -854,7 +854,7 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			s.Cash += netProceeds
 			now := time.Now().UTC()
 			trade := Trade{
-			Timestamp:       now,
+				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
 				Side:            "sell",
@@ -920,7 +920,7 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			s.Cash += pnl
 			now := time.Now().UTC()
 			trade := Trade{
-			Timestamp:       now,
+				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
 				Side:            "buy",
@@ -1023,7 +1023,7 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			s.Cash += pnl
 			now := time.Now().UTC()
 			trade := Trade{
-			Timestamp:       now,
+				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
 				Side:            "sell",

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -581,7 +581,7 @@ func TestExecuteSpotSignalLiveFillUsesExchangeFee(t *testing.T) {
 	fillQty := 0.015
 	fillPrice := 50000.0
 	fillFee := 0.17
-	trades, err := ExecuteSpotSignalWithFillFee(s, 1, "BTC", fillPrice, fillQty, fillFee, logger)
+	trades, err := ExecuteSpotSignalWithFillFee(s, 1, "BTC", fillPrice, fillQty, fillFee, "", logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -595,6 +595,58 @@ func TestExecuteSpotSignalLiveFillUsesExchangeFee(t *testing.T) {
 	if len(s.TradeHistory) != 1 || s.TradeHistory[0].ExchangeFee != fillFee {
 		t.Fatalf("ExchangeFee = %v, want %v", s.TradeHistory, fillFee)
 	}
+}
+
+func TestExecuteSpotSignalLiveFillUsesExchangeOrderID(t *testing.T) {
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	t.Run("open", func(t *testing.T) {
+		s := &StrategyState{
+			ID:              "rh-momentum-btc",
+			Cash:            1000,
+			Platform:        "robinhood",
+			Positions:       make(map[string]*Position),
+			OptionPositions: make(map[string]*OptionPosition),
+			TradeHistory:    []Trade{},
+			RiskState:       RiskState{},
+		}
+
+		trades, err := ExecuteSpotSignalWithFillFee(s, 1, "BTC", 50000, 0.015, 0.17, "rh-open-oid", logger)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if trades != 1 {
+			t.Fatalf("trades = %d, want 1", trades)
+		}
+		if got := s.TradeHistory[0].ExchangeOrderID; got != "rh-open-oid" {
+			t.Errorf("ExchangeOrderID = %q, want rh-open-oid", got)
+		}
+	})
+
+	t.Run("close", func(t *testing.T) {
+		s := &StrategyState{
+			ID:              "rh-momentum-btc",
+			Cash:            250,
+			Platform:        "robinhood",
+			Positions:       map[string]*Position{"BTC": {Symbol: "BTC", Quantity: 0.015, AvgCost: 49000, Side: "long"}},
+			OptionPositions: make(map[string]*OptionPosition),
+			TradeHistory:    []Trade{},
+			RiskState:       RiskState{},
+		}
+
+		trades, err := ExecuteSpotSignalWithFillFee(s, -1, "BTC", 50000, 0.015, 0.17, "rh-close-oid", logger)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if trades != 1 {
+			t.Fatalf("trades = %d, want 1", trades)
+		}
+		if got := s.TradeHistory[0].ExchangeOrderID; got != "rh-close-oid" {
+			t.Errorf("ExchangeOrderID = %q, want rh-close-oid", got)
+		}
+	})
 }
 
 // #254: ExecutePerpsSignal — margin-based accounting. Paper buy should NOT
@@ -1007,7 +1059,7 @@ func TestExecuteFuturesSignalLiveFillUsesExchangeFee(t *testing.T) {
 
 	spec := ContractSpec{TickSize: 0.25, TickValue: 12.5, Multiplier: 50, Margin: 500}
 	fillFee := 4.12
-	trades, err := ExecuteFuturesSignalWithFillFee(s, 1, "ES", 5000, spec, 2.5, 5, 2, fillFee, logger)
+	trades, err := ExecuteFuturesSignalWithFillFee(s, 1, "ES", 5000, spec, 2.5, 5, 2, fillFee, "", logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1021,6 +1073,63 @@ func TestExecuteFuturesSignalLiveFillUsesExchangeFee(t *testing.T) {
 	if s.TradeHistory[0].ExchangeFee != fillFee {
 		t.Errorf("ExchangeFee = %g, want %g", s.TradeHistory[0].ExchangeFee, fillFee)
 	}
+}
+
+func TestExecuteFuturesSignalLiveFillUsesExchangeOrderID(t *testing.T) {
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	spec := ContractSpec{TickSize: 0.25, TickValue: 12.5, Multiplier: 50, Margin: 500}
+
+	t.Run("open", func(t *testing.T) {
+		s := &StrategyState{
+			ID:              "ts-momentum-es",
+			Cash:            10000,
+			Platform:        "topstep",
+			Positions:       make(map[string]*Position),
+			OptionPositions: make(map[string]*OptionPosition),
+			TradeHistory:    []Trade{},
+			RiskState:       RiskState{},
+		}
+
+		trades, err := ExecuteFuturesSignalWithFillFee(s, 1, "ES", 5000, spec, 2.5, 5, 2, 4.12, "ts-open-oid", logger)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if trades != 1 {
+			t.Fatalf("trades = %d, want 1", trades)
+		}
+		if got := s.TradeHistory[0].ExchangeOrderID; got != "ts-open-oid" {
+			t.Errorf("ExchangeOrderID = %q, want ts-open-oid", got)
+		}
+	})
+
+	t.Run("close", func(t *testing.T) {
+		s := &StrategyState{
+			ID:              "ts-momentum-es",
+			Cash:            10000,
+			Platform:        "topstep",
+			Positions:       map[string]*Position{"ES": {Symbol: "ES", Quantity: 2, AvgCost: 4990, Side: "long", Multiplier: 50}},
+			OptionPositions: make(map[string]*OptionPosition),
+			TradeHistory:    []Trade{},
+			RiskState:       RiskState{},
+		}
+
+		trades, err := ExecuteFuturesSignalWithFillFee(s, -1, "ES", 5000, spec, 2.5, 5, 2, 4.12, "ts-close-oid", logger)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if trades != 2 {
+			t.Fatalf("trades = %d, want 2", trades)
+		}
+		if got := s.TradeHistory[0].ExchangeOrderID; got != "ts-close-oid" {
+			t.Errorf("ExchangeOrderID = %q, want ts-close-oid", got)
+		}
+		if got := s.TradeHistory[1].ExchangeOrderID; got != "" {
+			t.Errorf("open leg ExchangeOrderID = %q, want empty modeled metadata leg", got)
+		}
+	})
 }
 
 // #328 — AllowShorts=true lets signal=-1 from flat open a short perp position.

--- a/shared_scripts/check_okx.py
+++ b/shared_scripts/check_okx.py
@@ -231,6 +231,9 @@ def run_execute(symbol, side, size, mode, inst_type="swap"):
             fee = _extract_fee(result)
             if fee is not None:
                 fill["fee"] = fee
+            oid = result.get("id")
+            if oid is not None:
+                fill["oid"] = str(oid)
         except Exception:
             pass
 

--- a/shared_scripts/check_okx.py
+++ b/shared_scripts/check_okx.py
@@ -232,7 +232,7 @@ def run_execute(symbol, side, size, mode, inst_type="swap"):
             if fee is not None:
                 fill["fee"] = fee
             oid = result.get("id")
-            if oid is not None:
+            if oid:
                 fill["oid"] = str(oid)
         except Exception:
             pass

--- a/shared_scripts/check_robinhood.py
+++ b/shared_scripts/check_robinhood.py
@@ -238,7 +238,7 @@ def run_execute(symbol, side, amount_usd, quantity, mode):
                     if fee is not None:
                         fill["fee"] = fee
                     oid = result.get("id")
-                    if oid is not None:
+                    if oid:
                         fill["oid"] = str(oid)
         except Exception:
             pass

--- a/shared_scripts/check_robinhood.py
+++ b/shared_scripts/check_robinhood.py
@@ -237,6 +237,9 @@ def run_execute(symbol, side, amount_usd, quantity, mode):
                     fee = _extract_fee(result)
                     if fee is not None:
                         fill["fee"] = fee
+                    oid = result.get("id")
+                    if oid is not None:
+                        fill["oid"] = str(oid)
         except Exception:
             pass
 

--- a/shared_scripts/check_topstep.py
+++ b/shared_scripts/check_topstep.py
@@ -244,6 +244,9 @@ def run_execute(symbol, side, contracts, mode):
             fee = _extract_fee(result)
             if fee is not None:
                 fill["fee"] = fee
+            oid = result.get("orderId") or result.get("id")
+            if oid is not None:
+                fill["oid"] = str(oid)
         except Exception as e:
             print(f"[topstep] fill parse error: {e}", file=sys.stderr)
 

--- a/shared_scripts/check_topstep.py
+++ b/shared_scripts/check_topstep.py
@@ -244,8 +244,10 @@ def run_execute(symbol, side, contracts, mode):
             fee = _extract_fee(result)
             if fee is not None:
                 fill["fee"] = fee
-            oid = result.get("orderId") or result.get("id")
-            if oid is not None:
+            oid = result.get("orderId")
+            if oid is None:
+                oid = result.get("id")
+            if oid:
                 fill["oid"] = str(oid)
         except Exception as e:
             print(f"[topstep] fill parse error: {e}", file=sys.stderr)

--- a/shared_scripts/test_check_execute_fees.py
+++ b/shared_scripts/test_check_execute_fees.py
@@ -121,3 +121,48 @@ def test_topstep_execute_emits_exchange_order_id(monkeypatch, capsys):
     payload = json.loads(capsys.readouterr().out)
 
     assert payload["execution"]["fill"]["oid"] == "ts-order-789"
+
+
+def test_okx_execute_omits_empty_oid(monkeypatch, capsys):
+    mod = _load_script("check_okx.py")
+    adapter_mod = types.ModuleType("adapter")
+
+    class OKXExchangeAdapter:
+        def market_open(self, symbol, is_buy, size, inst_type="spot"):
+            return {
+                "id": "",
+                "average": "50000",
+                "filled": str(size),
+            }
+
+    adapter_mod.OKXExchangeAdapter = OKXExchangeAdapter
+    monkeypatch.setitem(sys.modules, "adapter", adapter_mod)
+
+    mod.run_execute("BTC", "buy", 0.01, "live", "swap")
+    payload = json.loads(capsys.readouterr().out)
+
+    assert "oid" not in payload["execution"]["fill"]
+
+
+def test_topstep_execute_falls_back_to_id_when_orderid_missing(monkeypatch, capsys):
+    mod = _load_script("check_topstep.py")
+    adapter_mod = types.ModuleType("adapter")
+
+    class TopStepExchangeAdapter:
+        def __init__(self, mode="paper"):
+            self.mode = mode
+
+        def market_open(self, symbol, is_buy, contracts):
+            return {
+                "id": "ts-fallback-1",
+                "avgPrice": "5000.25",
+                "filledQuantity": contracts,
+            }
+
+    adapter_mod.TopStepExchangeAdapter = TopStepExchangeAdapter
+    monkeypatch.setitem(sys.modules, "adapter", adapter_mod)
+
+    mod.run_execute("ES", "buy", 1, "live")
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["execution"]["fill"]["oid"] == "ts-fallback-1"

--- a/shared_scripts/test_check_execute_fees.py
+++ b/shared_scripts/test_check_execute_fees.py
@@ -1,7 +1,10 @@
 """Tests for live execute fee extraction in platform check scripts."""
 
 import importlib.util
+import json
 import os
+import sys
+import types
 
 
 def _load_script(filename):
@@ -46,3 +49,75 @@ def test_topstep_extracts_nested_fee_total():
 def test_topstep_ignores_generic_nested_totals_without_fee_context():
     mod = _load_script("check_topstep.py")
     assert mod._extract_fee_value([{"total": "750.00", "value": "0.015"}]) is None
+
+
+def test_okx_execute_emits_exchange_order_id(monkeypatch, capsys):
+    mod = _load_script("check_okx.py")
+    adapter_mod = types.ModuleType("adapter")
+
+    class OKXExchangeAdapter:
+        def market_open(self, symbol, is_buy, size, inst_type="spot"):
+            return {
+                "id": "okx-order-123",
+                "average": "50000",
+                "filled": str(size),
+                "fee": {"cost": "0.25"},
+            }
+
+    adapter_mod.OKXExchangeAdapter = OKXExchangeAdapter
+    monkeypatch.setitem(sys.modules, "adapter", adapter_mod)
+
+    mod.run_execute("BTC", "buy", 0.01, "live", "swap")
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["execution"]["fill"]["oid"] == "okx-order-123"
+
+
+def test_robinhood_execute_emits_exchange_order_id(monkeypatch, capsys):
+    mod = _load_script("check_robinhood.py")
+    adapter_mod = types.ModuleType("adapter")
+
+    class RobinhoodExchangeAdapter:
+        def __init__(self, mode="paper"):
+            self.mode = mode
+
+        def market_buy(self, symbol, amount_usd):
+            return {
+                "id": "rh-order-456",
+                "average_price": "50000",
+                "cumulative_quantity": "0.01",
+                "executions": [{"fees": [{"amount": "0.03"}]}],
+            }
+
+    adapter_mod.RobinhoodExchangeAdapter = RobinhoodExchangeAdapter
+    monkeypatch.setitem(sys.modules, "adapter", adapter_mod)
+
+    mod.run_execute("BTC", "buy", 500, 0, "live")
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["execution"]["fill"]["oid"] == "rh-order-456"
+
+
+def test_topstep_execute_emits_exchange_order_id(monkeypatch, capsys):
+    mod = _load_script("check_topstep.py")
+    adapter_mod = types.ModuleType("adapter")
+
+    class TopStepExchangeAdapter:
+        def __init__(self, mode="paper"):
+            self.mode = mode
+
+        def market_open(self, symbol, is_buy, contracts):
+            return {
+                "orderId": "ts-order-789",
+                "avgPrice": "5000.25",
+                "filledQuantity": contracts,
+                "totalFees": [{"amount": "4.12"}],
+            }
+
+    adapter_mod.TopStepExchangeAdapter = TopStepExchangeAdapter
+    monkeypatch.setitem(sys.modules, "adapter", adapter_mod)
+
+    mod.run_execute("ES", "buy", 2, "live")
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["execution"]["fill"]["oid"] == "ts-order-789"


### PR DESCRIPTION
## Summary
- Emit normalized `execution.fill.oid` from OKX, Robinhood crypto, and TopStep live execute scripts.
- Parse and thread platform order IDs through Go execute result handling into `Trade.ExchangeOrderID` before persistence.
- Add regression coverage for JSON parsing, portfolio trade metadata, execute result application, and Python emitters.

Closes #456

## Test plan
- `python3 -m py_compile shared_scripts/check_okx.py shared_scripts/check_robinhood.py shared_scripts/check_topstep.py shared_scripts/test_check_execute_fees.py`
- `uv run pytest shared_scripts/test_check_execute_fees.py -v`
- `/opt/homebrew/bin/go test ./...` from `scheduler`

Made with [Cursor](https://cursor.com)

LLM: GPT-5.5 | Effort: high