### PR TITLE
refactor(backtest): align Backtester API with co-located strategy refs

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -228,7 +228,13 @@ class Backtester:
                 "name": name,
                 "params": dict(ref.get("params") or {}),
             })
-        # Derived views for the per-bar evaluation loop.
+        # Derived views for the per-bar evaluation loop. The list preserves
+        # caller-provided order; the params map is keyed by name. If a caller
+        # passes the same name twice with different params, the map keeps only
+        # the last write — both list iterations would then see the second
+        # ref's params. This is fine under max-wins resolution but a footgun
+        # if a future change ever reads param state per-iteration; reject
+        # duplicates here if behavior depends on per-occurrence params.
         self.close_strategies = [r["name"] for r in self._close_refs]
         self.close_params = {r["name"]: r["params"] for r in self._close_refs}
         self.regime_enabled = regime_enabled

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -172,8 +172,8 @@ class Backtester:
                  commission_pct: Optional[float] = None,
                  slippage_pct: float = 0.0005,
                  platform: str = "binanceus",
-                 close_strategies: Optional[list[str]] = None,
-                 close_params: Optional[dict[str, dict]] = None,
+                 open_strategy: Optional[dict] = None,
+                 close_strategies: Optional[list[dict]] = None,
                  regime_enabled: bool = False,
                  regime_period: int = 14,
                  regime_adx_threshold: float = 20.0,
@@ -189,16 +189,20 @@ class Backtester:
             platform: Exchange fee model — one of ``PLATFORM_FEE_PCT`` keys.
                 Unknown platforms fall back to BinanceUS (0.1%) with no
                 warning, matching the Go dispatch default.
