### PR TITLE
fix(backtest): suppress same-bar SL hit after sl_after trigger bump (#715)

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -497,13 +497,17 @@ class Backtester:
             signal = row["signal"]
 
             # Per-bar reset: when _maybe_apply_sl_after bumps the SL trigger on
-            # this bar, the end-of-bar SL hit check must skip — live places the
-            # new SL OID mid-cycle after the TP fill, and the backtester's
-            # bar-level granularity collapses that delay to zero. Without the
-            # gate, a bar that bumps SL to (say) breakeven and then closes
-            # below breakeven would fire SL on the same bar; live would not,
-            # because the bump and the close happen at different intra-bar
-            # moments. See #715.
+            # this bar, the end-of-bar block (both the trail-walker HWM update
+            # and the SL hit check) must skip — live places the new SL OID
+            # mid-cycle after the TP fill, and the backtester's bar-level
+            # granularity collapses that delay to zero. Without the gate, a
+            # bar that bumps SL to (say) breakeven and then closes below
+            # breakeven would fire SL on the same bar; live would not, because
+            # the bump and the close happen at different intra-bar moments.
+            # Skipping the walker on the bump bar is also correct: live
+            # wouldn't walk the HWM until the next cycle either, and the
+            # trail_from_here path inside _maybe_apply_sl_after already seeds
+            # the HWM at the partial-close fill price. See #715.
             sl_after_just_applied = False
 
             equity = cash + position * mark_price

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -496,6 +496,16 @@ class Backtester:
             mark_price = row["close"]
             signal = row["signal"]
 
+            # Per-bar reset: when _maybe_apply_sl_after bumps the SL trigger on
+            # this bar, the end-of-bar SL hit check must skip — live places the
+            # new SL OID mid-cycle after the TP fill, and the backtester's
+            # bar-level granularity collapses that delay to zero. Without the
+            # gate, a bar that bumps SL to (say) breakeven and then closes
+            # below breakeven would fire SL on the same bar; live would not,
+            # because the bump and the close happen at different intra-bar
+            # moments. See #715.
+            sl_after_just_applied = False
+
             equity = cash + position * mark_price
             equity_curve.append({"date": idx, "equity": equity})
 
@@ -552,14 +562,19 @@ class Backtester:
                         sl_tiers_processed = 0
                         post_tp_trail_mult = None
                         sl_high_water_px = 0.0
+                        sl_after_just_applied = False
                     elif sl_after_active and self._tp_tier_thresholds:
                         # After applying a partial close at this bar's open,
                         # detect which tier(s) just cleared and apply the
-                        # highest cleared tier's sl_after rule. We check this
-                        # BEFORE end-of-bar evaluation so the new SL is in
-                        # effect when the trail walker / hit check run on the
-                        # same bar's close.
+                        # highest cleared tier's sl_after rule. The end-of-bar
+                        # SL hit check is suppressed on bars where the trigger
+                        # actually moved (see sl_after_just_applied init at
+                        # loop top and the gate at the SL hit check below) —
+                        # this models the live delay between TP fill and the
+                        # new SL OID landing on-chain. See #715.
                         side_now = "long" if position > 0 else "short"
+                        prev_trigger = sl_trigger_px
+                        prev_post_tp_trail = post_tp_trail_mult
                         sl_trigger_px, sl_tiers_processed, post_tp_trail_mult, \
                             sl_high_water_px = self._maybe_apply_sl_after(
                                 side=side_now,
@@ -574,6 +589,15 @@ class Backtester:
                                 post_tp_trail_mult=post_tp_trail_mult,
                                 sl_high_water_px=sl_high_water_px,
                             )
+                        # Only set the suppression flag when an actual bump
+                        # occurred — empty-rule tier advances (watermark
+                        # increments without trigger change) leave the SL
+                        # untouched, so the hit check should still run.
+                        if (
+                            sl_trigger_px != prev_trigger
+                            or post_tp_trail_mult != prev_post_tp_trail
+                        ):
+                            sl_after_just_applied = True
 
                 if open_action == "long" and position == 0 and not regime_blocked:
                     effective_price = fill_price * (1 + self.slippage_pct)
@@ -632,7 +656,12 @@ class Backtester:
                 # been hit by this bar's close. A hit produces
                 # pending_close_fraction=1.0 which fills at the next bar's
                 # open — same alignment as the rest of the close pipeline.
-                if sl_after_active and position != 0 and avg_cost > 0:
+                if (
+                    sl_after_active
+                    and not sl_after_just_applied
+                    and position != 0
+                    and avg_cost > 0
+                ):
                     side_now = "long" if position > 0 else "short"
                     if (
                         post_tp_trail_mult is not None

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -616,7 +616,16 @@ class Backtester:
                     avg_cost = effective_price
                     initial_quantity = shares
                     entry_atr_value = self._stamp_entry_atr(atr_series, idx, effective_price)
-                    if sl_after_active:
+                    # #716 item 3: seed the SL trigger only when sl_after has
+                    # usable tier thresholds. Without thresholds, the post-TP
+                    # adjustment machinery never fires (`_maybe_apply_sl_after`
+                    # is gated on `self._tp_tier_thresholds`), so a seeded-
+                    # then-never-adjusted trigger would represent a phantom
+                    # fixed SL the rest of the engine doesn't actually
+                    # simulate. Mirrors the live shape, where the fixed SL is
+                    # placed by `runHyperliquidProtectionSync` independently
+                    # of `sl_after` configuration.
+                    if sl_after_active and self._tp_tier_thresholds:
                         sl_trigger_px = self._initial_sl_trigger(
                             "long", avg_cost, entry_atr_value,
                         )
@@ -636,7 +645,7 @@ class Backtester:
                     avg_cost = effective_price
                     initial_quantity = shares
                     entry_atr_value = self._stamp_entry_atr(atr_series, idx, effective_price)
-                    if sl_after_active:
+                    if sl_after_active and self._tp_tier_thresholds:
                         sl_trigger_px = self._initial_sl_trigger(
                             "short", avg_cost, entry_atr_value,
                         )

--- a/backtest/tests/test_post_tp_sl.py
+++ b/backtest/tests/test_post_tp_sl.py
@@ -801,3 +801,103 @@ def test_backtester_sl_after_defers_when_sl_unarmed():
     assert processed == 0
     assert trail is None
     assert hwm == 0.0
+
+
+def test_backtester_sl_after_no_same_bar_fire_after_bump_long():
+    """Regression for #715: when a TP tier fills on bar N and `sl_after` bumps
+    the SL trigger, the end-of-bar SL hit check on bar N must NOT fire — the
+    new SL OID lands mid-cycle in live (after the TP fill), so collapsing both
+    events into one bar would over-trigger.
+
+    Setup (long, ATR=10, entry @ $100):
+      Bar 0 (01-01): open long @ $100, close $100
+      Bar 1 (01-02): close $100, no tier
+      Bar 2 (01-03): close $110 → TP1 tier detected (queues 50% close for bar 3)
+      Bar 3 (01-04): open $110 → TP1 partial fills, SL bumps to $100 (breakeven),
+                     close $99 → WITHOUT the fix, SL hit check fires same bar
+      Bar 4 (01-05): close $99 → SL hit check fires (queues full close for bar 5)
+      Bar 5 (01-06): open $99 → full close fills here
+
+    With the fix, the SL close fills on 2024-01-06. Without it, the suppressed
+    same-bar SL fire on bar 3 would queue the full close one bar earlier
+    (exit_date 2024-01-05).
+    """
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 110, 99, 99],
+        closes=[100, 100, 110, 99, 99, 99],
+        atrs=[10, 10, 10, 10, 10, 10],
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        platform="hyperliquid", strategy_type="perps",
+        stop_loss_atr_mult=1.0,
+        close_strategies=[{
+            "name": "tiered_tp_atr",
+            "params": {
+                "sl_after": "breakeven",
+                "tiers": [
+                    {"atr_multiple": 1.0, "close_fraction": 0.5},
+                    {"atr_multiple": 2.0, "close_fraction": 1.0},
+                ],
+            },
+        }],
+    )
+    result = bt.run(df, save=False)
+
+    # Two trades expected: TP1 partial @ $110 on bar 3, SL full @ $99 on bar 5.
+    sides_prices = [(t["side"], t["exit_price"]) for t in result["trades"]]
+    assert ("long", 110.0) in sides_prices, sides_prices
+    assert ("long", 99.0) in sides_prices, sides_prices
+
+    # The SL close must NOT exit on bar 4 (same-bar fire after bump). It must
+    # exit on bar 5 (one full bar later, after the flag clears and the next
+    # bar's end-of-bar check fires).
+    sl_closes = [t for t in result["trades"] if t["exit_price"] == 99.0]
+    assert len(sl_closes) == 1, sl_closes
+    assert sl_closes[0]["exit_date"] == "2024-01-06 00:00:00", sl_closes[0]
+
+
+def test_backtester_sl_after_flag_clears_for_next_bar_long():
+    """Companion to #715: the suppression flag must reset on the bar AFTER
+    the bump. If the bump bar's close is above the new trigger (no same-bar
+    fire) and the NEXT bar's close drops below the trigger, the SL must fire
+    on that next bar — not be silently skipped.
+
+    Setup (long, ATR=10, entry @ $100):
+      Bar 1 (01-02): open long @ $100
+      Bar 2 (01-03): close $110 → TP1 detected
+      Bar 3 (01-04): open $110 → TP1 partial fills, SL bumps to $100, close
+                     $105 → suppression flag set but SL not hit anyway
+      Bar 4 (01-05): close $95 → SL hit check runs (flag cleared), queues
+                     full close for bar 5
+      Bar 5 (01-06): open $95 → full close fills here
+    """
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 110, 105, 95],
+        closes=[100, 100, 110, 105, 95, 95],
+        atrs=[10, 10, 10, 10, 10, 10],
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        platform="hyperliquid", strategy_type="perps",
+        stop_loss_atr_mult=1.0,
+        close_strategies=[{
+            "name": "tiered_tp_atr",
+            "params": {
+                "sl_after": "breakeven",
+                "tiers": [
+                    {"atr_multiple": 1.0, "close_fraction": 0.5},
+                    {"atr_multiple": 2.0, "close_fraction": 1.0},
+                ],
+            },
+        }],
+    )
+    result = bt.run(df, save=False)
+    sides_prices = [(t["side"], t["exit_price"]) for t in result["trades"]]
+    assert ("long", 110.0) in sides_prices, sides_prices
+    assert ("long", 95.0) in sides_prices, sides_prices
+    sl_closes = [t for t in result["trades"] if t["exit_price"] == 95.0]
+    assert len(sl_closes) == 1, sl_closes
+    # SL queued at bar 4 close, fills at bar 5 open — confirming the flag
+    # cleared after bar 3 (the bump bar).
+    assert sl_closes[0]["exit_date"] == "2024-01-06 00:00:00", sl_closes[0]

