### PR TITLE
Prevent per-strategy Hyperliquid circuit breakers from closing shared coins

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -660,47 +660,6 @@ func hlLiveStrategiesForCoin(coin string, hlLiveAll []StrategyConfig) []Strategy
 	return out
 }
 
-func hlStrategyCapitalWeight(sc StrategyConfig) float64 {
-	if sc.CapitalPct > 0 {
-		return sc.CapitalPct
-	}
-	if sc.Capital > 0 {
-		return sc.Capital
-	}
-	return 1.0
-}
-
-// hlStrategyCapitalWeights returns per-peer weights for proportional close
-// sizing on a shared coin. When peers mix units (one declares CapitalPct as a
-// fraction, another declares raw Capital in dollars), their sum is nonsensical
-// (e.g. 0.5 + 1000 ≈ 1000.5) and the CapitalPct-only peer's share collapses to
-// ~0, producing a no-op close. Detect the mismatch and fall back to equal
-// weights (1.0 each) so the firing strategy still gets a meaningful share.
-// When all peers use the same field, behavior matches hlStrategyCapitalWeight
-// (#356 review).
-func hlStrategyCapitalWeights(peers []StrategyConfig) []float64 {
-	hasPct := false
-	hasAbs := false
-	for _, p := range peers {
-		switch {
-		case p.CapitalPct > 0:
-			hasPct = true
-		case p.Capital > 0:
-			hasAbs = true
-		}
-	}
-	mixed := hasPct && hasAbs
-	out := make([]float64, len(peers))
-	for i, p := range peers {
-		if mixed {
-			out[i] = 1.0
-			continue
-		}
-		out[i] = hlStrategyCapitalWeight(p)
-	}
-	return out
-}
-
 type hlVirtualQuantitySnapshot map[string]map[string]float64
 
 // snapshotHyperliquidVirtualQuantities captures the per-strategy virtual
