### PR TITLE
check_options.py: deduplicate OHLCV fetch helpers

### DIFF
--- a/shared_scripts/check_options.py
+++ b/shared_scripts/check_options.py
@@ -50,24 +50,6 @@ def _load_adapter(platform: str):
 
 # ── shared helpers ────────────────────────────────────────────────────────────
 
-def _fetch_ohlcv_closes(underlying, timeframe, limit, min_len, adapter=None):
-    """Fetch OHLCV closing prices. Uses adapter if available, else BinanceUS."""
-    # Try adapter's get_ohlcv_closes if available (e.g., Robinhood stocks)
-    if adapter is not None:
-        ohlcv_closes_fn = getattr(adapter, 'get_ohlcv_closes', None)
-        if ohlcv_closes_fn is not None:
-            return ohlcv_closes_fn(underlying, timeframe, limit, min_len)
-    try:
-        import ccxt
-        exchange = ccxt.binanceus({"enableRateLimit": True})
-        ohlcv = exchange.fetch_ohlcv(f"{underlying}/USDT", timeframe, limit=limit)
-        if not ohlcv or len(ohlcv) < min_len:
-            return None
-        return [c[4] for c in ohlcv]
-    except Exception:
-        return None
-
-
 def _fetch_ohlcv_df(underlying, timeframe, limit, min_len, adapter=None):
     """Fetch OHLCV rows as a pandas DataFrame for regime detection.
 
@@ -222,9 +204,10 @@ def score_new_trade(proposed_action, existing_positions, spot_price):
 def evaluate_momentum_options(underlying, spot_price, vol_annual, iv_rank,
                                existing_positions, spot_positions, adapter):
     try:
-        closes = _fetch_ohlcv_closes(underlying, "4h", 100, 30, adapter=adapter)
-        if closes is None:
+        df = _fetch_ohlcv_df(underlying, "4h", 100, 30, adapter=adapter)
+        if df is None:
             return 0, [], iv_rank
+        closes = df["close"].tolist()
 
         roc_period = 14
         threshold = 5.0


### PR DESCRIPTION
## Summary

- Removes `_fetch_ohlcv_closes` from `check_options.py` — a duplicate of the fetch+fallback logic already in `_fetch_ohlcv_df`
- Updates `evaluate_momentum_options` to call `_fetch_ohlcv_df` and slice `df["close"].tolist()`, eliminating the second code path
- No behavior change: OKX/Robinhood `get_ohlcv_closes` was a thin wrapper around `get_ohlcv`; Deribit/IBKR already fell back to BinanceUS via both paths

Closes #552

---
LLM: Claude Opus 4.7 | medium