### PR TITLE
fix: cap HL SL size at on-chain qty and use actual fill qty in reconciler

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -302,6 +302,13 @@ func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym st
 			lookup, useFillFee := resolveFee(sym, statePos.StopLossOID, statePos.Quantity)
 			oidStr := strconv.FormatInt(statePos.StopLossOID, 10)
 			logHyperliquidReconcileFillLookup(logger, sym, statePos.StopLossOID, statePos.Quantity, lookup, useFillFee)
+			// #621: When userFills returned a real fill qty smaller than the virtual
+			// position (e.g. SL was placed at the on-chain size after a manual TP
+			// reduced the position), use the actual fill qty so PnL/cash are correct.
+			if useFillFee && lookup.FilledQty > 1e-9 && lookup.FilledQty < statePos.Quantity-1e-9 {
+				logger.Info("hl-sync: %s SL close qty adjusted %.6f → %.6f (actual fill from userFills)", sym, statePos.Quantity, lookup.FilledQty)
+				statePos.Quantity = lookup.FilledQty
+			}
 			if recordPerpsStopLossCloseWithFillFee(stratState, sym, statePos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "stop_loss", logger) {
 				return true
 			}
@@ -556,6 +563,12 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 					lookup, useFillFee := resolveFee(coin, pos.StopLossOID, pos.Quantity)
 					oidStr := strconv.FormatInt(pos.StopLossOID, 10)
 					logHyperliquidReconcileFillLookup(logger, coin, pos.StopLossOID, pos.Quantity, lookup, useFillFee)
+					if useFillFee && lookup.FilledQty > 1e-9 && lookup.FilledQty < pos.Quantity-1e-9 {
+						if logger != nil {
+							logger.Info("hl-sync: %s SL close qty adjusted %.6f → %.6f (actual fill from userFills)", coin, pos.Quantity, lookup.FilledQty)
+						}
+						pos.Quantity = lookup.FilledQty
+					}
 					if recordPerpsStopLossCloseWithFillFee(ss, coin, pos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "hl_sync_stop_loss", logger) {
 						changed = true
 					}
@@ -629,6 +642,12 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 						lookup, useFillFee := resolveFee(coin, slOwnerPos.StopLossOID, slOwnerPos.Quantity)
 						oidStr := strconv.FormatInt(slOwnerPos.StopLossOID, 10)
 						logHyperliquidReconcileFillLookup(logger, coin, slOwnerPos.StopLossOID, slOwnerPos.Quantity, lookup, useFillFee)
+						if useFillFee && lookup.FilledQty > 1e-9 && lookup.FilledQty < slOwnerPos.Quantity-1e-9 {
+							if logger != nil {
+								logger.Info("hl-sync: %s SL close qty adjusted %.6f → %.6f (actual fill from userFills)", coin, slOwnerPos.Quantity, lookup.FilledQty)
+							}
+							slOwnerPos.Quantity = lookup.FilledQty
+						}
 						if recordPerpsStopLossCloseWithFillFee(ownerSS, coin, slOwnerPos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "hl_sync_stop_loss", logger) {
 							changed = true
 							virtualQty = expectedResidual

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -3031,6 +3031,147 @@ func TestReconcileManualPositionExternalClose(t *testing.T) {
 	}
 }
 
