### PR TITLE
feat(scheduler): inspect provenance + regime TP prices (#738)

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1099,7 +1099,7 @@ func collectPositions(sc StrategyConfig, ss *StrategyState, prices map[string]fl
 				extras += fmt.Sprintf(" | SL: $%s (%s)", fmtComma2(pos.StopLossTriggerPx), fmtPnlPct(slPct))
 			}
 		}
-		if tps := tieredTPATRPrices(sc, pos.Side, pos.AvgCost, pos.EntryATR); len(tps) > 0 {
+		if tps := tieredTPATRPricesForRegime(sc, pos.Side, pos.AvgCost, pos.EntryATR, pos.Regime); len(tps) > 0 {
 			// A zero TPOID alone is ambiguous (tiers also hold zero before the
 			// first protection-sync places them); require an observed shrink
 			// vs. InitialQuantity to mark a tier as filled (#662).
@@ -1190,7 +1190,7 @@ func tradeAlertExtras(sc StrategyConfig, trade Trade, isClose bool) []string {
 	var tiers []hlProtectionTier
 	var tps []float64
 	if !isClose && trade.EntryATR > 0 {
-		tiers = strategyTPTiers(sc)
+		tiers = strategyTPTiersForRegime(sc, trade.Regime)
 		tps = tieredTPATRPricesFromTiers(tiers, direction, trade.Price, trade.EntryATR)
 		if len(tps) > 0 {
 			extras = append(extras, fmt.Sprintf("ATR: $%s", fmtComma2(trade.EntryATR)))

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1052,10 +1052,9 @@ func positionMargin(qty, avgCost, leverage float64) float64 {
 }
 
 // strategyUsesTieredTPATRClose reports whether the strategy's configured close
-// evaluators include tiered_tp_atr or tiered_tp_atr_live. Both use the same
-// default 1×/2× tier multiples; hints are always priced from entry ATR × multiple
-// from avg_cost (see PR #529 review — live mode may use a different ATR ruler
-// at evaluation time, but the summary still shows the entry-ATR reference levels).
+// evaluators include any tiered_tp_atr* variant (scalar or regime, frozen or live).
+// Used for inspect-style questions and the on-chain-TP placement gate in
+// hyperliquidPlacesOnChainTPs.
 func strategyUsesTieredTPATRClose(sc StrategyConfig) bool {
 	for _, ref := range sc.CloseStrategies {
 		if isTieredTPATRCloseName(ref.Name) {

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -1620,6 +1620,34 @@ func TestCollectPositions_TieredTPATR_NoFillBeforeProtectionSync(t *testing.T) {
 	}
 }
 
+// TestCollectPositions_TieredTPATRRegime_StampedRegime verifies #738: once
+// pos.Regime is stamped, tiered_tp_atr_regime resolves TP display prices.
+func TestCollectPositions_TieredTPATRRegime_StampedRegime(t *testing.T) {
+	sc := StrategyConfig{
+		ID: "hl-reg-btc",
+		CloseStrategies: []StrategyRef{{
+			Name:   "tiered_tp_atr_regime",
+			Params: map[string]interface{}{"use_defaults": true},
+		}},
+	}
+	ss := &StrategyState{
+		Positions: map[string]*Position{
+			"BTC/USDT": {
+				Symbol:   "BTC/USDT",
+				Quantity: 0.025,
+				AvgCost:  63500,
+				Side:     "long",
+				EntryATR: 1000,
+				Regime:   "trending_up",
+			},
+		},
+	}
+	lines := collectPositions(sc, ss, map[string]float64{"BTC/USDT": 63500})
+	if !strings.Contains(lines[0], "| TP1: $65,500.00") || !strings.Contains(lines[0], "| TP2: $67,500.00") {
+		t.Errorf("expected regime-resolved TP prices, got: %s", lines[0])
+	}
+}
+
 // TestCollectPositions_AllFragments_WithTieredTP verifies ATR → SL → TP1 → TP2 →
 // leverage → date ordering when tiered_tp_atr is configured (#528).
 func TestCollectPositions_AllFragments_WithTieredTP(t *testing.T) {
@@ -2541,6 +2569,34 @@ func TestFormatTradeDM_TPATRMultipliersFractional(t *testing.T) {
 	}
 	if !strings.Contains(msg, "TP2: $66,000.00 (2.5x)") {
 		t.Errorf("expected TP2 with fractional 2.5× preserved, got:\n%s", msg)
+	}
+}
+
+// TestFormatTradeDM_TieredTPATRRegime verifies #738: trade-alert extras resolve TP
+// tier multiples from trade.Regime for regime-aware close evaluators.
+func TestFormatTradeDM_TieredTPATRRegime(t *testing.T) {
+	sc := StrategyConfig{
+		ID:       "hl-reg-btc",
+		Platform: "hyperliquid",
+		Type:     "perps",
+		CloseStrategies: []StrategyRef{{
+			Name:   "tiered_tp_atr_regime",
+			Params: map[string]interface{}{"use_defaults": true},
+		}},
+	}
+	trade := Trade{
+		Symbol:   "BTC",
+		Side:     "buy",
+		Quantity: 0.01,
+		Price:    63500.0,
+		Value:    635.0,
+		EntryATR: 1000.0,
+		Regime:   "trending_up",
+		Details:  "Open long 0.010000 @ $63500.00",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	if !strings.Contains(msg, "TP1: $65,500.00") || !strings.Contains(msg, "TP2: $67,500.00") {
+		t.Errorf("expected regime-resolved TP lines in DM, got:\n%s", msg)
 	}
 }
 

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -347,7 +347,7 @@ func tryBookSoleOwnerTPFill(
 		// price on the trade record AND wrong TP{n} label on the DM alert.
 		// Defer those cases to the legacy SL-owner branch in
 		// reconcileHyperliquidPositionsWithResolver.
-		tiers := strategyTPTiers(sc)
+		tiers := strategyTPTiersForRegime(sc, statePos.Regime)
 		tpOIDs := tpOIDsForTierCount(statePos.TPOIDs, len(tiers))
 		for _, oid := range tpOIDs {
 			if oid > 0 {
@@ -385,7 +385,7 @@ func tryBookSoleOwnerTPFill(
 		if onChainPos == nil || !useFillFee || lookup.OID <= 0 {
 			return false
 		}
-		tiers := strategyTPTiers(sc)
+		tiers := strategyTPTiersForRegime(sc, statePos.Regime)
 		if len(tiers) == 0 {
 			return false
 		}
@@ -407,7 +407,7 @@ func tryBookSoleOwnerTPFill(
 		// also feeds the plan-builder's "skip already-filled tiers" logic.
 	}
 
-	tpPrices := tieredTPATRPrices(sc, statePos.Side, statePos.AvgCost, statePos.EntryATR)
+	tpPrices := tieredTPATRPricesForRegime(sc, statePos.Side, statePos.AvgCost, statePos.EntryATR, statePos.Regime)
 	tpPrice := 0.0
 	if tierIdx >= 0 && tierIdx < len(tpPrices) {
 		tpPrice = tpPrices[tierIdx]
@@ -1111,7 +1111,7 @@ func hyperliquidClearedTPTier(sc StrategyConfig, pos *Position, closeQty float64
 	if pos == nil || len(pos.TPOIDs) == 0 {
 		return 0, false
 	}
-	tiers := strategyTPTiers(sc)
+	tiers := strategyTPTiersForRegime(sc, pos.Regime)
 	if len(tiers) == 0 {
 		return 0, false
 	}

--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -159,6 +159,13 @@ func tieredTPATRPrices(sc StrategyConfig, side string, entryPrice, entryATR floa
 	return tieredTPATRPricesFromTiers(strategyTPTiers(sc), side, entryPrice, entryATR)
 }
 
+// tieredTPATRPricesForRegime is tieredTPATRPrices with an explicit stamped regime
+// label so tiered_tp_atr_regime / tiered_tp_atr_live_regime resolve like
+// buildHyperliquidProtectionPlan (#738).
+func tieredTPATRPricesForRegime(sc StrategyConfig, side string, entryPrice, entryATR float64, regime string) []float64 {
+	return tieredTPATRPricesFromTiers(strategyTPTiersForRegime(sc, regime), side, entryPrice, entryATR)
+}
+
 // tieredTPATRPricesFromTiers is the price-only computation when the caller
 // already has tiers in hand — lets trade-alert extras call
 // strategyTPTiers once and zip prices with multiples (#665 review).

--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -476,7 +476,11 @@ func hyperliquidPlacesOnChainTPs(sc StrategyConfig) bool {
 	if (sc.Type != "perps" && sc.Type != "manual") || sc.Platform != "hyperliquid" {
 		return false
 	}
-	return len(strategyTPTiers(sc)) > 0
+	// Use strategyUsesTieredTPATRClose — not strategyTPTiers(sc) — because the
+	// latter passes an empty regime and returns nil for tiered_tp_atr_regime
+	// configs until pos.Regime is stamped, which left this gate false forever
+	// and skipped suppressing Python close evaluators (#750 / Sonnet review).
+	return strategyUsesTieredTPATRClose(sc)
 }
 
 // closeStrategiesSuppressedByOnChainProtection is the set of close evaluator

--- a/scheduler/hyperliquid_protection_test.go
+++ b/scheduler/hyperliquid_protection_test.go
@@ -609,6 +609,34 @@ func TestHyperliquidProtectionTiersRejectsSingleTier(t *testing.T) {
 	}
 }
 
+func TestHyperliquidPlacesOnChainTPs_RegimeAwareWithoutStampedRegime(t *testing.T) {
+	sc := StrategyConfig{
+		Type:     "perps",
+		Platform: "hyperliquid",
+		CloseStrategies: []StrategyRef{{
+			Name:   "tiered_tp_atr_regime",
+			Params: map[string]interface{}{"use_defaults": true},
+		}},
+	}
+	if len(strategyTPTiers(sc)) != 0 {
+		t.Fatalf("strategyTPTiers(sc) should be nil before regime is stamped, got %#v", strategyTPTiers(sc))
+	}
+	if !hyperliquidPlacesOnChainTPs(sc) {
+		t.Fatal("hyperliquidPlacesOnChainTPs must be true for regime tiered TP so HL on-chain suppression/filter gates apply (#750)")
+	}
+}
+
+func TestHyperliquidPlacesOnChainTPs_ScalarTiered(t *testing.T) {
+	sc := StrategyConfig{
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		CloseStrategies: []StrategyRef{{Name: "tiered_tp_atr"}},
+	}
+	if !hyperliquidPlacesOnChainTPs(sc) {
+		t.Fatal("expected true for scalar tiered_tp_atr")
+	}
+}
+
 func TestTieredTPATRPricesForRegimeUsesFleetDefaults(t *testing.T) {
 	sc := StrategyConfig{
 		Platform: "hyperliquid",

--- a/scheduler/hyperliquid_protection_test.go
+++ b/scheduler/hyperliquid_protection_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math"
 	"reflect"
 	"sync"
 	"testing"
@@ -605,5 +606,29 @@ func TestHyperliquidProtectionTiersRejectsSingleTier(t *testing.T) {
 	}
 	if got := strategyTPTiers(sc); len(got) != 0 {
 		t.Errorf("tiers = %+v, want nil/empty for single-tier config", got)
+	}
+}
+
+func TestTieredTPATRPricesForRegimeUsesFleetDefaults(t *testing.T) {
+	sc := StrategyConfig{
+		Platform: "hyperliquid",
+		Type:     "perps",
+		CloseStrategies: []StrategyRef{{
+			Name:   "tiered_tp_atr_regime",
+			Params: map[string]interface{}{"use_defaults": true},
+		}},
+	}
+	got := tieredTPATRPricesForRegime(sc, "long", 100, 10, "trending_up")
+	want := []float64{120, 140} // 2× and 4× ATR @ trending_up fleet baseline
+	if len(got) != len(want) {
+		t.Fatalf("len(prices)=%d, want %d; got=%v", len(got), len(want), got)
+	}
+	for i := range want {
+		if math.Abs(got[i]-want[i]) > 1e-9 {
+			t.Errorf("prices[%d]=%g, want %g (full %v)", i, got[i], want[i], got)
+		}
+	}
+	if empty := tieredTPATRPricesForRegime(sc, "long", 100, 10, ""); len(empty) != 0 {
+		t.Errorf("empty regime should yield no TP prices, got %v", empty)
 	}
 }

--- a/scheduler/inspect_cmd.go
+++ b/scheduler/inspect_cmd.go
@@ -115,16 +115,17 @@ func loadStrategyExplicitKeys(path string) (map[string]map[string]bool, error) {
 	return out, nil
 }
 
-// stopLossResolution summarizes which of the five mutually-exclusive HL stop
-// fields owns the effective trigger, the resolved price % (or "deferred" for
-// ATR-based stops), and whether the owner was set explicitly. Mirrors the
-// resolution logic in EffectiveStopLossPct so display can never lie about
-// which field is winning on a hot-reload boundary.
+// stopLossResolution summarizes which mutually-exclusive HL stop field owns
+// the effective trigger, the resolved price % (or "deferred" for ATR-based
+// stops), and whether the owner was set explicitly. Mirrors
+// EffectiveStopLossPct so display can never lie about which field is winning
+// on a hot-reload boundary.
 type stopLossResolution struct {
 	Source   string  // field name, e.g. "stop_loss_atr_mult"; "max_drawdown_pct"; "none"
 	Value    string  // human-readable value ("1.5× ATR (deferred)", "2.0% from entry", "—")
 	Explicit bool    // operator set the winning field explicitly
 	PriceTag float64 // computed price % when known (post-arming for ATR stops); 0 for deferred
+	Detail   []string
 }
 
 func resolveStopLoss(sc StrategyConfig, explicit map[string]bool) stopLossResolution {
@@ -143,6 +144,22 @@ func resolveStopLoss(sc StrategyConfig, explicit map[string]bool) stopLossResolu
 			Source:   "stop_loss_atr_mult",
 			Value:    fmt.Sprintf("%g× ATR (fixed, deferred until EntryATR stamped)", *sc.StopLossATRMult),
 			Explicit: explicit["stop_loss_atr_mult"],
+		}
+	}
+	if sc.StopLossATRRegime != nil && !sc.StopLossATRRegime.IsZero() {
+		return stopLossResolution{
+			Source:   "stop_loss_atr_regime",
+			Value:    fmt.Sprintf("regime-aware fixed ATR (deferred until EntryATR + %s stamped)", regimeClassifierKey),
+			Explicit: explicit["stop_loss_atr_regime"],
+			Detail:   formatRegimeATRInspectDetail("stop_loss_atr_regime", *sc.StopLossATRRegime, explicit["stop_loss_atr_regime"]),
+		}
+	}
+	if sc.TrailingStopATRRegime != nil && !sc.TrailingStopATRRegime.IsZero() {
+		return stopLossResolution{
+			Source:   "trailing_stop_atr_regime",
+			Value:    fmt.Sprintf("regime-aware trailing ATR (deferred until EntryATR + %s stamped)", regimeClassifierKey),
+			Explicit: explicit["trailing_stop_atr_regime"],
+			Detail:   formatRegimeATRInspectDetail("trailing_stop_atr_regime", *sc.TrailingStopATRRegime, explicit["trailing_stop_atr_regime"]),
 		}
 	}
 	if sc.TrailingStopPct != nil {
@@ -198,36 +215,174 @@ func resolveStopLoss(sc StrategyConfig, explicit map[string]bool) stopLossResolu
 }
 
 // tpResolution summarizes which close ref owns the take-profit logic and its
-// resolved tier shape. Returns ok=false when no TP close evaluator is wired
-// (i.e. close strategy isn't tiered_tp_atr or tiered_tp_atr_live).
+// resolved tier shape. Returns ok=false when no tiered_tp_atr* close evaluator
+// is wired.
 type tpResolution struct {
-	OK         bool
-	CloseIndex int
-	CloseName  string
-	Tiers      []hlProtectionTier
-	TiersFrom  string // "explicit on close ref" | "default (from registry)"
+	OK          bool
+	CloseIndex  int
+	CloseName   string
+	Tiers       []hlProtectionTier
+	TiersFrom   string // "explicit on close ref" | "default (from registry)"
+	DetailLines []string
+	TierCount   int
 }
 
 func resolveTP(sc StrategyConfig, explicit map[string]bool) tpResolution {
 	res := tpResolution{}
 	for i, ref := range sc.CloseStrategies {
 		n := strings.ToLower(strings.TrimSpace(ref.Name))
-		if n != "tiered_tp_atr" && n != "tiered_tp_atr_live" {
+		if !isTieredTPATRCloseName(n) {
 			continue
 		}
 		res.OK = true
 		res.CloseIndex = i
 		res.CloseName = ref.Name
 		_, hasTiers := ref.Params["tiers"]
-		res.Tiers = strategyTPTiers(sc)
-		if hasTiers {
-			res.TiersFrom = "explicit on close ref"
-		} else {
-			res.TiersFrom = "default (canonical [1×@50%, 2×@100%])"
+		useDefaults := false
+		if ud, ok := ref.Params["use_defaults"].(bool); ok && ud {
+			useDefaults = true
+		}
+		switch n {
+		case "tiered_tp_atr_regime", "tiered_tp_atr_live_regime":
+			res.DetailLines = formatInspectRegimeTPDetailLines(ref.Name, ref, hasTiers, useDefaults, explicit["close_strategies"])
+			if tiers := strategyTPTiersForRegime(sc, canonicalTrendRegimeLabels[0]); len(tiers) > 0 {
+				res.Tiers = tiers
+			}
+			res.TierCount = inferRegimeTPTierCount(ref, hasTiers, useDefaults)
+			switch {
+			case hasTiers:
+				res.TiersFrom = "explicit tier list on close ref"
+			case useDefaults:
+				res.TiersFrom = "fleet baseline (use_defaults)"
+			default:
+				res.TiersFrom = "incomplete (needs tiers or use_defaults:true)"
+			}
+		default:
+			res.Tiers = strategyTPTiers(sc)
+			res.TierCount = len(res.Tiers)
+			if hasTiers {
+				res.TiersFrom = "explicit on close ref"
+			} else {
+				res.TiersFrom = "default (canonical [1×@50%, 2×@100%])"
+			}
 		}
 		return res
 	}
 	return res
+}
+
+func inferRegimeTPTierCount(ref StrategyRef, hasTiers, useDefaults bool) int {
+	if hasTiers {
+		if raw, ok := ref.Params["tiers"]; ok {
+			if items, ok := raw.([]interface{}); ok {
+				return len(items)
+			}
+		}
+	}
+	if useDefaults {
+		return len(InspectRegimeTPFleetDefaultBlocks())
+	}
+	return 0
+}
+
+func formatRegimeATRInspectDetail(field string, block RegimeATRBlock, operatorExplicit bool) []string {
+	tag := explicitTag(operatorExplicit)
+	if block.UseDefaults {
+		return []string{fmt.Sprintf(
+			"%s: %s (from use_defaults baseline, classifier=%s)%s",
+			field, summarizeRegimeATRBlockATRs(block.TrendRegime), regimeClassifierKey, tag,
+		)}
+	}
+	labels := sortedTrendRegimeLabels(block.TrendRegime)
+	out := make([]string, 0, len(labels))
+	for _, label := range labels {
+		e := block.TrendRegime[label]
+		out = append(out, fmt.Sprintf(
+			"%s: %g×ATR (from %s.%s.%s.atr)%s",
+			field, e.ATR, field, regimeClassifierKey, label, tag,
+		))
+	}
+	return out
+}
+
+func summarizeRegimeATRBlockATRs(m map[string]RegimeATREntry) string {
+	labels := sortedTrendRegimeLabels(m)
+	parts := make([]string, 0, len(labels))
+	for _, label := range labels {
+		parts = append(parts, fmt.Sprintf("%s=%g×", label, m[label].ATR))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func sortedTrendRegimeLabels(m map[string]RegimeATREntry) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func formatInspectRegimeTPDetailLines(closeName string, ref StrategyRef, hasTiers, useDefaults, closeExplicit bool) []string {
+	tag := explicitTag(closeExplicit)
+	if !hasTiers {
+		if !useDefaults {
+			return []string{fmt.Sprintf(
+				"%s: incomplete regime TP config (needs tiers or use_defaults:true)%s",
+				closeName, tag,
+			)}
+		}
+		blocks := InspectRegimeTPFleetDefaultBlocks()
+		specs := make([]regimeTierSpec, len(blocks))
+		for i, b := range blocks {
+			specs[i] = regimeTierSpec{Block: b}
+		}
+		return summarizeInspectRegimeTPSpecs(closeName, specs, tag)
+	}
+	specs, errs := parseRegimeTPTiers(ref.Params["tiers"], closeName+".params")
+	if len(errs) > 0 || len(specs) == 0 {
+		return []string{fmt.Sprintf("%s: regime tiers: parse error — fix config (%v)", closeName, errs)}
+	}
+	return summarizeInspectRegimeTPSpecs(closeName, specs, tag)
+}
+
+func summarizeInspectRegimeTPSpecs(closeName string, specs []regimeTierSpec, closeExplicitTag string) []string {
+	out := make([]string, 0, len(specs))
+	for idx, spec := range specs {
+		prov := inspectRegimeTPTierProvenance(spec.Block, closeExplicitTag)
+		out = append(out, fmt.Sprintf("%s tier[%d]: %s%s", closeName, idx, summarizeRegimeTierSpecInspect(spec), prov))
+	}
+	return out
+}
+
+func summarizeRegimeTierSpecInspect(spec regimeTierSpec) string {
+	labels := sortedTrendRegimeLabels(spec.Block.TrendRegime)
+	parts := make([]string, 0, len(labels))
+	for _, label := range labels {
+		e, ok := spec.Block.TrendRegime[label]
+		if !ok {
+			continue
+		}
+		frac := 0.0
+		switch {
+		case spec.HasTierCloseFraction:
+			frac = spec.TierCloseFraction
+		case e.HasCloseFrac:
+			frac = e.CloseFraction
+		}
+		if frac <= 0 {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s=%g×@%g%%", label, e.ATR, frac*100))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func inspectRegimeTPTierProvenance(block RegimeATRBlock, closeExplicitTag string) string {
+	if block.UseDefaults {
+		return fmt.Sprintf(" (from use_defaults baseline, classifier=%s)%s", regimeClassifierKey, closeExplicitTag)
+	}
+	return fmt.Sprintf(" (explicit %s per label)%s", regimeClassifierKey, closeExplicitTag)
 }
 
 // formatStrategyInspection renders the multi-line human-facing inspect output
@@ -279,14 +434,30 @@ func formatStrategyInspection(sc StrategyConfig, explicit map[string]bool, cfg *
 		fmt.Fprintf(&b, "  stop_loss:\n")
 		fmt.Fprintf(&b, "    source:            %s%s\n", sl.Source, explicitTag(sl.Explicit))
 		fmt.Fprintf(&b, "    value:             %s\n", sl.Value)
+		for _, line := range sl.Detail {
+			fmt.Fprintf(&b, "                      %s\n", line)
+		}
 
 		tp := resolveTP(sc, explicit)
 		fmt.Fprintf(&b, "  take_profit:\n")
 		if !tp.OK {
-			fmt.Fprintf(&b, "    source:            none (no tiered_tp_atr / tiered_tp_atr_live in close_strategies)\n")
+			fmt.Fprintf(&b, "    source:            none (no tiered_tp_atr* in close_strategies)\n")
 		} else {
 			fmt.Fprintf(&b, "    source:            close_strategies[%d] %s\n", tp.CloseIndex, tp.CloseName)
-			fmt.Fprintf(&b, "    tiers:             %s — %s\n", formatTiers(tp.Tiers), tp.TiersFrom)
+			for _, line := range tp.DetailLines {
+				fmt.Fprintf(&b, "    %s\n", line)
+			}
+			n := strings.ToLower(strings.TrimSpace(tp.CloseName))
+			regimeTPName := n == "tiered_tp_atr_regime" || n == "tiered_tp_atr_live_regime"
+			if len(tp.Tiers) > 0 {
+				if regimeTPName {
+					fmt.Fprintf(&b, "    tiers (example: %s=%s): %s — %s\n", regimeClassifierKey, canonicalTrendRegimeLabels[0], formatTiers(tp.Tiers), tp.TiersFrom)
+				} else {
+					fmt.Fprintf(&b, "    tiers:             %s — %s\n", formatTiers(tp.Tiers), tp.TiersFrom)
+				}
+			} else {
+				fmt.Fprintf(&b, "    tiers:             %s — %s\n", formatTiers(tp.Tiers), tp.TiersFrom)
+			}
 		}
 	}
 
@@ -332,7 +503,11 @@ func formatStrategySummaryLine(sc StrategyConfig, explicit map[string]bool) stri
 		parts = append(parts, fmt.Sprintf("sl=%s%s", sl.Source, explicitTag(sl.Explicit)))
 		tp := resolveTP(sc, explicit)
 		if tp.OK {
-			parts = append(parts, fmt.Sprintf("tp=%s[%d-tier]", tp.CloseName, len(tp.Tiers)))
+			n := tp.TierCount
+			if n <= 0 {
+				n = len(tp.Tiers)
+			}
+			parts = append(parts, fmt.Sprintf("tp=%s[%d-tier]", tp.CloseName, n))
 		} else {
 			parts = append(parts, "tp=none")
 		}
@@ -376,11 +551,15 @@ func buildStrategyInspectionJSON(sc StrategyConfig, explicit map[string]bool, cf
 	}
 	if sc.Platform == "hyperliquid" && (sc.Type == "perps" || sc.Type == "manual") {
 		sl := resolveStopLoss(sc, explicit)
-		out["stop_loss"] = map[string]interface{}{
+		slMap := map[string]interface{}{
 			"source":   sl.Source,
 			"value":    sl.Value,
 			"explicit": sl.Explicit,
 		}
+		if len(sl.Detail) > 0 {
+			slMap["detail"] = sl.Detail
+		}
+		out["stop_loss"] = slMap
 		tp := resolveTP(sc, explicit)
 		tpMap := map[string]interface{}{"configured": tp.OK}
 		if tp.OK {
@@ -392,6 +571,19 @@ func buildStrategyInspectionJSON(sc StrategyConfig, explicit map[string]bool, cf
 			tpMap["close_name"] = tp.CloseName
 			tpMap["tiers"] = tiers
 			tpMap["tiers_source"] = tp.TiersFrom
+			tpMap["tier_count"] = tp.TierCount
+			if tp.TierCount <= 0 && len(tp.Tiers) > 0 {
+				tpMap["tier_count"] = len(tp.Tiers)
+			}
+			if len(tp.DetailLines) > 0 {
+				tpMap["detail"] = tp.DetailLines
+			}
+			closeNameLower := strings.ToLower(strings.TrimSpace(tp.CloseName))
+			if closeNameLower == "tiered_tp_atr_regime" || closeNameLower == "tiered_tp_atr_live_regime" {
+				if len(tp.Tiers) > 0 {
+					tpMap["example_classifier_label"] = canonicalTrendRegimeLabels[0]
+				}
+			}
 		}
 		out["take_profit"] = tpMap
 	}

--- a/scheduler/inspect_cmd.go
+++ b/scheduler/inspect_cmd.go
@@ -339,6 +339,8 @@ func formatInspectRegimeTPDetailLines(closeName string, ref StrategyRef, hasTier
 		}
 		return summarizeInspectRegimeTPSpecs(closeName, specs, tag)
 	}
+	// LoadConfig + validateRegimeATRConfig already rejected malformed tier JSON;
+	// re-parse here is defense-in-depth for inspect-only paths, not a hot path.
 	specs, errs := parseRegimeTPTiers(ref.Params["tiers"], closeName+".params")
 	if len(errs) > 0 || len(specs) == 0 {
 		return []string{fmt.Sprintf("%s: regime tiers: parse error — fix config (%v)", closeName, errs)}
@@ -435,7 +437,7 @@ func formatStrategyInspection(sc StrategyConfig, explicit map[string]bool, cfg *
 		fmt.Fprintf(&b, "    source:            %s%s\n", sl.Source, explicitTag(sl.Explicit))
 		fmt.Fprintf(&b, "    value:             %s\n", sl.Value)
 		for _, line := range sl.Detail {
-			fmt.Fprintf(&b, "                      %s\n", line)
+			fmt.Fprintf(&b, "%s%s\n", inspectHLDetailIndent, line)
 		}
 
 		tp := resolveTP(sc, explicit)
@@ -449,12 +451,8 @@ func formatStrategyInspection(sc StrategyConfig, explicit map[string]bool, cfg *
 			}
 			n := strings.ToLower(strings.TrimSpace(tp.CloseName))
 			regimeTPName := n == "tiered_tp_atr_regime" || n == "tiered_tp_atr_live_regime"
-			if len(tp.Tiers) > 0 {
-				if regimeTPName {
-					fmt.Fprintf(&b, "    tiers (example: %s=%s): %s — %s\n", regimeClassifierKey, canonicalTrendRegimeLabels[0], formatTiers(tp.Tiers), tp.TiersFrom)
-				} else {
-					fmt.Fprintf(&b, "    tiers:             %s — %s\n", formatTiers(tp.Tiers), tp.TiersFrom)
-				}
+			if regimeTPName && len(tp.Tiers) > 0 {
+				fmt.Fprintf(&b, "    tiers (example: %s=%s): %s — %s\n", regimeClassifierKey, canonicalTrendRegimeLabels[0], formatTiers(tp.Tiers), tp.TiersFrom)
 			} else {
 				fmt.Fprintf(&b, "    tiers:             %s — %s\n", formatTiers(tp.Tiers), tp.TiersFrom)
 			}
@@ -598,6 +596,10 @@ func buildStrategyInspectionJSON(sc StrategyConfig, explicit map[string]bool, cf
 }
 
 // --- formatting helpers ---
+
+// inspectHLDetailIndent aligns stop_loss continuation lines with the payload
+// column of "    source:" / "    value:" (23 runes). See PR #750 review.
+const inspectHLDetailIndent = "                       "
 
 func markIfDefault(explicit map[string]bool, key string) string {
 	if explicit[key] {

--- a/scheduler/inspect_cmd.go
+++ b/scheduler/inspect_cmd.go
@@ -221,6 +221,7 @@ type tpResolution struct {
 	OK          bool
 	CloseIndex  int
 	CloseName   string
+	RegimeTP    bool // tiered_tp_atr_regime or tiered_tp_atr_live_regime
 	Tiers       []hlProtectionTier
 	TiersFrom   string // "explicit on close ref" | "default (from registry)"
 	DetailLines []string
@@ -244,6 +245,7 @@ func resolveTP(sc StrategyConfig, explicit map[string]bool) tpResolution {
 		}
 		switch n {
 		case "tiered_tp_atr_regime", "tiered_tp_atr_live_regime":
+			res.RegimeTP = true
 			res.DetailLines = formatInspectRegimeTPDetailLines(ref.Name, ref, hasTiers, useDefaults, explicit["close_strategies"])
 			if tiers := strategyTPTiersForRegime(sc, canonicalTrendRegimeLabels[0]); len(tiers) > 0 {
 				res.Tiers = tiers
@@ -449,9 +451,7 @@ func formatStrategyInspection(sc StrategyConfig, explicit map[string]bool, cfg *
 			for _, line := range tp.DetailLines {
 				fmt.Fprintf(&b, "    %s\n", line)
 			}
-			n := strings.ToLower(strings.TrimSpace(tp.CloseName))
-			regimeTPName := n == "tiered_tp_atr_regime" || n == "tiered_tp_atr_live_regime"
-			if regimeTPName && len(tp.Tiers) > 0 {
+			if tp.RegimeTP && len(tp.Tiers) > 0 {
 				fmt.Fprintf(&b, "    tiers (example: %s=%s): %s — %s\n", regimeClassifierKey, canonicalTrendRegimeLabels[0], formatTiers(tp.Tiers), tp.TiersFrom)
 			} else {
 				fmt.Fprintf(&b, "    tiers:             %s — %s\n", formatTiers(tp.Tiers), tp.TiersFrom)
@@ -570,17 +570,11 @@ func buildStrategyInspectionJSON(sc StrategyConfig, explicit map[string]bool, cf
 			tpMap["tiers"] = tiers
 			tpMap["tiers_source"] = tp.TiersFrom
 			tpMap["tier_count"] = tp.TierCount
-			if tp.TierCount <= 0 && len(tp.Tiers) > 0 {
-				tpMap["tier_count"] = len(tp.Tiers)
-			}
 			if len(tp.DetailLines) > 0 {
 				tpMap["detail"] = tp.DetailLines
 			}
-			closeNameLower := strings.ToLower(strings.TrimSpace(tp.CloseName))
-			if closeNameLower == "tiered_tp_atr_regime" || closeNameLower == "tiered_tp_atr_live_regime" {
-				if len(tp.Tiers) > 0 {
-					tpMap["example_classifier_label"] = canonicalTrendRegimeLabels[0]
-				}
+			if tp.RegimeTP && len(tp.Tiers) > 0 {
+				tpMap["example_classifier_label"] = canonicalTrendRegimeLabels[0]
 			}
 		}
 		out["take_profit"] = tpMap

--- a/scheduler/inspect_cmd_test.go
+++ b/scheduler/inspect_cmd_test.go
@@ -320,3 +320,71 @@ func TestBuildStrategyInspectionJSONStableShape(t *testing.T) {
 		t.Errorf("take_profit.configured = %v", tp["configured"])
 	}
 }
+
+func TestResolveStopLossRegimeFixedInspectDetail(t *testing.T) {
+	sc := StrategyConfig{
+		Type:     "perps",
+		Platform: "hyperliquid",
+		StopLossATRRegime: &RegimeATRBlock{
+			UseDefaults: true,
+			TrendRegime: map[string]RegimeATREntry{
+				"trending_up":   {ATR: 2.0},
+				"trending_down": {ATR: 2.0},
+				"ranging":       {ATR: 1.5},
+			},
+		},
+	}
+	res := resolveStopLoss(sc, map[string]bool{"stop_loss_atr_regime": true})
+	if res.Source != "stop_loss_atr_regime" {
+		t.Fatalf("source=%q", res.Source)
+	}
+	if len(res.Detail) != 1 || !strings.Contains(res.Detail[0], "use_defaults baseline") {
+		t.Fatalf("unexpected detail: %v", res.Detail)
+	}
+	if !strings.Contains(res.Detail[0], "trend_regime") {
+		t.Errorf("classifier missing: %q", res.Detail[0])
+	}
+}
+
+func TestFormatStrategyInspectionRegimeTPUseDefaults(t *testing.T) {
+	mult := 1.0
+	sc := StrategyConfig{
+		ID:              "hl-reg-tp",
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		Script:          "shared_scripts/check_hyperliquid.py",
+		CloseStrategies: []StrategyRef{{Name: "tiered_tp_atr_regime", Params: map[string]interface{}{"use_defaults": true}}},
+		Leverage:        3,
+		StopLossATRMult: &mult,
+		MaxDrawdownPct:  50,
+	}
+	explicit := map[string]bool{
+		"id": true, "type": true, "platform": true, "script": true,
+		"close_strategies": true, "leverage": true, "max_drawdown_pct": true,
+	}
+	out := formatStrategyInspection(sc, explicit, &Config{IntervalSeconds: 60})
+	if !strings.Contains(out, "tiered_tp_atr_regime tier[0]:") {
+		t.Errorf("missing tier[0] provenance line:\n%s", out)
+	}
+	if !strings.Contains(out, "use_defaults baseline") {
+		t.Errorf("missing use_defaults provenance:\n%s", out)
+	}
+	if !strings.Contains(out, "tiers (example: trend_regime=trending_up):") {
+		t.Errorf("missing example tier line:\n%s", out)
+	}
+}
+
+func TestFormatStrategySummaryLineRegimeTPTierCount(t *testing.T) {
+	mult := 1.0
+	sc := StrategyConfig{
+		ID:              "hl-reg-tp",
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		CloseStrategies: []StrategyRef{{Name: "tiered_tp_atr_regime", Params: map[string]interface{}{"use_defaults": true}}},
+		StopLossATRMult: &mult,
+	}
+	line := formatStrategySummaryLine(sc, nil)
+	if !strings.Contains(line, "tp=tiered_tp_atr_regime[2-tier]") {
+		t.Errorf("expected 2-tier regime TP summary, got: %s", line)
+	}
+}

--- a/scheduler/regime_atr.go
+++ b/scheduler/regime_atr.go
@@ -711,3 +711,14 @@ func defaultRegimeTPTiersForRegime(regime string) []hlProtectionTier {
 	}
 	return finalizeProtectionTiers(out)
 }
+
+// InspectRegimeTPFleetDefaultBlocks returns deep copies of the fleet baseline
+// tier blocks used when a tiered_tp_atr{_live}_regime close ref sets
+// use_defaults:true. For go-trader inspect provenance (#738).
+func InspectRegimeTPFleetDefaultBlocks() []RegimeATRBlock {
+	out := make([]RegimeATRBlock, len(regimeATRDefaults.TPTiers))
+	for i, b := range regimeATRDefaults.TPTiers {
+		out[i] = RegimeATRBlock{UseDefaults: true, TrendRegime: cloneRegimeMap(b.TrendRegime)}
+	}
+	return out
+}


### PR DESCRIPTION
Closes #738

Observability-only follow-up to regime-aware ATR surfaces (#733/#735):

1. `go-trader inspect` shows provenance for `stop_loss_atr_regime`, `trailing_stop_atr_regime`, and tiered TP regime close evaluators (`use_defaults` vs explicit `trend_regime` paths).
2. Discord position summaries, trade-alert extras, and sole-owner TP reconciliation use stamped regime labels via `tieredTPATRPricesForRegime` / `strategyTPTiersForRegime`.
3. `hyperliquidClearedTPTier` resolves tier count against `pos.Regime` for regime TP configs.

Tests added in `inspect_cmd_test.go`, `discord_test.go`, and `hyperliquid_protection_test.go`.

LLM: Composer | high | Harness: draft PR #750