### PR TITLE
[codex] Harden Hyperliquid fee lookup shape

### DIFF
--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -27,6 +27,7 @@ import json
 import math
 import time
 import traceback
+from collections.abc import Mapping
 from datetime import datetime, timezone
 
 
@@ -314,6 +315,32 @@ def _classify_sl_response(sdk_response: dict):
     return ("missing", None)
 
 
+def _finite_number(value):
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, (int, float, str)):
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    return numeric if math.isfinite(numeric) else None
+
+
+def _apply_user_fills_lookup(fill, lookup):
+    if not isinstance(lookup, Mapping):
+        return False
+    fee = _finite_number(lookup.get("fee"))
+    if fee is None:
+        return False
+    fill["fee"] = fee
+    if "closed_pnl" in lookup:
+        closed_pnl = _finite_number(lookup.get("closed_pnl"))
+        if closed_pnl is not None:
+            fill["closed_pnl"] = closed_pnl
+    return True
+
+
 def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_pos_qty=0.0, margin_mode="", leverage=0, close_full_position=False):
     """Place a live market order on Hyperliquid, optionally wrapping it with
     a stop-loss trigger (open) or cancelling a stale SL trigger (close).
@@ -452,12 +479,10 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
         if fill.get("oid"):
             try:
                 lookup = adapter.lookup_fill_fee_by_oid(fill["oid"], fills_since_ms)
-                if lookup:
-                    fill["fee"] = lookup.get("fee", 0.0)
-                    if "closed_pnl" in lookup:
-                        fill["closed_pnl"] = lookup["closed_pnl"]
-                else:
+                if not lookup:
                     print(f"[WARN] userFills lookup returned no fills for oid={fill['oid']}", file=sys.stderr)
+                elif not _apply_user_fills_lookup(fill, lookup):
+                    print(f"[WARN] userFills lookup returned malformed fill data for oid={fill['oid']}", file=sys.stderr)
             except Exception as fe:
                 print(f"[WARN] userFills lookup failed for oid={fill['oid']}: {fe}", file=sys.stderr)
 

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -27,7 +27,6 @@ import json
 import math
 import time
 import traceback
-from collections.abc import Mapping
 from datetime import datetime, timezone
 
 
@@ -58,6 +57,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strateg
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
 from atr import ensure_atr_indicator, latest_atr
+from hl_user_fills import apply_user_fills_lookup
 from regime import latest_regime
 
 
@@ -315,32 +315,6 @@ def _classify_sl_response(sdk_response: dict):
     return ("missing", None)
 
 
-def _finite_number(value):
-    if isinstance(value, bool):
-        return None
-    if not isinstance(value, (int, float, str)):
-        return None
-    try:
-        numeric = float(value)
-    except (TypeError, ValueError):
-        return None
-    return numeric if math.isfinite(numeric) else None
-
-
-def _apply_user_fills_lookup(fill, lookup):
-    if not isinstance(lookup, Mapping):
-        return False
-    fee = _finite_number(lookup.get("fee"))
-    if fee is None:
-        return False
-    fill["fee"] = fee
-    if "closed_pnl" in lookup:
-        closed_pnl = _finite_number(lookup.get("closed_pnl"))
-        if closed_pnl is not None:
-            fill["closed_pnl"] = closed_pnl
-    return True
-
-
 def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_pos_qty=0.0, margin_mode="", leverage=0, close_full_position=False):
     """Place a live market order on Hyperliquid, optionally wrapping it with
     a stop-loss trigger (open) or cancelling a stale SL trigger (close).
@@ -481,7 +455,7 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
                 lookup = adapter.lookup_fill_fee_by_oid(fill["oid"], fills_since_ms)
                 if not lookup:
                     print(f"[WARN] userFills lookup returned no fills for oid={fill['oid']}", file=sys.stderr)
-                elif not _apply_user_fills_lookup(fill, lookup):
+                elif not apply_user_fills_lookup(fill, lookup):
                     print(f"[WARN] userFills lookup returned malformed fill data for oid={fill['oid']}", file=sys.stderr)
             except Exception as fe:
                 print(f"[WARN] userFills lookup failed for oid={fill['oid']}: {fe}", file=sys.stderr)

