### PR TITLE
fix: honor close_fraction from close strategies in live and paper execution

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1811,7 +1811,7 @@ func runSpotCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionC
 
 // executeSpotResult applies a spot signal to state. Must be called under Lock.
 func executeSpotResult(sc StrategyConfig, s *StrategyState, result *SpotResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
-	trades, err := ExecuteSpotSignal(s, result.Signal, result.Symbol, price, 0, logger)
+	trades, err := ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, price, 0, 0, "", result.CloseFraction, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -2094,7 +2094,7 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	sizingLeverage := EffectiveSizingLeverage(sc)
 	exchangeLeverage := EffectiveExchangeLeverage(sc)
 	marginPerTradeUSD := EffectiveMarginPerTradeUSD(sc)
-	size, ok, reason := perpsLiveOrderSize(result.Signal, price, cash, posQty, avgCost, sizingLeverage, exchangeLeverage, marginPerTradeUSD, posSide, sc.AllowShorts)
+	size, ok, reason := perpsLiveOrderSize(result.Signal, price, cash, posQty, avgCost, sizingLeverage, exchangeLeverage, marginPerTradeUSD, posSide, sc.AllowShorts, result.CloseFraction)
 	if !ok {
 		logger.Info("%s for %s", reason, result.Symbol)
 		return nil, false
@@ -2115,6 +2115,13 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	//   - on a flip, pass prev_pos_qty so the SL is sized against the new
 	//     net position (#421) — total_sz alone is closeQty+newQty.
 	pureClose := result.Signal == -1 && posSide == "long" && !sc.AllowShorts
+	// Partial close (#519): a fractional close from the open/close registry
+	// must NOT cancel the resting stop-loss — the SL is reduce-only and will
+	// continue to protect the residual position; cancelling without
+	// re-placing would leave the remainder unprotected. Skip both the cancel
+	// and the new-SL placement on partial close. The trailing-stop loop
+	// resizes the SL on its own cadence (#502).
+	partialClose := result.CloseFraction > 0 && result.CloseFraction < 1
 	// flipping predicate must mirror perpsLiveOrderSize exactly — both branches
 	// require sc.AllowShorts. A long-only strategy that inherited a short
 	// position (e.g. AllowShorts toggled true→false between restarts) would
@@ -2123,11 +2130,11 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	// the SL silently undersized (#421 review point 6).
 	flipping := sc.AllowShorts && posQty > 0 && ((result.Signal == 1 && posSide == "short") || (result.Signal == -1 && posSide == "long"))
 	var cancelOID int64
-	if existingStopLossOID > 0 && posQty > 0 {
+	if existingStopLossOID > 0 && posQty > 0 && !partialClose {
 		cancelOID = existingStopLossOID
 	}
 	var slPct float64
-	if !pureClose {
+	if !pureClose && !partialClose {
 		// EffectiveStopLossPct self-guards on platform/type and returns the
 		// explicit price %, derives it from stop_loss_margin_pct / leverage
 		// (#487), or falls back to max_drawdown_pct capped at 50% (#484).
@@ -2265,7 +2272,7 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 		fillFee = fill.Fee
 	}
 
-	trades, err := ExecutePerpsSignalWithLeverage(s, result.Signal, result.Symbol, fillPrice, sizingLeverage, exchangeLeverage, marginPerTradeUSD, fillQty, fillOID, fillFee, sc.AllowShorts, logger)
+	trades, err := ExecutePerpsSignalWithLeverage(s, result.Signal, result.Symbol, fillPrice, sizingLeverage, exchangeLeverage, marginPerTradeUSD, fillQty, fillOID, fillFee, sc.AllowShorts, result.CloseFraction, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -2436,6 +2443,19 @@ func runTopStepExecuteOrder(sc StrategyConfig, result *TopStepResult, price, cas
 			return nil, false
 		}
 		contracts = int(posQty)
+		if result.CloseFraction > 0 && result.CloseFraction < 1 {
+			// #519: partial close from the open/close registry, rounded
+			// DOWN to whole contracts so the residual position stays at
+			// least one contract.
+			partial := int(float64(contracts) * result.CloseFraction)
+			if partial < 1 {
+				logger.Info("Partial-close fraction %.4f rounds to 0 contracts for %s; skipping live order", result.CloseFraction, result.Symbol)
+				return nil, false
+			}
+			if partial < contracts {
+				contracts = partial
+			}
+		}
 	}
 
 	side := "buy"
@@ -2487,7 +2507,7 @@ func executeTopStepResult(sc StrategyConfig, s *StrategyState, result *TopStepRe
 		maxContracts = sc.FuturesConfig.MaxContracts
 	}
 
-	trades, err := ExecuteFuturesSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, result.ContractSpec, feePerContract, maxContracts, fillContracts, fillFee, fillOID, logger)
+	trades, err := ExecuteFuturesSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, result.ContractSpec, feePerContract, maxContracts, fillContracts, fillFee, fillOID, result.CloseFraction, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -2603,6 +2623,12 @@ func runRobinhoodExecuteOrder(sc StrategyConfig, result *RobinhoodResult, price,
 			return nil, false
 		}
 		quantity = posQty
+		if result.CloseFraction > 0 && result.CloseFraction < 1 {
+			// #519: partial close from the open/close registry sizes the
+			// live order to the fraction so the exchange and virtual state
+			// agree on the close leg.
+			quantity = posQty * result.CloseFraction
+		}
 	}
 
 	logger.Info("Placing live %s %s amount_usd=%.2f qty=%.6f", side, result.Symbol, amountUSD, quantity)
@@ -2643,7 +2669,7 @@ func executeRobinhoodResult(sc StrategyConfig, s *StrategyState, result *Robinho
 		logger.Info("Live fill at $%.2f qty=%.6f (mid was $%.2f)", fillPrice, fillQty, price)
 	}
 
-	trades, err := ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, fillOID, logger)
+	trades, err := ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, fillOID, result.CloseFraction, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -2770,7 +2796,7 @@ func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQt
 	if sc.Type == "perps" {
 		var ok bool
 		var reason string
-		size, ok, reason = perpsLiveOrderSize(result.Signal, price, cash, posQty, avgCost, sizingLeverage, exchangeLeverage, marginPerTradeUSD, posSide, sc.AllowShorts)
+		size, ok, reason = perpsLiveOrderSize(result.Signal, price, cash, posQty, avgCost, sizingLeverage, exchangeLeverage, marginPerTradeUSD, posSide, sc.AllowShorts, result.CloseFraction)
 		if !ok {
 			logger.Info("%s for %s", reason, result.Symbol)
 			return nil, false
@@ -2792,6 +2818,10 @@ func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQt
 				return nil, false
 			}
 			size = posQty
+			if result.CloseFraction > 0 && result.CloseFraction < 1 {
+				// #519: partial close on OKX spot from the open/close registry.
+				size = posQty * result.CloseFraction
+			}
 		}
 	}
 
