### PR TITLE
feat(hl): regime-aware directional policy with hold-on-transition (#779)

### DIFF
--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -109,6 +109,19 @@ def load_strategy_config(config_path: str, strategy_id: str) -> dict:
                 f"{config_path}: strategy {strategy_id!r} has no open_strategy.name; "
                 f"the migrated config should always populate it."
             )
+        # #779: regime_directional_policy is HL-live-only — the backtester
+        # has no per-cycle resolver hook that mirrors runHyperliquidCheck,
+        # so the per-regime Direction / InvertSignal flip wouldn't apply
+        # and results would silently use the static config instead. Reject
+        # at config-load time so the operator sees the gap (parity with
+        # the regime-aware `sl_after` rejection at backtester init).
+        if sc.get("regime_directional_policy"):
+            raise ValueError(
+                f"{config_path}: strategy {strategy_id!r} uses "
+                f"regime_directional_policy, which is HL-live-only in this "
+                f"release (backtester parity deferred — see #779). Use the "
+                f"static `direction` / `invert_signal` fields for backtesting."
+            )
         close_refs = []
         for ref in sc.get("close_strategies", []) or []:
             if isinstance(ref, dict) and ref.get("name"):

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -297,39 +297,40 @@ type StrategyRef struct {
 
 // StrategyConfig describes a single strategy job.
 type StrategyConfig struct {
-	ID                     string              `json:"id"`
-	Type                   string              `json:"type"`                // "spot", "options", "perps", "futures", or "manual"
-	Platform               string              `json:"platform"`            // "deribit", "ibkr", "binanceus", "hyperliquid", "topstep"
-	Symbol                 string              `json:"symbol,omitempty"`    // manual strategies: trading symbol (e.g. "ETH")
-	Timeframe              string              `json:"timeframe,omitempty"` // manual strategies: OHLCV timeframe (e.g. "1h")
-	Script                 string              `json:"script"`
-	Args                   []string            `json:"args"`
-	OpenStrategy           StrategyRef         `json:"open_strategy"`              // entry strategy ref (name + params). Migrated from legacy string-typed open_strategy / args[0] in v13 (#640)
-	CloseStrategies        []StrategyRef       `json:"close_strategies,omitempty"` // exit strategy refs (name + params); max close_fraction wins (#480). Migrated from legacy []string in v13 (#640)
-	AllowedRegimes         []string            `json:"allowed_regimes,omitempty"`  // gate entries: skip signal when current regime not in this list; empty = allow all (#482)
-	Capital                float64             `json:"capital"`
-	CapitalPct             float64             `json:"capital_pct,omitempty"`     // 0-1; dynamic capital = wallet_balance * capital_pct (overrides capital)
-	InitialCapital         float64             `json:"initial_capital,omitempty"` // fixed starting balance for PnL display (never overwritten by capital_pct)
-	MaxDrawdownPct         float64             `json:"max_drawdown_pct"`
-	IntervalSeconds        int                 `json:"interval_seconds,omitempty"`           // per-strategy override (0 = use global)
-	HTFFilter              bool                `json:"htf_filter,omitempty"`                 // higher-timeframe trend filter
-	InvertSignal           bool                `json:"invert_signal,omitempty"`              // HL perps/manual only: flip BUY<->SELL on a non-zero signal before execution (HOLD/0 is never flipped). Lets inverse variants reuse the same open/close refs. Composes with Direction — invert runs in the Go layer before direction interprets the resulting sign (e.g. direction="short" + invert_signal=true opens short on raw-BUY triggers, distinct from plain direction="short" which opens on raw-SELL). Rejected outside HL perps/manual.
-	AllowShorts            bool                `json:"allow_shorts,omitempty"`               // DEPRECATED — use Direction. Perps only; legacy boolean retained on the struct so pre-v14 JSON unmarshals cleanly. Read via EffectiveDirection / PerpsAllowsShort / PerpsAllowsLong, never directly. Migrated to Direction in v14 (#656).
-	Direction              string              `json:"direction,omitempty"`                  // perps only: "long" (default; signal=1 opens, signal=-1 closes long), "short" (signal=-1 opens, signal=1 closes short), "both" (bidirectional). Empty falls back to AllowShorts (legacy). v14 migration converts allow_shorts→direction. (#656)
-	Leverage               float64             `json:"leverage,omitempty"`                   // perps exchange leverage (default 1 = no leverage); used for exchange margin/risk and HL update_leverage (#254/#497)
-	SizingLeverage         float64             `json:"sizing_leverage,omitempty"`            // perps notional multiplier; defaults to Leverage for backwards compatibility (#497). Notional formula: notional = cash * sizing_leverage; size = notional / price. For margin-based sizing, prefer MarginPerTradeUSD (#518).
-	MarginPerTradeUSD      *float64            `json:"margin_per_trade_usd,omitempty"`       // perps only: USD margin to deploy per open. When set (positive), overrides SizingLeverage: notional = min(MarginPerTradeUSD, cash) * exchange_leverage; size = notional / price. Lets operators size in margin-space directly so high exchange_leverage doesn't decouple intent from outcome (#518).
-	StopLossPct            *float64            `json:"stop_loss_pct,omitempty"`              // HL perps only: % from entry to place a reduce-only stop-loss trigger. Pointer so omitted (nil) falls through to StopLossMarginPct then MaxDrawdownPct for single-coin strategies (#484); LoadConfig normalizes omitted same-coin peers to explicit 0 (#494); explicit 0 disables auto-SL (#412)
-	StopLossMarginPct      *float64            `json:"stop_loss_margin_pct,omitempty"`       // HL perps only: % of deployed margin to lose before stop-loss trigger; mutually exclusive with stop_loss_pct; price % derived as StopLossMarginPct / Leverage at order time. Pointer so omitted falls through to MaxDrawdownPct for single-coin strategies; LoadConfig normalizes omitted same-coin peers to explicit 0 (#494); explicit 0 disables (#487, #484)
-	TrailingStopPct        *float64            `json:"trailing_stop_pct,omitempty"`          // HL perps only: synthetic trailing SL distance from the best mark seen while open; mutually exclusive with stop_loss_pct and stop_loss_margin_pct (#501)
-	TrailingStopATRMult    *float64            `json:"trailing_stop_atr_mult,omitempty"`     // HL perps only: trailing SL distance derived from entry ATR at open (effective_pct = mult * entry_atr / avg_cost * 100); fixed for the life of the position; mutually exclusive with trailing_stop_pct, stop_loss_pct, stop_loss_margin_pct (#505)
-	StopLossATRMult        *float64            `json:"stop_loss_atr_mult,omitempty"`         // HL perps only: fixed (non-trailing) SL distance derived from entry ATR at open (trigger_px = avg_cost ± mult * entry_atr); armed once on the cycle after open and never updated; mutually exclusive with stop_loss_pct, stop_loss_margin_pct, trailing_stop_pct, trailing_stop_atr_mult. When all five stop fields are omitted on a sole-owner HL perps strategy, LoadConfig defaults this to 1.0 so every position has volatility-adjusted exchange-side protection (#562)
-	StopLossATRRegime      *RegimeATRBlock     `json:"stop_loss_atr_regime,omitempty"`       // HL perps only: regime-aware sibling of stop_loss_atr_mult — resolves the ATR multiplier from pos.Regime stamped at open. Mutually exclusive with the four scalar siblings AND stop_loss_atr_mult. Requires regime detection enabled at the top-level cfg.Regime. (#733)
-	TrailingStopATRRegime  *RegimeATRBlock     `json:"trailing_stop_atr_regime,omitempty"`   // HL perps only: regime-aware sibling of trailing_stop_atr_mult — trailing distance frozen at open via pos.Regime. Mutually exclusive with the scalar siblings. Requires regime detection. (#733)
-	TrailingStopMinMovePct *float64            `json:"trailing_stop_min_move_pct,omitempty"` // HL perps trailing SL only: minimum trigger-price move before cancel/replace; nil defaults to 0.5% (#501)
-	MarginMode             string              `json:"margin_mode,omitempty"`                // HL perps only: "isolated" (default) or "cross"; sent via update_leverage on fresh opens to enforce per-position liq isolation (#486)
-	ThetaHarvest           *ThetaHarvestConfig `json:"theta_harvest,omitempty"`
-	FuturesConfig          *FuturesConfig      `json:"futures,omitempty"`
+	ID                      string                   `json:"id"`
+	Type                    string                   `json:"type"`                // "spot", "options", "perps", "futures", or "manual"
+	Platform                string                   `json:"platform"`            // "deribit", "ibkr", "binanceus", "hyperliquid", "topstep"
+	Symbol                  string                   `json:"symbol,omitempty"`    // manual strategies: trading symbol (e.g. "ETH")
+	Timeframe               string                   `json:"timeframe,omitempty"` // manual strategies: OHLCV timeframe (e.g. "1h")
+	Script                  string                   `json:"script"`
+	Args                    []string                 `json:"args"`
+	OpenStrategy            StrategyRef              `json:"open_strategy"`              // entry strategy ref (name + params). Migrated from legacy string-typed open_strategy / args[0] in v13 (#640)
+	CloseStrategies         []StrategyRef            `json:"close_strategies,omitempty"` // exit strategy refs (name + params); max close_fraction wins (#480). Migrated from legacy []string in v13 (#640)
+	AllowedRegimes          []string                 `json:"allowed_regimes,omitempty"`  // gate entries: skip signal when current regime not in this list; empty = allow all (#482)
+	Capital                 float64                  `json:"capital"`
+	CapitalPct              float64                  `json:"capital_pct,omitempty"`     // 0-1; dynamic capital = wallet_balance * capital_pct (overrides capital)
+	InitialCapital          float64                  `json:"initial_capital,omitempty"` // fixed starting balance for PnL display (never overwritten by capital_pct)
+	MaxDrawdownPct          float64                  `json:"max_drawdown_pct"`
+	IntervalSeconds         int                      `json:"interval_seconds,omitempty"`           // per-strategy override (0 = use global)
+	HTFFilter               bool                     `json:"htf_filter,omitempty"`                 // higher-timeframe trend filter
+	InvertSignal            bool                     `json:"invert_signal,omitempty"`              // HL perps/manual only: flip BUY<->SELL on a non-zero signal before execution (HOLD/0 is never flipped). Lets inverse variants reuse the same open/close refs. Composes with Direction — invert runs in the Go layer before direction interprets the resulting sign (e.g. direction="short" + invert_signal=true opens short on raw-BUY triggers, distinct from plain direction="short" which opens on raw-SELL). Rejected outside HL perps/manual.
+	AllowShorts             bool                     `json:"allow_shorts,omitempty"`               // DEPRECATED — use Direction. Perps only; legacy boolean retained on the struct so pre-v14 JSON unmarshals cleanly. Read via EffectiveDirection / PerpsAllowsShort / PerpsAllowsLong, never directly. Migrated to Direction in v14 (#656).
+	Direction               string                   `json:"direction,omitempty"`                  // perps only: "long" (default; signal=1 opens, signal=-1 closes long), "short" (signal=-1 opens, signal=1 closes short), "both" (bidirectional). Empty falls back to AllowShorts (legacy). v14 migration converts allow_shorts→direction. (#656)
+	Leverage                float64                  `json:"leverage,omitempty"`                   // perps exchange leverage (default 1 = no leverage); used for exchange margin/risk and HL update_leverage (#254/#497)
+	SizingLeverage          float64                  `json:"sizing_leverage,omitempty"`            // perps notional multiplier; defaults to Leverage for backwards compatibility (#497). Notional formula: notional = cash * sizing_leverage; size = notional / price. For margin-based sizing, prefer MarginPerTradeUSD (#518).
+	MarginPerTradeUSD       *float64                 `json:"margin_per_trade_usd,omitempty"`       // perps only: USD margin to deploy per open. When set (positive), overrides SizingLeverage: notional = min(MarginPerTradeUSD, cash) * exchange_leverage; size = notional / price. Lets operators size in margin-space directly so high exchange_leverage doesn't decouple intent from outcome (#518).
+	StopLossPct             *float64                 `json:"stop_loss_pct,omitempty"`              // HL perps only: % from entry to place a reduce-only stop-loss trigger. Pointer so omitted (nil) falls through to StopLossMarginPct then MaxDrawdownPct for single-coin strategies (#484); LoadConfig normalizes omitted same-coin peers to explicit 0 (#494); explicit 0 disables auto-SL (#412)
+	StopLossMarginPct       *float64                 `json:"stop_loss_margin_pct,omitempty"`       // HL perps only: % of deployed margin to lose before stop-loss trigger; mutually exclusive with stop_loss_pct; price % derived as StopLossMarginPct / Leverage at order time. Pointer so omitted falls through to MaxDrawdownPct for single-coin strategies; LoadConfig normalizes omitted same-coin peers to explicit 0 (#494); explicit 0 disables (#487, #484)
+	TrailingStopPct         *float64                 `json:"trailing_stop_pct,omitempty"`          // HL perps only: synthetic trailing SL distance from the best mark seen while open; mutually exclusive with stop_loss_pct and stop_loss_margin_pct (#501)
+	TrailingStopATRMult     *float64                 `json:"trailing_stop_atr_mult,omitempty"`     // HL perps only: trailing SL distance derived from entry ATR at open (effective_pct = mult * entry_atr / avg_cost * 100); fixed for the life of the position; mutually exclusive with trailing_stop_pct, stop_loss_pct, stop_loss_margin_pct (#505)
+	StopLossATRMult         *float64                 `json:"stop_loss_atr_mult,omitempty"`         // HL perps only: fixed (non-trailing) SL distance derived from entry ATR at open (trigger_px = avg_cost ± mult * entry_atr); armed once on the cycle after open and never updated; mutually exclusive with stop_loss_pct, stop_loss_margin_pct, trailing_stop_pct, trailing_stop_atr_mult. When all five stop fields are omitted on a sole-owner HL perps strategy, LoadConfig defaults this to 1.0 so every position has volatility-adjusted exchange-side protection (#562)
+	StopLossATRRegime       *RegimeATRBlock          `json:"stop_loss_atr_regime,omitempty"`       // HL perps only: regime-aware sibling of stop_loss_atr_mult — resolves the ATR multiplier from pos.Regime stamped at open. Mutually exclusive with the four scalar siblings AND stop_loss_atr_mult. Requires regime detection enabled at the top-level cfg.Regime. (#733)
+	TrailingStopATRRegime   *RegimeATRBlock          `json:"trailing_stop_atr_regime,omitempty"`   // HL perps only: regime-aware sibling of trailing_stop_atr_mult — trailing distance frozen at open via pos.Regime. Mutually exclusive with the scalar siblings. Requires regime detection. (#733)
+	TrailingStopMinMovePct  *float64                 `json:"trailing_stop_min_move_pct,omitempty"` // HL perps trailing SL only: minimum trigger-price move before cancel/replace; nil defaults to 0.5% (#501)
+	MarginMode              string                   `json:"margin_mode,omitempty"`                // HL perps only: "isolated" (default) or "cross"; sent via update_leverage on fresh opens to enforce per-position liq isolation (#486)
+	ThetaHarvest            *ThetaHarvestConfig      `json:"theta_harvest,omitempty"`
+	FuturesConfig           *FuturesConfig           `json:"futures,omitempty"`
+	RegimeDirectionalPolicy *RegimeDirectionalPolicy `json:"regime_directional_policy,omitempty"` // HL perps only: regime-aware override for Direction + InvertSignal. When set, runHyperliquidCheck resolves the effective pair per-cycle from the current regime (when flat) or pos.Regime (when an open position is held — "hold until natural exit" semantics). Static Direction/InvertSignal are the base; the policy overrides per regime. Requires regime detection enabled at top-level cfg.Regime. (#779)
 }
 
 // EffectiveSizingLeverage returns the notional-sizing multiplier for perps.
@@ -1404,6 +1405,23 @@ func ValidateConfig(cfg *Config) error {
 			if sc.Platform != "hyperliquid" || (sc.Type != "perps" && sc.Type != "manual") {
 				errs = append(errs, fmt.Sprintf("%s: invert_signal is only supported for HL perps/manual strategies (got platform=%q type=%q)", prefix, sc.Platform, sc.Type))
 			}
+		}
+
+		// regime_directional_policy: HL perps only (same surface as invert_signal
+		// since both override the same fields runHyperliquidCheck consumes).
+		// Requires regime detection enabled at top-level cfg.Regime — without it
+		// result.Regime stays empty and the resolver always falls back to the
+		// static base config, which silently defeats the policy. Reject the
+		// asymmetric config at startup so the operator sees the gap. (#779)
+		if sc.RegimeDirectionalPolicy.IsConfigured() {
+			if sc.Platform != "hyperliquid" || sc.Type != "perps" {
+				errs = append(errs, fmt.Sprintf("%s: regime_directional_policy is only supported for HL perps strategies (got platform=%q type=%q)", prefix, sc.Platform, sc.Type))
+			}
+			if cfg.Regime == nil || !cfg.Regime.Enabled {
+				errs = append(errs, fmt.Sprintf("%s: regime_directional_policy requires top-level regime.enabled=true", prefix))
+			}
+			polErrs := sc.RegimeDirectionalPolicy.ResolveRaw(prefix + ".regime_directional_policy")
+			errs = append(errs, polErrs...)
 		}
 
 		// #486: validate margin_mode (HL perps only). Empty is allowed

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -151,6 +151,14 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 			sc.Direction = ns.Direction
 			sc.AllowShorts = ns.AllowShorts
 		}
