### PR TITLE
Dashboard: sortable strategy overview table

### DIFF
--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -190,6 +190,7 @@ func (ss *StatusServer) Start(port int) {
 	mux.HandleFunc("/dashboard", ss.handleDashboard)
 	mux.HandleFunc("/dashboard/", ss.handleDashboard)
 	mux.HandleFunc("/api/strategies", ss.handleAPIStrategies)
+	mux.HandleFunc("/api/strategies/overview", ss.handleAPIStrategiesOverview)
 	mux.HandleFunc("/api/strategies/", ss.handleAPIStrategy)
 
 	listener, boundPort, err := bindWithFallback(port, statusPortMaxAttempts)

--- a/scheduler/server_test.go
+++ b/scheduler/server_test.go
@@ -359,6 +359,73 @@ func TestHandleAPIStrategies(t *testing.T) {
 	}
 }
 
+func TestHandleAPIStrategiesOverview(t *testing.T) {
+	state := NewAppState()
+	state.Strategies["spot-btc"] = &StrategyState{
+		ID:              "spot-btc",
+		Type:            "spot",
+		Cash:            1100,
+		InitialCapital:  1000,
+		Regime:          "trending",
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+	}
+	state.Strategies["okx-eth"] = &StrategyState{
+		ID:              "okx-eth",
+		Type:            "perps",
+		Cash:            800,
+		InitialCapital:  1000,
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+	}
+	var mu sync.RWMutex
+	strategies := []StrategyConfig{
+		{ID: "okx-eth", Platform: "okx", Type: "perps", Args: []string{"ema", "ETH", "4h"}, Direction: DirectionBoth},
+		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Args: []string{"sma", "BTC/USDT", "1h"}},
+	}
+	ss := NewStatusServer(state, &mu, "", strategies, nil)
+
+	req := httptest.NewRequest("GET", "/api/strategies/overview", nil)
+	w := httptest.NewRecorder()
+	ss.handleAPIStrategiesOverview(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp struct {
+		Strategies []UIStrategyOverview `json:"strategies"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Strategies) != 2 {
+		t.Fatalf("strategies len = %d, want 2", len(resp.Strategies))
+	}
+	byID := make(map[string]UIStrategyOverview, len(resp.Strategies))
+	for _, row := range resp.Strategies {
+		byID[row.ID] = row
+	}
+	spot := byID["spot-btc"]
+	if spot.Platform != "binanceus" || spot.Symbol != "BTC/USDT" {
+		t.Errorf("spot-btc row = %+v, want binanceus BTC/USDT", spot)
+	}
+	if spot.PnL != 100 || spot.PnLPct != 10 {
+		t.Errorf("spot-btc pnl = %v/%v, want 100/10", spot.PnL, spot.PnLPct)
+	}
+	if spot.Regime != "trending" {
+		t.Errorf("spot-btc regime = %q, want trending", spot.Regime)
+	}
+	if spot.Direction != "" {
+		t.Errorf("spot-btc direction = %q, want empty", spot.Direction)
+	}
+	okx := byID["okx-eth"]
+	if okx.Direction != DirectionBoth {
+		t.Errorf("okx-eth direction = %q, want %q", okx.Direction, DirectionBoth)
+	}
+	if okx.PnL != -200 || okx.PnLPct != -20 {
+		t.Errorf("okx-eth pnl = %v/%v, want -200/-20", okx.PnL, okx.PnLPct)
+	}
+}
+
 func TestHandleAPIStrategyCandles_UsesFetcherAndCache(t *testing.T) {
 	state := NewAppState()
 	var mu sync.RWMutex

--- a/scheduler/static/ui/app.js
+++ b/scheduler/static/ui/app.js
@@ -1,7 +1,12 @@
 (function () {
+  const VIEW_MODE_KEY = "goTraderViewMode";
   const state = {
     strategies: [],
+    overviewRows: [],
     activeID: "",
+    viewMode: "detail",
+    sortKey: "id",
+    sortDir: "asc",
     chart: null,
     series: null,
     timer: 0,
@@ -16,6 +21,7 @@
     chart: document.getElementById("chart"),
     empty: document.getElementById("empty-chart"),
     refresh: document.getElementById("refresh-button"),
+    viewMode: document.getElementById("view-mode-button"),
     interval: document.getElementById("refresh-interval"),
     statusDot: document.getElementById("status-dot"),
     statusLabel: document.getElementById("status-label"),
@@ -23,6 +29,9 @@
     authToken: document.getElementById("auth-token"),
     statusGrid: document.getElementById("status-grid"),
     positions: document.getElementById("positions-list"),
+    overviewPanel: document.getElementById("overview-panel"),
+    overviewBody: document.getElementById("overview-body"),
+    detailPanel: document.getElementById("detail-panel"),
   };
 
   function authHeaders() {
@@ -39,6 +48,31 @@
       throw err;
     }
     return res.json();
+  }
+
+  function loadViewMode() {
+    const saved = window.localStorage.getItem(VIEW_MODE_KEY);
+    return saved === "table" ? "table" : "detail";
+  }
+
+  function saveViewMode(mode) {
+    window.localStorage.setItem(VIEW_MODE_KEY, mode);
+  }
+
+  function applyViewMode() {
+    const tableMode = state.viewMode === "table";
+    els.overviewPanel.hidden = !tableMode;
+    els.detailPanel.hidden = tableMode;
+    els.viewMode.textContent = tableMode ? "Detail" : "Table";
+    els.viewMode.setAttribute("aria-pressed", tableMode ? "true" : "false");
+    document.querySelector(".content").classList.toggle("content-table", tableMode);
+  }
+
+  function toggleViewMode() {
+    state.viewMode = state.viewMode === "table" ? "detail" : "table";
+    saveViewMode(state.viewMode);
+    applyViewMode();
+    refreshAll().catch(handleRefreshError);
   }
 
   function initChart() {
@@ -118,7 +152,8 @@
     });
   }
 
-  async function selectStrategy(id) {
+  async function selectStrategy(id, options) {
+    const opts = options || {};
     state.activeID = id;
     const strategy = activeStrategy();
     if (strategy) {
@@ -126,6 +161,11 @@
       els.subtitle.textContent = [strategy.platform, strategy.symbol, strategy.timeframe].filter(Boolean).join(" / ");
     }
     renderStrategies();
+    if (opts.switchToDetail) {
+      state.viewMode = "detail";
+      saveViewMode(state.viewMode);
+      applyViewMode();
+    }
     await refreshAll();
   }
 
@@ -209,24 +249,91 @@
       escapeHTML(side || "-") + '</span><span>' + escapeHTML(detail) + '</span><span></span></div>';
   }
 
-  async function refreshAll() {
-    try {
-      await Promise.all([refreshChart(), refreshStatus()]);
-    } catch (err) {
-      if (err.status === 401) {
-        showAuthPrompt();
-        return;
-      }
-      els.statusDot.className = "status-dot error";
-      els.statusLabel.textContent = "Error";
-      els.statusGrid.innerHTML = "<dt>Message</dt><dd>" + escapeHTML(err.message) + "</dd>";
+  function sortValue(row, key) {
+    if (key === "pnl_pct" || key === "win_rate" || key === "sharpe") {
+      const n = Number(row[key]);
+      return Number.isFinite(n) ? n : -Infinity;
     }
+    const value = row[key];
+    return value === undefined || value === null ? "" : String(value).toLowerCase();
+  }
+
+  function sortedOverviewRows() {
+    const rows = state.overviewRows.slice();
+    const dir = state.sortDir === "desc" ? -1 : 1;
+    rows.sort(function (a, b) {
+      const av = sortValue(a, state.sortKey);
+      const bv = sortValue(b, state.sortKey);
+      if (av < bv) return -1 * dir;
+      if (av > bv) return 1 * dir;
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
+    return rows;
+  }
+
+  function updateSortButtons() {
+    document.querySelectorAll(".sort-button").forEach(function (button) {
+      const key = button.dataset.key;
+      const active = key === state.sortKey;
+      button.classList.toggle("active", active);
+      button.setAttribute("aria-sort", active ? (state.sortDir === "asc" ? "ascending" : "descending") : "none");
+    });
+  }
+
+  function renderOverviewTable() {
+    const rows = sortedOverviewRows();
+    els.overviewBody.innerHTML = rows.map(function (row) {
+      const pnlClass = row.pnl_pct > 0 ? "pnl-pos" : row.pnl_pct < 0 ? "pnl-neg" : "";
+      return '<tr class="overview-row' + (row.id === state.activeID ? " active" : "") + '" data-id="' + escapeHTML(row.id) + '">' +
+        "<td>" + escapeHTML(row.id) + "</td>" +
+        "<td>" + escapeHTML(row.platform || "-") + "</td>" +
+        "<td>" + escapeHTML(row.symbol || "-") + "</td>" +
+        '<td class="' + pnlClass + '">' + escapeHTML(fmtPct(row.pnl_pct)) + "</td>" +
+        "<td>" + escapeHTML(row.win_rate ? fmtPct(row.win_rate) : "-") + "</td>" +
+        "<td>" + escapeHTML(row.sharpe ? fmtNumber(row.sharpe) : "-") + "</td>" +
+        "<td>" + escapeHTML(row.regime || "-") + "</td>" +
+        "<td>" + escapeHTML(row.direction || "-") + "</td>" +
+        "</tr>";
+    }).join("");
+    updateSortButtons();
+  }
+
+  async function refreshOverview() {
+    const resp = await getJSON("/api/strategies/overview");
+    state.overviewRows = resp.strategies || [];
+    renderOverviewTable();
+    els.statusDot.className = "status-dot ok";
+    els.statusLabel.textContent = "Live";
+    els.statusGrid.innerHTML = "<dt>Strategies</dt><dd>" + escapeHTML(String(state.overviewRows.length)) + "</dd>";
+    els.positions.innerHTML = '<div class="position-row"><span>Table view</span><span>Select a row for detail</span></div>';
+  }
+
+  async function refreshAll() {
+    if (state.viewMode === "table") {
+      await refreshOverview();
+      return;
+    }
+    await Promise.all([refreshChart(), refreshStatus()]);
+  }
+
+  function handleRefreshError(err) {
+    if (err.status === 401) {
+      showAuthPrompt();
+      return;
+    }
+    els.statusDot.className = "status-dot error";
+    els.statusLabel.textContent = "Error";
+    els.statusGrid.innerHTML = "<dt>Message</dt><dd>" + escapeHTML(err.message) + "</dd>";
   }
 
   function scheduleRefresh() {
     if (state.timer) clearInterval(state.timer);
     const ms = Number(els.interval.value);
-    if (ms > 0) state.timer = setInterval(refreshStatus, ms);
+    if (ms > 0) {
+      state.timer = setInterval(function () {
+        refreshAll().catch(handleRefreshError);
+      }, ms);
+    }
   }
 
   function fmtMoney(value) {
@@ -256,19 +363,43 @@
   }
 
   async function boot() {
+    state.viewMode = loadViewMode();
+    applyViewMode();
     initChart();
     const resp = await getJSON("/api/strategies");
     state.strategies = resp.strategies || [];
     renderStrategies();
     if (state.strategies.length) {
       await selectStrategy(state.strategies[0].id);
+    } else {
+      await refreshAll();
     }
     scheduleRefresh();
   }
 
   els.search.addEventListener("input", renderStrategies);
-  els.refresh.addEventListener("click", refreshAll);
+  els.refresh.addEventListener("click", function () {
+    refreshAll().catch(handleRefreshError);
+  });
+  els.viewMode.addEventListener("click", toggleViewMode);
   els.interval.addEventListener("change", scheduleRefresh);
+  els.overviewBody.addEventListener("click", function (event) {
+    const row = event.target.closest(".overview-row");
+    if (!row || !row.dataset.id) return;
+    selectStrategy(row.dataset.id, { switchToDetail: true }).catch(handleRefreshError);
+  });
+  document.querySelectorAll(".sort-button").forEach(function (button) {
+    button.addEventListener("click", function () {
+      const key = button.dataset.key;
+      if (state.sortKey === key) {
+        state.sortDir = state.sortDir === "asc" ? "desc" : "asc";
+      } else {
+        state.sortKey = key;
+        state.sortDir = "asc";
+      }
+      renderOverviewTable();
+    });
+  });
   els.authPanel.addEventListener("submit", function (event) {
     event.preventDefault();
     const token = els.authToken.value.trim();
@@ -285,9 +416,7 @@
       showAuthPrompt();
       return;
     }
-    els.statusDot.className = "status-dot error";
-    els.statusLabel.textContent = "Error";
-    els.statusGrid.innerHTML = "<dt>Message</dt><dd>" + escapeHTML(err.message) + "</dd>";
+    handleRefreshError(err);
   });
 
   function showAuthPrompt() {

--- a/scheduler/static/ui/app.js
+++ b/scheduler/static/ui/app.js
@@ -139,7 +139,7 @@
         button.querySelector(".strategy-meta").textContent =
           [strategy.type, strategy.timeframe, strategy.direction].filter(Boolean).join(" / ");
         button.addEventListener("click", function () {
-          selectStrategy(strategy.id);
+          selectStrategy(strategy.id).catch(handleRefreshError);
         });
         els.list.appendChild(button);
       });

--- a/scheduler/static/ui/index.html
+++ b/scheduler/static/ui/index.html
@@ -30,6 +30,7 @@
             <p id="active-subtitle">Select a strategy</p>
           </div>
           <div class="toolbar">
+            <button id="view-mode-button" class="view-mode-button" type="button" aria-pressed="false">Detail</button>
             <button id="refresh-button" class="icon-button" title="Refresh" aria-label="Refresh">
               <span aria-hidden="true">R</span>
             </button>
@@ -43,6 +44,24 @@
         </header>
 
         <section class="content">
+          <div id="overview-panel" class="overview-panel" hidden>
+            <table class="overview-table">
+              <thead>
+                <tr>
+                  <th scope="col"><button type="button" class="sort-button" data-key="id">ID</button></th>
+                  <th scope="col"><button type="button" class="sort-button" data-key="platform">Platform</button></th>
+                  <th scope="col"><button type="button" class="sort-button" data-key="symbol">Symbol</button></th>
+                  <th scope="col"><button type="button" class="sort-button" data-key="pnl_pct">PnL %</button></th>
+                  <th scope="col"><button type="button" class="sort-button" data-key="win_rate">Win Rate</button></th>
+                  <th scope="col"><button type="button" class="sort-button" data-key="sharpe">Sharpe</button></th>
+                  <th scope="col"><button type="button" class="sort-button" data-key="regime">Regime</button></th>
+                  <th scope="col"><button type="button" class="sort-button" data-key="direction">Direction</button></th>
+                </tr>
+              </thead>
+              <tbody id="overview-body"></tbody>
+            </table>
+          </div>
+          <div id="detail-panel" class="detail-panel">
           <div class="chart-panel">
             <div id="chart"></div>
             <div id="empty-chart" class="empty-state">No candles yet</div>
@@ -65,6 +84,7 @@
               <div id="positions-list"></div>
             </div>
           </aside>
+          </div>
         </section>
       </main>
     </div>

--- a/scheduler/static/ui/styles.css
+++ b/scheduler/static/ui/styles.css
@@ -215,12 +215,116 @@ h3 {
   font-weight: 800;
 }
 
+.view-mode-button {
+  border: 1px solid var(--line-strong);
+  background: #ffffff;
+  color: var(--text);
+  border-radius: 6px;
+  padding: 0 14px;
+  height: 40px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.view-mode-button[aria-pressed="true"] {
+  border-color: #2f6f51;
+  background: #e8efe8;
+}
+
 .content {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
   gap: 18px;
   padding: 18px;
   min-height: 0;
+}
+
+.content.content-table {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.detail-panel {
+  display: contents;
+}
+
+.detail-panel[hidden] {
+  display: none;
+}
+
+.overview-panel {
+  grid-column: 1 / -1;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  overflow: auto;
+}
+
+.overview-panel[hidden] {
+  display: none;
+}
+
+.overview-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.overview-table th,
+.overview-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #edf0ea;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.overview-table th {
+  position: sticky;
+  top: 0;
+  background: #fbfcf8;
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  z-index: 1;
+}
+
+.sort-button {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-transform: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+
+.sort-button.active {
+  color: var(--text);
+  font-weight: 700;
+}
+
+.overview-row {
+  cursor: pointer;
+}
+
+.overview-row:hover {
+  background: #eef2ea;
+}
+
+.overview-row.active {
+  background: #e8efe8;
+}
+
+.overview-table td {
+  font-variant-numeric: tabular-nums;
+}
+
+.pnl-pos {
+  color: var(--green);
+}
+
+.pnl-neg {
+  color: var(--red);
 }
 
 .chart-panel,

--- a/scheduler/ui_server.go
+++ b/scheduler/ui_server.go
@@ -27,6 +27,19 @@ type UIStrategy struct {
 	Direction string `json:"direction,omitempty"`
 }
 
+type UIStrategyOverview struct {
+	ID             string  `json:"id"`
+	Platform       string  `json:"platform"`
+	Symbol         string  `json:"symbol"`
+	PnLPct         float64 `json:"pnl_pct"`
+	WinRate        float64 `json:"win_rate,omitempty"`
+	Sharpe         float64 `json:"sharpe,omitempty"`
+	Regime         string  `json:"regime,omitempty"`
+	Direction      string  `json:"direction,omitempty"`
+	PnL            float64 `json:"pnl"`
+	PortfolioValue float64 `json:"portfolio_value"`
+}
+
 type UIStrategyStatus struct {
 	ID              string                     `json:"id"`
 	Type            string                     `json:"type"`
@@ -127,6 +140,34 @@ func (ss *StatusServer) handleAPIStrategies(w http.ResponseWriter, r *http.Reque
 	strategies := ss.uiStrategies()
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string][]UIStrategy{"strategies": strategies})
+}
+
+func (ss *StatusServer) handleAPIStrategiesOverview(w http.ResponseWriter, r *http.Request) {
+	if ss.rejectIfDraining(w) {
+		return
+	}
+	if !ss.requireAPIAuth(w, r) {
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if r.URL.Path != "/api/strategies/overview" && r.URL.Path != "/api/strategies/overview/" {
+		http.NotFound(w, r)
+		return
+	}
+
+	configs := ss.uiStrategies()
+	out := make([]UIStrategyOverview, 0, len(configs))
+	for _, item := range configs {
+		overview, _, ok := ss.uiStrategyOverview(item.ID)
+		if !ok {
+			continue
+		}
+		out = append(out, overview)
+	}
+	writeJSON(w, map[string][]UIStrategyOverview{"strategies": out})
 }
 
 func (ss *StatusServer) handleAPIStrategy(w http.ResponseWriter, r *http.Request) {
@@ -327,11 +368,10 @@ func (ss *StatusServer) handleAPIStrategyTrades(w http.ResponseWriter, r *http.R
 	})
 }
 
-func (ss *StatusServer) handleAPIStrategyStatus(w http.ResponseWriter, r *http.Request, id string) {
+func (ss *StatusServer) uiStrategyOverview(id string) (UIStrategyOverview, LifetimeTradeStats, bool) {
 	sc, ok := ss.strategyConfig(id)
 	if !ok {
-		writeJSONError(w, http.StatusNotFound, "strategy not found")
-		return
+		return UIStrategyOverview{}, LifetimeTradeStats{}, false
 	}
 
 	ss.mu.RLock()
@@ -339,15 +379,10 @@ func (ss *StatusServer) handleAPIStrategyStatus(w http.ResponseWriter, r *http.R
 	var snapshot StrategyState
 	if strat != nil {
 		snapshot = *strat
-		snapshot.Positions = cloneUIPositions(strat.Positions)
-		snapshot.OptionPositions = cloneUIOptionPositions(strat.OptionPositions)
-		snapshot.TradeHistory = append([]Trade(nil), strat.TradeHistory...)
-		snapshot.RiskState = cloneUIRiskState(strat.RiskState)
 	}
 	ss.mu.RUnlock()
 	if strat == nil {
-		writeJSONError(w, http.StatusNotFound, "strategy state not found")
-		return
+		return UIStrategyOverview{}, LifetimeTradeStats{}, false
 	}
 
 	prices := make(map[string]float64)
@@ -374,23 +409,62 @@ func (ss *StatusServer) handleAPIStrategyStatus(w http.ResponseWriter, r *http.R
 		winRate = float64(lifetime.Wins) / float64(lifetime.Wins+lifetime.Losses) * 100
 	}
 
+	return UIStrategyOverview{
+		ID:             id,
+		Platform:       sc.Platform,
+		Symbol:         strategyDisplaySymbol(sc),
+		PnLPct:         pnlPct,
+		WinRate:        winRate,
+		Sharpe:         sharpe,
+		Regime:         snapshot.Regime,
+		Direction:      strategyDisplayDirection(sc),
+		PnL:            pnl,
+		PortfolioValue: pv,
+	}, lifetime, true
+}
+
+func (ss *StatusServer) handleAPIStrategyStatus(w http.ResponseWriter, r *http.Request, id string) {
+	sc, ok := ss.strategyConfig(id)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "strategy not found")
+		return
+	}
+	overview, lifetime, ok := ss.uiStrategyOverview(id)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "strategy state not found")
+		return
+	}
+
+	ss.mu.RLock()
+	strat := ss.state.Strategies[id]
+	var snapshot StrategyState
+	if strat != nil {
+		snapshot = *strat
+		snapshot.Positions = cloneUIPositions(strat.Positions)
+		snapshot.OptionPositions = cloneUIOptionPositions(strat.OptionPositions)
+		snapshot.TradeHistory = append([]Trade(nil), strat.TradeHistory...)
+		snapshot.RiskState = cloneUIRiskState(strat.RiskState)
+	}
+	ss.mu.RUnlock()
+
+	initCap := EffectiveInitialCapital(sc, &snapshot)
 	resp := UIStrategyStatus{
-		ID:              id,
+		ID:              overview.ID,
 		Type:            sc.Type,
-		Platform:        sc.Platform,
-		Symbol:          strategyDisplaySymbol(sc),
+		Platform:        overview.Platform,
+		Symbol:          overview.Symbol,
 		Timeframe:       strategyDisplayTimeframe(sc),
-		Direction:       strategyDisplayDirection(sc),
+		Direction:       overview.Direction,
 		Cash:            snapshot.Cash,
 		InitialCapital:  initCap,
-		PortfolioValue:  pv,
-		PnL:             pnl,
-		PnLPct:          pnlPct,
+		PortfolioValue:  overview.PortfolioValue,
+		PnL:             overview.PnL,
+		PnLPct:          overview.PnLPct,
 		TradeCount:      len(snapshot.TradeHistory),
-		WinRate:         winRate,
+		WinRate:         overview.WinRate,
 		LifetimeStats:   lifetime,
-		Sharpe:          sharpe,
-		Regime:          snapshot.Regime,
+		Sharpe:          overview.Sharpe,
+		Regime:          overview.Regime,
 		RiskState:       snapshot.RiskState,
 		Positions:       snapshot.Positions,
 		OptionPositions: snapshot.OptionPositions,

--- a/scheduler/ui_server.go
+++ b/scheduler/ui_server.go
@@ -38,6 +38,7 @@ type UIStrategyOverview struct {
 	Direction      string  `json:"direction,omitempty"`
 	PnL            float64 `json:"pnl"`
 	PortfolioValue float64 `json:"portfolio_value"`
+	InitialCapital float64 `json:"initial_capital"`
 }
 
 type UIStrategyStatus struct {
@@ -420,6 +421,7 @@ func (ss *StatusServer) uiStrategyOverview(id string) (UIStrategyOverview, Lifet
 		Direction:      strategyDisplayDirection(sc),
 		PnL:            pnl,
 		PortfolioValue: pv,
+		InitialCapital: initCap,
 	}, lifetime, true
 }
 
@@ -446,8 +448,11 @@ func (ss *StatusServer) handleAPIStrategyStatus(w http.ResponseWriter, r *http.R
 		snapshot.RiskState = cloneUIRiskState(strat.RiskState)
 	}
 	ss.mu.RUnlock()
+	if strat == nil {
+		writeJSONError(w, http.StatusNotFound, "strategy state not found")
+		return
+	}
 
-	initCap := EffectiveInitialCapital(sc, &snapshot)
 	resp := UIStrategyStatus{
 		ID:              overview.ID,
 		Type:            sc.Type,
@@ -456,7 +461,7 @@ func (ss *StatusServer) handleAPIStrategyStatus(w http.ResponseWriter, r *http.R
 		Timeframe:       strategyDisplayTimeframe(sc),
 		Direction:       overview.Direction,
 		Cash:            snapshot.Cash,
-		InitialCapital:  initCap,
+		InitialCapital:  overview.InitialCapital,
 		PortfolioValue:  overview.PortfolioValue,
 		PnL:             overview.PnL,
 		PnLPct:          overview.PnLPct,


### PR DESCRIPTION
## Summary
- New `GET /api/strategies/overview` returns per-strategy stats in one request
- Table/Detail toggle in topbar with client-side column sorting
- Row click selects strategy and returns to detail view

## Test plan
- [ ] `go test ./... -run Overview` in scheduler
- [ ] Switch to Table view; sort by PnL %, win rate, Sharpe
- [ ] Click row → detail view with correct strategy selected

Closes #806