### PR TITLE
fix: query userFills for real exchange fee on HL fills

### DIFF
--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -32,6 +32,24 @@ except ImportError:
     _SDK_AVAILABLE = False
 
 
+def _safe_float(v) -> float:
+    if v is None:
+        return 0.0
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _safe_int(v) -> int:
+    if v is None:
+        return 0
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _round_perps_px(px: float, sz_decimals: int) -> float:
     """Round a perps price to HL's tick rules.
 
@@ -260,6 +278,56 @@ class HyperliquidExchangeAdapter:
             if sz <= 0:
                 raise ValueError(f"Size rounded to zero for {symbol} (sz_decimals={sz_decimals})")
         return self._exchange.market_close(symbol, sz)
+
+    def lookup_fill_fee_by_oid(
+        self,
+        oid: int,
+        since_ms: int,
+        max_retries: int = 4,
+        retry_delay_s: float = 0.5,
+    ) -> dict:
+        """Look up the actual exchange fee for a filled order via the userFills API.
+
+        HL's order placement response (`market_open` / `market_close`) does not
+        include the `fee` field — the modeled fee in the trade record drifts
+        from the on-chain balance over many trades (#585). This helper queries
+        the indexer-backed `userFills` endpoint to retrieve the real fee.
+
+        Returns a dict with summed `fee` and `closed_pnl` across all fills
+        sharing the OID (a single market order can fragment into multiple
+        partial fills at different price levels). Empty dict when no fills
+        match within the retry budget.
+
+        Indexer lag: fills can take several hundred ms to surface after the
+        order is placed. We retry up to `max_retries` times with
+        `retry_delay_s` between attempts. Total worst-case delay is
+        ~max_retries * retry_delay_s.
+        """
+        if not self._account_address:
+            return {}
+        attempt = 0
+        while attempt < max_retries:
+            try:
+                fills = self._info.user_fills_by_time(self._account_address, since_ms)
+            except Exception:
+                fills = None
+            if isinstance(fills, list):
+                matched = [f for f in fills if isinstance(f, dict) and _safe_int(f.get("oid")) == int(oid)]
+                if matched:
+                    fee_total = 0.0
+                    pnl_total = 0.0
+                    for f in matched:
+                        fee_total += _safe_float(f.get("fee"))
+                        pnl_total += _safe_float(f.get("closedPnl"))
+                    return {
+                        "fee": fee_total,
+                        "closed_pnl": pnl_total,
+                        "count": len(matched),
+                    }
+            attempt += 1
+            if attempt < max_retries:
+                time.sleep(retry_delay_s)
+        return {}
 
     def round_perps_trigger_px(self, symbol: str, px: float) -> float:
         """Public wrapper around HL's per-asset price-tick rounding.

--- a/platforms/hyperliquid/test_adapter.py
+++ b/platforms/hyperliquid/test_adapter.py
@@ -413,3 +413,85 @@ class TestStopLossPlacement:
         ex.cancel.return_value = {"status": "ok"}
         adapter.cancel_trigger_order("BTC", "12345")
         ex.cancel.assert_called_once_with("BTC", 12345)
+
+
+# ─── userFills Lookup (#585) ──────────────────────────
+
+class TestLookupFillFeeByOID:
+    def _make_adapter(self):
+        mock_info = MagicMock()
+        mock_info_cls = MagicMock(return_value=mock_info)
+        mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
+        adapter = mod.HyperliquidExchangeAdapter()
+        adapter._account_address = "0xABC123"
+        return adapter, mock_info
+
+    def test_returns_empty_when_no_address(self):
+        mock_info = MagicMock()
+        mock_info_cls = MagicMock(return_value=mock_info)
+        mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
+        adapter = mod.HyperliquidExchangeAdapter()
+        adapter._account_address = ""
+        assert adapter.lookup_fill_fee_by_oid(123, since_ms=0) == {}
+        mock_info.user_fills_by_time.assert_not_called()
+
+    def test_aggregates_fee_and_pnl_across_partial_fills(self):
+        adapter, mock_info = self._make_adapter()
+        mock_info.user_fills_by_time.return_value = [
+            {"oid": 100, "fee": "0.50", "closedPnl": "1.25"},
+            {"oid": 100, "fee": "0.30", "closedPnl": "0.75"},
+            {"oid": 999, "fee": "5.00", "closedPnl": "10.00"},  # different OID — ignored
+        ]
+        result = adapter.lookup_fill_fee_by_oid(100, since_ms=1000)
+        assert result["fee"] == pytest.approx(0.80)
+        assert result["closed_pnl"] == pytest.approx(2.00)
+        assert result["count"] == 2
+
+    def test_handles_string_oid_in_response(self):
+        adapter, mock_info = self._make_adapter()
+        mock_info.user_fills_by_time.return_value = [
+            {"oid": "100", "fee": "0.42", "closedPnl": "0"},
+        ]
+        result = adapter.lookup_fill_fee_by_oid(100, since_ms=1000)
+        assert result["fee"] == pytest.approx(0.42)
+        assert result["count"] == 1
+
+    def test_retries_until_indexer_catches_up(self, monkeypatch):
+        adapter, mock_info = self._make_adapter()
+        # First two attempts: fill not yet indexed. Third: appears.
+        mock_info.user_fills_by_time.side_effect = [
+            [],
+            [{"oid": 999, "fee": "1", "closedPnl": "0"}],  # different OID
+            [{"oid": 100, "fee": "0.65", "closedPnl": "0"}],
+        ]
+        sleeps = []
+        monkeypatch.setattr("time.sleep", lambda s: sleeps.append(s))
+        result = adapter.lookup_fill_fee_by_oid(100, since_ms=1000, max_retries=4, retry_delay_s=0.1)
+        assert result["fee"] == pytest.approx(0.65)
+        assert mock_info.user_fills_by_time.call_count == 3
+        assert sleeps == [0.1, 0.1]  # slept between attempts 1→2 and 2→3, not after the success
+
+    def test_returns_empty_after_max_retries_exhausted(self, monkeypatch):
+        adapter, mock_info = self._make_adapter()
+        mock_info.user_fills_by_time.return_value = []
+        monkeypatch.setattr("time.sleep", lambda s: None)
+        result = adapter.lookup_fill_fee_by_oid(100, since_ms=1000, max_retries=3, retry_delay_s=0.0)
+        assert result == {}
+        assert mock_info.user_fills_by_time.call_count == 3
+
+    def test_swallows_sdk_exceptions_and_retries(self, monkeypatch):
+        adapter, mock_info = self._make_adapter()
+        mock_info.user_fills_by_time.side_effect = [
+            Exception("network blip"),
+            [{"oid": 100, "fee": "0.10", "closedPnl": "0"}],
+        ]
+        monkeypatch.setattr("time.sleep", lambda s: None)
+        result = adapter.lookup_fill_fee_by_oid(100, since_ms=1000, max_retries=4, retry_delay_s=0.0)
+        assert result["fee"] == pytest.approx(0.10)
+
+    def test_treats_non_list_response_as_no_match(self, monkeypatch):
+        adapter, mock_info = self._make_adapter()
+        mock_info.user_fills_by_time.return_value = {"unexpected": "shape"}
+        monkeypatch.setattr("time.sleep", lambda s: None)
+        result = adapter.lookup_fill_fee_by_oid(100, since_ms=1000, max_retries=2, retry_delay_s=0.0)
+        assert result == {}

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -25,6 +25,7 @@ import sys
 import os
 import json
 import math
+import time
 import traceback
 from datetime import datetime, timezone
 
@@ -404,6 +405,11 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
                 cancel_err = str(ce)
                 print(f"[WARN] cancel_trigger_order({symbol}, {cancel_oid}) failed: {ce}", file=sys.stderr)
 
+        # Bound the userFills lookup window to "shortly before submit" so the
+        # post-fill query (#585) doesn't have to scan unrelated history.
+        # 10s buffer absorbs local-vs-indexer clock skew.
+        fills_since_ms = int(time.time() * 1000) - 10_000
+
         result = adapter.market_open(symbol, is_buy, size)
 
         # Extract fill info from SDK response structure:
@@ -421,12 +427,30 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
                 oid = filled.get("oid")
                 if oid is not None:
                     fill["oid"] = int(oid)
-                # Extract fee if present in response
+                # Extract fee if present in response (HL placeOrder response
+                # currently omits this — keep the read for forward compat).
                 fee = filled.get("fee")
                 if fee is not None:
                     fill["fee"] = float(fee)
         except Exception:
             pass
+
+        # The HL placeOrder response does not include `fee`; the real fee is
+        # only available via the userFills indexer endpoint (#585). Query it
+        # by OID so partial fills across multiple price levels aggregate
+        # correctly. Failures here fall back to the modeled fee on the Go
+        # side — non-fatal.
+        if fill.get("oid"):
+            try:
+                lookup = adapter.lookup_fill_fee_by_oid(fill["oid"], fills_since_ms)
+                if lookup:
+                    fill["fee"] = lookup.get("fee", 0.0)
+                    if "closed_pnl" in lookup:
+                        fill["closed_pnl"] = lookup["closed_pnl"]
+                else:
+                    print(f"[WARN] userFills lookup returned no fills for oid={fill['oid']}", file=sys.stderr)
+            except Exception as fe:
+                print(f"[WARN] userFills lookup failed for oid={fill['oid']}: {fe}", file=sys.stderr)
 
         # Place the stop-loss trigger on successful opens only. We only try to
         # place an SL when the main order actually filled; a zero-size fill

--- a/shared_scripts/close_hyperliquid_position.py
+++ b/shared_scripts/close_hyperliquid_position.py
@@ -38,6 +38,7 @@ import argparse
 import json
 import os
 import sys
+import time
 import traceback
 from datetime import datetime, timezone
 
@@ -97,6 +98,8 @@ def main():
                 print(f"[WARN] cancel_trigger_order({args.symbol}, {oid}) failed: {ce}", file=sys.stderr)
         if cancel_errors:
             cancel_err = "; ".join(cancel_errors)
+        # Bound the userFills lookup window for the post-close fee query (#585).
+        fills_since_ms = int(time.time() * 1000) - 10_000
         result = adapter.market_close(args.symbol, args.sz)
     except Exception as e:
         traceback.print_exc(file=sys.stderr)
@@ -163,9 +166,26 @@ def main():
     oid = filled.get("oid")
     if oid is not None:
         fill["oid"] = int(oid)
+    # HL placeOrder/market_close response omits `fee`; keep the read for
+    # forward-compat then overwrite via userFills (#585).
     fee = filled.get("fee")
     if fee is not None:
         fill["fee"] = float(fee)
+
+    # Look up the real fee + closedPnl via the userFills indexer endpoint.
+    # Aggregates across partial fills sharing the OID. Failures are non-fatal
+    # — Go falls back to the modeled fee.
+    if fill.get("oid"):
+        try:
+            lookup = adapter.lookup_fill_fee_by_oid(fill["oid"], fills_since_ms)
+            if lookup:
+                fill["fee"] = lookup.get("fee", 0.0)
+                if "closed_pnl" in lookup:
+                    fill["closed_pnl"] = lookup["closed_pnl"]
+            else:
+                print(f"[WARN] userFills lookup returned no fills for oid={fill['oid']}", file=sys.stderr)
+        except Exception as fe:
+            print(f"[WARN] userFills lookup failed for oid={fill['oid']}: {fe}", file=sys.stderr)
     _emit_success(args.symbol, fill, cancel_err=cancel_err, cancel_succeeded=cancel_succeeded)
 
 


### PR DESCRIPTION
## Summary
- Adds `HyperliquidExchangeAdapter.lookup_fill_fee_by_oid` that queries HL's `userFills` indexer endpoint, sums `fee` and `closedPnl` across partial fills sharing the same OID, and retries with backoff to absorb indexer lag (default 4 attempts × 0.5s).
- Wires the lookup into both `check_hyperliquid.py` (signal-driven opens/closes/flips, manual closes) and `close_hyperliquid_position.py` (kill-switch). Both capture `since_ms` immediately before submitting the order to bound the lookup window.
- Lookup failures are non-fatal — the Go side already falls back to the modeled `CalculatePlatformSpotFee` when `fillFee=0` (`useFillFee && fillFee > 0` guard in `executionFee`/`exchangeFeeForTrade`).

## Why
HL's `placeOrder` response omits `fee` from `statuses[0]["filled"]`; the only authoritative source is the `userFills` API. Live HL trades were recording `exchange_fee=0` for ~28/29 close legs (#585 evidence) and using the modeled fee in PnL, causing the virtual cash balance to drift ~$3.89 from on-chain accountValue across 50+ trades on `hl-tema-eth-live`.

## Out of scope (follow-ups)
- **SL-trigger / trailing-stop closes** — booked by the on-chain reconciler after the trigger fires; would need a retroactive `userFills` query keyed off the closed-position timestamp rather than an OID owned by the scheduler. Same drift source but architecturally different.
- **Historical backfill** of existing `trades.exchange_fee=0` rows; new code only fixes go-forward writes.

## Test plan
- [x] `platforms/hyperliquid/test_adapter.py` — 7 new tests covering missing-address short-circuit, fee+pnl aggregation across partial fills, string-OID coercion, retry-until-indexed, retry-budget exhaustion, exception swallowing, non-list-response handling.
- [x] Full Python suite (`platforms/`, `shared_tools/`, `shared_strategies/`) — 729 passed.
- [x] `go test ./...` from `scheduler/` — passes.
- [x] `go build .` from `scheduler/` — clean.
- [ ] Manual smoke on go-trader-live: submit a small HL trade, confirm `trades.exchange_fee` matches the on-chain `userFills` fee for that OID and that wallet drift stops accumulating.

Closes #585

---
LLM: Claude Sonnet 4.6 (1M) | high