### PR TITLE
ci: update Claude bot comment when workflow is cancelled or fails

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -246,3 +246,54 @@ jobs:
           gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
             --method PATCH \
             --field body="$NEW_BODY"
+
+      - name: Note workflow cancellation/failure on Claude comment
+        if: always() && steps.verify_invocation.outputs.invoked == 'true' && (cancelled() || failure())
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MODEL_ID: ${{ steps.resolve_model.outputs.model_id }}
+          EFFORT: ${{ steps.resolve_model.outputs.effort }}
+          CLAUDE_HARNESS: ${{ env.CLAUDE_HARNESS }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          IS_CANCELLED: ${{ cancelled() }}
+        run: |
+          case "$MODEL_ID" in
+            "claude-opus-4-7[1m]")   MODEL_NAME="Claude Opus 4.7 (1M)" ;;
+            "claude-sonnet-4-6[1m]") MODEL_NAME="Claude Sonnet 4.6 (1M)" ;;
+            claude-haiku-4-5)        MODEL_NAME="Claude Haiku 4.5" ;;
+            "")                      MODEL_NAME="(model not resolved)" ;;
+            *)                       MODEL_NAME="$MODEL_ID" ;;
+          esac
+
+          if [ "$IS_CANCELLED" = "true" ]; then
+            STATUS_NOTE="**Workflow cancelled before completion.** See [run log]($RUN_URL)."
+          else
+            STATUS_NOTE="**Workflow failed before completion.** See [run log]($RUN_URL)."
+          fi
+
+          COMMENT=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" \
+            --jq '[.[] | select(.user.login == "claude[bot]")] | sort_by(.updated_at) | last')
+
+          COMMENT_ID=$(echo "$COMMENT" | jq -r '.id')
+          BODY=$(echo "$COMMENT" | jq -r '.body')
+
+          if [ -z "$COMMENT_ID" ] || [ "$COMMENT_ID" = "null" ]; then
+            echo "No claude[bot] comment found — nothing to update."
+            exit 0
+          fi
+
+          # Strip any stale LLM footer Claude may have written so we don't stack footers.
+          BODY=$(printf '%s' "$BODY" | python3 .github/scripts/strip_llm_footer.py)
+
+          # Drop a previously appended status note (idempotent on retries / repeated failures).
+          BODY=$(printf '%s' "$BODY" | perl -0777 -pe 's/\n*\*\*Workflow (cancelled|failed) before completion\.\*\*[^\n]*\n?//g')
+
+          FOOTER="---"$'\n'"LLM: ${MODEL_NAME} | ${EFFORT:-unknown} | Harness: ${CLAUDE_HARNESS}"
+
+          NEW_BODY="${BODY}"$'\n\n'"${STATUS_NOTE}"$'\n\n'"${FOOTER}"
+
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
+            --method PATCH \
+            --field body="$NEW_BODY"


### PR DESCRIPTION
## Summary

`claude-code-action@v1` posts an in-progress comment on the issue/PR when invoked. The existing "Append LLM footer" step (`.github/workflows/claude.yml:196`) only runs on success — `if:` defaults to `success()` — so when a run is cancelled mid-stream or fails, the bot comment stays stuck in its in-progress state with no model/effort metadata and no indication the workflow aborted.

This adds a sibling step gated on `cancelled() || failure()` that:

- Looks up the most recent `claude[bot]` comment (same pattern as the success-path footer step).
- Strips any stale LLM footer + any previously appended status note (idempotent on retries).
- Appends a status note linking to the Actions run log, plus the standard `LLM: <model> | <effort> | Harness: …` footer.
- Skips ccusage to avoid burning a sub-minute on `npx` install when the run is being torn down.

`MODEL_NAME` falls back to `(model not resolved)` for the case where the failure happens before `Resolve model from @claude invocation` runs.

No untrusted input is interpolated into shell — `RUN_URL` is built from `github.{server_url,repository,run_id}` and `IS_CANCELLED` is a function result.

## Test plan

- [ ] Trigger `@claude …` on an issue, cancel the run mid-execution; confirm the bot comment gets a "Workflow cancelled before completion" note + LLM footer.
- [ ] Force a failure (e.g., temporarily break a setup step on a test branch); confirm the bot comment shows "Workflow failed before completion" + LLM footer.
- [ ] Verify a normal `@claude` run is unchanged (the new step has no effect when neither `cancelled()` nor `failure()` is true).

---
LLM: Claude Opus 4.7 (1M) | high