### PR TITLE
Backtester parity for regime-aware ATR surfaces (#737)

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -49,7 +49,7 @@ import os
 import json
 import math
 from datetime import datetime
-from typing import Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
@@ -110,6 +110,19 @@ def _load_close_registry():
     return _close_registry
 
 
+_CLOSE_STRATEGIES_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "shared_strategies", "close")
+)
+
+
+def _ensure_close_strategies_path() -> None:
+    """``regime_atr`` lives under ``shared_strategies/close``; add it to
+    ``sys.path`` so the backtester can import the same module the close
+    evaluators use without depending on PYTHONPATH."""
+    if _CLOSE_STRATEGIES_DIR not in sys.path:
+        sys.path.insert(0, _CLOSE_STRATEGIES_DIR)
+
+
 # Equity-curve points per year per timeframe — used to derive the Sharpe
 # annualization factor. Crypto trades 24/7, so a 1d run has ~365 points/yr,
 # a 4h run has ~365*6, etc. Hardcoding sqrt(365) overstated Sharpe by
@@ -160,6 +173,14 @@ def _open_action_from_signal(signal: int) -> str:
     if signal < 0:
         return "short"
     return "none"
+
+
+def _close_refs_use_regime_tiered_tp(refs: list[dict]) -> bool:
+    for ref in refs:
+        n = (ref.get("name") or "").strip().lower()
+        if n in ("tiered_tp_atr_regime", "tiered_tp_atr_live_regime"):
+            return True
+    return False
 
 
 def _normalize_open_action(value) -> str:
@@ -249,6 +270,8 @@ class Backtester:
                  stop_loss_margin_pct: Optional[float] = None,
                  trailing_stop_atr_mult: Optional[float] = None,
                  trailing_stop_pct: Optional[float] = None,
