### PR TITLE
fix(hl): protection-fill DM from hlAttemptCloseFromTPFills (#754)

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -237,7 +237,7 @@ func fetchHyperliquidState(accountAddress string) (float64, []HLPosition, error)
 // cached resolver outside the lock and call
 // reconcileHyperliquidPositionsWithResolver.
 func reconcileHyperliquidPositions(stratState *StrategyState, sym string, positions []HLPosition, accountAddress string, logger *StrategyLogger) bool {
-	return reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, directHyperliquidReconcileFillResolver(accountAddress), logger)
+	return reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, directHyperliquidReconcileFillResolver(accountAddress), logger, nil)
 }
 
 // reconcileHyperliquidPositionsForStrategy is the production entry point with
@@ -276,11 +276,11 @@ func reconcileHyperliquidPositionsForStrategy(
 		// by the booker; the legacy reconciler's qty/side/avgCost resync will
 		// no-op because virtual now matches on-chain. Continue through it for
 		// idempotent housekeeping (multiplier migration, leverage seed).
-		reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, resolveFee, logger)
+		reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, resolveFee, logger, pendingAlerts)
 		return true
 	}
 
-	return reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, resolveFee, logger)
+	return reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, resolveFee, logger, pendingAlerts)
 }
 
 // tryBookSoleOwnerTPFill is the sole-owner TP attribution helper. Returns true
@@ -463,7 +463,7 @@ func tryBookSoleOwnerTPFill(
 // resolver is expected to do pure in-memory cache reads when called under
 // mu.Lock() (see buildCachedHyperliquidReconcileFillResolver) — never make
 // HTTP calls.
-func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym string, positions []HLPosition, resolveFee hlReconcileFillResolver, logger *StrategyLogger) bool {
+func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym string, positions []HLPosition, resolveFee hlReconcileFillResolver, logger *StrategyLogger, pendingAlerts *[]ProtectionFillAlert) bool {
 	changed := false
 
 	// Find the on-chain position for this strategy's symbol.
@@ -522,7 +522,7 @@ func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym st
 		// the position was flattened by TPs (HL auto-cancels the resting
 		// reduce-only SL once flat). Book each TP fill at its actual price
 		// rather than mis-attributing to the SL trigger price.
-		if hlAttemptCloseFromTPFills(stratState, sym, statePos, resolveFee, logger) {
+		if hlAttemptCloseFromTPFills(stratState, sym, statePos, resolveFee, logger, pendingAlerts) {
 			return true
 		}
 		if statePos.StopLossOID > 0 && statePos.StopLossTriggerPx > 0 {
@@ -1165,10 +1165,11 @@ func hyperliquidHasClearedTPTier(sc StrategyConfig, pos *Position, closeQty floa
 //
 // Returns false (no mutation) when no TP attribution is possible; the caller
 // then falls through to the legacy SL-trigger-price path.
-func hlAttemptCloseFromTPFills(s *StrategyState, sym string, pos *Position, resolveFee hlReconcileFillResolver, logger *StrategyLogger) bool {
+func hlAttemptCloseFromTPFills(s *StrategyState, sym string, pos *Position, resolveFee hlReconcileFillResolver, logger *StrategyLogger, pendingAlerts *[]ProtectionFillAlert) bool {
 	if s == nil || pos == nil || len(pos.TPOIDs) == 0 || resolveFee == nil {
 		return false
 	}
+	alertSide := pos.Side
 	// If the SL OID has fills, leave attribution to the existing SL path —
 	// it knows how to handle the #621 "SL fired on the post-TP residual"
 	// case and we don't want to double-book by also crediting TPs here.
@@ -1207,6 +1208,25 @@ func hlAttemptCloseFromTPFills(s *StrategyState, sym string, pos *Position, reso
 		logPrefix := fmt.Sprintf("TP%d fill reconciled", f.tierIdx+1)
 		if !bookPerpsPartialCloseWithFillFee(s, sym, f.lookup.FilledQty, f.lookup.Px, f.lookup.Fee, true, oidStr, reason, detailsPrefix, logPrefix, logger) {
 			break
+		}
+		if pendingAlerts != nil {
+			remaining := 0.0
+			if posAfter := s.Positions[sym]; posAfter != nil {
+				remaining = posAfter.Quantity
+			}
+			*pendingAlerts = append(*pendingAlerts, ProtectionFillAlert{
+				StrategyID:      s.ID,
+				Symbol:          sym,
+				Side:            alertSide,
+				FillType:        tpTierLabel(f.tierIdx),
+				IsPartial:       remaining > 1e-9,
+				FillPrice:       f.lookup.Px,
+				CloseQty:        f.lookup.FilledQty,
+				RemainingQty:    remaining,
+				RealizedPnL:     lastBookedTradePnL(s),
+				HasPnL:          true,
+				ExchangeOrderID: oidStr,
+			})
 		}
 	}
 	// Finalize any residual at zero PnL. Hits when cumulative TP fills under-

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -3185,7 +3185,7 @@ func TestReconcilePositionSLClose_UsesFilledQtyFromLookup(t *testing.T) {
 	logger := newTestLogger(t)
 
 	// On-chain is flat → reconcileHyperliquidPositionsWithResolver closes position.
-	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger)
+	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil)
 	if !changed {
 		t.Fatal("expected changed=true")
 	}
@@ -3234,7 +3234,7 @@ func TestReconcilePositionSLClose_NoFillFallsThroughToExternal(t *testing.T) {
 	})
 	logger := newTestLogger(t)
 	startCash := ss.Cash
-	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger)
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil)
 
 	if len(ss.ClosedPositions) != 1 {
 		t.Fatalf("ClosedPositions = %d, want 1", len(ss.ClosedPositions))
@@ -3350,7 +3350,7 @@ func TestReconcilePosition_TPFillsAttributedNotSL(t *testing.T) {
 	logger := newTestLogger(t)
 
 	startCash := ss.Cash
-	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger)
+	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil)
 	if !changed {
 		t.Fatal("expected changed=true")
 	}
@@ -3402,7 +3402,7 @@ func TestReconcilePosition_SLFillStillTakesSLPath(t *testing.T) {
 		return HLFillLookup{}, false
 	})
 	logger := newTestLogger(t)
-	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger)
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil)
 
 	if len(ss.ClosedPositions) != 1 || ss.ClosedPositions[0].CloseReason != "stop_loss" {
 		t.Fatalf("expected one ClosedPosition with reason=stop_loss, got %+v", ss.ClosedPositions)
@@ -3445,7 +3445,7 @@ func TestReconcilePosition_PartialTPFillResidualZeroPnL(t *testing.T) {
 	})
 	logger := newTestLogger(t)
 	startCash := ss.Cash
