### PR TITLE
sl_after / inspect follow-ups from #707, #710, #712 review

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -588,7 +588,16 @@ class Backtester:
                     avg_cost = effective_price
                     initial_quantity = shares
                     entry_atr_value = self._stamp_entry_atr(atr_series, idx, effective_price)
-                    if sl_after_active:
+                    # #716 item 3: seed the SL trigger only when sl_after has
+                    # usable tier thresholds. Without thresholds, the post-TP
+                    # adjustment machinery never fires (`_maybe_apply_sl_after`
+                    # is gated on `self._tp_tier_thresholds`), so a seeded-
+                    # then-never-adjusted trigger would represent a phantom
+                    # fixed SL the rest of the engine doesn't actually
+                    # simulate. Mirrors the live shape, where the fixed SL is
+                    # placed by `runHyperliquidProtectionSync` independently
+                    # of `sl_after` configuration.
+                    if sl_after_active and self._tp_tier_thresholds:
                         sl_trigger_px = self._initial_sl_trigger(
                             "long", avg_cost, entry_atr_value,
                         )
@@ -608,7 +617,7 @@ class Backtester:
                     avg_cost = effective_price
                     initial_quantity = shares
                     entry_atr_value = self._stamp_entry_atr(atr_series, idx, effective_price)
-                    if sl_after_active:
+                    if sl_after_active and self._tp_tier_thresholds:
                         sl_trigger_px = self._initial_sl_trigger(
                             "short", avg_cost, entry_atr_value,
                         )

--- a/backtest/tests/test_post_tp_sl.py
+++ b/backtest/tests/test_post_tp_sl.py
@@ -801,3 +801,47 @@ def test_backtester_sl_after_defers_when_sl_unarmed():
     assert processed == 0
     assert trail is None
     assert hwm == 0.0
+
+
+def test_backtester_sl_after_does_not_seed_when_no_tier_thresholds():
+    """#716 item 3 regression: a degenerate sl_after config where
+    `parse_tp_tier_close_fractions` returns [] (e.g., all tiers have
+    close_fraction=0, which the parser drops) must NOT seed a phantom
+    fixed-SL trigger at open. Without tier thresholds the post-TP
+    adjustment machinery never fires; a seeded-then-never-adjusted SL
+    would represent a fixed-SL behavior the rest of the engine doesn't
+    actually simulate.
+
+    Construct a strategy with tiers whose close_fractions are all zero
+    so the parser drops them, then verify the SL never installs.
+    """
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 80, 80],
+        closes=[100, 100, 80, 80, 80],
+        atrs=[10, 10, 10, 10, 10],
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        platform="hyperliquid", strategy_type="perps",
+        stop_loss_atr_mult=1.0,
+        close_strategies=[{
+            "name": "tiered_tp_atr",
+            "params": {
+                "sl_after": "breakeven",
+                # All zero close_fractions are dropped by the parser →
+                # _tp_tier_thresholds == [].
+                "tiers": [
+                    {"atr_multiple": 1.0, "close_fraction": 0.0},
+                    {"atr_multiple": 2.0, "close_fraction": 0.0},
+                ],
+            },
+        }],
+    )
+    # Pre-condition: parser returned no usable thresholds.
+    assert bt._tp_tier_thresholds == []
+    result = bt.run(df, save=False)
+    # No SL fire — price dropped to $80 (well below the would-be SL at $90)
+    # but the gate must skip the seed entirely. Only the end-of-run forced
+    # close should appear.
+    sl_fires = [t for t in result["trades"] if t.get("exit_price") in (90.0, 89.0, 91.0)]
+    assert not sl_fires, f"phantom SL fired at {[t['exit_price'] for t in sl_fires]}"

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -358,6 +358,20 @@ func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error 
 					sc.ID))
 			}
 		}
+		// #716 item 1: sl_after rules are armed at the next cleared TP tier; a
+		// mid-position add/remove/mode change would engage the post-TP machinery
+		// (and, for trail_from_here, the trailing walker) without the validation
+		// the open respected. Numeric mult changes are also gated because they
+		// alter the trigger target a future tier-fill will install — operators
+		// must flatten to opt into the new rule set.
+		if (sc.Type == "perps" || sc.Type == "manual") && sc.Platform == "hyperliquid" && strategyHasOpenPositions(stateStrategy(state, sc.ID)) {
+			oldRules, _ := parseStrategyTPSLAfterRules(sc)
+			newRules, _ := parseStrategyTPSLAfterRules(ns)
+			if !oldRules.EqualForReload(newRules) {
+				errs = append(errs, fmt.Sprintf("strategy[%s] sl_after rules changed with open positions (flatten first or restart after close)",
+					sc.ID))
+			}
+		}
 	}
 	if len(errs) > 0 {
 		sort.Strings(errs)

--- a/scheduler/config_reload_test.go
+++ b/scheduler/config_reload_test.go
@@ -482,6 +482,151 @@ func TestApplyHotReloadConfigRejectsDirectionChangeWithOpenPerpsPosition(t *test
 	}
 }
 
