### PR TITLE
feat: position quantity precision + ATR/TP/SL in summaries and trade DMs (#561)

### DIFF
--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -270,6 +270,8 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE positions ADD COLUMN entry_atr REAL NOT NULL DEFAULT 0",
 		// Market regime label at trade time (#482).
 		"ALTER TABLE trades ADD COLUMN regime TEXT NOT NULL DEFAULT ''",
+		"ALTER TABLE trades ADD COLUMN entry_atr REAL NOT NULL DEFAULT 0",
+		"ALTER TABLE trades ADD COLUMN stop_loss_trigger_px REAL NOT NULL DEFAULT 0",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -467,15 +469,27 @@ func (sdb *StateDB) InsertTrade(strategyID string, trade Trade) error {
 		isClose = 1
 	}
 	_, err := sdb.db.Exec(`INSERT INTO trades
-			(strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, regime)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			(strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, regime, entry_atr, stop_loss_trigger_px)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		strategyID, formatTime(trade.Timestamp), trade.Symbol, trade.PositionID, trade.Side,
 		trade.Quantity, trade.Price, trade.Value, trade.TradeType, trade.Details,
-		trade.ExchangeOrderID, trade.ExchangeFee, isClose, trade.RealizedPnL, trade.Regime)
+		trade.ExchangeOrderID, trade.ExchangeFee, isClose, trade.RealizedPnL, trade.Regime,
+		trade.EntryATR, trade.StopLossTriggerPx)
 	if err != nil {
 		return fmt.Errorf("insert trade for %s: %w", strategyID, err)
 	}
 	return nil
+}
+
+// UpdateTradeStampedFields sets entry_atr and stop_loss_trigger_px on an
+// existing trade row identified by (strategy_id, timestamp). Called after
+// RecordTrade once the corresponding position values are available.
+func (sdb *StateDB) UpdateTradeStampedFields(strategyID string, ts time.Time, entryATR, stopLossTriggerPx float64) error {
+	_, err := sdb.db.Exec(
+		`UPDATE trades SET entry_atr = ?, stop_loss_trigger_px = ? WHERE strategy_id = ? AND timestamp = ?`,
+		entryATR, stopLossTriggerPx, strategyID, formatTime(ts),
+	)
+	return err
 }
 
 // SetInitialCapital is the ONLY sanctioned way to change a strategy's
@@ -1125,7 +1139,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 
 	// 5. Load most recent 1000 trades per strategy (full history stays in SQLite).
 	for id, s := range state.Strategies {
-		tradeRows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime
+		tradeRows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime, COALESCE(entry_atr, 0) AS entry_atr, COALESCE(stop_loss_trigger_px, 0) AS stop_loss_trigger_px
 			FROM trades WHERE strategy_id = ? ORDER BY timestamp ASC`, id)
 		if err != nil {
 			return nil, fmt.Errorf("load trades for %s: %w", id, err)
@@ -1135,7 +1149,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 			var t Trade
 			var tsStr string
 			var isCloseInt int
-			if err := tradeRows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL, &t.Regime); err != nil {
+			if err := tradeRows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL, &t.Regime, &t.EntryATR, &t.StopLossTriggerPx); err != nil {
 				tradeRows.Close()
 				return nil, fmt.Errorf("scan trade: %w", err)
 			}
@@ -1311,7 +1325,7 @@ func (sdb *StateDB) QueryTradeHistory(strategyID, symbol string, since, until ti
 		limit = 500
 	}
 
-	query := fmt.Sprintf("SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime FROM trades %s ORDER BY timestamp DESC LIMIT ? OFFSET ?", whereClause)
+	query := fmt.Sprintf("SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime, COALESCE(entry_atr, 0) AS entry_atr, COALESCE(stop_loss_trigger_px, 0) AS stop_loss_trigger_px FROM trades %s ORDER BY timestamp DESC LIMIT ? OFFSET ?", whereClause)
 	queryArgs := append(args, limit, offset)
 	rows, err := sdb.db.Query(query, queryArgs...)
 	if err != nil {
@@ -1324,7 +1338,7 @@ func (sdb *StateDB) QueryTradeHistory(strategyID, symbol string, since, until ti
 		var t Trade
 		var tsStr string
 		var isCloseInt int
-		if err := rows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL, &t.Regime); err != nil {
+		if err := rows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL, &t.Regime, &t.EntryATR, &t.StopLossTriggerPx); err != nil {
 			return nil, 0, fmt.Errorf("scan trade: %w", err)
 		}
 		t.Timestamp = parseTime(tsStr)

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -705,8 +705,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	//    failed, even if later-timestamped rows were persisted successfully
 	//    (fixes the MAX(timestamp) dedup gap that would silently drop
 	//    out-of-order retries).
-	stmtTrade, err := tx.Prepare(`INSERT INTO trades (strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtTrade, err := tx.Prepare(`INSERT INTO trades (strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, regime, entry_atr, stop_loss_trigger_px)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare trade insert: %w", err)
 	}
@@ -730,7 +730,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 			if t.IsClose {
 				isClose = 1
 			}
-			if _, err := stmtTrade.Exec(s.ID, formatTime(t.Timestamp), t.Symbol, t.PositionID, t.Side, t.Quantity, t.Price, t.Value, t.TradeType, t.Details, t.ExchangeOrderID, t.ExchangeFee, isClose, t.RealizedPnL); err != nil {
+			if _, err := stmtTrade.Exec(s.ID, formatTime(t.Timestamp), t.Symbol, t.PositionID, t.Side, t.Quantity, t.Price, t.Value, t.TradeType, t.Details, t.ExchangeOrderID, t.ExchangeFee, isClose, t.RealizedPnL, t.Regime, t.EntryATR, t.StopLossTriggerPx); err != nil {
 				return fmt.Errorf("insert trade for %s: %w", s.ID, err)
 			}
 			flushed = append(flushed, trackedFlush{strat: s, index: i})

--- a/scheduler/deribit.go
+++ b/scheduler/deribit.go
@@ -491,9 +491,12 @@ func applyAssignment(s *StrategyState, r markResult, logger *StrategyLogger) {
 		s.Cash += proceeds
 		pnl := 0.0
 		var positionID string
+		var posEntryATR, posStopLossTriggerPx float64
 		if existing, ok := s.Positions[symbol]; ok && existing.Side == "long" {
 			positionID = ensurePositionTradeID(s.ID, symbol, existing)
 			pnl = (r.AssignStrike - existing.AvgCost) * r.AssignQuantity
+			posEntryATR = existing.EntryATR
+			posStopLossTriggerPx = existing.StopLossTriggerPx
 			newQty := existing.Quantity - r.AssignQuantity
 			if newQty <= 0 {
 				recordClosedPosition(s, existing, r.AssignStrike, pnl, "assignment", now)
@@ -515,9 +518,11 @@ func applyAssignment(s *StrategyState, r markResult, logger *StrategyLogger) {
 			TradeType:  "assignment",
 			Details: fmt.Sprintf("Wheel call-away: sold call expired ITM (spot=$%.2f), sold %.4f %s @ $%.0f PnL=$%.2f",
 				r.AssignSpotPrice, r.AssignQuantity, symbol, r.AssignStrike, pnl),
-			IsClose:     true,
-			RealizedPnL: pnl,
-			Regime:      s.Regime,
+			IsClose:           true,
+			RealizedPnL:       pnl,
+			Regime:            s.Regime,
+			EntryATR:          posEntryATR,
+			StopLossTriggerPx: posStopLossTriggerPx,
 		})
 		logger.Info("CALL-AWAY: sold call %s-%.0f expired ITM (spot=$%.2f), sold %.4f %s @ $%.0f (proceeds=$%.2f, PnL=$%.2f)",
 			r.AssignUnderlying, r.AssignStrike, r.AssignSpotPrice, r.AssignQuantity, symbol, r.AssignStrike, proceeds, pnl)

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1003,6 +1003,9 @@ func collectPositions(sc StrategyConfig, ss *StrategyState, prices map[string]fl
 			slPct := percentFromEntry(pos.Side, pos.AvgCost, pos.StopLossTriggerPx)
 			extras += fmt.Sprintf(" | SL: $%s (%s)", fmtComma2(pos.StopLossTriggerPx), fmtPnlPct(slPct))
 		}
+		if pos.EntryATR > 0 {
+			extras += fmt.Sprintf(" | ATR: $%s", fmtComma2(pos.EntryATR))
+		}
 		if strategyUsesTieredTPATRClose(sc) && pos.EntryATR > 0 && pos.AvgCost > 0 {
 			sideLower := strings.ToLower(pos.Side)
 			var tp1, tp2 float64
@@ -1028,7 +1031,7 @@ func collectPositions(sc StrategyConfig, ss *StrategyState, prices map[string]fl
 			margin := positionMargin(pos.Quantity, pos.AvgCost, pos.Leverage)
 			extras += fmt.Sprintf(" | %gx ($%s margin)", pos.Leverage, fmtComma(math.Round(margin)))
 		}
-		lines = append(lines, fmt.Sprintf("%s %s %s x%g @ $%s (%s$%s)%s%s", sc.ID, strings.ToUpper(pos.Side), sym, pos.Quantity, fmtComma2(pos.AvgCost), sign, fmtComma2(absPnl), extras, dateStr))
+		lines = append(lines, fmt.Sprintf("%s %s %s x%.3f @ $%s (%s$%s)%s%s", sc.ID, strings.ToUpper(pos.Side), sym, pos.Quantity, fmtComma2(pos.AvgCost), sign, fmtComma2(absPnl), extras, dateStr))
 	}
 	for key, opt := range ss.OptionPositions {
 		dateStr := ""
@@ -1064,21 +1067,41 @@ func FormatTradeDM(sc StrategyConfig, trade Trade, mode string) string {
 	typeLabel := sc.Type
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%s **%s**\n", icon, header))
+	sb.WriteString(fmt.Sprintf("%s **%s - %s**\n", icon, header, strings.ToUpper(mode)))
 	sb.WriteString(fmt.Sprintf("Strategy: %s (%s %s)\n", sc.ID, platformLabel, typeLabel))
-	sb.WriteString(fmt.Sprintf("%s — %s %.6g @ $%s\n", trade.Symbol, tradeDirectionLabel(trade), trade.Quantity, fmtComma(trade.Price)))
+	sb.WriteString(fmt.Sprintf("%s — %s %.3f @ $%s | Value: $%s", trade.Symbol, tradeDirectionLabel(trade), trade.Quantity, fmtComma(trade.Price), fmtComma(trade.Value)))
 
-	valueLine := fmt.Sprintf("Value: $%s", fmtComma(trade.Value))
+	var extras []string
 	if isClose {
 		if pnl, ok := extractPnL(trade.Details); ok {
-			valueLine += fmt.Sprintf(" | PnL: $%s", pnl)
+			extras = append(extras, fmt.Sprintf("PnL: $%s", pnl))
 		}
 	}
 	if trade.Regime != "" {
-		valueLine += fmt.Sprintf(" | Regime: %s", trade.Regime)
+		extras = append(extras, "Regime: "+trade.Regime)
 	}
-	valueLine += fmt.Sprintf(" | Mode: %s", mode)
-	sb.WriteString(valueLine)
+	if trade.EntryATR > 0 && strategyUsesTieredTPATRClose(sc) {
+		extras = append(extras, fmt.Sprintf("ATR: $%s", fmtComma2(trade.EntryATR)))
+		direction := strings.ToLower(tradeDirectionLabel(trade))
+		var tp1, tp2 float64
+		if direction == "short" {
+			tp1 = trade.Price - trade.EntryATR
+			tp2 = trade.Price - 2*trade.EntryATR
+		} else {
+			tp1 = trade.Price + trade.EntryATR
+			tp2 = trade.Price + 2*trade.EntryATR
+		}
+		extras = append(extras, fmt.Sprintf("TP1: $%s", fmtComma2(tp1)))
+		extras = append(extras, fmt.Sprintf("TP2: $%s", fmtComma2(tp2)))
+	}
+	if trade.StopLossTriggerPx > 0 {
+		direction := strings.ToLower(tradeDirectionLabel(trade))
+		slPct := percentFromEntry(direction, trade.Price, trade.StopLossTriggerPx)
+		extras = append(extras, fmt.Sprintf("SL: $%s (%s)", fmtComma2(trade.StopLossTriggerPx), fmtPnlPct(slPct)))
+	}
+	if len(extras) > 0 {
+		sb.WriteString("\n" + strings.Join(extras, " | "))
+	}
 
 	return sb.String()
 }

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1069,7 +1069,7 @@ func FormatTradeDM(sc StrategyConfig, trade Trade, mode string) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%s **%s - %s**\n", icon, header, strings.ToUpper(mode)))
 	sb.WriteString(fmt.Sprintf("Strategy: %s (%s %s)\n", sc.ID, platformLabel, typeLabel))
-	sb.WriteString(fmt.Sprintf("%s — %s %.3f @ $%s | Value: $%s", trade.Symbol, tradeDirectionLabel(trade), trade.Quantity, fmtComma(trade.Price), fmtComma(trade.Value)))
+	sb.WriteString(fmt.Sprintf("%s — %s %.3f @ $%s | Value: $%s\n", trade.Symbol, tradeDirectionLabel(trade), trade.Quantity, fmtComma(trade.Price), fmtComma(trade.Value)))
 
 	var extras []string
 	if isClose {
@@ -1080,7 +1080,7 @@ func FormatTradeDM(sc StrategyConfig, trade Trade, mode string) string {
 	if trade.Regime != "" {
 		extras = append(extras, "Regime: "+trade.Regime)
 	}
-	if trade.EntryATR > 0 && strategyUsesTieredTPATRClose(sc) {
+	if !isClose && trade.EntryATR > 0 && strategyUsesTieredTPATRClose(sc) {
 		extras = append(extras, fmt.Sprintf("ATR: $%s", fmtComma2(trade.EntryATR)))
 		direction := strings.ToLower(tradeDirectionLabel(trade))
 		var tp1, tp2 float64
@@ -1100,7 +1100,7 @@ func FormatTradeDM(sc StrategyConfig, trade Trade, mode string) string {
 		extras = append(extras, fmt.Sprintf("SL: $%s (%s)", fmtComma2(trade.StopLossTriggerPx), fmtPnlPct(slPct)))
 	}
 	if len(extras) > 0 {
-		sb.WriteString("\n" + strings.Join(extras, " | "))
+		sb.WriteString(strings.Join(extras, " | "))
 	}
 
 	return sb.String()

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -354,8 +354,8 @@ func TestFormatTradeDM_OpenTrade(t *testing.T) {
 	if !strings.Contains(msg, "LONG") {
 		t.Errorf("expected LONG, got:\n%s", msg)
 	}
-	if !strings.Contains(msg, "Mode: paper") {
-		t.Errorf("expected 'Mode: paper', got:\n%s", msg)
+	if !strings.Contains(msg, "TRADE EXECUTED - PAPER") {
+		t.Errorf("expected 'TRADE EXECUTED - PAPER' in header, got:\n%s", msg)
 	}
 	if strings.Contains(msg, "PnL") {
 		t.Errorf("open trade should not contain PnL, got:\n%s", msg)
@@ -388,8 +388,8 @@ func TestFormatTradeDM_CloseTrade(t *testing.T) {
 	if !strings.Contains(msg, "PnL: $34.35") {
 		t.Errorf("expected PnL in close trade, got:\n%s", msg)
 	}
-	if !strings.Contains(msg, "Mode: live") {
-		t.Errorf("expected 'Mode: live', got:\n%s", msg)
+	if !strings.Contains(msg, "TRADE CLOSED - LIVE") {
+		t.Errorf("expected 'TRADE CLOSED - LIVE' in header, got:\n%s", msg)
 	}
 }
 
@@ -1406,6 +1406,9 @@ func TestCollectPositions_TieredTPATR_Long(t *testing.T) {
 	if len(lines) != 1 {
 		t.Fatalf("expected 1 line, got %d", len(lines))
 	}
+	if !strings.Contains(lines[0], "| ATR: $1,000.00") {
+		t.Errorf("expected ATR fragment, got: %s", lines[0])
+	}
 	if !strings.Contains(lines[0], "| TP1: $64,500.00 (+1.6%) | TP2: $65,500.00 (+3.1%)") {
 		t.Errorf("expected tiered TP fragments for long, got: %s", lines[0])
 	}
@@ -1422,6 +1425,9 @@ func TestCollectPositions_TieredTPATR_Short(t *testing.T) {
 		},
 	}
 	lines := collectPositions(sc, ss, map[string]float64{"BTC/USDT": 63500})
+	if !strings.Contains(lines[0], "| ATR: $1,000.00") {
+		t.Errorf("expected ATR fragment, got: %s", lines[0])
+	}
 	if !strings.Contains(lines[0], "| TP1: $62,500.00 (+1.6%) | TP2: $61,500.00 (+3.1%)") {
 		t.Errorf("expected tiered TP fragments for short, got: %s", lines[0])
 	}
@@ -1442,6 +1448,9 @@ func TestCollectPositions_TieredTPATRLive_Long(t *testing.T) {
 	lines := collectPositions(sc, ss, map[string]float64{"BTC/USDT": 63500})
 	if len(lines) != 1 {
 		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	if !strings.Contains(lines[0], "| ATR: $1,000.00") {
+		t.Errorf("expected ATR fragment, got: %s", lines[0])
 	}
 	want := "| TP1: $64,500.00 (+1.6%) | TP2: $65,500.00 (+3.1%)"
 	if !strings.Contains(lines[0], want) {
@@ -1490,15 +1499,16 @@ func TestCollectPositions_AllFragments_WithTieredTP(t *testing.T) {
 	}
 	got := collectPositions(sc, ss, map[string]float64{"BTC/USDT": 63500})[0]
 	slIdx := strings.Index(got, "| SL:")
+	atrIdx := strings.Index(got, "| ATR:")
 	tp1Idx := strings.Index(got, "| TP1:")
 	tp2Idx := strings.Index(got, "| TP2:")
 	levIdx := strings.Index(got, "| 5x")
 	dateIdx := strings.Index(got, "[Apr 28")
-	if slIdx < 0 || tp1Idx < 0 || tp2Idx < 0 || levIdx < 0 || dateIdx < 0 {
-		t.Fatalf("expected SL, TP1, TP2, leverage, and date fragments, got: %s", got)
+	if slIdx < 0 || atrIdx < 0 || tp1Idx < 0 || tp2Idx < 0 || levIdx < 0 || dateIdx < 0 {
+		t.Fatalf("expected SL, ATR, TP1, TP2, leverage, and date fragments, got: %s", got)
 	}
-	if !(slIdx < tp1Idx && tp1Idx < tp2Idx && tp2Idx < levIdx && levIdx < dateIdx) {
-		t.Errorf("expected SL → TP1 → TP2 → leverage → date ordering, got: %s", got)
+	if !(slIdx < atrIdx && atrIdx < tp1Idx && tp1Idx < tp2Idx && tp2Idx < levIdx && levIdx < dateIdx) {
+		t.Errorf("expected SL → ATR → TP1 → TP2 → leverage → date ordering, got: %s", got)
 	}
 }
 
@@ -1745,8 +1755,8 @@ func TestFormatTradeDMPlain_OpenTrade(t *testing.T) {
 	if !strings.Contains(msg, "LONG") {
 		t.Errorf("expected LONG, got:\n%s", msg)
 	}
-	if !strings.Contains(msg, "Mode: paper") {
-		t.Errorf("expected 'Mode: paper', got:\n%s", msg)
+	if !strings.Contains(msg, "TRADE EXECUTED - PAPER") {
+		t.Errorf("expected 'TRADE EXECUTED - PAPER' in header, got:\n%s", msg)
 	}
 	if strings.Contains(msg, "PnL") {
 		t.Errorf("open trade should not contain PnL, got:\n%s", msg)
@@ -1782,8 +1792,8 @@ func TestFormatTradeDMPlain_CloseTrade(t *testing.T) {
 	if !strings.Contains(msg, "PnL: $34.35") {
 		t.Errorf("expected PnL in close trade, got:\n%s", msg)
 	}
-	if !strings.Contains(msg, "Mode: live") {
-		t.Errorf("expected 'Mode: live', got:\n%s", msg)
+	if !strings.Contains(msg, "TRADE CLOSED - LIVE") {
+		t.Errorf("expected 'TRADE CLOSED - LIVE' in header, got:\n%s", msg)
 	}
 	// Plain format: no Discord bold markdown (**).
 	if strings.Contains(msg, "**") {
@@ -1888,5 +1898,135 @@ func TestFormatCategorySummary_LifetimeStatsNoFallback(t *testing.T) {
 	msgs2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, map[string]LifetimeTradeStats{})
 	if !strings.Contains(msgs2[0], " 0     —") {
 		t.Errorf("expected zero #T/W-L from empty lifetime stats map, got:\n%s", msgs2[0])
+	}
+}
+
+// TestFormatTradeDM_OpenWithATRAndTP verifies that when a strategy uses
+// tiered_tp_atr close and the trade has EntryATR set, the DM includes ATR,
+// TP1, and TP2 on the extras line (#561).
+func TestFormatTradeDM_OpenWithATRAndTP(t *testing.T) {
+	sc := StrategyConfig{
+		ID:              "hl-tatr-btc",
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		CloseStrategies: []string{"tiered_tp_atr"},
+	}
+	trade := Trade{
+		Symbol:   "BTC",
+		Side:     "buy",
+		Quantity: 0.01,
+		Price:    63500.0,
+		Value:    635.0,
+		EntryATR: 1000.0,
+		Details:  "Open long 0.010000 @ $63500.00 (fee $0.22)",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	if !strings.Contains(msg, "ATR: $1,000.00") {
+		t.Errorf("expected 'ATR: $1,000.00' in DM, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "TP1: $64,500.00") {
+		t.Errorf("expected 'TP1: $64,500.00' in DM, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "TP2: $65,500.00") {
+		t.Errorf("expected 'TP2: $65,500.00' in DM, got:\n%s", msg)
+	}
+}
+
+// TestFormatTradeDM_OpenWithSL verifies that a trade with StopLossTriggerPx
+// set shows the SL price and a negative percent on an open trade (#561).
+func TestFormatTradeDM_OpenWithSL(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps"}
+	trade := Trade{
+		Symbol:            "BTC",
+		Side:              "buy",
+		Quantity:          0.01,
+		Price:             63500.0,
+		Value:             635.0,
+		StopLossTriggerPx: 62000.0,
+		Details:           "Open long 0.010000 @ $63500.00 (fee $0.22)",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	if !strings.Contains(msg, "SL: $62,000.00") {
+		t.Errorf("expected 'SL: $62,000.00' in DM, got:\n%s", msg)
+	}
+	// SL is below entry for a long — should be a negative percent.
+	if !strings.Contains(msg, "(-") {
+		t.Errorf("expected negative SL percent for long trade, got:\n%s", msg)
+	}
+}
+
+// TestFormatTradeDM_CloseNoATR verifies that ATR/TP hints are NOT injected on
+// close legs even when EntryATR is set and the strategy uses tiered_tp_atr (#561).
+func TestFormatTradeDM_CloseNoATR(t *testing.T) {
+	sc := StrategyConfig{
+		ID:              "hl-tatr-btc",
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		CloseStrategies: []string{"tiered_tp_atr"},
+	}
+	trade := Trade{
+		Symbol:   "BTC",
+		Side:     "sell",
+		Quantity: 0.01,
+		Price:    64500.0,
+		Value:    645.0,
+		EntryATR: 1000.0,
+		IsClose:  true,
+		Details:  "Close long, PnL: $10.00 (fee $0.23)",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	if strings.Contains(msg, "ATR:") {
+		t.Errorf("close trade should not include ATR hint, got:\n%s", msg)
+	}
+	if strings.Contains(msg, "TP1:") {
+		t.Errorf("close trade should not include TP1 hint, got:\n%s", msg)
+	}
+	if strings.Contains(msg, "TP2:") {
+		t.Errorf("close trade should not include TP2 hint, got:\n%s", msg)
+	}
+}
+
+// TestStampOpenTradeFromPosition verifies the backfill helper for EntryATR and
+// StopLossTriggerPx on the most-recent open trade for a symbol (#561).
+func TestStampOpenTradeFromPosition(t *testing.T) {
+	// (a) updates the most recent open trade for symbol.
+	s := &StrategyState{ID: "s1", TradeHistory: []Trade{
+		{Symbol: "ETH", IsClose: false, EntryATR: 0, StopLossTriggerPx: 0, Timestamp: time.Now().UTC()},
+	}}
+	pos := &Position{EntryATR: 500.0, StopLossTriggerPx: 61000.0}
+	stampOpenTradeFromPosition(s, nil, "ETH", pos)
+	if s.TradeHistory[0].EntryATR != 500.0 {
+		t.Error("EntryATR not stamped")
+	}
+	if s.TradeHistory[0].StopLossTriggerPx != 61000.0 {
+		t.Error("StopLossTriggerPx not stamped")
+	}
+
+	// (b) idempotent: won't overwrite non-zero values.
+	stampOpenTradeFromPosition(s, nil, "ETH", &Position{EntryATR: 999.0, StopLossTriggerPx: 99.0})
+	if s.TradeHistory[0].EntryATR != 500.0 {
+		t.Error("EntryATR overwritten on second call")
+	}
+	if s.TradeHistory[0].StopLossTriggerPx != 61000.0 {
+		t.Error("StopLossTriggerPx overwritten on second call")
+	}
+
+	// (c) skips when most recent matching trade is a close.
+	s2 := &StrategyState{ID: "s2", TradeHistory: []Trade{
+		{Symbol: "ETH", IsClose: false},
+		{Symbol: "ETH", IsClose: true}, // most recent is a close
+	}}
+	stampOpenTradeFromPosition(s2, nil, "ETH", &Position{EntryATR: 500.0})
+	if s2.TradeHistory[0].EntryATR != 0 {
+		t.Error("should not backfill when most recent trade for symbol is a close")
+	}
+
+	// (d) nil pos returns immediately.
+	s3 := &StrategyState{ID: "s3", TradeHistory: []Trade{
+		{Symbol: "ETH", IsClose: false},
+	}}
+	stampOpenTradeFromPosition(s3, nil, "ETH", nil)
+	if s3.TradeHistory[0].EntryATR != 0 {
+		t.Error("nil pos should be a no-op")
 	}
 }

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -1213,20 +1213,22 @@ func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, f
 	positionID := ensurePositionTradeID(s.ID, symbol, pos)
 
 	RecordTrade(s, Trade{
-		Timestamp:   now,
-		StrategyID:  s.ID,
-		Symbol:      symbol,
-		PositionID:  positionID,
-		Side:        closeTradeSide(side),
-		Quantity:    qtyClosed,
-		Price:       fillPx,
-		Value:       qtyClosed * fillPx,
-		TradeType:   "perps",
-		Details:     fmt.Sprintf("Circuit breaker on-chain close, PnL: $%.2f (fee $%.4f)", pnl, fillFee),
-		ExchangeFee: exchangeFeeForTrade(fillFee, true),
-		IsClose:     true,
-		RealizedPnL: pnl,
-		Regime:      s.Regime,
+		Timestamp:         now,
+		StrategyID:        s.ID,
+		Symbol:            symbol,
+		PositionID:        positionID,
+		Side:              closeTradeSide(side),
+		Quantity:          qtyClosed,
+		Price:             fillPx,
+		Value:             qtyClosed * fillPx,
+		TradeType:         "perps",
+		Details:           fmt.Sprintf("Circuit breaker on-chain close, PnL: $%.2f (fee $%.4f)", pnl, fillFee),
+		ExchangeFee:       exchangeFeeForTrade(fillFee, true),
+		IsClose:           true,
+		RealizedPnL:       pnl,
+		Regime:            s.Regime,
+		EntryATR:          pos.EntryATR,
+		StopLossTriggerPx: pos.StopLossTriggerPx,
 	})
 	RecordTradeResult(&s.RiskState, pnl)
 

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -469,7 +469,7 @@ func TestExecuteHyperliquidResult_StopLossFilledImmediately_ReconcilesState(t *t
 
 	logger := silentStrategyLogger("hl-test-eth")
 	defer logger.Close()
-	trades, _ := executeHyperliquidResult(sc, state, result, execResult, "BUY", 3200, logger)
+	trades, _ := executeHyperliquidResult(sc, state, nil, result, execResult, "BUY", 3200, logger)
 
 	// Open + synthetic close = 2 trades.
 	if trades != 2 {
@@ -510,7 +510,7 @@ func TestExecuteHyperliquidResult_StopLossFilledImmediately_NoTriggerPxIsNoOp(t 
 	}
 	logger := silentStrategyLogger("hl")
 	defer logger.Close()
-	trades, _ := executeHyperliquidResult(sc, state, result, execResult, "BUY", 3200, logger)
+	trades, _ := executeHyperliquidResult(sc, state, nil, result, execResult, "BUY", 3200, logger)
 	if trades != 1 {
 		t.Errorf("trades=%d, want 1 (only open recorded; reconcile skipped)", trades)
 	}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1226,7 +1226,7 @@ func main() {
 								}
 								if !liveExecFailed {
 									mu.Lock()
-									trades, detail = executeOKXResult(sc, stratState, result, execResult, signalStr, price, logger)
+									trades, detail = executeOKXResult(sc, stratState, stateDB, result, execResult, signalStr, price, logger)
 									mu.Unlock()
 								}
 							}
@@ -1251,7 +1251,7 @@ func main() {
 								}
 								if !liveExecFailed {
 									mu.Lock()
-									trades, detail = executeRobinhoodResult(sc, stratState, result, execResult, signalStr, price, logger)
+									trades, detail = executeRobinhoodResult(sc, stratState, stateDB, result, execResult, signalStr, price, logger)
 									mu.Unlock()
 								}
 							}
@@ -1262,7 +1262,7 @@ func main() {
 							}
 							mu.Lock()
 							stratState.Regime = result.Regime
-							trades, detail = executeSpotResult(sc, stratState, result, signalStr, price, logger)
+							trades, detail = executeSpotResult(sc, stratState, stateDB, result, signalStr, price, logger)
 							mu.Unlock()
 						}
 					case "options":
@@ -1299,7 +1299,7 @@ func main() {
 								}
 								if !liveExecFailed {
 									mu.Lock()
-									trades, detail = executeOKXResult(sc, stratState, result, execResult, signalStr, price, logger)
+									trades, detail = executeOKXResult(sc, stratState, stateDB, result, execResult, signalStr, price, logger)
 									mu.Unlock()
 								}
 							}
@@ -1404,7 +1404,7 @@ func main() {
 							}
 							if !liveExecFailed {
 								mu.Lock()
-								trades, detail = executeHyperliquidResult(sc, stratState, result, execResult, signalStr, price, logger)
+								trades, detail = executeHyperliquidResult(sc, stratState, stateDB, result, execResult, signalStr, price, logger)
 								mu.Unlock()
 							}
 						}
@@ -1429,7 +1429,7 @@ func main() {
 							}
 							if !liveExecFailed {
 								mu.Lock()
-								trades, detail = executeTopStepResult(sc, stratState, result, execResult, signalStr, price, logger)
+								trades, detail = executeTopStepResult(sc, stratState, stateDB, result, execResult, signalStr, price, logger)
 								mu.Unlock()
 							}
 						}
@@ -1883,13 +1883,16 @@ func runSpotCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionC
 }
 
 // executeSpotResult applies a spot signal to state. Must be called under Lock.
-func executeSpotResult(sc StrategyConfig, s *StrategyState, result *SpotResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
+func executeSpotResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *SpotResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
 	trades, err := ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, price, 0, 0, "", result.CloseFraction, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
 	}
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators, trades)
+	if pos, ok := s.Positions[result.Symbol]; ok {
+		stampOpenTradeFromPosition(s, db, result.Symbol, pos)
+	}
 
 	detail := ""
 	if trades > 0 {
@@ -2325,7 +2328,7 @@ func isHLOpenOrderCapRejection(errStr string) bool {
 
 // executeHyperliquidResult applies a hyperliquid result to state. Must be called under Lock.
 // execResult is non-nil for successful live orders; nil for paper mode.
-func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *HyperliquidResult, execResult *HyperliquidExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
+func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *HyperliquidResult, execResult *HyperliquidExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
 	fillPrice := price
 	var fillQty float64
 	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.AvgPx > 0 {
@@ -2359,6 +2362,9 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 		return 0, ""
 	}
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators, trades)
+	if pos, ok := s.Positions[result.Symbol]; ok {
+		stampOpenTradeFromPosition(s, db, result.Symbol, pos)
+	}
 	if trades > 0 && fillOID != "" {
 		logger.Info("Exchange order ID: %s", fillOID)
 	}
@@ -2381,6 +2387,7 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 				pos.StopLossOID = slOID
 				pos.StopLossTriggerPx = execResult.Execution.Fill.StopLossTriggerPx
 				logger.Info("SL trigger placed oid=%d @ $%.4f", slOID, execResult.Execution.Fill.StopLossTriggerPx)
+				stampOpenTradeFromPosition(s, db, result.Symbol, pos)
 			}
 		}
 	}
@@ -2569,7 +2576,7 @@ func runTopStepExecuteOrder(sc StrategyConfig, result *TopStepResult, price, cas
 }
 
 // executeTopStepResult applies a TopStep futures result to state. Must be called under Lock.
-func executeTopStepResult(sc StrategyConfig, s *StrategyState, result *TopStepResult, execResult *TopStepExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
+func executeTopStepResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *TopStepResult, execResult *TopStepExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
 	fillPrice := price
 	var fillContracts int
 	var fillFee float64
@@ -2595,6 +2602,9 @@ func executeTopStepResult(sc StrategyConfig, s *StrategyState, result *TopStepRe
 		return 0, ""
 	}
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators, trades)
+	if pos, ok := s.Positions[result.Symbol]; ok {
+		stampOpenTradeFromPosition(s, db, result.Symbol, pos)
+	}
 
 	detail := ""
 	if trades > 0 {
@@ -2739,7 +2749,7 @@ func runRobinhoodExecuteOrder(sc StrategyConfig, result *RobinhoodResult, price,
 }
 
 // executeRobinhoodResult applies a Robinhood result to state. Must be called under Lock.
-func executeRobinhoodResult(sc StrategyConfig, s *StrategyState, result *RobinhoodResult, execResult *RobinhoodExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
+func executeRobinhoodResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *RobinhoodResult, execResult *RobinhoodExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
 	fillPrice := price
 	var fillQty float64
 	var fillFee float64
@@ -2758,6 +2768,9 @@ func executeRobinhoodResult(sc StrategyConfig, s *StrategyState, result *Robinho
 		return 0, ""
 	}
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators, trades)
+	if pos, ok := s.Positions[result.Symbol]; ok {
+		stampOpenTradeFromPosition(s, db, result.Symbol, pos)
+	}
 
 	detail := ""
 	if trades > 0 {
@@ -2939,7 +2952,7 @@ func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQt
 }
 
 // executeOKXResult applies an OKX result to state. Must be called under Lock.
-func executeOKXResult(sc StrategyConfig, s *StrategyState, result *OKXResult, execResult *OKXExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
+func executeOKXResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *OKXResult, execResult *OKXExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
 	fillPrice := price
 	var fillQty float64
 	var fillFee float64
@@ -2969,6 +2982,9 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, result *OKXResult, ex
 		return 0, ""
 	}
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators, trades)
+	if pos, ok := s.Positions[result.Symbol]; ok {
+		stampOpenTradeFromPosition(s, db, result.Symbol, pos)
+	}
 
 	detail := ""
 	if trades > 0 {

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -820,7 +820,7 @@ func TestExecuteHyperliquidResult_StampsExchangeData(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, _ := executeHyperliquidResult(sc, s, result, execResult, "BUY", 50000, logger)
+	trades, _ := executeHyperliquidResult(sc, s, nil, result, execResult, "BUY", 50000, logger)
 	if trades != 1 {
 		t.Fatalf("trades = %d, want 1", trades)
 	}
@@ -857,7 +857,7 @@ func TestExecuteHyperliquidResult_PaperModeNoExchangeData(t *testing.T) {
 	defer logger.Close()
 
 	// Paper mode: execResult is nil
-	trades, _ := executeHyperliquidResult(sc, s, result, nil, "BUY", 50000, logger)
+	trades, _ := executeHyperliquidResult(sc, s, nil, result, nil, "BUY", 50000, logger)
 	if trades != 1 {
 		t.Fatalf("trades = %d, want 1", trades)
 	}
@@ -897,7 +897,7 @@ func TestExecuteOKXResult_PerpsStampsExchangeData(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, _ := executeOKXResult(sc, s, result, execResult, "BUY", 50000, logger)
+	trades, _ := executeOKXResult(sc, s, nil, result, execResult, "BUY", 50000, logger)
 	if trades != 1 {
 		t.Fatalf("trades = %d, want 1", trades)
 	}
@@ -936,7 +936,7 @@ func TestExecuteOKXResult_SpotStampsExchangeData(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, _ := executeOKXResult(sc, s, result, execResult, "BUY", 50000, logger)
+	trades, _ := executeOKXResult(sc, s, nil, result, execResult, "BUY", 50000, logger)
 	if trades != 1 {
 		t.Fatalf("trades = %d, want 1", trades)
 	}
@@ -975,7 +975,7 @@ func TestExecuteRobinhoodResult_StampsExchangeData(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, _ := executeRobinhoodResult(sc, s, result, execResult, "BUY", 50000, logger)
+	trades, _ := executeRobinhoodResult(sc, s, nil, result, execResult, "BUY", 50000, logger)
 	if trades != 1 {
 		t.Fatalf("trades = %d, want 1", trades)
 	}
@@ -1074,7 +1074,7 @@ func TestExecuteTopStepResult_StampsExchangeData(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, _ := executeTopStepResult(sc, s, result, execResult, "BUY", 5000, logger)
+	trades, _ := executeTopStepResult(sc, s, nil, result, execResult, "BUY", 5000, logger)
 	if trades != 1 {
 		t.Fatalf("trades = %d, want 1", trades)
 	}

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -217,6 +217,9 @@ type Trade struct {
 	RealizedPnL float64 `json:"realized_pnl,omitempty"`
 	Regime      string  `json:"regime,omitempty"` // market regime label at time of trade (#482)
 
+	EntryATR          float64 `json:"entry_atr,omitempty"`
+	StopLossTriggerPx float64 `json:"stop_loss_trigger_px,omitempty"`
+
 	// persisted tracks whether this Trade has been written to SQLite — set by
 	// RecordTrade on successful InsertTrade and by LoadState for DB-loaded
 	// rows. SaveState uses this flag instead of a MAX(timestamp) check so an

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -154,6 +154,8 @@ func recordPerpsStopLossClose(s *StrategyState, symbol string, triggerPx float64
 		RealizedPnL: pnl,
 	}
 	trade.Regime = s.Regime
+	trade.EntryATR = pos.EntryATR
+	trade.StopLossTriggerPx = pos.StopLossTriggerPx
 	RecordTrade(s, trade)
 	RecordTradeResult(&s.RiskState, pnl)
 	recordClosedPosition(s, pos, triggerPx, pnl, reason, now)
@@ -652,6 +654,8 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 				RealizedPnL:     pnl,
 			}
 			trade.Regime = s.Regime
+			trade.EntryATR = pos.EntryATR
+			trade.StopLossTriggerPx = pos.StopLossTriggerPx
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
 			if partialClose {
@@ -800,6 +804,8 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 				RealizedPnL:     pnl,
 			}
 			trade.Regime = s.Regime
+			trade.EntryATR = pos.EntryATR
+			trade.StopLossTriggerPx = pos.StopLossTriggerPx
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
 			if partialClose {
@@ -977,6 +983,8 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 				RealizedPnL:     pnl,
 			}
 			trade.Regime = s.Regime
+			trade.EntryATR = pos.EntryATR
+			trade.StopLossTriggerPx = pos.StopLossTriggerPx
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
 			if partialClose {
@@ -1102,6 +1110,8 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 				RealizedPnL:     pnl,
 			}
 			trade.Regime = s.Regime
+			trade.EntryATR = pos.EntryATR
+			trade.StopLossTriggerPx = pos.StopLossTriggerPx
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
 			if partialClose {
@@ -1204,6 +1214,8 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 				RealizedPnL:     pnl,
 			}
 			trade.Regime = s.Regime
+			trade.EntryATR = pos.EntryATR
+			trade.StopLossTriggerPx = pos.StopLossTriggerPx
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
 			if partialClose {
@@ -1346,6 +1358,8 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 				RealizedPnL:     pnl,
 			}
 			trade.Regime = s.Regime
+			trade.EntryATR = pos.EntryATR
+			trade.StopLossTriggerPx = pos.StopLossTriggerPx
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
 			if partialClose {
@@ -1433,4 +1447,37 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 		}
 	}
 	return tradesExecuted, nil
+}
+
+// stampOpenTradeFromPosition backfills EntryATR and StopLossTriggerPx onto the
+// most recent open Trade for symbol after those values are stamped onto the
+// Position post-RecordTrade. Only updates fields that are currently zero so
+// subsequent calls are idempotent. Updates both the in-memory slice and the
+// SQLite row when db is non-nil.
+func stampOpenTradeFromPosition(s *StrategyState, db *StateDB, symbol string, pos *Position) {
+	if pos == nil {
+		return
+	}
+	for i := len(s.TradeHistory) - 1; i >= 0; i-- {
+		t := &s.TradeHistory[i]
+		if t.Symbol != symbol {
+			continue
+		}
+		if t.IsClose {
+			return // hit a close first — no open to backfill
+		}
+		changed := false
+		if pos.EntryATR > 0 && t.EntryATR == 0 {
+			t.EntryATR = pos.EntryATR
+			changed = true
+		}
+		if pos.StopLossTriggerPx > 0 && t.StopLossTriggerPx == 0 {
+			t.StopLossTriggerPx = pos.StopLossTriggerPx
+			changed = true
+		}
+		if changed && db != nil {
+			_ = db.UpdateTradeStampedFields(s.ID, t.Timestamp, t.EntryATR, t.StopLossTriggerPx)
+		}
+		return
+	}
 }

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -61,6 +61,7 @@ func TestExecuteSpotResultSetsInitialQuantityAndEntryATR(t *testing.T) {
 	trades, _ := executeSpotResult(
 		StrategyConfig{ID: "spot-test"},
 		state,
+		nil,
 		result,
 		"BUY",
 		100,

--- a/scheduler/regime_alerts_test.go
+++ b/scheduler/regime_alerts_test.go
@@ -53,13 +53,19 @@ func TestFormatTradeDM_RegimeBeforeMode(t *testing.T) {
 		Regime:   "ranging",
 	}
 	msg := FormatTradeDM(sc, trade, "paper")
-	regimeIdx := strings.Index(msg, "Regime:")
-	modeIdx := strings.Index(msg, "Mode:")
-	if regimeIdx == -1 || modeIdx == -1 {
-		t.Fatalf("missing Regime or Mode in DM: %s", msg)
+	// Mode is now embedded in the header line ("TRADE EXECUTED - PAPER"), not
+	// a separate "Mode:" field. Verify Regime appears in the message and that
+	// the header line (containing the mode) precedes the extras line.
+	if !strings.Contains(msg, "Regime: ranging") {
+		t.Fatalf("missing Regime in DM: %s", msg)
 	}
-	if regimeIdx >= modeIdx {
-		t.Errorf("Regime should appear before Mode; got:\n%s", msg)
+	headerIdx := strings.Index(msg, "TRADE EXECUTED - PAPER")
+	regimeIdx := strings.Index(msg, "Regime:")
+	if headerIdx == -1 {
+		t.Fatalf("missing mode in DM header: %s", msg)
+	}
+	if regimeIdx <= headerIdx {
+		t.Errorf("Regime should appear after the header line; got:\n%s", msg)
 	}
 }
 

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1129,19 +1129,21 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 		}
 		positionID := ensurePositionTradeID(s.ID, symbol, pos)
 		trade := Trade{
-			Timestamp:   now,
-			StrategyID:  s.ID,
-			Symbol:      symbol,
-			PositionID:  positionID,
-			Side:        closeTradeSide(pos.Side),
-			Quantity:    pos.Quantity,
-			Price:       price,
-			Value:       value,
-			TradeType:   tradeType,
-			Details:     fmt.Sprintf("Circuit breaker close %s, PnL: $%.2f", pos.Side, pnl),
-			IsClose:     true,
-			RealizedPnL: pnl,
-			Regime:      s.Regime,
+			Timestamp:         now,
+			StrategyID:        s.ID,
+			Symbol:            symbol,
+			PositionID:        positionID,
+			Side:              closeTradeSide(pos.Side),
+			Quantity:          pos.Quantity,
+			Price:             price,
+			Value:             value,
+			TradeType:         tradeType,
+			Details:           fmt.Sprintf("Circuit breaker close %s, PnL: $%.2f", pos.Side, pnl),
+			IsClose:           true,
+			RealizedPnL:       pnl,
+			Regime:            s.Regime,
+			EntryATR:          pos.EntryATR,
+			StopLossTriggerPx: pos.StopLossTriggerPx,
 		}
 		RecordTrade(s, trade)
 		RecordTradeResult(&s.RiskState, pnl)

--- a/scheduler/telegram.go
+++ b/scheduler/telegram.go
@@ -252,21 +252,41 @@ func FormatTradeDMPlain(sc StrategyConfig, trade Trade, mode string) string {
 	typeLabel := sc.Type
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%s %s\n", icon, header))
+	sb.WriteString(fmt.Sprintf("%s %s - %s\n", icon, header, strings.ToUpper(mode)))
 	sb.WriteString(fmt.Sprintf("Strategy: %s (%s %s)\n", sc.ID, platformLabel, typeLabel))
-	sb.WriteString(fmt.Sprintf("%s — %s %.6g @ $%s\n", trade.Symbol, tradeDirectionLabel(trade), trade.Quantity, fmtComma(trade.Price)))
+	sb.WriteString(fmt.Sprintf("%s — %s %.3f @ $%s | Value: $%s", trade.Symbol, tradeDirectionLabel(trade), trade.Quantity, fmtComma(trade.Price), fmtComma(trade.Value)))
 
-	valueLine := fmt.Sprintf("Value: $%s", fmtComma(trade.Value))
+	var extras []string
 	if isClose {
 		if pnl, ok := extractPnL(trade.Details); ok {
-			valueLine += fmt.Sprintf(" | PnL: $%s", pnl)
+			extras = append(extras, fmt.Sprintf("PnL: $%s", pnl))
 		}
 	}
 	if trade.Regime != "" {
-		valueLine += fmt.Sprintf(" | Regime: %s", trade.Regime)
+		extras = append(extras, "Regime: "+trade.Regime)
 	}
-	valueLine += fmt.Sprintf(" | Mode: %s", mode)
-	sb.WriteString(valueLine)
+	if trade.EntryATR > 0 && strategyUsesTieredTPATRClose(sc) {
+		extras = append(extras, fmt.Sprintf("ATR: $%s", fmtComma2(trade.EntryATR)))
+		direction := strings.ToLower(tradeDirectionLabel(trade))
+		var tp1, tp2 float64
+		if direction == "short" {
+			tp1 = trade.Price - trade.EntryATR
+			tp2 = trade.Price - 2*trade.EntryATR
+		} else {
+			tp1 = trade.Price + trade.EntryATR
+			tp2 = trade.Price + 2*trade.EntryATR
+		}
+		extras = append(extras, fmt.Sprintf("TP1: $%s", fmtComma2(tp1)))
+		extras = append(extras, fmt.Sprintf("TP2: $%s", fmtComma2(tp2)))
+	}
+	if trade.StopLossTriggerPx > 0 {
+		direction := strings.ToLower(tradeDirectionLabel(trade))
+		slPct := percentFromEntry(direction, trade.Price, trade.StopLossTriggerPx)
+		extras = append(extras, fmt.Sprintf("SL: $%s (%s)", fmtComma2(trade.StopLossTriggerPx), fmtPnlPct(slPct)))
+	}
+	if len(extras) > 0 {
+		sb.WriteString("\n" + strings.Join(extras, " | "))
+	}
 
 	return sb.String()
 }

--- a/scheduler/telegram.go
+++ b/scheduler/telegram.go
@@ -254,7 +254,7 @@ func FormatTradeDMPlain(sc StrategyConfig, trade Trade, mode string) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%s %s - %s\n", icon, header, strings.ToUpper(mode)))
 	sb.WriteString(fmt.Sprintf("Strategy: %s (%s %s)\n", sc.ID, platformLabel, typeLabel))
-	sb.WriteString(fmt.Sprintf("%s — %s %.3f @ $%s | Value: $%s", trade.Symbol, tradeDirectionLabel(trade), trade.Quantity, fmtComma(trade.Price), fmtComma(trade.Value)))
+	sb.WriteString(fmt.Sprintf("%s — %s %.3f @ $%s | Value: $%s\n", trade.Symbol, tradeDirectionLabel(trade), trade.Quantity, fmtComma(trade.Price), fmtComma(trade.Value)))
 
 	var extras []string
 	if isClose {
@@ -265,7 +265,7 @@ func FormatTradeDMPlain(sc StrategyConfig, trade Trade, mode string) string {
 	if trade.Regime != "" {
 		extras = append(extras, "Regime: "+trade.Regime)
 	}
-	if trade.EntryATR > 0 && strategyUsesTieredTPATRClose(sc) {
+	if !isClose && trade.EntryATR > 0 && strategyUsesTieredTPATRClose(sc) {
 		extras = append(extras, fmt.Sprintf("ATR: $%s", fmtComma2(trade.EntryATR)))
 		direction := strings.ToLower(tradeDirectionLabel(trade))
 		var tp1, tp2 float64
@@ -285,7 +285,7 @@ func FormatTradeDMPlain(sc StrategyConfig, trade Trade, mode string) string {
 		extras = append(extras, fmt.Sprintf("SL: $%s (%s)", fmtComma2(trade.StopLossTriggerPx), fmtPnlPct(slPct)))
 	}
 	if len(extras) > 0 {
-		sb.WriteString("\n" + strings.Join(extras, " | "))
+		sb.WriteString(strings.Join(extras, " | "))
 	}
 
 	return sb.String()


### PR DESCRIPTION
## Summary

- **Quantity precision:** position lines now show `x0.428` instead of `x0.4275141768103672` (`%.3f`)
- **Position summary:** adds `| ATR: $X.XX` between SL and TP1/TP2 when `pos.EntryATR > 0`
- **Trade DM layout:** mode moved to header (`TRADE EXECUTED - LIVE`), Value joined to symbol line, new optional extras line carries ATR + TP1/TP2 + SL on opens and PnL + Regime on closes
- **Persistence:** `Trade` struct gains `EntryATR` and `StopLossTriggerPx` fields backed by two new `trades` table columns; close-leg sites stamp from position at record time; open-leg sites backfill via `stampOpenTradeFromPosition` after `stampEntryATRIfOpened` and SL trigger placement run

## Changes

- `scheduler/portfolio.go` — `Trade` struct fields + close-leg stamping (7 sites) + `stampOpenTradeFromPosition` backfill helper
- `scheduler/db.go` — two new columns (`entry_atr`, `stop_loss_trigger_px`), idempotent migrations, `InsertTrade` + `SaveState` flush INSERT + both SELECT/Scan paths updated, `UpdateTradeStampedFields` helper
- `scheduler/main.go` — backfill calls after each `stampEntryATRIfOpened` (5 sites) + SL trigger stamp
- `scheduler/risk.go`, `hyperliquid_balance.go`, `deribit.go` — close-leg stamping
- `scheduler/discord.go` — `collectPositions` + `FormatTradeDM`
- `scheduler/telegram.go` — `FormatTradeDMPlain`
- `scheduler/discord_test.go`, `regime_alerts_test.go` — updated assertions + new ATR/TP/SL/backfill coverage

## Test Plan

- [x] `go test ./...` passes (all tests green)
- [ ] Position summary shows `x0.428`, `| ATR: $9.20 |` fragment in live summary
- [ ] Trade DM header reads `TRADE EXECUTED - LIVE`, Value on symbol line, ATR+TP1+TP2+SL on extras line when configured
- [ ] `sqlite3 state.db "SELECT entry_atr, stop_loss_trigger_px FROM trades ORDER BY timestamp DESC LIMIT 5"` shows non-zero values after open fills

Closes #561

---
LLM: Claude Sonnet 4.6 (1M) | high