### PR TITLE
fix: reject two manual HL strategies on the same coin (#595)

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -974,12 +974,29 @@ func ValidateConfig(cfg *Config) error {
 			// Fix #6: manual strategies cannot share a coin with a live perps strategy —
 			// the scheduler's close-eval loop snapshots pos under RLock without owning
 			// the full mutex, creating a TOCTOU window if a perps peer mutates the same position.
+			//
+			// #595: also reject two manual strategies on the same coin. Manual full-close
+			// paths pass closeFullPosition=true unconditionally, which calls
+			// adapter.market_close(sz=None) and flattens the entire wallet position. The
+			// perps path's shouldCloseFullPosition sole-peer guard does not run for manual
+			// closes, so without this check a full close on one manual strategy would
+			// silently flatten a peer manual strategy's on-chain exposure.
 			if sc.Symbol != "" {
 				for _, other := range cfg.Strategies {
-					if other.ID != sc.ID && other.Type == "perps" && other.Platform == "hyperliquid" {
-						if otherSym := hyperliquidSymbol(other.Args); strings.EqualFold(otherSym, sc.Symbol) {
-							errs = append(errs, fmt.Sprintf("%s: type=manual on %s conflicts with perps strategy %s on the same coin — use sub-account isolation", prefix, sc.Symbol, other.ID))
-						}
+					if other.ID == sc.ID || other.Platform != "hyperliquid" {
+						continue
+					}
+					var otherSym string
+					switch other.Type {
+					case "perps":
+						otherSym = hyperliquidSymbol(other.Args)
+					case "manual":
+						otherSym = other.Symbol
+					default:
+						continue
+					}
+					if strings.EqualFold(otherSym, sc.Symbol) {
+						errs = append(errs, fmt.Sprintf("%s: type=manual on %s conflicts with %s strategy %s on the same coin — use sub-account isolation", prefix, sc.Symbol, other.Type, other.ID))
 					}
 				}
 			}

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -1850,3 +1850,88 @@ func TestOrdinal(t *testing.T) {
 		}
 	}
 }
+
+// TestValidateConfigManualSymbolConflict covers issue #595: two manual
+// strategies on the same coin must be rejected. Manual full-close paths pass
+// closeFullPosition=true unconditionally, so without this guard a full close
+// on one manual strategy would flatten a peer manual strategy's on-chain
+// exposure via adapter.market_close(sz=None).
+func TestValidateConfigManualSymbolConflict(t *testing.T) {
+	cases := []struct {
+		name    string
+		other   StrategyConfig
+		wantErr bool
+	}{
+		{
+			name: "manual conflicts with manual on same coin",
+			other: StrategyConfig{
+				ID:             "hl-manual-eth-2",
+				Type:           "manual",
+				Platform:       "hyperliquid",
+				Symbol:         "ETH",
+				Timeframe:      "1h",
+				Leverage:       5,
+				Capital:        1000,
+				MaxDrawdownPct: 60,
+			},
+			wantErr: true,
+		},
+		{
+			name: "manual conflicts with perps on same coin",
+			other: StrategyConfig{
+				ID:             "hl-perps-eth-live",
+				Type:           "perps",
+				Platform:       "hyperliquid",
+				Script:         "shared_scripts/check_hyperliquid.py",
+				Args:           []string{"sma_crossover", "ETH", "1h", "--mode=live"},
+				Capital:        1000,
+				Leverage:       5,
+				MaxDrawdownPct: 60,
+			},
+			wantErr: true,
+		},
+		{
+			name: "manual on different coin is allowed",
+			other: StrategyConfig{
+				ID:             "hl-manual-btc",
+				Type:           "manual",
+				Platform:       "hyperliquid",
+				Symbol:         "BTC",
+				Timeframe:      "1h",
+				Leverage:       5,
+				Capital:        1000,
+				MaxDrawdownPct: 60,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{
+				Strategies: []StrategyConfig{
+					{
+						ID:             "hl-manual-eth",
+						Type:           "manual",
+						Platform:       "hyperliquid",
+						Symbol:         "ETH",
+						Timeframe:      "1h",
+						Leverage:       10,
+						Capital:        1000,
+						MaxDrawdownPct: 60,
+					},
+					tc.other,
+				},
+				PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+			}
+			err := ValidateConfig(&cfg)
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "conflicts with") {
+					t.Fatalf("expected conflict error, got: %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Manual full-close paths (`manual-close` CLI, scheduler close-eval loop) call `RunHyperliquidExecute(..., closeFullPosition=true)`, which makes `check_hyperliquid.py` invoke `adapter.market_close(sz=None)` and flattens the entire wallet position for the coin.
- The perps path's `shouldCloseFullPosition` sole-peer guard never runs for manual closes, and `hlLiveAll` is perps-only — so even routing through that helper would not see manual peers.
- Config validation already blocks `manual ↔ perps` on the same coin; this extends the same symbol-conflict check to `manual ↔ manual`. The structural fix (manual-aware peer guard at the call sites) is left for a follow-up; this closes the actual exploit window.

## Test plan
- [x] `go test ./...` (full scheduler suite) passes
- [x] New `TestValidateConfigManualSymbolConflict` covers manual+manual (rejected), manual+perps (rejected — regression coverage for existing rule), and manual+manual on different coins (allowed)

Closes #595

---
LLM: Claude Opus 4.7 (1M) | high