### PR TITLE
fix: attribute TP-fired closes to TP fills, not SL trigger price

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -299,6 +299,13 @@ func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym st
 		// Position in state but not on-chain — closed externally.
 		logger.Info("hl-sync: %s position (%.6f %s) no longer on-chain, removing",
 			sym, statePos.Quantity, statePos.Side)
+		// #673: When the position has TP OIDs and the SL OID has no fills,
+		// the position was flattened by TPs (HL auto-cancels the resting
+		// reduce-only SL once flat). Book each TP fill at its actual price
+		// rather than mis-attributing to the SL trigger price.
+		if hlAttemptCloseFromTPFills(stratState, sym, statePos, resolveFee, logger) {
+			return true
+		}
 		if statePos.StopLossOID > 0 && statePos.StopLossTriggerPx > 0 {
 			lookup, useFillFee := resolveFee(sym, statePos.StopLossOID, statePos.Quantity)
 			oidStr := strconv.FormatInt(statePos.StopLossOID, 10)
@@ -901,6 +908,75 @@ func hyperliquidClearedTPTier(sc StrategyConfig, pos *Position, closeQty float64
 func hyperliquidHasClearedTPTier(sc StrategyConfig, pos *Position, closeQty float64) bool {
 	_, ok := hyperliquidClearedTPTier(sc, pos, closeQty)
 	return ok
+}
+
+// hlAttemptCloseFromTPFills books a flat-on-chain perps position from
+// userFills-confirmed TP OID fills, returning true on success. Fixes #673:
+// when TPs flatten the position, HL auto-cancels the resting reduce-only SL
+// — without this check, the reconciler books the close at the SL trigger
+// price, producing a fictitious loss.
+//
+// Triggers when (a) pos has at least one TP OID, (b) the SL OID has NO
+// userFills entries (so SL didn't fire), and (c) at least one TP OID does.
+// Each filled TP OID is booked as a partial close at its actual VWAP fill
+// price + fee. Any residual after all TP fills is finalized at zero PnL —
+// that catches the rare "userFills indexer missed an SL partial" race.
+//
+// Returns false (no mutation) when no TP attribution is possible; the caller
+// then falls through to the legacy SL-trigger-price path.
+func hlAttemptCloseFromTPFills(s *StrategyState, sym string, pos *Position, resolveFee hlReconcileFillResolver, logger *StrategyLogger) bool {
+	if s == nil || pos == nil || len(pos.TPOIDs) == 0 || resolveFee == nil {
+		return false
+	}
+	// If the SL OID has fills, leave attribution to the existing SL path —
+	// it knows how to handle the #621 "SL fired on the post-TP residual"
+	// case and we don't want to double-book by also crediting TPs here.
+	if pos.StopLossOID > 0 {
+		if _, slFilled := resolveFee(sym, pos.StopLossOID, pos.Quantity); slFilled {
+			return false
+		}
+	}
+	type tpFill struct {
+		oid     int64
+		tierIdx int
+		lookup  HLFillLookup
+	}
+	var fills []tpFill
+	for i, oid := range pos.TPOIDs {
+		if oid <= 0 {
+			continue
+		}
+		lookup, ok := resolveFee(sym, oid, pos.Quantity)
+		if !ok || lookup.FilledQty <= 0 || lookup.Px <= 0 {
+			continue
+		}
+		fills = append(fills, tpFill{oid: oid, tierIdx: i, lookup: lookup})
+	}
+	if len(fills) == 0 {
+		return false
+	}
+	for _, f := range fills {
+		oidStr := strconv.FormatInt(f.oid, 10)
+		logHyperliquidReconcileFillLookup(logger, sym, f.oid, f.lookup.FilledQty, f.lookup, true)
+		reason := fmt.Sprintf("hl_sync_tp%d_fill", f.tierIdx+1)
+		detailsPrefix := fmt.Sprintf("TP%d fill close", f.tierIdx+1)
+		logPrefix := fmt.Sprintf("TP%d fill reconciled", f.tierIdx+1)
+		if !bookPerpsPartialCloseWithFillFee(s, sym, f.lookup.FilledQty, f.lookup.Px, f.lookup.Fee, true, oidStr, reason, detailsPrefix, logPrefix, logger) {
+			break
+		}
+	}
+	// Finalize any residual at zero PnL. Hits when cumulative TP fills under-
+	// shoot pos.Quantity — typically an SL fill the indexer hasn't surfaced
+	// yet. Better to clear virtual state than to leave a phantom position.
+	if residual := s.Positions[sym]; residual != nil {
+		if logger != nil {
+			logger.Warn("hl-sync: %s residual %.6f after TP fill attribution; finalizing at zero PnL", sym, residual.Quantity)
+		}
+		recordClosedPosition(s, residual, 0, 0, "hl_sync_external", time.Now().UTC())
+		delete(s.Positions, sym)
+	}
+	clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, sym)
+	return true
 }
 
 // HyperliquidLiveCloseReport summarizes a forceCloseHyperliquidLive run.

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -3388,6 +3388,60 @@ func TestReconcilePosition_SLFillStillTakesSLPath(t *testing.T) {
 	}
 }
 
