### PR TITLE
ValidateConfig: reject allowed_regimes on options + warn when regime disabled

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -866,6 +866,12 @@ func ValidateConfig(cfg *Config) error {
 				errs = append(errs, fmt.Sprintf("%s: allowed_regimes[%d] unknown label %q (valid: trending_up, trending_down, ranging)", prefix, j, label))
 			}
 		}
+		// The regime gate is not wired at the options dispatch site (#553), so
+		// allowed_regimes is a silent no-op for options strategies. Reject it
+		// here until the gate is properly implemented for the multi-position model.
+		if sc.Type == "options" && len(sc.AllowedRegimes) > 0 {
+			errs = append(errs, fmt.Sprintf("%s: allowed_regimes is not enforced for type=options (gate not wired at options dispatch; see issue #553)", prefix))
+		}
 
 		// Live-mode futures require TopStep API credentials.
 		if sc.Type == "futures" {
@@ -1235,6 +1241,17 @@ func ValidateConfig(cfg *Config) error {
 		}
 		if cfg.Regime.ADXThreshold <= 0 || cfg.Regime.ADXThreshold > 100 {
 			errs = append(errs, fmt.Sprintf("regime.adx_threshold must be in (0, 100], got %g", cfg.Regime.ADXThreshold))
+		}
+	}
+
+	// Warn when allowed_regimes is configured but regime.enabled=false — the
+	// gate reads result.Regime from the check script output, which requires
+	// regime detection to be running. Without it the gate is a no-op.
+	if cfg.Regime == nil || !cfg.Regime.Enabled {
+		for _, sc := range cfg.Strategies {
+			if len(sc.AllowedRegimes) > 0 {
+				fmt.Printf("[WARN] %s: allowed_regimes is set but regime.enabled=false — gate is a no-op until regime detection is enabled\n", sc.ID)
+			}
 		}
 	}
 

--- a/scheduler/regime_test.go
+++ b/scheduler/regime_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -219,6 +223,71 @@ func TestCurrentConfigVersion_IsEleven(t *testing.T) {
 	}
 }
 
+// ─── ValidateConfig — AllowedRegimes on options strategies ───────────────────
+
+func TestValidateConfig_AllowedRegimes_RejectsOnOptions(t *testing.T) {
+	cfg := minimalOptionsConfig()
+	cfg.Strategies[0].AllowedRegimes = []string{"trending_up"}
+	if err := ValidateConfig(&cfg); err == nil {
+		t.Fatal("allowed_regimes on options strategy should fail validation (gate not wired)")
+	}
+}
+
+func TestValidateConfig_AllowedRegimes_AcceptsEmptyOnOptions(t *testing.T) {
+	cfg := minimalOptionsConfig()
+	cfg.Strategies[0].AllowedRegimes = nil
+	if err := ValidateConfig(&cfg); err != nil {
+		t.Fatalf("nil allowed_regimes on options strategy should be valid, got: %v", err)
+	}
+}
+
+func TestValidateConfig_AllowedRegimes_AcceptsOnSpotWithRegimeEnabled(t *testing.T) {
+	cfg := minimalSpotConfig()
+	cfg.Regime = &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20.0}
+	cfg.Strategies[0].AllowedRegimes = []string{"trending_up"}
+	if err := ValidateConfig(&cfg); err != nil {
+		t.Fatalf("allowed_regimes on spot with regime enabled should pass, got: %v", err)
+	}
+}
+
+// captureStdout redirects os.Stdout for the duration of fn and returns what was printed.
+func captureStdout(fn func()) string {
+	orig := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	fn()
+	w.Close()
+	os.Stdout = orig
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestValidateConfig_AllowedRegimes_WarnsWhenRegimeDisabled(t *testing.T) {
+	cfg := minimalSpotConfig()
+	cfg.Regime = nil // disabled
+	cfg.Strategies[0].AllowedRegimes = []string{"trending_up"}
+	var out string
+	out = captureStdout(func() {
+		_ = ValidateConfig(&cfg)
+	})
+	if !strings.Contains(out, "[WARN]") || !strings.Contains(out, "regime.enabled=false") {
+		t.Fatalf("expected [WARN] about regime.enabled=false, got: %q", out)
+	}
+}
+
+func TestValidateConfig_AllowedRegimes_NoWarnWhenRegimeEnabled(t *testing.T) {
+	cfg := minimalSpotConfig()
+	cfg.Regime = &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20.0}
+	cfg.Strategies[0].AllowedRegimes = []string{"trending_up"}
+	out := captureStdout(func() {
+		_ = ValidateConfig(&cfg)
+	})
+	if strings.Contains(out, "regime.enabled=false") {
+		t.Fatalf("unexpected [WARN] about regime.enabled=false when regime is enabled, got: %q", out)
+	}
+}
+
 // ─── hot-reload: AllowedRegimes is soft, Regime is restart-required ───────────
 
 func TestHotReload_AllowedRegimesChangeIsAccepted(t *testing.T) {
@@ -252,6 +321,23 @@ func minimalSpotConfig() Config {
 				Platform:       "binanceus",
 				Script:         "shared_scripts/check_strategy.py",
 				Args:           []string{"sma_crossover", "BTC/USDT", "1h"},
+				Capital:        1000,
+				MaxDrawdownPct: 10,
+			},
+		},
+	}
+}
+
+func minimalOptionsConfig() Config {
+	return Config{
+		IntervalSeconds: 60,
+		Strategies: []StrategyConfig{
+			{
+				ID:             "test-options-1",
+				Type:           "options",
+				Platform:       "deribit",
+				Script:         "shared_scripts/check_options.py",
+				Args:           []string{"sell_covered_call", "BTC", "--platform=deribit"},
 				Capital:        1000,
 				MaxDrawdownPct: 10,
 			},


### PR DESCRIPTION
## Summary

Addresses two silent no-op gaps in regime gating flagged in #553 (review of PR #546):

1. **Hard error for `allowed_regimes` on options strategies** — the regime gate is absent at the `case "options":` dispatch site in `main.go`. `ValidateConfig` now rejects non-empty `allowed_regimes` on `type=options` strategies so operators get a startup error rather than a silent config that does nothing. This will be removed once the gate is wired for the multi-position options model.

2. **`[WARN]` when `regime.enabled=false` but `allowed_regimes` is set** — when regime detection is disabled, the gate cannot read a regime label from the check script output and becomes a no-op. A per-strategy `[WARN]` is now printed at startup for each affected strategy so operators know to either enable regime detection or remove the field.

Five new tests in `regime_test.go`:
1. `TestValidateConfig_AllowedRegimes_RejectsOnOptions`
2. `TestValidateConfig_AllowedRegimes_AcceptsEmptyOnOptions`
3. `TestValidateConfig_AllowedRegimes_AcceptsOnSpotWithRegimeEnabled`
4. `TestValidateConfig_AllowedRegimes_WarnsWhenRegimeDisabled`
5. `TestValidateConfig_AllowedRegimes_NoWarnWhenRegimeEnabled`

Plus `minimalOptionsConfig()` helper mirroring `minimalSpotConfig()`.

Closes #553

---
LLM: Claude Opus 4.7 | high