+		// #779: regime_directional_policy mutation when flat. State-compat
+		// gate above blocks the change while a position is open; if we got
+		// here with a different shape, the strategy is flat and the next
+		// cycle's resolver reads the new map. Compare structural equality.
+		if !sc.RegimeDirectionalPolicy.EqualForReload(ns.RegimeDirectionalPolicy) {
+			addChange("strategy[%s].regime_directional_policy: shape updated", sc.ID)
+			sc.RegimeDirectionalPolicy = ns.RegimeDirectionalPolicy
+		}
 	}
 
 	if portfolioRiskMaxDrawdown(cfg.PortfolioRisk) != portfolioRiskMaxDrawdown(next.PortfolioRisk) {
@@ -395,6 +403,25 @@ func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error 
 					sc.ID))
 			}
 		}
+		// #779: regime_directional_policy shape changes (add/remove/mutate)
+		// while a position is open would shift the resolver's effective
+		// (Direction, InvertSignal) underneath the held position. Since
+		// effectiveRegimeForPolicy uses pos.Regime while open — by design
+		// so the policy that opened the position governs its lifecycle —
+		// mutating the per-regime entry for pos.Regime mid-position can
+		// silently change what counts as a "close" signal. Block the
+		// reshape; changes when flat take effect on the next cycle.
+		if sc.Type == "perps" && sc.Platform == "hyperliquid" && strategyHasOpenPositions(stateStrategy(state, sc.ID)) {
+			oldConfigured := sc.RegimeDirectionalPolicy.IsConfigured()
+			newConfigured := ns.RegimeDirectionalPolicy.IsConfigured()
+			if oldConfigured != newConfigured {
+				errs = append(errs, fmt.Sprintf("strategy[%s] regime_directional_policy mode changed with open positions (flatten first or restart after close)",
+					sc.ID))
+			} else if oldConfigured && !sc.RegimeDirectionalPolicy.EqualForReload(ns.RegimeDirectionalPolicy) {
+				errs = append(errs, fmt.Sprintf("strategy[%s] regime_directional_policy shape changed with open positions (flatten first or restart after close)",
+					sc.ID))
+			}
+		}
 		// #716 item 1: sl_after rules are armed at the next cleared TP tier; a
 		// mid-position add/remove/mode change would engage the post-TP machinery
 		// (and, for trail_from_here, the trailing walker) without the validation
