### PR TITLE
Thread regime.period / adx_threshold / enabled to check scripts (#558)

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1206,7 +1206,7 @@ func main() {
 					switch sc.Type {
 					case "spot":
 						if sc.Platform == "okx" {
-							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, logger); ok {
+							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, cfg.Regime, logger); ok {
 								prices[result.Symbol] = price
 								if regimeBlocksOpen(sc.AllowedRegimes, result.Regime, okxPosQty) {
 									logger.Info("Regime gate: open signal blocked (regime=%s)", result.Regime)
@@ -1231,7 +1231,7 @@ func main() {
 								}
 							}
 						} else if sc.Platform == "robinhood" {
-							if result, signalStr, price, ok := runRobinhoodCheck(sc, prices, rhPosCtx, logger); ok {
+							if result, signalStr, price, ok := runRobinhoodCheck(sc, prices, rhPosCtx, cfg.Regime, logger); ok {
 								prices[result.Symbol] = price
 								if regimeBlocksOpen(sc.AllowedRegimes, result.Regime, rhPosQty) {
 									logger.Info("Regime gate: open signal blocked (regime=%s)", result.Regime)
@@ -1255,7 +1255,7 @@ func main() {
 									mu.Unlock()
 								}
 							}
-						} else if result, signalStr, price, ok := runSpotCheck(sc, prices, spotPosCtx, logger); ok {
+						} else if result, signalStr, price, ok := runSpotCheck(sc, prices, spotPosCtx, cfg.Regime, logger); ok {
 							if regimeBlocksOpen(sc.AllowedRegimes, result.Regime, spotPosCtx.Quantity) {
 								logger.Info("Regime gate: open signal blocked (regime=%s)", result.Regime)
 								result.Signal = 0
@@ -1279,7 +1279,7 @@ func main() {
 						}
 					case "perps":
 						if sc.Platform == "okx" {
-							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, logger); ok {
+							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, cfg.Regime, logger); ok {
 								prices[result.Symbol] = price
 								if regimeBlocksOpen(sc.AllowedRegimes, result.Regime, okxPosQty) {
 									logger.Info("Regime gate: open signal blocked (regime=%s)", result.Regime)
@@ -1303,7 +1303,7 @@ func main() {
 									mu.Unlock()
 								}
 							}
-						} else if result, signalStr, price, ok := runHyperliquidCheck(sc, prices, hlPosCtx, logger); ok {
+						} else if result, signalStr, price, ok := runHyperliquidCheck(sc, prices, hlPosCtx, cfg.Regime, logger); ok {
 							prices[result.Symbol] = price
 							if regimeBlocksOpen(sc.AllowedRegimes, result.Regime, hlPosQty) {
 								logger.Info("Regime gate: open signal blocked (regime=%s)", result.Regime)
@@ -1409,7 +1409,7 @@ func main() {
 							}
 						}
 					case "futures":
-						if result, signalStr, price, ok := runTopStepCheck(sc, prices, tsPosCtx, logger); ok {
+						if result, signalStr, price, ok := runTopStepCheck(sc, prices, tsPosCtx, cfg.Regime, logger); ok {
 							prices[result.Symbol] = price
 							if regimeBlocksOpen(sc.AllowedRegimes, result.Regime, tsContracts) {
 								logger.Info("Regime gate: open signal blocked (regime=%s)", result.Regime)
@@ -1824,12 +1824,13 @@ func spotSymbol(args []string) string {
 
 // runSpotCheck runs the spot check subprocess and returns the parsed result.
 // No state access. Returns (result, signalStr, price, ok); ok=false means skip execution.
-func runSpotCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, logger *StrategyLogger) (*SpotResult, string, float64, bool) {
+func runSpotCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, logger *StrategyLogger) (*SpotResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
 	args = appendOpenCloseArgs(args, sc, posCtx)
 	if sc.HTFFilter {
 		args = append(args, "--htf-filter")
 	}
+	args = appendRegimeArgs(args, regime)
 	if len(sc.Params) > 0 {
 		paramsJSON, err := json.Marshal(sc.Params)
 		if err == nil {
@@ -2097,12 +2098,13 @@ func hyperliquidSymbol(args []string) string {
 }
 
 // runHyperliquidCheck runs check_hyperliquid.py signal-check mode (Phase 3, no lock).
-func runHyperliquidCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, logger *StrategyLogger) (*HyperliquidResult, string, float64, bool) {
+func runHyperliquidCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, logger *StrategyLogger) (*HyperliquidResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
 	args = appendOpenCloseArgs(args, sc, posCtx)
 	if sc.HTFFilter {
 		args = append(args, "--htf-filter")
 	}
+	args = appendRegimeArgs(args, regime)
 	if len(sc.Params) > 0 {
 		paramsJSON, err := json.Marshal(sc.Params)
 		if err == nil {
@@ -2424,12 +2426,13 @@ func topstepSymbol(args []string) string {
 }
 
 // runTopStepCheck runs check_topstep.py signal-check mode (Phase 3, no lock).
-func runTopStepCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, logger *StrategyLogger) (*TopStepResult, string, float64, bool) {
+func runTopStepCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, logger *StrategyLogger) (*TopStepResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
 	args = appendOpenCloseArgs(args, sc, posCtx)
 	if sc.HTFFilter {
 		args = append(args, "--htf-filter")
 	}
+	args = appendRegimeArgs(args, regime)
 	if len(sc.Params) > 0 {
 		paramsJSON, err := json.Marshal(sc.Params)
 		if err == nil {
@@ -2618,12 +2621,13 @@ func robinhoodSymbol(args []string) string {
 }
 
 // runRobinhoodCheck runs check_robinhood.py signal-check mode (Phase 3, no lock).
-func runRobinhoodCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, logger *StrategyLogger) (*RobinhoodResult, string, float64, bool) {
+func runRobinhoodCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, logger *StrategyLogger) (*RobinhoodResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
 	args = appendOpenCloseArgs(args, sc, posCtx)
 	if sc.HTFFilter {
 		args = append(args, "--htf-filter")
 	}
+	args = appendRegimeArgs(args, regime)
 	if len(sc.Params) > 0 {
 		paramsJSON, err := json.Marshal(sc.Params)
 		if err == nil {
@@ -2790,12 +2794,13 @@ func okxInstType(args []string) string {
 }
 
 // runOKXCheck runs check_okx.py signal-check mode (Phase 3, no lock).
-func runOKXCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, logger *StrategyLogger) (*OKXResult, string, float64, bool) {
+func runOKXCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, logger *StrategyLogger) (*OKXResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
 	args = appendOpenCloseArgs(args, sc, posCtx)
 	if sc.HTFFilter {
 		args = append(args, "--htf-filter")
 	}
+	args = appendRegimeArgs(args, regime)
 	if len(sc.Params) > 0 {
 		paramsJSON, err := json.Marshal(sc.Params)
 		if err == nil {

--- a/scheduler/strategy_composition.go
+++ b/scheduler/strategy_composition.go
@@ -88,6 +88,16 @@ func appendPositionFloatArg(args []string, flag string, value float64) []string 
 	return append(args, flag+"="+strconv.FormatFloat(value, 'f', -1, 64))
 }
 
+func appendRegimeArgs(args []string, regime *RegimeConfig) []string {
+	if regime == nil || !regime.Enabled {
+		return args
+	}
+	out := append(args, "--regime-enabled")
+	out = append(out, "--regime-period", strconv.Itoa(regime.Period))
+	out = append(out, "--regime-adx-threshold", strconv.FormatFloat(regime.ADXThreshold, 'f', -1, 64))
+	return out
+}
+
 func positionCtxForSymbol(s *StrategyState, symbol string) PositionCtx {
 	if s == nil || strings.TrimSpace(symbol) == "" {
 		return PositionCtx{}

--- a/scheduler/strategy_composition_test.go
+++ b/scheduler/strategy_composition_test.go
@@ -150,6 +150,52 @@ func TestPositionCtxForSymbol(t *testing.T) {
 	}
 }
 
+func TestAppendRegimeArgs(t *testing.T) {
+	base := []string{"sma_crossover", "BTC/USDT", "1h"}
+
+	t.Run("nil regime returns args unchanged", func(t *testing.T) {
+		got := appendRegimeArgs(base, nil)
+		if !reflect.DeepEqual(got, base) {
+			t.Fatalf("appendRegimeArgs(nil) = %#v, want %#v", got, base)
+		}
+	})
+
+	t.Run("disabled regime returns args unchanged", func(t *testing.T) {
+		got := appendRegimeArgs(base, &RegimeConfig{Enabled: false})
+		if !reflect.DeepEqual(got, base) {
+			t.Fatalf("appendRegimeArgs(disabled) = %#v, want %#v", got, base)
+		}
+	})
+
+	t.Run("enabled regime appends all three flags", func(t *testing.T) {
+		regime := &RegimeConfig{Enabled: true, Period: 28, ADXThreshold: 25.5}
+		got := appendRegimeArgs(base, regime)
+		want := []string{
+			"sma_crossover", "BTC/USDT", "1h",
+			"--regime-enabled",
+			"--regime-period", "28",
+			"--regime-adx-threshold", "25.5",
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("appendRegimeArgs(enabled) = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("enabled with defaults appends correct values", func(t *testing.T) {
+		regime := &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20.0}
+		got := appendRegimeArgs(base, regime)
+		want := []string{
+			"sma_crossover", "BTC/USDT", "1h",
+			"--regime-enabled",
+			"--regime-period", "14",
+			"--regime-adx-threshold", "20",
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("appendRegimeArgs(defaults) = %#v, want %#v", got, want)
+		}
+	})
+}
+
 func TestMaxCloseFraction(t *testing.T) {
 	got := maxCloseFraction([]float64{0.25, 0.8, 1.2, -1})
 	if got != 1 {

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -89,7 +89,8 @@ def _position_ctx_from_args(args):
 def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=False,
                      strategy_params_override=None, open_strategy=None,
                      close_strategies=None,
-                     position_side="", position_ctx=None):
+                     position_side="", position_ctx=None,
+                     regime_enabled=False, regime_period=14, regime_adx_threshold=20.0):
     """Run strategy signal check using Hyperliquid OHLCV data."""
     try:
         from adapter import HyperliquidExchangeAdapter
@@ -155,7 +156,10 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             sys.exit(1)
 
         df = _make_dataframe(candles)
-        regime_payload = latest_regime(df)
+        if regime_enabled:
+            regime_payload = latest_regime(df, period=regime_period, adx_threshold=regime_adx_threshold)
+        else:
+            regime_payload = {"regime": "", "score": 0.0, "metrics": {}}
         strategy_params["regime"] = regime_payload
         if strategy_params_override:
             merged = {**strategy_params_override, **strategy_params}
@@ -652,6 +656,9 @@ def main():
         parser.add_argument("timeframe")
         parser.add_argument("--mode", default="paper")
         parser.add_argument("--htf-filter", action="store_true", default=False)
+        parser.add_argument("--regime-enabled", action="store_true", default=False)
+        parser.add_argument("--regime-period", type=int, default=14)
+        parser.add_argument("--regime-adx-threshold", type=float, default=20.0)
         parser.add_argument("--params", default=None)
         parser.add_argument("--open-strategy", default=None)
         parser.add_argument("--close-strategies", default=None)
@@ -668,6 +675,9 @@ def main():
             args.htf_filter, params_override, args.open_strategy,
             args.close_strategies,
             args.position_side, position_ctx,
+            regime_enabled=args.regime_enabled,
+            regime_period=args.regime_period,
+            regime_adx_threshold=args.regime_adx_threshold,
         )
 
 

--- a/shared_scripts/check_okx.py
+++ b/shared_scripts/check_okx.py
@@ -86,7 +86,8 @@ def _extract_fee(response):
 def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=False,
                      inst_type="swap", strategy_params_override=None,
                      open_strategy=None, close_strategies=None,
-                     position_side="", position_ctx=None):
+                     position_side="", position_ctx=None,
+                     regime_enabled=False, regime_period=14, regime_adx_threshold=20.0):
     """Run strategy signal check using OKX OHLCV data."""
     try:
         from adapter import OKXExchangeAdapter
@@ -155,7 +156,10 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             sys.exit(1)
 
         df = _make_dataframe(candles)
-        regime_payload = latest_regime(df)
+        if regime_enabled:
+            regime_payload = latest_regime(df, period=regime_period, adx_threshold=regime_adx_threshold)
+        else:
+            regime_payload = {"regime": "", "score": 0.0, "metrics": {}}
         strategy_params["regime"] = regime_payload
         if strategy_params_override:
             merged = {**strategy_params_override, **strategy_params}
@@ -353,6 +357,9 @@ def main():
         parser.add_argument("timeframe")
         parser.add_argument("--mode", default="paper")
         parser.add_argument("--htf-filter", action="store_true", default=False)
+        parser.add_argument("--regime-enabled", action="store_true", default=False)
+        parser.add_argument("--regime-period", type=int, default=14)
+        parser.add_argument("--regime-adx-threshold", type=float, default=20.0)
         parser.add_argument("--inst-type", default="swap", choices=["spot", "swap"])
         parser.add_argument("--params", default=None)
         parser.add_argument("--open-strategy", default=None)
@@ -370,6 +377,9 @@ def main():
             args.htf_filter, args.inst_type, params_override,
             args.open_strategy, args.close_strategies,
             args.position_side, position_ctx,
+            regime_enabled=args.regime_enabled,
+            regime_period=args.regime_period,
+            regime_adx_threshold=args.regime_adx_threshold,
         )
 
 

--- a/shared_scripts/check_robinhood.py
+++ b/shared_scripts/check_robinhood.py
@@ -114,7 +114,8 @@ def _extract_fee(response):
 def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=False,
                      strategy_params=None, open_strategy=None,
                      close_strategies=None,
-                     position_side="", position_ctx=None):
+                     position_side="", position_ctx=None,
+                     regime_enabled=False, regime_period=14, regime_adx_threshold=20.0):
     """Run strategy signal check using yfinance OHLCV data."""
     try:
         from adapter import RobinhoodExchangeAdapter
@@ -165,7 +166,10 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             sys.exit(1)
 
         df = _make_dataframe(candles)
-        regime_payload = latest_regime(df)
+        if regime_enabled:
+            regime_payload = latest_regime(df, period=regime_period, adx_threshold=regime_adx_threshold)
+        else:
+            regime_payload = {"regime": "", "score": 0.0, "metrics": {}}
         strategy_params = (strategy_params or {})
         strategy_params["regime"] = regime_payload
         decision = None
@@ -363,6 +367,9 @@ def main():
         parser.add_argument("timeframe")
         parser.add_argument("--mode", default="paper")
         parser.add_argument("--htf-filter", action="store_true", default=False)
+        parser.add_argument("--regime-enabled", action="store_true", default=False)
+        parser.add_argument("--regime-period", type=int, default=14)
+        parser.add_argument("--regime-adx-threshold", type=float, default=20.0)
         parser.add_argument("--params", default=None)
         parser.add_argument("--open-strategy", default=None)
         parser.add_argument("--close-strategies", default=None)
@@ -379,6 +386,9 @@ def main():
             args.htf_filter, params_parsed, args.open_strategy,
             args.close_strategies,
             args.position_side, position_ctx,
+            regime_enabled=args.regime_enabled,
+            regime_period=args.regime_period,
+            regime_adx_threshold=args.regime_adx_threshold,
         )
 
 

--- a/shared_scripts/check_strategy.py
+++ b/shared_scripts/check_strategy.py
@@ -68,6 +68,9 @@ def _position_ctx(position_side):
 def main():
     # Parse optional flags from argv before positional args
     htf_filter_enabled = "--htf-filter" in sys.argv
+    regime_enabled = "--regime-enabled" in sys.argv
+    regime_period = int(_arg_value("--regime-period") or 14)
+    regime_adx_threshold = float(_arg_value("--regime-adx-threshold") or 20.0)
     open_strategy = _arg_value("--open-strategy")
     close_strategies_raw = _arg_value("--close-strategies")
     position_side = (_arg_value("--position-side", "") or "").lower()
@@ -88,7 +91,7 @@ def main():
         if a in (
             "--params", "--open-strategy", "--close-strategies", "--position-side",
             "--position-avg-cost", "--position-qty", "--position-initial-qty",
-            "--position-entry-atr",
+            "--position-entry-atr", "--regime-period", "--regime-adx-threshold",
         ):
             skip_next = True
             continue
@@ -183,7 +186,10 @@ def main():
             }))
             return
 
-        regime_payload = latest_regime(df)
+        if regime_enabled:
+            regime_payload = latest_regime(df, period=regime_period, adx_threshold=regime_adx_threshold)
+        else:
+            regime_payload = {"regime": "", "score": 0.0, "metrics": {}}
         strategy_params = (strategy_params or {})
         strategy_params["regime"] = regime_payload
 

--- a/shared_scripts/check_topstep.py
+++ b/shared_scripts/check_topstep.py
@@ -102,7 +102,8 @@ def _extract_fee(response):
 def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=False,
                      strategy_params=None, open_strategy=None,
                      close_strategies=None,
-                     position_side="", position_ctx=None):
+                     position_side="", position_ctx=None,
+                     regime_enabled=False, regime_period=14, regime_adx_threshold=20.0):
     """Run strategy signal check using TopStep market data."""
     try:
         from adapter import TopStepExchangeAdapter
@@ -173,7 +174,10 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             sys.exit(1)
 
         df = _make_dataframe(candles)
-        regime_payload = latest_regime(df)
+        if regime_enabled:
+            regime_payload = latest_regime(df, period=regime_period, adx_threshold=regime_adx_threshold)
+        else:
+            regime_payload = {"regime": "", "score": 0.0, "metrics": {}}
         strategy_params = (strategy_params or {})
         strategy_params["regime"] = regime_payload
         decision = None
@@ -366,6 +370,9 @@ def main():
         parser.add_argument("timeframe")
         parser.add_argument("--mode", default="paper")
         parser.add_argument("--htf-filter", action="store_true", default=False)
+        parser.add_argument("--regime-enabled", action="store_true", default=False)
+        parser.add_argument("--regime-period", type=int, default=14)
+        parser.add_argument("--regime-adx-threshold", type=float, default=20.0)
         parser.add_argument("--params", default=None)
         parser.add_argument("--open-strategy", default=None)
         parser.add_argument("--close-strategies", default=None)
@@ -382,6 +389,9 @@ def main():
             args.htf_filter, params_parsed, args.open_strategy,
             args.close_strategies,
             args.position_side, position_ctx,
+            regime_enabled=args.regime_enabled,
+            regime_period=args.regime_period,
+            regime_adx_threshold=args.regime_adx_threshold,
         )
 
 

--- a/shared_scripts/test_regime_wiring.py
+++ b/shared_scripts/test_regime_wiring.py
@@ -216,3 +216,55 @@ def test_check_options_fetch_ohlcv_df_short_returns_none():
     # Current behavior: short non-empty rows do NOT trigger fallback; they short-circuit to None.
     df = module._fetch_ohlcv_df("BTC", "4h", 100, 30, adapter=StubAdapter())
     assert df is None
+
+
+# ─── regime_enabled flag tests (#558) ────────────────────────────────────────
+
+
+def test_latest_regime_honors_custom_period():
+    """latest_regime passes the period to compute_regime.
+
+    With a 50-bar df and period=200, adx_start = 2*200-1 = 399 > 50 so the ADX
+    loop never runs and returns the default warmup value (adx=0, regime="ranging").
+    With period=14 the same df produces a real ADX value.  Comparing the two
+    confirms the period argument is actually forwarded.
+    """
+    df = _make_uptrend_df(50)
+    warmup = latest_regime(df, period=200)   # loop skipped: adx_start=399 > 50
+    real = latest_regime(df, period=14)       # loop runs normally
+    assert warmup["metrics"]["adx"] == 0.0
+    assert real["metrics"]["adx"] > 0.0
+
+
+def test_latest_regime_honors_custom_adx_threshold():
+    """latest_regime uses adx_threshold to decide trending vs. ranging.
+
+    Uptrend data produces ADX saturating at 100.  With threshold=101 the
+    condition `adx < threshold` is true → "ranging".  With threshold=50 it is
+    false and +DI > -DI → "trending_up".
+    """
+    df = _make_uptrend_df(100)
+    assert latest_regime(df, adx_threshold=101.0)["regime"] == "ranging"
+    assert latest_regime(df, adx_threshold=50.0)["regime"] == "trending_up"
+
+
+def test_regime_disabled_path_returns_empty_label():
+    """When regime_enabled=False the check script contract emits regime='' without calling latest_regime."""
+    # Simulate the disabled path directly (as each check script implements it)
+    regime_enabled = False
+    df = _make_uptrend_df()
+    if regime_enabled:
+        regime_payload = latest_regime(df)
+    else:
+        regime_payload = {"regime": "", "score": 0.0, "metrics": {}}
+    assert regime_payload["regime"] == ""
+    assert regime_payload["score"] == 0.0
+    assert regime_payload["metrics"] == {}
+
+
+def test_regime_disabled_payload_is_json_serializable():
+    """The empty regime payload emitted when disabled must survive json.dumps."""
+    payload = {"regime": "", "score": 0.0, "metrics": {}}
+    serialized = json.dumps(payload)
+    parsed = json.loads(serialized)
+    assert parsed["regime"] == ""


### PR DESCRIPTION
## Summary

- `cfg.Regime.Period` and `cfg.Regime.ADXThreshold` were silent no-ops in live runs — check scripts called `latest_regime(df)` with hardcoded defaults because `executor.go` never forwarded them. Backtester did honor `--regime-period`/`--regime-adx-threshold` (PR #549), so customising these fields produced divergent live vs. backtest labels.
- `cfg.Regime.Enabled=false` also had no effect — check scripts ran regime detection unconditionally every cycle.

**Go:** `appendRegimeArgs` helper in `strategy_composition.go`; `regime *RegimeConfig` param added to all 5 `run*Check` functions; `cfg.Regime` threaded at all 6 call sites in `main.go`.

**Python (5 check scripts):** parse `--regime-enabled` / `--regime-period` / `--regime-adx-threshold`; pass to `latest_regime()`; skip detection entirely (emit `regime=""`) when `--regime-enabled` absent. `check_strategy.py` adds the value flags to its `skip_next` filter.

**Tests:** `TestAppendRegimeArgs` (Go, 4 subtests); 4 new Python tests in `test_regime_wiring.py` covering period/threshold forwarding and the disabled-path empty payload.

## Test plan

- [x] `go test ./...` passes
- [x] `pytest shared_scripts/test_regime_wiring.py -v` — 17/17 pass
- [x] `python3 -m py_compile` on all 5 modified check scripts

Closes #558

---
LLM: Claude Sonnet 4.6 (1M) | high