### PR TITLE
feat(sl_after): regime-aware atr_offset and trail_from_here rules (#736)

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -376,6 +376,28 @@ class Backtester:
             # "fixed SL" precondition, so we reject loudly here rather than
             # silently produce a backtest where the pre-bump SL never fires.
             if self._sl_after_rules.has_any():
+                # #736 explicitly defers regime-aware sl_after backtester
+                # parity to the parallel parity issue. Parsing the shape works
+                # (so live configs round-trip), but the per-bar engine here
+                # would silently fall back to zero scalars — atr_offset regime
+                # collapses to breakeven and trail_from_here regime defers
+                # every bar. Fail loud at load instead of producing results
+                # that look right but ignore the per-regime values.
+                regime_rules = []
+                if self._sl_after_rules.default.has_regime():
+                    regime_rules.append("strategy-level default")
+                for idx, r in enumerate(self._sl_after_rules.per_tier):
+                    if r.has_regime():
+                        regime_rules.append(f"tier[{idx}]")
+                if regime_rules:
+                    raise ValueError(
+                        "Invalid sl_after configuration: regime-aware "
+                        "trend_regime block is HL-live-only in this release "
+                        "(backtester parity deferred — see #736). Found on: "
+                        + ", ".join(regime_rules)
+                        + ". Use the scalar atr_mult / trail_from_here.atr_mult "
+                        "form for backtesting."
+                    )
                 has_atr_sl = (
                     self.stop_loss_atr_mult is not None
                     and self.stop_loss_atr_mult > 0

--- a/backtest/tests/test_post_tp_sl.py
+++ b/backtest/tests/test_post_tp_sl.py
@@ -601,6 +601,64 @@ def test_backtester_validation_rejects_sl_after_on_non_tiered_ref():
         )
 
 
+# #736 — regime-aware sl_after parses cleanly (live HL uses it) but the
+# backtester defers per-regime resolution to a follow-up parity issue. Verify
+# the loader fails loud rather than silently producing scalar=0 results.
+def test_backtester_validation_rejects_regime_sl_after_strategy_default():
+    with pytest.raises(ValueError, match="HL-live-only"):
+        Backtester(
+            initial_capital=1000, commission_pct=0, slippage_pct=0,
+            platform="hyperliquid", strategy_type="perps",
+            stop_loss_atr_mult=1.0,
+            close_strategies=[{
+                "name": "tiered_tp_atr",
+                "params": {
+                    "sl_after": {
+                        "trend_regime": {
+                            "trending_up": {"atr": 0.25},
+                            "trending_down": {"atr": 0.25},
+                            "ranging": {"atr": 0.0},
+                        },
+                    },
+                    "tiers": [
+                        {"atr_multiple": 1.0, "close_fraction": 0.5},
+                        {"atr_multiple": 2.0, "close_fraction": 1.0},
+                    ],
+                },
+            }],
+        )
+
+
+def test_backtester_validation_rejects_regime_sl_after_per_tier():
+    with pytest.raises(ValueError, match="HL-live-only"):
+        Backtester(
+            initial_capital=1000, commission_pct=0, slippage_pct=0,
+            platform="hyperliquid", strategy_type="perps",
+            stop_loss_atr_mult=1.0,
+            close_strategies=[{
+                "name": "tiered_tp_atr",
+                "params": {
+                    "tiers": [
+                        {
+                            "atr_multiple": 1.0,
+                            "close_fraction": 0.5,
+                            "sl_after": {
+                                "trail_from_here": {
+                                    "trend_regime": {
+                                        "trending_up": {"atr": 1.0},
+                                        "trending_down": {"atr": 1.0},
+                                        "ranging": {"atr": 0.5},
+                                    },
+                                },
+                            },
+                        },
+                        {"atr_multiple": 2.0, "close_fraction": 1.0},
+                    ],
+                },
+            }],
+        )
+
+
 def test_backtester_no_sl_after_unchanged_behavior():
     """Sanity check: a strategy with tiered_tp_atr but no sl_after still
     behaves as before — no extra SL hits, partial close at tier price."""

--- a/scheduler/config_reload_test.go
+++ b/scheduler/config_reload_test.go
@@ -649,6 +649,157 @@ func TestApplyHotReloadConfigRejectsSLAfterModeChangeWithOpenPosition(t *testing
 	}
 }
 
