### PR TITLE
fix(probe): skip live credential checks during update.sh probe

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -569,7 +569,21 @@ func EffectiveInitialCapital(sc StrategyConfig, ss *StrategyState) float64 {
 	return sc.Capital
 }
 
+// LoadConfig loads and validates a config file. Live-mode strategies require
+// platform credential env vars to be set in the process environment.
 func LoadConfig(path string) (*Config, error) {
+	return loadConfig(path, false)
+}
+
+// LoadConfigForProbe loads config for `go-trader probe` / update.sh pre-swap
+// validation. Skips live-credential env checks (#787): probe only verifies the
+// Python argv contract and never connects to exchanges; secrets may live only in
+// the running process (systemd EnvironmentFile, etc.).
+func LoadConfigForProbe(path string) (*Config, error) {
+	return loadConfig(path, true)
+}
+
+func loadConfig(path string, skipLiveCredentialChecks bool) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read config: %w", err)
@@ -903,7 +917,7 @@ func LoadConfig(path string) (*Config, error) {
 		cfg.Correlation.MaxSameDirectionPct = 75
 	}
 
-	if err := ValidateConfig(&cfg); err != nil {
+	if err := validateConfig(&cfg, skipLiveCredentialChecks); err != nil {
 		return nil, err
 	}
 	return &cfg, nil
@@ -1134,6 +1148,10 @@ func ordinal(n int) string {
 
 // ValidateConfig checks script paths and strategy fields (#34, #36).
 func ValidateConfig(cfg *Config) error {
+	return validateConfig(cfg, false)
+}
+
+func validateConfig(cfg *Config, skipLiveCredentialChecks bool) error {
 	var errs []string
 	seenIDs := make(map[string]bool)
 
@@ -1227,62 +1245,64 @@ func ValidateConfig(cfg *Config) error {
 			}
 		}
 
-		// Live-mode futures require TopStep API credentials.
-		if sc.Type == "futures" {
-			for _, arg := range sc.Args {
-				if arg == "--mode=live" {
-					if os.Getenv("TOPSTEP_API_KEY") == "" {
-						errs = append(errs, fmt.Sprintf("%s: --mode=live requires TOPSTEP_API_KEY env var", prefix))
+		if !skipLiveCredentialChecks {
+			// Live-mode futures require TopStep API credentials.
+			if sc.Type == "futures" {
+				for _, arg := range sc.Args {
+					if arg == "--mode=live" {
+						if os.Getenv("TOPSTEP_API_KEY") == "" {
+							errs = append(errs, fmt.Sprintf("%s: --mode=live requires TOPSTEP_API_KEY env var", prefix))
+						}
+						if os.Getenv("TOPSTEP_API_SECRET") == "" {
+							errs = append(errs, fmt.Sprintf("%s: --mode=live requires TOPSTEP_API_SECRET env var", prefix))
+						}
+						if os.Getenv("TOPSTEP_ACCOUNT_ID") == "" {
+							errs = append(errs, fmt.Sprintf("%s: --mode=live requires TOPSTEP_ACCOUNT_ID env var", prefix))
+						}
+						break
 					}
-					if os.Getenv("TOPSTEP_API_SECRET") == "" {
-						errs = append(errs, fmt.Sprintf("%s: --mode=live requires TOPSTEP_API_SECRET env var", prefix))
-					}
-					if os.Getenv("TOPSTEP_ACCOUNT_ID") == "" {
-						errs = append(errs, fmt.Sprintf("%s: --mode=live requires TOPSTEP_ACCOUNT_ID env var", prefix))
-					}
-					break
 				}
 			}
-		}
 
-		// Live-mode Robinhood crypto requires credentials.
-		if sc.Platform == "robinhood" {
-			for _, arg := range sc.Args {
-				if arg == "--mode=live" {
-					if os.Getenv("ROBINHOOD_USERNAME") == "" {
-						errs = append(errs, fmt.Sprintf("%s: --mode=live requires ROBINHOOD_USERNAME env var", prefix))
+			// Live-mode Robinhood crypto requires credentials.
+			if sc.Platform == "robinhood" {
+				for _, arg := range sc.Args {
+					if arg == "--mode=live" {
+						if os.Getenv("ROBINHOOD_USERNAME") == "" {
+							errs = append(errs, fmt.Sprintf("%s: --mode=live requires ROBINHOOD_USERNAME env var", prefix))
+						}
+						if os.Getenv("ROBINHOOD_PASSWORD") == "" {
+							errs = append(errs, fmt.Sprintf("%s: --mode=live requires ROBINHOOD_PASSWORD env var", prefix))
+						}
+						if os.Getenv("ROBINHOOD_TOTP_SECRET") == "" {
+							errs = append(errs, fmt.Sprintf("%s: --mode=live requires ROBINHOOD_TOTP_SECRET env var", prefix))
+						}
+						break
 					}
-					if os.Getenv("ROBINHOOD_PASSWORD") == "" {
-						errs = append(errs, fmt.Sprintf("%s: --mode=live requires ROBINHOOD_PASSWORD env var", prefix))
-					}
-					if os.Getenv("ROBINHOOD_TOTP_SECRET") == "" {
-						errs = append(errs, fmt.Sprintf("%s: --mode=live requires ROBINHOOD_TOTP_SECRET env var", prefix))
-					}
-					break
 				}
 			}
-		}
 
-		// Live-mode perps require platform-specific env vars.
-		if sc.Type == "perps" || (sc.Platform == "okx" && sc.Type == "spot") {
-			for _, arg := range sc.Args {
-				if arg == "--mode=live" {
-					if sc.Platform == "okx" {
-						if os.Getenv("OKX_API_KEY") == "" {
-							errs = append(errs, fmt.Sprintf("%s: --mode=live requires OKX_API_KEY env var", prefix))
+			// Live-mode perps require platform-specific env vars.
+			if sc.Type == "perps" || (sc.Platform == "okx" && sc.Type == "spot") {
+				for _, arg := range sc.Args {
+					if arg == "--mode=live" {
+						if sc.Platform == "okx" {
+							if os.Getenv("OKX_API_KEY") == "" {
+								errs = append(errs, fmt.Sprintf("%s: --mode=live requires OKX_API_KEY env var", prefix))
+							}
+							if os.Getenv("OKX_API_SECRET") == "" {
+								errs = append(errs, fmt.Sprintf("%s: --mode=live requires OKX_API_SECRET env var", prefix))
+							}
+							if os.Getenv("OKX_PASSPHRASE") == "" {
+								errs = append(errs, fmt.Sprintf("%s: --mode=live requires OKX_PASSPHRASE env var", prefix))
+							}
+						} else if sc.Platform == "hyperliquid" || sc.Platform == "" {
+							if os.Getenv("HYPERLIQUID_SECRET_KEY") == "" {
+								errs = append(errs, fmt.Sprintf("%s: --mode=live requires HYPERLIQUID_SECRET_KEY env var", prefix))
+							}
 						}
-						if os.Getenv("OKX_API_SECRET") == "" {
-							errs = append(errs, fmt.Sprintf("%s: --mode=live requires OKX_API_SECRET env var", prefix))
-						}
-						if os.Getenv("OKX_PASSPHRASE") == "" {
-							errs = append(errs, fmt.Sprintf("%s: --mode=live requires OKX_PASSPHRASE env var", prefix))
-						}
-					} else if sc.Platform == "hyperliquid" || sc.Platform == "" {
-						if os.Getenv("HYPERLIQUID_SECRET_KEY") == "" {
-							errs = append(errs, fmt.Sprintf("%s: --mode=live requires HYPERLIQUID_SECRET_KEY env var", prefix))
-						}
+						break
 					}
-					break
 				}
 			}
 		}
@@ -1296,7 +1316,7 @@ func ValidateConfig(cfg *Config) error {
 				fmt.Printf("[WARN] %s: both capital ($%.0f) and capital_pct (%.0f%%) set — capital_pct takes priority\n", sc.ID, sc.Capital, sc.CapitalPct*100)
 			}
 			// #101: capital_pct on hyperliquid requires account address for balance fetch.
-			if sc.CapitalPct > 0 && sc.Platform == "hyperliquid" {
+			if !skipLiveCredentialChecks && sc.CapitalPct > 0 && sc.Platform == "hyperliquid" {
 				if os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS") == "" {
 					errs = append(errs, fmt.Sprintf("%s: capital_pct requires HYPERLIQUID_ACCOUNT_ADDRESS env var", prefix))
 				}

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2534,4 +2535,72 @@ func TestValidateConfigInvertSignal(t *testing.T) {
 			t.Fatalf("expected HL-perps/manual-only error, got: %v", err)
 		}
 	})
+}
+
+// #787: normal startup still requires live credentials in the environment.
+func TestValidateConfigHLLiveRequiresSecretKey(t *testing.T) {
+	t.Setenv("HYPERLIQUID_SECRET_KEY", "")
+	cfg := Config{
+		Strategies: []StrategyConfig{{
+			ID:             "hl-tema-eth-live",
+			Type:           "perps",
+			Platform:       "hyperliquid",
+			Script:         "shared_scripts/check_hyperliquid.py",
+			Args:           []string{"triple_ema", "ETH", "1h", "--mode=live"},
+			Capital:        1000,
+			MaxDrawdownPct: 60,
+		}},
+	}
+	err := ValidateConfig(&cfg)
+	if err == nil || !strings.Contains(err.Error(), "HYPERLIQUID_SECRET_KEY") {
+		t.Fatalf("expected live secret error, got: %v", err)
+	}
+}
+
+// #787: probe/update.sh loads config without shell secrets when the running
+// process has them via systemd EnvironmentFile, etc.
+func TestLoadConfigForProbeSkipsLiveCredentialChecks(t *testing.T) {
+	t.Setenv("HYPERLIQUID_SECRET_KEY", "")
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "")
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.json")
+	body, err := json.Marshal(map[string]any{
+		"interval_seconds": 600,
+		"strategies": []any{
+			map[string]any{
+				"id":               "hl-tema-eth-live",
+				"type":             "perps",
+				"platform":         "hyperliquid",
+				"script":           "shared_scripts/check_hyperliquid.py",
+				"args":             []string{"triple_ema", "ETH", "1h", "--mode=live"},
+				"interval_seconds": 60,
+				"capital":          1000.0,
+				"max_drawdown_pct": 60.0,
+			},
+			map[string]any{
+				"id":               "hl-cap-pct",
+				"type":             "perps",
+				"platform":         "hyperliquid",
+				"script":           "shared_scripts/check_hyperliquid.py",
+				"args":             []string{"triple_ema", "BTC", "1h", "--mode=live"},
+				"interval_seconds": 60,
+				"capital_pct":      0.25,
+				"max_drawdown_pct": 60.0,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("LoadConfig should still require live credentials")
+	}
+	if _, err := LoadConfigForProbe(path); err != nil {
+		t.Fatalf("LoadConfigForProbe should skip live credential checks: %v", err)
+	}
 }

--- a/scheduler/probe_cmd.go
+++ b/scheduler/probe_cmd.go
@@ -18,7 +18,7 @@ func runProbe(args []string) int {
 		return 2
 	}
 
-	cfg, err := LoadConfig(*configPath)
+	cfg, err := LoadConfigForProbe(*configPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "probe: failed to load config %s: %v\n", *configPath, err)
 		return 1

--- a/scheduler/probe_cmd_test.go
+++ b/scheduler/probe_cmd_test.go
@@ -131,3 +131,37 @@ func TestRunProbeHappyPath(t *testing.T) {
 			hlSignal, hlFetchATR, hlExecute, spotSignal, candleHelper, probed)
 	}
 }
+
+// #787: update.sh probe must load live HL configs without shell secrets.
+func TestRunProbeSkipsLiveCredentialChecks(t *testing.T) {
+	t.Setenv("HYPERLIQUID_SECRET_KEY", "")
+
+	orig := probeOneCheckScriptFn
+	defer func() { probeOneCheckScriptFn = orig }()
+	probeOneCheckScriptFn = func(script string, argv []string) error { return nil }
+
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.json")
+	body, _ := json.Marshal(map[string]any{
+		"interval_seconds": 60,
+		"strategies": []any{
+			map[string]any{
+				"id":               "hl-tema-eth-live",
+				"type":             "perps",
+				"platform":         "hyperliquid",
+				"script":           "shared_scripts/check_hyperliquid.py",
+				"args":             []string{"triple_ema", "ETH", "1h", "--mode=live"},
+				"interval_seconds": 60,
+				"capital":          1000.0,
+				"max_drawdown_pct": 60.0,
+			},
+		},
+	})
+	if err := os.WriteFile(cfgPath, body, 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+	rc := runProbe([]string{"--config", cfgPath})
+	if rc != 0 {
+		t.Fatalf("probe with live HL config and no shell secrets should return 0, got %d", rc)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `LoadConfigForProbe` so `go-trader probe` (and `scripts/update.sh` pre-swap validation) skips live-mode credential env checks (#787).
- Probe only verifies the Python argv contract; it never connects to exchanges. Secrets may exist only in the running process (systemd `EnvironmentFile`, etc.), not in the shell running `update.sh`.
- Normal `LoadConfig` / startup still requires `HYPERLIQUID_SECRET_KEY` and other live credentials.

## Test plan

- [x] `go test -C scheduler ./...`
- [x] `TestValidateConfigHLLiveRequiresSecretKey` — startup path still fails without secrets
- [x] `TestLoadConfigForProbeSkipsLiveCredentialChecks` — probe path accepts live HL config without env
- [x] `TestRunProbeSkipsLiveCredentialChecks` — end-to-end `runProbe` with `--mode=live`

Closes #787

LLM: Composer | default | Harness: agent