### PR TITLE
[codex] Add HL shared-coin protection orders

### DIFF
--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -427,13 +427,17 @@ class HyperliquidExchangeAdapter:
         )
 
     def open_order_oids(self, symbol: str | None = None) -> set[int]:
-        """Return currently open order OIDs, optionally filtered by coin (#601)."""
+        """Return currently open order OIDs, optionally filtered by coin (#601).
+
+        Raises whatever the underlying SDK raises — callers in
+        check_hyperliquid.py treat a raise as "open-orders fetch failed,
+        defer placement decisions" so wrapping it in try/except here would
+        silently coerce uncertainty into "no open orders" and produce the
+        over-place hazard we're trying to avoid.
+        """
         if not self._account_address:
             return set()
-        try:
-            orders = self._info.open_orders(self._account_address)
-        except Exception:
-            raise
+        orders = self._info.open_orders(self._account_address)
         out: set[int] = set()
         for order in orders or []:
             if not isinstance(order, dict):
@@ -445,13 +449,27 @@ class HyperliquidExchangeAdapter:
                 out.add(oid)
         return out
 
-    def cancel_trigger_order(self, symbol: str, oid: int) -> dict:
-        """Cancel a resting trigger order by OID (#412)."""
+    def cancel_order_by_oid(self, symbol: str, oid: int) -> dict:
+        """Cancel any resting order (trigger or limit) by OID.
+
+        HL's cancel endpoint is order-type-agnostic — it accepts the OID and
+        figures out the underlying order kind from the book. Trigger orders
+        (stop-loss, take-profit-trigger) and limit orders (reduce-only TP
+        limits placed via place_take_profit_limit) are both cancellable
+        through this single primitive (#604 review #4).
+        """
         if not self._exchange:
             raise RuntimeError(
-                "cancel_trigger_order requires live mode (set HYPERLIQUID_SECRET_KEY)"
+                "cancel_order_by_oid requires live mode (set HYPERLIQUID_SECRET_KEY)"
             )
         return self._exchange.cancel(symbol, int(oid))
+
+    # Backwards-compatible alias. The original name implied only trigger
+    # orders were supported; in practice HL's cancel works for any order
+    # type. New code should call cancel_order_by_oid; existing callers can
+    # keep using cancel_trigger_order without a rename churn.
+    def cancel_trigger_order(self, symbol: str, oid: int) -> dict:
+        return self.cancel_order_by_oid(symbol, oid)
 
     def update_leverage(self, leverage: int, symbol: str, is_cross: bool) -> dict:
         """Set leverage and margin mode (cross/isolated) for ``symbol`` (#486).

--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -13,6 +13,7 @@ Environment variables:
 import math
 import os
 import sys
+from decimal import Decimal, ROUND_DOWN
 import time
 
 MAINNET_URL = "https://api.hyperliquid.xyz"
@@ -71,6 +72,14 @@ def _round_perps_px(px: float, sz_decimals: int) -> float:
     sig_decimals = max(0, 5 - 1 - int(log))
     decimals = min(px_decimals, sig_decimals)
     return round(px, decimals)
+
+
+def _floor_size(sz: float, sz_decimals: int) -> float:
+    """Floor order size to HL asset precision so reduce-only TPs never oversize."""
+    if sz <= 0:
+        return sz
+    quant = Decimal("1").scaleb(-max(sz_decimals, 0))
+    return float(Decimal(str(sz)).quantize(quant, rounding=ROUND_DOWN))
 
 
 class HyperliquidExchangeAdapter:
@@ -390,6 +399,51 @@ class HyperliquidExchangeAdapter:
         return self._exchange.order(
             symbol, is_buy, sz, limit_px, order_type, reduce_only=True
         )
+
+    def place_take_profit_limit(
+        self,
+        symbol: str,
+        sz: float,
+        limit_px: float,
+        is_buy: bool,
+    ) -> dict:
+        """Place a reduce-only take-profit limit order (#601)."""
+        if not self._exchange:
+            raise RuntimeError(
+                "place_take_profit_limit requires live mode (set HYPERLIQUID_SECRET_KEY)"
+            )
+        if symbol not in self._info.asset_to_sz_decimals:
+            print(f"[WARN] sz_decimals not found for {symbol}, defaulting to 3", file=sys.stderr)
+        sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3)
+        sz = _floor_size(sz, sz_decimals)
+        if sz <= 0:
+            raise ValueError(f"Size floored to zero for {symbol} (sz_decimals={sz_decimals})")
+        if limit_px <= 0:
+            raise ValueError(f"limit_px must be > 0, got {limit_px}")
+        limit_px = _round_perps_px(limit_px, sz_decimals)
+        order_type = {"limit": {"tif": "Gtc"}}
+        return self._exchange.order(
+            symbol, is_buy, sz, limit_px, order_type, reduce_only=True
+        )
+
+    def open_order_oids(self, symbol: str | None = None) -> set[int]:
+        """Return currently open order OIDs, optionally filtered by coin (#601)."""
+        if not self._account_address:
+            return set()
+        try:
+            orders = self._info.open_orders(self._account_address)
+        except Exception:
+            raise
+        out: set[int] = set()
+        for order in orders or []:
+            if not isinstance(order, dict):
+                continue
+            if symbol and order.get("coin") != symbol:
+                continue
+            oid = _safe_int(order.get("oid"))
+            if oid:
+                out.add(oid)
+        return out
 
     def cancel_trigger_order(self, symbol: str, oid: int) -> dict:
         """Cancel a resting trigger order by OID (#412)."""

--- a/platforms/hyperliquid/test_adapter.py
+++ b/platforms/hyperliquid/test_adapter.py
@@ -414,6 +414,28 @@ class TestStopLossPlacement:
         adapter.cancel_trigger_order("BTC", "12345")
         ex.cancel.assert_called_once_with("BTC", 12345)
 
+    def test_place_take_profit_limit_uses_reduce_only_limit(self):
+        adapter, ex, _ = self._live_adapter(sz_decimals={"ETH": 4})
+        ex.order.return_value = {"status": "ok"}
+        adapter.place_take_profit_limit("ETH", 0.123456, 3100.0, is_buy=False)
+        sym, is_buy, sz, limit_px, order_type = ex.order.call_args.args
+        assert sym == "ETH"
+        assert is_buy is False
+        assert sz == 0.1234
+        assert limit_px == 3100.0
+        assert order_type == {"limit": {"tif": "Gtc"}}
+        assert ex.order.call_args.kwargs == {"reduce_only": True}
+
+    def test_open_order_oids_filters_by_symbol(self):
+        adapter, _, _ = self._live_adapter()
+        adapter._account_address = "0xabc"
+        adapter._info.open_orders.return_value = [
+            {"coin": "ETH", "oid": 111},
+            {"coin": "BTC", "oid": 222},
+            {"coin": "ETH", "oid": "333"},
+        ]
+        assert adapter.open_order_oids("ETH") == {111, 333}
+
 
 # ─── userFills Lookup (#585) ──────────────────────────
 

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -558,13 +558,12 @@ func LoadConfig(path string) (*Config, error) {
 			fmt.Printf("[INFO] %s: no theta_harvest config, applying defaults (profit=60%%, stop=200%%, dte=3)\n", cfg.Strategies[i].ID)
 		}
 	}
-	normalizeHyperliquidPeerStopLosses(cfg.Strategies)
 
-	// #562: Default sole-owner HL perps strategies with no explicit stop-loss /
+	// #562/#601: Default HL perps strategies with no explicit stop-loss /
 	// trailing-stop fields to stop_loss_atr_mult=1.0. Volatility-adjusted
-	// exchange-side protection out of the box. Runs after peer normalization
-	// so peer strategies (which had StopLossPct=0 set by the normalizer) are
-	// skipped. The five-field nil check matches normalizeHyperliquidPeerStopLosses.
+	// exchange-side protection out of the box. Shared-coin peers are included
+	// because #601 places per-strategy sized reduce-only orders instead of one
+	// shared trigger owner.
 	for i := range cfg.Strategies {
 		sc := &cfg.Strategies[i]
 		if sc.Type != "perps" || sc.Platform != "hyperliquid" {
@@ -656,48 +655,11 @@ func LoadConfig(path string) (*Config, error) {
 	return &cfg, nil
 }
 
-// normalizeHyperliquidPeerStopLosses preserves the single-strategy auto-SL
-// fallback while avoiding accidental reduce-only trigger races for same-coin
-// peer strategies (#494). When multiple HL perps strategies share a coin,
-// omitted stop_loss_* / trailing_stop_* fields are treated as an explicit
-// opt-out; operators can still select one owner with a positive stop_loss_pct,
-// stop_loss_margin_pct, trailing_stop_pct, or trailing_stop_atr_mult.
+// normalizeHyperliquidPeerStopLosses is retained for callers/tests that still
+// reference the old #494 normalizer. It intentionally no-ops after #601:
+// shared-coin HL perps strategies now place per-strategy sized reduce-only
+// protection orders, so omitted stop fields should keep normal defaulting.
 func normalizeHyperliquidPeerStopLosses(strategies []StrategyConfig) {
-	type peerRef struct {
-		ID    string
-		Index int
-	}
-	groups := make(map[string][]peerRef)
-	for i, sc := range strategies {
-		if sc.Type != "perps" || sc.Platform != "hyperliquid" {
-			continue
-		}
-		coin := hyperliquidSymbol(sc.Args)
-		if coin == "" {
-			continue
-		}
-		groups[coin] = append(groups[coin], peerRef{ID: sc.ID, Index: i})
-	}
-
-	coins := make([]string, 0, len(groups))
-	for coin := range groups {
-		coins = append(coins, coin)
-	}
-	sort.Strings(coins)
-	for _, coin := range coins {
-		peers := groups[coin]
-		if len(peers) < 2 {
-			continue
-		}
-		sort.Slice(peers, func(i, j int) bool { return peers[i].ID < peers[j].ID })
-		for _, p := range peers {
-			sc := &strategies[p.Index]
-			if sc.StopLossPct == nil && sc.StopLossMarginPct == nil && sc.TrailingStopPct == nil && sc.TrailingStopATRMult == nil && sc.StopLossATRMult == nil {
-				zero := 0.0
-				sc.StopLossPct = &zero
-			}
-		}
-	}
 }
 
 // hasHyperliquidStopLossOwnership reports whether sc would place a reduce-only
@@ -720,19 +682,15 @@ func hasHyperliquidStopLossOwnership(sc StrategyConfig) bool {
 }
 
 // hyperliquidPeerStrategyErrors returns validation messages for HL perps
-// strategies that share a coin but disagree on MarginMode or exchange Leverage (#491),
-// or that have more than one stop-loss owner (after LoadConfig peer
-// normalization, #494, including trailing stops from #501 and ATR-derived
-// trailing stops from #505). Returns an empty slice when no peer conflicts exist.
+// strategies that share a coin but disagree on MarginMode or exchange Leverage (#491).
+// Returns an empty slice when no peer conflicts exist.
 //
 // HL aggregates positions per coin per account, so two go-trader strategies
 // on the same coin share an on-chain position, margin assignment, and
-// reduce-only stop-loss slots. Mismatched leverage/margin would either fail
+// reduce-only order slots. Mismatched leverage/margin would either fail
 // at first peer trade (HL rejects mode changes on an open position) or
-// silently land in the wrong mode; conflicting stop-loss triggers race on
-// a single position. Per-strategy bookkeeping in SQLite keeps the legs
-// separated when peers agree, so this validation is the only thing
-// preventing a foot-gun config.
+// silently land in the wrong mode. Per-strategy bookkeeping in SQLite keeps
+// the legs separated when peers agree.
 //
 // Sub-account isolation is the only correct path for full per-strategy
 // independence (different direction, leverage, margin); it is intentionally
@@ -754,7 +712,6 @@ func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 		Coin       string
 		MarginMode string
 		Leverage   float64
-		OwnsSL     bool // resolved after LoadConfig peer normalization: true means this strategy owns a trigger
 	}
 	groups := make(map[string][]peer)
 	for _, sc := range strategies {
@@ -770,7 +727,6 @@ func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 			Coin:       coin,
 			MarginMode: sc.MarginMode,
 			Leverage:   sc.Leverage,
-			OwnsSL:     hasHyperliquidStopLossOwnership(sc),
 		})
 	}
 	var errs []string
@@ -809,18 +765,6 @@ func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 					coin, idList))
 				break
 			}
-		}
-		stopLossOwners := make([]string, 0)
-		for _, p := range peers {
-			if p.OwnsSL {
-				stopLossOwners = append(stopLossOwners, p.ID)
-			}
-		}
-		if len(stopLossOwners) > 1 {
-			sort.Strings(stopLossOwners)
-			errs = append(errs, fmt.Sprintf(
-				"hyperliquid peers on %s have conflicting stop_loss_pct/trailing_stop_pct/trailing_stop_atr_mult (strategies %s): at most one peer may place a reduce-only SL trigger; the others' OIDs would race on the shared on-chain position",
-				coin, strings.Join(stopLossOwners, ", ")))
 		}
 	}
 	return errs

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -681,6 +681,25 @@ func hasHyperliquidStopLossOwnership(sc StrategyConfig) bool {
 	return false
 }
 