-	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger)
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil)
 
 	if _, open := ss.Positions["ETH"]; open {
 		t.Fatal("ETH should be removed even when TP fills under-shoot")
@@ -3483,7 +3483,7 @@ func TestReconcilePosition_NoFillsFallsBackToZeroPnL(t *testing.T) {
 	resolver := noFillFeeResolver
 	logger := newTestLogger(t)
 	startCash := ss.Cash
-	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger)
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil)
 
 	if _, open := ss.Positions["ETH"]; open {
 		t.Fatal("ETH should be removed even when no fills found")
@@ -3527,7 +3527,7 @@ func TestReconcilePosition_AllTPOIDsZeroedSLNotFilled(t *testing.T) {
 	})
 	logger := newTestLogger(t)
 	startCash := ss.Cash
-	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger)
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil)
 
 	if _, open := ss.Positions["ETH"]; open {
 		t.Fatal("ETH position should be removed after reconcile")
@@ -3580,7 +3580,7 @@ func TestAttemptCloseFromTPFills_CoinSizeSLFallbackDoesNotStarveTP(t *testing.T)
 	})
 	logger := newTestLogger(t)
 
-	if !hlAttemptCloseFromTPFills(ss, "ETH", ss.Positions["ETH"], resolver, logger) {
+	if !hlAttemptCloseFromTPFills(ss, "ETH", ss.Positions["ETH"], resolver, logger, nil) {
 		t.Fatal("expected TP attribution to proceed (SL gate must reject non-OID-match)")
 	}
 	if _, open := ss.Positions["ETH"]; open {

--- a/scheduler/hyperliquid_sole_owner_tp_test.go
+++ b/scheduler/hyperliquid_sole_owner_tp_test.go
@@ -228,6 +228,69 @@ func TestSoleOwnerTPFinal_FullCloseAtTPPrice_NotSL(t *testing.T) {
 	}
 }
 
+// TestSoleOwnerTPFullClose_TPOIDsLag_EmitsProtectionDM covers #754: when the
+// account is already flat but pos.TPOIDs still shows a positive tier-1 OID
+// (protection-sync has not zeroed it yet), tryBookSoleOwnerTPFill returns
+// false and hlAttemptCloseFromTPFills books the TP fill — that path must still
+// enqueue a ProtectionFillAlert for the owner DM.
+func TestSoleOwnerTPFullClose_TPOIDsLag_EmitsProtectionDM(t *testing.T) {
+	const (
+		entryPx     = 2000.0
+		entryATR    = 50.0
+		fullQty     = 0.2
+		expectedTP2 = entryPx + 3.0*entryATR
+	)
+	ss := &StrategyState{
+		ID:   "hl-tp-sole",
+		Cash: 100,
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol: "ETH", Quantity: fullQty, InitialQuantity: fullQty,
+				AvgCost: entryPx, EntryATR: entryATR, Side: "long",
+				Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-tp-sole",
+				TPOIDs:            []int64{0, 222},
+				StopLossOID:       42,
+				StopLossTriggerPx: 1900,
+			},
+		},
+	}
+	resolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
+		switch oid {
+		case 222:
+			return HLFillLookup{Fee: 0.05, FilledQty: fullQty, Px: expectedTP2, OID: 222, Count: 1}, true
+		case 42:
+			return HLFillLookup{}, false
+		default:
+			return HLFillLookup{}, false
+		}
+	})
+	var alerts []ProtectionFillAlert
+	logger := newTestLogger(t)
+
+	changed := reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", nil, resolver, logger, &alerts)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if _, open := ss.Positions["ETH"]; open {
+		t.Fatal("position should be closed after TP fill attribution")
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("pendingAlerts = %d, want 1", len(alerts))
+	}
+	if alerts[0].FillType != "TP2" {
+		t.Errorf("FillType = %q, want TP2", alerts[0].FillType)
+	}
+	if alerts[0].IsPartial {
+		t.Error("IsPartial = true, want false (full close)")
+	}
+	if len(ss.TradeHistory) != 1 {
+		t.Fatalf("TradeHistory = %d, want 1", len(ss.TradeHistory))
+	}
+	if math.Abs(ss.TradeHistory[0].Price-expectedTP2) > 1e-9 {
+		t.Errorf("trade.Price = %g, want %g", ss.TradeHistory[0].Price, expectedTP2)
+	}
+}
+
 // TestSoleOwnerTPFinal_PartialCloseShort verifies the short-side mirror of the
 // partial path — drop sign math + TP price formula.
 func TestSoleOwnerTPFinal_PartialCloseShort(t *testing.T) {

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -550,7 +550,7 @@ func TestReconcileHyperliquidPositions_RestingStopLossFillBooksPnL(t *testing.T)
 	resolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
 		return HLFillLookup{Fee: 0.05, FilledQty: 0.1, Px: 3104, Count: 1, OID: oid}, true
 	})
