### PR TITLE
[codex] Widen HL fee backfill lookup window

### DIFF
--- a/scheduler/backfill_hl_fees.go
+++ b/scheduler/backfill_hl_fees.go
@@ -33,6 +33,24 @@ type HLUserFillsResult struct {
 	Error          string                   `json:"error"`
 }
 
+// backfillHLUserFillsLookback widens the userFills query before the first DB
+// trade timestamp. Trade rows are recorded after the Python order call returns,
+// while HL's fill timestamp is earlier, so an exact lower bound can miss the
+// first order in a targeted backfill (#597).
+const backfillHLUserFillsLookback = 10 * time.Minute
+
+func backfillUserFillsStartTime(earliestTrade time.Time) time.Time {
+	if earliestTrade.IsZero() {
+		return time.Time{}
+	}
+	queryStart := earliestTrade.Add(-backfillHLUserFillsLookback)
+	minStart := time.UnixMilli(1).UTC()
+	if queryStart.Before(minStart) {
+		return minStart
+	}
+	return queryStart
+}
+
 // TradeBackfillRow is the subset of a `trades` row needed by planBackfillForStrategy.
 // Pulled into its own type so the planner is pure (no DB dep).
 type TradeBackfillRow struct {
@@ -480,8 +498,9 @@ func runBackfillHLFees(args []string) int {
 		return 1
 	}
 
-	// Fetch userFills once across all targets (same wallet). Use the earliest
-	// trade timestamp across all targets as the lower bound.
+	// Fetch userFills once across all targets (same wallet). Start slightly
+	// before the earliest trade timestamp because DB rows are stamped after
+	// the order returns, while HL userFills are stamped at exchange fill time.
 	earliest, err := stateDB.EarliestTradeTimestamp(strategyIDsOf(targets))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to read earliest trade timestamp: %v\n", err)
@@ -492,8 +511,12 @@ func runBackfillHLFees(args []string) int {
 		return 0
 	}
 
-	fmt.Printf("Fetching HL userFills since %s...\n", earliest.UTC().Format(time.RFC3339))
-	fillResult, err := runFetchHLUserFills(earliest)
+	queryStart := backfillUserFillsStartTime(earliest)
+	fmt.Printf("Fetching HL userFills since %s (earliest trade %s, lookback %s)...\n",
+		queryStart.UTC().Format(time.RFC3339),
+		earliest.UTC().Format(time.RFC3339),
+		backfillHLUserFillsLookback)
+	fillResult, err := runFetchHLUserFills(queryStart)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to fetch HL userFills: %v\n", err)
 		return 1

--- a/scheduler/backfill_hl_fees_test.go
+++ b/scheduler/backfill_hl_fees_test.go
@@ -15,6 +15,26 @@ func approxEq(a, b float64) bool {
 	return math.Abs(a-b) < 1e-6
 }
 
+func TestBackfillUserFillsStartTimeSubtractsLookback(t *testing.T) {
+	earliest := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	got := backfillUserFillsStartTime(earliest)
+	want := earliest.Add(-backfillHLUserFillsLookback)
+	if !got.Equal(want) {
+		t.Fatalf("backfillUserFillsStartTime() = %s, want %s", got, want)
+	}
+	if !got.Before(earliest) {
+		t.Fatalf("query start should predate earliest trade: got %s earliest %s", got, earliest)
+	}
+}
+
+func TestBackfillUserFillsStartTimeClampsNearUnixEpoch(t *testing.T) {
+	got := backfillUserFillsStartTime(time.Unix(1, 0).UTC())
+	want := time.UnixMilli(1).UTC()
+	if !got.Equal(want) {
+		t.Fatalf("backfillUserFillsStartTime() = %s, want %s", got, want)
+	}
+}
+
 // TestPlanBackfillRewritesFeeAndPnLOnCloseLeg verifies the core correction
 // math: a close leg with a real fee that differs from the modeled fee gets
 // realized_pnl adjusted by (modeledFee - realFee), and the row's exchange_fee


### PR DESCRIPTION
## Summary
- query Hyperliquid `userFills` from 10 minutes before the earliest DB trade timestamp during `backfill hl-fees`
- show both the query start and earliest trade timestamp in the command output
- add regression tests for the lookback helper and near-epoch clamp

## Root Cause
Trade rows are timestamped after the Python order call returns, while Hyperliquid fill timestamps come from the earlier exchange fill. Starting `userFillsByTime` exactly at the first DB trade timestamp can miss that first order's OID.

## Validation
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test -run 'Test(Backfill|PlanBackfill|ApplyBackfill)' -count=1`
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...`

Closes #597