+// hasHyperliquidTrailingStopOwnership reports whether sc would place a
+// trailing reduce-only HL trigger that cancels and replaces the resting OID
+// as the position moves favorably. Trailing stops are special because the
+// cancel/replace cycle races on the shared on-chain position when two peers
+// both run trailing logic — the second peer's place can land before the
+// first's cancel, briefly doubling the reduce-only quantity (#604 review #5).
+// Fixed-distance triggers (StopLossPct, StopLossMarginPct, StopLossATRMult)
+// are sized per-strategy and don't cancel/replace, so they coexist safely
+// under #601's per-strategy sized protection model.
+func hasHyperliquidTrailingStopOwnership(sc StrategyConfig) bool {
+	if sc.TrailingStopPct != nil && *sc.TrailingStopPct > 0 {
+		return true
+	}
+	if sc.TrailingStopATRMult != nil && *sc.TrailingStopATRMult > 0 {
+		return true
+	}
+	return false
+}
+
 // hyperliquidPeerStrategyErrors returns validation messages for HL perps
 // strategies that share a coin but disagree on MarginMode or exchange Leverage (#491).
 // Returns an empty slice when no peer conflicts exist.
@@ -708,10 +727,11 @@ func hasHyperliquidStopLossOwnership(sc StrategyConfig) bool {
 // any on-chain conflict.
 func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 	type peer struct {
-		ID         string
-		Coin       string
-		MarginMode string
-		Leverage   float64
+		ID           string
+		Coin         string
+		MarginMode   string
+		Leverage     float64
+		OwnsTrailing bool // trailing stops cancel/replace and race on shared coin (#604 review #5)
 	}
 	groups := make(map[string][]peer)
 	for _, sc := range strategies {
@@ -723,10 +743,11 @@ func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 			continue
 		}
 		groups[coin] = append(groups[coin], peer{
-			ID:         sc.ID,
-			Coin:       coin,
-			MarginMode: sc.MarginMode,
-			Leverage:   sc.Leverage,
+			ID:           sc.ID,
+			Coin:         coin,
+			MarginMode:   sc.MarginMode,
+			Leverage:     sc.Leverage,
+			OwnsTrailing: hasHyperliquidTrailingStopOwnership(sc),
 		})
 	}
 	var errs []string
@@ -765,6 +786,24 @@ func hyperliquidPeerStrategyErrors(strategies []StrategyConfig) []string {
 					coin, idList))
 				break
 			}
+		}
+		// Trailing-stop peers race on the shared on-chain position because
+		// each cycle's cancel/replace is non-atomic — peer A can place its
+		// new resting OID before peer B cancels its old one, briefly
+		// doubling the reduce-only quantity. Fixed-distance triggers
+		// (StopLossPct/StopLossATRMult/StopLossMarginPct) are sized
+		// per-strategy and rest forever, so they coexist safely.
+		trailingOwners := make([]string, 0)
+		for _, p := range peers {
+			if p.OwnsTrailing {
+				trailingOwners = append(trailingOwners, p.ID)
+			}
+		}
+		if len(trailingOwners) > 1 {
+			sort.Strings(trailingOwners)
+			errs = append(errs, fmt.Sprintf(
+				"hyperliquid peers on %s have multiple trailing-stop owners (strategies %s): trailing_stop_pct/trailing_stop_atr_mult cancel and replace OIDs each cycle, racing on the shared on-chain position; at most one peer may run a trailing stop",
+				coin, strings.Join(trailingOwners, ", ")))
 		}
 	}
 	return errs

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -1249,9 +1249,9 @@ func TestLoadConfigHLPerpsPeersMismatchedLeverage(t *testing.T) {
 	}
 }
 
-// #491: only one peer may carry stop_loss_pct — reduce-only triggers from
-// both peers would race on the shared on-chain position.
-func TestLoadConfigHLPerpsPeersConflictingStopLoss(t *testing.T) {
+// #601: multiple shared-coin peers may carry stop_loss_pct because protection
+// orders are now sized per strategy.
+func TestLoadConfigHLPerpsPeersMultipleStopLossAllowed(t *testing.T) {
 	dir := t.TempDir()
 	cfgJSON := `{
 		"strategies": [
@@ -1281,11 +1281,8 @@ func TestLoadConfigHLPerpsPeersConflictingStopLoss(t *testing.T) {
 	}`
 	path := writeTestConfig(t, dir, cfgJSON)
 	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected validation error for conflicting stop_loss_pct on peers")
-	}
-	if !strings.Contains(err.Error(), "conflicting stop_loss_pct") {
-		t.Errorf("error = %v, want 'conflicting stop_loss_pct'", err)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
 	}
 }
 

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -73,6 +73,8 @@ CREATE TABLE IF NOT EXISTS positions (
     stop_loss_oid INTEGER NOT NULL DEFAULT 0,
     stop_loss_trigger_px REAL NOT NULL DEFAULT 0,
     stop_loss_high_water_px REAL NOT NULL DEFAULT 0,
+    tp1_oid INTEGER NOT NULL DEFAULT 0,
+    tp2_oid INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (strategy_id, symbol)
 );
 
@@ -294,6 +296,9 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE trades ADD COLUMN manual INTEGER NOT NULL DEFAULT 0",
 		// Operator-intent full-close flag for manual close actions (#569 review).
 		"ALTER TABLE pending_manual_actions ADD COLUMN is_full_close INTEGER NOT NULL DEFAULT 0",
+		// Per-strategy HL reduce-only take-profit OIDs (#601).
+		"ALTER TABLE positions ADD COLUMN tp1_oid INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE positions ADD COLUMN tp2_oid INTEGER NOT NULL DEFAULT 0",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -655,8 +660,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	}
 	defer stmtStrat.Close()
 
-	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, tp1_oid, tp2_oid)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare position insert: %w", err)
 	}
@@ -706,7 +711,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 
 		for _, pos := range s.Positions {
 			positionID := ensurePositionTradeID(s.ID, pos.Symbol, pos)
-			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx); err != nil {
+			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx, pos.TP1OID, pos.TP2OID); err != nil {
 				return fmt.Errorf("insert position %s/%s: %w", s.ID, pos.Symbol, err)
 			}
 		}
@@ -1117,7 +1122,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	}
 
 	// 3. Load positions for each strategy.
-	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px FROM positions")
+	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, COALESCE(tp1_oid, 0) AS tp1_oid, COALESCE(tp2_oid, 0) AS tp2_oid FROM positions")
 	if err != nil {
 		return nil, fmt.Errorf("load positions: %w", err)
 	}
@@ -1126,7 +1131,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		var stratID string
 		var pos Position
 		var openedAtStr string
