### PR TITLE
fix(scheduler): validate perps direction via regime policy (#783)

### DIFF
--- a/scheduler/inspect_cmd.go
+++ b/scheduler/inspect_cmd.go
@@ -689,8 +689,16 @@ func stableParamSummary(params map[string]interface{}) string {
 
 func appendDirectionInspectLines(b *strings.Builder, sc StrategyConfig, explicit map[string]bool, state *AppState) {
 	baseDir := EffectiveDirection(sc)
-	fmt.Fprintf(b, "  base_direction:      %s (%s)\n", baseDir, directionProvenance(sc, explicit))
-	if sc.RegimeDirectionalPolicy != nil && sc.RegimeDirectionalPolicy.IsConfigured() {
+	prov := directionProvenance(sc, explicit)
+	policyConfigured := sc.RegimeDirectionalPolicy != nil && sc.RegimeDirectionalPolicy.IsConfigured()
+	if policyConfigured {
+		// Policy present: distinguish static base from per-regime overrides.
+		fmt.Fprintf(b, "  base_direction:      %s (%s)\n", baseDir, prov)
+	} else {
+		// No policy: keep legacy "direction:" label for operator scripts (#784).
+		fmt.Fprintf(b, "  direction:           %s (%s)\n", baseDir, prov)
+	}
+	if policyConfigured {
 		fmt.Fprintf(b, "  regime_directional_policy:\n")
 		for _, label := range canonicalTrendRegimeLabels {
 			dir := EffectiveDirectionForRegime(sc, label)

--- a/scheduler/inspect_cmd.go
+++ b/scheduler/inspect_cmd.go
@@ -95,11 +95,13 @@ func loadInspectState(cfg *Config) *AppState {
 	}
 	sdb, err := OpenStateDB(cfg.DBFile)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "[inspect] state DB unavailable: %v\n", err)
 		return nil
 	}
 	defer sdb.Close()
 	state, err := sdb.LoadState()
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "[inspect] state DB unavailable: %v\n", err)
 		return nil
 	}
 	if state == nil {
@@ -704,10 +706,16 @@ func appendDirectionInspectLines(b *strings.Builder, sc StrategyConfig, explicit
 		stratState = state.Strategies[sc.ID]
 	}
 	if stratState != nil {
+		syms := make([]string, 0, len(stratState.Positions))
 		for sym, pos := range stratState.Positions {
 			if pos == nil || pos.Quantity <= 0 {
 				continue
 			}
+			syms = append(syms, sym)
+		}
+		sort.Strings(syms)
+		for _, sym := range syms {
+			pos := stratState.Positions[sym]
 			effRegime := effectiveRegimeForPolicy(stratState.Regime, pos.Regime, pos.Quantity)
 			effDir := EffectiveDirectionForPosition(sc, stratState.Regime, pos.Regime, pos.Quantity)
 			regimeSrc := "stamped at open"
@@ -721,7 +729,8 @@ func appendDirectionInspectLines(b *strings.Builder, sc StrategyConfig, explicit
 
 func directionInspectJSON(sc StrategyConfig, state *AppState) map[string]interface{} {
 	out := map[string]interface{}{
-		"direction":      EffectiveDirection(sc), // legacy key: base direction
+		// "direction" is the legacy alias; prefer "base_direction" for new consumers.
+		"direction":      EffectiveDirection(sc),
 		"base_direction": EffectiveDirection(sc),
 	}
 	if sc.RegimeDirectionalPolicy != nil && sc.RegimeDirectionalPolicy.IsConfigured() {

--- a/scheduler/inspect_cmd.go
+++ b/scheduler/inspect_cmd.go
@@ -59,10 +59,12 @@ func runInspect(args []string) int {
 		}
 	}
 
+	inspectState := loadInspectState(cfg)
+
 	if *jsonOut {
 		out := make([]map[string]interface{}, 0, len(targets))
 		for _, sc := range targets {
-			out = append(out, buildStrategyInspectionJSON(sc, explicit[sc.ID], cfg))
+			out = append(out, buildStrategyInspectionJSON(sc, explicit[sc.ID], cfg, inspectState))
 		}
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
@@ -77,9 +79,33 @@ func runInspect(args []string) int {
 		if i > 0 {
 			fmt.Println()
 		}
-		fmt.Print(formatStrategyInspection(sc, explicit[sc.ID], cfg))
+		fmt.Print(formatStrategyInspection(sc, explicit[sc.ID], cfg, inspectState))
 	}
 	return 0
+}
+
+// loadInspectState best-effort loads persisted state so inspect can show
+// position-aware effective direction (#783). Missing or unreadable DB is fine.
+func loadInspectState(cfg *Config) *AppState {
+	if cfg == nil || cfg.DBFile == "" {
+		return nil
+	}
+	if _, err := os.Stat(cfg.DBFile); err != nil {
+		return nil
+	}
+	sdb, err := OpenStateDB(cfg.DBFile)
+	if err != nil {
+		return nil
+	}
+	defer sdb.Close()
+	state, err := sdb.LoadState()
+	if err != nil {
+		return nil
+	}
+	if state == nil {
+		return NewAppState()
+	}
+	return state
 }
 
 // loadStrategyExplicitKeys re-reads the raw config bytes and records which
@@ -393,7 +419,7 @@ func inspectRegimeTPTierProvenance(block RegimeATRBlock, closeExplicitTag string
 // for one strategy. Splitting from runInspect lets tests assert the formatter
 // independently of os.Args / file IO, and lets the startup logger reuse the
 // one-line summary helper below.
-func formatStrategyInspection(sc StrategyConfig, explicit map[string]bool, cfg *Config) string {
+func formatStrategyInspection(sc StrategyConfig, explicit map[string]bool, cfg *Config, state *AppState) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "strategy %s\n", sc.ID)
 	fmt.Fprintf(&b, "  type:                %s\n", sc.Type)
@@ -422,7 +448,7 @@ func formatStrategyInspection(sc StrategyConfig, explicit map[string]bool, cfg *
 	}
 
 	if sc.Type == "perps" || sc.Type == "manual" {
-		fmt.Fprintf(&b, "  direction:           %s (%s)\n", EffectiveDirection(sc), directionProvenance(sc, explicit))
+		appendDirectionInspectLines(&b, sc, explicit, state)
 		fmt.Fprintf(&b, "  leverage:            %g%s\n", EffectiveExchangeLeverage(sc), markIfDefault(explicit, "leverage"))
 		fmt.Fprintf(&b, "  sizing_leverage:     %g%s\n", EffectiveSizingLeverage(sc), sizingLeverageProvenance(sc, explicit))
 		if m := EffectiveMarginPerTradeUSD(sc); m > 0 {
@@ -516,7 +542,7 @@ func formatStrategySummaryLine(sc StrategyConfig, explicit map[string]bool) stri
 // buildStrategyInspectionJSON mirrors formatStrategyInspection in
 // machine-readable form. Keeps the same provenance info so external tools
 // (dashboards, audit scripts) can spot "field is at the default" cases.
-func buildStrategyInspectionJSON(sc StrategyConfig, explicit map[string]bool, cfg *Config) map[string]interface{} {
+func buildStrategyInspectionJSON(sc StrategyConfig, explicit map[string]bool, cfg *Config, state *AppState) map[string]interface{} {
 	if explicit == nil {
 		explicit = map[string]bool{}
 	}
@@ -542,7 +568,9 @@ func buildStrategyInspectionJSON(sc StrategyConfig, explicit map[string]bool, cf
 		"max_drawdown_pct_explicit": explicit["max_drawdown_pct"],
 	}
 	if sc.Type == "perps" || sc.Type == "manual" {
-		out["direction"] = EffectiveDirection(sc)
+		for k, v := range directionInspectJSON(sc, state) {
+			out[k] = v
+		}
 		out["leverage"] = EffectiveExchangeLeverage(sc)
 		out["sizing_leverage"] = EffectiveSizingLeverage(sc)
 		out["margin_mode"] = sc.MarginMode
@@ -655,6 +683,87 @@ func stableParamSummary(params map[string]interface{}) string {
 		parts = append(parts, fmt.Sprintf("%s=%v", k, params[k]))
 	}
 	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+func appendDirectionInspectLines(b *strings.Builder, sc StrategyConfig, explicit map[string]bool, state *AppState) {
+	baseDir := EffectiveDirection(sc)
+	fmt.Fprintf(b, "  base_direction:      %s (%s)\n", baseDir, directionProvenance(sc, explicit))
+	if sc.RegimeDirectionalPolicy != nil && sc.RegimeDirectionalPolicy.IsConfigured() {
+		fmt.Fprintf(b, "  regime_directional_policy:\n")
+		for _, label := range canonicalTrendRegimeLabels {
+			dir := EffectiveDirectionForRegime(sc, label)
+			inv := false
+			if entry, ok := sc.RegimeDirectionalPolicy.Resolve(label); ok {
+				inv = entry.InvertSignal
+			}
+			fmt.Fprintf(b, "    %s: direction=%s invert_signal=%v\n", label, dir, inv)
+		}
+	}
+	var stratState *StrategyState
+	if state != nil {
+		stratState = state.Strategies[sc.ID]
+	}
+	if stratState != nil {
+		for sym, pos := range stratState.Positions {
+			if pos == nil || pos.Quantity <= 0 {
+				continue
+			}
+			effRegime := effectiveRegimeForPolicy(stratState.Regime, pos.Regime, pos.Quantity)
+			effDir := EffectiveDirectionForPosition(sc, stratState.Regime, pos.Regime, pos.Quantity)
+			regimeSrc := "stamped at open"
+			if strings.TrimSpace(pos.Regime) == "" {
+				regimeSrc = "current cycle (position regime unknown)"
+			}
+			fmt.Fprintf(b, "  position %s:         side=%s effective_direction=%s (regime=%s, %s)\n", sym, pos.Side, effDir, effRegime, regimeSrc)
+		}
+	}
+}
+
+func directionInspectJSON(sc StrategyConfig, state *AppState) map[string]interface{} {
+	out := map[string]interface{}{
+		"direction":      EffectiveDirection(sc), // legacy key: base direction
+		"base_direction": EffectiveDirection(sc),
+	}
+	if sc.RegimeDirectionalPolicy != nil && sc.RegimeDirectionalPolicy.IsConfigured() {
+		byRegime := make(map[string]interface{}, len(canonicalTrendRegimeLabels))
+		for _, label := range canonicalTrendRegimeLabels {
+			entry := map[string]interface{}{
+				"direction": EffectiveDirectionForRegime(sc, label),
+			}
+			if e, ok := sc.RegimeDirectionalPolicy.Resolve(label); ok {
+				entry["invert_signal"] = e.InvertSignal
+			}
+			byRegime[label] = entry
+		}
+		out["regime_directional_policy"] = byRegime
+	}
+	var stratState *StrategyState
+	if state != nil {
+		stratState = state.Strategies[sc.ID]
+	}
+	if stratState != nil {
+		positions := make([]map[string]interface{}, 0)
+		for sym, pos := range stratState.Positions {
+			if pos == nil || pos.Quantity <= 0 {
+				continue
+			}
+			positions = append(positions, map[string]interface{}{
+				"symbol":                  sym,
+				"side":                    pos.Side,
+				"quantity":                pos.Quantity,
+				"regime":                  pos.Regime,
+				"effective_direction":     EffectiveDirectionForPosition(sc, stratState.Regime, pos.Regime, pos.Quantity),
+				"effective_policy_regime": effectiveRegimeForPolicy(stratState.Regime, pos.Regime, pos.Quantity),
+			})
+		}
+		if len(positions) > 0 {
+			sort.Slice(positions, func(i, j int) bool {
+				return positions[i]["symbol"].(string) < positions[j]["symbol"].(string)
+			})
+			out["open_positions"] = positions
+		}
+	}
+	return out
 }
 
 // directionProvenance distinguishes the four ways EffectiveDirection can land

--- a/scheduler/inspect_cmd_test.go
+++ b/scheduler/inspect_cmd_test.go
@@ -180,7 +180,7 @@ func TestFormatStrategyInspectionShowsResolvedTPSource(t *testing.T) {
 		"capital": true, "leverage": true, "sizing_leverage": true,
 		"margin_mode": true, "max_drawdown_pct": true, "stop_loss_atr_mult": true,
 	}
-	out := formatStrategyInspection(sc, explicit, &Config{IntervalSeconds: 600})
+	out := formatStrategyInspection(sc, explicit, &Config{IntervalSeconds: 600}, nil)
 
 	for _, want := range []string{
 		"strategy hl-rmc-eth-live",
@@ -219,7 +219,7 @@ func TestFormatStrategyInspectionMarksDefaultedFields(t *testing.T) {
 	}
 	// Operator only set id/type/platform/script/args/open_strategy.
 	explicit := map[string]bool{"id": true, "type": true, "platform": true, "script": true, "args": true, "open_strategy": true}
-	out := formatStrategyInspection(sc, explicit, &Config{IntervalSeconds: 600})
+	out := formatStrategyInspection(sc, explicit, &Config{IntervalSeconds: 600}, nil)
 
 	if !strings.Contains(out, "stop_loss_atr_mult (default)") {
 		t.Errorf("SL default marker missing.\nfull:\n%s", out)
@@ -292,7 +292,7 @@ func TestBuildStrategyInspectionJSONStableShape(t *testing.T) {
 	}
 	out := buildStrategyInspectionJSON(sc, map[string]bool{
 		"open_strategy": true, "close_strategies": true, "stop_loss_atr_mult": true,
-	}, &Config{IntervalSeconds: 600})
+	}, &Config{IntervalSeconds: 600}, nil)
 
 	bs, err := json.Marshal(out)
 	if err != nil {
@@ -362,7 +362,7 @@ func TestFormatStrategyInspectionRegimeTPUseDefaults(t *testing.T) {
 		"id": true, "type": true, "platform": true, "script": true,
 		"close_strategies": true, "leverage": true, "max_drawdown_pct": true,
 	}
-	out := formatStrategyInspection(sc, explicit, &Config{IntervalSeconds: 60})
+	out := formatStrategyInspection(sc, explicit, &Config{IntervalSeconds: 60}, nil)
 	if !strings.Contains(out, "tiered_tp_atr_regime tier[0]:") {
 		t.Errorf("missing tier[0] provenance line:\n%s", out)
 	}

--- a/scheduler/inspect_cmd_test.go
+++ b/scheduler/inspect_cmd_test.go
@@ -388,3 +388,25 @@ func TestFormatStrategySummaryLineRegimeTPTierCount(t *testing.T) {
 		t.Errorf("expected 2-tier regime TP summary, got: %s", line)
 	}
 }
+
+func TestFormatStrategyInspectionPositionOrderDeterministic(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-multi", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong}
+	state := NewAppState()
+	state.Strategies["hl-multi"] = &StrategyState{
+		ID:   "hl-multi",
+		Type: "perps",
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 1, Side: "long", Multiplier: 1, Leverage: 1},
+			"BTC": {Symbol: "BTC", Quantity: 0.1, Side: "short", Regime: "trending_down", Multiplier: 1, Leverage: 1},
+		},
+	}
+	out := formatStrategyInspection(sc, nil, nil, state)
+	btc := strings.Index(out, "position BTC:")
+	eth := strings.Index(out, "position ETH:")
+	if btc < 0 || eth < 0 {
+		t.Fatalf("missing position lines:\n%s", out)
+	}
+	if btc > eth {
+		t.Errorf("positions should be sorted by symbol (BTC before ETH), got BTC@%d ETH@%d", btc, eth)
+	}
+}

--- a/scheduler/inspect_cmd_test.go
+++ b/scheduler/inspect_cmd_test.go
@@ -389,6 +389,33 @@ func TestFormatStrategySummaryLineRegimeTPTierCount(t *testing.T) {
 	}
 }
 
+func TestFormatStrategyInspectionLegacyDirectionLabel(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-plain", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong}
+	out := formatStrategyInspection(sc, map[string]bool{"direction": true}, nil, nil)
+	if !strings.Contains(out, "  direction:           long") {
+		t.Errorf("strategies without regime_directional_policy should use legacy direction: label:\n%s", out)
+	}
+	if strings.Contains(out, "  base_direction:") {
+		t.Errorf("should not emit base_direction without policy:\n%s", out)
+	}
+}
+
+func TestFormatStrategyInspectionBaseDirectionWithPolicy(t *testing.T) {
+	sc := StrategyConfig{
+		ID: "hl-policy", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong,
+		RegimeDirectionalPolicy: &RegimeDirectionalPolicy{TrendRegime: map[string]RegimeDirectionalEntry{
+			"trending_up": {Direction: DirectionLong}, "trending_down": {Direction: DirectionShort}, "ranging": {Direction: DirectionLong},
+		}},
+	}
+	out := formatStrategyInspection(sc, map[string]bool{"direction": true}, nil, nil)
+	if !strings.Contains(out, "  base_direction:      long") {
+		t.Errorf("policy strategies should use base_direction: label:\n%s", out)
+	}
+	if !strings.Contains(out, "  regime_directional_policy:") {
+		t.Errorf("missing policy table:\n%s", out)
+	}
+}
+
 func TestFormatStrategyInspectionPositionOrderDeterministic(t *testing.T) {
 	sc := StrategyConfig{ID: "hl-multi", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong}
 	state := NewAppState()

--- a/scheduler/regime_directional_policy.go
+++ b/scheduler/regime_directional_policy.go
@@ -336,13 +336,20 @@ func EffectiveDirectionForPosition(sc StrategyConfig, currentRegime, posRegime s
 // policyAllowsPositionSide reports whether posSide is permitted under at least
 // one entry in regime_directional_policy. Used when pos.Regime is empty
 // (legacy / pre-#741) so validation does not false-positive a side that some
-// regime intentionally allows (#783).
+// regime intentionally allows (#783). Iterates resolved TrendRegime entries
+// only — no fallback to base direction for missing labels.
 func policyAllowsPositionSide(sc StrategyConfig, posSide string) bool {
 	if sc.RegimeDirectionalPolicy == nil || sc.RegimeDirectionalPolicy.IsZero() {
 		return false
 	}
-	for _, label := range canonicalTrendRegimeLabels {
-		if !perpsPositionConflictsDirection(posSide, EffectiveDirectionForRegime(sc, label)) {
+	labels := make([]string, 0, len(sc.RegimeDirectionalPolicy.TrendRegime))
+	for label := range sc.RegimeDirectionalPolicy.TrendRegime {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	for _, label := range labels {
+		entry := sc.RegimeDirectionalPolicy.TrendRegime[label]
+		if !perpsPositionConflictsDirection(posSide, entry.Direction) {
 			return true
 		}
 	}

--- a/scheduler/regime_directional_policy.go
+++ b/scheduler/regime_directional_policy.go
@@ -312,3 +312,54 @@ func applyRegimeDirectionalPolicy(sc *StrategyConfig, currentRegime, posRegime s
 	sc.InvertSignal = entry.InvertSignal
 	return entry, true, legacyFallback
 }
+
+// EffectiveDirectionForRegime returns the direction that applies for a single
+// regime label, honoring regime_directional_policy when configured (#783).
+func EffectiveDirectionForRegime(sc StrategyConfig, regime string) string {
+	if sc.RegimeDirectionalPolicy != nil && !sc.RegimeDirectionalPolicy.IsZero() {
+		if entry, ok := sc.RegimeDirectionalPolicy.Resolve(strings.TrimSpace(regime)); ok {
+			return entry.Direction
+		}
+	}
+	return EffectiveDirection(sc)
+}
+
+// EffectiveDirectionForPosition resolves direction for an open position using
+// the same hold-on-transition semantics as applyRegimeDirectionalPolicy: when
+// posQty > 0 and pos.Regime is stamped, that regime governs; otherwise the
+// current cycle regime is used (empty at startup validation → base direction).
+func EffectiveDirectionForPosition(sc StrategyConfig, currentRegime, posRegime string, posQty float64) string {
+	regime := effectiveRegimeForPolicy(currentRegime, posRegime, posQty)
+	return EffectiveDirectionForRegime(sc, regime)
+}
+
+// policyAllowsPositionSide reports whether posSide is permitted under at least
+// one entry in regime_directional_policy. Used when pos.Regime is empty
+// (legacy / pre-#741) so validation does not false-positive a side that some
+// regime intentionally allows (#783).
+func policyAllowsPositionSide(sc StrategyConfig, posSide string) bool {
+	if sc.RegimeDirectionalPolicy == nil || sc.RegimeDirectionalPolicy.IsZero() {
+		return false
+	}
+	for _, label := range canonicalTrendRegimeLabels {
+		if !perpsPositionConflictsDirection(posSide, EffectiveDirectionForRegime(sc, label)) {
+			return true
+		}
+	}
+	return false
+}
+
+// perpsPositionConflictsDirection reports whether an open position's side
+// conflicts with a resolved effective direction ("both" never conflicts).
+func perpsPositionConflictsDirection(posSide, effectiveDir string) bool {
+	switch effectiveDir {
+	case DirectionBoth:
+		return false
+	case DirectionLong:
+		return posSide == "short"
+	case DirectionShort:
+		return posSide == "long"
+	default:
+		return false
+	}
+}

--- a/scheduler/regime_directional_policy_test.go
+++ b/scheduler/regime_directional_policy_test.go
@@ -179,6 +179,48 @@ func TestRegimeDirectionalPolicyEqualForReload(t *testing.T) {
 	}
 }
 
+func TestEffectiveDirectionForPosition(t *testing.T) {
+	policy := &RegimeDirectionalPolicy{TrendRegime: map[string]RegimeDirectionalEntry{
+		"trending_up":   {Direction: DirectionLong},
+		"trending_down": {Direction: DirectionShort},
+		"ranging":       {Direction: DirectionLong},
+	}}
+	sc := StrategyConfig{Direction: DirectionLong, RegimeDirectionalPolicy: policy}
+
+	if got := EffectiveDirectionForPosition(sc, "trending_up", "trending_down", 1); got != DirectionShort {
+		t.Errorf("open position uses stamped regime: got %q want short", got)
+	}
+	if got := EffectiveDirectionForPosition(sc, "trending_up", "", 0); got != DirectionLong {
+		t.Errorf("flat uses current regime: got %q want long", got)
+	}
+	if got := EffectiveDirectionForPosition(sc, "", "", 1); got != DirectionLong {
+		t.Errorf("unstamped open falls back to current (empty): got %q want base long", got)
+	}
+}
+
+func TestPolicyAllowsPositionSide(t *testing.T) {
+	policy := &RegimeDirectionalPolicy{TrendRegime: map[string]RegimeDirectionalEntry{
+		"trending_up":   {Direction: DirectionLong},
+		"trending_down": {Direction: DirectionShort},
+		"ranging":       {Direction: DirectionLong},
+	}}
+	sc := StrategyConfig{Direction: DirectionLong, RegimeDirectionalPolicy: policy}
+	if !policyAllowsPositionSide(sc, "short") {
+		t.Error("short should be allowed via trending_down policy")
+	}
+	allLong := &RegimeDirectionalPolicy{TrendRegime: map[string]RegimeDirectionalEntry{
+		"trending_up": {Direction: DirectionLong}, "trending_down": {Direction: DirectionLong}, "ranging": {Direction: DirectionLong},
+	}}
+	scAllLong := StrategyConfig{Direction: DirectionLong, RegimeDirectionalPolicy: allLong}
+	if policyAllowsPositionSide(scAllLong, "short") {
+		t.Error("short should not be allowed when every regime is long-only")
+	}
+	scNoPolicy := StrategyConfig{Direction: DirectionLong}
+	if policyAllowsPositionSide(scNoPolicy, "short") {
+		t.Error("no policy should return false")
+	}
+}
+
 // TestApplyRegimeDirectionalPolicy covers the resolver semantics:
 // flat -> current regime, open -> pos.Regime (hold semantics),
 // no policy -> no-op.

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 )
@@ -245,7 +246,13 @@ func ValidatePerpsDirectionConfig(state *AppState, cfg *Config) []string {
 		}
 		baseDirection := EffectiveDirection(*sc)
 		policyConfigured := sc.RegimeDirectionalPolicy != nil && sc.RegimeDirectionalPolicy.IsConfigured()
-		for sym, pos := range s.Positions {
+		syms := make([]string, 0, len(s.Positions))
+		for sym := range s.Positions {
+			syms = append(syms, sym)
+		}
+		sort.Strings(syms)
+		for _, sym := range syms {
+			pos := s.Positions[sym]
 			if pos == nil || pos.Quantity <= 0 {
 				continue
 			}

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -218,14 +219,10 @@ func migrateLegacyPerpsPositionMultipliers(state *AppState, cfg *Config) int {
 }
 
 // ValidatePerpsDirectionConfig flags positions whose side conflicts with the
-// strategy's configured direction (#336/#656). Two gap classes:
-//
-//  1. direction="long" with a short position (legacy AllowShorts=false). The
-//     desync can arise from state migration, paper→live handoff, operator
-//     state.db edits, or a "both"→"long" config toggle without first closing.
-//  2. direction="short" with a long position (#656 short-only mode). The
-//     symmetric gap arises from a "long"→"short" config toggle without
-//     closing, or operator edits.
+// strategy's effective direction (#336/#656/#783). When regime_directional_policy
+// is configured, resolution uses the stamped position regime (hold-on-transition)
+// or treats the side as valid if any policy regime allows it when the stamp is
+// missing (legacy pre-#741 positions).
 //
 // In either case the strategy's next signal-driven order will desync virtual
 // state from the exchange. We warn-and-continue (matching ValidateState's
@@ -242,30 +239,36 @@ func ValidatePerpsDirectionConfig(state *AppState, cfg *Config) []string {
 		if sc.Type != "perps" {
 			continue
 		}
-		direction := EffectiveDirection(*sc)
-		if direction == DirectionBoth {
-			continue
-		}
 		s, ok := state.Strategies[sc.ID]
 		if !ok {
 			continue
 		}
+		baseDirection := EffectiveDirection(*sc)
+		policyConfigured := sc.RegimeDirectionalPolicy != nil && sc.RegimeDirectionalPolicy.IsConfigured()
 		for sym, pos := range s.Positions {
-			var conflictSide string
-			switch direction {
-			case DirectionLong:
-				if pos.Side == "short" {
-					conflictSide = "short"
-				}
-			case DirectionShort:
-				if pos.Side == "long" {
-					conflictSide = "long"
-				}
-			}
-			if conflictSide == "" {
+			if pos == nil || pos.Quantity <= 0 {
 				continue
 			}
-			msg := fmt.Sprintf("perps state-vs-config gap: strategy %s has %s %s qty=%g (direction=%q). Position was likely seeded by migration, paper→live handoff, or a prior conflicting direction. Close manually before the next signal — the executor's fresh-open sizing will otherwise desync virtual state from the exchange.", sc.ID, conflictSide, sym, pos.Quantity, direction)
+			posRegime := strings.TrimSpace(pos.Regime)
+			effectiveDir := EffectiveDirectionForPosition(*sc, "", posRegime, pos.Quantity)
+			if !perpsPositionConflictsDirection(pos.Side, effectiveDir) {
+				continue
+			}
+			// Legacy / unstamped: if any configured regime allows this side, skip.
+			if policyConfigured && posRegime == "" && policyAllowsPositionSide(*sc, pos.Side) {
+				continue
+			}
+			conflictSide := pos.Side
+			var regimeNote string
+			switch {
+			case posRegime != "":
+				regimeNote = fmt.Sprintf("effective_direction=%q from stamped regime=%q; base_direction=%q", effectiveDir, posRegime, baseDirection)
+			case policyConfigured:
+				regimeNote = fmt.Sprintf("effective_direction=%q (base_direction=%q; position regime unknown — validated against base only)", effectiveDir, baseDirection)
+			default:
+				regimeNote = fmt.Sprintf("direction=%q", baseDirection)
+			}
+			msg := fmt.Sprintf("perps state-vs-config gap: strategy %s has %s %s qty=%g (%s). Position was likely seeded by migration, paper→live handoff, or a prior conflicting direction. Close manually before the next signal — the executor's fresh-open sizing will otherwise desync virtual state from the exchange.", sc.ID, conflictSide, sym, pos.Quantity, regimeNote)
 			fmt.Printf("[WARN] %s\n", msg)
 			warnings = append(warnings, msg)
 		}

--- a/scheduler/state_test.go
+++ b/scheduler/state_test.go
@@ -323,6 +323,31 @@ func TestValidatePerpsDirectionConfig_RegimePolicyUnstampedAllowed(t *testing.T)
 	}
 }
 
+// #784 re-review: warnings for multi-position strategies must be symbol-sorted.
+func TestValidatePerpsDirectionConfig_WarningOrderDeterministic(t *testing.T) {
+	state := NewAppState()
+	state.Strategies["hl-multi"] = &StrategyState{
+		ID:   "hl-multi",
+		Type: "perps",
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 1, Side: "short", Multiplier: 1, Leverage: 1},
+			"BTC": {Symbol: "BTC", Quantity: 0.1, Side: "short", Multiplier: 1, Leverage: 1},
+		},
+	}
+	cfg := &Config{
+		Strategies: []StrategyConfig{{
+			ID: "hl-multi", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong,
+		}},
+	}
+	warnings := ValidatePerpsDirectionConfig(state, cfg)
+	if len(warnings) != 2 {
+		t.Fatalf("want 2 warnings, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], " BTC ") || !strings.Contains(warnings[1], " ETH ") {
+		t.Errorf("warnings should be sorted by symbol (BTC before ETH), got:\n%s\n%s", warnings[0], warnings[1])
+	}
+}
+
 func TestLoadStateWithDB_SQLitePrimary(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "state.db")

--- a/scheduler/state_test.go
+++ b/scheduler/state_test.go
@@ -248,6 +248,81 @@ func TestValidatePerpsDirectionConfig_LegacyAllowShortsFallthrough(t *testing.T)
 	}
 }
 
+func makeRegimeDirectionalPolicyForValidation() *RegimeDirectionalPolicy {
+	return &RegimeDirectionalPolicy{TrendRegime: map[string]RegimeDirectionalEntry{
+		"trending_up":   {Direction: DirectionLong, InvertSignal: false},
+		"trending_down": {Direction: DirectionShort, InvertSignal: true},
+		"ranging":       {Direction: DirectionLong, InvertSignal: false},
+	}}
+}
+
+// #783: short under base direction=long is valid when stamped regime policy allows short.
+func TestValidatePerpsDirectionConfig_RegimePolicyStampedTrendingDown(t *testing.T) {
+	state := NewAppState()
+	state.Strategies["hl-mr-hype"] = &StrategyState{
+		ID:   "hl-mr-hype",
+		Type: "perps",
+		Positions: map[string]*Position{
+			"HYPE": {Symbol: "HYPE", Quantity: 1, Side: "short", Regime: "trending_down", Multiplier: 1, Leverage: 1},
+		},
+	}
+	cfg := &Config{
+		Strategies: []StrategyConfig{{
+			ID: "hl-mr-hype", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong,
+			RegimeDirectionalPolicy: makeRegimeDirectionalPolicyForValidation(),
+		}},
+	}
+	if warnings := ValidatePerpsDirectionConfig(state, cfg); len(warnings) != 0 {
+		t.Fatalf("short under trending_down policy should not warn, got: %v", warnings)
+	}
+}
+
+// #783: short with stamped trending_up conflicts with policy long-only for that regime.
+func TestValidatePerpsDirectionConfig_RegimePolicyStampedTrendingUpConflict(t *testing.T) {
+	state := NewAppState()
+	state.Strategies["hl-mr-hype"] = &StrategyState{
+		ID:   "hl-mr-hype",
+		Type: "perps",
+		Positions: map[string]*Position{
+			"HYPE": {Symbol: "HYPE", Quantity: 1, Side: "short", Regime: "trending_up", Multiplier: 1, Leverage: 1},
+		},
+	}
+	cfg := &Config{
+		Strategies: []StrategyConfig{{
+			ID: "hl-mr-hype", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong,
+			RegimeDirectionalPolicy: makeRegimeDirectionalPolicyForValidation(),
+		}},
+	}
+	warnings := ValidatePerpsDirectionConfig(state, cfg)
+	if len(warnings) != 1 {
+		t.Fatalf("want 1 warning for short under trending_up policy, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "stamped regime=\"trending_up\"") {
+		t.Errorf("warning should cite stamped regime, got: %s", warnings[0])
+	}
+}
+
+// #783: unstamped short with policy that allows short in some regime → no hard warning.
+func TestValidatePerpsDirectionConfig_RegimePolicyUnstampedAllowed(t *testing.T) {
+	state := NewAppState()
+	state.Strategies["hl-mr-hype"] = &StrategyState{
+		ID:   "hl-mr-hype",
+		Type: "perps",
+		Positions: map[string]*Position{
+			"HYPE": {Symbol: "HYPE", Quantity: 1, Side: "short", Multiplier: 1, Leverage: 1},
+		},
+	}
+	cfg := &Config{
+		Strategies: []StrategyConfig{{
+			ID: "hl-mr-hype", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong,
+			RegimeDirectionalPolicy: makeRegimeDirectionalPolicyForValidation(),
+		}},
+	}
+	if warnings := ValidatePerpsDirectionConfig(state, cfg); len(warnings) != 0 {
+		t.Fatalf("unstamped short allowed by trending_down policy should not warn, got: %v", warnings)
+	}
+}
+
 func TestLoadStateWithDB_SQLitePrimary(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "state.db")


### PR DESCRIPTION
## Summary

- `ValidatePerpsDirectionConfig` resolves effective direction per open position using stamped `pos.Regime` (hold-on-transition) instead of static base `direction` only.
- Unstamped legacy positions skip warnings when any `regime_directional_policy` regime allows the held side.
- `go-trader inspect` shows base direction, per-regime policy table, and position-aware effective direction when state DB is available.
- Shared helpers: `EffectiveDirectionForRegime`, `EffectiveDirectionForPosition`, `policyAllowsPositionSide`, `perpsPositionConflictsDirection`.

**Behavior notes (beyond policy resolution):**
- Validator skips `pos == nil` or `pos.Quantity <= 0` (no warning on stale zero-qty rows).
- Base `direction: "both"` is no longer short-circuited when `regime_directional_policy` narrows a stamped regime to long-only or short-only.
- Inspect text: legacy `direction:` label when no policy; `base_direction:` + policy table when policy is configured. JSON keeps both `direction` and `base_direction` keys.

Closes #783

## Test plan

- [x] `go test ./...` in `scheduler/`
- [x] `TestValidatePerpsDirectionConfig_RegimePolicy*` + `TestValidatePerpsDirectionConfig_WarningOrderDeterministic`
- [x] `TestEffectiveDirectionForPosition`, `TestPolicyAllowsPositionSide`
- [x] `TestFormatStrategyInspectionLegacyDirectionLabel`, `TestFormatStrategyInspectionBaseDirectionWithPolicy`
- [ ] Manual: strategy with `regime_directional_policy` + short under `trending_down` stamp → no startup warning
- [ ] Manual: `./go-trader inspect <id>` shows policy table and open position effective direction

LLM: Composer | default | Harness: agent