@@ -2846,9 +2876,9 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, result *OKXResult, ex
 	var trades int
 	var err error
 	if sc.Type == "perps" {
-		trades, err = ExecutePerpsSignalWithLeverage(s, result.Signal, result.Symbol, fillPrice, EffectiveSizingLeverage(sc), EffectiveExchangeLeverage(sc), EffectiveMarginPerTradeUSD(sc), fillQty, fillOID, fillFee, sc.AllowShorts, logger)
+		trades, err = ExecutePerpsSignalWithLeverage(s, result.Signal, result.Symbol, fillPrice, EffectiveSizingLeverage(sc), EffectiveExchangeLeverage(sc), EffectiveMarginPerTradeUSD(sc), fillQty, fillOID, fillFee, sc.AllowShorts, result.CloseFraction, logger)
 	} else {
-		trades, err = ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, fillOID, logger)
+		trades, err = ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, fillOID, result.CloseFraction, logger)
 	}
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -389,7 +389,16 @@ func PerpsOrderSkipReason(signal int, posSide string, allowShorts bool) string {
 // removed in #518.
 //
 // Returns (size, ok); when ok is false `reason` is a log-ready string.
-func perpsLiveOrderSize(signal int, price, cash, posQty, avgCost, sizingLeverage, exchangeLeverage, marginPerTradeUSD float64, posSide string, allowShorts bool) (size float64, ok bool, reason string) {
+//
+// closeFraction (#519) scales the close-only return when 0 < frac < 1: a
+// partial-close decision from the open/close registry (e.g. tiered_tp_atr
+// tier 1) is composed into signal=-1 (long) / signal=+1 (short) by
+// shared_tools/strategy_composition.compose_signal — the fraction is the only
+// signal that fewer than all of posQty should be reduced. The flip branch is
+// unreachable when closeFraction > 0 because compose_signal does not emit a
+// flip alongside a close (open_action is dropped while a position is open),
+// so closeFraction is intentionally ignored on the open/flip path.
+func perpsLiveOrderSize(signal int, price, cash, posQty, avgCost, sizingLeverage, exchangeLeverage, marginPerTradeUSD float64, posSide string, allowShorts bool, closeFraction float64) (size float64, ok bool, reason string) {
 	isBuy := signal == 1
 	flipping := allowShorts && posQty > 0 && ((isBuy && posSide == "short") || (!isBuy && posSide == "long"))
 	// Fresh open: buy always fresh-sizes (legacy buy-vs-migrated-short kept
@@ -434,9 +443,17 @@ func perpsLiveOrderSize(signal int, price, cash, posQty, avgCost, sizingLeverage
 		}
 		return newSize, true, ""
 	}
-	// close-only: signal=-1 + long + !allowShorts
+	// close-only: signal=-1 + long + !allowShorts (or signal=+1 + short
+	// composed from a close strategy on a long-only-flipped runtime)
 	if posQty <= 0 {
 		return 0, false, "no position to close"
+	}
+	if closeFraction > 0 && closeFraction < 1 {
+		// Partial close (#519): tiered_tp_* / fractional close strategies
+		// emit close_fraction relative to current_quantity. Size the live
+		// order to match so the exchange and virtual state agree on the
+		// close leg before Execute*Signal records it.
+		return posQty * closeFraction, true, ""
 	}
 	return posQty, true, ""
 }
@@ -527,10 +544,20 @@ func FuturesOrderSkipReason(signal int, posSide string) string {
 // closes a long and never opens a short — the legacy long-only behavior
 // that strategies like triple_ema and rsi_macd_combo depend on.
 func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float64, leverage float64, fillQty float64, fillOID string, fillFee float64, allowShorts bool, logger *StrategyLogger) (int, error) {
-	return ExecutePerpsSignalWithLeverage(s, signal, symbol, price, leverage, leverage, 0, fillQty, fillOID, fillFee, allowShorts, logger)
+	return ExecutePerpsSignalWithLeverage(s, signal, symbol, price, leverage, leverage, 0, fillQty, fillOID, fillFee, allowShorts, 0, logger)
 }
 
-func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string, price float64, sizingLeverage, exchangeLeverage, marginPerTradeUSD float64, fillQty float64, fillOID string, fillFee float64, allowShorts bool, logger *StrategyLogger) (int, error) {
+// ExecutePerpsSignalWithLeverage processes a perps signal.
+//
+// closeFraction (#519) selects partial-close accounting: when 0 < frac < 1
+// AND the signal is a close-action emitted by the open/close registry
+// (compose_signal returns -1 on long / +1 on short), the close leg reduces
+// pos.Quantity by frac (paper) or fillQty (live) without deleting the
+// position, and the bidirectional open-leg path is skipped (compose_signal
+// never composes close+open in the same cycle). closeFraction == 0 preserves
+// the legacy full-close behavior used by direct strategy signals,
+// kill-switch, stop-loss, and forceCloseAllPositions paths.
+func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string, price float64, sizingLeverage, exchangeLeverage, marginPerTradeUSD float64, fillQty float64, fillOID string, fillFee float64, allowShorts bool, closeFraction float64, logger *StrategyLogger) (int, error) {
 	if signal == 0 {
 		return 0, nil
 	}
@@ -542,6 +569,11 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 	}
 	tradesExecuted := 0
 	leverageLabel := perpsLeverageLabel(exchangeLeverage, sizingLeverage)
+	// #519: partial close suppresses the bidirectional open-leg path —
+	// compose_signal never composes a close+open in the same cycle, so any
+	// fractional close emitted by the open/close registry is close-only.
+	partialClose := closeFraction > 0 && closeFraction < 1
+	closeOnlyAction := closeFraction > 0 // any close decision skips open-leg
 
 	// Fee dispatch: for Hyperliquid spot+perps and OKX perps the existing
 	// CalculatePlatformSpotFee table already encodes the correct taker fee.
