### PR TITLE
fix(hl): do not re-place consumed TP tiers after TP1 fill (#749)

### DIFF
--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"syscall"
 	"time"
@@ -370,7 +371,9 @@ func RunHyperliquidUpdateStopLoss(script, symbol, side string, size, triggerPx f
 	return parseHyperliquidUpdateStopLossOutput(stdout, string(stderr), err)
 }
 
-func RunHyperliquidSyncProtection(script, symbol, side string, size, avgCost, entryATR, stopLossATRMult float64, tiers []hlProtectionTier, stopLossOID int64, tpOIDs []int64, tpArmedTiers []bool) (*HyperliquidProtectionSyncResult, string, error) {
+// buildHyperliquidSyncProtectionArgv builds argv for check_hyperliquid.py
+// --sync-protection (used by RunHyperliquidSyncProtection and tests).
+func buildHyperliquidSyncProtectionArgv(symbol, side string, size, avgCost, entryATR, stopLossATRMult float64, tiers []hlProtectionTier, stopLossOID int64, tpOIDs []int64, tpArmedTiers []bool) []string {
 	args := []string{
 		"--sync-protection",
 		fmt.Sprintf("--symbol=%s", symbol),
@@ -405,8 +408,15 @@ func RunHyperliquidSyncProtection(script, symbol, side string, size, avgCost, en
 		armed := tpArmedTiersForTierCount(tpArmedTiers, len(tiers))
 		if b, err := json.Marshal(armed); err == nil {
 			args = append(args, fmt.Sprintf("--tp-armed-tiers-json=%s", string(b)))
+		} else {
+			fmt.Fprintf(os.Stderr, "[WARN] json.Marshal(tp armed tiers) failed: %v — sync-protection omitting --tp-armed-tiers-json\n", err)
 		}
 	}
+	return args
+}
+
+func RunHyperliquidSyncProtection(script, symbol, side string, size, avgCost, entryATR, stopLossATRMult float64, tiers []hlProtectionTier, stopLossOID int64, tpOIDs []int64, tpArmedTiers []bool) (*HyperliquidProtectionSyncResult, string, error) {
+	args := buildHyperliquidSyncProtectionArgv(symbol, side, size, avgCost, entryATR, stopLossATRMult, tiers, stopLossOID, tpOIDs, tpArmedTiers)
 	stdout, stderr, err := runPythonSideEffect(script, args)
 	stderrStr := string(stderr)
 	var result HyperliquidProtectionSyncResult

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -370,7 +370,7 @@ func RunHyperliquidUpdateStopLoss(script, symbol, side string, size, triggerPx f
 	return parseHyperliquidUpdateStopLossOutput(stdout, string(stderr), err)
 }
 
-func RunHyperliquidSyncProtection(script, symbol, side string, size, avgCost, entryATR, stopLossATRMult float64, tiers []hlProtectionTier, stopLossOID int64, tpOIDs []int64) (*HyperliquidProtectionSyncResult, string, error) {
+func RunHyperliquidSyncProtection(script, symbol, side string, size, avgCost, entryATR, stopLossATRMult float64, tiers []hlProtectionTier, stopLossOID int64, tpOIDs []int64, tpArmedTiers []bool) (*HyperliquidProtectionSyncResult, string, error) {
 	args := []string{
 		"--sync-protection",
 		fmt.Sprintf("--symbol=%s", symbol),
@@ -399,6 +399,12 @@ func RunHyperliquidSyncProtection(script, symbol, side string, size, avgCost, en
 	if len(tpOIDs) > 0 {
 		if b, err := json.Marshal(tpOIDs); err == nil {
 			args = append(args, fmt.Sprintf("--tp-oids-json=%s", string(b)))
+		}
+	}
+	if len(tiers) > 0 {
+		armed := tpArmedTiersForTierCount(tpArmedTiers, len(tiers))
+		if b, err := json.Marshal(armed); err == nil {
+			args = append(args, fmt.Sprintf("--tp-armed-tiers-json=%s", string(b)))
 		}
 	}
 	stdout, stderr, err := runPythonSideEffect(script, args)

--- a/scheduler/executor_test.go
+++ b/scheduler/executor_test.go
@@ -704,6 +704,45 @@ func TestBuildHyperliquidExecuteArgs_OptionalFlags(t *testing.T) {
 	})
 }
 
+func TestBuildHyperliquidSyncProtectionArgv_TPArmedTiersJSON(t *testing.T) {
+	tiers := []hlProtectionTier{{Multiple: 1, Fraction: 0.5}, {Multiple: 2, Fraction: 1}}
+	argv := buildHyperliquidSyncProtectionArgv("ETH", "long", 0.22, 3000, 100, 1.5, tiers, 999, []int64{0, 300}, []bool{true, true})
+	var armedArg string
+	for _, a := range argv {
+		if strings.HasPrefix(a, "--tp-armed-tiers-json=") {
+			armedArg = a
+			break
+		}
+	}
+	if armedArg == "" {
+		t.Fatal("missing --tp-armed-tiers-json flag (wire contract with check_hyperliquid.py)")
+	}
+	const prefix = "--tp-armed-tiers-json="
+	if got := strings.TrimPrefix(armedArg, prefix); got != `[true,true]` {
+		t.Errorf("armed tiers JSON = %q, want [true,true]", got)
+	}
+	// Shorter slice pads false (#749 / hyperliquid_protection.go).
+	argv = buildHyperliquidSyncProtectionArgv("ETH", "long", 0.22, 3000, 100, 1.5, tiers, 0, nil, []bool{true})
+	for _, a := range argv {
+		if strings.HasPrefix(a, "--tp-armed-tiers-json=") {
+			if got := strings.TrimPrefix(a, prefix); got != `[true,false]` {
+				t.Errorf("padded armed tiers JSON = %q, want [true,false]", got)
+			}
+			return
+		}
+	}
+	t.Fatal("missing --tp-armed-tiers-json after padding test")
+}
+
+func TestBuildHyperliquidSyncProtectionArgv_NoTiersOmitsArmedJSON(t *testing.T) {
+	argv := buildHyperliquidSyncProtectionArgv("ETH", "long", 0.22, 3000, 100, 1.5, nil, 0, nil, nil)
+	for _, a := range argv {
+		if strings.HasPrefix(a, "--tp-armed-tiers-json=") {
+			t.Fatalf("unexpected %q when tiers empty", a)
+		}
+	}
+}
+
 func TestPythonScriptTimeoutError_As(t *testing.T) {
 	var err error = &pythonScriptTimeoutError{d: 5 * time.Minute}
 	var toe *pythonScriptTimeoutError

--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -17,6 +17,11 @@ type hlProtectionPlan struct {
 	StopLossOID     int64
 	Tiers           []hlProtectionTier
 	TPOIDs          []int64
+	// TPArmedTiers mirrors Position.TPArmedTiers padded to len(Tiers): tier i
+	// was successfully placed at least once. When TPOIDs[i]==0 and
+	// TPArmedTiers[i]==true, the tier is treated as consumed (filled) and must
+	// not be re-placed from a zero OID — see #716 / #749.
+	TPArmedTiers []bool
 }
 
 func buildHyperliquidProtectionPlan(sc StrategyConfig, pos *Position) (hlProtectionPlan, bool) {
@@ -49,6 +54,7 @@ func buildHyperliquidProtectionPlan(sc StrategyConfig, pos *Position) (hlProtect
 	if slMult <= 0 && len(tiers) == 0 {
 		return hlProtectionPlan{}, false
 	}
+	tierCount := len(tiers)
 	return hlProtectionPlan{
 		Symbol:          pos.Symbol,
 		Side:            pos.Side,
@@ -58,7 +64,8 @@ func buildHyperliquidProtectionPlan(sc StrategyConfig, pos *Position) (hlProtect
 		StopLossATRMult: slMult,
 		StopLossOID:     pos.StopLossOID,
 		Tiers:           tiers,
-		TPOIDs:          tpOIDsForTierCount(pos.TPOIDs, len(tiers)),
+		TPOIDs:          tpOIDsForTierCount(pos.TPOIDs, tierCount),
+		TPArmedTiers:    tpArmedTiersForTierCount(pos.TPArmedTiers, tierCount),
 	}, true
 }
 
@@ -226,6 +233,15 @@ func tpOIDsForTierCount(oids []int64, tierCount int) []int64 {
 	return out
 }
 
+func tpArmedTiersForTierCount(armed []bool, tierCount int) []bool {
+	if tierCount <= 0 {
+		return nil
+	}
+	out := make([]bool, tierCount)
+	copy(out, armed)
+	return out
+}
+
 func cloneInt64s(vals []int64) []int64 {
 	if len(vals) == 0 {
 		return nil
@@ -287,7 +303,7 @@ type jsonNumber interface {
 var syncHyperliquidProtection = func(sc StrategyConfig, plan hlProtectionPlan, notifier *MultiNotifier, logger *StrategyLogger) (*HyperliquidProtectionSyncResult, bool) {
 	result, stderr, err := RunHyperliquidSyncProtection(
 		sc.Script, plan.Symbol, plan.Side, plan.Size, plan.AvgCost, plan.EntryATR,
-		plan.StopLossATRMult, plan.Tiers, plan.StopLossOID, plan.TPOIDs,
+		plan.StopLossATRMult, plan.Tiers, plan.StopLossOID, plan.TPOIDs, plan.TPArmedTiers,
 	)
 	if stderr != "" && logger != nil {
 		logger.Info("protection sync stderr: %s", stderr)

--- a/scheduler/hyperliquid_protection_test.go
+++ b/scheduler/hyperliquid_protection_test.go
@@ -593,6 +593,45 @@ func TestRunHyperliquidProtectionSyncStampsTradeInDB(t *testing.T) {
 	}
 }
 
+func TestBuildHyperliquidProtectionPlanPadsTPArmedTiers(t *testing.T) {
+	mult := 1.5
+	sc := StrategyConfig{
+		ID:              "hl-eth",
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		StopLossATRMult: &mult,
+		CloseStrategies: []StrategyRef{{Name: "tiered_tp_atr_live"}},
+	}
+	pos := &Position{
+		Symbol:       "ETH",
+		Quantity:     0.22,
+		AvgCost:      3000,
+		EntryATR:     100,
+		Side:         "long",
+		TPOIDs:       []int64{0, 300},
+		TPArmedTiers: []bool{true, true},
+	}
+	plan, ok := buildHyperliquidProtectionPlan(sc, pos)
+	if !ok {
+		t.Fatal("expected plan ok=true")
+	}
+	if want := []bool{true, true}; !reflect.DeepEqual(plan.TPArmedTiers, want) {
+		t.Errorf("TPArmedTiers = %v, want %v", plan.TPArmedTiers, want)
+	}
+	if want := []int64{0, 300}; !reflect.DeepEqual(plan.TPOIDs, want) {
+		t.Errorf("TPOIDs = %v, want %v", plan.TPOIDs, want)
+	}
+	// Shorter TPArmedTiers slice pads with false (#749 / #716 contract).
+	pos.TPArmedTiers = []bool{true}
+	plan, ok = buildHyperliquidProtectionPlan(sc, pos)
+	if !ok {
+		t.Fatal("expected plan ok=true (padded armed tiers)")
+	}
+	if want := []bool{true, false}; !reflect.DeepEqual(plan.TPArmedTiers, want) {
+		t.Errorf("padded TPArmedTiers = %v, want %v", plan.TPArmedTiers, want)
+	}
+}
+
 func TestHyperliquidProtectionTiersRejectsSingleTier(t *testing.T) {
 	sc := StrategyConfig{
 		Type:     "perps",

--- a/scheduler/manual_protection.go
+++ b/scheduler/manual_protection.go
@@ -60,7 +60,7 @@ func placeManualProtectionInline(
 
 	result, stderr, err := runHLSyncProtectionFn(
 		sc.Script, sc.Symbol, side, fillQty, fillPrice, entryATR,
-		effectiveSLATRMult, tiers, stopLossOID, nil,
+		effectiveSLATRMult, tiers, stopLossOID, nil, nil,
 	)
 	if stderr != "" {
 		fmt.Fprintf(os.Stderr, "[manual-open] sync-protection stderr: %s\n", stderr)

--- a/scheduler/manual_protection_test.go
+++ b/scheduler/manual_protection_test.go
@@ -54,7 +54,7 @@ func TestPlaceManualProtectionInline_TPErrorsSurface(t *testing.T) {
 	orig := runHLSyncProtectionFn
 	defer func() { runHLSyncProtectionFn = orig }()
 
-	runHLSyncProtectionFn = func(script, symbol, side string, size, avgCost, entryATR, stopLossATRMult float64, tiers []hlProtectionTier, stopLossOID int64, tpOIDs []int64) (*HyperliquidProtectionSyncResult, string, error) {
+	runHLSyncProtectionFn = func(script, symbol, side string, size, avgCost, entryATR, stopLossATRMult float64, tiers []hlProtectionTier, stopLossOID int64, tpOIDs []int64, _ []bool) (*HyperliquidProtectionSyncResult, string, error) {
 		return &HyperliquidProtectionSyncResult{
 			TPOIDs:   []int64{1001, 1002},
 			TPErrors: []string{"TP1: rejected", ""},

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -456,6 +456,7 @@ def run_sync_protection(
     tp2_oid=0,
     tp_tiers=None,
     tp_oids=None,
+    tp_armed_tiers=None,
 ):
     """Verify/re-place per-strategy reduce-only SL/TP orders (#601)."""
     if mode != "live":
@@ -572,6 +573,11 @@ def run_sync_protection(
                 tp_filled_externally = [False] * len(tiers)
                 tp_fills = [None] * len(tiers)
                 tp_filled_immediately = [False] * len(tiers)
+                armed = [bool(x) for x in (tp_armed_tiers or [])]
+                if len(armed) < len(tiers):
+                    armed.extend([False] * (len(tiers) - len(armed)))
+                else:
+                    armed = armed[: len(tiers)]
                 tier_sizes = compute_tp_tier_sizes(
                     size, tiers, lambda sz: adapter.floor_size(symbol, sz)
                 )
@@ -583,11 +589,21 @@ def run_sync_protection(
                     rounded_px = adapter.round_perps_trigger_px(symbol, raw_px)
                     tp_pxs.append(rounded_px)
                     prev_oid = int(existing_tp_oids[idx]) if idx < len(existing_tp_oids) else 0
+                    tier_armed = armed[idx] if idx < len(armed) else False
 
                     if tier_size <= 0:
                         continue
                     if _oid_is_open(open_oids, prev_oid):
                         tp_oids_out[idx] = prev_oid
+                        continue
+
+                    # #749: OID 0 means "no resting order" both before first placement
+                    # and after a tier filled (Go zeros the slot; TPArmedTiers marks
+                    # the tier as armed). Only the latter must skip re-placement —
+                    # otherwise cumulative fractions are re-applied to the reduced
+                    # size and tier 1 comes back as a "new TP1".
+                    if prev_oid <= 0 and tier_armed:
+                        tp_oids_out[idx] = 0
                         continue
 
                     action, fill = _resolve_missing_oid(prev_oid)
@@ -1050,10 +1066,14 @@ def main():
         parser.add_argument("--tp1-oid", type=int, default=0)
         parser.add_argument("--tp2-oid", type=int, default=0)
         parser.add_argument("--tp-oids-json", default="")
+        parser.add_argument("--tp-armed-tiers-json", default="")
         parser.add_argument("--mode", default="live")
         args = parser.parse_args()
         tp_tiers = json.loads(args.tp_tiers_json) if args.tp_tiers_json else None
         tp_oids = json.loads(args.tp_oids_json) if args.tp_oids_json else None
+        tp_armed_tiers = (
+            json.loads(args.tp_armed_tiers_json) if args.tp_armed_tiers_json else None
+        )
         run_sync_protection(
             args.symbol,
             args.side,
@@ -1070,6 +1090,7 @@ def main():
             tp2_oid=args.tp2_oid,
             tp_tiers=tp_tiers,
             tp_oids=tp_oids,
+            tp_armed_tiers=tp_armed_tiers,
         )
     elif "--update-stop-loss" in sys.argv:
         import argparse

--- a/shared_scripts/test_check_hyperliquid.py
+++ b/shared_scripts/test_check_hyperliquid.py
@@ -657,6 +657,7 @@ class TestSyncProtection:
         tp2_oid=0,
         tp_tiers=None,
         tp_oids=None,
+        tp_armed_tiers=None,
         open_oids=None,
         fill_lookup_by_oid=None,
         place_responses=None,
@@ -730,6 +731,7 @@ class TestSyncProtection:
                     tp2_oid=tp2_oid,
                     tp_tiers=tp_tiers,
                     tp_oids=tp_oids,
+                    tp_armed_tiers=tp_armed_tiers,
                 )
         return json.loads(captured.getvalue()), mock_adapter
 
@@ -785,6 +787,21 @@ class TestSyncProtection:
         assert not out.get("tp2_filled_externally")
         # Only ONE place_take_profit_limit call (for TP2), because TP1 was filled.
         assert adapter.place_take_profit_limit.call_count == 1
+
+    def test_zero_oid_armed_true_does_not_re_place_consumed_tp1(self):
+        """#749: after TP1 fills, Go passes TPArmedTiers with tier0=true and OID 0.
+        A later sync must not treat OID 0 as 'never placed' and recreate TP1."""
+        out, adapter = self._run_sync(
+            size=0.22,
+            tp_oids=[0, 300],
+            tp_armed_tiers=[True, True],
+            open_oids={300, 9000},
+            sl_oid=9000,
+        )
+        assert out["tp_oids"] == [0, 300]
+        assert out["tp2_oid"] == 300
+        assert "tp1_oid" not in out
+        adapter.place_take_profit_limit.assert_not_called()
 
     def test_three_tiers_places_incremental_sizes(self):
         """#612: N-tier protection sizes each order from cumulative fractions."""


### PR DESCRIPTION
## Summary
Fixes #749: after a partial TP1 fill, a later Hyperliquid protection sync was re-creating a TP in the first slot because OID `0` was interpreted as "never placed" while tier sizes were recomputed from the reduced position.

## Approach
- Extend the protection plan / subprocess contract with `TPArmedTiers` (`--tp-armed-tiers-json`), padded to tier count (mirrors `TPOIDs`).
- In `run_sync_protection`, when `prev_oid <= 0` and the tier is armed, skip placement (consumed tier per #716).

## Testing
- `go test -count=1 ./... -short` (scheduler)
- `pytest shared_scripts/test_check_hyperliquid.py::TestSyncProtection`

LLM: Composer | high | Harness: Cursor agent
