### PR TITLE
fix(discord): full positions list in dedicated message on summary split (#728)

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -594,11 +594,23 @@ func splitCategorySummary(header string, totalOpenPos int, posLines []string, tr
 		}
 	}
 
-	msg1 := headerOnly + tradeSuffix
 	posMsgs := buildPositionMessages(posLines)
 
-	out := make([]string, 0, 1+len(continuationTables)+len(posMsgs))
-	out = append(out, msg1)
+	// Belt-and-suspenders: if the leaderboard top chunk plus trades would push
+	// msg 1 over Discord's 2000-char limit, peel trades into their own message
+	// between msg 1 and the continuation tables. Header alone is already capped
+	// by writeCatTableChunks, so this only fires for unusually verbose trades.
+	leadMsgs := []string{headerOnly}
+	if tradeSuffix != "" {
+		if len(headerOnly)+len(tradeSuffix) > discordSplitThreshold {
+			leadMsgs = append(leadMsgs, tradeSuffix)
+		} else {
+			leadMsgs[0] = headerOnly + tradeSuffix
+		}
+	}
+
+	out := make([]string, 0, len(leadMsgs)+len(continuationTables)+len(posMsgs))
+	out = append(out, leadMsgs...)
 	out = append(out, continuationTables...)
 	out = append(out, posMsgs...)
 	return out

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -550,123 +550,107 @@ func FormatCategorySummary(
 }
 
 // splitCategorySummary assembles the header, position lines, and trade lines into
