### PR TITLE
feat: enable perps shorts on existing bearish-capable strategies

### DIFF
--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -77,9 +77,12 @@ var knownShortNames = map[string]string{
 // set AllowShorts=true so ExecutePerpsSignal opens shorts from flat instead
 // of skipping the signal (#328).
 var bidirectionalPerpsStrategies = map[string]bool{
-	"triple_ema_bidir": true,
-	"tema_cross_bd":    true,
-	"session_breakout": true,
+	"triple_ema_bidir":  true,
+	"tema_cross_bd":     true,
+	"session_breakout":  true,
+	"donchian_breakout": true, // emits short on lower-channel breakdown (#649)
+	"chart_pattern":     true, // emits short on bearish patterns (double top, H&S, bear flag) (#649)
+	"liquidity_sweeps":  true, // emits short on stop-hunt wicks above swing highs (#649)
 }
 
 func isBidirectionalPerpsStrategy(id string) bool {

--- a/scheduler/init_test.go
+++ b/scheduler/init_test.go
@@ -759,7 +759,15 @@ func TestGenerateConfig_PerpsAllowShortsWiring(t *testing.T) {
 	opts.EnablePerps = true
 	opts.Assets = []string{"ETH"}
 	opts.PerpsMode = "paper"
-	opts.PerpsStrategies = []string{"triple_ema_bidir", "triple_ema", "rsi_macd_combo", "session_breakout"}
+	opts.PerpsStrategies = []string{
+		"triple_ema_bidir",
+		"triple_ema",
+		"rsi_macd_combo",
+		"session_breakout",
+		"donchian_breakout",
+		"chart_pattern",
+		"liquidity_sweeps",
+	}
 
 	cfg := generateConfig(opts)
 
@@ -768,6 +776,9 @@ func TestGenerateConfig_PerpsAllowShortsWiring(t *testing.T) {
 		"hl-tema-eth":  false, // long-only — must NOT allow shorts
 		"hl-rmc-eth":   false, // long-only — must NOT allow shorts
 		"hl-sbo-eth":   true,  // bidirectional — must allow shorts (#371)
+		"hl-dbo-eth":   true,  // bidirectional — emits short on lower-channel breakdown (#649)
+		"hl-cpat-eth":  true,  // bidirectional — emits short on bearish patterns (#649)
+		"hl-liqsw-eth": true,  // bidirectional — emits short on stop-hunt wicks (#649)
 	}
 	seen := map[string]bool{}
 	for _, s := range cfg.Strategies {


### PR DESCRIPTION
## Summary

- Adds `donchian_breakout`, `chart_pattern`, `liquidity_sweeps` to `bidirectionalPerpsStrategies` (`scheduler/init.go:79`) so `generateConfig` wires `AllowShorts=true` for them.
- These strategies already emit `signal=-1` with bearish-specific structure (channel breakdown at `donchian_breakout.py:74`, double top / H&S / bear flag at `chart_patterns.py:127,201,281,445,561`, stop-hunt wicks at `liquidity_sweeps.py:77`); previously the perps executor treated those signals as long-exits only.
- Extends `TestGenerateConfig_PerpsAllowShortsWiring` (`scheduler/init_test.go`) to assert all three new IDs generate `AllowShorts=true`.

## Test plan

- [x] `go test ./...` (scheduler) — green (21.4s)
- [x] `gofmt -w` clean
- [ ] Operators pair these with `allowed_regimes=["trending_down"]` for bearish-regime gating (existing primitive, no code change needed)

Closes #649

---
LLM: Claude Opus 4.7 (1M) | high