### PR TITLE
ci: allow gh in @claude action --allowedTools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -160,7 +160,7 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: --model ${{ steps.resolve_model.outputs.model_id }} --effort ${{ steps.resolve_model.outputs.effort }} --allowedTools "Bash(go *),Bash(cd scheduler && go *),Bash(uv run *),Bash(python3 *),Bash(.venv/bin/python3 *),Bash(gofmt *),Bash(cd scheduler && gofmt *),Bash(git *)"
+          claude_args: --model ${{ steps.resolve_model.outputs.model_id }} --effort ${{ steps.resolve_model.outputs.effort }} --allowedTools "Bash(go *),Bash(cd scheduler && go *),Bash(uv run *),Bash(python3 *),Bash(.venv/bin/python3 *),Bash(gofmt *),Bash(cd scheduler && gofmt *),Bash(git *),Bash(gh *)"
 
       - name: Detect if Claude made commits
         if: steps.verify_invocation.outputs.invoked == 'true' && steps.claude.outcome == 'success'


### PR DESCRIPTION
## Summary
- Adds `Bash(gh *)` to the `@claude` action's `--allowedTools` so it can run `gh issue create`, `gh api ... --method POST/PATCH`, etc. without permission prompts.
- The workflow's `permissions:` block (`issues: write`, `pull-requests: write`, `contents: write`, `actions: read`) still caps what `gh` can actually do — this only widens the in-action tool allowlist, not the GitHub token scope.

## Test plan
- [ ] After merge, invoke \`@claude\` on an issue/PR with a request that requires \`gh issue create\` or \`gh api ... --method POST\` and confirm it executes without hitting an allowedTools denial.

---
LLM: Claude Opus 4.7 (1M) | high