### PR TITLE
fix: gate SL fallback on confirmed userFills hit (#685)

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -547,6 +547,11 @@ func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym st
 				if recordPerpsStopLossCloseWithFillFee(stratState, sym, statePos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "stop_loss", logger) {
 					return true
 				}
+			} else if useFillFee {
+				// #685 log clarity: the lookup hit (logged above) matched
+				// something other than this SL OID (e.g. a coin+size fallback
+				// onto a TP fill), so this close is NOT being booked as SL.
+				logger.Info("hl-sync: %s SL OID %s unfilled — routing to hl_sync_external (matched oid=%d qty=%.6f)", sym, oidStr, lookup.OID, lookup.FilledQty)
 			}
 		}
 		// Close price is unknown — the fill happened off-scheduler between
@@ -1159,8 +1164,11 @@ func hlAttemptCloseFromTPFills(s *StrategyState, sym string, pos *Position, reso
 	// If the SL OID has fills, leave attribution to the existing SL path —
 	// it knows how to handle the #621 "SL fired on the post-TP residual"
 	// case and we don't want to double-book by also crediting TPs here.
+	// #685: require OID equality so a coin+size fallback hit on a TP fill of
+	// the same size (lookup.OID != StopLossOID) doesn't masquerade as an SL
+	// fill and starve TP attribution.
 	if pos.StopLossOID > 0 {
-		if _, slFilled := resolveFee(sym, pos.StopLossOID, pos.Quantity); slFilled {
+		if lookup, slFilled := resolveFee(sym, pos.StopLossOID, pos.Quantity); slFilled && lookup.OID == pos.StopLossOID && lookup.FilledQty > 1e-9 {
 			return false
 		}
 	}

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -528,15 +528,25 @@ func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym st
 			lookup, useFillFee := resolveFee(sym, statePos.StopLossOID, statePos.Quantity)
 			oidStr := strconv.FormatInt(statePos.StopLossOID, 10)
 			logHyperliquidReconcileFillLookup(logger, sym, statePos.StopLossOID, statePos.Quantity, lookup, useFillFee)
-			// #621: When userFills returned a real fill qty smaller than the virtual
-			// position (e.g. SL was placed at the on-chain size after a manual TP
-			// reduced the position), use the actual fill qty so PnL/cash are correct.
-			if useFillFee && lookup.FilledQty > 1e-9 && lookup.FilledQty < statePos.Quantity-1e-9 {
-				logger.Info("hl-sync: %s SL close qty adjusted %.6f → %.6f (actual fill from userFills)", sym, statePos.Quantity, lookup.FilledQty)
-				statePos.Quantity = lookup.FilledQty
-			}
-			if recordPerpsStopLossCloseWithFillFee(stratState, sym, statePos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "stop_loss", logger) {
-				return true
+			// #685: Only book as SL when userFills confirms the SL OID actually
+			// filled. Without this gate, a TP-fired close whose TPOIDs have all
+			// been zeroed by a prior applyHyperliquidProtectionSync cycle (so
+			// hlAttemptCloseFromTPFills above returns false) lands here and gets
+			// mis-attributed to the cancelled SL at its trigger price. Match must
+			// be by exact OID; the coin+size fallback can spuriously hit a TP
+			// fill of the same size.
+			slConfirmed := useFillFee && lookup.OID == statePos.StopLossOID && lookup.FilledQty > 1e-9
+			if slConfirmed {
+				// #621: When userFills returned a real fill qty smaller than the virtual
+				// position (e.g. SL was placed at the on-chain size after a manual TP
+				// reduced the position), use the actual fill qty so PnL/cash are correct.
+				if lookup.FilledQty < statePos.Quantity-1e-9 {
+					logger.Info("hl-sync: %s SL close qty adjusted %.6f → %.6f (actual fill from userFills)", sym, statePos.Quantity, lookup.FilledQty)
+					statePos.Quantity = lookup.FilledQty
+				}
+				if recordPerpsStopLossCloseWithFillFee(stratState, sym, statePos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "stop_loss", logger) {
+					return true
+				}
 			}
 		}
 		// Close price is unknown — the fill happened off-scheduler between

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -3178,8 +3178,9 @@ func TestReconcilePositionSLClose_UsesFilledQtyFromLookup(t *testing.T) {
 		},
 	}
 	// Resolver returns filledQty < virtualQty (SL was capped at on-chain size).
-	resolver := hlReconcileFillResolver(func(_ string, _ int64, _ float64) (HLFillLookup, bool) {
-		return HLFillLookup{Fee: 0.08, FilledQty: filledQty, Count: 1}, true
+	// OID echo matches StopLossOID so the #685 SL-confirmed gate accepts it.
+	resolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
+		return HLFillLookup{Fee: 0.08, FilledQty: filledQty, Count: 1, OID: oid}, true
 	})
 	logger := newTestLogger(t)
 
@@ -3208,9 +3209,11 @@ func TestReconcilePositionSLClose_UsesFilledQtyFromLookup(t *testing.T) {
 	}
 }
 