+// #716 item 1 — adding an sl_after rule while a position is open must be
+// rejected. Without this guard, the new rule would engage on the next cleared
+// tier (post-TP machinery + trailing walker for trail_from_here) without the
+// validation the open respected.
+func TestApplyHotReloadConfigRejectsSLAfterAddWithOpenPosition(t *testing.T) {
+	tieredOpen := []StrategyRef{{
+		Name: "tiered_tp_atr",
+		Params: map[string]interface{}{
+			"tiers": []interface{}{
+				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.5},
+				map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
+			},
+		},
+	}}
+	tieredWithSLAfter := []StrategyRef{{
+		Name: "tiered_tp_atr",
+		Params: map[string]interface{}{
+			"sl_after": "breakeven",
+			"tiers": []interface{}{
+				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.5},
+				map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
+			},
+		},
+	}}
+	slMult := 1.5
+	cfg := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
+		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
+		CloseStrategies: tieredOpen,
+	}})
+	next := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
+		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
+		CloseStrategies: tieredWithSLAfter,
+	}})
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long"},
+		}},
+	}}
+
+	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
+	if err == nil {
+		t.Fatal("expected hot reload to reject sl_after addition with open position")
+	}
+	if !strings.Contains(err.Error(), "sl_after rules changed with open positions") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// #716 item 1 — sl_after rule changes are allowed when the strategy is flat.
+func TestApplyHotReloadConfigAllowsSLAfterAddWhenFlat(t *testing.T) {
+	tieredOpen := []StrategyRef{{
+		Name: "tiered_tp_atr",
+		Params: map[string]interface{}{
+			"tiers": []interface{}{
+				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
+			},
+		},
+	}}
+	tieredWithSLAfter := []StrategyRef{{
+		Name: "tiered_tp_atr",
+		Params: map[string]interface{}{
+			"sl_after": "breakeven",
+			"tiers": []interface{}{
+				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
+			},
+		},
+	}}
+	slMult := 1.5
+	cfg := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
+		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
+		CloseStrategies: tieredOpen,
+	}})
+	next := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
+		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
+		CloseStrategies: tieredWithSLAfter,
+	}})
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-eth": {ID: "hl-eth", Cash: 1000, Positions: map[string]*Position{}},
+	}}
+
+	if _, err := applyHotReloadConfig(cfg, next, state, nil, nil); err != nil {
+		t.Fatalf("expected sl_after change to be allowed when flat, got: %v", err)
+	}
+}
+
+// #716 item 1 — switching from breakeven to trail_from_here mid-position is
+// the highest-risk transition (engages trailing walker without open validation).
+func TestApplyHotReloadConfigRejectsSLAfterModeChangeWithOpenPosition(t *testing.T) {
+	tierWithBreakeven := []StrategyRef{{
+		Name: "tiered_tp_atr",
+		Params: map[string]interface{}{
+			"sl_after": "breakeven",
+			"tiers": []interface{}{
+				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
+			},
+		},
+	}}
+	tierWithTrail := []StrategyRef{{
+		Name: "tiered_tp_atr",
+		Params: map[string]interface{}{
+			"sl_after": map[string]interface{}{
+				"kind":            "trail_from_here",
+				"trail_from_here": map[string]interface{}{"atr_mult": 1.0},
+			},
+			"tiers": []interface{}{
+				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
+			},
+		},
+	}}
+	slMult := 1.5
+	cfg := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
+		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
+		CloseStrategies: tierWithBreakeven,
+	}})
+	next := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
+		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
+		CloseStrategies: tierWithTrail,
+	}})
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long"},
+		}},
+	}}
+
+	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
+	if err == nil {
+		t.Fatal("expected hot reload to reject sl_after mode switch")
+	}
+	if !strings.Contains(err.Error(), "sl_after rules changed with open positions") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // #656 — direction change is allowed when the strategy is flat.
 func TestApplyHotReloadConfigAllowsDirectionChangeWhenFlat(t *testing.T) {
 	cfg := minimalReloadConfig([]StrategyConfig{{

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -395,10 +395,11 @@ func parseTPOIDsJSON(raw string, legacyTP1, legacyTP2 int64) []int64 {
 }
 
 // marshalTPArmedTiersJSON / parseTPArmedTiersJSON persist Position.TPArmedTiers
-// (#716 item 2). Empty array marshals to "" so legacy DB rows (column added
-// with DEFAULT '') round-trip cleanly. parseTPArmedTiersJSON returns nil for
-// empty/malformed input — callers treat nil as "legacy row, assume armed-for-
-// any-OID-currently-positive" via backfillTPArmedTiers below.
+// (#716 item 2). An empty slice marshals to the empty string so legacy DB
+// rows (column added with an empty default) round-trip cleanly.
+// parseTPArmedTiersJSON returns nil for empty or malformed input; callers
+// treat nil as a legacy row and rely on backfillTPArmedTiers below to
+// assume any tier with a positive OID was armed.
 func marshalTPArmedTiersJSON(armed []bool) string {
 	if len(armed) == 0 {
 		return ""

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -76,6 +76,7 @@ CREATE TABLE IF NOT EXISTS positions (
     tp1_oid INTEGER NOT NULL DEFAULT 0,
     tp2_oid INTEGER NOT NULL DEFAULT 0,
     tp_oids_json TEXT NOT NULL DEFAULT '',
+    tp_armed_tiers_json TEXT NOT NULL DEFAULT '',
     stop_loss_atr_mult REAL,
     tp_tiers_json TEXT NOT NULL DEFAULT '',
     sl_adjusted_tiers_processed INTEGER NOT NULL DEFAULT 0,
@@ -332,6 +333,11 @@ func (sdb *StateDB) migrateSchema() error {
 		// needs a backfill for legacy rows.
 		"ALTER TABLE positions ADD COLUMN sl_adjusted_tiers_processed INTEGER NOT NULL DEFAULT 0",
 		"ALTER TABLE positions ADD COLUMN post_tp_trailing_atr_mult REAL",
+		// Per-tier "was ever armed" tracking so a tier whose first placement
+		// failed (OID=0, never armed) can be distinguished from a tier that
+		// filled (OID=0 after Python zeros it). Empty string = legacy row;
+		// findHighestClearedTier degrades to legacy behavior for those (#716).
+		"ALTER TABLE positions ADD COLUMN tp_armed_tiers_json TEXT NOT NULL DEFAULT ''",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -386,6 +392,53 @@ func parseTPOIDsJSON(raw string, legacyTP1, legacyTP2 int64) []int64 {
 		oids = []int64{legacyTP1, legacyTP2}
 	}
 	return oids
+}
+
+// marshalTPArmedTiersJSON / parseTPArmedTiersJSON persist Position.TPArmedTiers
+// (#716 item 2). Empty array marshals to "" so legacy DB rows (column added
+// with DEFAULT '') round-trip cleanly. parseTPArmedTiersJSON returns nil for
+// empty/malformed input — callers treat nil as "legacy row, assume armed-for-
+// any-OID-currently-positive" via backfillTPArmedTiers below.
+func marshalTPArmedTiersJSON(armed []bool) string {
+	if len(armed) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(armed)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func parseTPArmedTiersJSON(raw string) []bool {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var armed []bool
+	if err := json.Unmarshal([]byte(raw), &armed); err != nil {
+		return nil
+	}
+	return armed
+}
+
+// backfillTPArmedTiers infers the armed state of legacy positions loaded from
+// rows persisted before tp_armed_tiers_json existed. A pre-#716 row carries
+// pos.TPArmedTiers == nil; we assume any tier with a positive OID at load time
+// was successfully armed at some point. Tiers with OID=0 on a legacy row are
+// left unarmed — conservative: better to skip a real fill than to fire on a
+// never-armed tier.
+func backfillTPArmedTiers(pos *Position) {
+	if pos == nil || pos.TPArmedTiers != nil {
+		return
+	}
+	if len(pos.TPOIDs) == 0 {
+		return
+	}
+	armed := make([]bool, len(pos.TPOIDs))
+	for i, oid := range pos.TPOIDs {
+		armed[i] = oid > 0
+	}
+	pos.TPArmedTiers = armed
 }
 
 // backfillTradeCloseFlags is a one-time best-effort backfill (#455) for
@@ -744,8 +797,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	}
 	defer stmtStrat.Close()
 
-	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, tp1_oid, tp2_oid, tp_oids_json, stop_loss_atr_mult, tp_tiers_json, sl_adjusted_tiers_processed, post_tp_trailing_atr_mult)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, tp1_oid, tp2_oid, tp_oids_json, tp_armed_tiers_json, stop_loss_atr_mult, tp_tiers_json, sl_adjusted_tiers_processed, post_tp_trailing_atr_mult)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare position insert: %w", err)
 	}
@@ -796,7 +849,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		for _, pos := range s.Positions {
 			positionID := ensurePositionTradeID(s.ID, pos.Symbol, pos)
 			tp1OID, tp2OID := firstTwoTPOIDs(pos.TPOIDs)
-			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx, tp1OID, tp2OID, marshalTPOIDsJSON(pos.TPOIDs), nullableFloat64(pos.StopLossATRMult), pos.TPTiersJSON, pos.SLAdjustedTiersProcessed, nullableFloat64(pos.PostTPTrailingATRMult)); err != nil {
+			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx, tp1OID, tp2OID, marshalTPOIDsJSON(pos.TPOIDs), marshalTPArmedTiersJSON(pos.TPArmedTiers), nullableFloat64(pos.StopLossATRMult), pos.TPTiersJSON, pos.SLAdjustedTiersProcessed, nullableFloat64(pos.PostTPTrailingATRMult)); err != nil {
 				return fmt.Errorf("insert position %s/%s: %w", s.ID, pos.Symbol, err)
 			}
 		}
@@ -1207,7 +1260,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	}
 
 	// 3. Load positions for each strategy.
-	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, COALESCE(tp1_oid, 0) AS tp1_oid, COALESCE(tp2_oid, 0) AS tp2_oid, COALESCE(tp_oids_json, '') AS tp_oids_json, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json, COALESCE(sl_adjusted_tiers_processed, 0) AS sl_adjusted_tiers_processed, post_tp_trailing_atr_mult FROM positions")
+	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, COALESCE(tp1_oid, 0) AS tp1_oid, COALESCE(tp2_oid, 0) AS tp2_oid, COALESCE(tp_oids_json, '') AS tp_oids_json, COALESCE(tp_armed_tiers_json, '') AS tp_armed_tiers_json, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json, COALESCE(sl_adjusted_tiers_processed, 0) AS sl_adjusted_tiers_processed, post_tp_trailing_atr_mult FROM positions")
 	if err != nil {
 		return nil, fmt.Errorf("load positions: %w", err)
 	}
@@ -1218,13 +1271,16 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		var openedAtStr string
 		var tp1OID, tp2OID int64
 		var tpOIDsJSON string
+		var tpArmedTiersJSON string
 		var slATRMult sql.NullFloat64
 		var postTPTrailingMult sql.NullFloat64
-		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx, &tp1OID, &tp2OID, &tpOIDsJSON, &slATRMult, &pos.TPTiersJSON, &pos.SLAdjustedTiersProcessed, &postTPTrailingMult); err != nil {
+		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx, &tp1OID, &tp2OID, &tpOIDsJSON, &tpArmedTiersJSON, &slATRMult, &pos.TPTiersJSON, &pos.SLAdjustedTiersProcessed, &postTPTrailingMult); err != nil {
 			return nil, fmt.Errorf("scan position: %w", err)
 		}
 		pos.OpenedAt = parseTime(openedAtStr)
 		pos.TPOIDs = parseTPOIDsJSON(tpOIDsJSON, tp1OID, tp2OID)
+		pos.TPArmedTiers = parseTPArmedTiersJSON(tpArmedTiersJSON)
+		backfillTPArmedTiers(&pos)
 		if slATRMult.Valid {
 			v := slATRMult.Float64
 			pos.StopLossATRMult = &v

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1191,6 +1191,17 @@ func tradeDirectionLabel(trade Trade) string {
 func tradeAlertCloseSource(details string) string {
 	d := strings.ToLower(details)
 	switch {
+	// #716 item 4: paper / trailing SL closes get distinct labels so an
+	// operator reading the close DM doesn't see a paper-mode trailing SL
+	// labeled "exchange SL". The paper-trailing case must be checked
+	// before plain "trailing SL close" because the latter is a substring
+	// of the former.
+	case strings.Contains(d, "paper trailing sl close"):
+		return "paper trailing SL"
+	case strings.Contains(d, "trailing sl close"):
+		return "trailing SL"
+	case strings.Contains(d, "paper sl close"):
+		return "paper SL"
 	case strings.Contains(d, "stop loss close"):
 		return "exchange SL"
 	case strings.HasPrefix(d, "tp") && strings.Contains(d, "fill close"):

--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -289,6 +289,24 @@ func applyHyperliquidProtectionSync(pos *Position, result *HyperliquidProtection
 	} else if result.TP1OID > 0 || result.TP2OID > 0 {
 		pos.TPOIDs = []int64{result.TP1OID, result.TP2OID}
 	}
+	// #716 item 2: mark tiers as armed once Python reports a positive OID for
+	// them. Done BEFORE the stale-OID clearing below so a tier that fills in
+	// the same cycle it was first armed is recorded as armed —
+	// findHighestClearedTier requires armed=true before treating OID=0 as
+	// "cleared." This distinguishes a tier that filled (armed → 0) from a
+	// tier whose first placement failed transiently (never armed, still 0).
+	if len(pos.TPOIDs) > 0 {
+		if len(pos.TPArmedTiers) < len(pos.TPOIDs) {
+			extended := make([]bool, len(pos.TPOIDs))
+			copy(extended, pos.TPArmedTiers)
+			pos.TPArmedTiers = extended
+		}
+		for i, oid := range pos.TPOIDs {
+			if oid > 0 {
+				pos.TPArmedTiers[i] = true
+			}
+		}
+	}
 	// Clear stale TP OIDs after applying the latest echoed/placed OID list.
 	// The reconciler will book externally-filled closes; here we only stop
 	// pointing at dead OIDs that would otherwise be re-placed against stale
@@ -299,20 +317,34 @@ func applyHyperliquidProtectionSync(pos *Position, result *HyperliquidProtection
 		if len(pos.TPOIDs) < len(result.TPFilledExternally) {
 			pos.TPOIDs = tpOIDsForTierCount(pos.TPOIDs, len(result.TPFilledExternally))
 		}
+		if len(pos.TPArmedTiers) < len(result.TPFilledExternally) {
+			extended := make([]bool, len(result.TPFilledExternally))
+			copy(extended, pos.TPArmedTiers)
+			pos.TPArmedTiers = extended
+		}
 		for idx, filled := range result.TPFilledExternally {
 			if filled {
 				pos.TPOIDs[idx] = 0
+				// A filled tier is by definition one that was armed.
+				pos.TPArmedTiers[idx] = true
 			}
 		}
 	} else if result.TP1FilledExternally || result.TP2FilledExternally {
 		if len(pos.TPOIDs) < 2 {
 			pos.TPOIDs = tpOIDsForTierCount(pos.TPOIDs, 2)
 		}
+		if len(pos.TPArmedTiers) < 2 {
+			extended := make([]bool, 2)
+			copy(extended, pos.TPArmedTiers)
+			pos.TPArmedTiers = extended
+		}
 		if result.TP1FilledExternally {
 			pos.TPOIDs[0] = 0
+			pos.TPArmedTiers[0] = true
 		}
 		if result.TP2FilledExternally {
 			pos.TPOIDs[1] = 0
+			pos.TPArmedTiers[1] = true
 		}
 	}
 }

--- a/scheduler/hyperliquid_protection_test.go
+++ b/scheduler/hyperliquid_protection_test.go
@@ -129,6 +129,55 @@ func TestApplyHyperliquidProtectionSyncClearsFilledExternally(t *testing.T) {
 	}
 }
 
+// #716 item 2 — applyHyperliquidProtectionSync must record TPArmedTiers[i]=true
+// whenever Python returns a positive OID for tier i, so a future cycle that
+// observes OID=0 there can distinguish "filled" from "never armed". A filled
+// tier (TPFilledExternally=true) is also armed by definition.
+func TestApplyHyperliquidProtectionSyncStampsTPArmedTiers(t *testing.T) {
+	t.Run("positive OIDs stamp armed", func(t *testing.T) {
+		pos := &Position{Symbol: "ETH"}
+		applyHyperliquidProtectionSync(pos, &HyperliquidProtectionSyncResult{
+			TPOIDs: []int64{111, 222},
+		})
+		if !reflect.DeepEqual(pos.TPArmedTiers, []bool{true, true}) {
+			t.Errorf("TPArmedTiers = %v, want [true true]", pos.TPArmedTiers)
+		}
+	})
+
+	t.Run("zero OID does not stamp armed", func(t *testing.T) {
+		pos := &Position{Symbol: "ETH"}
+		applyHyperliquidProtectionSync(pos, &HyperliquidProtectionSyncResult{
+			TPOIDs: []int64{0, 222},
+		})
+		if !reflect.DeepEqual(pos.TPArmedTiers, []bool{false, true}) {
+			t.Errorf("TPArmedTiers = %v, want [false true]", pos.TPArmedTiers)
+		}
+	})
+
+	t.Run("armed survives later fill that zeros OID", func(t *testing.T) {
+		pos := &Position{Symbol: "ETH", TPArmedTiers: []bool{true, true}}
+		applyHyperliquidProtectionSync(pos, &HyperliquidProtectionSyncResult{
+			TPOIDs:             []int64{0, 222},
+			TPFilledExternally: []bool{true, false},
+		})
+		if !reflect.DeepEqual(pos.TPArmedTiers, []bool{true, true}) {
+			t.Errorf("TPArmedTiers = %v, want [true true] (filled-externally implies armed)", pos.TPArmedTiers)
+		}
+	})
+
+	t.Run("legacy TP1FilledExternally/TP2FilledExternally extends armed slice", func(t *testing.T) {
+		pos := &Position{Symbol: "ETH"}
+		applyHyperliquidProtectionSync(pos, &HyperliquidProtectionSyncResult{
+			TP1OID:                33,
+			TP2OID:                44,
+			TP1FilledExternally:   true,
+		})
+		if len(pos.TPArmedTiers) != 2 || !pos.TPArmedTiers[0] || !pos.TPArmedTiers[1] {
+			t.Errorf("TPArmedTiers = %v, want [true true]", pos.TPArmedTiers)
+		}
+	})
+}
+
 func TestFilterCloseStrategiesForHLOnChainProtection(t *testing.T) {
 	mult := 1.0
 	cases := []struct {

--- a/scheduler/hyperliquid_protection_test.go
+++ b/scheduler/hyperliquid_protection_test.go
@@ -168,9 +168,9 @@ func TestApplyHyperliquidProtectionSyncStampsTPArmedTiers(t *testing.T) {
 	t.Run("legacy TP1FilledExternally/TP2FilledExternally extends armed slice", func(t *testing.T) {
 		pos := &Position{Symbol: "ETH"}
 		applyHyperliquidProtectionSync(pos, &HyperliquidProtectionSyncResult{
-			TP1OID:                33,
-			TP2OID:                44,
-			TP1FilledExternally:   true,
+			TP1OID:              33,
+			TP2OID:              44,
+			TP1FilledExternally: true,
 		})
 		if len(pos.TPArmedTiers) != 2 || !pos.TPArmedTiers[0] || !pos.TPArmedTiers[1] {
 			t.Errorf("TPArmedTiers = %v, want [true true]", pos.TPArmedTiers)

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -316,11 +316,28 @@ func bookPerpsPartialCloseWithFillFee(s *StrategyState, symbol string, closeQty,
 	return true
 }
 
+// stopLossCloseDetailsPrefix picks the Trade.Details prefix based on the
+// internal SL-close reason so the trade-alert classifier can tell paper
+// stops, trailing stops, and exchange-fired stops apart (#716 item 4).
+// Reasons not listed default to "Stop loss close" — the canonical exchange-
+// SL prefix used by the reconciler and the immediate-fill paths.
+func stopLossCloseDetailsPrefix(reason string) string {
+	switch reason {
+	case "trailing_stop_loss_paper":
+		return "Paper trailing SL close"
+	case "trailing_stop_loss_immediate":
+		return "Trailing SL close"
+	case "stop_loss_atr_paper":
+		return "Paper SL close"
+	}
+	return "Stop loss close"
+}
+
 // recordPerpsStopLossClose books a tracked perps stop-loss fill and removes the
 // virtual position. Used both when HL reports an immediate trigger fill at
 // submit time and when a previously-resting trigger has fired between cycles.
 func recordPerpsStopLossClose(s *StrategyState, symbol string, triggerPx float64, reason string, logger *StrategyLogger) bool {
-	return bookPerpsClose(s, symbol, triggerPx, reason, "Stop loss close", "SL close reconciled", logger)
+	return bookPerpsClose(s, symbol, triggerPx, reason, stopLossCloseDetailsPrefix(reason), "SL close reconciled", logger)
 }
 
 // recordPerpsStopLossCloseWithFillFee is the reconciler entry point — same
@@ -329,7 +346,7 @@ func recordPerpsStopLossClose(s *StrategyState, symbol string, triggerPx float64
 // on-chain accountValue (#588). When useFillFee=false (or fillFee<=0) the
 // modeled fee is used; failed indexer lookups fall back to the legacy path.
 func recordPerpsStopLossCloseWithFillFee(s *StrategyState, symbol string, triggerPx, fillFee float64, useFillFee bool, exchangeOrderID, reason string, logger *StrategyLogger) bool {
-	return bookPerpsCloseWithFillFee(s, symbol, triggerPx, fillFee, useFillFee, exchangeOrderID, reason, "Stop loss close", "SL close reconciled", logger)
+	return bookPerpsCloseWithFillFee(s, symbol, triggerPx, fillFee, useFillFee, exchangeOrderID, reason, stopLossCloseDetailsPrefix(reason), "SL close reconciled", logger)
 }
 
 // recordPerpsExternalClose books a perps close detected by reconciliation

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -23,6 +23,13 @@ type Position struct {
 	StopLossTriggerPx   float64   `json:"stop_loss_trigger_px,omitempty"`    // HL perps: trigger price for the resting stop-loss (0 = unknown) (#421)
 	StopLossHighWaterPx float64   `json:"stop_loss_high_water_px,omitempty"` // HL perps trailing SL: best mark seen while position open (high for long, low for short) (#501)
 	TPOIDs              []int64   `json:"tp_oids,omitempty"`                 // HL perps: resting reduce-only TP limit OIDs, one per configured tier (#601/#612)
+	// TPArmedTiers[i] = true once tier i has been observed with a positive OID
+	// (i.e. successfully placed by runHyperliquidProtectionSync at least once).
+	// findHighestClearedTier requires this so a tier whose first placement
+	// failed transiently — leaving OID=0 with the tier never armed — is NOT
+	// mistaken for a fired TP when a non-TP partial close (close-evaluator)
+	// shrinks the position. See #716 item 2.
+	TPArmedTiers []bool `json:"tp_armed_tiers,omitempty"`
 	StopLossATRMult     *float64  `json:"stop_loss_atr_mult,omitempty"`      // HL perps: ATR multiplier resolved at fill time when SL was ATR-armed; nil = armed via pct/margin/trailing/none (#669)
 	TPTiersJSON         string    `json:"tp_tiers_json,omitempty"`           // HL perps: JSON snapshot of [{atr_multiple,close_fraction},...] resolved at fill time; "" = strategy doesn't use tiered_tp_atr* (#669)
 	// SLAdjustedTiersProcessed counts how many leading tiers have already had

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -29,9 +29,9 @@ type Position struct {
 	// failed transiently — leaving OID=0 with the tier never armed — is NOT
 	// mistaken for a fired TP when a non-TP partial close (close-evaluator)
 	// shrinks the position. See #716 item 2.
-	TPArmedTiers []bool `json:"tp_armed_tiers,omitempty"`
-	StopLossATRMult     *float64  `json:"stop_loss_atr_mult,omitempty"`      // HL perps: ATR multiplier resolved at fill time when SL was ATR-armed; nil = armed via pct/margin/trailing/none (#669)
-	TPTiersJSON         string    `json:"tp_tiers_json,omitempty"`           // HL perps: JSON snapshot of [{atr_multiple,close_fraction},...] resolved at fill time; "" = strategy doesn't use tiered_tp_atr* (#669)
+	TPArmedTiers    []bool   `json:"tp_armed_tiers,omitempty"`
+	StopLossATRMult *float64 `json:"stop_loss_atr_mult,omitempty"` // HL perps: ATR multiplier resolved at fill time when SL was ATR-armed; nil = armed via pct/margin/trailing/none (#669)
+	TPTiersJSON     string   `json:"tp_tiers_json,omitempty"`      // HL perps: JSON snapshot of [{atr_multiple,close_fraction},...] resolved at fill time; "" = strategy doesn't use tiered_tp_atr* (#669)
 	// SLAdjustedTiersProcessed counts how many leading tiers have already had
 	// their sl_after rule applied: 0 = none, N = tiers [0..N-1] processed.
 	// Idempotency watermark so restarts don't re-fire the same bump (#708).

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -2337,3 +2337,25 @@ func TestExecuteFuturesSignal_PartialCloseFractionTooSmallNoOps(t *testing.T) {
 		t.Errorf("position must remain at 2 contracts, got %v", got)
 	}
 }
+
+// #716 item 4 — stopLossCloseDetailsPrefix maps internal reason codes to
+// Trade.Details prefixes so the trade-alert classifier
+// (tradeAlertCloseSource) can label each SL flavor distinctly. Without
+// this mapping, paper-mode trailing closes would render as "exchange SL".
+func TestStopLossCloseDetailsPrefix(t *testing.T) {
+	cases := map[string]string{
+		"trailing_stop_loss_paper":     "Paper trailing SL close",
+		"trailing_stop_loss_immediate": "Trailing SL close",
+		"stop_loss_atr_paper":          "Paper SL close",
+		"stop_loss_atr_immediate":      "Stop loss close", // exchange-fired immediately on placement
+		"stop_loss_immediate":          "Stop loss close",
+		"stop_loss":                    "Stop loss close",
+		"hl_sync_stop_loss":            "Stop loss close",
+		"unknown_future_reason":        "Stop loss close",
+	}
+	for reason, want := range cases {
+		if got := stopLossCloseDetailsPrefix(reason); got != want {
+			t.Errorf("reason=%q → %q, want %q", reason, got, want)
+		}
+	}
+}

--- a/scheduler/post_tp_sl.go
+++ b/scheduler/post_tp_sl.go
@@ -233,6 +233,34 @@ func (r tierSLAfterRules) HasAny() bool {
 	return false
 }
 
+// EqualForReload reports whether two rule sets are equivalent for SIGHUP
+// hot-reload gating: same strategy-level default AND same per-tier rule at
+// every index. Trailing empty PerTier entries are ignored so that
+// `[breakeven, {}]` and `[breakeven]` compare equal — the second slot is a
+// no-op in both shapes. See #716 item 1.
+func (r tierSLAfterRules) EqualForReload(other tierSLAfterRules) bool {
+	if r.Default != other.Default {
+		return false
+	}
+	maxLen := len(r.PerTier)
+	if len(other.PerTier) > maxLen {
+		maxLen = len(other.PerTier)
+	}
+	for i := 0; i < maxLen; i++ {
+		var a, b SLAfterRule
+		if i < len(r.PerTier) {
+			a = r.PerTier[i]
+		}
+		if i < len(other.PerTier) {
+			b = other.PerTier[i]
+		}
+		if a != b {
+			return false
+		}
+	}
+	return true
+}
+
 // parseStrategyTPSLAfterRules walks a strategy's tiered_tp_atr / tiered_tp_atr_live
 // close ref and extracts the strategy-level default and per-tier sl_after rules.
 // errs is non-nil when individual fields are malformed; callers may surface

--- a/scheduler/post_tp_sl.go
+++ b/scheduler/post_tp_sl.go
@@ -438,18 +438,35 @@ func notifySLAdjustment(sender ownerDMSender, enabled bool, alert SLAdjustmentAl
 	sender.SendOwnerDM(formatSLAdjustmentAlert(alert))
 }
 
-// findHighestClearedTier returns the index of the highest-numbered tier in
-// tpOIDs that has been cleared (OID==0) at or above fromIdx. found=false when
-// no cleared tier exists in that range.
-func findHighestClearedTier(tpOIDs []int64, fromIdx int) (int, bool) {
+// findHighestClearedTier returns the index of the highest-numbered tier at or
+// above fromIdx that has been cleared. A tier is "cleared" iff it was
+// previously armed (tpArmedTiers[i] == true) AND its OID is now 0. The
+// armed requirement (#716 item 2) distinguishes a tier whose first placement
+// failed transiently (never armed, OID=0) from a tier that actually filled
+// (armed=true, then Python zeroed the OID on tp_filled_externally signal).
+// Without it, a non-TP partial close (e.g. close-evaluator) on a position with
+// one or more never-armed tiers would falsely advance the sl_after watermark
+// to that tier index.
+//
+// Legacy positions (pre-#716, no persisted armed state): backfillTPArmedTiers
+// at load time sets armed[i] = (oid[i] > 0), so an in-flight pre-upgrade
+// position never sees a tier go from OID=0 → cleared without first having
+// been armed in a later cycle.
+//
+// found=false when no qualifying cleared tier exists in [fromIdx, len).
+func findHighestClearedTier(tpOIDs []int64, tpArmedTiers []bool, fromIdx int) (int, bool) {
 	if fromIdx < 0 {
 		fromIdx = 0
 	}
 	highest := -1
 	for i := fromIdx; i < len(tpOIDs); i++ {
-		if tpOIDs[i] == 0 {
-			highest = i
+		if tpOIDs[i] != 0 {
+			continue
 		}
+		if i >= len(tpArmedTiers) || !tpArmedTiers[i] {
+			continue
+		}
+		highest = i
 	}
 	if highest >= 0 {
 		return highest, true
@@ -508,7 +525,7 @@ func runPostTPStopLossAdjustment(
 		mu.RUnlock()
 		return false
 	}
-	clearedIdx, clearedOK := findHighestClearedTier(pos.TPOIDs, pos.SLAdjustedTiersProcessed)
+	clearedIdx, clearedOK := findHighestClearedTier(pos.TPOIDs, pos.TPArmedTiers, pos.SLAdjustedTiersProcessed)
 	if !clearedOK {
 		mu.RUnlock()
 		return false

--- a/scheduler/post_tp_sl_test.go
+++ b/scheduler/post_tp_sl_test.go
@@ -586,6 +586,54 @@ func TestValidatePostTPStopLossRules_RejectsTrailFromHereOnManual(t *testing.T) 
 	}
 }
 
+// #716 item 2 regression: a non-TP partial close (e.g. close-evaluator firing
+// signal=-1 to half the position) on a position whose tier 0 was never armed
+// (transient placement failure left OID=0 with armed[0]=false) must NOT
+// trigger the sl_after rule for tier 0. Pre-#716, findHighestClearedTier
+// looked only at OID==0 and would return idx=0 here, firing breakeven against
+// a tier that never existed.
+func TestRunPostTPStopLossAdjustment_SkipsNeverArmedTier(t *testing.T) {
+	old := runHyperliquidUpdateStopLossFunc
+	defer func() { runHyperliquidUpdateStopLossFunc = old }()
+
+	calls := 0
+	runHyperliquidUpdateStopLossFunc = func(string, string, string, float64, float64, int64) (*HyperliquidStopLossUpdateResult, string, error) {
+		calls++
+		return &HyperliquidStopLossUpdateResult{StopLossOID: 999, StopLossTriggerPx: 100}, "", nil
+	}
+
+	sc := postTPSLTestStrategy("breakeven", []interface{}{
+		map[string]interface{}{"atr_multiple": 2, "close_fraction": 0.5},
+		map[string]interface{}{"atr_multiple": 3, "close_fraction": 1.0},
+	})
+	pos := &Position{
+		Symbol: "ETH", Quantity: 0.5, InitialQuantity: 1.0,
+		AvgCost: 100, EntryATR: 5, Side: "long",
+		StopLossOID: 111, StopLossTriggerPx: 95,
+		// Tier 0 placement failed transiently — OID=0 with armed[0]=false.
+		// Tier 1 is resting with OID=222. A non-TP partial close has shrunk
+		// Quantity to 0.5 (half InitialQuantity).
+		TPOIDs:                   []int64{0, 222},
+		TPArmedTiers:             []bool{false, true},
+		SLAdjustedTiersProcessed: 0,
+	}
+	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
+	var mu sync.RWMutex
+
+	if runPostTPStopLossAdjustment(sc, state, "ETH", 105, nil, &mu, nil, nil) {
+		t.Fatal("expected runPostTPStopLossAdjustment to skip never-armed tier")
+	}
+	if calls != 0 {
+		t.Errorf("subprocess should not be called for never-armed tier; got %d calls", calls)
+	}
+	if pos.StopLossOID != 111 {
+		t.Errorf("StopLossOID=%d, want 111 (unchanged)", pos.StopLossOID)
+	}
+	if pos.SLAdjustedTiersProcessed != 0 {
+		t.Errorf("SLAdjustedTiersProcessed=%d, want 0 (no advance)", pos.SLAdjustedTiersProcessed)
+	}
+}
+
 func TestRunPostTPStopLossAdjustment_BreakevenAfterTP1(t *testing.T) {
 	old := runHyperliquidUpdateStopLossFunc
 	defer func() { runHyperliquidUpdateStopLossFunc = old }()
@@ -612,6 +660,7 @@ func TestRunPostTPStopLossAdjustment_BreakevenAfterTP1(t *testing.T) {
 		StopLossOID:              111,
 		StopLossTriggerPx:        95,
 		TPOIDs:                   []int64{0, 222}, // tier 0 filled
+		TPArmedTiers:             []bool{true, true},
 		SLAdjustedTiersProcessed: 0,
 	}
 	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
@@ -655,6 +704,7 @@ func TestRunPostTPStopLossAdjustment_Idempotent(t *testing.T) {
 		AvgCost: 100, EntryATR: 5, Side: "long",
 		StopLossOID: 111, StopLossTriggerPx: 95,
 		TPOIDs:                   []int64{0, 222},
+		TPArmedTiers:             []bool{true, true},
 		SLAdjustedTiersProcessed: 0,
 	}
 	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
@@ -686,6 +736,7 @@ func TestRunPostTPStopLossAdjustment_TrailFromHereTransition(t *testing.T) {
 		AvgCost: 100, EntryATR: 5, Side: "long",
 		StopLossOID: 111, StopLossTriggerPx: 95,
 		TPOIDs:                   []int64{0, 222},
+		TPArmedTiers:             []bool{true, true},
 		SLAdjustedTiersProcessed: 0,
 	}
 	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
@@ -727,6 +778,7 @@ func TestRunPostTPStopLossAdjustment_TrailDefersWithoutMark(t *testing.T) {
 		AvgCost: 100, EntryATR: 5, Side: "long",
 		StopLossOID: 111, StopLossTriggerPx: 95,
 		TPOIDs:                   []int64{0, 222},
+		TPArmedTiers:             []bool{true, true},
 		SLAdjustedTiersProcessed: 0,
 	}
 	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
@@ -760,7 +812,7 @@ func TestRunPostTPStopLossAdjustment_NoRulesShortCircuits(t *testing.T) {
 	pos := &Position{
 		Symbol: "ETH", Quantity: 0.5, InitialQuantity: 1.0,
 		AvgCost: 100, EntryATR: 5, Side: "long",
-		StopLossOID: 111, TPOIDs: []int64{0, 222},
+		StopLossOID: 111, TPOIDs: []int64{0, 222}, TPArmedTiers: []bool{true, true},
 	}
 	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
 	var mu sync.RWMutex
@@ -790,8 +842,9 @@ func TestRunPostTPStopLossAdjustment_DefersWhenSLNotArmed(t *testing.T) {
 	pos := &Position{
 		Symbol: "ETH", Quantity: 0.5, InitialQuantity: 1.0,
 		AvgCost: 100, EntryATR: 5, Side: "long",
-		StopLossOID: 0, // not yet armed
-		TPOIDs:      []int64{0, 222},
+		StopLossOID:  0, // not yet armed
+		TPOIDs:       []int64{0, 222},
+		TPArmedTiers: []bool{true, true},
 	}
 	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
 	var mu sync.RWMutex
@@ -805,6 +858,16 @@ func TestRunPostTPStopLossAdjustment_DefersWhenSLNotArmed(t *testing.T) {
 }
 
 func TestFindHighestClearedTier(t *testing.T) {
+	// All cases here assume tiers were armed at some point (`armed` matches
+	// `oids` shape, all true). The "never armed" variant is exercised
+	// separately in TestFindHighestClearedTier_NeverArmedSkipped (#716 item 2).
+	mkArmed := func(oids []int64) []bool {
+		out := make([]bool, len(oids))
+		for i := range out {
+			out[i] = true
+		}
+		return out
+	}
 	cases := []struct {
 		name      string
 		oids      []int64
@@ -824,7 +887,65 @@ func TestFindHighestClearedTier(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotIdx, gotClear := findHighestClearedTier(tc.oids, tc.from)
+			gotIdx, gotClear := findHighestClearedTier(tc.oids, mkArmed(tc.oids), tc.from)
+			if gotClear != tc.wantClear {
+				t.Fatalf("cleared=%v, want %v", gotClear, tc.wantClear)
+			}
+			if tc.wantClear && gotIdx != tc.wantIdx {
+				t.Fatalf("idx=%d, want %d", gotIdx, tc.wantIdx)
+			}
+		})
+	}
+}
+
+// #716 item 2 — a tier that was never armed (OID=0 with armed[i]=false) must
+// not count as cleared, even if a partial close occurred from some other path.
+func TestFindHighestClearedTier_NeverArmedSkipped(t *testing.T) {
+	cases := []struct {
+		name      string
+		oids      []int64
+		armed     []bool
+		wantIdx   int
+		wantClear bool
+	}{
+		{
+			name:  "never armed tier 0, armed tier 1 still resting",
+			oids:  []int64{0, 222},
+			armed: []bool{false, true},
+			// Neither qualifies: tier 0 never armed, tier 1 still has a positive OID.
+			wantClear: false,
+		},
+		{
+			name:      "tier 0 filled (was armed), tier 1 still resting",
+			oids:      []int64{0, 222},
+			armed:     []bool{true, true},
+			wantIdx:   0,
+			wantClear: true,
+		},
+		{
+			name:      "tier 0 never armed, tier 1 filled",
+			oids:      []int64{0, 0},
+			armed:     []bool{false, true},
+			wantIdx:   1,
+			wantClear: true,
+		},
+		{
+			name:      "armed slice shorter than oids (legacy/transitional)",
+			oids:      []int64{0, 0, 0},
+			armed:     []bool{true, true},
+			wantIdx:   1,
+			wantClear: true,
+		},
+		{
+			name:      "armed slice nil (legacy row before backfill)",
+			oids:      []int64{0, 0},
+			armed:     nil,
+			wantClear: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotIdx, gotClear := findHighestClearedTier(tc.oids, tc.armed, 0)
 			if gotClear != tc.wantClear {
 				t.Fatalf("cleared=%v, want %v", gotClear, tc.wantClear)
 			}

--- a/scheduler/trade_alert_source_test.go
+++ b/scheduler/trade_alert_source_test.go
@@ -11,6 +11,11 @@ func TestTradeAlertCloseSourceClassification(t *testing.T) {
 		want    string
 	}{
 		{"Stop loss close ETH, PnL: $-22.45 (fee $1.10)", "exchange SL"},
+		// #716 item 4: paper / trailing variants classify distinctly so an
+		// operator doesn't see a paper-mode trailing SL labeled "exchange SL".
+		{"Paper trailing SL close ETH, PnL: $-22.45 (fee $1.10)", "paper trailing SL"},
+		{"Trailing SL close ETH, PnL: $-22.45 (fee $1.10)", "trailing SL"},
+		{"Paper SL close ETH, PnL: $-22.45 (fee $1.10)", "paper SL"},
 		{"TP1 fill close, PnL: $34.35 (fee $1.23)", "exchange TP1"},
 		{"TP2 fill close, PnL: $50.00 (fee $1.50)", "exchange TP2"},
 		{"Circuit breaker on-chain close (no virtual position), fill=0.5 fee=$0.20", "circuit breaker"},


### PR DESCRIPTION
Closes #716.

Four findings from the retrospective review of PRs #707, #710, #712, each as its own commit.

## 1. SIGHUP hot-reload guard for `sl_after` shape changes

`validateHotReloadStateCompatible` (`scheduler/config_reload.go`) now rejects an in-flight reload that adds, removes, or changes the kind/mult of any `sl_after` rule while a position is open under that strategy. Without this guard, the new rule would engage on the next cleared TP tier — and for `trail_from_here`, would hand control to the trailing walker — without the validation the open respected. Numeric changes are still allowed when the strategy is flat.

`tierSLAfterRules.EqualForReload` compares the parsed strategy-level default plus per-tier rules, ignoring trailing empty `PerTier` entries so equivalent shapes compare equal.

## 2. Distinguish never-armed from filled TP tiers

`findHighestClearedTier` previously returned any tier where `pos.TPOIDs[i] == 0`. A tier whose first protection-sync placement failed transiently (still 0, never armed) was indistinguishable from a tier that fired and was zeroed by Python's `tp_filled_externally` signal. A subsequent non-TP partial close (close-evaluator) would then falsely advance the `sl_after` watermark and trigger an SL adjustment for a TP that never fired.

`Position.TPArmedTiers []bool` now records which tiers have been observed with a positive OID at least once. `applyHyperliquidProtectionSync` stamps `armed[i] = true` whenever Python echoes a positive OID, and treats `TPFilledExternally` as proof-of-arming. `findHighestClearedTier` requires `armed[i] == true` before considering a zero OID as cleared.

A new `tp_armed_tiers_json` SQLite column persists the slice; legacy rows get a conservative backfill (`armed[i] = oid[i] > 0`) so an in-flight pre-upgrade position never sees a tier go from OID=0 → cleared without first arming in a later cycle.

## 3. Backtester SL seed gate

In `Backtester.run`, the entry-time SL seed was gated on `sl_after_active` alone, while the tier-fill adjuster `_maybe_apply_sl_after` was gated on `sl_after_active AND self._tp_tier_thresholds`. When `parse_tp_tier_close_fractions` returned `[]` (degenerate tier config), the seed installed a phantom fixed-SL trigger that the post-TP machinery could never adjust — diverging silently from live, where the fixed SL is placed by `runHyperliquidProtectionSync` independently of `sl_after`.

The fix gates the seed on `self._tp_tier_thresholds` (chosen over the issue's proposed gate-the-hit fix because it removes the phantom state at the source rather than letting it linger and be filtered later). The hit check already short-circuits on `sl_trigger_px <= 0`, so no further changes are needed.

## 4. Distinct labels for paper / trailing SL closes

Paper-mode trailing SL closes wrote `"Stop loss close ..."` to `Trade.Details`, which `tradeAlertCloseSource` matched as `"exchange SL"` — misleading operators into thinking the exchange had fired a resting trigger when no exchange was involved at all. The same misclassification affected paper ATR SL closes and live trailing-SL immediate fills (broader scope than the issue called out; fixed in one shot since the prefix string is the load-bearing signal).

`stopLossCloseDetailsPrefix(reason)` now picks the prefix based on the internal reason code:

| Reason | Details prefix | Alert label |
|---|---|---|
| `trailing_stop_loss_paper` | `Paper trailing SL close` | `paper trailing SL` |
| `trailing_stop_loss_immediate` | `Trailing SL close` | `trailing SL` |
| `stop_loss_atr_paper` | `Paper SL close` | `paper SL` |
| everything else | `Stop loss close` | `exchange SL` |

## Test plan

- [x] `go -C scheduler test ./...` — full suite green (24.6s)
- [x] `.venv/bin/python3 -m pytest shared_strategies/ shared_tools/ platforms/ backtest/` — 956 passed
- [x] Each commit verified to build independently (`go -C scheduler build ./...`)
- [x] Regression test per item:
  - Item 1: `TestApplyHotReloadConfigRejectsSLAfterAddWithOpenPosition`, `TestApplyHotReloadConfigAllowsSLAfterAddWhenFlat`, `TestApplyHotReloadConfigRejectsSLAfterModeChangeWithOpenPosition`
  - Item 2: `TestFindHighestClearedTier_NeverArmedSkipped`, `TestApplyHyperliquidProtectionSyncStampsTPArmedTiers`, `TestRunPostTPStopLossAdjustment_SkipsNeverArmedTier`
  - Item 3: `test_backtester_sl_after_does_not_seed_when_no_tier_thresholds`
  - Item 4: `TestStopLossCloseDetailsPrefix`, expanded `TestTradeAlertCloseSourceClassification`

---
LLM: Claude Opus 4.7 | high