### PR TITLE
fix: strip regime kwarg through **params wrappers (#720)

### DIFF
--- a/shared_scripts/test_regime_wiring.py
+++ b/shared_scripts/test_regime_wiring.py
@@ -145,6 +145,59 @@ def test_strip_unsupported_keeps_regime_for_aware_function():
     assert stripped["rsi_period"] == 14
 
 
+def test_strip_unsupported_drops_regime_for_var_keyword_wrapper():
+    """Regression for #720.
+
+    Real registered strategies wrap thin cores as ``def *_strategy(df, **params):
+    return *_core(df, **params)``. The wrapper has VAR_KEYWORD, but the core does
+    not accept ``regime`` — passing it through crashes with TypeError. The strip
+    helper must still drop position-context kwargs in this shape; only regular
+    strategy params should survive.
+    """
+    from strategy_composition import strip_unsupported_position_context
+
+    def dummy_strategy_wrapper(df, **params):  # mirrors registered wrappers
+        return df
+
+    df = _make_uptrend_df()
+    params = {
+        "adx_period": 14,
+        "adx_threshold": 25,
+        "regime": latest_regime(df),
+        "side": "long",
+        "avg_cost": 100.0,
+    }
+    stripped = strip_unsupported_position_context(dummy_strategy_wrapper, params)
+    assert "regime" not in stripped
+    assert "side" not in stripped
+    assert "avg_cost" not in stripped
+    assert stripped["adx_period"] == 14
+    assert stripped["adx_threshold"] == 25
+
+
+def test_apply_strategy_does_not_crash_on_regime_injection():
+    """End-to-end: invoke a real registered strategy whose core lacks **kwargs
+    with the framework-injected ``regime`` payload. Must not raise.
+    """
+    import importlib.util
+
+    futures_path = (
+        pathlib.Path(__file__).parent.parent
+        / "shared_strategies" / "open" / "futures" / "strategies.py"
+    )
+    spec = importlib.util.spec_from_file_location("_futures_shim_720", futures_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    df = _make_uptrend_df(n=200)
+    params = {"regime": latest_regime(df)}
+    for name in ("adx_trend", "sweep_squeeze_combo", "amd_ifvg", "range_scalper"):
+        if name not in mod.STRATEGY_REGISTRY:
+            continue  # platform filter excludes it; skip
+        result = mod.apply_strategy(name, df, params)
+        assert "signal" in result.columns, f"{name} returned no signal column"
+
+
 # ─── check_options.py regime computation (#544) ───────────────────────────────
 
 

--- a/shared_tools/strategy_composition.py
+++ b/shared_tools/strategy_composition.py
@@ -252,8 +252,6 @@ def strip_unsupported_position_context(fn, params: dict) -> dict:
     if not params:
         return params
     sig = inspect.signature(fn)
-    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
-        return params
     accepted = {
         name for name, p in sig.parameters.items()
         if name != "df" and p.kind in (
@@ -261,6 +259,11 @@ def strip_unsupported_position_context(fn, params: dict) -> dict:
             inspect.Parameter.KEYWORD_ONLY,
         )
     }
+    # Framework-injected position-context kwargs (regime, side, avg_cost, ...) must be
+    # opt-in via explicit signature. The earlier VAR_KEYWORD short-circuit silently
+    # forwarded them through `def *_strategy(df, **params)` wrappers into thin cores
+    # that crash on unknown kwargs (#720). Regular strategy params still pass through
+    # untouched — only POSITION_CONTEXT_PARAM_KEYS are stripped when undeclared.
     return {
         key: value for key, value in params.items()
         if key in accepted or key not in POSITION_CONTEXT_PARAM_KEYS


### PR DESCRIPTION
## Summary
- `strip_unsupported_position_context` short-circuited to "keep everything" whenever the inspected fn had `VAR_KEYWORD`. Every registered open strategy uses `def *_strategy(df, **params): return *_core(df, **params)`, so the framework-injected `regime` payload (and every other `POSITION_CONTEXT_PARAM_KEYS` entry) sailed through the wrapper into thin cores that crash with `TypeError: *_core() got an unexpected keyword argument 'regime'`.
- The fix drops the VAR_KEYWORD escape hatch. Framework-injected position-context kwargs are now opt-in via explicit signature; regular strategy `**params` keys still flow through because they aren't in `POSITION_CONTEXT_PARAM_KEYS`.
- Scope is broader than the four strategies named in #720: ten-plus wrapper-shaped strategies (`adx_trend`, `amd_ifvg`, `range_scalper`, `sweep_squeeze_combo`, `chart_pattern`, `donchian_breakout`, `liquidity_sweeps`, `session_breakout`, `bear_pullback_st`, `vwap_rejection_st`) on every check script that injects regime (HL/OKX/RH/TopStep/spot).

## Test plan
- [x] `.venv/bin/python3 -m pytest shared_scripts/test_regime_wiring.py` — 19 passed (incl. two new regressions)
- [x] `.venv/bin/python3 -m pytest shared_strategies/ shared_tools/ platforms/ backtest/` — 956 passed
- [x] `.venv/bin/python3 -m pytest shared_scripts/` — 139 passed
- [x] `go -C scheduler build .` clean

Closes #720

---
LLM: Claude Opus 4.7 | high