### PR TITLE
feat(close): add tiered_tp_atr_live close strategy

### DIFF
--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -55,7 +55,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'platforms', 'h
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strategies', 'open', 'futures'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
-from atr import ensure_atr_indicator
+from atr import ensure_atr_indicator, latest_atr
 
 
 def _make_dataframe(candles):
@@ -160,6 +160,9 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
         decision = None
         if open_close_enabled:
             market_ctx = {"mark_price": float(df["close"].iloc[-1])}
+            atr_now = latest_atr(df)
+            if atr_now > 0:
+                market_ctx["atr"] = atr_now
             evaluation = evaluate_open_close(
                 apply_strategy,
                 get_strategy,

--- a/shared_scripts/check_okx.py
+++ b/shared_scripts/check_okx.py
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'platforms', 'okx'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
-from atr import ensure_atr_indicator
+from atr import ensure_atr_indicator, latest_atr
 
 # Use futures registry for perps (swap), spot registry for spot.
 # Default is swap, matching argparse defaults below.
@@ -160,6 +160,9 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
         decision = None
         if open_close_enabled:
             market_ctx = {"mark_price": float(df["close"].iloc[-1])}
+            atr_now = latest_atr(df)
+            if atr_now > 0:
+                market_ctx["atr"] = atr_now
             evaluation = evaluate_open_close(
                 apply_strategy,
                 get_strategy,

--- a/shared_scripts/check_robinhood.py
+++ b/shared_scripts/check_robinhood.py
@@ -24,7 +24,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'platforms', 'r
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strategies', 'open', 'spot'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
-from atr import ensure_atr_indicator
+from atr import ensure_atr_indicator, latest_atr
 
 
 def _make_dataframe(candles):
@@ -167,6 +167,9 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
         decision = None
         if open_close_enabled:
             market_ctx = {"mark_price": float(df["close"].iloc[-1])}
+            atr_now = latest_atr(df)
+            if atr_now > 0:
+                market_ctx["atr"] = atr_now
             evaluation = evaluate_open_close(
                 apply_strategy,
                 get_strategy,

--- a/shared_scripts/check_strategy.py
+++ b/shared_scripts/check_strategy.py
@@ -22,7 +22,7 @@ from datetime import datetime, timezone
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strategies', 'open', 'spot'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
-from atr import ensure_atr_indicator
+from atr import ensure_atr_indicator, latest_atr
 
 
 def _arg_value(flag, default=None):
@@ -184,6 +184,9 @@ def main():
         decision = None
         if open_close_enabled:
             market_ctx = {"mark_price": float(df["close"].iloc[-1])}
+            atr_now = latest_atr(df)
+            if atr_now > 0:
+                market_ctx["atr"] = atr_now
             evaluation = evaluate_open_close(
                 apply_strategy,
                 get_strategy,

--- a/shared_scripts/check_topstep.py
+++ b/shared_scripts/check_topstep.py
@@ -22,7 +22,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'platforms', 't
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strategies', 'open', 'futures'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
-from atr import ensure_atr_indicator
+from atr import ensure_atr_indicator, latest_atr
 
 
 def _make_dataframe(candles):
@@ -175,6 +175,9 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
         decision = None
         if open_close_enabled:
             market_ctx = {"mark_price": float(df["close"].iloc[-1])}
+            atr_now = latest_atr(df)
+            if atr_now > 0:
+                market_ctx["atr"] = atr_now
             evaluation = evaluate_open_close(
                 apply_strategy,
                 get_strategy,

--- a/shared_strategies/close/registry.py
+++ b/shared_strategies/close/registry.py
@@ -12,6 +12,7 @@ if _THIS_DIR not in sys.path:
 
 from tiered_tp_atr import DEFAULT_TIERS as DEFAULT_ATR_TIERS
 from tiered_tp_atr import evaluate as tiered_tp_atr_evaluate
+from tiered_tp_atr_live import evaluate as tiered_tp_atr_live_evaluate
 from tiered_tp_pct import DEFAULT_TIERS as DEFAULT_PCT_TIERS
 from tiered_tp_pct import evaluate as tiered_tp_pct_evaluate
 from tp_at_pct import evaluate as tp_at_pct_evaluate
@@ -98,6 +99,12 @@ register(
     "Tiered take-profit by ATR multiples from average cost",
     {"tiers": list(DEFAULT_ATR_TIERS)},
 )(tiered_tp_atr_evaluate)
+
+register(
+    "tiered_tp_atr_live",
+    "Tiered take-profit by ATR multiples using live ATR per tick (atr_source: live|entry)",
+    {"tiers": list(DEFAULT_ATR_TIERS), "atr_source": "live"},
+)(tiered_tp_atr_live_evaluate)
 
 register(
     "tp_at_pct",

--- a/shared_strategies/close/test_close_registry.py
+++ b/shared_strategies/close/test_close_registry.py
@@ -21,7 +21,7 @@ def test_build_close_registry_filters_valid_platforms(registry):
     assert tuple(registry.VALID_PLATFORMS) == ("spot", "futures", "options")
     for platform in registry.VALID_PLATFORMS:
         built = registry.build_close_registry(platform)
-        assert set(built) == {"tiered_tp_pct", "tiered_tp_atr", "tp_at_pct"}
+        assert set(built) == {"tiered_tp_pct", "tiered_tp_atr", "tiered_tp_atr_live", "tp_at_pct"}
 
 
 def test_build_close_registry_rejects_unknown_platform(registry):
@@ -92,3 +92,68 @@ def test_tiered_tp_atr_uses_entry_atr_multiple(registry):
 
     assert missing_atr == {"close_fraction": 0.0, "reason": "noop:missing_entry_atr"}
     assert hit == {"close_fraction": 1.0, "reason": "tiered_tp_atr:2"}
+
+
+def test_tiered_tp_atr_live_uses_market_atr(registry):
+    # Live ATR (3.0) means 104 mark = 1.33 ATR profit, hits the 1.0x tier (50%).
+    live_hit = registry.evaluate(
+        "tiered_tp_atr_live",
+        {"side": "long", "avg_cost": 100, "current_quantity": 1, "initial_quantity": 1, "entry_atr": 2},
+        {"mark_price": 104, "atr": 3},
+        {},
+    )
+    assert live_hit == {"close_fraction": 0.5, "reason": "tiered_tp_atr_live:live:1"}
+
+
+def test_tiered_tp_atr_live_falls_back_to_entry_atr(registry):
+    # Live ATR missing -> falls back to entry_atr (2.0); 104 mark = 2 ATR -> 1.0x and 2.0x both hit.
+    fallback = registry.evaluate(
+        "tiered_tp_atr_live",
+        {"side": "long", "avg_cost": 100, "current_quantity": 1, "initial_quantity": 1, "entry_atr": 2},
+        {"mark_price": 104},
+        {},
+    )
+    assert fallback == {"close_fraction": 1.0, "reason": "tiered_tp_atr_live:entry_fallback:2"}
+
+
+def test_tiered_tp_atr_live_zero_live_atr_falls_back(registry):
+    # atr=0 should be treated as missing and fall back to entry_atr.
+    result = registry.evaluate(
+        "tiered_tp_atr_live",
+        {"side": "long", "avg_cost": 100, "current_quantity": 1, "initial_quantity": 1, "entry_atr": 2},
+        {"mark_price": 103, "atr": 0},
+        {},
+    )
+    assert result["reason"].startswith("tiered_tp_atr_live:entry_fallback")
+
+
+def test_tiered_tp_atr_live_missing_all_atr_noop(registry):
+    result = registry.evaluate(
+        "tiered_tp_atr_live",
+        {"side": "long", "avg_cost": 100, "current_quantity": 1, "initial_quantity": 1},
+        {"mark_price": 104},
+        {},
+    )
+    assert result == {"close_fraction": 0.0, "reason": "noop:missing_atr"}
+
+
+def test_tiered_tp_atr_live_entry_source_ignores_market_atr(registry):
+    # atr_source=entry must use entry_atr even when market.atr is present.
+    result = registry.evaluate(
+        "tiered_tp_atr_live",
+        {"side": "long", "avg_cost": 100, "current_quantity": 1, "initial_quantity": 1, "entry_atr": 2},
+        {"mark_price": 104, "atr": 10},
+        {"atr_source": "entry"},
+    )
+    assert result == {"close_fraction": 1.0, "reason": "tiered_tp_atr_live:entry:2"}
+
+
+def test_tiered_tp_atr_live_short_side(registry):
+    result = registry.evaluate(
+        "tiered_tp_atr_live",
+        {"side": "short", "avg_cost": 100, "current_quantity": 1, "initial_quantity": 1, "entry_atr": 5},
+        {"mark_price": 96, "atr": 2},
+        {},
+    )
+    # profit_distance = 4, atr=2 -> 2.0 atr_profit -> hits both tiers, full close.
+    assert result == {"close_fraction": 1.0, "reason": "tiered_tp_atr_live:live:2"}

--- a/shared_strategies/close/test_close_registry.py
+++ b/shared_strategies/close/test_close_registry.py
@@ -157,3 +157,55 @@ def test_tiered_tp_atr_live_short_side(registry):
     )
     # profit_distance = 4, atr=2 -> 2.0 atr_profit -> hits both tiers, full close.
     assert result == {"close_fraction": 1.0, "reason": "tiered_tp_atr_live:live:2"}
+
+
+def test_market_atr_wiring_end_to_end(registry):
+    """End-to-end: latest_atr(df) → market_ctx["atr"] → tiered_tp_atr_live evaluator.
+
+    This mirrors the wiring in shared_scripts/check_*.py: the check script computes
+    ATR from OHLCV via latest_atr(df) and stuffs the value into market_ctx["atr"]
+    before calling evaluate_open_close. The evaluator must see the live value
+    (reason starts with `live:`) rather than falling back to entry_atr.
+    """
+    import sys
+    from pathlib import Path
+
+    import pandas as pd
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "shared_tools"))
+    from atr import latest_atr  # type: ignore
+
+    # Build a 30-bar OHLCV frame with a stable ~$3 ATR.
+    n = 30
+    df = pd.DataFrame({
+        "open": [100.0] * n,
+        "high": [101.5] * n,
+        "low": [98.5] * n,
+        "close": [100.0] * n,
+        "volume": [1.0] * n,
+    })
+    atr_value = latest_atr(df)
+    assert atr_value > 0, "latest_atr must produce a positive value for live wiring"
+
+    market_ctx = {"mark_price": float(df["close"].iloc[-1])}
+    if atr_value > 0:
+        market_ctx["atr"] = atr_value
+
+    # Mark moves $4 above avg_cost; with live ATR=$3 that's 1.33 ATR profit
+    # → hits 1.0x tier (50%). Reason must reflect `live` source, not `entry_fallback`.
+    market_ctx["mark_price"] = 104  # mark moved up after market_ctx was built
+    result = registry.evaluate(
+        "tiered_tp_atr_live",
+        {
+            "side": "long",
+            "avg_cost": 100,
+            "current_quantity": 1,
+            "initial_quantity": 1,
+            "entry_atr": 99,  # garbage entry value to detect fallback
+        },
+        market_ctx,
+        {},
+    )
+    assert result["reason"].startswith("tiered_tp_atr_live:live:"), (
+        f"market_ctx['atr'] not flowing through to evaluator: reason={result['reason']!r}"
+    )

--- a/shared_strategies/close/tiered_tp_atr_live.py
+++ b/shared_strategies/close/tiered_tp_atr_live.py
@@ -1,0 +1,60 @@
+"""Tiered ATR-multiple take-profit close evaluator using live ATR per tick."""
+
+from __future__ import annotations
+
+from _helpers import clamp_fraction, current_close_fraction, float_from
+from tiered_tp_atr import DEFAULT_TIERS, _tiers
+
+
+def _resolve_atr(market: dict, position: dict, atr_source: str) -> tuple[float, str]:
+    """Return (atr, source_label). Falls back to entry_atr when live ATR is unusable."""
+    entry_atr = float_from(position, "entry_atr")
+    if atr_source == "entry":
+        return entry_atr, "entry"
+
+    live_atr = float_from(market, "atr")
+    if live_atr <= 0:
+        live_atr = float_from(market, "live_atr")
+    if live_atr > 0:
+        return live_atr, "live"
+    if entry_atr > 0:
+        return entry_atr, "entry_fallback"
+    return 0.0, "missing"
+
+
+def evaluate(position: dict, market: dict, params: dict) -> dict:
+    avg_cost = float_from(position, "avg_cost")
+    current_quantity = float_from(position, "current_quantity")
+    side = str(position.get("side", "") or "").strip().lower()
+    mark_price = float_from(market, "mark_price")
+    atr_source = str(params.get("atr_source", "live") or "live").strip().lower()
+    if atr_source not in ("live", "entry"):
+        atr_source = "live"
+
+    if mark_price <= 0:
+        return {"close_fraction": 0.0, "reason": "noop:missing_mark_price"}
+    if avg_cost <= 0 or current_quantity <= 0 or side not in ("long", "short"):
+        return {"close_fraction": 0.0, "reason": "noop:missing_position"}
+
+    atr_value, atr_label = _resolve_atr(market, position, atr_source)
+    if atr_value <= 0:
+        return {"close_fraction": 0.0, "reason": "noop:missing_atr"}
+
+    profit_distance = mark_price - avg_cost if side == "long" else avg_cost - mark_price
+    atr_profit = profit_distance / atr_value
+    hit_tiers = [
+        (multiple, fraction)
+        for multiple, fraction in _tiers(params.get("tiers"))
+        if atr_profit >= multiple
+    ]
+    if not hit_tiers:
+        return {"close_fraction": 0.0, "reason": "noop:not_hit"}
+
+    multiple, cumulative_fraction = hit_tiers[-1]
+    close_fraction = current_close_fraction(position, cumulative_fraction)
+    if close_fraction <= 0:
+        return {"close_fraction": 0.0, "reason": "noop:already_taken"}
+    return {
+        "close_fraction": clamp_fraction(close_fraction),
+        "reason": f"tiered_tp_atr_live:{atr_label}:{multiple:g}",
+    }

--- a/shared_strategies/close/tiered_tp_atr_live.py
+++ b/shared_strategies/close/tiered_tp_atr_live.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from _helpers import clamp_fraction, current_close_fraction, float_from
-from tiered_tp_atr import DEFAULT_TIERS, _tiers
+from _helpers import current_close_fraction, float_from
+from tiered_tp_atr import _tiers
 
 
 def _resolve_atr(market: dict, position: dict, atr_source: str) -> tuple[float, str]:
@@ -55,6 +55,6 @@ def evaluate(position: dict, market: dict, params: dict) -> dict:
     if close_fraction <= 0:
         return {"close_fraction": 0.0, "reason": "noop:already_taken"}
     return {
-        "close_fraction": clamp_fraction(close_fraction),
+        "close_fraction": close_fraction,
         "reason": f"tiered_tp_atr_live:{atr_label}:{multiple:g}",
     }

--- a/shared_tools/atr.py
+++ b/shared_tools/atr.py
@@ -37,3 +37,23 @@ def ensure_atr_indicator(df: pd.DataFrame, period: int = 14) -> pd.DataFrame:
     if "atr" not in df.columns:
         df["atr"] = standard_atr(df, period)
     return df
+
+
+def latest_atr(df: pd.DataFrame, period: int = 14) -> float:
+    """Return the most recent finite, positive ATR value, or 0.0 if none.
+
+    Used by check scripts to populate `market_ctx["atr"]` so live close
+    evaluators (e.g. tiered_tp_atr_live) see current volatility instead of
+    falling back to the entry-time ATR snapshot.
+    """
+    series = standard_atr(df, period)
+    if series.empty:
+        return 0.0
+    value = series.iloc[-1]
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if not (value > 0) or value != value:  # rejects NaN, 0, negative
+        return 0.0
+    return value

--- a/shared_tools/test_atr.py
+++ b/shared_tools/test_atr.py
@@ -15,6 +15,7 @@ _atr_mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(_atr_mod)
 standard_atr = _atr_mod.standard_atr
 ensure_atr_indicator = _atr_mod.ensure_atr_indicator
+latest_atr = _atr_mod.latest_atr
 
 
 def _make_ohlcv(n: int = 30, seed: int = 42) -> pd.DataFrame:
@@ -88,3 +89,33 @@ def test_ensure_atr_indicator_idempotent():
     first = df["atr"].copy()
     ensure_atr_indicator(df)
     pd.testing.assert_series_equal(df["atr"], first)
+
+
+def test_latest_atr_returns_last_finite_value():
+    df = _make_ohlcv(30)
+    expected = standard_atr(df, period=14).iloc[-1]
+    assert math.isclose(latest_atr(df), float(expected), rel_tol=1e-12)
+
+
+def test_latest_atr_zero_when_warmup_incomplete():
+    # Only 5 rows, period=14 → all NaN, no positive value to return.
+    df = _make_ohlcv(5)
+    assert latest_atr(df, period=14) == 0.0
+
+
+def test_latest_atr_zero_for_empty_series():
+    df = pd.DataFrame({"open": [], "high": [], "low": [], "close": [], "volume": []})
+    assert latest_atr(df) == 0.0
+
+
+def test_latest_atr_strict_positive():
+    # Construct a flat-bar dataframe where TR == 0 → ATR == 0 → latest_atr returns 0.
+    n = 30
+    df = pd.DataFrame({
+        "open": [100.0] * n,
+        "high": [100.0] * n,
+        "low": [100.0] * n,
+        "close": [100.0] * n,
+        "volume": [1.0] * n,
+    })
+    assert latest_atr(df) == 0.0


### PR DESCRIPTION
Adds `tiered_tp_atr_live`, a new close evaluator that recomputes ATR per tick from market data so take-profit tiers track current volatility instead of the entry-time ATR snapshot used by `tiered_tp_atr`.

- Reads `market["atr"]` (falls back to `market["live_atr"]`) each evaluation
- `atr_source` param (`live` default | `entry`) toggles live vs. snapshot without renaming the strategy
- Falls back to `position.entry_atr` when live ATR is missing/zero, so warm-up candle gaps don't block closes
- Reuses `tiered_tp_atr`'s tier parser for identical tier semantics

Closes #523

---

Generated with [Claude Code](https://claude.ai/code)