### PR TITLE
fix(strategies): remove look-ahead bias in amd_ifvg, liquidity_sweeps, chart_patterns (#732)

### DIFF
--- a/shared_strategies/open/amd_ifvg.py
+++ b/shared_strategies/open/amd_ifvg.py
@@ -114,75 +114,90 @@ def amd_ifvg_core(
         result.loc[london_mask, "sweep_dir"] = bias
         sweep_idx = swept_below_idx if bias == -1 else swept_above_idx
 
-        # --- Phase 3: IFVG Detection — 3-candle imbalance gap ---
-        # Scan candles from the sweep onward for fair value gaps
+        # --- Phase 3+4: IFVG Detection + Entry, processed bar-by-bar ---
+        # An IFVG forms across 3 consecutive candles; it is only observable at
+        # its completion bar (c2). For each candidate entry bar K, we select
+        # the IFVG nearest to bar K's close using ONLY IFVGs that have already
+        # completed at bars strictly before K — no day-final-close peek.
         post_sweep_mask = day_mask & (result.index >= sweep_idx)
         post_sweep = result.loc[post_sweep_mask]
 
         if len(post_sweep) < 3:
             continue
 
-        best_ifvg = None
-        best_ifvg_idx = None
-        latest_close = post_sweep["close"].iloc[-1]
-
         ps_indices = post_sweep.index.tolist()
+
+        # Pre-compute every IFVG candidate, indexed by its completion position
+        # in ps_indices. Candidate is (gap_low, gap_high, completion_position).
+        ifvg_candidates = []
         for i in range(2, len(ps_indices)):
             c0 = post_sweep.loc[ps_indices[i - 2]]  # candle before displacement
-            c2 = post_sweep.loc[ps_indices[i]]       # candle after displacement
+            c2 = post_sweep.loc[ps_indices[i]]      # candle after displacement
 
             if bias == -1:
-                # Bullish IFVG: gap up (c0 high < c2 low)
-                if c0["high"] < c2["low"]:
-                    gap_low = c0["high"]
-                    gap_high = c2["low"]
-                    gap_size = gap_high - gap_low
-                    mid_price = (gap_high + gap_low) / 2
-                    if mid_price > 0 and (gap_size / mid_price * 100) >= min_ifvg_pct:
-                        dist = abs(latest_close - (gap_high + gap_low) / 2)
-                        if best_ifvg is None or dist < best_ifvg[2]:
-                            best_ifvg = (gap_low, gap_high, dist)
-                            best_ifvg_idx = ps_indices[i]
+                if c0["high"] >= c2["low"]:
+                    continue
+                gap_low, gap_high = c0["high"], c2["low"]
             else:
-                # Bearish IFVG: gap down (c0 low > c2 high)
-                if c0["low"] > c2["high"]:
-                    gap_high = c0["low"]
-                    gap_low = c2["high"]
-                    gap_size = gap_high - gap_low
-                    mid_price = (gap_high + gap_low) / 2
-                    if mid_price > 0 and (gap_size / mid_price * 100) >= min_ifvg_pct:
-                        dist = abs(latest_close - (gap_high + gap_low) / 2)
-                        if best_ifvg is None or dist < best_ifvg[2]:
-                            best_ifvg = (gap_low, gap_high, dist)
-                            best_ifvg_idx = ps_indices[i]
+                if c0["low"] <= c2["high"]:
+                    continue
+                gap_low, gap_high = c2["high"], c0["low"]
 
-        if best_ifvg is None:
+            gap_size = gap_high - gap_low
+            mid_price = (gap_high + gap_low) / 2
+            if mid_price <= 0:
+                continue
+            if (gap_size / mid_price * 100) < min_ifvg_pct:
+                continue
+            ifvg_candidates.append((gap_low, gap_high, i))
+
+        if not ifvg_candidates:
             continue
 
-        ifvg_low, ifvg_high = best_ifvg[0], best_ifvg[1]
-        result.loc[day_mask, "ifvg_high"] = ifvg_high
-        result.loc[day_mask, "ifvg_low"] = ifvg_low
-
-        # --- Phase 4: Entry — Retracement into IFVG ---
-        # Look for price entering the IFVG zone after it forms
-        entry_mask = day_mask & (result.index > best_ifvg_idx)
-        entry_candles = result.loc[entry_mask]
-
         signal_fired = False
-        for idx in entry_candles.index:
-            if signal_fired:
-                break
-            row = entry_candles.loc[idx]
+        chosen_ifvg = None
+        chosen_entry_idx = None
+
+        # Walk entry bars in time order. At each bar K, only IFVGs completed
+        # strictly before K are visible; pick the one whose midpoint is closest
+        # to THIS bar's close.
+        for k in range(1, len(ps_indices)):
+            available = [c for c in ifvg_candidates if c[2] < k]
+            if not available:
+                continue
+
+            bar_idx = ps_indices[k]
+            bar_close = result.loc[bar_idx, "close"]
+            bar_low = result.loc[bar_idx, "low"]
+            bar_high = result.loc[bar_idx, "high"]
+
+            best = min(
+                available,
+                key=lambda c: abs(bar_close - (c[0] + c[1]) / 2),
+            )
+            ifvg_low, ifvg_high = best[0], best[1]
 
             if bias == -1:
                 # Bullish entry: price dips into bullish IFVG
-                if row["low"] <= ifvg_high and row["close"] >= ifvg_low:
-                    result.loc[idx, "signal"] = 1
+                if bar_low <= ifvg_high and bar_close >= ifvg_low:
+                    result.loc[bar_idx, "signal"] = 1
                     signal_fired = True
             else:
                 # Bearish entry: price rallies into bearish IFVG
-                if row["high"] >= ifvg_low and row["close"] <= ifvg_high:
-                    result.loc[idx, "signal"] = -1
+                if bar_high >= ifvg_low and bar_close <= ifvg_high:
+                    result.loc[bar_idx, "signal"] = -1
                     signal_fired = True
+
+            if signal_fired:
+                chosen_ifvg = (ifvg_low, ifvg_high)
+                chosen_entry_idx = bar_idx
+                break
+
+        # Stamp viz columns only from the entry bar onward so historical bars
+        # never carry an IFVG level chosen with future data.
+        if chosen_ifvg is not None and chosen_entry_idx is not None:
+            viz_mask = day_mask & (result.index >= chosen_entry_idx)
+            result.loc[viz_mask, "ifvg_low"] = chosen_ifvg[0]
+            result.loc[viz_mask, "ifvg_high"] = chosen_ifvg[1]
 
     return result

--- a/shared_strategies/open/chart_patterns.py
+++ b/shared_strategies/open/chart_patterns.py
@@ -97,8 +97,16 @@ def detect_double_top(
     highs: pd.Series, lows: pd.Series, close: pd.Series,
     swing_highs: pd.Series, swing_lows: pd.Series,
     tolerance: float = 0.03,
+    lookback: int = 5,
 ) -> list:
-    """Two consecutive swing highs within tolerance; break below intervening low."""
+    """Two consecutive swing highs within tolerance; break below intervening low.
+
+    The breakout bar must come at least ``lookback + 1`` bars after the second
+    peak — a swing high at bar k is confirmed using a centered
+    [k-lookback, k+lookback] window and is not observable until bar k+lookback
+    has closed. Starting the search at h2_bar+1 would consume a swing the
+    market hasn't confirmed yet (look-ahead).
+    """
     matches = []
     sh_idx = _get_swing_indices(swing_highs)
     sl_idx = _get_swing_indices(swing_lows)
@@ -120,8 +128,9 @@ def detect_double_top(
         neckline_bar = min(between_lows, key=lambda s: swing_lows.iloc[s])
         neckline = swing_lows.iloc[neckline_bar]
 
-        # Find breakout: first close below neckline after second peak
-        for j in range(h2_bar + 1, len(close)):
+        # Find breakout: first close below neckline after second peak's
+        # confirmation bar (h2_bar + lookback).
+        for j in range(h2_bar + lookback + 1, len(close)):
             if close.iloc[j] < neckline:
                 matches.append(PatternMatch(
                     pattern="double_top", signal=-1,
@@ -136,8 +145,13 @@ def detect_double_bottom(
     highs: pd.Series, lows: pd.Series, close: pd.Series,
     swing_highs: pd.Series, swing_lows: pd.Series,
     tolerance: float = 0.03,
+    lookback: int = 5,
 ) -> list:
-    """Two consecutive swing lows within tolerance; break above intervening high."""
+    """Two consecutive swing lows within tolerance; break above intervening high.
+
+    Breakout bar must come at least ``lookback + 1`` bars after the second
+    trough's confirmation window (see ``detect_double_top``).
+    """
     matches = []
     sl_idx = _get_swing_indices(swing_lows)
     sh_idx = _get_swing_indices(swing_highs)
@@ -157,7 +171,7 @@ def detect_double_bottom(
         neckline_bar = max(between_highs, key=lambda s: swing_highs.iloc[s])
         neckline = swing_highs.iloc[neckline_bar]
 
-        for j in range(l2_bar + 1, len(close)):
+        for j in range(l2_bar + lookback + 1, len(close)):
             if close.iloc[j] > neckline:
                 matches.append(PatternMatch(
                     pattern="double_bottom", signal=1,
@@ -172,6 +186,7 @@ def detect_triple_top(
     highs: pd.Series, lows: pd.Series, close: pd.Series,
     swing_highs: pd.Series, swing_lows: pd.Series,
     tolerance: float = 0.03,
+    lookback: int = 5,
 ) -> list:
     """Three consecutive swing highs within tolerance; break below lowest intervening low."""
     matches = []
@@ -195,7 +210,7 @@ def detect_triple_top(
             continue
         neckline = min(swing_lows.iloc[s] for s in between_lows)
 
-        for j in range(h3_bar + 1, len(close)):
+        for j in range(h3_bar + lookback + 1, len(close)):
             if close.iloc[j] < neckline:
                 matches.append(PatternMatch(
                     pattern="triple_top", signal=-1,
@@ -210,6 +225,7 @@ def detect_triple_bottom(
     highs: pd.Series, lows: pd.Series, close: pd.Series,
     swing_highs: pd.Series, swing_lows: pd.Series,
     tolerance: float = 0.03,
+    lookback: int = 5,
 ) -> list:
     """Three consecutive swing lows within tolerance; break above highest intervening high."""
     matches = []
@@ -233,7 +249,7 @@ def detect_triple_bottom(
             continue
         neckline = max(swing_highs.iloc[s] for s in between_highs)
 
-        for j in range(l3_bar + 1, len(close)):
+        for j in range(l3_bar + lookback + 1, len(close)):
             if close.iloc[j] > neckline:
                 matches.append(PatternMatch(
                     pattern="triple_bottom", signal=1,
@@ -248,6 +264,7 @@ def detect_head_and_shoulders(
     highs: pd.Series, lows: pd.Series, close: pd.Series,
     swing_highs: pd.Series, swing_lows: pd.Series,
     tolerance: float = 0.03,
+    lookback: int = 5,
 ) -> list:
     """Three swing highs where middle is highest and shoulders are within tolerance."""
     matches = []
@@ -275,7 +292,7 @@ def detect_head_and_shoulders(
             continue
         neckline = np.mean([swing_lows.iloc[s] for s in between_lows])
 
-        for j in range(rs_bar + 1, len(close)):
+        for j in range(rs_bar + lookback + 1, len(close)):
             if close.iloc[j] < neckline:
                 matches.append(PatternMatch(
                     pattern="head_shoulders", signal=-1,
@@ -290,6 +307,7 @@ def detect_inverse_head_and_shoulders(
     highs: pd.Series, lows: pd.Series, close: pd.Series,
     swing_highs: pd.Series, swing_lows: pd.Series,
     tolerance: float = 0.03,
+    lookback: int = 5,
 ) -> list:
     """Three swing lows where middle is lowest and shoulders are within tolerance."""
     matches = []
@@ -314,7 +332,7 @@ def detect_inverse_head_and_shoulders(
             continue
         neckline = np.mean([swing_highs.iloc[s] for s in between_highs])
 
-        for j in range(rs_bar + 1, len(close)):
+        for j in range(rs_bar + lookback + 1, len(close)):
             if close.iloc[j] > neckline:
                 matches.append(PatternMatch(
                     pattern="inv_head_shoulders", signal=1,
@@ -338,6 +356,7 @@ def _detect_flag(
     flag_min_bars: int = 5,
     flag_max_bars: int = 30,
     pole_atr_mult: float = 2.0,
+    lookback: int = 5,
 ) -> list:
     """
     Detect flag pattern in the given direction.
@@ -399,8 +418,11 @@ def _detect_flag(
             if (flag_high_level - flag_low_level) > 0.5 * pole_move:
                 continue
 
-            # Breakout: close above the flag high
-            for j in range(peak_bar + flag_min_bars, min(flag_end + 1, n)):
+            # Breakout: close above the flag high. The peak swing is only
+            # confirmable after peak_bar + lookback closes, so enforce the
+            # later of (flag_min_bars, lookback + 1).
+            breakout_start = peak_bar + max(flag_min_bars, lookback + 1)
+            for j in range(breakout_start, min(flag_end + 1, n)):
                 if close.iloc[j] > flag_high_level:
                     matches.append(PatternMatch(
                         pattern="bull_flag", signal=1,
@@ -439,7 +461,8 @@ def _detect_flag(
             if (flag_high_level - flag_low_level) > 0.5 * pole_move:
                 continue
 
-            for j in range(trough_bar + flag_min_bars, min(flag_end + 1, n)):
+            breakout_start = trough_bar + max(flag_min_bars, lookback + 1)
+            for j in range(breakout_start, min(flag_end + 1, n)):
                 if close.iloc[j] < flag_low_level:
                     matches.append(PatternMatch(
                         pattern="bear_flag", signal=-1,
@@ -454,16 +477,18 @@ def detect_bull_flag(
     highs: pd.Series, lows: pd.Series, close: pd.Series, volume: pd.Series,
     swing_highs: pd.Series, swing_lows: pd.Series,
     tolerance: float = 0.03,
+    lookback: int = 5,
 ) -> list:
-    return _detect_flag(highs, lows, close, volume, swing_highs, swing_lows, direction=1)
+    return _detect_flag(highs, lows, close, volume, swing_highs, swing_lows, direction=1, lookback=lookback)
 
 
 def detect_bear_flag(
     highs: pd.Series, lows: pd.Series, close: pd.Series, volume: pd.Series,
     swing_highs: pd.Series, swing_lows: pd.Series,
     tolerance: float = 0.03,
+    lookback: int = 5,
 ) -> list:
-    return _detect_flag(highs, lows, close, volume, swing_highs, swing_lows, direction=-1)
+    return _detect_flag(highs, lows, close, volume, swing_highs, swing_lows, direction=-1, lookback=lookback)
 
 
 # ─────────────────────────────────────────────
@@ -490,6 +515,7 @@ def _detect_triangle(
     pattern_type: str,  # "ascending", "descending", "symmetrical"
     tolerance: float = 0.03,
     min_points: int = 4,
+    lookback: int = 5,
 ) -> list:
     """
     Detect triangle patterns using linear regression on swing points.
@@ -532,7 +558,12 @@ def _detect_triangle(
 
         flat_threshold = 0.0001  # slope per bar, normalized
 
+        # The latest swing in the triangle is only confirmed lookback bars
+        # after it occurs, so the earliest legitimate breakout bar is
+        # triangle_end + lookback + 1.
         triangle_end = max(recent_sh[-1], recent_sl[-1])
+        breakout_start = triangle_end + lookback + 1
+        breakout_end = min(triangle_end + 20, len(close))
 
         if pattern_type == "ascending":
             if abs(norm_r_slope) > flat_threshold:
@@ -541,7 +572,7 @@ def _detect_triangle(
                 continue
             # Breakout above resistance
             resistance_level = np.mean(sh_values)
-            for j in range(triangle_end + 1, min(triangle_end + 20, len(close))):
+            for j in range(breakout_start, breakout_end):
                 if close.iloc[j] > resistance_level:
                     matches.append(PatternMatch(
                         pattern="ascending_triangle", signal=1,
@@ -555,7 +586,7 @@ def _detect_triangle(
             if norm_r_slope >= -flat_threshold:
                 continue
             support_level = np.mean(sl_values)
-            for j in range(triangle_end + 1, min(triangle_end + 20, len(close))):
+            for j in range(breakout_start, breakout_end):
                 if close.iloc[j] < support_level:
                     matches.append(PatternMatch(
                         pattern="descending_triangle", signal=-1,
@@ -568,7 +599,7 @@ def _detect_triangle(
                 continue
             # Lines must be converging
             mid_level = avg_price
-            for j in range(triangle_end + 1, min(triangle_end + 20, len(close))):
+            for j in range(breakout_start, breakout_end):
                 upper = np.mean(sh_values) + resistance_slope * (j - np.mean(recent_sh))
                 lower = np.mean(sl_values) + support_slope * (j - np.mean(recent_sl))
                 if close.iloc[j] > upper:
@@ -591,24 +622,27 @@ def detect_ascending_triangle(
     highs: pd.Series, lows: pd.Series, close: pd.Series,
     swing_highs: pd.Series, swing_lows: pd.Series,
     tolerance: float = 0.03,
+    lookback: int = 5,
 ) -> list:
-    return _detect_triangle(highs, lows, close, swing_highs, swing_lows, "ascending", tolerance)
+    return _detect_triangle(highs, lows, close, swing_highs, swing_lows, "ascending", tolerance, lookback=lookback)
 
 
 def detect_descending_triangle(
     highs: pd.Series, lows: pd.Series, close: pd.Series,
     swing_highs: pd.Series, swing_lows: pd.Series,
     tolerance: float = 0.03,
+    lookback: int = 5,
 ) -> list:
-    return _detect_triangle(highs, lows, close, swing_highs, swing_lows, "descending", tolerance)
+    return _detect_triangle(highs, lows, close, swing_highs, swing_lows, "descending", tolerance, lookback=lookback)
 
 
 def detect_symmetrical_triangle(
     highs: pd.Series, lows: pd.Series, close: pd.Series,
     swing_highs: pd.Series, swing_lows: pd.Series,
     tolerance: float = 0.03,
+    lookback: int = 5,
 ) -> list:
-    return _detect_triangle(highs, lows, close, swing_highs, swing_lows, "symmetrical", tolerance)
+    return _detect_triangle(highs, lows, close, swing_highs, swing_lows, "symmetrical", tolerance, lookback=lookback)
 
 
 # ─────────────────────────────────────────────
@@ -619,6 +653,7 @@ def detect_cup_and_handle(
     highs: pd.Series, lows: pd.Series, close: pd.Series,
     swing_highs: pd.Series, swing_lows: pd.Series,
     tolerance: float = 0.03,
+    lookback: int = 5,
 ) -> list:
     """
     Cup & Handle: U-shaped bottom with left/right rims at similar height,
@@ -667,9 +702,10 @@ def detect_cup_and_handle(
             if (rim_avg - handle_low) > 0.5 * cup_depth:
                 continue
 
-            # Breakout above rim
+            # Breakout above rim — right rim swing only confirmable
+            # ``lookback`` bars after right_rim_bar.
             breakout_level = max(left_rim, right_rim)
-            for k in range(right_rim_bar + 2, min(handle_end + 10, len(close))):
+            for k in range(right_rim_bar + lookback + 1, min(handle_end + 10, len(close))):
                 if close.iloc[k] > breakout_level:
                     matches.append(PatternMatch(
                         pattern="cup_and_handle", signal=1,
@@ -736,11 +772,13 @@ def chart_pattern_core(
             matches = detector(
                 result["high"], result["low"], result["close"], result["volume"],
                 swing_highs, swing_lows, tolerance,
+                lookback=pivot_lookback,
             )
         else:
             matches = detector(
                 result["high"], result["low"], result["close"],
                 swing_highs, swing_lows, tolerance,
+                lookback=pivot_lookback,
             )
         all_matches.extend(matches)
 

--- a/shared_strategies/open/liquidity_sweeps.py
+++ b/shared_strategies/open/liquidity_sweeps.py
@@ -84,12 +84,16 @@ def liquidity_sweep_core(
                     result.iloc[i, result.columns.get_loc("signal")] = 1
                     recent_swing_low = np.nan  # consumed
 
-        # Update liquidity pools from confirmed swing points
-        # Only use swing points from candles before the current one to avoid lookahead
-        if i > 0:
-            if not np.isnan(swing_highs.iloc[i - 1]):
-                recent_swing_high = swing_highs.iloc[i - 1]
-            if not np.isnan(swing_lows.iloc[i - 1]):
-                recent_swing_low = swing_lows.iloc[i - 1]
+        # Update liquidity pools from confirmed swing points.
+        # A swing at position p uses a centered window [p-lookback, p+lookback]
+        # — it can only be confirmed after bar p+lookback has closed. So at the
+        # current bar i, the freshest swing safely consumable is at position
+        # i - lookback - 1. Reading any later position would peek forward.
+        confirm_pos = i - swing_lookback - 1
+        if confirm_pos >= 0:
+            if not np.isnan(swing_highs.iloc[confirm_pos]):
+                recent_swing_high = swing_highs.iloc[confirm_pos]
+            if not np.isnan(swing_lows.iloc[confirm_pos]):
+                recent_swing_low = swing_lows.iloc[confirm_pos]
 
     return result

--- a/shared_strategies/open/test_amd_ifvg.py
+++ b/shared_strategies/open/test_amd_ifvg.py
@@ -1,0 +1,139 @@
+"""Tests for amd_ifvg.py — including a look-ahead regression covering #732.
+
+The bug being regressed: prior code selected the IFVG nearest to the *day's
+final close*, so the signal at bar K depended on bars K+1..end-of-day. The
+fix processes entry bar-by-bar, choosing the IFVG nearest to the current
+bar's close. Verify: replacing future bars cannot change earlier signals.
+"""
+
+import numpy as np
+import pandas as pd
+
+from amd_ifvg import amd_ifvg_core
+
+
+def _make_intraday_df(rows: list) -> pd.DataFrame:
+    """Build an OHLCV DataFrame from a list of (hour, o, h, l, c) tuples at
+    15-minute spacing on 2024-01-01 UTC. ``hour`` is purely for readability
+    in test fixtures (it does not appear in the resulting frame)."""
+    idx = pd.date_range("2024-01-01 00:00", periods=len(rows), freq="15min", tz="UTC")
+    return pd.DataFrame(
+        {
+            "open":   [r[1] for r in rows],
+            "high":   [r[2] for r in rows],
+            "low":    [r[3] for r in rows],
+            "close":  [r[4] for r in rows],
+            "volume": [100.0] * len(rows),
+        },
+        index=idx,
+    )
+
+
+def _build_two_ifvg_setup() -> list:
+    """Common prefix bars: Asian range, sweep, two bullish IFVGs (A near 100.4,
+    B near 102.5), and one drift bar. Stops before the divergent tail."""
+    rows = []
+    # 00–08 UTC Asian: oscillate 99.5–100.5 (32 bars × 15m = 8 h)
+    for i in range(32):
+        mid = 100 + 0.5 * (1 if i % 2 else -1)
+        rows.append((0, mid - 0.1, mid + 0.5, mid - 0.5, mid))
+    # 08:00 sweep below 99
+    rows.append((8, 99.5, 99.6, 98.7, 99.0))
+    # IFVG_A: 3 candles forming gap [100.0, 100.8] (midpoint 100.4)
+    rows.append((8, 99.5, 100.0, 99.4, 99.9))
+    rows.append((8, 100.3, 100.9, 100.1, 100.7))
+    rows.append((8, 100.5, 101.3, 100.8, 101.2))
+    # IFVG_B: 3 candles forming gap [102.0, 103.0] (midpoint 102.5)
+    rows.append((9, 101.5, 102.0, 101.4, 101.8))
+    rows.append((9, 101.7, 102.8, 101.6, 102.5))
+    rows.append((9, 102.3, 103.5, 103.0, 103.4))
+    return rows
+
+
+class TestLookahead:
+    """Regression: the IFVG choice at entry bar K must not depend on bars > K."""
+
+    def test_entry_bar_signal_independent_of_future_close(self):
+        """At entry bar K, the chosen IFVG must be the one nearest to K's
+        close. Two scenarios share an identical prefix through K but diverge
+        afterwards. The pre-fix implementation evaluated ``latest_close`` from
+        the last bar of the day; therefore in the full series the chosen IFVG
+        flipped to whichever sat nearer the *day-final close*, mutating the
+        signal at bar K. The fix uses bar K's close only.
+        """
+        common = _build_two_ifvg_setup()
+        # Entry bar K: close 102.5, low 102.2 → touches IFVG_B [102.0, 103.0]
+        # but NOT IFVG_A [100.0, 100.8] (low never reaches A).
+        # IFVG_B mid (102.5) is exactly at this close → fix picks B.
+        entry_bar = (9, 102.5, 102.8, 102.2, 102.5)
+
+        # Tail A: late drift up to 105. Buggy code's latest_close ≈ 105 → still
+        # picks B (mid 102.5 closer to 105 than A's 100.4) — same result as fix.
+        tail_up = [(10, 105, 105.3, 104.7, 105.0)] * 6
+        # Tail B: late drift down to 100. Buggy code's latest_close ≈ 100 →
+        # picks A (mid 100.4 closer to 100 than B's 102.5). Entry bar B's H/L
+        # do NOT touch IFVG_A, so buggy code yields NO signal at K — and may
+        # later signal on a different bar that touches A.
+        tail_down = [(10, 100, 100.3, 99.7, 100.0)] * 6
+
+        df_up = _make_intraday_df(common + [entry_bar] + tail_up)
+        df_dn = _make_intraday_df(common + [entry_bar] + tail_down)
+
+        out_up = amd_ifvg_core(df_up)
+        out_dn = amd_ifvg_core(df_dn)
+
+        entry_idx = df_up.index[len(common)]  # bar K, same timestamp in both
+
+        # Fix invariant: signal at K is identical regardless of bars > K.
+        # The pre-fix code would: produce signal=1 at K under tail_up
+        # (picks B → bar touches B), but no signal at K under tail_down
+        # (picks A → bar misses A).
+        assert out_up.loc[entry_idx, "signal"] == out_dn.loc[entry_idx, "signal"], (
+            f"signal at entry bar {entry_idx} changed when only future bars varied: "
+            f"up={out_up.loc[entry_idx,'signal']} dn={out_dn.loc[entry_idx,'signal']}"
+        )
+        # Sanity: at least one of the two must have actually fired here, else
+        # the test would trivially pass with both zero.
+        assert out_up.loc[entry_idx, "signal"] != 0, (
+            "test setup produced no signal at K — adjust fixture so the bug "
+            "regression actually exercises a signal-firing bar"
+        )
+
+    def test_truncation_invariant(self):
+        """For every bar K with a signal in the full series, regenerating the
+        signal from the prefix df[:K] must yield the same sign at K. Catches
+        any look-ahead that *also* changes the truncated answer."""
+        common = _build_two_ifvg_setup()
+        tail = [(10, 105, 105.3, 104.7, 105.0)] * 6
+        entry_bar = (9, 102.5, 102.8, 102.2, 102.5)
+        df = _make_intraday_df(common + [entry_bar] + tail)
+
+        full = amd_ifvg_core(df)
+        signal_bars = full.index[full["signal"] != 0]
+        assert len(signal_bars) >= 1
+
+        for k in signal_bars:
+            truncated = df.loc[:k]
+            partial = amd_ifvg_core(truncated)
+            assert partial.loc[k, "signal"] == full.loc[k, "signal"], (
+                f"signal at {k} differs after truncation: "
+                f"full={full.loc[k,'signal']} truncated={partial.loc[k,'signal']}"
+            )
+
+
+class TestSmoke:
+    def test_short_df_returns_zeros(self):
+        df = _make_intraday_df([(0, 100, 101, 99, 100)] * 2)
+        out = amd_ifvg_core(df)
+        assert (out["signal"] == 0).all()
+
+    def test_no_asian_range_skips_day(self):
+        df = _make_intraday_df([(0, 100, 100, 100, 100)] * 40)
+        out = amd_ifvg_core(df)
+        assert (out["signal"] == 0).all()
+
+    def test_signal_in_valid_set(self):
+        rows = [(0, 100, 100.5, 99.5, 100) for _ in range(64)]
+        df = _make_intraday_df(rows)
+        out = amd_ifvg_core(df)
+        assert set(out["signal"].unique()).issubset({-1, 0, 1})

--- a/shared_strategies/open/test_chart_patterns.py
+++ b/shared_strategies/open/test_chart_patterns.py
@@ -397,6 +397,112 @@ class TestDatetimeIndex:
 
 # ─── Orchestrator ────────────────────────────
 
+# ─── Look-ahead regression (#732) ───────────────
+
+class TestLookaheadRegression:
+    """Each pattern detector receives swing series that are only complete
+    ``lookback`` bars after their swing position. The breakout bar must come
+    at least one bar after the trailing swing's confirmation window closes —
+    i.e. ``bar_index >= trailing_swing_bar + lookback + 1`` — otherwise the
+    detector is consuming a swing classification derived from data not yet
+    observable at signal time.
+    """
+
+    def test_double_top_breakout_after_confirmation_window(self):
+        lookback = 3
+        prices = (
+            list(np.linspace(80, 100, 20)) +
+            list(np.linspace(100, 90, 15)) +
+            list(np.linspace(90, 99, 15)) +
+            list(np.linspace(99, 85, 20)) +
+            [85] * 30
+        )
+        df = make_ohlcv(prices)
+        sh, sl = find_swing_points(df["high"], df["low"], lookback=lookback)
+        matches = detect_double_top(
+            df["high"], df["low"], df["close"], sh, sl,
+            tolerance=0.03, lookback=lookback,
+        )
+        assert len(matches) >= 1
+        # Find the second peak's bar (h2_bar) and assert breakout is far
+        # enough out.
+        sh_positions = sorted(np.where(sh.notna())[0])
+        for m in matches:
+            # Identify h2_bar — the second of the two consecutive swing highs
+            # whose breakout produced this match. We don't reconstruct the
+            # exact pair, but assert that bar_index is at least lookback+1
+            # AFTER some swing high less than bar_index.
+            prior_swings = [s for s in sh_positions if s < m.bar_index]
+            assert prior_swings, "match should follow at least one swing high"
+            latest_prior = max(prior_swings)
+            assert m.bar_index >= latest_prior + lookback + 1, (
+                f"double_top breakout at {m.bar_index} too close to trailing "
+                f"swing at {latest_prior} (lookback={lookback}); allowed only "
+                f"from {latest_prior + lookback + 1} onward"
+            )
+
+    def test_head_and_shoulders_breakout_after_confirmation_window(self):
+        lookback = 3
+        prices = (
+            list(np.linspace(80, 95, 15)) +
+            list(np.linspace(95, 85, 10)) +
+            list(np.linspace(85, 105, 15)) +
+            list(np.linspace(105, 85, 10)) +
+            list(np.linspace(85, 96, 15)) +
+            list(np.linspace(96, 80, 20)) +
+            [80] * 15
+        )
+        df = make_ohlcv(prices)
+        sh, sl = find_swing_points(df["high"], df["low"], lookback=lookback)
+        matches = detect_head_and_shoulders(
+            df["high"], df["low"], df["close"], sh, sl,
+            tolerance=0.05, lookback=lookback,
+        )
+        assert len(matches) >= 1
+        sh_positions = sorted(np.where(sh.notna())[0])
+        for m in matches:
+            prior_swings = [s for s in sh_positions if s < m.bar_index]
+            assert prior_swings
+            latest_prior = max(prior_swings)
+            assert m.bar_index >= latest_prior + lookback + 1, (
+                f"H&S breakout at {m.bar_index} too close to trailing "
+                f"swing at {latest_prior} (lookback={lookback}); allowed only "
+                f"from {latest_prior + lookback + 1} onward"
+            )
+
+    def test_signal_independent_of_future_bars(self):
+        """For each bar K where the orchestrator emits a non-zero signal,
+        the same signal must arise from running the orchestrator on the
+        prefix df[:K+1]. The fix enforces that pattern breakouts only land at
+        bars where the trailing swing is fully past its centered-window
+        confirmation; that window is always contained in [0, K]."""
+        prices = (
+            list(np.linspace(80, 100, 20)) +
+            list(np.linspace(100, 90, 15)) +
+            list(np.linspace(90, 99, 15)) +
+            list(np.linspace(99, 85, 20)) +
+            [85] * 30
+        )
+        vol = [100] * len(prices)
+        for i in range(50, 70):
+            vol[i] = 200
+        df = make_ohlcv(prices, volume=vol)
+        full = chart_pattern_core(df, pivot_lookback=3, tolerance=0.03, vol_multiplier=1.0)
+
+        signal_bars = list(np.where(full["signal"].values != 0)[0])
+        # Test setup should actually produce at least one signal.
+        assert len(signal_bars) >= 1
+        for k in signal_bars:
+            partial_df = df.iloc[: k + 1]
+            partial = chart_pattern_core(
+                partial_df, pivot_lookback=3, tolerance=0.03, vol_multiplier=1.0
+            )
+            assert partial["signal"].iloc[k] == full["signal"].iloc[k], (
+                f"signal at bar {k} flipped under truncation: "
+                f"full={full['signal'].iloc[k]} truncated={partial['signal'].iloc[k]}"
+            )
+
+
 class TestChartPatternCore:
     def test_returns_signal_column(self):
         prices = list(np.linspace(90, 110, 50)) + list(np.linspace(110, 90, 50))

--- a/shared_strategies/open/test_liquidity_sweeps.py
+++ b/shared_strategies/open/test_liquidity_sweeps.py
@@ -1,0 +1,151 @@
+"""Tests for liquidity_sweeps.py — including a look-ahead regression covering #732.
+
+Bug regressed: ``_find_swing_highs`` / ``_find_swing_lows`` use a centered
+[i-lookback, i+lookback] window, so a swing at position p is only confirmable
+after bar p+lookback has closed. The pre-fix main loop read
+``swing_highs.iloc[i - 1]``, which consumes a swing classification that may
+depend on bars > i. The fix lags the swing read by ``lookback`` bars:
+``confirm_pos = i - lookback - 1``, so a swing at position p only becomes
+``recent_swing_high`` at iteration ``p + lookback + 1`` — once the live
+trading cycle has actually observed every bar in p's centered window.
+
+A direct truncation-vs-full output-divergence test is structurally hard to
+construct because the centered-window swing detector inherently rejects
+classifications when the sweep candidate's wick contaminates the window. The
+tests below instead validate the lag contract: signals never fire before the
+swing's confirmation window has fully closed.
+"""
+
+import numpy as np
+import pandas as pd
+
+from liquidity_sweeps import _find_swing_lows, liquidity_sweep_core
+
+
+def _make_ohlcv(highs, lows, closes, opens=None):
+    n = len(closes)
+    if opens is None:
+        opens = closes
+    return pd.DataFrame({
+        "open":   opens,
+        "high":   highs,
+        "low":    lows,
+        "close":  closes,
+        "volume": [100.0] * n,
+    })
+
+
+def _monotone_uptrend(n: int, start: float = 100.0, slope: float = 0.5) -> tuple:
+    """Strictly increasing baseline so the centered-window swing detector
+    finds no local maxima/minima in flat stretches."""
+    closes = start + slope * np.arange(n)
+    highs = closes + 0.3
+    lows = closes - 0.3
+    return highs.astype(float), lows.astype(float), closes.astype(float)
+
+
+class TestLookahead:
+    """Regression for #732: swing reads must lag by ``lookback`` bars."""
+
+    def test_sweep_never_fires_inside_confirmation_window(self):
+        """For every detected swing at position p, no sweep signal may fire
+        at any bar in ``[p+1, p+lookback]`` — the swing's centered window
+        hasn't fully observed yet. The earliest legitimate consumption is
+        bar ``p + lookback + 1`` (one bar after final confirmation, since the
+        fix's read is ``swing_highs.iloc[i - lookback - 1]``).
+        """
+        lookback = 5
+        n = 80
+
+        # Construct a setup with one clean swing low at p=15 (its centered
+        # window [10:21] sees no contamination), then a confirmed sweep at
+        # bar p + lookback + 1 = 21.
+        highs, lows, closes = _monotone_uptrend(n)
+        p = 15
+        lows[p] = 50.0
+        closes[p] = 80.0
+        # Sweep at the earliest legitimate consumption bar.
+        q = p + lookback + 1
+        lows[q] = 49.0
+        closes[q] = 81.0
+
+        df = _make_ohlcv(highs, lows, closes)
+        out = liquidity_sweep_core(df, swing_lookback=lookback)
+
+        # Identify every detected swing low and assert no signal landed
+        # within its confirmation window.
+        sl = _find_swing_lows(df["low"], lookback)
+        swing_positions = np.where(sl.notna())[0].tolist()
+        # At least the planted swing at p should be detected.
+        assert p in swing_positions, "test setup failed to plant swing at p"
+
+        for sp in swing_positions:
+            # Inside window: positions sp..sp+lookback (no consumption yet).
+            window_end = min(sp + lookback + 1, n)
+            inside = out["signal"].iloc[sp + 1: window_end]
+            assert (inside == 0).all(), (
+                f"signal fired inside confirmation window of swing at {sp}: "
+                f"non-zero at {[sp + 1 + i for i in np.where(inside != 0)[0]]}"
+            )
+
+    def test_signal_at_k_independent_of_bars_after_k(self):
+        """Truncation invariant: regenerating the signal series from df[:K+1]
+        must yield the same value at bar K as the full series. The fix's
+        ``confirm_pos = i - lookback - 1`` only ever reads swing_highs at
+        positions ≤ K-lookback-1, which are themselves classifications over
+        windows fully contained in [0, K]. So bars > K cannot influence the
+        decision at bar K.
+        """
+        lookback = 5
+        n = 80
+        highs, lows, closes = _monotone_uptrend(n)
+        # Plant a swing far enough back that a sweep fires past its window.
+        lows[20] = 60.0
+        closes[20] = 70.0
+        lows[40] = 59.0
+        closes[40] = 80.0
+
+        df = _make_ohlcv(highs, lows, closes)
+        full = liquidity_sweep_core(df, swing_lookback=lookback)
+
+        # For every bar K where a signal fires in the full series, regenerate
+        # from the prefix and assert the value at K matches.
+        signal_bars = list(np.where(full["signal"].values != 0)[0])
+        for k in signal_bars:
+            partial_df = df.iloc[: k + 1]
+            partial = liquidity_sweep_core(partial_df, swing_lookback=lookback)
+            assert partial["signal"].iloc[k] == full["signal"].iloc[k], (
+                f"signal at bar {k} differs after truncation: "
+                f"full={full['signal'].iloc[k]} truncated={partial['signal'].iloc[k]}"
+            )
+
+
+class TestBasic:
+    def test_bullish_sweep_after_confirmation(self):
+        """A swing low confirmed long before the sweep should fire a buy."""
+        lookback = 3
+        n = 40
+        highs, lows, closes = _monotone_uptrend(n)
+        lows[10] = 50.0
+        closes[10] = 80.0
+        lows[25] = 49.0
+        closes[25] = 81.0
+
+        df = _make_ohlcv(highs, lows, closes)
+        out = liquidity_sweep_core(df, swing_lookback=lookback)
+        assert (out["signal"].iloc[25:] == 1).any()
+
+    def test_no_signal_when_close_doesnt_recover(self):
+        lookback = 3
+        n = 40
+        highs, lows, closes = _monotone_uptrend(n)
+        lows[10] = 50.0; closes[10] = 80.0
+        lows[25] = 49.0; closes[25] = 48.0  # close stays below 50
+        df = _make_ohlcv(highs, lows, closes)
+        out = liquidity_sweep_core(df, swing_lookback=lookback)
+        assert (out["signal"] == 1).sum() == 0
+
+    def test_short_data_returns_zeros(self):
+        df = _make_ohlcv([100.5] * 5, [99.5] * 5, [100] * 5)
+        out = liquidity_sweep_core(df, swing_lookback=5)
+        assert (out["signal"] == 0).all()


### PR DESCRIPTION
Closes #732

Three caller strategies under `shared_strategies/open/` peeked forward at data not yet observable at signal-generation time:

- `amd_ifvg.py`: day-final-close peek replaced with bar-by-bar IFVG selection.
- `liquidity_sweeps.py`: swing read now lagged by `lookback` bars.
- `chart_patterns.py`: every detector enforces `breakout_bar >= trailing_swing + lookback + 1`.

Regression tests added: `test_amd_ifvg.py`, `test_liquidity_sweeps.py`, `TestLookaheadRegression` in `test_chart_patterns.py`. Full pytest suite (551 tests) passes.

Before/after backtest deltas (BTC/USDT):
- `amd_ifvg` (15m): Return -79.02% → -57.04%, Sharpe -0.81 → -0.36, Trades 206 → 242.
- `liquidity_sweeps` (1h): Return -52.40% → -55.14%, Trades 124 → 148.
- `chart_pattern` (1h): Return -1.94% → -4.25%, Trades 280 → 255.

## Test plan
- [x] `.venv/bin/python3 -m pytest shared_strategies/ shared_tools/`
- [x] Backtests on representative symbols before/after

---
LLM: Claude Opus 4.7 (1M) | high | Harness: anthropics/claude-code-action@v1 | Tokens: 111 in / 108765 out | Cache: 11540694 read / 305531 written | Cost: $10.4