### PR TITLE
feat: owner DM on HL TP/SL fill detection

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -122,7 +122,18 @@ type Config struct {
 	SummaryFrequency       map[string]string          `json:"summary_frequency,omitempty"`          // #30 — per-channel summary cadence; keys match Discord/Telegram channel keys (e.g. "spot", "options", "hyperliquid"). Values: Go duration ("30m", "2h"), alias ("hourly", "every"/"per_check"/"always"), or empty for legacy default (continuous: every channel run; spot: hourly)
 	RiskFreeRate           *float64                   `json:"risk_free_rate,omitempty"`             // #397 — annualized risk-free rate used in Sharpe-ratio calculations (e.g. 0.02 for 2%). Nil/missing falls back to DefaultAnnualRiskFreeRate; an explicit 0 is respected so backtest comparisons can pin to a 0% benchmark.
 	DefaultStopLossATRMult *float64                   `json:"default_stop_loss_atr_mult,omitempty"` // #605 — top-level default applied to HL perps/manual strategies that omit all stop_loss_* / trailing_stop_* fields. Nil/missing falls back to 1.0; explicit values let operators tune the ATR stop without recompiling.
+	NotifyTPSLFills        *bool                      `json:"notify_tp_sl_fills,omitempty"`         // #661 — owner DM when HL on-chain TP/SL fills are detected by the reconciler. Nil/missing → enabled; explicit false disables.
 	TradingViewExport      TradingViewExportConfig    `json:"tradingview_export,omitempty"`         // #3 — optional symbol overrides for TradingView portfolio CSV exports
+}
+
+// NotifyTPSLFillsEnabled reports whether reconciler-detected TP/SL fills should
+// trigger an owner DM. Nil pointer (missing field) defaults to true so existing
+// configs get the alert without an explicit opt-in.
+func (c *Config) NotifyTPSLFillsEnabled() bool {
+	if c == nil || c.NotifyTPSLFills == nil {
+		return true
+	}
+	return *c.NotifyTPSLFills
 }
 
 // ParseSummaryFrequency converts a summary_frequency value to a duration.

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -358,7 +358,9 @@ func syncHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppSt
 	// Self-contained entry: due and all are the same list. Prices are
 	// unavailable in this path (caller did not pre-fetch); external-close
 	// PnL falls back to zero (legacy behavior pre-#584).
-	return reconcileHyperliquidAccountPositions(hlStrategies, hlStrategies, state, mu, logMgr, positions, nil, accountAddr)
+	// This entry point is used by --once and tests; alerts are suppressed
+	// since no notifier is plumbed through here.
+	return reconcileHyperliquidAccountPositions(hlStrategies, hlStrategies, state, mu, logMgr, positions, nil, accountAddr, nil, false)
 }
 
 // reconcileHyperliquidAccountPositions reconciles pre-fetched on-chain positions
@@ -381,8 +383,13 @@ func syncHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppSt
 // string to skip the lookup — closes still book correctly using the
 // modeled fee.
 //
+// notifier and notifyTPSLFills control owner DMs emitted on TP/SL fill
+// detection (#661). Pass a nil notifier to suppress alerts; pass false for
+// notifyTPSLFills when the operator has explicitly opted out via
+// `notify_tp_sl_fills: false`.
+//
 // Must be called WITHOUT holding any lock; acquires Lock internally.
-func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager, positions []HLPosition, prices map[string]float64, accountAddress string) bool {
+func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager, positions []HLPosition, prices map[string]float64, accountAddress string, notifier *MultiNotifier, notifyTPSLFills bool) bool {
 	// Resolve userFills BEFORE taking mu.Lock(): each lookup can sleep up
 	// to ~1.5s on indexer-lag retries, and holding the write lock blocks
 	// every reader of state (/status, /health, per-strategy phase RLocks).
@@ -570,8 +577,23 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 						}
 						pos.Quantity = lookup.FilledQty
 					}
+					alertSide := pos.Side
+					alertQty := pos.Quantity
+					alertTriggerPx := pos.StopLossTriggerPx
 					if recordPerpsStopLossCloseWithFillFee(ss, coin, pos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "hl_sync_stop_loss", logger) {
 						changed = true
+						notifyProtectionFill(notifier, notifyTPSLFills, ProtectionFillAlert{
+							StrategyID:   id,
+							Symbol:       coin,
+							Side:         alertSide,
+							FillType:     "SL",
+							IsPartial:    false,
+							FillPrice:    alertTriggerPx,
+							CloseQty:     alertQty,
+							RemainingQty: 0,
+							RealizedPnL:  lastBookedTradePnL(ss),
+							HasPnL:       true,
+						})
 					}
 				} else if mark, ok := prices[coin]; ok && mark > 0 {
 					// #584: credit s.Cash with mark-based PnL so the per-strategy
@@ -649,10 +671,25 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 							}
 							slOwnerPos.Quantity = lookup.FilledQty
 						}
