### PR TITLE
fix: drive tiered ATR TP display from config, not hardcoded 1×/2×

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1038,25 +1038,10 @@ func collectPositions(sc StrategyConfig, ss *StrategyState, prices map[string]fl
 				extras += fmt.Sprintf(" | SL: $%s (%s)", fmtComma2(pos.StopLossTriggerPx), fmtPnlPct(slPct))
 			}
 		}
-		if strategyUsesTieredTPATRClose(sc) && pos.EntryATR > 0 && pos.AvgCost > 0 {
-			sideLower := strings.ToLower(pos.Side)
-			var tp1, tp2 float64
-			var haveTP bool
-			switch sideLower {
-			case "short":
-				tp1 = pos.AvgCost - pos.EntryATR
-				tp2 = pos.AvgCost - 2*pos.EntryATR
-				haveTP = true
-			case "long":
-				tp1 = pos.AvgCost + pos.EntryATR
-				tp2 = pos.AvgCost + 2*pos.EntryATR
-				haveTP = true
-			}
-			if haveTP {
-				tp1Pct := percentFromEntry(pos.Side, pos.AvgCost, tp1)
-				tp2Pct := percentFromEntry(pos.Side, pos.AvgCost, tp2)
-				extras += fmt.Sprintf(" | TP1: $%s (%s) | TP2: $%s (%s)",
-					fmtComma2(tp1), fmtPnlPct(tp1Pct), fmtComma2(tp2), fmtPnlPct(tp2Pct))
+		if tps := tieredTPATRPrices(sc, pos.Side, pos.AvgCost, pos.EntryATR); len(tps) > 0 {
+			for i, tp := range tps {
+				pct := percentFromEntry(pos.Side, pos.AvgCost, tp)
+				extras += fmt.Sprintf(" | TP%d: $%s (%s)", i+1, fmtComma2(tp), fmtPnlPct(pct))
 			}
 		}
 		if pos.Leverage > 1 {
@@ -1112,19 +1097,14 @@ func FormatTradeDM(sc StrategyConfig, trade Trade, mode string) string {
 	if trade.Regime != "" {
 		extras = append(extras, "Regime: "+trade.Regime)
 	}
-	if !isClose && trade.EntryATR > 0 && strategyUsesTieredTPATRClose(sc) {
-		extras = append(extras, fmt.Sprintf("ATR: $%s", fmtComma2(trade.EntryATR)))
+	if !isClose && trade.EntryATR > 0 {
 		direction := strings.ToLower(tradeDirectionLabel(trade))
-		var tp1, tp2 float64
-		if direction == "short" {
-			tp1 = trade.Price - trade.EntryATR
-			tp2 = trade.Price - 2*trade.EntryATR
-		} else {
-			tp1 = trade.Price + trade.EntryATR
-			tp2 = trade.Price + 2*trade.EntryATR
+		if tps := tieredTPATRPrices(sc, direction, trade.Price, trade.EntryATR); len(tps) > 0 {
+			extras = append(extras, fmt.Sprintf("ATR: $%s", fmtComma2(trade.EntryATR)))
+			for i, tp := range tps {
+				extras = append(extras, fmt.Sprintf("TP%d: $%s", i+1, fmtComma2(tp)))
+			}
 		}
-		extras = append(extras, fmt.Sprintf("TP1: $%s", fmtComma2(tp1)))
-		extras = append(extras, fmt.Sprintf("TP2: $%s", fmtComma2(tp2)))
 	}
 	if trade.StopLossTriggerPx > 0 {
 		direction := strings.ToLower(tradeDirectionLabel(trade))

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -1851,6 +1851,37 @@ func TestFormatTradeDMPlain_CloseTrade(t *testing.T) {
 	}
 }
 
+// TestFormatTradeDMPlain_OpenWithCustomTiers mirrors the Discord test for #659:
+// telegram plain DM must read tier multiples from config, not hardcode 1×/2×.
+func TestFormatTradeDMPlain_OpenWithCustomTiers(t *testing.T) {
+	sc := StrategyConfig{
+		ID:       "hl-tema-eth-live",
+		Platform: "hyperliquid",
+		Type:     "perps",
+		CloseStrategies: []StrategyRef{{
+			Name: "tiered_tp_atr_live",
+			Params: map[string]interface{}{
+				"tiers": []interface{}{
+					map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.5},
+					map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
+				},
+			},
+		}},
+	}
+	trade := Trade{
+		Symbol: "ETH", Side: "buy", Quantity: 0.1, Price: 2316.90, Value: 231.69,
+		EntryATR: 12.01,
+		Details:  "Open long 0.100000 @ $2316.90",
+	}
+	msg := FormatTradeDMPlain(sc, trade, "live")
+	if !strings.Contains(msg, "TP1: $2,340.92") {
+		t.Errorf("expected TP1=2,340.92 (2× ATR) in plain DM, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "TP2: $2,352.93") {
+		t.Errorf("expected TP2=2,352.93 (3× ATR) in plain DM, got:\n%s", msg)
+	}
+}
+
 // Issue #530: telegram plain DM must treat partial-close like full close.
 func TestFormatTradeDMPlain_PartialClose(t *testing.T) {
 	sc := StrategyConfig{ID: "hl-sma-eth", Platform: "hyperliquid", Type: "perps"}
@@ -1979,6 +2010,106 @@ func TestFormatTradeDM_OpenWithATRAndTP(t *testing.T) {
 	}
 	if !strings.Contains(msg, "TP2: $65,500.00") {
 		t.Errorf("expected 'TP2: $65,500.00' in DM, got:\n%s", msg)
+	}
+}
+
+// TestFormatTradeDM_OpenWithCustomTiers verifies that the trade DM reads tier
+// multiples from sc.CloseStrategies[].Params["tiers"] rather than hardcoded
+// 1×/2× (#659). Reproduces the original issue where 2×/3× config showed 1×/2×.
+func TestFormatTradeDM_OpenWithCustomTiers(t *testing.T) {
+	sc := StrategyConfig{
+		ID:       "hl-tema-eth-live",
+		Platform: "hyperliquid",
+		Type:     "perps",
+		CloseStrategies: []StrategyRef{{
+			Name: "tiered_tp_atr_live",
+			Params: map[string]interface{}{
+				"tiers": []interface{}{
+					map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.5},
+					map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
+				},
+			},
+		}},
+	}
+	trade := Trade{
+		Symbol:   "ETH",
+		Side:     "buy",
+		Quantity: 0.1,
+		Price:    2316.90,
+		Value:    231.69,
+		EntryATR: 12.01,
+		Details:  "Open long 0.100000 @ $2316.90",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	// 2316.90 + 2*12.01 = 2340.92, 2316.90 + 3*12.01 = 2352.93
+	if !strings.Contains(msg, "TP1: $2,340.92") {
+		t.Errorf("expected 'TP1: $2,340.92' (2× ATR) in DM, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "TP2: $2,352.93") {
+		t.Errorf("expected 'TP2: $2,352.93' (3× ATR) in DM, got:\n%s", msg)
+	}
+}
+
+// TestFormatTradeDM_OpenWithThreeTiers verifies the DM renders TP1/TP2/TP3
+// when three tiers are configured (#659 — N-tier display).
+func TestFormatTradeDM_OpenWithThreeTiers(t *testing.T) {
+	sc := StrategyConfig{
+		ID:       "hl-tatr-btc",
+		Platform: "hyperliquid",
+		Type:     "perps",
+		CloseStrategies: []StrategyRef{{
+			Name: "tiered_tp_atr",
+			Params: map[string]interface{}{
+				"tiers": []interface{}{
+					map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.3},
+					map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.6},
+					map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
+				},
+			},
+		}},
+	}
+	trade := Trade{
+		Symbol: "BTC", Side: "buy", Quantity: 0.01, Price: 63500.0, Value: 635.0,
+		EntryATR: 1000.0,
+		Details:  "Open long 0.010000 @ $63500.00",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	for _, want := range []string{"TP1: $64,500.00", "TP2: $65,500.00", "TP3: $66,500.00"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("expected %q in DM, got:\n%s", want, msg)
+		}
+	}
+}
+
+// TestCollectPositions_TieredTPATR_CustomTiers verifies position-extras read
+// tier multiples from config (#659).
+func TestCollectPositions_TieredTPATR_CustomTiers(t *testing.T) {
+	sc := StrategyConfig{
+		ID: "hl-tema-eth-live",
+		CloseStrategies: []StrategyRef{{
+			Name: "tiered_tp_atr_live",
+			Params: map[string]interface{}{
+				"tiers": []interface{}{
+					map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.5},
+					map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
+				},
+			},
+		}},
+	}
+	ss := &StrategyState{
+		Positions: map[string]*Position{
+			"ETH/USDT": {Symbol: "ETH/USDT", Quantity: 0.1, AvgCost: 2316.90, Side: "long", EntryATR: 12.01},
+		},
+	}
+	lines := collectPositions(sc, ss, map[string]float64{"ETH/USDT": 2316.90})
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	if !strings.Contains(lines[0], "TP1: $2,340.92") {
+		t.Errorf("expected TP1=2,340.92 (2× ATR) in line, got: %s", lines[0])
+	}
+	if !strings.Contains(lines[0], "TP2: $2,352.93") {
+		t.Errorf("expected TP2=2,352.93 (3× ATR) in line, got: %s", lines[0])
 	}
 }
 

--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -100,6 +100,36 @@ type hlProtectionTier struct {
 	Fraction float64
 }
 
+// tieredTPATRPrices returns the take-profit prices for each configured tier
+// given a position's entry price, side ("long"/"short"), and EntryATR. Display
+// helper for Discord/Telegram alerts so the rendered TPs can never diverge
+// from the on-chain reduce-only orders placed via hyperliquidProtectionTiers
+// (#659). Returns nil when the strategy doesn't use tiered_tp_atr* or any
+// required input is missing.
+func tieredTPATRPrices(sc StrategyConfig, side string, entryPrice, entryATR float64) []float64 {
+	if entryATR <= 0 || entryPrice <= 0 {
+		return nil
+	}
+	tiers := hyperliquidProtectionTiers(sc)
+	if len(tiers) == 0 {
+		return nil
+	}
+	sideLower := strings.ToLower(strings.TrimSpace(side))
+	prices := make([]float64, len(tiers))
+	for i, t := range tiers {
+		offset := t.Multiple * entryATR
+		switch sideLower {
+		case "short":
+			prices[i] = entryPrice - offset
+		case "long":
+			prices[i] = entryPrice + offset
+		default:
+			return nil
+		}
+	}
+	return prices
+}
+
 func parseHLProtectionTiers(raw interface{}) []hlProtectionTier {
 	items, ok := raw.([]interface{})
 	if !ok {

--- a/scheduler/telegram.go
+++ b/scheduler/telegram.go
@@ -265,19 +265,14 @@ func FormatTradeDMPlain(sc StrategyConfig, trade Trade, mode string) string {
 	if trade.Regime != "" {
 		extras = append(extras, "Regime: "+trade.Regime)
 	}
-	if !isClose && trade.EntryATR > 0 && strategyUsesTieredTPATRClose(sc) {
-		extras = append(extras, fmt.Sprintf("ATR: $%s", fmtComma2(trade.EntryATR)))
+	if !isClose && trade.EntryATR > 0 {
 		direction := strings.ToLower(tradeDirectionLabel(trade))
-		var tp1, tp2 float64
-		if direction == "short" {
-			tp1 = trade.Price - trade.EntryATR
-			tp2 = trade.Price - 2*trade.EntryATR
-		} else {
-			tp1 = trade.Price + trade.EntryATR
-			tp2 = trade.Price + 2*trade.EntryATR
+		if tps := tieredTPATRPrices(sc, direction, trade.Price, trade.EntryATR); len(tps) > 0 {
+			extras = append(extras, fmt.Sprintf("ATR: $%s", fmtComma2(trade.EntryATR)))
+			for i, tp := range tps {
+				extras = append(extras, fmt.Sprintf("TP%d: $%s", i+1, fmtComma2(tp)))
+			}
 		}
-		extras = append(extras, fmt.Sprintf("TP1: $%s", fmtComma2(tp1)))
-		extras = append(extras, fmt.Sprintf("TP2: $%s", fmtComma2(tp2)))
 	}
 	if trade.StopLossTriggerPx > 0 {
 		direction := strings.ToLower(tradeDirectionLabel(trade))


### PR DESCRIPTION
Closes #659

## Summary

Discord position extras, Discord trade DM, and Telegram trade DM all hardcoded TP1=1×ATR / TP2=2×ATR — silently correct for default tiers, wrong whenever an operator overrides `tiers` (e.g. 2×/3×). Replace with a shared `tieredTPATRPrices` helper that reads tiers via the same `hyperliquidProtectionTiers(sc)` the on-chain placer uses, and renders TP1…TPn so future N-tier configs no longer truncate to two slots.

## Test plan
- [x] `go test ./...`
- [ ] Live smoke: open a HL perps position under a `tiered_tp_atr_live` strategy with custom `tiers` and verify DM TP prices match on-chain reduce-only orders

---
LLM: Claude Opus 4.7 (1M) | high | Harness: anthropics/claude-code-action@v1 | Tokens: 58 in / 18694 out | Cache: 2826196 read / 195861 written | Cost: $3.1