+// TestReconcilePosition_PartialTPFillResidualZeroPnL covers the under-shoot
+// case: TP1 fills cleanly, TP2 OID returns no fill (indexer race or only one
+// tier configured). The booked TP1 portion credits real PnL; the residual is
+// closed at zero PnL via hl_sync_external. Locks in current behavior — see
+// PR #675 review for the trade-off vs. mark/SL-trigger pricing.
+func TestReconcilePosition_PartialTPFillResidualZeroPnL(t *testing.T) {
+	const (
+		entryPx  = 2000.0
+		tp1Px    = 2050.0
+		qtyTotal = 0.4
+		qtyTier1 = 0.2
+		feeTP1   = 0.05
+	)
+	ss := &StrategyState{
+		ID: "hl-eth", Cash: 1000,
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol: "ETH", Quantity: qtyTotal, InitialQuantity: qtyTotal,
+				AvgCost: entryPx, Side: "long",
+				Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-eth",
+				StopLossOID: 999, StopLossTriggerPx: 1900,
+				TPOIDs: []int64{111, 222},
+			},
+		},
+	}
+	resolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
+		if oid == 111 {
+			return HLFillLookup{Fee: feeTP1, FilledQty: qtyTier1, Px: tp1Px, Count: 1, OID: 111}, true
+		}
+		return HLFillLookup{}, false
+	})
+	logger := newTestLogger(t)
+	startCash := ss.Cash
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger)
+
+	if _, open := ss.Positions["ETH"]; open {
+		t.Fatal("ETH should be removed even when TP fills under-shoot")
+	}
+	if len(ss.TradeHistory) != 1 {
+		t.Fatalf("TradeHistory = %d, want 1 (TP1 only — TP2 had no fill)", len(ss.TradeHistory))
+	}
+	if len(ss.ClosedPositions) != 1 || ss.ClosedPositions[0].CloseReason != "hl_sync_external" {
+		t.Fatalf("expected residual ClosedPosition with reason=hl_sync_external, got %+v", ss.ClosedPositions)
+	}
+	if ss.ClosedPositions[0].Quantity < qtyTier1-1e-9 || ss.ClosedPositions[0].Quantity > qtyTier1+1e-9 {
+		t.Errorf("residual ClosedPosition.Quantity = %g, want %g", ss.ClosedPositions[0].Quantity, qtyTier1)
+	}
+	wantPnL := qtyTier1*(tp1Px-entryPx) - feeTP1
+	gotPnL := ss.Cash - startCash
+	if math.Abs(gotPnL-wantPnL) > 0.01 {
+		t.Errorf("cash delta = %g, want %g (TP1 only — residual contributes 0)", gotPnL, wantPnL)
+	}
+}
+
 // TestReconcilePosition_NoFillsFallsBackToZeroPnL verifies that when neither
 // SL nor TP OIDs return fills (e.g. manual UI close, indexer outage), the
 // legacy zero-PnL hl_sync_external path is preserved.

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -3279,3 +3279,141 @@ func TestReconcileManualPositionSLFired(t *testing.T) {
 		t.Errorf("ClosePrice = %g, want 1800", ss.ClosedPositions[0].ClosePrice)
 	}
 }
