### PR TITLE
Dashboard: trade history panel

### DIFF
--- a/scheduler/server_test.go
+++ b/scheduler/server_test.go
@@ -398,12 +398,13 @@ func TestHandleAPIStrategyTradesMarkers(t *testing.T) {
 	db := openTestDB(t)
 	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
 	if err := db.InsertTrade("spot-btc", Trade{
-		Timestamp: now, Symbol: "BTC/USDT", Side: "buy", Quantity: 1, Price: 100,
+		Timestamp: now, Symbol: "BTC/USDT", Side: "buy", Quantity: 1, Price: 100, Regime: "trending",
 	}); err != nil {
 		t.Fatalf("InsertTrade open: %v", err)
 	}
 	if err := db.InsertTrade("spot-btc", Trade{
-		Timestamp: now.Add(time.Hour), Symbol: "BTC/USDT", Side: "sell", Quantity: 1, Price: 110, IsClose: true, RealizedPnL: 10,
+		Timestamp: now.Add(time.Hour), Symbol: "BTC/USDT", Side: "sell", Quantity: 1, Price: 110,
+		IsClose: true, RealizedPnL: 10, Regime: "ranging",
 	}); err != nil {
 		t.Fatalf("InsertTrade close: %v", err)
 	}
@@ -422,16 +423,26 @@ func TestHandleAPIStrategyTradesMarkers(t *testing.T) {
 	}
 	var resp struct {
 		Markers []UITradeMarker `json:"markers"`
+		Trades  []UITradeMarker `json:"trades"`
 		Total   int             `json:"total"`
 	}
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.Total != 2 || len(resp.Markers) != 2 {
-		t.Fatalf("total/markers = %d/%d, want 2/2", resp.Total, len(resp.Markers))
+	if resp.Total != 2 || len(resp.Markers) != 2 || len(resp.Trades) != 2 {
+		t.Fatalf("total/markers/trades = %d/%d/%d, want 2/2/2", resp.Total, len(resp.Markers), len(resp.Trades))
 	}
 	if resp.Markers[0].Text != "BUY" || resp.Markers[1].Text != "CLOSE" {
 		t.Errorf("marker texts = %q/%q, want BUY/CLOSE", resp.Markers[0].Text, resp.Markers[1].Text)
+	}
+	if resp.Trades[0].Text != "BUY" || resp.Trades[1].Text != "CLOSE" {
+		t.Errorf("trade texts = %q/%q, want BUY/CLOSE", resp.Trades[0].Text, resp.Trades[1].Text)
+	}
+	if resp.Markers[0].Regime != "trending" || resp.Markers[1].Regime != "ranging" {
+		t.Errorf("marker regimes = %q/%q, want trending/ranging", resp.Markers[0].Regime, resp.Markers[1].Regime)
+	}
+	if resp.Trades[0].Regime != "trending" || resp.Trades[1].Regime != "ranging" {
+		t.Errorf("trade regimes = %q/%q, want trending/ranging", resp.Trades[0].Regime, resp.Trades[1].Regime)
 	}
 }
 

--- a/scheduler/static/ui/app.js
+++ b/scheduler/static/ui/app.js
@@ -14,7 +14,11 @@
     title: document.getElementById("active-title"),
     subtitle: document.getElementById("active-subtitle"),
     chart: document.getElementById("chart"),
+    chartWrap: document.querySelector(".chart-wrap"),
     empty: document.getElementById("empty-chart"),
+    tradeHistoryBody: document.getElementById("trade-history-body"),
+    tradeHistoryEmpty: document.getElementById("trade-history-empty"),
+    tradeHistoryTable: document.querySelector(".trade-history-table"),
     refresh: document.getElementById("refresh-button"),
     interval: document.getElementById("refresh-interval"),
     statusDot: document.getElementById("status-dot"),
@@ -65,9 +69,10 @@
       wickDownColor: "#c23b3b",
     });
     new ResizeObserver(function () {
-      const rect = els.chart.getBoundingClientRect();
+      const target = els.chartWrap || els.chart;
+      const rect = target.getBoundingClientRect();
       state.chart.resize(Math.max(320, rect.width), Math.max(320, rect.height));
-    }).observe(els.chart);
+    }).observe(els.chartWrap || els.chart);
   }
 
   function groupStrategies(strategies) {
@@ -155,6 +160,81 @@
     }));
     els.empty.style.display = candles.length ? "none" : "flex";
     if (candles.length) state.chart.timeScale().fitContent();