+// --- #621: hyperliquidHasClearedTPTier unit tests ---
+
+func tieredTPATRSC() StrategyConfig {
+	return StrategyConfig{
+		ID:              "hl-tp",
+		CloseStrategies: []string{"tiered_tp_atr"},
+		Params: map[string]interface{}{
+			"tiers": []interface{}{
+				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.5},
+				map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
+			},
+		},
+	}
+}
+
+func TestHyperliquidHasClearedTPTier_NoTPOIDs(t *testing.T) {
+	sc := tieredTPATRSC()
+	pos := &Position{Quantity: 0.422, TPOIDs: nil}
+	if hyperliquidHasClearedTPTier(sc, pos, 0.211) {
+		t.Error("expected false when pos.TPOIDs is nil")
+	}
+	pos.TPOIDs = []int64{}
+	if hyperliquidHasClearedTPTier(sc, pos, 0.211) {
+		t.Error("expected false when pos.TPOIDs is empty")
+	}
+}
+
+func TestHyperliquidHasClearedTPTier_AllActive(t *testing.T) {
+	sc := tieredTPATRSC()
+	pos := &Position{Quantity: 0.422, TPOIDs: []int64{111, 222}}
+	if hyperliquidHasClearedTPTier(sc, pos, 0.211) {
+		t.Error("expected false when all TP OIDs are active (non-zero)")
+	}
+}
+
+func TestHyperliquidHasClearedTPTier_OneClearedOneActive(t *testing.T) {
+	sc := tieredTPATRSC()
+	pos := &Position{Quantity: 0.422, TPOIDs: []int64{0, 222}} // tier 1 cleared, tier 2 active
+	if !hyperliquidHasClearedTPTier(sc, pos, 0.211) {
+		t.Error("expected true when one tier is cleared and one is still active")
+	}
+}
+
+func TestHyperliquidHasClearedTPTier_AllZeroFullClose(t *testing.T) {
+	sc := tieredTPATRSC()
+	// All zero OIDs — treated as final-tier fill only if closeQty == pos.Quantity.
+	pos := &Position{Quantity: 0.422, TPOIDs: []int64{0, 0}}
+	if hyperliquidHasClearedTPTier(sc, pos, 0.211) {
+		t.Error("expected false when all OIDs zero but closeQty != pos.Quantity (ambiguous gap)")
+	}
+	if !hyperliquidHasClearedTPTier(sc, pos, 0.422) {
+		t.Error("expected true when all OIDs zero and closeQty == pos.Quantity (sole-peer final close)")
+	}
+}
+
+// --- #621: SL close bookkeeping uses actual fill qty from userFills ---
+
+// TestReconcilePositionSLClose_UsesFilledQtyFromLookup verifies that when the
+// userFills resolver returns a FilledQty smaller than pos.Quantity (e.g. the
+// SL was placed at on-chain qty after a manual TP reduced the position), the
+// close trade records the actual fill qty rather than the stale virtual qty.
+func TestReconcilePositionSLClose_UsesFilledQtyFromLookup(t *testing.T) {
+	const (
+		virtualQty  = 0.422
+		filledQty   = 0.211
+		slTriggerPx = 1800.0
+		avgCost     = 2000.0
+	)
+	ss := &StrategyState{
+		ID:   "hl-eth",
+		Cash: 100,
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol: "ETH", Quantity: virtualQty, AvgCost: avgCost, Side: "long",
+				Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-eth",
+				StopLossOID: 42, StopLossTriggerPx: slTriggerPx,
+			},
+		},
+	}
+	// Resolver returns filledQty < virtualQty (SL was capped at on-chain size).
+	resolver := hlReconcileFillResolver(func(_ string, _ int64, _ float64) (HLFillLookup, bool) {
+		return HLFillLookup{Fee: 0.08, FilledQty: filledQty, Count: 1}, true
+	})
+	logger := newTestLogger(t)
+
+	// On-chain is flat → reconcileHyperliquidPositionsWithResolver closes position.
+	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if _, open := ss.Positions["ETH"]; open {
+		t.Fatal("ETH position should be closed after SL reconciliation")
+	}
+	if len(ss.ClosedPositions) != 1 {
+		t.Fatalf("ClosedPositions = %d, want 1", len(ss.ClosedPositions))
+	}
+	cp := ss.ClosedPositions[0]
+	if cp.Quantity < filledQty-1e-9 || cp.Quantity > filledQty+1e-9 {
+		t.Errorf("ClosedPosition.Quantity = %g, want %g (actual fill qty, not virtual)", cp.Quantity, filledQty)
+	}
+	// PnL must use filledQty: (1800 - 2000) * 0.211 - 0.08 = -42.28
+	wantPnL := filledQty*(slTriggerPx-avgCost) - 0.08
+	if len(ss.TradeHistory) != 1 {
+		t.Fatalf("TradeHistory = %d, want 1", len(ss.TradeHistory))
+	}
+	if ss.TradeHistory[0].RealizedPnL < wantPnL-0.01 || ss.TradeHistory[0].RealizedPnL > wantPnL+0.01 {
+		t.Errorf("RealizedPnL = %g, want %g (based on actual fill qty)", ss.TradeHistory[0].RealizedPnL, wantPnL)
+	}
+}
+
+// TestReconcilePositionSLClose_FallsBackToVirtualQtyOnMiss verifies that when
+// FilledQty is 0 (lookup miss), the virtual quantity is used unchanged.
+func TestReconcilePositionSLClose_FallsBackToVirtualQtyOnMiss(t *testing.T) {
+	const virtualQty = 0.422
+	ss := &StrategyState{
+		ID:   "hl-eth",
+		Cash: 100,
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol: "ETH", Quantity: virtualQty, AvgCost: 2000, Side: "long",
+				Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-eth",
+				StopLossOID: 42, StopLossTriggerPx: 1800,
+			},
+		},
+	}
+	// Lookup succeeds but FilledQty is 0 (should fall back to pos.Quantity).
+	resolver := hlReconcileFillResolver(func(_ string, _ int64, _ float64) (HLFillLookup, bool) {
+		return HLFillLookup{Fee: 0.15, FilledQty: 0, Count: 1}, true
+	})
+	logger := newTestLogger(t)
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger)
+
+	if len(ss.ClosedPositions) != 1 {
+		t.Fatalf("ClosedPositions = %d, want 1", len(ss.ClosedPositions))
+	}
+	cp := ss.ClosedPositions[0]
+	if cp.Quantity < virtualQty-1e-9 || cp.Quantity > virtualQty+1e-9 {
+		t.Errorf("ClosedPosition.Quantity = %g, want %g (fallback to virtual qty when FilledQty=0)", cp.Quantity, virtualQty)
+	}
+}
+
 // TestReconcileManualPositionSLFired verifies that a type=manual strategy with a
 // resting stop-loss OID uses the hl_sync_stop_loss close path when on-chain goes
 // flat. Regression for #576.