-// TestReconcilePositionSLClose_FallsBackToVirtualQtyOnMiss verifies that when
-// FilledQty is 0 (lookup miss), the virtual quantity is used unchanged.
-func TestReconcilePositionSLClose_FallsBackToVirtualQtyOnMiss(t *testing.T) {
+// TestReconcilePositionSLClose_NoFillFallsThroughToExternal verifies the #685
+// gate: when the resolver responds but reports no SL fill (FilledQty=0), the
+// reconciler does NOT book the close at the SL trigger price — the SL was
+// cancelled, not filled. Falls through to hl_sync_external at zero PnL.
+func TestReconcilePositionSLClose_NoFillFallsThroughToExternal(t *testing.T) {
 	const virtualQty = 0.422
 	ss := &StrategyState{
 		ID:   "hl-eth",
@@ -3223,19 +3226,28 @@ func TestReconcilePositionSLClose_FallsBackToVirtualQtyOnMiss(t *testing.T) {
 			},
 		},
 	}
-	// Lookup succeeds but FilledQty is 0 (should fall back to pos.Quantity).
+	// Lookup succeeds (useFillFee=true) but FilledQty=0 — userFills shows the
+	// SL OID never filled. Pre-#685 this booked as SL at trigger px; post-fix
+	// it falls through to hl_sync_external.
 	resolver := hlReconcileFillResolver(func(_ string, _ int64, _ float64) (HLFillLookup, bool) {
 		return HLFillLookup{Fee: 0.15, FilledQty: 0, Count: 1}, true
 	})
 	logger := newTestLogger(t)
+	startCash := ss.Cash
 	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger)
 
 	if len(ss.ClosedPositions) != 1 {
 		t.Fatalf("ClosedPositions = %d, want 1", len(ss.ClosedPositions))
 	}
 	cp := ss.ClosedPositions[0]
-	if cp.Quantity < virtualQty-1e-9 || cp.Quantity > virtualQty+1e-9 {
-		t.Errorf("ClosedPosition.Quantity = %g, want %g (fallback to virtual qty when FilledQty=0)", cp.Quantity, virtualQty)
+	if cp.CloseReason != "hl_sync_external" {
+		t.Errorf("CloseReason = %q, want hl_sync_external (SL not confirmed filled)", cp.CloseReason)
+	}
+	if cp.ClosePrice != 0 {
+		t.Errorf("ClosePrice = %g, want 0 (off-scheduler close, price unknown)", cp.ClosePrice)
+	}
+	if ss.Cash != startCash {
+		t.Errorf("cash = %g, want unchanged (%g) on zero-PnL fallback", ss.Cash, startCash)
 	}
 }
 
