### PR TITLE
Fix HL stop-loss defaults for shared peers

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -206,8 +206,8 @@ type StrategyConfig struct {
 	HTFFilter            bool                   `json:"htf_filter,omitempty"`           // higher-timeframe trend filter
 	AllowShorts          bool                   `json:"allow_shorts,omitempty"`         // perps only: opt-in to bidirectional execution — signal=-1 from flat opens a short, long+(-1) closes-and-flips. Default false preserves close-long-only behavior for strategies like triple_ema that emit -1 only as a long-exit (#328)
 	Leverage             float64                `json:"leverage,omitempty"`             // perps leverage multiplier (default 1 = no leverage); used for notional sizing and margin-based valuation (#254)
-	StopLossPct          *float64               `json:"stop_loss_pct,omitempty"`        // HL perps only: % from entry to place a reduce-only stop-loss trigger. Pointer so omitted (nil) falls through to StopLossMarginPct then MaxDrawdownPct (#484); explicit 0 disables auto-SL (#412)
-	StopLossMarginPct    *float64               `json:"stop_loss_margin_pct,omitempty"` // HL perps only: % of deployed margin to lose before stop-loss trigger; mutually exclusive with stop_loss_pct; price % derived as StopLossMarginPct / Leverage at order time. Pointer so omitted falls through to MaxDrawdownPct; explicit 0 disables (#487, #484)
+	StopLossPct          *float64               `json:"stop_loss_pct,omitempty"`        // HL perps only: % from entry to place a reduce-only stop-loss trigger. Pointer so omitted (nil) falls through to StopLossMarginPct then MaxDrawdownPct for single-coin strategies (#484); LoadConfig normalizes omitted same-coin peers to explicit 0 (#494); explicit 0 disables auto-SL (#412)
+	StopLossMarginPct    *float64               `json:"stop_loss_margin_pct,omitempty"` // HL perps only: % of deployed margin to lose before stop-loss trigger; mutually exclusive with stop_loss_pct; price % derived as StopLossMarginPct / Leverage at order time. Pointer so omitted falls through to MaxDrawdownPct for single-coin strategies; LoadConfig normalizes omitted same-coin peers to explicit 0 (#494); explicit 0 disables (#487, #484)
 	MarginMode           string                 `json:"margin_mode,omitempty"`          // HL perps only: "isolated" (default) or "cross"; sent via update_leverage on fresh opens to enforce per-position liq isolation (#486)
 	Params               map[string]interface{} `json:"params,omitempty"`               // custom strategy parameters passed to Python
 	ThetaHarvest         *ThetaHarvestConfig    `json:"theta_harvest,omitempty"`
@@ -227,6 +227,10 @@ const MaxAutoStopLossPct = 50.0
 //  3. MaxDrawdownPct as a fallback so any HL perps strategy with a configured
 //     drawdown automatically gets exchange-side protection. Capped at
 //     MaxAutoStopLossPct.
+//
+// LoadConfig normalizes omitted stop_loss_* fields to explicit 0 for same-coin
+// HL peer strategies (#494), so the fallback is used at runtime only for
+// strategies that are sole owners of a coin or explicitly retain a positive SL.
 //
 // HL perps only — returns 0 for non-HL platforms or non-perps types so the
 // caller can skip the trigger placement unconditionally.
@@ -416,6 +420,7 @@ func LoadConfig(path string) (*Config, error) {
 			fmt.Printf("[INFO] %s: no theta_harvest config, applying defaults (profit=60%%, stop=200%%, dte=3)\n", cfg.Strategies[i].ID)
 		}
 	}
