### PR TITLE
fix(validator): allow invert_signal with direction="short" (#775)

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -313,7 +313,7 @@ type StrategyConfig struct {
 	MaxDrawdownPct         float64             `json:"max_drawdown_pct"`
 	IntervalSeconds        int                 `json:"interval_seconds,omitempty"`           // per-strategy override (0 = use global)
 	HTFFilter              bool                `json:"htf_filter,omitempty"`                 // higher-timeframe trend filter
-	InvertSignal           bool                `json:"invert_signal,omitempty"`              // HL perps/manual only: flip BUY<->SELL on a non-zero signal before execution (HOLD/0 is never flipped). Lets inverse variants reuse the same open/close refs. Rejected with direction="short" (double-flip) and outside HL perps/manual.
+	InvertSignal           bool                `json:"invert_signal,omitempty"`              // HL perps/manual only: flip BUY<->SELL on a non-zero signal before execution (HOLD/0 is never flipped). Lets inverse variants reuse the same open/close refs. Composes with Direction — invert runs in the Go layer before direction interprets the resulting sign (e.g. direction="short" + invert_signal=true opens short on raw-BUY triggers, distinct from plain direction="short" which opens on raw-SELL). Rejected outside HL perps/manual.
 	AllowShorts            bool                `json:"allow_shorts,omitempty"`               // DEPRECATED — use Direction. Perps only; legacy boolean retained on the struct so pre-v14 JSON unmarshals cleanly. Read via EffectiveDirection / PerpsAllowsShort / PerpsAllowsLong, never directly. Migrated to Direction in v14 (#656).
 	Direction              string              `json:"direction,omitempty"`                  // perps only: "long" (default; signal=1 opens, signal=-1 closes long), "short" (signal=-1 opens, signal=1 closes short), "both" (bidirectional). Empty falls back to AllowShorts (legacy). v14 migration converts allow_shorts→direction. (#656)
 	Leverage               float64             `json:"leverage,omitempty"`                   // perps exchange leverage (default 1 = no leverage); used for exchange margin/risk and HL update_leverage (#254/#497)
@@ -1394,17 +1394,15 @@ func ValidateConfig(cfg *Config) error {
 		// scripts emit their own buy/sell logic that runHyperliquidCheck
 		// doesn't see, so the flag would be a silent no-op there. Reject
 		// the config at startup rather than letting it appear to work.
+		//
+		// invert_signal composes cleanly with direction="short": the invert
+		// runs before direction interprets the sign, so the combination opens
+		// short on raw-BUY triggers (an "inverse short-only" strategy),
+		// distinct from plain direction="short" which opens short on
+		// raw-SELL. Both are valid (#775).
 		if sc.InvertSignal {
 			if sc.Platform != "hyperliquid" || (sc.Type != "perps" && sc.Type != "manual") {
 				errs = append(errs, fmt.Sprintf("%s: invert_signal is only supported for HL perps/manual strategies (got platform=%q type=%q)", prefix, sc.Platform, sc.Type))
-			}
-			// direction="short" already inverts open/close semantics in the
-			// executor (signal=-1 opens, signal=1 closes). Adding
-			// invert_signal=true on top double-flips back to long semantics,
-			// which is almost certainly a config mistake — reject so the
-			// operator picks one or the other.
-			if EffectiveDirection(sc) == DirectionShort {
-				errs = append(errs, fmt.Sprintf("%s: invert_signal=true with direction=%q double-flips back to long semantics; drop one of the two", prefix, DirectionShort))
 			}
 		}
 

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -2419,3 +2419,119 @@ func TestValidateConfigManualPerpsMultipleTrailingStopOwnersRejected(t *testing.
 		t.Fatalf("expected trailing-stop peer error, got: %v", err)
 	}
 }
+
+// TestValidateConfigInvertSignal covers #775: invert_signal must be accepted
+// on HL perps/manual regardless of direction (long/short/both compose with
+// invert at different signal layers — invert runs in the Go executor before
+// direction interprets the sign), but must still be rejected on platforms or
+// strategy types where the Go layer never sees a numeric +1/-1 signal to flip.
+func TestValidateConfigInvertSignal(t *testing.T) {
+	hlPerps := func(direction string, invert bool) StrategyConfig {
+		return StrategyConfig{
+			ID:             "hl-test-eth",
+			Type:           "perps",
+			Platform:       "hyperliquid",
+			Script:         "shared_scripts/check_hyperliquid.py",
+			Args:           []string{"sma_crossover", "ETH", "1h", "--mode=paper"},
+			Capital:        1000,
+			Leverage:       5,
+			MaxDrawdownPct: 60,
+			Direction:      direction,
+			InvertSignal:   invert,
+		}
+	}
+	hlManual := func(direction string, invert bool) StrategyConfig {
+		return StrategyConfig{
+			ID:             "hl-manual-eth",
+			Type:           "manual",
+			Platform:       "hyperliquid",
+			Symbol:         "ETH",
+			Timeframe:      "1h",
+			Leverage:       5,
+			Capital:        1000,
+			MaxDrawdownPct: 60,
+			Direction:      direction,
+			InvertSignal:   invert,
+		}
+	}
+
+	t.Run("accepts HL perps + invert + direction=short", func(t *testing.T) {
+		cfg := Config{
+			Strategies:    []StrategyConfig{hlPerps(DirectionShort, true)},
+			PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+		}
+		if err := ValidateConfig(&cfg); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("accepts HL perps + invert + direction=long", func(t *testing.T) {
+		cfg := Config{
+			Strategies:    []StrategyConfig{hlPerps(DirectionLong, true)},
+			PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+		}
+		if err := ValidateConfig(&cfg); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("accepts HL perps + invert + direction=both", func(t *testing.T) {
+		cfg := Config{
+			Strategies:    []StrategyConfig{hlPerps(DirectionBoth, true)},
+			PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+		}
+		if err := ValidateConfig(&cfg); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("accepts HL manual + invert + direction=short", func(t *testing.T) {
+		cfg := Config{
+			Strategies:    []StrategyConfig{hlManual(DirectionShort, true)},
+			PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+		}
+		if err := ValidateConfig(&cfg); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("rejects invert on HL spot", func(t *testing.T) {
+		cfg := Config{
+			Strategies: []StrategyConfig{{
+				ID:             "hl-spot-btc",
+				Type:           "spot",
+				Platform:       "hyperliquid",
+				Script:         "shared_scripts/check_strategy.py",
+				Capital:        1000,
+				MaxDrawdownPct: 60,
+				InvertSignal:   true,
+			}},
+			PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+		}
+		err := ValidateConfig(&cfg)
+		if err == nil || !strings.Contains(err.Error(), "invert_signal is only supported for HL perps/manual") {
+			t.Fatalf("expected HL-perps/manual-only error, got: %v", err)
+		}
+	})
+
+	t.Run("rejects invert on non-HL perps", func(t *testing.T) {
+		cfg := Config{
+			Strategies: []StrategyConfig{{
+				ID:             "okx-perps-btc",
+				Type:           "perps",
+				Platform:       "okx",
+				Script:         "shared_scripts/check_okx.py",
+				Args:           []string{"sma_crossover", "BTC-USDT-SWAP", "1h"},
+				Capital:        1000,
+				Leverage:       5,
+				MaxDrawdownPct: 60,
+				InvertSignal:   true,
+			}},
+			PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+		}
+		err := ValidateConfig(&cfg)
+		if err == nil || !strings.Contains(err.Error(), "invert_signal is only supported for HL perps/manual") {
+			t.Fatalf("expected HL-perps/manual-only error, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Drop the validator's `invert_signal=true + direction="short"` double-flip rejection — it was based on an incorrect read of the executor (#775).
- `direction="short"` does not flip the signal sign; it changes which sign opens vs closes. Composed with `invert_signal` (Go-layer), the pipeline is `raw -> invert -> direction`, so `invert + direction="short"` opens short on raw-BUY triggers (inverse short-only), which is distinct from plain `direction="short"` opening on raw-SELL.
- Keep the unrelated rejection for `invert_signal` on non-HL or non-perps/non-manual strategies — the Go executor only flips signals on the HL perps/manual path, so the flag would be a silent no-op elsewhere.
- Add `TestValidateConfigInvertSignal` covering the four accept cases (HL perps × long/short/both, HL manual short) and two reject cases (HL spot, non-HL perps).

Closes #775

## Test plan
- [x] `go test ./...` (scheduler) — all pass
- [x] `go build` (scheduler) — clean
- [x] `gofmt -w`

---
LLM: Claude Opus 4.7 | high