### PR TITLE
Fix summary cadence wall-clock throttling

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -107,13 +107,13 @@ type Config struct {
 	Correlation          *CorrelationConfig         `json:"correlation,omitempty"`
 	Platforms            map[string]*PlatformConfig `json:"platforms,omitempty"`
 	LeaderboardSummaries []LeaderboardSummaryConfig `json:"leaderboard_summaries,omitempty"` // #308 — configurable per-channel leaderboards
-	SummaryFrequency     map[string]string          `json:"summary_frequency,omitempty"`     // #30 — per-channel summary cadence; keys match Discord/Telegram channel keys (e.g. "spot", "options", "hyperliquid"). Values: Go duration ("30m", "2h"), alias ("hourly", "every"/"per_check"/"always"), or empty for legacy default (continuous: every cycle; spot: hourly)
+	SummaryFrequency     map[string]string          `json:"summary_frequency,omitempty"`     // #30 — per-channel summary cadence; keys match Discord/Telegram channel keys (e.g. "spot", "options", "hyperliquid"). Values: Go duration ("30m", "2h"), alias ("hourly", "every"/"per_check"/"always"), or empty for legacy default (continuous: every channel run; spot: hourly)
 	RiskFreeRate         *float64                   `json:"risk_free_rate,omitempty"`        // #397 — annualized risk-free rate used in Sharpe-ratio calculations (e.g. 0.02 for 2%). Nil/missing falls back to DefaultAnnualRiskFreeRate; an explicit 0 is respected so backtest comparisons can pin to a 0% benchmark.
 	TradingViewExport    TradingViewExportConfig    `json:"tradingview_export,omitempty"`    // #3 — optional symbol overrides for TradingView portfolio CSV exports
 }
 
 // ParseSummaryFrequency converts a summary_frequency value to a duration.
