### PR TITLE
Shorten Discord summary strategy labels

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -240,7 +240,15 @@ const discordSplitThreshold = 1980
 // (including header/sep/totals) plus the base summary header and the per-channel
 // position section stays under the 2000-char limit (#381 added #T, #434 added
 // W/L, and #436 added DD; 15 rows remains within the Discord limit).
-const catTableMaxRows = 15
+const (
+	catTableMaxRows       = 15
+	catTableStrategyWidth = 18
+)
+
+var summaryStrategyLabelAliases = map[string]string{
+	"tiered-atr": "tatr",
+	"tiered-pct": "tpct",
+}
 
 // FormatCategorySummary creates Discord messages for a set of strategies sharing a channel.
 // Returns a slice of messages; when the content exceeds Discord's 2000-char limit,
@@ -671,6 +679,17 @@ func extractStrategyName(sc StrategyConfig) string {
 	return "unknown"
 }
 
+func summaryStrategyLabel(id string) string {
+	label := id
+	for old, new := range summaryStrategyLabelAliases {
+		label = strings.ReplaceAll(label, old, new)
+	}
+	if len(label) > catTableStrategyWidth {
+		label = label[:catTableStrategyWidth]
+	}
+	return label
+}
+
 func extractAsset(sc StrategyConfig) string {
 	// Args[1] is the canonical asset source for all strategy types.
 	// Spot uses "BTC/USDT" style symbols; strip the quote currency.
@@ -797,15 +816,12 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 	}
 	sb.WriteString("\n```\n")
 	if showWalletPct {
-		header := fmt.Sprintf("%-16s%9s %6s %6s %8s%5s %8s%5s %4s %4s %5s", "Strategy", "Init", "Value", "PnL", "PnL%", "DD", "Wallet%", "Tf", "Int", "#T", "W/L")
+		header := fmt.Sprintf("%-*s%9s %6s %6s %8s%5s %8s%5s %4s %4s %5s", catTableStrategyWidth, "Strategy", "Init", "Value", "PnL", "PnL%", "DD", "Wallet%", "Tf", "Int", "#T", "W/L")
 		sep := strings.Repeat("-", len(header))
 		sb.WriteString(header + "\n")
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {
-			label := bot.id
-			if len(label) > 16 {
-				label = label[:16]
-			}
+			label := summaryStrategyLabel(bot.id)
 			valStr := fmtComma(bot.value)
 			initStr := fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
@@ -816,7 +832,7 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 				wpStr = fmt.Sprintf("%.1f%%", bot.walletPct)
 			}
 			wlStr := fmtWinLossRatio(bot.winningTrades, bot.losingTrades)
-			sb.WriteString(fmt.Sprintf("%-16s%9s %6s %6s %8s%5s %8s%5s %4s %4d %5s\n", label, initStr, valStr, pnlStr, pctStr, maxDDStr, wpStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
+			sb.WriteString(fmt.Sprintf("%-*s%9s %6s %6s %8s%5s %8s%5s %4s %4d %5s\n", catTableStrategyWidth, label, initStr, valStr, pnlStr, pctStr, maxDDStr, wpStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
 		}
 		if includeTotals {
 			sb.WriteString(sep + "\n")
@@ -825,25 +841,22 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 			totPnlStr := fmtPnl(totalPnl)
 			totPctStr := fmtPnlPct(totalPnlPct)
 			totWlStr := fmtWinLossRatio(totalWins, totalLosses)
-			sb.WriteString(fmt.Sprintf("%-16s%9s %6s %6s %8s%5s %8s%5s %4s %4d %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", "100.0%", "", "", totalClosed, totWlStr))
+			sb.WriteString(fmt.Sprintf("%-*s%9s %6s %6s %8s%5s %8s%5s %4s %4d %5s\n", catTableStrategyWidth, "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", "100.0%", "", "", totalClosed, totWlStr))
 		}
 	} else {
-		header := fmt.Sprintf("%-16s%9s %6s %6s %8s%5s %5s %4s %4s %5s", "Strategy", "Init", "Value", "PnL", "PnL%", "DD", "Tf", "Int", "#T", "W/L")
+		header := fmt.Sprintf("%-*s%9s %6s %6s %8s%5s %5s %4s %4s %5s", catTableStrategyWidth, "Strategy", "Init", "Value", "PnL", "PnL%", "DD", "Tf", "Int", "#T", "W/L")
 		sep := strings.Repeat("-", len(header))
 		sb.WriteString(header + "\n")
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {
-			label := bot.id
-			if len(label) > 16 {
-				label = label[:16]
-			}
+			label := summaryStrategyLabel(bot.id)
 			valStr := fmtComma(bot.value)
 			initStr := fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
 			pctStr := fmtPnlPct(bot.pnlPct)
 			wlStr := fmtWinLossRatio(bot.winningTrades, bot.losingTrades)
 			maxDDStr := fmtDrawdownPct(bot.maxDrawdownPct)
-			sb.WriteString(fmt.Sprintf("%-16s%9s %6s %6s %8s%5s %5s %4s %4d %5s\n", label, initStr, valStr, pnlStr, pctStr, maxDDStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
+			sb.WriteString(fmt.Sprintf("%-*s%9s %6s %6s %8s%5s %5s %4s %4d %5s\n", catTableStrategyWidth, label, initStr, valStr, pnlStr, pctStr, maxDDStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
 		}
 		if includeTotals {
 			sb.WriteString(sep + "\n")
@@ -852,7 +865,7 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 			totPnlStr := fmtPnl(totalPnl)
 			totPctStr := fmtPnlPct(totalPnlPct)
 			totWlStr := fmtWinLossRatio(totalWins, totalLosses)
-			sb.WriteString(fmt.Sprintf("%-16s%9s %6s %6s %8s%5s %5s %4s %4d %5s\n", "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", "", "", totalClosed, totWlStr))
+			sb.WriteString(fmt.Sprintf("%-*s%9s %6s %6s %8s%5s %5s %4s %4d %5s\n", catTableStrategyWidth, "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", "", "", totalClosed, totWlStr))
 		}
 	}
 	sb.WriteString("```\n")

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -626,6 +626,35 @@ func TestFormatCategorySummary_TfIntGlobalFallback(t *testing.T) {
 	}
 }
 
+func TestFormatCategorySummary_StrategyLabelWidthAndTieredAliases(t *testing.T) {
+	strats := []StrategyConfig{
+		{ID: "hl-123456789012345", Type: "perps", Args: []string{"rsi", "BTC", "1h"}, Capital: 1000},
+		{ID: "hl-tiered-atr-btc", Type: "perps", Args: []string{"tiered_atr", "BTC", "1h"}, Capital: 1000},
+		{ID: "hl-tiered-pct-btc", Type: "perps", Args: []string{"tiered_pct", "BTC", "1h"}, Capital: 1000},
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-123456789012345": {Cash: 1000},
+			"hl-tiered-atr-btc":  {Cash: 1000},
+			"hl-tiered-pct-btc":  {Cash: 1000},
+		},
+	}
+	prices := map[string]float64{"BTC/USDT": 50000}
+
+	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
+	msg := strings.Join(msgs, "\n")
+
+	if !strings.Contains(msg, "hl-123456789012345") {
+		t.Errorf("expected 18-char strategy label to render without truncation, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "hl-tatr-btc") || strings.Contains(msg, "tiered-atr") {
+		t.Errorf("expected tiered-atr summary label alias tatr, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "hl-tpct-btc") || strings.Contains(msg, "tiered-pct") {
+		t.Errorf("expected tiered-pct summary label alias tpct, got:\n%s", msg)
+	}
+}
+
 func TestFormatCategorySummary_MaxDrawdownColumn(t *testing.T) {
 	// Issue #436: summary tables surface the effective max_drawdown_pct already
 	// resolved onto StrategyConfig by LoadConfig (strategy → platform → type).


### PR DESCRIPTION
## Summary
- Increase the Discord summary strategy label column width from 16 to 18 characters.
- Render `tiered-atr` as `tatr` and `tiered-pct` as `tpct` in summary tables.
- Keep the change limited to summary formatting so other strategy IDs and output paths remain unchanged.

Closes #510

## Testing
- Added a regression test covering the wider label column and the two tiered strategy aliases.
- `go test ./...` passed in `scheduler`.
- `go build .` passed in `scheduler`.

LLM: GPT-5 Codex | medium