### PR TITLE
fix(hl): reduce /info burst to stop 429 rate-limit (#768)

### DIFF
--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -10,14 +10,25 @@ Environment variables:
     HYPERLIQUID_TESTNET=1        — use testnet instead of mainnet
 """
 
+import json
 import math
 import os
 import sys
-from decimal import Decimal, ROUND_DOWN
+import tempfile
 import time
+from decimal import Decimal, ROUND_DOWN
 
 MAINNET_URL = "https://api.hyperliquid.xyz"
 TESTNET_URL = "https://api.hyperliquid-testnet.xyz"
+
+# /info `spotMeta` + `meta` rarely change (HL lists new coins on the order of
+# weeks). The SDK's Info constructor re-fetches both on every instantiation,
+# which costs 4 /info calls per scheduler cycle (signal-check + sync-protection
+# each spawn a subprocess). Cache the raw responses to disk and pass them into
+# Info(..., meta=..., spot_meta=...) on cache hit so the SDK skips the network
+# call entirely (#768).
+META_CACHE_PATH = "/tmp/hl_meta.json"
+META_CACHE_TTL_S = 3600  # 60 minutes
 
 # SDK imports: defer to avoid module-level ImportError when SDK not installed.
 # adapter.py is loaded with platforms/hyperliquid/ directly in sys.path (not platforms/),
@@ -26,10 +37,14 @@ TESTNET_URL = "https://api.hyperliquid-testnet.xyz"
 try:
     from hyperliquid.info import Info as _HLInfo
     from hyperliquid.exchange import Exchange as _HLExchange
+    from hyperliquid.api import API as _HLAPI
+    from hyperliquid.utils.error import ClientError as _HLClientError
     _SDK_AVAILABLE = True
 except ImportError:
     _HLInfo = None
     _HLExchange = None
+    _HLAPI = None
+    _HLClientError = Exception  # fall back so isinstance checks remain valid
     _SDK_AVAILABLE = False
 
 
@@ -82,6 +97,83 @@ def _floor_size(sz: float, sz_decimals: int) -> float:
     return float(Decimal(str(sz)).quantize(quant, rounding=ROUND_DOWN))
 
 
+def _load_meta_cache(path: str = META_CACHE_PATH, ttl_s: int = META_CACHE_TTL_S, now: float = None):
+    """Return (spot_meta, meta) from on-disk cache if fresh, else None.
+
+    Returns None on any read/parse failure so callers fall through to a fresh
+    fetch. Empty {} payloads are treated as cache misses — the SDK rejects them
+    on parse, and we want a fresh fetch in that case.
+    """
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    ts = data.get("ts")
+    try:
+        ts_f = float(ts) if ts is not None else 0.0
+    except (TypeError, ValueError):
+        return None
+    cur = now if now is not None else time.time()
+    if cur - ts_f > ttl_s:
+        return None
+    spot_meta = data.get("spot_meta")
+    meta = data.get("meta")
+    if not isinstance(spot_meta, dict) or not isinstance(meta, dict):
+        return None
+    if not spot_meta.get("universe") or not meta.get("universe"):
+        return None
+    return spot_meta, meta
+
+
+def _save_meta_cache(spot_meta, meta, path: str = META_CACHE_PATH) -> None:
+    """Persist (spot_meta, meta) atomically.
+
+    Uses a temp file in the same directory + os.replace so concurrent writers
+    (multiple go-trader instances on one host share /tmp/hl_meta.json) never
+    leave a torn file. Failures are logged and swallowed — caching is an
+    optimization, not a correctness requirement.
+    """
+    payload = {"ts": time.time(), "spot_meta": spot_meta, "meta": meta}
+    dir_ = os.path.dirname(path) or "."
+    fd = None
+    tmp_path = None
+    try:
+        fd, tmp_path = tempfile.mkstemp(prefix=".hl_meta_", suffix=".json", dir=dir_)
+        with os.fdopen(fd, "w") as f:
+            fd = None  # ownership transferred to file object
+            json.dump(payload, f)
+        os.replace(tmp_path, path)
+        tmp_path = None
+    except (OSError, TypeError, ValueError) as exc:
+        print(f"[WARN] hl meta cache save failed: {exc}", file=sys.stderr)
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+def _fetch_raw_meta(base_url: str):
+    """POST /info {type:spotMeta} + {type:meta} via the SDK's API base class.
+
+    Returns (spot_meta, meta) — same raw shape the SDK's Info constructor
+    consumes when passed via meta=/spot_meta= kwargs. Errors bubble.
+    """
+    api = _HLAPI(base_url=base_url)
+    spot_meta = api.post("/info", {"type": "spotMeta"})
+    meta = api.post("/info", {"type": "meta", "dex": ""})
+    return spot_meta, meta
+
+
 class HyperliquidExchangeAdapter:
     """
     Exchange adapter for Hyperliquid perpetual futures.
@@ -100,8 +192,9 @@ class HyperliquidExchangeAdapter:
         addr = os.environ.get("HYPERLIQUID_ACCOUNT_ADDRESS", "")
         testnet = os.environ.get("HYPERLIQUID_TESTNET", "") == "1"
         base_url = TESTNET_URL if testnet else MAINNET_URL
+        self._base_url = base_url
 
-        self._info = _HLInfo(base_url=base_url, skip_ws=True)
+        self._info = self._build_info(base_url, allow_cache=True)
         self._account_address = addr
         self._exchange = None
 
@@ -118,6 +211,58 @@ class HyperliquidExchangeAdapter:
                 raise RuntimeError(
                     f"Failed to initialize Hyperliquid Exchange client: {e}"
                 )
+
+    def _build_info(self, base_url: str, allow_cache: bool):
+        """Construct an SDK Info instance, using the /tmp/hl_meta.json cache
+        when fresh so the SDK skips its two-call init storm (#768).
+
+        On cache miss we POST /info {spotMeta, meta} ourselves (2 calls) and
+        pass the raw responses to Info via meta=/spot_meta= kwargs so its
+        constructor performs zero network calls. Net: 2 /info on miss, 0 on
+        hit (vs. 2 every construction in the unpatched path).
+
+        allow_cache=False forces a fresh fetch (used by _refresh_meta when a
+        symbol miss indicates the cached universe is stale).
+        """
+        cached = _load_meta_cache() if allow_cache else None
+        if cached is not None:
+            spot_meta, meta = cached
+            return _HLInfo(base_url=base_url, skip_ws=True, meta=meta, spot_meta=spot_meta)
+        try:
+            spot_meta, meta = _fetch_raw_meta(base_url)
+            _save_meta_cache(spot_meta, meta)
+            return _HLInfo(base_url=base_url, skip_ws=True, meta=meta, spot_meta=spot_meta)
+        except Exception as exc:
+            # Last-resort fallback: let the SDK's constructor fetch fresh.
+            # Costs the same 2 /info as before this change; cache write failed
+            # but trading must continue.
+            print(f"[WARN] hl meta fetch failed ({exc}); falling back to SDK init", file=sys.stderr)
+            return _HLInfo(base_url=base_url, skip_ws=True)
+
+    def _sz_decimals(self, symbol: str) -> int:
+        """Look up sz_decimals for ``symbol``, force-refreshing the cached
+        meta if the symbol is missing.
+
+        Silent fall-through to ``3`` on a missing symbol produced HL "price
+        has too many decimals" rejections on high-priced assets like BTC
+        (sz_decimals=5; allowed price decimals = 6-5 = 1). The guardrail
+        (#768 fix #1): on cache hit, if the configured symbol isn't in
+        ``asset_to_sz_decimals``, force a meta refresh once before falling
+        back. A still-missing symbol after refresh logs a warning and uses
+        the legacy default 3.
+        """
+        if self._info is not None and symbol in self._info.asset_to_sz_decimals:
+            return self._info.asset_to_sz_decimals[symbol]
+        # Symbol missing — could be a stale cached universe. Refresh once.
+        try:
+            self._info = self._build_info(self._base_url, allow_cache=False)
+        except Exception as exc:
+            print(f"[WARN] hl meta refresh failed for {symbol}: {exc}", file=sys.stderr)
+            return 3
+        if self._info is not None and symbol in self._info.asset_to_sz_decimals:
+            return self._info.asset_to_sz_decimals[symbol]
+        print(f"[WARN] sz_decimals not found for {symbol} after refresh, defaulting to 3", file=sys.stderr)
+        return 3
 
     @property
     def is_live(self) -> bool:
@@ -254,9 +399,7 @@ class HyperliquidExchangeAdapter:
                 "market_open requires live mode (set HYPERLIQUID_SECRET_KEY)"
             )
         # Round to asset's tick precision to avoid float_to_wire rounding error
-        if symbol not in self._info.asset_to_sz_decimals:
-            print(f"[WARN] sz_decimals not found for {symbol}, defaulting to 3", file=sys.stderr)
-        sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3)
+        sz_decimals = self._sz_decimals(symbol)
         size = round(size, sz_decimals)
         if size <= 0:
             raise ValueError(f"Size rounded to zero for {symbol} (sz_decimals={sz_decimals})")
@@ -280,9 +423,7 @@ class HyperliquidExchangeAdapter:
             )
         if sz is not None:
             # Round to asset's tick precision to avoid float_to_wire rounding error (#425)
