### PR TITLE
fix: reconcile shared-coin HL positions on stop-loss or external close (#565)

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -467,6 +467,99 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 		}
 		delta := virtualQty - onChainQty
 
+		// Detect and reconcile unambiguous shared-coin closes (#565).
+		//
+		// Detector 1 — full external close: on-chain is flat but virtual is not.
+		// Covers stop-loss sweep of the aggregate position, manual close on HL UI,
+		// and kill-switch closes that finish between scheduler cycles.
+		//
+		// Detector 2 — SL owner partial close: exactly one peer holds a resting
+		// trigger (StopLossOID) and the on-chain residual matches the signed sum of
+		// all non-owner peers' virtual qty. HL trigger orders are sized to the
+		// owner's qty at arm time, so when the trigger fires the non-owner peers'
+		// portion remains on-chain untouched.
+		//
+		// All other qty mismatches (ambiguous gaps that #258/#515 protect) fall
+		// through to the gap-recording block unchanged.
+		if math.Abs(onChainQty) < 1e-6 && math.Abs(virtualQty) > 1e-6 {
+			// Detector 1: everything gone on-chain — close all peers.
+			for _, id := range stratIDs {
+				ss := state.Strategies[id]
+				if ss == nil {
+					continue
+				}
+				pos := ss.Positions[coin]
+				if pos == nil {
+					continue
+				}
+				logger, logErr := logMgr.GetStrategyLogger(id)
+				if logErr != nil {
+					fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", id, logErr)
+				}
+				if pos.StopLossOID > 0 && pos.StopLossTriggerPx > 0 {
+					if recordPerpsStopLossClose(ss, coin, pos.StopLossTriggerPx, "hl_sync_stop_loss", logger) {
+						changed = true
+					}
+				} else {
+					recordClosedPosition(ss, pos, 0, 0, "hl_sync_external", now)
+					delete(ss.Positions, coin)
+					clearATRMultMissingEntryATRWarningOnHLPerpsClose(ss, coin)
+					if logger != nil {
+						logger.Info("hl-sync: %s position (%.6f %s) no longer on-chain, removing (external close)", coin, pos.Quantity, pos.Side)
+					}
+					changed = true
+				}
+			}
+			virtualQty = 0.0
+			delta = 0.0
+		} else if math.Abs(delta) > 1e-6 {
+			// Detector 2: partial drop — find the sole SL owner and check whether
+			// the on-chain residual matches the expected post-fire remainder.
+			var slOwnerID string
+			var slOwnerPos *Position
+			for _, id := range stratIDs {
+				ss := state.Strategies[id]
+				if ss == nil {
+					continue
+				}
+				pos := ss.Positions[coin]
+				if pos == nil {
+					continue
+				}
+				if pos.StopLossOID > 0 && pos.StopLossTriggerPx > 0 {
+					if slOwnerID != "" {
+						// Multiple SL owners — ambiguous, skip both detectors.
+						slOwnerID, slOwnerPos = "", nil
+						break
+					}
+					slOwnerID, slOwnerPos = id, pos
+				}
+			}
+			if slOwnerID != "" && slOwnerPos != nil {
+				// Expected residual = signed virtual qty minus the owner's signed qty.
+				expectedResidual := virtualQty
+				if slOwnerPos.Side == "long" {
+					expectedResidual -= slOwnerPos.Quantity
+				} else {
+					expectedResidual += slOwnerPos.Quantity
+				}
+				if math.Abs(onChainQty-expectedResidual) < 1e-6 {
+					ownerSS := state.Strategies[slOwnerID]
+					if ownerSS != nil {
+						logger, logErr := logMgr.GetStrategyLogger(slOwnerID)
+						if logErr != nil {
+							fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", slOwnerID, logErr)
+						}
+						if recordPerpsStopLossClose(ownerSS, coin, slOwnerPos.StopLossTriggerPx, "hl_sync_stop_loss", logger) {
+							changed = true
+							virtualQty = expectedResidual
+							delta = virtualQty - onChainQty
+						}
+					}
+				}
+			}
+		}
+
 		state.ReconciliationGaps[coin] = &ReconciliationGap{
 			Coin:       coin,
 			OnChainQty: onChainQty,

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -670,11 +670,14 @@ func TestAccountSyncSharedCoinSkipsReconciliation(t *testing.T) {
 	}
 }
 
