### PR TITLE
regime_alerts_test.go: LoadState round-trip + per-file stamping coverage

### DIFF
--- a/scheduler/regime_alerts_test.go
+++ b/scheduler/regime_alerts_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // ─── Trade.Regime field ───────────────────────────────────────────────────────
@@ -174,6 +175,180 @@ func TestInsertTrade_EmptyRegimeStored(t *testing.T) {
 	if regime != "" {
 		t.Errorf("expected empty regime, got %q", regime)
 	}
+}
+
+// ─── LoadState / QueryTradeHistory Scan round-trip ───────────────────────────
+
+// TestRegime_LoadStateAndQueryTradeHistoryRoundTrip locks the Scan column order
+// for the regime field. A misordered Scan (e.g. regime ↔ details swap) would
+// pass the raw-SQL InsertTrade tests above but corrupt application reads here.
+func TestRegime_LoadStateAndQueryTradeHistoryRoundTrip(t *testing.T) {
+	db := mustOpenTestDB(t)
+	defer db.Close()
+
+	// Seed app_state and strategies so LoadState finds the strategy.
+	if _, err := db.db.Exec("INSERT INTO app_state (id, cycle_count) VALUES (1, 1)"); err != nil {
+		t.Fatalf("seed app_state: %v", err)
+	}
+	if _, err := db.db.Exec("INSERT INTO strategies (id, type, platform, cash, initial_capital) VALUES (?, ?, ?, ?, ?)",
+		"s1", "perps", "hyperliquid", 1000.0, 1000.0); err != nil {
+		t.Fatalf("seed strategy: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	trade1 := Trade{Symbol: "BTC", Side: "buy", Quantity: 0.1, Price: 50000, Value: 5000, TradeType: "perps", Regime: "trending_up", Timestamp: now}
+	trade2 := Trade{Symbol: "BTC", Side: "sell", Quantity: 0.1, Price: 51000, Value: 5100, TradeType: "perps", Regime: "", Timestamp: now.Add(time.Second)}
+	if err := db.InsertTrade("s1", trade1); err != nil {
+		t.Fatalf("InsertTrade trade1: %v", err)
+	}
+	if err := db.InsertTrade("s1", trade2); err != nil {
+		t.Fatalf("InsertTrade trade2: %v", err)
+	}
+
+	// LoadState path (ASC order).
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	trades := loaded.Strategies["s1"].TradeHistory
+	if len(trades) != 2 {
+		t.Fatalf("LoadState trade count = %d; want 2", len(trades))
+	}
+	if got := trades[0].Regime; got != "trending_up" {
+		t.Errorf("LoadState trades[0].Regime = %q; want trending_up", got)
+	}
+	if got := trades[1].Regime; got != "" {
+		t.Errorf("LoadState trades[1].Regime = %q; want empty", got)
+	}
+
+	// QueryTradeHistory path (DESC order — newest first).
+	history, total, err := db.QueryTradeHistory("s1", "", time.Time{}, time.Time{}, 50, 0)
+	if err != nil {
+		t.Fatalf("QueryTradeHistory: %v", err)
+	}
+	if total != 2 || len(history) != 2 {
+		t.Fatalf("QueryTradeHistory total=%d len=%d; want 2/2", total, len(history))
+	}
+	if got := history[0].Regime; got != "" {
+		t.Errorf("QueryTradeHistory history[0].Regime = %q; want empty (newest, no regime)", got)
+	}
+	if got := history[1].Regime; got != "trending_up" {
+		t.Errorf("QueryTradeHistory history[1].Regime = %q; want trending_up (oldest)", got)
+	}
+}
+
+// ─── Regime stamped at production RecordTrade call sites ─────────────────────
+
+// TestRegime_StampedAtProductionCallSites asserts that s.Regime flows into the
+// recorded Trade at every file that contains a RecordTrade call. One
+// representative path per file is sufficient — the goal is catching a future
+// call site that forgets the stamping line, not exhaustive branch coverage.
+func TestRegime_StampedAtProductionCallSites(t *testing.T) {
+	newState := func(platform string) *StrategyState {
+		return &StrategyState{
+			ID: "test-strat", Cash: 100000, Platform: platform,
+			Positions:       make(map[string]*Position),
+			OptionPositions: make(map[string]*OptionPosition),
+			TradeHistory:    []Trade{}, RiskState: RiskState{},
+			Regime: "trending_up",
+		}
+	}
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	const want = "trending_up"
+	lastRegime := func(s *StrategyState) string {
+		if len(s.TradeHistory) == 0 {
+			return "<no trade recorded>"
+		}
+		return s.TradeHistory[len(s.TradeHistory)-1].Regime
+	}
+
+	t.Run("portfolio/ExecuteSpotSignalWithFillFee", func(t *testing.T) {
+		s := newState("binanceus")
+		ExecuteSpotSignalWithFillFee(s, 1, "BTC", 50000, 0, 0, "", 0, logger)
+		if got := lastRegime(s); got != want {
+			t.Errorf("Regime = %q; want %q", got, want)
+		}
+	})
+
+	t.Run("portfolio/recordPerpsStopLossClose", func(t *testing.T) {
+		s := newState("hyperliquid")
+		s.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "long", Leverage: 5}
+		ok := recordPerpsStopLossClose(s, "BTC", 49000, "stop_loss", logger)
+		if !ok {
+			t.Fatal("recordPerpsStopLossClose returned false")
+		}
+		if got := lastRegime(s); got != want {
+			t.Errorf("Regime = %q; want %q", got, want)
+		}
+	})
+
+	t.Run("risk/forceCloseAllPositions", func(t *testing.T) {
+		s := newState("hyperliquid")
+		s.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "long"}
+		forceCloseAllPositions(s, map[string]float64{"BTC": 51000}, logger)
+		if got := lastRegime(s); got != want {
+			t.Errorf("Regime = %q; want %q", got, want)
+		}
+	})
+
+	t.Run("hyperliquid_balance/applyHyperliquidCircuitCloseFill_normal", func(t *testing.T) {
+		s := newState("hyperliquid")
+		s.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 1.0, AvgCost: 50000, Side: "long", Multiplier: 1, Leverage: 5}
+		applyHyperliquidCircuitCloseFill(s, "BTC", 1.0, 49000, 1.5, 1.0)
+		if got := lastRegime(s); got != want {
+			t.Errorf("Regime = %q; want %q", got, want)
+		}
+	})
+
+	t.Run("hyperliquid_balance/applyHyperliquidCircuitCloseFill_noPosition", func(t *testing.T) {
+		s := newState("hyperliquid")
+		// Empty positions — exercises the defensive no-virtual-position branch.
+		applyHyperliquidCircuitCloseFill(s, "BTC", 1.0, 49000, 1.5, 1.0)
+		if got := lastRegime(s); got != want {
+			t.Errorf("Regime = %q; want %q", got, want)
+		}
+	})
+
+	t.Run("options/executeOptionBuy", func(t *testing.T) {
+		s := newState("ibkr")
+		result := &OptionsResult{Underlying: "BTC", SpotPrice: 60000}
+		action := &OptionsAction{Action: "buy", OptionType: "call", Strike: 60000, Expiry: "2026-12-26", Quantity: 1, PremiumUSD: 100}
+		executeOptionBuy(s, result, action, logger)
+		if got := lastRegime(s); got != want {
+			t.Errorf("Regime = %q; want %q", got, want)
+		}
+	})
+
+	t.Run("options/executeOptionSell", func(t *testing.T) {
+		s := newState("ibkr")
+		result := &OptionsResult{Underlying: "BTC", SpotPrice: 60000}
+		// Sell a call (not a put — avoids collateral check: strike*qty vs cash).
+		action := &OptionsAction{Action: "sell", OptionType: "call", Strike: 60000, Expiry: "2026-12-26", Quantity: 1, PremiumUSD: 100}
+		executeOptionSell(s, result, action, logger)
+		if got := lastRegime(s); got != want {
+			t.Errorf("Regime = %q; want %q", got, want)
+		}
+	})
+
+	t.Run("options/executeOptionClose", func(t *testing.T) {
+		s := newState("ibkr")
+		result := &OptionsResult{Underlying: "BTC", SpotPrice: 60000}
+		// Pre-populate a position that executeOptionClose will match on Underlying+OptionType+Strike.
+		posID := "BTC-call-buy-60000-2026-12-26"
+		s.OptionPositions[posID] = &OptionPosition{
+			ID: posID, Underlying: "BTC", OptionType: "call", Strike: 60000,
+			Expiry: "2026-12-26", Action: "buy", Quantity: 1,
+			EntryPremiumUSD: 100, CurrentValueUSD: 150,
+		}
+		action := &OptionsAction{Action: "close", OptionType: "call", Strike: 60000, Expiry: "2026-12-26", PremiumUSD: 150}
+		executeOptionClose(s, result, action, logger)
+		if got := lastRegime(s); got != want {
+			t.Errorf("Regime = %q; want %q", got, want)
+		}
+	})
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `TestRegime_LoadStateAndQueryTradeHistoryRoundTrip`: exercises `LoadState` and `QueryTradeHistory` Scan paths after `InsertTrade`, catching any column-order mismatch that raw-SQL assertions miss (the 15th Scan column `regime` ↔ `details` swap would be silent without this)
- Adds `TestRegime_StampedAtProductionCallSites`: table-driven subtests for one representative call site per file — `portfolio.go` (open via `ExecuteSpotSignalWithFillFee` + stop-loss via `recordPerpsStopLossClose`), `risk.go` (`forceCloseAllPositions`), `hyperliquid_balance.go` (normal branch + defensive no-position branch of `applyHyperliquidCircuitCloseFill`), `options.go` (`executeOptionBuy`, `executeOptionSell`, `executeOptionClose`) — each sets `s.Regime = "trending_up"` and asserts it lands on the recorded `Trade.Regime`

No production code changes.

## Test plan

- [x] `go -C scheduler test -run 'TestRegime_' -v` — all 9 subtests pass
- [x] `go -C scheduler test ./...` — full suite passes

Closes #554

---
LLM: Claude Opus 4.7 (1M) | high