+                 stop_loss_atr_regime: Optional[dict] = None,
+                 trailing_stop_atr_regime: Optional[dict] = None,
                  strategy_type: str = "perps"):
         """
         Args:
@@ -319,7 +342,135 @@ class Backtester:
         self.trailing_stop_atr_mult = trailing_stop_atr_mult
         self.trailing_stop_pct = trailing_stop_pct
         self.strategy_type = strategy_type
-        if self.close_strategies:
+        self.stop_loss_atr_regime = (
+            dict(stop_loss_atr_regime) if stop_loss_atr_regime else None
+        )
+        self.trailing_stop_atr_regime = (
+            dict(trailing_stop_atr_regime) if trailing_stop_atr_regime else None
+        )
+        self._stop_loss_regime_block = None
+        self._trailing_stop_regime_block = None
+        self._uses_regime_tiered_close = _close_refs_use_regime_tiered_tp(
+            self._close_refs,
+        )
+        _needs_regime_atr = (
+            self.stop_loss_atr_regime is not None
+            or self.trailing_stop_atr_regime is not None
+            or self._uses_regime_tiered_close
+        )
+        if _needs_regime_atr:
+            _ensure_close_strategies_path()
+            from regime_atr import (  # type: ignore
+                SURFACE_STOP_LOSS,
+                SURFACE_TRAILING,
+                parse_regime_atr_block,
+                resolve_regime_atr,
+            )
+
+            regime_errs: list[str] = []
+            if self.stop_loss_atr_regime is not None:
+                blk, errs = parse_regime_atr_block(
+                    self.stop_loss_atr_regime,
+                    "stop_loss_atr_regime",
+                    SURFACE_STOP_LOSS,
+                )
+                regime_errs.extend(errs)
+                self._stop_loss_regime_block = blk
+            if self.trailing_stop_atr_regime is not None:
+                blk, errs = parse_regime_atr_block(
+                    self.trailing_stop_atr_regime,
+                    "trailing_stop_atr_regime",
+                    SURFACE_TRAILING,
+                )
+                regime_errs.extend(errs)
+                self._trailing_stop_regime_block = blk
+            if regime_errs:
+                raise ValueError(
+                    "Invalid regime ATR stop configuration: " + "; ".join(regime_errs)
+                )
+
+            def _active_regime_sl(blk) -> bool:
+                return blk is not None and not blk.is_zero()
+
+            if _active_regime_sl(self._stop_loss_regime_block):
+                if (
+                    self.stop_loss_atr_mult is not None
+                    and self.stop_loss_atr_mult > 0
+                ):
+                    raise ValueError(
+                        "stop_loss_atr_regime is mutually exclusive with "
+                        "stop_loss_atr_mult"
+                    )
+                if self.stop_loss_pct is not None and self.stop_loss_pct > 0:
+                    raise ValueError(
+                        "stop_loss_atr_regime is mutually exclusive with "
+                        "stop_loss_pct"
+                    )
+                if (
+                    self.stop_loss_margin_pct is not None
+                    and self.stop_loss_margin_pct > 0
+                ):
+                    raise ValueError(
+                        "stop_loss_atr_regime is mutually exclusive with "
+                        "stop_loss_margin_pct"
+                    )
+                if self.trailing_stop_pct is not None and self.trailing_stop_pct > 0:
+                    raise ValueError(
+                        "stop_loss_atr_regime is mutually exclusive with "
+                        "trailing_stop_pct"
+                    )
+                if (
+                    self.trailing_stop_atr_mult is not None
+                    and self.trailing_stop_atr_mult > 0
+                ):
+                    raise ValueError(
+                        "stop_loss_atr_regime is mutually exclusive with "
+                        "trailing_stop_atr_mult"
+                    )
+                if _active_regime_sl(self._trailing_stop_regime_block):
+                    raise ValueError(
+                        "stop_loss_atr_regime is mutually exclusive with "
+                        "trailing_stop_atr_regime"
+                    )
+
+            if _active_regime_sl(self._trailing_stop_regime_block):
+                if (
+                    self.trailing_stop_atr_mult is not None
+                    and self.trailing_stop_atr_mult > 0
+                ):
+                    raise ValueError(
+                        "trailing_stop_atr_regime is mutually exclusive with "
+                        "trailing_stop_atr_mult"
+                    )
+                if self.trailing_stop_pct is not None and self.trailing_stop_pct > 0:
+                    raise ValueError(
+                        "trailing_stop_atr_regime is mutually exclusive with "
+                        "trailing_stop_pct"
+                    )
+                if self.stop_loss_pct is not None and self.stop_loss_pct > 0:
+                    raise ValueError(
+                        "trailing_stop_atr_regime is mutually exclusive with "
+                        "stop_loss_pct"
+                    )
+                if (
+                    self.stop_loss_margin_pct is not None
+                    and self.stop_loss_margin_pct > 0
+                ):
+                    raise ValueError(
+                        "trailing_stop_atr_regime is mutually exclusive with "
+                        "stop_loss_margin_pct"
+                    )
+                if (
+                    self.stop_loss_atr_mult is not None
+                    and self.stop_loss_atr_mult > 0
+                ):
+                    raise ValueError(
+                        "trailing_stop_atr_regime is mutually exclusive with "
+                        "stop_loss_atr_mult"
+                    )
+            self._resolve_regime_atr = resolve_regime_atr
+        else:
+            self._resolve_regime_atr = None  # type: ignore[assignment]
             _evaluate, list_strategies = _load_close_registry()
             available = set(list_strategies())
             for name in self.close_strategies:
@@ -333,10 +484,20 @@ class Backtester:
         # thresholds once at init. When no sl_after is configured this is a
         # no-op and the per-bar SL machinery in run() short-circuits.
         self._sl_mod = _load_post_tp_sl()
-        self._sl_after_rules, _sl_parse_errs = self._sl_mod.parse_strategy_tp_sl_after_rules(
-            self._close_refs
+        self._sl_after_rules_static, _sl_parse_errs = (
+            self._sl_mod.parse_strategy_tp_sl_after_rules(self._close_refs)
         )
-        self._tp_tier_thresholds = self._sl_mod.parse_tp_tier_close_fractions(self._close_refs)
+        self._tp_tier_thresholds_static = self._sl_mod.parse_tp_tier_close_fractions(
+            self._close_refs,
+        )
+        # Per-run mutable views (``run()`` re-seeds at each open). Unit tests
+        # that call ``_maybe_apply_sl_after`` directly expect these attrs to
+        # exist without going through ``run()``.
+        self._active_sl_after_rules = self._sl_after_rules_static
+        self._run_tp_tier_thresholds = list(self._tp_tier_thresholds_static)
+        self._run_stop_loss_atr_mult: Optional[float] = None
+        self._run_trailing_stop_atr_mult: Optional[float] = None
+        self._run_position_regime = ""
         # Validation parity with the live config — reject the same bad combos
         # at backtest-load time so users can't silently get a no-op. Run
         # whenever ANY close ref carries an `sl_after` key (or the tiered
@@ -355,7 +516,15 @@ class Backtester:
             ):
                 any_sl_after_key = True
                 break
-        if self._sl_after_rules.has_any() or _sl_parse_errs or any_sl_after_key:
+        self._any_sl_after_key = any_sl_after_key
+        self._sl_after_pipeline_enabled = (
+            self._sl_after_rules_static.has_any() or any_sl_after_key
+        )
+        if (
+            self._sl_after_rules_static.has_any()
+            or _sl_parse_errs
+            or any_sl_after_key
+        ):
             errs = self._sl_mod.validate_post_tp_stop_loss_rules(
                 self._close_refs,
                 stop_loss_atr_mult=self.stop_loss_atr_mult,
@@ -363,6 +532,7 @@ class Backtester:
                 stop_loss_margin_pct=self.stop_loss_margin_pct,
                 trailing_stop_atr_mult=self.trailing_stop_atr_mult,
                 trailing_stop_pct=self.trailing_stop_pct,
+                stop_loss_atr_regime=self.stop_loss_atr_regime,
                 strategy_type=self.strategy_type,
             )
             if errs:
@@ -375,7 +545,7 @@ class Backtester:
             # The live validator accepts margin_pct as satisfying the
             # "fixed SL" precondition, so we reject loudly here rather than
             # silently produce a backtest where the pre-bump SL never fires.
-            if self._sl_after_rules.has_any():
+            if self._sl_after_rules_static.has_any():
                 # #736 explicitly defers regime-aware sl_after backtester
                 # parity to the parallel parity issue. Parsing the shape works
                 # (so live configs round-trip), but the per-bar engine here
@@ -384,9 +554,9 @@ class Backtester:
                 # every bar. Fail loud at load instead of producing results
                 # that look right but ignore the per-regime values.
                 regime_rules = []
-                if self._sl_after_rules.default.has_regime():
+                if self._sl_after_rules_static.default.has_regime():
                     regime_rules.append("strategy-level default")
-                for idx, r in enumerate(self._sl_after_rules.per_tier):
+                for idx, r in enumerate(self._sl_after_rules_static.per_tier):
                     if r.has_regime():
                         regime_rules.append(f"tier[{idx}]")
                 if regime_rules:
@@ -399,8 +569,14 @@ class Backtester:
                         "form for backtesting."
                     )
                 has_atr_sl = (
-                    self.stop_loss_atr_mult is not None
-                    and self.stop_loss_atr_mult > 0
+                    (
+                        self.stop_loss_atr_mult is not None
+                        and self.stop_loss_atr_mult > 0
+                    )
+                    or (
+                        self._stop_loss_regime_block is not None
+                        and not self._stop_loss_regime_block.is_zero()
+                    )
                 )
                 has_pct_sl = (
                     self.stop_loss_pct is not None and self.stop_loss_pct > 0
@@ -501,6 +677,12 @@ class Backtester:
             ensure_regime = _load_regime()
             ensure_regime(df, period=self.regime_period, adx_threshold=self.regime_adx_threshold)
 
+        # Snapshot the bar-close regime label before any shift so close
+        # evaluators that re-resolve per bar (``tiered_tp_atr_live_regime``)
+        # read the same ``ensure_regime_columns`` output as live (#737).
+        if "regime" in df.columns:
+            df["_regime_bar_close"] = df["regime"].copy()
+
         # Shift regime to match the signal shift in the signal-normalization
         # block above. In live, the regime label is computed from bar N's
         # closed data at the same moment as the signal; both gate the order
@@ -520,6 +702,14 @@ class Backtester:
             df["regime"] = df["regime"].shift(1).fillna("")
 
         has_open = "open" in df.columns
+
+        def _entry_stamp(row) -> str:
+            if self.regime_enabled:
+                return str(row.get("regime", "") or "").strip()
+            return str(row.get("_regime_bar_close", "") or "").strip()
+
+        def _bar_close_regime(row) -> str:
+            return str(row.get("_regime_bar_close", "") or "").strip()
 
         cash = self.initial_capital
         position = 0.0  # shares held
@@ -543,9 +733,59 @@ class Backtester:
         sl_tiers_processed = 0
         post_tp_trail_mult: Optional[float] = None
         sl_high_water_px = 0.0
-        sl_after_active = self._sl_after_rules.has_any()
+        self._active_sl_after_rules = self._sl_after_rules_static
+        self._run_tp_tier_thresholds = list(self._tp_tier_thresholds_static)
+        self._run_stop_loss_atr_mult: Optional[float] = None
+        self._run_trailing_stop_atr_mult: Optional[float] = None
+        self._run_position_regime = ""
+        sl_after_active = self._sl_after_pipeline_enabled
 
         atr_series = df["atr"] if "atr" in df.columns else None
+
+        def stamp_open_from_label(stamp: str) -> None:
+            lab = (stamp or "").strip()
+            self._run_position_regime = lab
+            if self._uses_regime_tiered_close:
+                rules_rt, _ = self._sl_mod.parse_strategy_tp_sl_after_rules(
+                    self._close_refs, regime=lab,
+                )
+                self._active_sl_after_rules = rules_rt
+                self._run_tp_tier_thresholds = self._sl_mod.parse_tp_tier_close_fractions(
+                    self._close_refs, regime=lab,
+                )
+            else:
+                self._active_sl_after_rules = self._sl_after_rules_static
+                self._run_tp_tier_thresholds = list(self._tp_tier_thresholds_static)
+
+            self._run_stop_loss_atr_mult = None
+            self._run_trailing_stop_atr_mult = None
+            if self._resolve_regime_atr is not None and lab:
+                if (
+                    self._stop_loss_regime_block is not None
+                    and not self._stop_loss_regime_block.is_zero()
+                ):
+                    self._run_stop_loss_atr_mult = self._resolve_regime_atr(
+                        self._stop_loss_regime_block, lab,
+                    )
+                if (
+                    self._trailing_stop_regime_block is not None
+                    and not self._trailing_stop_regime_block.is_zero()
+                ):
+                    self._run_trailing_stop_atr_mult = self._resolve_regime_atr(
+                        self._trailing_stop_regime_block, lab,
+                    )
+            if self._run_stop_loss_atr_mult is None:
+                if (
+                    self.stop_loss_atr_mult is not None
+                    and self.stop_loss_atr_mult > 0
+                ):
+                    self._run_stop_loss_atr_mult = self.stop_loss_atr_mult
+            if self._run_trailing_stop_atr_mult is None:
+                if (
+                    self.trailing_stop_atr_mult is not None
+                    and self.trailing_stop_atr_mult > 0
+                ):
+                    self._run_trailing_stop_atr_mult = self.trailing_stop_atr_mult
 
         if starting_long:
             effective_entry = starting_long["entry_price"]
@@ -571,6 +811,10 @@ class Backtester:
                 seed_atr = 0.0
             if seed_atr > 0 and seed_atr <= 0.5 * effective_entry:
                 entry_atr_value = seed_atr
+            stamp = str(starting_long.get("entry_regime", "") or "").strip()
+            if not stamp:
+                stamp = _entry_stamp(df.iloc[0])
+            stamp_open_from_label(stamp)
 
         for i, (idx, row) in enumerate(df.iterrows()):
             fill_price = row["open"] if has_open else row["close"]
@@ -651,7 +895,14 @@ class Backtester:
                         post_tp_trail_mult = None
                         sl_high_water_px = 0.0
                         sl_after_just_applied = False
-                    elif sl_after_active and self._tp_tier_thresholds:
+                        self._active_sl_after_rules = self._sl_after_rules_static
+                        self._run_tp_tier_thresholds = list(
+                            self._tp_tier_thresholds_static,
+                        )
+                        self._run_stop_loss_atr_mult = None
+                        self._run_trailing_stop_atr_mult = None
+                        self._run_position_regime = ""
+                    elif sl_after_active and self._run_tp_tier_thresholds:
                         # After applying a partial close at this bar's open,
                         # detect which tier(s) just cleared and apply the
                         # highest cleared tier's sl_after rule. The end-of-bar
@@ -700,16 +951,17 @@ class Backtester:
                     avg_cost = effective_price
                     initial_quantity = shares
                     entry_atr_value = self._stamp_entry_atr(atr_series, idx, effective_price)
+                    stamp_open_from_label(_entry_stamp(row))
                     # #716 item 3: seed the SL trigger only when sl_after has
                     # usable tier thresholds. Without thresholds, the post-TP
                     # adjustment machinery never fires (`_maybe_apply_sl_after`
-                    # is gated on `self._tp_tier_thresholds`), so a seeded-
+                    # is gated on `self._run_tp_tier_thresholds`), so a seeded-
                     # then-never-adjusted trigger would represent a phantom
                     # fixed SL the rest of the engine doesn't actually
                     # simulate. Mirrors the live shape, where the fixed SL is
                     # placed by `runHyperliquidProtectionSync` independently
                     # of `sl_after` configuration.
-                    if sl_after_active and self._tp_tier_thresholds:
+                    if sl_after_active and self._run_tp_tier_thresholds:
                         sl_trigger_px = self._initial_sl_trigger(
                             "long", avg_cost, entry_atr_value,
                         )
@@ -729,7 +981,8 @@ class Backtester:
                     avg_cost = effective_price
                     initial_quantity = shares
                     entry_atr_value = self._stamp_entry_atr(atr_series, idx, effective_price)
-                    if sl_after_active and self._tp_tier_thresholds:
+                    stamp_open_from_label(_entry_stamp(row))
+                    if sl_after_active and self._run_tp_tier_thresholds:
                         sl_trigger_px = self._initial_sl_trigger(
                             "short", avg_cost, entry_atr_value,
                         )
@@ -745,6 +998,8 @@ class Backtester:
                     pending_close_fraction = self._evaluate_close_strategies(
                         position, avg_cost, initial_quantity, entry_atr_value,
                         mark_price, atr_series, idx,
+                        position_regime=self._run_position_regime,
+                        market_regime=_bar_close_regime(row),
                     )
 
                 # End-of-bar: walk the trailing-stop high-water mark (only
@@ -881,7 +1136,10 @@ class Backtester:
                                    entry_atr_value: float,
                                    mark_price: float,
                                    atr_series: Optional[pd.Series],
-                                   idx) -> float:
+                                   idx,
+                                   *,
+                                   position_regime: str = "",
+                                   market_regime: str = "") -> float:
         """Run every configured close evaluator against the simulated position
         and return the max ``close_fraction``. Same max-wins resolution as the
         live composition flow in shared_tools/strategy_composition.py.
