### PR TITLE
Wire close-strategy registry into backtester (#534)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@
 - **New platform:** (1) `platforms/<name>/adapter.py` + `__init__.py`, (2) `shared_scripts/check_<name>.py`, (3) `executor.go`, (4) `config.go` (prefix + validation), (5) `fees.go`, (6) `main.go` (dispatch), (7) `init.go` (wizard + generateConfig), (8) `pyproject.toml`.
 - **New options-on-existing-platform:** extend adapter with `get_vol_metrics`, `get_real_expiry`, `get_real_strike`, `get_premium_and_greeks`; add to `check_options.py` + `CalculateOptionFee` + init `OptionPlatforms`.
 - Adapters loaded via `importlib`; class detected by `endswith("ExchangeAdapter")` (one per file). Check scripts must use only public adapter methods.
+- **Close registry import:** never `import registry` directly to reach `shared_strategies/close/registry.py` — name collides with the open registry. Use `from close_registry_loader import evaluate, list_strategies, build_close_registry` (in `shared_tools/`); it loads via `importlib.util.spec_from_file_location` and caches.
 - Subprocess contract: scripts always emit JSON to stdout (even on error); exit 1 on error; Go parses regardless of exit code.
 - **State locking:** `mu sync.RWMutex` guards `state`. Per-strategy loop has 6 phases: RLock(read inputs) → Lock(CheckRisk) → no lock(subprocess) → Lock(execute signal) → RLock/no lock/Lock(marks) → RLock(status). Audit: `grep -n "mu\.\(R\)\?Lock\(\)\|mu\.\(R\)\?Unlock\(\)" scheduler/main.go`.
 - Platform dispatch: use `s.Platform == "ibkr"`, never ID prefix. ID → platform map: `hl-` HL, `ibkr-` IBKR, `deribit-` Deribit, `ts-` TopStep, `rh-` Robinhood, `okx-` OKX, `luno-` Luno, else BinanceUS.
@@ -111,6 +112,7 @@ Inline `pull_request_review_comment` threads are exempt from this format; this r
 - `.venv/bin/python3 backtest/run_backtest.py --strategy <n> --symbol BTC/USDT --timeframe 1h --mode single`
 - `.venv/bin/python3 backtest/backtest_options.py --underlying BTC --since YYYY-MM-DD --capital 10000`
 - `.venv/bin/python3 backtest/backtest_theta.py --underlying BTC --since YYYY-MM-DD --capital 10000`
+- Close-strategy registry runs in backtests (#535): `Backtester(close_strategies=[...], close_params={...})` or `--close-strategy NAME --close-params '{"name":{...}}'`. Per-bar eval against the simulated position; max `close_fraction` applied at next bar's open and combined with column-based `close_fraction` via max-wins. Entry context (`avg_cost`/`initial_quantity`/`entry_atr`) stamped at open with the same 50%-of-AvgCost ATR guard as `stampEntryATRIfOpened`. Bar-level granularity — live intra-bar trigger races (HL stop-loss OIDs) are not simulated.
 
 ## Testing
 - **New functionality must include tests.** Go: `_test.go`. Python: `test_*.py`. Bug fixes: regression test when feasible.
@@ -125,6 +127,7 @@ Inline `pull_request_review_comment` threads are exempt from this format; this r
   - JSON init: `./go-trader init --json '{"assets":["BTC"],"enableSpot":true,"spotStrategies":["sma_crossover"],"spotCapital":1000,"spotDrawdown":10}' --output /tmp/test.json`
   - Status port override: `./go-trader --once --status-port 9100` — verify `[server] Status endpoint at http://localhost:<port>/status`.
 - Pytest: `.venv/bin/python3 -m pytest shared_strategies/ -v`; also `shared_tools/`, `platforms/`, `backtest/` (run when modifying strategies). `uv run pytest <relative-path>` may fail if bash CWD differs from repo root — use `.venv/bin/python3 -m pytest` instead. `shared_scripts/test_*.py` is NOT in default `testpaths` — invoke explicitly.
+- When adding tests that touch sys.path or registries, run the FULL suite (`.venv/bin/python3 -m pytest backtest/tests/ shared_tools/ shared_strategies/`) — isolated single-file runs can mask import-order conflicts (e.g. open vs. close `registry.py` collision).
 - `stampEntryATRIfOpened` rejects ATR > 50% of AvgCost (plausibility guard); Go tests using `atr` indicators must use values < 50% of the entry price in the test.
 - Strategy tests must assert actual signal values (`assert (result["signal"] == 1).any()`), not just column existence. Smoke tests iterating registered strategies need a `DatetimeIndex` (`amd_ifvg` reads `index.hour`, `vwap_reversion` buckets by `index.date`).
 - Python test imports: use `importlib.util.spec_from_file_location` (avoids two `strategies.py` collisions).

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -216,8 +216,11 @@ class Backtester:
         open (no look-ahead bias). Falls back to close when an ``open`` column
         is not present.
 
-        starting_long: optional dict with keys ``entry_price`` (float, USD)
-            and ``entry_date`` (index value, defaults to df.index[0]).
+        starting_long: optional dict with keys ``entry_price`` (float, USD),
+            ``entry_date`` (index value, defaults to df.index[0]), and
+            optional ``entry_atr`` (float, used to stamp the seeded
+            position's EntryATR so ATR-based close evaluators like
+            ``tiered_tp_atr`` work across walk-forward fold boundaries).
             When provided, the run begins already-long: the full
             ``initial_capital`` is treated as committed at ``entry_price``
             (minus one commission for the implicit buy). Use for carrying
@@ -307,6 +310,17 @@ class Backtester:
             current_trade.shares = position
             avg_cost = effective_entry
             initial_quantity = position
+            # Optional ATR for the seeded position so walk-forward folds with
+            # ATR-based close evaluators (tiered_tp_atr) don't silently no-op
+            # for the seeded position's lifetime. Same plausibility guard as
+            # _stamp_entry_atr (rejects non-positive and >50% of entry price).
+            seed_atr = starting_long.get("entry_atr", 0.0)
+            try:
+                seed_atr = float(seed_atr or 0.0)
+            except (TypeError, ValueError):
+                seed_atr = 0.0
+            if seed_atr > 0 and seed_atr <= 0.5 * effective_entry:
+                entry_atr_value = seed_atr
 
         for i, (idx, row) in enumerate(df.iterrows()):
             fill_price = row["open"] if has_open else row["close"]
@@ -513,6 +527,9 @@ class Backtester:
             fraction = float(result.get("close_fraction", 0.0) or 0.0)
             if fraction > best:
                 best = fraction
+                if best >= 1.0:
+                    # Full close already wins — remaining evaluators can't change the outcome.
+                    return 1.0
         return min(max(best, 0.0), 1.0)
 
     def _calculate_metrics(self, equity_df: pd.DataFrame, trades: list,

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -17,6 +17,20 @@ import pandas as pd
 
 from storage import store_backtest_result
 
+# Close-registry import is deferred until needed so backtests with no
+# close_strategies don't pay the import cost. Uses ``close_registry_loader``
+# to avoid the bare ``import registry`` collision with the open registry's
+# module of the same name.
+_close_registry = None
+
+
+def _load_close_registry():
+    global _close_registry
+    if _close_registry is None:
+        from close_registry_loader import evaluate as _evaluate, list_strategies as _list
+        _close_registry = (_evaluate, _list)
+    return _close_registry
+
 
 # Equity-curve points per year per timeframe — used to derive the Sharpe
 # annualization factor. Crypto trades 24/7, so a 1d run has ~365 points/yr,
@@ -145,7 +159,9 @@ class Backtester:
     def __init__(self, initial_capital: float = 1000.0,
                  commission_pct: Optional[float] = None,
                  slippage_pct: float = 0.0005,
-                 platform: str = "binanceus"):
+                 platform: str = "binanceus",
+                 close_strategies: Optional[list[str]] = None,
+                 close_params: Optional[dict[str, dict]] = None):
         """
         Args:
             initial_capital: Starting portfolio value.
@@ -157,6 +173,16 @@ class Backtester:
             platform: Exchange fee model — one of ``PLATFORM_FEE_PCT`` keys.
                 Unknown platforms fall back to BinanceUS (0.1%) with no
                 warning, matching the Go dispatch default.
+            close_strategies: Ordered list of close-evaluator names from
+                ``shared_strategies/close/registry.py``. When provided, each
+                evaluator runs at the end of every bar against the simulated
+                open position; the max ``close_fraction`` across evaluators
+                is applied at the next bar's open. Combined with any
+                column-based ``close_fraction`` on the input DataFrame using
+                max-wins (mirrors the live composition contract).
+            close_params: Per-evaluator params dict (keyed by strategy name).
+                Merged over the registry's ``default_params`` for that
+                strategy. Unknown keys are forwarded as-is to the evaluator.
         """
         self.initial_capital = initial_capital
         self.platform = platform
@@ -165,6 +191,17 @@ class Backtester:
             else fee_pct_for_platform(platform)
         )
         self.slippage_pct = slippage_pct
+        self.close_strategies = list(close_strategies or [])
+        self.close_params = dict(close_params or {})
+        if self.close_strategies:
+            _evaluate, list_strategies = _load_close_registry()
+            available = set(list_strategies())
+            for name in self.close_strategies:
+                if name not in available:
+                    raise ValueError(
+                        f"Unknown close strategy: {name}. "
+                        f"Available: {sorted(available)}"
+                    )
 
     def run(self, df: pd.DataFrame, strategy_name: str = "Unknown",
             symbol: str = "BTC/USDT", timeframe: str = "1d",
@@ -197,7 +234,11 @@ class Backtester:
 
         Returns dict with all performance metrics.
         """
-        uses_open_close = "open_action" in df.columns or bool(_close_fraction_columns(df))
+        uses_open_close = (
+            "open_action" in df.columns
+            or bool(_close_fraction_columns(df))
+            or bool(self.close_strategies)
+        )
         if "signal" not in df.columns and not uses_open_close:
             raise ValueError("DataFrame must have a 'signal' column or open_action/close_fraction columns")
 
@@ -242,6 +283,17 @@ class Backtester:
         current_trade = None
         equity_curve = []
 
+        # Position context for close-strategy evaluators. Stamped at open,
+        # cleared at full close. ``initial_quantity`` is preserved across
+        # partial closes so tiered evaluators can compute incremental
+        # ``close_fraction`` correctly (mirrors live ``Position.InitialQuantity``).
+        avg_cost = 0.0
+        initial_quantity = 0.0
+        entry_atr_value = 0.0
+        pending_close_fraction = 0.0
+
+        atr_series = df["atr"] if "atr" in df.columns else None
+
         if starting_long:
             effective_entry = starting_long["entry_price"]
             entry_commission = self.initial_capital * self.commission_pct
@@ -253,6 +305,8 @@ class Backtester:
                 effective_entry, "long",
             )
             current_trade.shares = position
+            avg_cost = effective_entry
+            initial_quantity = position
 
         for i, (idx, row) in enumerate(df.iterrows()):
             fill_price = row["open"] if has_open else row["close"]
@@ -263,8 +317,10 @@ class Backtester:
             equity_curve.append({"date": idx, "equity": equity})
 
             if uses_open_close:
-                close_fraction = float(row["_close_fraction"])
-                open_action = row["_open_action"]
+                col_close_fraction = float(row.get("_close_fraction", 0.0))
+                close_fraction = max(col_close_fraction, pending_close_fraction)
+                pending_close_fraction = 0.0
+                open_action = row.get("_open_action", "none")
 
                 if close_fraction > 0 and position != 0:
                     qty_to_close = abs(position) * min(close_fraction, 1.0)
@@ -293,6 +349,9 @@ class Backtester:
 
                     if abs(position) <= 1e-12:
                         position = 0.0
+                        avg_cost = 0.0
+                        initial_quantity = 0.0
+                        entry_atr_value = 0.0
 
                 if open_action == "long" and position == 0:
                     effective_price = fill_price * (1 + self.slippage_pct)
@@ -304,6 +363,9 @@ class Backtester:
 
                     current_trade = Trade(idx, effective_price, "long")
                     current_trade.shares = shares
+                    avg_cost = effective_price
+                    initial_quantity = shares
+                    entry_atr_value = self._stamp_entry_atr(atr_series, idx, effective_price)
                 elif open_action == "short" and position == 0:
                     effective_price = fill_price * (1 - self.slippage_pct)
                     commission = cash * self.commission_pct
@@ -314,6 +376,19 @@ class Backtester:
 
                     current_trade = Trade(idx, effective_price, "short")
                     current_trade.shares = shares
+                    avg_cost = effective_price
+                    initial_quantity = shares
+                    entry_atr_value = self._stamp_entry_atr(atr_series, idx, effective_price)
+
+                # End-of-bar: evaluate close strategies against the now-current
+                # position using this bar's close as the mark. The result is
+                # applied at the NEXT bar's open (mirrors live: eval at end of
+                # bar, fill at next open).
+                if self.close_strategies and position != 0 and avg_cost > 0:
+                    pending_close_fraction = self._evaluate_close_strategies(
+                        position, avg_cost, initial_quantity, entry_atr_value,
+                        mark_price, atr_series, idx,
+                    )
                 continue
 
             if signal == 1 and position == 0:
@@ -380,6 +455,65 @@ class Backtester:
             store_backtest_result(metrics)
 
         return metrics
+
+    def _stamp_entry_atr(self, atr_series: Optional[pd.Series], idx,
+                         entry_price: float) -> float:
+        """Return the ATR at ``idx`` for stamping ``Position.EntryATR``.
+
+        Mirrors ``stampEntryATRIfOpened`` in scheduler/main.go: rejects NaN
+        and any value greater than 50% of the entry price as a plausibility
+        guard. Returns 0.0 when no usable ATR is available — close evaluators
+        that require ATR (``tiered_tp_atr``) then fall through with a no-op
+        until a position with a valid ATR is opened.
+        """
+        if atr_series is None or entry_price <= 0:
+            return 0.0
+        try:
+            value = float(atr_series.loc[idx])
+        except (KeyError, TypeError, ValueError):
+            return 0.0
+        if not (value > 0):  # rejects NaN, 0, negative
+            return 0.0
+        if value > 0.5 * entry_price:
+            return 0.0
+        return value
+
+    def _evaluate_close_strategies(self, position: float, avg_cost: float,
+                                   initial_quantity: float,
+                                   entry_atr_value: float,
+                                   mark_price: float,
+                                   atr_series: Optional[pd.Series],
+                                   idx) -> float:
+        """Run every configured close evaluator against the simulated position
+        and return the max ``close_fraction``. Same max-wins resolution as the
+        live composition flow in shared_tools/strategy_composition.py.
+        """
+        evaluate, _list_strategies = _load_close_registry()
+        side = "long" if position > 0 else "short"
+        position_dict = {
+            "side": side,
+            "avg_cost": float(avg_cost),
+            "current_quantity": float(abs(position)),
+            "initial_quantity": float(initial_quantity or abs(position)),
+            "entry_atr": float(entry_atr_value),
+        }
+        market_dict = {"mark_price": float(mark_price)}
+        if atr_series is not None:
+            try:
+                live_atr = float(atr_series.loc[idx])
+            except (KeyError, TypeError, ValueError):
+                live_atr = 0.0
+            if live_atr > 0:
+                market_dict["atr"] = live_atr
+
+        best = 0.0
+        for name in self.close_strategies:
+            params = self.close_params.get(name)
+            result = evaluate(name, position_dict, market_dict, params)
+            fraction = float(result.get("close_fraction", 0.0) or 0.0)
+            if fraction > best:
+                best = fraction
+        return min(max(best, 0.0), 1.0)
 
     def _calculate_metrics(self, equity_df: pd.DataFrame, trades: list,
                            df: pd.DataFrame, timeframe: str = "1d") -> dict:

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -16,6 +16,7 @@ import pandas as pd
 # dynamically per-registry via registry_loader.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
+from atr import ensure_atr_indicator
 from data_fetcher import load_cached_data
 from htf_filter import get_default_htf, apply_htf_filter  # noqa: E402
 from registry_loader import load_registry
@@ -120,6 +121,13 @@ def run_single_backtest(
     print(f"  Data: {len(df)} candles from {df.index[0]} to {df.index[-1]}")
 
     df_signals = reg.apply_strategy(strategy_name, df, strat_params)
+
+    # Mirror the runtime check-script contract: inject ATR(14) when the
+    # open strategy doesn't emit `atr`, so close evaluators that require
+    # `entry_atr` (tiered_tp_atr) and `market.atr` (tiered_tp_atr_live)
+    # see consistent volatility input. Idempotent when `atr` already exists.
+    if close_strategies:
+        df_signals = ensure_atr_indicator(df_signals)
 
     if htf_filter:
         df_signals = _apply_htf_filter_to_df(df_signals, symbol, timeframe)

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -84,6 +84,8 @@ def run_single_backtest(
     registry: str = "spot",
     platform: str = "binanceus",
     htf_filter: bool = False,
+    close_strategies: Optional[List[str]] = None,
+    close_params: Optional[dict] = None,
 ) -> Optional[dict]:
     """Run a single backtest and print results.
 
@@ -91,6 +93,10 @@ def run_single_backtest(
     ``platform`` selects the exchange fee model (``"binanceus"``,
     ``"hyperliquid"``, ``"robinhood"``, ``"luno"``, ``"okx"``,
     ``"okx-perps"``), matching ``scheduler/fees.go:CalculatePlatformSpotFee``.
+    ``close_strategies`` is an optional list of close-evaluator names from
+    the close registry (#511); each runs per-bar against the simulated
+    position. Backtest granularity is bar-level so live intra-bar trigger
+    races (e.g. HL stop-loss OIDs) are not simulated.
     """
     reg = load_registry(registry)
     strat = reg.STRATEGY_REGISTRY.get(strategy_name)
@@ -103,6 +109,8 @@ def run_single_backtest(
     print(f"\n▶ Strategy: {strat['description']}")
     print(f"  Params: {strat_params}")
     print(f"  Symbol: {symbol} | Timeframe: {timeframe} | Since: {since}")
+    if close_strategies:
+        print(f"  Close strategies: {close_strategies}")
 
     df = load_cached_data(symbol, timeframe, start_date=since)
     if df.empty:
@@ -117,7 +125,11 @@ def run_single_backtest(
         df_signals = _apply_htf_filter_to_df(df_signals, symbol, timeframe)
         print(f"  HTF filter: applied (HTF={get_default_htf(timeframe)})")
 
-    bt = Backtester(initial_capital=capital, platform=platform)
+    bt = Backtester(
+        initial_capital=capital, platform=platform,
+        close_strategies=close_strategies,
+        close_params=close_params,
+    )
     results = bt.run(
         df_signals,
         strategy_name=strategy_name,
@@ -139,6 +151,8 @@ def run_all_strategies(
     registry: str = "spot",
     platform: str = "binanceus",
     htf_filter: bool = False,
+    close_strategies: Optional[List[str]] = None,
+    close_params: Optional[dict] = None,
 ) -> list:
     """Run multiple strategies on one asset and compare."""
     reg = load_registry(registry)
@@ -153,6 +167,7 @@ def run_all_strategies(
         result = run_single_backtest(
             name, symbol, timeframe, since, capital,
             registry=registry, platform=platform, htf_filter=htf_filter,
+            close_strategies=close_strategies, close_params=close_params,
         )
         if result:
             all_results.append(result)
@@ -172,6 +187,8 @@ def run_multi_asset(
     registry: str = "spot",
     platform: str = "binanceus",
     htf_filter: bool = False,
+    close_strategies: Optional[List[str]] = None,
+    close_params: Optional[dict] = None,
 ) -> dict:
     """Run strategies across multiple assets."""
     reg = load_registry(registry)
@@ -194,6 +211,7 @@ def run_multi_asset(
             result = run_single_backtest(
                 strat_name, symbol, timeframe, since, capital,
                 registry=registry, platform=platform, htf_filter=htf_filter,
+                close_strategies=close_strategies, close_params=close_params,
             )
             if result:
                 results_by_asset[symbol].append(result)
@@ -282,11 +300,28 @@ def _build_parser() -> argparse.ArgumentParser:
                         help="Apply HTF trend filter (matches live "
                              "shared_tools/htf_filter.py); 50-EMA on the "
                              "default HTF for the chosen timeframe.")
+    parser.add_argument("--close-strategy", action="append", dest="close_strategies",
+                        default=None, metavar="NAME",
+                        help="Close-evaluator name from shared_strategies/close/registry.py "
+                             "(repeat for multiple). Each runs per-bar against the "
+                             "simulated position; max close_fraction wins.")
+    parser.add_argument("--close-params", default=None,
+                        help="Per-evaluator params as JSON string, keyed by "
+                             "evaluator name, e.g. "
+                             "'{\"tp_at_pct\":{\"pct\":0.03}}'.")
     return parser
 
 
 def main():
     args = _build_parser().parse_args()
+
+    close_params = None
+    if args.close_params:
+        import json as _json
+        close_params = _json.loads(args.close_params)
+        if not isinstance(close_params, dict):
+            print("--close-params must be a JSON object keyed by evaluator name")
+            sys.exit(1)
 
     reg = load_registry(args.registry)
 
@@ -297,14 +332,18 @@ def main():
         run_single_backtest(args.strategy, args.symbol, args.timeframe,
                             args.since, args.capital,
                             registry=args.registry, platform=args.platform,
-                            htf_filter=args.htf_filter)
+                            htf_filter=args.htf_filter,
+                            close_strategies=args.close_strategies,
+                            close_params=close_params)
 
     elif args.mode == "compare":
         strategies = None if args.strategy == "all" else [args.strategy]
         run_all_strategies(args.symbol, args.timeframe, args.since, args.capital,
                            strategies,
                            registry=args.registry, platform=args.platform,
-                           htf_filter=args.htf_filter)
+                           htf_filter=args.htf_filter,
+                           close_strategies=args.close_strategies,
+                           close_params=close_params)
 
     elif args.mode == "multi":
         strategies = None if args.strategy == "all" else [args.strategy]
@@ -312,7 +351,9 @@ def main():
         run_multi_asset(strategies, symbols, args.timeframe, args.since,
                         args.capital,
                         registry=args.registry, platform=args.platform,
-                        htf_filter=args.htf_filter)
+                        htf_filter=args.htf_filter,
+                        close_strategies=args.close_strategies,
+                        close_params=close_params)
 
     elif args.mode == "optimize":
         if args.strategy == "all":

--- a/backtest/tests/test_backtester_close_strategies.py
+++ b/backtest/tests/test_backtester_close_strategies.py
@@ -1,0 +1,196 @@
+"""
+Tests for close-strategy registry integration in Backtester (issue #534).
+
+The backtester evaluates the close registry per-bar against the simulated
+open position. Result is the max close_fraction across all evaluators,
+applied at the next bar's open (same fill alignment as the column-based
+close_fraction path).
+"""
+import pandas as pd
+
+from backtester import Backtester
+
+
+def _df_open_then_hold(opens, closes, atrs=None):
+    """Build a df where bar 0 emits open_action=long; remaining bars hold."""
+    n = len(closes)
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    open_actions = ["long"] + ["none"] * (n - 1)
+    data = {"open": opens, "close": closes, "open_action": open_actions}
+    if atrs is not None:
+        data["atr"] = atrs
+    return pd.DataFrame(data, index=idx)
+
+
+def test_tp_at_pct_closes_full_position_when_threshold_hit():
+    # Bar 0 emits open_action=long → opens at bar 1's open ($100), 10 shares.
+    # Bar 2's close hits +3% → close evaluator fires at end of bar 2,
+    # applied at bar 3's open ($103).
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 103, 103],
+        closes=[100, 100, 103, 103, 103],
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=["tp_at_pct"],
+        close_params={"tp_at_pct": {"pct": 0.03}},
+    )
+    result = bt.run(df, save=False)
+
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["side"] == "long"
+    assert result["trades"][0]["entry_price"] == 100.0
+    assert result["trades"][0]["exit_price"] == 103.0
+    assert result["final_capital"] == 1030.0
+
+
+def test_tp_at_pct_does_not_fire_when_threshold_not_hit():
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 101, 101],
+        closes=[100, 100, 101, 101, 101],
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=["tp_at_pct"],
+        close_params={"tp_at_pct": {"pct": 0.03}},
+    )
+    result = bt.run(df, save=False)
+    # Position closes at the end of run at the final close ($101).
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] == 101.0
+
+
+def test_tiered_tp_atr_partial_then_full_close():
+    # ATR=10 throughout. Two tiers: 1×ATR closes 50%, 2×ATR closes 100%.
+    # Entry at $100 (bar 1 open). Bar 2 close=$110 → tier 1 fires
+    # (close 5 shares at bar 3 open=$110). Bar 3 close=$120 → tier 2 fires
+    # (close remaining 5 at bar 4 open=$120).
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 110, 120],
+        closes=[100, 100, 110, 120, 120],
+        atrs=[10, 10, 10, 10, 10],
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=["tiered_tp_atr"],
+        close_params={"tiered_tp_atr": {"tiers": [
+            {"atr_multiple": 1.0, "close_fraction": 0.5},
+            {"atr_multiple": 2.0, "close_fraction": 1.0},
+        ]}},
+    )
+    result = bt.run(df, save=False)
+
+    assert result["total_trades"] == 2
+    assert result["trades"][0]["shares"] == 5.0
+    assert result["trades"][0]["exit_price"] == 110.0
+    assert result["trades"][1]["shares"] == 5.0
+    assert result["trades"][1]["exit_price"] == 120.0
+    # 5 × ($110 - $100) + 5 × ($120 - $100) = $50 + $100 = $150 PnL.
+    assert result["final_capital"] == 1150.0
+
+
+def test_tiered_tp_atr_live_uses_live_atr_from_market():
+    # Same scenario as the snapshot variant but using the live ATR evaluator
+    # (atr_source="live") which reads market["atr"] each bar. With constant
+    # ATR=10 the result is identical.
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 110, 120],
+        closes=[100, 100, 110, 120, 120],
+        atrs=[10, 10, 10, 10, 10],
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=["tiered_tp_atr_live"],
+        close_params={"tiered_tp_atr_live": {
+            "atr_source": "live",
+            "tiers": [
+                {"atr_multiple": 1.0, "close_fraction": 0.5},
+                {"atr_multiple": 2.0, "close_fraction": 1.0},
+            ],
+        }},
+    )
+    result = bt.run(df, save=False)
+
+    assert result["total_trades"] == 2
+    assert result["trades"][0]["exit_price"] == 110.0
+    assert result["trades"][1]["exit_price"] == 120.0
+    assert result["final_capital"] == 1150.0
+
+
+def test_max_close_fraction_wins_between_two_evaluators():
+    # tp_at_pct(2%) fires at +2%; tiered_tp_pct(5%) does not. Larger fraction
+    # (1.0 from tp_at_pct) wins → full close.
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 102, 102],
+        closes=[100, 100, 102, 102, 102],
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=["tp_at_pct", "tiered_tp_pct"],
+        close_params={
+            "tp_at_pct": {"pct": 0.02},
+            "tiered_tp_pct": {"tiers": [
+                {"profit_pct": 0.05, "close_fraction": 1.0},
+            ]},
+        },
+    )
+    result = bt.run(df, save=False)
+
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] == 102.0
+    assert result["final_capital"] == 1020.0
+
+
+def test_close_strategies_unset_preserves_legacy_close_fraction_behavior():
+    # Without close_strategies the column-based close_fraction path is the
+    # only mechanism — identical to test_open_close_backtester.py expectations.
+    idx = pd.date_range("2024-01-01", periods=4, freq="D")
+    df = pd.DataFrame({
+        "open": [100, 100, 110, 110],
+        "close": [100, 110, 110, 110],
+        "open_action": ["long", "none", "none", "none"],
+        "close_fraction": [0, 0, 1.0, 0],
+    }, index=idx)
+
+    bt = Backtester(initial_capital=1000, commission_pct=0, slippage_pct=0)
+    result = bt.run(df, save=False)
+
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] == 110.0
+    assert result["final_capital"] == 1100.0
+
+
+def test_close_strategy_short_position_long_take_profit():
+    # Short open at $100; price drops to $97 → tp_at_pct(3%) fires on short.
+    n = 5
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame({
+        "open": [100, 100, 100, 97, 97],
+        "close": [100, 100, 97, 97, 97],
+        "open_action": ["short", "none", "none", "none", "none"],
+    }, index=idx)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=["tp_at_pct"],
+        close_params={"tp_at_pct": {"pct": 0.03}},
+    )
+    result = bt.run(df, save=False)
+
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["side"] == "short"
+    assert result["trades"][0]["entry_price"] == 100.0
+    assert result["trades"][0]["exit_price"] == 97.0
+    # Short 10 @ $100 → cash 2000; close 10 @ $97 → cash 2000 - 970 = 1030.
+    assert result["final_capital"] == 1030.0
+
+
+def test_close_strategy_unknown_name_raises():
+    try:
+        Backtester(
+            initial_capital=1000, commission_pct=0, slippage_pct=0,
+            close_strategies=["does_not_exist"],
+        )
+    except ValueError as exc:
+        assert "does_not_exist" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for unknown close strategy")

--- a/backtest/tests/test_backtester_close_strategies.py
+++ b/backtest/tests/test_backtester_close_strategies.py
@@ -184,6 +184,66 @@ def test_close_strategy_short_position_long_take_profit():
     assert result["final_capital"] == 1030.0
 
 
+def test_starting_long_seed_with_entry_atr_lets_tiered_tp_atr_fire():
+    # Seed a long position at $100 with EntryATR=10. Eval is end-of-bar t,
+    # fill at bar t+1's open:
+    # - Bar 0 close=$110 → tier 1 fires (1×ATR, 50%) → fills at bar 1 open=$110
+    # - Bar 1 close=$120 → tier 2 fires (2×ATR, 100%) → fills at bar 2 open=$120
+    n = 3
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame({
+        "open":  [100, 110, 120],
+        "close": [110, 120, 120],
+        "atr":   [10,  10,  10],
+        "open_action": ["none", "none", "none"],
+    }, index=idx)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=["tiered_tp_atr"],
+        close_params={"tiered_tp_atr": {"tiers": [
+            {"atr_multiple": 1.0, "close_fraction": 0.5},
+            {"atr_multiple": 2.0, "close_fraction": 1.0},
+        ]}},
+    )
+    result = bt.run(
+        df, save=False,
+        starting_long={"entry_price": 100.0, "entry_atr": 10.0},
+    )
+    # Two close legs: tier 1 at $110 (5 shares), tier 2 at $120 (5 shares).
+    assert result["total_trades"] == 2
+    assert result["trades"][0]["exit_price"] == 110.0
+    assert result["trades"][0]["shares"] == 5.0
+    assert result["trades"][1]["exit_price"] == 120.0
+    assert result["trades"][1]["shares"] == 5.0
+    # 5 × $10 + 5 × $20 = $150 PnL.
+    assert result["final_capital"] == 1150.0
+
+
+def test_starting_long_seed_without_entry_atr_atr_evaluator_noops():
+    # Same scenario as above but no entry_atr passed — tiered_tp_atr should
+    # silently no-op (mirrors live: stampEntryATRIfOpened rejects 0 → noop).
+    # Position rides to forced end-of-run close.
+    n = 3
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame({
+        "open":  [100, 110, 120],
+        "close": [110, 120, 120],
+        "atr":   [10,  10,  10],
+        "open_action": ["none", "none", "none"],
+    }, index=idx)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=["tiered_tp_atr"],
+    )
+    result = bt.run(
+        df, save=False,
+        starting_long={"entry_price": 100.0},
+    )
+    # No tier hits → forced close at the final bar's close ($120).
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] == 120.0
+
+
 def test_close_strategy_unknown_name_raises():
     try:
         Backtester(


### PR DESCRIPTION
## Summary

- Backtester now runs the close registry per-bar against the simulated position. Configured evaluators fire at end-of-bar; the max `close_fraction` is applied at the next bar's open (same fill alignment as the column-based `close_fraction` path) and combined via max-wins.
- `Backtester.__init__` accepts `close_strategies` + `close_params`. Per-bar position context (`avg_cost`, `initial_quantity`, `entry_atr`) is stamped at open with the same 50%-of-AvgCost plausibility guard as `stampEntryATRIfOpened`. Unknown evaluator names fail fast at construction.
- `run_backtest.py` adds `--close-strategy NAME` (repeatable) and `--close-params` (JSON).
- Backtests with no `close_strategies` are unchanged — verified via `test_close_strategies_unset_preserves_legacy_close_fraction_behavior` and the existing 95-test backtest suite (all green).

Backtest granularity remains bar-level, so live intra-bar trigger races (HL stop-loss OIDs, sub-bar trailing-stop arms) are not simulated; the issue lists this as a non-goal.

Closes #534.

## Test plan

- [x] `.venv/bin/python3 -m pytest backtest/tests/test_backtester_close_strategies.py` — 8 new cases (full close, no-trigger, partial multi-leg, live ATR, max-wins, no-regression baseline, short-side, unknown-name).
- [x] `.venv/bin/python3 -m pytest backtest/tests/ shared_tools/ shared_strategies/` — 569 passed.
- [x] `python3 backtest/run_backtest.py --help` — `--close-strategy` and `--close-params` documented.

---
LLM: Claude Opus 4.7 (1M) | high