### PR TITLE
Add Detector 3 for Hyperliquid TP partial-fill reconciliation

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -749,6 +749,9 @@ func hyperliquidHasClearedTPTier(sc StrategyConfig, pos *Position, closeQty floa
 	if len(tiers) == 0 {
 		return false
 	}
+	if len(pos.TPOIDs) < len(tiers) {
+		return false
+	}
 	tpOIDs := tpOIDsForTierCount(pos.TPOIDs, len(tiers))
 	hasCleared := false
 	hasActive := false

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -400,6 +400,10 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 		}
 		coinStrategies[sym] = append(coinStrategies[sym], sc.ID)
 	}
+	strategyByID := make(map[string]StrategyConfig, len(allStrategies))
+	for _, sc := range allStrategies {
+		strategyByID[sc.ID] = sc
+	}
 	sharedCoins := make(map[string]bool)
 	for coin, ids := range coinStrategies {
 		if len(ids) > 1 {
@@ -515,6 +519,12 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 		// owner's qty at arm time, so when the trigger fires the non-owner peers'
 		// portion remains on-chain untouched.
 		//
+		// Detector 3 — TP partial fill: on-chain qty is a same-direction nonzero
+		// subset of virtual qty, and exactly one same-side strategy has a cleared
+		// on-chain TP tier. Book the virtual/on-chain delta as an external partial
+		// close for that strategy, then shrink its virtual qty so the next
+		// protection-sync cycle sizes SL/TP orders from the true residual (#609).
+		//
 		// All other qty mismatches (ambiguous gaps that #258/#515 protect) fall
 		// through to the gap-recording block unchanged.
 		if math.Abs(onChainQty) < 1e-6 && math.Abs(virtualQty) > 1e-6 {
@@ -627,6 +637,55 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 					}
 				}
 			}
+			if math.Abs(delta) > 1e-6 {
+				if closeSide, closeQty, ok := hyperliquidSharedPartialCloseDrift(virtualQty, onChainQty); ok {
+					var candidateID string
+					var candidateSS *StrategyState
+					var candidatePos *Position
+					for _, id := range stratIDs {
+						ss := state.Strategies[id]
+						if ss == nil {
+							continue
+						}
+						pos := ss.Positions[coin]
+						if pos == nil || pos.Side != closeSide {
+							continue
+						}
+						sc, ok := strategyByID[id]
+						if !ok || !hyperliquidHasClearedTPTier(sc, pos, closeQty) {
+							continue
+						}
+						if candidateID != "" {
+							// Multiple TP owners changed in the same window; leave the
+							// aggregate gap visible rather than guessing the allocation.
+							candidateID, candidateSS, candidatePos = "", nil, nil
+							break
+						}
+						candidateID, candidateSS, candidatePos = id, ss, pos
+					}
+					if candidateID != "" && candidateSS != nil && candidatePos != nil && closeQty <= candidatePos.Quantity+1e-6 {
+						if mark, ok := prices[coin]; ok && mark > 0 {
+							logger, logErr := logMgr.GetStrategyLogger(candidateID)
+							if logErr != nil {
+								fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", candidateID, logErr)
+							}
+							lookup, useFillFee := resolveFee(coin, 0, closeQty)
+							logHyperliquidReconcileFillLookup(logger, coin, 0, closeQty, lookup, useFillFee)
+							if recordPerpsExternalPartialCloseWithFillFee(candidateSS, coin, closeQty, mark, lookup.Fee, useFillFee, "", "hl_sync_external_partial", logger) {
+								changed = true
+								if closeSide == "long" {
+									virtualQty -= closeQty
+								} else {
+									virtualQty += closeQty
+								}
+								delta = virtualQty - onChainQty
+							}
+						} else {
+							fmt.Printf("[WARN] hl-sync: shared coin %s TP partial drift detected for %s but no mark price is available; leaving virtual qty unchanged\n", coin, candidateID)
+						}
+					}
+				}
+			}
 		}
 
 		state.ReconciliationGaps[coin] = &ReconciliationGap{
@@ -669,6 +728,48 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 	}
 
 	return changed
