### PR TITLE
feat(hl): reconcile fill hints for sync-protection (#759)

### DIFF
--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -372,7 +372,7 @@ func RunHyperliquidUpdateStopLoss(script, symbol, side string, size, triggerPx f
 
 // buildHyperliquidSyncProtectionArgv builds argv for check_hyperliquid.py
 // --sync-protection (used by RunHyperliquidSyncProtection and tests).
-func buildHyperliquidSyncProtectionArgv(symbol, side string, size, avgCost, entryATR, stopLossATRMult float64, tiers []hlProtectionTier, stopLossOID int64, tpOIDs []int64, tpArmedTiers []bool) []string {
+func buildHyperliquidSyncProtectionArgv(symbol, side string, size, avgCost, entryATR, stopLossATRMult float64, tiers []hlProtectionTier, stopLossOID int64, tpOIDs []int64, tpArmedTiers []bool, reconcileFillHintsJSON []byte) []string {
 	args := []string{
 		"--sync-protection",
 		fmt.Sprintf("--symbol=%s", symbol),
@@ -411,11 +411,14 @@ func buildHyperliquidSyncProtectionArgv(symbol, side string, size, avgCost, entr
 			fmt.Fprintf(os.Stderr, "[WARN] json.Marshal(tp armed tiers) failed: %v — sync-protection omitting --tp-armed-tiers-json\n", err)
 		}
 	}
+	if len(reconcileFillHintsJSON) > 0 {
+		args = append(args, fmt.Sprintf("--reconcile-fill-hints-json=%s", string(reconcileFillHintsJSON)))
+	}
 	return args
 }
 
-func RunHyperliquidSyncProtection(script, symbol, side string, size, avgCost, entryATR, stopLossATRMult float64, tiers []hlProtectionTier, stopLossOID int64, tpOIDs []int64, tpArmedTiers []bool) (*HyperliquidProtectionSyncResult, string, error) {
-	args := buildHyperliquidSyncProtectionArgv(symbol, side, size, avgCost, entryATR, stopLossATRMult, tiers, stopLossOID, tpOIDs, tpArmedTiers)
+func RunHyperliquidSyncProtection(script, symbol, side string, size, avgCost, entryATR, stopLossATRMult float64, tiers []hlProtectionTier, stopLossOID int64, tpOIDs []int64, tpArmedTiers []bool, reconcileFillHintsJSON []byte) (*HyperliquidProtectionSyncResult, string, error) {
+	args := buildHyperliquidSyncProtectionArgv(symbol, side, size, avgCost, entryATR, stopLossATRMult, tiers, stopLossOID, tpOIDs, tpArmedTiers, reconcileFillHintsJSON)
 	stdout, stderr, err := runPythonSideEffect(script, args)
 	stderrStr := string(stderr)
 	var result HyperliquidProtectionSyncResult

--- a/scheduler/executor_test.go
+++ b/scheduler/executor_test.go
@@ -706,7 +706,7 @@ func TestBuildHyperliquidExecuteArgs_OptionalFlags(t *testing.T) {
 
 func TestBuildHyperliquidSyncProtectionArgv_TPArmedTiersJSON(t *testing.T) {
 	tiers := []hlProtectionTier{{Multiple: 1, Fraction: 0.5}, {Multiple: 2, Fraction: 1}}
-	argv := buildHyperliquidSyncProtectionArgv("ETH", "long", 0.22, 3000, 100, 1.5, tiers, 999, []int64{0, 300}, []bool{true, true})
+	argv := buildHyperliquidSyncProtectionArgv("ETH", "long", 0.22, 3000, 100, 1.5, tiers, 999, []int64{0, 300}, []bool{true, true}, nil)
 	var armedArg string
 	for _, a := range argv {
 		if strings.HasPrefix(a, "--tp-armed-tiers-json=") {
@@ -722,7 +722,7 @@ func TestBuildHyperliquidSyncProtectionArgv_TPArmedTiersJSON(t *testing.T) {
 		t.Errorf("armed tiers JSON = %q, want [true,true]", got)
 	}
 	// Shorter slice pads false (#749 / hyperliquid_protection.go).
-	argv = buildHyperliquidSyncProtectionArgv("ETH", "long", 0.22, 3000, 100, 1.5, tiers, 0, nil, []bool{true})
+	argv = buildHyperliquidSyncProtectionArgv("ETH", "long", 0.22, 3000, 100, 1.5, tiers, 0, nil, []bool{true}, nil)
 	for _, a := range argv {
 		if strings.HasPrefix(a, "--tp-armed-tiers-json=") {
 			if got := strings.TrimPrefix(a, prefix); got != `[true,false]` {
@@ -735,11 +735,27 @@ func TestBuildHyperliquidSyncProtectionArgv_TPArmedTiersJSON(t *testing.T) {
 }
 
 func TestBuildHyperliquidSyncProtectionArgv_NoTiersOmitsArmedJSON(t *testing.T) {
-	argv := buildHyperliquidSyncProtectionArgv("ETH", "long", 0.22, 3000, 100, 1.5, nil, 0, nil, nil)
+	argv := buildHyperliquidSyncProtectionArgv("ETH", "long", 0.22, 3000, 100, 1.5, nil, 0, nil, nil, nil)
 	for _, a := range argv {
 		if strings.HasPrefix(a, "--tp-armed-tiers-json=") {
 			t.Fatalf("unexpected %q when tiers empty", a)
 		}
+	}
+}
+
+func TestBuildHyperliquidSyncProtectionArgv_ReconcileFillHintsJSON(t *testing.T) {
+	tiers := []hlProtectionTier{{Multiple: 1, Fraction: 0.5}, {Multiple: 2, Fraction: 1}}
+	hints := []byte(`[{"oid":42,"filled":true,"fee":0.01,"count":1}]`)
+	argv := buildHyperliquidSyncProtectionArgv("ETH", "long", 0.22, 3000, 100, 1.5, tiers, 1, []int64{2, 3}, nil, hints)
+	var got string
+	for _, a := range argv {
+		if strings.HasPrefix(a, "--reconcile-fill-hints-json=") {
+			got = strings.TrimPrefix(a, "--reconcile-fill-hints-json=")
+			break
+		}
+	}
+	if got != string(hints) {
+		t.Fatalf("hints argv = %q, want %q", got, string(hints))
 	}
 }
 

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -641,7 +641,8 @@ func syncHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppSt
 	// PnL falls back to zero (legacy behavior pre-#584).
 	// This entry point is used by --once and tests; alerts are suppressed
 	// since no notifier is plumbed through here.
-	return reconcileHyperliquidAccountPositions(hlStrategies, hlStrategies, state, mu, logMgr, positions, nil, accountAddr, nil, false)
+	changed, _ := reconcileHyperliquidAccountPositions(hlStrategies, hlStrategies, state, mu, logMgr, positions, nil, accountAddr, nil, false)
+	return changed
 }
 
 // reconcileHyperliquidAccountPositions reconciles pre-fetched on-chain positions
@@ -670,12 +671,12 @@ func syncHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppSt
 // `notify_tp_sl_fills: false`.
 //
 // Must be called WITHOUT holding any lock; acquires Lock internally.
-func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager, positions []HLPosition, prices map[string]float64, accountAddress string, notifier *MultiNotifier, notifyTPSLFills bool) bool {
+func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager, positions []HLPosition, prices map[string]float64, accountAddress string, notifier *MultiNotifier, notifyTPSLFills bool) (bool, []HyperliquidProtectionFillHint) {
 	// Resolve userFills BEFORE taking mu.Lock(): each lookup can sleep up
 	// to ~1.5s on indexer-lag retries, and holding the write lock blocks
 	// every reader of state (/status, /health, per-strategy phase RLocks).
 	// The resolver itself is a pure map read inside the locked region.
-	resolveFee := buildCachedHyperliquidReconcileFillResolver(accountAddress, allStrategies, state, mu, positions)
+	resolveFee, fillHints := buildCachedHyperliquidReconcileFillResolver(accountAddress, allStrategies, state, mu, positions)
 
 	// pendingAlerts is populated under mu.Lock() at the three protection-fill
 	// detection sites and drained AFTER mu.Unlock() so SendOwnerDM's blocking
@@ -1175,7 +1176,7 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 		}
 	}
 
-	return changed
+	return changed, fillHints
 }
 
 func hyperliquidSharedPartialCloseDrift(virtualQty, onChainQty float64) (string, float64, bool) {

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -989,7 +989,7 @@ func TestReconcileDueSubsetOfAllDetectsSharedCoins(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions(dueStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(dueStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	// Even though only rmc is due, allStrategies reveals ETH is shared by 3
 	// strategies, so rmc's position must NOT be reconciled to on-chain.
@@ -1058,7 +1058,7 @@ func TestReconcileSharedCoinShortAndMixedPositions(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	// Positions should be unchanged.
 	longPos := state.Strategies["hl-long-eth"].Positions["ETH"]
@@ -1121,7 +1121,7 @@ func TestReconcileSharedCoinBothShort(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	gap := state.ReconciliationGaps["ETH"]
 	if gap == nil {
@@ -1185,7 +1185,7 @@ func TestReconcileSharedCoin_OwnerStopLossFired_ClosesOwnerOnly(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "0xtest", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "0xtest", nil, false)
 
 	// Owner position must be closed and recorded.
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
@@ -1259,7 +1259,7 @@ func TestReconcileSharedCoin_OwnerStopLossFired_Short(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "0xtest", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "0xtest", nil, false)
 
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
 		t.Error("owner short ETH position should be nil after SL reconciliation")
@@ -1314,7 +1314,7 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "0xtest", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "0xtest", nil, false)
 
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
 		t.Error("owner ETH position should be nil")
@@ -1387,7 +1387,7 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally_CreditsPeerCash(t *tes
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "0xtest", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "0xtest", nil, false)
 
 	peer := state.Strategies["hl-peer-eth"]
 	if peer.Positions["ETH"] != nil {
@@ -1489,7 +1489,7 @@ func TestReconcileSharedCoin_Detector1_WrongOIDInUserfillsBooksExternal(t *testi
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 	prices := map[string]float64{"BTC": mark}
-	reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, nil, prices, "0xtest", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, nil, prices, "0xtest", nil, false)
 
 	owner := state.Strategies["hl-owner-btc"]
 	if len(owner.ClosedPositions) != 1 {
@@ -1547,7 +1547,7 @@ func TestReconcileSharedCoin_Detector2_WrongOIDInUserfillsBooksExternal(t *testi
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, positions, prices, "0xtest", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, positions, prices, "0xtest", nil, false)
 
 	owner := state.Strategies["hl-owner-eth"]
 	if len(owner.ClosedPositions) != 1 {
@@ -1604,7 +1604,7 @@ func TestReconcileSharedCoin_TPPartialFill_DecrementsOwnerAndBooksPnL(t *testing
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
 
 	owner := state.Strategies["hl-owner-eth"]
 	ownerPos := owner.Positions["ETH"]
@@ -1695,7 +1695,7 @@ func TestReconcileSharedCoin_TPPartialFill_Short(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
 
 	owner := state.Strategies["hl-owner-eth"]
 	ownerPos := owner.Positions["ETH"]
@@ -1759,7 +1759,7 @@ func TestReconcileSharedCoin_TPPartialFill_PaddedNeverPlacedTierDoesNotAttribute
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
 
 	owner := state.Strategies["hl-owner-eth"]
 	ownerPos := owner.Positions["ETH"]
@@ -1812,7 +1812,7 @@ func TestReconcileSharedCoin_TPPartialFill_MultipleCandidatesDoesNotAttribute(t 
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
 
 	for id, ss := range state.Strategies {
 		pos := ss.Positions["ETH"]
@@ -1867,7 +1867,7 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally_NoMarkPrice_FallsBack(
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 	// nil prices map → legacy zero-PnL path.
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	peer := state.Strategies["hl-peer-eth"]
 	if peer.Positions["ETH"] != nil {
@@ -1913,7 +1913,7 @@ func TestReconcileSharedCoin_GapWithoutSLOwner_LeavesPositionsAlone(t *testing.T
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	// Both positions must be untouched.
 	posA := state.Strategies["hl-a-eth"].Positions["ETH"]
@@ -1970,7 +1970,7 @@ func TestReconcileSharedCoin_ResidualMismatch_LeavesPositionsAlone(t *testing.T)
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	// Both positions must be untouched.
 	ownerPos := state.Strategies["hl-owner-eth"].Positions["ETH"]
@@ -3247,7 +3247,7 @@ func TestReconcileManualPositionExternalClose(t *testing.T) {
 	var mu sync.RWMutex
 
 	// Pass nil positions (on-chain flat).
-	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "", nil, false)
 
 	ss := state.Strategies["manual-eth"]
 	if _, ok := ss.Positions["ETH"]; ok {
@@ -3449,7 +3449,7 @@ func TestReconcileManualPositionSLFired(t *testing.T) {
 		return HLFillLookup{}, false
 	}
 
-	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "0xtest", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "0xtest", nil, false)
 
 	ss := state.Strategies["manual-eth"]
 	if _, ok := ss.Positions["ETH"]; ok {

--- a/scheduler/hyperliquid_fills.go
+++ b/scheduler/hyperliquid_fills.go
@@ -318,6 +318,18 @@ func defaultLookupHyperliquidReconcileFillFee(accountAddress, coin string, oid i
 // HTTP calls under mu.Lock(). See buildCachedHyperliquidReconcileFillResolver.
 type hlReconcileFillResolver func(coin string, oid int64, expectedQty float64) (HLFillLookup, bool)
 
+// HyperliquidProtectionFillHint is a reconciler-prefetched userFills snapshot
+// for one resting trigger OID. Passed to Python --sync-protection so it can
+// skip a duplicate userFills round-trip when the data was already resolved this
+// cycle (#759).
+type HyperliquidProtectionFillHint struct {
+	OID       int64   `json:"oid"`
+	Filled    bool    `json:"filled"`
+	Fee       float64 `json:"fee,omitempty"`
+	ClosedPnl float64 `json:"closed_pnl,omitempty"`
+	Count     int     `json:"count,omitempty"`
+}
+
 // noFillFeeResolver is the resolver used when fee lookups are disabled (no
 // account address) or when no candidate close events were detected. Always
 // returns ok=false so callers fall back to the modeled fee path.
@@ -361,16 +373,18 @@ func makeHLReconcileFeeCacheKey(coin string, oid int64, qty float64) hyperliquid
 // identify which (coin, oid, qty) lookups the reconciler is likely to need,
 // performs all userFills queries OUTSIDE the lock (each can take up to ~1.5s
 // under indexer-lag retry), then returns a pure map-reading resolver that the
-// locked apply phase calls. Cache misses fall back to noFillFeeResolver
-// behavior — never to a network call — so the lock-held region is bounded.
+// locked apply phase calls, plus per-OID fill hints for Python --sync-protection
+// to avoid duplicate indexer calls in the same scheduler cycle (#759). Cache
+// misses fall back to noFillFeeResolver behavior — never to a network call —
+// so the lock-held region is bounded.
 //
 // The candidate-detection pass is permissive: false positives just mean an
 // extra HTTP query per cycle, false negatives mean a close books with the
 // modeled fee. Detector logic is duplicated approximately, not exactly, so
 // the apply phase remains the source of truth for whether a close fires.
-func buildCachedHyperliquidReconcileFillResolver(accountAddress string, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, positions []HLPosition) hlReconcileFillResolver {
+func buildCachedHyperliquidReconcileFillResolver(accountAddress string, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, positions []HLPosition) (hlReconcileFillResolver, []HyperliquidProtectionFillHint) {
 	if accountAddress == "" {
-		return noFillFeeResolver
+		return noFillFeeResolver, nil
 	}
 
 	type candidate struct {
@@ -456,7 +470,7 @@ func buildCachedHyperliquidReconcileFillResolver(accountAddress string, allStrat
 	mu.RUnlock()
 
 	if len(candidates) == 0 {
-		return noFillFeeResolver
+		return noFillFeeResolver, nil
 	}
 
 	type cacheEntry struct {
@@ -469,11 +483,41 @@ func buildCachedHyperliquidReconcileFillResolver(accountAddress string, allStrat
 		cache[makeHLReconcileFeeCacheKey(c.coin, c.oid, c.qty)] = cacheEntry{lookup: lookup, ok: ok}
 	}
 
-	return func(coin string, oid int64, expectedQty float64) (HLFillLookup, bool) {
+	hintsByOID := make(map[int64]HyperliquidProtectionFillHint, len(candidates))
+	for _, c := range candidates {
+		if c.oid <= 0 {
+			continue
+		}
+		key := makeHLReconcileFeeCacheKey(c.coin, c.oid, c.qty)
+		ent := cache[key]
+		if _, exists := hintsByOID[c.oid]; exists {
+			continue // first prefetch wins — duplicate keys should be rare
+		}
+		filled := ent.ok && ent.lookup.Count > 0
+		hintsByOID[c.oid] = HyperliquidProtectionFillHint{
+			OID:       c.oid,
+			Filled:    filled,
+			Fee:       ent.lookup.Fee,
+			ClosedPnl: ent.lookup.ClosedPnLGross,
+			Count:     ent.lookup.Count,
+		}
+	}
+	var hintOIDs []int64
+	for oid := range hintsByOID {
+		hintOIDs = append(hintOIDs, oid)
+	}
+	sort.Slice(hintOIDs, func(i, j int) bool { return hintOIDs[i] < hintOIDs[j] })
+	fillHints := make([]HyperliquidProtectionFillHint, 0, len(hintOIDs))
+	for _, oid := range hintOIDs {
+		fillHints = append(fillHints, hintsByOID[oid])
+	}
+
+	resolver := func(coin string, oid int64, expectedQty float64) (HLFillLookup, bool) {
 		entry, hit := cache[makeHLReconcileFeeCacheKey(coin, oid, expectedQty)]
 		if !hit {
 			return HLFillLookup{}, false
 		}
 		return entry.lookup, entry.ok
 	}
+	return resolver, fillHints
 }

--- a/scheduler/hyperliquid_fills.go
+++ b/scheduler/hyperliquid_fills.go
@@ -491,7 +491,10 @@ func buildCachedHyperliquidReconcileFillResolver(accountAddress string, allStrat
 		key := makeHLReconcileFeeCacheKey(c.coin, c.oid, c.qty)
 		ent := cache[key]
 		if _, exists := hintsByOID[c.oid]; exists {
-			continue // first prefetch wins — duplicate keys should be rare
+			// First candidate wins: duplicate (coin, oid, qty) keys are deduped
+			// above, and for oid>0 all qty variants share the same OID-keyed
+			// lookup result from defaultLookupHyperliquidReconcileFillFee.
+			continue
 		}
 		filled := ent.ok && ent.lookup.Count > 0
 		hintsByOID[c.oid] = HyperliquidProtectionFillHint{

--- a/scheduler/hyperliquid_fills_test.go
+++ b/scheduler/hyperliquid_fills_test.go
@@ -294,7 +294,7 @@ func TestReconcileHyperliquidAccountPositions_DetectorOneUsesFillFee(t *testing.
 
 	prices := map[string]float64{"BTC": 59000}
 	// nil on-chain positions => Detector 1 fires for both peers.
-	reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, nil, prices, "0xtest", nil, false)
+	_, _ = reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, nil, prices, "0xtest", nil, false)
 
 	ownerSS := state.Strategies["hl-owner"]
 	if _, open := ownerSS.Positions["BTC"]; open {

--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -307,10 +307,11 @@ type jsonNumber interface {
 
 // syncHyperliquidProtection is a package var so tests can stub the subprocess
 // call without spawning Python. Production callers use runHyperliquidProtectionSync.
-var syncHyperliquidProtection = func(sc StrategyConfig, plan hlProtectionPlan, notifier *MultiNotifier, logger *StrategyLogger) (*HyperliquidProtectionSyncResult, bool) {
+var syncHyperliquidProtection = func(sc StrategyConfig, plan hlProtectionPlan, notifier *MultiNotifier, logger *StrategyLogger, reconcileFillHintsJSON []byte) (*HyperliquidProtectionSyncResult, bool) {
 	result, stderr, err := RunHyperliquidSyncProtection(
 		sc.Script, plan.Symbol, plan.Side, plan.Size, plan.AvgCost, plan.EntryATR,
 		plan.StopLossATRMult, plan.Tiers, plan.StopLossOID, plan.TPOIDs, plan.TPArmedTiers,
+		reconcileFillHintsJSON,
 	)
 	if stderr != "" && logger != nil {
 		logger.Info("protection sync stderr: %s", stderr)
@@ -443,6 +444,7 @@ func runHyperliquidProtectionSync(
 	notifier *MultiNotifier,
 	logger *StrategyLogger,
 	logTag string,
+	reconcileFillHintsJSON []byte,
 ) bool {
 	if stratState == nil || symbol == "" {
 		return false
@@ -457,7 +459,7 @@ func runHyperliquidProtectionSync(
 	if !syncOK {
 		return false
 	}
-	protection, ok := syncHyperliquidProtection(sc, plan, notifier, logger)
+	protection, ok := syncHyperliquidProtection(sc, plan, notifier, logger, reconcileFillHintsJSON)
 	if !ok || protection == nil {
 		return false
 	}

--- a/scheduler/hyperliquid_protection_test.go
+++ b/scheduler/hyperliquid_protection_test.go
@@ -426,7 +426,7 @@ func TestHyperliquidProtectionTiersPreservesDuplicateMultipleOrder(t *testing.T)
 // duration of the test, restoring the original on cleanup.
 func withStubbedSyncHyperliquidProtection(
 	t *testing.T,
-	stub func(sc StrategyConfig, plan hlProtectionPlan, notifier *MultiNotifier, logger *StrategyLogger) (*HyperliquidProtectionSyncResult, bool),
+	stub func(sc StrategyConfig, plan hlProtectionPlan, notifier *MultiNotifier, logger *StrategyLogger, reconcileFillHintsJSON []byte) (*HyperliquidProtectionSyncResult, bool),
 ) {
 	t.Helper()
 	orig := syncHyperliquidProtection
@@ -449,7 +449,7 @@ func TestRunHyperliquidProtectionSyncManualAppliesOIDs(t *testing.T) {
 		},
 	}
 	calls := 0
-	withStubbedSyncHyperliquidProtection(t, func(_ StrategyConfig, _ hlProtectionPlan, _ *MultiNotifier, _ *StrategyLogger) (*HyperliquidProtectionSyncResult, bool) {
+	withStubbedSyncHyperliquidProtection(t, func(_ StrategyConfig, _ hlProtectionPlan, _ *MultiNotifier, _ *StrategyLogger, _ []byte) (*HyperliquidProtectionSyncResult, bool) {
 		calls++
 		return &HyperliquidProtectionSyncResult{
 			StopLossOID: 999,
@@ -458,7 +458,7 @@ func TestRunHyperliquidProtectionSyncManualAppliesOIDs(t *testing.T) {
 	})
 
 	var mu sync.RWMutex
-	if !runHyperliquidProtectionSync(sc, state, nil, "ETH", &mu, nil, nil, "test") {
+	if !runHyperliquidProtectionSync(sc, state, nil, "ETH", &mu, nil, nil, "test", nil) {
 		t.Fatal("expected runHyperliquidProtectionSync to apply")
 	}
 	if calls != 1 {
@@ -486,13 +486,13 @@ func TestRunHyperliquidProtectionSyncSkipsWhenNoPlan(t *testing.T) {
 		},
 	}
 	called := false
-	withStubbedSyncHyperliquidProtection(t, func(_ StrategyConfig, _ hlProtectionPlan, _ *MultiNotifier, _ *StrategyLogger) (*HyperliquidProtectionSyncResult, bool) {
+	withStubbedSyncHyperliquidProtection(t, func(_ StrategyConfig, _ hlProtectionPlan, _ *MultiNotifier, _ *StrategyLogger, _ []byte) (*HyperliquidProtectionSyncResult, bool) {
 		called = true
 		return nil, false
 	})
 
 	var mu sync.RWMutex
-	if runHyperliquidProtectionSync(sc, state, nil, "ETH", &mu, nil, nil, "test") {
+	if runHyperliquidProtectionSync(sc, state, nil, "ETH", &mu, nil, nil, "test", nil) {
 		t.Fatal("expected runHyperliquidProtectionSync to skip when no plan")
 	}
 	if called {
@@ -519,14 +519,14 @@ func TestRunHyperliquidProtectionSyncSkipsApplyAfterExternalClose(t *testing.T) 
 			"ETH": {Symbol: "ETH", Quantity: 0.4, AvgCost: 3000, EntryATR: 100, Side: "long"},
 		},
 	}
-	withStubbedSyncHyperliquidProtection(t, func(_ StrategyConfig, _ hlProtectionPlan, _ *MultiNotifier, _ *StrategyLogger) (*HyperliquidProtectionSyncResult, bool) {
+	withStubbedSyncHyperliquidProtection(t, func(_ StrategyConfig, _ hlProtectionPlan, _ *MultiNotifier, _ *StrategyLogger, _ []byte) (*HyperliquidProtectionSyncResult, bool) {
 		// Simulate an external close racing the subprocess.
 		state.Positions["ETH"].Quantity = 0
 		return &HyperliquidProtectionSyncResult{StopLossOID: 999, TPOIDs: []int64{111}}, true
 	})
 
 	var mu sync.RWMutex
-	if runHyperliquidProtectionSync(sc, state, nil, "ETH", &mu, nil, nil, "test") {
+	if runHyperliquidProtectionSync(sc, state, nil, "ETH", &mu, nil, nil, "test", nil) {
 		t.Fatal("expected apply to be skipped after position closed externally")
 	}
 	pos := state.Positions["ETH"]
@@ -566,7 +566,7 @@ func TestRunHyperliquidProtectionSyncStampsTradeInDB(t *testing.T) {
 		t.Fatalf("InsertTrade: %v", err)
 	}
 
-	withStubbedSyncHyperliquidProtection(t, func(_ StrategyConfig, _ hlProtectionPlan, _ *MultiNotifier, _ *StrategyLogger) (*HyperliquidProtectionSyncResult, bool) {
+	withStubbedSyncHyperliquidProtection(t, func(_ StrategyConfig, _ hlProtectionPlan, _ *MultiNotifier, _ *StrategyLogger, _ []byte) (*HyperliquidProtectionSyncResult, bool) {
 		return &HyperliquidProtectionSyncResult{
 			StopLossOID:       999,
 			StopLossTriggerPx: 2850.0,
@@ -575,7 +575,7 @@ func TestRunHyperliquidProtectionSyncStampsTradeInDB(t *testing.T) {
 	})
 
 	var mu sync.RWMutex
-	if !runHyperliquidProtectionSync(sc, state, db, "ETH", &mu, nil, nil, "test") {
+	if !runHyperliquidProtectionSync(sc, state, db, "ETH", &mu, nil, nil, "test", nil) {
 		t.Fatal("expected runHyperliquidProtectionSync to apply")
 	}
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1158,8 +1158,14 @@ func main() {
 				// Reuses the clearinghouseState already fetched above for the
 				// shared-wallet risk check (#243 review feedback) so we don't
 				// pay two HL API round-trips per cycle.
+				var hlReconcileFillHintsJSON []byte
 				if len(hlReconcileDue) > 0 && hlStateFetched {
-					reconcileHyperliquidAccountPositions(hlReconcileDue, hlReconcileAll, state, &mu, logMgr, hlPositions, prices, os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS"), notifier, cfg.NotifyTPSLFillsEnabled())
+					_, fillHints := reconcileHyperliquidAccountPositions(hlReconcileDue, hlReconcileAll, state, &mu, logMgr, hlPositions, prices, os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS"), notifier, cfg.NotifyTPSLFillsEnabled())
+					if len(fillHints) > 0 {
+						if b, err := json.Marshal(fillHints); err == nil {
+							hlReconcileFillHintsJSON = b
+						}
+					}
 				}
 
 				// #621: Build a coin→|on-chain qty| map from the pre-fetched positions
@@ -1571,7 +1577,7 @@ func main() {
 								}
 							}
 							if hyperliquidIsLive(sc.Args) && result.Signal == 0 && hlPosQty > 0 {
-								runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced")
+								runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced", hlReconcileFillHintsJSON)
 								runPostTPStopLossAdjustment(sc, stratState, result.Symbol, price, cfg, &mu, notifier, logger, hlOnChainAbsQty)
 							}
 							if hyperliquidIsLive(sc.Args) && result.Signal != 0 {
@@ -1603,7 +1609,7 @@ func main() {
 								trades, detail, openTrade = executeHyperliquidResultDeferredOpen(sc, stratState, result, execResult, signalStr, price, logger)
 								mu.Unlock()
 								if execResult != nil && trades > 0 {
-									runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced after trade")
+									runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced after trade", hlReconcileFillHintsJSON)
 									runPostTPStopLossAdjustment(sc, stratState, result.Symbol, price, cfg, &mu, notifier, logger, hlOnChainAbsQty)
 									mu.Lock()
 									var pos *Position
@@ -1651,7 +1657,7 @@ func main() {
 							break
 						}
 						if pos != nil && hyperliquidIsLive(sc.Args) {
-							runHyperliquidProtectionSync(sc, stratState, stateDB, sc.Symbol, &mu, notifier, logger, "HL manual protection synced")
+							runHyperliquidProtectionSync(sc, stratState, stateDB, sc.Symbol, &mu, notifier, logger, "HL manual protection synced", hlReconcileFillHintsJSON)
 							runPostTPStopLossAdjustment(sc, stratState, sc.Symbol, prices[sc.Symbol], cfg, &mu, notifier, logger, hlOnChainAbsQty)
 						}
 						if closeFraction, _, ok := runManualCloseEval(sc, stratState, cfg, logger); ok && closeFraction > 0 {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1164,6 +1164,8 @@ func main() {
 					if len(fillHints) > 0 {
 						if b, err := json.Marshal(fillHints); err == nil {
 							hlReconcileFillHintsJSON = b
+						} else {
+							fmt.Fprintf(os.Stderr, "[WARN] hl-sync: json.Marshal(fillHints): %v\n", err)
 						}
 					}
 				}

--- a/scheduler/manual_protection.go
+++ b/scheduler/manual_protection.go
@@ -60,7 +60,7 @@ func placeManualProtectionInline(
 
 	result, stderr, err := runHLSyncProtectionFn(
 		sc.Script, sc.Symbol, side, fillQty, fillPrice, entryATR,
-		effectiveSLATRMult, tiers, stopLossOID, nil, nil,
+		effectiveSLATRMult, tiers, stopLossOID, nil, nil, nil,
 	)
 	if stderr != "" {
 		fmt.Fprintf(os.Stderr, "[manual-open] sync-protection stderr: %s\n", stderr)

--- a/scheduler/manual_protection_test.go
+++ b/scheduler/manual_protection_test.go
@@ -54,7 +54,7 @@ func TestPlaceManualProtectionInline_TPErrorsSurface(t *testing.T) {
 	orig := runHLSyncProtectionFn
 	defer func() { runHLSyncProtectionFn = orig }()
 
-	runHLSyncProtectionFn = func(script, symbol, side string, size, avgCost, entryATR, stopLossATRMult float64, tiers []hlProtectionTier, stopLossOID int64, tpOIDs []int64, _ []bool) (*HyperliquidProtectionSyncResult, string, error) {
+	runHLSyncProtectionFn = func(script, symbol, side string, size, avgCost, entryATR, stopLossATRMult float64, tiers []hlProtectionTier, stopLossOID int64, tpOIDs []int64, _ []bool, _ []byte) (*HyperliquidProtectionSyncResult, string, error) {
 		return &HyperliquidProtectionSyncResult{
 			TPOIDs:   []int64{1001, 1002},
 			TPErrors: []string{"TP1: rejected", ""},

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -337,8 +337,10 @@ def _oid_filled_externally(adapter, oid: int, since_ms: int, fill_hints=None) ->
     """Check whether ``oid`` has filled on-chain by querying userFills.
 
     When ``fill_hints`` is provided (oid → hint dict from the Go reconciler's
-    same-cycle prefetch, #759), a matching entry short-circuits the
-    ``lookup_fill_fee_by_oid`` call so Python does not re-hit the HL indexer.
+    same-cycle prefetch, #759), only a **confirmed fill** (``filled: true``)
+    short-circuits ``lookup_fill_fee_by_oid``. A ``filled: false`` hint does
+    not — Go's prefetch can miss on transient indexer errors, so Python keeps
+    an independent userFills attempt with its own retry budget.
 
     Returns a dict with at minimum ``{"filled": bool}``. When filled, also
     includes ``size`` (summed across partial fills) and the ``fee`` /
@@ -355,15 +357,13 @@ def _oid_filled_externally(adapter, oid: int, since_ms: int, fill_hints=None) ->
         return {"filled": False}
     if fill_hints is not None:
         hint = fill_hints.get(int(oid))
-        if hint is not None:
-            if hint.get("filled"):
-                return {
-                    "filled": True,
-                    "fee": float(hint.get("fee", 0) or 0),
-                    "closed_pnl": float(hint.get("closed_pnl", 0) or 0),
-                    "count": int(hint.get("count", 0) or 0),
-                }
-            return {"filled": False}
+        if hint is not None and hint.get("filled"):
+            return {
+                "filled": True,
+                "fee": float(hint.get("fee", 0) or 0),
+                "closed_pnl": float(hint.get("closed_pnl", 0) or 0),
+                "count": int(hint.get("count", 0) or 0),
+            }
     try:
         lookup = adapter.lookup_fill_fee_by_oid(int(oid), since_ms)
     except Exception as e:

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -333,8 +333,12 @@ def _oid_is_open(open_oids: set[int] | None, oid: int) -> bool:
     return oid > 0 and open_oids is not None and int(oid) in open_oids
 
 
-def _oid_filled_externally(adapter, oid: int, since_ms: int) -> dict:
+def _oid_filled_externally(adapter, oid: int, since_ms: int, fill_hints=None) -> dict:
     """Check whether ``oid`` has filled on-chain by querying userFills.
+
+    When ``fill_hints`` is provided (oid → hint dict from the Go reconciler's
+    same-cycle prefetch, #759), a matching entry short-circuits the
+    ``lookup_fill_fee_by_oid`` call so Python does not re-hit the HL indexer.
 
     Returns a dict with at minimum ``{"filled": bool}``. When filled, also
     includes ``size`` (summed across partial fills) and the ``fee`` /
@@ -349,6 +353,17 @@ def _oid_filled_externally(adapter, oid: int, since_ms: int) -> dict:
     """
     if oid <= 0:
         return {"filled": False}
+    if fill_hints is not None:
+        hint = fill_hints.get(int(oid))
+        if hint is not None:
+            if hint.get("filled"):
+                return {
+                    "filled": True,
+                    "fee": float(hint.get("fee", 0) or 0),
+                    "closed_pnl": float(hint.get("closed_pnl", 0) or 0),
+                    "count": int(hint.get("count", 0) or 0),
+                }
+            return {"filled": False}
     try:
         lookup = adapter.lookup_fill_fee_by_oid(int(oid), since_ms)
     except Exception as e:
@@ -457,6 +472,7 @@ def run_sync_protection(
     tp_tiers=None,
     tp_oids=None,
     tp_armed_tiers=None,
+    reconcile_fill_hints_json="",
 ):
     """Verify/re-place per-strategy reduce-only SL/TP orders (#601)."""
     if mode != "live":
@@ -477,6 +493,18 @@ def run_sync_protection(
     try:
         from adapter import HyperliquidExchangeAdapter
         adapter = HyperliquidExchangeAdapter()
+
+        fill_hints = None
+        if reconcile_fill_hints_json:
+            try:
+                parsed = json.loads(reconcile_fill_hints_json)
+                if isinstance(parsed, list):
+                    fill_hints = {}
+                    for item in parsed:
+                        if isinstance(item, dict) and "oid" in item:
+                            fill_hints[int(item["oid"])] = item
+            except json.JSONDecodeError as je:
+                print(f"[WARN] reconcile_fill_hints_json: {je}", file=sys.stderr)
 
         open_oids = None
         try:
@@ -510,7 +538,7 @@ def run_sync_protection(
                 # Re-placement here is what would over-close: better to
                 # surface the failure and try again next cycle.
                 return ("unknown", None)
-            fill = _oid_filled_externally(adapter, prev_oid, fill_check_since_ms)
+            fill = _oid_filled_externally(adapter, prev_oid, fill_check_since_ms, fill_hints)
             if fill.get("filled"):
                 return ("filled", fill)
             return ("place", None)
@@ -1067,6 +1095,11 @@ def main():
         parser.add_argument("--tp2-oid", type=int, default=0)
         parser.add_argument("--tp-oids-json", default="")
         parser.add_argument("--tp-armed-tiers-json", default="")
+        parser.add_argument(
+            "--reconcile-fill-hints-json",
+            default="",
+            help="Optional JSON array from Go reconciler prefetch (#759); skips duplicate userFills per OID.",
+        )
         parser.add_argument("--mode", default="live")
         args = parser.parse_args()
         tp_tiers = json.loads(args.tp_tiers_json) if args.tp_tiers_json else None
@@ -1091,6 +1124,7 @@ def main():
             tp_tiers=tp_tiers,
             tp_oids=tp_oids,
             tp_armed_tiers=tp_armed_tiers,
+            reconcile_fill_hints_json=args.reconcile_fill_hints_json or "",
         )
     elif "--update-stop-loss" in sys.argv:
         import argparse

--- a/shared_scripts/test_check_hyperliquid.py
+++ b/shared_scripts/test_check_hyperliquid.py
@@ -899,6 +899,49 @@ class TestSyncProtection:
         assert out["tp_fills"][1]["closed_pnl"] == 1.5
         adapter.lookup_fill_fee_by_oid.assert_not_called()
 
+    def test_reconcile_fill_hints_filled_false_still_queries_userfills(self):
+        """#761 review: filled=false hints must not suppress Python's indexer retry."""
+        hints = json.dumps([{"oid": 9101, "filled": False}])
+        out, adapter = self._run_sync(
+            tp1_oid=9100,
+            tp2_oid=9101,
+            sl_oid=0,
+            open_oids={9100},
+            fill_lookup_by_oid={9101: {"fee": 0.03, "closed_pnl": 2.0, "count": 1}},
+            reconcile_fill_hints_json=hints,
+        )
+        assert out["tp_filled_externally"][1] is True
+        assert out["tp_fills"][1]["fee"] == 0.03
+        adapter.lookup_fill_fee_by_oid.assert_called()
+
+    def test_reconcile_fill_hints_malformed_json_queries_userfills(self):
+        """#761 review: invalid JSON disables hints; userFills path still works."""
+        out, adapter = self._run_sync(
+            tp1_oid=9100,
+            tp2_oid=9101,
+            sl_oid=0,
+            open_oids={9100},
+            fill_lookup_by_oid={9101: {"fee": 0.04, "closed_pnl": 3.0, "count": 1}},
+            reconcile_fill_hints_json="{not-json",
+        )
+        assert out["tp_filled_externally"][1] is True
+        adapter.lookup_fill_fee_by_oid.assert_called()
+
+    def test_reconcile_fill_hints_extra_oid_does_not_skip_other_oid_lookup(self):
+        """#761 review: hints for an unrelated OID do not bypass lookup for missing TP."""
+        hints = json.dumps([{"oid": 1, "filled": True, "fee": 0.0, "count": 0}])
+        out, adapter = self._run_sync(
+            tp1_oid=9100,
+            tp2_oid=9101,
+            sl_oid=0,
+            open_oids={9100},
+            fill_lookup_by_oid={9101: {"fee": 0.05, "closed_pnl": 4.0, "count": 1}},
+            reconcile_fill_hints_json=hints,
+        )
+        assert out["tp_filled_externally"][1] is True
+        called_oids = [c.args[0] for c in adapter.lookup_fill_fee_by_oid.call_args_list]
+        assert 9101 in called_oids
+
     def test_open_orders_fetch_failure_defers_replacement(self):
         """open_order_oids() raise → leave existing OIDs alone, do not re-place
         (would double-up the protection). The script returns the failure

--- a/shared_scripts/test_check_hyperliquid.py
+++ b/shared_scripts/test_check_hyperliquid.py
@@ -661,6 +661,7 @@ class TestSyncProtection:
         open_oids=None,
         fill_lookup_by_oid=None,
         place_responses=None,
+        reconcile_fill_hints_json=None,
     ):
         mod, spec = _load_check_module()
         spec.loader.exec_module(mod)
@@ -732,6 +733,7 @@ class TestSyncProtection:
                     tp_tiers=tp_tiers,
                     tp_oids=tp_oids,
                     tp_armed_tiers=tp_armed_tiers,
+                    reconcile_fill_hints_json=reconcile_fill_hints_json or "",
                 )
         return json.loads(captured.getvalue()), mock_adapter
 
@@ -878,6 +880,25 @@ class TestSyncProtection:
         assert out["tp_fills"][1]["closed_pnl"] == 7.0
         adapter.place_take_profit_limit.assert_not_called()
 
+    def test_reconcile_fill_hints_skips_lookup_fill_fee_by_oid(self):
+        """#759: same-cycle Go prefetch JSON avoids duplicate userFills for that OID."""
+        hints = json.dumps(
+            [{"oid": 9101, "filled": True, "fee": 0.02, "closed_pnl": 1.5, "count": 2}]
+        )
+        out, adapter = self._run_sync(
+            tp1_oid=9100,
+            tp2_oid=9101,
+            sl_oid=0,
+            open_oids={9100},
+            fill_lookup_by_oid={},
+            reconcile_fill_hints_json=hints,
+        )
+        assert out["tp_oids"][1] == 0
+        assert out["tp_filled_externally"][1] is True
+        assert out["tp_fills"][1]["fee"] == 0.02
+        assert out["tp_fills"][1]["closed_pnl"] == 1.5
+        adapter.lookup_fill_fee_by_oid.assert_not_called()
+
     def test_open_orders_fetch_failure_defers_replacement(self):
         """open_order_oids() raise → leave existing OIDs alone, do not re-place
         (would double-up the protection). The script returns the failure
@@ -910,6 +931,7 @@ class TestSyncProtection:
                     "ETH", "long", 1.0, 2000.0, 20.0, "live",
                     stop_loss_atr_mult=1.0, tp1_atr_mult=1.0, tp1_fraction=0.5, tp2_atr_mult=2.0,
                     stop_loss_oid=100, tp1_oid=200, tp2_oid=300,
+                    reconcile_fill_hints_json="",
                 )
         out = json.loads(captured.getvalue())
         assert out["open_order_check_error"] == "indexer down"


### PR DESCRIPTION
Closes #759.

Pass OID fill snapshots from the Go reconciler prefetch cache to `check_hyperliquid.py --sync-protection` via `--reconcile-fill-hints-json` so Python skips duplicate `userFills` lookups when Go already resolved the OID in the same scheduler cycle.

- `buildCachedHyperliquidReconcileFillResolver` returns hints alongside the cached resolver
- `reconcileHyperliquidAccountPositions` returns `(changed, fillHints)`; main marshals once per cycle
- Python `_oid_filled_externally` prefers hints when present

Tests: `go -C scheduler test ./...`, `pytest shared_scripts/test_check_hyperliquid.py`.

Made with [Cursor](https://cursor.com)