### PR TITLE
Show regime on summary and leaderboard price lines (#741)

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -276,6 +276,61 @@ var summaryStrategyLabelAliases = map[string]string{
 	"tiered-pct": "tpct",
 }
 
+// regimeDisplayEnabled reports whether top-level regime detection is on.
+func regimeDisplayEnabled(rc *RegimeConfig) bool {
+	return rc != nil && rc.Enabled
+}
+
+// buildRegimeByBaseAsset maps base asset (e.g. "ETH") to the latest regime label
+// from the first matching strategy in strategies with non-empty state.Regime.
+// All strategies on the same (symbol, timeframe) share one label; callers use
+// this for summary price lines so the regime is not duplicated per strategy (#741).
+func buildRegimeByBaseAsset(strategies []StrategyConfig, state *AppState, regime *RegimeConfig) map[string]string {
+	if !regimeDisplayEnabled(regime) || state == nil {
+		return nil
+	}
+	out := make(map[string]string)
+	for _, sc := range strategies {
+		ss := state.Strategies[sc.ID]
+		if ss == nil || ss.Regime == "" {
+			continue
+		}
+		base := extractAsset(sc)
+		if base == "" {
+			continue
+		}
+		if _, ok := out[base]; !ok {
+			out[base] = ss.Regime
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// priceForAsset resolves a spot-style or perps price map entry for a base asset
+// ticker such as "ETH" or "BTC". Returns the price, display short symbol, and ok.
+func priceForAsset(prices map[string]float64, asset string) (float64, string, bool) {
+	asset = strings.ToUpper(strings.TrimSpace(asset))
+	if asset == "" || len(prices) == 0 {
+		return 0, "", false
+	}
+	if p, ok := prices[asset+"/USDT"]; ok {
+		return p, asset, true
+	}
+	if p, ok := prices[asset]; ok {
+		return p, asset, true
+	}
+	for k, p := range prices {
+		base := strings.TrimSuffix(strings.ToUpper(k), "/USDT")
+		if base == asset {
+			return p, asset, true
+		}
+	}
+	return 0, "", false
+}
+
 // FormatCategorySummary creates Discord messages for a set of strategies sharing a channel.
 // Returns a slice of messages; when the content exceeds Discord's 2000-char limit,
 // the position list is split across multiple messages.
@@ -284,6 +339,8 @@ var summaryStrategyLabelAliases = map[string]string{
 // globalIntervalSeconds is the config-level default interval used when a strategy has no per-strategy override.
 // lifetimeStats is keyed by strategy ID; missing keys render zero closed
 // round-trips because SQLite trades are authoritative (#472).
+// regime is the top-level cfg.regime pointer; when enabled and state has labels,
+// each symbol's price segment gains " | <regime>" (#741).
 func FormatCategorySummary(
 	cycle int,
 	elapsed time.Duration,
@@ -299,6 +356,7 @@ func FormatCategorySummary(
 	globalIntervalSeconds int,
 	categorySharpe float64,
 	lifetimeStats map[string]LifetimeTradeStats,
+	regime *RegimeConfig,
 ) []string {
 	var sb strings.Builder
 
@@ -391,19 +449,28 @@ func FormatCategorySummary(
 			syms = append(syms, s)
 		}
 		sort.Strings(syms)
+		regimeByBase := buildRegimeByBaseAsset(strategies, state, regime)
 		parts := make([]string, 0, len(syms))
 		for _, sym := range syms {
 			short := strings.TrimSuffix(sym, "/USDT")
 			priceStr := fmtComma2(displayPrices[sym])
+			var part string
 			if isFutures {
 				if fullName, ok := futuresFullNames[strings.ToUpper(short)]; ok {
-					parts = append(parts, fmt.Sprintf("%s (%s): $%s", short, fullName, priceStr))
+					part = fmt.Sprintf("%s (%s): $%s", short, fullName, priceStr)
 				} else {
-					parts = append(parts, fmt.Sprintf("%s: $%s", short, priceStr))
+					part = fmt.Sprintf("%s: $%s", short, priceStr)
 				}
 			} else {
-				parts = append(parts, fmt.Sprintf("%s: $%s", short, priceStr))
+				part = fmt.Sprintf("%s: $%s", short, priceStr)
 			}
+			if regimeByBase != nil {
+				base := strings.ToUpper(short)
+				if rl := regimeByBase[base]; rl != "" {
+					part += " | " + rl
+				}
+			}
+			parts = append(parts, part)
 		}
 		sb.WriteString(strings.Join(parts, " | "))
 		sb.WriteString("\n")

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -166,7 +166,7 @@ func TestFormatCategorySummary_WithAsset(t *testing.T) {
 	prices := map[string]float64{"BTC/USDT": 50000, "ETH/USDT": 3000}
 
 	// With asset — title should contain " — BTC" and only BTC price shown
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil, nil)
 	msg := strings.Join(msgs, "\n")
 	if !strings.Contains(msg, "— BTC") {
 		t.Errorf("expected '— BTC' in title, got:\n%s", msg)
@@ -176,7 +176,7 @@ func TestFormatCategorySummary_WithAsset(t *testing.T) {
 	}
 
 	// Without asset — no suffix in title
-	msgs2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "", 600, 0, nil)
+	msgs2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "", 600, 0, nil, nil)
 	msg2 := strings.Join(msgs2, "\n")
 	if strings.Contains(msg2, "— ") {
 		t.Errorf("expected no asset suffix when asset='', got:\n%s", msg2)
@@ -202,20 +202,20 @@ func TestFormatCategorySummary_VersionSuffix(t *testing.T) {
 	defer func() { Version = orig }()
 
 	Version = "v9.9.9-test"
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil, nil)
 	summary := strings.Join(msgs, "\n")
 	if !strings.Contains(summary, Version) {
 		t.Errorf("expected version %q in summary title, got:\n%s", Version, summary)
 	}
 
-	msgs = FormatCategorySummary(1, 0, 1, 3, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
+	msgs = FormatCategorySummary(1, 0, 1, 3, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil, nil)
 	trades := strings.Join(msgs, "\n")
 	if !strings.Contains(trades, Version) {
 		t.Errorf("expected version %q in trades title, got:\n%s", Version, trades)
 	}
 
 	Version = ""
-	msgs = FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
+	msgs = FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil, nil)
 	empty := strings.Join(msgs, "\n")
 	if strings.Contains(empty, "()") {
 		t.Errorf("empty Version should omit the suffix, got:\n%s", empty)
@@ -241,7 +241,7 @@ func TestFormatCategorySummary_CircuitBreakerActive(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil, nil)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "Circuit breaker active") {
@@ -275,7 +275,7 @@ func TestFormatCategorySummary_StrategiesSortedByID(t *testing.T) {
 		},
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
-	msgs := FormatCategorySummary(1, 0, 1, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil, nil)
 	msg := strings.Join(msgs, "\n")
 	idxAdx := strings.Index(msg, "hl-adx-btc")
 	idxZebra := strings.Index(msg, "hl-zebra-btc")
@@ -298,7 +298,7 @@ func TestFormatCategorySummary_NoCircuitBreaker(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil, nil)
 	msg := strings.Join(msgs, "\n")
 
 	if strings.Contains(msg, "Circuit breaker") {
@@ -615,7 +615,7 @@ func TestFormatCategorySummary_TfIntColumn(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 3600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 3600, 0, nil, nil)
 	msg := strings.Join(msgs, "\n")
 
 	// Separate Tf and Int column headers should be present (at end of table).
@@ -640,7 +640,7 @@ func TestFormatCategorySummary_TfIntGlobalFallback(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "spot", "", 3600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "spot", "", 3600, 0, nil, nil)
 	msg := strings.Join(msgs, "\n")
 
 	// No timeframe for spot → "—"; global interval 3600s → "1h". Separate columns now.
@@ -664,7 +664,7 @@ func TestFormatCategorySummary_StrategyLabelWidthAndTieredAliases(t *testing.T) 
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil, nil)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "hl-123456789012345") {
@@ -693,7 +693,7 @@ func TestFormatCategorySummary_MaxDrawdownColumn(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 50000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil, nil)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, " DD ") {
@@ -725,7 +725,7 @@ func TestFormatCategorySummary_MaxDrawdownColumn_SharedWallet(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil, nil)
 	msg := strings.Join(msgs, "\n")
 	lines := strings.Split(msg, "\n")
 	var headerLine, totalLine string
@@ -776,7 +776,7 @@ func TestFormatCategorySummary_ClosedTradesColumn(t *testing.T) {
 		"hl-mom-btc": {PositionsOpened: 0},
 	}
 
-	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, lifetime)
+	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, lifetime, nil)
 	msg := strings.Join(msgs, "\n")
 
 	// Header should include #T column.
@@ -834,7 +834,7 @@ func TestFormatCategorySummary_ClosedTradesColumn_SharedWallet(t *testing.T) {
 		"hl-tema-eth": {PositionsOpened: 9},
 	}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, lifetime)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, lifetime, nil)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "#T") {
@@ -912,7 +912,7 @@ func TestFormatCategorySummary_WinLossColumn(t *testing.T) {
 		"hl-mom-btc": {PositionsOpened: 0, Wins: 0, Losses: 0},
 	}
 
-	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, lifetime)
+	msgs := FormatCategorySummary(1, 0, 3, 0, 3000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, lifetime, nil)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "W/L") {
@@ -966,7 +966,7 @@ func TestFormatCategorySummary_SharedWallet(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil, nil)
 	msg := strings.Join(msgs, "\n")
 
 	// Should contain Wallet% column
@@ -1022,7 +1022,7 @@ func TestFormatCategorySummary_WalletPctFromConfig(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil, nil)
 	msg := strings.Join(msgs, "\n")
 
 	if !strings.Contains(msg, "30.0%") {
@@ -1047,7 +1047,7 @@ func TestFormatCategorySummary_NoSharedWallet(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 3000}
 
-	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil, nil)
 	msg := strings.Join(msgs, "\n")
 
 	if strings.Contains(msg, "Wallet%") {
@@ -1076,7 +1076,7 @@ func TestFormatCategorySummary_MessageSplitting(t *testing.T) {
 	state := &AppState{Strategies: strategies}
 	prices := map[string]float64{"BTC/USDT": 51000}
 
-	msgs := FormatCategorySummary(1, 0, 20, 0, 10000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 20, 0, 10000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil, nil)
 
 	// Should produce multiple messages.
 	if len(msgs) < 2 {
@@ -1145,7 +1145,7 @@ func TestFormatCategorySummary_NoSplitWhenShort(t *testing.T) {
 	}
 	prices := map[string]float64{"BTC/USDT": 51000}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil, nil)
 
 	if len(msgs) != 1 {
 		t.Errorf("expected single message for 1 position, got %d", len(msgs))
@@ -1714,7 +1714,7 @@ func TestFormatCategorySummary_HeaderPriceFormat(t *testing.T) {
 	}
 	prices := map[string]float64{"ETH/USDT": 2240.5}
 
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil, nil)
 	msg := strings.Join(msgs, "\n")
 	if !strings.Contains(msg, "ETH: $2,240.50") {
 		t.Errorf("expected header price 'ETH: $2,240.50', got:\n%s", msg)
@@ -1722,6 +1722,47 @@ func TestFormatCategorySummary_HeaderPriceFormat(t *testing.T) {
 	// Old format `ETH $2240` (no colon) must be gone.
 	if strings.Contains(msg, "ETH $2240") {
 		t.Errorf("old header format 'ETH $2240' should be removed, got:\n%s", msg)
+	}
+}
+
+// TestFormatCategorySummary_RegimePriceLine741 verifies issue #741: when
+// regime.enabled is true and state carries a label, the header price line
+// appends " | <regime>"; with regime off or empty label the line is unchanged.
+func TestFormatCategorySummary_RegimePriceLine741(t *testing.T) {
+	strats := []StrategyConfig{
+		{ID: "hl-a-eth", Type: "perps", Args: []string{"rsi", "ETH/USDT", "1h"}, Capital: 1000, Platform: "hyperliquid"},
+		{ID: "hl-b-eth", Type: "perps", Args: []string{"sma", "ETH/USDT", "1h"}, Capital: 1000, Platform: "hyperliquid"},
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-a-eth": {Cash: 1000, Regime: "trending_down"},
+			"hl-b-eth": {Cash: 1000, Regime: "trending_down"},
+		},
+	}
+	prices := map[string]float64{"ETH/USDT": 2277.25}
+	regimeOn := &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20}
+
+	msgs := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil, regimeOn)
+	msg := strings.Join(msgs, "\n")
+	if !strings.Contains(msg, "ETH: $2,277.25 | trending_down") {
+		t.Errorf("expected regime suffix on single ETH price segment, got:\n%s", msg)
+	}
+	if strings.Count(msg, "trending_down") != 1 {
+		t.Errorf("expected exactly one trending_down on price line, got:\n%s", msg)
+	}
+
+	msgsOff := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil, nil)
+	msgOff := strings.Join(msgsOff, "\n")
+	if !strings.Contains(msgOff, "ETH: $2,277.25") || strings.Contains(msgOff, "trending_down") {
+		t.Errorf("expected price line without regime when cfg.regime nil, got:\n%s", msgOff)
+	}
+
+	state.Strategies["hl-a-eth"].Regime = ""
+	state.Strategies["hl-b-eth"].Regime = ""
+	msgsEmpty := FormatCategorySummary(1, 0, 2, 0, 2000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil, regimeOn)
+	msgEmpty := strings.Join(msgsEmpty, "\n")
+	if !strings.Contains(msgEmpty, "ETH: $2,277.25") || strings.Contains(msgEmpty, "ETH: $2,277.25 |") {
+		t.Errorf("expected price line without regime suffix when labels empty, got:\n%s", msgEmpty)
 	}
 }
 
@@ -1782,7 +1823,7 @@ func TestFormatCategorySummary_LargeTableChunked(t *testing.T) {
 	state := &AppState{Strategies: strategies}
 	prices := map[string]float64{"BTC/USDT": 51000}
 
-	msgs := FormatCategorySummary(1, 0, stratCount, 0, 14000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, stratCount, 0, 14000, prices, nil, strats, state, "hyperliquid", "BTC", 600, 0, nil, nil)
 
 	if len(msgs) < 2 {
 		t.Fatalf("expected at least 2 messages for %d strategies, got %d", stratCount, len(msgs))
@@ -2133,7 +2174,7 @@ func TestFormatCategorySummary_LifetimeStatsOverride(t *testing.T) {
 	lifetime := map[string]LifetimeTradeStats{
 		"hl-rmc-eth-live": {PositionsOpened: 17, Wins: 10, Losses: 7},
 	}
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, lifetime)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, lifetime, nil)
 	if len(msgs) == 0 {
 		t.Fatal("expected at least one message")
 	}
@@ -2163,12 +2204,12 @@ func TestFormatCategorySummary_LifetimeStatsNoFallback(t *testing.T) {
 		},
 	}
 	// Nil map, such as a DB query failure, renders zero lifetime stats.
-	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil)
+	msgs := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, nil, nil)
 	if !strings.Contains(msgs[0], " 0     —") {
 		t.Errorf("expected zero #T/W-L without lifetime stats, got:\n%s", msgs[0])
 	}
 	// Empty map (DB returned no rows for this strategy) also renders zero.
