### PR TITLE
feat: include exchange order OID in TP/SL close alert headlines

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -443,16 +443,17 @@ func tryBookSoleOwnerTPFill(
 		// the booker; do not insert another RecordTrade between here and the
 		// booker call.
 		*pendingAlerts = append(*pendingAlerts, ProtectionFillAlert{
-			StrategyID:   sc.ID,
-			Symbol:       sym,
-			Side:         alertSide,
-			FillType:     tpTierLabel(tierIdx),
-			IsPartial:    remaining > 1e-9,
-			FillPrice:    closePx,
-			CloseQty:     closeQty,
-			RemainingQty: remaining,
-			RealizedPnL:  lastBookedTradePnL(stratState),
-			HasPnL:       true,
+			StrategyID:      sc.ID,
+			Symbol:          sym,
+			Side:            alertSide,
+			FillType:        tpTierLabel(tierIdx),
+			IsPartial:       remaining > 1e-9,
+			FillPrice:       closePx,
+			CloseQty:        closeQty,
+			RemainingQty:    remaining,
+			RealizedPnL:     lastBookedTradePnL(stratState),
+			HasPnL:          true,
+			ExchangeOrderID: exchangeOrderID,
 		})
 	}
 	return true
@@ -838,16 +839,17 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 						// RecordTrade inside the booker; do not insert another
 						// RecordTrade between here and the booker call.
 						pendingAlerts = append(pendingAlerts, ProtectionFillAlert{
-							StrategyID:   id,
-							Symbol:       coin,
-							Side:         alertSide,
-							FillType:     "SL",
-							IsPartial:    false,
-							FillPrice:    alertTriggerPx,
-							CloseQty:     alertQty,
-							RemainingQty: 0,
-							RealizedPnL:  lastBookedTradePnL(ss),
-							HasPnL:       true,
+							StrategyID:      id,
+							Symbol:          coin,
+							Side:            alertSide,
+							FillType:        "SL",
+							IsPartial:       false,
+							FillPrice:       alertTriggerPx,
+							CloseQty:        alertQty,
+							RemainingQty:    0,
+							RealizedPnL:     lastBookedTradePnL(ss),
+							HasPnL:          true,
+							ExchangeOrderID: oidStr,
 						})
 					}
 				} else if mark, ok := prices[coin]; ok && mark > 0 {
@@ -937,16 +939,17 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 							// RecordTrade inside the booker; do not insert another
 							// RecordTrade between here and the booker call.
 							pendingAlerts = append(pendingAlerts, ProtectionFillAlert{
-								StrategyID:   slOwnerID,
-								Symbol:       coin,
-								Side:         alertSide,
-								FillType:     "SL",
-								IsPartial:    false,
-								FillPrice:    alertTriggerPx,
-								CloseQty:     alertQty,
-								RemainingQty: 0,
-								RealizedPnL:  lastBookedTradePnL(ownerSS),
-								HasPnL:       true,
+								StrategyID:      slOwnerID,
+								Symbol:          coin,
+								Side:            alertSide,
+								FillType:        "SL",
+								IsPartial:       false,
+								FillPrice:       alertTriggerPx,
+								CloseQty:        alertQty,
+								RemainingQty:    0,
+								RealizedPnL:     lastBookedTradePnL(ownerSS),
+								HasPnL:          true,
+								ExchangeOrderID: oidStr,
 							})
 						}
 					}
@@ -991,7 +994,11 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 							}
 							lookup, useFillFee := resolveFee(coin, 0, closeQty)
 							logHyperliquidReconcileFillLookup(logger, coin, 0, closeQty, lookup, useFillFee)
