### PR TITLE
update.sh: --rsync-from safe sync and EnvironmentFile warning

### DIFF
--- a/scheduler/update_sh_feature_test.go
+++ b/scheduler/update_sh_feature_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func updateShellScriptPath(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "scripts", "update.sh")
+}
+
+func TestUpdateShellHelpDocumentsRsyncFrom790(t *testing.T) {
+	t.Parallel()
+	script := updateShellScriptPath(t)
+	out, err := exec.Command("bash", script, "--help").CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash %s --help: %v\n%s", script, err, out)
+	}
+	text := string(out)
+	for _, want := range []string{
+		"--rsync-from",
+		"hardcoded exclusions",
+		".env",
+		"state DB",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("help missing %q", want)
+		}
+	}
+}
+
+func TestUpdateShellRejectsMissingRsyncFromDir790(t *testing.T) {
+	t.Parallel()
+	script := updateShellScriptPath(t)
+	out, err := exec.Command("bash", script, "--rsync-from", "/nonexistent-go-trader-rsync-src").CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit for missing --rsync-from dir\n%s", out)
+	}
+	if !strings.Contains(string(out), "requires an existing source directory") {
+		t.Fatalf("unexpected error output:\n%s", out)
+	}
+}

--- a/scheduler/update_sh_feature_test.go
+++ b/scheduler/update_sh_feature_test.go
@@ -37,6 +37,22 @@ func TestUpdateShellHelpDocumentsRsyncFrom790(t *testing.T) {
 	}
 }
 