@@ -427,15 +454,17 @@ func strategyRestartShape(sc StrategyConfig) StrategyConfig {
 	sc.OpenStrategy = StrategyRef{}
 	sc.CloseStrategies = nil
 	sc.AllowedRegimes = nil
-	sc.MarginMode = ""              // #486: hot-reloadable when flat (state-compat check enforces flat-only change)
-	sc.TrailingStopPct = nil        // #501: hot-reloadable; state-compat allows pct changes but blocks mode switches while open
-	sc.TrailingStopATRMult = nil    // #505: hot-reloadable; same state-compat treatment as TrailingStopPct
-	sc.StopLossATRMult = nil        // #562: hot-reloadable; mode toggle blocked while open
-	sc.StopLossATRRegime = nil      // #733: hot-reloadable; state-compat blocks scalar↔regime + shape changes while open
-	sc.TrailingStopATRRegime = nil  // #733: hot-reloadable; state-compat blocks scalar↔regime + shape changes while open
-	sc.TrailingStopMinMovePct = nil // #501: hot-reloadable tuning knob for trailing trigger churn
-	sc.Direction = ""               // #656: hot-reloadable when flat; state-compat blocks change while open
-	sc.AllowShorts = false          // #656: legacy field — direction change is what gates hot reload
+	sc.MarginMode = ""               // #486: hot-reloadable when flat (state-compat check enforces flat-only change)
+	sc.TrailingStopPct = nil         // #501: hot-reloadable; state-compat allows pct changes but blocks mode switches while open
+	sc.TrailingStopATRMult = nil     // #505: hot-reloadable; same state-compat treatment as TrailingStopPct
+	sc.StopLossATRMult = nil         // #562: hot-reloadable; mode toggle blocked while open
+	sc.StopLossATRRegime = nil       // #733: hot-reloadable; state-compat blocks scalar↔regime + shape changes while open
+	sc.TrailingStopATRRegime = nil   // #733: hot-reloadable; state-compat blocks scalar↔regime + shape changes while open
+	sc.TrailingStopMinMovePct = nil  // #501: hot-reloadable tuning knob for trailing trigger churn
+	sc.Direction = ""                // #656: hot-reloadable when flat; state-compat blocks change while open
+	sc.AllowShorts = false           // #656: legacy field — direction change is what gates hot reload
+	sc.InvertSignal = false          // #775: hot-reloadable; state-compat blocks change while open. Needed in shape mask so the immutable-fields DeepEqual doesn't flag a pure invert_signal toggle as "restart required" (parallel to Direction above).
+	sc.RegimeDirectionalPolicy = nil // #779: hot-reloadable; state-compat blocks add/remove/reshape while open
 	return sc
 }
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2499,10 +2499,21 @@ func runHyperliquidCheck(sc *StrategyConfig, prices map[string]float64, posCtx P
 	// resolves from result.Regime (current cycle); while a position is open,
 	// uses posCtx.Regime (the regime stamped at open) so the position runs
 	// to its natural exit under the policy that opened it.
-	if entry, applied := applyRegimeDirectionalPolicy(sc, result.Regime, posCtx.Regime, posCtx.Quantity); applied {
+	if entry, applied, legacyFallback := applyRegimeDirectionalPolicy(sc, result.Regime, posCtx.Regime, posCtx.Quantity); applied {
 		regimeKey := effectiveRegimeForPolicy(result.Regime, posCtx.Regime, posCtx.Quantity)
 		logger.Info("Regime directional policy: regime=%s -> direction=%q invert_signal=%t",
 			regimeKey, entry.Direction, entry.InvertSignal)
+		// One-shot operator alert for pre-#741 legacy positions opened before
+		// regime stamping landed. The policy still applies, but the
+		// hold-on-transition contract (position runs under the regime it
+		// opened in) can't be honored for that position — it instead floats
+		// with the current regime until it closes naturally. Self-heals once
+		// the next entry stamps regime at open.
+		if legacyFallback {
+			if _, loaded := regimeDirectionalLegacyWarned.LoadOrStore(sc.ID, struct{}{}); !loaded {
+				logger.Warn("Regime directional policy: open position has no stamped regime (legacy pre-#741); resolving against current regime=%q. Hold-on-transition not guaranteed for this position; self-heals on next entry.", regimeKey)
+			}
+		}
 	}
 	applySignalInversion(*sc, result, logger)
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1445,7 +1445,7 @@ func main() {
 									mu.Unlock()
 								}
 							}
-						} else if result, signalStr, price, ok := runHyperliquidCheck(sc, prices, hlPosCtx, cfg.Regime, logger); ok {
+						} else if result, signalStr, price, ok := runHyperliquidCheck(&sc, prices, hlPosCtx, cfg.Regime, logger); ok {
 							prices[result.Symbol] = price
 							if regimeBlocksOpen(sc.AllowedRegimes, result.Regime, hlPosQty) {
 								logger.Info("Regime gate: open signal blocked (regime=%s)", result.Regime)
@@ -2446,13 +2446,19 @@ func isHLLiveReconcilable(sc StrategyConfig) bool {
 }
 
 // runHyperliquidCheck runs check_hyperliquid.py signal-check mode (Phase 3, no lock).
-func runHyperliquidCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, logger *StrategyLogger) (*HyperliquidResult, string, float64, bool) {
+//
+// sc is a pointer because the regime-aware directional policy (#779) needs
+// to mutate Direction + InvertSignal in the caller's local sc copy after
+// result.Regime is known, so downstream EffectiveDirection / perpsLiveOrderSize
+// / PerpsOrderSkipReason calls in execute paths see the effective values.
+// Mutation is scoped to the loop-local sc; cfg.Strategies is never touched.
+func runHyperliquidCheck(sc *StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, logger *StrategyLogger) (*HyperliquidResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
 	// Suppress in-process close evaluators that overlap on-chain reduce-only
 	// protection — running both races on the shared on-chain position
 	// (#604 review #2). Filter only changes the argv passed to Python; the
 	// stored config is untouched.
-	scForCheck := strategyConfigWithOnChainProtectionFilter(sc)
+	scForCheck := strategyConfigWithOnChainProtectionFilter(*sc)
 	args = appendOpenCloseArgs(args, scForCheck, posCtx)
 	if sc.HTFFilter {
 		args = append(args, "--htf-filter")
@@ -2488,7 +2494,17 @@ func runHyperliquidCheck(sc StrategyConfig, prices map[string]float64, posCtx Po
 		logger.Error("Script returned error: %s", result.Error)
 		return nil, "", 0, false
 	}
-	applySignalInversion(sc, result, logger)
+	// #779: resolve regime-aware directional policy BEFORE applySignalInversion
+	// so the invert decision uses the effective sc.InvertSignal. When flat,
+	// resolves from result.Regime (current cycle); while a position is open,
+	// uses posCtx.Regime (the regime stamped at open) so the position runs
+	// to its natural exit under the policy that opened it.
+	if entry, applied := applyRegimeDirectionalPolicy(sc, result.Regime, posCtx.Regime, posCtx.Quantity); applied {
+		regimeKey := effectiveRegimeForPolicy(result.Regime, posCtx.Regime, posCtx.Quantity)
+		logger.Info("Regime directional policy: regime=%s -> direction=%q invert_signal=%t",
+			regimeKey, entry.Direction, entry.InvertSignal)
+	}
+	applySignalInversion(*sc, result, logger)
 
 	signalStr := signalLabel(result.Signal)
 	logger.Info("Signal: %s | %s @ $%.2f [%s]", signalStr, result.Symbol, result.Price, result.Mode)

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -888,7 +888,7 @@ func runManualCloseEval(sc StrategyConfig, ss *StrategyState, cfg *Config, logge
 	}
 
 	posCtx := positionCtxFromPosition(pos)
-	result, _, price, ok := runHyperliquidCheck(sc, nil, posCtx, cfg.Regime, logger)
+	result, _, price, ok := runHyperliquidCheck(&sc, nil, posCtx, cfg.Regime, logger)
 	if !ok {
 		return 0, 0, false
 	}

--- a/scheduler/regime_directional_policy.go
+++ b/scheduler/regime_directional_policy.go
@@ -37,7 +37,17 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 )
+
+// regimeDirectionalLegacyWarned tracks per-strategy one-shot warnings for the
+// "open position with empty pos.Regime" fallback path (positions opened before
+// regime stamping landed in #741). Keyed by strategy ID; cleared on process
+// restart. Warning is informational — the policy still resolves under the
+// current cycle's regime — but hold-on-transition isn't guaranteed for that
+// position. Self-heals once the position closes and the next entry stamps
+// regime at open.
+var regimeDirectionalLegacyWarned sync.Map
 
 // RegimeDirectionalEntry is the per-regime override pair.
 type RegimeDirectionalEntry struct {
@@ -168,12 +178,19 @@ func (p *RegimeDirectionalPolicy) ResolveRaw(label string) []string {
 		return errs
 	}
 	parsed := make(map[string]RegimeDirectionalEntry, len(classifier))
+	// `seen` records every regime label the operator actually wrote in the
+	// config (even if its body failed validation). The canonical-label
+	// "missing required" check below consults `seen`, not `parsed`, so a
+	// single typo (e.g. direction="sideways") fires one error against the
+	// offending key instead of also being double-reported as "missing".
+	seen := make(map[string]bool, len(classifier))
 	keys := make([]string, 0, len(classifier))
 	for k := range classifier {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	for _, regimeLabel := range keys {
+		seen[regimeLabel] = true
 		entryRaw := classifier[regimeLabel]
 		entryMap, ok := entryRaw.(map[string]interface{})
 		if !ok {
@@ -228,10 +245,11 @@ func (p *RegimeDirectionalPolicy) ResolveRaw(label string) []string {
 	}
 	// Require all canonical labels present so there's never an undefined
 	// fallback at runtime. Operators who want the static config to apply
-	// for one regime can spell it out explicitly.
+	// for one regime can spell it out explicitly. Uses `seen` (not `parsed`)
+	// so a label that's present-but-invalid isn't also reported as missing.
 	missing := []string{}
 	for _, l := range canonicalTrendRegimeLabels {
-		if _, ok := parsed[l]; !ok {
+		if !seen[l] {
 			missing = append(missing, l)
 		}
 	}
@@ -266,14 +284,21 @@ func effectiveRegimeForPolicy(currentRegime, posRegime string, posQty float64) s
 // /status and inspect can show it. When the strategy has no policy block
 // (or no regime is available), sc is left untouched and changed=false.
 //
+// `legacyFallback` is true iff a position is open but pos.Regime is empty
+// (pre-#741 position predating regime stamping). The resolver still resolves
+// against the current regime so the policy doesn't no-op, but the
+// hold-on-transition guarantee can't be honored for that position — the
+// caller should emit a one-shot operator warning.
+//
 // Caller contract: pass a LOCAL copy of sc (the loop iteration variable),
 // not a pointer into cfg.Strategies. The mutation propagates to all
 // downstream uses in the same cycle (applySignalInversion, EffectiveDirection
 // calls in execute paths, etc.) without persisting into shared config state.
-func applyRegimeDirectionalPolicy(sc *StrategyConfig, currentRegime, posRegime string, posQty float64) (effective RegimeDirectionalEntry, applied bool) {
+func applyRegimeDirectionalPolicy(sc *StrategyConfig, currentRegime, posRegime string, posQty float64) (effective RegimeDirectionalEntry, applied bool, legacyFallback bool) {
 	if sc == nil || sc.RegimeDirectionalPolicy.IsZero() {
-		return RegimeDirectionalEntry{}, false
+		return RegimeDirectionalEntry{}, false, false
 	}
+	legacyFallback = posQty > 0 && strings.TrimSpace(posRegime) == ""
 	regime := effectiveRegimeForPolicy(currentRegime, posRegime, posQty)
 	entry, ok := sc.RegimeDirectionalPolicy.Resolve(regime)
 	if !ok {
@@ -281,9 +306,9 @@ func applyRegimeDirectionalPolicy(sc *StrategyConfig, currentRegime, posRegime s
 		// static base config applies. Validation guarantees all canonical
 		// labels are present, so this only happens for empty/unknown
 		// regimes (e.g. regime detection disabled).
-		return RegimeDirectionalEntry{}, false
+		return RegimeDirectionalEntry{}, false, false
 	}
 	sc.Direction = entry.Direction
 	sc.InvertSignal = entry.InvertSignal
-	return entry, true
+	return entry, true, legacyFallback
 }

--- a/scheduler/regime_directional_policy.go
+++ b/scheduler/regime_directional_policy.go
@@ -1,0 +1,289 @@
+package main
+
+// Regime-aware directional policy (#779).
+//
+// Lets a single HL perps strategy switch between long/short/inverse modes
+// automatically as the market regime changes, without operator hot-edits.
+// Pairs with #775's `invert_signal` so an "inverse short in trending_down,
+// plain long otherwise" config is encoded once and applied deterministically.
+//
+// Shape (all three canonical labels required):
+//
+//	"regime_directional_policy": {
+//	  "trend_regime": {
+//	    "trending_down": { "direction": "short", "invert_signal": true },
+//	    "trending_up":   { "direction": "long",  "invert_signal": false },
+//	    "ranging":       { "direction": "long",  "invert_signal": false }
+//	  }
+//	}
+//
+// Resolver semantics (applied inside runHyperliquidCheck after the script
+// returns and result.Regime is known):
+//
+//   - When flat (posQty == 0): resolve from result.Regime (current cycle).
+//   - When a position is open (posQty > 0): resolve from pos.Regime —
+//     positions inherit the policy they were opened under and run to their
+//     natural exit (SL/TP/close evaluator). New entries opposite to the
+//     held side never fire because PerpsOrderSkipReason / perpsLiveOrderSize
+//     both gate on the resolved Direction; close evaluators always run.
+//
+// HL perps only (mirrors invert_signal's surface, validated in config.go).
+// Static StrategyConfig.Direction / InvertSignal remain the BASE config —
+// used when this block is absent. When present, the policy overrides both
+// fields per-regime.
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// RegimeDirectionalEntry is the per-regime override pair.
+type RegimeDirectionalEntry struct {
+	Direction    string `json:"direction"`
+	InvertSignal bool   `json:"invert_signal"`
+}
+
+// RegimeDirectionalPolicy wraps the trend_regime map. The wrapper key
+// matches RegimeATRBlock (regimeClassifierKey) so future classifiers
+// (e.g. vol_regime) can compose alongside the trend_regime block.
+type RegimeDirectionalPolicy struct {
+	TrendRegime map[string]RegimeDirectionalEntry
+	raw         map[string]interface{}
+}
+
+// UnmarshalJSON captures the raw shape for later strategy-scoped validation
+// in LoadConfig — mirrors RegimeATRBlock's deferred-resolve pattern so
+// error messages can name the offending strategy ID.
+func (p *RegimeDirectionalPolicy) UnmarshalJSON(data []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("regime_directional_policy: %w", err)
+	}
+	p.raw = raw
+	return nil
+}
+
+// MarshalJSON renders the canonical form for hot-reload diff logging and
+// `go-trader inspect`. Defined on the value receiver so encoding/json picks
+// it up whether the field is a pointer or value.
+func (p RegimeDirectionalPolicy) MarshalJSON() ([]byte, error) {
+	if len(p.TrendRegime) == 0 {
+		return json.Marshal(p.raw)
+	}
+	inner := map[string]RegimeDirectionalEntry{}
+	for k, v := range p.TrendRegime {
+		inner[k] = v
+	}
+	return json.Marshal(map[string]map[string]RegimeDirectionalEntry{regimeClassifierKey: inner})
+}
+
+// Resolve runs after ResolveRaw has populated TrendRegime. Validation
+// guarantees the lookup hits when regime is one of the canonical labels;
+// fallback returns (zero, false) which callers translate to "use static
+// base Direction/InvertSignal".
+func (p *RegimeDirectionalPolicy) Resolve(regime string) (RegimeDirectionalEntry, bool) {
+	if p == nil || len(p.TrendRegime) == 0 {
+		return RegimeDirectionalEntry{}, false
+	}
+	entry, ok := p.TrendRegime[strings.TrimSpace(regime)]
+	return entry, ok
+}
+
+// IsConfigured reports whether the operator supplied any value. Safe to
+// call before ResolveRaw (relies on captured raw, parallels
+// RegimeATRBlock.IsConfigured).
+func (p *RegimeDirectionalPolicy) IsConfigured() bool {
+	if p == nil {
+		return false
+	}
+	if len(p.TrendRegime) > 0 {
+		return true
+	}
+	return len(p.raw) > 0
+}
+
+// IsZero reports whether the block is empty after resolution. Pointer
+// receiver so calls on a nil *RegimeDirectionalPolicy don't panic.
+func (p *RegimeDirectionalPolicy) IsZero() bool {
+	if p == nil {
+		return true
+	}
+	return len(p.TrendRegime) == 0
+}
+
+// EqualForReload reports shape equality for hot-reload state-compat
+// (parallels RegimeATRBlock.EqualForReload).
+func (p *RegimeDirectionalPolicy) EqualForReload(other *RegimeDirectionalPolicy) bool {
+	aZero := p == nil || p.IsZero()
+	bZero := other == nil || other.IsZero()
+	if aZero != bZero {
+		return false
+	}
+	if aZero {
+		return true
+	}
+	if len(p.TrendRegime) != len(other.TrendRegime) {
+		return false
+	}
+	for k, va := range p.TrendRegime {
+		vb, ok := other.TrendRegime[k]
+		if !ok {
+			return false
+		}
+		if va.Direction != vb.Direction || va.InvertSignal != vb.InvertSignal {
+			return false
+		}
+	}
+	return true
+}
+
+// ResolveRaw parses the captured raw JSON into the typed TrendRegime map.
+// Called from LoadConfig with strategy-scoped errors. The validation
+// enforces:
+//   - top-level shape: { "trend_regime": { <label>: { direction, invert_signal } } }
+//   - every canonical label (trending_up, trending_down, ranging) present
+//   - direction is one of "long" / "short" / "both"
+//   - invert_signal is bool (json default false when omitted)
+//
+// Once resolved, TrendRegime is the runtime source of truth and raw is
+// retained only for MarshalJSON re-rendering.
+func (p *RegimeDirectionalPolicy) ResolveRaw(label string) []string {
+	var errs []string
+	if p == nil {
+		return errs
+	}
+	if len(p.raw) == 0 {
+		return errs
+	}
+	classifierRaw, ok := p.raw[regimeClassifierKey]
+	if !ok {
+		errs = append(errs, fmt.Sprintf("%s: missing required %q wrapper key", label, regimeClassifierKey))
+		return errs
+	}
+	classifier, ok := classifierRaw.(map[string]interface{})
+	if !ok {
+		errs = append(errs, fmt.Sprintf("%s: %q must be an object", label, regimeClassifierKey))
+		return errs
+	}
+	parsed := make(map[string]RegimeDirectionalEntry, len(classifier))
+	keys := make([]string, 0, len(classifier))
+	for k := range classifier {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, regimeLabel := range keys {
+		entryRaw := classifier[regimeLabel]
+		entryMap, ok := entryRaw.(map[string]interface{})
+		if !ok {
+			errs = append(errs, fmt.Sprintf("%s.%s: must be an object with {direction, invert_signal}", label, regimeLabel))
+			continue
+		}
+		// Direction is required.
+		dirRaw, hasDir := entryMap["direction"]
+		if !hasDir {
+			errs = append(errs, fmt.Sprintf("%s.%s: missing required key %q", label, regimeLabel, "direction"))
+			continue
+		}
+		dir, ok := dirRaw.(string)
+		if !ok {
+			errs = append(errs, fmt.Sprintf("%s.%s.direction: must be a string", label, regimeLabel))
+			continue
+		}
+		switch dir {
+		case DirectionLong, DirectionShort, DirectionBoth:
+			// valid
+		default:
+			errs = append(errs, fmt.Sprintf("%s.%s.direction: must be %q, %q, or %q (got %q)", label, regimeLabel, DirectionLong, DirectionShort, DirectionBoth, dir))
+			continue
+		}
+		// invert_signal is optional (defaults to false).
+		invert := false
+		if invRaw, hasInv := entryMap["invert_signal"]; hasInv {
+			b, ok := invRaw.(bool)
+			if !ok {
+				errs = append(errs, fmt.Sprintf("%s.%s.invert_signal: must be a boolean", label, regimeLabel))
+				continue
+			}
+			invert = b
+		}
+		// Reject unknown keys to catch typos early.
+		for k := range entryMap {
+			if k != "direction" && k != "invert_signal" {
+				errs = append(errs, fmt.Sprintf("%s.%s: unknown key %q (valid: direction, invert_signal)", label, regimeLabel, k))
+			}
+		}
+		parsed[regimeLabel] = RegimeDirectionalEntry{Direction: dir, InvertSignal: invert}
+	}
+	// Reject unknown regime labels.
+	validLabels := map[string]bool{}
+	for _, l := range canonicalTrendRegimeLabels {
+		validLabels[l] = true
+	}
+	for _, k := range keys {
+		if !validLabels[k] {
+			errs = append(errs, fmt.Sprintf("%s: unknown regime label %q (valid: %s)", label, k, strings.Join(canonicalTrendRegimeLabels, ", ")))
+		}
+	}
+	// Require all canonical labels present so there's never an undefined
+	// fallback at runtime. Operators who want the static config to apply
+	// for one regime can spell it out explicitly.
+	missing := []string{}
+	for _, l := range canonicalTrendRegimeLabels {
+		if _, ok := parsed[l]; !ok {
+			missing = append(missing, l)
+		}
+	}
+	if len(missing) > 0 {
+		errs = append(errs, fmt.Sprintf("%s: missing required regime labels: %s", label, strings.Join(missing, ", ")))
+	}
+	if len(errs) == 0 {
+		p.TrendRegime = parsed
+	}
+	return errs
+}
+
+// effectiveRegimeForPolicy chooses which regime label to feed the resolver.
+//   - When flat (posQty <= 0), use the current cycle's regime (the fresh
+//     entry decision should reflect the new regime immediately).
+//   - When a position is open (posQty > 0), use the regime stamped on the
+//     position at open time. This implements the "hold until natural exit"
+//     semantics: the policy that opened the position governs its lifecycle,
+//     and the new regime's policy only takes effect once flat.
+//
+// When posRegime is empty (legacy position pre-dating regime stamping),
+// fall back to the current cycle's regime so the policy still resolves.
+func effectiveRegimeForPolicy(currentRegime, posRegime string, posQty float64) string {
+	if posQty > 0 && strings.TrimSpace(posRegime) != "" {
+		return posRegime
+	}
+	return currentRegime
+}
+
+// applyRegimeDirectionalPolicy resolves the per-regime override and mutates
+// the local sc copy in place. Returns the effective entry actually used so
+// /status and inspect can show it. When the strategy has no policy block
+// (or no regime is available), sc is left untouched and changed=false.
+//
+// Caller contract: pass a LOCAL copy of sc (the loop iteration variable),
+// not a pointer into cfg.Strategies. The mutation propagates to all
+// downstream uses in the same cycle (applySignalInversion, EffectiveDirection
+// calls in execute paths, etc.) without persisting into shared config state.
+func applyRegimeDirectionalPolicy(sc *StrategyConfig, currentRegime, posRegime string, posQty float64) (effective RegimeDirectionalEntry, applied bool) {
+	if sc == nil || sc.RegimeDirectionalPolicy.IsZero() {
+		return RegimeDirectionalEntry{}, false
+	}
+	regime := effectiveRegimeForPolicy(currentRegime, posRegime, posQty)
+	entry, ok := sc.RegimeDirectionalPolicy.Resolve(regime)
+	if !ok {
+		// Regime unknown / not in policy map. Leave sc untouched so the
+		// static base config applies. Validation guarantees all canonical
+		// labels are present, so this only happens for empty/unknown
+		// regimes (e.g. regime detection disabled).
+		return RegimeDirectionalEntry{}, false
+	}
+	sc.Direction = entry.Direction
+	sc.InvertSignal = entry.InvertSignal
+	return entry, true
+}

--- a/scheduler/regime_directional_policy_test.go
+++ b/scheduler/regime_directional_policy_test.go
@@ -1,0 +1,431 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestRegimeDirectionalPolicyResolveRaw covers parsing + validation:
+// canonical labels required, valid direction enum, wrapper key enforced,
+// unknown keys rejected.
+func TestRegimeDirectionalPolicyResolveRaw(t *testing.T) {
+	t.Run("accepts canonical shape", func(t *testing.T) {
+		raw := `{"trend_regime": {
+			"trending_up":   {"direction": "long",  "invert_signal": false},
+			"trending_down": {"direction": "short", "invert_signal": true},
+			"ranging":       {"direction": "long",  "invert_signal": false}
+		}}`
+		var p RegimeDirectionalPolicy
+		if err := json.Unmarshal([]byte(raw), &p); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		errs := p.ResolveRaw("strategy[test].regime_directional_policy")
+		if len(errs) != 0 {
+			t.Fatalf("expected no errors, got: %v", errs)
+		}
+		if len(p.TrendRegime) != 3 {
+			t.Fatalf("expected 3 entries, got %d", len(p.TrendRegime))
+		}
+		entry := p.TrendRegime["trending_down"]
+		if entry.Direction != "short" || !entry.InvertSignal {
+			t.Fatalf("trending_down: got %+v", entry)
+		}
+	})
+
+	t.Run("rejects missing wrapper key", func(t *testing.T) {
+		raw := `{"trending_up": {"direction": "long"}}`
+		var p RegimeDirectionalPolicy
+		_ = json.Unmarshal([]byte(raw), &p)
+		errs := p.ResolveRaw("x")
+		if len(errs) == 0 || !strings.Contains(errs[0], "trend_regime") {
+			t.Fatalf("expected wrapper-key error, got: %v", errs)
+		}
+	})
+
+	t.Run("rejects missing canonical label", func(t *testing.T) {
+		raw := `{"trend_regime": {
+			"trending_up":   {"direction": "long"},
+			"trending_down": {"direction": "short", "invert_signal": true}
+		}}`
+		var p RegimeDirectionalPolicy
+		_ = json.Unmarshal([]byte(raw), &p)
+		errs := p.ResolveRaw("x")
+		found := false
+		for _, e := range errs {
+			if strings.Contains(e, "missing required regime labels") && strings.Contains(e, "ranging") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected missing-labels error mentioning ranging, got: %v", errs)
+		}
+	})
+
+	t.Run("rejects unknown regime label", func(t *testing.T) {
+		raw := `{"trend_regime": {
+			"trending_up":   {"direction": "long"},
+			"trending_down": {"direction": "short"},
+			"ranging":       {"direction": "long"},
+			"trending_sideways": {"direction": "long"}
+		}}`
+		var p RegimeDirectionalPolicy
+		_ = json.Unmarshal([]byte(raw), &p)
+		errs := p.ResolveRaw("x")
+		found := false
+		for _, e := range errs {
+			if strings.Contains(e, "unknown regime label") && strings.Contains(e, "trending_sideways") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected unknown-label error, got: %v", errs)
+		}
+	})
+
+	t.Run("rejects invalid direction value", func(t *testing.T) {
+		raw := `{"trend_regime": {
+			"trending_up":   {"direction": "sideways"},
+			"trending_down": {"direction": "short"},
+			"ranging":       {"direction": "long"}
+		}}`
+		var p RegimeDirectionalPolicy
+		_ = json.Unmarshal([]byte(raw), &p)
+		errs := p.ResolveRaw("x")
+		found := false
+		for _, e := range errs {
+			if strings.Contains(e, "direction") && strings.Contains(e, "sideways") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected invalid-direction error, got: %v", errs)
+		}
+	})
+
+	t.Run("rejects unknown entry key", func(t *testing.T) {
+		raw := `{"trend_regime": {
+			"trending_up":   {"direction": "long", "size_mult": 2.0},
+			"trending_down": {"direction": "short"},
+			"ranging":       {"direction": "long"}
+		}}`
+		var p RegimeDirectionalPolicy
+		_ = json.Unmarshal([]byte(raw), &p)
+		errs := p.ResolveRaw("x")
+		found := false
+		for _, e := range errs {
+			if strings.Contains(e, "unknown key") && strings.Contains(e, "size_mult") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected unknown-key error, got: %v", errs)
+		}
+	})
+
+	t.Run("invert_signal defaults to false when omitted", func(t *testing.T) {
+		raw := `{"trend_regime": {
+			"trending_up":   {"direction": "long"},
+			"trending_down": {"direction": "short"},
+			"ranging":       {"direction": "long"}
+		}}`
+		var p RegimeDirectionalPolicy
+		_ = json.Unmarshal([]byte(raw), &p)
+		errs := p.ResolveRaw("x")
+		if len(errs) != 0 {
+			t.Fatalf("unexpected errs: %v", errs)
+		}
+		if p.TrendRegime["trending_down"].InvertSignal {
+			t.Fatalf("expected invert default false")
+		}
+	})
+}
+
+func TestRegimeDirectionalPolicyEqualForReload(t *testing.T) {
+	makePolicy := func(downDir string, downInvert bool) *RegimeDirectionalPolicy {
+		return &RegimeDirectionalPolicy{TrendRegime: map[string]RegimeDirectionalEntry{
+			"trending_up":   {Direction: "long", InvertSignal: false},
+			"trending_down": {Direction: downDir, InvertSignal: downInvert},
+			"ranging":       {Direction: "long", InvertSignal: false},
+		}}
+	}
+	a := makePolicy("short", true)
+	b := makePolicy("short", true)
+	if !a.EqualForReload(b) {
+		t.Fatalf("identical policies should be equal")
+	}
+	c := makePolicy("short", false)
+	if a.EqualForReload(c) {
+		t.Fatalf("invert change should not be equal")
+	}
+	d := makePolicy("long", true)
+	if a.EqualForReload(d) {
+		t.Fatalf("direction change should not be equal")
+	}
+	var nilP *RegimeDirectionalPolicy
+	if !nilP.EqualForReload(nil) {
+		t.Fatalf("nil/nil should be equal")
+	}
+	if a.EqualForReload(nil) {
+		t.Fatalf("nil and configured should not be equal")
+	}
+}
+
+// TestApplyRegimeDirectionalPolicy covers the resolver semantics:
+// flat -> current regime, open -> pos.Regime (hold semantics),
+// no policy -> no-op.
+func TestApplyRegimeDirectionalPolicy(t *testing.T) {
+	makePolicy := func() *RegimeDirectionalPolicy {
+		return &RegimeDirectionalPolicy{TrendRegime: map[string]RegimeDirectionalEntry{
+			"trending_up":   {Direction: "long", InvertSignal: false},
+			"trending_down": {Direction: "short", InvertSignal: true},
+			"ranging":       {Direction: "long", InvertSignal: false},
+		}}
+	}
+
+	t.Run("flat uses current regime", func(t *testing.T) {
+		sc := StrategyConfig{Direction: "long", InvertSignal: false, RegimeDirectionalPolicy: makePolicy()}
+		entry, applied := applyRegimeDirectionalPolicy(&sc, "trending_down", "", 0)
+		if !applied {
+			t.Fatalf("expected applied")
+		}
+		if entry.Direction != "short" || !entry.InvertSignal {
+			t.Fatalf("bad entry: %+v", entry)
+		}
+		if sc.Direction != "short" || !sc.InvertSignal {
+			t.Fatalf("sc not mutated: dir=%q invert=%t", sc.Direction, sc.InvertSignal)
+		}
+	})
+
+	t.Run("open position uses pos.Regime (hold)", func(t *testing.T) {
+		sc := StrategyConfig{Direction: "long", InvertSignal: false, RegimeDirectionalPolicy: makePolicy()}
+		// pos opened under trending_down, current regime flipped to trending_up
+		entry, applied := applyRegimeDirectionalPolicy(&sc, "trending_up", "trending_down", 0.001)
+		if !applied {
+			t.Fatalf("expected applied")
+		}
+		// Should resolve from pos.Regime -> short policy continues
+		if entry.Direction != "short" || !entry.InvertSignal {
+			t.Fatalf("expected hold under prior policy, got: %+v", entry)
+		}
+		if sc.Direction != "short" {
+			t.Fatalf("sc.Direction not held: %q", sc.Direction)
+		}
+	})
+
+	t.Run("flat after pos closed picks new regime", func(t *testing.T) {
+		sc := StrategyConfig{Direction: "long", InvertSignal: false, RegimeDirectionalPolicy: makePolicy()}
+		// Position closed (qty=0); current regime is trending_up
+		entry, applied := applyRegimeDirectionalPolicy(&sc, "trending_up", "trending_down", 0)
+		if !applied {
+			t.Fatalf("expected applied")
+		}
+		if entry.Direction != "long" || entry.InvertSignal {
+			t.Fatalf("expected long+no-invert after flat under trending_up, got: %+v", entry)
+		}
+	})
+
+	t.Run("no policy is no-op", func(t *testing.T) {
+		sc := StrategyConfig{Direction: "long", InvertSignal: false}
+		_, applied := applyRegimeDirectionalPolicy(&sc, "trending_down", "", 0)
+		if applied {
+			t.Fatalf("expected no-op when policy nil")
+		}
+		if sc.Direction != "long" || sc.InvertSignal {
+			t.Fatalf("sc mutated unexpectedly: dir=%q invert=%t", sc.Direction, sc.InvertSignal)
+		}
+	})
+
+	t.Run("unknown regime is no-op", func(t *testing.T) {
+		sc := StrategyConfig{Direction: "long", InvertSignal: false, RegimeDirectionalPolicy: makePolicy()}
+		_, applied := applyRegimeDirectionalPolicy(&sc, "", "", 0)
+		if applied {
+			t.Fatalf("empty regime should not resolve")
+		}
+		if sc.Direction != "long" {
+			t.Fatalf("sc mutated under empty regime: %q", sc.Direction)
+		}
+	})
+
+	t.Run("legacy position without pos.Regime falls back to current", func(t *testing.T) {
+		sc := StrategyConfig{Direction: "long", InvertSignal: false, RegimeDirectionalPolicy: makePolicy()}
+		entry, applied := applyRegimeDirectionalPolicy(&sc, "trending_up", "", 0.5)
+		if !applied {
+			t.Fatalf("expected applied")
+		}
+		if entry.Direction != "long" {
+			t.Fatalf("expected fallback to current trending_up -> long, got: %+v", entry)
+		}
+	})
+}
+
+// TestValidateConfigRegimeDirectionalPolicy covers config-level validation:
+// HL perps only, requires regime.enabled, valid shape.
+func TestValidateConfigRegimeDirectionalPolicy(t *testing.T) {
+	makePolicyJSON := `{"trend_regime": {
+		"trending_up":   {"direction": "long",  "invert_signal": false},
+		"trending_down": {"direction": "short", "invert_signal": true},
+		"ranging":       {"direction": "long",  "invert_signal": false}
+	}}`
+	unmarshal := func() *RegimeDirectionalPolicy {
+		var p RegimeDirectionalPolicy
+		if err := json.Unmarshal([]byte(makePolicyJSON), &p); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return &p
+	}
+
+	t.Run("accepts HL perps with regime enabled", func(t *testing.T) {
+		cfg := Config{
+			Strategies: []StrategyConfig{{
+				ID:                      "hl-test-btc",
+				Type:                    "perps",
+				Platform:                "hyperliquid",
+				Script:                  "shared_scripts/check_hyperliquid.py",
+				Args:                    []string{"sma_crossover", "BTC", "1h", "--mode=paper"},
+				Capital:                 1000,
+				Leverage:                5,
+				MaxDrawdownPct:          60,
+				Direction:               "long",
+				RegimeDirectionalPolicy: unmarshal(),
+			}},
+			Regime:        &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20},
+			PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+		}
+		if err := ValidateConfig(&cfg); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("rejects when regime detection disabled", func(t *testing.T) {
+		cfg := Config{
+			Strategies: []StrategyConfig{{
+				ID:                      "hl-test-btc",
+				Type:                    "perps",
+				Platform:                "hyperliquid",
+				Script:                  "shared_scripts/check_hyperliquid.py",
+				Args:                    []string{"sma_crossover", "BTC", "1h", "--mode=paper"},
+				Capital:                 1000,
+				Leverage:                5,
+				MaxDrawdownPct:          60,
+				Direction:               "long",
+				RegimeDirectionalPolicy: unmarshal(),
+			}},
+			Regime:        &RegimeConfig{Enabled: false},
+			PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+		}
+		err := ValidateConfig(&cfg)
+		if err == nil || !strings.Contains(err.Error(), "regime_directional_policy requires top-level regime.enabled=true") {
+			t.Fatalf("expected regime-enabled error, got: %v", err)
+		}
+	})
+
+	t.Run("rejects on non-HL platform", func(t *testing.T) {
+		cfg := Config{
+			Strategies: []StrategyConfig{{
+				ID:                      "okx-test-btc",
+				Type:                    "perps",
+				Platform:                "okx",
+				Script:                  "shared_scripts/check_okx.py",
+				Args:                    []string{"sma_crossover", "BTC-USDT-SWAP", "1h"},
+				Capital:                 1000,
+				Leverage:                5,
+				MaxDrawdownPct:          60,
+				Direction:               "long",
+				RegimeDirectionalPolicy: unmarshal(),
+			}},
+			Regime:        &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20},
+			PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+		}
+		err := ValidateConfig(&cfg)
+		if err == nil || !strings.Contains(err.Error(), "regime_directional_policy is only supported for HL perps") {
+			t.Fatalf("expected HL-perps-only error, got: %v", err)
+		}
+	})
+
+	t.Run("hot reload blocks shape change while open", func(t *testing.T) {
+		old := StrategyConfig{
+			ID:       "hl-test-btc",
+			Type:     "perps",
+			Platform: "hyperliquid",
+			RegimeDirectionalPolicy: &RegimeDirectionalPolicy{TrendRegime: map[string]RegimeDirectionalEntry{
+				"trending_up":   {Direction: "long", InvertSignal: false},
+				"trending_down": {Direction: "short", InvertSignal: true},
+				"ranging":       {Direction: "long", InvertSignal: false},
+			}},
+		}
+		ns := old
+		ns.RegimeDirectionalPolicy = &RegimeDirectionalPolicy{TrendRegime: map[string]RegimeDirectionalEntry{
+			"trending_up":   {Direction: "long", InvertSignal: false},
+			"trending_down": {Direction: "both", InvertSignal: false}, // shape change
+			"ranging":       {Direction: "long", InvertSignal: false},
+		}}
+		openState := &AppState{
+			Strategies: map[string]*StrategyState{
+				"hl-test-btc": {ID: "hl-test-btc", Positions: map[string]*Position{
+					"BTC": {Symbol: "BTC", Quantity: 0.001, AvgCost: 60000, Side: "short", Regime: "trending_down"},
+				}},
+			},
+		}
+		flatState := &AppState{
+			Strategies: map[string]*StrategyState{
+				"hl-test-btc": {ID: "hl-test-btc", Positions: map[string]*Position{}},
+			},
+		}
+		err := validateHotReloadStateCompatible(&Config{Strategies: []StrategyConfig{old}}, &Config{Strategies: []StrategyConfig{ns}}, openState)
+		if err == nil || !strings.Contains(err.Error(), "regime_directional_policy shape changed with open positions") {
+			t.Fatalf("expected shape-change rejection while open, got: %v", err)
+		}
+		if err := validateHotReloadStateCompatible(&Config{Strategies: []StrategyConfig{old}}, &Config{Strategies: []StrategyConfig{ns}}, flatState); err != nil {
+			t.Fatalf("flat hot reload should be accepted, got: %v", err)
+		}
+	})
+
+	t.Run("hot reload blocks add/remove while open", func(t *testing.T) {
+		old := StrategyConfig{
+			ID:       "hl-test-btc",
+			Type:     "perps",
+			Platform: "hyperliquid",
+		}
+		ns := old
+		ns.RegimeDirectionalPolicy = &RegimeDirectionalPolicy{TrendRegime: map[string]RegimeDirectionalEntry{
+			"trending_up":   {Direction: "long", InvertSignal: false},
+			"trending_down": {Direction: "short", InvertSignal: true},
+			"ranging":       {Direction: "long", InvertSignal: false},
+		}}
+		openState := &AppState{
+			Strategies: map[string]*StrategyState{
+				"hl-test-btc": {ID: "hl-test-btc", Positions: map[string]*Position{
+					"BTC": {Symbol: "BTC", Quantity: 0.001, AvgCost: 60000, Side: "short", Regime: "trending_down"},
+				}},
+			},
+		}
+		err := validateHotReloadStateCompatible(&Config{Strategies: []StrategyConfig{old}}, &Config{Strategies: []StrategyConfig{ns}}, openState)
+		if err == nil || !strings.Contains(err.Error(), "regime_directional_policy mode changed with open positions") {
+			t.Fatalf("expected mode-change rejection while open, got: %v", err)
+		}
+	})
+
+	t.Run("rejects on HL manual type", func(t *testing.T) {
+		cfg := Config{
+			Strategies: []StrategyConfig{{
+				ID:                      "hl-manual-btc",
+				Type:                    "manual",
+				Platform:                "hyperliquid",
+				Symbol:                  "BTC",
+				Timeframe:               "1h",
+				Leverage:                5,
+				Capital:                 1000,
+				MaxDrawdownPct:          60,
+				Direction:               "long",
+				RegimeDirectionalPolicy: unmarshal(),
+			}},
+			Regime:        &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20},
+			PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+		}
+		err := ValidateConfig(&cfg)
+		if err == nil || !strings.Contains(err.Error(), "regime_directional_policy is only supported for HL perps") {
+			t.Fatalf("expected HL-perps-only error, got: %v", err)
+		}
+	})
+}

--- a/scheduler/regime_directional_policy_test.go
+++ b/scheduler/regime_directional_policy_test.go
@@ -101,6 +101,14 @@ func TestRegimeDirectionalPolicyResolveRaw(t *testing.T) {
 		if !found {
 			t.Fatalf("expected invalid-direction error, got: %v", errs)
 		}
+		// A present-but-invalid label must NOT also surface as
+		// "missing required regime labels: trending_up" — the operator
+		// should see one error per typo, not two.
+		for _, e := range errs {
+			if strings.Contains(e, "missing required regime labels") {
+				t.Fatalf("invalid-direction must not double-report as missing: %v", errs)
+			}
+		}
 	})
 
 	t.Run("rejects unknown entry key", func(t *testing.T) {
@@ -185,9 +193,12 @@ func TestApplyRegimeDirectionalPolicy(t *testing.T) {
 
 	t.Run("flat uses current regime", func(t *testing.T) {
 		sc := StrategyConfig{Direction: "long", InvertSignal: false, RegimeDirectionalPolicy: makePolicy()}
-		entry, applied := applyRegimeDirectionalPolicy(&sc, "trending_down", "", 0)
+		entry, applied, legacy := applyRegimeDirectionalPolicy(&sc, "trending_down", "", 0)
 		if !applied {
 			t.Fatalf("expected applied")
+		}
+		if legacy {
+			t.Fatalf("flat state should not flag legacy fallback")
 		}
 		if entry.Direction != "short" || !entry.InvertSignal {
 			t.Fatalf("bad entry: %+v", entry)
@@ -200,9 +211,12 @@ func TestApplyRegimeDirectionalPolicy(t *testing.T) {
 	t.Run("open position uses pos.Regime (hold)", func(t *testing.T) {
 		sc := StrategyConfig{Direction: "long", InvertSignal: false, RegimeDirectionalPolicy: makePolicy()}
 		// pos opened under trending_down, current regime flipped to trending_up
-		entry, applied := applyRegimeDirectionalPolicy(&sc, "trending_up", "trending_down", 0.001)
+		entry, applied, legacy := applyRegimeDirectionalPolicy(&sc, "trending_up", "trending_down", 0.001)
 		if !applied {
 			t.Fatalf("expected applied")
+		}
+		if legacy {
+			t.Fatalf("posRegime set; should not flag legacy fallback")
 		}
 		// Should resolve from pos.Regime -> short policy continues
 		if entry.Direction != "short" || !entry.InvertSignal {
@@ -216,9 +230,12 @@ func TestApplyRegimeDirectionalPolicy(t *testing.T) {
 	t.Run("flat after pos closed picks new regime", func(t *testing.T) {
 		sc := StrategyConfig{Direction: "long", InvertSignal: false, RegimeDirectionalPolicy: makePolicy()}
 		// Position closed (qty=0); current regime is trending_up
-		entry, applied := applyRegimeDirectionalPolicy(&sc, "trending_up", "trending_down", 0)
+		entry, applied, legacy := applyRegimeDirectionalPolicy(&sc, "trending_up", "trending_down", 0)
 		if !applied {
 			t.Fatalf("expected applied")
+		}
+		if legacy {
+			t.Fatalf("flat state should not flag legacy fallback")
 		}
 		if entry.Direction != "long" || entry.InvertSignal {
 			t.Fatalf("expected long+no-invert after flat under trending_up, got: %+v", entry)
@@ -227,7 +244,7 @@ func TestApplyRegimeDirectionalPolicy(t *testing.T) {
 
 	t.Run("no policy is no-op", func(t *testing.T) {
 		sc := StrategyConfig{Direction: "long", InvertSignal: false}
-		_, applied := applyRegimeDirectionalPolicy(&sc, "trending_down", "", 0)
+		_, applied, _ := applyRegimeDirectionalPolicy(&sc, "trending_down", "", 0)
 		if applied {
 			t.Fatalf("expected no-op when policy nil")
 		}
@@ -238,7 +255,7 @@ func TestApplyRegimeDirectionalPolicy(t *testing.T) {
 
 	t.Run("unknown regime is no-op", func(t *testing.T) {
 		sc := StrategyConfig{Direction: "long", InvertSignal: false, RegimeDirectionalPolicy: makePolicy()}
-		_, applied := applyRegimeDirectionalPolicy(&sc, "", "", 0)
+		_, applied, _ := applyRegimeDirectionalPolicy(&sc, "", "", 0)
 		if applied {
 			t.Fatalf("empty regime should not resolve")
 		}
@@ -249,9 +266,12 @@ func TestApplyRegimeDirectionalPolicy(t *testing.T) {
 
 	t.Run("legacy position without pos.Regime falls back to current", func(t *testing.T) {
 		sc := StrategyConfig{Direction: "long", InvertSignal: false, RegimeDirectionalPolicy: makePolicy()}
-		entry, applied := applyRegimeDirectionalPolicy(&sc, "trending_up", "", 0.5)
+		entry, applied, legacy := applyRegimeDirectionalPolicy(&sc, "trending_up", "", 0.5)
 		if !applied {
 			t.Fatalf("expected applied")
+		}
+		if !legacy {
+			t.Fatalf("open position with empty posRegime should flag legacy fallback")
 		}
 		if entry.Direction != "long" {
 			t.Fatalf("expected fallback to current trending_up -> long, got: %+v", entry)

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -325,18 +325,24 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 	defer ss.mu.RUnlock()
 
 	type StratStatus struct {
-		ID              string                     `json:"id"`
-		Type            string                     `json:"type"`
-		Cash            float64                    `json:"cash"`
-		InitialCapital  float64                    `json:"initial_capital"`
-		Positions       map[string]*Position       `json:"positions"`
-		OptionPositions map[string]*OptionPosition `json:"option_positions"`
-		TradeCount      int                        `json:"trade_count"`
-		PortfolioValue  float64                    `json:"portfolio_value"`
-		PnL             float64                    `json:"pnl"`
-		PnLPct          float64                    `json:"pnl_pct"`
-		RiskState       RiskState                  `json:"risk_state"`
-		Regime          string                     `json:"regime,omitempty"`
+		ID                      string                     `json:"id"`
+		Type                    string                     `json:"type"`
+		Cash                    float64                    `json:"cash"`
+		InitialCapital          float64                    `json:"initial_capital"`
+		Positions               map[string]*Position       `json:"positions"`
+		OptionPositions         map[string]*OptionPosition `json:"option_positions"`
+		TradeCount              int                        `json:"trade_count"`
+		PortfolioValue          float64                    `json:"portfolio_value"`
+		PnL                     float64                    `json:"pnl"`
+		PnLPct                  float64                    `json:"pnl_pct"`
+		RiskState               RiskState                  `json:"risk_state"`
+		Regime                  string                     `json:"regime,omitempty"`
+		Direction               string                     `json:"direction,omitempty"`                 // #779: base direction from config
+		InvertSignal            bool                       `json:"invert_signal,omitempty"`             // #779: base invert from config
+		EffectiveDirection      string                     `json:"effective_direction,omitempty"`       // #779: resolved direction for the active regime (policy override or base)
+		EffectiveInvertSignal   bool                       `json:"effective_invert_signal,omitempty"`   // #779: resolved invert for the active regime
+		RegimeDirectionalPolicy bool                       `json:"regime_directional_policy,omitempty"` // #779: true when strategy has a policy block configured
+		EffectivePolicyRegime   string                     `json:"effective_policy_regime,omitempty"`   // #779: regime key the resolver used (pos.Regime while open, current regime when flat); shown only when policy is configured
 	}
 
 	type StatusResp struct {
@@ -385,19 +391,50 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 		if initCap > 0 {
 			pnlPct = (pnl / initCap) * 100
 		}
+		// #779: surface base + effective directional policy so operators can
+		// verify why the bot is in long vs. short mode. Effective values are
+		// what the next signal will be evaluated under — pulled by replaying
+		// the resolver against the strategy's first open position (or flat).
+		effDir := EffectiveDirection(sc)
+		effInvert := sc.InvertSignal
+		var effRegimeKey string
+		policyConfigured := sc.RegimeDirectionalPolicy.IsConfigured()
+		if policyConfigured && !sc.RegimeDirectionalPolicy.IsZero() {
+			posQty := 0.0
+			posRegime := ""
+			for _, p := range s.Positions {
+				if p != nil && p.Quantity > 0 {
+					posQty = p.Quantity
+					posRegime = p.Regime
+					break
+				}
+			}
+			effRegimeKey = effectiveRegimeForPolicy(s.Regime, posRegime, posQty)
+			if entry, ok := sc.RegimeDirectionalPolicy.Resolve(effRegimeKey); ok {
+				effDir = entry.Direction
+				effInvert = entry.InvertSignal
+			}
+		}
+
 		resp.Strategies[id] = StratStatus{
-			ID:              s.ID,
-			Type:            s.Type,
-			Cash:            s.Cash,
-			InitialCapital:  initCap,
-			Positions:       s.Positions,
-			OptionPositions: s.OptionPositions,
-			TradeCount:      len(s.TradeHistory),
-			PortfolioValue:  pv,
-			PnL:             pnl,
-			PnLPct:          pnlPct,
-			RiskState:       s.RiskState,
-			Regime:          s.Regime,
+			ID:                      s.ID,
+			Type:                    s.Type,
+			Cash:                    s.Cash,
+			InitialCapital:          initCap,
+			Positions:               s.Positions,
+			OptionPositions:         s.OptionPositions,
+			TradeCount:              len(s.TradeHistory),
+			PortfolioValue:          pv,
+			PnL:                     pnl,
+			PnLPct:                  pnlPct,
+			RiskState:               s.RiskState,
+			Regime:                  s.Regime,
+			Direction:               EffectiveDirection(sc),
+			InvertSignal:            sc.InvertSignal,
+			EffectiveDirection:      effDir,
+			EffectiveInvertSignal:   effInvert,
+			RegimeDirectionalPolicy: policyConfigured,
+			EffectivePolicyRegime:   effRegimeKey,
 		}
 	}
 

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -337,8 +337,8 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 		PnLPct                  float64                    `json:"pnl_pct"`
 		RiskState               RiskState                  `json:"risk_state"`
 		Regime                  string                     `json:"regime,omitempty"`
-		Direction               string                     `json:"direction,omitempty"`                 // #779: base direction from config
-		InvertSignal            bool                       `json:"invert_signal,omitempty"`             // #779: base invert from config
+		BaseDirection           string                     `json:"base_direction,omitempty"`            // #779: base direction from config (pre-policy resolution)
+		BaseInvertSignal        bool                       `json:"base_invert_signal,omitempty"`        // #779: base invert from config (pre-policy resolution)
 		EffectiveDirection      string                     `json:"effective_direction,omitempty"`       // #779: resolved direction for the active regime (policy override or base)
 		EffectiveInvertSignal   bool                       `json:"effective_invert_signal,omitempty"`   // #779: resolved invert for the active regime
 		RegimeDirectionalPolicy bool                       `json:"regime_directional_policy,omitempty"` // #779: true when strategy has a policy block configured
@@ -395,11 +395,13 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 		// verify why the bot is in long vs. short mode. Effective values are
 		// what the next signal will be evaluated under — pulled by replaying
 		// the resolver against the strategy's first open position (or flat).
-		effDir := EffectiveDirection(sc)
-		effInvert := sc.InvertSignal
+		baseDir := EffectiveDirection(sc)
+		baseInvert := sc.InvertSignal
+		effDir := baseDir
+		effInvert := baseInvert
 		var effRegimeKey string
 		policyConfigured := sc.RegimeDirectionalPolicy.IsConfigured()
-		if policyConfigured && !sc.RegimeDirectionalPolicy.IsZero() {
+		if policyConfigured {
 			posQty := 0.0
 			posRegime := ""
 			for _, p := range s.Positions {
@@ -429,8 +431,8 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 			PnLPct:                  pnlPct,
 			RiskState:               s.RiskState,
 			Regime:                  s.Regime,
-			Direction:               EffectiveDirection(sc),
-			InvertSignal:            sc.InvertSignal,
+			BaseDirection:           baseDir,
+			BaseInvertSignal:        baseInvert,
 			EffectiveDirection:      effDir,
 			EffectiveInvertSignal:   effInvert,
 			RegimeDirectionalPolicy: policyConfigured,


### PR DESCRIPTION
## Summary

Adds `regime_directional_policy` per-strategy — a per-regime override for `Direction` + `InvertSignal` so a single HL perps strategy can run inverse short in `trending_down` and plain long otherwise, switching deterministically as regime changes instead of needing operator hot-edits.

Closes #779.

## Design

**Runtime override layer**, not config rewrite. Persisted config is operator-authored; the policy resolves the *effective* `(Direction, InvertSignal)` pair at signal time. This preserves the existing operator-authored config model and the `validateHotReloadStateCompatible` open-position guards (`config_reload.go:334`).

**Shape:**

```json
\"regime_directional_policy\": {
  \"trend_regime\": {
    \"trending_down\": { \"direction\": \"short\", \"invert_signal\": true },
    \"trending_up\":   { \"direction\": \"long\",  \"invert_signal\": false },
    \"ranging\":       { \"direction\": \"long\",  \"invert_signal\": false }
  }
}
```

**Hold semantics (transition rule):** when a position is open, the resolver uses `pos.Regime` (the regime stamped at open) — *not* the current regime. The position runs to its natural exit via existing SL / TP / close-evaluator paths under the policy that opened it. Once flat, the next entry uses the current regime's policy. No forced flatten, no operator-required transition state.

**Wired in `runHyperliquidCheck`** after `result.Regime` is known and **before** `applySignalInversion`, so the invert decision uses the effective `InvertSignal`. The function signature changes from `sc StrategyConfig` to `sc *StrategyConfig` so the mutation propagates to downstream `EffectiveDirection` / `perpsLiveOrderSize` / `PerpsOrderSkipReason` calls in the same cycle. The mutation is scoped to the loop-local `sc` copy; `cfg.Strategies` is never touched.

## Validation + reload

- **HL perps only** (mirrors `invert_signal`'s surface — both override the same Go-layer signal that only HL consumes numerically).
- **Requires top-level `regime.enabled=true`** — without regime detection, `result.Regime` is empty, the resolver always no-ops, and the policy silently defeats. Reject at startup so the asymmetric config never ships.
- **All canonical regime labels required** (`trending_up`, `trending_down`, `ranging`) so there's never an undefined runtime fallback.
- **Unknown keys / unknown labels / invalid direction values rejected** at config-load time.
- **Hot reload:** shape change while open → REJECTED (state-compat parity with `stop_loss_atr_regime` in `regime_atr.go`); change when flat → hot-applies on next cycle.
- **invert_signal added to `strategyRestartShape`** (existing #775 oversight, surfaced here): a pure invert toggle no longer trips the immutable-fields DeepEqual gate.

## /status surfacing

Per-strategy now exposes:
- `direction` / `invert_signal` — base config values
- `effective_direction` / `effective_invert_signal` — resolved for the active regime
- `regime_directional_policy` (bool) — whether the strategy has a policy block
- `effective_policy_regime` — the regime key the resolver used (`pos.Regime` while open, current regime when flat)

So operators can answer \"why is the bot in long/short mode\" without grepping logs.

## Test plan

- [x] `go build` (with `-ldflags Version`)
- [x] `go test ./...` — 24.4s, all pass including 3 new test groups (16 subtests):
  - `TestRegimeDirectionalPolicyResolveRaw` — parsing + validation (canonical labels, valid direction enum, wrapper key, unknown keys, invert default)
  - `TestRegimeDirectionalPolicyEqualForReload` — reload-equality semantics
  - `TestApplyRegimeDirectionalPolicy` — resolver: flat→current, open→pos.Regime hold, post-close fresh, no-policy no-op, unknown-regime no-op, legacy-position fallback
  - `TestValidateConfigRegimeDirectionalPolicy` — HL-perps-only, requires regime.enabled, hot-reload shape + add/remove blocked while open
- [x] `pytest shared_strategies/ shared_tools/ platforms/ backtest/` — 1044 passed
- [x] `gofmt -w` on touched files
- [ ] Operator: enable on `hl-hae-btc-1h` / `hl-vwap-btc-1h` (note: existing 0.001 BTC short on `hl-vwap-btc-1h` will run under the policy that opened it until natural exit)

---
LLM: Claude Opus 4.7 (1M) | high | Harness: Claude Code
