### PR TITLE
Run Python subprocesses through uv

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@
 - Go 1.26.2 (`brew install go@1.26` on macOS); use full binary path if not on PATH (e.g. `/opt/homebrew/bin/go`).
 - Python runs through `uv run --no-sync python`; deps via `uv` (`pyproject.toml` / `uv.lock`).
 - Git worktrees work without a copied virtualenv; run `uv sync` once per checkout and ensure `uv` is on PATH.
+- Optional: set `GO_TRADER_UV` to an absolute path when `uv` is not discoverable via `PATH` (e.g. custom install); read in `scheduler/python_cmd.go`.
+- **systemd:** `go-trader.service` and `systemd/go-trader@.service` set `PATH` (includes `%h/.local/bin`) and `UV_CACHE_DIR` under `scheduler/` so `uv run` works under `ProtectSystem=strict`. `/opt/go-trader/.env` (or per-instance `.env`) may override `PATH`, `UV_CACHE_DIR`, or set `GO_TRADER_UV`.
+- Optional: set `GO_TRADER_UV` to an absolute path when `uv` is not discoverable via `PATH` (e.g. custom install); read in `scheduler/python_cmd.go`.
+- **systemd:** `go-trader.service` and `systemd/go-trader@.service` set `PATH` (includes `%h/.local/bin`) and `UV_CACHE_DIR` under `scheduler/` so `uv run` works under `ProtectSystem=strict`. `/opt/go-trader/.env` (or per-instance `.env`) may override `PATH`, `UV_CACHE_DIR`, or set `GO_TRADER_UV`.
 
 ## Setup
 - `uv sync` — install Python deps
@@ -127,6 +131,8 @@ Inline review threads are exempt.
 - Restart: `systemctl restart go-trader` (service-file changes: `daemon-reload` first). Config-only: `kill -HUP $(pgrep go-trader)`. Python changes pick up next cycle.
 - **Startup compatibility probe:** binary invokes each unique check script with `--probe-only`; non-zero → log + owner DM + `os.Exit(1)`. Startup failure post-update → ensure `git pull` updated `shared_scripts/` and rebuild.
 - **Post-update protocol:** after `git pull` / auto-update, follow `SKILL.md` → "Post-Update Agent Protocol". Diff `<running>..HEAD`, classify via SKILL.md Reference table, prompt per item. `runConfigMigrationDM` only covers `configFieldRegistry` (≤ v3) — later runtime-default/opt-in items surfaced manually.