-            if symbol not in self._info.asset_to_sz_decimals:
-                print(f"[WARN] sz_decimals not found for {symbol}, defaulting to 3", file=sys.stderr)
-            sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3)
+            sz_decimals = self._sz_decimals(symbol)
             sz = round(sz, sz_decimals)
             if sz <= 0:
                 raise ValueError(f"Size rounded to zero for {symbol} (sz_decimals={sz_decimals})")
@@ -318,6 +459,22 @@ class HyperliquidExchangeAdapter:
         while attempt < max_retries:
             try:
                 fills = self._info.user_fills_by_time(self._account_address, since_ms)
+            except _HLClientError as exc:
+                # 429 is a multi-second cool-down, not the sub-second indexer
+                # lag the retry budget exists for. Hammering through 4 retries
+                # at 0.5s intervals just deepens the rate-limit hole and turns
+                # one cycle's burst into a sustained outage (#768 fix #2). Bail
+                # immediately; callers fall through to modeled-fee / reconcile
+                # defaults. The over-close safety net is preserved because
+                # `_oid_filled_externally` treats {} as "no fill observed",
+                # not "OID confirmed unfilled".
+                if getattr(exc, "status_code", None) == 429:
+                    print(
+                        f"[WARN] userFills lookup got HTTP 429 for oid={oid}; not retrying",
+                        file=sys.stderr,
+                    )
+                    return {}
+                fills = None
             except Exception:
                 fills = None
             if isinstance(fills, list):
@@ -345,7 +502,7 @@ class HyperliquidExchangeAdapter:
         bookkeeping when the SL fills) can pre-round before calling
         ``place_stop_loss``; rounding is idempotent.
         """
-        sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3) if self._info else 3
+        sz_decimals = self._sz_decimals(symbol) if self._info else 3
         return _round_perps_px(px, sz_decimals)
 
     def place_stop_loss(
@@ -373,9 +530,7 @@ class HyperliquidExchangeAdapter:
             raise RuntimeError(
                 "place_stop_loss requires live mode (set HYPERLIQUID_SECRET_KEY)"
             )
-        if symbol not in self._info.asset_to_sz_decimals:
-            print(f"[WARN] sz_decimals not found for {symbol}, defaulting to 3", file=sys.stderr)
-        sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3)
+        sz_decimals = self._sz_decimals(symbol)
         sz = round(sz, sz_decimals)
         if sz <= 0:
             raise ValueError(f"Size rounded to zero for {symbol} (sz_decimals={sz_decimals})")
@@ -412,9 +567,7 @@ class HyperliquidExchangeAdapter:
             raise RuntimeError(
                 "place_take_profit_limit requires live mode (set HYPERLIQUID_SECRET_KEY)"
             )
-        if symbol not in self._info.asset_to_sz_decimals:
-            print(f"[WARN] sz_decimals not found for {symbol}, defaulting to 3", file=sys.stderr)
-        sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3)
+        sz_decimals = self._sz_decimals(symbol)
         sz = _floor_size(sz, sz_decimals)
         if sz <= 0:
             raise ValueError(f"Size floored to zero for {symbol} (sz_decimals={sz_decimals})")
@@ -430,7 +583,7 @@ class HyperliquidExchangeAdapter:
         """Exposes the same lot-precision flooring `place_take_profit_limit`
         applies internally, so callers can pre-compute the on-chain size each
         tier will occupy and absorb the remainder into a final tier."""
-        sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3) if self._info else 3
+        sz_decimals = self._sz_decimals(symbol) if self._info else 3
         return _floor_size(sz, sz_decimals)
 
     def round_size(self, symbol: str, sz: float) -> float:
@@ -441,7 +594,7 @@ class HyperliquidExchangeAdapter:
         0.0009999...).  place_stop_loss already uses round(); this makes TP
         tier sizing consistent.
         """
-        sz_decimals = self._info.asset_to_sz_decimals.get(symbol, 3) if self._info else 3
+        sz_decimals = self._sz_decimals(symbol) if self._info else 3
         return round(sz, sz_decimals)
 
     def open_order_oids(self, symbol: str | None = None) -> set[int]:

--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -31,21 +31,38 @@ META_CACHE_PATH = "/tmp/hl_meta.json"
 META_CACHE_TTL_S = 3600  # 60 minutes
 
 # SDK imports: defer to avoid module-level ImportError when SDK not installed.
-# adapter.py is loaded with platforms/hyperliquid/ directly in sys.path (not platforms/),
-# so `from hyperliquid.info import Info` resolves to the SDK package (site-packages),
-# not this local directory.
+# adapter.py is loaded with platforms/hyperliquid/ directly in sys.path (not
+# platforms/), so `from hyperliquid.info import Info` resolves to the SDK
+# package (site-packages), not this local directory.
+#
+# Info + Exchange are load-bearing — if either fails to import the adapter is
+# unusable. API + ClientError power the cache-miss fetch and 429 short-circuit
+# respectively; we degrade them gracefully in their own try blocks so a future
+# SDK reshuffle of those submodules doesn't take the whole adapter dark when
+# the core Info/Exchange surface is still intact (PR #769 review point 3).
 try:
     from hyperliquid.info import Info as _HLInfo
     from hyperliquid.exchange import Exchange as _HLExchange
-    from hyperliquid.api import API as _HLAPI
-    from hyperliquid.utils.error import ClientError as _HLClientError
     _SDK_AVAILABLE = True
 except ImportError:
     _HLInfo = None
     _HLExchange = None
-    _HLAPI = None
-    _HLClientError = Exception  # fall back so isinstance checks remain valid
     _SDK_AVAILABLE = False
+
+try:
+    from hyperliquid.api import API as _HLAPI
+except ImportError:
+    _HLAPI = None  # _build_info falls back to letting Info's constructor fetch
+
+try:
+    from hyperliquid.utils.error import ClientError as _HLClientError
+except ImportError:
+    # ClientError is what we match for HTTP 429 in lookup_fill_fee_by_oid.
+    # When absent, fall back to a sentinel that never matches a real HL
+    # error, so the 429 short-circuit silently degrades to the original
+    # retry path rather than catching unrelated exceptions.
+    class _HLClientError(Exception):
+        pass
 
 
 def _safe_float(v) -> float:
@@ -166,8 +183,13 @@ def _fetch_raw_meta(base_url: str):
     """POST /info {type:spotMeta} + {type:meta} via the SDK's API base class.
 
     Returns (spot_meta, meta) — same raw shape the SDK's Info constructor
-    consumes when passed via meta=/spot_meta= kwargs. Errors bubble.
+    consumes when passed via meta=/spot_meta= kwargs. Errors bubble. Raises
+    RuntimeError when the SDK's API class isn't importable so callers fall
+    back to letting the SDK's Info constructor do the fetch (preserves the
+    pre-#768 path).
     """
+    if _HLAPI is None:
+        raise RuntimeError("hyperliquid.api.API unavailable; cannot prefetch meta")
     api = _HLAPI(base_url=base_url)
     spot_meta = api.post("/info", {"type": "spotMeta"})
     meta = api.post("/info", {"type": "meta", "dex": ""})
@@ -197,6 +219,11 @@ class HyperliquidExchangeAdapter:
         self._info = self._build_info(base_url, allow_cache=True)
         self._account_address = addr
         self._exchange = None
+        # Symbols we've already refreshed meta for and still couldn't find —
+        # capped at one /info refresh per missing symbol per subprocess
+        # lifetime, otherwise a typo or delisted asset would re-fetch meta
+        # on every order operation. (PR #769 review point 2.)
+        self._sz_decimals_misses: set[str] = set()
 
         if secret:
             try:
@@ -253,15 +280,22 @@ class HyperliquidExchangeAdapter:
         """
         if self._info is not None and symbol in self._info.asset_to_sz_decimals:
             return self._info.asset_to_sz_decimals[symbol]
+        # Already tried to refresh for this symbol earlier in this subprocess
+        # and still couldn't find it — typo or genuinely unlisted asset; the
+        # cached universe will not save us. Skip the redundant /info calls.
+        if symbol in self._sz_decimals_misses:
+            return 3
         # Symbol missing — could be a stale cached universe. Refresh once.
         try:
             self._info = self._build_info(self._base_url, allow_cache=False)
         except Exception as exc:
             print(f"[WARN] hl meta refresh failed for {symbol}: {exc}", file=sys.stderr)
+            self._sz_decimals_misses.add(symbol)
             return 3
         if self._info is not None and symbol in self._info.asset_to_sz_decimals:
             return self._info.asset_to_sz_decimals[symbol]
         print(f"[WARN] sz_decimals not found for {symbol} after refresh, defaulting to 3", file=sys.stderr)
+        self._sz_decimals_misses.add(symbol)
         return 3
 
     @property

--- a/platforms/hyperliquid/test_adapter.py
+++ b/platforms/hyperliquid/test_adapter.py
@@ -7,26 +7,50 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 
-def _load_hl_adapter(mock_info_cls=None, mock_exchange_cls=None):
+def _load_hl_adapter(mock_info_cls=None, mock_exchange_cls=None, mock_api_cls=None):
     """Load the hyperliquid adapter with mocked SDK modules.
 