-// TestAccountSyncSharedCoinNotRemovedWhenOnChainGone verifies the phantom
-// circuit breaker fix (#258): when one strategy sells the shared position,
-// the other strategy's virtual position is NOT removed by sync.
-func TestAccountSyncSharedCoinNotRemovedWhenOnChainGone(t *testing.T) {
-	// On-chain ETH position is gone (sold by rmc).
+// TestAccountSyncSharedCoinClosedWhenOnChainGone verifies #565: when one
+// strategy's virtual position is already cleared (rmc sold via
+// ExecutePerpsSignal) and on-chain is fully flat, the remaining peer's stale
+// virtual position (tema) is reconciled away via hl_sync_external. This
+// supersedes the old #258 behavior that left virtual positions intact — that
+// protection is still in place for non-zero on-chain gaps (ambiguous cases).
+func TestAccountSyncSharedCoinClosedWhenOnChainGone(t *testing.T) {
+	// On-chain ETH position is gone (rmc sold its portion, aggregate is flat).
 	ts := setupHLTestServer(1336, []HLPosition{})
 	defer ts.Close()
 
@@ -708,28 +711,30 @@ func TestAccountSyncSharedCoinNotRemovedWhenOnChainGone(t *testing.T) {
 
 	syncHyperliquidAccountPositions(strategies, state, &mu, logMgr)
 
-	// tema's position should NOT be removed (phantom circuit breaker fix).
+	// tema's stale virtual position must be closed by Detector 1 (#565).
 	temaPos := state.Strategies["hl-tema-eth-live"].Positions["ETH"]
-	if temaPos == nil {
-		t.Fatal("hl-tema-eth-live should still have ETH position (shared coin — not removed by sync)")
+	if temaPos != nil {
+		t.Errorf("hl-tema-eth-live ETH position should be nil after external close reconcile, got %+v", temaPos)
 	}
-	if temaPos.Quantity != 0.212 {
-		t.Errorf("tema ETH quantity = %g, want 0.212", temaPos.Quantity)
+	if len(state.Strategies["hl-tema-eth-live"].ClosedPositions) != 1 {
+		t.Errorf("tema ClosedPositions = %d, want 1", len(state.Strategies["hl-tema-eth-live"].ClosedPositions))
+	} else if state.Strategies["hl-tema-eth-live"].ClosedPositions[0].CloseReason != "hl_sync_external" {
+		t.Errorf("CloseReason = %q, want hl_sync_external", state.Strategies["hl-tema-eth-live"].ClosedPositions[0].CloseReason)
 	}
 
-	// Reconciliation gap should show the drift.
+	// Gap should show zero delta after reconciliation.
 	gap := state.ReconciliationGaps["ETH"]
 	if gap == nil {
-		t.Fatal("expected reconciliation gap for ETH")
+		t.Fatal("expected reconciliation gap entry for ETH")
 	}
 	if gap.OnChainQty != 0 {
 		t.Errorf("gap OnChainQty = %g, want 0", gap.OnChainQty)
 	}
-	if gap.VirtualQty != 0.212 {
-		t.Errorf("gap VirtualQty = %g, want 0.212", gap.VirtualQty)
+	if math.Abs(gap.VirtualQty) > 1e-6 {
+		t.Errorf("gap VirtualQty = %g, want ~0 after close", gap.VirtualQty)
 	}
-	if len(gap.Strategies) != 2 {
-		t.Errorf("gap Strategies = %v, want 2 entries", gap.Strategies)
+	if math.Abs(gap.DeltaQty) > 1e-6 {
+		t.Errorf("gap DeltaQty = %g, want ~0 after close", gap.DeltaQty)
 	}
 	if gap.UpdatedAt.IsZero() {
 		t.Error("gap UpdatedAt should be set")
@@ -1133,6 +1138,282 @@ func TestReconcileSharedCoinBothShort(t *testing.T) {
 	}
 	if math.Abs(gap.DeltaQty) > 0.000001 {
 		t.Errorf("gap DeltaQty = %g, want ~0", gap.DeltaQty)
+	}
+}
+
+// --- #565: shared-coin close reconciliation tests ---
+
+// TestReconcileSharedCoin_OwnerStopLossFired_ClosesOwnerOnly verifies that
+// when a shared-coin SL owner's trigger fires (on-chain qty drops to the
+// non-owner peers' residual), only the owner's virtual position is closed.
+func TestReconcileSharedCoin_OwnerStopLossFired_ClosesOwnerOnly(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-eth": {
+				ID: "hl-owner-eth", Cash: 1000, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 1.0, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth",
+						StopLossOID: 42, StopLossTriggerPx: 2900},
+				},
+			},
+			"hl-peer-eth": {
+				ID: "hl-peer-eth", Cash: 500, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-peer-eth"},
+				},
+			},
+		},
+	}
+
+	allStrategies := []StrategyConfig{
+		{ID: "hl-owner-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-peer-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	// Owner fired — on-chain residual is only the peer's 0.5 long.
+	positions := []HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 3000, Leverage: 10}}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions)
+
+	// Owner position must be closed and recorded.
+	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
+		t.Error("owner ETH position should be nil after SL reconciliation")
+	}
+	if len(state.Strategies["hl-owner-eth"].ClosedPositions) != 1 {
+		t.Errorf("owner ClosedPositions = %d, want 1", len(state.Strategies["hl-owner-eth"].ClosedPositions))
+	} else {
+		cp := state.Strategies["hl-owner-eth"].ClosedPositions[0]
+		if cp.CloseReason != "hl_sync_stop_loss" {
+			t.Errorf("CloseReason = %q, want hl_sync_stop_loss", cp.CloseReason)
+		}
+		if math.Abs(cp.ClosePrice-2900) > 0.01 {
+			t.Errorf("ClosePrice = %g, want 2900", cp.ClosePrice)
+		}
+	}
+
+	// Peer position must be untouched.
+	peerPos := state.Strategies["hl-peer-eth"].Positions["ETH"]
+	if peerPos == nil || math.Abs(peerPos.Quantity-0.5) > 1e-6 {
+		t.Errorf("peer ETH = %+v, want 0.5 long (unchanged)", peerPos)
+	}
+
+	// Gap should now show ~zero delta.
+	gap := state.ReconciliationGaps["ETH"]
+	if gap == nil {
+		t.Fatal("expected gap entry for ETH")
+	}
+	if math.Abs(gap.DeltaQty) > 1e-6 {
+		t.Errorf("gap DeltaQty = %g after SL reconcile, want ~0", gap.DeltaQty)
+	}
+}
+
+// TestReconcileSharedCoin_OwnerStopLossFired_Short verifies the short-side mirror.
+func TestReconcileSharedCoin_OwnerStopLossFired_Short(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-eth": {
+				ID: "hl-owner-eth", Cash: 1000, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.8, AvgCost: 3000, Side: "short",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth",
+						StopLossOID: 99, StopLossTriggerPx: 3100},
+				},
+			},
+			"hl-peer-eth": {
+				ID: "hl-peer-eth", Cash: 500, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.3, AvgCost: 3000, Side: "short",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-peer-eth"},
+				},
+			},
+		},
+	}
+
+	allStrategies := []StrategyConfig{
+		{ID: "hl-owner-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-peer-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	// Short positions: on-chain residual after owner's stop = -0.3 (peer only).
+	positions := []HLPosition{{Coin: "ETH", Size: -0.3, EntryPrice: 3000, Leverage: 10}}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions)
+
+	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
+		t.Error("owner short ETH position should be nil after SL reconciliation")
+	}
+	peerPos := state.Strategies["hl-peer-eth"].Positions["ETH"]
+	if peerPos == nil || math.Abs(peerPos.Quantity-0.3) > 1e-6 || peerPos.Side != "short" {
+		t.Errorf("peer ETH = %+v, want 0.3 short (unchanged)", peerPos)
+	}
+}
+
+// TestReconcileSharedCoin_AllPositionsClosedExternally verifies that when
+// on-chain is fully flat, all peers are closed: SL owner via hl_sync_stop_loss,
+// others via hl_sync_external with close price 0.
+func TestReconcileSharedCoin_AllPositionsClosedExternally(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-eth": {
+				ID: "hl-owner-eth", Cash: 1000, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 1.0, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth",
+						StopLossOID: 7, StopLossTriggerPx: 2800},
+				},
+			},
+			"hl-peer-eth": {
+				ID: "hl-peer-eth", Cash: 500, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-peer-eth"},
+				},
+			},
+		},
+	}
+
+	allStrategies := []StrategyConfig{
+		{ID: "hl-owner-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-peer-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	// On-chain: fully flat (aggregate stop sweep / manual close).
+	positions := []HLPosition{}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions)
+
+	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
+		t.Error("owner ETH position should be nil")
+	}
+	if len(state.Strategies["hl-owner-eth"].ClosedPositions) != 1 {
+		t.Errorf("owner ClosedPositions = %d, want 1", len(state.Strategies["hl-owner-eth"].ClosedPositions))
+	} else if state.Strategies["hl-owner-eth"].ClosedPositions[0].CloseReason != "hl_sync_stop_loss" {
+		t.Errorf("owner CloseReason = %q, want hl_sync_stop_loss", state.Strategies["hl-owner-eth"].ClosedPositions[0].CloseReason)
+	}
+
+	if state.Strategies["hl-peer-eth"].Positions["ETH"] != nil {
+		t.Error("peer ETH position should be nil")
+	}
+	if len(state.Strategies["hl-peer-eth"].ClosedPositions) != 1 {
+		t.Errorf("peer ClosedPositions = %d, want 1", len(state.Strategies["hl-peer-eth"].ClosedPositions))
+	} else if state.Strategies["hl-peer-eth"].ClosedPositions[0].CloseReason != "hl_sync_external" {
+		t.Errorf("peer CloseReason = %q, want hl_sync_external", state.Strategies["hl-peer-eth"].ClosedPositions[0].CloseReason)
+	}
+}
+
+// TestReconcileSharedCoin_GapWithoutSLOwner_LeavesPositionsAlone is the
+// regression guard for #258: when no peer holds a stop-loss OID and the gap
+// is non-zero (ambiguous on-chain mismatch), positions must not be touched.
+func TestReconcileSharedCoin_GapWithoutSLOwner_LeavesPositionsAlone(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-a-eth": {
+				ID: "hl-a-eth", Cash: 1000, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.6, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-a-eth"},
+				},
+			},
+			"hl-b-eth": {
+				ID: "hl-b-eth", Cash: 500, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.4, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-b-eth"},
+				},
+			},
+		},
+	}
+
+	allStrategies := []StrategyConfig{
+		{ID: "hl-a-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-b-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	// On-chain qty differs but neither peer has a stop OID — ambiguous gap.
+	positions := []HLPosition{{Coin: "ETH", Size: 0.7, EntryPrice: 3000, Leverage: 10}}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions)
+
+	// Both positions must be untouched.
+	posA := state.Strategies["hl-a-eth"].Positions["ETH"]
+	if posA == nil || math.Abs(posA.Quantity-0.6) > 1e-6 {
+		t.Errorf("hl-a-eth ETH = %+v, want 0.6 (unchanged)", posA)
+	}
+	posB := state.Strategies["hl-b-eth"].Positions["ETH"]
+	if posB == nil || math.Abs(posB.Quantity-0.4) > 1e-6 {
+		t.Errorf("hl-b-eth ETH = %+v, want 0.4 (unchanged)", posB)
+	}
+
+	// Gap should still be recorded with the correct delta.
+	gap := state.ReconciliationGaps["ETH"]
+	if gap == nil {
+		t.Fatal("expected gap entry for ETH")
+	}
+	if math.Abs(gap.DeltaQty-0.3) > 1e-6 {
+		t.Errorf("gap DeltaQty = %g, want 0.3", gap.DeltaQty)
+	}
+}
+
+// TestReconcileSharedCoin_ResidualMismatch_LeavesPositionsAlone verifies that
+// when a SL owner exists but the on-chain qty does not match the expected
+// post-fire residual (e.g. the peer also partially closed), no position is
+// auto-closed — the ambiguous gap is left for operator review.
+func TestReconcileSharedCoin_ResidualMismatch_LeavesPositionsAlone(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-eth": {
+				ID: "hl-owner-eth", Cash: 1000, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 1.0, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth",
+						StopLossOID: 55, StopLossTriggerPx: 2900},
+				},
+			},
+			"hl-peer-eth": {
+				ID: "hl-peer-eth", Cash: 500, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-peer-eth"},
+				},
+			},
+		},
+	}
+
+	allStrategies := []StrategyConfig{
+		{ID: "hl-owner-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-peer-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	// On-chain = 0.2, but expected residual after owner's stop = 0.5 (peer).
+	// The mismatch (0.2 ≠ 0.5) means something else changed — leave it alone.
+	positions := []HLPosition{{Coin: "ETH", Size: 0.2, EntryPrice: 3000, Leverage: 10}}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions)
+
+	// Both positions must be untouched.
+	ownerPos := state.Strategies["hl-owner-eth"].Positions["ETH"]
+	if ownerPos == nil || math.Abs(ownerPos.Quantity-1.0) > 1e-6 {
+		t.Errorf("owner ETH = %+v, want 1.0 (unchanged)", ownerPos)
+	}
+	peerPos := state.Strategies["hl-peer-eth"].Positions["ETH"]
+	if peerPos == nil || math.Abs(peerPos.Quantity-0.5) > 1e-6 {
+		t.Errorf("peer ETH = %+v, want 0.5 (unchanged)", peerPos)
+	}
+
+	gap := state.ReconciliationGaps["ETH"]
+	if gap == nil {
+		t.Fatal("expected gap entry for ETH")
+	}
+	// delta = (1.0 + 0.5) - 0.2 = 1.3
+	if math.Abs(gap.DeltaQty-1.3) > 1e-6 {
+		t.Errorf("gap DeltaQty = %g, want 1.3", gap.DeltaQty)
 	}
 }
 