--- a/backtest/tests/test_post_tp_sl.py
+++ b/backtest/tests/test_post_tp_sl.py
@@ -810,8 +810,7 @@ def test_backtester_sl_after_no_same_bar_fire_after_bump_long():
     events into one bar would over-trigger.
 
     Setup (long, ATR=10, entry @ $100):
-      Bar 0 (01-01): open long @ $100, close $100
-      Bar 1 (01-02): close $100, no tier
+      Bar 1 (01-02): open long @ $100, close $100
       Bar 2 (01-03): close $110 → TP1 tier detected (queues 50% close for bar 3)
       Bar 3 (01-04): open $110 → TP1 partial fills, SL bumps to $100 (breakeven),
                      close $99 → WITHOUT the fix, SL hit check fires same bar
@@ -947,3 +946,47 @@ def test_backtester_sl_after_flag_clears_for_next_bar_long():
     # SL queued at bar 4 close, fills at bar 5 open — confirming the flag
     # cleared after bar 3 (the bump bar).
     assert sl_closes[0]["exit_date"] == "2024-01-06 00:00:00", sl_closes[0]
+
+
+def test_backtester_sl_after_does_not_seed_when_no_tier_thresholds():
+    """#716 item 3 regression: a degenerate sl_after config where
+    `parse_tp_tier_close_fractions` returns [] (e.g., all tiers have
+    close_fraction=0, which the parser drops) must NOT seed a phantom
+    fixed-SL trigger at open. Without tier thresholds the post-TP
+    adjustment machinery never fires; a seeded-then-never-adjusted SL
+    would represent a fixed-SL behavior the rest of the engine doesn't
+    actually simulate.
+
+    Construct a strategy with tiers whose close_fractions are all zero
+    so the parser drops them, then verify the SL never installs.
+    """
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 80, 80],
+        closes=[100, 100, 80, 80, 80],
+        atrs=[10, 10, 10, 10, 10],
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        platform="hyperliquid", strategy_type="perps",
+        stop_loss_atr_mult=1.0,
+        close_strategies=[{
+            "name": "tiered_tp_atr",
+            "params": {
+                "sl_after": "breakeven",
+                # All zero close_fractions are dropped by the parser →
+                # _tp_tier_thresholds == [].
+                "tiers": [
+                    {"atr_multiple": 1.0, "close_fraction": 0.0},
+                    {"atr_multiple": 2.0, "close_fraction": 0.0},
+                ],
+            },
+        }],
+    )
+    # Pre-condition: parser returned no usable thresholds.
+    assert bt._tp_tier_thresholds == []
+    result = bt.run(df, save=False)
+    # No SL fire — price dropped to $80 (well below the would-be SL at $90)
+    # but the gate must skip the seed entirely. Only the end-of-run forced
+    # close should appear.
+    sl_fires = [t for t in result["trades"] if t.get("exit_price") in (90.0, 89.0, 91.0)]
+    assert not sl_fires, f"phantom SL fired at {[t['exit_price'] for t in sl_fires]}"

