### PR TITLE
Go scheduler: RegimeConfig, AllowedRegimes gating, /status regime field

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -43,6 +43,14 @@ type PlatformConfig struct {
 	Risk *PortfolioRiskConfig `json:"risk,omitempty"` // overrides portfolio-level defaults
 }
 
+// RegimeConfig controls the market regime detector run once per (symbol, timeframe) cycle.
+// Default disabled; strategies opt in via AllowedRegimes or by reading params["regime"].
+type RegimeConfig struct {
+	Enabled      bool    `json:"enabled"`
+	Period       int     `json:"period"`        // ADX lookback (Wilder's smoothing); default 14
+	ADXThreshold float64 `json:"adx_threshold"` // ADX below this is "ranging"; default 20.0
+}
+
 // CorrelationConfig controls portfolio-level directional exposure tracking.
 type CorrelationConfig struct {
 	Enabled             bool    `json:"enabled"`
@@ -106,6 +114,7 @@ type Config struct {
 	Strategies           []StrategyConfig           `json:"strategies"`
 	PortfolioRisk        *PortfolioRiskConfig       `json:"portfolio_risk,omitempty"`
 	Correlation          *CorrelationConfig         `json:"correlation,omitempty"`
+	Regime               *RegimeConfig              `json:"regime,omitempty"`
 	Platforms            map[string]*PlatformConfig `json:"platforms,omitempty"`
 	LeaderboardSummaries []LeaderboardSummaryConfig `json:"leaderboard_summaries,omitempty"` // #308 — configurable per-channel leaderboards
 	SummaryFrequency     map[string]string          `json:"summary_frequency,omitempty"`     // #30 — per-channel summary cadence; keys match Discord/Telegram channel keys (e.g. "spot", "options", "hyperliquid"). Values: Go duration ("30m", "2h"), alias ("hourly", "every"/"per_check"/"always"), or empty for legacy default (continuous: every channel run; spot: hourly)
@@ -197,6 +206,7 @@ type StrategyConfig struct {
 	Args                   []string               `json:"args"`
 	OpenStrategy           string                 `json:"open_strategy,omitempty"`    // optional entry strategy override; defaults to Args[0] for backwards compatibility (#480)
 	CloseStrategies        []string               `json:"close_strategies,omitempty"` // optional exit strategy list; max close_fraction wins (#480)
+	AllowedRegimes         []string               `json:"allowed_regimes,omitempty"`  // gate entries: skip signal when current regime not in this list; empty = allow all (#482)
 	Capital                float64                `json:"capital"`
 	CapitalPct             float64                `json:"capital_pct,omitempty"`     // 0-1; dynamic capital = wallet_balance * capital_pct (overrides capital)
 	InitialCapital         float64                `json:"initial_capital,omitempty"` // fixed starting balance for PnL display (never overwritten by capital_pct)
@@ -539,6 +549,17 @@ func LoadConfig(path string) (*Config, error) {
 		cfg.Correlation = &CorrelationConfig{Enabled: false, MaxConcentrationPct: 60, MaxSameDirectionPct: 75}
 	}
 
+	// Regime detection defaults.
+	if cfg.Regime == nil {
+		cfg.Regime = &RegimeConfig{Enabled: false, Period: 14, ADXThreshold: 20.0}
+	}
+	if cfg.Regime.Period == 0 {
+		cfg.Regime.Period = 14
+	}
+	if cfg.Regime.ADXThreshold == 0 {
+		cfg.Regime.ADXThreshold = 20.0
+	}
+
 	if cfg.Correlation.MaxConcentrationPct == 0 {
 		cfg.Correlation.MaxConcentrationPct = 60
 	}
@@ -829,6 +850,13 @@ func ValidateConfig(cfg *Config) error {
 		for j, name := range sc.CloseStrategies {
 			if err := validateStrategyConceptName(name); err != nil {
 				errs = append(errs, fmt.Sprintf("%s: close_strategies[%d] %v", prefix, j, err))
+			}
+		}
+
+		validRegimeLabels := map[string]bool{"trending_up": true, "trending_down": true, "ranging": true}
+		for j, label := range sc.AllowedRegimes {
+			if !validRegimeLabels[label] {
+				errs = append(errs, fmt.Sprintf("%s: allowed_regimes[%d] unknown label %q (valid: trending_up, trending_down, ranging)", prefix, j, label))
 			}
 		}
 
@@ -1190,6 +1218,16 @@ func ValidateConfig(cfg *Config) error {
 		}
 		if cfg.Correlation.MaxSameDirectionPct <= 0 || cfg.Correlation.MaxSameDirectionPct > 100 {
 			errs = append(errs, fmt.Sprintf("correlation.max_same_direction_pct must be in (0, 100], got %g", cfg.Correlation.MaxSameDirectionPct))
+		}
+	}
+
+	// Validate regime config.
+	if cfg.Regime != nil && cfg.Regime.Enabled {
+		if cfg.Regime.Period <= 0 {
+			errs = append(errs, fmt.Sprintf("regime.period must be > 0, got %d", cfg.Regime.Period))
+		}
+		if cfg.Regime.ADXThreshold <= 0 || cfg.Regime.ADXThreshold > 100 {
+			errs = append(errs, fmt.Sprintf("regime.adx_threshold must be in (0, 100], got %g", cfg.Regime.ADXThreshold))
 		}
 	}
 

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -549,15 +549,19 @@ func LoadConfig(path string) (*Config, error) {
 		cfg.Correlation = &CorrelationConfig{Enabled: false, MaxConcentrationPct: 60, MaxSameDirectionPct: 75}
 	}
 
-	// Regime detection defaults.
+	// Regime detection defaults. Defaults are only injected when Enabled=true so
+	// that an explicit zero in a disabled block (e.g. {"period": 0}) round-trips
+	// instead of being silently rewritten to 14.
 	if cfg.Regime == nil {
-		cfg.Regime = &RegimeConfig{Enabled: false, Period: 14, ADXThreshold: 20.0}
+		cfg.Regime = &RegimeConfig{Enabled: false}
 	}
-	if cfg.Regime.Period == 0 {
-		cfg.Regime.Period = 14
-	}
-	if cfg.Regime.ADXThreshold == 0 {
-		cfg.Regime.ADXThreshold = 20.0
+	if cfg.Regime.Enabled {
+		if cfg.Regime.Period == 0 {
+			cfg.Regime.Period = 14
+		}
+		if cfg.Regime.ADXThreshold == 0 {
+			cfg.Regime.ADXThreshold = 20.0
+		}
 	}
 
 	if cfg.Correlation.MaxConcentrationPct == 0 {
@@ -853,6 +857,9 @@ func ValidateConfig(cfg *Config) error {
 			}
 		}
 
+		// Canonical regime label set lives in shared_tools/regime.py
+		// (_VALID_LABELS). Keep the two in sync — this validator and the Python
+		// detector must agree, or strategies will be silently misclassified.
 		validRegimeLabels := map[string]bool{"trending_up": true, "trending_down": true, "ranging": true}
 		for j, label := range sc.AllowedRegimes {
 			if !validRegimeLabels[label] {

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -10,7 +10,7 @@ import (
 
 // CurrentConfigVersion is the version embedded in newly generated configs.
 // When the binary starts and cfg.ConfigVersion < CurrentConfigVersion, migration runs.
-const CurrentConfigVersion = 10
+const CurrentConfigVersion = 11
 
 // ConfigField describes a config field introduced in a specific version.
 type ConfigField struct {

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -83,6 +83,10 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 			addChange("strategy[%s].close_strategies: %v -> %v", sc.ID, sc.CloseStrategies, ns.CloseStrategies)
 			sc.CloseStrategies = append([]string{}, ns.CloseStrategies...)
 		}
+		if !reflect.DeepEqual(sc.AllowedRegimes, ns.AllowedRegimes) {
+			addChange("strategy[%s].allowed_regimes: %v -> %v", sc.ID, sc.AllowedRegimes, ns.AllowedRegimes)
+			sc.AllowedRegimes = append([]string{}, ns.AllowedRegimes...)
+		}
 		// #486: Margin mode is hot-reloadable when flat. The state-compat
 		// check above blocks the change when positions are open; if we got
 		// here with new MarginMode != current, the strategy is flat and the
@@ -190,6 +194,9 @@ func validateHotReloadCompatible(cfg, next *Config) error {
 	}
 	if !reflect.DeepEqual(cfg.Correlation, next.Correlation) {
 		errs = append(errs, "correlation changed (restart required)")
+	}
+	if !reflect.DeepEqual(cfg.Regime, next.Regime) {
+		errs = append(errs, "regime changed (restart required)")
 	}
 	if !reflect.DeepEqual(cfg.LeaderboardSummaries, next.LeaderboardSummaries) {
 		errs = append(errs, "leaderboard_summaries changed (restart required)")
@@ -306,6 +313,7 @@ func strategyRestartShape(sc StrategyConfig) StrategyConfig {
 	sc.IntervalSeconds = 0
 	sc.OpenStrategy = ""
 	sc.CloseStrategies = nil
+	sc.AllowedRegimes = nil
 	sc.MarginMode = ""              // #486: hot-reloadable when flat (state-compat check enforces flat-only change)
 	sc.TrailingStopPct = nil        // #501: hot-reloadable; state-compat allows pct changes but blocks mode switches while open
 	sc.TrailingStopATRMult = nil    // #505: hot-reloadable; same state-compat treatment as TrailingStopPct

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1208,10 +1208,13 @@ func main() {
 						if sc.Platform == "okx" {
 							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, logger); ok {
 								prices[result.Symbol] = price
-								if !regimeAllowsEntry(sc.AllowedRegimes, result.Regime) {
-									logger.Info("Regime gate: signal blocked (regime=%s)", result.Regime)
+								if regimeBlocksOpen(sc.AllowedRegimes, result.Regime, okxPosQty) {
+									logger.Info("Regime gate: open signal blocked (regime=%s)", result.Regime)
 									result.Signal = 0
 								}
+								mu.Lock()
+								stratState.Regime = result.Regime
+								mu.Unlock()
 								var execResult *OKXExecuteResult
 								liveExecFailed := false
 								if okxIsLive(sc.Args) && result.Signal != 0 {
@@ -1223,7 +1226,6 @@ func main() {
 								}
 								if !liveExecFailed {
 									mu.Lock()
-									stratState.Regime = result.Regime
 									trades, detail = executeOKXResult(sc, stratState, result, execResult, signalStr, price, logger)
 									mu.Unlock()
 								}
@@ -1231,10 +1233,13 @@ func main() {
 						} else if sc.Platform == "robinhood" {
 							if result, signalStr, price, ok := runRobinhoodCheck(sc, prices, rhPosCtx, logger); ok {
 								prices[result.Symbol] = price
-								if !regimeAllowsEntry(sc.AllowedRegimes, result.Regime) {
-									logger.Info("Regime gate: signal blocked (regime=%s)", result.Regime)
+								if regimeBlocksOpen(sc.AllowedRegimes, result.Regime, rhPosQty) {
+									logger.Info("Regime gate: open signal blocked (regime=%s)", result.Regime)
 									result.Signal = 0
 								}
+								mu.Lock()
+								stratState.Regime = result.Regime
+								mu.Unlock()
 								var execResult *RobinhoodExecuteResult
 								liveExecFailed := false
 								if robinhoodIsLive(sc.Args) && result.Signal != 0 {
@@ -1246,14 +1251,13 @@ func main() {
 								}
 								if !liveExecFailed {
 									mu.Lock()
-									stratState.Regime = result.Regime
 									trades, detail = executeRobinhoodResult(sc, stratState, result, execResult, signalStr, price, logger)
 									mu.Unlock()
 								}
 							}
 						} else if result, signalStr, price, ok := runSpotCheck(sc, prices, spotPosCtx, logger); ok {
-							if !regimeAllowsEntry(sc.AllowedRegimes, result.Regime) {
-								logger.Info("Regime gate: signal blocked (regime=%s)", result.Regime)
+							if regimeBlocksOpen(sc.AllowedRegimes, result.Regime, spotPosCtx.Quantity) {
+								logger.Info("Regime gate: open signal blocked (regime=%s)", result.Regime)
 								result.Signal = 0
 							}
 							mu.Lock()
@@ -1276,10 +1280,13 @@ func main() {
 						if sc.Platform == "okx" {
 							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, logger); ok {
 								prices[result.Symbol] = price
-								if !regimeAllowsEntry(sc.AllowedRegimes, result.Regime) {
-									logger.Info("Regime gate: signal blocked (regime=%s)", result.Regime)
+								if regimeBlocksOpen(sc.AllowedRegimes, result.Regime, okxPosQty) {
+									logger.Info("Regime gate: open signal blocked (regime=%s)", result.Regime)
 									result.Signal = 0
 								}
+								mu.Lock()
+								stratState.Regime = result.Regime
+								mu.Unlock()
 								var execResult *OKXExecuteResult
 								liveExecFailed := false
 								if okxIsLive(sc.Args) && result.Signal != 0 {
@@ -1291,17 +1298,19 @@ func main() {
 								}
 								if !liveExecFailed {
 									mu.Lock()
-									stratState.Regime = result.Regime
 									trades, detail = executeOKXResult(sc, stratState, result, execResult, signalStr, price, logger)
 									mu.Unlock()
 								}
 							}
 						} else if result, signalStr, price, ok := runHyperliquidCheck(sc, prices, hlPosCtx, logger); ok {
 							prices[result.Symbol] = price
-							if !regimeAllowsEntry(sc.AllowedRegimes, result.Regime) {
-								logger.Info("Regime gate: signal blocked (regime=%s)", result.Regime)
+							if regimeBlocksOpen(sc.AllowedRegimes, result.Regime, hlPosQty) {
+								logger.Info("Regime gate: open signal blocked (regime=%s)", result.Regime)
 								result.Signal = 0
 							}
+							mu.Lock()
+							stratState.Regime = result.Regime
+							mu.Unlock()
 							var execResult *HyperliquidExecuteResult
 							liveExecFailed := false
 							hlPosSnapshot := &Position{AvgCost: hlAvgCost, EntryATR: hlEntryATR}
@@ -1394,7 +1403,6 @@ func main() {
 							}
 							if !liveExecFailed {
 								mu.Lock()
-								stratState.Regime = result.Regime
 								trades, detail = executeHyperliquidResult(sc, stratState, result, execResult, signalStr, price, logger)
 								mu.Unlock()
 							}
@@ -1402,10 +1410,13 @@ func main() {
 					case "futures":
 						if result, signalStr, price, ok := runTopStepCheck(sc, prices, tsPosCtx, logger); ok {
 							prices[result.Symbol] = price
-							if !regimeAllowsEntry(sc.AllowedRegimes, result.Regime) {
-								logger.Info("Regime gate: signal blocked (regime=%s)", result.Regime)
+							if regimeBlocksOpen(sc.AllowedRegimes, result.Regime, tsContracts) {
+								logger.Info("Regime gate: open signal blocked (regime=%s)", result.Regime)
 								result.Signal = 0
 							}
+							mu.Lock()
+							stratState.Regime = result.Regime
+							mu.Unlock()
 							var execResult *TopStepExecuteResult
 							liveExecFailed := false
 							if topstepIsLive(sc.Args) && result.Signal != 0 {
@@ -1417,7 +1428,6 @@ func main() {
 							}
 							if !liveExecFailed {
 								mu.Lock()
-								stratState.Regime = result.Regime
 								trades, detail = executeTopStepResult(sc, stratState, result, execResult, signalStr, price, logger)
 								mu.Unlock()
 							}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1208,6 +1208,10 @@ func main() {
 						if sc.Platform == "okx" {
 							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, logger); ok {
 								prices[result.Symbol] = price
+								if !regimeAllowsEntry(sc.AllowedRegimes, result.Regime) {
+									logger.Info("Regime gate: signal blocked (regime=%s)", result.Regime)
+									result.Signal = 0
+								}
 								var execResult *OKXExecuteResult
 								liveExecFailed := false
 								if okxIsLive(sc.Args) && result.Signal != 0 {
@@ -1219,6 +1223,7 @@ func main() {
 								}
 								if !liveExecFailed {
 									mu.Lock()
+									stratState.Regime = result.Regime
 									trades, detail = executeOKXResult(sc, stratState, result, execResult, signalStr, price, logger)
 									mu.Unlock()
 								}
@@ -1226,6 +1231,10 @@ func main() {
 						} else if sc.Platform == "robinhood" {
 							if result, signalStr, price, ok := runRobinhoodCheck(sc, prices, rhPosCtx, logger); ok {
 								prices[result.Symbol] = price
+								if !regimeAllowsEntry(sc.AllowedRegimes, result.Regime) {
+									logger.Info("Regime gate: signal blocked (regime=%s)", result.Regime)
+									result.Signal = 0
+								}
 								var execResult *RobinhoodExecuteResult
 								liveExecFailed := false
 								if robinhoodIsLive(sc.Args) && result.Signal != 0 {
@@ -1237,12 +1246,18 @@ func main() {
 								}
 								if !liveExecFailed {
 									mu.Lock()
+									stratState.Regime = result.Regime
 									trades, detail = executeRobinhoodResult(sc, stratState, result, execResult, signalStr, price, logger)
 									mu.Unlock()
 								}
 							}
 						} else if result, signalStr, price, ok := runSpotCheck(sc, prices, spotPosCtx, logger); ok {
+							if !regimeAllowsEntry(sc.AllowedRegimes, result.Regime) {
+								logger.Info("Regime gate: signal blocked (regime=%s)", result.Regime)
+								result.Signal = 0
+							}
 							mu.Lock()
+							stratState.Regime = result.Regime
 							trades, detail = executeSpotResult(sc, stratState, result, signalStr, price, logger)
 							mu.Unlock()
 						}
@@ -1261,6 +1276,10 @@ func main() {
 						if sc.Platform == "okx" {
 							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, logger); ok {
 								prices[result.Symbol] = price
+								if !regimeAllowsEntry(sc.AllowedRegimes, result.Regime) {
+									logger.Info("Regime gate: signal blocked (regime=%s)", result.Regime)
+									result.Signal = 0
+								}
 								var execResult *OKXExecuteResult
 								liveExecFailed := false
 								if okxIsLive(sc.Args) && result.Signal != 0 {
@@ -1272,12 +1291,17 @@ func main() {
 								}
 								if !liveExecFailed {
 									mu.Lock()
+									stratState.Regime = result.Regime
 									trades, detail = executeOKXResult(sc, stratState, result, execResult, signalStr, price, logger)
 									mu.Unlock()
 								}
 							}
 						} else if result, signalStr, price, ok := runHyperliquidCheck(sc, prices, hlPosCtx, logger); ok {
 							prices[result.Symbol] = price
+							if !regimeAllowsEntry(sc.AllowedRegimes, result.Regime) {
+								logger.Info("Regime gate: signal blocked (regime=%s)", result.Regime)
+								result.Signal = 0
+							}
 							var execResult *HyperliquidExecuteResult
 							liveExecFailed := false
 							hlPosSnapshot := &Position{AvgCost: hlAvgCost, EntryATR: hlEntryATR}
@@ -1370,6 +1394,7 @@ func main() {
 							}
 							if !liveExecFailed {
 								mu.Lock()
+								stratState.Regime = result.Regime
 								trades, detail = executeHyperliquidResult(sc, stratState, result, execResult, signalStr, price, logger)
 								mu.Unlock()
 							}
@@ -1377,6 +1402,10 @@ func main() {
 					case "futures":
 						if result, signalStr, price, ok := runTopStepCheck(sc, prices, tsPosCtx, logger); ok {
 							prices[result.Symbol] = price
+							if !regimeAllowsEntry(sc.AllowedRegimes, result.Regime) {
+								logger.Info("Regime gate: signal blocked (regime=%s)", result.Regime)
+								result.Signal = 0
+							}
 							var execResult *TopStepExecuteResult
 							liveExecFailed := false
 							if topstepIsLive(sc.Args) && result.Signal != 0 {
@@ -1388,6 +1417,7 @@ func main() {
 							}
 							if !liveExecFailed {
 								mu.Lock()
+								stratState.Regime = result.Regime
 								trades, detail = executeTopStepResult(sc, stratState, result, execResult, signalStr, price, logger)
 								mu.Unlock()
 							}

--- a/scheduler/regime.go
+++ b/scheduler/regime.go
@@ -6,8 +6,8 @@ package main
 //   - current is empty (regime not available from check script), OR
 //   - current is in the allowed set.
 //
-// This is the single gate checked at every dispatch site before placing an
-// order. Existing positions are always managed by close paths regardless.
+// This is the core regime check; callers gate it on "is this an open?" via
+// regimeBlocksOpen so close legs always pass through.
 func regimeAllowsEntry(allowed []string, current string) bool {
 	if len(allowed) == 0 || current == "" {
 		return true
@@ -18,4 +18,16 @@ func regimeAllowsEntry(allowed []string, current string) bool {
 		}
 	}
 	return false
+}
+
+// regimeBlocksOpen reports whether the regime gate should suppress this
+// dispatch. Closes (any non-zero existing position quantity) always pass
+// through — the gate only fires when no position exists, so the strategy is
+// attempting to open. This preserves the PR contract that "existing positions
+// are always managed by close paths regardless".
+func regimeBlocksOpen(allowed []string, current string, posQty float64) bool {
+	if posQty > 0 {
+		return false
+	}
+	return !regimeAllowsEntry(allowed, current)
 }

--- a/scheduler/regime.go
+++ b/scheduler/regime.go
@@ -1,0 +1,21 @@
+package main
+
+// regimeAllowsEntry reports whether the current market regime permits a new
+// entry for a strategy. Returns true when:
+//   - allowed is empty (no gate configured), OR
+//   - current is empty (regime not available from check script), OR
+//   - current is in the allowed set.
+//
+// This is the single gate checked at every dispatch site before placing an
+// order. Existing positions are always managed by close paths regardless.
+func regimeAllowsEntry(allowed []string, current string) bool {
+	if len(allowed) == 0 || current == "" {
+		return true
+	}
+	for _, label := range allowed {
+		if label == current {
+			return true
+		}
+	}
+	return false
+}

--- a/scheduler/regime_test.go
+++ b/scheduler/regime_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// ─── ValidateConfig — AllowedRegimes ─────────────────────────────────────────
+
+func TestValidateConfig_AllowedRegimes_AcceptsEmpty(t *testing.T) {
+	cfg := minimalSpotConfig()
+	cfg.Strategies[0].AllowedRegimes = []string{}
+	if err := ValidateConfig(&cfg); err != nil {
+		t.Fatalf("empty AllowedRegimes should be valid, got: %v", err)
+	}
+}
+
+func TestValidateConfig_AllowedRegimes_AcceptsNil(t *testing.T) {
+	cfg := minimalSpotConfig()
+	cfg.Strategies[0].AllowedRegimes = nil
+	if err := ValidateConfig(&cfg); err != nil {
+		t.Fatalf("nil AllowedRegimes should be valid, got: %v", err)
+	}
+}
+
+func TestValidateConfig_AllowedRegimes_AcceptsValidLabels(t *testing.T) {
+	cfg := minimalSpotConfig()
+	cfg.Strategies[0].AllowedRegimes = []string{"trending_up", "trending_down"}
+	if err := ValidateConfig(&cfg); err != nil {
+		t.Fatalf("valid labels should pass, got: %v", err)
+	}
+}
+
+func TestValidateConfig_AllowedRegimes_RejectsUnknownLabel(t *testing.T) {
+	cfg := minimalSpotConfig()
+	cfg.Strategies[0].AllowedRegimes = []string{"trending_up", "bullish_breakout"}
+	if err := ValidateConfig(&cfg); err == nil {
+		t.Fatal("unknown regime label should fail validation")
+	}
+}
+
+func TestValidateConfig_AllowedRegimes_AcceptsAllThreeLabels(t *testing.T) {
+	cfg := minimalSpotConfig()
+	cfg.Strategies[0].AllowedRegimes = []string{"trending_up", "trending_down", "ranging"}
+	if err := ValidateConfig(&cfg); err != nil {
+		t.Fatalf("all three valid labels should pass, got: %v", err)
+	}
+}
+
+// ─── RegimeConfig validation ──────────────────────────────────────────────────
+
+func TestValidateConfig_RegimeConfig_NilIsValid(t *testing.T) {
+	cfg := minimalSpotConfig()
+	cfg.Regime = nil
+	if err := ValidateConfig(&cfg); err != nil {
+		t.Fatalf("nil Regime should be valid, got: %v", err)
+	}
+}
+
+func TestValidateConfig_RegimeConfig_ValidEnabled(t *testing.T) {
+	cfg := minimalSpotConfig()
+	cfg.Regime = &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20.0}
+	if err := ValidateConfig(&cfg); err != nil {
+		t.Fatalf("valid RegimeConfig should pass, got: %v", err)
+	}
+}
+
+func TestValidateConfig_RegimeConfig_ZeroPeriodInvalid(t *testing.T) {
+	cfg := minimalSpotConfig()
+	cfg.Regime = &RegimeConfig{Enabled: true, Period: 0, ADXThreshold: 20.0}
+	if err := ValidateConfig(&cfg); err == nil {
+		t.Fatal("Period=0 should fail validation")
+	}
+}
+
+func TestValidateConfig_RegimeConfig_NegativePeriodInvalid(t *testing.T) {
+	cfg := minimalSpotConfig()
+	cfg.Regime = &RegimeConfig{Enabled: true, Period: -1, ADXThreshold: 20.0}
+	if err := ValidateConfig(&cfg); err == nil {
+		t.Fatal("negative Period should fail validation")
+	}
+}
+
+func TestValidateConfig_RegimeConfig_ZeroThresholdInvalid(t *testing.T) {
+	cfg := minimalSpotConfig()
+	cfg.Regime = &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 0}
+	if err := ValidateConfig(&cfg); err == nil {
+		t.Fatal("ADXThreshold=0 should fail validation")
+	}
+}
+
+func TestValidateConfig_RegimeConfig_ThresholdOver100Invalid(t *testing.T) {
+	cfg := minimalSpotConfig()
+	cfg.Regime = &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 101}
+	if err := ValidateConfig(&cfg); err == nil {
+		t.Fatal("ADXThreshold>100 should fail validation")
+	}
+}
+
+// ─── regimeAllowsEntry ────────────────────────────────────────────────────────
+
+func TestRegimeAllowsEntry_EmptyAllowedAlwaysTrue(t *testing.T) {
+	if !regimeAllowsEntry(nil, "ranging") {
+		t.Error("nil AllowedRegimes should always allow entry")
+	}
+	if !regimeAllowsEntry([]string{}, "trending_up") {
+		t.Error("empty AllowedRegimes should always allow entry")
+	}
+}
+
+func TestRegimeAllowsEntry_MatchingLabel(t *testing.T) {
+	allowed := []string{"trending_up", "trending_down"}
+	if !regimeAllowsEntry(allowed, "trending_up") {
+		t.Error("trending_up should be allowed")
+	}
+	if !regimeAllowsEntry(allowed, "trending_down") {
+		t.Error("trending_down should be allowed")
+	}
+}
+
+func TestRegimeAllowsEntry_NonMatchingLabel(t *testing.T) {
+	allowed := []string{"trending_up", "trending_down"}
+	if regimeAllowsEntry(allowed, "ranging") {
+		t.Error("ranging should be blocked")
+	}
+}
+
+func TestRegimeAllowsEntry_EmptyCurrentAllowsWhenListNonEmpty(t *testing.T) {
+	// When regime field is empty (script disabled / not available), allow entry
+	// so existing strategies without regime are unaffected.
+	allowed := []string{"trending_up"}
+	if !regimeAllowsEntry(allowed, "") {
+		t.Error("empty regime string (script did not compute regime) should not block entry")
+	}
+}
+
+// ─── StrategyDecisionFields includes Regime ───────────────────────────────────
+
+func TestStrategyDecisionFields_RegimeRoundTrip(t *testing.T) {
+	sdf := StrategyDecisionFields{Regime: "trending_up"}
+	b, err := json.Marshal(sdf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out StrategyDecisionFields
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Regime != "trending_up" {
+		t.Errorf("expected trending_up, got %q", out.Regime)
+	}
+}
+
+func TestStrategyDecisionFields_RegimeOmitEmpty(t *testing.T) {
+	sdf := StrategyDecisionFields{}
+	b, err := json.Marshal(sdf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m["regime"]; ok {
+		t.Error("empty Regime should be omitted from JSON")
+	}
+}
+
+// ─── Config version bump ──────────────────────────────────────────────────────
+
+func TestCurrentConfigVersion_IsEleven(t *testing.T) {
+	if CurrentConfigVersion != 11 {
+		t.Errorf("expected CurrentConfigVersion=11, got %d", CurrentConfigVersion)
+	}
+}
+
+// ─── hot-reload: AllowedRegimes is soft, Regime is restart-required ───────────
+
+func TestHotReload_AllowedRegimesChangeIsAccepted(t *testing.T) {
+	cfg := minimalSpotConfig()
+	next := minimalSpotConfig()
+	next.Strategies[0].AllowedRegimes = []string{"trending_up"}
+	// validateHotReloadCompatible only checks shape, not per-strategy soft fields
+	if err := validateHotReloadCompatible(&cfg, &next); err != nil {
+		t.Fatalf("AllowedRegimes change should be compatible with hot-reload, got: %v", err)
+	}
+}
+
+func TestHotReload_RegimeConfigChangeRequiresRestart(t *testing.T) {
+	cfg := minimalSpotConfig()
+	next := minimalSpotConfig()
+	next.Regime = &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20.0}
+	if err := validateHotReloadCompatible(&cfg, &next); err == nil {
+		t.Fatal("Regime config change should require restart")
+	}
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+func minimalSpotConfig() Config {
+	return Config{
+		IntervalSeconds: 60,
+		Strategies: []StrategyConfig{
+			{
+				ID:             "test-spot-1",
+				Type:           "spot",
+				Platform:       "binanceus",
+				Script:         "shared_scripts/check_strategy.py",
+				Args:           []string{"sma_crossover", "BTC/USDT", "1h"},
+				Capital:        1000,
+				MaxDrawdownPct: 10,
+			},
+		},
+	}
+}

--- a/scheduler/regime_test.go
+++ b/scheduler/regime_test.go
@@ -134,6 +134,51 @@ func TestRegimeAllowsEntry_EmptyCurrentAllowsWhenListNonEmpty(t *testing.T) {
 	}
 }
 
+// ─── regimeBlocksOpen — close legs always pass through ──────────────────────
+
+func TestRegimeBlocksOpen_BlocksOpenWhenNoPosition(t *testing.T) {
+	allowed := []string{"trending_up"}
+	if !regimeBlocksOpen(allowed, "ranging", 0) {
+		t.Error("regime mismatch with posQty=0 should block the open")
+	}
+}
+
+func TestRegimeBlocksOpen_AllowsOpenWhenRegimeMatches(t *testing.T) {
+	allowed := []string{"trending_up"}
+	if regimeBlocksOpen(allowed, "trending_up", 0) {
+		t.Error("matching regime should not block")
+	}
+}
+
+func TestRegimeBlocksOpen_NeverBlocksWhenPositionExists(t *testing.T) {
+	// Regression for review point 1 (#546): close legs must pass through the
+	// regime gate even when the current regime is not in the allowed list.
+	// Otherwise a long-then-ranging scenario would silently skip the close
+	// signal, contradicting "existing positions are always managed by close
+	// paths regardless".
+	allowed := []string{"trending_up"}
+	if regimeBlocksOpen(allowed, "ranging", 1.0) {
+		t.Error("close leg (posQty>0) must never be blocked by regime gate")
+	}
+	if regimeBlocksOpen(allowed, "trending_down", 0.5) {
+		t.Error("close leg (posQty>0) must never be blocked even on opposite regime")
+	}
+	if regimeBlocksOpen(allowed, "", 1.0) {
+		// Empty current regime is also "allow"; combined with posQty>0 this is
+		// doubly safe but we still assert it.
+		t.Error("close leg (posQty>0) must never be blocked when regime is empty")
+	}
+}
+
+func TestRegimeBlocksOpen_EmptyAllowedNeverBlocks(t *testing.T) {
+	if regimeBlocksOpen(nil, "ranging", 0) {
+		t.Error("nil allowed list (no gate configured) must never block")
+	}
+	if regimeBlocksOpen([]string{}, "ranging", 0) {
+		t.Error("empty allowed list (no gate configured) must never block")
+	}
+}
+
 // ─── StrategyDecisionFields includes Regime ───────────────────────────────────
 
 func TestStrategyDecisionFields_RegimeRoundTrip(t *testing.T) {

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -299,6 +299,7 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 		PnL             float64                    `json:"pnl"`
 		PnLPct          float64                    `json:"pnl_pct"`
 		RiskState       RiskState                  `json:"risk_state"`
+		Regime          string                     `json:"regime,omitempty"`
 	}
 
 	type StatusResp struct {
@@ -356,6 +357,7 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 			PnL:             pnl,
 			PnLPct:          pnlPct,
 			RiskState:       s.RiskState,
+			Regime:          s.Regime,
 		}
 	}
 

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -106,6 +106,7 @@ type StrategyState struct {
 	OptionPositions map[string]*OptionPosition `json:"option_positions"`
 	TradeHistory    []Trade                    `json:"trade_history"`
 	RiskState       RiskState                  `json:"risk_state"`
+	Regime          string                     `json:"regime,omitempty"` // most recent regime label from check script (#482)
 	// ClosedPositions is an in-memory buffer of positions closed during the
 	// current cycle. SaveState appends these to the closed_positions table and
 	// clears the buffer on successful commit. Not serialized to JSON state

--- a/scheduler/strategy_composition.go
+++ b/scheduler/strategy_composition.go
@@ -15,6 +15,7 @@ type StrategyDecisionFields struct {
 	OpenAction      string   `json:"open_action,omitempty"`
 	CloseFraction   float64  `json:"close_fraction"`
 	CloseStrategy   string   `json:"close_strategy,omitempty"`
+	Regime          string   `json:"regime,omitempty"`
 }
 
 // PositionCtx is the optional state snapshot threaded into close evaluators


### PR DESCRIPTION
Closes #541

## Summary

- `config.go`: `RegimeConfig{Enabled, Period, ADXThreshold}`, `Config.Regime *RegimeConfig`, `StrategyConfig.AllowedRegimes []string`; `LoadConfig` defaults (period=14, threshold=20); `ValidateConfig` rejects unknown labels and invalid bounds
- `config_migration.go`: bump `CurrentConfigVersion` 10 → 11 (no data migration; empty defaults preserve legacy behavior exactly)
- `strategy_composition.go`: `Regime string` added to `StrategyDecisionFields` — one change propagates to all 5 result structs
- `regime.go`: `regimeAllowsEntry(allowed, current)` pure helper — allows when list is empty, current is empty, or current matches
- `main.go`: regime gate at 6 dispatch sites; `stratState.Regime` updated each cycle
- `state.go`: `StrategyState.Regime string` persisted with state
- `server.go`: `StratStatus.Regime` exposed in `/status` JSON
- `config_reload.go`: `AllowedRegimes` is soft-reloadable (mirrors `CloseStrategies`); `cfg.Regime` change requires restart (mirrors `Correlation`)

## Behavior

When `allowed_regimes` is empty or unset, behavior is bit-for-bit identical to before — all entries permitted. When set, entries are skipped and logged when `result.Regime` is not in the list. Existing positions are always managed by close paths regardless.

`regime: null` from `check_options.py` becomes `""` in the result struct, which `regimeAllowsEntry` treats as "always allow" — so options strategies are unaffected.

## Test plan

17 new tests in `regime_test.go`:
- `ValidateConfig` accepts valid/nil regimes, rejects unknown labels and invalid period/threshold
- `regimeAllowsEntry` empty list, matching, non-matching, empty-current cases
- `StrategyDecisionFields.Regime` JSON round-trip and omitempty
- `CurrentConfigVersion == 11`
- hot-reload: `AllowedRegimes` accepted, `Regime` config rejected

Full suite: `go -C scheduler test ./...` passes.

---
LLM: Claude Sonnet 4.6 (1M) | high