### PR TITLE
fix: include type=manual strategies in HL on-chain reconciler

### DIFF
--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -2579,3 +2579,82 @@ func TestRunPendingHyperliquidCircuitCloses_TenthFailureNotifies(t *testing.T) {
 		t.Errorf("expected 1 DM on failure #10 (every-10th cadence), got %d", len(dmMsgs))
 	}
 }
+
+// TestReconcileManualPositionExternalClose verifies that a type=manual HL strategy
+// whose on-chain position is flat gets its virtual position removed with
+// close_reason="hl_sync_external". Regression for #576.
+func TestReconcileManualPositionExternalClose(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"manual-eth": {
+				ID: "manual-eth", Cash: 100,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2000, Side: "long",
+						Multiplier: 1, Leverage: 5, OwnerStrategyID: "manual-eth"},
+				},
+			},
+		},
+	}
+	sc := StrategyConfig{
+		ID: "manual-eth", Platform: "hyperliquid", Type: "manual",
+		Symbol: "ETH", Timeframe: "1h", Leverage: 5,
+		Args: []string{"hold", "ETH", "1h", "--mode=live"},
+	}
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+
+	// Pass nil positions (on-chain flat).
+	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil)
+
+	ss := state.Strategies["manual-eth"]
+	if _, ok := ss.Positions["ETH"]; ok {
+		t.Error("ETH position should have been removed after external close")
+	}
+	if len(ss.ClosedPositions) != 1 {
+		t.Fatalf("ClosedPositions = %d, want 1", len(ss.ClosedPositions))
+	}
+	if ss.ClosedPositions[0].CloseReason != "hl_sync_external" {
+		t.Errorf("CloseReason = %q, want hl_sync_external", ss.ClosedPositions[0].CloseReason)
+	}
+}
+
+// TestReconcileManualPositionSLFired verifies that a type=manual strategy with a
+// resting stop-loss OID uses the hl_sync_stop_loss close path when on-chain goes
+// flat. Regression for #576.
+func TestReconcileManualPositionSLFired(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"manual-eth": {
+				ID: "manual-eth", Cash: 100,
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2000, Side: "long",
+						Multiplier: 1, Leverage: 5, OwnerStrategyID: "manual-eth",
+						StopLossOID: 77, StopLossTriggerPx: 1800},
+				},
+			},
+		},
+	}
+	sc := StrategyConfig{
+		ID: "manual-eth", Platform: "hyperliquid", Type: "manual",
+		Symbol: "ETH", Timeframe: "1h", Leverage: 5,
+		Args: []string{"hold", "ETH", "1h", "--mode=live"},
+	}
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+
+	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil)
+
+	ss := state.Strategies["manual-eth"]
+	if _, ok := ss.Positions["ETH"]; ok {
+		t.Error("ETH position should have been removed after SL fire")
+	}
+	if len(ss.ClosedPositions) != 1 {
+		t.Fatalf("ClosedPositions = %d, want 1", len(ss.ClosedPositions))
+	}
+	if ss.ClosedPositions[0].CloseReason != "stop_loss" {
+		t.Errorf("CloseReason = %q, want stop_loss", ss.ClosedPositions[0].CloseReason)
+	}
+	if ss.ClosedPositions[0].ClosePrice != 1800 {
+		t.Errorf("ClosePrice = %g, want 1800", ss.ClosedPositions[0].ClosePrice)
+	}
+}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -608,6 +608,22 @@ func main() {
 					hlLiveDue = append(hlLiveDue, sc)
 				}
 			}
+			// Reconcile lists extend hlLive* to include type=manual: manual
+			// positions are real on-chain HL positions that can be closed
+			// externally and must be reconciled. Other hlLiveAll consumers
+			// (kill-switch, trailing-stop, risk math) remain perps-only (#576).
+			var hlReconcileAll []StrategyConfig
+			for _, sc := range cfg.Strategies {
+				if isHLLiveReconcilable(sc) {
+					hlReconcileAll = append(hlReconcileAll, sc)
+				}
+			}
+			var hlReconcileDue []StrategyConfig
+			for _, sc := range dueStrategies {
+				if isHLLiveReconcilable(sc) {
+					hlReconcileDue = append(hlReconcileDue, sc)
+				}
+			}
 
 			// #345: Partition live OKX strategies for the kill-switch close
 			// path. Perps and spot are separated because only perps support
