### PR TITLE
fix(backtest): regime gate shift + look-ahead contract + regression tests

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -1,6 +1,45 @@
 """
 Backtesting engine — simulates strategy execution on historical data.
 Calculates comprehensive performance metrics.
+
+Look-ahead contract (#730)
+--------------------------
+The engine simulates the live trading cycle, which runs at end-of-bar:
+  1. Strategy reads OHLCV through bar N's close.
+  2. Strategy emits signal, regime label, indicators (all using bar-N-closed data).
+  3. Scheduler places order. Order fills at start of bar N+1's open.
+
+To preserve that ordering in vectorized form, ``run()`` shifts every column
+that represents a *decision input* forward by one bar before the per-bar
+loop reads it, so row N+1 carries the decision values computed from bar N's
+closed data:
+  • ``signal``        — shift(1) at :421 → fills at row N+1's open at :495
+  • ``_open_action``  — shift(1) at :431 (open/close-split mode)
+  • ``_close_fraction`` (column-based) — shift(1) at :432
+  • ``regime``        — shift(1) post-injection (#730) so entries gate on
+                        bar N's regime, not bar N+1's.
+
+Close evaluators run end-of-bar at :660-664 against bar N's mark and bar N's
+ATR. Their result becomes ``pending_close_fraction``, applied at row N+1's
+open — same alignment as the rest of the close pipeline. The current-bar ATR
+access at :815-821 is intentional and matches live: close evaluators see the
+ATR at decision time, not a frozen entry-time snapshot.
+
+Indicator semantics
+-------------------
+Indicator columns supplied by the caller (``atr``, ``regime``, ``adx``, etc.)
+represent bar N's value computed from data through bar N's close. The engine
+treats them as closed-bar quantities. Caller strategy scripts MUST NOT emit
+forward-peeking signals (e.g. ``signal = (close.shift(-1) > close)``); the
+shift(1) at :421 is the only look-ahead guard on the signal path and is
+defeated by upstream peeking. ``backtest/tests/test_backtester_lookahead.py``
+regression-tests the shift's effectiveness.
+
+SL/TP intra-bar races
+---------------------
+Bar-level granularity — when an SL hit and a TP fill could both occur within
+the same bar, the engine resolves them at bar close, not by intra-bar OHLC
+walking. Documented under ``Backtest`` in CLAUDE.md.
 """
 
 import sys
@@ -438,6 +477,21 @@ class Backtester:
             ensure_regime = _load_regime()
             ensure_regime(df, period=self.regime_period, adx_threshold=self.regime_adx_threshold)
 
+        # Shift regime to match the signal shift at :421. In live, the regime
+        # label is computed from bar N's closed data at the same moment as
+        # the signal; both gate the order that fills at bar N+1's open. Here
+        # the signal is already shifted forward by one row, so the regime
+        # consumed at row N+1 must be bar N's regime — not the regime that
+        # would only be knowable after bar N+1 closes. Without this shift,
+        # the entry gate at :520 reads a future bar's regime relative to the
+        # decision time, which is look-ahead bias (#730).
+        #
+        # Empty/missing regime (e.g. row 0 after shift) → empty string, which
+        # fails the ``in allowed_regimes`` check and blocks the entry. That
+        # matches live behavior: no regime data, no entry.
+        if self.regime_enabled and "regime" in df.columns:
+            df["regime"] = df["regime"].shift(1).fillna("")
+
         has_open = "open" in df.columns
 
         cash = self.initial_capital
@@ -513,10 +567,13 @@ class Backtester:
             equity = cash + position * mark_price
             equity_curve.append({"date": idx, "equity": equity})
 
-            # Regime gate: block new entries when the bar's regime isn't in the
-            # allowed set. Existing positions are always managed by close paths.
-            # ``compute_regime`` initializes every row to ``"ranging"`` (warmup
-            # bars included), so bar_regime is always a non-empty label here.
+            # Regime gate: block new entries when the prior bar's regime
+            # isn't in the allowed set. Existing positions are always managed
+            # by close paths. ``compute_regime`` initializes every row to
+            # ``"ranging"`` (warmup bars included). After the post-injection
+            # shift (#730) row 0 is empty — that empty label fails the
+            # ``in allowed_regimes`` check and blocks the bar-0 entry, which
+            # is correct (no prior-bar data, no decision).
             bar_regime = str(row.get("regime", "")) if self.regime_enabled else ""
             regime_blocked = (
                 self.regime_enabled
@@ -813,6 +870,15 @@ class Backtester:
         }
         market_dict = {"mark_price": float(mark_price)}
         if atr_series is not None:
+            # Current-bar ATR access is intentional and matches live (#730):
+            # close evaluators run end-of-bar with this bar's closed mark and
+            # this bar's closed ATR; the resulting close_fraction becomes
+            # pending_close_fraction and applies at the NEXT bar's open. This
+            # is the live ``tiered_tp_atr_live`` contract — see CLAUDE.md
+            # "ATR for close evaluators". Entries, by contrast, gate on the
+            # PRIOR bar's regime/signal via the shifts at :421/:431/:452 —
+            # different timing for different decision points, both matching
+            # live.
             try:
                 live_atr = float(atr_series.loc[idx])
             except (KeyError, TypeError, ValueError):

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -13,17 +13,19 @@ To preserve that ordering in vectorized form, ``run()`` shifts every column
 that represents a *decision input* forward by one bar before the per-bar
 loop reads it, so row N+1 carries the decision values computed from bar N's
 closed data:
-  • ``signal``        — shift(1) at :421 → fills at row N+1's open at :495
-  • ``_open_action``  — shift(1) at :431 (open/close-split mode)
-  • ``_close_fraction`` (column-based) — shift(1) at :432
-  • ``regime``        — shift(1) post-injection (#730) so entries gate on
-                        bar N's regime, not bar N+1's.
+  • ``signal``         — shift(1) in the signal-normalization block; fills
+                         at row N+1's open in the per-bar entry block.
+  • ``_open_action``   — shift(1) in the open/close-split normalization block.
+  • ``_close_fraction`` (column-based) — shift(1) in the same block.
+  • ``regime``         — shift(1) in the regime-shift block (post-injection,
+                         #730) so entries gate on bar N's regime, not N+1's.
 
-Close evaluators run end-of-bar at :660-664 against bar N's mark and bar N's
-ATR. Their result becomes ``pending_close_fraction``, applied at row N+1's
-open — same alignment as the rest of the close pipeline. The current-bar ATR
-access at :815-821 is intentional and matches live: close evaluators see the
-ATR at decision time, not a frozen entry-time snapshot.
+Close evaluators run end-of-bar in ``_evaluate_close_strategies`` against
+bar N's mark and bar N's ATR. Their result becomes ``pending_close_fraction``,
+applied at row N+1's open — same alignment as the rest of the close pipeline.
+The current-bar ATR access in the ``market_dict`` build is intentional and
+matches live: close evaluators see the ATR at decision time, not a frozen
+entry-time snapshot.
 
 Indicator semantics
 -------------------
@@ -31,7 +33,7 @@ Indicator columns supplied by the caller (``atr``, ``regime``, ``adx``, etc.)
 represent bar N's value computed from data through bar N's close. The engine
 treats them as closed-bar quantities. Caller strategy scripts MUST NOT emit
 forward-peeking signals (e.g. ``signal = (close.shift(-1) > close)``); the
-shift(1) at :421 is the only look-ahead guard on the signal path and is
+signal ``shift(1)`` is the only look-ahead guard on the signal path and is
 defeated by upstream peeking. ``backtest/tests/test_backtester_lookahead.py``
 regression-tests the shift's effectiveness.
 
@@ -477,18 +479,21 @@ class Backtester:
             ensure_regime = _load_regime()
             ensure_regime(df, period=self.regime_period, adx_threshold=self.regime_adx_threshold)
 
-        # Shift regime to match the signal shift at :421. In live, the regime
-        # label is computed from bar N's closed data at the same moment as
-        # the signal; both gate the order that fills at bar N+1's open. Here
-        # the signal is already shifted forward by one row, so the regime
-        # consumed at row N+1 must be bar N's regime — not the regime that
-        # would only be knowable after bar N+1 closes. Without this shift,
-        # the entry gate at :520 reads a future bar's regime relative to the
-        # decision time, which is look-ahead bias (#730).
+        # Shift regime to match the signal shift in the signal-normalization
+        # block above. In live, the regime label is computed from bar N's
+        # closed data at the same moment as the signal; both gate the order
+        # that fills at bar N+1's open. Here the signal is already shifted
+        # forward by one row, so the regime consumed at row N+1 must be bar
+        # N's regime — not the regime that would only be knowable after bar
+        # N+1 closes. Without this shift, the entry gate in the per-bar loop
+        # reads a future bar's regime relative to the decision time, which
+        # is look-ahead bias (#730).
         #
-        # Empty/missing regime (e.g. row 0 after shift) → empty string, which
-        # fails the ``in allowed_regimes`` check and blocks the entry. That
-        # matches live behavior: no regime data, no entry.
+        # Empty/missing regime (e.g. row 0 after shift, or mid-series NaN
+        # rows from upstream gaps) → empty string after fillna, which fails
+        # the ``in allowed_regimes`` check and blocks the entry. That matches
+        # live behavior: no regime data, no entry. Intentional — do not
+        # "fix" the fillna to forward-fill or interpolate.
         if self.regime_enabled and "regime" in df.columns:
             df["regime"] = df["regime"].shift(1).fillna("")
 
@@ -876,9 +881,10 @@ class Backtester:
             # pending_close_fraction and applies at the NEXT bar's open. This
             # is the live ``tiered_tp_atr_live`` contract — see CLAUDE.md
             # "ATR for close evaluators". Entries, by contrast, gate on the
-            # PRIOR bar's regime/signal via the shifts at :421/:431/:452 —
-            # different timing for different decision points, both matching
-            # live.
+            # PRIOR bar's regime/signal via the shifts in the
+            # signal-normalization and regime-shift blocks at the top of
+            # ``run()`` — different timing for different decision points,
+            # both matching live.
             try:
                 live_atr = float(atr_series.loc[idx])
             except (KeyError, TypeError, ValueError):

--- a/backtest/tests/test_backtester_lookahead.py
+++ b/backtest/tests/test_backtester_lookahead.py
@@ -5,11 +5,13 @@ These tests pin the engine's look-ahead contract so future refactors can't
 silently regress it:
 
   1. Entry fill timing — signal computed on bar N fills at bar N+1's open.
-     The shift(1) at backtester.py:421 is the only thing preventing same-bar
-     fill from a signal generated at end-of-bar.
+     The ``shift(1)`` in the signal-normalization block of
+     ``Backtester.run`` is the only thing preventing same-bar fill from a
+     signal generated at end-of-bar.
   2. Regime gate timing — regime label gating entry at row N+1 must be the
      regime from bar N's closed data, not bar N+1's (#730 Gap 1). Backtester
-     shifts the regime column post-injection at backtester.py:447-452.
+     shifts the regime column post-injection in the regime-shift block of
+     ``Backtester.run``.
   3. Forward-peek contract — strategies that peek forward (e.g.
      ``signal = (close.shift(-1) > close)``) WILL inflate returns. The shift
      is not a defense against caller-side forward-peeking; it only enforces
@@ -58,9 +60,10 @@ def _step_up_df(n: int = 20, jump_bar: int = 10, jump_pct: float = 0.10) -> pd.D
 
 def test_signal_at_bar_k_fills_at_bar_k_plus_1_open():
     """Signal=1 at bar K must fill at row K+1's open price (the shift(1)
-    contract). If anyone removes the shift at backtester.py:421, this test
-    detects it: the entry would land at bar K's open (the jump) and the
-    backtest would book a +10% gain instead of ~0%.
+    contract). If anyone removes the shift in the signal-normalization
+    block of ``Backtester.run``, this test detects it: the entry would land
+    at bar K's open (the jump) and the backtest would book a +10% gain
+    instead of ~0%.
     """
     df = _step_up_df(n=20, jump_bar=10, jump_pct=0.10)
     df["signal"] = 0
@@ -80,18 +83,24 @@ def test_signal_at_bar_k_fills_at_bar_k_plus_1_open():
     # bar 9 + 1 = bar 10 = 2024-01-11
     assert entry_date == df.index[10], (
         f"Entry filled at {entry_date}, expected {df.index[10]} (bar 10 = signal_bar + 1). "
-        f"Shift-by-1 protection at backtester.py:421 may be broken."
+        f"Shift-by-1 protection in the signal-normalization block of "
+        f"Backtester.run may be broken."
     )
     assert entry_price == 100.0, f"Expected entry at bar 10's open=100, got {entry_price}"
 
 
-def test_signal_with_intra_bar_jump_does_not_capture_jump():
-    """End-to-end variant: a signal that 'magically' fires the bar BEFORE
-    a jump still doesn't capture the jump, because the entry fills at the
-    jump bar's open (post-jump close, pre-jump open — but the close already
-    reflects the jump).
+def test_intra_bar_jump_captured_at_next_bar_open_documents_limit():
+    """End-to-end variant documenting the engine's *fill-timing only*
+    contract: a signal that 'magically' fires the bar BEFORE a jump DOES
+    capture the jump in this fixture, because the entry fills at the jump
+    bar's open (which is still pre-jump in our setup) and then rides the
+    intra-bar move up to the post-jump close.
 
-    This pins the entry fill price to bar K+1's open, not bar K's close.
+    This pins the entry fill price to bar K+1's OPEN (not bar K's close,
+    and not bar K+1's close): the shift only enforces next-bar fill
+    timing — it is NOT a defense against caller-side forward-peeking.
+    True forward-peek protection is the caller's responsibility (closed-bar
+    indicator consumption).
     """
     df = _step_up_df(n=20, jump_bar=10, jump_pct=0.20)
     df["signal"] = 0
@@ -148,7 +157,7 @@ def test_regime_gate_uses_prior_bar_regime_not_current():
     assert result["total_trades"] == 1, (
         "Entry should pass: bar 9's regime is 'trending_up' (allowed). "
         "If 0 trades, the backtester is reading bar 10's regime (look-ahead) "
-        "instead of bar 9's. See backtester.py:447-452 regime shift."
+        "instead of bar 9's. See the regime-shift block in Backtester.run."
     )
 
 
@@ -172,7 +181,7 @@ def test_regime_gate_blocks_when_prior_bar_regime_disallows():
     assert result["total_trades"] == 0, (
         "Entry should be blocked by bar 9's 'ranging' regime. "
         "If a trade fired, the backtester is reading bar 10's regime "
-        "(look-ahead). See backtester.py:447-452 regime shift."
+        "(look-ahead). See the regime-shift block in Backtester.run."
     )
 
 
@@ -230,7 +239,8 @@ def test_forward_peek_signal_documents_caller_responsibility():
         f"Forward-peek signal should inflate returns past buy-and-hold "
         f"(documented limit). Got {final_pct:.1f}% vs BAH {buy_and_hold_pct:.1f}%. "
         f"If this assertion fails, the engine has gained forward-peek detection — "
-        f"update the test and the docstring at backtester.py:1-40."
+        f"update the test and the look-ahead contract docstring at the top of "
+        f"backtest/backtester.py."
     )
 
 

--- a/backtest/tests/test_backtester_lookahead.py
+++ b/backtest/tests/test_backtester_lookahead.py
@@ -1,0 +1,255 @@
+"""
+Look-ahead bias regression tests for Backtester (issue #730).
+
+These tests pin the engine's look-ahead contract so future refactors can't
+silently regress it:
+
+  1. Entry fill timing — signal computed on bar N fills at bar N+1's open.
+     The shift(1) at backtester.py:421 is the only thing preventing same-bar
+     fill from a signal generated at end-of-bar.
+  2. Regime gate timing — regime label gating entry at row N+1 must be the
+     regime from bar N's closed data, not bar N+1's (#730 Gap 1). Backtester
+     shifts the regime column post-injection at backtester.py:447-452.
+  3. Forward-peek contract — strategies that peek forward (e.g.
+     ``signal = (close.shift(-1) > close)``) WILL inflate returns. The shift
+     is not a defense against caller-side forward-peeking; it only enforces
+     next-bar fill timing. This is a documented limitation — strategy
+     scripts are responsible for not peeking.
+"""
+import sys
+import pathlib
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / "shared_tools"))
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from backtester import Backtester
+
+
+def _step_up_df(n: int = 20, jump_bar: int = 10, jump_pct: float = 0.10) -> pd.DataFrame:
+    """Flat price with a single up-jump at ``jump_bar``.
+
+    Designed so that the entry fill price differs sharply depending on
+    whether the engine fills at bar K's open vs bar K+1's open:
+      • close[K-1] = open[K] = 100, close[K] = open[K+1] = 110 (jump),
+        close[K+1] = 110 (held).
+      • Entry at open[K] = 100 → captures the jump → +10% return.
+      • Entry at open[K+1] = 110 → misses the jump → ~0% return.
+    """
+    close = np.full(n, 100.0)
+    close[jump_bar:] = 100.0 * (1.0 + jump_pct)
+    open_ = close.copy()
+    # open[K] = pre-jump price (matches close[K-1]) — the jump happens
+    # within bar K, between open and close.
+    open_[jump_bar] = 100.0
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    return pd.DataFrame(
+        {"open": open_, "high": np.maximum(open_, close) + 0.01,
+         "low": np.minimum(open_, close) - 0.01, "close": close,
+         "volume": 1000.0},
+        index=idx,
+    )
+
+
+# ─── 1. Entry fills at next bar's open, not same bar ─────────────────────────
+
+
+def test_signal_at_bar_k_fills_at_bar_k_plus_1_open():
+    """Signal=1 at bar K must fill at row K+1's open price (the shift(1)
+    contract). If anyone removes the shift at backtester.py:421, this test
+    detects it: the entry would land at bar K's open (the jump) and the
+    backtest would book a +10% gain instead of ~0%.
+    """
+    df = _step_up_df(n=20, jump_bar=10, jump_pct=0.10)
+    df["signal"] = 0
+    # Signal placed on bar 9 (pre-jump). Pre-shift contract:
+    # signal generator saw close[9] = 100, didn't see close[10] = 110.
+    df.iloc[9, df.columns.get_loc("signal")] = 1
+
+    bt = Backtester(initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0)
+    result = bt.run(df, save=False)
+
+    assert result["total_trades"] >= 1
+    entry_price = result["trades"][0]["entry_price"]
+    # Bar 10's open = 100 (pre-jump). If shift is broken, entry would be
+    # at bar 9's open = 100 (also 100 — bad luck with this fixture).
+    # The discriminator is the entry timestamp.
+    entry_date = pd.Timestamp(result["trades"][0]["entry_date"])
+    # bar 9 + 1 = bar 10 = 2024-01-11
+    assert entry_date == df.index[10], (
+        f"Entry filled at {entry_date}, expected {df.index[10]} (bar 10 = signal_bar + 1). "
+        f"Shift-by-1 protection at backtester.py:421 may be broken."
+    )
+    assert entry_price == 100.0, f"Expected entry at bar 10's open=100, got {entry_price}"
+
+
+def test_signal_with_intra_bar_jump_does_not_capture_jump():
+    """End-to-end variant: a signal that 'magically' fires the bar BEFORE
+    a jump still doesn't capture the jump, because the entry fills at the
+    jump bar's open (post-jump close, pre-jump open — but the close already
+    reflects the jump).
+
+    This pins the entry fill price to bar K+1's open, not bar K's close.
+    """
+    df = _step_up_df(n=20, jump_bar=10, jump_pct=0.20)
+    df["signal"] = 0
+    df.iloc[9, df.columns.get_loc("signal")] = 1   # buy
+    df.iloc[15, df.columns.get_loc("signal")] = -1  # sell
+
+    bt = Backtester(initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0)
+    result = bt.run(df, save=False)
+
+    # Entry at bar 10's open = 100 (the open is pre-jump; close is post-jump).
+    # Exit at bar 16's open = 120 (post-jump, flat thereafter).
+    # P&L ≈ +20% — captures the jump because entry happened to land at
+    # bar 10's open which is still pre-jump in our fixture.
+    #
+    # This documents the contract: the shift puts the fill at bar K+1's
+    # OPEN, not close. A strategy peeking forward by 1 bar and emitting
+    # signal at bar K-1 will still capture moves that happen WITHIN bar K
+    # (between bar K's open and close). True forward-peek protection
+    # requires the caller to not peek; the engine only enforces timing.
+    final_pct = (result["final_capital"] - 1000.0) / 1000.0 * 100.0
+    assert final_pct > 15.0, (
+        f"Expected ≥+15% (captures intra-bar jump at bar 10's open), got {final_pct:.2f}%"
+    )
+
+
+# ─── 2. Regime gate uses bar N's regime when entry fills at bar N+1 ──────────
+
+
+def test_regime_gate_uses_prior_bar_regime_not_current():
+    """The regime gating an entry at row N+1 must be bar N's regime
+    (knowable at decision time), not bar N+1's regime (only knowable after
+    bar N+1 closes). Pre-#730 the backtester used the row-N+1 regime —
+    look-ahead.
+
+    Test: signal at bar 9 → entry at bar 10's open. Set bar 9's regime to
+    'trending_up' (allowed) and bar 10's regime to 'ranging' (not allowed).
+    Post-fix, the entry sees bar 9's regime → entry passes.
+    Pre-fix, the entry saw bar 10's regime → entry blocked.
+    """
+    df = _step_up_df(n=20, jump_bar=15)
+    df["signal"] = 0
+    df.iloc[9, df.columns.get_loc("signal")] = 1
+    # Hand-construct regime so the test depends on which bar's regime is read.
+    df["regime"] = "ranging"
+    df.iloc[9, df.columns.get_loc("regime")] = "trending_up"   # bar 9 (decision)
+    # bar 10's regime stays "ranging" — pre-fix this blocks the entry.
+
+    bt = Backtester(
+        initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0,
+        regime_enabled=True, allowed_regimes=["trending_up"],
+    )
+    result = bt.run(df, save=False)
+
+    assert result["total_trades"] == 1, (
+        "Entry should pass: bar 9's regime is 'trending_up' (allowed). "
+        "If 0 trades, the backtester is reading bar 10's regime (look-ahead) "
+        "instead of bar 9's. See backtester.py:447-452 regime shift."
+    )
+
+
+def test_regime_gate_blocks_when_prior_bar_regime_disallows():
+    """Opposite of the above: bar N's regime disallows, bar N+1's regime
+    would have allowed. Entry must be blocked (gate honors bar N).
+    """
+    df = _step_up_df(n=20, jump_bar=15)
+    df["signal"] = 0
+    df.iloc[9, df.columns.get_loc("signal")] = 1
+    df["regime"] = "trending_up"
+    df.iloc[9, df.columns.get_loc("regime")] = "ranging"   # bar 9 disallows
+    # bar 10's regime is "trending_up" — pre-fix this would let entry pass.
+
+    bt = Backtester(
+        initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0,
+        regime_enabled=True, allowed_regimes=["trending_up"],
+    )
+    result = bt.run(df, save=False)
+
+    assert result["total_trades"] == 0, (
+        "Entry should be blocked by bar 9's 'ranging' regime. "
+        "If a trade fired, the backtester is reading bar 10's regime "
+        "(look-ahead). See backtester.py:447-452 regime shift."
+    )
+
+
+# ─── 3. Forward-peek in caller signal is NOT defended (documented limit) ─────
+
+
+def test_forward_peek_signal_documents_caller_responsibility():
+    """A signal generator that peeks forward by 1 bar
+    (``signal = (close.shift(-1) > close)``) bypasses the engine's
+    shift(1). The shift moves the signal from row N to row N+1; the
+    forward-peek read close[N+1] when computing signal[N]; net result:
+    the engine fills at row N+1's open knowing the bar will close higher
+    than the prior bar.
+
+    This is a DOCUMENTED LIMITATION (#730): the engine enforces fill
+    timing, not signal purity. Callers are responsible for closed-bar
+    indicator consumption.
+
+    Test asserts that a forward-peek signal produces returns meaningfully
+    above a no-trade baseline — confirming the engine does NOT magically
+    catch forward-peeking strategies. If a future change makes the engine
+    detect/reject forward-peek signals, this test should be updated to
+    reflect the new contract.
+    """
+    n = 200
+    rng = np.random.default_rng(42)
+    returns = rng.normal(0.001, 0.02, n)  # noisy upward drift
+    close = 100.0 * np.cumprod(1.0 + returns)
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame(
+        {"open": close, "high": close * 1.005, "low": close * 0.995,
+         "close": close, "volume": 1000.0},
+        index=idx,
+    )
+    # Forward-peek: 1 if next bar closes higher, else -1.
+    df["signal"] = np.where(
+        df["close"].shift(-1) > df["close"], 1, -1
+    ).astype(int)
+    # First/last NaN-derived values get fillna(0) inside the backtester.
+    df.loc[df.index[-1], "signal"] = 0
+
+    bt = Backtester(initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0)
+    result = bt.run(df, save=False)
+
+    # Buy-and-hold baseline for comparison.
+    buy_and_hold_pct = (close[-1] - close[0]) / close[0] * 100.0
+    final_pct = (result["final_capital"] - 1000.0) / 1000.0 * 100.0
+
+    # Forward-peek with shift still beats buy-and-hold by a wide margin
+    # because the signal correlates with next-bar direction and the entry
+    # at row N+1's open captures bar N+1's intraday move (open → close).
+    # We assert strictly above buy-and-hold to lock in the contract that
+    # the engine does NOT defend against forward-peek.
+    assert final_pct > buy_and_hold_pct + 20.0, (
+        f"Forward-peek signal should inflate returns past buy-and-hold "
+        f"(documented limit). Got {final_pct:.1f}% vs BAH {buy_and_hold_pct:.1f}%. "
+        f"If this assertion fails, the engine has gained forward-peek detection — "
+        f"update the test and the docstring at backtester.py:1-40."
+    )
+
+
+def test_shift_moves_signal_by_exactly_one_row():
+    """Mechanical test of the shift(1): a single signal=1 at bar K produces
+    an entry at bar K+1, not bar K and not bar K+2.
+
+    This is the cheapest possible canary for the shift's presence.
+    """
+    df = _step_up_df(n=20, jump_bar=15)
+    df["signal"] = 0
+    df.iloc[5, df.columns.get_loc("signal")] = 1
+    df.iloc[10, df.columns.get_loc("signal")] = -1
+
+    bt = Backtester(initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0)
+    result = bt.run(df, save=False)
+
+    assert result["total_trades"] == 1
+    entry_date = pd.Timestamp(result["trades"][0]["entry_date"])
+    exit_date = pd.Timestamp(result["trades"][0]["exit_date"])
+    assert entry_date == df.index[6], f"Entry should be at bar 6, got {entry_date}"
+    assert exit_date == df.index[11], f"Exit should be at bar 11, got {exit_date}"


### PR DESCRIPTION
## Summary

- Fix regime-gate look-ahead in `Backtester`: regime column is shifted by 1 post-injection so the entry gate at row N+1 reads bar N's regime (matches live), not bar N+1's. Pre-fix, the gate consumed a regime label that depended on bar N+1's high/low/close — data not knowable at decision time.
- Add a top-of-file look-ahead contract docstring in `backtest/backtester.py` documenting entries (fill N+1 open), close evaluators (eval N close, fill N+1 open), SL/TP (bar-granular), and the caller-side forward-peek limitation.
- Add 6 regression tests in `backtest/tests/test_backtester_lookahead.py` pinning the shift(1) signal protection, regime-gate prior-bar semantics (positive + negative), and the documented forward-peek limit.
- Add inline comment at `_evaluate_close_strategies` explaining intentional current-bar ATR access (live `tiered_tp_atr_live` parity).

Closes #730.

## Audit findings (out-of-scope, follow-up filed)

Per issue acceptance criterion 5, audited `shared_strategies/open/` and `shared_strategies/close/` for unshifted indicator consumption. Found three high-severity look-ahead bugs at the strategy layer that are independent of the engine fix in this PR. Filed as a single follow-up issue (linked below).

Clean: `session_breakout.py`, `range_scalper.py`, all of `shared_strategies/close/`.

## Test plan

- [x] `pytest shared_strategies/ shared_tools/ platforms/ backtest/` — 965 passed (was 959 baseline + 6 new look-ahead tests).
- [x] `go test ./...` — ok.
- [x] `go build` — clean.
- [x] Existing regime test `test_regime_gate_does_not_close_open_position` continues to pass post-shift (manually-constructed regime column is robust to the shift since adjacent bars are equal).
- [ ] CI green.

---
LLM: Claude Opus 4.7 (1M) | high