### PR TITLE
Dashboard: PnL sparklines / equity curve per strategy

### DIFF
--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -257,68 +257,7 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Always fetch prices for all configured spot symbols + any with open
-	// positions (in case config changed). Perps marks come from venue-native
-	// fetchers below (#263), not BinanceUS, so we only pull spot symbols here.
-	symbolSet := make(map[string]bool)
-	for _, sym := range ss.priceSymbols {
-		symbolSet[sym] = true
-	}
-	ss.mu.RLock()
-	for _, s := range ss.state.Strategies {
-		for sym := range s.Positions {
-			// Include only spot-style keys (contain "/") to avoid routing
-			// HL/OKX perps position keys through BinanceUS (#263).
-			if strings.Contains(sym, "/") {
-				symbolSet[sym] = true
-			}
-		}
-	}
-	ss.mu.RUnlock()
-
-	symbols := make([]string, 0, len(symbolSet))
-	for s := range symbolSet {
-		symbols = append(symbols, s)
-	}
-
-	// Fetch live prices WITHOUT holding the lock.
-	prices := make(map[string]float64)
-	if len(symbols) > 0 {
-		p, err := FetchPrices(symbols)
-		if err == nil {
-			prices = p
-		}
-	}
-	// HL perps marks — venue-native oracle (#263). Best-effort.
-	if len(ss.hlPerpsCoins) > 0 {
-		if hlMarks, err := fetchHyperliquidMids(ss.hlPerpsCoins); err == nil {
-			mergePerpsMarks(prices, hlMarks)
-		} else {
-			ss.logHLPerpsErrThrottled(err)
-		}
-	}
-	// OKX perps marks — venue-native oracle (#263). Best-effort.
-	if len(ss.okxPerpsCoins) > 0 {
-		if okxMarks, err := fetchOKXPerpsMids(ss.okxPerpsCoins); err == nil {
-			mergePerpsMarks(prices, okxMarks)
-		} else {
-			ss.logOKXPerpsErrThrottled(err)
-		}
-	}
-	// Fetch CME futures marks on their separate rail (#261). Best-effort:
-	// on error, open futures positions fall back to pos.AvgCost. Errors are
-	// throttle-logged so repeated /status polls don't spam on a sustained
-	// outage, but the first failure (and periodic reminders) remain visible.
-	if len(ss.futuresSymbols) > 0 {
-		if marks, mode, err := FetchFuturesMarks(ss.futuresSymbols); err == nil {
-			if mode == FuturesMarkModePaperFallback {
-				ss.logFuturesModeThrottled()
-			}
-			mergeFuturesMarks(prices, marks)
-		} else {
-			ss.logFuturesErrThrottled(err)
-		}
-	}
+	prices := ss.fetchLiveMarkPrices()
 
 	// Re-acquire read lock to build the response
 	ss.mu.RLock()
