### PR TITLE
Fix Hyperliquid kill-switch to record real close fills

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -765,7 +765,11 @@ func hyperliquidKillSwitchFillShare(sc StrategyConfig, coin string, fillSz, fill
 		}
 	}
 	if !foundSelf || sumW <= 0 {
-		return fillSz, fillFee
+		// Fail closed: a misconfigured caller passing an `sc` that isn't among
+		// peers must not cause a single strategy to claim the entire portfolio
+		// fill. The generic fallback in forceCloseAllPositions will then close
+		// any residual virtual position at mark price.
+		return 0, 0
 	}
 	ratio := wSelf / sumW
 	if ratio < 0 {

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -522,6 +522,10 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 // so future readers see the predicate spelled out.
 type HyperliquidLiveCloseReport struct {
 	ClosedCoins []string
+	// Fills carries the real exchange fill for coins in ClosedCoins when the
+	// adapter returned one. Kill-switch state clearing uses this to book
+	// realized PnL from the close fill instead of the pre-close mark (#454).
+	Fills map[string]HyperliquidCloseFill
 	// AlreadyFlat is set from two sources: the pre-submit szi==0 short-circuit
 	// in forceCloseHyperliquidLive (defense-in-depth — FetchHyperliquidPositions
 	// pre-filters szi≠0, so this branch should not fire in production) AND the
@@ -586,7 +590,10 @@ func (r HyperliquidLiveCloseReport) SortedErrorCoins() []string {
 // doesn't leave orphan triggers consuming HL's 10/day account-wide cap
 // (#421). nil/empty disables the cancel; the closer is otherwise unchanged.
 func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLiveAll []StrategyConfig, closer HyperliquidLiveCloser, stopLossOIDsByCoin map[string][]int64) HyperliquidLiveCloseReport {
-	report := HyperliquidLiveCloseReport{Errors: make(map[string]error)}
+	report := HyperliquidLiveCloseReport{
+		Fills:  make(map[string]HyperliquidCloseFill),
+		Errors: make(map[string]error),
+	}
 
 	tradedCoins := make(map[string]bool)
 	for _, sc := range hlLiveAll {
@@ -632,6 +639,9 @@ func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLi
 		if result != nil && result.Close != nil && result.Close.AlreadyFlat {
 			report.AlreadyFlat = append(report.AlreadyFlat, p.Coin)
 			continue
+		}
+		if result != nil && result.Close != nil && result.Close.Fill != nil {
+			report.Fills[p.Coin] = *result.Close.Fill
 		}
 		report.ClosedCoins = append(report.ClosedCoins, p.Coin)
 	}
@@ -736,6 +746,56 @@ func computeHyperliquidCircuitCloseQty(coin, strategyID string, hlPositions []HL
 		return 0, false
 	}
 	return q, true
+}
+
+func hyperliquidKillSwitchFillShare(sc StrategyConfig, coin string, fillSz, fillFee float64, hlLiveAll []StrategyConfig) (float64, float64) {
+	peers := hlLiveStrategiesForCoin(coin, hlLiveAll)
+	if len(peers) <= 1 {
+		return fillSz, fillFee
+	}
+	weights := hlStrategyCapitalWeights(peers)
+	sumW := 0.0
+	var wSelf float64
+	foundSelf := false
+	for i, p := range peers {
+		sumW += weights[i]
+		if p.ID == sc.ID {
+			wSelf = weights[i]
+			foundSelf = true
+		}
+	}
+	if !foundSelf || sumW <= 0 {
+		return fillSz, fillFee
+	}
+	ratio := wSelf / sumW
+	if ratio < 0 {
+		ratio = 0
+	} else if ratio > 1 {
+		ratio = 1
+	}
+	return fillSz * ratio, fillFee * ratio
+}
+
+// applyHyperliquidKillSwitchCloseFill applies one strategy's weighted share of
+// the portfolio kill-switch fill before generic virtual-state cleanup runs.
+func applyHyperliquidKillSwitchCloseFill(s *StrategyState, sc StrategyConfig, fills map[string]HyperliquidCloseFill, hlLiveAll []StrategyConfig) bool {
+	if s == nil || sc.Platform != "hyperliquid" || sc.Type != "perps" || !hyperliquidIsLive(sc.Args) {
+		return false
+	}
+	coin := hyperliquidSymbol(sc.Args)
+	if coin == "" {
+		return false
+	}
+	fill, ok := fills[coin]
+	if !ok || fill.TotalSz <= 1e-15 || fill.AvgPx <= 0 {
+		return false
+	}
+	fillSz, fillFee := hyperliquidKillSwitchFillShare(sc, coin, fill.TotalSz, fill.Fee, hlLiveAll)
+	if fillSz <= 1e-15 {
+		return false
+	}
+	applyHyperliquidCircuitCloseFill(s, coin, fillSz, fill.AvgPx, fillFee, 0)
+	return true
 }
 
 func lookupStrategyConfig(strategies []StrategyConfig, id string) *StrategyConfig {
@@ -1117,15 +1177,16 @@ func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, f
 			closeSide = "buy"
 		}
 		RecordTrade(s, Trade{
-			Timestamp:  now,
-			StrategyID: s.ID,
-			Symbol:     symbol,
-			Side:       closeSide,
-			Quantity:   fillSz,
-			Price:      fillPx,
-			Value:      fillSz * fillPx,
-			TradeType:  "perps",
-			Details:    fmt.Sprintf("Circuit breaker on-chain close (no virtual position), fill=%.6f fee=$%.4f", fillSz, fillFee),
+			Timestamp:   now,
+			StrategyID:  s.ID,
+			Symbol:      symbol,
+			Side:        closeSide,
+			Quantity:    fillSz,
+			Price:       fillPx,
+			Value:       fillSz * fillPx,
+			TradeType:   "perps",
+			Details:     fmt.Sprintf("Circuit breaker on-chain close (no virtual position), fill=%.6f fee=$%.4f", fillSz, fillFee),
+			ExchangeFee: exchangeFeeForTrade(fillFee, true),
 			// No virtual position to derive PnL from. Still mark as a close
 			// leg so the lifetime round-trip count (#455) reflects that the
 			// exchange-side position was reduced, but leave RealizedPnL=0
@@ -1166,6 +1227,7 @@ func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, f
 		Value:       qtyClosed * fillPx,
 		TradeType:   "perps",
 		Details:     fmt.Sprintf("Circuit breaker on-chain close, PnL: $%.2f (fee $%.4f)", pnl, fillFee),
+		ExchangeFee: exchangeFeeForTrade(fillFee, true),
 		IsClose:     true,
 		RealizedPnL: pnl,
 	})

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -187,7 +187,7 @@ func TestHyperliquidKillSwitchClose_UsesRealFillBeforeMark(t *testing.T) {
 			"BTC": {Symbol: "BTC", Quantity: 1.0, AvgCost: 50000, Side: "long", Multiplier: 1, Leverage: 5},
 		},
 	}
-	forceCloseKillSwitchPositions(s, hlLive[0], map[string]float64{"BTC": 48000}, plan, hlLive, nil)
+	forceCloseKillSwitchPositions(s, hlLive[0], map[string]float64{"BTC": 48000}, plan.CloseReport.Fills, hlLive, nil)
 
 	if len(s.TradeHistory) != 1 {
 		t.Fatalf("expected 1 trade, got %d", len(s.TradeHistory))
@@ -243,7 +243,7 @@ func TestHyperliquidKillSwitchClose_SharedCoinSplitsFillByWeights(t *testing.T) 
 		},
 	}
 
