### PR TITLE
feat: enrich trade alert DMs with OID, ATR mults, SL ordering

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1094,8 +1094,25 @@ func FormatTradeDM(sc StrategyConfig, trade Trade, mode string) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%s **%s - %s**\n", icon, header, strings.ToUpper(mode)))
 	sb.WriteString(fmt.Sprintf("Strategy: %s (%s %s)\n", sc.ID, platformLabel, typeLabel))
-	sb.WriteString(fmt.Sprintf("%s — %s %.3f @ $%s | Value: $%s\n", trade.Symbol, tradeDirectionLabel(trade), trade.Quantity, fmtComma(trade.Price), fmtComma(trade.Value)))
+	sb.WriteString(fmt.Sprintf("%s — %s %.3f @ $%s | Value: $%s", trade.Symbol, tradeDirectionLabel(trade), trade.Quantity, fmtComma(trade.Price), fmtComma(trade.Value)))
+	if oid := strings.TrimSpace(trade.ExchangeOrderID); oid != "" {
+		sb.WriteString(fmt.Sprintf(" | OID: %s", oid))
+	}
+	sb.WriteString("\n")
 
+	if extras := tradeAlertExtras(sc, trade, isClose); len(extras) > 0 {
+		sb.WriteString(strings.Join(extras, " | "))
+	}
+
+	return sb.String()
+}
+
+// tradeAlertExtras builds the extras line for trade-alert DMs (#665).
+// Order: PnL (close only) → Regime → ATR → SL → TP[1..n]. SL and each TP gain
+// an ATR multiplier suffix `(<n>x)` when EntryATR is known. Shared between
+// FormatTradeDM (Discord) and FormatTradeDMPlain (Telegram) so the two
+// channels can never drift on extras formatting.
+func tradeAlertExtras(sc StrategyConfig, trade Trade, isClose bool) []string {
 	var extras []string
 	if isClose {
 		if pnl, ok := extractPnL(trade.Details); ok {
@@ -1105,25 +1122,33 @@ func FormatTradeDM(sc StrategyConfig, trade Trade, mode string) string {
 	if trade.Regime != "" {
 		extras = append(extras, "Regime: "+trade.Regime)
 	}
+	direction := strings.ToLower(tradeDirectionLabel(trade))
+	var tps []float64
+	var tiers []hlProtectionTier
 	if !isClose && trade.EntryATR > 0 {
-		direction := strings.ToLower(tradeDirectionLabel(trade))
-		if tps := tieredTPATRPrices(sc, direction, trade.Price, trade.EntryATR); len(tps) > 0 {
+		tps = tieredTPATRPrices(sc, direction, trade.Price, trade.EntryATR)
+		if len(tps) > 0 {
+			tiers = hyperliquidProtectionTiers(sc)
 			extras = append(extras, fmt.Sprintf("ATR: $%s", fmtComma2(trade.EntryATR)))
-			for i, tp := range tps {
-				extras = append(extras, fmt.Sprintf("TP%d: $%s", i+1, fmtComma2(tp)))
-			}
 		}
 	}
 	if trade.StopLossTriggerPx > 0 {
-		direction := strings.ToLower(tradeDirectionLabel(trade))
 		slPct := percentFromEntry(direction, trade.Price, trade.StopLossTriggerPx)
-		extras = append(extras, fmt.Sprintf("SL: $%s (%s)", fmtComma2(trade.StopLossTriggerPx), fmtPnlPct(slPct)))
+		if trade.EntryATR > 0 {
+			atrMult := math.Abs(trade.Price-trade.StopLossTriggerPx) / trade.EntryATR
+			extras = append(extras, fmt.Sprintf("SL: $%s (%s) (%.2gx)", fmtComma2(trade.StopLossTriggerPx), fmtPnlPct(slPct), atrMult))
+		} else {
+			extras = append(extras, fmt.Sprintf("SL: $%s (%s)", fmtComma2(trade.StopLossTriggerPx), fmtPnlPct(slPct)))
+		}
 	}
-	if len(extras) > 0 {
-		sb.WriteString(strings.Join(extras, " | "))
+	for i, tp := range tps {
+		if i < len(tiers) {
+			extras = append(extras, fmt.Sprintf("TP%d: $%s (%.2gx)", i+1, fmtComma2(tp), tiers[i].Multiple))
+		} else {
+			extras = append(extras, fmt.Sprintf("TP%d: $%s", i+1, fmtComma2(tp)))
+		}
 	}
-
-	return sb.String()
+	return extras
 }
 
 // tradeSideToDirection converts buy/sell trade sides to LONG/SHORT direction labels.

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1033,7 +1033,7 @@ func collectPositions(sc StrategyConfig, ss *StrategyState, prices map[string]fl
 			slPct := percentFromEntry(pos.Side, pos.AvgCost, pos.StopLossTriggerPx)
 			if pos.EntryATR > 0 {
 				atrMult := math.Abs(pos.AvgCost-pos.StopLossTriggerPx) / pos.EntryATR
-				extras += fmt.Sprintf(" | SL: $%s (%s) (%.2gx)", fmtComma2(pos.StopLossTriggerPx), fmtPnlPct(slPct), atrMult)
+				extras += fmt.Sprintf(" | SL: $%s (%s) (%gx)", fmtComma2(pos.StopLossTriggerPx), fmtPnlPct(slPct), atrMult)
 			} else {
 				extras += fmt.Sprintf(" | SL: $%s (%s)", fmtComma2(pos.StopLossTriggerPx), fmtPnlPct(slPct))
 			}
@@ -1123,12 +1123,12 @@ func tradeAlertExtras(sc StrategyConfig, trade Trade, isClose bool) []string {
 		extras = append(extras, "Regime: "+trade.Regime)
 	}
 	direction := strings.ToLower(tradeDirectionLabel(trade))
-	var tps []float64
 	var tiers []hlProtectionTier
+	var tps []float64
 	if !isClose && trade.EntryATR > 0 {
-		tps = tieredTPATRPrices(sc, direction, trade.Price, trade.EntryATR)
+		tiers = hyperliquidProtectionTiers(sc)
+		tps = tieredTPATRPricesFromTiers(tiers, direction, trade.Price, trade.EntryATR)
 		if len(tps) > 0 {
-			tiers = hyperliquidProtectionTiers(sc)
 			extras = append(extras, fmt.Sprintf("ATR: $%s", fmtComma2(trade.EntryATR)))
 		}
 	}
@@ -1136,17 +1136,13 @@ func tradeAlertExtras(sc StrategyConfig, trade Trade, isClose bool) []string {
 		slPct := percentFromEntry(direction, trade.Price, trade.StopLossTriggerPx)
 		if trade.EntryATR > 0 {
 			atrMult := math.Abs(trade.Price-trade.StopLossTriggerPx) / trade.EntryATR
-			extras = append(extras, fmt.Sprintf("SL: $%s (%s) (%.2gx)", fmtComma2(trade.StopLossTriggerPx), fmtPnlPct(slPct), atrMult))
+			extras = append(extras, fmt.Sprintf("SL: $%s (%s) (%gx)", fmtComma2(trade.StopLossTriggerPx), fmtPnlPct(slPct), atrMult))
 		} else {
 			extras = append(extras, fmt.Sprintf("SL: $%s (%s)", fmtComma2(trade.StopLossTriggerPx), fmtPnlPct(slPct)))
 		}
 	}
 	for i, tp := range tps {
-		if i < len(tiers) {
-			extras = append(extras, fmt.Sprintf("TP%d: $%s (%.2gx)", i+1, fmtComma2(tp), tiers[i].Multiple))
-		} else {
-			extras = append(extras, fmt.Sprintf("TP%d: $%s", i+1, fmtComma2(tp)))
-		}
+		extras = append(extras, fmt.Sprintf("TP%d: $%s (%gx)", i+1, fmtComma2(tp), tiers[i].Multiple))
 	}
 	return extras
 }

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -1342,10 +1342,13 @@ func TestCollectPositions_StopLossATRMultiplier(t *testing.T) {
 		atr     float64
 		wantSub string
 	}{
-		// long: diff = 1000, mult = 1.0 → "1x" via %.2g
+		// long: diff = 1000, mult = 1.0 → "1x" via %g
 		{name: "long_1x", side: "long", avg: 10000, sl: 9000, atr: 1000, wantSub: "| SL: $9,000.00 (-10.0%) (1x)"},
 		// long: diff = 300, mult = 1.5 → "1.5x"
 		{name: "long_1.5x", side: "long", avg: 10000, sl: 9700, atr: 200, wantSub: "| SL: $9,700.00 (-3.0%) (1.5x)"},
+		// long: diff = 250, mult = 1.25 → "1.25x". %.2g would mangle to "1.3x"
+		// (#665 review): %g preserves the configured value.
+		{name: "long_1.25x", side: "long", avg: 10000, sl: 9750, atr: 200, wantSub: "| SL: $9,750.00 (-2.5%) (1.25x)"},
 		// short: diff = 1000, mult = 1.0 → "1x"
 		{name: "short_1x", side: "short", avg: 10000, sl: 11000, atr: 1000, wantSub: "| SL: $11,000.00 (-10.0%) (1x)"},
 	}
@@ -2304,6 +2307,38 @@ func TestFormatTradeDM_TPATRMultipliers(t *testing.T) {
 	}
 	if !strings.Contains(msg, "TP2: $65,500.00 (2x)") {
 		t.Errorf("expected TP2 with 2× multiplier, got:\n%s", msg)
+	}
+}
+
+// TestFormatTradeDM_TPATRMultipliersFractional verifies %g preserves
+// fractional tier multiples without rounding artifacts (#665 review). %.2g
+// would render 1.25→1.3 and 12.5→12.
+func TestFormatTradeDM_TPATRMultipliersFractional(t *testing.T) {
+	sc := StrategyConfig{
+		ID:       "hl-tatr-btc",
+		Platform: "hyperliquid",
+		Type:     "perps",
+		CloseStrategies: []StrategyRef{{
+			Name: "tiered_tp_atr",
+			Params: map[string]interface{}{
+				"tiers": []interface{}{
+					map[string]interface{}{"atr_multiple": 1.25, "close_fraction": 0.5},
+					map[string]interface{}{"atr_multiple": 2.5, "close_fraction": 1.0},
+				},
+			},
+		}},
+	}
+	trade := Trade{
+		Symbol: "BTC", Side: "buy", Quantity: 0.01, Price: 63500.0, Value: 635.0,
+		EntryATR: 1000.0,
+		Details:  "Open long 0.010000 @ $63500.00",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	if !strings.Contains(msg, "TP1: $64,750.00 (1.25x)") {
+		t.Errorf("expected TP1 with fractional 1.25× preserved, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "TP2: $66,000.00 (2.5x)") {
+		t.Errorf("expected TP2 with fractional 2.5× preserved, got:\n%s", msg)
 	}
 }
 

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -2197,6 +2197,182 @@ func TestFormatTradeDM_OpenWithSL(t *testing.T) {
 	}
 }
 
+// TestFormatTradeDM_IncludesOID verifies that when a live-fill Trade has a
+// non-empty ExchangeOrderID it is rendered on the symbol/value line as
+// `| OID: <id>` (#665).
+func TestFormatTradeDM_IncludesOID(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-eth-perps", Platform: "hyperliquid", Type: "perps"}
+	trade := Trade{
+		Symbol:          "ETH",
+		Side:            "buy",
+		Quantity:        0.432,
+		Price:           2306.00,
+		Value:           996.0,
+		ExchangeOrderID: "418206313303",
+		Details:         "Open long 0.432 @ $2306.00",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	if !strings.Contains(msg, "| Value: $996 | OID: 418206313303") {
+		t.Errorf("expected OID appended to symbol/value line, got:\n%s", msg)
+	}
+}
+
+// TestFormatTradeDM_PaperOmitsOID verifies that paper trades (empty
+// ExchangeOrderID) render no `| OID: …` segment so paper output is unchanged
+// from pre-#665 (#665 implementation note).
+func TestFormatTradeDM_PaperOmitsOID(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-eth-perps", Platform: "hyperliquid", Type: "perps"}
+	trade := Trade{
+		Symbol:   "ETH",
+		Side:     "buy",
+		Quantity: 0.432,
+		Price:    2306.00,
+		Value:    996.0,
+		Details:  "Open long 0.432 @ $2306.00",
+	}
+	msg := FormatTradeDM(sc, trade, "paper")
+	if strings.Contains(msg, "OID:") {
+		t.Errorf("paper trade should not render OID segment, got:\n%s", msg)
+	}
+}
+
+// TestFormatTradeDM_SLATRMultiplier verifies that when EntryATR is known the
+// SL line gains a `(<n>x)` ATR multiplier suffix (#665).
+func TestFormatTradeDM_SLATRMultiplier(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps"}
+	trade := Trade{
+		Symbol:            "BTC",
+		Side:              "buy",
+		Quantity:          0.01,
+		Price:             63500.0,
+		Value:             635.0,
+		EntryATR:          1500.0, // SL is 1× ATR below entry: 63500 - 1500 = 62000
+		StopLossTriggerPx: 62000.0,
+		Details:           "Open long 0.010000 @ $63500.00",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	// %.2g drops trailing zeros so 1.0 renders as "1".
+	if !strings.Contains(msg, "SL: $62,000.00 (-2.4%) (1x)") {
+		t.Errorf("expected SL line with ATR multiplier, got:\n%s", msg)
+	}
+}
+
+// TestFormatTradeDM_SLNoATRMultiplier verifies that when EntryATR is unknown
+// the SL line keeps the legacy format with no `(<n>x)` suffix instead of
+// rendering `(infx)` / `(0x)` (#665 implementation note).
+func TestFormatTradeDM_SLNoATRMultiplier(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps"}
+	trade := Trade{
+		Symbol:            "BTC",
+		Side:              "buy",
+		Quantity:          0.01,
+		Price:             63500.0,
+		Value:             635.0,
+		StopLossTriggerPx: 62000.0,
+		Details:           "Open long 0.010000 @ $63500.00",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	if !strings.Contains(msg, "SL: $62,000.00 (-2.4%)") {
+		t.Errorf("expected legacy SL line, got:\n%s", msg)
+	}
+	if strings.Contains(msg, "(0x)") || strings.Contains(msg, "(infx)") {
+		t.Errorf("SL line must not render bogus mult when EntryATR is missing, got:\n%s", msg)
+	}
+}
+
+// TestFormatTradeDM_TPATRMultipliers verifies that each TP tier renders its
+// own ATR multiplier (#665). Default tiers are 1×/2×.
+func TestFormatTradeDM_TPATRMultipliers(t *testing.T) {
+	sc := StrategyConfig{
+		ID:              "hl-tatr-btc",
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		CloseStrategies: []StrategyRef{{Name: "tiered_tp_atr"}},
+	}
+	trade := Trade{
+		Symbol:   "BTC",
+		Side:     "buy",
+		Quantity: 0.01,
+		Price:    63500.0,
+		Value:    635.0,
+		EntryATR: 1000.0,
+		Details:  "Open long 0.010000 @ $63500.00",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	if !strings.Contains(msg, "TP1: $64,500.00 (1x)") {
+		t.Errorf("expected TP1 with 1× multiplier, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "TP2: $65,500.00 (2x)") {
+		t.Errorf("expected TP2 with 2× multiplier, got:\n%s", msg)
+	}
+}
+
+// TestFormatTradeDM_ExtrasOrder verifies the new ordering: ATR → SL → TP1 → TP2
+// (#665). SL was previously appended after the TP tiers.
+func TestFormatTradeDM_ExtrasOrder(t *testing.T) {
+	sc := StrategyConfig{
+		ID:              "hl-tatr-btc",
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		CloseStrategies: []StrategyRef{{Name: "tiered_tp_atr"}},
+	}
+	trade := Trade{
+		Symbol:            "BTC",
+		Side:              "buy",
+		Quantity:          0.01,
+		Price:             63500.0,
+		Value:             635.0,
+		EntryATR:          1000.0,
+		StopLossTriggerPx: 62500.0,
+		Details:           "Open long 0.010000 @ $63500.00",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	atrIdx := strings.Index(msg, "ATR:")
+	slIdx := strings.Index(msg, "SL:")
+	tp1Idx := strings.Index(msg, "TP1:")
+	tp2Idx := strings.Index(msg, "TP2:")
+	if atrIdx < 0 || slIdx < 0 || tp1Idx < 0 || tp2Idx < 0 {
+		t.Fatalf("missing one of ATR/SL/TP1/TP2, got:\n%s", msg)
+	}
+	if !(atrIdx < slIdx && slIdx < tp1Idx && tp1Idx < tp2Idx) {
+		t.Errorf("expected ATR < SL < TP1 < TP2 ordering, got idx ATR=%d SL=%d TP1=%d TP2=%d:\n%s",
+			atrIdx, slIdx, tp1Idx, tp2Idx, msg)
+	}
+}
+
+// TestFormatTradeDMPlain_IncludesOID is the Telegram parity test for #665 —
+// OID, SL ordering, and ATR mults must apply to both Discord and Telegram
+// since they share `tradeAlertExtras`.
+func TestFormatTradeDMPlain_IncludesOID(t *testing.T) {
+	sc := StrategyConfig{
+		ID:              "hl-tatr-eth",
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		CloseStrategies: []StrategyRef{{Name: "tiered_tp_atr"}},
+	}
+	trade := Trade{
+		Symbol:            "ETH",
+		Side:              "buy",
+		Quantity:          0.5,
+		Price:             2300.0,
+		Value:             1150.0,
+		EntryATR:          15.0,
+		StopLossTriggerPx: 2285.0,
+		ExchangeOrderID:   "987654321",
+		Details:           "Open long 0.5 @ $2300.00",
+	}
+	msg := FormatTradeDMPlain(sc, trade, "live")
+	if !strings.Contains(msg, "| OID: 987654321") {
+		t.Errorf("expected OID on Telegram DM, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "SL: $2,285.00 (-0.7%) (1x)") {
+		t.Errorf("expected SL with mult on Telegram DM, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "TP1: $2,315.00 (1x)") {
+		t.Errorf("expected TP1 with mult on Telegram DM, got:\n%s", msg)
+	}
+}
+
 // TestFormatTradeDM_CloseNoATR verifies that ATR/TP hints are NOT injected on
 // close legs even when EntryATR is set and the strategy uses tiered_tp_atr (#561).
 func TestFormatTradeDM_CloseNoATR(t *testing.T) {

--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -107,11 +107,14 @@ type hlProtectionTier struct {
 // (#659). Returns nil when the strategy doesn't use tiered_tp_atr* or any
 // required input is missing.
 func tieredTPATRPrices(sc StrategyConfig, side string, entryPrice, entryATR float64) []float64 {
-	if entryATR <= 0 || entryPrice <= 0 {
-		return nil
-	}
-	tiers := hyperliquidProtectionTiers(sc)
-	if len(tiers) == 0 {
+	return tieredTPATRPricesFromTiers(hyperliquidProtectionTiers(sc), side, entryPrice, entryATR)
+}
+
+// tieredTPATRPricesFromTiers is the price-only computation when the caller
+// already has tiers in hand — lets trade-alert extras call
+// hyperliquidProtectionTiers once and zip prices with multiples (#665 review).
+func tieredTPATRPricesFromTiers(tiers []hlProtectionTier, side string, entryPrice, entryATR float64) []float64 {
+	if len(tiers) == 0 || entryATR <= 0 || entryPrice <= 0 {
 		return nil
 	}
 	sideLower := strings.ToLower(strings.TrimSpace(side))

--- a/scheduler/telegram.go
+++ b/scheduler/telegram.go
@@ -254,32 +254,13 @@ func FormatTradeDMPlain(sc StrategyConfig, trade Trade, mode string) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%s %s - %s\n", icon, header, strings.ToUpper(mode)))
 	sb.WriteString(fmt.Sprintf("Strategy: %s (%s %s)\n", sc.ID, platformLabel, typeLabel))
-	sb.WriteString(fmt.Sprintf("%s — %s %.3f @ $%s | Value: $%s\n", trade.Symbol, tradeDirectionLabel(trade), trade.Quantity, fmtComma(trade.Price), fmtComma(trade.Value)))
+	sb.WriteString(fmt.Sprintf("%s — %s %.3f @ $%s | Value: $%s", trade.Symbol, tradeDirectionLabel(trade), trade.Quantity, fmtComma(trade.Price), fmtComma(trade.Value)))
+	if oid := strings.TrimSpace(trade.ExchangeOrderID); oid != "" {
+		sb.WriteString(fmt.Sprintf(" | OID: %s", oid))
+	}
+	sb.WriteString("\n")
 
-	var extras []string
-	if isClose {
-		if pnl, ok := extractPnL(trade.Details); ok {
-			extras = append(extras, fmt.Sprintf("PnL: $%s", pnl))
-		}
-	}
-	if trade.Regime != "" {
-		extras = append(extras, "Regime: "+trade.Regime)
-	}
-	if !isClose && trade.EntryATR > 0 {
-		direction := strings.ToLower(tradeDirectionLabel(trade))
-		if tps := tieredTPATRPrices(sc, direction, trade.Price, trade.EntryATR); len(tps) > 0 {
-			extras = append(extras, fmt.Sprintf("ATR: $%s", fmtComma2(trade.EntryATR)))
-			for i, tp := range tps {
-				extras = append(extras, fmt.Sprintf("TP%d: $%s", i+1, fmtComma2(tp)))
-			}
-		}
-	}
-	if trade.StopLossTriggerPx > 0 {
-		direction := strings.ToLower(tradeDirectionLabel(trade))
-		slPct := percentFromEntry(direction, trade.Price, trade.StopLossTriggerPx)
-		extras = append(extras, fmt.Sprintf("SL: $%s (%s)", fmtComma2(trade.StopLossTriggerPx), fmtPnlPct(slPct)))
-	}
-	if len(extras) > 0 {
+	if extras := tradeAlertExtras(sc, trade, isClose); len(extras) > 0 {
 		sb.WriteString(strings.Join(extras, " | "))
 	}
 


### PR DESCRIPTION
## Summary
- **OID on symbol line**: live fills now render `| OID: <exchange_order_id>` after `| Value: $…` so trade alerts cross-reference cleanly with exchange order history. Paper fills (empty `ExchangeOrderID`) keep the legacy line.
- **SL after ATR, before TPs**: extras order is now `PnL → Regime → ATR → SL → TP[1..n]`. SL was previously appended after the TP tiers.
- **ATR multipliers**: SL gains `(<n>x)` when `EntryATR > 0`; each TP tier gains its own `(<n>x)` sourced from `hyperliquidProtectionTiers(sc)`. Falls back to legacy format when ATR is unknown — never renders `(infx)` / `(0x)`.
- **Shared helper**: extracted `tradeAlertExtras` so `FormatTradeDM` (Discord) and `FormatTradeDMPlain` (Telegram) can never drift on the extras line.

Example (open, live, with tiered TP and SL):

```
🟢 **TRADE EXECUTED - LIVE**
Strategy: hl-tatr-eth (Hyperliquid perps)
ETH — LONG 0.500 @ $2,300 | Value: $1,150 | OID: 987654321
ATR: $15.00 | SL: $2,285.00 (-0.7%) (1x) | TP1: $2,315.00 (1x) | TP2: $2,330.00 (2x)
```

Closes #665

## Test plan
- [x] `go test ./...` (full scheduler suite, 21s)
- [x] `gofmt -w` on all touched files
- [x] `go build` with version stamp
- [x] New unit tests for OID present/absent, SL ATR mult present/absent, TP ATR mults, extras ordering, Telegram parity
- [ ] Manual smoke: deploy and verify a live HL fill renders OID + new SL/TP ordering in Discord

---
LLM: Claude Opus 4.7 | high