### PR TITLE
ci: bump Claude GitHub worker to Opus 4.8

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -91,10 +91,10 @@ jobs:
           MODEL_SHORT=$(printf '%s' "$STRIPPED" | grep -oE '(^|(\r?\n))[[:space:]]*@claude[[:space:]]+[a-z]+' | head -1 | awk '{print $NF}' || true)
 
           case "$MODEL_SHORT" in
-            opus)    MODEL_ID="claude-opus-4-7[1m]" ;;
+            opus)    MODEL_ID="claude-opus-4-8[1m]" ;;
             sonnet)  MODEL_ID="claude-sonnet-4-6[1m]" ;;
             haiku)   MODEL_ID="claude-haiku-4-5" ;;
-            *)       MODEL_ID="claude-opus-4-7[1m]" ;;  # default (no model specified)
+            *)       MODEL_ID="claude-opus-4-8[1m]" ;;  # default (no model specified)
           esac
 
           echo "model_id=$MODEL_ID" >> "$GITHUB_OUTPUT"
@@ -204,7 +204,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           case "$MODEL_ID" in
-            "claude-opus-4-7[1m]")   MODEL_NAME="Claude Opus 4.7 (1M)" ;;
+            "claude-opus-4-8[1m]")   MODEL_NAME="Claude Opus 4.8 (1M)" ;;
             "claude-sonnet-4-6[1m]") MODEL_NAME="Claude Sonnet 4.6 (1M)" ;;
             claude-haiku-4-5)        MODEL_NAME="Claude Haiku 4.5" ;;
             *)                       MODEL_NAME="$MODEL_ID" ;;
@@ -263,7 +263,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           case "$MODEL_ID" in
-            "claude-opus-4-7[1m]")   MODEL_NAME="Claude Opus 4.7 (1M)" ;;
+            "claude-opus-4-8[1m]")   MODEL_NAME="Claude Opus 4.8 (1M)" ;;
             "claude-sonnet-4-6[1m]") MODEL_NAME="Claude Sonnet 4.6 (1M)" ;;
             claude-haiku-4-5)        MODEL_NAME="Claude Haiku 4.5" ;;
             "")                      MODEL_NAME="(model not resolved)" ;;


### PR DESCRIPTION
## Summary

Point the Claude GitHub worker (`.github/workflows/claude.yml`) at **Opus 4.8 (1M)**, which supersedes the previously pinned Opus 4.7.

Three call sites updated:
1. **Model resolver** — `@claude opus` shorthand and the no-model default now resolve to `claude-opus-4-8[1m]`.
2. **Issue-comment footer** — display name map emits `Claude Opus 4.8 (1M)`.
3. **PR-body footer** — display name map emits `Claude Opus 4.8 (1M)`.

Sonnet 4.6 and Haiku 4.5 are unchanged (still the latest of their tiers). No `4.7`/`4-7` references remain in the file.

## Effect

`@claude` and `@claude opus` invocations run on Opus 4.8 (1M); the `LLM:` footer on the worker's PRs/comments reads `Claude Opus 4.8 (1M)`.

Workflow-only change — no build/test impact.

---
LLM: Claude Opus 4.8 (1M) | high | Harness: Claude Code