### PR TITLE
Remove RiskState trade counters

### DIFF
--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -55,10 +55,7 @@ CREATE TABLE IF NOT EXISTS strategies (
     -- risk_pending_circuit_closes_json. Keeping the legacy name in CREATE
     -- TABLE so fresh installs land on the same rename path as post-#356
     -- DBs — one code path, no schema fork (#359).
-    risk_pending_hl_close_json TEXT NOT NULL DEFAULT '',
-    risk_total_trades INTEGER NOT NULL DEFAULT 0,
-    risk_winning_trades INTEGER NOT NULL DEFAULT 0,
-    risk_losing_trades INTEGER NOT NULL DEFAULT 0
+    risk_pending_hl_close_json TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS positions (
@@ -601,9 +598,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	stmtStrat, err := tx.Prepare(`INSERT OR REPLACE INTO strategies (id, type, platform, cash, initial_capital,
 		risk_peak_value, risk_max_drawdown_pct, risk_current_drawdown_pct,
 		risk_daily_pnl, risk_daily_pnl_date, risk_consecutive_losses,
-		risk_circuit_breaker, risk_circuit_breaker_until, risk_pending_circuit_closes_json,
-		risk_total_trades, risk_winning_trades, risk_losing_trades)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		risk_circuit_breaker, risk_circuit_breaker_until, risk_pending_circuit_closes_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare strategy insert: %w", err)
 	}
@@ -654,7 +650,6 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 			s.RiskState.DailyPnL, s.RiskState.DailyPnLDate, s.RiskState.ConsecutiveLosses,
 			cbInt, formatTime(s.RiskState.CircuitBreakerUntil),
 			s.RiskState.MarshalPendingCircuitClosesJSON(),
-			s.RiskState.TotalTrades, s.RiskState.WinningTrades, s.RiskState.LosingTrades,
 		); err != nil {
 			return fmt.Errorf("insert strategy %s: %w", s.ID, err)
 		}
@@ -1036,8 +1031,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	rows, err := sdb.db.Query(`SELECT id, type, platform, cash, initial_capital,
 		risk_peak_value, risk_max_drawdown_pct, risk_current_drawdown_pct,
 		risk_daily_pnl, risk_daily_pnl_date, risk_consecutive_losses,
-		risk_circuit_breaker, risk_circuit_breaker_until, risk_pending_circuit_closes_json,
-		risk_total_trades, risk_winning_trades, risk_losing_trades
+		risk_circuit_breaker, risk_circuit_breaker_until, risk_pending_circuit_closes_json
 		FROM strategies`)
 	if err != nil {
 		return nil, fmt.Errorf("load strategies: %w", err)
@@ -1053,7 +1047,6 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 			&s.RiskState.PeakValue, &s.RiskState.MaxDrawdownPct, &s.RiskState.CurrentDrawdownPct,
 			&s.RiskState.DailyPnL, &s.RiskState.DailyPnLDate, &s.RiskState.ConsecutiveLosses,
 			&cbInt, &cbUntilStr, &pendingCircuitClosesJSON,
-			&s.RiskState.TotalTrades, &s.RiskState.WinningTrades, &s.RiskState.LosingTrades,
 		); err != nil {
 			return nil, fmt.Errorf("scan strategy: %w", err)
 		}

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -138,7 +138,6 @@ func makeTestState() *AppState {
 					PeakValue: 1050, MaxDrawdownPct: 10, CurrentDrawdownPct: 2.5,
 					DailyPnL: 50, DailyPnLDate: "2026-04-08",
 					ConsecutiveLosses: 0, CircuitBreaker: false,
-					TotalTrades: 15, WinningTrades: 10, LosingTrades: 5,
 				},
 			},
 			"spot-rsi-eth": {
@@ -252,7 +251,7 @@ func TestSaveAndLoadDBRoundTrip(t *testing.T) {
 	}
 
 	// Risk state round-trip.
-	if hlStrat.RiskState.TotalTrades != 15 || hlStrat.RiskState.WinningTrades != 10 {
+	if hlStrat.RiskState.DailyPnL != 50 || hlStrat.RiskState.CurrentDrawdownPct != 2.5 {
 		t.Errorf("risk state mismatch: %+v", hlStrat.RiskState)
 	}
 
@@ -1004,10 +1003,7 @@ func TestMigrateSchema_AddsExchangeColumns(t *testing.T) {
 	    risk_daily_pnl_date TEXT NOT NULL DEFAULT '',
 	    risk_consecutive_losses INTEGER NOT NULL DEFAULT 0,
 	    risk_circuit_breaker INTEGER NOT NULL DEFAULT 0,
-	    risk_circuit_breaker_until TEXT NOT NULL DEFAULT '',
-	    risk_total_trades INTEGER NOT NULL DEFAULT 0,
-	    risk_winning_trades INTEGER NOT NULL DEFAULT 0,
-	    risk_losing_trades INTEGER NOT NULL DEFAULT 0
+	    risk_circuit_breaker_until TEXT NOT NULL DEFAULT ''
 	);
 	CREATE TABLE IF NOT EXISTS positions (
 	    strategy_id TEXT NOT NULL REFERENCES strategies(id) ON DELETE CASCADE,
@@ -2017,8 +2013,7 @@ func TestMigrateSchema_PendingCircuitClosesColumn_FromLegacyDB(t *testing.T) {
 		risk_peak_value, risk_max_drawdown_pct, risk_current_drawdown_pct,
 		risk_daily_pnl, risk_daily_pnl_date, risk_consecutive_losses,
 		risk_circuit_breaker, risk_circuit_breaker_until,
-		risk_pending_circuit_closes_json AS risk_pending_hl_close_json,
-		risk_total_trades, risk_winning_trades, risk_losing_trades
+		risk_pending_circuit_closes_json AS risk_pending_hl_close_json
 		FROM strategies`)
 	if err != nil {
 		t.Fatalf("build legacy table: %v", err)
@@ -2387,8 +2382,8 @@ func TestLifetimeTradeStatsAll_OptionsSameContractReopenUsesDistinctPositionIDs(
 }
 
 // TestLifetimeTradeStats_SurvivesRiskStateReset is the core regression test
-// for #455: kill-switch / circuit-breaker resets of the in-memory RiskState
-// counters MUST NOT change the lifetime stats query. The query reads from
+// for #455: kill-switch / circuit-breaker resets of RiskState MUST NOT
+// change the lifetime stats query. The query reads from
 // trades, which is append-only, so simulating a counter reset leaves the DB
 // result intact.
 func TestLifetimeTradeStats_SurvivesRiskStateReset(t *testing.T) {

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -247,9 +247,8 @@ const catTableMaxRows = 15
 // channelStrategies is pre-filtered by the caller; channelKey is the display label.
 // asset, when non-empty, appends " — <ASSET>" to the title and filters the prices line.
 // globalIntervalSeconds is the config-level default interval used when a strategy has no per-strategy override.
-// lifetimeStats is keyed by strategy ID; missing keys fall back to the
-// in-memory RiskState counters (#455). When nil, all rows fall back —
-// preserves existing test call sites that pre-date this parameter.
+// lifetimeStats is keyed by strategy ID; missing keys render zero closed
+// round-trips because SQLite trades are authoritative (#472).
 func FormatCategorySummary(
 	cycle int,
 	elapsed time.Duration,
@@ -424,28 +423,14 @@ func FormatCategorySummary(
 		if effectiveInterval <= 0 {
 			effectiveInterval = globalIntervalSeconds
 		}
-		// Lifetime round-trip stats from the trades table (#455). Survives
-		// kill-switch and circuit-breaker resets; counts each open+close
-		// pair as a single trade. Falls back to the in-memory RiskState
-		// counters when the DB hasn't reported a stat for this strategy
-		// (e.g. tests that don't wire a DB, or first-run before any
-		// trade has been recorded).
-		closedT := ss.RiskState.TotalTrades
-		winT := ss.RiskState.WinningTrades
-		lossT := ss.RiskState.LosingTrades
-		if lifetimeStats != nil {
-			if lt, ok := lifetimeStats[sc.ID]; ok {
-				closedT = lt.RoundTrips
-				winT = lt.Wins
-				lossT = lt.Losses
-			} else if ss.RiskState.TotalTrades > 0 {
-				// DB was queried (non-nil map) but this strategy has no close
-				// trades recorded — RiskState counters may be stale (e.g. from
-				// a run before #455 landed). Log once per summary cycle so the
-				// discrepancy is visible without spamming the operator.
-				fmt.Fprintf(os.Stderr, "[discord] WARN: strategy %s has RiskState.TotalTrades=%d but no lifetime trades in DB; using in-memory fallback\n",
-					sc.ID, ss.RiskState.TotalTrades)
-			}
+		// Lifetime round-trip stats from the trades table (#455/#471). Survives
+		// kill-switch and circuit-breaker resets; counts grouped close legs as
+		// one position-level round trip. Missing DB rows render as zero.
+		closedT, winT, lossT := 0, 0, 0
+		if lt, ok := lifetimeStats[sc.ID]; ok {
+			closedT = lt.RoundTrips
+			winT = lt.Wins
+			lossT = lt.Losses
 		}
 		tableBots = append(tableBots, botInfo{
 			id:             sc.ID,

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -711,14 +711,19 @@ func TestFormatCategorySummary_ClosedTradesColumn(t *testing.T) {
 	}
 	state := &AppState{
 		Strategies: map[string]*StrategyState{
-			"hl-rsi-btc": {Cash: 1000, RiskState: RiskState{TotalTrades: 7}},
-			"hl-sma-btc": {Cash: 1000, RiskState: RiskState{TotalTrades: 12}},
-			"hl-mom-btc": {Cash: 1000, RiskState: RiskState{TotalTrades: 0}},
+			"hl-rsi-btc": {Cash: 1000},
+			"hl-sma-btc": {Cash: 1000},
+			"hl-mom-btc": {Cash: 1000},
 		},
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
+	lifetime := map[string]LifetimeTradeStats{
+		"hl-rsi-btc": {RoundTrips: 7},
+		"hl-sma-btc": {RoundTrips: 12},
+		"hl-mom-btc": {RoundTrips: 0},
+	}
 
-	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, lifetime)
 	msg := strings.Join(msgs, "\n")
 
 	// Header should include #T column.
@@ -732,9 +737,8 @@ func TestFormatCategorySummary_ClosedTradesColumn(t *testing.T) {
 		t.Errorf("expected #T column to follow Int column, got Int@%d #T@%d:\n%s", intIdx, tIdx, msg)
 	}
 
-	// Each strategy row should render its TotalTrades count right-justified in 5 chars,
-	// followed by the W/L column (issue #434). With no winning/losing trades recorded
-	// the W/L column renders as "—".
+	// Each strategy row should render its DB-sourced round-trip count
+	// right-justified in 5 chars, followed by W/L (issue #434).
 	if !strings.Contains(msg, "    7     —\n") {
 		t.Errorf("expected closed-trade count '7' for hl-rsi-btc, got:\n%s", msg)
 	}
@@ -767,13 +771,17 @@ func TestFormatCategorySummary_ClosedTradesColumn_SharedWallet(t *testing.T) {
 	}
 	state := &AppState{
 		Strategies: map[string]*StrategyState{
-			"hl-rmc-eth":  {Cash: 500, InitialCapital: 500, RiskState: RiskState{TotalTrades: 4}},
-			"hl-tema-eth": {Cash: 500, InitialCapital: 500, RiskState: RiskState{TotalTrades: 9}},
+			"hl-rmc-eth":  {Cash: 500, InitialCapital: 500},
+			"hl-tema-eth": {Cash: 500, InitialCapital: 500},
 		},
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
+	lifetime := map[string]LifetimeTradeStats{
+		"hl-rmc-eth":  {RoundTrips: 4},
+		"hl-tema-eth": {RoundTrips: 9},
+	}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, lifetime)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "#T") {
@@ -839,14 +847,19 @@ func TestFormatCategorySummary_WinLossColumn(t *testing.T) {
 	}
 	state := &AppState{
 		Strategies: map[string]*StrategyState{
-			"hl-rsi-btc": {Cash: 1000, RiskState: RiskState{TotalTrades: 10, WinningTrades: 7, LosingTrades: 3}},
-			"hl-sma-btc": {Cash: 1000, RiskState: RiskState{TotalTrades: 5, WinningTrades: 5, LosingTrades: 0}},
-			"hl-mom-btc": {Cash: 1000, RiskState: RiskState{TotalTrades: 0}},
+			"hl-rsi-btc": {Cash: 1000},
+			"hl-sma-btc": {Cash: 1000},
+			"hl-mom-btc": {Cash: 1000},
 		},
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
+	lifetime := map[string]LifetimeTradeStats{
+		"hl-rsi-btc": {RoundTrips: 10, Wins: 7, Losses: 3},
+		"hl-sma-btc": {RoundTrips: 5, Wins: 5, Losses: 0},
+		"hl-mom-btc": {RoundTrips: 0, Wins: 0, Losses: 0},
+	}
 
-	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, lifetime)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "W/L") {
@@ -1460,11 +1473,7 @@ func TestSplitCategorySummary_MultiMessage(t *testing.T) {
 }
 
 // TestFormatCategorySummary_LifetimeStatsOverride verifies that
-// FormatCategorySummary prefers the lifetime stats map over the in-memory
-// RiskState counters (#455). Simulates a strategy whose RiskState was
-// reset by a kill switch (showing 2 trades) but whose trades-table
-// lifetime stats show 17 round-trips — the table must render the lifetime
-// figure.
+// FormatCategorySummary renders lifetime stats from the trades table (#455).
 func TestFormatCategorySummary_LifetimeStatsOverride(t *testing.T) {
 	prices := map[string]float64{"ETH/USDT": 2000.0}
 	strats := []StrategyConfig{
@@ -1474,8 +1483,6 @@ func TestFormatCategorySummary_LifetimeStatsOverride(t *testing.T) {
 		Strategies: map[string]*StrategyState{
 			"hl-rmc-eth-live": {
 				Cash: 1000,
-				// Post-kill-switch reset: in-memory counters are stale.
-				RiskState: RiskState{TotalTrades: 2, WinningTrades: 1, LosingTrades: 1},
 			},
 		},
 	}
@@ -1487,22 +1494,19 @@ func TestFormatCategorySummary_LifetimeStatsOverride(t *testing.T) {
 		t.Fatal("expected at least one message")
 	}
 	msg := msgs[0]
-	// Lifetime #T should appear (17), not the stale RiskState count (2).
+	// Lifetime #T should appear (17).
 	if !strings.Contains(msg, " 17 ") {
 		t.Errorf("expected lifetime #T=17 in summary, got:\n%s", msg)
 	}
-	// W/L renders as wins/losses ratio (10/7 ≈ 1.43). The stale 1/1
-	// fallback would have rendered "1.00", so its absence confirms the
-	// override took effect.
+	// W/L renders as wins/losses ratio (10/7 ≈ 1.43).
 	if !strings.Contains(msg, "1.43") {
 		t.Errorf("expected lifetime W/L ratio (10/7=1.43) in summary, got:\n%s", msg)
 	}
 }
 
-// TestFormatCategorySummary_LifetimeStatsFallback verifies the legacy
-// fallback: when lifetimeStats is nil OR has no entry for a strategy, the
-// summary uses RiskState counters so existing test fixtures keep working.
-func TestFormatCategorySummary_LifetimeStatsFallback(t *testing.T) {
+// TestFormatCategorySummary_LifetimeStatsNoFallback verifies that missing DB
+// lifetime stats render as zero instead of using stale in-memory counters.
+func TestFormatCategorySummary_LifetimeStatsNoFallback(t *testing.T) {
 	prices := map[string]float64{"ETH/USDT": 2000.0}
 	strats := []StrategyConfig{
 		{ID: "hl-rmc-eth-live", Type: "perps", Platform: "hyperliquid", Args: []string{"rmc", "ETH/USDT", "1h"}},
@@ -1510,23 +1514,18 @@ func TestFormatCategorySummary_LifetimeStatsFallback(t *testing.T) {
 	state := &AppState{
 		Strategies: map[string]*StrategyState{
 			"hl-rmc-eth-live": {
-				Cash:      1000,
-				RiskState: RiskState{TotalTrades: 5, WinningTrades: 3, LosingTrades: 2},
+				Cash: 1000,
 			},
 		},
 	}
-	// Nil map → fallback.
+	// Nil map, such as a DB query failure, renders zero lifetime stats.
 	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil)
-	if !strings.Contains(msgs[0], " 5 ") {
-		t.Errorf("expected fallback #T=5 in summary, got:\n%s", msgs[0])
+	if !strings.Contains(msgs[0], " 0     —") {
+		t.Errorf("expected zero #T/W-L without lifetime stats, got:\n%s", msgs[0])
 	}
-	// W/L from RiskState wins=3 losses=2 → ratio 1.50.
-	if !strings.Contains(msgs[0], "1.50") {
-		t.Errorf("expected fallback W/L ratio (3/2=1.50) in summary, got:\n%s", msgs[0])
-	}
-	// Empty map (DB returned no rows for this strategy) → also fallback.
+	// Empty map (DB returned no rows for this strategy) also renders zero.
 	msgs2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, map[string]LifetimeTradeStats{})
-	if !strings.Contains(msgs2[0], " 5 ") {
-		t.Errorf("expected fallback #T=5 from empty map, got:\n%s", msgs2[0])
+	if !strings.Contains(msgs2[0], " 0     —") {
+		t.Errorf("expected zero #T/W-L from empty lifetime stats map, got:\n%s", msgs2[0])
 	}
 }

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -429,8 +429,8 @@ func TestReconcileHyperliquidPositions_RestingStopLossFillBooksPnL(t *testing.T)
 	if len(state.TradeHistory) != 1 || state.TradeHistory[0].Side != "sell" {
 		t.Errorf("expected one synthetic sell trade, got %+v", state.TradeHistory)
 	}
-	if state.RiskState.TotalTrades != 1 || state.RiskState.LosingTrades != 1 {
-		t.Errorf("risk stats not updated for SL fill: %+v", state.RiskState)
+	if state.RiskState.ConsecutiveLosses != 1 {
+		t.Errorf("consecutive losses not updated for SL fill: %+v", state.RiskState)
 	}
 }
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1362,9 +1362,9 @@ func main() {
 		rfr := RiskFreeRateOrDefault(cfg)
 
 		// Lifetime round-trip / W-L stats sourced from the trades table (#455).
-		// One DB round-trip per cycle; missing keys fall back to RiskState
-		// counters inside FormatCategorySummary. Errors are downgraded to a
-		// nil map so the summary still posts using the in-memory fallback.
+		// One DB round-trip per cycle; missing keys render as zero inside
+		// FormatCategorySummary. Errors are downgraded to a nil map so the
+		// summary still posts without in-memory lifetime counters (#472).
 		var lifetimeStats map[string]LifetimeTradeStats
 		if stateDB != nil {
 			if ls, err := stateDB.LifetimeTradeStatsAll(); err != nil {

--- a/scheduler/operator_required_close_test.go
+++ b/scheduler/operator_required_close_test.go
@@ -175,7 +175,7 @@ func TestCheckRisk_LiveOKXSpot_SetsOperatorRequiredPending(t *testing.T) {
 		ID: sc.ID, Type: "spot", Platform: "okx",
 		Cash: 0,
 		RiskState: RiskState{
-			PeakValue: 1000, MaxDrawdownPct: 10, TotalTrades: 1, DailyPnLDate: todayUTC(),
+			PeakValue: 1000, MaxDrawdownPct: 10, DailyPnLDate: todayUTC(),
 		},
 		Positions: map[string]*Position{
 			"BTC-USDT": {Symbol: "BTC-USDT", Quantity: 0.01, AvgCost: 80000, Side: "long"},

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -575,9 +575,6 @@ type RiskState struct {
 	ConsecutiveLosses   int       `json:"consecutive_losses"`
 	CircuitBreaker      bool      `json:"circuit_breaker"`
 	CircuitBreakerUntil time.Time `json:"circuit_breaker_until"`
-	TotalTrades         int       `json:"total_trades"`
-	WinningTrades       int       `json:"winning_trades"`
-	LosingTrades        int       `json:"losing_trades"`
 	// PendingCircuitCloses holds venue-appropriate reduce-only / flatten close
 	// requests queued by per-strategy circuit breakers, keyed by platform string.
 	// The key MUST match StrategyConfig.Platform ("hyperliquid", "okx",
@@ -1341,16 +1338,14 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 	return true, ""
 }
 
-// RecordTradeResult updates risk state with trade outcome.
+// RecordTradeResult updates risk state with realized PnL for daily limits and
+// consecutive-loss circuit breakers. Lifetime trade stats come from SQLite.
 func RecordTradeResult(r *RiskState, pnl float64) {
 	rolloverDailyPnL(r)
-	r.TotalTrades++
 	r.DailyPnL += pnl
 	if pnl >= 0 {
-		r.WinningTrades++
 		r.ConsecutiveLosses = 0
 	} else {
-		r.LosingTrades++
 		r.ConsecutiveLosses++
 	}
 }

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -80,9 +80,6 @@ func TestRecordTradeResult_MidnightCrossing(t *testing.T) {
 	if r.DailyPnLDate != todayUTC() {
 		t.Errorf("expected DailyPnLDate=%s; got %s", todayUTC(), r.DailyPnLDate)
 	}
-	if r.TotalTrades != 1 {
-		t.Errorf("expected TotalTrades=1; got %d", r.TotalTrades)
-	}
 }
 
 // TestRecordTradeResult_SameDayAccumulation verifies that multiple trades on the
@@ -95,9 +92,6 @@ func TestRecordTradeResult_SameDayAccumulation(t *testing.T) {
 
 	if r.DailyPnL != 120.0 {
 		t.Errorf("expected DailyPnL=120 after two trades; got %.2f", r.DailyPnL)
-	}
-	if r.TotalTrades != 2 {
-		t.Errorf("expected TotalTrades=2; got %d", r.TotalTrades)
 	}
 }
 
@@ -131,7 +125,6 @@ func TestCheckRisk_ForceCloseOnDrawdown(t *testing.T) {
 		RiskState: RiskState{
 			PeakValue:      10000.0,
 			MaxDrawdownPct: 20.0,
-			TotalTrades:    1,
 			DailyPnLDate:   todayUTC(),
 		},
 		InitialCapital: 10000.0,
@@ -185,11 +178,6 @@ func TestCheckRisk_ForceCloseOnDrawdown(t *testing.T) {
 	// 3 trades recorded (1 spot + 2 options)
 	if len(s.TradeHistory) != 3 {
 		t.Errorf("expected 3 trades in history; got %d", len(s.TradeHistory))
-	}
-
-	// RiskState.TotalTrades incremented by 3 (was 1, now 4)
-	if s.RiskState.TotalTrades != 4 {
-		t.Errorf("expected TotalTrades=4; got %d", s.RiskState.TotalTrades)
 	}
 
 	// Cash: started $5000
@@ -738,7 +726,6 @@ func TestCheckRisk_ConsecutiveLossesForceClose(t *testing.T) {
 		RiskState: RiskState{
 			PeakValue:         10000.0,
 			MaxDrawdownPct:    50.0,
-			TotalTrades:       5,
 			ConsecutiveLosses: 5,
 			DailyPnLDate:      todayUTC(),
 		},
@@ -1563,7 +1550,6 @@ func TestCheckRisk_PerpsMarginDrawdown_FiresEarly(t *testing.T) {
 		RiskState: RiskState{
 			PeakValue:      589.0,
 			MaxDrawdownPct: 25.0,
-			TotalTrades:    1,
 			DailyPnLDate:   todayUTC(),
 		},
 		Positions: map[string]*Position{
@@ -1611,7 +1597,6 @@ func TestCheckRisk_PerpsDrawdownFiresBeforeAnyClosedTrades(t *testing.T) {
 		RiskState: RiskState{
 			PeakValue:      500,
 			MaxDrawdownPct: 10,
-			TotalTrades:    0,
 			DailyPnLDate:   todayUTC(),
 		},
 		Positions: map[string]*Position{
@@ -1669,7 +1654,6 @@ func TestCheckRisk_LiveHLSharedCoin_SetsPendingPartialClose(t *testing.T) {
 		RiskState: RiskState{
 			PeakValue:      589.0,
 			MaxDrawdownPct: 25.0,
-			TotalTrades:    1,
 			DailyPnLDate:   todayUTC(),
 		},
 		Positions: map[string]*Position{
@@ -1723,7 +1707,6 @@ func TestCheckRisk_LiveTopStepCB_SetsPendingFullFlatten(t *testing.T) {
 		RiskState: RiskState{
 			PeakValue:      5000.0,
 			MaxDrawdownPct: 25.0,
-			TotalTrades:    1,
 			DailyPnLDate:   todayUTC(),
 		},
 		Positions: map[string]*Position{
@@ -1783,7 +1766,6 @@ func TestCheckRisk_LiveTopStepCB_MultiPeerNoPending(t *testing.T) {
 		RiskState: RiskState{
 			PeakValue:      5000.0,
 			MaxDrawdownPct: 25.0,
-			TotalTrades:    1,
 			DailyPnLDate:   todayUTC(),
 		},
 		Positions: map[string]*Position{
@@ -1818,7 +1800,6 @@ func TestCheckRisk_PerpsMarginDrawdown_BelowThreshold(t *testing.T) {
 		RiskState: RiskState{
 			PeakValue:      589.0,
 			MaxDrawdownPct: 25.0,
-			TotalTrades:    1,
 			DailyPnLDate:   todayUTC(),
 		},
 		Positions: map[string]*Position{
@@ -1853,7 +1834,6 @@ func TestCheckRisk_PerpsPriorRealizedLossesDoNotInflateDrawdown(t *testing.T) {
 		RiskState: RiskState{
 			PeakValue:      1000.0,
 			MaxDrawdownPct: 25.0,
-			TotalTrades:    5,
 			DailyPnLDate:   todayUTC(),
 		},
 		Positions: map[string]*Position{
@@ -1890,7 +1870,6 @@ func TestCheckRisk_PerpsNoOpenPositions_FallsBackToPeak(t *testing.T) {
 		RiskState: RiskState{
 			PeakValue:      1000.0,
 			MaxDrawdownPct: 25.0,
-			TotalTrades:    3,
 			DailyPnLDate:   todayUTC(),
 		},
 		Positions:       map[string]*Position{},
@@ -1917,7 +1896,6 @@ func TestCheckRisk_SpotUnchanged(t *testing.T) {
 		RiskState: RiskState{
 			PeakValue:      1000.0,
 			MaxDrawdownPct: 25.0,
-			TotalTrades:    1,
 			DailyPnLDate:   todayUTC(),
 		},
 		Positions: map[string]*Position{

--- a/scheduler/strategy_interval.go
+++ b/scheduler/strategy_interval.go
@@ -42,7 +42,7 @@ func strategyDrawdownWarningActive(s *StrategyState, warnThresholdPct float64) b
 		return false
 	}
 	r := s.RiskState
-	if r.TotalTrades <= 0 || r.MaxDrawdownPct <= 0 || warnThresholdPct <= 0 {
+	if r.MaxDrawdownPct <= 0 || warnThresholdPct <= 0 {
 		return false
 	}
 	warnDrawdownPct := r.MaxDrawdownPct * warnThresholdPct / 100

--- a/scheduler/strategy_interval_test.go
+++ b/scheduler/strategy_interval_test.go
@@ -11,7 +11,6 @@ func TestEffectiveStrategyIntervalSeconds_DrawdownWarningUsesFastInterval(t *tes
 		RiskState: RiskState{
 			MaxDrawdownPct:     10,
 			CurrentDrawdownPct: 8.5,
-			TotalTrades:        1,
 		},
 	}
 
@@ -27,7 +26,6 @@ func TestEffectiveStrategyIntervalSeconds_DrawdownRecoveryReverts(t *testing.T) 
 		RiskState: RiskState{
 			MaxDrawdownPct:     10,
 			CurrentDrawdownPct: 7.5,
-			TotalTrades:        1,
 		},
 	}
 
@@ -44,10 +42,10 @@ func TestEffectiveStrategyIntervalSeconds_OnlyWarningStrategySpeedsUp(t *testing
 	}
 	states := map[string]*StrategyState{
 		"warning": {
-			RiskState: RiskState{MaxDrawdownPct: 10, CurrentDrawdownPct: 8.1, TotalTrades: 1},
+			RiskState: RiskState{MaxDrawdownPct: 10, CurrentDrawdownPct: 8.1},
 		},
 		"normal": {
-			RiskState: RiskState{MaxDrawdownPct: 10, CurrentDrawdownPct: 2.0, TotalTrades: 1},
+			RiskState: RiskState{MaxDrawdownPct: 10, CurrentDrawdownPct: 2.0},
 		},
 	}
 
@@ -65,7 +63,6 @@ func TestEffectiveStrategyIntervalSeconds_DoesNotSlowAlreadyFastStrategy(t *test
 		RiskState: RiskState{
 			MaxDrawdownPct:     10,
 			CurrentDrawdownPct: 8.5,
-			TotalTrades:        1,
 		},
 	}
 
@@ -81,7 +78,6 @@ func TestEffectiveStrategyIntervalSeconds_CircuitBreakerIsNotWarningMode(t *test
 		RiskState: RiskState{
 			MaxDrawdownPct:     10,
 			CurrentDrawdownPct: 12,
-			TotalTrades:        1,
 			CircuitBreaker:     true,
 		},
 	}
@@ -104,7 +100,6 @@ func TestEffectiveStrategyIntervalSeconds_OverMaxDrawdownStillFast(t *testing.T)
 		RiskState: RiskState{
 			MaxDrawdownPct:     10,
 			CurrentDrawdownPct: 12, // already over max; CB not yet set
-			TotalTrades:        1,
 		},
 	}
 
@@ -122,10 +117,10 @@ func TestNextStrategyCheckDelay_UsesWarningInterval(t *testing.T) {
 	}
 	states := map[string]*StrategyState{
 		"warning": {
-			RiskState: RiskState{MaxDrawdownPct: 10, CurrentDrawdownPct: 8.5, TotalTrades: 1},
+			RiskState: RiskState{MaxDrawdownPct: 10, CurrentDrawdownPct: 8.5},
 		},
 		"normal": {
-			RiskState: RiskState{MaxDrawdownPct: 10, CurrentDrawdownPct: 1.0, TotalTrades: 1},
+			RiskState: RiskState{MaxDrawdownPct: 10, CurrentDrawdownPct: 1.0},
 		},
 	}
 	lastRun := map[string]time.Time{


### PR DESCRIPTION
### Summary
- Remove vestigial `RiskState` lifetime trade counters and their SQLite read/write paths.
- Render summary `#T` / `W/L` exclusively from `LifetimeTradeStatsAll`, with missing DB rows showing zero instead of falling back to in-memory state.
- Keep `RecordTradeResult` focused on daily PnL and consecutive-loss accounting, and let drawdown warning interval acceleration depend on drawdown state rather than removed counters.
- Update persistence, summary, stop-loss, risk, and strategy interval tests for the counter removal.

### Testing
- `go test -run 'TestSaveAndLoadDBRoundTrip|TestFormatCategorySummary_ClosedTradesColumn|TestFormatCategorySummary_WinLossColumn|TestFormatCategorySummary_LifetimeStats|TestRecordTradeResult|TestEffectiveStrategyIntervalSeconds|TestReconcileHyperliquidPositions_RestingStopLossFillClosesLongWithSell' .` in `scheduler`
- `go test ./...` in `scheduler`
- `go build -o /tmp/go-trader-issue-472 .` in `scheduler`
- `git diff --check`

Closes #472

LLM: GPT-5 | high