+    renderTradeHistory(tradeResp.trades || tradeResp.markers || []);
+  }
+
+  function tradeRowsForDisplay(rows) {
+    const list = (rows || []).slice();
+    list.reverse();
+    return list;
+  }
+
+  function tradeSideLabel(trade) {
+    if (trade.text) return trade.text;
+    if (!trade.side) return "-";
+    return trade.is_close ? "CLOSE" : String(trade.side).toUpperCase();
+  }
+
+  function tradeSideClass(trade) {
+    const label = tradeSideLabel(trade);
+    if (label === "BUY") return "trade-history-side-buy";
+    if (label === "SELL") return "trade-history-side-sell";
+    if (label === "CLOSE") {
+      return String(trade.side).toLowerCase() === "buy" ? "trade-history-side-buy" : "trade-history-side-sell";
+    }
+    return "";
+  }
+
+  function tradePnLCell(trade) {
+    if (!trade.is_close) return "-";
+    if (trade.realized_pnl === undefined || trade.realized_pnl === null) return "-";
+    return fmtSignedMoney(trade.realized_pnl);
+  }
+
+  function tradeRowClass(trade) {
+    if (!trade.is_close || trade.realized_pnl === undefined || trade.realized_pnl === null) {
+      return "";
+    }
+    if (trade.realized_pnl > 0) return "trade-history-row pnl-win";
+    if (trade.realized_pnl < 0) return "trade-history-row pnl-loss";
+    return "trade-history-row";
+  }
+
+  function fmtTradeTime(unixSeconds) {
+    if (!unixSeconds) return "-";
+    return new Date(unixSeconds * 1000).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+
+  function renderTradeHistory(rows) {
+    const trades = tradeRowsForDisplay(rows);
+    if (!trades.length) {
+      els.tradeHistoryBody.innerHTML = "";
+      els.tradeHistoryEmpty.hidden = false;
+      els.tradeHistoryTable.hidden = true;
+      return;
+    }
+    els.tradeHistoryEmpty.hidden = true;
+    els.tradeHistoryTable.hidden = false;
+    els.tradeHistoryBody.innerHTML = trades.map(function (trade) {
+      const sideClass = tradeSideClass(trade);
+      const rowClass = tradeRowClass(trade);
+      return (
+        "<tr class=\"" + escapeHTML(rowClass) + "\">" +
+        "<td>" + escapeHTML(fmtTradeTime(trade.time)) + "</td>" +
+        "<td class=\"" + escapeHTML(sideClass) + "\">" + escapeHTML(tradeSideLabel(trade)) + "</td>" +
+        "<td>" + escapeHTML(fmtMoney(trade.price)) + "</td>" +
+        "<td>" + escapeHTML(fmtNumber(trade.quantity)) + "</td>" +
+        "<td>" + escapeHTML(tradePnLCell(trade)) + "</td>" +
+        "<td>" + escapeHTML(trade.regime || "-") + "</td>" +
+        "<td>" + escapeHTML(trade.details || "-") + "</td>" +
+        "</tr>"
+      );
+    }).join("");
   }
 
   async function refreshStatus() {

--- a/scheduler/static/ui/app.js
+++ b/scheduler/static/ui/app.js
@@ -179,9 +179,10 @@
     const label = tradeSideLabel(trade);
     if (label === "BUY") return "trade-history-side-buy";
     if (label === "SELL") return "trade-history-side-sell";
-    if (label === "CLOSE") {
-      return String(trade.side).toLowerCase() === "buy" ? "trade-history-side-buy" : "trade-history-side-sell";
-    }
+    if (label === "CLOSE") return "";
+    const side = trade.side ? String(trade.side).toLowerCase() : "";
+    if (side === "buy") return "trade-history-side-buy";
+    if (side === "sell") return "trade-history-side-sell";
     return "";
   }
 

--- a/scheduler/static/ui/index.html
+++ b/scheduler/static/ui/index.html
@@ -44,8 +44,30 @@
 
         <section class="content">
           <div class="chart-panel">
-            <div id="chart"></div>
-            <div id="empty-chart" class="empty-state">No candles yet</div>
+            <div class="chart-wrap">
+              <div id="chart"></div>
+              <div id="empty-chart" class="empty-state">No candles yet</div>
+            </div>
+            <div id="trade-history" class="trade-history">
+              <h3>Trade history</h3>
+              <div class="trade-history-scroll">
+                <table class="trade-history-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Time</th>
+                      <th scope="col">Side</th>
+                      <th scope="col">Price</th>
+                      <th scope="col">Qty</th>
+                      <th scope="col">PnL</th>
+                      <th scope="col">Regime</th>
+                      <th scope="col">Details</th>
+                    </tr>
+                  </thead>
+                  <tbody id="trade-history-body"></tbody>
+                </table>
+                <p id="trade-history-empty" class="trade-history-empty" hidden>No trades yet</p>
+              </div>
+            </div>
           </div>
           <aside class="status-panel">
             <div class="status-header">

--- a/scheduler/static/ui/styles.css
+++ b/scheduler/static/ui/styles.css
@@ -232,9 +232,16 @@ h3 {
 }
 
 .chart-panel {
-  position: relative;
+  display: flex;
+  flex-direction: column;
   min-height: 520px;
   overflow: hidden;
+}
+
+.chart-wrap {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 320px;
 }
 
 #chart {
@@ -372,6 +379,97 @@ h3 {
 
 .pos-short {
   color: var(--red);
+}
+
+.trade-history {
+  flex: 0 0 auto;
+  border-top: 1px solid var(--line);
+  padding: 12px 14px 14px;
+  background: #fbfcf8;
+}
+
+.trade-history h3 {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+
+.trade-history-scroll {
+  max-height: 220px;
+  min-height: 160px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #ffffff;
+}
+
+.trade-history-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.trade-history-table thead {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: #f6f8f3;
+}
+
+.trade-history-table th,
+.trade-history-table td {
+  padding: 7px 10px;
+  text-align: left;
+  border-bottom: 1px solid #edf0ea;
+  white-space: nowrap;
+}
+
+.trade-history-table th {
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.trade-history-table td:last-child {
+  white-space: normal;
+  max-width: 180px;
+  overflow-wrap: anywhere;
+}
+
+.trade-history-row.pnl-win {
+  background: rgba(15, 138, 95, 0.08);
+}
+
+.trade-history-row.pnl-loss {
+  background: rgba(194, 59, 59, 0.08);
+}
+
+.trade-history-side-buy {
+  color: var(--green);
+  font-weight: 600;
+}
+
+.trade-history-side-sell {
+  color: var(--red);
+  font-weight: 600;
+}
+
+.trade-history-empty {
+  margin: 0;
+  padding: 24px 12px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.trade-history-empty[hidden],
+.trade-history-table[hidden] {
+  display: none;
 }
 
 @media (max-width: 980px) {

--- a/scheduler/ui_server.go
+++ b/scheduler/ui_server.go
@@ -64,6 +64,7 @@ type UITradeMarker struct {
 	Quantity    float64 `json:"quantity"`
 	RealizedPnL float64 `json:"realized_pnl,omitempty"`
 	Details     string  `json:"details,omitempty"`
+	Regime      string  `json:"regime,omitempty"`
 }
 
 func (ss *StatusServer) rejectIfDraining(w http.ResponseWriter) bool {
@@ -323,6 +324,7 @@ func (ss *StatusServer) handleAPIStrategyTrades(w http.ResponseWriter, r *http.R
 	writeJSON(w, map[string]interface{}{
 		"strategy_id": id,
 		"markers":     markers,
+		"trades":      tradeMarkersForTable(markers),
 		"total":       total,
 	})
 }
@@ -446,6 +448,7 @@ func tradeMarkers(trades []Trade) []UITradeMarker {
 			Quantity:    tr.Quantity,
 			RealizedPnL: tr.RealizedPnL,
 			Details:     tr.Details,
+			Regime:      tr.Regime,
 		}
 		if tr.IsClose {
 			m.Position = "aboveBar"
@@ -465,6 +468,16 @@ func tradeMarkers(trades []Trade) []UITradeMarker {
 		}
 		out = append(out, m)
 	}
+	return out
+}
+
+// tradeMarkersForTable returns markers oldest-first for table display (#808).
+func tradeMarkersForTable(markers []UITradeMarker) []UITradeMarker {
+	if len(markers) == 0 {
+		return nil
+	}
+	out := make([]UITradeMarker, len(markers))
+	copy(out, markers)
 	return out
 }
 

--- a/scheduler/ui_server.go
+++ b/scheduler/ui_server.go
@@ -471,10 +471,10 @@ func tradeMarkers(trades []Trade) []UITradeMarker {
 	return out
 }
 
-// tradeMarkersForTable returns markers oldest-first for table display (#808).
+// tradeMarkersForTable returns a copy of markers (already oldest-first from tradeMarkers) for the trades JSON key (#808).
 func tradeMarkersForTable(markers []UITradeMarker) []UITradeMarker {
 	if len(markers) == 0 {
-		return nil
+		return []UITradeMarker{}
 	}
 	out := make([]UITradeMarker, len(markers))
 	copy(out, markers)


### PR DESCRIPTION
## Summary
- Trades API exposes `regime` on markers and `trades` array (oldest-first)
- Scrollable trade history table below chart with PnL row coloring

## Test plan
- [ ] `go test ./... -run TestHandleAPIStrategyTrades` in scheduler
- [ ] Select strategy with trades; verify table columns and newest-first order
- [ ] Close legs show realized PnL coloring

Closes #808