### PR TITLE
fix(hl): prevent sole-owner double TP fill booking (#758)

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -290,6 +290,29 @@ func reconcileHyperliquidPositionsForStrategy(
 	return reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, resolveFee, logger, pendingAlerts)
 }
 
+// stampSoleOwnerRecoveryTierConsumed mirrors post-protection-sync state for a
+// tier that tryBookSoleOwnerTPFill attributed via the cycle-ordering recovery
+// path (#758). Without this, pos.TPOIDs[i] stays positive until Python
+// protection-sync runs, and hlAttemptCloseFromTPFills on a later vanish
+// snapshot can book the same TP OID again.
+func stampSoleOwnerRecoveryTierConsumed(s *StrategyState, sym string, tierIdx int) {
+	pos := s.Positions[sym]
+	if pos == nil || tierIdx < 0 {
+		return
+	}
+	n := len(pos.TPOIDs)
+	if tierIdx >= n {
+		return
+	}
+	if len(pos.TPArmedTiers) < n {
+		ext := make([]bool, n)
+		copy(ext, pos.TPArmedTiers)
+		pos.TPArmedTiers = ext
+	}
+	pos.TPOIDs[tierIdx] = 0
+	pos.TPArmedTiers[tierIdx] = true
+}
+
 // tryBookSoleOwnerTPFill is the sole-owner TP attribution helper. Returns true
 // when a TP-tier fill was detected and booked via
 // recordPerpsExternalPartialCloseWithFillFee — covers both the partial-drop