--- a/scheduler/hyperliquid_fills.go
+++ b/scheduler/hyperliquid_fills.go
@@ -20,6 +20,7 @@ import (
 type HLFillLookup struct {
 	Fee       float64
 	ClosedPnL float64
+	FilledQty float64 // sum of sz across matched fill records; 0 when lookup missed
 	Count     int
 	OID       int64
 }
@@ -102,6 +103,7 @@ func lookupHyperliquidFillByOID(accountAddress string, oid int64, startTimeMs in
 				}
 				out.Fee += parseHLFloat(f.Fee)
 				out.ClosedPnL += parseHLFloat(f.ClosedPnl)
+				out.FilledQty += parseHLFloat(f.Sz)
 				out.Count++
 			}
 			if out.Count > 0 {
@@ -156,6 +158,7 @@ func lookupHyperliquidFillByCoinSize(accountAddress, coin string, absSize, toler
 					return HLFillLookup{
 						Fee:       parseHLFloat(anchor.Fee),
 						ClosedPnL: parseHLFloat(anchor.ClosedPnl),
+						FilledQty: parseHLFloat(anchor.Sz),
 						Count:     1,
 					}, true
 				}
@@ -166,6 +169,7 @@ func lookupHyperliquidFillByCoinSize(accountAddress, coin string, absSize, toler
 					}
 					out.Fee += parseHLFloat(f.Fee)
 					out.ClosedPnL += parseHLFloat(f.ClosedPnl)
+					out.FilledQty += parseHLFloat(f.Sz)
 					out.Count++
 				}
 				if out.Count > 0 {

--- a/scheduler/hyperliquid_fills_test.go
+++ b/scheduler/hyperliquid_fills_test.go
@@ -325,3 +325,74 @@ func TestReconcileFillLookupSinceMs_BoundsTo24h(t *testing.T) {
 		t.Errorf("got %d, want %d", got, want)
 	}
 }
