### PR TITLE
Add position-aware close evaluator plumbing

### DIFF
--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -420,6 +420,9 @@ DEFAULT_PARAM_RANGES = {
         "entry_period": [10, 20, 30],
         "exit_period": [5, 10, 15],
     },
+    "tp_at_pct": {
+        "pct": [0.01, 0.03, 0.05],
+    },
     # Futures-only
     "breakout": {
         "lookback": [10, 20, 30],

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -67,6 +67,18 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 			addChange("strategy[%s].interval_seconds: %d -> %d", sc.ID, sc.IntervalSeconds, ns.IntervalSeconds)
 			sc.IntervalSeconds = ns.IntervalSeconds
 		}
+		if sc.OpenStrategy != ns.OpenStrategy {
+			addChange("strategy[%s].open_strategy: %q -> %q", sc.ID, sc.OpenStrategy, ns.OpenStrategy)
+			sc.OpenStrategy = ns.OpenStrategy
+		}
+		if !reflect.DeepEqual(sc.CloseStrategies, ns.CloseStrategies) {
+			addChange("strategy[%s].close_strategies: %v -> %v", sc.ID, sc.CloseStrategies, ns.CloseStrategies)
+			sc.CloseStrategies = append([]string{}, ns.CloseStrategies...)
+		}
+		if sc.DisableImplicitClose != ns.DisableImplicitClose {
+			addChange("strategy[%s].disable_implicit_close: %t -> %t", sc.ID, sc.DisableImplicitClose, ns.DisableImplicitClose)
+			sc.DisableImplicitClose = ns.DisableImplicitClose
+		}
 		// #486: Margin mode is hot-reloadable when flat. The state-compat
 		// check above blocks the change when positions are open; if we got
 		// here with new MarginMode != current, the strategy is flat and the
@@ -248,6 +260,9 @@ func strategyRestartShape(sc StrategyConfig) StrategyConfig {
 	sc.Capital = 0
 	sc.Leverage = 0
 	sc.IntervalSeconds = 0
+	sc.OpenStrategy = ""
+	sc.CloseStrategies = nil
+	sc.DisableImplicitClose = false
 	sc.MarginMode = "" // #486: hot-reloadable when flat (state-compat check enforces flat-only change)
 	return sc
 }

--- a/scheduler/config_reload_test.go
+++ b/scheduler/config_reload_test.go
@@ -200,6 +200,42 @@ func TestApplyHotReloadConfigRejectsNonReloadableStrategyField(t *testing.T) {
 	}
 }
 
