### PR TITLE
Dashboard: dark mode

### DIFF
--- a/scheduler/static/ui/app.js
+++ b/scheduler/static/ui/app.js
@@ -15,6 +15,8 @@
     subtitle: document.getElementById("active-subtitle"),
     chart: document.getElementById("chart"),
     empty: document.getElementById("empty-chart"),
+    darkToggle: document.getElementById("dark-mode-toggle"),
+    darkIcon: document.getElementById("dark-mode-icon"),
     refresh: document.getElementById("refresh-button"),
     interval: document.getElementById("refresh-interval"),
     statusDot: document.getElementById("status-dot"),
@@ -41,21 +43,58 @@
     return res.json();
   }
 
-  function initChart() {
-    if (state.chart) return;
-    state.chart = LightweightCharts.createChart(els.chart, {
+  function isDarkMode() {
+    return document.documentElement.classList.contains("dark");
+  }
+
+  function chartThemeOptions() {
+    const dark = isDarkMode();
+    return {
       layout: {
-        background: { type: "solid", color: "#ffffff" },
-        textColor: "#334139",
+        background: { type: "solid", color: dark ? "#1a211c" : "#ffffff" },
+        textColor: dark ? "#c5cec8" : "#334139",
       },
       grid: {
-        vertLines: { color: "#eef1eb" },
-        horzLines: { color: "#eef1eb" },
+        vertLines: { color: dark ? "#2b342f" : "#eef1eb" },
+        horzLines: { color: dark ? "#2b342f" : "#eef1eb" },
       },
-      rightPriceScale: { borderColor: "#d8ddd2" },
-      timeScale: { borderColor: "#d8ddd2", timeVisible: true },
+      rightPriceScale: { borderColor: dark ? "#3a4540" : "#d8ddd2" },
+      timeScale: { borderColor: dark ? "#3a4540" : "#d8ddd2" },
+    };
+  }
+
+  function applyChartTheme() {
+    if (!state.chart) return;
+    state.chart.applyOptions(chartThemeOptions());
+  }
+
+  function updateDarkModeToggle() {
+    const dark = isDarkMode();
+    els.darkToggle.setAttribute("aria-pressed", dark ? "true" : "false");
+    els.darkToggle.title = dark ? "Light mode" : "Dark mode";
+    els.darkIcon.textContent = dark ? "☀" : "☾";
+  }
+
+  function setDarkMode(enabled) {
+    document.documentElement.classList.toggle("dark", enabled);
+    try {
+      window.localStorage.setItem("goTraderDarkMode", enabled ? "1" : "0");
+    } catch (e) {}
+    updateDarkModeToggle();
+    applyChartTheme();
+  }
+
+  function initDarkMode() {
+    updateDarkModeToggle();
+    applyChartTheme();
+  }
+
+  function initChart() {
+    if (state.chart) return;
+    state.chart = LightweightCharts.createChart(els.chart, Object.assign({
+      timeScale: { timeVisible: true },
       crosshair: { mode: LightweightCharts.CrosshairMode.Normal },
-    });
+    }, chartThemeOptions()));
     state.series = state.chart.addCandlestickSeries({
       upColor: "#0f8a5f",
       downColor: "#c23b3b",
@@ -256,6 +295,7 @@
   }
 
   async function boot() {
+    initDarkMode();
     initChart();
     const resp = await getJSON("/api/strategies");
     state.strategies = resp.strategies || [];
@@ -267,6 +307,9 @@
   }
 
   els.search.addEventListener("input", renderStrategies);
+  els.darkToggle.addEventListener("click", function () {
+    setDarkMode(!isDarkMode());
+  });
   els.refresh.addEventListener("click", refreshAll);
   els.interval.addEventListener("change", scheduleRefresh);
   els.authPanel.addEventListener("submit", function (event) {

--- a/scheduler/static/ui/app.js
+++ b/scheduler/static/ui/app.js
@@ -59,7 +59,7 @@
         horzLines: { color: dark ? "#2b342f" : "#eef1eb" },
       },
       rightPriceScale: { borderColor: dark ? "#3a4540" : "#d8ddd2" },
-      timeScale: { borderColor: dark ? "#3a4540" : "#d8ddd2" },
+      timeScale: { borderColor: dark ? "#3a4540" : "#d8ddd2", timeVisible: true },
     };
   }
 
@@ -84,17 +84,11 @@
     applyChartTheme();
   }
 
-  function initDarkMode() {
-    updateDarkModeToggle();
-    applyChartTheme();
-  }
-
   function initChart() {
     if (state.chart) return;
-    state.chart = LightweightCharts.createChart(els.chart, Object.assign({
-      timeScale: { timeVisible: true },
+    state.chart = LightweightCharts.createChart(els.chart, Object.assign({}, chartThemeOptions(), {
       crosshair: { mode: LightweightCharts.CrosshairMode.Normal },
-    }, chartThemeOptions()));
+    }));
     state.series = state.chart.addCandlestickSeries({
       upColor: "#0f8a5f",
       downColor: "#c23b3b",
@@ -295,7 +289,7 @@
   }
 
   async function boot() {
-    initDarkMode();
+    updateDarkModeToggle();
     initChart();
     const resp = await getJSON("/api/strategies");
     state.strategies = resp.strategies || [];

--- a/scheduler/static/ui/index.html
+++ b/scheduler/static/ui/index.html
@@ -42,7 +42,7 @@
             <button id="dark-mode-toggle" class="icon-button" type="button" title="Dark mode" aria-label="Toggle dark mode" aria-pressed="false">
               <span id="dark-mode-icon" aria-hidden="true">☾</span>
             </button>
-            <button id="refresh-button" class="icon-button" title="Refresh" aria-label="Refresh">
+            <button id="refresh-button" class="icon-button" type="button" title="Refresh" aria-label="Refresh">
               <span aria-hidden="true">R</span>
             </button>
             <select id="refresh-interval" aria-label="Refresh interval">

--- a/scheduler/static/ui/index.html
+++ b/scheduler/static/ui/index.html
@@ -4,6 +4,15 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>go-trader dashboard</title>
+    <script>
+      (function () {
+        try {
+          if (window.localStorage.getItem("goTraderDarkMode") === "1") {
+            document.documentElement.classList.add("dark");
+          }
+        } catch (e) {}
+      })();
+    </script>
     <link rel="stylesheet" href="/dashboard/styles.css">
   </head>
   <body>
@@ -30,6 +39,9 @@
             <p id="active-subtitle">Select a strategy</p>
           </div>
           <div class="toolbar">
+            <button id="dark-mode-toggle" class="icon-button" type="button" title="Dark mode" aria-label="Toggle dark mode" aria-pressed="false">
+              <span id="dark-mode-icon" aria-hidden="true">☾</span>
+            </button>
             <button id="refresh-button" class="icon-button" title="Refresh" aria-label="Refresh">
               <span aria-hidden="true">R</span>
             </button>

--- a/scheduler/static/ui/styles.css
+++ b/scheduler/static/ui/styles.css
@@ -11,6 +11,41 @@
   --blue: #2563eb;
   --amber: #a45f08;
   --shadow: 0 10px 30px rgba(31, 37, 28, 0.08);
+  --sidebar-bg: #fbfcf8;
+  --topbar-bg: rgba(255, 255, 255, 0.78);
+  --input-bg: #ffffff;
+  --strategy-hover: #eef2ea;
+  --strategy-active-border: #9db5a8;
+  --strategy-active-bg: #e8efe8;
+  --empty-bg: #ffffff;
+  --position-line: #edf0ea;
+  --auth-bg: #fff8e8;
+  --auth-border: #e2c17d;
+  --focus-ring: rgba(15, 138, 95, 0.16);
+  --focus-border: #2f6f51;
+}
+
+html.dark {
+  color-scheme: dark;
+  --bg: #121614;
+  --panel: #1a211c;
+  --line: #2b342f;
+  --line-strong: #3a4540;
+  --text: #e6ebe7;
+  --muted: #8b968f;
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.42);
+  --sidebar-bg: #161b18;
+  --topbar-bg: rgba(22, 27, 24, 0.92);
+  --input-bg: #1f2622;
+  --strategy-hover: #232b27;
+  --strategy-active-border: #4a5f54;
+  --strategy-active-bg: #28332d;
+  --empty-bg: #1a211c;
+  --position-line: #2b342f;
+  --auth-bg: #2a2418;
+  --auth-border: #6b5528;
+  --focus-ring: rgba(47, 168, 118, 0.22);
+  --focus-border: #3d9a6f;
 }
 
 * {
@@ -43,7 +78,7 @@ select {
 
 .sidebar {
   border-right: 1px solid var(--line);
-  background: #fbfcf8;
+  background: var(--sidebar-bg);
   padding: 18px 14px;
   overflow: auto;
 }
@@ -113,7 +148,7 @@ h3 {
 .toolbar select {
   width: 100%;
   border: 1px solid var(--line-strong);
-  background: #ffffff;
+  background: var(--input-bg);
   color: var(--text);
   border-radius: 6px;
   padding: 9px 10px;
@@ -123,8 +158,8 @@ h3 {
 .search-wrap input:focus,
 .toolbar select:focus,
 .icon-button:focus {
-  border-color: #2f6f51;
-  box-shadow: 0 0 0 3px rgba(15, 138, 95, 0.16);
+  border-color: var(--focus-border);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .strategy-list {
@@ -154,12 +189,12 @@ h3 {
 }
 
 .strategy-button:hover {
-  background: #eef2ea;
+  background: var(--strategy-hover);
 }
 
 .strategy-button.active {
-  border-color: #9db5a8;
-  background: #e8efe8;
+  border-color: var(--strategy-active-border);
+  background: var(--strategy-active-bg);
 }
 
 .strategy-id {
@@ -192,7 +227,7 @@ h3 {
   align-items: center;
   gap: 16px;
   border-bottom: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.78);
+  background: var(--topbar-bg);
   padding: 18px 22px;
 }
 
@@ -208,11 +243,16 @@ h3 {
   width: 40px;
   height: 40px;
   border: 1px solid var(--line-strong);
-  background: #ffffff;
+  background: var(--input-bg);
   color: var(--text);
   border-radius: 6px;
   cursor: pointer;
   font-weight: 800;
+}
+
+.icon-button[aria-pressed="true"] {
+  border-color: var(--focus-border);
+  background: var(--strategy-active-bg);
 }
 
 .content {
@@ -249,7 +289,7 @@ h3 {
   align-items: center;
   justify-content: center;
   color: var(--muted);
-  background: #ffffff;
+  background: var(--empty-bg);
 }
 
 .status-panel {
@@ -284,8 +324,8 @@ h3 {
 .auth-panel {
   display: grid;
   gap: 10px;
-  border: 1px solid #e2c17d;
-  background: #fff8e8;
+  border: 1px solid var(--auth-border);
+  background: var(--auth-bg);
   border-radius: 8px;
   padding: 12px;
   margin-bottom: 14px;
@@ -308,7 +348,7 @@ h3 {
   border-radius: 6px;
   padding: 9px 10px;
   color: var(--text);
-  background: #ffffff;
+  background: var(--input-bg);
 }
 
 .auth-panel button {
@@ -349,7 +389,7 @@ h3 {
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 6px 10px;
-  border-bottom: 1px solid #edf0ea;
+  border-bottom: 1px solid var(--position-line);
   padding: 9px 0;
   font-size: 13px;
 }

--- a/scheduler/static/ui/styles.css
+++ b/scheduler/static/ui/styles.css
@@ -33,6 +33,8 @@ html.dark {
   --line-strong: #3a4540;
   --text: #e6ebe7;
   --muted: #8b968f;
+  --green: #22c47e;
+  --red: #e06060;
   --shadow: 0 10px 30px rgba(0, 0, 0, 0.42);
   --sidebar-bg: #161b18;
   --topbar-bg: rgba(22, 27, 24, 0.92);


### PR DESCRIPTION
## Summary
- Topbar toggle persists dark mode to `localStorage` (`goTraderDarkMode`)
- Inline head script applies `html.dark` before paint to avoid flash
- CSS variable overrides and chart theme sync via `applyChartTheme()`

## Test plan
- [ ] Toggle dark mode; reload page and confirm preference persists
- [ ] Verify chart/grid colors update in dark mode
- [ ] Check sidebar, topbar, status panel, and auth panel readability

Closes #804