### PR TITLE
feat: persist SL ATR mult + TP tier snapshot on trades for analytics

### DIFF
--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -76,6 +76,8 @@ CREATE TABLE IF NOT EXISTS positions (
     tp1_oid INTEGER NOT NULL DEFAULT 0,
     tp2_oid INTEGER NOT NULL DEFAULT 0,
     tp_oids_json TEXT NOT NULL DEFAULT '',
+    stop_loss_atr_mult REAL,
+    tp_tiers_json TEXT NOT NULL DEFAULT '',
     PRIMARY KEY (strategy_id, symbol)
 );
 
@@ -159,7 +161,9 @@ CREATE TABLE IF NOT EXISTS trades (
     exchange_order_id TEXT NOT NULL DEFAULT '',
     exchange_fee REAL NOT NULL DEFAULT 0,
     is_close INTEGER NOT NULL DEFAULT 0,
-    realized_pnl REAL NOT NULL DEFAULT 0
+    realized_pnl REAL NOT NULL DEFAULT 0,
+    stop_loss_atr_mult REAL,
+    tp_tiers_json TEXT NOT NULL DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_trades_strategy ON trades(strategy_id);
@@ -305,6 +309,16 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE positions ADD COLUMN tp_oids_json TEXT NOT NULL DEFAULT ''",
 		// Inline TP OIDs for manual-open actions so the scheduler drain sets pos.TPOIDs (#632).
 		"ALTER TABLE pending_manual_actions ADD COLUMN tp_oids_json TEXT NOT NULL DEFAULT ''",
+		// SL arming method + TP tier snapshot at fill time (#669). stop_loss_atr_mult
+		// stays nullable: NULL = legacy/unknown or non-ATR arming (pct/margin/trailing-pct);
+		// non-NULL = ATR-armed at the recorded multiplier. tp_tiers_json carries the
+		// full tier snapshot ([{atr_multiple,close_fraction},...]) so historical
+		// tier-config edits don't erase the record. Both columns are additive — no
+		// backfill of legacy rows.
+		"ALTER TABLE trades ADD COLUMN stop_loss_atr_mult REAL",
+		"ALTER TABLE trades ADD COLUMN tp_tiers_json TEXT NOT NULL DEFAULT ''",
+		"ALTER TABLE positions ADD COLUMN stop_loss_atr_mult REAL",
+		"ALTER TABLE positions ADD COLUMN tp_tiers_json TEXT NOT NULL DEFAULT ''",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -544,27 +558,41 @@ func (sdb *StateDB) InsertTrade(strategyID string, trade Trade) error {
 		isManual = 1
 	}
 	_, err := sdb.db.Exec(`INSERT INTO trades
-			(strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, regime, entry_atr, stop_loss_trigger_px, manual)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			(strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, regime, entry_atr, stop_loss_trigger_px, manual, stop_loss_atr_mult, tp_tiers_json)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		strategyID, formatTime(trade.Timestamp), trade.Symbol, trade.PositionID, trade.Side,
 		trade.Quantity, trade.Price, trade.Value, trade.TradeType, trade.Details,
 		trade.ExchangeOrderID, trade.ExchangeFee, isClose, trade.RealizedPnL, trade.Regime,
-		trade.EntryATR, trade.StopLossTriggerPx, isManual)
+		trade.EntryATR, trade.StopLossTriggerPx, isManual,
+		nullableFloat64(trade.StopLossATRMult), trade.TPTiersJSON)
 	if err != nil {
 		return fmt.Errorf("insert trade for %s: %w", strategyID, err)
 	}
 	return nil
 }
 
-// UpdateTradeStampedFields sets entry_atr and stop_loss_trigger_px on an
-// existing trade row identified by (strategy_id, timestamp). Called after
-// RecordTrade once the corresponding position values are available.
-func (sdb *StateDB) UpdateTradeStampedFields(strategyID string, ts time.Time, entryATR, stopLossTriggerPx float64) error {
+// UpdateTradeStampedFields sets entry_atr, stop_loss_trigger_px,
+// stop_loss_atr_mult, and tp_tiers_json on an existing trade row identified by
+// (strategy_id, timestamp). Called after RecordTrade once the corresponding
+// position values are available. stopLossATRMult==nil writes SQL NULL so the
+// "ATR-armed?" gate stays interpretable from nullness alone (#669).
+func (sdb *StateDB) UpdateTradeStampedFields(strategyID string, ts time.Time, entryATR, stopLossTriggerPx float64, stopLossATRMult *float64, tpTiersJSON string) error {
 	_, err := sdb.db.Exec(
-		`UPDATE trades SET entry_atr = ?, stop_loss_trigger_px = ? WHERE strategy_id = ? AND timestamp = ?`,
-		entryATR, stopLossTriggerPx, strategyID, formatTime(ts),
+		`UPDATE trades SET entry_atr = ?, stop_loss_trigger_px = ?, stop_loss_atr_mult = ?, tp_tiers_json = ? WHERE strategy_id = ? AND timestamp = ?`,
+		entryATR, stopLossTriggerPx, nullableFloat64(stopLossATRMult), tpTiersJSON, strategyID, formatTime(ts),
 	)
 	return err
+}
+
+// nullableFloat64 returns a *float64 unchanged for use with database/sql so a
+// nil pointer maps to SQL NULL while a non-nil pointer's value is bound. The
+// helper exists purely as a callsite-readability anchor — passing the *float64
+// directly works the same way under database/sql but obscures intent.
+func nullableFloat64(v *float64) interface{} {
+	if v == nil {
+		return nil
+	}
+	return *v
 }
 
 // SetInitialCapital is the ONLY sanctioned way to change a strategy's
@@ -704,8 +732,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	}
 	defer stmtStrat.Close()
 
-	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, tp1_oid, tp2_oid, tp_oids_json)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, tp1_oid, tp2_oid, tp_oids_json, stop_loss_atr_mult, tp_tiers_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare position insert: %w", err)
 	}
@@ -756,7 +784,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		for _, pos := range s.Positions {
 			positionID := ensurePositionTradeID(s.ID, pos.Symbol, pos)
 			tp1OID, tp2OID := firstTwoTPOIDs(pos.TPOIDs)
-			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx, tp1OID, tp2OID, marshalTPOIDsJSON(pos.TPOIDs)); err != nil {
+			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx, tp1OID, tp2OID, marshalTPOIDsJSON(pos.TPOIDs), nullableFloat64(pos.StopLossATRMult), pos.TPTiersJSON); err != nil {
 				return fmt.Errorf("insert position %s/%s: %w", s.ID, pos.Symbol, err)
 			}
 		}
@@ -781,8 +809,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	//    failed, even if later-timestamped rows were persisted successfully
 	//    (fixes the MAX(timestamp) dedup gap that would silently drop
 	//    out-of-order retries).
-	stmtTrade, err := tx.Prepare(`INSERT INTO trades (strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, regime, entry_atr, stop_loss_trigger_px, manual)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtTrade, err := tx.Prepare(`INSERT INTO trades (strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, regime, entry_atr, stop_loss_trigger_px, manual, stop_loss_atr_mult, tp_tiers_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare trade insert: %w", err)
 	}
@@ -810,7 +838,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 			if t.Manual {
 				isManual = 1
 			}
-			if _, err := stmtTrade.Exec(s.ID, formatTime(t.Timestamp), t.Symbol, t.PositionID, t.Side, t.Quantity, t.Price, t.Value, t.TradeType, t.Details, t.ExchangeOrderID, t.ExchangeFee, isClose, t.RealizedPnL, t.Regime, t.EntryATR, t.StopLossTriggerPx, isManual); err != nil {
+			if _, err := stmtTrade.Exec(s.ID, formatTime(t.Timestamp), t.Symbol, t.PositionID, t.Side, t.Quantity, t.Price, t.Value, t.TradeType, t.Details, t.ExchangeOrderID, t.ExchangeFee, isClose, t.RealizedPnL, t.Regime, t.EntryATR, t.StopLossTriggerPx, isManual, nullableFloat64(t.StopLossATRMult), t.TPTiersJSON); err != nil {
 				return fmt.Errorf("insert trade for %s: %w", s.ID, err)
 			}
 			flushed = append(flushed, trackedFlush{strat: s, index: i})
@@ -1167,7 +1195,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	}
 
 	// 3. Load positions for each strategy.
-	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, COALESCE(tp1_oid, 0) AS tp1_oid, COALESCE(tp2_oid, 0) AS tp2_oid, COALESCE(tp_oids_json, '') AS tp_oids_json FROM positions")
+	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, COALESCE(tp1_oid, 0) AS tp1_oid, COALESCE(tp2_oid, 0) AS tp2_oid, COALESCE(tp_oids_json, '') AS tp_oids_json, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json FROM positions")
 	if err != nil {
 		return nil, fmt.Errorf("load positions: %w", err)
 	}
@@ -1178,11 +1206,16 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		var openedAtStr string
 		var tp1OID, tp2OID int64
 		var tpOIDsJSON string
-		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx, &tp1OID, &tp2OID, &tpOIDsJSON); err != nil {
+		var slATRMult sql.NullFloat64
+		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx, &tp1OID, &tp2OID, &tpOIDsJSON, &slATRMult, &pos.TPTiersJSON); err != nil {
 			return nil, fmt.Errorf("scan position: %w", err)
 		}
 		pos.OpenedAt = parseTime(openedAtStr)
 		pos.TPOIDs = parseTPOIDsJSON(tpOIDsJSON, tp1OID, tp2OID)
+		if slATRMult.Valid {
+			v := slATRMult.Float64
+			pos.StopLossATRMult = &v
+		}
 		if s, ok := state.Strategies[stratID]; ok {
 			s.Positions[pos.Symbol] = &pos
 		}
@@ -1222,7 +1255,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 
 	// 5. Load most recent 1000 trades per strategy (full history stays in SQLite).
 	for id, s := range state.Strategies {
-		tradeRows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime, COALESCE(entry_atr, 0) AS entry_atr, COALESCE(stop_loss_trigger_px, 0) AS stop_loss_trigger_px, COALESCE(manual, 0) AS manual
+		tradeRows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime, COALESCE(entry_atr, 0) AS entry_atr, COALESCE(stop_loss_trigger_px, 0) AS stop_loss_trigger_px, COALESCE(manual, 0) AS manual, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json
 			FROM trades WHERE strategy_id = ? ORDER BY timestamp ASC`, id)
 		if err != nil {
 			return nil, fmt.Errorf("load trades for %s: %w", id, err)
@@ -1232,13 +1265,18 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 			var t Trade
 			var tsStr string
 			var isCloseInt, isManualInt int
-			if err := tradeRows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL, &t.Regime, &t.EntryATR, &t.StopLossTriggerPx, &isManualInt); err != nil {
+			var slATRMult sql.NullFloat64
+			if err := tradeRows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL, &t.Regime, &t.EntryATR, &t.StopLossTriggerPx, &isManualInt, &slATRMult, &t.TPTiersJSON); err != nil {
 				tradeRows.Close()
 				return nil, fmt.Errorf("scan trade: %w", err)
 			}
 			t.Timestamp = parseTime(tsStr)
 			t.IsClose = isCloseInt != 0
 			t.Manual = isManualInt != 0
+			if slATRMult.Valid {
+				v := slATRMult.Float64
+				t.StopLossATRMult = &v
+			}
 			t.persisted = true // loaded from DB → already persisted; SaveState will skip.
 			allTrades = append(allTrades, t)
 		}
@@ -1434,7 +1472,7 @@ func (sdb *StateDB) QueryTradeHistory(strategyID, symbol string, since, until ti
 		limit = 500
 	}
 
-	query := fmt.Sprintf("SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime, COALESCE(entry_atr, 0) AS entry_atr, COALESCE(stop_loss_trigger_px, 0) AS stop_loss_trigger_px FROM trades %s ORDER BY timestamp DESC LIMIT ? OFFSET ?", whereClause)
+	query := fmt.Sprintf("SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime, COALESCE(entry_atr, 0) AS entry_atr, COALESCE(stop_loss_trigger_px, 0) AS stop_loss_trigger_px, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json FROM trades %s ORDER BY timestamp DESC LIMIT ? OFFSET ?", whereClause)
 	queryArgs := append(args, limit, offset)
 	rows, err := sdb.db.Query(query, queryArgs...)
 	if err != nil {
@@ -1447,11 +1485,16 @@ func (sdb *StateDB) QueryTradeHistory(strategyID, symbol string, since, until ti
 		var t Trade
 		var tsStr string
 		var isCloseInt int
-		if err := rows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL, &t.Regime, &t.EntryATR, &t.StopLossTriggerPx); err != nil {
+		var slATRMult sql.NullFloat64
+		if err := rows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL, &t.Regime, &t.EntryATR, &t.StopLossTriggerPx, &slATRMult, &t.TPTiersJSON); err != nil {
 			return nil, 0, fmt.Errorf("scan trade: %w", err)
 		}
 		t.Timestamp = parseTime(tsStr)
 		t.IsClose = isCloseInt != 0
+		if slATRMult.Valid {
+			v := slATRMult.Float64
+			t.StopLossATRMult = &v
+		}
 		trades = append(trades, t)
 	}
 	if err := rows.Err(); err != nil {

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1126,7 +1126,7 @@ func tradeAlertExtras(sc StrategyConfig, trade Trade, isClose bool) []string {
 	var tiers []hlProtectionTier
 	var tps []float64
 	if !isClose && trade.EntryATR > 0 {
-		tiers = hyperliquidProtectionTiers(sc)
+		tiers = strategyTPTiers(sc)
 		tps = tieredTPATRPricesFromTiers(tiers, direction, trade.Price, trade.EntryATR)
 		if len(tps) > 0 {
 			extras = append(extras, fmt.Sprintf("ATR: $%s", fmtComma2(trade.EntryATR)))

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -863,7 +863,7 @@ func hyperliquidClearedTPTier(sc StrategyConfig, pos *Position, closeQty float64
 	if pos == nil || len(pos.TPOIDs) == 0 {
 		return 0, false
 	}
-	tiers := hyperliquidProtectionTiers(sc)
+	tiers := strategyTPTiers(sc)
 	if len(tiers) == 0 {
 		return 0, false
 	}
@@ -1659,6 +1659,8 @@ func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, f
 		Regime:            s.Regime,
 		EntryATR:          pos.EntryATR,
 		StopLossTriggerPx: pos.StopLossTriggerPx,
+		StopLossATRMult:   pos.StopLossATRMult,
+		TPTiersJSON:       pos.TPTiersJSON,
 	})
 	RecordTradeResult(&s.RiskState, pnl)
 

--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -33,7 +33,7 @@ func buildHyperliquidProtectionPlan(sc StrategyConfig, pos *Position) (hlProtect
 	if sc.StopLossATRMult != nil && *sc.StopLossATRMult > 0 {
 		slMult = *sc.StopLossATRMult
 	}
-	tiers := hyperliquidProtectionTiers(sc)
+	tiers := strategyTPTiers(sc)
 	if slMult <= 0 && len(tiers) == 0 {
 		return hlProtectionPlan{}, false
 	}
@@ -50,13 +50,13 @@ func buildHyperliquidProtectionPlan(sc StrategyConfig, pos *Position) (hlProtect
 	}, true
 }
 
-// hyperliquidProtectionTiers returns the cumulative ATR take-profit tiers used
+// strategyTPTiers returns the cumulative ATR take-profit tiers used
 // to place per-strategy reduce-only limit orders. Fractions are cumulative,
 // matching the tiered_tp_atr close evaluator: 0.5/0.8/1.0 becomes order sizes
 // of 50%, 30%, and 20% of the current virtual quantity (#612). The final tier
 // is coerced to 1.0 so older two-tier configs that ended below 100% keep the
 // prior "everything remaining" TP2 behavior from #604.
-func hyperliquidProtectionTiers(sc StrategyConfig) []hlProtectionTier {
+func strategyTPTiers(sc StrategyConfig) []hlProtectionTier {
 	if !strategyUsesTieredTPATRClose(sc) {
 		return nil
 	}
@@ -103,16 +103,16 @@ type hlProtectionTier struct {
 // tieredTPATRPrices returns the take-profit prices for each configured tier
 // given a position's entry price, side ("long"/"short"), and EntryATR. Display
 // helper for Discord/Telegram alerts so the rendered TPs can never diverge
-// from the on-chain reduce-only orders placed via hyperliquidProtectionTiers
+// from the on-chain reduce-only orders placed via strategyTPTiers
 // (#659). Returns nil when the strategy doesn't use tiered_tp_atr* or any
 // required input is missing.
 func tieredTPATRPrices(sc StrategyConfig, side string, entryPrice, entryATR float64) []float64 {
-	return tieredTPATRPricesFromTiers(hyperliquidProtectionTiers(sc), side, entryPrice, entryATR)
+	return tieredTPATRPricesFromTiers(strategyTPTiers(sc), side, entryPrice, entryATR)
 }
 
 // tieredTPATRPricesFromTiers is the price-only computation when the caller
 // already has tiers in hand — lets trade-alert extras call
-// hyperliquidProtectionTiers once and zip prices with multiples (#665 review).
+// strategyTPTiers once and zip prices with multiples (#665 review).
 func tieredTPATRPricesFromTiers(tiers []hlProtectionTier, side string, entryPrice, entryATR float64) []float64 {
 	if len(tiers) == 0 || entryATR <= 0 || entryPrice <= 0 {
 		return nil
@@ -388,7 +388,7 @@ func hyperliquidPlacesOnChainTPs(sc StrategyConfig) bool {
 	if (sc.Type != "perps" && sc.Type != "manual") || sc.Platform != "hyperliquid" {
 		return false
 	}
-	return len(hyperliquidProtectionTiers(sc)) > 0
+	return len(strategyTPTiers(sc)) > 0
 }
 
 // closeStrategiesSuppressedByOnChainProtection is the set of close evaluator

--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -367,8 +367,10 @@ func runHyperliquidProtectionSync(
 	// Re-stamp TradeHistory so the trade alert picks up SL/TP prices placed
 	// by the protection sync (#625). Without this, execute-path SL=0 leaves the
 	// trade's StopLossTriggerPx unset even though the sync correctly populated
-	// pos.StopLossTriggerPx — the alert then shows no SL price.
-	stampOpenTradeFromPosition(stratState, db, symbol, pos)
+	// pos.StopLossTriggerPx — the alert then shows no SL price. Also stamp the
+	// SL ATR mult + TP tier snapshot so trades opened pre-arming get the
+	// fill-time config recorded in SQLite (#669).
+	stampOpenTradeWithProtectionSnapshot(stratState, db, sc, symbol, pos)
 	if logger != nil {
 		logger.Info("%s (sl_oid=%d tp_oids=%v)", logTag, pos.StopLossOID, pos.TPOIDs)
 	}

--- a/scheduler/hyperliquid_protection_test.go
+++ b/scheduler/hyperliquid_protection_test.go
@@ -329,7 +329,7 @@ func TestHyperliquidProtectionTiersCoercesFinalTierToFullCoverage(t *testing.T) 
 		}}},
 	}
 	want := []hlProtectionTier{{Multiple: 1, Fraction: 0.5}, {Multiple: 2, Fraction: 1}}
-	if got := hyperliquidProtectionTiers(sc); !reflect.DeepEqual(got, want) {
+	if got := strategyTPTiers(sc); !reflect.DeepEqual(got, want) {
 		t.Errorf("tiers = %+v, want %+v", got, want)
 	}
 }
@@ -345,7 +345,7 @@ func TestHyperliquidProtectionTiersRejectsNonIncreasingAfterSort(t *testing.T) {
 			},
 		}}},
 	}
-	if got := hyperliquidProtectionTiers(sc); len(got) != 0 {
+	if got := strategyTPTiers(sc); len(got) != 0 {
 		t.Errorf("tiers = %+v, want nil/empty for non-increasing sorted fractions", got)
 	}
 }
@@ -367,7 +367,7 @@ func TestHyperliquidProtectionTiersPreservesDuplicateMultipleOrder(t *testing.T)
 		{Multiple: 1, Fraction: 0.6},
 		{Multiple: 2, Fraction: 1},
 	}
-	if got := hyperliquidProtectionTiers(sc); !reflect.DeepEqual(got, want) {
+	if got := strategyTPTiers(sc); !reflect.DeepEqual(got, want) {
 		t.Errorf("tiers = %+v, want stable duplicate-multiple order %+v", got, want)
 	}
 }
@@ -554,7 +554,7 @@ func TestHyperliquidProtectionTiersRejectsSingleTier(t *testing.T) {
 			},
 		}}},
 	}
