### PR TITLE
feat: place SL and TP[n] orders inline on manual-open

### DIFF
--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -210,6 +210,7 @@ CREATE TABLE IF NOT EXISTS pending_manual_actions (
     entry_atr REAL NOT NULL DEFAULT 0,
     realized_pnl REAL NOT NULL DEFAULT 0,
     is_full_close INTEGER NOT NULL DEFAULT 0,
+    tp_oids_json TEXT NOT NULL DEFAULT '',
     created_at TEXT NOT NULL
 );
 `
@@ -302,6 +303,8 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE positions ADD COLUMN tp2_oid INTEGER NOT NULL DEFAULT 0",
 		// Variable-length per-strategy HL reduce-only take-profit OIDs (#612).
 		"ALTER TABLE positions ADD COLUMN tp_oids_json TEXT NOT NULL DEFAULT ''",
+		// Inline TP OIDs for manual-open actions so the scheduler drain sets pos.TPOIDs (#632).
+		"ALTER TABLE pending_manual_actions ADD COLUMN tp_oids_json TEXT NOT NULL DEFAULT ''",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -1521,7 +1524,8 @@ type PendingManualAction struct {
 	StopLossTriggerPx float64
 	EntryATR          float64
 	RealizedPnL       float64
-	IsFullClose       bool // close-only: operator/scheduler intent flag (avoids tolerance heuristics on the drain side)
+	IsFullClose       bool    // close-only: operator/scheduler intent flag (avoids tolerance heuristics on the drain side)
+	TPOIDs            []int64 // open-only: TP OIDs placed inline at manual-open time (#632)
 	CreatedAt         time.Time
 }
 
@@ -1536,11 +1540,11 @@ func (sdb *StateDB) InsertPendingManualAction(a PendingManualAction) error {
 		isFullClose = 1
 	}
 	_, err := sdb.db.Exec(`INSERT INTO pending_manual_actions
-		(strategy_id, action, symbol, side, quantity, fill_price, fill_fee, exchange_order_id, stop_loss_oid, stop_loss_trigger_px, entry_atr, realized_pnl, is_full_close, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		(strategy_id, action, symbol, side, quantity, fill_price, fill_fee, exchange_order_id, stop_loss_oid, stop_loss_trigger_px, entry_atr, realized_pnl, is_full_close, tp_oids_json, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.StrategyID, a.Action, a.Symbol, a.Side, a.Quantity, a.FillPrice, a.FillFee,
 		a.ExchangeOrderID, a.StopLossOID, a.StopLossTriggerPx, a.EntryATR, a.RealizedPnL,
-		isFullClose, formatTime(a.CreatedAt))
+		isFullClose, marshalTPOIDsJSON(a.TPOIDs), formatTime(a.CreatedAt))
 	return err
 }
 