+func TestApplyHotReloadConfigAllowsOpenCloseCompositionChanges(t *testing.T) {
+	cfg := minimalReloadConfig([]StrategyConfig{{
+		ID: "s1", Type: "spot", Platform: "binanceus", Script: "x.py",
+		Args: []string{"triple_ema", "BTC/USDT", "1h"}, Capital: 100, MaxDrawdownPct: 10,
+	}})
+	next := minimalReloadConfig([]StrategyConfig{{
+		ID: "s1", Type: "spot", Platform: "binanceus", Script: "x.py",
+		Args: []string{"triple_ema", "BTC/USDT", "1h"}, Capital: 100, MaxDrawdownPct: 10,
+		OpenStrategy: "triple_ema", CloseStrategies: []string{"tp_at_pct"}, DisableImplicitClose: true,
+	}})
+
+	changes, err := applyHotReloadConfig(cfg, next, NewAppState(), nil, nil)
+	if err != nil {
+		t.Fatalf("applyHotReloadConfig returned error: %v", err)
+	}
+	joined := strings.Join(changes, "\n")
+	for _, want := range []string{
+		"strategy[s1].open_strategy:",
+		"strategy[s1].close_strategies:",
+		"strategy[s1].disable_implicit_close:",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("changes missing %q:\n%s", want, joined)
+		}
+	}
+	if cfg.Strategies[0].OpenStrategy != "triple_ema" {
+		t.Fatalf("OpenStrategy = %q, want triple_ema", cfg.Strategies[0].OpenStrategy)
+	}
+	if len(cfg.Strategies[0].CloseStrategies) != 1 || cfg.Strategies[0].CloseStrategies[0] != "tp_at_pct" {
+		t.Fatalf("CloseStrategies = %#v, want [tp_at_pct]", cfg.Strategies[0].CloseStrategies)
+	}
+	if !cfg.Strategies[0].DisableImplicitClose {
+		t.Fatal("DisableImplicitClose = false, want true")
+	}
+}
+
 func TestApplyHotReloadConfigRejectsLeverageChangeWithOpenPerpsPosition(t *testing.T) {
 	cfg := minimalReloadConfig([]StrategyConfig{{
 		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 2,

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -63,7 +63,9 @@ CREATE TABLE IF NOT EXISTS positions (
     symbol TEXT NOT NULL,
     position_id TEXT NOT NULL DEFAULT '',
     quantity REAL NOT NULL,
+    initial_quantity REAL NOT NULL DEFAULT 0,
     avg_cost REAL NOT NULL,
+    entry_atr REAL NOT NULL DEFAULT 0,
     side TEXT NOT NULL,
     multiplier REAL NOT NULL DEFAULT 0,
     owner_strategy_id TEXT NOT NULL DEFAULT '',
@@ -260,6 +262,9 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE positions ADD COLUMN position_id TEXT NOT NULL DEFAULT ''",
 		"ALTER TABLE option_positions ADD COLUMN position_id TEXT NOT NULL DEFAULT ''",
 		"CREATE INDEX IF NOT EXISTS idx_trades_strategy_position ON trades(strategy_id, position_id)",
+		// Position-aware close evaluator context (#496).
+		"ALTER TABLE positions ADD COLUMN initial_quantity REAL NOT NULL DEFAULT 0",
+		"ALTER TABLE positions ADD COLUMN entry_atr REAL NOT NULL DEFAULT 0",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -605,8 +610,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	}
 	defer stmtStrat.Close()
 
-	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, avg_cost, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare position insert: %w", err)
 	}
@@ -656,7 +661,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 
 		for _, pos := range s.Positions {
 			positionID := ensurePositionTradeID(s.ID, pos.Symbol, pos)
-			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.AvgCost, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx); err != nil {
+			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx); err != nil {
 				return fmt.Errorf("insert position %s/%s: %w", s.ID, pos.Symbol, err)
 			}
 		}
@@ -1063,7 +1068,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	}
 
 	// 3. Load positions for each strategy.
-	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, avg_cost, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px FROM positions")
+	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px FROM positions")
 	if err != nil {
 		return nil, fmt.Errorf("load positions: %w", err)
 	}
@@ -1072,7 +1077,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		var stratID string
 		var pos Position
 		var openedAtStr string
-		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.AvgCost, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx); err != nil {
+		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx); err != nil {
 			return nil, fmt.Errorf("scan position: %w", err)
 		}
 		pos.OpenedAt = parseTime(openedAtStr)

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -1070,6 +1070,10 @@ func TestMigrateSchema_AddsExchangeColumns(t *testing.T) {
 	if _, err := db.Exec(`INSERT INTO strategies (id, type) VALUES ('test', 'perps')`); err != nil {
 		t.Fatalf("insert strategy: %v", err)
 	}
+	if _, err := db.Exec(`INSERT INTO positions (strategy_id, symbol, quantity, avg_cost, side, multiplier, owner_strategy_id)
+		VALUES ('test', 'BTC', 0.5, 40000, 'long', 1, 'test')`); err != nil {
+		t.Fatalf("insert old position: %v", err)
+	}
 	if _, err := db.Exec(`INSERT INTO trades (strategy_id, timestamp, symbol, side, quantity, price, value, trade_type, details)
 		VALUES ('test', '2026-01-01T00:00:00Z', 'BTC', 'buy', 0.1, 50000, 5000, 'perps', 'old trade')`); err != nil {
 		t.Fatalf("insert old trade: %v", err)
@@ -1100,6 +1104,16 @@ func TestMigrateSchema_AddsExchangeColumns(t *testing.T) {
 	}
 	if len(strat.TradeHistory) != 1 {
 		t.Fatalf("trade count = %d, want 1", len(strat.TradeHistory))
+	}
+	pos := strat.Positions["BTC"]
+	if pos == nil {
+		t.Fatal("migrated position missing")
+	}
+	if pos.InitialQuantity != 0 {
+		t.Errorf("migrated position InitialQuantity = %g, want 0", pos.InitialQuantity)
+	}
+	if pos.EntryATR != 0 {
+		t.Errorf("migrated position EntryATR = %g, want 0", pos.EntryATR)
 	}
 	tr := strat.TradeHistory[0]
 	if tr.ExchangeOrderID != "" {

--- a/scheduler/deribit.go
+++ b/scheduler/deribit.go
@@ -461,6 +461,7 @@ func applyAssignment(s *StrategyState, r markResult, logger *StrategyLogger) {
 				Symbol:          symbol,
 				TradePositionID: positionID,
 				Quantity:        r.AssignQuantity,
+				InitialQuantity: r.AssignQuantity,
 				AvgCost:         r.AssignStrike,
 				Side:            "long",
 				OpenedAt:        now,

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1088,6 +1088,9 @@ func main() {
 						if hlLiveStrategy {
 							hlCash = stratState.Cash
 						}
+						// Live-order sizing/cancel snapshots below are intentionally
+						// consumed only inside live execution branches. Paper paths
+						// should continue using PositionCtx only for close evaluation.
 						if sym := hyperliquidSymbol(sc.Args); sym != "" {
 							if pos, ok := stratState.Positions[sym]; ok {
 								hlPosCtx = positionCtxFromPosition(pos)

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1072,18 +1072,17 @@ func main() {
 					if sc.Type == "options" {
 						posJSON = EncodeAllPositionsJSON(stratState.OptionPositions, stratState.Positions)
 					}
-					var spotPosSide string
+					var spotPosCtx PositionCtx
 					if sc.Type == "spot" && sc.Platform != "okx" && sc.Platform != "robinhood" {
 						if sym := spotSymbol(sc.Args); sym != "" {
-							if pos, ok := stratState.Positions[sym]; ok {
-								spotPosSide = pos.Side
-							}
+							spotPosCtx = positionCtxForSymbol(stratState, sym)
 						}
 					}
 					var hlCash float64
 					var hlPosQty float64
 					var hlPosSide string
 					var hlAvgCost float64
+					var hlPosCtx PositionCtx
 					var hlStopLossOID int64
 					if sc.Type == "perps" && sc.Platform == "hyperliquid" {
 						if hlLiveStrategy {
@@ -1091,12 +1090,11 @@ func main() {
 						}
 						if sym := hyperliquidSymbol(sc.Args); sym != "" {
 							if pos, ok := stratState.Positions[sym]; ok {
-								hlPosSide = pos.Side
-								if hlLiveStrategy {
-									hlPosQty = pos.Quantity
-									hlAvgCost = pos.AvgCost
-									hlStopLossOID = pos.StopLossOID
-								}
+								hlPosCtx = positionCtxFromPosition(pos)
+								hlPosSide = hlPosCtx.Side
+								hlPosQty = hlPosCtx.Quantity
+								hlAvgCost = hlPosCtx.AvgCost
+								hlStopLossOID = pos.StopLossOID
 							}
 						}
 					}
@@ -1104,49 +1102,49 @@ func main() {
 					var okxPosQty float64
 					var okxPosSide string
 					var okxAvgCost float64
+					var okxPosCtx PositionCtx
 					if sc.Platform == "okx" {
 						if okxLiveStrategy {
 							okxCash = stratState.Cash
 						}
 						if sym := okxSymbol(sc.Args); sym != "" {
 							if pos, ok := stratState.Positions[sym]; ok {
-								okxPosSide = pos.Side
-								if okxLiveStrategy {
-									okxPosQty = pos.Quantity
-									okxAvgCost = pos.AvgCost
-								}
+								okxPosCtx = positionCtxFromPosition(pos)
+								okxPosSide = okxPosCtx.Side
+								okxPosQty = okxPosCtx.Quantity
+								okxAvgCost = okxPosCtx.AvgCost
 							}
 						}
 					}
 					var rhCash float64
 					var rhPosQty float64
 					var rhPosSide string
+					var rhPosCtx PositionCtx
 					if sc.Platform == "robinhood" {
 						if rhLiveStrategy {
 							rhCash = stratState.Cash
 						}
 						if sym := robinhoodSymbol(sc.Args); sym != "" {
 							if pos, ok := stratState.Positions[sym]; ok {
-								rhPosSide = pos.Side
-								if rhLiveStrategy {
-									rhPosQty = pos.Quantity
-								}
+								rhPosCtx = positionCtxFromPosition(pos)
+								rhPosSide = rhPosCtx.Side
+								rhPosQty = rhPosCtx.Quantity
 							}
 						}
 					}
 					var tsCash float64
 					var tsContracts float64
 					var tsPosSide string
+					var tsPosCtx PositionCtx
 					if sc.Type == "futures" {
 						if tsLiveStrategy {
 							tsCash = stratState.Cash
 						}
 						if sym := topstepSymbol(sc.Args); sym != "" {
 							if pos, ok := stratState.Positions[sym]; ok {
-								tsPosSide = pos.Side
-								if tsLiveStrategy {
-									tsContracts = pos.Quantity
-								}
+								tsPosCtx = positionCtxFromPosition(pos)
+								tsPosSide = tsPosCtx.Side
+								tsContracts = tsPosCtx.Quantity
 							}
 						}
 					}
@@ -1197,7 +1195,7 @@ func main() {
 					switch sc.Type {
 					case "spot":
 						if sc.Platform == "okx" {
-							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosSide, logger); ok {
+							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, logger); ok {
 								prices[result.Symbol] = price
 								var execResult *OKXExecuteResult
 								liveExecFailed := false
@@ -1215,7 +1213,7 @@ func main() {
 								}
 							}
 						} else if sc.Platform == "robinhood" {
-							if result, signalStr, price, ok := runRobinhoodCheck(sc, prices, rhPosSide, logger); ok {
+							if result, signalStr, price, ok := runRobinhoodCheck(sc, prices, rhPosCtx, logger); ok {
 								prices[result.Symbol] = price
 								var execResult *RobinhoodExecuteResult
 								liveExecFailed := false
@@ -1232,7 +1230,7 @@ func main() {
 									mu.Unlock()
 								}
 							}
-						} else if result, signalStr, price, ok := runSpotCheck(sc, prices, spotPosSide, logger); ok {
+						} else if result, signalStr, price, ok := runSpotCheck(sc, prices, spotPosCtx, logger); ok {
 							mu.Lock()
 							trades, detail = executeSpotResult(sc, stratState, result, signalStr, price, logger)
 							mu.Unlock()
@@ -1250,7 +1248,7 @@ func main() {
 						}
 					case "perps":
 						if sc.Platform == "okx" {
-							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosSide, logger); ok {
+							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, logger); ok {
 								prices[result.Symbol] = price
 								var execResult *OKXExecuteResult
 								liveExecFailed := false
@@ -1267,7 +1265,7 @@ func main() {
 									mu.Unlock()
 								}
 							}
-						} else if result, signalStr, price, ok := runHyperliquidCheck(sc, prices, hlPosSide, logger); ok {
+						} else if result, signalStr, price, ok := runHyperliquidCheck(sc, prices, hlPosCtx, logger); ok {
 							prices[result.Symbol] = price
 							var execResult *HyperliquidExecuteResult
 							liveExecFailed := false
@@ -1301,7 +1299,7 @@ func main() {
 							}
 						}
 					case "futures":
-						if result, signalStr, price, ok := runTopStepCheck(sc, prices, tsPosSide, logger); ok {
+						if result, signalStr, price, ok := runTopStepCheck(sc, prices, tsPosCtx, logger); ok {
 							prices[result.Symbol] = price
 							var execResult *TopStepExecuteResult
 							liveExecFailed := false
@@ -1709,9 +1707,9 @@ func spotSymbol(args []string) string {
 
 // runSpotCheck runs the spot check subprocess and returns the parsed result.
 // No state access. Returns (result, signalStr, price, ok); ok=false means skip execution.
-func runSpotCheck(sc StrategyConfig, prices map[string]float64, posSide string, logger *StrategyLogger) (*SpotResult, string, float64, bool) {
+func runSpotCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, logger *StrategyLogger) (*SpotResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
-	args = appendOpenCloseArgs(args, sc, posSide)
+	args = appendOpenCloseArgs(args, sc, posCtx)
 	if sc.HTFFilter {
 		args = append(args, "--htf-filter")
 	}
@@ -1773,12 +1771,51 @@ func executeSpotResult(sc StrategyConfig, s *StrategyState, result *SpotResult, 
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
 	}
+	stampEntryATRIfOpened(s, result.Symbol, result.Indicators, trades)
 
 	detail := ""
 	if trades > 0 {
 		detail = fmt.Sprintf("[%s] %s %s @ $%.2f", sc.ID, signalStr, result.Symbol, price)
 	}
 	return trades, detail
+}
+
+func stampEntryATRIfOpened(s *StrategyState, symbol string, indicators map[string]interface{}, trades int) {
+	if trades <= 0 || s == nil {
+		return
+	}
+	atr, ok := indicatorFloat(indicators, "atr")
+	if !ok || atr <= 0 {
+		return
+	}
+	if pos, exists := s.Positions[symbol]; exists && pos != nil && pos.EntryATR == 0 {
+		pos.EntryATR = atr
+	}
+}
+
+func indicatorFloat(indicators map[string]interface{}, key string) (float64, bool) {
+	if indicators == nil {
+		return 0, false
+	}
+	value, ok := indicators[key]
+	if !ok {
+		return 0, false
+	}
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case json.Number:
+		f, err := v.Float64()
+		return f, err == nil
+	default:
+		return 0, false
+	}
 }
 
 // runOptionsCheck runs the options check subprocess and returns the parsed result.
@@ -1936,9 +1973,9 @@ func hyperliquidSymbol(args []string) string {
 }
 
 // runHyperliquidCheck runs check_hyperliquid.py signal-check mode (Phase 3, no lock).
-func runHyperliquidCheck(sc StrategyConfig, prices map[string]float64, posSide string, logger *StrategyLogger) (*HyperliquidResult, string, float64, bool) {
+func runHyperliquidCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, logger *StrategyLogger) (*HyperliquidResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
-	args = appendOpenCloseArgs(args, sc, posSide)
+	args = appendOpenCloseArgs(args, sc, posCtx)
 	if sc.HTFFilter {
 		args = append(args, "--htf-filter")
 	}
@@ -2189,6 +2226,7 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
 	}
+	stampEntryATRIfOpened(s, result.Symbol, result.Indicators, trades)
 	if trades > 0 && fillOID != "" {
 		logger.Info("Exchange order ID: %s", fillOID)
 	}
@@ -2249,9 +2287,9 @@ func topstepSymbol(args []string) string {
 }
 
 // runTopStepCheck runs check_topstep.py signal-check mode (Phase 3, no lock).
-func runTopStepCheck(sc StrategyConfig, prices map[string]float64, posSide string, logger *StrategyLogger) (*TopStepResult, string, float64, bool) {
+func runTopStepCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, logger *StrategyLogger) (*TopStepResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
-	args = appendOpenCloseArgs(args, sc, posSide)
+	args = appendOpenCloseArgs(args, sc, posCtx)
 	if sc.HTFFilter {
 		args = append(args, "--htf-filter")
 	}
@@ -2402,6 +2440,7 @@ func executeTopStepResult(sc StrategyConfig, s *StrategyState, result *TopStepRe
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
 	}
+	stampEntryATRIfOpened(s, result.Symbol, result.Indicators, trades)
 
 	detail := ""
 	if trades > 0 {
@@ -2428,9 +2467,9 @@ func robinhoodSymbol(args []string) string {
 }
 
 // runRobinhoodCheck runs check_robinhood.py signal-check mode (Phase 3, no lock).
-func runRobinhoodCheck(sc StrategyConfig, prices map[string]float64, posSide string, logger *StrategyLogger) (*RobinhoodResult, string, float64, bool) {
+func runRobinhoodCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, logger *StrategyLogger) (*RobinhoodResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
-	args = appendOpenCloseArgs(args, sc, posSide)
+	args = appendOpenCloseArgs(args, sc, posCtx)
 	if sc.HTFFilter {
 		args = append(args, "--htf-filter")
 	}
@@ -2556,6 +2595,7 @@ func executeRobinhoodResult(sc StrategyConfig, s *StrategyState, result *Robinho
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
 	}
+	stampEntryATRIfOpened(s, result.Symbol, result.Indicators, trades)
 
 	detail := ""
 	if trades > 0 {
@@ -2592,9 +2632,9 @@ func okxInstType(args []string) string {
 }
 
 // runOKXCheck runs check_okx.py signal-check mode (Phase 3, no lock).
-func runOKXCheck(sc StrategyConfig, prices map[string]float64, posSide string, logger *StrategyLogger) (*OKXResult, string, float64, bool) {
+func runOKXCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, logger *StrategyLogger) (*OKXResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
-	args = appendOpenCloseArgs(args, sc, posSide)
+	args = appendOpenCloseArgs(args, sc, posCtx)
 	if sc.HTFFilter {
 		args = append(args, "--htf-filter")
 	}
@@ -2763,6 +2803,7 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, result *OKXResult, ex
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
 	}
+	stampEntryATRIfOpened(s, result.Symbol, result.Indicators, trades)
 
 	detail := ""
 	if trades > 0 {

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -11,7 +11,9 @@ type Position struct {
 	Symbol            string    `json:"symbol"`
 	TradePositionID   string    `json:"position_id,omitempty"`
 	Quantity          float64   `json:"quantity"`
+	InitialQuantity   float64   `json:"initial_quantity,omitempty"` // original open size; partial closes must not rewrite it (#496)
 	AvgCost           float64   `json:"avg_cost"`
+	EntryATR          float64   `json:"entry_atr,omitempty"`            // ATR value from the entry strategy's open candle when available (#496)
 	Side              string    `json:"side"`                           // "long" or "short"
 	Multiplier        float64   `json:"multiplier,omitempty"`           // contract multiplier (0 = spot, >0 = futures/perps PnL branch; canonical perps value is 1 — do NOT set to leverage)
 	Leverage          float64   `json:"leverage,omitempty"`             // perps leverage (informational; PnL is not scaled by leverage) (#254)
@@ -625,6 +627,7 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 		s.Positions[symbol] = &Position{
 			Symbol:          symbol,
 			Quantity:        qty,
+			InitialQuantity: qty,
 			AvgCost:         execPrice,
 			Side:            "long",
 			Multiplier:      1, // perps use 1:1 contract size; PnL-branch in PortfolioValue
@@ -747,6 +750,7 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 		s.Positions[symbol] = &Position{
 			Symbol:          symbol,
 			Quantity:        qty,
+			InitialQuantity: qty,
 			AvgCost:         execPrice,
 			Side:            "short",
 			Multiplier:      1,
@@ -872,6 +876,7 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			Symbol:          symbol,
 			TradePositionID: positionID,
 			Quantity:        qty,
+			InitialQuantity: qty,
 			AvgCost:         execPrice,
 			Side:            "long",
 			OwnerStrategyID: s.ID,
@@ -1047,6 +1052,7 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			Symbol:          symbol,
 			TradePositionID: positionID,
 			Quantity:        float64(contracts),
+			InitialQuantity: float64(contracts),
 			AvgCost:         execPrice,
 			Side:            "long",
 			Multiplier:      multiplier,
@@ -1156,6 +1162,7 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 				Symbol:          symbol,
 				TradePositionID: positionID,
 				Quantity:        float64(contracts),
+				InitialQuantity: float64(contracts),
 				AvgCost:         execPrice,
 				Side:            "short",
 				Multiplier:      multiplier,

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -41,6 +41,85 @@ func TestPositionJSONUsesPositionID(t *testing.T) {
 	}
 }
 
+func TestExecuteSpotResultSetsInitialQuantityAndEntryATR(t *testing.T) {
+	prevRecorder := tradeRecorder
+	tradeRecorder = nil
+	t.Cleanup(func() { tradeRecorder = prevRecorder })
+
+	state := &StrategyState{
+		ID:        "spot-test",
+		Type:      "spot",
+		Platform:  "binanceus",
+		Cash:      1000,
+		Positions: map[string]*Position{},
+	}
+	result := &SpotResult{
+		Symbol:     "BTC/USDT",
+		Signal:     1,
+		Indicators: map[string]interface{}{"atr": 123.45},
+	}
+	trades, _ := executeSpotResult(
+		StrategyConfig{ID: "spot-test"},
+		state,
+		result,
+		"BUY",
+		100,
+		silentStrategyLogger("spot-test"),
+	)
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	pos := state.Positions["BTC/USDT"]
+	if pos == nil {
+		t.Fatal("position was not opened")
+	}
+	if pos.InitialQuantity != pos.Quantity {
+		t.Fatalf("InitialQuantity = %g, want current open qty %g", pos.InitialQuantity, pos.Quantity)
+	}
+	if pos.EntryATR != 123.45 {
+		t.Fatalf("EntryATR = %g, want 123.45", pos.EntryATR)
+	}
+}
+
+func TestPartialClosePreservesInitialQuantityAndEntryATR(t *testing.T) {
+	prevRecorder := tradeRecorder
+	tradeRecorder = nil
+	t.Cleanup(func() { tradeRecorder = prevRecorder })
+
+	state := &StrategyState{
+		ID:       "hl-test",
+		Type:     "perps",
+		Platform: "hyperliquid",
+		Cash:     1000,
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol:          "ETH",
+				Quantity:        1,
+				InitialQuantity: 1,
+				AvgCost:         3000,
+				EntryATR:        150,
+				Side:            "long",
+				Multiplier:      1,
+			},
+		},
+	}
+
+	applyHyperliquidCircuitCloseFill(state, "ETH", 0.4, 3100, 1, 1)
+	pos := state.Positions["ETH"]
+	if pos == nil {
+		t.Fatal("position should remain after partial close")
+	}
+	if math.Abs(pos.Quantity-0.6) > 1e-9 {
+		t.Fatalf("Quantity = %g, want 0.6", pos.Quantity)
+	}
+	if pos.InitialQuantity != 1 {
+		t.Fatalf("InitialQuantity = %g, want 1", pos.InitialQuantity)
+	}
+	if pos.EntryATR != 150 {
+		t.Fatalf("EntryATR = %g, want 150", pos.EntryATR)
+	}
+}
+
 func TestPortfolioValueCashOnly(t *testing.T) {
 	s := &StrategyState{
 		Cash:            1000,

--- a/scheduler/strategy_composition.go
+++ b/scheduler/strategy_composition.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -14,6 +15,16 @@ type StrategyDecisionFields struct {
 	OpenAction      string   `json:"open_action,omitempty"`
 	CloseFraction   float64  `json:"close_fraction"`
 	CloseStrategy   string   `json:"close_strategy,omitempty"`
+}
+
+// PositionCtx is the optional state snapshot threaded into close evaluators
+// when a strategy opts into the open/close composition model (#496).
+type PositionCtx struct {
+	Side            string
+	AvgCost         float64
+	Quantity        float64
+	InitialQuantity float64
+	EntryATR        float64
 }
 
 func usesOpenCloseConfig(sc StrategyConfig) bool {
@@ -48,7 +59,7 @@ func validateStrategyConceptName(name string) error {
 	return nil
 }
 
-func appendOpenCloseArgs(args []string, sc StrategyConfig, positionSide string) []string {
+func appendOpenCloseArgs(args []string, sc StrategyConfig, pos PositionCtx) []string {
 	if !usesOpenCloseConfig(sc) {
 		return args
 	}
@@ -62,10 +73,41 @@ func appendOpenCloseArgs(args []string, sc StrategyConfig, positionSide string) 
 	if sc.DisableImplicitClose {
 		out = append(out, "--disable-implicit-close")
 	}
-	if side := strings.TrimSpace(positionSide); side != "" {
+	if side := strings.TrimSpace(pos.Side); side != "" {
 		out = append(out, "--position-side", side)
 	}
+	out = appendPositionFloatArg(out, "--position-avg-cost", pos.AvgCost)
+	out = appendPositionFloatArg(out, "--position-qty", pos.Quantity)
+	out = appendPositionFloatArg(out, "--position-initial-qty", pos.InitialQuantity)
+	out = appendPositionFloatArg(out, "--position-entry-atr", pos.EntryATR)
 	return out
+}
+
+func appendPositionFloatArg(args []string, flag string, value float64) []string {
+	if value == 0 {
+		return args
+	}
+	return append(args, flag+"="+strconv.FormatFloat(value, 'f', -1, 64))
+}
+
+func positionCtxForSymbol(s *StrategyState, symbol string) PositionCtx {
+	if s == nil || strings.TrimSpace(symbol) == "" {
+		return PositionCtx{}
+	}
+	return positionCtxFromPosition(s.Positions[symbol])
+}
+
+func positionCtxFromPosition(pos *Position) PositionCtx {
+	if pos == nil {
+		return PositionCtx{}
+	}
+	return PositionCtx{
+		Side:            pos.Side,
+		AvgCost:         pos.AvgCost,
+		Quantity:        pos.Quantity,
+		InitialQuantity: pos.InitialQuantity,
+		EntryATR:        pos.EntryATR,
+	}
 }
 
 func explicitCloseStrategies(sc StrategyConfig) []string {

--- a/scheduler/strategy_composition_test.go
+++ b/scheduler/strategy_composition_test.go
@@ -34,7 +34,7 @@ func TestEffectiveOpenStrategy(t *testing.T) {
 
 func TestAppendOpenCloseArgsOnlyWhenOptedIn(t *testing.T) {
 	legacy := StrategyConfig{Args: []string{"sma_crossover", "BTC/USDT", "1h"}}
-	if got := appendOpenCloseArgs(legacy.Args, legacy, "long"); !reflect.DeepEqual(got, legacy.Args) {
+	if got := appendOpenCloseArgs(legacy.Args, legacy, PositionCtx{Side: "long"}); !reflect.DeepEqual(got, legacy.Args) {
 		t.Fatalf("legacy args mutated: %#v", got)
 	}
 
@@ -42,7 +42,7 @@ func TestAppendOpenCloseArgsOnlyWhenOptedIn(t *testing.T) {
 		Args:         []string{"sma_crossover", "BTC/USDT", "1h"},
 		OpenStrategy: "momentum",
 	}
-	gotOpenOnly := appendOpenCloseArgs(openOnly.Args, openOnly, "")
+	gotOpenOnly := appendOpenCloseArgs(openOnly.Args, openOnly, PositionCtx{})
 	wantOpenOnly := []string{
 		"sma_crossover", "BTC/USDT", "1h",
 		"--open-strategy", "momentum",
@@ -57,7 +57,7 @@ func TestAppendOpenCloseArgsOnlyWhenOptedIn(t *testing.T) {
 		CloseStrategies:      []string{"rsi", "macd"},
 		DisableImplicitClose: true,
 	}
-	got := appendOpenCloseArgs(sc.Args, sc, "long")
+	got := appendOpenCloseArgs(sc.Args, sc, PositionCtx{Side: "long"})
 	want := []string{
 		"sma_crossover", "BTC/USDT", "1h",
 		"--open-strategy", "momentum",
@@ -67,6 +67,88 @@ func TestAppendOpenCloseArgsOnlyWhenOptedIn(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("appendOpenCloseArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestAppendOpenCloseArgsPositionCtx(t *testing.T) {
+	sc := StrategyConfig{
+		Args:            []string{"triple_ema", "ETH", "1h"},
+		CloseStrategies: []string{"tp_at_pct"},
+	}
+	tests := []struct {
+		name string
+		pos  PositionCtx
+		want []string
+	}{
+		{
+			name: "flat omits position context",
+			pos:  PositionCtx{},
+			want: []string{"triple_ema", "ETH", "1h", "--close-strategies", "tp_at_pct"},
+		},
+		{
+			name: "partial position includes current and initial qty",
+			pos: PositionCtx{
+				Side:            "long",
+				AvgCost:         3000,
+				Quantity:        0.25,
+				InitialQuantity: 1,
+			},
+			want: []string{
+				"triple_ema", "ETH", "1h",
+				"--close-strategies", "tp_at_pct",
+				"--position-side", "long",
+				"--position-avg-cost=3000",
+				"--position-qty=0.25",
+				"--position-initial-qty=1",
+			},
+		},
+		{
+			name: "full position with atr",
+			pos: PositionCtx{
+				Side:            "short",
+				AvgCost:         51000.5,
+				Quantity:        0.4,
+				InitialQuantity: 0.4,
+				EntryATR:        750.25,
+			},
+			want: []string{
+				"triple_ema", "ETH", "1h",
+				"--close-strategies", "tp_at_pct",
+				"--position-side", "short",
+				"--position-avg-cost=51000.5",
+				"--position-qty=0.4",
+				"--position-initial-qty=0.4",
+				"--position-entry-atr=750.25",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appendOpenCloseArgs(sc.Args, sc, tt.pos); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("appendOpenCloseArgs() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPositionCtxForSymbol(t *testing.T) {
+	s := &StrategyState{Positions: map[string]*Position{
+		"ETH": {
+			Symbol:          "ETH",
+			Side:            "long",
+			Quantity:        0.5,
+			InitialQuantity: 1,
+			AvgCost:         3000,
+			EntryATR:        125,
+		},
+	}}
+	got := positionCtxForSymbol(s, "ETH")
+	want := PositionCtx{Side: "long", AvgCost: 3000, Quantity: 0.5, InitialQuantity: 1, EntryATR: 125}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("positionCtxForSymbol() = %#v, want %#v", got, want)
+	}
+	if got := positionCtxForSymbol(s, "BTC"); !reflect.DeepEqual(got, PositionCtx{}) {
+		t.Fatalf("missing symbol ctx = %#v, want zero", got)
 	}
 }
 

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -62,10 +62,27 @@ def _make_dataframe(candles):
     return df
 
 
+def _position_ctx_from_args(args):
+    ctx = {}
+    side = (args.position_side or "").lower()
+    if side:
+        ctx["side"] = side
+    for attr, key in (
+        ("position_avg_cost", "avg_cost"),
+        ("position_qty", "current_quantity"),
+        ("position_initial_qty", "initial_quantity"),
+        ("position_entry_atr", "entry_atr"),
+    ):
+        value = getattr(args, attr, None)
+        if value is not None:
+            ctx[key] = value
+    return ctx
+
+
 def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=False,
                      strategy_params_override=None, open_strategy=None,
                      close_strategies=None, disable_implicit_close=False,
-                     position_side=""):
+                     position_side="", position_ctx=None):
     """Run strategy signal check using Hyperliquid OHLCV data."""
     try:
         from adapter import HyperliquidExchangeAdapter
@@ -136,6 +153,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
                 position_side,
                 disable_implicit_close,
                 strategy_params or None,
+                position_ctx,
             )
             result_df = evaluation.open_result_df
             signal = evaluation.open_signal
@@ -506,13 +524,18 @@ def main():
         parser.add_argument("--close-strategies", default=None)
         parser.add_argument("--disable-implicit-close", action="store_true", default=False)
         parser.add_argument("--position-side", default="")
+        parser.add_argument("--position-avg-cost", type=float, default=None)
+        parser.add_argument("--position-qty", type=float, default=None)
+        parser.add_argument("--position-initial-qty", type=float, default=None)
+        parser.add_argument("--position-entry-atr", type=float, default=None)
         args = parser.parse_args()
         params_override = json.loads(args.params) if args.params else None
+        position_ctx = _position_ctx_from_args(args)
         run_signal_check(
             args.strategy, args.symbol, args.timeframe, args.mode,
             args.htf_filter, params_override, args.open_strategy,
             args.close_strategies, args.disable_implicit_close,
-            args.position_side,
+            args.position_side, position_ctx,
         )
 
 

--- a/shared_scripts/check_okx.py
+++ b/shared_scripts/check_okx.py
@@ -44,6 +44,23 @@ def _make_dataframe(candles):
     return df
 
 
+def _position_ctx_from_args(args):
+    ctx = {}
+    side = (args.position_side or "").lower()
+    if side:
+        ctx["side"] = side
+    for attr, key in (
+        ("position_avg_cost", "avg_cost"),
+        ("position_qty", "current_quantity"),
+        ("position_initial_qty", "initial_quantity"),
+        ("position_entry_atr", "entry_atr"),
+    ):
+        value = getattr(args, attr, None)
+        if value is not None:
+            ctx[key] = value
+    return ctx
+
+
 def _float_or_none(value):
     if value is None:
         return None
@@ -66,7 +83,7 @@ def _extract_fee(response):
 def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=False,
                      inst_type="swap", strategy_params_override=None,
                      open_strategy=None, close_strategies=None,
-                     disable_implicit_close=False, position_side=""):
+                     disable_implicit_close=False, position_side="", position_ctx=None):
     """Run strategy signal check using OKX OHLCV data."""
     try:
         from adapter import OKXExchangeAdapter
@@ -140,6 +157,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
                 position_side,
                 disable_implicit_close,
                 strategy_params or None,
+                position_ctx,
             )
             result_df = evaluation.open_result_df
             signal = evaluation.open_signal
@@ -318,13 +336,18 @@ def main():
         parser.add_argument("--close-strategies", default=None)
         parser.add_argument("--disable-implicit-close", action="store_true", default=False)
         parser.add_argument("--position-side", default="")
+        parser.add_argument("--position-avg-cost", type=float, default=None)
+        parser.add_argument("--position-qty", type=float, default=None)
+        parser.add_argument("--position-initial-qty", type=float, default=None)
+        parser.add_argument("--position-entry-atr", type=float, default=None)
         args = parser.parse_args()
         params_override = json.loads(args.params) if args.params else None
+        position_ctx = _position_ctx_from_args(args)
         run_signal_check(
             args.strategy, args.symbol, args.timeframe, args.mode,
             args.htf_filter, args.inst_type, params_override,
             args.open_strategy, args.close_strategies,
-            args.disable_implicit_close, args.position_side,
+            args.disable_implicit_close, args.position_side, position_ctx,
         )
 
 

--- a/shared_scripts/check_robinhood.py
+++ b/shared_scripts/check_robinhood.py
@@ -35,6 +35,23 @@ def _make_dataframe(candles):
     return df
 
 
+def _position_ctx_from_args(args):
+    ctx = {}
+    side = (args.position_side or "").lower()
+    if side:
+        ctx["side"] = side
+    for attr, key in (
+        ("position_avg_cost", "avg_cost"),
+        ("position_qty", "current_quantity"),
+        ("position_initial_qty", "initial_quantity"),
+        ("position_entry_atr", "entry_atr"),
+    ):
+        value = getattr(args, attr, None)
+        if value is not None:
+            ctx[key] = value
+    return ctx
+
+
 def _float_or_none(value):
     if value is None:
         return None
@@ -94,7 +111,7 @@ def _extract_fee(response):
 def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=False,
                      strategy_params=None, open_strategy=None,
                      close_strategies=None, disable_implicit_close=False,
-                     position_side=""):
+                     position_side="", position_ctx=None):
     """Run strategy signal check using yfinance OHLCV data."""
     try:
         from adapter import RobinhoodExchangeAdapter
@@ -147,6 +164,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
                 position_side,
                 disable_implicit_close,
                 strategy_params,
+                position_ctx,
             )
             result_df = evaluation.open_result_df
             signal = evaluation.open_signal
@@ -326,13 +344,18 @@ def main():
         parser.add_argument("--close-strategies", default=None)
         parser.add_argument("--disable-implicit-close", action="store_true", default=False)
         parser.add_argument("--position-side", default="")
+        parser.add_argument("--position-avg-cost", type=float, default=None)
+        parser.add_argument("--position-qty", type=float, default=None)
+        parser.add_argument("--position-initial-qty", type=float, default=None)
+        parser.add_argument("--position-entry-atr", type=float, default=None)
         args = parser.parse_args()
         params_parsed = json.loads(args.params) if args.params else None
+        position_ctx = _position_ctx_from_args(args)
         run_signal_check(
             args.strategy, args.symbol, args.timeframe, args.mode,
             args.htf_filter, params_parsed, args.open_strategy,
             args.close_strategies, args.disable_implicit_close,
-            args.position_side,
+            args.position_side, position_ctx,
         )
 
 

--- a/shared_scripts/check_strategy.py
+++ b/shared_scripts/check_strategy.py
@@ -24,12 +24,42 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools')
 
 
 def _arg_value(flag, default=None):
+    prefix = flag + "="
+    for arg in sys.argv:
+        if arg.startswith(prefix):
+            return arg.split("=", 1)[1]
     if flag not in sys.argv:
         return default
     idx = sys.argv.index(flag)
     if idx + 1 >= len(sys.argv):
         return default
     return sys.argv[idx + 1]
+
+
+def _arg_float(flag):
+    raw = _arg_value(flag)
+    if raw in (None, ""):
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _position_ctx(position_side):
+    ctx = {}
+    if position_side:
+        ctx["side"] = position_side
+    for flag, key in (
+        ("--position-avg-cost", "avg_cost"),
+        ("--position-qty", "current_quantity"),
+        ("--position-initial-qty", "initial_quantity"),
+        ("--position-entry-atr", "entry_atr"),
+    ):
+        value = _arg_float(flag)
+        if value is not None:
+            ctx[key] = value
+    return ctx
 
 
 def main():
@@ -39,6 +69,7 @@ def main():
     close_strategies_raw = _arg_value("--close-strategies")
     disable_implicit_close = "--disable-implicit-close" in sys.argv
     position_side = (_arg_value("--position-side", "") or "").lower()
+    position_ctx = _position_ctx(position_side)
     open_close_enabled = bool(open_strategy or close_strategies_raw or disable_implicit_close)
     strategy_params = None
     if "--params" in sys.argv:
@@ -52,7 +83,11 @@ def main():
         if skip_next:
             skip_next = False
             continue
-        if a in ("--params", "--open-strategy", "--close-strategies", "--position-side"):
+        if a in (
+            "--params", "--open-strategy", "--close-strategies", "--position-side",
+            "--position-avg-cost", "--position-qty", "--position-initial-qty",
+            "--position-entry-atr",
+        ):
             skip_next = True
             continue
         if a.startswith("--"):
@@ -147,6 +182,7 @@ def main():
                 position_side,
                 disable_implicit_close,
                 strategy_params,
+                position_ctx,
             )
             result_df = evaluation.open_result_df
             signal = evaluation.open_signal

--- a/shared_scripts/check_topstep.py
+++ b/shared_scripts/check_topstep.py
@@ -33,6 +33,23 @@ def _make_dataframe(candles):
     return df
 
 
+def _position_ctx_from_args(args):
+    ctx = {}
+    side = (args.position_side or "").lower()
+    if side:
+        ctx["side"] = side
+    for attr, key in (
+        ("position_avg_cost", "avg_cost"),
+        ("position_qty", "current_quantity"),
+        ("position_initial_qty", "initial_quantity"),
+        ("position_entry_atr", "entry_atr"),
+    ):
+        value = getattr(args, attr, None)
+        if value is not None:
+            ctx[key] = value
+    return ctx
+
+
 def _float_or_none(value):
     if value is None:
         return None
@@ -82,7 +99,7 @@ def _extract_fee(response):
 def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=False,
                      strategy_params=None, open_strategy=None,
                      close_strategies=None, disable_implicit_close=False,
-                     position_side=""):
+                     position_side="", position_ctx=None):
     """Run strategy signal check using TopStep market data."""
     try:
         from adapter import TopStepExchangeAdapter
@@ -155,6 +172,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
                 position_side,
                 disable_implicit_close,
                 strategy_params,
+                position_ctx,
             )
             result_df = evaluation.open_result_df
             signal = evaluation.open_signal
@@ -329,13 +347,18 @@ def main():
         parser.add_argument("--close-strategies", default=None)
         parser.add_argument("--disable-implicit-close", action="store_true", default=False)
         parser.add_argument("--position-side", default="")
+        parser.add_argument("--position-avg-cost", type=float, default=None)
+        parser.add_argument("--position-qty", type=float, default=None)
+        parser.add_argument("--position-initial-qty", type=float, default=None)
+        parser.add_argument("--position-entry-atr", type=float, default=None)
         args = parser.parse_args()
         params_parsed = json.loads(args.params) if args.params else None
+        position_ctx = _position_ctx_from_args(args)
         run_signal_check(
             args.strategy, args.symbol, args.timeframe, args.mode,
             args.htf_filter, params_parsed, args.open_strategy,
             args.close_strategies, args.disable_implicit_close,
-            args.position_side,
+            args.position_side, position_ctx,
         )
 
 

--- a/shared_strategies/futures/strategies.py
+++ b/shared_strategies/futures/strategies.py
@@ -10,6 +10,7 @@ so the surface (``STRATEGY_REGISTRY``, ``apply_strategy``, ``list_strategies``,
 """
 
 import importlib.util
+import inspect
 import json
 import os
 import sys
@@ -31,6 +32,7 @@ def _load_registry_module():
 _registry = _load_registry_module()
 
 STRATEGY_REGISTRY: Dict[str, dict] = _registry.build_registry("futures")
+POSITION_CONTEXT_PARAM_KEYS = {"side", "avg_cost", "current_quantity", "initial_quantity", "entry_atr"}
 
 
 def get_strategy(name: str) -> dict:
@@ -46,7 +48,27 @@ def list_strategies() -> List[str]:
 def apply_strategy(name: str, df: pd.DataFrame, params: Optional[dict] = None) -> pd.DataFrame:
     strat = get_strategy(name)
     p = {**strat["default_params"], **(params or {})}
+    p = _strip_unsupported_position_context(strat["fn"], p)
     return strat["fn"](df, **p)
+
+
+def _strip_unsupported_position_context(fn, params: dict) -> dict:
+    if not params:
+        return params
+    sig = inspect.signature(fn)
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+        return params
+    accepted = {
+        name for name, p in sig.parameters.items()
+        if name != "df" and p.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+    }
+    return {
+        key: value for key, value in params.items()
+        if key in accepted or key not in POSITION_CONTEXT_PARAM_KEYS
+    }
 
 
 if __name__ == "__main__":

--- a/shared_strategies/futures/strategies.py
+++ b/shared_strategies/futures/strategies.py
@@ -10,13 +10,18 @@ so the surface (``STRATEGY_REGISTRY``, ``apply_strategy``, ``list_strategies``,
 """
 
 import importlib.util
-import inspect
 import json
 import os
 import sys
 from typing import Dict, List, Optional
 
 import pandas as pd
+
+_TOOLS_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "shared_tools")
+if _TOOLS_DIR not in sys.path:
+    sys.path.insert(0, _TOOLS_DIR)
+
+from strategy_composition import strip_unsupported_position_context
 
 
 def _load_registry_module():
@@ -32,7 +37,6 @@ def _load_registry_module():
 _registry = _load_registry_module()
 
 STRATEGY_REGISTRY: Dict[str, dict] = _registry.build_registry("futures")
-POSITION_CONTEXT_PARAM_KEYS = {"side", "avg_cost", "current_quantity", "initial_quantity", "entry_atr"}
 
 
 def get_strategy(name: str) -> dict:
@@ -48,27 +52,8 @@ def list_strategies() -> List[str]:
 def apply_strategy(name: str, df: pd.DataFrame, params: Optional[dict] = None) -> pd.DataFrame:
     strat = get_strategy(name)
     p = {**strat["default_params"], **(params or {})}
-    p = _strip_unsupported_position_context(strat["fn"], p)
+    p = strip_unsupported_position_context(strat["fn"], p)
     return strat["fn"](df, **p)
-
-
-def _strip_unsupported_position_context(fn, params: dict) -> dict:
-    if not params:
-        return params
-    sig = inspect.signature(fn)
-    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
-        return params
-    accepted = {
-        name for name, p in sig.parameters.items()
-        if name != "df" and p.kind in (
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            inspect.Parameter.KEYWORD_ONLY,
-        )
-    }
-    return {
-        key: value for key, value in params.items()
-        if key in accepted or key not in POSITION_CONTEXT_PARAM_KEYS
-    }
 
 
 if __name__ == "__main__":

--- a/shared_strategies/registry.py
+++ b/shared_strategies/registry.py
@@ -940,7 +940,12 @@ def _position_close_frame(df: pd.DataFrame, close_fraction: float, reason: str) 
     {"pct": 0.03},
 )
 def tp_at_pct_strategy(df: pd.DataFrame, pct: float = 0.03, **params) -> pd.DataFrame:
-    """Reference close evaluator for position-aware wiring tests (#496)."""
+    """Reference close evaluator for position-aware wiring tests (#496).
+
+    Entry ATR is available only when the entry strategy's result includes an
+    ``atr`` column; check scripts copy that last-row value into ``entry_atr``.
+    ATR-dependent close evaluators should return a no-op reason when it is 0.
+    """
     avg_cost = _position_float(params, "avg_cost")
     current_quantity = _position_float(params, "current_quantity")
     initial_quantity = _position_float(params, "initial_quantity")

--- a/shared_strategies/registry.py
+++ b/shared_strategies/registry.py
@@ -917,6 +917,61 @@ def session_breakout_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
     return session_breakout_core(df, **params)
 
 
+def _position_float(params: dict, key: str) -> float:
+    try:
+        return float(params.get(key, 0) or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _position_close_frame(df: pd.DataFrame, close_fraction: float, reason: str) -> pd.DataFrame:
+    result = df.tail(1).copy()
+    if result.empty:
+        result = pd.DataFrame({"close": [0.0]})
+    result["signal"] = 0
+    result["close_fraction"] = close_fraction
+    result["reason"] = reason
+    return result
+
+
+@register(
+    "tp_at_pct",
+    "Position-aware test close — close when mark reaches a profit percentage from avg cost",
+    {"pct": 0.03},
+)
+def tp_at_pct_strategy(df: pd.DataFrame, pct: float = 0.03, **params) -> pd.DataFrame:
+    """Reference close evaluator for position-aware wiring tests (#496)."""
+    avg_cost = _position_float(params, "avg_cost")
+    current_quantity = _position_float(params, "current_quantity")
+    initial_quantity = _position_float(params, "initial_quantity")
+    entry_atr = _position_float(params, "entry_atr")
+    side = str(params.get("side", "") or "").strip().lower()
+    _ = (initial_quantity, entry_atr)  # Read for the canonical wrapper shape; unused by this simple TP.
+
+    if df.empty or "close" not in df.columns:
+        return _position_close_frame(df, 0.0, "noop:missing_mark_price")
+    if avg_cost <= 0 or current_quantity <= 0 or side not in ("long", "short"):
+        return _position_close_frame(df, 0.0, "noop:missing_position")
+    try:
+        mark_price = float(df["close"].iloc[-1])
+    except (TypeError, ValueError):
+        return _position_close_frame(df, 0.0, "noop:missing_mark_price")
+    if mark_price <= 0:
+        return _position_close_frame(df, 0.0, "noop:missing_mark_price")
+
+    try:
+        threshold = max(float(pct), 0.0)
+    except (TypeError, ValueError):
+        threshold = 0.0
+    if side == "long":
+        pnl_pct = (mark_price - avg_cost) / avg_cost
+    else:
+        pnl_pct = (avg_cost - mark_price) / avg_cost
+    if pnl_pct >= threshold:
+        return _position_close_frame(df, 1.0, "tp_at_pct:hit")
+    return _position_close_frame(df, 0.0, "noop:not_hit")
+
+
 # ─────────────────────────────────────────────
 # Per-platform display order.
 # These lists MUST match the legacy registration order in each shim so
@@ -932,6 +987,7 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "heikin_ashi_ema", "order_blocks", "vwap_reversion", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
         "sweep_squeeze_combo", "adx_trend", "donchian_breakout",
+        "tp_at_pct",
     ],
     "futures": [
         "sma_crossover", "ema_crossover", "bollinger_bands", "volume_weighted",
@@ -941,6 +997,6 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "heikin_ashi_ema", "order_blocks", "vwap_reversion", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
         "sweep_squeeze_combo", "adx_trend", "delta_neutral_funding",
-        "donchian_breakout", "session_breakout",
+        "donchian_breakout", "session_breakout", "tp_at_pct",
     ],
 }

--- a/shared_strategies/spot/strategies.py
+++ b/shared_strategies/spot/strategies.py
@@ -9,6 +9,7 @@ the surface (``STRATEGY_REGISTRY`` dict, ``apply_strategy``, ``list_strategies``
 """
 
 import importlib.util
+import inspect
 import json
 import os
 import sys
@@ -35,6 +36,7 @@ def _load_registry_module():
 _registry = _load_registry_module()
 
 STRATEGY_REGISTRY: Dict[str, dict] = _registry.build_registry("spot")
+POSITION_CONTEXT_PARAM_KEYS = {"side", "avg_cost", "current_quantity", "initial_quantity", "entry_atr"}
 
 
 def get_strategy(name: str) -> dict:
@@ -51,7 +53,27 @@ def apply_strategy(name: str, df: pd.DataFrame, params: Optional[dict] = None) -
     """Apply a named strategy with optional parameter overrides."""
     strat = get_strategy(name)
     p = {**strat["default_params"], **(params or {})}
+    p = _strip_unsupported_position_context(strat["fn"], p)
     return strat["fn"](df, **p)
+
+
+def _strip_unsupported_position_context(fn, params: dict) -> dict:
+    if not params:
+        return params
+    sig = inspect.signature(fn)
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+        return params
+    accepted = {
+        name for name, p in sig.parameters.items()
+        if name != "df" and p.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+    }
+    return {
+        key: value for key, value in params.items()
+        if key in accepted or key not in POSITION_CONTEXT_PARAM_KEYS
+    }
 
 
 if __name__ == "__main__":

--- a/shared_strategies/spot/strategies.py
+++ b/shared_strategies/spot/strategies.py
@@ -9,13 +9,18 @@ the surface (``STRATEGY_REGISTRY`` dict, ``apply_strategy``, ``list_strategies``
 """
 
 import importlib.util
-import inspect
 import json
 import os
 import sys
 from typing import Dict, List, Optional
 
 import pandas as pd
+
+_TOOLS_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "shared_tools")
+if _TOOLS_DIR not in sys.path:
+    sys.path.insert(0, _TOOLS_DIR)
+
+from strategy_composition import strip_unsupported_position_context
 
 
 def _load_registry_module():
@@ -36,7 +41,6 @@ def _load_registry_module():
 _registry = _load_registry_module()
 
 STRATEGY_REGISTRY: Dict[str, dict] = _registry.build_registry("spot")
-POSITION_CONTEXT_PARAM_KEYS = {"side", "avg_cost", "current_quantity", "initial_quantity", "entry_atr"}
 
 
 def get_strategy(name: str) -> dict:
@@ -53,27 +57,8 @@ def apply_strategy(name: str, df: pd.DataFrame, params: Optional[dict] = None) -
     """Apply a named strategy with optional parameter overrides."""
     strat = get_strategy(name)
     p = {**strat["default_params"], **(params or {})}
-    p = _strip_unsupported_position_context(strat["fn"], p)
+    p = strip_unsupported_position_context(strat["fn"], p)
     return strat["fn"](df, **p)
-
-
-def _strip_unsupported_position_context(fn, params: dict) -> dict:
-    if not params:
-        return params
-    sig = inspect.signature(fn)
-    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
-        return params
-    accepted = {
-        name for name, p in sig.parameters.items()
-        if name != "df" and p.kind in (
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            inspect.Parameter.KEYWORD_ONLY,
-        )
-    }
-    return {
-        key: value for key, value in params.items()
-        if key in accepted or key not in POSITION_CONTEXT_PARAM_KEYS
-    }
 
 
 if __name__ == "__main__":

--- a/shared_tools/strategy_composition.py
+++ b/shared_tools/strategy_composition.py
@@ -9,6 +9,7 @@ separately, then compose them back to the existing signal contract.
 from __future__ import annotations
 
 import json
+import inspect
 from dataclasses import dataclass
 from typing import Callable, Iterable, Optional
 
@@ -17,6 +18,7 @@ import pandas as pd
 
 VALID_POSITION_SIDES = {"", "long", "short"}
 VALID_OPEN_ACTIONS = {"long", "short", "none"}
+POSITION_CONTEXT_PARAM_KEYS = {"side", "avg_cost", "current_quantity", "initial_quantity", "entry_atr"}
 
 
 @dataclass
@@ -161,6 +163,25 @@ def _merge_close_params(base: Optional[dict], position_ctx: Optional[dict]) -> O
     merged = dict(base or {})
     merged.update(position_ctx)
     return merged
+
+
+def strip_unsupported_position_context(fn, params: dict) -> dict:
+    if not params:
+        return params
+    sig = inspect.signature(fn)
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+        return params
+    accepted = {
+        name for name, p in sig.parameters.items()
+        if name != "df" and p.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+    }
+    return {
+        key: value for key, value in params.items()
+        if key in accepted or key not in POSITION_CONTEXT_PARAM_KEYS
+    }
 
 
 def evaluate_open_close(

--- a/shared_tools/strategy_composition.py
+++ b/shared_tools/strategy_composition.py
@@ -8,6 +8,7 @@ separately, then compose them back to the existing signal contract.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Callable, Iterable, Optional
 
@@ -145,6 +146,23 @@ def _last_close_fraction(result_df: pd.DataFrame, signal: int, position_side: st
     return legacy_close_fraction_from_signal(signal, position_side)
 
 
+def _cache_key_params(params: Optional[dict]) -> str:
+    if params is None:
+        return ""
+    try:
+        return json.dumps(params, sort_keys=True, default=str)
+    except TypeError:
+        return repr(sorted((str(k), repr(v)) for k, v in params.items()))
+
+
+def _merge_close_params(base: Optional[dict], position_ctx: Optional[dict]) -> Optional[dict]:
+    if not position_ctx:
+        return base
+    merged = dict(base or {})
+    merged.update(position_ctx)
+    return merged
+
+
 def evaluate_open_close(
     apply_strategy: Callable[[str, pd.DataFrame, Optional[dict]], pd.DataFrame],
     get_strategy: Callable[[str], object],
@@ -155,17 +173,18 @@ def evaluate_open_close(
     position_side: str,
     disable_implicit_close: bool,
     params: Optional[dict] = None,
+    position_ctx: Optional[dict] = None,
 ) -> OpenCloseEvaluation:
     open_name = (open_strategy or positional_strategy).strip()
     close_names = effective_close_strategies(
         positional_strategy, open_name, close_strategies, disable_implicit_close
     )
-    cache: dict[tuple[str, bool], pd.DataFrame] = {}
+    cache: dict[tuple[str, str], pd.DataFrame] = {}
 
     def run(name: str, run_params: Optional[dict]) -> pd.DataFrame:
         if not name:
             raise ValueError("strategy name must not be empty")
-        key = (name, run_params is not None)
+        key = (name, _cache_key_params(run_params))
         if key not in cache:
             get_strategy(name)
             cache[key] = apply_strategy(name, df, run_params)
@@ -178,7 +197,8 @@ def evaluate_open_close(
         # Until per-close params blocks exist, only the implicit-self close
         # shares the open strategy's params. Distinct close strategies run with
         # their own defaults so open-only params do not break another function.
-        close_params = params if name == open_name else None
+        base_close_params = params if name == open_name else None
+        close_params = _merge_close_params(base_close_params, position_ctx)
         result = run(name, close_params)
         signal = _last_signal(result)
         close_evals.append(CloseEvaluation(

--- a/shared_tools/test_strategy_composition.py
+++ b/shared_tools/test_strategy_composition.py
@@ -1,3 +1,6 @@
+import importlib.util
+from pathlib import Path
+
 import pandas as pd
 
 from strategy_composition import (
@@ -84,3 +87,118 @@ def test_disable_implicit_close_ignores_reversal_without_explicit_close():
     assert decision["close_strategies"] == []
     assert decision["close_fraction"] == 0.0
     assert decision["signal"] == 0
+
+
+def test_evaluate_open_close_passes_position_ctx_to_close_only():
+    calls = []
+    df = pd.DataFrame({"close": [100, 106]})
+
+    def get_strategy(name):
+        assert name in {"open", "close"}
+
+    def apply_strategy(name, data, params=None):
+        calls.append((name, dict(params or {})))
+        result = data.copy()
+        result["signal"] = 0
+        if name == "close":
+            result["close_fraction"] = 1.0 if params and params.get("avg_cost") == 100 else 0.0
+        return result
+
+    evaluation = evaluate_open_close(
+        apply_strategy,
+        get_strategy,
+        df,
+        positional_strategy="legacy",
+        open_strategy="open",
+        close_strategies=["close"],
+        position_side="long",
+        disable_implicit_close=False,
+        params={"open_only": 1},
+        position_ctx={
+            "side": "long",
+            "avg_cost": 100,
+            "current_quantity": 0.5,
+            "initial_quantity": 1.0,
+            "entry_atr": 12.5,
+        },
+    )
+    decision = finalize_decision(evaluation, position_side="long")
+
+    assert calls[0] == ("open", {"open_only": 1})
+    assert calls[1] == (
+        "close",
+        {
+            "side": "long",
+            "avg_cost": 100,
+            "current_quantity": 0.5,
+            "initial_quantity": 1.0,
+            "entry_atr": 12.5,
+        },
+    )
+    assert decision["close_fraction"] == 1.0
+    assert decision["signal"] == -1
+
+
+def test_evaluate_open_close_reruns_same_strategy_when_close_params_differ():
+    calls = []
+    df = pd.DataFrame({"close": [100, 106]})
+
+    def get_strategy(name):
+        assert name == "same"
+
+    def apply_strategy(name, data, params=None):
+        calls.append(dict(params or {}))
+        result = data.copy()
+        result["signal"] = [0, 0]
+        result["close_fraction"] = 1.0 if params and params.get("avg_cost") == 100 else 0.0
+        return result
+
+    evaluation = evaluate_open_close(
+        apply_strategy,
+        get_strategy,
+        df,
+        positional_strategy="same",
+        open_strategy=None,
+        close_strategies=None,
+        position_side="long",
+        disable_implicit_close=False,
+        params={"lookback": 5},
+        position_ctx={"avg_cost": 100},
+    )
+
+    assert calls == [{"lookback": 5}, {"lookback": 5, "avg_cost": 100}]
+    assert finalize_decision(evaluation, position_side="long")["close_fraction"] == 1.0
+
+
+def test_tp_at_pct_position_aware_close_handles_missing_and_hit():
+    strategy_path = Path(__file__).resolve().parents[1] / "shared_strategies" / "spot" / "strategies.py"
+    spec = importlib.util.spec_from_file_location("_spot_strategies_for_tp_test", strategy_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    df = pd.DataFrame({"close": [100, 106]})
+    missing = mod.apply_strategy("tp_at_pct", df)
+    assert missing.iloc[-1]["close_fraction"] == 0.0
+    assert missing.iloc[-1]["reason"] == "noop:missing_position"
+
+    legacy = mod.apply_strategy(
+        "sma_crossover",
+        df,
+        {"side": "long", "avg_cost": 100, "current_quantity": 0.5},
+    )
+    assert "signal" in legacy.columns
+
+    hit = mod.apply_strategy(
+        "tp_at_pct",
+        df,
+        {
+            "pct": 0.05,
+            "side": "long",
+            "avg_cost": 100,
+            "current_quantity": 0.5,
+            "initial_quantity": 1.0,
+            "entry_atr": 12.5,
+        },
+    )
+    assert hit.iloc[-1]["close_fraction"] == 1.0
+    assert hit.iloc[-1]["reason"] == "tp_at_pct:hit"


### PR DESCRIPTION
## Summary
- Thread position context through open/close composition so close evaluators can see `avg_cost`, `current_quantity`, `initial_quantity`, `entry_atr`, and `side`
- Add durable `initial_quantity` and `entry_atr` fields to positions with SQLite migration and state load/save support
- Add a reference `tp_at_pct` close evaluator plus hot-reload support for open/close composition fields
- Update check scripts and strategy shims to pass and safely ignore position context where unsupported

Closes #496

## Testing
- `go test ./...` in `scheduler`
- `go build .` in `scheduler`
- Python compilation checks for updated scripts
- Pytest coverage for strategy composition, registry parity, and strategy suites