--- a/shared_scripts/close_hyperliquid_position.py
+++ b/shared_scripts/close_hyperliquid_position.py
@@ -36,14 +36,42 @@ on every error path so a malformed-JSON crash still surfaces as failure.
 
 import argparse
 import json
+import math
 import os
 import sys
 import time
 import traceback
+from collections.abc import Mapping
 from datetime import datetime, timezone
 
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "platforms", "hyperliquid"))
+
+
+def _finite_number(value):
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, (int, float, str)):
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    return numeric if math.isfinite(numeric) else None
+
+
+def _apply_user_fills_lookup(fill, lookup):
+    if not isinstance(lookup, Mapping):
+        return False
+    fee = _finite_number(lookup.get("fee"))
+    if fee is None:
+        return False
+    fill["fee"] = fee
+    if "closed_pnl" in lookup:
+        closed_pnl = _finite_number(lookup.get("closed_pnl"))
+        if closed_pnl is not None:
+            fill["closed_pnl"] = closed_pnl
+    return True
 
 
 def main():
@@ -178,12 +206,10 @@ def main():
     if fill.get("oid"):
         try:
             lookup = adapter.lookup_fill_fee_by_oid(fill["oid"], fills_since_ms)
-            if lookup:
-                fill["fee"] = lookup.get("fee", 0.0)
-                if "closed_pnl" in lookup:
-                    fill["closed_pnl"] = lookup["closed_pnl"]
-            else:
+            if not lookup:
                 print(f"[WARN] userFills lookup returned no fills for oid={fill['oid']}", file=sys.stderr)
+            elif not _apply_user_fills_lookup(fill, lookup):
+                print(f"[WARN] userFills lookup returned malformed fill data for oid={fill['oid']}", file=sys.stderr)
         except Exception as fe:
             print(f"[WARN] userFills lookup failed for oid={fill['oid']}: {fe}", file=sys.stderr)
     _emit_success(args.symbol, fill, cancel_err=cancel_err, cancel_succeeded=cancel_succeeded)

--- a/shared_scripts/close_hyperliquid_position.py
+++ b/shared_scripts/close_hyperliquid_position.py
@@ -36,42 +36,17 @@ on every error path so a malformed-JSON crash still surfaces as failure.
 
 import argparse
 import json
-import math
 import os
 import sys
 import time
 import traceback
-from collections.abc import Mapping
 from datetime import datetime, timezone
 
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "platforms", "hyperliquid"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "shared_tools"))
 
-
-def _finite_number(value):
-    if isinstance(value, bool):
-        return None
-    if not isinstance(value, (int, float, str)):
-        return None
-    try:
-        numeric = float(value)
-    except (TypeError, ValueError):
-        return None
-    return numeric if math.isfinite(numeric) else None
-
-
-def _apply_user_fills_lookup(fill, lookup):
-    if not isinstance(lookup, Mapping):
-        return False
-    fee = _finite_number(lookup.get("fee"))
-    if fee is None:
-        return False
-    fill["fee"] = fee
-    if "closed_pnl" in lookup:
-        closed_pnl = _finite_number(lookup.get("closed_pnl"))
-        if closed_pnl is not None:
-            fill["closed_pnl"] = closed_pnl
-    return True
+from hl_user_fills import apply_user_fills_lookup
 
 
 def main():
@@ -208,7 +183,7 @@ def main():
             lookup = adapter.lookup_fill_fee_by_oid(fill["oid"], fills_since_ms)
             if not lookup:
                 print(f"[WARN] userFills lookup returned no fills for oid={fill['oid']}", file=sys.stderr)
-            elif not _apply_user_fills_lookup(fill, lookup):
+            elif not apply_user_fills_lookup(fill, lookup):
                 print(f"[WARN] userFills lookup returned malformed fill data for oid={fill['oid']}", file=sys.stderr)
         except Exception as fe:
             print(f"[WARN] userFills lookup failed for oid={fill['oid']}: {fe}", file=sys.stderr)

--- a/shared_scripts/test_check_hyperliquid.py
+++ b/shared_scripts/test_check_hyperliquid.py
@@ -10,6 +10,9 @@ from io import StringIO
 import pytest
 
 
+_UNSET = object()
+
+
 def _load_check_module():
     """Load check_hyperliquid.py as a module."""
     script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "check_hyperliquid.py")
@@ -22,7 +25,7 @@ def _load_check_module():
 class TestFillExtraction:
     """Test that run_execute extracts oid and fee from Hyperliquid SDK responses."""
 
