### PR TITLE
feat: auto-derive HL perps stop-loss from max_drawdown_pct

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -466,11 +466,11 @@ func LoadConfig(path string) (*Config, error) {
 // independence requires HL sub-accounts (out of scope for #491).
 func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 	type peer struct {
-		ID          string
-		Coin        string
-		MarginMode  string
-		Leverage    float64
-		StopLossPct float64
+		ID             string
+		Coin           string
+		MarginMode     string
+		Leverage       float64
+		EffectiveSLPct float64 // resolved via EffectiveStopLossPct: nil→auto from MaxDrawdownPct, 0→disabled, >0→explicit
 	}
 	groups := make(map[string][]peer)
 	for _, sc := range strategies {
@@ -482,11 +482,11 @@ func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 			continue
 		}
 		groups[coin] = append(groups[coin], peer{
-			ID:          sc.ID,
-			Coin:        coin,
-			MarginMode:  sc.MarginMode,
-			Leverage:    sc.Leverage,
-			StopLossPct: sc.StopLossPct,
+			ID:             sc.ID,
+			Coin:           coin,
+			MarginMode:     sc.MarginMode,
+			Leverage:       sc.Leverage,
+			EffectiveSLPct: EffectiveStopLossPct(sc),
 		})
 	}
 	var errs []string