-	forceCloseKillSwitchPositions(s, hlLive[0], map[string]float64{"ETH": 2800}, plan, hlLive, nil)
+	forceCloseKillSwitchPositions(s, hlLive[0], map[string]float64{"ETH": 2800}, plan.CloseReport.Fills, hlLive, nil)
 
 	if len(s.TradeHistory) != 1 {
 		t.Fatalf("expected 1 trade, got %d", len(s.TradeHistory))
@@ -264,6 +264,53 @@ func TestHyperliquidKillSwitchClose_SharedCoinSplitsFillByWeights(t *testing.T) 
 	wantPnL := -51.0 // 0.5 * (3000 - 3100) - weighted fee 1.0
 	if math.Abs(s.ClosedPositions[0].RealizedPnL-wantPnL) > 1e-9 {
 		t.Errorf("RealizedPnL = %.4f; want %.4f", s.ClosedPositions[0].RealizedPnL, wantPnL)
+	}
+}
+
+// Closing both peers of a shared HL coin against the same kill-switch fill
+// must split the fill size and fee exactly, with no over- or under-counting.
+// Regression for capital-weighted fill split on shared coins.
+func TestHyperliquidKillSwitchClose_SharedCoinPeersSumToReport(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-a", Platform: "hyperliquid", Type: "perps", Leverage: 5, CapitalPct: 0.25,
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-b", Platform: "hyperliquid", Type: "perps", Leverage: 5, CapitalPct: 0.75,
+			Args: []string{"ema", "ETH", "1h", "--mode=live"}},
+	}
+	const totalSz, totalFee, avgPx = 2.0, 4.0, 3000.0
+	fills := map[string]HyperliquidCloseFill{
+		"ETH": {TotalSz: totalSz, AvgPx: avgPx, Fee: totalFee},
+	}
+	stateA := &StrategyState{
+		ID: "hl-a", Type: "perps", Platform: "hyperliquid", Cash: 1000,
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3100, Side: "long", Multiplier: 1, Leverage: 5},
+		},
+	}
+	stateB := &StrategyState{
+		ID: "hl-b", Type: "perps", Platform: "hyperliquid", Cash: 3000,
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 1.5, AvgCost: 3100, Side: "long", Multiplier: 1, Leverage: 5},
+		},
+	}
+	prices := map[string]float64{"ETH": 2800}
+
+	forceCloseKillSwitchPositions(stateA, hlLive[0], prices, fills, hlLive, nil)
+	forceCloseKillSwitchPositions(stateB, hlLive[1], prices, fills, hlLive, nil)
+
+	if len(stateA.TradeHistory) != 1 || len(stateB.TradeHistory) != 1 {
+		t.Fatalf("expected 1 trade per peer, got %d / %d",
+			len(stateA.TradeHistory), len(stateB.TradeHistory))
+	}
+	tA, tB := stateA.TradeHistory[0], stateB.TradeHistory[0]
+	if math.Abs((tA.Quantity+tB.Quantity)-totalSz) > 1e-9 {
+		t.Errorf("peer fill quantities sum to %.6f; want %.6f", tA.Quantity+tB.Quantity, totalSz)
+	}
+	if math.Abs((tA.ExchangeFee+tB.ExchangeFee)-totalFee) > 1e-9 {
+		t.Errorf("peer fees sum to %.6f; want %.6f", tA.ExchangeFee+tB.ExchangeFee, totalFee)
+	}
+	if tA.Price != avgPx || tB.Price != avgPx {
+		t.Errorf("peer fill prices = %.2f / %.2f; want %.2f for both", tA.Price, tB.Price, avgPx)
 	}
 }
 

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -151,6 +152,118 @@ func TestPlanKillSwitchClose_HappyPath(t *testing.T) {
 	if got := formatKillSwitchAutoResetMessage(plan.DiscordMessage); !strings.Contains(got, "Kill switch auto-reset; trading will resume next cycle") ||
 		strings.Contains(got, "Manual reset required") {
 		t.Errorf("expected auto-reset message to replace manual-reset instruction, got: %s", got)
+	}
+}
+
+func TestHyperliquidKillSwitchClose_UsesRealFillBeforeMark(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Leverage: 5,
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "BTC", Size: 1.0, EntryPrice: 50000}}
+	closer := func(symbol string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
+		return &HyperliquidCloseResult{
+			Close: &HyperliquidClose{
+				Symbol: symbol,
+				Fill:   &HyperliquidCloseFill{TotalSz: 1.0, AvgPx: 49000, Fee: 2.0},
+			},
+			Platform: "hyperliquid",
+		}, nil
+	}
+	fetcher, _ := stubHLStateFetcher(nil, nil)
+	plan := planKillSwitchClose(defaultHLInputs("0xaddr", true, positions, hlLive,
+		"portfolio drawdown 25.0% exceeds limit 20.0%",
+		time.Second, closer, fetcher))
+	if !plan.OnChainConfirmedFlat {
+		t.Fatalf("expected confirmed-flat plan, got %+v", plan)
+	}
+
+	s := &StrategyState{
+		ID:       "hl-btc",
+		Type:     "perps",
+		Platform: "hyperliquid",
+		Cash:     1000,
+		Positions: map[string]*Position{
+			"BTC": {Symbol: "BTC", Quantity: 1.0, AvgCost: 50000, Side: "long", Multiplier: 1, Leverage: 5},
+		},
+	}
+	forceCloseKillSwitchPositions(s, hlLive[0], map[string]float64{"BTC": 48000}, plan, hlLive, nil)
+
+	if len(s.TradeHistory) != 1 {
+		t.Fatalf("expected 1 trade, got %d", len(s.TradeHistory))
+	}
+	trade := s.TradeHistory[0]
+	if trade.Price != 49000 {
+		t.Fatalf("Trade.Price = %.2f; want closer fill AvgPx 49000, not mark 48000", trade.Price)
+	}
+	if trade.Quantity != 1.0 {
+		t.Errorf("Trade.Quantity = %.6f; want closer fill TotalSz 1.0", trade.Quantity)
+	}
+	if trade.ExchangeFee != 2.0 {
+		t.Errorf("Trade.ExchangeFee = %.4f; want closer fill Fee 2.0", trade.ExchangeFee)
+	}
+	if len(s.ClosedPositions) != 1 {
+		t.Fatalf("expected 1 closed position, got %d", len(s.ClosedPositions))
+	}
+	closed := s.ClosedPositions[0]
+	if closed.ClosePrice != 49000 {
+		t.Errorf("ClosedPosition.ClosePrice = %.2f; want fill AvgPx 49000", closed.ClosePrice)
+	}
+	wantPnL := -1002.0
+	if math.Abs(closed.RealizedPnL-wantPnL) > 1e-9 {
+		t.Errorf("ClosedPosition.RealizedPnL = %.4f; want %.4f", closed.RealizedPnL, wantPnL)
+	}
+	if math.Abs(s.Cash-(1000+wantPnL)) > 1e-9 {
+		t.Errorf("Cash = %.4f; want %.4f", s.Cash, 1000+wantPnL)
+	}
+}
+
+func TestHyperliquidKillSwitchClose_SharedCoinSplitsFillByWeights(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-a", Platform: "hyperliquid", Type: "perps", Leverage: 5, CapitalPct: 0.25,
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-b", Platform: "hyperliquid", Type: "perps", Leverage: 5, CapitalPct: 0.75,
+			Args: []string{"ema", "ETH", "1h", "--mode=live"}},
+	}
+	plan := KillSwitchClosePlan{
+		OnChainConfirmedFlat: true,
+		CloseReport: HyperliquidLiveCloseReport{
+			Fills: map[string]HyperliquidCloseFill{
+				"ETH": {TotalSz: 2.0, AvgPx: 3000, Fee: 4.0},
+			},
+		},
+	}
+	s := &StrategyState{
+		ID:       "hl-a",
+		Type:     "perps",
+		Platform: "hyperliquid",
+		Cash:     1000,
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3100, Side: "long", Multiplier: 1, Leverage: 5},
+		},
+	}
+
+	forceCloseKillSwitchPositions(s, hlLive[0], map[string]float64{"ETH": 2800}, plan, hlLive, nil)
+
+	if len(s.TradeHistory) != 1 {
+		t.Fatalf("expected 1 trade, got %d", len(s.TradeHistory))
+	}
+	trade := s.TradeHistory[0]
+	if math.Abs(trade.Quantity-0.5) > 1e-9 {
+		t.Errorf("Trade.Quantity = %.6f; want 0.5 weighted share of 2.0 fill", trade.Quantity)
+	}
+	if trade.Price != 3000 {
+		t.Errorf("Trade.Price = %.2f; want real fill AvgPx 3000", trade.Price)
+	}
+	if trade.ExchangeFee != 1.0 {
+		t.Errorf("Trade.ExchangeFee = %.4f; want weighted fill Fee 1.0", trade.ExchangeFee)
+	}
+	if len(s.ClosedPositions) != 1 {
+		t.Fatalf("expected 1 closed position, got %d", len(s.ClosedPositions))
+	}
+	wantPnL := -51.0 // 0.5 * (3000 - 3100) - weighted fee 1.0
+	if math.Abs(s.ClosedPositions[0].RealizedPnL-wantPnL) > 1e-9 {
+		t.Errorf("RealizedPnL = %.4f; want %.4f", s.ClosedPositions[0].RealizedPnL, wantPnL)
 	}
 }
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -849,7 +849,7 @@ func main() {
 				mu.Lock()
 				for _, sc := range cfg.Strategies {
 					if s, ok := state.Strategies[sc.ID]; ok {
-						forceCloseKillSwitchPositions(s, sc, prices, plan, hlLiveAll, nil)
+						forceCloseKillSwitchPositions(s, sc, prices, plan.CloseReport.Fills, hlLiveAll, nil)
 						// Pending HL circuit close was already cleared above
 						// when portfolio kill fired (line ~611); nothing to do
 						// here. The per-strategy pending field is owned by the

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -849,7 +849,7 @@ func main() {
 				mu.Lock()
 				for _, sc := range cfg.Strategies {
 					if s, ok := state.Strategies[sc.ID]; ok {
-						forceCloseAllPositions(s, prices, nil)
+						forceCloseKillSwitchPositions(s, sc, prices, plan, hlLiveAll, nil)
 						// Pending HL circuit close was already cleared above
 						// when portfolio kill fired (line ~611); nothing to do
 						// here. The per-strategy pending field is owned by the

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1063,13 +1063,15 @@ func rolloverDailyPnL(r *RiskState) {
 }
 
 // forceCloseKillSwitchPositions clears virtual positions after a confirmed
-// portfolio kill-switch close.
-func forceCloseKillSwitchPositions(s *StrategyState, sc StrategyConfig, prices map[string]float64, plan KillSwitchClosePlan, hlLiveAll []StrategyConfig, logger *StrategyLogger) {
+// portfolio kill-switch close. `hlFills` carries the realized Hyperliquid
+// close fills (price/size/fee) so HL strategies record accurate Trade and
+// ClosedPosition rows; pass nil for non-HL or when no fill data is available.
+func forceCloseKillSwitchPositions(s *StrategyState, sc StrategyConfig, prices map[string]float64, hlFills map[string]HyperliquidCloseFill, hlLiveAll []StrategyConfig, logger *StrategyLogger) {
 	// Live HL portfolio-kill closes can carry real exchange fills. Apply them
 	// first so Trade and ClosedPosition rows use realized fill price/fee; the
 	// generic pass below remains the cleanup path for non-HL strategies,
 	// missing-fill fallbacks, options, and any residual virtual positions.
-	applyHyperliquidKillSwitchCloseFill(s, sc, plan.CloseReport.Fills, hlLiveAll)
+	applyHyperliquidKillSwitchCloseFill(s, sc, hlFills, hlLiveAll)
 	forceCloseAllPositions(s, prices, logger)
 }
 

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1062,6 +1062,17 @@ func rolloverDailyPnL(r *RiskState) {
 	}
 }
 
+// forceCloseKillSwitchPositions clears virtual positions after a confirmed
+// portfolio kill-switch close.
+func forceCloseKillSwitchPositions(s *StrategyState, sc StrategyConfig, prices map[string]float64, plan KillSwitchClosePlan, hlLiveAll []StrategyConfig, logger *StrategyLogger) {
+	// Live HL portfolio-kill closes can carry real exchange fills. Apply them
+	// first so Trade and ClosedPosition rows use realized fill price/fee; the
+	// generic pass below remains the cleanup path for non-HL strategies,
+	// missing-fill fallbacks, options, and any residual virtual positions.
+	applyHyperliquidKillSwitchCloseFill(s, sc, plan.CloseReport.Fills, hlLiveAll)
+	forceCloseAllPositions(s, prices, logger)
+}
+
 // forceCloseAllPositions liquidates all open positions at current prices.
 // Called when any circuit breaker fires.
 func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger *StrategyLogger) {


### PR DESCRIPTION
## Summary
- Thread Hyperliquid close fills through the kill-switch close report.
- Apply the real HL fill price, size, and fee when clearing virtual state after a confirmed portfolio close.
- Preserve shared-coin proportional fill/fee splitting and add regression coverage.

## Testing
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...`
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler build -o ../go-trader .`

Closes #454