### PR TITLE
check_options.py: regime detection from underlying OHLCV

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1268,6 +1268,7 @@ func main() {
 					case "options":
 						if result, signalStr, ok := runOptionsCheck(sc, posJSON, logger); ok {
 							mu.Lock()
+							stratState.Regime = result.Regime
 							var harvestDetails []string
 							trades, detail, harvestDetails = executeOptionsResult(sc, stratState, result, signalStr, logger)
 							mu.Unlock()

--- a/scheduler/options.go
+++ b/scheduler/options.go
@@ -53,6 +53,7 @@ type OptionsResult struct {
 	SpotPrice  float64         `json:"spot_price"`
 	Actions    []OptionsAction `json:"actions"`
 	IVRank     float64         `json:"iv_rank"`
+	Regime     string          `json:"regime,omitempty"`
 	Timestamp  string          `json:"timestamp"`
 	Error      string          `json:"error,omitempty"`
 }

--- a/shared_scripts/check_options.py
+++ b/shared_scripts/check_options.py
@@ -18,9 +18,15 @@ from datetime import datetime, timezone
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.dirname(_THIS_DIR)
 sys.path.insert(0, _REPO_ROOT)
+sys.path.insert(0, os.path.join(_REPO_ROOT, "shared_tools"))
+
+from regime import latest_regime
 
 MAX_POSITIONS_PER_STRATEGY = 4
 MIN_SCORE_THRESHOLD = 0.3
+REGIME_TIMEFRAME = "4h"
+REGIME_LIMIT = 100
+REGIME_MIN_BARS = 30
 
 
 # ── adapter loader ───────────────────────────────────────────────────────────
@@ -59,6 +65,52 @@ def _fetch_ohlcv_closes(underlying, timeframe, limit, min_len, adapter=None):
             return None
         return [c[4] for c in ohlcv]
     except Exception:
+        return None
+
+
+def _fetch_ohlcv_df(underlying, timeframe, limit, min_len, adapter=None):
+    """Fetch OHLCV rows as a pandas DataFrame for regime detection.
+
+    Uses adapter.get_ohlcv when available (Robinhood stocks, OKX), otherwise
+    falls back to BinanceUS ccxt. Returns None when the upstream fetch fails or
+    produces fewer than min_len bars (regime requires ~2*ADX_period for warmup).
+    """
+    rows = None
+    if adapter is not None:
+        ohlcv_fn = getattr(adapter, "get_ohlcv", None)
+        if ohlcv_fn is not None:
+            try:
+                rows = ohlcv_fn(underlying, timeframe, limit)
+            except Exception as e:
+                print(f"adapter.get_ohlcv failed: {e}", file=sys.stderr)
+                rows = None
+    if not rows:
+        try:
+            import ccxt
+            exchange = ccxt.binanceus({"enableRateLimit": True})
+            rows = exchange.fetch_ohlcv(f"{underlying}/USDT", timeframe, limit=limit)
+        except Exception as e:
+            print(f"BinanceUS OHLCV fetch failed: {e}", file=sys.stderr)
+            return None
+    if not rows or len(rows) < min_len:
+        return None
+    try:
+        import pandas as pd
+        df = pd.DataFrame(rows, columns=["timestamp", "open", "high", "low", "close", "volume"])
+        return df
+    except Exception as e:
+        print(f"OHLCV DataFrame construction failed: {e}", file=sys.stderr)
+        return None
+
+
+def _regime_label_from_df(df):
+    """Return the regime string label, or None if df is None / too short / errors."""
+    if df is None or len(df) < REGIME_MIN_BARS:
+        return None
+    try:
+        return latest_regime(df)["regime"]
+    except Exception as e:
+        print(f"Regime detection failed: {e}", file=sys.stderr)
         return None
 
 
@@ -460,6 +512,10 @@ def main():
 
         vol_annual, iv_rank = adapter.get_vol_metrics(underlying)
 
+        regime_df = _fetch_ohlcv_df(underlying, REGIME_TIMEFRAME, REGIME_LIMIT,
+                                    REGIME_MIN_BARS, adapter=adapter)
+        regime_label = _regime_label_from_df(regime_df)
+
         evaluate_fn = STRATEGY_MAP[strategy_name]
         signal, actions, iv_rank = evaluate_fn(
             underlying, spot_price, vol_annual, iv_rank,
@@ -488,7 +544,7 @@ def main():
             "spot_price": round(spot_price, 2),
             "actions": scored_actions,
             "iv_rank": round(iv_rank, 1),
-            "regime": None,
+            "regime": regime_label,
             "platform": platform,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }

--- a/shared_scripts/test_regime_wiring.py
+++ b/shared_scripts/test_regime_wiring.py
@@ -1,11 +1,11 @@
 """Tests for regime injection contract in check scripts.
 
-Verifies the regime injection pattern used by all 5 standard check scripts:
+Verifies the regime injection pattern used by all 6 standard check scripts:
   - latest_regime() is importable via shared_tools sys.path
   - regime payload is JSON-serializable (no NaN/Inf; SafeEncoder compat)
   - strip_unsupported_position_context drops "regime" for non-aware strategies
   - regime payload can safely be merged into strategy_params (even when None)
-  - check_options.py emits regime: null (tested via source inspection)
+  - check_options.py computes a regime label from underlying OHLCV (#544)
 """
 
 import json
@@ -145,13 +145,74 @@ def test_strip_unsupported_keeps_regime_for_aware_function():
     assert stripped["rsi_period"] == 14
 
 
-# ─── check_options.py emits regime: null ─────────────────────────────────────
+# ─── check_options.py regime computation (#544) ───────────────────────────────
 
 
-def test_check_options_source_emits_regime_null():
-    """check_options.py must emit 'regime': None (null in JSON) in its output paths."""
+def _load_check_options_module():
+    """Import shared_scripts/check_options.py as a module without executing main()."""
     src_path = pathlib.Path(__file__).parent / "check_options.py"
-    source = src_path.read_text()
-    assert '"regime"' in source or "'regime'" in source, (
-        "check_options.py does not emit a 'regime' field — add \"'regime': None\" to all output dicts"
-    )
+    spec = importlib.util.spec_from_file_location("_check_options_under_test", src_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_check_options_regime_label_from_uptrend_df():
+    """_regime_label_from_df returns a valid label for a sufficient uptrend df."""
+    module = _load_check_options_module()
+    df = _make_uptrend_df(100)
+    label = module._regime_label_from_df(df)
+    assert label in ("trending_up", "trending_down", "ranging")
+
+
+def test_check_options_regime_label_from_short_df_is_none():
+    """_regime_label_from_df returns None when the df has fewer than min bars (warmup)."""
+    module = _load_check_options_module()
+    df = _make_uptrend_df(10)
+    assert module._regime_label_from_df(df) is None
+
+
+def test_check_options_regime_label_from_none_df_is_none():
+    """_regime_label_from_df tolerates a None df (fetch failure path)."""
+    module = _load_check_options_module()
+    assert module._regime_label_from_df(None) is None
+
+
+def test_check_options_fetch_ohlcv_df_uses_adapter_when_available():
+    """_fetch_ohlcv_df prefers adapter.get_ohlcv when present and returns a DataFrame."""
+    module = _load_check_options_module()
+
+    class StubAdapter:
+        def __init__(self, rows):
+            self._rows = rows
+            self.calls = []
+
+        def get_ohlcv(self, symbol, timeframe, limit):
+            self.calls.append((symbol, timeframe, limit))
+            return self._rows
+
+    rows = [
+        [i * 1000, 100.0 + i, 101.0 + i, 99.0 + i, 100.5 + i, 1000.0]
+        for i in range(50)
+    ]
+    adapter = StubAdapter(rows)
+    df = module._fetch_ohlcv_df("BTC", "4h", 100, 30, adapter=adapter)
+    assert df is not None
+    assert len(df) == 50
+    assert {"high", "low", "close"}.issubset(df.columns)
+    assert adapter.calls == [("BTC", "4h", 100)]
+
+
+def test_check_options_fetch_ohlcv_df_short_returns_none():
+    """_fetch_ohlcv_df returns None when adapter rows are below min_len (no fallback to ccxt)."""
+    module = _load_check_options_module()
+
+    class StubAdapter:
+        def get_ohlcv(self, symbol, timeframe, limit):
+            return [[i * 1000, 100.0, 101.0, 99.0, 100.5, 1000.0] for i in range(5)]
+
+    # Adapter returned 5 bars; min_len is 30 → expect None (without ccxt fallback,
+    # since adapter explicitly returned data — empty/None would fall back).
+    # Current behavior: short non-empty rows do NOT trigger fallback; they short-circuit to None.
+    df = module._fetch_ohlcv_df("BTC", "4h", 100, 30, adapter=StubAdapter())
+    assert df is None


### PR DESCRIPTION
Closes #544

Replaces the schema-only `"regime": null` placeholder with a real ADX-derived regime label, bringing `check_options.py` to parity with the spot/perps/futures check scripts.

## Summary
- New `_fetch_ohlcv_df` helper — uses `adapter.get_ohlcv` when available, else BinanceUS ccxt fallback (mirrors `_fetch_ohlcv_closes`).
- New `_regime_label_from_df` helper wraps `latest_regime` with None-tolerant handling for warmup/fetch-failure paths.
- `OptionsResult.Regime` added on the Go side; `main.go` options dispatch records it on `StrategyState`, so `trade.Regime` propagates through the existing `options.go` wiring to DB rows/Discord/Telegram output.
- Regression tests in `test_regime_wiring.py` cover uptrend label, short/None df fallbacks, and adapter-preferred fetch path.

## Test plan
- [x] `.venv/bin/python3 -m pytest shared_scripts/test_regime_wiring.py -v` — 13 passed
- [x] `.venv/bin/python3 -m pytest shared_tools/ shared_strategies/` — 503 passed
- [x] `go -C scheduler build .` + `go -C scheduler test ./...` — ok
- [x] `gofmt -l scheduler/` — clean

## Not included
Options-side regime gating (`regimeBlocksOpen`) intentionally deferred — issue scope was emission, and options signal semantics (spreads) warrant a separate design discussion.

---
LLM: Claude Opus 4.7 (1M) | medium | Harness: anthropics/claude-code-action@v1