-	if got := hyperliquidProtectionTiers(sc); len(got) != 0 {
+	if got := strategyTPTiers(sc); len(got) != 0 {
 		t.Errorf("tiers = %+v, want nil/empty for single-tier config", got)
 	}
 }

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1438,7 +1438,7 @@ func main() {
 										}
 									} else if newTrigger > 0 && pos.StopLossTriggerPx == 0 {
 										pos.StopLossTriggerPx = newTrigger
-										stampOpenTradeFromPosition(stratState, stateDB, result.Symbol, pos)
+										stampOpenTradeWithProtectionSnapshot(stratState, stateDB, sc, result.Symbol, pos)
 										logger.Info("Paper fixed ATR SL armed @ $%.4f (%.2f%% from entry $%.4f)",
 											newTrigger, effectiveFixedStopLossATRPct(sc, hlPosSnapshot), pos.AvgCost)
 									}
@@ -1464,7 +1464,7 @@ func main() {
 											} else if slResult.StopLossOID > 0 {
 												pos.StopLossOID = slResult.StopLossOID
 												pos.StopLossTriggerPx = slResult.StopLossTriggerPx
-												stampOpenTradeFromPosition(stratState, stateDB, result.Symbol, pos)
+												stampOpenTradeWithProtectionSnapshot(stratState, stateDB, sc, result.Symbol, pos)
 												logger.Info("Fixed ATR SL armed oid=%d @ $%.4f", slResult.StopLossOID, slResult.StopLossTriggerPx)
 											}
 										}
