### PR TITLE
fix: skip CheckRisk for type=manual strategies

### DIFF
--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1265,6 +1265,11 @@ const (
 // (HL clearinghouse positions today; OKX/TS/RH in later phases) so live
 // strategies can enqueue on-chain closes on circuit breaker (#356 / #359).
 func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, prices map[string]float64, logger *StrategyLogger, assist *PlatformRiskAssist) (bool, string) {
+	// #574: manual strategies are operator-controlled and start with capital=0
+	// funded ad-hoc, so peak-relative drawdown is meaningless.
+	if sc != nil && sc.Type == "manual" {
+		return true, ""
+	}
 	r := &s.RiskState
 	now := time.Now().UTC()
 

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -2557,6 +2557,22 @@ func TestRiskState_PendingCircuitClose_ConsecutiveFailureserRoundTrip(t *testing
 // TestRiskState_PendingCircuitClose_LegacyShapeDefaultsZeroConsecutiveFailures verifies
 // that pre-#427 DB rows (which have no failure_count field) load with
 // ConsecutiveFailures=0 so the first new-code failure increments to 1 and notifies.
+func TestCheckRisk_ManualStrategyAlwaysAllowed(t *testing.T) {
+	sc := &StrategyConfig{ID: "hl-manual-eth-live", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 10}
+	s := &StrategyState{Type: "manual", RiskState: RiskState{PeakValue: 100, MaxDrawdownPct: 60}}
+	// pv=5 vs peak=100 would be 95% drawdown — far over 60% — for a normal strategy.
+	allowed, reason := CheckRisk(sc, s, 5.0, nil, nil, nil)
+	if !allowed {
+		t.Errorf("manual strategy should always pass CheckRisk, got reason=%q", reason)
+	}
+	if reason != "" {
+		t.Errorf("expected empty reason, got %q", reason)
+	}
+	if s.RiskState.CircuitBreaker {
+		t.Error("CheckRisk must not set CircuitBreaker for manual strategy")
+	}
+}
+
 func TestRiskState_PendingCircuitClose_LegacyShapeDefaultsZeroConsecutiveFailures(t *testing.T) {
 	var r RiskState
 	// Legacy DB row has no failure_count or last_notified_at fields.


### PR DESCRIPTION
## Problem

Manual strategies (`type=manual`) trip the per-strategy drawdown circuit breaker with false positives:

```
[manual-eth] [WARN] Risk block: max drawdown exceeded (74.5% > 60.0%, portfolio=$5.06 peak=$19.80, denom=peak=$19.80)
```

They start with `capital=0` and get funded ad-hoc by operator fills, so the peak-relative drawdown math is meaningless — the high-water mark is set by the first manual fill and any subsequent unrealized dip looks like a breach.

## Fix

Early return in `CheckRisk` for `sc.Type == "manual"`, mirroring the existing `type=manual` exemptions in `config.go` (capital validation at `:910`, peer conflict check at `:961-985`).

**Scope:** only per-strategy `CheckRisk`. Portfolio-wide kill switch is unaffected (for shared HL wallets it runs off real wallet equity, not the virtual capital=0 baseline). Pending circuit-close drains and per-platform close planners already exclude manual strategies by type filter.

## Changes

- `scheduler/risk.go` — 4-line early return at top of `CheckRisk`
- `scheduler/risk_test.go` — `TestCheckRisk_ManualStrategyAlwaysAllowed`: rigs 95% paper drawdown on a manual strategy, asserts `allowed=true` and `CircuitBreaker=false`

Closes #574

---
LLM: Claude Sonnet 4.6 (1M) | high