### PR TITLE
Fix partial-close trade DM labels (#530)

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1004,9 +1004,15 @@ func collectPositions(stratID string, ss *StrategyState, prices map[string]float
 	return lines
 }
 
+// isTradeCloseDetails returns true when Details describes closing (full or partial).
+// Matching is case-insensitive so strings like "Partial-close long …" classify as closes (#530).
+func isTradeCloseDetails(details string) bool {
+	return strings.Contains(strings.ToLower(details), "close")
+}
+
 // FormatTradeDM formats a Trade into a concise DM message for the bot owner.
 func FormatTradeDM(sc StrategyConfig, trade Trade, mode string) string {
-	isClose := strings.Contains(trade.Details, "Close")
+	isClose := isTradeCloseDetails(trade.Details)
 
 	icon := "🟢"
 	header := "TRADE EXECUTED"

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -393,6 +393,29 @@ func TestFormatTradeDM_CloseTrade(t *testing.T) {
 	}
 }
 
+// Issue #530: partial closes use lowercase "close" (e.g. "Partial-close long …").
+func TestFormatTradeDM_PartialClose(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-sma-eth", Platform: "hyperliquid", Type: "perps"}
+	trade := Trade{
+		Symbol:   "ETH",
+		Side:     "sell",
+		Quantity: 0.1,
+		Price:    2800,
+		Value:    280,
+		Details:  "Partial-close long ETH, PnL: $12.34 (fee $0.05)",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	if !strings.Contains(msg, "TRADE CLOSED") {
+		t.Errorf("expected 'TRADE CLOSED' for partial close, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "PnL: $12.34") {
+		t.Errorf("expected PnL line for partial close, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "LONG") {
+		t.Errorf("expected LONG position side, got:\n%s", msg)
+	}
+}
+
 func TestFormatTradeDM_CloseShort(t *testing.T) {
 	sc := StrategyConfig{ID: "hl-bidir-eth", Platform: "hyperliquid", Type: "perps"}
 	trade := Trade{
@@ -1639,6 +1662,26 @@ func TestFormatTradeDMPlain_CloseTrade(t *testing.T) {
 	// Plain format: no Discord bold markdown (**).
 	if strings.Contains(msg, "**") {
 		t.Errorf("plain format should not contain Discord markdown '**', got:\n%s", msg)
+	}
+}
+
+// Issue #530: telegram plain DM must treat partial-close like full close.
+func TestFormatTradeDMPlain_PartialClose(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-sma-eth", Platform: "hyperliquid", Type: "perps"}
+	trade := Trade{
+		Symbol:   "ETH",
+		Side:     "sell",
+		Quantity: 0.1,
+		Price:    2800,
+		Value:    280,
+		Details:  "Partial-close long ETH, PnL: $12.34 (fee $0.05)",
+	}
+	msg := FormatTradeDMPlain(sc, trade, "live")
+	if !strings.Contains(msg, "TRADE CLOSED") {
+		t.Errorf("expected 'TRADE CLOSED' for partial close, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "PnL: $12.34") {
+		t.Errorf("expected PnL line for partial close, got:\n%s", msg)
 	}
 }
 

--- a/scheduler/telegram.go
+++ b/scheduler/telegram.go
@@ -236,7 +236,7 @@ func (t *TelegramNotifier) Close() {
 
 // FormatTradeDMPlain formats a Trade into a plain-text DM (no Discord markdown).
 func FormatTradeDMPlain(sc StrategyConfig, trade Trade, mode string) string {
-	isClose := strings.Contains(trade.Details, "Close")
+	isClose := isTradeCloseDetails(trade.Details)
 
 	icon := "🟢"
 	header := "TRADE EXECUTED"


### PR DESCRIPTION
## Summary

Fixes https://github.com/richkuo/go-trader/issues/530.

Partial closes emit details like `Partial-close long …` (lowercase `close`). The previous case-sensitive `strings.Contains(..., "Close")` check missed these, so DMs showed **TRADE EXECUTED** instead of **TRADE CLOSED**.

## Changes

- Add `isTradeCloseDetails` using `strings.Contains(strings.ToLower(details), "close")`.
- Wire `FormatTradeDM` and `FormatTradeDMPlain` to the helper.
- Add tests for Discord and Telegram partial-close formatting.

## Testing

`cd scheduler && go test ./...`

Made with [Cursor](https://cursor.com)

---
LLM: Composer | Effort: low
