### PR TITLE
fix: narrow HL coin-size fill fallback to one logical close (#596)

### DIFF
--- a/scheduler/hyperliquid_fills.go
+++ b/scheduler/hyperliquid_fills.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -117,16 +118,13 @@ func lookupHyperliquidFillByOID(accountAddress string, oid int64, startTimeMs in
 // lookupHyperliquidFillByCoinSize is the fallback for closes detected without
 // a tracked OID — typically external UI closes for shared-coin peers, where
 // only the SL owner has an OID stamped on its Position. Matches by coin and
-// absolute size within `tolerance` (coin units), summing fee + closedPnl
-// across all matching fills in the window. Newest-first scanning so the
-// first match is the most recent fill that reduced exposure.
+// absolute size within `tolerance` (coin units).
 //
-// The match is intentionally permissive — coin + size + window is sufficient
-// to disambiguate the SL-trigger / trailing-stop / manual UI close cases
-// we care about. If two strategies sized identically on the same coin closed
-// in the same window with no OIDs, fees may be double-counted; the issue
-// (#588) accepts this tradeoff in exchange for closing the much larger
-// virtual-vs-on-chain drift caused by always using the modeled fee.
+// To avoid conflating multiple unrelated closes within the lookup window
+// (#596), fills are sorted newest-first; the first matching record's OID
+// anchors the result, and fee/closedPnl are aggregated across only that OID
+// (one logical close group, including any partial fills). When the anchor
+// has no OID, only that single record is returned.
 func lookupHyperliquidFillByCoinSize(accountAddress, coin string, absSize, tolerance float64, startTimeMs int64) (HLFillLookup, bool) {
 	if accountAddress == "" || coin == "" || absSize <= 0 {
 		return HLFillLookup{}, false
@@ -134,8 +132,13 @@ func lookupHyperliquidFillByCoinSize(accountAddress, coin string, absSize, toler
 	for attempt := 0; attempt < hlFillLookupRetries; attempt++ {
 		fills, err := fetchHyperliquidUserFillsByTime(accountAddress, startTimeMs)
 		if err == nil {
-			out := HLFillLookup{}
-			for _, f := range fills {
+			sorted := make([]hlFillRecord, len(fills))
+			copy(sorted, fills)
+			sort.SliceStable(sorted, func(i, j int) bool {
+				return sorted[i].Time > sorted[j].Time
+			})
+			anchorIdx := -1
+			for i, f := range sorted {
 				if f.Coin != coin {
 					continue
 				}
@@ -143,12 +146,31 @@ func lookupHyperliquidFillByCoinSize(accountAddress, coin string, absSize, toler
 				if math.Abs(math.Abs(sz)-absSize) > tolerance {
 					continue
 				}
-				out.Fee += parseHLFloat(f.Fee)
-				out.ClosedPnL += parseHLFloat(f.ClosedPnl)
-				out.Count++
+				anchorIdx = i
+				break
 			}
-			if out.Count > 0 {
-				return out, true
+			if anchorIdx >= 0 {
+				anchor := sorted[anchorIdx]
+				anchorOID, oidErr := anchor.OID.Int64()
+				if oidErr != nil || anchorOID <= 0 {
+					return HLFillLookup{
+						Fee:       parseHLFloat(anchor.Fee),
+						ClosedPnL: parseHLFloat(anchor.ClosedPnl),
+						Count:     1,
+					}, true
+				}
+				out := HLFillLookup{OID: anchorOID}
+				for _, f := range fills {
+					if !fillOIDMatches(f, anchorOID) {
+						continue
+					}
+					out.Fee += parseHLFloat(f.Fee)
+					out.ClosedPnL += parseHLFloat(f.ClosedPnl)
+					out.Count++
+				}
+				if out.Count > 0 {
+					return out, true
+				}
 			}
 		}
 		if attempt < hlFillLookupRetries-1 {

--- a/scheduler/hyperliquid_fills_test.go
+++ b/scheduler/hyperliquid_fills_test.go
@@ -105,6 +105,70 @@ func TestLookupHyperliquidFillByCoinSize_MatchesByCoinAndSize(t *testing.T) {
 	}
 }
 
+func TestLookupHyperliquidFillByCoinSize_PicksNewestGroupNotSumOfWindow(t *testing.T) {
+	// Regression for #596: two unrelated same-size BTC closes within the
+	// 24h window must not be summed. The fallback should anchor on the
+	// newest matching fill and aggregate only that OID's group.
+	withFastFillRetries(t)
+	srv := newHLUserFillsServer(t, []map[string]any{
+		{"coin": "BTC", "oid": 100, "fee": "0.40", "closedPnl": "75.00", "sz": "0.1", "time": 1_000_000_000},
+		{"coin": "BTC", "oid": 200, "fee": "0.50", "closedPnl": "90.00", "sz": "0.1", "time": 2_000_000_000},
+	})
+	defer srv.Close()
+	origURL := hlMainnetURL
+	hlMainnetURL = srv.URL
+	defer func() { hlMainnetURL = origURL }()
+
+	got, ok := lookupHyperliquidFillByCoinSize("0xtest", "BTC", 0.1, 1e-4, 0)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got.Count != 1 {
+		t.Errorf("Count = %d, want 1 (only newest OID's group)", got.Count)
+	}
+	if got.OID != 200 {
+		t.Errorf("OID = %d, want 200 (newest fill)", got.OID)
+	}
+	if got.Fee < 0.499 || got.Fee > 0.501 {
+		t.Errorf("Fee = %g, want ~0.50 (newest only, not 0.40+0.50)", got.Fee)
+	}
+	if got.ClosedPnL < 89.99 || got.ClosedPnL > 90.01 {
+		t.Errorf("ClosedPnL = %g, want ~90.00 (newest only)", got.ClosedPnL)
+	}
+}
+
+func TestLookupHyperliquidFillByCoinSize_AggregatesPartialFillsByAnchorOID(t *testing.T) {
+	// When the newest matching fill has partial siblings sharing its OID,
+	// fee/closedPnl should aggregate across the whole group.
+	withFastFillRetries(t)
+	srv := newHLUserFillsServer(t, []map[string]any{
+		{"coin": "BTC", "oid": 555, "fee": "0.20", "closedPnl": "30.00", "sz": "0.04", "time": 1_500_000_000}, // partial of OID 555
+		{"coin": "BTC", "oid": 555, "fee": "0.30", "closedPnl": "40.00", "sz": "0.10", "time": 2_000_000_000}, // anchor
+		{"coin": "BTC", "oid": 999, "fee": "0.99", "closedPnl": "99.00", "sz": "0.10", "time": 1_000_000_000}, // older same-size, different OID — must be ignored
+	})
+	defer srv.Close()
+	origURL := hlMainnetURL
+	hlMainnetURL = srv.URL
+	defer func() { hlMainnetURL = origURL }()
+
+	got, ok := lookupHyperliquidFillByCoinSize("0xtest", "BTC", 0.10, 1e-4, 0)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got.OID != 555 {
+		t.Errorf("OID = %d, want 555 (newest matching anchor)", got.OID)
+	}
+	if got.Count != 2 {
+		t.Errorf("Count = %d, want 2 (both fills sharing OID 555)", got.Count)
+	}
+	if got.Fee < 0.499 || got.Fee > 0.501 {
+		t.Errorf("Fee = %g, want ~0.50 (0.20+0.30, not including OID 999)", got.Fee)
+	}
+	if got.ClosedPnL < 69.99 || got.ClosedPnL > 70.01 {
+		t.Errorf("ClosedPnL = %g, want ~70.00 (30+40, not including OID 999)", got.ClosedPnL)
+	}
+}
+
 func TestLookupHyperliquidReconcileFillFee_OIDFirstFallsBackToCoinSize(t *testing.T) {
 	withFastFillRetries(t)
 	// First call (OID lookup) returns no match; second call (coin+size) returns hit.


### PR DESCRIPTION
## Summary
- `lookupHyperliquidFillByCoinSize` previously summed every coin+size match across the 24h reconciler window, so two unrelated same-size closes on the same coin would conflate fees and closedPnl onto whichever close was being reconciled — silently distorting `Trade.ExchangeFee` and the cash credit booked in `recordPerpsExternalClose`.
- Sort fetched fills newest-first by `Time`, anchor on the first matching record, and aggregate fee/closedPnl across only that record's OID group (handles partial fills sharing one OID without admitting unrelated same-size closes). When the anchor lacks a usable OID, return only that single record.
- Fixed the misleading "Newest-first scanning so the first match is the most recent fill" comment that did not match the previous implementation (no sort, no break-on-first).

## Test plan
- [x] `go test ./scheduler/...` (full suite, 21s, all green)
- [x] New regression: `TestLookupHyperliquidFillByCoinSize_PicksNewestGroupNotSumOfWindow` — two unrelated 0.1 BTC closes (OIDs 100 + 200) → result anchors on OID 200 only, fee=0.50 not 0.90.
- [x] New regression: `TestLookupHyperliquidFillByCoinSize_AggregatesPartialFillsByAnchorOID` — newest match's OID has a partial sibling; older same-size fill on a different OID is ignored.
- [x] Existing tests preserved: `TestLookupHyperliquidFillByCoinSize_MatchesByCoinAndSize`, `TestLookupHyperliquidReconcileFillFee_OIDFirstFallsBackToCoinSize`, `TestReconcileHyperliquidPositions_ExternalCloseUsesFillFee`, `TestReconcileHyperliquidAccountPositions_DetectorOneUsesFillFee`.

Closes #596

---
LLM: Claude Opus 4.7 (1M) | high