@@ -894,8 +1152,11 @@ class Backtester:
             "current_quantity": float(abs(position)),
             "initial_quantity": float(initial_quantity or abs(position)),
             "entry_atr": float(entry_atr_value),
+            "regime": str(position_regime or ""),
         }
         market_dict = {"mark_price": float(mark_price)}
+        if market_regime:
+            market_dict["regime"] = str(market_regime)
         if atr_series is not None:
             # Current-bar ATR access is intentional and matches live (#730):
             # close evaluators run end-of-bar with this bar's closed mark and
@@ -941,11 +1202,11 @@ class Backtester:
         if avg_cost <= 0 or side not in ("long", "short"):
             return 0.0
         if (
-            self.stop_loss_atr_mult is not None
-            and self.stop_loss_atr_mult > 0
+            self._run_stop_loss_atr_mult is not None
+            and self._run_stop_loss_atr_mult > 0
             and entry_atr > 0
         ):
-            distance = self.stop_loss_atr_mult * entry_atr
+            distance = self._run_stop_loss_atr_mult * entry_atr
             return avg_cost - distance if side == "long" else avg_cost + distance
         if self.stop_loss_pct is not None and self.stop_loss_pct > 0:
             return (
@@ -1029,11 +1290,11 @@ class Backtester:
         if closed_ratio <= 0:
             return sl_trigger_px, sl_tiers_processed, post_tp_trail_mult, sl_high_water_px
         highest = self._sl_mod.find_highest_cleared_tier(
-            self._tp_tier_thresholds, closed_ratio, sl_tiers_processed,
+            self._run_tp_tier_thresholds, closed_ratio, sl_tiers_processed,
         )
         if highest < 0:
             return sl_trigger_px, sl_tiers_processed, post_tp_trail_mult, sl_high_water_px
-        rule = self._sl_after_rules.for_tier(highest)
+        rule = self._active_sl_after_rules.for_tier(highest)
         if rule.is_empty():
             return sl_trigger_px, highest + 1, post_tp_trail_mult, sl_high_water_px
         # Defer when no fixed SL is currently armed — mirrors the live

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -517,6 +517,9 @@ class Backtester:
                 any_sl_after_key = True
                 break
         self._any_sl_after_key = any_sl_after_key
+        # For regime-tiered closes, ``parse_strategy_tp_sl_after_rules(..., regime=None)``
+        # leaves ``per_tier`` empty at load time; ``stamp_open_from_label`` in
+        # ``run()`` reparses with the stamped regime before any tier fires.
         self._sl_after_pipeline_enabled = (
             self._sl_after_rules_static.has_any() or any_sl_after_key
         )
@@ -1154,9 +1157,13 @@ class Backtester:
             "entry_atr": float(entry_atr_value),
             "regime": str(position_regime or ""),
         }