@@ -2079,7 +2079,7 @@ func executeSpotResult(sc StrategyConfig, s *StrategyState, db *StateDB, result 
 	}
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
 	if pos, ok := s.Positions[result.Symbol]; ok {
-		stampOpenTradeFromPosition(s, db, result.Symbol, pos)
+		stampOpenTradeWithProtectionSnapshot(s, db, sc, result.Symbol, pos)
 	}
 
 	detail := ""
@@ -2609,7 +2609,7 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, db *StateDB, 
 	}
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
 	if pos, ok := s.Positions[result.Symbol]; ok {
-		stampOpenTradeFromPosition(s, db, result.Symbol, pos)
+		stampOpenTradeWithProtectionSnapshot(s, db, sc, result.Symbol, pos)
 	}
 	if trades > 0 && fillOID != "" {
 		logger.Info("Exchange order ID: %s", fillOID)
@@ -2633,7 +2633,7 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, db *StateDB, 
 				pos.StopLossOID = slOID
 				pos.StopLossTriggerPx = execResult.Execution.Fill.StopLossTriggerPx
 				logger.Info("SL trigger placed oid=%d @ $%.4f", slOID, execResult.Execution.Fill.StopLossTriggerPx)
-				stampOpenTradeFromPosition(s, db, result.Symbol, pos)
+				stampOpenTradeWithProtectionSnapshot(s, db, sc, result.Symbol, pos)
 			}
 		}
 	}