-    We inject fake hyperliquid.info.Info and hyperliquid.exchange.Exchange
-    before loading the adapter module, so it picks up _SDK_AVAILABLE = True.
+    Mocks hyperliquid.info.Info, hyperliquid.exchange.Exchange,
+    hyperliquid.api.API, and hyperliquid.utils.error.ClientError before
+    loading adapter.py so it picks up _SDK_AVAILABLE = True. ClientError
+    must be a real Exception subclass so the adapter's except clause is
+    a valid exception type.
     """
     info_mod = MagicMock()
     exchange_mod = MagicMock()
+    api_mod = MagicMock()
+    utils_pkg = MagicMock()
+    error_mod = MagicMock()
     hl_pkg = MagicMock()
 
     info_mod.Info = mock_info_cls or MagicMock()
     exchange_mod.Exchange = mock_exchange_cls or MagicMock()
+    api_mod.API = mock_api_cls or MagicMock()
+
+    class _StubClientError(Exception):
+        def __init__(self, status_code=None, *a, **kw):
+            super().__init__(*a, **kw)
+            self.status_code = status_code
+    error_mod.ClientError = _StubClientError
 
     saved = {}
-    for name in ("hyperliquid", "hyperliquid.info", "hyperliquid.exchange"):
+    mod_names = (
+        "hyperliquid",
+        "hyperliquid.info",
+        "hyperliquid.exchange",
+        "hyperliquid.api",
+        "hyperliquid.utils",
+        "hyperliquid.utils.error",
+    )
+    for name in mod_names:
         saved[name] = sys.modules.get(name)
 
     sys.modules["hyperliquid"] = hl_pkg
     sys.modules["hyperliquid.info"] = info_mod
     sys.modules["hyperliquid.exchange"] = exchange_mod
+    sys.modules["hyperliquid.api"] = api_mod
+    sys.modules["hyperliquid.utils"] = utils_pkg
+    sys.modules["hyperliquid.utils.error"] = error_mod
 
     try:
         adapter_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "adapter.py")

--- a/platforms/hyperliquid/test_meta_cache.py
+++ b/platforms/hyperliquid/test_meta_cache.py
@@ -1,0 +1,302 @@
+"""Tests for /tmp/hl_meta.json caching + 429 short-circuit in lookup_fill_fee_by_oid (#768)."""
+
+import importlib.util
+import json
+import os
+import sys
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _load_adapter_module():
+    """Load adapter.py with the same SDK mocks the existing suite uses.
+
+    We deliberately don't use _load_hl_adapter from test_adapter.py — we need
+    fresh module state per test to exercise module-level _load_meta_cache /
+    _save_meta_cache / _fetch_raw_meta in isolation.
+    """
+    info_mod = MagicMock()
+    exchange_mod = MagicMock()
+    api_mod = MagicMock()
+    utils_pkg = MagicMock()
+    error_mod = MagicMock()
+    hl_pkg = MagicMock()
+
+    info_mod.Info = MagicMock()
+    exchange_mod.Exchange = MagicMock()
+    api_mod.API = MagicMock()
+
+    class _StubClientError(Exception):
+        def __init__(self, status_code=None, *a, **kw):
+            super().__init__(*a, **kw)
+            self.status_code = status_code
+
+    error_mod.ClientError = _StubClientError
+
+    mod_names = (
+        "hyperliquid",
+        "hyperliquid.info",
+        "hyperliquid.exchange",
+        "hyperliquid.api",
+        "hyperliquid.utils",
+        "hyperliquid.utils.error",
+    )
+    saved = {name: sys.modules.get(name) for name in mod_names}
+    sys.modules["hyperliquid"] = hl_pkg
+    sys.modules["hyperliquid.info"] = info_mod
+    sys.modules["hyperliquid.exchange"] = exchange_mod
+    sys.modules["hyperliquid.api"] = api_mod
+    sys.modules["hyperliquid.utils"] = utils_pkg
+    sys.modules["hyperliquid.utils.error"] = error_mod
+
+    try:
+        path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "adapter.py")
+        spec = importlib.util.spec_from_file_location("hl_adapter_cache_test", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    finally:
+        for name, orig in saved.items():
+            if orig is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = orig
+
+    # Hand back the StubClientError too so 429 tests can raise it.
+    mod._test_stub_client_error = _StubClientError
+    return mod
+
+
+@pytest.fixture
+def adapter_mod():
+    return _load_adapter_module()
+
+
+@pytest.fixture
+def cache_path(tmp_path):
+    return str(tmp_path / "hl_meta.json")
+
+
+# ─── Cache load/save round-trip ────────────────────────────────────
+
+def _sample_meta():
+    return (
+        {"universe": [{"index": 0, "name": "USDC/USDC", "tokens": [0, 0]}],
+         "tokens": [{"name": "USDC", "szDecimals": 0}]},
+        {"universe": [{"name": "BTC", "szDecimals": 5}, {"name": "ETH", "szDecimals": 4}]},
+    )
+
+
+def test_save_then_load_returns_payload(adapter_mod, cache_path):
+    spot_meta, meta = _sample_meta()
+    adapter_mod._save_meta_cache(spot_meta, meta, path=cache_path)
+    got = adapter_mod._load_meta_cache(path=cache_path)
+    assert got is not None
+    got_spot, got_meta = got
+    assert got_spot == spot_meta
+    assert got_meta == meta
+
+
+def test_load_returns_none_when_file_missing(adapter_mod, cache_path):
+    assert adapter_mod._load_meta_cache(path=cache_path) is None
+
+
+def test_load_returns_none_when_ttl_expired(adapter_mod, cache_path):
+    spot_meta, meta = _sample_meta()
+    # Manually stamp an old timestamp so we don't have to wait.
+    payload = {"ts": time.time() - 7200, "spot_meta": spot_meta, "meta": meta}
+    with open(cache_path, "w") as f:
+        json.dump(payload, f)
+    # TTL is 3600s; 7200s-old cache must be a miss.
+    assert adapter_mod._load_meta_cache(path=cache_path) is None
+
+
+def test_load_within_ttl_returns_payload(adapter_mod, cache_path):
+    spot_meta, meta = _sample_meta()
+    payload = {"ts": time.time() - 60, "spot_meta": spot_meta, "meta": meta}
+    with open(cache_path, "w") as f:
+        json.dump(payload, f)
+    got = adapter_mod._load_meta_cache(path=cache_path)
+    assert got is not None
+
+
+def test_load_rejects_empty_universe(adapter_mod, cache_path):
+    # An empty universe would silently bypass the symbol-miss guardrail —
+    # treat as cache miss so we re-fetch.
+    payload = {
+        "ts": time.time(),
+        "spot_meta": {"universe": [], "tokens": []},
+        "meta": {"universe": []},
+    }
+    with open(cache_path, "w") as f:
+        json.dump(payload, f)
+    assert adapter_mod._load_meta_cache(path=cache_path) is None
+
+
+def test_load_rejects_garbage(adapter_mod, cache_path):
+    with open(cache_path, "w") as f:
+        f.write("not json")
+    assert adapter_mod._load_meta_cache(path=cache_path) is None
+
+
+def test_save_atomic_replace_does_not_leak_tmp(adapter_mod, cache_path, tmp_path):
+    spot_meta, meta = _sample_meta()
+    adapter_mod._save_meta_cache(spot_meta, meta, path=cache_path)
+    # No `.hl_meta_*` leftover from the mkstemp side.
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.startswith(".hl_meta_")]
+    assert leftovers == []
+    assert os.path.exists(cache_path)
+
+
+def test_save_unserializable_payload_swallows_error(adapter_mod, cache_path):
+    """A bogus payload (e.g. a MagicMock from a misconfigured SDK mock) must
+    not raise — caching is best-effort.
+    """
+    # MagicMock is not JSON-serializable; the helper must log and return.
+    adapter_mod._save_meta_cache(MagicMock(), MagicMock(), path=cache_path)
+    # Either no file or no leftover .hl_meta_* — both are acceptable.
+    if os.path.exists(cache_path):
+        pytest.fail("cache file should not exist after a failed save")
+
+
+# ─── 429 short-circuit ─────────────────────────────────────────────
+
+def _make_live_adapter(adapter_mod, monkeypatch):
+    """Build an adapter instance with a fake address and a controllable Info."""
+    monkeypatch.setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xdeadbeef")
+    # Pre-seed the cache so __init__ doesn't try to network-fetch.
+    monkeypatch.setattr(adapter_mod, "_load_meta_cache",
+                        lambda *a, **kw: (
+                            {"universe": [], "tokens": []},
+                            {"universe": [{"name": "BTC", "szDecimals": 5}]},
+                        ))
+    a = adapter_mod.HyperliquidExchangeAdapter()
+    # Replace Info with a stub we can poke.
+    a._info = MagicMock()
+    return a
+
+
+def test_lookup_fill_fee_returns_empty_on_429_and_no_retry(adapter_mod, monkeypatch):
+    a = _make_live_adapter(adapter_mod, monkeypatch)
+    err = adapter_mod._test_stub_client_error(status_code=429)
+    a._info.user_fills_by_time = MagicMock(side_effect=err)
+
+    sleeps = []
+    monkeypatch.setattr(adapter_mod.time, "sleep", lambda s: sleeps.append(s))
+
+    result = a.lookup_fill_fee_by_oid(oid=12345, since_ms=0)
+    assert result == {}
+    # Single attempt — no retry budget burned.
+    assert a._info.user_fills_by_time.call_count == 1
+    assert sleeps == []
+
+
+def test_lookup_fill_fee_still_retries_non_429_errors(adapter_mod, monkeypatch):
+    """Other ClientErrors (and generic Exceptions) must keep the original
+    retry behavior — only 429 short-circuits.
+    """
+    a = _make_live_adapter(adapter_mod, monkeypatch)
+    # Mix: 500-like error first, then a successful empty fills list.
+    err = adapter_mod._test_stub_client_error(status_code=500)
+    call_count = {"n": 0}
+
+    def side(addr, since_ms):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise err
+        return []
+    a._info.user_fills_by_time = side
+
+    sleeps = []
+    monkeypatch.setattr(adapter_mod.time, "sleep", lambda s: sleeps.append(s))
+
+    result = a.lookup_fill_fee_by_oid(oid=12345, since_ms=0, max_retries=4)
+    assert result == {}
+    assert call_count["n"] >= 2
+    assert len(sleeps) >= 1
+
+
+def test_lookup_fill_fee_returns_real_fill_on_match(adapter_mod, monkeypatch):
+    """Sanity: matched OIDs still sum fees and closed_pnl correctly so we
+    don't regress the happy path while adding the 429 branch.
+    """
+    a = _make_live_adapter(adapter_mod, monkeypatch)
+    a._info.user_fills_by_time = MagicMock(return_value=[
+        {"oid": 42, "fee": "0.10", "closedPnl": "1.50"},
+        {"oid": 42, "fee": "0.05", "closedPnl": "0.75"},
+        {"oid": 999, "fee": "0.99", "closedPnl": "9.99"},  # different OID
+    ])
+    monkeypatch.setattr(adapter_mod.time, "sleep", lambda s: None)
+    result = a.lookup_fill_fee_by_oid(oid=42, since_ms=0)
+    assert result["count"] == 2
+    assert result["fee"] == pytest.approx(0.15)
+    assert result["closed_pnl"] == pytest.approx(2.25)
+
+
+# ─── _sz_decimals symbol-miss force-refresh ────────────────────────
+
+def test_sz_decimals_refreshes_on_missing_symbol(adapter_mod, monkeypatch):
+    """When a symbol is not in the cached universe (stale cache after HL adds
+    a new coin), _sz_decimals must force a meta refresh once before falling
+    back to 3.
+    """
+    monkeypatch.setattr(adapter_mod, "_load_meta_cache",
+                        lambda *a, **kw: (
+                            {"universe": [], "tokens": []},
+                            {"universe": [{"name": "BTC", "szDecimals": 5}]},
+                        ))
+    a = adapter_mod.HyperliquidExchangeAdapter()
+
+    # Initial cached map: only BTC known.
+    a._info = MagicMock()
+    a._info.asset_to_sz_decimals = {"BTC": 5}
+
+    # Refresh path: _build_info returns a new Info whose map includes NEWCOIN.
+    refreshed = MagicMock()
+    refreshed.asset_to_sz_decimals = {"BTC": 5, "NEWCOIN": 2}
+    monkeypatch.setattr(a, "_build_info", lambda base_url, allow_cache: refreshed)
+
+    assert a._sz_decimals("NEWCOIN") == 2
+    # And the refreshed Info is retained on the adapter.
+    assert a._info is refreshed
+
+
+def test_sz_decimals_returns_3_when_still_missing_after_refresh(adapter_mod, monkeypatch):
+    monkeypatch.setattr(adapter_mod, "_load_meta_cache",
+                        lambda *a, **kw: (
+                            {"universe": [], "tokens": []},
+                            {"universe": [{"name": "BTC", "szDecimals": 5}]},
+                        ))
+    a = adapter_mod.HyperliquidExchangeAdapter()
+    a._info = MagicMock()
+    a._info.asset_to_sz_decimals = {"BTC": 5}
+
+    refreshed = MagicMock()
+    refreshed.asset_to_sz_decimals = {"BTC": 5}  # still missing UNLISTED
+    monkeypatch.setattr(a, "_build_info", lambda base_url, allow_cache: refreshed)
+
+    assert a._sz_decimals("UNLISTED") == 3
+
+
+def test_sz_decimals_uses_cached_value_without_refresh(adapter_mod, monkeypatch):
+    monkeypatch.setattr(adapter_mod, "_load_meta_cache",
+                        lambda *a, **kw: (
+                            {"universe": [], "tokens": []},
+                            {"universe": [{"name": "BTC", "szDecimals": 5}]},
+                        ))
+    a = adapter_mod.HyperliquidExchangeAdapter()
+    a._info = MagicMock()
+    a._info.asset_to_sz_decimals = {"BTC": 5, "ETH": 4}
+
+    rebuilt = {"called": False}
+
+    def fake_build(base_url, allow_cache):
+        rebuilt["called"] = True
+        return MagicMock()
+
+    monkeypatch.setattr(a, "_build_info", fake_build)
+
+    assert a._sz_decimals("BTC") == 5
+    assert a._sz_decimals("ETH") == 4
+    assert rebuilt["called"] is False