-	changed := reconcileHyperliquidPositionsWithResolver(state, "ETH", nil, resolver, logger)
+	changed := reconcileHyperliquidPositionsWithResolver(state, "ETH", nil, resolver, logger, nil)
 	if !changed {
 		t.Fatalf("expected reconcile to report a state change")
 	}
@@ -609,7 +609,7 @@ func TestReconcileHyperliquidPositions_RestingStopLossFillClosesShortWithBuy(t *
 	resolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
 		return HLFillLookup{Fee: 0.05, FilledQty: 0.1, Px: 3296, Count: 1, OID: oid}, true
 	})
-	changed := reconcileHyperliquidPositionsWithResolver(state, "ETH", nil, resolver, logger)
+	changed := reconcileHyperliquidPositionsWithResolver(state, "ETH", nil, resolver, logger, nil)
 	if !changed {
 		t.Fatalf("expected reconcile to report a state change")
 	}


### PR DESCRIPTION
Closes #754.

When `tryBookSoleOwnerTPFill` returns false (e.g. flat on-chain but a TP OID is still positive until protection-sync runs), the close is booked via `hlAttemptCloseFromTPFills`, which previously never appended `ProtectionFillAlert`. Plumb `pendingAlerts` through `reconcileHyperliquidPositionsWithResolver` and enqueue alerts after each successful TP fill booking.

Adds `TestSoleOwnerTPFullClose_TPOIDsLag_EmitsProtectionDM` regression coverage.

Made with [Cursor](https://cursor.com)