### PR TITLE
feat(config): effective-config introspection (#704)

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -579,6 +579,12 @@ func LoadConfig(path string) (*Config, error) {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
+	// #704: flag unknown per-strategy fields (typos like `take_profit_atr_mult`)
+	// before applying defaults; json.Unmarshal silently drops them and would
+	// otherwise produce a struct indistinguishable from "no protection configured".
+	if unknownErrs := validateStrategyJSONKeys(data); len(unknownErrs) > 0 {
+		return nil, fmt.Errorf("config validation errors:\n  %s", strings.Join(unknownErrs, "\n  "))
+	}
 	if cfg.IntervalSeconds <= 0 {
 		cfg.IntervalSeconds = 600
 	}

--- a/scheduler/config_unknown_keys.go
+++ b/scheduler/config_unknown_keys.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// knownStrategyConfigKeys returns the JSON tag names declared on
+// StrategyConfig. Used by validateStrategyJSONKeys to flag operator typos
+// (e.g. `take_profit_atr_mult`) instead of silently dropping invented fields
+// that would otherwise produce a config that looks correct but is missing the
+// requested protection (#704).
+func knownStrategyConfigKeys() map[string]bool {
+	known := make(map[string]bool)
+	t := reflect.TypeOf(StrategyConfig{})
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.SplitN(tag, ",", 2)[0]
+		if name != "" {
+			known[name] = true
+		}
+	}
+	return known
+}
+
+// unknownKeyHint returns a one-line suggestion for an unknown strategy field,
+// chosen by substring match against the most commonly mistyped categories. The
+// goal is to make the most frequent miss — TP/SL fields that look plausible
+// but never existed — fail loudly with actionable guidance (#704).
+func unknownKeyHint(key string) string {
+	lk := strings.ToLower(key)
+	switch {
+	case strings.Contains(lk, "take_profit") || strings.Contains(lk, "tp_tier") || lk == "tp_tiers":
+		return "TP logic lives under close_strategies (e.g. [{\"name\":\"tiered_tp_atr\",\"params\":{\"tiers\":[...]}}]); manual_defaults.tp_tiers only seeds defaults for type=manual"
+	case strings.HasPrefix(lk, "stop_loss") || strings.Contains(lk, "stoploss"):
+		return "valid SL fields: stop_loss_atr_mult, stop_loss_pct, stop_loss_margin_pct, trailing_stop_pct, trailing_stop_atr_mult (mutually exclusive)"
+	case lk == "close_strategy":
+		return "legacy pre-v13 field; use close_strategies (array of refs)"
+	case lk == "params" || lk == "open" || lk == "close":
+		return "pre-v13 flat shape; use open_strategy: {name, params} and close_strategies: [{name, params}, ...]"
+	default:
+		return ""
+	}
+}
+
+// validateStrategyJSONKeys re-parses the raw config bytes and flags any key
+// inside an entry of `strategies[]` that isn't declared on StrategyConfig.
+// json.Unmarshal silently drops unknown keys, so without this check an
+// operator typo (e.g. `take_profit_atr_mult`) loads as a stripped struct
+// indistinguishable from "no TP configured" — which is exactly the misdiagnosis
+// path that led to #704.
+//
+// Scoped to the strategies array only. We don't enable DisallowUnknownFields
+// globally because the surrounding config has optional/extension fields
+// (platforms, notifier backends) that intentionally tolerate forward-compat
+// keys. Returns a sorted list of "strategy[id]: unknown field %q" errors.
+func validateStrategyJSONKeys(rawData []byte) []string {
+	var envelope struct {
+		Strategies []map[string]json.RawMessage `json:"strategies"`
+	}
+	if err := json.Unmarshal(rawData, &envelope); err != nil {
+		// Top-level shape errors are reported by the main json.Unmarshal in
+		// LoadConfig; skip here so we don't double-report.
+		return nil
+	}
+	known := knownStrategyConfigKeys()
+	var errs []string
+	for i, s := range envelope.Strategies {
+		prefix := fmt.Sprintf("strategy[%d]", i)
+		if idRaw, ok := s["id"]; ok {
+			var id string
+			if json.Unmarshal(idRaw, &id) == nil && id != "" {
+				prefix = fmt.Sprintf("strategy[%s]", id)
+			}
+		}
+		keys := make([]string, 0, len(s))
+		for k := range s {
+			if !known[k] {
+				keys = append(keys, k)
+			}
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			msg := fmt.Sprintf("%s: unknown field %q", prefix, k)
+			if hint := unknownKeyHint(k); hint != "" {
+				msg += " — " + hint
+			}
+			errs = append(errs, msg)
+		}
+	}
+	return errs
+}

--- a/scheduler/config_unknown_keys_test.go
+++ b/scheduler/config_unknown_keys_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Sanity-check that the reflection-derived known-keys set actually contains
+// the fields operators rely on day-to-day. A future rename of a json tag that
+// also missed a deprecation here would otherwise silently turn live configs
+// into "unknown field" errors on the next deploy.
+func TestKnownStrategyConfigKeysCoversCoreFields(t *testing.T) {
+	known := knownStrategyConfigKeys()
+	mustHave := []string{
+		"id", "type", "platform", "symbol", "timeframe",
+		"script", "args",
+		"open_strategy", "close_strategies", "allowed_regimes",
+		"capital", "capital_pct", "initial_capital",
+		"max_drawdown_pct", "interval_seconds",
+		"htf_filter", "allow_shorts", "direction",
+		"leverage", "sizing_leverage", "margin_per_trade_usd",
+		"stop_loss_pct", "stop_loss_margin_pct",
+		"trailing_stop_pct", "trailing_stop_atr_mult", "stop_loss_atr_mult",
+		"trailing_stop_min_move_pct", "margin_mode",
+		"theta_harvest", "futures",
+	}
+	for _, k := range mustHave {
+		if !known[k] {
+			t.Errorf("knownStrategyConfigKeys missing %q — did a StrategyConfig json tag get renamed?", k)
+		}
+	}
+}
+
+func TestValidateStrategyJSONKeysFlagsInventedTPField(t *testing.T) {
+	raw := []byte(`{
+		"strategies": [
+			{
+				"id": "hl-momentum-btc",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["momentum", "BTC", "1h"],
+				"take_profit_atr_mult": 2.0
+			}
+		]
+	}`)
+	errs := validateStrategyJSONKeys(raw)
+	if len(errs) != 1 {
+		t.Fatalf("want 1 error for invented field, got %d: %v", len(errs), errs)
+	}
+	if !strings.Contains(errs[0], `strategy[hl-momentum-btc]: unknown field "take_profit_atr_mult"`) {
+		t.Errorf("error missing strategy id + field name: %q", errs[0])
+	}
+	if !strings.Contains(errs[0], "close_strategies") {
+		t.Errorf("error missing TP-field hint pointing operator to close_strategies: %q", errs[0])
+	}
+}
+
+func TestValidateStrategyJSONKeysHintsLegacyCloseStrategy(t *testing.T) {
+	raw := []byte(`{
+		"strategies": [
+			{"id": "s1", "type": "spot", "script": "x.py", "args": [], "close_strategy": "tiered_tp_atr"}
+		]
+	}`)
+	errs := validateStrategyJSONKeys(raw)
+	if len(errs) != 1 || !strings.Contains(errs[0], "close_strategies (array of refs)") {
+		t.Fatalf("want legacy close_strategy hint, got %v", errs)
+	}
+}
+
+func TestValidateStrategyJSONKeysHintsLegacyParams(t *testing.T) {
+	raw := []byte(`{
+		"strategies": [
+			{"id": "s1", "type": "spot", "script": "x.py", "args": [], "params": {"foo": 1}}
+		]
+	}`)
+	errs := validateStrategyJSONKeys(raw)
+	if len(errs) != 1 || !strings.Contains(errs[0], "open_strategy: {name, params}") {
+		t.Fatalf("want legacy params hint, got %v", errs)
+	}
+}
+
+func TestValidateStrategyJSONKeysHintsStopLossTypos(t *testing.T) {
+	raw := []byte(`{
+		"strategies": [
+			{"id": "s1", "type": "perps", "script": "x.py", "args": [], "stop_loss_atr_multiple": 1.5}
+		]
+	}`)
+	errs := validateStrategyJSONKeys(raw)
+	if len(errs) != 1 || !strings.Contains(errs[0], "valid SL fields") {
+		t.Fatalf("want SL hint for misspelled stop_loss_atr_multiple, got %v", errs)
+	}
+}
+
+func TestValidateStrategyJSONKeysAcceptsAllKnownFields(t *testing.T) {
+	raw := []byte(`{
+		"strategies": [
+			{
+				"id": "hl-rmc-eth-live",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["range_mean_revert", "ETH", "1h", "--mode=live"],
+				"open_strategy": {"name": "range_mean_revert"},
+				"close_strategies": [{"name": "tiered_tp_atr"}],
+				"capital": 1000,
+				"leverage": 5,
+				"sizing_leverage": 5,
+				"margin_mode": "isolated",
+				"stop_loss_atr_mult": 1.5,
+				"trailing_stop_min_move_pct": 0.5,
+				"direction": "long",
+				"max_drawdown_pct": 50
+			}
+		]
+	}`)
+	if errs := validateStrategyJSONKeys(raw); len(errs) != 0 {
+		t.Fatalf("expected no errors for known fields, got: %v", errs)
+	}
+}
+
+func TestValidateStrategyJSONKeysIgnoresTopLevelKeys(t *testing.T) {
+	raw := []byte(`{
+		"some_top_level_unknown": true,
+		"strategies": [{"id": "s1", "type": "spot", "script": "x.py", "args": []}]
+	}`)
+	if errs := validateStrategyJSONKeys(raw); len(errs) != 0 {
+		t.Fatalf("unknown top-level keys should not be flagged here (only strategy fields), got: %v", errs)
+	}
+}
+
+func TestValidateStrategyJSONKeysReportsByIDDeterministically(t *testing.T) {
+	raw := []byte(`{
+		"strategies": [
+			{"id": "b-strat", "type": "spot", "script": "x.py", "args": [], "zzz": 1, "aaa": 2},
+			{"id": "a-strat", "type": "spot", "script": "x.py", "args": [], "bogus": 3}
+		]
+	}`)
+	errs := validateStrategyJSONKeys(raw)
+	// Strategy-major order, key-sorted within each strategy.
+	want := []string{
+		`strategy[b-strat]: unknown field "aaa"`,
+		`strategy[b-strat]: unknown field "zzz"`,
+		`strategy[a-strat]: unknown field "bogus"`,
+	}
+	if len(errs) != len(want) {
+		t.Fatalf("want %d errs, got %d: %v", len(want), len(errs), errs)
+	}
+	for i, w := range want {
+		if !strings.HasPrefix(errs[i], w) {
+			t.Errorf("errs[%d] = %q, want prefix %q", i, errs[i], w)
+		}
+	}
+}
+
+func TestLoadConfigRejectsUnknownStrategyKey(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.json")
+	body := `{
+		"config_version": 14,
+		"db_file": "` + filepath.Join(tmp, "state.db") + `",
+		"strategies": [
+			{
+				"id": "hl-rmc-eth-live",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["range_mean_revert", "ETH", "1h", "--mode=paper"],
+				"open_strategy": {"name": "range_mean_revert"},
+				"close_strategies": [{"name": "tiered_tp_atr"}],
+				"capital": 1000,
+				"max_drawdown_pct": 50,
+				"take_profit_atr_mult": 2.0
+			}
+		]
+	}`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("LoadConfig accepted unknown strategy field")
+	}
+	if !strings.Contains(err.Error(), `unknown field "take_profit_atr_mult"`) {
+		t.Errorf("error %q does not name the unknown field", err)
+	}
+}

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1107,13 +1107,16 @@ func FormatTradeDM(sc StrategyConfig, trade Trade, mode string) string {
 }
 
 // tradeAlertExtras builds the extras line for trade-alert DMs (#665).
