### PR TITLE
Backtester regime parity + --regime-* CLI flags

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -23,17 +23,17 @@ from storage import store_backtest_result
 # module of the same name.
 _close_registry = None
 
-# Regime module imported lazily so backtests without regime_enabled=True
+# Regime helper imported lazily so backtests without regime_enabled=True
 # don't pay the import cost.
-_regime_mod = None
+_ensure_regime_fn = None
 
 
 def _load_regime():
-    global _regime_mod
-    if _regime_mod is None:
+    global _ensure_regime_fn
+    if _ensure_regime_fn is None:
         from regime import ensure_regime_columns as _ensure_regime_columns
-        _regime_mod = _ensure_regime_columns
-    return _regime_mod
+        _ensure_regime_fn = _ensure_regime_columns
+    return _ensure_regime_fn
 
 
 def _load_close_registry():
@@ -359,11 +359,12 @@ class Backtester:
 
             # Regime gate: block new entries when the bar's regime isn't in the
             # allowed set. Existing positions are always managed by close paths.
+            # ``compute_regime`` initializes every row to ``"ranging"`` (warmup
+            # bars included), so bar_regime is always a non-empty label here.
             bar_regime = str(row.get("regime", "")) if self.regime_enabled else ""
             regime_blocked = (
                 self.regime_enabled
                 and bool(self.allowed_regimes)
-                and bar_regime != ""
                 and bar_regime not in self.allowed_regimes
             )
 

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -23,6 +23,18 @@ from storage import store_backtest_result
 # module of the same name.
 _close_registry = None
 
+# Regime module imported lazily so backtests without regime_enabled=True
+# don't pay the import cost.
+_regime_mod = None
+
+
+def _load_regime():
+    global _regime_mod
+    if _regime_mod is None:
+        from regime import ensure_regime_columns as _ensure_regime_columns
+        _regime_mod = _ensure_regime_columns
+    return _regime_mod
+
 
 def _load_close_registry():
     global _close_registry
@@ -161,7 +173,11 @@ class Backtester:
                  slippage_pct: float = 0.0005,
                  platform: str = "binanceus",
                  close_strategies: Optional[list[str]] = None,
