### PR TITLE
fix: mark filled TP tiers with ✓ in position summaries

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1039,7 +1039,15 @@ func collectPositions(sc StrategyConfig, ss *StrategyState, prices map[string]fl
 			}
 		}
 		if tps := tieredTPATRPrices(sc, pos.Side, pos.AvgCost, pos.EntryATR); len(tps) > 0 {
+			// A zero TPOID alone is ambiguous (tiers also hold zero before the
+			// first protection-sync places them); require an observed shrink
+			// vs. InitialQuantity to mark a tier as filled (#662).
+			partiallyClosed := pos.InitialQuantity > 0 && pos.Quantity+1e-9 < pos.InitialQuantity
 			for i, tp := range tps {
+				if partiallyClosed && i < len(pos.TPOIDs) && pos.TPOIDs[i] == 0 {
+					extras += fmt.Sprintf(" | TP%d: $%s ✓", i+1, fmtComma2(tp))
+					continue
+				}
 				pct := percentFromEntry(pos.Side, pos.AvgCost, tp)
 				extras += fmt.Sprintf(" | TP%d: $%s (%s)", i+1, fmtComma2(tp), fmtPnlPct(pct))
 			}

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -1534,6 +1534,67 @@ func TestCollectPositions_TieredTPATR_OmittedWhenEntryATRZero(t *testing.T) {
 	}
 }
 
+// TestCollectPositions_TieredTPATR_FilledTierMarked verifies #662: once a TP
+// tier has filled (TPOID zeroed AND position quantity dropped below
+// InitialQuantity), the summary marks that tier with ✓ instead of rendering it
+// as still pending. Pending tiers retain the price-and-percent format.
+func TestCollectPositions_TieredTPATR_FilledTierMarked(t *testing.T) {
+	sc := StrategyConfig{
+		ID:              "hl-tatr-btc",
+		CloseStrategies: []StrategyRef{{Name: "tiered_tp_atr"}},
+	}
+	ss := &StrategyState{
+		Positions: map[string]*Position{
+			"BTC/USDT": {
+				Symbol:          "BTC/USDT",
+				Quantity:        0.0125,
+				InitialQuantity: 0.025,
+				AvgCost:         63500,
+				Side:            "long",
+				EntryATR:        1000,
+				TPOIDs:          []int64{0, 99999},
+			},
+		},
+	}
+	lines := collectPositions(sc, ss, map[string]float64{"BTC/USDT": 63500})
+	if !strings.Contains(lines[0], "| TP1: $64,500.00 ✓") {
+		t.Errorf("expected TP1 marked filled, got: %s", lines[0])
+	}
+	if !strings.Contains(lines[0], "| TP2: $65,500.00 (+3.1%)") {
+		t.Errorf("expected TP2 still pending, got: %s", lines[0])
+	}
+}
+
+// TestCollectPositions_TieredTPATR_NoFillBeforeProtectionSync verifies #662
+// edge case: TPOIDs all-zero before the first protection-sync places tiers
+// must NOT be rendered as filled (no shrink vs InitialQuantity).
+func TestCollectPositions_TieredTPATR_NoFillBeforeProtectionSync(t *testing.T) {
+	sc := StrategyConfig{
+		ID:              "hl-tatr-btc",
+		CloseStrategies: []StrategyRef{{Name: "tiered_tp_atr"}},
+	}
+	ss := &StrategyState{
+		Positions: map[string]*Position{
+			"BTC/USDT": {
+				Symbol:          "BTC/USDT",
+				Quantity:        0.025,
+				InitialQuantity: 0.025,
+				AvgCost:         63500,
+				Side:            "long",
+				EntryATR:        1000,
+				TPOIDs:          []int64{0, 0},
+			},
+		},
+	}
+	lines := collectPositions(sc, ss, map[string]float64{"BTC/USDT": 63500})
+	if strings.Contains(lines[0], "✓") {
+		t.Errorf("filled marker leaked before any TP fill, got: %s", lines[0])
+	}
+	if !strings.Contains(lines[0], "| TP1: $64,500.00 (+1.6%) | TP2: $65,500.00 (+3.1%)") {
+		t.Errorf("expected both tiers pending, got: %s", lines[0])
+	}
+}
+
 // TestCollectPositions_AllFragments_WithTieredTP verifies ATR → SL → TP1 → TP2 →
 // leverage → date ordering when tiered_tp_atr is configured (#528).
 func TestCollectPositions_AllFragments_WithTieredTP(t *testing.T) {


### PR DESCRIPTION
## Summary

`collectPositions` rendered every tier from `tieredTPATRPrices` regardless of fill state, so periodic summaries kept showing TP1 as pending even after it filled and shrunk the position. Mark a tier with `✓` when its `TPOIDs[i]==0` **and** the position has shrunk vs `InitialQuantity` — `TPOIDs` are also all-zero before the first protection-sync places tiers, so `OID==0` alone is ambiguous.

Both Discord and Telegram summaries share this formatter via `FormatCategorySummary`, so a single fix covers both surfaces.

## Test plan

- [x] `go test ./...` passes
- [x] New regression `TestCollectPositions_TieredTPATR_FilledTierMarked` covers the post-fill case
- [x] New regression `TestCollectPositions_TieredTPATR_NoFillBeforeProtectionSync` covers the pre-placement (all-zero OIDs, full quantity) case so the marker doesn't leak

Closes #662

---
LLM: Claude Opus 4.7 | high