-    def _run_execute_with_mock_response(self, sdk_response):
+    def _run_execute_with_mock_response(self, sdk_response, lookup_result=_UNSET):
         """Helper: mock the adapter and capture JSON output from run_execute."""
         mod, spec = _load_check_module()
         spec.loader.exec_module(mod)
@@ -31,6 +34,8 @@ class TestFillExtraction:
         mock_adapter = MagicMock()
         mock_adapter_cls.return_value = mock_adapter
         mock_adapter.market_open.return_value = sdk_response
+        if lookup_result is not _UNSET:
+            mock_adapter.lookup_fill_fee_by_oid.return_value = lookup_result
 
         captured = StringIO()
         with patch.dict(sys.modules, {}):
@@ -102,6 +107,86 @@ class TestFillExtraction:
         fill = result["execution"]["fill"]
         assert fill["oid"] == 9876543210
         assert "fee" not in fill
+
+    def test_fill_uses_numeric_lookup_result(self):
+        """userFills lookup fee + closed PnL should be copied only as numbers."""
+        sdk_response = {
+            "status": "ok",
+            "response": {
+                "type": "order",
+                "data": {
+                    "statuses": [
+                        {
+                            "filled": {
+                                "avgPx": "2100.0",
+                                "totalSz": "0.5",
+                                "oid": 9876543210,
+                            }
+                        }
+                    ]
+                },
+            },
+        }
+        result = self._run_execute_with_mock_response(
+            sdk_response,
+            lookup_result={"fee": "0.42", "closed_pnl": "3.14"},
+        )
+        fill = result["execution"]["fill"]
+        assert fill["fee"] == 0.42
+        assert fill["closed_pnl"] == 3.14
+
+    def test_fill_ignores_truthy_non_mapping_lookup_result(self):
+        """A bare MagicMock lookup result must not leak into JSON output."""
+        sdk_response = {
+            "status": "ok",
+            "response": {
+                "type": "order",
+                "data": {
+                    "statuses": [
+                        {
+                            "filled": {
+                                "avgPx": "2100.0",
+                                "totalSz": "0.5",
+                                "oid": 9876543210,
+                            }
+                        }
+                    ]
+                },
+            },
+        }
+        result = self._run_execute_with_mock_response(sdk_response, lookup_result=MagicMock())
+        fill = result["execution"]["fill"]
+        assert fill["oid"] == 9876543210
+        assert "fee" not in fill
+        assert "closed_pnl" not in fill
+
+    def test_fill_ignores_malformed_lookup_values(self):
+        """Truthy dicts with non-numeric payloads are ignored."""
+        sdk_response = {
+            "status": "ok",
+            "response": {
+                "type": "order",
+                "data": {
+                    "statuses": [
+                        {
+                            "filled": {
+                                "avgPx": "2100.0",
+                                "totalSz": "0.5",
+                                "oid": 9876543210,
+                            }
+                        }
+                    ]
+                },
+            },
+        }
+        result = self._run_execute_with_mock_response(
+            sdk_response,
+            lookup_result={"fee": MagicMock(), "closed_pnl": MagicMock()},
+        )
+        fill = result["execution"]["fill"]
+        assert fill["oid"] == 9876543210
+        assert "fee" not in fill
+        assert "closed_pnl" not in fill
 
     def test_fill_without_oid(self):
         """SDK response has no oid — backwards compatible with old responses."""

