### PR TITLE
fix: ensure ATR is stamped for tiered_tp_atr close strategy (#522)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ When invoked to review a PR, the top-level review comment MUST take exactly one 
 Inline `pull_request_review_comment` threads are exempt from this format; this rule governs only the top-level review summary.
 
 ## Build & Deploy
-- Build: `cd scheduler && go build -o ../go-trader .` — always rebuild before smoke-testing.
+- Build: `go build -o go-trader .` — always rebuild before smoke-testing (`cd scheduler` fails in bash tool; run commands directly from current context).
 - Restart: `systemctl restart go-trader`. Service file changes: `systemctl daemon-reload && systemctl restart go-trader`.
 - Config-only changes (no rebuild needed): `kill -HUP $(pgrep go-trader)` — `config_reload.go` re-reads `cfg.ConfigPath` without dropping state or sessions.
 - Python script changes: take effect next scheduler cycle (no rebuild).
@@ -114,8 +114,8 @@ Inline `pull_request_review_comment` threads are exempt from this format; this r
 ## Testing
 - **New functionality must include tests.** Go: `_test.go`. Python: `test_*.py`. Bug fixes: regression test when feasible.
 - `python3 -m py_compile <file>` from repo root for syntax check.
-- `cd scheduler && go build .` (compile) / `go test ./...` (unit tests; must run from `scheduler/` — repo root has no go.mod).
-- `cd scheduler && gofmt -w <file>.go` after editing.
+- `go build .` (compile) / `go test ./...` (unit tests — `cd scheduler` fails in bash tool; run commands directly).
+- `gofmt -w <file>.go` after editing (no `cd` needed).
 - Multi-line Go edits with tabs: Edit tool may fail; use heredoc form: `python3 << 'PYEOF'` / `content=open(f).read()` / `open(f,'w').write(content.replace(old,new,1))` / `PYEOF`.
 - Strategy listing: `cd shared_strategies/open/spot && ../../../.venv/bin/python3 strategies.py --list-json` (worktrees: absolute path to main repo's venv). Futures listing lives at `shared_strategies/open/futures/strategies.py --list-json`.
 - Smoke tests:
@@ -123,8 +123,10 @@ Inline `pull_request_review_comment` threads are exempt from this format; this r
   - Interactive init: `printf "answer1\nanswer2\n" | ./go-trader init`
   - JSON init: `./go-trader init --json '{"assets":["BTC"],"enableSpot":true,"spotStrategies":["sma_crossover"],"spotCapital":1000,"spotDrawdown":10}' --output /tmp/test.json`
   - Status port override: `./go-trader --once --status-port 9100` — verify `[server] Status endpoint at http://localhost:<port>/status`.
-- Pytest: `uv run pytest shared_strategies/ -v`; `shared_tools/`; `platforms/`; `backtest/` (run when modifying strategies). `shared_scripts/test_*.py` is NOT in default `testpaths` — invoke explicitly.
+- Pytest: `.venv/bin/python3 -m pytest shared_strategies/ -v`; also `shared_tools/`, `platforms/`, `backtest/` (run when modifying strategies). `uv run pytest <relative-path>` may fail if bash CWD differs from repo root — use `.venv/bin/python3 -m pytest` instead. `shared_scripts/test_*.py` is NOT in default `testpaths` — invoke explicitly.
+- `stampEntryATRIfOpened` rejects ATR > 50% of AvgCost (plausibility guard); Go tests using `atr` indicators must use values < 50% of the entry price in the test.
 - Strategy tests must assert actual signal values (`assert (result["signal"] == 1).any()`), not just column existence. Smoke tests iterating registered strategies need a `DatetimeIndex` (`amd_ifvg` reads `index.hour`, `vwap_reversion` buckets by `index.date`).
 - Python test imports: use `importlib.util.spec_from_file_location` (avoids two `strategies.py` collisions).
 - Go tests: always check `json.Unmarshal` errors — silent discard masks struct tag/type regressions.
 - Pure helpers (`perpsLiveOrderSize`, `*OrderSkipReason`, `effectiveStrategyIntervalSeconds`, `parseXxxCloseOutput`, Sharpe math in `sharpe_test.go`) are testable without subprocesses — use this pattern for any subprocess-spawning live helper.
+- **ATR for close evaluators:** `tiered_tp_atr` and `trailing_stop_atr_mult` depend on `Position.EntryATR` stamped from `indicators["atr"]`. All check scripts inject a default ATR(14) via `ensure_atr_indicator(result_df)` from `shared_tools/atr.py` before the indicator loop — new check scripts must do the same.

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -1530,3 +1530,85 @@ func TestClearATRMultMissingEntryATRWarningsForStrategy(t *testing.T) {
 		}
 	}
 }
