### PR TITLE
fix: credit peer cash on detected HL external close (#584)

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -510,7 +510,12 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 				} else if mark, ok := prices[coin]; ok && mark > 0 && recordPerpsExternalClose(ss, coin, mark, "hl_sync_external", logger) {
 					// #584: credit s.Cash with mark-based PnL so the per-strategy
 					// PortfolioValue (and the summary TOTAL) match the real HL
-					// account after an external close.
+					// account after an external close. The mark is fetched at
+					// cycle start, so cp.RealizedPnL is an *approximation* — it
+					// will drift from the true on-chain fill price (which can be
+					// minutes earlier). Do not treat the resulting Trade /
+					// ClosedPosition rows as authoritative for tax or reporting;
+					// they exist to keep cash bookkeeping in sync.
 					changed = true
 				} else {
 					// No mark price available — fall back to recording the

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -329,8 +329,10 @@ func syncHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppSt
 		return false
 	}
 
-	// Self-contained entry: due and all are the same list.
-	return reconcileHyperliquidAccountPositions(hlStrategies, hlStrategies, state, mu, logMgr, positions)
+	// Self-contained entry: due and all are the same list. Prices are
+	// unavailable in this path (caller did not pre-fetch); external-close
+	// PnL falls back to zero (legacy behavior pre-#584).
+	return reconcileHyperliquidAccountPositions(hlStrategies, hlStrategies, state, mu, logMgr, positions, nil)
 }
 
 // reconcileHyperliquidAccountPositions reconciles pre-fetched on-chain positions
@@ -343,8 +345,13 @@ func syncHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppSt
 // allStrategies includes every live HL strategy in the config — needed to detect
 // shared coins (#258) even when only some strategies are due.
 //
+// prices supplies the current mark for each coin (keyed by HL coin symbol such
+// as "BTC"). When an external close is detected for a non-SL-owner peer, the
+// mark is used as the approximate close price so realized PnL can be credited
+// to s.Cash (#584). Pass nil to fall back to the legacy zero-PnL recording.
+//
 // Must be called WITHOUT holding any lock; acquires Lock internally.