--- a/shared_scripts/test_close_hyperliquid_position.py
+++ b/shared_scripts/test_close_hyperliquid_position.py
@@ -23,7 +23,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-def _run_script(sdk_response_or_exc, argv):
+_UNSET = object()
+
+
+def _run_script(sdk_response_or_exc, argv, lookup_result=_UNSET):
     """Helper: invoke close_hyperliquid_position.main() with a mocked adapter.
 
     sdk_response_or_exc may be either a dict (returned by adapter.market_close)
@@ -46,6 +49,8 @@ def _run_script(sdk_response_or_exc, argv):
         mock_adapter.market_close.side_effect = sdk_response_or_exc
     else:
         mock_adapter.market_close.return_value = sdk_response_or_exc
+    if lookup_result is not _UNSET:
+        mock_adapter.lookup_fill_fee_by_oid.return_value = lookup_result
 
     captured = StringIO()
     exit_code = {"value": 0}
@@ -138,6 +143,59 @@ class TestSuccessFill:
         assert fill["total_sz"] == 0.01
         assert "oid" not in fill
         assert "fee" not in fill
+
+    def test_filled_uses_numeric_lookup_result(self):
+        sdk_response = {
+            "status": "ok",
+            "response": {"type": "order", "data": {"statuses": [
+                {"filled": {"avgPx": "3000.5", "totalSz": "0.517", "oid": 9999999}}
+            ]}},
+        }
+        out, code = _run_script(
+            sdk_response,
+            ["--symbol=ETH", "--mode=live"],
+            lookup_result={"fee": "0.91", "closed_pnl": "7.5"},
+        )
+        assert code == 0
+        fill = out["close"]["fill"]
+        assert fill["fee"] == 0.91
+        assert fill["closed_pnl"] == 7.5
+
+    def test_filled_ignores_truthy_non_mapping_lookup_result(self):
+        sdk_response = {
+            "status": "ok",
+            "response": {"type": "order", "data": {"statuses": [
+                {"filled": {"avgPx": "3000.5", "totalSz": "0.517", "oid": 9999999}}
+            ]}},
+        }
+        out, code = _run_script(
+            sdk_response,
+            ["--symbol=ETH", "--mode=live"],
+            lookup_result=MagicMock(),
+        )
+        assert code == 0
+        fill = out["close"]["fill"]
+        assert fill["oid"] == 9999999
+        assert "fee" not in fill
+        assert "closed_pnl" not in fill
+
+    def test_filled_ignores_malformed_lookup_values(self):
+        sdk_response = {
+            "status": "ok",
+            "response": {"type": "order", "data": {"statuses": [
+                {"filled": {"avgPx": "3000.5", "totalSz": "0.517", "oid": 9999999}}
+            ]}},
+        }
+        out, code = _run_script(
+            sdk_response,
+            ["--symbol=ETH", "--mode=live"],
+            lookup_result={"fee": MagicMock(), "closed_pnl": MagicMock()},
+        )
+        assert code == 0
+        fill = out["close"]["fill"]
+        assert fill["oid"] == 9999999
+        assert "fee" not in fill
+        assert "closed_pnl" not in fill
 
 
 class TestAlreadyFlat:

--- a/shared_tools/hl_user_fills.py
+++ b/shared_tools/hl_user_fills.py
@@ -1,0 +1,49 @@
+"""
+Shared helpers for applying Hyperliquid userFills lookup results to fill dicts.
+
+Used by shared_scripts/check_hyperliquid.py and shared_scripts/close_hyperliquid_position.py
+to keep the shape-validation and numeric-guard logic in one place (#598).
+"""
+
+import math
+import sys
+from collections.abc import Mapping
+
+
+def _finite_number(value):
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, (int, float, str)):
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    return numeric if math.isfinite(numeric) else None
+
+
+def apply_user_fills_lookup(fill, lookup):
+    """Apply fee and closed_pnl from a userFills lookup result to *fill* in-place.
+
+    Returns True when fee was successfully applied, False when lookup is not a
+    Mapping or fee is malformed (caller should warn). A present-but-malformed
+    closed_pnl emits a [WARN] to stderr and is silently dropped so the fee
+    (the primary goal of #585/#587) is still recorded.
+    """
+    if not isinstance(lookup, Mapping):
+        return False
+    fee = _finite_number(lookup.get("fee"))
+    if fee is None:
+        return False
+    fill["fee"] = fee
+    if "closed_pnl" in lookup:
+        closed_pnl = _finite_number(lookup.get("closed_pnl"))
+        if closed_pnl is not None:
+            fill["closed_pnl"] = closed_pnl
+        else:
+            print(
+                f"[WARN] userFills lookup: closed_pnl present but malformed"
+                f" ({lookup.get('closed_pnl')!r}), dropping",
+                file=sys.stderr,
+            )
+    return True

--- a/shared_tools/test_hl_user_fills.py
+++ b/shared_tools/test_hl_user_fills.py
@@ -1,0 +1,111 @@
+"""Tests for shared_tools/hl_user_fills.py — shape/numeric guard helpers."""
+
+import importlib.util
+import pathlib
+import sys
+from io import StringIO
+from unittest.mock import MagicMock
+
+import pytest
+
+_spec = importlib.util.spec_from_file_location(
+    "hl_user_fills", pathlib.Path(__file__).parent / "hl_user_fills.py"
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+_finite_number = _mod._finite_number
+apply_user_fills_lookup = _mod.apply_user_fills_lookup
+
+
+class TestFiniteNumber:
+    def test_float_string(self):
+        assert _finite_number("3.14") == pytest.approx(3.14)
+
+    def test_int(self):
+        assert _finite_number(42) == pytest.approx(42.0)
+
+    def test_float(self):
+        assert _finite_number(1.5) == pytest.approx(1.5)
+
+    def test_bool_rejected(self):
+        assert _finite_number(True) is None
+        assert _finite_number(False) is None
+
+    def test_non_numeric_string(self):
+        assert _finite_number("abc") is None
+
+    def test_none(self):
+        assert _finite_number(None) is None
+
+    def test_mock_rejected(self):
+        assert _finite_number(MagicMock()) is None
+
+    def test_inf_rejected(self):
+        assert _finite_number(float("inf")) is None
+        assert _finite_number("-inf") is None
+
+    def test_nan_rejected(self):
+        assert _finite_number(float("nan")) is None
+
+
+class TestApplyUserFillsLookup:
+    def test_valid_fee_and_closed_pnl(self):
+        fill = {}
+        result = apply_user_fills_lookup(fill, {"fee": "0.42", "closed_pnl": "3.14"})
+        assert result is True
+        assert fill["fee"] == pytest.approx(0.42)
+        assert fill["closed_pnl"] == pytest.approx(3.14)
+
+    def test_valid_fee_no_closed_pnl_key(self):
+        fill = {}
+        result = apply_user_fills_lookup(fill, {"fee": 0.5})
+        assert result is True
+        assert fill["fee"] == pytest.approx(0.5)
+        assert "closed_pnl" not in fill
+
+    def test_truthy_non_mapping_rejected(self):
+        fill = {}
+        result = apply_user_fills_lookup(fill, MagicMock())
+        assert result is False
+        assert "fee" not in fill
+
+    def test_malformed_fee_rejected(self):
+        fill = {}
+        result = apply_user_fills_lookup(fill, {"fee": MagicMock()})
+        assert result is False
+        assert "fee" not in fill
+
+    def test_malformed_closed_pnl_warns_and_keeps_fee(self, capsys):
+        fill = {}
+        result = apply_user_fills_lookup(fill, {"fee": "1.0", "closed_pnl": MagicMock()})
+        assert result is True
+        assert fill["fee"] == pytest.approx(1.0)
+        assert "closed_pnl" not in fill
+        captured = capsys.readouterr()
+        assert "[WARN]" in captured.err
+        assert "closed_pnl" in captured.err
+
+    def test_bool_fee_rejected(self):
+        fill = {}
+        result = apply_user_fills_lookup(fill, {"fee": True})
+        assert result is False
+        assert "fee" not in fill
+
+    def test_empty_mapping_rejected(self):
+        fill = {}
+        result = apply_user_fills_lookup(fill, {})
+        assert result is False
+        assert "fee" not in fill
+
+    def test_none_lookup_rejected(self):
+        fill = {}
+        result = apply_user_fills_lookup(fill, None)
+        assert result is False
+        assert "fee" not in fill
+
+    def test_numeric_int_fee(self):
+        fill = {}
+        result = apply_user_fills_lookup(fill, {"fee": 2})
+        assert result is True
+        assert fill["fee"] == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- Harden Hyperliquid execute fee lookup before copying userFills data into the subprocess JSON contract.
- Apply the same shape and numeric-value guard to the Hyperliquid close script.
- Add regression tests for numeric lookup payloads, truthy non-mapping responses, and malformed lookup values.

## Root Cause
The execute path treated any truthy `lookup_fill_fee_by_oid()` result as dict-like. A bare `MagicMock` is truthy and can return more mocks from `.get()`, which can leak non-JSON values into stdout.

## Validation
- `uv run --extra test pytest shared_scripts/test_check_hyperliquid.py shared_scripts/test_close_hyperliquid_position.py`
- `uv run --extra test pytest shared_scripts/test_check_execute_fees.py`
- `git diff --check`

Closes #598