@@ -3263,7 +3275,19 @@ func TestReconcileManualPositionSLFired(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "", nil, false)
+	// #685: stub the HL userFills lookup to confirm the SL OID actually filled.
+	// Without confirmation, the new gate routes to hl_sync_external; production
+	// supplies an account address + real indexer, so tests do the same.
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(_, _ string, oid int64, _ float64) (HLFillLookup, bool) {
+		if oid == 77 {
+			return HLFillLookup{Fee: 0.05, FilledQty: 0.5, Px: 1800, Count: 1, OID: 77}, true
+		}
+		return HLFillLookup{}, false
+	}
+
+	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "0xtest", nil, false)
 
 	ss := state.Strategies["manual-eth"]
 	if _, ok := ss.Positions["ETH"]; ok {
@@ -3469,5 +3493,56 @@ func TestReconcilePosition_NoFillsFallsBackToZeroPnL(t *testing.T) {
 	}
 	if ss.Cash != startCash {
 		t.Errorf("cash = %g, want unchanged (%g) on zero-PnL fallback", ss.Cash, startCash)
+	}
+}
+
+// --- #685: TP-fired close with all TPOIDs zeroed must not mis-book as SL ---
+
+// TestReconcilePosition_AllTPOIDsZeroedSLNotFilled is the regression for #685:
+// when applyHyperliquidProtectionSync zeroes every pos.TPOIDs[i] across
+// successive cycles, hlAttemptCloseFromTPFills returns false (nothing left to
+// look up). Pre-fix, the legacy SL fallback then booked the close at the
+// (stale) SL trigger price even though userFills shows the SL never filled —
+// producing a fictitious loss on what was actually a TP-fired win. The new
+// SL-confirmed gate falls through to hl_sync_external when the SL OID has no
+// real fill.
+func TestReconcilePosition_AllTPOIDsZeroedSLNotFilled(t *testing.T) {
+	const slTriggerPx = 1800.0
+	ss := &StrategyState{
+		ID: "hl-eth", Cash: 100,
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol: "ETH", Quantity: 0.215, AvgCost: 2329.8, Side: "long",
+				Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-eth",
+				StopLossOID: 999, StopLossTriggerPx: slTriggerPx,
+				// Both tiers zeroed by prior protection-sync cycles.
+				TPOIDs: []int64{0, 0},
+			},
+		},
+	}
+	// Resolver: SL OID lookup returns no fill (it was auto-cancelled when the
+	// final TP flattened the position). TP OIDs are 0 so no lookup runs.
+	resolver := hlReconcileFillResolver(func(_ string, _ int64, _ float64) (HLFillLookup, bool) {
+		return HLFillLookup{}, false
+	})
+	logger := newTestLogger(t)
+	startCash := ss.Cash
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger)
+
+	if _, open := ss.Positions["ETH"]; open {
+		t.Fatal("ETH position should be removed after reconcile")
+	}
+	if len(ss.ClosedPositions) != 1 {
+		t.Fatalf("ClosedPositions = %d, want 1", len(ss.ClosedPositions))
+	}
+	cp := ss.ClosedPositions[0]
+	if cp.CloseReason != "hl_sync_external" {
+		t.Errorf("CloseReason = %q, want hl_sync_external (SL not confirmed filled)", cp.CloseReason)
+	}
+	if cp.ClosePrice == slTriggerPx {
+		t.Errorf("ClosePrice = %g matches stale SL trigger — #685 regression", cp.ClosePrice)
+	}
+	if ss.Cash != startCash {
+		t.Errorf("cash = %g, want unchanged (%g) — fictitious SL PnL must not credit/debit", ss.Cash, startCash)
 	}
 }

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -3546,3 +3546,50 @@ func TestReconcilePosition_AllTPOIDsZeroedSLNotFilled(t *testing.T) {
 		t.Errorf("cash = %g, want unchanged (%g) — fictitious SL PnL must not credit/debit", ss.Cash, startCash)
 	}
 }