+
+// #621: FilledQty must be accumulated across all OID-matching fill records.
+func TestLookupHyperliquidFillByOID_AccumulatesFilledQty(t *testing.T) {
+	withFastFillRetries(t)
+	srv := newHLUserFillsServer(t, []map[string]any{
+		{"coin": "ETH", "oid": 55555, "fee": "0.10", "closedPnl": "5.00", "sz": "0.211"},
+		{"coin": "ETH", "oid": 55555, "fee": "0.05", "closedPnl": "2.50", "sz": "0.100"},
+		{"coin": "ETH", "oid": 99999, "fee": "1.00", "closedPnl": "50.00", "sz": "0.422"}, // unrelated
+	})
+	defer srv.Close()
+	origURL := hlMainnetURL
+	hlMainnetURL = srv.URL
+	defer func() { hlMainnetURL = origURL }()
+
+	got, ok := lookupHyperliquidFillByOID("0xtest", 55555, 0)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got.Count != 2 {
+		t.Errorf("Count = %d, want 2", got.Count)
+	}
+	wantQty := 0.311
+	if got.FilledQty < wantQty-1e-9 || got.FilledQty > wantQty+1e-9 {
+		t.Errorf("FilledQty = %g, want %g", got.FilledQty, wantQty)
+	}
+}
+
+// #621: FilledQty must be set in the coin+size fallback (no-OID anchor case).
+func TestLookupHyperliquidFillByCoinSize_SetsFilledQtyNoOIDCase(t *testing.T) {
+	withFastFillRetries(t)
+	srv := newHLUserFillsServer(t, []map[string]any{
+		{"coin": "ETH", "oid": nil, "fee": "0.08", "closedPnl": "4.00", "sz": "0.211", "time": 1000},
+	})
+	defer srv.Close()
+	origURL := hlMainnetURL
+	hlMainnetURL = srv.URL
+	defer func() { hlMainnetURL = origURL }()
+
+	got, ok := lookupHyperliquidFillByCoinSize("0xtest", "ETH", 0.211, 1e-4, 0)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got.FilledQty < 0.211-1e-9 || got.FilledQty > 0.211+1e-9 {
+		t.Errorf("FilledQty = %g, want 0.211", got.FilledQty)
+	}
+}
+
+// #621: FilledQty must be accumulated across OID-aggregation fills in the
+// coin+size fallback when the anchor has a valid OID.
+func TestLookupHyperliquidFillByCoinSize_AccumulatesFilledQtyWithOID(t *testing.T) {
+	withFastFillRetries(t)
+	srv := newHLUserFillsServer(t, []map[string]any{
+		{"coin": "ETH", "oid": 77777, "fee": "0.05", "closedPnl": "2.00", "sz": "0.100", "time": 2000},
+		{"coin": "ETH", "oid": 77777, "fee": "0.06", "closedPnl": "3.00", "sz": "0.111", "time": 1900},
+		{"coin": "ETH", "oid": 88888, "fee": "0.50", "closedPnl": "10.00", "sz": "0.422", "time": 1000},
+	})
+	defer srv.Close()
+	origURL := hlMainnetURL
+	hlMainnetURL = srv.URL
+	defer func() { hlMainnetURL = origURL }()
+
+	// 0.100 is the sz of the newest fill that matches; anchor OID is 77777.
+	got, ok := lookupHyperliquidFillByCoinSize("0xtest", "ETH", 0.100, 1e-4, 0)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	wantQty := 0.211
+	if got.FilledQty < wantQty-1e-9 || got.FilledQty > wantQty+1e-9 {
+		t.Errorf("FilledQty = %g, want %g (sum across OID group)", got.FilledQty, wantQty)
+	}
+}

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -2465,6 +2465,62 @@ func TestHyperliquidArmFixedATRStopLossLive_NotifiesOnError(t *testing.T) {
 	}
 }
 
