### PR TITLE
ci: fix claude.yml parse error from cancelled() in env block

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -247,6 +247,10 @@ jobs:
             --method PATCH \
             --field body="$NEW_BODY"
 
+      - name: Mark cancellation for downstream status note
+        if: always() && cancelled()
+        run: echo "IS_CANCELLED=true" >> "$GITHUB_ENV"
+
       - name: Note workflow cancellation/failure on Claude comment
         if: always() && steps.verify_invocation.outputs.invoked == 'true' && (cancelled() || failure())
         env:
@@ -257,7 +261,6 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          IS_CANCELLED: ${{ cancelled() }}
         run: |
           case "$MODEL_ID" in
             "claude-opus-4-7[1m]")   MODEL_NAME="Claude Opus 4.7 (1M)" ;;


### PR DESCRIPTION
## Summary

- `cancelled()` is a status check function only valid inside `if:` conditionals; using it in an `env:` block caused workflow validation to fail with `Unrecognized function: cancelled` since #676 landed (e.g. run [25613496315](https://github.com/richkuo/go-trader/actions/runs/25613496315) on main, run [25613936143](https://github.com/richkuo/go-trader/actions/runs/25613936143) on the issue-674 branch — both fail in 0s with "workflow file issue").
- Add a preceding step gated on `if: cancelled()` that writes `IS_CANCELLED=true` to `\$GITHUB_ENV`; the existing run script reads `\$IS_CANCELLED` unchanged. When the workflow merely fails (not cancelled) the variable stays empty and the script falls through to the "Workflow failed" branch.

Closes #678

## Test plan

- [ ] Workflow file parses (push to branch no longer fails in 0s).
- [ ] On a cancelled `@claude` run, the bot comment gets the "Workflow cancelled before completion." note.
- [ ] On a failed `@claude` run, the bot comment gets the "Workflow failed before completion." note.

---
LLM: Claude Opus 4.7 | high | Harness: Claude Code CLI