### PR TITLE
#T column counts positions opened, not round trips

### DIFF
--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -1251,32 +1251,59 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	return state, nil
 }
 
-// LifetimeTradeStats holds the per-strategy round-trip totals derived from
-// the trades table (#455/#471). RoundTrips is the lifetime count of distinct
-// trade position IDs among close rows; legacy rows without a position ID fall
-// back to one synthetic group per row to preserve historical per-leg counts.
-// Wins and Losses partition round trips by strict net realized PnL sign
-// (PnL > 0 → win, PnL < 0 → loss). Breakeven positions are excluded from both
-// buckets. Open positions without a recorded close do not count.
+// LifetimeTradeStats holds the per-strategy lifetime totals derived from
+// the trades table (#455/#471/#607). PositionsOpened is the lifetime count
+// of open legs (is_close=0 rows) — the #T column in summaries / leaderboard
+// shows positions entered, not closed round trips, so partial-close legs
+// don't inflate the count and still-open positions are included. Wins and
+// Losses are derived from closed round trips grouped by position_id and
+// partitioned by strict net realized PnL sign (PnL > 0 → win, PnL < 0 →
+// loss); breakeven round trips are excluded from both buckets. Legacy close
+// rows without a position_id fall back to one synthetic group per row.
 type LifetimeTradeStats struct {
-	RoundTrips int
-	Wins       int
-	Losses     int
+	PositionsOpened int
+	Wins            int
+	Losses          int
 }
 