@@ -528,7 +528,7 @@ func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 		}
 		stopLossOwners := make([]string, 0)
 		for _, p := range peers {
-			if p.StopLossPct > 0 {
+			if p.EffectiveSLPct > 0 {
 				stopLossOwners = append(stopLossOwners, p.ID)
 			}
 		}

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -206,25 +206,53 @@ type StrategyConfig struct {
 	HTFFilter            bool                   `json:"htf_filter,omitempty"`           // higher-timeframe trend filter
 	AllowShorts          bool                   `json:"allow_shorts,omitempty"`         // perps only: opt-in to bidirectional execution — signal=-1 from flat opens a short, long+(-1) closes-and-flips. Default false preserves close-long-only behavior for strategies like triple_ema that emit -1 only as a long-exit (#328)
 	Leverage             float64                `json:"leverage,omitempty"`             // perps leverage multiplier (default 1 = no leverage); used for notional sizing and margin-based valuation (#254)
-	StopLossPct          float64                `json:"stop_loss_pct,omitempty"`        // HL perps only: % from entry to place a reduce-only stop-loss trigger (0 = disabled) (#412)
-	StopLossMarginPct    float64                `json:"stop_loss_margin_pct,omitempty"` // HL perps only: % of deployed margin to lose before stop-loss trigger; mutually exclusive with stop_loss_pct; price % derived as StopLossMarginPct / Leverage at order time (#487)
+	StopLossPct          *float64               `json:"stop_loss_pct,omitempty"`        // HL perps only: % from entry to place a reduce-only stop-loss trigger. Pointer so omitted (nil) falls through to StopLossMarginPct then MaxDrawdownPct (#484); explicit 0 disables auto-SL (#412)
+	StopLossMarginPct    *float64               `json:"stop_loss_margin_pct,omitempty"` // HL perps only: % of deployed margin to lose before stop-loss trigger; mutually exclusive with stop_loss_pct; price % derived as StopLossMarginPct / Leverage at order time. Pointer so omitted falls through to MaxDrawdownPct; explicit 0 disables (#487, #484)
 	MarginMode           string                 `json:"margin_mode,omitempty"`          // HL perps only: "isolated" (default) or "cross"; sent via update_leverage on fresh opens to enforce per-position liq isolation (#486)
 	Params               map[string]interface{} `json:"params,omitempty"`               // custom strategy parameters passed to Python
 	ThetaHarvest         *ThetaHarvestConfig    `json:"theta_harvest,omitempty"`
 	FuturesConfig        *FuturesConfig         `json:"futures,omitempty"`
 }
 
+// MaxAutoStopLossPct caps the auto-derived per-trade stop at 50% to mirror the
+// hand-edited bound enforced on StopLossPct (#421). MaxDrawdownPct can default
+// to 50–60 across platforms; using it raw as a price stop would land triggers
+// at entry×0 / entry×2 on long/short legs.
+const MaxAutoStopLossPct = 50.0
+
 // EffectiveStopLossPct returns the price % to use as the HL reduce-only stop-loss
-// trigger for a given strategy. Returns the explicit StopLossPct when set;
-// otherwise derives it from StopLossMarginPct / Leverage so margin-loss-based
-// triggers stay correct as leverage changes (#487). Returns 0 when neither is
-// configured or when leverage is missing/invalid for the margin-pct path.
+// trigger for a given strategy. Resolution order (#484):
+//  1. Explicit StopLossPct (nil → fall through; explicit 0 → disabled).
+//  2. StopLossMarginPct / Leverage (nil → fall through; explicit 0 → disabled).
+//  3. MaxDrawdownPct as a fallback so any HL perps strategy with a configured
+//     drawdown automatically gets exchange-side protection. Capped at
+//     MaxAutoStopLossPct.
+//
+// HL perps only — returns 0 for non-HL platforms or non-perps types so the
+// caller can skip the trigger placement unconditionally.
 func EffectiveStopLossPct(sc StrategyConfig) float64 {
-	if sc.StopLossPct > 0 {
-		return sc.StopLossPct
+	if sc.Platform != "hyperliquid" || sc.Type != "perps" {
+		return 0
 	}
-	if sc.StopLossMarginPct > 0 && sc.Leverage > 0 {
-		return sc.StopLossMarginPct / sc.Leverage
+	if sc.StopLossPct != nil {
+		// Explicit value (including 0 = disabled) wins.
+		if *sc.StopLossPct > 0 {
+			return *sc.StopLossPct
+		}
+		return 0
+	}
+	if sc.StopLossMarginPct != nil {
+		if *sc.StopLossMarginPct > 0 && sc.Leverage > 0 {
+			return *sc.StopLossMarginPct / sc.Leverage
+		}
+		return 0
+	}
+	if sc.MaxDrawdownPct > 0 {
+		fallback := sc.MaxDrawdownPct
+		if fallback > MaxAutoStopLossPct {
+			fallback = MaxAutoStopLossPct
+		}
+		return fallback
 	}
 	return 0
 }
@@ -754,10 +782,13 @@ func ValidateConfig(cfg *Config) error {
 		// #421: bound-check stop_loss_pct to mirror the init wizard's range.
 		// A hand-edited config with stop_loss_pct=200 would otherwise silently
 		// place an SL at $0 (long) or 3× entry (short) — both never trigger,
-		// breaking the safety feature without any warning.
-		if sc.StopLossPct != 0 {
-			if sc.StopLossPct < 0 || sc.StopLossPct > 50 {
-				errs = append(errs, fmt.Sprintf("%s: stop_loss_pct must be in [0, 50], got %g", prefix, sc.StopLossPct))
+		// breaking the safety feature without any warning. Pointer-aware (#484):
+		// nil means the field was omitted (auto-SL falls through to margin/DD);
+		// explicit 0 means the operator opted out and is allowed.
+		if sc.StopLossPct != nil {
+			pct := *sc.StopLossPct
+			if pct < 0 || pct > 50 {
+				errs = append(errs, fmt.Sprintf("%s: stop_loss_pct must be in [0, 50], got %g", prefix, pct))
 			}
 			if sc.Type != "perps" || sc.Platform != "hyperliquid" {
 				errs = append(errs, fmt.Sprintf("%s: stop_loss_pct is only supported for HL perps strategies (got platform=%q type=%q)", prefix, sc.Platform, sc.Type))
@@ -767,12 +798,14 @@ func ValidateConfig(cfg *Config) error {
 		// #487: stop_loss_margin_pct expresses the trigger as a % of deployed
 		// margin (leverage-aware) and is converted to a price % at order time.
 		// Mutually exclusive with stop_loss_pct so the operator can't double up.
-		if sc.StopLossMarginPct != 0 {
-			if sc.StopLossPct != 0 {
+		// Pointer-aware (#484): same explicit-vs-omitted distinction.
+		if sc.StopLossMarginPct != nil {
+			marginPct := *sc.StopLossMarginPct
+			if sc.StopLossPct != nil {
 				errs = append(errs, fmt.Sprintf("%s: stop_loss_pct and stop_loss_margin_pct are mutually exclusive — set only one", prefix))
 			}
-			if sc.StopLossMarginPct <= 0 || sc.StopLossMarginPct > 100 {
-				errs = append(errs, fmt.Sprintf("%s: stop_loss_margin_pct must be in (0, 100], got %g", prefix, sc.StopLossMarginPct))
+			if marginPct < 0 || marginPct > 100 {
+				errs = append(errs, fmt.Sprintf("%s: stop_loss_margin_pct must be in [0, 100], got %g", prefix, marginPct))
 			}
 			if sc.Type != "perps" || sc.Platform != "hyperliquid" {
 				errs = append(errs, fmt.Sprintf("%s: stop_loss_margin_pct is only supported for HL perps strategies (got platform=%q type=%q)", prefix, sc.Platform, sc.Type))
@@ -780,13 +813,16 @@ func ValidateConfig(cfg *Config) error {
 			// Mirror the #421 [0, 50] cap on the *derived* price stop so a
 			// hand-edited config like {StopLossMarginPct: 80, Leverage: 1}
 			// can't pass validation and silently land an HL trigger at
-			// entry×0 (long) or entry×1.8 (short).
-			lev := sc.Leverage
-			if lev < 1 {
-				lev = 1
-			}
-			if derived := sc.StopLossMarginPct / lev; derived > 50 {
-				errs = append(errs, fmt.Sprintf("%s: derived stop-loss price %% (stop_loss_margin_pct / leverage = %g) must be <= 50; lower stop_loss_margin_pct or raise leverage", prefix, derived))
+			// entry×0 (long) or entry×1.8 (short). Skip when explicitly 0
+			// (disabled) — derived stop is also 0.
+			if marginPct > 0 {
+				lev := sc.Leverage
+				if lev < 1 {
+					lev = 1
+				}
+				if derived := marginPct / lev; derived > 50 {
+					errs = append(errs, fmt.Sprintf("%s: derived stop-loss price %% (stop_loss_margin_pct / leverage = %g) must be <= 50; lower stop_loss_margin_pct or raise leverage", prefix, derived))
+				}
 			}
 		}
 

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -802,7 +802,7 @@ func ValidateConfig(cfg *Config) error {
 		if sc.StopLossMarginPct != nil {
 			marginPct := *sc.StopLossMarginPct
 			if sc.StopLossPct != nil {
-				errs = append(errs, fmt.Sprintf("%s: stop_loss_pct and stop_loss_margin_pct are mutually exclusive — set only one", prefix))
+				errs = append(errs, fmt.Sprintf("%s: stop_loss_pct and stop_loss_margin_pct are mutually exclusive — set only one (note: stop_loss_pct=0 counts as \"set\" and explicitly disables the auto-SL; remove the field entirely to fall through to stop_loss_margin_pct)", prefix))
 			}
 			if marginPct < 0 || marginPct > 100 {
 				errs = append(errs, fmt.Sprintf("%s: stop_loss_margin_pct must be in [0, 100], got %g", prefix, marginPct))

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -798,10 +798,13 @@ func ValidateConfig(cfg *Config) error {
 		// #487: stop_loss_margin_pct expresses the trigger as a % of deployed
 		// margin (leverage-aware) and is converted to a price % at order time.
 		// Mutually exclusive with stop_loss_pct so the operator can't double up.
-		// Pointer-aware (#484): same explicit-vs-omitted distinction.
+		// Pointer-aware (#484): same explicit-vs-omitted distinction. The
+		// mutual-exclusion check fires only when at least one field is
+		// non-zero; both = 0 is benign (both mean "disabled" — neither
+		// places a trigger at runtime, so there is nothing to conflict).
 		if sc.StopLossMarginPct != nil {
 			marginPct := *sc.StopLossMarginPct
-			if sc.StopLossPct != nil {
+			if sc.StopLossPct != nil && (*sc.StopLossPct > 0 || marginPct > 0) {
 				errs = append(errs, fmt.Sprintf("%s: stop_loss_pct and stop_loss_margin_pct are mutually exclusive — set only one (note: stop_loss_pct=0 counts as \"set\" and explicitly disables the auto-SL; remove the field entirely to fall through to stop_loss_margin_pct)", prefix))
 			}
 			if marginPct < 0 || marginPct > 100 {

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -10,7 +10,7 @@ import (
 
 // CurrentConfigVersion is the version embedded in newly generated configs.
 // When the binary starts and cfg.ConfigVersion < CurrentConfigVersion, migration runs.
-const CurrentConfigVersion = 8
+const CurrentConfigVersion = 9
 
 // ConfigField describes a config field introduced in a specific version.
 type ConfigField struct {
@@ -72,6 +72,20 @@ const v8DeprecationNotice = "**Note:** `discord.spot_summary_freq` and `discord.
 	"a top-level `summary_frequency` map keyed by channel (e.g. `\"spot\": \"hourly\"`, `\"options\": \"every\"`). " +
 	"Values may be `\"every\"`/`\"per_check\"`/`\"always\"` (every cycle), `\"hourly\"` (1h), `\"daily\"` (24h), or any Go duration like `\"30m\"`. " +
 	"Empty/missing falls back to legacy defaults (options/perps/futures every cycle, spot hourly). See issue #30."
+
+// v9 introduced auto-derivation of HL perps per-trade stop-loss from
+// max_drawdown_pct (#484). The field types changed from float64 to *float64
+// so omitted (nil) is distinguishable from explicit 0. Behavior change for
+// existing configs: any HL perps strategy without an explicit `stop_loss_pct`
+// or `stop_loss_margin_pct` will now place an exchange-side reduce-only
+// trigger on every fresh open (capped at 50%). Operators who relied on the
+// pre-v9 "no SL when field is omitted" behavior must set `"stop_loss_pct": 0`
+// explicitly to opt out.
+const v9DeprecationNotice = "**Note:** HL perps strategies now auto-derive a per-trade stop-loss from `max_drawdown_pct` " +
+	"(capped at 50%) when neither `stop_loss_pct` nor `stop_loss_margin_pct` is set. This means existing configs " +
+	"with an omitted `stop_loss_pct` will start placing reduce-only trigger orders on-chain (counts against HL's " +
+	"1000/account trigger cap). To preserve the old \"no exchange-side stop\" behavior, set `\"stop_loss_pct\": 0` " +
+	"explicitly on the affected strategies. See issue #484."
 
 const v7DeprecationNotice = "**Note:** `dm_paper_trades` and `dm_live_trades` have been replaced by a `dm_channels` map. " +
 	"Paper trades use `dm_channels[\"<platform>-paper\"]`; live trades use `dm_channels[\"<platform>\"]`. " +
@@ -310,6 +324,14 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 				fmt.Printf("[migration] %s\n", v8DeprecationNotice)
 			}
 		}
+		// v9: notify about HL perps auto-SL fallback to max_drawdown_pct (#484).
+		if cfg.ConfigVersion < 9 {
+			if notifier != nil && notifier.HasOwner() {
+				notifier.SendOwnerDM(v9DeprecationNotice)
+			} else {
+				fmt.Printf("[migration] %s\n", v9DeprecationNotice)
+			}
+		}
 		return
 	}
 
@@ -334,6 +356,9 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 		}
 		if cfg.ConfigVersion < 8 {
 			fmt.Printf("[migration] %s\n", v8DeprecationNotice)
+		}
+		if cfg.ConfigVersion < 9 {
+			fmt.Printf("[migration] %s\n", v9DeprecationNotice)
 		}
 		return
 	}
@@ -375,5 +400,9 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 	// v8: notify about summary_frequency migration (#30).
 	if cfg.ConfigVersion < 8 {
 		notifier.SendOwnerDM(v8DeprecationNotice)
+	}
+	// v9: notify about HL perps auto-SL fallback to max_drawdown_pct (#484).
+	if cfg.ConfigVersion < 9 {
+		notifier.SendOwnerDM(v9DeprecationNotice)
 	}
 }

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -893,6 +893,9 @@ func TestLoadConfigMarginModeRejectsSpot(t *testing.T) {
 // share a single on-chain position. Matching peers load successfully.
 func TestLoadConfigHLPerpsPeersOnSameCoinMatching(t *testing.T) {
 	dir := t.TempDir()
+	// #484: omitting stop_loss_pct now auto-derives from max_drawdown_pct, so
+	// peers that both omit it would each place a SL trigger — a conflict.
+	// Use stop_loss_pct:0 on the second peer to disable auto-SL for that leg.
 	cfgJSON := `{
 		"strategies": [
 			{
@@ -913,7 +916,8 @@ func TestLoadConfigHLPerpsPeersOnSameCoinMatching(t *testing.T) {
 				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
 				"capital": 500,
 				"leverage": 5,
-				"margin_mode": "isolated"
+				"margin_mode": "isolated",
+				"stop_loss_pct": 0
 			}
 		]
 	}`
@@ -1048,6 +1052,9 @@ func TestLoadConfigHLPerpsPeersConflictingStopLoss(t *testing.T) {
 // two or more peers configure SLs that would race on the shared position.
 func TestLoadConfigHLPerpsPeersSingleStopLossAllowed(t *testing.T) {
 	dir := t.TempDir()
+	// #484: the second peer must use stop_loss_pct:0 to opt out of auto-SL —
+	// omitting the field would auto-derive from max_drawdown_pct and create
+	// a second SL trigger that races with the first peer's trigger.
 	cfgJSON := `{
 		"strategies": [
 			{
@@ -1069,7 +1076,8 @@ func TestLoadConfigHLPerpsPeersSingleStopLossAllowed(t *testing.T) {
 				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
 				"capital": 500,
 				"leverage": 5,
-				"margin_mode": "isolated"
+				"margin_mode": "isolated",
+				"stop_loss_pct": 0
 			}
 		]
 	}`
@@ -1113,8 +1121,9 @@ func TestLoadConfigHLPerpsPeersDifferentCoinsIndependent(t *testing.T) {
 	}
 }
 
-// #491: zero-default stop_loss_pct on both peers must not trip the conflict
-// guard — the boundary between "no SL configured" and "SL conflict".
+// #491/#484: peers that both disable SL via explicit stop_loss_pct:0 must not
+// trip the conflict guard. Omitting the field auto-derives from MaxDrawdownPct
+// (#484), so disabling requires an explicit 0.
 func TestLoadConfigHLPerpsPeersNoStopLossAllowed(t *testing.T) {
 	dir := t.TempDir()
 	cfgJSON := `{
@@ -1127,7 +1136,8 @@ func TestLoadConfigHLPerpsPeersNoStopLossAllowed(t *testing.T) {
 				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
 				"capital": 1000,
 				"leverage": 5,
-				"margin_mode": "isolated"
+				"margin_mode": "isolated",
+				"stop_loss_pct": 0
 			},
 			{
 				"id": "hl-eth-breakout",
@@ -1137,13 +1147,14 @@ func TestLoadConfigHLPerpsPeersNoStopLossAllowed(t *testing.T) {
 				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
 				"capital": 500,
 				"leverage": 5,
-				"margin_mode": "isolated"
+				"margin_mode": "isolated",
+				"stop_loss_pct": 0
 			}
 		]
 	}`
 	path := writeTestConfig(t, dir, cfgJSON)
 	if _, err := LoadConfig(path); err != nil {
-		t.Fatalf("LoadConfig failed for two peers with no stop_loss_pct: %v", err)
+		t.Fatalf("LoadConfig failed for two peers with stop_loss_pct:0: %v", err)
 	}
 }
 
@@ -1152,6 +1163,7 @@ func TestLoadConfigHLPerpsPeersNoStopLossAllowed(t *testing.T) {
 // margin_mode:"" should match a peer with margin_mode:"isolated".
 func TestLoadConfigHLPerpsPeersDefaultedMarginModeMatches(t *testing.T) {
 	dir := t.TempDir()
+	// #484: disable auto-SL on one peer to avoid the SL-conflict error.
 	cfgJSON := `{
 		"strategies": [
 			{
@@ -1171,7 +1183,8 @@ func TestLoadConfigHLPerpsPeersDefaultedMarginModeMatches(t *testing.T) {
 				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
 				"capital": 500,
 				"leverage": 5,
-				"margin_mode": "isolated"
+				"margin_mode": "isolated",
+				"stop_loss_pct": 0
 			}
 		]
 	}`
@@ -1184,6 +1197,45 @@ func TestLoadConfigHLPerpsPeersDefaultedMarginModeMatches(t *testing.T) {
 		if sc.MarginMode != "isolated" {
 			t.Errorf("strategy %s margin_mode = %q, want %q", sc.ID, sc.MarginMode, "isolated")
 		}
+	}
+}
+
+// #484: two peers that both omit stop_loss_pct both auto-derive from
+// max_drawdown_pct; each would place a reduce-only SL trigger on the shared
+// on-chain position, so the config is rejected.
+func TestLoadConfigHLPerpsPeersAutoSLConflict(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [
+			{
+				"id": "hl-eth-trend",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+				"capital": 1000,
+				"leverage": 5,
+				"margin_mode": "isolated"
+			},
+			{
+				"id": "hl-eth-breakout",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
+				"capital": 500,
+				"leverage": 5,
+				"margin_mode": "isolated"
+			}
+		]
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected conflict error for two peers both auto-deriving SL from max_drawdown_pct")
+	}
+	if !strings.Contains(err.Error(), "conflicting stop_loss_pct") {
+		t.Errorf("error = %v, want 'conflicting stop_loss_pct'", err)
 	}
 }
 

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -113,11 +113,12 @@ func TestParseHyperliquidExecuteOutput_ErrorJSONPreserved(t *testing.T) {
 }
 
 func TestStrategyConfig_StopLossPctJSON(t *testing.T) {
+	v := 3.5
 	sc := StrategyConfig{
 		ID:          "hl-donch-btc",
 		Platform:    "hyperliquid",
 		Type:        "perps",
-		StopLossPct: 3.5,
+		StopLossPct: &v,
 	}
 	b, err := json.Marshal(sc)
 	if err != nil {
@@ -127,13 +128,28 @@ func TestStrategyConfig_StopLossPctJSON(t *testing.T) {
 	if err := json.Unmarshal(b, &round); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if round.StopLossPct != 3.5 {
+	if round.StopLossPct == nil || *round.StopLossPct != 3.5 {
 		t.Errorf("round-trip StopLossPct: got %v, want 3.5", round.StopLossPct)
 	}
-	// omitempty check: default-value config must not emit the field.
+	// omitempty check: nil pointer must not emit the field.
 	b2, _ := json.Marshal(StrategyConfig{ID: "x", Platform: "hyperliquid", Type: "perps"})
 	if containsKey(b2, "stop_loss_pct") {
-		t.Errorf("zero StopLossPct should be omitted; got %s", b2)
+		t.Errorf("nil StopLossPct should be omitted; got %s", b2)
+	}
+	// #484: pointer-vs-omitted distinction — explicit 0 must round-trip and
+	// re-emit, since it carries the operator's "disabled" semantic.
+	zero := 0.0
+	scZero := StrategyConfig{ID: "x", Platform: "hyperliquid", Type: "perps", StopLossPct: &zero}
+	b3, _ := json.Marshal(scZero)
+	if !containsKey(b3, "stop_loss_pct") {
+		t.Errorf("explicit zero StopLossPct must be preserved in JSON; got %s", b3)
+	}
+	var roundZero StrategyConfig
+	if err := json.Unmarshal(b3, &roundZero); err != nil {
+		t.Fatalf("unmarshal zero: %v", err)
+	}
+	if roundZero.StopLossPct == nil || *roundZero.StopLossPct != 0 {
+		t.Errorf("round-trip explicit-zero StopLossPct: got %v, want 0 (non-nil)", roundZero.StopLossPct)
 	}
 }
 
@@ -246,7 +262,8 @@ func TestIsHLOpenOrderCapRejection(t *testing.T) {
 func TestValidateConfig_StopLossPctBounds(t *testing.T) {
 	// Issue 421 (review point 4): hand-edited configs with out-of-range
 	// stop_loss_pct must fail validation rather than silently break the
-	// safety feature.
+	// safety feature. Pointer-aware (#484): explicit 0 is the operator
+	// opt-out, valid; nil = field omitted (auto-derive path).
 	cases := []struct {
 		name      string
 		pct       float64
@@ -254,7 +271,7 @@ func TestValidateConfig_StopLossPctBounds(t *testing.T) {
 		typ       string
 		wantError bool
 	}{
-		{"zero ok", 0, "hyperliquid", "perps", false},
+		{"explicit zero ok (disabled)", 0, "hyperliquid", "perps", false},
 		{"in range", 5, "hyperliquid", "perps", false},
 		{"max boundary", 50, "hyperliquid", "perps", false},
 		{"too high", 200, "hyperliquid", "perps", true},
@@ -264,6 +281,7 @@ func TestValidateConfig_StopLossPctBounds(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			pct := c.pct
 			cfg := &Config{
 				IntervalSeconds: 60,
 				Strategies: []StrategyConfig{
@@ -274,7 +292,7 @@ func TestValidateConfig_StopLossPctBounds(t *testing.T) {
 						Script:         "shared_scripts/check_hyperliquid.py",
 						Capital:        1000,
 						MaxDrawdownPct: 10,
-						StopLossPct:    c.pct,
+						StopLossPct:    &pct,
 					},
 				},
 				PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 60},
@@ -611,24 +629,39 @@ func TestForceCloseHyperliquidLive_CancelsAllSharedCoinStopLossOIDs(t *testing.T
 	}
 }
 
-// #487: EffectiveStopLossPct returns the price % to send to the HL execute
-// helper. It must (a) honor an explicit StopLossPct, (b) derive price % from
-// StopLossMarginPct / Leverage when only the margin form is set, (c) prefer
-// StopLossPct when both are set (validation rejects this combo before runtime,
-// but the helper must stay deterministic), and (d) fail safe at 0 when the
-// margin path lacks a positive leverage divisor.
+// #487/#484: EffectiveStopLossPct returns the price % to send to the HL execute
+// helper. Resolution order: explicit StopLossPct → StopLossMarginPct/Leverage →
+// MaxDrawdownPct fallback (capped at MaxAutoStopLossPct). Each pointer field
+// distinguishes nil (omitted, fall through) from explicit 0 (disabled).
+// Non-HL/non-perps strategies always return 0.
 func TestEffectiveStopLossPct(t *testing.T) {
+	hlPerps := func(sc StrategyConfig) StrategyConfig {
+		sc.Platform = "hyperliquid"
+		sc.Type = "perps"
+		return sc
+	}
+	pf := func(v float64) *float64 { return &v }
 	cases := []struct {
 		name string
 		sc   StrategyConfig
 		want float64
 	}{
-		{"unset", StrategyConfig{Leverage: 5}, 0},
-		{"explicit pct", StrategyConfig{StopLossPct: 1.5, Leverage: 5}, 1.5},
-		{"margin pct at 20x", StrategyConfig{StopLossMarginPct: 20, Leverage: 20}, 1.0},
-		{"margin pct at 10x rescales", StrategyConfig{StopLossMarginPct: 20, Leverage: 10}, 2.0},
-		{"margin pct without leverage fails safe", StrategyConfig{StopLossMarginPct: 20}, 0},
-		{"explicit wins over margin", StrategyConfig{StopLossPct: 3, StopLossMarginPct: 20, Leverage: 10}, 3},
+		{"non-HL returns 0", StrategyConfig{Platform: "okx", Type: "perps", StopLossPct: pf(1.5)}, 0},
+		{"non-perps returns 0", StrategyConfig{Platform: "hyperliquid", Type: "spot", StopLossPct: pf(1.5)}, 0},
+		{"unset and no drawdown", hlPerps(StrategyConfig{Leverage: 5}), 0},
+		{"explicit pct", hlPerps(StrategyConfig{StopLossPct: pf(1.5), Leverage: 5}), 1.5},
+		{"explicit zero is disabled (no fallback)", hlPerps(StrategyConfig{StopLossPct: pf(0), MaxDrawdownPct: 5, Leverage: 5}), 0},
+		{"margin pct at 20x", hlPerps(StrategyConfig{StopLossMarginPct: pf(20), Leverage: 20}), 1.0},
+		{"margin pct at 10x rescales", hlPerps(StrategyConfig{StopLossMarginPct: pf(20), Leverage: 10}), 2.0},
+		{"margin pct without leverage fails safe", hlPerps(StrategyConfig{StopLossMarginPct: pf(20)}), 0},
+		{"explicit-zero margin disables (no fallback)", hlPerps(StrategyConfig{StopLossMarginPct: pf(0), MaxDrawdownPct: 7, Leverage: 5}), 0},
+		{"explicit wins over margin", hlPerps(StrategyConfig{StopLossPct: pf(3), StopLossMarginPct: pf(20), Leverage: 10}), 3},
+		// #484 fallback path.
+		{"drawdown fallback when both nil", hlPerps(StrategyConfig{MaxDrawdownPct: 5, Leverage: 5}), 5},
+		{"drawdown fallback capped at 50", hlPerps(StrategyConfig{MaxDrawdownPct: 60, Leverage: 5}), 50},
+		{"drawdown fallback at cap boundary", hlPerps(StrategyConfig{MaxDrawdownPct: 50, Leverage: 5}), 50},
+		{"drawdown fallback ignored when explicit set", hlPerps(StrategyConfig{StopLossPct: pf(2), MaxDrawdownPct: 10}), 2},
+		{"margin fallthrough beats drawdown", hlPerps(StrategyConfig{StopLossMarginPct: pf(20), MaxDrawdownPct: 5, Leverage: 20}), 1.0},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -647,47 +680,54 @@ func TestValidateConfig_StopLossMarginPctBounds(t *testing.T) {
 	cases := []struct {
 		name      string
 		marginPct float64
+		setMargin bool
 		pricePct  float64
+		setPrice  bool
 		leverage  float64
 		platform  string
 		typ       string
 		wantError bool
 	}{
-		{"zero (disabled)", 0, 0, 10, "hyperliquid", "perps", false},
-		{"in range", 20, 0, 10, "hyperliquid", "perps", false},
-		{"max boundary at 10x leverage", 100, 0, 10, "hyperliquid", "perps", false},
-		{"too high", 150, 0, 10, "hyperliquid", "perps", true},
-		{"negative", -1, 0, 10, "hyperliquid", "perps", true},
-		{"non-HL platform", 20, 0, 10, "okx", "perps", true},
-		{"non-perps type", 20, 0, 10, "hyperliquid", "spot", true},
-		{"mutually exclusive", 20, 1, 10, "hyperliquid", "perps", true},
+		{"explicit zero disables", 0, true, 0, false, 10, "hyperliquid", "perps", false},
+		{"in range", 20, true, 0, false, 10, "hyperliquid", "perps", false},
+		{"max boundary at 10x leverage", 100, true, 0, false, 10, "hyperliquid", "perps", false},
+		{"too high", 150, true, 0, false, 10, "hyperliquid", "perps", true},
+		{"negative", -1, true, 0, false, 10, "hyperliquid", "perps", true},
+		{"non-HL platform", 20, true, 0, false, 10, "okx", "perps", true},
+		{"non-perps type", 20, true, 0, false, 10, "hyperliquid", "spot", true},
+		{"mutually exclusive", 20, true, 1, true, 10, "hyperliquid", "perps", true},
 		// Derived price stop must mirror the #421 [0, 50] cap: at leverage=1
 		// a marginPct of 80 implies an 80% price stop, which would land the
 		// HL trigger at entry×0 (long) or entry×1.8 (short) and silently
 		// never fire.
-		{"derived price stop exceeds 50% cap", 80, 0, 1, "hyperliquid", "perps", true},
+		{"derived price stop exceeds 50% cap", 80, true, 0, false, 1, "hyperliquid", "perps", true},
 		// Edge of the derived cap: marginPct=50 at leverage=1 is exactly 50%
 		// and must be accepted (matches the inclusive #421 upper bound).
-		{"derived price stop at 50% cap", 50, 0, 1, "hyperliquid", "perps", false},
+		{"derived price stop at 50% cap", 50, true, 0, false, 1, "hyperliquid", "perps", false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			sc := StrategyConfig{
+				ID:             "test",
+				Type:           c.typ,
+				Platform:       c.platform,
+				Script:         "shared_scripts/check_hyperliquid.py",
+				Capital:        1000,
+				MaxDrawdownPct: 10,
+				Leverage:       c.leverage,
+			}
+			if c.setMargin {
+				m := c.marginPct
+				sc.StopLossMarginPct = &m
+			}
+			if c.setPrice {
+				p := c.pricePct
+				sc.StopLossPct = &p
+			}
 			cfg := &Config{
 				IntervalSeconds: 60,
-				Strategies: []StrategyConfig{
-					{
-						ID:                "test",
-						Type:              c.typ,
-						Platform:          c.platform,
-						Script:            "shared_scripts/check_hyperliquid.py",
-						Capital:           1000,
-						MaxDrawdownPct:    10,
-						Leverage:          c.leverage,
-						StopLossPct:       c.pricePct,
-						StopLossMarginPct: c.marginPct,
-					},
-				},
-				PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 60},
+				Strategies:      []StrategyConfig{sc},
+				PortfolioRisk:   &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 60},
 			}
 			err := ValidateConfig(cfg)
 			gotErr := err != nil && strings.Contains(err.Error(), "stop_loss")
@@ -701,12 +741,13 @@ func TestValidateConfig_StopLossMarginPctBounds(t *testing.T) {
 // #487: zero StopLossMarginPct must be omitted from the JSON encoding so
 // existing configs don't grow a noisy field after a round-trip.
 func TestStrategyConfig_StopLossMarginPctJSON(t *testing.T) {
+	v := 25.0
 	sc := StrategyConfig{
 		ID:                "hl-test",
 		Type:              "perps",
 		Platform:          "hyperliquid",
 		Leverage:          20,
-		StopLossMarginPct: 25,
+		StopLossMarginPct: &v,
 	}
 	b, err := json.Marshal(sc)
 	if err != nil {
@@ -719,16 +760,31 @@ func TestStrategyConfig_StopLossMarginPctJSON(t *testing.T) {
 	if err := json.Unmarshal(b, &round); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if round.StopLossMarginPct != 25 {
+	if round.StopLossMarginPct == nil || *round.StopLossMarginPct != 25 {
 		t.Errorf("round-trip StopLossMarginPct: got %v, want 25", round.StopLossMarginPct)
 	}
 
-	sc.StopLossMarginPct = 0
+	// nil pointer (omitted) must not emit the field — operator hasn't opted
+	// in or out, auto-derive path applies.
+	sc.StopLossMarginPct = nil
 	b2, err := json.Marshal(sc)
+	if err != nil {
+		t.Fatalf("marshal nil: %v", err)
+	}
+	if strings.Contains(string(b2), "stop_loss_margin_pct") {
+		t.Errorf("nil StopLossMarginPct should be omitted; got %s", b2)
+	}
+
+	// #484: explicit zero is the "operator opt-out" semantic and must be
+	// preserved in JSON so a config round-trip doesn't silently re-enable
+	// the auto-SL fallback.
+	zero := 0.0
+	sc.StopLossMarginPct = &zero
+	b3, err := json.Marshal(sc)
 	if err != nil {
 		t.Fatalf("marshal zero: %v", err)
 	}
-	if strings.Contains(string(b2), "stop_loss_margin_pct") {
-		t.Errorf("zero StopLossMarginPct should be omitted; got %s", b2)
+	if !strings.Contains(string(b3), `"stop_loss_margin_pct":0`) {
+		t.Errorf("explicit zero StopLossMarginPct must round-trip; got %s", b3)
 	}
 }

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -696,6 +696,11 @@ func TestValidateConfig_StopLossMarginPctBounds(t *testing.T) {
 		{"non-HL platform", 20, true, 0, false, 10, "okx", "perps", true},
 		{"non-perps type", 20, true, 0, false, 10, "hyperliquid", "spot", true},
 		{"mutually exclusive", 20, true, 1, true, 10, "hyperliquid", "perps", true},
+		// #484/#487: both fields explicit-zero is benign — both mean "disabled"
+		// and neither places a trigger at runtime, so the mutual-exclusion
+		// guard must not fire. Operators may end up here after migrating from
+		// the legacy float StopLossPct semantics.
+		{"both explicit zero is benign", 0, true, 0, true, 10, "hyperliquid", "perps", false},
 		// Derived price stop must mirror the #421 [0, 50] cap: at leverage=1
 		// a marginPct of 80 implies an 80% price stop, which would land the
 		// HL trigger at entry×0 (long) or entry×1.8 (short) and silently

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -302,9 +302,9 @@ type InitOptions struct {
 	SpotCapital             float64
 	OptionsCapital          float64
 	PerpsCapital            float64
-	PerpsLeverage           float64 // perps leverage multiplier (default 1 = no leverage) (#254)
-	HLStopLossPct           float64 // HL perps only: per-trade stop-loss % from entry (0 = disabled) (#412)
-	HLStopLossMarginPct     float64 // HL perps only: per-trade stop-loss as % of deployed margin (0 = disabled); mutually exclusive with HLStopLossPct (#487)
+	PerpsLeverage           float64  // perps leverage multiplier (default 1 = no leverage) (#254)
+	HLStopLossPct           *float64 // HL perps only: per-trade stop-loss % from entry. nil = auto-derive from MaxDrawdownPct (#484); explicit 0 = disabled; >0 = override (#412)
+	HLStopLossMarginPct     *float64 // HL perps only: per-trade stop-loss as % of deployed margin. nil = auto-derive; explicit 0 = disabled; mutually exclusive with HLStopLossPct (#487, #484)
 	SpotDrawdown            float64
 	OptionsDrawdown         float64
 	PerpsDrawdown           float64
@@ -501,9 +501,9 @@ func generateConfig(opts InitOptions) *Config {
 					IntervalSeconds:   3600,
 					Leverage:          perpsLeverage,
 					AllowShorts:       allowShorts,
-					StopLossPct:       opts.HLStopLossPct,
-					StopLossMarginPct: opts.HLStopLossMarginPct,
-					MarginMode:        "isolated", // #486: hard-cap loss per position; cross would let one strategy drain another's margin
+					StopLossPct:       opts.HLStopLossPct,       // *float64 — nil falls through to MaxDrawdownPct (#484)
+					StopLossMarginPct: opts.HLStopLossMarginPct, // *float64 — nil falls through (#484/#487)
+					MarginMode:        "isolated",               // #486: hard-cap loss per position; cross would let one strategy drain another's margin
 				})
 			}
 		}
@@ -1084,9 +1084,9 @@ func runInit(args []string) int {
 	spotDrawdown := 5.0
 	optionsDrawdown := 10.0
 	perpsDrawdown := 5.0
-	perpsLeverage := 1.0       // #254 default: 1x (no leverage); user can edit config
-	hlStopLossPct := 0.0       // #412 default: disabled; prompted below whenever HL perps is enabled (paper or live)
-	hlStopLossMarginPct := 0.0 // #487 default: disabled; alternative leverage-aware framing
+	perpsLeverage := 1.0             // #254 default: 1x (no leverage); user can edit config
+	var hlStopLossPct *float64       // #484 default: nil → auto-derive from MaxDrawdownPct; set via wizard for an explicit override or opt-out
+	var hlStopLossMarginPct *float64 // #487/#484 same semantics — nil = auto, explicit 0 = disabled, >0 = leverage-aware override
 	robinhoodCapital := 500.0
 	robinhoodDrawdown := 5.0
 	lunoCapital := 500.0
@@ -1133,27 +1133,32 @@ func runInit(args []string) int {
 		portfolioWarnPct = p.FloatRange("Portfolio warn threshold % (of kill switch)", 60, 0, 100)
 	}
 
-	// #412 / #487: per-trade stop-loss is HL-only today and is a no-op in paper
-	// mode (no on-chain trigger order is placed), but we still prompt for paper
-	// configs so operators iterating in paper and later flipping to live by
-	// editing config don't silently lose the SL — the field is already set.
-	// Default 0 disables it; HL caps trigger orders at 1000/account (scales to
-	// 5000 with volume) and we start disabled by default until the operator
-	// explicitly opts in (#479). Two equivalent framings:
+	// #484: HL perps per-trade SL is auto-derived from each strategy's
+	// max_drawdown_pct by default (capped at 50%), so a strategy with
+	// max_drawdown_pct=5 opens every position with a 5% reduce-only trigger
+	// without any extra knob. Operators can still override with an explicit
+	// price % or leverage-aware margin %. The "Disabled" option exists for
+	// strategies that intentionally want no exchange-side stop.
 	//   - price %:  trigger when price moves X% against entry (#412)
 	//   - margin %: trigger when unrealized loss reaches X% of deployed
 	//               margin; auto-rescales when leverage changes (#487)
 	if enablePerps {
 		slOptions := []string{
-			"Disabled",
+			"Auto (derive from per-strategy max_drawdown_pct)",
 			"Price % from entry (e.g. 1.0 = trigger on 1% adverse move)",
 			"% of deployed margin (leverage-aware; e.g. 20 = trigger on 20% margin loss)",
+			"Explicitly disabled (no exchange-side stop-loss)",
 		}
 		switch p.Choice("HL perps per-trade stop-loss framing", slOptions, 0) {
 		case 1:
-			hlStopLossPct = p.FloatRange("HL perps per-trade stop-loss % from entry", 1, 0, 50)
+			v := p.FloatRange("HL perps per-trade stop-loss % from entry", 1, 0, 50)
+			hlStopLossPct = &v
 		case 2:
-			hlStopLossMarginPct = p.FloatRange("HL perps per-trade stop-loss % of deployed margin", 20, 0, 100)
+			v := p.FloatRange("HL perps per-trade stop-loss % of deployed margin", 20, 0, 100)
+			hlStopLossMarginPct = &v
+		case 3:
+			zero := 0.0
+			hlStopLossPct = &zero
 		}
 	}
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2045,10 +2045,12 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 		cancelOID = existingStopLossOID
 	}
 	var slPct float64
-	if !pureClose && sc.Platform == "hyperliquid" {
-		// EffectiveStopLossPct returns the explicit price % or derives it from
-		// stop_loss_margin_pct / leverage (#487). Validation in config.go
-		// guarantees the two fields are mutually exclusive.
+	if !pureClose {
+		// EffectiveStopLossPct self-guards on platform/type and returns the
+		// explicit price %, derives it from stop_loss_margin_pct / leverage
+		// (#487), or falls back to max_drawdown_pct capped at 50% (#484).
+		// Validation in config.go guarantees stop_loss_pct and
+		// stop_loss_margin_pct are mutually exclusive.
 		slPct = EffectiveStopLossPct(sc)
 	}
 	var prevPosQty float64


### PR DESCRIPTION
## Summary
- `EffectiveStopLossPct` now falls through to `MaxDrawdownPct` (capped at 50%) when neither `stop_loss_pct` nor `stop_loss_margin_pct` is set, so HL perps strategies auto-get an exchange-side stop on every open
- `StopLossPct` / `StopLossMarginPct` → `*float64` to distinguish "omitted" (auto) from "explicit 0" (operator opt-out)
- Init wizard choices: Auto / Price% / Margin% / Explicitly disabled

Closing #484

## Test plan
- [x] `go test ./...` passes
- [ ] Smoke-test `./go-trader init --json ...` on a fresh perps config
- [ ] Verify a config with no `stop_loss_pct` now opens HL positions with a derived trigger
- [ ] Verify a config with `"stop_loss_pct": 0` stays disabled

---
LLM: Claude Opus 4.7 (1M) | high | Tokens: 92 in / 38364 out | Cache: 5849334 read / 193037 written | Cost: $5.09