+}
+
+func hyperliquidSharedPartialCloseDrift(virtualQty, onChainQty float64) (string, float64, bool) {
+	const tol = 1e-6
+	if virtualQty > tol && onChainQty > tol && onChainQty < virtualQty-tol {
+		return "long", virtualQty - onChainQty, true
+	}
+	if virtualQty < -tol && onChainQty < -tol && onChainQty > virtualQty+tol {
+		return "short", onChainQty - virtualQty, true
+	}
+	return "", 0, false
+}
+
+func hyperliquidHasClearedTPTier(sc StrategyConfig, pos *Position, closeQty float64) bool {
+	if pos == nil || len(pos.TPOIDs) == 0 {
+		return false
+	}
+	tiers := hyperliquidProtectionTiers(sc)
+	if len(tiers) == 0 {
+		return false
+	}
+	tpOIDs := tpOIDsForTierCount(pos.TPOIDs, len(tiers))
+	hasCleared := false
+	hasActive := false
+	for _, oid := range tpOIDs {
+		if oid > 0 {
+			hasActive = true
+		} else {
+			hasCleared = true
+		}
+	}
+	if !hasCleared {
+		return false
+	}
+	if hasActive {
+		return true
+	}
+	// All TP tiers gone usually means the final tier filled. Treat that as
+	// attributable only when the observed drift can fully close this strategy;
+	// otherwise an all-zero, never-placed TP list would make ambiguous gaps look
+	// actionable.
+	return math.Abs(pos.Quantity-closeQty) <= 1e-6
 }
 
 // HyperliquidLiveCloseReport summarizes a forceCloseHyperliquidLive run.

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1405,6 +1405,168 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally_CreditsPeerCash(t *tes
 	}
 }
 