+						alertSide := slOwnerPos.Side
+						alertQty := slOwnerPos.Quantity
+						alertTriggerPx := slOwnerPos.StopLossTriggerPx
 						if recordPerpsStopLossCloseWithFillFee(ownerSS, coin, slOwnerPos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "hl_sync_stop_loss", logger) {
 							changed = true
 							virtualQty = expectedResidual
 							delta = virtualQty - onChainQty
+							notifyProtectionFill(notifier, notifyTPSLFills, ProtectionFillAlert{
+								StrategyID:   slOwnerID,
+								Symbol:       coin,
+								Side:         alertSide,
+								FillType:     "SL",
+								IsPartial:    false,
+								FillPrice:    alertTriggerPx,
+								CloseQty:     alertQty,
+								RemainingQty: 0,
+								RealizedPnL:  lastBookedTradePnL(ownerSS),
+								HasPnL:       true,
+							})
 						}
 					}
 				}
@@ -662,6 +699,7 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 					var candidateID string
 					var candidateSS *StrategyState
 					var candidatePos *Position
+					var candidateTierIdx int
 					for _, id := range stratIDs {
 						ss := state.Strategies[id]
 						if ss == nil {
@@ -672,7 +710,11 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 							continue
 						}
 						sc, ok := strategyByID[id]
-						if !ok || !hyperliquidHasClearedTPTier(sc, pos, closeQty) {
+						if !ok {
+							continue
+						}
+						tierIdx, hasCleared := hyperliquidClearedTPTier(sc, pos, closeQty)
+						if !hasCleared {
 							continue
 						}
 						if candidateID != "" {
@@ -681,7 +723,7 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 							candidateID, candidateSS, candidatePos = "", nil, nil
 							break
 						}
-						candidateID, candidateSS, candidatePos = id, ss, pos
+						candidateID, candidateSS, candidatePos, candidateTierIdx = id, ss, pos, tierIdx
 					}
 					if candidateID != "" && candidateSS != nil && candidatePos != nil && closeQty <= candidatePos.Quantity+1e-6 {
 						if mark, ok := prices[coin]; ok && mark > 0 {
@@ -699,6 +741,26 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 									virtualQty += closeQty
 								}
 								delta = virtualQty - onChainQty
+								// candidatePos.Quantity is decremented in-place by
+								// the partial-close booker (or the position is
+								// deleted when fully drained); read it back for
+								// the DM remaining-qty line.
+								remaining := 0.0
+								if posAfter := candidateSS.Positions[coin]; posAfter != nil {
+									remaining = posAfter.Quantity
+								}
+								notifyProtectionFill(notifier, notifyTPSLFills, ProtectionFillAlert{
+									StrategyID:   candidateID,
+									Symbol:       coin,
+									Side:         closeSide,
+									FillType:     tpTierLabel(candidateTierIdx),
+									IsPartial:    true,
+									FillPrice:    mark,
+									CloseQty:     closeQty,
+									RemainingQty: remaining,
+									RealizedPnL:  lastBookedTradePnL(candidateSS),
+									HasPnL:       true,
+								})
 							}
 						} else {
 							fmt.Printf("[WARN] hl-sync: shared coin %s TP partial drift detected for %s but no mark price is available; leaving virtual qty unchanged\n", coin, candidateID)
@@ -761,38 +823,57 @@ func hyperliquidSharedPartialCloseDrift(virtualQty, onChainQty float64) (string,
 	return "", 0, false
 }
 
-func hyperliquidHasClearedTPTier(sc StrategyConfig, pos *Position, closeQty float64) bool {
+// hyperliquidClearedTPTier reports whether sc/pos shows a cleared TP tier
+// attributable to closeQty, and which tier index (0-based) cleared. Used by
+// reconciler Detector 3 to attribute partial closes and by the TP-fill DM
+// alert to label the tier (#661).
+//
+// Returns (clearedIdx, true) when at least one TP OID is zero AND either:
+//   - some other tier is still active (the cleared one is the freshest fill), or
+//   - all tiers are zero AND closeQty matches pos.Quantity (sole-peer final close,
+//     attributed to the last tier).
+func hyperliquidClearedTPTier(sc StrategyConfig, pos *Position, closeQty float64) (int, bool) {
 	if pos == nil || len(pos.TPOIDs) == 0 {
-		return false
+		return 0, false
 	}
 	tiers := hyperliquidProtectionTiers(sc)
 	if len(tiers) == 0 {
-		return false
+		return 0, false
 	}
 	if len(pos.TPOIDs) < len(tiers) {
-		return false
+		return 0, false
 	}
 	tpOIDs := tpOIDsForTierCount(pos.TPOIDs, len(tiers))
-	hasCleared := false
+	clearedIdx := -1
 	hasActive := false
-	for _, oid := range tpOIDs {
+	for i, oid := range tpOIDs {
 		if oid > 0 {
 			hasActive = true
-		} else {
-			hasCleared = true
+		} else if clearedIdx < 0 {
+			clearedIdx = i
 		}
 	}
-	if !hasCleared {
-		return false
+	if clearedIdx < 0 {
+		return 0, false
 	}
 	if hasActive {
-		return true
+		return clearedIdx, true
 	}
 	// All TP tiers gone usually means the final tier filled. Treat that as
 	// attributable only when the observed drift can fully close this strategy;
 	// otherwise an all-zero, never-placed TP list would make ambiguous gaps look
 	// actionable.
-	return math.Abs(pos.Quantity-closeQty) <= 1e-6
+	if math.Abs(pos.Quantity-closeQty) <= 1e-6 {
+		return len(tpOIDs) - 1, true
+	}
+	return 0, false
+}
+
+// hyperliquidHasClearedTPTier is the bool-returning shim retained for callers
+// that don't need the tier index.
+func hyperliquidHasClearedTPTier(sc StrategyConfig, pos *Position, closeQty float64) bool {
+	_, ok := hyperliquidClearedTPTier(sc, pos, closeQty)
+	return ok
 }
 
 // HyperliquidLiveCloseReport summarizes a forceCloseHyperliquidLive run.

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -396,6 +396,18 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 	// The resolver itself is a pure map read inside the locked region.
 	resolveFee := buildCachedHyperliquidReconcileFillResolver(accountAddress, allStrategies, state, mu, positions)
 
+	// pendingAlerts is populated under mu.Lock() at the three protection-fill
+	// detection sites and drained AFTER mu.Unlock() so SendOwnerDM's blocking
+	// HTTP calls don't extend the critical section. Defer ordering: the flush
+	// closure is registered first, so it fires LAST — after defer mu.Unlock()
+	// has already released the lock (defer runs LIFO).
+	var pendingAlerts []ProtectionFillAlert
+	defer func() {
+		for _, a := range pendingAlerts {
+			notifyProtectionFill(notifier, notifyTPSLFills, a)
+		}
+	}()
+
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -582,7 +594,10 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 					alertTriggerPx := pos.StopLossTriggerPx
 					if recordPerpsStopLossCloseWithFillFee(ss, coin, pos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "hl_sync_stop_loss", logger) {
 						changed = true
-						notifyProtectionFill(notifier, notifyTPSLFills, ProtectionFillAlert{
+						// lastBookedTradePnL relies on the just-completed
+						// RecordTrade inside the booker; do not insert another
+						// RecordTrade between here and the booker call.
+						pendingAlerts = append(pendingAlerts, ProtectionFillAlert{
 							StrategyID:   id,
 							Symbol:       coin,
 							Side:         alertSide,
@@ -678,7 +693,10 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 							changed = true
 							virtualQty = expectedResidual
 							delta = virtualQty - onChainQty
-							notifyProtectionFill(notifier, notifyTPSLFills, ProtectionFillAlert{
+							// lastBookedTradePnL relies on the just-completed
+							// RecordTrade inside the booker; do not insert another
+							// RecordTrade between here and the booker call.
+							pendingAlerts = append(pendingAlerts, ProtectionFillAlert{
 								StrategyID:   slOwnerID,
 								Symbol:       coin,
 								Side:         alertSide,
@@ -749,7 +767,10 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 								if posAfter := candidateSS.Positions[coin]; posAfter != nil {
 									remaining = posAfter.Quantity
 								}
-								notifyProtectionFill(notifier, notifyTPSLFills, ProtectionFillAlert{
+								// lastBookedTradePnL relies on the just-completed
+								// RecordTrade inside the booker; do not insert another
+								// RecordTrade between here and the booker call.
+								pendingAlerts = append(pendingAlerts, ProtectionFillAlert{
 									StrategyID:   candidateID,
 									Symbol:       coin,
 									Side:         closeSide,
@@ -832,6 +853,12 @@ func hyperliquidSharedPartialCloseDrift(virtualQty, onChainQty float64) (string,
 //   - some other tier is still active (the cleared one is the freshest fill), or
 //   - all tiers are zero AND closeQty matches pos.Quantity (sole-peer final close,
 //     attributed to the last tier).
+//
+// Caveat: when multiple tiers have already cleared but none is yet booked,
+// this returns the FIRST cleared index. Detector 3 is expected to fire once
+// per fill (each cycle's drift detection books exactly one tier), so the
+// "earliest cleared" answer matches the unbooked fill in practice. If a future
+// caller batches multiple un-booked fills, revisit this assumption.
 func hyperliquidClearedTPTier(sc StrategyConfig, pos *Position, closeQty float64) (int, bool) {
 	if pos == nil || len(pos.TPOIDs) == 0 {
 		return 0, false

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -989,7 +989,7 @@ func TestReconcileDueSubsetOfAllDetectsSharedCoins(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions(dueStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
+	reconcileHyperliquidAccountPositions(dueStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	// Even though only rmc is due, allStrategies reveals ETH is shared by 3
 	// strategies, so rmc's position must NOT be reconciled to on-chain.
@@ -1058,7 +1058,7 @@ func TestReconcileSharedCoinShortAndMixedPositions(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	// Positions should be unchanged.
 	longPos := state.Strategies["hl-long-eth"].Positions["ETH"]
@@ -1121,7 +1121,7 @@ func TestReconcileSharedCoinBothShort(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	gap := state.ReconciliationGaps["ETH"]
 	if gap == nil {
@@ -1176,7 +1176,7 @@ func TestReconcileSharedCoin_OwnerStopLossFired_ClosesOwnerOnly(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	// Owner position must be closed and recorded.
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
@@ -1241,7 +1241,7 @@ func TestReconcileSharedCoin_OwnerStopLossFired_Short(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
 		t.Error("owner short ETH position should be nil after SL reconciliation")
@@ -1285,7 +1285,7 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
 		t.Error("owner ETH position should be nil")
@@ -1345,7 +1345,7 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally_CreditsPeerCash(t *tes
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "")
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
 
 	peer := state.Strategies["hl-peer-eth"]
 	if peer.Positions["ETH"] != nil {
@@ -1442,7 +1442,7 @@ func TestReconcileSharedCoin_TPPartialFill_DecrementsOwnerAndBooksPnL(t *testing
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "")
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
 
 	owner := state.Strategies["hl-owner-eth"]
 	ownerPos := owner.Positions["ETH"]
@@ -1533,7 +1533,7 @@ func TestReconcileSharedCoin_TPPartialFill_Short(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "")
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
 
 	owner := state.Strategies["hl-owner-eth"]
 	ownerPos := owner.Positions["ETH"]
@@ -1597,7 +1597,7 @@ func TestReconcileSharedCoin_TPPartialFill_PaddedNeverPlacedTierDoesNotAttribute
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "")
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
 
 	owner := state.Strategies["hl-owner-eth"]
 	ownerPos := owner.Positions["ETH"]
@@ -1650,7 +1650,7 @@ func TestReconcileSharedCoin_TPPartialFill_MultipleCandidatesDoesNotAttribute(t 
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "")
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
 
 	for id, ss := range state.Strategies {
 		pos := ss.Positions["ETH"]
@@ -1705,7 +1705,7 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally_NoMarkPrice_FallsBack(
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 	// nil prices map → legacy zero-PnL path.
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	peer := state.Strategies["hl-peer-eth"]
 	if peer.Positions["ETH"] != nil {
@@ -1751,7 +1751,7 @@ func TestReconcileSharedCoin_GapWithoutSLOwner_LeavesPositionsAlone(t *testing.T
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	// Both positions must be untouched.
 	posA := state.Strategies["hl-a-eth"].Positions["ETH"]
@@ -1808,7 +1808,7 @@ func TestReconcileSharedCoin_ResidualMismatch_LeavesPositionsAlone(t *testing.T)
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "")
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	// Both positions must be untouched.
 	ownerPos := state.Strategies["hl-owner-eth"].Positions["ETH"]
@@ -3085,7 +3085,7 @@ func TestReconcileManualPositionExternalClose(t *testing.T) {
 	var mu sync.RWMutex
 
 	// Pass nil positions (on-chain flat).
-	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "")
+	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "", nil, false)
 
 	ss := state.Strategies["manual-eth"]
 	if _, ok := ss.Positions["ETH"]; ok {
@@ -3263,7 +3263,7 @@ func TestReconcileManualPositionSLFired(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "")
+	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "", nil, false)
 
 	ss := state.Strategies["manual-eth"]
 	if _, ok := ss.Positions["ETH"]; ok {

--- a/scheduler/hyperliquid_fills_test.go
+++ b/scheduler/hyperliquid_fills_test.go
@@ -292,7 +292,7 @@ func TestReconcileHyperliquidAccountPositions_DetectorOneUsesFillFee(t *testing.
 
 	prices := map[string]float64{"BTC": 59000}
 	// nil on-chain positions => Detector 1 fires for both peers.
-	reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, nil, prices, "0xtest")
+	reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, nil, prices, "0xtest", nil, false)
 
 	ownerSS := state.Strategies["hl-owner"]
 	if _, open := ownerSS.Positions["BTC"]; open {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1061,7 +1061,7 @@ func main() {
 				// shared-wallet risk check (#243 review feedback) so we don't
 				// pay two HL API round-trips per cycle.
 				if len(hlReconcileDue) > 0 && hlStateFetched {
-					reconcileHyperliquidAccountPositions(hlReconcileDue, hlReconcileAll, state, &mu, logMgr, hlPositions, prices, os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS"))
+					reconcileHyperliquidAccountPositions(hlReconcileDue, hlReconcileAll, state, &mu, logMgr, hlPositions, prices, os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS"), notifier, cfg.NotifyTPSLFillsEnabled())
 				}
 
 				// #621: Build a coin→|on-chain qty| map from the pre-fetched positions

--- a/scheduler/protection_fill_alert.go
+++ b/scheduler/protection_fill_alert.go
@@ -1,0 +1,68 @@
+package main
+
+import "fmt"
+
+// ProtectionFillAlert describes a TP or SL fill detected by the HL reconciler.
+// Emission sites build this struct from in-scope state and pass it to
+// notifyProtectionFill, which formats and DMs the owner.
+type ProtectionFillAlert struct {
+	StrategyID   string
+	Symbol       string
+	Side         string  // "long" or "short" — the position side, not the trade direction
+	FillType     string  // "TP1", "TP2", …, or "SL"
+	IsPartial    bool    // partial close (TP tier or partial SL) vs. full close
+	FillPrice    float64 // actual fill price; 0 if unknown
+	CloseQty     float64 // qty closed by this fill
+	RemainingQty float64 // remaining position qty after this fill
+	RealizedPnL  float64 // 0 when not computable
+	HasPnL       bool    // distinguishes "PnL=0" from "PnL unknown"
+}
+
+// formatProtectionFillAlert produces the DM body for a TP/SL fill notification.
+// Pure function so it's testable without spinning a notifier.
+func formatProtectionFillAlert(a ProtectionFillAlert) string {
+	headline := fmt.Sprintf("%s filled — %s", a.FillType, a.StrategyID)
+	if a.IsPartial {
+		headline += " (partial)"
+	}
+	side := "LONG"
+	if a.Side == "short" {
+		side = "SHORT"
+	}
+	priceLine := ""
+	if a.FillPrice > 0 {
+		priceLine = fmt.Sprintf("%s %s — %.6f @ $%.4f", a.Symbol, side, a.CloseQty, a.FillPrice)
+	} else {
+		priceLine = fmt.Sprintf("%s %s — %.6f (fill price unknown)", a.Symbol, side, a.CloseQty)
+	}
+	remaining := fmt.Sprintf("Remaining: %.6f %s", a.RemainingQty, a.Symbol)
+	if a.HasPnL {
+		return fmt.Sprintf("%s\n%s\n%s | PnL=$%.2f", headline, priceLine, remaining, a.RealizedPnL)
+	}
+	return fmt.Sprintf("%s\n%s\n%s", headline, priceLine, remaining)
+}
+
+// notifyProtectionFill emits an owner DM for a protection-order fill detected
+// by the reconciler. No-ops when notifier is nil or the feature is disabled.
+func notifyProtectionFill(notifier *MultiNotifier, enabled bool, alert ProtectionFillAlert) {
+	if notifier == nil || !enabled {
+		return
+	}
+	notifier.SendOwnerDM(formatProtectionFillAlert(alert))
+}
+
+// tpTierLabel formats a 0-based tier index as "TP1", "TP2", … for DM display.
+func tpTierLabel(tierIdx int) string {
+	return fmt.Sprintf("TP%d", tierIdx+1)
+}
+
+// lastBookedTradePnL returns the realized PnL of the most recently recorded
+// trade on s, or 0 when TradeHistory is empty. Used by the reconciler hook
+// sites to surface the per-fill PnL in the DM alert without changing the
+// signature of the bookPerps* helpers.
+func lastBookedTradePnL(s *StrategyState) float64 {
+	if s == nil || len(s.TradeHistory) == 0 {
+		return 0
+	}
+	return s.TradeHistory[len(s.TradeHistory)-1].RealizedPnL
+}

--- a/scheduler/protection_fill_alert.go
+++ b/scheduler/protection_fill_alert.go
@@ -37,18 +37,45 @@ func formatProtectionFillAlert(a ProtectionFillAlert) string {
 	}
 	remaining := fmt.Sprintf("Remaining: %.6f %s", a.RemainingQty, a.Symbol)
 	if a.HasPnL {
-		return fmt.Sprintf("%s\n%s\n%s | PnL=$%.2f", headline, priceLine, remaining, a.RealizedPnL)
+		return fmt.Sprintf("%s\n%s\n%s | PnL=%s", headline, priceLine, remaining, formatSignedUSD(a.RealizedPnL))
 	}
 	return fmt.Sprintf("%s\n%s\n%s", headline, priceLine, remaining)
 }
 
+// formatSignedUSD formats a USD amount with the sign before the currency symbol
+// so negative values read as "-$42.10" instead of "$-42.10".
+func formatSignedUSD(v float64) string {
+	if v < 0 {
+		return fmt.Sprintf("-$%.2f", -v)
+	}
+	return fmt.Sprintf("$%.2f", v)
+}
+
+// ownerDMSender is the minimal interface notifyProtectionFill needs from a
+// notifier. *MultiNotifier satisfies it; tests can stub with a counting fake
+// to assert the disabled-flag actually suppresses emission.
+type ownerDMSender interface {
+	SendOwnerDM(content string)
+}
+
 // notifyProtectionFill emits an owner DM for a protection-order fill detected
-// by the reconciler. No-ops when notifier is nil or the feature is disabled.
-func notifyProtectionFill(notifier *MultiNotifier, enabled bool, alert ProtectionFillAlert) {
-	if notifier == nil || !enabled {
+// by the reconciler. No-ops when sender is a nil interface, when the underlying
+// pointer is nil, or when the feature is disabled.
+func notifyProtectionFill(sender ownerDMSender, enabled bool, alert ProtectionFillAlert) {
+	if !enabled || sender == nil || isNilSender(sender) {
 		return
 	}
-	notifier.SendOwnerDM(formatProtectionFillAlert(alert))
+	sender.SendOwnerDM(formatProtectionFillAlert(alert))
+}
+
+// isNilSender reports whether a non-nil interface value carries a nil
+// underlying pointer (e.g. (*MultiNotifier)(nil)). Without this check the
+// interface compares != nil even though invoking SendOwnerDM would panic.
+func isNilSender(s ownerDMSender) bool {
+	if mn, ok := s.(*MultiNotifier); ok {
+		return mn == nil
+	}
+	return false
 }
 
 // tpTierLabel formats a 0-based tier index as "TP1", "TP2", … for DM display.
@@ -60,6 +87,11 @@ func tpTierLabel(tierIdx int) string {
 // trade on s, or 0 when TradeHistory is empty. Used by the reconciler hook
 // sites to surface the per-fill PnL in the DM alert without changing the
 // signature of the bookPerps* helpers.
+//
+// IMPORTANT: this assumes the booker just appended via RecordTrade and no
+// other RecordTrade has run between the booker and this read. Each call site
+// MUST live immediately after a successful record* call, with no intervening
+// trade-recording in between — otherwise the DM will silently mis-report PnL.
 func lastBookedTradePnL(s *StrategyState) float64 {
 	if s == nil || len(s.TradeHistory) == 0 {
 		return 0

--- a/scheduler/protection_fill_alert_test.go
+++ b/scheduler/protection_fill_alert_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatProtectionFillAlert_FullSL(t *testing.T) {
+	out := formatProtectionFillAlert(ProtectionFillAlert{
+		StrategyID:   "hl-tema-eth-live",
+		Symbol:       "ETH",
+		Side:         "long",
+		FillType:     "SL",
+		IsPartial:    false,
+		FillPrice:    1800.50,
+		CloseQty:     0.42,
+		RemainingQty: 0,
+		RealizedPnL:  -42.10,
+		HasPnL:       true,
+	})
+	for _, want := range []string{
+		"SL filled — hl-tema-eth-live",
+		"ETH LONG",
+		"@ $1800.5000",
+		"Remaining: 0.000000 ETH",
+		"PnL=$-42.10",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in alert body:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "(partial)") {
+		t.Errorf("full-close alert should not contain '(partial)':\n%s", out)
+	}
+}
+
+func TestFormatProtectionFillAlert_PartialTPShort(t *testing.T) {
+	out := formatProtectionFillAlert(ProtectionFillAlert{
+		StrategyID:   "hl-bear-btc-live",
+		Symbol:       "BTC",
+		Side:         "short",
+		FillType:     "TP2",
+		IsPartial:    true,
+		FillPrice:    65000.0,
+		CloseQty:     0.005,
+		RemainingQty: 0.005,
+		RealizedPnL:  12.34,
+		HasPnL:       true,
+	})
+	for _, want := range []string{
+		"TP2 filled — hl-bear-btc-live (partial)",
+		"BTC SHORT",
+		"PnL=$12.34",
+		"Remaining: 0.005000 BTC",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in alert body:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatProtectionFillAlert_NoPnL(t *testing.T) {
+	out := formatProtectionFillAlert(ProtectionFillAlert{
+		StrategyID: "hl-x", Symbol: "BTC", Side: "long", FillType: "SL",
+		FillPrice: 50000, CloseQty: 0.1, HasPnL: false,
+	})
+	if strings.Contains(out, "PnL=") {
+		t.Errorf("expected no PnL line when HasPnL=false:\n%s", out)
+	}
+}
+
+func TestFormatProtectionFillAlert_UnknownPrice(t *testing.T) {
+	out := formatProtectionFillAlert(ProtectionFillAlert{
+		StrategyID: "hl-x", Symbol: "BTC", Side: "long", FillType: "SL",
+		FillPrice: 0, CloseQty: 0.1,
+	})
+	if !strings.Contains(out, "(fill price unknown)") {
+		t.Errorf("expected unknown-price marker:\n%s", out)
+	}
+}
+
+func TestNotifyProtectionFill_NilNotifierIsNoop(t *testing.T) {
+	// Should not panic.
+	notifyProtectionFill(nil, true, ProtectionFillAlert{StrategyID: "x"})
+}
+
+func TestNotifyProtectionFill_DisabledFlagSuppresses(t *testing.T) {
+	mn := &MultiNotifier{}
+	// With enabled=false the notifier must not be invoked. We can't observe
+	// SendOwnerDM's no-op directly, but the bare MultiNotifier has no backends
+	// so any path through is harmless — assert only that the call doesn't panic.
+	notifyProtectionFill(mn, false, ProtectionFillAlert{StrategyID: "x"})
+}
+
+func TestTPTierLabel(t *testing.T) {
+	cases := map[int]string{0: "TP1", 1: "TP2", 4: "TP5"}
+	for in, want := range cases {
+		if got := tpTierLabel(in); got != want {
+			t.Errorf("tpTierLabel(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestLastBookedTradePnL(t *testing.T) {
+	if got := lastBookedTradePnL(nil); got != 0 {
+		t.Errorf("nil state: got %v, want 0", got)
+	}
+	s := &StrategyState{}
+	if got := lastBookedTradePnL(s); got != 0 {
+		t.Errorf("empty history: got %v, want 0", got)
+	}
+	s.TradeHistory = []Trade{
+		{RealizedPnL: 1.5},
+		{RealizedPnL: -2.5},
+	}
+	if got := lastBookedTradePnL(s); got != -2.5 {
+		t.Errorf("last trade pnl: got %v, want -2.5", got)
+	}
+}
+
+func TestNotifyTPSLFillsEnabled_DefaultsToTrue(t *testing.T) {
+	var c *Config
+	if !c.NotifyTPSLFillsEnabled() {
+		t.Error("nil config must default to enabled")
+	}
+	c = &Config{}
+	if !c.NotifyTPSLFillsEnabled() {
+		t.Error("nil pointer field must default to enabled")
+	}
+	f := false
+	c.NotifyTPSLFills = &f
+	if c.NotifyTPSLFillsEnabled() {
+		t.Error("explicit false must disable")
+	}
+	tr := true
+	c.NotifyTPSLFills = &tr
+	if !c.NotifyTPSLFillsEnabled() {
+		t.Error("explicit true must enable")
+	}
+}
+
+func TestHyperliquidClearedTPTier_TierIndex(t *testing.T) {
+	sc := tieredTPATRSC()
+	// Tier 0 cleared, tier 1 active → idx=0
+	pos := &Position{Quantity: 0.422, TPOIDs: []int64{0, 222}}
+	if idx, ok := hyperliquidClearedTPTier(sc, pos, 0.211); !ok || idx != 0 {
+		t.Errorf("tier 0 cleared: idx=%d ok=%v, want 0,true", idx, ok)
+	}
+	// Tier 0 active, tier 1 cleared → idx=1
+	pos = &Position{Quantity: 0.422, TPOIDs: []int64{111, 0}}
+	if idx, ok := hyperliquidClearedTPTier(sc, pos, 0.211); !ok || idx != 1 {
+		t.Errorf("tier 1 cleared: idx=%d ok=%v, want 1,true", idx, ok)
+	}
+	// All tiers zero, full-close qty match → final tier (idx=1)
+	pos = &Position{Quantity: 0.422, TPOIDs: []int64{0, 0}}
+	if idx, ok := hyperliquidClearedTPTier(sc, pos, 0.422); !ok || idx != 1 {
+		t.Errorf("final tier: idx=%d ok=%v, want 1,true", idx, ok)
+	}
+	// All zero but qty mismatch → not attributable
+	if _, ok := hyperliquidClearedTPTier(sc, pos, 0.1); ok {
+		t.Error("ambiguous all-zero with mismatched qty must not attribute")
+	}
+}

--- a/scheduler/protection_fill_alert_test.go
+++ b/scheduler/protection_fill_alert_test.go
@@ -23,7 +23,7 @@ func TestFormatProtectionFillAlert_FullSL(t *testing.T) {
 		"ETH LONG",
 		"@ $1800.5000",
 		"Remaining: 0.000000 ETH",
-		"PnL=$-42.10",
+		"PnL=-$42.10",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("missing %q in alert body:\n%s", want, out)
@@ -79,17 +79,45 @@ func TestFormatProtectionFillAlert_UnknownPrice(t *testing.T) {
 	}
 }
 
-func TestNotifyProtectionFill_NilNotifierIsNoop(t *testing.T) {
-	// Should not panic.
+type countingDMSender struct {
+	count int
+	last  string
+}
+
+func (c *countingDMSender) SendOwnerDM(s string) {
+	c.count++
+	c.last = s
+}
+
+func TestNotifyProtectionFill_NilSenderIsNoop(t *testing.T) {
+	// Untyped nil interface — must not panic.
 	notifyProtectionFill(nil, true, ProtectionFillAlert{StrategyID: "x"})
+	// Typed nil *MultiNotifier wrapped in non-nil interface — must not panic.
+	var mn *MultiNotifier
+	notifyProtectionFill(mn, true, ProtectionFillAlert{StrategyID: "x"})
 }
 
 func TestNotifyProtectionFill_DisabledFlagSuppresses(t *testing.T) {
-	mn := &MultiNotifier{}
-	// With enabled=false the notifier must not be invoked. We can't observe
-	// SendOwnerDM's no-op directly, but the bare MultiNotifier has no backends
-	// so any path through is harmless — assert only that the call doesn't panic.
-	notifyProtectionFill(mn, false, ProtectionFillAlert{StrategyID: "x"})
+	c := &countingDMSender{}
+	notifyProtectionFill(c, false, ProtectionFillAlert{
+		StrategyID: "x", Symbol: "BTC", Side: "long", FillType: "SL", FillPrice: 100, CloseQty: 0.1,
+	})
+	if c.count != 0 {
+		t.Errorf("disabled flag must suppress; got %d invocations", c.count)
+	}
+}
+
+func TestNotifyProtectionFill_EnabledEmits(t *testing.T) {
+	c := &countingDMSender{}
+	notifyProtectionFill(c, true, ProtectionFillAlert{
+		StrategyID: "hl-x", Symbol: "BTC", Side: "long", FillType: "SL", FillPrice: 100, CloseQty: 0.1,
+	})
+	if c.count != 1 {
+		t.Fatalf("enabled must emit once; got %d", c.count)
+	}
+	if !strings.Contains(c.last, "SL filled — hl-x") {
+		t.Errorf("body missing headline: %s", c.last)
+	}
 }
 
 func TestTPTierLabel(t *testing.T) {


### PR DESCRIPTION
## Summary
- Reconciler-detected TP/SL fills now emit an owner DM the same cycle, instead of waiting for the next summary post (up to 5 minutes later). `sendTradeAlerts` is gated on the per-strategy execute loop's `trades` counter, which the reconciler bypasses entirely.
- Hooks at the three booking sites in `reconcileHyperliquidAccountPositions`: Detector 1 SL-owner full close, Detector 2 SL-owner partial, Detector 3 TP partial.
- TP tier label sourced from `hyperliquidProtectionTiers(sc)` via new `hyperliquidClearedTPTier(sc, pos, closeQty) (int, bool)` so operator-configured tier counts are honored (no hardcoded TP1/TP2 — see #660).
- Toggle: `notify_tp_sl_fills` (top-level, `*bool`, default true). Nil/missing keeps the alert on; explicit `false` disables.

## DM format
```
TP1 filled — hl-tema-eth-live (partial)
ETH LONG — 0.216000 @ $2340.9000
Remaining: 0.216000 ETH | PnL=$12.34
```

## Test plan
- [x] `go test ./scheduler/...` — full suite passes (21.5s)
- [x] `gofmt -l scheduler/` — clean
- [x] New tests: `TestFormatProtectionFillAlert_*`, `TestNotifyProtectionFill_*`, `TestTPTierLabel`, `TestLastBookedTradePnL`, `TestNotifyTPSLFillsEnabled_DefaultsToTrue`, `TestHyperliquidClearedTPTier_TierIndex`
- [x] Existing reconciler test call sites updated for the two new args (`notifier`, `notifyTPSLFills`); behavior unchanged when both nil/false

## Notes
- `applyHyperliquidProtectionSync` (the OID-clear path in `hyperliquid_protection.go`) was deliberately NOT chosen as the hook site — it doesn't book trades, so a DM there would either fire before the booking succeeds or double-fire alongside the reconciler. Single emission at the three `record*` call sites avoids both.
- `syncHyperliquidAccountPositions` (used by `--once` and tests) passes `nil, false` for the new args. The notifier-aware path is only the main loop's reconcile call.

Closes #661

---
LLM: Claude Opus 4.7 | high