### PR TITLE
feat: `go-trader backfill hl-fees` to backfill modeled fees from HL userFills

### DIFF
--- a/scheduler/backfill_hl_fees.go
+++ b/scheduler/backfill_hl_fees.go
@@ -129,10 +129,6 @@ func planBackfillForStrategy(
 		return sortedTrades[i].Timestamp.Before(sortedTrades[j].Timestamp)
 	})
 
-	// Map rowid → resolved (newFee, newPnL) so the closed-position recompute
-	// pass below can read the corrected values.
-	corrected := make(map[int64]TradeBackfillRow, len(sortedTrades))
-
 	// Pre-correction replay: walk the trades using the values *currently*
 	// stored on disk (modeled fee fallback when exchange_fee=0 — that's what
 	// was actually deducted at execution time). If the result diverges from
@@ -247,18 +243,6 @@ func planBackfillForStrategy(
 			cash -= effectiveFee
 		}
 
-		// Stash corrected values for the closed-position aggregate pass.
-		corrected[t.RowID] = TradeBackfillRow{
-			RowID:           t.RowID,
-			Timestamp:       t.Timestamp,
-			Symbol:          t.Symbol,
-			PositionID:      t.PositionID,
-			Value:           t.Value,
-			IsClose:         t.IsClose,
-			ExchangeOrderID: t.ExchangeOrderID,
-			ExchangeFee:     newFee,
-			RealizedPnL:     newPnL,
-		}
 	}
 
 	plan.NewCash = cash
