### PR TITLE
Support custom systemd units in the update restart path

### DIFF
--- a/scheduler/updater.go
+++ b/scheduler/updater.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+const defaultGoTraderSystemdUnit = "go-trader"
+
 // checkForUpdates uses git fetch to check for upstream changes. If new commits are found
 // (and the remote hash differs from lastNotifiedHash), it sends a Discord channel notification
 // and, if OwnerID is configured, a DM offering to auto-upgrade.
@@ -134,7 +136,7 @@ func restartSelf() error {
 	// Try systemctl first (Linux/systemd deployments).
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	if err := exec.CommandContext(ctx, "systemctl", "restart", "go-trader").Run(); err == nil {
+	if err := exec.CommandContext(ctx, "systemctl", "restart", updateSystemdUnitName()).Run(); err == nil {
 		// systemd will SIGTERM this process; give it time to do so.
 		time.Sleep(30 * time.Second)
 	}
@@ -145,6 +147,14 @@ func restartSelf() error {
 		return fmt.Errorf("get executable: %w", err)
 	}
 	return syscall.Exec(exe, os.Args, os.Environ())
+}
+
+func updateSystemdUnitName() string {
+	unit := strings.TrimSpace(os.Getenv("GO_TRADER_SERVICE"))
+	if unit == "" {
+		return defaultGoTraderSystemdUnit
+	}
+	return unit
 }
 
 // gitCheck verifies that git is available and the working directory is a git repo.
@@ -214,6 +224,7 @@ func formatUpdateMessage(localHash, remoteHash, commitLog, newTag string) string
 
 	sb.WriteString("To update:\n```\n")
 	sb.WriteString("cd /path/to/go-trader && bash scripts/update.sh --restart\n")
+	sb.WriteString("# custom unit: GO_TRADER_SERVICE=go-trader-live.service bash scripts/update.sh --restart\n")
 	sb.WriteString("```")
 
 	return sb.String()

--- a/scheduler/updater_test.go
+++ b/scheduler/updater_test.go
@@ -25,6 +25,9 @@ func TestFormatUpdateMessage(t *testing.T) {
 	if !strings.Contains(msg, "scripts/update.sh --restart") {
 		t.Error("should point operators at scripts/update.sh --restart")
 	}
+	if !strings.Contains(msg, "GO_TRADER_SERVICE=go-trader-live.service") {
+		t.Error("should mention the custom unit env override")
+	}
 	if !strings.Contains(msg, "Update Available") {
 		t.Error("should contain update header")
 	}
@@ -73,6 +76,22 @@ func TestTailForDM(t *testing.T) {
 	}
 	if len(got) > 1500+len("...truncated...\n") {
 		t.Errorf("trimmed output too long: %d", len(got))
+	}
+}
+
+func TestUpdateSystemdUnitNameDefaultsToCanonicalUnit(t *testing.T) {
+	t.Setenv("GO_TRADER_SERVICE", "")
+
+	if got := updateSystemdUnitName(); got != defaultGoTraderSystemdUnit {
+		t.Fatalf("expected default unit %q, got %q", defaultGoTraderSystemdUnit, got)
+	}
+}
+
+func TestUpdateSystemdUnitNameUsesEnvOverride(t *testing.T) {
+	t.Setenv("GO_TRADER_SERVICE", " go-trader-live.service ")
+
+	if got := updateSystemdUnitName(); got != "go-trader-live.service" {
+		t.Fatalf("expected env override to be trimmed and used, got %q", got)
 	}
 }
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -9,11 +9,11 @@
 #   build      — go build to go-trader.new (live binary untouched)
 #   probe      — go-trader.new probe against the just-synced Python
 #   swap       — atomic mv: live binary -> .prev, staged -> live
-#   restart    — sudo systemctl restart go-trader (only with --restart)
+#   restart    — sudo systemctl restart <unit> (only with --restart)
 #   verify     — wait active + /health version match (only with --restart)
 #   rollback   — restore .prev on verify failure (only with --restart)
 #
-# Use --restart (or RESTART=1) to restart the service after a successful build
+# Use --restart (or RESTART=1) to restart the systemd unit after a successful build
 # AND verify the running process matches the just-built version. Without
 # --restart the script stops after swap; the caller (scheduler/updater.go's
 # applyUpgrade) handles its own restart via restartSelf.
@@ -21,25 +21,49 @@
 set -euo pipefail
 
 restart=0
-for arg in "$@"; do
-    case "$arg" in
-        --restart) restart=1 ;;
+service_unit="${GO_TRADER_SERVICE:-go-trader}"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --restart)
+            restart=1
+            shift
+            ;;
+        --unit|--service)
+            if [[ $# -lt 2 || -z "$2" || "$2" == --* ]]; then
+                echo "$1 requires a systemd unit name" >&2
+                exit 2
+            fi
+            service_unit="$2"
+            shift 2
+            ;;
+        --unit=*|--service=*)
+            service_unit="${1#*=}"
+            if [[ -z "$service_unit" ]]; then
+                echo "${1%%=*} requires a systemd unit name" >&2
+                exit 2
+            fi
+            shift
+            ;;
         -h|--help)
-            echo "Usage: $0 [--restart]"
+            echo "Usage: $0 [--restart] [--unit <systemd-unit>]"
             echo "  RESTART=1 env var also enables restart."
             echo ""
             echo "Env overrides:"
+            echo "  GO_TRADER_SERVICE=<unit> systemd unit to restart/verify (default: go-trader)"
             echo "  STATUS_PORT=<n>          override /health port (default: read from config, else 8099)"
             echo "  ACTIVE_TIMEOUT=<sec>     systemctl is-active poll timeout (default: 30)"
             echo "  HEALTH_TIMEOUT=<sec>     /health version-match poll timeout (default: 60)"
             exit 0
             ;;
         *)
