### PR TITLE
fix(hl): confirm userFills SL OID on shared-coin reconcile (#756)

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -543,7 +543,7 @@ func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym st
 			// mis-attributed to the cancelled SL at its trigger price. Match must
 			// be by exact OID; the coin+size fallback can spuriously hit a TP
 			// fill of the same size.
-			slConfirmed := useFillFee && lookup.OID == statePos.StopLossOID && lookup.FilledQty > 1e-9
+			slConfirmed := hlReconcileSLFillConfirmed(lookup, useFillFee, statePos.StopLossOID)
 			if slConfirmed {
 				// #621: When userFills returned a real fill qty smaller than the virtual
 				// position (e.g. SL was placed at the on-chain size after a manual TP
@@ -840,14 +840,16 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 							}
 							pos.Quantity = lookup.FilledQty
 						}
+						// Snapshot alertSide/alertQty/alertTriggerPx before
+						// recordPerpsStopLossCloseWithFillFee mutates state.
+						// lastBookedTradePnL relies on the just-completed RecordTrade
+						// inside the booker; do not insert another RecordTrade between
+						// here and pendingAlerts append.
 						alertSide := pos.Side
 						alertQty := pos.Quantity
 						alertTriggerPx := pos.StopLossTriggerPx
 						if recordPerpsStopLossCloseWithFillFee(ss, coin, pos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "hl_sync_stop_loss", logger) {
 							changed = true
-							// lastBookedTradePnL relies on the just-completed
-							// RecordTrade inside the booker; do not insert another
-							// RecordTrade between here and the booker call.
 							pendingAlerts = append(pendingAlerts, ProtectionFillAlert{
 								StrategyID:      id,
 								Symbol:          coin,
@@ -962,6 +964,11 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 								}
 								slOwnerPos.Quantity = lookup.FilledQty
 							}
+							// Snapshot alertSide/alertQty/alertTriggerPx before
+							// recordPerpsStopLossCloseWithFillFee mutates state.
+							// lastBookedTradePnL relies on the just-completed RecordTrade
+							// inside the booker; do not insert another RecordTrade between
+							// here and pendingAlerts append.
 							alertSide := slOwnerPos.Side
 							alertQty := slOwnerPos.Quantity
 							alertTriggerPx := slOwnerPos.StopLossTriggerPx
@@ -969,9 +976,6 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 								changed = true
 								virtualQty = expectedResidual
 								delta = virtualQty - onChainQty
-								// lastBookedTradePnL relies on the just-completed
-								// RecordTrade inside the booker; do not insert another
-								// RecordTrade between here and the booker call.
 								pendingAlerts = append(pendingAlerts, ProtectionFillAlert{
 									StrategyID:      slOwnerID,
 									Symbol:          coin,

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -24,6 +24,13 @@ type HLPosition struct {
 	Leverage   float64 // on-chain leverage value (#254)
 }
 
+// hlReconcileSLFillConfirmed mirrors the #685 sole-owner vanish gate for
+// shared-coin Detectors 1 and 2: attribute hl_sync_stop_loss only when
+// userFills confirms this exact SL OID filled with positive size (#756).
+func hlReconcileSLFillConfirmed(lookup HLFillLookup, useFillFee bool, stopLossOID int64) bool {
+	return useFillFee && lookup.OID == stopLossOID && lookup.FilledQty > 1e-9
+}
+
 var hlMainnetURL = "https://api.hyperliquid.xyz"
 
 // hyperliquidLiveCloseScript is the path to the Python close helper. Exposed as
@@ -803,10 +810,11 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 			// quantity, while each non-owner peer here queries with its own
 			// per-strategy pos.Quantity. The hlReconcileFillSizeTolerance
 			// (1e-4) won't accept that mismatch, so peers fall back to the
-			// modeled fee. The OID-keyed lookup still works for the SL owner.
-			// Per-peer fee accuracy is only achievable when each peer's qty
-			// happens to equal the aggregate close size (e.g. a sole-peer
-			// close, or a closer that happened to size at one peer's qty).
+			// modeled fee. SL attribution additionally requires an OID-keyed
+			// userFills hit matching Position.StopLossOID (#756); otherwise the
+			// peer is closed as hl_sync_external (mark or zero PnL). Per-peer fee
+			// accuracy on external closes is only achievable when each peer's qty
+			// happens to equal the aggregate close size.
 			for _, id := range stratIDs {
 				ss := state.Strategies[id]
 				if ss == nil {
@@ -824,33 +832,57 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 					lookup, useFillFee := resolveFee(coin, pos.StopLossOID, pos.Quantity)
 					oidStr := strconv.FormatInt(pos.StopLossOID, 10)
 					logHyperliquidReconcileFillLookup(logger, coin, pos.StopLossOID, pos.Quantity, lookup, useFillFee)
-					if useFillFee && lookup.FilledQty > 1e-9 && lookup.FilledQty < pos.Quantity-1e-9 {
-						if logger != nil {
-							logger.Info("hl-sync: %s SL close qty adjusted %.6f → %.6f (actual fill from userFills)", coin, pos.Quantity, lookup.FilledQty)
+					slConfirmed := hlReconcileSLFillConfirmed(lookup, useFillFee, pos.StopLossOID)
+					if slConfirmed {
+						if lookup.FilledQty < pos.Quantity-1e-9 {
+							if logger != nil {
+								logger.Info("hl-sync: %s SL close qty adjusted %.6f → %.6f (actual fill from userFills)", coin, pos.Quantity, lookup.FilledQty)
+							}
+							pos.Quantity = lookup.FilledQty
 						}
-						pos.Quantity = lookup.FilledQty
-					}
-					alertSide := pos.Side
-					alertQty := pos.Quantity
-					alertTriggerPx := pos.StopLossTriggerPx
-					if recordPerpsStopLossCloseWithFillFee(ss, coin, pos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "hl_sync_stop_loss", logger) {
-						changed = true
-						// lastBookedTradePnL relies on the just-completed
-						// RecordTrade inside the booker; do not insert another
-						// RecordTrade between here and the booker call.
-						pendingAlerts = append(pendingAlerts, ProtectionFillAlert{
-							StrategyID:      id,
-							Symbol:          coin,
-							Side:            alertSide,
-							FillType:        "SL",
-							IsPartial:       false,
-							FillPrice:       alertTriggerPx,
-							CloseQty:        alertQty,
-							RemainingQty:    0,
-							RealizedPnL:     lastBookedTradePnL(ss),
-							HasPnL:          true,
-							ExchangeOrderID: oidStr,
-						})
+						alertSide := pos.Side
+						alertQty := pos.Quantity
+						alertTriggerPx := pos.StopLossTriggerPx
+						if recordPerpsStopLossCloseWithFillFee(ss, coin, pos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "hl_sync_stop_loss", logger) {
+							changed = true
+							// lastBookedTradePnL relies on the just-completed
+							// RecordTrade inside the booker; do not insert another
+							// RecordTrade between here and the booker call.
+							pendingAlerts = append(pendingAlerts, ProtectionFillAlert{
+								StrategyID:      id,
+								Symbol:          coin,
+								Side:            alertSide,
+								FillType:        "SL",
+								IsPartial:       false,
+								FillPrice:       alertTriggerPx,
+								CloseQty:        alertQty,
+								RemainingQty:    0,
+								RealizedPnL:     lastBookedTradePnL(ss),
+								HasPnL:          true,
+								ExchangeOrderID: oidStr,
+							})
+						}
+					} else {
+						if useFillFee && logger != nil {
+							logger.Info("hl-sync: %s Detector 1 SL OID %s unfilled — routing external (matched oid=%d qty=%.6f)", coin, oidStr, lookup.OID, lookup.FilledQty)
+						} else if logger != nil {
+							logger.Info("hl-sync: %s Detector 1 SL OID %s unfilled — routing external (userFills miss)", coin, oidStr)
+						}
+						if mark, ok := prices[coin]; ok && mark > 0 {
+							lookupExt, useFillFeeExt := resolveFee(coin, 0, pos.Quantity)
+							logHyperliquidReconcileFillLookup(logger, coin, 0, pos.Quantity, lookupExt, useFillFeeExt)
+							if recordPerpsExternalCloseWithFillFee(ss, coin, mark, lookupExt.Fee, useFillFeeExt, "", "hl_sync_external", logger) {
+								changed = true
+							}
+						} else {
+							recordClosedPosition(ss, pos, 0, 0, "hl_sync_external", now)
+							delete(ss.Positions, coin)
+							clearATRMultMissingEntryATRWarningOnHLPerpsClose(ss, coin)
+							if logger != nil {
+								logger.Info("hl-sync: %s position (%.6f %s) no longer on-chain, removing (Detector 1 external close, no mark price)", coin, pos.Quantity, pos.Side)
+							}
+							changed = true
+						}
 					}
 				} else if mark, ok := prices[coin]; ok && mark > 0 {
 					// #584: credit s.Cash with mark-based PnL so the per-strategy
@@ -922,35 +954,63 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 						lookup, useFillFee := resolveFee(coin, slOwnerPos.StopLossOID, slOwnerPos.Quantity)
 						oidStr := strconv.FormatInt(slOwnerPos.StopLossOID, 10)
 						logHyperliquidReconcileFillLookup(logger, coin, slOwnerPos.StopLossOID, slOwnerPos.Quantity, lookup, useFillFee)
-						if useFillFee && lookup.FilledQty > 1e-9 && lookup.FilledQty < slOwnerPos.Quantity-1e-9 {
-							if logger != nil {
-								logger.Info("hl-sync: %s SL close qty adjusted %.6f → %.6f (actual fill from userFills)", coin, slOwnerPos.Quantity, lookup.FilledQty)
+						slConfirmed := hlReconcileSLFillConfirmed(lookup, useFillFee, slOwnerPos.StopLossOID)
+						if slConfirmed {
+							if lookup.FilledQty < slOwnerPos.Quantity-1e-9 {
+								if logger != nil {
+									logger.Info("hl-sync: %s SL close qty adjusted %.6f → %.6f (actual fill from userFills)", coin, slOwnerPos.Quantity, lookup.FilledQty)
+								}
+								slOwnerPos.Quantity = lookup.FilledQty
 							}
-							slOwnerPos.Quantity = lookup.FilledQty
-						}
-						alertSide := slOwnerPos.Side
-						alertQty := slOwnerPos.Quantity
-						alertTriggerPx := slOwnerPos.StopLossTriggerPx
-						if recordPerpsStopLossCloseWithFillFee(ownerSS, coin, slOwnerPos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "hl_sync_stop_loss", logger) {
-							changed = true
-							virtualQty = expectedResidual
-							delta = virtualQty - onChainQty
-							// lastBookedTradePnL relies on the just-completed
-							// RecordTrade inside the booker; do not insert another
-							// RecordTrade between here and the booker call.
-							pendingAlerts = append(pendingAlerts, ProtectionFillAlert{
-								StrategyID:      slOwnerID,
-								Symbol:          coin,
-								Side:            alertSide,
-								FillType:        "SL",
-								IsPartial:       false,
-								FillPrice:       alertTriggerPx,
-								CloseQty:        alertQty,
-								RemainingQty:    0,
-								RealizedPnL:     lastBookedTradePnL(ownerSS),
-								HasPnL:          true,
-								ExchangeOrderID: oidStr,
-							})
+							alertSide := slOwnerPos.Side
+							alertQty := slOwnerPos.Quantity
+							alertTriggerPx := slOwnerPos.StopLossTriggerPx
+							if recordPerpsStopLossCloseWithFillFee(ownerSS, coin, slOwnerPos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "hl_sync_stop_loss", logger) {
+								changed = true
+								virtualQty = expectedResidual
+								delta = virtualQty - onChainQty
+								// lastBookedTradePnL relies on the just-completed
+								// RecordTrade inside the booker; do not insert another
+								// RecordTrade between here and the booker call.
+								pendingAlerts = append(pendingAlerts, ProtectionFillAlert{
+									StrategyID:      slOwnerID,
+									Symbol:          coin,
+									Side:            alertSide,
+									FillType:        "SL",
+									IsPartial:       false,
+									FillPrice:       alertTriggerPx,
+									CloseQty:        alertQty,
+									RemainingQty:    0,
+									RealizedPnL:     lastBookedTradePnL(ownerSS),
+									HasPnL:          true,
+									ExchangeOrderID: oidStr,
+								})
+							}
+						} else {
+							if useFillFee && logger != nil {
+								logger.Info("hl-sync: %s Detector 2 SL OID %s unfilled — routing external (matched oid=%d qty=%.6f)", coin, oidStr, lookup.OID, lookup.FilledQty)
+							} else if logger != nil {
+								logger.Info("hl-sync: %s Detector 2 SL OID %s unfilled — routing external (userFills miss)", coin, oidStr)
+							}
+							if mark, ok := prices[coin]; ok && mark > 0 {
+								lookupExt, useFillFeeExt := resolveFee(coin, 0, slOwnerPos.Quantity)
+								logHyperliquidReconcileFillLookup(logger, coin, 0, slOwnerPos.Quantity, lookupExt, useFillFeeExt)
+								if recordPerpsExternalCloseWithFillFee(ownerSS, coin, mark, lookupExt.Fee, useFillFeeExt, "", "hl_sync_external", logger) {
+									changed = true
+									virtualQty = expectedResidual
+									delta = virtualQty - onChainQty
+								}
+							} else {
+								recordClosedPosition(ownerSS, slOwnerPos, 0, 0, "hl_sync_external", now)
+								delete(ownerSS.Positions, coin)
+								clearATRMultMissingEntryATRWarningOnHLPerpsClose(ownerSS, coin)
+								if logger != nil {
+									logger.Info("hl-sync: %s position (%.6f %s) no longer on-chain, removing (Detector 2 external close, no mark price)", coin, slOwnerPos.Quantity, slOwnerPos.Side)
+								}
+								changed = true
+								virtualQty = expectedResidual
+								delta = virtualQty - onChainQty
+							}
 						}
 					}
 				}

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -1248,7 +1248,7 @@ func hlAttemptCloseFromTPFills(s *StrategyState, sym string, pos *Position, reso
 	// the same size (lookup.OID != StopLossOID) doesn't masquerade as an SL
 	// fill and starve TP attribution.
 	if pos.StopLossOID > 0 {
-		if lookup, slFilled := resolveFee(sym, pos.StopLossOID, pos.Quantity); slFilled && lookup.OID == pos.StopLossOID && lookup.FilledQty > 1e-9 {
+		if lookup, slFilled := resolveFee(sym, pos.StopLossOID, pos.Quantity); hlReconcileSLFillConfirmed(lookup, slFilled, pos.StopLossOID) {
 			return false
 		}
 	}

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -470,6 +470,10 @@ func tryBookSoleOwnerTPFill(
 // resolver is expected to do pure in-memory cache reads when called under
 // mu.Lock() (see buildCachedHyperliquidReconcileFillResolver) — never make
 // HTTP calls.
+//
+// When pendingAlerts is non-nil, hlAttemptCloseFromTPFills appends TP fill
+// alerts here (same contract as tryBookSoleOwnerTPFill) for owner DM flush
+// after mu.Unlock (#757 re-review).
 func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym string, positions []HLPosition, resolveFee hlReconcileFillResolver, logger *StrategyLogger, pendingAlerts *[]ProtectionFillAlert) bool {
 	changed := false
 
@@ -1229,11 +1233,14 @@ func hyperliquidHasClearedTPTier(sc StrategyConfig, pos *Position, closeQty floa
 //
 // Returns false (no mutation) when no TP attribution is possible; the caller
 // then falls through to the legacy SL-trigger-price path.
+//
+// When pendingAlerts is non-nil, each successful TP partial book appends a
+// ProtectionFillAlert (same ordering contract as tryBookSoleOwnerTPFill) so
+// sole-owner cycle-ordering races still emit owner TP fill DMs (#757).
 func hlAttemptCloseFromTPFills(s *StrategyState, sym string, pos *Position, resolveFee hlReconcileFillResolver, logger *StrategyLogger, pendingAlerts *[]ProtectionFillAlert) bool {
 	if s == nil || pos == nil || len(pos.TPOIDs) == 0 || resolveFee == nil {
 		return false
 	}
-	alertSide := pos.Side
 	// If the SL OID has fills, leave attribution to the existing SL path —
 	// it knows how to handle the #621 "SL fired on the post-TP residual"
 	// case and we don't want to double-book by also crediting TPs here.
@@ -1265,6 +1272,11 @@ func hlAttemptCloseFromTPFills(s *StrategyState, sym string, pos *Position, reso
 		return false
 	}
 	for _, f := range fills {
+		curBefore := s.Positions[sym]
+		if curBefore == nil {
+			break
+		}
+		alertSide := curBefore.Side
 		oidStr := strconv.FormatInt(f.oid, 10)
 		logHyperliquidReconcileFillLookup(logger, sym, f.oid, f.lookup.FilledQty, f.lookup, true)
 		reason := fmt.Sprintf("hl_sync_tp%d_fill", f.tierIdx+1)

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1503,6 +1503,72 @@ func TestReconcileSharedCoin_Detector1_WrongOIDInUserfillsBooksExternal(t *testi
 	}
 }
 
+// TestReconcileSharedCoin_Detector2_WrongOIDInUserfillsBooksExternal mirrors
+// TestReconcileSharedCoin_Detector1_WrongOIDInUserfillsBooksExternal for
+// Detector 2 (SL-owner partial): on-chain residual matches peer-only geometry
+// but userFills returns a non-matching OID for the SL query — must not book
+// hl_sync_stop_loss at the trigger (#756).
+func TestReconcileSharedCoin_Detector2_WrongOIDInUserfillsBooksExternal(t *testing.T) {
+	const mark = 3020.0
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-eth": {
+				ID: "hl-owner-eth", Cash: 1000, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 1.0, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth",
+						StopLossOID: 4242, StopLossTriggerPx: 2900},
+				},
+			},
+			"hl-peer-eth": {
+				ID: "hl-peer-eth", Cash: 500, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-peer-eth"},
+				},
+			},
+		},
+	}
+	scs := []StrategyConfig{
+		{ID: "hl-owner-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-peer-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 3000, Leverage: 10}}
+	prices := map[string]float64{"ETH": mark}
+
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(_, coin string, oid int64, qty float64) (HLFillLookup, bool) {
+		if oid == 4242 {
+			return HLFillLookup{Fee: 0.1, FilledQty: 1.0, Count: 1, OID: 9999}, true
+		}
+		_ = coin
+		_ = qty
+		return HLFillLookup{}, false
+	}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, positions, prices, "0xtest", nil, false)
+
+	owner := state.Strategies["hl-owner-eth"]
+	if len(owner.ClosedPositions) != 1 {
+		t.Fatalf("owner ClosedPositions = %d, want 1", len(owner.ClosedPositions))
+	}
+	if owner.ClosedPositions[0].CloseReason != "hl_sync_external" {
+		t.Errorf("owner CloseReason = %q, want hl_sync_external (wrong userFills OID)", owner.ClosedPositions[0].CloseReason)
+	}
+	if owner.ClosedPositions[0].ClosePrice != mark {
+		t.Errorf("owner ClosePrice = %v, want mark %v", owner.ClosedPositions[0].ClosePrice, mark)
+	}
+
+	peer := state.Strategies["hl-peer-eth"]
+	p := peer.Positions["ETH"]
+	if p == nil || math.Abs(p.Quantity-0.5) > 1e-9 || p.Side != "long" {
+		t.Errorf("peer ETH = %+v, want 0.5 long unchanged", p)
+	}
+}
+
 func TestReconcileSharedCoin_TPPartialFill_DecrementsOwnerAndBooksPnL(t *testing.T) {
 	const ownerStartCash = 1000.0
 	const ownerQty = 0.5

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1538,12 +1538,10 @@ func TestReconcileSharedCoin_Detector2_WrongOIDInUserfillsBooksExternal(t *testi
 
 	origLookup := lookupHyperliquidReconcileFillFee
 	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
-	lookupHyperliquidReconcileFillFee = func(_, coin string, oid int64, qty float64) (HLFillLookup, bool) {
+	lookupHyperliquidReconcileFillFee = func(_, _ string, oid int64, _ float64) (HLFillLookup, bool) {
 		if oid == 4242 {
 			return HLFillLookup{Fee: 0.1, FilledQty: 1.0, Count: 1, OID: 9999}, true
 		}
-		_ = coin
-		_ = qty
 		return HLFillLookup{}, false
 	}
 
@@ -3513,10 +3511,17 @@ func TestReconcilePosition_TPFillsAttributedNotSL(t *testing.T) {
 	})
 	logger := newTestLogger(t)
 
+	var alerts []ProtectionFillAlert
 	startCash := ss.Cash
-	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil)
+	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, &alerts)
 	if !changed {
 		t.Fatal("expected changed=true")
+	}
+	if len(alerts) != 2 {
+		t.Fatalf("pendingAlerts = %d, want 2 (TP1+TP2 fill DMs)", len(alerts))
+	}
+	if alerts[0].FillType != "TP1" || alerts[1].FillType != "TP2" {
+		t.Errorf("FillType = %q, %q, want TP1, TP2", alerts[0].FillType, alerts[1].FillType)
 	}
 	if _, open := ss.Positions["ETH"]; open {
 		t.Fatal("ETH position should be removed after TP-fill attribution")
@@ -3744,7 +3749,8 @@ func TestAttemptCloseFromTPFills_CoinSizeSLFallbackDoesNotStarveTP(t *testing.T)
 	})
 	logger := newTestLogger(t)
 
-	if !hlAttemptCloseFromTPFills(ss, "ETH", ss.Positions["ETH"], resolver, logger, nil) {
+	var tpAlerts []ProtectionFillAlert
+	if !hlAttemptCloseFromTPFills(ss, "ETH", ss.Positions["ETH"], resolver, logger, &tpAlerts) {
 		t.Fatal("expected TP attribution to proceed (SL gate must reject non-OID-match)")
 	}
 	if _, open := ss.Positions["ETH"]; open {
@@ -3755,5 +3761,8 @@ func TestAttemptCloseFromTPFills_CoinSizeSLFallbackDoesNotStarveTP(t *testing.T)
 	}
 	if math.Abs(ss.TradeHistory[0].Price-tpPx) > 1e-9 {
 		t.Errorf("Trade.Price = %g, want %g (TP fill price)", ss.TradeHistory[0].Price, tpPx)
+	}
+	if len(tpAlerts) != 1 || tpAlerts[0].FillType != "TP1" {
+		t.Errorf("tpAlerts = %+v, want one TP1 protection alert", tpAlerts)
 	}
 }

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1174,9 +1174,18 @@ func TestReconcileSharedCoin_OwnerStopLossFired_ClosesOwnerOnly(t *testing.T) {
 	// Owner fired — on-chain residual is only the peer's 0.5 long.
 	positions := []HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 3000, Leverage: 10}}
 
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(_, _ string, oid int64, _ float64) (HLFillLookup, bool) {
+		if oid == 42 {
+			return HLFillLookup{Fee: 0.05, FilledQty: 1.0, Px: 2900, Count: 1, OID: 42}, true
+		}
+		return HLFillLookup{}, false
+	}
+
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "0xtest", nil, false)
 
 	// Owner position must be closed and recorded.
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
@@ -1239,9 +1248,18 @@ func TestReconcileSharedCoin_OwnerStopLossFired_Short(t *testing.T) {
 	// Short positions: on-chain residual after owner's stop = -0.3 (peer only).
 	positions := []HLPosition{{Coin: "ETH", Size: -0.3, EntryPrice: 3000, Leverage: 10}}
 
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(_, _ string, oid int64, _ float64) (HLFillLookup, bool) {
+		if oid == 99 {
+			return HLFillLookup{Fee: 0.04, FilledQty: 0.8, Px: 3100, Count: 1, OID: 99}, true
+		}
+		return HLFillLookup{}, false
+	}
+
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "0xtest", nil, false)
 
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
 		t.Error("owner short ETH position should be nil after SL reconciliation")
@@ -1253,8 +1271,9 @@ func TestReconcileSharedCoin_OwnerStopLossFired_Short(t *testing.T) {
 }
 
 // TestReconcileSharedCoin_AllPositionsClosedExternally verifies that when
-// on-chain is fully flat, all peers are closed: SL owner via hl_sync_stop_loss,
-// others via hl_sync_external with close price 0.
+// on-chain is fully flat, all peers are closed: SL owner via hl_sync_stop_loss
+// when userFills confirms the SL OID (#756), others via hl_sync_external with
+// close price 0 when no mark is supplied.
 func TestReconcileSharedCoin_AllPositionsClosedExternally(t *testing.T) {
 	state := &AppState{
 		Strategies: map[string]*StrategyState{
@@ -1283,9 +1302,19 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally(t *testing.T) {
 	// On-chain: fully flat (aggregate stop sweep / manual close).
 	positions := []HLPosition{}
 
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(_, _ string, oid int64, qty float64) (HLFillLookup, bool) {
+		if oid == 7 {
+			return HLFillLookup{Fee: 0.02, FilledQty: 1.0, Px: 2800, Count: 1, OID: 7}, true
+		}
+		_ = qty
+		return HLFillLookup{}, false
+	}
+
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "0xtest", nil, false)
 
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
 		t.Error("owner ETH position should be nil")
@@ -1342,10 +1371,23 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally_CreditsPeerCash(t *tes
 	}
 	positions := []HLPosition{}
 	prices := map[string]float64{"ETH": mark}
+	wantPeerFee := peerQty * mark * HyperliquidTakerFeePct
+
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(_, coin string, oid int64, qty float64) (HLFillLookup, bool) {
+		if oid == 7 && coin == "ETH" {
+			return HLFillLookup{Fee: 0.02, FilledQty: 1.0, Px: 2800, Count: 1, OID: 7}, true
+		}
+		if oid == 0 && coin == "ETH" && math.Abs(qty-peerQty) < 1e-9 {
+			return HLFillLookup{Fee: wantPeerFee, Count: 1}, true
+		}
+		return HLFillLookup{}, false
+	}
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
+	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "0xtest", nil, false)
 
 	peer := state.Strategies["hl-peer-eth"]
 	if peer.Positions["ETH"] != nil {
@@ -1402,6 +1444,62 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally_CreditsPeerCash(t *tes
 	}
 	if len(owner.ClosedPositions) != 1 || owner.ClosedPositions[0].CloseReason != "hl_sync_stop_loss" {
 		t.Errorf("owner ClosedPositions wrong: %+v", owner.ClosedPositions)
+	}
+}
+
+// TestReconcileSharedCoin_Detector1_WrongOIDInUserfillsBooksExternal is a #756
+// regression: userFills hit for the SL lookup query but with a non-matching OID
+// must not book hl_sync_stop_loss — fall back to mark-based hl_sync_external.
+func TestReconcileSharedCoin_Detector1_WrongOIDInUserfillsBooksExternal(t *testing.T) {
+	const mark = 61000.0
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-btc": {
+				ID: "hl-owner-btc", Cash: 10000, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"BTC": {Symbol: "BTC", Quantity: 0.2, AvgCost: 60000, Side: "long",
+						Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-owner-btc",
+						StopLossOID: 5005, StopLossTriggerPx: 58000},
+				},
+			},
+			"hl-peer-btc": {
+				ID: "hl-peer-btc", Cash: 10000, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"BTC": {Symbol: "BTC", Quantity: 0.1, AvgCost: 60500, Side: "long",
+						Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-peer-btc"},
+				},
+			},
+		},
+	}
+	scs := []StrategyConfig{
+		{ID: "hl-owner-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"hold", "BTC", "1h", "--mode=live"}, Leverage: 5},
+		{ID: "hl-peer-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"hold", "BTC", "1h", "--mode=live"}, Leverage: 5},
+	}
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(_, coin string, oid int64, qty float64) (HLFillLookup, bool) {
+		if oid == 5005 {
+			return HLFillLookup{Fee: 1.0, FilledQty: 0.2, Count: 1, OID: 9999}, true
+		}
+		if oid == 0 && coin == "BTC" && math.Abs(qty-0.1) < 1e-9 {
+			return HLFillLookup{Fee: 0.05, Count: 1}, true
+		}
+		return HLFillLookup{}, false
+	}
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	prices := map[string]float64{"BTC": mark}
+	reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, nil, prices, "0xtest", nil, false)
+
+	owner := state.Strategies["hl-owner-btc"]
+	if len(owner.ClosedPositions) != 1 {
+		t.Fatalf("owner ClosedPositions = %d, want 1", len(owner.ClosedPositions))
+	}
+	if owner.ClosedPositions[0].CloseReason != "hl_sync_external" {
+		t.Errorf("owner CloseReason = %q, want hl_sync_external (wrong userFills OID)", owner.ClosedPositions[0].CloseReason)
+	}
+	if owner.ClosedPositions[0].ClosePrice != mark {
+		t.Errorf("owner ClosePrice = %v, want mark %v", owner.ClosedPositions[0].ClosePrice, mark)
 	}
 }
 

--- a/scheduler/hyperliquid_fills_test.go
+++ b/scheduler/hyperliquid_fills_test.go
@@ -253,7 +253,8 @@ func TestReconcileHyperliquidAccountPositions_DetectorOneUsesFillFee(t *testing.
 	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
 	lookupHyperliquidReconcileFillFee = func(addr, coin string, oid int64, qty float64) (HLFillLookup, bool) {
 		if oid == 5005 {
-			return HLFillLookup{Fee: 2.50, Count: 1, OID: oid}, true
+			// #756: FilledQty + OID echo required for shared-coin SL attribution.
+			return HLFillLookup{Fee: 2.50, Count: 1, OID: oid, FilledQty: 0.2}, true
 		}
 		if oid == 0 && coin == "BTC" && qty > 0 {
 			return HLFillLookup{Fee: 0.75, Count: 1}, true


### PR DESCRIPTION
Closes #756.

Shared-coin Detectors 1 and 2 now require the same userFills confirmation as the sole-owner vanish path (#685): `lookup.OID == StopLossOID` and positive `FilledQty` before booking `hl_sync_stop_loss` or emitting an SL protection-fill alert. Unconfirmed closes route to `hl_sync_external` (mark when available, otherwise the existing zero-price removal).

Tests: stubbed indexer responses where SL attribution is intended; new regression when indexer returns a mismatched OID for the SL lookup query.

Made with [Cursor](https://cursor.com)