### PR TITLE
fix(hl): book filled TP tiers when on-chain dust remains

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -279,7 +279,7 @@ func fetchHyperliquidState(accountAddress string) (float64, []HLPosition, error)
 // cached resolver outside the lock and call
 // reconcileHyperliquidPositionsWithResolver.
 func reconcileHyperliquidPositions(stratState *StrategyState, sym string, positions []HLPosition, accountAddress string, logger *StrategyLogger) bool {
-	return reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, directHyperliquidReconcileFillResolver(accountAddress), logger, nil)
+	return reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, directHyperliquidReconcileFillResolver(accountAddress), logger, nil, StrategyConfig{})
 }
 
 // reconcileHyperliquidPositionsForStrategy is the production entry point with
@@ -318,11 +318,11 @@ func reconcileHyperliquidPositionsForStrategy(
 		// by the booker; the legacy reconciler's qty/side/avgCost resync will
 		// no-op because virtual now matches on-chain. Continue through it for
 		// idempotent housekeeping (multiplier migration, leverage seed).
-		reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, resolveFee, logger, pendingAlerts)
+		reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, resolveFee, logger, pendingAlerts, sc)
 		return true
 	}
 
-	return reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, resolveFee, logger, pendingAlerts)
+	return reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, resolveFee, logger, pendingAlerts, sc)
 }
 
 // stampSoleOwnerRecoveryTierConsumed mirrors post-protection-sync state for a
@@ -440,6 +440,13 @@ func tryBookSoleOwnerTPFill(
 		return false
 	}
 
+	if onChainPos != nil && hyperliquidAllTiersArmedAndCleared(sc, statePos) {
+		onChainAbs := math.Abs(onChainPos.Size)
+		if hlAttemptCloseFromArmedTPClears(stratState, sc, sym, statePos, onChainAbs, resolveFee, logger, pendingAlerts) {
+			return true
+		}
+	}
+
 	lookup, useFillFee := resolveFee(sym, 0, closeQty)
 	logHyperliquidReconcileFillLookup(logger, sym, 0, closeQty, lookup, useFillFee)
 
@@ -538,7 +545,7 @@ func tryBookSoleOwnerTPFill(
 // When pendingAlerts is non-nil, hlAttemptCloseFromTPFills appends TP fill
 // alerts here (same contract as tryBookSoleOwnerTPFill) for owner DM flush
 // after mu.Unlock (#757 re-review).
-func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym string, positions []HLPosition, resolveFee hlReconcileFillResolver, logger *StrategyLogger, pendingAlerts *[]ProtectionFillAlert) bool {
+func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym string, positions []HLPosition, resolveFee hlReconcileFillResolver, logger *StrategyLogger, pendingAlerts *[]ProtectionFillAlert, sc StrategyConfig) bool {
 	changed := false
 
 	// Find the on-chain position for this strategy's symbol.
@@ -560,12 +567,20 @@ func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym st
 			side = "short"
 		}
 		if statePos.Quantity != qty || statePos.Side != side {
-			logger.Info("hl-sync: reconciled %s: state=%.6f %s → on-chain=%.6f %s @ $%.2f",
-				sym, statePos.Quantity, statePos.Side, qty, side, onChainPos.EntryPrice)
-			statePos.Quantity = qty
-			statePos.Side = side
-			statePos.AvgCost = onChainPos.EntryPrice
-			changed = true
+			skipQtyResync := sc.ID != "" &&
+				math.Abs(statePos.Quantity-qty) > 1e-6 &&
+				hyperliquidAllTiersArmedAndCleared(sc, statePos)
+			if skipQtyResync {
+				logger.Info("hl-sync: %s qty drift state=%.6f %s on-chain=%.6f %s (not auto-resyncing — all TP tiers armed/cleared, #777)",
+					sym, statePos.Quantity, statePos.Side, qty, side)
+			} else {
+				logger.Info("hl-sync: reconciled %s: state=%.6f %s → on-chain=%.6f %s @ $%.2f",
+					sym, statePos.Quantity, statePos.Side, qty, side, onChainPos.EntryPrice)
+				statePos.Quantity = qty
+				statePos.Side = side
+				statePos.AvgCost = onChainPos.EntryPrice
+				changed = true
+			}
 		}
 		// #254: always pull the current on-chain leverage and ensure Multiplier=1
 		// so PortfolioValue uses the PnL branch. Also migrates legacy positions
@@ -1108,8 +1123,17 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 							continue
 						}
 						tierIdx, hasCleared := hyperliquidClearedTPTier(sc, pos, closeQty)
