### PR TITLE
Backfill open trade SL price after fixed-ATR arming

### DIFF
--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -2029,4 +2029,30 @@ func TestStampOpenTradeFromPosition(t *testing.T) {
 	if s3.TradeHistory[0].EntryATR != 0 {
 		t.Error("nil pos should be a no-op")
 	}
+
+	// (e) updates the persisted SQLite row for the already-inserted open trade.
+	db, err := OpenStateDB(":memory:")
+	if err != nil {
+		t.Fatalf("OpenStateDB: %v", err)
+	}
+	defer db.Close()
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	s4 := &StrategyState{ID: "s4", TradeHistory: []Trade{
+		{Symbol: "ETH", IsClose: false, EntryATR: 0, StopLossTriggerPx: 0, Timestamp: ts},
+	}}
+	if err := db.InsertTrade(s4.ID, s4.TradeHistory[0]); err != nil {
+		t.Fatalf("InsertTrade: %v", err)
+	}
+	stampOpenTradeFromPosition(s4, db, "ETH", &Position{EntryATR: 250.0, StopLossTriggerPx: 2950.0})
+
+	var entryATR, stopLossTriggerPx float64
+	if err := db.db.QueryRow(
+		`SELECT entry_atr, stop_loss_trigger_px FROM trades WHERE strategy_id = ? AND timestamp = ?`,
+		s4.ID, formatTime(ts),
+	).Scan(&entryATR, &stopLossTriggerPx); err != nil {
+		t.Fatalf("query stamped trade: %v", err)
+	}
+	if entryATR != 250.0 || stopLossTriggerPx != 2950.0 {
+		t.Fatalf("persisted EntryATR/StopLossTriggerPx = %v/%v, want 250/2950", entryATR, stopLossTriggerPx)
+	}
 }

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1434,6 +1434,7 @@ func main() {
 										}
 									} else if newTrigger > 0 && pos.StopLossTriggerPx == 0 {
 										pos.StopLossTriggerPx = newTrigger
+										stampOpenTradeFromPosition(stratState, stateDB, result.Symbol, pos)
 										logger.Info("Paper fixed ATR SL armed @ $%.4f (%.2f%% from entry $%.4f)",
 											newTrigger, effectiveFixedStopLossATRPct(sc, hlPosSnapshot), pos.AvgCost)
 									}
@@ -1455,6 +1456,7 @@ func main() {
 											} else if slResult.StopLossOID > 0 {
 												pos.StopLossOID = slResult.StopLossOID
 												pos.StopLossTriggerPx = slResult.StopLossTriggerPx
+												stampOpenTradeFromPosition(stratState, stateDB, result.Symbol, pos)
 												logger.Info("Fixed ATR SL armed oid=%d @ $%.4f", slResult.StopLossOID, slResult.StopLossTriggerPx)
 											}
 										}


### PR DESCRIPTION
## Summary
- Backfill `StopLossTriggerPx` onto the most recent open trade when a fixed-ATR Hyperliquid stop-loss is armed in the paper and live paths.
- Keep the persisted SQLite trade row in sync so TradingView export, leaderboard reads, and later queries see the armed SL price.
- Add regression coverage for the helper’s SQLite update behavior.

## Root Cause
Fixed-ATR stop-loss arming happens one cycle after the open trade is recorded, so the open `trades` row was inserted before the position had a known stop-loss trigger price.

## Testing
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test -run 'TestStampOpenTradeFromPosition|TestRunHyperliquidFixedATRStopLossPaper|TestHyperliquidArmFixedATRStopLossLive'`
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...`

Closes #623

LLM: GPT-5 | Effort: medium | Harness: Codex desktop app