-func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager, positions []HLPosition) bool {
+func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager, positions []HLPosition, prices map[string]float64) bool {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -500,12 +507,20 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 					if recordPerpsStopLossClose(ss, coin, pos.StopLossTriggerPx, "hl_sync_stop_loss", logger) {
 						changed = true
 					}
+				} else if mark, ok := prices[coin]; ok && mark > 0 && recordPerpsExternalClose(ss, coin, mark, "hl_sync_external", logger) {
+					// #584: credit s.Cash with mark-based PnL so the per-strategy
+					// PortfolioValue (and the summary TOTAL) match the real HL
+					// account after an external close.
+					changed = true
 				} else {
+					// No mark price available — fall back to recording the
+					// close with zero PnL. s.Cash will be stale until the
+					// strategy reopens; tracked for follow-up if it matters.
 					recordClosedPosition(ss, pos, 0, 0, "hl_sync_external", now)
 					delete(ss.Positions, coin)
 					clearATRMultMissingEntryATRWarningOnHLPerpsClose(ss, coin)
 					if logger != nil {
-						logger.Info("hl-sync: %s position (%.6f %s) no longer on-chain, removing (external close)", coin, pos.Quantity, pos.Side)
+						logger.Info("hl-sync: %s position (%.6f %s) no longer on-chain, removing (external close, no mark price)", coin, pos.Quantity, pos.Side)
 					}
 					changed = true
 				}

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1371,6 +1371,30 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally_CreditsPeerCash(t *tes
 	if math.Abs(peer.Cash-wantCash) > 1e-6 {
 		t.Errorf("peer Cash = %v, want %v (started %v + PnL %v)", peer.Cash, wantCash, peerStartCash, wantPnL)
 	}
+	// SQLite-backed leaderboard #T / W/L reads from trades, not closed positions —
+	// assert the close Trade row mirrors the ClosedPosition.
+	var closeTrades []Trade
+	for _, tr := range peer.TradeHistory {
+		if tr.IsClose {
+			closeTrades = append(closeTrades, tr)
+		}
+	}
+	if len(closeTrades) != 1 {
+		t.Fatalf("peer close trades = %d, want 1 (history=%+v)", len(closeTrades), peer.TradeHistory)
+	}
+	ct := closeTrades[0]
+	if math.Abs(ct.RealizedPnL-wantPnL) > 1e-6 {
+		t.Errorf("trade RealizedPnL = %v, want %v", ct.RealizedPnL, wantPnL)
+	}
+	if ct.Price != mark {
+		t.Errorf("trade Price = %v, want %v", ct.Price, mark)
+	}
+	if ct.Side != "sell" {
+		t.Errorf("trade Side = %q, want %q (long close)", ct.Side, "sell")
+	}
+	if ct.TradeType != "perps" {
+		t.Errorf("trade TradeType = %q, want perps", ct.TradeType)
+	}
 	// Owner still goes through the SL path and also has its cash credited.
 	owner := state.Strategies["hl-owner-eth"]
 	if owner.Positions["ETH"] != nil {

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -989,7 +989,7 @@ func TestReconcileDueSubsetOfAllDetectsSharedCoins(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions(dueStrategies, allStrategies, state, &mu, logMgr, positions)
+	reconcileHyperliquidAccountPositions(dueStrategies, allStrategies, state, &mu, logMgr, positions, nil)
 
 	// Even though only rmc is due, allStrategies reveals ETH is shared by 3
 	// strategies, so rmc's position must NOT be reconciled to on-chain.
@@ -1058,7 +1058,7 @@ func TestReconcileSharedCoinShortAndMixedPositions(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
 
 	// Positions should be unchanged.
 	longPos := state.Strategies["hl-long-eth"].Positions["ETH"]
@@ -1121,7 +1121,7 @@ func TestReconcileSharedCoinBothShort(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
 
 	gap := state.ReconciliationGaps["ETH"]
 	if gap == nil {
@@ -1176,7 +1176,7 @@ func TestReconcileSharedCoin_OwnerStopLossFired_ClosesOwnerOnly(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
 
 	// Owner position must be closed and recorded.
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
@@ -1241,7 +1241,7 @@ func TestReconcileSharedCoin_OwnerStopLossFired_Short(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
 
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
 		t.Error("owner short ETH position should be nil after SL reconciliation")
@@ -1285,7 +1285,7 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
 
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
 		t.Error("owner ETH position should be nil")
@@ -1303,6 +1303,127 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally(t *testing.T) {
 		t.Errorf("peer ClosedPositions = %d, want 1", len(state.Strategies["hl-peer-eth"].ClosedPositions))
 	} else if state.Strategies["hl-peer-eth"].ClosedPositions[0].CloseReason != "hl_sync_external" {
 		t.Errorf("peer CloseReason = %q, want hl_sync_external", state.Strategies["hl-peer-eth"].ClosedPositions[0].CloseReason)
+	}
+}
+
+// TestReconcileSharedCoin_AllPositionsClosedExternally_CreditsPeerCash is the
+// #584 regression: when a non-SL-owner peer's position disappears on-chain and
+// a mark price is supplied, s.Cash must be credited with the mark-based PnL so
+// PortfolioValue matches the real HL account balance.
+func TestReconcileSharedCoin_AllPositionsClosedExternally_CreditsPeerCash(t *testing.T) {
+	const peerStartCash = 500.0
+	const peerQty = 0.5
+	const peerAvgCost = 3000.0
+	const mark = 3200.0
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-eth": {
+				ID: "hl-owner-eth", Cash: 1000, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 1.0, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth",
+						StopLossOID: 7, StopLossTriggerPx: 2800},
+				},
+			},
+			"hl-peer-eth": {
+				ID: "hl-peer-eth", Cash: peerStartCash, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: peerQty, AvgCost: peerAvgCost, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-peer-eth"},
+				},
+			},
+		},
+	}
+
+	allStrategies := []StrategyConfig{
+		{ID: "hl-owner-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-peer-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{}
+	prices := map[string]float64{"ETH": mark}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices)
+
+	peer := state.Strategies["hl-peer-eth"]
+	if peer.Positions["ETH"] != nil {
+		t.Error("peer ETH position should be nil after external close")
+	}
+	if len(peer.ClosedPositions) != 1 {
+		t.Fatalf("peer ClosedPositions = %d, want 1", len(peer.ClosedPositions))
+	}
+	cp := peer.ClosedPositions[0]
+	if cp.CloseReason != "hl_sync_external" {
+		t.Errorf("CloseReason = %q, want hl_sync_external", cp.CloseReason)
+	}
+	if cp.ClosePrice != mark {
+		t.Errorf("ClosePrice = %v, want %v", cp.ClosePrice, mark)
+	}
+	// Expected: gross PnL = qty*(mark-avgCost) = 0.5*200 = 100, fee = qty*mark*HyperliquidTakerFeePct = 0.5*3200*0.00035 = 0.56.
+	wantFee := peerQty * mark * HyperliquidTakerFeePct
+	wantPnL := peerQty*(mark-peerAvgCost) - wantFee
+	wantCash := peerStartCash + wantPnL
+	if math.Abs(cp.RealizedPnL-wantPnL) > 1e-6 {
+		t.Errorf("RealizedPnL = %v, want %v", cp.RealizedPnL, wantPnL)
+	}
+	if math.Abs(peer.Cash-wantCash) > 1e-6 {
+		t.Errorf("peer Cash = %v, want %v (started %v + PnL %v)", peer.Cash, wantCash, peerStartCash, wantPnL)
+	}
+	// Owner still goes through the SL path and also has its cash credited.
+	owner := state.Strategies["hl-owner-eth"]
+	if owner.Positions["ETH"] != nil {
+		t.Error("owner ETH position should be nil")
+	}
+	if len(owner.ClosedPositions) != 1 || owner.ClosedPositions[0].CloseReason != "hl_sync_stop_loss" {
+		t.Errorf("owner ClosedPositions wrong: %+v", owner.ClosedPositions)
+	}
+}
+
+// TestReconcileSharedCoin_AllPositionsClosedExternally_NoMarkPrice_FallsBack
+// verifies the legacy zero-PnL path still applies when the caller supplies no
+// mark price for the coin (e.g. the syncHyperliquidAccountPositions entry).
+func TestReconcileSharedCoin_AllPositionsClosedExternally_NoMarkPrice_FallsBack(t *testing.T) {
+	const peerStartCash = 500.0
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-peer-eth": {
+				ID: "hl-peer-eth", Cash: peerStartCash, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-peer-eth"},
+				},
+			},
+			"hl-other-eth": {
+				ID: "hl-other-eth", Cash: 1000, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-other-eth"},
+				},
+			},
+		},
+	}
+	allStrategies := []StrategyConfig{
+		{ID: "hl-peer-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-other-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	// nil prices map → legacy zero-PnL path.
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
+
+	peer := state.Strategies["hl-peer-eth"]
+	if peer.Positions["ETH"] != nil {
+		t.Error("peer ETH position should be nil")
+	}
+	if len(peer.ClosedPositions) != 1 || peer.ClosedPositions[0].RealizedPnL != 0 {
+		t.Errorf("expected zero-PnL fallback, got %+v", peer.ClosedPositions)
+	}
+	if peer.Cash != peerStartCash {
+		t.Errorf("peer Cash = %v, want unchanged %v (no mark price → no credit)", peer.Cash, peerStartCash)
 	}
 }
 
@@ -1338,7 +1459,7 @@ func TestReconcileSharedCoin_GapWithoutSLOwner_LeavesPositionsAlone(t *testing.T
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
 
 	// Both positions must be untouched.
 	posA := state.Strategies["hl-a-eth"].Positions["ETH"]
@@ -1395,7 +1516,7 @@ func TestReconcileSharedCoin_ResidualMismatch_LeavesPositionsAlone(t *testing.T)
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
 
 	// Both positions must be untouched.
 	ownerPos := state.Strategies["hl-owner-eth"].Positions["ETH"]
@@ -2604,7 +2725,7 @@ func TestReconcileManualPositionExternalClose(t *testing.T) {
 	var mu sync.RWMutex
 
 	// Pass nil positions (on-chain flat).
-	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil)
+	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil)
 
 	ss := state.Strategies["manual-eth"]
 	if _, ok := ss.Positions["ETH"]; ok {
@@ -2642,7 +2763,7 @@ func TestReconcileManualPositionSLFired(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil)
+	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil)
 
 	ss := state.Strategies["manual-eth"]
 	if _, ok := ss.Positions["ETH"]; ok {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1070,7 +1070,7 @@ func main() {
 				// shared-wallet risk check (#243 review feedback) so we don't
 				// pay two HL API round-trips per cycle.
 				if len(hlReconcileDue) > 0 && hlStateFetched {
-					reconcileHyperliquidAccountPositions(hlReconcileDue, hlReconcileAll, state, &mu, logMgr, hlPositions)
+					reconcileHyperliquidAccountPositions(hlReconcileDue, hlReconcileAll, state, &mu, logMgr, hlPositions, prices)
 				}
 
 				for _, sc := range dueStrategies {

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -167,6 +167,69 @@ func recordPerpsStopLossClose(s *StrategyState, symbol string, triggerPx float64
 	return true
 }
 
+// recordPerpsExternalClose books a perps close detected by reconciliation
+// when the position has disappeared on-chain without a tracked trigger fill
+// (manual UI close, kill-switch close from a peer, etc.). The caller supplies
+// a close price (typically the current mark) so realized PnL is approximated
+// and credited to s.Cash — matching how recordPerpsStopLossClose handles the
+// SL-owner case. Returns false if the price is non-positive or the position
+// is missing, so callers can fall back to a zero-PnL recordClosedPosition (#584).
+func recordPerpsExternalClose(s *StrategyState, symbol string, closePx float64, reason string, logger *StrategyLogger) bool {
+	if closePx <= 0 {
+		return false
+	}
+	pos, ok := s.Positions[symbol]
+	if !ok || pos == nil {
+		return false
+	}
+
+	now := time.Now().UTC()
+	qty := pos.Quantity
+	avgCost := pos.AvgCost
+	side := pos.Side
+	var pnl float64
+	if side == "long" {
+		pnl = qty * (closePx - avgCost)
+	} else {
+		pnl = qty * (avgCost - closePx)
+	}
+	feePlatform := s.Platform
+	if s.Platform == "okx" && s.Type == "perps" {
+		feePlatform = "okx-perps"
+	}
+	fee := CalculatePlatformSpotFee(feePlatform, qty*closePx)
+	pnl -= fee
+	s.Cash += pnl
+	positionID := ensurePositionTradeID(s.ID, symbol, pos)
+
+	trade := Trade{
+		Timestamp:   now,
+		StrategyID:  s.ID,
+		Symbol:      symbol,
+		PositionID:  positionID,
+		Side:        closeTradeSide(side),
+		Quantity:    qty,
+		Price:       closePx,
+		Value:       qty * closePx,
+		TradeType:   "perps",
+		Details:     fmt.Sprintf("External close @ mark, PnL: $%.2f (fee $%.2f)", pnl, fee),
+		IsClose:     true,
+		RealizedPnL: pnl,
+	}
+	trade.Regime = s.Regime
+	trade.EntryATR = pos.EntryATR
+	trade.StopLossTriggerPx = pos.StopLossTriggerPx
+	RecordTrade(s, trade)
+	RecordTradeResult(&s.RiskState, pnl)
+	recordClosedPosition(s, pos, closePx, pnl, reason, now)
+	delete(s.Positions, symbol)
+	clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
+	if logger != nil {
+		logger.Warn("External close reconciled @ $%.4f, PnL: $%.2f (fee $%.2f)", closePx, pnl, fee)
+	}
+	return true
+}
+
 // recordClosedOptionPosition appends a ClosedOptionPosition entry to the
 // strategy's buffer. Same durability boundary as recordClosedPosition —
 // in-memory until SaveState commits.

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -33,8 +33,9 @@ type Position struct {
 // by duration should treat zero as a sentinel, not a real value.
 //
 // ClosePrice note: for the synthetic "hl_sync_external" reason — positions
-// that disappeared from the exchange between reconcile cycles — both
-// ClosePrice and RealizedPnL are 0 (the real fill price is unknown). Downstream
+// that disappeared from the exchange between reconcile cycles — ClosePrice and
+// RealizedPnL are 0 when no mark price was available at reconcile time, and
+// approximate (mark-based, not the actual fill price) otherwise. Downstream
 // analytics that compute avg close price or slippage should filter
 // `close_reason != 'hl_sync_external'`.
 //

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -108,73 +108,14 @@ func recordClosedPosition(s *StrategyState, pos *Position, closePrice, realizedP
 	})
 }
 
-// recordPerpsStopLossClose books a tracked perps stop-loss fill and removes the
-// virtual position. Used both when HL reports an immediate trigger fill at
-// submit time and when a previously-resting trigger has fired between cycles.
-func recordPerpsStopLossClose(s *StrategyState, symbol string, triggerPx float64, reason string, logger *StrategyLogger) bool {
-	if triggerPx <= 0 {
-		return false
-	}
-	pos, ok := s.Positions[symbol]
-	if !ok || pos == nil {
-		return false
-	}
-
-	now := time.Now().UTC()
-	qty := pos.Quantity
-	avgCost := pos.AvgCost
-	side := pos.Side
-	var pnl float64
-	if side == "long" {
-		pnl = qty * (triggerPx - avgCost)
-	} else {
-		pnl = qty * (avgCost - triggerPx)
-	}
-	feePlatform := s.Platform
-	if s.Platform == "okx" && s.Type == "perps" {
-		feePlatform = "okx-perps"
-	}
-	fee := CalculatePlatformSpotFee(feePlatform, qty*triggerPx)
-	pnl -= fee
-	s.Cash += pnl
-	positionID := ensurePositionTradeID(s.ID, symbol, pos)
-
-	trade := Trade{
-		Timestamp:   now,
-		StrategyID:  s.ID,
-		Symbol:      symbol,
-		PositionID:  positionID,
-		Side:        closeTradeSide(side),
-		Quantity:    qty,
-		Price:       triggerPx,
-		Value:       qty * triggerPx,
-		TradeType:   "perps",
-		Details:     fmt.Sprintf("Stop loss close, PnL: $%.2f (fee $%.2f)", pnl, fee),
-		IsClose:     true,
-		RealizedPnL: pnl,
-	}
-	trade.Regime = s.Regime
-	trade.EntryATR = pos.EntryATR
-	trade.StopLossTriggerPx = pos.StopLossTriggerPx
-	RecordTrade(s, trade)
-	RecordTradeResult(&s.RiskState, pnl)
-	recordClosedPosition(s, pos, triggerPx, pnl, reason, now)
-	delete(s.Positions, symbol)
-	clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
-	if logger != nil {
-		logger.Warn("SL close reconciled @ $%.4f, PnL: $%.2f (fee $%.2f)", triggerPx, pnl, fee)
-	}
-	return true
-}
-
-// recordPerpsExternalClose books a perps close detected by reconciliation
-// when the position has disappeared on-chain without a tracked trigger fill
-// (manual UI close, kill-switch close from a peer, etc.). The caller supplies
-// a close price (typically the current mark) so realized PnL is approximated
-// and credited to s.Cash — matching how recordPerpsStopLossClose handles the
-// SL-owner case. Returns false if the price is non-positive or the position
-// is missing, so callers can fall back to a zero-PnL recordClosedPosition (#584).
-func recordPerpsExternalClose(s *StrategyState, symbol string, closePx float64, reason string, logger *StrategyLogger) bool {
+// bookPerpsClose is the shared close-booking path for perps: computes PnL at
+// closePx, deducts the platform taker fee, credits s.Cash, records a close
+// Trade + ClosedPosition, and removes the virtual position. detailsPrefix is
+// embedded in Trade.Details ("<prefix>, PnL: $X (fee $Y)") and logPrefix in
+// the strategy-logger Warn line ("<prefix> @ $px, PnL: $X (fee $Y)").
+// Returns false (no mutation) when closePx <= 0 or the position is missing,
+// so callers can choose a fallback path.
+func bookPerpsClose(s *StrategyState, symbol string, closePx float64, reason, detailsPrefix, logPrefix string, logger *StrategyLogger) bool {
 	if closePx <= 0 {
 		return false
 	}
@@ -212,7 +153,7 @@ func recordPerpsExternalClose(s *StrategyState, symbol string, closePx float64, 
 		Price:       closePx,
 		Value:       qty * closePx,
 		TradeType:   "perps",
-		Details:     fmt.Sprintf("External close @ mark, PnL: $%.2f (fee $%.2f)", pnl, fee),
+		Details:     fmt.Sprintf("%s, PnL: $%.2f (fee $%.2f)", detailsPrefix, pnl, fee),
 		IsClose:     true,
 		RealizedPnL: pnl,
 	}
@@ -225,9 +166,27 @@ func recordPerpsExternalClose(s *StrategyState, symbol string, closePx float64, 
 	delete(s.Positions, symbol)
 	clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
 	if logger != nil {
-		logger.Warn("External close reconciled @ $%.4f, PnL: $%.2f (fee $%.2f)", closePx, pnl, fee)
+		logger.Warn("%s @ $%.4f, PnL: $%.2f (fee $%.2f)", logPrefix, closePx, pnl, fee)
 	}
 	return true
+}
+
+// recordPerpsStopLossClose books a tracked perps stop-loss fill and removes the
+// virtual position. Used both when HL reports an immediate trigger fill at
+// submit time and when a previously-resting trigger has fired between cycles.
+func recordPerpsStopLossClose(s *StrategyState, symbol string, triggerPx float64, reason string, logger *StrategyLogger) bool {
+	return bookPerpsClose(s, symbol, triggerPx, reason, "Stop loss close", "SL close reconciled", logger)
+}
+
+// recordPerpsExternalClose books a perps close detected by reconciliation
+// when the position has disappeared on-chain without a tracked trigger fill
+// (manual UI close, kill-switch close from a peer, etc.). The caller supplies
+// a close price (typically the current mark) so realized PnL is approximated
+// and credited to s.Cash — matching how recordPerpsStopLossClose handles the
+// SL-owner case. Returns false if the price is non-positive or the position
+// is missing, so callers can fall back to a zero-PnL recordClosedPosition (#584).
+func recordPerpsExternalClose(s *StrategyState, symbol string, closePx float64, reason string, logger *StrategyLogger) bool {
+	return bookPerpsClose(s, symbol, closePx, reason, "External close @ mark", "External close reconciled", logger)
 }
 
 // recordClosedOptionPosition appends a ClosedOptionPosition entry to the


### PR DESCRIPTION
## Summary

- New helper \`recordPerpsExternalClose\` (\`portfolio.go\`) mirrors \`recordPerpsStopLossClose\` but takes an arbitrary close price; computes PnL, deducts the platform fee, credits \`s.Cash\`, and records the trade + ClosedPosition.
- \`reconcileHyperliquidAccountPositions\` now takes a \`prices map[string]float64\`. In the Detector 1 non-SL-owner branch it uses \`prices[coin]\` as the close price via the new helper; falls back to the legacy zero-PnL \`recordClosedPosition\` only when no mark is available.
- \`main.go\` passes the already-fetched HL marks at the call site. \`syncHyperliquidAccountPositions\` (no prefetched prices) passes \`nil\` to preserve legacy behavior.
- 2 new regression tests in \`hyperliquid_balance_test.go\`:
  1. credit-cash path: peer with mark price has \`s.Cash\` credited with mark-based PnL
  2. fallback path: nil prices → zero-PnL preserved

## Why

Per #584, the hl-live summary diverged from the real HL account balance after any external close (manual UI close, kill-switch close, stop sweep) of a shared-wallet position because the non-SL-owner peer's \`s.Cash\` was never updated. Using the current mark as the close price is the most robust fix without an extra API call — it corrects \`s.Cash\` at the source so per-strategy \`PortfolioValue\`, the summary TOTAL, and \`CheckRisk\`'s drawdown math all become accurate.

## Test plan

- [x] \`go -C scheduler test ./...\` green
- [x] \`TestReconcileSharedCoin_AllPositionsClosedExternally_CreditsPeerCash\` (new)
- [x] \`TestReconcileSharedCoin_AllPositionsClosedExternally_NoMarkPrice_FallsBack\` (new)
- [x] All existing reconcile tests pass with \`nil\` prices (backwards-compatible)

Closes #584

---
LLM: Claude Sonnet 4.6 (1M) | high