-                 close_params: Optional[dict[str, dict]] = None):
+                 close_params: Optional[dict[str, dict]] = None,
+                 regime_enabled: bool = False,
+                 regime_period: int = 14,
+                 regime_adx_threshold: float = 20.0,
+                 allowed_regimes: Optional[list[str]] = None):
         """
         Args:
             initial_capital: Starting portfolio value.
@@ -193,6 +209,10 @@ class Backtester:
         self.slippage_pct = slippage_pct
         self.close_strategies = list(close_strategies or [])
         self.close_params = dict(close_params or {})
+        self.regime_enabled = regime_enabled
+        self.regime_period = regime_period
+        self.regime_adx_threshold = regime_adx_threshold
+        self.allowed_regimes = list(allowed_regimes or [])
         if self.close_strategies:
             _evaluate, list_strategies = _load_close_registry()
             available = set(list_strategies())
@@ -278,6 +298,13 @@ class Backtester:
             df["_open_action"] = open_actions.shift(1).fillna("none")
             df["_close_fraction"] = _max_close_fraction_series(df).shift(1).fillna(0.0)
 
+        # Regime: inject vectorized labels before the per-bar loop so each bar
+        # can gate new entries. Mirrors the live path: latest_regime(df) on the
+        # same OHLCV window → identical label by construction (same algorithm).
+        if self.regime_enabled and "regime" not in df.columns:
+            ensure_regime = _load_regime()
+            ensure_regime(df, period=self.regime_period, adx_threshold=self.regime_adx_threshold)
+
         has_open = "open" in df.columns
 
         cash = self.initial_capital
@@ -330,6 +357,16 @@ class Backtester:
             equity = cash + position * mark_price
             equity_curve.append({"date": idx, "equity": equity})
 
+            # Regime gate: block new entries when the bar's regime isn't in the
+            # allowed set. Existing positions are always managed by close paths.
+            bar_regime = str(row.get("regime", "")) if self.regime_enabled else ""
+            regime_blocked = (
+                self.regime_enabled
+                and bool(self.allowed_regimes)
+                and bar_regime != ""
+                and bar_regime not in self.allowed_regimes
+            )
+
             if uses_open_close:
                 col_close_fraction = float(row.get("_close_fraction", 0.0))
                 close_fraction = max(col_close_fraction, pending_close_fraction)
@@ -367,7 +404,7 @@ class Backtester:
                         initial_quantity = 0.0
                         entry_atr_value = 0.0
 
-                if open_action == "long" and position == 0:
+                if open_action == "long" and position == 0 and not regime_blocked:
                     effective_price = fill_price * (1 + self.slippage_pct)
                     commission = cash * self.commission_pct
                     available = cash - commission
@@ -380,7 +417,7 @@ class Backtester:
                     avg_cost = effective_price
                     initial_quantity = shares
                     entry_atr_value = self._stamp_entry_atr(atr_series, idx, effective_price)
-                elif open_action == "short" and position == 0:
+                elif open_action == "short" and position == 0 and not regime_blocked:
                     effective_price = fill_price * (1 - self.slippage_pct)
                     commission = cash * self.commission_pct
                     notional = cash - commission
@@ -405,7 +442,7 @@ class Backtester:
                     )
                 continue
 
-            if signal == 1 and position == 0:
+            if signal == 1 and position == 0 and not regime_blocked:
                 # BUY — go long with all available cash
                 effective_price = fill_price * (1 + self.slippage_pct)
                 commission = cash * self.commission_pct

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -101,6 +101,10 @@ def walk_forward_optimize(
     registry: str = "spot",
     platform: str = "binanceus",
     verbose: bool = True,
+    regime_enabled: bool = False,
+    regime_period: int = 14,
+    regime_adx_threshold: float = 20.0,
+    allowed_regimes: Optional[List[str]] = None,
 ) -> dict:
     """
     Walk-forward optimization.