+func TestUpdateHelpersEnvfileParsing790(t *testing.T) {
+	t.Parallel()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	script := filepath.Join(filepath.Dir(thisFile), "..", "scripts", "test_update_helpers.sh")
+	out, err := exec.Command("bash", script).CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash %s: %v\n%s", script, err, out)
+	}
+	if !strings.Contains(string(out), "OK:") {
+		t.Fatalf("unexpected output:\n%s", out)
+	}
+}
+
 func TestUpdateShellRejectsMissingRsyncFromDir790(t *testing.T) {
 	t.Parallel()
 	script := updateShellScriptPath(t)

--- a/scheduler/update_sh_syntax_test.go
+++ b/scheduler/update_sh_syntax_test.go
@@ -15,7 +15,7 @@ func TestUpdateShellScriptSyntax(t *testing.T) {
 	}
 	schedDir := filepath.Dir(thisFile)
 	repoRoot := filepath.Join(schedDir, "..")
-	for _, name := range []string{"update.sh", "create-run-sh.sh"} {
+	for _, name := range []string{"update.sh", "update_helpers.sh", "create-run-sh.sh", "test_update_helpers.sh"} {
 		script := filepath.Join(repoRoot, "scripts", name)
 		out, err := exec.Command("bash", "-n", script).CombinedOutput()
 		if err != nil {

--- a/scripts/test_update_helpers.sh
+++ b/scripts/test_update_helpers.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Regression tests for scripts/update_helpers.sh (#790 review).
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=update_helpers.sh
+source "${SCRIPT_DIR}/update_helpers.sh"
+
+assert_eq() {
+    local got="$1" want="$2" msg="$3"
+    if [[ "$got" != "$want" ]]; then
+        echo "FAIL: $msg (got=$got want=$want)" >&2
+        exit 1
+    fi
+}
+
+assert_eq "$(update_systemd_envfile_check_path '/opt/go-trader/.env (ignore_errors=no)')" \
+    "/opt/go-trader/.env" "strip ignore_errors suffix"
+
+assert_eq "$(update_systemd_envfile_check_path '-/opt/go-trader/.env (ignore_errors=yes)')" \
+    "" "optional EnvironmentFile (- prefix) yields no check path"
+
+assert_eq "$(update_systemd_envfile_check_path '(ignore_errors=no)')" \
+    "" "ignore word-split artifact"
+
+warn_out=$(
+    printf '%s\n' \
+        '/etc/required.env (ignore_errors=no)' \
+        '-/etc/optional.env (ignore_errors=yes)' \
+        '(ignore_errors=no)' \
+        | warn_missing_systemd_environment_files_from_text 'test-unit' 2>&1 || true
+)
+if [[ "$warn_out" != *'/etc/required.env'* ]]; then
+    echo "FAIL: expected warning for required missing env file" >&2
+    echo "$warn_out" >&2
+    exit 1
+fi
+if [[ "$warn_out" == *'optional.env'* || "$warn_out" == *'ignore_errors'* ]]; then
+    echo "FAIL: must not warn for optional or metadata lines" >&2
+    echo "$warn_out" >&2
+    exit 1
+fi
+
+echo "OK: update_helpers tests passed"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -5,6 +5,8 @@
 # RESTART_MODE=signal (explicit) for bare-process + pidfile deployments.
 # #785: systemd mode falls back to signal restart when unit missing (exit 5).
 # #790: --rsync-from safe tree sync; warn on missing systemd EnvironmentFile.
+#   --rsync-from preserves deployment .git/ (not copied from source) so rollback
+#   git reset --hard still targets the deployment repo's pre-sync SHA.
 #
 # Phases:
 #   preflight  — git/uv/go sanity checks
@@ -27,6 +29,8 @@ set -euo pipefail
 
 THIS_SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 THIS_SCRIPT="${THIS_SCRIPT_DIR}/$(basename "${BASH_SOURCE[0]}")"
+# shellcheck source=update_helpers.sh
+source "${THIS_SCRIPT_DIR}/update_helpers.sh"
 orig_argv=("$@")
 
 trim_space() {
@@ -379,43 +383,33 @@ except Exception:
 run_rsync_from() {
     local src="$1"
     local dest="$2"
-    local db_excl
+    local db_excl signal_log_excl
+    local -a rsync_excludes
     if ! command -v rsync >/dev/null 2>&1; then
         fail "rsync not on PATH — install rsync or omit --rsync-from"
     fi
     db_excl=$(update_resolve_db_exclude)
-    echo "[update] rsync: $src/ -> $dest/ (excludes deployment secrets/state/venv/binaries)"
-    rsync -a --delete \
-        --exclude='.env' \
-        --exclude='scheduler/config.json' \
-        --exclude="$db_excl" \
-        --exclude='trading_bot.db*' \
-        --exclude='.venv/' \
-        --exclude='node_modules/' \
-        --exclude='__pycache__/' \
-        --exclude='go-trader' \
-        --exclude='go-trader.new' \
-        --exclude='go-trader.prev' \
-        --exclude='go-trader.pid' \
-        "$src/" "$dest/"
-}
-
-warn_missing_systemd_environment_files() {
-    local unit="$1"
-    local raw entry path
-    raw=$(systemctl show -p EnvironmentFiles --value "$unit" 2>/dev/null || true)
-    [[ -n "$raw" ]] || return 0
-    for entry in $raw; do
-        [[ -n "$entry" ]] || continue
-        path="$entry"
-        if [[ "$path" == -* ]]; then
-            path="${path#-}"
-        fi
-        [[ -n "$path" ]] || continue
-        if [[ ! -f "$path" ]]; then
-            printf '\033[1;31m[update] WARNING: EnvironmentFile %s is missing for unit %s; restart proceeds but secrets from this file will be absent\033[0m\n' "$entry" "$unit" >&2
-        fi
-    done
+    signal_log_excl="${GO_TRADER_SIGNAL_LOG:-./go-trader-signal.log}"
+    rsync_excludes=(
+        --exclude='.git/'
+        --exclude='.env'
+        --exclude='scheduler/config.json'
+        --exclude="${db_excl}*"
+        --exclude='trading_bot.db*'
+        --exclude='.venv/'
+        --exclude='node_modules/'
+        --exclude='__pycache__/'
+        --exclude='go-trader'
+        --exclude='go-trader.new'
+        --exclude='go-trader.prev'
+        --exclude='go-trader.pid'
+        --exclude='go-trader-signal.log'
+    )
+    if [[ "$signal_log_excl" != "./go-trader-signal.log" && "$signal_log_excl" != "go-trader-signal.log" ]]; then
+        rsync_excludes+=(--exclude="$signal_log_excl")
+    fi
+    echo "[update] rsync: $src/ -> $dest/ (excludes deployment .git, secrets, state DB, venv, binaries, signal log)"
+    rsync -a --delete "${rsync_excludes[@]}" "$src/" "$dest/"
 }
 
 warn_execstart_vs_swap() {

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -4,9 +4,11 @@
 # paths + ExecStart vs swap-target warning before systemd restart. #766:
 # RESTART_MODE=signal (explicit) for bare-process + pidfile deployments.
 # #785: systemd mode falls back to signal restart when unit missing (exit 5).
+# #790: --rsync-from safe tree sync; warn on missing systemd EnvironmentFile.
 #
 # Phases:
 #   preflight  — git/uv/go sanity checks
+#   rsync      — optional --rsync-from (replaces pull)
 #   pull       — git pull --ff-only
 #   sync       — uv sync
 #   build      — go build to go-trader.new (live binary untouched)
@@ -45,6 +47,8 @@ if [[ -z "$service_unit" ]]; then
 fi
 go_trader_pidfile="$(trim_space "${GO_TRADER_PIDFILE:-./go-trader.pid}")"
 go_trader_run_sh="$(trim_space "${GO_TRADER_RUN_SH:-./run.sh}")"
+rsync_from=""
+tree_mutated=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -79,6 +83,18 @@ while [[ $# -gt 0 ]]; do
         --update-all-root=*)
             shift
             ;;
+        --rsync-from)
+            if [[ $# -lt 2 ]]; then
+                echo "$1 requires a source directory path" >&2
+                exit 2
+            fi
+            rsync_from="$(trim_space "$2")"
+            shift 2
+            ;;
+        --rsync-from=*)
+            rsync_from="$(trim_space "${1#*=}")"
+            shift
+            ;;
         --unit|--service)
             if [[ $# -lt 2 ]]; then
                 echo "$1 requires a systemd unit name" >&2
@@ -104,7 +120,10 @@ while [[ $# -gt 0 ]]; do
         -h|--help)
             echo "Usage: $0 [--restart] [--restart-mode systemd|signal] [--unit <systemd-unit>]"
             echo "       $0 [--restart] [--service <systemd-unit>]"
+            echo "       $0 [--rsync-from <source-dir>] [--restart] ..."
             echo "       $0 --all [--restart] [--restart-mode systemd|signal] [--update-all-root <dir>] [...]"
+            echo "  --rsync-from <dir>  rsync code from a source clone into this deployment (skips git pull;"
+            echo "                      hardcoded exclusions protect .env, config, state DB, venv, binaries)."
             echo "  With --all + systemd: each child inherits GO_TRADER_SERVICE — set per-worktree env if units differ."
             echo "  RESTART=1 env var also enables restart."
             echo "  RESTART_MODE=signal requires Linux, GO_TRADER_RUN_SH, GO_TRADER_PIDFILE (see #766)."
@@ -143,6 +162,11 @@ esac
 
 if [[ "$update_all" == "1" && "$restart" != "1" ]]; then
     echo "--all requires --restart (each instance is restarted after swap)" >&2
+    exit 2
+fi
+
+if [[ -n "$rsync_from" && ( "$rsync_from" == --* || ! -d "$rsync_from" ) ]]; then
+    echo "--rsync-from requires an existing source directory (got: ${rsync_from:-<empty>})" >&2
     exit 2
 fi
 
@@ -331,6 +355,69 @@ update_canonicalize_path() {
     printf '%s' "$p"
 }
 
+update_resolve_db_exclude() {
+    local db_path="scheduler/state.db"
+    if [[ -f scheduler/config.json && -x .venv/bin/python3 ]]; then
+        local custom
+        custom=$(.venv/bin/python3 -c '
+import json
+try:
+    cfg = json.load(open("scheduler/config.json"))
+    p = cfg.get("db_file") or ""
+    if isinstance(p, str) and p.strip():
+        print(p.strip())
+except Exception:
+    pass
+' 2>/dev/null || true)
+        if [[ -n "$custom" ]]; then
+            db_path="$custom"
+        fi
+    fi
+    printf '%s' "$db_path"
+}
+
+run_rsync_from() {
+    local src="$1"
+    local dest="$2"
+    local db_excl
+    if ! command -v rsync >/dev/null 2>&1; then
+        fail "rsync not on PATH — install rsync or omit --rsync-from"
+    fi
+    db_excl=$(update_resolve_db_exclude)
+    echo "[update] rsync: $src/ -> $dest/ (excludes deployment secrets/state/venv/binaries)"
+    rsync -a --delete \
+        --exclude='.env' \
+        --exclude='scheduler/config.json' \
+        --exclude="$db_excl" \
+        --exclude='trading_bot.db*' \
+        --exclude='.venv/' \
+        --exclude='node_modules/' \
+        --exclude='__pycache__/' \
+        --exclude='go-trader' \
+        --exclude='go-trader.new' \
+        --exclude='go-trader.prev' \
+        --exclude='go-trader.pid' \
+        "$src/" "$dest/"
+}
+
+warn_missing_systemd_environment_files() {
+    local unit="$1"
+    local raw entry path
+    raw=$(systemctl show -p EnvironmentFiles --value "$unit" 2>/dev/null || true)
+    [[ -n "$raw" ]] || return 0
+    for entry in $raw; do
+        [[ -n "$entry" ]] || continue
+        path="$entry"
+        if [[ "$path" == -* ]]; then
+            path="${path#-}"
+        fi
+        [[ -n "$path" ]] || continue
+        if [[ ! -f "$path" ]]; then
+            printf '\033[1;31m[update] WARNING: EnvironmentFile %s is missing for unit %s; restart proceeds but secrets from this file will be absent\033[0m\n' "$entry" "$unit" >&2
+        fi
+    done
+}
+
 warn_execstart_vs_swap() {
     local unit="$1"
     local exec_line binary swap_abs bin_abs swap_res
@@ -359,7 +446,7 @@ do_rollback() {
     fi
     mv -f ./go-trader.prev ./go-trader
 
-    if [[ -n "$pre_pull_sha" && -n "${post_pull_sha:-}" && "$pre_pull_sha" != "$post_pull_sha" ]]; then
+    if [[ "$tree_mutated" == "1" && -n "$pre_pull_sha" ]]; then
         echo "[update] rollback: reverting git tree to $pre_pull_sha" >&2
         if git reset --hard "$pre_pull_sha" >&2; then
             if ! uv sync >&2; then
@@ -528,6 +615,15 @@ EOF
     fail "scheduler/config.json missing — refusing to mutate tree from a non-deployment directory"
 fi
 
+if [[ -n "$rsync_from" ]]; then
+    rsync_from=$(cd "$rsync_from" && pwd)
+    if [[ "$(pwd)" == "$rsync_from" ]]; then
+        fail "--rsync-from cannot be the deployment directory ($(pwd))"
+    fi
+fi
+
+pre_pull_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
+
 if [[ "$restart" == "1" && "$restart_mode" == "signal" ]]; then
     if [[ ! -d /proc/self ]]; then
         fail "RESTART_MODE=signal requires Linux (/proc); use systemd mode on other OSes"
@@ -537,33 +633,35 @@ if [[ "$restart" == "1" && "$restart_mode" == "signal" ]]; then
     fi
 fi
 
-build_paths=(
-    scheduler
-    shared_scripts
-    shared_strategies
-    shared_tools
-    platforms
-    backtest
-    pyproject.toml
-    uv.lock
-)
+if [[ -z "$rsync_from" ]]; then
+    build_paths=(
+        scheduler
+        shared_scripts
+        shared_strategies
+        shared_tools
+        platforms
+        backtest
+        pyproject.toml
+        uv.lock
+    )
 
-if ! git diff --quiet -- "${build_paths[@]}" || ! git diff --cached --quiet -- "${build_paths[@]}"; then
-    git status --short -- "${build_paths[@]}" >&2
-    fail "working tree has uncommitted changes in build-input paths; commit, stash, or revert first"
-fi
-if ! git diff --quiet || ! git diff --cached --quiet; then
-    echo "[update] warning: uncommitted changes outside build-input paths (will survive git pull):" >&2
-    git status --short >&2
-fi
+    if ! git diff --quiet -- "${build_paths[@]}" || ! git diff --cached --quiet -- "${build_paths[@]}"; then
+        git status --short -- "${build_paths[@]}" >&2
+        fail "working tree has uncommitted changes in build-input paths; commit, stash, or revert first"
+    fi
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        echo "[update] warning: uncommitted changes outside build-input paths (will survive git pull):" >&2
+        git status --short >&2
+    fi
 
-untracked=$(git ls-files --others --exclude-standard \
-    scheduler shared_scripts shared_strategies shared_tools platforms backtest 2>/dev/null || true)
-untracked_root=$(git ls-files --others --exclude-standard 2>/dev/null | grep -v '/' || true)
-if [[ -n "$untracked" || -n "$untracked_root" ]]; then
-    echo "[update] warning: untracked files (will not affect the build):" >&2
-    [[ -n "$untracked" ]] && echo "$untracked" >&2
-    [[ -n "$untracked_root" ]] && echo "$untracked_root" >&2
+    untracked=$(git ls-files --others --exclude-standard \
+        scheduler shared_scripts shared_strategies shared_tools platforms backtest 2>/dev/null || true)
+    untracked_root=$(git ls-files --others --exclude-standard 2>/dev/null | grep -v '/' || true)
+    if [[ -n "$untracked" || -n "$untracked_root" ]]; then
+        echo "[update] warning: untracked files (will not affect the build):" >&2
+        [[ -n "$untracked" ]] && echo "$untracked" >&2
+        [[ -n "$untracked_root" ]] && echo "$untracked_root" >&2
+    fi
 fi
 
 prev_running_version=""
@@ -572,7 +670,6 @@ if [[ -x ./go-trader ]]; then
 fi
 echo "[update] previous binary version: ${prev_running_version:-<none>}"
 
-pre_pull_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
 prev_main_pid=""
 if [[ "$restart" == "1" && "$restart_mode" == "signal" ]]; then
     prev_main_pid=$(signal_read_pidfile "$go_trader_pidfile") || fail "signal mode: could not read valid pid from $go_trader_pidfile"
@@ -599,17 +696,31 @@ fi
 
 end_phase
 
-begin_phase pull
-git pull --ff-only
-post_pull_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
-end_phase
+if [[ -n "$rsync_from" ]]; then
+    begin_phase rsync
+    run_rsync_from "$rsync_from" "$(pwd)"
+    tree_mutated=1
+    end_phase
+else
+    begin_phase pull
+    git pull --ff-only
+    post_pull_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
+    if [[ -n "$pre_pull_sha" && -n "$post_pull_sha" && "$pre_pull_sha" != "$post_pull_sha" ]]; then
+        tree_mutated=1
+    fi
+    end_phase
+fi
 
 begin_phase sync
 uv sync
 end_phase
 
 begin_phase build
-ver=$(git describe --tags --always --dirty=-mod 2>/dev/null || echo dev)
+if [[ -n "$rsync_from" ]]; then
+    ver=$(git -C "$rsync_from" describe --tags --always --dirty=-mod 2>/dev/null || echo dev)
+else
+    ver=$(git describe --tags --always --dirty=-mod 2>/dev/null || echo dev)
+fi
 rm -f ./go-trader.new
 "$go_bin" -C scheduler build -ldflags "-X main.Version=$ver" -o ../go-trader.new .
 if [[ ! -s ./go-trader.new ]]; then
@@ -658,6 +769,7 @@ status_port="${status_port:-8099}"
 
 if [[ "$restart_mode" == "systemd" ]]; then
     warn_execstart_vs_swap "$service_unit"
+    warn_missing_systemd_environment_files "$service_unit"
 
     begin_phase restart
     restart_rc=0

--- a/scripts/update_helpers.sh
+++ b/scripts/update_helpers.sh
@@ -1,0 +1,42 @@
+# shellcheck shell=bash
+# Pure helpers sourced by update.sh (and test_update_helpers.sh).
+
+# Emit the filesystem path to check for one EnvironmentFiles line from systemctl show.
+# Returns empty when the entry is optional (-prefix), malformed, or only metadata.
+update_systemd_envfile_check_path() {
+    local entry="$1"
+    local path="$entry"
+
+    [[ -n "$path" ]] || return 0
+    if [[ "$path" == '('* ]]; then
+        return 0
+    fi
+    # EnvironmentFile=-/path — operator declared missing file tolerable.
+    if [[ "$path" == -* ]]; then
+        return 0
+    fi
+    if [[ "$path" == *' (ignore_errors='* ]]; then
+        path="${path%% (ignore_errors=*}"
+    fi
+    [[ -n "$path" ]] || return 0
+    printf '%s' "$path"
+}
+
+# Read EnvironmentFiles lines on stdin; warn on stderr for required missing paths.
+warn_missing_systemd_environment_files_from_text() {
+    local unit="$1"
+    local entry path
+    while IFS= read -r entry || [[ -n "$entry" ]]; do
+        path=$(update_systemd_envfile_check_path "$entry")
+        [[ -n "$path" ]] || continue
+        if [[ ! -f "$path" ]]; then
+            printf '\033[1;31m[update] WARNING: EnvironmentFile %s is missing for unit %s; restart proceeds but secrets from this file will be absent\033[0m\n' "$path" "$unit" >&2
+        fi
+    done
+}
+
+warn_missing_systemd_environment_files() {
+    local unit="$1"
+    systemctl show -p EnvironmentFiles --value "$unit" 2>/dev/null \
+        | warn_missing_systemd_environment_files_from_text "$unit"
+}


### PR DESCRIPTION
## Summary
- Add `--rsync-from <source-dir>` to rsync code into a deployment with hardcoded exclusions (replaces `git pull` for that run).
- Warn in bold before systemd restart when the unit's `EnvironmentFile` paths are missing (non-blocking).
- Rollback uses `tree_mutated` so rsync runs revert via `git reset --hard` like pull updates.

## Test plan
- [x] `bash -n scripts/update.sh`
- [x] `go test -C scheduler -run TestUpdateShell -count=1`
- [ ] Manual: `bash scripts/update.sh --rsync-from /path/to/clone` (no `--restart`) on a deployment dir
- [ ] Manual: `bash scripts/update.sh --restart` with a missing `.env` referenced by the unit — confirm bold warning, service still restarts

Closes #790