+// #736 — switching sl_after from scalar atr_offset to a regime-aware shape
+// with a position open is a higher-risk transition than tweaking the scalar
+// value: the post-TP machinery would arm against a re-derived target the
+// open never saw. Verifies the existing tierSLAfterRules.EqualForReload site
+// picks up the new SLAfterRule.Equal contract (which compares regime blocks
+// via RegimeATRBlock.EqualForReload).
+func TestApplyHotReloadConfigRejectsSLAfterScalarToRegimeWithOpenPosition(t *testing.T) {
+	tierScalar := []StrategyRef{{
+		Name: "tiered_tp_atr",
+		Params: map[string]interface{}{
+			"sl_after": map[string]interface{}{"atr_mult": 0.25},
+			"tiers": []interface{}{
+				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
+			},
+		},
+	}}
+	tierRegime := []StrategyRef{{
+		Name: "tiered_tp_atr",
+		Params: map[string]interface{}{
+			"sl_after": map[string]interface{}{
+				"trend_regime": map[string]interface{}{
+					"trending_up":   map[string]interface{}{"atr": 0.25},
+					"trending_down": map[string]interface{}{"atr": 0.25},
+					"ranging":       map[string]interface{}{"atr": 0.0},
+				},
+			},
+			"tiers": []interface{}{
+				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
+			},
+		},
+	}}
+	slMult := 1.5
+	cfg := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
+		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
+		CloseStrategies: tierScalar,
+	}})
+	next := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
+		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
+		CloseStrategies: tierRegime,
+	}})
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long"},
+		}},
+	}}
+
+	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
+	if err == nil {
+		t.Fatal("expected hot reload to reject sl_after scalar→regime shape change with open position")
+	}
+	if !strings.Contains(err.Error(), "sl_after rules changed with open positions") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// #736 — switching the regime block's per-label atr value (same shape, different
+// numbers) is also a shape change for hot-reload purposes — the resting SL was
+// armed against the old value at open.
+func TestApplyHotReloadConfigRejectsSLAfterRegimeValueChangeWithOpenPosition(t *testing.T) {
+	makeRef := func(ranging float64) []StrategyRef {
+		return []StrategyRef{{
+			Name: "tiered_tp_atr",
+			Params: map[string]interface{}{
+				"sl_after": map[string]interface{}{
+					"trend_regime": map[string]interface{}{
+						"trending_up":   map[string]interface{}{"atr": 0.25},
+						"trending_down": map[string]interface{}{"atr": 0.25},
+						"ranging":       map[string]interface{}{"atr": ranging},
+					},
+				},
+				"tiers": []interface{}{
+					map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
+				},
+			},
+		}}
+	}
+	slMult := 1.5
+	cfg := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
+		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
+		CloseStrategies: makeRef(0.0),
+	}})
+	next := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
+		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
+		CloseStrategies: makeRef(-0.5),
+	}})
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long"},
+		}},
+	}}
+
+	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
+	if err == nil {
+		t.Fatal("expected hot reload to reject sl_after regime value change with open position")
+	}
+	if !strings.Contains(err.Error(), "sl_after rules changed with open positions") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// #736 — identical regime configs across reload should pass (no shape change).
+// Guards against false-positive blocks once SLAfterRule.Equal handles regime
+// blocks via RegimeATRBlock.EqualForReload.
+func TestApplyHotReloadConfigAllowsSLAfterRegimeIdentical(t *testing.T) {
+	tierRegime := []StrategyRef{{
+		Name: "tiered_tp_atr",
+		Params: map[string]interface{}{
+			"sl_after": map[string]interface{}{
+				"trend_regime": map[string]interface{}{
+					"trending_up":   map[string]interface{}{"atr": 0.25},
+					"trending_down": map[string]interface{}{"atr": 0.25},
+					"ranging":       map[string]interface{}{"atr": 0.0},
+				},
+			},
+			"tiers": []interface{}{
+				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
+			},
+		},
+	}}
+	slMult := 1.5
+	cfg := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
+		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
+		CloseStrategies: tierRegime,
+	}})
+	next := minimalReloadConfig([]StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
+		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
+		CloseStrategies: tierRegime,
+	}})
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long"},
+		}},
+	}}
+
+	if _, err := applyHotReloadConfig(cfg, next, state, nil, nil); err != nil {
+		t.Fatalf("identical sl_after regime configs should reload cleanly with open position, got: %v", err)
+	}
+}
+
 // #656 — direction change is allowed when the strategy is flat.
 func TestApplyHotReloadConfigAllowsDirectionChangeWhenFlat(t *testing.T) {
 	cfg := minimalReloadConfig([]StrategyConfig{{

--- a/scheduler/post_tp_sl.go
+++ b/scheduler/post_tp_sl.go
@@ -10,22 +10,86 @@ import (
 
 // SLAfterRule describes how to adjust the stop-loss trigger after a tiered TP
 // fills. Configured per-tier (with optional strategy-level default) on
-// tiered_tp_atr / tiered_tp_atr_live close evaluators. See #708.
+// tiered_tp_atr / tiered_tp_atr_live close evaluators. See #708, #736.
 type SLAfterRule struct {
 	// Kind is "" (no rule, default behavior preserved), "breakeven",
 	// "atr_offset", or "trail_from_here".
 	Kind string
 	// ATRMult is the signed multiplier for "atr_offset"; positive values move
 	// the SL toward profit (long: above AvgCost, short: below). Zero is
-	// equivalent to "breakeven" but legal.
+	// equivalent to "breakeven" but legal. Ignored when ATRRegime is set.
 	ATRMult float64
 	// TrailATRMult is the trail distance in ATR units for "trail_from_here".
-	// Must be > 0.
+	// Must be > 0. Ignored when TrailATRRegime is set.
 	TrailATRMult float64
+	// ATRRegime, when non-nil, supplies the atr_offset multiplier per regime
+	// (resolved from pos.Regime at fire time). Set instead of ATRMult; signed
+	// values are legal here too. Kind must be "atr_offset". #736.
+	ATRRegime *RegimeATRBlock
+	// TrailATRRegime, when non-nil, supplies the trail_from_here distance per
+	// regime. Set instead of TrailATRMult; values must be strictly positive
+	// (validated at config-load via the regimeSurfaceSLAfterTrail surface).
+	// Kind must be "trail_from_here". #736.
+	TrailATRRegime *RegimeATRBlock
 }
 
 // IsEmpty reports whether the rule is a no-op.
 func (r SLAfterRule) IsEmpty() bool { return r.Kind == "" }
+
+// HasRegime reports whether the rule's active multiplier comes from a regime
+// block (vs the scalar ATRMult / TrailATRMult fields).
+func (r SLAfterRule) HasRegime() bool {
+	return r.ATRRegime != nil || r.TrailATRRegime != nil
+}
+
+// resolveForRegime collapses a regime-aware rule into the scalar form for the
+// given regime label by reading the per-label entry. Returns (resolved, true)
+// when the resolution succeeds; (zero, false) when the rule is regime-aware
+// but the label is missing or yields an invalid entry — caller should defer
+// (next cycle, with a stamped pos.Regime, retries). Scalar rules pass through
+// unchanged.
+func (r SLAfterRule) resolveForRegime(regime string) (SLAfterRule, bool) {
+	switch r.Kind {
+	case "atr_offset":
+		if r.ATRRegime == nil {
+			return r, true
+		}
+		entry, ok := r.ATRRegime.Resolve(regime)
+		if !ok {
+			return SLAfterRule{}, false
+		}
+		return SLAfterRule{Kind: "atr_offset", ATRMult: entry.ATR}, true
+	case "trail_from_here":
+		if r.TrailATRRegime == nil {
+			return r, true
+		}
+		entry, ok := r.TrailATRRegime.Resolve(regime)
+		if !ok || entry.ATR <= 0 {
+			return SLAfterRule{}, false
+		}
+		return SLAfterRule{Kind: "trail_from_here", TrailATRMult: entry.ATR}, true
+	default:
+		return r, true
+	}
+}
+
+// Equal reports whether two rules are equivalent, including any regime block
+// shape. Replaces direct struct == (which doesn't work once the rule carries
+// pointer fields). Used by tierSLAfterRules.EqualForReload for SIGHUP gating
+// — scalar↔regime and use_defaults↔explicit shape changes both surface as
+// !Equal so an open position blocks the reload.
+func (r SLAfterRule) Equal(other SLAfterRule) bool {
+	if r.Kind != other.Kind || r.ATRMult != other.ATRMult || r.TrailATRMult != other.TrailATRMult {
+		return false
+	}
+	if !r.ATRRegime.EqualForReload(other.ATRRegime) {
+		return false
+	}
+	if !r.TrailATRRegime.EqualForReload(other.TrailATRRegime) {
+		return false
+	}
+	return true
+}
 
 // computePostTPStopLossTrigger returns the proposed new SL trigger price after
 // a TP tier fires. ok=false signals insufficient inputs (rule kind requires
@@ -101,10 +165,28 @@ func formatATROffsetMode(m float64) string {
 // rule. Use from config parsing.
 func validateSLAfterRule(rule SLAfterRule) error {
 	switch rule.Kind {
-	case "", "breakeven", "atr_offset":
+	case "":
+		return nil
+	case "breakeven":
+		if rule.ATRRegime != nil || rule.TrailATRRegime != nil {
+			return errors.New("sl_after breakeven does not accept a trend_regime block")
+		}
+		return nil
+	case "atr_offset":
+		if rule.TrailATRRegime != nil {
+			return errors.New("sl_after atr_offset accepts trend_regime under atr, not trail_from_here.atr")
+		}
+		// Scalar atr_mult of zero is legal (== breakeven). Regime variant
+		// validates per-label atr at parse time via regimeSurfaceSLAfter.
 		return nil
 	case "trail_from_here":
-		if rule.TrailATRMult <= 0 {
+		if rule.ATRRegime != nil {
+			return errors.New("sl_after trail_from_here accepts trend_regime under trail_from_here.atr, not at the top level")
+		}
+		// Scalar form requires explicit > 0; regime form is validated at
+		// parse time (regimeSurfaceSLAfterTrail enforces strictly positive
+		// per-label atr).
+		if rule.TrailATRRegime == nil && rule.TrailATRMult <= 0 {
 			return errors.New("sl_after trail_from_here requires atr_mult > 0")
 		}
 		return nil
@@ -117,12 +199,20 @@ func validateSLAfterRule(rule SLAfterRule) error {
 // inside a tier object) into a typed SLAfterRule. Accepted shapes:
 //
 //	"breakeven"                                          string shorthand
-//	{"atr_mult": 0.25}                                    → atr_offset
-//	{"trail_from_here": {"atr_mult": 1.0}}                → trail_from_here
+//	{"atr_mult": 0.25}                                    → atr_offset scalar
+//	{"trend_regime": {<labels>}}                          → atr_offset regime (#736)
+//	{"trail_from_here": {"atr_mult": 1.0}}                → trail_from_here scalar
+//	{"trail_from_here": {"trend_regime": {<labels>}}}     → trail_from_here regime (#736)
 //	{"kind": "atr_offset", "atr_mult": 0.25}              → explicit kind
+//	{"kind": "atr_offset", "trend_regime": {<labels>}}    → explicit kind, regime
 //	{"kind": "trail_from_here", "atr_mult": 1.0}          → explicit kind
+//	{"kind": "trail_from_here", "trend_regime": {<labels>}} → explicit kind, regime
 //
 // nil input returns an empty rule with no error (field omitted).
+//
+// Regime-aware shapes resolve via parseRegimeATRBlock; multiple per-label
+// errors are concatenated into a single returned error (with "; " between
+// entries) so callers that surface a single error per field stay compatible.
 func parseSLAfterRule(raw interface{}) (SLAfterRule, error) {
 	if raw == nil {
 		return SLAfterRule{}, nil
@@ -150,18 +240,9 @@ func parseSLAfterRule(raw interface{}) (SLAfterRule, error) {
 			case "breakeven":
 				return SLAfterRule{Kind: "breakeven"}, nil
 			case "atr_offset":
-				mult, err := floatFromAnyChecked(firstPresent(v, "atr_mult", "atr_offset"))
-				if err != nil {
-					return SLAfterRule{}, fmt.Errorf("sl_after kind=atr_offset: %w", err)
-				}
-				return SLAfterRule{Kind: "atr_offset", ATRMult: mult}, nil
+				return parseSLAfterATROffset(v, "sl_after kind=atr_offset")
 			case "trail_from_here":
-				mult, err := floatFromAnyChecked(firstPresent(v, "atr_mult", "trail_atr_mult"))
-				if err != nil {
-					return SLAfterRule{}, fmt.Errorf("sl_after kind=trail_from_here: %w", err)
-				}
-				rule := SLAfterRule{Kind: "trail_from_here", TrailATRMult: mult}
-				return rule, validateSLAfterRule(rule)
+				return parseSLAfterTrailFromHere(v, "sl_after kind=trail_from_here")
 			default:
 				return SLAfterRule{}, fmt.Errorf("sl_after kind %q is not recognized", kind)
 			}
@@ -172,25 +253,89 @@ func parseSLAfterRule(raw interface{}) (SLAfterRule, error) {
 			if !isMap {
 				return SLAfterRule{}, fmt.Errorf("sl_after.trail_from_here must be an object, got %T", trailRaw)
 			}
-			mult, err := floatFromAnyChecked(firstPresent(trailMap, "atr_mult", "trail_atr_mult"))
-			if err != nil {
-				return SLAfterRule{}, fmt.Errorf("sl_after.trail_from_here: %w", err)
-			}
-			rule := SLAfterRule{Kind: "trail_from_here", TrailATRMult: mult}
-			return rule, validateSLAfterRule(rule)
+			return parseSLAfterTrailFromHere(trailMap, "sl_after.trail_from_here")
 		}
-		// Implicit discrimination: atr_mult at top level → atr_offset.
+		// Implicit discrimination: trend_regime at top level → atr_offset regime.
+		if _, ok := v[regimeClassifierKey]; ok {
+			return parseSLAfterATROffset(v, "sl_after")
+		}
+		// Implicit discrimination: atr_mult at top level → atr_offset scalar.
 		if _, ok := firstNonNil(v, "atr_mult", "atr_offset"); ok {
-			mult, err := floatFromAnyChecked(firstPresent(v, "atr_mult", "atr_offset"))
-			if err != nil {
-				return SLAfterRule{}, fmt.Errorf("sl_after atr_mult: %w", err)
-			}
-			return SLAfterRule{Kind: "atr_offset", ATRMult: mult}, nil
+			return parseSLAfterATROffset(v, "sl_after atr_mult")
 		}
-		return SLAfterRule{}, fmt.Errorf("sl_after object must contain \"kind\", \"atr_mult\", or \"trail_from_here\"")
+		// `use_defaults: true` at the top level is ambiguous between
+		// atr_offset and trail_from_here — the operator has to nest it
+		// under a kind to disambiguate. #736.
+		if _, ok := v["use_defaults"]; ok {
+			return SLAfterRule{}, fmt.Errorf("sl_after: use_defaults requires a kind — wrap under \"trail_from_here\" or set \"kind\" explicitly (atr_offset/trail_from_here)")
+		}
+		return SLAfterRule{}, fmt.Errorf("sl_after object must contain \"kind\", \"atr_mult\", \"trail_from_here\", or \"trend_regime\"")
 	default:
 		return SLAfterRule{}, fmt.Errorf("sl_after must be a string or object, got %T", raw)
 	}
+}
+
+// parseSLAfterATROffset parses the atr_offset variant — either scalar
+// (atr_mult / atr_offset) or regime (trend_regime / use_defaults). ctxLabel
+// is prefixed onto regime sub-errors so per-label problems are attributable.
+func parseSLAfterATROffset(m map[string]interface{}, ctxLabel string) (SLAfterRule, error) {
+	_, hasTrend := m[regimeClassifierKey]
+	_, hasUseDefaults := m["use_defaults"]
+	if hasTrend || hasUseDefaults {
+		if _, ok := firstNonNil(m, "atr_mult", "atr_offset"); ok {
+			return SLAfterRule{}, fmt.Errorf("%s: cannot combine scalar atr_mult with trend_regime/use_defaults — pick one shape", ctxLabel)
+		}
+		regimeRaw := map[string]interface{}{}
+		if hasTrend {
+			regimeRaw[regimeClassifierKey] = m[regimeClassifierKey]
+		}
+		if hasUseDefaults {
+			regimeRaw["use_defaults"] = m["use_defaults"]
+		}
+		block, subErrs := parseRegimeATRBlock(regimeRaw, ctxLabel, regimeSurfaceSLAfter)
+		if len(subErrs) > 0 {
+			return SLAfterRule{}, errors.New(strings.Join(subErrs, "; "))
+		}
+		return SLAfterRule{Kind: "atr_offset", ATRRegime: &block}, nil
+	}
+	mult, err := floatFromAnyChecked(firstPresent(m, "atr_mult", "atr_offset"))
+	if err != nil {
+		return SLAfterRule{}, fmt.Errorf("%s: %w", ctxLabel, err)
+	}
+	return SLAfterRule{Kind: "atr_offset", ATRMult: mult}, nil
+}
+
+// parseSLAfterTrailFromHere parses the trail_from_here variant — either
+// scalar (atr_mult / trail_atr_mult) or regime (trend_regime / use_defaults).
+// The regime form uses regimeSurfaceSLAfterTrail so per-label atr must be
+// strictly positive (trail distance is a magnitude).
+func parseSLAfterTrailFromHere(m map[string]interface{}, ctxLabel string) (SLAfterRule, error) {
+	_, hasTrend := m[regimeClassifierKey]
+	_, hasUseDefaults := m["use_defaults"]
+	if hasTrend || hasUseDefaults {
+		if _, ok := firstNonNil(m, "atr_mult", "trail_atr_mult"); ok {
+			return SLAfterRule{}, fmt.Errorf("%s: cannot combine scalar atr_mult with trend_regime/use_defaults — pick one shape", ctxLabel)
+		}
+		regimeRaw := map[string]interface{}{}
+		if hasTrend {
+			regimeRaw[regimeClassifierKey] = m[regimeClassifierKey]
+		}
+		if hasUseDefaults {
+			regimeRaw["use_defaults"] = m["use_defaults"]
+		}
+		block, subErrs := parseRegimeATRBlock(regimeRaw, ctxLabel, regimeSurfaceSLAfterTrail)
+		if len(subErrs) > 0 {
+			return SLAfterRule{}, errors.New(strings.Join(subErrs, "; "))
+		}
+		rule := SLAfterRule{Kind: "trail_from_here", TrailATRRegime: &block}
+		return rule, validateSLAfterRule(rule)
+	}
+	mult, err := floatFromAnyChecked(firstPresent(m, "atr_mult", "trail_atr_mult"))
+	if err != nil {
+		return SLAfterRule{}, fmt.Errorf("%s: %w", ctxLabel, err)
+	}
+	rule := SLAfterRule{Kind: "trail_from_here", TrailATRMult: mult}
+	return rule, validateSLAfterRule(rule)
 }
 
 func firstNonNil(m map[string]interface{}, keys ...string) (interface{}, bool) {
@@ -238,8 +383,11 @@ func (r tierSLAfterRules) HasAny() bool {
 // every index. Trailing empty PerTier entries are ignored so that
 // `[breakeven, {}]` and `[breakeven]` compare equal — the second slot is a
 // no-op in both shapes. See #716 item 1.
+//
+// Uses SLAfterRule.Equal so scalar↔regime and use_defaults↔explicit shape
+// changes inside any rule surface as a config-load mismatch (#736).
 func (r tierSLAfterRules) EqualForReload(other tierSLAfterRules) bool {
-	if r.Default != other.Default {
+	if !r.Default.Equal(other.Default) {
 		return false
 	}
 	maxLen := len(r.PerTier)
@@ -254,7 +402,7 @@ func (r tierSLAfterRules) EqualForReload(other tierSLAfterRules) bool {
 		if i < len(other.PerTier) {
 			b = other.PerTier[i]
 		}
-		if a != b {
+		if !a.Equal(b) {
 			return false
 		}
 	}
@@ -531,17 +679,18 @@ func runPostTPStopLossAdjustment(
 		mu.RUnlock()
 		return false
 	}
-	rule := rules.ForTier(clearedIdx)
+	rawRule := rules.ForTier(clearedIdx)
 	side := pos.Side
 	avgCost := pos.AvgCost
 	entryATR := pos.EntryATR
 	qty := pos.Quantity
 	currentOID := pos.StopLossOID
+	posRegime := pos.Regime
 	mu.RUnlock()
 
 	// If the matched tier has no rule, advance the watermark so we stop
 	// re-evaluating it each cycle. No subprocess work.
-	if rule.IsEmpty() {
+	if rawRule.IsEmpty() {
 		mu.Lock()
 		if p, ok := stratState.Positions[symbol]; ok && p != nil && p.SLAdjustedTiersProcessed <= clearedIdx {
 			p.SLAdjustedTiersProcessed = clearedIdx + 1
@@ -556,6 +705,20 @@ func runPostTPStopLossAdjustment(
 	if currentOID == 0 {
 		return false
 	}
+
+	// Regime-aware rules collapse to the scalar form at fire time via the
+	// position's stamped regime. A missing/unstamped regime defers (no
+	// watermark advance) so the next cycle retries once stampPositionRegimeIfOpened
+	// runs. #736.
+	rule, resolved := rawRule.resolveForRegime(posRegime)
+	if !resolved {
+		if logger != nil {
+			logger.Info("post-TP SL adjustment for %s deferred: tier %d rule is regime-aware but pos.Regime=%q yields no entry",
+				symbol, clearedIdx, posRegime)
+		}
+		return false
+	}
+
 	triggerPx, mode, computeOK := computePostTPStopLossTrigger(rule, side, avgCost, entryATR, mark)
 	if !computeOK {
 		// trail_from_here without a mark (or other malformed input) — defer.

--- a/scheduler/post_tp_sl.go
+++ b/scheduler/post_tp_sl.go
@@ -275,6 +275,16 @@ func parseSLAfterRule(raw interface{}) (SLAfterRule, error) {
 	}
 }
 
+// scalarMultKeysAtROffset lists the scalar-form keys that conflict with a
+// regime block on the atr_offset variant. Used by parseSLAfterATROffset to
+// reject mixed-shape configs (incl. misplaced trail_atr_mult).
+var scalarMultKeysAtROffset = []string{"atr_mult", "atr_offset", "trail_atr_mult"}
+
+// scalarMultKeysTrailFromHere lists the scalar-form keys that conflict with
+// a regime block on the trail_from_here variant. atr_offset would be a
+// misplaced key here too.
+var scalarMultKeysTrailFromHere = []string{"atr_mult", "trail_atr_mult", "atr_offset"}
+
 // parseSLAfterATROffset parses the atr_offset variant — either scalar
 // (atr_mult / atr_offset) or regime (trend_regime / use_defaults). ctxLabel
 // is prefixed onto regime sub-errors so per-label problems are attributable.
@@ -282,8 +292,8 @@ func parseSLAfterATROffset(m map[string]interface{}, ctxLabel string) (SLAfterRu
 	_, hasTrend := m[regimeClassifierKey]
 	_, hasUseDefaults := m["use_defaults"]
 	if hasTrend || hasUseDefaults {
-		if _, ok := firstNonNil(m, "atr_mult", "atr_offset"); ok {
-			return SLAfterRule{}, fmt.Errorf("%s: cannot combine scalar atr_mult with trend_regime/use_defaults — pick one shape", ctxLabel)
+		if _, ok := firstNonNil(m, scalarMultKeysAtROffset...); ok {
+			return SLAfterRule{}, fmt.Errorf("%s: cannot combine scalar atr_mult/atr_offset/trail_atr_mult with trend_regime/use_defaults — pick one shape", ctxLabel)
 		}
 		regimeRaw := map[string]interface{}{}
 		if hasTrend {
@@ -296,13 +306,15 @@ func parseSLAfterATROffset(m map[string]interface{}, ctxLabel string) (SLAfterRu
 		if len(subErrs) > 0 {
 			return SLAfterRule{}, errors.New(strings.Join(subErrs, "; "))
 		}
-		return SLAfterRule{Kind: "atr_offset", ATRRegime: &block}, nil
+		rule := SLAfterRule{Kind: "atr_offset", ATRRegime: &block}
+		return rule, validateSLAfterRule(rule)
 	}
 	mult, err := floatFromAnyChecked(firstPresent(m, "atr_mult", "atr_offset"))
 	if err != nil {
 		return SLAfterRule{}, fmt.Errorf("%s: %w", ctxLabel, err)
 	}
-	return SLAfterRule{Kind: "atr_offset", ATRMult: mult}, nil
+	rule := SLAfterRule{Kind: "atr_offset", ATRMult: mult}
+	return rule, validateSLAfterRule(rule)
 }
 
 // parseSLAfterTrailFromHere parses the trail_from_here variant — either
@@ -313,8 +325,8 @@ func parseSLAfterTrailFromHere(m map[string]interface{}, ctxLabel string) (SLAft
 	_, hasTrend := m[regimeClassifierKey]
 	_, hasUseDefaults := m["use_defaults"]
 	if hasTrend || hasUseDefaults {
-		if _, ok := firstNonNil(m, "atr_mult", "trail_atr_mult"); ok {
-			return SLAfterRule{}, fmt.Errorf("%s: cannot combine scalar atr_mult with trend_regime/use_defaults — pick one shape", ctxLabel)
+		if _, ok := firstNonNil(m, scalarMultKeysTrailFromHere...); ok {
+			return SLAfterRule{}, fmt.Errorf("%s: cannot combine scalar atr_mult/trail_atr_mult/atr_offset with trend_regime/use_defaults — pick one shape", ctxLabel)
 		}
 		regimeRaw := map[string]interface{}{}
 		if hasTrend {

--- a/scheduler/post_tp_sl_test.go
+++ b/scheduler/post_tp_sl_test.go
@@ -1101,3 +1101,336 @@ func TestValidatePostTPStopLossRules_NoOpWhenAbsent(t *testing.T) {
 		t.Fatalf("expected no errors when sl_after is absent, got %v", errs)
 	}
 }
+
+// --- #736: sl_after trend_regime parsing -----------------------------------
+
+// slAfterRegimeRaw is a helper that builds the implicit atr_offset trend_regime
+// shape from a (label → atr) map. Used by the regime parser tests below.
+func slAfterRegimeRaw(entries map[string]float64) map[string]interface{} {
+	tr := map[string]interface{}{}
+	for label, atr := range entries {
+		tr[label] = map[string]interface{}{"atr": atr}
+	}
+	return map[string]interface{}{"trend_regime": tr}
+}
+
+func TestParseSLAfterRule_RegimeATROffset(t *testing.T) {
+	raw := slAfterRegimeRaw(map[string]float64{
+		"trending_up":   0.0,
+		"trending_down": 0.0,
+		"ranging":       -0.5,
+	})
+	got, err := parseSLAfterRule(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Kind != "atr_offset" {
+		t.Fatalf("kind = %q, want atr_offset", got.Kind)
+	}
+	if got.ATRRegime == nil {
+		t.Fatalf("ATRRegime should be populated")
+	}
+	if got.ATRMult != 0 || got.TrailATRMult != 0 {
+		t.Fatalf("scalar fields should be zero, got %+v", got)
+	}
+	// Signed atr values must round-trip — the regime surface is the one
+	// place where 0 and negative atrs are legal.
+	for label, want := range map[string]float64{
+		"trending_up":   0.0,
+		"trending_down": 0.0,
+		"ranging":       -0.5,
+	} {
+		entry, ok := got.ATRRegime.Resolve(label)
+		if !ok {
+			t.Fatalf("missing entry for %q", label)
+		}
+		if entry.ATR != want {
+			t.Fatalf("%s atr = %g, want %g", label, entry.ATR, want)
+		}
+	}
+}
+
+func TestParseSLAfterRule_RegimeTrailFromHere(t *testing.T) {
+	raw := map[string]interface{}{
+		"trail_from_here": map[string]interface{}{
+			"trend_regime": map[string]interface{}{
+				"trending_up":   map[string]interface{}{"atr": 1.0},
+				"trending_down": map[string]interface{}{"atr": 1.0},
+				"ranging":       map[string]interface{}{"atr": 0.5},
+			},
+		},
+	}
+	got, err := parseSLAfterRule(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Kind != "trail_from_here" {
+		t.Fatalf("kind = %q, want trail_from_here", got.Kind)
+	}
+	if got.TrailATRRegime == nil {
+		t.Fatalf("TrailATRRegime should be populated")
+	}
+	if got.TrailATRMult != 0 {
+		t.Fatalf("scalar trail_atr_mult should be zero, got %g", got.TrailATRMult)
+	}
+}
+
+func TestParseSLAfterRule_RegimeExplicitKindAtROffset(t *testing.T) {
+	raw := map[string]interface{}{
+		"kind": "atr_offset",
+		"trend_regime": map[string]interface{}{
+			"trending_up":   map[string]interface{}{"atr": 0.25},
+			"trending_down": map[string]interface{}{"atr": 0.25},
+			"ranging":       map[string]interface{}{"atr": 0.0},
+		},
+	}
+	got, err := parseSLAfterRule(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Kind != "atr_offset" || got.ATRRegime == nil {
+		t.Fatalf("got %+v, want atr_offset with regime block", got)
+	}
+}
+
+func TestParseSLAfterRule_RegimeRejectsTrailNonPositive(t *testing.T) {
+	cases := map[string]float64{
+		"trail_zero":     0.0,
+		"trail_negative": -1.0,
+	}
+	for name, atr := range cases {
+		t.Run(name, func(t *testing.T) {
+			raw := map[string]interface{}{
+				"trail_from_here": map[string]interface{}{
+					"trend_regime": map[string]interface{}{
+						"trending_up":   map[string]interface{}{"atr": 1.0},
+						"trending_down": map[string]interface{}{"atr": 1.0},
+						"ranging":       map[string]interface{}{"atr": atr},
+					},
+				},
+			}
+			if _, err := parseSLAfterRule(raw); err == nil {
+				t.Fatalf("expected error for trail_from_here ranging atr=%g", atr)
+			}
+		})
+	}
+}
+
+func TestParseSLAfterRule_RegimeErrors(t *testing.T) {
+	cases := []struct {
+		name      string
+		raw       interface{}
+		wantInErr string
+	}{
+		{
+			name: "bare_label_keys",
+			raw: map[string]interface{}{
+				"trending_up": map[string]interface{}{"atr": 0.25},
+			},
+			wantInErr: "trend_regime",
+		},
+		{
+			name: "missing_label",
+			raw: map[string]interface{}{
+				"trend_regime": map[string]interface{}{
+					"trending_up": map[string]interface{}{"atr": 0.25},
+					"ranging":     map[string]interface{}{"atr": 0.0},
+				},
+			},
+			wantInErr: "missing required regime labels",
+		},
+		{
+			name: "use_defaults_and_explicit",
+			raw: map[string]interface{}{
+				"use_defaults": true,
+				"trend_regime": map[string]interface{}{
+					"trending_up":   map[string]interface{}{"atr": 0.25},
+					"trending_down": map[string]interface{}{"atr": 0.25},
+					"ranging":       map[string]interface{}{"atr": 0.0},
+				},
+			},
+			wantInErr: "use_defaults",
+		},
+		{
+			name: "scalar_and_regime_mix",
+			raw: map[string]interface{}{
+				"atr_mult": 0.25,
+				"trend_regime": map[string]interface{}{
+					"trending_up":   map[string]interface{}{"atr": 0.25},
+					"trending_down": map[string]interface{}{"atr": 0.25},
+					"ranging":       map[string]interface{}{"atr": 0.0},
+				},
+			},
+			wantInErr: "pick one shape",
+		},
+		{
+			name: "trail_use_defaults_unsupported",
+			raw: map[string]interface{}{
+				"trail_from_here": map[string]interface{}{
+					"use_defaults": true,
+				},
+			},
+			wantInErr: "use_defaults",
+		},
+		{
+			name: "atr_offset_use_defaults_unsupported",
+			raw: map[string]interface{}{
+				"use_defaults": true,
+			},
+			wantInErr: "use_defaults",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseSLAfterRule(tc.raw)
+			if err == nil {
+				t.Fatalf("expected error containing %q", tc.wantInErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantInErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantInErr)
+			}
+		})
+	}
+}
+
+func TestSLAfterRule_EqualRegime(t *testing.T) {
+	makeRule := func(atr float64) SLAfterRule {
+		got, err := parseSLAfterRule(slAfterRegimeRaw(map[string]float64{
+			"trending_up":   atr,
+			"trending_down": atr,
+			"ranging":       atr,
+		}))
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		return got
+	}
+	a := makeRule(0.5)
+	b := makeRule(0.5)
+	if !a.Equal(b) {
+		t.Fatalf("identically-shaped regime rules should be Equal")
+	}
+	c := makeRule(0.25)
+	if a.Equal(c) {
+		t.Fatalf("rules with different atr values should not be Equal")
+	}
+	// Scalar vs regime: different shapes.
+	scalar := SLAfterRule{Kind: "atr_offset", ATRMult: 0.5}
+	if a.Equal(scalar) {
+		t.Fatalf("scalar atr_offset must not Equal regime atr_offset")
+	}
+}
+
+func TestParseStrategyTPSLAfterRules_RegimeRoundTrip(t *testing.T) {
+	sc := StrategyConfig{
+		Type:     "perps",
+		Platform: "hyperliquid",
+		CloseStrategies: []StrategyRef{{
+			Name: "tiered_tp_atr_live",
+			Params: map[string]interface{}{
+				"sl_after": slAfterRegimeRaw(map[string]float64{
+					"trending_up":   0.0,
+					"trending_down": 0.0,
+					"ranging":       -0.5,
+				}),
+				"tiers": []interface{}{
+					map[string]interface{}{
+						"atr_multiple":   2,
+						"close_fraction": 0.5,
+						"sl_after": map[string]interface{}{
+							"trail_from_here": map[string]interface{}{
+								"trend_regime": map[string]interface{}{
+									"trending_up":   map[string]interface{}{"atr": 1.0},
+									"trending_down": map[string]interface{}{"atr": 1.0},
+									"ranging":       map[string]interface{}{"atr": 0.5},
+								},
+							},
+						},
+					},
+					map[string]interface{}{"atr_multiple": 3, "close_fraction": 1.0},
+				},
+			},
+		}},
+	}
+	rules, errs := parseStrategyTPSLAfterRules(sc)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if rules.Default.Kind != "atr_offset" || rules.Default.ATRRegime == nil {
+		t.Fatalf("default = %+v, want atr_offset regime", rules.Default)
+	}
+	if len(rules.PerTier) != 2 {
+		t.Fatalf("per-tier len = %d, want 2", len(rules.PerTier))
+	}
+	if rules.PerTier[0].Kind != "trail_from_here" || rules.PerTier[0].TrailATRRegime == nil {
+		t.Fatalf("tier 0 = %+v, want trail_from_here regime", rules.PerTier[0])
+	}
+}
+
+func TestSLAfterRule_ResolveForRegime(t *testing.T) {
+	rule, err := parseSLAfterRule(slAfterRegimeRaw(map[string]float64{
+		"trending_up":   0.0,
+		"trending_down": 0.0,
+		"ranging":       -0.5,
+	}))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	resolved, ok := rule.resolveForRegime("ranging")
+	if !ok {
+		t.Fatalf("expected ok=true for ranging")
+	}
+	if resolved.Kind != "atr_offset" || resolved.ATRMult != -0.5 {
+		t.Fatalf("ranging resolution = %+v, want atr_offset/-0.5", resolved)
+	}
+	if resolved.ATRRegime != nil {
+		t.Fatalf("resolved rule must drop the regime block")
+	}
+	if _, ok := rule.resolveForRegime("unknown"); ok {
+		t.Fatalf("missing label should yield ok=false")
+	}
+	if _, ok := rule.resolveForRegime(""); ok {
+		t.Fatalf("empty regime should yield ok=false")
+	}
+}
+
+// validatePostTPStopLossRules already rejects trail_from_here on type=manual
+// by checking rule.Kind (lines ~385-394 in scheduler/post_tp_sl.go). The
+// regime variant carries the same Kind, so the gate fires for both shapes
+// — this test makes that contract explicit (#736 acceptance criterion).
+func TestValidatePostTPStopLossRules_RejectsTrailRegimeOnManual(t *testing.T) {
+	atrSL := 1.5
+	sc := StrategyConfig{
+		Type:            "manual",
+		Platform:        "hyperliquid",
+		StopLossATRMult: &atrSL,
+		CloseStrategies: []StrategyRef{{
+			Name: "tiered_tp_atr_live",
+			Params: map[string]interface{}{
+				"sl_after": map[string]interface{}{
+					"trail_from_here": map[string]interface{}{
+						"trend_regime": map[string]interface{}{
+							"trending_up":   map[string]interface{}{"atr": 1.0},
+							"trending_down": map[string]interface{}{"atr": 1.0},
+							"ranging":       map[string]interface{}{"atr": 0.5},
+						},
+					},
+				},
+				"tiers": []interface{}{
+					map[string]interface{}{"atr_multiple": 2, "close_fraction": 0.5},
+					map[string]interface{}{"atr_multiple": 3, "close_fraction": 1.0},
+				},
+			},
+		}},
+	}
+	errs := validatePostTPStopLossRules(sc)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e, "trail_from_here is not supported on manual") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected manual rejection, got %v", errs)
+	}
+}

--- a/scheduler/post_tp_sl_test.go
+++ b/scheduler/post_tp_sl_test.go
@@ -1264,6 +1264,36 @@ func TestParseSLAfterRule_RegimeErrors(t *testing.T) {
 			wantInErr: "pick one shape",
 		},
 		{
+			// Misplaced trail_atr_mult in an atr_offset regime config: the
+			// pre-review parser silently dropped it. Now it surfaces.
+			name: "atr_offset_regime_with_stray_trail_atr_mult",
+			raw: map[string]interface{}{
+				"kind": "atr_offset",
+				"trend_regime": map[string]interface{}{
+					"trending_up":   map[string]interface{}{"atr": 0.25},
+					"trending_down": map[string]interface{}{"atr": 0.25},
+					"ranging":       map[string]interface{}{"atr": 0.0},
+				},
+				"trail_atr_mult": 99.0,
+			},
+			wantInErr: "pick one shape",
+		},
+		{
+			// Misplaced atr_offset key inside a trail_from_here regime block.
+			name: "trail_regime_with_stray_atr_offset",
+			raw: map[string]interface{}{
+				"trail_from_here": map[string]interface{}{
+					"trend_regime": map[string]interface{}{
+						"trending_up":   map[string]interface{}{"atr": 1.0},
+						"trending_down": map[string]interface{}{"atr": 1.0},
+						"ranging":       map[string]interface{}{"atr": 0.5},
+					},
+					"atr_offset": -3.0,
+				},
+			},
+			wantInErr: "pick one shape",
+		},
+		{
 			name: "trail_use_defaults_unsupported",
 			raw: map[string]interface{}{
 				"trail_from_here": map[string]interface{}{

--- a/scheduler/regime_atr.go
+++ b/scheduler/regime_atr.go
@@ -48,11 +48,12 @@ const regimeClassifierKey = "trend_regime"
 type regimeATRSurface int
 
 const (
-	regimeSurfaceStopLoss       regimeATRSurface = iota // stop_loss_atr_regime: ATR only
-	regimeSurfaceTrailing                               // trailing_stop_atr_regime: ATR only
-	regimeSurfaceTPTierATROnly                          // tier with tier-level scalar close_fraction: ATR only inside per-regime
-	regimeSurfaceTPTierWithFrac                         // tier with per-regime close_fraction: ATR + close_fraction
-	regimeSurfaceSLAfter                                // sl_after.{atr,trail_from_here.atr}: ATR only
+	regimeSurfaceStopLoss       regimeATRSurface = iota // stop_loss_atr_regime: ATR only, strictly positive
+	regimeSurfaceTrailing                               // trailing_stop_atr_regime: ATR only, strictly positive
+	regimeSurfaceTPTierATROnly                          // tier with tier-level scalar close_fraction: ATR only, strictly positive
+	regimeSurfaceTPTierWithFrac                         // tier with per-regime close_fraction: ATR + close_fraction, strictly positive
+	regimeSurfaceSLAfter                                // sl_after.atr (atr_offset variant): ATR only, signed allowed (0 and negatives legal — matches the scalar sl_after atr_offset semantics where signed mults move the SL behind/ahead of entry)
+	regimeSurfaceSLAfterTrail                           // sl_after.trail_from_here.atr: ATR only, strictly positive (trail distance is a magnitude)
 )
 
 // RegimeATREntry is one resolution slot inside the trend_regime map.
@@ -394,7 +395,10 @@ func parseRegimeATRBlock(raw map[string]interface{}, ctxLabel string, surface re
 			errs = append(errs, fmt.Sprintf("%s.%s.%s.atr: %v", ctxLabel, regimeClassifierKey, label, err))
 			continue
 		}
-		if atr <= 0 {
+		// sl_after atr_offset accepts signed atr (zero = breakeven, negative
+		// = SL behind entry). Every other surface requires a strictly
+		// positive magnitude. See #736.
+		if surface != regimeSurfaceSLAfter && atr <= 0 {
 			errs = append(errs, fmt.Sprintf("%s.%s.%s.atr: must be > 0, got %g", ctxLabel, regimeClassifierKey, label, atr))
 			continue
 		}

--- a/shared_strategies/close/post_tp_sl.py
+++ b/shared_strategies/close/post_tp_sl.py
@@ -175,6 +175,14 @@ def parse_sl_after_rule(raw: Any) -> SLAfterRule:
     )
 
 
+# Scalar-form keys that conflict with a regime block on the atr_offset
+# variant. trail_atr_mult here is a misplaced field, surfaced loudly.
+_SCALAR_MULT_KEYS_ATR_OFFSET = ("atr_mult", "atr_offset", "trail_atr_mult")
+# Scalar-form keys that conflict with a regime block on the trail_from_here
+# variant. atr_offset here is a misplaced field.
+_SCALAR_MULT_KEYS_TRAIL = ("atr_mult", "trail_atr_mult", "atr_offset")
+
+
 def _parse_sl_after_atr_offset(m: dict, ctx_label: str) -> SLAfterRule:
     """Parse the atr_offset variant — scalar (atr_mult/atr_offset) or regime
     (trend_regime/use_defaults). Multi-label regime errors join with '; '
@@ -182,9 +190,10 @@ def _parse_sl_after_atr_offset(m: dict, ctx_label: str) -> SLAfterRule:
     has_trend = REGIME_CLASSIFIER_KEY in m
     has_use_defaults = "use_defaults" in m
     if has_trend or has_use_defaults:
-        if _first_non_nil(m, "atr_mult", "atr_offset"):
+        if _first_non_nil(m, *_SCALAR_MULT_KEYS_ATR_OFFSET):
             raise ValueError(
-                f"{ctx_label}: cannot combine scalar atr_mult with "
+                f"{ctx_label}: cannot combine scalar "
+                "atr_mult/atr_offset/trail_atr_mult with "
                 "trend_regime/use_defaults — pick one shape"
             )
         regime_raw: dict = {}
@@ -195,12 +204,16 @@ def _parse_sl_after_atr_offset(m: dict, ctx_label: str) -> SLAfterRule:
         block, errs = parse_regime_atr_block(regime_raw, ctx_label, SURFACE_SL_AFTER)
         if errs:
             raise ValueError("; ".join(errs))
-        return SLAfterRule(kind="atr_offset", atr_regime=block)
+        rule = SLAfterRule(kind="atr_offset", atr_regime=block)
+        validate_sl_after_rule(rule)
+        return rule
     mult = _float_or_raise(
         _first_present(m, "atr_mult", "atr_offset"),
         ctx_label,
     )
-    return SLAfterRule(kind="atr_offset", atr_mult=mult)
+    rule = SLAfterRule(kind="atr_offset", atr_mult=mult)
+    validate_sl_after_rule(rule)
+    return rule
 
 
 def _parse_sl_after_trail_from_here(m: dict, ctx_label: str) -> SLAfterRule:
@@ -210,9 +223,10 @@ def _parse_sl_after_trail_from_here(m: dict, ctx_label: str) -> SLAfterRule:
     has_trend = REGIME_CLASSIFIER_KEY in m
     has_use_defaults = "use_defaults" in m
     if has_trend or has_use_defaults:
-        if _first_non_nil(m, "atr_mult", "trail_atr_mult"):
+        if _first_non_nil(m, *_SCALAR_MULT_KEYS_TRAIL):
             raise ValueError(
-                f"{ctx_label}: cannot combine scalar atr_mult with "
+                f"{ctx_label}: cannot combine scalar "
+                "atr_mult/trail_atr_mult/atr_offset with "
                 "trend_regime/use_defaults — pick one shape"
             )
         regime_raw: dict = {}

--- a/shared_strategies/close/post_tp_sl.py
+++ b/shared_strategies/close/post_tp_sl.py
@@ -10,20 +10,62 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Iterable, List, Optional, Tuple
 
+# Absolute import (not relative) so this module loads cleanly under
+# importlib.util.spec_from_file_location — the backtester tests use that
+# loader to sidestep the open/close registry.py name collision, and
+# relative imports require a parent-package context that the loader
+# doesn't set up.
+from shared_strategies.close.regime_atr import (
+    REGIME_CLASSIFIER_KEY,
+    SURFACE_SL_AFTER,
+    SURFACE_SL_AFTER_TRAIL,
+    RegimeATRBlock,
+    parse_regime_atr_block,
+)
+
 
 _TIERED_TP_NAMES = ("tiered_tp_atr", "tiered_tp_atr_live")
 
 
 @dataclass(frozen=True)
 class SLAfterRule:
-    """Typed sl_after rule. ``kind=""`` means the empty / no-op rule."""
+    """Typed sl_after rule. ``kind=""`` means the empty / no-op rule.
+
+    ``atr_regime`` / ``trail_atr_regime`` are set instead of the scalar
+    multiplier when the operator wrote a ``trend_regime`` block (#736);
+    the backtester resolves them per regime at fire time (live behavior
+    lives in scheduler/post_tp_sl.go).
+    """
 
     kind: str = ""
     atr_mult: float = 0.0  # signed; +N moves toward profit (long: above avg)
     trail_atr_mult: float = 0.0  # > 0 for trail_from_here
+    atr_regime: Optional[RegimeATRBlock] = None
+    trail_atr_regime: Optional[RegimeATRBlock] = None
 
     def is_empty(self) -> bool:
         return self.kind == ""
+
+    def has_regime(self) -> bool:
+        return self.atr_regime is not None or self.trail_atr_regime is not None
+
+    def resolve_for_regime(self, regime: str) -> Optional["SLAfterRule"]:
+        """Collapse a regime-aware rule to its scalar form for the given
+        regime label. Returns None when the rule is regime-aware but the
+        label is missing (caller should defer). Scalar rules pass through
+        unchanged. Mirrors Go's SLAfterRule.resolveForRegime.
+        """
+        if self.kind == "atr_offset" and self.atr_regime is not None:
+            entry = self.atr_regime.resolve(regime)
+            if entry is None:
+                return None
+            return SLAfterRule(kind="atr_offset", atr_mult=entry.atr)
+        if self.kind == "trail_from_here" and self.trail_atr_regime is not None:
+            entry = self.trail_atr_regime.resolve(regime)
+            if entry is None or entry.atr <= 0:
+                return None
+            return SLAfterRule(kind="trail_from_here", trail_atr_mult=entry.atr)
+        return self
 
 
 @dataclass
@@ -73,12 +115,16 @@ def parse_sl_after_rule(raw: Any) -> SLAfterRule:
 
     Mirrors ``parseSLAfterRule`` in scheduler/post_tp_sl.go. Accepts:
 
-      * ``None`` / ``""``                          → empty rule
-      * ``"breakeven"``                            → breakeven
-      * ``{"atr_mult": 0.25}``                     → atr_offset
-      * ``{"trail_from_here": {"atr_mult": 1.0}}`` → trail_from_here
+      * ``None`` / ``""``                                  → empty rule
+      * ``"breakeven"``                                    → breakeven
+      * ``{"atr_mult": 0.25}``                             → atr_offset scalar
+      * ``{"trend_regime": {<labels>}}``                   → atr_offset regime (#736)
+      * ``{"trail_from_here": {"atr_mult": 1.0}}``         → trail_from_here scalar
+      * ``{"trail_from_here": {"trend_regime": {...}}}``   → trail_from_here regime (#736)
       * ``{"kind": "atr_offset", "atr_mult": ...}``
+      * ``{"kind": "atr_offset", "trend_regime": {...}}``  → atr_offset regime, explicit kind
       * ``{"kind": "trail_from_here", "atr_mult": ...}``
+      * ``{"kind": "trail_from_here", "trend_regime": {...}}``
 
     Raises ``ValueError`` on malformed shapes.
     """
@@ -104,19 +150,9 @@ def parse_sl_after_rule(raw: Any) -> SLAfterRule:
             if kind == "breakeven":
                 return SLAfterRule(kind="breakeven")
             if kind == "atr_offset":
-                mult = _float_or_raise(
-                    _first_present(raw, "atr_mult", "atr_offset"),
-                    "sl_after kind=atr_offset",
-                )
-                return SLAfterRule(kind="atr_offset", atr_mult=mult)
+                return _parse_sl_after_atr_offset(raw, "sl_after kind=atr_offset")
             if kind == "trail_from_here":
-                mult = _float_or_raise(
-                    _first_present(raw, "atr_mult", "trail_atr_mult"),
-                    "sl_after kind=trail_from_here",
-                )
-                rule = SLAfterRule(kind="trail_from_here", trail_atr_mult=mult)
-                validate_sl_after_rule(rule)
-                return rule
+                return _parse_sl_after_trail_from_here(raw, "sl_after kind=trail_from_here")
             raise ValueError(f"sl_after kind {kind!r} is not recognized")
         if "trail_from_here" in raw:
             trail_raw = raw["trail_from_here"]
@@ -125,34 +161,105 @@ def parse_sl_after_rule(raw: Any) -> SLAfterRule:
                     f"sl_after.trail_from_here must be an object, got "
                     f"{type(trail_raw).__name__}"
                 )
-            mult = _float_or_raise(
-                _first_present(trail_raw, "atr_mult", "trail_atr_mult"),
-                "sl_after.trail_from_here",
-            )
-            rule = SLAfterRule(kind="trail_from_here", trail_atr_mult=mult)
-            validate_sl_after_rule(rule)
-            return rule
+            return _parse_sl_after_trail_from_here(trail_raw, "sl_after.trail_from_here")
+        if REGIME_CLASSIFIER_KEY in raw:
+            return _parse_sl_after_atr_offset(raw, "sl_after")
         if _first_non_nil(raw, "atr_mult", "atr_offset"):
-            mult = _float_or_raise(
-                _first_present(raw, "atr_mult", "atr_offset"),
-                "sl_after atr_mult",
-            )
-            return SLAfterRule(kind="atr_offset", atr_mult=mult)
+            return _parse_sl_after_atr_offset(raw, "sl_after atr_mult")
         raise ValueError(
-            'sl_after object must contain "kind", "atr_mult", or "trail_from_here"'
+            'sl_after object must contain "kind", "atr_mult", "trail_from_here", '
+            'or "trend_regime"'
         )
     raise ValueError(
         f"sl_after must be a string or object, got {type(raw).__name__}"
     )
 
 
+def _parse_sl_after_atr_offset(m: dict, ctx_label: str) -> SLAfterRule:
+    """Parse the atr_offset variant — scalar (atr_mult/atr_offset) or regime
+    (trend_regime/use_defaults). Multi-label regime errors join with '; '
+    so callers that surface a single error per field stay compatible."""
+    has_trend = REGIME_CLASSIFIER_KEY in m
+    has_use_defaults = "use_defaults" in m
+    if has_trend or has_use_defaults:
+        if _first_non_nil(m, "atr_mult", "atr_offset"):
+            raise ValueError(
+                f"{ctx_label}: cannot combine scalar atr_mult with "
+                "trend_regime/use_defaults — pick one shape"
+            )
+        regime_raw: dict = {}
+        if has_trend:
+            regime_raw[REGIME_CLASSIFIER_KEY] = m[REGIME_CLASSIFIER_KEY]
+        if has_use_defaults:
+            regime_raw["use_defaults"] = m["use_defaults"]
+        block, errs = parse_regime_atr_block(regime_raw, ctx_label, SURFACE_SL_AFTER)
+        if errs:
+            raise ValueError("; ".join(errs))
+        return SLAfterRule(kind="atr_offset", atr_regime=block)
+    mult = _float_or_raise(
+        _first_present(m, "atr_mult", "atr_offset"),
+        ctx_label,
+    )
+    return SLAfterRule(kind="atr_offset", atr_mult=mult)
+
+
+def _parse_sl_after_trail_from_here(m: dict, ctx_label: str) -> SLAfterRule:
+    """Parse the trail_from_here variant — scalar (atr_mult/trail_atr_mult)
+    or regime (trend_regime/use_defaults). Regime form uses
+    SURFACE_SL_AFTER_TRAIL so per-label atr must be strictly positive."""
+    has_trend = REGIME_CLASSIFIER_KEY in m
+    has_use_defaults = "use_defaults" in m
+    if has_trend or has_use_defaults:
+        if _first_non_nil(m, "atr_mult", "trail_atr_mult"):
+            raise ValueError(
+                f"{ctx_label}: cannot combine scalar atr_mult with "
+                "trend_regime/use_defaults — pick one shape"
+            )
+        regime_raw: dict = {}
+        if has_trend:
+            regime_raw[REGIME_CLASSIFIER_KEY] = m[REGIME_CLASSIFIER_KEY]
+        if has_use_defaults:
+            regime_raw["use_defaults"] = m["use_defaults"]
+        block, errs = parse_regime_atr_block(
+            regime_raw, ctx_label, SURFACE_SL_AFTER_TRAIL
+        )
+        if errs:
+            raise ValueError("; ".join(errs))
+        rule = SLAfterRule(kind="trail_from_here", trail_atr_regime=block)
+        validate_sl_after_rule(rule)
+        return rule
+    mult = _float_or_raise(
+        _first_present(m, "atr_mult", "trail_atr_mult"),
+        ctx_label,
+    )
+    rule = SLAfterRule(kind="trail_from_here", trail_atr_mult=mult)
+    validate_sl_after_rule(rule)
+    return rule
+
+
 def validate_sl_after_rule(rule: SLAfterRule) -> None:
     """Sanity-check a parsed rule. Raises ``ValueError`` on bad shapes; the
     empty rule passes silently."""
-    if rule.kind in ("", "breakeven", "atr_offset"):
+    if rule.kind == "":
+        return
+    if rule.kind == "breakeven":
+        if rule.atr_regime is not None or rule.trail_atr_regime is not None:
+            raise ValueError("sl_after breakeven does not accept a trend_regime block")
+        return
+    if rule.kind == "atr_offset":
+        if rule.trail_atr_regime is not None:
+            raise ValueError(
+                "sl_after atr_offset accepts trend_regime under atr, not "
+                "trail_from_here.atr"
+            )
         return
     if rule.kind == "trail_from_here":
-        if rule.trail_atr_mult <= 0:
+        if rule.atr_regime is not None:
+            raise ValueError(
+                "sl_after trail_from_here accepts trend_regime under "
+                "trail_from_here.atr, not at the top level"
+            )
+        if rule.trail_atr_regime is None and rule.trail_atr_mult <= 0:
             raise ValueError("sl_after trail_from_here requires atr_mult > 0")
         return
     raise ValueError(

--- a/shared_strategies/close/regime_atr.py
+++ b/shared_strategies/close/regime_atr.py
@@ -26,7 +26,8 @@ SURFACE_STOP_LOSS = "stop_loss"
 SURFACE_TRAILING = "trailing"
 SURFACE_TP_TIER_ATR_ONLY = "tp_tier_atr_only"
 SURFACE_TP_TIER_WITH_FRAC = "tp_tier_with_frac"
-SURFACE_SL_AFTER = "sl_after"
+SURFACE_SL_AFTER = "sl_after"  # atr_offset variant — signed atr legal (#736)
+SURFACE_SL_AFTER_TRAIL = "sl_after_trail"  # trail_from_here variant — strictly positive atr (#736)
 
 
 @dataclass(frozen=True)
@@ -221,7 +222,10 @@ def parse_regime_atr_block(
                 f"got {atr_raw!r}"
             )
             continue
-        if atr <= 0:
+        # sl_after atr_offset accepts signed atr (zero = breakeven, negative
+        # = SL behind entry). Every other surface requires strictly positive.
+        # See #736.
+        if surface != SURFACE_SL_AFTER and atr <= 0:
             errs.append(
                 f"{ctx_label}.{REGIME_CLASSIFIER_KEY}.{label}.atr: must be > 0, "
                 f"got {atr}"

--- a/shared_strategies/close/test_post_tp_sl.py
+++ b/shared_strategies/close/test_post_tp_sl.py
@@ -159,6 +159,41 @@ def test_regime_rejects_scalar_and_regime_mix():
     assert "pick one shape" in str(exc.value)
 
 
+def test_atr_offset_regime_rejects_stray_trail_atr_mult():
+    # Misplaced trail_atr_mult on an atr_offset regime config — pre-review
+    # the parser silently dropped it.
+    with pytest.raises(ValueError) as exc:
+        parse_sl_after_rule(
+            {
+                "kind": "atr_offset",
+                "trend_regime": {
+                    "trending_up": {"atr": 0.25},
+                    "trending_down": {"atr": 0.25},
+                    "ranging": {"atr": 0.0},
+                },
+                "trail_atr_mult": 99.0,
+            }
+        )
+    assert "pick one shape" in str(exc.value)
+
+
+def test_trail_regime_rejects_stray_atr_offset():
+    with pytest.raises(ValueError) as exc:
+        parse_sl_after_rule(
+            {
+                "trail_from_here": {
+                    "trend_regime": {
+                        "trending_up": {"atr": 1.0},
+                        "trending_down": {"atr": 1.0},
+                        "ranging": {"atr": 0.5},
+                    },
+                    "atr_offset": -3.0,
+                }
+            }
+        )
+    assert "pick one shape" in str(exc.value)
+
+
 # --- Equality / resolve helpers --------------------------------------------
 
 

--- a/shared_strategies/close/test_post_tp_sl.py
+++ b/shared_strategies/close/test_post_tp_sl.py
@@ -1,0 +1,288 @@
+"""Parser tests for sl_after (#708, #736).
+
+Mirrors the Go tests in scheduler/post_tp_sl_test.go covering the scalar +
+trend_regime shapes. The backtester resolver is tested via the runtime
+helpers; this file focuses on parse/validate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .post_tp_sl import (
+    SLAfterRule,
+    parse_sl_after_rule,
+    parse_strategy_tp_sl_after_rules,
+    validate_post_tp_stop_loss_rules,
+    validate_sl_after_rule,
+)
+
+
+def _regime(entries):
+    return {
+        "trend_regime": {
+            label: {"atr": atr} for label, atr in entries.items()
+        }
+    }
+
+
+# --- Scalar shapes still parse identically ---------------------------------
+
+
+def test_scalar_atr_offset_implicit():
+    rule = parse_sl_after_rule({"atr_mult": 0.25})
+    assert rule == SLAfterRule(kind="atr_offset", atr_mult=0.25)
+
+
+def test_scalar_atr_offset_signed():
+    rule = parse_sl_after_rule({"atr_mult": -0.5})
+    assert rule == SLAfterRule(kind="atr_offset", atr_mult=-0.5)
+
+
+def test_scalar_trail_from_here():
+    rule = parse_sl_after_rule(
+        {"trail_from_here": {"atr_mult": 1.0}}
+    )
+    assert rule == SLAfterRule(kind="trail_from_here", trail_atr_mult=1.0)
+
+
+def test_scalar_breakeven_string():
+    assert parse_sl_after_rule("breakeven") == SLAfterRule(kind="breakeven")
+
+
+# --- Regime shape (#736) ---------------------------------------------------
+
+
+def test_regime_atr_offset_implicit():
+    rule = parse_sl_after_rule(
+        _regime({"trending_up": 0.0, "trending_down": 0.0, "ranging": -0.5})
+    )
+    assert rule.kind == "atr_offset"
+    assert rule.atr_mult == 0.0
+    assert rule.atr_regime is not None
+    # Signed atr values must round-trip — sl_after.atr_offset is the one
+    # surface where 0 and negative atrs are legal.
+    entry = rule.atr_regime.resolve("ranging")
+    assert entry is not None and entry.atr == -0.5
+    entry_up = rule.atr_regime.resolve("trending_up")
+    assert entry_up is not None and entry_up.atr == 0.0
+
+
+def test_regime_atr_offset_explicit_kind():
+    rule = parse_sl_after_rule(
+        {
+            "kind": "atr_offset",
+            **_regime(
+                {"trending_up": 0.25, "trending_down": 0.25, "ranging": 0.0}
+            ),
+        }
+    )
+    assert rule.kind == "atr_offset"
+    assert rule.atr_regime is not None
+
+
+def test_regime_trail_from_here():
+    rule = parse_sl_after_rule(
+        {
+            "trail_from_here": _regime(
+                {"trending_up": 1.0, "trending_down": 1.0, "ranging": 0.5}
+            )
+        }
+    )
+    assert rule.kind == "trail_from_here"
+    assert rule.trail_atr_regime is not None
+    assert rule.trail_atr_mult == 0.0
+
+
+@pytest.mark.parametrize("atr", [0.0, -1.0])
+def test_regime_trail_rejects_non_positive(atr):
+    with pytest.raises(ValueError):
+        parse_sl_after_rule(
+            {
+                "trail_from_here": _regime(
+                    {
+                        "trending_up": 1.0,
+                        "trending_down": 1.0,
+                        "ranging": atr,
+                    }
+                )
+            }
+        )
+
+
+def test_regime_rejects_bare_label_keys():
+    # Operator forgot the trend_regime wrapper.
+    with pytest.raises(ValueError) as exc:
+        parse_sl_after_rule({"trending_up": {"atr": 0.25}})
+    assert "trend_regime" in str(exc.value) or "object must contain" in str(exc.value)
+
+
+def test_regime_rejects_missing_labels():
+    with pytest.raises(ValueError) as exc:
+        parse_sl_after_rule(
+            {
+                "trend_regime": {
+                    "trending_up": {"atr": 0.25},
+                    "ranging": {"atr": 0.0},
+                }
+            }
+        )
+    assert "missing required regime labels" in str(exc.value)
+
+
+def test_regime_rejects_use_defaults_with_explicit():
+    with pytest.raises(ValueError):
+        parse_sl_after_rule(
+            {
+                "use_defaults": True,
+                "trend_regime": {
+                    "trending_up": {"atr": 0.25},
+                    "trending_down": {"atr": 0.25},
+                    "ranging": {"atr": 0.0},
+                },
+            }
+        )
+
+
+def test_regime_rejects_scalar_and_regime_mix():
+    with pytest.raises(ValueError) as exc:
+        parse_sl_after_rule(
+            {
+                "atr_mult": 0.25,
+                "trend_regime": {
+                    "trending_up": {"atr": 0.25},
+                    "trending_down": {"atr": 0.25},
+                    "ranging": {"atr": 0.0},
+                },
+            }
+        )
+    assert "pick one shape" in str(exc.value)
+
+
+# --- Equality / resolve helpers --------------------------------------------
+
+
+def test_resolve_for_regime_atr_offset():
+    rule = parse_sl_after_rule(
+        _regime({"trending_up": 0.0, "trending_down": 0.0, "ranging": -0.5})
+    )
+    resolved = rule.resolve_for_regime("ranging")
+    assert resolved is not None
+    assert resolved.kind == "atr_offset"
+    assert resolved.atr_mult == -0.5
+    # Resolved rule drops the regime block — purely scalar.
+    assert resolved.atr_regime is None
+
+
+def test_resolve_for_regime_trail_from_here():
+    rule = parse_sl_after_rule(
+        {
+            "trail_from_here": _regime(
+                {"trending_up": 1.0, "trending_down": 1.0, "ranging": 0.5}
+            )
+        }
+    )
+    resolved = rule.resolve_for_regime("ranging")
+    assert resolved is not None
+    assert resolved.kind == "trail_from_here"
+    assert resolved.trail_atr_mult == 0.5
+
+
+def test_resolve_for_regime_unknown_label_defers():
+    rule = parse_sl_after_rule(
+        _regime({"trending_up": 0.0, "trending_down": 0.0, "ranging": -0.5})
+    )
+    assert rule.resolve_for_regime("never") is None
+    assert rule.resolve_for_regime("") is None
+
+
+def test_resolve_scalar_pass_through():
+    rule = SLAfterRule(kind="atr_offset", atr_mult=0.25)
+    resolved = rule.resolve_for_regime("trending_up")
+    assert resolved is rule  # scalar form unchanged
+
+
+# --- Strategy-level parse round trip ---------------------------------------
+
+
+def test_parse_strategy_tp_sl_after_rules_regime():
+    close_refs = [
+        {
+            "name": "tiered_tp_atr_live",
+            "params": {
+                "sl_after": _regime(
+                    {
+                        "trending_up": 0.0,
+                        "trending_down": 0.0,
+                        "ranging": -0.5,
+                    }
+                ),
+                "tiers": [
+                    {
+                        "atr_multiple": 2,
+                        "close_fraction": 0.5,
+                        "sl_after": {
+                            "trail_from_here": _regime(
+                                {
+                                    "trending_up": 1.0,
+                                    "trending_down": 1.0,
+                                    "ranging": 0.5,
+                                }
+                            )
+                        },
+                    },
+                    {"atr_multiple": 3, "close_fraction": 1.0},
+                ],
+            },
+        }
+    ]
+    rules, errs = parse_strategy_tp_sl_after_rules(close_refs)
+    assert errs == []
+    assert rules.default.kind == "atr_offset"
+    assert rules.default.atr_regime is not None
+    assert len(rules.per_tier) == 2
+    assert rules.per_tier[0].kind == "trail_from_here"
+    assert rules.per_tier[0].trail_atr_regime is not None
+
+
+# --- Manual rejection: trail_from_here regime variant ----------------------
+
+
+def test_validate_rejects_trail_regime_on_manual():
+    close_refs = [
+        {
+            "name": "tiered_tp_atr_live",
+            "params": {
+                "sl_after": {
+                    "trail_from_here": _regime(
+                        {
+                            "trending_up": 1.0,
+                            "trending_down": 1.0,
+                            "ranging": 0.5,
+                        }
+                    )
+                },
+                "tiers": [
+                    {"atr_multiple": 2, "close_fraction": 0.5},
+                    {"atr_multiple": 3, "close_fraction": 1.0},
+                ],
+            },
+        }
+    ]
+    errs = validate_post_tp_stop_loss_rules(
+        close_refs,
+        stop_loss_atr_mult=1.5,
+        strategy_type="manual",
+    )
+    assert any(
+        "trail_from_here is not supported on manual" in e for e in errs
+    ), errs
+
+
+# --- validate_sl_after_rule guards -----------------------------------------
+
+
+def test_validate_breakeven_rejects_regime_block():
+    rule = SLAfterRule(kind="breakeven", atr_regime=object())  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        validate_sl_after_rule(rule)


### PR DESCRIPTION
## Summary

Extends `sl_after` rules on `tiered_tp_atr*` close refs to accept a `trend_regime` block — same shape as the other #733 surfaces — in place of the scalar `atr_mult` / `trail_from_here.atr_mult` fields.

- **`sl_after.atr_offset` regime**: `{trend_regime: {trending_up: {atr: 0.0}, ranging: {atr: -0.5}}}` at the top level. Signed `atr` legal (0 = breakeven, negative = SL behind entry).
- **`sl_after.trail_from_here` regime**: nested under `trail_from_here: {trend_regime: {...}}`. Strictly positive `atr` enforced via the new `regimeSurfaceSLAfterTrail` surface.
- Both explicit-`kind` and implicit-discrimination forms accepted.
- Regime-aware rules collapse to scalar form at fire time via `pos.Regime` (stamped at open); defers (no watermark advance) when the label is missing.

## What changed

**Go (`scheduler/`):**
- `regime_atr.go` — `regimeSurfaceSLAfterTrail` added; `atr ≤ 0` rejection relaxed for `regimeSurfaceSLAfter` (signed legal).
- `post_tp_sl.go` — `SLAfterRule` gains `ATRRegime`/`TrailATRRegime` pointer fields + `.Equal()`, `.HasRegime()`, `.resolveForRegime()`; `parseSLAfterRule` routes through two new helpers that call `parseRegimeATRBlock`; `validateSLAfterRule` handles regime variants (manual trail_from_here rejection fires via `Kind` — same path for scalar and regime); `tierSLAfterRules.EqualForReload` uses `.Equal()` so scalar↔regime shape changes block SIGHUP reload; `runPostTPStopLossAdjustment` snapshots `pos.Regime` and resolves before computing the trigger.

**Python (`shared_strategies/close/`):**
- `regime_atr.py` — `SURFACE_SL_AFTER_TRAIL` constant; signed-atr allowance for `SURFACE_SL_AFTER`.
- `post_tp_sl.py` — mirror of all Go changes; switched to absolute import for backtester `spec_from_file_location` compatibility.

## Tests

- 12 new Go tests (parser, resolution, equality, 3 SIGHUP reload cases).
- 20 new Python tests covering the same surface.
- `go test ./...` and `pytest` (1006 tests) pass clean.

Closes #736

---
LLM: Claude Sonnet 4.6 (1M) | high