### PR TITLE
Wire regime detection into check scripts

### DIFF
--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -56,6 +56,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strateg
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
 from atr import ensure_atr_indicator, latest_atr
+from regime import latest_regime
 
 
 def _make_dataframe(candles):
@@ -154,6 +155,8 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             sys.exit(1)
 
         df = _make_dataframe(candles)
+        regime_payload = latest_regime(df)
+        strategy_params["regime"] = regime_payload
         if strategy_params_override:
             merged = {**strategy_params_override, **strategy_params}
             strategy_params = merged
@@ -244,6 +247,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             "signal": signal,
             "price": round(price, 2),
             "indicators": indicators,
+            "regime": regime_payload["regime"],
             "mode": mode,
             "platform": "hyperliquid",
             "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -261,6 +265,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             "signal": 0,
             "price": 0,
             "indicators": {},
+            "regime": None,
             "mode": mode,
             "platform": "hyperliquid",
             "timestamp": datetime.now(timezone.utc).isoformat(),

--- a/shared_scripts/check_okx.py
+++ b/shared_scripts/check_okx.py
@@ -22,6 +22,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'platforms', 'o
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
 from atr import ensure_atr_indicator, latest_atr
+from regime import latest_regime
 
 # Use futures registry for perps (swap), spot registry for spot.
 # Default is swap, matching argparse defaults below.
@@ -154,6 +155,8 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             sys.exit(1)
 
         df = _make_dataframe(candles)
+        regime_payload = latest_regime(df)
+        strategy_params["regime"] = regime_payload
         if strategy_params_override:
             merged = {**strategy_params_override, **strategy_params}
             strategy_params = merged
@@ -250,6 +253,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             "signal": signal,
             "price": round(price, 2),
             "indicators": indicators,
+            "regime": regime_payload["regime"],
             "mode": mode,
             "platform": "okx",
             "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -267,6 +271,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             "signal": 0,
             "price": 0,
             "indicators": {},
+            "regime": None,
             "mode": mode,
             "platform": "okx",
             "timestamp": datetime.now(timezone.utc).isoformat(),

--- a/shared_scripts/check_options.py
+++ b/shared_scripts/check_options.py
@@ -417,6 +417,7 @@ def main():
             "spot_price": 0,
             "actions": [],
             "iv_rank": 0,
+            "regime": None,
             "platform": platform,
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "skip_reason": f"Max positions reached ({len(existing_positions)}/{MAX_POSITIONS_PER_STRATEGY})"
@@ -431,6 +432,7 @@ def main():
             "spot_price": 0,
             "actions": [],
             "iv_rank": 0,
+            "regime": None,
             "platform": platform,
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "error": f"Unknown strategy: {strategy_name}. Available: {list(STRATEGY_MAP.keys())}"
@@ -449,6 +451,7 @@ def main():
                 "spot_price": 0,
                 "actions": [],
                 "iv_rank": 0,
+                "regime": None,
                 "platform": platform,
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "error": "Could not fetch spot price"
@@ -485,6 +488,7 @@ def main():
             "spot_price": round(spot_price, 2),
             "actions": scored_actions,
             "iv_rank": round(iv_rank, 1),
+            "regime": None,
             "platform": platform,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
@@ -505,6 +509,7 @@ def main():
             "spot_price": 0,
             "actions": [],
             "iv_rank": 0,
+            "regime": None,
             "platform": platform,
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "error": str(e)

--- a/shared_scripts/check_robinhood.py
+++ b/shared_scripts/check_robinhood.py
@@ -25,6 +25,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strateg
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
 from atr import ensure_atr_indicator, latest_atr
+from regime import latest_regime
 
 
 def _make_dataframe(candles):
@@ -164,6 +165,9 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             sys.exit(1)
 
         df = _make_dataframe(candles)
+        regime_payload = latest_regime(df)
+        strategy_params = (strategy_params or {})
+        strategy_params["regime"] = regime_payload
         decision = None
         if open_close_enabled:
             market_ctx = {"mark_price": float(df["close"].iloc[-1])}
@@ -251,6 +255,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             "signal": signal,
             "price": round(price, 2),
             "indicators": indicators,
+            "regime": regime_payload["regime"],
             "mode": mode,
             "platform": "robinhood",
             "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -268,6 +273,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             "signal": 0,
             "price": 0,
             "indicators": {},
+            "regime": None,
             "mode": mode,
             "platform": "robinhood",
             "timestamp": datetime.now(timezone.utc).isoformat(),

--- a/shared_scripts/check_strategy.py
+++ b/shared_scripts/check_strategy.py
@@ -23,6 +23,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strateg
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
 from atr import ensure_atr_indicator, latest_atr
+from regime import latest_regime
 
 
 def _arg_value(flag, default=None):
@@ -176,10 +177,15 @@ def main():
                 "signal": 0,
                 "price": 0,
                 "indicators": {},
+                "regime": None,
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "error": f"Insufficient data: {len(df)} candles"
             }))
             return
