### PR TITLE
fix: persist SL trigger px on protection-sync stamp (#625)

### DIFF
--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -302,6 +302,7 @@ func applyHyperliquidProtectionSync(pos *Position, result *HyperliquidProtection
 func runHyperliquidProtectionSync(
 	sc StrategyConfig,
 	stratState *StrategyState,
+	db *StateDB,
 	symbol string,
 	mu *sync.RWMutex,
 	notifier *MultiNotifier,
@@ -336,7 +337,7 @@ func runHyperliquidProtectionSync(
 	// by the protection sync (#625). Without this, execute-path SL=0 leaves the
 	// trade's StopLossTriggerPx unset even though the sync correctly populated
 	// pos.StopLossTriggerPx — the alert then shows no SL price.
-	stampOpenTradeFromPosition(stratState, nil, symbol, pos)
+	stampOpenTradeFromPosition(stratState, db, symbol, pos)
 	if logger != nil {
 		logger.Info("%s (sl_oid=%d tp_oids=%v)", logTag, pos.StopLossOID, pos.TPOIDs)
 	}

--- a/scheduler/hyperliquid_protection_test.go
+++ b/scheduler/hyperliquid_protection_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestBuildHyperliquidProtectionPlanUsesDefaultTieredATR(t *testing.T) {
@@ -412,7 +413,7 @@ func TestRunHyperliquidProtectionSyncManualAppliesOIDs(t *testing.T) {
 	})
 
 	var mu sync.RWMutex
-	if !runHyperliquidProtectionSync(sc, state, "ETH", &mu, nil, nil, "test") {
+	if !runHyperliquidProtectionSync(sc, state, nil, "ETH", &mu, nil, nil, "test") {
 		t.Fatal("expected runHyperliquidProtectionSync to apply")
 	}
 	if calls != 1 {
@@ -446,7 +447,7 @@ func TestRunHyperliquidProtectionSyncSkipsWhenNoPlan(t *testing.T) {
 	})
 
 	var mu sync.RWMutex
-	if runHyperliquidProtectionSync(sc, state, "ETH", &mu, nil, nil, "test") {
+	if runHyperliquidProtectionSync(sc, state, nil, "ETH", &mu, nil, nil, "test") {
 		t.Fatal("expected runHyperliquidProtectionSync to skip when no plan")
 	}
 	if called {
@@ -480,12 +481,71 @@ func TestRunHyperliquidProtectionSyncSkipsApplyAfterExternalClose(t *testing.T) 
 	})
 
 	var mu sync.RWMutex
-	if runHyperliquidProtectionSync(sc, state, "ETH", &mu, nil, nil, "test") {
+	if runHyperliquidProtectionSync(sc, state, nil, "ETH", &mu, nil, nil, "test") {
 		t.Fatal("expected apply to be skipped after position closed externally")
 	}
 	pos := state.Positions["ETH"]
 	if pos.StopLossOID != 0 || len(pos.TPOIDs) != 0 {
 		t.Errorf("OIDs leaked into closed position: sl=%d tp=%v", pos.StopLossOID, pos.TPOIDs)
+	}
+}
+
+// TestRunHyperliquidProtectionSyncStampsTradeInDB regresses #625: when
+// protection sync places the SL post-open, the SQLite trade row's
+// stop_loss_trigger_px must be backfilled (not just the in-memory TradeHistory).
+func TestRunHyperliquidProtectionSyncStampsTradeInDB(t *testing.T) {
+	mult := 1.5
+	sc := StrategyConfig{
+		ID:              "hl-eth",
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		CloseStrategies: []string{"tiered_tp_atr_live"},
+		StopLossATRMult: &mult,
+	}
+	ts := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	state := &StrategyState{
+		ID: sc.ID,
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.4, AvgCost: 3000, EntryATR: 100, Side: "long"},
+		},
+		TradeHistory: []Trade{
+			{Symbol: "ETH", IsClose: false, Timestamp: ts},
+		},
+	}
+	db, err := OpenStateDB(":memory:")
+	if err != nil {
+		t.Fatalf("OpenStateDB: %v", err)
+	}
+	defer db.Close()
+	if err := db.InsertTrade(state.ID, state.TradeHistory[0]); err != nil {
+		t.Fatalf("InsertTrade: %v", err)
+	}
+
+	withStubbedSyncHyperliquidProtection(t, func(_ StrategyConfig, _ hlProtectionPlan, _ *MultiNotifier, _ *StrategyLogger) (*HyperliquidProtectionSyncResult, bool) {
+		return &HyperliquidProtectionSyncResult{
+			StopLossOID:       999,
+			StopLossTriggerPx: 2850.0,
+			TPOIDs:            []int64{111, 222},
+		}, true
+	})
+
+	var mu sync.RWMutex
+	if !runHyperliquidProtectionSync(sc, state, db, "ETH", &mu, nil, nil, "test") {
+		t.Fatal("expected runHyperliquidProtectionSync to apply")
+	}
+
+	if got := state.TradeHistory[0].StopLossTriggerPx; got != 2850.0 {
+		t.Errorf("in-memory StopLossTriggerPx = %v, want 2850", got)
+	}
+	var stopLossTriggerPx float64
+	if err := db.db.QueryRow(
+		`SELECT stop_loss_trigger_px FROM trades WHERE strategy_id = ? AND timestamp = ?`,
+		state.ID, formatTime(ts),
+	).Scan(&stopLossTriggerPx); err != nil {
+		t.Fatalf("query stamped trade: %v", err)
+	}
+	if stopLossTriggerPx != 2850.0 {
+		t.Errorf("persisted stop_loss_trigger_px = %v, want 2850", stopLossTriggerPx)
 	}
 }
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1487,7 +1487,7 @@ func main() {
 								}
 							}
 							if hyperliquidIsLive(sc.Args) && result.Signal == 0 && hlPosQty > 0 {
-								runHyperliquidProtectionSync(sc, stratState, result.Symbol, &mu, notifier, logger, "HL protection synced")
+								runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced")
 							}
 							if hyperliquidIsLive(sc.Args) && result.Signal != 0 {
 								er, ok2 := runHyperliquidExecuteOrder(sc, result, price, hlCash, hlPosQty, hlPosSide, hlAvgCost, hlStopLossOID, hlTPOIDs, hlReconcileAll, notifier, logger)
@@ -1517,7 +1517,7 @@ func main() {
 								trades, detail = executeHyperliquidResult(sc, stratState, stateDB, result, execResult, signalStr, price, logger)
 								mu.Unlock()
 								if execResult != nil && trades > 0 {
-									runHyperliquidProtectionSync(sc, stratState, result.Symbol, &mu, notifier, logger, "HL protection synced after trade")
+									runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced after trade")
 								}
 							}
 						}
@@ -1557,7 +1557,7 @@ func main() {
 							break
 						}
 						if pos != nil && hyperliquidIsLive(sc.Args) {
-							runHyperliquidProtectionSync(sc, stratState, sc.Symbol, &mu, notifier, logger, "HL manual protection synced")
+							runHyperliquidProtectionSync(sc, stratState, stateDB, sc.Symbol, &mu, notifier, logger, "HL manual protection synced")
 						}
 						if closeFraction, _, ok := runManualCloseEval(sc, stratState, cfg, logger); ok && closeFraction > 0 {
 							mu.RLock()


### PR DESCRIPTION
## Summary

Threads `*StateDB` into `runHyperliquidProtectionSync` so the `stampOpenTradeFromPosition` call after `applyHyperliquidProtectionSync` updates `trades.stop_loss_trigger_px` in SQLite, not just in-memory `TradeHistory`.

4ddbd5f added the in-memory stamp with `db=nil` — that fixed the trade alert but left the SQLite row at 0, inconsistent with #561/#624 which populate that column for analytics and TradingView export.

## Changes

- `scheduler/hyperliquid_protection.go`: add `db *StateDB` parameter; pass to `stampOpenTradeFromPosition`.
- `scheduler/main.go`: pass `stateDB` at the three call sites (open-no-trade, post-trade, manual).
- `scheduler/hyperliquid_protection_test.go`: update three existing call sites; add regression test `TestRunHyperliquidProtectionSyncStampsTradeInDB` that asserts SQLite `stop_loss_trigger_px` is backfilled.

## Test plan
- [x] `go build` and full `go test ./...` pass in `scheduler/`.
- [x] New regression test asserts SQLite row updated, not just `TradeHistory`.

Closes #625

---
LLM: Claude Opus 4.7 (1M) | high