-	msgs2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, map[string]LifetimeTradeStats{})
+	msgs2 := FormatCategorySummary(1, 0, 1, 0, 1000, prices, nil, strats, state, "hyperliquid", "ETH", 600, 0, map[string]LifetimeTradeStats{}, nil)
 	if !strings.Contains(msgs2[0], " 0     —") {
 		t.Errorf("expected zero #T/W-L from empty lifetime stats map, got:\n%s", msgs2[0])
 	}

--- a/scheduler/leaderboard.go
+++ b/scheduler/leaderboard.go
@@ -13,6 +13,7 @@ import (
 type LeaderboardEntry struct {
 	ID              string  `json:"id"`
 	Type            string  `json:"type"`
+	Asset           string  `json:"asset,omitempty"` // base symbol for header prices (#741)
 	Value           float64 `json:"value"`
 	Capital         float64 `json:"capital"`
 	PnL             float64 `json:"pnl"`
@@ -66,8 +67,8 @@ func BuildLeaderboardMessages(cfg *Config, state *AppState, prices map[string]fl
 
 	topN := leaderboardTopN(cfg)
 	return map[string]string{
-		"top":    formatAllTimeMessage("🏆", "Top All-Time Performers", allEntries, true, topN),
-		"bottom": formatAllTimeMessage("💀", "Bottom All-Time Performers", allEntries, false, topN),
+		"top":    formatAllTimeMessage("🏆", "Top All-Time Performers", allEntries, true, topN, prices, cfg.Regime, state, cfg),
+		"bottom": formatAllTimeMessage("💀", "Bottom All-Time Performers", allEntries, false, topN, prices, cfg.Regime, state, cfg),
 	}
 }
 
@@ -83,6 +84,7 @@ func newLeaderboardEntry(sc StrategyConfig, ss *StrategyState, pv, initCap, pnl,
 	return LeaderboardEntry{
 		ID:              sc.ID,
 		Type:            sc.Type,
+		Asset:           extractAsset(sc),
 		Value:           pv,
 		Capital:         initCap,
 		PnL:             pnl,
@@ -97,10 +99,84 @@ func newLeaderboardEntry(sc StrategyConfig, ss *StrategyState, pv, initCap, pnl,
 	}
 }
 
+// leaderboardAssetUsesFuturesName reports whether any entry for asset uses
+// type=futures so the header price line can show full contract names (#741).
+func leaderboardAssetUsesFuturesName(entries []LeaderboardEntry, asset string) bool {
+	for _, e := range entries {
+		if e.Asset != asset {
+			continue
+		}
+		if e.Type == "futures" {
+			return true
+		}
+	}
+	return false
+}
+
+// writeLeaderboardHeaderPrices emits an inline "SYM: $price [| regime]" line after
+// the daily banner when prices are available (#741).
+func writeLeaderboardHeaderPrices(sb *strings.Builder, entries []LeaderboardEntry, prices map[string]float64, regime *RegimeConfig, state *AppState, cfg *Config) {
+	if len(prices) == 0 || len(entries) == 0 {
+		return
+	}
+	seen := make(map[string]struct{})
+	var assets []string
+	for _, e := range entries {
+		a := strings.TrimSpace(e.Asset)
+		if a == "" {
+			continue
+		}
+		if _, ok := seen[a]; ok {
+			continue
+		}
+		seen[a] = struct{}{}
+		assets = append(assets, a)
+	}
+	if len(assets) == 0 {
+		return
+	}
+	sort.SliceStable(assets, func(i, j int) bool {
+		return assetSortKey(assets[i]) < assetSortKey(assets[j])
+	})
+	var regimeByBase map[string]string
+	if cfg != nil && state != nil {
+		regimeByBase = buildRegimeByBaseAsset(cfg.Strategies, state, regime)
+	}
+	parts := make([]string, 0, len(assets))
+	for _, asset := range assets {
+		price, short, ok := priceForAsset(prices, asset)
+		if !ok {
+			continue
+		}
+		priceStr := fmtComma2(price)
+		var part string
+		if leaderboardAssetUsesFuturesName(entries, asset) {
+			if fullName, ok := futuresFullNames[strings.ToUpper(short)]; ok {
+				part = fmt.Sprintf("%s (%s): $%s", short, fullName, priceStr)
+			} else {
+				part = fmt.Sprintf("%s: $%s", short, priceStr)
+			}
+		} else {
+			part = fmt.Sprintf("%s: $%s", short, priceStr)
+		}
+		if regimeByBase != nil {
+			if rl := regimeByBase[strings.ToUpper(asset)]; rl != "" {
+				part += " | " + rl
+			}
+		}
+		parts = append(parts, part)
+	}
+	if len(parts) == 0 {
+		return
+	}
+	sb.WriteString(strings.Join(parts, " | "))
+	sb.WriteString("\n")
+}
+
 // formatLeaderboardMessage formats a leaderboard message for a sorted slice of entries.
 // Used by formatAllTimeMessage (top/bottom) and BuildLeaderboardSummary (per-platform summaries).
 // Callers are responsible for passing a positive topN (see leaderboardTopN).
-func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, showType bool, topN int) string {
+func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, showType bool, topN int, prices map[string]float64, regime *RegimeConfig, state *AppState, cfg *Config) string {
 	// Sort by PnL% descending.
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].PnLPct > entries[j].PnLPct
@@ -111,6 +187,7 @@ func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, sh
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%s **%s**\n", icon, title))
 	sb.WriteString(fmt.Sprintf("Daily Report | %s\n", dateStr))
+	writeLeaderboardHeaderPrices(&sb, entries, prices, regime, state, cfg)
 
 	// Totals across ALL strategies in this category.
 	var totalValue, totalCapital float64
@@ -210,7 +287,7 @@ func formatLeaderboardMessage(icon, title string, entries []LeaderboardEntry, sh
 
 // formatAllTimeMessage formats the top/bottom all-time leaderboard.
 // isTop controls sort direction; topN controls how many entries to show.
-func formatAllTimeMessage(icon, title string, entries []LeaderboardEntry, isTop bool, topN int) string {
+func formatAllTimeMessage(icon, title string, entries []LeaderboardEntry, isTop bool, topN int, prices map[string]float64, regime *RegimeConfig, state *AppState, cfg *Config) string {
 	// Sort: top = descending PnL%, bottom = ascending PnL%.
 	sorted := make([]LeaderboardEntry, len(entries))
 	copy(sorted, entries)
@@ -230,7 +307,7 @@ func formatAllTimeMessage(icon, title string, entries []LeaderboardEntry, isTop 
 	}
 	top := sorted[:n]
 
-	return formatLeaderboardMessage(icon, title, top, true, n)
+	return formatLeaderboardMessage(icon, title, top, true, n, prices, regime, state, cfg)
 }
 
 // PostLeaderboard computes the leaderboard on-demand and posts all messages to
@@ -352,7 +429,7 @@ func BuildLeaderboardSummary(lc LeaderboardSummaryConfig, cfg *Config, state *Ap
 	if tickerFilter != "" {
 		title = fmt.Sprintf("%s %s Top %d", platformTitle, tickerFilter, n)
 	}
-	return formatLeaderboardMessage(platformIcon(lc.Platform), title, entries[:n], false, n)
+	return formatLeaderboardMessage(platformIcon(lc.Platform), title, entries[:n], false, n, prices, cfg.Regime, state, cfg)
 }
 
 // truncateRunes returns s clipped to at most max runes. Rune-aware so multi-byte

--- a/scheduler/leaderboard_test.go
+++ b/scheduler/leaderboard_test.go
@@ -544,6 +544,30 @@ func TestBuildLeaderboardSummary_PlatformOnly(t *testing.T) {
 	}
 }
 
+func TestBuildLeaderboardSummary_RegimePriceLine741(t *testing.T) {
+	cfg := &Config{
+		Regime: &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20},
+		Strategies: []StrategyConfig{
+			{ID: "hl-sma-btc", Type: "perps", Capital: 1000, Platform: "hyperliquid", Args: []string{"sma_crossover", "ETH/USDT", "1h"}},
+		},
+	}
+	state := NewAppState()
+	ss := NewStrategyState(cfg.Strategies[0])
+	ss.Cash = 1100
+	ss.Regime = "ranging"
+	state.Strategies["hl-sma-btc"] = ss
+
+	lc := LeaderboardSummaryConfig{Platform: "hyperliquid", TopN: 5, Channel: "chan-1"}
+	prices := map[string]float64{"ETH/USDT": 3000}
+	msg := BuildLeaderboardSummary(lc, cfg, state, prices, nil, nil)
+	if msg == "" {
+		t.Fatal("Expected non-empty message")
+	}
+	if !containsStr(msg, "ETH: $3,000.00 | ranging") {
+		t.Errorf("expected header price line with regime, got:\n%s", msg)
+	}
+}
+
 func TestBuildLeaderboardSummary_TickerFilter(t *testing.T) {
 	cfg := &Config{
 		Strategies: []StrategyConfig{

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1865,7 +1865,7 @@ func main() {
 					chDetails := channelTradeDetails[detailKey]
 					chValue := channelValue[chKey]
 					chSharpe := aggregateSharpe(closedByStrategy, chStrats, state, rfr)
-					msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), chTrades, chValue, prices, chDetails, chStrats, state, chKey, "", cfg.IntervalSeconds, chSharpe, lifetimeStats)
+					msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), chTrades, chValue, prices, chDetails, chStrats, state, chKey, "", cfg.IntervalSeconds, chSharpe, lifetimeStats, cfg.Regime)
 					for _, msg := range msgs {
 						notifier.SendToChannel(chKey, chKey, msg)
 					}
@@ -1882,7 +1882,7 @@ func main() {
 						}
 						assetTrades := len(assetDetails)
 						assetSharpe := aggregateSharpe(closedByStrategy, assetStrats, state, rfr)
-						msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), assetTrades, assetValue, prices, assetDetails, assetStrats, state, chKey, asset, cfg.IntervalSeconds, assetSharpe, lifetimeStats)
+						msgs := FormatCategorySummary(cycle, elapsed, len(dueStrategies), assetTrades, assetValue, prices, assetDetails, assetStrats, state, chKey, asset, cfg.IntervalSeconds, assetSharpe, lifetimeStats, cfg.Regime)
 						for _, msg := range msgs {
 							notifier.SendToChannel(chKey, chKey, msg)
 						}