+// --- #621: hlSLEffectiveQty caps SL size at on-chain qty ---
+
+func TestHLSLEffectiveQty_NoCapWhenOnChainGeVirtual(t *testing.T) {
+	onChain := map[string]float64{"ETH": 0.422}
+	got, capped := hlSLEffectiveQty("ETH", 0.422, onChain)
+	if capped {
+		t.Error("capped=true, want false when on-chain == virtual")
+	}
+	if got != 0.422 {
+		t.Errorf("qty = %g, want 0.422", got)
+	}
+
+	onChain2 := map[string]float64{"ETH": 0.500}
+	got2, capped2 := hlSLEffectiveQty("ETH", 0.422, onChain2)
+	if capped2 {
+		t.Error("capped=true, want false when on-chain > virtual")
+	}
+	if got2 != 0.422 {
+		t.Errorf("qty = %g, want 0.422", got2)
+	}
+}
+
+func TestHLSLEffectiveQty_CapsWhenOnChainLtVirtual(t *testing.T) {
+	onChain := map[string]float64{"ETH": 0.211}
+	got, capped := hlSLEffectiveQty("ETH", 0.422, onChain)
+	if !capped {
+		t.Error("capped=false, want true when on-chain < virtual")
+	}
+	if got < 0.211-1e-9 || got > 0.211+1e-9 {
+		t.Errorf("qty = %g, want 0.211 (on-chain qty)", got)
+	}
+}
+
+func TestHLSLEffectiveQty_NoCapWhenSymbolNotInMap(t *testing.T) {
+	onChain := map[string]float64{"BTC": 0.01}
+	got, capped := hlSLEffectiveQty("ETH", 0.422, onChain)
+	if capped {
+		t.Error("capped=true, want false when symbol not in on-chain map")
+	}
+	if got != 0.422 {
+		t.Errorf("qty = %g, want 0.422", got)
+	}
+}
+
+func TestHLSLEffectiveQty_NoCapWhenOnChainZero(t *testing.T) {
+	// On-chain zero means Detector 1 territory; don't cap to zero.
+	onChain := map[string]float64{"ETH": 0}
+	got, capped := hlSLEffectiveQty("ETH", 0.422, onChain)
+	if capped {
+		t.Error("capped=true, want false when on-chain qty is zero")
+	}
+	if got != 0.422 {
+		t.Errorf("qty = %g, want 0.422", got)
+	}
+}
+
 // #562: atrMultMissingEntryATR fires when StopLossATRMult is configured but
 // the open candle didn't produce an ATR — same alert behavior as
 // TrailingStopATRMult.

--- a/scheduler/hyperliquid_trailing_stop.go
+++ b/scheduler/hyperliquid_trailing_stop.go
@@ -10,6 +10,18 @@ const defaultTrailingStopMinMovePct = 0.5
 
 var runHyperliquidUpdateStopLossFunc = RunHyperliquidUpdateStopLoss
 
