### PR TITLE
fix(sl-after): cap SL replace qty at on-chain qty in runPostTPStopLossAdjustment

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1572,7 +1572,7 @@ func main() {
 							}
 							if hyperliquidIsLive(sc.Args) && result.Signal == 0 && hlPosQty > 0 {
 								runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced")
-								runPostTPStopLossAdjustment(sc, stratState, result.Symbol, price, cfg, &mu, notifier, logger)
+								runPostTPStopLossAdjustment(sc, stratState, result.Symbol, price, cfg, &mu, notifier, logger, hlOnChainAbsQty)
 							}
 							if hyperliquidIsLive(sc.Args) && result.Signal != 0 {
 								er, ok2 := runHyperliquidExecuteOrder(sc, result, price, hlCash, hlPosQty, hlPosSide, hlAvgCost, hlStopLossOID, hlTPOIDs, hlReconcileAll, notifier, logger)
@@ -1604,7 +1604,7 @@ func main() {
 								mu.Unlock()
 								if execResult != nil && trades > 0 {
 									runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced after trade")
-									runPostTPStopLossAdjustment(sc, stratState, result.Symbol, price, cfg, &mu, notifier, logger)
+									runPostTPStopLossAdjustment(sc, stratState, result.Symbol, price, cfg, &mu, notifier, logger, hlOnChainAbsQty)
 									mu.Lock()
 									var pos *Position
 									if p, ok := stratState.Positions[result.Symbol]; ok {
@@ -1652,7 +1652,7 @@ func main() {
 						}
 						if pos != nil && hyperliquidIsLive(sc.Args) {
 							runHyperliquidProtectionSync(sc, stratState, stateDB, sc.Symbol, &mu, notifier, logger, "HL manual protection synced")
-							runPostTPStopLossAdjustment(sc, stratState, sc.Symbol, prices[sc.Symbol], cfg, &mu, notifier, logger)
+							runPostTPStopLossAdjustment(sc, stratState, sc.Symbol, prices[sc.Symbol], cfg, &mu, notifier, logger, hlOnChainAbsQty)
 						}
 						if closeFraction, _, ok := runManualCloseEval(sc, stratState, cfg, logger); ok && closeFraction > 0 {
 							mu.RLock()

--- a/scheduler/post_tp_sl.go
+++ b/scheduler/post_tp_sl.go
@@ -524,7 +524,7 @@ func runPostTPStopLossAdjustment(
 	// the trailing-stop walker (main.go:1491) and fixed-ATR arm (main.go:1549).
 	slEffectiveQty, capped := hlSLEffectiveQty(symbol, qty, hlOnChainAbsQty)
 	if capped && logger != nil {
-		logger.Warn("post-TP SL replace: virtual qty %.6f > on-chain %.6f for %s; capping SL size to on-chain qty (#714)", qty, slEffectiveQty, symbol)
+		logger.Warn("post-TP SL replace: virtual qty %.6f > on-chain %.6f for %s; capping SL size to on-chain qty (#621)", qty, slEffectiveQty, symbol)
 	}
 
 	// Phase 2: no-lock subprocess — cancel+replace SL OID. RunHyperliquidUpdateStopLoss

--- a/scheduler/post_tp_sl.go
+++ b/scheduler/post_tp_sl.go
@@ -450,6 +450,7 @@ func runPostTPStopLossAdjustment(
 	mu *sync.RWMutex,
 	notifier *MultiNotifier,
 	logger *StrategyLogger,
+	hlOnChainAbsQty map[string]float64,
 ) bool {
 	if sc.Platform != "hyperliquid" || (sc.Type != "perps" && sc.Type != "manual") {
 		return false
@@ -517,6 +518,15 @@ func runPostTPStopLossAdjustment(
 		return false
 	}
 
+	// #714: cap SL size at on-chain qty. After a TP tier fills, on-chain qty is
+	// below virtual qty until the reconciler / protection-sync books the fill;
+	// without the cap HL rejects the reduce-only replace as oversized. Mirrors
+	// the trailing-stop walker (main.go:1491) and fixed-ATR arm (main.go:1549).
+	slEffectiveQty, capped := hlSLEffectiveQty(symbol, qty, hlOnChainAbsQty)
+	if capped && logger != nil {
+		logger.Warn("post-TP SL replace: virtual qty %.6f > on-chain %.6f for %s; capping SL size to on-chain qty (#714)", qty, slEffectiveQty, symbol)
+	}
+
 	// Phase 2: no-lock subprocess — cancel+replace SL OID. RunHyperliquidUpdateStopLoss
 	// is the trailing-stop primitive but it just cancels an existing OID and
 	// places a fresh reduce-only trigger, which is what every sl_after mode
@@ -527,7 +537,7 @@ func runPostTPStopLossAdjustment(
 		logger.Info("post-TP SL adjustment for %s: tier %d cleared, mode=%s new_trigger=$%.4f (cancel oid=%d)",
 			symbol, clearedIdx, mode, triggerPx, currentOID)
 	}
-	result, stderr, err := runHyperliquidUpdateStopLossFunc(sc.Script, symbol, side, qty, triggerPx, currentOID)
+	result, stderr, err := runHyperliquidUpdateStopLossFunc(sc.Script, symbol, side, slEffectiveQty, triggerPx, currentOID)
 	if stderr != "" && logger != nil {
 		logger.Info("post-TP SL stderr: %s", stderr)
 	}

--- a/scheduler/post_tp_sl_test.go
+++ b/scheduler/post_tp_sl_test.go
@@ -617,7 +617,7 @@ func TestRunPostTPStopLossAdjustment_BreakevenAfterTP1(t *testing.T) {
 	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
 	var mu sync.RWMutex
 
-	if !runPostTPStopLossAdjustment(sc, state, "ETH", 105, nil, &mu, nil, nil) {
+	if !runPostTPStopLossAdjustment(sc, state, "ETH", 105, nil, &mu, nil, nil, nil) {
 		t.Fatal("expected runPostTPStopLossAdjustment to apply")
 	}
 
@@ -660,8 +660,8 @@ func TestRunPostTPStopLossAdjustment_Idempotent(t *testing.T) {
 	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
 	var mu sync.RWMutex
 
-	runPostTPStopLossAdjustment(sc, state, "ETH", 105, nil, &mu, nil, nil)
-	runPostTPStopLossAdjustment(sc, state, "ETH", 105, nil, &mu, nil, nil)
+	runPostTPStopLossAdjustment(sc, state, "ETH", 105, nil, &mu, nil, nil, nil)
+	runPostTPStopLossAdjustment(sc, state, "ETH", 105, nil, &mu, nil, nil, nil)
 	if calls != 1 {
 		t.Fatalf("expected exactly 1 subprocess call, got %d", calls)
 	}
@@ -691,7 +691,7 @@ func TestRunPostTPStopLossAdjustment_TrailFromHereTransition(t *testing.T) {
 	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
 	var mu sync.RWMutex
 
-	if !runPostTPStopLossAdjustment(sc, state, "ETH", 110, nil, &mu, nil, nil) {
+	if !runPostTPStopLossAdjustment(sc, state, "ETH", 110, nil, &mu, nil, nil, nil) {
 		t.Fatal("expected runPostTPStopLossAdjustment to apply")
 	}
 	// trail_from_here at mark=110, ATR=5, mult=1.0 → trigger = 110 - 5 = 105
@@ -732,7 +732,7 @@ func TestRunPostTPStopLossAdjustment_TrailDefersWithoutMark(t *testing.T) {
 	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
 	var mu sync.RWMutex
 
-	if runPostTPStopLossAdjustment(sc, state, "ETH", 0, nil, &mu, nil, nil) {
+	if runPostTPStopLossAdjustment(sc, state, "ETH", 0, nil, &mu, nil, nil, nil) {
 		t.Fatal("expected runPostTPStopLossAdjustment to defer without mark")
 	}
 	if calls != 0 {
@@ -765,7 +765,7 @@ func TestRunPostTPStopLossAdjustment_NoRulesShortCircuits(t *testing.T) {
 	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
 	var mu sync.RWMutex
 
-	if runPostTPStopLossAdjustment(sc, state, "ETH", 105, nil, &mu, nil, nil) {
+	if runPostTPStopLossAdjustment(sc, state, "ETH", 105, nil, &mu, nil, nil, nil) {
 		t.Fatal("expected runPostTPStopLossAdjustment to return false when no rules configured")
 	}
 	if calls != 0 {
@@ -796,11 +796,81 @@ func TestRunPostTPStopLossAdjustment_DefersWhenSLNotArmed(t *testing.T) {
 	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
 	var mu sync.RWMutex
 
-	if runPostTPStopLossAdjustment(sc, state, "ETH", 105, nil, &mu, nil, nil) {
+	if runPostTPStopLossAdjustment(sc, state, "ETH", 105, nil, &mu, nil, nil, nil) {
 		t.Fatal("expected defer when SL OID is 0")
 	}
 	if calls != 0 {
 		t.Errorf("subprocess should not be called; got %d", calls)
+	}
+}
+
+// #714: SL replace must cap at on-chain qty when virtual > on-chain (e.g. a
+// manual TP shrank on-chain before the reconciler caught up). Mirrors the
+// trailing/fixed-ATR SL placement sites that already use hlSLEffectiveQty.
+func TestRunPostTPStopLossAdjustment_CapsAtOnChainQty(t *testing.T) {
+	old := runHyperliquidUpdateStopLossFunc
+	defer func() { runHyperliquidUpdateStopLossFunc = old }()
+
+	var gotQty float64
+	runHyperliquidUpdateStopLossFunc = func(_, _, _ string, size, triggerPx float64, _ int64) (*HyperliquidStopLossUpdateResult, string, error) {
+		gotQty = size
+		return &HyperliquidStopLossUpdateResult{StopLossOID: 999, StopLossTriggerPx: triggerPx}, "", nil
+	}
+
+	sc := postTPSLTestStrategy("breakeven", []interface{}{
+		map[string]interface{}{"atr_multiple": 2, "close_fraction": 0.5},
+		map[string]interface{}{"atr_multiple": 3, "close_fraction": 1.0},
+	})
+	pos := &Position{
+		Symbol: "ETH", Quantity: 1.0, InitialQuantity: 2.0,
+		AvgCost: 100, EntryATR: 5, Side: "long",
+		StopLossOID: 111, StopLossTriggerPx: 95,
+		TPOIDs:                   []int64{0, 222},
+		SLAdjustedTiersProcessed: 0,
+	}
+	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
+	var mu sync.RWMutex
+
+	onChain := map[string]float64{"ETH": 0.7}
+	if !runPostTPStopLossAdjustment(sc, state, "ETH", 105, nil, &mu, nil, nil, onChain) {
+		t.Fatal("expected runPostTPStopLossAdjustment to apply")
+	}
+	if gotQty != 0.7 {
+		t.Fatalf("subprocess size=%v, want 0.7 (capped at on-chain)", gotQty)
+	}
+}
+
+// Confirms the no-cap path: when on-chain >= virtual (or map is nil/missing),
+// the subprocess receives the virtual qty unchanged.
+func TestRunPostTPStopLossAdjustment_NoCapWhenOnChainGEVirtual(t *testing.T) {
+	old := runHyperliquidUpdateStopLossFunc
+	defer func() { runHyperliquidUpdateStopLossFunc = old }()
+
+	var gotQty float64
+	runHyperliquidUpdateStopLossFunc = func(_, _, _ string, size, triggerPx float64, _ int64) (*HyperliquidStopLossUpdateResult, string, error) {
+		gotQty = size
+		return &HyperliquidStopLossUpdateResult{StopLossOID: 999, StopLossTriggerPx: triggerPx}, "", nil
+	}
+
+	sc := postTPSLTestStrategy("breakeven", []interface{}{
+		map[string]interface{}{"atr_multiple": 2, "close_fraction": 0.5},
+		map[string]interface{}{"atr_multiple": 3, "close_fraction": 1.0},
+	})
+	pos := &Position{
+		Symbol: "ETH", Quantity: 1.0, InitialQuantity: 2.0,
+		AvgCost: 100, EntryATR: 5, Side: "long",
+		StopLossOID: 111, StopLossTriggerPx: 95,
+		TPOIDs:                   []int64{0, 222},
+		SLAdjustedTiersProcessed: 0,
+	}
+	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
+	var mu sync.RWMutex
+
+	if !runPostTPStopLossAdjustment(sc, state, "ETH", 105, nil, &mu, nil, nil, map[string]float64{"ETH": 1.0}) {
+		t.Fatal("expected runPostTPStopLossAdjustment to apply")
+	}
+	if gotQty != 1.0 {
+		t.Fatalf("subprocess size=%v, want 1.0 (uncapped)", gotQty)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Thread `hlOnChainAbsQty map[string]float64` into `runPostTPStopLossAdjustment` and apply `hlSLEffectiveQty` before the cancel+replace subprocess call
- Mirrors the identical cap already applied at the trailing-stop walker (`main.go:1491`) and fixed-ATR arm (`main.go:1549`)
- All three call sites in `main.go` (perps idle cycle, perps post-trade, manual) updated; `hlOnChainAbsQty` is already in scope at all three (built at `main.go:1168`)

## Why

After a TP tier fills, on-chain qty drops below virtual qty until the reconciler/protection-sync books the fill. `runPostTPStopLossAdjustment` was passing the stale virtual qty as the size for a reduce-only trigger order, which HL rejects as oversized. This is the exact scenario `sl_after` targets.

## Test plan

- `TestRunPostTPStopLossAdjustment_CapsAtOnChainQty` — asserts subprocess receives `0.7` when virtual=`1.0` / on-chain=`0.7`
- `TestRunPostTPStopLossAdjustment_NoCapWhenOnChainGEVirtual` — asserts no cap when on-chain matches virtual
- All existing `TestRunPostTPStopLossAdjustment_*` tests pass with `nil` map (no-op path)
- Full `go test .` suite green (24.8s)

Closes #714

---
LLM: Claude Opus 4.7 | high