+func TestReconcileSharedCoin_TPPartialFill_DecrementsOwnerAndBooksPnL(t *testing.T) {
+	const ownerStartCash = 1000.0
+	const ownerQty = 0.5
+	const peerQty = 0.5
+	const avgCost = 3000.0
+	const mark = 3200.0
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-eth": {
+				ID: "hl-owner-eth", Cash: ownerStartCash, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: ownerQty, InitialQuantity: ownerQty, AvgCost: avgCost, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth",
+						EntryATR: 100, StopLossOID: 77, StopLossTriggerPx: 2900,
+						TPOIDs: []int64{0, 222}},
+				},
+			},
+			"hl-peer-eth": {
+				ID: "hl-peer-eth", Cash: 500, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: peerQty, InitialQuantity: peerQty, AvgCost: avgCost, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-peer-eth"},
+				},
+			},
+		},
+	}
+
+	allStrategies := []StrategyConfig{
+		{ID: "hl-owner-eth", Platform: "hyperliquid", Type: "perps", CloseStrategies: []string{"tiered_tp_atr_live"}, Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-peer-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 0.75, EntryPrice: avgCost, Leverage: 10}}
+	prices := map[string]float64{"ETH": mark}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "")
+
+	owner := state.Strategies["hl-owner-eth"]
+	ownerPos := owner.Positions["ETH"]
+	if ownerPos == nil {
+		t.Fatal("owner ETH position should remain after TP1 partial fill")
+	}
+	if math.Abs(ownerPos.Quantity-0.25) > 1e-9 {
+		t.Errorf("owner quantity = %g, want 0.25", ownerPos.Quantity)
+	}
+	if ownerPos.InitialQuantity != ownerQty {
+		t.Errorf("InitialQuantity = %g, want %g", ownerPos.InitialQuantity, ownerQty)
+	}
+	if ownerPos.AvgCost != avgCost {
+		t.Errorf("AvgCost = %g, want %g", ownerPos.AvgCost, avgCost)
+	}
+	if ownerPos.StopLossOID != 77 {
+		t.Errorf("StopLossOID = %d, want preserved 77", ownerPos.StopLossOID)
+	}
+
+	wantFee := 0.25 * mark * HyperliquidTakerFeePct
+	wantPnL := 0.25*(mark-avgCost) - wantFee
+	if math.Abs(owner.Cash-(ownerStartCash+wantPnL)) > 1e-6 {
+		t.Errorf("owner Cash = %v, want %v", owner.Cash, ownerStartCash+wantPnL)
+	}
+	if len(owner.TradeHistory) != 1 {
+		t.Fatalf("owner close trades = %d, want 1", len(owner.TradeHistory))
+	}
+	tr := owner.TradeHistory[0]
+	if !tr.IsClose || tr.Side != "sell" || math.Abs(tr.Quantity-0.25) > 1e-9 || tr.Price != mark {
+		t.Errorf("close trade = %+v, want sell close 0.25 @ %v", tr, mark)
+	}
+	if math.Abs(tr.RealizedPnL-wantPnL) > 1e-6 {
+		t.Errorf("trade RealizedPnL = %v, want %v", tr.RealizedPnL, wantPnL)
+	}
+	if tr.EntryATR != 100 || tr.StopLossTriggerPx != 2900 {
+		t.Errorf("trade context EntryATR/SL = %v/%v, want 100/2900", tr.EntryATR, tr.StopLossTriggerPx)
+	}
+	if len(owner.ClosedPositions) != 0 {
+		t.Errorf("ClosedPositions = %d, want 0 for partial close", len(owner.ClosedPositions))
+	}
+
+	peerPos := state.Strategies["hl-peer-eth"].Positions["ETH"]
+	if peerPos == nil || math.Abs(peerPos.Quantity-peerQty) > 1e-9 {
+		t.Errorf("peer ETH = %+v, want unchanged %.2f", peerPos, peerQty)
+	}
+	gap := state.ReconciliationGaps["ETH"]
+	if gap == nil {
+		t.Fatal("expected gap entry for ETH")
+	}
+	if math.Abs(gap.VirtualQty-0.75) > 1e-9 || math.Abs(gap.OnChainQty-0.75) > 1e-9 || math.Abs(gap.DeltaQty) > 1e-9 {
+		t.Errorf("gap = %+v, want virtual/on-chain 0.75 with zero delta", gap)
+	}
+}
+
+func TestReconcileSharedCoin_TPPartialFill_Short(t *testing.T) {
+	const ownerStartCash = 1000.0
+	const ownerQty = 0.5
+	const peerQty = 0.5
+	const avgCost = 3000.0
+	const mark = 2800.0
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-eth": {
+				ID: "hl-owner-eth", Cash: ownerStartCash, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: ownerQty, InitialQuantity: ownerQty, AvgCost: avgCost, Side: "short",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth",
+						TPOIDs: []int64{0, 222}},
+				},
+			},
+			"hl-peer-eth": {
+				ID: "hl-peer-eth", Cash: 500, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: peerQty, InitialQuantity: peerQty, AvgCost: avgCost, Side: "short",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-peer-eth"},
+				},
+			},
+		},
+	}
+
+	allStrategies := []StrategyConfig{
+		{ID: "hl-owner-eth", Platform: "hyperliquid", Type: "perps", CloseStrategies: []string{"tiered_tp_atr_live"}, Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-peer-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: -0.75, EntryPrice: avgCost, Leverage: 10}}
+	prices := map[string]float64{"ETH": mark}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "")
+
+	owner := state.Strategies["hl-owner-eth"]
+	ownerPos := owner.Positions["ETH"]
+	if ownerPos == nil {
+		t.Fatal("owner ETH short should remain after TP partial fill")
+	}
+	if math.Abs(ownerPos.Quantity-0.25) > 1e-9 {
+		t.Errorf("owner short quantity = %g, want 0.25", ownerPos.Quantity)
+	}
+	wantFee := 0.25 * mark * HyperliquidTakerFeePct
+	wantPnL := 0.25*(avgCost-mark) - wantFee
+	if math.Abs(owner.Cash-(ownerStartCash+wantPnL)) > 1e-6 {
+		t.Errorf("owner Cash = %v, want %v", owner.Cash, ownerStartCash+wantPnL)
+	}
+	if len(owner.TradeHistory) != 1 {
+		t.Fatalf("owner close trades = %d, want 1", len(owner.TradeHistory))
+	}
+	tr := owner.TradeHistory[0]
+	if !tr.IsClose || tr.Side != "buy" || math.Abs(tr.Quantity-0.25) > 1e-9 || tr.Price != mark {
+		t.Errorf("close trade = %+v, want buy close 0.25 @ %v", tr, mark)
+	}
+	if math.Abs(tr.RealizedPnL-wantPnL) > 1e-6 {
+		t.Errorf("trade RealizedPnL = %v, want %v", tr.RealizedPnL, wantPnL)
+	}
+	gap := state.ReconciliationGaps["ETH"]
+	if gap == nil {
+		t.Fatal("expected gap entry for ETH")
+	}
+	if math.Abs(gap.VirtualQty-(-0.75)) > 1e-9 || math.Abs(gap.OnChainQty-(-0.75)) > 1e-9 || math.Abs(gap.DeltaQty) > 1e-9 {
+		t.Errorf("gap = %+v, want virtual/on-chain -0.75 with zero delta", gap)
+	}
+}
+
 // TestReconcileSharedCoin_AllPositionsClosedExternally_NoMarkPrice_FallsBack
 // verifies the legacy zero-PnL path still applies when the caller supplies no
 // mark price for the coin (e.g. the syncHyperliquidAccountPositions entry).

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1619,6 +1619,60 @@ func TestReconcileSharedCoin_TPPartialFill_PaddedNeverPlacedTierDoesNotAttribute
 	}
 }
 
