### PR TITLE
feat: auto-fetch ATR for manual-open via --fetch-atr

### DIFF
--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -210,20 +210,39 @@ func runManualOpen(args []string) int {
 		effectiveATRMult = *sc.StopLossATRMult
 	}
 
-	// When --atr is omitted, compute a leverage-aware fallback so SL and TPs still
-	// post. Fallback = 0.1*fillPrice/leverage → risks 10% of margin at 1× ATR.
+	// When --atr is omitted, fetch ATR from the same OHLCV/period strategy opens
+	// see via stampEntryATRIfOpened (#689). On fetch failure, fall back to the
+	// leverage-aware heuristic (0.1*fillPrice/leverage = ~10% margin risk at 1× ATR).
 	if !*recordOnly && entryATR == 0 {
 		needsATRProtection := effectiveATRMult > 0 || strategyUsesTieredTPATRClose(sc)
 		if needsATRProtection {
-			if fb, ok := computeFallbackATR(resolvedFillPrice, sc.Leverage); ok {
-				entryATR = fb
-				warnNotifier(notifier, fmt.Sprintf(
-					"[manual-open] %s %s: --atr omitted; using fallback ATR=%.6f (0.1*%.4f/%.2f lev) — pass --atr explicitly for accuracy",
-					strategyID, sc.Symbol, fb, resolvedFillPrice, sc.Leverage))
+			if fetched, fetchErr, ok := fetchManualEntryATR(sc); ok {
+				// Mirror stampEntryATRIfOpened's 50%-of-AvgCost plausibility guard.
+				if resolvedFillPrice > 0 && fetched > 0.5*resolvedFillPrice {
+					warnNotifier(notifier, fmt.Sprintf(
+						"[manual-open] %s %s: fetched ATR=%.6f exceeds 50%% of fill price %.4f — rejecting and trying fallback",
+						strategyID, sc.Symbol, fetched, resolvedFillPrice))
+				} else {
+					entryATR = fetched
+					fmt.Fprintf(os.Stderr, "[manual-open] %s %s: --atr omitted; auto-fetched ATR=%.6f (period=14, %s)\n",
+						strategyID, sc.Symbol, fetched, sc.Timeframe)
+				}
 			} else {
 				warnNotifier(notifier, fmt.Sprintf(
-					"[manual-open] %s %s: --atr omitted and leverage<=0 — cannot compute fallback; position is NAKED (no ATR-based SL/TP)",
-					strategyID, sc.Symbol))
+					"[manual-open] %s %s: ATR auto-fetch failed (%s); falling back to leverage heuristic — pass --atr for accuracy",
+					strategyID, sc.Symbol, fetchErr))
+			}
+			if entryATR == 0 {
+				if fb, ok := computeFallbackATR(resolvedFillPrice, sc.Leverage); ok {
+					entryATR = fb
+					warnNotifier(notifier, fmt.Sprintf(
+						"[manual-open] %s %s: using fallback ATR=%.6f (0.1*%.4f/%.2f lev) — pass --atr explicitly for accuracy",
+						strategyID, sc.Symbol, fb, resolvedFillPrice, sc.Leverage))
+				} else {
+					warnNotifier(notifier, fmt.Sprintf(
+						"[manual-open] %s %s: --atr omitted, fetch failed, and leverage<=0 — cannot compute fallback; position is NAKED (no ATR-based SL/TP)",
+						strategyID, sc.Symbol))
+				}
 			}
 		}
 	}

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -213,35 +213,33 @@ func runManualOpen(args []string) int {
 	// When --atr is omitted, fetch ATR from the same OHLCV/period strategy opens
 	// see via stampEntryATRIfOpened (#689). On fetch failure, fall back to the
 	// leverage-aware heuristic (0.1*fillPrice/leverage = ~10% margin risk at 1× ATR).
+	// Collapses fetch-failure + fallback into a single notifier message so one
+	// event = one Discord/Telegram alert.
 	if !*recordOnly && entryATR == 0 {
 		needsATRProtection := effectiveATRMult > 0 || strategyUsesTieredTPATRClose(sc)
 		if needsATRProtection {
-			if fetched, fetchErr, ok := fetchManualEntryATR(sc); ok {
+			fetched, fetchErr, fetchedOK := fetchManualEntryATR(sc)
+			if fetchedOK {
 				// Mirror stampEntryATRIfOpened's 50%-of-AvgCost plausibility guard.
 				if resolvedFillPrice > 0 && fetched > 0.5*resolvedFillPrice {
-					warnNotifier(notifier, fmt.Sprintf(
-						"[manual-open] %s %s: fetched ATR=%.6f exceeds 50%% of fill price %.4f — rejecting and trying fallback",
-						strategyID, sc.Symbol, fetched, resolvedFillPrice))
+					fetchErr = fmt.Sprintf("fetched ATR=%.6f exceeds 50%% of fill price %.4f", fetched, resolvedFillPrice)
+					fetchedOK = false
 				} else {
 					entryATR = fetched
 					fmt.Fprintf(os.Stderr, "[manual-open] %s %s: --atr omitted; auto-fetched ATR=%.6f (period=14, %s)\n",
 						strategyID, sc.Symbol, fetched, sc.Timeframe)
 				}
-			} else {
-				warnNotifier(notifier, fmt.Sprintf(
-					"[manual-open] %s %s: ATR auto-fetch failed (%s); falling back to leverage heuristic — pass --atr for accuracy",
-					strategyID, sc.Symbol, fetchErr))
 			}
-			if entryATR == 0 {
+			if !fetchedOK {
 				if fb, ok := computeFallbackATR(resolvedFillPrice, sc.Leverage); ok {
 					entryATR = fb
 					warnNotifier(notifier, fmt.Sprintf(
-						"[manual-open] %s %s: using fallback ATR=%.6f (0.1*%.4f/%.2f lev) — pass --atr explicitly for accuracy",
-						strategyID, sc.Symbol, fb, resolvedFillPrice, sc.Leverage))
+						"[manual-open] %s %s: ATR auto-fetch failed (%s); using fallback ATR=%.6f (0.1*%.4f/%.2f lev) — pass --atr explicitly for accuracy",
+						strategyID, sc.Symbol, fetchErr, fb, resolvedFillPrice, sc.Leverage))
 				} else {
 					warnNotifier(notifier, fmt.Sprintf(
-						"[manual-open] %s %s: --atr omitted, fetch failed, and leverage<=0 — cannot compute fallback; position is NAKED (no ATR-based SL/TP)",
-						strategyID, sc.Symbol))
+						"[manual-open] %s %s: ATR auto-fetch failed (%s) and leverage<=0 — cannot compute fallback; position is NAKED (no ATR-based SL/TP)",
+						strategyID, sc.Symbol, fetchErr))
 				}
 			}
 		}