-// Returns -1 to mean "use legacy default", 0 to mean "every cycle", or a
+// Returns -1 to mean "use legacy default", 0 to mean "every channel run", or a
 // positive duration when caller should post every duration. An unrecognized
 // value returns a non-nil error.
 func ParseSummaryFrequency(s string) (time.Duration, error) {
@@ -139,32 +139,21 @@ func ParseSummaryFrequency(s string) (time.Duration, error) {
 	return d, nil
 }
 
-// ShouldPostSummary reports whether a channel summary should be posted on the
-// given cycle. hasTrades unconditionally forces a post (users want immediate
-// trade visibility). Otherwise the cadence is derived from freq:
-//   - freq empty → legacy default: continuous channels post every cycle;
-//     non-continuous channels post hourly.
-//   - freq "every"/"per_check"/"always" (or a duration shorter than the
-//     scheduler interval) → every cycle.
-//   - freq parseable as Go duration or alias → post every N cycles where
-//     N = max(1, duration/intervalSeconds).
+// ShouldPostSummary reports whether a channel summary should be posted at now.
+// hasTrades unconditionally forces a post (users want immediate trade
+// visibility). Otherwise the cadence is derived from freq:
+//   - freq empty or invalid → legacy default: continuous channels post every
+//     channel run; non-continuous channels post hourly.
+//   - freq "every"/"per_check"/"always" → every channel run.
+//   - freq parseable as Go duration or alias → post when that wall-clock
+//     duration has elapsed since lastPost.
 //
 // continuous is true for channel types (options/perps/futures) that legacy
-// posted every cycle.
-func ShouldPostSummary(freq string, cycle, intervalSeconds int, continuous, hasTrades bool) bool {
+// posted every channel run.
+func ShouldPostSummary(freq string, continuous, hasTrades bool, lastPost, now time.Time) bool {
 	if hasTrades {
 		return true
 	}
-	cyclesBetween := summaryCyclesBetween(freq, intervalSeconds, continuous)
-	if cycle < 1 {
-		cycle = 1
-	}
-	return (cycle-1)%cyclesBetween == 0
-}
-
-// summaryCyclesBetween returns N such that a summary posts every N cycles.
-// Always >= 1.
-func summaryCyclesBetween(freq string, intervalSeconds int, continuous bool) int {
 	dur, err := ParseSummaryFrequency(freq)
 	if err != nil {
 		dur = -1
@@ -172,28 +161,16 @@ func summaryCyclesBetween(freq string, intervalSeconds int, continuous bool) int
 	switch {
 	case dur < 0: // legacy default
 		if continuous {
-			return 1
+			return true
 		}
-		if intervalSeconds > 0 {
-			n := 3600 / intervalSeconds
-			if n < 1 {
-				n = 1
-			}
-			return n
-		}
-		return 12
+		dur = time.Hour
 	case dur == 0:
-		return 1
-	default:
-		if intervalSeconds <= 0 {
-			return 1
-		}
-		n := int(dur.Seconds()) / intervalSeconds
-		if n < 1 {
-			n = 1
-		}
-		return n
+		return true
 	}
+	if lastPost.IsZero() {
+		return true
+	}
+	return now.Sub(lastPost) >= dur
 }
 
 // ThetaHarvestConfig controls early exit on sold options.

--- a/scheduler/config_reload_test.go
+++ b/scheduler/config_reload_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestApplyHotReloadConfigAppliesAllowedFields(t *testing.T) {
@@ -82,17 +83,21 @@ func TestApplyHotReloadConfigAppliesAllowedFields(t *testing.T) {
 		}},
 		PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 30, WarnThresholdPct: 70},
 	}
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"spot-btc": {
-			ID: "spot-btc", Cash: 900,
-			RiskState: RiskState{MaxDrawdownPct: 20},
+	summaryLast := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	state := &AppState{
+		LastSummaryPost: map[string]time.Time{"spot": summaryLast},
+		Strategies: map[string]*StrategyState{
+			"spot-btc": {
+				ID: "spot-btc", Cash: 900,
+				RiskState: RiskState{MaxDrawdownPct: 20},
+			},
+			"hl-eth": {
+				ID:        "hl-eth",
+				Cash:      450,
+				RiskState: RiskState{MaxDrawdownPct: 50},
+			},
 		},
-		"hl-eth": {
-			ID:        "hl-eth",
-			Cash:      450,
-			RiskState: RiskState{MaxDrawdownPct: 50},
-		},
-	}}
+	}
 	mock := &mockNotifier{}
 	tgMock := &mockNotifier{}
 	notifier := NewMultiNotifier(
@@ -137,6 +142,9 @@ func TestApplyHotReloadConfigAppliesAllowedFields(t *testing.T) {
 	}
 	if got := state.Strategies["spot-btc"].RiskState.MaxDrawdownPct; got != 15 {
 		t.Errorf("spot risk max drawdown = %g, want 15", got)
+	}
+	if got := state.LastSummaryPost["spot"]; !got.Equal(summaryLast) {
+		t.Errorf("summary last post changed during reload: got %v, want %v", got, summaryLast)
 	}
 	notifier.SendToChannel("binanceus", "spot", "hello")
 	if len(mock.messages) != 1 || mock.messages[0].channelID != "new-spot" {

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -33,7 +33,8 @@ CREATE TABLE IF NOT EXISTS app_state (
     cycle_count INTEGER NOT NULL DEFAULT 0,
     last_cycle TEXT NOT NULL DEFAULT '',
     last_leaderboard_post_date TEXT NOT NULL DEFAULT '',
-    last_leaderboard_summaries TEXT NOT NULL DEFAULT ''
+    last_leaderboard_summaries TEXT NOT NULL DEFAULT '',
+    last_summary_post TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS strategies (
@@ -242,6 +243,8 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE kill_switch_events ADD COLUMN source TEXT NOT NULL DEFAULT ''",
 		// Per-leaderboard-summary last-post timestamps stored as JSON (#308).
 		"ALTER TABLE app_state ADD COLUMN last_leaderboard_summaries TEXT NOT NULL DEFAULT ''",
+		// Per-channel regular summary last-post timestamps stored as JSON (#474).
+		"ALTER TABLE app_state ADD COLUMN last_summary_post TEXT NOT NULL DEFAULT ''",
 		// Per-trade HL stop-loss trigger OID (#412).
 		"ALTER TABLE positions ADD COLUMN stop_loss_oid INTEGER NOT NULL DEFAULT 0",
 		// Per-trade HL stop-loss trigger price for later-fill reconciliation (#421).
@@ -534,12 +537,21 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		}
 		lbSummariesJSON = string(raw)
 	}
-	if _, err := tx.Exec(`INSERT OR REPLACE INTO app_state (id, cycle_count, last_cycle, last_leaderboard_post_date, last_leaderboard_summaries)
-		VALUES (1, ?, ?, ?, ?)`,
+	summaryPostJSON := ""
+	if len(state.LastSummaryPost) > 0 {
+		raw, err := json.Marshal(state.LastSummaryPost)
+		if err != nil {
+			return fmt.Errorf("marshal last_summary_post: %w", err)
+		}
+		summaryPostJSON = string(raw)
+	}
+	if _, err := tx.Exec(`INSERT OR REPLACE INTO app_state (id, cycle_count, last_cycle, last_leaderboard_post_date, last_leaderboard_summaries, last_summary_post)
+		VALUES (1, ?, ?, ?, ?, ?)`,
 		state.CycleCount,
 		formatTime(state.LastCycle),
 		state.LastLeaderboardPostDate,
 		lbSummariesJSON,
+		summaryPostJSON,
 	); err != nil {
 		return fmt.Errorf("upsert app_state: %w", err)
 	}
@@ -977,9 +989,9 @@ func (sdb *StateDB) QueryClosedOptionPositions(strategyID, underlying string, si
 func (sdb *StateDB) LoadState() (*AppState, error) {
 	// 1. Load app_state singleton.
 	var cycleCount int
-	var lastCycleStr, lastLeaderboardDate, lastLBSummariesJSON string
-	err := sdb.db.QueryRow("SELECT cycle_count, last_cycle, last_leaderboard_post_date, last_leaderboard_summaries FROM app_state WHERE id = 1").
-		Scan(&cycleCount, &lastCycleStr, &lastLeaderboardDate, &lastLBSummariesJSON)
+	var lastCycleStr, lastLeaderboardDate, lastLBSummariesJSON, lastSummaryPostJSON string
+	err := sdb.db.QueryRow("SELECT cycle_count, last_cycle, last_leaderboard_post_date, last_leaderboard_summaries, last_summary_post FROM app_state WHERE id = 1").
+		Scan(&cycleCount, &lastCycleStr, &lastLeaderboardDate, &lastLBSummariesJSON, &lastSummaryPostJSON)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -993,12 +1005,19 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 			return nil, fmt.Errorf("parse last_leaderboard_summaries: %w", err)
 		}
 	}
+	summaryPosts := make(map[string]time.Time)
+	if lastSummaryPostJSON != "" {
+		if err := json.Unmarshal([]byte(lastSummaryPostJSON), &summaryPosts); err != nil {
+			return nil, fmt.Errorf("parse last_summary_post: %w", err)
+		}
+	}
 
 	state := &AppState{
 		CycleCount:               cycleCount,
 		LastCycle:                parseTime(lastCycleStr),
 		LastLeaderboardPostDate:  lastLeaderboardDate,
 		LastLeaderboardSummaries: lbSummaries,
+		LastSummaryPost:          summaryPosts,
 		Strategies:               make(map[string]*StrategyState),
 	}
 

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -926,6 +926,9 @@ func TestMigrateSchema_AddsExchangeColumns(t *testing.T) {
 	if loaded == nil {
 		t.Fatal("loaded state is nil")
 	}
+	if len(loaded.LastSummaryPost) != 0 {
+		t.Fatalf("migrated LastSummaryPost = %v, want empty", loaded.LastSummaryPost)
+	}
 	strat := loaded.Strategies["test"]
 	if strat == nil {
 		t.Fatal("missing strategy 'test'")
@@ -1358,6 +1361,44 @@ func TestSaveLoadState_LeaderboardSummaries(t *testing.T) {
 	}
 	for k, want := range state.LastLeaderboardSummaries {
 		got, ok := loaded.LastLeaderboardSummaries[k]
+		if !ok {
+			t.Errorf("key %q missing after reload", k)
+			continue
+		}
+		if !got.Equal(want) {
+			t.Errorf("key %q: got %v, want %v", k, got, want)
+		}
+	}
+}
+
+func TestSaveLoadState_LastSummaryPost(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.db")
+	sdb, err := OpenStateDB(path)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer sdb.Close()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	state := NewAppState()
+	state.LastSummaryPost = map[string]time.Time{
+		"spot":        now.Add(-5 * time.Minute),
+		"hyperliquid": now.Add(-30 * time.Minute),
+	}
+	if err := sdb.SaveState(state); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := sdb.LoadState()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(loaded.LastSummaryPost) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(loaded.LastSummaryPost))
+	}
+	for k, want := range state.LastSummaryPost {
+		got, ok := loaded.LastSummaryPost[k]
 		if !ok {
 			t.Errorf("key %q missing after reload", k)
 			continue

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -349,6 +349,9 @@ func main() {
 	// If you ever split writes across goroutines, add explicit locking —
 	// the existing `mu` lock guards `state`, not `lastRun`.
 	lastRun := make(map[string]time.Time)
+	// Same single-writer invariant as lastRun; copied into AppState only during
+	// the save phase so restart throttling survives without widening state locks.
+	lastSummaryPost := cloneTimeMap(state.LastSummaryPost)
 
 	// Determine tick interval from configured strategy intervals, min 60s.
 	tickSeconds := schedulerTickSeconds(cfg)
@@ -1373,6 +1376,7 @@ func main() {
 
 		// Notification — one message per channel per asset, sent to all backends.
 		if notifier.HasBackends() {
+			summaryNow := time.Now().UTC()
 			mu.RLock()
 			for chKey, chStrats := range channelStrats {
 				// Only post if at least one due strategy maps to this channel key.
@@ -1388,12 +1392,12 @@ func main() {
 				}
 				chTrades := channelTrades[chKey]
 				// Per-channel summary cadence (#30). Legacy default: continuous
-				// channel types (options/perps/futures) post every cycle; spot
+				// channel types (options/perps/futures) post every channel run; spot
 				// posts hourly. Override per channel via cfg.SummaryFrequency.
 				// Trades always force a post so operators see executions
 				// immediately regardless of cadence.
 				continuous := isOptionsType(chStrats) || isFuturesType(chStrats) || isPerpsType(chStrats)
-				if !ShouldPostSummary(cfg.SummaryFrequency[chKey], cycle, cfg.IntervalSeconds, continuous, chTrades > 0) {
+				if !ShouldPostSummary(cfg.SummaryFrequency[chKey], continuous, chTrades > 0, lastSummaryPost[chKey], summaryNow) {
 					continue
 				}
 				assetGroups, assetKeys := groupByAsset(chStrats)
@@ -1429,6 +1433,7 @@ func main() {
 						}
 					}
 				}
+				lastSummaryPost[chKey] = summaryNow
 			}
 			mu.RUnlock()
 		}
@@ -1436,6 +1441,7 @@ func main() {
 		// Save state after each cycle
 		mu.Lock()
 		state.LastCycle = time.Now().UTC()
+		state.LastSummaryPost = cloneTimeMap(lastSummaryPost)
 
 		// Periodic configurable leaderboard summaries (#308). Compute + update
 		// state.LastLeaderboardSummaries under Lock; post outside so Discord
@@ -2795,6 +2801,14 @@ func runLeaderboardSummariesAndExit(lcs []LeaderboardSummaryConfig, cfg *Config,
 	}
 	fmt.Printf("-summary=%s: posted %d leaderboard summaries, exiting.\n", lcs[0].Channel, posted)
 	os.Exit(0)
+}
+
+func cloneTimeMap(in map[string]time.Time) map[string]time.Time {
+	out := make(map[string]time.Time, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 // pendingLeaderboardSummary carries a computed summary from under-lock

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -84,6 +84,8 @@ type AppState struct {
 	// leaderboard_summaries entry, keyed by LeaderboardSummaryConfig.Key().
 	// Used by the scheduler to avoid reposting within the configured frequency. (#308)
 	LastLeaderboardSummaries map[string]time.Time `json:"last_leaderboard_summaries,omitempty"`
+	// LastSummaryPost tracks the last regular summary post per notification channel key.
+	LastSummaryPost map[string]time.Time `json:"last_summary_post,omitempty"`
 }
 
 // StrategyState is the per-strategy persistent state.

--- a/scheduler/summary_frequency_test.go
+++ b/scheduler/summary_frequency_test.go
@@ -47,93 +47,149 @@ func TestParseSummaryFrequency(t *testing.T) {
 }
 
 func TestShouldPostSummary_TradesForcePost(t *testing.T) {
-	// Trades always post, regardless of cadence setting or cycle position.
-	if !ShouldPostSummary("hourly", 5, 300, false, true) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	lastPost := now.Add(-10 * time.Second)
+
+	// Trades always post, regardless of cadence setting or elapsed time.
+	if !ShouldPostSummary("hourly", false, true, lastPost, now) {
 		t.Error("trades should force a post even mid-window")
 	}
-	if !ShouldPostSummary("daily", 2, 300, false, true) {
+	if !ShouldPostSummary("daily", false, true, lastPost, now) {
 		t.Error("trades should force a post even with daily cadence")
 	}
 }
 
-func TestShouldPostSummary_LegacyContinuousPostsEveryCycle(t *testing.T) {
-	// Empty freq + continuous (options/perps/futures) = every cycle.
-	for c := 1; c <= 5; c++ {
-		if !ShouldPostSummary("", c, 300, true, false) {
-			t.Errorf("continuous legacy default should post every cycle; cycle %d did not", c)
+func TestShouldPostSummary_TradeForcedPostResetsCadenceWindow(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	lastByChannel := map[string]time.Time{}
+	shouldPost := func(chKey string, at time.Time, hasTrades bool) bool {
+		if !ShouldPostSummary("5m", false, hasTrades, lastByChannel[chKey], at) {
+			return false
+		}
+		lastByChannel[chKey] = at
+		return true
+	}
+
+	if !shouldPost("spot", now, false) {
+		t.Fatal("first cadence check should post")
+	}
+	if shouldPost("spot", now.Add(10*time.Second), false) {
+		t.Fatal("non-trade post should be suppressed before the 5m cadence elapses")
+	}
+	if !shouldPost("spot", now.Add(10*time.Second), true) {
+		t.Fatal("trade should force a post before the cadence elapses")
+	}
+	if shouldPost("spot", now.Add(5*time.Minute), false) {
+		t.Fatal("trade-forced post should reset the cadence window")
+	}
+	if !shouldPost("spot", now.Add(5*time.Minute+10*time.Second), false) {
+		t.Fatal("cadence should elapse relative to the trade-forced post time")
+	}
+}
+
+func TestShouldPostSummary_LegacyContinuousPostsEveryRun(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	lastPost := now
+
+	// Empty freq + continuous (options/perps/futures) = every channel run.
+	for i := 0; i < 5; i++ {
+		if !ShouldPostSummary("", true, false, lastPost, now.Add(time.Duration(i)*time.Second)) {
+			t.Errorf("continuous legacy default should post every run; iteration %d did not", i)
 		}
 	}
 }
 
 func TestShouldPostSummary_LegacySpotPostsHourly(t *testing.T) {
-	// Empty freq + non-continuous + interval=300s (5m) → 12 cycles between posts.
-	// Cycles 1, 13, 25 post; 2..12 and 14..24 don't.
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
 	cases := []struct {
-		cycle int
-		want  bool
+		name     string
+		lastPost time.Time
+		now      time.Time
+		want     bool
 	}{
-		{1, true}, {2, false}, {6, false}, {12, false}, {13, true}, {24, false}, {25, true},
+		{"first post", time.Time{}, now, true},
+		{"before one hour", now, now.Add(time.Hour - time.Second), false},
+		{"at one hour", now, now.Add(time.Hour), true},
+		{"after one hour", now, now.Add(time.Hour + time.Second), true},
 	}
 	for _, tc := range cases {
-		got := ShouldPostSummary("", tc.cycle, 300, false, false)
-		if got != tc.want {
-			t.Errorf("spot legacy cycle %d: got %v, want %v", tc.cycle, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got := ShouldPostSummary("", false, false, tc.lastPost, tc.now)
+			if got != tc.want {
+				t.Errorf("legacy spot cadence: got %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 
 func TestShouldPostSummary_EveryAliasOverridesSpotDefault(t *testing.T) {
-	// User sets spot to "every" — should post every cycle.
-	for c := 1; c <= 10; c++ {
-		if !ShouldPostSummary("every", c, 300, false, false) {
-			t.Errorf(`freq="every" should post every cycle; cycle %d did not`, c)
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	lastPost := now
+
+	// User sets spot to "every" — should post every channel run.
+	for i := 0; i < 10; i++ {
+		if !ShouldPostSummary("every", false, false, lastPost, now.Add(time.Duration(i)*time.Second)) {
+			t.Errorf(`freq="every" should post every run; iteration %d did not`, i)
 		}
 	}
 }
 
-func TestShouldPostSummary_HourlyAliasThrottlesContinuous(t *testing.T) {
-	// User sets options (continuous) to "hourly" — should throttle to 1/hour.
-	// interval=300s → 12 cycles between posts.
-	if !ShouldPostSummary("hourly", 1, 300, true, false) {
-		t.Error("cycle 1 should post")
+func TestShouldPostSummary_HourlyAliasThrottlesContinuousByWallClock(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+
+	if !ShouldPostSummary("hourly", true, false, time.Time{}, now) {
+		t.Error("first run should post")
 	}
-	if ShouldPostSummary("hourly", 2, 300, true, false) {
-		t.Error("cycle 2 should be throttled")
+	if ShouldPostSummary("hourly", true, false, now, now.Add(time.Hour-time.Second)) {
+		t.Error("continuous channel should be throttled before one hour elapses")
 	}
-	if !ShouldPostSummary("hourly", 13, 300, true, false) {
-		t.Error("cycle 13 should post (12 cycles after cycle 1)")
+	if !ShouldPostSummary("hourly", true, false, now, now.Add(time.Hour)) {
+		t.Error("continuous channel should post once one hour elapses")
 	}
 }
 
-func TestShouldPostSummary_CustomDuration(t *testing.T) {
-	// 30m with 5m interval → every 6 cycles.
-	want := map[int]bool{1: true, 2: false, 6: false, 7: true, 12: false, 13: true}
-	for c, expect := range want {
-		got := ShouldPostSummary("30m", c, 300, false, false)
-		if got != expect {
-			t.Errorf("30m cadence cycle %d: got %v, want %v", c, got, expect)
+func TestShouldPostSummary_CustomDurationUsesWallClock(t *testing.T) {
+	start := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	lastPost := time.Time{}
+	check := func(at time.Time) bool {
+		if !ShouldPostSummary("30m", false, false, lastPost, at) {
+			return false
 		}
+		lastPost = at
+		return true
 	}
-}
 
-func TestShouldPostSummary_DurationShorterThanInterval(t *testing.T) {
-	// 1m cadence with 5m interval — clamp to every cycle.
-	for c := 1; c <= 5; c++ {
-		if !ShouldPostSummary("1m", c, 300, false, false) {
-			t.Errorf("sub-interval cadence should clamp to every cycle; cycle %d did not", c)
-		}
+	if !check(start) {
+		t.Fatal("first 30m cadence check should post")
+	}
+	if check(start.Add(30*time.Minute - time.Second)) {
+		t.Fatal("30m cadence should suppress before duration elapses")
+	}
+	if !check(start.Add(30 * time.Minute)) {
+		t.Fatal("30m cadence should post when duration elapses")
+	}
+	if check(start.Add(30 * time.Minute)) {
+		t.Fatal("30m cadence should suppress immediately after updating last post")
+	}
+	if !check(start.Add(60 * time.Minute)) {
+		t.Fatal("30m cadence should post again at 2x duration")
 	}
 }
 
 func TestShouldPostSummary_InvalidValueFallsBackToLegacy(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+
 	// Invalid freq should fall back to the legacy default rather than crashing.
-	// Continuous legacy = every cycle.
-	if !ShouldPostSummary("nonsense", 3, 300, true, false) {
-		t.Error("invalid freq + continuous should fall back to legacy every-cycle")
+	// Continuous legacy = every channel run.
+	if !ShouldPostSummary("nonsense", true, false, now, now.Add(time.Second)) {
+		t.Error("invalid freq + continuous should fall back to legacy every-run")
 	}
-	// Non-continuous legacy = hourly (12 cycles at 300s interval).
-	if ShouldPostSummary("nonsense", 2, 300, false, false) {
-		t.Error("invalid freq + spot should fall back to legacy hourly (cycle 2 suppressed)")
+	// Non-continuous legacy = hourly wall-clock cadence.
+	if ShouldPostSummary("nonsense", false, false, now, now.Add(time.Hour-time.Second)) {
+		t.Error("invalid freq + spot should fall back to legacy hourly cadence")
+	}
+	if !ShouldPostSummary("nonsense", false, false, now, now.Add(time.Hour)) {
+		t.Error("invalid freq + spot should post once the legacy hourly cadence elapses")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace cycle-count summary throttling with wall-clock per-channel timestamps so variable scheduler wakeups do not spam summaries.
- Persist `LastSummaryPost` in SQLite state so restarts and auto-updates keep cadence windows intact.
- Rewrite summary cadence tests for wall-clock behavior, trade-forced window resets, persistence, migration, and hot reload preservation.

## Test plan
- [x] `cd scheduler && /opt/homebrew/bin/gofmt -w config.go main.go state.go db.go summary_frequency_test.go db_test.go config_reload_test.go`
- [x] `cd scheduler && /opt/homebrew/bin/go test ./...`
- [x] `cd scheduler && /opt/homebrew/bin/go build .`

Closes #474

## Metadata
LLM: GPT-5.5 | planning effort: high | build effort: high

Made with [Cursor](https://cursor.com)