### PR TITLE
feat: add per-strategy direction gate (long/short/both) for perps

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -366,7 +366,7 @@ When the user says `/menu`, "show menu", "what can I configure", "what's availab
    Per-strategy: capital, max_drawdown_pct, interval_seconds, htf_filter,
      params, leverage, sizing_leverage, margin_per_trade_usd, stop_loss_pct,
      stop_loss_margin_pct, trailing_stop_pct, trailing_stop_atr_mult,
-     trailing_stop_min_move_pct, margin_mode, allow_shorts, open_strategy,
+     trailing_stop_min_move_pct, margin_mode, direction, open_strategy,
      close_strategies, allowed_regimes, theta_harvest.*
    Discord/Telegram: enabled, channels, trade_alert_channels, dm_channels, owner_id
    Environment: Discord token, status token, exchange credentials
@@ -547,7 +547,7 @@ Per-strategy:
 | HTF filter | `htf_filter` | Skips counter-trend signals |
 | Open strategy params | `open_strategy.params` | Per-open overrides; no longer a flat top-level `params` map (#640). Migrated from legacy on first start |
 | Close strategy params | `close_strategies[i].params` | Per-close evaluator overrides (e.g. `tiered_tp_atr.tiers`); each ref carries its own params so they don't leak into the open strategy |
-| Allow shorts | `allow_shorts` | Required for bidirectional perps |
+| Direction | `direction` | Perps gate: `"long"` (default), `"short"` (#656 — open shorts only), or `"both"` (bidirectional). Replaces legacy `allow_shorts`; v14 migration converts `false→"long"`, `true→"both"`. SIGHUP-aware when flat. |
 | Stop loss (price %) | `stop_loss_pct` | HL perps. Sole-owner auto-derives from `max_drawdown_pct` (cap 50) when omitted; same-coin peers need one explicit positive owner. `0` opts out. |
 | Stop loss (margin %) | `stop_loss_margin_pct` | HL perps — leverage-aware; mutually exclusive with the other four owners. `0` opts out. |
 | Fixed ATR stop | `stop_loss_atr_mult` | HL perps — trigger `avg_cost ± mult × entry_atr`, armed once after open. Top-level `default_stop_loss_atr_mult` defaults to `1.0` and applies to every HL perps with all five stop fields omitted (incl. shared-coin peers since #601) (#562/#601/#605); per-strategy `0` or top-level `0` restores `max_drawdown_pct` fallback. |
@@ -630,7 +630,7 @@ Short-name conventions:
 - TopStep: `ts-{strategy}-{symbol}`
 - Robinhood: `rh-{strategy_short}-{asset_or_symbol}`
 - OKX: `okx-{strategy_short}-{asset}` for spot/options, `okx-{strategy_short}-{asset}-perp` for perps
-- `triple_ema_bidir` is futures/perps only and needs `"allow_shorts": true`
+- `triple_ema_bidir` is futures/perps only and needs `"direction": "both"` (formerly `"allow_shorts": true`; v14 migrates automatically). Use `"direction": "short"` to run any bidirectional strategy as a dedicated bear-only instrument (#656).
 - `session_breakout` is futures/perps only; short name `sbo`
 - Multiple HL perps strategies on the same coin share an on-chain position; peers must agree on `margin_mode` and exchange `leverage` (`sizing_leverage` may differ). Since #601 each peer places its own per-strategy sized reduce-only protection, so multiple peers can own fixed ATR / margin / trailing stops simultaneously. `LoadConfig` defaults all-five-omitted peers to `default_stop_loss_atr_mult` (#562/#601/#605); set per-strategy `stop_loss_atr_mult: 0` (one) or top-level `default_stop_loss_atr_mult: 0` (fleet-wide) to opt out. **Per-strategy CB (#515):** drain skips on-chain close when peers share the coin — exchange leg stays open until another path flattens. Sub-account isolation is the only path for full per-strategy independence.
 

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -819,10 +819,10 @@ func hasHyperliquidTrailingStopOwnership(sc StrategyConfig) bool {
 // agree on exchange leverage and margin mode even though their virtual state
 // and close sizing are isolated.
 //
-// Note: AllowShorts mismatches across peers on the same coin are NOT
-// validated here. A long-only and a short-allowed strategy on the same HL
-// coin would silently net/flip at the position level — directional
-// independence requires HL sub-accounts (out of scope for #491).
+// Note: Direction (#656) mismatches across peers on the same coin are NOT
+// validated here. A direction="long" and a direction="short"/"both" peer on
+// the same HL coin would silently net/flip at the position level —
+// directional independence requires HL sub-accounts (out of scope for #491).
 //
 // Note: SizingLeverage is intentionally NOT required to match across peers
 // (#497). It only affects per-strategy order sizing — exchange margin and

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -291,14 +291,15 @@ const (
 	DirectionBoth  = "both"
 )
 
-// EffectiveDirection returns the canonical direction for a perps strategy:
-// "long" (signal=1 opens, signal=-1 closes long), "short" (signal=-1 opens,
-// signal=1 closes short), or "both" (bidirectional). Empty Direction falls
-// back to AllowShorts (legacy pre-v14): false→"long", true→"both". Non-perps
-// strategies always return "long" — direction is meaningful only for perps,
+// EffectiveDirection returns the canonical direction for a perps or manual
+// strategy: "long" (signal=1 opens, signal=-1 closes long), "short" (signal=-1
+// opens, signal=1 closes short), or "both" (bidirectional). Empty Direction
+// falls back to AllowShorts (legacy pre-v14): false→"long", true→"both".
+// Non-perps/manual strategies always return "long" — direction is meaningful
+// only for perps and manual (which trades HL perps via the manual-open CLI),
 // and validation rejects Direction on other types. (#656)
 func EffectiveDirection(sc StrategyConfig) string {
-	if sc.Type != "perps" {
+	if sc.Type != "perps" && sc.Type != "manual" {
 		return DirectionLong
 	}
 	switch sc.Direction {

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -228,7 +228,8 @@ type StrategyConfig struct {
 	MaxDrawdownPct         float64             `json:"max_drawdown_pct"`
 	IntervalSeconds        int                 `json:"interval_seconds,omitempty"`           // per-strategy override (0 = use global)
 	HTFFilter              bool                `json:"htf_filter,omitempty"`                 // higher-timeframe trend filter
-	AllowShorts            bool                `json:"allow_shorts,omitempty"`               // perps only: opt-in to bidirectional execution — signal=-1 from flat opens a short, long+(-1) closes-and-flips. Default false preserves close-long-only behavior for strategies like triple_ema that emit -1 only as a long-exit (#328)
+	AllowShorts            bool                `json:"allow_shorts,omitempty"`               // DEPRECATED — use Direction. Perps only; legacy boolean retained on the struct so pre-v14 JSON unmarshals cleanly. Read via EffectiveDirection / PerpsAllowsShort / PerpsAllowsLong, never directly. Migrated to Direction in v14 (#656).
+	Direction              string              `json:"direction,omitempty"`                  // perps only: "long" (default; signal=1 opens, signal=-1 closes long), "short" (signal=-1 opens, signal=1 closes short), "both" (bidirectional). Empty falls back to AllowShorts (legacy). v14 migration converts allow_shorts→direction. (#656)
 	Leverage               float64             `json:"leverage,omitempty"`                   // perps exchange leverage (default 1 = no leverage); used for exchange margin/risk and HL update_leverage (#254/#497)
 	SizingLeverage         float64             `json:"sizing_leverage,omitempty"`            // perps notional multiplier; defaults to Leverage for backwards compatibility (#497). Notional formula: notional = cash * sizing_leverage; size = notional / price. For margin-based sizing, prefer MarginPerTradeUSD (#518).
 	MarginPerTradeUSD      *float64            `json:"margin_per_trade_usd,omitempty"`       // perps only: USD margin to deploy per open. When set (positive), overrides SizingLeverage: notional = min(MarginPerTradeUSD, cash) * exchange_leverage; size = notional / price. Lets operators size in margin-space directly so high exchange_leverage doesn't decouple intent from outcome (#518).
@@ -281,6 +282,56 @@ func EffectiveMarginPerTradeUSD(sc StrategyConfig) float64 {
 		return 0
 	}
 	return *sc.MarginPerTradeUSD
+}
+
+// Direction enum constants for StrategyConfig.Direction (#656).
+const (
+	DirectionLong  = "long"
+	DirectionShort = "short"
+	DirectionBoth  = "both"
+)
+
+// EffectiveDirection returns the canonical direction for a perps strategy:
+// "long" (signal=1 opens, signal=-1 closes long), "short" (signal=-1 opens,
+// signal=1 closes short), or "both" (bidirectional). Empty Direction falls
+// back to AllowShorts (legacy pre-v14): false→"long", true→"both". Non-perps
+// strategies always return "long" — direction is meaningful only for perps,
+// and validation rejects Direction on other types. (#656)
+func EffectiveDirection(sc StrategyConfig) string {
+	if sc.Type != "perps" {
+		return DirectionLong
+	}
+	switch sc.Direction {
+	case DirectionLong, DirectionShort, DirectionBoth:
+		return sc.Direction
+	}
+	if sc.AllowShorts {
+		return DirectionBoth
+	}
+	return DirectionLong
+}
+
+// PerpsAllowsLong reports whether the strategy may open long positions —
+// i.e. EffectiveDirection is "long" or "both". (#656)
+func PerpsAllowsLong(sc StrategyConfig) bool {
+	d := EffectiveDirection(sc)
+	return d == DirectionLong || d == DirectionBoth
+}
+
+// PerpsAllowsShort reports whether the strategy may open short positions —
+// i.e. EffectiveDirection is "short" or "both". (#656)
+func PerpsAllowsShort(sc StrategyConfig) bool {
+	d := EffectiveDirection(sc)
+	return d == DirectionShort || d == DirectionBoth
+}
+
+// directionFromAllowShorts is the legacy bool→direction mapping used by
+// migration and by call sites that still pass the bool. (#656)
+func directionFromAllowShorts(allowShorts bool) string {
+	if allowShorts {
+		return DirectionBoth
+	}
+	return DirectionLong
 }
 
 // PerpsOpenNotional is the primitive sizing helper: returns the USD notional
@@ -1148,6 +1199,28 @@ func ValidateConfig(cfg *Config) error {
 			}
 			if *sc.MarginPerTradeUSD <= 0 {
 				errs = append(errs, fmt.Sprintf("%s: margin_per_trade_usd must be positive, got %g", prefix, *sc.MarginPerTradeUSD))
+			}
+		}
+
+		// #656: validate direction (perps only). Empty is allowed and falls
+		// back to AllowShorts via EffectiveDirection (legacy pre-v14 configs).
+		if sc.Direction != "" {
+			switch sc.Direction {
+			case DirectionLong, DirectionShort, DirectionBoth:
+			default:
+				errs = append(errs, fmt.Sprintf("%s: direction must be %q, %q, or %q, got %q", prefix, DirectionLong, DirectionShort, DirectionBoth, sc.Direction))
+			}
+			if sc.Type != "perps" && sc.Type != "manual" {
+				errs = append(errs, fmt.Sprintf("%s: direction is only supported for perps/manual strategies (got type %q)", prefix, sc.Type))
+			}
+			// Hand-edit detection: direction="long" alongside an explicit
+			// allow_shorts=true is contradictory (Direction wins; the
+			// AllowShorts=true is dead). Catch it so the operator can clean up.
+			// The opposite case (direction set, AllowShorts=false zero value)
+			// is indistinguishable from "AllowShorts not set in JSON" so we
+			// can't reliably warn about it.
+			if sc.AllowShorts && sc.Direction == DirectionLong {
+				errs = append(errs, fmt.Sprintf("%s: direction=%q conflicts with legacy allow_shorts=true (remove allow_shorts; v14 migration normally handles this)", prefix, sc.Direction))
 			}
 		}
 

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -573,9 +573,12 @@ func migrateV14Direction(raw map[string]interface{}) {
 		if !hadLegacy {
 			continue
 		}
-		// Skip non-perps types (allow_shorts was meaningless there; nothing
-		// to translate).
-		if stringFromJSON(sc["type"]) != "perps" {
+		// Skip types that never honored allow_shorts. Both perps and manual
+		// run on HL perps and consult Direction/EffectiveDirection, so both
+		// must translate; everything else is meaningless and dropped above.
+		switch stringFromJSON(sc["type"]) {
+		case "perps", "manual":
+		default:
 			continue
 		}
 		// If direction is already set explicitly, preserve it.

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -10,7 +10,7 @@ import (
 
 // CurrentConfigVersion is the version embedded in newly generated configs.
 // When the binary starts and cfg.ConfigVersion < CurrentConfigVersion, migration runs.
-const CurrentConfigVersion = 13
+const CurrentConfigVersion = 14
 
 // ConfigField describes a config field introduced in a specific version.
 type ConfigField struct {
@@ -89,6 +89,14 @@ const v9DeprecationNotice = "**Note:** HL perps strategies now auto-derive a per
 const v10DeprecationNotice = "**Note:** perps configs now distinguish `sizing_leverage` from exchange `leverage`. " +
 	"Migration copies existing perps `leverage` into `sizing_leverage` so old configs keep identical order sizing; " +
 	"`leverage` now represents the exchange leverage used for margin drawdown and HL `update_leverage`. See issue #497."
+
+// v14 replaces the legacy `allow_shorts: bool` field with `direction: "long"|"short"|"both"`,
+// unlocking dedicated short-only strategies (#656). Migration translates
+// allow_shorts=false→"long", allow_shorts=true→"both", deletes the old key.
+const v14DeprecationNotice = "**Note:** perps configs now use `direction: \"long\"|\"short\"|\"both\"` instead of `allow_shorts`. " +
+	"Migration converts `allow_shorts: false` → `direction: \"long\"` and `allow_shorts: true` → `direction: \"both\"`. " +
+	"The new `\"short\"` value lets you run a bidirectional strategy as a dedicated short-only instrument " +
+	"(useful with `allowed_regimes: [\"trending_down\"]`). See issue #656."
 
 const v7DeprecationNotice = "**Note:** `dm_paper_trades` and `dm_live_trades` have been replaced by a `dm_channels` map. " +
 	"Paper trades use `dm_channels[\"<platform>-paper\"]`; live trades use `dm_channels[\"<platform>\"]`. " +
@@ -182,6 +190,13 @@ func MigrateConfig(configPath string, fieldValues map[string]string, cfg *Config
 	// on the open ref. Any remaining empty `params` field is removed.
 	if oldVer < 13 {
 		migrateV13StrategyShape(raw)
+	}
+
+	// v14: convert legacy allow_shorts (bool) to direction (string enum)
+	// per #656. Each perps strategy gets `direction: "long"` or
+	// `direction: "both"` based on the old boolean; the field is removed.
+	if oldVer < 14 {
+		migrateV14Direction(raw)
 	}
 
 	raw["config_version"] = CurrentConfigVersion
@@ -406,6 +421,14 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 				fmt.Printf("[migration] %s\n", v10DeprecationNotice)
 			}
 		}
+		// v14: notify about allow_shorts → direction migration (#656).
+		if cfg.ConfigVersion < 14 {
+			if notifier != nil && notifier.HasOwner() {
+				notifier.SendOwnerDM(v14DeprecationNotice)
+			} else {
+				fmt.Printf("[migration] %s\n", v14DeprecationNotice)
+			}
+		}
 		return
 	}
 
@@ -436,6 +459,9 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 		}
 		if cfg.ConfigVersion < 10 {
 			fmt.Printf("[migration] %s\n", v10DeprecationNotice)
+		}
+		if cfg.ConfigVersion < 14 {
+			fmt.Printf("[migration] %s\n", v14DeprecationNotice)
 		}
 		return
 	}
@@ -486,6 +512,10 @@ func runConfigMigrationDM(cfg *Config, notifier *MultiNotifier, configPath strin
 	if cfg.ConfigVersion < 10 {
 		notifier.SendOwnerDM(v10DeprecationNotice)
 	}
+	// v14: notify about allow_shorts → direction migration (#656).
+	if cfg.ConfigVersion < 14 {
+		notifier.SendOwnerDM(v14DeprecationNotice)
+	}
 }
 
 // needsV13SchemaMigration reports whether the on-disk config still uses the
@@ -513,6 +543,51 @@ var closeStrategyOwnedKeys = map[string]map[string]struct{}{
 	"tiered_tp_atr_live": {"tiers": {}, "atr_source": {}},
 	"tiered_tp_pct":      {"tiers": {}},
 	"tp_at_pct":          {"pct": {}},
+}
+
+// migrateV14Direction translates the legacy boolean `allow_shorts` field on
+// each strategy into the new `direction` enum (#656). Only perps strategies
+// receive the new field; non-perps strategies have `allow_shorts` deleted
+// silently if present (it was always meaningless for non-perps types).
+//
+// Behavior preservation:
+//   - allow_shorts: false → direction: "long"
+//   - allow_shorts: true  → direction: "both"
+//
+// If the strategy already has a `direction` field (because the operator
+// pre-emptively set it before upgrading), we preserve it and just delete
+// the legacy key.
+func migrateV14Direction(raw map[string]interface{}) {
+	strategies, ok := raw["strategies"].([]interface{})
+	if !ok {
+		return
+	}
+	for _, item := range strategies {
+		sc, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		legacyAllow, hadLegacy := sc["allow_shorts"]
+		// Always drop the legacy key — it has no v14 semantics.
+		delete(sc, "allow_shorts")
+		if !hadLegacy {
+			continue
+		}
+		// Skip non-perps types (allow_shorts was meaningless there; nothing
+		// to translate).
+		if stringFromJSON(sc["type"]) != "perps" {
+			continue
+		}
+		// If direction is already set explicitly, preserve it.
+		if existing := strictStringFromJSON(sc["direction"]); existing != "" {
+			continue
+		}
+		if jsonBoolish(legacyAllow) {
+			sc["direction"] = "both"
+		} else {
+			sc["direction"] = "long"
+		}
+	}
 }
 
 // migrateV13StrategyShape rewrites each strategy in-place from the legacy flat

--- a/scheduler/config_migration_test.go
+++ b/scheduler/config_migration_test.go
@@ -1129,9 +1129,9 @@ func TestLoadConfigMigratesV12EndToEnd(t *testing.T) {
 // boolean values must map correctly, and the legacy key must be removed.
 func TestMigrateV14Direction(t *testing.T) {
 	cases := []struct {
-		name      string
-		strategy  map[string]interface{}
-		wantDir   string
+		name           string
+		strategy       map[string]interface{}
+		wantDir        string
 		wantLegacyKept bool // legacy key preserved (e.g. non-perps shouldn't get a direction)
 	}{
 		{
@@ -1165,6 +1165,26 @@ func TestMigrateV14Direction(t *testing.T) {
 				"allow_shorts": true,
 			},
 			wantDir: "",
+		},
+		// #656 review: type=manual trades HL perps and previously gated
+		// manual-open --side via allow_shorts. The migration must translate
+		// manual the same as perps, otherwise existing manual configs with
+		// allow_shorts:true silently regress to long-only post-v14.
+		{
+			name: "manual_allow_shorts_true_to_both",
+			strategy: map[string]interface{}{
+				"id": "hl-manual-eth", "type": "manual", "platform": "hyperliquid",
+				"allow_shorts": true,
+			},
+			wantDir: "both",
+		},
+		{
+			name: "manual_allow_shorts_false_to_long",
+			strategy: map[string]interface{}{
+				"id": "hl-manual-btc", "type": "manual", "platform": "hyperliquid",
+				"allow_shorts": false,
+			},
+			wantDir: "long",
 		},
 	}
 	for _, tc := range cases {

--- a/scheduler/config_migration_test.go
+++ b/scheduler/config_migration_test.go
@@ -1124,3 +1124,142 @@ func TestLoadConfigMigratesV12EndToEnd(t *testing.T) {
 		t.Error("re-load produced different OpenStrategy — migration is not idempotent")
 	}
 }
+
+// #656 — v14 migration converts allow_shorts:bool → direction:string. Both
+// boolean values must map correctly, and the legacy key must be removed.
+func TestMigrateV14Direction(t *testing.T) {
+	cases := []struct {
+		name      string
+		strategy  map[string]interface{}
+		wantDir   string
+		wantLegacyKept bool // legacy key preserved (e.g. non-perps shouldn't get a direction)
+	}{
+		{
+			name: "perps_allow_shorts_true_to_both",
+			strategy: map[string]interface{}{
+				"id": "hl-temab-eth", "type": "perps", "platform": "hyperliquid",
+				"allow_shorts": true,
+			},
+			wantDir: "both",
+		},
+		{
+			name: "perps_allow_shorts_false_to_long",
+			strategy: map[string]interface{}{
+				"id": "hl-tema-eth", "type": "perps", "platform": "hyperliquid",
+				"allow_shorts": false,
+			},
+			wantDir: "long",
+		},
+		{
+			name: "perps_already_has_direction_preserves",
+			strategy: map[string]interface{}{
+				"id": "hl-bear-eth", "type": "perps", "platform": "hyperliquid",
+				"allow_shorts": false, "direction": "short",
+			},
+			wantDir: "short", // direction wins, allow_shorts dropped
+		},
+		{
+			name: "non_perps_drops_legacy_key_no_direction",
+			strategy: map[string]interface{}{
+				"id": "bn-sma-btc", "type": "spot", "platform": "binanceus",
+				"allow_shorts": true,
+			},
+			wantDir: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := map[string]interface{}{
+				"strategies": []interface{}{tc.strategy},
+			}
+			migrateV14Direction(raw)
+
+			strategies := raw["strategies"].([]interface{})
+			sc := strategies[0].(map[string]interface{})
+			if _, leaked := sc["allow_shorts"]; leaked {
+				t.Errorf("allow_shorts must be deleted post-migration, got %+v", sc)
+			}
+			gotDir, _ := sc["direction"].(string)
+			if gotDir != tc.wantDir {
+				t.Errorf("direction = %q, want %q (full strategy: %+v)", gotDir, tc.wantDir, sc)
+			}
+		})
+	}
+}
+
+// #656 — full LoadConfig migration path: a v12 config with allow_shorts:true
+// must end up with Direction="both" and no AllowShorts in the parsed struct
+// (since the JSON key is gone). Mirror of the v13 schema-shape migration test.
+func TestLoadConfig_V14_TranslatesAllowShortsToDirection(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "v12.json")
+
+	v12 := map[string]interface{}{
+		"config_version": 12,
+		"strategies": []interface{}{
+			map[string]interface{}{
+				"id":               "hl-temab-eth",
+				"type":             "perps",
+				"platform":         "hyperliquid",
+				"script":           "shared_scripts/check_hyperliquid.py",
+				"args":             []interface{}{"triple_ema_bidir", "ETH", "1h", "--mode=paper"},
+				"open_strategy":    "triple_ema_bidir",
+				"capital":          1000.0,
+				"max_drawdown_pct": 25.0,
+				"leverage":         1.0,
+				"allow_shorts":     true,
+			},
+			map[string]interface{}{
+				"id":               "hl-tema-btc",
+				"type":             "perps",
+				"platform":         "hyperliquid",
+				"script":           "shared_scripts/check_hyperliquid.py",
+				"args":             []interface{}{"triple_ema", "BTC", "1h", "--mode=paper"},
+				"open_strategy":    "triple_ema",
+				"capital":          1000.0,
+				"max_drawdown_pct": 25.0,
+				"leverage":         1.0,
+				"allow_shorts":     false,
+			},
+		},
+	}
+	data, err := json.MarshalIndent(v12, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.ConfigVersion != CurrentConfigVersion {
+		t.Errorf("ConfigVersion = %d, want %d", cfg.ConfigVersion, CurrentConfigVersion)
+	}
+	byID := map[string]StrategyConfig{}
+	for _, sc := range cfg.Strategies {
+		byID[sc.ID] = sc
+	}
+	if got := byID["hl-temab-eth"].Direction; got != "both" {
+		t.Errorf("hl-temab-eth Direction = %q, want %q (allow_shorts=true)", got, "both")
+	}
+	if got := byID["hl-tema-btc"].Direction; got != "long" {
+		t.Errorf("hl-tema-btc Direction = %q, want %q (allow_shorts=false)", got, "long")
+	}
+	// Legacy field must be gone (zero value).
+	if byID["hl-temab-eth"].AllowShorts {
+		t.Error("hl-temab-eth AllowShorts should be false post-migration (key removed from JSON)")
+	}
+	if byID["hl-tema-btc"].AllowShorts {
+		t.Error("hl-tema-btc AllowShorts should be false post-migration")
+	}
+	// EffectiveDirection should agree.
+	if got := EffectiveDirection(byID["hl-temab-eth"]); got != DirectionBoth {
+		t.Errorf("EffectiveDirection(temab) = %q, want %q", got, DirectionBoth)
+	}
+	if got := EffectiveDirection(byID["hl-tema-btc"]); got != DirectionLong {
+		t.Errorf("EffectiveDirection(tema) = %q, want %q", got, DirectionLong)
+	}
+}

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -127,6 +127,16 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 			addChange("strategy[%s].trailing_stop_min_move_pct: %s -> %s", sc.ID, formatFloatPtrPct(sc.TrailingStopMinMovePct), formatFloatPtrPct(ns.TrailingStopMinMovePct))
 			sc.TrailingStopMinMovePct = ns.TrailingStopMinMovePct
 		}
+		// #656: direction (long|short|both) is hot-reloadable when flat. The
+		// state-compat check above blocks the change when positions are open;
+		// if we got here with a different direction, the strategy is flat and
+		// the next signal observes the new gate. Compare via EffectiveDirection
+		// so legacy AllowShorts toggles map cleanly.
+		if EffectiveDirection(*sc) != EffectiveDirection(ns) {
+			addChange("strategy[%s].direction: %q -> %q", sc.ID, EffectiveDirection(*sc), EffectiveDirection(ns))
+			sc.Direction = ns.Direction
+			sc.AllowShorts = ns.AllowShorts
+		}
 	}
 
 	if portfolioRiskMaxDrawdown(cfg.PortfolioRisk) != portfolioRiskMaxDrawdown(next.PortfolioRisk) {
@@ -292,6 +302,15 @@ func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error 
 			errs = append(errs, fmt.Sprintf("strategy[%s] leverage changed with open positions (%.2fx -> %.2fx; flatten first or restart after close)",
 				sc.ID, sc.Leverage, ns.Leverage))
 		}
+		// #656: direction change with open positions risks orphaning the
+		// existing side or flipping it on the next signal. Block until flat;
+		// numeric changes when flat take effect on the next cycle. Compares
+		// EffectiveDirection so legacy AllowShorts toggles map to "long"/"both"
+		// and behave identically.
+		if sc.Type == "perps" && EffectiveDirection(sc) != EffectiveDirection(ns) && strategyHasOpenPositions(stateStrategy(state, sc.ID)) {
+			errs = append(errs, fmt.Sprintf("strategy[%s] direction changed with open positions (%q -> %q; flatten first or restart after close)",
+				sc.ID, EffectiveDirection(sc), EffectiveDirection(ns)))
+		}
 		// #486: HL rejects margin-mode changes on an open position; treat
 		// the same way as Leverage. Stays hot-reloadable when flat.
 		if sc.Type == "perps" && sc.Platform == "hyperliquid" && sc.MarginMode != ns.MarginMode && strategyHasOpenPositions(stateStrategy(state, sc.ID)) {
@@ -350,6 +369,8 @@ func strategyRestartShape(sc StrategyConfig) StrategyConfig {
 	sc.TrailingStopATRMult = nil    // #505: hot-reloadable; same state-compat treatment as TrailingStopPct
 	sc.StopLossATRMult = nil        // #562: hot-reloadable; mode toggle blocked while open
 	sc.TrailingStopMinMovePct = nil // #501: hot-reloadable tuning knob for trailing trigger churn
+	sc.Direction = ""               // #656: hot-reloadable when flat; state-compat blocks change while open
+	sc.AllowShorts = false          // #656: legacy field — direction change is what gates hot reload
 	return sc
 }
 

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -306,8 +306,10 @@ func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error 
 		// existing side or flipping it on the next signal. Block until flat;
 		// numeric changes when flat take effect on the next cycle. Compares
 		// EffectiveDirection so legacy AllowShorts toggles map to "long"/"both"
-		// and behave identically.
-		if sc.Type == "perps" && EffectiveDirection(sc) != EffectiveDirection(ns) && strategyHasOpenPositions(stateStrategy(state, sc.ID)) {
+		// and behave identically. Manual strategies use the same Direction
+		// gate to authorize manual-open --side, so they get the same flatten-
+		// first guard for symmetry.
+		if (sc.Type == "perps" || sc.Type == "manual") && EffectiveDirection(sc) != EffectiveDirection(ns) && strategyHasOpenPositions(stateStrategy(state, sc.ID)) {
 			errs = append(errs, fmt.Sprintf("strategy[%s] direction changed with open positions (%q -> %q; flatten first or restart after close)",
 				sc.ID, EffectiveDirection(sc), EffectiveDirection(ns)))
 		}

--- a/scheduler/config_reload_test.go
+++ b/scheduler/config_reload_test.go
@@ -450,6 +450,58 @@ func minimalReloadConfig(strategies []StrategyConfig) *Config {
 	}
 }
 
+// #656 — direction change while a position is open must be rejected. Toggling
+// from "long" → "short" mid-position would either orphan the existing long or
+// flip it on the next signal; both desync virtual state from the exchange.
+func TestApplyHotReloadConfigRejectsDirectionChangeWithOpenPerpsPosition(t *testing.T) {
+	cfg := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, Direction: DirectionLong,
+	}})
+	next := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, Direction: DirectionShort,
+	}})
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-eth": {
+			ID: "hl-eth", Cash: 900,
+			RiskState: RiskState{MaxDrawdownPct: 10},
+			Positions: map[string]*Position{
+				"ETH": {Symbol: "ETH", Quantity: 1, Side: "long", AvgCost: 3000, Leverage: 2},
+			},
+		},
+	}}
+
+	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
+	if err == nil {
+		t.Fatal("expected direction change with open position to be rejected")
+	}
+	if !strings.Contains(err.Error(), "direction changed with open positions") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Strategies[0].Direction != DirectionLong {
+		t.Fatalf("current config mutated after rejected reload: %+v", cfg.Strategies[0])
+	}
+}
+
+// #656 — direction change is allowed when the strategy is flat.
+func TestApplyHotReloadConfigAllowsDirectionChangeWhenFlat(t *testing.T) {
+	cfg := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, Direction: DirectionLong,
+	}})
+	next := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, Direction: DirectionShort,
+	}})
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-eth": {ID: "hl-eth", Cash: 1000, Positions: map[string]*Position{}},
+	}}
+
+	if _, err := applyHotReloadConfig(cfg, next, state, nil, nil); err != nil {
+		t.Fatalf("expected direction change to be allowed when flat, got: %v", err)
+	}
+	if cfg.Strategies[0].Direction != DirectionShort {
+		t.Errorf("Direction = %q, want %q after applied reload", cfg.Strategies[0].Direction, DirectionShort)
+	}
+}
+
 func TestValidateHotReloadCompatible(t *testing.T) {
 	baseStrategy := StrategyConfig{
 		ID:             "spot-btc",

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -516,7 +516,15 @@ func generateConfig(opts InitOptions) *Config {
 			// short-opening execution, otherwise ExecutePerpsSignal drops
 			// their signal=-1 from flat and the strategy becomes effectively
 			// long-only at the executor layer (#328 review feedback).
-			allowShorts := isBidirectionalPerpsStrategy(stratID)
+			// #656: direction enum replaces allow_shorts. Bidirectional
+			// strategies default to "both"; long-only signal strategies get
+			// "long". The wizard does not auto-generate "short" — operators
+			// who want a dedicated short-only instrument edit direction
+			// post-init (typically alongside allowed_regimes=["trending_down"]).
+			direction := DirectionLong
+			if isBidirectionalPerpsStrategy(stratID) {
+				direction = DirectionBoth
+			}
 			for _, assetName := range opts.Assets {
 				id := fmt.Sprintf("hl-%s-%s", shortName, strings.ToLower(assetName))
 				cfg.Strategies = append(cfg.Strategies, StrategyConfig{
@@ -530,7 +538,7 @@ func generateConfig(opts InitOptions) *Config {
 					IntervalSeconds:   3600,
 					Leverage:          perpsLeverage,
 					SizingLeverage:    perpsSizingLeverage,
-					AllowShorts:       allowShorts,
+					Direction:         direction,
 					StopLossPct:       opts.HLStopLossPct,       // *float64 — nil falls through to MaxDrawdownPct (#484)
 					StopLossMarginPct: opts.HLStopLossMarginPct, // *float64 — nil falls through (#484/#487)
 					TrailingStopPct:   opts.HLTrailingStopPct,   // *float64 — synthetic high/low-water trailing stop (#501)

--- a/scheduler/init_test.go
+++ b/scheduler/init_test.go
@@ -750,10 +750,10 @@ func TestDeriveShortName(t *testing.T) {
 	}
 }
 
-// #328 — triple_ema_bidir must generate AllowShorts=true in perps configs so
-// ExecutePerpsSignal opens shorts from flat. Long-only strategies must keep
-// AllowShorts=false so they can't silently flip into short positions.
-func TestGenerateConfig_PerpsAllowShortsWiring(t *testing.T) {
+// #328/#656 — triple_ema_bidir must generate Direction="both" in perps
+// configs so ExecutePerpsSignal opens shorts from flat. Long-only strategies
+// must keep Direction="long" so they can't silently flip into short positions.
+func TestGenerateConfig_PerpsDirectionWiring(t *testing.T) {
 	opts := baseOpts()
 	opts.EnableSpot = false
 	opts.EnablePerps = true
@@ -771,14 +771,14 @@ func TestGenerateConfig_PerpsAllowShortsWiring(t *testing.T) {
 
 	cfg := generateConfig(opts)
 
-	want := map[string]bool{
-		"hl-temab-eth": true,  // bidirectional — must allow shorts
-		"hl-tema-eth":  false, // long-only — must NOT allow shorts
-		"hl-rmc-eth":   false, // long-only — must NOT allow shorts
-		"hl-sbo-eth":   true,  // bidirectional — must allow shorts (#371)
-		"hl-dbo-eth":   true,  // bidirectional — emits short on lower-channel breakdown (#649)
-		"hl-cpat-eth":  true,  // bidirectional — emits short on bearish patterns (#649)
-		"hl-liqsw-eth": true,  // bidirectional — emits short on stop-hunt wicks (#649)
+	want := map[string]string{
+		"hl-temab-eth": DirectionBoth, // bidirectional — must allow shorts
+		"hl-tema-eth":  DirectionLong, // long-only — must NOT allow shorts
+		"hl-rmc-eth":   DirectionLong, // long-only — must NOT allow shorts
+		"hl-sbo-eth":   DirectionBoth, // bidirectional — must allow shorts (#371)
+		"hl-dbo-eth":   DirectionBoth, // bidirectional — emits short on lower-channel breakdown (#649)
+		"hl-cpat-eth":  DirectionBoth, // bidirectional — emits short on bearish patterns (#649)
+		"hl-liqsw-eth": DirectionBoth, // bidirectional — emits short on stop-hunt wicks (#649)
 	}
 	seen := map[string]bool{}
 	for _, s := range cfg.Strategies {
@@ -787,8 +787,12 @@ func TestGenerateConfig_PerpsAllowShortsWiring(t *testing.T) {
 			continue
 		}
 		seen[s.ID] = true
-		if s.AllowShorts != expected {
-			t.Errorf("%s AllowShorts = %v, want %v", s.ID, s.AllowShorts, expected)
+		if s.Direction != expected {
+			t.Errorf("%s Direction = %q, want %q", s.ID, s.Direction, expected)
+		}
+		// Defensive: never emit the legacy AllowShorts boolean from generateConfig.
+		if s.AllowShorts {
+			t.Errorf("%s AllowShorts = true, want false (deprecated; use Direction)", s.ID)
 		}
 	}
 	for id := range want {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2418,8 +2418,8 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	//     (close path must free the trigger slot; flip path too, since the
 	//     new side gets a fresh SL below).
 	//   - place a new SL after the open leg unless the action is a pure close
-	//     (signal=-1 on a long without AllowShorts → no new position to
-	//     protect). Skip for non-HL platforms or when pct<=0.
+	//     (no new position will follow — see pureClose predicate below).
+	//     Skip for non-HL platforms or when pct<=0.
 	//   - on a flip, pass prev_pos_qty so the SL is sized against the new
 	//     net position (#421) — total_sz alone is closeQty+newQty.
 	// pureClose: the signal will close an existing position with no new open

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -151,11 +151,13 @@ func main() {
 		}
 	}
 
-	// #336: Detect perps shorts held under AllowShorts=false strategies. The
-	// executor can't reconcile this on its own — a fresh-open buy against an
-	// existing short nets on the exchange but flips virtually. Collect here,
-	// forward to owner DM once the notifier is wired below.
-	allowShortsWarnings := ValidatePerpsAllowShortsConfig(state, cfg)
+	// #336/#656: Detect perps positions whose side conflicts with the
+	// configured direction (e.g. a short under direction="long", or a long
+	// under direction="short"). The executor can't reconcile this on its
+	// own — a fresh-open signal against the conflicting position nets on
+	// the exchange but flips virtually. Collect here, forward to owner DM
+	// once the notifier is wired below.
+	directionConfigWarnings := ValidatePerpsDirectionConfig(state, cfg)
 
 	// #42 / #243: Initialize portfolio peak from sum of capitals on first run.
 	// For strategies that share an exchange wallet (e.g. multiple Hyperliquid
@@ -242,10 +244,10 @@ func main() {
 		}
 	}
 
-	// #336: Forward startup AllowShorts warnings to the owner so the desync is
-	// surfaced even when the operator isn't tailing stderr.
-	if len(allowShortsWarnings) > 0 && notifier.HasOwner() {
-		for _, msg := range allowShortsWarnings {
+	// #336/#656: Forward startup direction-vs-position warnings to the owner
+	// so the desync is surfaced even when the operator isn't tailing stderr.
+	if len(directionConfigWarnings) > 0 && notifier.HasOwner() {
+		for _, msg := range directionConfigWarnings {
 			notifier.SendOwnerDM("[state] " + msg)
 		}
 	}
@@ -2388,7 +2390,8 @@ func shouldCloseFullPosition(closeFraction float64, symbol string, hlLiveAll []S
 // issue #298 — 0.716 ETH of live fills were lost this way because the
 // "already long, skipping buy" branch sat AFTER RunHyperliquidExecute.
 func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, price, cash, posQty float64, posSide string, avgCost float64, existingStopLossOID int64, existingTPOIDs []int64, hlLiveAll []StrategyConfig, notifier *MultiNotifier, logger *StrategyLogger) (*HyperliquidExecuteResult, bool) {
-	if reason := PerpsOrderSkipReason(result.Signal, posSide, sc.AllowShorts); reason != "" {
+	directionEnum := EffectiveDirection(sc)
+	if reason := PerpsOrderSkipReason(result.Signal, posSide, directionEnum); reason != "" {
 		logger.Info("Skipping live order for %s: %s", result.Symbol, reason)
 		return nil, false
 	}
@@ -2399,7 +2402,7 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	sizingLeverage := EffectiveSizingLeverage(sc)
 	exchangeLeverage := EffectiveExchangeLeverage(sc)
 	marginPerTradeUSD := EffectiveMarginPerTradeUSD(sc)
-	size, ok, reason := perpsLiveOrderSize(result.Signal, price, cash, posQty, avgCost, sizingLeverage, exchangeLeverage, marginPerTradeUSD, posSide, sc.AllowShorts, result.CloseFraction)
+	size, ok, reason := perpsLiveOrderSize(result.Signal, price, cash, posQty, avgCost, sizingLeverage, exchangeLeverage, marginPerTradeUSD, posSide, directionEnum, result.CloseFraction)
 	if !ok {
 		logger.Info("%s for %s", reason, result.Symbol)
 		return nil, false
@@ -2419,7 +2422,19 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	//     protect). Skip for non-HL platforms or when pct<=0.
 	//   - on a flip, pass prev_pos_qty so the SL is sized against the new
 	//     net position (#421) — total_sz alone is closeQty+newQty.
-	pureClose := result.Signal == -1 && posSide == "long" && !sc.AllowShorts
+	// pureClose: the signal will close an existing position with no new open
+	// to follow. Holds for direction="long" + signal=-1 + long (close-only),
+	// direction="short" + signal=1 + short (close-only), and direction="both"
+	// only when there's nothing to flip into (never true here — flips always
+	// open a new side). Direction="short" + signal=-1 with orphan long is
+	// blocked by PerpsOrderSkipReason so it never reaches this code (#656).
+	pureClose := false
+	if result.Signal == -1 && posSide == "long" && !PerpsAllowsShort(sc) {
+		pureClose = true
+	}
+	if result.Signal == 1 && posSide == "short" && !PerpsAllowsLong(sc) {
+		pureClose = true
+	}
 	// Partial close (#519): a fractional close from the open/close registry
 	// must NOT cancel the resting stop-loss — the SL is reduce-only and will
 	// continue to protect the residual position; cancelling without
@@ -2427,13 +2442,13 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	// and the new-SL placement on partial close. The trailing-stop loop
 	// resizes the SL on its own cadence (#502).
 	partialClose := result.CloseFraction > 0 && result.CloseFraction < 1
-	// flipping predicate must mirror perpsLiveOrderSize exactly — both branches
-	// require sc.AllowShorts. A long-only strategy that inherited a short
-	// position (e.g. AllowShorts toggled true→false between restarts) would
-	// otherwise see prevPosQty=posQty here while perpsLiveOrderSize sized it
-	// as a fresh open without that offset, leaving net_new_sz negative and
-	// the SL silently undersized (#421 review point 6).
-	flipping := sc.AllowShorts && posQty > 0 && ((result.Signal == 1 && posSide == "short") || (result.Signal == -1 && posSide == "long"))
+	// flipping predicate must mirror perpsLiveOrderSize exactly — flips are
+	// only emitted under direction="both" (both directions allowed AND there's
+	// an opposite-side position to flip away from). A long-only strategy that
+	// inherited a short position would otherwise see prevPosQty=posQty here
+	// while perpsLiveOrderSize sized it as a fresh open without that offset,
+	// leaving net_new_sz negative and the SL silently undersized (#421 review).
+	flipping := EffectiveDirection(sc) == DirectionBoth && posQty > 0 && ((result.Signal == 1 && posSide == "short") || (result.Signal == -1 && posSide == "long"))
 	var cancelOID int64
 	if existingStopLossOID > 0 && posQty > 0 && !partialClose {
 		cancelOID = existingStopLossOID
@@ -2587,7 +2602,7 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, db *StateDB, 
 		fillFee = fill.Fee
 	}
 
-	trades, err := ExecutePerpsSignalWithLeverage(s, result.Signal, result.Symbol, fillPrice, sizingLeverage, exchangeLeverage, marginPerTradeUSD, fillQty, fillOID, fillFee, sc.AllowShorts, result.CloseFraction, logger)
+	trades, err := ExecutePerpsSignalWithLeverage(s, result.Signal, result.Symbol, fillPrice, sizingLeverage, exchangeLeverage, marginPerTradeUSD, fillQty, fillOID, fillFee, EffectiveDirection(sc), result.CloseFraction, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
@@ -3095,7 +3110,7 @@ func runOKXCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCt
 func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQty float64, posSide string, avgCost float64, notifier *MultiNotifier, logger *StrategyLogger) (*OKXExecuteResult, bool) {
 	var skip string
 	if sc.Type == "perps" {
-		skip = PerpsOrderSkipReason(result.Signal, posSide, sc.AllowShorts)
+		skip = PerpsOrderSkipReason(result.Signal, posSide, EffectiveDirection(sc))
 	} else {
 		skip = SpotOrderSkipReason(result.Signal, posSide)
 	}
@@ -3115,7 +3130,7 @@ func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQt
 	if sc.Type == "perps" {
 		var ok bool
 		var reason string
-		size, ok, reason = perpsLiveOrderSize(result.Signal, price, cash, posQty, avgCost, sizingLeverage, exchangeLeverage, marginPerTradeUSD, posSide, sc.AllowShorts, result.CloseFraction)
+		size, ok, reason = perpsLiveOrderSize(result.Signal, price, cash, posQty, avgCost, sizingLeverage, exchangeLeverage, marginPerTradeUSD, posSide, EffectiveDirection(sc), result.CloseFraction)
 		if !ok {
 			logger.Info("%s for %s", reason, result.Symbol)
 			return nil, false
@@ -3195,7 +3210,7 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *
 	var trades int
 	var err error
 	if sc.Type == "perps" {
-		trades, err = ExecutePerpsSignalWithLeverage(s, result.Signal, result.Symbol, fillPrice, EffectiveSizingLeverage(sc), EffectiveExchangeLeverage(sc), EffectiveMarginPerTradeUSD(sc), fillQty, fillOID, fillFee, sc.AllowShorts, result.CloseFraction, logger)
+		trades, err = ExecutePerpsSignalWithLeverage(s, result.Signal, result.Symbol, fillPrice, EffectiveSizingLeverage(sc), EffectiveExchangeLeverage(sc), EffectiveMarginPerTradeUSD(sc), fillQty, fillOID, fillFee, EffectiveDirection(sc), result.CloseFraction, logger)
 	} else {
 		trades, err = ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, fillOID, result.CloseFraction, logger)
 	}

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -54,8 +54,15 @@ func runManualOpen(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: --side must be \"long\" or \"short\", got %q\n", *side)
 		return 2
 	}
-	if !sc.AllowShorts && *side == "short" {
-		fmt.Fprintf(os.Stderr, "error: strategy %q does not allow shorts (set allow_shorts: true in config)\n", strategyID)
+	// #656: direction enum gates manual-open sides. direction="long" rejects
+	// --side short (legacy allow_shorts=false behavior); direction="short"
+	// rejects --side long; direction="both" allows either.
+	if *side == "short" && !PerpsAllowsShort(sc) {
+		fmt.Fprintf(os.Stderr, "error: strategy %q direction=%q does not allow shorts (set direction to %q or %q)\n", strategyID, EffectiveDirection(sc), DirectionShort, DirectionBoth)
+		return 1
+	}
+	if *side == "long" && !PerpsAllowsLong(sc) {
+		fmt.Fprintf(os.Stderr, "error: strategy %q direction=%q does not allow longs (set direction to %q or %q)\n", strategyID, EffectiveDirection(sc), DirectionLong, DirectionBoth)
 		return 1
 	}
 

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -503,47 +503,85 @@ func PortfolioValue(s *StrategyState, prices map[string]float64) float64 {
 // virtual state permanently behind actual exchange positions (#298).
 //
 // posSide is "" when no position exists; "long" or "short" otherwise.
-// allowShorts toggles the branches that ExecutePerpsSignal exposes when
-// bidirectional execution is enabled (#328):
-//   - allowShorts=false (legacy): signal=-1 with no long is a skip (close-long-only).
-//   - allowShorts=true: signal=-1 with no position opens a short; signal=-1
-//     while already short is a skip (mirrors "already long, skipping buy").
+// direction is the StrategyConfig.Direction enum (#656):
+//   - "long" (legacy): signal=-1 with no long is a skip (close-long-only); signal=1 only opens longs.
+//   - "short": signal=1 with no short is a skip (close-short-only); signal=-1 only opens shorts.
+//   - "both": bidirectional — signal=-1 with no position opens a short; signal=-1
+//     while already short is a skip (mirrors "already long, skipping buy"); signal=1
+//     opens long from flat or flips a short.
+//
+// Empty/unknown direction is treated as "long" for safety (matches the legacy
+// allow_shorts=false default).
 //
 // The `s.Cash < 1` branch inside the open paths is NOT mirrored here because
 // cash after a flip-close leg cannot be derived from (signal, posSide) alone —
 // live callers guard cash upstream before placing the order (see
 // runHyperliquidExecuteOrder). If a new side-based no-op branch is added to
 // ExecutePerpsSignal, add it here too.
-func PerpsOrderSkipReason(signal int, posSide string, allowShorts bool) string {
-	switch signal {
-	case 1:
-		if posSide == "long" {
-			return "already long, skipping buy"
+func PerpsOrderSkipReason(signal int, posSide, direction string) string {
+	switch direction {
+	case DirectionLong, "":
+		switch signal {
+		case 1:
+			if posSide == "long" {
+				return "already long, skipping buy"
+			}
+		case -1:
+			if posSide != "long" {
+				return "no long position to sell, skipping"
+			}
 		}
-	case -1:
-		if allowShorts {
+	case DirectionShort:
+		switch signal {
+		case 1:
+			if posSide != "short" {
+				return "no short position to buy-cover, skipping"
+			}
+		case -1:
 			if posSide == "short" {
 				return "already short, skipping sell"
 			}
-		} else if posSide != "long" {
-			return "no long position to sell, skipping"
+			// #656: orphan long under direction="short" must NOT place an
+			// open-short order. ExecutePerpsSignal would skip-and-warn, so
+			// skipping the live order here mirrors that and avoids the #298
+			// "live fill lands but no Trade recorded" gap.
+			if posSide == "long" {
+				return "orphan long under direction=\"short\", skipping (state-config gap)"
+			}
+		}
+	case DirectionBoth:
+		switch signal {
+		case 1:
+			if posSide == "long" {
+				return "already long, skipping buy"
+			}
+		case -1:
+			if posSide == "short" {
+				return "already short, skipping sell"
+			}
 		}
 	}
 	return ""
 }
 
 // perpsLiveOrderSize returns the market-order size to place for a live perps
-// execution. PerpsOrderSkipReason must already have passed (no skip). The
-// four cases:
+// execution. PerpsOrderSkipReason must already have passed (no skip).
 //
-//   - Fresh open (posQty <= 0):
-//   - signal=1           → size = PerpsOpenNotional(...)/price (long from flat)
-//   - signal=-1 + AllowShorts → size = PerpsOpenNotional(...)/price (short from flat)
-//   - Close-only (legacy, !AllowShorts):
-//   - signal=-1 + long   → size = posQty
-//   - Flip (AllowShorts + opposite-side position):
-//   - signal=1 + short   → size = posQty + PerpsOpenNotional(cash+closePnL,...)/price
-//   - signal=-1 + long   → size = posQty + PerpsOpenNotional(cash+closePnL,...)/price
+// direction is the StrategyConfig.Direction enum (#656). The four cases per
+// direction value:
+//
+//   - direction="long" (legacy long-only):
+//   - signal=1 + flat   → size = PerpsOpenNotional(...)/price (open long)
+//   - signal=1 + short  → size = posQty + new (legacy migrated short flip)
+//   - signal=-1 + long  → size = posQty (close-only)
+//   - direction="short" (#656 short-only):
+//   - signal=-1 + flat  → size = PerpsOpenNotional(...)/price (open short)
+//   - signal=1 + short  → size = posQty (close-only)
+//   - direction="both" (bidirectional):
+//   - signal=1 + flat   → fresh long
+//   - signal=-1 + flat  → fresh short
+//   - signal=1 + short  → flip = posQty + new
+//   - signal=-1 + long  → flip = posQty + new
 //
 // The flip branch is what this helper exists for: without `posQty + newSize`
 // a bidirectional scheduler tells ExecutePerpsSignal to virtually close+open
@@ -574,14 +612,26 @@ func PerpsOrderSkipReason(signal int, posSide string, allowShorts bool) string {
 // unreachable when closeFraction > 0 because compose_signal does not emit a
 // flip alongside a close (open_action is dropped while a position is open),
 // so closeFraction is intentionally ignored on the open/flip path.
-func perpsLiveOrderSize(signal int, price, cash, posQty, avgCost, sizingLeverage, exchangeLeverage, marginPerTradeUSD float64, posSide string, allowShorts bool, closeFraction float64) (size float64, ok bool, reason string) {
+func perpsLiveOrderSize(signal int, price, cash, posQty, avgCost, sizingLeverage, exchangeLeverage, marginPerTradeUSD float64, posSide, direction string, closeFraction float64) (size float64, ok bool, reason string) {
 	isBuy := signal == 1
-	flipping := allowShorts && posQty > 0 && ((isBuy && posSide == "short") || (!isBuy && posSide == "long"))
-	// Fresh open: buy always fresh-sizes (legacy buy-vs-migrated-short kept
-	// the pre-#330 fresh-open sizing for that edge case), or AllowShorts
-	// short-from-flat. Sell + !AllowShorts + no long is unreachable —
-	// PerpsOrderSkipReason handled it.
-	openingFresh := isBuy || (!isBuy && allowShorts && posQty <= 0)
+	allowsLong := direction == DirectionLong || direction == DirectionBoth || direction == ""
+	allowsShort := direction == DirectionShort || direction == DirectionBoth
+	// Flip only happens under bidirectional ("both"); a directional gate
+	// ("long"/"short") never flips because the opposite-direction signal is
+	// either a close-only (long-only sell on long, short-only buy on short)
+	// or has already been rejected by PerpsOrderSkipReason.
+	flipping := direction == DirectionBoth && posQty > 0 && ((isBuy && posSide == "short") || (!isBuy && posSide == "long"))
+	// Fresh open: a buy from flat under any direction that allows longs, or
+	// a sell from flat under any direction that allows shorts. Buy + short
+	// position under "long"-direction is the legacy-migrated-short edge case
+	// (pre-#330) that fresh-sizes without offset; #656 keeps that intact.
+	openingFresh := false
+	if isBuy && allowsLong && (posQty <= 0 || (posSide == "short" && direction == DirectionLong)) {
+		openingFresh = true
+	}
+	if !isBuy && allowsShort && posQty <= 0 {
+		openingFresh = true
+	}
 
 	if openingFresh || flipping {
 		effectiveCash := cash
@@ -719,8 +769,12 @@ func FuturesOrderSkipReason(signal int, posSide string) string {
 // which already closes-and-flips). When false (default), signal=-1 only
 // closes a long and never opens a short — the legacy long-only behavior
 // that strategies like triple_ema and rsi_macd_combo depend on.
+//
+// allowShorts maps to the direction enum (#656): false → "long",
+// true → "both". To get short-only semantics (#656), call
+// ExecutePerpsSignalWithDirection directly with direction="short".
 func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float64, leverage float64, fillQty float64, fillOID string, fillFee float64, allowShorts bool, logger *StrategyLogger) (int, error) {
-	return ExecutePerpsSignalWithLeverage(s, signal, symbol, price, leverage, leverage, 0, fillQty, fillOID, fillFee, allowShorts, 0, logger)
+	return ExecutePerpsSignalWithLeverage(s, signal, symbol, price, leverage, leverage, 0, fillQty, fillOID, fillFee, directionFromAllowShorts(allowShorts), 0, logger)
 }
 
 // ExecutePerpsSignalWithLeverage processes a perps signal.
@@ -733,7 +787,20 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 // never composes close+open in the same cycle). closeFraction == 0 preserves
 // the legacy full-close behavior used by direct strategy signals,
 // kill-switch, stop-loss, and forceCloseAllPositions paths.
-func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string, price float64, sizingLeverage, exchangeLeverage, marginPerTradeUSD float64, fillQty float64, fillOID string, fillFee float64, allowShorts bool, closeFraction float64, logger *StrategyLogger) (int, error) {
+//
+// direction (#656) gates the open-side branches:
+//   - "long": signal=1 opens long; signal=-1 closes long; never opens short.
+//   - "short": signal=-1 opens short; signal=1 closes short; never opens long.
+//   - "both": fully bidirectional (legacy AllowShorts=true).
+//
+// Empty direction is treated as "long" for safety.
+func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string, price float64, sizingLeverage, exchangeLeverage, marginPerTradeUSD float64, fillQty float64, fillOID string, fillFee float64, direction string, closeFraction float64, logger *StrategyLogger) (int, error) {
+	if direction == "" {
+		direction = DirectionLong
+	}
+	allowsLong := direction == DirectionLong || direction == DirectionBoth
+	allowsShort := direction == DirectionShort || direction == DirectionBoth
+	bidirectional := direction == DirectionBoth // flip semantics retained only for "both"
 	if signal == 0 {
 		return 0, nil
 	}
@@ -782,7 +849,11 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 					closeQty = pos.Quantity * closeFraction
 				}
 			}
-			if allowShorts {
+			// Flip semantics only under direction="both"; "short"-direction
+			// closes the short terminally (no open-long follows), and the
+			// legacy "long"-direction migrated-short close also has no flip
+			// counterpart that needs offsetting (open-long fresh-sizes from cash).
+			if bidirectional {
 				flipCloseQty = closeQty
 			}
 			var execPrice float64
@@ -792,7 +863,11 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 				execPrice = ApplySlippage(price)
 			}
 			pnl := closeQty * (pos.AvgCost - execPrice)
-			useFillFee := flipCloseQty > 0 || closeOnlyAction
+			// Terminal close: no open-long leg follows when this is a registry
+			// close-only action (#519) or when direction forbids long opens (#656).
+			// Either way the close leg owns the single live fill fee.
+			terminalClose := closeOnlyAction || !allowsLong
+			useFillFee := flipCloseQty > 0 || terminalClose
 			fee := executionFee(CalculatePlatformSpotFee(feePlatform, closeQty*execPrice), fillFee, useFillFee)
 			pnl -= fee
 			s.Cash += pnl
@@ -843,6 +918,15 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 		// (partial OR full) skips the open-leg path. Legacy direct-signal
 		// flips (closeFraction == 0) keep falling through.
 		if closeOnlyAction {
+			return tradesExecuted, nil
+		}
+		// #656: direction="short" closes shorts on signal=1 but never opens
+		// a long. PerpsOrderSkipReason already drops signal=1 from flat under
+		// "short", so this path is reached only after a close-short above.
+		if !allowsLong {
+			if tradesExecuted == 0 {
+				logger.Info("No short position in %s to buy-cover, skipping (direction=%q)", symbol, direction)
+			}
 			return tradesExecuted, nil
 		}
 		// Open long
@@ -915,15 +999,28 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 		tradesExecuted++
 
 	} else if signal == -1 { // Sell
-		// Dedupe: already short and allowShorts means nothing new to do —
-		// symmetric mirror of the "Already long ... skipping buy" branch at
-		// portfolio.go:408 in the signal==1 block above.
-		if pos, exists := s.Positions[symbol]; exists && pos.Side == "short" && allowShorts {
+		// Dedupe: already short under any direction that allows shorts —
+		// symmetric mirror of the "Already long ... skipping buy" branch
+		// in the signal==1 block above. Covers direction="short" (#656)
+		// and direction="both" (#328); under direction="long" (legacy),
+		// allowsShort=false so the migrated-short edge case falls through
+		// and is handled by the close-long branch (no match) + the
+		// "no long to sell" return at the bottom.
+		if pos, exists := s.Positions[symbol]; exists && pos.Side == "short" && allowsShort {
 			logger.Info("Already short %s (qty=%.6f), skipping sell", symbol, pos.Quantity)
 			return 0, nil
 		}
 		// Close long if exists — realize PnL.
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
+			// #656: direction="short" with an orphan long is a state-config
+			// gap (ValidatePerpsDirectionConfig surfaces it at startup). Don't
+			// auto-close here — silent flatten of an operator-seeded position
+			// is worse than leaving it visible. The orphan stays put; signal=1
+			// would also skip via PerpsOrderSkipReason.
+			if !allowsLong {
+				logger.Warn("Orphan long %s under direction=%q (qty=%.6f); leaving in place — close manually if intentional", symbol, direction, pos.Quantity)
+				return tradesExecuted, nil
+			}
 			closeQty := pos.Quantity
 			if partialClose {
 				if fillQty > 0 {
@@ -932,7 +1029,7 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 					closeQty = pos.Quantity * closeFraction
 				}
 			}
-			if allowShorts {
+			if bidirectional {
 				flipCloseQty = closeQty
 			}
 			var execPrice float64
@@ -942,7 +1039,10 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 				execPrice = ApplySlippage(price)
 			}
 			pnl := closeQty * (execPrice - pos.AvgCost)
-			useFillFee := flipCloseQty > 0 || !allowShorts || closeOnlyAction
+			// Terminal close: no open-short leg follows when this is a registry
+			// close-only action (#519) or when direction forbids short opens (#656).
+			terminalClose := closeOnlyAction || !allowsShort
+			useFillFee := flipCloseQty > 0 || terminalClose
 			fee := executionFee(CalculatePlatformSpotFee(feePlatform, closeQty*execPrice), fillFee, useFillFee)
 			pnl -= fee
 			s.Cash += pnl
@@ -993,16 +1093,16 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 		if closeOnlyAction {
 			return tradesExecuted, nil
 		}
-		// Legacy long-only path: whether we closed a long or had nothing to
-		// close, AllowShorts=false never opens a short. Log only when we did
-		// nothing (close-path already logged).
-		if !allowShorts {
+		// Long-only path: whether we closed a long or had nothing to close,
+		// direction="long" never opens a short. Log only when we did nothing
+		// (close-path already logged). #656: also gates direction="" defaulting.
+		if !allowsShort {
 			if tradesExecuted == 0 {
 				logger.Info("No long position in %s to sell, skipping", symbol)
 			}
 			return tradesExecuted, nil
 		}
-		// Open short (AllowShorts=true).
+		// Open short (direction="short" or "both").
 		if s.Cash < 1 {
 			logger.Info("Insufficient cash ($%.2f) to open short %s perp", s.Cash, symbol)
 			return tradesExecuted, nil

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -836,7 +836,14 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 
 	if signal == 1 { // Buy — go long (close short first if any)
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
-			logger.Info("Already long %s (qty=%.6f), skipping buy", symbol, pos.Quantity)
+			// #656 review: surface the state-config gap on signal=1 with an
+			// orphan long under direction="short" — symmetric with the
+			// orphan-long warning in the signal=-1 branch below.
+			if !allowsLong {
+				logger.Warn("Orphan long %s under direction=%q (qty=%.6f); skipping buy — close manually if intentional", symbol, direction, pos.Quantity)
+			} else {
+				logger.Info("Already long %s (qty=%.6f), skipping buy", symbol, pos.Quantity)
+			}
 			return 0, nil
 		}
 		// Close short if exists — realize PnL only (no notional swing).

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -1471,7 +1471,7 @@ func TestExecutePerpsSignal_DirectionShort_BuyClosesShort(t *testing.T) {
 
 	s := &StrategyState{
 		ID:       "hl-bear-eth",
-		Cash:    1000,
+		Cash:     1000,
 		Platform: "hyperliquid",
 		Type:     "perps",
 		Positions: map[string]*Position{
@@ -1508,7 +1508,7 @@ func TestExecutePerpsSignal_DirectionShort_OrphanLongNotAutoClosed(t *testing.T)
 
 	s := &StrategyState{
 		ID:       "hl-bear-eth",
-		Cash:    1000,
+		Cash:     1000,
 		Platform: "hyperliquid",
 		Type:     "perps",
 		Positions: map[string]*Position{
@@ -1545,7 +1545,7 @@ func TestExecutePerpsSignal_DirectionShort_AlreadyShortDedupes(t *testing.T) {
 
 	s := &StrategyState{
 		ID:       "hl-bear-eth",
-		Cash:    1000,
+		Cash:     1000,
 		Platform: "hyperliquid",
 		Type:     "perps",
 		Positions: map[string]*Position{
@@ -1572,11 +1572,11 @@ func TestExecutePerpsSignal_DirectionShort_AlreadyShortDedupes(t *testing.T) {
 // cross-product of {Direction set, AllowShorts legacy} for non-perps and perps.
 func TestEffectiveDirection_PrecedenceAndFallback(t *testing.T) {
 	cases := []struct {
-		name       string
-		sc         StrategyConfig
-		wantDir    string
-		wantLong   bool
-		wantShort  bool
+		name      string
+		sc        StrategyConfig
+		wantDir   string
+		wantLong  bool
+		wantShort bool
 	}{
 		{"perps_explicit_long", StrategyConfig{Type: "perps", Direction: DirectionLong}, DirectionLong, true, false},
 		{"perps_explicit_short", StrategyConfig{Type: "perps", Direction: DirectionShort}, DirectionShort, false, true},
@@ -1585,6 +1585,12 @@ func TestEffectiveDirection_PrecedenceAndFallback(t *testing.T) {
 		{"perps_legacy_allowshorts_false", StrategyConfig{Type: "perps", AllowShorts: false}, DirectionLong, true, false},
 		{"perps_unknown_falls_back", StrategyConfig{Type: "perps", Direction: "weird", AllowShorts: true}, DirectionBoth, true, true},
 		{"non_perps_always_long", StrategyConfig{Type: "spot", Direction: DirectionShort}, DirectionLong, true, false},
+		// #656 review: manual strategies trade HL perps via manual-open and
+		// must honor Direction/AllowShorts the same way perps do.
+		{"manual_explicit_short", StrategyConfig{Type: "manual", Direction: DirectionShort}, DirectionShort, false, true},
+		{"manual_explicit_both", StrategyConfig{Type: "manual", Direction: DirectionBoth}, DirectionBoth, true, true},
+		{"manual_legacy_allowshorts_true", StrategyConfig{Type: "manual", AllowShorts: true}, DirectionBoth, true, true},
+		{"manual_legacy_allowshorts_false", StrategyConfig{Type: "manual"}, DirectionLong, true, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -835,7 +835,7 @@ func TestExecutePerpsSignalDecouplesSizingAndExchangeLeverage(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, err := ExecutePerpsSignalWithLeverage(s, 1, "ETH", 2000, 2, 20, 0, 0, "", 0, false, 0, logger)
+	trades, err := ExecutePerpsSignalWithLeverage(s, 1, "ETH", 2000, 2, 20, 0, 0, "", 0, DirectionLong, 0, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1015,36 +1015,49 @@ func TestExecutePerpsSignalCloseLong(t *testing.T) {
 // ExecutePerpsSignal. Live execution paths consult this guard BEFORE placing
 // on-chain orders; a missed case re-introduces the "trade fills but isn't
 // recorded" gap that lost 0.716 ETH on Hyperliquid.
+//
+// #656 — direction enum replaces the allow_shorts boolean; cases cover all
+// three direction values plus the empty/legacy default.
 func TestPerpsOrderSkipReason(t *testing.T) {
 	cases := []struct {
-		name        string
-		signal      int
-		posSide     string
-		allowShorts bool
-		wantSet     bool
+		name      string
+		signal    int
+		posSide   string
+		direction string
+		wantSet   bool
 	}{
-		// Legacy (allowShorts=false) — long-only execution
-		{"buy_flat_allowed", 1, "", false, false},
-		{"buy_short_allowed_flip", 1, "short", false, false},
-		{"buy_long_skipped", 1, "long", false, true},
-		{"sell_long_allowed", -1, "long", false, false},
-		{"sell_flat_skipped", -1, "", false, true},
-		{"sell_short_skipped_legacy", -1, "short", false, true},
-		{"signal_zero_flat", 0, "", false, false},
-		{"signal_zero_long", 0, "long", false, false},
-		// #328 — AllowShorts opens short from flat and dedupes already-short
-		{"sell_flat_allowed_bidir", -1, "", true, false},
-		{"sell_short_deduped_bidir", -1, "short", true, true},
-		{"sell_long_allowed_bidir", -1, "long", true, false},
-		{"buy_long_still_skipped_bidir", 1, "long", true, true},
-		{"buy_short_flip_bidir", 1, "short", true, false},
+		// direction="long" (legacy AllowShorts=false) — long-only execution
+		{"buy_flat_allowed_long", 1, "", DirectionLong, false},
+		{"buy_short_allowed_flip_long", 1, "short", DirectionLong, false},
+		{"buy_long_skipped_long", 1, "long", DirectionLong, true},
+		{"sell_long_allowed_long", -1, "long", DirectionLong, false},
+		{"sell_flat_skipped_long", -1, "", DirectionLong, true},
+		{"sell_short_skipped_long", -1, "short", DirectionLong, true},
+		{"signal_zero_flat", 0, "", DirectionLong, false},
+		{"signal_zero_long", 0, "long", DirectionLong, false},
+		// Empty defaults to "long" semantics (back-compat with pre-#656 callers).
+		{"empty_dir_buy_long_skipped", 1, "long", "", true},
+		{"empty_dir_sell_flat_skipped", -1, "", "", true},
+		// direction="both" (legacy AllowShorts=true) — bidirectional
+		{"sell_flat_allowed_both", -1, "", DirectionBoth, false},
+		{"sell_short_deduped_both", -1, "short", DirectionBoth, true},
+		{"sell_long_allowed_both", -1, "long", DirectionBoth, false},
+		{"buy_long_skipped_both", 1, "long", DirectionBoth, true},
+		{"buy_short_flip_both", 1, "short", DirectionBoth, false},
+		// #656 direction="short" — short-only
+		{"sell_flat_allowed_short", -1, "", DirectionShort, false}, // open short from flat
+		{"sell_short_skipped_short", -1, "short", DirectionShort, true},
+		{"sell_long_skipped_short", -1, "long", DirectionShort, true}, // orphan long must skip (#298 class)
+		{"buy_short_allowed_short", 1, "short", DirectionShort, false},
+		{"buy_flat_skipped_short", 1, "", DirectionShort, true},
+		{"buy_long_skipped_short", 1, "long", DirectionShort, true}, // no short to cover
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := PerpsOrderSkipReason(tc.signal, tc.posSide, tc.allowShorts)
+			got := PerpsOrderSkipReason(tc.signal, tc.posSide, tc.direction)
 			if (got != "") != tc.wantSet {
-				t.Errorf("PerpsOrderSkipReason(%d, %q, allowShorts=%v) = %q, wantSet=%v",
-					tc.signal, tc.posSide, tc.allowShorts, got, tc.wantSet)
+				t.Errorf("PerpsOrderSkipReason(%d, %q, direction=%q) = %q, wantSet=%v",
+					tc.signal, tc.posSide, tc.direction, got, tc.wantSet)
 			}
 		})
 	}
@@ -1381,6 +1394,213 @@ func TestExecutePerpsSignalLegacyFlatNoShort(t *testing.T) {
 	}
 }
 
+// #656 — direction="short" opens short from flat on signal=-1, mirroring
+// direction="both" but rejecting any signal=1 from flat. This is the headline
+// new feature: existing bidirectional strategies can run as bear-only
+// instruments without writing dedicated short strategies.
+func TestExecutePerpsSignal_DirectionShort_OpenShortFromFlat(t *testing.T) {
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	s := &StrategyState{
+		ID:              "hl-bear-eth",
+		Cash:            1000,
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+	}
+
+	trades, err := ExecutePerpsSignalWithLeverage(s, -1, "ETH", 2000, 1, 1, 0, 0, "", 0, DirectionShort, 0, logger)
+	if err != nil {
+		t.Fatalf("ExecutePerpsSignalWithLeverage: %v", err)
+	}
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1 (open short under direction=short)", trades)
+	}
+	pos := s.Positions["ETH"]
+	if pos == nil || pos.Side != "short" {
+		t.Fatalf("expected short position, got %+v", pos)
+	}
+	if len(s.TradeHistory) != 1 || s.TradeHistory[0].Side != "sell" {
+		t.Errorf("expected one sell trade, got %+v", s.TradeHistory)
+	}
+}
+
+// #656 — direction="short" with signal=1 from flat must be a no-op (no short
+// to close, and longs are forbidden). Mirror of TestExecutePerpsSignalLegacyFlatNoShort
+// for the new short-only mode.
+func TestExecutePerpsSignal_DirectionShort_BuyFromFlatSkipped(t *testing.T) {
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	s := &StrategyState{
+		ID:              "hl-bear-eth",
+		Cash:            1000,
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+	}
+
+	trades, err := ExecutePerpsSignalWithLeverage(s, 1, "ETH", 2000, 1, 1, 0, 0, "", 0, DirectionShort, 0, logger)
+	if err != nil {
+		t.Fatalf("ExecutePerpsSignalWithLeverage: %v", err)
+	}
+	if trades != 0 {
+		t.Errorf("trades = %d, want 0 (signal=1 from flat is a no-op under direction=short)", trades)
+	}
+	if len(s.Positions) != 0 {
+		t.Error("no long should be opened under direction=short")
+	}
+	if s.Cash != 1000 {
+		t.Errorf("cash = %g, want unchanged 1000", s.Cash)
+	}
+}
+
+// #656 — direction="short" with signal=1 on an existing short closes the
+// short cleanly. Reduce-only behavior; no flip into long.
+func TestExecutePerpsSignal_DirectionShort_BuyClosesShort(t *testing.T) {
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	s := &StrategyState{
+		ID:       "hl-bear-eth",
+		Cash:    1000,
+		Platform: "hyperliquid",
+		Type:     "perps",
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2100, Side: "short", Multiplier: 1, Leverage: 1, OwnerStrategyID: "hl-bear-eth"},
+		},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+	}
+
+	trades, err := ExecutePerpsSignalWithLeverage(s, 1, "ETH", 2000, 1, 1, 0, 0, "", 0, DirectionShort, 0, logger)
+	if err != nil {
+		t.Fatalf("ExecutePerpsSignalWithLeverage: %v", err)
+	}
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1 (close short, no flip)", trades)
+	}
+	if _, exists := s.Positions["ETH"]; exists {
+		t.Error("position should be closed (no flip into long under direction=short)")
+	}
+	if len(s.TradeHistory) != 1 {
+		t.Fatalf("TradeHistory len = %d, want 1 (close leg only)", len(s.TradeHistory))
+	}
+	if !s.TradeHistory[0].IsClose {
+		t.Error("trade should be marked IsClose=true")
+	}
+}
+
+// #656 — direction="short" must NOT auto-close an orphan long (state-config
+// gap). The validator surfaces it; the executor leaves it visible.
+func TestExecutePerpsSignal_DirectionShort_OrphanLongNotAutoClosed(t *testing.T) {
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	s := &StrategyState{
+		ID:       "hl-bear-eth",
+		Cash:    1000,
+		Platform: "hyperliquid",
+		Type:     "perps",
+		Positions: map[string]*Position{
+			// Orphan long under short-only direction (e.g. operator flipped direction
+			// without first closing the position).
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2000, Side: "long", Multiplier: 1, Leverage: 1, OwnerStrategyID: "hl-bear-eth"},
+		},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+	}
+	cashBefore := s.Cash
+
+	trades, err := ExecutePerpsSignalWithLeverage(s, -1, "ETH", 2000, 1, 1, 0, 0, "", 0, DirectionShort, 0, logger)
+	if err != nil {
+		t.Fatalf("ExecutePerpsSignalWithLeverage: %v", err)
+	}
+	if trades != 0 {
+		t.Errorf("trades = %d, want 0 (orphan long must not be auto-closed)", trades)
+	}
+	if pos := s.Positions["ETH"]; pos == nil || pos.Side != "long" {
+		t.Error("orphan long should remain in place")
+	}
+	if s.Cash != cashBefore {
+		t.Errorf("cash should be unchanged on orphan-skip, got %g", s.Cash)
+	}
+}
+
+// #656 — direction="short" must NOT flip on signal=-1 with an existing short;
+// it dedupes (mirrors the "Already long ... skipping buy" branch).
+func TestExecutePerpsSignal_DirectionShort_AlreadyShortDedupes(t *testing.T) {
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	s := &StrategyState{
+		ID:       "hl-bear-eth",
+		Cash:    1000,
+		Platform: "hyperliquid",
+		Type:     "perps",
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2000, Side: "short", Multiplier: 1, Leverage: 1, OwnerStrategyID: "hl-bear-eth"},
+		},
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+	}
+	cashBefore := s.Cash
+
+	trades, err := ExecutePerpsSignalWithLeverage(s, -1, "ETH", 2000, 1, 1, 0, 0, "", 0, DirectionShort, 0, logger)
+	if err != nil {
+		t.Fatalf("ExecutePerpsSignalWithLeverage: %v", err)
+	}
+	if trades != 0 {
+		t.Errorf("trades = %d, want 0 (already short dedupe)", trades)
+	}
+	if s.Cash != cashBefore {
+		t.Errorf("cash should be unchanged on dedupe, got %g", s.Cash)
+	}
+}
+
+// #656 — EffectiveDirection / PerpsAllowsLong / PerpsAllowsShort cover the
+// cross-product of {Direction set, AllowShorts legacy} for non-perps and perps.
+func TestEffectiveDirection_PrecedenceAndFallback(t *testing.T) {
+	cases := []struct {
+		name       string
+		sc         StrategyConfig
+		wantDir    string
+		wantLong   bool
+		wantShort  bool
+	}{
+		{"perps_explicit_long", StrategyConfig{Type: "perps", Direction: DirectionLong}, DirectionLong, true, false},
+		{"perps_explicit_short", StrategyConfig{Type: "perps", Direction: DirectionShort}, DirectionShort, false, true},
+		{"perps_explicit_both", StrategyConfig{Type: "perps", Direction: DirectionBoth}, DirectionBoth, true, true},
+		{"perps_legacy_allowshorts_true", StrategyConfig{Type: "perps", AllowShorts: true}, DirectionBoth, true, true},
+		{"perps_legacy_allowshorts_false", StrategyConfig{Type: "perps", AllowShorts: false}, DirectionLong, true, false},
+		{"perps_unknown_falls_back", StrategyConfig{Type: "perps", Direction: "weird", AllowShorts: true}, DirectionBoth, true, true},
+		{"non_perps_always_long", StrategyConfig{Type: "spot", Direction: DirectionShort}, DirectionLong, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EffectiveDirection(tc.sc); got != tc.wantDir {
+				t.Errorf("EffectiveDirection = %q, want %q", got, tc.wantDir)
+			}
+			if got := PerpsAllowsLong(tc.sc); got != tc.wantLong {
+				t.Errorf("PerpsAllowsLong = %v, want %v", got, tc.wantLong)
+			}
+			if got := PerpsAllowsShort(tc.sc); got != tc.wantShort {
+				t.Errorf("PerpsAllowsShort = %v, want %v", got, tc.wantShort)
+			}
+		})
+	}
+}
+
 func TestExecutePerpsSignalLegacyCloseShortThenOpenLongUsesOpenFillFee(t *testing.T) {
 	lm, _ := NewLogManager("")
 	logger, _ := lm.GetStrategyLogger("test")
@@ -1534,30 +1754,34 @@ func TestPerpsLiveOrderSize_FlipIncludesCloseLeg(t *testing.T) {
 	// cash=1000, sizing_leverage=1, price=2000, avgCost=2000 (no PnL on close) →
 	// after #518 (no 0.95 buffer): newSize = 1000/2000 = 0.5
 	cases := []struct {
-		name       string
-		signal     int
-		posQty     float64
-		avgCost    float64
-		posSide    string
-		allowShort bool
-		wantSize   float64
-		wantOK     bool
+		name      string
+		signal    int
+		posQty    float64
+		avgCost   float64
+		posSide   string
+		direction string
+		wantSize  float64
+		wantOK    bool
 	}{
 		// Fresh opens — avgCost is 0 (no position)
-		{"long_from_flat", 1, 0, 0, "", false, 0.5, true},
-		{"short_from_flat_allowed", -1, 0, 0, "", true, 0.5, true},
-		// Close-only (legacy)
-		{"close_long_legacy", -1, 0.3, 2000, "long", false, 0.3, true},
-		// Flat-PnL flips: avgCost == price so effectiveCash == cash.
-		{"flip_long_to_short_flat_pnl", -1, 0.5, 2000, "long", true, 1.0, true}, // 0.5 + 0.5
-		{"flip_short_to_long_flat_pnl", 1, 0.5, 2000, "short", true, 1.0, true}, // 0.5 + 0.5
-		// Legacy buy against migrated short is NOT a flip (AllowShorts=false):
+		{"long_from_flat", 1, 0, 0, "", DirectionLong, 0.5, true},
+		{"short_from_flat_allowed_both", -1, 0, 0, "", DirectionBoth, 0.5, true},
+		// #656: short-only — open short from flat
+		{"short_from_flat_short_only", -1, 0, 0, "", DirectionShort, 0.5, true},
+		// Close-only (legacy long-direction)
+		{"close_long_legacy", -1, 0.3, 2000, "long", DirectionLong, 0.3, true},
+		// #656: short-direction close-short on signal=1
+		{"close_short_short_only", 1, 0.4, 2000, "short", DirectionShort, 0.4, true},
+		// Flat-PnL flips (direction="both" only): avgCost == price so effectiveCash == cash.
+		{"flip_long_to_short_flat_pnl", -1, 0.5, 2000, "long", DirectionBoth, 1.0, true}, // 0.5 + 0.5
+		{"flip_short_to_long_flat_pnl", 1, 0.5, 2000, "short", DirectionBoth, 1.0, true}, // 0.5 + 0.5
+		// Legacy buy against migrated short is NOT a flip (direction="long"):
 		// sizing stays at newSize — the legacy behavior pre-dating #328.
-		{"buy_vs_short_legacy_not_flip", 1, 0.5, 2000, "short", false, 0.5, true},
+		{"buy_vs_short_legacy_not_flip", 1, 0.5, 2000, "short", DirectionLong, 0.5, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			size, ok, reason := perpsLiveOrderSize(tc.signal, 2000, 1000, tc.posQty, tc.avgCost, 1.0, 1.0, 0, tc.posSide, tc.allowShort, 0)
+			size, ok, reason := perpsLiveOrderSize(tc.signal, 2000, 1000, tc.posQty, tc.avgCost, 1.0, 1.0, 0, tc.posSide, tc.direction, 0)
 			if ok != tc.wantOK {
 				t.Fatalf("ok = %v (reason=%q), want %v", ok, reason, tc.wantOK)
 			}
@@ -1573,7 +1797,7 @@ func TestPerpsLiveOrderSize_FlipIncludesCloseLeg(t *testing.T) {
 // (the old close-only behavior that silently broke bidirectional execution).
 func TestPerpsLiveOrderSize_FlipLongToShortExceedsCloseOnly(t *testing.T) {
 	posQty := 0.5
-	size, ok, _ := perpsLiveOrderSize(-1, 2000, 1000, posQty, 2000, 1.0, 1.0, 0, "long", true, 0)
+	size, ok, _ := perpsLiveOrderSize(-1, 2000, 1000, posQty, 2000, 1.0, 1.0, 0, "long", DirectionBoth, 0)
 	if !ok {
 		t.Fatal("expected ok")
 	}
@@ -1593,7 +1817,7 @@ func TestPerpsLiveOrderSize_FlipSizesAgainstPostCloseMargin(t *testing.T) {
 	// After #518 (no 0.95 buffer): new-side budget = 950 * 5 / 1900 = 2.5 →
 	// flip size = 0.5 + 2.5 = 3.0. Pre-close sizing (bug) would yield:
 	// 1000 * 5 / 1900 = 2.6316 → 3.1316, over-sized.
-	size, ok, reason := perpsLiveOrderSize(-1, 1900, 1000, 0.5, 2000, 5.0, 5.0, 0, "long", true, 0)
+	size, ok, reason := perpsLiveOrderSize(-1, 1900, 1000, 0.5, 2000, 5.0, 5.0, 0, "long", DirectionBoth, 0)
 	if !ok {
 		t.Fatalf("expected ok, got reason=%q", reason)
 	}
@@ -1617,7 +1841,7 @@ func TestPerpsLiveOrderSize_CatastrophicFlipDegradesToCloseOnly(t *testing.T) {
 	// long 1.0 ETH @ 2000, price crashes to 500, 1x leverage, cash=100.
 	// closePnL = 1.0 * (500 - 2000) = -1500 → effectiveCash = 100 - 1500 = -1400.
 	// PerpsOpenNotional returns 0 for non-positive cash → fallback to close-only.
-	size, ok, reason := perpsLiveOrderSize(-1, 500, 100, 1.0, 2000, 1.0, 1.0, 0, "long", true, 0)
+	size, ok, reason := perpsLiveOrderSize(-1, 500, 100, 1.0, 2000, 1.0, 1.0, 0, "long", DirectionBoth, 0)
 	if !ok {
 		t.Fatalf("expected ok (should degrade to close-only, not abort); reason=%q", reason)
 	}
@@ -1634,7 +1858,7 @@ func TestPerpsLiveOrderSize_FlipProfitableFlipUsesRealizedGain(t *testing.T) {
 	// Close leg realizes: 0.5 * (2000 - 1900) = +50 → post-close cash = 1050.
 	// After #518 (no 0.95 buffer): new-side budget = 1050 * 5 / 1900 = 2.7632 →
 	// flip size = 0.5 + 2.7632 = 3.2632.
-	size, ok, _ := perpsLiveOrderSize(1, 1900, 1000, 0.5, 2000, 5.0, 5.0, 0, "short", true, 0)
+	size, ok, _ := perpsLiveOrderSize(1, 1900, 1000, 0.5, 2000, 5.0, 5.0, 0, "short", DirectionBoth, 0)
 	if !ok {
 		t.Fatal("expected ok")
 	}
@@ -1715,7 +1939,7 @@ func TestExecutePerpsSignalMarginPerTradeUSDOverridesSizingLeverage(t *testing.T
 	// Mirrors issue #518: sizing_leverage=0.1, exchange leverage=20, price=2257.
 	// Without margin_per_trade_usd: notional = 560 * 0.1 = 56 → qty ≈ 0.025 ETH.
 	// With margin_per_trade_usd=56: notional = 56 * 20 = 1120 → qty ≈ 0.50 ETH.
-	trades, err := ExecutePerpsSignalWithLeverage(s, 1, "ETH", 2257, 0.1, 20, 56, 0, "", 0, false, 0, logger)
+	trades, err := ExecutePerpsSignalWithLeverage(s, 1, "ETH", 2257, 0.1, 20, 56, 0, "", 0, DirectionLong, 0, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1737,7 +1961,7 @@ func TestExecutePerpsSignalMarginPerTradeUSDOverridesSizingLeverage(t *testing.T
 // live order to match the residual it intends to leave behind.
 func TestPerpsLiveOrderSize_PartialCloseScalesPosQty(t *testing.T) {
 	// long 0.4 ETH @ 2000, signal=-1 (close), fraction=0.5 → size 0.2.
-	size, ok, reason := perpsLiveOrderSize(-1, 2100, 1000, 0.4, 2000, 1.0, 1.0, 0, "long", false, 0.5)
+	size, ok, reason := perpsLiveOrderSize(-1, 2100, 1000, 0.4, 2000, 1.0, 1.0, 0, "long", DirectionLong, 0.5)
 	if !ok {
 		t.Fatalf("expected ok, got reason=%q", reason)
 	}
@@ -1750,7 +1974,7 @@ func TestPerpsLiveOrderSize_PartialCloseScalesPosQty(t *testing.T) {
 // pin: don't accidentally re-scale the close leg on a complete tier hit.
 func TestPerpsLiveOrderSize_FullCloseFractionIsFullPosQty(t *testing.T) {
 	for _, frac := range []float64{0, 1.0} {
-		size, ok, _ := perpsLiveOrderSize(-1, 2100, 1000, 0.4, 2000, 1.0, 1.0, 0, "long", false, frac)
+		size, ok, _ := perpsLiveOrderSize(-1, 2100, 1000, 0.4, 2000, 1.0, 1.0, 0, "long", DirectionLong, frac)
 		if !ok || math.Abs(size-0.4) > 1e-9 {
 			t.Errorf("frac=%g: size = %g (ok=%v), want 0.4", frac, size, ok)
 		}
@@ -1788,7 +2012,7 @@ func TestExecutePerpsSignal_PartialCloseLongPaperPreservesRemainder(t *testing.T
 	defer logger.Close()
 
 	// Close 0.5 of 0.4 ETH @ 2100 (+5% from cost). closeFraction=0.5.
-	trades, err := ExecutePerpsSignalWithLeverage(s, -1, "ETH", 2100, 1, 1, 0, 0, "", 0, false, 0.5, logger)
+	trades, err := ExecutePerpsSignalWithLeverage(s, -1, "ETH", 2100, 1, 1, 0, 0, "", 0, DirectionLong, 0.5, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1860,7 +2084,7 @@ func TestExecutePerpsSignal_PartialCloseDoesNotFlipShortWithAllowShorts(t *testi
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, err := ExecutePerpsSignalWithLeverage(s, -1, "ETH", 2100, 1, 1, 0, 0, "", 0, true /*allowShorts*/, 0.5, logger)
+	trades, err := ExecutePerpsSignalWithLeverage(s, -1, "ETH", 2100, 1, 1, 0, 0, "", 0, DirectionBoth, 0.5, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1909,7 +2133,7 @@ func TestExecutePerpsSignal_FullCloseFromRegistryDoesNotFlip(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, err := ExecutePerpsSignalWithLeverage(s, -1, "ETH", 2100, 1, 1, 0, 0, "", 0, true /*allowShorts*/, 1.0, logger)
+	trades, err := ExecutePerpsSignalWithLeverage(s, -1, "ETH", 2100, 1, 1, 0, 0, "", 0, DirectionBoth, 1.0, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1953,7 +2177,7 @@ func TestExecutePerpsSignal_PartialCloseLongLiveUsesFillQty(t *testing.T) {
 	// fillQty=0.18 (slightly below the 0.2 the order requested due to
 	// exchange rounding). closeFraction signals "partial" but the actual
 	// closed qty must come from fillQty.
-	_, err := ExecutePerpsSignalWithLeverage(s, -1, "ETH", 2100, 1, 1, 0, 0.18, "live-oid", 0.05, false, 0.5, logger)
+	_, err := ExecutePerpsSignalWithLeverage(s, -1, "ETH", 2100, 1, 1, 0, 0.18, "live-oid", 0.05, DirectionLong, 0.5, logger)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scheduler/regime_test.go
+++ b/scheduler/regime_test.go
@@ -217,9 +217,9 @@ func TestStrategyDecisionFields_RegimeOmitEmpty(t *testing.T) {
 
 // ─── Config version bump ──────────────────────────────────────────────────────
 
-func TestCurrentConfigVersion_IsThirteen(t *testing.T) {
-	if CurrentConfigVersion != 13 {
-		t.Errorf("expected CurrentConfigVersion=13, got %d", CurrentConfigVersion)
+func TestCurrentConfigVersion_IsFourteen(t *testing.T) {
+	if CurrentConfigVersion != 14 {
+		t.Errorf("expected CurrentConfigVersion=14, got %d", CurrentConfigVersion)
 	}
 }
 

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -217,23 +217,33 @@ func migrateLegacyPerpsPositionMultipliers(state *AppState, cfg *Config) int {
 	return migrated
 }
 
-// ValidatePerpsAllowShortsConfig flags short positions that belong to a perps
-// strategy currently configured with AllowShorts=false (#336). The desync can
-// arise from state migration, paper→live handoff, operator edits of state.db,
-// or a config toggle from true→false without first closing the short. When the
-// strategy next emits a buy signal, the executor's fresh-open sizing will
-// collide with the pre-existing short and leave virtual state out of sync with
-// the exchange. We warn-and-continue (matching ValidateState's precedent)
-// rather than force-closing — marks may be unavailable at startup and silent
-// auto-close of an operator-seeded position is worse than a loud warning.
+// ValidatePerpsDirectionConfig flags positions whose side conflicts with the
+// strategy's configured direction (#336/#656). Two gap classes:
+//
+//  1. direction="long" with a short position (legacy AllowShorts=false). The
+//     desync can arise from state migration, paper→live handoff, operator
+//     state.db edits, or a "both"→"long" config toggle without first closing.
+//  2. direction="short" with a long position (#656 short-only mode). The
+//     symmetric gap arises from a "long"→"short" config toggle without
+//     closing, or operator edits.
+//
+// In either case the strategy's next signal-driven order will desync virtual
+// state from the exchange. We warn-and-continue (matching ValidateState's
+// precedent) rather than force-closing — marks may be unavailable at startup
+// and silent auto-close of an operator-seeded position is worse than a loud
+// warning.
 //
 // Returns human-readable warnings so the caller can both log them and forward
 // to the operator via DM once the notifier is ready.
-func ValidatePerpsAllowShortsConfig(state *AppState, cfg *Config) []string {
+func ValidatePerpsDirectionConfig(state *AppState, cfg *Config) []string {
 	var warnings []string
 	for i := range cfg.Strategies {
 		sc := &cfg.Strategies[i]
-		if sc.Type != "perps" || sc.AllowShorts {
+		if sc.Type != "perps" {
+			continue
+		}
+		direction := EffectiveDirection(*sc)
+		if direction == DirectionBoth {
 			continue
 		}
 		s, ok := state.Strategies[sc.ID]
@@ -241,10 +251,21 @@ func ValidatePerpsAllowShortsConfig(state *AppState, cfg *Config) []string {
 			continue
 		}
 		for sym, pos := range s.Positions {
-			if pos.Side != "short" {
+			var conflictSide string
+			switch direction {
+			case DirectionLong:
+				if pos.Side == "short" {
+					conflictSide = "short"
+				}
+			case DirectionShort:
+				if pos.Side == "long" {
+					conflictSide = "long"
+				}
+			}
+			if conflictSide == "" {
 				continue
 			}
-			msg := fmt.Sprintf("perps state-vs-config gap: strategy %s has short %s qty=%g (AllowShorts=false). Position was likely seeded by migration, paper→live handoff, or a prior AllowShorts=true config. Close manually before the next buy signal — the executor's fresh-open sizing will otherwise desync virtual state from the exchange.", sc.ID, sym, pos.Quantity)
+			msg := fmt.Sprintf("perps state-vs-config gap: strategy %s has %s %s qty=%g (direction=%q). Position was likely seeded by migration, paper→live handoff, or a prior conflicting direction. Close manually before the next signal — the executor's fresh-open sizing will otherwise desync virtual state from the exchange.", sc.ID, conflictSide, sym, pos.Quantity, direction)
 			fmt.Printf("[WARN] %s\n", msg)
 			warnings = append(warnings, msg)
 		}

--- a/scheduler/state_test.go
+++ b/scheduler/state_test.go
@@ -112,18 +112,18 @@ func TestValidateState(t *testing.T) {
 	}
 }
 
-// TestValidatePerpsAllowShortsConfig exercises the #336 startup check: a short
-// position seeded into SQLite (via migration, paper→live handoff, or operator
-// edit) under a perps strategy whose config has AllowShorts=false must be
-// flagged so the operator sees it before the executor's flip path quietly
-// desyncs virtual state from the exchange on the next buy signal.
-func TestValidatePerpsAllowShortsConfig(t *testing.T) {
+// TestValidatePerpsDirectionConfig exercises the #336/#656 startup check:
+// positions seeded into SQLite (via migration, paper→live handoff, or operator
+// edit) whose side conflicts with the configured direction must be flagged so
+// the operator sees the gap before the executor's flip path quietly desyncs
+// virtual state from the exchange on the next signal.
+func TestValidatePerpsDirectionConfig(t *testing.T) {
 	state := NewAppState()
 	state.Strategies["hl-triple-ema-eth"] = &StrategyState{
 		ID:   "hl-triple-ema-eth",
 		Type: "perps",
 		Positions: map[string]*Position{
-			// The gap case: short under AllowShorts=false.
+			// Gap A: short under direction="long" (legacy AllowShorts=false).
 			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2000, Side: "short", Multiplier: 1, Leverage: 1},
 		},
 	}
@@ -131,46 +131,55 @@ func TestValidatePerpsAllowShortsConfig(t *testing.T) {
 		ID:   "hl-bidir-btc",
 		Type: "perps",
 		Positions: map[string]*Position{
-			// Allowed short: AllowShorts=true in config below, must not warn.
+			// Allowed: direction="both" tolerates either side.
 			"BTC": {Symbol: "BTC", Quantity: 0.1, AvgCost: 60000, Side: "short", Multiplier: 1, Leverage: 1},
+		},
+	}
+	state.Strategies["hl-bear-sol"] = &StrategyState{
+		ID:   "hl-bear-sol",
+		Type: "perps",
+		Positions: map[string]*Position{
+			// Gap B (#656): long under direction="short".
+			"SOL": {Symbol: "SOL", Quantity: 1.0, AvgCost: 200, Side: "long", Multiplier: 1, Leverage: 1},
 		},
 	}
 	state.Strategies["bn-sma-btc"] = &StrategyState{
 		ID:   "bn-sma-btc",
 		Type: "spot",
 		Positions: map[string]*Position{
-			// Non-perps: AllowShorts is meaningless, must not warn.
+			// Non-perps: direction is irrelevant, must not warn.
 			"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.01, AvgCost: 60000, Side: "long"},
 		},
 	}
 
 	cfg := &Config{
 		Strategies: []StrategyConfig{
-			{ID: "hl-triple-ema-eth", Type: "perps", Platform: "hyperliquid", AllowShorts: false},
-			{ID: "hl-bidir-btc", Type: "perps", Platform: "hyperliquid", AllowShorts: true},
-			{ID: "bn-sma-btc", Type: "spot", Platform: "binanceus", AllowShorts: false},
+			{ID: "hl-triple-ema-eth", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong},
+			{ID: "hl-bidir-btc", Type: "perps", Platform: "hyperliquid", Direction: DirectionBoth},
+			{ID: "hl-bear-sol", Type: "perps", Platform: "hyperliquid", Direction: DirectionShort},
+			{ID: "bn-sma-btc", Type: "spot", Platform: "binanceus"},
 		},
 	}
 
-	warnings := ValidatePerpsAllowShortsConfig(state, cfg)
-	if len(warnings) != 1 {
-		t.Fatalf("want 1 warning, got %d: %v", len(warnings), warnings)
+	warnings := ValidatePerpsDirectionConfig(state, cfg)
+	if len(warnings) != 2 {
+		t.Fatalf("want 2 warnings (long-direction short pos + short-direction long pos), got %d: %v", len(warnings), warnings)
 	}
-	w := warnings[0]
-	if !strings.Contains(w, "hl-triple-ema-eth") {
-		t.Errorf("warning should name the offending strategy, got: %s", w)
+	joined := strings.Join(warnings, "\n")
+	if !strings.Contains(joined, "hl-triple-ema-eth") {
+		t.Errorf("warnings should name the long-direction strategy, got: %s", joined)
 	}
-	if !strings.Contains(w, "ETH") {
-		t.Errorf("warning should name the symbol, got: %s", w)
+	if !strings.Contains(joined, "hl-bear-sol") {
+		t.Errorf("warnings should name the short-direction strategy, got: %s", joined)
 	}
-	if !strings.Contains(w, "AllowShorts=false") {
-		t.Errorf("warning should cite the config gap, got: %s", w)
+	if !strings.Contains(joined, "direction=") {
+		t.Errorf("warnings should cite direction in the gap message, got: %s", joined)
 	}
 }
 
-// TestValidatePerpsAllowShortsConfig_NoShorts confirms the validator is silent
-// when all perps positions match their strategy's AllowShorts setting.
-func TestValidatePerpsAllowShortsConfig_NoShorts(t *testing.T) {
+// TestValidatePerpsDirectionConfig_NoConflicts confirms the validator is
+// silent when all perps positions match their strategy's direction.
+func TestValidatePerpsDirectionConfig_NoConflicts(t *testing.T) {
 	state := NewAppState()
 	state.Strategies["hl-triple-ema-eth"] = &StrategyState{
 		ID:   "hl-triple-ema-eth",
@@ -179,20 +188,28 @@ func TestValidatePerpsAllowShortsConfig_NoShorts(t *testing.T) {
 			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2000, Side: "long", Multiplier: 1, Leverage: 1},
 		},
 	}
-	cfg := &Config{
-		Strategies: []StrategyConfig{
-			{ID: "hl-triple-ema-eth", Type: "perps", Platform: "hyperliquid", AllowShorts: false},
+	state.Strategies["hl-bear-sol"] = &StrategyState{
+		ID:   "hl-bear-sol",
+		Type: "perps",
+		Positions: map[string]*Position{
+			"SOL": {Symbol: "SOL", Quantity: 1.0, AvgCost: 200, Side: "short", Multiplier: 1, Leverage: 1},
 		},
 	}
-	if warnings := ValidatePerpsAllowShortsConfig(state, cfg); len(warnings) != 0 {
-		t.Errorf("want no warnings for a long-only state, got: %v", warnings)
+	cfg := &Config{
+		Strategies: []StrategyConfig{
+			{ID: "hl-triple-ema-eth", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong},
+			{ID: "hl-bear-sol", Type: "perps", Platform: "hyperliquid", Direction: DirectionShort},
+		},
+	}
+	if warnings := ValidatePerpsDirectionConfig(state, cfg); len(warnings) != 0 {
+		t.Errorf("want no warnings when sides match direction, got: %v", warnings)
 	}
 }
 
-// TestValidatePerpsAllowShortsConfig_OrphanState verifies we don't crash when
+// TestValidatePerpsDirectionConfig_OrphanState verifies we don't crash when
 // state has a strategy that's been removed from config (pruning happens
 // separately in main.go but validators must tolerate the intermediate state).
-func TestValidatePerpsAllowShortsConfig_OrphanState(t *testing.T) {
+func TestValidatePerpsDirectionConfig_OrphanState(t *testing.T) {
 	state := NewAppState()
 	state.Strategies["gone"] = &StrategyState{
 		ID:   "gone",
@@ -202,8 +219,32 @@ func TestValidatePerpsAllowShortsConfig_OrphanState(t *testing.T) {
 		},
 	}
 	cfg := &Config{Strategies: []StrategyConfig{}}
-	if warnings := ValidatePerpsAllowShortsConfig(state, cfg); len(warnings) != 0 {
+	if warnings := ValidatePerpsDirectionConfig(state, cfg); len(warnings) != 0 {
 		t.Errorf("orphan state should not produce warnings, got: %v", warnings)
+	}
+}
+
+// TestValidatePerpsDirectionConfig_LegacyAllowShortsFallthrough verifies that
+// configs that have not been v14-migrated yet (Direction empty, AllowShorts
+// set) are still validated correctly via EffectiveDirection.
+func TestValidatePerpsDirectionConfig_LegacyAllowShortsFallthrough(t *testing.T) {
+	state := NewAppState()
+	state.Strategies["hl-legacy-eth"] = &StrategyState{
+		ID:   "hl-legacy-eth",
+		Type: "perps",
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2000, Side: "short", Multiplier: 1, Leverage: 1},
+		},
+	}
+	cfg := &Config{
+		Strategies: []StrategyConfig{
+			// Pre-v14 shape: Direction empty, AllowShorts=false → EffectiveDirection="long".
+			{ID: "hl-legacy-eth", Type: "perps", Platform: "hyperliquid", AllowShorts: false},
+		},
+	}
+	warnings := ValidatePerpsDirectionConfig(state, cfg)
+	if len(warnings) != 1 {
+		t.Fatalf("legacy AllowShorts=false should map to direction=long and flag the short, got %d warnings: %v", len(warnings), warnings)
 	}
 }
 


### PR DESCRIPTION
Closes #656

## Summary
- Replace `allow_shorts` boolean with a `direction` enum: `"long"` (default), `"short"` (new), `"both"` (legacy bidirectional). Unlocks running existing bidirectional strategies as dedicated short-only instruments.
- `CurrentConfigVersion` bumped to 14; migration converts `allow_shorts: false`→`direction: "long"` and `allow_shorts: true`→`direction: "both"`.
- `PerpsOrderSkipReason`, `perpsLiveOrderSize`, `ExecutePerpsSignalWithLeverage` take `direction string`; short-only branches open on signal=-1, close on signal=1, never flip into long. Orphan long under `direction="short"` skipped (mirrors #336 gap detection).
- Hot-reload blocks direction change with open positions; `manual-open` rejects wrong-side flags; wizard emits `Direction`.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (short-only open/close/dedupe/orphan, EffectiveDirection precedence, v14 migration unit + LoadConfig path, hot-reload allowed/rejected)

---
LLM: Claude Opus 4.7 (1M) | high | Harness: anthropics/claude-code-action@v1 | Tokens: 205 in / 101990 out | Cache: 31288995 read / 352301 written | Cost: $20.4