@@ -1549,7 +1553,7 @@ func (sdb *StateDB) LoadPendingManualActions() ([]PendingManualAction, error) {
 	if sdb == nil || sdb.db == nil {
 		return nil, nil
 	}
-	rows, err := sdb.db.Query(`SELECT id, strategy_id, action, symbol, side, quantity, fill_price, fill_fee, exchange_order_id, stop_loss_oid, stop_loss_trigger_px, entry_atr, realized_pnl, COALESCE(is_full_close, 0) AS is_full_close, created_at FROM pending_manual_actions ORDER BY id`)
+	rows, err := sdb.db.Query(`SELECT id, strategy_id, action, symbol, side, quantity, fill_price, fill_fee, exchange_order_id, stop_loss_oid, stop_loss_trigger_px, entry_atr, realized_pnl, COALESCE(is_full_close, 0) AS is_full_close, COALESCE(tp_oids_json, '') AS tp_oids_json, created_at FROM pending_manual_actions ORDER BY id`)
 	if err != nil {
 		return nil, fmt.Errorf("load pending manual actions: %w", err)
 	}
@@ -1559,10 +1563,12 @@ func (sdb *StateDB) LoadPendingManualActions() ([]PendingManualAction, error) {
 		var a PendingManualAction
 		var createdStr string
 		var isFullCloseInt int
-		if err := rows.Scan(&a.ID, &a.StrategyID, &a.Action, &a.Symbol, &a.Side, &a.Quantity, &a.FillPrice, &a.FillFee, &a.ExchangeOrderID, &a.StopLossOID, &a.StopLossTriggerPx, &a.EntryATR, &a.RealizedPnL, &isFullCloseInt, &createdStr); err != nil {
+		var tpOIDsJSON string
+		if err := rows.Scan(&a.ID, &a.StrategyID, &a.Action, &a.Symbol, &a.Side, &a.Quantity, &a.FillPrice, &a.FillFee, &a.ExchangeOrderID, &a.StopLossOID, &a.StopLossTriggerPx, &a.EntryATR, &a.RealizedPnL, &isFullCloseInt, &tpOIDsJSON, &createdStr); err != nil {
 			return nil, fmt.Errorf("scan pending manual action: %w", err)
 		}
 		a.IsFullClose = isFullCloseInt != 0
+		a.TPOIDs = parseTPOIDsJSON(tpOIDsJSON, 0, 0)
 		a.CreatedAt = parseTime(createdStr)
 		actions = append(actions, a)
 	}

--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -213,23 +213,7 @@ var syncHyperliquidProtection = func(sc StrategyConfig, plan hlProtectionPlan, n
 		notifyHLProtectionFailure(notifier, sc, plan.Symbol, result.Error)
 		return result, false
 	}
-	var warnings []string
-	if result.StopLossError != "" {
-		warnings = append(warnings, "SL: "+result.StopLossError)
-	}
-	for idx, errMsg := range result.TPErrors {
-		if errMsg != "" {
-			warnings = append(warnings, fmt.Sprintf("TP%d: %s", idx+1, errMsg))
-		}
-	}
-	if len(result.TPErrors) == 0 {
-		if result.TP1Error != "" {
-			warnings = append(warnings, "TP1: "+result.TP1Error)
-		}
-		if result.TP2Error != "" {
-			warnings = append(warnings, "TP2: "+result.TP2Error)
-		}
-	}
+	warnings := formatProtectionSyncWarnings(result)
 	if len(warnings) > 0 {
 		msg := fmt.Sprintf("%s %s protection partially failed: %v", sc.ID, plan.Symbol, warnings)
 		if logger != nil {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -194,53 +194,8 @@ func main() {
 	}()
 
 	// Initialize notification backends (Discord and/or Telegram).
-	var backends []notifierBackend
-
-	if cfg.Discord.Enabled && cfg.Discord.Token != "" {
-		discord, err := NewDiscordNotifier(cfg.Discord.Token, cfg.Discord.OwnerID)
-		if err != nil {
-			fmt.Printf("[WARN] Discord init failed: %v — continuing without Discord\n", err)
-		} else {
-			fmt.Printf("Discord gateway connected (%d channels", len(cfg.Discord.Channels))
-			if cfg.Discord.OwnerID != "" {
-				fmt.Printf(", DM owner enabled")
-			}
-			fmt.Println(")")
-			backends = append(backends, notifierBackend{
-				notifier:           discord,
-				channels:           cfg.Discord.Channels,
-				tradeAlertChannels: cfg.Discord.TradeAlertChannels,
-				ownerID:            cfg.Discord.OwnerID,
-				leaderboardChannel: cfg.Discord.LeaderboardChannel,
-				dmChannels:         cfg.Discord.DMChannels,
-			})
-			defer discord.Close()
-		}
-	}
-
-	if cfg.Telegram.Enabled && cfg.Telegram.BotToken != "" {
-		tg, err := NewTelegramNotifier(cfg.Telegram.BotToken, cfg.Telegram.OwnerChatID)
-		if err != nil {
-			fmt.Printf("[WARN] Telegram init failed: %v — continuing without Telegram\n", err)
-		} else {
-			fmt.Printf("Telegram bot connected (%d channels", len(cfg.Telegram.Channels))
-			if cfg.Telegram.OwnerChatID != "" {
-				fmt.Printf(", DM owner enabled")
-			}
-			fmt.Println(")")
-			backends = append(backends, notifierBackend{
-				notifier:           tg,
-				channels:           cfg.Telegram.Channels,
-				tradeAlertChannels: cfg.Telegram.TradeAlertChannels,
-				ownerID:            cfg.Telegram.OwnerChatID,
-				dmChannels:         cfg.Telegram.DMChannels,
-				plainText:          true,
-			})
-			defer tg.Close()
-		}
-	}
-
-	notifier := NewMultiNotifier(backends...)
+	notifier, cleanupNotifier := buildNotifierFromConfig(cfg)
+	defer cleanupNotifier()
 	fmt.Printf("Notification backends: %d active\n", notifier.BackendCount())
 
 	// Route trade-persist warnings (#289) to owner DM so operators see

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -251,6 +251,8 @@ func runManualOpen(args []string) int {
 
 	// Place TP[n] reduce-only orders inline immediately after the fill so the
 	// position is fully protected before the next scheduler cycle.
+	// Note: if the strategy has no tiered close AND no ATR-based SL configured,
+	// no warning fires here — that is intentional (no ATR protection requested).
 	var tpOIDs []int64
 	if !*recordOnly && strategyUsesTieredTPATRClose(sc) && entryATR > 0 {
 		oids, warn, err := placeManualProtectionInline(sc, *side, fillQty, resolvedFillPrice, entryATR, effectiveATRMult, stopLossOID)

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -194,15 +194,37 @@ func runManualOpen(args []string) int {
 
 	fmt.Printf("Filled: %s %.6f %s @ $%.4f (fee=$%.4f)\n", *side, fillQty, sc.Symbol, resolvedFillPrice, fillFee)
 
-	// Arm ATR-based stop-loss after fill (separate from the execute call so we
-	// control trigger placement independently of the pct-based SL path).
-	var stopLossOID int64
-	var stopLossTriggerPx float64
+	// Build notifier for warning paths (no-op when Discord/Telegram not configured).
+	notifier, closeNotifier := buildNotifierFromConfig(cfg)
+	defer closeNotifier()
 
 	effectiveATRMult := *slATRMult
 	if effectiveATRMult == 0 && sc.StopLossATRMult != nil {
 		effectiveATRMult = *sc.StopLossATRMult
 	}
+
+	// When --atr is omitted, compute a leverage-aware fallback so SL and TPs still
+	// post. Fallback = 0.1*fillPrice/leverage → risks 10% of margin at 1× ATR.
+	if !*recordOnly && entryATR == 0 {
+		needsATRProtection := effectiveATRMult > 0 || strategyUsesTieredTPATRClose(sc)
+		if needsATRProtection {
+			if fb, ok := computeFallbackATR(resolvedFillPrice, sc.Leverage); ok {
+				entryATR = fb
+				warnNotifier(notifier, fmt.Sprintf(
+					"[manual-open] %s %s: --atr omitted; using fallback ATR=%.6f (0.1*%.4f/%.2f lev) — pass --atr explicitly for accuracy",
+					strategyID, sc.Symbol, fb, resolvedFillPrice, sc.Leverage))
+			} else {
+				warnNotifier(notifier, fmt.Sprintf(
+					"[manual-open] %s %s: --atr omitted and leverage<=0 — cannot compute fallback; position is NAKED (no ATR-based SL/TP)",
+					strategyID, sc.Symbol))
+			}
+		}
+	}
+
+	// Arm ATR-based stop-loss after fill (separate from the execute call so we
+	// control trigger placement independently of the pct-based SL path).
+	var stopLossOID int64
+	var stopLossTriggerPx float64
 
 	if effectiveATRMult > 0 && entryATR > 0 && !*recordOnly {
 		if *side == "long" {
@@ -225,8 +247,22 @@ func runManualOpen(args []string) int {
 				fmt.Printf("Stop-loss armed at $%.4f (OID=%d)\n", stopLossTriggerPx, stopLossOID)
 			}
 		}
-	} else if effectiveATRMult > 0 && entryATR == 0 {
-		fmt.Fprintln(os.Stderr, "warning: stop_loss_atr_mult is set but --atr was not provided; SL not armed")
+	}
+
+	// Place TP[n] reduce-only orders inline immediately after the fill so the
+	// position is fully protected before the next scheduler cycle.
+	var tpOIDs []int64
+	if !*recordOnly && strategyUsesTieredTPATRClose(sc) && entryATR > 0 {
+		oids, warn, err := placeManualProtectionInline(sc, *side, fillQty, resolvedFillPrice, entryATR, effectiveATRMult, stopLossOID)
+		if err != nil || warn != "" {
+			warnNotifier(notifier, fmt.Sprintf(
+				"[manual-open] %s %s: TP placement issue (position open with SL only): err=%v warn=%s",
+				strategyID, sc.Symbol, err, warn))
+		}
+		tpOIDs = oids
+		if len(oids) > 0 {
+			fmt.Printf("Take-profits armed: OIDs=%v\n", oids)
+		}
 	}
 
 	action := PendingManualAction{
@@ -241,6 +277,7 @@ func runManualOpen(args []string) int {
 		StopLossOID:       stopLossOID,
 		StopLossTriggerPx: stopLossTriggerPx,
 		EntryATR:          entryATR,
+		TPOIDs:            tpOIDs,
 		CreatedAt:         time.Now().UTC(),
 	}
 	if err := stateDB.InsertPendingManualAction(action); err != nil {
@@ -493,6 +530,7 @@ func applyManualAction(state *AppState, scByID map[string]StrategyConfig, a Pend
 			OpenedAt:          now,
 			StopLossOID:       a.StopLossOID,
 			StopLossTriggerPx: a.StopLossTriggerPx,
+			TPOIDs:            a.TPOIDs,
 		}
 		pos.TradePositionID = newTradePositionID(a.StrategyID, a.Symbol, now)
 		ss.Positions[a.Symbol] = pos

--- a/scheduler/manual_protection.go
+++ b/scheduler/manual_protection.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// runHLSyncProtectionFn is a package var so tests can stub without spawning Python.
+var runHLSyncProtectionFn = RunHyperliquidSyncProtection
+
+// computeFallbackATR returns a leverage-aware ATR fallback of 0.1*fillPrice/leverage,
+// representing a price move that risks 10% of deployed margin at 1× ATR. Returns
+// ok=false when leverage or fillPrice are not positive (caller must warn naked).
+func computeFallbackATR(fillPrice, leverage float64) (float64, bool) {
+	if leverage <= 0 || fillPrice <= 0 {
+		return 0, false
+	}
+	return 0.1 * fillPrice / leverage, true
+}
+
+// placeManualProtectionInline calls --sync-protection inline after a manual fill
+// and returns the placed TP OIDs. Returns (nil, "", nil) when no tiers are configured
+// without spawning Python. A non-empty warnMsg signals a partial failure (position
+// remains open; caller should warn but not abort).
+func placeManualProtectionInline(
+	sc StrategyConfig,
+	side string,
+	fillQty, fillPrice, entryATR, effectiveSLATRMult float64,
+	stopLossOID int64,
+) ([]int64, string, error) {
+	tiers := hyperliquidProtectionTiers(sc)
+	if len(tiers) == 0 {
+		return nil, "", nil
+	}
+
+	result, stderr, err := runHLSyncProtectionFn(
+		sc.Script, sc.Symbol, side, fillQty, fillPrice, entryATR,
+		effectiveSLATRMult, tiers, stopLossOID, nil,
+	)
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, "[manual-open] sync-protection stderr: %s\n", stderr)
+	}
+	if err != nil {
+		return nil, "", err
+	}
+	if result == nil {
+		return nil, "nil result from protection sync", nil
+	}
+	if result.Error != "" {
+		return nil, result.Error, nil
+	}
+
+	var warns []string
+	if result.StopLossError != "" {
+		warns = append(warns, "SL: "+result.StopLossError)
+	}
+	for i, e := range result.TPErrors {
+		if e != "" {
+			warns = append(warns, fmt.Sprintf("TP%d: %s", i+1, e))
+		}
+	}
+	if len(result.TPErrors) == 0 {
+		if result.TP1Error != "" {
+			warns = append(warns, "TP1: "+result.TP1Error)
+		}
+		if result.TP2Error != "" {
+			warns = append(warns, "TP2: "+result.TP2Error)
+		}
+	}
+
+	return result.TPOIDs, strings.Join(warns, "; "), nil
+}
+
+// warnNotifier writes msg to stderr and, when the notifier has backends, also
+// broadcasts to all channels and fires an owner DM.
+func warnNotifier(notifier *MultiNotifier, msg string) {
+	fmt.Fprintln(os.Stderr, "[WARN] "+msg)
+	if notifier != nil && notifier.HasBackends() {
+		notifier.SendToAllChannels(msg)
+		notifier.SendOwnerDM(msg)
+	}
+}

--- a/scheduler/manual_protection.go
+++ b/scheduler/manual_protection.go
@@ -9,6 +9,30 @@ import (
 // runHLSyncProtectionFn is a package var so tests can stub without spawning Python.
 var runHLSyncProtectionFn = RunHyperliquidSyncProtection
 
+// formatProtectionSyncWarnings extracts per-field error strings from a
+// HyperliquidProtectionSyncResult into a flat slice. Prefers the tiered
+// TPErrors slice; falls back to legacy TP1Error/TP2Error scalar fields.
+func formatProtectionSyncWarnings(result *HyperliquidProtectionSyncResult) []string {
+	var warns []string
+	if result.StopLossError != "" {
+		warns = append(warns, "SL: "+result.StopLossError)
+	}
+	for i, e := range result.TPErrors {
+		if e != "" {
+			warns = append(warns, fmt.Sprintf("TP%d: %s", i+1, e))
+		}
+	}
+	if len(result.TPErrors) == 0 {
+		if result.TP1Error != "" {
+			warns = append(warns, "TP1: "+result.TP1Error)
+		}
+		if result.TP2Error != "" {
+			warns = append(warns, "TP2: "+result.TP2Error)
+		}
+	}
+	return warns
+}
+
 // computeFallbackATR returns a leverage-aware ATR fallback of 0.1*fillPrice/leverage,
 // representing a price move that risks 10% of deployed margin at 1× ATR. Returns
 // ok=false when leverage or fillPrice are not positive (caller must warn naked).
@@ -51,25 +75,7 @@ func placeManualProtectionInline(
 		return nil, result.Error, nil
 	}
 
-	var warns []string
-	if result.StopLossError != "" {
-		warns = append(warns, "SL: "+result.StopLossError)
-	}
-	for i, e := range result.TPErrors {
-		if e != "" {
-			warns = append(warns, fmt.Sprintf("TP%d: %s", i+1, e))
-		}
-	}
-	if len(result.TPErrors) == 0 {
-		if result.TP1Error != "" {
-			warns = append(warns, "TP1: "+result.TP1Error)
-		}
-		if result.TP2Error != "" {
-			warns = append(warns, "TP2: "+result.TP2Error)
-		}
-	}
-
-	return result.TPOIDs, strings.Join(warns, "; "), nil
+	return result.TPOIDs, strings.Join(formatProtectionSyncWarnings(result), "; "), nil
 }
 
 // warnNotifier writes msg to stderr and, when the notifier has backends, also

--- a/scheduler/manual_protection_test.go
+++ b/scheduler/manual_protection_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComputeFallbackATR(t *testing.T) {
+	cases := []struct {
+		fillPrice float64
+		leverage  float64
+		wantATR   float64
+		wantOK    bool
+	}{
+		{2500, 20, 12.5, true}, // issue worked example: ETH @ $2500, 20× lev
+		{100, 10, 1.0, true},   // basic
+		{100, 0, 0, false},     // leverage == 0
+		{100, -1, 0, false},    // leverage < 0
+		{0, 10, 0, false},      // fillPrice == 0
+		{-1, 10, 0, false},     // fillPrice < 0
+		{2500, 1, 250, true},   // 1× leverage → 10% of price
+	}
+	for _, c := range cases {
+		got, ok := computeFallbackATR(c.fillPrice, c.leverage)
+		if ok != c.wantOK {
+			t.Errorf("computeFallbackATR(%.2f, %.2f): ok=%v want %v", c.fillPrice, c.leverage, ok, c.wantOK)
+		}
+		if ok && (got < c.wantATR*0.9999 || got > c.wantATR*1.0001) {
+			t.Errorf("computeFallbackATR(%.2f, %.2f): atr=%.6f want %.6f", c.fillPrice, c.leverage, got, c.wantATR)
+		}
+	}
+}
+
+func TestPlaceManualProtectionInline_NoTiers(t *testing.T) {
+	sc := StrategyConfig{
+		Type:            "manual",
+		Platform:        "hyperliquid",
+		CloseStrategies: []string{"tp_at_pct"}, // not tiered_tp_atr*
+	}
+	oids, warn, err := placeManualProtectionInline(sc, "long", 0.8, 2500, 12.5, 1.0, 0)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if warn != "" {
+		t.Errorf("expected empty warn, got %q", warn)
+	}
+	if len(oids) != 0 {
+		t.Errorf("expected no OIDs for non-tiered strategy, got %v", oids)
+	}
+}
+
+func TestPlaceManualProtectionInline_TPErrorsSurface(t *testing.T) {
+	orig := runHLSyncProtectionFn
+	defer func() { runHLSyncProtectionFn = orig }()
+
+	runHLSyncProtectionFn = func(script, symbol, side string, size, avgCost, entryATR, stopLossATRMult float64, tiers []hlProtectionTier, stopLossOID int64, tpOIDs []int64) (*HyperliquidProtectionSyncResult, string, error) {
+		return &HyperliquidProtectionSyncResult{
+			TPOIDs:   []int64{1001, 1002},
+			TPErrors: []string{"TP1: rejected", ""},
+		}, "", nil
+	}
+
+	sc := StrategyConfig{
+		Type:            "manual",
+		Platform:        "hyperliquid",
+		Script:          "shared_scripts/check_hyperliquid.py",
+		Symbol:          "ETH",
+		CloseStrategies: []string{"tiered_tp_atr_live"},
+	}
+	oids, warn, err := placeManualProtectionInline(sc, "long", 0.8, 2500, 12.5, 1.0, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(warn, "TP1") {
+		t.Errorf("expected warn to mention TP1, got %q", warn)
+	}
+	if len(oids) != 2 {
+		t.Errorf("expected 2 OIDs, got %v", oids)
+	}
+}
+
+func TestWarnNotifier_NilNotifier(t *testing.T) {
+	// Should not panic when notifier is nil.
+	warnNotifier(nil, "test warning")
+}

--- a/scheduler/manual_test.go
+++ b/scheduler/manual_test.go
@@ -474,3 +474,95 @@ func TestManualPositionOwnedByStrategy(t *testing.T) {
 		})
 	}
 }
+
+// TestPendingManualActionTPOIDsRoundtrip verifies that TPOIDs survive an
+// InsertPendingManualAction → LoadPendingManualActions round-trip (#632).
+func TestPendingManualActionTPOIDsRoundtrip(t *testing.T) {
+	db, err := OpenStateDB(":memory:")
+	if err != nil {
+		t.Fatalf("open state db: %v", err)
+	}
+	defer db.Close()
+
+	want := []int64{111, 222, 333}
+	if err := db.InsertPendingManualAction(PendingManualAction{
+		StrategyID: "hl-manual-eth-live", Action: "open", Symbol: "ETH", Side: "long",
+		Quantity: 0.8, FillPrice: 2500, FillFee: 0.35, EntryATR: 12.5,
+		TPOIDs:    want,
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	actions, err := db.LoadPendingManualActions()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	got := actions[0].TPOIDs
+	if len(got) != len(want) {
+		t.Fatalf("TPOIDs len=%d want %d (got=%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("TPOIDs[%d]=%d want %d", i, got[i], want[i])
+		}
+	}
+}
+
+// TestApplyManualAction_OpenSetsTPOIDs verifies that applyManualAction stamps
+// TPOIDs onto the materialised position (#632).
+func TestApplyManualAction_OpenSetsTPOIDs(t *testing.T) {
+	db, err := OpenStateDB(":memory:")
+	if err != nil {
+		t.Fatalf("open state db: %v", err)
+	}
+	defer db.Close()
+
+	stratID := "hl-manual-eth-live"
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			stratID: {
+				ID:        stratID,
+				Type:      "manual",
+				Platform:  "hyperliquid",
+				Positions: map[string]*Position{},
+				Cash:      1000,
+			},
+		},
+	}
+	cfg := &Config{
+		Strategies: []StrategyConfig{{
+			ID: stratID, Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 20,
+		}},
+	}
+
+	origRecorder := tradeRecorder
+	tradeRecorder = func(_ string, _ Trade) error { return nil }
+	defer func() { tradeRecorder = origRecorder }()
+
+	wantOIDs := []int64{2001, 2002}
+	_ = db.InsertPendingManualAction(PendingManualAction{
+		StrategyID: stratID, Action: "open", Symbol: "ETH", Side: "long",
+		Quantity: 0.8, FillPrice: 2500, FillFee: 0.875, EntryATR: 12.5,
+		TPOIDs:    wantOIDs,
+		CreatedAt: time.Now().UTC(),
+	})
+
+	drainPendingManualActions(state, cfg, db)
+
+	pos := state.Strategies[stratID].Positions["ETH"]
+	if pos == nil {
+		t.Fatal("expected position after drain")
+	}
+	if len(pos.TPOIDs) != len(wantOIDs) {
+		t.Fatalf("pos.TPOIDs len=%d want %d (got=%v)", len(pos.TPOIDs), len(wantOIDs), pos.TPOIDs)
+	}
+	for i, oid := range wantOIDs {
+		if pos.TPOIDs[i] != oid {
+			t.Errorf("pos.TPOIDs[%d]=%d want %d", i, pos.TPOIDs[i], oid)
+		}
+	}
+}

--- a/scheduler/notifier_build.go
+++ b/scheduler/notifier_build.go
@@ -3,8 +3,9 @@ package main
 import "fmt"
 
 // buildNotifierFromConfig constructs a MultiNotifier from the Discord and Telegram
-// sections of cfg, mirroring the backend assembly in main(). The returned cleanup
-// function must be deferred by the caller to close gateway connections.
+// sections of cfg. It prints the same connection messages as the daemon startup path
+// so callers (main and CLI subcommands alike) see consistent output. The returned
+// cleanup function must be deferred by the caller to close gateway connections.
 func buildNotifierFromConfig(cfg *Config) (*MultiNotifier, func()) {
 	var backends []notifierBackend
 	var closers []func()
@@ -14,6 +15,11 @@ func buildNotifierFromConfig(cfg *Config) (*MultiNotifier, func()) {
 		if err != nil {
 			fmt.Printf("[WARN] Discord init failed: %v — continuing without Discord\n", err)
 		} else {
+			fmt.Printf("Discord gateway connected (%d channels", len(cfg.Discord.Channels))
+			if cfg.Discord.OwnerID != "" {
+				fmt.Printf(", DM owner enabled")
+			}
+			fmt.Println(")")
 			backends = append(backends, notifierBackend{
 				notifier:           discord,
 				channels:           cfg.Discord.Channels,
@@ -31,6 +37,11 @@ func buildNotifierFromConfig(cfg *Config) (*MultiNotifier, func()) {
 		if err != nil {
 			fmt.Printf("[WARN] Telegram init failed: %v — continuing without Telegram\n", err)
 		} else {
+			fmt.Printf("Telegram bot connected (%d channels", len(cfg.Telegram.Channels))
+			if cfg.Telegram.OwnerChatID != "" {
+				fmt.Printf(", DM owner enabled")
+			}
+			fmt.Println(")")
 			backends = append(backends, notifierBackend{
 				notifier:           tg,
 				channels:           cfg.Telegram.Channels,

--- a/scheduler/notifier_build.go
+++ b/scheduler/notifier_build.go
@@ -1,0 +1,52 @@
+package main
+
+import "fmt"
+
+// buildNotifierFromConfig constructs a MultiNotifier from the Discord and Telegram
+// sections of cfg, mirroring the backend assembly in main(). The returned cleanup
+// function must be deferred by the caller to close gateway connections.
+func buildNotifierFromConfig(cfg *Config) (*MultiNotifier, func()) {
+	var backends []notifierBackend
+	var closers []func()
+
+	if cfg.Discord.Enabled && cfg.Discord.Token != "" {
+		discord, err := NewDiscordNotifier(cfg.Discord.Token, cfg.Discord.OwnerID)
+		if err != nil {
+			fmt.Printf("[WARN] Discord init failed: %v — continuing without Discord\n", err)
+		} else {
+			backends = append(backends, notifierBackend{
+				notifier:           discord,
+				channels:           cfg.Discord.Channels,
+				tradeAlertChannels: cfg.Discord.TradeAlertChannels,
+				ownerID:            cfg.Discord.OwnerID,
+				leaderboardChannel: cfg.Discord.LeaderboardChannel,
+				dmChannels:         cfg.Discord.DMChannels,
+			})
+			closers = append(closers, discord.Close)
+		}
+	}
+
+	if cfg.Telegram.Enabled && cfg.Telegram.BotToken != "" {
+		tg, err := NewTelegramNotifier(cfg.Telegram.BotToken, cfg.Telegram.OwnerChatID)
+		if err != nil {
+			fmt.Printf("[WARN] Telegram init failed: %v — continuing without Telegram\n", err)
+		} else {
+			backends = append(backends, notifierBackend{
+				notifier:           tg,
+				channels:           cfg.Telegram.Channels,
+				tradeAlertChannels: cfg.Telegram.TradeAlertChannels,
+				ownerID:            cfg.Telegram.OwnerChatID,
+				dmChannels:         cfg.Telegram.DMChannels,
+				plainText:          true,
+			})
+			closers = append(closers, tg.Close)
+		}
+	}
+
+	cleanup := func() {
+		for _, c := range closers {
+			c()
+		}
+	}
+	return NewMultiNotifier(backends...), cleanup
+}


### PR DESCRIPTION
## Summary

- `manual-open` now places SL **and** TP[n] reduce-only orders inline at fill time, before returning. Previously TPs were deferred to the next scheduler cycle.
- When `--atr` is omitted on a strategy that uses ATR-based protection, a leverage-aware fallback `0.1 * fillPrice / leverage` is used. This risks ~10% of margin at SL (1× ATR). A warning is sent via notifier (owner DM + all channels) and stderr.
- `buildNotifierFromConfig` extracted from `main()` into `notifier_build.go`; `main()` now calls it directly — single source of truth for backend assembly.
- `PendingManualAction.TPOIDs []int64` added with `tp_oids_json` DB column + idempotent migration; `applyManualAction` stamps `pos.TPOIDs` so the scheduler-cycle protection sync is a no-op on already-placed OIDs.

**Worked example** — $100 margin, 20× leverage, ETH @ $2500, qty = 0.8 ETH, fallback ATR = $12.50 (default `type=manual` tiers: TP1 @ 2× ATR, TP2 @ 3× ATR):

| Order | Price | P&L |
|-------|-------|-----|
| SL (1× ATR) | $2,487.50 | −$10 = −10% of margin |
| TP1 (2× ATR, 50%) | $2,525.00 | +$10 = +10% of margin |
| TP2 (3× ATR, remaining 50%) | $2,537.50 | +$15 = +15% of margin |

Full close at both TPs nets +$25 = +25% of margin.

## Test plan

- [ ] `go test ./...` passes (6 new tests: fallback ATR table, no-tiers skip, TP error surfacing, nil notifier guard, DB round-trip, drain stamps pos.TPOIDs)
- [ ] `manual-open` with explicit `--atr` → SL + TP OIDs printed immediately
- [ ] `manual-open` without `--atr`, leverage=20, ETH @ $2500 → fallback ATR=12.5 warning fires via Discord; SL at $2487.50 + TPs at $2525.00/$2537.50 posted
- [ ] `manual-open --record-only` → no SL or TP placed (existing behavior preserved)
- [ ] After scheduler cycle drains: `pos.TPOIDs` matches printed OIDs; `runHyperliquidProtectionSync` no-ops

Closes #632

---
LLM: Claude Opus 4.7 (1M) | high | Harness: Claude Code