+
+        regime_payload = latest_regime(df)
+        strategy_params = (strategy_params or {})
+        strategy_params["regime"] = regime_payload
 
         decision = None
         if open_close_enabled:
@@ -259,6 +265,7 @@ def main():
             "signal": signal,
             "price": round(price, 2),
             "indicators": indicators,
+            "regime": regime_payload["regime"],
             "timestamp": datetime.now(timezone.utc).isoformat()
         }
         if decision:
@@ -274,6 +281,7 @@ def main():
             "signal": 0,
             "price": 0,
             "indicators": {},
+            "regime": None,
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "error": str(e)
         }))

--- a/shared_scripts/check_topstep.py
+++ b/shared_scripts/check_topstep.py
@@ -23,6 +23,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strateg
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
 from atr import ensure_atr_indicator, latest_atr
+from regime import latest_regime
 
 
 def _make_dataframe(candles):
@@ -172,6 +173,9 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             sys.exit(1)
 
         df = _make_dataframe(candles)
+        regime_payload = latest_regime(df)
+        strategy_params = (strategy_params or {})
+        strategy_params["regime"] = regime_payload
         decision = None
         if open_close_enabled:
             market_ctx = {"mark_price": float(df["close"].iloc[-1])}
@@ -261,6 +265,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             "contract_spec": adapter.get_contract_spec(symbol),
             "market_open": market_open,
             "indicators": indicators,
+            "regime": regime_payload["regime"],
             "mode": mode,
             "platform": "topstep",
             "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -280,6 +285,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             "contract_spec": {},
             "market_open": False,
             "indicators": {},
+            "regime": None,
             "mode": mode,
             "platform": "topstep",
             "timestamp": datetime.now(timezone.utc).isoformat(),

--- a/shared_scripts/test_regime_wiring.py
+++ b/shared_scripts/test_regime_wiring.py
@@ -1,0 +1,157 @@
+"""Tests for regime injection contract in check scripts.
+
+Verifies the regime injection pattern used by all 5 standard check scripts:
+  - latest_regime() is importable via shared_tools sys.path
+  - regime payload is JSON-serializable (no NaN/Inf; SafeEncoder compat)
+  - strip_unsupported_position_context drops "regime" for non-aware strategies
+  - regime payload can safely be merged into strategy_params (even when None)
+  - check_options.py emits regime: null (tested via source inspection)
+"""
+
+import json
+import sys
+import pathlib
+import importlib.util
+
+import numpy as np
+import pandas as pd
+
+# Mirror the sys.path setup that check scripts use for shared_tools
+_SHARED_TOOLS = pathlib.Path(__file__).parent.parent / "shared_tools"
+if str(_SHARED_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_SHARED_TOOLS))
+
+from regime import latest_regime
+
+_SHARED_STRATEGIES_TOOLS = str(_SHARED_TOOLS)
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+
+def _make_uptrend_df(n: int = 100) -> pd.DataFrame:
+    close = np.linspace(100.0, 200.0, n)
+    idx = pd.date_range("2024-01-01", periods=n, freq="1h", tz="UTC")
+    return pd.DataFrame(
+        {"open": close, "high": close + 0.5, "low": close - 0.5, "close": close, "volume": 1000.0},
+        index=idx,
+    )
+
+
+def _make_flat_df(n: int = 100) -> pd.DataFrame:
+    close = np.full(n, 100.0)
+    idx = pd.date_range("2024-01-01", periods=n, freq="1h", tz="UTC")
+    return pd.DataFrame(
+        {"open": close, "high": close + 0.05, "low": close - 0.05, "close": close, "volume": 1000.0},
+        index=idx,
+    )
+
+
+# ─── Import path tests ────────────────────────────────────────────────────────
+
+
+def test_latest_regime_importable_via_check_script_syspath():
+    """latest_regime must be importable via the sys.path check scripts set up."""
+    assert callable(latest_regime)
+
+
+# ─── JSON-serializability tests ───────────────────────────────────────────────
+
+
+def test_latest_regime_output_json_serializable_uptrend():
+    """regime payload from an uptrend df must survive json.dumps (no NaN/Inf)."""
+    df = _make_uptrend_df()
+    payload = latest_regime(df)
+    serialized = json.dumps(payload)
+    parsed = json.loads(serialized)
+    assert parsed["regime"] in ("trending_up", "trending_down", "ranging")
+    assert isinstance(parsed["score"], float)
+    assert isinstance(parsed["metrics"], dict)
+
+
+def test_latest_regime_output_json_serializable_flat():
+    """regime payload from a flat/ranging df must survive json.dumps."""
+    df = _make_flat_df()
+    payload = latest_regime(df)
+    serialized = json.dumps(payload)
+    parsed = json.loads(serialized)
+    assert parsed["regime"] == "ranging"
+
+
+def test_regime_label_string_is_safe_for_output_field():
+    """The regime label (just the string) is safe to embed directly in check script output."""
+    df = _make_uptrend_df()
+    payload = latest_regime(df)
+    label = payload["regime"]
+    assert isinstance(label, str)
+    assert label in ("trending_up", "trending_down", "ranging")
+    # Must be embeddable as a JSON string value
+    assert json.dumps({"regime": label})
+
+
+# ─── strategy_params merge tests ─────────────────────────────────────────────
+
+
+def test_regime_merge_into_none_params():
+    """When strategy_params is None, merging regime must not crash."""
+    df = _make_uptrend_df()
+    payload = latest_regime(df)
+    strategy_params = None
+    strategy_params = (strategy_params or {})
+    strategy_params["regime"] = payload
+    assert "regime" in strategy_params
+    assert strategy_params["regime"]["regime"] in ("trending_up", "trending_down", "ranging")
+
+
+def test_regime_merge_preserves_existing_params():
+    """Merging regime into existing params must not drop other keys."""
+    df = _make_uptrend_df()
+    payload = latest_regime(df)
+    strategy_params = {"rsi_period": 14, "threshold": 0.6}
+    strategy_params["regime"] = payload
+    assert strategy_params["rsi_period"] == 14
+    assert strategy_params["threshold"] == 0.6
+    assert "regime" in strategy_params
+
+
+# ─── strip_unsupported_position_context tests ─────────────────────────────────
+
+
+def test_strip_unsupported_drops_regime_for_non_aware_function():
+    """strip_unsupported_position_context must drop 'regime' for a strategy that doesn't declare it."""
+    from strategy_composition import strip_unsupported_position_context
+
+    def dummy_strategy(df, rsi_period=14):
+        return df
+
+    df = _make_uptrend_df()
+    params = {"rsi_period": 14, "regime": latest_regime(df)}
+    stripped = strip_unsupported_position_context(dummy_strategy, params)
+    assert "regime" not in stripped
+    assert stripped["rsi_period"] == 14
+
+
+def test_strip_unsupported_keeps_regime_for_aware_function():
+    """strip_unsupported_position_context must keep 'regime' when the strategy declares it."""
+    from strategy_composition import strip_unsupported_position_context
+
+    def regime_aware_strategy(df, regime=None, rsi_period=14):
+        return df
+
+    df = _make_uptrend_df()
+    params = {"rsi_period": 14, "regime": latest_regime(df)}
+    stripped = strip_unsupported_position_context(regime_aware_strategy, params)
+    assert "regime" in stripped
+    assert stripped["rsi_period"] == 14
+
+
+# ─── check_options.py emits regime: null ─────────────────────────────────────
+
+
+def test_check_options_source_emits_regime_null():
+    """check_options.py must emit 'regime': None (null in JSON) in its output paths."""
+    src_path = pathlib.Path(__file__).parent / "check_options.py"
+    source = src_path.read_text()
+    assert '"regime"' in source or "'regime'" in source, (
+        "check_options.py does not emit a 'regime' field — add \"'regime': None\" to all output dicts"
+    )