-            echo "unknown arg: $arg" >&2
+            echo "unknown arg: $1" >&2
             exit 2
             ;;
     esac
 done
+if [[ -z "$service_unit" ]]; then
+    service_unit="go-trader"
+fi
 if [[ "${RESTART:-0}" == "1" ]]; then
     restart=1
 fi
@@ -173,7 +197,7 @@ echo "[update] previous binary version: ${prev_running_version:-<none>}"
 # touched by this update (binary, git tree, Python deps, running process),
 # not just the binary swap.
 pre_pull_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
-prev_main_pid=$(systemctl show -p MainPID --value go-trader 2>/dev/null || echo "")
+prev_main_pid=$(systemctl show -p MainPID --value "$service_unit" 2>/dev/null || echo "")
 # systemd reports MainPID=0 when the unit is inactive; normalize to empty
 # so the verify step doesn't try to compare against a meaningless 0.
 if [[ "$prev_main_pid" == "0" ]]; then
@@ -285,12 +309,12 @@ do_rollback() {
         fi
     fi
 
-    sudo systemctl restart go-trader || true
+    sudo systemctl restart "$service_unit" || true
     # Best-effort wait for active after rollback. We don't fail the rollback
     # itself on a slow restart — operators see the rollback marker either way.
     local waited=0
     while [[ $waited -lt $active_timeout ]]; do
-        if systemctl is-active --quiet go-trader; then
+        if systemctl is-active --quiet "$service_unit"; then
             echo "[update] rollback: previous binary active again (${prev_running_version:-unknown})"
             return
         fi
@@ -301,10 +325,10 @@ do_rollback() {
 }
 
 begin_phase restart
-sudo systemctl restart go-trader
+sudo systemctl restart "$service_unit"
 
 waited=0
-until systemctl is-active --quiet go-trader; do
+until systemctl is-active --quiet "$service_unit"; do
     if [[ $waited -ge $active_timeout ]]; then
         do_rollback "systemctl is-active timeout after ${active_timeout}s"
         fail "service did not reach active state within ${active_timeout}s"
@@ -312,7 +336,7 @@ until systemctl is-active --quiet go-trader; do
     sleep 1
     waited=$((waited + 1))
 done
-echo "[update] systemd reports active (${waited}s)"
+echo "[update] systemd reports active: $service_unit (${waited}s)"
 end_phase
 
 begin_phase verify
@@ -336,7 +360,7 @@ while [[ $waited -lt $health_timeout ]]; do
         # sufficient — the version string is git describe output, no quoting
         # ambiguity.
         if [[ "$body" == *"\"version\":\"$ver\""* ]]; then
-            cur_main_pid=$(systemctl show -p MainPID --value go-trader 2>/dev/null || echo "")
+            cur_main_pid=$(systemctl show -p MainPID --value "$service_unit" 2>/dev/null || echo "")
             if [[ "$cur_main_pid" == "0" ]]; then
                 cur_main_pid=""
             fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -20,8 +20,18 @@
 
 set -euo pipefail
 
+trim_space() {
+    local value="$1"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    printf '%s' "$value"
+}
+
 restart=0
-service_unit="${GO_TRADER_SERVICE:-go-trader}"
+service_unit="$(trim_space "${GO_TRADER_SERVICE:-}")"
+if [[ -z "$service_unit" ]]; then
+    service_unit="go-trader"
+fi
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --restart)
@@ -29,23 +39,30 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --unit|--service)
-            if [[ $# -lt 2 || -z "$2" || "$2" == --* ]]; then
+            if [[ $# -lt 2 ]]; then
                 echo "$1 requires a systemd unit name" >&2
                 exit 2
             fi
-            service_unit="$2"
+            unit_arg="$(trim_space "$2")"
+            if [[ -z "$unit_arg" || "$unit_arg" == --* ]]; then
+                echo "$1 requires a systemd unit name" >&2
+                exit 2
+            fi
+            service_unit="$unit_arg"
             shift 2
             ;;
         --unit=*|--service=*)
-            service_unit="${1#*=}"
-            if [[ -z "$service_unit" ]]; then
+            unit_arg="$(trim_space "${1#*=}")"
+            if [[ -z "$unit_arg" || "$unit_arg" == --* ]]; then
                 echo "${1%%=*} requires a systemd unit name" >&2
                 exit 2
             fi
+            service_unit="$unit_arg"
             shift
             ;;
         -h|--help)
             echo "Usage: $0 [--restart] [--unit <systemd-unit>]"
+            echo "       $0 [--restart] [--service <systemd-unit>]"
             echo "  RESTART=1 env var also enables restart."
             echo ""
             echo "Env overrides:"
@@ -61,9 +78,6 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
-if [[ -z "$service_unit" ]]; then
-    service_unit="go-trader"
-fi
 if [[ "${RESTART:-0}" == "1" ]]; then
     restart=1
 fi


### PR DESCRIPTION
## Summary
- Added `GO_TRADER_SERVICE` and `--unit`/`--service` overrides to `scripts/update.sh` so restart, active checks, PID verification, and rollback all target the selected systemd unit.
- Updated the in-process auto-update restart path in `scheduler/updater.go` to use the same environment-driven unit selection.
- Added tests for the unit resolver and expanded update-message coverage to mention the custom-unit override.

Closes #726

## Testing
- `bash -n scripts/update.sh`
- `bash scripts/update.sh --help`
- `bash scripts/update.sh --unit --restart` (verifies invalid usage is rejected)
- `bash scripts/update.sh --unit '   ' --restart` (verifies whitespace-only units are rejected)
- `bash scripts/update.sh --service=--restart` (verifies flag-looking unit names are rejected)
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...`