### PR TITLE
fix: cleanup orphaned manual-open orders if queue insert fails

### DIFF
--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -283,7 +283,26 @@ func runManualOpen(args []string) int {
 		CreatedAt:         time.Now().UTC(),
 	}
 	if err := stateDB.InsertPendingManualAction(action); err != nil {
-		fmt.Fprintf(os.Stderr, "error queuing action: %v\n", err)
+		// On-chain fill (and SL/TPs) succeeded but the queue insert failed —
+		// the scheduler will never adopt this position, so reconcile would see
+		// an unowned on-chain position with orphaned reduce-only triggers.
+		// Skip cleanup in --record-only because the operator's pre-existing
+		// fill is theirs to manage; we never placed those on-chain orders.
+		if *recordOnly {
+			fmt.Fprintf(os.Stderr, "error queuing action: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "CRITICAL: queue insert failed (%v); on-chain position is open but the scheduler cannot adopt it. Attempting cleanup...\n", err)
+		cleanedUp, cleanupMsg := attemptManualOpenCleanup(sc.Symbol, fillQty, stopLossOID, tpOIDs)
+		if cleanedUp {
+			warnNotifier(notifier, fmt.Sprintf(
+				"[manual-open] %s %s: queue insert failed (%v); position auto-flattened: %s",
+				strategyID, sc.Symbol, err, cleanupMsg))
+		} else {
+			warnNotifier(notifier, fmt.Sprintf(
+				"[manual-open] %s %s: queue insert failed (%v) AND auto-flatten failed: %s — MANUAL INTERVENTION REQUIRED on HL UI (side=%s qty=%.6f sl_oid=%d tp_oids=%v)",
+				strategyID, sc.Symbol, err, cleanupMsg, *side, fillQty, stopLossOID, tpOIDs))
+		}
 		return 1
 	}
 

--- a/scheduler/manual_protection.go
+++ b/scheduler/manual_protection.go
@@ -78,6 +78,49 @@ func placeManualProtectionInline(
 	return result.TPOIDs, strings.Join(formatProtectionSyncWarnings(result), "; "), nil
 }
 
+// manualOpenCleanupCloseFn is the close path used by attemptManualOpenCleanup.
+// Exposed as a package var so tests can stub without spawning Python (#634).
+var manualOpenCleanupCloseFn = func(symbol string, partialSz *float64, cancelOIDs []int64) (*HyperliquidCloseResult, string, error) {
+	return RunHyperliquidClose(hyperliquidLiveCloseScript, symbol, partialSz, cancelOIDs)
+}
+
+// attemptManualOpenCleanup tries to flatten a position that was just opened by
+// manual-open and cancel its protective triggers, after a fatal error
+// (typically pending-action queue insert failure) prevented the scheduler from
+// adopting the position. Without this, the next reconcile cycle would see an
+// unowned on-chain position with orphaned reduce-only SL/TP orders (#634).
+//
+// Sized to fillQty (not the full on-chain position) so a peer manual/perps
+// position on the same coin is preserved. Returns (cleanedUp, msg) where msg
+// is suitable for inclusion in an operator notification.
+func attemptManualOpenCleanup(symbol string, fillQty float64, stopLossOID int64, tpOIDs []int64) (bool, string) {
+	cancelOIDs := make([]int64, 0, 1+len(tpOIDs))
+	if stopLossOID > 0 {
+		cancelOIDs = append(cancelOIDs, stopLossOID)
+	}
+	for _, oid := range tpOIDs {
+		if oid > 0 {
+			cancelOIDs = append(cancelOIDs, oid)
+		}
+	}
+
+	sz := fillQty
+	result, stderr, err := manualOpenCleanupCloseFn(symbol, &sz, cancelOIDs)
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, "[manual-open cleanup] close stderr: %s\n", stderr)
+	}
+	if err != nil {
+		return false, fmt.Sprintf("close failed: %v", err)
+	}
+	if result != nil && result.Error != "" {
+		return false, fmt.Sprintf("close error: %s", result.Error)
+	}
+	if result != nil && result.CancelStopLossError != "" {
+		return true, fmt.Sprintf("position closed but trigger cancel reported: %s", result.CancelStopLossError)
+	}
+	return true, "position flattened and orphan triggers cancelled"
+}
+
 // warnNotifier writes msg to stderr and, when the notifier has backends, also
 // broadcasts to all channels and fires an owner DM.
 func warnNotifier(notifier *MultiNotifier, msg string) {

--- a/scheduler/manual_protection.go
+++ b/scheduler/manual_protection.go
@@ -112,10 +112,10 @@ func attemptManualOpenCleanup(symbol string, fillQty float64, stopLossOID int64,
 	if err != nil {
 		return false, fmt.Sprintf("close failed: %v", err)
 	}
-	if result != nil && result.Error != "" {
-		return false, fmt.Sprintf("close error: %s", result.Error)
+	if result == nil {
+		return false, "cleanup close returned nil result"
 	}
-	if result != nil && result.CancelStopLossError != "" {
+	if result.CancelStopLossError != "" {
 		return true, fmt.Sprintf("position closed but trigger cancel reported: %s", result.CancelStopLossError)
 	}
 	return true, "position flattened and orphan triggers cancelled"

--- a/scheduler/manual_protection_test.go
+++ b/scheduler/manual_protection_test.go
@@ -175,3 +175,22 @@ func TestAttemptManualOpenCleanup_FiltersZeroOIDs(t *testing.T) {
 		t.Errorf("cancelOIDs should filter zeros; got %v want [67891]", gotCancelOIDs)
 	}
 }
+
+// TestAttemptManualOpenCleanup_NilResultNoError: a broken stub returning
+// (nil, "", nil) must not report false success — guarded by the nil check.
+func TestAttemptManualOpenCleanup_NilResultNoError(t *testing.T) {
+	orig := manualOpenCleanupCloseFn
+	defer func() { manualOpenCleanupCloseFn = orig }()
+
+	manualOpenCleanupCloseFn = func(symbol string, partialSz *float64, cancelOIDs []int64) (*HyperliquidCloseResult, string, error) {
+		return nil, "", nil
+	}
+
+	cleanedUp, msg := attemptManualOpenCleanup("ETH", 0.8, 12345, nil)
+	if cleanedUp {
+		t.Fatalf("expected cleanedUp=false for nil result, got msg=%q", msg)
+	}
+	if !strings.Contains(msg, "nil") {
+		t.Errorf("msg should mention nil result; got %q", msg)
+	}
+}

--- a/scheduler/manual_protection_test.go
+++ b/scheduler/manual_protection_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -82,4 +83,95 @@ func TestPlaceManualProtectionInline_TPErrorsSurface(t *testing.T) {
 func TestWarnNotifier_NilNotifier(t *testing.T) {
 	// Should not panic when notifier is nil.
 	warnNotifier(nil, "test warning")
+}
+
+// TestAttemptManualOpenCleanup_Success covers the happy path: queue insert
+// failed, cleanup close succeeded, SL+TPs cancelled in one shot.
+func TestAttemptManualOpenCleanup_Success(t *testing.T) {
+	orig := manualOpenCleanupCloseFn
+	defer func() { manualOpenCleanupCloseFn = orig }()
+
+	var gotSymbol string
+	var gotSize *float64
+	var gotCancelOIDs []int64
+	manualOpenCleanupCloseFn = func(symbol string, partialSz *float64, cancelOIDs []int64) (*HyperliquidCloseResult, string, error) {
+		gotSymbol = symbol
+		gotSize = partialSz
+		gotCancelOIDs = cancelOIDs
+		return &HyperliquidCloseResult{}, "", nil
+	}
+
+	cleanedUp, msg := attemptManualOpenCleanup("ETH", 0.8, 12345, []int64{67890, 67891})
+	if !cleanedUp {
+		t.Fatalf("expected cleanedUp=true, got msg=%q", msg)
+	}
+	if gotSymbol != "ETH" {
+		t.Errorf("symbol: got %q want ETH", gotSymbol)
+	}
+	if gotSize == nil || *gotSize != 0.8 {
+		t.Errorf("partialSz: got %v want 0.8", gotSize)
+	}
+	if len(gotCancelOIDs) != 3 || gotCancelOIDs[0] != 12345 || gotCancelOIDs[1] != 67890 || gotCancelOIDs[2] != 67891 {
+		t.Errorf("cancelOIDs: got %v want [12345 67890 67891]", gotCancelOIDs)
+	}
+}
+
+// TestAttemptManualOpenCleanup_CloseFails covers the worst-case path where the
+// recovery close itself fails — operator must be alerted that intervention is
+// required because both fill ownership and cleanup failed.
+func TestAttemptManualOpenCleanup_CloseFails(t *testing.T) {
+	orig := manualOpenCleanupCloseFn
+	defer func() { manualOpenCleanupCloseFn = orig }()
+
+	manualOpenCleanupCloseFn = func(symbol string, partialSz *float64, cancelOIDs []int64) (*HyperliquidCloseResult, string, error) {
+		return nil, "stderr noise", fmt.Errorf("rpc timeout")
+	}
+
+	cleanedUp, msg := attemptManualOpenCleanup("ETH", 0.8, 12345, []int64{67890})
+	if cleanedUp {
+		t.Fatalf("expected cleanedUp=false, got msg=%q", msg)
+	}
+	if !strings.Contains(msg, "rpc timeout") {
+		t.Errorf("msg should mention close failure cause; got %q", msg)
+	}
+}
+
+// TestAttemptManualOpenCleanup_CancelStopLossError: position closed but the
+// inline trigger cancel reported an error — partial success: position is
+// flat (good) but some triggers may persist (operator should verify).
+func TestAttemptManualOpenCleanup_CancelStopLossError(t *testing.T) {
+	orig := manualOpenCleanupCloseFn
+	defer func() { manualOpenCleanupCloseFn = orig }()
+
+	manualOpenCleanupCloseFn = func(symbol string, partialSz *float64, cancelOIDs []int64) (*HyperliquidCloseResult, string, error) {
+		return &HyperliquidCloseResult{CancelStopLossError: "trigger 12345 not found"}, "", nil
+	}
+
+	cleanedUp, msg := attemptManualOpenCleanup("ETH", 0.8, 12345, nil)
+	if !cleanedUp {
+		t.Fatalf("expected cleanedUp=true (position closed), got msg=%q", msg)
+	}
+	if !strings.Contains(msg, "trigger 12345 not found") {
+		t.Errorf("msg should surface cancel error; got %q", msg)
+	}
+}
+
+// TestAttemptManualOpenCleanup_FiltersZeroOIDs: zero/unset OIDs must not be
+// passed to the cancel list — close_hyperliquid_position.py would otherwise
+// reject the request.
+func TestAttemptManualOpenCleanup_FiltersZeroOIDs(t *testing.T) {
+	orig := manualOpenCleanupCloseFn
+	defer func() { manualOpenCleanupCloseFn = orig }()
+
+	var gotCancelOIDs []int64
+	manualOpenCleanupCloseFn = func(symbol string, partialSz *float64, cancelOIDs []int64) (*HyperliquidCloseResult, string, error) {
+		gotCancelOIDs = cancelOIDs
+		return &HyperliquidCloseResult{}, "", nil
+	}
+
+	// SL OID = 0 (not placed) and one TP OID = 0 (placement failed for one tier).
+	attemptManualOpenCleanup("ETH", 0.8, 0, []int64{0, 67891})
+	if len(gotCancelOIDs) != 1 || gotCancelOIDs[0] != 67891 {
+		t.Errorf("cancelOIDs should filter zeros; got %v want [67891]", gotCancelOIDs)
+	}
 }


### PR DESCRIPTION
Closes #634

When the manual-open CLI placed the on-chain fill, SL, and TP[n] orders successfully but `InsertPendingManualAction` then failed (disk full / DB locked), real on-chain orders existed with no virtual position record. The next reconcile cycle would see an unowned on-chain position with orphaned reduce-only triggers.

On insert failure the CLI now submits a reduce-only market close sized to `fillQty` that simultaneously cancels the SL + TP OIDs in one shot. Sized to `fillQty` so peer positions on the same coin are preserved. Skipped in `--record-only` mode (operator owns the pre-existing fill). If cleanup itself fails, a MANUAL INTERVENTION REQUIRED notification fires with enough detail to flatten via the HL UI.

---
LLM: Claude Opus 4.7 (1M) | high | Harness: anthropics/claude-code-action@v1 | Tokens: 59 in / 21253 out | Cache: 2904856 read / 202276 written | Cost: $3.25