@@ -320,12 +304,21 @@ func planClosedPositionRecomputes(
 		if pid == "" {
 			// Tolerance match: nearest close-leg trade on same symbol within
 			// 5s, but require BOTH (a) directional ordering — the trade leg
-			// must land at or after the closed_positions row (close legs are
-			// always written before/with the SaveState that emits the
-			// closed_positions row, never before it) — AND (b) uniqueness:
-			// no other candidate within the same window. This rules out
-			// rapid back-to-back partial-then-final closes on the same symbol
-			// silently mapping to the wrong position_id.
+			// must land at or after the closed_positions row — AND (b)
+			// uniqueness: no other candidate within the same window. This
+			// rules out rapid back-to-back partial-then-final closes on the
+			// same symbol silently mapping to the wrong position_id.
+			//
+			// Timestamp invariant (post-#471): both trades.timestamp and
+			// closed_positions.closed_at are written from pos.ClosedAt in the
+			// same SaveState pass, so they are the same value and the exact-ns
+			// path above handles all modern rows without reaching here.
+			// Legacy rows (pre-#471) may violate the ordering assumption
+			// because trades.timestamp was the HL exchange fill time (a few
+			// ms–s before the scheduler runs SaveState) while closed_at is the
+			// scheduler processing time — meaning leg.Ts could be slightly
+			// before cp.ClosedAt, causing this guard to produce no match
+			// rather than a wrong match. That is the safe failure mode.
 			var candidate string
 			candidates := 0
 			for _, leg := range closeLegs {

--- a/scheduler/backfill_hl_fees.go
+++ b/scheduler/backfill_hl_fees.go
@@ -1,0 +1,584 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// HLFillSummary is a per-OID aggregate from fetch_hl_user_fills.py.
+// A single market order can fragment into multiple partial fills sharing the
+// same OID; the script sums fee + closedPnl across legs before emitting.
+type HLFillSummary struct {
+	Fee       float64 `json:"fee"`
+	ClosedPnL float64 `json:"closed_pnl"`
+	Count     int     `json:"count"`
+}
+
+// HLUserFillsResult is the stdout envelope from fetch_hl_user_fills.py.
+type HLUserFillsResult struct {
+	ByOID          map[string]HLFillSummary `json:"by_oid"`
+	FillCount      int                      `json:"fill_count"`
+	PageCount      int                      `json:"page_count"`
+	AccountAddress string                   `json:"account_address"`
+	Error          string                   `json:"error"`
+}
+
+// TradeBackfillRow is the subset of a `trades` row needed by planBackfillForStrategy.
+// Pulled into its own type so the planner is pure (no DB dep).
+type TradeBackfillRow struct {
+	RowID           int64
+	Timestamp       time.Time
+	Symbol          string
+	PositionID      string
+	Value           float64
+	IsClose         bool
+	ExchangeOrderID string
+	ExchangeFee     float64
+	RealizedPnL     float64
+}
+
+// TradeChange describes one trade-row update produced by planBackfillForStrategy.
+type TradeChange struct {
+	RowID          int64
+	Timestamp      time.Time
+	Symbol         string
+	OID            string
+	OldFee         float64
+	NewFee         float64
+	OldRealizedPnL float64
+	NewRealizedPnL float64
+	IsClose        bool
+}
+
+// SkippedTrade explains why a trade row was not updated.
+type SkippedTrade struct {
+	RowID     int64
+	Timestamp time.Time
+	Symbol    string
+	OID       string
+	Reason    string // "missing_oid", "no_fill_match", "already_real_fee"
+}
+
+// ClosedPositionRecompute carries the new aggregate PnL for a single
+// closed_positions row. Pinned by row id (closed_positions has no
+// position_id column yet, so we identify the target row directly).
+type ClosedPositionRecompute struct {
+	RowID      int64
+	Symbol     string
+	PositionID string // resolved from the matched close-leg trade
+	OldPnL     float64
+	NewPnL     float64
+}
+
+// BackfillPlan is the full set of changes for one strategy.
+type BackfillPlan struct {
+	StrategyID        string
+	TradeChanges      []TradeChange
+	Skipped           []SkippedTrade
+	ClosedPositions   []ClosedPositionRecompute
+	OldCash           float64
+	NewCash           float64
+	TotalFeeDeltaUSD  float64 // sum of (oldFee - newFee) across rows; positive = strategy "got back" fees
+	TotalPnLDeltaUSD  float64 // sum of (newPnL - oldPnL) across close legs
+	MatchedTradeCount int
+	UnmatchedOIDCount int
+	MissingOIDCount   int
+}
+
+// planBackfillForStrategy is the pure planner used by the backfill command.
+// It does no IO — given a trade history, an OID→fill map, and the strategy's
+// initial capital + current cash, it returns the change list and the
+// recomputed cash baseline.
+//
+// Cash recompute model (perps): cash starts at initial_capital; each open leg
+// debits the *real* fee (or the modeled fee if no OID match was available);
+// each close leg credits the *new* realized_pnl (already net of the real fee
+// in the corrected value). This mirrors the live model
+// (`ExecutePerpsSignalWithLeverage` / `applyManualAction`) where notional
+// stays virtual and only fees + realized pnl move cash.
+func planBackfillForStrategy(
+	strategyID string,
+	trades []TradeBackfillRow,
+	fillMap map[string]HLFillSummary,
+	initialCapital, oldCash float64,
+) BackfillPlan {
+	plan := BackfillPlan{
+		StrategyID: strategyID,
+		OldCash:    oldCash,
+	}
+
+	// Sort trades chronologically so the cash replay matches the on-chain
+	// sequence — close-leg credits depend on the open leg landing first when
+	// realized_pnl is recomputed via the corrected fee.
+	sortedTrades := make([]TradeBackfillRow, len(trades))
+	copy(sortedTrades, trades)
+	sort.SliceStable(sortedTrades, func(i, j int) bool {
+		return sortedTrades[i].Timestamp.Before(sortedTrades[j].Timestamp)
+	})
+
+	// Map rowid → resolved (newFee, newPnL) so the closed-position recompute
+	// pass below can read the corrected values.
+	corrected := make(map[int64]TradeBackfillRow, len(sortedTrades))
+
+	cash := initialCapital
+	for _, t := range sortedTrades {
+		newFee := t.ExchangeFee
+		newPnL := t.RealizedPnL
+		modeledFee := math.Abs(t.Value) * HyperliquidTakerFeePct
+
+		matchAttempted := false
+		matched := false
+		if t.ExchangeOrderID == "" {
+			plan.MissingOIDCount++
+			plan.Skipped = append(plan.Skipped, SkippedTrade{
+				RowID:     t.RowID,
+				Timestamp: t.Timestamp,
+				Symbol:    t.Symbol,
+				Reason:    "missing_oid",
+			})
+		} else {
+			matchAttempted = true
+			summary, ok := fillMap[t.ExchangeOrderID]
+			if ok {
+				matched = true
+			} else {
+				plan.UnmatchedOIDCount++
+				plan.Skipped = append(plan.Skipped, SkippedTrade{
+					RowID:     t.RowID,
+					Timestamp: t.Timestamp,
+					Symbol:    t.Symbol,
+					OID:       t.ExchangeOrderID,
+					Reason:    "no_fill_match",
+				})
+			}
+			if matched {
+				realFee := summary.Fee
+				if t.ExchangeFee != 0 {
+					// Already-real-fee guard: never overwrite a non-zero
+					// stored fee (post-#587 rows). Keep the stored values.
+					plan.Skipped = append(plan.Skipped, SkippedTrade{
+						RowID:     t.RowID,
+						Timestamp: t.Timestamp,
+						Symbol:    t.Symbol,
+						OID:       t.ExchangeOrderID,
+						Reason:    "already_real_fee",
+					})
+				} else {
+					newFee = realFee
+					if t.IsClose {
+						// realized_pnl was originally `pnl_pre_fee - modeledFee`.
+						// We want `pnl_pre_fee - realFee` → adjust by (modeledFee - realFee).
+						newPnL = t.RealizedPnL + (modeledFee - realFee)
+					}
+					if newFee != t.ExchangeFee || newPnL != t.RealizedPnL {
+						plan.TradeChanges = append(plan.TradeChanges, TradeChange{
+							RowID:          t.RowID,
+							Timestamp:      t.Timestamp,
+							Symbol:         t.Symbol,
+							OID:            t.ExchangeOrderID,
+							OldFee:         t.ExchangeFee,
+							NewFee:         newFee,
+							OldRealizedPnL: t.RealizedPnL,
+							NewRealizedPnL: newPnL,
+							IsClose:        t.IsClose,
+						})
+						plan.MatchedTradeCount++
+						plan.TotalFeeDeltaUSD += t.ExchangeFee - newFee
+						plan.TotalPnLDeltaUSD += newPnL - t.RealizedPnL
+					}
+				}
+			}
+		}
+
+		// Cash replay: open leg debits effective fee, close leg credits newPnL.
+		// For an unmatched open leg we fall back to the modeled fee since
+		// that's what was originally deducted from cash at execution time
+		// (and remains a closer estimate than zero).
+		effectiveFee := newFee
+		if !matched && matchAttempted {
+			effectiveFee = modeledFee
+		} else if !matched && !matchAttempted {
+			// missing_oid: pre-OID-stamping legacy row — also uses modeled fee
+			effectiveFee = modeledFee
+		}
+		if t.IsClose {
+			cash += newPnL
+		} else {
+			cash -= effectiveFee
+		}
+
+		// Stash corrected values for the closed-position aggregate pass.
+		corrected[t.RowID] = TradeBackfillRow{
+			RowID:           t.RowID,
+			Timestamp:       t.Timestamp,
+			Symbol:          t.Symbol,
+			PositionID:      t.PositionID,
+			Value:           t.Value,
+			IsClose:         t.IsClose,
+			ExchangeOrderID: t.ExchangeOrderID,
+			ExchangeFee:     newFee,
+			RealizedPnL:     newPnL,
+		}
+	}
+
+	plan.NewCash = cash
+	return plan
+}
+
+// planClosedPositionRecomputes matches each closed_positions row to a
+// corrected close-leg trade by (symbol, closed_at == trade.timestamp), then
+// emits a recompute when the per-position aggregate (sum of close-leg
+// realized_pnl sharing that position_id) differs from the stored value.
+//
+// closed_positions has no position_id column yet, so we recover the grouping
+// via the matching close-leg trade. Rows whose match has empty position_id
+// (legacy pre-#471 entries, or non-perps closes) are skipped — there's no
+// reliable way to aggregate them.
+func planClosedPositionRecomputes(
+	corrected []TradeBackfillRow,
+	closedRows []ClosedPositionRow,
+) []ClosedPositionRecompute {
+	// Sum corrected close-leg PnL by position_id.
+	sumsByPID := make(map[string]float64)
+	pidToSymbol := make(map[string]string)
+	for _, t := range corrected {
+		if !t.IsClose || t.PositionID == "" {
+			continue
+		}
+		sumsByPID[t.PositionID] += t.RealizedPnL
+		pidToSymbol[t.PositionID] = t.Symbol
+	}
+
+	// Build a lookup: (symbol, ms-truncated timestamp) → position_id from
+	// the corrected close-leg trades. The closed_at column on
+	// closed_positions is RFC 3339 with nanosecond precision matching the
+	// trade row written in the same SaveState pass, so an exact-key lookup
+	// works in practice; use a tolerance-based fallback for legacy rows.
+	type tradeKey struct {
+		Symbol string
+		UnixNs int64
+	}
+	exact := make(map[tradeKey]string)
+	type closeTrade struct {
+		Symbol string
+		Ts     time.Time
+		PID    string
+	}
+	var closeLegs []closeTrade
+	for _, t := range corrected {
+		if !t.IsClose || t.PositionID == "" {
+			continue
+		}
+		exact[tradeKey{Symbol: t.Symbol, UnixNs: t.Timestamp.UnixNano()}] = t.PositionID
+		closeLegs = append(closeLegs, closeTrade{Symbol: t.Symbol, Ts: t.Timestamp, PID: t.PositionID})
+	}
+	sort.Slice(closeLegs, func(i, j int) bool { return closeLegs[i].Ts.Before(closeLegs[j].Ts) })
+
+	out := make([]ClosedPositionRecompute, 0)
+	for _, cp := range closedRows {
+		pid := exact[tradeKey{Symbol: cp.Symbol, UnixNs: cp.ClosedAt.UnixNano()}]
+		if pid == "" {
+			// Tolerance match: closest close-leg trade on same symbol within 5s.
+			best := time.Duration(0)
+			for _, leg := range closeLegs {
+				if leg.Symbol != cp.Symbol {
+					continue
+				}
+				d := leg.Ts.Sub(cp.ClosedAt)
+				if d < 0 {
+					d = -d
+				}
+				if d > 5*time.Second {
+					continue
+				}
+				if pid == "" || d < best {
+					pid = leg.PID
+					best = d
+				}
+			}
+		}
+		if pid == "" {
+			continue
+		}
+		newPnL, ok := sumsByPID[pid]
+		if !ok {
+			continue
+		}
+		// Tolerance: skip when the delta is below 0.001 USD to avoid
+		// floating-point noise rewriting the row for nothing.
+		if math.Abs(newPnL-cp.RealizedPnL) < 1e-3 {
+			continue
+		}
+		out = append(out, ClosedPositionRecompute{
+			RowID:      cp.ID,
+			Symbol:     cp.Symbol,
+			PositionID: pid,
+			OldPnL:     cp.RealizedPnL,
+			NewPnL:     newPnL,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].RowID < out[j].RowID })
+	return out
+}
+
+// runBackfill is the dispatcher for `go-trader backfill <subcommand>`.
+func runBackfill(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "Usage: go-trader backfill hl-fees [--config scheduler/config.json] (--all | --strategy <id>) [--apply]")
+		return 2
+	}
+	switch args[0] {
+	case "hl-fees":
+		return runBackfillHLFees(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown backfill target %q\n", args[0])
+		return 2
+	}
+}
+
+// runBackfillHLFees implements `go-trader backfill hl-fees`.
+//
+// Backfills `trades.exchange_fee` (and `realized_pnl` on close legs) for live
+// HL strategies whose rows pre-date #587 — when modeled fees were written
+// directly because HL's order-placement response did not surface the real fee.
+//
+// Default mode is dry-run. Pass --apply to commit. The scheduler should be
+// stopped before running with --apply (this command opens its own write
+// transaction; SQLite serializes writers but a concurrent SaveState could
+// overwrite the recomputed cash on its next cycle if left running).
+func runBackfillHLFees(args []string) int {
+	fs := flag.NewFlagSet("backfill hl-fees", flag.ContinueOnError)
+	configPath := fs.String("config", "scheduler/config.json", "Path to config file")
+	strategyID := fs.String("strategy", "", "Strategy ID to backfill (mutually exclusive with --all)")
+	all := fs.Bool("all", false, "Backfill all live HL perps strategies")
+	apply := fs.Bool("apply", false, "Commit changes (default: dry-run)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if (*strategyID == "" && !*all) || (*strategyID != "" && *all) {
+		fmt.Fprintln(os.Stderr, "error: exactly one of --strategy <id> or --all is required")
+		return 2
+	}
+
+	cfg, err := LoadConfig(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load config: %v\n", err)
+		return 1
+	}
+
+	stateDB, err := OpenStateDB(cfg.DBFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to open state DB: %v\n", err)
+		return 1
+	}
+	defer stateDB.Close()
+
+	state, err := LoadStateWithDB(cfg, stateDB)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load state: %v\n", err)
+		return 1
+	}
+
+	var targets []StrategyConfig
+	if *strategyID != "" {
+		var found bool
+		for _, sc := range cfg.Strategies {
+			if sc.ID == *strategyID {
+				if sc.Platform != "hyperliquid" {
+					fmt.Fprintf(os.Stderr, "error: strategy %q platform=%q (expected hyperliquid)\n", *strategyID, sc.Platform)
+					return 1
+				}
+				targets = []StrategyConfig{sc}
+				found = true
+				break
+			}
+		}
+		if !found {
+			fmt.Fprintf(os.Stderr, "error: strategy %q not found in config\n", *strategyID)
+			return 1
+		}
+	} else {
+		for _, sc := range cfg.Strategies {
+			if sc.Platform != "hyperliquid" {
+				continue
+			}
+			if sc.Type != "perps" && sc.Type != "manual" {
+				continue
+			}
+			targets = append(targets, sc)
+		}
+		sort.Slice(targets, func(i, j int) bool { return targets[i].ID < targets[j].ID })
+	}
+	if len(targets) == 0 {
+		fmt.Fprintln(os.Stderr, "error: no live HL strategies found in config")
+		return 1
+	}
+
+	// Fetch userFills once across all targets (same wallet). Use the earliest
+	// trade timestamp across all targets as the lower bound.
+	earliest, err := stateDB.EarliestTradeTimestamp(strategyIDsOf(targets))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to read earliest trade timestamp: %v\n", err)
+		return 1
+	}
+	if earliest.IsZero() {
+		fmt.Fprintln(os.Stderr, "info: no trades found for the selected strategies — nothing to backfill")
+		return 0
+	}
+
+	fmt.Printf("Fetching HL userFills since %s...\n", earliest.UTC().Format(time.RFC3339))
+	fillResult, err := runFetchHLUserFills(earliest)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to fetch HL userFills: %v\n", err)
+		return 1
+	}
+	if fillResult.Error != "" {
+		fmt.Fprintf(os.Stderr, "HL userFills returned an error: %s\n", fillResult.Error)
+		return 1
+	}
+	fmt.Printf("Fetched %d fills across %d pages (account=%s)\n",
+		fillResult.FillCount, fillResult.PageCount, fillResult.AccountAddress)
+	if len(fillResult.ByOID) == 0 {
+		fmt.Println("warning: HL returned 0 fills — nothing to match against (verify HYPERLIQUID_ACCOUNT_ADDRESS)")
+	}
+
+	mode := "DRY-RUN"
+	if *apply {
+		mode = "APPLY"
+	}
+	fmt.Printf("\n=== %s mode ===\n", mode)
+
+	exitCode := 0
+	for _, sc := range targets {
+		ss := state.Strategies[sc.ID]
+		var oldCash float64
+		var initialCapital float64
+		if ss != nil {
+			oldCash = ss.Cash
+			initialCapital = ss.InitialCapital
+		}
+		if initialCapital == 0 {
+			initialCapital = sc.Capital
+		}
+
+		trades, err := stateDB.ListTradesForBackfill(sc.ID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[%s] failed to list trades: %v\n", sc.ID, err)
+			exitCode = 1
+			continue
+		}
+
+		closedRows, err := stateDB.LoadClosedPositionRows(sc.ID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[%s] failed to load closed_positions: %v\n", sc.ID, err)
+			exitCode = 1
+			continue
+		}
+
+		plan := planBackfillForStrategy(sc.ID, trades, fillResult.ByOID, initialCapital, oldCash)
+
+		correctedTrades := make([]TradeBackfillRow, 0, len(trades))
+		for _, t := range trades {
+			row := t
+			for _, c := range plan.TradeChanges {
+				if c.RowID == t.RowID {
+					row.ExchangeFee = c.NewFee
+					row.RealizedPnL = c.NewRealizedPnL
+					break
+				}
+			}
+			correctedTrades = append(correctedTrades, row)
+		}
+		plan.ClosedPositions = planClosedPositionRecomputes(correctedTrades, closedRows)
+
+		printBackfillReport(plan)
+
+		if *apply {
+			if err := stateDB.ApplyBackfillPlan(plan); err != nil {
+				fmt.Fprintf(os.Stderr, "[%s] APPLY failed: %v\n", sc.ID, err)
+				exitCode = 1
+				continue
+			}
+			fmt.Printf("[%s] APPLY committed: %d trade rows, %d closed_positions, cash %.4f → %.4f\n",
+				sc.ID, len(plan.TradeChanges), len(plan.ClosedPositions), plan.OldCash, plan.NewCash)
+		}
+	}
+
+	if !*apply {
+		fmt.Println("\n(dry-run — re-run with --apply to commit)")
+	}
+	return exitCode
+}
+
+func strategyIDsOf(strategies []StrategyConfig) []string {
+	ids := make([]string, 0, len(strategies))
+	for _, sc := range strategies {
+		ids = append(ids, sc.ID)
+	}
+	return ids
+}
+
+// printBackfillReport renders a per-strategy summary block to stdout.
+func printBackfillReport(plan BackfillPlan) {
+	fmt.Printf("\n--- %s ---\n", plan.StrategyID)
+	fmt.Printf("  rows updated:        %d\n", len(plan.TradeChanges))
+	fmt.Printf("  rows skipped:        %d (missing_oid=%d, unmatched=%d)\n",
+		len(plan.Skipped), plan.MissingOIDCount, plan.UnmatchedOIDCount)
+	fmt.Printf("  fee delta (sum):     $%+.4f (positive = fees were over-modeled)\n", plan.TotalFeeDeltaUSD)
+	fmt.Printf("  pnl delta (sum):     $%+.4f\n", plan.TotalPnLDeltaUSD)
+	fmt.Printf("  cash:                $%.4f → $%.4f (Δ %+.4f)\n",
+		plan.OldCash, plan.NewCash, plan.NewCash-plan.OldCash)
+	fmt.Printf("  closed_positions:    %d aggregate rows to update\n", len(plan.ClosedPositions))
+}
+
+// runFetchHLUserFills spawns shared_scripts/fetch_hl_user_fills.py with a
+// generous timeout (paging through years of history can exceed the standard
+// 30s scriptTimeout used by the per-cycle check scripts).
+func runFetchHLUserFills(since time.Time) (*HLUserFillsResult, error) {
+	script := "shared_scripts/fetch_hl_user_fills.py"
+	args := []string{
+		fmt.Sprintf("--since-ms=%d", since.UnixMilli()),
+	}
+
+	pythonSemaphore <- struct{}{}
+	defer func() { <-pythonSemaphore }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, ".venv/bin/python3", append([]string{script}, args...)...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		if cmd.Process != nil {
+			syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		return nil, fmt.Errorf("script timed out after 5m")
+	}
+	stderrStr := strings.TrimSpace(stderr.String())
+	if stderrStr != "" {
+		fmt.Fprintln(os.Stderr, stderrStr)
+	}
+	var result HLUserFillsResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		return nil, fmt.Errorf("parse output: %w (stdout: %s)", err, stdout.String())
+	}
+	if runErr != nil && result.Error == "" {
+		return &result, fmt.Errorf("script error: %w", runErr)
+	}
+	return &result, nil
+}