-						if !hasCleared {
+						dustAllArmed := !hasCleared &&
+							hyperliquidAllTiersArmedAndCleared(sc, pos) &&
+							closeQty > 1e-9 && closeQty < pos.Quantity-1e-6
+						if !hasCleared && !dustAllArmed {
 							continue
+						}
+						if dustAllArmed {
+							tiers := strategyTPTiersForRegime(sc, pos.Regime)
+							if len(tiers) > 0 {
+								tierIdx = len(tiers) - 1
+							}
 						}
 						if candidateID != "" {
 							// Multiple TP owners changed in the same window; leave the
@@ -1120,11 +1144,31 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 						candidateID, candidateSS, candidatePos, candidateTierIdx = id, ss, pos, tierIdx
 					}
 					if candidateID != "" && candidateSS != nil && candidatePos != nil && closeQty <= candidatePos.Quantity+1e-6 {
-						if mark, ok := prices[coin]; ok && mark > 0 {
-							logger, logErr := logMgr.GetStrategyLogger(candidateID)
-							if logErr != nil {
-								fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", candidateID, logErr)
+						sc, scOK := strategyByID[candidateID]
+						logger, logErr := logMgr.GetStrategyLogger(candidateID)
+						if logErr != nil {
+							fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", candidateID, logErr)
+						}
+						targetResidual := candidatePos.Quantity - closeQty
+						if targetResidual < 0 {
+							targetResidual = 0
+						}
+						if scOK && hyperliquidAllTiersArmedAndCleared(sc, candidatePos) {
+							beforeQty := candidatePos.Quantity
+							if hlAttemptCloseFromArmedTPClears(candidateSS, sc, coin, candidatePos, targetResidual, resolveFee, logger, &pendingAlerts) {
+								changed = true
+								bookedQty := beforeQty
+								if posAfter := candidateSS.Positions[coin]; posAfter != nil {
+									bookedQty -= posAfter.Quantity
+								}
+								if closeSide == "long" {
+									virtualQty -= bookedQty
+								} else {
+									virtualQty += bookedQty
+								}
+								delta = virtualQty - onChainQty
 							}
+						} else if mark, ok := prices[coin]; ok && mark > 0 {
 							lookup, useFillFee := resolveFee(coin, 0, closeQty)
 							logHyperliquidReconcileFillLookup(logger, coin, 0, closeQty, lookup, useFillFee)
 							detector3OID := ""
@@ -1225,6 +1269,187 @@ func hyperliquidSharedPartialCloseDrift(virtualQty, onChainQty float64) (string,
 	return "", 0, false
 }
 
+// hyperliquidAllTiersArmedAndCleared is true when every configured TP tier was
+// armed at least once and every resting TP OID is zero — i.e. all tiers have
+// filled/cleared. Distinguishes that state from a never-placed TP list
+// (TPArmedTiers all false, TPOIDs all zero) per #777.
+func hyperliquidAllTiersArmedAndCleared(sc StrategyConfig, pos *Position) bool {
+	if pos == nil {
+		return false
+	}
+	tiers := strategyTPTiersForRegime(sc, pos.Regime)
+	if len(tiers) == 0 {
+		return false
+	}
+	tpOIDs := tpOIDsForTierCount(pos.TPOIDs, len(tiers))
+	armed := tpArmedTiersForTierCount(pos.TPArmedTiers, len(tiers))
+	for i := range tiers {
+		if tpOIDs[i] != 0 {
+			return false
+		}
+		if !armed[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// hyperliquidTPTierIncrementalCloseQty returns the position-fraction closed
+// by tier tierIdx given cumulative close_fraction tiers on initialQty.
+func hyperliquidTPTierIncrementalCloseQty(initialQty float64, tiers []hlProtectionTier, tierIdx int) float64 {
+	if initialQty <= 0 || tierIdx < 0 || tierIdx >= len(tiers) {
+		return 0
+	}
+	prevFrac := 0.0
+	if tierIdx > 0 {
+		prevFrac = tiers[tierIdx-1].Fraction
+	}
+	currFrac := tiers[tierIdx].Fraction
+	if tierIdx == len(tiers)-1 {
+		currFrac = 1.0
+	}
+	delta := currFrac - prevFrac
+	if delta <= 0 {
+		return 0
+	}
+	return initialQty * delta
+}
+
+// tpOIDsFromOpenTrade returns TP OIDs snapshotted on the open trade row when
+// protection-sync has already zeroed pos.TPOIDs but the open trade still
+// carries the resting order IDs from placement time (#777).
+func tpOIDsFromOpenTrade(s *StrategyState, sym string, tierCount int) []int64 {
+	if s == nil || sym == "" || tierCount <= 0 {
+		return nil
+	}
+	for i := len(s.TradeHistory) - 1; i >= 0; i-- {
+		t := &s.TradeHistory[i]
+		if t.Symbol != sym {
+			continue
+		}
+		if t.IsClose {
+			break
+		}
+		oids := tpOIDsForTierCount(t.TPOIDs, tierCount)
+		for _, oid := range oids {
+			if oid > 0 {
+				return oids
+			}
+		}
+		return oids
+	}
+	return nil
+}
+
+// tpOIDsForReconcileLookup prefers live pos.TPOIDs when any are positive;
+// otherwise falls back to the open-trade snapshot for dust reconciliation.
+func tpOIDsForReconcileLookup(s *StrategyState, pos *Position, sym string, tierCount int) []int64 {
+	live := tpOIDsForTierCount(pos.TPOIDs, tierCount)
+	for _, oid := range live {
+		if oid > 0 {
+			return live
+		}
+	}
+	return tpOIDsFromOpenTrade(s, sym, tierCount)
+}
+
+// hlAttemptCloseFromArmedTPClears books each filled TP tier at userFills VWAP
+// when all tiers are armed+cleared (TPOIDs all zero) but a same-direction dust
+// residual remains on-chain. Returns true when at least one tier was booked.
+func hlAttemptCloseFromArmedTPClears(
+	s *StrategyState,
+	sc StrategyConfig,
+	sym string,
+	pos *Position,
+	targetResidualQty float64,
+	resolveFee hlReconcileFillResolver,
+	logger *StrategyLogger,
+	pendingAlerts *[]ProtectionFillAlert,
+) bool {
+	if s == nil || pos == nil || resolveFee == nil || !hyperliquidAllTiersArmedAndCleared(sc, pos) {
+		return false
+	}
+	if pos.Quantity <= targetResidualQty+1e-9 {
+		return false
+	}
+	if pos.StopLossOID > 0 {
+		if lookup, slFilled := resolveFee(sym, pos.StopLossOID, pos.Quantity); hlReconcileSLFillConfirmed(lookup, slFilled, pos.StopLossOID) {
+			return false
+		}
+	}
+	tiers := strategyTPTiersForRegime(sc, pos.Regime)
+	if len(tiers) == 0 {
+		return false
+	}
+	initQty := pos.InitialQuantity
+	if initQty <= 0 {
+		initQty = pos.Quantity
+	}
+	lookupOIDs := tpOIDsForReconcileLookup(s, pos, sym, len(tiers))
+	booked := false
+	for i := range tiers {
+		cur := s.Positions[sym]
+		if cur == nil || cur.Quantity <= targetResidualQty+1e-9 {
+			break
+		}
+		tierQty := hyperliquidTPTierIncrementalCloseQty(initQty, tiers, i)
+		if tierQty <= 1e-9 {
+			continue
+		}
+		var lookup HLFillLookup
+		var useFillFee bool
+		if i < len(lookupOIDs) && lookupOIDs[i] > 0 {
+			lookup, useFillFee = resolveFee(sym, lookupOIDs[i], tierQty)
+		}
+		if !useFillFee || lookup.Px <= 0 || lookup.FilledQty <= 0 {
+			lookup, useFillFee = resolveFee(sym, 0, tierQty)
+		}
+		if !useFillFee || lookup.Px <= 0 || lookup.FilledQty <= 0 {
+			continue
+		}
+		closeQty := lookup.FilledQty
+		if closeQty > cur.Quantity-targetResidualQty+1e-9 {
+			closeQty = cur.Quantity - targetResidualQty
+		}
+		if closeQty <= 1e-9 {
+			continue
+		}
+		alertSide := cur.Side
+		oidStr := ""
+		if lookup.OID > 0 {
+			oidStr = strconv.FormatInt(lookup.OID, 10)
+		}
+		logHyperliquidReconcileFillLookup(logger, sym, lookup.OID, closeQty, lookup, useFillFee)
+		reason := fmt.Sprintf("hl_sync_tp%d_fill", i+1)
+		detailsPrefix := fmt.Sprintf("TP%d fill close", i+1)
+		logPrefix := fmt.Sprintf("TP%d fill reconciled", i+1)
+		if !bookPerpsPartialCloseWithFillFee(s, sym, closeQty, lookup.Px, lookup.Fee, true, oidStr, reason, detailsPrefix, logPrefix, logger) {
+			break
+		}
+		booked = true
+		if pendingAlerts != nil {
+			remaining := 0.0
+			if posAfter := s.Positions[sym]; posAfter != nil {
+				remaining = posAfter.Quantity
+			}
+			*pendingAlerts = append(*pendingAlerts, ProtectionFillAlert{
+				StrategyID:      s.ID,
+				Symbol:          sym,
+				Side:            alertSide,
+				FillType:        tpTierLabel(i),
+				IsPartial:       remaining > targetResidualQty+1e-9,
+				FillPrice:       lookup.Px,
+				CloseQty:        closeQty,
+				RemainingQty:    remaining,
+				RealizedPnL:     lastBookedTradePnL(s),
+				HasPnL:          true,
+				ExchangeOrderID: oidStr,
+			})
+		}
+	}
+	return booked
+}
+
 // hyperliquidClearedTPTier reports whether sc/pos shows a cleared TP tier
 // attributable to closeQty, and which tier index (0-based) cleared. Used by
 // reconciler Detector 3 to attribute partial closes and by the TP-fill DM
@@ -1270,7 +1495,8 @@ func hyperliquidClearedTPTier(sc StrategyConfig, pos *Position, closeQty float64
 	// All TP tiers gone usually means the final tier filled. Treat that as
 	// attributable only when the observed drift can fully close this strategy;
 	// otherwise an all-zero, never-placed TP list would make ambiguous gaps look
-	// actionable.
+	// actionable — unless every tier was armed (filled) and only dust remains
+	// (#777).
 	if math.Abs(pos.Quantity-closeQty) <= 1e-6 {
 		return len(tpOIDs) - 1, true
 	}

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -3313,6 +3313,11 @@ func TestHyperliquidHasClearedTPTier_AllZeroFullClose(t *testing.T) {
 	if !hyperliquidHasClearedTPTier(sc, pos, 0.422) {
 		t.Error("expected true when all OIDs zero and closeQty == pos.Quantity (sole-peer final close)")
 	}
+	if hyperliquidAllTiersArmedAndCleared(sc, &Position{Quantity: 0.422, TPOIDs: []int64{0, 0}, TPArmedTiers: []bool{true, true}}) {
+		if hyperliquidHasClearedTPTier(sc, pos, 0.211) {
+			t.Error("hyperliquidHasClearedTPTier must stay false for dust; use hlAttemptCloseFromArmedTPClears (#777)")
+		}
+	}
 }
 
 // --- #621: SL close bookkeeping uses actual fill qty from userFills ---
@@ -3347,7 +3352,7 @@ func TestReconcilePositionSLClose_UsesFilledQtyFromLookup(t *testing.T) {
 	logger := newTestLogger(t)
 
 	// On-chain is flat → reconcileHyperliquidPositionsWithResolver closes position.
-	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil)
+	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, StrategyConfig{})
 	if !changed {
 		t.Fatal("expected changed=true")
 	}
@@ -3396,7 +3401,7 @@ func TestReconcilePositionSLClose_NoFillFallsThroughToExternal(t *testing.T) {
 	})
 	logger := newTestLogger(t)
 	startCash := ss.Cash
-	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil)
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, StrategyConfig{})
 
 	if len(ss.ClosedPositions) != 1 {
 		t.Fatalf("ClosedPositions = %d, want 1", len(ss.ClosedPositions))
@@ -3513,7 +3518,7 @@ func TestReconcilePosition_TPFillsAttributedNotSL(t *testing.T) {
 
 	var alerts []ProtectionFillAlert
 	startCash := ss.Cash
-	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, &alerts)
+	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, &alerts, StrategyConfig{})
 	if !changed {
 		t.Fatal("expected changed=true")
 	}
@@ -3571,7 +3576,7 @@ func TestReconcilePosition_SLFillStillTakesSLPath(t *testing.T) {
 		return HLFillLookup{}, false
 	})
 	logger := newTestLogger(t)
-	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil)
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, StrategyConfig{})
 
 	if len(ss.ClosedPositions) != 1 || ss.ClosedPositions[0].CloseReason != "stop_loss" {
 		t.Fatalf("expected one ClosedPosition with reason=stop_loss, got %+v", ss.ClosedPositions)
@@ -3614,7 +3619,7 @@ func TestReconcilePosition_PartialTPFillResidualZeroPnL(t *testing.T) {
 	})
 	logger := newTestLogger(t)
 	startCash := ss.Cash
-	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil)
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, StrategyConfig{})
 
 	if _, open := ss.Positions["ETH"]; open {
 		t.Fatal("ETH should be removed even when TP fills under-shoot")
@@ -3652,7 +3657,7 @@ func TestReconcilePosition_NoFillsFallsBackToZeroPnL(t *testing.T) {
 	resolver := noFillFeeResolver
 	logger := newTestLogger(t)
 	startCash := ss.Cash
-	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil)
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, StrategyConfig{})
 
 	if _, open := ss.Positions["ETH"]; open {
 		t.Fatal("ETH should be removed even when no fills found")
@@ -3696,7 +3701,7 @@ func TestReconcilePosition_AllTPOIDsZeroedSLNotFilled(t *testing.T) {
 	})
 	logger := newTestLogger(t)
 	startCash := ss.Cash