@@ -2087,7 +2087,7 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, sdb *Sta
 	assetGroups, assetKeys := groupByAsset(chStrats)
 	if len(assetKeys) <= 1 {
 		chSharpe := aggregateSharpe(closedByStrategy, chStrats, state, rfr)
-		msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, chValue, prices, nil, chStrats, state, channelKey, "", cfg.IntervalSeconds, chSharpe, lifetimeStats)
+		msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, chValue, prices, nil, chStrats, state, channelKey, "", cfg.IntervalSeconds, chSharpe, lifetimeStats, cfg.Regime)
 		for _, msg := range msgs {
 			notifier.SendToChannel(channelKey, channelKey, msg)
 			fmt.Println(msg)
@@ -2102,7 +2102,7 @@ func runSummaryAndExit(channelKey string, cfg *Config, state *AppState, sdb *Sta
 				}
 			}
 			assetSharpe := aggregateSharpe(closedByStrategy, assetStrats, state, rfr)
-			msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, assetValue, prices, nil, assetStrats, state, channelKey, asset, cfg.IntervalSeconds, assetSharpe, lifetimeStats)
+			msgs := FormatCategorySummary(state.CycleCount, 0, 0, 0, assetValue, prices, nil, assetStrats, state, channelKey, asset, cfg.IntervalSeconds, assetSharpe, lifetimeStats, cfg.Regime)
 			for _, msg := range msgs {
 				notifier.SendToChannel(channelKey, channelKey, msg)
 				fmt.Println(msg)


### PR DESCRIPTION
Closes https://github.com/richkuo/go-trader/issues/741

- Channel summaries: append ` | <regime>` to each symbol on the inline price line when `regime.enabled` is true and `StrategyState.Regime` is set; one label per base asset (no duplication when multiple strategies share a symbol).
- Leaderboard summaries and daily top/bottom: header line after the daily banner with the same price and optional regime formatting when prices are available.
- `FormatCategorySummary` takes `cfg.Regime`; callers updated.

Tests: `TestFormatCategorySummary_RegimePriceLine741`, `TestBuildLeaderboardSummary_RegimePriceLine741`.

Made with [Cursor](https://cursor.com)