### PR TITLE
feat: add tema_cross and tema_cross_bd strategies

### DIFF
--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -333,6 +333,16 @@ DEFAULT_PARAM_RANGES = {
         "mid_period": [15, 21, 30],
         "long_period": [40, 55, 80],
     },
+    "tema_cross": {
+        "short_period": [3, 5, 8],
+        "mid_period": [10, 13, 18],
+        "long_period": [25, 34, 50],
+    },
+    "tema_cross_bd": {
+        "short_period": [3, 5, 8],
+        "mid_period": [10, 13, 18],
+        "long_period": [25, 34, 50],
+    },
     "rsi_macd_combo": {
         "rsi_period": [10, 14],
         "rsi_oversold": [30, 35, 40],

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -45,6 +45,8 @@ var knownShortNames = map[string]string{
 	"volume_weighted":       "vw",
 	"triple_ema":            "tema",
 	"triple_ema_bidir":      "temab",
+	"tema_cross":            "temac",
+	"tema_cross_bd":         "temacb",
 	"rsi_macd_combo":        "rmc",
 	"vol_mean_reversion":    "vol",
 	"momentum_options":      "mom",
@@ -76,6 +78,7 @@ var knownShortNames = map[string]string{
 // of skipping the signal (#328).
 var bidirectionalPerpsStrategies = map[string]bool{
 	"triple_ema_bidir": true,
+	"tema_cross_bd":    true,
 	"session_breakout": true,
 }
 
@@ -122,6 +125,7 @@ var defaultSpotStrategies = []stratDef{
 	{ID: "sweep_squeeze_combo", ShortName: "ssc"},
 	{ID: "adx_trend", ShortName: "adxt"},
 	{ID: "donchian_breakout", ShortName: "dbo"},
+	{ID: "tema_cross", ShortName: "temac"},
 }
 
 var defaultOptionsStrategies = []stratDef{
@@ -134,6 +138,7 @@ var defaultOptionsStrategies = []stratDef{
 var defaultPerpsStrategies = []stratDef{
 	{ID: "momentum", ShortName: "momentum"},
 	{ID: "triple_ema_bidir", ShortName: "temab"},
+	{ID: "tema_cross_bd", ShortName: "temacb"},
 	{ID: "chart_pattern", ShortName: "cpat"},
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 	{ID: "delta_neutral_funding", ShortName: "dnf"},
@@ -164,6 +169,8 @@ var defaultFuturesStrategies = []stratDef{
 	{ID: "adx_trend", ShortName: "adxt"},
 	{ID: "donchian_breakout", ShortName: "dbo"},
 	{ID: "session_breakout", ShortName: "sbo"},
+	{ID: "tema_cross", ShortName: "temac"},
+	{ID: "tema_cross_bd", ShortName: "temacb"},
 }
 
 // Supported CME futures symbols for the init wizard.

--- a/shared_strategies/registry.py
+++ b/shared_strategies/registry.py
@@ -319,6 +319,50 @@ def triple_ema_bidir_strategy(df: pd.DataFrame, short_period: int = 8, mid_perio
 
 
 @register(
+    "tema_cross",
+    "Triple EMA Crossover — EMA fast/mid cross with long EMA trend filter",
+    {"short_period": 5, "mid_period": 13, "long_period": 34},
+)
+def tema_cross_strategy(df: pd.DataFrame, short_period: int = 5, mid_period: int = 13, long_period: int = 34) -> pd.DataFrame:
+    result = df.copy()
+    result["ema_short"] = ema(result["close"], short_period)
+    result["ema_mid"] = ema(result["close"], mid_period)
+    result["ema_long"] = ema(result["close"], long_period)
+    uptrend = result["ema_mid"] > result["ema_long"]
+    bullish_cross = (result["ema_short"] > result["ema_mid"]) & (
+        result["ema_short"].shift(1) <= result["ema_mid"].shift(1)
+    )
+    result["position"] = np.where(uptrend & bullish_cross, 1, 0)
+    result["signal"] = result["position"].diff()
+    return result
+
+
+@register(
+    "tema_cross_bd",
+    "Triple EMA Crossover Bidirectional — long/short on cross with trend filter",
+    {"short_period": 5, "mid_period": 13, "long_period": 34},
+    platforms=("futures",),
+)
+def tema_cross_bd_strategy(df: pd.DataFrame, short_period: int = 5, mid_period: int = 13, long_period: int = 34) -> pd.DataFrame:
+    result = df.copy()
+    result["ema_short"] = ema(result["close"], short_period)
+    result["ema_mid"] = ema(result["close"], mid_period)
+    result["ema_long"] = ema(result["close"], long_period)
+    uptrend = result["ema_mid"] > result["ema_long"]
+    downtrend = result["ema_mid"] < result["ema_long"]
+    bullish_cross = (result["ema_short"] > result["ema_mid"]) & (
+        result["ema_short"].shift(1) <= result["ema_mid"].shift(1)
+    )
+    bearish_cross = (result["ema_short"] < result["ema_mid"]) & (
+        result["ema_short"].shift(1) >= result["ema_mid"].shift(1)
+    )
+    result["position"] = np.where(uptrend & bullish_cross, 1,
+                                 np.where(downtrend & bearish_cross, -1, 0))
+    result["signal"] = result["position"].diff().clip(-1, 1)
+    return result
+
+
+@register(
     "rsi_macd_combo",
     "RSI+MACD Combo \u2014 dual confirmation for higher quality signals",
     {"rsi_period": 14, "rsi_oversold": 35, "rsi_overbought": 65,
@@ -931,11 +975,11 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "pairs_spread", "squeeze_momentum", "atr_breakout", "amd_ifvg",
         "heikin_ashi_ema", "order_blocks", "vwap_reversion", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
-        "sweep_squeeze_combo", "adx_trend", "donchian_breakout",
+        "sweep_squeeze_combo", "adx_trend", "donchian_breakout", "tema_cross",
     ],
     "futures": [
         "sma_crossover", "ema_crossover", "bollinger_bands", "volume_weighted",
-        "triple_ema", "triple_ema_bidir", "rsi_macd_combo", "momentum",
+        "triple_ema", "triple_ema_bidir", "tema_cross", "tema_cross_bd", "rsi_macd_combo", "momentum",
         "mean_reversion", "rsi", "macd", "breakout", "stoch_rsi", "supertrend",
         "squeeze_momentum", "ichimoku_cloud", "atr_breakout", "amd_ifvg",
         "heikin_ashi_ema", "order_blocks", "vwap_reversion", "chart_pattern",

--- a/shared_strategies/registry.py
+++ b/shared_strategies/registry.py
@@ -332,8 +332,16 @@ def tema_cross_strategy(df: pd.DataFrame, short_period: int = 5, mid_period: int
     bullish_cross = (result["ema_short"] > result["ema_mid"]) & (
         result["ema_short"].shift(1) <= result["ema_mid"].shift(1)
     )
-    result["position"] = np.where(uptrend & bullish_cross, 1, 0)
-    result["signal"] = result["position"].diff()
+    bearish_cross = (result["ema_short"] < result["ema_mid"]) & (
+        result["ema_short"].shift(1) >= result["ema_mid"].shift(1)
+    )
+    # Position persists between cross events: enter long on bullish cross while uptrend,
+    # exit on the next bearish cross. Forward-fill carries the state across silent bars.
+    raw = pd.Series(np.nan, index=result.index)
+    raw[uptrend & bullish_cross] = 1
+    raw[bearish_cross] = 0
+    result["position"] = raw.ffill().fillna(0).astype(int)
+    result["signal"] = result["position"].diff().fillna(0).astype(int)
     return result
 
 
@@ -356,9 +364,16 @@ def tema_cross_bd_strategy(df: pd.DataFrame, short_period: int = 5, mid_period: 
     bearish_cross = (result["ema_short"] < result["ema_mid"]) & (
         result["ema_short"].shift(1) >= result["ema_mid"].shift(1)
     )
-    result["position"] = np.where(uptrend & bullish_cross, 1,
-                                 np.where(downtrend & bearish_cross, -1, 0))
-    result["signal"] = result["position"].diff().clip(-1, 1)
+    # Position persists between cross events; opposite-direction cross with confirming
+    # trend flips the position, otherwise it flattens on the unconfirmed cross.
+    raw = pd.Series(np.nan, index=result.index)
+    raw[uptrend & bullish_cross] = 1
+    raw[downtrend & bearish_cross] = -1
+    raw[(~uptrend) & bullish_cross] = 0
+    raw[(~downtrend) & bearish_cross] = 0
+    result["position"] = raw.ffill().fillna(0).astype(int)
+    # A direct long→short flip yields diff == -2; clamp so downstream sees {-1, 0, 1}.
+    result["signal"] = result["position"].diff().fillna(0).clip(-1, 1).astype(int)
     return result
 
 

--- a/shared_strategies/test_tema_cross.py
+++ b/shared_strategies/test_tema_cross.py
@@ -1,0 +1,152 @@
+"""Tests for tema_cross and tema_cross_bd strategies in registry.py."""
+
+import importlib.util
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def make_ohlcv(closes, volume=None, noise=0.5):
+    closes = np.array(closes, dtype=float)
+    n = len(closes)
+    if volume is None:
+        volume = np.full(n, 100.0)
+    return pd.DataFrame({
+        "open": closes - noise * 0.3,
+        "high": closes + noise,
+        "low": closes - noise,
+        "close": closes,
+        "volume": np.array(volume, dtype=float),
+    })
+
+
+def _load_registry():
+    spec = importlib.util.spec_from_file_location(
+        "_registry_tema_cross", os.path.join(_HERE, "registry.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def registry():
+    return _load_registry()
+
+
+def _oscillating_uptrend(n=200, start=100.0, drift=0.4, amp=3.0, period=20, seed=0):
+    """Linear uptrend with sinusoidal oscillation so ema_short crosses ema_mid repeatedly."""
+    t = np.arange(n)
+    rng = np.random.RandomState(seed)
+    return start + t * drift + amp * np.sin(2 * np.pi * t / period) + rng.randn(n) * 0.05
+
+
+def _oscillating_downtrend(n=200, start=200.0, drift=0.4, amp=3.0, period=20, seed=0):
+    t = np.arange(n)
+    rng = np.random.RandomState(seed)
+    return start - t * drift + amp * np.sin(2 * np.pi * t / period) + rng.randn(n) * 0.05
+
+
+def _trend_up_then_down(up_n=200, down_n=200, start=100.0, amp=3.0, period=20):
+    up = _oscillating_uptrend(up_n, start=start, amp=amp, period=period)
+    down = _oscillating_downtrend(down_n, start=up[-1], amp=amp, period=period)
+    return np.concatenate([up, down])
+
+
+# ─── tema_cross (long-only) ─────────────────────────────────────────────
+
+
+def test_tema_cross_emits_buy_during_uptrend(registry):
+    """A run-up after a downtrend should fire a buy on the bullish cross."""
+    prices = _oscillating_uptrend(200, start=100.0)
+    df = make_ohlcv(prices)
+    result = registry.tema_cross_strategy(df)
+    assert (result["signal"] == 1).any(), "Expected a buy signal on bullish cross during uptrend"
+
+
+def test_tema_cross_position_persists_between_crosses(registry):
+    """Position must hold at 1 across silent bars between bullish and bearish cross."""
+    prices = _trend_up_then_down(150, 100, start=100.0)
+    df = make_ohlcv(prices)
+    result = registry.tema_cross_strategy(df)
+    assert (result["signal"] == 1).any(), "Expected an entry"
+    # After the first +1 signal and before any -1, position should equal 1 on multiple bars.
+    entry_idx = result.index[result["signal"] == 1][0]
+    after_entry = result.loc[entry_idx:]
+    in_position = after_entry["position"] == 1
+    # At least 5 consecutive in-position bars proves persistence vs single-bar bug.
+    assert in_position.sum() > 5, (
+        f"Position only held for {in_position.sum()} bars after entry — should persist until bearish cross"
+    )
+
+
+def test_tema_cross_exits_on_bearish_cross(registry):
+    """An uptrend followed by a sustained downtrend should produce a -1 exit signal."""
+    prices = _trend_up_then_down(120, 120, start=100.0)
+    df = make_ohlcv(prices)
+    result = registry.tema_cross_strategy(df)
+    assert (result["signal"] == 1).any()
+    assert (result["signal"] == -1).any(), "Expected an exit on the bearish cross"
+
+
+def test_tema_cross_no_short_entries(registry):
+    """Long-only strategy must never go to position == -1."""
+    prices = _trend_up_then_down(120, 120, start=100.0)
+    df = make_ohlcv(prices)
+    result = registry.tema_cross_strategy(df)
+    assert (result["position"] >= 0).all(), "tema_cross must be long-only"
+
+
+def test_tema_cross_flat_market_no_signals(registry):
+    """A flat market should produce no entry signals."""
+    df = make_ohlcv(np.full(200, 100.0), noise=0)
+    result = registry.tema_cross_strategy(df)
+    # No bullish cross can fire when EMAs converge to the same flat value.
+    assert not (result["signal"] == 1).any()
+
+
+# ─── tema_cross_bd (bidirectional) ───────────────────────────────────────
+
+
+def test_tema_cross_bd_emits_long_in_uptrend(registry):
+    prices = _oscillating_uptrend(200, start=100.0)
+    df = make_ohlcv(prices)
+    result = registry.tema_cross_bd_strategy(df)
+    assert (result["signal"] == 1).any()
+
+
+def test_tema_cross_bd_emits_short_in_downtrend(registry):
+    # Prime EMAs with an uptrend, then a sharp dump to push ema_mid below ema_long
+    # (confirmed downtrend), then a small oscillating drift down so bearish crosses
+    # keep firing while the downtrend remains confirmed.
+    up = _oscillating_uptrend(120, start=100.0, drift=0.6, amp=2.0)
+    dump = np.linspace(up[-1], up[-1] - 60.0, 80)
+    rng = np.random.RandomState(0)
+    t = np.arange(400)
+    grind = dump[-1] - 0.05 * t + 1.5 * np.sin(2 * np.pi * t / 25) + rng.randn(400) * 0.05
+    prices = np.concatenate([up, dump, grind])
+    df = make_ohlcv(prices)
+    result = registry.tema_cross_bd_strategy(df)
+    assert (result["signal"] == -1).any(), "Expected a short entry on bearish cross during downtrend"
+    assert (result["position"] == -1).any(), "Expected position to take -1 (short)"
+
+
+def test_tema_cross_bd_position_persists(registry):
+    """Position must hold across silent bars between confirmed crosses."""
+    prices = _trend_up_then_down(150, 150, start=100.0)
+    df = make_ohlcv(prices)
+    result = registry.tema_cross_bd_strategy(df)
+    long_bars = (result["position"] == 1).sum()
+    assert long_bars > 5, f"Long position only held {long_bars} bars — should persist between crosses"
+
+
+def test_tema_cross_bd_signal_bounded(registry):
+    """Signal must be in {-1, 0, 1} even on direct long→short flips."""
+    prices = _trend_up_then_down(100, 100, start=100.0)
+    df = make_ohlcv(prices)
+    result = registry.tema_cross_bd_strategy(df)
+    assert result["signal"].isin([-1, 0, 1]).all(), "Signal values must be clamped to {-1, 0, 1}"


### PR DESCRIPTION
## Summary

- Adds `tema_cross` (spot + futures): fires a long entry on a fast/mid EMA bullish cross when mid > long EMA is true; clears on the next cross down
- Adds `tema_cross_bd` (futures + HL perps): same cross logic but fires short entries on a bearish cross when downtrend is confirmed; registered in `bidirectionalPerpsStrategies` so the init wizard sets `allow_shorts=true`
- Both strategies use default periods 5/13/34 vs the existing `triple_ema` periods 8/21/55 — cross-based entries rather than full stack alignment

## Test plan

- [ ] `python3 -m py_compile shared_strategies/registry.py`
- [ ] `go build -C scheduler .`
- [ ] `build_registry('spot')` contains `tema_cross`, not `tema_cross_bd`
- [ ] `build_registry('futures')` contains both
- [ ] `go-trader init` with HL perps shows `tema_cross_bd` with `allow_shorts: true`

---
LLM: Sonnet 4.6 (1M context) | high