### PR TITLE
leaderboard: add Tf/Int/#T/W/L columns to ranked summary

### DIFF
--- a/scheduler/leaderboard.go
+++ b/scheduler/leaderboard.go
@@ -11,14 +11,19 @@ import (
 
 // LeaderboardEntry holds computed PnL data for one strategy.
 type LeaderboardEntry struct {
-	ID      string  `json:"id"`
-	Type    string  `json:"type"`
-	Value   float64 `json:"value"`
-	Capital float64 `json:"capital"`
-	PnL     float64 `json:"pnl"`
-	PnLPct  float64 `json:"pnl_pct"`
-	Trades  int     `json:"trades"`
-	Sharpe  float64 `json:"sharpe"` // #397 — annualized Sharpe; 0 = undefined/no data. Kept in the serialized form (no omitempty) so consumers can distinguish "present but zero" from "omitted".
+	ID         string  `json:"id"`
+	Type       string  `json:"type"`
+	Value      float64 `json:"value"`
+	Capital    float64 `json:"capital"`
+	PnL        float64 `json:"pnl"`
+	PnLPct     float64 `json:"pnl_pct"`
+	Trades     int     `json:"trades"`
+	Sharpe     float64 `json:"sharpe"`      // #397 — annualized Sharpe; 0 = undefined/no data. Kept in the serialized form (no omitempty) so consumers can distinguish "present but zero" from "omitted".
+	Timeframe  string  `json:"timeframe"`   // #580 — candle timeframe (Args[2]) or "—".
+	Interval   string  `json:"interval"`    // #580 — formatted check interval (e.g. "1h").
+	RoundTrips int     `json:"round_trips"` // #580 — closed round-trip count from trades table (immune to RiskState resets).
+	Wins       int     `json:"wins"`        // #580 — round trips with net realized PnL > 0.
+	Losses     int     `json:"losses"`      // #580 — round trips with net realized PnL < 0.
 }
 
 // leaderboardTopN returns the configured top-N count, defaulting to 5 when unset.
@@ -33,8 +38,10 @@ func leaderboardTopN(cfg *Config) int {
 // messages from the current state. Returned map keys are "top" and "bottom";
 // the actual entry count is controlled by Discord.LeaderboardTopN. Returns nil
 // if no strategies have state. Issue #313 moved this to an on-demand compute
-// (previously written to leaderboard.json every cycle).
-func BuildLeaderboardMessages(cfg *Config, state *AppState, prices map[string]float64, sharpeByStrategy map[string]float64) map[string]string {
+// (previously written to leaderboard.json every cycle). lifetimeStats (#580)
+// is keyed by strategy ID; missing keys render zero round trips because
+// SQLite trades are authoritative — pass nil when unavailable.
+func BuildLeaderboardMessages(cfg *Config, state *AppState, prices map[string]float64, sharpeByStrategy map[string]float64, lifetimeStats map[string]LifetimeTradeStats) map[string]string {
 	var allEntries []LeaderboardEntry
 
 	for _, sc := range cfg.Strategies {
@@ -50,16 +57,7 @@ func BuildLeaderboardMessages(cfg *Config, state *AppState, prices map[string]fl
 			pnlPct = (pnl / initCap) * 100
 		}
 
-		allEntries = append(allEntries, LeaderboardEntry{
-			ID:      sc.ID,
-			Type:    sc.Type,
-			Value:   pv,
-			Capital: initCap,
-			PnL:     pnl,
-			PnLPct:  pnlPct,
-			Trades:  len(ss.TradeHistory),
-			Sharpe:  sharpeByStrategy[sc.ID],
-		})
+		allEntries = append(allEntries, newLeaderboardEntry(sc, ss, pv, initCap, pnl, pnlPct, sharpeByStrategy, lifetimeStats, cfg.IntervalSeconds))
 	}
 
 	if len(allEntries) == 0 {
@@ -70,6 +68,32 @@ func BuildLeaderboardMessages(cfg *Config, state *AppState, prices map[string]fl
 	return map[string]string{
 		"top":    formatAllTimeMessage("🏆", "Top All-Time Performers", allEntries, true, topN),
 		"bottom": formatAllTimeMessage("💀", "Bottom All-Time Performers", allEntries, false, topN),
+	}
+}
+
+// newLeaderboardEntry assembles a LeaderboardEntry, pulling timeframe/interval
+// from the strategy config and round-trip / W-L counts from the lifetime stats
+// map (#580). Missing lifetimeStats entry → zero round trips.
+func newLeaderboardEntry(sc StrategyConfig, ss *StrategyState, pv, initCap, pnl, pnlPct float64, sharpeByStrategy map[string]float64, lifetimeStats map[string]LifetimeTradeStats, globalIntervalSeconds int) LeaderboardEntry {
+	effectiveInterval := sc.IntervalSeconds
+	if effectiveInterval <= 0 {
+		effectiveInterval = globalIntervalSeconds
+	}
+	lt := lifetimeStats[sc.ID]
+	return LeaderboardEntry{
+		ID:         sc.ID,
+		Type:       sc.Type,
+		Value:      pv,
+		Capital:    initCap,
+		PnL:        pnl,
+		PnLPct:     pnlPct,
+		Trades:     len(ss.TradeHistory),
+		Sharpe:     sharpeByStrategy[sc.ID],
+		Timeframe:  extractTimeframe(sc),
+		Interval:   formatInterval(effectiveInterval),
+		RoundTrips: lt.RoundTrips,
+		Wins:       lt.Wins,
+		Losses:     lt.Losses,
 	}
 }
 
@@ -90,12 +114,14 @@ func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, sh
 
 	// Totals across ALL strategies in this category.
 	var totalValue, totalCapital float64
-	totalTrades := 0
+	totalRoundTrips, totalWins, totalLosses := 0, 0, 0
 	winning, losing, flat := 0, 0, 0
 	for _, e := range entries {
 		totalValue += e.Value
 		totalCapital += e.Capital
-		totalTrades += e.Trades
+		totalRoundTrips += e.RoundTrips
+		totalWins += e.Wins
+		totalLosses += e.Losses
 		if e.PnLPct > 0 {
 			winning++
 		} else if e.PnLPct < 0 {
@@ -116,45 +142,62 @@ func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, sh
 		top = top[:topN]
 	}
 
-	const sep = "--------------------------------------------------------------------------------"
-	sb.WriteString("\n```\n")
+	// Tf/Int/#T/W/L columns added in #580 to match FormatCategorySummary's
+	// per-channel A→Z table. Sharpe stays at the end as the leaderboard's
+	// distinguishing column.
+	var (
+		header   string
+		rowFmt   string
+		labelMax int
+	)
 	if showType {
-		sb.WriteString(fmt.Sprintf("%-22s %-6s %10s %10s %7s %8s %7s\n", "Strategy", "Type", "Value", "PnL", "PnL%", "Trades", "Sharpe"))
+		header = fmt.Sprintf("%-18s %-6s %10s %10s %7s %4s %4s %4s %5s %7s",
+			"Strategy", "Type", "Value", "PnL", "PnL%", "Tf", "Int", "#T", "W/L", "Sharpe")
+		rowFmt = "%-18s %-6s %10s %10s %7s %4s %4s %4d %5s %7s\n"
+		labelMax = 18
 	} else {
-		sb.WriteString(fmt.Sprintf("%-26s %10s %10s %7s %8s %7s\n", "Strategy", "Value", "PnL", "PnL%", "Trades", "Sharpe"))
+		header = fmt.Sprintf("%-22s %10s %10s %7s %4s %4s %4s %5s %7s",
+			"Strategy", "Value", "PnL", "PnL%", "Tf", "Int", "#T", "W/L", "Sharpe")
+		rowFmt = "%-22s %10s %10s %7s %4s %4s %4d %5s %7s\n"
+		labelMax = 22
 	}
+	sep := strings.Repeat("-", len(header))
+	sb.WriteString("\n```\n")
+	sb.WriteString(header + "\n")
 	sb.WriteString(sep + "\n")
 
 	for _, e := range top {
 		label := e.ID
+		if len(label) > labelMax {
+			label = label[:labelMax]
+		}
 		valStr := "$" + fmtComma(e.Value)
 		pnlStr := fmtSignedDollar(e.PnL)
 		pctStr := fmtSignedPct(e.PnLPct)
-		tradesStr := fmt.Sprintf("%d", e.Trades)
+		tfStr := leaderboardTfStr(e.Timeframe)
+		intStr := leaderboardIntStr(e.Interval)
+		wlStr := fmtWinLossRatio(e.Wins, e.Losses)
 		sharpeStr := fmtSharpe(e.Sharpe)
 		if showType {
-			if len(label) > 22 {
-				label = label[:22]
-			}
-			sb.WriteString(fmt.Sprintf("%-22s %-6s %10s %10s %7s %8s %7s\n", label, e.Type, valStr, pnlStr, pctStr, tradesStr, sharpeStr))
+			sb.WriteString(fmt.Sprintf(rowFmt, label, e.Type, valStr, pnlStr, pctStr, tfStr, intStr, e.RoundTrips, wlStr, sharpeStr))
 		} else {
-			if len(label) > 26 {
-				label = label[:26]
-			}
-			sb.WriteString(fmt.Sprintf("%-26s %10s %10s %7s %8s %7s\n", label, valStr, pnlStr, pctStr, tradesStr, sharpeStr))
+			sb.WriteString(fmt.Sprintf(rowFmt, label, valStr, pnlStr, pctStr, tfStr, intStr, e.RoundTrips, wlStr, sharpeStr))
 		}
 	}
 	sb.WriteString(sep + "\n")
 
 	totalLabel := fmt.Sprintf("TOTAL (%d strategies)", len(entries))
+	if len(totalLabel) > labelMax {
+		totalLabel = totalLabel[:labelMax]
+	}
 	totValStr := "$" + fmtComma(totalValue)
 	totPnlStr := fmtSignedDollar(totalPnl)
 	totPctStr := fmtSignedPct(totalPnlPct)
-	totTradesStr := fmt.Sprintf("%d", totalTrades)
+	totWlStr := fmtWinLossRatio(totalWins, totalLosses)
 	if showType {
-		sb.WriteString(fmt.Sprintf("%-22s %-6s %10s %10s %7s %8s %7s\n", totalLabel, "", totValStr, totPnlStr, totPctStr, totTradesStr, ""))
+		sb.WriteString(fmt.Sprintf(rowFmt, totalLabel, "", totValStr, totPnlStr, totPctStr, "", "", totalRoundTrips, totWlStr, ""))
 	} else {
-		sb.WriteString(fmt.Sprintf("%-26s %10s %10s %7s %8s %7s\n", totalLabel, totValStr, totPnlStr, totPctStr, totTradesStr, ""))
+		sb.WriteString(fmt.Sprintf(rowFmt, totalLabel, totValStr, totPnlStr, totPctStr, "", "", totalRoundTrips, totWlStr, ""))
 	}
 	sb.WriteString("```\n")
 	sb.WriteString(fmt.Sprintf("🟢 %d winning · 🔴 %d losing · ⚪ %d flat\n", winning, losing, flat))
@@ -192,8 +235,8 @@ func formatAllTimeMessage(icon, title string, entries []LeaderboardEntry, isTop 
 // pre-computed leaderboard.json (which was rewritten every cycle) to computing
 // fresh data at post time — the data is only used by the daily cron post and
 // the --leaderboard flag, so there is no benefit to pre-computation.
-func PostLeaderboard(cfg *Config, state *AppState, prices map[string]float64, sharpeByStrategy map[string]float64, notifier *MultiNotifier) error {
-	return postLeaderboardMessages(BuildLeaderboardMessages(cfg, state, prices, sharpeByStrategy), notifier)
+func PostLeaderboard(cfg *Config, state *AppState, prices map[string]float64, sharpeByStrategy map[string]float64, lifetimeStats map[string]LifetimeTradeStats, notifier *MultiNotifier) error {
+	return postLeaderboardMessages(BuildLeaderboardMessages(cfg, state, prices, sharpeByStrategy, lifetimeStats), notifier)
 }
 
 // postLeaderboardMessages posts pre-built leaderboard messages. Separated from
@@ -259,8 +302,8 @@ func platformIcon(platform string) string {
 // LeaderboardSummaryConfig entry: strategies filtered by platform (and
 // optionally ticker) sorted by PnL% descending, truncated to TopN. Returns ""
 // if no strategies match — caller should skip posting in that case.
-// Issue #308.
-func BuildLeaderboardSummary(lc LeaderboardSummaryConfig, cfg *Config, state *AppState, prices map[string]float64, sharpeByStrategy map[string]float64) string {
+// Issue #308. lifetimeStats may be nil; missing keys render zero round trips.
+func BuildLeaderboardSummary(lc LeaderboardSummaryConfig, cfg *Config, state *AppState, prices map[string]float64, sharpeByStrategy map[string]float64, lifetimeStats map[string]LifetimeTradeStats) string {
 	topN := lc.TopN
 	if topN <= 0 {
 		topN = 5
@@ -286,16 +329,7 @@ func BuildLeaderboardSummary(lc LeaderboardSummaryConfig, cfg *Config, state *Ap
 		if initCap > 0 {
 			pnlPct = (pnl / initCap) * 100
 		}
-		entries = append(entries, LeaderboardEntry{
-			ID:      sc.ID,
-			Type:    sc.Type,
-			Value:   pv,
-			Capital: initCap,
-			PnL:     pnl,
-			PnLPct:  pnlPct,
-			Trades:  len(ss.TradeHistory),
-			Sharpe:  sharpeByStrategy[sc.ID],
-		})
+		entries = append(entries, newLeaderboardEntry(sc, ss, pv, initCap, pnl, pnlPct, sharpeByStrategy, lifetimeStats, cfg.IntervalSeconds))
 	}
 
 	if len(entries) == 0 {
@@ -316,6 +350,29 @@ func BuildLeaderboardSummary(lc LeaderboardSummaryConfig, cfg *Config, state *Ap
 		title = fmt.Sprintf("%s %s Top %d", platformTitle, tickerFilter, n)
 	}
 	return formatLeaderboardMessage(platformIcon(lc.Platform), title, entries[:n], false, n)
+}
+
+// leaderboardTfStr trims long timeframe strings to fit the 4-char Tf column.
+// Empty / missing values render as "—" to match FormatCategorySummary.
+func leaderboardTfStr(tf string) string {
+	if tf == "" {
+		return "—"
+	}
+	if len(tf) > 4 {
+		return tf[:4]
+	}
+	return tf
+}
+
+// leaderboardIntStr applies the same width guard for the Int column.
+func leaderboardIntStr(s string) string {
+	if s == "" {
+		return "—"
+	}
+	if len(s) > 4 {
+		return s[:4]
+	}
+	return s
 }
 
 // fmtSignedDollar formats a dollar value with +/- prefix.

--- a/scheduler/leaderboard.go
+++ b/scheduler/leaderboard.go
@@ -156,10 +156,13 @@ func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, sh
 		rowFmt = "%-18s %-6s %10s %10s %7s %4s %4s %4d %5s %7s\n"
 		labelMax = 18
 	} else {
-		header = fmt.Sprintf("%-22s %10s %10s %7s %4s %4s %4s %5s %7s",
+		// Non-showType keeps the wider 26-char Strategy column from origin/main
+		// so IDs like "hl-btc-tiered-atr-paper" (23 chars) render in full. The
+		// showType branch shrinks to 18 to match catTableStrategyWidth.
+		header = fmt.Sprintf("%-26s %10s %10s %7s %4s %4s %4s %5s %7s",
 			"Strategy", "Value", "PnL", "PnL%", "Tf", "Int", "#T", "W/L", "Sharpe")
-		rowFmt = "%-22s %10s %10s %7s %4s %4s %4d %5s %7s\n"
-		labelMax = 22
+		rowFmt = "%-26s %10s %10s %7s %4s %4s %4d %5s %7s\n"
+		labelMax = 26
 	}
 	sep := strings.Repeat("-", len(header))
 	sb.WriteString("\n```\n")
@@ -174,8 +177,8 @@ func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, sh
 		valStr := "$" + fmtComma(e.Value)
 		pnlStr := fmtSignedDollar(e.PnL)
 		pctStr := fmtSignedPct(e.PnLPct)
-		tfStr := leaderboardTfStr(e.Timeframe)
-		intStr := leaderboardIntStr(e.Interval)
+		tfStr := truncateRunes(e.Timeframe, 4)
+		intStr := truncateRunes(e.Interval, 4)
 		wlStr := fmtWinLossRatio(e.Wins, e.Losses)
 		sharpeStr := fmtSharpe(e.Sharpe)
 		if showType {
@@ -352,27 +355,16 @@ func BuildLeaderboardSummary(lc LeaderboardSummaryConfig, cfg *Config, state *Ap
 	return formatLeaderboardMessage(platformIcon(lc.Platform), title, entries[:n], false, n)
 }
 
-// leaderboardTfStr trims long timeframe strings to fit the 4-char Tf column.
-// Empty / missing values render as "—" to match FormatCategorySummary.
-func leaderboardTfStr(tf string) string {
-	if tf == "" {
-		return "—"
+// truncateRunes returns s clipped to at most max runes. Rune-aware so multi-byte
+// glyphs (e.g. "—") aren't sliced into invalid UTF-8. Used for the Tf/Int
+// column width guard. Callers that pass `extractTimeframe` / `formatInterval`
+// values can rely on those helpers to produce non-empty output.
+func truncateRunes(s string, max int) string {
+	if utf8.RuneCountInString(s) <= max {
+		return s
 	}
-	if len(tf) > 4 {
-		return tf[:4]
-	}
-	return tf
-}
-
-// leaderboardIntStr applies the same width guard for the Int column.
-func leaderboardIntStr(s string) string {
-	if s == "" {
-		return "—"
-	}
-	if len(s) > 4 {
-		return s[:4]
-	}
-	return s
+	runes := []rune(s)
+	return string(runes[:max])
 }
 
 // fmtSignedDollar formats a dollar value with +/- prefix.

--- a/scheduler/leaderboard_test.go
+++ b/scheduler/leaderboard_test.go
@@ -134,6 +134,10 @@ func TestBuildLeaderboardMessages_SharpeColumn(t *testing.T) {
 // TestBuildLeaderboardMessages_TfIntColumns verifies that Tf (Args[2]) and Int
 // (per-strategy or global IntervalSeconds) are extracted into LeaderboardEntry
 // and surfaced in the rendered message. Regression for #580.
+//
+// Asserts on the full Tf+Int cell pair (right-aligned in a %4s %4s row) rather
+// than each value as a free substring — `"4h"` would otherwise match elsewhere
+// in the rendered table.
 func TestBuildLeaderboardMessages_TfIntColumns(t *testing.T) {
 	cfg := &Config{
 		IntervalSeconds: 3600,
@@ -150,10 +154,15 @@ func TestBuildLeaderboardMessages_TfIntColumns(t *testing.T) {
 	}
 	messages := BuildLeaderboardMessages(cfg, state, map[string]float64{"BTC/USDT": 50000, "ETH/USDT": 3000}, nil, nil)
 	topMsg := messages["top"]
-	for _, want := range []string{"30m", "10m", "4h", "1h"} {
-		if !containsStr(topMsg, want) {
-			t.Errorf("top message should contain %q (Tf or Int), got:\n%s", want, topMsg)
-		}
+	// Per-strategy interval (sma-btc): Tf="30m", Int="10m" → " 30m  10m".
+	smaCell := fmt.Sprintf("%4s %4s", "30m", "10m")
+	if !containsStr(topMsg, smaCell) {
+		t.Errorf("top message should contain Tf+Int cell %q for sma-btc, got:\n%s", smaCell, topMsg)
+	}
+	// Global fallback (rsi-eth): Tf="4h", Int="1h" → "  4h   1h".
+	rsiCell := fmt.Sprintf("%4s %4s", "4h", "1h")
+	if !containsStr(topMsg, rsiCell) {
+		t.Errorf("top message should contain Tf+Int cell %q for rsi-eth, got:\n%s", rsiCell, topMsg)
 	}
 }
 
@@ -176,12 +185,12 @@ func TestBuildLeaderboardMessages_RoundTripsAndWinLoss(t *testing.T) {
 	}
 	messages := BuildLeaderboardMessages(cfg, state, map[string]float64{"BTC/USDT": 50000}, nil, lifetime)
 	topMsg := messages["top"]
-	// 5 wins / 2 losses = 2.50
-	if !containsStr(topMsg, "2.50") {
-		t.Errorf("top message should render W/L 2.50, got:\n%s", topMsg)
-	}
-	if !containsStr(topMsg, " 7 ") {
-		t.Errorf("top message should render round-trip count 7 in #T column, got:\n%s", topMsg)
+	// Assert on the full #T+W/L cell pair (`"%4d %5s"`) so a future width
+	// change to either column fails loudly instead of silently passing on the
+	// happy substring " 7 ". 5 wins / 2 losses → fmtWinLossRatio="2.50".
+	wantCell := fmt.Sprintf("%4d %5s", 7, fmtWinLossRatio(5, 2))
+	if !containsStr(topMsg, wantCell) {
+		t.Errorf("top message should render #T+W/L cell %q, got:\n%s", wantCell, topMsg)
 	}
 }
 
@@ -597,6 +606,33 @@ func TestBuildLeaderboardSummary_DefaultTopN(t *testing.T) {
 	msg := BuildLeaderboardSummary(lc, cfg, state, nil, nil, nil)
 	if !containsStr(msg, "Hyperliquid Top 5") {
 		t.Errorf("Expected default TopN=5 in title, got:\n%s", msg)
+	}
+}
+
+// TestBuildLeaderboardSummary_RoundTripsAndWinLoss covers the per-platform path
+// (BuildLeaderboardSummary) for the #T / W/L columns introduced in #580 — the
+// top/bottom path is covered by TestBuildLeaderboardMessages_RoundTripsAndWinLoss.
+func TestBuildLeaderboardSummary_RoundTripsAndWinLoss(t *testing.T) {
+	cfg := &Config{
+		Strategies: []StrategyConfig{
+			{ID: "hl-sma-btc", Type: "perps", Capital: 1000, Platform: "hyperliquid", Args: []string{"sma_crossover", "BTC/USDT", "1h"}},
+		},
+	}
+	state := NewAppState()
+	state.Strategies["hl-sma-btc"] = NewStrategyState(cfg.Strategies[0])
+	state.Strategies["hl-sma-btc"].Cash = 1100
+
+	lifetime := map[string]LifetimeTradeStats{
+		"hl-sma-btc": {RoundTrips: 4, Wins: 3, Losses: 1},
+	}
+	lc := LeaderboardSummaryConfig{Platform: "hyperliquid", TopN: 5, Channel: "c1"}
+	msg := BuildLeaderboardSummary(lc, cfg, state, map[string]float64{"BTC/USDT": 50000}, nil, lifetime)
+	if msg == "" {
+		t.Fatal("BuildLeaderboardSummary returned empty message")
+	}
+	wantCell := fmt.Sprintf("%4d %5s", 4, fmtWinLossRatio(3, 1))
+	if !containsStr(msg, wantCell) {
+		t.Errorf("summary should render #T+W/L cell %q for hl-sma-btc, got:\n%s", wantCell, msg)
 	}
 }
 

--- a/scheduler/leaderboard_test.go
+++ b/scheduler/leaderboard_test.go
@@ -49,7 +49,7 @@ func TestBuildLeaderboardMessages(t *testing.T) {
 		"ETH/USDT": 3000,
 	}
 
-	messages := BuildLeaderboardMessages(cfg, state, prices, nil)
+	messages := BuildLeaderboardMessages(cfg, state, prices, nil, nil)
 	if messages == nil {
 		t.Fatal("BuildLeaderboardMessages returned nil")
 	}
@@ -84,8 +84,10 @@ func TestBuildLeaderboardMessages(t *testing.T) {
 	if !containsStr(topMsg, "winning") {
 		t.Error("top message should contain winning/losing/flat counts")
 	}
-	if !containsStr(topMsg, "Trades") {
-		t.Error("top message should contain Trades column header")
+	for _, hdr := range []string{"Tf", "Int", "#T", "W/L", "Sharpe"} {
+		if !containsStr(topMsg, hdr) {
+			t.Errorf("top message should contain %q column header, got:\n%s", hdr, topMsg)
+		}
 	}
 }
 
@@ -112,7 +114,7 @@ func TestBuildLeaderboardMessages_SharpeColumn(t *testing.T) {
 		"rsi-eth": -0.33,
 	}
 
-	messages := BuildLeaderboardMessages(cfg, state, map[string]float64{"BTC/USDT": 50000, "ETH/USDT": 3000}, sharpe)
+	messages := BuildLeaderboardMessages(cfg, state, map[string]float64{"BTC/USDT": 50000, "ETH/USDT": 3000}, sharpe, nil)
 	if messages == nil {
 		t.Fatal("BuildLeaderboardMessages returned nil")
 	}
@@ -129,6 +131,60 @@ func TestBuildLeaderboardMessages_SharpeColumn(t *testing.T) {
 	}
 }
 
+// TestBuildLeaderboardMessages_TfIntColumns verifies that Tf (Args[2]) and Int
+// (per-strategy or global IntervalSeconds) are extracted into LeaderboardEntry
+// and surfaced in the rendered message. Regression for #580.
+func TestBuildLeaderboardMessages_TfIntColumns(t *testing.T) {
+	cfg := &Config{
+		IntervalSeconds: 3600,
+		Strategies: []StrategyConfig{
+			{ID: "sma-btc", Type: "spot", Capital: 1000, Platform: "binanceus", Args: []string{"sma_crossover", "BTC/USDT", "30m"}, IntervalSeconds: 600},
+			{ID: "rsi-eth", Type: "spot", Capital: 500, Platform: "binanceus", Args: []string{"rsi_divergence", "ETH/USDT", "4h"}}, // falls back to global 1h
+		},
+	}
+	state := NewAppState()
+	for _, sc := range cfg.Strategies {
+		ss := NewStrategyState(sc)
+		ss.Cash = sc.Capital + 100
+		state.Strategies[sc.ID] = ss
+	}
+	messages := BuildLeaderboardMessages(cfg, state, map[string]float64{"BTC/USDT": 50000, "ETH/USDT": 3000}, nil, nil)
+	topMsg := messages["top"]
+	for _, want := range []string{"30m", "10m", "4h", "1h"} {
+		if !containsStr(topMsg, want) {
+			t.Errorf("top message should contain %q (Tf or Int), got:\n%s", want, topMsg)
+		}
+	}
+}
+
+// TestBuildLeaderboardMessages_RoundTripsAndWinLoss verifies that #T and W/L
+// columns reflect the supplied lifetimeStats map (not in-memory TradeHistory).
+// Regression for #580.
+func TestBuildLeaderboardMessages_RoundTripsAndWinLoss(t *testing.T) {
+	cfg := &Config{
+		Strategies: []StrategyConfig{
+			{ID: "sma-btc", Type: "spot", Capital: 1000, Platform: "binanceus", Args: []string{"sma_crossover", "BTC/USDT", "1h"}},
+		},
+	}
+	state := NewAppState()
+	ss := NewStrategyState(cfg.Strategies[0])
+	ss.Cash = 1100
+	state.Strategies["sma-btc"] = ss
+
+	lifetime := map[string]LifetimeTradeStats{
+		"sma-btc": {RoundTrips: 7, Wins: 5, Losses: 2},
+	}
+	messages := BuildLeaderboardMessages(cfg, state, map[string]float64{"BTC/USDT": 50000}, nil, lifetime)
+	topMsg := messages["top"]
+	// 5 wins / 2 losses = 2.50
+	if !containsStr(topMsg, "2.50") {
+		t.Errorf("top message should render W/L 2.50, got:\n%s", topMsg)
+	}
+	if !containsStr(topMsg, " 7 ") {
+		t.Errorf("top message should render round-trip count 7 in #T column, got:\n%s", topMsg)
+	}
+}
+
 // TestBuildLeaderboardMessages_Empty verifies BuildLeaderboardMessages returns
 // nil when no strategies have state. PostLeaderboard relies on this to surface
 // the "no strategies" error instead of posting empty messages.
@@ -136,7 +192,7 @@ func TestBuildLeaderboardMessages_Empty(t *testing.T) {
 	cfg := &Config{DBFile: filepath.Join(t.TempDir(), "state.db")}
 	state := NewAppState()
 
-	if messages := BuildLeaderboardMessages(cfg, state, nil, nil); messages != nil {
+	if messages := BuildLeaderboardMessages(cfg, state, nil, nil, nil); messages != nil {
 		t.Errorf("Expected nil messages for empty state, got %v", messages)
 	}
 }
@@ -226,7 +282,7 @@ func TestBuildLeaderboardMessages_TopN(t *testing.T) {
 		state.Strategies[sc.ID] = ss
 	}
 
-	messages := BuildLeaderboardMessages(cfg, state, map[string]float64{"BTC/USDT": 50000}, nil)
+	messages := BuildLeaderboardMessages(cfg, state, map[string]float64{"BTC/USDT": 50000}, nil, nil)
 	if messages == nil {
 		t.Fatal("BuildLeaderboardMessages returned nil")
 	}
@@ -292,7 +348,7 @@ func TestPostLeaderboard_DedicatedChannel(t *testing.T) {
 		leaderboardChannel: "lb-ch",
 	})
 
-	if err := PostLeaderboard(cfg, state, prices, nil, notifier); err != nil {
+	if err := PostLeaderboard(cfg, state, prices, nil, nil, notifier); err != nil {
 		t.Fatalf("PostLeaderboard: %v", err)
 	}
 
@@ -318,7 +374,7 @@ func TestPostLeaderboard_FallbackRouting(t *testing.T) {
 		channels: map[string]string{"spot": "spot-ch", "perps": "perps-ch"},
 	})
 
-	if err := PostLeaderboard(cfg, state, prices, nil, notifier); err != nil {
+	if err := PostLeaderboard(cfg, state, prices, nil, nil, notifier); err != nil {
 		t.Fatalf("PostLeaderboard: %v", err)
 	}
 
@@ -371,7 +427,7 @@ func TestPostLeaderboard_MixedBackends(t *testing.T) {
 		},
 	)
 
-	if err := PostLeaderboard(cfg, state, prices, nil, notifier); err != nil {
+	if err := PostLeaderboard(cfg, state, prices, nil, nil, notifier); err != nil {
 		t.Fatalf("PostLeaderboard: %v", err)
 	}
 
@@ -412,7 +468,7 @@ func TestPostLeaderboard_NoStrategies(t *testing.T) {
 	mock := &mockNotifier{}
 	notifier := NewMultiNotifier(notifierBackend{notifier: mock, channels: map[string]string{"spot": "spot-ch"}})
 
-	err := PostLeaderboard(cfg, state, nil, nil, notifier)
+	err := PostLeaderboard(cfg, state, nil, nil, nil, notifier)
 	if err == nil {
 		t.Error("expected error when no strategies configured")
 	}
@@ -463,7 +519,7 @@ func TestBuildLeaderboardSummary_PlatformOnly(t *testing.T) {
 	}
 
 	lc := LeaderboardSummaryConfig{Platform: "hyperliquid", TopN: 10, Channel: "chan-1"}
-	msg := BuildLeaderboardSummary(lc, cfg, state, nil, nil)
+	msg := BuildLeaderboardSummary(lc, cfg, state, nil, nil, nil)
 	if msg == "" {
 		t.Fatal("Expected non-empty message")
 	}
@@ -495,7 +551,7 @@ func TestBuildLeaderboardSummary_TickerFilter(t *testing.T) {
 	}
 
 	lc := LeaderboardSummaryConfig{Platform: "hyperliquid", Ticker: "eth", TopN: 5, Channel: "chan-1"}
-	msg := BuildLeaderboardSummary(lc, cfg, state, nil, nil)
+	msg := BuildLeaderboardSummary(lc, cfg, state, nil, nil, nil)
 	if msg == "" {
 		t.Fatal("Expected non-empty message")
 	}
@@ -538,7 +594,7 @@ func TestBuildLeaderboardSummary_DefaultTopN(t *testing.T) {
 
 	// TopN=0 means default (5).
 	lc := LeaderboardSummaryConfig{Platform: "hyperliquid", Channel: "c1"}
-	msg := BuildLeaderboardSummary(lc, cfg, state, nil, nil)
+	msg := BuildLeaderboardSummary(lc, cfg, state, nil, nil, nil)
 	if !containsStr(msg, "Hyperliquid Top 5") {
 		t.Errorf("Expected default TopN=5 in title, got:\n%s", msg)
 	}
@@ -554,7 +610,7 @@ func TestBuildLeaderboardSummary_NoMatches(t *testing.T) {
 	state.Strategies["sma-btc"] = NewStrategyState(cfg.Strategies[0])
 
 	lc := LeaderboardSummaryConfig{Platform: "hyperliquid", Channel: "c1"}
-	if msg := BuildLeaderboardSummary(lc, cfg, state, nil, nil); msg != "" {
+	if msg := BuildLeaderboardSummary(lc, cfg, state, nil, nil, nil); msg != "" {
 		t.Errorf("Expected empty message when no strategies match, got:\n%s", msg)
 	}
 }

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -309,7 +309,8 @@ func main() {
 		}
 		prices := fetchPricesForSummary(cfg)
 		sharpeByStrategy := ComputeSharpeByStrategy(LoadClosedPositionsByStrategy(stateDB, cfg), cfg, state)
-		if err := PostLeaderboard(cfg, state, prices, sharpeByStrategy, notifier); err != nil {
+		lifetimeStats := loadLifetimeStatsBestEffort(stateDB)
+		if err := PostLeaderboard(cfg, state, prices, sharpeByStrategy, lifetimeStats, notifier); err != nil {
 			fmt.Fprintf(os.Stderr, "Leaderboard post failed: %v\n", err)
 			os.Exit(1)
 		}
@@ -1743,7 +1744,7 @@ func main() {
 		// HTTPS latency can't stall the scheduler cycle.
 		var duePending []pendingLeaderboardSummary
 		if notifier.HasBackends() {
-			duePending = collectDueLeaderboardSummaries(cfg, state, prices, ComputeSharpeByStrategy(closedByStrategy, cfg, state))
+			duePending = collectDueLeaderboardSummaries(cfg, state, prices, ComputeSharpeByStrategy(closedByStrategy, cfg, state), lifetimeStats)
 		}
 
 		if err := SaveStateWithDB(state, cfg, stateDB); err != nil {
@@ -1799,7 +1800,7 @@ func main() {
 			} else {
 				sharpeByStrategy := ComputeSharpeByStrategy(closedByStrategy, cfg, state)
 				mu.RLock()
-				lbMessages := BuildLeaderboardMessages(cfg, state, prices, sharpeByStrategy)
+				lbMessages := BuildLeaderboardMessages(cfg, state, prices, sharpeByStrategy, lifetimeStats)
 				mu.RUnlock()
 				if len(lbMessages) == 0 {
 					fmt.Println("[leaderboard] Auto-post skipped: no strategy state to leaderboard yet")
@@ -3234,9 +3235,10 @@ func fetchPricesForSummary(cfg *Config) map[string]float64 {
 func runLeaderboardSummariesAndExit(lcs []LeaderboardSummaryConfig, cfg *Config, state *AppState, sdb *StateDB, notifier *MultiNotifier) {
 	prices := fetchPricesForSummary(cfg)
 	sharpeByStrategy := ComputeSharpeByStrategy(LoadClosedPositionsByStrategy(sdb, cfg), cfg, state)
+	lifetimeStats := loadLifetimeStatsBestEffort(sdb)
 	posted := 0
 	for _, lc := range lcs {
-		msg := BuildLeaderboardSummary(lc, cfg, state, prices, sharpeByStrategy)
+		msg := BuildLeaderboardSummary(lc, cfg, state, prices, sharpeByStrategy, lifetimeStats)
 		if msg == "" {
 			fmt.Fprintf(os.Stderr, "No strategies match leaderboard summary platform=%s ticker=%s\n", lc.Platform, lc.Ticker)
 			continue
@@ -3253,6 +3255,23 @@ func runLeaderboardSummariesAndExit(lcs []LeaderboardSummaryConfig, cfg *Config,
 	}
 	fmt.Printf("-summary=%s: posted %d leaderboard summaries, exiting.\n", lcs[0].Channel, posted)
 	os.Exit(0)
+}
+
+// loadLifetimeStatsBestEffort fetches per-strategy lifetime round-trip stats
+// from the trades table, downgrading errors to a nil map (the same fallback
+// FormatCategorySummary uses) so leaderboard #T / W/L columns render zero
+// instead of failing the post. Used by the on-demand leaderboard / summary
+// exit paths that don't have a pre-cached map. (#580)
+func loadLifetimeStatsBestEffort(sdb *StateDB) map[string]LifetimeTradeStats {
+	if sdb == nil {
+		return nil
+	}
+	stats, err := sdb.LifetimeTradeStatsAll()
+	if err != nil {
+		fmt.Printf("[leaderboard] lifetime trade stats unavailable: %v\n", err)
+		return nil
+	}
+	return stats
 }
 
 func cloneTimeMap(in map[string]time.Time) map[string]time.Time {
@@ -3277,7 +3296,7 @@ type pendingLeaderboardSummary struct {
 // optimistically so duplicate posts are avoided if the caller's Discord send
 // fails; same semantics as the previous in-lock implementation. Caller must
 // hold the write lock on state. (#308)
-func collectDueLeaderboardSummaries(cfg *Config, state *AppState, prices map[string]float64, sharpeByStrategy map[string]float64) []pendingLeaderboardSummary {
+func collectDueLeaderboardSummaries(cfg *Config, state *AppState, prices map[string]float64, sharpeByStrategy map[string]float64, lifetimeStats map[string]LifetimeTradeStats) []pendingLeaderboardSummary {
 	if len(cfg.LeaderboardSummaries) == 0 {
 		return nil
 	}
@@ -3296,7 +3315,7 @@ func collectDueLeaderboardSummaries(cfg *Config, state *AppState, prices map[str
 		if !last.IsZero() && now.Sub(last) < freq {
 			continue
 		}
-		msg := BuildLeaderboardSummary(lc, cfg, state, prices, sharpeByStrategy)
+		msg := BuildLeaderboardSummary(lc, cfg, state, prices, sharpeByStrategy, lifetimeStats)
 		if msg == "" {
 			continue
 		}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -309,7 +309,7 @@ func main() {
 		}
 		prices := fetchPricesForSummary(cfg)
 		sharpeByStrategy := ComputeSharpeByStrategy(LoadClosedPositionsByStrategy(stateDB, cfg), cfg, state)
-		lifetimeStats := loadLifetimeStatsBestEffort(stateDB)
+		lifetimeStats := loadLifetimeStatsBestEffort(stateDB, "[leaderboard]")
 		if err := PostLeaderboard(cfg, state, prices, sharpeByStrategy, lifetimeStats, notifier); err != nil {
 			fmt.Fprintf(os.Stderr, "Leaderboard post failed: %v\n", err)
 			os.Exit(1)
@@ -1661,14 +1661,7 @@ func main() {
 		// One DB round-trip per cycle; missing keys render as zero inside
 		// FormatCategorySummary. Errors are downgraded to a nil map so the
 		// summary still posts without in-memory lifetime counters (#472).
-		var lifetimeStats map[string]LifetimeTradeStats
-		if stateDB != nil {
-			if ls, err := stateDB.LifetimeTradeStatsAll(); err != nil {
-				fmt.Printf("[summary] lifetime trade stats unavailable: %v\n", err)
-			} else {
-				lifetimeStats = ls
-			}
-		}
+		lifetimeStats := loadLifetimeStatsBestEffort(stateDB, "[summary]")
 
 		// Notification — one message per channel per asset, sent to all backends.
 		if notifier.HasBackends() {
@@ -1924,14 +1917,7 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, sdb *Sta
 	// Format and send summary using the same asset-grouping logic as the main loop.
 	closedByStrategy := LoadClosedPositionsByStrategy(sdb, cfg)
 	rfr := RiskFreeRateOrDefault(cfg)
-	var lifetimeStats map[string]LifetimeTradeStats
-	if sdb != nil {
-		if ls, err := sdb.LifetimeTradeStatsAll(); err != nil {
-			fmt.Printf("[summary] lifetime trade stats unavailable: %v\n", err)
-		} else {
-			lifetimeStats = ls
-		}
-	}
+	lifetimeStats := loadLifetimeStatsBestEffort(sdb, "[summary]")
 	assetGroups, assetKeys := groupByAsset(chStrats)
 	if len(assetKeys) <= 1 {
 		chSharpe := aggregateSharpe(closedByStrategy, chStrats, state, rfr)
@@ -3235,7 +3221,7 @@ func fetchPricesForSummary(cfg *Config) map[string]float64 {
 func runLeaderboardSummariesAndExit(lcs []LeaderboardSummaryConfig, cfg *Config, state *AppState, sdb *StateDB, notifier *MultiNotifier) {
 	prices := fetchPricesForSummary(cfg)
 	sharpeByStrategy := ComputeSharpeByStrategy(LoadClosedPositionsByStrategy(sdb, cfg), cfg, state)
-	lifetimeStats := loadLifetimeStatsBestEffort(sdb)
+	lifetimeStats := loadLifetimeStatsBestEffort(sdb, "[leaderboard]")
 	posted := 0
 	for _, lc := range lcs {
 		msg := BuildLeaderboardSummary(lc, cfg, state, prices, sharpeByStrategy, lifetimeStats)
@@ -3260,15 +3246,16 @@ func runLeaderboardSummariesAndExit(lcs []LeaderboardSummaryConfig, cfg *Config,
 // loadLifetimeStatsBestEffort fetches per-strategy lifetime round-trip stats
 // from the trades table, downgrading errors to a nil map (the same fallback
 // FormatCategorySummary uses) so leaderboard #T / W/L columns render zero
-// instead of failing the post. Used by the on-demand leaderboard / summary
-// exit paths that don't have a pre-cached map. (#580)
-func loadLifetimeStatsBestEffort(sdb *StateDB) map[string]LifetimeTradeStats {
+// instead of failing the post. logPrefix tags the warning when the DB read
+// fails ("[summary]" for the per-cycle paths, "[leaderboard]" for the
+// on-demand paths). (#580)
+func loadLifetimeStatsBestEffort(sdb *StateDB, logPrefix string) map[string]LifetimeTradeStats {
 	if sdb == nil {
 		return nil
 	}
 	stats, err := sdb.LifetimeTradeStatsAll()
 	if err != nil {
-		fmt.Printf("[leaderboard] lifetime trade stats unavailable: %v\n", err)
+		fmt.Printf("%s lifetime trade stats unavailable: %v\n", logPrefix, err)
 		return nil
 	}
 	return stats


### PR DESCRIPTION
Closes #580

Extend `formatLeaderboardMessage` to surface the same per-strategy context the per-channel A→Z `FormatCategorySummary` table already shows: candle timeframe, check interval, lifetime closed round trips, and win/loss ratio. Sharpe stays as the trailing column.

#T / W/L pull from the authoritative `trades` table via `LifetimeTradeStatsAll` — immune to RiskState / kill-switch resets, matches `FormatCategorySummary`.

Generated with [Claude Code](https://claude.ai/code

---
LLM: Claude Opus 4.7 (1M) | high | Harness: anthropics/claude-code-action@v1 | Tokens: 108 in / 38008 out | Cache: 8495813 read / 207211 written | Cost: $6.49