### PR TITLE
fix: mark HL closedPnl as gross-of-fee + lock in fee-net booking (#698)

### DIFF
--- a/scheduler/backfill_hl_fees.go
+++ b/scheduler/backfill_hl_fees.go
@@ -18,10 +18,15 @@ import (
 // HLFillSummary is a per-OID aggregate from fetch_hl_user_fills.py.
 // A single market order can fragment into multiple partial fills sharing the
 // same OID; the script sums fee + closedPnl across legs before emitting.
+//
+// ClosedPnLGross is Hyperliquid's `closedPnl` summed across legs. It is
+// gross of fees — do not use it for realized-PnL bookkeeping (#698). The
+// backfill recomputes realized PnL locally from the stored pre-fee PnL
+// and the real exchange fee (see planTradeRewrites in this file).
 type HLFillSummary struct {
-	Fee       float64 `json:"fee"`
-	ClosedPnL float64 `json:"closed_pnl"`
-	Count     int     `json:"count"`
+	Fee            float64 `json:"fee"`
+	ClosedPnLGross float64 `json:"closed_pnl"`
+	Count          int     `json:"count"`
 }
 
 // HLUserFillsResult is the stdout envelope from fetch_hl_user_fills.py.

--- a/scheduler/backfill_hl_fees_test.go
+++ b/scheduler/backfill_hl_fees_test.go
@@ -56,8 +56,8 @@ func TestPlanBackfillRewritesFeeAndPnLOnCloseLeg(t *testing.T) {
 	realOpenFee := 0.40  // higher than modeled
 	realCloseFee := 0.30 // lower than modeled
 	fillMap := map[string]HLFillSummary{
-		"111": {Fee: realOpenFee, ClosedPnL: 0, Count: 1},
-		"222": {Fee: realCloseFee, ClosedPnL: 9.7, Count: 1},
+		"111": {Fee: realOpenFee, ClosedPnLGross: 0, Count: 1},
+		"222": {Fee: realCloseFee, ClosedPnLGross: 9.7, Count: 1},
 	}
 
 	plan := planBackfillForStrategy("hl-eth", trades, fillMap, 1000.0, 1000.0)

--- a/scheduler/hyperliquid_fills.go
+++ b/scheduler/hyperliquid_fills.go
@@ -23,13 +23,22 @@ import (
 // zero size. Reconciler close paths prefer Px over the configured TP/mark
 // price when available so the booked Trade row reflects what actually
 // happened on-chain (#670, #673).
+//
+// ClosedPnLGross is Hyperliquid's reported `closedPnl` summed across the
+// matched fills. It is **gross of fees** — the exchange UI shows net PnL
+// after subtracting the trading fee. DO NOT plug this value into
+// Trade.RealizedPnL or any cash-bookkeeping path; doing so overstates
+// realized PnL by exactly the fee amount (#698). Realized PnL is always
+// computed locally from AvgCost/FillPx/Qty minus the real Fee (see
+// bookPerpsPartialCloseWithFillFee in portfolio.go). This field exists
+// for logging and operator-side reconciliation only.
 type HLFillLookup struct {
-	Fee       float64
-	ClosedPnL float64
-	FilledQty float64 // sum of sz across matched fill records; 0 when lookup missed
-	Px        float64 // size-weighted avg fill price across matched records; 0 when missed
-	Count     int
-	OID       int64
+	Fee            float64
+	ClosedPnLGross float64
+	FilledQty      float64 // sum of sz across matched fill records; 0 when lookup missed
+	Px             float64 // size-weighted avg fill price across matched records; 0 when missed
+	Count          int
+	OID            int64
 }
 
 // hlFillRecord is the trimmed userFills payload we care about. The HL indexer
@@ -97,6 +106,9 @@ var (
 // summing fee + closedPnl across partial fills. Retries with backoff to
 // absorb HL indexer lag. Returns ok=false when no fill matches within the
 // retry budget — callers fall back to the modeled fee.
+//
+// Note: aggregated closedPnl is stored in HLFillLookup.ClosedPnLGross — it
+// is gross of fees and must not be used for realized-PnL bookkeeping (#698).
 func lookupHyperliquidFillByOID(accountAddress string, oid int64, startTimeMs int64) (HLFillLookup, bool) {
 	if oid <= 0 || accountAddress == "" {
 		return HLFillLookup{}, false
@@ -112,7 +124,7 @@ func lookupHyperliquidFillByOID(accountAddress string, oid int64, startTimeMs in
 				}
 				sz := parseHLFloat(f.Sz)
 				out.Fee += parseHLFloat(f.Fee)
-				out.ClosedPnL += parseHLFloat(f.ClosedPnl)
+				out.ClosedPnLGross += parseHLFloat(f.ClosedPnl)
 				out.FilledQty += sz
 				pxNumerator += sz * parseHLFloat(f.Px)
 				out.Count++
@@ -141,6 +153,9 @@ func lookupHyperliquidFillByOID(accountAddress string, oid int64, startTimeMs in
 // anchors the result, and fee/closedPnl are aggregated across only that OID
 // (one logical close group, including any partial fills). When the anchor
 // has no OID, only that single record is returned.
+//
+// Note: aggregated closedPnl is stored in HLFillLookup.ClosedPnLGross — it
+// is gross of fees and must not be used for realized-PnL bookkeeping (#698).
 func lookupHyperliquidFillByCoinSize(accountAddress, coin string, absSize, tolerance float64, startTimeMs int64) (HLFillLookup, bool) {
 	if accountAddress == "" || coin == "" || absSize <= 0 {
 		return HLFillLookup{}, false
@@ -170,11 +185,11 @@ func lookupHyperliquidFillByCoinSize(accountAddress, coin string, absSize, toler
 				anchorOID, oidErr := anchor.OID.Int64()
 				if oidErr != nil || anchorOID <= 0 {
 					return HLFillLookup{
-						Fee:       parseHLFloat(anchor.Fee),
-						ClosedPnL: parseHLFloat(anchor.ClosedPnl),
-						FilledQty: parseHLFloat(anchor.Sz),
-						Px:        parseHLFloat(anchor.Px),
-						Count:     1,
+						Fee:            parseHLFloat(anchor.Fee),
+						ClosedPnLGross: parseHLFloat(anchor.ClosedPnl),
+						FilledQty:      parseHLFloat(anchor.Sz),
+						Px:             parseHLFloat(anchor.Px),
+						Count:          1,
 					}, true
 				}
 				out := HLFillLookup{OID: anchorOID}
@@ -185,7 +200,7 @@ func lookupHyperliquidFillByCoinSize(accountAddress, coin string, absSize, toler
 					}
 					sz := parseHLFloat(f.Sz)
 					out.Fee += parseHLFloat(f.Fee)
-					out.ClosedPnL += parseHLFloat(f.ClosedPnl)
+					out.ClosedPnLGross += parseHLFloat(f.ClosedPnl)
 					out.FilledQty += sz
 					pxNumerator += sz * parseHLFloat(f.Px)
 					out.Count++
@@ -271,7 +286,7 @@ func logHyperliquidReconcileFillLookup(logger *StrategyLogger, coin string, oid 
 		return
 	}
 	if useFillFee && lookup.Count > 0 {
-		logger.Info("hl-sync: %s userFills hit oid=%d qty=%.6f → fee=$%.4f closedPnl=$%.2f (%d fills)", coin, oid, expectedQty, lookup.Fee, lookup.ClosedPnL, lookup.Count)
+		logger.Info("hl-sync: %s userFills hit oid=%d qty=%.6f → fee=$%.4f closedPnl_gross=$%.2f (%d fills)", coin, oid, expectedQty, lookup.Fee, lookup.ClosedPnLGross, lookup.Count)
 		return
 	}
 	if oid > 0 || expectedQty > 0 {

--- a/scheduler/hyperliquid_fills_test.go
+++ b/scheduler/hyperliquid_fills_test.go
@@ -54,8 +54,8 @@ func TestLookupHyperliquidFillByOID_AggregatesPartialFills(t *testing.T) {
 	if got.Fee < 0.799 || got.Fee > 0.801 {
 		t.Errorf("Fee = %g, want ~0.80", got.Fee)
 	}
-	if got.ClosedPnL < 149.99 || got.ClosedPnL > 150.01 {
-		t.Errorf("ClosedPnL = %g, want ~150.00", got.ClosedPnL)
+	if got.ClosedPnLGross < 149.99 || got.ClosedPnLGross > 150.01 {
+		t.Errorf("ClosedPnLGross = %g, want ~150.00", got.ClosedPnLGross)
 	}
 }
 
@@ -132,8 +132,8 @@ func TestLookupHyperliquidFillByCoinSize_PicksNewestGroupNotSumOfWindow(t *testi
 	if got.Fee < 0.499 || got.Fee > 0.501 {
 		t.Errorf("Fee = %g, want ~0.50 (newest only, not 0.40+0.50)", got.Fee)
 	}
-	if got.ClosedPnL < 89.99 || got.ClosedPnL > 90.01 {
-		t.Errorf("ClosedPnL = %g, want ~90.00 (newest only)", got.ClosedPnL)
+	if got.ClosedPnLGross < 89.99 || got.ClosedPnLGross > 90.01 {
+		t.Errorf("ClosedPnLGross = %g, want ~90.00 (newest only)", got.ClosedPnLGross)
 	}
 }
 
@@ -164,8 +164,8 @@ func TestLookupHyperliquidFillByCoinSize_AggregatesPartialFillsByAnchorOID(t *te
 	if got.Fee < 0.499 || got.Fee > 0.501 {
 		t.Errorf("Fee = %g, want ~0.50 (0.20+0.30, not including OID 999)", got.Fee)
 	}
-	if got.ClosedPnL < 69.99 || got.ClosedPnL > 70.01 {
-		t.Errorf("ClosedPnL = %g, want ~70.00 (30+40, not including OID 999)", got.ClosedPnL)
+	if got.ClosedPnLGross < 69.99 || got.ClosedPnLGross > 70.01 {
+		t.Errorf("ClosedPnLGross = %g, want ~70.00 (30+40, not including OID 999)", got.ClosedPnLGross)
 	}
 }
 
@@ -207,7 +207,7 @@ func TestReconcileHyperliquidPositions_ExternalCloseUsesFillFee(t *testing.T) {
 	lookupHyperliquidReconcileFillFee = func(addr, coin string, oid int64, qty float64) (HLFillLookup, bool) {
 		// #685: include FilledQty so the SL-confirmed gate accepts the fill.
 		if oid == 4242 && coin == "BTC" {
-			return HLFillLookup{Fee: 1.23, ClosedPnL: 0, FilledQty: 0.1, Px: 58000, Count: 1, OID: oid}, true
+			return HLFillLookup{Fee: 1.23, ClosedPnLGross: 0, FilledQty: 0.1, Px: 58000, Count: 1, OID: oid}, true
 		}
 		return HLFillLookup{}, false
 	}

--- a/scheduler/portfolio_closedpnl_gross_test.go
+++ b/scheduler/portfolio_closedpnl_gross_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+// TestBookPerpsPartialCloseWithFillFee_NetOfFee locks in the contract that
+// realized PnL is computed locally as `(closePx - avgCost) * qty - fillFee`
+// (long) — i.e. NET of the real exchange fee. Hyperliquid's `userFills.closedPnl`
+// is gross of fees (#698); any future refactor that wires HLFillLookup.ClosedPnLGross
+// into Trade.RealizedPnL would overstate PnL by exactly the fee and fail this test.
+//
+// Numbers below are the live manual-eth example from #698:
+//
+//	entry: 0.428 ETH @ 2331.5
+//	TP1:   0.214 ETH @ 2354.8, fee 0.072565 → net PnL 4.913635 (HL closedPnl was 4.9862)
+//	TP2:   0.214 ETH @ 2366.5, fee 0.072926 → net PnL 7.417074 (HL closedPnl was 7.49)
+func TestBookPerpsPartialCloseWithFillFee_NetOfFee(t *testing.T) {
+	const (
+		entryQty  = 0.428
+		entryPx   = 2331.5
+		tp1Qty    = 0.214
+		tp1Px     = 2354.8
+		tp1Fee    = 0.072565
+		tp1NetPnL = 4.913635 // (2354.8 - 2331.5) * 0.214 - 0.072565
+		tp1Gross  = 4.9862   // what HL userFills.closedPnl reports
+		tp2Qty    = 0.214
+		tp2Px     = 2366.5
+		tp2Fee    = 0.072926
+		tp2NetPnL = 7.417074 // (2366.5 - 2331.5) * 0.214 - 0.072926
+		tp2Gross  = 7.49     // what HL userFills.closedPnl reports
+	)
+
+	s := &StrategyState{
+		ID: "hl-manual-eth", Platform: "hyperliquid", Type: "manual",
+		Cash: 1000,
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol:          "ETH",
+				Quantity:        entryQty,
+				InitialQuantity: entryQty,
+				AvgCost:         entryPx,
+				Side:            "long",
+			},
+		},
+	}
+
+	if !bookPerpsPartialCloseWithFillFee(s, "ETH", tp1Qty, tp1Px, tp1Fee, true, "tp1-oid", "tp_partial_test", "TP1", "TP1", nil) {
+		t.Fatal("TP1 booking returned false")
+	}
+	tp1Trade := s.TradeHistory[len(s.TradeHistory)-1]
+	if math.Abs(tp1Trade.RealizedPnL-tp1NetPnL) > 1e-6 {
+		t.Errorf("TP1 RealizedPnL = %.6f, want %.6f (local fee-net)", tp1Trade.RealizedPnL, tp1NetPnL)
+	}
+	if math.Abs(tp1Trade.RealizedPnL-tp1Gross) < 0.01 {
+		t.Errorf("TP1 RealizedPnL = %.6f matches HL closedPnl gross %.4f — booking must use fee-net, not gross (#698)", tp1Trade.RealizedPnL, tp1Gross)
+	}
+	if math.Abs(tp1Trade.ExchangeFee-tp1Fee) > 1e-9 {
+		t.Errorf("TP1 ExchangeFee = %.6f, want %.6f", tp1Trade.ExchangeFee, tp1Fee)
+	}
+
+	if !bookPerpsPartialCloseWithFillFee(s, "ETH", tp2Qty, tp2Px, tp2Fee, true, "tp2-oid", "tp_partial_test", "TP2", "TP2", nil) {
+		t.Fatal("TP2 booking returned false")
+	}
+	tp2Trade := s.TradeHistory[len(s.TradeHistory)-1]
+	if math.Abs(tp2Trade.RealizedPnL-tp2NetPnL) > 1e-6 {
+		t.Errorf("TP2 RealizedPnL = %.6f, want %.6f (local fee-net)", tp2Trade.RealizedPnL, tp2NetPnL)
+	}
+	if math.Abs(tp2Trade.RealizedPnL-tp2Gross) < 0.01 {
+		t.Errorf("TP2 RealizedPnL = %.6f matches HL closedPnl gross %.4f — booking must use fee-net, not gross (#698)", tp2Trade.RealizedPnL, tp2Gross)
+	}
+
+	// After both partial closes the position should be flat and recorded as closed.
+	if _, ok := s.Positions["ETH"]; ok {
+		t.Errorf("position still open after both TPs filled; want flat")
+	}
+	if len(s.ClosedPositions) != 1 {
+		t.Errorf("ClosedPositions = %d, want 1", len(s.ClosedPositions))
+	}
+
+	// Cash should be entry + net PnL (entry cash unchanged at the open here since
+	// we constructed the StrategyState mid-trade). Verify the sum credited to cash
+	// equals the local fee-net total, not the gross total.
+	gotCashDelta := s.Cash - 1000
+	wantCashDelta := tp1NetPnL + tp2NetPnL
+	if math.Abs(gotCashDelta-wantCashDelta) > 1e-6 {
+		t.Errorf("cash delta = %.6f, want %.6f (sum of fee-net PnL)", gotCashDelta, wantCashDelta)
+	}
+	if math.Abs(gotCashDelta-(tp1Gross+tp2Gross)) < 0.01 {
+		t.Errorf("cash delta = %.6f matches sum of gross closedPnl %.4f — must be fee-net (#698)", gotCashDelta, tp1Gross+tp2Gross)
+	}
+}
+
+// TestHLFillLookup_ClosedPnLGrossNotUsedForBooking verifies the static contract
+// that HLFillLookup.ClosedPnLGross is never read by bookPerpsPartialCloseWithFillFee.
+// We pass a HLFillLookup-shaped payload with a clearly-wrong gross PnL and
+// confirm the booked PnL ignores it entirely.
+func TestHLFillLookup_ClosedPnLGrossNotUsedForBooking(t *testing.T) {
+	s := &StrategyState{
+		ID: "hl-test", Platform: "hyperliquid", Type: "perps",
+		Cash: 1000,
+		Positions: map[string]*Position{
+			"BTC": {
+				Symbol:          "BTC",
+				Quantity:        0.1,
+				InitialQuantity: 0.1,
+				AvgCost:         60000,
+				Side:            "long",
+			},
+		},
+	}
+
+	// Simulate a reconciler hand-off: lookup reports a wildly inflated gross PnL.
+	lookup := HLFillLookup{
+		Fee:            5.0,
+		ClosedPnLGross: 9999.0, // intentionally absurd; must NOT leak into Trade.RealizedPnL
+		FilledQty:      0.05,
+		Px:             61000,
+		Count:          1,
+		OID:            123,
+	}
+	if !bookPerpsPartialCloseWithFillFee(s, "BTC", lookup.FilledQty, lookup.Px, lookup.Fee, true, "123", "tp_partial_test", "TP", "TP", nil) {
+		t.Fatal("booking returned false")
+	}
+
+	wantNet := (lookup.Px-60000)*lookup.FilledQty - lookup.Fee // 1000*0.05 - 5 = 45
+	got := s.TradeHistory[len(s.TradeHistory)-1].RealizedPnL
+	if math.Abs(got-wantNet) > 1e-9 {
+		t.Errorf("RealizedPnL = %.6f, want %.6f (local fee-net)", got, wantNet)
+	}
+	if math.Abs(got-lookup.ClosedPnLGross) < 1.0 {
+		t.Errorf("RealizedPnL = %.6f leaked from HLFillLookup.ClosedPnLGross %.2f (#698)", got, lookup.ClosedPnLGross)
+	}
+}


### PR DESCRIPTION
## Summary

- Hyperliquid `userFills.closedPnl` is **gross of fees** while the exchange UI shows net PnL. No production code currently mis-uses it — `bookPerpsPartialCloseWithFillFee` (`scheduler/portfolio.go:219`) computes realized PnL locally from `(closePx - avgCost) * qty - fillFee`, and `backfill_hl_fees.go:225` recomputes from the stored pre-fee PnL. This PR is a forward-looking guardrail so any future refactor that wires the gross value into `Trade.RealizedPnL` fails loudly.
- Rename `HLFillLookup.ClosedPnL` and `HLFillSummary.ClosedPnL` → `ClosedPnLGross` with doc comments warning against use for PnL bookkeeping. Reconciler log line now prints `closedPnl_gross=...` so operators see the qualifier.
- Add `scheduler/portfolio_closedpnl_gross_test.go` regression test using the live manual-eth example from #698: `0.428 ETH @ 2331.5` entry, TP1 `0.214 @ 2354.8` fee `0.072565`, TP2 `0.214 @ 2366.5` fee `0.072926` — asserts booked `RealizedPnL` is the fee-net value (`4.913635` / `7.417074`), not the gross `closedPnl` (`4.9862` / `7.49`).

## Test plan

- [x] `go build -ldflags "-X main.Version=$(git describe --tags --always --dirty=-mod)" .` succeeds
- [x] `go test ./...` from `scheduler/` — full suite passes (24.7s)
- [x] New tests pass: `TestBookPerpsPartialCloseWithFillFee_NetOfFee`, `TestHLFillLookup_ClosedPnLGrossNotUsedForBooking`
- [ ] Operator-side: confirm Hyperliquid `userFills.closedPnl` is gross via one live-fill probe before treating the gross assumption as authoritative anywhere beyond docs

Closes #698

---
LLM: Claude Opus 4.7 | high