### PR TITLE
feat(hl): allow multiple HL perps strategies on the same coin

### DIFF
--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -336,7 +336,9 @@ class HyperliquidExchangeAdapter:
 
         HL's SDK takes both fields in one call, so callers always pass both.
         Fails closed: HL rejects this when there is an open position on the
-        coin, so the scheduler must only invoke it when opening from flat.
+        coin, so the scheduler must only invoke it when opening from flat —
+        or when ``get_position_leverage`` confirms the on-chain state already
+        matches the desired (mode, leverage) pair (#491).
         """
         if not self._exchange:
             raise RuntimeError(
@@ -345,3 +347,45 @@ class HyperliquidExchangeAdapter:
         if leverage < 1:
             raise ValueError(f"leverage must be >= 1, got {leverage}")
         return self._exchange.update_leverage(int(leverage), symbol, bool(is_cross))
+
+    def get_position_leverage(self, symbol: str) -> dict | None:
+        """Return ``{"margin_mode": "isolated"|"cross", "leverage": int}`` for the
+        on-chain position on ``symbol`` if one exists, else ``None`` (#491).
+
+        HL aggregates positions per coin per account, so two go-trader
+        strategies sharing a coin land on the same on-chain position. When
+        strategy A has already pinned (mode, leverage) on the coin, strategy
+        B can use this to detect the existing state and skip a redundant
+        ``update_leverage`` call — HL rejects mode/leverage changes while a
+        position is open, so the redundant call would fail-closed and abort
+        B's order. ``None`` means HL has no open position for ``symbol``;
+        ``update_leverage`` is then safe to call.
+        """
+        if not self._account_address:
+            return None
+        try:
+            user_state = self._info.user_state(self._account_address)
+        except Exception:
+            return None
+        for asset_pos in user_state.get("assetPositions", []):
+            pos = asset_pos.get("position", {}) or {}
+            if pos.get("coin") != symbol:
+                continue
+            try:
+                szi = float(pos.get("szi", 0) or 0)
+            except (TypeError, ValueError):
+                szi = 0.0
+            if szi == 0:
+                continue
+            lev = pos.get("leverage", {}) or {}
+            mode = lev.get("type")
+            if mode not in ("isolated", "cross"):
+                return None
+            try:
+                value = int(lev.get("value", 0) or 0)
+            except (TypeError, ValueError):
+                return None
+            if value < 1:
+                return None
+            return {"margin_mode": mode, "leverage": value}
+        return None

--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -365,7 +365,15 @@ class HyperliquidExchangeAdapter:
             return None
         try:
             user_state = self._info.user_state(self._account_address)
-        except Exception:
+        except Exception as exc:
+            # Don't swallow silently: a transient `info` failure is
+            # indistinguishable from "no position" to the caller, which would
+            # then call update_leverage and HL would reject it. Surface the
+            # cause to stderr so operators can see *why* the fallback ran.
+            print(
+                f"[WARN] HL get_position_leverage({symbol}) user_state failed: {exc}",
+                file=sys.stderr,
+            )
             return None
         for asset_pos in user_state.get("assetPositions", []):
             pos = asset_pos.get("position", {}) or {}

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -415,6 +415,11 @@ func LoadConfig(path string) (*Config, error) {
 // Sub-account isolation is the only correct path for full per-strategy
 // independence (different direction, leverage, margin); it is intentionally
 // out of scope here and tracked separately.
+//
+// Note: AllowShorts mismatches across peers on the same coin are NOT
+// validated here. A long-only and a short-allowed strategy on the same HL
+// coin would silently net/flip at the position level — directional
+// independence requires HL sub-accounts (out of scope for #491).
 func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 	type peer struct {
 		ID          string
@@ -451,25 +456,29 @@ func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 		if len(peers) < 2 {
 			continue
 		}
+		// Sort peers by ID so `base` (the comparison reference) is deterministic;
+		// any mismatch still triggers regardless of base, but a stable base lets
+		// future "report which peer is the outlier" extensions stay reproducible.
+		sort.Slice(peers, func(i, j int) bool { return peers[i].ID < peers[j].ID })
 		ids := make([]string, len(peers))
 		for i, p := range peers {
 			ids[i] = p.ID
 		}
-		sort.Strings(ids)
+		idList := strings.Join(ids, ", ")
 		base := peers[0]
 		for _, p := range peers[1:] {
 			if p.MarginMode != base.MarginMode {
 				errs = append(errs, fmt.Sprintf(
-					"hyperliquid peers on %s disagree on margin_mode (strategies %v): HL aggregates per coin per account, all peers must share margin_mode",
-					coin, ids))
+					"hyperliquid peers on %s disagree on margin_mode (strategies %s): HL aggregates per coin per account, all peers must share margin_mode",
+					coin, idList))
 				break
 			}
 		}
 		for _, p := range peers[1:] {
 			if p.Leverage != base.Leverage {
 				errs = append(errs, fmt.Sprintf(
-					"hyperliquid peers on %s disagree on leverage (strategies %v): HL aggregates per coin per account, all peers must share leverage",
-					coin, ids))
+					"hyperliquid peers on %s disagree on leverage (strategies %s): HL aggregates per coin per account, all peers must share leverage",
+					coin, idList))
 				break
 			}
 		}
@@ -482,8 +491,8 @@ func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 		if len(stopLossOwners) > 1 {
 			sort.Strings(stopLossOwners)
 			errs = append(errs, fmt.Sprintf(
-				"hyperliquid peers on %s have conflicting stop_loss_pct (strategies %v): at most one peer may place a reduce-only SL trigger; the others' OIDs would race on the shared on-chain position",
-				coin, stopLossOwners))
+				"hyperliquid peers on %s have conflicting stop_loss_pct (strategies %s): at most one peer may place a reduce-only SL trigger; the others' OIDs would race on the shared on-chain position",
+				coin, strings.Join(stopLossOwners, ", ")))
 		}
 	}
 	return errs

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -398,6 +399,96 @@ func LoadConfig(path string) (*Config, error) {
 	return &cfg, nil
 }
 
+// hyperliquidPeerStrategyErrors returns validation messages for HL perps
+// strategies that share a coin but disagree on MarginMode, Leverage, or
+// StopLossPct (#491). Returns an empty slice when no peer conflicts exist.
+//
+// HL aggregates positions per coin per account, so two go-trader strategies
+// on the same coin share an on-chain position, margin assignment, and
+// reduce-only stop-loss slots. Mismatched leverage/margin would either fail
+// at first peer trade (HL rejects mode changes on an open position) or
+// silently land in the wrong mode; conflicting stop-loss triggers race on
+// a single position. Per-strategy bookkeeping in SQLite keeps the legs
+// separated when peers agree, so this validation is the only thing
+// preventing a foot-gun config.
+//
+// Sub-account isolation is the only correct path for full per-strategy
+// independence (different direction, leverage, margin); it is intentionally
+// out of scope here and tracked separately.
+func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
+	type peer struct {
+		ID          string
+		Coin        string
+		MarginMode  string
+		Leverage    float64
+		StopLossPct float64
+	}
+	groups := make(map[string][]peer)
+	for _, sc := range strategies {
+		if sc.Type != "perps" || sc.Platform != "hyperliquid" {
+			continue
+		}
+		coin := hyperliquidSymbol(sc.Args)
+		if coin == "" {
+			continue
+		}
+		groups[coin] = append(groups[coin], peer{
+			ID:          sc.ID,
+			Coin:        coin,
+			MarginMode:  sc.MarginMode,
+			Leverage:    sc.Leverage,
+			StopLossPct: sc.StopLossPct,
+		})
+	}
+	var errs []string
+	coins := make([]string, 0, len(groups))
+	for coin := range groups {
+		coins = append(coins, coin)
+	}
+	sort.Strings(coins)
+	for _, coin := range coins {
+		peers := groups[coin]
+		if len(peers) < 2 {
+			continue
+		}
+		ids := make([]string, len(peers))
+		for i, p := range peers {
+			ids[i] = p.ID
+		}
+		sort.Strings(ids)
+		base := peers[0]
+		for _, p := range peers[1:] {
+			if p.MarginMode != base.MarginMode {
+				errs = append(errs, fmt.Sprintf(
+					"hyperliquid peers on %s disagree on margin_mode (strategies %v): HL aggregates per coin per account, all peers must share margin_mode",
+					coin, ids))
+				break
+			}
+		}
+		for _, p := range peers[1:] {
+			if p.Leverage != base.Leverage {
+				errs = append(errs, fmt.Sprintf(
+					"hyperliquid peers on %s disagree on leverage (strategies %v): HL aggregates per coin per account, all peers must share leverage",
+					coin, ids))
+				break
+			}
+		}
+		stopLossOwners := make([]string, 0)
+		for _, p := range peers {
+			if p.StopLossPct > 0 {
+				stopLossOwners = append(stopLossOwners, p.ID)
+			}
+		}
+		if len(stopLossOwners) > 1 {
+			sort.Strings(stopLossOwners)
+			errs = append(errs, fmt.Sprintf(
+				"hyperliquid peers on %s have conflicting stop_loss_pct (strategies %v): at most one peer may place a reduce-only SL trigger; the others' OIDs would race on the shared on-chain position",
+				coin, stopLossOwners))
+		}
+	}
+	return errs
+}
+
 // ParseLeaderboardPostTime parses a "HH:MM" string and returns (hour, minute, ok).
 func ParseLeaderboardPostTime(s string) (int, int, bool) {
 	if s == "" {
@@ -661,6 +752,16 @@ func ValidateConfig(cfg *Config) error {
 				errs = append(errs, fmt.Sprintf("%s: theta_harvest.min_dte_close must be >= 0", prefix))
 			}
 		}
+	}
+
+	// #491: Two HL perps strategies on the same coin land on a single on-chain
+	// position (HL nets per coin per account). Peer strategies must agree on
+	// MarginMode and Leverage, and at most one peer may carry a per-trade
+	// stop-loss — otherwise reduce-only triggers placed by both peers will
+	// race on the shared position. Validate up front instead of failing at
+	// first trade.
+	for _, msg := range hyperliquidPeerStrategyErrors(cfg.Strategies) {
+		errs = append(errs, msg)
 	}
 
 	// #42: Validate portfolio risk config.

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -204,6 +204,12 @@ func validateHotReloadCompatible(cfg, next *Config) error {
 		}
 	}
 
+	// #491: re-run peer-strategy validation against the new config so that
+	// reloads can't introduce a peer-conflict that startup would have caught.
+	for _, msg := range hyperliquidPeerStrategyErrors(next.Strategies) {
+		errs = append(errs, msg)
+	}
+
 	if len(errs) > 0 {
 		sort.Strings(errs)
 		return fmt.Errorf("config reload rejected:\n  %s", strings.Join(errs, "\n  "))

--- a/scheduler/config_reload_test.go
+++ b/scheduler/config_reload_test.go
@@ -315,6 +315,34 @@ func TestApplyHotReloadConfigPreservesRuntimeCapitalPctCapital(t *testing.T) {
 	}
 }
 
+// #491: hot-reload mirrors LoadConfig peer validation — a reload that would
+// introduce two HL perps strategies on the same coin with mismatched
+// margin_mode/leverage must be rejected.
+func TestApplyHotReloadConfigRejectsHLPeerMismatchOnReload(t *testing.T) {
+	cfg := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth-a", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 5, MarginMode: "isolated",
+	}, {
+		ID: "hl-eth-b", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"b", "ETH", "1h"}, Capital: 500, MaxDrawdownPct: 10, Leverage: 5, MarginMode: "isolated",
+	}})
+	next := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth-a", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 5, MarginMode: "isolated",
+	}, {
+		ID: "hl-eth-b", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"b", "ETH", "1h"}, Capital: 500, MaxDrawdownPct: 10, Leverage: 10, MarginMode: "isolated",
+	}})
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-eth-a": {ID: "hl-eth-a", Cash: 1000},
+		"hl-eth-b": {ID: "hl-eth-b", Cash: 500},
+	}}
+
+	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
+	if err == nil {
+		t.Fatal("expected hot reload to reject peer leverage mismatch")
+	}
+	if !strings.Contains(err.Error(), "disagree on leverage") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func minimalReloadConfig(strategies []StrategyConfig) *Config {
 	return &Config{
 		IntervalSeconds: 600,

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -888,6 +888,231 @@ func TestLoadConfigMarginModeRejectsSpot(t *testing.T) {
 	}
 }
 
+// #491: two HL perps strategies on the same coin must agree on margin_mode
+// and leverage — HL aggregates positions per coin per account, so peers
+// share a single on-chain position. Matching peers load successfully.
+func TestLoadConfigHLPerpsPeersOnSameCoinMatching(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [
+			{
+				"id": "hl-eth-trend",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+				"capital": 1000,
+				"leverage": 5,
+				"margin_mode": "isolated"
+			},
+			{
+				"id": "hl-eth-breakout",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
+				"capital": 500,
+				"leverage": 5,
+				"margin_mode": "isolated"
+			}
+		]
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	if len(cfg.Strategies) != 2 {
+		t.Fatalf("expected 2 strategies, got %d", len(cfg.Strategies))
+	}
+}
+
+// #491: peers on the same coin with mismatched margin_mode are rejected.
+func TestLoadConfigHLPerpsPeersMismatchedMarginMode(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [
+			{
+				"id": "hl-eth-trend",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+				"capital": 1000,
+				"leverage": 5,
+				"margin_mode": "isolated"
+			},
+			{
+				"id": "hl-eth-breakout",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
+				"capital": 500,
+				"leverage": 5,
+				"margin_mode": "cross"
+			}
+		]
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected validation error for mismatched margin_mode on peers")
+	}
+	if !strings.Contains(err.Error(), "disagree on margin_mode") {
+		t.Errorf("error = %v, want 'disagree on margin_mode'", err)
+	}
+	if !strings.Contains(err.Error(), "ETH") {
+		t.Errorf("error = %v, want mention of coin ETH", err)
+	}
+}
+
+// #491: peers on the same coin with mismatched leverage are rejected.
+func TestLoadConfigHLPerpsPeersMismatchedLeverage(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [
+			{
+				"id": "hl-eth-trend",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+				"capital": 1000,
+				"leverage": 5,
+				"margin_mode": "isolated"
+			},
+			{
+				"id": "hl-eth-breakout",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
+				"capital": 500,
+				"leverage": 10,
+				"margin_mode": "isolated"
+			}
+		]
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected validation error for mismatched leverage on peers")
+	}
+	if !strings.Contains(err.Error(), "disagree on leverage") {
+		t.Errorf("error = %v, want 'disagree on leverage'", err)
+	}
+}
+
+// #491: only one peer may carry stop_loss_pct — reduce-only triggers from
+// both peers would race on the shared on-chain position.
+func TestLoadConfigHLPerpsPeersConflictingStopLoss(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [
+			{
+				"id": "hl-eth-trend",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+				"capital": 1000,
+				"leverage": 5,
+				"margin_mode": "isolated",
+				"stop_loss_pct": 3.0
+			},
+			{
+				"id": "hl-eth-breakout",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
+				"capital": 500,
+				"leverage": 5,
+				"margin_mode": "isolated",
+				"stop_loss_pct": 5.0
+			}
+		]
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected validation error for conflicting stop_loss_pct on peers")
+	}
+	if !strings.Contains(err.Error(), "conflicting stop_loss_pct") {
+		t.Errorf("error = %v, want 'conflicting stop_loss_pct'", err)
+	}
+}
+
+// #491: a single peer with stop_loss_pct is fine; the guard only fires when
+// two or more peers configure SLs that would race on the shared position.
+func TestLoadConfigHLPerpsPeersSingleStopLossAllowed(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [
+			{
+				"id": "hl-eth-trend",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+				"capital": 1000,
+				"leverage": 5,
+				"margin_mode": "isolated",
+				"stop_loss_pct": 3.0
+			},
+			{
+				"id": "hl-eth-breakout",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
+				"capital": 500,
+				"leverage": 5,
+				"margin_mode": "isolated"
+			}
+		]
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	if _, err := LoadConfig(path); err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+}
+
+// #491: peer-validation only applies within a single coin — strategies on
+// different coins don't constrain each other.
+func TestLoadConfigHLPerpsPeersDifferentCoinsIndependent(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [
+			{
+				"id": "hl-eth-trend",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+				"capital": 1000,
+				"leverage": 5,
+				"margin_mode": "isolated"
+			},
+			{
+				"id": "hl-btc-trend",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["sma_crossover", "BTC", "1h", "--mode=paper"],
+				"capital": 1000,
+				"leverage": 10,
+				"margin_mode": "cross"
+			}
+		]
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	if _, err := LoadConfig(path); err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+}
+
 func TestValidateConfigDMChannelsInvalidKey(t *testing.T) {
 	dir := t.TempDir()
 	cfgJSON := `{

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -1113,6 +1113,80 @@ func TestLoadConfigHLPerpsPeersDifferentCoinsIndependent(t *testing.T) {
 	}
 }
 
+// #491: zero-default stop_loss_pct on both peers must not trip the conflict
+// guard — the boundary between "no SL configured" and "SL conflict".
+func TestLoadConfigHLPerpsPeersNoStopLossAllowed(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [
+			{
+				"id": "hl-eth-trend",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+				"capital": 1000,
+				"leverage": 5,
+				"margin_mode": "isolated"
+			},
+			{
+				"id": "hl-eth-breakout",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
+				"capital": 500,
+				"leverage": 5,
+				"margin_mode": "isolated"
+			}
+		]
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	if _, err := LoadConfig(path); err != nil {
+		t.Fatalf("LoadConfig failed for two peers with no stop_loss_pct: %v", err)
+	}
+}
+
+// #491: margin_mode defaulting (empty -> "isolated") happens at LoadConfig
+// time, so peer comparison must see normalized values. A peer with
+// margin_mode:"" should match a peer with margin_mode:"isolated".
+func TestLoadConfigHLPerpsPeersDefaultedMarginModeMatches(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [
+			{
+				"id": "hl-eth-trend",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+				"capital": 1000,
+				"leverage": 5
+			},
+			{
+				"id": "hl-eth-breakout",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
+				"capital": 500,
+				"leverage": 5,
+				"margin_mode": "isolated"
+			}
+		]
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig failed for defaulted vs explicit margin_mode peers: %v", err)
+	}
+	for _, sc := range cfg.Strategies {
+		if sc.MarginMode != "isolated" {
+			t.Errorf("strategy %s margin_mode = %q, want %q", sc.ID, sc.MarginMode, "isolated")
+		}
+	}
+}
+
 func TestValidateConfigDMChannelsInvalidKey(t *testing.T) {
 	dir := t.TempDir()
 	cfgJSON := `{

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -294,9 +294,12 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
 
         # Enforce margin mode + leverage before placing the order (#486).
         # Fail closed: if HL rejects this we abort the order rather than
-        # silently opening into the wrong margin mode. The scheduler only
-        # passes margin_mode on a fresh open from flat, so HL won't reject
-        # because of an existing position.
+        # silently opening into the wrong margin mode. When a peer strategy
+        # has already opened the same coin (#491), HL has the desired state
+        # pinned and would reject a fresh update_leverage call — so skip the
+        # call when get_position_leverage confirms the on-chain state already
+        # matches. LoadConfig validates that all peers share margin_mode and
+        # leverage, so a match here is the expected case.
         if margin_mode:
             if margin_mode not in ("isolated", "cross"):
                 print(json.dumps({
@@ -314,18 +317,30 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
                     "error": f"--margin-mode requires --leverage >= 1, got {leverage}",
                 }, cls=SafeEncoder))
                 sys.exit(1)
+            current = None
             try:
-                adapter.update_leverage(int(leverage), symbol, is_cross=(margin_mode == "cross"))
-                print(f"update_leverage({symbol}, {leverage}x, mode={margin_mode}) OK", file=sys.stderr)
-            except Exception as ue:
-                traceback.print_exc(file=sys.stderr)
-                print(json.dumps({
-                    "execution": None,
-                    "platform": "hyperliquid",
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
-                    "error": f"update_leverage failed (margin_mode={margin_mode}, leverage={leverage}): {ue}",
-                }, cls=SafeEncoder))
-                sys.exit(1)
+                current = adapter.get_position_leverage(symbol)
+            except Exception as ce:
+                # Don't fail-closed on a state-fetch hiccup — the
+                # update_leverage call below will fail loudly if the on-chain
+                # state actually disagrees, preserving the original safety
+                # behavior. We still log so the cause is debuggable.
+                print(f"[WARN] get_position_leverage({symbol}) failed: {ce}; will call update_leverage", file=sys.stderr)
+            if current is not None and current.get("margin_mode") == margin_mode and current.get("leverage") == int(leverage):
+                print(f"update_leverage({symbol}, {leverage}x, mode={margin_mode}) SKIPPED (HL state already matches)", file=sys.stderr)
+            else:
+                try:
+                    adapter.update_leverage(int(leverage), symbol, is_cross=(margin_mode == "cross"))
+                    print(f"update_leverage({symbol}, {leverage}x, mode={margin_mode}) OK", file=sys.stderr)
+                except Exception as ue:
+                    traceback.print_exc(file=sys.stderr)
+                    print(json.dumps({
+                        "execution": None,
+                        "platform": "hyperliquid",
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "error": f"update_leverage failed (margin_mode={margin_mode}, leverage={leverage}): {ue}",
+                    }, cls=SafeEncoder))
+                    sys.exit(1)
 
         # Cancel stale SL first: we want to free the trigger slot before
         # possibly spending another one on the new entry. A cancel failure is

--- a/shared_scripts/test_check_hyperliquid.py
+++ b/shared_scripts/test_check_hyperliquid.py
@@ -225,6 +225,118 @@ class TestMarginMode:
         assert "position open" in result.get("error", "")
 
 
+class TestPeerLeverageSkip:
+    """#491: when a peer strategy has already opened the same coin, HL has
+    (margin_mode, leverage) pinned to the existing on-chain position. A fresh
+    update_leverage call would fail, so run_execute queries get_position_leverage
+    and skips the call when state already matches. LoadConfig validates that
+    peers agree on (margin_mode, leverage), so a match is the expected case
+    when peers share a coin."""
+
+    def _run_execute_with_existing_pos(self, margin_mode, leverage, current_state):
+        mod, spec = _load_check_module()
+        spec.loader.exec_module(mod)
+
+        mock_adapter_cls = MagicMock()
+        mock_adapter = MagicMock()
+        mock_adapter_cls.return_value = mock_adapter
+        mock_adapter.get_position_leverage.return_value = current_state
+        mock_adapter.market_open.return_value = {
+            "status": "ok",
+            "response": {"type": "order", "data": {"statuses": [
+                {"filled": {"avgPx": "50000", "totalSz": "0.01"}}
+            ]}},
+        }
+
+        captured = StringIO()
+        import builtins
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "adapter":
+                fake_mod = MagicMock()
+                fake_mod.HyperliquidExchangeAdapter = mock_adapter_cls
+                return fake_mod
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            with patch("sys.stdout", captured):
+                exit_code = 0
+                try:
+                    mod.run_execute("ETH", "buy", 0.5, "live",
+                                    margin_mode=margin_mode, leverage=leverage)
+                except SystemExit as e:
+                    exit_code = e.code
+        return json.loads(captured.getvalue()), mock_adapter, exit_code
+
+    def test_skips_update_leverage_when_state_matches(self):
+        result, adapter, exit_code = self._run_execute_with_existing_pos(
+            "isolated", 5, {"margin_mode": "isolated", "leverage": 5})
+        assert exit_code == 0
+        adapter.update_leverage.assert_not_called()
+        adapter.market_open.assert_called_once()
+        assert result["execution"]["action"] == "buy"
+
+    def test_calls_update_leverage_when_mode_mismatches(self):
+        result, adapter, exit_code = self._run_execute_with_existing_pos(
+            "isolated", 5, {"margin_mode": "cross", "leverage": 5})
+        adapter.update_leverage.assert_called_once_with(5, "ETH", is_cross=False)
+
+    def test_calls_update_leverage_when_leverage_mismatches(self):
+        result, adapter, exit_code = self._run_execute_with_existing_pos(
+            "isolated", 5, {"margin_mode": "isolated", "leverage": 3})
+        adapter.update_leverage.assert_called_once_with(5, "ETH", is_cross=False)
+
+    def test_calls_update_leverage_when_no_existing_position(self):
+        # get_position_leverage returns None when HL has no open position
+        # for the coin — then update_leverage is safe to call (HL only
+        # rejects mode changes on an OPEN position).
+        result, adapter, exit_code = self._run_execute_with_existing_pos(
+            "isolated", 5, None)
+        adapter.update_leverage.assert_called_once_with(5, "ETH", is_cross=False)
+
+    def test_state_fetch_failure_falls_back_to_calling_update_leverage(self):
+        # If get_position_leverage raises, fall back to calling
+        # update_leverage so the existing fail-closed safety net catches a
+        # genuine mismatch — never silently skip without confirmation.
+        mod, spec = _load_check_module()
+        spec.loader.exec_module(mod)
+
+        mock_adapter_cls = MagicMock()
+        mock_adapter = MagicMock()
+        mock_adapter_cls.return_value = mock_adapter
+        mock_adapter.get_position_leverage.side_effect = RuntimeError("info endpoint timeout")
+        mock_adapter.market_open.return_value = {
+            "status": "ok",
+            "response": {"type": "order", "data": {"statuses": [
+                {"filled": {"avgPx": "50000", "totalSz": "0.01"}}
+            ]}},
+        }
+
+        captured = StringIO()
+        import builtins
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "adapter":
+                fake_mod = MagicMock()
+                fake_mod.HyperliquidExchangeAdapter = mock_adapter_cls
+                return fake_mod
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            with patch("sys.stdout", captured):
+                exit_code = 0
+                try:
+                    mod.run_execute("ETH", "buy", 0.5, "live",
+                                    margin_mode="isolated", leverage=5)
+                except SystemExit as e:
+                    exit_code = e.code
+
+        assert exit_code == 0
+        mock_adapter.update_leverage.assert_called_once_with(5, "ETH", is_cross=False)
+
+
 class TestClassifySLResponse:
     """Unit coverage for _classify_sl_response added in #421. The classifier
     is the load-bearing piece that distinguishes a resting SL from an instant


### PR DESCRIPTION
Closes #491.

## Summary
- Skip `update_leverage` when HL already matches the desired (margin_mode, leverage), so a peer strategy on a shared coin can open onto the existing on-chain position instead of fail-closing.
- Validate HL perps peers (same coin) share `margin_mode` / `leverage` at `LoadConfig` and on SIGHUP hot reload.
- At most one peer may carry `stop_loss_pct` — avoids OID collision on reduce-only triggers.

## Test plan
- [x] `go test ./...`
- [x] `uv run pytest shared_scripts/test_check_hyperliquid.py`

---
LLM: Claude Opus 4.7 (1M) | high | Tokens: 95 in / 33083 out | Cache: 6654441 read / 180681 written | Cost: $5.28