--- a/shared_tools/strategy_composition.py
+++ b/shared_tools/strategy_composition.py
@@ -18,7 +18,7 @@ import pandas as pd
 
 VALID_POSITION_SIDES = {"", "long", "short"}
 VALID_OPEN_ACTIONS = {"long", "short", "none"}
-POSITION_CONTEXT_PARAM_KEYS = {"side", "avg_cost", "current_quantity", "initial_quantity", "entry_atr"}
+POSITION_CONTEXT_PARAM_KEYS = {"side", "avg_cost", "current_quantity", "initial_quantity", "entry_atr", "regime"}
 
 
 @dataclass


### PR DESCRIPTION
Closes #540

## Summary

- Adds `from regime import latest_regime` and injects regime payload into `strategy_params` before `apply_strategy` in all 5 standard check scripts (`check_strategy`, `check_hyperliquid`, `check_okx`, `check_topstep`, `check_robinhood`)
- Emits `"regime": <label>` in every success JSON output path; `"regime": null` in all error/early-exit paths
- `check_options.py` emits `"regime": null` across all output paths (computation deferred to #544)
- Adds `"regime"` to `POSITION_CONTEXT_PARAM_KEYS` in `strategy_composition.py` so `strip_unsupported_position_context` correctly drops it for strategies that don't declare `regime=` — without this, non-aware strategies would raise `TypeError` on the injected kwarg

## Design note

The TDD RED phase caught the `strip_unsupported_position_context` gap: the function only strips keys listed in `POSITION_CONTEXT_PARAM_KEYS`, so `regime` would have passed through to every strategy fn. Adding it to that set is the correct fix — `regime` is auto-injected context, same as position side/avg_cost.

## Test plan

- `shared_scripts/test_regime_wiring.py`: 9 tests covering importability, JSON serializability, params merge safety, and `strip_unsupported` behavior for aware/non-aware strategies
- Full suite: 596 passed, 0 failures

## Not yet wired

Go scheduler does not read `"regime"` from script output yet — that is PR-C (#541).

---
LLM: Claude Sonnet 4.6 (1M) | high