+
+// TestAttemptCloseFromTPFills_CoinSizeSLFallbackDoesNotStarveTP guards the
+// review-followup tightening on the SL-filled gate inside
+// hlAttemptCloseFromTPFills: before the fix, a coin+size fallback hit on a TP
+// fill of the same size made slFilled=true (the resolver returned ok=true with
+// lookup.OID pointing at the TP, not the SL OID) and TP attribution was
+// skipped. With the OID-equality check, the SL gate rejects the non-SL match
+// and TP attribution proceeds normally.
+func TestAttemptCloseFromTPFills_CoinSizeSLFallbackDoesNotStarveTP(t *testing.T) {
+	const (
+		entryPx = 2000.0
+		tpPx    = 2100.0
+		qty     = 0.2
+	)
+	ss := &StrategyState{
+		ID: "hl-eth", Cash: 1000,
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol: "ETH", Quantity: qty, InitialQuantity: qty,
+				AvgCost: entryPx, Side: "long",
+				Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-eth",
+				StopLossOID: 42, StopLossTriggerPx: 1900,
+				TPOIDs: []int64{111},
+			},
+		},
+	}
+	// Resolver behavior: any (coin, oid, qty) returns a hit whose OID is the
+	// TP OID 111 — modeling the coin+size fallback hitting a TP fill record
+	// of the same size when probed for the SL OID.
+	resolver := hlReconcileFillResolver(func(_ string, _ int64, _ float64) (HLFillLookup, bool) {
+		return HLFillLookup{Fee: 0.04, FilledQty: qty, Px: tpPx, Count: 1, OID: 111}, true
+	})
+	logger := newTestLogger(t)
+
+	if !hlAttemptCloseFromTPFills(ss, "ETH", ss.Positions["ETH"], resolver, logger) {
+		t.Fatal("expected TP attribution to proceed (SL gate must reject non-OID-match)")
+	}
+	if _, open := ss.Positions["ETH"]; open {
+		t.Error("ETH position should be removed after TP attribution")
+	}
+	if len(ss.TradeHistory) != 1 || !ss.TradeHistory[0].IsClose {
+		t.Fatalf("expected one close trade, got %+v", ss.TradeHistory)
+	}
+	if math.Abs(ss.TradeHistory[0].Price-tpPx) > 1e-9 {
+		t.Errorf("Trade.Price = %g, want %g (TP fill price)", ss.TradeHistory[0].Price, tpPx)
+	}
+}

--- a/scheduler/hyperliquid_fills_test.go
+++ b/scheduler/hyperliquid_fills_test.go
@@ -205,8 +205,9 @@ func TestReconcileHyperliquidPositions_ExternalCloseUsesFillFee(t *testing.T) {
 	origLookup := lookupHyperliquidReconcileFillFee
 	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
 	lookupHyperliquidReconcileFillFee = func(addr, coin string, oid int64, qty float64) (HLFillLookup, bool) {
+		// #685: include FilledQty so the SL-confirmed gate accepts the fill.
 		if oid == 4242 && coin == "BTC" {
-			return HLFillLookup{Fee: 1.23, ClosedPnL: 0, Count: 1, OID: oid}, true
+			return HLFillLookup{Fee: 1.23, ClosedPnL: 0, FilledQty: 0.1, Px: 58000, Count: 1, OID: oid}, true
 		}
 		return HLFillLookup{}, false
 	}

--- a/scheduler/hyperliquid_sole_owner_tp_test.go
+++ b/scheduler/hyperliquid_sole_owner_tp_test.go
@@ -457,7 +457,13 @@ func TestSoleOwnerTP_FullCloseWithStaleClearedTier_DefersToSL(t *testing.T) {
 			},
 		},
 	}
-	resolver := hlReconcileFillResolver(func(string, int64, float64) (HLFillLookup, bool) {
+	// #685: SL OID lookup must confirm the SL actually filled for the legacy
+	// SL-owner branch to fire; otherwise the new gate routes to hl_sync_external.
+	// Model an SL fill at trigger px so the original "defer to SL" intent holds.
+	resolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
+		if oid == 42 {
+			return HLFillLookup{Fee: 0.05, FilledQty: residualQty, Px: slTriggerPx, Count: 1, OID: 42}, true
+		}
 		return HLFillLookup{}, false
 	})
 	var alerts []ProtectionFillAlert