@@ -566,8 +598,16 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 		}
 		// Close short if exists — realize PnL only (no notional swing).
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "short" {
+			closeQty := pos.Quantity
+			if partialClose {
+				if fillQty > 0 {
+					closeQty = fillQty
+				} else {
+					closeQty = pos.Quantity * closeFraction
+				}
+			}
 			if allowShorts {
-				flipCloseQty = pos.Quantity
+				flipCloseQty = closeQty
 			}
 			var execPrice float64
 			if fillQty > 0 {
@@ -575,9 +615,9 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 			} else {
 				execPrice = ApplySlippage(price)
 			}
-			pnl := pos.Quantity * (pos.AvgCost - execPrice)
-			useFillFee := flipCloseQty > 0
-			fee := executionFee(CalculatePlatformSpotFee(feePlatform, pos.Quantity*execPrice), fillFee, useFillFee)
+			pnl := closeQty * (pos.AvgCost - execPrice)
+			useFillFee := flipCloseQty > 0 || closeOnlyAction
+			fee := executionFee(CalculatePlatformSpotFee(feePlatform, closeQty*execPrice), fillFee, useFillFee)
 			pnl -= fee
 			s.Cash += pnl
 			now := time.Now().UTC()
@@ -586,17 +626,21 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 			if useFillFee {
 				closeOID = fillOID
 			}
+			details := fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee)
+			if partialClose {
+				details = fmt.Sprintf("Partial-close short %.6f, PnL: $%.2f (fee $%.2f)", closeQty, pnl, fee)
+			}
 			trade := Trade{
 				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
 				PositionID:      positionID,
 				Side:            "buy",
-				Quantity:        pos.Quantity,
+				Quantity:        closeQty,
 				Price:           execPrice,
-				Value:           pos.Quantity * execPrice,
+				Value:           closeQty * execPrice,
 				TradeType:       "perps",
-				Details:         fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				Details:         details,
 				ExchangeOrderID: closeOID,
 				ExchangeFee:     exchangeFeeForTrade(fillFee, useFillFee),
 				IsClose:         true,
@@ -604,11 +648,23 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
-			recordClosedPosition(s, pos, execPrice, pnl, "signal", now)
-			delete(s.Positions, symbol)
-			clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
-			logger.Info("Closed short %s @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, execPrice, fee, pnl)
+			if partialClose {
+				pos.Quantity -= closeQty
+				logger.Info("Partial-close short %s: %.6f (remaining %.6f) @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, closeQty, pos.Quantity, execPrice, fee, pnl)
+			} else {
+				recordClosedPosition(s, pos, execPrice, pnl, "signal", now)
+				delete(s.Positions, symbol)
+				clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
+				logger.Info("Closed short %s @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, execPrice, fee, pnl)
+			}
 			tradesExecuted++
+		}
+		// Close-action from the open/close registry (#519): the registry
+		// never composes close+open in the same cycle, so any close decision
+		// (partial OR full) skips the open-leg path. Legacy direct-signal
+		// flips (closeFraction == 0) keep falling through.
+		if closeOnlyAction {
+			return tradesExecuted, nil
 		}
 		// Open long
 		if s.Cash < 1 {
@@ -688,8 +744,16 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 		}
 		// Close long if exists — realize PnL.
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
+			closeQty := pos.Quantity
+			if partialClose {
+				if fillQty > 0 {
+					closeQty = fillQty
+				} else {
+					closeQty = pos.Quantity * closeFraction
+				}
+			}
 			if allowShorts {
-				flipCloseQty = pos.Quantity
+				flipCloseQty = closeQty
 			}
 			var execPrice float64
 			if fillQty > 0 {
@@ -697,9 +761,9 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 			} else {
 				execPrice = ApplySlippage(price)
 			}
-			pnl := pos.Quantity * (execPrice - pos.AvgCost)
-			useFillFee := flipCloseQty > 0 || !allowShorts
-			fee := executionFee(CalculatePlatformSpotFee(feePlatform, pos.Quantity*execPrice), fillFee, useFillFee)
+			pnl := closeQty * (execPrice - pos.AvgCost)
+			useFillFee := flipCloseQty > 0 || !allowShorts || closeOnlyAction
+			fee := executionFee(CalculatePlatformSpotFee(feePlatform, closeQty*execPrice), fillFee, useFillFee)
 			pnl -= fee
 			s.Cash += pnl
 			now := time.Now().UTC()
@@ -708,17 +772,21 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 			if useFillFee {
 				closeOID = fillOID
 			}
+			details := fmt.Sprintf("Close long, PnL: $%.2f (fee $%.2f)", pnl, fee)
+			if partialClose {
+				details = fmt.Sprintf("Partial-close long %.6f, PnL: $%.2f (fee $%.2f)", closeQty, pnl, fee)
+			}
 			trade := Trade{
 				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
 				PositionID:      positionID,
 				Side:            "sell",
-				Quantity:        pos.Quantity,
+				Quantity:        closeQty,
 				Price:           execPrice,
-				Value:           pos.Quantity * execPrice,
+				Value:           closeQty * execPrice,
 				TradeType:       "perps",
-				Details:         fmt.Sprintf("Close long, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				Details:         details,
 				ExchangeOrderID: closeOID,
 				ExchangeFee:     exchangeFeeForTrade(fillFee, useFillFee),
 				IsClose:         true,
@@ -726,11 +794,21 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
-			recordClosedPosition(s, pos, execPrice, pnl, "signal", now)
-			delete(s.Positions, symbol)
-			clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
-			logger.Info("SELL %s: %.6f @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, pos.Quantity, execPrice, fee, pnl)
+			if partialClose {
+				pos.Quantity -= closeQty
+				logger.Info("Partial-close long %s: %.6f (remaining %.6f) @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, closeQty, pos.Quantity, execPrice, fee, pnl)
+			} else {
+				recordClosedPosition(s, pos, execPrice, pnl, "signal", now)
+				delete(s.Positions, symbol)
+				clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
+				logger.Info("SELL %s: %.6f @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, closeQty, execPrice, fee, pnl)
+			}
 			tradesExecuted++
+		}
+		// Close-action from the open/close registry (#519): see comment on
+		// the symmetric branch in the signal==1 block above.
+		if closeOnlyAction {
+			return tradesExecuted, nil
 		}
 		// Legacy long-only path: whether we closed a long or had nothing to
 		// close, AllowShorts=false never opens a short. Log only when we did
@@ -816,10 +894,15 @@ func perpsLeverageLabel(exchangeLeverage, sizingLeverage float64) string {
 // fillQty > 0 means a live fill: use price as-is (no slippage) and fillQty as position quantity for buys.
 // fillQty == 0 means paper mode: apply ApplySlippage and compute qty from state budget.
 func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float64, fillQty float64, logger *StrategyLogger) (int, error) {
-	return ExecuteSpotSignalWithFillFee(s, signal, symbol, price, fillQty, 0, "", logger)
+	return ExecuteSpotSignalWithFillFee(s, signal, symbol, price, fillQty, 0, "", 0, logger)
 }
 
-func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, fillQty float64, fillFee float64, fillOID string, logger *StrategyLogger) (int, error) {
+// ExecuteSpotSignalWithFillFee processes a spot signal with optional live
+// fill metadata. closeFraction (#519) is the partial-close fraction emitted by
+// the open/close registry: when 0 < frac < 1 on a close-side signal the close
+// leg reduces pos.Quantity (paper) or uses fillQty (live) without deleting
+// the position. closeFraction == 0 preserves the legacy full-close semantics.
+func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, fillQty float64, fillFee float64, fillOID string, closeFraction float64, logger *StrategyLogger) (int, error) {
 	if signal == 0 {
 		return 0, nil
 	}
@@ -829,6 +912,7 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 		feePlatform = "okx-perps"
 	}
 	fillMetadataUsed := false
+	partialClose := closeFraction > 0 && closeFraction < 1
 
 	if signal == 1 { // Buy
 		// Check if already long
@@ -838,34 +922,46 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 		}
 		// Close short if exists
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "short" {
+			closeQty := pos.Quantity
+			if partialClose {
+				if fillQty > 0 {
+					closeQty = fillQty
+				} else {
+					closeQty = pos.Quantity * closeFraction
+				}
+			}
 			var execPrice float64
 			if fillQty > 0 {
 				execPrice = price
 			} else {
 				execPrice = ApplySlippage(price)
 			}
-			buyCost := pos.Quantity * execPrice
+			buyCost := closeQty * execPrice
 			useFillMetadata := fillQty > 0 && !fillMetadataUsed
 			fee := executionFee(CalculatePlatformSpotFee(feePlatform, buyCost), fillFee, useFillMetadata)
 			if useFillMetadata {
 				fillMetadataUsed = true
 			}
 			totalCost := buyCost + fee
-			pnl := pos.Quantity*pos.AvgCost - totalCost
-			s.Cash += pos.Quantity*pos.AvgCost - totalCost
+			pnl := closeQty*pos.AvgCost - totalCost
+			s.Cash += closeQty*pos.AvgCost - totalCost
 			now := time.Now().UTC()
 			positionID := ensurePositionTradeID(s.ID, symbol, pos)
+			details := fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee)
+			if partialClose {
+				details = fmt.Sprintf("Partial-close short %.6f, PnL: $%.2f (fee $%.2f)", closeQty, pnl, fee)
+			}
 			trade := Trade{
 				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
 				PositionID:      positionID,
 				Side:            "buy",
-				Quantity:        pos.Quantity,
+				Quantity:        closeQty,
 				Price:           execPrice,
 				Value:           totalCost,
 				TradeType:       "spot",
-				Details:         fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				Details:         details,
 				ExchangeOrderID: exchangeOrderIDForTrade(fillOID, useFillMetadata),
 				ExchangeFee:     exchangeFeeForTrade(fillFee, useFillMetadata),
 				IsClose:         true,
@@ -873,10 +969,21 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
-			recordClosedPosition(s, pos, execPrice, pnl, "signal", now)
-			delete(s.Positions, symbol)
-			logger.Info("Closed short %s @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, execPrice, fee, pnl)
+			if partialClose {
+				pos.Quantity -= closeQty
+				logger.Info("Partial-close short %s: %.6f (remaining %.6f) @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, closeQty, pos.Quantity, execPrice, fee, pnl)
+			} else {
+				recordClosedPosition(s, pos, execPrice, pnl, "signal", now)
+				delete(s.Positions, symbol)
+				logger.Info("Closed short %s @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, execPrice, fee, pnl)
+			}
 			tradesExecuted++
+		}
+		// Spot has no flip semantics: a partial close on a short does not
+		// open a long in the same cycle. Stop here when this signal is a
+		// close-action emitted by the open/close registry (#519).
+		if closeFraction > 0 {
+			return tradesExecuted, nil
 		}
 		// Open long — deploy full cash (paper) or exact fill qty (live). The
 		// hardcoded 0.95 safety buffer was removed in #518; spot has no
@@ -938,34 +1045,46 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 	} else if signal == -1 { // Sell
 		// Close long if exists
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
+			closeQty := pos.Quantity
+			if partialClose {
+				if fillQty > 0 {
+					closeQty = fillQty
+				} else {
+					closeQty = pos.Quantity * closeFraction
+				}
+			}
 			var execPrice float64
 			if fillQty > 0 {
 				execPrice = price
 			} else {
 				execPrice = ApplySlippage(price)
 			}
-			saleValue := pos.Quantity * execPrice
+			saleValue := closeQty * execPrice
 			useFillMetadata := fillQty > 0 && !fillMetadataUsed
 			fee := executionFee(CalculatePlatformSpotFee(feePlatform, saleValue), fillFee, useFillMetadata)
 			if useFillMetadata {
 				fillMetadataUsed = true
 			}
 			netProceeds := saleValue - fee
-			pnl := netProceeds - (pos.Quantity * pos.AvgCost)
+			pnl := netProceeds - (closeQty * pos.AvgCost)
 			s.Cash += netProceeds
 			now := time.Now().UTC()
 			positionID := ensurePositionTradeID(s.ID, symbol, pos)
+			details := fmt.Sprintf("Close long, PnL: $%.2f (fee $%.2f)", pnl, fee)
+			if partialClose {
+				details = fmt.Sprintf("Partial-close long %.6f, PnL: $%.2f (fee $%.2f)", closeQty, pnl, fee)
+			}
 			trade := Trade{
 				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
 				PositionID:      positionID,
 				Side:            "sell",
-				Quantity:        pos.Quantity,
+				Quantity:        closeQty,
 				Price:           execPrice,
 				Value:           netProceeds,
 				TradeType:       "spot",
-				Details:         fmt.Sprintf("Close long, PnL: $%.2f (fee $%.2f)", pnl, fee),
+				Details:         details,
 				ExchangeOrderID: exchangeOrderIDForTrade(fillOID, useFillMetadata),
 				ExchangeFee:     exchangeFeeForTrade(fillFee, useFillMetadata),
 				IsClose:         true,
@@ -973,9 +1092,14 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
-			recordClosedPosition(s, pos, execPrice, pnl, "signal", now)
-			delete(s.Positions, symbol)
-			logger.Info("SELL %s: %.6f @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, pos.Quantity, execPrice, fee, pnl)
+			if partialClose {
+				pos.Quantity -= closeQty
+				logger.Info("Partial-close long %s: %.6f (remaining %.6f) @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, closeQty, pos.Quantity, execPrice, fee, pnl)
+			} else {
+				recordClosedPosition(s, pos, execPrice, pnl, "signal", now)
+				delete(s.Positions, symbol)
+				logger.Info("SELL %s: %.6f @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, closeQty, execPrice, fee, pnl)
+			}
 			tradesExecuted++
 		} else {
 			logger.Info("No long position in %s to sell, skipping", symbol)
@@ -988,16 +1112,23 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 // fillContracts > 0 means a live fill: use price as-is (no slippage) and fillContracts as contract count for opens.
 // fillContracts == 0 means paper mode: apply ApplySlippage and compute contracts from state budget.
 func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price float64, spec ContractSpec, feePerContract float64, maxContracts int, fillContracts int, logger *StrategyLogger) (int, error) {
-	return ExecuteFuturesSignalWithFillFee(s, signal, symbol, price, spec, feePerContract, maxContracts, fillContracts, 0, "", logger)
+	return ExecuteFuturesSignalWithFillFee(s, signal, symbol, price, spec, feePerContract, maxContracts, fillContracts, 0, "", 0, logger)
 }
 
-func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, spec ContractSpec, feePerContract float64, maxContracts int, fillContracts int, fillFee float64, fillOID string, logger *StrategyLogger) (int, error) {
+// ExecuteFuturesSignalWithFillFee processes a futures signal with optional
+// live fill metadata. closeFraction (#519) is the partial-close fraction
+// emitted by the open/close registry; whole-contract sizing rounds the close
+// leg DOWN to ensure the residual position has at least one contract
+// remaining (a tier returning a fraction smaller than 1 contract is a no-op
+// rather than a full close).
+func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, spec ContractSpec, feePerContract float64, maxContracts int, fillContracts int, fillFee float64, fillOID string, closeFraction float64, logger *StrategyLogger) (int, error) {
 	if signal == 0 {
 		return 0, nil
 	}
 	tradesExecuted := 0
 	multiplier := spec.Multiplier
 	fillMetadataUsed := false
+	partialClose := closeFraction > 0 && closeFraction < 1
 
 	if signal == 1 { // Buy
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
@@ -1006,13 +1137,30 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 		}
 		// Close short if exists
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "short" {
+			contracts := int(pos.Quantity)
+			if partialClose {
+				if fillContracts > 0 {
+					contracts = fillContracts
+				} else {
+					contracts = int(float64(int(pos.Quantity)) * closeFraction)
+				}
+				if contracts < 1 {
+					logger.Info("Partial-close fraction %.4f rounds to 0 contracts for %s; skipping", closeFraction, symbol)
+					return tradesExecuted, nil
+				}
+				if contracts >= int(pos.Quantity) {
+					// Round-up edge case (e.g. fraction=0.99 of 1 contract):
+					// degrade to a full close rather than over-closing.
+					partialClose = false
+					contracts = int(pos.Quantity)
+				}
+			}
 			var execPrice float64
 			if fillContracts > 0 {
 				execPrice = price
 			} else {
 				execPrice = ApplySlippage(price)
 			}
-			contracts := int(pos.Quantity)
 			pnl := float64(contracts) * multiplier * (pos.AvgCost - execPrice)
 			useFillMetadata := fillContracts > 0 && !fillMetadataUsed
 			fee := executionFee(CalculateFuturesFee(contracts, feePerContract), fillFee, useFillMetadata)
@@ -1023,17 +1171,21 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			s.Cash += pnl
 			now := time.Now().UTC()
 			positionID := ensurePositionTradeID(s.ID, symbol, pos)
+			details := fmt.Sprintf("Close short %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee)
+			if partialClose {
+				details = fmt.Sprintf("Partial-close short %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee)
+			}
 			trade := Trade{
 				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
 				PositionID:      positionID,
 				Side:            "buy",
-				Quantity:        pos.Quantity,
+				Quantity:        float64(contracts),
 				Price:           execPrice,
 				Value:           float64(contracts) * multiplier * execPrice,
 				TradeType:       "futures",
-				Details:         fmt.Sprintf("Close short %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee),
+				Details:         details,
 				ExchangeOrderID: exchangeOrderIDForTrade(fillOID, useFillMetadata),
 				ExchangeFee:     exchangeFeeForTrade(fillFee, useFillMetadata),
 				IsClose:         true,
@@ -1041,10 +1193,20 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
-			recordClosedPosition(s, pos, execPrice, pnl, "signal", now)
-			delete(s.Positions, symbol)
-			logger.Info("Closed short %s %d contracts @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, contracts, execPrice, fee, pnl)
+			if partialClose {
+				pos.Quantity -= float64(contracts)
+				logger.Info("Partial-close short %s %d contracts (remaining %d) @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, contracts, int(pos.Quantity), execPrice, fee, pnl)
+			} else {
+				recordClosedPosition(s, pos, execPrice, pnl, "signal", now)
+				delete(s.Positions, symbol)
+				logger.Info("Closed short %s %d contracts @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, contracts, execPrice, fee, pnl)
+			}
 			tradesExecuted++
+		}
+		// Close-action from the open/close registry (#519): a partial-close
+		// signal does not flip into a fresh long.
+		if closeFraction > 0 {
+			return tradesExecuted, nil
 		}
 		// Open long — whole contracts only. The 0.95 buffer was removed in
 		// #518; futures size in whole contracts so the 5% buffer often had no
@@ -1117,13 +1279,28 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 	} else if signal == -1 { // Sell
 		// Close long if exists
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
+			contracts := int(pos.Quantity)
+			if partialClose {
+				if fillContracts > 0 {
+					contracts = fillContracts
+				} else {
+					contracts = int(float64(int(pos.Quantity)) * closeFraction)
+				}
+				if contracts < 1 {
+					logger.Info("Partial-close fraction %.4f rounds to 0 contracts for %s; skipping", closeFraction, symbol)
+					return tradesExecuted, nil
+				}
+				if contracts >= int(pos.Quantity) {
+					partialClose = false
+					contracts = int(pos.Quantity)
+				}
+			}
 			var execPrice float64
 			if fillContracts > 0 {
 				execPrice = price
 			} else {
 				execPrice = ApplySlippage(price)
 			}
-			contracts := int(pos.Quantity)
 			pnl := float64(contracts) * multiplier * (execPrice - pos.AvgCost)
 			useFillMetadata := fillContracts > 0 && !fillMetadataUsed
 			fee := executionFee(CalculateFuturesFee(contracts, feePerContract), fillFee, useFillMetadata)
@@ -1134,17 +1311,21 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			s.Cash += pnl
 			now := time.Now().UTC()
 			positionID := ensurePositionTradeID(s.ID, symbol, pos)
+			details := fmt.Sprintf("Close long %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee)
+			if partialClose {
+				details = fmt.Sprintf("Partial-close long %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee)
+			}
 			trade := Trade{
 				Timestamp:       now,
 				StrategyID:      s.ID,
 				Symbol:          symbol,
 				PositionID:      positionID,
 				Side:            "sell",
-				Quantity:        pos.Quantity,
+				Quantity:        float64(contracts),
 				Price:           execPrice,
 				Value:           float64(contracts) * multiplier * execPrice,
 				TradeType:       "futures",
-				Details:         fmt.Sprintf("Close long %d contracts, PnL: $%.2f (fee $%.2f)", contracts, pnl, fee),
+				Details:         details,
 				ExchangeOrderID: exchangeOrderIDForTrade(fillOID, useFillMetadata),
 				ExchangeFee:     exchangeFeeForTrade(fillFee, useFillMetadata),
 				IsClose:         true,
@@ -1152,10 +1333,20 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			}
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
-			recordClosedPosition(s, pos, execPrice, pnl, "signal", now)
-			delete(s.Positions, symbol)
-			logger.Info("SELL %s: %d contracts @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, contracts, execPrice, fee, pnl)
+			if partialClose {
+				pos.Quantity -= float64(contracts)
+				logger.Info("Partial-close long %s %d contracts (remaining %d) @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, contracts, int(pos.Quantity), execPrice, fee, pnl)
+			} else {
+				recordClosedPosition(s, pos, execPrice, pnl, "signal", now)
+				delete(s.Positions, symbol)
+				logger.Info("SELL %s: %d contracts @ $%.2f (fee $%.2f) | PnL: $%.2f", symbol, contracts, execPrice, fee, pnl)
+			}
 			tradesExecuted++
+		}
+		// Close-action from the open/close registry (#519): partial close
+		// does not flip into a fresh short.
+		if closeFraction > 0 {
+			return tradesExecuted, nil
 		}
 		// Open short if no long was closed or after closing long
 		if _, exists := s.Positions[symbol]; !exists {

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -696,7 +696,7 @@ func TestExecuteSpotSignalLiveFillUsesExchangeFee(t *testing.T) {
 	fillQty := 0.015
 	fillPrice := 50000.0
 	fillFee := 0.17
-	trades, err := ExecuteSpotSignalWithFillFee(s, 1, "BTC", fillPrice, fillQty, fillFee, "", logger)
+	trades, err := ExecuteSpotSignalWithFillFee(s, 1, "BTC", fillPrice, fillQty, fillFee, "", 0, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -728,7 +728,7 @@ func TestExecuteSpotSignalLiveFillUsesExchangeOrderID(t *testing.T) {
 			RiskState:       RiskState{},
 		}
 
-		trades, err := ExecuteSpotSignalWithFillFee(s, 1, "BTC", 50000, 0.015, 0.17, "rh-open-oid", logger)
+		trades, err := ExecuteSpotSignalWithFillFee(s, 1, "BTC", 50000, 0.015, 0.17, "rh-open-oid", 0, logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -751,7 +751,7 @@ func TestExecuteSpotSignalLiveFillUsesExchangeOrderID(t *testing.T) {
 			RiskState:       RiskState{},
 		}
 
-		trades, err := ExecuteSpotSignalWithFillFee(s, -1, "BTC", 50000, 0.015, 0.17, "rh-close-oid", logger)
+		trades, err := ExecuteSpotSignalWithFillFee(s, -1, "BTC", 50000, 0.015, 0.17, "rh-close-oid", 0, logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -834,7 +834,7 @@ func TestExecutePerpsSignalDecouplesSizingAndExchangeLeverage(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, err := ExecutePerpsSignalWithLeverage(s, 1, "ETH", 2000, 2, 20, 0, 0, "", 0, false, logger)
+	trades, err := ExecutePerpsSignalWithLeverage(s, 1, "ETH", 2000, 2, 20, 0, 0, "", 0, false, 0, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1213,7 +1213,7 @@ func TestExecuteFuturesSignalLiveFillUsesExchangeFee(t *testing.T) {
 
 	spec := ContractSpec{TickSize: 0.25, TickValue: 12.5, Multiplier: 50, Margin: 500}
 	fillFee := 4.12
-	trades, err := ExecuteFuturesSignalWithFillFee(s, 1, "ES", 5000, spec, 2.5, 5, 2, fillFee, "", logger)
+	trades, err := ExecuteFuturesSignalWithFillFee(s, 1, "ES", 5000, spec, 2.5, 5, 2, fillFee, "", 0, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1247,7 +1247,7 @@ func TestExecuteFuturesSignalLiveFillUsesExchangeOrderID(t *testing.T) {
 			RiskState:       RiskState{},
 		}
 
-		trades, err := ExecuteFuturesSignalWithFillFee(s, 1, "ES", 5000, spec, 2.5, 5, 2, 4.12, "ts-open-oid", logger)
+		trades, err := ExecuteFuturesSignalWithFillFee(s, 1, "ES", 5000, spec, 2.5, 5, 2, 4.12, "ts-open-oid", 0, logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1270,7 +1270,7 @@ func TestExecuteFuturesSignalLiveFillUsesExchangeOrderID(t *testing.T) {
 			RiskState:       RiskState{},
 		}
 
-		trades, err := ExecuteFuturesSignalWithFillFee(s, -1, "ES", 5000, spec, 2.5, 5, 2, 4.12, "ts-close-oid", logger)
+		trades, err := ExecuteFuturesSignalWithFillFee(s, -1, "ES", 5000, spec, 2.5, 5, 2, 4.12, "ts-close-oid", 0, logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1556,7 +1556,7 @@ func TestPerpsLiveOrderSize_FlipIncludesCloseLeg(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			size, ok, reason := perpsLiveOrderSize(tc.signal, 2000, 1000, tc.posQty, tc.avgCost, 1.0, 1.0, 0, tc.posSide, tc.allowShort)
+			size, ok, reason := perpsLiveOrderSize(tc.signal, 2000, 1000, tc.posQty, tc.avgCost, 1.0, 1.0, 0, tc.posSide, tc.allowShort, 0)
 			if ok != tc.wantOK {
 				t.Fatalf("ok = %v (reason=%q), want %v", ok, reason, tc.wantOK)
 			}
@@ -1572,7 +1572,7 @@ func TestPerpsLiveOrderSize_FlipIncludesCloseLeg(t *testing.T) {
 // (the old close-only behavior that silently broke bidirectional execution).
 func TestPerpsLiveOrderSize_FlipLongToShortExceedsCloseOnly(t *testing.T) {
 	posQty := 0.5
-	size, ok, _ := perpsLiveOrderSize(-1, 2000, 1000, posQty, 2000, 1.0, 1.0, 0, "long", true)
+	size, ok, _ := perpsLiveOrderSize(-1, 2000, 1000, posQty, 2000, 1.0, 1.0, 0, "long", true, 0)
 	if !ok {
 		t.Fatal("expected ok")
 	}
@@ -1592,7 +1592,7 @@ func TestPerpsLiveOrderSize_FlipSizesAgainstPostCloseMargin(t *testing.T) {
 	// After #518 (no 0.95 buffer): new-side budget = 950 * 5 / 1900 = 2.5 →
 	// flip size = 0.5 + 2.5 = 3.0. Pre-close sizing (bug) would yield:
 	// 1000 * 5 / 1900 = 2.6316 → 3.1316, over-sized.
-	size, ok, reason := perpsLiveOrderSize(-1, 1900, 1000, 0.5, 2000, 5.0, 5.0, 0, "long", true)
+	size, ok, reason := perpsLiveOrderSize(-1, 1900, 1000, 0.5, 2000, 5.0, 5.0, 0, "long", true, 0)
 	if !ok {
 		t.Fatalf("expected ok, got reason=%q", reason)
 	}
@@ -1616,7 +1616,7 @@ func TestPerpsLiveOrderSize_CatastrophicFlipDegradesToCloseOnly(t *testing.T) {
 	// long 1.0 ETH @ 2000, price crashes to 500, 1x leverage, cash=100.
 	// closePnL = 1.0 * (500 - 2000) = -1500 → effectiveCash = 100 - 1500 = -1400.
 	// PerpsOpenNotional returns 0 for non-positive cash → fallback to close-only.
-	size, ok, reason := perpsLiveOrderSize(-1, 500, 100, 1.0, 2000, 1.0, 1.0, 0, "long", true)
+	size, ok, reason := perpsLiveOrderSize(-1, 500, 100, 1.0, 2000, 1.0, 1.0, 0, "long", true, 0)
 	if !ok {
 		t.Fatalf("expected ok (should degrade to close-only, not abort); reason=%q", reason)
 	}
@@ -1633,7 +1633,7 @@ func TestPerpsLiveOrderSize_FlipProfitableFlipUsesRealizedGain(t *testing.T) {
 	// Close leg realizes: 0.5 * (2000 - 1900) = +50 → post-close cash = 1050.
 	// After #518 (no 0.95 buffer): new-side budget = 1050 * 5 / 1900 = 2.7632 →
 	// flip size = 0.5 + 2.7632 = 3.2632.
-	size, ok, _ := perpsLiveOrderSize(1, 1900, 1000, 0.5, 2000, 5.0, 5.0, 0, "short", true)
+	size, ok, _ := perpsLiveOrderSize(1, 1900, 1000, 0.5, 2000, 5.0, 5.0, 0, "short", true, 0)
 	if !ok {
 		t.Fatal("expected ok")
 	}
@@ -1714,7 +1714,7 @@ func TestExecutePerpsSignalMarginPerTradeUSDOverridesSizingLeverage(t *testing.T
 	// Mirrors issue #518: sizing_leverage=0.1, exchange leverage=20, price=2257.
 	// Without margin_per_trade_usd: notional = 560 * 0.1 = 56 → qty ≈ 0.025 ETH.
 	// With margin_per_trade_usd=56: notional = 56 * 20 = 1120 → qty ≈ 0.50 ETH.
-	trades, err := ExecutePerpsSignalWithLeverage(s, 1, "ETH", 2257, 0.1, 20, 56, 0, "", 0, false, logger)
+	trades, err := ExecutePerpsSignalWithLeverage(s, 1, "ETH", 2257, 0.1, 20, 56, 0, "", 0, false, 0, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1728,5 +1728,381 @@ func TestExecutePerpsSignalMarginPerTradeUSDOverridesSizingLeverage(t *testing.T
 	// Allow a small slippage margin around 0.50 ETH.
 	if pos.Quantity < 0.45 || pos.Quantity > 0.55 {
 		t.Errorf("quantity = %g, want ~0.50 (margin_per_trade_usd=$56 × 20x leverage at $2257)", pos.Quantity)
+	}
+}
+
+// #519 — perpsLiveOrderSize must scale the close-only return by closeFraction
+// when 0 < frac < 1 so a tiered_tp_atr / tiered_tp_pct decision sizes the
+// live order to match the residual it intends to leave behind.
+func TestPerpsLiveOrderSize_PartialCloseScalesPosQty(t *testing.T) {
+	// long 0.4 ETH @ 2000, signal=-1 (close), fraction=0.5 → size 0.2.
+	size, ok, reason := perpsLiveOrderSize(-1, 2100, 1000, 0.4, 2000, 1.0, 1.0, 0, "long", false, 0.5)
+	if !ok {
+		t.Fatalf("expected ok, got reason=%q", reason)
+	}
+	if math.Abs(size-0.2) > 1e-9 {
+		t.Errorf("size = %g, want 0.2 (0.4 * 0.5)", size)
+	}
+}
+
+// #519 — closeFraction = 1.0 (or 0) keeps full-close behavior. Regression
+// pin: don't accidentally re-scale the close leg on a complete tier hit.
+func TestPerpsLiveOrderSize_FullCloseFractionIsFullPosQty(t *testing.T) {
+	for _, frac := range []float64{0, 1.0} {
+		size, ok, _ := perpsLiveOrderSize(-1, 2100, 1000, 0.4, 2000, 1.0, 1.0, 0, "long", false, frac)
+		if !ok || math.Abs(size-0.4) > 1e-9 {
+			t.Errorf("frac=%g: size = %g (ok=%v), want 0.4", frac, size, ok)
+		}
+	}
+}
+
+// #519 — paper partial close on a long perps position must keep the
+// position open with the residual quantity, share the original PositionID
+// across legs (so round-trip grouping holds), preserve InitialQuantity, and
+// realize PnL only on the closed slice.
+func TestExecutePerpsSignal_PartialCloseLongPaperPreservesRemainder(t *testing.T) {
+	pos := &Position{
+		Symbol:          "ETH",
+		TradePositionID: "etrip-1",
+		Quantity:        0.4,
+		InitialQuantity: 0.4,
+		AvgCost:         2000,
+		Side:            "long",
+		Multiplier:      1,
+		Leverage:        1,
+	}
+	s := &StrategyState{
+		ID:              "hl-test-eth",
+		Cash:            990,
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		Positions:       map[string]*Position{"ETH": pos},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 1000},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	// Close 0.5 of 0.4 ETH @ 2100 (+5% from cost). closeFraction=0.5.
+	trades, err := ExecutePerpsSignalWithLeverage(s, -1, "ETH", 2100, 1, 1, 0, 0, "", 0, false, 0.5, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	got, ok := s.Positions["ETH"]
+	if !ok {
+		t.Fatal("position should remain after partial close")
+	}
+	if math.Abs(got.Quantity-0.2) > 1e-9 {
+		t.Errorf("Quantity = %g, want 0.2 (0.4 - 0.4*0.5)", got.Quantity)
+	}
+	if math.Abs(got.InitialQuantity-0.4) > 1e-9 {
+		t.Errorf("InitialQuantity = %g, want 0.4 (must not rewrite)", got.InitialQuantity)
+	}
+	if got.AvgCost != 2000 {
+		t.Errorf("AvgCost = %g, want 2000 (unchanged on partial close)", got.AvgCost)
+	}
+	if len(s.TradeHistory) != 1 {
+		t.Fatalf("trade history = %d, want 1", len(s.TradeHistory))
+	}
+	tr := s.TradeHistory[0]
+	if math.Abs(tr.Quantity-0.2) > 1e-9 {
+		t.Errorf("trade.Quantity = %g, want 0.2", tr.Quantity)
+	}
+	if !tr.IsClose {
+		t.Error("trade.IsClose = false, want true")
+	}
+	if tr.PositionID != "etrip-1" {
+		t.Errorf("trade.PositionID = %q, want %q (round-trip grouping)", tr.PositionID, "etrip-1")
+	}
+	// Paper mode applies ApplySlippage to the requested price; recompute
+	// expected PnL using the actual recorded price so the assertion is
+	// slippage-tolerant.
+	wantPnL := 0.2*(tr.Price-2000) - CalculatePlatformSpotFee("hyperliquid", 0.2*tr.Price)
+	if math.Abs(tr.RealizedPnL-wantPnL) > 1e-6 {
+		t.Errorf("RealizedPnL = %g, want %g (partial slice only)", tr.RealizedPnL, wantPnL)
+	}
+}
+
+// #519 — partial close composed by the open/close registry must not flip
+// into a fresh short even when AllowShorts=true. compose_signal never emits
+// a close+open in the same cycle, so closeFraction>0 + AllowShorts=true is
+// close-only.
+func TestExecutePerpsSignal_PartialCloseDoesNotFlipShortWithAllowShorts(t *testing.T) {
+	pos := &Position{
+		Symbol:          "ETH",
+		TradePositionID: "etrip-1",
+		Quantity:        0.4,
+		InitialQuantity: 0.4,
+		AvgCost:         2000,
+		Side:            "long",
+		Multiplier:      1,
+		Leverage:        1,
+	}
+	s := &StrategyState{
+		ID:              "hl-bidir",
+		Cash:            990,
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		Positions:       map[string]*Position{"ETH": pos},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 1000},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	trades, err := ExecutePerpsSignalWithLeverage(s, -1, "ETH", 2100, 1, 1, 0, 0, "", 0, true /*allowShorts*/, 0.5, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1 (only the close leg, no flip-open)", trades)
+	}
+	got, ok := s.Positions["ETH"]
+	if !ok {
+		t.Fatal("position should remain after partial close (residual long)")
+	}
+	if got.Side != "long" {
+		t.Errorf("Side = %q, want long (no flip)", got.Side)
+	}
+	if math.Abs(got.Quantity-0.2) > 1e-9 {
+		t.Errorf("Quantity = %g, want 0.2", got.Quantity)
+	}
+}
+
+// #519 — full close (closeFraction = 1.0) from the open/close registry must
+// also skip the bidirectional open-leg path. Pre-fix, signal=-1 with
+// AllowShorts=true would close the long AND open a fresh short in the same
+// cycle, but compose_signal never composes that pair.
+func TestExecutePerpsSignal_FullCloseFromRegistryDoesNotFlip(t *testing.T) {
+	pos := &Position{
+		Symbol:          "ETH",
+		TradePositionID: "etrip-1",
+		Quantity:        0.4,
+		InitialQuantity: 0.4,
+		AvgCost:         2000,
+		Side:            "long",
+		Multiplier:      1,
+		Leverage:        1,
+	}
+	s := &StrategyState{
+		ID:              "hl-bidir-full",
+		Cash:            990,
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		Positions:       map[string]*Position{"ETH": pos},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 1000},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	trades, err := ExecutePerpsSignalWithLeverage(s, -1, "ETH", 2100, 1, 1, 0, 0, "", 0, true /*allowShorts*/, 1.0, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1 (close only, no fresh short)", trades)
+	}
+	if _, ok := s.Positions["ETH"]; ok {
+		t.Error("position should be deleted after full close")
+	}
+}
+
+// #519 — live partial close on perps uses fillQty (the actual exchange
+// fill) for the close leg, not pos.Quantity * closeFraction; the live
+// helper sized the order to the fraction so fillQty is already partial.
+func TestExecutePerpsSignal_PartialCloseLongLiveUsesFillQty(t *testing.T) {
+	pos := &Position{
+		Symbol:          "ETH",
+		TradePositionID: "etrip-live",
+		Quantity:        0.4,
+		InitialQuantity: 0.4,
+		AvgCost:         2000,
+		Side:            "long",
+		Multiplier:      1,
+		Leverage:        1,
+	}
+	s := &StrategyState{
+		ID:              "hl-test-eth",
+		Cash:            990,
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		Positions:       map[string]*Position{"ETH": pos},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 1000},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	// fillQty=0.18 (slightly below the 0.2 the order requested due to
+	// exchange rounding). closeFraction signals "partial" but the actual
+	// closed qty must come from fillQty.
+	_, err := ExecutePerpsSignalWithLeverage(s, -1, "ETH", 2100, 1, 1, 0, 0.18, "live-oid", 0.05, false, 0.5, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := s.Positions["ETH"]
+	if got == nil {
+		t.Fatal("position should remain")
+	}
+	if math.Abs(got.Quantity-(0.4-0.18)) > 1e-9 {
+		t.Errorf("Quantity = %g, want 0.22 (0.4 - fillQty 0.18)", got.Quantity)
+	}
+	if len(s.TradeHistory) != 1 {
+		t.Fatalf("history = %d, want 1", len(s.TradeHistory))
+	}
+	if math.Abs(s.TradeHistory[0].Quantity-0.18) > 1e-9 {
+		t.Errorf("trade.Quantity = %g, want 0.18 (live fillQty)", s.TradeHistory[0].Quantity)
+	}
+}
+
+// #519 — paper partial close on a spot long must keep the position with
+// the residual quantity and realize PnL only on the closed slice.
+func TestExecuteSpotSignal_PartialCloseLongPaperPreservesRemainder(t *testing.T) {
+	pos := &Position{
+		Symbol:          "BTC/USDT",
+		TradePositionID: "spot-trip",
+		Quantity:        0.02,
+		InitialQuantity: 0.02,
+		AvgCost:         50000,
+		Side:            "long",
+	}
+	s := &StrategyState{
+		ID:              "test",
+		Cash:            100,
+		Platform:        "binanceus",
+		Positions:       map[string]*Position{"BTC/USDT": pos},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 1000},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	trades, err := ExecuteSpotSignalWithFillFee(s, -1, "BTC/USDT", 55000, 0, 0, "", 0.5, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	got, ok := s.Positions["BTC/USDT"]
+	if !ok {
+		t.Fatal("position should remain after partial close")
+	}
+	if math.Abs(got.Quantity-0.01) > 1e-12 {
+		t.Errorf("Quantity = %g, want 0.01 (0.02 * 0.5)", got.Quantity)
+	}
+	if math.Abs(got.InitialQuantity-0.02) > 1e-12 {
+		t.Errorf("InitialQuantity = %g, want 0.02 (must not rewrite)", got.InitialQuantity)
+	}
+	if !s.TradeHistory[0].IsClose {
+		t.Error("trade.IsClose = false, want true")
+	}
+	if s.TradeHistory[0].PositionID != "spot-trip" {
+		t.Errorf("trade.PositionID = %q, want spot-trip (round-trip grouping)", s.TradeHistory[0].PositionID)
+	}
+}
+
+// #519 — futures partial close rounds DOWN to whole contracts so the
+// residual position has at least one contract remaining. Tier returning a
+// fraction smaller than one contract is a no-op rather than a full close.
+func TestExecuteFuturesSignal_PartialCloseRoundsDownContracts(t *testing.T) {
+	pos := &Position{
+		Symbol:          "ES",
+		TradePositionID: "futures-trip",
+		Quantity:        4,
+		InitialQuantity: 4,
+		AvgCost:         5000,
+		Side:            "long",
+		Multiplier:      50,
+	}
+	s := &StrategyState{
+		ID:              "ts-es",
+		Cash:            10000,
+		Platform:        "topstep",
+		Positions:       map[string]*Position{"ES": pos},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 10000},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	spec := ContractSpec{Multiplier: 50, Margin: 1000}
+	// closeFraction=0.5 of 4 contracts → 2 contracts.
+	trades, err := ExecuteFuturesSignalWithFillFee(s, -1, "ES", 5050, spec, 2.5, 5, 0, 0, "", 0.5, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	got, ok := s.Positions["ES"]
+	if !ok {
+		t.Fatal("position should remain")
+	}
+	if int(got.Quantity) != 2 {
+		t.Errorf("Quantity = %g, want 2", got.Quantity)
+	}
+	if int(s.TradeHistory[0].Quantity) != 2 {
+		t.Errorf("trade.Quantity = %g, want 2", s.TradeHistory[0].Quantity)
+	}
+}
+
+// #519 — when closeFraction rounds to <1 contract the futures executor
+// must no-op rather than full-close the position.
+func TestExecuteFuturesSignal_PartialCloseFractionTooSmallNoOps(t *testing.T) {
+	pos := &Position{
+		Symbol:          "ES",
+		TradePositionID: "futures-trip-2",
+		Quantity:        2,
+		InitialQuantity: 2,
+		AvgCost:         5000,
+		Side:            "long",
+		Multiplier:      50,
+	}
+	s := &StrategyState{
+		ID:              "ts-es",
+		Cash:            10000,
+		Platform:        "topstep",
+		Positions:       map[string]*Position{"ES": pos},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 10000},
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	spec := ContractSpec{Multiplier: 50, Margin: 1000}
+	// 2 contracts * 0.25 = 0.5 → int = 0 → no-op (NOT full close).
+	trades, _ := ExecuteFuturesSignalWithFillFee(s, -1, "ES", 5050, spec, 2.5, 5, 0, 0, "", 0.25, logger)
+	if trades != 0 {
+		t.Errorf("trades = %d, want 0 (sub-contract fraction must no-op)", trades)
+	}
+	got := s.Positions["ES"]
+	if got == nil || int(got.Quantity) != 2 {
+		t.Errorf("position must remain at 2 contracts, got %v", got)
 	}
 }


### PR DESCRIPTION
## Summary

- `close_fraction` parsed from check script output was never read by any execution path — every close-side signal sold 100% of the position regardless of the fraction returned by `tiered_tp_atr`, `tiered_tp_pct`, or `tp_at_pct`
- `perpsLiveOrderSize` now accepts `closeFraction` and scales the close-only return to `posQty * frac` when `0 < frac < 1`
- `ExecutePerpsSignalWithLeverage`, `ExecuteSpotSignalWithFillFee`, and `ExecuteFuturesSignalWithFillFee` gain `closeFraction`: partial close legs record the fractional qty/PnL, decrement `pos.Quantity` without deleting the position, preserve `InitialQuantity`, and skip the bidirectional open-leg fall-through (registry compose never emits close+open in the same cycle); legacy wrappers pass `0` so kill-switch / stop-loss / `forceClose*` keep full-close semantics
- `runHyperliquidExecuteOrder` suppresses SL cancel/replace on partial close — the resting reduce-only trigger continues to protect the residual; the trailing-stop loop resizes independently
- `runOKXExecuteOrder` (spot + perps), `runRobinhoodExecuteOrder`, and `runTopStepExecuteOrder` scale the close-side live order size; TopStep rounds DOWN to whole contracts with a sub-contract no-op guard
- All five execute-result callers (HL, OKX, Robinhood, TopStep, paper spot) thread `result.CloseFraction` into `Execute*Signal*`

## Test plan

- [ ] `go test ./...` green (9 new unit tests + all existing pass)
- [ ] `go vet ./...` clean; `gofmt -l` clean
- [ ] `uv run pytest shared_strategies/close/` — 6/6 pass (no Python changes)
- [ ] New tests cover: `perpsLiveOrderSize` partial scaling, paper + live perps partial close (residual qty, `InitialQuantity` preservation, `PositionID` round-trip grouping, PnL), no-flip with `AllowShorts=true`, full-close-from-registry no-flip, spot partial close, futures contract rounding, sub-contract no-op

Closes #519

---
LLM: Claude Opus 4.7 (1M) | high