### PR TITLE
fix(update): refuse early when scheduler/config.json missing (#702)

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -76,12 +76,30 @@ fail() {
 # Phase 1: pre-flight — every check that should abort BEFORE any mutation.
 begin_phase preflight
 
+if ! command -v uv >/dev/null 2>&1; then
+    fail "uv not on PATH — install uv first (see CLAUDE.md → Setup)"
+fi
+
+go_bin=""
+if command -v go >/dev/null 2>&1; then
+    go_bin=$(command -v go)
+elif [[ -x /opt/homebrew/bin/go ]]; then
+    go_bin=/opt/homebrew/bin/go
+else
+    fail "go not on PATH and /opt/homebrew/bin/go missing"
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
 # scheduler/config.json is gitignored, so a bare source clone never has one.
 # Without it, `go-trader.new probe` later loads no strategies and fails with
 # "read config: open scheduler/config.json: no such file or directory" — but
 # only after git pull + uv sync + build have already mutated the tree (#702).
 # Refuse early so the operator runs update.sh from the deployment directory
 # instead of improvising rsync-based syncs that can clobber deployment state.
+# Check runs AFTER `cd "$repo_root"` so a subdirectory invocation (e.g. from
+# `scheduler/`) doesn't report a misleading "missing config" message.
 if [[ ! -f scheduler/config.json ]]; then
     cat >&2 <<EOF
 [update] scheduler/config.json not found in $(pwd).
@@ -98,22 +116,6 @@ source repo and run scripts/update.sh from each deployment instance.
 EOF
     fail "scheduler/config.json missing — refusing to mutate tree from a non-deployment directory"
 fi
-
-if ! command -v uv >/dev/null 2>&1; then
-    fail "uv not on PATH — install uv first (see CLAUDE.md → Setup)"
-fi
-
-go_bin=""
-if command -v go >/dev/null 2>&1; then
-    go_bin=$(command -v go)
-elif [[ -x /opt/homebrew/bin/go ]]; then
-    go_bin=/opt/homebrew/bin/go
-else
-    fail "go not on PATH and /opt/homebrew/bin/go missing"
-fi
-
-repo_root=$(git rev-parse --show-toplevel)
-cd "$repo_root"
 
 # Build-input paths — anything touched here would actually affect the binary
 # or its Python contract. Modifications outside this list (e.g. CLAUDE.md,

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -76,6 +76,29 @@ fail() {
 # Phase 1: pre-flight — every check that should abort BEFORE any mutation.
 begin_phase preflight
 
+# scheduler/config.json is gitignored, so a bare source clone never has one.
+# Without it, `go-trader.new probe` later loads no strategies and fails with
+# "read config: open scheduler/config.json: no such file or directory" — but
+# only after git pull + uv sync + build have already mutated the tree (#702).
+# Refuse early so the operator runs update.sh from the deployment directory
+# instead of improvising rsync-based syncs that can clobber deployment state.
+if [[ ! -f scheduler/config.json ]]; then
+    cat >&2 <<EOF
+[update] scheduler/config.json not found in $(pwd).
+
+update.sh must run from a deployment directory (where scheduler/config.json
+exists). scheduler/config.json is gitignored, so a bare source clone has none
+and the probe phase would later fail without it.
+
+If this IS your deployment directory, copy scheduler/config.example.json to
+scheduler/config.json and fill in API keys (see CLAUDE.md → Setup).
+
+If you are syncing source to multiple deployment instances, build in the
+source repo and run scripts/update.sh from each deployment instance.
+EOF
+    fail "scheduler/config.json missing — refusing to mutate tree from a non-deployment directory"
+fi
+
 if ! command -v uv >/dev/null 2>&1; then
     fail "uv not on PATH — install uv first (see CLAUDE.md → Setup)"
 fi


### PR DESCRIPTION
## Summary

- Add a preflight guard to `scripts/update.sh` that detects a missing `scheduler/config.json` *before* any git pull / uv sync / build mutation, with operator-facing guidance pointing at the deployment directory and `scheduler/config.example.json`.

## Why

Running `update.sh` from a bare source clone used to fail in the **probe** phase with:

```
probe: failed to load config scheduler/config.json: read config: open scheduler/config.json: no such file or directory
[update] FAIL phase=probe: go-trader.new probe rejected the freshly synced Python — refusing to swap
```

By that point `git pull` + `uv sync` + `go build` had already run. Operators sometimes recovered by improvising rsync-based syncs that clobbered deployment-specific files like `scheduler/config.json`.

Failing in `preflight` keeps the tree untouched and tells the operator exactly what to do.

The skip-config-dependent-probe alternative was rejected: it makes the source-clone probe a no-op for `--strategy-refs` / `--probe-only` argv-drift mismatches, which is the failure mode the probe was added to catch (#683).

## Test plan

- [x] `bash -n scripts/update.sh` — syntax OK
- [x] Simulated missing-config run in a scratch repo: exits 1 in `preflight`, prints the guidance block, never reaches `pull` / `sync` / `build`
- [x] Simulated present-config run: guard passes, preflight proceeds to subsequent checks

Closes #702

---
LLM: Claude Opus 4.7 | high