--- a/scheduler/backfill_hl_fees.go
+++ b/scheduler/backfill_hl_fees.go
@@ -82,17 +82,20 @@ type ClosedPositionRecompute struct {
 
 // BackfillPlan is the full set of changes for one strategy.
 type BackfillPlan struct {
-	StrategyID        string
-	TradeChanges      []TradeChange
-	Skipped           []SkippedTrade
-	ClosedPositions   []ClosedPositionRecompute
-	OldCash           float64
-	NewCash           float64
-	TotalFeeDeltaUSD  float64 // sum of (oldFee - newFee) across rows; positive = strategy "got back" fees
-	TotalPnLDeltaUSD  float64 // sum of (newPnL - oldPnL) across close legs
-	MatchedTradeCount int
-	UnmatchedOIDCount int
-	MissingOIDCount   int
+	StrategyID            string
+	TradeChanges          []TradeChange
+	Skipped               []SkippedTrade
+	ClosedPositions       []ClosedPositionRecompute
+	OldCash               float64
+	NewCash               float64
+	TotalFeeDeltaUSD      float64 // sum of (oldFee - newFee) across rows; positive = strategy "got back" fees
+	TotalPnLDeltaUSD      float64 // sum of (newPnL - oldPnL) across close legs
+	MatchedTradeCount     int
+	UnmatchedOIDCount     int
+	MissingOIDCount       int
+	AlreadyRealFeeCount   int     // post-#587 rows skipped because exchange_fee was already non-zero
+	ReplayedCash          float64 // pre-correction cash replay (initial_capital + old fees + old pnl) — diverges from OldCash when SIGHUP capital top-ups landed
+	CashBaselineDivergent bool    // ReplayedCash differs from OldCash by more than $1 → likely SIGHUP capital top-up; --apply must be gated
 }
 
 // planBackfillForStrategy is the pure planner used by the backfill command.
@@ -130,6 +133,32 @@ func planBackfillForStrategy(
 	// pass below can read the corrected values.
 	corrected := make(map[int64]TradeBackfillRow, len(sortedTrades))
 
+	// Pre-correction replay: walk the trades using the values *currently*
+	// stored on disk (modeled fee fallback when exchange_fee=0 — that's what
+	// was actually deducted at execution time). If the result diverges from
+	// `oldCash` by more than $1, the strategy almost certainly had its
+	// `capital` raised mid-run via SIGHUP (config_reload.go applies
+	// `Cash += new - old` directly with no trade row), so a forward replay
+	// from initial_capital would silently roll cash back to a wrong baseline
+	// on --apply. Surface it as a divergence flag so the report and
+	// runBackfillHLFees can refuse --apply unless the operator opts in.
+	preReplayCash := initialCapital
+	for _, t := range sortedTrades {
+		preFee := t.ExchangeFee
+		if preFee == 0 {
+			preFee = math.Abs(t.Value) * HyperliquidTakerFeePct
+		}
+		if t.IsClose {
+			preReplayCash += t.RealizedPnL
+		} else {
+			preReplayCash -= preFee
+		}
+	}
+	plan.ReplayedCash = preReplayCash
+	if math.Abs(preReplayCash-oldCash) > 1.0 {
+		plan.CashBaselineDivergent = true
+	}
+
 	cash := initialCapital
 	for _, t := range sortedTrades {
 		newFee := t.ExchangeFee
@@ -166,6 +195,7 @@ func planBackfillForStrategy(
 				if t.ExchangeFee != 0 {
 					// Already-real-fee guard: never overwrite a non-zero
 					// stored fee (post-#587 rows). Keep the stored values.
+					plan.AlreadyRealFeeCount++
 					plan.Skipped = append(plan.Skipped, SkippedTrade{
 						RowID:     t.RowID,
 						Timestamp: t.Timestamp,
@@ -288,23 +318,34 @@ func planClosedPositionRecomputes(
 	for _, cp := range closedRows {
 		pid := exact[tradeKey{Symbol: cp.Symbol, UnixNs: cp.ClosedAt.UnixNano()}]
 		if pid == "" {
-			// Tolerance match: closest close-leg trade on same symbol within 5s.
-			best := time.Duration(0)
+			// Tolerance match: nearest close-leg trade on same symbol within
+			// 5s, but require BOTH (a) directional ordering — the trade leg
+			// must land at or after the closed_positions row (close legs are
+			// always written before/with the SaveState that emits the
+			// closed_positions row, never before it) — AND (b) uniqueness:
+			// no other candidate within the same window. This rules out
+			// rapid back-to-back partial-then-final closes on the same symbol
+			// silently mapping to the wrong position_id.
+			var candidate string
+			candidates := 0
 			for _, leg := range closeLegs {
 				if leg.Symbol != cp.Symbol {
 					continue
 				}
-				d := leg.Ts.Sub(cp.ClosedAt)
-				if d < 0 {
-					d = -d
-				}
-				if d > 5*time.Second {
+				if leg.Ts.Before(cp.ClosedAt) {
 					continue
 				}
-				if pid == "" || d < best {
-					pid = leg.PID
-					best = d
+				if leg.Ts.Sub(cp.ClosedAt) > 5*time.Second {
+					continue
 				}
+				candidate = leg.PID
+				candidates++
+				if candidates > 1 {
+					break
+				}
+			}
+			if candidates == 1 {
+				pid = candidate
 			}
 		}
 		if pid == "" {
@@ -352,18 +393,28 @@ func runBackfill(args []string) int {
 // HL strategies whose rows pre-date #587 — when modeled fees were written
 // directly because HL's order-placement response did not surface the real fee.
 //
-// Default mode is dry-run. Pass --apply to commit. The scheduler should be
-// stopped before running with --apply (this command opens its own write
-// transaction; SQLite serializes writers but a concurrent SaveState could
-// overwrite the recomputed cash on its next cycle if left running).
+// Default mode is dry-run. Pass --apply to commit. --apply refuses to run
+// when another go-trader process is alive (a concurrent SaveState would
+// overwrite the recomputed cash on its next cycle), and refuses per-strategy
+// when the pre-correction cash replay diverges from the stored cash by more
+// than $1 (likely a SIGHUP capital top-up via config_reload.go that a
+// forward-from-initial-capital replay cannot reproduce). Pass --reset-cash to
+// override the divergence guard.
 func runBackfillHLFees(args []string) int {
 	fs := flag.NewFlagSet("backfill hl-fees", flag.ContinueOnError)
 	configPath := fs.String("config", "scheduler/config.json", "Path to config file")
 	strategyID := fs.String("strategy", "", "Strategy ID to backfill (mutually exclusive with --all)")
 	all := fs.Bool("all", false, "Backfill all live HL perps strategies")
 	apply := fs.Bool("apply", false, "Commit changes (default: dry-run)")
+	resetCash := fs.Bool("reset-cash", false, "Allow --apply to overwrite strategies.cash even when the pre-correction replay diverges from the stored value (e.g. after a SIGHUP capital top-up)")
 	if err := fs.Parse(args); err != nil {
 		return 2
+	}
+	if *apply {
+		if err := refuseIfSchedulerRunning(); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
 	}
 	if (*strategyID == "" && !*all) || (*strategyID != "" && *all) {
 		fmt.Fprintln(os.Stderr, "error: exactly one of --strategy <id> or --all is required")
@@ -398,6 +449,10 @@ func runBackfillHLFees(args []string) int {
 					fmt.Fprintf(os.Stderr, "error: strategy %q platform=%q (expected hyperliquid)\n", *strategyID, sc.Platform)
 					return 1
 				}
+				if sc.Type == "perps" && !hyperliquidIsLive(sc.Args) {
+					fmt.Fprintf(os.Stderr, "error: strategy %q is paper-mode (no real OIDs to match against userFills)\n", *strategyID)
+					return 1
+				}
 				targets = []StrategyConfig{sc}
 				found = true
 				break
@@ -413,6 +468,14 @@ func runBackfillHLFees(args []string) int {
 				continue
 			}
 			if sc.Type != "perps" && sc.Type != "manual" {
+				continue
+			}
+			// Paper-mode HL perps trades have synthetic OIDs that won't match
+			// any userFills row; skip them with a one-line note rather than
+			// burying the operator in noisy `missing_oid` skip lines.
+			// `manual` strategies are always live (no paper mode).
+			if sc.Type == "perps" && !hyperliquidIsLive(sc.Args) {
+				fmt.Printf("[%s] skipped: paper-mode (no real OIDs)\n", sc.ID)
 				continue
 			}
 			targets = append(targets, sc)
@@ -487,15 +550,16 @@ func runBackfillHLFees(args []string) int {
 
 		plan := planBackfillForStrategy(sc.ID, trades, fillResult.ByOID, initialCapital, oldCash)
 
+		changeByRowID := make(map[int64]TradeChange, len(plan.TradeChanges))
+		for _, c := range plan.TradeChanges {
+			changeByRowID[c.RowID] = c
+		}
 		correctedTrades := make([]TradeBackfillRow, 0, len(trades))
 		for _, t := range trades {
 			row := t
-			for _, c := range plan.TradeChanges {
-				if c.RowID == t.RowID {
-					row.ExchangeFee = c.NewFee
-					row.RealizedPnL = c.NewRealizedPnL
-					break
-				}
+			if c, ok := changeByRowID[t.RowID]; ok {
+				row.ExchangeFee = c.NewFee
+				row.RealizedPnL = c.NewRealizedPnL
 			}
 			correctedTrades = append(correctedTrades, row)
 		}
@@ -504,6 +568,12 @@ func runBackfillHLFees(args []string) int {
 		printBackfillReport(plan)
 
 		if *apply {
+			if plan.CashBaselineDivergent && !*resetCash {
+				fmt.Fprintf(os.Stderr, "[%s] APPLY refused: cash baseline diverges from pre-correction replay by $%+.4f. Re-run with --reset-cash to acknowledge that the recomputed cash will not preserve mid-run capital top-ups.\n",
+					sc.ID, plan.OldCash-plan.ReplayedCash)
+				exitCode = 1
+				continue
+			}
 			if err := stateDB.ApplyBackfillPlan(plan); err != nil {
 				fmt.Fprintf(os.Stderr, "[%s] APPLY failed: %v\n", sc.ID, err)
 				exitCode = 1
@@ -532,13 +602,59 @@ func strategyIDsOf(strategies []StrategyConfig) []string {
 func printBackfillReport(plan BackfillPlan) {
 	fmt.Printf("\n--- %s ---\n", plan.StrategyID)
 	fmt.Printf("  rows updated:        %d\n", len(plan.TradeChanges))
-	fmt.Printf("  rows skipped:        %d (missing_oid=%d, unmatched=%d)\n",
-		len(plan.Skipped), plan.MissingOIDCount, plan.UnmatchedOIDCount)
+	fmt.Printf("  rows skipped:        %d (missing_oid=%d, unmatched=%d, already_real=%d)\n",
+		len(plan.Skipped), plan.MissingOIDCount, plan.UnmatchedOIDCount, plan.AlreadyRealFeeCount)
 	fmt.Printf("  fee delta (sum):     $%+.4f (positive = fees were over-modeled)\n", plan.TotalFeeDeltaUSD)
 	fmt.Printf("  pnl delta (sum):     $%+.4f\n", plan.TotalPnLDeltaUSD)
 	fmt.Printf("  cash:                $%.4f → $%.4f (Δ %+.4f)\n",
 		plan.OldCash, plan.NewCash, plan.NewCash-plan.OldCash)
 	fmt.Printf("  closed_positions:    %d aggregate rows to update\n", len(plan.ClosedPositions))
+	if plan.CashBaselineDivergent {
+		fmt.Printf("  WARNING: cash baseline diverges from pre-correction replay by $%+.4f\n",
+			plan.OldCash-plan.ReplayedCash)
+		fmt.Printf("           (replayed=$%.4f vs stored=$%.4f). Likely SIGHUP capital top-up\n",
+			plan.ReplayedCash, plan.OldCash)
+		fmt.Printf("           — SIGHUP applies Cash += new - old with no trade row, which a\n")
+		fmt.Printf("           forward replay cannot reproduce. --apply requires --reset-cash.\n")
+	}
+}
+
+// refuseIfSchedulerRunning aborts when another `go-trader` process is alive.
+//
+// The backfill rewrites `strategies.cash` directly. SQLite's WAL journal lets
+// the running scheduler keep its own write connection open in parallel, so the
+// next SaveState in that scheduler will overwrite the recomputed cash with
+// whatever value its in-memory `AppState` holds — silently undoing the
+// backfill. Detect a peer process via `pgrep` and refuse with an actionable
+// error before the operator commits.
+func refuseIfSchedulerRunning() error {
+	out, err := exec.Command("pgrep", "-x", "go-trader").Output()
+	if err != nil {
+		// pgrep exits 1 when no match — that's the success path here. Any
+		// other error means pgrep itself failed (missing binary, etc.); skip
+		// the check rather than blocking apply on operator tooling.
+		return nil
+	}
+	self := os.Getpid()
+	var others []int
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var pid int
+		if _, perr := fmt.Sscanf(line, "%d", &pid); perr != nil {
+			continue
+		}
+		if pid == self {
+			continue
+		}
+		others = append(others, pid)
+	}
+	if len(others) == 0 {
+		return nil
+	}
+	return fmt.Errorf("another go-trader process is running (pid %v); stop it before running --apply (concurrent SaveState would overwrite the recomputed strategies.cash)", others)
 }
 
 // runFetchHLUserFills spawns shared_scripts/fetch_hl_user_fills.py with a

--- a/scheduler/backfill_hl_fees_test.go
+++ b/scheduler/backfill_hl_fees_test.go
@@ -295,15 +295,16 @@ func TestApplyBackfillPlanRoundTrip(t *testing.T) {
 	}
 
 	plan := planBackfillForStrategy("hl-eth-live", trades, fillMap, 1000.0, 999.65)
+	changeByRowID := make(map[int64]TradeChange, len(plan.TradeChanges))
+	for _, c := range plan.TradeChanges {
+		changeByRowID[c.RowID] = c
+	}
 	correctedTrades := make([]TradeBackfillRow, 0, len(trades))
 	for _, tr := range trades {
 		row := tr
-		for _, c := range plan.TradeChanges {
-			if c.RowID == tr.RowID {
-				row.ExchangeFee = c.NewFee
-				row.RealizedPnL = c.NewRealizedPnL
-				break
-			}
+		if c, ok := changeByRowID[tr.RowID]; ok {
+			row.ExchangeFee = c.NewFee
+			row.RealizedPnL = c.NewRealizedPnL
 		}
 		correctedTrades = append(correctedTrades, row)
 	}
@@ -379,5 +380,108 @@ func TestPlanClosedPositionRecomputesAggregatesPartialCloses(t *testing.T) {
 	}
 	if !approxEq(out[0].NewPnL, 9.6) {
 		t.Fatalf("NewPnL=%v want 9.6 (sum of partial closes)", out[0].NewPnL)
+	}
+}
+
+// TestPlanBackfillAlreadyRealFeeCount: post-#587 rows with non-zero
+// exchange_fee bump AlreadyRealFeeCount so the report's skip breakdown adds up.
+func TestPlanBackfillAlreadyRealFeeCount(t *testing.T) {
+	trades := []TradeBackfillRow{
+		{RowID: 1, Timestamp: ts(100), Symbol: "ETH", Value: 1000,
+			IsClose: false, ExchangeOrderID: "111", ExchangeFee: 0.32},
+		{RowID: 2, Timestamp: ts(200), Symbol: "ETH", Value: 1000,
+			IsClose: false, ExchangeOrderID: "222", ExchangeFee: 0.40},
+	}
+	fillMap := map[string]HLFillSummary{
+		"111": {Fee: 0.30},
+		"222": {Fee: 0.45},
+	}
+	plan := planBackfillForStrategy("hl-eth", trades, fillMap, 1000.0, 999.28)
+	if plan.AlreadyRealFeeCount != 2 {
+		t.Fatalf("AlreadyRealFeeCount=%d want 2", plan.AlreadyRealFeeCount)
+	}
+	if got := plan.MissingOIDCount + plan.UnmatchedOIDCount + plan.AlreadyRealFeeCount; got != len(plan.Skipped) {
+		t.Fatalf("skip breakdown does not add up: missing=%d + unmatched=%d + already=%d != len(Skipped)=%d",
+			plan.MissingOIDCount, plan.UnmatchedOIDCount, plan.AlreadyRealFeeCount, len(plan.Skipped))
+	}
+}
+
+// TestPlanBackfillCashBaselineDivergent flags a strategy whose stored
+// strategies.cash diverges from the pre-correction replay (modeled-fee
+// fallback) by more than $1 — typically a SIGHUP capital top-up that didn't
+// emit a trade row. Forward-replay-from-initial-capital cannot reproduce that
+// mutation, so --apply must require --reset-cash to acknowledge the loss.
+func TestPlanBackfillCashBaselineDivergent(t *testing.T) {
+	trades := []TradeBackfillRow{
+		{RowID: 1, Timestamp: ts(100), Symbol: "ETH", Value: 1000,
+			IsClose: false, ExchangeOrderID: "111", ExchangeFee: 0},
+	}
+	// Stored cash is 1500 — way above what initial_capital(1000) - modeledFee
+	// (~0.35) would predict. Operator must have raised capital mid-run.
+	plan := planBackfillForStrategy("hl-eth", trades, map[string]HLFillSummary{}, 1000.0, 1500.0)
+	if !plan.CashBaselineDivergent {
+		t.Fatalf("expected CashBaselineDivergent=true (replayed=%v vs old=%v)",
+			plan.ReplayedCash, plan.OldCash)
+	}
+	expectedReplay := 1000.0 - 1000*HyperliquidTakerFeePct
+	if !approxEq(plan.ReplayedCash, expectedReplay) {
+		t.Fatalf("ReplayedCash=%v want %v", plan.ReplayedCash, expectedReplay)
+	}
+}
+
+// TestPlanBackfillCashBaselineWithinTolerance: a row whose stored cash is
+// within $1 of the pre-correction replay should NOT trip the divergence flag
+// (e.g. tiny fee-rounding skew should not gate --apply).
+func TestPlanBackfillCashBaselineWithinTolerance(t *testing.T) {
+	trades := []TradeBackfillRow{
+		{RowID: 1, Timestamp: ts(100), Symbol: "ETH", Value: 1000,
+			IsClose: false, ExchangeOrderID: "111", ExchangeFee: 0},
+	}
+	// Cash sits within $1 of (1000 - modeled_fee).
+	plan := planBackfillForStrategy("hl-eth", trades, map[string]HLFillSummary{}, 1000.0, 999.65)
+	if plan.CashBaselineDivergent {
+		t.Fatalf("did not expect divergence (replayed=%v old=%v)",
+			plan.ReplayedCash, plan.OldCash)
+	}
+}
+
+// TestPlanClosedPositionRecomputesRejectsAmbiguousFallback: when the exact-ns
+// match misses and two close legs sit within the 5s tolerance window on the
+// same symbol, the row stays unmatched rather than picking the nearest leg —
+// a partial-then-final close back-to-back must not silently land on the wrong
+// position_id.
+func TestPlanClosedPositionRecomputesRejectsAmbiguousFallback(t *testing.T) {
+	corrected := []TradeBackfillRow{
+		{RowID: 1, Timestamp: ts(101), Symbol: "ETH", PositionID: "pA",
+			IsClose: true, RealizedPnL: 5.0},
+		{RowID: 2, Timestamp: ts(103), Symbol: "ETH", PositionID: "pB",
+			IsClose: true, RealizedPnL: 7.0},
+	}
+	// closed_positions row at ts(100): exact match misses; both close legs
+	// fall within the 5s window. Old code would pick pA; tightened code
+	// refuses to guess.
+	closedRows := []ClosedPositionRow{
+		{ID: 11, Symbol: "ETH", ClosedAt: ts(100), RealizedPnL: 4.9},
+	}
+	out := planClosedPositionRecomputes(corrected, closedRows)
+	if len(out) != 0 {
+		t.Fatalf("expected 0 recomputes (ambiguous match), got %d (%+v)", len(out), out)
+	}
+}
+
+// TestPlanClosedPositionRecomputesRejectsBackwardFallback: when the only
+// candidate leg lands BEFORE the closed_positions row, refuse to match —
+// close legs are written before/with their closed_positions row, never after.
+func TestPlanClosedPositionRecomputesRejectsBackwardFallback(t *testing.T) {
+	corrected := []TradeBackfillRow{
+		{RowID: 1, Timestamp: ts(95), Symbol: "ETH", PositionID: "pA",
+			IsClose: true, RealizedPnL: 5.0},
+	}
+	closedRows := []ClosedPositionRow{
+		{ID: 11, Symbol: "ETH", ClosedAt: ts(100), RealizedPnL: 4.9},
+	}
+	out := planClosedPositionRecomputes(corrected, closedRows)
+	if len(out) != 0 {
+		t.Fatalf("expected 0 recomputes (backward leg), got %d (%+v)", len(out), out)
 	}
 }

--- a/scheduler/backfill_hl_fees_test.go
+++ b/scheduler/backfill_hl_fees_test.go
@@ -1,0 +1,383 @@
+package main
+
+import (
+	"math"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func ts(unixSec int64) time.Time {
+	return time.Unix(unixSec, 0).UTC()
+}
+
+func approxEq(a, b float64) bool {
+	return math.Abs(a-b) < 1e-6
+}
+
+// TestPlanBackfillRewritesFeeAndPnLOnCloseLeg verifies the core correction
+// math: a close leg with a real fee that differs from the modeled fee gets
+// realized_pnl adjusted by (modeledFee - realFee), and the row's exchange_fee
+// is rewritten to the real value.
+func TestPlanBackfillRewritesFeeAndPnLOnCloseLeg(t *testing.T) {
+	openValue := 1000.0
+	closeValue := 1010.0
+	modeledCloseFee := closeValue * HyperliquidTakerFeePct // 0.3535
+	// realized_pnl as written at execution time: pnl_pre_fee - modeledFee.
+	// long position: closeValue - openValue = 10; minus modeledCloseFee.
+	storedRealizedPnL := 10.0 - modeledCloseFee
+
+	trades := []TradeBackfillRow{
+		{RowID: 1, Timestamp: ts(100), Symbol: "ETH", PositionID: "p1", Value: openValue,
+			IsClose: false, ExchangeOrderID: "111", ExchangeFee: 0, RealizedPnL: 0},
+		{RowID: 2, Timestamp: ts(200), Symbol: "ETH", PositionID: "p1", Value: closeValue,
+			IsClose: true, ExchangeOrderID: "222", ExchangeFee: 0, RealizedPnL: storedRealizedPnL},
+	}
+	realOpenFee := 0.40  // higher than modeled
+	realCloseFee := 0.30 // lower than modeled
+	fillMap := map[string]HLFillSummary{
+		"111": {Fee: realOpenFee, ClosedPnL: 0, Count: 1},
+		"222": {Fee: realCloseFee, ClosedPnL: 9.7, Count: 1},
+	}
+
+	plan := planBackfillForStrategy("hl-eth", trades, fillMap, 1000.0, 1000.0)
+
+	if got, want := len(plan.TradeChanges), 2; got != want {
+		t.Fatalf("expected %d trade changes, got %d", want, got)
+	}
+	if plan.MissingOIDCount != 0 || plan.UnmatchedOIDCount != 0 {
+		t.Fatalf("unexpected skips: missing=%d unmatched=%d", plan.MissingOIDCount, plan.UnmatchedOIDCount)
+	}
+
+	openChange := plan.TradeChanges[0]
+	if !approxEq(openChange.NewFee, realOpenFee) {
+		t.Fatalf("open: NewFee=%v want %v", openChange.NewFee, realOpenFee)
+	}
+	if !approxEq(openChange.NewRealizedPnL, 0) {
+		t.Fatalf("open: NewRealizedPnL should stay 0 (open leg), got %v", openChange.NewRealizedPnL)
+	}
+
+	closeChange := plan.TradeChanges[1]
+	if !approxEq(closeChange.NewFee, realCloseFee) {
+		t.Fatalf("close: NewFee=%v want %v", closeChange.NewFee, realCloseFee)
+	}
+	expectedNewPnL := storedRealizedPnL + (modeledCloseFee - realCloseFee)
+	if !approxEq(closeChange.NewRealizedPnL, expectedNewPnL) {
+		t.Fatalf("close: NewRealizedPnL=%v want %v (stored %v + modeled %v - real %v)",
+			closeChange.NewRealizedPnL, expectedNewPnL, storedRealizedPnL, modeledCloseFee, realCloseFee)
+	}
+}
+
+// TestPlanBackfillCashReplay verifies the cash recompute walks trades in
+// chronological order: open fee debit (real) + close pnl credit (corrected).
+func TestPlanBackfillCashReplay(t *testing.T) {
+	trades := []TradeBackfillRow{
+		{RowID: 1, Timestamp: ts(100), Symbol: "ETH", PositionID: "p1", Value: 1000,
+			IsClose: false, ExchangeOrderID: "111", ExchangeFee: 0},
+		{RowID: 2, Timestamp: ts(200), Symbol: "ETH", PositionID: "p1", Value: 1010,
+			IsClose: true, ExchangeOrderID: "222", ExchangeFee: 0,
+			RealizedPnL: 10.0 - 1010*HyperliquidTakerFeePct},
+	}
+	fillMap := map[string]HLFillSummary{
+		"111": {Fee: 0.5},
+		"222": {Fee: 0.4},
+	}
+
+	plan := planBackfillForStrategy("hl-eth", trades, fillMap, 1000.0, 999.0)
+
+	// Expected cash:
+	//   start = 1000
+	//   - real open fee 0.5 = 999.5
+	//   + corrected close pnl: 10 - 0.4 = 9.6 → 1009.1
+	expectedCash := 1000.0 - 0.5 + (10.0 - 0.4)
+	if !approxEq(plan.NewCash, expectedCash) {
+		t.Fatalf("NewCash=%v want %v", plan.NewCash, expectedCash)
+	}
+	if plan.OldCash != 999.0 {
+		t.Fatalf("OldCash should be passed through, got %v", plan.OldCash)
+	}
+}
+
+// TestPlanBackfillSkipsAlreadyRealFee guards against double-corrected rows:
+// if exchange_fee != 0, the row was written by post-#587 code and must NOT
+// be touched.
+func TestPlanBackfillSkipsAlreadyRealFee(t *testing.T) {
+	trades := []TradeBackfillRow{
+		{RowID: 1, Timestamp: ts(100), Symbol: "ETH", Value: 1000,
+			IsClose: false, ExchangeOrderID: "111", ExchangeFee: 0.32, RealizedPnL: 0},
+	}
+	fillMap := map[string]HLFillSummary{
+		"111": {Fee: 0.40},
+	}
+	plan := planBackfillForStrategy("hl-eth", trades, fillMap, 1000.0, 999.68)
+	if len(plan.TradeChanges) != 0 {
+		t.Fatalf("expected 0 trade changes (already-real guard), got %d", len(plan.TradeChanges))
+	}
+	skipped := false
+	for _, s := range plan.Skipped {
+		if s.Reason == "already_real_fee" {
+			skipped = true
+		}
+	}
+	if !skipped {
+		t.Fatalf("expected an already_real_fee skip entry, got %+v", plan.Skipped)
+	}
+}
+
+// TestPlanBackfillMissingOID covers pre-#453/#461 rows with empty
+// exchange_order_id: they're skipped (can't match) and the cash replay falls
+// back to the modeled fee for them.
+func TestPlanBackfillMissingOID(t *testing.T) {
+	trades := []TradeBackfillRow{
+		{RowID: 1, Timestamp: ts(100), Symbol: "ETH", Value: 1000,
+			IsClose: false, ExchangeOrderID: "", ExchangeFee: 0},
+	}
+	fillMap := map[string]HLFillSummary{}
+	plan := planBackfillForStrategy("hl-eth", trades, fillMap, 1000.0, 999.65)
+	if len(plan.TradeChanges) != 0 {
+		t.Fatalf("expected no trade changes for missing-OID row, got %d", len(plan.TradeChanges))
+	}
+	if plan.MissingOIDCount != 1 {
+		t.Fatalf("MissingOIDCount=%d want 1", plan.MissingOIDCount)
+	}
+	// Cash replay falls back to modeled fee.
+	expectedCash := 1000.0 - 1000*HyperliquidTakerFeePct
+	if !approxEq(plan.NewCash, expectedCash) {
+		t.Fatalf("NewCash=%v want %v (modeled fee fallback)", plan.NewCash, expectedCash)
+	}
+}
+
+// TestPlanBackfillUnmatchedOID: row has an OID but HL didn't return a fill
+// for it (e.g. fill predates the userFills query window). Skip + fall back
+// to modeled fee in the cash replay.
+func TestPlanBackfillUnmatchedOID(t *testing.T) {
+	trades := []TradeBackfillRow{
+		{RowID: 1, Timestamp: ts(100), Symbol: "ETH", Value: 1000,
+			IsClose: false, ExchangeOrderID: "999", ExchangeFee: 0},
+	}
+	fillMap := map[string]HLFillSummary{
+		"111": {Fee: 0.4},
+	}
+	plan := planBackfillForStrategy("hl-eth", trades, fillMap, 1000.0, 999.65)
+	if plan.UnmatchedOIDCount != 1 {
+		t.Fatalf("UnmatchedOIDCount=%d want 1", plan.UnmatchedOIDCount)
+	}
+	expectedCash := 1000.0 - 1000*HyperliquidTakerFeePct
+	if !approxEq(plan.NewCash, expectedCash) {
+		t.Fatalf("NewCash=%v want %v", plan.NewCash, expectedCash)
+	}
+}
+
+// TestPlanClosedPositionRecomputesMatchByTimestamp verifies the closed_positions
+// pass: each closed_positions row matches the corrected close-leg trade with
+// the same (symbol, closed_at == trade.timestamp), then reads its position_id
+// and emits the new aggregate.
+func TestPlanClosedPositionRecomputesMatchByTimestamp(t *testing.T) {
+	corrected := []TradeBackfillRow{
+		{RowID: 1, Timestamp: ts(100), Symbol: "ETH", PositionID: "p1",
+			IsClose: false, RealizedPnL: 0},
+		{RowID: 2, Timestamp: ts(200), Symbol: "ETH", PositionID: "p1",
+			IsClose: true, RealizedPnL: 9.6},
+	}
+	closedRows := []ClosedPositionRow{
+		{ID: 11, Symbol: "ETH", ClosedAt: ts(200), RealizedPnL: 9.65},
+	}
+	out := planClosedPositionRecomputes(corrected, closedRows)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 recompute, got %d (%+v)", len(out), out)
+	}
+	if out[0].RowID != 11 {
+		t.Fatalf("RowID=%d want 11", out[0].RowID)
+	}
+	if !approxEq(out[0].NewPnL, 9.6) {
+		t.Fatalf("NewPnL=%v want 9.6", out[0].NewPnL)
+	}
+	if out[0].PositionID != "p1" {
+		t.Fatalf("PositionID=%q want p1", out[0].PositionID)
+	}
+}
+
+// TestPlanClosedPositionRecomputesSkipsBelowTolerance: when corrected
+// realized_pnl matches the stored value within 0.001 USD, no recompute is
+// emitted (avoid floating-point noise rewrites).
+func TestPlanClosedPositionRecomputesSkipsBelowTolerance(t *testing.T) {
+	corrected := []TradeBackfillRow{
+		{RowID: 1, Timestamp: ts(100), Symbol: "ETH", PositionID: "p1",
+			IsClose: true, RealizedPnL: 9.6500001},
+	}
+	closedRows := []ClosedPositionRow{
+		{ID: 11, Symbol: "ETH", ClosedAt: ts(100), RealizedPnL: 9.65},
+	}
+	out := planClosedPositionRecomputes(corrected, closedRows)
+	if len(out) != 0 {
+		t.Fatalf("expected 0 recomputes (tolerance), got %d", len(out))
+	}
+}
+
+// TestApplyBackfillPlanRoundTrip seeds a fresh SQLite, runs the planner end
+// to end against a synthetic fill map, applies, and reads back to confirm
+// the trade rows, closed_positions, and strategies.cash were rewritten as
+// the planner promised.
+func TestApplyBackfillPlanRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "state.db")
+	db, err := OpenStateDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Seed: one strategy with one round trip — open + close legs that have
+	// modeled fees written to realized_pnl but exchange_fee=0.
+	openTs := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	closeTs := openTs.Add(2 * time.Hour)
+	closeValue := 1010.0
+	modeledCloseFee := closeValue * HyperliquidTakerFeePct
+
+	state := &AppState{
+		CycleCount: 1,
+		Strategies: map[string]*StrategyState{
+			"hl-eth-live": {
+				ID: "hl-eth-live", Type: "perps", Platform: "hyperliquid",
+				Cash: 999.65, InitialCapital: 1000,
+				Positions: make(map[string]*Position), OptionPositions: make(map[string]*OptionPosition),
+				ClosedPositions: []ClosedPosition{
+					{StrategyID: "hl-eth-live", Symbol: "ETH", Quantity: 0.1, AvgCost: 10000,
+						Side: "long", Multiplier: 1, OpenedAt: openTs, ClosedAt: closeTs,
+						ClosePrice: 10100, RealizedPnL: 10.0 - modeledCloseFee, CloseReason: "manual_close"},
+				},
+			},
+		},
+	}
+	if err := db.SaveState(state); err != nil {
+		t.Fatal(err)
+	}
+
+	openTrade := Trade{
+		Timestamp: openTs, StrategyID: "hl-eth-live", Symbol: "ETH",
+		PositionID: "p1", Side: "buy", Quantity: 0.1, Price: 10000, Value: 1000,
+		TradeType: "perps", Details: "open", ExchangeOrderID: "111", ExchangeFee: 0,
+	}
+	closeTrade := Trade{
+		Timestamp: closeTs, StrategyID: "hl-eth-live", Symbol: "ETH",
+		PositionID: "p1", Side: "sell", Quantity: 0.1, Price: 10100, Value: 1010,
+		TradeType: "perps", Details: "close", ExchangeOrderID: "222", ExchangeFee: 0,
+		IsClose: true, RealizedPnL: 10.0 - modeledCloseFee,
+	}
+	if err := db.InsertTrade("hl-eth-live", openTrade); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.InsertTrade("hl-eth-live", closeTrade); err != nil {
+		t.Fatal(err)
+	}
+
+	// Real fees from the exchange (close fee was overstated by the model).
+	realOpenFee := 0.40
+	realCloseFee := 0.30
+	fillMap := map[string]HLFillSummary{
+		"111": {Fee: realOpenFee, Count: 1},
+		"222": {Fee: realCloseFee, Count: 1},
+	}
+
+	trades, err := db.ListTradesForBackfill("hl-eth-live")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(trades) != 2 {
+		t.Fatalf("ListTradesForBackfill returned %d rows, want 2", len(trades))
+	}
+	closedRows, err := db.LoadClosedPositionRows("hl-eth-live")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(closedRows) != 1 {
+		t.Fatalf("LoadClosedPositionRows returned %d rows, want 1", len(closedRows))
+	}
+
+	plan := planBackfillForStrategy("hl-eth-live", trades, fillMap, 1000.0, 999.65)
+	correctedTrades := make([]TradeBackfillRow, 0, len(trades))
+	for _, tr := range trades {
+		row := tr
+		for _, c := range plan.TradeChanges {
+			if c.RowID == tr.RowID {
+				row.ExchangeFee = c.NewFee
+				row.RealizedPnL = c.NewRealizedPnL
+				break
+			}
+		}
+		correctedTrades = append(correctedTrades, row)
+	}
+	plan.ClosedPositions = planClosedPositionRecomputes(correctedTrades, closedRows)
+
+	if err := db.ApplyBackfillPlan(plan); err != nil {
+		t.Fatalf("ApplyBackfillPlan failed: %v", err)
+	}
+
+	// Verify trades.exchange_fee + realized_pnl rewritten.
+	post, err := db.ListTradesForBackfill("hl-eth-live")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tr := range post {
+		if tr.IsClose {
+			if !approxEq(tr.ExchangeFee, realCloseFee) {
+				t.Errorf("close exchange_fee=%v want %v", tr.ExchangeFee, realCloseFee)
+			}
+			expectedPnL := (10.0 - modeledCloseFee) + (modeledCloseFee - realCloseFee)
+			if !approxEq(tr.RealizedPnL, expectedPnL) {
+				t.Errorf("close realized_pnl=%v want %v", tr.RealizedPnL, expectedPnL)
+			}
+		} else {
+			if !approxEq(tr.ExchangeFee, realOpenFee) {
+				t.Errorf("open exchange_fee=%v want %v", tr.ExchangeFee, realOpenFee)
+			}
+		}
+	}
+
+	// Verify closed_positions.realized_pnl rewritten.
+	postCP, err := db.LoadClosedPositionRows("hl-eth-live")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedCPPnL := (10.0 - modeledCloseFee) + (modeledCloseFee - realCloseFee)
+	if !approxEq(postCP[0].RealizedPnL, expectedCPPnL) {
+		t.Errorf("closed_positions realized_pnl=%v want %v", postCP[0].RealizedPnL, expectedCPPnL)
+	}
+
+	// Verify strategies.cash rewritten to plan.NewCash.
+	cfg := &Config{DBFile: dbPath}
+	loaded, err := LoadStateWithDB(cfg, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss := loaded.Strategies["hl-eth-live"]
+	if ss == nil {
+		t.Fatal("strategy not loaded")
+	}
+	expectedCash := 1000.0 - realOpenFee + (10.0 - realCloseFee)
+	if !approxEq(ss.Cash, expectedCash) {
+		t.Errorf("strategies.cash=%v want %v", ss.Cash, expectedCash)
+	}
+}
+
+// TestPlanClosedPositionRecomputesAggregatesPartialCloses: a single
+// closed_positions row whose position_id has multiple corrected close legs
+// gets the sum.
+func TestPlanClosedPositionRecomputesAggregatesPartialCloses(t *testing.T) {
+	corrected := []TradeBackfillRow{
+		{RowID: 1, Timestamp: ts(100), Symbol: "ETH", PositionID: "p1",
+			IsClose: true, RealizedPnL: 5.0},
+		{RowID: 2, Timestamp: ts(200), Symbol: "ETH", PositionID: "p1",
+			IsClose: true, RealizedPnL: 4.6}, // final close
+	}
+	closedRows := []ClosedPositionRow{
+		{ID: 11, Symbol: "ETH", ClosedAt: ts(200), RealizedPnL: 9.65},
+	}
+	out := planClosedPositionRecomputes(corrected, closedRows)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 recompute, got %d", len(out))
+	}
+	if !approxEq(out[0].NewPnL, 9.6) {
+		t.Fatalf("NewPnL=%v want 9.6 (sum of partial closes)", out[0].NewPnL)
+	}
+}

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -1503,6 +1503,162 @@ func (sdb *StateDB) DeletePendingManualActionsThrough(maxID int64) error {
 	return err
 }
 
+// EarliestTradeTimestamp returns the oldest trade timestamp across the given
+// strategy IDs, or zero time when none exist. Used by `go-trader backfill
+// hl-fees` to set the lower bound on the userFills query.
+func (sdb *StateDB) EarliestTradeTimestamp(strategyIDs []string) (time.Time, error) {
+	if sdb == nil || sdb.db == nil {
+		return time.Time{}, fmt.Errorf("state db unavailable")
+	}
+	if len(strategyIDs) == 0 {
+		return time.Time{}, nil
+	}
+	placeholders := make([]string, len(strategyIDs))
+	args := make([]interface{}, len(strategyIDs))
+	for i, id := range strategyIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	query := fmt.Sprintf(
+		"SELECT MIN(timestamp) FROM trades WHERE strategy_id IN (%s) AND timestamp != ''",
+		strings.Join(placeholders, ","),
+	)
+	var ts sql.NullString
+	if err := sdb.db.QueryRow(query, args...).Scan(&ts); err != nil {
+		return time.Time{}, fmt.Errorf("earliest trade timestamp: %w", err)
+	}
+	if !ts.Valid || ts.String == "" {
+		return time.Time{}, nil
+	}
+	return parseTime(ts.String), nil
+}
+
+// ListTradesForBackfill returns the trade rows for one strategy that the
+// backfill planner needs (rowid + the columns it reads/rewrites). Ordered by
+// timestamp ascending so the cash replay runs in the same order as the live
+// fills did.
+func (sdb *StateDB) ListTradesForBackfill(strategyID string) ([]TradeBackfillRow, error) {
+	if sdb == nil || sdb.db == nil {
+		return nil, fmt.Errorf("state db unavailable")
+	}
+	rows, err := sdb.db.Query(`
+		SELECT rowid, timestamp, symbol, COALESCE(position_id, '') AS position_id,
+		       value, is_close, exchange_order_id, exchange_fee, realized_pnl
+		FROM trades
+		WHERE strategy_id = ?
+		ORDER BY timestamp ASC, rowid ASC`, strategyID)
+	if err != nil {
+		return nil, fmt.Errorf("list trades for backfill: %w", err)
+	}
+	defer rows.Close()
+	var out []TradeBackfillRow
+	for rows.Next() {
+		var t TradeBackfillRow
+		var tsStr string
+		var isCloseInt int
+		if err := rows.Scan(&t.RowID, &tsStr, &t.Symbol, &t.PositionID, &t.Value, &isCloseInt,
+			&t.ExchangeOrderID, &t.ExchangeFee, &t.RealizedPnL); err != nil {
+			return nil, fmt.Errorf("scan trade: %w", err)
+		}
+		t.Timestamp = parseTime(tsStr)
+		t.IsClose = isCloseInt != 0
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// ClosedPositionRow captures the closed_positions columns the backfill needs
+// to match its rows back to a position_id (which closed_positions itself does
+// not store yet — only trades does, since #471).
+type ClosedPositionRow struct {
+	ID          int64
+	Symbol      string
+	ClosedAt    time.Time
+	RealizedPnL float64
+}
+
+// LoadClosedPositionRows returns the closed_positions rows for one strategy
+// in close-time order. The backfill matches each row to a close-leg trade row
+// (same symbol + matching timestamp) to recover the position_id grouping
+// since closed_positions has no position_id column of its own.
+func (sdb *StateDB) LoadClosedPositionRows(strategyID string) ([]ClosedPositionRow, error) {
+	if sdb == nil || sdb.db == nil {
+		return nil, fmt.Errorf("state db unavailable")
+	}
+	rows, err := sdb.db.Query(`
+		SELECT id, symbol, closed_at, realized_pnl
+		FROM closed_positions
+		WHERE strategy_id = ?
+		ORDER BY closed_at ASC, id ASC`, strategyID)
+	if err != nil {
+		return nil, fmt.Errorf("load closed_positions: %w", err)
+	}
+	defer rows.Close()
+	var out []ClosedPositionRow
+	for rows.Next() {
+		var r ClosedPositionRow
+		var tsStr string
+		if err := rows.Scan(&r.ID, &r.Symbol, &tsStr, &r.RealizedPnL); err != nil {
+			return nil, fmt.Errorf("scan closed_positions row: %w", err)
+		}
+		r.ClosedAt = parseTime(tsStr)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ApplyBackfillPlan writes the planner's changes to disk inside one
+// transaction: trade row updates, closed_positions PnL recompute, and the
+// strategies.cash baseline. Caller is responsible for ensuring no scheduler
+// is concurrently issuing SaveState — SQLite serializes writers so the
+// transaction itself is safe, but a SaveState fired right after a successful
+// commit will overwrite the recomputed cash with whatever value its
+// in-memory AppState held.
+func (sdb *StateDB) ApplyBackfillPlan(plan BackfillPlan) error {
+	if sdb == nil || sdb.db == nil {
+		return fmt.Errorf("state db unavailable")
+	}
+	tx, err := sdb.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	tradeStmt, err := tx.Prepare(
+		"UPDATE trades SET exchange_fee = ?, realized_pnl = ? WHERE rowid = ?",
+	)
+	if err != nil {
+		return fmt.Errorf("prepare trade update: %w", err)
+	}
+	defer tradeStmt.Close()
+	for _, c := range plan.TradeChanges {
+		if _, err := tradeStmt.Exec(c.NewFee, c.NewRealizedPnL, c.RowID); err != nil {
+			return fmt.Errorf("update trade rowid=%d: %w", c.RowID, err)
+		}
+	}
+
+	// closed_positions are pinned by rowid (planner resolved each one back
+	// to a position_id via close-leg trade timestamps).
+	cpStmt, err := tx.Prepare(
+		"UPDATE closed_positions SET realized_pnl = ? WHERE id = ? AND strategy_id = ?",
+	)
+	if err != nil {
+		return fmt.Errorf("prepare closed_positions update: %w", err)
+	}
+	defer cpStmt.Close()
+	for _, cp := range plan.ClosedPositions {
+		if _, err := cpStmt.Exec(cp.NewPnL, cp.RowID, plan.StrategyID); err != nil {
+			return fmt.Errorf("update closed_positions id=%d: %w", cp.RowID, err)
+		}
+	}
+
+	if _, err := tx.Exec("UPDATE strategies SET cash = ? WHERE id = ?", plan.NewCash, plan.StrategyID); err != nil {
+		return fmt.Errorf("update strategy cash: %w", err)
+	}
+
+	return tx.Commit()
+}
+
 // formatTime converts a time.Time to RFC 3339 string, or "" for zero time.
 func formatTime(t time.Time) string {
 	if t.IsZero() {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -24,6 +24,8 @@ func main() {
 			os.Exit(runManualOpen(os.Args[2:]))
 		case "manual-close":
 			os.Exit(runManualClose(os.Args[2:]))
+		case "backfill":
+			os.Exit(runBackfill(os.Args[2:]))
 		}
 	}
 

--- a/shared_scripts/fetch_hl_user_fills.py
+++ b/shared_scripts/fetch_hl_user_fills.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Page through Hyperliquid userFills history and emit an OID-keyed map of real
+exchange fees and closed PnL.
+
+Used by `go-trader backfill hl-fees` (issue #589) to replay live fills against
+the trades table and rewrite `exchange_fee` / `realized_pnl` for rows that were
+written before #587 — when HL's order placement response did not surface the
+real fee.
+
+Args:
+    --since-ms <int>: lower bound (ms epoch) for the userFills query
+    [--end-ms <int>]: upper bound (defaults to "now")
+
+Stdout (always JSON):
+    {
+        "by_oid": {"<oid>": {"fee": float, "closed_pnl": float, "count": int}, ...},
+        "fill_count": int,
+        "page_count": int,
+        "account_address": "0x...",
+        "error": ""
+    }
+
+Exits 1 on error (stdout still contains a JSON envelope with "error" set).
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import traceback
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "platforms", "hyperliquid"))
+
+
+# HL's user_fills_by_time returns at most ~2000 rows per call; we page forward
+# from the last fill's `time` field. PAGE_LIMIT_HARD caps total requests so a
+# pathological response (e.g. a stuck cursor) can't loop forever.
+PAGE_LIMIT_HARD = 200
+
+
+def _safe_int(v):
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _safe_float(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _emit(payload: dict, exit_code: int = 0):
+    print(json.dumps(payload))
+    sys.exit(exit_code)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--since-ms", type=int, required=True)
+    parser.add_argument("--end-ms", type=int, default=0,
+                        help="upper bound (ms epoch); defaults to now")
+    args = parser.parse_args()
+
+    since_ms = args.since_ms
+    end_ms = args.end_ms or int(time.time() * 1000)
+
+    if since_ms <= 0:
+        _emit({
+            "by_oid": {},
+            "fill_count": 0,
+            "page_count": 0,
+            "account_address": "",
+            "error": "--since-ms must be > 0",
+        }, exit_code=1)
+
+    try:
+        from adapter import HyperliquidExchangeAdapter
+        adapter = HyperliquidExchangeAdapter()
+    except Exception as e:
+        traceback.print_exc(file=sys.stderr)
+        _emit({
+            "by_oid": {},
+            "fill_count": 0,
+            "page_count": 0,
+            "account_address": "",
+            "error": f"failed to init HL adapter: {e}",
+        }, exit_code=1)
+
+    addr = adapter._account_address
+    if not addr:
+        _emit({
+            "by_oid": {},
+            "fill_count": 0,
+            "page_count": 0,
+            "account_address": "",
+            "error": "HYPERLIQUID_ACCOUNT_ADDRESS not set (and no HYPERLIQUID_SECRET_KEY to derive it)",
+        }, exit_code=1)
+
+    # Aggregate across pages: a single market order can fragment into multiple
+    # partial fills, all sharing the same OID — sum fee + closedPnl across
+    # those rows so the OID-keyed map gives the true total.
+    by_oid: dict = {}
+    fill_count = 0
+    page_count = 0
+    cursor_ms = since_ms
+    seen_first_ts_at_cursor = set()
+
+    while page_count < PAGE_LIMIT_HARD:
+        page_count += 1
+        try:
+            page = adapter._info.user_fills_by_time(addr, cursor_ms, end_ms)
+        except Exception as e:
+            traceback.print_exc(file=sys.stderr)
+            _emit({
+                "by_oid": by_oid,
+                "fill_count": fill_count,
+                "page_count": page_count,
+                "account_address": addr,
+                "error": f"user_fills_by_time failed at page {page_count}: {e}",
+            }, exit_code=1)
+
+        if not isinstance(page, list) or not page:
+            break
+
+        # Track which fills we already consumed at the exact cursor_ms
+        # boundary so a partial fill landing on the same ms as the cursor
+        # isn't double counted on the next loop (HL's API is inclusive on
+        # the lower bound). When we advance the cursor below, we re-seed
+        # this set with the rows from this page that landed exactly on the
+        # new cursor — those will reappear in the next response and need
+        # to be skipped.
+        next_cursor = cursor_ms
+        new_in_page = 0
+        page_rows = []  # parsed (ts, dedup_key) pairs for boundary re-seeding
+
+        for f in page:
+            if not isinstance(f, dict):
+                continue
+            oid = _safe_int(f.get("oid"))
+            ts = _safe_int(f.get("time"))
+            tid = f.get("tid")
+            # Dedup key — within one ms bucket, HL's tid (trade id) uniquely
+            # identifies a leg; fall back to (oid, sz, px) when tid is absent.
+            dedup_key = (ts, oid, tid if tid is not None else (
+                _safe_float(f.get("sz")), _safe_float(f.get("px"))))
+            if ts == cursor_ms and dedup_key in seen_first_ts_at_cursor:
+                continue
+            if ts == cursor_ms:
+                seen_first_ts_at_cursor.add(dedup_key)
+            page_rows.append((ts, dedup_key))
+
+            fee = _safe_float(f.get("fee"))
+            closed_pnl = _safe_float(f.get("closedPnl"))
+            if oid > 0:
+                key = str(oid)
+                entry = by_oid.get(key)
+                if entry is None:
+                    entry = {"fee": 0.0, "closed_pnl": 0.0, "count": 0}
+                    by_oid[key] = entry
+                entry["fee"] += fee
+                entry["closed_pnl"] += closed_pnl
+                entry["count"] += 1
+            fill_count += 1
+            new_in_page += 1
+            if ts > next_cursor:
+                next_cursor = ts
+
+        # No new rows means we're done (cursor stuck on rows we've already
+        # consumed at this ms).
+        if new_in_page == 0:
+            break
+
+        # Advance cursor. If next_cursor moved forward, re-seed the dedup
+        # set with the boundary rows from this page that share the new
+        # cursor's timestamp — HL's user_fills_by_time is inclusive on the
+        # lower bound, so those rows will reappear in the next response.
+        if next_cursor > cursor_ms:
+            seen_first_ts_at_cursor = {dk for (ts, dk) in page_rows if ts == next_cursor}
+            cursor_ms = next_cursor
+        else:
+            # HL returned a full page all at the same ms — push past it to
+            # avoid an infinite loop.
+            cursor_ms = next_cursor + 1
+            seen_first_ts_at_cursor = set()
+
+        if cursor_ms > end_ms:
+            break
+
+    _emit({
+        "by_oid": by_oid,
+        "fill_count": fill_count,
+        "page_count": page_count,
+        "account_address": addr,
+        "error": "",
+    }, exit_code=0)
+
+
+if __name__ == "__main__":
+    main()

--- a/shared_scripts/fetch_hl_user_fills.py
+++ b/shared_scripts/fetch_hl_user_fills.py
@@ -185,7 +185,13 @@ def main():
             cursor_ms = next_cursor
         else:
             # HL returned a full page all at the same ms — push past it to
-            # avoid an infinite loop.
+            # avoid an infinite loop. Trade-off: any leg landing on
+            # next_cursor + 0 (same ms as the cursor we just exhausted) that
+            # was NOT in this page is dropped, in exchange for guaranteed
+            # forward progress. In practice HL caps pages at ~2000 rows and
+            # same-ms full pages essentially never occur for a single
+            # account, so the data-loss risk is vanishingly small relative
+            # to the cost of looping forever on a stuck cursor.
             cursor_ms = next_cursor + 1
             seen_first_ts_at_cursor = set()
 

--- a/shared_scripts/test_fetch_hl_user_fills.py
+++ b/shared_scripts/test_fetch_hl_user_fills.py
@@ -1,0 +1,168 @@
+"""Tests for fetch_hl_user_fills.py — userFills paging + OID aggregation
+used by `go-trader backfill hl-fees` (issue #589).
+
+Pattern mirrors test_close_hyperliquid_position.py: load the script as a
+module, mock the HL adapter, run main() with --since-ms, capture stdout +
+exit code, assert on the JSON envelope.
+"""
+
+import builtins
+import importlib.util
+import json
+import os
+import sys
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _run_script(pages_or_exc, argv, account_address="0xabc"):
+    """Helper: invoke fetch_hl_user_fills.main() with a mocked adapter.
+
+    pages_or_exc is either:
+      - a list of pages (each page = list of fill dicts) returned by
+        successive user_fills_by_time calls, OR
+      - an Exception instance to raise on the first call.
+
+    Returns (parsed_stdout_json, exit_code).
+    """
+    script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               "fetch_hl_user_fills.py")
+    spec = importlib.util.spec_from_file_location("fetch_hl_user_fills", script_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    mock_adapter = MagicMock()
+    mock_adapter._account_address = account_address
+    mock_adapter._info = MagicMock()
+    if isinstance(pages_or_exc, Exception):
+        mock_adapter._info.user_fills_by_time.side_effect = pages_or_exc
+    else:
+        mock_adapter._info.user_fills_by_time.side_effect = pages_or_exc
+
+    mock_adapter_cls = MagicMock(return_value=mock_adapter)
+
+    captured = StringIO()
+    exit_code = {"value": 0}
+
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "adapter":
+            fake_mod = MagicMock()
+            fake_mod.HyperliquidExchangeAdapter = mock_adapter_cls
+            return fake_mod
+        return original_import(name, *args, **kwargs)
+
+    def mock_exit(code=0):
+        exit_code["value"] = code
+        raise SystemExit(code)
+
+    with patch("builtins.__import__", side_effect=mock_import), \
+         patch("sys.stdout", captured), \
+         patch("sys.argv", ["fetch_hl_user_fills.py"] + argv), \
+         patch.object(mod.sys, "exit", side_effect=mock_exit):
+        try:
+            mod.main()
+        except SystemExit:
+            pass
+
+    raw = captured.getvalue().strip()
+    parsed = json.loads(raw) if raw else {}
+    return parsed, exit_code["value"]
+
+
+class TestSinglePage:
+    def test_aggregates_per_oid(self):
+        # Two fills, different OIDs.
+        page = [
+            {"oid": 111, "time": 1000, "fee": "0.40", "closedPnl": "0", "tid": 1},
+            {"oid": 222, "time": 1100, "fee": "0.30", "closedPnl": "9.7", "tid": 2},
+        ]
+        # Adapter returns the page once, then [] to terminate the loop.
+        out, code = _run_script([page, []], ["--since-ms=500"])
+        assert code == 0, out
+        assert out["error"] == ""
+        assert out["fill_count"] == 2
+        assert out["by_oid"]["111"]["fee"] == pytest.approx(0.40)
+        assert out["by_oid"]["222"]["fee"] == pytest.approx(0.30)
+        assert out["by_oid"]["222"]["closed_pnl"] == pytest.approx(9.7)
+        assert out["by_oid"]["111"]["count"] == 1
+
+    def test_partial_fills_same_oid_summed(self):
+        # One OID, two partial-fill rows — script must sum fee + closed_pnl.
+        page = [
+            {"oid": 111, "time": 1000, "fee": "0.20", "closedPnl": "5.0", "tid": 1},
+            {"oid": 111, "time": 1000, "fee": "0.20", "closedPnl": "4.7", "tid": 2},
+        ]
+        out, code = _run_script([page, []], ["--since-ms=500"])
+        assert code == 0, out
+        entry = out["by_oid"]["111"]
+        assert entry["fee"] == pytest.approx(0.40)
+        assert entry["closed_pnl"] == pytest.approx(9.7)
+        assert entry["count"] == 2
+
+
+class TestMultiPage:
+    def test_advances_cursor_to_last_fill_time(self):
+        page1 = [
+            {"oid": 111, "time": 1000, "fee": "0.10", "closedPnl": "0", "tid": 1},
+            {"oid": 222, "time": 2000, "fee": "0.20", "closedPnl": "0", "tid": 2},
+        ]
+        page2 = [
+            # Same time as page1's last fill, different tid — must NOT be deduped
+            # (different leg of a different OID at the same ms boundary).
+            {"oid": 333, "time": 2000, "fee": "0.30", "closedPnl": "0", "tid": 3},
+            {"oid": 444, "time": 3000, "fee": "0.40", "closedPnl": "0", "tid": 4},
+        ]
+        out, code = _run_script([page1, page2, []], ["--since-ms=500"])
+        assert code == 0, out
+        assert set(out["by_oid"].keys()) == {"111", "222", "333", "444"}
+        assert out["page_count"] >= 2
+
+    def test_dedups_boundary_row_seen_in_prior_page(self):
+        # The same fill (same tid + same time as the cursor) reappears on
+        # the next page — must NOT be double-counted.
+        page1 = [
+            {"oid": 111, "time": 1000, "fee": "0.10", "closedPnl": "0", "tid": 1},
+            {"oid": 222, "time": 2000, "fee": "0.20", "closedPnl": "0", "tid": 2},
+        ]
+        page2 = [
+            {"oid": 222, "time": 2000, "fee": "0.20", "closedPnl": "0", "tid": 2},  # dup
+            {"oid": 333, "time": 3000, "fee": "0.30", "closedPnl": "0", "tid": 3},
+        ]
+        out, code = _run_script([page1, page2, []], ["--since-ms=500"])
+        assert code == 0, out
+        # OID 222 should have count=1, not 2.
+        assert out["by_oid"]["222"]["count"] == 1
+        assert out["by_oid"]["222"]["fee"] == pytest.approx(0.20)
+
+
+class TestErrorPaths:
+    def test_missing_account_address_errors_cleanly(self):
+        out, code = _run_script([], ["--since-ms=500"], account_address="")
+        assert code == 1
+        assert "HYPERLIQUID_ACCOUNT_ADDRESS" in out["error"]
+        assert out["by_oid"] == {}
+
+    def test_invalid_since_ms_errors(self):
+        out, code = _run_script([], ["--since-ms=0"], account_address="0xabc")
+        assert code == 1
+        assert "since-ms" in out["error"]
+
+    def test_user_fills_exception_surfaces(self):
+        out, code = _run_script(RuntimeError("indexer down"),
+                                ["--since-ms=500"], account_address="0xabc")
+        assert code == 1
+        assert "user_fills_by_time" in out["error"]
+        assert "indexer down" in out["error"]
+
+
+class TestNoFills:
+    def test_empty_first_page_terminates(self):
+        out, code = _run_script([[]], ["--since-ms=500"])
+        assert code == 0
+        assert out["fill_count"] == 0
+        assert out["by_oid"] == {}
+        assert out["page_count"] == 1


### PR DESCRIPTION
Closes #589.

Adds a one-shot CLI subcommand that pages Hyperliquid `userFills` history and rewrites trade rows whose `exchange_fee=0` pre-date #587. Per row:
- `exchange_fee` ← real HL fee
- Close legs: `realized_pnl` += `(modeled_fee - real_fee

---
LLM: Claude Opus 4.7 (1M) | high | Harness: anthropics/claude-code-action@v1 | Tokens: 109 in / 58975 out | Cache: 9845071 read / 260725 written | Cost: $8.03