+func TestReconcileSharedCoin_TPPartialFill_MultipleCandidatesDoesNotAttribute(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-a-eth": {
+				ID: "hl-owner-a-eth", Cash: 1000, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, InitialQuantity: 0.5, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-a-eth",
+						EntryATR: 100, TPOIDs: []int64{0, 222}},
+				},
+			},
+			"hl-owner-b-eth": {
+				ID: "hl-owner-b-eth", Cash: 1000, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, InitialQuantity: 0.5, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-b-eth",
+						EntryATR: 100, TPOIDs: []int64{0, 333}},
+				},
+			},
+		},
+	}
+
+	allStrategies := []StrategyConfig{
+		{ID: "hl-owner-a-eth", Platform: "hyperliquid", Type: "perps", CloseStrategies: []string{"tiered_tp_atr_live"}, Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-owner-b-eth", Platform: "hyperliquid", Type: "perps", CloseStrategies: []string{"tiered_tp_atr_live"}, Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 0.75, EntryPrice: 3000, Leverage: 10}}
+	prices := map[string]float64{"ETH": 3200}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "")
+
+	for id, ss := range state.Strategies {
+		pos := ss.Positions["ETH"]
+		if pos == nil {
+			t.Fatalf("%s ETH position should remain", id)
+		}
+		if math.Abs(pos.Quantity-0.5) > 1e-9 {
+			t.Errorf("%s quantity = %g, want unchanged 0.5", id, pos.Quantity)
+		}
+		if len(ss.TradeHistory) != 0 {
+			t.Fatalf("%s close trades = %d, want 0 because multiple TP candidates are ambiguous", id, len(ss.TradeHistory))
+		}
+	}
+	gap := state.ReconciliationGaps["ETH"]
+	if gap == nil {
+		t.Fatal("expected gap entry for ETH")
+	}
+	if math.Abs(gap.VirtualQty-1.0) > 1e-9 || math.Abs(gap.OnChainQty-0.75) > 1e-9 || math.Abs(gap.DeltaQty-0.25) > 1e-9 {
+		t.Errorf("gap = %+v, want unresolved virtual=1.0 on-chain=0.75 delta=0.25", gap)
+	}
+}
+
 // TestReconcileSharedCoin_AllPositionsClosedExternally_NoMarkPrice_FallsBack
 // verifies the legacy zero-PnL path still applies when the caller supplies no
 // mark price for the coin (e.g. the syncHyperliquidAccountPositions entry).

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1567,6 +1567,58 @@ func TestReconcileSharedCoin_TPPartialFill_Short(t *testing.T) {
 	}
 }
 