-	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil)
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, StrategyConfig{})
 
 	if _, open := ss.Positions["ETH"]; open {
 		t.Fatal("ETH position should be removed after reconcile")

--- a/scheduler/hyperliquid_fills.go
+++ b/scheduler/hyperliquid_fills.go
@@ -465,6 +465,26 @@ func buildCachedHyperliquidReconcileFillResolver(accountAddress string, allStrat
 			if sameDirection && onChainAbs+1e-9 < pos.Quantity {
 				addCandidate(sym, 0, pos.Quantity-onChainAbs)
 			}
+			// #777: all tiers armed+cleared with dust — prefetch per-tier fills
+			// (OID from open-trade snapshot when pos.TPOIDs are already zero).
+			if sameDirection && hyperliquidAllTiersArmedAndCleared(sc, pos) {
+				tiers := strategyTPTiersForRegime(sc, pos.Regime)
+				initQty := pos.InitialQuantity
+				if initQty <= 0 {
+					initQty = pos.Quantity
+				}
+				lookupOIDs := tpOIDsForReconcileLookup(ss, pos, sym, len(tiers))
+				for i := range tiers {
+					tierQty := hyperliquidTPTierIncrementalCloseQty(initQty, tiers, i)
+					if tierQty <= 0 {
+						continue
+					}
+					if i < len(lookupOIDs) && lookupOIDs[i] > 0 {
+						addCandidate(sym, lookupOIDs[i], tierQty)
+					}
+					addCandidate(sym, 0, tierQty)
+				}
+			}
 		}
 	}
 	mu.RUnlock()

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -550,7 +550,7 @@ func TestReconcileHyperliquidPositions_RestingStopLossFillBooksPnL(t *testing.T)
 	resolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
 		return HLFillLookup{Fee: 0.05, FilledQty: 0.1, Px: 3104, Count: 1, OID: oid}, true
 	})
