### PR TITLE
feat: manual-open/close CLI + type=manual tracking strategy

### DIFF
--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -473,6 +473,7 @@ DEFAULT_PARAM_RANGES = {
         "exit_threshold": [0.0, 0.00002, 0.00005],
         "drift_threshold": [1.5, 2.0, 2.5],
     },
+    "hold": {},  # no parameters — always signal=0; used by type=manual close-eval loop (#569)
 }
 
 

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -969,6 +969,18 @@ func ValidateConfig(cfg *Config) error {
 			if sc.Leverage <= 0 {
 				errs = append(errs, fmt.Sprintf("%s: type=manual requires leverage > 0", prefix))
 			}
+			// Fix #6: manual strategies cannot share a coin with a live perps strategy —
+			// the scheduler's close-eval loop snapshots pos under RLock without owning
+			// the full mutex, creating a TOCTOU window if a perps peer mutates the same position.
+			if sc.Symbol != "" {
+				for _, other := range cfg.Strategies {
+					if other.ID != sc.ID && other.Type == "perps" && other.Platform == "hyperliquid" {
+						if otherSym := hyperliquidSymbol(other.Args); strings.EqualFold(otherSym, sc.Symbol) {
+							errs = append(errs, fmt.Sprintf("%s: type=manual on %s conflicts with perps strategy %s on the same coin — use sub-account isolation", prefix, sc.Symbol, other.ID))
+						}
+					}
+				}
+			}
 		}
 
 		// Live-mode futures require TopStep API credentials.

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -200,8 +200,10 @@ type FuturesConfig struct {
 // StrategyConfig describes a single strategy job.
 type StrategyConfig struct {
 	ID                     string                 `json:"id"`
-	Type                   string                 `json:"type"`     // "spot", "options", "perps", or "futures"
-	Platform               string                 `json:"platform"` // "deribit", "ibkr", "binanceus", "hyperliquid", "topstep"
+	Type                   string                 `json:"type"`                // "spot", "options", "perps", "futures", or "manual"
+	Platform               string                 `json:"platform"`            // "deribit", "ibkr", "binanceus", "hyperliquid", "topstep"
+	Symbol                 string                 `json:"symbol,omitempty"`    // manual strategies: trading symbol (e.g. "ETH")
+	Timeframe              string                 `json:"timeframe,omitempty"` // manual strategies: OHLCV timeframe (e.g. "1h")
 	Script                 string                 `json:"script"`
 	Args                   []string               `json:"args"`
 	OpenStrategy           string                 `json:"open_strategy,omitempty"`    // optional entry strategy override; defaults to Args[0] for backwards compatibility (#480)
@@ -573,6 +575,44 @@ func LoadConfig(path string) (*Config, error) {
 		}
 	}
 
+	// #569: Apply defaults for type=manual HL strategies: auto-set script/args,
+	// default close_strategies, default stop_loss_atr_mult, default TP tiers.
+	for i := range cfg.Strategies {
+		sc := &cfg.Strategies[i]
+		if sc.Type != "manual" || sc.Platform != "hyperliquid" {
+			continue
+		}
+		if sc.Script == "" {
+			sc.Script = "shared_scripts/check_hyperliquid.py"
+		}
+		if len(sc.Args) == 0 && sc.Symbol != "" && sc.Timeframe != "" {
+			mode := "live"
+			sc.Args = []string{"hold", sc.Symbol, sc.Timeframe, "--mode=" + mode}
+		}
+		if sc.Leverage > 0 && sc.SizingLeverage == 0 {
+			sc.SizingLeverage = sc.Leverage
+		}
+		if sc.MarginMode == "" {
+			sc.MarginMode = "isolated"
+		}
+		if len(sc.CloseStrategies) == 0 {
+			sc.CloseStrategies = []string{"tiered_tp_atr_live"}
+		}
+		if sc.StopLossATRMult == nil {
+			defaultMult := DefaultStopLossATRMult
+			sc.StopLossATRMult = &defaultMult
+		}
+		if sc.Params == nil {
+			sc.Params = map[string]interface{}{}
+		}
+		if _, hasTP := sc.Params["tiers"]; !hasTP {
+			sc.Params["tiers"] = []interface{}{
+				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.5},
+				map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
+			}
+		}
+	}
+
 	// #42: Apply portfolio risk defaults if not configured.
 	if cfg.PortfolioRisk == nil {
 		cfg.PortfolioRisk = &PortfolioRiskConfig{MaxDrawdownPct: 25}
@@ -864,24 +904,26 @@ func ValidateConfig(cfg *Config) error {
 			prefix = fmt.Sprintf("strategy[%s]", sc.ID)
 		}
 
-		// #34: Script path validation.
-		if sc.Script == "" {
-			errs = append(errs, fmt.Sprintf("%s: script is empty", prefix))
-		} else {
-			if filepath.IsAbs(sc.Script) {
-				errs = append(errs, fmt.Sprintf("%s: script must be a relative path, got %q", prefix, sc.Script))
-			}
-			if !strings.HasSuffix(sc.Script, ".py") {
-				errs = append(errs, fmt.Sprintf("%s: script must end with .py, got %q", prefix, sc.Script))
-			}
-			if strings.HasPrefix(filepath.Clean(sc.Script), "..") {
-				errs = append(errs, fmt.Sprintf("%s: script path escapes working directory: %q", prefix, sc.Script))
+		// #34: Script path validation (manual strategies auto-set their script in LoadConfig).
+		if sc.Type != "manual" {
+			if sc.Script == "" {
+				errs = append(errs, fmt.Sprintf("%s: script is empty", prefix))
+			} else {
+				if filepath.IsAbs(sc.Script) {
+					errs = append(errs, fmt.Sprintf("%s: script must be a relative path, got %q", prefix, sc.Script))
+				}
+				if !strings.HasSuffix(sc.Script, ".py") {
+					errs = append(errs, fmt.Sprintf("%s: script must end with .py, got %q", prefix, sc.Script))
+				}
+				if strings.HasPrefix(filepath.Clean(sc.Script), "..") {
+					errs = append(errs, fmt.Sprintf("%s: script path escapes working directory: %q", prefix, sc.Script))
+				}
 			}
 		}
 
-		// #36: Type must be "spot", "options", "perps", or "futures".
-		if sc.Type != "spot" && sc.Type != "options" && sc.Type != "perps" && sc.Type != "futures" {
-			errs = append(errs, fmt.Sprintf("%s: type must be \"spot\", \"options\", \"perps\", or \"futures\", got %q", prefix, sc.Type))
+		// #36: Type must be "spot", "options", "perps", "futures", or "manual" (#569).
+		if sc.Type != "spot" && sc.Type != "options" && sc.Type != "perps" && sc.Type != "futures" && sc.Type != "manual" {
+			errs = append(errs, fmt.Sprintf("%s: type must be \"spot\", \"options\", \"perps\", \"futures\", or \"manual\", got %q", prefix, sc.Type))
 		}
 		if usesOpenCloseConfig(sc) && sc.Type == "options" {
 			errs = append(errs, fmt.Sprintf("%s: open_strategy/close_strategies are supported for spot, perps, and futures strategies only", prefix))
@@ -911,6 +953,22 @@ func ValidateConfig(cfg *Config) error {
 		// here until the gate is properly implemented for the multi-position model.
 		if sc.Type == "options" && len(sc.AllowedRegimes) > 0 {
 			errs = append(errs, fmt.Sprintf("%s: allowed_regimes is not enforced for type=options (gate not wired at options dispatch; see issue #553)", prefix))
+		}
+
+		// #569: manual strategies require symbol + timeframe + leverage.
+		if sc.Type == "manual" {
+			if sc.Platform != "hyperliquid" {
+				errs = append(errs, fmt.Sprintf("%s: type=manual is only supported for platform=hyperliquid", prefix))
+			}
+			if strings.TrimSpace(sc.Symbol) == "" {
+				errs = append(errs, fmt.Sprintf("%s: type=manual requires symbol (e.g. \"ETH\")", prefix))
+			}
+			if strings.TrimSpace(sc.Timeframe) == "" {
+				errs = append(errs, fmt.Sprintf("%s: type=manual requires timeframe (e.g. \"1h\")", prefix))
+			}
+			if sc.Leverage <= 0 {
+				errs = append(errs, fmt.Sprintf("%s: type=manual requires leverage > 0", prefix))
+			}
 		}
 
 		// Live-mode futures require TopStep API credentials.
@@ -1016,9 +1074,9 @@ func ValidateConfig(cfg *Config) error {
 		}
 
 		// #254/#497: Leverage is exchange leverage and must be >= 1 when set.
-		// Only applicable to perps.
+		// Only applicable to perps and manual (#569: manual uses leverage for sizing).
 		if sc.Leverage != 0 {
-			if sc.Type != "perps" {
+			if sc.Type != "perps" && sc.Type != "manual" {
 				errs = append(errs, fmt.Sprintf("%s: leverage is only supported for perps strategies (got type %q)", prefix, sc.Type))
 			}
 			if sc.Leverage < 1 || sc.Leverage > 100 {
@@ -1031,7 +1089,7 @@ func ValidateConfig(cfg *Config) error {
 		// bound is a small positive value rather than 1. The math
 		// (cash * sizing_leverage) tolerates fractional values fine.
 		if sc.SizingLeverage != 0 {
-			if sc.Type != "perps" {
+			if sc.Type != "perps" && sc.Type != "manual" {
 				errs = append(errs, fmt.Sprintf("%s: sizing_leverage is only supported for perps strategies (got type %q)", prefix, sc.Type))
 			}
 			if sc.SizingLeverage < 0.01 || sc.SizingLeverage > 100 {
@@ -1060,7 +1118,7 @@ func ValidateConfig(cfg *Config) error {
 			if sc.MarginMode != "isolated" && sc.MarginMode != "cross" {
 				errs = append(errs, fmt.Sprintf("%s: margin_mode must be \"isolated\" or \"cross\", got %q", prefix, sc.MarginMode))
 			}
-			if sc.Type != "perps" || sc.Platform != "hyperliquid" {
+			if (sc.Type != "perps" && sc.Type != "manual") || sc.Platform != "hyperliquid" {
 				errs = append(errs, fmt.Sprintf("%s: margin_mode is only supported for HL perps strategies (got platform=%q type=%q)", prefix, sc.Platform, sc.Type))
 			}
 		}
@@ -1177,7 +1235,7 @@ func ValidateConfig(cfg *Config) error {
 			if mult < 0 {
 				errs = append(errs, fmt.Sprintf("%s: stop_loss_atr_mult must be >= 0, got %g", prefix, mult))
 			}
-			if sc.Type != "perps" || sc.Platform != "hyperliquid" {
+			if (sc.Type != "perps" && sc.Type != "manual") || sc.Platform != "hyperliquid" {
 				errs = append(errs, fmt.Sprintf("%s: stop_loss_atr_mult is only supported for HL perps strategies (got platform=%q type=%q)", prefix, sc.Platform, sc.Type))
 			}
 			if mult > 0 {

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -206,6 +206,7 @@ CREATE TABLE IF NOT EXISTS pending_manual_actions (
     stop_loss_trigger_px REAL NOT NULL DEFAULT 0,
     entry_atr REAL NOT NULL DEFAULT 0,
     realized_pnl REAL NOT NULL DEFAULT 0,
+    is_full_close INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL
 );
 `
@@ -291,6 +292,8 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE trades ADD COLUMN stop_loss_trigger_px REAL NOT NULL DEFAULT 0",
 		// Manual trade flag (#569).
 		"ALTER TABLE trades ADD COLUMN manual INTEGER NOT NULL DEFAULT 0",
+		// Operator-intent full-close flag for manual close actions (#569 review).
+		"ALTER TABLE pending_manual_actions ADD COLUMN is_full_close INTEGER NOT NULL DEFAULT 0",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -1443,6 +1446,7 @@ type PendingManualAction struct {
 	StopLossTriggerPx float64
 	EntryATR          float64
 	RealizedPnL       float64
+	IsFullClose       bool // close-only: operator/scheduler intent flag (avoids tolerance heuristics on the drain side)
 	CreatedAt         time.Time
 }
 
@@ -1452,12 +1456,16 @@ func (sdb *StateDB) InsertPendingManualAction(a PendingManualAction) error {
 	if sdb == nil || sdb.db == nil {
 		return fmt.Errorf("state db unavailable")
 	}
+	isFullClose := 0
+	if a.IsFullClose {
+		isFullClose = 1
+	}
 	_, err := sdb.db.Exec(`INSERT INTO pending_manual_actions
-		(strategy_id, action, symbol, side, quantity, fill_price, fill_fee, exchange_order_id, stop_loss_oid, stop_loss_trigger_px, entry_atr, realized_pnl, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		(strategy_id, action, symbol, side, quantity, fill_price, fill_fee, exchange_order_id, stop_loss_oid, stop_loss_trigger_px, entry_atr, realized_pnl, is_full_close, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.StrategyID, a.Action, a.Symbol, a.Side, a.Quantity, a.FillPrice, a.FillFee,
 		a.ExchangeOrderID, a.StopLossOID, a.StopLossTriggerPx, a.EntryATR, a.RealizedPnL,
-		formatTime(a.CreatedAt))
+		isFullClose, formatTime(a.CreatedAt))
 	return err
 }
 
@@ -1466,7 +1474,7 @@ func (sdb *StateDB) LoadPendingManualActions() ([]PendingManualAction, error) {
 	if sdb == nil || sdb.db == nil {
 		return nil, nil
 	}
-	rows, err := sdb.db.Query(`SELECT id, strategy_id, action, symbol, side, quantity, fill_price, fill_fee, exchange_order_id, stop_loss_oid, stop_loss_trigger_px, entry_atr, realized_pnl, created_at FROM pending_manual_actions ORDER BY id`)
+	rows, err := sdb.db.Query(`SELECT id, strategy_id, action, symbol, side, quantity, fill_price, fill_fee, exchange_order_id, stop_loss_oid, stop_loss_trigger_px, entry_atr, realized_pnl, COALESCE(is_full_close, 0) AS is_full_close, created_at FROM pending_manual_actions ORDER BY id`)
 	if err != nil {
 		return nil, fmt.Errorf("load pending manual actions: %w", err)
 	}
@@ -1475,9 +1483,11 @@ func (sdb *StateDB) LoadPendingManualActions() ([]PendingManualAction, error) {
 	for rows.Next() {
 		var a PendingManualAction
 		var createdStr string
-		if err := rows.Scan(&a.ID, &a.StrategyID, &a.Action, &a.Symbol, &a.Side, &a.Quantity, &a.FillPrice, &a.FillFee, &a.ExchangeOrderID, &a.StopLossOID, &a.StopLossTriggerPx, &a.EntryATR, &a.RealizedPnL, &createdStr); err != nil {
+		var isFullCloseInt int
+		if err := rows.Scan(&a.ID, &a.StrategyID, &a.Action, &a.Symbol, &a.Side, &a.Quantity, &a.FillPrice, &a.FillFee, &a.ExchangeOrderID, &a.StopLossOID, &a.StopLossTriggerPx, &a.EntryATR, &a.RealizedPnL, &isFullCloseInt, &createdStr); err != nil {
 			return nil, fmt.Errorf("scan pending manual action: %w", err)
 		}
+		a.IsFullClose = isFullCloseInt != 0
 		a.CreatedAt = parseTime(createdStr)
 		actions = append(actions, a)
 	}

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -191,6 +191,23 @@ CREATE TABLE IF NOT EXISTS correlation_snapshot (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     snapshot_json TEXT NOT NULL DEFAULT '{}'
 );
+
+CREATE TABLE IF NOT EXISTS pending_manual_actions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    strategy_id TEXT NOT NULL,
+    action TEXT NOT NULL,
+    symbol TEXT NOT NULL,
+    side TEXT NOT NULL,
+    quantity REAL NOT NULL,
+    fill_price REAL NOT NULL,
+    fill_fee REAL NOT NULL DEFAULT 0,
+    exchange_order_id TEXT NOT NULL DEFAULT '',
+    stop_loss_oid INTEGER NOT NULL DEFAULT 0,
+    stop_loss_trigger_px REAL NOT NULL DEFAULT 0,
+    entry_atr REAL NOT NULL DEFAULT 0,
+    realized_pnl REAL NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL
+);
 `
 
 // StateDB wraps a SQLite database for persistent state storage.
@@ -272,6 +289,8 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE trades ADD COLUMN regime TEXT NOT NULL DEFAULT ''",
 		"ALTER TABLE trades ADD COLUMN entry_atr REAL NOT NULL DEFAULT 0",
 		"ALTER TABLE trades ADD COLUMN stop_loss_trigger_px REAL NOT NULL DEFAULT 0",
+		// Manual trade flag (#569).
+		"ALTER TABLE trades ADD COLUMN manual INTEGER NOT NULL DEFAULT 0",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -468,13 +487,17 @@ func (sdb *StateDB) InsertTrade(strategyID string, trade Trade) error {
 	if trade.IsClose {
 		isClose = 1
 	}
+	isManual := 0
+	if trade.Manual {
+		isManual = 1
+	}
 	_, err := sdb.db.Exec(`INSERT INTO trades
-			(strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, regime, entry_atr, stop_loss_trigger_px)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			(strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, regime, entry_atr, stop_loss_trigger_px, manual)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		strategyID, formatTime(trade.Timestamp), trade.Symbol, trade.PositionID, trade.Side,
 		trade.Quantity, trade.Price, trade.Value, trade.TradeType, trade.Details,
 		trade.ExchangeOrderID, trade.ExchangeFee, isClose, trade.RealizedPnL, trade.Regime,
-		trade.EntryATR, trade.StopLossTriggerPx)
+		trade.EntryATR, trade.StopLossTriggerPx, isManual)
 	if err != nil {
 		return fmt.Errorf("insert trade for %s: %w", strategyID, err)
 	}
@@ -705,8 +728,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	//    failed, even if later-timestamped rows were persisted successfully
 	//    (fixes the MAX(timestamp) dedup gap that would silently drop
 	//    out-of-order retries).
-	stmtTrade, err := tx.Prepare(`INSERT INTO trades (strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, regime, entry_atr, stop_loss_trigger_px)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtTrade, err := tx.Prepare(`INSERT INTO trades (strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, regime, entry_atr, stop_loss_trigger_px, manual)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare trade insert: %w", err)
 	}
@@ -730,7 +753,11 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 			if t.IsClose {
 				isClose = 1
 			}
-			if _, err := stmtTrade.Exec(s.ID, formatTime(t.Timestamp), t.Symbol, t.PositionID, t.Side, t.Quantity, t.Price, t.Value, t.TradeType, t.Details, t.ExchangeOrderID, t.ExchangeFee, isClose, t.RealizedPnL, t.Regime, t.EntryATR, t.StopLossTriggerPx); err != nil {
+			isManual := 0
+			if t.Manual {
+				isManual = 1
+			}
+			if _, err := stmtTrade.Exec(s.ID, formatTime(t.Timestamp), t.Symbol, t.PositionID, t.Side, t.Quantity, t.Price, t.Value, t.TradeType, t.Details, t.ExchangeOrderID, t.ExchangeFee, isClose, t.RealizedPnL, t.Regime, t.EntryATR, t.StopLossTriggerPx, isManual); err != nil {
 				return fmt.Errorf("insert trade for %s: %w", s.ID, err)
 			}
 			flushed = append(flushed, trackedFlush{strat: s, index: i})
@@ -1139,7 +1166,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 
 	// 5. Load most recent 1000 trades per strategy (full history stays in SQLite).
 	for id, s := range state.Strategies {
-		tradeRows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime, COALESCE(entry_atr, 0) AS entry_atr, COALESCE(stop_loss_trigger_px, 0) AS stop_loss_trigger_px
+		tradeRows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime, COALESCE(entry_atr, 0) AS entry_atr, COALESCE(stop_loss_trigger_px, 0) AS stop_loss_trigger_px, COALESCE(manual, 0) AS manual
 			FROM trades WHERE strategy_id = ? ORDER BY timestamp ASC`, id)
 		if err != nil {
 			return nil, fmt.Errorf("load trades for %s: %w", id, err)
@@ -1148,13 +1175,14 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		for tradeRows.Next() {
 			var t Trade
 			var tsStr string
-			var isCloseInt int
-			if err := tradeRows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL, &t.Regime, &t.EntryATR, &t.StopLossTriggerPx); err != nil {
+			var isCloseInt, isManualInt int
+			if err := tradeRows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL, &t.Regime, &t.EntryATR, &t.StopLossTriggerPx, &isManualInt); err != nil {
 				tradeRows.Close()
 				return nil, fmt.Errorf("scan trade: %w", err)
 			}
 			t.Timestamp = parseTime(tsStr)
 			t.IsClose = isCloseInt != 0
+			t.Manual = isManualInt != 0
 			t.persisted = true // loaded from DB → already persisted; SaveState will skip.
 			allTrades = append(allTrades, t)
 		}
@@ -1396,6 +1424,73 @@ func (sdb *StateDB) QueryTradingViewExportTrades(strategyIDs []string) ([]Trade,
 		trades = []Trade{}
 	}
 	return trades, nil
+}
+
+// PendingManualAction is a row from the pending_manual_actions queue table
+// written by the manual-open / manual-close CLI and drained by the scheduler
+// at the top of each cycle (#569).
+type PendingManualAction struct {
+	ID                int64
+	StrategyID        string
+	Action            string // "open" | "close"
+	Symbol            string
+	Side              string
+	Quantity          float64
+	FillPrice         float64
+	FillFee           float64
+	ExchangeOrderID   string
+	StopLossOID       int64
+	StopLossTriggerPx float64
+	EntryATR          float64
+	RealizedPnL       float64
+	CreatedAt         time.Time
+}
+
+// InsertPendingManualAction enqueues a manual-open or manual-close action for
+// the scheduler to drain on its next cycle.
+func (sdb *StateDB) InsertPendingManualAction(a PendingManualAction) error {
+	if sdb == nil || sdb.db == nil {
+		return fmt.Errorf("state db unavailable")
+	}
+	_, err := sdb.db.Exec(`INSERT INTO pending_manual_actions
+		(strategy_id, action, symbol, side, quantity, fill_price, fill_fee, exchange_order_id, stop_loss_oid, stop_loss_trigger_px, entry_atr, realized_pnl, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		a.StrategyID, a.Action, a.Symbol, a.Side, a.Quantity, a.FillPrice, a.FillFee,
+		a.ExchangeOrderID, a.StopLossOID, a.StopLossTriggerPx, a.EntryATR, a.RealizedPnL,
+		formatTime(a.CreatedAt))
+	return err
+}
+
+// LoadPendingManualActions returns all queued actions ordered by id (oldest first).
+func (sdb *StateDB) LoadPendingManualActions() ([]PendingManualAction, error) {
+	if sdb == nil || sdb.db == nil {
+		return nil, nil
+	}
+	rows, err := sdb.db.Query(`SELECT id, strategy_id, action, symbol, side, quantity, fill_price, fill_fee, exchange_order_id, stop_loss_oid, stop_loss_trigger_px, entry_atr, realized_pnl, created_at FROM pending_manual_actions ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("load pending manual actions: %w", err)
+	}
+	defer rows.Close()
+	var actions []PendingManualAction
+	for rows.Next() {
+		var a PendingManualAction
+		var createdStr string
+		if err := rows.Scan(&a.ID, &a.StrategyID, &a.Action, &a.Symbol, &a.Side, &a.Quantity, &a.FillPrice, &a.FillFee, &a.ExchangeOrderID, &a.StopLossOID, &a.StopLossTriggerPx, &a.EntryATR, &a.RealizedPnL, &createdStr); err != nil {
+			return nil, fmt.Errorf("scan pending manual action: %w", err)
+		}
+		a.CreatedAt = parseTime(createdStr)
+		actions = append(actions, a)
+	}
+	return actions, rows.Err()
+}
+
+// DeletePendingManualActionsThrough deletes all rows with id <= maxID.
+func (sdb *StateDB) DeletePendingManualActionsThrough(maxID int64) error {
+	if sdb == nil || sdb.db == nil {
+		return nil
+	}
+	_, err := sdb.db.Exec("DELETE FROM pending_manual_actions WHERE id <= ?", maxID)
+	return err
 }
 
 // formatTime converts a time.Time to RFC 3339 string, or "" for zero time.

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -247,7 +247,7 @@ func discoverStrategies() {
 }
 
 func hasAnyEnabledStrategyType(opts InitOptions) bool {
-	return opts.EnableSpot || opts.EnableOptions || opts.EnablePerps || opts.EnableFutures || opts.EnableRobinhood || opts.EnableLuno || opts.EnableOKX
+	return opts.EnableSpot || opts.EnableOptions || opts.EnablePerps || opts.EnableFutures || opts.EnableRobinhood || opts.EnableLuno || opts.EnableOKX || opts.EnableManual
 }
 
 // applyMinimalStarterDefaults turns the empty/default init path into one safe,
@@ -355,6 +355,13 @@ type InitOptions struct {
 	TelegramOwnerChatID       string            // Telegram chat ID for owner DMs
 	TelegramChannelMap        map[string]string // keyed by platform/type ("spot", "hyperliquid", etc.)
 	AutoUpdate                string            // "off", "daily", "heartbeat" (default: "off")
+	// #569: Manual trading tracking strategy.
+	EnableManual    bool
+	ManualSymbol    string
+	ManualTimeframe string
+	ManualCapital   float64
+	ManualDrawdown  float64
+	ManualLeverage  float64
 }
 
 // generateConfig builds a Config from InitOptions. Pure function, no I/O.
@@ -642,6 +649,33 @@ func generateConfig(opts InitOptions) *Config {
 				})
 			}
 		}
+	}
+
+	// #569: Manual trading tracking strategy.
+	if opts.EnableManual && opts.ManualSymbol != "" {
+		tf := opts.ManualTimeframe
+		if tf == "" {
+			tf = "1h"
+		}
+		lev := opts.ManualLeverage
+		if lev <= 0 {
+			lev = 1
+		}
+		dd := opts.ManualDrawdown
+		if dd <= 0 {
+			dd = 20
+		}
+		id := fmt.Sprintf("hl-manual-%s-live", strings.ToLower(opts.ManualSymbol))
+		cfg.Strategies = append(cfg.Strategies, StrategyConfig{
+			ID:             id,
+			Type:           "manual",
+			Platform:       "hyperliquid",
+			Symbol:         opts.ManualSymbol,
+			Timeframe:      tf,
+			Capital:        opts.ManualCapital,
+			MaxDrawdownPct: dd,
+			Leverage:       lev,
+		})
 	}
 
 	// Apply HTF filter to all non-options strategies if enabled.
@@ -1194,6 +1228,22 @@ func runInit(args []string) int {
 		}
 	}
 
+	// #569: Manual trading tracking strategy.
+	enableManual := false
+	manualSymbol := ""
+	manualTimeframe := "1h"
+	manualCapital := 1000.0
+	manualDrawdown := 20.0
+	manualLeverage := 10.0
+	if p.YesNo("Do you plan to do any manual trading on Hyperliquid?", false) {
+		enableManual = true
+		manualSymbol = strings.TrimSpace(p.String("Symbol for manual trades (e.g. ETH)", "ETH"))
+		manualTimeframe = strings.TrimSpace(p.String("Timeframe for TP evaluation", "1h"))
+		manualCapital = p.FloatRange("Capital budget (USD)", 1000, 1, 1e9)
+		manualLeverage = p.FloatRange("Leverage", 10, 1, 100)
+		manualDrawdown = p.FloatRange("Max drawdown %", 20, 1, 100)
+	}
+
 	// Notifications default to disabled.
 	discordEnabled := false
 	channelMap := make(map[string]string)
@@ -1296,6 +1346,12 @@ func runInit(args []string) int {
 		OKXCapital:                okxCapital,
 		OKXDrawdown:               okxDrawdown,
 		HTFFilter:                 htfFilter,
+		EnableManual:              enableManual,
+		ManualSymbol:              manualSymbol,
+		ManualTimeframe:           manualTimeframe,
+		ManualCapital:             manualCapital,
+		ManualDrawdown:            manualDrawdown,
+		ManualLeverage:            manualLeverage,
 		PortfolioMaxDrawdownPct:   portfolioMaxDD,
 		PortfolioWarnThresholdPct: portfolioWarnPct,
 		DiscordEnabled:            discordEnabled,

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -20,6 +20,10 @@ func main() {
 			os.Exit(runInit(os.Args[2:]))
 		case "export":
 			os.Exit(runExport(os.Args[2:]))
+		case "manual-open":
+			os.Exit(runManualOpen(os.Args[2:]))
+		case "manual-close":
+			os.Exit(runManualClose(os.Args[2:]))
 		}
 	}
 
@@ -421,6 +425,12 @@ func main() {
 		totalTrades := 0
 		channelTrades := make(map[string]int)
 		channelTradeDetails := make(map[string][]string)
+
+		// #569: Drain pending manual-open / manual-close actions before the
+		// dueStrategies loop so newly-materialised positions are visible this cycle.
+		mu.Lock()
+		drainPendingManualActions(state, cfg, stateDB)
+		mu.Unlock()
 
 		// #87: Resolve capital_pct → capital for strategies with dynamic sizing.
 		// Must run on cfg.Strategies (not dueStrategies) so resolved capital persists
@@ -1478,6 +1488,70 @@ func main() {
 								mu.Lock()
 								trades, detail = executeTopStepResult(sc, stratState, stateDB, result, execResult, signalStr, price, logger)
 								mu.Unlock()
+							}
+						}
+					case "manual":
+						// #569: manual strategies have no open signal; only run
+						// close evaluators when a position is open.
+						if closeFraction, _, ok := runManualCloseEval(sc, stratState, cfg, logger); ok && closeFraction > 0 {
+							mu.RLock()
+							pos := stratState.Positions[sc.Symbol]
+							mu.RUnlock()
+							if pos != nil {
+								closeQty := pos.Quantity * closeFraction
+								closeSide := "sell"
+								if pos.Side == "short" {
+									closeSide = "buy"
+								}
+								execResult, execStderr, execErr := RunHyperliquidExecute(
+									sc.Script, sc.Symbol, closeSide, closeQty,
+									0, pos.StopLossOID, 0, "", 0,
+								)
+								if execStderr != "" {
+									logger.Info("HL manual close stderr: %s", execStderr)
+								}
+								if execErr != nil {
+									logger.Error("manual close execute failed: %v", execErr)
+									break
+								}
+								if execResult.Error != "" {
+									logger.Error("manual close HL error: %s", execResult.Error)
+									break
+								}
+								if execResult.Execution != nil && execResult.Execution.Fill != nil {
+									fill := execResult.Execution.Fill
+									var oid string
+									if fill.OID != 0 {
+										oid = fmt.Sprintf("%d", fill.OID)
+									}
+									var realizedPnL float64
+									if pos.Side == "long" {
+										realizedPnL = closeQty * (fill.AvgPx - pos.AvgCost)
+									} else {
+										realizedPnL = closeQty * (pos.AvgCost - fill.AvgPx)
+									}
+									realizedPnL -= fill.Fee
+									action := PendingManualAction{
+										StrategyID:      sc.ID,
+										Action:          "close",
+										Symbol:          sc.Symbol,
+										Side:            closeSide,
+										Quantity:        closeQty,
+										FillPrice:       fill.AvgPx,
+										FillFee:         fill.Fee,
+										ExchangeOrderID: oid,
+										RealizedPnL:     realizedPnL,
+										CreatedAt:       time.Now().UTC(),
+									}
+									if err := stateDB.InsertPendingManualAction(action); err != nil {
+										logger.Error("failed to queue manual close action: %v", err)
+									} else {
+										prices[sc.Symbol] = fill.AvgPx
+										trades = 1
+										detail = fmt.Sprintf("manual close %.4f %s @ $%.2f | PnL=$%.2f", closeQty, sc.Symbol, fill.AvgPx, realizedPnL)
+										logger.Info("Queued manual close: %s", detail)
+									}
+								}
 							}
 						}
 					default:

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1504,9 +1504,10 @@ func main() {
 									closeSide = "buy"
 								}
 								// Fix #2: only cancel the SL on a full close; leave it resting on partial.
-								isFullClose := closeQty >= pos.Quantity*0.99
+								// Intent is full-close iff the close-eval returned closeFraction >= 1.
+								intentFullClose := closeFraction >= 1.0
 								cancelOID := int64(0)
-								if isFullClose {
+								if intentFullClose {
 									cancelOID = pos.StopLossOID
 								}
 								execResult, execStderr, execErr := RunHyperliquidExecute(
@@ -1547,6 +1548,7 @@ func main() {
 										FillFee:         fill.Fee,
 										ExchangeOrderID: oid,
 										RealizedPnL:     realizedPnL,
+										IsFullClose:     intentFullClose,
 										CreatedAt:       time.Now().UTC(),
 									}
 									if err := stateDB.InsertPendingManualAction(action); err != nil {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1503,9 +1503,15 @@ func main() {
 								if pos.Side == "short" {
 									closeSide = "buy"
 								}
+								// Fix #2: only cancel the SL on a full close; leave it resting on partial.
+								isFullClose := closeQty >= pos.Quantity*0.99
+								cancelOID := int64(0)
+								if isFullClose {
+									cancelOID = pos.StopLossOID
+								}
 								execResult, execStderr, execErr := RunHyperliquidExecute(
 									sc.Script, sc.Symbol, closeSide, closeQty,
-									0, pos.StopLossOID, 0, "", 0,
+									0, cancelOID, 0, "", 0,
 								)
 								if execStderr != "" {
 									logger.Info("HL manual close stderr: %s", execStderr)

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -146,6 +146,12 @@ func runManualOpen(args []string) int {
 			fmt.Fprintf(os.Stderr, "error: --atr %.4f exceeds 50%% of fill price %.4f (plausibility guard)\n", entryATR, resolvedFillPrice)
 			return 1
 		}
+		// --record-only does not auto-arm the SL trigger (the operator placed
+		// the fill on the UI, so they're responsible for its protection).
+		// Warn if the operator passed SL-related flags that won't take effect.
+		if (*slATRMult > 0 || *slPct > 0 || (sc.StopLossATRMult != nil && *sc.StopLossATRMult > 0)) {
+			fmt.Fprintln(os.Stderr, "warning: --record-only does not arm a stop-loss trigger automatically — place the SL manually on the HL UI")
+		}
 	} else {
 		execResult, execStderr, execErr := RunHyperliquidExecute(
 			script, sc.Symbol, openSide,
@@ -292,13 +298,22 @@ func runManualClose(args []string) int {
 		return 1
 	}
 
+	// Operator intent: --qty omitted (or equal to the full position) is a full
+	// close; any smaller value is a partial close. We track this explicitly
+	// rather than inferring from the eventual fill quantity, since lot-size
+	// rounding can otherwise collapse a deliberate ~99% partial into a full.
 	closeQty := pos.Quantity
+	intentFullClose := true
 	if *qty > 0 {
 		if *qty > pos.Quantity {
 			fmt.Fprintf(os.Stderr, "error: --qty %.6f exceeds open position %.6f\n", *qty, pos.Quantity)
 			return 1
 		}
 		closeQty = *qty
+		// Within 0.0001 (typical HL lot size) is treated as full close.
+		if pos.Quantity-*qty > 0.0001 {
+			intentFullClose = false
+		}
 	}
 
 	closeSide := "sell"
@@ -313,9 +328,8 @@ func runManualClose(args []string) int {
 	}
 
 	// Fix #2: only cancel the SL on a full close; leave it resting on partial close.
-	isFullClose := closeQty >= pos.Quantity*0.99
 	cancelOID := int64(0)
-	if isFullClose {
+	if intentFullClose {
 		cancelOID = pos.StopLossOID
 	}
 
@@ -369,6 +383,7 @@ func runManualClose(args []string) int {
 		FillFee:         fillFee,
 		ExchangeOrderID: exchangeOID,
 		RealizedPnL:     realizedPnL,
+		IsFullClose:     intentFullClose,
 		CreatedAt:       time.Now().UTC(),
 	}
 	if err := stateDB.InsertPendingManualAction(action); err != nil {
@@ -489,8 +504,10 @@ func applyManualAction(state *AppState, scByID map[string]StrategyConfig, a Pend
 		if !exists || pos == nil {
 			return fmt.Errorf("no open position for %s/%s", a.StrategyID, a.Symbol)
 		}
-		// Fix #5: use 0.99 relative tolerance matching HL lot-size rounding semantics.
-		closedFull := a.Quantity >= pos.Quantity*0.99
+		// Use the explicit IsFullClose intent flag rather than a tolerance
+		// heuristic, so a deliberate 99% partial close isn't silently
+		// collapsed into a full close.
+		closedFull := a.IsFullClose
 		side := closeTradeSide(pos.Side)
 
 		trade := Trade{

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -22,7 +21,8 @@ func runManualOpen(args []string) int {
 	atr := fs.Float64("atr", 0, "ATR value to stamp on the position (required for ATR-based stops when not auto-fetched)")
 	slATRMult := fs.Float64("stop-loss-atr-mult", 0, "Override stop_loss_atr_mult for this position (0 = use strategy default)")
 	slPct := fs.Float64("stop-loss-pct", 0, "Override stop_loss_pct for this position (0 = use strategy default)")
-	recordOnly := fs.Bool("record-only", false, "Register an existing fill; skip placing a new on-chain order")
+	fillPrice := fs.Float64("fill-price", 0, "Fill price for --record-only (required when --record-only is set)")
+	recordOnly := fs.Bool("record-only", false, "Register an existing fill without placing a new on-chain order")
 	dryRun := fs.Bool("dry-run", false, "Print planned action without placing order or mutating state")
 
 	if err := fs.Parse(args); err != nil {
@@ -69,6 +69,17 @@ func runManualOpen(args []string) int {
 		return 2
 	}
 
+	if *recordOnly {
+		if *size <= 0 {
+			fmt.Fprintln(os.Stderr, "error: --record-only requires --size (coin qty of the fill you placed)")
+			return 2
+		}
+		if *fillPrice <= 0 {
+			fmt.Fprintln(os.Stderr, "error: --record-only requires --fill-price (the price at which your fill executed)")
+			return 2
+		}
+	}
+
 	stateDB, err := OpenStateDB(cfg.DBFile)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to open state DB: %v\n", err)
@@ -76,98 +87,109 @@ func runManualOpen(args []string) int {
 	}
 	defer stateDB.Close()
 
-	// Resolve order size (coin qty). For --notional / --margin we need the
-	// current price, which comes back from the execute result itself (or a
-	// price-check subprocess). For simplicity: resolve after the fill.
-	// The Python executor returns the actual fill price, so we compute qty
-	// from the fill if notional/margin was specified.
+	// Fix #4: guard against placing into a kill-switched or CB-pending account.
+	if !*dryRun {
+		state, loadErr := LoadStateWithDB(cfg, stateDB)
+		if loadErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not load state for safety check: %v\n", loadErr)
+		} else {
+			if state.PortfolioRisk.KillSwitchActive {
+				fmt.Fprintln(os.Stderr, "error: portfolio kill switch is active — manual-open blocked (use manual-close to flatten)")
+				return 1
+			}
+			if ss := state.Strategies[strategyID]; ss != nil {
+				if ss.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid) != nil {
+					fmt.Fprintln(os.Stderr, "error: strategy has a pending circuit-breaker close — manual-open blocked")
+					return 1
+				}
+			}
+		}
+	}
+
+	// ATR plausibility guard: mirror stampEntryATRIfOpened's 50%-of-AvgCost check.
+	// We don't have fillPrice yet for live orders so defer to post-fill; for
+	// --record-only we can check immediately.
+	entryATR := *atr
+	if *recordOnly && entryATR > 0 && *fillPrice > 0 && entryATR > 0.5**fillPrice {
+		fmt.Fprintf(os.Stderr, "error: --atr %.4f exceeds 50%% of fill price %.4f (plausibility guard)\n", entryATR, *fillPrice)
+		return 1
+	}
+
 	openSide := "buy"
 	if *side == "short" {
 		openSide = "sell"
 	}
 
-	// Determine effective stop-loss pct for the execute call.
-	// Priority: CLI flags > strategy config.
 	effectiveSLPct := 0.0
 	if *slPct > 0 {
 		effectiveSLPct = *slPct
-	} else if *slATRMult > 0 && *atr > 0 {
-		// Convert ATR-based stop to a placeholder pct — the actual trigger
-		// placement happens after fill via RunHyperliquidUpdateStopLoss.
-		// Pass 0 to execute so no in-script trigger is placed; we arm it below.
-		effectiveSLPct = 0
 	}
 
-	// Use strategy's script (auto-set by LoadConfig).
 	script := sc.Script
 
-	var fillPrice, fillQty, fillFee float64
+	var resolvedFillPrice, fillQty, fillFee float64
 	var exchangeOID string
 
 	if *dryRun {
-		// In dry-run mode, resolve a display-only qty from size inputs (use 0 price for notional/margin).
 		displayQty := resolveManualSize(*size, *notional, *margin, 0, sc.Leverage)
-		sideStr := *side
 		fmt.Printf("[dry-run] manual-open %s: %s %.6f %s (script=%s, sl_pct=%.2f)\n",
-			strategyID, sideStr, displayQty, sc.Symbol, script, effectiveSLPct)
+			strategyID, *side, displayQty, sc.Symbol, script, effectiveSLPct)
 		return 0
 	}
 
 	if *recordOnly {
-		// Operator already placed the fill. Require explicit fill price and size.
-		if *size <= 0 {
-			fmt.Fprintln(os.Stderr, "error: --record-only requires --size (coin qty of the fill you placed)")
-			return 2
-		}
+		// Operator already placed the fill on the exchange UI.
 		fillQty = *size
-		// No fill price available without the exchange response — operator
-		// must supply it. For now, fail fast and ask them to use the normal path.
-		fmt.Fprintln(os.Stderr, "error: --record-only requires --fill-price (the price at which your fill executed)")
-		fmt.Fprintln(os.Stderr, "       (add --fill-price <price> to record an existing fill)")
-		return 2
+		resolvedFillPrice = *fillPrice
+		// ATR post-fill plausibility (same guard as above, unified path)
+		if entryATR > 0 && entryATR > 0.5*resolvedFillPrice {
+			fmt.Fprintf(os.Stderr, "error: --atr %.4f exceeds 50%% of fill price %.4f (plausibility guard)\n", entryATR, resolvedFillPrice)
+			return 1
+		}
+	} else {
+		execResult, execStderr, execErr := RunHyperliquidExecute(
+			script, sc.Symbol, openSide,
+			resolveManualSize(*size, *notional, *margin, 0, sc.Leverage),
+			effectiveSLPct, 0, 0, sc.MarginMode, sc.Leverage,
+		)
+		if execStderr != "" {
+			fmt.Fprintf(os.Stderr, "HL execute stderr: %s\n", execStderr)
+		}
+		if execErr != nil {
+			fmt.Fprintf(os.Stderr, "error placing order: %v\n", execErr)
+			return 1
+		}
+		if execResult.Error != "" {
+			fmt.Fprintf(os.Stderr, "error from HL: %s\n", execResult.Error)
+			return 1
+		}
+
+		fill := execResult.Execution
+		if fill == nil || fill.Fill == nil {
+			fmt.Fprintln(os.Stderr, "error: no fill returned from execute")
+			return 1
+		}
+		resolvedFillPrice = fill.Fill.AvgPx
+		fillQty = fill.Fill.TotalSz
+		fillFee = fill.Fill.Fee
+		if fill.Fill.OID != 0 {
+			exchangeOID = fmt.Sprintf("%d", fill.Fill.OID)
+		}
+		if fillQty <= 0 {
+			fillQty = resolveManualSize(*size, *notional, *margin, resolvedFillPrice, sc.Leverage)
+		}
+
+		// Post-fill ATR plausibility guard.
+		if entryATR > 0 && resolvedFillPrice > 0 && entryATR > 0.5*resolvedFillPrice {
+			fmt.Fprintf(os.Stderr, "warning: --atr %.4f exceeds 50%% of fill price %.4f — EntryATR will not be stamped\n", entryATR, resolvedFillPrice)
+			entryATR = 0
+		}
 	}
 
-	// Place the on-chain order via the existing RunHyperliquidExecute path.
-	execResult, stderr, execErr := RunHyperliquidExecute(
-		script, sc.Symbol, openSide,
-		resolveManualSize(*size, *notional, *margin, 0, sc.Leverage),
-		effectiveSLPct, 0, 0, sc.MarginMode, sc.Leverage,
-	)
-	if stderr != "" {
-		fmt.Fprintf(os.Stderr, "HL execute stderr: %s\n", stderr)
-	}
-	if execErr != nil {
-		fmt.Fprintf(os.Stderr, "error placing order: %v\n", execErr)
-		return 1
-	}
-	if execResult.Error != "" {
-		fmt.Fprintf(os.Stderr, "error from HL: %s\n", execResult.Error)
-		return 1
-	}
+	fmt.Printf("Filled: %s %.6f %s @ $%.4f (fee=$%.4f)\n", *side, fillQty, sc.Symbol, resolvedFillPrice, fillFee)
 
-	fill := execResult.Execution
-	if fill == nil || fill.Fill == nil {
-		fmt.Fprintln(os.Stderr, "error: no fill returned from execute")
-		return 1
-	}
-	fillPrice = fill.Fill.AvgPx
-	fillQty = fill.Fill.TotalSz
-	fillFee = fill.Fill.Fee
-	if fill.Fill.OID != 0 {
-		exchangeOID = fmt.Sprintf("%d", fill.Fill.OID)
-	}
-
-	// Resolve actual qty for notional/margin inputs now that we have fillPrice.
-	if fillQty <= 0 {
-		fillQty = resolveManualSize(*size, *notional, *margin, fillPrice, sc.Leverage)
-	}
-
-	fmt.Printf("Filled: %s %.6f %s @ $%.4f (fee=$%.4f)\n", *side, fillQty, sc.Symbol, fillPrice, fillFee)
-
-	// Resolve ATR: use --atr flag if provided.
-	entryATR := *atr
-
-	// Arm ATR-based stop-loss if configured and no pct-based SL was passed to execute.
+	// Arm ATR-based stop-loss after fill (separate from the execute call so we
+	// control trigger placement independently of the pct-based SL path).
 	var stopLossOID int64
 	var stopLossTriggerPx float64
 
@@ -176,11 +198,11 @@ func runManualOpen(args []string) int {
 		effectiveATRMult = *sc.StopLossATRMult
 	}
 
-	if effectiveATRMult > 0 && entryATR > 0 {
+	if effectiveATRMult > 0 && entryATR > 0 && !*recordOnly {
 		if *side == "long" {
-			stopLossTriggerPx = fillPrice - effectiveATRMult*entryATR
+			stopLossTriggerPx = resolvedFillPrice - effectiveATRMult*entryATR
 		} else {
-			stopLossTriggerPx = fillPrice + effectiveATRMult*entryATR
+			stopLossTriggerPx = resolvedFillPrice + effectiveATRMult*entryATR
 		}
 		if stopLossTriggerPx > 0 {
 			slResult, slStderr, slErr := RunHyperliquidUpdateStopLoss(script, sc.Symbol, *side, fillQty, stopLossTriggerPx, 0)
@@ -207,7 +229,7 @@ func runManualOpen(args []string) int {
 		Symbol:            sc.Symbol,
 		Side:              *side,
 		Quantity:          fillQty,
-		FillPrice:         fillPrice,
+		FillPrice:         resolvedFillPrice,
 		FillFee:           fillFee,
 		ExchangeOrderID:   exchangeOID,
 		StopLossOID:       stopLossOID,
@@ -258,7 +280,6 @@ func runManualClose(args []string) int {
 	}
 	defer stateDB.Close()
 
-	// Load current position from SQLite for display / size resolution.
 	state, err := LoadStateWithDB(cfg, stateDB)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to load state: %v\n", err)
@@ -291,9 +312,16 @@ func runManualClose(args []string) int {
 		return 0
 	}
 
+	// Fix #2: only cancel the SL on a full close; leave it resting on partial close.
+	isFullClose := closeQty >= pos.Quantity*0.99
+	cancelOID := int64(0)
+	if isFullClose {
+		cancelOID = pos.StopLossOID
+	}
+
 	execResult, stderr, execErr := RunHyperliquidExecute(
 		sc.Script, sc.Symbol, closeSide, closeQty,
-		0, pos.StopLossOID, 0, "", 0,
+		0, cancelOID, 0, "", 0,
 	)
 	if stderr != "" {
 		fmt.Fprintf(os.Stderr, "HL close stderr: %s\n", stderr)
@@ -313,24 +341,23 @@ func runManualClose(args []string) int {
 		return 1
 	}
 
-	fillPrice := fill.Fill.AvgPx
+	fillAvgPx := fill.Fill.AvgPx
 	fillFee := fill.Fill.Fee
 	var exchangeOID string
 	if fill.Fill.OID != 0 {
 		exchangeOID = fmt.Sprintf("%d", fill.Fill.OID)
 	}
 
-	// Compute realized PnL.
 	var realizedPnL float64
 	if pos.Side == "long" {
-		realizedPnL = closeQty * (fillPrice - pos.AvgCost)
+		realizedPnL = closeQty * (fillAvgPx - pos.AvgCost)
 	} else {
-		realizedPnL = closeQty * (pos.AvgCost - fillPrice)
+		realizedPnL = closeQty * (pos.AvgCost - fillAvgPx)
 	}
 	realizedPnL -= fillFee
 
 	fmt.Printf("Closed: %.6f %s @ $%.4f | PnL=$%.2f (fee=$%.4f)\n",
-		closeQty, sc.Symbol, fillPrice, realizedPnL, fillFee)
+		closeQty, sc.Symbol, fillAvgPx, realizedPnL, fillFee)
 
 	action := PendingManualAction{
 		StrategyID:      strategyID,
@@ -338,7 +365,7 @@ func runManualClose(args []string) int {
 		Symbol:          sc.Symbol,
 		Side:            closeSide,
 		Quantity:        closeQty,
-		FillPrice:       fillPrice,
+		FillPrice:       fillAvgPx,
 		FillFee:         fillFee,
 		ExchangeOrderID: exchangeOID,
 		RealizedPnL:     realizedPnL,
@@ -369,7 +396,6 @@ func drainPendingManualActions(state *AppState, cfg *Config, stateDB *StateDB) {
 		return
 	}
 
-	// Build a quick lookup from strategy ID to StrategyConfig.
 	scByID := make(map[string]StrategyConfig, len(cfg.Strategies))
 	for _, sc := range cfg.Strategies {
 		scByID[sc.ID] = sc
@@ -453,7 +479,8 @@ func applyManualAction(state *AppState, scByID map[string]StrategyConfig, a Pend
 			Manual:            true,
 		}
 		RecordTrade(ss, trade)
-		ss.Cash -= a.Quantity * a.FillPrice
+		// Fix #1: perps open deducts only the fee; notional stays virtual.
+		ss.Cash -= a.FillFee
 		fmt.Printf("[manual] applied open: %s %s %.6f %s @ $%.4f\n",
 			a.StrategyID, a.Side, a.Quantity, a.Symbol, a.FillPrice)
 
@@ -462,7 +489,8 @@ func applyManualAction(state *AppState, scByID map[string]StrategyConfig, a Pend
 		if !exists || pos == nil {
 			return fmt.Errorf("no open position for %s/%s", a.StrategyID, a.Symbol)
 		}
-		closedFull := a.Quantity >= pos.Quantity-1e-9
+		// Fix #5: use 0.99 relative tolerance matching HL lot-size rounding semantics.
+		closedFull := a.Quantity >= pos.Quantity*0.99
 		side := closeTradeSide(pos.Side)
 
 		trade := Trade{
@@ -483,7 +511,8 @@ func applyManualAction(state *AppState, scByID map[string]StrategyConfig, a Pend
 			Manual:          true,
 		}
 		RecordTrade(ss, trade)
-		ss.Cash += a.RealizedPnL + a.Quantity*pos.AvgCost
+		// Fix #1: perps close credits only the realized PnL; notional was never debited.
+		ss.Cash += a.RealizedPnL
 
 		if closedFull {
 			recordClosedPosition(ss, pos, a.FillPrice, a.RealizedPnL, "manual_close", now)
@@ -571,17 +600,4 @@ func runManualCloseEval(sc StrategyConfig, ss *StrategyState, cfg *Config, logge
 		return 0, 0, false
 	}
 	return result.CloseFraction, price, true
-}
-
-// manualCloseParamsJSON returns a JSON-encoded params blob for use in --close-params.
-// Returns empty string on error.
-func manualCloseParamsJSON(sc StrategyConfig) string {
-	if len(sc.Params) == 0 {
-		return ""
-	}
-	b, err := json.Marshal(sc.Params)
-	if err != nil {
-		return ""
-	}
-	return string(b)
 }

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -1,0 +1,587 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// runManualOpen implements `go-trader manual-open <strategy-id>`.
+// It places an on-chain HL order (or records an existing fill with --record-only),
+// then enqueues the fill in pending_manual_actions for the scheduler to drain.
+func runManualOpen(args []string) int {
+	fs := flag.NewFlagSet("manual-open", flag.ContinueOnError)
+	configPath := fs.String("config", "scheduler/config.json", "Path to config file")
+	side := fs.String("side", "", "Position side: long or short")
+	size := fs.Float64("size", 0, "Size in base units (coin qty)")
+	notional := fs.Float64("notional", 0, "Size as USD notional (size = notional / price)")
+	margin := fs.Float64("margin", 0, "Size as USD margin (size = margin * leverage / price)")
+	atr := fs.Float64("atr", 0, "ATR value to stamp on the position (required for ATR-based stops when not auto-fetched)")
+	slATRMult := fs.Float64("stop-loss-atr-mult", 0, "Override stop_loss_atr_mult for this position (0 = use strategy default)")
+	slPct := fs.Float64("stop-loss-pct", 0, "Override stop_loss_pct for this position (0 = use strategy default)")
+	recordOnly := fs.Bool("record-only", false, "Register an existing fill; skip placing a new on-chain order")
+	dryRun := fs.Bool("dry-run", false, "Print planned action without placing order or mutating state")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "Usage: go-trader manual-open <strategy-id> --side long|short (--size N | --notional N | --margin N) [flags]")
+		return 2
+	}
+	strategyID := fs.Arg(0)
+
+	cfg, err := LoadConfig(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load config: %v\n", err)
+		return 1
+	}
+
+	sc, ok := findManualStrategy(cfg, strategyID)
+	if !ok {
+		return 1
+	}
+
+	if strings.TrimSpace(*side) == "" {
+		fmt.Fprintln(os.Stderr, "error: --side is required (long or short)")
+		return 2
+	}
+	*side = strings.ToLower(strings.TrimSpace(*side))
+	if *side != "long" && *side != "short" {
+		fmt.Fprintf(os.Stderr, "error: --side must be \"long\" or \"short\", got %q\n", *side)
+		return 2
+	}
+	if !sc.AllowShorts && *side == "short" {
+		fmt.Fprintf(os.Stderr, "error: strategy %q does not allow shorts (set allow_shorts: true in config)\n", strategyID)
+		return 1
+	}
+
+	sizingInputs := countSizingFlags(*size, *notional, *margin)
+	if sizingInputs == 0 {
+		fmt.Fprintln(os.Stderr, "error: one of --size, --notional, or --margin is required")
+		return 2
+	}
+	if sizingInputs > 1 {
+		fmt.Fprintln(os.Stderr, "error: only one of --size, --notional, or --margin may be specified")
+		return 2
+	}
+
+	stateDB, err := OpenStateDB(cfg.DBFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to open state DB: %v\n", err)
+		return 1
+	}
+	defer stateDB.Close()
+
+	// Resolve order size (coin qty). For --notional / --margin we need the
+	// current price, which comes back from the execute result itself (or a
+	// price-check subprocess). For simplicity: resolve after the fill.
+	// The Python executor returns the actual fill price, so we compute qty
+	// from the fill if notional/margin was specified.
+	openSide := "buy"
+	if *side == "short" {
+		openSide = "sell"
+	}
+
+	// Determine effective stop-loss pct for the execute call.
+	// Priority: CLI flags > strategy config.
+	effectiveSLPct := 0.0
+	if *slPct > 0 {
+		effectiveSLPct = *slPct
+	} else if *slATRMult > 0 && *atr > 0 {
+		// Convert ATR-based stop to a placeholder pct — the actual trigger
+		// placement happens after fill via RunHyperliquidUpdateStopLoss.
+		// Pass 0 to execute so no in-script trigger is placed; we arm it below.
+		effectiveSLPct = 0
+	}
+
+	// Use strategy's script (auto-set by LoadConfig).
+	script := sc.Script
+
+	var fillPrice, fillQty, fillFee float64
+	var exchangeOID string
+
+	if *dryRun {
+		// In dry-run mode, resolve a display-only qty from size inputs (use 0 price for notional/margin).
+		displayQty := resolveManualSize(*size, *notional, *margin, 0, sc.Leverage)
+		sideStr := *side
+		fmt.Printf("[dry-run] manual-open %s: %s %.6f %s (script=%s, sl_pct=%.2f)\n",
+			strategyID, sideStr, displayQty, sc.Symbol, script, effectiveSLPct)
+		return 0
+	}
+
+	if *recordOnly {
+		// Operator already placed the fill. Require explicit fill price and size.
+		if *size <= 0 {
+			fmt.Fprintln(os.Stderr, "error: --record-only requires --size (coin qty of the fill you placed)")
+			return 2
+		}
+		fillQty = *size
+		// No fill price available without the exchange response — operator
+		// must supply it. For now, fail fast and ask them to use the normal path.
+		fmt.Fprintln(os.Stderr, "error: --record-only requires --fill-price (the price at which your fill executed)")
+		fmt.Fprintln(os.Stderr, "       (add --fill-price <price> to record an existing fill)")
+		return 2
+	}
+
+	// Place the on-chain order via the existing RunHyperliquidExecute path.
+	execResult, stderr, execErr := RunHyperliquidExecute(
+		script, sc.Symbol, openSide,
+		resolveManualSize(*size, *notional, *margin, 0, sc.Leverage),
+		effectiveSLPct, 0, 0, sc.MarginMode, sc.Leverage,
+	)
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, "HL execute stderr: %s\n", stderr)
+	}
+	if execErr != nil {
+		fmt.Fprintf(os.Stderr, "error placing order: %v\n", execErr)
+		return 1
+	}
+	if execResult.Error != "" {
+		fmt.Fprintf(os.Stderr, "error from HL: %s\n", execResult.Error)
+		return 1
+	}
+
+	fill := execResult.Execution
+	if fill == nil || fill.Fill == nil {
+		fmt.Fprintln(os.Stderr, "error: no fill returned from execute")
+		return 1
+	}
+	fillPrice = fill.Fill.AvgPx
+	fillQty = fill.Fill.TotalSz
+	fillFee = fill.Fill.Fee
+	if fill.Fill.OID != 0 {
+		exchangeOID = fmt.Sprintf("%d", fill.Fill.OID)
+	}
+
+	// Resolve actual qty for notional/margin inputs now that we have fillPrice.
+	if fillQty <= 0 {
+		fillQty = resolveManualSize(*size, *notional, *margin, fillPrice, sc.Leverage)
+	}
+
+	fmt.Printf("Filled: %s %.6f %s @ $%.4f (fee=$%.4f)\n", *side, fillQty, sc.Symbol, fillPrice, fillFee)
+
+	// Resolve ATR: use --atr flag if provided.
+	entryATR := *atr
+
+	// Arm ATR-based stop-loss if configured and no pct-based SL was passed to execute.
+	var stopLossOID int64
+	var stopLossTriggerPx float64
+
+	effectiveATRMult := *slATRMult
+	if effectiveATRMult == 0 && sc.StopLossATRMult != nil {
+		effectiveATRMult = *sc.StopLossATRMult
+	}
+
+	if effectiveATRMult > 0 && entryATR > 0 {
+		if *side == "long" {
+			stopLossTriggerPx = fillPrice - effectiveATRMult*entryATR
+		} else {
+			stopLossTriggerPx = fillPrice + effectiveATRMult*entryATR
+		}
+		if stopLossTriggerPx > 0 {
+			slResult, slStderr, slErr := RunHyperliquidUpdateStopLoss(script, sc.Symbol, *side, fillQty, stopLossTriggerPx, 0)
+			if slStderr != "" {
+				fmt.Fprintf(os.Stderr, "SL arm stderr: %s\n", slStderr)
+			}
+			if slErr != nil {
+				fmt.Fprintf(os.Stderr, "warning: SL placement failed: %v (position is open but unprotected)\n", slErr)
+			} else if slResult.Error != "" {
+				fmt.Fprintf(os.Stderr, "warning: SL arm error: %s\n", slResult.Error)
+			} else {
+				stopLossOID = slResult.StopLossOID
+				stopLossTriggerPx = slResult.StopLossTriggerPx
+				fmt.Printf("Stop-loss armed at $%.4f (OID=%d)\n", stopLossTriggerPx, stopLossOID)
+			}
+		}
+	} else if effectiveATRMult > 0 && entryATR == 0 {
+		fmt.Fprintln(os.Stderr, "warning: stop_loss_atr_mult is set but --atr was not provided; SL not armed")
+	}
+
+	action := PendingManualAction{
+		StrategyID:        strategyID,
+		Action:            "open",
+		Symbol:            sc.Symbol,
+		Side:              *side,
+		Quantity:          fillQty,
+		FillPrice:         fillPrice,
+		FillFee:           fillFee,
+		ExchangeOrderID:   exchangeOID,
+		StopLossOID:       stopLossOID,
+		StopLossTriggerPx: stopLossTriggerPx,
+		EntryATR:          entryATR,
+		CreatedAt:         time.Now().UTC(),
+	}
+	if err := stateDB.InsertPendingManualAction(action); err != nil {
+		fmt.Fprintf(os.Stderr, "error queuing action: %v\n", err)
+		return 1
+	}
+
+	fmt.Printf("Queued: %s position will appear in the dashboard after the next scheduler cycle.\n", strategyID)
+	return 0
+}
+
+// runManualClose implements `go-trader manual-close <strategy-id>`.
+func runManualClose(args []string) int {
+	fs := flag.NewFlagSet("manual-close", flag.ContinueOnError)
+	configPath := fs.String("config", "scheduler/config.json", "Path to config file")
+	qty := fs.Float64("qty", 0, "Quantity to close in base units (0 = full position)")
+	dryRun := fs.Bool("dry-run", false, "Print planned action without placing order or mutating state")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "Usage: go-trader manual-close <strategy-id> [--qty N] [--dry-run]")
+		return 2
+	}
+	strategyID := fs.Arg(0)
+
+	cfg, err := LoadConfig(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load config: %v\n", err)
+		return 1
+	}
+
+	sc, ok := findManualStrategy(cfg, strategyID)
+	if !ok {
+		return 1
+	}
+
+	stateDB, err := OpenStateDB(cfg.DBFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to open state DB: %v\n", err)
+		return 1
+	}
+	defer stateDB.Close()
+
+	// Load current position from SQLite for display / size resolution.
+	state, err := LoadStateWithDB(cfg, stateDB)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load state: %v\n", err)
+		return 1
+	}
+	ss := state.Strategies[strategyID]
+	pos := ss.Positions[sc.Symbol]
+	if pos == nil {
+		fmt.Fprintf(os.Stderr, "error: no open position found for %s/%s\n", strategyID, sc.Symbol)
+		return 1
+	}
+
+	closeQty := pos.Quantity
+	if *qty > 0 {
+		if *qty > pos.Quantity {
+			fmt.Fprintf(os.Stderr, "error: --qty %.6f exceeds open position %.6f\n", *qty, pos.Quantity)
+			return 1
+		}
+		closeQty = *qty
+	}
+
+	closeSide := "sell"
+	if pos.Side == "short" {
+		closeSide = "buy"
+	}
+
+	if *dryRun {
+		fmt.Printf("[dry-run] manual-close %s: %s %.6f %s (current pos=%.6f, avg_cost=$%.4f)\n",
+			strategyID, closeSide, closeQty, sc.Symbol, pos.Quantity, pos.AvgCost)
+		return 0
+	}
+
+	execResult, stderr, execErr := RunHyperliquidExecute(
+		sc.Script, sc.Symbol, closeSide, closeQty,
+		0, pos.StopLossOID, 0, "", 0,
+	)
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, "HL close stderr: %s\n", stderr)
+	}
+	if execErr != nil {
+		fmt.Fprintf(os.Stderr, "error placing close order: %v\n", execErr)
+		return 1
+	}
+	if execResult.Error != "" {
+		fmt.Fprintf(os.Stderr, "error from HL: %s\n", execResult.Error)
+		return 1
+	}
+
+	fill := execResult.Execution
+	if fill == nil || fill.Fill == nil {
+		fmt.Fprintln(os.Stderr, "error: no fill returned from close execute")
+		return 1
+	}
+
+	fillPrice := fill.Fill.AvgPx
+	fillFee := fill.Fill.Fee
+	var exchangeOID string
+	if fill.Fill.OID != 0 {
+		exchangeOID = fmt.Sprintf("%d", fill.Fill.OID)
+	}
+
+	// Compute realized PnL.
+	var realizedPnL float64
+	if pos.Side == "long" {
+		realizedPnL = closeQty * (fillPrice - pos.AvgCost)
+	} else {
+		realizedPnL = closeQty * (pos.AvgCost - fillPrice)
+	}
+	realizedPnL -= fillFee
+
+	fmt.Printf("Closed: %.6f %s @ $%.4f | PnL=$%.2f (fee=$%.4f)\n",
+		closeQty, sc.Symbol, fillPrice, realizedPnL, fillFee)
+
+	action := PendingManualAction{
+		StrategyID:      strategyID,
+		Action:          "close",
+		Symbol:          sc.Symbol,
+		Side:            closeSide,
+		Quantity:        closeQty,
+		FillPrice:       fillPrice,
+		FillFee:         fillFee,
+		ExchangeOrderID: exchangeOID,
+		RealizedPnL:     realizedPnL,
+		CreatedAt:       time.Now().UTC(),
+	}
+	if err := stateDB.InsertPendingManualAction(action); err != nil {
+		fmt.Fprintf(os.Stderr, "error queuing close action: %v\n", err)
+		return 1
+	}
+
+	fmt.Printf("Queued: close will be reflected in the dashboard after the next scheduler cycle.\n")
+	return 0
+}
+
+// drainPendingManualActions reads all rows from pending_manual_actions and
+// applies them to the in-memory AppState, then deletes the drained rows.
+// Called at the top of each scheduler cycle before dueStrategies is built.
+func drainPendingManualActions(state *AppState, cfg *Config, stateDB *StateDB) {
+	if stateDB == nil {
+		return
+	}
+	actions, err := stateDB.LoadPendingManualActions()
+	if err != nil {
+		fmt.Printf("[manual] failed to load pending actions: %v\n", err)
+		return
+	}
+	if len(actions) == 0 {
+		return
+	}
+
+	// Build a quick lookup from strategy ID to StrategyConfig.
+	scByID := make(map[string]StrategyConfig, len(cfg.Strategies))
+	for _, sc := range cfg.Strategies {
+		scByID[sc.ID] = sc
+	}
+
+	var maxDrained int64
+	for _, a := range actions {
+		if err := applyManualAction(state, scByID, a); err != nil {
+			fmt.Printf("[manual] failed to apply action %d (%s %s): %v\n", a.ID, a.Action, a.StrategyID, err)
+			continue
+		}
+		if a.ID > maxDrained {
+			maxDrained = a.ID
+		}
+	}
+
+	if maxDrained > 0 {
+		if err := stateDB.DeletePendingManualActionsThrough(maxDrained); err != nil {
+			fmt.Printf("[manual] failed to delete drained actions: %v\n", err)
+		}
+	}
+}
+
+// applyManualAction materialises one pending_manual_actions row into AppState.
+func applyManualAction(state *AppState, scByID map[string]StrategyConfig, a PendingManualAction) error {
+	sc, hasSC := scByID[a.StrategyID]
+	if !hasSC {
+		return fmt.Errorf("strategy %q not found in config", a.StrategyID)
+	}
+	if sc.Type != "manual" {
+		return fmt.Errorf("strategy %q is not type=manual", a.StrategyID)
+	}
+
+	ss := state.Strategies[a.StrategyID]
+	if ss == nil {
+		return fmt.Errorf("strategy state for %q not found", a.StrategyID)
+	}
+
+	now := a.CreatedAt
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	switch a.Action {
+	case "open":
+		if _, exists := ss.Positions[a.Symbol]; exists {
+			return fmt.Errorf("position already open for %s/%s; close it first", a.StrategyID, a.Symbol)
+		}
+		pos := &Position{
+			Symbol:            a.Symbol,
+			Quantity:          a.Quantity,
+			InitialQuantity:   a.Quantity,
+			AvgCost:           a.FillPrice,
+			EntryATR:          a.EntryATR,
+			Side:              a.Side,
+			Multiplier:        1, // perps
+			Leverage:          sc.Leverage,
+			OwnerStrategyID:   a.StrategyID,
+			OpenedAt:          now,
+			StopLossOID:       a.StopLossOID,
+			StopLossTriggerPx: a.StopLossTriggerPx,
+		}
+		pos.TradePositionID = newTradePositionID(a.StrategyID, a.Symbol, now)
+		ss.Positions[a.Symbol] = pos
+
+		trade := Trade{
+			Timestamp:         now,
+			StrategyID:        a.StrategyID,
+			Symbol:            a.Symbol,
+			Side:              openTradeSide(a.Side),
+			Quantity:          a.Quantity,
+			Price:             a.FillPrice,
+			Value:             a.Quantity * a.FillPrice,
+			TradeType:         "perps",
+			Details:           fmt.Sprintf("manual open %s %s @ $%.4f", a.Side, a.Symbol, a.FillPrice),
+			PositionID:        pos.TradePositionID,
+			ExchangeOrderID:   a.ExchangeOrderID,
+			ExchangeFee:       a.FillFee,
+			EntryATR:          a.EntryATR,
+			StopLossTriggerPx: a.StopLossTriggerPx,
+			Manual:            true,
+		}
+		RecordTrade(ss, trade)
+		ss.Cash -= a.Quantity * a.FillPrice
+		fmt.Printf("[manual] applied open: %s %s %.6f %s @ $%.4f\n",
+			a.StrategyID, a.Side, a.Quantity, a.Symbol, a.FillPrice)
+
+	case "close":
+		pos, exists := ss.Positions[a.Symbol]
+		if !exists || pos == nil {
+			return fmt.Errorf("no open position for %s/%s", a.StrategyID, a.Symbol)
+		}
+		closedFull := a.Quantity >= pos.Quantity-1e-9
+		side := closeTradeSide(pos.Side)
+
+		trade := Trade{
+			Timestamp:       now,
+			StrategyID:      a.StrategyID,
+			Symbol:          a.Symbol,
+			Side:            side,
+			Quantity:        a.Quantity,
+			Price:           a.FillPrice,
+			Value:           a.Quantity * a.FillPrice,
+			TradeType:       "perps",
+			Details:         fmt.Sprintf("manual close %s @ $%.4f | PnL=$%.2f", a.Symbol, a.FillPrice, a.RealizedPnL),
+			PositionID:      ensurePositionTradeID(a.StrategyID, a.Symbol, pos),
+			ExchangeOrderID: a.ExchangeOrderID,
+			ExchangeFee:     a.FillFee,
+			IsClose:         true,
+			RealizedPnL:     a.RealizedPnL,
+			Manual:          true,
+		}
+		RecordTrade(ss, trade)
+		ss.Cash += a.RealizedPnL + a.Quantity*pos.AvgCost
+
+		if closedFull {
+			recordClosedPosition(ss, pos, a.FillPrice, a.RealizedPnL, "manual_close", now)
+			delete(ss.Positions, a.Symbol)
+		} else {
+			pos.Quantity -= a.Quantity
+		}
+		fmt.Printf("[manual] applied close: %s %.6f %s @ $%.4f | PnL=$%.2f\n",
+			a.StrategyID, a.Quantity, a.Symbol, a.FillPrice, a.RealizedPnL)
+
+	default:
+		return fmt.Errorf("unknown action %q", a.Action)
+	}
+	return nil
+}
+
+// findManualStrategy locates a type=manual strategy by ID in the config,
+// printing a clear error if not found or wrong type.
+func findManualStrategy(cfg *Config, id string) (StrategyConfig, bool) {
+	for _, sc := range cfg.Strategies {
+		if sc.ID == id {
+			if sc.Type != "manual" {
+				fmt.Fprintf(os.Stderr, "error: strategy %q has type=%q; manual-open/close only works with type=manual strategies\n", id, sc.Type)
+				return StrategyConfig{}, false
+			}
+			return sc, true
+		}
+	}
+	fmt.Fprintf(os.Stderr, "error: strategy %q not found in config\n", id)
+	return StrategyConfig{}, false
+}
+
+// resolveManualSize converts the sizing inputs to a coin qty.
+// price=0 is acceptable for --size (qty is already explicit).
+func resolveManualSize(size, notional, margin, price, leverage float64) float64 {
+	if size > 0 {
+		return size
+	}
+	if price <= 0 {
+		return 0
+	}
+	if notional > 0 {
+		return notional / price
+	}
+	if margin > 0 && leverage > 0 {
+		return (margin * leverage) / price
+	}
+	return 0
+}
+
+func countSizingFlags(size, notional, margin float64) int {
+	n := 0
+	if size > 0 {
+		n++
+	}
+	if notional > 0 {
+		n++
+	}
+	if margin > 0 {
+		n++
+	}
+	return n
+}
+
+// openTradeSide converts a position side ("long"/"short") to the trade buy/sell side for an open.
+func openTradeSide(posSide string) string {
+	if posSide == "short" {
+		return "sell"
+	}
+	return "buy"
+}
+
+// runManualCloseEval runs the close-evaluator loop for a single type=manual
+// strategy that has an open position. Called from the main scheduler loop.
+// Returns (closeFraction, closePrice, ok).
+func runManualCloseEval(sc StrategyConfig, ss *StrategyState, cfg *Config, logger *StrategyLogger) (float64, float64, bool) {
+	pos := ss.Positions[sc.Symbol]
+	if pos == nil {
+		return 0, 0, true // flat — nothing to do
+	}
+
+	posCtx := positionCtxFromPosition(pos)
+	result, _, price, ok := runHyperliquidCheck(sc, nil, posCtx, cfg.Regime, logger)
+	if !ok {
+		return 0, 0, false
+	}
+	return result.CloseFraction, price, true
+}
+
+// manualCloseParamsJSON returns a JSON-encoded params blob for use in --close-params.
+// Returns empty string on error.
+func manualCloseParamsJSON(sc StrategyConfig) string {
+	if len(sc.Params) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(sc.Params)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -149,7 +149,7 @@ func runManualOpen(args []string) int {
 		// --record-only does not auto-arm the SL trigger (the operator placed
 		// the fill on the UI, so they're responsible for its protection).
 		// Warn if the operator passed SL-related flags that won't take effect.
-		if (*slATRMult > 0 || *slPct > 0 || (sc.StopLossATRMult != nil && *sc.StopLossATRMult > 0)) {
+		if *slATRMult > 0 || *slPct > 0 || (sc.StopLossATRMult != nil && *sc.StopLossATRMult > 0) {
 			fmt.Fprintln(os.Stderr, "warning: --record-only does not arm a stop-loss trigger automatically — place the SL manually on the HL UI")
 		}
 	} else {

--- a/scheduler/manual_test.go
+++ b/scheduler/manual_test.go
@@ -1,0 +1,334 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestResolveManualSize checks the three sizing modes.
+func TestResolveManualSize(t *testing.T) {
+	cases := []struct {
+		size, notional, margin, price, leverage float64
+		want                                    float64
+	}{
+		{size: 0.5, notional: 0, margin: 0, price: 2000, leverage: 10, want: 0.5},
+		{size: 0, notional: 1000, margin: 0, price: 2000, leverage: 10, want: 0.5},
+		{size: 0, notional: 0, margin: 100, price: 2000, leverage: 10, want: 0.5},
+		{size: 0, notional: 0, margin: 0, price: 2000, leverage: 10, want: 0}, // no input
+		{size: 0, notional: 500, margin: 0, price: 0, leverage: 10, want: 0},  // price=0
+	}
+	for _, c := range cases {
+		got := resolveManualSize(c.size, c.notional, c.margin, c.price, c.leverage)
+		if fmt.Sprintf("%.6f", got) != fmt.Sprintf("%.6f", c.want) {
+			t.Errorf("resolveManualSize(size=%g,notional=%g,margin=%g,price=%g,lev=%g) = %g, want %g",
+				c.size, c.notional, c.margin, c.price, c.leverage, got, c.want)
+		}
+	}
+}
+
+func TestCountSizingFlags(t *testing.T) {
+	if countSizingFlags(1, 0, 0) != 1 {
+		t.Error("size only should be 1")
+	}
+	if countSizingFlags(0, 500, 0) != 1 {
+		t.Error("notional only should be 1")
+	}
+	if countSizingFlags(1, 500, 0) != 2 {
+		t.Error("size+notional should be 2")
+	}
+	if countSizingFlags(1, 500, 100) != 3 {
+		t.Error("all three should be 3")
+	}
+	if countSizingFlags(0, 0, 0) != 0 {
+		t.Error("none should be 0")
+	}
+}
+
+func TestOpenTradeSide(t *testing.T) {
+	if openTradeSide("long") != "buy" {
+		t.Error("long should map to buy")
+	}
+	if openTradeSide("short") != "sell" {
+		t.Error("short should map to sell")
+	}
+}
+
+// TestApplyManualActionOpen verifies that an open action creates a Position and Trade.
+func TestApplyManualActionOpen(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-manual-eth-live": {
+				ID:        "hl-manual-eth-live",
+				Platform:  "hyperliquid",
+				Type:      "manual",
+				Positions: map[string]*Position{},
+				Cash:      10000,
+			},
+		},
+	}
+	scByID := map[string]StrategyConfig{
+		"hl-manual-eth-live": {
+			ID:       "hl-manual-eth-live",
+			Type:     "manual",
+			Platform: "hyperliquid",
+			Symbol:   "ETH",
+			Leverage: 10,
+		},
+	}
+	now := time.Now().UTC()
+	a := PendingManualAction{
+		ID:         1,
+		StrategyID: "hl-manual-eth-live",
+		Action:     "open",
+		Symbol:     "ETH",
+		Side:       "long",
+		Quantity:   0.5,
+		FillPrice:  2000,
+		FillFee:    0.7,
+		EntryATR:   50,
+		CreatedAt:  now,
+	}
+
+	var recorded []Trade
+	origRecorder := tradeRecorder
+	tradeRecorder = func(stratID string, trade Trade) error {
+		recorded = append(recorded, trade)
+		return nil
+	}
+	defer func() { tradeRecorder = origRecorder }()
+
+	if err := applyManualAction(state, scByID, a); err != nil {
+		t.Fatalf("applyManualAction open: %v", err)
+	}
+
+	ss := state.Strategies["hl-manual-eth-live"]
+	pos := ss.Positions["ETH"]
+	if pos == nil {
+		t.Fatal("expected position to be created")
+	}
+	if pos.Quantity != 0.5 {
+		t.Errorf("pos.Quantity = %g, want 0.5", pos.Quantity)
+	}
+	if pos.AvgCost != 2000 {
+		t.Errorf("pos.AvgCost = %g, want 2000", pos.AvgCost)
+	}
+	if pos.Side != "long" {
+		t.Errorf("pos.Side = %q, want \"long\"", pos.Side)
+	}
+	if pos.EntryATR != 50 {
+		t.Errorf("pos.EntryATR = %g, want 50", pos.EntryATR)
+	}
+	if !pos.OpenedAt.Equal(now) {
+		t.Errorf("pos.OpenedAt = %v, want %v", pos.OpenedAt, now)
+	}
+	if pos.TradePositionID == "" {
+		t.Error("expected TradePositionID to be set")
+	}
+
+	if len(recorded) != 1 {
+		t.Fatalf("expected 1 trade recorded, got %d", len(recorded))
+	}
+	tr := recorded[0]
+	if !tr.Manual {
+		t.Error("expected trade.Manual = true")
+	}
+	if tr.Side != "buy" {
+		t.Errorf("trade.Side = %q, want \"buy\"", tr.Side)
+	}
+	if tr.EntryATR != 50 {
+		t.Errorf("trade.EntryATR = %g, want 50", tr.EntryATR)
+	}
+}
+
+// TestApplyManualActionClose verifies that a close action records a closing trade and removes the position.
+func TestApplyManualActionClose(t *testing.T) {
+	openAt := time.Now().UTC().Add(-time.Hour)
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-manual-eth-live": {
+				ID:       "hl-manual-eth-live",
+				Platform: "hyperliquid",
+				Type:     "manual",
+				Positions: map[string]*Position{
+					"ETH": {
+						Symbol:          "ETH",
+						Quantity:        0.5,
+						InitialQuantity: 0.5,
+						AvgCost:         2000,
+						Side:            "long",
+						Multiplier:      1,
+						Leverage:        10,
+						OwnerStrategyID: "hl-manual-eth-live",
+						OpenedAt:        openAt,
+					},
+				},
+				Cash: 9000, // after open deduction
+			},
+		},
+	}
+	scByID := map[string]StrategyConfig{
+		"hl-manual-eth-live": {
+			ID:       "hl-manual-eth-live",
+			Type:     "manual",
+			Platform: "hyperliquid",
+			Symbol:   "ETH",
+			Leverage: 10,
+		},
+	}
+
+	var recorded []Trade
+	origRecorder := tradeRecorder
+	tradeRecorder = func(stratID string, trade Trade) error {
+		recorded = append(recorded, trade)
+		return nil
+	}
+	defer func() { tradeRecorder = origRecorder }()
+
+	now := time.Now().UTC()
+	a := PendingManualAction{
+		ID:          2,
+		StrategyID:  "hl-manual-eth-live",
+		Action:      "close",
+		Symbol:      "ETH",
+		Side:        "sell",
+		Quantity:    0.5,
+		FillPrice:   2100,
+		FillFee:     0.7,
+		RealizedPnL: 49.3, // 0.5*(2100-2000) - 0.7
+		CreatedAt:   now,
+	}
+	if err := applyManualAction(state, scByID, a); err != nil {
+		t.Fatalf("applyManualAction close: %v", err)
+	}
+
+	ss := state.Strategies["hl-manual-eth-live"]
+	if _, exists := ss.Positions["ETH"]; exists {
+		t.Error("expected position to be removed after full close")
+	}
+
+	if len(recorded) != 1 {
+		t.Fatalf("expected 1 trade recorded, got %d", len(recorded))
+	}
+	tr := recorded[0]
+	if !tr.IsClose {
+		t.Error("expected trade.IsClose = true")
+	}
+	if !tr.Manual {
+		t.Error("expected trade.Manual = true")
+	}
+	if tr.Side != "sell" {
+		t.Errorf("trade.Side = %q, want \"sell\"", tr.Side)
+	}
+
+	if len(ss.ClosedPositions) != 1 {
+		t.Errorf("expected 1 closed position, got %d", len(ss.ClosedPositions))
+	}
+}
+
+// TestApplyManualActionPartialClose verifies that partial close decrements quantity without removing the position.
+func TestApplyManualActionPartialClose(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-manual-eth-live": {
+				ID:       "hl-manual-eth-live",
+				Platform: "hyperliquid",
+				Type:     "manual",
+				Positions: map[string]*Position{
+					"ETH": {
+						Symbol:          "ETH",
+						Quantity:        1.0,
+						InitialQuantity: 1.0,
+						AvgCost:         2000,
+						Side:            "long",
+						Multiplier:      1,
+						OwnerStrategyID: "hl-manual-eth-live",
+					},
+				},
+				Cash: 8000,
+			},
+		},
+	}
+	scByID := map[string]StrategyConfig{
+		"hl-manual-eth-live": {ID: "hl-manual-eth-live", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 10},
+	}
+
+	origRecorder := tradeRecorder
+	tradeRecorder = func(_ string, _ Trade) error { return nil }
+	defer func() { tradeRecorder = origRecorder }()
+
+	a := PendingManualAction{
+		StrategyID:  "hl-manual-eth-live",
+		Action:      "close",
+		Symbol:      "ETH",
+		Side:        "sell",
+		Quantity:    0.4, // partial
+		FillPrice:   2100,
+		RealizedPnL: 40,
+		CreatedAt:   time.Now().UTC(),
+	}
+	if err := applyManualAction(state, scByID, a); err != nil {
+		t.Fatalf("partial close: %v", err)
+	}
+
+	pos := state.Strategies["hl-manual-eth-live"].Positions["ETH"]
+	if pos == nil {
+		t.Fatal("position should remain after partial close")
+	}
+	if fmt.Sprintf("%.4f", pos.Quantity) != "0.6000" {
+		t.Errorf("pos.Quantity after partial close = %g, want 0.6", pos.Quantity)
+	}
+}
+
+// TestDrainPendingManualActions verifies the queue drain applies actions and cleans up.
+func TestDrainPendingManualActions(t *testing.T) {
+	db, err := OpenStateDB(":memory:")
+	if err != nil {
+		t.Fatalf("open state db: %v", err)
+	}
+	defer db.Close()
+
+	stratID := "hl-manual-eth-live"
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			stratID: {
+				ID:        stratID,
+				Platform:  "hyperliquid",
+				Type:      "manual",
+				Positions: map[string]*Position{},
+				Cash:      10000,
+			},
+		},
+	}
+	cfg := &Config{
+		Strategies: []StrategyConfig{{
+			ID: stratID, Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 10,
+		}},
+	}
+
+	origRecorder := tradeRecorder
+	tradeRecorder = func(_ string, _ Trade) error { return nil }
+	defer func() { tradeRecorder = origRecorder }()
+
+	_ = db.InsertPendingManualAction(PendingManualAction{
+		StrategyID: stratID, Action: "open", Symbol: "ETH", Side: "long",
+		Quantity: 0.5, FillPrice: 2000, FillFee: 0.7, EntryATR: 50,
+		CreatedAt: time.Now().UTC(),
+	})
+
+	drainPendingManualActions(state, cfg, db)
+
+	pos := state.Strategies[stratID].Positions["ETH"]
+	if pos == nil {
+		t.Fatal("expected position after drain")
+	}
+	if pos.Quantity != 0.5 {
+		t.Errorf("pos.Quantity = %g, want 0.5", pos.Quantity)
+	}
+
+	// Queue should be empty after drain.
+	remaining, _ := db.LoadPendingManualActions()
+	if len(remaining) != 0 {
+		t.Errorf("expected empty queue after drain, got %d rows", len(remaining))
+	}
+}

--- a/scheduler/manual_test.go
+++ b/scheduler/manual_test.go
@@ -196,6 +196,7 @@ func TestApplyManualActionClose(t *testing.T) {
 		FillPrice:   2100,
 		FillFee:     0.7,
 		RealizedPnL: 49.3, // 0.5*(2100-2000) - 0.7
+		IsFullClose: true,
 		CreatedAt:   now,
 	}
 	if err := applyManualAction(state, scByID, a); err != nil {
@@ -278,6 +279,71 @@ func TestApplyManualActionPartialClose(t *testing.T) {
 	if fmt.Sprintf("%.4f", pos.Quantity) != "0.6000" {
 		t.Errorf("pos.Quantity after partial close = %g, want 0.6", pos.Quantity)
 	}
+}
+
+// TestApplyManualAction99PercentPartialNotCollapsedToFull verifies that a
+// deliberate ~99% partial close is NOT collapsed into a full close (the prior
+// 0.99 relative tolerance would silently delete the residual dust).
+func TestApplyManualAction99PercentPartialNotCollapsedToFull(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-manual-eth-live": {
+				ID:       "hl-manual-eth-live",
+				Platform: "hyperliquid",
+				Type:     "manual",
+				Positions: map[string]*Position{
+					"ETH": {
+						Symbol:          "ETH",
+						Quantity:        0.5,
+						InitialQuantity: 0.5,
+						AvgCost:         2000,
+						Side:            "long",
+						Multiplier:      1,
+						OwnerStrategyID: "hl-manual-eth-live",
+					},
+				},
+				Cash: 9000,
+			},
+		},
+	}
+	scByID := map[string]StrategyConfig{
+		"hl-manual-eth-live": {ID: "hl-manual-eth-live", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 10},
+	}
+
+	origRecorder := tradeRecorder
+	tradeRecorder = func(_ string, _ Trade) error { return nil }
+	defer func() { tradeRecorder = origRecorder }()
+
+	a := PendingManualAction{
+		StrategyID:  "hl-manual-eth-live",
+		Action:      "close",
+		Symbol:      "ETH",
+		Side:        "sell",
+		Quantity:    0.495, // 99% of 0.5 — exactly at the prior tolerance boundary
+		FillPrice:   2100,
+		RealizedPnL: 49.0,
+		IsFullClose: false, // explicit partial-close intent
+		CreatedAt:   time.Now().UTC(),
+	}
+	if err := applyManualAction(state, scByID, a); err != nil {
+		t.Fatalf("99%% partial close: %v", err)
+	}
+
+	pos := state.Strategies["hl-manual-eth-live"].Positions["ETH"]
+	if pos == nil {
+		t.Fatal("99%% partial close should leave the position open with dust qty (regression: 0.99 tolerance was collapsing this to full)")
+	}
+	expectedQty := 0.5 - 0.495
+	if abs(pos.Quantity-expectedQty) > 1e-9 {
+		t.Errorf("residual qty = %g, want %g", pos.Quantity, expectedQty)
+	}
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
 }
 
 // TestDrainPendingManualActions verifies the queue drain applies actions and cleans up.

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -221,6 +221,7 @@ type Trade struct {
 
 	EntryATR          float64 `json:"entry_atr,omitempty"`
 	StopLossTriggerPx float64 `json:"stop_loss_trigger_px,omitempty"`
+	Manual            bool    `json:"manual,omitempty"` // set when position was opened via manual-open CLI (#569)
 
 	// persisted tracks whether this Trade has been written to SQLite — set by
 	// RecordTrade on successful InsertTrade and by LoadState for DB-loaded

--- a/shared_strategies/open/registry.py
+++ b/shared_strategies/open/registry.py
@@ -977,6 +977,18 @@ def session_breakout_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
     return session_breakout_core(df, **params)
 
 
+@register(
+    "hold",
+    "Hold — always returns signal=0; used internally by type=manual strategies for the close-evaluator loop (#569)",
+    {},
+    platforms=("spot", "futures"),
+)
+def hold_strategy(df: pd.DataFrame) -> pd.DataFrame:
+    result = df.copy()
+    result["signal"] = 0
+    return result
+
+
 # ─────────────────────────────────────────────
 # Per-platform display order.
 # These lists MUST match the legacy registration order in each shim so
@@ -992,6 +1004,7 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "heikin_ashi_ema", "order_blocks", "vwap_reversion", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
         "sweep_squeeze_combo", "adx_trend", "donchian_breakout", "tema_cross",
+        "hold",
     ],
     "futures": [
         "sma_crossover", "ema_crossover", "bollinger_bands", "volume_weighted",
@@ -1001,6 +1014,6 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "heikin_ashi_ema", "order_blocks", "vwap_reversion", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
         "sweep_squeeze_combo", "adx_trend", "delta_neutral_funding",
-        "donchian_breakout", "session_breakout",
+        "donchian_breakout", "session_breakout", "hold",
     ],
 }


### PR DESCRIPTION
## Summary

Implements #569 — a `go-trader manual-open` / `manual-close` CLI and a new `type: "manual"` strategy for placing and tracking HL trades outside the scheduler's signal loop.

## Changes

**New CLI commands:**
- `go-trader manual-open <strategy-id> --side long|short (--size N | --notional N | --margin N) [--atr N] [--stop-loss-atr-mult N] [--record-only] [--dry-run]` — places a live HL market order, arms the ATR-based stop-loss trigger, and enqueues the fill in `pending_manual_actions`
- `go-trader manual-close <strategy-id> [--qty N] [--dry-run]` — closes the position (full or partial) and enqueues the fill

**New `type: "manual"` strategy:**
- No `script`/`interval_seconds` required; `LoadConfig` auto-sets `check_hyperliquid.py` + `hold` open strategy
- Defaults: SL @ 1× ATR (HL trigger order), TP1 @ 2× ATR (50%), TP2 @ 3× ATR (100%) via `tiered_tp_atr_live`
- Scheduler skips when flat; runs close-evaluator loop each cycle when a position is open

**Concurrency model:**
- CLI writes to new `pending_manual_actions` SQLite table (outside `SaveState`'s `DELETE FROM strategies` blast radius)
- Scheduler drains at top of each cycle under `mu.Lock()` before `dueStrategies` is built
- Position appears in dashboard within one cycle of `manual-open`

**Other:**
- New `hold` open strategy (always signal=0) registered in `shared_strategies/open/registry.py` for the close-eval loop placeholder
- `trades.manual` column (idempotent migration) flags manual-opened trades for audit
- Config validation: type enum, script-empty gate, leverage/margin_mode/stop_loss_atr_mult guards all allow `type=manual`
- `go-trader init` wizard gains a "Do you plan to do any manual trading on Hyperliquid?" step

## Tests

1. `go -C scheduler test ./...` — all pass (6 new tests: `TestApplyManualActionOpen`, `TestApplyManualActionClose`, `TestApplyManualActionPartialClose`, `TestDrainPendingManualActions`, `TestResolveManualSize`, `TestCountSizingFlags`)
2. `.venv/bin/python3 -m pytest shared_strategies/ shared_tools/ -q` — 503 passed
3. Config smoke test: `./go-trader --config /tmp/test-manual-config.json --once` loads and runs a manual strategy cycle cleanly
4. Dry-run: `./go-trader manual-open --help` and `./go-trader manual-close --help` show correct flag docs

## Example config

```json
{
  "id": "hl-manual-eth-live",
  "type": "manual",
  "platform": "hyperliquid",
  "symbol": "ETH",
  "timeframe": "1h",
  "capital": 1000,
  "max_drawdown_pct": 20,
  "leverage": 10
}
```

```
go-trader manual-open hl-manual-eth-live --side long --notional 500 --atr 42.5
# → places HL order, arms SL at fill_price - 42.5, queues position
# → next scheduler cycle: position appears in summaries, tiered_tp_atr_live evaluates TPs
```

Closes #569

---
LLM: Claude Sonnet 4.6 (1M) | high