-// Order: PnL (close only) → Regime → ATR → SL → TP[1..n]. SL and each TP gain
-// an ATR multiplier suffix `(<n>x)` when EntryATR is known. Shared between
-// FormatTradeDM (Discord) and FormatTradeDMPlain (Telegram) so the two
-// channels can never drift on extras formatting.
+// Order: Source (close only) → PnL (close only) → Regime → ATR → SL → TP[1..n].
+// SL and each TP gain an ATR multiplier suffix `(<n>x)` when EntryATR is known.
+// Shared between FormatTradeDM (Discord) and FormatTradeDMPlain (Telegram) so
+// the two channels can never drift on extras formatting.
 func tradeAlertExtras(sc StrategyConfig, trade Trade, isClose bool) []string {
 	var extras []string
 	if isClose {
+		if src := tradeAlertCloseSource(trade.Details); src != "" {
+			extras = append(extras, "Source: "+src)
+		}
 		if pnl, ok := extractPnL(trade.Details); ok {
 			extras = append(extras, fmt.Sprintf("PnL: $%s", pnl))
 		}
@@ -1175,6 +1178,38 @@ func tradeDirectionLabel(trade Trade) string {
 		return "SHORT"
 	}
 	return tradeSideToDirection(trade.Side)
+}
+
+// tradeAlertCloseSource classifies a close-trade Details string into a human
+// label that names the *trigger* — exchange-side reduce-only SL, exchange-side
+// TP tier N, signal-driven close-strategy exit, external (peer / manual UI),
+// or circuit breaker. Surfaced as `Source: <label>` on the close DM so an
+// operator reading `🔴 TRADE CLOSED` knows whether it was the exchange
+// firing a resting trigger or the close evaluator firing on a signal — the
+// exact distinction that drove the #704 misdiagnosis on `hl-rmc-eth-live`.
+// Empty return means we can't confidently classify; caller skips the line.
+func tradeAlertCloseSource(details string) string {
+	d := strings.ToLower(details)
+	switch {
+	case strings.Contains(d, "stop loss close"):
+		return "exchange SL"
+	case strings.HasPrefix(d, "tp") && strings.Contains(d, "fill close"):
+		// "TP1 fill close" / "TP2 fill close" — preserve original casing.
+		end := strings.Index(d, " ")
+		if end > 0 {
+			return "exchange " + strings.ToUpper(details[:end])
+		}
+		return "exchange TP"
+	case strings.Contains(d, "circuit breaker"):
+		return "circuit breaker"
+	case strings.Contains(d, "external partial close"):
+		return "external (peer / manual UI, partial)"
+	case strings.Contains(d, "external close"):
+		return "external (peer / manual UI)"
+	case strings.HasPrefix(d, "close long") || strings.HasPrefix(d, "close short"):
+		return "close-strategy exit"
+	}
+	return ""
 }
 
 // extractPnL parses the PnL value from a trade Details string.

--- a/scheduler/inspect_cmd.go
+++ b/scheduler/inspect_cmd.go
@@ -1,0 +1,497 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// runInspect is the `go-trader inspect <strategy-id>` subcommand: load the
+// config, find the strategy, and print its effective (post-migration,
+// post-default) shape. Built for the incident workflow in #704 — operators
+// were grep'ing for plausible-sounding field names (`take_profit_atr_mult`,
+// `tp_tiers` per-strategy) that don't exist and concluding "no TP configured"
+// from the wrong inspection path. The output names the actual fields, their
+// resolved values, and whether each was set explicitly or filled by defaults.
+func runInspect(args []string) int {
+	fs := flag.NewFlagSet("inspect", flag.ContinueOnError)
+	configPath := fs.String("config", "scheduler/config.json", "Path to config file")
+	jsonOut := fs.Bool("json", false, "Emit the effective view as JSON (machine-readable)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	rest := fs.Args()
+	if len(rest) == 0 {
+		fmt.Fprintln(os.Stderr, "inspect: missing <strategy-id>")
+		fmt.Fprintln(os.Stderr, "usage: go-trader inspect [--config <path>] [--json] <strategy-id>|--all")
+		return 2
+	}
+	target := rest[0]
+
+	cfg, err := LoadConfig(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "inspect: failed to load config %s: %v\n", *configPath, err)
+		return 1
+	}
+	explicit, err := loadStrategyExplicitKeys(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "inspect: failed to read raw config for explicit-key detection: %v\n", err)
+		return 1
+	}
+
+	var targets []StrategyConfig
+	if target == "--all" {
+		targets = append(targets, cfg.Strategies...)
+		sort.Slice(targets, func(i, j int) bool { return targets[i].ID < targets[j].ID })
+	} else {
+		for _, sc := range cfg.Strategies {
+			if sc.ID == target {
+				targets = append(targets, sc)
+				break
+			}
+		}
+		if len(targets) == 0 {
+			fmt.Fprintf(os.Stderr, "inspect: strategy %q not found in %s\n", target, *configPath)
+			return 1
+		}
+	}
+
+	if *jsonOut {
+		out := make([]map[string]interface{}, 0, len(targets))
+		for _, sc := range targets {
+			out = append(out, buildStrategyInspectionJSON(sc, explicit[sc.ID], cfg))
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(out); err != nil {
+			fmt.Fprintf(os.Stderr, "inspect: encode JSON: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+
+	for i, sc := range targets {
+		if i > 0 {
+			fmt.Println()
+		}
+		fmt.Print(formatStrategyInspection(sc, explicit[sc.ID], cfg))
+	}
+	return 0
+}
+
+// loadStrategyExplicitKeys re-reads the raw config bytes and records which
+// JSON keys are explicitly present on each strategy entry. Used by inspect to
+// distinguish "operator wrote this value" from "LoadConfig filled it in".
+// Keyed by strategy id — entries without an id fall back to "strategy[<i>]".
+func loadStrategyExplicitKeys(path string) (map[string]map[string]bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var envelope struct {
+		Strategies []map[string]json.RawMessage `json:"strategies"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return nil, err
+	}
+	out := make(map[string]map[string]bool, len(envelope.Strategies))
+	for i, s := range envelope.Strategies {
+		id := fmt.Sprintf("strategy[%d]", i)
+		if raw, ok := s["id"]; ok {
+			var v string
+			if json.Unmarshal(raw, &v) == nil && v != "" {
+				id = v
+			}
+		}
+		keys := make(map[string]bool, len(s))
+		for k := range s {
+			keys[k] = true
+		}
+		out[id] = keys
+	}
+	return out, nil
+}
+
+// stopLossResolution summarizes which of the five mutually-exclusive HL stop
+// fields owns the effective trigger, the resolved price % (or "deferred" for
+// ATR-based stops), and whether the owner was set explicitly. Mirrors the
+// resolution logic in EffectiveStopLossPct so display can never lie about
+// which field is winning on a hot-reload boundary.
+type stopLossResolution struct {
+	Source   string  // field name, e.g. "stop_loss_atr_mult"; "max_drawdown_pct"; "none"
+	Value    string  // human-readable value ("1.5× ATR (deferred)", "2.0% from entry", "—")
+	Explicit bool    // operator set the winning field explicitly
+	PriceTag float64 // computed price % when known (post-arming for ATR stops); 0 for deferred
+}
+
+func resolveStopLoss(sc StrategyConfig, explicit map[string]bool) stopLossResolution {
+	if sc.Platform != "hyperliquid" || (sc.Type != "perps" && sc.Type != "manual") {
+		return stopLossResolution{Source: "n/a", Value: "—"}
+	}
+	if sc.TrailingStopATRMult != nil && *sc.TrailingStopATRMult > 0 {
+		return stopLossResolution{
+			Source:   "trailing_stop_atr_mult",
+			Value:    fmt.Sprintf("%g× ATR (trailing, deferred until EntryATR stamped)", *sc.TrailingStopATRMult),
+			Explicit: explicit["trailing_stop_atr_mult"],
+		}
+	}
+	if sc.StopLossATRMult != nil && *sc.StopLossATRMult > 0 {
+		return stopLossResolution{
+			Source:   "stop_loss_atr_mult",
+			Value:    fmt.Sprintf("%g× ATR (fixed, deferred until EntryATR stamped)", *sc.StopLossATRMult),
+			Explicit: explicit["stop_loss_atr_mult"],
+		}
+	}
+	if sc.TrailingStopPct != nil {
+		if *sc.TrailingStopPct > 0 {
+			return stopLossResolution{
+				Source:   "trailing_stop_pct",
+				Value:    fmt.Sprintf("%g%% trailing", *sc.TrailingStopPct),
+				Explicit: explicit["trailing_stop_pct"],
+				PriceTag: *sc.TrailingStopPct,
+			}
+		}
+		return stopLossResolution{Source: "trailing_stop_pct", Value: "disabled (explicit 0)", Explicit: true}
+	}
+	if sc.StopLossPct != nil {
+		if *sc.StopLossPct > 0 {
+			return stopLossResolution{
+				Source:   "stop_loss_pct",
+				Value:    fmt.Sprintf("%g%% from entry", *sc.StopLossPct),
+				Explicit: explicit["stop_loss_pct"],
+				PriceTag: *sc.StopLossPct,
+			}
+		}
+		return stopLossResolution{Source: "stop_loss_pct", Value: "disabled (explicit 0)", Explicit: true}
+	}
+	if sc.StopLossMarginPct != nil {
+		if *sc.StopLossMarginPct > 0 && sc.Leverage > 0 {
+			derived := *sc.StopLossMarginPct / sc.Leverage
+			return stopLossResolution{
+				Source:   "stop_loss_margin_pct",
+				Value:    fmt.Sprintf("%g%% margin → %.3g%% from entry (÷ leverage %g)", *sc.StopLossMarginPct, derived, sc.Leverage),
+				Explicit: explicit["stop_loss_margin_pct"],
+				PriceTag: derived,
+			}
+		}
+		return stopLossResolution{Source: "stop_loss_margin_pct", Value: "disabled (explicit 0 or zero leverage)", Explicit: true}
+	}
+	// All five nil — only reachable when DefaultStopLossATRMult was explicitly
+	// disabled (=0). Falls back to MaxDrawdownPct (capped). LoadConfig should
+	// have filled stop_loss_atr_mult otherwise.
+	if sc.MaxDrawdownPct > 0 {
+		v := sc.MaxDrawdownPct
+		if v > MaxAutoStopLossPct {
+			v = MaxAutoStopLossPct
+		}
+		return stopLossResolution{
+			Source:   "max_drawdown_pct (fallback)",
+			Value:    fmt.Sprintf("%g%% from entry (capped at %g%%)", v, MaxAutoStopLossPct),
+			Explicit: false,
+			PriceTag: v,
+		}
+	}
+	return stopLossResolution{Source: "none", Value: "no exchange-side stop"}
+}
+
+// tpResolution summarizes which close ref owns the take-profit logic and its
+// resolved tier shape. Returns ok=false when no TP close evaluator is wired
+// (i.e. close strategy isn't tiered_tp_atr or tiered_tp_atr_live).
+type tpResolution struct {
+	OK         bool
+	CloseIndex int
+	CloseName  string
+	Tiers      []hlProtectionTier
+	TiersFrom  string // "explicit on close ref" | "default (from registry)"
+}
+
+func resolveTP(sc StrategyConfig, explicit map[string]bool) tpResolution {
+	res := tpResolution{}
+	for i, ref := range sc.CloseStrategies {
+		n := strings.ToLower(strings.TrimSpace(ref.Name))
+		if n != "tiered_tp_atr" && n != "tiered_tp_atr_live" {
+			continue
+		}
+		res.OK = true
+		res.CloseIndex = i
+		res.CloseName = ref.Name
+		_, hasTiers := ref.Params["tiers"]
+		res.Tiers = strategyTPTiers(sc)
+		if hasTiers {
+			res.TiersFrom = "explicit on close ref"
+		} else {
+			res.TiersFrom = "default (canonical [1×@50%, 2×@100%])"
+		}
+		return res
+	}
+	return res
+}
+
+// formatStrategyInspection renders the multi-line human-facing inspect output
+// for one strategy. Splitting from runInspect lets tests assert the formatter
+// independently of os.Args / file IO, and lets the startup logger reuse the
+// one-line summary helper below.
+func formatStrategyInspection(sc StrategyConfig, explicit map[string]bool, cfg *Config) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "strategy %s\n", sc.ID)
+	fmt.Fprintf(&b, "  type:                %s\n", sc.Type)
+	fmt.Fprintf(&b, "  platform:            %s%s\n", sc.Platform, markIfDefault(explicit, "platform"))
+	if sc.Symbol != "" {
+		fmt.Fprintf(&b, "  symbol:              %s\n", sc.Symbol)
+	}
+	if sc.Timeframe != "" {
+		fmt.Fprintf(&b, "  timeframe:           %s\n", sc.Timeframe)
+	}
+	fmt.Fprintf(&b, "  script:              %s%s\n", sc.Script, markIfDefault(explicit, "script"))
+	if len(sc.Args) > 0 {
+		fmt.Fprintf(&b, "  args:                %v\n", sc.Args)
+	}
+
+	fmt.Fprintf(&b, "  open_strategy:       %s%s\n", strategyRefDisplayName(sc.OpenStrategy), markIfDefault(explicit, "open_strategy"))
+	if len(sc.OpenStrategy.Params) > 0 {
+		fmt.Fprintf(&b, "    params:            %s\n", stableParamSummary(sc.OpenStrategy.Params))
+	}
+	fmt.Fprintf(&b, "  close_strategies:    %s%s\n", formatCloseStrategyList(sc.CloseStrategies), markIfDefault(explicit, "close_strategies"))
+	for i, ref := range sc.CloseStrategies {
+		if len(ref.Params) == 0 {
+			continue
+		}
+		fmt.Fprintf(&b, "    [%d] %s params: %s\n", i, ref.Name, stableParamSummary(ref.Params))
+	}
+
+	if sc.Type == "perps" || sc.Type == "manual" {
+		fmt.Fprintf(&b, "  direction:           %s (%s)\n", EffectiveDirection(sc), directionProvenance(sc, explicit))
+		fmt.Fprintf(&b, "  leverage:            %g%s\n", EffectiveExchangeLeverage(sc), markIfDefault(explicit, "leverage"))
+		fmt.Fprintf(&b, "  sizing_leverage:     %g%s\n", EffectiveSizingLeverage(sc), sizingLeverageProvenance(sc, explicit))
+		if m := EffectiveMarginPerTradeUSD(sc); m > 0 {
+			fmt.Fprintf(&b, "  margin_per_trade:    $%.2f%s\n", m, markIfDefault(explicit, "margin_per_trade_usd"))
+		}
+		if sc.MarginMode != "" {
+			fmt.Fprintf(&b, "  margin_mode:         %s%s\n", sc.MarginMode, markIfDefault(explicit, "margin_mode"))
+		}
+	}
+
+	if sc.Platform == "hyperliquid" && (sc.Type == "perps" || sc.Type == "manual") {
+		sl := resolveStopLoss(sc, explicit)
+		fmt.Fprintf(&b, "  stop_loss:\n")
+		fmt.Fprintf(&b, "    source:            %s%s\n", sl.Source, explicitTag(sl.Explicit))
+		fmt.Fprintf(&b, "    value:             %s\n", sl.Value)
+
+		tp := resolveTP(sc, explicit)
+		fmt.Fprintf(&b, "  take_profit:\n")
+		if !tp.OK {
+			fmt.Fprintf(&b, "    source:            none (no tiered_tp_atr / tiered_tp_atr_live in close_strategies)\n")
+		} else {
+			fmt.Fprintf(&b, "    source:            close_strategies[%d] %s\n", tp.CloseIndex, tp.CloseName)
+			fmt.Fprintf(&b, "    tiers:             %s — %s\n", formatTiers(tp.Tiers), tp.TiersFrom)
+		}
+	}
+
+	fmt.Fprintf(&b, "  max_drawdown_pct:    %g%s\n", sc.MaxDrawdownPct, markIfDefault(explicit, "max_drawdown_pct"))
+	if sc.IntervalSeconds > 0 {
+		fmt.Fprintf(&b, "  interval_seconds:    %d\n", sc.IntervalSeconds)
+	} else if cfg != nil {
+		fmt.Fprintf(&b, "  interval_seconds:    %d (inherited from global)\n", cfg.IntervalSeconds)
+	}
+	if len(sc.AllowedRegimes) > 0 {
+		fmt.Fprintf(&b, "  allowed_regimes:     %v\n", sc.AllowedRegimes)
+	}
+	if sc.HTFFilter {
+		fmt.Fprintf(&b, "  htf_filter:          true\n")
+	}
+	if sc.ThetaHarvest != nil {
+		fmt.Fprintf(&b, "  theta_harvest:       enabled=%v profit=%g%% stop=%g%% min_dte=%g%s\n",
+			sc.ThetaHarvest.Enabled, sc.ThetaHarvest.ProfitTargetPct, sc.ThetaHarvest.StopLossPct, sc.ThetaHarvest.MinDTEClose,
+			markIfDefault(explicit, "theta_harvest"))
+	}
+	return b.String()
+}
+
+// formatStrategySummaryLine compresses the effective resolution into one line
+// for startup logging — meant to be the operator's "did my close/SL config
+// actually land?" sanity check the moment the daemon boots (#704 suggestion 2).
+func formatStrategySummaryLine(sc StrategyConfig, explicit map[string]bool) string {
+	parts := []string{fmt.Sprintf("type=%s", sc.Type)}
+	if sc.OpenStrategy.Name != "" {
+		parts = append(parts, fmt.Sprintf("open=%s", sc.OpenStrategy.Name))
+	}
+	if len(sc.CloseStrategies) > 0 {
+		names := make([]string, 0, len(sc.CloseStrategies))
+		for _, ref := range sc.CloseStrategies {
+			names = append(names, ref.Name)
+		}
+		parts = append(parts, fmt.Sprintf("close=[%s]", strings.Join(names, ",")))
+	} else {
+		parts = append(parts, "close=open-as-close")
+	}
+	if sc.Platform == "hyperliquid" && (sc.Type == "perps" || sc.Type == "manual") {
+		sl := resolveStopLoss(sc, explicit)
+		parts = append(parts, fmt.Sprintf("sl=%s%s", sl.Source, explicitTag(sl.Explicit)))
+		tp := resolveTP(sc, explicit)
+		if tp.OK {
+			parts = append(parts, fmt.Sprintf("tp=%s[%d-tier]", tp.CloseName, len(tp.Tiers)))
+		} else {
+			parts = append(parts, "tp=none")
+		}
+	}
+	return fmt.Sprintf("[config] %s: %s", sc.ID, strings.Join(parts, " "))
+}
+
+// buildStrategyInspectionJSON mirrors formatStrategyInspection in
+// machine-readable form. Keeps the same provenance info so external tools
+// (dashboards, audit scripts) can spot "field is at the default" cases.
+func buildStrategyInspectionJSON(sc StrategyConfig, explicit map[string]bool, cfg *Config) map[string]interface{} {
+	if explicit == nil {
+		explicit = map[string]bool{}
+	}
+	closeRefs := make([]map[string]interface{}, 0, len(sc.CloseStrategies))
+	for _, ref := range sc.CloseStrategies {
+		closeRefs = append(closeRefs, map[string]interface{}{
+			"name":   ref.Name,
+			"params": ref.Params,
+		})
+	}
+	out := map[string]interface{}{
+		"id":       sc.ID,
+		"type":     sc.Type,
+		"platform": sc.Platform,
+		"open_strategy": map[string]interface{}{
+			"name":     sc.OpenStrategy.Name,
+			"params":   sc.OpenStrategy.Params,
+			"explicit": explicit["open_strategy"],
+		},
+		"close_strategies":          closeRefs,
+		"close_strategies_explicit": explicit["close_strategies"],
+		"max_drawdown_pct":          sc.MaxDrawdownPct,
+		"max_drawdown_pct_explicit": explicit["max_drawdown_pct"],
+	}
+	if sc.Type == "perps" || sc.Type == "manual" {
+		out["direction"] = EffectiveDirection(sc)
+		out["leverage"] = EffectiveExchangeLeverage(sc)
+		out["sizing_leverage"] = EffectiveSizingLeverage(sc)
+		out["margin_mode"] = sc.MarginMode
+	}
+	if sc.Platform == "hyperliquid" && (sc.Type == "perps" || sc.Type == "manual") {
+		sl := resolveStopLoss(sc, explicit)
+		out["stop_loss"] = map[string]interface{}{
+			"source":   sl.Source,
+			"value":    sl.Value,
+			"explicit": sl.Explicit,
+		}
+		tp := resolveTP(sc, explicit)
+		tpMap := map[string]interface{}{"configured": tp.OK}
+		if tp.OK {
+			tiers := make([]map[string]interface{}, len(tp.Tiers))
+			for i, t := range tp.Tiers {
+				tiers[i] = map[string]interface{}{"atr_multiple": t.Multiple, "fraction": t.Fraction}
+			}
+			tpMap["close_index"] = tp.CloseIndex
+			tpMap["close_name"] = tp.CloseName
+			tpMap["tiers"] = tiers
+			tpMap["tiers_source"] = tp.TiersFrom
+		}
+		out["take_profit"] = tpMap
+	}
+	if sc.IntervalSeconds > 0 {
+		out["interval_seconds"] = sc.IntervalSeconds
+		out["interval_seconds_explicit"] = true
+	} else if cfg != nil {
+		out["interval_seconds"] = cfg.IntervalSeconds
+		out["interval_seconds_explicit"] = false
+	}
+	return out
+}
+
+// --- formatting helpers ---
+
+func markIfDefault(explicit map[string]bool, key string) string {
+	if explicit[key] {
+		return ""
+	}
+	return " (default)"
+}
+
+func explicitTag(explicit bool) string {
+	if explicit {
+		return " (explicit)"
+	}
+	return " (default)"
+}
+
+func strategyRefDisplayName(ref StrategyRef) string {
+	if ref.Name == "" {
+		return "(unset)"
+	}
+	return ref.Name
+}
+
+func formatCloseStrategyList(refs []StrategyRef) string {
+	if len(refs) == 0 {
+		return "[] (falls back to open-as-close)"
+	}
+	names := make([]string, len(refs))
+	for i, r := range refs {
+		names[i] = r.Name
+	}
+	return "[" + strings.Join(names, ", ") + "]"
+}
+
+func formatTiers(tiers []hlProtectionTier) string {
+	if len(tiers) == 0 {
+		return "(none)"
+	}
+	parts := make([]string, len(tiers))
+	for i, t := range tiers {
+		parts[i] = fmt.Sprintf("%g× ATR @ %g%%", t.Multiple, t.Fraction*100)
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+// stableParamSummary renders a params map with deterministic key ordering so
+// inspect output is comparable across runs. Lifted instead of using fmt.Sprintf
+// directly because Go map iteration is randomized (CLAUDE.md "Map iteration").
+func stableParamSummary(params map[string]interface{}) string {
+	if len(params) == 0 {
+		return "{}"
+	}
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%v", k, params[k]))
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+// directionProvenance distinguishes the four ways EffectiveDirection can land
+// on "long"/"short"/"both": explicit direction field, legacy allow_shorts
+// bool, or the implicit "long" default. Surfacing this matters because the
+// v14 migration silently rewrites allow_shorts → direction and operators
+// won't see that on a stale checkout.
+func directionProvenance(sc StrategyConfig, explicit map[string]bool) string {
+	switch {
+	case explicit["direction"]:
+		return "explicit"
+	case explicit["allow_shorts"]:
+		return "legacy allow_shorts (pre-v14)"
+	default:
+		return "default long"
+	}
+}
+
+func sizingLeverageProvenance(sc StrategyConfig, explicit map[string]bool) string {
+	switch {
+	case explicit["sizing_leverage"]:
+		return ""
+	case explicit["leverage"]:
+		return " (inherited from leverage)"
+	default:
+		return " (default)"
+	}
+}

--- a/scheduler/inspect_cmd_test.go
+++ b/scheduler/inspect_cmd_test.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadStrategyExplicitKeysCapturesPresence(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.json")
+	body := `{
+		"strategies": [
+			{
+				"id": "hl-rmc-eth-live",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["range_mean_revert", "ETH", "1h"],
+				"close_strategies": [{"name": "tiered_tp_atr"}],
+				"capital": 1000,
+				"leverage": 5
+			},
+			{
+				"id": "hl-tema-eth-live",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["triple_ema", "ETH", "1h"],
+				"capital": 1000
+			}
+		]
+	}`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	keys, err := loadStrategyExplicitKeys(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !keys["hl-rmc-eth-live"]["close_strategies"] {
+		t.Errorf("expected close_strategies marked explicit on hl-rmc-eth-live")
+	}
+	if !keys["hl-rmc-eth-live"]["leverage"] {
+		t.Errorf("expected leverage marked explicit on hl-rmc-eth-live")
+	}
+	if keys["hl-rmc-eth-live"]["stop_loss_atr_mult"] {
+		t.Errorf("stop_loss_atr_mult should not be marked explicit when omitted")
+	}
+	if keys["hl-tema-eth-live"]["close_strategies"] {
+		t.Errorf("close_strategies should not be explicit when omitted")
+	}
+}
+
+func TestResolveStopLossPicksHighestPriorityField(t *testing.T) {
+	mult := 1.5
+	sc := StrategyConfig{
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		StopLossATRMult: &mult,
+		Leverage:        5,
+	}
+	res := resolveStopLoss(sc, map[string]bool{"stop_loss_atr_mult": true})
+	if res.Source != "stop_loss_atr_mult" {
+		t.Errorf("source = %q, want stop_loss_atr_mult", res.Source)
+	}
+	if !res.Explicit {
+		t.Errorf("explicit should be true")
+	}
+	if !strings.Contains(res.Value, "1.5× ATR") {
+		t.Errorf("value missing mult: %q", res.Value)
+	}
+}
+
+func TestResolveStopLossTrailingATRWinsOverFixed(t *testing.T) {
+	fixed := 1.5
+	trail := 2.0
+	sc := StrategyConfig{
+		Type:                "perps",
+		Platform:            "hyperliquid",
+		StopLossATRMult:     &fixed,
+		TrailingStopATRMult: &trail,
+	}
+	res := resolveStopLoss(sc, nil)
+	if res.Source != "trailing_stop_atr_mult" {
+		t.Errorf("source = %q, want trailing_stop_atr_mult (higher priority)", res.Source)
+	}
+}
+
+func TestResolveStopLossMarginPctDerivesPriceFromLeverage(t *testing.T) {
+	m := 10.0
+	sc := StrategyConfig{
+		Type:              "perps",
+		Platform:          "hyperliquid",
+		StopLossMarginPct: &m,
+		Leverage:          5,
+	}
+	res := resolveStopLoss(sc, map[string]bool{"stop_loss_margin_pct": true})
+	if res.Source != "stop_loss_margin_pct" {
+		t.Errorf("source = %q", res.Source)
+	}
+	if res.PriceTag != 2.0 {
+		t.Errorf("price tag = %g, want 2.0 (10/5)", res.PriceTag)
+	}
+}
+
+func TestResolveStopLossNonHLReturnsNA(t *testing.T) {
+	sc := StrategyConfig{Type: "spot", Platform: "binanceus"}
+	res := resolveStopLoss(sc, nil)
+	if res.Source != "n/a" {
+		t.Errorf("source = %q, want n/a for non-HL", res.Source)
+	}
+}
+
+func TestResolveTPMatchesFirstTieredCloseRef(t *testing.T) {
+	sc := StrategyConfig{
+		Platform: "hyperliquid",
+		Type:     "perps",
+		CloseStrategies: []StrategyRef{
+			{Name: "trailing_stop_atr"}, // unrelated
+			{Name: "tiered_tp_atr", Params: map[string]interface{}{
+				"tiers": []interface{}{
+					map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.5},
+					map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
+				},
+			}},
+		},
+	}
+	res := resolveTP(sc, nil)
+	if !res.OK {
+		t.Fatal("expected TP resolution to succeed")
+	}
+	if res.CloseIndex != 1 || res.CloseName != "tiered_tp_atr" {
+		t.Errorf("index=%d name=%q", res.CloseIndex, res.CloseName)
+	}
+	if !strings.Contains(res.TiersFrom, "explicit") {
+		t.Errorf("tiers source = %q, want explicit", res.TiersFrom)
+	}
+	if len(res.Tiers) != 2 {
+		t.Errorf("len(tiers) = %d, want 2", len(res.Tiers))
+	}
+}
+
+func TestResolveTPNoTieredCloseRefReturnsNotOK(t *testing.T) {
+	sc := StrategyConfig{
+		Platform:        "hyperliquid",
+		Type:            "perps",
+		CloseStrategies: []StrategyRef{{Name: "trailing_stop_atr"}},
+	}
+	res := resolveTP(sc, nil)
+	if res.OK {
+		t.Errorf("expected TP resolution to be missing")
+	}
+}
+
+func TestFormatStrategyInspectionShowsResolvedTPSource(t *testing.T) {
+	sc := StrategyConfig{
+		ID:           "hl-rmc-eth-live",
+		Type:         "perps",
+		Platform:     "hyperliquid",
+		Script:       "shared_scripts/check_hyperliquid.py",
+		Args:         []string{"range_mean_revert", "ETH", "1h"},
+		OpenStrategy: StrategyRef{Name: "range_mean_revert"},
+		CloseStrategies: []StrategyRef{
+			{Name: "tiered_tp_atr"},
+		},
+		Capital:        1000,
+		Leverage:       5,
+		SizingLeverage: 5,
+		MarginMode:     "isolated",
+		MaxDrawdownPct: 50,
+	}
+	mult := 1.5
+	sc.StopLossATRMult = &mult
+	explicit := map[string]bool{
+		"id": true, "type": true, "platform": true, "script": true, "args": true,
+		"open_strategy": true, "close_strategies": true,
+		"capital": true, "leverage": true, "sizing_leverage": true,
+		"margin_mode": true, "max_drawdown_pct": true, "stop_loss_atr_mult": true,
+	}
+	out := formatStrategyInspection(sc, explicit, &Config{IntervalSeconds: 600})
+
+	for _, want := range []string{
+		"strategy hl-rmc-eth-live",
+		"close_strategies:    [tiered_tp_atr]",
+		"stop_loss:",
+		"source:            stop_loss_atr_mult (explicit)",
+		"take_profit:",
+		"source:            close_strategies[0] tiered_tp_atr",
+		"tiers:             [1× ATR @ 50%, 2× ATR @ 100%]",
+		"default (canonical [1×@50%, 2×@100%])",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q.\nfull:\n%s", want, out)
+		}
+	}
+	// Verify default markers do NOT appear for explicit fields.
+	if strings.Contains(out, "platform:            hyperliquid (default)") {
+		t.Errorf("platform was explicit but rendered as default")
+	}
+}
+
+func TestFormatStrategyInspectionMarksDefaultedFields(t *testing.T) {
+	mult := 1.0 // applied by LoadConfig default
+	sc := StrategyConfig{
+		ID:              "hl-tema-eth-live",
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		Script:          "shared_scripts/check_hyperliquid.py",
+		Args:            []string{"triple_ema", "ETH", "1h"},
+		OpenStrategy:    StrategyRef{Name: "triple_ema"},
+		Leverage:        1, // LoadConfig default
+		SizingLeverage:  1, // inherited from leverage
+		MarginMode:      "isolated",
+		MaxDrawdownPct:  50,
+		StopLossATRMult: &mult,
+	}
+	// Operator only set id/type/platform/script/args/open_strategy.
+	explicit := map[string]bool{"id": true, "type": true, "platform": true, "script": true, "args": true, "open_strategy": true}
+	out := formatStrategyInspection(sc, explicit, &Config{IntervalSeconds: 600})
+
+	if !strings.Contains(out, "stop_loss_atr_mult (default)") {
+		t.Errorf("SL default marker missing.\nfull:\n%s", out)
+	}
+	if !strings.Contains(out, "leverage:            1 (default)") {
+		t.Errorf("leverage default marker missing.\nfull:\n%s", out)
+	}
+	if !strings.Contains(out, "sizing_leverage:     1 (default)") {
+		t.Errorf("sizing_leverage default marker missing.\nfull:\n%s", out)
+	}
+	if !strings.Contains(out, "margin_mode:         isolated (default)") {
+		t.Errorf("margin_mode default marker missing.\nfull:\n%s", out)
+	}
+}
+
+func TestFormatStrategySummaryLineCompressesEverything(t *testing.T) {
+	mult := 1.5
+	sc := StrategyConfig{
+		ID:              "hl-rmc-eth-live",
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		OpenStrategy:    StrategyRef{Name: "range_mean_revert"},
+		CloseStrategies: []StrategyRef{{Name: "tiered_tp_atr"}},
+		StopLossATRMult: &mult,
+	}
+	line := formatStrategySummaryLine(sc, map[string]bool{"stop_loss_atr_mult": true})
+	for _, want := range []string{
+		"[config] hl-rmc-eth-live:",
+		"type=perps",
+		"open=range_mean_revert",
+		"close=[tiered_tp_atr]",
+		"sl=stop_loss_atr_mult (explicit)",
+		"tp=tiered_tp_atr[2-tier]",
+	} {
+		if !strings.Contains(line, want) {
+			t.Errorf("summary line missing %q: %s", want, line)
+		}
+	}
+}
+
+func TestFormatStrategySummaryLineSpotOmitsHLFields(t *testing.T) {
+	sc := StrategyConfig{
+		ID:           "momentum-btc",
+		Type:         "spot",
+		Platform:     "binanceus",
+		OpenStrategy: StrategyRef{Name: "momentum"},
+	}
+	line := formatStrategySummaryLine(sc, nil)
+	if strings.Contains(line, "sl=") || strings.Contains(line, "tp=") {
+		t.Errorf("spot summary should not include sl/tp fields: %s", line)
+	}
+	if !strings.Contains(line, "close=open-as-close") {
+		t.Errorf("spot summary should show open-as-close: %s", line)
+	}
+}
+
+func TestBuildStrategyInspectionJSONStableShape(t *testing.T) {
+	mult := 1.5
+	sc := StrategyConfig{
+		ID:              "hl-rmc-eth-live",
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		OpenStrategy:    StrategyRef{Name: "range_mean_revert"},
+		CloseStrategies: []StrategyRef{{Name: "tiered_tp_atr"}},
+		Leverage:        5,
+		SizingLeverage:  5,
+		MarginMode:      "isolated",
+		MaxDrawdownPct:  50,
+		StopLossATRMult: &mult,
+	}
+	out := buildStrategyInspectionJSON(sc, map[string]bool{
+		"open_strategy": true, "close_strategies": true, "stop_loss_atr_mult": true,
+	}, &Config{IntervalSeconds: 600})
+
+	bs, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(bs)
+	if !strings.Contains(s, `"id":"hl-rmc-eth-live"`) {
+		t.Errorf("json missing id: %s", s)
+	}
+	sl, ok := out["stop_loss"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("stop_loss not a map: %v", out["stop_loss"])
+	}
+	if sl["source"] != "stop_loss_atr_mult" {
+		t.Errorf("stop_loss.source = %v", sl["source"])
+	}
+	if sl["explicit"] != true {
+		t.Errorf("stop_loss.explicit = %v", sl["explicit"])
+	}
+	tp, ok := out["take_profit"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("take_profit not a map: %v", out["take_profit"])
+	}
+	if tp["configured"] != true {
+		t.Errorf("take_profit.configured = %v", tp["configured"])
+	}
+}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -23,6 +23,7 @@ var knownSubcommands = []string{
 	"manual-close",
 	"backfill",
 	"probe",
+	"inspect",
 	"version",
 }
 
@@ -61,6 +62,8 @@ func main() {
 			os.Exit(runBackfill(os.Args[2:]))
 		case "probe":
 			os.Exit(runProbe(os.Args[2:]))
+		case "inspect":
+			os.Exit(runInspect(os.Args[2:]))
 		case "version", "--version", "-version":
 			fmt.Println(Version)
 			os.Exit(0)
@@ -86,6 +89,15 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Printf("Loaded config: %d strategies, interval=%ds\n", len(cfg.Strategies), cfg.IntervalSeconds)
+
+	// #704: emit a one-line resolved summary per strategy so operators can
+	// audit close/SL/TP wiring without grepping the JSON. Best-effort — a
+	// failed re-read just means we can't mark explicit-vs-default but the
+	// summary still shows the resolved source.
+	explicitKeys, _ := loadStrategyExplicitKeys(*configPath)
+	for _, sc := range cfg.Strategies {
+		fmt.Println(formatStrategySummaryLine(sc, explicitKeys[sc.ID]))
+	}
 
 	// #339: Detect a missing state DB on a live deployment *before* OpenStateDB
 	// creates it — a wiped directory (vs. an in-place `git pull`) would otherwise

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -1216,7 +1216,7 @@ func TestValidateDaemonInvocation(t *testing.T) {
 }
 
 func TestKnownSubcommandsMatchDispatch(t *testing.T) {
-	expected := []string{"init", "export", "manual-open", "manual-close", "backfill", "probe", "version"}
+	expected := []string{"init", "export", "manual-open", "manual-close", "backfill", "probe", "inspect", "version"}
 	if len(knownSubcommands) != len(expected) {
 		t.Fatalf("knownSubcommands length = %d, want %d (update validateDaemonInvocation when adding/removing a subcommand in main())", len(knownSubcommands), len(expected))
 	}

--- a/scheduler/trade_alert_source_test.go
+++ b/scheduler/trade_alert_source_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTradeAlertCloseSourceClassification(t *testing.T) {
+	cases := []struct {
+		details string
+		want    string
+	}{
+		{"Stop loss close ETH, PnL: $-22.45 (fee $1.10)", "exchange SL"},
+		{"TP1 fill close, PnL: $34.35 (fee $1.23)", "exchange TP1"},
+		{"TP2 fill close, PnL: $50.00 (fee $1.50)", "exchange TP2"},
+		{"Circuit breaker on-chain close (no virtual position), fill=0.5 fee=$0.20", "circuit breaker"},
+		{"External close @ mark $3077, PnL: $0.00 (fee $0.00)", "external (peer / manual UI)"},
+		{"External partial close @ mark $3077", "external (peer / manual UI, partial)"},
+		{"Close long, PnL: $34.35 (fee $1.23)", "close-strategy exit"},
+		{"Close short, PnL: $12.50 (fee $1.23)", "close-strategy exit"},
+		{"Partial-close long ETH, PnL: $12.34 (fee $0.05)", ""}, // partial-close from signal: not a trigger, no annotation
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := tradeAlertCloseSource(c.details)
+		if got != c.want {
+			t.Errorf("details=%q → %q, want %q", c.details, got, c.want)
+		}
+	}
+}
+
+func TestFormatTradeDMCloseTradeIncludesSource(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-rmc-eth-live", Platform: "hyperliquid", Type: "perps"}
+	trade := Trade{
+		Symbol:   "ETH",
+		Side:     "sell",
+		Quantity: 0.47,
+		Price:    3077.70,
+		Value:    1446.52,
+		Details:  "Stop loss close ETH, PnL: $-22.45 (fee $1.10)",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	if !strings.Contains(msg, "Source: exchange SL") {
+		t.Errorf("expected Source line for SL close, got:\n%s", msg)
+	}
+}
+
+func TestFormatTradeDMOpenTradeOmitsSource(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-rmc-eth-live", Platform: "hyperliquid", Type: "perps"}
+	trade := Trade{
+		Symbol:   "ETH",
+		Side:     "buy",
+		Quantity: 0.47,
+		Price:    3077.70,
+		Value:    1446.52,
+		Details:  "Open long 0.47 @ $3077.70 (5x, fee $1.10)",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	if strings.Contains(msg, "Source:") {
+		t.Errorf("open trade should not carry a Source line, got:\n%s", msg)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #704. Four observability levers so an operator (or agent) can never again misdiagnose a live trade by inspecting the wrong field — the failure mode that drove the incident on \`hl-rmc-eth-live\`.

1. **LoadConfig rejects unknown per-strategy keys.** Reflection-derived known-keys set from \`StrategyConfig\` json tags; surgical re-parse of \`strategies[]\` only (top-level forward-compat preserved). Targeted hints for the most common misses:
   - \`take_profit_*\` → \"TP lives under \`close_strategies\`\"
   - \`stop_loss_*\` typos → list of the five mutually-exclusive valid fields
   - legacy \`close_strategy\` / \`params\` → pointers to the co-located \`StrategyRef\` shape
2. **\`./go-trader inspect <strategy-id> [--all] [--json]\`** — prints the post-migration, post-default effective shape: open/close refs (+ params), SL field that won \`EffectiveStopLossPct\`'s priority cascade with value + explicit/default provenance, TP close ref + resolved tier list, direction provenance, per-field explicit-vs-default markers derived from re-reading the raw JSON.
3. **Startup logging** — one-line \`[config] <id>: type=X open=Y close=[..] sl=... tp=...\` summary per strategy after \`LoadConfig\`, sharing the same resolver as \`inspect\` so the two can never diverge.
4. **Trade-alert DM \`Source:\` line on close legs** — classifies the trigger as \`exchange SL\`, \`exchange TP1\`, \`close-strategy exit\`, \`external (peer / manual UI)\`, or \`circuit breaker\` based on \`Trade.Details\` prefix. Open legs skip the line.

## Sample output

\`\`\`
\$ ./go-trader inspect hl-rmc-eth-live
strategy hl-rmc-eth-live
  type:                perps
  platform:            hyperliquid
  open_strategy:       range_mean_revert
  close_strategies:    [tiered_tp_atr]
  direction:           long (default long)
  leverage:            5
  sizing_leverage:     5 (inherited from leverage)
  margin_mode:         isolated
  stop_loss:
    source:            stop_loss_atr_mult (default)
    value:             1× ATR (fixed, deferred until EntryATR stamped)
  take_profit:
    source:            close_strategies[0] tiered_tp_atr
    tiers:             [1× ATR @ 50%, 2× ATR @ 100%] — default (canonical [1×@50%, 2×@100%])
  max_drawdown_pct:    50
  interval_seconds:    300
\`\`\`

\`\`\`
\$ ./go-trader inspect --config /tmp/bad-config.json hl-rmc-eth-live
inspect: failed to load config /tmp/bad-config.json: config validation errors:
  strategy[hl-rmc-eth-live]: unknown field \"take_profit_atr_mult\" — TP logic lives under close_strategies (e.g. [{\"name\":\"tiered_tp_atr\",\"params\":{\"tiers\":[...]}}]); manual_defaults.tp_tiers only seeds defaults for type=manual
\`\`\`

## Test plan
- [x] \`go test ./...\` from \`scheduler/\` — all green (24.6s)
- [x] \`go build\` clean
- [x] \`./go-trader inspect\` smoke-tested against \`config.example.json\` — renders defaulted SL + 'TP none', flags hl-momentum-btc's missing TP path
- [x] Unknown-key smoke: \`take_profit_atr_mult\` on a real-shaped config returns the operator-friendly hint
- [x] Startup summary verified locally
- [ ] Manual smoke on a live config in staging after merge

---
LLM: Claude Opus 4.7 | high