@@ -140,7 +144,12 @@ def walk_forward_optimize(
         print(f"  Warmup bars per fold: {warmup}")
         print(f"  Optimizing: {optimize_metric}")
 
-    bt = Backtester(initial_capital=initial_capital, platform=platform)
+    bt = Backtester(
+        initial_capital=initial_capital, platform=platform,
+        regime_enabled=regime_enabled, regime_period=regime_period,
+        regime_adx_threshold=regime_adx_threshold,
+        allowed_regimes=allowed_regimes,
+    )
     window_results = []
 
     for fold in range(n_splits):

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -87,6 +87,10 @@ def run_single_backtest(
     htf_filter: bool = False,
     close_strategies: Optional[List[str]] = None,
     close_params: Optional[dict] = None,
+    regime_enabled: bool = False,
+    regime_period: int = 14,
+    regime_adx_threshold: float = 20.0,
+    allowed_regimes: Optional[List[str]] = None,
 ) -> Optional[dict]:
     """Run a single backtest and print results.
 
@@ -137,6 +141,10 @@ def run_single_backtest(
         initial_capital=capital, platform=platform,
         close_strategies=close_strategies,
         close_params=close_params,
+        regime_enabled=regime_enabled,
+        regime_period=regime_period,
+        regime_adx_threshold=regime_adx_threshold,
+        allowed_regimes=allowed_regimes,
     )
     results = bt.run(
         df_signals,
@@ -317,6 +325,18 @@ def _build_parser() -> argparse.ArgumentParser:
                         help="Per-evaluator params as JSON string, keyed by "
                              "evaluator name, e.g. "
                              "'{\"tp_at_pct\":{\"pct\":0.03}}'.")
+    parser.add_argument("--regime-enabled", action="store_true", default=False,
+                        help="Enable market regime detection. Injects vectorized regime "
+                             "column from shared_tools/regime.py before the per-bar loop, "
+                             "matching the live check-script contract (#482).")
+    parser.add_argument("--regime-period", type=int, default=14,
+                        help="ADX lookback period for regime detection (default: 14).")
+    parser.add_argument("--regime-adx-threshold", type=float, default=20.0,
+                        help="ADX threshold below which market is 'ranging' (default: 20.0).")
+    parser.add_argument("--allowed-regimes", action="append", dest="allowed_regimes",
+                        default=None, metavar="LABEL",
+                        help="Regime label to allow entries for (repeat for multiple). "
+                             "Empty = allow all. Valid: trending_up, trending_down, ranging.")
     return parser
 
 
@@ -342,7 +362,11 @@ def main():
                             registry=args.registry, platform=args.platform,
                             htf_filter=args.htf_filter,
                             close_strategies=args.close_strategies,
-                            close_params=close_params)
+                            close_params=close_params,
+                            regime_enabled=args.regime_enabled,
+                            regime_period=args.regime_period,
+                            regime_adx_threshold=args.regime_adx_threshold,
+                            allowed_regimes=args.allowed_regimes)
 
     elif args.mode == "compare":
         strategies = None if args.strategy == "all" else [args.strategy]

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -169,6 +169,10 @@ def run_all_strategies(
     htf_filter: bool = False,
     close_strategies: Optional[List[str]] = None,
     close_params: Optional[dict] = None,
+    regime_enabled: bool = False,
+    regime_period: int = 14,
+    regime_adx_threshold: float = 20.0,
+    allowed_regimes: Optional[List[str]] = None,
 ) -> list:
     """Run multiple strategies on one asset and compare."""
     reg = load_registry(registry)
@@ -184,6 +188,9 @@ def run_all_strategies(
             name, symbol, timeframe, since, capital,
             registry=registry, platform=platform, htf_filter=htf_filter,
             close_strategies=close_strategies, close_params=close_params,
+            regime_enabled=regime_enabled, regime_period=regime_period,
+            regime_adx_threshold=regime_adx_threshold,
+            allowed_regimes=allowed_regimes,
         )
         if result:
             all_results.append(result)
@@ -205,6 +212,10 @@ def run_multi_asset(
     htf_filter: bool = False,
     close_strategies: Optional[List[str]] = None,
     close_params: Optional[dict] = None,
+    regime_enabled: bool = False,
+    regime_period: int = 14,
+    regime_adx_threshold: float = 20.0,
+    allowed_regimes: Optional[List[str]] = None,
 ) -> dict:
     """Run strategies across multiple assets."""
     reg = load_registry(registry)
@@ -228,6 +239,9 @@ def run_multi_asset(
                 strat_name, symbol, timeframe, since, capital,
                 registry=registry, platform=platform, htf_filter=htf_filter,
                 close_strategies=close_strategies, close_params=close_params,
+                regime_enabled=regime_enabled, regime_period=regime_period,
+                regime_adx_threshold=regime_adx_threshold,
+                allowed_regimes=allowed_regimes,
             )
             if result:
                 results_by_asset[symbol].append(result)
@@ -245,6 +259,10 @@ def run_walk_forward(
     capital: float = 1000.0,
     registry: str = "spot",
     platform: str = "binanceus",
+    regime_enabled: bool = False,
+    regime_period: int = 14,
+    regime_adx_threshold: float = 20.0,
+    allowed_regimes: Optional[List[str]] = None,
 ) -> Optional[dict]:
     """Run walk-forward optimization for a strategy."""
     reg = load_registry(registry)
@@ -280,6 +298,10 @@ def run_walk_forward(
         registry=registry,
         platform=platform,
         verbose=True,
+        regime_enabled=regime_enabled,
+        regime_period=regime_period,
+        regime_adx_threshold=regime_adx_threshold,
+        allowed_regimes=allowed_regimes,
     )
 
     print(format_walk_forward_report(result))
@@ -334,7 +356,8 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--regime-adx-threshold", type=float, default=20.0,
                         help="ADX threshold below which market is 'ranging' (default: 20.0).")
     parser.add_argument("--allowed-regimes", action="append", dest="allowed_regimes",
-                        default=None, metavar="LABEL",
+                        default=None, choices=["trending_up", "trending_down", "ranging"],
+                        metavar="LABEL",
                         help="Regime label to allow entries for (repeat for multiple). "
                              "Empty = allow all. Valid: trending_up, trending_down, ranging.")
     return parser
@@ -375,7 +398,11 @@ def main():
                            registry=args.registry, platform=args.platform,
                            htf_filter=args.htf_filter,
                            close_strategies=args.close_strategies,
-                           close_params=close_params)
+                           close_params=close_params,
+                           regime_enabled=args.regime_enabled,
+                           regime_period=args.regime_period,
+                           regime_adx_threshold=args.regime_adx_threshold,
+                           allowed_regimes=args.allowed_regimes)
 
     elif args.mode == "multi":
         strategies = None if args.strategy == "all" else [args.strategy]
@@ -385,18 +412,30 @@ def main():
                         registry=args.registry, platform=args.platform,
                         htf_filter=args.htf_filter,
                         close_strategies=args.close_strategies,
-                        close_params=close_params)
+                        close_params=close_params,
+                        regime_enabled=args.regime_enabled,
+                        regime_period=args.regime_period,
+                        regime_adx_threshold=args.regime_adx_threshold,
+                        allowed_regimes=args.allowed_regimes)
 
     elif args.mode == "optimize":
         if args.strategy == "all":
             for strat in reg.list_strategies():
                 run_walk_forward(strat, args.symbol, args.timeframe,
                                  args.since, args.splits, args.capital,
-                                 registry=args.registry, platform=args.platform)
+                                 registry=args.registry, platform=args.platform,
+                                 regime_enabled=args.regime_enabled,
+                                 regime_period=args.regime_period,
+                                 regime_adx_threshold=args.regime_adx_threshold,
+                                 allowed_regimes=args.allowed_regimes)
         else:
             run_walk_forward(args.strategy, args.symbol, args.timeframe,
                              args.since, args.splits, args.capital,
-                             registry=args.registry, platform=args.platform)
+                             registry=args.registry, platform=args.platform,
+                             regime_enabled=args.regime_enabled,
+                             regime_period=args.regime_period,
+                             regime_adx_threshold=args.regime_adx_threshold,
+                             allowed_regimes=args.allowed_regimes)
 
 
 if __name__ == "__main__":

--- a/backtest/tests/test_backtester_regime.py
+++ b/backtest/tests/test_backtester_regime.py
@@ -1,0 +1,228 @@
+"""
+Tests for regime detection integration in Backtester (issue #482/#543).
+
+Verifies:
+- Vectorized regime column computed before Backtester.run() via ensure_regime_columns.
+- Entry gating: signals blocked when bar's regime not in allowed_regimes.
+- Live↔backtest parity: latest_regime(df) and compute_regime(df).iloc[-1]
+  produce identical labels for the same OHLCV window.
+"""
+import sys
+import pathlib
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / "shared_tools"))
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from backtester import Backtester
+from regime import compute_regime, latest_regime, ensure_regime_columns
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+
+def _uptrend_df(n: int = 100) -> pd.DataFrame:
+    """Monotonic uptrend — ADX will be high, +DI >> -DI → trending_up."""
+    close = np.linspace(100.0, 200.0, n)
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    return pd.DataFrame(
+        {"open": close, "high": close + 0.5, "low": close - 0.5,
+         "close": close, "volume": 1000.0},
+        index=idx,
+    )
+
+
+def _ranging_df(n: int = 100) -> pd.DataFrame:
+    """Flat prices — ADX stays near 0 → ranging."""
+    close = np.full(n, 100.0)
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    return pd.DataFrame(
+        {"open": close, "high": close + 0.05, "low": close - 0.05,
+         "close": close, "volume": 1000.0},
+        index=idx,
+    )
+
+
+def _signal_df(df: pd.DataFrame, *, buy_at: int = 30) -> pd.DataFrame:
+    """Attach a signal column: buy at bar buy_at, hold rest."""
+    out = df.copy()
+    out["signal"] = 0
+    out.iloc[buy_at, out.columns.get_loc("signal")] = 1
+    return out
+
+
+# ─── ensure_regime_columns integration ───────────────────────────────────────
+
+
+def test_ensure_regime_columns_adds_regime_column():
+    df = _uptrend_df()
+    out = ensure_regime_columns(df)
+    assert "regime" in out.columns
+    assert "regime_score" in out.columns
+
+
+def test_ensure_regime_columns_uptrend_labels_trending_up():
+    df = _uptrend_df(n=100)
+    out = ensure_regime_columns(df, period=14, adx_threshold=20.0)
+    assert out["regime"].iloc[-1] == "trending_up"
+
+
+def test_ensure_regime_columns_ranging_labels_ranging():
+    df = _ranging_df(n=100)
+    out = ensure_regime_columns(df, period=14, adx_threshold=20.0)
+    assert out["regime"].iloc[-1] == "ranging"
+
+
+# ─── Backtester regime constructor params ─────────────────────────────────────
+
+
+def test_backtester_accepts_regime_params():
+    bt = Backtester(
+        initial_capital=1000,
+        commission_pct=0,
+        slippage_pct=0,
+        regime_enabled=True,
+        regime_period=14,
+        regime_adx_threshold=20.0,
+        allowed_regimes=["trending_up"],
+    )
+    assert bt.regime_enabled is True
+    assert bt.regime_period == 14
+    assert bt.regime_adx_threshold == 20.0
+    assert bt.allowed_regimes == ["trending_up"]
+
+
+def test_backtester_regime_defaults():
+    bt = Backtester(initial_capital=1000, commission_pct=0, slippage_pct=0)
+    assert bt.regime_enabled is False
+    assert bt.allowed_regimes == []
+
+
+# ─── Regime gating: uptrend df + trending_up allowed → entries pass ───────────
+
+
+def test_regime_gate_allows_entry_when_regime_matches():
+    df = _uptrend_df(n=100)
+    ensure_regime_columns(df, period=14, adx_threshold=20.0)
+    df_sig = _signal_df(df, buy_at=50)
+
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, allowed_regimes=["trending_up"],
+    )
+    result = bt.run(df_sig, save=False)
+    # Bar 50 should be trending_up (well past warmup on an uptrend) — entry allowed
+    assert result["total_trades"] >= 1, "Expected at least one trade when regime matches"
+
+
+# ─── Regime gating: uptrend df + ranging-only gate → entries blocked ──────────
+
+
+def test_regime_gate_blocks_entry_when_regime_mismatches():
+    df = _uptrend_df(n=100)
+    ensure_regime_columns(df, period=14, adx_threshold=20.0)
+    df_sig = _signal_df(df, buy_at=50)
+
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, allowed_regimes=["ranging"],
+    )
+    result = bt.run(df_sig, save=False)
+    # Bar 50 is trending_up, not ranging → entry blocked
+    assert result["total_trades"] == 0, "Expected no trades when regime gate blocks entry"
+
+
+# ─── Regime gate doesn't affect close paths ───────────────────────────────────
+
+
+def test_regime_gate_does_not_close_open_position():
+    """Once a position is open, a regime mismatch must not force-close it.
+
+    The backtester shifts signals by 1 bar (signal on bar N executes at bar N+1).
+    So the entry fires at bar 51. We set regime to trending_up through bar 51
+    (entry allowed) then ranging at bar 52+ (position already open — not force-closed).
+    """
+    df = _uptrend_df(n=100)
+    ensure_regime_columns(df, period=14, adx_threshold=20.0)
+    df_sig = df.copy()
+    df_sig["signal"] = 0
+    # Signal at bar 50 → executes at bar 51's open (next-bar execution model)
+    df_sig.iloc[50, df_sig.columns.get_loc("signal")] = 1
+    # Keep trending_up through bar 51 so the shifted entry passes the gate;
+    # regime becomes ranging at bar 52+, but the position should be held.
+    df_sig["regime"] = "trending_up"
+    df_sig.iloc[52:, df_sig.columns.get_loc("regime")] = "ranging"
+
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, allowed_regimes=["trending_up"],
+    )
+    result = bt.run(df_sig, save=False)
+    # Position opened at bar 51, held to end (no sell signal) → 1 trade
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] > 0
+
+
+# ─── Empty allowed_regimes = allow all ────────────────────────────────────────
+
+
+def test_regime_enabled_empty_allowed_allows_all():
+    df = _uptrend_df(n=100)
+    ensure_regime_columns(df, period=14, adx_threshold=20.0)
+    df_sig = _signal_df(df, buy_at=50)
+
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, allowed_regimes=[],  # empty = allow all
+    )
+    result = bt.run(df_sig, save=False)
+    assert result["total_trades"] >= 1
+
+
+# ─── Live↔backtest parity ─────────────────────────────────────────────────────
+
+
+def test_parity_latest_regime_matches_compute_regime_last_bar():
+    """
+    Parity test: latest_regime(df) and compute_regime(df).iloc[-1] must
+    produce identical labels for the same OHLCV window.
+    This is guaranteed by design (both call the same _adx_components logic),
+    but this test makes the contract explicit and regression-guards it.
+    """
+    df = _uptrend_df(n=100)
+    live_result = latest_regime(df, period=14, adx_threshold=20.0)
+    backtest_series = compute_regime(df, period=14, adx_threshold=20.0)
+    backtest_last = backtest_series.iloc[-1]
+
+    assert live_result["regime"] == backtest_last["regime"], (
+        f"Parity violation: live={live_result['regime']}, "
+        f"backtest last bar={backtest_last['regime']}"
+    )
+    assert abs(live_result["score"] - float(backtest_last["regime_score"])) < 1e-9, (
+        "Score mismatch between live and backtest"
+    )
+
+
+def test_parity_ranging_df():
+    df = _ranging_df(n=100)
+    live = latest_regime(df, period=14, adx_threshold=20.0)
+    bt_last = compute_regime(df, period=14, adx_threshold=20.0).iloc[-1]
+    assert live["regime"] == bt_last["regime"]
+
+
+# ─── Regime disabled = no behavior change ─────────────────────────────────────
+
+
+def test_regime_disabled_does_not_block_entries():
+    df = _ranging_df(n=100)  # ranging would block if regime gating were on
+    df_sig = _signal_df(df, buy_at=50)
+
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=False, allowed_regimes=["trending_up"],
+    )
+    result = bt.run(df_sig, save=False)
+    assert result["total_trades"] >= 1, "Disabled regime gate must not block entries"


### PR DESCRIPTION
Closes #543

## Summary

- `backtest/backtester.py`: `Backtester()` adds `regime_enabled`, `regime_period`, `regime_adx_threshold`, `allowed_regimes` params. When enabled, `ensure_regime_columns()` injects vectorized regime labels before the per-bar loop (deferred import, no cost when disabled). Per-bar gate blocks new entries when `bar_regime ∉ allowed_regimes`; close paths always run.
- `backtest/run_backtest.py`: `--regime-enabled`, `--regime-period`, `--regime-adx-threshold`, `--allowed-regimes` CLI flags (mirrors `--close-strategy`/`--close-params` pattern). Threaded into `run_single_backtest()` → `Backtester()`.

## Parity guarantee

`latest_regime(df)` (live check-script path) and `compute_regime(df).iloc[-1]` (backtester path) call the same `_adx_components` Wilder smoothing function. Labels are identical for the same OHLCV window by construction — the parity test makes this explicit.

## Note on execution model

The backtester shifts signals by 1 bar (signal on bar N → executes at bar N+1). The regime gate reads `row["regime"]` at the execution bar, so a regime change between signal-bar and execution-bar can block an entry — matching live behavior where the check script reads the regime at execution time.

## Test plan

12 new tests in `backtest/tests/test_backtester_regime.py`:
- `ensure_regime_columns` integration
- `Backtester` constructor params and defaults
- Entry gate: match / mismatch / empty-allowed / disabled
- Regime mismatch doesn't close open positions
- Live↔backtest parity: labels and scores match for uptrend and ranging dfs

Full suite: `.venv/bin/python3 -m pytest backtest/tests/ shared_tools/ shared_strategies/ -q` → 608 passed.

---
LLM: Claude Sonnet 4.6 (1M) | high