### PR TITLE
feat: add vwap_rejection_st short-focused strategy (#652)

### DIFF
--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -445,6 +445,13 @@ DEFAULT_PARAM_RANGES = {
         "adx_threshold": [18, 20, 25],
         "pullback_window": [3, 5, 8],
     },
+    "vwap_rejection_st": {
+        "ema_short": [13, 20, 26],
+        "ema_mid": [34, 50, 80],
+        "rsi_max_reclaim": [45.0, 50.0, 55.0],
+        "rally_window": [3, 5, 8],
+        "rally_touch_buffer_pct": [0.0005, 0.001, 0.002],
+    },
     "tp_at_pct": {
         "pct": [0.01, 0.03, 0.05],
     },

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -71,6 +71,7 @@ var knownShortNames = map[string]string{
 	"donchian_breakout":     "dbo",
 	"session_breakout":      "sbo",
 	"bear_pullback_st":      "bps",
+	"vwap_rejection_st":     "vrs",
 }
 
 // bidirectionalPerpsStrategies lists strategy IDs that emit signal=-1 as a
@@ -85,6 +86,7 @@ var bidirectionalPerpsStrategies = map[string]bool{
 	"chart_pattern":     true, // emits short on bearish patterns (double top, H&S, bear flag) (#649)
 	"liquidity_sweeps":  true, // emits short on stop-hunt wicks above swing highs (#649)
 	"bear_pullback_st":  true, // dedicated short-only strategy for bear-market rally rejections (#651)
+	"vwap_rejection_st": true, // dedicated short-only strategy for VWAP/EMA rally rejections in bearish regime (#652)
 }
 
 func isBidirectionalPerpsStrategy(id string) bool {

--- a/shared_strategies/open/registry.py
+++ b/shared_strategies/open/registry.py
@@ -43,6 +43,7 @@ from adx_trend import adx_trend_core
 from bear_pullback_st import bear_pullback_st_core
 from donchian_breakout import donchian_breakout_core
 from session_breakout import session_breakout_core
+from vwap_rejection_st import vwap_rejection_st_core
 
 
 VALID_PLATFORMS: Tuple[str, ...] = ("spot", "futures")
@@ -994,6 +995,20 @@ def session_breakout_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
 
 
 @register(
+    "vwap_rejection_st",
+    "VWAP Rejection Short — short weak rallies into session VWAP / EMA20 / EMA50 with RSI sub-50 + bearish EMA50<EMA200 regime",
+    {
+        "ema_short": 20, "ema_mid": 50, "ema_long": 200,
+        "rsi_period": 14, "rsi_max_reclaim": 50.0,
+        "rally_window": 5, "rally_touch_buffer_pct": 0.001,
+    },
+    platforms=("futures",),
+)
+def vwap_rejection_st_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return vwap_rejection_st_core(df, **params)
+
+
+@register(
     "hold",
     "Hold — always returns signal=0; used internally by type=manual strategies for the close-evaluator loop (#569)",
     {},
@@ -1030,6 +1045,7 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "heikin_ashi_ema", "order_blocks", "vwap_reversion", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
         "sweep_squeeze_combo", "adx_trend", "delta_neutral_funding",
-        "donchian_breakout", "session_breakout", "bear_pullback_st", "hold",
+        "donchian_breakout", "session_breakout", "bear_pullback_st",
+        "vwap_rejection_st", "hold",
     ],
 }

--- a/shared_strategies/open/test_vwap_rejection_st.py
+++ b/shared_strategies/open/test_vwap_rejection_st.py
@@ -1,0 +1,148 @@
+"""Tests for vwap_rejection_st.py — VWAP Rejection Short strategy."""
+
+import numpy as np
+import pandas as pd
+
+from vwap_rejection_st import vwap_rejection_st_core
+
+
+def make_ohlc(opens, highs, lows, closes, index, volume=100.0):
+    n = len(closes)
+    return pd.DataFrame(
+        {
+            "open": np.asarray(opens, dtype=float),
+            "high": np.asarray(highs, dtype=float),
+            "low": np.asarray(lows, dtype=float),
+            "close": np.asarray(closes, dtype=float),
+            "volume": np.full(n, float(volume)),
+        },
+        index=index,
+    )
+
+
+def make_ohlcv_from_closes(closes, index, noise=0.5):
+    closes = np.asarray(closes, dtype=float)
+    n = len(closes)
+    opens = closes - noise * 0.3
+    highs = closes + noise
+    lows = closes - noise
+    return make_ohlc(opens, highs, lows, closes, index)
+
+
+def _hourly_index(n: int, start: str = "2026-01-01 00:00:00") -> pd.DatetimeIndex:
+    return pd.date_range(start, periods=n, freq="1h")
+
+
+def _bear_setup_with_rally_and_rejection():
+    """Long multi-day hourly downtrend, then a same-day rally + rejection.
+
+    The rally is *contained inside the final session* so the daily-anchored
+    VWAP starts fresh near the rally's lows and gets pierced by the rally
+    high — this is the level the strategy expects price to reject from.
+    """
+    rng = np.random.default_rng(42)
+    # 230 hourly bars (~10 days) trending 200 → 110 — long enough for
+    # EMA200 to sit well above EMA50.
+    down = np.linspace(200.0, 110.0, 230) + rng.normal(0, 0.4, 230)
+    # 5-bar rally up to ~130 — overshoots EMA20/50 and pierces same-day VWAP.
+    rally = np.linspace(110.0, 130.0, 5)
+    # Rejection bars — engineered as red candles closing back below VWAP/EMA20.
+    reject_closes = [120.0, 113.0, 109.0, 106.0]
+    closes = np.concatenate([down, rally, reject_closes])
+    n = len(closes)
+    idx = _hourly_index(n)
+    df = make_ohlcv_from_closes(closes, idx, noise=0.4)
+    # Force the last 4 bars into clean red candles (open above close) so the
+    # rejection-trigger gate (close < open) actually fires.
+    for i, close_px in enumerate(reject_closes, start=len(down) + len(rally)):
+        prev_close = closes[i - 1]
+        df.iat[i, df.columns.get_loc("open")] = prev_close + 0.5
+        df.iat[i, df.columns.get_loc("high")] = prev_close + 1.0
+        df.iat[i, df.columns.get_loc("low")] = close_px - 1.0
+        df.iat[i, df.columns.get_loc("close")] = close_px
+    return df
+
+
+def test_emits_short_on_vwap_rejection_in_bear_trend():
+    df = _bear_setup_with_rally_and_rejection()
+    result = vwap_rejection_st_core(df)
+    assert (result["signal"] == -1).any(), (
+        "Expected at least one short signal on rejection bars after a VWAP/EMA rally"
+    )
+    last_signals = result["signal"].iloc[-5:]
+    assert (last_signals == -1).any(), (
+        f"Short signal should land in the rejection window, got {last_signals.tolist()}"
+    )
+
+
+def test_no_long_signals_emitted():
+    """Strategy is short-only — signal must never be +1."""
+    df = _bear_setup_with_rally_and_rejection()
+    result = vwap_rejection_st_core(df)
+    assert not (result["signal"] == 1).any(), "Strategy should never emit long signals"
+    assert set(result["signal"].unique()).issubset({-1, 0})
+
+
+def test_bullish_regime_blocks_shorts():
+    """In an uptrend (EMA50 > EMA200) the regime filter must veto every short."""
+    rng = np.random.default_rng(0)
+    closes = np.linspace(100.0, 200.0, 250) + rng.normal(0, 0.4, 250)
+    idx = _hourly_index(len(closes))
+    df = make_ohlcv_from_closes(closes, idx)
+    result = vwap_rejection_st_core(df)
+    assert (result["signal"] == 0).all(), "Bullish regime must produce no short signals"
+
+
+def test_short_data_returns_zero_signal_without_crash():
+    idx = _hourly_index(50)
+    df = make_ohlcv_from_closes([100.0] * 50, idx)
+    result = vwap_rejection_st_core(df)
+    assert "signal" in result.columns
+    assert (result["signal"] == 0).all()
+    for col in ("ema_short", "ema_mid", "ema_long", "vwap", "rsi"):
+        assert col in result.columns
+
+
+def test_indicator_columns_exposed():
+    df = _bear_setup_with_rally_and_rejection()
+    result = vwap_rejection_st_core(df)
+    for col in ("ema_short", "ema_mid", "ema_long", "vwap", "rsi"):
+        assert col in result.columns, f"{col} column missing from output"
+
+
+def test_rsi_reclaim_above_50_blocks_short():
+    """If RSI is forced above the reclaim cap, every trigger must be vetoed.
+
+    The RSI gate is the momentum filter — even with a textbook rally + red
+    rejection candle, RSI > rsi_max_reclaim says momentum has flipped and the
+    short setup is no longer valid.
+    """
+    df = _bear_setup_with_rally_and_rejection()
+    # Drop the cap to a value the trigger-bar RSI cannot satisfy.
+    result = vwap_rejection_st_core(df, rsi_max_reclaim=0.0)
+    assert (result["signal"] == 0).all(), (
+        "RSI reclaim gate at 0 must veto every short"
+    )
+
+
+def test_buffer_rejects_wick_only_touch():
+    """A high that merely *grazes* the resistance levels without exceeding the
+    buffer must not count as a rally touch.
+
+    Construct a tame setup where the rally bar's high sits very close to —
+    but never meaningfully above — VWAP/EMA(short). With a fat 50% buffer
+    nothing realistic can satisfy the touch gate, so no short signal can fire.
+    """
+    df = _bear_setup_with_rally_and_rejection()
+    # 50% buffer is far wider than any high-vs-EMA gap in the synthetic setup,
+    # so every touch is filtered out — proves the buffer gate is wired up.
+    result = vwap_rejection_st_core(df, rally_touch_buffer_pct=0.5)
+    assert (result["signal"] == 0).all(), (
+        "Buffer gate at 50% must veto every short — no high realistically overshoots that much"
+    )
+
+
+def test_signal_values_valid():
+    df = _bear_setup_with_rally_and_rejection()
+    result = vwap_rejection_st_core(df)
+    assert set(result["signal"].unique()).issubset({-1, 0, 1})

--- a/shared_strategies/open/test_vwap_rejection_st.py
+++ b/shared_strategies/open/test_vwap_rejection_st.py
@@ -146,3 +146,29 @@ def test_signal_values_valid():
     df = _bear_setup_with_rally_and_rejection()
     result = vwap_rejection_st_core(df)
     assert set(result["signal"].unique()).issubset({-1, 0, 1})
+
+
+def test_trigger_closes_below_every_rally_magnet():
+    """Every fired short must close back below VWAP AND EMA(short) AND EMA(mid).
+
+    Regression for PR #657 review: the rally check ORs three levels (VWAP,
+    EMA20, EMA50) but the original trigger only ANDed two (VWAP, EMA20).
+    A rally piercing only EMA(mid) could therefore fire a short whose
+    trigger bar close was still above EMA(mid) — the level that was
+    pierced never actually got rejected. Post-fix the trigger set mirrors
+    the rally set; this property test pins the invariant.
+    """
+    df = _bear_setup_with_rally_and_rejection()
+    result = vwap_rejection_st_core(df)
+    fired = result[result["signal"] == -1]
+    assert len(fired) > 0, "Setup should produce at least one short signal"
+    for ts, row in fired.iterrows():
+        assert row["close"] < row["vwap"], (
+            f"{ts}: close {row['close']} not below VWAP {row['vwap']}"
+        )
+        assert row["close"] < row["ema_short"], (
+            f"{ts}: close {row['close']} not below EMA(short) {row['ema_short']}"
+        )
+        assert row["close"] < row["ema_mid"], (
+            f"{ts}: close {row['close']} not below EMA(mid) {row['ema_mid']}"
+        )

--- a/shared_strategies/open/vwap_rejection_st.py
+++ b/shared_strategies/open/vwap_rejection_st.py
@@ -10,8 +10,12 @@ Rules
    resistance from a noisy wick tagging the level.
 3. RSI cannot reclaim 50: the trigger bar's RSI must sit at or below
    ``rsi_max_reclaim`` (default 50) — bearish momentum still in control.
-4. Trigger: a rejection candle — close < open AND close back below the rally's
-   reference (VWAP and EMA(short)) — confirms loss of reclaim.
+4. Trigger: a rejection candle — close < open AND close back below *every*
+   rally-magnet level (VWAP, EMA(short), and EMA(mid)) — confirms loss of
+   reclaim. The trigger set must mirror the rally set so a rally that
+   pierced only EMA(mid) (e.g. early-session bear-flag where VWAP/EMA20
+   already sit lower) cannot fire a short whose "rejection" never
+   actually closed back below the level that was pierced.
 
 Emits ``signal = -1`` on the trigger bar; otherwise 0.
 
@@ -113,7 +117,11 @@ def vwap_rejection_st_core(
     bearish_regime = result["ema_mid"] < result["ema_long"]
 
     # Rally into resistance: high must *exceed* VWAP / EMA(short) / EMA(mid) by
-    # the buffer. Wicks that only tag the level don't count.
+    # the buffer. Wicks that only tag the level don't count. The buffer is
+    # applied asymmetrically — overshoot side only — by design: we want a
+    # decisive pierce on the way up, but the rejection close below a level
+    # is meaningful even without buffer (a clean close-through is its own
+    # confirmation).
     touch_mult = 1.0 + rally_touch_buffer_pct
     rally_touch = (
         (high > result["vwap"] * touch_mult)
@@ -130,12 +138,14 @@ def vwap_rejection_st_core(
     rsi_capped = result["rsi"] <= rsi_max_reclaim
 
     # Rejection candle: red bar (close < open) sitting back below VWAP AND
-    # EMA(short). Both must be lost — a candle below VWAP that's still above
-    # EMA(short) is ambiguous.
+    # EMA(short) AND EMA(mid). All three rally magnets must be lost — the
+    # trigger set mirrors the rally set so whichever level was pierced gets
+    # rejected. A close below VWAP but still above EMA(mid) is ambiguous.
     red_bar = close < open_
     below_vwap = close < result["vwap"]
     below_ema_short = close < result["ema_short"]
-    trigger = red_bar & below_vwap & below_ema_short
+    below_ema_mid = close < result["ema_mid"]
+    trigger = red_bar & below_vwap & below_ema_short & below_ema_mid
 
     short_mask = bearish_regime & rally_recent & rsi_capped & trigger
     result.loc[short_mask, "signal"] = -1

--- a/shared_strategies/open/vwap_rejection_st.py
+++ b/shared_strategies/open/vwap_rejection_st.py
@@ -1,0 +1,142 @@
+"""
+VWAP Rejection Short — intraday short on weak rallies into VWAP / EMA20 / EMA50
+that fail to reclaim and roll over inside a bearish higher-timeframe regime.
+
+Rules
+-----
+1. Bearish regime: EMA(mid) < EMA(long) (e.g. EMA50 < EMA200) on the working frame.
+2. Rally into resistance: a recent bar's high *exceeded* session VWAP, EMA(short),
+   or EMA(mid) by ``rally_touch_buffer_pct`` — separates a real rally into
+   resistance from a noisy wick tagging the level.
+3. RSI cannot reclaim 50: the trigger bar's RSI must sit at or below
+   ``rsi_max_reclaim`` (default 50) — bearish momentum still in control.
+4. Trigger: a rejection candle — close < open AND close back below the rally's
+   reference (VWAP and EMA(short)) — confirms loss of reclaim.
+
+Emits ``signal = -1`` on the trigger bar; otherwise 0.
+
+Notes
+-----
+* VWAP is session-anchored using the bar's calendar date. Requires a
+  ``DatetimeIndex``; if absent the index is coerced via ``pd.to_datetime``.
+* Volume is needed for VWAP — flat-volume series still work but the VWAP
+  collapses to a typical-price moving anchor.
+"""
+
+import numpy as np
+import pandas as pd
+
+
+def _session_vwap(df: pd.DataFrame) -> pd.Series:
+    """Session-anchored VWAP keyed by calendar date.
+
+    Cumulative within each day so it resets at the session boundary, matching
+    how intraday traders read the level.
+    """
+    if isinstance(df.index, pd.DatetimeIndex):
+        day = df.index.date
+    else:
+        day = pd.to_datetime(df.index).date
+    typical = (df["high"] + df["low"] + df["close"]) / 3.0
+    tp_vol = typical * df["volume"]
+    grouped_tp = tp_vol.groupby(day).cumsum()
+    grouped_vol = df["volume"].groupby(day).cumsum()
+    # Avoid div-by-zero on zero-volume bars; fall back to typical price.
+    vwap = grouped_tp / grouped_vol.replace(0, np.nan)
+    return vwap.fillna(typical)
+
+
+def vwap_rejection_st_core(
+    df: pd.DataFrame,
+    ema_short: int = 20,
+    ema_mid: int = 50,
+    ema_long: int = 200,
+    rsi_period: int = 14,
+    rsi_max_reclaim: float = 50.0,
+    rally_window: int = 5,
+    rally_touch_buffer_pct: float = 0.001,
+) -> pd.DataFrame:
+    """Generate short signals on VWAP/EMA rejections inside a bearish regime.
+
+    Parameters
+    ----------
+    df : DataFrame with open, high, low, close, volume columns
+    ema_short / ema_mid / ema_long : EMAs for the rally magnet + regime filter
+    rsi_period : Wilder RSI lookback
+    rsi_max_reclaim : trigger bar RSI must be ≤ this (default 50 — momentum
+        still bearish; a clean reclaim above 50 invalidates the setup)
+    rally_window : bars to look back for the rally touch
+    rally_touch_buffer_pct : fraction by which the bar's high must *exceed*
+        VWAP / EMA(short) / EMA(mid) to count as a rally touch — guards against
+        wicks merely tagging the level
+
+    Returns
+    -------
+    DataFrame with added columns:
+        signal      : -1 (short), 0 (no entry)
+        ema_short   : EMA(close, ema_short)
+        ema_mid     : EMA(close, ema_mid)
+        ema_long    : EMA(close, ema_long)
+        vwap        : session-anchored VWAP
+        rsi         : Wilder RSI (NaN during warmup)
+    """
+    result = df.copy()
+    result["signal"] = 0
+
+    n = len(result)
+    min_len = max(ema_long, rsi_period) + rally_window + 2
+    if n < min_len:
+        result["ema_short"] = result["close"].ewm(span=ema_short, adjust=False).mean()
+        result["ema_mid"] = result["close"].ewm(span=ema_mid, adjust=False).mean()
+        result["ema_long"] = result["close"].ewm(span=ema_long, adjust=False).mean()
+        result["vwap"] = result["close"] if n == 0 else _session_vwap(result)
+        result["rsi"] = np.nan
+        return result
+
+    close = result["close"]
+    open_ = result["open"]
+    high = result["high"]
+
+    result["ema_short"] = close.ewm(span=ema_short, adjust=False).mean()
+    result["ema_mid"] = close.ewm(span=ema_mid, adjust=False).mean()
+    result["ema_long"] = close.ewm(span=ema_long, adjust=False).mean()
+    result["vwap"] = _session_vwap(result)
+
+    delta = close.diff()
+    gain = delta.clip(lower=0)
+    loss = (-delta).clip(lower=0)
+    avg_gain = gain.ewm(alpha=1 / rsi_period, min_periods=rsi_period, adjust=False).mean()
+    avg_loss = loss.ewm(alpha=1 / rsi_period, min_periods=rsi_period, adjust=False).mean()
+    rs = avg_gain / avg_loss
+    result["rsi"] = 100 - (100 / (1 + rs))
+
+    bearish_regime = result["ema_mid"] < result["ema_long"]
+
+    # Rally into resistance: high must *exceed* VWAP / EMA(short) / EMA(mid) by
+    # the buffer. Wicks that only tag the level don't count.
+    touch_mult = 1.0 + rally_touch_buffer_pct
+    rally_touch = (
+        (high > result["vwap"] * touch_mult)
+        | (high > result["ema_short"] * touch_mult)
+        | (high > result["ema_mid"] * touch_mult)
+    )
+    # .shift(1) so the rally must come from a *prior* bar — we never let the
+    # trigger bar itself satisfy the touch.
+    rally_recent = (
+        rally_touch.shift(1).rolling(window=rally_window).max().fillna(0).astype(bool)
+    )
+
+    # RSI cannot reclaim 50 on the trigger bar — bearish momentum gate.
+    rsi_capped = result["rsi"] <= rsi_max_reclaim
+
+    # Rejection candle: red bar (close < open) sitting back below VWAP AND
+    # EMA(short). Both must be lost — a candle below VWAP that's still above
+    # EMA(short) is ambiguous.
+    red_bar = close < open_
+    below_vwap = close < result["vwap"]
+    below_ema_short = close < result["ema_short"]
+    trigger = red_bar & below_vwap & below_ema_short
+
+    short_mask = bearish_regime & rally_recent & rsi_capped & trigger
+    result.loc[short_mask, "signal"] = -1
+    return result


### PR DESCRIPTION
Closes #652

Dedicated short strategy for intraday rejections off session VWAP / EMA20 / EMA50 inside a bearish higher-timeframe regime (EMA50 < EMA200). Trigger is a red rejection candle that closes back below VWAP and EMA(short) after a prior-bar rally pierced one of those levels by a configurable buffer; RSI on the trigger bar must sit at or below 50.

---
LLM: Claude Opus 4.7 (1M) | high | Harness: anthropics/claude-code-action@v1 | Tokens: 85 in / 25186 out | Cache: 5028358 read / 155982 written | Cost: $4.12