### PR TITLE
Add per-position trade IDs for lifetime stats

### DIFF
--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -63,6 +63,7 @@ CREATE TABLE IF NOT EXISTS strategies (
 CREATE TABLE IF NOT EXISTS positions (
     strategy_id TEXT NOT NULL REFERENCES strategies(id) ON DELETE CASCADE,
     symbol TEXT NOT NULL,
+    position_id TEXT NOT NULL DEFAULT '',
     quantity REAL NOT NULL,
     avg_cost REAL NOT NULL,
     side TEXT NOT NULL,
@@ -120,6 +121,7 @@ CREATE INDEX IF NOT EXISTS idx_closed_opt_closed_at ON closed_option_positions(c
 CREATE TABLE IF NOT EXISTS option_positions (
     strategy_id TEXT NOT NULL REFERENCES strategies(id) ON DELETE CASCADE,
     id TEXT NOT NULL,
+    position_id TEXT NOT NULL DEFAULT '',
     underlying TEXT NOT NULL,
     option_type TEXT NOT NULL,
     strike REAL NOT NULL,
@@ -143,6 +145,7 @@ CREATE TABLE IF NOT EXISTS trades (
     strategy_id TEXT NOT NULL,
     timestamp TEXT NOT NULL,
     symbol TEXT NOT NULL,
+    position_id TEXT NOT NULL DEFAULT '',
     side TEXT NOT NULL,
     quantity REAL NOT NULL,
     price REAL NOT NULL,
@@ -158,8 +161,9 @@ CREATE TABLE IF NOT EXISTS trades (
 CREATE INDEX IF NOT EXISTS idx_trades_strategy ON trades(strategy_id);
 CREATE INDEX IF NOT EXISTS idx_trades_symbol ON trades(symbol);
 CREATE INDEX IF NOT EXISTS idx_trades_timestamp ON trades(timestamp DESC);
--- idx_trades_close (#455) is created in migrateSchema, not here, so legacy
--- DBs add the is_close column before the index references it.
+-- idx_trades_close (#455) and idx_trades_strategy_position (#471) are created
+-- in migrateSchema, not here, so legacy DBs add columns before indexes
+-- reference them.
 
 CREATE TABLE IF NOT EXISTS portfolio_risk (
     id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -251,6 +255,11 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE trades ADD COLUMN is_close INTEGER NOT NULL DEFAULT 0",
 		"ALTER TABLE trades ADD COLUMN realized_pnl REAL NOT NULL DEFAULT 0",
 		"CREATE INDEX IF NOT EXISTS idx_trades_close ON trades(strategy_id, is_close)",
+		// Per-position trade grouping (#471).
+		"ALTER TABLE trades ADD COLUMN position_id TEXT NOT NULL DEFAULT ''",
+		"ALTER TABLE positions ADD COLUMN position_id TEXT NOT NULL DEFAULT ''",
+		"ALTER TABLE option_positions ADD COLUMN position_id TEXT NOT NULL DEFAULT ''",
+		"CREATE INDEX IF NOT EXISTS idx_trades_strategy_position ON trades(strategy_id, position_id)",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -448,9 +457,9 @@ func (sdb *StateDB) InsertTrade(strategyID string, trade Trade) error {
 		isClose = 1
 	}
 	_, err := sdb.db.Exec(`INSERT INTO trades
-		(strategy_id, timestamp, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		strategyID, formatTime(trade.Timestamp), trade.Symbol, trade.Side,
+			(strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		strategyID, formatTime(trade.Timestamp), trade.Symbol, trade.PositionID, trade.Side,
 		trade.Quantity, trade.Price, trade.Value, trade.TradeType, trade.Details,
 		trade.ExchangeOrderID, trade.ExchangeFee, isClose, trade.RealizedPnL)
 	if err != nil {
@@ -588,17 +597,17 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	}
 	defer stmtStrat.Close()
 
-	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, quantity, avg_cost, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, avg_cost, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare position insert: %w", err)
 	}
 	defer stmtPos.Close()
 
-	stmtOpt, err := tx.Prepare(`INSERT INTO option_positions (strategy_id, id, underlying, option_type, strike, expiry, dte,
+	stmtOpt, err := tx.Prepare(`INSERT INTO option_positions (strategy_id, id, position_id, underlying, option_type, strike, expiry, dte,
 		action, quantity, entry_premium, entry_premium_usd, current_value_usd,
 		delta, gamma, theta, vega, opened_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare option_position insert: %w", err)
 	}
@@ -639,14 +648,16 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		}
 
 		for _, pos := range s.Positions {
-			if _, err := stmtPos.Exec(s.ID, pos.Symbol, pos.Quantity, pos.AvgCost, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx); err != nil {
+			positionID := ensurePositionTradeID(s.ID, pos.Symbol, pos)
+			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.AvgCost, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx); err != nil {
 				return fmt.Errorf("insert position %s/%s: %w", s.ID, pos.Symbol, err)
 			}
 		}
 
 		for key, opt := range s.OptionPositions {
+			positionID := ensureOptionTradeID(s.ID, opt)
 			if _, err := stmtOpt.Exec(
-				s.ID, key, opt.Underlying, opt.OptionType, opt.Strike, opt.Expiry, opt.DTE,
+				s.ID, key, positionID, opt.Underlying, opt.OptionType, opt.Strike, opt.Expiry, opt.DTE,
 				opt.Action, opt.Quantity, opt.EntryPremium, opt.EntryPremiumUSD, opt.CurrentValueUSD,
 				opt.Greeks.Delta, opt.Greeks.Gamma, opt.Greeks.Theta, opt.Greeks.Vega,
 				formatTime(opt.OpenedAt),
@@ -663,8 +674,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	//    failed, even if later-timestamped rows were persisted successfully
 	//    (fixes the MAX(timestamp) dedup gap that would silently drop
 	//    out-of-order retries).
-	stmtTrade, err := tx.Prepare(`INSERT INTO trades (strategy_id, timestamp, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtTrade, err := tx.Prepare(`INSERT INTO trades (strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare trade insert: %w", err)
 	}
@@ -688,7 +699,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 			if t.IsClose {
 				isClose = 1
 			}
-			if _, err := stmtTrade.Exec(s.ID, formatTime(t.Timestamp), t.Symbol, t.Side, t.Quantity, t.Price, t.Value, t.TradeType, t.Details, t.ExchangeOrderID, t.ExchangeFee, isClose, t.RealizedPnL); err != nil {
+			if _, err := stmtTrade.Exec(s.ID, formatTime(t.Timestamp), t.Symbol, t.PositionID, t.Side, t.Quantity, t.Price, t.Value, t.TradeType, t.Details, t.ExchangeOrderID, t.ExchangeFee, isClose, t.RealizedPnL); err != nil {
 				return fmt.Errorf("insert trade for %s: %w", s.ID, err)
 			}
 			flushed = append(flushed, trackedFlush{strat: s, index: i})
@@ -1040,7 +1051,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	}
 
 	// 3. Load positions for each strategy.
-	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, quantity, avg_cost, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px FROM positions")
+	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, avg_cost, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px FROM positions")
 	if err != nil {
 		return nil, fmt.Errorf("load positions: %w", err)
 	}
@@ -1049,7 +1060,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		var stratID string
 		var pos Position
 		var openedAtStr string
-		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.Quantity, &pos.AvgCost, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx); err != nil {
+		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.AvgCost, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx); err != nil {
 			return nil, fmt.Errorf("scan position: %w", err)
 		}
 		pos.OpenedAt = parseTime(openedAtStr)
@@ -1062,7 +1073,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	}
 
 	// 4. Load option positions for each strategy.
-	optRows, err := sdb.db.Query(`SELECT strategy_id, id, underlying, option_type, strike, expiry, dte,
+	optRows, err := sdb.db.Query(`SELECT strategy_id, id, COALESCE(position_id, '') AS position_id, underlying, option_type, strike, expiry, dte,
 		action, quantity, entry_premium, entry_premium_usd, current_value_usd,
 		delta, gamma, theta, vega, opened_at FROM option_positions`)
 	if err != nil {
@@ -1074,7 +1085,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		var opt OptionPosition
 		var openedAtStr string
 		if err := optRows.Scan(
-			&stratID, &opt.ID, &opt.Underlying, &opt.OptionType, &opt.Strike, &opt.Expiry, &opt.DTE,
+			&stratID, &opt.ID, &opt.TradePositionID, &opt.Underlying, &opt.OptionType, &opt.Strike, &opt.Expiry, &opt.DTE,
 			&opt.Action, &opt.Quantity, &opt.EntryPremium, &opt.EntryPremiumUSD, &opt.CurrentValueUSD,
 			&opt.Greeks.Delta, &opt.Greeks.Gamma, &opt.Greeks.Theta, &opt.Greeks.Vega,
 			&openedAtStr,
@@ -1092,7 +1103,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 
 	// 5. Load most recent 1000 trades per strategy (full history stays in SQLite).
 	for id, s := range state.Strategies {
-		tradeRows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl
+		tradeRows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl
 			FROM trades WHERE strategy_id = ? ORDER BY timestamp ASC`, id)
 		if err != nil {
 			return nil, fmt.Errorf("load trades for %s: %w", id, err)
@@ -1102,7 +1113,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 			var t Trade
 			var tsStr string
 			var isCloseInt int
-			if err := tradeRows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL); err != nil {
+			if err := tradeRows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL); err != nil {
 				tradeRows.Close()
 				return nil, fmt.Errorf("scan trade: %w", err)
 			}
@@ -1174,12 +1185,12 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 }
 
 // LifetimeTradeStats holds the per-strategy round-trip totals derived from
-// the trades table (#455). RoundTrips is the lifetime count of close legs
-// (1 trade = 1 round-trip per the issue spec); Wins and Losses partition
-// that count by strict realized PnL sign (PnL > 0 → win, PnL < 0 → loss).
-// Breakeven closes (PnL = 0) are excluded from both buckets so that the
-// on-chain "no virtual position" fallback (which records realized_pnl=0)
-// does not inflate W. Open positions without a recorded close do not count.
+// the trades table (#455/#471). RoundTrips is the lifetime count of distinct
+// trade position IDs among close rows; legacy rows without a position ID fall
+// back to one synthetic group per row to preserve historical per-leg counts.
+// Wins and Losses partition round trips by strict net realized PnL sign
+// (PnL > 0 → win, PnL < 0 → loss). Breakeven positions are excluded from both
+// buckets. Open positions without a recorded close do not count.
 type LifetimeTradeStats struct {
 	RoundTrips int
 	Wins       int
@@ -1198,11 +1209,22 @@ func (sdb *StateDB) LifetimeTradeStatsAll() (map[string]LifetimeTradeStats, erro
 	}
 	rows, err := sdb.db.Query(`SELECT
 			strategy_id,
-			COUNT(*),
-			SUM(CASE WHEN realized_pnl > 0 THEN 1 ELSE 0 END),
-			SUM(CASE WHEN realized_pnl < 0 THEN 1 ELSE 0 END)
-		FROM trades
-		WHERE is_close = 1
+			COUNT(*) AS round_trips,
+			SUM(CASE WHEN net_pnl > 0 THEN 1 ELSE 0 END) AS wins,
+			SUM(CASE WHEN net_pnl < 0 THEN 1 ELSE 0 END) AS losses
+		FROM (
+			SELECT
+				strategy_id,
+				CASE
+					WHEN position_id IS NULL OR position_id = ''
+					THEN 'legacy:' || rowid
+					ELSE position_id
+				END AS pkey,
+				SUM(realized_pnl) AS net_pnl
+			FROM trades
+			WHERE is_close = 1
+			GROUP BY strategy_id, pkey
+		)
 		GROUP BY strategy_id`)
 	if err != nil {
 		return nil, fmt.Errorf("query lifetime trade stats: %w", err)
@@ -1267,7 +1289,7 @@ func (sdb *StateDB) QueryTradeHistory(strategyID, symbol string, since, until ti
 		limit = 500
 	}
 
-	query := fmt.Sprintf("SELECT timestamp, strategy_id, symbol, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl FROM trades %s ORDER BY timestamp DESC LIMIT ? OFFSET ?", whereClause)
+	query := fmt.Sprintf("SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl FROM trades %s ORDER BY timestamp DESC LIMIT ? OFFSET ?", whereClause)
 	queryArgs := append(args, limit, offset)
 	rows, err := sdb.db.Query(query, queryArgs...)
 	if err != nil {
@@ -1280,7 +1302,7 @@ func (sdb *StateDB) QueryTradeHistory(strategyID, symbol string, since, until ti
 		var t Trade
 		var tsStr string
 		var isCloseInt int
-		if err := rows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL); err != nil {
+		if err := rows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL); err != nil {
 			return nil, 0, fmt.Errorf("scan trade: %w", err)
 		}
 		t.Timestamp = parseTime(tsStr)

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -14,6 +15,30 @@ import (
 func openTestDB(t *testing.T) *StateDB {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "state.db")
+	db, err := OpenStateDB(path)
+	if err != nil {
+		t.Fatalf("OpenStateDB: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	resetInitialCapitalGuardDedup(t)
+	return db
+}
+
+func openNullablePositionIDDB(t *testing.T) *StateDB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "state.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	nullableDDL := strings.ReplaceAll(schemaDDL, "position_id TEXT NOT NULL DEFAULT ''", "position_id TEXT")
+	if _, err := raw.Exec(nullableDDL); err != nil {
+		raw.Close()
+		t.Fatalf("create nullable-position-id schema: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close raw db: %v", err)
+	}
 	db, err := OpenStateDB(path)
 	if err != nil {
 		t.Fatalf("OpenStateDB: %v", err)
@@ -802,6 +827,150 @@ func TestQueryTradeHistory_ExchangeFields(t *testing.T) {
 	}
 	if trades[0].ExchangeFee != 2.50 {
 		t.Errorf("ExchangeFee = %g, want 2.50", trades[0].ExchangeFee)
+	}
+}
+
+func TestSaveLoadState_PositionIDsRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+	now := time.Now().UTC().Truncate(time.Nanosecond)
+	state := &AppState{
+		CycleCount: 1,
+		Strategies: map[string]*StrategyState{
+			"s1": {
+				ID: "s1", Type: "options", Platform: "deribit",
+				Cash: 1000, InitialCapital: 1000,
+				Positions: map[string]*Position{
+					"BTC": {Symbol: "BTC", TradePositionID: "spot-position-1", Quantity: 0.1, AvgCost: 50000, Side: "long", OpenedAt: now},
+				},
+				OptionPositions: map[string]*OptionPosition{
+					"BTC-call-buy-65000-2026-12-31": {
+						ID: "BTC-call-buy-65000-2026-12-31", TradePositionID: "option-position-1",
+						Underlying: "BTC", OptionType: "call", Strike: 65000, Expiry: "2026-12-31",
+						DTE: 30, Action: "buy", Quantity: 1, EntryPremiumUSD: 300, CurrentValueUSD: 350,
+						OpenedAt: now,
+					},
+				},
+				TradeHistory: []Trade{},
+			},
+		},
+	}
+	if err := db.SaveState(state); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got := loaded.Strategies["s1"].Positions["BTC"].TradePositionID; got != "spot-position-1" {
+		t.Errorf("position TradePositionID = %q, want spot-position-1", got)
+	}
+	if got := loaded.Strategies["s1"].OptionPositions["BTC-call-buy-65000-2026-12-31"].TradePositionID; got != "option-position-1" {
+		t.Errorf("option TradePositionID = %q, want option-position-1", got)
+	}
+}
+
+func TestSaveStateFlushWritesTradePositionID(t *testing.T) {
+	db := openTestDB(t)
+	now := time.Now().UTC().Truncate(time.Nanosecond)
+	state := &AppState{
+		CycleCount: 1,
+		Strategies: map[string]*StrategyState{
+			"s1": {
+				ID: "s1", Type: "spot", Platform: "binanceus",
+				Cash: 1000, InitialCapital: 1000,
+				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+				TradeHistory: []Trade{{
+					Timestamp: now, StrategyID: "s1", Symbol: "BTC", PositionID: "position-save-fallback",
+					Side: "sell", Quantity: 1, Price: 110, Value: 110, TradeType: "spot",
+					Details: "Close long, PnL: $10", IsClose: true, RealizedPnL: 10,
+				}},
+			},
+		},
+	}
+	if err := db.SaveState(state); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	var got string
+	if err := db.db.QueryRow("SELECT position_id FROM trades WHERE strategy_id = 's1'").Scan(&got); err != nil {
+		t.Fatalf("query position_id: %v", err)
+	}
+	if got != "position-save-fallback" {
+		t.Errorf("position_id = %q, want position-save-fallback", got)
+	}
+}
+
+func TestLoadState_TradePositionIDRoundTripAndLegacyNull(t *testing.T) {
+	db := openNullablePositionIDDB(t)
+	now := time.Now().UTC().Truncate(time.Nanosecond)
+	if _, err := db.db.Exec("INSERT INTO app_state (id, cycle_count) VALUES (1, 1)"); err != nil {
+		t.Fatalf("seed app_state: %v", err)
+	}
+	if _, err := db.db.Exec("INSERT INTO strategies (id, type, platform, cash, initial_capital) VALUES (?, ?, ?, ?, ?)", "s1", "perps", "hyperliquid", 1000.0, 1000.0); err != nil {
+		t.Fatalf("seed strategy: %v", err)
+	}
+	rows := []struct {
+		positionID any
+		ts         time.Time
+	}{
+		{"position-load-roundtrip", now},
+		{nil, now.Add(time.Second)},
+	}
+	for i, row := range rows {
+		if _, err := db.db.Exec(`INSERT INTO trades
+			(strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, is_close, realized_pnl)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			"s1", formatTime(row.ts), "BTC", row.positionID, "sell", 0.1, 50000.0, 5000.0, "perps", "Close long, PnL: $1", 1, float64(i+1),
+		); err != nil {
+			t.Fatalf("seed trade %d: %v", i, err)
+		}
+	}
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	trades := loaded.Strategies["s1"].TradeHistory
+	if len(trades) != 2 {
+		t.Fatalf("trade count = %d, want 2", len(trades))
+	}
+	if got := trades[0].PositionID; got != "position-load-roundtrip" {
+		t.Errorf("trade[0].PositionID = %q, want position-load-roundtrip", got)
+	}
+	if got := trades[1].PositionID; got != "" {
+		t.Errorf("legacy NULL PositionID = %q, want empty string", got)
+	}
+}
+
+func TestQueryTradeHistory_PositionIDRoundTripAndLegacyNull(t *testing.T) {
+	db := openNullablePositionIDDB(t)
+	now := time.Now().UTC().Truncate(time.Nanosecond)
+	rows := []struct {
+		positionID any
+		ts         time.Time
+	}{
+		{"position-query-roundtrip", now},
+		{nil, now.Add(time.Second)},
+	}
+	for i, row := range rows {
+		if _, err := db.db.Exec(`INSERT INTO trades
+			(strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, is_close, realized_pnl)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			"s1", formatTime(row.ts), "BTC", row.positionID, "sell", 0.1, 50000.0, 5000.0, "perps", "Close long, PnL: $1", 1, float64(i+1),
+		); err != nil {
+			t.Fatalf("seed trade %d: %v", i, err)
+		}
+	}
+	trades, total, err := db.QueryTradeHistory("s1", "", time.Time{}, time.Time{}, 50, 0)
+	if err != nil {
+		t.Fatalf("QueryTradeHistory: %v", err)
+	}
+	if total != 2 || len(trades) != 2 {
+		t.Fatalf("total=%d len=%d, want 2/2", total, len(trades))
+	}
+	if got := trades[0].PositionID; got != "" {
+		t.Errorf("newest legacy NULL PositionID = %q, want empty string", got)
+	}
+	if got := trades[1].PositionID; got != "position-query-roundtrip" {
+		t.Errorf("oldest PositionID = %q, want position-query-roundtrip", got)
 	}
 }
 
@@ -1997,6 +2166,182 @@ func TestLifetimeTradeStatsAll_FreshInsert(t *testing.T) {
 	}
 	if _, ok := stats["s3"]; ok {
 		t.Errorf("unexpected entry for s3 with no closes: %+v", stats["s3"])
+	}
+}
+
+func TestLifetimeTradeStatsAll_PartialClosesNetByPositionID(t *testing.T) {
+	sdb := openTestDB(t)
+	now := time.Now().UTC()
+	positionID := "s1-BTC-open-1"
+	trades := []Trade{
+		{StrategyID: "s1", Timestamp: now, Symbol: "BTC", PositionID: positionID, Side: "buy", Quantity: 0.5, Price: 50000, Value: 25000, TradeType: "perps", Details: "Open long"},
+		{StrategyID: "s1", Timestamp: now.Add(time.Second), Symbol: "BTC", PositionID: positionID, Side: "sell", Quantity: 0.25, Price: 50100, Value: 12525, TradeType: "perps", Details: "Close long, PnL: $10.00", IsClose: true, RealizedPnL: 10},
+		{StrategyID: "s1", Timestamp: now.Add(2 * time.Second), Symbol: "BTC", PositionID: positionID, Side: "sell", Quantity: 0.25, Price: 49900, Value: 12475, TradeType: "perps", Details: "Close long, PnL: $-3.00", IsClose: true, RealizedPnL: -3},
+	}
+	for _, tr := range trades {
+		if err := sdb.InsertTrade(tr.StrategyID, tr); err != nil {
+			t.Fatalf("InsertTrade: %v", err)
+		}
+	}
+
+	stats, err := sdb.LifetimeTradeStatsAll()
+	if err != nil {
+		t.Fatalf("LifetimeTradeStatsAll: %v", err)
+	}
+	if got := stats["s1"]; got.RoundTrips != 1 || got.Wins != 1 || got.Losses != 0 {
+		t.Errorf("stats = %+v, want RoundTrips=1 Wins=1 Losses=0", got)
+	}
+}
+
+func TestLifetimeTradeStatsAll_LegacyNullAndEmptyPositionIDStayPerLeg(t *testing.T) {
+	sdb := openNullablePositionIDDB(t)
+	now := time.Now().UTC()
+	rows := []struct {
+		positionID any
+		pnl        float64
+	}{
+		{nil, 10},
+		{"", -3},
+	}
+	for i, row := range rows {
+		if _, err := sdb.db.Exec(`INSERT INTO trades
+			(strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, is_close, realized_pnl)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			"s1", formatTime(now.Add(time.Duration(i)*time.Second)), "BTC", row.positionID, "sell", 0.25, 50000.0, 12500.0, "perps", "legacy close", 1, row.pnl,
+		); err != nil {
+			t.Fatalf("seed legacy trade %d: %v", i, err)
+		}
+	}
+
+	stats, err := sdb.LifetimeTradeStatsAll()
+	if err != nil {
+		t.Fatalf("LifetimeTradeStatsAll: %v", err)
+	}
+	if got := stats["s1"]; got.RoundTrips != 2 || got.Wins != 1 || got.Losses != 1 {
+		t.Errorf("legacy stats = %+v, want RoundTrips=2 Wins=1 Losses=1", got)
+	}
+}
+
+func TestLifetimeTradeStatsAll_PositionIDScopedByStrategy(t *testing.T) {
+	sdb := openTestDB(t)
+	now := time.Now().UTC()
+	for _, tr := range []Trade{
+		{StrategyID: "s1", Timestamp: now, Symbol: "BTC", PositionID: "shared-position", Side: "sell", Quantity: 1, Price: 101, Value: 101, TradeType: "spot", Details: "Close long, PnL: $1", IsClose: true, RealizedPnL: 1},
+		{StrategyID: "s2", Timestamp: now, Symbol: "BTC", PositionID: "shared-position", Side: "sell", Quantity: 1, Price: 99, Value: 99, TradeType: "spot", Details: "Close long, PnL: $-1", IsClose: true, RealizedPnL: -1},
+	} {
+		if err := sdb.InsertTrade(tr.StrategyID, tr); err != nil {
+			t.Fatalf("InsertTrade: %v", err)
+		}
+	}
+
+	stats, err := sdb.LifetimeTradeStatsAll()
+	if err != nil {
+		t.Fatalf("LifetimeTradeStatsAll: %v", err)
+	}
+	if got := stats["s1"]; got.RoundTrips != 1 || got.Wins != 1 || got.Losses != 0 {
+		t.Errorf("s1 stats = %+v, want RoundTrips=1 Wins=1 Losses=0", got)
+	}
+	if got := stats["s2"]; got.RoundTrips != 1 || got.Wins != 0 || got.Losses != 1 {
+		t.Errorf("s2 stats = %+v, want RoundTrips=1 Wins=0 Losses=1", got)
+	}
+}
+
+func TestLifetimeTradeStatsAll_BreakevenPositionNeitherWinNorLoss(t *testing.T) {
+	sdb := openTestDB(t)
+	now := time.Now().UTC()
+	for _, tr := range []Trade{
+		{StrategyID: "s1", Timestamp: now, Symbol: "BTC", PositionID: "p1", Side: "sell", Quantity: 0.25, Price: 50100, Value: 12525, TradeType: "perps", Details: "Close long, PnL: $10", IsClose: true, RealizedPnL: 10},
+		{StrategyID: "s1", Timestamp: now.Add(time.Second), Symbol: "BTC", PositionID: "p1", Side: "sell", Quantity: 0.25, Price: 49900, Value: 12475, TradeType: "perps", Details: "Close long, PnL: $-10", IsClose: true, RealizedPnL: -10},
+	} {
+		if err := sdb.InsertTrade(tr.StrategyID, tr); err != nil {
+			t.Fatalf("InsertTrade: %v", err)
+		}
+	}
+
+	stats, err := sdb.LifetimeTradeStatsAll()
+	if err != nil {
+		t.Fatalf("LifetimeTradeStatsAll: %v", err)
+	}
+	if got := stats["s1"]; got.RoundTrips != 1 || got.Wins != 0 || got.Losses != 0 {
+		t.Errorf("breakeven stats = %+v, want RoundTrips=1 Wins=0 Losses=0", got)
+	}
+}
+
+func TestLifetimeTradeStatsAll_OptionsSameContractReopenUsesDistinctPositionIDs(t *testing.T) {
+	sdb := openTestDB(t)
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("options")
+	defer logger.Close()
+
+	s := &StrategyState{
+		ID:              "options",
+		Type:            "options",
+		Platform:        "deribit",
+		Cash:            100000,
+		InitialCapital:  100000,
+		Positions:       map[string]*Position{},
+		OptionPositions: map[string]*OptionPosition{},
+		TradeHistory:    []Trade{},
+	}
+	openResult := &OptionsResult{
+		Signal:     1,
+		Underlying: "BTC",
+		SpotPrice:  60000,
+		Actions: []OptionsAction{{
+			Action:     "buy",
+			OptionType: "call",
+			Strike:     65000,
+			Expiry:     "2026-12-31",
+			DTE:        30,
+			PremiumUSD: 300,
+			Quantity:   1,
+		}},
+	}
+	closeResult := &OptionsResult{
+		Signal:     -1,
+		Underlying: "BTC",
+		SpotPrice:  60000,
+		Actions: []OptionsAction{{
+			Action:     "close",
+			OptionType: "call",
+			Strike:     65000,
+			PremiumUSD: 400,
+		}},
+	}
+	posKey := "BTC-call-buy-65000-2026-12-31"
+
+	if _, err := ExecuteOptionsSignal(s, openResult, logger); err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	firstID := s.OptionPositions[posKey].TradePositionID
+	s.OptionPositions[posKey].CurrentValueUSD = 400
+	if _, err := ExecuteOptionsSignal(s, closeResult, logger); err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+	if _, err := ExecuteOptionsSignal(s, openResult, logger); err != nil {
+		t.Fatalf("second open: %v", err)
+	}
+	secondID := s.OptionPositions[posKey].TradePositionID
+	if firstID == "" || secondID == "" {
+		t.Fatalf("option trade position IDs must be populated: first=%q second=%q", firstID, secondID)
+	}
+	if firstID == secondID {
+		t.Fatalf("reopened same option contract reused position_id %q", firstID)
+	}
+	s.OptionPositions[posKey].CurrentValueUSD = 350
+	if _, err := ExecuteOptionsSignal(s, closeResult, logger); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+
+	if err := sdb.SaveState(&AppState{Strategies: map[string]*StrategyState{s.ID: s}}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	stats, err := sdb.LifetimeTradeStatsAll()
+	if err != nil {
+		t.Fatalf("LifetimeTradeStatsAll: %v", err)
+	}
+	if got := stats[s.ID]; got.RoundTrips != 2 || got.Wins != 2 || got.Losses != 0 {
+		t.Errorf("option stats = %+v, want RoundTrips=2 Wins=2 Losses=0", got)
 	}
 }
 

--- a/scheduler/deribit.go
+++ b/scheduler/deribit.go
@@ -484,6 +484,7 @@ func applyAssignment(s *StrategyState, r markResult, logger *StrategyLogger) {
 
 	case "call":
 		// Sold call ITM (call-away): we must sell the underlying at strike.
+		now := time.Now().UTC()
 		proceeds := r.AssignStrike * r.AssignQuantity
 		s.Cash += proceeds
 		pnl := 0.0
@@ -493,7 +494,7 @@ func applyAssignment(s *StrategyState, r markResult, logger *StrategyLogger) {
 			pnl = (r.AssignStrike - existing.AvgCost) * r.AssignQuantity
 			newQty := existing.Quantity - r.AssignQuantity
 			if newQty <= 0 {
-				recordClosedPosition(s, existing, r.AssignStrike, pnl, "assignment", time.Now().UTC())
+				recordClosedPosition(s, existing, r.AssignStrike, pnl, "assignment", now)
 				delete(s.Positions, symbol)
 			} else {
 				existing.Quantity = newQty
@@ -501,7 +502,7 @@ func applyAssignment(s *StrategyState, r markResult, logger *StrategyLogger) {
 			RecordTradeResult(&s.RiskState, pnl)
 		}
 		RecordTrade(s, Trade{
-			Timestamp:  time.Now().UTC(),
+			Timestamp:  now,
 			StrategyID: s.ID,
 			Symbol:     symbol,
 			PositionID: positionID,

--- a/scheduler/deribit.go
+++ b/scheduler/deribit.go
@@ -447,24 +447,30 @@ func applyAssignment(s *StrategyState, r markResult, logger *StrategyLogger) {
 		// Sold put ITM: we are obligated to buy the underlying at strike.
 		cost := r.AssignStrike * r.AssignQuantity
 		s.Cash -= cost
+		now := time.Now().UTC()
+		var positionID string
 		if existing, ok := s.Positions[symbol]; ok && existing.Side == "long" {
 			// Weighted average cost with existing long position.
 			totalQty := existing.Quantity + r.AssignQuantity
 			existing.AvgCost = (existing.AvgCost*existing.Quantity + r.AssignStrike*r.AssignQuantity) / totalQty
 			existing.Quantity = totalQty
+			positionID = ensurePositionTradeID(s.ID, symbol, existing)
 		} else {
+			positionID = newTradePositionID(s.ID, symbol, now)
 			s.Positions[symbol] = &Position{
-				Symbol:   symbol,
-				Quantity: r.AssignQuantity,
-				AvgCost:  r.AssignStrike,
-				Side:     "long",
-				OpenedAt: time.Now().UTC(),
+				Symbol:          symbol,
+				TradePositionID: positionID,
+				Quantity:        r.AssignQuantity,
+				AvgCost:         r.AssignStrike,
+				Side:            "long",
+				OpenedAt:        now,
 			}
 		}
 		RecordTrade(s, Trade{
-			Timestamp:  time.Now().UTC(),
+			Timestamp:  now,
 			StrategyID: s.ID,
 			Symbol:     symbol,
+			PositionID: positionID,
 			Side:       "buy",
 			Quantity:   r.AssignQuantity,
 			Price:      r.AssignStrike,
@@ -481,7 +487,9 @@ func applyAssignment(s *StrategyState, r markResult, logger *StrategyLogger) {
 		proceeds := r.AssignStrike * r.AssignQuantity
 		s.Cash += proceeds
 		pnl := 0.0
+		var positionID string
 		if existing, ok := s.Positions[symbol]; ok && existing.Side == "long" {
+			positionID = ensurePositionTradeID(s.ID, symbol, existing)
 			pnl = (r.AssignStrike - existing.AvgCost) * r.AssignQuantity
 			newQty := existing.Quantity - r.AssignQuantity
 			if newQty <= 0 {
@@ -496,6 +504,7 @@ func applyAssignment(s *StrategyState, r markResult, logger *StrategyLogger) {
 			Timestamp:  time.Now().UTC(),
 			StrategyID: s.ID,
 			Symbol:     symbol,
+			PositionID: positionID,
 			Side:       "sell",
 			Quantity:   r.AssignQuantity,
 			Price:      r.AssignStrike,

--- a/scheduler/deribit_test.go
+++ b/scheduler/deribit_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestFormatInstrument(t *testing.T) {
@@ -251,6 +252,58 @@ func TestApplyAssignmentCall(t *testing.T) {
 	}
 	if pos.Quantity != 0.1 {
 		t.Errorf("Quantity = %g, want 0.1 (0.2 - 0.1)", pos.Quantity)
+	}
+}
+
+func TestApplyAssignmentCallFullCloseUsesSingleTimestamp(t *testing.T) {
+	openedAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	s := &StrategyState{
+		ID:   "test",
+		Cash: 5000,
+		Positions: map[string]*Position{
+			"BTC": {
+				Symbol:          "BTC",
+				TradePositionID: "btc-position-1",
+				Quantity:        0.1,
+				AvgCost:         45000,
+				Side:            "long",
+				OpenedAt:        openedAt,
+			},
+		},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	r := markResult{
+		Assigned:         true,
+		AssignUnderlying: "BTC",
+		AssignOptionType: "call",
+		AssignStrike:     55000,
+		AssignSpotPrice:  56000,
+		AssignQuantity:   0.1,
+	}
+
+	applyAssignment(s, r, logger)
+
+	if _, ok := s.Positions["BTC"]; ok {
+		t.Fatal("BTC position should be removed after full call-away")
+	}
+	if len(s.ClosedPositions) != 1 {
+		t.Fatalf("ClosedPositions len = %d, want 1", len(s.ClosedPositions))
+	}
+	if len(s.TradeHistory) != 1 {
+		t.Fatalf("TradeHistory len = %d, want 1", len(s.TradeHistory))
+	}
+	if !s.ClosedPositions[0].ClosedAt.Equal(s.TradeHistory[0].Timestamp) {
+		t.Fatalf("closed position timestamp %s != trade timestamp %s", s.ClosedPositions[0].ClosedAt, s.TradeHistory[0].Timestamp)
+	}
+	if got := s.TradeHistory[0].PositionID; got != "btc-position-1" {
+		t.Fatalf("trade PositionID = %q, want btc-position-1", got)
 	}
 }
 

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -1234,9 +1234,8 @@ func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, f
 			// No virtual position to derive PnL from. Still mark as a close
 			// leg so the lifetime round-trip count (#455) reflects that the
 			// exchange-side position was reduced, but leave RealizedPnL=0
-			// (no AvgCost basis available). Counts as a "win" by the
-			// pnl >= 0 partition — acceptable since this branch is a
-			// defensive fallback for already-flat virtual state.
+			// (no AvgCost basis available). With strict #471 W/L semantics,
+			// this breakeven close counts as neither win nor loss.
 			IsClose: true,
 		})
 		return
@@ -1256,11 +1255,13 @@ func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, f
 	}
 	pnl -= fillFee
 	s.Cash += pnl
+	positionID := ensurePositionTradeID(s.ID, symbol, pos)
 
 	RecordTrade(s, Trade{
 		Timestamp:   now,
 		StrategyID:  s.ID,
 		Symbol:      symbol,
+		PositionID:  positionID,
 		Side:        closeTradeSide(side),
 		Quantity:    qtyClosed,
 		Price:       fillPx,

--- a/scheduler/options.go
+++ b/scheduler/options.go
@@ -9,7 +9,7 @@ import (
 // OptionPosition represents a tracked options position.
 type OptionPosition struct {
 	ID              string    `json:"id"`
-	TradePositionID string    `json:"trade_position_id,omitempty"`
+	TradePositionID string    `json:"position_id,omitempty"`
 	Underlying      string    `json:"underlying"`
 	OptionType      string    `json:"option_type"` // "call" or "put"
 	Strike          float64   `json:"strike"`

--- a/scheduler/options.go
+++ b/scheduler/options.go
@@ -9,6 +9,7 @@ import (
 // OptionPosition represents a tracked options position.
 type OptionPosition struct {
 	ID              string    `json:"id"`
+	TradePositionID string    `json:"trade_position_id,omitempty"`
 	Underlying      string    `json:"underlying"`
 	OptionType      string    `json:"option_type"` // "call" or "put"
 	Strike          float64   `json:"strike"`
@@ -125,9 +126,12 @@ func executeOptionBuy(s *StrategyState, result *OptionsResult, action *OptionsAc
 	posID := fmt.Sprintf("%s-%s-%s-%.0f-%s",
 		result.Underlying, action.OptionType, action.Action, action.Strike, action.Expiry)
 
+	now := time.Now().UTC()
+	positionID := newTradePositionID(s.ID, posID, now)
 	s.Cash -= totalCost
 	s.OptionPositions[posID] = &OptionPosition{
 		ID:              posID,
+		TradePositionID: positionID,
 		Underlying:      result.Underlying,
 		OptionType:      action.OptionType,
 		Strike:          action.Strike,
@@ -139,13 +143,14 @@ func executeOptionBuy(s *StrategyState, result *OptionsResult, action *OptionsAc
 		EntryPremiumUSD: cost,
 		CurrentValueUSD: cost, // initial value = cost
 		Greeks:          action.Greeks,
-		OpenedAt:        time.Now().UTC(),
+		OpenedAt:        now,
 	}
 
 	trade := Trade{
-		Timestamp:  time.Now().UTC(),
+		Timestamp:  now,
 		StrategyID: s.ID,
 		Symbol:     fmt.Sprintf("%s-%s-%.0f-%s", result.Underlying, action.OptionType, action.Strike, action.Expiry),
+		PositionID: positionID,
 		Side:       "buy",
 		Quantity:   1.0,
 		Price:      cost,
@@ -188,9 +193,12 @@ func executeOptionSell(s *StrategyState, result *OptionsResult, action *OptionsA
 	posID := fmt.Sprintf("%s-%s-%s-%.0f-%s",
 		result.Underlying, action.OptionType, action.Action, action.Strike, action.Expiry)
 
+	now := time.Now().UTC()
+	positionID := newTradePositionID(s.ID, posID, now)
 	s.Cash += netPremium
 	s.OptionPositions[posID] = &OptionPosition{
 		ID:              posID,
+		TradePositionID: positionID,
 		Underlying:      result.Underlying,
 		OptionType:      action.OptionType,
 		Strike:          action.Strike,
@@ -202,13 +210,14 @@ func executeOptionSell(s *StrategyState, result *OptionsResult, action *OptionsA
 		EntryPremiumUSD: netPremium,  // net after fees
 		CurrentValueUSD: -netPremium, // liability
 		Greeks:          action.Greeks,
-		OpenedAt:        time.Now().UTC(),
+		OpenedAt:        now,
 	}
 
 	trade := Trade{
-		Timestamp:  time.Now().UTC(),
+		Timestamp:  now,
 		StrategyID: s.ID,
 		Symbol:     fmt.Sprintf("%s-%s-%.0f-%s", result.Underlying, action.OptionType, action.Strike, action.Expiry),
+		PositionID: positionID,
 		Side:       "sell",
 		Quantity:   1.0,
 		Price:      premium,
@@ -238,10 +247,12 @@ func executeOptionClose(s *StrategyState, result *OptionsResult, action *Options
 				closePriceUSD = action.PremiumUSD
 			}
 			now := time.Now().UTC()
+			positionID := ensureOptionTradeID(s.ID, pos)
 			trade := Trade{
 				Timestamp:   now,
 				StrategyID:  s.ID,
 				Symbol:      pos.ID,
+				PositionID:  positionID,
 				Side:        optionCloseTradeSide(pos.Action),
 				Quantity:    pos.Quantity,
 				Price:       action.PremiumUSD,
@@ -440,10 +451,12 @@ func CheckThetaHarvest(s *StrategyState, cfg *ThetaHarvestConfig, logger *Strate
 		s.Cash -= buybackCost
 
 		now := time.Now().UTC()
+		positionID := ensureOptionTradeID(s.ID, pos)
 		trade := Trade{
 			Timestamp:   now,
 			StrategyID:  s.ID,
 			Symbol:      pos.ID,
+			PositionID:  positionID,
 			Side:        optionCloseTradeSide(pos.Action),
 			Quantity:    pos.Quantity,
 			Price:       buybackCost,

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"fmt"
+	"sync/atomic"
 	"time"
 )
 
 // Position represents a spot, futures, or perps position.
 type Position struct {
 	Symbol            string    `json:"symbol"`
+	TradePositionID   string    `json:"trade_position_id,omitempty"`
 	Quantity          float64   `json:"quantity"`
 	AvgCost           float64   `json:"avg_cost"`
 	Side              string    `json:"side"`                           // "long" or "short"
@@ -132,11 +134,13 @@ func recordPerpsStopLossClose(s *StrategyState, symbol string, triggerPx float64
 	fee := CalculatePlatformSpotFee(feePlatform, qty*triggerPx)
 	pnl -= fee
 	s.Cash += pnl
+	positionID := ensurePositionTradeID(s.ID, symbol, pos)
 
 	trade := Trade{
 		Timestamp:   now,
 		StrategyID:  s.ID,
 		Symbol:      symbol,
+		PositionID:  positionID,
 		Side:        closeTradeSide(side),
 		Quantity:    qty,
 		Price:       triggerPx,
@@ -194,6 +198,7 @@ type Trade struct {
 	Value           float64   `json:"value"`
 	TradeType       string    `json:"trade_type"` // "spot", "options", or "futures"
 	Details         string    `json:"details"`
+	PositionID      string    `json:"position_id"`
 	ExchangeOrderID string    `json:"exchange_order_id,omitempty"` // exchange-provided order ID (e.g. Hyperliquid oid)
 	ExchangeFee     float64   `json:"exchange_fee,omitempty"`      // fee charged by exchange (if available)
 
@@ -213,6 +218,36 @@ type Trade struct {
 	// on the next flush rather than silently dropped because T1 < latestTS.
 	// Not serialized — purely in-memory bookkeeping.
 	persisted bool
+}
+
+var tradePositionNonce uint64
+
+func newTradePositionID(strategyID, symbol string, openedAt time.Time) string {
+	if openedAt.IsZero() {
+		openedAt = time.Now().UTC()
+	}
+	nonce := atomic.AddUint64(&tradePositionNonce, 1)
+	return fmt.Sprintf("%s:%s:%d:%d", strategyID, symbol, openedAt.UnixNano(), nonce)
+}
+
+func ensurePositionTradeID(strategyID, symbol string, pos *Position) string {
+	if pos == nil {
+		return ""
+	}
+	if pos.TradePositionID == "" {
+		pos.TradePositionID = newTradePositionID(strategyID, symbol, pos.OpenedAt)
+	}
+	return pos.TradePositionID
+}
+
+func ensureOptionTradeID(strategyID string, pos *OptionPosition) string {
+	if pos == nil {
+		return ""
+	}
+	if pos.TradePositionID == "" {
+		pos.TradePositionID = newTradePositionID(strategyID, pos.ID, pos.OpenedAt)
+	}
+	return pos.TradePositionID
 }
 
 // Defaulting to "sell" preserves legacy behavior for missing/unknown sides.
@@ -524,6 +559,7 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 			pnl -= fee
 			s.Cash += pnl
 			now := time.Now().UTC()
+			positionID := ensurePositionTradeID(s.ID, symbol, pos)
 			var closeOID string
 			if useFillFee {
 				closeOID = fillOID
@@ -532,6 +568,7 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
+				PositionID:      positionID,
 				Side:            "buy",
 				Quantity:        pos.Quantity,
 				Price:           execPrice,
@@ -580,6 +617,7 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 		fee := executionFee(CalculatePlatformSpotFee(feePlatform, notional), fillFee, useFillFee)
 		s.Cash -= fee // margin-based: only fee leaves cash, notional stays virtual
 		now := time.Now().UTC()
+		positionID := newTradePositionID(s.ID, symbol, now)
 		var openOID string
 		if useFillFee {
 			openOID = fillOID
@@ -593,11 +631,13 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 			Leverage:        leverage,
 			OwnerStrategyID: s.ID,
 			OpenedAt:        now,
+			TradePositionID: positionID,
 		}
 		trade := Trade{
 			Timestamp:       now,
 			StrategyID:      s.ID,
 			Symbol:          symbol,
+			PositionID:      positionID,
 			Side:            "buy",
 			Quantity:        qty,
 			Price:           execPrice,
@@ -636,6 +676,7 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 			pnl -= fee
 			s.Cash += pnl
 			now := time.Now().UTC()
+			positionID := ensurePositionTradeID(s.ID, symbol, pos)
 			var closeOID string
 			if useFillFee {
 				closeOID = fillOID
@@ -644,6 +685,7 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
+				PositionID:      positionID,
 				Side:            "sell",
 				Quantity:        pos.Quantity,
 				Price:           execPrice,
@@ -697,6 +739,7 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 		fee := executionFee(CalculatePlatformSpotFee(feePlatform, notional), fillFee, useFillFee)
 		s.Cash -= fee // margin-based: only fee leaves cash
 		now := time.Now().UTC()
+		positionID := newTradePositionID(s.ID, symbol, now)
 		var openOID string
 		if useFillFee {
 			openOID = fillOID
@@ -710,11 +753,13 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 			Leverage:        leverage,
 			OwnerStrategyID: s.ID,
 			OpenedAt:        now,
+			TradePositionID: positionID,
 		}
 		trade := Trade{
 			Timestamp:       now,
 			StrategyID:      s.ID,
 			Symbol:          symbol,
+			PositionID:      positionID,
 			Side:            "sell",
 			Quantity:        qty,
 			Price:           execPrice,
@@ -773,10 +818,12 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			pnl := pos.Quantity*pos.AvgCost - totalCost
 			s.Cash += pos.Quantity*pos.AvgCost - totalCost
 			now := time.Now().UTC()
+			positionID := ensurePositionTradeID(s.ID, symbol, pos)
 			trade := Trade{
 				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
+				PositionID:      positionID,
 				Side:            "buy",
 				Quantity:        pos.Quantity,
 				Price:           execPrice,
@@ -820,8 +867,10 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 		}
 		s.Cash -= tradeCost + fee
 		now := time.Now().UTC()
+		positionID := newTradePositionID(s.ID, symbol, now)
 		s.Positions[symbol] = &Position{
 			Symbol:          symbol,
+			TradePositionID: positionID,
 			Quantity:        qty,
 			AvgCost:         execPrice,
 			Side:            "long",
@@ -832,6 +881,7 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			Timestamp:       now,
 			StrategyID:      s.ID,
 			Symbol:          symbol,
+			PositionID:      positionID,
 			Side:            "buy",
 			Quantity:        qty,
 			Price:           execPrice,
@@ -864,10 +914,12 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			pnl := netProceeds - (pos.Quantity * pos.AvgCost)
 			s.Cash += netProceeds
 			now := time.Now().UTC()
+			positionID := ensurePositionTradeID(s.ID, symbol, pos)
 			trade := Trade{
 				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
+				PositionID:      positionID,
 				Side:            "sell",
 				Quantity:        pos.Quantity,
 				Price:           execPrice,
@@ -930,10 +982,12 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			pnl -= fee
 			s.Cash += pnl
 			now := time.Now().UTC()
+			positionID := ensurePositionTradeID(s.ID, symbol, pos)
 			trade := Trade{
 				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
+				PositionID:      positionID,
 				Side:            "buy",
 				Quantity:        pos.Quantity,
 				Price:           execPrice,
@@ -988,8 +1042,10 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 		}
 		s.Cash -= fee // futures use margin, not full notional; deduct fee only
 		now := time.Now().UTC()
+		positionID := newTradePositionID(s.ID, symbol, now)
 		s.Positions[symbol] = &Position{
 			Symbol:          symbol,
+			TradePositionID: positionID,
 			Quantity:        float64(contracts),
 			AvgCost:         execPrice,
 			Side:            "long",
@@ -1001,6 +1057,7 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			Timestamp:       now,
 			StrategyID:      s.ID,
 			Symbol:          symbol,
+			PositionID:      positionID,
 			Side:            "buy",
 			Quantity:        float64(contracts),
 			Price:           execPrice,
@@ -1033,10 +1090,12 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			pnl -= fee
 			s.Cash += pnl
 			now := time.Now().UTC()
+			positionID := ensurePositionTradeID(s.ID, symbol, pos)
 			trade := Trade{
 				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
+				PositionID:      positionID,
 				Side:            "sell",
 				Quantity:        pos.Quantity,
 				Price:           execPrice,
@@ -1092,8 +1151,10 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			}
 			s.Cash -= fee
 			now := time.Now().UTC()
+			positionID := newTradePositionID(s.ID, symbol, now)
 			s.Positions[symbol] = &Position{
 				Symbol:          symbol,
+				TradePositionID: positionID,
 				Quantity:        float64(contracts),
 				AvgCost:         execPrice,
 				Side:            "short",
@@ -1105,6 +1166,7 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
+				PositionID:      positionID,
 				Side:            "sell",
 				Quantity:        float64(contracts),
 				Price:           execPrice,

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -9,7 +9,7 @@ import (
 // Position represents a spot, futures, or perps position.
 type Position struct {
 	Symbol            string    `json:"symbol"`
-	TradePositionID   string    `json:"trade_position_id,omitempty"`
+	TradePositionID   string    `json:"position_id,omitempty"`
 	Quantity          float64   `json:"quantity"`
 	AvgCost           float64   `json:"avg_cost"`
 	Side              string    `json:"side"`                           // "long" or "short"

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -1,9 +1,45 @@
 package main
 
 import (
+	"encoding/json"
 	"math"
 	"testing"
 )
+
+func TestPositionJSONUsesPositionID(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+	}{
+		{
+			name:  "position",
+			value: Position{Symbol: "BTC", TradePositionID: "spot-position-1"},
+		},
+		{
+			name:  "option_position",
+			value: OptionPosition{ID: "opt-1", TradePositionID: "option-position-1"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(tc.value)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(raw, &payload); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if _, ok := payload["position_id"]; !ok {
+				t.Fatalf("position_id missing from %s JSON: %s", tc.name, raw)
+			}
+			if _, ok := payload["trade_position_id"]; ok {
+				t.Fatalf("trade_position_id should not be emitted in %s JSON: %s", tc.name, raw)
+			}
+		})
+	}
+}
 
 func TestPortfolioValueCashOnly(t *testing.T) {
 	s := &StrategyState{

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1112,10 +1112,12 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 		if logger != nil {
 			logger.Warn("Circuit breaker: force-closing %s %s @ $%.2f (PnL: $%.2f)", pos.Side, symbol, price, pnl)
 		}
+		positionID := ensurePositionTradeID(s.ID, symbol, pos)
 		trade := Trade{
 			Timestamp:   now,
 			StrategyID:  s.ID,
 			Symbol:      symbol,
+			PositionID:  positionID,
 			Side:        closeTradeSide(pos.Side),
 			Quantity:    pos.Quantity,
 			Price:       price,
@@ -1146,10 +1148,12 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 		if logger != nil {
 			logger.Warn("Circuit breaker: force-closing %s %s @ $%.2f (PnL: $%.2f)", pos.Action, id, closePrice, pnl)
 		}
+		positionID := ensureOptionTradeID(s.ID, pos)
 		trade := Trade{
 			Timestamp:   now,
 			StrategyID:  s.ID,
 			Symbol:      id,
+			PositionID:  positionID,
 			Side:        optionCloseTradeSide(pos.Action),
 			Quantity:    pos.Quantity,
 			Price:       closePrice,

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -41,6 +41,13 @@ func RecordTrade(s *StrategyState, trade Trade) {
 	if trade.StrategyID == "" {
 		trade.StrategyID = s.ID
 	}
+	if trade.PositionID == "" {
+		if pos := s.Positions[trade.Symbol]; pos != nil {
+			trade.PositionID = ensurePositionTradeID(s.ID, trade.Symbol, pos)
+		} else if opt := s.OptionPositions[trade.Symbol]; opt != nil {
+			trade.PositionID = ensureOptionTradeID(s.ID, opt)
+		}
+	}
 	s.TradeHistory = append(s.TradeHistory, trade)
 	if tradeRecorder == nil {
 		return


### PR DESCRIPTION
### Summary
- Add `position_id` persistence across `trades`, `positions`, and `option_positions`.
- Thread stable per-position IDs through open, close, assignment, stop-loss, and circuit-breaker trade paths.
- Rewrite lifetime trade stats to aggregate by position and preserve legacy NULL/empty rows.
- Extend load/query paths and add regression coverage for partial closes, legacy rows, and option reopen behavior.

### Testing
- `go test ./...` in `scheduler`
- Focused regression tests for lifetime stats, round-trip persistence, and trade history queries

Closes #471

LLM: GPT-5 | extra high