### PR TITLE
feat(hl-perps): add trailing_stop_atr_mult as ATR-derived trailing stop

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -209,6 +209,7 @@ type StrategyConfig struct {
 	StopLossPct            *float64               `json:"stop_loss_pct,omitempty"`              // HL perps only: % from entry to place a reduce-only stop-loss trigger. Pointer so omitted (nil) falls through to StopLossMarginPct then MaxDrawdownPct for single-coin strategies (#484); LoadConfig normalizes omitted same-coin peers to explicit 0 (#494); explicit 0 disables auto-SL (#412)
 	StopLossMarginPct      *float64               `json:"stop_loss_margin_pct,omitempty"`       // HL perps only: % of deployed margin to lose before stop-loss trigger; mutually exclusive with stop_loss_pct; price % derived as StopLossMarginPct / Leverage at order time. Pointer so omitted falls through to MaxDrawdownPct for single-coin strategies; LoadConfig normalizes omitted same-coin peers to explicit 0 (#494); explicit 0 disables (#487, #484)
 	TrailingStopPct        *float64               `json:"trailing_stop_pct,omitempty"`          // HL perps only: synthetic trailing SL distance from the best mark seen while open; mutually exclusive with stop_loss_pct and stop_loss_margin_pct (#501)
+	TrailingStopATRMult    *float64               `json:"trailing_stop_atr_mult,omitempty"`     // HL perps only: trailing SL distance derived from entry ATR at open (effective_pct = mult * entry_atr / avg_cost * 100); fixed for the life of the position; mutually exclusive with trailing_stop_pct, stop_loss_pct, stop_loss_margin_pct (#505)
 	TrailingStopMinMovePct *float64               `json:"trailing_stop_min_move_pct,omitempty"` // HL perps trailing SL only: minimum trigger-price move before cancel/replace; nil defaults to 0.5% (#501)
 	MarginMode             string                 `json:"margin_mode,omitempty"`                // HL perps only: "isolated" (default) or "cross"; sent via update_leverage on fresh opens to enforce per-position liq isolation (#486)
 	Params                 map[string]interface{} `json:"params,omitempty"`                     // custom strategy parameters passed to Python
@@ -249,20 +250,31 @@ const MaxAutoStopLossPct = 50.0
 
 // EffectiveStopLossPct returns the price % to use as the HL reduce-only stop-loss
 // trigger for a given strategy. Resolution order (#484):
-//  1. Explicit TrailingStopPct (nil → fall through; explicit 0 → disabled).
-//  2. Explicit StopLossPct (nil → fall through; explicit 0 → disabled).
-//  3. StopLossMarginPct / Leverage (nil → fall through; explicit 0 → disabled).
-//  4. MaxDrawdownPct as a fallback so a sole-owner HL perps strategy with a
+//  1. Explicit TrailingStopATRMult (nil → fall through; explicit 0 → disabled).
+//     Returns 0 because the price % can only be derived once a position carries
+//     EntryATR and AvgCost — initial trigger placement is deferred to the next
+//     trailing-stop cycle (#505).
+//  2. Explicit TrailingStopPct (nil → fall through; explicit 0 → disabled).
+//  3. Explicit StopLossPct (nil → fall through; explicit 0 → disabled).
+//  4. StopLossMarginPct / Leverage (nil → fall through; explicit 0 → disabled).
+//  5. MaxDrawdownPct as a fallback so a sole-owner HL perps strategy with a
 //     configured drawdown automatically gets exchange-side protection. Capped
 //     at MaxAutoStopLossPct. Only applies to single-strategy coins because
-//     LoadConfig normalizes omitted stop_loss_* / trailing_stop_pct fields to
-//     explicit 0 for
-//     same-coin HL peer strategies (#494).
+//     LoadConfig normalizes omitted stop_loss_* / trailing_stop_* fields to
+//     explicit 0 for same-coin HL peer strategies (#494).
 //
 // HL perps only — returns 0 for non-HL platforms or non-perps types so the
 // caller can skip the trigger placement unconditionally.
 func EffectiveStopLossPct(sc StrategyConfig) float64 {
 	if sc.Platform != "hyperliquid" || sc.Type != "perps" {
+		return 0
+	}
+	if sc.TrailingStopATRMult != nil {
+		// ATR-derived trailing stop. The price % depends on per-position
+		// EntryATR and AvgCost which are not available at order placement
+		// time (the position record is created after the fill). The trailing
+		// stop loop arms the initial trigger on the next cycle once
+		// stampEntryATRIfOpened has populated Position.EntryATR (#505).
 		return 0
 	}
 	if sc.TrailingStopPct != nil {
@@ -487,9 +499,9 @@ func LoadConfig(path string) (*Config, error) {
 // normalizeHyperliquidPeerStopLosses preserves the single-strategy auto-SL
 // fallback while avoiding accidental reduce-only trigger races for same-coin
 // peer strategies (#494). When multiple HL perps strategies share a coin,
-// omitted stop_loss_* / trailing_stop_pct fields are treated as an explicit
+// omitted stop_loss_* / trailing_stop_* fields are treated as an explicit
 // opt-out; operators can still select one owner with a positive stop_loss_pct,
-// stop_loss_margin_pct, or trailing_stop_pct.
+// stop_loss_margin_pct, trailing_stop_pct, or trailing_stop_atr_mult.
 func normalizeHyperliquidPeerStopLosses(strategies []StrategyConfig) {
 	type peerRef struct {
 		ID    string
@@ -520,7 +532,7 @@ func normalizeHyperliquidPeerStopLosses(strategies []StrategyConfig) {
 		sort.Slice(peers, func(i, j int) bool { return peers[i].ID < peers[j].ID })
 		for _, p := range peers {
 			sc := &strategies[p.Index]
-			if sc.StopLossPct == nil && sc.StopLossMarginPct == nil && sc.TrailingStopPct == nil {
+			if sc.StopLossPct == nil && sc.StopLossMarginPct == nil && sc.TrailingStopPct == nil && sc.TrailingStopATRMult == nil {
 				zero := 0.0
 				sc.StopLossPct = &zero
 			}
@@ -528,11 +540,27 @@ func normalizeHyperliquidPeerStopLosses(strategies []StrategyConfig) {
 	}
 }
 
+// hasHyperliquidStopLossOwnership reports whether sc would place a reduce-only
+// HL trigger at any point in its lifecycle. It is the peer-conflict predicate
+// rather than the runtime price-% predicate: TrailingStopATRMult arms an
+// initial trigger only on the cycle after the position opens (EntryATR must be
+// stamped first), so EffectiveStopLossPct returns 0 at order-placement time.
+// Peer validation must still treat that strategy as the trigger owner.
+func hasHyperliquidStopLossOwnership(sc StrategyConfig) bool {
+	if EffectiveStopLossPct(sc) > 0 {
+		return true
+	}
+	if sc.TrailingStopATRMult != nil && *sc.TrailingStopATRMult > 0 {
+		return true
+	}
+	return false
+}
+
 // hyperliquidPeerStrategyErrors returns validation messages for HL perps
 // strategies that share a coin but disagree on MarginMode or exchange Leverage (#491),
-// or that have more than one stop-loss owner (EffectiveStopLossPct > 0 after
-// LoadConfig peer normalization, #494, including trailing stops from #501).
-// Returns an empty slice when no peer conflicts exist.
+// or that have more than one stop-loss owner (after LoadConfig peer
+// normalization, #494, including trailing stops from #501 and ATR-derived
+// trailing stops from #505). Returns an empty slice when no peer conflicts exist.
 //
 // HL aggregates positions per coin per account, so two go-trader strategies
 // on the same coin share an on-chain position, margin assignment, and
@@ -559,11 +587,11 @@ func normalizeHyperliquidPeerStopLosses(strategies []StrategyConfig) {
 // any on-chain conflict.
 func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 	type peer struct {
-		ID             string
-		Coin           string
-		MarginMode     string
-		Leverage       float64
-		EffectiveSLPct float64 // resolved after LoadConfig peer normalization: >0 means this strategy owns a trigger
+		ID         string
+		Coin       string
+		MarginMode string
+		Leverage   float64
+		OwnsSL     bool // resolved after LoadConfig peer normalization: true means this strategy owns a trigger
 	}
 	groups := make(map[string][]peer)
 	for _, sc := range strategies {
@@ -575,11 +603,11 @@ func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 			continue
 		}
 		groups[coin] = append(groups[coin], peer{
-			ID:             sc.ID,
-			Coin:           coin,
-			MarginMode:     sc.MarginMode,
-			Leverage:       sc.Leverage,
-			EffectiveSLPct: EffectiveStopLossPct(sc),
+			ID:         sc.ID,
+			Coin:       coin,
+			MarginMode: sc.MarginMode,
+			Leverage:   sc.Leverage,
+			OwnsSL:     hasHyperliquidStopLossOwnership(sc),
 		})
 	}
 	var errs []string
@@ -621,14 +649,14 @@ func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 		}
 		stopLossOwners := make([]string, 0)
 		for _, p := range peers {
-			if p.EffectiveSLPct > 0 {
+			if p.OwnsSL {
 				stopLossOwners = append(stopLossOwners, p.ID)
 			}
 		}
 		if len(stopLossOwners) > 1 {
 			sort.Strings(stopLossOwners)
 			errs = append(errs, fmt.Sprintf(
-				"hyperliquid peers on %s have conflicting stop_loss_pct/trailing_stop_pct (strategies %s): at most one peer may place a reduce-only SL trigger; the others' OIDs would race on the shared on-chain position",
+				"hyperliquid peers on %s have conflicting stop_loss_pct/trailing_stop_pct/trailing_stop_atr_mult (strategies %s): at most one peer may place a reduce-only SL trigger; the others' OIDs would race on the shared on-chain position",
 				coin, strings.Join(stopLossOwners, ", ")))
 		}
 	}
@@ -960,6 +988,35 @@ func ValidateConfig(cfg *Config) error {
 				errs = append(errs, fmt.Sprintf("%s: trailing_stop_pct is mutually exclusive with stop_loss_pct and stop_loss_margin_pct", prefix))
 			}
 		}
+		// #505: ATR-derived trailing stops. The price % is resolved per-position
+		// at runtime from EntryATR / AvgCost, so validation only enforces shape:
+		// HL perps only, > 0, mutually exclusive with the fixed-distance stops.
+		if sc.TrailingStopATRMult != nil {
+			mult := *sc.TrailingStopATRMult
+			if mult < 0 {
+				errs = append(errs, fmt.Sprintf("%s: trailing_stop_atr_mult must be >= 0, got %g", prefix, mult))
+			}
+			if sc.Type != "perps" || sc.Platform != "hyperliquid" {
+				errs = append(errs, fmt.Sprintf("%s: trailing_stop_atr_mult is only supported for HL perps strategies (got platform=%q type=%q)", prefix, sc.Platform, sc.Type))
+			}
+			if mult > 0 {
+				fixedPct := 0.0
+				if sc.StopLossPct != nil {
+					fixedPct = *sc.StopLossPct
+				}
+				marginPct := 0.0
+				if sc.StopLossMarginPct != nil {
+					marginPct = *sc.StopLossMarginPct
+				}
+				trailingPct := 0.0
+				if sc.TrailingStopPct != nil {
+					trailingPct = *sc.TrailingStopPct
+				}
+				if fixedPct > 0 || marginPct > 0 || trailingPct > 0 {
+					errs = append(errs, fmt.Sprintf("%s: trailing_stop_atr_mult is mutually exclusive with stop_loss_pct, stop_loss_margin_pct, and trailing_stop_pct", prefix))
+				}
+			}
+		}
 		if sc.TrailingStopMinMovePct != nil {
 			pct := *sc.TrailingStopMinMovePct
 			if pct < 0 || pct > 100 {
@@ -968,8 +1025,16 @@ func ValidateConfig(cfg *Config) error {
 			if sc.Type != "perps" || sc.Platform != "hyperliquid" {
 				errs = append(errs, fmt.Sprintf("%s: trailing_stop_min_move_pct is only supported for HL perps strategies (got platform=%q type=%q)", prefix, sc.Platform, sc.Type))
 			}
-			if effectiveTrailingStopPct(sc) <= 0 {
-				errs = append(errs, fmt.Sprintf("%s: trailing_stop_min_move_pct requires trailing_stop_pct > 0", prefix))
+			fixedTrailingPct := 0.0
+			if sc.TrailingStopPct != nil {
+				fixedTrailingPct = *sc.TrailingStopPct
+			}
+			atrMult := 0.0
+			if sc.TrailingStopATRMult != nil {
+				atrMult = *sc.TrailingStopATRMult
+			}
+			if fixedTrailingPct <= 0 && atrMult <= 0 {
+				errs = append(errs, fmt.Sprintf("%s: trailing_stop_min_move_pct requires trailing_stop_pct > 0 or trailing_stop_atr_mult > 0", prefix))
 			}
 		}
 

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -250,10 +250,12 @@ const MaxAutoStopLossPct = 50.0
 
 // EffectiveStopLossPct returns the price % to use as the HL reduce-only stop-loss
 // trigger for a given strategy. Resolution order (#484):
-//  1. Explicit TrailingStopATRMult (nil → fall through; explicit 0 → disabled).
-//     Returns 0 because the price % can only be derived once a position carries
-//     EntryATR and AvgCost — initial trigger placement is deferred to the next
-//     trailing-stop cycle (#505).
+//  1. Explicit TrailingStopATRMult > 0 returns 0 because the price % can only
+//     be derived once a position carries EntryATR and AvgCost — initial
+//     trigger placement is deferred to the next trailing-stop cycle (#505).
+//     Explicit 0 falls through to the next priority instead of short-
+//     circuiting; a config like {trailing_stop_atr_mult: 0, stop_loss_pct: 2}
+//     is rare but well-defined and the explicit fixed stop should still arm.
 //  2. Explicit TrailingStopPct (nil → fall through; explicit 0 → disabled).
 //  3. Explicit StopLossPct (nil → fall through; explicit 0 → disabled).
 //  4. StopLossMarginPct / Leverage (nil → fall through; explicit 0 → disabled).
@@ -269,7 +271,7 @@ func EffectiveStopLossPct(sc StrategyConfig) float64 {
 	if sc.Platform != "hyperliquid" || sc.Type != "perps" {
 		return 0
 	}
-	if sc.TrailingStopATRMult != nil {
+	if sc.TrailingStopATRMult != nil && *sc.TrailingStopATRMult > 0 {
 		// ATR-derived trailing stop. The price % depends on per-position
 		// EntryATR and AvgCost which are not available at order placement
 		// time (the position record is created after the fill). The trailing

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -91,6 +91,10 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 			addChange("strategy[%s].trailing_stop_pct: %s -> %s", sc.ID, formatFloatPtrPct(sc.TrailingStopPct), formatFloatPtrPct(ns.TrailingStopPct))
 			sc.TrailingStopPct = ns.TrailingStopPct
 		}
+		if !floatPtrEqual(sc.TrailingStopATRMult, ns.TrailingStopATRMult) {
+			addChange("strategy[%s].trailing_stop_atr_mult: %s -> %s", sc.ID, formatFloatPtr(sc.TrailingStopATRMult), formatFloatPtr(ns.TrailingStopATRMult))
+			sc.TrailingStopATRMult = ns.TrailingStopATRMult
+		}
 		if !floatPtrEqual(sc.TrailingStopMinMovePct, ns.TrailingStopMinMovePct) {
 			addChange("strategy[%s].trailing_stop_min_move_pct: %s -> %s", sc.ID, formatFloatPtrPct(sc.TrailingStopMinMovePct), formatFloatPtrPct(ns.TrailingStopMinMovePct))
 			sc.TrailingStopMinMovePct = ns.TrailingStopMinMovePct
@@ -262,6 +266,16 @@ func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error 
 				errs = append(errs, fmt.Sprintf("strategy[%s] trailing_stop_pct mode changed with open positions (flatten first or restart after close)",
 					sc.ID))
 			}
+			// #505: ATR-derived trailing stop pct is computed once per
+			// position from the entry ATR; toggling the mode mid-position
+			// would mix two distance regimes against the same on-chain
+			// trigger. Treat exactly like trailing_stop_pct.
+			oldATR := sc.TrailingStopATRMult != nil && *sc.TrailingStopATRMult > 0
+			newATR := ns.TrailingStopATRMult != nil && *ns.TrailingStopATRMult > 0
+			if oldATR != newATR {
+				errs = append(errs, fmt.Sprintf("strategy[%s] trailing_stop_atr_mult mode changed with open positions (flatten first or restart after close)",
+					sc.ID))
+			}
 		}
 	}
 	if len(errs) > 0 {
@@ -281,6 +295,7 @@ func strategyRestartShape(sc StrategyConfig) StrategyConfig {
 	sc.CloseStrategies = nil
 	sc.MarginMode = ""              // #486: hot-reloadable when flat (state-compat check enforces flat-only change)
 	sc.TrailingStopPct = nil        // #501: hot-reloadable; state-compat allows pct changes but blocks mode switches while open
+	sc.TrailingStopATRMult = nil    // #505: hot-reloadable; same state-compat treatment as TrailingStopPct
 	sc.TrailingStopMinMovePct = nil // #501: hot-reloadable tuning knob for trailing trigger churn
 	return sc
 }
@@ -297,6 +312,13 @@ func formatFloatPtrPct(p *float64) string {
 		return "<nil>"
 	}
 	return fmt.Sprintf("%.2f%%", *p)
+}
+
+func formatFloatPtr(p *float64) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%g", *p)
 }
 
 func strategyConfigByID(strategies []StrategyConfig) map[string]StrategyConfig {

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -94,6 +94,14 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 		if !floatPtrEqual(sc.TrailingStopATRMult, ns.TrailingStopATRMult) {
 			addChange("strategy[%s].trailing_stop_atr_mult: %s -> %s", sc.ID, formatFloatPtr(sc.TrailingStopATRMult), formatFloatPtr(ns.TrailingStopATRMult))
 			sc.TrailingStopATRMult = ns.TrailingStopATRMult
+			// #505 review: when ATR-mult is disabled (or zeroed) the
+			// missing-EntryATR throttle no longer applies — drop any
+			// outstanding keys for this strategy so the next regime
+			// (e.g. fixed trailing_stop_pct or no trailing stop at all)
+			// starts with a clean slate.
+			if ns.TrailingStopATRMult == nil || *ns.TrailingStopATRMult <= 0 {
+				clearATRMultMissingEntryATRWarningsForStrategy(sc.ID)
+			}
 		}
 		if !floatPtrEqual(sc.TrailingStopMinMovePct, ns.TrailingStopMinMovePct) {
 			addChange("strategy[%s].trailing_stop_min_move_pct: %s -> %s", sc.ID, formatFloatPtrPct(sc.TrailingStopMinMovePct), formatFloatPtrPct(ns.TrailingStopMinMovePct))

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -1283,6 +1283,7 @@ func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, f
 		// right amount. delete() runs after the snapshot.
 		recordClosedPosition(s, pos, fillPx, pnl, "circuit_breaker", now)
 		delete(s.Positions, symbol)
+		clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
 	} else {
 		pos.Quantity = remaining
 	}

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -294,6 +294,7 @@ func reconcileHyperliquidPositions(stratState *StrategyState, sym string, positi
 		// close_reason != 'hl_sync_external' to avoid biased aggregates.
 		recordClosedPosition(stratState, statePos, 0, 0, "hl_sync_external", time.Now().UTC())
 		delete(stratState.Positions, sym)
+		clearATRMultMissingEntryATRWarningOnHLPerpsClose(stratState, sym)
 		changed = true
 	}
 	// If on-chain exists but NOT in this strategy's state, we skip it —

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -248,7 +248,7 @@ func TestRunHyperliquidTrailingStopUpdate_CancelThenPlaceArgs(t *testing.T) {
 	logger := silentStrategyLogger("hl-test")
 	defer logger.Close()
 
-	newHighWater, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 0.5, 100, 0, 110, 100, 97, 111, nil, logger)
+	newHighWater, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 0.5, &Position{AvgCost: 100}, 110, 100, 97, 111, nil, logger)
 	if !ok {
 		t.Fatalf("runHyperliquidTrailingStopUpdate returned ok=false")
 	}
@@ -287,7 +287,7 @@ func TestRunHyperliquidTrailingStopUpdate_AlertsOnOrphanedOldOID(t *testing.T) {
 		ownerID:  "owner",
 	})
 
-	_, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 0.5, 100, 0, 110, 100, 97, 111, notifier, logger)
+	_, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 0.5, &Position{AvgCost: 100}, 110, 100, 97, 111, notifier, logger)
 	if !ok || result == nil || result.StopLossOID != 222 {
 		t.Fatalf("runHyperliquidTrailingStopUpdate = (%+v, %v), want placed replacement", result, ok)
 	}
@@ -1322,5 +1322,142 @@ func TestStrategyConfig_TrailingStopATRMultJSON(t *testing.T) {
 	}
 	if !strings.Contains(string(b3), `"trailing_stop_atr_mult":0`) {
 		t.Errorf("explicit zero TrailingStopATRMult must round-trip; got %s", b3)
+	}
+}
+
+// #505 review: a volatile coin (e.g. mult=3 with ATR ≈ 30% of price) would
+// otherwise produce a derived 90% trailing distance and a long-side trigger
+// price <= 0 that HL silently rejects. effectiveTrailingStopPct must clamp the
+// derived percentage to MaxAutoStopLossPct (50) to mirror the cap on the other
+// auto-derive paths in EffectiveStopLossPct.
+func TestEffectiveTrailingStopPct_ATRMultCappedAtMaxAutoStopLossPct(t *testing.T) {
+	pf := func(v float64) *float64 { return &v }
+	sc := StrategyConfig{
+		Platform:            "hyperliquid",
+		Type:                "perps",
+		TrailingStopATRMult: pf(3),
+	}
+	pos := &Position{AvgCost: 100, EntryATR: 30} // raw derived = 3 * 30 / 100 * 100 = 90%
+	got := effectiveTrailingStopPct(sc, pos)
+	if got != MaxAutoStopLossPct {
+		t.Errorf("effectiveTrailingStopPct = %g, want %g (capped at MaxAutoStopLossPct)", got, MaxAutoStopLossPct)
+	}
+
+	// Just under the cap stays exactly the derived value.
+	sc.TrailingStopATRMult = pf(1.5)
+	pos = &Position{AvgCost: 100, EntryATR: 20} // raw derived = 30%
+	got = effectiveTrailingStopPct(sc, pos)
+	if d := got - 30.0; d > 1e-9 || d < -1e-9 {
+		t.Errorf("effectiveTrailingStopPct = %g, want 30 (under cap, no clamp)", got)
+	}
+}
+
+// #505 review: explicit-zero TrailingStopATRMult must fall through to the
+// next priority instead of short-circuiting EffectiveStopLossPct. A config
+// like {trailing_stop_atr_mult: 0, stop_loss_pct: 2} passes validation
+// (mutex check skips when ATR mult == 0) and the explicit fixed stop should
+// still arm the on-chain trigger.
+func TestEffectiveStopLossPct_ATRMultExplicitZeroFallsThrough(t *testing.T) {
+	pf := func(v float64) *float64 { return &v }
+	sc := StrategyConfig{
+		Platform:            "hyperliquid",
+		Type:                "perps",
+		Leverage:            5,
+		MaxDrawdownPct:      10,
+		TrailingStopATRMult: pf(0),
+		StopLossPct:         pf(2),
+	}
+	if got := EffectiveStopLossPct(sc); got != 2 {
+		t.Errorf("EffectiveStopLossPct with ATR mult=0 + stop_loss_pct=2 = %g, want 2 (fall through)", got)
+	}
+
+	// And with no other field set, mult=0 falls through to MaxDrawdownPct.
+	sc.StopLossPct = nil
+	sc.MaxDrawdownPct = 8
+	if got := EffectiveStopLossPct(sc); got != 8 {
+		t.Errorf("EffectiveStopLossPct with ATR mult=0 + MaxDrawdownPct=8 = %g, want 8 (fall through to DD)", got)
+	}
+}
+
+// #505 review: atrMultMissingEntryATR detects the silent foot-gun where an
+// ATR-mult-configured strategy opens a position but the entry candle did not
+// produce an ATR indicator, so EntryATR stays 0 and the trailing loop never
+// arms an on-chain trigger.
+func TestATRMultMissingEntryATR(t *testing.T) {
+	pf := func(v float64) *float64 { return &v }
+	hl := func(sc StrategyConfig) StrategyConfig {
+		sc.Platform = "hyperliquid"
+		sc.Type = "perps"
+		return sc
+	}
+	cases := []struct {
+		name string
+		sc   StrategyConfig
+		pos  *Position
+		want bool
+	}{
+		{"non-HL platform", StrategyConfig{Platform: "okx", Type: "perps", TrailingStopATRMult: pf(1.5)}, &Position{AvgCost: 100, EntryATR: 0}, false},
+		{"non-perps type", StrategyConfig{Platform: "hyperliquid", Type: "spot", TrailingStopATRMult: pf(1.5)}, &Position{AvgCost: 100, EntryATR: 0}, false},
+		{"ATR mult unset", hl(StrategyConfig{}), &Position{AvgCost: 100, EntryATR: 0}, false},
+		{"ATR mult explicit zero", hl(StrategyConfig{TrailingStopATRMult: pf(0)}), &Position{AvgCost: 100, EntryATR: 0}, false},
+		{"fixed pct wins", hl(StrategyConfig{TrailingStopPct: pf(3), TrailingStopATRMult: pf(1.5)}), &Position{AvgCost: 100, EntryATR: 0}, false},
+		{"nil position", hl(StrategyConfig{TrailingStopATRMult: pf(1.5)}), nil, false},
+		{"EntryATR stamped", hl(StrategyConfig{TrailingStopATRMult: pf(1.5)}), &Position{AvgCost: 100, EntryATR: 2}, false},
+		{"missing EntryATR", hl(StrategyConfig{TrailingStopATRMult: pf(1.5)}), &Position{AvgCost: 100, EntryATR: 0}, true},
+		{"missing AvgCost", hl(StrategyConfig{TrailingStopATRMult: pf(1.5)}), &Position{AvgCost: 0, EntryATR: 2}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := atrMultMissingEntryATR(c.sc, c.pos); got != c.want {
+				t.Errorf("atrMultMissingEntryATR = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// #505 review: notifyATRMultMissingEntryATROnce must emit exactly one
+// alert per (strategy, symbol). Repeated cycles must be suppressed so the
+// alert channel is not flooded; clearATRMultMissingEntryATRWarning resets
+// the throttle for re-opens.
+func TestNotifyATRMultMissingEntryATROnce_ThrottlesPerStrategySymbol(t *testing.T) {
+	mock := &mockNotifier{}
+	notifier := NewMultiNotifier(notifierBackend{
+		notifier: mock,
+		channels: map[string]string{"hyperliquid": "chan"},
+		ownerID:  "owner",
+	})
+	logger := silentStrategyLogger("hl-test")
+	defer logger.Close()
+	sc := StrategyConfig{ID: "hl-test", Platform: "hyperliquid", Type: "perps"}
+
+	// Reset between subtests so other tests don't leak warning state.
+	defer clearATRMultMissingEntryATRWarning(sc.ID, "ETH")
+	defer clearATRMultMissingEntryATRWarning(sc.ID, "BTC")
+
+	notifyATRMultMissingEntryATROnce(sc, "ETH", notifier, logger)
+	notifyATRMultMissingEntryATROnce(sc, "ETH", notifier, logger)
+	notifyATRMultMissingEntryATROnce(sc, "ETH", notifier, logger)
+
+	if got := len(mock.messages); got != 1 {
+		t.Errorf("expected 1 broadcast for ETH, got %d (%+v)", got, mock.messages)
+	}
+	if got := len(mock.dms); got != 1 {
+		t.Errorf("expected 1 owner DM for ETH, got %d (%+v)", got, mock.dms)
+	}
+	if len(mock.messages) > 0 && !strings.Contains(mock.messages[0].content, "MISSING ENTRY ATR") {
+		t.Errorf("alert content missing MISSING ENTRY ATR phrase: %q", mock.messages[0].content)
+	}
+
+	// A different symbol on the same strategy must alert independently.
+	notifyATRMultMissingEntryATROnce(sc, "BTC", notifier, logger)
+	if got := len(mock.messages); got != 2 {
+		t.Errorf("expected 2 broadcasts after BTC alert, got %d", got)
+	}
+
+	// Clearing the throttle re-arms the alert.
+	clearATRMultMissingEntryATRWarning(sc.ID, "ETH")
+	notifyATRMultMissingEntryATROnce(sc, "ETH", notifier, logger)
+	if got := len(mock.messages); got != 3 {
+		t.Errorf("expected 3 broadcasts after clear+re-alert, got %d", got)
 	}
 }

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -1461,3 +1461,72 @@ func TestNotifyATRMultMissingEntryATROnce_ThrottlesPerStrategySymbol(t *testing.
 		t.Errorf("expected 3 broadcasts after clear+re-alert, got %d", got)
 	}
 }
+
+// #505 review follow-up: clearATRMultMissingEntryATRWarningOnHLPerpsClose
+// is the production-path shortcut wired into HL perps close sites
+// (recordPerpsStopLossClose, ExecutePerpsSignal close-long/short,
+// forceCloseAllPositions, hyperliquid_balance circuit-breaker close). It
+// must clear the throttle for HL perps and no-op for any other state, so
+// non-HL strategy closes don't accidentally drop a peer's throttle key.
+func TestClearATRMultMissingEntryATRWarningOnHLPerpsClose(t *testing.T) {
+	defer clearATRMultMissingEntryATRWarning("hl-test", "ETH")
+	defer clearATRMultMissingEntryATRWarning("spot-test", "ETH")
+
+	atrMultMissingEntryATRWarned.Store(atrMultMissingEntryATRKey("hl-test", "ETH"), struct{}{})
+	atrMultMissingEntryATRWarned.Store(atrMultMissingEntryATRKey("spot-test", "ETH"), struct{}{})
+
+	// Nil state must be safe.
+	clearATRMultMissingEntryATRWarningOnHLPerpsClose(nil, "ETH")
+	if _, ok := atrMultMissingEntryATRWarned.Load(atrMultMissingEntryATRKey("hl-test", "ETH")); !ok {
+		t.Fatalf("nil state should not have cleared HL key")
+	}
+
+	// Non-HL platform must not clear anything.
+	spotState := &StrategyState{ID: "spot-test", Platform: "binanceus", Type: "spot"}
+	clearATRMultMissingEntryATRWarningOnHLPerpsClose(spotState, "ETH")
+	if _, ok := atrMultMissingEntryATRWarned.Load(atrMultMissingEntryATRKey("spot-test", "ETH")); !ok {
+		t.Fatalf("non-HL close should not have cleared spot-test key")
+	}
+
+	// HL spot must not clear (the throttle only fires for HL perps).
+	hlSpot := &StrategyState{ID: "hl-test", Platform: "hyperliquid", Type: "spot"}
+	clearATRMultMissingEntryATRWarningOnHLPerpsClose(hlSpot, "ETH")
+	if _, ok := atrMultMissingEntryATRWarned.Load(atrMultMissingEntryATRKey("hl-test", "ETH")); !ok {
+		t.Fatalf("HL-spot close should not have cleared HL-perps key")
+	}
+
+	// HL perps clears the matching key.
+	hlPerps := &StrategyState{ID: "hl-test", Platform: "hyperliquid", Type: "perps"}
+	clearATRMultMissingEntryATRWarningOnHLPerpsClose(hlPerps, "ETH")
+	if _, ok := atrMultMissingEntryATRWarned.Load(atrMultMissingEntryATRKey("hl-test", "ETH")); ok {
+		t.Fatalf("HL perps close should have cleared the throttle key")
+	}
+}
+
+// #505 review follow-up: clearATRMultMissingEntryATRWarningsForStrategy is
+// invoked from the hot-reload disable path. It must drop every key for the
+// target strategy ID and leave other strategies' keys untouched (including
+// strategies whose IDs share a common prefix).
+func TestClearATRMultMissingEntryATRWarningsForStrategy(t *testing.T) {
+	keys := []struct{ strategyID, symbol string }{
+		{"hl-momo", "ETH"},
+		{"hl-momo", "BTC"},
+		{"hl-momo-fast", "ETH"}, // share prefix; must NOT be cleared
+		{"hl-other", "ETH"},
+	}
+	for _, k := range keys {
+		atrMultMissingEntryATRWarned.Store(atrMultMissingEntryATRKey(k.strategyID, k.symbol), struct{}{})
+		defer clearATRMultMissingEntryATRWarning(k.strategyID, k.symbol)
+	}
+
+	clearATRMultMissingEntryATRWarningsForStrategy("hl-momo")
+
+	for _, k := range keys {
+		_, ok := atrMultMissingEntryATRWarned.Load(atrMultMissingEntryATRKey(k.strategyID, k.symbol))
+		shouldRemain := k.strategyID != "hl-momo"
+		if ok != shouldRemain {
+			t.Errorf("after clearing hl-momo: key %s:%s present=%v want present=%v",
+				k.strategyID, k.symbol, ok, shouldRemain)
+		}
+	}
+}

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -248,7 +248,7 @@ func TestRunHyperliquidTrailingStopUpdate_CancelThenPlaceArgs(t *testing.T) {
 	logger := silentStrategyLogger("hl-test")
 	defer logger.Close()
 
-	newHighWater, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 0.5, 100, 110, 100, 97, 111, nil, logger)
+	newHighWater, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 0.5, 100, 0, 110, 100, 97, 111, nil, logger)
 	if !ok {
 		t.Fatalf("runHyperliquidTrailingStopUpdate returned ok=false")
 	}
@@ -287,7 +287,7 @@ func TestRunHyperliquidTrailingStopUpdate_AlertsOnOrphanedOldOID(t *testing.T) {
 		ownerID:  "owner",
 	})
 
-	_, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 0.5, 100, 110, 100, 97, 111, notifier, logger)
+	_, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 0.5, 100, 0, 110, 100, 97, 111, notifier, logger)
 	if !ok || result == nil || result.StopLossOID != 222 {
 		t.Fatalf("runHyperliquidTrailingStopUpdate = (%+v, %v), want placed replacement", result, ok)
 	}
@@ -1060,5 +1060,267 @@ func TestStrategyConfig_StopLossMarginPctJSON(t *testing.T) {
 	}
 	if !strings.Contains(string(b3), `"stop_loss_margin_pct":0`) {
 		t.Errorf("explicit zero StopLossMarginPct must round-trip; got %s", b3)
+	}
+}
+
+// #505: TrailingStopATRMult derives the trailing distance from the entry ATR
+// and avg cost of the open position. Once derived the percentage is fixed for
+// the life of the position. effectiveTrailingStopPct must:
+//   - return 0 (no-op) when EntryATR or AvgCost is zero so the initial-trigger
+//     placement is deferred to the cycle after stampEntryATRIfOpened populates
+//     the position rather than crashing or arming with bogus distance,
+//   - return mult * entry_atr / avg_cost * 100 once both are set,
+//   - prefer an explicit fixed TrailingStopPct over the ATR multiplier when
+//     both are present (validation rejects this combo at config-load time but
+//     the helper must still resolve deterministically),
+//   - stay HL-perps-only.
+func TestEffectiveTrailingStopPct_ATRMult(t *testing.T) {
+	pf := func(v float64) *float64 { return &v }
+	hl := func(sc StrategyConfig) StrategyConfig {
+		sc.Platform = "hyperliquid"
+		sc.Type = "perps"
+		return sc
+	}
+	cases := []struct {
+		name string
+		sc   StrategyConfig
+		pos  *Position
+		want float64
+	}{
+		{"non-HL returns 0", StrategyConfig{Platform: "okx", Type: "perps", TrailingStopATRMult: pf(1)}, &Position{AvgCost: 100, EntryATR: 2}, 0},
+		{"non-perps returns 0", StrategyConfig{Platform: "hyperliquid", Type: "spot", TrailingStopATRMult: pf(1)}, &Position{AvgCost: 100, EntryATR: 2}, 0},
+		{"nil position returns 0", hl(StrategyConfig{TrailingStopATRMult: pf(1.5)}), nil, 0},
+		{"zero EntryATR returns 0", hl(StrategyConfig{TrailingStopATRMult: pf(1.5)}), &Position{AvgCost: 100, EntryATR: 0}, 0},
+		{"zero AvgCost returns 0", hl(StrategyConfig{TrailingStopATRMult: pf(1.5)}), &Position{AvgCost: 0, EntryATR: 2}, 0},
+		{"explicit zero mult disabled", hl(StrategyConfig{TrailingStopATRMult: pf(0)}), &Position{AvgCost: 100, EntryATR: 2}, 0},
+		{"derives 3% at mult=1.5 atr=2 cost=100", hl(StrategyConfig{TrailingStopATRMult: pf(1.5)}), &Position{AvgCost: 100, EntryATR: 2}, 3.0},
+		{"derives 5% at mult=2 atr=1 cost=40", hl(StrategyConfig{TrailingStopATRMult: pf(2)}), &Position{AvgCost: 40, EntryATR: 1}, 5.0},
+		{"fixed pct wins over ATR mult", hl(StrategyConfig{TrailingStopPct: pf(2.5), TrailingStopATRMult: pf(99)}), &Position{AvgCost: 100, EntryATR: 50}, 2.5},
+		{"fixed pct zero disables before ATR fallback", hl(StrategyConfig{TrailingStopPct: pf(0), TrailingStopATRMult: pf(1.5)}), &Position{AvgCost: 100, EntryATR: 2}, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := effectiveTrailingStopPct(c.sc, c.pos)
+			// Compare with a small epsilon to keep the table values readable.
+			if d := got - c.want; d > 1e-9 || d < -1e-9 {
+				t.Errorf("effectiveTrailingStopPct = %g, want %g", got, c.want)
+			}
+		})
+	}
+}
+
+// #505: ATR-derived trailing stops must not arm at order-placement time
+// because EntryATR is stamped on the Position only after the fill. Until
+// EntryATR exists, EffectiveStopLossPct must return 0 so the live execute
+// path skips the initial trigger and the trailing loop arms it on the next
+// cycle.
+func TestEffectiveStopLossPct_TrailingATRMultDefersInitialTrigger(t *testing.T) {
+	pf := func(v float64) *float64 { return &v }
+	mult := pf(1.5)
+	sc := StrategyConfig{
+		Platform:            "hyperliquid",
+		Type:                "perps",
+		Leverage:            10,
+		MaxDrawdownPct:      5, // would otherwise fall through to a 5% auto stop
+		TrailingStopATRMult: mult,
+	}
+	if got := EffectiveStopLossPct(sc); got != 0 {
+		t.Errorf("EffectiveStopLossPct with TrailingStopATRMult set = %g, want 0 (deferred to trailing loop)", got)
+	}
+}
+
+// #505: trailing_stop_atr_mult shape validation. Acceptance criteria:
+//   - HL perps only.
+//   - mutually exclusive with trailing_stop_pct, stop_loss_pct, and
+//     stop_loss_margin_pct (each conflict surfaces a trailing_stop_atr_mult
+//     error string).
+//   - negative values rejected; zero is a benign opt-out.
+func TestValidateConfig_TrailingStopATRMult(t *testing.T) {
+	pf := func(v float64) *float64 { return &v }
+	cases := []struct {
+		name      string
+		sc        StrategyConfig
+		wantError bool
+	}{
+		{"in range", StrategyConfig{
+			ID: "hl-test", Type: "perps", Platform: "hyperliquid",
+			Script: "shared_scripts/check_hyperliquid.py", Capital: 1000, MaxDrawdownPct: 10, Leverage: 5,
+			TrailingStopATRMult: pf(1.5),
+		}, false},
+		{"explicit zero disables (benign)", StrategyConfig{
+			ID: "hl-test", Type: "perps", Platform: "hyperliquid",
+			Script: "shared_scripts/check_hyperliquid.py", Capital: 1000, MaxDrawdownPct: 10, Leverage: 5,
+			TrailingStopATRMult: pf(0),
+		}, false},
+		{"negative rejected", StrategyConfig{
+			ID: "hl-test", Type: "perps", Platform: "hyperliquid",
+			Script: "shared_scripts/check_hyperliquid.py", Capital: 1000, MaxDrawdownPct: 10, Leverage: 5,
+			TrailingStopATRMult: pf(-0.5),
+		}, true},
+		{"non-HL platform rejected", StrategyConfig{
+			ID: "ok-test", Type: "perps", Platform: "okx",
+			Script: "shared_scripts/check_okx.py", Capital: 1000, MaxDrawdownPct: 10, Leverage: 5,
+			TrailingStopATRMult: pf(1.5),
+		}, true},
+		{"non-perps type rejected", StrategyConfig{
+			ID: "hl-test", Type: "spot", Platform: "hyperliquid",
+			Script: "shared_scripts/check_hyperliquid.py", Capital: 1000, MaxDrawdownPct: 10,
+			TrailingStopATRMult: pf(1.5),
+		}, true},
+		{"mutually exclusive with trailing_stop_pct", StrategyConfig{
+			ID: "hl-test", Type: "perps", Platform: "hyperliquid",
+			Script: "shared_scripts/check_hyperliquid.py", Capital: 1000, MaxDrawdownPct: 10, Leverage: 5,
+			TrailingStopATRMult: pf(1.5), TrailingStopPct: pf(2),
+		}, true},
+		{"mutually exclusive with stop_loss_pct", StrategyConfig{
+			ID: "hl-test", Type: "perps", Platform: "hyperliquid",
+			Script: "shared_scripts/check_hyperliquid.py", Capital: 1000, MaxDrawdownPct: 10, Leverage: 5,
+			TrailingStopATRMult: pf(1.5), StopLossPct: pf(2),
+		}, true},
+		{"mutually exclusive with stop_loss_margin_pct", StrategyConfig{
+			ID: "hl-test", Type: "perps", Platform: "hyperliquid",
+			Script: "shared_scripts/check_hyperliquid.py", Capital: 1000, MaxDrawdownPct: 10, Leverage: 5,
+			TrailingStopATRMult: pf(1.5), StopLossMarginPct: pf(20),
+		}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := &Config{
+				IntervalSeconds: 60,
+				Strategies:      []StrategyConfig{c.sc},
+				PortfolioRisk:   &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 60},
+			}
+			err := ValidateConfig(cfg)
+			gotErr := err != nil && strings.Contains(err.Error(), "trailing_stop_atr_mult")
+			if gotErr != c.wantError {
+				t.Errorf("got err=%v wantATRMultErr=%v (full err: %v)", gotErr, c.wantError, err)
+			}
+		})
+	}
+}
+
+// #505: peer ownership detection must treat trailing_stop_atr_mult as one of
+// the four "this strategy owns the on-chain trigger" signals so two HL peers
+// on the same coin can't both arm a trailing stop and race their cancel/replace
+// against the shared on-chain position.
+func TestValidateConfig_HLPeersATRTrailingConflict(t *testing.T) {
+	mult := 1.5
+	fixed := 2.0
+	cfg := &Config{
+		IntervalSeconds: 60,
+		Strategies: []StrategyConfig{
+			{
+				ID:                  "hl-eth-trend",
+				Type:                "perps",
+				Platform:            "hyperliquid",
+				Script:              "shared_scripts/check_hyperliquid.py",
+				Args:                []string{"trend", "ETH", "1h", "--mode=live"},
+				Capital:             1000,
+				MaxDrawdownPct:      10,
+				Leverage:            10,
+				MarginMode:          "isolated",
+				TrailingStopATRMult: &mult,
+			},
+			{
+				ID:             "hl-eth-breakout",
+				Type:           "perps",
+				Platform:       "hyperliquid",
+				Script:         "shared_scripts/check_hyperliquid.py",
+				Args:           []string{"breakout", "ETH", "1h", "--mode=live"},
+				Capital:        1000,
+				MaxDrawdownPct: 10,
+				Leverage:       10,
+				MarginMode:     "isolated",
+				StopLossPct:    &fixed,
+			},
+		},
+		PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 60},
+	}
+	err := ValidateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected peer stop-loss conflict")
+	}
+	if !strings.Contains(err.Error(), "trailing_stop_atr_mult") {
+		t.Fatalf("error=%v, want trailing_stop_atr_mult conflict", err)
+	}
+}
+
+// #505: peer normalization must coerce omitted trailing_stop_atr_mult on
+// same-coin HL peers to an explicit zero on stop_loss_pct (the same treatment
+// trailing_stop_pct already gets) so the MaxDrawdownPct auto-derive only fires
+// for sole-owner strategies.
+func TestNormalizeHyperliquidPeerStopLosses_TrailingATRMultOwner(t *testing.T) {
+	mult := 1.5
+	strategies := []StrategyConfig{
+		{
+			ID:                  "hl-eth-trend",
+			Type:                "perps",
+			Platform:            "hyperliquid",
+			Args:                []string{"trend", "ETH", "1h"},
+			Leverage:            5,
+			MaxDrawdownPct:      10,
+			TrailingStopATRMult: &mult,
+		},
+		{
+			ID:             "hl-eth-breakout",
+			Type:           "perps",
+			Platform:       "hyperliquid",
+			Args:           []string{"breakout", "ETH", "1h"},
+			Leverage:       5,
+			MaxDrawdownPct: 10,
+		},
+	}
+	normalizeHyperliquidPeerStopLosses(strategies)
+
+	if strategies[0].StopLossPct != nil {
+		t.Errorf("ATR-mult owner should not gain a normalized StopLossPct; got %v", strategies[0].StopLossPct)
+	}
+	if strategies[1].StopLossPct == nil {
+		t.Fatalf("non-owner peer should be normalized to explicit 0 StopLossPct, got nil")
+	}
+	if *strategies[1].StopLossPct != 0 {
+		t.Errorf("non-owner peer normalized StopLossPct = %g, want 0", *strategies[1].StopLossPct)
+	}
+	if got := EffectiveStopLossPct(strategies[1]); got != 0 {
+		t.Errorf("non-owner peer EffectiveStopLossPct = %g, want 0 (no MaxDrawdownPct fallback)", got)
+	}
+}
+
+// #505: trailing_stop_atr_mult round-trips through JSON only when explicit
+// (omitempty drops nil) and is a hot-reloadable field via formatFloatPtr.
+func TestStrategyConfig_TrailingStopATRMultJSON(t *testing.T) {
+	v := 1.5
+	sc := StrategyConfig{
+		ID:                  "hl-test",
+		Type:                "perps",
+		Platform:            "hyperliquid",
+		Leverage:            10,
+		TrailingStopATRMult: &v,
+	}
+	b, err := json.Marshal(sc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"trailing_stop_atr_mult":1.5`) {
+		t.Errorf("expected trailing_stop_atr_mult in JSON; got %s", b)
+	}
+
+	sc.TrailingStopATRMult = nil
+	b2, err := json.Marshal(sc)
+	if err != nil {
+		t.Fatalf("marshal nil: %v", err)
+	}
+	if strings.Contains(string(b2), "trailing_stop_atr_mult") {
+		t.Errorf("nil TrailingStopATRMult should be omitted; got %s", b2)
+	}
+
+	zero := 0.0
+	sc.TrailingStopATRMult = &zero
+	b3, err := json.Marshal(sc)
+	if err != nil {
+		t.Fatalf("marshal zero: %v", err)
+	}
+	if !strings.Contains(string(b3), `"trailing_stop_atr_mult":0`) {
+		t.Errorf("explicit zero TrailingStopATRMult must round-trip; got %s", b3)
 	}
 }

--- a/scheduler/hyperliquid_trailing_stop.go
+++ b/scheduler/hyperliquid_trailing_stop.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"math"
+	"sync"
 )
 
 const defaultTrailingStopMinMovePct = 0.5
@@ -15,12 +16,22 @@ var runHyperliquidUpdateStopLossFunc = RunHyperliquidUpdateStopLoss
 // Resolution order:
 //   - explicit TrailingStopPct (fixed distance) wins; explicit 0 disables.
 //   - TrailingStopATRMult derives the distance from the position's EntryATR
-//     and AvgCost: pct = mult * entry_atr / avg_cost * 100. The percentage is
-//     fixed for the life of the position once derived because EntryATR is
-//     stamped on Position.OpenedAt and never re-read after that. Returns 0 if
-//     pos is nil or EntryATR / AvgCost is missing — the trailing loop will
-//     simply no-op until stampEntryATRIfOpened populates the position on the
-//     cycle after the open fills (#505).
+//     and AvgCost: pct = mult * entry_atr / avg_cost * 100, capped at
+//     MaxAutoStopLossPct so a volatile coin (e.g. mult=3 on a 30%-of-price
+//     ATR coin) cannot produce a long-side trigger price <= 0 that HL would
+//     silently reject (review of #505). Returns 0 if pos is nil or
+//     EntryATR / AvgCost is missing — the trailing loop will simply no-op
+//     until stampEntryATRIfOpened populates the position on the cycle after
+//     the open fills.
+//
+// Mutability: EntryATR is stamped once at position open and never re-read,
+// so the EntryATR/AvgCost inputs are fixed for the life of the position.
+// However, the TrailingStopATRMult value itself IS hot-reloadable — bumping
+// the multiplier mid-position via SIGHUP will alter the derived distance on
+// the next trailing cycle. Only the nil↔positive *mode* toggle is blocked
+// while open (see config_reload.go's state-compat check). Operators who
+// expect a strictly fixed distance for the life of a position should not
+// edit the multiplier while a position is active.
 func effectiveTrailingStopPct(sc StrategyConfig, pos *Position) float64 {
 	if sc.Platform != "hyperliquid" || sc.Type != "perps" {
 		return 0
@@ -35,9 +46,79 @@ func effectiveTrailingStopPct(sc StrategyConfig, pos *Position) float64 {
 		if pos == nil || pos.EntryATR <= 0 || pos.AvgCost <= 0 {
 			return 0
 		}
-		return *sc.TrailingStopATRMult * pos.EntryATR / pos.AvgCost * 100.0
+		pct := *sc.TrailingStopATRMult * pos.EntryATR / pos.AvgCost * 100.0
+		if pct > MaxAutoStopLossPct {
+			pct = MaxAutoStopLossPct
+		}
+		return pct
 	}
 	return 0
+}
+
+// atrMultMissingEntryATR reports whether sc is configured for ATR-derived
+// trailing stops but the open position is missing the EntryATR/AvgCost inputs
+// needed to derive a trigger distance. The trailing loop uses this to surface
+// a one-shot operator alert when stampEntryATRIfOpened never fired (e.g. the
+// open strategy did not emit an "atr" indicator), so the position cannot run
+// indefinitely without exchange-side protection (#505 review).
+//
+// Returns false when an explicit TrailingStopPct > 0 takes precedence over the
+// ATR multiplier — in that case the fixed-pct path arms the trigger and ATR
+// is irrelevant.
+func atrMultMissingEntryATR(sc StrategyConfig, pos *Position) bool {
+	if sc.Platform != "hyperliquid" || sc.Type != "perps" {
+		return false
+	}
+	if sc.TrailingStopATRMult == nil || *sc.TrailingStopATRMult <= 0 {
+		return false
+	}
+	if sc.TrailingStopPct != nil && *sc.TrailingStopPct > 0 {
+		return false
+	}
+	if pos == nil {
+		return false
+	}
+	return pos.EntryATR <= 0 || pos.AvgCost <= 0
+}
+
+// atrMultMissingEntryATRWarned throttles missing-EntryATR alerts to one per
+// (strategy, symbol). Keys are reset by clearATRMultMissingEntryATRWarning
+// when a position closes (so a future re-open can re-warn if the bug
+// persists) and on hot-reload when the strategy disables ATR-mult.
+var atrMultMissingEntryATRWarned sync.Map
+
+func atrMultMissingEntryATRKey(strategyID, symbol string) string {
+	return strategyID + ":" + symbol
+}
+
+// notifyATRMultMissingEntryATROnce emits a WARN log + notifier alert the
+// first time we observe an ATR-mult-configured strategy with a position that
+// lacks the EntryATR input. Repeated cycles for the same (strategy, symbol)
+// are suppressed so the alert channel is not flooded; downstream operators
+// see a single, clear notice that the position is running without
+// exchange-side protection.
+func notifyATRMultMissingEntryATROnce(sc StrategyConfig, symbol string, notifier *MultiNotifier, logger *StrategyLogger) {
+	key := atrMultMissingEntryATRKey(sc.ID, symbol)
+	if _, loaded := atrMultMissingEntryATRWarned.LoadOrStore(key, struct{}{}); loaded {
+		return
+	}
+	if logger != nil {
+		logger.Warn("trailing_stop_atr_mult set but Position.EntryATR is 0 for %s — entry strategy must emit an 'atr' indicator on the open candle. Position is running WITHOUT a reduce-only stop-loss.", symbol)
+	}
+	if notifier != nil && notifier.HasBackends() {
+		msg := fmt.Sprintf("**HL TRAILING ATR-MULT MISSING ENTRY ATR** [%s] %s — strategy is configured with trailing_stop_atr_mult but the open candle did not produce an ATR indicator, so no on-chain trigger has been armed. Verify the entry strategy emits `atr`, or switch to a fixed `trailing_stop_pct`.",
+			sc.ID, symbol)
+		notifier.SendToAllChannels(msg)
+		notifier.SendOwnerDM(msg)
+	}
+}
+
+// clearATRMultMissingEntryATRWarning drops the throttle key for a
+// (strategy, symbol) so the next missing-EntryATR observation re-warns.
+// Callers should invoke this on position close and on config reload that
+// disables ATR-mult.
+func clearATRMultMissingEntryATRWarning(strategyID, symbol string) {
+	atrMultMissingEntryATRWarned.Delete(atrMultMissingEntryATRKey(strategyID, symbol))
 }
 
 func effectiveTrailingStopMinMovePct(sc StrategyConfig) float64 {
@@ -98,11 +179,20 @@ func computeTrailingStopUpdate(side string, mark, highWater, trailingPct, minMov
 	return candidateHighWater, 0, false
 }
 
-func runHyperliquidTrailingStopUpdate(sc StrategyConfig, symbol, side string, qty, avgCost, entryATR, mark, highWater, currentTrigger float64, currentOID int64, notifier *MultiNotifier, logger *StrategyLogger) (float64, *HyperliquidStopLossUpdateResult, bool) {
-	pos := &Position{AvgCost: avgCost, EntryATR: entryATR}
+// runHyperliquidTrailingStopUpdate evaluates the per-cycle trailing-stop
+// update for an HL perps position. pos is the caller's snapshot of the
+// position fields needed for trailing math (AvgCost, EntryATR — held
+// outside the state mutex so the subprocess call below can run without
+// blocking other strategies). The pointer is taken by value semantics; the
+// helper only reads, never writes through it.
+func runHyperliquidTrailingStopUpdate(sc StrategyConfig, symbol, side string, qty float64, pos *Position, mark, highWater, currentTrigger float64, currentOID int64, notifier *MultiNotifier, logger *StrategyLogger) (float64, *HyperliquidStopLossUpdateResult, bool) {
 	trailingPct := effectiveTrailingStopPct(sc, pos)
 	if trailingPct <= 0 || qty <= 0 || mark <= 0 {
 		return highWater, nil, true
+	}
+	avgCost := 0.0
+	if pos != nil {
+		avgCost = pos.AvgCost
 	}
 	if highWater <= 0 {
 		highWater = avgCost

--- a/scheduler/hyperliquid_trailing_stop.go
+++ b/scheduler/hyperliquid_trailing_stop.go
@@ -9,12 +9,33 @@ const defaultTrailingStopMinMovePct = 0.5
 
 var runHyperliquidUpdateStopLossFunc = RunHyperliquidUpdateStopLoss
 
-func effectiveTrailingStopPct(sc StrategyConfig) float64 {
-	if sc.Platform != "hyperliquid" || sc.Type != "perps" || sc.TrailingStopPct == nil {
+// effectiveTrailingStopPct returns the per-position trailing-stop distance as a
+// price-% (e.g. 3.0 == 3%). HL perps only.
+//
+// Resolution order:
+//   - explicit TrailingStopPct (fixed distance) wins; explicit 0 disables.
+//   - TrailingStopATRMult derives the distance from the position's EntryATR
+//     and AvgCost: pct = mult * entry_atr / avg_cost * 100. The percentage is
+//     fixed for the life of the position once derived because EntryATR is
+//     stamped on Position.OpenedAt and never re-read after that. Returns 0 if
+//     pos is nil or EntryATR / AvgCost is missing — the trailing loop will
+//     simply no-op until stampEntryATRIfOpened populates the position on the
+//     cycle after the open fills (#505).
+func effectiveTrailingStopPct(sc StrategyConfig, pos *Position) float64 {
+	if sc.Platform != "hyperliquid" || sc.Type != "perps" {
 		return 0
 	}
-	if *sc.TrailingStopPct > 0 {
-		return *sc.TrailingStopPct
+	if sc.TrailingStopPct != nil {
+		if *sc.TrailingStopPct > 0 {
+			return *sc.TrailingStopPct
+		}
+		return 0
+	}
+	if sc.TrailingStopATRMult != nil && *sc.TrailingStopATRMult > 0 {
+		if pos == nil || pos.EntryATR <= 0 || pos.AvgCost <= 0 {
+			return 0
+		}
+		return *sc.TrailingStopATRMult * pos.EntryATR / pos.AvgCost * 100.0
 	}
 	return 0
 }
@@ -77,8 +98,9 @@ func computeTrailingStopUpdate(side string, mark, highWater, trailingPct, minMov
 	return candidateHighWater, 0, false
 }
 
-func runHyperliquidTrailingStopUpdate(sc StrategyConfig, symbol, side string, qty, avgCost, mark, highWater, currentTrigger float64, currentOID int64, notifier *MultiNotifier, logger *StrategyLogger) (float64, *HyperliquidStopLossUpdateResult, bool) {
-	trailingPct := effectiveTrailingStopPct(sc)
+func runHyperliquidTrailingStopUpdate(sc StrategyConfig, symbol, side string, qty, avgCost, entryATR, mark, highWater, currentTrigger float64, currentOID int64, notifier *MultiNotifier, logger *StrategyLogger) (float64, *HyperliquidStopLossUpdateResult, bool) {
+	pos := &Position{AvgCost: avgCost, EntryATR: entryATR}
+	trailingPct := effectiveTrailingStopPct(sc, pos)
 	if trailingPct <= 0 || qty <= 0 || mark <= 0 {
 		return highWater, nil, true
 	}

--- a/scheduler/hyperliquid_trailing_stop.go
+++ b/scheduler/hyperliquid_trailing_stop.go
@@ -103,10 +103,10 @@ func notifyATRMultMissingEntryATROnce(sc StrategyConfig, symbol string, notifier
 		return
 	}
 	if logger != nil {
-		logger.Warn("trailing_stop_atr_mult set but Position.EntryATR is 0 for %s — entry strategy must emit an 'atr' indicator on the open candle. Position is running WITHOUT a reduce-only stop-loss.", symbol)
+		logger.Warn("trailing_stop_atr_mult set but Position.EntryATR is 0 for %s — entry strategy must emit an 'atr' indicator on the open candle, so no ATR-derived trigger has been armed for this strategy.", symbol)
 	}
 	if notifier != nil && notifier.HasBackends() {
-		msg := fmt.Sprintf("**HL TRAILING ATR-MULT MISSING ENTRY ATR** [%s] %s — strategy is configured with trailing_stop_atr_mult but the open candle did not produce an ATR indicator, so no on-chain trigger has been armed. Verify the entry strategy emits `atr`, or switch to a fixed `trailing_stop_pct`.",
+		msg := fmt.Sprintf("**HL TRAILING ATR-MULT MISSING ENTRY ATR** [%s] %s — strategy is configured with trailing_stop_atr_mult but the open candle did not produce an ATR indicator, so no ATR-derived trigger has been armed for this strategy. Verify the entry strategy emits `atr`, or switch to a fixed `trailing_stop_pct`. (If a peer strategy on the same coin owns the trigger, this strategy is still covered by the shared exchange-side stop.)",
 			sc.ID, symbol)
 		notifier.SendToAllChannels(msg)
 		notifier.SendOwnerDM(msg)
@@ -115,10 +115,40 @@ func notifyATRMultMissingEntryATROnce(sc StrategyConfig, symbol string, notifier
 
 // clearATRMultMissingEntryATRWarning drops the throttle key for a
 // (strategy, symbol) so the next missing-EntryATR observation re-warns.
-// Callers should invoke this on position close and on config reload that
-// disables ATR-mult.
+// Callers should invoke this on position close so a future re-open that
+// hits the same missing-ATR bug is not silently suppressed.
 func clearATRMultMissingEntryATRWarning(strategyID, symbol string) {
 	atrMultMissingEntryATRWarned.Delete(atrMultMissingEntryATRKey(strategyID, symbol))
+}
+
+// clearATRMultMissingEntryATRWarningOnHLPerpsClose is a no-op shortcut for
+// non-HL-perps state. Position-close call sites in shared code (e.g.
+// ExecutePerpsSignal close-long/short, forceCloseAllPositions) live on a
+// path that may run for spot or futures strategies as well; this helper
+// avoids spraying platform/type checks at every call site.
+func clearATRMultMissingEntryATRWarningOnHLPerpsClose(s *StrategyState, symbol string) {
+	if s == nil || s.Platform != "hyperliquid" || s.Type != "perps" {
+		return
+	}
+	clearATRMultMissingEntryATRWarning(s.ID, symbol)
+}
+
+// clearATRMultMissingEntryATRWarningsForStrategy drops every throttle key
+// belonging to strategyID. Used by hot-reload when the operator disables
+// trailing_stop_atr_mult — the throttle should not survive into the next
+// configuration regime, since the alert logic no longer applies.
+func clearATRMultMissingEntryATRWarningsForStrategy(strategyID string) {
+	prefix := strategyID + ":"
+	atrMultMissingEntryATRWarned.Range(func(k, _ any) bool {
+		key, ok := k.(string)
+		if !ok {
+			return true
+		}
+		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
+			atrMultMissingEntryATRWarned.Delete(k)
+		}
+		return true
+	})
 }
 
 func effectiveTrailingStopMinMovePct(sc StrategyConfig) float64 {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1278,8 +1278,16 @@ func main() {
 							prices[result.Symbol] = price
 							var execResult *HyperliquidExecuteResult
 							liveExecFailed := false
-							if hyperliquidIsLive(sc.Args) && result.Signal == 0 && hlPosQty > 0 && effectiveTrailingStopPct(sc, &Position{AvgCost: hlAvgCost, EntryATR: hlEntryATR}) > 0 {
-								newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, result.Symbol, hlPosSide, hlPosQty, hlAvgCost, hlEntryATR, price, hlStopLossHighWaterPx, hlStopLossTriggerPx, hlStopLossOID, notifier, logger)
+							hlPosSnapshot := &Position{AvgCost: hlAvgCost, EntryATR: hlEntryATR}
+							if hyperliquidIsLive(sc.Args) && result.Signal == 0 && hlPosQty > 0 && atrMultMissingEntryATR(sc, hlPosSnapshot) {
+								// ATR-mult is configured but the position is missing EntryATR — the
+								// open candle did not produce an ATR indicator, so the trailing loop
+								// will keep no-opping until the position closes. Emit a one-shot
+								// operator alert; the position is running unprotected.
+								notifyATRMultMissingEntryATROnce(sc, result.Symbol, notifier, logger)
+							}
+							if hyperliquidIsLive(sc.Args) && result.Signal == 0 && hlPosQty > 0 && effectiveTrailingStopPct(sc, hlPosSnapshot) > 0 {
+								newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, result.Symbol, hlPosSide, hlPosQty, hlPosSnapshot, price, hlStopLossHighWaterPx, hlStopLossTriggerPx, hlStopLossOID, notifier, logger)
 								mu.Lock()
 								if pos, ok3 := stratState.Positions[result.Symbol]; ok3 && pos.Quantity > 0 && pos.Side == hlPosSide {
 									if newHighWater > 0 && updateConfirmed {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1082,6 +1082,7 @@ func main() {
 					var hlPosQty float64
 					var hlPosSide string
 					var hlAvgCost float64
+					var hlEntryATR float64
 					var hlPosCtx PositionCtx
 					var hlStopLossOID int64
 					var hlStopLossTriggerPx float64
@@ -1099,6 +1100,7 @@ func main() {
 								hlPosSide = hlPosCtx.Side
 								hlPosQty = hlPosCtx.Quantity
 								hlAvgCost = hlPosCtx.AvgCost
+								hlEntryATR = pos.EntryATR
 								hlStopLossOID = pos.StopLossOID
 								hlStopLossTriggerPx = pos.StopLossTriggerPx
 								hlStopLossHighWaterPx = pos.StopLossHighWaterPx
@@ -1276,8 +1278,8 @@ func main() {
 							prices[result.Symbol] = price
 							var execResult *HyperliquidExecuteResult
 							liveExecFailed := false
-							if hyperliquidIsLive(sc.Args) && result.Signal == 0 && hlPosQty > 0 && effectiveTrailingStopPct(sc) > 0 {
-								newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, result.Symbol, hlPosSide, hlPosQty, hlAvgCost, price, hlStopLossHighWaterPx, hlStopLossTriggerPx, hlStopLossOID, notifier, logger)
+							if hyperliquidIsLive(sc.Args) && result.Signal == 0 && hlPosQty > 0 && effectiveTrailingStopPct(sc, &Position{AvgCost: hlAvgCost, EntryATR: hlEntryATR}) > 0 {
+								newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, result.Symbol, hlPosSide, hlPosQty, hlAvgCost, hlEntryATR, price, hlStopLossHighWaterPx, hlStopLossTriggerPx, hlStopLossOID, notifier, logger)
 								mu.Lock()
 								if pos, ok3 := stratState.Positions[result.Symbol]; ok3 && pos.Quantity > 0 && pos.Side == hlPosSide {
 									if newHighWater > 0 && updateConfirmed {
@@ -2258,8 +2260,8 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 	if trades > 0 && fillOID != "" {
 		logger.Info("Exchange order ID: %s", fillOID)
 	}
-	if trades > 0 && effectiveTrailingStopPct(sc) > 0 {
-		if pos, ok := s.Positions[result.Symbol]; ok {
+	if trades > 0 {
+		if pos, ok := s.Positions[result.Symbol]; ok && effectiveTrailingStopPct(sc, pos) > 0 {
 			// Partial closes may reset this hint, but StopLossTriggerPx is the
 			// durable ratchet. The helper never lowers a favorable trigger.
 			pos.StopLossHighWaterPx = fillPrice

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -157,6 +157,7 @@ func recordPerpsStopLossClose(s *StrategyState, symbol string, triggerPx float64
 	RecordTradeResult(&s.RiskState, pnl)
 	recordClosedPosition(s, pos, triggerPx, pnl, reason, now)
 	delete(s.Positions, symbol)
+	clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
 	if logger != nil {
 		logger.Warn("SL close reconciled @ $%.4f, PnL: $%.2f (fee $%.2f)", triggerPx, pnl, fee)
 	}
@@ -596,6 +597,7 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 			RecordTradeResult(&s.RiskState, pnl)
 			recordClosedPosition(s, pos, execPrice, pnl, "signal", now)
 			delete(s.Positions, symbol)
+			clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
 			logger.Info("Closed short %s @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, execPrice, fee, pnl)
 			tradesExecuted++
 		}
@@ -714,6 +716,7 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 			RecordTradeResult(&s.RiskState, pnl)
 			recordClosedPosition(s, pos, execPrice, pnl, "signal", now)
 			delete(s.Positions, symbol)
+			clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
 			logger.Info("SELL %s: %.6f @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, pos.Quantity, execPrice, fee, pnl)
 			tradesExecuted++
 		}

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1128,6 +1128,7 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 		RecordTradeResult(&s.RiskState, pnl)
 		recordClosedPosition(s, pos, price, pnl, "circuit_breaker", now)
 		delete(s.Positions, symbol)
+		clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
 	}
 
 	for id, pos := range s.OptionPositions {


### PR DESCRIPTION
Closes #505

## Summary
- Adds `trailing_stop_atr_mult` as a per-position trailing SL distance derived from `Position.EntryATR / Position.AvgCost` at open time: `effective_pct = mult × entry_atr / avg_cost × 100`. Fixed for the life of the position.
- Mutually exclusive with `trailing_stop_pct`, `stop_loss_pct`, `stop_loss_margin_pct`. HL perps only.
- `effectiveTrailingStopPct` now takes `*Position` and returns 0 when `EntryATR`/`AvgCost` are missing, so the initial trigger placement defers to the cycle after `stampEntryATRIfOpened` stamps the position.
- `EffectiveStopLossPct` returns 0 for ATR-mult strategies (pre-fill EntryATR is unavailable); peer ownership uses a new `hasHyperliquidStopLossOwnership` helper that still treats ATR-mult > 0 as a trigger owner so peer-conflict validation stays accurate.
- Hot-reloadable; state-compat blocks ATR-mult mode toggles with open positions (mirrors `trailing_stop_pct`).
- One-shot operator alert when `trailing_stop_atr_mult > 0` but a position is open with missing `EntryATR` (position running unprotected); throttle cleared on all HL perps close paths including `hl_sync_external` (manual close via HL UI between scheduler cycles).

## Files changed
- `scheduler/config.go` — `TrailingStopATRMult *float64` field, validation, peer-ownership normalization
- `scheduler/config_reload.go` — ATR-mult hot-reload state-compat check
- `scheduler/hyperliquid_trailing_stop.go` — ATR-mult derivation, cap, missing-EntryATR alert + throttle helper
- `scheduler/hyperliquid_balance.go` — throttle-reset in `hl_sync_external` close path + circuit-breaker close path
- `scheduler/portfolio.go` — throttle-reset in signal close and stop-loss close paths
- `scheduler/risk.go` — throttle-reset in `forceCloseAllPositions`
- `scheduler/main.go` — `hlEntryATR` Phase 1 capture, `atrMultMissingEntryATR` alert invocation, `effectiveTrailingStopPct(sc, pos)` signature update
- `scheduler/hyperliquid_stop_loss_test.go` — ATR-mult tests (derivation, cap, peer-ownership, hot-reload, alert throttle)

## Test plan
- [x] `go build .`
- [x] `go test ./...`
- [x] `gofmt -l .`
- [ ] Manual smoke test with a live HL perps strategy configured with `trailing_stop_atr_mult`

---
LLM: Claude Opus 4.7 (1M) | high