@@ -443,6 +382,61 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
+}
+
+// fetchLiveMarkPrices returns best-effort mark prices for /status and dashboard
+// API handlers. Call without holding ss.mu.
+func (ss *StatusServer) fetchLiveMarkPrices() map[string]float64 {
+	symbolSet := make(map[string]bool)
+	for _, sym := range ss.priceSymbols {
+		symbolSet[sym] = true
+	}
+	ss.mu.RLock()
+	for _, s := range ss.state.Strategies {
+		for sym := range s.Positions {
+			if strings.Contains(sym, "/") {
+				symbolSet[sym] = true
+			}
+		}
+	}
+	ss.mu.RUnlock()
+
+	symbols := make([]string, 0, len(symbolSet))
+	for s := range symbolSet {
+		symbols = append(symbols, s)
+	}
+
+	prices := make(map[string]float64)
+	if len(symbols) > 0 {
+		if p, err := FetchPrices(symbols); err == nil {
+			prices = p
+		}
+	}
+	if len(ss.hlPerpsCoins) > 0 {
+		if hlMarks, err := fetchHyperliquidMids(ss.hlPerpsCoins); err == nil {
+			mergePerpsMarks(prices, hlMarks)
+		} else {
+			ss.logHLPerpsErrThrottled(err)
+		}
+	}
+	if len(ss.okxPerpsCoins) > 0 {
+		if okxMarks, err := fetchOKXPerpsMids(ss.okxPerpsCoins); err == nil {
+			mergePerpsMarks(prices, okxMarks)
+		} else {
+			ss.logOKXPerpsErrThrottled(err)
+		}
+	}
+	if len(ss.futuresSymbols) > 0 {
+		if marks, mode, err := FetchFuturesMarks(ss.futuresSymbols); err == nil {
+			if mode == FuturesMarkModePaperFallback {
+				ss.logFuturesModeThrottled()
+			}
+			mergeFuturesMarks(prices, marks)
+		} else {
+			ss.logFuturesErrThrottled(err)
+		}
+	}
+	return prices
 }
 
 func (ss *StatusServer) handleHistory(w http.ResponseWriter, r *http.Request) {

--- a/scheduler/server_test.go
+++ b/scheduler/server_test.go
@@ -435,6 +435,103 @@ func TestHandleAPIStrategyTradesMarkers(t *testing.T) {
 	}
 }
 
