### PR TITLE
fix: rebaseline portfolio peak after strategy prune (#650)

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -129,10 +129,25 @@ func main() {
 	for _, sc := range cfg.Strategies {
 		configIDs[sc.ID] = true
 	}
+	pruned := false
 	for id := range state.Strategies {
 		if !configIDs[id] {
 			delete(state.Strategies, id)
 			fmt.Printf("  Pruned stale strategy: %s\n", id)
+			pruned = true
+		}
+	}
+
+	// #650: After prune, rebaseline portfolio peak from surviving strategies'
+	// per-strategy peaks. Without this, the stale portfolio peak (sized for the
+	// pre-prune strategy set) can immediately latch the kill switch on the
+	// first risk-check cycle once current value drops to the surviving subset.
+	if pruned && state.PortfolioRisk.PeakValue > 0 {
+		oldPeak := state.PortfolioRisk.PeakValue
+		newPeak := rebaselinePortfolioPeakAfterPrune(state, cfg)
+		if newPeak != oldPeak {
+			state.PortfolioRisk.PeakValue = newPeak
+			fmt.Printf("  Portfolio peak rebaselined after prune: $%.0f -> $%.0f\n", oldPeak, newPeak)
 		}
 	}
 

--- a/scheduler/shared_wallet.go
+++ b/scheduler/shared_wallet.go
@@ -329,3 +329,46 @@ func computeInitialPortfolioPeak(strategies []StrategyConfig, fetcher WalletBala
 	}
 	return total
 }
+
+// rebaselinePortfolioPeakAfterPrune recomputes PortfolioRisk.PeakValue from the
+// per-strategy peaks of remaining strategies after one or more strategies are
+// pruned from config. Without this, the stale portfolio peak (which reflects
+// the pre-prune strategy set) can immediately latch the kill switch on the
+// first risk-check cycle since current portfolio value drops to the sum of
+// only the surviving strategies. See issue #650.
+//
+// For each surviving strategy, prefers RiskState.PeakValue (the per-strategy
+// high-water mark recorded by CheckRisk). Falls back to that strategy's
+// configured Capital when no per-strategy peak has been recorded yet
+// (cold-start or migrated state).
+//
+// The result is floored at computeInitialPortfolioPeak(remaining) so the
+// rebaseline never drops below the sum-of-capitals baseline that a fresh
+// install would use — protects against under-baseline when most surviving
+// strategies are themselves cold-started.
+func rebaselinePortfolioPeakAfterPrune(state *AppState, cfg *Config) float64 {
+	byID := make(map[string]StrategyConfig, len(cfg.Strategies))
+	for _, sc := range cfg.Strategies {
+		byID[sc.ID] = sc
+	}
+
+	sum := 0.0
+	for id, ss := range state.Strategies {
+		if ss == nil {
+			continue
+		}
+		if ss.RiskState.PeakValue > 0 {
+			sum += ss.RiskState.PeakValue
+			continue
+		}
+		if sc, ok := byID[id]; ok {
+			sum += sc.Capital
+		}
+	}
+
+	floor := computeInitialPortfolioPeak(cfg.Strategies, nil)
+	if sum < floor {
+		sum = floor
+	}
+	return sum
+}

--- a/scheduler/shared_wallet_test.go
+++ b/scheduler/shared_wallet_test.go
@@ -657,3 +657,101 @@ func TestComputeInitialPortfolioPeak_NoSharedWalletsSumsCapital(t *testing.T) {
 		t.Errorf("expected peak=%v; got %v", want, got)
 	}
 }