@@ -735,9 +741,13 @@ func TestSoleOwnerTP_CycleOrderingRecovery_NotAppliedToFullClose(t *testing.T) {
 			},
 		},
 	}
-	resolver := hlReconcileFillResolver(func(string, int64, float64) (HLFillLookup, bool) {
-		// Stale fill record matching tier 1 OID is irrelevant — full close
-		// path must defer regardless.
+	// #685: provide an SL fill so the legacy SL-owner branch books at trigger
+	// price; a stale TP-tier fill record is still returned for other OIDs to
+	// verify the recovery path doesn't fire on a full close.
+	resolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
+		if oid == 42 {
+			return HLFillLookup{Fee: 0.05, FilledQty: residualQty, Px: slTriggerPx, Count: 1, OID: 42}, true
+		}
 		return HLFillLookup{Fee: 0.04, FilledQty: residualQty, Px: 2150, OID: 222, Count: 1}, true
 	})
 	var alerts []ProtectionFillAlert

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -544,7 +544,13 @@ func TestReconcileHyperliquidPositions_RestingStopLossFillBooksPnL(t *testing.T)
 	logger := silentStrategyLogger("hl-test-eth")
 	defer logger.Close()
 
-	changed := reconcileHyperliquidPositions(state, "ETH", nil, "", logger)
+	// #685: SL-confirmed resolver. Without a userFills hit on the SL OID, the
+	// gated fallback now routes to hl_sync_external; production paths always
+	// supply a resolver, so tests do the same.
+	resolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
+		return HLFillLookup{Fee: 0.05, FilledQty: 0.1, Px: 3104, Count: 1, OID: oid}, true
+	})
+	changed := reconcileHyperliquidPositionsWithResolver(state, "ETH", nil, resolver, logger)
 	if !changed {
 		t.Fatalf("expected reconcile to report a state change")
 	}
@@ -599,7 +605,11 @@ func TestReconcileHyperliquidPositions_RestingStopLossFillClosesShortWithBuy(t *
 	logger := silentStrategyLogger("hl-test-eth")
 	defer logger.Close()
 
-	changed := reconcileHyperliquidPositions(state, "ETH", nil, "", logger)
+	// #685: SL-confirmed resolver — see RestingStopLossFillBooksPnL.
+	resolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
+		return HLFillLookup{Fee: 0.05, FilledQty: 0.1, Px: 3296, Count: 1, OID: oid}, true
+	})
+	changed := reconcileHyperliquidPositionsWithResolver(state, "ETH", nil, resolver, logger)
 	if !changed {
 		t.Fatalf("expected reconcile to report a state change")
 	}


### PR DESCRIPTION
## Summary

- Off-chain reconcile path mis-attributed TP-fired closes (with all `TPOIDs` zeroed by prior protection-sync cycles) as `hl_sync_stop_loss` at the cancelled SL's trigger price, producing a fictitious loss.
- `hlAttemptCloseFromTPFills` (PR #675) only handles the case where ≥1 `TPOIDs[i]` is still positive; once `applyHyperliquidProtectionSync` zeros them all, the helper returns false and the legacy SL fallback fired without verifying SL actually filled.
- Gate the SL fallback at `scheduler/hyperliquid_balance.go:527` on a userFills-confirmed SL fill (`useFillFee && lookup.OID == StopLossOID && FilledQty > 0`). Otherwise fall through to `hl_sync_external` at zero PnL.
- Existing SL-booking tests updated to supply confirming resolvers/stubs (production always has an account address + real indexer). New regression `TestReconcilePosition_AllTPOIDsZeroedSLNotFilled` locks in the #685 scenario.

## Test plan

- [x] `go test ./...` — all green (24.6s)
- [x] `go build -ldflags ...` clean
- [x] `go vet ./...` clean
- [x] Regression test asserts `hl_sync_external` (not `hl_sync_stop_loss`) when `TPOIDs=[0,0]` and SL has no userFills entry

Closes #685

---
LLM: Claude Opus 4.7 | high