-            close_strategies: Ordered list of close-evaluator names from
-                ``shared_strategies/close/registry.py``. When provided, each
-                evaluator runs at the end of every bar against the simulated
-                open position; the max ``close_fraction`` across evaluators
-                is applied at the next bar's open. Combined with any
-                column-based ``close_fraction`` on the input DataFrame using
-                max-wins (mirrors the live composition contract).
-            close_params: Per-evaluator params dict (keyed by strategy name).
-                Merged over the registry's ``default_params`` for that
-                strategy. Unknown keys are forwarded as-is to the evaluator.
+            open_strategy: Optional ``{"name": str, "params": dict}`` ref
+                describing the open evaluator that produced the signal column
+                on the DataFrame passed to ``run()``. The caller is responsible
+                for actually applying the open strategy; this ref is recorded
+                on the result for reporting parity with the live config (#641).
+            close_strategies: Ordered list of close-evaluator refs, each
+                ``{"name": str, "params": dict}``. The named evaluator must be
+                registered in ``shared_strategies/close/registry.py``; per-ref
+                ``params`` are merged over the registry's ``default_params`` at
+                evaluation time. Each ref runs per-bar against the simulated
+                position; the max ``close_fraction`` across refs wins (max-wins
+                vs any column-based ``close_fraction`` mirrors the live
+                composition contract). Replaces the pre-#641 parallel
+                ``close_strategies: list[str]`` + ``close_params: dict`` pair.
         """
         self.initial_capital = initial_capital
         self.platform = platform
@@ -207,8 +211,26 @@ class Backtester:
             else fee_pct_for_platform(platform)
         )
         self.slippage_pct = slippage_pct
-        self.close_strategies = list(close_strategies or [])
-        self.close_params = dict(close_params or {})
+        self.open_strategy = dict(open_strategy or {})
+        # Normalize close refs into the form the eval loop wants. Each ref must
+        # have a non-empty `name`; missing/empty `params` becomes an empty dict.
+        self._close_refs: list[dict] = []
+        for ref in close_strategies or []:
+            if not isinstance(ref, dict):
+                raise ValueError(
+                    f"close_strategies entries must be dicts of shape "
+                    f"{{'name': str, 'params': dict}}, got {type(ref).__name__}"
+                )
+            name = (ref.get("name") or "").strip()
+            if not name:
+                raise ValueError(f"close_strategies ref missing 'name': {ref}")
+            self._close_refs.append({
+                "name": name,
+                "params": dict(ref.get("params") or {}),
+            })
+        # Derived views for the per-bar evaluation loop.
+        self.close_strategies = [r["name"] for r in self._close_refs]
+        self.close_params = {r["name"]: r["params"] for r in self._close_refs}
         self.regime_enabled = regime_enabled
         self.regime_period = regime_period
         self.regime_adx_threshold = regime_adx_threshold
@@ -491,15 +513,25 @@ class Backtester:
 
         # Calculate metrics
         metrics = self._calculate_metrics(equity_df, trades, df, timeframe)
+        # Resolve the open strategy ref for reporting. Caller can supply it
+        # in __init__ (preferred — matches the live config shape from #640) or
+        # via run()'s strategy_name + params (legacy path).
+        open_ref = dict(self.open_strategy) if self.open_strategy else {}
+        if not open_ref.get("name") and strategy_name:
+            open_ref["name"] = strategy_name
+        if "params" not in open_ref and params:
+            open_ref["params"] = dict(params)
         metrics.update({
-            "strategy_name": strategy_name,
+            "strategy_name": open_ref.get("name") or strategy_name,
             "symbol": symbol,
             "timeframe": timeframe,
             "start_date": str(df.index[0]),
             "end_date": str(df.index[-1]),
             "initial_capital": self.initial_capital,
             "final_capital": round(final_equity, 2),
-            "params": params or {},
+            "params": open_ref.get("params") or params or {},
+            "open_strategy": open_ref,
+            "close_strategies": [dict(r) for r in self._close_refs],
             "trades": [t.to_dict() for t in trades],
         })
 

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -75,6 +75,57 @@ DEFAULT_SYMBOLS = ["BTC/USDT", "ETH/USDT", "SOL/USDT", "BNB/USDT"]
 DEFAULT_TIMEFRAMES = ["4h", "1d"]
 
 
+def load_strategy_config(config_path: str, strategy_id: str) -> dict:
+    """Load a single strategy's refs from a live go-trader config (#641).
+
+    Reads the v13+ config at ``config_path``, finds the strategy with
+    ``id == strategy_id``, and returns kwargs ready to splat into
+    ``Backtester(**kwargs)`` plus the open name needed for the upstream
+    ``apply_strategy`` call. Lets operators backtest the exact live
+    config without translating shapes.
+
+    Returns ``{"open_strategy": {...}, "close_strategies": [...]}``.
+
+    Raises ValueError when the config is pre-v13 (legacy flat shape) or
+    the strategy ID is not found — the caller should run the live
+    binary's migration first.
+    """
+    import json as _json
+    with open(config_path) as fh:
+        cfg = _json.load(fh)
+    version = int(cfg.get("config_version", 0) or 0)
+    if version < 13:
+        raise ValueError(
+            f"{config_path}: config_version={version} predates the co-located "
+            f"strategy ref shape (#640). Run go-trader once against this file "
+            f"to migrate it, then retry."
+        )
+    for sc in cfg.get("strategies", []) or []:
+        if sc.get("id") != strategy_id:
+            continue
+        open_ref = sc.get("open_strategy") or {}
+        if not isinstance(open_ref, dict) or not open_ref.get("name"):
+            raise ValueError(
+                f"{config_path}: strategy {strategy_id!r} has no open_strategy.name; "
+                f"the migrated config should always populate it."
+            )
+        close_refs = []
+        for ref in sc.get("close_strategies", []) or []:
+            if isinstance(ref, dict) and ref.get("name"):
+                close_refs.append({"name": ref["name"], "params": dict(ref.get("params") or {})})
+        return {
+            "open_strategy": {
+                "name": open_ref["name"],
+                "params": dict(open_ref.get("params") or {}),
+            },
+            "close_strategies": close_refs,
+        }
+    raise ValueError(
+        f"{config_path}: no strategy with id={strategy_id!r}. "
+        f"Available: {[s.get('id') for s in cfg.get('strategies', []) or []]}"
+    )
+
+
 def run_single_backtest(
     strategy_name: str = "sma_crossover",
     symbol: str = "BTC/USDT",
@@ -85,8 +136,7 @@ def run_single_backtest(
     registry: str = "spot",
     platform: str = "binanceus",
     htf_filter: bool = False,
-    close_strategies: Optional[List[str]] = None,
-    close_params: Optional[dict] = None,
+    close_strategies: Optional[List[dict]] = None,
     regime_enabled: bool = False,
     regime_period: int = 14,
     regime_adx_threshold: float = 20.0,
@@ -98,10 +148,11 @@ def run_single_backtest(
     ``platform`` selects the exchange fee model (``"binanceus"``,
     ``"hyperliquid"``, ``"robinhood"``, ``"luno"``, ``"okx"``,
     ``"okx-perps"``), matching ``scheduler/fees.go:CalculatePlatformSpotFee``.
-    ``close_strategies`` is an optional list of close-evaluator names from
-    the close registry (#511); each runs per-bar against the simulated
-    position. Backtest granularity is bar-level so live intra-bar trigger
-    races (e.g. HL stop-loss OIDs) are not simulated.
+    ``close_strategies`` is an optional list of co-located close-evaluator
+    refs (``[{"name": str, "params": dict}, ...]``) from the close registry
+    (#511, #641); each runs per-bar against the simulated position. Backtest
+    granularity is bar-level so live intra-bar trigger races (e.g. HL
+    stop-loss OIDs) are not simulated.
     """
     reg = load_registry(registry)
     strat = reg.STRATEGY_REGISTRY.get(strategy_name)
@@ -115,7 +166,7 @@ def run_single_backtest(
     print(f"  Params: {strat_params}")
     print(f"  Symbol: {symbol} | Timeframe: {timeframe} | Since: {since}")
     if close_strategies:
-        print(f"  Close strategies: {close_strategies}")
+        print(f"  Close strategies: {[r.get('name') for r in close_strategies]}")
 
     df = load_cached_data(symbol, timeframe, start_date=since)
     if df.empty:
@@ -139,8 +190,8 @@ def run_single_backtest(
 
     bt = Backtester(
         initial_capital=capital, platform=platform,
+        open_strategy={"name": strategy_name, "params": dict(strat_params or {})},
         close_strategies=close_strategies,
-        close_params=close_params,
         regime_enabled=regime_enabled,
         regime_period=regime_period,
         regime_adx_threshold=regime_adx_threshold,
@@ -167,8 +218,7 @@ def run_all_strategies(
     registry: str = "spot",
     platform: str = "binanceus",
     htf_filter: bool = False,
-    close_strategies: Optional[List[str]] = None,
-    close_params: Optional[dict] = None,
+    close_strategies: Optional[List[dict]] = None,
     regime_enabled: bool = False,
     regime_period: int = 14,
     regime_adx_threshold: float = 20.0,
@@ -187,7 +237,7 @@ def run_all_strategies(
         result = run_single_backtest(
             name, symbol, timeframe, since, capital,
             registry=registry, platform=platform, htf_filter=htf_filter,
-            close_strategies=close_strategies, close_params=close_params,
+            close_strategies=close_strategies,
             regime_enabled=regime_enabled, regime_period=regime_period,
             regime_adx_threshold=regime_adx_threshold,
             allowed_regimes=allowed_regimes,
@@ -210,8 +260,7 @@ def run_multi_asset(
     registry: str = "spot",
     platform: str = "binanceus",
     htf_filter: bool = False,
-    close_strategies: Optional[List[str]] = None,
-    close_params: Optional[dict] = None,
+    close_strategies: Optional[List[dict]] = None,
     regime_enabled: bool = False,
     regime_period: int = 14,
     regime_adx_threshold: float = 20.0,
@@ -238,7 +287,7 @@ def run_multi_asset(
             result = run_single_backtest(
                 strat_name, symbol, timeframe, since, capital,
                 registry=registry, platform=platform, htf_filter=htf_filter,
-                close_strategies=close_strategies, close_params=close_params,
+                close_strategies=close_strategies,
                 regime_enabled=regime_enabled, regime_period=regime_period,
                 regime_adx_threshold=regime_adx_threshold,
                 allowed_regimes=allowed_regimes,
@@ -339,14 +388,17 @@ def _build_parser() -> argparse.ArgumentParser:
                              "shared_tools/htf_filter.py); 50-EMA on the "
                              "default HTF for the chosen timeframe.")
     parser.add_argument("--close-strategy", action="append", dest="close_strategies",
-                        default=None, metavar="NAME",
-                        help="Close-evaluator name from shared_strategies/close/registry.py "
-                             "(repeat for multiple). Each runs per-bar against the "
-                             "simulated position; max close_fraction wins.")
-    parser.add_argument("--close-params", default=None,
-                        help="Per-evaluator params as JSON string, keyed by "
-                             "evaluator name, e.g. "
-                             "'{\"tp_at_pct\":{\"pct\":0.03}}'.")
+                        default=None, metavar="REF",
+                        help="Close-evaluator ref. Two accepted shapes (#641):\n"
+                             "  - bare name: --close-strategy tp_at_pct\n"
+                             "  - JSON ref:  --close-strategy '{\"name\":\"tp_at_pct\",\"params\":{\"pct\":0.03}}'\n"
+                             "Repeat for multiple. Each runs per-bar against the simulated position; "
+                             "max close_fraction wins. Replaces the pre-#641 --close-strategy NAME + "
+                             "--close-params JSON pair.")
+    parser.add_argument("--config", default=None,
+                        help="Path to a live go-trader config.json. Loads a single strategy by "
+                             "--strategy ID and uses its open_strategy/close_strategies refs verbatim "
+                             "for the backtest. Lets you backtest a live config without reshaping (#641).")
     parser.add_argument("--regime-enabled", action="store_true", default=False,
                         help="Enable market regime detection. Injects vectorized regime "
                              "column from shared_tools/regime.py before the per-bar loop, "
@@ -363,16 +415,48 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _parse_close_strategy_arg(raw: str) -> dict:
+    """Parse a --close-strategy CLI value into a {name, params} ref (#641).
+
+    Accepts two shapes for ergonomics:
+      - bare name (no leading '{'): wraps as {"name": <raw>, "params": {}}
+      - JSON object: parsed as-is, requires "name" key, normalized "params"
+    """
+    import json as _json
+    s = raw.strip()
+    if not s.startswith(("{", "[")):
+        return {"name": s, "params": {}}
+    try:
+        ref = _json.loads(s)
+    except _json.JSONDecodeError as exc:
+        raise SystemExit(f"--close-strategy not valid JSON: {exc}\nGot: {raw}")
+    if not isinstance(ref, dict):
+        raise SystemExit(f"--close-strategy JSON must be an object, got {type(ref).__name__}")
+    name = (ref.get("name") or "").strip()
+    if not name:
+        raise SystemExit(f"--close-strategy ref missing 'name': {raw}")
+    return {"name": name, "params": dict(ref.get("params") or {})}
+
+
 def main():
     args = _build_parser().parse_args()
 
-    close_params = None
-    if args.close_params:
-        import json as _json
-        close_params = _json.loads(args.close_params)
-        if not isinstance(close_params, dict):
-            print("--close-params must be a JSON object keyed by evaluator name")
+    close_refs = None
+    if args.close_strategies:
+        close_refs = [_parse_close_strategy_arg(v) for v in args.close_strategies]
+
+    # #641: --config loads a live strategy by ID and uses its refs directly.
+    if args.config:
+        live_kwargs = load_strategy_config(args.config, args.strategy)
+        # Live config refs take precedence; --close-strategy on top is rejected
+        # to avoid silent overrides.
+        if close_refs:
+            print("--close-strategy is not allowed alongside --config (refs come from the live config)")
             sys.exit(1)
+        close_refs = live_kwargs["close_strategies"]
+        # Open strategy name + params come from the live config too. We override
+        # args.strategy and any --strategy-params downstream.
+        args.strategy = live_kwargs["open_strategy"]["name"]
 
     reg = load_registry(args.registry)
 
@@ -384,8 +468,7 @@ def main():
                             args.since, args.capital,
                             registry=args.registry, platform=args.platform,
                             htf_filter=args.htf_filter,
-                            close_strategies=args.close_strategies,
-                            close_params=close_params,
+                            close_strategies=close_refs,
                             regime_enabled=args.regime_enabled,
                             regime_period=args.regime_period,
                             regime_adx_threshold=args.regime_adx_threshold,
@@ -397,8 +480,7 @@ def main():
                            strategies,
                            registry=args.registry, platform=args.platform,
                            htf_filter=args.htf_filter,
-                           close_strategies=args.close_strategies,
-                           close_params=close_params,
+                           close_strategies=close_refs,
                            regime_enabled=args.regime_enabled,
                            regime_period=args.regime_period,
                            regime_adx_threshold=args.regime_adx_threshold,
@@ -411,8 +493,7 @@ def main():
                         args.capital,
                         registry=args.registry, platform=args.platform,
                         htf_filter=args.htf_filter,
-                        close_strategies=args.close_strategies,
-                        close_params=close_params,
+                        close_strategies=close_refs,
                         regime_enabled=args.regime_enabled,
                         regime_period=args.regime_period,
                         regime_adx_threshold=args.regime_adx_threshold,

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -445,8 +445,15 @@ def main():
     if args.close_strategies:
         close_refs = [_parse_close_strategy_arg(v) for v in args.close_strategies]
 
-    # #641: --config loads a live strategy by ID and uses its refs directly.
+    # #641: --config loads a single strategy by ID and uses its refs directly.
+    open_params: Optional[dict] = None
     if args.config:
+        # --config loads exactly one strategy; non-single modes would silently
+        # ignore the loaded refs for every strategy except the one matching
+        # --strategy. Reject upfront instead of producing misleading reports.
+        if args.mode != "single":
+            print("--config is only valid with --mode single (loads one strategy by --strategy <id>)")
+            sys.exit(1)
         live_kwargs = load_strategy_config(args.config, args.strategy)
         # Live config refs take precedence; --close-strategy on top is rejected
         # to avoid silent overrides.
@@ -454,9 +461,12 @@ def main():
             print("--close-strategy is not allowed alongside --config (refs come from the live config)")
             sys.exit(1)
         close_refs = live_kwargs["close_strategies"]
-        # Open strategy name + params come from the live config too. We override
-        # args.strategy and any --strategy-params downstream.
+        # Open strategy name + params come from the live config. Threading
+        # params through to run_single_backtest is required — without it,
+        # run_single_backtest falls back to the registry default_params and
+        # silently ignores per-strategy params from the live config (#643 review #1).
         args.strategy = live_kwargs["open_strategy"]["name"]
+        open_params = dict(live_kwargs["open_strategy"]["params"]) or None
 
     reg = load_registry(args.registry)
 
@@ -466,6 +476,7 @@ def main():
             sys.exit(1)
         run_single_backtest(args.strategy, args.symbol, args.timeframe,
                             args.since, args.capital,
+                            params=open_params,
                             registry=args.registry, platform=args.platform,
                             htf_filter=args.htf_filter,
                             close_strategies=close_refs,

--- a/backtest/tests/test_backtester_close_strategies.py
+++ b/backtest/tests/test_backtester_close_strategies.py
@@ -32,8 +32,7 @@ def test_tp_at_pct_closes_full_position_when_threshold_hit():
     )
     bt = Backtester(
         initial_capital=1000, commission_pct=0, slippage_pct=0,
-        close_strategies=["tp_at_pct"],
-        close_params={"tp_at_pct": {"pct": 0.03}},
+        close_strategies=[{"name": "tp_at_pct", "params": {"pct": 0.03}}],
     )
     result = bt.run(df, save=False)
 
@@ -51,8 +50,7 @@ def test_tp_at_pct_does_not_fire_when_threshold_not_hit():
     )
     bt = Backtester(
         initial_capital=1000, commission_pct=0, slippage_pct=0,
-        close_strategies=["tp_at_pct"],
-        close_params={"tp_at_pct": {"pct": 0.03}},
+        close_strategies=[{"name": "tp_at_pct", "params": {"pct": 0.03}}],
     )
     result = bt.run(df, save=False)
     # Position closes at the end of run at the final close ($101).
@@ -72,11 +70,12 @@ def test_tiered_tp_atr_partial_then_full_close():
     )
     bt = Backtester(
         initial_capital=1000, commission_pct=0, slippage_pct=0,
-        close_strategies=["tiered_tp_atr"],
-        close_params={"tiered_tp_atr": {"tiers": [
+        close_strategies=[
+            {"name": "tiered_tp_atr", "params": {"tiers": [
             {"atr_multiple": 1.0, "close_fraction": 0.5},
             {"atr_multiple": 2.0, "close_fraction": 1.0},
         ]}},
+        ],
     )
     result = bt.run(df, save=False)
 
@@ -100,14 +99,15 @@ def test_tiered_tp_atr_live_uses_live_atr_from_market():
     )
     bt = Backtester(
         initial_capital=1000, commission_pct=0, slippage_pct=0,
-        close_strategies=["tiered_tp_atr_live"],
-        close_params={"tiered_tp_atr_live": {
+        close_strategies=[
+            {"name": "tiered_tp_atr_live", "params": {
             "atr_source": "live",
             "tiers": [
                 {"atr_multiple": 1.0, "close_fraction": 0.5},
                 {"atr_multiple": 2.0, "close_fraction": 1.0},
             ],
         }},
+        ],
     )
     result = bt.run(df, save=False)
 
@@ -126,13 +126,12 @@ def test_max_close_fraction_wins_between_two_evaluators():
     )
     bt = Backtester(
         initial_capital=1000, commission_pct=0, slippage_pct=0,
-        close_strategies=["tp_at_pct", "tiered_tp_pct"],
-        close_params={
-            "tp_at_pct": {"pct": 0.02},
-            "tiered_tp_pct": {"tiers": [
+        close_strategies=[
+            {"name": "tp_at_pct", "params": {"pct": 0.02}},
+            {"name": "tiered_tp_pct", "params": {"tiers": [
                 {"profit_pct": 0.05, "close_fraction": 1.0},
-            ]},
-        },
+            ]}},
+        ],
     )
     result = bt.run(df, save=False)
 
@@ -171,8 +170,7 @@ def test_close_strategy_short_position_long_take_profit():
     }, index=idx)
     bt = Backtester(
         initial_capital=1000, commission_pct=0, slippage_pct=0,
-        close_strategies=["tp_at_pct"],
-        close_params={"tp_at_pct": {"pct": 0.03}},
+        close_strategies=[{"name": "tp_at_pct", "params": {"pct": 0.03}}],
     )
     result = bt.run(df, save=False)
 
@@ -199,11 +197,12 @@ def test_starting_long_seed_with_entry_atr_lets_tiered_tp_atr_fire():
     }, index=idx)
     bt = Backtester(
         initial_capital=1000, commission_pct=0, slippage_pct=0,
-        close_strategies=["tiered_tp_atr"],
-        close_params={"tiered_tp_atr": {"tiers": [
+        close_strategies=[
+            {"name": "tiered_tp_atr", "params": {"tiers": [
             {"atr_multiple": 1.0, "close_fraction": 0.5},
             {"atr_multiple": 2.0, "close_fraction": 1.0},
         ]}},
+        ],
     )
     result = bt.run(
         df, save=False,
@@ -233,7 +232,7 @@ def test_starting_long_seed_without_entry_atr_atr_evaluator_noops():
     }, index=idx)
     bt = Backtester(
         initial_capital=1000, commission_pct=0, slippage_pct=0,
-        close_strategies=["tiered_tp_atr"],
+        close_strategies=[{"name": "tiered_tp_atr"}],
     )
     result = bt.run(
         df, save=False,
@@ -248,7 +247,7 @@ def test_close_strategy_unknown_name_raises():
     try:
         Backtester(
             initial_capital=1000, commission_pct=0, slippage_pct=0,
-            close_strategies=["does_not_exist"],
+            close_strategies=[{"name": "does_not_exist"}],
         )
     except ValueError as exc:
         assert "does_not_exist" in str(exc)

--- a/backtest/tests/test_strategy_refs_641.py
+++ b/backtest/tests/test_strategy_refs_641.py
@@ -1,0 +1,199 @@
+"""#641: Backtester accepts co-located strategy refs (name + params), CLI
+parses both bare-name and JSON-ref forms, and load_strategy_config produces
+ready-to-use kwargs from a live go-trader config.
+
+These tests pin the ref-shape contract on the Python side after #641 (mirror
+of the Go-side StrategyRef change in #640) so a future refactor that loses
+per-ref params or breaks the live-config import path fails immediately.
+"""
+import json
+
+import pandas as pd
+import pytest
+
+from backtester import Backtester
+import run_backtest
+
+
+def _flat_df():
+    """3-bar flat DataFrame; Backtester runs but produces no signal action."""
+    return pd.DataFrame(
+        {
+            "open":   [100, 100, 100],
+            "high":   [101, 101, 101],
+            "low":    [ 99,  99,  99],
+            "close":  [100, 100, 100],
+            "volume": [1000, 1000, 1000],
+            "signal": [0, 0, 0],
+        },
+        index=pd.date_range("2024-01-01", periods=3, freq="D"),
+    )
+
+
+# ─── Backtester accepts ref shape ────────────────────────────────────────────
+
+
+def test_backtester_accepts_open_strategy_ref():
+    bt = Backtester(
+        initial_capital=1000,
+        open_strategy={"name": "tema_cross_bd", "params": {"short_period": 5}},
+    )
+    # Run records the open ref on the result for parity with live config.
+    df = _flat_df()
+    result = bt.run(df, save=False)
+    assert result["open_strategy"]["name"] == "tema_cross_bd"
+    assert result["open_strategy"]["params"]["short_period"] == 5
+
+
+def test_backtester_accepts_close_strategy_ref_with_params():
+    """Close ref params must reach the eval loop's per-name params dict
+    (mirrors how the live scheduler passes per-ref params, post #640)."""
+    bt = Backtester(
+        initial_capital=1000,
+        close_strategies=[
+            {"name": "tiered_tp_atr", "params": {"tiers": [
+                {"atr_multiple": 2.0, "close_fraction": 1.0},
+            ]}},
+        ],
+    )
+    assert bt.close_strategies == ["tiered_tp_atr"]
+    assert bt.close_params["tiered_tp_atr"]["tiers"] == [
+        {"atr_multiple": 2.0, "close_fraction": 1.0}
+    ]
+
+
+def test_backtester_close_strategies_records_refs_on_result():
+    bt = Backtester(
+        initial_capital=1000,
+        close_strategies=[
+            {"name": "tp_at_pct", "params": {"pct": 0.05}},
+            {"name": "tiered_tp_pct"},
+        ],
+    )
+    result = bt.run(_flat_df(), save=False)
+    refs = result["close_strategies"]
+    assert [r["name"] for r in refs] == ["tp_at_pct", "tiered_tp_pct"]
+    assert refs[0]["params"] == {"pct": 0.05}
+    assert refs[1]["params"] == {}
+
+
+def test_backtester_rejects_close_strategy_without_name():
+    with pytest.raises(ValueError, match="missing 'name'"):
+        Backtester(close_strategies=[{"params": {"pct": 0.03}}])
+
+
+def test_backtester_rejects_close_strategy_non_dict():
+    with pytest.raises(ValueError, match="must be dicts"):
+        Backtester(close_strategies=["bare_string_no_longer_supported"])
+
+
+# ─── CLI: --close-strategy parses bare names and JSON refs ───────────────────
+
+
+def test_parse_close_strategy_arg_bare_name():
+    ref = run_backtest._parse_close_strategy_arg("tp_at_pct")
+    assert ref == {"name": "tp_at_pct", "params": {}}
+
+
+def test_parse_close_strategy_arg_json_with_params():
+    ref = run_backtest._parse_close_strategy_arg(
+        '{"name": "tiered_tp_atr", "params": {"tiers": [{"atr_multiple": 2.0}]}}'
+    )
+    assert ref["name"] == "tiered_tp_atr"
+    assert ref["params"]["tiers"][0]["atr_multiple"] == 2.0
+
+
+def test_parse_close_strategy_arg_json_without_params():
+    ref = run_backtest._parse_close_strategy_arg('{"name": "tp_at_pct"}')
+    assert ref == {"name": "tp_at_pct", "params": {}}
+
+
+def test_parse_close_strategy_arg_json_missing_name_rejected():
+    with pytest.raises(SystemExit, match="missing 'name'"):
+        run_backtest._parse_close_strategy_arg('{"params": {"pct": 0.03}}')
+
+
+def test_parse_close_strategy_arg_invalid_json_rejected():
+    with pytest.raises(SystemExit, match="not valid JSON"):
+        run_backtest._parse_close_strategy_arg('{"name": "tp_at_pct"')
+
+
+def test_parse_close_strategy_arg_non_object_json_rejected():
+    with pytest.raises(SystemExit, match="must be an object"):
+        run_backtest._parse_close_strategy_arg('["tp_at_pct"]')
+
+
+# ─── load_strategy_config: live config → Backtester kwargs ───────────────────
+
+
+def _write_config(tmp_path, version, strategies):
+    cfg = {"config_version": version, "strategies": strategies}
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps(cfg, indent=2))
+    return str(p)
+
+
+def test_load_strategy_config_extracts_refs(tmp_path):
+    path = _write_config(tmp_path, version=13, strategies=[
+        {
+            "id": "hl-temacb-btc",
+            "type": "perps",
+            "open_strategy": {"name": "tema_cross_bd", "params": {"short_period": 5}},
+            "close_strategies": [
+                {"name": "tiered_tp_atr", "params": {"tiers": [
+                    {"atr_multiple": 2.0, "close_fraction": 0.5},
+                    {"atr_multiple": 3.0, "close_fraction": 1.0},
+                ]}},
+            ],
+        },
+    ])
+    kwargs = run_backtest.load_strategy_config(path, "hl-temacb-btc")
+    assert kwargs["open_strategy"]["name"] == "tema_cross_bd"
+    assert kwargs["open_strategy"]["params"]["short_period"] == 5
+    assert len(kwargs["close_strategies"]) == 1
+    assert kwargs["close_strategies"][0]["name"] == "tiered_tp_atr"
+    assert kwargs["close_strategies"][0]["params"]["tiers"][0]["atr_multiple"] == 2.0
+
+
+def test_load_strategy_config_rejects_pre_v13(tmp_path):
+    path = _write_config(tmp_path, version=12, strategies=[
+        # Pre-v13 flat shape: open_strategy is a string, params is flat.
+        {"id": "hl-temacb-btc", "open_strategy": "tema_cross_bd",
+         "close_strategies": ["tiered_tp_atr"], "params": {"tiers": []}},
+    ])
+    with pytest.raises(ValueError, match="config_version=12"):
+        run_backtest.load_strategy_config(path, "hl-temacb-btc")
+
+
+def test_load_strategy_config_rejects_unknown_id(tmp_path):
+    path = _write_config(tmp_path, version=13, strategies=[
+        {"id": "hl-temacb-btc",
+         "open_strategy": {"name": "tema_cross_bd"},
+         "close_strategies": []},
+    ])
+    with pytest.raises(ValueError, match="no strategy with id='hl-other-eth'"):
+        run_backtest.load_strategy_config(path, "hl-other-eth")
+
+
+def test_load_strategy_config_then_backtester_parity(tmp_path):
+    """Same JSON block produces same Backtester wiring as constructing the
+    refs by hand. This is the live↔backtest parity contract from the issue."""
+    path = _write_config(tmp_path, version=13, strategies=[
+        {
+            "id": "hl-temacb-btc",
+            "open_strategy": {"name": "tema_cross_bd", "params": {"short_period": 5}},
+            "close_strategies": [
+                {"name": "tp_at_pct", "params": {"pct": 0.05}},
+            ],
+        },
+    ])
+    kwargs = run_backtest.load_strategy_config(path, "hl-temacb-btc")
+    bt_from_config = Backtester(initial_capital=1000, **kwargs)
+    bt_inline = Backtester(
+        initial_capital=1000,
+        open_strategy={"name": "tema_cross_bd", "params": {"short_period": 5}},
+        close_strategies=[{"name": "tp_at_pct", "params": {"pct": 0.05}}],
+    )
+    assert bt_from_config.open_strategy == bt_inline.open_strategy
+    assert bt_from_config.close_strategies == bt_inline.close_strategies
+    assert bt_from_config.close_params == bt_inline.close_params

--- a/backtest/tests/test_strategy_refs_641.py
+++ b/backtest/tests/test_strategy_refs_641.py
@@ -197,3 +197,77 @@ def test_load_strategy_config_then_backtester_parity(tmp_path):
     assert bt_from_config.open_strategy == bt_inline.open_strategy
     assert bt_from_config.close_strategies == bt_inline.close_strategies
     assert bt_from_config.close_params == bt_inline.close_params
+
+
+# ─── End-to-end: --config threads live open params (#643 review #1) ──────────
+
+
+def test_config_flag_threads_live_open_params_to_result(tmp_path, monkeypatch):
+    """Drive main() with --config and verify the live config's open_strategy.params
+    reach the Backtester result, instead of being silently overridden by the
+    registry's default_params. Regression for #643 review #1.
+    """
+    # Real strategy that has overridable defaults: triple_ema (default short=8).
+    config_path = _write_config(tmp_path, version=13, strategies=[
+        {
+            "id": "hl-triple-btc",
+            "type": "perps",
+            "open_strategy": {
+                "name": "triple_ema",
+                # Non-default value: registry default short_period is 8.
+                "params": {"short_period": 3, "mid_period": 13, "long_period": 34},
+            },
+            "close_strategies": [],
+        },
+    ])
+
+    captured = {}
+    real_run_single = run_backtest.run_single_backtest
+
+    def spy_run_single(*args, **kwargs):
+        captured["params"] = kwargs.get("params")
+        captured["close_refs"] = kwargs.get("close_strategies")
+        captured["strategy_name"] = kwargs.get("strategy_name") or (args[0] if args else None)
+        # Don't actually run the backtest — just record what main() forwarded.
+        return None
+
+    monkeypatch.setattr(run_backtest, "run_single_backtest", spy_run_single)
+    monkeypatch.setattr("sys.argv", [
+        "run_backtest.py",
+        "--mode", "single",
+        "--config", config_path,
+        "--strategy", "hl-triple-btc",
+    ])
+
+    run_backtest.main()
+
+    assert captured["strategy_name"] == "triple_ema", (
+        f"main() did not rewrite --strategy to the live open ref name; "
+        f"got {captured.get('strategy_name')!r}"
+    )
+    assert captured["params"] == {"short_period": 3, "mid_period": 13, "long_period": 34}, (
+        f"main() did not thread live open_strategy.params; got {captured.get('params')!r}. "
+        f"Without this, run_single_backtest falls back to triple_ema's registry default "
+        f"short_period=8 and silently ignores the live config."
+    )
+    # Restore (defensive — monkeypatch handles it but explicit reads better).
+    assert real_run_single is not None  # silence unused
+
+
+def test_config_flag_rejects_non_single_modes(tmp_path):
+    """--config loads exactly one strategy; rejecting compare/multi/optimize
+    upfront prevents misleading reports where only the matched strategy gets
+    the live close refs and the rest run with no close strategies (#643 review #4)."""
+    config_path = _write_config(tmp_path, version=13, strategies=[
+        {"id": "x", "open_strategy": {"name": "triple_ema"}, "close_strategies": []},
+    ])
+    import sys as _sys
+    for bad_mode in ("compare", "multi", "optimize"):
+        old_argv = _sys.argv
+        _sys.argv = ["run_backtest.py", "--mode", bad_mode,
+                     "--config", config_path, "--strategy", "x"]
+        try:
+            with pytest.raises(SystemExit):
+                run_backtest.main()
+        finally:
+            _sys.argv = old_argv


### PR DESCRIPTION
Closes #641. Follow-up to #640.

## Summary

- `Backtester.__init__` now takes `open_strategy` + `close_strategies` as co-located `{"name", "params"}` refs, matching the live config shape from #640. Drops the parallel `close_strategies: list[str]` + `close_params: dict` pair.
- `--close-strategy` CLI flag accepts both bare names (`tp_at_pct`) and JSON refs (`'{"name":"tp_at_pct","params":{"pct":0.03}}'`). Repeatable. `--close-params` removed.
- New `--config <path>` flag loads a single strategy from a v13+ live config and uses its refs verbatim. One-command backtest of a live strategy.
- New `load_strategy_config(path, id)` helper for programmatic callers.

## Test plan

- [x] 109 backtest tests pass (10 in `test_backtester_close_strategies.py` rewritten to ref shape)
- [x] 15 new tests in `test_strategy_refs_641.py` pin the contract: ref accept/reject, CLI parser, live-config loader, and live↔backtest parity (same JSON block produces identical Backtester wiring)
- [x] Full Python suite: 873 pass
- [x] Go suite unchanged (no Go changes in this PR): pass
- [ ] Smoke run on a real v13 config: `python3 backtest/run_backtest.py --config /path/to/live.json --strategy <id> --mode single`

## Notes

- Optimizer untouched; it never used the dropped close params.
- Backtester result dict now records `open_strategy` and `close_strategies` refs alongside `strategy_name` / `params` (kept for back-compat with reporting code).

---
LLM: Claude Sonnet 4.6 (1M) | high