+	normalizeHyperliquidPeerStopLosses(cfg.Strategies)
 
 	// #42: Apply portfolio risk defaults if not configured.
 	if cfg.PortfolioRisk == nil {
@@ -441,6 +446,49 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+// normalizeHyperliquidPeerStopLosses preserves the single-strategy auto-SL
+// fallback while avoiding accidental reduce-only trigger races for same-coin
+// peer strategies (#494). When multiple HL perps strategies share a coin,
+// omitted stop_loss_* fields are treated as an explicit opt-out; operators can
+// still select one owner with a positive stop_loss_pct or stop_loss_margin_pct.
+func normalizeHyperliquidPeerStopLosses(strategies []StrategyConfig) {
+	type peerRef struct {
+		ID    string
+		Index int
+	}
+	groups := make(map[string][]peerRef)
+	for i, sc := range strategies {
+		if sc.Type != "perps" || sc.Platform != "hyperliquid" {
+			continue
+		}
+		coin := hyperliquidSymbol(sc.Args)
+		if coin == "" {
+			continue
+		}
+		groups[coin] = append(groups[coin], peerRef{ID: sc.ID, Index: i})
+	}
+
+	coins := make([]string, 0, len(groups))
+	for coin := range groups {
+		coins = append(coins, coin)
+	}
+	sort.Strings(coins)
+	for _, coin := range coins {
+		peers := groups[coin]
+		if len(peers) < 2 {
+			continue
+		}
+		sort.Slice(peers, func(i, j int) bool { return peers[i].ID < peers[j].ID })
+		for _, p := range peers {
+			sc := &strategies[p.Index]
+			if sc.StopLossPct == nil && sc.StopLossMarginPct == nil {
+				zero := 0.0
+				sc.StopLossPct = &zero
+			}
+		}
+	}
 }
 
 // hyperliquidPeerStrategyErrors returns validation messages for HL perps
@@ -470,7 +518,7 @@ func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 		Coin           string
 		MarginMode     string
 		Leverage       float64
-		EffectiveSLPct float64 // resolved via EffectiveStopLossPct: nil→auto from MaxDrawdownPct, 0→disabled, >0→explicit
+		EffectiveSLPct float64 // resolved after LoadConfig peer normalization: >0 means this strategy owns a trigger
 	}
 	groups := make(map[string][]peer)
 	for _, sc := range strategies {
@@ -783,8 +831,9 @@ func ValidateConfig(cfg *Config) error {
 		// A hand-edited config with stop_loss_pct=200 would otherwise silently
 		// place an SL at $0 (long) or 3× entry (short) — both never trigger,
 		// breaking the safety feature without any warning. Pointer-aware (#484):
-		// nil means the field was omitted (auto-SL falls through to margin/DD);
-		// explicit 0 means the operator opted out and is allowed.
+		// nil means the field was omitted (auto-SL falls through to margin/DD
+		// for single-coin strategies); explicit 0 means the operator opted out
+		// and is allowed. LoadConfig rewrites omitted same-coin peers to 0 (#494).
 		if sc.StopLossPct != nil {
 			pct := *sc.StopLossPct
 			if pct < 0 || pct > 50 {

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -224,13 +224,11 @@ const MaxAutoStopLossPct = 50.0
 // trigger for a given strategy. Resolution order (#484):
 //  1. Explicit StopLossPct (nil → fall through; explicit 0 → disabled).
 //  2. StopLossMarginPct / Leverage (nil → fall through; explicit 0 → disabled).
-//  3. MaxDrawdownPct as a fallback so any HL perps strategy with a configured
-//     drawdown automatically gets exchange-side protection. Capped at
-//     MaxAutoStopLossPct.
-//
-// LoadConfig normalizes omitted stop_loss_* fields to explicit 0 for same-coin
-// HL peer strategies (#494), so the fallback is used at runtime only for
-// strategies that are sole owners of a coin or explicitly retain a positive SL.
+//  3. MaxDrawdownPct as a fallback so a sole-owner HL perps strategy with a
+//     configured drawdown automatically gets exchange-side protection. Capped
+//     at MaxAutoStopLossPct. Only applies to single-strategy coins because
+//     LoadConfig normalizes omitted stop_loss_* fields to explicit 0 for
+//     same-coin HL peer strategies (#494).
 //
 // HL perps only — returns 0 for non-HL platforms or non-perps types so the
 // caller can skip the trigger placement unconditionally.
@@ -492,8 +490,10 @@ func normalizeHyperliquidPeerStopLosses(strategies []StrategyConfig) {
 }
 
 // hyperliquidPeerStrategyErrors returns validation messages for HL perps
-// strategies that share a coin but disagree on MarginMode, Leverage, or
-// StopLossPct (#491). Returns an empty slice when no peer conflicts exist.
+// strategies that share a coin but disagree on MarginMode or Leverage (#491),
+// or that have more than one stop-loss owner (EffectiveStopLossPct > 0 after
+// LoadConfig peer normalization, #494). Returns an empty slice when no peer
+// conflicts exist.
 //
 // HL aggregates positions per coin per account, so two go-trader strategies
 // on the same coin share an on-chain position, margin assignment, and

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -76,16 +76,15 @@ const v8DeprecationNotice = "**Note:** `discord.spot_summary_freq` and `discord.
 // v9 introduced auto-derivation of HL perps per-trade stop-loss from
 // max_drawdown_pct (#484). The field types changed from float64 to *float64
 // so omitted (nil) is distinguishable from explicit 0. Behavior change for
-// existing configs: any HL perps strategy without an explicit `stop_loss_pct`
-// or `stop_loss_margin_pct` will now place an exchange-side reduce-only
-// trigger on every fresh open (capped at 50%). Operators who relied on the
-// pre-v9 "no SL when field is omitted" behavior must set `"stop_loss_pct": 0`
-// explicitly to opt out.
+// existing configs: a single HL perps strategy on a coin without an explicit
+// `stop_loss_pct` or `stop_loss_margin_pct` will now place an exchange-side
+// reduce-only trigger on every fresh open (capped at 50%). Same-coin peer
+// groups are normalized at LoadConfig time so omitted fields opt out unless
+// the operator chooses one explicit stop-loss owner (#494).
 const v9DeprecationNotice = "**Note:** HL perps strategies now auto-derive a per-trade stop-loss from `max_drawdown_pct` " +
-	"(capped at 50%) when neither `stop_loss_pct` nor `stop_loss_margin_pct` is set. This means existing configs " +
-	"with an omitted `stop_loss_pct` will start placing reduce-only trigger orders on-chain (counts against HL's " +
-	"1000/account trigger cap). To preserve the old \"no exchange-side stop\" behavior, set `\"stop_loss_pct\": 0` " +
-	"explicitly on the affected strategies. See issue #484."
+	"(capped at 50%) when neither `stop_loss_pct` nor `stop_loss_margin_pct` is set and the strategy is the only " +
+	"HL perps strategy for that coin. Same-coin peer groups keep omitted fields as an exchange-side stop opt-out; " +
+	"choose one explicit positive stop-loss owner if you want a shared-position trigger. See issues #484 and #494."
 
 const v7DeprecationNotice = "**Note:** `dm_paper_trades` and `dm_live_trades` have been replaced by a `dm_channels` map. " +
 	"Paper trades use `dm_channels[\"<platform>-paper\"]`; live trades use `dm_channels[\"<platform>\"]`. " +

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -817,6 +817,32 @@ func TestLoadConfigHLPerpsDefaultsToIsolatedMargin(t *testing.T) {
 	}
 }
 
+// #494: a single HL perps strategy on a coin still auto-derives its
+// exchange-side stop-loss from max_drawdown_pct when stop_loss_* is omitted.
+func TestLoadConfigHLPerpsSingleStrategyAutoDerivesStopLoss(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"strategies": [{
+			"id": "hl-test-eth",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000,
+			"max_drawdown_pct": 10,
+			"leverage": 5
+		}]
+	}`
+	path := writeTestConfig(t, dir, cfgJSON)
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	if got := EffectiveStopLossPct(cfg.Strategies[0]); got != 10 {
+		t.Errorf("EffectiveStopLossPct = %g, want 10", got)
+	}
+}
+
 // #486: explicit cross margin mode is preserved.
 func TestLoadConfigHLPerpsExplicitCross(t *testing.T) {
 	dir := t.TempDir()
@@ -893,9 +919,8 @@ func TestLoadConfigMarginModeRejectsSpot(t *testing.T) {
 // share a single on-chain position. Matching peers load successfully.
 func TestLoadConfigHLPerpsPeersOnSameCoinMatching(t *testing.T) {
 	dir := t.TempDir()
-	// #484: omitting stop_loss_pct now auto-derives from max_drawdown_pct, so
-	// peers that both omit it would each place a SL trigger — a conflict.
-	// Use stop_loss_pct:0 on the second peer to disable auto-SL for that leg.
+	// #494: omitted stop_loss_* on same-coin peers is normalized to opt-out so
+	// existing multi-strategy configs don't all become stop-loss owners.
 	cfgJSON := `{
 		"strategies": [
 			{
@@ -916,8 +941,7 @@ func TestLoadConfigHLPerpsPeersOnSameCoinMatching(t *testing.T) {
 				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
 				"capital": 500,
 				"leverage": 5,
-				"margin_mode": "isolated",
-				"stop_loss_pct": 0
+				"margin_mode": "isolated"
 			}
 		]
 	}`
@@ -928,6 +952,11 @@ func TestLoadConfigHLPerpsPeersOnSameCoinMatching(t *testing.T) {
 	}
 	if len(cfg.Strategies) != 2 {
 		t.Fatalf("expected 2 strategies, got %d", len(cfg.Strategies))
+	}
+	for _, sc := range cfg.Strategies {
+		if got := EffectiveStopLossPct(sc); got != 0 {
+			t.Errorf("%s EffectiveStopLossPct = %g, want 0 for omitted same-coin peer", sc.ID, got)
+		}
 	}
 }
 
@@ -1052,9 +1081,8 @@ func TestLoadConfigHLPerpsPeersConflictingStopLoss(t *testing.T) {
 // two or more peers configure SLs that would race on the shared position.
 func TestLoadConfigHLPerpsPeersSingleStopLossAllowed(t *testing.T) {
 	dir := t.TempDir()
-	// #484: the second peer must use stop_loss_pct:0 to opt out of auto-SL —
-	// omitting the field would auto-derive from max_drawdown_pct and create
-	// a second SL trigger that races with the first peer's trigger.
+	// #494: an omitted same-coin peer is normalized to opt-out, while the
+	// explicit positive stop_loss_pct remains the sole trigger owner.
 	cfgJSON := `{
 		"strategies": [
 			{
@@ -1076,14 +1104,24 @@ func TestLoadConfigHLPerpsPeersSingleStopLossAllowed(t *testing.T) {
 				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
 				"capital": 500,
 				"leverage": 5,
-				"margin_mode": "isolated",
-				"stop_loss_pct": 0
+				"margin_mode": "isolated"
 			}
 		]
 	}`
 	path := writeTestConfig(t, dir, cfgJSON)
-	if _, err := LoadConfig(path); err != nil {
+	cfg, err := LoadConfig(path)
+	if err != nil {
 		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	got := map[string]float64{}
+	for _, sc := range cfg.Strategies {
+		got[sc.ID] = EffectiveStopLossPct(sc)
+	}
+	if got["hl-eth-trend"] != 3 {
+		t.Errorf("explicit owner EffectiveStopLossPct = %g, want 3", got["hl-eth-trend"])
+	}
+	if got["hl-eth-breakout"] != 0 {
+		t.Errorf("omitted peer EffectiveStopLossPct = %g, want 0", got["hl-eth-breakout"])
 	}
 }
 
@@ -1121,9 +1159,9 @@ func TestLoadConfigHLPerpsPeersDifferentCoinsIndependent(t *testing.T) {
 	}
 }
 
-// #491/#484: peers that both disable SL via explicit stop_loss_pct:0 must not
-// trip the conflict guard. Omitting the field auto-derives from MaxDrawdownPct
-// (#484), so disabling requires an explicit 0.
+// #491/#494: peers that disable SL via explicit stop_loss_pct:0 must not trip
+// the conflict guard. Explicit zero remains an opt-out even though omitted
+// same-coin peers are also normalized to opt-out.
 func TestLoadConfigHLPerpsPeersNoStopLossAllowed(t *testing.T) {
 	dir := t.TempDir()
 	cfgJSON := `{
@@ -1163,7 +1201,6 @@ func TestLoadConfigHLPerpsPeersNoStopLossAllowed(t *testing.T) {
 // margin_mode:"" should match a peer with margin_mode:"isolated".
 func TestLoadConfigHLPerpsPeersDefaultedMarginModeMatches(t *testing.T) {
 	dir := t.TempDir()
-	// #484: disable auto-SL on one peer to avoid the SL-conflict error.
 	cfgJSON := `{
 		"strategies": [
 			{
@@ -1183,8 +1220,7 @@ func TestLoadConfigHLPerpsPeersDefaultedMarginModeMatches(t *testing.T) {
 				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
 				"capital": 500,
 				"leverage": 5,
-				"margin_mode": "isolated",
-				"stop_loss_pct": 0
+				"margin_mode": "isolated"
 			}
 		]
 	}`
@@ -1200,10 +1236,9 @@ func TestLoadConfigHLPerpsPeersDefaultedMarginModeMatches(t *testing.T) {
 	}
 }
 
-// #484: two peers that both omit stop_loss_pct both auto-derive from
-// max_drawdown_pct; each would place a reduce-only SL trigger on the shared
-// on-chain position, so the config is rejected.
-func TestLoadConfigHLPerpsPeersAutoSLConflict(t *testing.T) {
+// #494: two peers that both omit stop_loss_* on the same coin are normalized
+// to explicit opt-out so old multi-strategy configs keep loading after v9.
+func TestLoadConfigHLPerpsPeersOmittedStopLossDoesNotConflict(t *testing.T) {
 	dir := t.TempDir()
 	cfgJSON := `{
 		"strategies": [
@@ -1230,12 +1265,14 @@ func TestLoadConfigHLPerpsPeersAutoSLConflict(t *testing.T) {
 		]
 	}`
 	path := writeTestConfig(t, dir, cfgJSON)
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected conflict error for two peers both auto-deriving SL from max_drawdown_pct")
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig failed for omitted same-coin stop_loss_* peers: %v", err)
 	}
-	if !strings.Contains(err.Error(), "conflicting stop_loss_pct") {
-		t.Errorf("error = %v, want 'conflicting stop_loss_pct'", err)
+	for _, sc := range cfg.Strategies {
+		if got := EffectiveStopLossPct(sc); got != 0 {
+			t.Errorf("%s EffectiveStopLossPct = %g, want 0", sc.ID, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Normalize omitted HL perps stop-loss fields to opt out for same-coin peer groups so upgraded configs keep loading.
- Preserve single-strategy auto-derived stop-loss behavior and explicit same-coin owner validation.
- Update v9 migration messaging and regression coverage for issue 494.

## Test plan
- [x] `cd scheduler && /opt/homebrew/bin/go test ./... -run 'TestLoadConfigHLPerps'`
- [x] `cd scheduler && /opt/homebrew/bin/go test ./...`
- [x] `cd scheduler && /opt/homebrew/bin/go build .`

Closes #494

LLM: GPT-5.5 | high

Made with [Cursor](https://cursor.com)