@@ -2846,7 +2846,7 @@ func executeTopStepResult(sc StrategyConfig, s *StrategyState, db *StateDB, resu
 	}
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
 	if pos, ok := s.Positions[result.Symbol]; ok {
-		stampOpenTradeFromPosition(s, db, result.Symbol, pos)
+		stampOpenTradeWithProtectionSnapshot(s, db, sc, result.Symbol, pos)
 	}
 
 	detail := ""
@@ -3009,7 +3009,7 @@ func executeRobinhoodResult(sc StrategyConfig, s *StrategyState, db *StateDB, re
 	}
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
 	if pos, ok := s.Positions[result.Symbol]; ok {
-		stampOpenTradeFromPosition(s, db, result.Symbol, pos)
+		stampOpenTradeWithProtectionSnapshot(s, db, sc, result.Symbol, pos)
 	}
 
 	detail := ""
@@ -3220,7 +3220,7 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *
 	}
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
 	if pos, ok := s.Positions[result.Symbol]; ok {
-		stampOpenTradeFromPosition(s, db, result.Symbol, pos)
+		stampOpenTradeWithProtectionSnapshot(s, db, sc, result.Symbol, pos)
 	}
 
 	detail := ""

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -561,6 +561,10 @@ func applyManualAction(state *AppState, scByID map[string]StrategyConfig, a Pend
 			TPOIDs:            a.TPOIDs,
 		}
 		pos.TradePositionID = newTradePositionID(a.StrategyID, a.Symbol, now)