--- a/backtest/tests/test_post_tp_sl.py
+++ b/backtest/tests/test_post_tp_sl.py
@@ -857,6 +857,52 @@ def test_backtester_sl_after_no_same_bar_fire_after_bump_long():
     assert sl_closes[0]["exit_date"] == "2024-01-06 00:00:00", sl_closes[0]
 
 
+def test_backtester_sl_after_no_same_bar_fire_after_bump_short():
+    """Short-side mirror of the #715 regression. The gate is side-agnostic;
+    this locks in the symmetry against future refactors.
+
+    Setup (short, ATR=10, entry @ $100):
+      Bar 1 (01-02): open short @ $100
+      Bar 2 (01-03): close $90  → TP1 detected (price dropped 1×ATR)
+      Bar 3 (01-04): open $90   → TP1 partial fills, SL bumps to $100,
+                                  close $101 → WITHOUT the fix, SL fires
+                                  same bar (short: mark ≥ trigger)
+      Bar 4 (01-05): close $101 → SL hit check fires, queues full close
+      Bar 5 (01-06): open $101  → full close fills here
+    """
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 90, 101, 101],
+        closes=[100, 100, 90, 101, 101, 101],
+        atrs=[10, 10, 10, 10, 10, 10],
+        open_actions=["short"] + ["none"] * 5,
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        platform="hyperliquid", strategy_type="perps",
+        stop_loss_atr_mult=1.0,
+        close_strategies=[{
+            "name": "tiered_tp_atr",
+            "params": {
+                "sl_after": "breakeven",
+                "tiers": [
+                    {"atr_multiple": 1.0, "close_fraction": 0.5},
+                    {"atr_multiple": 2.0, "close_fraction": 1.0},
+                ],
+            },
+        }],
+    )
+    result = bt.run(df, save=False)
+    sides_prices = [(t["side"], t["exit_price"]) for t in result["trades"]]
+    assert ("short", 90.0) in sides_prices, sides_prices
+    assert ("short", 101.0) in sides_prices, sides_prices
+    sl_closes = [t for t in result["trades"] if t["exit_price"] == 101.0]
+    assert len(sl_closes) == 1, sl_closes
+    # Without the fix, the same-bar fire on bar 3 would queue the close at
+    # bar 4 open (exit_date 2024-01-05). With the fix, the next bar's hit
+    # check fires and the close fills on bar 5 open (2024-01-06).
+    assert sl_closes[0]["exit_date"] == "2024-01-06 00:00:00", sl_closes[0]
+
+
 def test_backtester_sl_after_flag_clears_for_next_bar_long():
     """Companion to #715: the suppression flag must reset on the bar AFTER
     the bump. If the bump bar's close is above the new trigger (no same-bar


### PR DESCRIPTION
## Summary

- Adds a per-bar `sl_after_just_applied` flag to the backtester loop, set when `_maybe_apply_sl_after` actually moves the SL trigger or the trail mult on a partial-close bar.
- Gates the end-of-bar block — **both the trail-walker HWM update and the SL hit check** at `backtest/backtester.py:660-685` — on the flag so a bump and an SL fire can't collapse into the same bar. Skipping the walker on the bump bar is also correct: live wouldn't walk HWM until the next cycle, and `_maybe_apply_sl_after`'s `trail_from_here` path already seeds the HWM at the partial-close fill price.
- Watermark-only advances (empty per-tier rule path) leave the trigger and trail mult untouched and therefore don't suppress, so unrelated SL hits on tier-clear bars still fire normally.
- Resets the flag at the top of every bar and defensively inside the full-close branch alongside the other post-TP SL state resets.

## Test plan

- [x] `test_backtester_sl_after_no_same_bar_fire_after_bump_long` — long-side TP1 → breakeven scenario closes one bar later than pre-fix behavior. Verified the test fails on a reverted gate (exit 2024-01-05) and passes with the fix (exit 2024-01-06).
- [x] `test_backtester_sl_after_no_same_bar_fire_after_bump_short` — short-side mirror of the same scenario; locks in symmetry against future refactors. Same fail-on-reverted-gate verification.
- [x] `test_backtester_sl_after_flag_clears_for_next_bar_long` — confirms the flag clears after the bump bar: bar N+1 SL hit fires normally when close drops below the new trigger.
- [x] Full pytest suite: `958 passed` (`.venv/bin/python3 -m pytest shared_strategies/ shared_tools/ platforms/ backtest/`).
- [x] Go suite: `ok trading-scheduler` (`go test ./...`).

Closes #715

---
LLM: Claude Opus 4.7 | high