### PR TITLE
fix: query userFills for real exchange fee on reconciler closes (#588)

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -231,8 +231,19 @@ func fetchHyperliquidState(accountAddress string) (float64, []HLPosition, error)
 //
 // accountAddress is used to resolve the on-chain fill fee via userFills when
 // the reconciler detects an external close (#588). Empty disables the
-// lookup — the close still books with the modeled fee.
+// lookup — the close still books with the modeled fee. This entry point
+// performs the lookup synchronously; production reconcile paths build a
+// cached resolver outside the lock and call
+// reconcileHyperliquidPositionsWithResolver.
 func reconcileHyperliquidPositions(stratState *StrategyState, sym string, positions []HLPosition, accountAddress string, logger *StrategyLogger) bool {
+	return reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, directHyperliquidReconcileFillResolver(accountAddress), logger)
+}
+
+// reconcileHyperliquidPositionsWithResolver is the resolver-aware variant. The
+// resolver is expected to do pure in-memory cache reads when called under
+// mu.Lock() (see buildCachedHyperliquidReconcileFillResolver) — never make
+// HTTP calls.
+func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym string, positions []HLPosition, resolveFee hlReconcileFillResolver, logger *StrategyLogger) bool {
 	changed := false
 
 	// Find the on-chain position for this strategy's symbol.
@@ -288,11 +299,8 @@ func reconcileHyperliquidPositions(stratState *StrategyState, sym string, positi
 		logger.Info("hl-sync: %s position (%.6f %s) no longer on-chain, removing",
 			sym, statePos.Quantity, statePos.Side)
 		if statePos.StopLossOID > 0 && statePos.StopLossTriggerPx > 0 {
-			lookup, useFillFee := lookupHyperliquidReconcileFillFee(accountAddress, sym, statePos.StopLossOID, statePos.Quantity)
-			oidStr := ""
-			if statePos.StopLossOID > 0 {
-				oidStr = strconv.FormatInt(statePos.StopLossOID, 10)
-			}
+			lookup, useFillFee := resolveFee(sym, statePos.StopLossOID, statePos.Quantity)
+			oidStr := strconv.FormatInt(statePos.StopLossOID, 10)
 			logHyperliquidReconcileFillLookup(logger, sym, statePos.StopLossOID, statePos.Quantity, lookup, useFillFee)
 			if recordPerpsStopLossCloseWithFillFee(stratState, sym, statePos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "stop_loss", logger) {
 				return true
@@ -367,6 +375,12 @@ func syncHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppSt
 //
 // Must be called WITHOUT holding any lock; acquires Lock internally.
 func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager, positions []HLPosition, prices map[string]float64, accountAddress string) bool {
+	// Resolve userFills BEFORE taking mu.Lock(): each lookup can sleep up
+	// to ~1.5s on indexer-lag retries, and holding the write lock blocks
+	// every reader of state (/status, /health, per-strategy phase RLocks).
+	// The resolver itself is a pure map read inside the locked region.
+	resolveFee := buildCachedHyperliquidReconcileFillResolver(accountAddress, allStrategies, state, mu, positions)
+
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -411,7 +425,7 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 			fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", sc.ID, err)
 			continue
 		}
-		if reconcileHyperliquidPositions(ss, sym, positions, accountAddress, logger) {
+		if reconcileHyperliquidPositionsWithResolver(ss, sym, positions, resolveFee, logger) {
 			changed = true
 		}
 	}
@@ -505,6 +519,16 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 		// through to the gap-recording block unchanged.
 		if math.Abs(onChainQty) < 1e-6 && math.Abs(virtualQty) > 1e-6 {
 			// Detector 1: everything gone on-chain — close all peers.
+			//
+			// Fee-lookup caveat for the multi-peer case: a single aggregated
+			// UI close produces one userFills row sized at the *aggregate*
+			// quantity, while each non-owner peer here queries with its own
+			// per-strategy pos.Quantity. The hlReconcileFillSizeTolerance
+			// (1e-4) won't accept that mismatch, so peers fall back to the
+			// modeled fee. The OID-keyed lookup still works for the SL owner.
+			// Per-peer fee accuracy is only achievable when each peer's qty
+			// happens to equal the aggregate close size (e.g. a sole-peer
+			// close, or a closer that happened to size at one peer's qty).
 			for _, id := range stratIDs {
 				ss := state.Strategies[id]
 				if ss == nil {
@@ -519,7 +543,7 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 					fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", id, logErr)
 				}
 				if pos.StopLossOID > 0 && pos.StopLossTriggerPx > 0 {
-					lookup, useFillFee := lookupHyperliquidReconcileFillFee(accountAddress, coin, pos.StopLossOID, pos.Quantity)
+					lookup, useFillFee := resolveFee(coin, pos.StopLossOID, pos.Quantity)
 					oidStr := strconv.FormatInt(pos.StopLossOID, 10)
 					logHyperliquidReconcileFillLookup(logger, coin, pos.StopLossOID, pos.Quantity, lookup, useFillFee)
 					if recordPerpsStopLossCloseWithFillFee(ss, coin, pos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "hl_sync_stop_loss", logger) {
@@ -534,7 +558,7 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 					// minutes earlier). Do not treat the resulting Trade /
 					// ClosedPosition rows as authoritative for tax or reporting;
 					// they exist to keep cash bookkeeping in sync.
-					lookup, useFillFee := lookupHyperliquidReconcileFillFee(accountAddress, coin, 0, pos.Quantity)
+					lookup, useFillFee := resolveFee(coin, 0, pos.Quantity)
 					logHyperliquidReconcileFillLookup(logger, coin, 0, pos.Quantity, lookup, useFillFee)
 					if recordPerpsExternalCloseWithFillFee(ss, coin, mark, lookup.Fee, useFillFee, "", "hl_sync_external", logger) {
 						changed = true
@@ -592,7 +616,7 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 						if logErr != nil {
 							fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", slOwnerID, logErr)
 						}
-						lookup, useFillFee := lookupHyperliquidReconcileFillFee(accountAddress, coin, slOwnerPos.StopLossOID, slOwnerPos.Quantity)
+						lookup, useFillFee := resolveFee(coin, slOwnerPos.StopLossOID, slOwnerPos.Quantity)
 						oidStr := strconv.FormatInt(slOwnerPos.StopLossOID, 10)
 						logHyperliquidReconcileFillLookup(logger, coin, slOwnerPos.StopLossOID, slOwnerPos.Quantity, lookup, useFillFee)
 						if recordPerpsStopLossCloseWithFillFee(ownerSS, coin, slOwnerPos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "hl_sync_stop_loss", logger) {

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -228,7 +228,11 @@ func fetchHyperliquidState(accountAddress string) (float64, []HLPosition, error)
 // It updates or removes the position for the given symbol based on ownership.
 // Does NOT sync cash (each strategy manages its own virtual cash).
 // Returns true if any state was changed. Must be called under Lock.
-func reconcileHyperliquidPositions(stratState *StrategyState, sym string, positions []HLPosition, logger *StrategyLogger) bool {
+//
+// accountAddress is used to resolve the on-chain fill fee via userFills when
+// the reconciler detects an external close (#588). Empty disables the
+// lookup — the close still books with the modeled fee.
+func reconcileHyperliquidPositions(stratState *StrategyState, sym string, positions []HLPosition, accountAddress string, logger *StrategyLogger) bool {
 	changed := false
 
 	// Find the on-chain position for this strategy's symbol.
@@ -284,7 +288,13 @@ func reconcileHyperliquidPositions(stratState *StrategyState, sym string, positi
 		logger.Info("hl-sync: %s position (%.6f %s) no longer on-chain, removing",
 			sym, statePos.Quantity, statePos.Side)
 		if statePos.StopLossOID > 0 && statePos.StopLossTriggerPx > 0 {
-			if recordPerpsStopLossClose(stratState, sym, statePos.StopLossTriggerPx, "stop_loss", logger) {
+			lookup, useFillFee := lookupHyperliquidReconcileFillFee(accountAddress, sym, statePos.StopLossOID, statePos.Quantity)
+			oidStr := ""
+			if statePos.StopLossOID > 0 {
+				oidStr = strconv.FormatInt(statePos.StopLossOID, 10)
+			}
+			logHyperliquidReconcileFillLookup(logger, sym, statePos.StopLossOID, statePos.Quantity, lookup, useFillFee)
+			if recordPerpsStopLossCloseWithFillFee(stratState, sym, statePos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "stop_loss", logger) {
 				return true
 			}
 		}
@@ -332,7 +342,7 @@ func syncHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppSt
 	// Self-contained entry: due and all are the same list. Prices are
 	// unavailable in this path (caller did not pre-fetch); external-close
 	// PnL falls back to zero (legacy behavior pre-#584).
-	return reconcileHyperliquidAccountPositions(hlStrategies, hlStrategies, state, mu, logMgr, positions, nil)
+	return reconcileHyperliquidAccountPositions(hlStrategies, hlStrategies, state, mu, logMgr, positions, nil, accountAddr)
 }
 
 // reconcileHyperliquidAccountPositions reconciles pre-fetched on-chain positions
@@ -350,8 +360,13 @@ func syncHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppSt
 // mark is used as the approximate close price so realized PnL can be credited
 // to s.Cash (#584). Pass nil to fall back to the legacy zero-PnL recording.
 //
+// accountAddress is the HL account whose userFills are queried for real
+// exchange fees on closes detected by the reconciler (#588). Pass an empty
+// string to skip the lookup — closes still book correctly using the
+// modeled fee.
+//
 // Must be called WITHOUT holding any lock; acquires Lock internally.
-func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager, positions []HLPosition, prices map[string]float64) bool {
+func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager, positions []HLPosition, prices map[string]float64, accountAddress string) bool {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -396,7 +411,7 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 			fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", sc.ID, err)
 			continue
 		}
-		if reconcileHyperliquidPositions(ss, sym, positions, logger) {
+		if reconcileHyperliquidPositions(ss, sym, positions, accountAddress, logger) {
 			changed = true
 		}
 	}
@@ -504,10 +519,13 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 					fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", id, logErr)
 				}
 				if pos.StopLossOID > 0 && pos.StopLossTriggerPx > 0 {
-					if recordPerpsStopLossClose(ss, coin, pos.StopLossTriggerPx, "hl_sync_stop_loss", logger) {
+					lookup, useFillFee := lookupHyperliquidReconcileFillFee(accountAddress, coin, pos.StopLossOID, pos.Quantity)
+					oidStr := strconv.FormatInt(pos.StopLossOID, 10)
+					logHyperliquidReconcileFillLookup(logger, coin, pos.StopLossOID, pos.Quantity, lookup, useFillFee)
+					if recordPerpsStopLossCloseWithFillFee(ss, coin, pos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "hl_sync_stop_loss", logger) {
 						changed = true
 					}
-				} else if mark, ok := prices[coin]; ok && mark > 0 && recordPerpsExternalClose(ss, coin, mark, "hl_sync_external", logger) {
+				} else if mark, ok := prices[coin]; ok && mark > 0 {
 					// #584: credit s.Cash with mark-based PnL so the per-strategy
 					// PortfolioValue (and the summary TOTAL) match the real HL
 					// account after an external close. The mark is fetched at
@@ -516,7 +534,11 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 					// minutes earlier). Do not treat the resulting Trade /
 					// ClosedPosition rows as authoritative for tax or reporting;
 					// they exist to keep cash bookkeeping in sync.
-					changed = true
+					lookup, useFillFee := lookupHyperliquidReconcileFillFee(accountAddress, coin, 0, pos.Quantity)
+					logHyperliquidReconcileFillLookup(logger, coin, 0, pos.Quantity, lookup, useFillFee)
+					if recordPerpsExternalCloseWithFillFee(ss, coin, mark, lookup.Fee, useFillFee, "", "hl_sync_external", logger) {
+						changed = true
+					}
 				} else {
 					// No mark price available — fall back to recording the
 					// close with zero PnL. s.Cash will be stale until the
@@ -570,7 +592,10 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 						if logErr != nil {
 							fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", slOwnerID, logErr)
 						}
-						if recordPerpsStopLossClose(ownerSS, coin, slOwnerPos.StopLossTriggerPx, "hl_sync_stop_loss", logger) {
+						lookup, useFillFee := lookupHyperliquidReconcileFillFee(accountAddress, coin, slOwnerPos.StopLossOID, slOwnerPos.Quantity)
+						oidStr := strconv.FormatInt(slOwnerPos.StopLossOID, 10)
+						logHyperliquidReconcileFillLookup(logger, coin, slOwnerPos.StopLossOID, slOwnerPos.Quantity, lookup, useFillFee)
+						if recordPerpsStopLossCloseWithFillFee(ownerSS, coin, slOwnerPos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "hl_sync_stop_loss", logger) {
 							changed = true
 							virtualQty = expectedResidual
 							delta = virtualQty - onChainQty

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -139,7 +139,7 @@ func TestReconcileUpdatesExistingOwnedPosition(t *testing.T) {
 	logger := newTestLogger(t)
 	positions := []HLPosition{{Coin: "BTC", Size: 0.334, EntryPrice: 42000}}
 
-	changed := reconcileHyperliquidPositions(s, "BTC", positions, logger)
+	changed := reconcileHyperliquidPositions(s, "BTC", positions, "", logger)
 
 	if !changed {
 		t.Error("expected changed=true")
@@ -167,7 +167,7 @@ func TestReconcileRemoveClosedPosition(t *testing.T) {
 	logger := newTestLogger(t)
 	positions := []HLPosition{} // No on-chain position
 
-	changed := reconcileHyperliquidPositions(s, "BTC", positions, logger)
+	changed := reconcileHyperliquidPositions(s, "BTC", positions, "", logger)
 
 	if !changed {
 		t.Error("expected changed=true")
@@ -194,7 +194,7 @@ func TestReconcileNoChange(t *testing.T) {
 	logger := newTestLogger(t)
 	positions := []HLPosition{{Coin: "BTC", Size: 0.5, EntryPrice: 40000, Leverage: 2}}
 
-	changed := reconcileHyperliquidPositions(s, "BTC", positions, logger)
+	changed := reconcileHyperliquidPositions(s, "BTC", positions, "", logger)
 
 	if changed {
 		t.Error("expected changed=false when state matches on-chain")
@@ -212,7 +212,7 @@ func TestReconcileSkipsUnownedOnChainPosition(t *testing.T) {
 	logger := newTestLogger(t)
 	positions := []HLPosition{{Coin: "BTC", Size: 0.5, EntryPrice: 40000}}
 
-	changed := reconcileHyperliquidPositions(s, "BTC", positions, logger)
+	changed := reconcileHyperliquidPositions(s, "BTC", positions, "", logger)
 
 	if changed {
 		t.Error("expected changed=false — should not adopt unowned position")
@@ -243,7 +243,7 @@ func TestReconcilePreservesConfiguredLeverage(t *testing.T) {
 	// pos.Leverage and inflated the drawdown denominator 10x.
 	positions := []HLPosition{{Coin: "ETH", Size: 1, EntryPrice: 3000, Leverage: 20}}
 
-	reconcileHyperliquidPositions(s, "ETH", positions, logger)
+	reconcileHyperliquidPositions(s, "ETH", positions, "", logger)
 
 	if s.Positions["ETH"].Leverage != 2 {
 		t.Errorf("Leverage = %v; want 2 (configured value must be preserved against on-chain 20)", s.Positions["ETH"].Leverage)
@@ -266,7 +266,7 @@ func TestReconcileSeedsZeroLeverageFromOnChain(t *testing.T) {
 	logger := newTestLogger(t)
 	positions := []HLPosition{{Coin: "ETH", Size: 1, EntryPrice: 3000, Leverage: 10}}
 
-	reconcileHyperliquidPositions(s, "ETH", positions, logger)
+	reconcileHyperliquidPositions(s, "ETH", positions, "", logger)
 
 	if s.Positions["ETH"].Leverage != 10 {
 		t.Errorf("Leverage = %v; want 10 (zero-value position seeded from on-chain)", s.Positions["ETH"].Leverage)
@@ -282,7 +282,7 @@ func TestReconcileNoPositionBothSides(t *testing.T) {
 	logger := newTestLogger(t)
 	positions := []HLPosition{}
 
-	changed := reconcileHyperliquidPositions(s, "BTC", positions, logger)
+	changed := reconcileHyperliquidPositions(s, "BTC", positions, "", logger)
 
 	if changed {
 		t.Error("expected changed=false when no position on either side")
@@ -498,7 +498,7 @@ func TestReconcileMigratesLegacyMultiplierAndSyncsLeverage(t *testing.T) {
 	logger := newTestLogger(t)
 	positions := []HLPosition{{Coin: "ETH", Size: 0.279, EntryPrice: 2210.71, Leverage: 20}}
 
-	changed := reconcileHyperliquidPositions(s, "ETH", positions, logger)
+	changed := reconcileHyperliquidPositions(s, "ETH", positions, "", logger)
 
 	if !changed {
 		t.Fatal("expected changed=true (migration)")
@@ -534,7 +534,7 @@ func TestReconcileLegacyPositionPortfolioValueAfterMigration(t *testing.T) {
 
 	logger := newTestLogger(t)
 	reconcileHyperliquidPositions(s, "ETH",
-		[]HLPosition{{Coin: "ETH", Size: 0.279, EntryPrice: 2210.71, Leverage: 20}}, logger)
+		[]HLPosition{{Coin: "ETH", Size: 0.279, EntryPrice: 2210.71, Leverage: 20}}, "", logger)
 
 	// Post-migration value: cash + qty*(price-entry) = 27.15 + 0.279*(2201.10-2210.71) = ~24.47
 	postFix := PortfolioValue(s, map[string]float64{"ETH": 2201.10})
@@ -989,7 +989,7 @@ func TestReconcileDueSubsetOfAllDetectsSharedCoins(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions(dueStrategies, allStrategies, state, &mu, logMgr, positions, nil)
+	reconcileHyperliquidAccountPositions(dueStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
 
 	// Even though only rmc is due, allStrategies reveals ETH is shared by 3
 	// strategies, so rmc's position must NOT be reconciled to on-chain.
@@ -1058,7 +1058,7 @@ func TestReconcileSharedCoinShortAndMixedPositions(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
 
 	// Positions should be unchanged.
 	longPos := state.Strategies["hl-long-eth"].Positions["ETH"]
@@ -1121,7 +1121,7 @@ func TestReconcileSharedCoinBothShort(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
 
 	gap := state.ReconciliationGaps["ETH"]
 	if gap == nil {
@@ -1176,7 +1176,7 @@ func TestReconcileSharedCoin_OwnerStopLossFired_ClosesOwnerOnly(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
 
 	// Owner position must be closed and recorded.
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
@@ -1241,7 +1241,7 @@ func TestReconcileSharedCoin_OwnerStopLossFired_Short(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
 
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
 		t.Error("owner short ETH position should be nil after SL reconciliation")
@@ -1285,7 +1285,7 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
 
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
 		t.Error("owner ETH position should be nil")
@@ -1345,7 +1345,7 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally_CreditsPeerCash(t *tes
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "")
 
 	peer := state.Strategies["hl-peer-eth"]
 	if peer.Positions["ETH"] != nil {
@@ -1437,7 +1437,7 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally_NoMarkPrice_FallsBack(
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 	// nil prices map → legacy zero-PnL path.
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
 
 	peer := state.Strategies["hl-peer-eth"]
 	if peer.Positions["ETH"] != nil {
@@ -1483,7 +1483,7 @@ func TestReconcileSharedCoin_GapWithoutSLOwner_LeavesPositionsAlone(t *testing.T
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
 
 	// Both positions must be untouched.
 	posA := state.Strategies["hl-a-eth"].Positions["ETH"]
@@ -1540,7 +1540,7 @@ func TestReconcileSharedCoin_ResidualMismatch_LeavesPositionsAlone(t *testing.T)
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
 
 	// Both positions must be untouched.
 	ownerPos := state.Strategies["hl-owner-eth"].Positions["ETH"]
@@ -2749,7 +2749,7 @@ func TestReconcileManualPositionExternalClose(t *testing.T) {
 	var mu sync.RWMutex
 
 	// Pass nil positions (on-chain flat).
-	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil)
+	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "")
 
 	ss := state.Strategies["manual-eth"]
 	if _, ok := ss.Positions["ETH"]; ok {
@@ -2787,7 +2787,7 @@ func TestReconcileManualPositionSLFired(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil)
+	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "")
 
 	ss := state.Strategies["manual-eth"]
 	if _, ok := ss.Positions["ETH"]; ok {

--- a/scheduler/hyperliquid_fills.go
+++ b/scheduler/hyperliquid_fills.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 )
 
@@ -247,4 +248,146 @@ func defaultLookupHyperliquidReconcileFillFee(accountAddress, coin string, oid i
 		}
 	}
 	return HLFillLookup{}, false
+}
+
+// hlReconcileFillResolver returns the userFills lookup result for a (coin,
+// oid, expectedQty) tuple. The reconciler resolves fees via this indirection
+// so the locked apply phase can read pre-fetched results without making any
+// HTTP calls under mu.Lock(). See buildCachedHyperliquidReconcileFillResolver.
+type hlReconcileFillResolver func(coin string, oid int64, expectedQty float64) (HLFillLookup, bool)
+
+// noFillFeeResolver is the resolver used when fee lookups are disabled (no
+// account address) or when no candidate close events were detected. Always
+// returns ok=false so callers fall back to the modeled fee path.
+var noFillFeeResolver hlReconcileFillResolver = func(string, int64, float64) (HLFillLookup, bool) {
+	return HLFillLookup{}, false
+}
+
+// directHyperliquidReconcileFillResolver wraps lookupHyperliquidReconcileFillFee
+// for paths that can safely block on HTTP I/O — primarily tests that stub the
+// underlying function. Production reconcile paths must use
+// buildCachedHyperliquidReconcileFillResolver to keep network calls outside
+// mu.Lock().
+func directHyperliquidReconcileFillResolver(accountAddress string) hlReconcileFillResolver {
+	if accountAddress == "" {
+		return noFillFeeResolver
+	}
+	return func(coin string, oid int64, expectedQty float64) (HLFillLookup, bool) {
+		return lookupHyperliquidReconcileFillFee(accountAddress, coin, oid, expectedQty)
+	}
+}
+
+// hyperliquidReconcileFeeCacheKey identifies one userFills lookup. Quantity is
+// rounded to 1e-8 so float identity comparisons across the snapshot/apply
+// boundary survive — HL sz_decimals tops out at 8 so the round is lossless
+// for legitimate fills.
+type hyperliquidReconcileFeeCacheKey struct {
+	coin string
+	oid  int64
+	qty  int64 // qty * 1e8, rounded
+}
+
+func makeHLReconcileFeeCacheKey(coin string, oid int64, qty float64) hyperliquidReconcileFeeCacheKey {
+	return hyperliquidReconcileFeeCacheKey{
+		coin: coin,
+		oid:  oid,
+		qty:  int64(math.Round(qty * 1e8)),
+	}
+}
+
+// buildCachedHyperliquidReconcileFillResolver runs a brief RLock pass to
+// identify which (coin, oid, qty) lookups the reconciler is likely to need,
+// performs all userFills queries OUTSIDE the lock (each can take up to ~1.5s
+// under indexer-lag retry), then returns a pure map-reading resolver that the
+// locked apply phase calls. Cache misses fall back to noFillFeeResolver
+// behavior — never to a network call — so the lock-held region is bounded.
+//
+// The candidate-detection pass is permissive: false positives just mean an
+// extra HTTP query per cycle, false negatives mean a close books with the
+// modeled fee. Detector logic is duplicated approximately, not exactly, so
+// the apply phase remains the source of truth for whether a close fires.
+func buildCachedHyperliquidReconcileFillResolver(accountAddress string, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, positions []HLPosition) hlReconcileFillResolver {
+	if accountAddress == "" {
+		return noFillFeeResolver
+	}
+
+	type candidate struct {
+		coin string
+		oid  int64
+		qty  float64
+	}
+
+	onChainByCoin := make(map[string]float64, len(positions))
+	for _, p := range positions {
+		onChainByCoin[p.Coin] = p.Size
+	}
+
+	seen := make(map[hyperliquidReconcileFeeCacheKey]bool)
+	var candidates []candidate
+	addCandidate := func(coin string, oid int64, qty float64) {
+		if coin == "" || qty <= 0 {
+			return
+		}
+		key := makeHLReconcileFeeCacheKey(coin, oid, qty)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		candidates = append(candidates, candidate{coin: coin, oid: oid, qty: qty})
+	}
+
+	mu.RLock()
+	for _, sc := range allStrategies {
+		ss := state.Strategies[sc.ID]
+		if ss == nil {
+			continue
+		}
+		sym := hyperliquidSymbol(sc.Args)
+		if sym == "" {
+			continue
+		}
+		pos := ss.Positions[sym]
+		if pos == nil || pos.Quantity <= 0 {
+			continue
+		}
+		onChainSize, present := onChainByCoin[sym]
+		// Trigger lookup when on-chain is absent OR signed-qty differs from
+		// virtual qty. Sign mismatch is intentional: it covers both Detector 1
+		// (full external close, on-chain ≈ 0) and Detector 2 (partial close
+		// where on-chain residual ≠ virtual).
+		mismatched := !present || math.Abs(math.Abs(onChainSize)-pos.Quantity) > 1e-9
+		if !mismatched {
+			continue
+		}
+		if pos.StopLossOID > 0 && pos.StopLossTriggerPx > 0 {
+			addCandidate(sym, pos.StopLossOID, pos.Quantity)
+		}
+		// Always include the (coin, 0, qty) form so peers without a tracked
+		// OID — Detector 1 mark-based path and Detector 2 non-owner — hit a
+		// cached entry. The resolver drops to coin+size internally.
+		addCandidate(sym, 0, pos.Quantity)
+	}
+	mu.RUnlock()
+
+	if len(candidates) == 0 {
+		return noFillFeeResolver
+	}
+
+	type cacheEntry struct {
+		lookup HLFillLookup
+		ok     bool
+	}
+	cache := make(map[hyperliquidReconcileFeeCacheKey]cacheEntry, len(candidates))
+	for _, c := range candidates {
+		lookup, ok := lookupHyperliquidReconcileFillFee(accountAddress, c.coin, c.oid, c.qty)
+		cache[makeHLReconcileFeeCacheKey(c.coin, c.oid, c.qty)] = cacheEntry{lookup: lookup, ok: ok}
+	}
+
+	return func(coin string, oid int64, expectedQty float64) (HLFillLookup, bool) {
+		entry, hit := cache[makeHLReconcileFeeCacheKey(coin, oid, expectedQty)]
+		if !hit {
+			return HLFillLookup{}, false
+		}
+		return entry.lookup, entry.ok
+	}
 }

--- a/scheduler/hyperliquid_fills.go
+++ b/scheduler/hyperliquid_fills.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// HLFillLookup carries the aggregated fee + closed PnL across the on-chain
+// fills that match a single logical close. A "logical close" can fragment
+// into multiple userFills entries (different price levels, partial fills),
+// so callers always receive the sum.
+type HLFillLookup struct {
+	Fee       float64
+	ClosedPnL float64
+	Count     int
+	OID       int64
+}
+
+// hlFillRecord is the trimmed userFills payload we care about. The HL indexer
+// returns numeric fields as strings; ParseFloat tolerates missing/empty.
+type hlFillRecord struct {
+	Coin      string      `json:"coin"`
+	Sz        string      `json:"sz"`
+	OID       json.Number `json:"oid"`
+	Fee       string      `json:"fee"`
+	ClosedPnl string      `json:"closedPnl"`
+	Time      int64       `json:"time"`
+	Dir       string      `json:"dir"`
+}
+
+// fetchHyperliquidUserFillsByTime is a function variable so tests can stub the
+// HTTP layer without spinning up an httptest server (some reconciler tests
+// already stub clearinghouseState — composing two stubs in one process is
+// awkward when both target hlMainnetURL).
+var fetchHyperliquidUserFillsByTime = defaultFetchHyperliquidUserFillsByTime
+
+func defaultFetchHyperliquidUserFillsByTime(accountAddress string, startTimeMs int64) ([]hlFillRecord, error) {
+	if accountAddress == "" {
+		return nil, fmt.Errorf("HYPERLIQUID_ACCOUNT_ADDRESS not set")
+	}
+	payload := map[string]any{
+		"type":      "userFillsByTime",
+		"user":      accountAddress,
+		"startTime": startTimeMs,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Post(hlMainnetURL+"/info", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("http request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("http %d from %s", resp.StatusCode, hlMainnetURL)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	var fills []hlFillRecord
+	if err := json.Unmarshal(data, &fills); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return fills, nil
+}
+
+// hlFillLookupRetries / hlFillLookupRetryDelay control the indexer-lag retry
+// budget. HL fills can take a few hundred ms to surface after the on-chain
+// trigger; we mirror the Python adapter's defaults (4 attempts × 500ms).
+// Variables (not consts) so tests can shorten without sleeps.
+var (
+	hlFillLookupRetries    = 4
+	hlFillLookupRetryDelay = 500 * time.Millisecond
+)
+
+// lookupHyperliquidFillByOID queries userFills for fills matching `oid`,
+// summing fee + closedPnl across partial fills. Retries with backoff to
+// absorb HL indexer lag. Returns ok=false when no fill matches within the
+// retry budget — callers fall back to the modeled fee.
+func lookupHyperliquidFillByOID(accountAddress string, oid int64, startTimeMs int64) (HLFillLookup, bool) {
+	if oid <= 0 || accountAddress == "" {
+		return HLFillLookup{}, false
+	}
+	for attempt := 0; attempt < hlFillLookupRetries; attempt++ {
+		fills, err := fetchHyperliquidUserFillsByTime(accountAddress, startTimeMs)
+		if err == nil {
+			out := HLFillLookup{OID: oid}
+			for _, f := range fills {
+				if !fillOIDMatches(f, oid) {
+					continue
+				}
+				out.Fee += parseHLFloat(f.Fee)
+				out.ClosedPnL += parseHLFloat(f.ClosedPnl)
+				out.Count++
+			}
+			if out.Count > 0 {
+				return out, true
+			}
+		}
+		if attempt < hlFillLookupRetries-1 {
+			time.Sleep(hlFillLookupRetryDelay)
+		}
+	}
+	return HLFillLookup{}, false
+}
+
+// lookupHyperliquidFillByCoinSize is the fallback for closes detected without
+// a tracked OID — typically external UI closes for shared-coin peers, where
+// only the SL owner has an OID stamped on its Position. Matches by coin and
+// absolute size within `tolerance` (coin units), summing fee + closedPnl
+// across all matching fills in the window. Newest-first scanning so the
+// first match is the most recent fill that reduced exposure.
+//
+// The match is intentionally permissive — coin + size + window is sufficient
+// to disambiguate the SL-trigger / trailing-stop / manual UI close cases
+// we care about. If two strategies sized identically on the same coin closed
+// in the same window with no OIDs, fees may be double-counted; the issue
+// (#588) accepts this tradeoff in exchange for closing the much larger
+// virtual-vs-on-chain drift caused by always using the modeled fee.
+func lookupHyperliquidFillByCoinSize(accountAddress, coin string, absSize, tolerance float64, startTimeMs int64) (HLFillLookup, bool) {
+	if accountAddress == "" || coin == "" || absSize <= 0 {
+		return HLFillLookup{}, false
+	}
+	for attempt := 0; attempt < hlFillLookupRetries; attempt++ {
+		fills, err := fetchHyperliquidUserFillsByTime(accountAddress, startTimeMs)
+		if err == nil {
+			out := HLFillLookup{}
+			for _, f := range fills {
+				if f.Coin != coin {
+					continue
+				}
+				sz := parseHLFloat(f.Sz)
+				if math.Abs(math.Abs(sz)-absSize) > tolerance {
+					continue
+				}
+				out.Fee += parseHLFloat(f.Fee)
+				out.ClosedPnL += parseHLFloat(f.ClosedPnl)
+				out.Count++
+			}
+			if out.Count > 0 {
+				return out, true
+			}
+		}
+		if attempt < hlFillLookupRetries-1 {
+			time.Sleep(hlFillLookupRetryDelay)
+		}
+	}
+	return HLFillLookup{}, false
+}
+
+// hlReconcileFillLookupWindow is how far back the reconciler looks for the
+// matching userFills entry. The reconciler runs once per scheduler cycle
+// (typically 60s+) but a fill could pre-date the cycle by minutes — for
+// example after a process restart with on-chain SL fired during downtime.
+// 24h is a generous default that still bounds the indexer scan; tests
+// shorten it.
+var hlReconcileFillLookupWindow = 24 * time.Hour
+
+// reconcileFillLookupSinceMs returns the userFills lookup window start in ms.
+// Tests stub the window via hlReconcileFillLookupWindow.
+func reconcileFillLookupSinceMs(now time.Time) int64 {
+	return now.Add(-hlReconcileFillLookupWindow).UnixMilli()
+}
+
+// hlReconcileFillSizeTolerance bounds the fuzzy size match in the coin+size
+// fallback. HL rounds to per-asset sz_decimals; 1e-4 covers the smallest
+// denominations (BTC sz_decimals=4) without admitting cross-strategy drift.
+const hlReconcileFillSizeTolerance = 1e-4
+
+// fillOIDMatches handles HL's mixed-type OID encoding: indexer responses
+// have arrived as both numeric and string-numeric depending on indexer
+// version. json.Number normalises both.
+func fillOIDMatches(f hlFillRecord, oid int64) bool {
+	if f.OID == "" {
+		return false
+	}
+	if v, err := f.OID.Int64(); err == nil {
+		return v == oid
+	}
+	// Fallback to string compare for floats / scientific notation.
+	return f.OID.String() == strconv.FormatInt(oid, 10)
+}
+
+func parseHLFloat(s string) float64 {
+	if s == "" {
+		return 0
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// lookupHyperliquidReconcileFillFee is the reconciler-facing fee resolver.
+// Tries OID lookup first (precise match against Position.StopLossOID); when
+// that returns no match — or no OID is known — falls back to the coin+size
+// search over the same indexer window. Stubbed to a no-op in tests that
+// don't exercise fee plumbing.
+//
+// Returns ok=false on any failure so callers fall back to the modeled fee
+// path. The function never returns an error: HL indexer hiccups should not
+// block the reconciler from clearing virtual state. Failures emit a single
+// stderr line so operators can correlate drift complaints with lookup misses.
+var lookupHyperliquidReconcileFillFee = defaultLookupHyperliquidReconcileFillFee
+
+// logHyperliquidReconcileFillLookup logs one INFO line per reconciler close
+// summarising whether the userFills lookup hit, missed, or was skipped.
+// Operators correlating drift / Trade.ExchangeFee=0 rows back to a specific
+// close event use these markers; emitted at INFO so they stay out of the
+// default-error stream during clean operation.
+func logHyperliquidReconcileFillLookup(logger *StrategyLogger, coin string, oid int64, expectedQty float64, lookup HLFillLookup, useFillFee bool) {
+	if logger == nil {
+		return
+	}
+	if useFillFee && lookup.Count > 0 {
+		logger.Info("hl-sync: %s userFills hit oid=%d qty=%.6f → fee=$%.4f closedPnl=$%.2f (%d fills)", coin, oid, expectedQty, lookup.Fee, lookup.ClosedPnL, lookup.Count)
+		return
+	}
+	if oid > 0 || expectedQty > 0 {
+		logger.Info("hl-sync: %s userFills miss oid=%d qty=%.6f — falling back to modeled fee", coin, oid, expectedQty)
+	}
+}
+
+func defaultLookupHyperliquidReconcileFillFee(accountAddress, coin string, oid int64, expectedQty float64) (HLFillLookup, bool) {
+	if accountAddress == "" {
+		return HLFillLookup{}, false
+	}
+	since := reconcileFillLookupSinceMs(time.Now().UTC())
+	if oid > 0 {
+		if lookup, ok := lookupHyperliquidFillByOID(accountAddress, oid, since); ok {
+			return lookup, true
+		}
+	}
+	if coin != "" && expectedQty > 0 {
+		if lookup, ok := lookupHyperliquidFillByCoinSize(accountAddress, coin, expectedQty, hlReconcileFillSizeTolerance, since); ok {
+			return lookup, true
+		}
+	}
+	return HLFillLookup{}, false
+}

--- a/scheduler/hyperliquid_fills_test.go
+++ b/scheduler/hyperliquid_fills_test.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Tests in this file mutate package-level hlMainnetURL / fetchHyperliquidUserFillsByTime
+// and must NOT use t.Parallel().
+
+func newHLUserFillsServer(t *testing.T, fills []map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(fills)
+	}))
+}
+
+func withFastFillRetries(t *testing.T) {
+	t.Helper()
+	origRetries := hlFillLookupRetries
+	origDelay := hlFillLookupRetryDelay
+	hlFillLookupRetries = 1
+	hlFillLookupRetryDelay = 0
+	t.Cleanup(func() {
+		hlFillLookupRetries = origRetries
+		hlFillLookupRetryDelay = origDelay
+	})
+}
+
+func TestLookupHyperliquidFillByOID_AggregatesPartialFills(t *testing.T) {
+	withFastFillRetries(t)
+	srv := newHLUserFillsServer(t, []map[string]any{
+		{"coin": "BTC", "oid": 12345, "fee": "0.50", "closedPnl": "100.00", "sz": "0.1"},
+		{"coin": "BTC", "oid": 12345, "fee": "0.30", "closedPnl": "50.00", "sz": "0.05"},
+		{"coin": "BTC", "oid": 99999, "fee": "1.00", "closedPnl": "200.00", "sz": "0.2"}, // unrelated
+	})
+	defer srv.Close()
+	origURL := hlMainnetURL
+	hlMainnetURL = srv.URL
+	defer func() { hlMainnetURL = origURL }()
+
+	got, ok := lookupHyperliquidFillByOID("0xtest", 12345, 0)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got.Count != 2 {
+		t.Errorf("Count = %d, want 2", got.Count)
+	}
+	if got.Fee < 0.799 || got.Fee > 0.801 {
+		t.Errorf("Fee = %g, want ~0.80", got.Fee)
+	}
+	if got.ClosedPnL < 149.99 || got.ClosedPnL > 150.01 {
+		t.Errorf("ClosedPnL = %g, want ~150.00", got.ClosedPnL)
+	}
+}
+
+func TestLookupHyperliquidFillByOID_NoMatchReturnsFalse(t *testing.T) {
+	withFastFillRetries(t)
+	srv := newHLUserFillsServer(t, []map[string]any{
+		{"coin": "BTC", "oid": 99999, "fee": "1.00", "sz": "0.2"},
+	})
+	defer srv.Close()
+	origURL := hlMainnetURL
+	hlMainnetURL = srv.URL
+	defer func() { hlMainnetURL = origURL }()
+
+	if _, ok := lookupHyperliquidFillByOID("0xtest", 12345, 0); ok {
+		t.Error("expected ok=false for missing OID")
+	}
+}
+
+func TestLookupHyperliquidFillByOID_EmptyAddressShortCircuits(t *testing.T) {
+	withFastFillRetries(t)
+	if _, ok := lookupHyperliquidFillByOID("", 12345, 0); ok {
+		t.Error("expected ok=false for empty address")
+	}
+}
+
+func TestLookupHyperliquidFillByCoinSize_MatchesByCoinAndSize(t *testing.T) {
+	withFastFillRetries(t)
+	srv := newHLUserFillsServer(t, []map[string]any{
+		{"coin": "BTC", "oid": 1, "fee": "0.40", "closedPnl": "75.00", "sz": "0.123456"},
+		{"coin": "ETH", "oid": 2, "fee": "0.10", "closedPnl": "5.00", "sz": "0.123456"}, // wrong coin
+		{"coin": "BTC", "oid": 3, "fee": "0.20", "closedPnl": "10.00", "sz": "0.5"},     // wrong size
+	})
+	defer srv.Close()
+	origURL := hlMainnetURL
+	hlMainnetURL = srv.URL
+	defer func() { hlMainnetURL = origURL }()
+
+	got, ok := lookupHyperliquidFillByCoinSize("0xtest", "BTC", 0.123456, 1e-4, 0)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got.Count != 1 {
+		t.Errorf("Count = %d, want 1", got.Count)
+	}
+	if got.Fee < 0.399 || got.Fee > 0.401 {
+		t.Errorf("Fee = %g, want ~0.40", got.Fee)
+	}
+}
+
+func TestLookupHyperliquidReconcileFillFee_OIDFirstFallsBackToCoinSize(t *testing.T) {
+	withFastFillRetries(t)
+	// First call (OID lookup) returns no match; second call (coin+size) returns hit.
+	calls := 0
+	orig := fetchHyperliquidUserFillsByTime
+	defer func() { fetchHyperliquidUserFillsByTime = orig }()
+	fetchHyperliquidUserFillsByTime = func(addr string, sinceMs int64) ([]hlFillRecord, error) {
+		calls++
+		switch calls {
+		case 1:
+			// No match for OID 999.
+			return []hlFillRecord{
+				{Coin: "BTC", OID: "1", Fee: "0.10", Sz: "0.5"},
+			}, nil
+		default:
+			// Coin+size match for BTC@0.5.
+			return []hlFillRecord{
+				{Coin: "BTC", OID: "1", Fee: "0.10", ClosedPnl: "20.00", Sz: "0.5"},
+			}, nil
+		}
+	}
+
+	got, ok := lookupHyperliquidReconcileFillFee("0xtest", "BTC", 999, 0.5)
+	if !ok {
+		t.Fatal("expected ok=true via coin+size fallback")
+	}
+	if got.Fee < 0.099 || got.Fee > 0.101 {
+		t.Errorf("Fee = %g, want ~0.10", got.Fee)
+	}
+}
+
+func TestReconcileHyperliquidPositions_ExternalCloseUsesFillFee(t *testing.T) {
+	// Stub the fee lookup to return a known fee for the SL trigger OID.
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(addr, coin string, oid int64, qty float64) (HLFillLookup, bool) {
+		if oid == 4242 && coin == "BTC" {
+			return HLFillLookup{Fee: 1.23, ClosedPnL: 0, Count: 1, OID: oid}, true
+		}
+		return HLFillLookup{}, false
+	}
+
+	s := &StrategyState{
+		ID: "hl-test", Platform: "hyperliquid", Type: "perps", Cash: 10000,
+		Positions: map[string]*Position{
+			"BTC": {
+				Symbol: "BTC", Quantity: 0.1, AvgCost: 60000, Side: "long",
+				Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-test",
+				StopLossOID: 4242, StopLossTriggerPx: 58000,
+			},
+		},
+	}
+	logMgr, _ := NewLogManager(t.TempDir())
+	logger, _ := logMgr.GetStrategyLogger("hl-test")
+
+	changed := reconcileHyperliquidPositions(s, "BTC", nil, "0xtest", logger)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+
+	// One open trade (none in this test) + one close trade.
+	if len(s.TradeHistory) != 1 {
+		t.Fatalf("TradeHistory = %d, want 1", len(s.TradeHistory))
+	}
+	closeTrade := s.TradeHistory[0]
+	if !closeTrade.IsClose {
+		t.Error("expected IsClose=true on the booked close trade")
+	}
+	if closeTrade.ExchangeFee < 1.229 || closeTrade.ExchangeFee > 1.231 {
+		t.Errorf("ExchangeFee = %g, want ~1.23 (real fill fee from userFills)", closeTrade.ExchangeFee)
+	}
+	if closeTrade.ExchangeOrderID != "4242" {
+		t.Errorf("ExchangeOrderID = %q, want %q", closeTrade.ExchangeOrderID, "4242")
+	}
+}
+
+func TestReconcileHyperliquidAccountPositions_DetectorOneUsesFillFee(t *testing.T) {
+	// Detector 1 (Full external close on shared coin): SL owner gets OID-keyed
+	// fee lookup; non-owner peer gets coin+size match.
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(addr, coin string, oid int64, qty float64) (HLFillLookup, bool) {
+		if oid == 5005 {
+			return HLFillLookup{Fee: 2.50, Count: 1, OID: oid}, true
+		}
+		if oid == 0 && coin == "BTC" && qty > 0 {
+			return HLFillLookup{Fee: 0.75, Count: 1}, true
+		}
+		return HLFillLookup{}, false
+	}
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner": {
+				ID: "hl-owner", Platform: "hyperliquid", Type: "perps", Cash: 5000,
+				Positions: map[string]*Position{
+					"BTC": {
+						Symbol: "BTC", Quantity: 0.2, AvgCost: 60000, Side: "long",
+						Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-owner",
+						StopLossOID: 5005, StopLossTriggerPx: 58000,
+					},
+				},
+			},
+			"hl-peer": {
+				ID: "hl-peer", Platform: "hyperliquid", Type: "perps", Cash: 5000,
+				Positions: map[string]*Position{
+					"BTC": {
+						Symbol: "BTC", Quantity: 0.1, AvgCost: 60500, Side: "long",
+						Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-peer",
+					},
+				},
+			},
+		},
+	}
+	scs := []StrategyConfig{
+		{ID: "hl-owner", Platform: "hyperliquid", Type: "perps", Args: []string{"hold", "BTC", "1h", "--mode=live"}, Leverage: 5},
+		{ID: "hl-peer", Platform: "hyperliquid", Type: "perps", Args: []string{"hold", "BTC", "1h", "--mode=live"}, Leverage: 5},
+	}
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+
+	prices := map[string]float64{"BTC": 59000}
+	// nil on-chain positions => Detector 1 fires for both peers.
+	reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, nil, prices, "0xtest")
+
+	ownerSS := state.Strategies["hl-owner"]
+	if _, open := ownerSS.Positions["BTC"]; open {
+		t.Error("owner BTC position should have been closed")
+	}
+	if len(ownerSS.TradeHistory) != 1 {
+		t.Fatalf("owner TradeHistory = %d, want 1", len(ownerSS.TradeHistory))
+	}
+	if ownerSS.TradeHistory[0].ExchangeFee < 2.499 || ownerSS.TradeHistory[0].ExchangeFee > 2.501 {
+		t.Errorf("owner ExchangeFee = %g, want ~2.50 (OID-keyed)", ownerSS.TradeHistory[0].ExchangeFee)
+	}
+
+	peerSS := state.Strategies["hl-peer"]
+	if _, open := peerSS.Positions["BTC"]; open {
+		t.Error("peer BTC position should have been closed")
+	}
+	if len(peerSS.TradeHistory) != 1 {
+		t.Fatalf("peer TradeHistory = %d, want 1", len(peerSS.TradeHistory))
+	}
+	if peerSS.TradeHistory[0].ExchangeFee < 0.749 || peerSS.TradeHistory[0].ExchangeFee > 0.751 {
+		t.Errorf("peer ExchangeFee = %g, want ~0.75 (coin+size fallback)", peerSS.TradeHistory[0].ExchangeFee)
+	}
+}
+
+func TestReconcileFillLookupSinceMs_BoundsTo24h(t *testing.T) {
+	now := time.Now().UTC()
+	got := reconcileFillLookupSinceMs(now)
+	want := now.Add(-hlReconcileFillLookupWindow).UnixMilli()
+	if got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+}

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -544,7 +544,7 @@ func TestReconcileHyperliquidPositions_RestingStopLossFillBooksPnL(t *testing.T)
 	logger := silentStrategyLogger("hl-test-eth")
 	defer logger.Close()
 
-	changed := reconcileHyperliquidPositions(state, "ETH", nil, logger)
+	changed := reconcileHyperliquidPositions(state, "ETH", nil, "", logger)
 	if !changed {
 		t.Fatalf("expected reconcile to report a state change")
 	}
@@ -599,7 +599,7 @@ func TestReconcileHyperliquidPositions_RestingStopLossFillClosesShortWithBuy(t *
 	logger := silentStrategyLogger("hl-test-eth")
 	defer logger.Close()
 
-	changed := reconcileHyperliquidPositions(state, "ETH", nil, logger)
+	changed := reconcileHyperliquidPositions(state, "ETH", nil, "", logger)
 	if !changed {
 		t.Fatalf("expected reconcile to report a state change")
 	}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1070,7 +1070,7 @@ func main() {
 				// shared-wallet risk check (#243 review feedback) so we don't
 				// pay two HL API round-trips per cycle.
 				if len(hlReconcileDue) > 0 && hlStateFetched {
-					reconcileHyperliquidAccountPositions(hlReconcileDue, hlReconcileAll, state, &mu, logMgr, hlPositions, prices)
+					reconcileHyperliquidAccountPositions(hlReconcileDue, hlReconcileAll, state, &mu, logMgr, hlPositions, prices, os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS"))
 				}
 
 				for _, sc := range dueStrategies {

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -121,11 +121,15 @@ func bookPerpsClose(s *StrategyState, symbol string, closePx float64, reason, de
 }
 
 // bookPerpsCloseWithFillFee extends bookPerpsClose with on-chain fill metadata.
-// When useFillFee is true and fillFee > 0, the supplied fee replaces the
-// modeled fee in PnL math AND populates Trade.ExchangeFee — closing the
-// virtual-vs-on-chain drift identified in #585 / #588. exchangeOrderID is
-// stamped on Trade.ExchangeOrderID when non-empty (typically the OID that
-// triggered the on-chain close, e.g. Position.StopLossOID).
+// When useFillFee is true the supplied fillFee is treated as authoritative —
+// it replaces the modeled fee in PnL math AND populates Trade.ExchangeFee
+// regardless of sign (zero / negative maker rebate fills are kept verbatim
+// rather than silently falling back to the modeled taker fee). useFillFee
+// must only be set when an actual userFills row was matched, so this is the
+// "lookup performed and produced data" sentinel — see #588 review point 2.
+// exchangeOrderID is stamped on Trade.ExchangeOrderID when non-empty
+// (typically the OID that triggered the on-chain close, e.g.
+// Position.StopLossOID).
 func bookPerpsCloseWithFillFee(s *StrategyState, symbol string, closePx, fillFee float64, useFillFee bool, exchangeOrderID, reason, detailsPrefix, logPrefix string, logger *StrategyLogger) bool {
 	if closePx <= 0 {
 		return false
@@ -149,8 +153,18 @@ func bookPerpsCloseWithFillFee(s *StrategyState, symbol string, closePx, fillFee
 	if s.Platform == "okx" && s.Type == "perps" {
 		feePlatform = "okx-perps"
 	}
-	modeledFee := CalculatePlatformSpotFee(feePlatform, qty*closePx)
-	fee := executionFee(modeledFee, fillFee, useFillFee)
+	// Reconciler-side fee selection: trust the userFills lookup result when
+	// useFillFee is true, even if the fee is zero or negative (maker rebate).
+	// Only fall back to the modeled fee when no row matched. Diverges from
+	// executionFee() which gates on `> 0` for spot/futures paper paths where
+	// useFillFee=true with fillFee=0 simply means "paper close, no exchange
+	// fee" and the modeled fee is the right model.
+	fee := CalculatePlatformSpotFee(feePlatform, qty*closePx)
+	exchangeFeeStamp := 0.0
+	if useFillFee {
+		fee = fillFee
+		exchangeFeeStamp = fillFee
+	}
 	pnl -= fee
 	s.Cash += pnl
 	positionID := ensurePositionTradeID(s.ID, symbol, pos)
@@ -169,7 +183,7 @@ func bookPerpsCloseWithFillFee(s *StrategyState, symbol string, closePx, fillFee
 		IsClose:         true,
 		RealizedPnL:     pnl,
 		ExchangeOrderID: exchangeOrderIDForTrade(exchangeOrderID, useFillFee),
-		ExchangeFee:     exchangeFeeForTrade(fillFee, useFillFee),
+		ExchangeFee:     exchangeFeeStamp,
 	}
 	trade.Regime = s.Regime
 	trade.EntryATR = pos.EntryATR

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -117,6 +117,16 @@ func recordClosedPosition(s *StrategyState, pos *Position, closePrice, realizedP
 // Returns false (no mutation) when closePx <= 0 or the position is missing,
 // so callers can choose a fallback path.
 func bookPerpsClose(s *StrategyState, symbol string, closePx float64, reason, detailsPrefix, logPrefix string, logger *StrategyLogger) bool {
+	return bookPerpsCloseWithFillFee(s, symbol, closePx, 0, false, "", reason, detailsPrefix, logPrefix, logger)
+}
+
+// bookPerpsCloseWithFillFee extends bookPerpsClose with on-chain fill metadata.
+// When useFillFee is true and fillFee > 0, the supplied fee replaces the
+// modeled fee in PnL math AND populates Trade.ExchangeFee — closing the
+// virtual-vs-on-chain drift identified in #585 / #588. exchangeOrderID is
+// stamped on Trade.ExchangeOrderID when non-empty (typically the OID that
+// triggered the on-chain close, e.g. Position.StopLossOID).
+func bookPerpsCloseWithFillFee(s *StrategyState, symbol string, closePx, fillFee float64, useFillFee bool, exchangeOrderID, reason, detailsPrefix, logPrefix string, logger *StrategyLogger) bool {
 	if closePx <= 0 {
 		return false
 	}
@@ -139,24 +149,27 @@ func bookPerpsClose(s *StrategyState, symbol string, closePx float64, reason, de
 	if s.Platform == "okx" && s.Type == "perps" {
 		feePlatform = "okx-perps"
 	}
-	fee := CalculatePlatformSpotFee(feePlatform, qty*closePx)
+	modeledFee := CalculatePlatformSpotFee(feePlatform, qty*closePx)
+	fee := executionFee(modeledFee, fillFee, useFillFee)
 	pnl -= fee
 	s.Cash += pnl
 	positionID := ensurePositionTradeID(s.ID, symbol, pos)
 
 	trade := Trade{
-		Timestamp:   now,
-		StrategyID:  s.ID,
-		Symbol:      symbol,
-		PositionID:  positionID,
-		Side:        closeTradeSide(side),
-		Quantity:    qty,
-		Price:       closePx,
-		Value:       qty * closePx,
-		TradeType:   "perps",
-		Details:     fmt.Sprintf("%s, PnL: $%.2f (fee $%.2f)", detailsPrefix, pnl, fee),
-		IsClose:     true,
-		RealizedPnL: pnl,
+		Timestamp:       now,
+		StrategyID:      s.ID,
+		Symbol:          symbol,
+		PositionID:      positionID,
+		Side:            closeTradeSide(side),
+		Quantity:        qty,
+		Price:           closePx,
+		Value:           qty * closePx,
+		TradeType:       "perps",
+		Details:         fmt.Sprintf("%s, PnL: $%.2f (fee $%.2f)", detailsPrefix, pnl, fee),
+		IsClose:         true,
+		RealizedPnL:     pnl,
+		ExchangeOrderID: exchangeOrderIDForTrade(exchangeOrderID, useFillFee),
+		ExchangeFee:     exchangeFeeForTrade(fillFee, useFillFee),
 	}
 	trade.Regime = s.Regime
 	trade.EntryATR = pos.EntryATR
@@ -179,6 +192,15 @@ func recordPerpsStopLossClose(s *StrategyState, symbol string, triggerPx float64
 	return bookPerpsClose(s, symbol, triggerPx, reason, "Stop loss close", "SL close reconciled", logger)
 }
 
+// recordPerpsStopLossCloseWithFillFee is the reconciler entry point — same
+// behavior as recordPerpsStopLossClose but threads the userFills-resolved
+// exchange fee + OID into the close Trade so virtual cash matches the
+// on-chain accountValue (#588). When useFillFee=false (or fillFee<=0) the
+// modeled fee is used; failed indexer lookups fall back to the legacy path.
+func recordPerpsStopLossCloseWithFillFee(s *StrategyState, symbol string, triggerPx, fillFee float64, useFillFee bool, exchangeOrderID, reason string, logger *StrategyLogger) bool {
+	return bookPerpsCloseWithFillFee(s, symbol, triggerPx, fillFee, useFillFee, exchangeOrderID, reason, "Stop loss close", "SL close reconciled", logger)
+}
+
 // recordPerpsExternalClose books a perps close detected by reconciliation
 // when the position has disappeared on-chain without a tracked trigger fill
 // (manual UI close, kill-switch close from a peer, etc.). The caller supplies
@@ -188,6 +210,15 @@ func recordPerpsStopLossClose(s *StrategyState, symbol string, triggerPx float64
 // is missing, so callers can fall back to a zero-PnL recordClosedPosition (#584).
 func recordPerpsExternalClose(s *StrategyState, symbol string, closePx float64, reason string, logger *StrategyLogger) bool {
 	return bookPerpsClose(s, symbol, closePx, reason, "External close @ mark", "External close reconciled", logger)
+}
+
+// recordPerpsExternalCloseWithFillFee is the reconciler entry point — same
+// as recordPerpsExternalClose but threads the userFills-resolved fee and
+// (optional) exchange OID. The OID is rarely available for external closes
+// since the close happened off-scheduler, but the coin+size match path
+// can still recover the fee.
+func recordPerpsExternalCloseWithFillFee(s *StrategyState, symbol string, closePx, fillFee float64, useFillFee bool, exchangeOrderID, reason string, logger *StrategyLogger) bool {
+	return bookPerpsCloseWithFillFee(s, symbol, closePx, fillFee, useFillFee, exchangeOrderID, reason, "External close @ mark", "External close reconciled", logger)
 }
 
 // recordClosedOptionPosition appends a ClosedOptionPosition entry to the


### PR DESCRIPTION
## Summary

Follow-up to #585 / #587 — closes the `Trade.ExchangeFee=0` / virtual-vs-on-chain cash drift on HL closes booked by the reconciler (resting SL fires, walked trailing stops, external UI closes).

- Adds native-Go `userFills` query (`lookupHyperliquidFillByOID`, `lookupHyperliquidFillByCoinSize`) with the same retry-for-indexer-lag pattern as the Python adapter helper.
- New `recordPerpsStopLossCloseWithFillFee` / `recordPerpsExternalCloseWithFillFee` variants thread `fillFee` / `useFillFee` / `exchangeOrderID` through `bookPerpsClose`.
- Wired into all three reconciler close paths in `scheduler/hyperliquid_balance.go`. OID preferred, coin+size fallback over a 24h window.
- Lookup failures are non-fatal — close books with the modeled fee.

## Test plan

- [x] `go test ./...` - full suite passes (4.4s)
- [x] New unit tests: OID aggregation, miss, coin+size match, OID→coin+size fallback, single-strategy external close, Detector 1 owner (OID-keyed) + non-owner peer (coin+size)
- [ ] Manual: trip an SL on a low-cap test position; verify `trades.exchange_fee` is non-zero and matches HL's `userFills` entry

Closes #588

---
LLM: Claude Opus 4.7 (1M) | high | Harness: anthropics/claude-code-action@v1 | Tokens: 101 in / 47001 out | Cache: 7809612 read / 212591 written | Cost: $6.41