+- **Post-deploy smoke (#739):** after a release that changes the Python launcher, run `./go-trader --config scheduler/config.json --once` (or your deploy path) once to confirm startup probe and slow scripts still finish within timeouts.
+- **Post-deploy smoke (#739):** after a release that changes the Python launcher, run `./go-trader --config scheduler/config.json --once` (or your deploy path) once to confirm startup probe and slow scripts still finish within timeouts.
 
 ## Backtest
 - `uv run --no-sync python backtest/run_backtest.py --strategy <n> --symbol BTC/USDT --timeframe 1h --mode single`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,6 @@
 - Git worktrees work without a copied virtualenv; run `uv sync` once per checkout and ensure `uv` is on PATH.
 - Optional: set `GO_TRADER_UV` to an absolute path when `uv` is not discoverable via `PATH` (e.g. custom install); read in `scheduler/python_cmd.go`.
 - **systemd:** `go-trader.service` and `systemd/go-trader@.service` set `PATH` (includes `%h/.local/bin`) and `UV_CACHE_DIR` under `scheduler/` so `uv run` works under `ProtectSystem=strict`. `/opt/go-trader/.env` (or per-instance `.env`) may override `PATH`, `UV_CACHE_DIR`, or set `GO_TRADER_UV`.
-- Optional: set `GO_TRADER_UV` to an absolute path when `uv` is not discoverable via `PATH` (e.g. custom install); read in `scheduler/python_cmd.go`.
-- **systemd:** `go-trader.service` and `systemd/go-trader@.service` set `PATH` (includes `%h/.local/bin`) and `UV_CACHE_DIR` under `scheduler/` so `uv run` works under `ProtectSystem=strict`. `/opt/go-trader/.env` (or per-instance `.env`) may override `PATH`, `UV_CACHE_DIR`, or set `GO_TRADER_UV`.
 
 ## Setup
 - `uv sync` — install Python deps
@@ -131,7 +129,6 @@ Inline review threads are exempt.
 - Restart: `systemctl restart go-trader` (service-file changes: `daemon-reload` first). Config-only: `kill -HUP $(pgrep go-trader)`. Python changes pick up next cycle.
 - **Startup compatibility probe:** binary invokes each unique check script with `--probe-only`; non-zero → log + owner DM + `os.Exit(1)`. Startup failure post-update → ensure `git pull` updated `shared_scripts/` and rebuild.
 - **Post-update protocol:** after `git pull` / auto-update, follow `SKILL.md` → "Post-Update Agent Protocol". Diff `<running>..HEAD`, classify via SKILL.md Reference table, prompt per item. `runConfigMigrationDM` only covers `configFieldRegistry` (≤ v3) — later runtime-default/opt-in items surfaced manually.
-- **Post-deploy smoke (#739):** after a release that changes the Python launcher, run `./go-trader --config scheduler/config.json --once` (or your deploy path) once to confirm startup probe and slow scripts still finish within timeouts.
 - **Post-deploy smoke (#739):** after a release that changes the Python launcher, run `./go-trader --config scheduler/config.json --once` (or your deploy path) once to confirm startup probe and slow scripts still finish within timeouts.
 
 ## Backtest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,8 @@
 
 ## Environment
 - Go 1.26.2 (`brew install go@1.26` on macOS); use full binary path if not on PATH (e.g. `/opt/homebrew/bin/go`).
-- Python venv at `.venv/bin/python3` (executor.go runtime); deps via `uv` (`pyproject.toml` / `uv.lock`).
-- Git worktrees: `.venv` not copied — use `<main-repo>/.venv/bin/python3`.
+- Python runs through `uv run --no-sync python`; deps via `uv` (`pyproject.toml` / `uv.lock`).
+- Git worktrees work without a copied virtualenv; run `uv sync` once per checkout and ensure `uv` is on PATH.
 
 ## Setup
 - `uv sync` — install Python deps
@@ -90,7 +90,7 @@
 - **Strategy registries:** open source of truth `shared_strategies/open/registry.py`; spot/futures shims build via `build_registry()`. Close: `shared_strategies/close/registry.py` with `evaluate(position,market,params)`. New open strategy: (1) `open/registry.py` + `PLATFORM_ORDER`, (2) `knownShortNames` + defaults in `init.go`, (3) `DEFAULT_PARAM_RANGES` in `backtest/optimizer.py`. Use `variants={"futures":{...}}`. Before refactoring registry: snapshot `--list-json` and `diff` after — Go `discoverStrategies` depends on byte-identical output.
 - Strategy DSL gotchas: `apply_strategy(name,df,params)` merges config params UNDER runtime (runtime wins); `check_strategy.py` uses manual `sys.argv`, others argparse; `HTFFilter` not applied to options or `delta_neutral_funding`; `delta_neutral_funding` perps-only; perps vs futures `Position` both have `Multiplier>0`, only perps have `Leverage>0`.
 - Per-strategy DD: spot/options/futures peak-relative; perps `unrealized_loss/deployed_margin` when open. Margin uses exchange `Leverage`, not `SizingLeverage`. `RecordTradeResult` only updates `DailyPnL`/`ConsecutiveLosses`; lifetime counts come from SQLite.
-- **Test pattern:** extract pure helpers from subprocess wrappers — Go CI lacks `.venv/bin/python3`, so tests calling `RunPythonScript`/`RunHyperliquid{Execute,Close}` fail CI.
+- **Test pattern:** extract pure helpers from subprocess wrappers — Go CI should not depend on spawning Python for live helper tests.
 - Per-strategy CB pending close: `RiskState.PendingCircuitCloses map[string]*PendingCircuitClose` keyed by `PlatformPendingClose{Hyperliquid,OKX,Robinhood,TopStep,OKXSpot,RobinhoodOptions}`. Use `set/clear/getPendingCircuitClose`. RH enqueue runs only from drain's stuck-CB recovery. **HL CB drain:** when `hlLiveStrategiesForCoin(sym)` reports >1 live strategy on same coin/wallet, drain clears pending without on-chain close.
 - **Operator-required CBs** (`OKXSpot`, `RobinhoodOptions`): `OperatorRequired=true`; `drainOperatorRequiredPendingCloses` emits one CRITICAL log + notifier per cycle until CB resets.
 - **Kill switch:** `planKillSwitchClose(KillSwitchCloseInputs)` returns pure `KillSwitchClosePlan` with `OnChainConfirmedFlat`. New platform = add fields + close/fetcher pair, not signature change. OKX-spot / RH-options warn but don't block confirmed-flat. Per-platform timeouts. Auto-reset on confirmed-flat clears virtual state, resumes next cycle.
@@ -129,9 +129,9 @@ Inline review threads are exempt.
 - **Post-update protocol:** after `git pull` / auto-update, follow `SKILL.md` → "Post-Update Agent Protocol". Diff `<running>..HEAD`, classify via SKILL.md Reference table, prompt per item. `runConfigMigrationDM` only covers `configFieldRegistry` (≤ v3) — later runtime-default/opt-in items surfaced manually.
 
 ## Backtest
-- `.venv/bin/python3 backtest/run_backtest.py --strategy <n> --symbol BTC/USDT --timeframe 1h --mode single`
-- `.venv/bin/python3 backtest/backtest_options.py --underlying BTC --since YYYY-MM-DD --capital 10000`
-- `.venv/bin/python3 backtest/backtest_theta.py --underlying BTC --since YYYY-MM-DD --capital 10000`
+- `uv run --no-sync python backtest/run_backtest.py --strategy <n> --symbol BTC/USDT --timeframe 1h --mode single`
+- `uv run --no-sync python backtest/backtest_options.py --underlying BTC --since YYYY-MM-DD --capital 10000`
+- `uv run --no-sync python backtest/backtest_theta.py --underlying BTC --since YYYY-MM-DD --capital 10000`
 - Close registry: `Backtester(open_strategy={"name":..., "params":{...}}, close_strategies=[{...}])` — co-located refs mirror live `StrategyConfig`; `--close-strategy` repeatable, accepts bare names or JSON refs. `--config <path> --strategy <id>` loads a v13+ live strategy verbatim (single mode only). Per-bar eval; max `close_fraction` at next bar's open, max-wins vs column-based. Entry context (`avg_cost`/`initial_quantity`/`entry_atr`) stamped at open with the 50%-of-AvgCost ATR guard. Bar-level granularity — intra-bar trigger races not simulated.
 - Regime: `Backtester(regime_enabled=True, regime_period=14, regime_adx_threshold=20, allowed_regimes=[...])` or matching `--regime-*` flags. Vectorized `ensure_regime_columns()` runs once before per-bar loop; entries blocked when `bar_regime ∉ allowed_regimes`; closes always execute. Options backtests don't support regime yet.
 - `sl_after` parity (#709): see Key Patterns "Post-TP SL adjustment" bullet for backtester args + behavior + same-bar suppression flag.
@@ -140,13 +140,13 @@ Inline review threads are exempt.
 
 ## Testing
 - **New functionality must include tests.** Go: `_test.go`. Python: `test_*.py`. Bug fixes: regression test when feasible.
-- `python3 -m py_compile <file>` from repo root.
+- `uv run --no-sync python -m py_compile <file>` from repo root.
 - `go build -ldflags "-X main.Version=$(git describe --tags --always --dirty=-mod)" .` / `go test ./...` (from repo root, not `cd scheduler`).
 - `gofmt -w <file>.go` post-edit.
 - Multi-line Go edits with tabs may fail Edit tool; use Python heredoc with `read()`+`replace(old,new,1)`+`write()`.
-- Strategy listing: `shared_strategies/open/{spot,futures}/strategies.py --list-json` (absolute venv path in worktrees).
+- Strategy listing: `uv run --no-sync python shared_strategies/open/{spot,futures}/strategies.py --list-json`.
 - Smoke: `./go-trader --once`; interactive init `printf "...\n" | ./go-trader init`; JSON init `./go-trader init --json '{...}' --output /tmp/test.json`; alt port `--status-port 9100`.
-- Pytest: `.venv/bin/python3 -m pytest shared_strategies/ shared_tools/ platforms/ backtest/`. `uv run pytest` may fail on CWD drift. `shared_scripts/test_*.py` is NOT in `testpaths` — invoke explicitly.
+- Pytest: `uv run --no-sync python -m pytest shared_strategies/ shared_tools/ platforms/ backtest/`. `shared_scripts/test_*.py` is NOT in `testpaths` — invoke explicitly.
 - When tests touch sys.path/registries, run the FULL suite — isolated runs mask import-order conflicts (open vs close `registry.py`).
 - `stampEntryATRIfOpened` rejects ATR > 50% of AvgCost; Go tests using `atr` indicators must use values < 50% of entry price.
 - Strategy tests must assert actual signal values (`assert (result["signal"] == 1).any()`), not just column existence. Smoke tests iterating registered strategies need `DatetimeIndex` (`amd_ifvg` reads `index.hour`, `vwap_reversion` buckets by `index.date`).

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ cd scheduler && go build -ldflags "-X main.Version=$VER" -o ../go-trader . && cd
 ./go-trader init                                    # or --json '{...}', or copy config.example.json
 ./go-trader --config scheduler/config.json --once   # smoke-test one cycle
 
+On Linux systemd installs, `go-trader.service` sets `PATH` and `UV_CACHE_DIR`; use `/opt/go-trader/.env` to set `GO_TRADER_UV` if `uv` is outside the default PATH (#739).
+
 export DISCORD_BOT_TOKEN="your-token"
 sudo bash scripts/install-service.sh                # systemd install + enable + start
 curl -s localhost:8099/status | python3 -m json.tool

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,7 +12,7 @@ Quick flow for a new server: tell OpenClaw `install https://github.com/richkuo/g
 
 - Run git from repo root.
 - Use `/opt/homebrew/bin/go` (macOS) or `/usr/local/go/bin/go` (Linux) if `go` is not on PATH.
-- Use `.venv/bin/python3`; in worktrees, use the main repo's `.venv`.
+- Use `uv run --no-sync python`; worktrees do not need a copied virtualenv.
 - Install Python deps with `uv sync`.
 - Scheduler config: `scheduler/config.json` (start from `scheduler/config.example.json` when generating manually).
 - State is SQLite only: default `scheduler/state.db`.
@@ -428,9 +428,9 @@ When the user says `/menu`, "show menu", "what can I configure", "what's availab
    curl -s localhost:8099/status | python3 -m json.tool
 
 5. BACKTESTING
-   .venv/bin/python3 backtest/run_backtest.py --strategy <n> --symbol BTC/USDT --timeframe 1h --mode single|compare|multi|optimize
-   .venv/bin/python3 backtest/backtest_options.py --underlying BTC --since 90 --capital 10000
-   .venv/bin/python3 backtest/backtest_theta.py --underlying BTC --since 90 --capital 10000
+   uv run --no-sync python backtest/run_backtest.py --strategy <n> --symbol BTC/USDT --timeframe 1h --mode single|compare|multi|optimize
+   uv run --no-sync python backtest/backtest_options.py --underlying BTC --since 90 --capital 10000
+   uv run --no-sync python backtest/backtest_theta.py --underlying BTC --since 90 --capital 10000
 ```
 
 ---
@@ -511,33 +511,33 @@ Notes:
 
 ## Backtesting
 
-Use `.venv/bin/python3` for all backtests.
+Use `uv run --no-sync python` for all backtests.
 
 ```bash
-.venv/bin/python3 backtest/run_backtest.py --strategy momentum --symbol BTC/USDT --timeframe 1h --mode single
-.venv/bin/python3 backtest/run_backtest.py --strategy momentum --symbol BTC/USDT --timeframe 1h --mode compare
-.venv/bin/python3 backtest/run_backtest.py --strategy momentum --timeframe 1h --mode multi
-.venv/bin/python3 backtest/run_backtest.py --strategy momentum --symbol BTC/USDT --timeframe 1h --mode optimize
-.venv/bin/python3 backtest/run_backtest.py --strategy momentum --symbol BTC/USDT --timeframe 1h --since 90
+uv run --no-sync python backtest/run_backtest.py --strategy momentum --symbol BTC/USDT --timeframe 1h --mode single
+uv run --no-sync python backtest/run_backtest.py --strategy momentum --symbol BTC/USDT --timeframe 1h --mode compare
+uv run --no-sync python backtest/run_backtest.py --strategy momentum --timeframe 1h --mode multi
+uv run --no-sync python backtest/run_backtest.py --strategy momentum --symbol BTC/USDT --timeframe 1h --mode optimize
+uv run --no-sync python backtest/run_backtest.py --strategy momentum --symbol BTC/USDT --timeframe 1h --since 90
 
 # Close-strategy registry (#535/#641) — repeatable; max close_fraction wins.
 # --close-strategy accepts both bare names and JSON refs ({"name","params"}).
 # --close-params is removed — fold params into the JSON ref.
-.venv/bin/python3 backtest/run_backtest.py --strategy momentum --symbol BTC/USDT --timeframe 1h \
+uv run --no-sync python backtest/run_backtest.py --strategy momentum --symbol BTC/USDT --timeframe 1h \
   --close-strategy tp_at_pct \
   --close-strategy '{"name":"tiered_tp_atr","params":{"tiers":[{"atr_multiple":1,"close_fraction":0.5},{"atr_multiple":2,"close_fraction":1.0}]}}'
 
 # Backtest a live strategy verbatim (single mode only) — pulls the strategy's
 # open + close refs from the live config (#643). Pre-v13 configs are rejected.
-.venv/bin/python3 backtest/run_backtest.py --config scheduler/config.json --strategy hl-btc-momentum \
+uv run --no-sync python backtest/run_backtest.py --config scheduler/config.json --strategy hl-btc-momentum \
   --symbol BTC/USDT --timeframe 1h --mode single
 
 # Regime gate (#549) — blocks entries outside allowed regimes; closes always execute
-.venv/bin/python3 backtest/run_backtest.py --strategy momentum --symbol BTC/USDT --timeframe 1h \
+uv run --no-sync python backtest/run_backtest.py --strategy momentum --symbol BTC/USDT --timeframe 1h \
   --regime-enabled --regime-period 14 --regime-adx-threshold 20 --allowed-regimes trending_up trending_down
 
-.venv/bin/python3 backtest/backtest_options.py --underlying BTC --since 90 --capital 10000
-.venv/bin/python3 backtest/backtest_theta.py --underlying BTC --since 90 --capital 10000
+uv run --no-sync python backtest/backtest_options.py --underlying BTC --since 90 --capital 10000
+uv run --no-sync python backtest/backtest_theta.py --underlying BTC --since 90 --capital 10000
 ```
 
 ---
@@ -644,9 +644,9 @@ Regime detection (global opt-in):
 Source of truth:
 
 ```bash
-.venv/bin/python3 shared_strategies/open/spot/strategies.py --list-json
-.venv/bin/python3 shared_strategies/open/futures/strategies.py --list-json
-.venv/bin/python3 shared_strategies/options/strategies.py --list-json
+uv run --no-sync python shared_strategies/open/spot/strategies.py --list-json
+uv run --no-sync python shared_strategies/open/futures/strategies.py --list-json
+uv run --no-sync python shared_strategies/options/strategies.py --list-json
 ```
 
 Platform conventions:
@@ -711,8 +711,8 @@ Do not edit `shared_strategies/open/{spot,futures}/strategies.py` to add strateg
 Before refactoring registry/shims:
 
 ```bash
-.venv/bin/python3 shared_strategies/open/spot/strategies.py --list-json > /tmp/spot.json
-.venv/bin/python3 shared_strategies/open/futures/strategies.py --list-json > /tmp/futures.json
+uv run --no-sync python shared_strategies/open/spot/strategies.py --list-json > /tmp/spot.json
+uv run --no-sync python shared_strategies/open/futures/strategies.py --list-json > /tmp/futures.json
 ```
 
 Diff afterwards unless intentionally changing discovery.
@@ -739,8 +739,8 @@ Implementation:
 Adapter references: spot — `binanceus`; perps — `hyperliquid`; futures — `topstep`; options — `deribit`.
 
 ```bash
-.venv/bin/python3 -m py_compile platforms/<name>/adapter.py
-.venv/bin/python3 -m py_compile shared_scripts/check_<name>.py
+uv run --no-sync python -m py_compile platforms/<name>/adapter.py
+uv run --no-sync python -m py_compile shared_scripts/check_<name>.py
 /opt/homebrew/bin/go -C scheduler build .
 ./go-trader --config scheduler/config.json --once
 ```
@@ -761,7 +761,7 @@ Triggered → scheduler enqueues `operator_required: true` and emits a CRITICAL 
 Detect:
 
 ```bash
-curl -s localhost:8099/status | .venv/bin/python3 -c "
+curl -s localhost:8099/status | uv run --no-sync python -c "
 import json, sys
 d = json.load(sys.stdin)
 for sid, s in d['strategies'].items():
@@ -817,8 +817,8 @@ grep -n "liveExecFailed" scheduler/main.go
 
 ```bash
 /opt/homebrew/bin/go -C scheduler test ./...
-.venv/bin/python3 -m pytest
-.venv/bin/python3 shared_strategies/open/test_registry_parity.py
+uv run --no-sync python -m pytest
+uv run --no-sync python shared_strategies/open/test_registry_parity.py
 ```
 
 If Go cache needs an explicit writable path:
@@ -827,4 +827,4 @@ If Go cache needs an explicit writable path:
 env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...
 ```
 
-Go CI does not install `.venv`, so tests for subprocess-based live helpers should extract pure parsers/decision helpers rather than invoking Python.
+Go CI should not depend on a Python runtime, so tests for subprocess-based live helpers should extract pure parsers/decision helpers rather than invoking Python.

--- a/SKILL.md
+++ b/SKILL.md
@@ -13,6 +13,7 @@ Quick flow for a new server: tell OpenClaw `install https://github.com/richkuo/g
 - Run git from repo root.
 - Use `/opt/homebrew/bin/go` (macOS) or `/usr/local/go/bin/go` (Linux) if `go` is not on PATH.
 - Use `uv run --no-sync python`; worktrees do not need a copied virtualenv.
+- **Production:** bundled systemd units set `PATH` and `UV_CACHE_DIR` for `uv run` under `ProtectSystem=strict`. Override in deployment `.env` or set `GO_TRADER_UV` to an absolute `uv` path if needed (#739).
 - Install Python deps with `uv sync`.
 - Scheduler config: `scheduler/config.json` (start from `scheduler/config.example.json` when generating manually).
 - State is SQLite only: default `scheduler/state.db`.

--- a/go-trader.service
+++ b/go-trader.service
@@ -15,6 +15,13 @@ RestartSec=10
 StandardOutput=journal
 StandardError=journal
 
+# Python (uv): default systemd PATH often omits ~/.local/bin (common uv install
+# location). UV_CACHE_DIR must live under ReadWritePaths (#739 / ProtectSystem).
+# Defaults here; EnvironmentFile= below allows /opt/go-trader/.env to override
+# PATH, UV_CACHE_DIR, or set GO_TRADER_UV to an absolute uv binary path.
+Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:%h/.local/bin"
+Environment=UV_CACHE_DIR=/opt/go-trader/scheduler/.uv-cache
+
 # Prefer loading the Discord token from an env file rather than embedding
 # it in the unit file or config.json:
 #   echo "DISCORD_BOT_TOKEN=Bot your-token-here" > /opt/go-trader/.env

--- a/scheduler/backfill_hl_fees.go
+++ b/scheduler/backfill_hl_fees.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"math"
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -678,44 +677,36 @@ func refuseIfSchedulerRunning() error {
 	return fmt.Errorf("another go-trader process is running (pid %v); stop it before running --apply (concurrent SaveState would overwrite the recomputed strategies.cash)", others)
 }
 
-// runFetchHLUserFills spawns shared_scripts/fetch_hl_user_fills.py with a
-// generous timeout (paging through years of history can exceed the standard
-// 30s scriptTimeout used by the per-cycle check scripts).
+// hlUserFillsFetchTimeout bounds fetch_hl_user_fills.py — paging through years
+// of history can exceed the standard scriptTimeout used by per-cycle scripts.
+const hlUserFillsFetchTimeout = 5 * time.Minute
+
+// runFetchHLUserFills spawns shared_scripts/fetch_hl_user_fills.py with
+// hlUserFillsFetchTimeout via the shared Python runner (semaphore + uv argv).
 func runFetchHLUserFills(since time.Time) (*HLUserFillsResult, error) {
 	script := "shared_scripts/fetch_hl_user_fills.py"
 	args := []string{
 		fmt.Sprintf("--since-ms=%d", since.UnixMilli()),
 	}
 
-	pythonSemaphore <- struct{}{}
-	defer func() { <-pythonSemaphore }()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	cmd, err := newPythonCommand(ctx, script, args...)
-	if err != nil {
-		return nil, err
-	}
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	runErr := cmd.Run()
-	if ctx.Err() == context.DeadlineExceeded {
-		if cmd.Process != nil {
-			syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	stdout, stderr, runErr := runPythonWithTimeout(context.Background(), script, args, nil, hlUserFillsFetchTimeout)
+	if runErr != nil {
+		var toe *pythonScriptTimeoutError
+		if errors.As(runErr, &toe) {
+			return nil, runErr
 		}
-		return nil, fmt.Errorf("script timed out after 5m")
+		if stdout == nil {
+			return nil, runErr
+		}
 	}
-	stderrStr := strings.TrimSpace(stderr.String())
+
+	stderrStr := strings.TrimSpace(string(stderr))
 	if stderrStr != "" {
 		fmt.Fprintln(os.Stderr, stderrStr)
 	}
 	var result HLUserFillsResult
-	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
-		return nil, fmt.Errorf("parse output: %w (stdout: %s)", err, stdout.String())
+	if err := json.Unmarshal(stdout, &result); err != nil {
+		return nil, fmt.Errorf("parse output: %w (stdout: %s)", err, string(stdout))
 	}
 	if runErr != nil && result.Error == "" {
 		return &result, fmt.Errorf("script error: %w", runErr)

--- a/scheduler/backfill_hl_fees.go
+++ b/scheduler/backfill_hl_fees.go
@@ -693,7 +693,10 @@ func runFetchHLUserFills(since time.Time) (*HLUserFillsResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, ".venv/bin/python3", append([]string{script}, args...)...)
+	cmd, err := newPythonCommand(ctx, script, args...)
+	if err != nil {
+		return nil, err
+	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	var stdout, stderr bytes.Buffer

--- a/scheduler/config_migration_test.go
+++ b/scheduler/config_migration_test.go
@@ -867,30 +867,12 @@ func TestMigrateV13StrategyShape(t *testing.T) {
 // adding a new close evaluator in shared_strategies/close/registry.py without
 // also updating the Go-side migration map cannot silently route legacy params
 // to the open ref. The test shells out to a small Python script that prints
-// the registry's default_params per strategy as JSON; CI runs this via the
-// repo's .venv. Skipped if no Python interpreter is available.
+// the registry's default_params per strategy as JSON. It prefers the locked
+// uv environment, with plain python3 as a fallback for local test runs.
 func TestCloseStrategyOwnedKeysMirrorsPythonRegistry(t *testing.T) {
 	repoRoot, err := filepath.Abs("..")
 	if err != nil {
 		t.Fatal(err)
-	}
-	// Resolve the venv interpreter against repoRoot so cmd.Dir doesn't
-	// re-root the relative path. PATH lookup is the fallback.
-	candidates := []string{
-		filepath.Join(repoRoot, ".venv", "bin", "python3"),
-	}
-	if pathPython, err := exec.LookPath("python3"); err == nil {
-		candidates = append(candidates, pathPython)
-	}
-	var py string
-	for _, p := range candidates {
-		if _, err := os.Stat(p); err == nil {
-			py = p
-			break
-		}
-	}
-	if py == "" {
-		t.Skip("no python3 available; skipping registry sync check")
 	}
 	script := `
 import sys, json, os
@@ -903,16 +885,40 @@ spec.loader.exec_module(mod)
 out = {name: list(entry["default_params"].keys()) for name, entry in mod.STRATEGIES.items()}
 print(json.dumps(out))
 `
-	cmd := exec.Command(py, "-c", script)
-	cmd.Dir = repoRoot
-	// CombinedOutput so a Python crash (real bug — e.g. broken close registry
-	// import) surfaces in the failure message instead of being swallowed.
-	// We've already verified an interpreter exists; from here on, any
-	// execution failure is a real defect, not "Python missing" (#642 re-review).
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("python close registry script failed (%v):\n%s", err, output)
+	run := func(name string, args ...string) ([]byte, error) {
+		cmd := exec.Command(name, args...)
+		cmd.Dir = repoRoot
+		return cmd.CombinedOutput()
 	}
+
+	var output []byte
+	var uvOutput []byte
+	var uvErr error
+	ran := false
+	if uvPath, err := exec.LookPath("uv"); err == nil {
+		output, uvErr = run(uvPath, "run", "--no-sync", "python", "-c", script)
+		if uvErr == nil {
+			ran = true
+		} else {
+			uvOutput = output
+		}
+	}
+	if !ran {
+		if pyPath, err := exec.LookPath("python3"); err == nil {
+			output, err = run(pyPath, "-c", script)
+			if err != nil {
+				if uvErr != nil {
+					t.Fatalf("uv close registry script failed (%v):\n%s\npython3 fallback failed (%v):\n%s", uvErr, uvOutput, err, output)
+				}
+				t.Fatalf("python close registry script failed (%v):\n%s", err, output)
+			}
+		} else if uvErr != nil {
+			t.Fatalf("uv close registry script failed (%v):\n%s\nno python3 fallback available", uvErr, uvOutput)
+		} else {
+			t.Skip("no python3 available; skipping registry sync check")
+		}
+	}
+
 	// CombinedOutput merges stdout+stderr. The script writes only the JSON
 	// blob to stdout, but a Python warning to stderr would prepend non-JSON.
 	// Locate the JSON object by trimming to the first '{'.

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"syscall"
 	"time"
@@ -132,8 +131,10 @@ func runPython(parentCtx context.Context, script string, args []string, stdinDat
 	ctx, cancel := context.WithTimeout(parentCtx, scriptTimeout)
 	defer cancel()
 
-	cmdArgs := append([]string{script}, args...)
-	cmd := exec.CommandContext(ctx, ".venv/bin/python3", cmdArgs...)
+	cmd, err := newPythonCommand(ctx, script, args...)
+	if err != nil {
+		return nil, nil, err
+	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if stdinData != nil {
 		cmd.Stdin = bytes.NewReader(stdinData)
@@ -143,7 +144,7 @@ func runPython(parentCtx context.Context, script string, args []string, stdinDat
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if ctx.Err() == context.DeadlineExceeded {
 		if cmd.Process != nil {
 			syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
@@ -416,7 +417,7 @@ func parseHyperliquidUpdateStopLossOutput(stdout []byte, stderrStr string, runEr
 
 // parseHyperliquidExecuteOutput turns subprocess output into
 // (*HyperliquidExecuteResult, stderr, error). Extracted from RunHyperliquidExecute
-// so Go CI (no .venv) can test the parsing contract without spawning Python
+// so Go CI can test the parsing contract without spawning Python
 // — same pattern as parseHyperliquidCloseOutput (#341).
 func parseHyperliquidExecuteOutput(stdout []byte, stderrStr string, runErr error) (*HyperliquidExecuteResult, string, error) {
 	if runErr != nil {
@@ -505,7 +506,7 @@ func RunHyperliquidClose(script, symbol string, partialSz *float64, cancelStopLo
 // parseHyperliquidCloseOutput turns the raw subprocess result into
 // (*HyperliquidCloseResult, stderr, error) following the RunHyperliquidClose
 // contract. Extracted from RunHyperliquidClose so the decision logic can be
-// tested without spawning .venv/bin/python3 (absent in the Go CI job).
+// tested without spawning Python.
 func parseHyperliquidCloseOutput(stdout []byte, stderrStr string, runErr error) (*HyperliquidCloseResult, string, error) {
 	var result HyperliquidCloseResult
 	parseErr := json.Unmarshal(stdout, &result)
@@ -674,7 +675,7 @@ func RunTopStepClose(script, symbol string) (*TopStepCloseResult, string, error)
 // parseTopStepCloseOutput turns raw subprocess output into
 // (*TopStepCloseResult, stderr, error) following the RunTopStepClose
 // contract. Extracted so decision logic can be tested without spawning
-// .venv/bin/python3 — same pattern as parseHyperliquidCloseOutput /
+// Python — same pattern as parseHyperliquidCloseOutput /
 // parseOKXCloseOutput / parseRobinhoodCloseOutput (#341/#342/#345/#346).
 func parseTopStepCloseOutput(stdout []byte, stderrStr string, runErr error) (*TopStepCloseResult, string, error) {
 	var result TopStepCloseResult
@@ -986,8 +987,7 @@ func RunOKXClose(script, symbol string, partialSz *float64) (*OKXCloseResult, st
 // parseOKXCloseOutput turns raw subprocess output into
 // (*OKXCloseResult, stderr, error) following the RunOKXClose contract.
 // Extracted so the decision logic can be tested without spawning
-// .venv/bin/python3 (absent in the Go CI job — same reason as
-// parseHyperliquidCloseOutput, #341/#342).
+// Python (same reason as parseHyperliquidCloseOutput, #341/#342).
 func parseOKXCloseOutput(stdout []byte, stderrStr string, runErr error) (*OKXCloseResult, string, error) {
 	var result OKXCloseResult
 	parseErr := json.Unmarshal(stdout, &result)
@@ -1094,9 +1094,9 @@ func RunOKXFetchBalance(script string) (*OKXBalanceResult, string, error) {
 }
 
 // parseOKXBalanceOutput is the pure parser for RunOKXFetchBalance. Extracted
-// so the decision logic can be tested without spawning .venv/bin/python3
-// (absent in the Go CI job). Mirrors parseOKXPositionsOutput's 5-case
-// matrix — contract drift across fetch parsers would be bad.
+// so the decision logic can be tested without spawning Python. Mirrors
+// parseOKXPositionsOutput's 5-case matrix — contract drift across fetch
+// parsers would be bad.
 func parseOKXBalanceOutput(stdout []byte, stderrStr string, runErr error) (*OKXBalanceResult, string, error) {
 	var result OKXBalanceResult
 	parseErr := json.Unmarshal(stdout, &result)
@@ -1165,7 +1165,7 @@ func RunRobinhoodClose(script, symbol string) (*RobinhoodCloseResult, string, er
 // parseRobinhoodCloseOutput turns raw subprocess output into
 // (*RobinhoodCloseResult, stderr, error) following the RunRobinhoodClose
 // contract. Extracted so decision logic can be tested without spawning
-// .venv/bin/python3 — same pattern as parseHyperliquidCloseOutput /
+// Python — same pattern as parseHyperliquidCloseOutput /
 // parseOKXCloseOutput (#341/#342/#345).
 func parseRobinhoodCloseOutput(stdout []byte, stderrStr string, runErr error) (*RobinhoodCloseResult, string, error) {
 	var result RobinhoodCloseResult

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -10,6 +10,16 @@ import (
 	"time"
 )
 
+// pythonScriptTimeoutError is returned when a Python subprocess hits its
+// deadline (runPython / runPythonWithTimeout). Callers can use errors.As.
+type pythonScriptTimeoutError struct {
+	d time.Duration
+}
+
+func (e *pythonScriptTimeoutError) Error() string {
+	return fmt.Sprintf("script timed out after %s", e.d)
+}
+
 // pythonSemaphore limits concurrent Python subprocess executions.
 var pythonSemaphore = make(chan struct{}, 4)
 
@@ -125,10 +135,17 @@ type HyperliquidProtectionSyncResult struct {
 // daemon entry point hasn't called initShutdownContexts (one-off CLI commands
 // and tests).
 func runPython(parentCtx context.Context, script string, args []string, stdinData []byte) ([]byte, []byte, error) {
+	return runPythonWithTimeout(parentCtx, script, args, stdinData, scriptTimeout)
+}
+
+// runPythonWithTimeout mirrors runPython but uses an explicit deadline (e.g.
+// long-running fetch scripts). Semaphore, Setpgid, stdin, and SIGKILL-on-
+// deadline behavior match runPython.
+func runPythonWithTimeout(parentCtx context.Context, script string, args []string, stdinData []byte, timeout time.Duration) ([]byte, []byte, error) {
 	pythonSemaphore <- struct{}{}
 	defer func() { <-pythonSemaphore }()
 
-	ctx, cancel := context.WithTimeout(parentCtx, scriptTimeout)
+	ctx, cancel := context.WithTimeout(parentCtx, timeout)
 	defer cancel()
 
 	cmd, err := newPythonCommand(ctx, script, args...)
@@ -149,7 +166,7 @@ func runPython(parentCtx context.Context, script string, args []string, stdinDat
 		if cmd.Process != nil {
 			syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 		}
-		return stdout.Bytes(), stderr.Bytes(), fmt.Errorf("script timed out after %s", scriptTimeout)
+		return stdout.Bytes(), stderr.Bytes(), &pythonScriptTimeoutError{d: timeout}
 	}
 	return stdout.Bytes(), stderr.Bytes(), err
 }

--- a/scheduler/executor_test.go
+++ b/scheduler/executor_test.go
@@ -347,7 +347,7 @@ func TestContractSpecJSON(t *testing.T) {
 
 // These tests exercise parseHyperliquidCloseOutput directly (the pure decision
 // helper extracted from RunHyperliquidClose) so they don't depend on
-// .venv/bin/python3, which isn't installed in the Go CI job.
+// spawning Python in the Go CI job.
 
 // Case 1: clean success — exit 0, valid JSON, no error field.
 func TestParseHyperliquidCloseOutput_CleanSuccess(t *testing.T) {
@@ -587,7 +587,7 @@ func TestParseOKXPositionsOutput_MalformedJSON(t *testing.T) {
 
 // ── buildHyperliquidExecuteArgs (#592) ─────────────────────────────────────
 // These tests assert the argv contract between Go and check_hyperliquid.py
-// without invoking the subprocess (no .venv required).
+// without invoking the subprocess.
 
 func argsContains(args []string, want string) bool {
 	for _, a := range args {

--- a/scheduler/executor_test.go
+++ b/scheduler/executor_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 // These tests verify JSON deserialization of executor result structs, not subprocess
@@ -700,4 +702,18 @@ func TestBuildHyperliquidExecuteArgs_OptionalFlags(t *testing.T) {
 			t.Errorf("--leverage must be omitted when leverage=0, got %v", args)
 		}
 	})
+}
+
+func TestPythonScriptTimeoutError_As(t *testing.T) {
+	var err error = &pythonScriptTimeoutError{d: 5 * time.Minute}
+	var toe *pythonScriptTimeoutError
+	if !errors.As(err, &toe) {
+		t.Fatal("errors.As failed")
+	}
+	if toe.d != 5*time.Minute {
+		t.Errorf("duration = %v, want 5m", toe.d)
+	}
+	if !strings.HasPrefix(toe.Error(), "script timed out after ") {
+		t.Errorf("Error() = %q", toe.Error())
+	}
 }

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -20,7 +20,7 @@ func silentStrategyLogger(id string) *StrategyLogger {
 }
 
 // Tests for the stop-loss plumbing added in #412. We exercise the pure
-// output parser (which Go CI can run without .venv/bin/python3) plus
+// output parser (which Go CI can run without spawning Python) plus
 // StrategyConfig/Position serialization round-trips so struct-tag
 // regressions on the new fields surface here.
 

--- a/scheduler/probe_cmd_test.go
+++ b/scheduler/probe_cmd_test.go
@@ -41,7 +41,7 @@ func TestRunProbeNoStrategies(t *testing.T) {
 // TestRunProbeHappyPath: a config with two strategies sharing one script and
 // one with a distinct script produces exactly two probe invocations (one per
 // unique script) and runProbe returns 0. Stubs probeOneCheckScriptFn because
-// Go CI doesn't have .venv/bin/python3 (see CLAUDE.md → Testing).
+// Go CI should not depend on a real Python runtime for this command-level test.
 func TestRunProbeHappyPath(t *testing.T) {
 	orig := probeOneCheckScriptFn
 	defer func() { probeOneCheckScriptFn = orig }()

--- a/scheduler/python_cmd.go
+++ b/scheduler/python_cmd.go
@@ -7,6 +7,9 @@ import (
 	"os/exec"
 )
 
+// uvBinaryEnv names an optional absolute path to the uv executable. Use when
+// uv is not on systemd's default PATH (e.g. install under a custom prefix); set
+// in /opt/go-trader/.env or a systemd drop-in.
 const uvBinaryEnv = "GO_TRADER_UV"
 
 // newPythonCommand builds the canonical Python subprocess invocation.

--- a/scheduler/python_cmd.go
+++ b/scheduler/python_cmd.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+const uvBinaryEnv = "GO_TRADER_UV"
+
+// newPythonCommand builds the canonical Python subprocess invocation.
+// Runtime and startup probes must share this argv shape so the probe validates
+// the same contract the scheduler uses during normal operation.
+func newPythonCommand(ctx context.Context, script string, args ...string) (*exec.Cmd, error) {
+	uvPath := os.Getenv(uvBinaryEnv)
+	if uvPath == "" {
+		var err error
+		uvPath, err = exec.LookPath("uv")
+		if err != nil {
+			return nil, fmt.Errorf("uv not found on PATH: %w", err)
+		}
+	}
+
+	cmdArgs := append([]string{"run", "--no-sync", "python", script}, args...)
+	return exec.CommandContext(ctx, uvPath, cmdArgs...), nil
+}

--- a/scheduler/version_probe.go
+++ b/scheduler/version_probe.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -57,9 +56,9 @@ const probeTimeout = 15 * time.Second
 // signal value is highest for argparse-strict scripts (HL/TopStep/RH/OKX),
 // where unknown flags cause the same exit-2 the May 7 outage exhibited.
 // probeOneCheckScriptFn is the per-script probe invoker — package var so
-// tests can stub it without standing up a real .venv (Go CI doesn't have
-// one — see CLAUDE.md → Testing). The argv parameter lets a single script
-// be probed against multiple argv shapes (e.g. signal-check + --fetch-atr).
+// tests can stub it without standing up a real Python environment. The argv
+// parameter lets a single script be probed against multiple argv shapes
+// (e.g. signal-check + --fetch-atr).
 var probeOneCheckScriptFn = probeOneCheckScript
 
 func probeCheckScripts(cfg *Config) error {
@@ -105,15 +104,17 @@ func probeOneCheckScript(script string, argv []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
 	defer cancel()
 
-	cmdArgs := append([]string{script}, argv...)
-	cmd := exec.CommandContext(ctx, ".venv/bin/python3", cmdArgs...)
+	cmd, err := newPythonCommand(ctx, script, argv...)
+	if err != nil {
+		return fmt.Errorf("%s: %w", script, err)
+	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if ctx.Err() == context.DeadlineExceeded {
 		if cmd.Process != nil {
 			syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)

--- a/scheduler/version_probe.go
+++ b/scheduler/version_probe.go
@@ -106,7 +106,7 @@ func probeOneCheckScript(script string, argv []string) error {
 
 	cmd, err := newPythonCommand(ctx, script, argv...)
 	if err != nil {
-		return fmt.Errorf("%s: %w", script, err)
+		return fmt.Errorf("uv runtime unavailable (script %s): %w", script, err)
 	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 

--- a/scheduler/version_probe_test.go
+++ b/scheduler/version_probe_test.go
@@ -34,23 +34,29 @@ sys.exit(2)
 }
 
 // runProbeWithCwd runs probeCheckScripts from a tmp cwd containing a
-// fake .venv/bin/python3 shim that just execs whichever script it's
-// handed. Returns the probe's error.
+// fake uv shim that accepts `uv run --no-sync python ...` and execs
+// whichever script it's handed. Returns the probe's error.
 func runProbeWithCwd(t *testing.T, cfg *Config) error {
 	t.Helper()
 	tmp := t.TempDir()
-	venvBin := filepath.Join(tmp, ".venv", "bin")
-	if err := os.MkdirAll(venvBin, 0o755); err != nil {
-		t.Fatalf("mkdir venv: %v", err)
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
 	}
-	// Shim: forward argv unchanged to the real python3 found on PATH.
+	// Shim: validate the production argv prefix, then forward to python3.
 	shim := `#!/usr/bin/env bash
+if [[ "$1" != "run" || "$2" != "--no-sync" || "$3" != "python" ]]; then
+  echo "unexpected uv argv: $*" >&2
+  exit 64
+fi
+shift 3
 exec /usr/bin/env python3 "$@"
 `
-	pyShim := filepath.Join(venvBin, "python3")
-	if err := os.WriteFile(pyShim, []byte(shim), 0o755); err != nil {
+	uvShim := filepath.Join(binDir, "uv")
+	if err := os.WriteFile(uvShim, []byte(shim), 0o755); err != nil {
 		t.Fatalf("write shim: %v", err)
 	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	fetchDir := filepath.Join(tmp, "shared_scripts")
 	if err := os.MkdirAll(fetchDir, 0o755); err != nil {
 		t.Fatalf("mkdir shared_scripts: %v", err)
@@ -65,8 +71,7 @@ exec /usr/bin/env python3 "$@"
 
 	// Script paths in cfg are already absolute (from writeProbeStub) and
 	// stay valid regardless of cwd; the chdir above only matters so the
-	// relative ".venv/bin/python3" path inside probeOneCheckScript hits
-	// the shim we just dropped in tmp/.venv/bin/.
+	// helper resolves the tmp/bin/uv shim and runs probes from the project root.
 	return probeCheckScripts(cfg)
 }
 
@@ -134,7 +139,7 @@ func TestProbeIgnoresEmptyScripts(t *testing.T) {
 
 // TestProbeRunsFetchATRForHL verifies the second --fetch-atr probe (#689) is
 // dispatched only for check_hyperliquid.py. Stubs probeOneCheckScriptFn to
-// record argv shapes per script without requiring a real .venv.
+// record argv shapes per script without requiring a real Python runtime.
 func TestProbeRunsFetchATRForHL(t *testing.T) {
 	orig := probeOneCheckScriptFn
 	defer func() { probeOneCheckScriptFn = orig }()

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -95,6 +95,20 @@ if [[ -n "$LOG_DIR" ]]; then
   fi
 fi
 
+# uv cache for `uv run` (systemd unit sets UV_CACHE_DIR here; #739)
+if [[ -n "$WORKING_DIR" ]]; then
+  UV_CACHE_DIR="${WORKING_DIR}/scheduler/.uv-cache"
+  echo "Ensuring uv cache directory exists: $UV_CACHE_DIR"
+  install -d -m 0755 "$UV_CACHE_DIR"
+  if [[ -n "$SERVICE_USER" ]]; then
+    OWNER="$SERVICE_USER"
+    if [[ -n "$SERVICE_GROUP" ]]; then
+      OWNER="${SERVICE_USER}:${SERVICE_GROUP}"
+    fi
+    chown "$OWNER" "$UV_CACHE_DIR"
+  fi
+fi
+
 echo "Reloading systemd"
 systemctl daemon-reload
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -276,10 +276,10 @@ if [[ "$restart" != "1" ]]; then
 fi
 
 # Determine the /health port: explicit STATUS_PORT env > config.status_port > 8099.
-# Use the freshly synced .venv to parse JSON so we don't depend on jq.
+# Use the freshly synced uv environment to parse JSON so we don't depend on jq.
 status_port="${STATUS_PORT:-}"
-if [[ -z "$status_port" && -f scheduler/config.json && -x .venv/bin/python3 ]]; then
-    status_port=$(.venv/bin/python3 -c '
+if [[ -z "$status_port" && -f scheduler/config.json ]]; then
+    status_port=$(uv run --no-sync python -c '
 import json, sys
 try:
     cfg = json.load(open("scheduler/config.json"))

--- a/systemd/go-trader@.service
+++ b/systemd/go-trader@.service
@@ -20,6 +20,11 @@ TimeoutStopSec=20
 StandardOutput=journal
 StandardError=journal
 
+# Python (uv): default systemd PATH often omits ~/.local/bin. UV_CACHE_DIR
+# under scheduler/ stays inside ReadWritePaths (#739). Override via instance .env.
+Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:%h/.local/bin"
+Environment=UV_CACHE_DIR=/opt/go-trader-%i/scheduler/.uv-cache
+
 # Prefer loading secrets from an instance-specific env file rather than embedding
 # them in the unit file or config.json:
 #   echo "DISCORD_BOT_TOKEN=Bot your-token-here" > /opt/go-trader-%i/.env


### PR DESCRIPTION
## Summary
- Route scheduler Python subprocesses and startup probes through `uv run --no-sync python`.
- Update update-script port parsing, probe test shims, and agent docs for the uv runtime path.

## Test plan
- `go -C scheduler test ./...`
- `rg '\.venv/bin/python3' --glob '*.go'`
- `git diff --check`

Closes #739

Model: Composer 2
Effort: high
Harness: Cursor

Made with [Cursor](https://cursor.com)