### PR TITLE
fix: show ATR before SL in position extras string

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1026,6 +1026,9 @@ func collectPositions(sc StrategyConfig, ss *StrategyState, prices map[string]fl
 			dateStr = fmt.Sprintf(" [%s]", pos.OpenedAt.Format("Jan 02 15:04"))
 		}
 		extras := ""
+		if pos.EntryATR > 0 {
+			extras += fmt.Sprintf(" | ATR: $%s", fmtComma2(pos.EntryATR))
+		}
 		if pos.StopLossTriggerPx > 0 {
 			slPct := percentFromEntry(pos.Side, pos.AvgCost, pos.StopLossTriggerPx)
 			if pos.EntryATR > 0 {
@@ -1034,9 +1037,6 @@ func collectPositions(sc StrategyConfig, ss *StrategyState, prices map[string]fl
 			} else {
 				extras += fmt.Sprintf(" | SL: $%s (%s)", fmtComma2(pos.StopLossTriggerPx), fmtPnlPct(slPct))
 			}
-		}
-		if pos.EntryATR > 0 {
-			extras += fmt.Sprintf(" | ATR: $%s", fmtComma2(pos.EntryATR))
 		}
 		if strategyUsesTieredTPATRClose(sc) && pos.EntryATR > 0 && pos.AvgCost > 0 {
 			sideLower := strings.ToLower(pos.Side)

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -1534,7 +1534,7 @@ func TestCollectPositions_TieredTPATR_OmittedWhenEntryATRZero(t *testing.T) {
 	}
 }
 
-// TestCollectPositions_AllFragments_WithTieredTP verifies SL → TP1 → TP2 →
+// TestCollectPositions_AllFragments_WithTieredTP verifies ATR → SL → TP1 → TP2 →
 // leverage → date ordering when tiered_tp_atr is configured (#528).
 func TestCollectPositions_AllFragments_WithTieredTP(t *testing.T) {
 	opened := time.Date(2026, 4, 28, 14, 32, 0, 0, time.UTC)
@@ -1557,8 +1557,8 @@ func TestCollectPositions_AllFragments_WithTieredTP(t *testing.T) {
 	if slIdx < 0 || atrIdx < 0 || tp1Idx < 0 || tp2Idx < 0 || levIdx < 0 || dateIdx < 0 {
 		t.Fatalf("expected SL, ATR, TP1, TP2, leverage, and date fragments, got: %s", got)
 	}
-	if !(slIdx < atrIdx && atrIdx < tp1Idx && tp1Idx < tp2Idx && tp2Idx < levIdx && levIdx < dateIdx) {
-		t.Errorf("expected SL → ATR → TP1 → TP2 → leverage → date ordering, got: %s", got)
+	if !(atrIdx < slIdx && slIdx < tp1Idx && tp1Idx < tp2Idx && tp2Idx < levIdx && levIdx < dateIdx) {
+		t.Errorf("expected ATR → SL → TP1 → TP2 → leverage → date ordering, got: %s", got)
 	}
 }
 


### PR DESCRIPTION
Moves the ATR display before the SL line in `collectPositions` so context (ATR value) precedes the derived value (SL trigger), matching reading order.

**Before:** `SL: $94,200 (-1.9%) (1.0x) | ATR: $1,800 | TP1: ...`
**After:** `ATR: $1,800 | SL: $94,200 (-1.9%) (1.0x) | TP1: ...`

Closes #637

---
LLM: Sonnet 4.6 | medium