-// one or more Discord messages, splitting at logical boundaries to stay under the
-// 2000-char Discord limit. continuationTables are extra strategy-table chunks
-// (already formatted as their own code blocks) that get inserted right after the
-// first message so the rest of the table is the very next thing the user sees.
+// one or more Discord messages, staying under the 2000-char Discord limit.
+//
+// Layout rules (issue #728):
+//   - If everything fits in a single message AND there are no continuation
+//     table chunks, return a single message.
+//   - Otherwise msg 1 carries the header (incl. the leaderboard table top
+//     chunk), the "Positions: N open" line, and the trades section. Any
+//     continuation table chunks follow. The full position bullets list lives
+//     in its own message(s) after that — never interleaved with the header
+//     and never truncated with "... and N more".
+//
+// continuationTables are extra strategy-table chunks already formatted as their
+// own code blocks (from writeCatTableChunks) that splice in between msg 1 and
+// the positions block so readers see the rest of the leaderboard first.
 func splitCategorySummary(header string, totalOpenPos int, posLines []string, tradeLines []string, continuationTables []string) []string {
-	msgs := splitCategorySummaryCore(header, totalOpenPos, posLines, tradeLines)
-	if len(continuationTables) == 0 {
-		return msgs
+	headerOnly := buildSummaryHeader(header, totalOpenPos)
+	tradeSuffix := buildTradeSuffix(tradeLines)
+
+	if totalOpenPos == 0 || len(posLines) == 0 {
+		msg := headerOnly + tradeSuffix
+		if len(continuationTables) == 0 {
+			return []string{msg}
+		}
+		out := make([]string, 0, 1+len(continuationTables))
+		out = append(out, msg)
+		out = append(out, continuationTables...)
+		return out
 	}
-	// Insert continuation table chunks immediately after the first message so
-	// readers see the rest of the strategy table before any position overflow.
-	out := make([]string, 0, len(msgs)+len(continuationTables))
-	out = append(out, msgs[0])
+
+	// Single-message fit is only viable when the leaderboard itself didn't
+	// already split. Otherwise the summary is multi-message anyway, and
+	// positions belong on their own block per #728.
+	if len(continuationTables) == 0 {
+		var single strings.Builder
+		single.WriteString(headerOnly)
+		for _, line := range posLines {
+			single.WriteString(fmt.Sprintf("  • %s\n", line))
+		}
+		single.WriteString(tradeSuffix)
+		if single.Len() <= discordSplitThreshold {
+			return []string{single.String()}
+		}
+	}
+
+	msg1 := headerOnly + tradeSuffix
+	posMsgs := buildPositionMessages(posLines)
+
+	out := make([]string, 0, 1+len(continuationTables)+len(posMsgs))
+	out = append(out, msg1)
 	out = append(out, continuationTables...)
-	out = append(out, msgs[1:]...)
+	out = append(out, posMsgs...)
 	return out
 }
 
-// splitCategorySummaryCore builds the message list without considering
-// strategy-table continuation chunks. Callers wanting continuation handling
-// should call splitCategorySummary instead.
-func splitCategorySummaryCore(header string, totalOpenPos int, posLines []string, tradeLines []string) []string {
+func buildSummaryHeader(header string, totalOpenPos int) string {
 	var sb strings.Builder
 	sb.WriteString(header)
-
-	// Position header
 	if totalOpenPos == 0 {
 		sb.WriteString("Positions: no open positions\n")
 	} else {
 		sb.WriteString(fmt.Sprintf("Positions: %d open\n", totalOpenPos))
 	}
+	return sb.String()
+}
 
-	// Trade details section
-	var tradeSuffix string
-	if len(tradeLines) > 0 {
-		var tsb strings.Builder
-		tsb.WriteString("\n**Trades:**\n")
-		for _, tl := range tradeLines {
-			tsb.WriteString(tl + "\n")
-		}
-		tradeSuffix = tsb.String()
+func buildTradeSuffix(tradeLines []string) string {
+	if len(tradeLines) == 0 {
+		return ""
 	}
+	var sb strings.Builder
+	sb.WriteString("\n**Trades:**\n")
+	for _, tl := range tradeLines {
+		sb.WriteString(tl + "\n")
+	}
+	return sb.String()
+}
 
-	// If no positions, just append trades and return.
-	if totalOpenPos == 0 || len(posLines) == 0 {
-		sb.WriteString(tradeSuffix)
-		return []string{sb.String()}
+// buildPositionMessages renders posLines as one or more Discord messages, each
+// under discordSplitThreshold. The first message is headed "Positions:"; any
+// spill-over messages are headed "Positions (cont'd):". Every line in posLines
+// appears in the returned slice — no truncation, no "... and N more".
+func buildPositionMessages(posLines []string) []string {
+	if len(posLines) == 0 {
+		return nil
 	}
-
-	// Try fitting everything in one message.
-	fullMsg := sb.String()
-	for _, line := range posLines {
-		fullMsg += fmt.Sprintf("  • %s\n", line)
-	}
-	fullMsg += tradeSuffix
-	if len(fullMsg) <= discordSplitThreshold {
-		return []string{fullMsg}
-	}
-
-	// Need to split: add positions until we approach the limit.
-	firstMsg := sb.String() // header + "Positions: N open\n"
-	included := 0
-	for _, line := range posLines {
-		candidate := fmt.Sprintf("  • %s\n", line)
-		// Reserve room for the "... and N more" indicator.
-		remaining := len(posLines) - included - 1
-		moreIndicator := ""
-		if remaining > 0 {
-			moreIndicator = fmt.Sprintf("  ... and %d more\n", remaining)
-		}
-		if len(firstMsg)+len(candidate)+len(moreIndicator) > discordSplitThreshold {
-			break
-		}
-		firstMsg += candidate
-		included++
-	}
-
-	if included < len(posLines) {
-		firstMsg += fmt.Sprintf("  ... and %d more\n", len(posLines)-included)
-	}
-
-	// If all positions fit (edge case where trades push us over), include trades in second message.
-	if included >= len(posLines) {
-		// Trades caused the overflow. Put all positions in first message, trades in second.
-		firstMsg = sb.String()
-		for _, line := range posLines {
-			firstMsg += fmt.Sprintf("  • %s\n", line)
-		}
-		if len(tradeSuffix) > 0 {
-			return []string{firstMsg, tradeSuffix}
-		}
-		return []string{firstMsg}
-	}
-
-	// Build continuation message(s) with remaining positions + trades.
 	var msgs []string
-	msgs = append(msgs, firstMsg)
-
-	contMsg := fmt.Sprintf("Positions (cont'd %d/%d):\n", included+1, len(posLines))
-	for _, line := range posLines[included:] {
-		candidate := fmt.Sprintf("  • %s\n", line)
-		if len(contMsg)+len(candidate) > discordSplitThreshold {
-			msgs = append(msgs, contMsg)
-			contMsg = fmt.Sprintf("Positions (cont'd):\n")
+	cur := "Positions:\n"
+	curHasContent := false
+	for _, line := range posLines {
+		bullet := fmt.Sprintf("  • %s\n", line)
+		if curHasContent && len(cur)+len(bullet) > discordSplitThreshold {
+			msgs = append(msgs, cur)
+			cur = "Positions (cont'd):\n"
+			curHasContent = false
 		}
-		contMsg += candidate
+		cur += bullet
+		curHasContent = true
 	}
-	if len(contMsg)+len(tradeSuffix) > discordSplitThreshold {
-		msgs = append(msgs, contMsg)
-		if tradeSuffix != "" {
-			msgs = append(msgs, tradeSuffix)
-		}
-	} else {
-		contMsg += tradeSuffix
-		msgs = append(msgs, contMsg)
+	if curHasContent {
+		msgs = append(msgs, cur)
 	}
-
 	return msgs
 }
 

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -1881,6 +1881,53 @@ func TestSplitCategorySummary_ContinuationTablesInserted(t *testing.T) {
 	}
 }
 
+// TestSplitCategorySummary_PeelTradesWhenMsg1Overflows covers the
+// belt-and-suspenders guard: when the header is already near the threshold and
+// the trades section would push msg 1 over the 2000-char Discord hard limit,
+// trades are peeled into their own message between msg 1 and the positions
+// block. (Bot review on #729 flagged this as a widened edge case post-refactor.)
+func TestSplitCategorySummary_PeelTradesWhenMsg1Overflows(t *testing.T) {
+	// Header sits just under the 1980 split threshold but well under 2000 alone.
+	header := strings.Repeat("h", 1950) + "\n"
+	posLines := []string{"alpha", "beta"}
+	// Big enough trades block that header+trades exceeds discordSplitThreshold.
+	var tradeLines []string
+	for i := 0; i < 5; i++ {
+		tradeLines = append(tradeLines, fmt.Sprintf("  • TRADE %d EXECUTED LONG BTC/USDT x0.025 @ $63,500.00", i))
+	}
+
+	msgs := splitCategorySummary(header, len(posLines), posLines, tradeLines, nil)
+	if len(msgs) < 3 {
+		t.Fatalf("expected at least 3 messages (header / trades / positions), got %d:\n%s", len(msgs), strings.Join(msgs, "\n---\n"))
+	}
+	for i, m := range msgs {
+		if len(m) > discordCharLimit {
+			t.Errorf("msg[%d] exceeds Discord hard limit %d: %d", i, discordCharLimit, len(m))
+		}
+	}
+	// msg[0]: header + count, no trades, no bullets.
+	if strings.Contains(msgs[0], "**Trades:**") {
+		t.Errorf("msg[0] should NOT contain trades section when peeled, got tail:\n%s", msgs[0][len(msgs[0])-200:])
+	}
+	if strings.Contains(msgs[0], "  • ") {
+		t.Errorf("msg[0] should NOT contain bullets, got tail:\n%s", msgs[0][len(msgs[0])-200:])
+	}
+	// msg[1]: trades only.
+	if !strings.Contains(msgs[1], "**Trades:**") {
+		t.Errorf("msg[1] should be the trades section, got:\n%s", msgs[1])
+	}
+	// Last msg: positions block with all bullets.
+	last := msgs[len(msgs)-1]
+	if !strings.HasPrefix(last, "Positions:\n") {
+		t.Errorf("final message should be positions block, got:\n%s", last)
+	}
+	for _, want := range posLines {
+		if !strings.Contains(last, want) {
+			t.Errorf("final message missing position %q:\n%s", want, last)
+		}
+	}
+}
+
 // TestSplitCategorySummary_PositionsAlwaysInSeparateMessage_Issue728 is the
 // canonical regression for #728. When the summary needs to split, every
 // position bullet must live in msg 2+; msg 1 carries the header, the

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -1087,25 +1087,44 @@ func TestFormatCategorySummary_MessageSplitting(t *testing.T) {
 		t.Errorf("expected multiple messages for 20 positions, got %d (total chars: %d)", len(msgs), totalLen)
 	}
 
-	// First message should contain "... and N more".
-	if !strings.Contains(msgs[0], "... and") {
-		t.Errorf("first message should contain '... and N more' indicator, got:\n%s", msgs[0])
+	// Per #728: msg 1 carries the header + counts but NO position bullets,
+	// no truncation indicator. All bullets land in msg 2+.
+	if strings.Contains(msgs[0], "  • ") {
+		t.Errorf("first message should not contain position bullets, got:\n%s", msgs[0])
+	}
+	if strings.Contains(msgs[0], "... and") {
+		t.Errorf("first message should not contain '... and N more' indicator under #728 layout, got:\n%s", msgs[0])
+	}
+	if !strings.Contains(msgs[0], "Positions: 20 open") {
+		t.Errorf("first message should still contain 'Positions: 20 open' summary line, got:\n%s", msgs[0])
 	}
 
-	// First message should not exceed the split threshold.
-	if len(msgs[0]) > discordCharLimit {
-		t.Errorf("first message exceeds %d chars: %d", discordCharLimit, len(msgs[0]))
+	// No message should exceed the Discord limit.
+	for i, m := range msgs {
+		if len(m) > discordCharLimit {
+			t.Errorf("msg[%d] exceeds %d chars: %d", i, discordCharLimit, len(m))
+		}
 	}
 
-	// Second message should contain continuation header.
-	if !strings.Contains(msgs[1], "cont'd") {
-		t.Errorf("second message should contain continuation header, got:\n%s", msgs[1])
+	// Positions block lives in msg 2+; first such message uses "Positions:" header.
+	posStart := -1
+	for i := 1; i < len(msgs); i++ {
+		if strings.HasPrefix(msgs[i], "Positions:\n") {
+			posStart = i
+			break
+		}
+	}
+	if posStart == -1 {
+		t.Fatalf("expected a 'Positions:' message after msg 0, got:\n%s", strings.Join(msgs, "\n---\n"))
 	}
 
-	// All position lines should appear across all messages.
-	allMsgs := strings.Join(msgs, "\n")
-	if !strings.Contains(allMsgs, "Positions: 20 open") {
-		t.Errorf("expected 'Positions: 20 open' header, got:\n%s", allMsgs)
+	// Every position line must appear in the positions block (no truncation).
+	posBlock := strings.Join(msgs[posStart:], "\n")
+	for i := 0; i < 20; i++ {
+		want := fmt.Sprintf("hl-strat%02d-btc", i)
+		if !strings.Contains(posBlock, want) {
+			t.Errorf("position for %s missing from positions block:\n%s", want, posBlock)
+		}
 	}
 }
 
@@ -1832,22 +1851,73 @@ func TestFormatCategorySummary_LargeTableChunked(t *testing.T) {
 
 func TestSplitCategorySummary_ContinuationTablesInserted(t *testing.T) {
 	// Continuation tables should be spliced in immediately after the first message.
+	// Per #728: when continuation tables exist, positions also get their own
+	// message after the table chunks (never interleaved with msg 1).
 	header := "Header line\n"
 	posLines := []string{"pos1", "pos2"}
 	conts := []string{"```\nchunk2\n```\n", "```\nchunk3\n```\n"}
 
 	msgs := splitCategorySummary(header, 2, posLines, nil, conts)
-	if len(msgs) != 3 {
-		t.Fatalf("expected 3 messages (1 main + 2 continuation tables), got %d", len(msgs))
+	if len(msgs) != 4 {
+		t.Fatalf("expected 4 messages (header + 2 table conts + positions), got %d:\n%s", len(msgs), strings.Join(msgs, "\n---\n"))
 	}
 	if !strings.Contains(msgs[0], "Header line") {
 		t.Errorf("msg[0] should contain header, got: %s", msgs[0])
+	}
+	if strings.Contains(msgs[0], "  • ") {
+		t.Errorf("msg[0] should not contain position bullets, got: %s", msgs[0])
 	}
 	if msgs[1] != conts[0] {
 		t.Errorf("msg[1] should be first continuation table, got: %s", msgs[1])
 	}
 	if msgs[2] != conts[1] {
 		t.Errorf("msg[2] should be second continuation table, got: %s", msgs[2])
+	}
+	if !strings.HasPrefix(msgs[3], "Positions:\n") {
+		t.Errorf("msg[3] should be positions block, got: %s", msgs[3])
+	}
+	if !strings.Contains(msgs[3], "pos1") || !strings.Contains(msgs[3], "pos2") {
+		t.Errorf("msg[3] should contain all positions, got: %s", msgs[3])
+	}
+}
+
+// TestSplitCategorySummary_PositionsAlwaysInSeparateMessage_Issue728 is the
+// canonical regression for #728. When the summary needs to split, every
+// position bullet must live in msg 2+; msg 1 carries the header, the
+// "Positions: N open" count, trades, and nothing else position-related.
+func TestSplitCategorySummary_PositionsAlwaysInSeparateMessage_Issue728(t *testing.T) {
+	// Big enough header that positions cannot fit alongside it (threshold 1980).
+	header := strings.Repeat("h", 1900) + "\n"
+	posLines := []string{"alpha", "beta", "gamma"}
+	tradeLines := []string{"  • TRADE EXECUTED LONG BTC"}
+
+	msgs := splitCategorySummary(header, len(posLines), posLines, tradeLines, nil)
+	if len(msgs) < 2 {
+		t.Fatalf("expected split, got %d msgs", len(msgs))
+	}
+
+	// msg[0]: header + "Positions: N open" + trades, no bullets, no truncation marker.
+	if !strings.Contains(msgs[0], "Positions: 3 open") {
+		t.Errorf("msg[0] should contain position count line, got tail:\n%s", msgs[0][len(msgs[0])-200:])
+	}
+	if !strings.Contains(msgs[0], "**Trades:**") {
+		t.Errorf("msg[0] should contain trades section, got tail:\n%s", msgs[0][len(msgs[0])-200:])
+	}
+	if strings.Contains(msgs[0], "  • alpha") || strings.Contains(msgs[0], "  • beta") || strings.Contains(msgs[0], "  • gamma") {
+		t.Errorf("msg[0] should NOT contain any position bullet under #728 layout, got tail:\n%s", msgs[0][len(msgs[0])-200:])
+	}
+	if strings.Contains(msgs[0], "... and") {
+		t.Errorf("msg[0] should NOT contain '... and N more' truncation marker, got tail:\n%s", msgs[0][len(msgs[0])-200:])
+	}
+
+	// msg[1]: positions block, all bullets present, "Positions:" header.
+	if !strings.HasPrefix(msgs[1], "Positions:\n") {
+		t.Errorf("msg[1] should begin with 'Positions:' header, got:\n%s", msgs[1])
+	}
+	for _, want := range []string{"alpha", "beta", "gamma"} {
+		if !strings.Contains(msgs[1], want) {
+			t.Errorf("msg[1] should contain position %q, got:\n%s", want, msgs[1])
+		}
 	}
 }
 
@@ -1978,16 +2048,24 @@ func TestSplitCategorySummary_MultiMessage(t *testing.T) {
 	if len(msgs) < 2 {
 		t.Fatalf("expected multiple messages with large header, got %d", len(msgs))
 	}
-	// First message should have "... and N more"
-	if !strings.Contains(msgs[0], "... and") {
-		t.Errorf("expected '... and N more' in first message, got:\n%s", msgs[0][:100])
+	// Per #728: msg 1 has the header + count line, no position bullets,
+	// no "... and N more" truncation.
+	if strings.Contains(msgs[0], "  • ") {
+		t.Errorf("first message should not contain position bullets, got tail:\n%s", msgs[0][len(msgs[0])-200:])
 	}
-	// All positions should appear across messages
-	all := strings.Join(msgs, "\n")
+	if strings.Contains(msgs[0], "... and") {
+		t.Errorf("first message should not contain '... and N more' under #728 layout, got tail:\n%s", msgs[0][len(msgs[0])-200:])
+	}
+	// All positions should appear in the positions block (msg 2+).
+	posBlock := strings.Join(msgs[1:], "\n")
 	for _, pl := range posLines {
-		if !strings.Contains(all, pl) {
-			t.Errorf("position %q missing from messages", pl)
+		if !strings.Contains(posBlock, pl) {
+			t.Errorf("position %q missing from positions block:\n%s", pl, posBlock)
 		}
+	}
+	// Positions block starts with "Positions:" header.
+	if !strings.HasPrefix(msgs[1], "Positions:\n") {
+		t.Errorf("msg[1] should start with 'Positions:' header, got:\n%s", msgs[1])
 	}
 }
 


### PR DESCRIPTION
## Summary
When the category summary needs to split across Discord messages, the full open-positions list now lives in its own message(s) instead of being packed into msg 1 with a `... and N more` truncation.

Closes #728

## Behavior change
- **Single-message fit (unchanged):** if header + positions + trades fit under the threshold and there are no leaderboard continuation chunks, return a single message.
- **Split required:**
  - msg 1: header (incl. top leaderboard table chunk) + `Positions: N open` line + trades section
  - leaderboard continuation table chunks (if any)
  - one or more position-only messages headed `Positions:` / `Positions (cont'd):` with every bullet present — no truncation, no `... and N more`

## Implementation
`splitCategorySummary` (`scheduler/discord.go:557`) rewritten in terms of three small helpers (`buildSummaryHeader`, `buildTradeSuffix`, `buildPositionMessages`). The old `splitCategorySummaryCore` is gone — its responsibilities are now split between the helpers and the simpler driver.

## Test plan
- [x] `TestSplitCategorySummary_PositionsAlwaysInSeparateMessage_Issue728` — new regression: asserts msg 1 has no `  • ` bullets and no `... and N more`, and msg 2 starts with `Positions:` and contains every line.
- [x] `TestFormatCategorySummary_MessageSplitting` — updated for the new layout (20 positions on hyperliquid).
- [x] `TestSplitCategorySummary_MultiMessage` — updated for the new layout (large header forcing split).
- [x] `TestSplitCategorySummary_ContinuationTablesInserted` — updated: positions now land after the table chunks (4 msgs total).
- [x] `TestSplitCategorySummary_LongPositionLines`, `TestSplitCategorySummary_SingleMessage`, `TestFormatCategorySummary_LargeTableChunked`, `TestFormatCategorySummary_NoSplitWhenShort` — pass unmodified.
- [x] Full `go -C scheduler test ./...` — green.

---
LLM: Claude Opus 4.7 | high