+// hlSLEffectiveQty returns the quantity to use for stop-loss placement.
+// When the on-chain position is smaller than the virtual position (e.g.
+// after a manual TP reduced the position without the bot's knowledge),
+// the on-chain qty is used to avoid placing an oversized reduce-only order
+// that HL would reject (#621). Returns (virtualQty, false) when no cap applies.
+func hlSLEffectiveQty(symbol string, virtualQty float64, onChainQtyMap map[string]float64) (float64, bool) {
+	if onChainQty, ok := onChainQtyMap[symbol]; ok && onChainQty > 1e-9 && onChainQty < virtualQty-1e-9 {
+		return onChainQty, true
+	}
+	return virtualQty, false
+}
+
 // effectiveTrailingStopPct returns the per-position trailing-stop distance as a
 // price-% (e.g. 3.0 == 3%). HL perps only.
 //

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1078,6 +1078,20 @@ func main() {
 					reconcileHyperliquidAccountPositions(hlReconcileDue, hlReconcileAll, state, &mu, logMgr, hlPositions, prices, os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS"))
 				}
 
+				// #621: Build a coin→|on-chain qty| map from the pre-fetched positions
+				// so SL placement can cap its size when virtual qty > on-chain qty
+				// (e.g. after a manual TP reduced the position without the bot's knowledge).
+				hlOnChainAbsQty := make(map[string]float64, len(hlPositions))
+				for _, p := range hlPositions {
+					sz := p.Size
+					if sz < 0 {
+						sz = -sz
+					}
+					if sz > 1e-9 {
+						hlOnChainAbsQty[p.Coin] = sz
+					}
+				}
+
 				for _, sc := range dueStrategies {
 					stratState := state.Strategies[sc.ID]
 					if stratState == nil {
@@ -1390,7 +1404,11 @@ func main() {
 								mu.Unlock()
 							}
 							if hyperliquidIsLive(sc.Args) && result.Signal == 0 && hlPosQty > 0 && effectiveTrailingStopPct(sc, hlPosSnapshot) > 0 {
-								newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, result.Symbol, hlPosSide, hlPosQty, hlPosSnapshot, price, hlStopLossHighWaterPx, hlStopLossTriggerPx, hlStopLossOID, notifier, logger)
+								slEffectiveQty, capped := hlSLEffectiveQty(result.Symbol, hlPosQty, hlOnChainAbsQty)
+								if capped {
+									logger.Warn("trailing SL arm: virtual qty %.6f > on-chain %.6f for %s; capping SL size to on-chain qty (#621)", hlPosQty, slEffectiveQty, result.Symbol)
+								}
+								newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, result.Symbol, hlPosSide, slEffectiveQty, hlPosSnapshot, price, hlStopLossHighWaterPx, hlStopLossTriggerPx, hlStopLossOID, notifier, logger)
 								mu.Lock()
 								if pos, ok3 := stratState.Positions[result.Symbol]; ok3 && pos.Quantity > 0 && pos.Side == hlPosSide {
 									if newHighWater > 0 && updateConfirmed {
@@ -1443,7 +1461,11 @@ func main() {
 							if hyperliquidIsLive(sc.Args) && result.Signal == 0 && hlPosQty > 0 && sc.StopLossATRMult != nil && *sc.StopLossATRMult > 0 && hlStopLossOID == 0 {
 								triggerPx := fixedStopLossATRTriggerPx(sc, hlPosSide, hlPosSnapshot)
 								if triggerPx > 0 {
-									slResult, ok2 := hyperliquidArmFixedATRStopLossLive(sc, result.Symbol, hlPosSide, hlPosQty, triggerPx, notifier, logger)
+									slEffectiveQty, capped := hlSLEffectiveQty(result.Symbol, hlPosQty, hlOnChainAbsQty)
+									if capped {
+										logger.Warn("fixed ATR SL arm: virtual qty %.6f > on-chain %.6f for %s; capping SL size to on-chain qty (#621)", hlPosQty, slEffectiveQty, result.Symbol)
+									}
+									slResult, ok2 := hyperliquidArmFixedATRStopLossLive(sc, result.Symbol, hlPosSide, slEffectiveQty, triggerPx, notifier, logger)
 									if ok2 && slResult != nil {
 										mu.Lock()
 										if pos, ok3 := stratState.Positions[result.Symbol]; ok3 && pos.Quantity > 0 && pos.Side == hlPosSide && pos.StopLossOID == 0 {


### PR DESCRIPTION
## Summary

- **Part A — SL quantity guard**: adds `hlSLEffectiveQty()` helper that caps stop-loss placement size at `min(virtualQty, onChainQty)`. A coin→qty map is built from the pre-fetched `hlPositions` before the per-strategy loop and applied at both SL arm sites (trailing stop `main.go:1404`, fixed ATR SL `main.go:1461`). Prevents HL from rejecting an oversized reduce-only order — which leaves the position unprotected — when a manual TP reduced the on-chain position without the bot's knowledge.
- **Part B — bookkeeping fix**: adds `FilledQty float64` to `HLFillLookup`, accumulated from `f.Sz` in both OID and coin+size lookup paths. When the reconciler closes a position via SL and `useFillFee` is true, overrides `pos.Quantity` with `lookup.FilledQty` (when smaller) so PnL and cash credit the actual fill size rather than the stale virtual quantity. Applied at all three reconciler SL-close sites (single-strategy path, Detector 1, Detector 2).
- **13 new tests**: `hlSLEffectiveQty` (4), `hyperliquidHasClearedTPTier` (4, previously zero coverage), `FilledQty` accumulation in fills lookup (3), SL-close bookkeeping with real fill qty vs. fallback (2).

## Test plan

- [x] `go -C scheduler build .` — clean
- [x] `go -C scheduler test ./...` — all pass (21s)
- [x] `gofmt` — no diff

Closes #621

---
LLM: Claude Sonnet 4.6 (1M) | high