+
+// --- #673: TP-fired close attributed to TP fills, not SL trigger ---
+
+// TestReconcilePosition_TPFillsAttributedNotSL is the regression test for #673:
+// when both TPs fire and HL auto-cancels the resting SL, the reconciler must
+// book the close at the actual TP fill prices, not at the (stale) SL trigger
+// price. Pre-fix this scenario produced a fictitious loss because the close
+// was mis-attributed to the SL.
+func TestReconcilePosition_TPFillsAttributedNotSL(t *testing.T) {
+	const (
+		entryPx     = 2315.70
+		tp1Px       = 2325.19
+		tp2Px       = 2329.93
+		slTriggerPx = 2308.60
+		qtyTotal    = 0.432
+		qtyTier     = 0.216
+		feeTP1      = 0.10
+		feeTP2      = 0.11
+	)
+	ss := &StrategyState{
+		ID:   "hl-tema-eth-live",
+		Cash: 1000,
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol: "ETH", Quantity: qtyTotal, InitialQuantity: qtyTotal,
+				AvgCost: entryPx, Side: "long",
+				Multiplier: 1, Leverage: 20, OwnerStrategyID: "hl-tema-eth-live",
+				StopLossOID: 999, StopLossTriggerPx: slTriggerPx,
+				TPOIDs: []int64{111, 222},
+			},
+		},
+	}
+	// Resolver: SL OID returns no fill (SL was auto-cancelled by HL once flat).
+	// Both TP OIDs return their actual VWAP fill price + fee.
+	resolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
+		switch oid {
+		case 111:
+			return HLFillLookup{Fee: feeTP1, FilledQty: qtyTier, Px: tp1Px, Count: 1, OID: 111}, true
+		case 222:
+			return HLFillLookup{Fee: feeTP2, FilledQty: qtyTier, Px: tp2Px, Count: 1, OID: 222}, true
+		default:
+			return HLFillLookup{}, false
+		}
+	})
+	logger := newTestLogger(t)
+
+	startCash := ss.Cash
+	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if _, open := ss.Positions["ETH"]; open {
+		t.Fatal("ETH position should be removed after TP-fill attribution")
+	}
+	if len(ss.TradeHistory) != 2 {
+		t.Fatalf("TradeHistory = %d, want 2 (one per TP tier)", len(ss.TradeHistory))
+	}
+	for i, trade := range ss.TradeHistory {
+		if !trade.IsClose {
+			t.Errorf("trade[%d].IsClose = false, want true", i)
+		}
+		if trade.RealizedPnL <= 0 {
+			t.Errorf("trade[%d].RealizedPnL = %g, want positive (TP profit)", i, trade.RealizedPnL)
+		}
+	}
+	wantPnL := qtyTier*(tp1Px-entryPx) - feeTP1 + qtyTier*(tp2Px-entryPx) - feeTP2
+	gotPnL := ss.Cash - startCash
+	if math.Abs(gotPnL-wantPnL) > 0.01 {
+		t.Errorf("cash delta = %g, want %g (sum of TP fill PnLs minus fees)", gotPnL, wantPnL)
+	}
+	if gotPnL <= 0 {
+		t.Errorf("cash delta = %g, want positive — pre-fix this booked at SL trigger and was negative", gotPnL)
+	}
+}
+
+// TestReconcilePosition_SLFillStillTakesSLPath verifies that when the SL OID
+// DID fire (userFills returns a hit), the existing SL-trigger-price path is
+// still used and the new TP attribution does not interfere.
+func TestReconcilePosition_SLFillStillTakesSLPath(t *testing.T) {
+	const slTriggerPx = 1800.0
+	ss := &StrategyState{
+		ID: "hl-eth", Cash: 100,
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol: "ETH", Quantity: 0.4, AvgCost: 2000, Side: "long",
+				Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-eth",
+				StopLossOID: 42, StopLossTriggerPx: slTriggerPx,
+				TPOIDs: []int64{111, 222},
+			},
+		},
+	}
+	resolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
+		// SL fired; TPs auto-cancelled.
+		if oid == 42 {
+			return HLFillLookup{Fee: 0.05, FilledQty: 0.4, Px: slTriggerPx, Count: 1, OID: 42}, true
+		}
+		return HLFillLookup{}, false
+	})
+	logger := newTestLogger(t)
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger)
+
+	if len(ss.ClosedPositions) != 1 || ss.ClosedPositions[0].CloseReason != "stop_loss" {
+		t.Fatalf("expected one ClosedPosition with reason=stop_loss, got %+v", ss.ClosedPositions)
+	}
+	if ss.ClosedPositions[0].ClosePrice != slTriggerPx {
+		t.Errorf("ClosePrice = %g, want %g (SL trigger)", ss.ClosedPositions[0].ClosePrice, slTriggerPx)
+	}
+}
+
+// TestReconcilePosition_NoFillsFallsBackToZeroPnL verifies that when neither
+// SL nor TP OIDs return fills (e.g. manual UI close, indexer outage), the
+// legacy zero-PnL hl_sync_external path is preserved.
+func TestReconcilePosition_NoFillsFallsBackToZeroPnL(t *testing.T) {
+	ss := &StrategyState{
+		ID: "hl-eth", Cash: 100,
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol: "ETH", Quantity: 0.4, AvgCost: 2000, Side: "long",
+				Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-eth",
+				TPOIDs: []int64{111, 222},
+			},
+		},
+	}
+	resolver := noFillFeeResolver
+	logger := newTestLogger(t)
+	startCash := ss.Cash
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger)
+
+	if _, open := ss.Positions["ETH"]; open {
+		t.Fatal("ETH should be removed even when no fills found")
+	}
+	if len(ss.ClosedPositions) != 1 || ss.ClosedPositions[0].CloseReason != "hl_sync_external" {
+		t.Fatalf("expected ClosedPosition with reason=hl_sync_external, got %+v", ss.ClosedPositions)
+	}
+	if ss.Cash != startCash {
+		t.Errorf("cash = %g, want unchanged (%g) on zero-PnL fallback", ss.Cash, startCash)
+	}
+}