--- a/scheduler/manual_atr.go
+++ b/scheduler/manual_atr.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// HyperliquidFetchATRResult is the JSON output from check_hyperliquid.py
+// --fetch-atr (#689). Used by manual-open to derive entry ATR from the same
+// OHLCV/period the strategy script would, without requiring --atr.
+type HyperliquidFetchATRResult struct {
+	ATR     float64 `json:"atr,omitempty"`
+	Candles int     `json:"candles,omitempty"`
+	Error   string  `json:"error,omitempty"`
+}
+
+// RunHyperliquidFetchATR invokes check_hyperliquid.py --fetch-atr to compute
+// latest ATR from HL OHLCV. Read-only (no on-chain side effects).
+func RunHyperliquidFetchATR(script, symbol, timeframe string, period int) (*HyperliquidFetchATRResult, string, error) {
+	if period <= 0 {
+		period = 14
+	}
+	args := []string{
+		"--fetch-atr",
+		fmt.Sprintf("--symbol=%s", symbol),
+		fmt.Sprintf("--timeframe=%s", timeframe),
+		fmt.Sprintf("--period=%d", period),
+	}
+	stdout, stderr, err := RunPythonScript(script, args)
+	return parseHyperliquidFetchATROutput(stdout, string(stderr), err)
+}
+
+func parseHyperliquidFetchATROutput(stdout []byte, stderrStr string, runErr error) (*HyperliquidFetchATRResult, string, error) {
+	if runErr != nil {
+		// fetch-atr emits structured JSON even on its own internal failures (it
+		// catches and reports), so a process-level error is real (e.g. Python
+		// missing). Surface it without trying to parse stdout.
+		return nil, stderrStr, fmt.Errorf("fetch-atr error: %w (stderr: %s)", runErr, stderrStr)
+	}
+	var result HyperliquidFetchATRResult
+	if err := json.Unmarshal(stdout, &result); err != nil {
+		return nil, stderrStr, fmt.Errorf("parse fetch-atr output: %w (stdout: %s)", err, string(stdout))
+	}
+	return &result, stderrStr, nil
+}
+
+// runHyperliquidFetchATRFn is a package var so manual.go callers and tests can
+// stub the subprocess without spawning Python.
+var runHyperliquidFetchATRFn = RunHyperliquidFetchATR
+
+// fetchManualEntryATR resolves the ATR for a manual-open by calling the
+// HL --fetch-atr path with the strategy's configured symbol+timeframe. Returns
+// (atr, ok). ok=false signals callers should fall back (typically to
+// computeFallbackATR). Period is fixed at 14 to match ensure_atr_indicator's
+// default — same baseline strategy opens see via stampEntryATRIfOpened.
+func fetchManualEntryATR(sc StrategyConfig) (float64, string, bool) {
+	if sc.Script == "" || sc.Symbol == "" || sc.Timeframe == "" {
+		return 0, "missing script/symbol/timeframe on strategy config", false
+	}
+	result, stderr, err := runHyperliquidFetchATRFn(sc.Script, sc.Symbol, sc.Timeframe, 14)
+	if err != nil {
+		msg := err.Error()
+		if stderr != "" {
+			msg = fmt.Sprintf("%s; stderr=%s", msg, stderr)
+		}
+		return 0, msg, false
+	}
+	if result == nil {
+		return 0, "nil fetch-atr result", false
+	}
+	if result.Error != "" {
+		return 0, result.Error, false
+	}
+	if !(result.ATR > 0) {
+		return 0, "fetch-atr returned non-positive ATR", false
+	}
+	return result.ATR, "", true
+}