@@ -1052,8 +1068,8 @@ func main() {
 				// Reuses the clearinghouseState already fetched above for the
 				// shared-wallet risk check (#243 review feedback) so we don't
 				// pay two HL API round-trips per cycle.
-				if len(hlLiveDue) > 0 && hlStateFetched {
-					reconcileHyperliquidAccountPositions(hlLiveDue, hlLiveAll, state, &mu, logMgr, hlPositions)
+				if len(hlReconcileDue) > 0 && hlStateFetched {
+					reconcileHyperliquidAccountPositions(hlReconcileDue, hlReconcileAll, state, &mu, logMgr, hlPositions)
 				}
 
 				for _, sc := range dueStrategies {
@@ -2229,6 +2245,17 @@ func hyperliquidSymbol(args []string) string {
 		return args[1]
 	}
 	return ""
+}
+
+// isHLLiveReconcilable reports whether sc should participate in on-chain
+// reconciliation. Both type=perps and type=manual are live HL positions that
+// can be closed externally; the reconciler is type-agnostic so both are safe.
+// Other consumers of hlLiveAll (kill-switch, trailing-stop arming, risk math)
+// intentionally stay perps-only.
+func isHLLiveReconcilable(sc StrategyConfig) bool {
+	return sc.Platform == "hyperliquid" &&
+		(sc.Type == "perps" || sc.Type == "manual") &&
+		hyperliquidIsLive(sc.Args)
 }
 
 // runHyperliquidCheck runs check_hyperliquid.py signal-check mode (Phase 3, no lock).

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -1085,3 +1085,27 @@ func TestExecuteTopStepResult_StampsExchangeData(t *testing.T) {
 		t.Errorf("ExchangeFee = %g, want 4.12", tr.ExchangeFee)
 	}
 }
+
+func TestIsHLLiveReconcilable(t *testing.T) {
+	liveArgs := []string{"hold", "ETH", "1h", "--mode=live"}
+	paperArgs := []string{"hold", "ETH", "1h", "--mode=paper"}
+	cases := []struct {
+		name string
+		sc   StrategyConfig
+		want bool
+	}{
+		{"perps live", StrategyConfig{Platform: "hyperliquid", Type: "perps", Args: liveArgs}, true},
+		{"manual live", StrategyConfig{Platform: "hyperliquid", Type: "manual", Args: liveArgs}, true},
+		{"perps paper", StrategyConfig{Platform: "hyperliquid", Type: "perps", Args: paperArgs}, false},
+		{"manual paper", StrategyConfig{Platform: "hyperliquid", Type: "manual", Args: paperArgs}, false},
+		{"spot live", StrategyConfig{Platform: "hyperliquid", Type: "spot", Args: liveArgs}, false},
+		{"non-hl perps", StrategyConfig{Platform: "okx", Type: "perps", Args: liveArgs}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isHLLiveReconcilable(tc.sc); got != tc.want {
+				t.Errorf("isHLLiveReconcilable = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`type=manual` HL strategies were excluded from `reconcileHyperliquidAccountPositions` because `hlLiveDue`/`hlLiveAll` filtered on `sc.Type == "perps"` only. When a manual position was closed on-chain (SL trigger fire, TP fill, or HL UI close), the bot retained the ghost position indefinitely.

## Fix

Add `isHLLiveReconcilable` predicate (`perps|manual` + `platform=hyperliquid` + live args) and build dedicated `hlReconcileAll`/`hlReconcileDue` lists for the reconciler call site. The existing perps-only `hlLiveAll`/`hlLiveDue` are intentionally unchanged — they feed kill-switch close, trailing-stop arming, and risk math which are perps-specific.

The reconciler itself (`reconcileHyperliquidPositions`) is type-agnostic and already handles the `onChainPos == nil && statePos != nil` case correctly.

## Tests

1. `TestReconcileManualPositionExternalClose` — manual position flat on-chain → removed with `close_reason=hl_sync_external`
2. `TestReconcileManualPositionSLFired` — manual position with resting OID flat on-chain → removed with `close_reason=stop_loss` at trigger price
3. `TestIsHLLiveReconcilable` — unit-tests the new predicate across 6 cases (perps/manual × live/paper, spot, non-HL)

Closes #576

---
LLM: Claude Sonnet 4.6 (1M) | high