@@ -315,7 +338,12 @@ func reconcileHyperliquidPositionsForStrategy(
 // fills (lookup.OID == pos.StopLossOID) and operator/CB closes (different OID)
 // don't mis-attribute. The booker shrinks pos.Quantity to match on-chain so a
 // later same-cycle protection-sync sees the fill, zeros TPOIDs[i] normally,
-// and the next cycle's reconcile finds no drift — no double-booking.
+// and the next cycle's reconcile finds no drift.
+//
+// Cycle-ordering recovery additionally stamps the consumed tier immediately
+// (#758) so a later vanish reconcile cannot re-book the same TP OID in
+// hlAttemptCloseFromTPFills while pos.TPOIDs[i] would otherwise still be
+// positive until applyHyperliquidProtectionSync runs.
 func tryBookSoleOwnerTPFill(
 	sc StrategyConfig,
 	stratState *StrategyState,
@@ -381,6 +409,7 @@ func tryBookSoleOwnerTPFill(
 	lookup, useFillFee := resolveFee(sym, 0, closeQty)
 	logHyperliquidReconcileFillLookup(logger, sym, 0, closeQty, lookup, useFillFee)
 
+	var soleOwnerRecoveryBook bool
 	tierIdx, hasCleared := hyperliquidClearedTPTier(sc, statePos, closeQty)
 	if !hasCleared {
 		// Cycle-ordering recovery (#672): protection-sync hasn't yet zeroed
@@ -408,10 +437,7 @@ func tryBookSoleOwnerTPFill(
 			return false
 		}
 		tierIdx = matched
-		// Leave pos.TPOIDs[matched] positive — protection-sync's Python
-		// pipeline re-detects the fill via userFills and zeros it through
-		// applyHyperliquidProtectionSync later this cycle (idempotent), which
-		// also feeds the plan-builder's "skip already-filled tiers" logic.
+		soleOwnerRecoveryBook = true
 	}
 
 	tpPrices := tieredTPATRPricesForRegime(sc, statePos.Side, statePos.AvgCost, statePos.EntryATR, statePos.Regime)
@@ -439,6 +465,9 @@ func tryBookSoleOwnerTPFill(
 		exchangeOrderID, "hl_sync_external_partial", logger,
 	) {
 		return false
+	}
+	if soleOwnerRecoveryBook {
+		stampSoleOwnerRecoveryTierConsumed(stratState, sym, tierIdx)
 	}
 
 	remaining := 0.0

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -295,8 +295,7 @@ func reconcileHyperliquidPositionsForStrategy(
 // path (#758). Without this, pos.TPOIDs[i] stays positive until Python
 // protection-sync runs, and hlAttemptCloseFromTPFills on a later vanish
 // snapshot can book the same TP OID again.
-func stampSoleOwnerRecoveryTierConsumed(s *StrategyState, sym string, tierIdx int) {
-	pos := s.Positions[sym]
+func stampSoleOwnerRecoveryTierConsumed(pos *Position, tierIdx int) {
 	if pos == nil || tierIdx < 0 {
 		return
 	}
@@ -466,12 +465,13 @@ func tryBookSoleOwnerTPFill(
 	) {
 		return false
 	}
-	if soleOwnerRecoveryBook {
-		stampSoleOwnerRecoveryTierConsumed(stratState, sym, tierIdx)
+	posAfter := stratState.Positions[sym]
+	if soleOwnerRecoveryBook && posAfter != nil {
+		stampSoleOwnerRecoveryTierConsumed(posAfter, tierIdx)
 	}
 
 	remaining := 0.0
-	if posAfter := stratState.Positions[sym]; posAfter != nil {
+	if posAfter != nil {
 		remaining = posAfter.Quantity
 	}
 	if pendingAlerts != nil {

--- a/scheduler/hyperliquid_sole_owner_tp_test.go
+++ b/scheduler/hyperliquid_sole_owner_tp_test.go
@@ -725,11 +725,70 @@ func TestSoleOwnerTP_CycleOrderingRecovery_BooksWhenUserFillsOIDMatchesTPOID(t *
 	if pos == nil {
 		t.Fatal("expected position to remain after partial close")
 	}
-	// TPOIDs are NOT zeroed inline — protection-sync zeros them later this
-	// cycle via applyHyperliquidProtectionSync (idempotent). Asserting the
-	// invariant locks in the contract with the protection-sync plan-builder.
-	if pos.TPOIDs[0] != tp1OID || pos.TPOIDs[1] != 222 {
-		t.Errorf("TPOIDs = %v, want [%d 222] (recovery path must not zero TPOIDs inline)", pos.TPOIDs, tp1OID)
+	// #758: recovery path stamps consumed tier immediately (TPOID 0 + armed)
+	// so vanish reconcile cannot re-book the same OID.
+	if pos.TPOIDs[0] != 0 || pos.TPOIDs[1] != 222 {
+		t.Errorf("TPOIDs = %v, want [0 222]", pos.TPOIDs)
+	}
+	if len(pos.TPArmedTiers) < 2 || !pos.TPArmedTiers[0] || pos.TPArmedTiers[1] {
+		t.Errorf("TPArmedTiers = %v, want [true false] (tier0 consumed)", pos.TPArmedTiers)
+	}
+}
+
+// TestSoleOwnerTP758_RecoveryStampsTierSoHlAttemptSkipsOID verifies that after
+// cycle-ordering recovery books TP1, hlAttemptCloseFromTPFills does not
+// attribute the same TP OID again (#758).
+func TestSoleOwnerTP758_RecoveryStampsTierSoHlAttemptSkipsOID(t *testing.T) {
+	const (
+		entryPx    = 2000.0
+		entryATR   = 50.0
+		fullQty    = 0.4
+		onChainQty = 0.2
+		tp1OID     = int64(111)
+		fillPx     = 2103.50
+		fillFee    = 0.05
+	)
+	ss := &StrategyState{
+		ID:   "hl-tp-sole",
+		Cash: 100,
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol: "ETH", Quantity: fullQty, InitialQuantity: fullQty,
+				AvgCost: entryPx, EntryATR: entryATR, Side: "long",
+				Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-tp-sole",
+				TPOIDs: []int64{tp1OID, 222},
+			},
+		},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: onChainQty, EntryPrice: entryPx, Leverage: 5}}
+	resolver := hlReconcileFillResolver(func(_ string, _ int64, qty float64) (HLFillLookup, bool) {
+		if math.Abs(qty-(fullQty-onChainQty)) < 1e-6 {
+			return HLFillLookup{Fee: fillFee, FilledQty: 0.2, Px: fillPx, OID: tp1OID, Count: 1}, true
+		}
+		return HLFillLookup{}, false
+	})
+	logger := newTestLogger(t)
+	if !reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, nil) {
+		t.Fatal("expected reconcile to return true")
+	}
+	if len(ss.TradeHistory) != 1 {
+		t.Fatalf("TradeHistory = %d, want 1", len(ss.TradeHistory))
+	}
+	pos := ss.Positions["ETH"]
+	if pos == nil {
+		t.Fatal("expected position after partial recovery")
+	}
+	dupResolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
+		if oid == tp1OID {
+			return HLFillLookup{Fee: fillFee, FilledQty: 0.2, Px: fillPx, OID: tp1OID, Count: 1}, true
+		}
+		return HLFillLookup{}, false
+	})
+	if hlAttemptCloseFromTPFills(ss, "ETH", pos, dupResolver, logger, nil) {
+		t.Fatal("hlAttemptCloseFromTPFills should not re-book TP1 after recovery stamped tier consumed")
+	}
+	if len(ss.TradeHistory) != 1 {
+		t.Fatalf("TradeHistory = %d after hlAttempt, want 1 (no duplicate TP1 book)", len(ss.TradeHistory))
 	}
 }
 


### PR DESCRIPTION
## Summary

After sole-owner **cycle-ordering recovery** books a TP partial in `tryBookSoleOwnerTPFill`, stamp the tier as consumed (`TPOIDs[i]=0`, `TPArmedTiers[i]=true`) so a later vanish reconcile cannot re-book the same OID in `hlAttemptCloseFromTPFills`.

## Test plan

- [x] `go test -C scheduler ./...`

Closes #758

Made with [Cursor](https://cursor.com)