### PR TITLE
[codex] Refactor open trade snapshot recording

### DIFF
--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -162,10 +162,10 @@ CREATE TABLE IF NOT EXISTS trades (
     exchange_fee REAL NOT NULL DEFAULT 0,
     is_close INTEGER NOT NULL DEFAULT 0,
     realized_pnl REAL NOT NULL DEFAULT 0,
-    stop_loss_oid INTEGER NOT NULL DEFAULT 0,
-    tp_oids_json TEXT NOT NULL DEFAULT '',
     stop_loss_atr_mult REAL,
-    tp_tiers_json TEXT NOT NULL DEFAULT ''
+    tp_tiers_json TEXT NOT NULL DEFAULT '',
+    stop_loss_oid INTEGER NOT NULL DEFAULT 0,
+    tp_oids_json TEXT NOT NULL DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_trades_strategy ON trades(strategy_id);
@@ -311,9 +311,6 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE positions ADD COLUMN tp_oids_json TEXT NOT NULL DEFAULT ''",
 		// Inline TP OIDs for manual-open actions so the scheduler drain sets pos.TPOIDs (#632).
 		"ALTER TABLE pending_manual_actions ADD COLUMN tp_oids_json TEXT NOT NULL DEFAULT ''",
-		// Immutable trade-row snapshot of protection OIDs known at open time (#674).
-		"ALTER TABLE trades ADD COLUMN stop_loss_oid INTEGER NOT NULL DEFAULT 0",
-		"ALTER TABLE trades ADD COLUMN tp_oids_json TEXT NOT NULL DEFAULT ''",
 		// SL arming method + TP tier snapshot at fill time (#669). stop_loss_atr_mult
 		// stays nullable: NULL = legacy/unknown or non-ATR arming (pct/margin/trailing-pct);
 		// non-NULL = ATR-armed at the recorded multiplier. tp_tiers_json carries the
@@ -324,6 +321,9 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE trades ADD COLUMN tp_tiers_json TEXT NOT NULL DEFAULT ''",
 		"ALTER TABLE positions ADD COLUMN stop_loss_atr_mult REAL",
 		"ALTER TABLE positions ADD COLUMN tp_tiers_json TEXT NOT NULL DEFAULT ''",
+		// Immutable trade-row snapshot of protection OIDs known at open time (#674).
+		"ALTER TABLE trades ADD COLUMN stop_loss_oid INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE trades ADD COLUMN tp_oids_json TEXT NOT NULL DEFAULT ''",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -162,6 +162,8 @@ CREATE TABLE IF NOT EXISTS trades (
     exchange_fee REAL NOT NULL DEFAULT 0,
     is_close INTEGER NOT NULL DEFAULT 0,
     realized_pnl REAL NOT NULL DEFAULT 0,
+    stop_loss_oid INTEGER NOT NULL DEFAULT 0,
+    tp_oids_json TEXT NOT NULL DEFAULT '',
     stop_loss_atr_mult REAL,
     tp_tiers_json TEXT NOT NULL DEFAULT ''
 );
@@ -309,6 +311,9 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE positions ADD COLUMN tp_oids_json TEXT NOT NULL DEFAULT ''",
 		// Inline TP OIDs for manual-open actions so the scheduler drain sets pos.TPOIDs (#632).
 		"ALTER TABLE pending_manual_actions ADD COLUMN tp_oids_json TEXT NOT NULL DEFAULT ''",
+		// Immutable trade-row snapshot of protection OIDs known at open time (#674).
+		"ALTER TABLE trades ADD COLUMN stop_loss_oid INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE trades ADD COLUMN tp_oids_json TEXT NOT NULL DEFAULT ''",
 		// SL arming method + TP tier snapshot at fill time (#669). stop_loss_atr_mult
 		// stays nullable: NULL = legacy/unknown or non-ATR arming (pct/margin/trailing-pct);
 		// non-NULL = ATR-armed at the recorded multiplier. tp_tiers_json carries the
@@ -558,12 +563,12 @@ func (sdb *StateDB) InsertTrade(strategyID string, trade Trade) error {
 		isManual = 1
 	}
 	_, err := sdb.db.Exec(`INSERT INTO trades
-			(strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, regime, entry_atr, stop_loss_trigger_px, manual, stop_loss_atr_mult, tp_tiers_json)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			(strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, regime, entry_atr, stop_loss_oid, stop_loss_trigger_px, tp_oids_json, manual, stop_loss_atr_mult, tp_tiers_json)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		strategyID, formatTime(trade.Timestamp), trade.Symbol, trade.PositionID, trade.Side,
 		trade.Quantity, trade.Price, trade.Value, trade.TradeType, trade.Details,
 		trade.ExchangeOrderID, trade.ExchangeFee, isClose, trade.RealizedPnL, trade.Regime,
-		trade.EntryATR, trade.StopLossTriggerPx, isManual,
+		trade.EntryATR, trade.StopLossOID, trade.StopLossTriggerPx, marshalTPOIDsJSON(trade.TPOIDs), isManual,
 		nullableFloat64(trade.StopLossATRMult), trade.TPTiersJSON)
 	if err != nil {
 		return fmt.Errorf("insert trade for %s: %w", strategyID, err)
@@ -571,15 +576,14 @@ func (sdb *StateDB) InsertTrade(strategyID string, trade Trade) error {
 	return nil
 }
 
-// UpdateTradeStampedFields sets entry_atr, stop_loss_trigger_px,
-// stop_loss_atr_mult, and tp_tiers_json on an existing trade row identified by
-// (strategy_id, timestamp). Called after RecordTrade once the corresponding
-// position values are available. stopLossATRMult==nil writes SQL NULL so the
-// "ATR-armed?" gate stays interpretable from nullness alone (#669).
-func (sdb *StateDB) UpdateTradeStampedFields(strategyID string, ts time.Time, entryATR, stopLossTriggerPx float64, stopLossATRMult *float64, tpTiersJSON string) error {
+// UpdateTradeStampedFields updates open-trade snapshot fields on an existing
+// trade row identified by (strategy_id, timestamp). The normal same-cycle open
+// path writes these fields in InsertTrade; this remains for fallback arming
+// after the open row already exists.
+func (sdb *StateDB) UpdateTradeStampedFields(strategyID string, ts time.Time, entryATR float64, stopLossOID int64, stopLossTriggerPx float64, tpOIDs []int64, stopLossATRMult *float64, tpTiersJSON string) error {
 	_, err := sdb.db.Exec(
-		`UPDATE trades SET entry_atr = ?, stop_loss_trigger_px = ?, stop_loss_atr_mult = ?, tp_tiers_json = ? WHERE strategy_id = ? AND timestamp = ?`,
-		entryATR, stopLossTriggerPx, nullableFloat64(stopLossATRMult), tpTiersJSON, strategyID, formatTime(ts),
+		`UPDATE trades SET entry_atr = ?, stop_loss_oid = ?, stop_loss_trigger_px = ?, tp_oids_json = ?, stop_loss_atr_mult = ?, tp_tiers_json = ? WHERE strategy_id = ? AND timestamp = ?`,
+		entryATR, stopLossOID, stopLossTriggerPx, marshalTPOIDsJSON(tpOIDs), nullableFloat64(stopLossATRMult), tpTiersJSON, strategyID, formatTime(ts),
 	)
 	return err
 }
@@ -809,8 +813,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	//    failed, even if later-timestamped rows were persisted successfully
 	//    (fixes the MAX(timestamp) dedup gap that would silently drop
 	//    out-of-order retries).
-	stmtTrade, err := tx.Prepare(`INSERT INTO trades (strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, regime, entry_atr, stop_loss_trigger_px, manual, stop_loss_atr_mult, tp_tiers_json)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtTrade, err := tx.Prepare(`INSERT INTO trades (strategy_id, timestamp, symbol, position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, regime, entry_atr, stop_loss_oid, stop_loss_trigger_px, tp_oids_json, manual, stop_loss_atr_mult, tp_tiers_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare trade insert: %w", err)
 	}
@@ -838,7 +842,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 			if t.Manual {
 				isManual = 1
 			}
-			if _, err := stmtTrade.Exec(s.ID, formatTime(t.Timestamp), t.Symbol, t.PositionID, t.Side, t.Quantity, t.Price, t.Value, t.TradeType, t.Details, t.ExchangeOrderID, t.ExchangeFee, isClose, t.RealizedPnL, t.Regime, t.EntryATR, t.StopLossTriggerPx, isManual, nullableFloat64(t.StopLossATRMult), t.TPTiersJSON); err != nil {
+			if _, err := stmtTrade.Exec(s.ID, formatTime(t.Timestamp), t.Symbol, t.PositionID, t.Side, t.Quantity, t.Price, t.Value, t.TradeType, t.Details, t.ExchangeOrderID, t.ExchangeFee, isClose, t.RealizedPnL, t.Regime, t.EntryATR, t.StopLossOID, t.StopLossTriggerPx, marshalTPOIDsJSON(t.TPOIDs), isManual, nullableFloat64(t.StopLossATRMult), t.TPTiersJSON); err != nil {
 				return fmt.Errorf("insert trade for %s: %w", s.ID, err)
 			}
 			flushed = append(flushed, trackedFlush{strat: s, index: i})
@@ -1255,7 +1259,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 
 	// 5. Load most recent 1000 trades per strategy (full history stays in SQLite).
 	for id, s := range state.Strategies {
-		tradeRows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime, COALESCE(entry_atr, 0) AS entry_atr, COALESCE(stop_loss_trigger_px, 0) AS stop_loss_trigger_px, COALESCE(manual, 0) AS manual, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json
+		tradeRows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime, COALESCE(entry_atr, 0) AS entry_atr, COALESCE(stop_loss_oid, 0) AS stop_loss_oid, COALESCE(stop_loss_trigger_px, 0) AS stop_loss_trigger_px, COALESCE(tp_oids_json, '') AS tp_oids_json, COALESCE(manual, 0) AS manual, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json
 			FROM trades WHERE strategy_id = ? ORDER BY timestamp ASC`, id)
 		if err != nil {
 			return nil, fmt.Errorf("load trades for %s: %w", id, err)
@@ -1265,14 +1269,16 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 			var t Trade
 			var tsStr string
 			var isCloseInt, isManualInt int
+			var tpOIDsJSON string
 			var slATRMult sql.NullFloat64
-			if err := tradeRows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL, &t.Regime, &t.EntryATR, &t.StopLossTriggerPx, &isManualInt, &slATRMult, &t.TPTiersJSON); err != nil {
+			if err := tradeRows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL, &t.Regime, &t.EntryATR, &t.StopLossOID, &t.StopLossTriggerPx, &tpOIDsJSON, &isManualInt, &slATRMult, &t.TPTiersJSON); err != nil {
 				tradeRows.Close()
 				return nil, fmt.Errorf("scan trade: %w", err)
 			}
 			t.Timestamp = parseTime(tsStr)
 			t.IsClose = isCloseInt != 0
 			t.Manual = isManualInt != 0
+			t.TPOIDs = parseTPOIDsJSON(tpOIDsJSON, 0, 0)
 			if slATRMult.Valid {
 				v := slATRMult.Float64
 				t.StopLossATRMult = &v
@@ -1472,7 +1478,7 @@ func (sdb *StateDB) QueryTradeHistory(strategyID, symbol string, since, until ti
 		limit = 500
 	}
 
-	query := fmt.Sprintf("SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime, COALESCE(entry_atr, 0) AS entry_atr, COALESCE(stop_loss_trigger_px, 0) AS stop_loss_trigger_px, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json FROM trades %s ORDER BY timestamp DESC LIMIT ? OFFSET ?", whereClause)
+	query := fmt.Sprintf("SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime, COALESCE(entry_atr, 0) AS entry_atr, COALESCE(stop_loss_oid, 0) AS stop_loss_oid, COALESCE(stop_loss_trigger_px, 0) AS stop_loss_trigger_px, COALESCE(tp_oids_json, '') AS tp_oids_json, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json FROM trades %s ORDER BY timestamp DESC LIMIT ? OFFSET ?", whereClause)
 	queryArgs := append(args, limit, offset)
 	rows, err := sdb.db.Query(query, queryArgs...)
 	if err != nil {
@@ -1485,12 +1491,14 @@ func (sdb *StateDB) QueryTradeHistory(strategyID, symbol string, since, until ti
 		var t Trade
 		var tsStr string
 		var isCloseInt int
+		var tpOIDsJSON string
 		var slATRMult sql.NullFloat64
-		if err := rows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL, &t.Regime, &t.EntryATR, &t.StopLossTriggerPx, &slATRMult, &t.TPTiersJSON); err != nil {
+		if err := rows.Scan(&tsStr, &t.StrategyID, &t.Symbol, &t.PositionID, &t.Side, &t.Quantity, &t.Price, &t.Value, &t.TradeType, &t.Details, &t.ExchangeOrderID, &t.ExchangeFee, &isCloseInt, &t.RealizedPnL, &t.Regime, &t.EntryATR, &t.StopLossOID, &t.StopLossTriggerPx, &tpOIDsJSON, &slATRMult, &t.TPTiersJSON); err != nil {
 			return nil, 0, fmt.Errorf("scan trade: %w", err)
 		}
 		t.Timestamp = parseTime(tsStr)
 		t.IsClose = isCloseInt != 0
+		t.TPOIDs = parseTPOIDsJSON(tpOIDsJSON, 0, 0)
 		if slATRMult.Valid {
 			v := slATRMult.Float64
 			t.StopLossATRMult = &v

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -470,7 +470,7 @@ func TestExecuteHyperliquidResult_StopLossFilledImmediately_ReconcilesState(t *t
 
 	logger := silentStrategyLogger("hl-test-eth")
 	defer logger.Close()
-	trades, _ := executeHyperliquidResult(sc, state, nil, result, execResult, "BUY", 3200, logger)
+	trades, _ := executeHyperliquidResult(sc, state, result, execResult, "BUY", 3200, logger)
 
 	// Open + synthetic close = 2 trades.
 	if trades != 2 {
@@ -511,7 +511,7 @@ func TestExecuteHyperliquidResult_StopLossFilledImmediately_NoTriggerPxIsNoOp(t 
 	}
 	logger := silentStrategyLogger("hl")
 	defer logger.Close()
-	trades, _ := executeHyperliquidResult(sc, state, nil, result, execResult, "BUY", 3200, logger)
+	trades, _ := executeHyperliquidResult(sc, state, result, execResult, "BUY", 3200, logger)
 	if trades != 1 {
 		t.Errorf("trades=%d, want 1 (only open recorded; reconcile skipped)", trades)
 	}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1501,14 +1501,16 @@ func main() {
 							if !liveExecFailed {
 								mu.Lock()
 								var openTrade *Trade
-								trades, detail, openTrade = executeHyperliquidResultDeferredOpen(sc, stratState, stateDB, result, execResult, signalStr, price, logger)
+								trades, detail, openTrade = executeHyperliquidResultDeferredOpen(sc, stratState, result, execResult, signalStr, price, logger)
 								mu.Unlock()
 								if execResult != nil && trades > 0 {
 									runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced after trade")
 									mu.Lock()
-									if pos, ok := stratState.Positions[result.Symbol]; ok {
-										recordPositionOpen(stratState, sc, openTrade, pos)
+									var pos *Position
+									if p, ok := stratState.Positions[result.Symbol]; ok {
+										pos = p
 									}
+									recordPositionOpen(stratState, sc, openTrade, pos)
 									mu.Unlock()
 								}
 							}
@@ -2579,12 +2581,14 @@ func isHLOpenOrderCapRejection(errStr string) bool {
 	return strings.Contains(lower, "trigger order") || strings.Contains(lower, "open order") || strings.Contains(lower, "open orders")
 }
 
-func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *HyperliquidResult, execResult *HyperliquidExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
-	trades, detail, openTrade := executeHyperliquidResultDeferredOpen(sc, s, db, result, execResult, signalStr, price, logger)
+func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *HyperliquidResult, execResult *HyperliquidExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
+	trades, detail, openTrade := executeHyperliquidResultDeferredOpen(sc, s, result, execResult, signalStr, price, logger)
 	if openTrade != nil {
-		if pos, ok := s.Positions[result.Symbol]; ok {
-			recordPositionOpen(s, sc, openTrade, pos)
+		var pos *Position
+		if p, ok := s.Positions[result.Symbol]; ok {
+			pos = p
 		}
+		recordPositionOpen(s, sc, openTrade, pos)
 	}
 	return trades, detail
 }
@@ -2593,7 +2597,7 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, db *StateDB, 
 // Must be called under Lock. execResult is non-nil for successful live orders;
 // nil for paper mode. Live open trades are returned so the caller can run
 // same-cycle protection sync before the single INSERT.
-func executeHyperliquidResultDeferredOpen(sc StrategyConfig, s *StrategyState, db *StateDB, result *HyperliquidResult, execResult *HyperliquidExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string, *Trade) {
+func executeHyperliquidResultDeferredOpen(sc StrategyConfig, s *StrategyState, result *HyperliquidResult, execResult *HyperliquidExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string, *Trade) {
 	fillPrice := price
 	var fillQty float64
 	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.AvgPx > 0 {
@@ -2668,8 +2672,13 @@ func executeHyperliquidResultDeferredOpen(sc StrategyConfig, s *StrategyState, d
 	// the realized loss is booked correctly.
 	if trades > 0 && execResult != nil && execResult.StopLossFilledImmediately &&
 		execResult.Execution != nil && execResult.Execution.Fill != nil {
-		if pos, ok := s.Positions[result.Symbol]; ok {
-			recordPositionOpen(s, sc, openTrade, pos)
+		var pos *Position
+		if p, ok := s.Positions[result.Symbol]; ok {
+			pos = p
+		}
+		// The immediate-close leg records next; nil openTrade prevents the
+		// wrapper/caller from inserting the open a second time.
+		if recordPositionOpen(s, sc, openTrade, pos) {
 			openTrade = nil
 		}
 		triggerPx := execResult.Execution.Fill.StopLossTriggerPx
@@ -2687,12 +2696,16 @@ func executeHyperliquidResultDeferredOpen(sc StrategyConfig, s *StrategyState, d
 		detail = fmt.Sprintf("[%s] %s%s %s @ $%.2f", sc.ID, prefix, signalStr, result.Symbol, fillPrice)
 	}
 	if execResult == nil {
-		if pos, ok := s.Positions[result.Symbol]; ok {
-			recordPositionOpen(s, sc, openTrade, pos)
+		var pos *Position
+		if p, ok := s.Positions[result.Symbol]; ok {
+			pos = p
+		}
+		// Paper mode has no post-unlock protection sync; record now and nil the
+		// deferred trade so the legacy wrapper cannot double-insert it.
+		if recordPositionOpen(s, sc, openTrade, pos) {
 			openTrade = nil
 		}
 	}
-	_ = db
 	return trades, detail, openTrade
 }
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1500,10 +1500,16 @@ func main() {
 							}
 							if !liveExecFailed {
 								mu.Lock()
-								trades, detail = executeHyperliquidResult(sc, stratState, stateDB, result, execResult, signalStr, price, logger)
+								var openTrade *Trade
+								trades, detail, openTrade = executeHyperliquidResultDeferredOpen(sc, stratState, stateDB, result, execResult, signalStr, price, logger)
 								mu.Unlock()
 								if execResult != nil && trades > 0 {
 									runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced after trade")
+									mu.Lock()
+									if pos, ok := stratState.Positions[result.Symbol]; ok {
+										recordPositionOpen(stratState, sc, openTrade, pos)
+									}
+									mu.Unlock()
 								}
 							}
 						}
@@ -2072,14 +2078,15 @@ func runSpotCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionC
 
 // executeSpotResult applies a spot signal to state. Must be called under Lock.
 func executeSpotResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *SpotResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
-	trades, err := ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, price, 0, 0, "", result.CloseFraction, logger)
+	exec, err := ExecuteSpotSignalWithFillFeeDeferredOpen(s, result.Signal, result.Symbol, price, 0, 0, "", result.CloseFraction, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
 	}
+	trades := exec.TradesExecuted
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
 	if pos, ok := s.Positions[result.Symbol]; ok {
-		stampOpenTradeWithProtectionSnapshot(s, db, sc, result.Symbol, pos)
+		recordPositionOpen(s, sc, exec.OpenTrade, pos)
 	}
 
 	detail := ""
@@ -2572,9 +2579,21 @@ func isHLOpenOrderCapRejection(errStr string) bool {
 	return strings.Contains(lower, "trigger order") || strings.Contains(lower, "open order") || strings.Contains(lower, "open orders")
 }
 
-// executeHyperliquidResult applies a hyperliquid result to state. Must be called under Lock.
-// execResult is non-nil for successful live orders; nil for paper mode.
 func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *HyperliquidResult, execResult *HyperliquidExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string) {
+	trades, detail, openTrade := executeHyperliquidResultDeferredOpen(sc, s, db, result, execResult, signalStr, price, logger)
+	if openTrade != nil {
+		if pos, ok := s.Positions[result.Symbol]; ok {
+			recordPositionOpen(s, sc, openTrade, pos)
+		}
+	}
+	return trades, detail
+}
+
+// executeHyperliquidResultDeferredOpen applies a hyperliquid result to state.
+// Must be called under Lock. execResult is non-nil for successful live orders;
+// nil for paper mode. Live open trades are returned so the caller can run
+// same-cycle protection sync before the single INSERT.
+func executeHyperliquidResultDeferredOpen(sc StrategyConfig, s *StrategyState, db *StateDB, result *HyperliquidResult, execResult *HyperliquidExecuteResult, signalStr string, price float64, logger *StrategyLogger) (int, string, *Trade) {
 	fillPrice := price
 	var fillQty float64
 	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.AvgPx > 0 {
@@ -2602,14 +2621,16 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, db *StateDB, 
 		fillFee = fill.Fee
 	}
 
-	trades, err := ExecutePerpsSignalWithLeverage(s, result.Signal, result.Symbol, fillPrice, sizingLeverage, exchangeLeverage, marginPerTradeUSD, fillQty, fillOID, fillFee, EffectiveDirection(sc), result.CloseFraction, logger)
+	exec, err := ExecutePerpsSignalWithLeverageDeferredOpen(s, result.Signal, result.Symbol, fillPrice, sizingLeverage, exchangeLeverage, marginPerTradeUSD, fillQty, fillOID, fillFee, EffectiveDirection(sc), result.CloseFraction, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
-		return 0, ""
+		return 0, "", nil
 	}
+	trades := exec.TradesExecuted
+	openTrade := exec.OpenTrade
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
 	if pos, ok := s.Positions[result.Symbol]; ok {
-		stampOpenTradeWithProtectionSnapshot(s, db, sc, result.Symbol, pos)
+		stampPositionProtectionSnapshot(pos, sc)
 	}
 	if trades > 0 && fillOID != "" {
 		logger.Info("Exchange order ID: %s", fillOID)
@@ -2633,7 +2654,6 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, db *StateDB, 
 				pos.StopLossOID = slOID
 				pos.StopLossTriggerPx = execResult.Execution.Fill.StopLossTriggerPx
 				logger.Info("SL trigger placed oid=%d @ $%.4f", slOID, execResult.Execution.Fill.StopLossTriggerPx)
-				stampOpenTradeWithProtectionSnapshot(s, db, sc, result.Symbol, pos)
 			}
 		}
 	}
@@ -2648,6 +2668,10 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, db *StateDB, 
 	// the realized loss is booked correctly.
 	if trades > 0 && execResult != nil && execResult.StopLossFilledImmediately &&
 		execResult.Execution != nil && execResult.Execution.Fill != nil {
+		if pos, ok := s.Positions[result.Symbol]; ok {
+			recordPositionOpen(s, sc, openTrade, pos)
+			openTrade = nil
+		}
 		triggerPx := execResult.Execution.Fill.StopLossTriggerPx
 		if recordPerpsStopLossClose(s, result.Symbol, triggerPx, "stop_loss_immediate", logger) {
 			trades++
@@ -2662,7 +2686,14 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, db *StateDB, 
 		}
 		detail = fmt.Sprintf("[%s] %s%s %s @ $%.2f", sc.ID, prefix, signalStr, result.Symbol, fillPrice)
 	}
-	return trades, detail
+	if execResult == nil {
+		if pos, ok := s.Positions[result.Symbol]; ok {
+			recordPositionOpen(s, sc, openTrade, pos)
+			openTrade = nil
+		}
+	}
+	_ = db
+	return trades, detail, openTrade
 }
 
 // topstepIsLive reports whether --mode=live appears in strategy args.
@@ -2839,14 +2870,15 @@ func executeTopStepResult(sc StrategyConfig, s *StrategyState, db *StateDB, resu
 		maxContracts = sc.FuturesConfig.MaxContracts
 	}
 
-	trades, err := ExecuteFuturesSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, result.ContractSpec, feePerContract, maxContracts, fillContracts, fillFee, fillOID, result.CloseFraction, logger)
+	exec, err := ExecuteFuturesSignalWithFillFeeDeferredOpen(s, result.Signal, result.Symbol, fillPrice, result.ContractSpec, feePerContract, maxContracts, fillContracts, fillFee, fillOID, result.CloseFraction, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
 	}
+	trades := exec.TradesExecuted
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
 	if pos, ok := s.Positions[result.Symbol]; ok {
-		stampOpenTradeWithProtectionSnapshot(s, db, sc, result.Symbol, pos)
+		recordPositionOpen(s, sc, exec.OpenTrade, pos)
 	}
 
 	detail := ""
@@ -3002,14 +3034,15 @@ func executeRobinhoodResult(sc StrategyConfig, s *StrategyState, db *StateDB, re
 		logger.Info("Live fill at $%.2f qty=%.6f (mid was $%.2f)", fillPrice, fillQty, price)
 	}
 
-	trades, err := ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, fillOID, result.CloseFraction, logger)
+	exec, err := ExecuteSpotSignalWithFillFeeDeferredOpen(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, fillOID, result.CloseFraction, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
 	}
+	trades := exec.TradesExecuted
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
 	if pos, ok := s.Positions[result.Symbol]; ok {
-		stampOpenTradeWithProtectionSnapshot(s, db, sc, result.Symbol, pos)
+		recordPositionOpen(s, sc, exec.OpenTrade, pos)
 	}
 
 	detail := ""
@@ -3207,20 +3240,21 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *
 	// fields onto s.TradeHistory after the fact would never reach SQLite — the
 	// eager INSERT has already happened and SaveState's timestamp dedup skips
 	// re-inserts for the same trade.
-	var trades int
+	var exec SignalExecutionResult
 	var err error
 	if sc.Type == "perps" {
-		trades, err = ExecutePerpsSignalWithLeverage(s, result.Signal, result.Symbol, fillPrice, EffectiveSizingLeverage(sc), EffectiveExchangeLeverage(sc), EffectiveMarginPerTradeUSD(sc), fillQty, fillOID, fillFee, EffectiveDirection(sc), result.CloseFraction, logger)
+		exec, err = ExecutePerpsSignalWithLeverageDeferredOpen(s, result.Signal, result.Symbol, fillPrice, EffectiveSizingLeverage(sc), EffectiveExchangeLeverage(sc), EffectiveMarginPerTradeUSD(sc), fillQty, fillOID, fillFee, EffectiveDirection(sc), result.CloseFraction, logger)
 	} else {
-		trades, err = ExecuteSpotSignalWithFillFee(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, fillOID, result.CloseFraction, logger)
+		exec, err = ExecuteSpotSignalWithFillFeeDeferredOpen(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, fillOID, result.CloseFraction, logger)
 	}
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
 		return 0, ""
 	}
+	trades := exec.TradesExecuted
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
 	if pos, ok := s.Positions[result.Symbol]; ok {
-		stampOpenTradeWithProtectionSnapshot(s, db, sc, result.Symbol, pos)
+		recordPositionOpen(s, sc, exec.OpenTrade, pos)
 	}
 
 	detail := ""

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -820,7 +820,7 @@ func TestExecuteHyperliquidResult_StampsExchangeData(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, _ := executeHyperliquidResult(sc, s, nil, result, execResult, "BUY", 50000, logger)
+	trades, _ := executeHyperliquidResult(sc, s, result, execResult, "BUY", 50000, logger)
 	if trades != 1 {
 		t.Fatalf("trades = %d, want 1", trades)
 	}
@@ -857,7 +857,7 @@ func TestExecuteHyperliquidResult_PaperModeNoExchangeData(t *testing.T) {
 	defer logger.Close()
 
 	// Paper mode: execResult is nil
-	trades, _ := executeHyperliquidResult(sc, s, nil, result, nil, "BUY", 50000, logger)
+	trades, _ := executeHyperliquidResult(sc, s, result, nil, "BUY", 50000, logger)
 	if trades != 1 {
 		t.Fatalf("trades = %d, want 1", trades)
 	}

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -561,10 +561,6 @@ func applyManualAction(state *AppState, scByID map[string]StrategyConfig, a Pend
 			TPOIDs:            a.TPOIDs,
 		}
 		pos.TradePositionID = newTradePositionID(a.StrategyID, a.Symbol, now)
-		// Stamp SL ATR mult + TP tier snapshot at fill time so the analytics
-		// row in `trades` reflects the config that armed the order, not whatever
-		// the operator edits later (#669).
-		stampPositionProtectionSnapshot(pos, sc)
 		ss.Positions[a.Symbol] = pos
 
 		trade := Trade{
@@ -581,12 +577,12 @@ func applyManualAction(state *AppState, scByID map[string]StrategyConfig, a Pend
 			ExchangeOrderID:   a.ExchangeOrderID,
 			ExchangeFee:       a.FillFee,
 			EntryATR:          a.EntryATR,
+			StopLossOID:       a.StopLossOID,
 			StopLossTriggerPx: a.StopLossTriggerPx,
-			StopLossATRMult:   pos.StopLossATRMult,
-			TPTiersJSON:       pos.TPTiersJSON,
+			TPOIDs:            cloneInt64s(a.TPOIDs),
 			Manual:            true,
 		}
-		RecordTrade(ss, trade)
+		recordPositionOpen(ss, sc, &trade, pos)
 		// Fix #1: perps open deducts only the fee; notional stays virtual.
 		ss.Cash -= a.FillFee
 		fmt.Printf("[manual] applied open: %s %s %.6f %s @ $%.4f\n",

--- a/scheduler/manual_test.go
+++ b/scheduler/manual_test.go
@@ -68,27 +68,33 @@ func TestApplyManualActionOpen(t *testing.T) {
 			},
 		},
 	}
+	slMult := 1.5
 	scByID := map[string]StrategyConfig{
 		"hl-manual-eth-live": {
-			ID:       "hl-manual-eth-live",
-			Type:     "manual",
-			Platform: "hyperliquid",
-			Symbol:   "ETH",
-			Leverage: 10,
+			ID:              "hl-manual-eth-live",
+			Type:            "manual",
+			Platform:        "hyperliquid",
+			Symbol:          "ETH",
+			Leverage:        10,
+			StopLossATRMult: &slMult,
 		},
 	}
+	tpOIDs := []int64{2001, 2002}
 	now := time.Now().UTC()
 	a := PendingManualAction{
-		ID:         1,
-		StrategyID: "hl-manual-eth-live",
-		Action:     "open",
-		Symbol:     "ETH",
-		Side:       "long",
-		Quantity:   0.5,
-		FillPrice:  2000,
-		FillFee:    0.7,
-		EntryATR:   50,
-		CreatedAt:  now,
+		ID:                1,
+		StrategyID:        "hl-manual-eth-live",
+		Action:            "open",
+		Symbol:            "ETH",
+		Side:              "long",
+		Quantity:          0.5,
+		FillPrice:         2000,
+		FillFee:           0.7,
+		EntryATR:          50,
+		StopLossOID:       1001,
+		StopLossTriggerPx: 1900,
+		TPOIDs:            tpOIDs,
+		CreatedAt:         now,
 	}
 
 	var recorded []Trade
@@ -139,6 +145,18 @@ func TestApplyManualActionOpen(t *testing.T) {
 	}
 	if tr.EntryATR != 50 {
 		t.Errorf("trade.EntryATR = %g, want 50", tr.EntryATR)
+	}
+	if tr.StopLossOID != 1001 {
+		t.Errorf("trade.StopLossOID = %d, want 1001", tr.StopLossOID)
+	}
+	if tr.StopLossTriggerPx != 1900 {
+		t.Errorf("trade.StopLossTriggerPx = %g, want 1900", tr.StopLossTriggerPx)
+	}
+	if len(tr.TPOIDs) != len(tpOIDs) || tr.TPOIDs[0] != tpOIDs[0] || tr.TPOIDs[1] != tpOIDs[1] {
+		t.Errorf("trade.TPOIDs = %v, want %v", tr.TPOIDs, tpOIDs)
+	}
+	if tr.StopLossATRMult == nil || *tr.StopLossATRMult != slMult {
+		t.Errorf("trade.StopLossATRMult = %v, want %.1f", tr.StopLossATRMult, slMult)
 	}
 }
 

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -394,7 +394,9 @@ type Trade struct {
 	Regime      string  `json:"regime,omitempty"` // market regime label at time of trade (#482)
 
 	EntryATR          float64 `json:"entry_atr,omitempty"`
+	StopLossOID       int64   `json:"stop_loss_oid,omitempty"`
 	StopLossTriggerPx float64 `json:"stop_loss_trigger_px,omitempty"`
+	TPOIDs            []int64 `json:"tp_oids,omitempty"`
 	Manual            bool    `json:"manual,omitempty"` // set when position was opened via manual-open CLI (#569)
 
 	// SL arming method + TP tier snapshot at fill time (#669). StopLossATRMult
@@ -415,6 +417,11 @@ type Trade struct {
 	// on the next flush rather than silently dropped because T1 < latestTS.
 	// Not serialized — purely in-memory bookkeeping.
 	persisted bool
+}
+
+type SignalExecutionResult struct {
+	TradesExecuted int
+	OpenTrade      *Trade
 }
 
 var tradePositionNonce uint64
@@ -812,6 +819,22 @@ func ExecutePerpsSignal(s *StrategyState, signal int, symbol string, price float
 //
 // Empty direction is treated as "long" for safety.
 func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string, price float64, sizingLeverage, exchangeLeverage, marginPerTradeUSD float64, fillQty float64, fillOID string, fillFee float64, direction string, closeFraction float64, logger *StrategyLogger) (int, error) {
+	return executePerpsSignalWithLeverage(s, signal, symbol, price, sizingLeverage, exchangeLeverage, marginPerTradeUSD, fillQty, fillOID, fillFee, direction, closeFraction, logger, func(trade Trade) {
+		RecordTrade(s, trade)
+	})
+}
+
+func ExecutePerpsSignalWithLeverageDeferredOpen(s *StrategyState, signal int, symbol string, price float64, sizingLeverage, exchangeLeverage, marginPerTradeUSD float64, fillQty float64, fillOID string, fillFee float64, direction string, closeFraction float64, logger *StrategyLogger) (SignalExecutionResult, error) {
+	var result SignalExecutionResult
+	trades, err := executePerpsSignalWithLeverage(s, signal, symbol, price, sizingLeverage, exchangeLeverage, marginPerTradeUSD, fillQty, fillOID, fillFee, direction, closeFraction, logger, func(trade Trade) {
+		t := trade
+		result.OpenTrade = &t
+	})
+	result.TradesExecuted = trades
+	return result, err
+}
+
+func executePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string, price float64, sizingLeverage, exchangeLeverage, marginPerTradeUSD float64, fillQty float64, fillOID string, fillFee float64, direction string, closeFraction float64, logger *StrategyLogger, recordOpen func(Trade)) (int, error) {
 	if direction == "" {
 		direction = DirectionLong
 	}
@@ -1020,7 +1043,7 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 			ExchangeFee:     exchangeFeeForTrade(fillFee, useFillFee),
 		}
 		trade.Regime = s.Regime
-		RecordTrade(s, trade)
+		recordOpen(trade)
 		logger.Info("BUY %s: %.6f @ $%.2f (%s, notional $%.2f, fee $%.2f)", symbol, qty, execPrice, leverageLabel, notional, fee)
 		tradesExecuted++
 
@@ -1188,7 +1211,7 @@ func ExecutePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 			ExchangeFee:     exchangeFeeForTrade(fillFee, useFillFee),
 		}
 		trade.Regime = s.Regime
-		RecordTrade(s, trade)
+		recordOpen(trade)
 		logger.Info("SELL %s: %.6f @ $%.2f (%s, notional $%.2f, fee $%.2f) [open short]", symbol, qty, execPrice, leverageLabel, notional, fee)
 		tradesExecuted++
 	}
@@ -1215,6 +1238,22 @@ func ExecuteSpotSignal(s *StrategyState, signal int, symbol string, price float6
 // leg reduces pos.Quantity (paper) or uses fillQty (live) without deleting
 // the position. closeFraction == 0 preserves the legacy full-close semantics.
 func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, fillQty float64, fillFee float64, fillOID string, closeFraction float64, logger *StrategyLogger) (int, error) {
+	return executeSpotSignalWithFillFee(s, signal, symbol, price, fillQty, fillFee, fillOID, closeFraction, logger, func(trade Trade) {
+		RecordTrade(s, trade)
+	})
+}
+
+func ExecuteSpotSignalWithFillFeeDeferredOpen(s *StrategyState, signal int, symbol string, price float64, fillQty float64, fillFee float64, fillOID string, closeFraction float64, logger *StrategyLogger) (SignalExecutionResult, error) {
+	var result SignalExecutionResult
+	trades, err := executeSpotSignalWithFillFee(s, signal, symbol, price, fillQty, fillFee, fillOID, closeFraction, logger, func(trade Trade) {
+		t := trade
+		result.OpenTrade = &t
+	})
+	result.TradesExecuted = trades
+	return result, err
+}
+
+func executeSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, fillQty float64, fillFee float64, fillOID string, closeFraction float64, logger *StrategyLogger, recordOpen func(Trade)) (int, error) {
 	if signal == 0 {
 		return 0, nil
 	}
@@ -1356,7 +1395,7 @@ func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			ExchangeFee:     exchangeFeeForTrade(fillFee, useFillMetadata),
 		}
 		trade.Regime = s.Regime
-		RecordTrade(s, trade)
+		recordOpen(trade)
 		logger.Info("BUY %s: %.6f @ $%.2f (fee $%.2f, total $%.2f)", symbol, qty, execPrice, fee, tradeCost+fee)
 		tradesExecuted++
 
@@ -1445,6 +1484,22 @@ func ExecuteFuturesSignal(s *StrategyState, signal int, symbol string, price flo
 // remaining (a tier returning a fraction smaller than 1 contract is a no-op
 // rather than a full close).
 func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, spec ContractSpec, feePerContract float64, maxContracts int, fillContracts int, fillFee float64, fillOID string, closeFraction float64, logger *StrategyLogger) (int, error) {
+	return executeFuturesSignalWithFillFee(s, signal, symbol, price, spec, feePerContract, maxContracts, fillContracts, fillFee, fillOID, closeFraction, logger, func(trade Trade) {
+		RecordTrade(s, trade)
+	})
+}
+
+func ExecuteFuturesSignalWithFillFeeDeferredOpen(s *StrategyState, signal int, symbol string, price float64, spec ContractSpec, feePerContract float64, maxContracts int, fillContracts int, fillFee float64, fillOID string, closeFraction float64, logger *StrategyLogger) (SignalExecutionResult, error) {
+	var result SignalExecutionResult
+	trades, err := executeFuturesSignalWithFillFee(s, signal, symbol, price, spec, feePerContract, maxContracts, fillContracts, fillFee, fillOID, closeFraction, logger, func(trade Trade) {
+		t := trade
+		result.OpenTrade = &t
+	})
+	result.TradesExecuted = trades
+	return result, err
+}
+
+func executeFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, spec ContractSpec, feePerContract float64, maxContracts int, fillContracts int, fillFee float64, fillOID string, closeFraction float64, logger *StrategyLogger, recordOpen func(Trade)) (int, error) {
 	if signal == 0 {
 		return 0, nil
 	}
@@ -1601,7 +1656,7 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 			ExchangeFee:     exchangeFeeForTrade(fillFee, useFillMetadata),
 		}
 		trade.Regime = s.Regime
-		RecordTrade(s, trade)
+		recordOpen(trade)
 		logger.Info("BUY %s: %d contracts @ $%.2f (fee $%.2f)", symbol, contracts, execPrice, fee)
 		tradesExecuted++
 
@@ -1746,7 +1801,7 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 				ExchangeFee:     exchangeFeeForTrade(fillFee, useFillMetadata),
 			}
 			trade.Regime = s.Regime
-			RecordTrade(s, trade)
+			recordOpen(trade)
 			logger.Info("SHORT %s: %d contracts @ $%.2f (fee $%.2f)", symbol, contracts, execPrice, fee)
 			tradesExecuted++
 		}
@@ -1754,12 +1809,11 @@ func ExecuteFuturesSignalWithFillFee(s *StrategyState, signal int, symbol string
 	return tradesExecuted, nil
 }
 
-// stampOpenTradeFromPosition backfills EntryATR, StopLossTriggerPx,
-// StopLossATRMult, and TPTiersJSON onto the most recent open Trade for symbol
-// after those values are stamped onto the Position post-RecordTrade. Only
-// updates fields that are currently zero / nil / empty so subsequent calls are
-// idempotent. Updates both the in-memory slice and the SQLite row when db is
-// non-nil.
+// stampOpenTradeFromPosition backfills open-trade protection snapshot fields
+// onto the most recent open Trade for symbol after those values are stamped
+// onto the Position post-RecordTrade. The normal same-cycle open path records
+// these fields in one INSERT via recordPositionOpen; this helper remains for
+// fallback protection arming after the open row already exists.
 func stampOpenTradeFromPosition(s *StrategyState, db *StateDB, symbol string, pos *Position) {
 	if pos == nil {
 		return
@@ -1777,8 +1831,16 @@ func stampOpenTradeFromPosition(s *StrategyState, db *StateDB, symbol string, po
 			t.EntryATR = pos.EntryATR
 			changed = true
 		}
+		if pos.StopLossOID > 0 && t.StopLossOID == 0 {
+			t.StopLossOID = pos.StopLossOID
+			changed = true
+		}
 		if pos.StopLossTriggerPx > 0 && t.StopLossTriggerPx == 0 {
 			t.StopLossTriggerPx = pos.StopLossTriggerPx
+			changed = true
+		}
+		if len(pos.TPOIDs) > 0 && len(t.TPOIDs) == 0 {
+			t.TPOIDs = cloneInt64s(pos.TPOIDs)
 			changed = true
 		}
 		if pos.StopLossATRMult != nil && t.StopLossATRMult == nil {
@@ -1791,7 +1853,7 @@ func stampOpenTradeFromPosition(s *StrategyState, db *StateDB, symbol string, po
 			changed = true
 		}
 		if changed && db != nil {
-			_ = db.UpdateTradeStampedFields(s.ID, t.Timestamp, t.EntryATR, t.StopLossTriggerPx, t.StopLossATRMult, t.TPTiersJSON)
+			_ = db.UpdateTradeStampedFields(s.ID, t.Timestamp, t.EntryATR, t.StopLossOID, t.StopLossTriggerPx, t.TPOIDs, t.StopLossATRMult, t.TPTiersJSON)
 		}
 		return
 	}

--- a/scheduler/trade_persist_test.go
+++ b/scheduler/trade_persist_test.go
@@ -300,6 +300,104 @@ func TestDeferredOpenRecordsProtectionOIDSnapshotOnce(t *testing.T) {
 	}
 }
 
+func TestDeferredOpenWrappersDoNotInsertBeforeRecordPositionOpen(t *testing.T) {
+	db := openTestDB(t)
+	prev := tradeRecorder
+	tradeRecorder = db.InsertTrade
+	t.Cleanup(func() { tradeRecorder = prev })
+	logger := newTestLogger(t)
+
+	t.Run("spot", func(t *testing.T) {
+		s := &StrategyState{
+			ID:              "spot1",
+			Platform:        "binanceus",
+			Type:            "spot",
+			Cash:            1000,
+			InitialCapital:  1000,
+			Positions:       map[string]*Position{},
+			OptionPositions: map[string]*OptionPosition{},
+			TradeHistory:    []Trade{},
+		}
+		exec, err := ExecuteSpotSignalWithFillFeeDeferredOpen(s, 1, "BTC", 50000, 0.01, 0.25, "spot-oid", 0, logger)
+		if err != nil {
+			t.Fatalf("ExecuteSpotSignalWithFillFeeDeferredOpen: %v", err)
+		}
+		if exec.TradesExecuted != 1 || exec.OpenTrade == nil {
+			t.Fatalf("exec = %+v, want one deferred open trade", exec)
+		}
+		assertTradeCount(t, db, "spot1", 0)
+		recordPositionOpen(s, StrategyConfig{ID: "spot1", Type: "spot", Platform: "binanceus"}, exec.OpenTrade, s.Positions["BTC"])
+		assertTradeCount(t, db, "spot1", 1)
+	})
+
+	t.Run("futures", func(t *testing.T) {
+		s := &StrategyState{
+			ID:              "ts-es",
+			Platform:        "topstep",
+			Type:            "futures",
+			Cash:            10000,
+			InitialCapital:  10000,
+			Positions:       map[string]*Position{},
+			OptionPositions: map[string]*OptionPosition{},
+			TradeHistory:    []Trade{},
+		}
+		spec := ContractSpec{Multiplier: 50, Margin: 500}
+		exec, err := ExecuteFuturesSignalWithFillFeeDeferredOpen(s, 1, "ES", 5000, spec, 2.5, 5, 1, 1.25, "fut-oid", 0, logger)
+		if err != nil {
+			t.Fatalf("ExecuteFuturesSignalWithFillFeeDeferredOpen: %v", err)
+		}
+		if exec.TradesExecuted != 1 || exec.OpenTrade == nil {
+			t.Fatalf("exec = %+v, want one deferred open trade", exec)
+		}
+		assertTradeCount(t, db, "ts-es", 0)
+		recordPositionOpen(s, StrategyConfig{ID: "ts-es", Type: "futures", Platform: "topstep"}, exec.OpenTrade, s.Positions["ES"])
+		assertTradeCount(t, db, "ts-es", 1)
+	})
+}
+
+func TestRecordPositionOpenFallsBackWhenPositionMissing(t *testing.T) {
+	db := openTestDB(t)
+	prev := tradeRecorder
+	tradeRecorder = db.InsertTrade
+	t.Cleanup(func() { tradeRecorder = prev })
+
+	s := &StrategyState{
+		ID:              "hl-live",
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		Cash:            1000,
+		InitialCapital:  1000,
+		Positions:       map[string]*Position{},
+		OptionPositions: map[string]*OptionPosition{},
+		TradeHistory:    []Trade{},
+	}
+	logger := newTestLogger(t)
+	exec, err := ExecutePerpsSignalWithLeverageDeferredOpen(s, 1, "ETH", 2000, 1, 1, 0, 0.5, "12345", 0.42, DirectionLong, 0, logger)
+	if err != nil {
+		t.Fatalf("ExecutePerpsSignalWithLeverageDeferredOpen: %v", err)
+	}
+	delete(s.Positions, "ETH")
+
+	if !recordPositionOpen(s, StrategyConfig{ID: "hl-live", Platform: "hyperliquid", Type: "perps"}, exec.OpenTrade, nil) {
+		t.Fatal("recordPositionOpen returned false, want fallback insert")
+	}
+	assertTradeCount(t, db, "hl-live", 1)
+	if len(s.TradeHistory) != 1 || s.TradeHistory[0].ExchangeOrderID != "12345" {
+		t.Fatalf("fallback trade = %+v, want bare deferred trade recorded", s.TradeHistory)
+	}
+}
+
+func assertTradeCount(t *testing.T, db *StateDB, strategyID string, want int) {
+	t.Helper()
+	var count int
+	if err := db.db.QueryRow("SELECT COUNT(*) FROM trades WHERE strategy_id = ?", strategyID).Scan(&count); err != nil {
+		t.Fatalf("count trades for %s: %v", strategyID, err)
+	}
+	if count != want {
+		t.Fatalf("trade rows for %s = %d, want %d", strategyID, count, want)
+	}
+}
+
 // TestRecordTrade_OutOfOrderFailureRecoveredBySaveState verifies the dedup
 // fix for the #289 carry-over: when an earlier-timestamped RecordTrade fails
 // eager-insert but a later-timestamped one succeeds, the pre-fix MAX(timestamp)

--- a/scheduler/trade_persist_test.go
+++ b/scheduler/trade_persist_test.go
@@ -244,6 +244,62 @@ func TestExecutePerpsSignal_PersistsExchangeMetadata(t *testing.T) {
 	}
 }
 
+func TestDeferredOpenRecordsProtectionOIDSnapshotOnce(t *testing.T) {
+	db := openTestDB(t)
+	prev := tradeRecorder
+	tradeRecorder = db.InsertTrade
+	t.Cleanup(func() { tradeRecorder = prev })
+
+	s := &StrategyState{
+		ID:              "hl-live",
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		Cash:            1000,
+		InitialCapital:  1000,
+		Positions:       map[string]*Position{},
+		OptionPositions: map[string]*OptionPosition{},
+		TradeHistory:    []Trade{},
+	}
+	logger := newTestLogger(t)
+
+	exec, err := ExecutePerpsSignalWithLeverageDeferredOpen(s, 1, "ETH", 2000, 1, 1, 0, 0.5, "12345", 0.42, DirectionLong, 0, logger)
+	if err != nil {
+		t.Fatalf("ExecutePerpsSignalWithLeverageDeferredOpen: %v", err)
+	}
+	if exec.TradesExecuted != 1 || exec.OpenTrade == nil {
+		t.Fatalf("exec = %+v, want one deferred open trade", exec)
+	}
+	var count int
+	if err := db.db.QueryRow("SELECT COUNT(*) FROM trades WHERE strategy_id = 'hl-live'").Scan(&count); err != nil {
+		t.Fatalf("count before record: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("trade rows before recordPositionOpen = %d, want 0", count)
+	}
+
+	pos := s.Positions["ETH"]
+	pos.EntryATR = 12.5
+	pos.StopLossOID = 111
+	pos.StopLossTriggerPx = 1875
+	pos.TPOIDs = []int64{222, 333}
+	mult := 1.5
+	sc := StrategyConfig{ID: "hl-live", Platform: "hyperliquid", Type: "perps", StopLossATRMult: &mult}
+	recordPositionOpen(s, sc, exec.OpenTrade, pos)
+
+	var entryATR, triggerPx, slATRMult float64
+	var slOID int64
+	var tpOIDsJSON string
+	if err := db.db.QueryRow(`SELECT entry_atr, stop_loss_oid, stop_loss_trigger_px, tp_oids_json, stop_loss_atr_mult FROM trades WHERE strategy_id = 'hl-live'`).Scan(&entryATR, &slOID, &triggerPx, &tpOIDsJSON, &slATRMult); err != nil {
+		t.Fatalf("query trade snapshot: %v", err)
+	}
+	if entryATR != 12.5 || slOID != 111 || triggerPx != 1875 || tpOIDsJSON != "[222,333]" || slATRMult != 1.5 {
+		t.Fatalf("snapshot = atr %.2f slOID %d trigger %.2f tp %q mult %.2f, want atr 12.5 slOID 111 trigger 1875 tp [222,333] mult 1.5", entryATR, slOID, triggerPx, tpOIDsJSON, slATRMult)
+	}
+	if len(s.TradeHistory) != 1 || s.TradeHistory[0].StopLossOID != 111 || len(s.TradeHistory[0].TPOIDs) != 2 || s.TradeHistory[0].TPOIDs[0] != 222 || s.TradeHistory[0].TPOIDs[1] != 333 {
+		t.Fatalf("in-memory trade snapshot = %+v, want SL/TPOID snapshot", s.TradeHistory)
+	}
+}
+
 // TestRecordTrade_OutOfOrderFailureRecoveredBySaveState verifies the dedup
 // fix for the #289 carry-over: when an earlier-timestamped RecordTrade fails
 // eager-insert but a later-timestamped one succeeds, the pre-fix MAX(timestamp)

--- a/scheduler/trade_protection_snapshot.go
+++ b/scheduler/trade_protection_snapshot.go
@@ -82,13 +82,14 @@ func copyPositionOpenSnapshotToTrade(trade *Trade, pos *Position) {
 	trade.TPTiersJSON = pos.TPTiersJSON
 }
 
-func recordPositionOpen(s *StrategyState, sc StrategyConfig, trade *Trade, pos *Position) {
+func recordPositionOpen(s *StrategyState, sc StrategyConfig, trade *Trade, pos *Position) bool {
 	if s == nil || trade == nil {
-		return
+		return false
 	}
 	stampPositionProtectionSnapshot(pos, sc)
 	copyPositionOpenSnapshotToTrade(trade, pos)
 	RecordTrade(s, *trade)
+	return true
 }
 
 // stampOpenTradeWithProtectionSnapshot is the trade-open helper that combines

--- a/scheduler/trade_protection_snapshot.go
+++ b/scheduler/trade_protection_snapshot.go
@@ -65,6 +65,32 @@ func stampPositionProtectionSnapshot(pos *Position, sc StrategyConfig) {
 	}
 }
 
+func copyPositionOpenSnapshotToTrade(trade *Trade, pos *Position) {
+	if trade == nil || pos == nil {
+		return
+	}
+	trade.EntryATR = pos.EntryATR
+	trade.StopLossOID = pos.StopLossOID
+	trade.StopLossTriggerPx = pos.StopLossTriggerPx
+	trade.TPOIDs = cloneInt64s(pos.TPOIDs)
+	if pos.StopLossATRMult != nil {
+		v := *pos.StopLossATRMult
+		trade.StopLossATRMult = &v
+	} else {
+		trade.StopLossATRMult = nil
+	}
+	trade.TPTiersJSON = pos.TPTiersJSON
+}
+
+func recordPositionOpen(s *StrategyState, sc StrategyConfig, trade *Trade, pos *Position) {
+	if s == nil || trade == nil {
+		return
+	}
+	stampPositionProtectionSnapshot(pos, sc)
+	copyPositionOpenSnapshotToTrade(trade, pos)
+	RecordTrade(s, *trade)
+}
+
 // stampOpenTradeWithProtectionSnapshot is the trade-open helper that combines
 // the protection-config snapshot (sc-derived) with the position-derived backfill
 // onto the most recent open Trade for symbol. Idempotent on both layers — call


### PR DESCRIPTION
## Summary

- add immutable trade-row protection snapshots for `stop_loss_oid` and `tp_oids_json`
- add deferred-open execution paths so scheduler callers can record open trades once after ATR/protection snapshots are known
- route manual, spot, futures, Robinhood, OKX, and Hyperliquid open paths through `recordPositionOpen`
- preserve deferred open fills with a bare trade fallback if the position disappears before final snapshot recording
- keep fallback trade-stamping support for later/missed protection arming

Closes #674

## Tests

- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...`

LLM: GPT-5.5 | Effort: high | Harness: Codex CLI