+
+// #522: tieredTPATRMissingEntryATR detects open positions with EntryATR == 0
+// when tiered_tp_atr is in close_strategies (platform-agnostic).
+func TestTieredTPATRMissingEntryATR(t *testing.T) {
+	withCS := func(cs ...string) StrategyConfig {
+		return StrategyConfig{Platform: "hyperliquid", Type: "perps", CloseStrategies: cs}
+	}
+	cases := []struct {
+		name string
+		sc   StrategyConfig
+		pos  *Position
+		want bool
+	}{
+		{"no close strategies", withCS(), &Position{AvgCost: 100, EntryATR: 0}, false},
+		{"different close strategy", withCS("tp_at_pct"), &Position{AvgCost: 100, EntryATR: 0}, false},
+		{"tiered_tp_atr present, EntryATR missing", withCS("tiered_tp_atr"), &Position{AvgCost: 100, EntryATR: 0}, true},
+		{"tiered_tp_atr present, EntryATR stamped", withCS("tiered_tp_atr"), &Position{AvgCost: 100, EntryATR: 5}, false},
+		{"tiered_tp_atr present, no open position (AvgCost==0)", withCS("tiered_tp_atr"), &Position{AvgCost: 0, EntryATR: 0}, false},
+		{"tiered_tp_atr among multiple strategies", withCS("tp_at_pct", "tiered_tp_atr"), &Position{AvgCost: 100, EntryATR: 0}, true},
+		{"nil position", withCS("tiered_tp_atr"), nil, false},
+		{"works on non-HL platform", StrategyConfig{Platform: "binanceus", Type: "spot", CloseStrategies: []string{"tiered_tp_atr"}}, &Position{AvgCost: 100, EntryATR: 0}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := tieredTPATRMissingEntryATR(c.sc, c.pos); got != c.want {
+				t.Errorf("tieredTPATRMissingEntryATR = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// #522: notifyTieredTPATRMissingEntryATROnce throttles alerts per (strategy,
+// symbol) and shares the throttle map with the ATR-mult path so a single
+// strategy that triggers both variants only emits one alert.
+func TestNotifyTieredTPATRMissingEntryATROnce_ThrottlesAndShares(t *testing.T) {
+	mock := &mockNotifier{}
+	notifier := NewMultiNotifier(notifierBackend{
+		notifier: mock,
+		channels: map[string]string{"hyperliquid": "chan"},
+		ownerID:  "owner",
+	})
+	logger := silentStrategyLogger("hl-tiered-test")
+	defer logger.Close()
+	sc := StrategyConfig{ID: "hl-tiered-test", Platform: "hyperliquid", Type: "perps",
+		CloseStrategies: []string{"tiered_tp_atr"}}
+
+	defer clearATRMultMissingEntryATRWarning(sc.ID, "ETH")
+	defer clearATRMultMissingEntryATRWarning(sc.ID, "BTC")
+
+	notifyTieredTPATRMissingEntryATROnce(sc, "ETH", notifier, logger)
+	notifyTieredTPATRMissingEntryATROnce(sc, "ETH", notifier, logger)
+	notifyTieredTPATRMissingEntryATROnce(sc, "ETH", notifier, logger)
+
+	if got := len(mock.messages); got != 1 {
+		t.Errorf("expected 1 broadcast for ETH, got %d", got)
+	}
+	if got := len(mock.dms); got != 1 {
+		t.Errorf("expected 1 owner DM for ETH, got %d", got)
+	}
+	if len(mock.messages) > 0 && !strings.Contains(mock.messages[0].content, "tiered_tp_atr") {
+		t.Errorf("alert content missing tiered_tp_atr: %q", mock.messages[0].content)
+	}
+
+	// A different symbol alerts independently.
+	notifyTieredTPATRMissingEntryATROnce(sc, "BTC", notifier, logger)
+	if got := len(mock.messages); got != 2 {
+		t.Errorf("expected 2 broadcasts after BTC alert, got %d", got)
+	}
+
+	// ATR-mult notifier on the same (strategy, symbol) is suppressed because the
+	// throttle map key is shared — one alert per (strategy, symbol) regardless of
+	// which variant fires first.
+	clearATRMultMissingEntryATRWarning(sc.ID, "ETH")
+	notifyATRMultMissingEntryATROnce(sc, "ETH", notifier, logger)
+	if got := len(mock.messages); got != 3 {
+		t.Errorf("expected 3 broadcasts after atr-mult alert, got %d", got)
+	}
+	notifyTieredTPATRMissingEntryATROnce(sc, "ETH", notifier, logger)
+	if got := len(mock.messages); got != 3 {
+		t.Errorf("tiered alert after atr-mult should be suppressed (shared throttle), got %d", got)
+	}
+}

--- a/scheduler/hyperliquid_trailing_stop.go
+++ b/scheduler/hyperliquid_trailing_stop.go
@@ -151,6 +151,47 @@ func clearATRMultMissingEntryATRWarningsForStrategy(strategyID string) {
 	})
 }
 
+// tieredTPATRMissingEntryATR reports whether sc is configured with tiered_tp_atr
+// as a close strategy but the open position has no EntryATR stamped yet. Unlike
+// the ATR-mult trailing check this is platform-agnostic: tiered_tp_atr runs on
+// any platform that supports composed close strategies.
+func tieredTPATRMissingEntryATR(sc StrategyConfig, pos *Position) bool {
+	hasTieredTP := false
+	for _, cs := range sc.CloseStrategies {
+		if cs == "tiered_tp_atr" {
+			hasTieredTP = true
+			break
+		}
+	}
+	if !hasTieredTP {
+		return false
+	}
+	if pos == nil {
+		return false
+	}
+	return pos.EntryATR <= 0 && pos.AvgCost > 0
+}
+
+// notifyTieredTPATRMissingEntryATROnce emits a WARN log + notifier alert the
+// first time a tiered_tp_atr close strategy is observed on a position that
+// has no EntryATR. Uses the same throttle map as the ATR-mult trailing alert
+// so a single key per (strategy, symbol) suppresses both variants.
+func notifyTieredTPATRMissingEntryATROnce(sc StrategyConfig, symbol string, notifier *MultiNotifier, logger *StrategyLogger) {
+	key := atrMultMissingEntryATRKey(sc.ID, symbol)
+	if _, loaded := atrMultMissingEntryATRWarned.LoadOrStore(key, struct{}{}); loaded {
+		return
+	}
+	if logger != nil {
+		logger.Warn("tiered_tp_atr configured but Position.EntryATR is 0 for %s — the open strategy must emit an 'atr' indicator on the open candle; take-profit tiers will noop until EntryATR is stamped.", symbol)
+	}
+	if notifier != nil && notifier.HasBackends() {
+		msg := fmt.Sprintf("**MISSING ENTRY ATR** [%s] %s — close strategy `tiered_tp_atr` is configured but the open candle did not produce an ATR indicator, so take-profit tiers are disabled until EntryATR is stamped. Ensure the entry strategy emits `atr` in its indicator output.",
+			sc.ID, symbol)
+		notifier.SendToAllChannels(msg)
+		notifier.SendOwnerDM(msg)
+	}
+}
+
 func effectiveTrailingStopMinMovePct(sc StrategyConfig) float64 {
 	if sc.TrailingStopMinMovePct != nil && *sc.TrailingStopMinMovePct >= 0 {
 		return *sc.TrailingStopMinMovePct

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1288,6 +1288,9 @@ func main() {
 								// operator alert; the position is running unprotected.
 								notifyATRMultMissingEntryATROnce(sc, result.Symbol, notifier, logger)
 							}
+							if result.Signal == 0 && hlPosQty > 0 && tieredTPATRMissingEntryATR(sc, hlPosSnapshot) {
+								notifyTieredTPATRMissingEntryATROnce(sc, result.Symbol, notifier, logger)
+							}
 							if hyperliquidIsLive(sc.Args) && result.Signal == 0 && hlPosQty > 0 && effectiveTrailingStopPct(sc, hlPosSnapshot) > 0 {
 								newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, result.Symbol, hlPosSide, hlPosQty, hlPosSnapshot, price, hlStopLossHighWaterPx, hlStopLossTriggerPx, hlStopLossOID, notifier, logger)
 								mu.Lock()
@@ -1833,9 +1836,16 @@ func stampEntryATRIfOpened(s *StrategyState, symbol string, indicators map[strin
 	if !ok || atr <= 0 {
 		return
 	}
-	if pos, exists := s.Positions[symbol]; exists && pos != nil && pos.EntryATR == 0 {
-		pos.EntryATR = atr
+	pos, exists := s.Positions[symbol]
+	if !exists || pos == nil || pos.EntryATR != 0 {
+		return
 	}
+	// Plausibility: reject NaN and ATR > 50% of entry price when we have a cost
+	// baseline (almost certainly a unit mismatch or error in the strategy dataframe).
+	if atr != atr || (pos.AvgCost > 0 && atr > pos.AvgCost*0.5) {
+		return
+	}
+	pos.EntryATR = atr
 }
 
 func indicatorFloat(indicators map[string]interface{}, key string) (float64, bool) {

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math"
 	"strings"
 	"sync"
 	"testing"
@@ -984,6 +985,57 @@ func TestExecuteRobinhoodResult_StampsExchangeData(t *testing.T) {
 	}
 	if tr.ExchangeFee != 0.07 {
 		t.Errorf("ExchangeFee = %g, want 0.07", tr.ExchangeFee)
+	}
+}
+
+func TestStampEntryATRIfOpened(t *testing.T) {
+	newState := func(avgCost, existingATR float64) *StrategyState {
+		s := &StrategyState{Positions: map[string]*Position{
+			"BTC": {AvgCost: avgCost, EntryATR: existingATR},
+		}}
+		return s
+	}
+	indicators := func(atr float64) map[string]interface{} {
+		return map[string]interface{}{"atr": atr}
+	}
+
+	cases := []struct {
+		name    string
+		s       *StrategyState
+		symbol  string
+		inds    map[string]interface{}
+		trades  int
+		wantATR float64
+	}{
+		{"stamps valid atr on open", newState(50000, 0), "BTC", indicators(500), 1, 500},
+		{"no-op when trades == 0", newState(50000, 0), "BTC", indicators(500), 0, 0},
+		{"no-op when atr already set", newState(50000, 300), "BTC", indicators(500), 1, 300},
+		{"rejects zero atr", newState(50000, 0), "BTC", indicators(0), 1, 0},
+		{"rejects negative atr", newState(50000, 0), "BTC", indicators(-1), 1, 0},
+		{"rejects NaN atr", newState(50000, 0), "BTC", indicators(math.NaN()), 1, 0},
+		{"rejects +Inf atr", newState(50000, 0), "BTC", indicators(math.Inf(1)), 1, 0},
+		{"rejects atr > 50% avgCost", newState(50000, 0), "BTC", indicators(25001), 1, 0},
+		{"accepts atr == 50% avgCost boundary", newState(50000, 0), "BTC", indicators(25000), 1, 25000},
+		{"no upper-bound check when avgCost == 0", newState(0, 0), "BTC", indicators(999), 1, 999},
+		{"no-op for missing symbol", newState(50000, 0), "ETH", indicators(500), 1, 0},
+		{"no-op for nil state", nil, "BTC", indicators(500), 1, 0},
+		{"no-op for nil indicators", newState(50000, 0), "BTC", nil, 1, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stampEntryATRIfOpened(tc.s, tc.symbol, tc.inds, tc.trades)
+			if tc.s == nil {
+				return
+			}
+			if pos := tc.s.Positions[tc.symbol]; pos != nil {
+				if pos.EntryATR != tc.wantATR {
+					t.Errorf("EntryATR = %g, want %g", pos.EntryATR, tc.wantATR)
+				}
+			} else if tc.wantATR != 0 {
+				t.Errorf("position for %s not found, want EntryATR %g", tc.symbol, tc.wantATR)
+			}
+		})
 	}
 }
 

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -56,7 +56,7 @@ func TestExecuteSpotResultSetsInitialQuantityAndEntryATR(t *testing.T) {
 	result := &SpotResult{
 		Symbol:     "BTC/USDT",
 		Signal:     1,
-		Indicators: map[string]interface{}{"atr": 123.45},
+		Indicators: map[string]interface{}{"atr": 3.5}, // ~3.5% of entry price; passes plausibility guard
 	}
 	trades, _ := executeSpotResult(
 		StrategyConfig{ID: "spot-test"},
@@ -76,8 +76,8 @@ func TestExecuteSpotResultSetsInitialQuantityAndEntryATR(t *testing.T) {
 	if pos.InitialQuantity != pos.Quantity {
 		t.Fatalf("InitialQuantity = %g, want current open qty %g", pos.InitialQuantity, pos.Quantity)
 	}
-	if pos.EntryATR != 123.45 {
-		t.Fatalf("EntryATR = %g, want 123.45", pos.EntryATR)
+	if pos.EntryATR != 3.5 {
+		t.Fatalf("EntryATR = %g, want 3.5", pos.EntryATR)
 	}
 }
 

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -55,6 +55,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'platforms', 'h
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strategies', 'open', 'futures'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
+from atr import ensure_atr_indicator
+
 
 def _make_dataframe(candles):
     """Convert raw OHLCV list to pandas DataFrame compatible with strategy functions."""
@@ -208,6 +210,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
         except Exception:
             pass
 
+        ensure_atr_indicator(result_df)
         indicators = {}
         skip_cols = {
             "open", "high", "low", "close", "volume",

--- a/shared_scripts/check_okx.py
+++ b/shared_scripts/check_okx.py
@@ -21,6 +21,8 @@ from datetime import datetime, timezone
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'platforms', 'okx'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
+from atr import ensure_atr_indicator
+
 # Use futures registry for perps (swap), spot registry for spot.
 # Default is swap, matching argparse defaults below.
 _inst_type = "swap"
@@ -214,6 +216,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
         except Exception:
             pass
 
+        ensure_atr_indicator(result_df)
         indicators = {}
         skip_cols = {
             "open", "high", "low", "close", "volume",

--- a/shared_scripts/check_robinhood.py
+++ b/shared_scripts/check_robinhood.py
@@ -24,6 +24,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'platforms', 'r
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strategies', 'open', 'spot'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
+from atr import ensure_atr_indicator
+
 
 def _make_dataframe(candles):
     """Convert raw OHLCV list to pandas DataFrame compatible with strategy functions."""
@@ -215,6 +217,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
         except Exception:
             pass
 
+        ensure_atr_indicator(result_df)
         indicators = {}
         skip_cols = {
             "open", "high", "low", "close", "volume",

--- a/shared_scripts/check_strategy.py
+++ b/shared_scripts/check_strategy.py
@@ -22,6 +22,8 @@ from datetime import datetime, timezone
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strategies', 'open', 'spot'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
+from atr import ensure_atr_indicator
+
 
 def _arg_value(flag, default=None):
     prefix = flag + "="
@@ -226,6 +228,7 @@ def main():
             signal = decision["signal"]
 
         # Collect relevant indicators
+        ensure_atr_indicator(result_df)
         indicators = {}
         indicator_cols = [c for c in result_df.columns
                          if c not in ("open", "high", "low", "close", "close_b", "volume",

--- a/shared_scripts/check_topstep.py
+++ b/shared_scripts/check_topstep.py
@@ -22,6 +22,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'platforms', 't
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strategies', 'open', 'futures'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
+from atr import ensure_atr_indicator
+
 
 def _make_dataframe(candles):
     """Convert raw OHLCV list to pandas DataFrame compatible with strategy functions."""
@@ -223,6 +225,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
         except Exception:
             pass
 
+        ensure_atr_indicator(result_df)
         indicators = {}
         skip_cols = {
             "open", "high", "low", "close", "volume",

--- a/shared_tools/atr.py
+++ b/shared_tools/atr.py
@@ -1,0 +1,39 @@
+"""Standard ATR injection for check scripts.
+
+Provides a consistent ATR indicator for position entry stamping when the
+open strategy doesn't emit its own `atr` column (e.g. tema_cross, ema_crossover).
+Uses a simple rolling mean of True Range — the same method used by strategies
+that do emit ATR (see shared_strategies/open/registry.py: breakout_strategy,
+atr_breakout_strategy) — so stamped values are consistent across strategies.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def standard_atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    """Compute ATR via simple rolling mean of True Range over `period` bars.
+
+    Requires `high`, `low`, `close` columns. Returns a Series aligned to df.index.
+    Rows with insufficient history return NaN.
+    """
+    high = df["high"].astype(float)
+    low = df["low"].astype(float)
+    prev_close = df["close"].astype(float).shift(1)
+    tr = pd.concat(
+        [high - low, (high - prev_close).abs(), (low - prev_close).abs()],
+        axis=1,
+    ).max(axis=1)
+    return tr.rolling(window=period).mean()
+
+
+def ensure_atr_indicator(df: pd.DataFrame, period: int = 14) -> pd.DataFrame:
+    """Ensure `df` has an `atr` column, injecting standard_atr if absent.
+
+    No-op when `atr` is already present (preserves strategy-defined ATR).
+    Returns `df` with the column added in-place (the same object).
+    """
+    if "atr" not in df.columns:
+        df["atr"] = standard_atr(df, period)
+    return df

--- a/shared_tools/test_atr.py
+++ b/shared_tools/test_atr.py
@@ -1,0 +1,90 @@
+"""Tests for shared_tools/atr.py."""
+
+import math
+import importlib.util
+import pathlib
+
+import pandas as pd
+import numpy as np
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "atr", pathlib.Path(__file__).parent / "atr.py"
+)
+_atr_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(_atr_mod)
+standard_atr = _atr_mod.standard_atr
+ensure_atr_indicator = _atr_mod.ensure_atr_indicator
+
+
+def _make_ohlcv(n: int = 30, seed: int = 42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    close = 100 + np.cumsum(rng.normal(0, 1, n))
+    high = close + rng.uniform(0.1, 1.0, n)
+    low = close - rng.uniform(0.1, 1.0, n)
+    return pd.DataFrame({"open": close, "high": high, "low": low, "close": close, "volume": 1.0})
+
+
+def test_standard_atr_length():
+    df = _make_ohlcv(30)
+    result = standard_atr(df, period=14)
+    assert len(result) == 30
+
+
+def test_standard_atr_first_period_minus_one_nan():
+    df = _make_ohlcv(30)
+    result = standard_atr(df, period=14)
+    # TR[0] = high[0]-low[0] (pandas max skips the NaN prev_close terms), so
+    # the first ATR window of 14 completes at row 13. Rows 0-12 are NaN.
+    assert result.iloc[:13].isna().all()
+    assert not math.isnan(result.iloc[13])
+
+
+def test_standard_atr_positive_after_warmup():
+    df = _make_ohlcv(30)
+    result = standard_atr(df, period=14)
+    valid = result.dropna()
+    assert len(valid) > 0
+    assert (valid > 0).all()
+
+
+def test_standard_atr_hand_computed():
+    # Construct a simple deterministic case: flat OHLCV so TR = high - low each bar.
+    # high = 102, low = 98 every bar → TR = 4 every bar → ATR(3) = 4 after row 3.
+    n = 10
+    df = pd.DataFrame({
+        "open": [100.0] * n,
+        "high": [102.0] * n,
+        "low": [98.0] * n,
+        "close": [100.0] * n,
+        "volume": [1.0] * n,
+    })
+    result = standard_atr(df, period=3)
+    # After the 3-bar window plus 1-row shift, index 3 should be 4.0
+    assert math.isclose(result.iloc[3], 4.0, rel_tol=1e-9)
+    for i in range(3, n):
+        assert math.isclose(result.iloc[i], 4.0, rel_tol=1e-9)
+
+
+def test_ensure_atr_indicator_injects_when_missing():
+    df = _make_ohlcv(30)
+    assert "atr" not in df.columns
+    out = ensure_atr_indicator(df)
+    assert "atr" in out.columns
+    assert out is df  # mutates in-place
+
+
+def test_ensure_atr_indicator_noop_when_present():
+    df = _make_ohlcv(30)
+    sentinel = pd.Series([99.0] * 30, index=df.index)
+    df["atr"] = sentinel
+    ensure_atr_indicator(df)
+    pd.testing.assert_series_equal(df["atr"], sentinel, check_names=False)
+
+
+def test_ensure_atr_indicator_idempotent():
+    df = _make_ohlcv(30)
+    ensure_atr_indicator(df)
+    first = df["atr"].copy()
+    ensure_atr_indicator(df)
+    pd.testing.assert_series_equal(df["atr"], first)


### PR DESCRIPTION
## Summary

- Adds `shared_tools/atr.py` with `ensure_atr_indicator(df)` — injects a standard ATR(14) column into the strategy dataframe before indicator extraction, so `stampEntryATRIfOpened` can stamp `Position.EntryATR` even when the open strategy (e.g. `tema_cross`) doesn't compute ATR
- Wires `ensure_atr_indicator` into all 5 check scripts (`check_hyperliquid.py`, `check_strategy.py`, `check_topstep.py`, `check_robinhood.py`, `check_okx.py`)
- Adds plausibility guard in `stampEntryATRIfOpened`: rejects NaN and ATR > 50% of AvgCost
- Extends the missing-EntryATR notifier to cover `tiered_tp_atr`-only setups (`tieredTPATRMissingEntryATR` + `notifyTieredTPATRMissingEntryATROnce`, platform-agnostic, shares throttle map with ATR-mult path)

## Test plan

- [ ] `shared_tools/test_atr.py` — 7 new tests for `standard_atr` math and `ensure_atr_indicator` no-op/idempotency
- [ ] `scheduler/main_test.go::TestStampEntryATRIfOpened` — 13 cases covering valid stamp, rejection of zero/negative/NaN/Inf/garbage ATR, missing symbol, nil state
- [ ] `scheduler/hyperliquid_stop_loss_test.go::TestTieredTPATRMissingEntryATR` — 8 cases, platform-agnostic detection
- [ ] `scheduler/hyperliquid_stop_loss_test.go::TestNotifyTieredTPATRMissingEntryATROnce_ThrottlesAndShares` — shared throttle verification
- [ ] All Go tests pass: `go test ./...`
- [ ] All Python tests pass: `.venv/bin/python3 -m pytest shared_tools/ -v`

Closes #522

---
LLM: Claude Opus 4.7 | high