-// LifetimeTradeStatsAll returns lifetime round-trip stats for every strategy
-// that has at least one close trade in the trades table. Strategies with no
-// closes are absent from the result; callers should treat a missing key as
-// an all-zero struct. Used by FormatCategorySummary (#455) to render lifetime
-// #T / W/L columns that are immune to kill-switch / circuit-breaker resets
-// of the in-memory RiskState counters.
+// LifetimeTradeStatsAll returns lifetime stats for every strategy that has
+// any trade row in the trades table. Strategies with no trades are absent
+// from the result; callers should treat a missing key as an all-zero
+// struct. PositionsOpened counts is_close=0 rows; Wins/Losses come from
+// closed-round-trip aggregation. Used by FormatCategorySummary (#455) and
+// the leaderboard (#580) to render lifetime #T / W/L columns that are
+// immune to kill-switch / circuit-breaker resets of the in-memory RiskState
+// counters.
 func (sdb *StateDB) LifetimeTradeStatsAll() (map[string]LifetimeTradeStats, error) {
 	if sdb == nil || sdb.db == nil {
 		return nil, fmt.Errorf("state db unavailable")
 	}
-	rows, err := sdb.db.Query(`SELECT
+	out := make(map[string]LifetimeTradeStats)
+
+	openRows, err := sdb.db.Query(`SELECT strategy_id, COUNT(*)
+		FROM trades
+		WHERE is_close = 0
+		GROUP BY strategy_id`)
+	if err != nil {
+		return nil, fmt.Errorf("query lifetime open counts: %w", err)
+	}
+	defer openRows.Close()
+	for openRows.Next() {
+		var id string
+		var opens sql.NullInt64
+		if err := openRows.Scan(&id, &opens); err != nil {
+			return nil, fmt.Errorf("scan lifetime open counts: %w", err)
+		}
+		entry := out[id]
+		entry.PositionsOpened = int(opens.Int64)
+		out[id] = entry
+	}
+	if err := openRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate lifetime open counts: %w", err)
+	}
+
+	closeRows, err := sdb.db.Query(`SELECT
 			strategy_id,
-			COUNT(*) AS round_trips,
 			SUM(CASE WHEN net_pnl > 0 THEN 1 ELSE 0 END) AS wins,
 			SUM(CASE WHEN net_pnl < 0 THEN 1 ELSE 0 END) AS losses
 		FROM (
@@ -1296,21 +1323,19 @@ func (sdb *StateDB) LifetimeTradeStatsAll() (map[string]LifetimeTradeStats, erro
 	if err != nil {
 		return nil, fmt.Errorf("query lifetime trade stats: %w", err)
 	}
-	defer rows.Close()
-	out := make(map[string]LifetimeTradeStats)
-	for rows.Next() {
+	defer closeRows.Close()
+	for closeRows.Next() {
 		var id string
-		var total, wins, losses sql.NullInt64
-		if err := rows.Scan(&id, &total, &wins, &losses); err != nil {
+		var wins, losses sql.NullInt64
+		if err := closeRows.Scan(&id, &wins, &losses); err != nil {
 			return nil, fmt.Errorf("scan lifetime trade stats: %w", err)
 		}
-		out[id] = LifetimeTradeStats{
-			RoundTrips: int(total.Int64),
-			Wins:       int(wins.Int64),
-			Losses:     int(losses.Int64),
-		}
+		entry := out[id]
+		entry.Wins = int(wins.Int64)
+		entry.Losses = int(losses.Int64)
+		out[id] = entry
 	}
-	if err := rows.Err(); err != nil {
+	if err := closeRows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate lifetime trade stats: %w", err)
 	}
 	return out, nil

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -2173,8 +2173,8 @@ CREATE TABLE trades (
 		t.Fatalf("LifetimeTradeStatsAll: %v", err)
 	}
 	got := stats["s1"]
-	if got.RoundTrips != 3 {
-		t.Errorf("RoundTrips = %d, want 3 (3 close legs of 5 rows)", got.RoundTrips)
+	if got.PositionsOpened != 2 {
+		t.Errorf("PositionsOpened = %d, want 2 (2 open legs of 5 rows)", got.PositionsOpened)
 	}
 	if got.Wins != 2 {
 		t.Errorf("Wins = %d, want 2 (PnL > 0: $42.50, $3.14)", got.Wins)
@@ -2208,14 +2208,14 @@ func TestLifetimeTradeStatsAll_FreshInsert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LifetimeTradeStatsAll: %v", err)
 	}
-	if got := stats["s1"]; got.RoundTrips != 2 || got.Wins != 1 || got.Losses != 1 {
-		t.Errorf("s1 stats = %+v, want RoundTrips=2 Wins=1 Losses=1", got)
+	if got := stats["s1"]; got.PositionsOpened != 2 || got.Wins != 1 || got.Losses != 1 {
+		t.Errorf("s1 stats = %+v, want PositionsOpened=2 Wins=1 Losses=1", got)
 	}
-	if got := stats["s2"]; got.RoundTrips != 1 || got.Wins != 1 || got.Losses != 0 {
-		t.Errorf("s2 stats = %+v, want RoundTrips=1 Wins=1 Losses=0", got)
+	if got := stats["s2"]; got.PositionsOpened != 1 || got.Wins != 1 || got.Losses != 0 {
+		t.Errorf("s2 stats = %+v, want PositionsOpened=1 Wins=1 Losses=0", got)
 	}
 	if _, ok := stats["s3"]; ok {
-		t.Errorf("unexpected entry for s3 with no closes: %+v", stats["s3"])
+		t.Errorf("unexpected entry for s3 with no trades: %+v", stats["s3"])
 	}
 }
 
@@ -2238,8 +2238,8 @@ func TestLifetimeTradeStatsAll_PartialClosesNetByPositionID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LifetimeTradeStatsAll: %v", err)
 	}
-	if got := stats["s1"]; got.RoundTrips != 1 || got.Wins != 1 || got.Losses != 0 {
-		t.Errorf("stats = %+v, want RoundTrips=1 Wins=1 Losses=0", got)
+	if got := stats["s1"]; got.PositionsOpened != 1 || got.Wins != 1 || got.Losses != 0 {
+		t.Errorf("stats = %+v, want PositionsOpened=1 Wins=1 Losses=0", got)
 	}
 }
 
@@ -2267,8 +2267,8 @@ func TestLifetimeTradeStatsAll_LegacyNullAndEmptyPositionIDStayPerLeg(t *testing
 	if err != nil {
 		t.Fatalf("LifetimeTradeStatsAll: %v", err)
 	}
-	if got := stats["s1"]; got.RoundTrips != 2 || got.Wins != 1 || got.Losses != 1 {
-		t.Errorf("legacy stats = %+v, want RoundTrips=2 Wins=1 Losses=1", got)
+	if got := stats["s1"]; got.PositionsOpened != 0 || got.Wins != 1 || got.Losses != 1 {
+		t.Errorf("legacy stats = %+v, want PositionsOpened=0 Wins=1 Losses=1 (only close legs seeded)", got)
 	}
 }
 
@@ -2288,11 +2288,11 @@ func TestLifetimeTradeStatsAll_PositionIDScopedByStrategy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LifetimeTradeStatsAll: %v", err)
 	}
-	if got := stats["s1"]; got.RoundTrips != 1 || got.Wins != 1 || got.Losses != 0 {
-		t.Errorf("s1 stats = %+v, want RoundTrips=1 Wins=1 Losses=0", got)
+	if got := stats["s1"]; got.PositionsOpened != 0 || got.Wins != 1 || got.Losses != 0 {
+		t.Errorf("s1 stats = %+v, want PositionsOpened=0 Wins=1 Losses=0 (only close legs seeded)", got)
 	}
-	if got := stats["s2"]; got.RoundTrips != 1 || got.Wins != 0 || got.Losses != 1 {
-		t.Errorf("s2 stats = %+v, want RoundTrips=1 Wins=0 Losses=1", got)
+	if got := stats["s2"]; got.PositionsOpened != 0 || got.Wins != 0 || got.Losses != 1 {
+		t.Errorf("s2 stats = %+v, want PositionsOpened=0 Wins=0 Losses=1 (only close legs seeded)", got)
 	}
 }
 
@@ -2312,8 +2312,8 @@ func TestLifetimeTradeStatsAll_BreakevenPositionNeitherWinNorLoss(t *testing.T) 
 	if err != nil {
 		t.Fatalf("LifetimeTradeStatsAll: %v", err)
 	}
-	if got := stats["s1"]; got.RoundTrips != 1 || got.Wins != 0 || got.Losses != 0 {
-		t.Errorf("breakeven stats = %+v, want RoundTrips=1 Wins=0 Losses=0", got)
+	if got := stats["s1"]; got.PositionsOpened != 0 || got.Wins != 0 || got.Losses != 0 {
+		t.Errorf("breakeven stats = %+v, want PositionsOpened=0 Wins=0 Losses=0 (only close legs seeded)", got)
 	}
 }
 
@@ -2390,8 +2390,8 @@ func TestLifetimeTradeStatsAll_OptionsSameContractReopenUsesDistinctPositionIDs(
 	if err != nil {
 		t.Fatalf("LifetimeTradeStatsAll: %v", err)
 	}
-	if got := stats[s.ID]; got.RoundTrips != 2 || got.Wins != 2 || got.Losses != 0 {
-		t.Errorf("option stats = %+v, want RoundTrips=2 Wins=2 Losses=0", got)
+	if got := stats[s.ID]; got.PositionsOpened != 2 || got.Wins != 2 || got.Losses != 0 {
+		t.Errorf("option stats = %+v, want PositionsOpened=2 Wins=2 Losses=0", got)
 	}
 }
 
@@ -2422,7 +2422,7 @@ func TestLifetimeTradeStats_SurvivesRiskStateReset(t *testing.T) {
 		t.Fatalf("LifetimeTradeStatsAll: %v", err)
 	}
 	got := stats["s1"]
-	if got.RoundTrips != 2 || got.Wins != 1 || got.Losses != 1 {
-		t.Errorf("post-reset stats = %+v, want RoundTrips=2 Wins=1 Losses=1", got)
+	if got.PositionsOpened != 0 || got.Wins != 1 || got.Losses != 1 {
+		t.Errorf("post-reset stats = %+v, want PositionsOpened=0 Wins=1 Losses=1 (only close legs seeded)", got)
 	}
 }

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -458,12 +458,13 @@ func FormatCategorySummary(
 		if effectiveInterval <= 0 {
 			effectiveInterval = globalIntervalSeconds
 		}
-		// Lifetime round-trip stats from the trades table (#455/#471). Survives
-		// kill-switch and circuit-breaker resets; counts grouped close legs as
-		// one position-level round trip. Missing DB rows render as zero.
+		// Lifetime trade stats from the trades table (#455/#471/#607). Survives
+		// kill-switch and circuit-breaker resets. #T renders the lifetime
+		// open-leg count (positions entered, not closed round trips); W/L is
+		// still derived from closed round trips. Missing DB rows render zero.
 		closedT, winT, lossT := 0, 0, 0
 		if lt, ok := lifetimeStats[sc.ID]; ok {
-			closedT = lt.RoundTrips
+			closedT = lt.PositionsOpened
 			winT = lt.Wins
 			lossT = lt.Losses
 		}

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -771,9 +771,9 @@ func TestFormatCategorySummary_ClosedTradesColumn(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 	lifetime := map[string]LifetimeTradeStats{
-		"hl-rsi-btc": {RoundTrips: 7},
-		"hl-sma-btc": {RoundTrips: 12},
-		"hl-mom-btc": {RoundTrips: 0},
+		"hl-rsi-btc": {PositionsOpened: 7},
+		"hl-sma-btc": {PositionsOpened: 12},
+		"hl-mom-btc": {PositionsOpened: 0},
 	}
 
 	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, lifetime)
@@ -830,8 +830,8 @@ func TestFormatCategorySummary_ClosedTradesColumn_SharedWallet(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 	lifetime := map[string]LifetimeTradeStats{
-		"hl-rmc-eth":  {RoundTrips: 4},
-		"hl-tema-eth": {RoundTrips: 9},
+		"hl-rmc-eth":  {PositionsOpened: 4},
+		"hl-tema-eth": {PositionsOpened: 9},
 	}
 
 	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, lifetime)
@@ -907,9 +907,9 @@ func TestFormatCategorySummary_WinLossColumn(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 	lifetime := map[string]LifetimeTradeStats{
-		"hl-rsi-btc": {RoundTrips: 10, Wins: 7, Losses: 3},
-		"hl-sma-btc": {RoundTrips: 5, Wins: 5, Losses: 0},
-		"hl-mom-btc": {RoundTrips: 0, Wins: 0, Losses: 0},
+		"hl-rsi-btc": {PositionsOpened: 10, Wins: 7, Losses: 3},
+		"hl-sma-btc": {PositionsOpened: 5, Wins: 5, Losses: 0},
+		"hl-mom-btc": {PositionsOpened: 0, Wins: 0, Losses: 0},
 	}
 
 	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, lifetime)
@@ -1858,7 +1858,7 @@ func TestFormatCategorySummary_LifetimeStatsOverride(t *testing.T) {
 		},
 	}
 	lifetime := map[string]LifetimeTradeStats{
-		"hl-rmc-eth-live": {RoundTrips: 17, Wins: 10, Losses: 7},
+		"hl-rmc-eth-live": {PositionsOpened: 17, Wins: 10, Losses: 7},
 	}
 	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, lifetime)
 	if len(msgs) == 0 {

--- a/scheduler/leaderboard.go
+++ b/scheduler/leaderboard.go
@@ -11,19 +11,19 @@ import (
 
 // LeaderboardEntry holds computed PnL data for one strategy.
 type LeaderboardEntry struct {
-	ID         string  `json:"id"`
-	Type       string  `json:"type"`
-	Value      float64 `json:"value"`
-	Capital    float64 `json:"capital"`
-	PnL        float64 `json:"pnl"`
-	PnLPct     float64 `json:"pnl_pct"`
-	Trades     int     `json:"trades"`
-	Sharpe     float64 `json:"sharpe"`      // #397 — annualized Sharpe; 0 = undefined/no data. Kept in the serialized form (no omitempty) so consumers can distinguish "present but zero" from "omitted".
-	Timeframe  string  `json:"timeframe"`   // #580 — candle timeframe (Args[2]) or "—".
-	Interval   string  `json:"interval"`    // #580 — formatted check interval (e.g. "1h").
-	RoundTrips int     `json:"round_trips"` // #580 — closed round-trip count from trades table (immune to RiskState resets).
-	Wins       int     `json:"wins"`        // #580 — round trips with net realized PnL > 0.
-	Losses     int     `json:"losses"`      // #580 — round trips with net realized PnL < 0.
+	ID              string  `json:"id"`
+	Type            string  `json:"type"`
+	Value           float64 `json:"value"`
+	Capital         float64 `json:"capital"`
+	PnL             float64 `json:"pnl"`
+	PnLPct          float64 `json:"pnl_pct"`
+	Trades          int     `json:"trades"`
+	Sharpe          float64 `json:"sharpe"`           // #397 — annualized Sharpe; 0 = undefined/no data. Kept in the serialized form (no omitempty) so consumers can distinguish "present but zero" from "omitted".
+	Timeframe       string  `json:"timeframe"`        // #580 — candle timeframe (Args[2]) or "—".
+	Interval        string  `json:"interval"`         // #580 — formatted check interval (e.g. "1h").
+	PositionsOpened int     `json:"positions_opened"` // #607 — lifetime open-leg count (is_close=0 rows) from trades table; survives RiskState resets. Replaces the round-trip count for the #T column.
+	Wins            int     `json:"wins"`             // #580 — closed round trips with net realized PnL > 0.
+	Losses          int     `json:"losses"`           // #580 — closed round trips with net realized PnL < 0.
 }
 
 // leaderboardTopN returns the configured top-N count, defaulting to 5 when unset.
@@ -72,8 +72,8 @@ func BuildLeaderboardMessages(cfg *Config, state *AppState, prices map[string]fl
 }
 
 // newLeaderboardEntry assembles a LeaderboardEntry, pulling timeframe/interval
-// from the strategy config and round-trip / W-L counts from the lifetime stats
-// map (#580). Missing lifetimeStats entry → zero round trips.
+// from the strategy config and lifetime open-leg / W-L counts from the
+// lifetime stats map (#580/#607). Missing lifetimeStats entry → zero counts.
 func newLeaderboardEntry(sc StrategyConfig, ss *StrategyState, pv, initCap, pnl, pnlPct float64, sharpeByStrategy map[string]float64, lifetimeStats map[string]LifetimeTradeStats, globalIntervalSeconds int) LeaderboardEntry {
 	effectiveInterval := sc.IntervalSeconds
 	if effectiveInterval <= 0 {
@@ -81,19 +81,19 @@ func newLeaderboardEntry(sc StrategyConfig, ss *StrategyState, pv, initCap, pnl,
 	}
 	lt := lifetimeStats[sc.ID]
 	return LeaderboardEntry{
-		ID:         sc.ID,
-		Type:       sc.Type,
-		Value:      pv,
-		Capital:    initCap,
-		PnL:        pnl,
-		PnLPct:     pnlPct,
-		Trades:     len(ss.TradeHistory),
-		Sharpe:     sharpeByStrategy[sc.ID],
-		Timeframe:  extractTimeframe(sc),
-		Interval:   formatInterval(effectiveInterval),
-		RoundTrips: lt.RoundTrips,
-		Wins:       lt.Wins,
-		Losses:     lt.Losses,
+		ID:              sc.ID,
+		Type:            sc.Type,
+		Value:           pv,
+		Capital:         initCap,
+		PnL:             pnl,
+		PnLPct:          pnlPct,
+		Trades:          len(ss.TradeHistory),
+		Sharpe:          sharpeByStrategy[sc.ID],
+		Timeframe:       extractTimeframe(sc),
+		Interval:        formatInterval(effectiveInterval),
+		PositionsOpened: lt.PositionsOpened,
+		Wins:            lt.Wins,
+		Losses:          lt.Losses,
 	}
 }
 
@@ -114,12 +114,12 @@ func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, sh
 
 	// Totals across ALL strategies in this category.
 	var totalValue, totalCapital float64
-	totalRoundTrips, totalWins, totalLosses := 0, 0, 0
+	totalPositionsOpened, totalWins, totalLosses := 0, 0, 0
 	winning, losing, flat := 0, 0, 0
 	for _, e := range entries {
 		totalValue += e.Value
 		totalCapital += e.Capital
-		totalRoundTrips += e.RoundTrips
+		totalPositionsOpened += e.PositionsOpened
 		totalWins += e.Wins
 		totalLosses += e.Losses
 		if e.PnLPct > 0 {
@@ -182,9 +182,9 @@ func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, sh
 		wlStr := fmtWinLossRatio(e.Wins, e.Losses)
 		sharpeStr := fmtSharpe(e.Sharpe)
 		if showType {
-			sb.WriteString(fmt.Sprintf(rowFmt, label, e.Type, valStr, pnlStr, pctStr, tfStr, intStr, e.RoundTrips, wlStr, sharpeStr))
+			sb.WriteString(fmt.Sprintf(rowFmt, label, e.Type, valStr, pnlStr, pctStr, tfStr, intStr, e.PositionsOpened, wlStr, sharpeStr))
 		} else {
-			sb.WriteString(fmt.Sprintf(rowFmt, label, valStr, pnlStr, pctStr, tfStr, intStr, e.RoundTrips, wlStr, sharpeStr))
+			sb.WriteString(fmt.Sprintf(rowFmt, label, valStr, pnlStr, pctStr, tfStr, intStr, e.PositionsOpened, wlStr, sharpeStr))
 		}
 	}
 	sb.WriteString(sep + "\n")
@@ -198,9 +198,9 @@ func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, sh
 	totPctStr := fmtSignedPct(totalPnlPct)
 	totWlStr := fmtWinLossRatio(totalWins, totalLosses)
 	if showType {
-		sb.WriteString(fmt.Sprintf(rowFmt, totalLabel, "", totValStr, totPnlStr, totPctStr, "", "", totalRoundTrips, totWlStr, ""))
+		sb.WriteString(fmt.Sprintf(rowFmt, totalLabel, "", totValStr, totPnlStr, totPctStr, "", "", totalPositionsOpened, totWlStr, ""))
 	} else {
-		sb.WriteString(fmt.Sprintf(rowFmt, totalLabel, totValStr, totPnlStr, totPctStr, "", "", totalRoundTrips, totWlStr, ""))
+		sb.WriteString(fmt.Sprintf(rowFmt, totalLabel, totValStr, totPnlStr, totPctStr, "", "", totalPositionsOpened, totWlStr, ""))
 	}
 	sb.WriteString("```\n")
 	sb.WriteString(fmt.Sprintf("🟢 %d winning · 🔴 %d losing · ⚪ %d flat\n", winning, losing, flat))

--- a/scheduler/leaderboard_test.go
+++ b/scheduler/leaderboard_test.go
@@ -166,10 +166,10 @@ func TestBuildLeaderboardMessages_TfIntColumns(t *testing.T) {
 	}
 }
 
-// TestBuildLeaderboardMessages_RoundTripsAndWinLoss verifies that #T and W/L
+// TestBuildLeaderboardMessages_PositionsOpenedAndWinLoss verifies that #T and W/L
 // columns reflect the supplied lifetimeStats map (not in-memory TradeHistory).
 // Regression for #580.
-func TestBuildLeaderboardMessages_RoundTripsAndWinLoss(t *testing.T) {
+func TestBuildLeaderboardMessages_PositionsOpenedAndWinLoss(t *testing.T) {
 	cfg := &Config{
 		Strategies: []StrategyConfig{
 			{ID: "sma-btc", Type: "spot", Capital: 1000, Platform: "binanceus", Args: []string{"sma_crossover", "BTC/USDT", "1h"}},
@@ -181,7 +181,7 @@ func TestBuildLeaderboardMessages_RoundTripsAndWinLoss(t *testing.T) {
 	state.Strategies["sma-btc"] = ss
 
 	lifetime := map[string]LifetimeTradeStats{
-		"sma-btc": {RoundTrips: 7, Wins: 5, Losses: 2},
+		"sma-btc": {PositionsOpened: 7, Wins: 5, Losses: 2},
 	}
 	messages := BuildLeaderboardMessages(cfg, state, map[string]float64{"BTC/USDT": 50000}, nil, lifetime)
 	topMsg := messages["top"]
@@ -609,10 +609,10 @@ func TestBuildLeaderboardSummary_DefaultTopN(t *testing.T) {
 	}
 }
 
-// TestBuildLeaderboardSummary_RoundTripsAndWinLoss covers the per-platform path
+// TestBuildLeaderboardSummary_PositionsOpenedAndWinLoss covers the per-platform path
 // (BuildLeaderboardSummary) for the #T / W/L columns introduced in #580 — the
-// top/bottom path is covered by TestBuildLeaderboardMessages_RoundTripsAndWinLoss.
-func TestBuildLeaderboardSummary_RoundTripsAndWinLoss(t *testing.T) {
+// top/bottom path is covered by TestBuildLeaderboardMessages_PositionsOpenedAndWinLoss.
+func TestBuildLeaderboardSummary_PositionsOpenedAndWinLoss(t *testing.T) {
 	cfg := &Config{
 		Strategies: []StrategyConfig{
 			{ID: "hl-sma-btc", Type: "perps", Capital: 1000, Platform: "hyperliquid", Args: []string{"sma_crossover", "BTC/USDT", "1h"}},
@@ -623,7 +623,7 @@ func TestBuildLeaderboardSummary_RoundTripsAndWinLoss(t *testing.T) {
 	state.Strategies["hl-sma-btc"].Cash = 1100
 
 	lifetime := map[string]LifetimeTradeStats{
-		"hl-sma-btc": {RoundTrips: 4, Wins: 3, Losses: 1},
+		"hl-sma-btc": {PositionsOpened: 4, Wins: 3, Losses: 1},
 	}
 	lc := LeaderboardSummaryConfig{Platform: "hyperliquid", TopN: 5, Channel: "c1"}
 	msg := BuildLeaderboardSummary(lc, cfg, state, map[string]float64{"BTC/USDT": 50000}, nil, lifetime)


### PR DESCRIPTION
Closes #607

#T column in per-strategy summary and leaderboard now counts lifetime positions opened (`is_close=0` rows) instead of closed round trips. Leaderboard TOTAL #T sums per-strategy opens. W/L still derives from closed round trips.

- `LifetimeTradeStats.RoundTrips` → `PositionsOpened` with a dedicated `WHERE is_close=0` query, merged with the existing round-trip W/L aggregation.
- `LeaderboardEntry` JSON tag renamed `round_trips` → `positions_opened`.
- `FormatCategorySummary` and leaderboard rendering (per-row + TOTAL) updated.
- Tests updated; fixtures that seed only close legs now expect `PositionsOpened=0`.

---
LLM: Claude Opus 4.7 (1M) | high | Harness: anthropics/claude-code-action@v1 | Tokens: 70 in / 23268 out | Cache: 4254180 read / 167036 written | Cost: $3.75