+		// Stamp SL ATR mult + TP tier snapshot at fill time so the analytics
+		// row in `trades` reflects the config that armed the order, not whatever
+		// the operator edits later (#669).
+		stampPositionProtectionSnapshot(pos, sc)
 		ss.Positions[a.Symbol] = pos
 
 		trade := Trade{
@@ -578,6 +582,8 @@ func applyManualAction(state *AppState, scByID map[string]StrategyConfig, a Pend
 			ExchangeFee:       a.FillFee,
 			EntryATR:          a.EntryATR,
 			StopLossTriggerPx: a.StopLossTriggerPx,
+			StopLossATRMult:   pos.StopLossATRMult,
+			TPTiersJSON:       pos.TPTiersJSON,
 			Manual:            true,
 		}
 		RecordTrade(ss, trade)

--- a/scheduler/manual_protection.go
+++ b/scheduler/manual_protection.go
@@ -53,7 +53,7 @@ func placeManualProtectionInline(
 	fillQty, fillPrice, entryATR, effectiveSLATRMult float64,
 	stopLossOID int64,
 ) ([]int64, string, error) {
-	tiers := hyperliquidProtectionTiers(sc)
+	tiers := strategyTPTiers(sc)
 	if len(tiers) == 0 {
 		return nil, "", nil
 	}

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -23,6 +23,8 @@ type Position struct {
 	StopLossTriggerPx   float64   `json:"stop_loss_trigger_px,omitempty"`    // HL perps: trigger price for the resting stop-loss (0 = unknown) (#421)
 	StopLossHighWaterPx float64   `json:"stop_loss_high_water_px,omitempty"` // HL perps trailing SL: best mark seen while position open (high for long, low for short) (#501)
 	TPOIDs              []int64   `json:"tp_oids,omitempty"`                 // HL perps: resting reduce-only TP limit OIDs, one per configured tier (#601/#612)
+	StopLossATRMult     *float64  `json:"stop_loss_atr_mult,omitempty"`      // HL perps: ATR multiplier resolved at fill time when SL was ATR-armed; nil = armed via pct/margin/trailing/none (#669)
+	TPTiersJSON         string    `json:"tp_tiers_json,omitempty"`           // HL perps: JSON snapshot of [{atr_multiple,close_fraction},...] resolved at fill time; "" = strategy doesn't use tiered_tp_atr* (#669)
 }
 
 // ClosedPosition is a historical record of a position after it closed (#288).
@@ -198,6 +200,8 @@ func bookPerpsCloseWithFillFee(s *StrategyState, symbol string, closePx, fillFee
 	trade.Regime = s.Regime
 	trade.EntryATR = pos.EntryATR
 	trade.StopLossTriggerPx = pos.StopLossTriggerPx
+	trade.StopLossATRMult = pos.StopLossATRMult
+	trade.TPTiersJSON = pos.TPTiersJSON
 	RecordTrade(s, trade)
 	RecordTradeResult(&s.RiskState, pnl)
 	recordClosedPosition(s, pos, closePx, pnl, reason, now)
@@ -274,6 +278,8 @@ func bookPerpsPartialCloseWithFillFee(s *StrategyState, symbol string, closeQty,
 	trade.Regime = s.Regime
 	trade.EntryATR = pos.EntryATR
 	trade.StopLossTriggerPx = pos.StopLossTriggerPx
+	trade.StopLossATRMult = pos.StopLossATRMult
+	trade.TPTiersJSON = pos.TPTiersJSON
 	RecordTrade(s, trade)
 	RecordTradeResult(&s.RiskState, pnl)
 
@@ -390,6 +396,17 @@ type Trade struct {
 	EntryATR          float64 `json:"entry_atr,omitempty"`
 	StopLossTriggerPx float64 `json:"stop_loss_trigger_px,omitempty"`
 	Manual            bool    `json:"manual,omitempty"` // set when position was opened via manual-open CLI (#569)
+
+	// SL arming method + TP tier snapshot at fill time (#669). StopLossATRMult
+	// is non-nil iff SL was ATR-armed (sc.StopLossATRMult>0 OR
+	// sc.TrailingStopATRMult>0); the value is the configured multiplier
+	// resolved at open. nil = armed via pct/margin/trailing-pct or no SL.
+	// Nullness alone gates the SL display suffix correctly. TPTiersJSON is the
+	// full tier snapshot ([{atr_multiple,close_fraction},...]) resolved at
+	// open so historical tier-config changes don't erase the record. Empty =
+	// strategy doesn't use tiered_tp_atr*.
+	StopLossATRMult *float64 `json:"stop_loss_atr_mult,omitempty"`
+	TPTiersJSON     string   `json:"tp_tiers_json,omitempty"`
 
 	// persisted tracks whether this Trade has been written to SQLite — set by
 	// RecordTrade on successful InsertTrade and by LoadState for DB-loaded
@@ -907,6 +924,8 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 			trade.Regime = s.Regime
 			trade.EntryATR = pos.EntryATR
 			trade.StopLossTriggerPx = pos.StopLossTriggerPx
+			trade.StopLossATRMult = pos.StopLossATRMult
+			trade.TPTiersJSON = pos.TPTiersJSON
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
 			if partialClose {
@@ -1082,6 +1101,8 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 			trade.Regime = s.Regime
 			trade.EntryATR = pos.EntryATR
 			trade.StopLossTriggerPx = pos.StopLossTriggerPx
+			trade.StopLossATRMult = pos.StopLossATRMult
+			trade.TPTiersJSON = pos.TPTiersJSON
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
 			if partialClose {
@@ -1261,6 +1282,8 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			trade.Regime = s.Regime
 			trade.EntryATR = pos.EntryATR
 			trade.StopLossTriggerPx = pos.StopLossTriggerPx
+			trade.StopLossATRMult = pos.StopLossATRMult
+			trade.TPTiersJSON = pos.TPTiersJSON
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
 			if partialClose {
@@ -1388,6 +1411,8 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			trade.Regime = s.Regime
 			trade.EntryATR = pos.EntryATR
 			trade.StopLossTriggerPx = pos.StopLossTriggerPx
+			trade.StopLossATRMult = pos.StopLossATRMult
+			trade.TPTiersJSON = pos.TPTiersJSON
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
 			if partialClose {
@@ -1492,6 +1517,8 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			trade.Regime = s.Regime
 			trade.EntryATR = pos.EntryATR
 			trade.StopLossTriggerPx = pos.StopLossTriggerPx
+			trade.StopLossATRMult = pos.StopLossATRMult
+			trade.TPTiersJSON = pos.TPTiersJSON
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
 			if partialClose {
@@ -1636,6 +1663,8 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			trade.Regime = s.Regime
 			trade.EntryATR = pos.EntryATR
 			trade.StopLossTriggerPx = pos.StopLossTriggerPx
+			trade.StopLossATRMult = pos.StopLossATRMult
+			trade.TPTiersJSON = pos.TPTiersJSON
 			RecordTrade(s, trade)
 			RecordTradeResult(&s.RiskState, pnl)
 			if partialClose {
@@ -1725,11 +1754,12 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 	return tradesExecuted, nil
 }
 
-// stampOpenTradeFromPosition backfills EntryATR and StopLossTriggerPx onto the
-// most recent open Trade for symbol after those values are stamped onto the
-// Position post-RecordTrade. Only updates fields that are currently zero so
-// subsequent calls are idempotent. Updates both the in-memory slice and the
-// SQLite row when db is non-nil.
+// stampOpenTradeFromPosition backfills EntryATR, StopLossTriggerPx,
+// StopLossATRMult, and TPTiersJSON onto the most recent open Trade for symbol
+// after those values are stamped onto the Position post-RecordTrade. Only
+// updates fields that are currently zero / nil / empty so subsequent calls are
+// idempotent. Updates both the in-memory slice and the SQLite row when db is
+// non-nil.
 func stampOpenTradeFromPosition(s *StrategyState, db *StateDB, symbol string, pos *Position) {
 	if pos == nil {
 		return
@@ -1751,8 +1781,17 @@ func stampOpenTradeFromPosition(s *StrategyState, db *StateDB, symbol string, po
 			t.StopLossTriggerPx = pos.StopLossTriggerPx
 			changed = true
 		}
+		if pos.StopLossATRMult != nil && t.StopLossATRMult == nil {
+			v := *pos.StopLossATRMult
+			t.StopLossATRMult = &v
+			changed = true
+		}
+		if pos.TPTiersJSON != "" && t.TPTiersJSON == "" {
+			t.TPTiersJSON = pos.TPTiersJSON
+			changed = true
+		}
 		if changed && db != nil {
-			_ = db.UpdateTradeStampedFields(s.ID, t.Timestamp, t.EntryATR, t.StopLossTriggerPx)
+			_ = db.UpdateTradeStampedFields(s.ID, t.Timestamp, t.EntryATR, t.StopLossTriggerPx, t.StopLossATRMult, t.TPTiersJSON)
 		}
 		return
 	}

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1144,6 +1144,8 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 			Regime:            s.Regime,
 			EntryATR:          pos.EntryATR,
 			StopLossTriggerPx: pos.StopLossTriggerPx,
+			StopLossATRMult:   pos.StopLossATRMult,
+			TPTiersJSON:       pos.TPTiersJSON,
 		}
 		RecordTrade(s, trade)
 		RecordTradeResult(&s.RiskState, pnl)

--- a/scheduler/trade_protection_snapshot.go
+++ b/scheduler/trade_protection_snapshot.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// tradeOpenStopLossATRMult returns the SL ATR multiplier resolved at trade-open
+// time, or nil when SL was armed via a non-ATR mechanism (StopLossPct,
+// StopLossMarginPct, TrailingStopPct) or no SL at all (#669). Nullness alone
+// gates the SL display suffix correctly — a back-computed mult on a pct-armed
+// SL position is now distinguishable from a true ATR-armed mult.
+func tradeOpenStopLossATRMult(sc StrategyConfig) *float64 {
+	if sc.StopLossATRMult != nil && *sc.StopLossATRMult > 0 {
+		v := *sc.StopLossATRMult
+		return &v
+	}
+	if sc.TrailingStopATRMult != nil && *sc.TrailingStopATRMult > 0 {
+		v := *sc.TrailingStopATRMult
+		return &v
+	}
+	return nil
+}
+
+// tradeOpenTPTiersJSON returns a JSON snapshot of the configured ATR-tiered TP
+// plan resolved at trade-open time, or "" when the strategy doesn't use
+// tiered_tp_atr* (#669). Storing the snapshot at fill time means subsequent
+// tier-config edits don't lose the historical record needed for analytics.
+func tradeOpenTPTiersJSON(sc StrategyConfig) string {
+	tiers := hyperliquidProtectionTiers(sc)
+	if len(tiers) == 0 {
+		return ""
+	}
+	type tierJSON struct {
+		ATRMultiple   float64 `json:"atr_multiple"`
+		CloseFraction float64 `json:"close_fraction"`
+	}
+	out := make([]tierJSON, 0, len(tiers))
+	for _, t := range tiers {
+		out = append(out, tierJSON{ATRMultiple: t.Multiple, CloseFraction: t.Fraction})
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		// Tier values are floats produced by hyperliquidProtectionTiers; this
+		// path is unreachable in practice but log so a regression is visible.
+		fmt.Printf("[WARN] %s: marshal tp_tiers_json failed: %v\n", sc.ID, err)
+		return ""
+	}
+	return string(b)
+}
+
+// stampPositionProtectionSnapshot writes the SL ATR mult + TP tier snapshot
+// derived from sc onto the Position so subsequent calls to
+// stampOpenTradeFromPosition can backfill the trade row. Idempotent — only
+// fills nil/empty fields, leaving any pre-existing fill-time snapshot intact.
+func stampPositionProtectionSnapshot(pos *Position, sc StrategyConfig) {
+	if pos == nil {
+		return
+	}
+	if pos.StopLossATRMult == nil {
+		pos.StopLossATRMult = tradeOpenStopLossATRMult(sc)
+	}
+	if pos.TPTiersJSON == "" {
+		pos.TPTiersJSON = tradeOpenTPTiersJSON(sc)
+	}
+}
+
+// stampOpenTradeWithProtectionSnapshot is the trade-open helper that combines
+// the protection-config snapshot (sc-derived) with the position-derived backfill
+// onto the most recent open Trade for symbol. Idempotent on both layers — call
+// it after every Execute*Signal trade-open path so analytics rows always carry
+// the SL arming method + TP tier snapshot resolved at fill time (#669).
+func stampOpenTradeWithProtectionSnapshot(s *StrategyState, db *StateDB, sc StrategyConfig, symbol string, pos *Position) {
+	stampPositionProtectionSnapshot(pos, sc)
+	stampOpenTradeFromPosition(s, db, symbol, pos)
+}

--- a/scheduler/trade_protection_snapshot.go
+++ b/scheduler/trade_protection_snapshot.go
@@ -27,7 +27,7 @@ func tradeOpenStopLossATRMult(sc StrategyConfig) *float64 {
 // tiered_tp_atr* (#669). Storing the snapshot at fill time means subsequent
 // tier-config edits don't lose the historical record needed for analytics.
 func tradeOpenTPTiersJSON(sc StrategyConfig) string {
-	tiers := hyperliquidProtectionTiers(sc)
+	tiers := strategyTPTiers(sc)
 	if len(tiers) == 0 {
 		return ""
 	}
@@ -41,7 +41,7 @@ func tradeOpenTPTiersJSON(sc StrategyConfig) string {
 	}
 	b, err := json.Marshal(out)
 	if err != nil {
-		// Tier values are floats produced by hyperliquidProtectionTiers; this
+		// Tier values are floats produced by strategyTPTiers; this
 		// path is unreachable in practice but log so a regression is visible.
 		fmt.Printf("[WARN] %s: marshal tp_tiers_json failed: %v\n", sc.ID, err)
 		return ""

--- a/scheduler/trade_protection_snapshot_test.go
+++ b/scheduler/trade_protection_snapshot_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestTradeOpenStopLossATRMult_FixedATR(t *testing.T) {
+	mult := 1.5
+	sc := StrategyConfig{StopLossATRMult: &mult}
+	got := tradeOpenStopLossATRMult(sc)
+	if got == nil || *got != 1.5 {
+		t.Fatalf("StopLossATRMult=1.5: got %v, want *1.5", got)
+	}
+}
+
+func TestTradeOpenStopLossATRMult_TrailingATR(t *testing.T) {
+	mult := 2.0
+	sc := StrategyConfig{TrailingStopATRMult: &mult}
+	got := tradeOpenStopLossATRMult(sc)
+	if got == nil || *got != 2.0 {
+		t.Fatalf("TrailingStopATRMult=2.0: got %v, want *2.0", got)
+	}
+}
+
+func TestTradeOpenStopLossATRMult_NilForPctArmedAndZero(t *testing.T) {
+	pct := 5.0
+	zero := 0.0
+	cases := []struct {
+		name string
+		sc   StrategyConfig
+	}{
+		{"pct-armed (StopLossPct)", StrategyConfig{StopLossPct: &pct}},
+		{"pct-armed (TrailingStopPct)", StrategyConfig{TrailingStopPct: &pct}},
+		{"pct-armed (StopLossMarginPct)", StrategyConfig{StopLossMarginPct: &pct}},
+		{"no SL fields", StrategyConfig{}},
+		{"explicit zero StopLossATRMult", StrategyConfig{StopLossATRMult: &zero}},
+		{"explicit zero TrailingStopATRMult", StrategyConfig{TrailingStopATRMult: &zero}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tradeOpenStopLossATRMult(tc.sc); got != nil {
+				t.Fatalf("expected nil (non-ATR-armed), got %v", *got)
+			}
+		})
+	}
+}
+
+func TestTradeOpenTPTiersJSON_TieredCloseStrategy(t *testing.T) {
+	sc := StrategyConfig{
+		Type:     "perps",
+		Platform: "hyperliquid",
+		CloseStrategies: []StrategyRef{
+			{Name: "tiered_tp_atr", Params: map[string]interface{}{
+				"tiers": []interface{}{
+					map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.5},
+					map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
+				},
+			}},
+		},
+	}
+	got := tradeOpenTPTiersJSON(sc)
+	if got == "" {
+		t.Fatal("expected non-empty TPTiersJSON for tiered_tp_atr close strategy")
+	}
+	var parsed []map[string]float64
+	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+		t.Fatalf("unmarshal TPTiersJSON: %v (raw=%s)", err, got)
+	}
+	if len(parsed) != 2 {
+		t.Fatalf("want 2 tiers, got %d (raw=%s)", len(parsed), got)
+	}
+	if parsed[0]["atr_multiple"] != 1.0 || parsed[0]["close_fraction"] != 0.5 {
+		t.Fatalf("tier[0] = %v, want {atr_multiple:1, close_fraction:0.5}", parsed[0])
+	}
+	if parsed[1]["atr_multiple"] != 2.0 || parsed[1]["close_fraction"] != 1.0 {
+		t.Fatalf("tier[1] = %v, want {atr_multiple:2, close_fraction:1}", parsed[1])
+	}
+}
+
+func TestTradeOpenTPTiersJSON_NoTieredCloseReturnsEmpty(t *testing.T) {
+	sc := StrategyConfig{
+		Type:     "perps",
+		Platform: "hyperliquid",
+		CloseStrategies: []StrategyRef{
+			{Name: "tp_at_pct", Params: map[string]interface{}{"pct": 0.05}},
+		},
+	}
+	if got := tradeOpenTPTiersJSON(sc); got != "" {
+		t.Fatalf("expected empty (no tiered_tp_atr*), got %q", got)
+	}
+}
+
+func TestStampPositionProtectionSnapshot_NilPos(t *testing.T) {
+	stampPositionProtectionSnapshot(nil, StrategyConfig{}) // must not panic
+}
+
+func TestStampPositionProtectionSnapshot_Idempotent(t *testing.T) {
+	mult := 1.5
+	pos := &Position{}
+	sc := StrategyConfig{StopLossATRMult: &mult}
+
+	stampPositionProtectionSnapshot(pos, sc)
+	if pos.StopLossATRMult == nil || *pos.StopLossATRMult != 1.5 {
+		t.Fatalf("first stamp: got %v", pos.StopLossATRMult)
+	}
+
+	// Idempotent: re-stamp with a different config does not overwrite.
+	otherMult := 9.9
+	stampPositionProtectionSnapshot(pos, StrategyConfig{StopLossATRMult: &otherMult})
+	if *pos.StopLossATRMult != 1.5 {
+		t.Fatalf("second stamp overwrote: got %v, want 1.5", *pos.StopLossATRMult)
+	}
+}
+
+// TestStampOpenTradeFromPositionBackfillsProtectionSnapshot verifies that the
+// SL ATR mult + TP tier snapshot stamped on Position post-fill flows onto the
+// most-recent open Trade row (#669).
+func TestStampOpenTradeFromPositionBackfillsProtectionSnapshot(t *testing.T) {
+	db, err := OpenStateDB(":memory:")
+	if err != nil {
+		t.Fatalf("OpenStateDB: %v", err)
+	}
+	defer db.Close()
+
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	s := &StrategyState{ID: "stamp-test", TradeHistory: []Trade{
+		{Symbol: "ETH", IsClose: false, Timestamp: ts},
+	}}
+	if err := db.InsertTrade(s.ID, s.TradeHistory[0]); err != nil {
+		t.Fatalf("InsertTrade: %v", err)
+	}
+
+	mult := 1.5
+	pos := &Position{
+		StopLossATRMult: &mult,
+		TPTiersJSON:     `[{"atr_multiple":1,"close_fraction":0.5},{"atr_multiple":2,"close_fraction":1}]`,
+	}
+	stampOpenTradeFromPosition(s, db, "ETH", pos)
+
+	if s.TradeHistory[0].StopLossATRMult == nil || *s.TradeHistory[0].StopLossATRMult != 1.5 {
+		t.Fatalf("in-memory StopLossATRMult: got %v, want *1.5", s.TradeHistory[0].StopLossATRMult)
+	}
+	if s.TradeHistory[0].TPTiersJSON != pos.TPTiersJSON {
+		t.Fatalf("in-memory TPTiersJSON: got %q, want %q", s.TradeHistory[0].TPTiersJSON, pos.TPTiersJSON)
+	}
+
+	// Verify SQLite row was updated.
+	var slMult float64
+	var tpTiersJSON string
+	if err := db.db.QueryRow(
+		`SELECT stop_loss_atr_mult, tp_tiers_json FROM trades WHERE strategy_id = ? AND timestamp = ?`,
+		s.ID, formatTime(ts),
+	).Scan(&slMult, &tpTiersJSON); err != nil {
+		t.Fatalf("query stamped trade: %v", err)
+	}
+	if slMult != 1.5 || tpTiersJSON != pos.TPTiersJSON {
+		t.Fatalf("persisted snapshot = (%v, %q), want (1.5, %q)", slMult, tpTiersJSON, pos.TPTiersJSON)
+	}
+}
+
+// TestInsertTradePreservesNullStopLossATRMult verifies the nullness gate: a
+// pct-armed open trade lands as SQL NULL so analytics can distinguish ATR-armed
+// from pct-armed without back-computing.
+func TestInsertTradePreservesNullStopLossATRMult(t *testing.T) {
+	db, err := OpenStateDB(":memory:")
+	if err != nil {
+		t.Fatalf("OpenStateDB: %v", err)
+	}
+	defer db.Close()
+
+	ts := time.Date(2026, 5, 9, 10, 0, 0, 0, time.UTC)
+	pctArmed := Trade{Symbol: "BTC", Timestamp: ts, StrategyID: "s1"}
+	if err := db.InsertTrade(pctArmed.StrategyID, pctArmed); err != nil {
+		t.Fatalf("InsertTrade: %v", err)
+	}
+
+	var slMult interface{}
+	if err := db.db.QueryRow(
+		`SELECT stop_loss_atr_mult FROM trades WHERE strategy_id = ? AND timestamp = ?`,
+		pctArmed.StrategyID, formatTime(ts),
+	).Scan(&slMult); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if slMult != nil {
+		t.Fatalf("expected NULL for pct-armed trade, got %v", slMult)
+	}
+
+	// ATR-armed → non-NULL value preserved exactly.
+	mult := 1.25
+	atrArmed := Trade{Symbol: "ETH", Timestamp: ts.Add(time.Second), StrategyID: "s1", StopLossATRMult: &mult, TPTiersJSON: `[{"atr_multiple":1,"close_fraction":1}]`}
+	if err := db.InsertTrade(atrArmed.StrategyID, atrArmed); err != nil {
+		t.Fatalf("InsertTrade ATR: %v", err)
+	}
+	var got float64
+	var tiers string
+	if err := db.db.QueryRow(
+		`SELECT stop_loss_atr_mult, tp_tiers_json FROM trades WHERE strategy_id = ? AND timestamp = ?`,
+		atrArmed.StrategyID, formatTime(atrArmed.Timestamp),
+	).Scan(&got, &tiers); err != nil {
+		t.Fatalf("query ATR: %v", err)
+	}
+	if got != 1.25 || tiers != atrArmed.TPTiersJSON {
+		t.Fatalf("ATR row: got (%v, %q), want (1.25, %q)", got, tiers, atrArmed.TPTiersJSON)
+	}
+}

--- a/scheduler/trade_protection_snapshot_test.go
+++ b/scheduler/trade_protection_snapshot_test.go
@@ -205,3 +205,73 @@ func TestInsertTradePreservesNullStopLossATRMult(t *testing.T) {
 		t.Fatalf("ATR row: got (%v, %q), want (1.25, %q)", got, tiers, atrArmed.TPTiersJSON)
 	}
 }
+
+// TestApplyHyperliquidCircuitCloseFill_StampsProtectionSnapshot verifies that
+// the kill-switch on-chain close path copies StopLossATRMult and TPTiersJSON
+// from the position onto the Trade — without this the round-trip analytics
+// promise from #669 breaks for kill-switch closes (PR #671 review).
+func TestApplyHyperliquidCircuitCloseFill_StampsProtectionSnapshot(t *testing.T) {
+	mult := 1.5
+	tiersJSON := `[{"atr_multiple":1,"close_fraction":0.5},{"atr_multiple":2,"close_fraction":1}]`
+	s := &StrategyState{
+		ID:   "hl-snapshot",
+		Cash: 1000,
+		Positions: map[string]*Position{
+			"BTC": {
+				Symbol: "BTC", Quantity: 1.0, AvgCost: 50000, Side: "long",
+				Multiplier: 1, Leverage: 5,
+				StopLossATRMult: &mult,
+				TPTiersJSON:     tiersJSON,
+			},
+		},
+	}
+	applyHyperliquidCircuitCloseFill(s, "BTC", 0.3, 49000, 1.5, 1.0)
+
+	if len(s.TradeHistory) != 1 {
+		t.Fatalf("TradeHistory len = %d, want 1", len(s.TradeHistory))
+	}
+	tr := s.TradeHistory[0]
+	if tr.StopLossATRMult == nil || *tr.StopLossATRMult != mult {
+		t.Errorf("Trade.StopLossATRMult = %v, want *%v", tr.StopLossATRMult, mult)
+	}
+	if tr.TPTiersJSON != tiersJSON {
+		t.Errorf("Trade.TPTiersJSON = %q, want %q", tr.TPTiersJSON, tiersJSON)
+	}
+}
+
+// TestForceCloseAllPositions_StampsProtectionSnapshot verifies the same
+// round-trip on the circuit-breaker force-close path (risk.go).
+func TestForceCloseAllPositions_StampsProtectionSnapshot(t *testing.T) {
+	mult := 2.0
+	tiersJSON := `[{"atr_multiple":1,"close_fraction":0.5},{"atr_multiple":2,"close_fraction":1}]`
+	s := &StrategyState{
+		ID:   "perps-snapshot",
+		Cash: 10000,
+		Positions: map[string]*Position{
+			"BTC": {
+				Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "long",
+				Multiplier: 1, Leverage: 5,
+				StopLossATRMult: &mult,
+				TPTiersJSON:     tiersJSON,
+			},
+		},
+		TradeHistory: []Trade{},
+		RiskState:    RiskState{},
+	}
+
+	forceCloseAllPositions(s, map[string]float64{"BTC": 51000}, nil)
+
+	if len(s.TradeHistory) != 1 {
+		t.Fatalf("TradeHistory len = %d, want 1", len(s.TradeHistory))
+	}
+	tr := s.TradeHistory[0]
+	if !tr.IsClose {
+		t.Errorf("Trade.IsClose = false, want true")
+	}
+	if tr.StopLossATRMult == nil || *tr.StopLossATRMult != mult {
+		t.Errorf("Trade.StopLossATRMult = %v, want *%v", tr.StopLossATRMult, mult)
+	}
+	if tr.TPTiersJSON != tiersJSON {
+		t.Errorf("Trade.TPTiersJSON = %q, want %q", tr.TPTiersJSON, tiersJSON)
+	}
+}


### PR DESCRIPTION
Closes #669

## Summary
- Two additive nullable `trades` columns: `stop_loss_atr_mult REAL` (non-NULL iff ATR-armed at fill time) and `tp_tiers_json TEXT` (full [{atr_multiple, close_fraction}] snapshot).
- Mirrored on `positions` to support same-cycle backfill via `stampOpenTradeFromPosition`, following the same pattern as `entry_atr` / `stop_loss_trigger_px`.
- Stamped at fill time on every trade-open path (perps live/paper, spot, dispatch, manual, protection sync) and propagated onto close legs from `Position` so round-trip analytics queries see both sides.
- Helpers `tradeOpenStopLossATRMult`, `tradeOpenTPTiersJSON`, `stampPositionProtectionSnapshot` resolve values from `sc`.

## Test plan
- [x] `go test ./...` full suite passes
- [x] 7 new tests cover ATR/pct/zero resolution, tier JSON snapshot shape, stamper idempotency, in-memory + SQLite backfill, NULL preservation

## Out of scope
- Display fix for the back-computed `(<n>x)` suffix (#665 follow-up noted in the issue)
- Backfill of legacy trade rows (NULL = unknown by design)

---
LLM: Claude Opus 4.7 (1M) | high | Harness: anthropics/claude-code-action@v1 | Tokens: 129 in / 57447 out | Cache: 11980535 read / 235152 written | Cost: $8.9