-							if recordPerpsExternalPartialCloseWithFillFee(candidateSS, coin, closeQty, mark, lookup.Fee, useFillFee, "", "hl_sync_external_partial", logger) {
+							detector3OID := ""
+							if useFillFee && lookup.OID > 0 {
+								detector3OID = strconv.FormatInt(lookup.OID, 10)
+							}
+							if recordPerpsExternalPartialCloseWithFillFee(candidateSS, coin, closeQty, mark, lookup.Fee, useFillFee, detector3OID, "hl_sync_external_partial", logger) {
 								changed = true
 								if closeSide == "long" {
 									virtualQty -= closeQty
@@ -1011,16 +1018,17 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 								// RecordTrade inside the booker; do not insert another
 								// RecordTrade between here and the booker call.
 								pendingAlerts = append(pendingAlerts, ProtectionFillAlert{
-									StrategyID:   candidateID,
-									Symbol:       coin,
-									Side:         closeSide,
-									FillType:     tpTierLabel(candidateTierIdx),
-									IsPartial:    true,
-									FillPrice:    mark,
-									CloseQty:     closeQty,
-									RemainingQty: remaining,
-									RealizedPnL:  lastBookedTradePnL(candidateSS),
-									HasPnL:       true,
+									StrategyID:      candidateID,
+									Symbol:          coin,
+									Side:            closeSide,
+									FillType:        tpTierLabel(candidateTierIdx),
+									IsPartial:       true,
+									FillPrice:       mark,
+									CloseQty:        closeQty,
+									RemainingQty:    remaining,
+									RealizedPnL:     lastBookedTradePnL(candidateSS),
+									HasPnL:          true,
+									ExchangeOrderID: detector3OID,
 								})
 							}
 						} else {

--- a/scheduler/protection_fill_alert.go
+++ b/scheduler/protection_fill_alert.go
@@ -6,22 +6,27 @@ import "fmt"
 // Emission sites build this struct from in-scope state and pass it to
 // notifyProtectionFill, which formats and DMs the owner.
 type ProtectionFillAlert struct {
-	StrategyID   string
-	Symbol       string
-	Side         string  // "long" or "short" — the position side, not the trade direction
-	FillType     string  // "TP1", "TP2", …, or "SL"
-	IsPartial    bool    // partial close (TP tier or partial SL) vs. full close
-	FillPrice    float64 // actual fill price; 0 if unknown
-	CloseQty     float64 // qty closed by this fill
-	RemainingQty float64 // remaining position qty after this fill
-	RealizedPnL  float64 // 0 when not computable
-	HasPnL       bool    // distinguishes "PnL=0" from "PnL unknown"
+	StrategyID      string
+	Symbol          string
+	Side            string  // "long" or "short" — the position side, not the trade direction
+	FillType        string  // "TP1", "TP2", …, or "SL"
+	IsPartial       bool    // partial close (TP tier or partial SL) vs. full close
+	FillPrice       float64 // actual fill price; 0 if unknown
+	CloseQty        float64 // qty closed by this fill
+	RemainingQty    float64 // remaining position qty after this fill
+	RealizedPnL     float64 // 0 when not computable
+	HasPnL          bool    // distinguishes "PnL=0" from "PnL unknown"
+	ExchangeOrderID string  // HL order OID (placed-order or fill OID) — appears in headline when non-empty, drives userFills reconciliation
 }
 
 // formatProtectionFillAlert produces the DM body for a TP/SL fill notification.
 // Pure function so it's testable without spinning a notifier.
 func formatProtectionFillAlert(a ProtectionFillAlert) string {
-	headline := fmt.Sprintf("%s filled — %s", a.FillType, a.StrategyID)
+	headline := fmt.Sprintf("%s filled", a.FillType)
+	if a.ExchangeOrderID != "" {
+		headline += fmt.Sprintf(" (oid=%s)", a.ExchangeOrderID)
+	}
+	headline += fmt.Sprintf(" — %s", a.StrategyID)
 	if a.IsPartial {
 		headline += " (partial)"
 	}

--- a/scheduler/protection_fill_alert_test.go
+++ b/scheduler/protection_fill_alert_test.go
@@ -69,6 +69,56 @@ func TestFormatProtectionFillAlert_NoPnL(t *testing.T) {
 	}
 }
 
+func TestFormatProtectionFillAlert_WithOID(t *testing.T) {
+	out := formatProtectionFillAlert(ProtectionFillAlert{
+		StrategyID:      "manual-eth",
+		Symbol:          "ETH",
+		Side:            "long",
+		FillType:        "SL",
+		IsPartial:       false,
+		FillPrice:       2301.0,
+		CloseQty:        0.429,
+		RemainingQty:    0,
+		RealizedPnL:     -12.31,
+		HasPnL:          true,
+		ExchangeOrderID: "420267328218",
+	})
+	if !strings.Contains(out, "SL filled (oid=420267328218) — manual-eth") {
+		t.Errorf("missing headline with OID:\n%s", out)
+	}
+}
+
+func TestFormatProtectionFillAlert_WithOIDPartial(t *testing.T) {
+	out := formatProtectionFillAlert(ProtectionFillAlert{
+		StrategyID:      "hl-bear-btc-live",
+		Symbol:          "BTC",
+		Side:            "short",
+		FillType:        "TP1",
+		IsPartial:       true,
+		FillPrice:       65000.0,
+		CloseQty:        0.005,
+		RemainingQty:    0.005,
+		HasPnL:          false,
+		ExchangeOrderID: "999000111",
+	})
+	if !strings.Contains(out, "TP1 filled (oid=999000111) — hl-bear-btc-live (partial)") {
+		t.Errorf("partial headline with OID missing/misordered:\n%s", out)
+	}
+}
+
+func TestFormatProtectionFillAlert_EmptyOIDOmitsParens(t *testing.T) {
+	out := formatProtectionFillAlert(ProtectionFillAlert{
+		StrategyID: "hl-x", Symbol: "BTC", Side: "long", FillType: "SL",
+		FillPrice: 50000, CloseQty: 0.1, HasPnL: false,
+	})
+	if strings.Contains(out, "(oid=") {
+		t.Errorf("empty ExchangeOrderID must not render oid=():\n%s", out)
+	}
+	if !strings.Contains(out, "SL filled — hl-x") {
+		t.Errorf("expected plain headline when OID is empty:\n%s", out)
+	}
+}
+
 func TestFormatProtectionFillAlert_UnknownPrice(t *testing.T) {
 	out := formatProtectionFillAlert(ProtectionFillAlert{
 		StrategyID: "hl-x", Symbol: "BTC", Side: "long", FillType: "SL",


### PR DESCRIPTION
## Summary

- Add `ExchangeOrderID` to `ProtectionFillAlert` and render it in the headline as `<FillType> filled (oid=<id>) — <strategyID>` when non-empty (`scheduler/protection_fill_alert.go`).
- Populate `ExchangeOrderID` at all four reconciler emission sites: SL Detector 1, SL Detector 2, sole-owner TP, and shared-coin TP Detector 3 (`scheduler/hyperliquid_balance.go`).
- Detector 3 was also dropping `lookup.OID` when calling `recordPerpsExternalPartialCloseWithFillFee` — now threaded in, so `Trade.ExchangeOrderID` stays consistent with the DM headline for `userFills` reconciliation.
- New format tests cover OID-present (full/partial), empty-OID (no stray `(oid=)`), and the suggested example from the issue.

Closes #705

## Test plan
- [x] `go build` (worktree, with `-ldflags Version`)
- [x] `go test ./...` — passes (24.6s)
- [x] New unit tests assert headline format `SL filled (oid=420267328218) — manual-eth` and `(partial)` ordering
- [ ] Operator smoke: trigger an SL fill on a real or paper position and confirm the DM headline contains `(oid=...)`

---
LLM: Claude Opus 4.7 | high