### PR TITLE
fix(test): repair post_tp_sl_test.go after #717/#719 merge (#722)

### DIFF
--- a/scheduler/post_tp_sl_test.go
+++ b/scheduler/post_tp_sl_test.go
@@ -620,7 +620,7 @@ func TestRunPostTPStopLossAdjustment_SkipsNeverArmedTier(t *testing.T) {
 	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
 	var mu sync.RWMutex
 
-	if runPostTPStopLossAdjustment(sc, state, "ETH", 105, nil, &mu, nil, nil) {
+	if runPostTPStopLossAdjustment(sc, state, "ETH", 105, nil, &mu, nil, nil, nil) {
 		t.Fatal("expected runPostTPStopLossAdjustment to skip never-armed tier")
 	}
 	if calls != 0 {
@@ -879,6 +879,7 @@ func TestRunPostTPStopLossAdjustment_CapsAtOnChainQty(t *testing.T) {
 		AvgCost: 100, EntryATR: 5, Side: "long",
 		StopLossOID: 111, StopLossTriggerPx: 95,
 		TPOIDs:                   []int64{0, 222},
+		TPArmedTiers:             []bool{true, true},
 		SLAdjustedTiersProcessed: 0,
 	}
 	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}
@@ -914,6 +915,7 @@ func TestRunPostTPStopLossAdjustment_NoCapWhenOnChainGEVirtual(t *testing.T) {
 		AvgCost: 100, EntryATR: 5, Side: "long",
 		StopLossOID: 111, StopLossTriggerPx: 95,
 		TPOIDs:                   []int64{0, 222},
+		TPArmedTiers:             []bool{true, true},
 		SLAdjustedTiersProcessed: 0,
 	}
 	state := &StrategyState{ID: sc.ID, Positions: map[string]*Position{"ETH": pos}}


### PR DESCRIPTION
## Summary
- `go -C scheduler test ./...` fails on `main` because #717 and #719 landed in a sequence that broke each other's test fixtures.
- Compile error at `post_tp_sl_test.go:623` — #719 added a 9th `map[string]float64` arg to `runPostTPStopLossAdjustment` and updated every call site except `TestRunPostTPStopLossAdjustment_DefersWhenNeverArmed`. Add the missing trailing `nil`.
- Stale fixtures at `:863` / `:898` — #717's `CapsAtOnChainQty` and `NoCapWhenOnChainGEVirtual` tests build a `Position` with `TPOIDs` but no `TPArmedTiers`. #719's `findHighestClearedTier` now requires `tpArmedTiers[i]==true`, so both tests no longer detect a cleared tier. Set `TPArmedTiers: []bool{true, true}` to match how #719 migrated `DefersWhenSLNotArmed`.

## Test plan
- [x] `go -C scheduler test ./...` — `ok trading-scheduler 24.482s`
- [x] `go -C scheduler build .` — clean

Closes #722

---
LLM: Claude Opus 4.7 | high