### PR TITLE
feat: add bear_pullback_st short-focused strategy

### DIFF
--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -439,6 +439,12 @@ DEFAULT_PARAM_RANGES = {
         "entry_period": [10, 20, 30],
         "exit_period": [5, 10, 15],
     },
+    "bear_pullback_st": {
+        "ema_short": [13, 20, 26],
+        "ema_mid": [34, 50, 80],
+        "adx_threshold": [18, 20, 25],
+        "pullback_window": [3, 5, 8],
+    },
     "tp_at_pct": {
         "pct": [0.01, 0.03, 0.05],
     },

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -70,6 +70,7 @@ var knownShortNames = map[string]string{
 	"adx_trend":             "adxt",
 	"donchian_breakout":     "dbo",
 	"session_breakout":      "sbo",
+	"bear_pullback_st":      "bps",
 }
 
 // bidirectionalPerpsStrategies lists strategy IDs that emit signal=-1 as a
@@ -83,6 +84,7 @@ var bidirectionalPerpsStrategies = map[string]bool{
 	"donchian_breakout": true, // emits short on lower-channel breakdown (#649)
 	"chart_pattern":     true, // emits short on bearish patterns (double top, H&S, bear flag) (#649)
 	"liquidity_sweeps":  true, // emits short on stop-hunt wicks above swing highs (#649)
+	"bear_pullback_st":  true, // dedicated short-only strategy for bear-market rally rejections (#651)
 }
 
 func isBidirectionalPerpsStrategy(id string) bool {

--- a/shared_strategies/open/bear_pullback_st.py
+++ b/shared_strategies/open/bear_pullback_st.py
@@ -10,8 +10,7 @@ Rules
 5. Trigger: current close has lost EMA(short) (cross-down) OR closed below the
    prior bar's low — and the current close confirms by sitting below EMA(short).
 
-Emits ``signal = -1`` on the trigger bar; otherwise 0. Long-only platforms
-(spot) can register this strategy but it will never enter long.
+Emits ``signal = -1`` on the trigger bar; otherwise 0.
 """
 
 import numpy as np
@@ -31,6 +30,7 @@ def bear_pullback_st_core(
     rsi_lower: float = 55.0,
     rsi_upper: float = 65.0,
     pullback_window: int = 5,
+    pullback_touch_buffer_pct: float = 0.001,
 ) -> pd.DataFrame:
     """Generate short signals on failed rallies inside a bearish trend.
 
@@ -43,6 +43,9 @@ def bear_pullback_st_core(
     rsi_lower / rsi_upper : RSI band the rally must rebound into during the
         pullback window (default 55–65 — overbought relative to a bear trend)
     pullback_window : bars to look back for the rally touch + RSI rebound
+    pullback_touch_buffer_pct : fraction by which the bar's high must *exceed*
+        EMA(short)/EMA(mid) to count as a rally touch — separates real rallies
+        into resistance from noisy wicks tagging the EMA
 
     Returns
     -------
@@ -89,8 +92,14 @@ def bear_pullback_st_core(
     bearish_regime = result["ema_mid"] < result["ema_long"]
     strong_trend = result["adx"] > adx_threshold
 
-    # Rally into resistance: high pierced EMA(short) or EMA(mid) on a prior bar.
-    pullback_touch = (high >= result["ema_short"]) | (high >= result["ema_mid"])
+    # Rally into resistance: high must *exceed* EMA(short) or EMA(mid) by a
+    # buffer — guards against noisy wicks merely tagging the EMA in a downtrend.
+    touch_mult = 1.0 + pullback_touch_buffer_pct
+    pullback_touch = (high > result["ema_short"] * touch_mult) | (
+        high > result["ema_mid"] * touch_mult
+    )
+    # .shift(1) so the rally must have happened on a *prior* bar — we never let
+    # the trigger bar itself satisfy the touch/RSI condition.
     pullback_recent = (
         pullback_touch.shift(1).rolling(window=pullback_window).max().fillna(0).astype(bool)
     )

--- a/shared_strategies/open/bear_pullback_st.py
+++ b/shared_strategies/open/bear_pullback_st.py
@@ -1,0 +1,121 @@
+"""
+Bear Pullback Short — short bear-market rallies into resistance.
+
+Rules
+-----
+1. Bearish regime: EMA(mid) < EMA(long).
+2. Trend strength: ADX > threshold.
+3. Pullback into resistance: a recent bar's high touched EMA(short) or EMA(mid).
+4. RSI rebounded into [rsi_lower, rsi_upper] during the pullback window.
+5. Trigger: current close has lost EMA(short) (cross-down) OR closed below the
+   prior bar's low — and the current close confirms by sitting below EMA(short).
+
+Emits ``signal = -1`` on the trigger bar; otherwise 0. Long-only platforms
+(spot) can register this strategy but it will never enter long.
+"""
+
+import numpy as np
+import pandas as pd
+
+from adx_trend import _compute_adx_components
+
+
+def bear_pullback_st_core(
+    df: pd.DataFrame,
+    ema_short: int = 20,
+    ema_mid: int = 50,
+    ema_long: int = 200,
+    adx_period: int = 14,
+    adx_threshold: float = 20.0,
+    rsi_period: int = 14,
+    rsi_lower: float = 55.0,
+    rsi_upper: float = 65.0,
+    pullback_window: int = 5,
+) -> pd.DataFrame:
+    """Generate short signals on failed rallies inside a bearish trend.
+
+    Parameters
+    ----------
+    df : DataFrame with open, high, low, close columns
+    ema_short / ema_mid / ema_long : EMAs for the pullback magnet and regime filter
+    adx_period / adx_threshold : trend-strength gate (ADX > threshold)
+    rsi_period : Wilder RSI lookback
+    rsi_lower / rsi_upper : RSI band the rally must rebound into during the
+        pullback window (default 55–65 — overbought relative to a bear trend)
+    pullback_window : bars to look back for the rally touch + RSI rebound
+
+    Returns
+    -------
+    DataFrame with added columns:
+        signal      : -1 (short), 0 (no entry)
+        ema_short   : EMA(close, ema_short)
+        ema_mid     : EMA(close, ema_mid)
+        ema_long    : EMA(close, ema_long)
+        adx         : Wilder ADX (0 during warmup)
+        rsi         : Wilder RSI (NaN during warmup)
+    """
+    result = df.copy()
+    result["signal"] = 0
+
+    n = len(result)
+    min_len = max(ema_long, adx_period * 2, rsi_period) + pullback_window + 2
+    if n < min_len:
+        result["ema_short"] = result["close"].ewm(span=ema_short, adjust=False).mean()
+        result["ema_mid"] = result["close"].ewm(span=ema_mid, adjust=False).mean()
+        result["ema_long"] = result["close"].ewm(span=ema_long, adjust=False).mean()
+        result["adx"] = 0.0
+        result["rsi"] = np.nan
+        return result
+
+    close = result["close"]
+    high = result["high"]
+    low = result["low"]
+
+    result["ema_short"] = close.ewm(span=ema_short, adjust=False).mean()
+    result["ema_mid"] = close.ewm(span=ema_mid, adjust=False).mean()
+    result["ema_long"] = close.ewm(span=ema_long, adjust=False).mean()
+
+    comps = _compute_adx_components(high.values, low.values, close.values, adx_period)
+    result["adx"] = comps["adx"]
+
+    delta = close.diff()
+    gain = delta.clip(lower=0)
+    loss = (-delta).clip(lower=0)
+    avg_gain = gain.ewm(alpha=1 / rsi_period, min_periods=rsi_period, adjust=False).mean()
+    avg_loss = loss.ewm(alpha=1 / rsi_period, min_periods=rsi_period, adjust=False).mean()
+    rs = avg_gain / avg_loss
+    result["rsi"] = 100 - (100 / (1 + rs))
+
+    bearish_regime = result["ema_mid"] < result["ema_long"]
+    strong_trend = result["adx"] > adx_threshold
+
+    # Rally into resistance: high pierced EMA(short) or EMA(mid) on a prior bar.
+    pullback_touch = (high >= result["ema_short"]) | (high >= result["ema_mid"])
+    pullback_recent = (
+        pullback_touch.shift(1).rolling(window=pullback_window).max().fillna(0).astype(bool)
+    )
+
+    rsi_in_zone = (result["rsi"] >= rsi_lower) & (result["rsi"] <= rsi_upper)
+    rsi_recent = (
+        rsi_in_zone.shift(1).rolling(window=pullback_window).max().fillna(0).astype(bool)
+    )
+
+    prev_low = low.shift(1)
+    prev_ema_short = result["ema_short"].shift(1)
+    prev_close = close.shift(1)
+    trigger_lose_ema = (close < result["ema_short"]) & (prev_close >= prev_ema_short)
+    trigger_lower_low = close < prev_low
+    trigger = trigger_lose_ema | trigger_lower_low
+
+    confirm = close < result["ema_short"]
+
+    short_mask = (
+        bearish_regime
+        & strong_trend
+        & pullback_recent
+        & rsi_recent
+        & trigger
+        & confirm
+    )
+    result.loc[short_mask, "signal"] = -1
+    return result

--- a/shared_strategies/open/registry.py
+++ b/shared_strategies/open/registry.py
@@ -40,6 +40,7 @@ from liquidity_sweeps import liquidity_sweep_core
 from range_scalper import range_scalper_core
 from sweep_squeeze_combo import sweep_squeeze_combo_core
 from adx_trend import adx_trend_core
+from bear_pullback_st import bear_pullback_st_core
 from donchian_breakout import donchian_breakout_core
 from session_breakout import session_breakout_core
 
@@ -965,6 +966,21 @@ def donchian_breakout_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
 
 
 @register(
+    "bear_pullback_st",
+    "Bear Pullback Short — short bear-market rallies into EMA20/50 resistance with RSI rebound + ADX trend filter",
+    {
+        "ema_short": 20, "ema_mid": 50, "ema_long": 200,
+        "adx_period": 14, "adx_threshold": 20.0,
+        "rsi_period": 14, "rsi_lower": 55.0, "rsi_upper": 65.0,
+        "pullback_window": 5,
+    },
+    platforms=("futures",),
+)
+def bear_pullback_st_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return bear_pullback_st_core(df, **params)
+
+
+@register(
     "session_breakout",
     "Session Breakout — break of prior session (Asian/US open/US close) high/low with volume confirmation",
     {
@@ -1014,6 +1030,6 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "heikin_ashi_ema", "order_blocks", "vwap_reversion", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
         "sweep_squeeze_combo", "adx_trend", "delta_neutral_funding",
-        "donchian_breakout", "session_breakout", "hold",
+        "donchian_breakout", "session_breakout", "bear_pullback_st", "hold",
     ],
 }

--- a/shared_strategies/open/registry.py
+++ b/shared_strategies/open/registry.py
@@ -972,7 +972,7 @@ def donchian_breakout_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
         "ema_short": 20, "ema_mid": 50, "ema_long": 200,
         "adx_period": 14, "adx_threshold": 20.0,
         "rsi_period": 14, "rsi_lower": 55.0, "rsi_upper": 65.0,
-        "pullback_window": 5,
+        "pullback_window": 5, "pullback_touch_buffer_pct": 0.001,
     },
     platforms=("futures",),
 )

--- a/shared_strategies/open/test_bear_pullback_st.py
+++ b/shared_strategies/open/test_bear_pullback_st.py
@@ -1,0 +1,89 @@
+"""Tests for bear_pullback_st.py — Bear Pullback Short strategy."""
+
+import numpy as np
+import pandas as pd
+
+from bear_pullback_st import bear_pullback_st_core
+
+
+def make_ohlcv(closes, noise=0.5):
+    closes = np.array(closes, dtype=float)
+    n = len(closes)
+    return pd.DataFrame({
+        "open": closes - noise * 0.3,
+        "high": closes + noise,
+        "low": closes - noise,
+        "close": closes,
+        "volume": np.full(n, 100.0),
+    })
+
+
+def _bear_setup_with_rally_and_rejection():
+    """Build a long downtrend, a rally bouncing above EMA20/50, then a rejection.
+
+    The downtrend must be long enough for EMA200 to be above EMA50, ADX > 20,
+    and the rally must lift RSI into the 55–65 zone before the trigger bar.
+    """
+    rng = np.random.default_rng(42)
+    # 230 bars of downtrend from 200 → 110 with mild noise so ADX trends up.
+    down = np.linspace(200.0, 110.0, 230) + rng.normal(0, 0.4, 230)
+    # 10-bar rally up to 130 — overshoots the recent EMA20/50.
+    rally = np.linspace(110.0, 132.0, 10)
+    # Rejection: 4 bars closing back below the rally peak with progressively
+    # lower lows so the trigger fires.
+    reject = [128.0, 124.0, 119.0, 113.0]
+    closes = np.concatenate([down, rally, reject])
+    return make_ohlcv(closes)
+
+
+def test_emits_short_on_failed_rally_in_bear_trend():
+    df = _bear_setup_with_rally_and_rejection()
+    result = bear_pullback_st_core(df)
+    assert (result["signal"] == -1).any(), (
+        "Expected at least one short signal on rejection bars after a bear-trend rally"
+    )
+    # Signals should be confined to the post-rally rejection window (last 5 bars).
+    last_signals = result["signal"].iloc[-5:]
+    assert (last_signals == -1).any(), (
+        f"Short signal should land in the rejection window, got {last_signals.tolist()}"
+    )
+
+
+def test_no_long_signals_emitted():
+    """Strategy is short-only — signal must never be +1."""
+    df = _bear_setup_with_rally_and_rejection()
+    result = bear_pullback_st_core(df)
+    assert not (result["signal"] == 1).any(), "Strategy should never emit long signals"
+    assert set(result["signal"].unique()).issubset({-1, 0})
+
+
+def test_bullish_regime_blocks_shorts():
+    """In an uptrend (EMA50 > EMA200) the regime filter must veto every short."""
+    rng = np.random.default_rng(0)
+    closes = np.linspace(100.0, 200.0, 250) + rng.normal(0, 0.4, 250)
+    df = make_ohlcv(closes)
+    result = bear_pullback_st_core(df)
+    assert (result["signal"] == 0).all(), "Bullish regime must produce no short signals"
+
+
+def test_short_data_returns_zero_signal_without_crash():
+    df = make_ohlcv([100.0] * 50)
+    result = bear_pullback_st_core(df)
+    assert "signal" in result.columns
+    assert (result["signal"] == 0).all()
+    # Indicator columns are still attached so downstream consumers can inspect them.
+    for col in ("ema_short", "ema_mid", "ema_long", "adx", "rsi"):
+        assert col in result.columns
+
+
+def test_signal_values_valid():
+    df = _bear_setup_with_rally_and_rejection()
+    result = bear_pullback_st_core(df)
+    assert set(result["signal"].unique()).issubset({-1, 0, 1})
+
+
+def test_indicator_columns_exposed():
+    df = _bear_setup_with_rally_and_rejection()
+    result = bear_pullback_st_core(df)
+    for col in ("ema_short", "ema_mid", "ema_long", "adx", "rsi"):
+        assert col in result.columns, f"{col} column missing from output"

--- a/shared_strategies/open/test_bear_pullback_st.py
+++ b/shared_strategies/open/test_bear_pullback_st.py
@@ -87,3 +87,57 @@ def test_indicator_columns_exposed():
     result = bear_pullback_st_core(df)
     for col in ("ema_short", "ema_mid", "ema_long", "adx", "rsi"):
         assert col in result.columns, f"{col} column missing from output"
+
+
+def test_shallow_rally_below_rsi_zone_blocks_short():
+    """Bear regime + a rally too shallow to push RSI into [55, 65] must emit no signals.
+
+    The RSI gate is the most important quality filter — a rally that doesn't
+    actually overshoot momentum-wise shouldn't fire even if other gates pass.
+    """
+    rng = np.random.default_rng(7)
+    # Long downtrend so EMA50 < EMA200 and ADX is high.
+    down = np.linspace(200.0, 110.0, 230) + rng.normal(0, 0.4, 230)
+    # Tiny rally — only ~2% retrace, far too small to lift RSI into 55–65.
+    rally = np.linspace(110.0, 112.0, 6)
+    # Mild rejection bars so the price-action trigger could fire if the gates allowed it.
+    reject = [111.5, 110.8, 109.5, 108.0]
+    closes = np.concatenate([down, rally, reject])
+    df = make_ohlcv(closes)
+    result = bear_pullback_st_core(df)
+    # Confirm the regime + ADX gates would have allowed entries (sanity check —
+    # otherwise we're testing the wrong thing).
+    last = result.iloc[-1]
+    assert last["ema_mid"] < last["ema_long"], "Setup must produce a bearish regime"
+    assert last["adx"] > 20.0, "Setup must produce a strong trend"
+    # The shallow rally should never have lifted RSI into the 55–65 zone, so
+    # the RSI-recent gate vetoes every trigger.
+    rsi_tail = result["rsi"].iloc[-20:]
+    assert not ((rsi_tail >= 55.0) & (rsi_tail <= 65.0)).any(), (
+        f"Shallow-rally setup unexpectedly hit the RSI zone: {rsi_tail.tolist()}"
+    )
+    assert (result["signal"] == 0).all(), (
+        "Shallow rally must not produce any short signals"
+    )
+
+
+def test_buffer_rejects_wick_only_touch():
+    """A high that merely *grazes* EMA(short) without exceeding it by the
+    buffer must not satisfy the rally-touch gate.
+
+    Constructs a downtrend where the rally bar tops out exactly at EMA(short).
+    With ``pullback_touch_buffer_pct=0.01`` (1%), that wick fails to register
+    as a touch, so no short signal can fire even if the trigger gate trips.
+    """
+    rng = np.random.default_rng(13)
+    down = np.linspace(200.0, 110.0, 230) + rng.normal(0, 0.05, 230)
+    rally = np.linspace(110.0, 113.0, 6)
+    reject = [111.5, 110.8, 109.5, 108.0]
+    closes = np.concatenate([down, rally, reject])
+    df = make_ohlcv(closes, noise=0.05)
+    # 1% buffer is tighter than the gap between high and EMA(short) on this
+    # tame setup, so any touches above EMA(short) get filtered out.
+    result = bear_pullback_st_core(df, pullback_touch_buffer_pct=0.01)
+    assert (result["signal"] == 0).all(), (
+        "Wick-only touch (no buffer overshoot) should not produce a short signal"
+    )


### PR DESCRIPTION
Closes #651.

Dedicated short strategy for bear-market rallies into resistance: EMA50<EMA200 regime + ADX>20 trend strength + rally touch of EMA20/50 + RSI rebound into 55–65, then short on close losing fast EMA or prior low.

---
LLM: Claude Opus 4.7 (1M) | high | Harness: anthropics/claude-code-action@v1 | Tokens: 79 in / 21887 out | Cache: 4198249 read / 143970 written | Cost: $3.55