-        market_dict = {"mark_price": float(mark_price)}
-        if market_regime:
-            market_dict["regime"] = str(market_regime)
+        # Always pass ``regime`` (possibly empty) so live-regime evaluators see
+        # the same key shape as live check scripts — empty/NaN bars no-op with
+        # an explicit label instead of a missing dict key (#747 review).
+        market_dict = {
+            "mark_price": float(mark_price),
+            "regime": str(market_regime or ""),
+        }
         if atr_series is not None:
             # Current-bar ATR access is intentional and matches live (#730):
             # close evaluators run end-of-bar with this bar's closed mark and

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -119,6 +119,14 @@ def load_strategy_config(config_path: str, strategy_id: str) -> dict:
                 "params": dict(open_ref.get("params") or {}),
             },
             "close_strategies": close_refs,
+            "stop_loss_atr_mult": sc.get("stop_loss_atr_mult"),
+            "stop_loss_pct": sc.get("stop_loss_pct"),
+            "stop_loss_margin_pct": sc.get("stop_loss_margin_pct"),
+            "trailing_stop_atr_mult": sc.get("trailing_stop_atr_mult"),
+            "trailing_stop_pct": sc.get("trailing_stop_pct"),
+            "stop_loss_atr_regime": sc.get("stop_loss_atr_regime"),
+            "trailing_stop_atr_regime": sc.get("trailing_stop_atr_regime"),
+            "strategy_type": str(sc.get("type") or "perps"),
         }
     raise ValueError(
         f"{config_path}: no strategy with id={strategy_id!r}. "
@@ -141,6 +149,14 @@ def run_single_backtest(
     regime_period: int = 14,
     regime_adx_threshold: float = 20.0,
     allowed_regimes: Optional[List[str]] = None,
+    stop_loss_atr_mult: Optional[float] = None,
+    stop_loss_pct: Optional[float] = None,
+    stop_loss_margin_pct: Optional[float] = None,
+    trailing_stop_atr_mult: Optional[float] = None,
+    trailing_stop_pct: Optional[float] = None,
+    stop_loss_atr_regime: Optional[dict] = None,
+    trailing_stop_atr_regime: Optional[dict] = None,
+    strategy_type: str = "perps",
 ) -> Optional[dict]:
     """Run a single backtest and print results.
 
@@ -196,6 +212,14 @@ def run_single_backtest(
         regime_period=regime_period,
         regime_adx_threshold=regime_adx_threshold,
         allowed_regimes=allowed_regimes,
+        stop_loss_atr_mult=stop_loss_atr_mult,
+        stop_loss_pct=stop_loss_pct,
+        stop_loss_margin_pct=stop_loss_margin_pct,
+        trailing_stop_atr_mult=trailing_stop_atr_mult,
+        trailing_stop_pct=trailing_stop_pct,
+        stop_loss_atr_regime=stop_loss_atr_regime,
+        trailing_stop_atr_regime=trailing_stop_atr_regime,
+        strategy_type=strategy_type,
     )
     results = bt.run(
         df_signals,
@@ -447,6 +471,7 @@ def main():
 
     # #641: --config loads a single strategy by ID and uses its refs directly.
     open_params: Optional[dict] = None
+    live_stop_kwargs: dict = {}
     if args.config:
         # --config loads exactly one strategy; non-single modes would silently
         # ignore the loaded refs for every strategy except the one matching
@@ -467,8 +492,17 @@ def main():
         # silently ignores per-strategy params from the live config (#643 review #1).
         args.strategy = live_kwargs["open_strategy"]["name"]
         open_params = dict(live_kwargs["open_strategy"]["params"]) or None
-
-    reg = load_registry(args.registry)
+        stop_keys = (
+            "stop_loss_atr_mult",
+            "stop_loss_pct",
+            "stop_loss_margin_pct",
+            "trailing_stop_atr_mult",
+            "trailing_stop_pct",
+            "stop_loss_atr_regime",
+            "trailing_stop_atr_regime",
+            "strategy_type",
+        )
+        live_stop_kwargs = {k: live_kwargs[k] for k in stop_keys if k in live_kwargs}
 
     if args.mode == "single":
         if args.strategy == "all":
@@ -483,7 +517,8 @@ def main():
                             regime_enabled=args.regime_enabled,
                             regime_period=args.regime_period,
                             regime_adx_threshold=args.regime_adx_threshold,
-                            allowed_regimes=args.allowed_regimes)
+                            allowed_regimes=args.allowed_regimes,
+                            **live_stop_kwargs)
 
     elif args.mode == "compare":
         strategies = None if args.strategy == "all" else [args.strategy]

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -504,6 +504,8 @@ def main():
         )
         live_stop_kwargs = {k: live_kwargs[k] for k in stop_keys if k in live_kwargs}
 
+    reg = load_registry(args.registry)
+
     if args.mode == "single":
         if args.strategy == "all":
             print("Specify a strategy for single mode: --strategy <name>")

--- a/backtest/tests/test_post_tp_sl.py
+++ b/backtest/tests/test_post_tp_sl.py
@@ -1041,7 +1041,7 @@ def test_backtester_sl_after_does_not_seed_when_no_tier_thresholds():
         }],
     )
     # Pre-condition: parser returned no usable thresholds.
-    assert bt._tp_tier_thresholds == []
+    assert bt._tp_tier_thresholds_static == []
     result = bt.run(df, save=False)
     # No SL fire — price dropped to $80 (well below the would-be SL at $90)
     # but the gate must skip the seed entirely. Only the end-of-run forced

--- a/backtest/tests/test_regime_backtester_737.py
+++ b/backtest/tests/test_regime_backtester_737.py
@@ -1,0 +1,186 @@
+"""Backtester parity for regime-aware ATR surfaces (#737)."""
+
+import pytest
+import pandas as pd
+
+from backtester import Backtester
+from shared_strategies.close import regime_atr
+
+
+def _tier_spec_widely_separated():
+    """Single tier whose ATR multiple differs sharply by regime label."""
+    return [
+        {
+            "trend_regime": {
+                "trending_up": {"atr": 10.0, "close_fraction": 1.0},
+                "trending_down": {"atr": 10.0, "close_fraction": 1.0},
+                "ranging": {"atr": 0.25, "close_fraction": 1.0},
+            }
+        }
+    ]
+
+
+def test_tiered_tp_atr_regime_frozen_multiplier_ignores_mid_trade_regime_shift():
+    """Tier distances stay anchored to the open-time label across regime flips."""
+    idx = pd.date_range("2024-01-01", periods=6, freq="D")
+    df = pd.DataFrame(
+        {
+            "open": [100.0, 100.0, 100.0, 100.26, 100.26, 100.26],
+            "close": [100.0, 100.0, 100.0, 100.26, 100.26, 100.26],
+            "atr": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            # Raw labels (``regime_enabled`` is off — stamp + live paths read
+            # from ``_regime_bar_close`` captured before any shift).
+            "regime": [
+                "ranging",
+                "ranging",
+                "ranging",
+                "trending_up",
+                "trending_up",
+                "trending_up",
+            ],
+            # Shifted pipeline: raw ``long`` at idx1 fills at idx2 open.
+            "open_action": ["none", "long", "none", "none", "none", "none"],
+        },
+        index=idx,
+    )
+
+    close_ref = {
+        "name": "tiered_tp_atr_regime",
+        "params": {"tiers": _tier_spec_widely_separated()},
+    }
+    bt = Backtester(
+        initial_capital=10_000.0,
+        commission_pct=0.0,
+        slippage_pct=0.0,
+        close_strategies=[close_ref],
+    )
+    result = bt.run(df, save=False)
+
+    # End-of-bar idx3 close hits ranging multiple 0.25×ATR → pending full close
+    # at idx4 open (shifted pipeline).
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_date"] == str(idx[4])
+
+
+def test_tiered_tp_atr_live_regime_re_resolves_multiplier_mid_trade():
+    """Live variant moves tier distances with each bar's regime label."""
+    idx = pd.date_range("2024-01-01", periods=6, freq="D")
+    df = pd.DataFrame(
+        {
+            "open": [100.0, 100.0, 100.0, 100.26, 100.26, 100.26],
+            "close": [100.0, 100.0, 100.0, 100.26, 100.26, 100.26],
+            "atr": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            "regime": [
+                "ranging",
+                "ranging",
+                "ranging",
+                "trending_up",
+                "trending_up",
+                "trending_up",
+            ],
+            "open_action": ["none", "long", "none", "none", "none", "none"],
+        },
+        index=idx,
+    )
+
+    close_ref = {
+        "name": "tiered_tp_atr_live_regime",
+        "params": {"tiers": _tier_spec_widely_separated()},
+    }
+    bt = Backtester(
+        initial_capital=10_000.0,
+        commission_pct=0.0,
+        slippage_pct=0.0,
+        close_strategies=[close_ref],
+    )
+    result = bt.run(df, save=False)
+
+    # No TP partial: the engine flattens at the last bar (still one round-trip).
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_date"] == str(idx[-1])
+
+
+def test_stop_loss_atr_regime_use_defaults_matches_baseline_table():
+    """``use_defaults: true`` expands to the shared REGIME_ATR_DEFAULTS_STOP_LOSS."""
+    mult = regime_atr.resolve_regime_atr(
+        regime_atr.parse_regime_atr_block(
+            {"use_defaults": True}, "probe", regime_atr.SURFACE_STOP_LOSS,
+        )[0],
+        "ranging",
+    )
+    assert mult == regime_atr.REGIME_ATR_DEFAULTS_STOP_LOSS["ranging"].atr
+
+
+def test_stop_loss_atr_regime_seeds_initial_sl_trigger_from_open_stamp():
+    """Hand-check: ranging default SL is 1.5×ATR below entry for a long."""
+    idx = pd.date_range("2024-01-01", periods=6, freq="D")
+    df = pd.DataFrame(
+        {
+            "open": [100.0, 100.0, 100.0, 96.0, 96.0, 96.0],
+            "close": [100.0, 100.0, 100.0, 96.0, 96.0, 96.0],
+            "atr": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            "regime": ["ranging"] * 6,
+            "open_action": ["none", "long", "none", "none", "none", "none"],
+        },
+        index=idx,
+    )
+
+    close_ref = {
+        "name": "tiered_tp_atr",
+        "params": {
+            "tiers": [{"atr_multiple": 100.0, "close_fraction": 1.0}],
+            # ``sl_after`` arms the bar-level SL machinery (``_initial_sl_trigger``),
+            # which is otherwise unused in the open/close engine (#737 test).
+            "sl_after": "breakeven",
+        },
+    }
+    bt = Backtester(
+        initial_capital=10_000.0,
+        commission_pct=0.0,
+        slippage_pct=0.0,
+        close_strategies=[close_ref],
+        stop_loss_atr_regime={"use_defaults": True},
+    )
+    result = bt.run(df, save=False)
+
+    # SL trigger at 100 - 1.5 = 98.5; idx3 close 96 trips SL next open at 96.
+    assert result["total_trades"] == 1
+    tr = result["trades"][0]
+    assert tr["entry_price"] == 100.0
+    assert tr["exit_price"] == 96.0
+
+
+def test_trailing_stop_atr_regime_use_defaults_parses():
+    blk, errs = regime_atr.parse_regime_atr_block(
+        {"use_defaults": True},
+        "trailing_stop_atr_regime",
+        regime_atr.SURFACE_TRAILING,
+    )
+    assert not errs
+    mult = regime_atr.resolve_regime_atr(blk, "trending_up")
+    assert mult == regime_atr.REGIME_ATR_DEFAULTS_TRAILING["trending_up"].atr
+
+
+def test_backtester_rejects_mutex_stop_loss_scalar_with_regime_block():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        Backtester(
+            stop_loss_atr_mult=1.0,
+            stop_loss_atr_regime={"use_defaults": True},
+        )
+
+
+def test_backtester_rejects_mutex_trailing_scalar_with_regime_block():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        Backtester(
+            trailing_stop_atr_mult=1.0,
+            trailing_stop_atr_regime={"use_defaults": True},
+        )
+
+
+def test_parse_tp_tier_close_fractions_use_defaults_requires_regime_label():
+    from shared_strategies.close import post_tp_sl as sl
+
+    refs = [{"name": "tiered_tp_atr_regime", "params": {"use_defaults": True}}]
+    assert sl.parse_tp_tier_close_fractions(refs, regime=None) == []
+    fracs = sl.parse_tp_tier_close_fractions(refs, regime="ranging")
+    assert fracs == [0.5, 1.0]

--- a/shared_strategies/close/post_tp_sl.py
+++ b/shared_strategies/close/post_tp_sl.py
@@ -19,12 +19,20 @@ from shared_strategies.close.regime_atr import (
     REGIME_CLASSIFIER_KEY,
     SURFACE_SL_AFTER,
     SURFACE_SL_AFTER_TRAIL,
+    SURFACE_STOP_LOSS,
     RegimeATRBlock,
     parse_regime_atr_block,
+    parse_regime_tp_tiers,
+    resolve_regime_tier,
 )
 
 
-_TIERED_TP_NAMES = ("tiered_tp_atr", "tiered_tp_atr_live")
+_TIERED_TP_NAMES = (
+    "tiered_tp_atr",
+    "tiered_tp_atr_live",
+    "tiered_tp_atr_regime",
+    "tiered_tp_atr_live_regime",
+)
 
 
 @dataclass(frozen=True)
@@ -358,6 +366,7 @@ def _strategy_uses_tiered_tp_atr_close(close_refs: Iterable[dict]) -> bool:
 
 def parse_strategy_tp_sl_after_rules(
     close_refs: Iterable[dict],
+    regime: Optional[str] = None,
 ) -> Tuple[TierSLAfterRules, List[str]]:
     """Walk the strategy's close refs and extract the strategy-level default
     and per-tier sl_after rules from the first ``tiered_tp_atr*`` entry.
@@ -365,6 +374,12 @@ def parse_strategy_tp_sl_after_rules(
     Returns ``(rules, errs)``. Errors describe individual malformed fields;
     the parser still returns whatever it could so the caller can surface the
     problems at config-load time without losing the rest of the config.
+
+    When the first tiered ref is ``tiered_tp_atr_regime`` /
+    ``tiered_tp_atr_live_regime``, per-tier ``sl_after`` alignment uses the
+    tier's ATR multiple **resolved for the given regime label** (same order as
+    ``parse_tp_tier_close_fractions``). Pass ``regime=None`` at static load
+    time to skip per-tier extraction (defaults still parse).
     """
     rules = TierSLAfterRules()
     errs: List[str] = []
@@ -372,10 +387,12 @@ def parse_strategy_tp_sl_after_rules(
         return rules, errs
     default_raw: Any = None
     tiers_raw: Any = None
+    tiered_name = ""
     for ref in close_refs:
         name = (ref.get("name") or "").strip().lower()
         if name not in _TIERED_TP_NAMES:
             continue
+        tiered_name = name
         params = ref.get("params") or {}
         if "sl_after" in params:
             default_raw = params["sl_after"]
@@ -389,6 +406,49 @@ def parse_strategy_tp_sl_after_rules(
             rules.default = r
         except ValueError as e:
             errs.append(f"sl_after (strategy-level): {e}")
+    if tiered_name in ("tiered_tp_atr_regime", "tiered_tp_atr_live_regime"):
+        reg = (regime or "").strip()
+        if not reg:
+            return rules, errs
+        ref_params: dict = {}
+        for ref in close_refs:
+            if (ref.get("name") or "").strip().lower() == tiered_name:
+                ref_params = dict(ref.get("params") or {})
+                break
+        use_defaults = bool(ref_params.get("use_defaults"))
+        specs, terr = parse_regime_tp_tiers(
+            tiers_raw, f"{tiered_name}.tiers", use_defaults,
+        )
+        errs.extend(terr)
+        if terr:
+            return rules, errs
+        pairs: List[Tuple[float, SLAfterRule]] = []
+        items_list = tiers_raw if isinstance(tiers_raw, list) else []
+        for idx, spec in enumerate(specs):
+            pair = resolve_regime_tier(spec, reg)
+            if pair is None:
+                errs.append(
+                    f"{tiered_name}.tiers[{idx}]: regime {reg!r} resolved to no "
+                    "atr/close_fraction for sl_after tier alignment"
+                )
+                continue
+            mult, _ = pair
+            item: dict = {}
+            if idx < len(items_list) and isinstance(items_list[idx], dict):
+                item = items_list[idx]
+            rule = SLAfterRule()
+            if item.get("sl_after") is not None:
+                try:
+                    parsed = parse_sl_after_rule(item["sl_after"])
+                    validate_sl_after_rule(parsed)
+                    rule = parsed
+                except ValueError as e:
+                    errs.append(f"sl_after (tier[{idx}]): {e}")
+            pairs.append((mult, rule))
+        pairs.sort(key=lambda p: p[0])
+        rules.per_tier = [p[1] for p in pairs]
+        return rules, errs
+
     if not isinstance(tiers_raw, list):
         return rules, errs
     pairs: List[Tuple[float, SLAfterRule]] = []
@@ -424,6 +484,7 @@ def validate_post_tp_stop_loss_rules(
     stop_loss_margin_pct: Optional[float] = None,
     trailing_stop_atr_mult: Optional[float] = None,
     trailing_stop_pct: Optional[float] = None,
+    stop_loss_atr_regime: Optional[Any] = None,
     strategy_type: str = "perps",
 ) -> List[str]:
     """Mirror ``validatePostTPStopLossRules`` in scheduler/post_tp_sl.go.
@@ -446,8 +507,8 @@ def validate_post_tp_stop_loss_rules(
         params = ref.get("params") or {}
         if "sl_after" in params:
             out.append(
-                f"sl_after is only honored on tiered_tp_atr / "
-                f"tiered_tp_atr_live close refs; found on {ref.get('name')!r}"
+                f"sl_after is only honored on tiered_tp_atr* close refs; "
+                f"found on {ref.get('name')!r}"
             )
         tiers_raw = params.get("tiers")
         if isinstance(tiers_raw, list):
@@ -466,15 +527,27 @@ def validate_post_tp_stop_loss_rules(
             "sl_after cannot be combined with trailing_stop_atr_mult or "
             "trailing_stop_pct — trailing already walks the SL continuously"
         )
+    blk_sl_regime, sl_regime_errs = parse_regime_atr_block(
+        stop_loss_atr_regime, "stop_loss_atr_regime", SURFACE_STOP_LOSS,
+    )
+    if stop_loss_atr_regime is not None and sl_regime_errs:
+        out.extend(sl_regime_errs)
+    has_regime_sl = (
+        stop_loss_atr_regime is not None
+        and not blk_sl_regime.is_zero()
+        and not sl_regime_errs
+    )
     has_fixed_sl = (
         (stop_loss_atr_mult is not None and stop_loss_atr_mult > 0)
         or (stop_loss_pct is not None and stop_loss_pct > 0)
         or (stop_loss_margin_pct is not None and stop_loss_margin_pct > 0)
+        or has_regime_sl
     )
     if not has_fixed_sl:
         out.append(
             "sl_after requires a fixed stop-loss to adjust (set "
-            "stop_loss_atr_mult, stop_loss_pct, or stop_loss_margin_pct)"
+            "stop_loss_atr_mult, stop_loss_atr_regime, stop_loss_pct, "
+            "or stop_loss_margin_pct)"
         )
     if (strategy_type or "").strip().lower() == "manual":
         if rules.default.kind == "trail_from_here":
@@ -493,24 +566,60 @@ def validate_post_tp_stop_loss_rules(
     return out
 
 
-def parse_tp_tier_close_fractions(close_refs: Iterable[dict]) -> List[float]:
+def parse_tp_tier_close_fractions(
+    close_refs: Iterable[dict],
+    regime: Optional[str] = None,
+) -> List[float]:
     """Return cumulative ``close_fraction`` values for the strategy's
     ``tiered_tp_atr*`` close ref (sorted by ascending ``atr_multiple``).
 
-    Used by the backtester (#709) to detect which tier just fired by
+    Used by the backtester (#709, #737) to detect which tier just fired by
     comparing the post-bar ``closed_qty / initial_qty`` ratio against the
     cumulative thresholds. Returns an empty list when no tiered ATR ref is
     configured. Final-tier close_fraction is coerced to 1.0 to match the
     live ``strategyTPTiers`` behavior.
+
+    For ``tiered_tp_atr_regime`` / ``tiered_tp_atr_live_regime``, pass the
+    stamped position regime label so per-regime ATR multiples resolve to the
+    same tier ordering used by the close evaluators. With ``regime=None`` or
+    an empty label, regime-aware refs return ``[]`` (caller re-parses at
+    open with a concrete label).
     """
     for ref in close_refs:
         name = (ref.get("name") or "").strip().lower()
         if name not in _TIERED_TP_NAMES:
             continue
-        tiers_raw = (ref.get("params") or {}).get("tiers")
+        params = ref.get("params") or {}
+        if name in ("tiered_tp_atr_regime", "tiered_tp_atr_live_regime"):
+            reg = (regime or "").strip()
+            if not reg:
+                return []
+            use_defaults = bool(params.get("use_defaults"))
+            tiers_raw = params.get("tiers")
+            specs, terr = parse_regime_tp_tiers(
+                tiers_raw, f"{name}.tiers", use_defaults,
+            )
+            if terr:
+                return []
+            pairs: List[Tuple[float, float]] = []
+            for spec in specs:
+                pair = resolve_regime_tier(spec, reg)
+                if pair is None:
+                    return []
+                mult, frac = pair
+                pairs.append((mult, max(min(frac, 1.0), 0.0)))
+            if not pairs:
+                return []
+            pairs.sort(key=lambda p: p[0])
+            out = [p[1] for p in pairs]
+            if out:
+                out[-1] = 1.0
+            return out
+
+        tiers_raw = params.get("tiers")
         if not isinstance(tiers_raw, list):
             return []
-        pairs: List[Tuple[float, float]] = []
+        pairs = []
         for item in tiers_raw:
             if not isinstance(item, dict):
                 continue


### PR DESCRIPTION
## Summary
Closes #737.

Backtester accepts and resolves `tiered_tp_atr_regime`, `tiered_tp_atr_live_regime`, `stop_loss_atr_regime`, and `trailing_stop_atr_regime` with live-aligned regime timing. See [issue #737](https://github.com/richkuo/go-trader/issues/737).

## Changes
- Snapshot `_regime_bar_close` before entry-gate regime shift; stamp `position["regime"]` at open; pass live regime into close evaluators
- Regime tier thresholds + per-tier `sl_after` re-parsed at open when using regime tiered closes
- Strategy-level regime SL/trailing: parse (`regime_atr.py`), mutex validation, seed `_initial_sl_trigger` from open-time regime
- `post_tp_sl.py`: extend tiered names, `parse_tp_tier_close_fractions(..., regime)`, `parse_strategy_tp_sl_after_rules(..., regime)`, `validate_post_tp_stop_loss_rules(..., stop_loss_atr_regime)`
- `run_backtest.py`: `load_strategy_config` + `--config` thread stop fields and `strategy_type`
- Tests: `test_regime_backtester_737.py`; update `test_post_tp_sl.py` for `_tp_tier_thresholds_static`

## Notes
- `sl_after` with `trend_regime` remains deferred (#736)
- Strategy-level trailing walker for plain/regime trailing is still not modeled in the bar engine (pre-existing gap); regime trailing is parsed and resolved at open

## Agent metadata
- **Model:** Composer
- **Effort level:** High

Made with [Cursor](https://cursor.com)