### PR TITLE
SKILL.md: add critical rule to always use scripts/update.sh

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -19,6 +19,7 @@ Quick flow for a new server: tell OpenClaw `install https://github.com/richkuo/g
 - Never store secrets in config files — put Discord/exchange credentials in systemd environment variables.
 - Prefer `./go-trader init` for humans, `./go-trader init --json ... --output scheduler/config.json` for agents/scripts.
 - TradingView export: ask which strategy IDs (or all) before running.
+- **CRITICAL: ALWAYS use `scripts/update.sh` to update go-trader. NEVER manually run git pull + go build.** `update.sh` is the single source of truth for `git pull --ff-only` + `uv sync` + `go build` atomically. Manual steps cause asymmetric deploys (#642).
 
 ---
 


### PR DESCRIPTION
Adds a bolded core rule in SKILL.md requiring [update] phase: preflight
[update] previous binary version: v0.57.0
[update] phase: preflight done (0s)
[update] phase: pull for all go-trader updates instead of manual git pull + go build.\n\nManual steps cause asymmetric deploys (#642). This makes the rule unmissable at the top of the skill file.\n\nReference only: LLM model used: z.ai GLM-5.1