+
+// --- rebaselinePortfolioPeakAfterPrune (#650) ---
+
+// TestRebaselinePortfolioPeakAfterPrune_SumsRemainingPerStrategyPeaks verifies
+// that the rebaselined peak sums RiskState.PeakValue from surviving strategies,
+// dropping the contribution of the pruned one.
+func TestRebaselinePortfolioPeakAfterPrune_SumsRemainingPerStrategyPeaks(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "")
+
+	cfg := &Config{Strategies: []StrategyConfig{
+		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 5000},
+	}}
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"spot-btc": {ID: "spot-btc", RiskState: RiskState{PeakValue: 7000}},
+	}}
+
+	got := rebaselinePortfolioPeakAfterPrune(state, cfg)
+	want := 7000.0
+	if got != want {
+		t.Errorf("expected rebaselined peak=%v; got %v", want, got)
+	}
+}
+
+// TestRebaselinePortfolioPeakAfterPrune_FloorAtCapitalSum verifies that when a
+// surviving strategy has zero per-strategy peak (cold-start) the result floors
+// at computeInitialPortfolioPeak so we never under-baseline.
+func TestRebaselinePortfolioPeakAfterPrune_FloorAtCapitalSum(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "")
+
+	cfg := &Config{Strategies: []StrategyConfig{
+		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 5000},
+		{ID: "spot-eth", Platform: "binanceus", Type: "spot", Capital: 3000},
+	}}
+	state := &AppState{Strategies: map[string]*StrategyState{
+		// One surviving strategy with no per-strategy peak yet.
+		"spot-btc": {ID: "spot-btc"},
+		"spot-eth": {ID: "spot-eth"},
+	}}
+
+	got := rebaselinePortfolioPeakAfterPrune(state, cfg)
+	want := 8000.0 // floor: 5000 + 3000
+	if got != want {
+		t.Errorf("expected floored peak=%v; got %v", want, got)
+	}
+}
+
+// TestRebaselinePortfolioPeakAfterPrune_FallbackToCapitalWhenPeakMissing verifies
+// that strategies missing per-strategy peak fall back to their configured
+// capital (mixed with surviving strategies that do have peaks).
+func TestRebaselinePortfolioPeakAfterPrune_FallbackToCapitalWhenPeakMissing(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "")
+
+	cfg := &Config{Strategies: []StrategyConfig{
+		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 5000},
+		{ID: "spot-eth", Platform: "binanceus", Type: "spot", Capital: 3000},
+	}}
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"spot-btc": {ID: "spot-btc", RiskState: RiskState{PeakValue: 6000}},
+		"spot-eth": {ID: "spot-eth"}, // no peak yet → use capital
+	}}
+
+	got := rebaselinePortfolioPeakAfterPrune(state, cfg)
+	want := 9000.0 // 6000 (peak) + 3000 (capital fallback)
+	if got != want {
+		t.Errorf("expected mixed peak=%v; got %v", want, got)
+	}
+}
+
+// TestRebaselinePortfolioPeakAfterPrune_PreventsImmediateKillSwitch is the
+// regression test for #650: pre-fix, a stale peak from a pruned multi-strategy
+// run latched the kill switch on the first cycle. With the fix, the rebaseline
+// reflects only surviving strategies so CheckPortfolioRisk does not fire.
+func TestRebaselinePortfolioPeakAfterPrune_PreventsImmediateKillSwitch(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "")
+
+	// Surviving config: one strategy that itself peaked at $9034 and is still
+	// sitting at $9034 (no drawdown on what's left).
+	cfg := &Config{Strategies: []StrategyConfig{
+		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 5000},
+	}}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"spot-btc": {ID: "spot-btc", RiskState: RiskState{PeakValue: 9034.24}},
+		},
+		PortfolioRisk: PortfolioRiskState{PeakValue: 15148.90}, // pre-prune peak
+	}
+
+	state.PortfolioRisk.PeakValue = rebaselinePortfolioPeakAfterPrune(state, cfg)
+
+	prsCfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+	allowed, _, _, reason := CheckPortfolioRisk(&state.PortfolioRisk, prsCfg, 9034.24, 0, 0, 0)
+	if !allowed {
+		t.Errorf("expected kill switch NOT to fire after rebaseline; got reason=%q", reason)
+	}
+	if state.PortfolioRisk.KillSwitchActive {
+		t.Errorf("expected kill switch inactive after rebaseline; got active")
+	}
+}


### PR DESCRIPTION
## Summary

When strategies are pruned from config and the service restarts, `PortfolioRisk.PeakValue` keeps its pre-prune value. The first risk-check cycle compares it against the now-smaller surviving portfolio and immediately latches the kill switch.

The peak-init guard at `scheduler/main.go:150` only fires on `PeakValue == 0`, so the stale value survives. `ClearLatchedKillSwitchSharedWallet` re-baselines for shared wallets only after the latch — too late.

`rebaselinePortfolioPeakAfterPrune` sums surviving strategies' `RiskState.PeakValue` (per-strategy high-water marks already tracked by `CheckRisk`), falls back to configured `Capital` for cold-start strategies, and floors at `computeInitialPortfolioPeak(remaining)` so we never under-baseline. Wired into the prune block in `main.go` when any strategy was removed.

Per-strategy peaks are summed (rather than scaling the old peak by cash ratio or resetting to cap-sum) because they're the most accurate signal already on hand — they preserve accrued gains for surviving strategies without over-attributing them.

## Test plan

- [x] `go test ./...` from `scheduler/` passes (21s)
- [x] New tests in `shared_wallet_test.go`:
  - sums per-strategy peaks of surviving strategies
  - floors at sum-of-capitals when surviving strategies have no recorded peak
  - falls back to capital per-strategy when peak is missing
  - regression: pre-fix kill switch latched, post-fix `CheckPortfolioRisk` allows trading

Closes #650

---
LLM: Claude Opus 4.7 | high