-	changed := reconcileHyperliquidPositionsWithResolver(state, "ETH", nil, resolver, logger, nil)
+	changed := reconcileHyperliquidPositionsWithResolver(state, "ETH", nil, resolver, logger, nil, StrategyConfig{})
 	if !changed {
 		t.Fatalf("expected reconcile to report a state change")
 	}
@@ -609,7 +609,7 @@ func TestReconcileHyperliquidPositions_RestingStopLossFillClosesShortWithBuy(t *
 	resolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
 		return HLFillLookup{Fee: 0.05, FilledQty: 0.1, Px: 3296, Count: 1, OID: oid}, true
 	})
-	changed := reconcileHyperliquidPositionsWithResolver(state, "ETH", nil, resolver, logger, nil)
+	changed := reconcileHyperliquidPositionsWithResolver(state, "ETH", nil, resolver, logger, nil, StrategyConfig{})
 	if !changed {
 		t.Fatalf("expected reconcile to report a state change")
 	}

--- a/scheduler/hyperliquid_tp_dust_test.go
+++ b/scheduler/hyperliquid_tp_dust_test.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"math"
+	"sync"
+	"testing"
+)
+
+// TestHyperliquidAllTiersArmedAndCleared_DustGuard verifies #777: all-zero TPOIDs
+// with every tier armed is distinct from a never-placed TP list.
+func TestHyperliquidAllTiersArmedAndCleared_DustGuard(t *testing.T) {
+	sc := tieredTPATRSC()
+	pos := &Position{
+		Quantity:     0.013,
+		TPOIDs:       []int64{0, 0},
+		TPArmedTiers: []bool{true, true},
+	}
+	if !hyperliquidAllTiersArmedAndCleared(sc, pos) {
+		t.Fatal("expected all tiers armed and cleared")
+	}
+	pos.TPArmedTiers = []bool{false, false}
+	if hyperliquidAllTiersArmedAndCleared(sc, pos) {
+		t.Error("never-placed TP list must not look armed+cleared")
+	}
+	if _, ok := hyperliquidClearedTPTier(sc, pos, 0.012); ok {
+		t.Error("hyperliquidClearedTPTier must not attribute ambiguous all-zero dust")
+	}
+}
+
+// TestSoleOwnerTPDust_BooksBothTiersAtUserFills is the #777 positive case:
+// short qty=0.013, all TPOIDs zero, all tiers armed, on-chain dust -0.001,
+// userFills carry both TP partials — expect two close trades and qty=0.001.
+func TestSoleOwnerTPDust_BooksBothTiersAtUserFills(t *testing.T) {
+	const (
+		fullQty  = 0.012 // 50/50 tiers → 0.006 per TP leg
+		dustQty  = 0.001
+		tp1OID   = int64(438613562733)
+		tp2OID   = int64(438613569010)
+		tp1Qty   = 0.006
+		tp2Qty   = 0.006
+		tp1Px    = 74605.0
+		tp2Px    = 74284.0
+		tp1Fee   = 0.064458
+		tp2Fee   = 0.06418
+		entryPx  = 75249.0
+		entryATR = 200.0
+	)
+	sc := soleOwnerTPSC()
+	sc.Symbol = "BTC"
+	sc.Args = []string{"sma", "BTC", "1h", "--mode=live"}
+
+	ss := &StrategyState{
+		ID:   sc.ID,
+		Cash: 1000,
+		Positions: map[string]*Position{
+			"BTC": {
+				Symbol: "BTC", Quantity: fullQty, InitialQuantity: fullQty,
+				AvgCost: entryPx, EntryATR: entryATR, Side: "short",
+				Multiplier: 1, Leverage: 5, OwnerStrategyID: sc.ID,
+				TPOIDs: []int64{0, 0}, TPArmedTiers: []bool{true, true},
+			},
+		},
+		TradeHistory: []Trade{{
+			Symbol: "BTC", Side: "sell", Quantity: fullQty, Price: entryPx,
+			TPOIDs: []int64{tp1OID, tp2OID},
+		}},
+	}
+	positions := []HLPosition{{Coin: "BTC", Size: -dustQty, EntryPrice: entryPx, Leverage: 5}}
+	resolver := hlReconcileFillResolver(func(_ string, oid int64, qty float64) (HLFillLookup, bool) {
+		switch {
+		case oid == tp1OID || (oid == 0 && math.Abs(qty-tp1Qty) < 1e-9):
+			return HLFillLookup{Fee: tp1Fee, FilledQty: tp1Qty, Px: tp1Px, Count: 1, OID: tp1OID}, true
+		case oid == tp2OID || (oid == 0 && math.Abs(qty-tp2Qty) < 1e-9):
+			return HLFillLookup{Fee: tp2Fee, FilledQty: tp2Qty, Px: tp2Px, Count: 1, OID: tp2OID}, true
+		default:
+			return HLFillLookup{}, false
+		}
+	})
+	logger := newTestLogger(t)
+
+	changed := reconcileHyperliquidPositionsForStrategy(sc, ss, "BTC", positions, resolver, logger, nil)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	pos := ss.Positions["BTC"]
+	if pos == nil {
+		t.Fatal("expected BTC position to remain as dust")
+	}
+	if math.Abs(pos.Quantity-dustQty) > 1e-9 {
+		t.Errorf("Quantity = %g, want %g", pos.Quantity, dustQty)
+	}
+	if len(ss.TradeHistory) < 2 {
+		t.Fatalf("TradeHistory = %d rows, want at least 2 TP closes", len(ss.TradeHistory))
+	}
+	var closes []Trade
+	for _, tr := range ss.TradeHistory {
+		if tr.IsClose {
+			closes = append(closes, tr)
+		}
+	}
+	if len(closes) != 2 {
+		t.Fatalf("close trades = %d, want 2", len(closes))
+	}
+	if math.Abs(closes[0].Quantity-tp1Qty) > 1e-9 || math.Abs(closes[0].Price-tp1Px) > 1e-9 {
+		t.Errorf("TP1 trade = %+v, want qty=%g px=%g", closes[0], tp1Qty, tp1Px)
+	}
+	wantTP2Qty := fullQty - dustQty - tp1Qty // clamped to leave dust residual
+	if math.Abs(closes[1].Quantity-wantTP2Qty) > 1e-9 || math.Abs(closes[1].Price-tp2Px) > 1e-9 {
+		t.Errorf("TP2 trade = %+v, want qty=%g px=%g", closes[1], wantTP2Qty, tp2Px)
+	}
+}
+
+// TestSoleOwnerTPDust_NeverPlaced_NoBook is the #777 negative guard: all-zero
+// TPOIDs with TPArmedTiers never set must not fabricate TP close trades.
+func TestSoleOwnerTPDust_NeverPlaced_NoBook(t *testing.T) {
+	const (
+		fullQty  = 0.013
+		dustQty  = 0.001
+		entryPx  = 75249.0
+		entryATR = 200.0
+	)
+	sc := soleOwnerTPSC()
+	sc.Symbol = "BTC"
+	sc.Args = []string{"sma", "BTC", "1h", "--mode=live"}
+
+	ss := &StrategyState{
+		ID:   sc.ID,
+		Cash: 1000,
+		Positions: map[string]*Position{
+			"BTC": {
+				Symbol: "BTC", Quantity: fullQty, InitialQuantity: fullQty,
+				AvgCost: entryPx, EntryATR: entryATR, Side: "short",
+				Multiplier: 1, Leverage: 5, OwnerStrategyID: sc.ID,
+				TPOIDs: []int64{0, 0}, TPArmedTiers: []bool{false, false},
+			},
+		},
+	}
+	positions := []HLPosition{{Coin: "BTC", Size: -dustQty, EntryPrice: entryPx, Leverage: 5}}
+	resolver := hlReconcileFillResolver(func(string, int64, float64) (HLFillLookup, bool) {
+		return HLFillLookup{}, false
+	})
+	logger := newTestLogger(t)
+
+	reconcileHyperliquidPositionsForStrategy(sc, ss, "BTC", positions, resolver, logger, nil)
+
+	if len(ss.TradeHistory) != 0 {
+		t.Fatalf("TradeHistory = %d, want 0 close trades", len(ss.TradeHistory))
+	}
+	pos := ss.Positions["BTC"]
+	if pos == nil {
+		t.Fatal("expected position to remain")
+	}
+	// Legacy reconciler resyncs qty to on-chain when dust is not TP-attributable.
+	if math.Abs(pos.Quantity-dustQty) > 1e-9 {
+		t.Errorf("Quantity = %g, want legacy resync to %g", pos.Quantity, dustQty)
+	}
+}
+
+// TestReconcileSharedCoin_TPDust_BooksBothTiers is Detector 3 parity for #777.
+func TestReconcileSharedCoin_TPDust_BooksBothTiers(t *testing.T) {
+	const (
+		fullQty  = 0.012 // 50/50 tiers → 0.006 per TP leg
+		dustQty  = 0.001
+		tp1OID   = int64(438613562733)
+		tp2OID   = int64(438613569010)
+		tp1Qty   = 0.006
+		tp2Qty   = 0.006
+		tp1Px    = 74605.0
+		tp2Px    = 74284.0
+		tp1Fee   = 0.064458
+		tp2Fee   = 0.06418
+		entryPx  = 75249.0
+		entryATR = 200.0
+	)
+	ownerID := "hl-owner-btc"
+	sc := StrategyConfig{
+		ID: ownerID, Platform: "hyperliquid", Type: "perps",
+		Args: []string{"sma", "BTC", "1h", "--mode=live"},
+		CloseStrategies: []StrategyRef{{Name: "tiered_tp_atr_live", Params: map[string]interface{}{
+			"tiers": []interface{}{
+				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.5},
+				map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
+			},
+		}}},
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			ownerID: {
+				ID: ownerID, Cash: 1000, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"BTC": {
+						Symbol: "BTC", Quantity: fullQty, InitialQuantity: fullQty,
+						AvgCost: entryPx, EntryATR: entryATR, Side: "short",
+						Multiplier: 1, Leverage: 5, OwnerStrategyID: ownerID,
+						TPOIDs: []int64{0, 0}, TPArmedTiers: []bool{true, true},
+					},
+				},
+				TradeHistory: []Trade{{
+					Symbol: "BTC", Side: "sell", Quantity: fullQty, Price: entryPx,
+					TPOIDs: []int64{tp1OID, tp2OID},
+				}},
+			},
+			"hl-peer-btc": {
+				ID: "hl-peer-btc", Cash: 500, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{},
+			},
+		},
+	}
+	allStrategies := []StrategyConfig{
+		sc,
+		{ID: "hl-peer-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"hold", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "BTC", Size: -dustQty, EntryPrice: entryPx, Leverage: 5}}
+	oldLookup := lookupHyperliquidReconcileFillFee
+	lookupHyperliquidReconcileFillFee = func(_ string, coin string, oid int64, qty float64) (HLFillLookup, bool) {
+		if coin != "BTC" {
+			return HLFillLookup{}, false
+		}
+		switch {
+		case oid == tp1OID || (oid == 0 && math.Abs(qty-tp1Qty) < 1e-9):
+			return HLFillLookup{Fee: tp1Fee, FilledQty: tp1Qty, Px: tp1Px, Count: 1, OID: tp1OID}, true
+		case oid == tp2OID || (oid == 0 && math.Abs(qty-tp2Qty) < 1e-9):
+			return HLFillLookup{Fee: tp2Fee, FilledQty: tp2Qty, Px: tp2Px, Count: 1, OID: tp2OID}, true
+		default:
+			return HLFillLookup{}, false
+		}
+	}
+	t.Cleanup(func() { lookupHyperliquidReconcileFillFee = oldLookup })
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, map[string]float64{"BTC": entryPx}, "0xtest", nil, false)
+
+	owner := state.Strategies[ownerID]
+	pos := owner.Positions["BTC"]
+	if pos == nil || math.Abs(pos.Quantity-dustQty) > 1e-9 {
+		t.Fatalf("owner BTC = %+v, want qty %g", pos, dustQty)
+	}
+	var closes int
+	for _, tr := range owner.TradeHistory {
+		if tr.IsClose {
+			closes++
+		}
+	}
+	if closes != 2 {
+		t.Fatalf("owner close trades = %d, want 2", closes)
+	}
+	gap := state.ReconciliationGaps["BTC"]
+	if gap == nil {
+		t.Fatal("expected ReconciliationGaps[BTC]")
+	}
+	if math.Abs(gap.DeltaQty) > 1e-6 {
+		t.Errorf("DeltaQty = %g, want 0", gap.DeltaQty)
+	}
+	if math.Abs(gap.VirtualQty-(-dustQty)) > 1e-6 {
+		t.Errorf("VirtualQty = %g, want %g", gap.VirtualQty, -dustQty)
+	}
+}