@@ -736,10 +695,11 @@ func snapshotHyperliquidVirtualQuantities(strategies map[string]*StrategyState, 
 
 // computeHyperliquidCircuitCloseQty returns the unsigned coin quantity for a
 // reduce-only market_close when strategyID's per-strategy circuit breaker fires
-// (#356). For a coin traded by multiple live HL strategies on the same wallet,
-// the close size is proportional to capital_pct (or capital) weights. For a
-// sole configured trader of that coin, the full on-chain absolute size is used.
-// ok is false when there is no non-zero on-chain position for the coin.
+// (#356). Shared-coin peers are deliberately skipped: Hyperliquid aggregates a
+// coin into one exchange-side position per wallet, so even a partial close can
+// disturb other strategies' live exposure (#512). For a sole configured trader
+// of that coin, the full on-chain absolute size is used. ok is false when there
+// is no non-zero on-chain position or the coin is shared by multiple live peers.
 func computeHyperliquidCircuitCloseQty(coin, strategyID string, hlPositions []HLPosition, hlLiveAll []StrategyConfig) (qty float64, ok bool) {
 	var onChain float64
 	found := false
@@ -755,31 +715,10 @@ func computeHyperliquidCircuitCloseQty(coin, strategyID string, hlPositions []HL
 	}
 	absSzi := math.Abs(onChain)
 	peers := hlLiveStrategiesForCoin(coin, hlLiveAll)
-	if len(peers) <= 1 {
-		return absSzi, true
-	}
-	weights := hlStrategyCapitalWeights(peers)
-	sumW := 0.0
-	var wFiring float64
-	foundFiring := false
-	for i, p := range peers {
-		sumW += weights[i]
-		if p.ID == strategyID {
-			wFiring = weights[i]
-			foundFiring = true
-		}
-	}
-	if !foundFiring || sumW <= 0 {
-		return absSzi, true
-	}
-	q := absSzi * (wFiring / sumW)
-	if q > absSzi {
-		q = absSzi
-	}
-	if q < 1e-12 {
+	if len(peers) > 1 {
 		return 0, false
 	}
-	return q, true
+	return absSzi, true
 }
 
 func hyperliquidKillSwitchFillShare(sc StrategyConfig, coin string, fillSz, fillFee float64, hlLiveAll []StrategyConfig, virtualQty hlVirtualQuantitySnapshot) (float64, float64) {
@@ -909,6 +848,10 @@ func runPendingHyperliquidCircuitCloses(
 		if ss == nil {
 			continue
 		}
+		sym := hyperliquidSymbol(sc.Args)
+		if sym == "" || len(hlLiveStrategiesForCoin(sym, hlLiveAll)) > 1 {
+			continue
+		}
 		if ss.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid) == nil && ss.RiskState.CircuitBreaker {
 			hasStuckCB = true
 			break
@@ -1017,6 +960,16 @@ func runPendingHyperliquidCircuitCloses(
 		}
 		sc := lookupStrategyConfig(strategies, j.stratID)
 		if sc == nil || sc.Platform != "hyperliquid" || sc.Type != "perps" || !hyperliquidIsLive(sc.Args) {
+			mu.Lock()
+			if ss := state.Strategies[j.stratID]; ss != nil {
+				ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseHyperliquid)
+			}
+			mu.Unlock()
+			continue
+		}
+		if sym := hyperliquidSymbol(sc.Args); sym != "" && len(hlLiveStrategiesForCoin(sym, hlLiveAll)) > 1 {
+			fmt.Printf("[INFO] hl-circuit-close: strategy %s coin %s shares the wallet position with peers — clearing pending close and leaving exchange position untouched\n",
+				j.stratID, sym)
 			mu.Lock()
 			if ss := state.Strategies[j.stratID]; ss != nil {
 				ss.RiskState.clearPendingCircuitClose(PlatformPendingCloseHyperliquid)

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1481,7 +1481,7 @@ func TestComputeHyperliquidCircuitCloseQty_SoleOwnerFullSzi(t *testing.T) {
 	}
 }
 
-func TestComputeHyperliquidCircuitCloseQty_Shared50_50(t *testing.T) {
+func TestComputeHyperliquidCircuitCloseQty_SharedCoinSkipped(t *testing.T) {
 	hlLive := []StrategyConfig{
 		{ID: "hl-a", Platform: "hyperliquid", Type: "perps", CapitalPct: 0.5, Capital: 1000,
 			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
@@ -1490,20 +1490,12 @@ func TestComputeHyperliquidCircuitCloseQty_Shared50_50(t *testing.T) {
 	}
 	pos := []HLPosition{{Coin: "ETH", Size: 0.517, EntryPrice: 3000}}
 	q, ok := computeHyperliquidCircuitCloseQty("ETH", "hl-a", pos, hlLive)
-	if !ok {
-		t.Fatal("expected ok")
-	}
-	want := 0.517 * 0.5
-	if math.Abs(q-want) > 1e-9 {
-		t.Errorf("qty=%.6f want %.6f", q, want)
+	if ok || q != 0 {
+		t.Fatalf("shared Hyperliquid coin must not enqueue a per-strategy close; qty=%.6f ok=%v", q, ok)
 	}
 }
 
-// Mixed-units weight normalization (#356 review finding 3): when peers on a
-// shared coin declare weights in different fields (fractional CapitalPct vs
-// absolute Capital), their sum is nonsensical. Detect the mismatch and fall
-// back to equal weights so the firing strategy still gets a meaningful share.
-func TestComputeHyperliquidCircuitCloseQty_MixedUnitsFallsBackToEqualWeights(t *testing.T) {
+func TestComputeHyperliquidCircuitCloseQty_MixedUnitsSharedCoinSkipped(t *testing.T) {
 	hlLive := []StrategyConfig{
 		{ID: "hl-a", Platform: "hyperliquid", Type: "perps", CapitalPct: 0.5,
 			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
@@ -1512,14 +1504,8 @@ func TestComputeHyperliquidCircuitCloseQty_MixedUnitsFallsBackToEqualWeights(t *
 	}
 	pos := []HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 3000}}
 	q, ok := computeHyperliquidCircuitCloseQty("ETH", "hl-a", pos, hlLive)
-	if !ok {
-		t.Fatal("expected ok")
-	}
-	// With equal 1.0/1.0 fallback, hl-a gets half of |szi| = 0.25. Without the
-	// fallback, the old logic would compute 0.5/(0.5+1000) ≈ 0.00025 — a no-op.
-	want := 0.25
-	if math.Abs(q-want) > 1e-9 {
-		t.Errorf("qty=%.6f want %.6f (equal-weight fallback on mixed units)", q, want)
+	if ok || q != 0 {
+		t.Fatalf("shared Hyperliquid coin must not enqueue a per-strategy close; qty=%.6f ok=%v", q, ok)
 	}
 }
 
@@ -1681,6 +1667,60 @@ func TestRunPendingHyperliquidCircuitCloses_ClearsOnSuccess(t *testing.T) {
 	}
 }
 
+func TestRunPendingHyperliquidCircuitCloses_SharedCoinClearsPendingWithoutClose(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-a": {
+				ID: "hl-a",
+				RiskState: RiskState{
+					PendingCircuitCloses: map[string]*PendingCircuitClose{
+						PlatformPendingCloseHyperliquid: {
+							Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.1}},
+						},
+					},
+				},
+			},
+			"hl-b": {ID: "hl-b"},
+		},
+	}
+	cfg := []StrategyConfig{
+		{ID: "hl-a", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-b", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"ema", "ETH", "1h", "--mode=live"}},
+	}
+	var mu sync.RWMutex
+	var calls []string
+	closer := func(sym string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
+		calls = append(calls, sym)
+		return &HyperliquidCloseResult{
+			Close:    &HyperliquidClose{Symbol: sym, Fill: &HyperliquidCloseFill{TotalSz: 0.1, AvgPx: 1}},
+			Platform: "hyperliquid",
+		}, nil
+	}
+
+	runPendingHyperliquidCircuitCloses(
+		context.Background(),
+		state,
+		cfg,
+		"0xabc",
+		[]HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 1}},
+		true,
+		nil,
+		closer,
+		30*time.Second,
+		&mu,
+		nil,
+	)
+
+	if len(calls) != 0 {
+		t.Fatalf("expected no closer calls for shared Hyperliquid coin; got %v", calls)
+	}
+	if state.Strategies["hl-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid) != nil {
+		t.Fatal("expected stale shared-coin pending close to be cleared")
+	}
+}
+
 // #418 Fix 1: a closer that returns Fill.TotalSz < requested size must NOT
 // clear pending — the residual must remain queued for retry next cycle, and
 // virtual state must reflect only what actually filled.
@@ -1821,14 +1861,10 @@ func TestRunPendingHyperliquidCircuitCloses_FullFillDecrementsAndClears(t *testi
 	}
 }
 
-// #418 Fix 2 shared-coin variant: a weighted partial close (the firing
-// strategy's share of a shared on-chain position) must still decrement the
-// firing strategy's virtual quantity, because reconcileHyperliquidPositions
-// deliberately does NOT overwrite virtual quantities for shared coins (#258).
-// Without this decrement, the firing strategy's virtual position stays at
-// 100% while on-chain dropped to its weighted share — and on the next cycle
-// the inflated virtual notional re-fires the CB.
-func TestRunPendingHyperliquidCircuitCloses_SharedCoinDecrementsFiringStrategy(t *testing.T) {
+// #512: per-strategy CB on a shared Hyperliquid coin must not submit a close
+// or mutate virtual state. Hyperliquid has one exchange-side position per
+// coin/wallet; closing a "share" of it changes other strategies' exposure.
+func TestRunPendingHyperliquidCircuitCloses_SharedCoinLeavesVirtualPosition(t *testing.T) {
 	state := &AppState{
 		Strategies: map[string]*StrategyState{
 			"hl-tema": {
@@ -1843,7 +1879,6 @@ func TestRunPendingHyperliquidCircuitCloses_SharedCoinDecrementsFiringStrategy(t
 				RiskState: RiskState{
 					PendingCircuitCloses: map[string]*PendingCircuitClose{
 						PlatformPendingCloseHyperliquid: {
-							// Equal weights → close 0.5 of the shared 1.0 wallet.
 							Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.5}},
 						},
 					},
@@ -1860,7 +1895,9 @@ func TestRunPendingHyperliquidCircuitCloses_SharedCoinDecrementsFiringStrategy(t
 			Args: []string{"rsi_macd", "ETH", "1h", "--mode=live"}},
 	}
 	var mu sync.RWMutex
+	var calls int
 	closer := func(sym string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
+		calls++
 		return &HyperliquidCloseResult{
 			Close:    &HyperliquidClose{Symbol: sym, Fill: &HyperliquidCloseFill{TotalSz: 0.5, AvgPx: 3000, Fee: 0.5}},
 			Platform: "hyperliquid",
@@ -1873,9 +1910,14 @@ func TestRunPendingHyperliquidCircuitCloses_SharedCoinDecrementsFiringStrategy(t
 		nil,
 	)
 
-	// Firing strategy's virtual position should be fully closed.
-	if _, ok := state.Strategies["hl-tema"].Positions["ETH"]; ok {
-		t.Error("firing strategy's ETH position must be removed after weighted close fill (#418)")
+	if calls != 0 {
+		t.Fatalf("expected no closer calls for shared Hyperliquid coin; got %d", calls)
+	}
+	if pos := state.Strategies["hl-tema"].Positions["ETH"]; pos == nil || pos.Quantity != 0.5 {
+		t.Fatalf("expected firing strategy virtual position to remain unchanged; got %+v", pos)
+	}
+	if p := state.Strategies["hl-tema"].RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid); p != nil {
+		t.Fatalf("expected shared-coin pending close cleared; got %+v", p)
 	}
 }
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1161,14 +1161,16 @@ func main() {
 
 					// Phase 2: Lock — CheckRisk (fast, no I/O)
 					var riskAssist *PlatformRiskAssist
-					needHL := hlStateFetched && len(hlLiveAll) > 0
+					needHL := len(hlLiveAll) > 0
 					needOKX := okxStateFetched && len(okxLivePerps) > 0
 					needTS := tsStateFetched && len(tsLiveAll) > 0
 					if needHL || needOKX || needTS {
 						riskAssist = &PlatformRiskAssist{}
 						if needHL {
-							riskAssist.HLPositions = hlPositions
 							riskAssist.HLLiveAll = hlLiveAll
+							if hlStateFetched {
+								riskAssist.HLPositions = hlPositions
+							}
 						}
 						if needOKX {
 							riskAssist.OKXPositions = okxPositions

--- a/scheduler/okx_close.go
+++ b/scheduler/okx_close.go
@@ -209,7 +209,7 @@ func okxLiveStrategiesForCoin(coin string, okxLiveAll []StrategyConfig) []Strate
 }
 
 // okxStrategyCapitalWeight returns a single strategy's proportional weight for
-// shared-coin close sizing. Matches hlStrategyCapitalWeight.
+// OKX shared-coin close sizing.
 func okxStrategyCapitalWeight(sc StrategyConfig) float64 {
 	if sc.CapitalPct > 0 {
 		return sc.CapitalPct
@@ -221,11 +221,11 @@ func okxStrategyCapitalWeight(sc StrategyConfig) float64 {
 }
 
 // okxStrategyCapitalWeights returns per-peer weights for proportional close
-// sizing on a shared coin. Mixed-units guard matches hlStrategyCapitalWeights:
-// when peers declare CapitalPct (fractional) alongside raw Capital (dollars)
-// their sum is nonsensical and the CapitalPct-only peer's share collapses to
-// near-zero, producing a no-op close. Detect the mismatch and fall back to
-// equal weights so the firing strategy still gets a meaningful share.
+// sizing on a shared coin. When peers declare CapitalPct (fractional) alongside
+// raw Capital (dollars), their sum is nonsensical and the CapitalPct-only
+// peer's share collapses to near-zero, producing a no-op close. Detect the
+// mismatch and fall back to equal weights so the firing strategy still gets a
+// meaningful share.
 func okxStrategyCapitalWeights(peers []StrategyConfig) []float64 {
 	hasPct := false
 	hasAbs := false
@@ -255,7 +255,7 @@ func okxStrategyCapitalWeights(peers []StrategyConfig) []float64 {
 // same wallet, the close size is proportional to capital_pct (or capital)
 // weights. For a sole configured trader of that coin, the full on-chain
 // absolute size is used. ok is false when there is no non-zero on-chain
-// position for the coin. Mirrors computeHyperliquidCircuitCloseQty.
+// position for the coin.
 func computeOKXCircuitCloseQty(coin, strategyID string, okxPositions []OKXPosition, okxLiveAll []StrategyConfig) (qty float64, ok bool) {
 	var onChain float64
 	found := false

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -883,6 +883,9 @@ func setHyperliquidCircuitBreakerPending(sc *StrategyConfig, s *StrategyState, a
 	if sym == "" {
 		return
 	}
+	if hyperliquidCircuitBreakerHasSharedCoin(sc, assist) {
+		return
+	}
 	if _, ok := s.Positions[sym]; !ok {
 		return
 	}
@@ -893,6 +896,21 @@ func setHyperliquidCircuitBreakerPending(sc *StrategyConfig, s *StrategyState, a
 	s.RiskState.setPendingCircuitClose(PlatformPendingCloseHyperliquid, &PendingCircuitClose{
 		Symbols: []PendingCircuitCloseSymbol{{Symbol: sym, Size: qty}},
 	})
+}
+
+func hyperliquidCircuitBreakerHasSharedCoin(sc *StrategyConfig, assist *PlatformRiskAssist) bool {
+	if sc == nil || assist == nil || sc.Platform != "hyperliquid" || sc.Type != "perps" || !hyperliquidIsLive(sc.Args) {
+		return false
+	}
+	sym := hyperliquidSymbol(sc.Args)
+	if sym == "" {
+		return false
+	}
+	return len(hlLiveStrategiesForCoin(sym, assist.HLLiveAll)) > 1
+}
+
+func shouldForceCloseAllPositionsOnCircuitBreaker(sc *StrategyConfig, assist *PlatformRiskAssist) bool {
+	return !hyperliquidCircuitBreakerHasSharedCoin(sc, assist)
 }
 
 // setOperatorRequiredCircuitBreakerPending enqueues an OperatorRequired=true
@@ -1313,7 +1331,9 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 			setRobinhoodCircuitBreakerPending(sc, s, assist)
 			setTopStepCircuitBreakerPending(sc, s, assist)
 			setOperatorRequiredCircuitBreakerPending(sc, s)
-			forceCloseAllPositions(s, prices, logger)
+			if shouldForceCloseAllPositionsOnCircuitBreaker(sc, assist) {
+				forceCloseAllPositions(s, prices, logger)
+			}
 			return false, fmt.Sprintf("%s (%.1f%% > %.1f%%, portfolio=$%.2f peak=$%.2f, denom=%s=$%.2f)",
 				RiskReasonMaxDrawdownExceeded, r.CurrentDrawdownPct, r.MaxDrawdownPct, portfolioValue, r.PeakValue, denomLabel, denom)
 		}
@@ -1328,7 +1348,9 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 		setRobinhoodCircuitBreakerPending(sc, s, assist)
 		setTopStepCircuitBreakerPending(sc, s, assist)
 		setOperatorRequiredCircuitBreakerPending(sc, s)
-		forceCloseAllPositions(s, prices, logger)
+		if shouldForceCloseAllPositionsOnCircuitBreaker(sc, assist) {
+			forceCloseAllPositions(s, prices, logger)
+		}
 		return false, RiskReasonConsecutiveLosses
 	}
 

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -1650,11 +1650,12 @@ func TestCheckRisk_PerpsDrawdownFiresBeforeAnyClosedTrades(t *testing.T) {
 	}
 }
 
-// TestCheckRisk_LiveHLSharedCoin_SetsPendingPartialClose verifies #356: a live
-// HL strategy that shares a coin with another configured live HL strategy gets
-// a proportional pending on-chain close (capital_pct weights), not the full
-// wallet szi.
-func TestCheckRisk_LiveHLSharedCoin_SetsPendingPartialClose(t *testing.T) {
+// TestCheckRisk_LiveHLSharedCoin_PausesWithoutClose verifies #512: a live HL
+// strategy that shares a coin with another configured live HL strategy only
+// latches its per-strategy circuit breaker. It must not enqueue an on-chain
+// close or delete virtual state, because Hyperliquid has one shared exchange
+// position per coin/wallet.
+func TestCheckRisk_LiveHLSharedCoin_PausesWithoutClose(t *testing.T) {
 	sc := StrategyConfig{
 		ID: "hl-tema", Platform: "hyperliquid", Type: "perps",
 		CapitalPct: 0.5, Capital: 500, Leverage: 20,
@@ -1692,20 +1693,105 @@ func TestCheckRisk_LiveHLSharedCoin_SetsPendingPartialClose(t *testing.T) {
 
 	_, _ = CheckRisk(&sc, s, pv, prices, nil, assist)
 
-	p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
-	if p == nil {
-		t.Fatal("expected PendingCircuitCloses[hyperliquid] after CB fire")
+	if !s.RiskState.CircuitBreaker {
+		t.Fatal("expected circuit breaker to be active")
 	}
-	if len(p.Symbols) != 1 {
-		t.Fatalf("expected 1 pending symbol, got %d", len(p.Symbols))
+	if p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid); p != nil {
+		t.Fatalf("expected no Hyperliquid pending close for shared coin; got %+v", p)
 	}
-	c0 := p.Symbols[0]
-	if c0.Symbol != "ETH" {
-		t.Errorf("symbol=%q want ETH", c0.Symbol)
+	if _, ok := s.Positions["ETH"]; !ok {
+		t.Fatal("expected shared-coin virtual position to remain open")
 	}
-	want := 0.517 * 0.5
-	if math.Abs(c0.Size-want) > 1e-6 {
-		t.Errorf("pending size=%.6f want %.6f (half of shared on-chain 0.517)", c0.Size, want)
+	if len(s.TradeHistory) != 0 {
+		t.Fatalf("expected no circuit-breaker close trade for shared coin; got %d", len(s.TradeHistory))
+	}
+}
+
+func TestCheckRisk_LiveHLSharedCoin_PausesWithoutCloseWhenHLFetchFailed(t *testing.T) {
+	sc := StrategyConfig{
+		ID: "hl-tema", Platform: "hyperliquid", Type: "perps",
+		CapitalPct: 0.5, Capital: 500, Leverage: 20,
+		Args: []string{"triple_ema", "ETH", "1h", "--mode=live"},
+	}
+	assist := &PlatformRiskAssist{
+		HLLiveAll: []StrategyConfig{
+			sc,
+			{ID: "hl-rmc", Platform: "hyperliquid", Type: "perps",
+				CapitalPct: 0.5, Capital: 500, Leverage: 20,
+				Args: []string{"rsi_macd", "ETH", "1h", "--mode=live"}},
+		},
+	}
+	s := &StrategyState{
+		ID:       sc.ID,
+		Type:     "perps",
+		Platform: "hyperliquid",
+		Cash:     584.0,
+		RiskState: RiskState{
+			PeakValue:      589.0,
+			MaxDrawdownPct: 25.0,
+			DailyPnLDate:   todayUTC(),
+		},
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.236, AvgCost: 2357.0, Side: "long", Multiplier: 1, Leverage: 20},
+		},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+	}
+
+	allowed, _ := CheckRisk(&sc, s, PortfolioValue(s, map[string]float64{"ETH": 2307.5}), map[string]float64{"ETH": 2307.5}, nil, assist)
+
+	if allowed {
+		t.Fatal("expected risk block")
+	}
+	if p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid); p != nil {
+		t.Fatalf("expected no pending close without HL position snapshot for shared coin; got %+v", p)
+	}
+	if _, ok := s.Positions["ETH"]; !ok {
+		t.Fatal("expected virtual position to remain open when HL fetch failed")
+	}
+}
+
+func TestCheckRisk_LiveHLSoleOwner_StillForceCloses(t *testing.T) {
+	sc := StrategyConfig{
+		ID: "hl-tema", Platform: "hyperliquid", Type: "perps",
+		Capital: 500, Leverage: 20,
+		Args: []string{"triple_ema", "ETH", "1h", "--mode=live"},
+	}
+	assist := &PlatformRiskAssist{
+		HLPositions: []HLPosition{{Coin: "ETH", Size: 0.517, EntryPrice: 3000}},
+		HLLiveAll:   []StrategyConfig{sc},
+	}
+	s := &StrategyState{
+		ID:       sc.ID,
+		Type:     "perps",
+		Platform: "hyperliquid",
+		Cash:     584.0,
+		RiskState: RiskState{
+			PeakValue:      589.0,
+			MaxDrawdownPct: 25.0,
+			DailyPnLDate:   todayUTC(),
+		},
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.236, AvgCost: 2357.0, Side: "long", Multiplier: 1, Leverage: 20},
+		},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+	}
+	prices := map[string]float64{"ETH": 2307.5}
+
+	allowed, _ := CheckRisk(&sc, s, PortfolioValue(s, prices), prices, nil, assist)
+
+	if allowed {
+		t.Fatal("expected risk block")
+	}
+	if p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid); p == nil || len(p.Symbols) != 1 || p.Symbols[0].Symbol != "ETH" {
+		t.Fatalf("expected Hyperliquid pending close for sole owner; got %+v", p)
+	}
+	if _, ok := s.Positions["ETH"]; ok {
+		t.Fatal("expected sole-owner virtual position to be force-closed")
+	}
+	if len(s.TradeHistory) != 1 {
+		t.Fatalf("expected one circuit-breaker close trade; got %d", len(s.TradeHistory))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Changed per-strategy Hyperliquid circuit-breaker handling so shared-coin wallets are paused without submitting exchange-side close orders.
- Sole-owner Hyperliquid circuit breakers still enqueue and execute force-closes as before.
- Preserved portfolio kill-switch behavior and updated the main loop so shared-coin detection still works even when the HL position fetch is unavailable.
- Added and updated regression tests for shared-coin pause behavior, sole-owner force-close behavior, and pending-close recovery.

## Testing
- `go test ./...` in `scheduler` passed.
- `go build` in `scheduler` passed after the change.

Closes #512

LLM: Codex (GPT-5) | medium