### PR TITLE
ci: default Claude GitHub worker effort to xhigh

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -100,9 +100,9 @@ jobs:
           echo "model_id=$MODEL_ID" >> "$GITHUB_OUTPUT"
           echo "::notice::Using model: $MODEL_ID"
 
-          # Extract optional effort level from comment: "effort:low", "effort:medium", "effort:high"
-          EFFORT_RAW=$(printf '%s' "$STRIPPED" | grep -oiE 'effort:(low|medium|high)' | head -1 | tr '[:upper:]' '[:lower:]' | cut -d: -f2 || true)
-          EFFORT="${EFFORT_RAW:-high}"
+          # Extract optional effort level from comment: "effort:low", "effort:medium", "effort:high", "effort:xhigh"
+          EFFORT_RAW=$(printf '%s' "$STRIPPED" | grep -oiE 'effort:(low|medium|xhigh|high)' | head -1 | tr '[:upper:]' '[:lower:]' | cut -d: -f2 || true)
+          EFFORT="${EFFORT_RAW:-xhigh}"
           echo "effort=$EFFORT" >> "$GITHUB_OUTPUT"
           echo "::notice::Using effort: $EFFORT"
 


### PR DESCRIPTION
Change the default `@claude` invocation effort from `high` to `xhigh` in the GitHub Actions worker.

## Changes
- **Default effort** (`.github/workflows/claude.yml`): `high` → `xhigh`. Any `@claude` invocation without an explicit `effort:` directive now runs at xhigh.
- **Effort parser**: extended the regex from `(low|medium|high)` to `(low|medium|xhigh|high)` so users can still request any level explicitly via `effort:xhigh` (ordered before `high` to avoid partial-match ambiguity).

The resolved effort flows unchanged into `claude_args: --effort …` and the LLM footer, so comment/PR footers now read `| xhigh |` by default.

---
LLM: Claude Opus 4.8 (1M) | xhigh | Harness: Claude Code