+func TestReconcileSharedCoin_TPPartialFill_PaddedNeverPlacedTierDoesNotAttribute(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-eth": {
+				ID: "hl-owner-eth", Cash: 1000, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, InitialQuantity: 0.5, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth",
+						EntryATR: 100, TPOIDs: []int64{111}},
+				},
+			},
+			"hl-peer-eth": {
+				ID: "hl-peer-eth", Cash: 500, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, InitialQuantity: 0.5, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-peer-eth"},
+				},
+			},
+		},
+	}
+
+	allStrategies := []StrategyConfig{
+		{ID: "hl-owner-eth", Platform: "hyperliquid", Type: "perps", CloseStrategies: []string{"tiered_tp_atr_live"}, Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-peer-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 0.75, EntryPrice: 3000, Leverage: 10}}
+	prices := map[string]float64{"ETH": 3200}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "")
+
+	owner := state.Strategies["hl-owner-eth"]
+	ownerPos := owner.Positions["ETH"]
+	if ownerPos == nil {
+		t.Fatal("owner ETH position should remain")
+	}
+	if math.Abs(ownerPos.Quantity-0.5) > 1e-9 {
+		t.Errorf("owner quantity = %g, want unchanged 0.5", ownerPos.Quantity)
+	}
+	if len(owner.TradeHistory) != 0 {
+		t.Fatalf("owner close trades = %d, want 0 because missing tier slot was never placed", len(owner.TradeHistory))
+	}
+	gap := state.ReconciliationGaps["ETH"]
+	if gap == nil {
+		t.Fatal("expected gap entry for ETH")
+	}
+	if math.Abs(gap.VirtualQty-1.0) > 1e-9 || math.Abs(gap.OnChainQty-0.75) > 1e-9 || math.Abs(gap.DeltaQty-0.25) > 1e-9 {
+		t.Errorf("gap = %+v, want unresolved virtual=1.0 on-chain=0.75 delta=0.25", gap)
+	}
+}
+
 // TestReconcileSharedCoin_AllPositionsClosedExternally_NoMarkPrice_FallsBack
 // verifies the legacy zero-PnL path still applies when the caller supplies no
 // mark price for the coin (e.g. the syncHyperliquidAccountPositions entry).

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -209,6 +209,85 @@ func bookPerpsCloseWithFillFee(s *StrategyState, symbol string, closePx, fillFee
 	return true
 }
 
+// bookPerpsPartialCloseWithFillFee records a reconciler-observed perps partial
+// close, credits realized PnL on the closed slice, and leaves the remaining
+// virtual position open with its original AvgCost/InitialQuantity.
+func bookPerpsPartialCloseWithFillFee(s *StrategyState, symbol string, closeQty, closePx, fillFee float64, useFillFee bool, exchangeOrderID, reason, detailsPrefix, logPrefix string, logger *StrategyLogger) bool {
+	if closeQty <= 0 || closePx <= 0 {
+		return false
+	}
+	pos, ok := s.Positions[symbol]
+	if !ok || pos == nil || pos.Quantity <= 0 {
+		return false
+	}
+
+	now := time.Now().UTC()
+	qty := closeQty
+	if qty > pos.Quantity {
+		qty = pos.Quantity
+	}
+	avgCost := pos.AvgCost
+	side := pos.Side
+	var pnl float64
+	if side == "long" {
+		pnl = qty * (closePx - avgCost)
+	} else {
+		pnl = qty * (avgCost - closePx)
+	}
+	feePlatform := s.Platform
+	if s.Platform == "okx" && s.Type == "perps" {
+		feePlatform = "okx-perps"
+	}
+	fee := CalculatePlatformSpotFee(feePlatform, qty*closePx)
+	exchangeFeeStamp := 0.0
+	if useFillFee {
+		fee = fillFee
+		exchangeFeeStamp = fillFee
+	}
+	pnl -= fee
+	s.Cash += pnl
+	positionID := ensurePositionTradeID(s.ID, symbol, pos)
+
+	trade := Trade{
+		Timestamp:       now,
+		StrategyID:      s.ID,
+		Symbol:          symbol,
+		PositionID:      positionID,
+		Side:            closeTradeSide(side),
+		Quantity:        qty,
+		Price:           closePx,
+		Value:           qty * closePx,
+		TradeType:       "perps",
+		Details:         fmt.Sprintf("%s %.6f, PnL: $%.2f (fee $%.2f)", detailsPrefix, qty, pnl, fee),
+		IsClose:         true,
+		RealizedPnL:     pnl,
+		ExchangeOrderID: exchangeOrderIDForTrade(exchangeOrderID, useFillFee),
+		ExchangeFee:     exchangeFeeStamp,
+	}
+	trade.Regime = s.Regime
+	trade.EntryATR = pos.EntryATR
+	trade.StopLossTriggerPx = pos.StopLossTriggerPx
+	RecordTrade(s, trade)
+	RecordTradeResult(&s.RiskState, pnl)
+
+	remaining := pos.Quantity - qty
+	if remaining <= 1e-9 {
+		recordClosedPosition(s, pos, closePx, pnl, reason, now)
+		delete(s.Positions, symbol)
+		clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
+	} else {
+		pos.Quantity = remaining
+	}
+	if logger != nil {
+		remainingForLog := remaining
+		if remainingForLog < 0 {
+			remainingForLog = 0
+		}
+		logger.Warn("%s %.6f @ $%.4f, remaining %.6f, PnL: $%.2f (fee $%.2f)", logPrefix, qty, closePx, remainingForLog, pnl, fee)
+	}
+	return true
+}
+
 // recordPerpsStopLossClose books a tracked perps stop-loss fill and removes the
 // virtual position. Used both when HL reports an immediate trigger fill at
 // submit time and when a previously-resting trigger has fired between cycles.
