### PR TITLE
fix(manual-open): accept interspersed flags and resolve --margin/--notional via mark fetch

### DIFF
--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -35,6 +35,12 @@ func runManualOpen(args []string) int {
 	recordOnly := fs.Bool("record-only", false, "Register an existing fill without placing a new on-chain order")
 	dryRun := fs.Bool("dry-run", false, "Print planned action without placing order or mutating state")
 
+	// #711: stdlib flag.Parse stops at the first positional arg, so the
+	// documented `manual-open <strategy-id> --flag value` form fails to parse
+	// the trailing flags. Reorder to put the positional last so both
+	// orderings work.
+	args = reorderArgsForPositional(args, manualOpenBoolFlags)
+
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -150,13 +156,32 @@ func runManualOpen(args []string) int {
 
 	script := sc.Script
 
+	// #711: --margin/--notional need a price to resolve to coin qty; passing
+	// price=0 to resolveManualSize returns 0 and HL rejects the order with
+	// "--size must be > 0". Fetch the current HL mid as the price reference
+	// (market orders fill at ~mid). --size and --record-only paths skip the
+	// fetch since size is explicit.
+	var resolvedOrderSize, sizingMark float64
+	if !*recordOnly {
+		qty, mark, err := resolveManualOpenOrderSize(sc, *size, *notional, *margin, fetchHyperliquidMids)
+		if err != nil {
+			if *dryRun {
+				fmt.Fprintf(os.Stderr, "warning: dry-run sizing best-effort failed: %v\n", err)
+			} else {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				return 1
+			}
+		}
+		resolvedOrderSize = qty
+		sizingMark = mark
+	}
+
 	var resolvedFillPrice, fillQty, fillFee float64
 	var exchangeOID string
 
 	if *dryRun {
-		displayQty := resolveManualSize(*size, *notional, *margin, 0, sc.Leverage)
-		fmt.Printf("[dry-run] manual-open %s: %s %.6f %s (script=%s, sl_pct=%.2f)\n",
-			strategyID, *side, displayQty, sc.Symbol, script, effectiveSLPct)
+		fmt.Printf("[dry-run] manual-open %s: %s %.6f %s (script=%s, sl_pct=%.2f, mark=$%.4f)\n",
+			strategyID, *side, resolvedOrderSize, sc.Symbol, script, effectiveSLPct, sizingMark)
 		return 0
 	}
 
@@ -178,7 +203,7 @@ func runManualOpen(args []string) int {
 	} else {
 		execResult, execStderr, execErr := RunHyperliquidExecute(
 			script, sc.Symbol, openSide,
-			resolveManualSize(*size, *notional, *margin, 0, sc.Leverage),
+			resolvedOrderSize,
 			effectiveSLPct, 0, 0, sc.MarginMode, sc.Leverage, false,
 		)
 		if execStderr != "" {
@@ -356,6 +381,8 @@ func runManualClose(args []string) int {
 	configPath := fs.String("config", "scheduler/config.json", "Path to config file")
 	qty := fs.Float64("qty", 0, "Quantity to close in base units (0 = full position)")
 	dryRun := fs.Bool("dry-run", false, "Print planned action without placing order or mutating state")
+
+	args = reorderArgsForPositional(args, manualCloseBoolFlags)
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -685,6 +712,83 @@ func findManualStrategy(cfg *Config, id string) (StrategyConfig, bool) {
 	}
 	fmt.Fprintf(os.Stderr, "error: strategy %q not found in config\n", id)
 	return StrategyConfig{}, false
+}
+
+// manualOpenBoolFlags / manualCloseBoolFlags list flags that do NOT consume
+// the following arg as a value — needed by reorderArgsForPositional so it
+// doesn't mistake the strategy-id positional for a flag value.
+var manualOpenBoolFlags = map[string]bool{"record-only": true, "dry-run": true}
+var manualCloseBoolFlags = map[string]bool{"dry-run": true}
+
+// reorderArgsForPositional moves positional (non-flag) arguments to the end
+// so Go's stdlib flag.Parse — which stops at the first non-flag — can still
+// parse flags placed after a positional. This makes both invocation styles
+// work for `manual-open` / `manual-close` (#711):
+//
+//	manual-open <strategy-id> --flag value
+//	manual-open --flag value <strategy-id>
+//
+// boolFlags lists flags that take no value (so we don't consume the next arg
+// as their value when it is actually the positional).
+func reorderArgsForPositional(args []string, boolFlags map[string]bool) []string {
+	var flagArgs, positional []string
+	i := 0
+	for i < len(args) {
+		a := args[i]
+		if a == "--" {
+			positional = append(positional, args[i+1:]...)
+			break
+		}
+		if len(a) > 1 && strings.HasPrefix(a, "-") {
+			flagArgs = append(flagArgs, a)
+			if strings.Contains(a, "=") {
+				i++
+				continue
+			}
+			name := strings.TrimLeft(a, "-")
+			if !boolFlags[name] && i+1 < len(args) {
+				flagArgs = append(flagArgs, args[i+1])
+				i += 2
+				continue
+			}
+			i++
+			continue
+		}
+		positional = append(positional, a)
+		i++
+	}
+	return append(flagArgs, positional...)
+}
+
+// manualMarkFetcher matches fetchHyperliquidMids for dependency injection in
+// tests of resolveManualOpenOrderSize.
+type manualMarkFetcher func(coins []string) (map[string]float64, error)
+
+// resolveManualOpenOrderSize converts --size/--margin/--notional inputs into a
+// concrete coin qty for the HL execute call. --size is explicit; --margin and
+// --notional need a price reference (HL mid) to compute the qty. Returns
+// (qty, mark, err); on --size path mark is 0. (#711)
+func resolveManualOpenOrderSize(sc StrategyConfig, size, notional, margin float64, fetch manualMarkFetcher) (float64, float64, error) {
+	if size > 0 {
+		return size, 0, nil
+	}
+	coin := hyperliquidConfiguredCoin(sc)
+	if coin == "" {
+		return 0, 0, fmt.Errorf("cannot determine HL coin for strategy %q (symbol=%q)", sc.ID, sc.Symbol)
+	}
+	marks, err := fetch([]string{coin})
+	if err != nil {
+		return 0, 0, fmt.Errorf("fetch HL mark for %s: %w", coin, err)
+	}
+	mark := marks[coin]
+	if mark <= 0 {
+		return 0, 0, fmt.Errorf("HL mark for %s missing or non-positive — cannot resolve --margin/--notional sizing", coin)
+	}
+	qty := resolveManualSize(size, notional, margin, mark, sc.Leverage)
+	if qty <= 0 {
+		return 0, mark, fmt.Errorf("resolved size is zero (size=%g notional=%g margin=%g mark=%g leverage=%g) — check --margin/--notional and strategy leverage", size, notional, margin, mark, sc.Leverage)
+	}
+	return qty, mark, nil
 }
 
 // resolveManualSize converts the sizing inputs to a coin qty.

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -39,7 +39,7 @@ func runManualOpen(args []string) int {
 	// documented `manual-open <strategy-id> --flag value` form fails to parse
 	// the trailing flags. Reorder to put the positional last so both
 	// orderings work.
-	args = reorderArgsForPositional(args, manualOpenBoolFlags)
+	args = reorderArgsForPositional(args, collectBoolFlagNames(fs))
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -162,11 +162,13 @@ func runManualOpen(args []string) int {
 	// (market orders fill at ~mid). --size and --record-only paths skip the
 	// fetch since size is explicit.
 	var resolvedOrderSize, sizingMark float64
+	var sizingFailed bool
 	if !*recordOnly {
 		qty, mark, err := resolveManualOpenOrderSize(sc, *size, *notional, *margin, fetchHyperliquidMids)
 		if err != nil {
 			if *dryRun {
 				fmt.Fprintf(os.Stderr, "warning: dry-run sizing best-effort failed: %v\n", err)
+				sizingFailed = true
 			} else {
 				fmt.Fprintf(os.Stderr, "error: %v\n", err)
 				return 1
@@ -180,8 +182,12 @@ func runManualOpen(args []string) int {
 	var exchangeOID string
 
 	if *dryRun {
-		fmt.Printf("[dry-run] manual-open %s: %s %.6f %s (script=%s, sl_pct=%.2f, mark=$%.4f)\n",
-			strategyID, *side, resolvedOrderSize, sc.Symbol, script, effectiveSLPct, sizingMark)
+		prefix := "[dry-run]"
+		if sizingFailed {
+			prefix = "[dry-run] [sizing failed]"
+		}
+		fmt.Printf("%s manual-open %s: %s %.6f %s (script=%s, sl_pct=%.2f, mark=$%.4f)\n",
+			prefix, strategyID, *side, resolvedOrderSize, sc.Symbol, script, effectiveSLPct, sizingMark)
 		return 0
 	}
 
@@ -382,7 +388,7 @@ func runManualClose(args []string) int {
 	qty := fs.Float64("qty", 0, "Quantity to close in base units (0 = full position)")
 	dryRun := fs.Bool("dry-run", false, "Print planned action without placing order or mutating state")
 
-	args = reorderArgsForPositional(args, manualCloseBoolFlags)
+	args = reorderArgsForPositional(args, collectBoolFlagNames(fs))
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -714,11 +720,20 @@ func findManualStrategy(cfg *Config, id string) (StrategyConfig, bool) {
 	return StrategyConfig{}, false
 }
 
-// manualOpenBoolFlags / manualCloseBoolFlags list flags that do NOT consume
-// the following arg as a value — needed by reorderArgsForPositional so it
-// doesn't mistake the strategy-id positional for a flag value.
-var manualOpenBoolFlags = map[string]bool{"record-only": true, "dry-run": true}
-var manualCloseBoolFlags = map[string]bool{"dry-run": true}
+// collectBoolFlagNames returns the names of bool flags registered on fs.
+// reorderArgsForPositional uses this to avoid consuming the strategy-id
+// positional as the value of a preceding bool flag. Derived from the FlagSet
+// (rather than a hardcoded map) so new bool flags self-register.
+func collectBoolFlagNames(fs *flag.FlagSet) map[string]bool {
+	out := map[string]bool{}
+	fs.VisitAll(func(f *flag.Flag) {
+		type boolFlag interface{ IsBoolFlag() bool }
+		if bf, ok := f.Value.(boolFlag); ok && bf.IsBoolFlag() {
+			out[f.Name] = true
+		}
+	})
+	return out
+}
 
 // reorderArgsForPositional moves positional (non-flag) arguments to the end
 // so Go's stdlib flag.Parse — which stops at the first non-flag — can still

--- a/scheduler/manual_test.go
+++ b/scheduler/manual_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -602,4 +604,175 @@ func TestDefaultManualStopLossATRMult(t *testing.T) {
 	if defaultManualStopLossATRMult != 1.5 {
 		t.Errorf("defaultManualStopLossATRMult = %g, want 1.5", defaultManualStopLossATRMult)
 	}
+}
+
+// TestReorderArgsForPositional verifies that flags placed after the positional
+// strategy-id are still parsed correctly — the bug from #711 where
+// `manual-open manual-eth --side long --margin 50` failed because stdlib
+// flag.Parse stops at the first non-flag arg.
+func TestReorderArgsForPositional(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        []string
+		boolFlags map[string]bool
+		want      []string
+	}{
+		{
+			name:      "documented order: positional first",
+			in:        []string{"manual-eth", "--side", "long", "--margin", "50"},
+			boolFlags: manualOpenBoolFlags,
+			want:      []string{"--side", "long", "--margin", "50", "manual-eth"},
+		},
+		{
+			name:      "workaround order: positional last",
+			in:        []string{"--side", "long", "--margin", "50", "manual-eth"},
+			boolFlags: manualOpenBoolFlags,
+			want:      []string{"--side", "long", "--margin", "50", "manual-eth"},
+		},
+		{
+			name:      "positional in the middle",
+			in:        []string{"--side", "long", "manual-eth", "--margin", "50"},
+			boolFlags: manualOpenBoolFlags,
+			want:      []string{"--side", "long", "--margin", "50", "manual-eth"},
+		},
+		{
+			name:      "bool flag does not swallow positional",
+			in:        []string{"manual-eth", "--dry-run", "--side", "long"},
+			boolFlags: manualOpenBoolFlags,
+			want:      []string{"--dry-run", "--side", "long", "manual-eth"},
+		},
+		{
+			name:      "--record-only treated as bool",
+			in:        []string{"manual-eth", "--record-only", "--size", "0.5", "--fill-price", "2000"},
+			boolFlags: manualOpenBoolFlags,
+			want:      []string{"--record-only", "--size", "0.5", "--fill-price", "2000", "manual-eth"},
+		},
+		{
+			name:      "--flag=value form preserved",
+			in:        []string{"--side=long", "manual-eth", "--margin=50"},
+			boolFlags: manualOpenBoolFlags,
+			want:      []string{"--side=long", "--margin=50", "manual-eth"},
+		},
+		{
+			name:      "double-dash terminator",
+			in:        []string{"--side", "long", "--", "manual-eth"},
+			boolFlags: manualOpenBoolFlags,
+			want:      []string{"--side", "long", "manual-eth"},
+		},
+		{
+			name:      "manual-close style with --qty",
+			in:        []string{"manual-eth", "--qty", "0.1", "--dry-run"},
+			boolFlags: manualCloseBoolFlags,
+			want:      []string{"--qty", "0.1", "--dry-run", "manual-eth"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := reorderArgsForPositional(c.in, c.boolFlags)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("reorderArgsForPositional(%v) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestResolveManualOpenOrderSize covers the post-#711 sizing path that fetches
+// the HL mark price before resolving --margin/--notional to a coin qty.
+func TestResolveManualOpenOrderSize(t *testing.T) {
+	sc := StrategyConfig{
+		ID:       "hl-manual-eth-live",
+		Platform: "hyperliquid",
+		Type:     "manual",
+		Symbol:   "ETH",
+		Leverage: 10,
+	}
+
+	t.Run("--size bypasses fetch", func(t *testing.T) {
+		called := false
+		fetch := func(coins []string) (map[string]float64, error) {
+			called = true
+			return nil, errors.New("should not be called")
+		}
+		qty, mark, err := resolveManualOpenOrderSize(sc, 0.5, 0, 0, fetch)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if qty != 0.5 || mark != 0 || called {
+			t.Errorf("got qty=%g mark=%g called=%v; want qty=0.5 mark=0 called=false", qty, mark, called)
+		}
+	})
+
+	t.Run("--margin resolves with fetched mark", func(t *testing.T) {
+		fetch := func(coins []string) (map[string]float64, error) {
+			return map[string]float64{"ETH": 2000}, nil
+		}
+		qty, mark, err := resolveManualOpenOrderSize(sc, 0, 0, 50, fetch)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// 50 margin * 10 leverage / 2000 price = 0.25 ETH
+		if fmt.Sprintf("%.6f", qty) != "0.250000" || mark != 2000 {
+			t.Errorf("got qty=%g mark=%g; want qty=0.25 mark=2000", qty, mark)
+		}
+	})
+
+	t.Run("--notional resolves with fetched mark", func(t *testing.T) {
+		fetch := func(coins []string) (map[string]float64, error) {
+			return map[string]float64{"ETH": 2000}, nil
+		}
+		qty, mark, err := resolveManualOpenOrderSize(sc, 0, 1000, 0, fetch)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if fmt.Sprintf("%.6f", qty) != "0.500000" || mark != 2000 {
+			t.Errorf("got qty=%g mark=%g; want qty=0.5 mark=2000", qty, mark)
+		}
+	})
+
+	t.Run("fetch error surfaces", func(t *testing.T) {
+		fetch := func(coins []string) (map[string]float64, error) {
+			return nil, errors.New("network down")
+		}
+		qty, _, err := resolveManualOpenOrderSize(sc, 0, 0, 50, fetch)
+		if err == nil || qty != 0 {
+			t.Errorf("got qty=%g err=%v; want non-nil err", qty, err)
+		}
+		if !strings.Contains(err.Error(), "network down") {
+			t.Errorf("expected wrapped fetch error, got: %v", err)
+		}
+	})
+
+	t.Run("missing coin in mark map errors", func(t *testing.T) {
+		fetch := func(coins []string) (map[string]float64, error) {
+			return map[string]float64{}, nil
+		}
+		_, _, err := resolveManualOpenOrderSize(sc, 0, 0, 50, fetch)
+		if err == nil || !strings.Contains(err.Error(), "missing or non-positive") {
+			t.Errorf("expected missing-mark error, got: %v", err)
+		}
+	})
+
+	t.Run("zero qty errors (e.g. leverage=0 with --margin)", func(t *testing.T) {
+		scNoLev := sc
+		scNoLev.Leverage = 0
+		fetch := func(coins []string) (map[string]float64, error) {
+			return map[string]float64{"ETH": 2000}, nil
+		}
+		_, _, err := resolveManualOpenOrderSize(scNoLev, 0, 0, 50, fetch)
+		if err == nil || !strings.Contains(err.Error(), "resolved size is zero") {
+			t.Errorf("expected zero-size error, got: %v", err)
+		}
+	})
+
+	t.Run("non-hl strategy errors", func(t *testing.T) {
+		scOKX := sc
+		scOKX.Platform = "okx"
+		fetch := func(coins []string) (map[string]float64, error) {
+			return map[string]float64{"ETH": 2000}, nil
+		}
+		_, _, err := resolveManualOpenOrderSize(scOKX, 0, 0, 50, fetch)
+		if err == nil || !strings.Contains(err.Error(), "cannot determine HL coin") {
+			t.Errorf("expected coin-resolution error, got: %v", err)
+		}
+	})
 }

--- a/scheduler/manual_test.go
+++ b/scheduler/manual_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"reflect"
 	"strings"
@@ -606,11 +607,29 @@ func TestDefaultManualStopLossATRMult(t *testing.T) {
 	}
 }
 
+// TestCollectBoolFlagNames verifies the helper returns only bool-typed flags.
+// reorderArgsForPositional relies on this distinction to avoid consuming the
+// positional arg as a value-flag's value.
+func TestCollectBoolFlagNames(t *testing.T) {
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	fs.Bool("flag-a", false, "")
+	fs.Bool("flag-b", false, "")
+	fs.String("flag-c", "", "")
+	fs.Float64("flag-d", 0, "")
+	got := collectBoolFlagNames(fs)
+	want := map[string]bool{"flag-a": true, "flag-b": true}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("collectBoolFlagNames = %v, want %v", got, want)
+	}
+}
+
 // TestReorderArgsForPositional verifies that flags placed after the positional
 // strategy-id are still parsed correctly — the bug from #711 where
 // `manual-open manual-eth --side long --margin 50` failed because stdlib
 // flag.Parse stops at the first non-flag arg.
 func TestReorderArgsForPositional(t *testing.T) {
+	openBoolFlags := map[string]bool{"record-only": true, "dry-run": true}
+	closeBoolFlags := map[string]bool{"dry-run": true}
 	cases := []struct {
 		name      string
 		in        []string
@@ -620,49 +639,49 @@ func TestReorderArgsForPositional(t *testing.T) {
 		{
 			name:      "documented order: positional first",
 			in:        []string{"manual-eth", "--side", "long", "--margin", "50"},
-			boolFlags: manualOpenBoolFlags,
+			boolFlags: openBoolFlags,
 			want:      []string{"--side", "long", "--margin", "50", "manual-eth"},
 		},
 		{
 			name:      "workaround order: positional last",
 			in:        []string{"--side", "long", "--margin", "50", "manual-eth"},
-			boolFlags: manualOpenBoolFlags,
+			boolFlags: openBoolFlags,
 			want:      []string{"--side", "long", "--margin", "50", "manual-eth"},
 		},
 		{
 			name:      "positional in the middle",
 			in:        []string{"--side", "long", "manual-eth", "--margin", "50"},
-			boolFlags: manualOpenBoolFlags,
+			boolFlags: openBoolFlags,
 			want:      []string{"--side", "long", "--margin", "50", "manual-eth"},
 		},
 		{
 			name:      "bool flag does not swallow positional",
 			in:        []string{"manual-eth", "--dry-run", "--side", "long"},
-			boolFlags: manualOpenBoolFlags,
+			boolFlags: openBoolFlags,
 			want:      []string{"--dry-run", "--side", "long", "manual-eth"},
 		},
 		{
 			name:      "--record-only treated as bool",
 			in:        []string{"manual-eth", "--record-only", "--size", "0.5", "--fill-price", "2000"},
-			boolFlags: manualOpenBoolFlags,
+			boolFlags: openBoolFlags,
 			want:      []string{"--record-only", "--size", "0.5", "--fill-price", "2000", "manual-eth"},
 		},
 		{
 			name:      "--flag=value form preserved",
 			in:        []string{"--side=long", "manual-eth", "--margin=50"},
-			boolFlags: manualOpenBoolFlags,
+			boolFlags: openBoolFlags,
 			want:      []string{"--side=long", "--margin=50", "manual-eth"},
 		},
 		{
 			name:      "double-dash terminator",
 			in:        []string{"--side", "long", "--", "manual-eth"},
-			boolFlags: manualOpenBoolFlags,
+			boolFlags: openBoolFlags,
 			want:      []string{"--side", "long", "manual-eth"},
 		},
 		{
 			name:      "manual-close style with --qty",
 			in:        []string{"manual-eth", "--qty", "0.1", "--dry-run"},
-			boolFlags: manualCloseBoolFlags,
+			boolFlags: closeBoolFlags,
 			want:      []string{"--qty", "0.1", "--dry-run", "manual-eth"},
 		},
 	}


### PR DESCRIPTION
Closes #711.

## Summary

- Reorder `manual-open` / `manual-close` args before `fs.Parse` so the documented `manual-open <strategy-id> --flag value` form works.
- Fetch the HL mid before `RunHyperliquidExecute` so `--margin` / `--notional` resolve to a non-zero coin qty instead of 0.
- Tests cover both fixes.

## Test plan
- [x] `go test ./.` passes
- [ ] `./go-trader manual-open manual-eth --side long --margin 50 --dry-run` renders non-zero qty
- [ ] `./go-trader manual-open --side long --margin 50 manual-eth` opens a live position

---
LLM: Claude Opus 4.7 (1M) | high | Harness: anthropics/claude-code-action@v1 | Tokens: 71 in / 27907 out | Cache: 3933836 read / 157987 written | Cost: $3.65