--- a/scheduler/protection_fill_alert_test.go
+++ b/scheduler/protection_fill_alert_test.go
@@ -234,8 +234,18 @@ func TestHyperliquidClearedTPTier_TierIndex(t *testing.T) {
 	if idx, ok := hyperliquidClearedTPTier(sc, pos, 0.422); !ok || idx != 1 {
 		t.Errorf("final tier: idx=%d ok=%v, want 1,true", idx, ok)
 	}
-	// All zero but qty mismatch → not attributable
+	// All zero but qty mismatch → not attributable without armed tiers
+	pos = &Position{Quantity: 0.422, TPOIDs: []int64{0, 0}, TPArmedTiers: []bool{false, false}}
 	if _, ok := hyperliquidClearedTPTier(sc, pos, 0.1); ok {
-		t.Error("ambiguous all-zero with mismatched qty must not attribute")
+		t.Error("ambiguous all-zero with mismatched qty must not attribute when tiers never armed")
+	}
+	// All zero, dust drift, every tier armed — hyperliquidClearedTPTier stays
+	// false; hlAttemptCloseFromArmedTPClears handles booking (#777).
+	pos = &Position{Quantity: 0.422, TPOIDs: []int64{0, 0}, TPArmedTiers: []bool{true, true}}
+	if !hyperliquidAllTiersArmedAndCleared(sc, pos) {
+		t.Error("expected all tiers armed and cleared for dust path")
+	}
+	if _, ok := hyperliquidClearedTPTier(sc, pos, 0.211); ok {
+		t.Error("hyperliquidClearedTPTier must not attribute dust drift directly")
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `hlAttemptCloseFromArmedTPClears` to book each armed/cleared TP tier at userFills VWAP when a same-direction dust residual remains after all TPs fill.
- Wires the path through sole-owner reconcile and shared-coin Detector 3; guards against silent qty resync when all tiers are armed/cleared.
- Prefetches per-tier fill lookups in the reconcile fee cache; regression tests cover positive (armed+dust) and negative (never-placed TP) cases.

Closes #777

## Test plan
- [x] `go test -C scheduler ./... -run 'TPDust|HyperliquidAllTiersArmed|SoleOwnerTP|HyperliquidHasCleared|AttemptCloseFromTP|ReconcileSharedCoin_TP'`

LLM: Composer 2.5 | high | Harness: cursor