@@ -243,6 +322,10 @@ func recordPerpsExternalClose(s *StrategyState, symbol string, closePx float64, 
 // can still recover the fee.
 func recordPerpsExternalCloseWithFillFee(s *StrategyState, symbol string, closePx, fillFee float64, useFillFee bool, exchangeOrderID, reason string, logger *StrategyLogger) bool {
 	return bookPerpsCloseWithFillFee(s, symbol, closePx, fillFee, useFillFee, exchangeOrderID, reason, "External close @ mark", "External close reconciled", logger)
+}
+
+func recordPerpsExternalPartialCloseWithFillFee(s *StrategyState, symbol string, closeQty, closePx, fillFee float64, useFillFee bool, exchangeOrderID, reason string, logger *StrategyLogger) bool {
+	return bookPerpsPartialCloseWithFillFee(s, symbol, closeQty, closePx, fillFee, useFillFee, exchangeOrderID, reason, "External partial close @ mark", "External partial close reconciled", logger)
 }
 
 // recordClosedOptionPosition appends a ClosedOptionPosition entry to the

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -224,6 +224,11 @@ func bookPerpsPartialCloseWithFillFee(s *StrategyState, symbol string, closeQty,
 	now := time.Now().UTC()
 	qty := closeQty
 	if qty > pos.Quantity {
+		if logger != nil {
+			logger.Warn("Partial close qty %.6f exceeds virtual position qty %.6f for %s; clamping to position qty", qty, pos.Quantity, symbol)
+		} else {
+			fmt.Printf("[WARN] partial close qty %.6f exceeds virtual position qty %.6f for %s; clamping to position qty\n", qty, pos.Quantity, symbol)
+		}
 		qty = pos.Quantity
 	}
 	avgCost := pos.AvgCost
@@ -238,9 +243,8 @@ func bookPerpsPartialCloseWithFillFee(s *StrategyState, symbol string, closeQty,
 	if s.Platform == "okx" && s.Type == "perps" {
 		feePlatform = "okx-perps"
 	}
-	// TP fills are resting reduce-only limits and often maker-priced, but when
-	// userFills lookup misses we keep the reconciler's existing conservative
-	// taker-fee fallback so virtual cash is not overstated.
+	// TP fills are typically maker-priced; use the taker rate as a conservative
+	// fallback when userFills misses so virtual cash is not overstated.
 	fee := CalculatePlatformSpotFee(feePlatform, qty*closePx)
 	exchangeFeeStamp := 0.0
 	if useFillFee {

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -238,6 +238,9 @@ func bookPerpsPartialCloseWithFillFee(s *StrategyState, symbol string, closeQty,
 	if s.Platform == "okx" && s.Type == "perps" {
 		feePlatform = "okx-perps"
 	}
+	// TP fills are resting reduce-only limits and often maker-priced, but when
+	// userFills lookup misses we keep the reconciler's existing conservative
+	// taker-fee fallback so virtual cash is not overstated.
 	fee := CalculatePlatformSpotFee(feePlatform, qty*closePx)
 	exchangeFeeStamp := 0.0
 	if useFillFee {


### PR DESCRIPTION
## Summary
- Adds a third shared-coin reconciler path for Hyperliquid TP partial fills when on-chain quantity is a same-direction subset of virtual quantity.
- Books the partial close into trade history and cash, then reduces the remaining virtual position so protection sync resizes SL/TP orders from the true residual.
- Covers both long and short cases with regression tests for PnL, position quantity, and gap normalization.

## Testing
- Added focused unit coverage for long and short TP partial-fill reconciliation scenarios.
- `go test ./...` in `scheduler` passed.

Closes #609

LLM: GPT-5.5 | high | Harness: OpenAI Codex