### PR TITLE
fix: final TP tier absorbs per-tier floor rounding to eliminate position residual

### DIFF
--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -426,6 +426,11 @@ class HyperliquidExchangeAdapter:
             symbol, is_buy, sz, limit_px, order_type, reduce_only=True
         )
 
+    def floor_size(self, symbol: str, sz: float) -> float:
+        """Return sz floored to the asset's lot precision — mirrors place_take_profit_limit."""
+        sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3) if self._info else 3
+        return _floor_size(sz, sz_decimals)
+
     def open_order_oids(self, symbol: str | None = None) -> set[int]:
         """Return currently open order OIDs, optionally filtered by coin (#601).
 

--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -431,6 +431,17 @@ class HyperliquidExchangeAdapter:
         sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3) if self._info else 3
         return _floor_size(sz, sz_decimals)
 
+    def round_size(self, symbol: str, sz: float) -> float:
+        """Round sz to the asset's lot precision (nearest, not floor).
+
+        Use this to normalize a virtual qty that may have drifted just below a
+        lot boundary due to float64 subtraction in Go (e.g. 0.011 - 0.010 =
+        0.0009999...).  place_stop_loss already uses round(); this makes TP
+        tier sizing consistent.
+        """
+        sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3) if self._info else 3
+        return round(sz, sz_decimals)
+
     def open_order_oids(self, symbol: str | None = None) -> set[int]:
         """Return currently open order OIDs, optionally filtered by coin (#601).
 

--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -427,7 +427,9 @@ class HyperliquidExchangeAdapter:
         )
 
     def floor_size(self, symbol: str, sz: float) -> float:
-        """Return sz floored to the asset's lot precision — mirrors place_take_profit_limit."""
+        """Exposes the same lot-precision flooring `place_take_profit_limit`
+        applies internally, so callers can pre-compute the on-chain size each
+        tier will occupy and absorb the remainder into a final tier."""
         sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3) if self._info else 3
         return _floor_size(sz, sz_decimals)
 

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -513,12 +513,22 @@ def run_sync_protection(
             tp_fills = [None] * len(tiers)
             tp_filled_immediately = [False] * len(tiers)
             prev_fraction = 0.0
+            placed_size_total = 0.0
 
             for idx, (atr_mult, cumulative_fraction) in enumerate(tiers):
                 raw_px = avg_cost + atr_mult * entry_atr if side == "long" else avg_cost - atr_mult * entry_atr
                 rounded_px = adapter.round_perps_trigger_px(symbol, raw_px)
                 tp_pxs.append(rounded_px)
-                tier_size = size * max(cumulative_fraction - prev_fraction, 0.0)
+                is_final_tier = idx == len(tiers) - 1
+                if is_final_tier:
+                    # Use exact remainder so per-tier flooring doesn't leave a
+                    # residual position uncovered after all TPs fill.
+                    tier_size = max(size - placed_size_total, 0.0)
+                else:
+                    tier_size = size * max(cumulative_fraction - prev_fraction, 0.0)
+                    # Accumulate the floored amount so the final tier gets the
+                    # exact residual, not the fractional one.
+                    placed_size_total += adapter.floor_size(symbol, tier_size)
                 prev_fraction = cumulative_fraction
                 prev_oid = int(existing_tp_oids[idx]) if idx < len(existing_tp_oids) else 0
 

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -512,6 +512,18 @@ def run_sync_protection(
             tp_filled_externally = [False] * len(tiers)
             tp_fills = [None] * len(tiers)
             tp_filled_immediately = [False] * len(tiers)
+            # Normalize to lot precision before computing tier sizes.  Go's
+            # float64 arithmetic (pos.Quantity -= closeQty) can drift just below
+            # a lot boundary (e.g. 0.011 - 0.010 = 0.000999...) even though the
+            # true virtual qty is exactly one lot.  round() matches what
+            # place_stop_loss already does for SL size.
+            size = adapter.round_size(symbol, size)
+            if size <= 0:
+                print(
+                    f"[INFO] TP protection skipped for {symbol}: virtual qty "
+                    f"rounds to zero at lot precision — peer TPs cover the on-chain position",
+                    file=sys.stderr,
+                )
             prev_fraction = 0.0
             placed_size_total = 0.0
 

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -393,6 +393,39 @@ def _normalize_tp_tiers(tp_tiers=None, tp1_atr_mult=0.0, tp1_fraction=0.0, tp2_a
     return tiers
 
 
+def compute_tp_tier_sizes(size, tiers, floor_size_fn):
+    """Compute per-tier reduce-only sizes that cover the full lot-aligned position.
+
+    Non-final tiers are pre-floored so each on-chain order is lot-aligned;
+    the final tier absorbs the remainder via integer-lot subtraction
+    (`floor_size(size) - sum(non-final floors)`) so per-tier truncation
+    cannot strand a permanent residual (#628).
+
+    `tiers` is the normalized output of `_normalize_tp_tiers`: a list of
+    (atr_multiple, cumulative_fraction) with the final fraction == 1.0.
+
+    Returns a list of float sizes the same length as `tiers`. Returns all
+    zeros when `size <= 0` or `tiers` is empty.
+    """
+    if not tiers or size <= 0:
+        return [0.0] * len(tiers)
+    floored_total = floor_size_fn(size)
+    sizes = []
+    placed = 0.0
+    prev_fraction = 0.0
+    for idx, (_atr_mult, cumulative_fraction) in enumerate(tiers):
+        is_final = idx == len(tiers) - 1
+        if is_final:
+            tier_size = max(floored_total - placed, 0.0)
+        else:
+            raw = size * max(cumulative_fraction - prev_fraction, 0.0)
+            tier_size = floor_size_fn(raw)
+            placed += tier_size
+        prev_fraction = cumulative_fraction
+        sizes.append(tier_size)
+    return sizes
+
+
 def run_sync_protection(
     symbol,
     side,
@@ -506,12 +539,6 @@ def run_sync_protection(
             if len(existing_tp_oids) < len(tiers):
                 existing_tp_oids.extend([0] * (len(tiers) - len(existing_tp_oids)))
 
-            tp_oids_out = list(existing_tp_oids[:len(tiers)])
-            tp_pxs = []
-            tp_errors = [""] * len(tiers)
-            tp_filled_externally = [False] * len(tiers)
-            tp_fills = [None] * len(tiers)
-            tp_filled_immediately = [False] * len(tiers)
             # Normalize to lot precision before computing tier sizes.  Go's
             # float64 arithmetic (pos.Quantity -= closeQty) can drift just below
             # a lot boundary (e.g. 0.011 - 0.010 = 0.000999...) even though the
@@ -524,84 +551,83 @@ def run_sync_protection(
                     f"rounds to zero at lot precision — peer TPs cover the on-chain position",
                     file=sys.stderr,
                 )
-            prev_fraction = 0.0
-            placed_size_total = 0.0
+            else:
+                tp_oids_out = list(existing_tp_oids[:len(tiers)])
+                tp_pxs = []
+                tp_errors = [""] * len(tiers)
+                tp_filled_externally = [False] * len(tiers)
+                tp_fills = [None] * len(tiers)
+                tp_filled_immediately = [False] * len(tiers)
+                tier_sizes = compute_tp_tier_sizes(
+                    size, tiers, lambda sz: adapter.floor_size(symbol, sz)
+                )
 
-            for idx, (atr_mult, cumulative_fraction) in enumerate(tiers):
-                raw_px = avg_cost + atr_mult * entry_atr if side == "long" else avg_cost - atr_mult * entry_atr
-                rounded_px = adapter.round_perps_trigger_px(symbol, raw_px)
-                tp_pxs.append(rounded_px)
-                is_final_tier = idx == len(tiers) - 1
-                if is_final_tier:
-                    # Use exact remainder so per-tier flooring doesn't leave a
-                    # residual position uncovered after all TPs fill.
-                    tier_size = max(size - placed_size_total, 0.0)
-                else:
-                    tier_size = size * max(cumulative_fraction - prev_fraction, 0.0)
-                    # Accumulate the floored amount so the final tier gets the
-                    # exact residual, not the fractional one.
-                    placed_size_total += adapter.floor_size(symbol, tier_size)
-                prev_fraction = cumulative_fraction
-                prev_oid = int(existing_tp_oids[idx]) if idx < len(existing_tp_oids) else 0
+                for idx, ((atr_mult, _cumulative_fraction), tier_size) in enumerate(
+                    zip(tiers, tier_sizes)
+                ):
+                    raw_px = avg_cost + atr_mult * entry_atr if side == "long" else avg_cost - atr_mult * entry_atr
+                    rounded_px = adapter.round_perps_trigger_px(symbol, raw_px)
+                    tp_pxs.append(rounded_px)
+                    prev_oid = int(existing_tp_oids[idx]) if idx < len(existing_tp_oids) else 0
 
-                if tier_size <= 0:
-                    continue
-                if _oid_is_open(open_oids, prev_oid):
-                    tp_oids_out[idx] = prev_oid
-                    continue
+                    if tier_size <= 0:
+                        continue
+                    if _oid_is_open(open_oids, prev_oid):
+                        tp_oids_out[idx] = prev_oid
+                        continue
 
-                action, fill = _resolve_missing_oid(prev_oid)
-                if action == "filled":
-                    tp_oids_out[idx] = 0
-                    tp_filled_externally[idx] = True
-                    tp_fills[idx] = fill
-                    print(f"[WARN] TP{idx + 1} OID={prev_oid} already filled on-chain; not re-placing — reconciler will book the close", file=sys.stderr)
-                elif action == "place":
-                    try:
-                        resp = adapter.place_take_profit_limit(symbol, tier_size, rounded_px, close_is_buy)
-                        kind, payload = _classify_sl_response(resp)
-                        if kind == "resting":
-                            tp_oids_out[idx] = payload
-                        elif kind == "filled":
-                            tp_filled_immediately[idx] = True
-                        elif kind == "error":
-                            tp_errors[idx] = f"place_take_profit_limit SDK error: {payload}"
-                        else:
-                            tp_errors[idx] = f"place_take_profit_limit returned no usable status: {resp}"
-                    except Exception as te:
-                        tp_errors[idx] = str(te)
-                # action=="unknown" → echo previous OID, retry next cycle
+                    action, fill = _resolve_missing_oid(prev_oid)
+                    if action == "filled":
+                        tp_oids_out[idx] = 0
+                        tp_filled_externally[idx] = True
+                        tp_fills[idx] = fill
+                        print(f"[WARN] TP{idx + 1} OID={prev_oid} already filled on-chain; not re-placing — reconciler will book the close", file=sys.stderr)
+                    elif action == "place":
+                        try:
+                            resp = adapter.place_take_profit_limit(symbol, tier_size, rounded_px, close_is_buy)
+                            kind, payload = _classify_sl_response(resp)
+                            if kind == "resting":
+                                tp_oids_out[idx] = payload
+                            elif kind == "filled":
+                                tp_filled_immediately[idx] = True
+                            elif kind == "error":
+                                tp_errors[idx] = f"place_take_profit_limit SDK error: {payload}"
+                            else:
+                                tp_errors[idx] = f"place_take_profit_limit returned no usable status: {resp}"
+                        except Exception as te:
+                            tp_errors[idx] = str(te)
+                    # action=="unknown" → echo previous OID, retry next cycle
 
-            out["tp_oids"] = tp_oids_out
-            out["tp_pxs"] = tp_pxs
-            if any(tp_errors):
-                out["tp_errors"] = tp_errors
-            if any(tp_filled_externally):
-                out["tp_filled_externally"] = tp_filled_externally
-                out["tp_fills"] = tp_fills
-            if any(tp_filled_immediately):
-                out["tp_filled_immediately"] = tp_filled_immediately
+                out["tp_oids"] = tp_oids_out
+                out["tp_pxs"] = tp_pxs
+                if any(tp_errors):
+                    out["tp_errors"] = tp_errors
+                if any(tp_filled_externally):
+                    out["tp_filled_externally"] = tp_filled_externally
+                    out["tp_fills"] = tp_fills
+                if any(tp_filled_immediately):
+                    out["tp_filled_immediately"] = tp_filled_immediately
 
-            # Legacy fields stay populated for older callers/tests during the
-            # migration from fixed TP1/TP2 fields to the N-tier slice (#612).
-            if len(tp_oids_out) > 0 and tp_oids_out[0] > 0:
-                out["tp1_oid"] = tp_oids_out[0]
-            if len(tp_oids_out) > 1 and tp_oids_out[1] > 0:
-                out["tp2_oid"] = tp_oids_out[1]
-            if len(tp_pxs) > 0:
-                out["tp1_px"] = tp_pxs[0]
-            if len(tp_pxs) > 1:
-                out["tp2_px"] = tp_pxs[1]
-            if len(tp_errors) > 0 and tp_errors[0]:
-                out["tp1_error"] = tp_errors[0]
-            if len(tp_errors) > 1 and tp_errors[1]:
-                out["tp2_error"] = tp_errors[1]
-            if len(tp_filled_externally) > 0 and tp_filled_externally[0]:
-                out["tp1_filled_externally"] = True
-                out["tp1_fill"] = tp_fills[0]
-            if len(tp_filled_externally) > 1 and tp_filled_externally[1]:
-                out["tp2_filled_externally"] = True
-                out["tp2_fill"] = tp_fills[1]
+                # Legacy fields stay populated for older callers/tests during the
+                # migration from fixed TP1/TP2 fields to the N-tier slice (#612).
+                if len(tp_oids_out) > 0 and tp_oids_out[0] > 0:
+                    out["tp1_oid"] = tp_oids_out[0]
+                if len(tp_oids_out) > 1 and tp_oids_out[1] > 0:
+                    out["tp2_oid"] = tp_oids_out[1]
+                if len(tp_pxs) > 0:
+                    out["tp1_px"] = tp_pxs[0]
+                if len(tp_pxs) > 1:
+                    out["tp2_px"] = tp_pxs[1]
+                if len(tp_errors) > 0 and tp_errors[0]:
+                    out["tp1_error"] = tp_errors[0]
+                if len(tp_errors) > 1 and tp_errors[1]:
+                    out["tp2_error"] = tp_errors[1]
+                if len(tp_filled_externally) > 0 and tp_filled_externally[0]:
+                    out["tp1_filled_externally"] = True
+                    out["tp1_fill"] = tp_fills[0]
+                if len(tp_filled_externally) > 1 and tp_filled_externally[1]:
+                    out["tp2_filled_externally"] = True
+                    out["tp2_fill"] = tp_fills[1]
 
         print(json.dumps(out, cls=SafeEncoder))
     except Exception as e:

--- a/shared_scripts/test_check_hyperliquid.py
+++ b/shared_scripts/test_check_hyperliquid.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import json
+import math
 import importlib.util
 from unittest.mock import MagicMock, patch
 from io import StringIO
@@ -670,6 +671,10 @@ class TestSyncProtection:
             set() if open_oids is None else set(open_oids)
         )
         mock_adapter.round_perps_trigger_px.side_effect = lambda _sym, px: round(px, 4)
+        # ETH on HL has sz_decimals=3.  Match the real adapter's behavior so
+        # the new round-then-floor tier sizing logic exercises real lot math.
+        mock_adapter.round_size.side_effect = lambda _sym, sz: round(sz, 3)
+        mock_adapter.floor_size.side_effect = lambda _sym, sz: math.floor(sz * 1000) / 1000
 
         fills = fill_lookup_by_oid or {}
 
@@ -868,6 +873,8 @@ class TestSyncProtection:
         mock_adapter_cls.return_value = mock_adapter
         mock_adapter.open_order_oids.side_effect = RuntimeError("indexer down")
         mock_adapter.round_perps_trigger_px.side_effect = lambda _sym, px: round(px, 4)
+        mock_adapter.round_size.side_effect = lambda _sym, sz: round(sz, 3)
+        mock_adapter.floor_size.side_effect = lambda _sym, sz: math.floor(sz * 1000) / 1000
 
         captured = StringIO()
         import builtins
@@ -892,3 +899,143 @@ class TestSyncProtection:
         # No re-placements issued — existing OIDs are left alone.
         mock_adapter.place_take_profit_limit.assert_not_called()
         mock_adapter.place_stop_loss.assert_not_called()
+
+    def test_floor_residual_absorbed_by_final_tier(self):
+        """#628 issue 1: at sz_decimals=3 a 0.003 ETH virtual qty with 50/50
+        tiers must place 0.001 + 0.002, NOT 0.001 + 0.001 (which would strand
+        0.001 ETH uncovered for the life of the position)."""
+        out, adapter = self._run_sync(
+            size=0.003,
+            tp_tiers=[
+                {"atr_multiple": 1.0, "close_fraction": 0.5},
+                {"atr_multiple": 2.0, "close_fraction": 1.0},
+            ],
+            tp_oids=[0, 0],
+            open_oids=set(),
+        )
+        assert out["tp_oids"]
+        sizes = [call.args[1] for call in adapter.place_take_profit_limit.call_args_list]
+        assert sizes == pytest.approx([0.001, 0.002])
+        assert sum(sizes) == pytest.approx(0.003)
+
+    def test_float_drift_below_lot_boundary_normalizes(self):
+        """#628 issue 2: Go's `pos.Quantity -= closeQty` can produce values
+        like 0.011 - 0.010 = 0.0009999999999999992.  round_size must lift
+        this back to 0.001 so the tier loop places a real reduce-only
+        order rather than failing with `Size floored to zero`."""
+        drifted = 0.011 - 0.010  # 0.0009999999999999992
+        assert drifted < 0.001  # confirm we're testing the drift case
+        out, adapter = self._run_sync(
+            size=drifted,
+            tp_tiers=[
+                {"atr_multiple": 1.0, "close_fraction": 0.5},
+                {"atr_multiple": 2.0, "close_fraction": 1.0},
+            ],
+            tp_oids=[0, 0],
+            open_oids=set(),
+        )
+        # At 0.001 lot with sz_decimals=3, tier 1 floors to 0 (skipped) and
+        # tier 2 absorbs the full 0.001 remainder.
+        assert out["tp_oids"]
+        sizes = [call.args[1] for call in adapter.place_take_profit_limit.call_args_list]
+        assert sum(sizes) == pytest.approx(0.001)
+
+    def test_size_rounds_to_zero_skips_tier_block(self):
+        """When the virtual qty rounds below one lot, no TPs should be placed
+        and the output must not carry stale tp_oids/tp_pxs (#628 review #4)."""
+        out, adapter = self._run_sync(
+            size=0.0004,  # rounds to 0 at sz_decimals=3
+            tp_tiers=[
+                {"atr_multiple": 1.0, "close_fraction": 0.5},
+                {"atr_multiple": 2.0, "close_fraction": 1.0},
+            ],
+            tp_oids=[0, 0],
+            open_oids=set(),
+        )
+        adapter.place_take_profit_limit.assert_not_called()
+        assert "tp_oids" not in out
+        assert "tp_pxs" not in out
+
+    def test_three_tier_non_uniform_flooring_zero_residual(self):
+        """Multi-tier non-uniform fractions where each tier's `size*fraction`
+        truncates differently — final tier must still cover the lot-aligned
+        remainder so `sum(tier_sizes) == floor(size)`."""
+        out, adapter = self._run_sync(
+            size=0.007,
+            tp_tiers=[
+                {"atr_multiple": 1.0, "close_fraction": 0.3},
+                {"atr_multiple": 2.0, "close_fraction": 0.6},
+                {"atr_multiple": 3.0, "close_fraction": 1.0},
+            ],
+            tp_oids=[0, 0, 0],
+            open_oids=set(),
+        )
+        assert out["tp_oids"]
+        sizes = [call.args[1] for call in adapter.place_take_profit_limit.call_args_list]
+        # 0.007 * 0.3 = 0.0021 → floor 0.002; 0.007 * 0.3 = 0.0021 → floor 0.002;
+        # final = 0.007 - (0.002 + 0.002) = 0.003.  No residual stranded.
+        assert sum(sizes) == pytest.approx(0.007)
+
+
+class TestComputeTPTierSizes:
+    """#628 review #3: pure helper for per-tier reduce-only sizing.  Exercises
+    the same flooring math as run_sync_protection without needing the full
+    sync-protection plumbing or adapter mocks."""
+
+    @staticmethod
+    def _floor3(sz):
+        """sz_decimals=3 (matches ETH on Hyperliquid)."""
+        return math.floor(sz * 1000) / 1000
+
+    def _load(self):
+        mod, spec = _load_check_module()
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_zero_size_returns_zero_sizes(self):
+        mod = self._load()
+        sizes = mod.compute_tp_tier_sizes(0.0, [(1.0, 0.5), (2.0, 1.0)], self._floor3)
+        assert sizes == [0.0, 0.0]
+
+    def test_negative_size_returns_zero_sizes(self):
+        mod = self._load()
+        sizes = mod.compute_tp_tier_sizes(-0.5, [(1.0, 0.5), (2.0, 1.0)], self._floor3)
+        assert sizes == [0.0, 0.0]
+
+    def test_empty_tiers_returns_empty(self):
+        mod = self._load()
+        assert mod.compute_tp_tier_sizes(1.0, [], self._floor3) == []
+
+    def test_two_tier_5050_split_zero_residual(self):
+        """0.003 / [0.5, 1.0] / sz_decimals=3 → [0.001, 0.002], NOT [0.001, 0.001]."""
+        mod = self._load()
+        sizes = mod.compute_tp_tier_sizes(0.003, [(1.0, 0.5), (2.0, 1.0)], self._floor3)
+        assert sizes == pytest.approx([0.001, 0.002])
+        assert sum(sizes) == pytest.approx(0.003)
+
+    def test_final_tier_absorbs_subdivided_floor_loss(self):
+        """3 tiers, fractions that don't divide evenly into size."""
+        mod = self._load()
+        # 0.007 / [0.3, 0.6, 1.0]: floors are [0.002, 0.002, remainder=0.003]
+        sizes = mod.compute_tp_tier_sizes(
+            0.007, [(1.0, 0.3), (2.0, 0.6), (3.0, 1.0)], self._floor3
+        )
+        assert sizes == pytest.approx([0.002, 0.002, 0.003])
+        assert sum(sizes) == pytest.approx(0.007)
+
+    def test_lot_aligned_size_preserves_exact_split(self):
+        """Lot-aligned size with even fraction → no residual to absorb."""
+        mod = self._load()
+        sizes = mod.compute_tp_tier_sizes(10.0, [(1.0, 0.5), (2.0, 1.0)], self._floor3)
+        assert sizes == pytest.approx([5.0, 5.0])
+
+    def test_final_tier_below_one_uses_floored_remainder(self):
+        """When the helper is fed a normalized [(_, 0.5), (_, 0.7)] (final
+        coerced to 1.0 by _normalize_tp_tiers, but the helper itself accepts
+        any cumulative shape), the final tier still gets the floored remainder."""
+        mod = self._load()
+        # Use 1.0 final like the real normalizer produces.
+        sizes = mod.compute_tp_tier_sizes(0.5, [(1.0, 0.5), (2.0, 1.0)], self._floor3)
+        assert sum(sizes) == pytest.approx(0.5)
+        assert sizes[0] == pytest.approx(0.25)
+        assert sizes[1] == pytest.approx(0.25)


### PR DESCRIPTION
## Summary

Closes #628

### Issue 1 — per-tier floor rounding leaves a permanent residual

Each tier independently applied `_floor_size` to its fraction of the virtual position size. When `size × fraction` wasn't an exact lot multiple, the truncation losses accumulated and the last tier left a permanent gap that no TP ever covered.

**Before / after — 0.003 ETH, default 50/50 split, `sz_decimals=3`:**

| | TP1 | TP2 | Total | Gap |
|---|---|---|---|---|
| Before | 0.001 | 0.001 | 0.002 | **0.001 ETH stranded** |
| After  | 0.001 | 0.002 | 0.003 | 0 |

Fix: non-final tiers accumulate their floored size via the new `adapter.floor_size(symbol, sz)`; the final tier uses `size - placed_size_total` (exact remainder).

### Issue 2 — float64 drift pushes virtual qty below lot boundary

Go's `pos.Quantity -= closeQty` uses float64 arithmetic. Subtracting two valid lot-boundary quantities can drift just below the boundary — e.g. `0.011 - 0.010 = 0.0009999999999999992`. `_floor_size` then truncates this to zero, causing all tiers to fail with "Size floored to zero" even though the virtual qty represents exactly one lot.

Fix: `adapter.round_size(symbol, sz)` (using `round()`, consistent with how `place_stop_loss` already sizes SL orders) normalizes `size` at the top of the TP tier block before any tier calculation runs.

## Test plan

1. Verified zero gap across representative ETH position sizes (0.001–0.015 ETH) via inline simulation.
2. Verified `0.011 - 0.010` drift case normalizes to `0.001` and covers position fully.
3. `python3 -m py_compile` passes on both modified files.

---
LLM: Claude Sonnet 4.6 (1M) | high