--- a/scheduler/hyperliquid_fills.go
+++ b/scheduler/hyperliquid_fills.go
@@ -16,11 +16,14 @@ import (
 // HLFillLookup carries the aggregated fee + closed PnL across the on-chain
 // fills that match a single logical close. A "logical close" can fragment
 // into multiple userFills entries (different price levels, partial fills),
-// so callers always receive the sum.
+// so callers always receive the sum. Px is the size-weighted average fill
+// price across matched records (#673), used by the TP-fill attribution path
+// to book closes at the actual fill price rather than a virtual trigger.
 type HLFillLookup struct {
 	Fee       float64
 	ClosedPnL float64
 	FilledQty float64 // sum of sz across matched fill records; 0 when lookup missed
+	Px        float64 // size-weighted avg fill price; 0 when no fills matched
 	Count     int
 	OID       int64
 }
@@ -30,6 +33,7 @@ type HLFillLookup struct {
 type hlFillRecord struct {
 	Coin      string      `json:"coin"`
 	Sz        string      `json:"sz"`
+	Px        string      `json:"px"`
 	OID       json.Number `json:"oid"`
 	Fee       string      `json:"fee"`
 	ClosedPnl string      `json:"closedPnl"`
@@ -97,16 +101,23 @@ func lookupHyperliquidFillByOID(accountAddress string, oid int64, startTimeMs in
 		fills, err := fetchHyperliquidUserFillsByTime(accountAddress, startTimeMs)
 		if err == nil {
 			out := HLFillLookup{OID: oid}
+			pxNumerator := 0.0
 			for _, f := range fills {
 				if !fillOIDMatches(f, oid) {
 					continue
 				}
+				sz := parseHLFloat(f.Sz)
+				px := parseHLFloat(f.Px)
 				out.Fee += parseHLFloat(f.Fee)
 				out.ClosedPnL += parseHLFloat(f.ClosedPnl)
-				out.FilledQty += parseHLFloat(f.Sz)
+				out.FilledQty += sz
+				pxNumerator += sz * px
 				out.Count++
 			}
 			if out.Count > 0 {
+				if out.FilledQty > 0 {
+					out.Px = pxNumerator / out.FilledQty
+				}
 				return out, true
 			}
 		}
@@ -159,20 +170,28 @@ func lookupHyperliquidFillByCoinSize(accountAddress, coin string, absSize, toler
 						Fee:       parseHLFloat(anchor.Fee),
 						ClosedPnL: parseHLFloat(anchor.ClosedPnl),
 						FilledQty: parseHLFloat(anchor.Sz),
+						Px:        parseHLFloat(anchor.Px),
 						Count:     1,
 					}, true
 				}
 				out := HLFillLookup{OID: anchorOID}
+				pxNumerator := 0.0
 				for _, f := range fills {
 					if !fillOIDMatches(f, anchorOID) {
 						continue
 					}
+					sz := parseHLFloat(f.Sz)
+					px := parseHLFloat(f.Px)
 					out.Fee += parseHLFloat(f.Fee)
 					out.ClosedPnL += parseHLFloat(f.ClosedPnl)
-					out.FilledQty += parseHLFloat(f.Sz)
+					out.FilledQty += sz
+					pxNumerator += sz * px
 					out.Count++
 				}
 				if out.Count > 0 {
+					if out.FilledQty > 0 {
+						out.Px = pxNumerator / out.FilledQty
+					}
 					return out, true
 				}
 			}
@@ -387,6 +406,15 @@ func buildCachedHyperliquidReconcileFillResolver(accountAddress string, allStrat
 		}
 		if pos.StopLossOID > 0 && pos.StopLossTriggerPx > 0 {
 			addCandidate(sym, pos.StopLossOID, pos.Quantity)
+		}
+		// #673: Pre-fetch each TP OID lookup so the apply phase can distinguish
+		// SL-fired vs TP-fired closes when the position goes flat. Without
+		// these, hlAttemptCloseFromTPFills always misses the cache and the
+		// reconciler falls through to the SL-trigger-price path.
+		for _, tpOID := range pos.TPOIDs {
+			if tpOID > 0 {
+				addCandidate(sym, tpOID, pos.Quantity)
+			}
 		}
 		// Always include the (coin, 0, qty) form so peers without a tracked
 		// OID — Detector 1 mark-based path and Detector 2 non-owner — hit a


### PR DESCRIPTION
## Summary

- When both reduce-only TPs flatten a HL perps position, HL auto-cancels the resting SL on-chain. The reconciler's sole-owner external-close path (`reconcileHyperliquidPositionsWithResolver`) previously assumed `StopLossOID > 0 + on-chain flat = SL fired`, booking the close at the SL trigger price and producing a fictitious loss (observed: strategy value 185 → 180 on a winning trade).
- New `hlAttemptCloseFromTPFills` helper checks whether the SL OID has fills before falling through to the SL path. When SL has no fills but TP OIDs do, books each tier as a partial close at its actual VWAP fill price + fee from `userFills`.
- `HLFillLookup` gains a `Px` field (size-weighted avg fill price) computed in both `lookupHyperliquidFillByOID` and the coin+size fallback. The cached resolver pre-fetches TP OID lookups so the apply phase has them ready under `mu.Lock()`.

## Test plan

- [x] `TestReconcilePosition_TPFillsAttributedNotSL` — reproduces the exact #673 scenario (ETH long, both TPs fill, SL OID has no fills); asserts cash delta is positive and two close trades are booked at TP prices.
- [x] `TestReconcilePosition_SLFillStillTakesSLPath` — SL OID has fills; asserts legacy SL path is unchanged and TP attribution does not interfere.
- [x] `TestReconcilePosition_NoFillsFallsBackToZeroPnL` — neither SL nor TP fills; asserts `hl_sync_external` zero-PnL fallback is preserved.
- [x] Full `go test ./...` passes (245 lines added, 0 existing tests broken).

Closes #673

---
LLM: Claude Opus 4.7 | high