-		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx); err != nil {
+		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx, &pos.TP1OID, &pos.TP2OID); err != nil {
 			return nil, fmt.Errorf("scan position: %w", err)
 		}
 		pos.OpenedAt = parseTime(openedAtStr)

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -92,20 +92,27 @@ type HyperliquidStopLossUpdateResult struct {
 // HyperliquidProtectionSyncResult is emitted by check_hyperliquid.py
 // --sync-protection. It keeps per-strategy reduce-only SL/TP order OIDs in
 // Position so restart recovery can verify or re-place missing protection (#601).
+//
+// `*_filled_externally` flags signal that the recorded OID had already filled
+// on-chain when sync ran (reconciler will book the close); the Go side must
+// clear the OID without re-placing to avoid the over-close hazard from #604.
 type HyperliquidProtectionSyncResult struct {
-	Platform            string  `json:"platform"`
-	Timestamp           string  `json:"timestamp"`
-	Error               string  `json:"error,omitempty"`
-	StopLossOID         int64   `json:"stop_loss_oid,omitempty"`
-	StopLossTriggerPx   float64 `json:"stop_loss_trigger_px,omitempty"`
-	TP1OID              int64   `json:"tp1_oid,omitempty"`
-	TP2OID              int64   `json:"tp2_oid,omitempty"`
-	TP1Px               float64 `json:"tp1_px,omitempty"`
-	TP2Px               float64 `json:"tp2_px,omitempty"`
-	StopLossError       string  `json:"stop_loss_error,omitempty"`
-	TP1Error            string  `json:"tp1_error,omitempty"`
-	TP2Error            string  `json:"tp2_error,omitempty"`
-	OpenOrderCheckError string  `json:"open_order_check_error,omitempty"`
+	Platform                 string  `json:"platform"`
+	Timestamp                string  `json:"timestamp"`
+	Error                    string  `json:"error,omitempty"`
+	StopLossOID              int64   `json:"stop_loss_oid,omitempty"`
+	StopLossTriggerPx        float64 `json:"stop_loss_trigger_px,omitempty"`
+	TP1OID                   int64   `json:"tp1_oid,omitempty"`
+	TP2OID                   int64   `json:"tp2_oid,omitempty"`
+	TP1Px                    float64 `json:"tp1_px,omitempty"`
+	TP2Px                    float64 `json:"tp2_px,omitempty"`
+	StopLossError            string  `json:"stop_loss_error,omitempty"`
+	TP1Error                 string  `json:"tp1_error,omitempty"`
+	TP2Error                 string  `json:"tp2_error,omitempty"`
+	OpenOrderCheckError      string  `json:"open_order_check_error,omitempty"`
+	StopLossFilledExternally bool    `json:"stop_loss_filled_externally,omitempty"`
+	TP1FilledExternally      bool    `json:"tp1_filled_externally,omitempty"`
+	TP2FilledExternally      bool    `json:"tp2_filled_externally,omitempty"`
 }
 
 // RunPythonScript executes a Python script and returns stdout/stderr.

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -89,6 +89,25 @@ type HyperliquidStopLossUpdateResult struct {
 	StopLossFilledImmediately bool    `json:"stop_loss_filled_immediately,omitempty"`
 }
 
+// HyperliquidProtectionSyncResult is emitted by check_hyperliquid.py
+// --sync-protection. It keeps per-strategy reduce-only SL/TP order OIDs in
+// Position so restart recovery can verify or re-place missing protection (#601).
+type HyperliquidProtectionSyncResult struct {
+	Platform            string  `json:"platform"`
+	Timestamp           string  `json:"timestamp"`
+	Error               string  `json:"error,omitempty"`
+	StopLossOID         int64   `json:"stop_loss_oid,omitempty"`
+	StopLossTriggerPx   float64 `json:"stop_loss_trigger_px,omitempty"`
+	TP1OID              int64   `json:"tp1_oid,omitempty"`
+	TP2OID              int64   `json:"tp2_oid,omitempty"`
+	TP1Px               float64 `json:"tp1_px,omitempty"`
+	TP2Px               float64 `json:"tp2_px,omitempty"`
+	StopLossError       string  `json:"stop_loss_error,omitempty"`
+	TP1Error            string  `json:"tp1_error,omitempty"`
+	TP2Error            string  `json:"tp2_error,omitempty"`
+	OpenOrderCheckError string  `json:"open_order_check_error,omitempty"`
+}
+
 // RunPythonScript executes a Python script and returns stdout/stderr.
 func RunPythonScript(script string, args []string) ([]byte, []byte, error) {
 	pythonSemaphore <- struct{}{}
@@ -239,7 +258,7 @@ func RunHyperliquidCheck(script string, args []string) (*HyperliquidResult, stri
 // Python script calls adapter.market_close(sz=None) — closing the entire
 // on-chain residual without a sized order, eliminating rounding dust on final
 // TP tiers (#592).
-func buildHyperliquidExecuteArgs(symbol, side string, size, stopLossPct float64, cancelStopLossOID int64, prevPosQty float64, marginMode string, leverage float64, closeFullPosition bool) []string {
+func buildHyperliquidExecuteArgs(symbol, side string, size, stopLossPct float64, cancelStopLossOID int64, prevPosQty float64, marginMode string, leverage float64, closeFullPosition bool, extraCancelOIDs ...int64) []string {
 	args := []string{
 		"--execute",
 		fmt.Sprintf("--symbol=%s", symbol),
@@ -257,6 +276,11 @@ func buildHyperliquidExecuteArgs(symbol, side string, size, stopLossPct float64,
 	if cancelStopLossOID > 0 {
 		args = append(args, fmt.Sprintf("--cancel-stop-loss-oid=%d", cancelStopLossOID))
 	}
+	for _, oid := range extraCancelOIDs {
+		if oid > 0 && oid != cancelStopLossOID {
+			args = append(args, fmt.Sprintf("--cancel-stop-loss-oid=%d", oid))
+		}
+	}
 	if prevPosQty > 0 {
 		args = append(args, fmt.Sprintf("--prev-pos-qty=%g", prevPosQty))
 	}
@@ -271,8 +295,8 @@ func buildHyperliquidExecuteArgs(symbol, side string, size, stopLossPct float64,
 
 // RunHyperliquidExecute runs check_hyperliquid.py in execute mode (live orders).
 // See buildHyperliquidExecuteArgs for argv-contract details.
-func RunHyperliquidExecute(script, symbol, side string, size, stopLossPct float64, cancelStopLossOID int64, prevPosQty float64, marginMode string, leverage float64, closeFullPosition bool) (*HyperliquidExecuteResult, string, error) {
-	args := buildHyperliquidExecuteArgs(symbol, side, size, stopLossPct, cancelStopLossOID, prevPosQty, marginMode, leverage, closeFullPosition)
+func RunHyperliquidExecute(script, symbol, side string, size, stopLossPct float64, cancelStopLossOID int64, prevPosQty float64, marginMode string, leverage float64, closeFullPosition bool, extraCancelOIDs ...int64) (*HyperliquidExecuteResult, string, error) {
+	args := buildHyperliquidExecuteArgs(symbol, side, size, stopLossPct, cancelStopLossOID, prevPosQty, marginMode, leverage, closeFullPosition, extraCancelOIDs...)
 	stdout, stderr, err := RunPythonScript(script, args)
 	return parseHyperliquidExecuteOutput(stdout, string(stderr), err)
 }
@@ -294,6 +318,44 @@ func RunHyperliquidUpdateStopLoss(script, symbol, side string, size, triggerPx f
 	}
 	stdout, stderr, err := RunPythonScript(script, args)
 	return parseHyperliquidUpdateStopLossOutput(stdout, string(stderr), err)
+}
+
+func RunHyperliquidSyncProtection(script, symbol, side string, size, avgCost, entryATR, stopLossATRMult, tp1Mult, tp1Fraction, tp2Mult float64, stopLossOID, tp1OID, tp2OID int64) (*HyperliquidProtectionSyncResult, string, error) {
+	args := []string{
+		"--sync-protection",
+		fmt.Sprintf("--symbol=%s", symbol),
+		fmt.Sprintf("--side=%s", side),
+		fmt.Sprintf("--size=%g", size),
+		fmt.Sprintf("--avg-cost=%g", avgCost),
+		fmt.Sprintf("--entry-atr=%g", entryATR),
+		fmt.Sprintf("--stop-loss-atr-mult=%g", stopLossATRMult),
+		fmt.Sprintf("--tp1-atr-mult=%g", tp1Mult),
+		fmt.Sprintf("--tp1-fraction=%g", tp1Fraction),
+		fmt.Sprintf("--tp2-atr-mult=%g", tp2Mult),
+		"--mode=live",
+	}
+	if stopLossOID > 0 {
+		args = append(args, fmt.Sprintf("--stop-loss-oid=%d", stopLossOID))
+	}
+	if tp1OID > 0 {
+		args = append(args, fmt.Sprintf("--tp1-oid=%d", tp1OID))
+	}
+	if tp2OID > 0 {
+		args = append(args, fmt.Sprintf("--tp2-oid=%d", tp2OID))
+	}
+	stdout, stderr, err := RunPythonScript(script, args)
+	stderrStr := string(stderr)
+	var result HyperliquidProtectionSyncResult
+	if jsonErr := json.Unmarshal(stdout, &result); jsonErr != nil {
+		if err != nil {
+			return nil, stderrStr, fmt.Errorf("script error: %w (stderr: %s; stdout: %s)", err, stderrStr, string(stdout))
+		}
+		return nil, stderrStr, fmt.Errorf("parse output: %w (stdout: %s)", jsonErr, string(stdout))
+	}
+	if err != nil && result.Error == "" {
+		return &result, stderrStr, fmt.Errorf("script error: %w (stderr: %s)", err, stderrStr)
+	}
+	return &result, stderrStr, nil
 }
 
 func parseHyperliquidUpdateStopLossOutput(stdout []byte, stderrStr string, runErr error) (*HyperliquidStopLossUpdateResult, string, error) {

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -1096,8 +1096,10 @@ func runPendingHyperliquidCircuitCloses(
 		}
 		slOIDs := make(map[string][]int64, len(p.Symbols))
 		for _, c := range p.Symbols {
-			if pos, ok := ss.Positions[c.Symbol]; ok && pos != nil && pos.StopLossOID > 0 {
-				slOIDs[c.Symbol] = []int64{pos.StopLossOID}
+			if pos, ok := ss.Positions[c.Symbol]; ok && pos != nil {
+				slOIDs[c.Symbol] = appendUniquePositiveStopLossOID(slOIDs[c.Symbol], pos.StopLossOID)
+				slOIDs[c.Symbol] = appendUniquePositiveStopLossOID(slOIDs[c.Symbol], pos.TP1OID)
+				slOIDs[c.Symbol] = appendUniquePositiveStopLossOID(slOIDs[c.Symbol], pos.TP2OID)
 			}
 		}
 		jobs = append(jobs, job{id, *p, slOIDs})
@@ -1239,15 +1241,24 @@ func runPendingHyperliquidCircuitCloses(
 				fmt.Printf("[INFO] hl-circuit-close: strategy %s coin %s closed sz=%.6f (filled %.6f)\n", j.stratID, c.Symbol, sz, fillSz)
 			}
 
-			// Clear the StopLossOID under Lock when the cancel went
+			// Clear protection OIDs under Lock when the cancel went
 			// through, so a follow-up cycle doesn't try to cancel the
-			// already-cancelled trigger.
-			cancelOID := firstPositiveStopLossOID(cancelOIDs)
-			if cancelOID > 0 && result != nil && result.CancelStopLossSucceeded {
+			// already-cancelled orders.
+			if len(cancelOIDs) > 0 && result != nil && result.CancelStopLossSucceeded {
 				mu.Lock()
 				if ss := state.Strategies[j.stratID]; ss != nil {
-					if pos, ok := ss.Positions[c.Symbol]; ok && pos != nil && pos.StopLossOID == cancelOID {
-						pos.StopLossOID = 0
+					if pos, ok := ss.Positions[c.Symbol]; ok && pos != nil {
+						for _, cancelOID := range cancelOIDs {
+							if cancelOID > 0 && pos.StopLossOID == cancelOID {
+								pos.StopLossOID = 0
+							}
+							if cancelOID > 0 && pos.TP1OID == cancelOID {
+								pos.TP1OID = 0
+							}
+							if cancelOID > 0 && pos.TP2OID == cancelOID {
+								pos.TP2OID = 0
+							}
+						}
 					}
 				}
 				mu.Unlock()

--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+type hlProtectionPlan struct {
+	Symbol          string
+	Side            string
+	Size            float64
+	AvgCost         float64
+	EntryATR        float64
+	StopLossATRMult float64
+	TP1Mult         float64
+	TP1Fraction     float64
+	TP2Mult         float64
+	StopLossOID     int64
+	TP1OID          int64
+	TP2OID          int64
+}
+
+func buildHyperliquidProtectionPlan(sc StrategyConfig, pos *Position) (hlProtectionPlan, bool) {
+	if sc.Type != "perps" || sc.Platform != "hyperliquid" || pos == nil {
+		return hlProtectionPlan{}, false
+	}
+	if pos.Symbol == "" || pos.Quantity <= 0 || pos.AvgCost <= 0 || pos.EntryATR <= 0 {
+		return hlProtectionPlan{}, false
+	}
+	if pos.Side != "long" && pos.Side != "short" {
+		return hlProtectionPlan{}, false
+	}
+	slMult := 0.0
+	if sc.StopLossATRMult != nil && *sc.StopLossATRMult > 0 {
+		slMult = *sc.StopLossATRMult
+	}
+	tp1Mult, tp1Fraction, tp2Mult := hyperliquidProtectionTiers(sc)
+	if slMult <= 0 && (tp1Mult <= 0 || tp1Fraction <= 0 || tp2Mult <= 0) {
+		return hlProtectionPlan{}, false
+	}
+	return hlProtectionPlan{
+		Symbol:          pos.Symbol,
+		Side:            pos.Side,
+		Size:            pos.Quantity,
+		AvgCost:         pos.AvgCost,
+		EntryATR:        pos.EntryATR,
+		StopLossATRMult: slMult,
+		TP1Mult:         tp1Mult,
+		TP1Fraction:     tp1Fraction,
+		TP2Mult:         tp2Mult,
+		StopLossOID:     pos.StopLossOID,
+		TP1OID:          pos.TP1OID,
+		TP2OID:          pos.TP2OID,
+	}, true
+}
+
+func hyperliquidProtectionTiers(sc StrategyConfig) (float64, float64, float64) {
+	if !strategyUsesTieredTPATRClose(sc) {
+		return 0, 0, 0
+	}
+	tiers := parseHLProtectionTiers(sc.Params["tiers"])
+	if len(tiers) == 0 {
+		tiers = []hlProtectionTier{
+			{Multiple: 1, Fraction: 0.5},
+			{Multiple: 2, Fraction: 1},
+		}
+	}
+	if len(tiers) < 2 {
+		return 0, 0, 0
+	}
+	tp1 := tiers[0]
+	tp2 := tiers[1]
+	if tp1.Multiple <= 0 || tp1.Fraction <= 0 || tp2.Multiple <= 0 || tp2.Fraction <= tp1.Fraction {
+		return 0, 0, 0
+	}
+	return tp1.Multiple, tp1.Fraction, tp2.Multiple
+}
+
+type hlProtectionTier struct {
+	Multiple float64
+	Fraction float64
+}
+
+func parseHLProtectionTiers(raw interface{}) []hlProtectionTier {
+	items, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+	tiers := make([]hlProtectionTier, 0, len(items))
+	for _, item := range items {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		multiple := floatFromAny(firstPresent(m, "atr_multiple", "multiple"))
+		fraction := floatFromAny(firstPresent(m, "close_fraction", "fraction"))
+		if multiple <= 0 || fraction <= 0 {
+			continue
+		}
+		if fraction > 1 {
+			fraction = 1
+		}
+		tiers = append(tiers, hlProtectionTier{Multiple: multiple, Fraction: fraction})
+	}
+	sort.Slice(tiers, func(i, j int) bool { return tiers[i].Multiple < tiers[j].Multiple })
+	return tiers
+}
+
+func firstPresent(m map[string]interface{}, keys ...string) interface{} {
+	for _, key := range keys {
+		if v, ok := m[key]; ok {
+			return v
+		}
+	}
+	return nil
+}
+
+func floatFromAny(v interface{}) float64 {
+	switch x := v.(type) {
+	case float64:
+		return x
+	case float32:
+		return float64(x)
+	case int:
+		return float64(x)
+	case int64:
+		return float64(x)
+	case jsonNumber:
+		f, _ := x.Float64()
+		return f
+	default:
+		return 0
+	}
+}
+
+type jsonNumber interface {
+	Float64() (float64, error)
+}
+
+func syncHyperliquidProtection(sc StrategyConfig, plan hlProtectionPlan, notifier *MultiNotifier, logger *StrategyLogger) (*HyperliquidProtectionSyncResult, bool) {
+	result, stderr, err := RunHyperliquidSyncProtection(
+		sc.Script, plan.Symbol, plan.Side, plan.Size, plan.AvgCost, plan.EntryATR,
+		plan.StopLossATRMult, plan.TP1Mult, plan.TP1Fraction, plan.TP2Mult,
+		plan.StopLossOID, plan.TP1OID, plan.TP2OID,
+	)
+	if stderr != "" && logger != nil {
+		logger.Info("protection sync stderr: %s", stderr)
+	}
+	if err != nil {
+		if logger != nil {
+			logger.Error("HL protection sync failed: %v", err)
+		}
+		notifyHLProtectionFailure(notifier, sc, plan.Symbol, err.Error())
+		return result, false
+	}
+	if result == nil {
+		return nil, false
+	}
+	if result.Error != "" {
+		if logger != nil {
+			logger.Error("HL protection sync returned error: %s", result.Error)
+		}
+		notifyHLProtectionFailure(notifier, sc, plan.Symbol, result.Error)
+		return result, false
+	}
+	var warnings []string
+	if result.StopLossError != "" {
+		warnings = append(warnings, "SL: "+result.StopLossError)
+	}
+	if result.TP1Error != "" {
+		warnings = append(warnings, "TP1: "+result.TP1Error)
+	}
+	if result.TP2Error != "" {
+		warnings = append(warnings, "TP2: "+result.TP2Error)
+	}
+	if len(warnings) > 0 {
+		msg := fmt.Sprintf("%s %s protection partially failed: %v", sc.ID, plan.Symbol, warnings)
+		if logger != nil {
+			logger.Warn("%s", msg)
+		}
+		notifyHLProtectionFailure(notifier, sc, plan.Symbol, msg)
+	}
+	return result, true
+}
+
+func applyHyperliquidProtectionSync(pos *Position, result *HyperliquidProtectionSyncResult) {
+	if pos == nil || result == nil {
+		return
+	}
+	if result.StopLossOID > 0 {
+		pos.StopLossOID = result.StopLossOID
+	}
+	if result.StopLossTriggerPx > 0 {
+		pos.StopLossTriggerPx = result.StopLossTriggerPx
+	}
+	if result.TP1OID > 0 {
+		pos.TP1OID = result.TP1OID
+	}
+	if result.TP2OID > 0 {
+		pos.TP2OID = result.TP2OID
+	}
+}
+
+func notifyHLProtectionFailure(notifier *MultiNotifier, sc StrategyConfig, symbol, reason string) {
+	if notifier == nil || !notifier.HasBackends() {
+		return
+	}
+	msg := fmt.Sprintf("**HL PROTECTION WARNING** [%s] %s reduce-only SL/TP sync failed: %s", sc.ID, symbol, reason)
+	notifier.SendToAllChannels(msg)
+	notifier.SendOwnerDM(msg)
+}

--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 type hlProtectionPlan struct {
@@ -54,6 +55,20 @@ func buildHyperliquidProtectionPlan(sc StrategyConfig, pos *Position) (hlProtect
 	}, true
 }
 
+// hyperliquidProtectionTiers returns (tp1AtrMultiple, tp1Fraction, tp2AtrMultiple).
+//
+// Note: tier 2's close_fraction is INTENTIONALLY ignored — the on-chain TP2
+// limit is sized as `size * (1 - tp1Fraction)` so that TP1 + TP2 always equal
+// the strategy's full virtual quantity. The validation `tp2.Fraction <=
+// tp1.Fraction` exists only to enforce a sane ordering of the operator's
+// configured tiers; it does not flow into sizing. This mirrors the
+// `tiered_tp_atr` close-evaluator's "everything remaining" semantics for the
+// last tier and avoids leaving a residual sliver of position open after TP2.
+//
+// If you want a non-1.0 final tier (e.g. 50%/30%/20% across three tiers),
+// extend hlProtectionPlan to carry a slice of tiers and rework the Python
+// run_sync_protection placement loop accordingly. The current implementation
+// is fixed at exactly two tiers (#604 review optional 3).
 func hyperliquidProtectionTiers(sc StrategyConfig) (float64, float64, float64) {
 	if !strategyUsesTieredTPATRClose(sc) {
 		return 0, 0, 0
@@ -87,14 +102,24 @@ func parseHLProtectionTiers(raw interface{}) []hlProtectionTier {
 		return nil
 	}
 	tiers := make([]hlProtectionTier, 0, len(items))
-	for _, item := range items {
+	for idx, item := range items {
 		m, ok := item.(map[string]interface{})
 		if !ok {
+			fmt.Printf("[WARN] hl-protection: tier[%d] is not an object, skipping (got %T)\n", idx, item)
 			continue
 		}
-		multiple := floatFromAny(firstPresent(m, "atr_multiple", "multiple"))
-		fraction := floatFromAny(firstPresent(m, "close_fraction", "fraction"))
+		multiple, mErr := floatFromAnyChecked(firstPresent(m, "atr_multiple", "multiple"))
+		if mErr != nil {
+			fmt.Printf("[WARN] hl-protection: tier[%d] atr_multiple/multiple invalid: %v — tier skipped\n", idx, mErr)
+			continue
+		}
+		fraction, fErr := floatFromAnyChecked(firstPresent(m, "close_fraction", "fraction"))
+		if fErr != nil {
+			fmt.Printf("[WARN] hl-protection: tier[%d] close_fraction/fraction invalid: %v — tier skipped\n", idx, fErr)
+			continue
+		}
 		if multiple <= 0 || fraction <= 0 {
+			fmt.Printf("[WARN] hl-protection: tier[%d] non-positive multiple=%g fraction=%g — tier skipped\n", idx, multiple, fraction)
 			continue
 		}
 		if fraction > 1 {
@@ -116,20 +141,36 @@ func firstPresent(m map[string]interface{}, keys ...string) interface{} {
 }
 
 func floatFromAny(v interface{}) float64 {
+	f, _ := floatFromAnyChecked(v)
+	return f
+}
+
+// floatFromAnyChecked is the error-aware variant of floatFromAny. It accepts
+// numeric JSON values plus encoding/json.Number-shaped types and returns an
+// error for anything else (string, nil, bool, …) so the caller can surface
+// a config-author mistake instead of silently coercing to 0 (#604 review #6).
+func floatFromAnyChecked(v interface{}) (float64, error) {
 	switch x := v.(type) {
+	case nil:
+		return 0, fmt.Errorf("missing value")
 	case float64:
-		return x
+		return x, nil
 	case float32:
-		return float64(x)
+		return float64(x), nil
 	case int:
-		return float64(x)
+		return float64(x), nil
 	case int64:
-		return float64(x)
+		return float64(x), nil
 	case jsonNumber:
-		f, _ := x.Float64()
-		return f
+		f, err := x.Float64()
+		if err != nil {
+			return 0, fmt.Errorf("jsonNumber: %w", err)
+		}
+		return f, nil
+	case string:
+		return 0, fmt.Errorf("string %q is not a number; quote-strip the value in config.json", x)
 	default:
-		return 0
+		return 0, fmt.Errorf("unsupported type %T", v)
 	}
 }
 
@@ -187,6 +228,19 @@ func applyHyperliquidProtectionSync(pos *Position, result *HyperliquidProtection
 	if pos == nil || result == nil {
 		return
 	}
+	// Clear stale OIDs first when the Python side detected the prior order
+	// already filled on-chain. The reconciler will book the close in the
+	// next pass; here we just stop pointing at a dead OID that would be
+	// re-placed against stale virtual qty (#604 review #1).
+	if result.StopLossFilledExternally {
+		pos.StopLossOID = 0
+	}
+	if result.TP1FilledExternally {
+		pos.TP1OID = 0
+	}
+	if result.TP2FilledExternally {
+		pos.TP2OID = 0
+	}
 	if result.StopLossOID > 0 {
 		pos.StopLossOID = result.StopLossOID
 	}
@@ -199,6 +253,66 @@ func applyHyperliquidProtectionSync(pos *Position, result *HyperliquidProtection
 	if result.TP2OID > 0 {
 		pos.TP2OID = result.TP2OID
 	}
+}
+
+// hyperliquidPlacesOnChainTPs reports whether sc is configured to place
+// per-strategy on-chain reduce-only TP orders for HL perps. When true the
+// in-process tiered close evaluator MUST be suppressed — the on-chain limits
+// are the source of truth for tiered exits, and running both produces a race
+// where the limit fills on-chain (shrinking position) and then the close
+// evaluator emits another close_fraction sized off the stale virtual qty
+// (#604 review #2).
+func hyperliquidPlacesOnChainTPs(sc StrategyConfig) bool {
+	if sc.Type != "perps" || sc.Platform != "hyperliquid" {
+		return false
+	}
+	tp1Mult, tp1Fraction, tp2Mult := hyperliquidProtectionTiers(sc)
+	return tp1Mult > 0 && tp1Fraction > 0 && tp2Mult > 0
+}
+
+// closeStrategiesSuppressedByOnChainProtection is the set of close evaluator
+// names that are functionally replaced by on-chain reduce-only TP orders.
+// Adding a new ATR-tiered close evaluator? It probably belongs here too.
+var closeStrategiesSuppressedByOnChainProtection = map[string]struct{}{
+	"tiered_tp_atr":      {},
+	"tiered_tp_atr_live": {},
+}
+
+// filterCloseStrategiesForHLOnChainProtection returns the close-strategy list
+// with names that overlap on-chain reduce-only TPs removed. Other close
+// strategies (tp_at_pct, tiered_tp_pct, …) pass through unchanged so an
+// operator can layer a percent-based stop alongside the ATR-tiered TP limits.
+func filterCloseStrategiesForHLOnChainProtection(sc StrategyConfig) []string {
+	if !hyperliquidPlacesOnChainTPs(sc) {
+		return sc.CloseStrategies
+	}
+	if len(sc.CloseStrategies) == 0 {
+		return sc.CloseStrategies
+	}
+	out := make([]string, 0, len(sc.CloseStrategies))
+	for _, name := range sc.CloseStrategies {
+		trimmed := strings.TrimSpace(name)
+		if _, suppress := closeStrategiesSuppressedByOnChainProtection[trimmed]; suppress {
+			continue
+		}
+		out = append(out, name)
+	}
+	return out
+}
+
+// strategyConfigWithOnChainProtectionFilter returns a shallow copy of sc with
+// CloseStrategies filtered to drop on-chain-overlapping evaluators. Used at the
+// runHyperliquidCheck call site so the Python check script doesn't see the
+// suppressed names. Other fields share storage with the original — callers
+// must not mutate slice/map fields on the returned copy.
+func strategyConfigWithOnChainProtectionFilter(sc StrategyConfig) StrategyConfig {
+	filtered := filterCloseStrategiesForHLOnChainProtection(sc)
+	if len(filtered) == len(sc.CloseStrategies) {
+		return sc
+	}
+	clone := sc
+	clone.CloseStrategies = filtered
+	return clone
 }
 
 func notifyHLProtectionFailure(notifier *MultiNotifier, sc StrategyConfig, symbol, reason string) {

--- a/scheduler/hyperliquid_protection_test.go
+++ b/scheduler/hyperliquid_protection_test.go
@@ -1,6 +1,8 @@
 package main
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestBuildHyperliquidProtectionPlanUsesDefaultTieredATR(t *testing.T) {
 	mult := 1.0
@@ -32,6 +34,166 @@ func TestBuildHyperliquidProtectionPlanUsesDefaultTieredATR(t *testing.T) {
 	}
 	if plan.TP1OID != 101 || plan.TP2OID != 202 {
 		t.Errorf("TP OIDs = (%d, %d), want (101, 202)", plan.TP1OID, plan.TP2OID)
+	}
+}
+
+// TestApplyHyperliquidProtectionSyncPreservesExistingOIDs verifies the
+// "OID still resting" branch of run_sync_protection: when the result echoes
+// the existing OID back (via open_orders verification), pos.TP1OID/TP2OID
+// must remain set. A bug where the apply path overwrote with 0 would lose
+// the OID and trigger a duplicate-place on the next cycle.
+func TestApplyHyperliquidProtectionSyncPreservesExistingOIDs(t *testing.T) {
+	pos := &Position{
+		Symbol:      "ETH",
+		StopLossOID: 100,
+		TP1OID:      200,
+		TP2OID:      300,
+	}
+	result := &HyperliquidProtectionSyncResult{
+		StopLossOID:       100,
+		StopLossTriggerPx: 2900,
+		TP1OID:            200,
+		TP2OID:            300,
+	}
+	applyHyperliquidProtectionSync(pos, result)
+	if pos.StopLossOID != 100 || pos.TP1OID != 200 || pos.TP2OID != 300 {
+		t.Errorf("OIDs mutated: SL=%d TP1=%d TP2=%d, want 100/200/300",
+			pos.StopLossOID, pos.TP1OID, pos.TP2OID)
+	}
+	if pos.StopLossTriggerPx != 2900 {
+		t.Errorf("StopLossTriggerPx = %g, want 2900", pos.StopLossTriggerPx)
+	}
+}
+
+// TestApplyHyperliquidProtectionSyncRetainsOnZeroFields covers the case
+// where the Python side couldn't fetch open_orders (so it omits OID fields
+// from the result) — pos.TP1OID/TP2OID must NOT be cleared, otherwise the
+// next cycle would re-place against an OID that's still resting.
+func TestApplyHyperliquidProtectionSyncRetainsOnZeroFields(t *testing.T) {
+	pos := &Position{Symbol: "ETH", StopLossOID: 11, TP1OID: 22, TP2OID: 33}
+	applyHyperliquidProtectionSync(pos, &HyperliquidProtectionSyncResult{
+		OpenOrderCheckError: "indexer down",
+	})
+	if pos.StopLossOID != 11 || pos.TP1OID != 22 || pos.TP2OID != 33 {
+		t.Errorf("zero-field result mutated OIDs: SL=%d TP1=%d TP2=%d, want 11/22/33",
+			pos.StopLossOID, pos.TP1OID, pos.TP2OID)
+	}
+}
+
+// TestApplyHyperliquidProtectionSyncClearsFilledExternally is the over-close
+// guard: when the Python side detected the OID actually filled on-chain
+// (via userFills), the apply path must clear pos.TP1OID so the next cycle
+// does not re-place against stale virtual qty (#604 review #1).
+func TestApplyHyperliquidProtectionSyncClearsFilledExternally(t *testing.T) {
+	pos := &Position{Symbol: "ETH", StopLossOID: 11, TP1OID: 22, TP2OID: 33}
+	applyHyperliquidProtectionSync(pos, &HyperliquidProtectionSyncResult{
+		StopLossFilledExternally: true,
+		TP1FilledExternally:      true,
+		// TP2 still resting in this scenario.
+		TP2OID: 33,
+	})
+	if pos.StopLossOID != 0 {
+		t.Errorf("StopLossOID = %d, want 0 (cleared because filled externally)", pos.StopLossOID)
+	}
+	if pos.TP1OID != 0 {
+		t.Errorf("TP1OID = %d, want 0 (cleared because filled externally)", pos.TP1OID)
+	}
+	if pos.TP2OID != 33 {
+		t.Errorf("TP2OID = %d, want 33 (still resting)", pos.TP2OID)
+	}
+}
+
+func TestFilterCloseStrategiesForHLOnChainProtection(t *testing.T) {
+	mult := 1.0
+	cases := []struct {
+		name     string
+		sc       StrategyConfig
+		expected []string
+	}{
+		{
+			name: "tiered_tp_atr_live filtered when TP plan emitted",
+			sc: StrategyConfig{
+				Type:            "perps",
+				Platform:        "hyperliquid",
+				StopLossATRMult: &mult,
+				CloseStrategies: []string{"tiered_tp_atr_live", "tp_at_pct"},
+			},
+			expected: []string{"tp_at_pct"},
+		},
+		{
+			name: "no filter when no on-chain TPs (no tiered close strategy)",
+			sc: StrategyConfig{
+				Type:            "perps",
+				Platform:        "hyperliquid",
+				StopLossATRMult: &mult,
+				CloseStrategies: []string{"tp_at_pct"},
+			},
+			expected: []string{"tp_at_pct"},
+		},
+		{
+			name: "non-perps untouched",
+			sc: StrategyConfig{
+				Type:            "spot",
+				Platform:        "hyperliquid",
+				CloseStrategies: []string{"tiered_tp_atr_live"},
+			},
+			expected: []string{"tiered_tp_atr_live"},
+		},
+		{
+			name: "tiered_tp_atr also filtered",
+			sc: StrategyConfig{
+				Type:            "perps",
+				Platform:        "hyperliquid",
+				StopLossATRMult: &mult,
+				CloseStrategies: []string{"tiered_tp_atr"},
+			},
+			expected: []string{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterCloseStrategiesForHLOnChainProtection(tc.sc)
+			if len(got) != len(tc.expected) {
+				t.Fatalf("filtered = %v, want %v", got, tc.expected)
+			}
+			for i, name := range got {
+				if name != tc.expected[i] {
+					t.Errorf("filtered[%d] = %q, want %q", i, name, tc.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFloatFromAnyCheckedRejectsStrings(t *testing.T) {
+	if _, err := floatFromAnyChecked("1.5"); err == nil {
+		t.Error("expected error for string input, got nil")
+	}
+	if _, err := floatFromAnyChecked(nil); err == nil {
+		t.Error("expected error for nil input, got nil")
+	}
+	if _, err := floatFromAnyChecked(true); err == nil {
+		t.Error("expected error for bool input, got nil")
+	}
+	if v, err := floatFromAnyChecked(1.5); err != nil || v != 1.5 {
+		t.Errorf("float64 1.5: got (%g, %v), want (1.5, nil)", v, err)
+	}
+	if v, err := floatFromAnyChecked(2); err != nil || v != 2 {
+		t.Errorf("int 2: got (%g, %v), want (2, nil)", v, err)
+	}
+}
+
+func TestParseHLProtectionTiersSkipsInvalidValues(t *testing.T) {
+	raw := []interface{}{
+		map[string]interface{}{"atr_multiple": "1.5", "close_fraction": 0.5}, // string rejected
+		map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
+	}
+	tiers := parseHLProtectionTiers(raw)
+	if len(tiers) != 1 {
+		t.Fatalf("len(tiers) = %d, want 1 (string-typed tier should be skipped)", len(tiers))
+	}
+	if tiers[0].Multiple != 2 || tiers[0].Fraction != 1 {
+		t.Errorf("surviving tier = (%g, %g), want (2, 1)", tiers[0].Multiple, tiers[0].Fraction)
 	}
 }
 

--- a/scheduler/hyperliquid_protection_test.go
+++ b/scheduler/hyperliquid_protection_test.go
@@ -1,0 +1,60 @@
+package main
+
+import "testing"
+
+func TestBuildHyperliquidProtectionPlanUsesDefaultTieredATR(t *testing.T) {
+	mult := 1.0
+	sc := StrategyConfig{
+		ID:              "hl-eth",
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		StopLossATRMult: &mult,
+		CloseStrategies: []string{"tiered_tp_atr_live"},
+	}
+	pos := &Position{
+		Symbol:   "ETH",
+		Quantity: 2,
+		AvgCost:  3000,
+		EntryATR: 50,
+		Side:     "long",
+		TP1OID:   101,
+		TP2OID:   202,
+	}
+	plan, ok := buildHyperliquidProtectionPlan(sc, pos)
+	if !ok {
+		t.Fatal("buildHyperliquidProtectionPlan returned ok=false")
+	}
+	if plan.StopLossATRMult != 1 {
+		t.Errorf("StopLossATRMult = %g, want 1", plan.StopLossATRMult)
+	}
+	if plan.TP1Mult != 1 || plan.TP1Fraction != 0.5 || plan.TP2Mult != 2 {
+		t.Errorf("tiers = (%g, %g, %g), want (1, 0.5, 2)", plan.TP1Mult, plan.TP1Fraction, plan.TP2Mult)
+	}
+	if plan.TP1OID != 101 || plan.TP2OID != 202 {
+		t.Errorf("TP OIDs = (%d, %d), want (101, 202)", plan.TP1OID, plan.TP2OID)
+	}
+}
+
+func TestBuildHyperliquidProtectionPlanCustomTiers(t *testing.T) {
+	mult := 1.25
+	sc := StrategyConfig{
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		StopLossATRMult: &mult,
+		CloseStrategies: []string{"tiered_tp_atr_live"},
+		Params: map[string]interface{}{
+			"tiers": []interface{}{
+				map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
+				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.4},
+			},
+		},
+	}
+	pos := &Position{Symbol: "ETH", Quantity: 1, AvgCost: 2500, EntryATR: 25, Side: "short"}
+	plan, ok := buildHyperliquidProtectionPlan(sc, pos)
+	if !ok {
+		t.Fatal("buildHyperliquidProtectionPlan returned ok=false")
+	}
+	if plan.TP1Mult != 2 || plan.TP1Fraction != 0.4 || plan.TP2Mult != 3 {
+		t.Errorf("custom tiers = (%g, %g, %g), want (2, 0.4, 3)", plan.TP1Mult, plan.TP1Fraction, plan.TP2Mult)
+	}
+}

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -971,7 +971,7 @@ func TestValidateConfig_TrailingStopMinMovePct(t *testing.T) {
 	}
 }
 
-func TestValidateConfig_HLPeersTrailingAndFixedStopLossConflict(t *testing.T) {
+func TestValidateConfig_HLPeersTrailingAndFixedStopLossAllowed(t *testing.T) {
 	trailing := 3.0
 	fixed := 2.0
 	cfg := &Config{
@@ -982,7 +982,7 @@ func TestValidateConfig_HLPeersTrailingAndFixedStopLossConflict(t *testing.T) {
 				Type:            "perps",
 				Platform:        "hyperliquid",
 				Script:          "shared_scripts/check_hyperliquid.py",
-				Args:            []string{"trend", "ETH", "1h", "--mode=live"},
+				Args:            []string{"trend", "ETH", "1h", "--mode=paper"},
 				Capital:         1000,
 				MaxDrawdownPct:  10,
 				Leverage:        10,
@@ -994,7 +994,7 @@ func TestValidateConfig_HLPeersTrailingAndFixedStopLossConflict(t *testing.T) {
 				Type:           "perps",
 				Platform:       "hyperliquid",
 				Script:         "shared_scripts/check_hyperliquid.py",
-				Args:           []string{"breakout", "ETH", "1h", "--mode=live"},
+				Args:           []string{"breakout", "ETH", "1h", "--mode=paper"},
 				Capital:        1000,
 				MaxDrawdownPct: 10,
 				Leverage:       10,
@@ -1005,11 +1005,8 @@ func TestValidateConfig_HLPeersTrailingAndFixedStopLossConflict(t *testing.T) {
 		PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 60},
 	}
 	err := ValidateConfig(cfg)
-	if err == nil {
-		t.Fatal("expected peer stop-loss conflict")
-	}
-	if !strings.Contains(err.Error(), "trailing_stop_pct") {
-		t.Fatalf("error=%v, want trailing_stop_pct conflict", err)
+	if err != nil {
+		t.Fatalf("ValidateConfig failed: %v", err)
 	}
 }
 
@@ -1200,11 +1197,9 @@ func TestValidateConfig_TrailingStopATRMult(t *testing.T) {
 	}
 }
 
-// #505: peer ownership detection must treat trailing_stop_atr_mult as one of
-// the four "this strategy owns the on-chain trigger" signals so two HL peers
-// on the same coin can't both arm a trailing stop and race their cancel/replace
-// against the shared on-chain position.
-func TestValidateConfig_HLPeersATRTrailingConflict(t *testing.T) {
+// #601: peer stop ownership is allowed because protection orders are sized per
+// strategy.
+func TestValidateConfig_HLPeersATRTrailingAllowed(t *testing.T) {
 	mult := 1.5
 	fixed := 2.0
 	cfg := &Config{
@@ -1215,7 +1210,7 @@ func TestValidateConfig_HLPeersATRTrailingConflict(t *testing.T) {
 				Type:                "perps",
 				Platform:            "hyperliquid",
 				Script:              "shared_scripts/check_hyperliquid.py",
-				Args:                []string{"trend", "ETH", "1h", "--mode=live"},
+				Args:                []string{"trend", "ETH", "1h", "--mode=paper"},
 				Capital:             1000,
 				MaxDrawdownPct:      10,
 				Leverage:            10,
@@ -1227,7 +1222,7 @@ func TestValidateConfig_HLPeersATRTrailingConflict(t *testing.T) {
 				Type:           "perps",
 				Platform:       "hyperliquid",
 				Script:         "shared_scripts/check_hyperliquid.py",
-				Args:           []string{"breakout", "ETH", "1h", "--mode=live"},
+				Args:           []string{"breakout", "ETH", "1h", "--mode=paper"},
 				Capital:        1000,
 				MaxDrawdownPct: 10,
 				Leverage:       10,
@@ -1238,19 +1233,14 @@ func TestValidateConfig_HLPeersATRTrailingConflict(t *testing.T) {
 		PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 60},
 	}
 	err := ValidateConfig(cfg)
-	if err == nil {
-		t.Fatal("expected peer stop-loss conflict")
-	}
-	if !strings.Contains(err.Error(), "trailing_stop_atr_mult") {
-		t.Fatalf("error=%v, want trailing_stop_atr_mult conflict", err)
+	if err != nil {
+		t.Fatalf("ValidateConfig failed: %v", err)
 	}
 }
 
-// #505: peer normalization must coerce omitted trailing_stop_atr_mult on
-// same-coin HL peers to an explicit zero on stop_loss_pct (the same treatment
-// trailing_stop_pct already gets) so the MaxDrawdownPct auto-derive only fires
-// for sole-owner strategies.
-func TestNormalizeHyperliquidPeerStopLosses_TrailingATRMultOwner(t *testing.T) {
+// #601: peer normalization is now a no-op; shared-coin peers keep normal
+// stop-loss defaulting because protection orders are sized per strategy.
+func TestNormalizeHyperliquidPeerStopLosses_TrailingATRMultOwnerNoop(t *testing.T) {
 	mult := 1.5
 	strategies := []StrategyConfig{
 		{
@@ -1276,14 +1266,8 @@ func TestNormalizeHyperliquidPeerStopLosses_TrailingATRMultOwner(t *testing.T) {
 	if strategies[0].StopLossPct != nil {
 		t.Errorf("ATR-mult owner should not gain a normalized StopLossPct; got %v", strategies[0].StopLossPct)
 	}
-	if strategies[1].StopLossPct == nil {
-		t.Fatalf("non-owner peer should be normalized to explicit 0 StopLossPct, got nil")
-	}
-	if *strategies[1].StopLossPct != 0 {
-		t.Errorf("non-owner peer normalized StopLossPct = %g, want 0", *strategies[1].StopLossPct)
-	}
-	if got := EffectiveStopLossPct(strategies[1]); got != 0 {
-		t.Errorf("non-owner peer EffectiveStopLossPct = %g, want 0 (no MaxDrawdownPct fallback)", got)
+	if strategies[1].StopLossPct != nil {
+		t.Fatalf("peer StopLossPct = %v, want nil", strategies[1].StopLossPct)
 	}
 }
 
@@ -2012,17 +1996,14 @@ func TestNormalizeHyperliquidPeerStopLosses_FixedATRMultOwner(t *testing.T) {
 	if strategies[0].StopLossPct != nil {
 		t.Errorf("fixed ATR-mult owner should not gain a normalized StopLossPct; got %v", strategies[0].StopLossPct)
 	}
-	if strategies[1].StopLossPct == nil {
-		t.Fatalf("non-owner peer should be normalized to explicit 0 StopLossPct, got nil")
-	}
-	if *strategies[1].StopLossPct != 0 {
-		t.Errorf("non-owner peer normalized StopLossPct = %g, want 0", *strategies[1].StopLossPct)
+	if strategies[1].StopLossPct != nil {
+		t.Fatalf("peer StopLossPct = %v, want nil", strategies[1].StopLossPct)
 	}
 }
 
-// #562: hyperliquidPeerStrategyErrors flags two peers on the same coin both
-// owning a fixed ATR-mult stop loss — at most one peer may place a trigger.
-func TestHyperliquidPeerStrategyErrors_FixedATRMultConflict(t *testing.T) {
+// #601: hyperliquidPeerStrategyErrors allows multiple same-coin peers with
+// fixed ATR stops because each order is sized to that strategy's virtual qty.
+func TestHyperliquidPeerStrategyErrors_FixedATRMultAllowed(t *testing.T) {
 	a := 1.5
 	b := 2.0
 	strategies := []StrategyConfig{
@@ -2038,18 +2019,13 @@ func TestHyperliquidPeerStrategyErrors_FixedATRMultConflict(t *testing.T) {
 		},
 	}
 	errs := hyperliquidPeerStrategyErrors(strategies)
-	if len(errs) == 0 {
-		t.Fatal("expected peer stop-loss conflict error")
-	}
-	joined := strings.Join(errs, " | ")
-	if !strings.Contains(joined, "conflicting") {
-		t.Errorf("expected conflict message, got: %v", errs)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected peer errors: %v", errs)
 	}
 }
 
-// #562: LoadConfig defaults sole-owner HL perps strategies with no explicit
-// stop fields to stop_loss_atr_mult=1.0. Peers don't get the default — peer
-// normalization sets StopLossPct=0 first.
+// #562/#601: LoadConfig defaults HL perps strategies with no explicit stop
+// fields to stop_loss_atr_mult=1.0, including shared-coin peers.
 func TestLoadConfig_DefaultsStopLossATRMultForSoleOwner(t *testing.T) {
 	dir := t.TempDir()
 	cfgJSON := `{
@@ -2105,9 +2081,9 @@ func TestLoadConfig_NoDefaultStopLossATRMultWhenExplicitFieldSet(t *testing.T) {
 	}
 }
 
-// #562: peer strategies on the same coin do NOT receive the default — peer
-// normalization runs first and sets StopLossPct=0, which makes them ineligible.
-func TestLoadConfig_NoDefaultStopLossATRMultForPeers(t *testing.T) {
+// #601: peer strategies on the same coin receive the default ATR stop because
+// exchange-side orders are sized per strategy.
+func TestLoadConfig_DefaultStopLossATRMultForPeers(t *testing.T) {
 	dir := t.TempDir()
 	cfgJSON := `{
 		"strategies": [
@@ -2139,11 +2115,11 @@ func TestLoadConfig_NoDefaultStopLossATRMultForPeers(t *testing.T) {
 	}
 	for _, sc := range cfg.Strategies {
 		if sc.ID == "hl-eth-breakout" {
-			if sc.StopLossATRMult != nil {
-				t.Errorf("peer should not receive default StopLossATRMult; got %v", sc.StopLossATRMult)
+			if sc.StopLossATRMult == nil || *sc.StopLossATRMult != DefaultStopLossATRMult {
+				t.Errorf("peer StopLossATRMult = %v, want default %.1f", sc.StopLossATRMult, DefaultStopLossATRMult)
 			}
-			if sc.StopLossPct == nil || *sc.StopLossPct != 0 {
-				t.Errorf("peer StopLossPct should be normalized to 0; got %v", sc.StopLossPct)
+			if sc.StopLossPct != nil {
+				t.Errorf("peer StopLossPct = %v, want nil", sc.StopLossPct)
 			}
 		}
 	}

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -2001,6 +2001,63 @@ func TestNormalizeHyperliquidPeerStopLosses_FixedATRMultOwner(t *testing.T) {
 	}
 }
 
+// #604 review #5: trailing stops still race on the shared on-chain position
+// because each cycle's cancel/replace is non-atomic. Two trailing peers must
+// be rejected even though fixed-distance peers are allowed.
+func TestHyperliquidPeerStrategyErrors_TrailingStopConflict(t *testing.T) {
+	a := 0.05 // 5% trailing
+	b := 0.03
+	strategies := []StrategyConfig{
+		{
+			ID: "hl-eth-trail-a", Type: "perps", Platform: "hyperliquid",
+			Args: []string{"trend", "ETH", "1h"}, Leverage: 5,
+			TrailingStopPct: &a,
+		},
+		{
+			ID: "hl-eth-trail-b", Type: "perps", Platform: "hyperliquid",
+			Args: []string{"breakout", "ETH", "1h"}, Leverage: 5,
+			TrailingStopPct: &b,
+		},
+	}
+	errs := hyperliquidPeerStrategyErrors(strategies)
+	if len(errs) == 0 {
+		t.Fatal("expected trailing-stop peer conflict error, got none")
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e, "trailing-stop owners") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected error mentioning trailing-stop owners, got: %v", errs)
+	}
+}
+
+// #604 review #5: ATR-mult trailing stops have the same race as percentage
+// trailing — both call hyperliquidArmFixedATRStopLossLive's cancel/replace.
+func TestHyperliquidPeerStrategyErrors_TrailingATRConflict(t *testing.T) {
+	a := 1.0
+	b := 1.5
+	strategies := []StrategyConfig{
+		{
+			ID: "hl-btc-a", Type: "perps", Platform: "hyperliquid",
+			Args: []string{"trend", "BTC", "1h"}, Leverage: 3,
+			TrailingStopATRMult: &a,
+		},
+		{
+			ID: "hl-btc-b", Type: "perps", Platform: "hyperliquid",
+			Args: []string{"breakout", "BTC", "1h"}, Leverage: 3,
+			TrailingStopATRMult: &b,
+		},
+	}
+	errs := hyperliquidPeerStrategyErrors(strategies)
+	if len(errs) == 0 {
+		t.Fatal("expected trailing-ATR peer conflict error, got none")
+	}
+}
+
 // #601: hyperliquidPeerStrategyErrors allows multiple same-coin peers with
 // fixed ATR stops because each order is sized to that strategy's virtual qty.
 func TestHyperliquidPeerStrategyErrors_FixedATRMultAllowed(t *testing.T) {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -838,8 +838,10 @@ func main() {
 						continue
 					}
 					if ss, ok := state.Strategies[sc.ID]; ok && ss != nil {
-						if pos, pok := ss.Positions[sym]; pok && pos != nil && pos.StopLossOID > 0 {
+						if pos, pok := ss.Positions[sym]; pok && pos != nil {
 							hlSLOIDs[sym] = appendUniquePositiveStopLossOID(hlSLOIDs[sym], pos.StopLossOID)
+							hlSLOIDs[sym] = appendUniquePositiveStopLossOID(hlSLOIDs[sym], pos.TP1OID)
+							hlSLOIDs[sym] = appendUniquePositiveStopLossOID(hlSLOIDs[sym], pos.TP2OID)
 						}
 					}
 				}
@@ -1116,6 +1118,8 @@ func main() {
 					var hlEntryATR float64
 					var hlPosCtx PositionCtx
 					var hlStopLossOID int64
+					var hlTP1OID int64
+					var hlTP2OID int64
 					var hlStopLossTriggerPx float64
 					var hlStopLossHighWaterPx float64
 					if sc.Type == "perps" && sc.Platform == "hyperliquid" {
@@ -1133,6 +1137,8 @@ func main() {
 								hlAvgCost = hlPosCtx.AvgCost
 								hlEntryATR = pos.EntryATR
 								hlStopLossOID = pos.StopLossOID
+								hlTP1OID = pos.TP1OID
+								hlTP2OID = pos.TP2OID
 								hlStopLossTriggerPx = pos.StopLossTriggerPx
 								hlStopLossHighWaterPx = pos.StopLossHighWaterPx
 							}
@@ -1457,8 +1463,27 @@ func main() {
 									}
 								}
 							}
+							if hyperliquidIsLive(sc.Args) && result.Signal == 0 && hlPosQty > 0 {
+								var plan hlProtectionPlan
+								var syncOK bool
+								mu.RLock()
+								if pos, ok3 := stratState.Positions[result.Symbol]; ok3 {
+									plan, syncOK = buildHyperliquidProtectionPlan(sc, pos)
+								}
+								mu.RUnlock()
+								if syncOK {
+									if protection, ok2 := syncHyperliquidProtection(sc, plan, notifier, logger); ok2 && protection != nil {
+										mu.Lock()
+										if pos, ok3 := stratState.Positions[result.Symbol]; ok3 && pos.Quantity > 0 && pos.Side == plan.Side {
+											applyHyperliquidProtectionSync(pos, protection)
+											logger.Info("HL protection synced (sl_oid=%d tp1_oid=%d tp2_oid=%d)", pos.StopLossOID, pos.TP1OID, pos.TP2OID)
+										}
+										mu.Unlock()
+									}
+								}
+							}
 							if hyperliquidIsLive(sc.Args) && result.Signal != 0 {
-								er, ok2 := runHyperliquidExecuteOrder(sc, result, price, hlCash, hlPosQty, hlPosSide, hlAvgCost, hlStopLossOID, hlLiveAll, notifier, logger)
+								er, ok2 := runHyperliquidExecuteOrder(sc, result, price, hlCash, hlPosQty, hlPosSide, hlAvgCost, hlStopLossOID, hlTP1OID, hlTP2OID, hlLiveAll, notifier, logger)
 								if ok2 {
 									execResult = er
 								} else {
@@ -1484,6 +1509,25 @@ func main() {
 								mu.Lock()
 								trades, detail = executeHyperliquidResult(sc, stratState, stateDB, result, execResult, signalStr, price, logger)
 								mu.Unlock()
+								if execResult != nil && trades > 0 {
+									var plan hlProtectionPlan
+									var syncOK bool
+									mu.RLock()
+									if pos, ok3 := stratState.Positions[result.Symbol]; ok3 {
+										plan, syncOK = buildHyperliquidProtectionPlan(sc, pos)
+									}
+									mu.RUnlock()
+									if syncOK {
+										if protection, ok2 := syncHyperliquidProtection(sc, plan, notifier, logger); ok2 && protection != nil {
+											mu.Lock()
+											if pos, ok3 := stratState.Positions[result.Symbol]; ok3 && pos.Quantity > 0 && pos.Side == plan.Side {
+												applyHyperliquidProtectionSync(pos, protection)
+												logger.Info("HL protection synced after trade (sl_oid=%d tp1_oid=%d tp2_oid=%d)", pos.StopLossOID, pos.TP1OID, pos.TP2OID)
+											}
+											mu.Unlock()
+										}
+									}
+								}
 							}
 						}
 					case "futures":
@@ -2333,7 +2377,7 @@ func shouldCloseFullPosition(closeFraction float64, symbol string, hlLiveAll []S
 // Trade record, leaving state silently behind actual exchange holdings. See
 // issue #298 — 0.716 ETH of live fills were lost this way because the
 // "already long, skipping buy" branch sat AFTER RunHyperliquidExecute.
-func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, price, cash, posQty float64, posSide string, avgCost float64, existingStopLossOID int64, hlLiveAll []StrategyConfig, notifier *MultiNotifier, logger *StrategyLogger) (*HyperliquidExecuteResult, bool) {
+func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, price, cash, posQty float64, posSide string, avgCost float64, existingStopLossOID, existingTP1OID, existingTP2OID int64, hlLiveAll []StrategyConfig, notifier *MultiNotifier, logger *StrategyLogger) (*HyperliquidExecuteResult, bool) {
 	if reason := PerpsOrderSkipReason(result.Signal, posSide, sc.AllowShorts); reason != "" {
 		logger.Info("Skipping live order for %s: %s", result.Symbol, reason)
 		return nil, false
@@ -2384,6 +2428,10 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	if existingStopLossOID > 0 && posQty > 0 && !partialClose {
 		cancelOID = existingStopLossOID
 	}
+	var extraCancelOIDs []int64
+	if posQty > 0 && !partialClose {
+		extraCancelOIDs = append(extraCancelOIDs, existingTP1OID, existingTP2OID)
+	}
 	var slPct float64
 	if !pureClose && !partialClose {
 		// EffectiveStopLossPct self-guards on platform/type and returns the
@@ -2428,7 +2476,7 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	} else if result.CloseFraction == 1.0 {
 		logger.Info("Final-tier close %s shares coin with HL perps peers — using sized close to preserve peer exposure", result.Symbol)
 	}
-	execResult, stderr, err := RunHyperliquidExecute(sc.Script, result.Symbol, side, size, slPct, cancelOID, prevPosQty, marginMode, leverageForOpen, closeFullPosition)
+	execResult, stderr, err := RunHyperliquidExecute(sc.Script, result.Symbol, side, size, slPct, cancelOID, prevPosQty, marginMode, leverageForOpen, closeFullPosition, extraCancelOIDs...)
 	if stderr != "" {
 		logger.Info("execute stderr: %s", stderr)
 	}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2294,7 +2294,12 @@ func isHLLiveReconcilable(sc StrategyConfig) bool {
 // runHyperliquidCheck runs check_hyperliquid.py signal-check mode (Phase 3, no lock).
 func runHyperliquidCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, logger *StrategyLogger) (*HyperliquidResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
-	args = appendOpenCloseArgs(args, sc, posCtx)
+	// Suppress in-process close evaluators that overlap on-chain reduce-only
+	// protection — running both races on the shared on-chain position
+	// (#604 review #2). Filter only changes the argv passed to Python; the
+	// stored config is untouched.
+	scForCheck := strategyConfigWithOnChainProtectionFilter(sc)
+	args = appendOpenCloseArgs(args, scForCheck, posCtx)
 	if sc.HTFFilter {
 		args = append(args, "--htf-filter")
 	}

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -170,6 +170,15 @@ func bookPerpsCloseWithFillFee(s *StrategyState, symbol string, closePx, fillFee
 	pnl -= fee
 	s.Cash += pnl
 	positionID := ensurePositionTradeID(s.ID, symbol, pos)
+	// Note (#604 review #3): pos.TP1OID/TP2OID are dropped on the floor here
+	// when the reconciler detects an external close. HL auto-cancels
+	// reduce-only orders once the underlying position is flat (a TP fill
+	// would otherwise create a new opposite-side position, violating the
+	// reduce-only flag), so the orphan OIDs are cleared exchange-side. The
+	// executable close paths (full-close via runHyperliquidExecuteOrder,
+	// kill-switch flatten, per-strategy circuit drain) DO explicitly cancel
+	// TP OIDs by piggy-backing on the existing --cancel-stop-loss-oid argv
+	// so we don't depend on auto-cancel timing for paths under our control.
 
 	trade := Trade{
 		Timestamp:       now,

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -22,6 +22,8 @@ type Position struct {
 	StopLossOID         int64     `json:"stop_loss_oid,omitempty"`           // HL perps: resting trigger-order OID for the per-trade stop-loss (0 = none) (#412)
 	StopLossTriggerPx   float64   `json:"stop_loss_trigger_px,omitempty"`    // HL perps: trigger price for the resting stop-loss (0 = unknown) (#421)
 	StopLossHighWaterPx float64   `json:"stop_loss_high_water_px,omitempty"` // HL perps trailing SL: best mark seen while position open (high for long, low for short) (#501)
+	TP1OID              int64     `json:"tp1_oid,omitempty"`                 // HL perps: resting reduce-only TP1 limit OID for per-strategy protection (#601)
+	TP2OID              int64     `json:"tp2_oid,omitempty"`                 // HL perps: resting reduce-only TP2 limit OID for per-strategy protection (#601)
 }
 
 // ClosedPosition is a historical record of a position after it closed (#288).

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -319,6 +319,37 @@ def _oid_is_open(open_oids: set[int] | None, oid: int) -> bool:
     return oid > 0 and open_oids is not None and int(oid) in open_oids
 
 
+def _oid_filled_externally(adapter, oid: int, since_ms: int) -> dict:
+    """Check whether ``oid`` has filled on-chain by querying userFills.
+
+    Returns a dict with at minimum ``{"filled": bool}``. When filled, also
+    includes ``size`` (summed across partial fills) and the ``fee`` /
+    ``closed_pnl`` fields surfaced by ``lookup_fill_fee_by_oid``. Failure to
+    query is non-fatal: the caller treats {"filled": False} as "we don't
+    know" and proceeds with re-placement only when we have positive evidence
+    the order was cancelled (open-orders fetch succeeded and OID absent).
+
+    Used by run_sync_protection to avoid the over-close hazard where a TP
+    OID that has actually filled (shrinking the on-chain position) is
+    re-placed at the same price sized against stale virtual qty (#604 review #1).
+    """
+    if oid <= 0:
+        return {"filled": False}
+    try:
+        lookup = adapter.lookup_fill_fee_by_oid(int(oid), since_ms)
+    except Exception as e:
+        print(f"[WARN] userFills lookup({oid}) failed: {e}", file=sys.stderr)
+        return {"filled": False, "error": str(e)}
+    if not lookup:
+        return {"filled": False}
+    return {
+        "filled": True,
+        "fee": float(lookup.get("fee", 0) or 0),
+        "closed_pnl": float(lookup.get("closed_pnl", 0) or 0),
+        "count": int(lookup.get("count", 0) or 0),
+    }
+
+
 def run_sync_protection(
     symbol,
     side,
@@ -363,6 +394,34 @@ def run_sync_protection(
 
         close_is_buy = side == "short"
 
+        # Wide window for the userFills "did this OID fill?" lookup. We don't
+        # know how long the prior OID was outstanding, so look back 7 days —
+        # any fill older than that is irrelevant (the OID would have been
+        # rotated long since). Bounding at 7d keeps the indexer scan cheap
+        # but still catches fills that occurred during a multi-day outage.
+        fill_check_since_ms = int(time.time() * 1000) - 7 * 24 * 3600 * 1000
+
+        def _resolve_missing_oid(prev_oid: int):
+            """Decide what to do with a previously-recorded OID that is no
+            longer in open_orders. Returns one of:
+                ("place",   None)  — OID never existed or was cancelled; place new
+                ("filled",  fill)  — OID actually filled on-chain; do NOT re-place
+                ("unknown", None)  — open_orders fetch failed; defer
+            (#604 review #1)
+            """
+            if prev_oid <= 0:
+                return ("place", None)
+            if open_oids is None:
+                # We couldn't fetch open_orders — don't re-place a TP/SL
+                # without knowing whether the prior one is still resting.
+                # Re-placement here is what would over-close: better to
+                # surface the failure and try again next cycle.
+                return ("unknown", None)
+            fill = _oid_filled_externally(adapter, prev_oid, fill_check_since_ms)
+            if fill.get("filled"):
+                return ("filled", fill)
+            return ("place", None)
+
         if stop_loss_atr_mult > 0:
             if side == "long":
                 sl_px = avg_cost - stop_loss_atr_mult * entry_atr
@@ -372,20 +431,27 @@ def run_sync_protection(
             out["stop_loss_trigger_px"] = sl_px
             if _oid_is_open(open_oids, stop_loss_oid):
                 out["stop_loss_oid"] = int(stop_loss_oid)
-            elif stop_loss_oid <= 0 or open_oids is not None:
-                try:
-                    resp = adapter.place_stop_loss(symbol, size, sl_px, close_is_buy)
-                    kind, payload = _classify_sl_response(resp)
-                    if kind == "resting":
-                        out["stop_loss_oid"] = payload
-                    elif kind == "filled":
-                        out["stop_loss_filled_immediately"] = True
-                    elif kind == "error":
-                        out["stop_loss_error"] = f"place_stop_loss SDK error: {payload}"
-                    else:
-                        out["stop_loss_error"] = f"place_stop_loss returned no usable status: {resp}"
-                except Exception as se:
-                    out["stop_loss_error"] = str(se)
+            else:
+                action, fill = _resolve_missing_oid(stop_loss_oid)
+                if action == "filled":
+                    out["stop_loss_filled_externally"] = True
+                    out["stop_loss_fill"] = fill
+                    print(f"[WARN] stop-loss OID={stop_loss_oid} already filled on-chain; not re-placing — reconciler will book the close", file=sys.stderr)
+                elif action == "place":
+                    try:
+                        resp = adapter.place_stop_loss(symbol, size, sl_px, close_is_buy)
+                        kind, payload = _classify_sl_response(resp)
+                        if kind == "resting":
+                            out["stop_loss_oid"] = payload
+                        elif kind == "filled":
+                            out["stop_loss_filled_immediately"] = True
+                        elif kind == "error":
+                            out["stop_loss_error"] = f"place_stop_loss SDK error: {payload}"
+                        else:
+                            out["stop_loss_error"] = f"place_stop_loss returned no usable status: {resp}"
+                    except Exception as se:
+                        out["stop_loss_error"] = str(se)
+                # action=="unknown" → leave SL OID untouched, retry next cycle
 
         if tp1_atr_mult > 0 and tp1_fraction > 0 and tp2_atr_mult > 0:
             if side == "long":
@@ -400,37 +466,49 @@ def run_sync_protection(
             out["tp2_px"] = adapter.round_perps_trigger_px(symbol, tp2_px)
             if _oid_is_open(open_oids, tp1_oid):
                 out["tp1_oid"] = int(tp1_oid)
-            elif tp1_oid <= 0 or open_oids is not None:
-                try:
-                    resp = adapter.place_take_profit_limit(symbol, tp1_size, tp1_px, close_is_buy)
-                    kind, payload = _classify_sl_response(resp)
-                    if kind == "resting":
-                        out["tp1_oid"] = payload
-                    elif kind == "filled":
-                        out["tp1_filled_immediately"] = True
-                    elif kind == "error":
-                        out["tp1_error"] = f"place_take_profit_limit SDK error: {payload}"
-                    else:
-                        out["tp1_error"] = f"place_take_profit_limit returned no usable status: {resp}"
-                except Exception as te:
-                    out["tp1_error"] = str(te)
+            else:
+                action, fill = _resolve_missing_oid(tp1_oid)
+                if action == "filled":
+                    out["tp1_filled_externally"] = True
+                    out["tp1_fill"] = fill
+                    print(f"[WARN] TP1 OID={tp1_oid} already filled on-chain; not re-placing — reconciler will book the close", file=sys.stderr)
+                elif action == "place":
+                    try:
+                        resp = adapter.place_take_profit_limit(symbol, tp1_size, tp1_px, close_is_buy)
+                        kind, payload = _classify_sl_response(resp)
+                        if kind == "resting":
+                            out["tp1_oid"] = payload
+                        elif kind == "filled":
+                            out["tp1_filled_immediately"] = True
+                        elif kind == "error":
+                            out["tp1_error"] = f"place_take_profit_limit SDK error: {payload}"
+                        else:
+                            out["tp1_error"] = f"place_take_profit_limit returned no usable status: {resp}"
+                    except Exception as te:
+                        out["tp1_error"] = str(te)
             if tp2_size > 0:
                 if _oid_is_open(open_oids, tp2_oid):
                     out["tp2_oid"] = int(tp2_oid)
-                elif tp2_oid <= 0 or open_oids is not None:
-                    try:
-                        resp = adapter.place_take_profit_limit(symbol, tp2_size, tp2_px, close_is_buy)
-                        kind, payload = _classify_sl_response(resp)
-                        if kind == "resting":
-                            out["tp2_oid"] = payload
-                        elif kind == "filled":
-                            out["tp2_filled_immediately"] = True
-                        elif kind == "error":
-                            out["tp2_error"] = f"place_take_profit_limit SDK error: {payload}"
-                        else:
-                            out["tp2_error"] = f"place_take_profit_limit returned no usable status: {resp}"
-                    except Exception as te:
-                        out["tp2_error"] = str(te)
+                else:
+                    action, fill = _resolve_missing_oid(tp2_oid)
+                    if action == "filled":
+                        out["tp2_filled_externally"] = True
+                        out["tp2_fill"] = fill
+                        print(f"[WARN] TP2 OID={tp2_oid} already filled on-chain; not re-placing — reconciler will book the close", file=sys.stderr)
+                    elif action == "place":
+                        try:
+                            resp = adapter.place_take_profit_limit(symbol, tp2_size, tp2_px, close_is_buy)
+                            kind, payload = _classify_sl_response(resp)
+                            if kind == "resting":
+                                out["tp2_oid"] = payload
+                            elif kind == "filled":
+                                out["tp2_filled_immediately"] = True
+                            elif kind == "error":
+                                out["tp2_error"] = f"place_take_profit_limit SDK error: {payload}"
+                            else:
+                                out["tp2_error"] = f"place_take_profit_limit returned no usable status: {resp}"
+                        except Exception as te:
+                            out["tp2_error"] = str(te)
 
         print(json.dumps(out, cls=SafeEncoder))
     except Exception as e:

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -315,6 +315,131 @@ def _classify_sl_response(sdk_response: dict):
     return ("missing", None)
 
 
+def _oid_is_open(open_oids: set[int] | None, oid: int) -> bool:
+    return oid > 0 and open_oids is not None and int(oid) in open_oids
+
+
+def run_sync_protection(
+    symbol,
+    side,
+    size,
+    avg_cost,
+    entry_atr,
+    mode,
+    stop_loss_atr_mult=0.0,
+    tp1_atr_mult=0.0,
+    tp1_fraction=0.0,
+    tp2_atr_mult=0.0,
+    stop_loss_oid=0,
+    tp1_oid=0,
+    tp2_oid=0,
+):
+    """Verify/re-place per-strategy reduce-only SL/TP orders (#601)."""
+    if mode != "live":
+        print(json.dumps({"error": "--sync-protection requires --mode=live"}, cls=SafeEncoder))
+        sys.exit(1)
+    side = side.lower()
+    if side not in ("long", "short"):
+        print(json.dumps({"error": f"invalid side {side!r}"}, cls=SafeEncoder))
+        sys.exit(1)
+    if size <= 0 or avg_cost <= 0 or entry_atr <= 0:
+        print(json.dumps({"error": "size, avg-cost, and entry-atr must be > 0"}, cls=SafeEncoder))
+        sys.exit(1)
+
+    out = {
+        "platform": "hyperliquid",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    try:
+        from adapter import HyperliquidExchangeAdapter
+        adapter = HyperliquidExchangeAdapter()
+
+        open_oids = None
+        try:
+            open_oids = adapter.open_order_oids(symbol)
+        except Exception as oe:
+            out["open_order_check_error"] = str(oe)
+            print(f"[WARN] open_order_oids({symbol}) failed: {oe}; will place only missing zero-OID protection", file=sys.stderr)
+
+        close_is_buy = side == "short"
+
+        if stop_loss_atr_mult > 0:
+            if side == "long":
+                sl_px = avg_cost - stop_loss_atr_mult * entry_atr
+            else:
+                sl_px = avg_cost + stop_loss_atr_mult * entry_atr
+            sl_px = adapter.round_perps_trigger_px(symbol, sl_px)
+            out["stop_loss_trigger_px"] = sl_px
+            if _oid_is_open(open_oids, stop_loss_oid):
+                out["stop_loss_oid"] = int(stop_loss_oid)
+            elif stop_loss_oid <= 0 or open_oids is not None:
+                try:
+                    resp = adapter.place_stop_loss(symbol, size, sl_px, close_is_buy)
+                    kind, payload = _classify_sl_response(resp)
+                    if kind == "resting":
+                        out["stop_loss_oid"] = payload
+                    elif kind == "filled":
+                        out["stop_loss_filled_immediately"] = True
+                    elif kind == "error":
+                        out["stop_loss_error"] = f"place_stop_loss SDK error: {payload}"
+                    else:
+                        out["stop_loss_error"] = f"place_stop_loss returned no usable status: {resp}"
+                except Exception as se:
+                    out["stop_loss_error"] = str(se)
+
+        if tp1_atr_mult > 0 and tp1_fraction > 0 and tp2_atr_mult > 0:
+            if side == "long":
+                tp1_px = avg_cost + tp1_atr_mult * entry_atr
+                tp2_px = avg_cost + tp2_atr_mult * entry_atr
+            else:
+                tp1_px = avg_cost - tp1_atr_mult * entry_atr
+                tp2_px = avg_cost - tp2_atr_mult * entry_atr
+            tp1_size = size * min(max(tp1_fraction, 0.0), 1.0)
+            tp2_size = max(size - tp1_size, 0.0)
+            out["tp1_px"] = adapter.round_perps_trigger_px(symbol, tp1_px)
+            out["tp2_px"] = adapter.round_perps_trigger_px(symbol, tp2_px)
+            if _oid_is_open(open_oids, tp1_oid):
+                out["tp1_oid"] = int(tp1_oid)
+            elif tp1_oid <= 0 or open_oids is not None:
+                try:
+                    resp = adapter.place_take_profit_limit(symbol, tp1_size, tp1_px, close_is_buy)
+                    kind, payload = _classify_sl_response(resp)
+                    if kind == "resting":
+                        out["tp1_oid"] = payload
+                    elif kind == "filled":
+                        out["tp1_filled_immediately"] = True
+                    elif kind == "error":
+                        out["tp1_error"] = f"place_take_profit_limit SDK error: {payload}"
+                    else:
+                        out["tp1_error"] = f"place_take_profit_limit returned no usable status: {resp}"
+                except Exception as te:
+                    out["tp1_error"] = str(te)
+            if tp2_size > 0:
+                if _oid_is_open(open_oids, tp2_oid):
+                    out["tp2_oid"] = int(tp2_oid)
+                elif tp2_oid <= 0 or open_oids is not None:
+                    try:
+                        resp = adapter.place_take_profit_limit(symbol, tp2_size, tp2_px, close_is_buy)
+                        kind, payload = _classify_sl_response(resp)
+                        if kind == "resting":
+                            out["tp2_oid"] = payload
+                        elif kind == "filled":
+                            out["tp2_filled_immediately"] = True
+                        elif kind == "error":
+                            out["tp2_error"] = f"place_take_profit_limit SDK error: {payload}"
+                        else:
+                            out["tp2_error"] = f"place_take_profit_limit returned no usable status: {resp}"
+                    except Exception as te:
+                        out["tp2_error"] = str(te)
+
+        print(json.dumps(out, cls=SafeEncoder))
+    except Exception as e:
+        traceback.print_exc(file=sys.stderr)
+        out["error"] = str(e)
+        print(json.dumps(out, cls=SafeEncoder))
+        sys.exit(1)
+
+
 def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_pos_qty=0.0, margin_mode="", leverage=0, close_full_position=False):
     """Place a live market order on Hyperliquid, optionally wrapping it with
     a stop-loss trigger (open) or cancelling a stale SL trigger (close).
@@ -338,7 +463,9 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
     # raises. Otherwise pos.StopLossOID points at a dead OID for another cycle
     # and the next signal tries to cancel a non-existent order. (#421)
     cancel_err = ""
-    cancel_attempted = cancel_oid > 0
+    cancel_oids = cancel_oid if isinstance(cancel_oid, list) else [cancel_oid]
+    cancel_oids = [int(oid) for oid in cancel_oids if int(oid or 0) > 0]
+    cancel_attempted = len(cancel_oids) > 0
     cancel_succeeded = False
 
     try:
@@ -403,12 +530,18 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
         # position sync will detect the close on the next cycle) but is
         # surfaced in the JSON so the scheduler can log it.
         if cancel_attempted:
+            cancel_errors = []
             try:
-                adapter.cancel_trigger_order(symbol, cancel_oid)
-                cancel_succeeded = True
-            except Exception as ce:
-                cancel_err = str(ce)
-                print(f"[WARN] cancel_trigger_order({symbol}, {cancel_oid}) failed: {ce}", file=sys.stderr)
+                for oid in cancel_oids:
+                    try:
+                        adapter.cancel_trigger_order(symbol, oid)
+                        cancel_succeeded = True
+                    except Exception as ce:
+                        cancel_errors.append(f"{oid}: {ce}")
+                        print(f"[WARN] cancel_trigger_order({symbol}, {oid}) failed: {ce}", file=sys.stderr)
+            finally:
+                if cancel_errors:
+                    cancel_err = "; ".join(cancel_errors)
 
         # Bound the userFills lookup window to "shortly before submit" so the
         # post-fill query (#585) doesn't have to scan unrelated history.
@@ -641,7 +774,40 @@ def run_update_stop_loss(symbol, side, size, trigger_px, mode, cancel_oid=0):
 
 
 def main():
-    if "--update-stop-loss" in sys.argv:
+    if "--sync-protection" in sys.argv:
+        import argparse
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--sync-protection", action="store_true")
+        parser.add_argument("--symbol", required=True)
+        parser.add_argument("--side", required=True, choices=["long", "short"])
+        parser.add_argument("--size", type=float, required=True)
+        parser.add_argument("--avg-cost", type=float, required=True)
+        parser.add_argument("--entry-atr", type=float, required=True)
+        parser.add_argument("--stop-loss-atr-mult", type=float, default=0.0)
+        parser.add_argument("--tp1-atr-mult", type=float, default=0.0)
+        parser.add_argument("--tp1-fraction", type=float, default=0.0)
+        parser.add_argument("--tp2-atr-mult", type=float, default=0.0)
+        parser.add_argument("--stop-loss-oid", type=int, default=0)
+        parser.add_argument("--tp1-oid", type=int, default=0)
+        parser.add_argument("--tp2-oid", type=int, default=0)
+        parser.add_argument("--mode", default="live")
+        args = parser.parse_args()
+        run_sync_protection(
+            args.symbol,
+            args.side,
+            args.size,
+            args.avg_cost,
+            args.entry_atr,
+            args.mode,
+            stop_loss_atr_mult=args.stop_loss_atr_mult,
+            tp1_atr_mult=args.tp1_atr_mult,
+            tp1_fraction=args.tp1_fraction,
+            tp2_atr_mult=args.tp2_atr_mult,
+            stop_loss_oid=args.stop_loss_oid,
+            tp1_oid=args.tp1_oid,
+            tp2_oid=args.tp2_oid,
+        )
+    elif "--update-stop-loss" in sys.argv:
         import argparse
         parser = argparse.ArgumentParser()
         parser.add_argument("--update-stop-loss", action="store_true")
@@ -670,7 +836,7 @@ def main():
         parser.add_argument("--mode", default="live")
         parser.add_argument("--stop-loss-pct", type=float, default=0.0,
                             help="place a reduce-only SL trigger this pct away from fill (#412)")
-        parser.add_argument("--cancel-stop-loss-oid", type=int, default=0,
+        parser.add_argument("--cancel-stop-loss-oid", type=int, action="append", default=[],
                             help="cancel this trigger OID before placing the new order (#412)")
         parser.add_argument("--prev-pos-qty", type=float, default=0.0,
                             help="abs qty of existing position being flipped, so SL is sized against the new net position (#421)")

--- a/shared_scripts/test_check_hyperliquid.py
+++ b/shared_scripts/test_check_hyperliquid.py
@@ -635,3 +635,181 @@ class TestCloseFullPosition:
         })
         # market_close called with sz=None — HL determines the size, not the caller
         adapter.market_close.assert_called_once_with("ETH", sz=None)
+
+
+class TestSyncProtection:
+    """#601 / #604 review #1: run_sync_protection branches for OID present /
+    gone-but-cancelled / gone-but-filled. The over-close hazard arises when a
+    TP OID dropped from open_orders because it actually filled (not because
+    it was cancelled), and the script blindly re-places at the same price
+    sized off the stale virtual qty."""
+
+    def _run_sync(
+        self,
+        *,
+        size=1.0,
+        avg_cost=2000.0,
+        entry_atr=20.0,
+        side="long",
+        sl_oid=0,
+        tp1_oid=0,
+        tp2_oid=0,
+        open_oids=None,
+        fill_lookup_by_oid=None,
+        place_responses=None,
+    ):
+        mod, spec = _load_check_module()
+        spec.loader.exec_module(mod)
+
+        mock_adapter_cls = MagicMock()
+        mock_adapter = MagicMock()
+        mock_adapter_cls.return_value = mock_adapter
+        mock_adapter.open_order_oids.return_value = (
+            set() if open_oids is None else set(open_oids)
+        )
+        mock_adapter.round_perps_trigger_px.side_effect = lambda _sym, px: round(px, 4)
+
+        fills = fill_lookup_by_oid or {}
+
+        def lookup_side_effect(oid, *args, **kwargs):
+            return fills.get(int(oid), {})
+
+        mock_adapter.lookup_fill_fee_by_oid.side_effect = lookup_side_effect
+
+        responses = place_responses or {}
+
+        def stop_loss_side_effect(*args, **kwargs):
+            return responses.get("sl", {"status": "ok", "response": {"type": "order", "data": {"statuses": [{"resting": {"oid": 9000}}]}}})
+
+        def tp_side_effect(symbol, sz, px, is_buy):
+            # Return distinct OIDs for TP1 vs TP2 by detecting which call this
+            # is via a counter on the side_effect itself.
+            count = mock_adapter.place_take_profit_limit.call_count
+            key = "tp1" if count == 1 else "tp2"
+            return responses.get(key, {
+                "status": "ok",
+                "response": {"type": "order", "data": {"statuses": [{"resting": {"oid": 9100 + count}}]}}
+            })
+
+        mock_adapter.place_stop_loss.side_effect = stop_loss_side_effect
+        mock_adapter.place_take_profit_limit.side_effect = tp_side_effect
+
+        captured = StringIO()
+        import builtins
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "adapter":
+                fake_mod = MagicMock()
+                fake_mod.HyperliquidExchangeAdapter = mock_adapter_cls
+                return fake_mod
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            with patch("sys.stdout", captured):
+                mod.run_sync_protection(
+                    "ETH",
+                    side,
+                    size,
+                    avg_cost,
+                    entry_atr,
+                    "live",
+                    stop_loss_atr_mult=1.0,
+                    tp1_atr_mult=1.0,
+                    tp1_fraction=0.5,
+                    tp2_atr_mult=2.0,
+                    stop_loss_oid=sl_oid,
+                    tp1_oid=tp1_oid,
+                    tp2_oid=tp2_oid,
+                )
+        return json.loads(captured.getvalue()), mock_adapter
+
+    def test_existing_oid_still_open_returns_same_oid(self):
+        """OID still in open_orders → echo it back, do NOT call place_take_profit_limit."""
+        out, adapter = self._run_sync(
+            tp1_oid=200,
+            tp2_oid=300,
+            sl_oid=100,
+            open_oids={100, 200, 300},
+        )
+        assert out["tp1_oid"] == 200
+        assert out["tp2_oid"] == 300
+        assert out["stop_loss_oid"] == 100
+        adapter.place_take_profit_limit.assert_not_called()
+        adapter.place_stop_loss.assert_not_called()
+        adapter.lookup_fill_fee_by_oid.assert_not_called()
+
+    def test_missing_oid_with_no_fill_places_replacement(self):
+        """OID gone from open_orders AND not in userFills → cancelled, place new."""
+        out, adapter = self._run_sync(
+            tp1_oid=200,
+            tp2_oid=300,
+            open_oids=set(),  # empty — TP OIDs gone
+            fill_lookup_by_oid={},  # no fills for any OID
+        )
+        # New OIDs surfaced
+        assert "tp1_oid" in out
+        assert "tp2_oid" in out
+        # userFills was consulted to make sure the OID hadn't filled
+        assert adapter.lookup_fill_fee_by_oid.called
+        # New TPs placed
+        assert adapter.place_take_profit_limit.call_count == 2
+        # Filled-externally flag NOT set
+        assert not out.get("tp1_filled_externally")
+        assert not out.get("tp2_filled_externally")
+
+    def test_missing_oid_with_fill_marks_externally_filled(self):
+        """OID gone AND userFills shows a fill → filled externally; do NOT re-place. (#604 review #1)"""
+        out, adapter = self._run_sync(
+            tp1_oid=200,
+            tp2_oid=300,
+            open_oids=set(),
+            fill_lookup_by_oid={
+                200: {"fee": 0.05, "closed_pnl": 25.0, "count": 1},
+                # TP2 still missing (cancelled, not filled)
+            },
+        )
+        assert out.get("tp1_filled_externally") is True
+        assert "tp1_fill" in out
+        assert out["tp1_fill"]["fee"] == 0.05
+        # TP2 should be placed since no fill found
+        assert not out.get("tp2_filled_externally")
+        # Only ONE place_take_profit_limit call (for TP2), because TP1 was filled.
+        assert adapter.place_take_profit_limit.call_count == 1
+
+    def test_open_orders_fetch_failure_defers_replacement(self):
+        """open_order_oids() raise → leave existing OIDs alone, do not re-place
+        (would double-up the protection). The script returns the failure
+        marker so the Go side knows to retry next cycle."""
+        mod, spec = _load_check_module()
+        spec.loader.exec_module(mod)
+
+        mock_adapter_cls = MagicMock()
+        mock_adapter = MagicMock()
+        mock_adapter_cls.return_value = mock_adapter
+        mock_adapter.open_order_oids.side_effect = RuntimeError("indexer down")
+        mock_adapter.round_perps_trigger_px.side_effect = lambda _sym, px: round(px, 4)
+
+        captured = StringIO()
+        import builtins
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "adapter":
+                fake_mod = MagicMock()
+                fake_mod.HyperliquidExchangeAdapter = mock_adapter_cls
+                return fake_mod
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            with patch("sys.stdout", captured):
+                mod.run_sync_protection(
+                    "ETH", "long", 1.0, 2000.0, 20.0, "live",
+                    stop_loss_atr_mult=1.0, tp1_atr_mult=1.0, tp1_fraction=0.5, tp2_atr_mult=2.0,
+                    stop_loss_oid=100, tp1_oid=200, tp2_oid=300,
+                )
+        out = json.loads(captured.getvalue())
+        assert out["open_order_check_error"] == "indexer down"
+        # No re-placements issued — existing OIDs are left alone.
+        mock_adapter.place_take_profit_limit.assert_not_called()
+        mock_adapter.place_stop_loss.assert_not_called()


### PR DESCRIPTION
## Summary

- Add per-strategy Hyperliquid protection syncing for shared-coin perps positions: fixed ATR stop-loss plus tiered ATR TP1/TP2 reduce-only orders sized to the strategy virtual position.
- Persist TP1/TP2 OIDs on positions, migrate SQLite state, and verify/re-place missing protection on live idle cycles and immediately after live opens.
- Stop normalizing shared-coin peers out of default ATR stop protection now that protection orders are sized per strategy.
- Cancel TP OIDs alongside SL OIDs during full/flip closes, circuit closes, and kill-switch flattening so stale protection does not linger on-chain.

## Root Cause

Shared-coin Hyperliquid strategies were normalized to opt out of default SL ownership to avoid unsized trigger races on the pooled exchange position. That left peer strategies without on-chain protection, and tiered TP exits only existed as in-process close evaluators.

## Validation

- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...`
- `uv run --extra test pytest platforms/hyperliquid/test_adapter.py shared_scripts/test_check_hyperliquid.py`

Closes #601 

LLM: GPT-5.5 | high