### PR TITLE
Fix Hyperliquid kill-switch fill attribution for shared coins

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -700,6 +700,39 @@ func hlStrategyCapitalWeights(peers []StrategyConfig) []float64 {
 	return out
 }
 
+type hlVirtualQuantitySnapshot map[string]map[string]float64
+
+// snapshotHyperliquidVirtualQuantities captures the per-strategy virtual
+// quantities that exist before a portfolio kill-switch close mutates state.
+func snapshotHyperliquidVirtualQuantities(strategies map[string]*StrategyState, hlLiveAll []StrategyConfig) hlVirtualQuantitySnapshot {
+	if len(strategies) == 0 || len(hlLiveAll) == 0 {
+		return nil
+	}
+	out := make(hlVirtualQuantitySnapshot)
+	for _, sc := range hlLiveAll {
+		coin := hyperliquidSymbol(sc.Args)
+		if coin == "" {
+			continue
+		}
+		ss := strategies[sc.ID]
+		if ss == nil {
+			continue
+		}
+		pos := ss.Positions[coin]
+		if pos == nil || pos.Quantity <= 0 {
+			continue
+		}
+		if out[coin] == nil {
+			out[coin] = make(map[string]float64)
+		}
+		out[coin][sc.ID] = pos.Quantity
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // computeHyperliquidCircuitCloseQty returns the unsigned coin quantity for a
 // reduce-only market_close when strategyID's per-strategy circuit breaker fires
 // (#356). For a coin traded by multiple live HL strategies on the same wallet,
@@ -748,30 +781,36 @@ func computeHyperliquidCircuitCloseQty(coin, strategyID string, hlPositions []HL
 	return q, true
 }
 
-func hyperliquidKillSwitchFillShare(sc StrategyConfig, coin string, fillSz, fillFee float64, hlLiveAll []StrategyConfig) (float64, float64) {
+func hyperliquidKillSwitchFillShare(sc StrategyConfig, coin string, fillSz, fillFee float64, hlLiveAll []StrategyConfig, virtualQty hlVirtualQuantitySnapshot) (float64, float64) {
 	peers := hlLiveStrategiesForCoin(coin, hlLiveAll)
 	if len(peers) <= 1 {
 		return fillSz, fillFee
 	}
-	weights := hlStrategyCapitalWeights(peers)
-	sumW := 0.0
-	var wSelf float64
+	qtyByStrategy := virtualQty[coin]
+	sumQty := 0.0
+	var selfQty float64
 	foundSelf := false
-	for i, p := range peers {
-		sumW += weights[i]
+	for _, p := range peers {
 		if p.ID == sc.ID {
-			wSelf = weights[i]
 			foundSelf = true
 		}
+		qty := qtyByStrategy[p.ID]
+		if qty <= 0 {
+			continue
+		}
+		sumQty += qty
+		if p.ID == sc.ID {
+			selfQty = qty
+		}
 	}
-	if !foundSelf || sumW <= 0 {
+	if !foundSelf || sumQty <= 0 || selfQty <= 0 {
 		// Fail closed: a misconfigured caller passing an `sc` that isn't among
 		// peers must not cause a single strategy to claim the entire portfolio
 		// fill. The generic fallback in forceCloseAllPositions will then close
 		// any residual virtual position at mark price.
 		return 0, 0
 	}
-	ratio := wSelf / sumW
+	ratio := selfQty / sumQty
 	if ratio < 0 {
 		ratio = 0
 	} else if ratio > 1 {
@@ -780,9 +819,10 @@ func hyperliquidKillSwitchFillShare(sc StrategyConfig, coin string, fillSz, fill
 	return fillSz * ratio, fillFee * ratio
 }
 
-// applyHyperliquidKillSwitchCloseFill applies one strategy's weighted share of
-// the portfolio kill-switch fill before generic virtual-state cleanup runs.
-func applyHyperliquidKillSwitchCloseFill(s *StrategyState, sc StrategyConfig, fills map[string]HyperliquidCloseFill, hlLiveAll []StrategyConfig) bool {
+// applyHyperliquidKillSwitchCloseFill applies one strategy's virtual-quantity
+// share of the portfolio kill-switch fill before generic virtual-state cleanup
+// runs.
+func applyHyperliquidKillSwitchCloseFill(s *StrategyState, sc StrategyConfig, fills map[string]HyperliquidCloseFill, hlLiveAll []StrategyConfig, virtualQty hlVirtualQuantitySnapshot) bool {
 	if s == nil || sc.Platform != "hyperliquid" || sc.Type != "perps" || !hyperliquidIsLive(sc.Args) {
 		return false
 	}
@@ -794,7 +834,7 @@ func applyHyperliquidKillSwitchCloseFill(s *StrategyState, sc StrategyConfig, fi
 	if !ok || fill.TotalSz <= 1e-15 || fill.AvgPx <= 0 {
 		return false
 	}
-	fillSz, fillFee := hyperliquidKillSwitchFillShare(sc, coin, fill.TotalSz, fill.Fee, hlLiveAll)
+	fillSz, fillFee := hyperliquidKillSwitchFillShare(sc, coin, fill.TotalSz, fill.Fee, hlLiveAll, virtualQty)
 	if fillSz <= 1e-15 {
 		return false
 	}

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -187,7 +187,7 @@ func TestHyperliquidKillSwitchClose_UsesRealFillBeforeMark(t *testing.T) {
 			"BTC": {Symbol: "BTC", Quantity: 1.0, AvgCost: 50000, Side: "long", Multiplier: 1, Leverage: 5},
 		},
 	}
-	forceCloseKillSwitchPositions(s, hlLive[0], map[string]float64{"BTC": 48000}, plan.CloseReport.Fills, hlLive, nil)
+	forceCloseKillSwitchPositions(s, hlLive[0], map[string]float64{"BTC": 48000}, plan.CloseReport.Fills, hlLive, nil, nil)
 
 	if len(s.TradeHistory) != 1 {
 		t.Fatalf("expected 1 trade, got %d", len(s.TradeHistory))
@@ -218,7 +218,7 @@ func TestHyperliquidKillSwitchClose_UsesRealFillBeforeMark(t *testing.T) {
 	}
 }
 
-func TestHyperliquidKillSwitchClose_SharedCoinSplitsFillByWeights(t *testing.T) {
+func TestHyperliquidKillSwitchClose_SharedCoinSplitsFillByVirtualQuantity(t *testing.T) {
 	hlLive := []StrategyConfig{
 		{ID: "hl-a", Platform: "hyperliquid", Type: "perps", Leverage: 5, CapitalPct: 0.25,
 			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
@@ -239,29 +239,42 @@ func TestHyperliquidKillSwitchClose_SharedCoinSplitsFillByWeights(t *testing.T) 
 		Platform: "hyperliquid",
 		Cash:     1000,
 		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 1.5, AvgCost: 3100, Side: "long", Multiplier: 1, Leverage: 5},
+		},
+	}
+	peerState := &StrategyState{
+		ID:       "hl-b",
+		Type:     "perps",
+		Platform: "hyperliquid",
+		Cash:     3000,
+		Positions: map[string]*Position{
 			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3100, Side: "long", Multiplier: 1, Leverage: 5},
 		},
 	}
+	hlVirtualQty := snapshotHyperliquidVirtualQuantities(map[string]*StrategyState{
+		"hl-a": s,
+		"hl-b": peerState,
+	}, hlLive)
 
-	forceCloseKillSwitchPositions(s, hlLive[0], map[string]float64{"ETH": 2800}, plan.CloseReport.Fills, hlLive, nil)
+	forceCloseKillSwitchPositions(s, hlLive[0], map[string]float64{"ETH": 2800}, plan.CloseReport.Fills, hlLive, hlVirtualQty, nil)
 
 	if len(s.TradeHistory) != 1 {
 		t.Fatalf("expected 1 trade, got %d", len(s.TradeHistory))
 	}
 	trade := s.TradeHistory[0]
-	if math.Abs(trade.Quantity-0.5) > 1e-9 {
-		t.Errorf("Trade.Quantity = %.6f; want 0.5 weighted share of 2.0 fill", trade.Quantity)
+	if math.Abs(trade.Quantity-1.5) > 1e-9 {
+		t.Errorf("Trade.Quantity = %.6f; want 1.5 virtual-quantity share of 2.0 fill", trade.Quantity)
 	}
 	if trade.Price != 3000 {
 		t.Errorf("Trade.Price = %.2f; want real fill AvgPx 3000", trade.Price)
 	}
-	if trade.ExchangeFee != 1.0 {
-		t.Errorf("Trade.ExchangeFee = %.4f; want weighted fill Fee 1.0", trade.ExchangeFee)
+	if trade.ExchangeFee != 3.0 {
+		t.Errorf("Trade.ExchangeFee = %.4f; want virtual-quantity fill Fee 3.0", trade.ExchangeFee)
 	}
 	if len(s.ClosedPositions) != 1 {
 		t.Fatalf("expected 1 closed position, got %d", len(s.ClosedPositions))
 	}
-	wantPnL := -51.0 // 0.5 * (3000 - 3100) - weighted fee 1.0
+	wantPnL := -153.0 // 1.5 * (3000 - 3100) - quantity-weighted fee 3.0
 	if math.Abs(s.ClosedPositions[0].RealizedPnL-wantPnL) > 1e-9 {
 		t.Errorf("RealizedPnL = %.4f; want %.4f", s.ClosedPositions[0].RealizedPnL, wantPnL)
 	}
@@ -269,7 +282,8 @@ func TestHyperliquidKillSwitchClose_SharedCoinSplitsFillByWeights(t *testing.T) 
 
 // Closing both peers of a shared HL coin against the same kill-switch fill
 // must split the fill size and fee exactly, with no over- or under-counting.
-// Regression for capital-weighted fill split on shared coins.
+// Regression for capital-weighted fill split on shared coins where runtime
+// virtual quantities have drifted away from configured capital percentages.
 func TestHyperliquidKillSwitchClose_SharedCoinPeersSumToReport(t *testing.T) {
 	hlLive := []StrategyConfig{
 		{ID: "hl-a", Platform: "hyperliquid", Type: "perps", Leverage: 5, CapitalPct: 0.25,
@@ -284,25 +298,32 @@ func TestHyperliquidKillSwitchClose_SharedCoinPeersSumToReport(t *testing.T) {
 	stateA := &StrategyState{
 		ID: "hl-a", Type: "perps", Platform: "hyperliquid", Cash: 1000,
 		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3100, Side: "long", Multiplier: 1, Leverage: 5},
+			"ETH": {Symbol: "ETH", Quantity: 1.5, AvgCost: 3100, Side: "long", Multiplier: 1, Leverage: 5},
 		},
 	}
 	stateB := &StrategyState{
 		ID: "hl-b", Type: "perps", Platform: "hyperliquid", Cash: 3000,
 		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 1.5, AvgCost: 3100, Side: "long", Multiplier: 1, Leverage: 5},
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3100, Side: "long", Multiplier: 1, Leverage: 5},
 		},
 	}
 	prices := map[string]float64{"ETH": 2800}
+	hlVirtualQty := snapshotHyperliquidVirtualQuantities(map[string]*StrategyState{
+		"hl-a": stateA,
+		"hl-b": stateB,
+	}, hlLive)
 
-	forceCloseKillSwitchPositions(stateA, hlLive[0], prices, fills, hlLive, nil)
-	forceCloseKillSwitchPositions(stateB, hlLive[1], prices, fills, hlLive, nil)
+	forceCloseKillSwitchPositions(stateA, hlLive[0], prices, fills, hlLive, hlVirtualQty, nil)
+	forceCloseKillSwitchPositions(stateB, hlLive[1], prices, fills, hlLive, hlVirtualQty, nil)
 
 	if len(stateA.TradeHistory) != 1 || len(stateB.TradeHistory) != 1 {
 		t.Fatalf("expected 1 trade per peer, got %d / %d",
 			len(stateA.TradeHistory), len(stateB.TradeHistory))
 	}
 	tA, tB := stateA.TradeHistory[0], stateB.TradeHistory[0]
+	if math.Abs(tA.Quantity-1.5) > 1e-9 || math.Abs(tB.Quantity-0.5) > 1e-9 {
+		t.Errorf("peer fill quantities = %.6f / %.6f; want 1.500000 / 0.500000", tA.Quantity, tB.Quantity)
+	}
 	if math.Abs((tA.Quantity+tB.Quantity)-totalSz) > 1e-9 {
 		t.Errorf("peer fill quantities sum to %.6f; want %.6f", tA.Quantity+tB.Quantity, totalSz)
 	}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -788,6 +788,7 @@ func main() {
 			// the next cycle re-enters this branch (CheckPortfolioRisk
 			// early-returns false while KillSwitchActive is true) and retries.
 			var plan KillSwitchClosePlan
+			var hlVirtualQty hlVirtualQuantitySnapshot
 			if killSwitchFired {
 				// Snapshot per-coin StopLossOIDs so the kill-switch close
 				// path can cancel resting SLs before flattening, freeing
@@ -808,6 +809,7 @@ func main() {
 						}
 					}
 				}
+				hlVirtualQty = snapshotHyperliquidVirtualQuantities(state.Strategies, hlLiveAll)
 				mu.RUnlock()
 
 				inputs := KillSwitchCloseInputs{
@@ -849,7 +851,7 @@ func main() {
 				mu.Lock()
 				for _, sc := range cfg.Strategies {
 					if s, ok := state.Strategies[sc.ID]; ok {
-						forceCloseKillSwitchPositions(s, sc, prices, plan.CloseReport.Fills, hlLiveAll, nil)
+						forceCloseKillSwitchPositions(s, sc, prices, plan.CloseReport.Fills, hlLiveAll, hlVirtualQty, nil)
 						// Pending HL circuit close was already cleared above
 						// when portfolio kill fired (line ~611); nothing to do
 						// here. The per-strategy pending field is owned by the

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1065,13 +1065,15 @@ func rolloverDailyPnL(r *RiskState) {
 // forceCloseKillSwitchPositions clears virtual positions after a confirmed
 // portfolio kill-switch close. `hlFills` carries the realized Hyperliquid
 // close fills (price/size/fee) so HL strategies record accurate Trade and
-// ClosedPosition rows; pass nil for non-HL or when no fill data is available.
-func forceCloseKillSwitchPositions(s *StrategyState, sc StrategyConfig, prices map[string]float64, hlFills map[string]HyperliquidCloseFill, hlLiveAll []StrategyConfig, logger *StrategyLogger) {
+// ClosedPosition rows; `hlVirtualQty` is the pre-close peer snapshot used to
+// split shared-coin fills by virtual quantity. Pass nil for non-HL or when no
+// fill data is available.
+func forceCloseKillSwitchPositions(s *StrategyState, sc StrategyConfig, prices map[string]float64, hlFills map[string]HyperliquidCloseFill, hlLiveAll []StrategyConfig, hlVirtualQty hlVirtualQuantitySnapshot, logger *StrategyLogger) {
 	// Live HL portfolio-kill closes can carry real exchange fills. Apply them
 	// first so Trade and ClosedPosition rows use realized fill price/fee; the
 	// generic pass below remains the cleanup path for non-HL strategies,
 	// missing-fill fallbacks, options, and any residual virtual positions.
-	applyHyperliquidKillSwitchCloseFill(s, sc, hlFills, hlLiveAll)
+	applyHyperliquidKillSwitchCloseFill(s, sc, hlFills, hlLiveAll, hlVirtualQty)
 	forceCloseAllPositions(s, prices, logger)
 }
 


### PR DESCRIPTION
## Summary
- Snapshot Hyperliquid virtual quantities before kill-switch flattening and use those quantities to split shared-coin fills.
- Thread the snapshot through the confirmed-flat close path so sequential state mutation does not distort peer ratios.
- Add regression coverage for shared-coin closes where configured capital percentages diverge from runtime position sizes.

## Testing
- Added and updated Go unit tests for the Hyperliquid kill-switch close path.
- Ran `go test ./...` in `scheduler` and the focused Hyperliquid kill-switch test subset.
- Verified formatting and diff hygiene with `gofmt` and `git diff --check`.

Closes #466