--- a/platforms/hyperliquid/test_meta_cache.py
+++ b/platforms/hyperliquid/test_meta_cache.py
@@ -262,6 +262,44 @@ def test_sz_decimals_refreshes_on_missing_symbol(adapter_mod, monkeypatch):
     assert a._info is refreshed
 
 
+def test_sz_decimals_caches_misses_to_avoid_repeat_refresh(adapter_mod, monkeypatch):
+    """A typo'd or genuinely-unlisted symbol must only trigger one meta
+    refresh per subprocess. Without the miss cache, every subsequent
+    order/round/floor call would fire 2 fresh /info calls — exactly the
+    burst behavior #768 set out to eliminate. (PR #769 review point 2.)
+    """
+    monkeypatch.setattr(adapter_mod, "_load_meta_cache",
+                        lambda *a, **kw: (
+                            {"universe": [], "tokens": []},
+                            {"universe": [{"name": "BTC", "szDecimals": 5}]},
+                        ))
+    a = adapter_mod.HyperliquidExchangeAdapter()
+    a._info = MagicMock()
+    a._info.asset_to_sz_decimals = {"BTC": 5}
+
+    refresh_calls = {"n": 0}
+
+    def fake_build(base_url, allow_cache):
+        refresh_calls["n"] += 1
+        refreshed = MagicMock()
+        # Refresh doesn't bring UNLISTED in — typo or delisted.
+        refreshed.asset_to_sz_decimals = {"BTC": 5}
+        return refreshed
+
+    monkeypatch.setattr(a, "_build_info", fake_build)
+
+    # First call: refresh fires, miss is recorded.
+    assert a._sz_decimals("UNLISTED") == 3
+    assert refresh_calls["n"] == 1
+    # Subsequent calls: short-circuit on the recorded miss, no more refreshes.
+    for _ in range(5):
+        assert a._sz_decimals("UNLISTED") == 3
+    assert refresh_calls["n"] == 1
+    # And a different missing symbol still gets its one refresh.
+    assert a._sz_decimals("ALSOUNLISTED") == 3
+    assert refresh_calls["n"] == 2
+
+
 def test_sz_decimals_returns_3_when_still_missing_after_refresh(adapter_mod, monkeypatch):
     monkeypatch.setattr(adapter_mod, "_load_meta_cache",
                         lambda *a, **kw: (

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -308,7 +308,17 @@ func RunHyperliquidCheck(script string, args []string) (*HyperliquidResult, stri
 // Python script calls adapter.market_close(sz=None) — closing the entire
 // on-chain residual without a sized order, eliminating rounding dust on final
 // TP tiers (#592).
-func buildHyperliquidExecuteArgs(symbol, side string, size, stopLossPct float64, cancelStopLossOID int64, prevPosQty float64, marginMode string, leverage float64, closeFullPosition bool, extraCancelOIDs ...int64) []string {
+// hlExecuteSnapshot carries cycle-local on-chain state from Go's Phase 1
+// clearinghouseState fetch into the --execute argv (#768 fix #4). When both
+// fields are present, Python skips its duplicate get_position_leverage /info
+// call. Zero-valued fields are omitted from argv — Python falls back to the
+// original fetch path.
+type hlExecuteSnapshot struct {
+	AccountLeverage   int    // on-chain leverage value for the symbol (0 == unknown)
+	AccountMarginMode string // "isolated" | "cross" (empty == unknown)
+}
+
+func buildHyperliquidExecuteArgs(symbol, side string, size, stopLossPct float64, cancelStopLossOID int64, prevPosQty float64, marginMode string, leverage float64, closeFullPosition bool, snapshot hlExecuteSnapshot, extraCancelOIDs ...int64) []string {
 	args := []string{
 		"--execute",
 		fmt.Sprintf("--symbol=%s", symbol),
@@ -339,14 +349,21 @@ func buildHyperliquidExecuteArgs(symbol, side string, size, stopLossPct float64,
 		if leverage > 0 {
 			args = append(args, fmt.Sprintf("--leverage=%g", leverage))
 		}
+		// Forward Go's clearinghouseState snapshot only when both fields are
+		// known — Python ignores partial snapshots and falls back to its own
+		// get_position_leverage call.
+		if snapshot.AccountLeverage > 0 && (snapshot.AccountMarginMode == "isolated" || snapshot.AccountMarginMode == "cross") {
+			args = append(args, fmt.Sprintf("--account-leverage=%d", snapshot.AccountLeverage))
+			args = append(args, fmt.Sprintf("--account-margin-mode=%s", snapshot.AccountMarginMode))
+		}
 	}
 	return args
 }
 
 // RunHyperliquidExecute runs check_hyperliquid.py in execute mode (live orders).
 // See buildHyperliquidExecuteArgs for argv-contract details.
-func RunHyperliquidExecute(script, symbol, side string, size, stopLossPct float64, cancelStopLossOID int64, prevPosQty float64, marginMode string, leverage float64, closeFullPosition bool, extraCancelOIDs ...int64) (*HyperliquidExecuteResult, string, error) {
-	args := buildHyperliquidExecuteArgs(symbol, side, size, stopLossPct, cancelStopLossOID, prevPosQty, marginMode, leverage, closeFullPosition, extraCancelOIDs...)
+func RunHyperliquidExecute(script, symbol, side string, size, stopLossPct float64, cancelStopLossOID int64, prevPosQty float64, marginMode string, leverage float64, closeFullPosition bool, snapshot hlExecuteSnapshot, extraCancelOIDs ...int64) (*HyperliquidExecuteResult, string, error) {
+	args := buildHyperliquidExecuteArgs(symbol, side, size, stopLossPct, cancelStopLossOID, prevPosQty, marginMode, leverage, closeFullPosition, snapshot, extraCancelOIDs...)
 	stdout, stderr, err := runPythonSideEffect(script, args)
 	return parseHyperliquidExecuteOutput(stdout, string(stderr), err)
 }

--- a/scheduler/executor_test.go
+++ b/scheduler/executor_test.go
@@ -613,7 +613,7 @@ func argsHasPrefix(args []string, prefix string) bool {
 // the Python script calls adapter.market_close(sz=None) instead of
 // market_open(size). This is the load-bearing #592 contract.
 func TestBuildHyperliquidExecuteArgs_CloseFullPosition(t *testing.T) {
-	args := buildHyperliquidExecuteArgs("ETH", "sell", 0, 0, 0, 0, "", 0, true)
+	args := buildHyperliquidExecuteArgs("ETH", "sell", 0, 0, 0, 0, "", 0, true, hlExecuteSnapshot{})
 
 	if !argsContains(args, "--close-full-position") {
 		t.Errorf("expected --close-full-position flag in argv, got %v", args)
@@ -633,7 +633,7 @@ func TestBuildHyperliquidExecuteArgs_CloseFullPosition(t *testing.T) {
 // --close-full-position. This is the path used for shared-coin peers and for
 // partial closes.
 func TestBuildHyperliquidExecuteArgs_SizedClose(t *testing.T) {
-	args := buildHyperliquidExecuteArgs("ETH", "sell", 0.42, 0, 0, 0, "", 0, false)
+	args := buildHyperliquidExecuteArgs("ETH", "sell", 0.42, 0, 0, 0, "", 0, false, hlExecuteSnapshot{})
 
 	if argsContains(args, "--close-full-position") {
 		t.Errorf("--close-full-position must be omitted when closeFullPosition=false, got %v", args)
@@ -650,7 +650,7 @@ func TestBuildHyperliquidExecuteArgs_SizedClose(t *testing.T) {
 // --cancel-stop-loss-oid flags (mirrors the posQty>0 && !partialClose gate in
 // main.go that cancels every tier TP OID on a full or flip close).
 func TestBuildHyperliquidExecuteArgs_ExtraCancelOIDsFullClose(t *testing.T) {
-	args := buildHyperliquidExecuteArgs("ETH", "sell", 0, 0, 0, 0, "", 0, true, 111, 222, 333)
+	args := buildHyperliquidExecuteArgs("ETH", "sell", 0, 0, 0, 0, "", 0, true, hlExecuteSnapshot{}, 111, 222, 333)
 
 	for _, want := range []string{"--cancel-stop-loss-oid=111", "--cancel-stop-loss-oid=222", "--cancel-stop-loss-oid=333"} {
 		if !argsContains(args, want) {
@@ -664,7 +664,7 @@ func TestBuildHyperliquidExecuteArgs_ExtraCancelOIDsFullClose(t *testing.T) {
 func TestBuildHyperliquidExecuteArgs_ExtraCancelOIDsPartialClose(t *testing.T) {
 	// No extraCancelOIDs passed — matches what runHyperliquidExecuteOrder does on
 	// a partial close.
-	args := buildHyperliquidExecuteArgs("ETH", "sell", 0.5, 0, 0, 0, "", 0, false)
+	args := buildHyperliquidExecuteArgs("ETH", "sell", 0.5, 0, 0, 0, "", 0, false, hlExecuteSnapshot{})
 
 	for _, notWant := range []string{"--cancel-stop-loss-oid=111", "--cancel-stop-loss-oid=222"} {
 		if argsContains(args, notWant) {
@@ -676,7 +676,7 @@ func TestBuildHyperliquidExecuteArgs_ExtraCancelOIDsPartialClose(t *testing.T) {
 // Optional flags should be conditionally present.
 func TestBuildHyperliquidExecuteArgs_OptionalFlags(t *testing.T) {
 	t.Run("no optional flags", func(t *testing.T) {
-		args := buildHyperliquidExecuteArgs("BTC", "buy", 0.001, 0, 0, 0, "", 0, false)
+		args := buildHyperliquidExecuteArgs("BTC", "buy", 0.001, 0, 0, 0, "", 0, false, hlExecuteSnapshot{})
 		for _, prefix := range []string{"--stop-loss-pct=", "--cancel-stop-loss-oid=", "--prev-pos-qty=", "--margin-mode=", "--leverage="} {
 			if argsHasPrefix(args, prefix) {
 				t.Errorf("expected %s to be omitted, got %v", prefix, args)
@@ -684,7 +684,7 @@ func TestBuildHyperliquidExecuteArgs_OptionalFlags(t *testing.T) {
 		}
 	})
 	t.Run("all optional flags", func(t *testing.T) {
-		args := buildHyperliquidExecuteArgs("BTC", "buy", 0.001, 2.5, 12345, 0.0005, "isolated", 5, false)
+		args := buildHyperliquidExecuteArgs("BTC", "buy", 0.001, 2.5, 12345, 0.0005, "isolated", 5, false, hlExecuteSnapshot{})
 		for _, want := range []string{"--stop-loss-pct=2.5", "--cancel-stop-loss-oid=12345", "--prev-pos-qty=0.0005", "--margin-mode=isolated", "--leverage=5"} {
 			if !argsContains(args, want) {
 				t.Errorf("expected %q in argv, got %v", want, args)
@@ -694,7 +694,7 @@ func TestBuildHyperliquidExecuteArgs_OptionalFlags(t *testing.T) {
 	t.Run("margin mode without leverage", func(t *testing.T) {
 		// leverage=0 with non-empty margin_mode: --leverage must not appear (would
 		// confuse the Python validator) but --margin-mode is still emitted.
-		args := buildHyperliquidExecuteArgs("BTC", "buy", 0.001, 0, 0, 0, "cross", 0, false)
+		args := buildHyperliquidExecuteArgs("BTC", "buy", 0.001, 0, 0, 0, "cross", 0, false, hlExecuteSnapshot{})
 		if !argsContains(args, "--margin-mode=cross") {
 			t.Errorf("expected --margin-mode=cross, got %v", args)
 		}
@@ -702,6 +702,79 @@ func TestBuildHyperliquidExecuteArgs_OptionalFlags(t *testing.T) {
 			t.Errorf("--leverage must be omitted when leverage=0, got %v", args)
 		}
 	})
+}
+
+// #768 fix #4: --account-leverage / --account-margin-mode must appear in argv
+// ONLY when both fields are present AND --margin-mode is being enforced. The
+// Python side only consults them inside the `if margin_mode:` branch.
+func TestBuildHyperliquidExecuteArgs_AccountSnapshotForwarded(t *testing.T) {
+	snap := hlExecuteSnapshot{AccountLeverage: 10, AccountMarginMode: "isolated"}
+	args := buildHyperliquidExecuteArgs("BTC", "buy", 0.001, 0, 0, 0, "isolated", 10, false, snap)
+	for _, want := range []string{"--account-leverage=10", "--account-margin-mode=isolated"} {
+		if !argsContains(args, want) {
+			t.Errorf("expected %q in argv when snapshot is known, got %v", want, args)
+		}
+	}
+}
+
+func TestBuildHyperliquidExecuteArgs_AccountSnapshotOmittedWhenIncomplete(t *testing.T) {
+	cases := []struct {
+		name string
+		snap hlExecuteSnapshot
+	}{
+		{"zero leverage", hlExecuteSnapshot{AccountMarginMode: "isolated"}},
+		{"empty mode", hlExecuteSnapshot{AccountLeverage: 10}},
+		{"invalid mode", hlExecuteSnapshot{AccountLeverage: 10, AccountMarginMode: "weird"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := buildHyperliquidExecuteArgs("BTC", "buy", 0.001, 0, 0, 0, "isolated", 10, false, tc.snap)
+			for _, prefix := range []string{"--account-leverage=", "--account-margin-mode="} {
+				if argsHasPrefix(args, prefix) {
+					t.Errorf("expected %s to be omitted on incomplete snapshot (%s), got %v", prefix, tc.name, args)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildHyperliquidExecuteArgs_AccountSnapshotOmittedWithoutMarginMode(t *testing.T) {
+	// Python only consults --account-leverage inside the `if margin_mode:`
+	// branch; forwarding it when margin_mode is empty would be wasted argv
+	// noise. Verify the omission so we don't drift from that contract.
+	snap := hlExecuteSnapshot{AccountLeverage: 10, AccountMarginMode: "isolated"}
+	args := buildHyperliquidExecuteArgs("BTC", "buy", 0.001, 0, 0, 0, "", 0, false, snap)
+	for _, prefix := range []string{"--account-leverage=", "--account-margin-mode="} {
+		if argsHasPrefix(args, prefix) {
+			t.Errorf("expected %s to be omitted when margin-mode is empty, got %v", prefix, args)
+		}
+	}
+}
+
+func TestHLExecuteSnapshotForCoin(t *testing.T) {
+	positions := []HLPosition{
+		{Coin: "BTC", Size: 0.1, EntryPrice: 60000, Leverage: 10, MarginMode: "isolated"},
+		{Coin: "ETH", Size: -2, EntryPrice: 3000, Leverage: 5, MarginMode: "cross"},
+		{Coin: "SOL", Size: 100, EntryPrice: 150, Leverage: 0, MarginMode: ""}, // bogus row — skip
+	}
+	if got := hlExecuteSnapshotForCoin(positions, "BTC"); got.AccountLeverage != 10 || got.AccountMarginMode != "isolated" {
+		t.Errorf("BTC snapshot = %+v, want lev=10 mode=isolated", got)
+	}
+	if got := hlExecuteSnapshotForCoin(positions, "ETH"); got.AccountLeverage != 5 || got.AccountMarginMode != "cross" {
+		t.Errorf("ETH snapshot = %+v, want lev=5 mode=cross", got)
+	}
+	// Bogus rows (missing margin mode) must yield zero — Python falls back.
+	if got := hlExecuteSnapshotForCoin(positions, "SOL"); got != (hlExecuteSnapshot{}) {
+		t.Errorf("SOL with bogus row should yield zero, got %+v", got)
+	}
+	// Unknown coin yields zero.
+	if got := hlExecuteSnapshotForCoin(positions, "XRP"); got != (hlExecuteSnapshot{}) {
+		t.Errorf("unknown coin should yield zero, got %+v", got)
+	}
+	// Empty coin string yields zero.
+	if got := hlExecuteSnapshotForCoin(positions, ""); got != (hlExecuteSnapshot{}) {
+		t.Errorf("empty coin should yield zero, got %+v", got)
+	}
 }
 
 func TestBuildHyperliquidSyncProtectionArgv_TPArmedTiersJSON(t *testing.T) {

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -22,6 +22,31 @@ type HLPosition struct {
 	Size       float64 // signed: positive = long, negative = short
 	EntryPrice float64
 	Leverage   float64 // on-chain leverage value (#254)
+	MarginMode string  // "isolated" | "cross" — forwarded to Python so it can skip a duplicate /info call (#768)
+}
+
+// hlExecuteSnapshotForCoin extracts the cycle-local on-chain leverage + margin
+// mode for “coin“ from the Phase 1 clearinghouseState snapshot. Returns a
+// zero-valued snapshot when “coin“ has no open position (the wallet only
+// reports leverage for assets with non-zero size), in which case Python falls
+// back to its own get_position_leverage call (#768 fix #4).
+func hlExecuteSnapshotForCoin(positions []HLPosition, coin string) hlExecuteSnapshot {
+	if coin == "" {
+		return hlExecuteSnapshot{}
+	}
+	for _, p := range positions {
+		if p.Coin != coin {
+			continue
+		}
+		if p.Leverage < 1 || (p.MarginMode != "isolated" && p.MarginMode != "cross") {
+			return hlExecuteSnapshot{}
+		}
+		return hlExecuteSnapshot{
+			AccountLeverage:   int(p.Leverage),
+			AccountMarginMode: p.MarginMode,
+		}
+	}
+	return hlExecuteSnapshot{}
 }
 
 // hlReconcileSLFillConfirmed mirrors the #685 sole-owner vanish gate for
@@ -221,11 +246,21 @@ func fetchHyperliquidState(accountAddress string) (float64, []HLPosition, error)
 				lev = parsed
 			}
 		}
+		// #768: also capture the margin-mode label so Python can skip its
+		// duplicate get_position_leverage /info call on --execute. HL returns
+		// "isolated" or "cross"; any other value is ignored (Python falls
+		// through to today's fetch path).
+		mode := ""
+		switch ap.Position.Leverage.Type {
+		case "isolated", "cross":
+			mode = ap.Position.Leverage.Type
+		}
 		positions = append(positions, HLPosition{
 			Coin:       ap.Position.Coin,
 			Size:       szi,
 			EntryPrice: entryPx,
 			Leverage:   lev,
+			MarginMode: mode,
 		})
 	}
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1583,7 +1583,13 @@ func main() {
 								runPostTPStopLossAdjustment(sc, stratState, result.Symbol, price, cfg, &mu, notifier, logger, hlOnChainAbsQty)
 							}
 							if hyperliquidIsLive(sc.Args) && result.Signal != 0 {
-								er, ok2 := runHyperliquidExecuteOrder(sc, result, price, hlCash, hlPosQty, hlPosSide, hlAvgCost, hlStopLossOID, hlTPOIDs, hlReconcileAll, notifier, logger)
+								// #768 fix #4: Forward Go's clearinghouseState
+								// snapshot for this coin so Python can skip its
+								// duplicate get_position_leverage /info call.
+								// Only meaningful when a peer/prior position
+								// has the leverage already pinned on-chain.
+								walletSnapshot := hlExecuteSnapshotForCoin(hlPositions, result.Symbol)
+								er, ok2 := runHyperliquidExecuteOrder(sc, result, price, hlCash, hlPosQty, hlPosSide, hlAvgCost, hlStopLossOID, hlTPOIDs, hlReconcileAll, walletSnapshot, notifier, logger)
 								if ok2 {
 									execResult = er
 								} else {
@@ -1698,7 +1704,7 @@ func main() {
 								}
 								execResult, execStderr, execErr := RunHyperliquidExecute(
 									sc.Script, sc.Symbol, closeSide, closeQty,
-									0, cancelOID, 0, "", 0, closeFullPosition, extraCancelOIDs...,
+									0, cancelOID, 0, "", 0, closeFullPosition, hlExecuteSnapshot{}, extraCancelOIDs...,
 								)
 								if execStderr != "" {
 									logger.Info("HL manual close stderr: %s", execStderr)
@@ -2457,6 +2463,14 @@ func runHyperliquidCheck(sc StrategyConfig, prices map[string]float64, posCtx Po
 	} else if len(refsArgs) > 0 {
 		args = append(args, refsArgs...)
 	}
+	// #768 fix #3: Forward Go's cycle-local allMids snapshot so Python skips
+	// its duplicate adapter.get_spot_price /info call. Same source, seconds
+	// old, used only to freshen the display price.
+	if sym := hyperliquidSymbol(sc.Args); sym != "" {
+		if mid, ok := prices[sym]; ok && mid > 0 {
+			args = append(args, fmt.Sprintf("--mark-price=%g", mid))
+		}
+	}
 	logger.Info("Running: python3 %s %v", sc.Script, args)
 
 	result, stderr, err := RunHyperliquidCheck(sc.Script, args)
@@ -2529,7 +2543,7 @@ func shouldCloseFullPosition(closeFraction float64, symbol string, hlLiveAll []S
 // Trade record, leaving state silently behind actual exchange holdings. See
 // issue #298 — 0.716 ETH of live fills were lost this way because the
 // "already long, skipping buy" branch sat AFTER RunHyperliquidExecute.
-func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, price, cash, posQty float64, posSide string, avgCost float64, existingStopLossOID int64, existingTPOIDs []int64, hlLiveAll []StrategyConfig, notifier *MultiNotifier, logger *StrategyLogger) (*HyperliquidExecuteResult, bool) {
+func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, price, cash, posQty float64, posSide string, avgCost float64, existingStopLossOID int64, existingTPOIDs []int64, hlLiveAll []StrategyConfig, walletSnapshot hlExecuteSnapshot, notifier *MultiNotifier, logger *StrategyLogger) (*HyperliquidExecuteResult, bool) {
 	directionEnum := EffectiveDirection(sc)
 	if reason := PerpsOrderSkipReason(result.Signal, posSide, directionEnum); reason != "" {
 		logger.Info("Skipping live order for %s: %s", result.Symbol, reason)
@@ -2641,7 +2655,7 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	} else if result.CloseFraction == 1.0 {
 		logger.Info("Final-tier close %s shares coin with HL perps peers — using sized close to preserve peer exposure", result.Symbol)
 	}
-	execResult, stderr, err := RunHyperliquidExecute(sc.Script, result.Symbol, side, size, slPct, cancelOID, prevPosQty, marginMode, leverageForOpen, closeFullPosition, extraCancelOIDs...)
+	execResult, stderr, err := RunHyperliquidExecute(sc.Script, result.Symbol, side, size, slPct, cancelOID, prevPosQty, marginMode, leverageForOpen, closeFullPosition, walletSnapshot, extraCancelOIDs...)
 	if stderr != "" {
 		logger.Info("execute stderr: %s", stderr)
 	}

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -211,6 +211,7 @@ func runManualOpen(args []string) int {
 			script, sc.Symbol, openSide,
 			resolvedOrderSize,
 			effectiveSLPct, 0, 0, sc.MarginMode, sc.Leverage, false,
+			hlExecuteSnapshot{},
 		)
 		if execStderr != "" {
 			fmt.Fprintf(os.Stderr, "HL execute stderr: %s\n", execStderr)
@@ -479,7 +480,7 @@ func runManualClose(args []string) int {
 
 	execResult, stderr, execErr := RunHyperliquidExecute(
 		sc.Script, sc.Symbol, closeSide, closeQty,
-		0, cancelOID, 0, "", 0, closeFullPosition, extraCancelOIDs...,
+		0, cancelOID, 0, "", 0, closeFullPosition, hlExecuteSnapshot{}, extraCancelOIDs...,
 	)
 	if stderr != "" {
 		fmt.Fprintf(os.Stderr, "HL close stderr: %s\n", stderr)

--- a/scheduler/probe_cmd_test.go
+++ b/scheduler/probe_cmd_test.go
@@ -57,6 +57,10 @@ func TestRunProbeHappyPath(t *testing.T) {
 				mode = "fetch-atr"
 				break
 			}
+			if a == "--execute" {
+				mode = "execute"
+				break
+			}
 		}
 		probed = append(probed, probeCall{script, mode})
 		return nil
@@ -102,26 +106,28 @@ func TestRunProbeHappyPath(t *testing.T) {
 	if rc != 0 {
 		t.Fatalf("happy-path probe should return 0, got %d", rc)
 	}
-	// Expect 4 invocations: HL signal-check, HL --fetch-atr (#689), spot
-	// signal-check, and the dashboard candle helper.
-	if len(probed) != 4 {
-		t.Fatalf("expected 4 probe invocations, got %d: %v", len(probed), probed)
+	// Expect 5 invocations: HL signal-check, HL --fetch-atr (#689), HL
+	// --execute (PR #769), spot signal-check, and the dashboard candle helper.
+	if len(probed) != 5 {
+		t.Fatalf("expected 5 probe invocations, got %d: %v", len(probed), probed)
 	}
-	var hlSignal, hlFetchATR, spotSignal, candleHelper int
+	var hlSignal, hlFetchATR, hlExecute, spotSignal, candleHelper int
 	for _, p := range probed {
 		switch {
 		case p.script == "shared_scripts/check_hyperliquid.py" && p.mode == "signal":
 			hlSignal++
 		case p.script == "shared_scripts/check_hyperliquid.py" && p.mode == "fetch-atr":
 			hlFetchATR++
+		case p.script == "shared_scripts/check_hyperliquid.py" && p.mode == "execute":
+			hlExecute++
 		case p.script == "shared_scripts/check_strategy.py" && p.mode == "signal":
 			spotSignal++
 		case p.script == "shared_scripts/fetch_candles.py" && p.mode == "signal":
 			candleHelper++
 		}
 	}
-	if hlSignal != 1 || hlFetchATR != 1 || spotSignal != 1 || candleHelper != 1 {
-		t.Fatalf("expected 1 of each (hl-signal, hl-fetch-atr, spot-signal, candle-helper); got %d/%d/%d/%d (probed=%v)",
-			hlSignal, hlFetchATR, spotSignal, candleHelper, probed)
+	if hlSignal != 1 || hlFetchATR != 1 || hlExecute != 1 || spotSignal != 1 || candleHelper != 1 {
+		t.Fatalf("expected 1 of each (hl-signal, hl-fetch-atr, hl-execute, spot-signal, candle-helper); got %d/%d/%d/%d/%d (probed=%v)",
+			hlSignal, hlFetchATR, hlExecute, spotSignal, candleHelper, probed)
 	}
 }

--- a/scheduler/version_probe.go
+++ b/scheduler/version_probe.go
@@ -29,6 +29,10 @@ import (
 var probeArgv = []string{
 	"probe", "BTC", "1h",
 	"--strategy-refs", `{"open":{"name":"probe","params":{}},"closes":[{"name":"probe_close","params":{}}]}`,
+	// #768: new Go forwards --mark-price on every HL signal-check; probe it
+	// so a stale Python that doesn't accept the flag fails startup loudly
+	// instead of every cycle's argparse rejecting the cycle's argv.
+	"--mark-price=0",
 	"--probe-only",
 }
 

--- a/scheduler/version_probe.go
+++ b/scheduler/version_probe.go
@@ -43,6 +43,22 @@ var fetchATRProbeArgv = []string{
 	"--fetch-atr", "--symbol=BTC", "--timeframe=1h", "--period=14", "--probe-only",
 }
 
+// executeProbeArgv probes check_hyperliquid.py's --execute mode (PR #769
+// review point 1). The signal-check probe doesn't cover the execute branch,
+// so without this an asymmetric deploy (new Go binary forwarding
+// --account-leverage / --account-margin-mode to a stale Python) would only
+// fail on the first signal-fire rather than at startup. --mode=paper so the
+// probe never enters the live-credentials branch; --probe-only short-circuits
+// at the top of run_execute before any adapter or order code runs.
+var executeProbeArgv = []string{
+	"--execute",
+	"--symbol=BTC", "--side=buy", "--size=0",
+	"--mode=paper",
+	"--margin-mode=cross", "--leverage=1",
+	"--account-leverage=1", "--account-margin-mode=cross",
+	"--probe-only",
+}
+
 // fetchCandlesProbeArgv probes the dashboard's on-demand OHLCV helper. The
 // helper is not a configured strategy script, so it needs its own argv shape to
 // catch stale Python deploys before the dashboard starts returning 500s.
@@ -77,6 +93,12 @@ func probeCheckScripts(cfg *Config) error {
 		// than silently degrading every manual-open to computeFallbackATR.
 		if filepath.Base(script) == "check_hyperliquid.py" {
 			if err := probeOneCheckScriptFn(script, fetchATRProbeArgv); err != nil {
+				return err
+			}
+			// PR #769: also probe --execute so the new --account-leverage /
+			// --account-margin-mode flags fail loudly at startup if Python is
+			// stale, rather than on the first signal-fire.
+			if err := probeOneCheckScriptFn(script, executeProbeArgv); err != nil {
 				return err
 			}
 		}

--- a/scheduler/version_probe_test.go
+++ b/scheduler/version_probe_test.go
@@ -132,10 +132,11 @@ func TestProbeIgnoresEmptyScripts(t *testing.T) {
 	}
 }
 
-// TestProbeRunsFetchATRForHL verifies the second --fetch-atr probe (#689) is
-// dispatched only for check_hyperliquid.py. Stubs probeOneCheckScriptFn to
-// record argv shapes per script without requiring a real .venv.
-func TestProbeRunsFetchATRForHL(t *testing.T) {
+// TestProbeRunsExtraArgvForHL verifies the extra --fetch-atr (#689) and
+// --execute (PR #769) probes are dispatched only for check_hyperliquid.py.
+// Stubs probeOneCheckScriptFn to record argv shapes per script without
+// requiring a real .venv.
+func TestProbeRunsExtraArgvForHL(t *testing.T) {
 	orig := probeOneCheckScriptFn
 	defer func() { probeOneCheckScriptFn = orig }()
 	calls := map[string][]string{}
@@ -144,6 +145,10 @@ func TestProbeRunsFetchATRForHL(t *testing.T) {
 		for _, a := range argv {
 			if a == "--fetch-atr" {
 				mode = "fetch-atr"
+				break
+			}
+			if a == "--execute" {
+				mode = "execute"
 				break
 			}
 		}
@@ -160,8 +165,8 @@ func TestProbeRunsFetchATRForHL(t *testing.T) {
 		t.Fatalf("probe failed: %v", err)
 	}
 	hl := calls["shared_scripts/check_hyperliquid.py"]
-	if len(hl) != 2 || hl[0] != "signal" || hl[1] != "fetch-atr" {
-		t.Errorf("HL should be probed signal+fetch-atr, got %v", hl)
+	if len(hl) != 3 || hl[0] != "signal" || hl[1] != "fetch-atr" || hl[2] != "execute" {
+		t.Errorf("HL should be probed signal+fetch-atr+execute, got %v", hl)
 	}
 	spot := calls["shared_scripts/check_strategy.py"]
 	if len(spot) != 1 || spot[0] != "signal" {

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -1187,7 +1187,11 @@ def main():
                             help="on-chain leverage observed in Go's clearinghouseState snapshot; when paired with --account-margin-mode lets Python skip the duplicate get_position_leverage /info call (#768)")
         parser.add_argument("--account-margin-mode", default="",
                             help="on-chain margin mode observed in Go's clearinghouseState snapshot; see --account-leverage (#768)")
+        parser.add_argument("--probe-only", action="store_true",
+                            help="Startup compatibility probe (PR #769): validate execute-mode argv shape — including --account-leverage / --account-margin-mode — and exit 0 without trading.")
         args = parser.parse_args()
+        if args.probe_only:
+            sys.exit(0)
         if not args.close_full_position and args.size <= 0:
             print(json.dumps({"error": "--size must be > 0 unless --close-full-position is set"}))
             sys.exit(1)

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -99,7 +99,8 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
                      close_strategies=None,
                      position_side="", position_ctx=None,
                      regime_enabled=False, regime_period=14, regime_adx_threshold=20.0,
-                     close_params_by_name=None):
+                     close_params_by_name=None,
+                     mark_price=0.0):
     """Run strategy signal check using Hyperliquid OHLCV data."""
     try:
         from adapter import HyperliquidExchangeAdapter
@@ -229,13 +230,21 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             decision = finalize_decision(evaluation, position_side, signal)
             signal = decision["signal"]
 
-        # Freshen price with live mid if available
-        try:
-            mid = adapter.get_spot_price(symbol)
-            if mid > 0:
-                price = mid
-        except Exception:
-            pass
+        # Freshen price with live mid if available. Go fetches /info allMids
+        # once per cycle (fetchHyperliquidMids) and forwards the mid via
+        # --mark-price so this subprocess can skip its own /info call (#768
+        # fix #3). Zero staleness risk: same source, seconds old, used only
+        # to freshen the display price in the output JSON. Fall back to
+        # adapter.get_spot_price when the flag is absent.
+        if mark_price and mark_price > 0:
+            price = mark_price
+        else:
+            try:
+                mid = adapter.get_spot_price(symbol)
+                if mid > 0:
+                    price = mid
+            except Exception:
+                pass
 
         indicators = {}
         skip_cols = {
@@ -695,7 +704,7 @@ def run_sync_protection(
         sys.exit(1)
 
 
-def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_pos_qty=0.0, margin_mode="", leverage=0, close_full_position=False):
+def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_pos_qty=0.0, margin_mode="", leverage=0, close_full_position=False, account_leverage=0, account_margin_mode=""):
     """Place a live market order on Hyperliquid, optionally wrapping it with
     a stop-loss trigger (open) or cancelling a stale SL trigger (close).
 
@@ -755,14 +764,25 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
                 }, cls=SafeEncoder))
                 sys.exit(1)
             current = None
-            try:
-                current = adapter.get_position_leverage(symbol)
-            except Exception as ce:
-                # Don't fail-closed on a state-fetch hiccup — the
-                # update_leverage call below will fail loudly if the on-chain
-                # state actually disagrees, preserving the original safety
-                # behavior. We still log so the cause is debuggable.
-                print(f"[WARN] get_position_leverage({symbol}) failed: {ce}; will call update_leverage", file=sys.stderr)
+            # Go pulls clearinghouseState once per cycle (fetchHyperliquidState)
+            # and forwards the per-coin leverage + margin mode via
+            # --account-leverage / --account-margin-mode (#768 fix #4). When
+            # provided, skip get_position_leverage entirely — the snapshot is
+            # the same /info endpoint Python would call. Zero staleness risk:
+            # this subprocess runs in the same cycle Go produced the snapshot,
+            # and update_leverage failures still trip the original fail-loud
+            # safety path below.
+            if account_leverage and account_margin_mode in ("isolated", "cross"):
+                current = {"margin_mode": account_margin_mode, "leverage": int(account_leverage)}
+            else:
+                try:
+                    current = adapter.get_position_leverage(symbol)
+                except Exception as ce:
+                    # Don't fail-closed on a state-fetch hiccup — the
+                    # update_leverage call below will fail loudly if the on-chain
+                    # state actually disagrees, preserving the original safety
+                    # behavior. We still log so the cause is debuggable.
+                    print(f"[WARN] get_position_leverage({symbol}) failed: {ce}; will call update_leverage", file=sys.stderr)
             if current is not None and current.get("margin_mode") == margin_mode and current.get("leverage") == int(leverage):
                 print(f"update_leverage({symbol}, {leverage}x, mode={margin_mode}) SKIPPED (HL state already matches)", file=sys.stderr)
             else:
@@ -1163,6 +1183,10 @@ def main():
                             help="enforce 'isolated' or 'cross' margin via update_leverage before the order; only safe on a fresh open from flat (#486)")
         parser.add_argument("--leverage", type=float, default=0.0,
                             help="leverage to set alongside --margin-mode (HL update_leverage takes both in one call) (#486)")
+        parser.add_argument("--account-leverage", type=int, default=0,
+                            help="on-chain leverage observed in Go's clearinghouseState snapshot; when paired with --account-margin-mode lets Python skip the duplicate get_position_leverage /info call (#768)")
+        parser.add_argument("--account-margin-mode", default="",
+                            help="on-chain margin mode observed in Go's clearinghouseState snapshot; see --account-leverage (#768)")
         args = parser.parse_args()
         if not args.close_full_position and args.size <= 0:
             print(json.dumps({"error": "--size must be > 0 unless --close-full-position is set"}))
@@ -1171,7 +1195,9 @@ def main():
                     stop_loss_pct=args.stop_loss_pct, cancel_oid=args.cancel_stop_loss_oid,
                     prev_pos_qty=args.prev_pos_qty,
                     margin_mode=args.margin_mode, leverage=args.leverage,
-                    close_full_position=args.close_full_position)
+                    close_full_position=args.close_full_position,
+                    account_leverage=args.account_leverage,
+                    account_margin_mode=args.account_margin_mode)
     else:
         # Signal check mode: <strategy> <symbol> <timeframe> [--mode=paper|live] [--htf-filter]
         import argparse
@@ -1196,6 +1222,8 @@ def main():
         parser.add_argument("--position-initial-qty", type=float, default=None)
         parser.add_argument("--position-entry-atr", type=float, default=None)
         parser.add_argument("--position-regime", default="")
+        parser.add_argument("--mark-price", type=float, default=0.0,
+            help="Optional mid from Go's fetchHyperliquidMids cycle; when >0 skips adapter.get_spot_price's duplicate /info allMids call (#768).")
         parser.add_argument("--probe-only", action="store_true",
             help="Startup compatibility probe (#645): validate argv shape and exit 0.")
         args = parser.parse_args()
@@ -1217,6 +1245,7 @@ def main():
             regime_period=args.regime_period,
             regime_adx_threshold=args.regime_adx_threshold,
             close_params_by_name=close_params_by_name,
+            mark_price=args.mark_price,
         )
 
 

--- a/shared_scripts/check_okx.py
+++ b/shared_scripts/check_okx.py
@@ -379,6 +379,7 @@ def main():
         parser.add_argument("--position-initial-qty", type=float, default=None)
         parser.add_argument("--position-entry-atr", type=float, default=None)
         parser.add_argument("--position-regime", default="")
+        parser.add_argument("--mark-price", type=float, default=0.0, help="Accepted for argv-shape compatibility with check_hyperliquid.py (#768); ignored on this platform.")
         parser.add_argument("--probe-only", action="store_true",
             help="Startup compatibility probe (#645): validate argv shape and exit 0.")
         args = parser.parse_args()

--- a/shared_scripts/check_robinhood.py
+++ b/shared_scripts/check_robinhood.py
@@ -388,6 +388,7 @@ def main():
         parser.add_argument("--position-initial-qty", type=float, default=None)
         parser.add_argument("--position-entry-atr", type=float, default=None)
         parser.add_argument("--position-regime", default="")
+        parser.add_argument("--mark-price", type=float, default=0.0, help="Accepted for argv-shape compatibility with check_hyperliquid.py (#768); ignored on this platform.")
         parser.add_argument("--probe-only", action="store_true",
             help="Startup compatibility probe (#645): validate argv shape and exit 0.")
         args = parser.parse_args()

--- a/shared_scripts/check_topstep.py
+++ b/shared_scripts/check_topstep.py
@@ -391,6 +391,7 @@ def main():
         parser.add_argument("--position-initial-qty", type=float, default=None)
         parser.add_argument("--position-entry-atr", type=float, default=None)
         parser.add_argument("--position-regime", default="")
+        parser.add_argument("--mark-price", type=float, default=0.0, help="Accepted for argv-shape compatibility with check_hyperliquid.py (#768); ignored on this platform.")
         parser.add_argument("--probe-only", action="store_true",
             help="Startup compatibility probe (#645): validate argv shape and exit 0.")
         args = parser.parse_args()


### PR DESCRIPTION
## Summary

- Cache `spot_meta` + `meta` to `/tmp/hl_meta.json` (60-min TTL) so the HL SDK's `Info` constructor skips its 2-call init storm on cache hit; symbol-miss force-refresh preserves the high-priced-asset `sz_decimals` guardrail (#421).
- Catch HTTP 429 in `lookup_fill_fee_by_oid` and return `{}` immediately — 429 is a multi-second cool-down, not the sub-second indexer lag the 4× retry budget exists for.
- Forward Go's per-cycle `allMids` snapshot via `--mark-price` so `check_hyperliquid.py` skips its duplicate `adapter.get_spot_price` call.
- Forward `clearinghouseState`'s per-coin leverage + margin mode via `--account-leverage` / `--account-margin-mode` so Python skips the duplicate `get_position_leverage` call inside the `--margin-mode` branch.

Per-cycle effect for a 1-SL+2-TP HL strategy: ~21 → ~8 `/info` calls (≤5 during a 429 burst). Cross-platform check scripts (OKX/RH/TopStep) accept `--mark-price` as a silent no-op so the unified `probeArgv` shape still works.

Closes #768

## Test plan

- [x] `go test ./scheduler/` (incl. new `TestBuildHyperliquidExecuteArgs_AccountSnapshot*` + `TestHLExecuteSnapshotForCoin`)
- [x] `uv run --no-sync python -m pytest platforms/ shared_strategies/ shared_tools/ backtest/ shared_scripts/` (incl. 14 new `test_meta_cache.py` cases covering load/save/TTL, atomic write, 429 short-circuit, `_sz_decimals` symbol-miss refresh)
- [x] `go build` + binary smoke (`--help`, `inspect --help`)
- [x] `gofmt -w` on all touched Go files
- [ ] Staging deploy: monitor `/info` 429 rate over a full trading day with a 1-SL+2-TP HL strategy
- [ ] Verify `/tmp/hl_meta.json` is written on first cycle and reused on subsequent cycles within 60 min (check mtime)
- [ ] Force a 429 in `userFills` (e.g. with a tight loop or fault injection) and confirm `[WARN] userFills lookup got HTTP 429` shows up exactly once per OID

---
LLM: Claude Opus 4.7 (1M) | high