### PR DESCRIPTION
## Problem

When a shared-coin HL position (multiple strategies on the same wallet coin, e.g. `hl-tema-eth-live` + `hl-rmc-eth-live`) was closed on-chain by a stop-loss trigger or manually, the scheduler's local state never reconciled the close. Virtual positions stayed open indefinitely, causing wrong portfolio values, stale data passed to check scripts, and no recovery path short of hand-editing `state.db`.

Root cause: `reconcileHyperliquidAccountPositions` deliberately skipped destructive updates for shared coins (#258/#515) to avoid phantom CB triggers from intermediate on-chain states. That protection is correct for ambiguous gaps — but unambiguous closes were left unhandled.

## Solution

Two detectors added inside the shared-coin reconciliation loop, after the existing signed-qty computation:

**Detector 1 — full flat**: `|onChainQty| < 1e-6` and `|virtualQty| > 0` → the aggregate position is gone. Closes all peers: SL owner via `recordPerpsStopLossClose` at `StopLossTriggerPx` (reason `hl_sync_stop_loss`), non-owners via `recordClosedPosition` (reason `hl_sync_external`, close price 0).

**Detector 2 — SL owner partial close**: Non-zero on-chain qty with a gap, exactly one peer holds a `StopLossOID`, and the on-chain residual matches the signed sum of all non-owner peers' virtual qty (within `1e-6`). HL trigger orders are sized to the owner's qty at arm time, so when the trigger fires the peers' portion stays on-chain unchanged. Closes the owner only via `recordPerpsStopLossClose`.

All other mismatches (ambiguous gaps) continue to fall through to gap-only recording — the #258/#515 protection is fully preserved.

## Tests

1. `TestReconcileSharedCoin_OwnerStopLossFired_ClosesOwnerOnly` — Detector 2, long
2. `TestReconcileSharedCoin_OwnerStopLossFired_Short` — Detector 2, short
3. `TestReconcileSharedCoin_AllPositionsClosedExternally` — Detector 1, owner + peer
4. `TestReconcileSharedCoin_GapWithoutSLOwner_LeavesPositionsAlone` — regression guard for #258
5. `TestReconcileSharedCoin_ResidualMismatch_LeavesPositionsAlone` — residual mismatch, no close
6. `TestAccountSyncSharedCoinClosedWhenOnChainGone` — updated from the old `NotRemoved` test to assert new correct behavior (tema's stale virtual is closed via `hl_sync_external` when on-chain is flat)

Closes #565

---
LLM: Claude Sonnet 4.6 (1M) | high