+func TestBuildEquityCurvePoints(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(24 * time.Hour)
+	t2 := t0.Add(48 * time.Hour)
+	closed := []ClosedPosition{
+		{OpenedAt: t0, ClosedAt: t1, RealizedPnL: 50},
+		{OpenedAt: t1, ClosedAt: t2, RealizedPnL: -20},
+	}
+	points := buildEquityCurvePoints(1000, closed, 1030, 10)
+	if len(points) != 4 {
+		t.Fatalf("len = %d, want 4 (start + 2 closes + current)", len(points))
+	}
+	if points[0].T != t0.Unix() || points[0].V != 1000 {
+		t.Errorf("start = %+v, want t=%d v=1000", points[0], t0.Unix())
+	}
+	if points[1].T != t1.Unix() || points[1].V != 1050 {
+		t.Errorf("after first close = %+v, want v=1050", points[1])
+	}
+	if points[2].T != t2.Unix() || points[2].V != 1030 {
+		t.Errorf("after second close = %+v, want v=1030", points[2])
+	}
+	if points[3].V != 1030 {
+		t.Errorf("final value = %v, want 1030", points[3].V)
+	}
+
+	trimmed := buildEquityCurvePoints(1000, closed, 1030, 2)
+	if len(trimmed) != 2 {
+		t.Fatalf("trimmed len = %d, want 2", len(trimmed))
+	}
+	if trimmed[0].V != 1030 || trimmed[1].V != 1030 {
+		t.Errorf("trimmed keeps most recent points, got %+v", trimmed)
+	}
+}
+
+func TestHandleAPIStrategyEquity(t *testing.T) {
+	db := openTestDB(t)
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"spot-btc": {
+				ID:             "spot-btc",
+				Type:           "spot",
+				Cash:           1010,
+				InitialCapital: 1000,
+				Positions:      map[string]*Position{},
+				ClosedPositions: []ClosedPosition{
+					{
+						StrategyID: "spot-btc", Symbol: "BTC/USDT", Quantity: 1, AvgCost: 100,
+						Side: "long", OpenedAt: now.Add(-2 * time.Hour), ClosedAt: now.Add(-time.Hour),
+						ClosePrice: 110, RealizedPnL: 10, CloseReason: "signal",
+					},
+				},
+			},
+		},
+	}
+	if err := db.SaveState(state); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	var mu sync.RWMutex
+	ss := NewStatusServer(state, &mu, "", []StrategyConfig{
+		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 1000, Args: []string{"sma", "BTC/USDT", "1h"}},
+	}, db)
+
+	req := httptest.NewRequest("GET", "/api/strategies/spot-btc/equity?limit=40", nil)
+	w := httptest.NewRecorder()
+	ss.handleAPIStrategy(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp struct {
+		StrategyID string          `json:"strategy_id"`
+		Points     []UIEquityPoint `json:"points"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.StrategyID != "spot-btc" {
+		t.Errorf("strategy_id = %q, want spot-btc", resp.StrategyID)
+	}
+	if len(resp.Points) < 2 {
+		t.Fatalf("points len = %d, want at least 2", len(resp.Points))
+	}
+	if resp.Points[0].V != 1000 {
+		t.Errorf("first point value = %v, want 1000", resp.Points[0].V)
+	}
+	foundClose := false
+	for _, p := range resp.Points {
+		if p.T == now.Add(-time.Hour).Unix() && p.V == 1010 {
+			foundClose = true
+		}
+	}
+	if !foundClose {
+		t.Errorf("missing close point at %+v", resp.Points)
+	}
+}
+
 func TestHandleAPIReturnsDraining(t *testing.T) {
 	shutdownDraining.Store(false)
 	beginDrain()

--- a/scheduler/static/ui/app.js
+++ b/scheduler/static/ui/app.js
@@ -8,7 +8,11 @@
     chart: null,
     series: null,
     timer: 0,
+    sparklines: {},
   };
+
+  const SPARKLINE_LIMIT = 40;
+  const SPARKLINE_FETCH_CAP = 30;
 
   const els = {
     count: document.getElementById("strategy-count"),
@@ -206,12 +210,16 @@
     }, {});
   }
 
-  function renderStrategies() {
+  function filteredStrategies() {
     const query = els.search.value.trim().toLowerCase();
-    const filtered = state.strategies.filter(function (s) {
+    return state.strategies.filter(function (s) {
       const haystack = [s.id, s.platform, s.symbol, s.timeframe, s.strategy].join(" ").toLowerCase();
       return haystack.includes(query);
     });
+  }
+
+  function renderStrategies() {
+    const filtered = filteredStrategies();
     els.count.textContent = filtered.length + " strategies";
     els.list.innerHTML = "";
     const groups = groupStrategies(filtered);
@@ -226,7 +234,10 @@
         button.type = "button";
         button.dataset.id = strategy.id;
         button.innerHTML =
-          '<span class="strategy-id"></span><span class="strategy-symbol"></span><span class="strategy-meta"></span>';
+          '<span class="strategy-id"></span>' +
+          '<canvas class="strategy-sparkline" width="48" height="28" aria-hidden="true"></canvas>' +
+          '<span class="strategy-symbol"></span>' +
+          '<span class="strategy-meta"></span>';
         button.querySelector(".strategy-id").textContent = strategy.id;
         button.querySelector(".strategy-symbol").textContent = strategy.symbol || "-";
         button.querySelector(".strategy-meta").textContent =
@@ -235,8 +246,72 @@
           selectStrategy(strategy.id);
         });
         els.list.appendChild(button);
+        const cached = state.sparklines[strategy.id];
+        if (cached) {
+          drawSparkline(button.querySelector(".strategy-sparkline"), cached);
+        }
       });
     });
+    loadSparklines(filtered.map(function (s) {
+      return s.id;
+    }));
+  }
+
+  function drawSparkline(canvas, points) {
+    if (!canvas || !points || points.length < 2) {
+      return;
+    }
+    const dpr = window.devicePixelRatio || 1;
+    const cssW = canvas.clientWidth || 48;
+    const cssH = canvas.clientHeight || 28;
+    canvas.width = Math.round(cssW * dpr);
+    canvas.height = Math.round(cssH * dpr);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssW, cssH);
+
+    const values = points.map(function (p) {
+      return Number(p.v);
+    });
+    const min = Math.min.apply(null, values);
+    const max = Math.max.apply(null, values);
+    const span = max - min || 1;
+    const pad = 2;
+    const up = values[values.length - 1] >= values[0];
+    const color = up ? "#0f8a5f" : "#c23b3b";
+
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.5;
+    ctx.lineJoin = "round";
+    ctx.lineCap = "round";
+    ctx.beginPath();
+    values.forEach(function (value, index) {
+      const x = pad + (index / (values.length - 1)) * (cssW - pad * 2);
+      const y = pad + (1 - (value - min) / span) * (cssH - pad * 2);
+      if (index === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+  }
+
+  async function loadSparklines(ids) {
+    const unique = Array.from(new Set(ids)).slice(0, SPARKLINE_FETCH_CAP);
+    await Promise.all(unique.map(async function (id) {
+      try {
+        const resp = await getJSON(
+          "/api/strategies/" + encodeURIComponent(id) + "/equity?limit=" + SPARKLINE_LIMIT
+        );
+        const points = resp.points || [];
+        state.sparklines[id] = points;
+        const button = els.list.querySelector('.strategy-button[data-id="' + CSS.escape(id) + '"]');
+        if (button) {
+          drawSparkline(button.querySelector(".strategy-sparkline"), points);
+        }
+      } catch (_err) {
+        // Sidebar sparklines are best-effort; ignore per-strategy failures.
+      }
+    }));
   }
 
   function activeStrategy() {

--- a/scheduler/static/ui/app.js
+++ b/scheduler/static/ui/app.js
@@ -12,7 +12,6 @@
   };
 
   const SPARKLINE_LIMIT = 40;
-  const SPARKLINE_FETCH_CAP = 30;
 
   const els = {
     count: document.getElementById("strategy-count"),
@@ -296,7 +295,7 @@
   }
 
   async function loadSparklines(ids) {
-    const unique = Array.from(new Set(ids)).slice(0, SPARKLINE_FETCH_CAP);
+    const unique = Array.from(new Set(ids));
     await Promise.all(unique.map(async function (id) {
       try {
         const resp = await getJSON(
@@ -452,7 +451,13 @@
 
   async function refreshAll() {
     try {
-      await Promise.all([refreshChart(), refreshStatus()]);
+      await Promise.all([
+        refreshChart(),
+        refreshStatus(),
+        loadSparklines(filteredStrategies().map(function (s) {
+          return s.id;
+        })),
+      ]);
     } catch (err) {
       if (err.status === 401) {
         showAuthPrompt();
@@ -467,7 +472,14 @@
   function scheduleRefresh() {
     if (state.timer) clearInterval(state.timer);
     const ms = Number(els.interval.value);
-    if (ms > 0) state.timer = setInterval(refreshStatus, ms);
+    if (ms > 0) {
+      state.timer = setInterval(function () {
+        refreshStatus();
+        loadSparklines(filteredStrategies().map(function (s) {
+          return s.id;
+        }));
+      }, ms);
+    }
   }
 
   function fmtMoney(value) {

--- a/scheduler/static/ui/styles.css
+++ b/scheduler/static/ui/styles.css
@@ -178,7 +178,8 @@ h3 {
 
 .strategy-button {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: minmax(0, 1fr) auto 52px;
+  grid-template-rows: auto auto;
   gap: 4px 10px;
   width: 100%;
   border: 1px solid transparent;
@@ -215,6 +216,16 @@ h3 {
 
 .strategy-symbol {
   justify-self: end;
+}
+
+.strategy-sparkline {
+  grid-column: 3;
+  grid-row: 1 / span 2;
+  align-self: center;
+  justify-self: end;
+  width: 48px;
+  height: 28px;
+  display: block;
 }
 
 .workspace {

--- a/scheduler/ui_server.go
+++ b/scheduler/ui_server.go
@@ -52,6 +52,11 @@ type UIStrategyStatus struct {
 	MarginMode      string                     `json:"margin_mode,omitempty"`
 }
 
+type UIEquityPoint struct {
+	T int64   `json:"t"`
+	V float64 `json:"v"`
+}
+
 type UITradeMarker struct {
 	Time        int64   `json:"time"`
 	Position    string  `json:"position"`
@@ -152,6 +157,8 @@ func (ss *StatusServer) handleAPIStrategy(w http.ResponseWriter, r *http.Request
 		ss.handleAPIStrategyTrades(w, r, id)
 	case "status":
 		ss.handleAPIStrategyStatus(w, r, id)
+	case "equity":
+		ss.handleAPIStrategyEquity(w, r, id)
 	default:
 		http.NotFound(w, r)
 	}
@@ -399,6 +406,120 @@ func (ss *StatusServer) handleAPIStrategyStatus(w http.ResponseWriter, r *http.R
 		MarginMode:      sc.MarginMode,
 	}
 	writeJSON(w, resp)
+}
+
+func (ss *StatusServer) handleAPIStrategyEquity(w http.ResponseWriter, r *http.Request, id string) {
+	sc, ok := ss.strategyConfig(id)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "strategy not found")
+		return
+	}
+
+	ss.mu.RLock()
+	strat := ss.state.Strategies[id]
+	var snapshot StrategyState
+	if strat != nil {
+		snapshot = *strat
+	}
+	ss.mu.RUnlock()
+	if strat == nil {
+		writeJSONError(w, http.StatusNotFound, "strategy state not found")
+		return
+	}
+
+	initCap := EffectiveInitialCapital(sc, &snapshot)
+	pv := PortfolioValue(&snapshot, map[string]float64{})
+
+	closed := []ClosedPosition{}
+	if ss.stateDB != nil {
+		rows, _, err := ss.stateDB.QueryClosedPositions(id, "", time.Time{}, time.Time{}, sharpeLookbackLimit, 0)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		closed = make([]ClosedPosition, len(rows))
+		for i := len(rows) - 1; i >= 0; i-- {
+			closed[len(rows)-1-i] = rows[i]
+		}
+	}
+
+	limit := parseUIEquityLimit(r)
+	points := buildEquityCurvePoints(initCap, closed, pv, limit)
+	writeJSON(w, map[string]interface{}{
+		"strategy_id": id,
+		"points":      points,
+	})
+}
+
+// buildEquityCurvePoints builds a mini equity curve from initial capital, realized
+// PnL at each closed position (ASC), and the current portfolio value.
+func buildEquityCurvePoints(initCap float64, closed []ClosedPosition, currentPV float64, limit int) []UIEquityPoint {
+	if limit <= 0 {
+		limit = 40
+	}
+	if limit > 500 {
+		limit = 500
+	}
+
+	sorted := append([]ClosedPosition(nil), closed...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].ClosedAt.Equal(sorted[j].ClosedAt) {
+			return sorted[i].OpenedAt.Before(sorted[j].OpenedAt)
+		}
+		return sorted[i].ClosedAt.Before(sorted[j].ClosedAt)
+	})
+
+	points := make([]UIEquityPoint, 0, len(sorted)+2)
+	equity := initCap
+
+	var startT int64
+	if len(sorted) > 0 {
+		cp := sorted[0]
+		if !cp.OpenedAt.IsZero() {
+			startT = cp.OpenedAt.UTC().Unix()
+		} else if !cp.ClosedAt.IsZero() {
+			startT = cp.ClosedAt.UTC().Unix()
+		}
+	}
+	if startT == 0 {
+		startT = time.Now().UTC().Unix()
+	}
+	points = append(points, UIEquityPoint{T: startT, V: initCap})
+
+	for _, cp := range sorted {
+		if cp.ClosedAt.IsZero() {
+			continue
+		}
+		equity += cp.RealizedPnL
+		points = append(points, UIEquityPoint{
+			T: cp.ClosedAt.UTC().Unix(),
+			V: equity,
+		})
+	}
+
+	now := time.Now().UTC().Unix()
+	last := points[len(points)-1]
+	if last.V != currentPV || last.T != now {
+		points = append(points, UIEquityPoint{T: now, V: currentPV})
+	}
+
+	if len(points) > limit {
+		points = points[len(points)-limit:]
+	}
+	return points
+}
+
+func parseUIEquityLimit(r *http.Request) int {
+	limit := 40
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	return limit
 }
 
 func parseUITimeQuery(r *http.Request) (from, to time.Time, limit int) {

--- a/scheduler/ui_server.go
+++ b/scheduler/ui_server.go
@@ -424,6 +424,8 @@ func (ss *StatusServer) handleAPIStrategyEquity(w http.ResponseWriter, r *http.R
 	var snapshot StrategyState
 	if strat != nil {
 		snapshot = *strat
+		snapshot.Positions = cloneUIPositions(strat.Positions)
+		snapshot.OptionPositions = cloneUIOptionPositions(strat.OptionPositions)
 	}
 	ss.mu.RUnlock()
 	if strat == nil {
@@ -432,8 +434,9 @@ func (ss *StatusServer) handleAPIStrategyEquity(w http.ResponseWriter, r *http.R
 	}
 
 	initCap := EffectiveInitialCapital(sc, &snapshot)
-	prices := ss.fetchLiveMarkPrices()
-	pv := PortfolioValue(&snapshot, prices)
+	// Cost-basis terminal point only — avoids N× external mark fetches when
+	// loadSparklines polls one equity URL per visible strategy (#813).
+	pv := PortfolioValue(&snapshot, map[string]float64{})
 
 	var closed []ClosedPosition
 	if ss.stateDB != nil {

--- a/scheduler/ui_server.go
+++ b/scheduler/ui_server.go
@@ -57,6 +57,10 @@ type UIEquityPoint struct {
 	V float64 `json:"v"`
 }
 
+// uiEquityLookbackLimit caps closed-position rows for dashboard equity curves (#805).
+// Independent of sharpeLookbackLimit so Sharpe tuning does not shrink sparklines.
+const uiEquityLookbackLimit = 500
+
 type UITradeMarker struct {
 	Time        int64   `json:"time"`
 	Position    string  `json:"position"`
@@ -357,7 +361,7 @@ func (ss *StatusServer) handleAPIStrategyStatus(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	prices := make(map[string]float64)
+	prices := ss.fetchLiveMarkPrices()
 	pv := PortfolioValue(&snapshot, prices)
 	initCap := EffectiveInitialCapital(sc, &snapshot)
 	pnl := pv - initCap
@@ -428,19 +432,17 @@ func (ss *StatusServer) handleAPIStrategyEquity(w http.ResponseWriter, r *http.R
 	}
 
 	initCap := EffectiveInitialCapital(sc, &snapshot)
-	pv := PortfolioValue(&snapshot, map[string]float64{})
+	prices := ss.fetchLiveMarkPrices()
+	pv := PortfolioValue(&snapshot, prices)
 
-	closed := []ClosedPosition{}
+	var closed []ClosedPosition
 	if ss.stateDB != nil {
-		rows, _, err := ss.stateDB.QueryClosedPositions(id, "", time.Time{}, time.Time{}, sharpeLookbackLimit, 0)
+		rows, _, err := ss.stateDB.QueryClosedPositions(id, "", time.Time{}, time.Time{}, uiEquityLookbackLimit, 0)
 		if err != nil {
 			writeJSONError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-		closed = make([]ClosedPosition, len(rows))
-		for i := len(rows) - 1; i >= 0; i-- {
-			closed[len(rows)-1-i] = rows[i]
-		}
+		closed = rows
 	}
 
 	limit := parseUIEquityLimit(r)


### PR DESCRIPTION
## Summary
- New `GET /api/strategies/{id}/equity?limit=40` builds curve from initial capital, closed positions, and current portfolio value
- Sidebar strategy cards render canvas sparklines (green/red by trend)

## Test plan
- [ ] `go test ./... -run 'Equity|Sparkline'` in scheduler
- [ ] Open dashboard with multiple strategies; confirm sparklines load
- [ ] Strategies with no closed positions show flat/minimal line

Closes #805