--- a/scheduler/manual_atr.go
+++ b/scheduler/manual_atr.go
@@ -50,9 +50,12 @@ var runHyperliquidFetchATRFn = RunHyperliquidFetchATR
 
 // fetchManualEntryATR resolves the ATR for a manual-open by calling the
 // HL --fetch-atr path with the strategy's configured symbol+timeframe. Returns
-// (atr, ok). ok=false signals callers should fall back (typically to
+// (atr, errMsg, ok). ok=false signals callers should fall back (typically to
 // computeFallbackATR). Period is fixed at 14 to match ensure_atr_indicator's
 // default — same baseline strategy opens see via stampEntryATRIfOpened.
+// Strategies that override ATR period via params will see drift between fetched
+// and stamped ATR; if that becomes a problem, plumb a per-strategy ATR period
+// from sc.OpenStrategy.Params here.
 func fetchManualEntryATR(sc StrategyConfig) (float64, string, bool) {
 	if sc.Script == "" || sc.Symbol == "" || sc.Timeframe == "" {
 		return 0, "missing script/symbol/timeframe on strategy config", false
@@ -71,7 +74,7 @@ func fetchManualEntryATR(sc StrategyConfig) (float64, string, bool) {
 	if result.Error != "" {
 		return 0, result.Error, false
 	}
-	if !(result.ATR > 0) {
+	if result.ATR <= 0 {
 		return 0, "fetch-atr returned non-positive ATR", false
 	}
 	return result.ATR, "", true

--- a/scheduler/manual_atr_test.go
+++ b/scheduler/manual_atr_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseHyperliquidFetchATROutput_Success(t *testing.T) {
+	stdout := []byte(`{"atr": 12.34, "candles": 200}`)
+	result, _, err := parseHyperliquidFetchATROutput(stdout, "", nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if result == nil {
+		t.Fatal("nil result")
+	}
+	if result.ATR != 12.34 {
+		t.Errorf("ATR=%v want 12.34", result.ATR)
+	}
+	if result.Candles != 200 {
+		t.Errorf("Candles=%d want 200", result.Candles)
+	}
+	if result.Error != "" {
+		t.Errorf("Error=%q want empty", result.Error)
+	}
+}
+
+func TestParseHyperliquidFetchATROutput_StructuredError(t *testing.T) {
+	stdout := []byte(`{"error": "insufficient candles: got 5, need 15", "candles": 5}`)
+	result, _, err := parseHyperliquidFetchATROutput(stdout, "", nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if result == nil || result.Error == "" {
+		t.Fatal("expected structured error in result")
+	}
+}
+
+func TestParseHyperliquidFetchATROutput_RunError(t *testing.T) {
+	_, _, err := parseHyperliquidFetchATROutput(nil, "missing python", errors.New("exit 127"))
+	if err == nil {
+		t.Fatal("expected error on runErr")
+	}
+}
+
+func TestParseHyperliquidFetchATROutput_BadJSON(t *testing.T) {
+	_, _, err := parseHyperliquidFetchATROutput([]byte("not json"), "", nil)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestFetchManualEntryATR_MissingFields(t *testing.T) {
+	cases := []struct {
+		name string
+		sc   StrategyConfig
+	}{
+		{"no script", StrategyConfig{Symbol: "ETH", Timeframe: "1h"}},
+		{"no symbol", StrategyConfig{Script: "x.py", Timeframe: "1h"}},
+		{"no timeframe", StrategyConfig{Script: "x.py", Symbol: "ETH"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			atr, msg, ok := fetchManualEntryATR(c.sc)
+			if ok {
+				t.Errorf("ok=true want false")
+			}
+			if atr != 0 {
+				t.Errorf("atr=%v want 0", atr)
+			}
+			if msg == "" {
+				t.Errorf("expected non-empty error message")
+			}
+		})
+	}
+}
+
+func TestFetchManualEntryATR_StubSuccess(t *testing.T) {
+	prev := runHyperliquidFetchATRFn
+	defer func() { runHyperliquidFetchATRFn = prev }()
+	runHyperliquidFetchATRFn = func(script, symbol, timeframe string, period int) (*HyperliquidFetchATRResult, string, error) {
+		if script != "check.py" || symbol != "ETH" || timeframe != "1h" || period != 14 {
+			t.Errorf("unexpected args: script=%s symbol=%s tf=%s period=%d", script, symbol, timeframe, period)
+		}
+		return &HyperliquidFetchATRResult{ATR: 25.5, Candles: 200}, "", nil
+	}
+	sc := StrategyConfig{Script: "check.py", Symbol: "ETH", Timeframe: "1h"}
+	atr, msg, ok := fetchManualEntryATR(sc)
+	if !ok {
+		t.Fatalf("ok=false msg=%s", msg)
+	}
+	if atr != 25.5 {
+		t.Errorf("atr=%v want 25.5", atr)
+	}
+}
+
+func TestFetchManualEntryATR_StubScriptError(t *testing.T) {
+	prev := runHyperliquidFetchATRFn
+	defer func() { runHyperliquidFetchATRFn = prev }()
+	runHyperliquidFetchATRFn = func(script, symbol, timeframe string, period int) (*HyperliquidFetchATRResult, string, error) {
+		return &HyperliquidFetchATRResult{Error: "insufficient candles"}, "", nil
+	}
+	sc := StrategyConfig{Script: "check.py", Symbol: "ETH", Timeframe: "1h"}
+	_, msg, ok := fetchManualEntryATR(sc)
+	if ok {
+		t.Fatal("ok=true on script error")
+	}
+	if msg != "insufficient candles" {
+		t.Errorf("msg=%q want insufficient candles", msg)
+	}
+}
+
+func TestFetchManualEntryATR_StubNonPositiveATR(t *testing.T) {
+	prev := runHyperliquidFetchATRFn
+	defer func() { runHyperliquidFetchATRFn = prev }()
+	runHyperliquidFetchATRFn = func(script, symbol, timeframe string, period int) (*HyperliquidFetchATRResult, string, error) {
+		return &HyperliquidFetchATRResult{ATR: 0, Candles: 200}, "", nil
+	}
+	sc := StrategyConfig{Script: "check.py", Symbol: "ETH", Timeframe: "1h"}
+	_, _, ok := fetchManualEntryATR(sc)
+	if ok {
+		t.Fatal("ok=true on zero ATR")
+	}
+}
+
+func TestFetchManualEntryATR_StubRunError(t *testing.T) {
+	prev := runHyperliquidFetchATRFn
+	defer func() { runHyperliquidFetchATRFn = prev }()
+	runHyperliquidFetchATRFn = func(script, symbol, timeframe string, period int) (*HyperliquidFetchATRResult, string, error) {
+		return nil, "boom", errors.New("subprocess died")
+	}
+	sc := StrategyConfig{Script: "check.py", Symbol: "ETH", Timeframe: "1h"}
+	_, msg, ok := fetchManualEntryATR(sc)
+	if ok {
+		t.Fatal("ok=true on run error")
+	}
+	if msg == "" {
+		t.Error("expected non-empty error message")
+	}
+}

--- a/scheduler/manual_atr_test.go
+++ b/scheduler/manual_atr_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -40,6 +41,14 @@ func TestParseHyperliquidFetchATROutput_RunError(t *testing.T) {
 	_, _, err := parseHyperliquidFetchATROutput(nil, "missing python", errors.New("exit 127"))
 	if err == nil {
 		t.Fatal("expected error on runErr")
+	}
+	// fetchManualEntryATR weaves stderr into the message; the parser must
+	// surface stderr in its returned error so that contract is satisfiable.
+	if !strings.Contains(err.Error(), "missing python") {
+		t.Errorf("error should include stderr; got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "exit 127") {
+		t.Errorf("error should include underlying runErr; got %q", err.Error())
 	}
 }
 

--- a/scheduler/probe_cmd_test.go
+++ b/scheduler/probe_cmd_test.go
@@ -45,9 +45,20 @@ func TestRunProbeNoStrategies(t *testing.T) {
 func TestRunProbeHappyPath(t *testing.T) {
 	orig := probeOneCheckScriptFn
 	defer func() { probeOneCheckScriptFn = orig }()
-	var probed []string
-	probeOneCheckScriptFn = func(script string) error {
-		probed = append(probed, script)
+	type probeCall struct {
+		script string
+		mode   string // "signal" or "fetch-atr"
+	}
+	var probed []probeCall
+	probeOneCheckScriptFn = func(script string, argv []string) error {
+		mode := "signal"
+		for _, a := range argv {
+			if a == "--fetch-atr" {
+				mode = "fetch-atr"
+				break
+			}
+		}
+		probed = append(probed, probeCall{script, mode})
 		return nil
 	}
 
@@ -91,7 +102,23 @@ func TestRunProbeHappyPath(t *testing.T) {
 	if rc != 0 {
 		t.Fatalf("happy-path probe should return 0, got %d", rc)
 	}
-	if len(probed) != 2 {
-		t.Fatalf("expected 2 unique scripts probed, got %d: %v", len(probed), probed)
+	// Expect 3 invocations: HL signal-check, HL --fetch-atr (#689), spot signal-check.
+	if len(probed) != 3 {
+		t.Fatalf("expected 3 probe invocations, got %d: %v", len(probed), probed)
+	}
+	var hlSignal, hlFetchATR, spotSignal int
+	for _, p := range probed {
+		switch {
+		case p.script == "shared_scripts/check_hyperliquid.py" && p.mode == "signal":
+			hlSignal++
+		case p.script == "shared_scripts/check_hyperliquid.py" && p.mode == "fetch-atr":
+			hlFetchATR++
+		case p.script == "shared_scripts/check_strategy.py" && p.mode == "signal":
+			spotSignal++
+		}
+	}
+	if hlSignal != 1 || hlFetchATR != 1 || spotSignal != 1 {
+		t.Fatalf("expected 1 of each (hl-signal, hl-fetch-atr, spot-signal); got %d/%d/%d (probed=%v)",
+			hlSignal, hlFetchATR, spotSignal, probed)
 	}
 }

--- a/scheduler/version_probe.go
+++ b/scheduler/version_probe.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
@@ -31,6 +32,13 @@ var probeArgv = []string{
 	"--probe-only",
 }
 
+// fetchATRProbeArgv probes check_hyperliquid.py's --fetch-atr mode (#689) so a
+// stale Python missing run_fetch_atr fails startup loudly instead of degrading
+// silently to computeFallbackATR on every manual-open.
+var fetchATRProbeArgv = []string{
+	"--fetch-atr", "--symbol=BTC", "--timeframe=1h", "--period=14", "--probe-only",
+}
+
 const probeTimeout = 15 * time.Second
 
 // probeCheckScripts invokes each unique check script configured in cfg
@@ -43,14 +51,23 @@ const probeTimeout = 15 * time.Second
 // where unknown flags cause the same exit-2 the May 7 outage exhibited.
 // probeOneCheckScriptFn is the per-script probe invoker — package var so
 // tests can stub it without standing up a real .venv (Go CI doesn't have
-// one — see CLAUDE.md → Testing).
+// one — see CLAUDE.md → Testing). The argv parameter lets a single script
+// be probed against multiple argv shapes (e.g. signal-check + --fetch-atr).
 var probeOneCheckScriptFn = probeOneCheckScript
 
 func probeCheckScripts(cfg *Config) error {
 	scripts := uniqueCheckScripts(cfg)
 	for _, script := range scripts {
-		if err := probeOneCheckScriptFn(script); err != nil {
+		if err := probeOneCheckScriptFn(script, probeArgv); err != nil {
 			return err
+		}
+		// HL exposes --fetch-atr (#689) for manual-open ATR auto-fetch; probe
+		// it so an old Python without run_fetch_atr fails the probe rather
+		// than silently degrading every manual-open to computeFallbackATR.
+		if filepath.Base(script) == "check_hyperliquid.py" {
+			if err := probeOneCheckScriptFn(script, fetchATRProbeArgv); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -72,11 +89,11 @@ func uniqueCheckScripts(cfg *Config) []string {
 	return out
 }
 
-func probeOneCheckScript(script string) error {
+func probeOneCheckScript(script string, argv []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
 	defer cancel()
 
-	cmdArgs := append([]string{script}, probeArgv...)
+	cmdArgs := append([]string{script}, argv...)
 	cmd := exec.CommandContext(ctx, ".venv/bin/python3", cmdArgs...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 

--- a/scheduler/version_probe_test.go
+++ b/scheduler/version_probe_test.go
@@ -127,6 +127,43 @@ func TestProbeIgnoresEmptyScripts(t *testing.T) {
 	}
 }
 
+// TestProbeRunsFetchATRForHL verifies the second --fetch-atr probe (#689) is
+// dispatched only for check_hyperliquid.py. Stubs probeOneCheckScriptFn to
+// record argv shapes per script without requiring a real .venv.
+func TestProbeRunsFetchATRForHL(t *testing.T) {
+	orig := probeOneCheckScriptFn
+	defer func() { probeOneCheckScriptFn = orig }()
+	calls := map[string][]string{}
+	probeOneCheckScriptFn = func(script string, argv []string) error {
+		mode := "signal"
+		for _, a := range argv {
+			if a == "--fetch-atr" {
+				mode = "fetch-atr"
+				break
+			}
+		}
+		calls[script] = append(calls[script], mode)
+		return nil
+	}
+	cfg := &Config{
+		Strategies: []StrategyConfig{
+			{Script: "shared_scripts/check_hyperliquid.py"},
+			{Script: "shared_scripts/check_strategy.py"},
+		},
+	}
+	if err := probeCheckScripts(cfg); err != nil {
+		t.Fatalf("probe failed: %v", err)
+	}
+	hl := calls["shared_scripts/check_hyperliquid.py"]
+	if len(hl) != 2 || hl[0] != "signal" || hl[1] != "fetch-atr" {
+		t.Errorf("HL should be probed signal+fetch-atr, got %v", hl)
+	}
+	spot := calls["shared_scripts/check_strategy.py"]
+	if len(spot) != 1 || spot[0] != "signal" {
+		t.Errorf("non-HL should be probed signal-only, got %v", spot)
+	}
+}
+
 func TestFormatProbeFailureFallsBackThroughChannels(t *testing.T) {
 	// stderr present -> uses stderr
 	err := formatProbeFailure("check.py", os.ErrInvalid, " stderr-msg\n", "stdout-msg")

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -19,6 +19,9 @@ Execution mode (live only, called by Go as phase 2):
 Trailing stop update mode (live only):
     check_hyperliquid.py --update-stop-loss --symbol=BTC --side=long|short --size=0.01 \
         --trigger-px=62000 --cancel-stop-loss-oid=OID [--mode=live]
+
+Fetch ATR mode (read-only, used by manual-open when --atr is omitted):
+    check_hyperliquid.py --fetch-atr --symbol=BTC --timeframe=1h [--period=14]
 """
 
 import sys
@@ -1001,6 +1004,7 @@ def run_fetch_atr(symbol: str, timeframe: str, period: int):
             return
         print(json.dumps({"atr": atr, "candles": len(candles)}, cls=SafeEncoder))
     except Exception as e:
+        traceback.print_exc(file=sys.stderr)
         print(json.dumps({"error": f"{type(e).__name__}: {e}"}, cls=SafeEncoder))
 
 

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -972,7 +972,53 @@ def run_update_stop_loss(symbol, side, size, trigger_px, mode, cancel_oid=0):
         sys.exit(1)
 
 
+def run_fetch_atr(symbol: str, timeframe: str, period: int):
+    """Fetch OHLCV from Hyperliquid and emit latest ATR as JSON.
+
+    Used by manual-open when --atr is omitted so manual positions get the
+    same ATR baseline strategy opens compute via ensure_atr_indicator (#689).
+    Emits {"atr": <float>, "candles": <int>} on success; {"error": "..."} on
+    failure (still exits 0 so Go can parse the JSON and decide whether to
+    fall back to computeFallbackATR).
+    """
+    try:
+        from adapter import HyperliquidExchangeAdapter
+        adapter = HyperliquidExchangeAdapter()
+        candles = adapter.get_ohlcv(symbol, interval=timeframe, limit=200)
+        if not candles or len(candles) < period + 1:
+            print(json.dumps({
+                "error": f"insufficient candles: got {len(candles) if candles else 0}, need {period + 1}",
+                "candles": len(candles) if candles else 0,
+            }, cls=SafeEncoder))
+            return
+        df = _make_dataframe(candles)
+        atr = latest_atr(df, period=period)
+        if not (atr > 0):
+            print(json.dumps({
+                "error": "latest ATR is not positive",
+                "candles": len(candles),
+            }, cls=SafeEncoder))
+            return
+        print(json.dumps({"atr": atr, "candles": len(candles)}, cls=SafeEncoder))
+    except Exception as e:
+        print(json.dumps({"error": f"{type(e).__name__}: {e}"}, cls=SafeEncoder))
+
+
 def main():
+    if "--fetch-atr" in sys.argv:
+        import argparse
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--fetch-atr", action="store_true")
+        parser.add_argument("--symbol", required=True)
+        parser.add_argument("--timeframe", required=True)
+        parser.add_argument("--period", type=int, default=14)
+        parser.add_argument("--probe-only", action="store_true",
+            help="Startup compatibility probe: validate argv shape and exit 0.")
+        args = parser.parse_args()
+        if args.probe_only:
+            sys.exit(0)
+        run_fetch_atr(args.symbol, args.timeframe, args.period)
+        return
     if "--sync-protection" in sys.argv:
         import argparse
         parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Summary
- Add `--fetch-atr` mode to `check_hyperliquid.py` that fetches OHLCV via the HL adapter and emits the latest ATR(14) as JSON — the same baseline strategy opens see via `ensure_atr_indicator` + `stampEntryATRIfOpened`.
- `manual-open` now calls this when `--atr` is omitted, so manual positions get correct SL/TP placement instead of the leverage heuristic. Uses the strategy's configured `Symbol`/`Timeframe`.
- Preserve `computeFallbackATR` (0.1*fillPrice/leverage) as a last-resort when the fetch fails, behind a loud notifier warning.
- Mirror `stampEntryATRIfOpened`'s 50%-of-fillPrice plausibility guard on the fetched ATR before stamping.

Closes #689

## Test plan
- [x] `go test ./...` (full scheduler suite)
- [x] `python3 -m py_compile shared_scripts/check_hyperliquid.py`
- [x] Live smoke: `check_hyperliquid.py --fetch-atr --symbol=ETH --timeframe=1h` → `{"atr": 14.21, "candles": 201}`
- [x] Probe: `check_hyperliquid.py --fetch-atr --symbol=ETH --timeframe=1h --probe-only` → exit 0
- [x] `go build` with `-ldflags Version`

---
LLM: Claude Opus 4.7 | high