### PR TITLE
Dashboard: strategy tuner page with live signal preview

### DIFF
--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -225,6 +225,7 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 	}
 	if server != nil {
 		server.UpdateStrategies(cfg.Strategies)
+		server.SetConfigContext(server.configPath, cfg.Regime)
 	}
 
 	sort.Strings(changes)

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -245,6 +245,7 @@ func main() {
 	// Start HTTP status server. Priority: CLI flag > config > default.
 	statusPort := resolveStatusPort(*statusPortFlag, cfg.StatusPort)
 	server := NewStatusServer(state, &mu, cfg.StatusToken, cfg.Strategies, stateDB)
+	server.SetConfigContext(*configPath, cfg.Regime)
 	server.Start(statusPort)
 
 	// Graceful shutdown — two-phase drain (see scheduler/shutdown.go).

--- a/scheduler/probe_cmd_test.go
+++ b/scheduler/probe_cmd_test.go
@@ -106,12 +106,12 @@ func TestRunProbeHappyPath(t *testing.T) {
 	if rc != 0 {
 		t.Fatalf("happy-path probe should return 0, got %d", rc)
 	}
-	// Expect 7 invocations: HL signal-check (adx+composite), HL --fetch-atr (#689),
-	// HL --execute (PR #769), spot signal-check (adx+composite), dashboard candle helper.
-	if len(probed) != 7 {
-		t.Fatalf("expected 7 probe invocations, got %d: %v", len(probed), probed)
+	// Expect 9 invocations: HL signal-check (adx+composite), HL --fetch-atr (#689),
+	// HL --execute (PR #769), spot signal-check (adx+composite), dashboard helpers.
+	if len(probed) != 9 {
+		t.Fatalf("expected 9 probe invocations, got %d: %v", len(probed), probed)
 	}
-	var hlSignal, hlFetchATR, hlExecute, spotSignal, candleHelper int
+	var hlSignal, hlFetchATR, hlExecute, spotSignal, candleHelper, schemaHelper, simulateHelper int
 	for _, p := range probed {
 		switch {
 		case p.script == "shared_scripts/check_hyperliquid.py" && p.mode == "signal":
@@ -124,11 +124,15 @@ func TestRunProbeHappyPath(t *testing.T) {
 			spotSignal++
 		case p.script == "shared_scripts/fetch_candles.py" && p.mode == "signal":
 			candleHelper++
+		case p.script == "shared_scripts/strategy_tuner_schema.py" && p.mode == "signal":
+			schemaHelper++
+		case p.script == "shared_scripts/simulate_strategy.py" && p.mode == "signal":
+			simulateHelper++
 		}
 	}
-	if hlSignal != 2 || hlFetchATR != 1 || hlExecute != 1 || spotSignal != 2 || candleHelper != 1 {
-		t.Fatalf("expected hl-signal=2, hl-fetch-atr=1, hl-execute=1, spot-signal=2, candle-helper=1; got %d/%d/%d/%d/%d (probed=%v)",
-			hlSignal, hlFetchATR, hlExecute, spotSignal, candleHelper, probed)
+	if hlSignal != 2 || hlFetchATR != 1 || hlExecute != 1 || spotSignal != 2 || candleHelper != 1 || schemaHelper != 1 || simulateHelper != 1 {
+		t.Fatalf("expected hl-signal=2, hl-fetch-atr=1, hl-execute=1, spot-signal=2, candle-helper=1, schema=1, simulate=1; got %d/%d/%d/%d/%d/%d/%d (probed=%v)",
+			hlSignal, hlFetchATR, hlExecute, spotSignal, candleHelper, schemaHelper, simulateHelper, probed)
 	}
 }
 

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -29,10 +29,11 @@ type StatusServer struct {
 	// UpdateStrategies is invoked from that path, so reusing `mu` here would
 	// deadlock. Readers on the /api/strategies path also benefit: they no
 	// longer contend with the scheduler's state writes during dashboard polls.
-	strategiesMu sync.RWMutex
-	strategies   []StrategyConfig // strategy configs for initial capital lookup
-	configPath   string           // live config file for tuner Apply (#811)
-	regime       *RegimeConfig    // global regime settings for simulate preview
+	strategiesMu  sync.RWMutex
+	strategies    []StrategyConfig // strategy configs for initial capital lookup
+	configPath    string           // live config file for tuner Apply (#811)
+	regime        *RegimeConfig    // global regime settings for simulate preview
+	configWriteMu sync.Mutex       // serializes dashboard config Apply writes
 
 	// Throttled logging for repeated mark-fetch failures on the /status
 	// rail. /status can be polled frequently (oncall dashboard, monitoring),

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -31,6 +31,8 @@ type StatusServer struct {
 	// longer contend with the scheduler's state writes during dashboard polls.
 	strategiesMu sync.RWMutex
 	strategies   []StrategyConfig // strategy configs for initial capital lookup
+	configPath   string           // live config file for tuner Apply (#811)
+	regime       *RegimeConfig    // global regime settings for simulate preview
 
 	// Throttled logging for repeated mark-fetch failures on the /status
 	// rail. /status can be polled frequently (oncall dashboard, monitoring),

--- a/scheduler/static/ui/app.js
+++ b/scheduler/static/ui/app.js
@@ -609,6 +609,16 @@
     refreshChart().catch(handleRefreshError);
   }
 
+  function tunerApplyRequiresRestartClient() {
+    const keys = Object.keys(state.tuner.overrides);
+    if (state.tuner.config && state.tuner.config.has_open_position) {
+      if (keys.indexOf("direction") >= 0 || keys.indexOf("invert_signal") >= 0 || keys.indexOf("leverage") >= 0) {
+        return true;
+      }
+    }
+    return keys.indexOf("htf_filter") >= 0;
+  }
+
   async function applyTunerConfig() {
     if (!state.activeID || !tunerHasOverrides()) return;
     const resp = await postJSON(
@@ -999,7 +1009,7 @@
   if (els.tunerApply) {
     els.tunerApply.addEventListener("click", function () {
       if (!state.tuner.config) return;
-      const restart = state.tuner.config.apply_requires_restart;
+      const restart = tunerApplyRequiresRestartClient();
       if (els.tunerConfirmText) {
         els.tunerConfirmText.textContent = restart
           ? "This writes tuned parameters to the live config file. Restart go-trader afterward — hot reload cannot apply most tuner fields."

--- a/scheduler/static/ui/app.js
+++ b/scheduler/static/ui/app.js
@@ -14,6 +14,15 @@
     series: null,
     timer: 0,
     sparklines: {},
+    tuner: {
+      config: null,
+      overrides: {},
+      liveMarkers: [],
+      simulatedMarkers: [],
+      previewActive: false,
+      simulateTimer: 0,
+      loading: false,
+    },
   };
 
   const SPARKLINE_LIMIT = 40;
@@ -49,6 +58,13 @@
     overviewPanel: document.getElementById("overview-panel"),
     overviewBody: document.getElementById("overview-body"),
     detailPanel: document.getElementById("detail-panel"),
+    tunerPanel: document.getElementById("tuner-panel"),
+    tunerForm: document.getElementById("tuner-form"),
+    tunerStatus: document.getElementById("tuner-status"),
+    tunerReset: document.getElementById("tuner-reset"),
+    tunerApply: document.getElementById("tuner-apply"),
+    tunerConfirmDialog: document.getElementById("tuner-confirm-dialog"),
+    tunerConfirmText: document.getElementById("tuner-confirm-text"),
   };
 
   function isMobileSidebar() {
@@ -140,6 +156,21 @@
   function authHeaders() {
     const token = window.localStorage.getItem("goTraderStatusToken");
     return token ? { Authorization: "Bearer " + token } : {};
+  }
+
+  async function postJSON(url, body) {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: Object.assign({ "Content-Type": "application/json" }, authHeaders()),
+      body: JSON.stringify(body || {}),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      const err = new Error(text || res.statusText);
+      err.status = res.status;
+      throw err;
+    }
+    return res.json();
   }
 
   async function getJSON(url) {
@@ -361,6 +392,7 @@
   async function selectStrategy(id, options) {
     const opts = options || {};
     state.activeID = id;
+    resetTunerState();
     updateRegimeBadge("");
     const strategy = activeStrategy();
     if (strategy) {
@@ -379,10 +411,255 @@
     await refreshAll();
   }
 
+  function resetTunerState() {
+    state.tuner.config = null;
+    state.tuner.overrides = {};
+    state.tuner.liveMarkers = [];
+    state.tuner.simulatedMarkers = [];
+    state.tuner.previewActive = false;
+    if (state.tuner.simulateTimer) {
+      clearTimeout(state.tuner.simulateTimer);
+      state.tuner.simulateTimer = 0;
+    }
+    updateTunerStatus();
+    if (els.tunerPanel) {
+      els.tunerPanel.hidden = true;
+    }
+    if (els.tunerForm) {
+      els.tunerForm.innerHTML = "";
+    }
+  }
+
+  function tunerHasOverrides() {
+    return Object.keys(state.tuner.overrides).length > 0;
+  }
+
+  function updateTunerStatus() {
+    if (!els.tunerStatus) return;
+    if (state.tuner.loading) {
+      els.tunerStatus.textContent = "Simulating…";
+      els.tunerStatus.className = "tuner-status preview";
+      return;
+    }
+    if (tunerHasOverrides()) {
+      els.tunerStatus.textContent = "Preview active";
+      els.tunerStatus.className = "tuner-status preview";
+      return;
+    }
+    els.tunerStatus.textContent = "Live config";
+    els.tunerStatus.className = "tuner-status";
+  }
+
+  function groupEditableFields(fields) {
+    const groups = { runtime: [], risk: [], open_params: [] };
+    (fields || []).forEach(function (field) {
+      const key = field.group || "open_params";
+      if (!groups[key]) groups[key] = [];
+      groups[key].push(field);
+    });
+    return groups;
+  }
+
+  function renderTunerForm(config) {
+    if (!els.tunerForm || !els.tunerPanel) return;
+    if (!config || !config.editable_fields || !config.editable_fields.length) {
+      els.tunerPanel.hidden = true;
+      els.tunerForm.innerHTML = "";
+      return;
+    }
+    els.tunerPanel.hidden = false;
+    const groups = groupEditableFields(config.editable_fields);
+    const groupLabels = {
+      runtime: "Runtime",
+      risk: "Risk",
+      open_params: "Indicator params",
+    };
+    let html = "";
+    ["runtime", "risk", "open_params"].forEach(function (groupKey) {
+      const fields = groups[groupKey] || [];
+      if (!fields.length) return;
+      html += '<div class="tuner-group-label">' + escapeHTML(groupLabels[groupKey] || groupKey) + "</div>";
+      fields.forEach(function (field) {
+        const value = state.tuner.overrides[field.key] !== undefined
+          ? state.tuner.overrides[field.key]
+          : field.value;
+        html += '<label class="tuner-field" data-key="' + escapeHTML(field.key) + '">';
+        html += "<span>" + escapeHTML(field.label || field.key) + "</span>";
+        if (field.type === "boolean") {
+          html += '<input type="checkbox" data-key="' + escapeHTML(field.key) + '"' +
+            (value ? " checked" : "") + ">";
+        } else if (field.type === "select") {
+          html += '<select data-key="' + escapeHTML(field.key) + '">';
+          (field.options || []).forEach(function (opt) {
+            html += '<option value="' + escapeHTML(opt) + '"' +
+              (String(value) === String(opt) ? " selected" : "") + ">" +
+              escapeHTML(opt) + "</option>";
+          });
+          html += "</select>";
+        } else {
+          html += '<input type="number" step="any" data-key="' + escapeHTML(field.key) + '" value="' +
+            escapeHTML(value === null || value === undefined ? "" : value) + '">';
+        }
+        html += "</label>";
+      });
+    });
+    els.tunerForm.innerHTML = html;
+  }
+
+  async function loadTunerConfig() {
+    if (!state.activeID) return;
+    const config = await getJSON("/api/strategies/" + encodeURIComponent(state.activeID) + "/config");
+    state.tuner.config = config;
+    renderTunerForm(config);
+  }
+
+  function buildSimulateOverrides() {
+    const overrides = {};
+    Object.keys(state.tuner.overrides).forEach(function (key) {
+      overrides[key] = state.tuner.overrides[key];
+    });
+    if (state.tuner.config && state.tuner.config.open_strategy && state.tuner.config.open_strategy.params) {
+      const paramOverrides = {};
+      Object.keys(overrides).forEach(function (key) {
+        if (key.indexOf("open_strategy.params.") === 0) {
+          paramOverrides[key.slice("open_strategy.params.".length)] = overrides[key];
+          delete overrides[key];
+        }
+      });
+      if (Object.keys(paramOverrides).length) {
+        overrides.open_strategy = {
+          name: state.tuner.config.open_strategy.name,
+          params: paramOverrides,
+        };
+      }
+    }
+    return overrides;
+  }
+
+  function scheduleSimulate() {
+    if (state.tuner.simulateTimer) {
+      clearTimeout(state.tuner.simulateTimer);
+    }
+    state.tuner.simulateTimer = setTimeout(function () {
+      runSimulate().catch(handleRefreshError);
+    }, 450);
+  }
+
+  async function runSimulate() {
+    if (!state.activeID) return;
+    if (!tunerHasOverrides()) {
+      state.tuner.previewActive = false;
+      state.tuner.liveMarkers = [];
+      state.tuner.simulatedMarkers = [];
+      updateTunerStatus();
+      await refreshChart();
+      return;
+    }
+    state.tuner.loading = true;
+    updateTunerStatus();
+    try {
+      const resp = await postJSON(
+        "/api/strategies/" + encodeURIComponent(state.activeID) + "/simulate",
+        { overrides: buildSimulateOverrides(), limit: 400 }
+      );
+      state.tuner.liveMarkers = resp.live_markers || [];
+      state.tuner.simulatedMarkers = resp.simulated_markers || [];
+      state.tuner.previewActive = true;
+      await refreshChart();
+    } finally {
+      state.tuner.loading = false;
+      updateTunerStatus();
+    }
+  }
+
+  function onTunerFieldChange(event) {
+    const target = event.target;
+    const key = target.dataset.key;
+    if (!key) return;
+    let value;
+    if (target.type === "checkbox") {
+      value = target.checked;
+    } else if (target.type === "number") {
+      value = target.value === "" ? null : Number(target.value);
+    } else {
+      value = target.value;
+    }
+    const base = state.tuner.config && state.tuner.config.editable_fields
+      ? state.tuner.config.editable_fields.find(function (f) { return f.key === key; })
+      : null;
+    const baseline = base ? base.value : undefined;
+    if (value === baseline || (value === null && (baseline === null || baseline === undefined))) {
+      delete state.tuner.overrides[key];
+    } else {
+      state.tuner.overrides[key] = value;
+    }
+    updateTunerStatus();
+    scheduleSimulate();
+  }
+
+  function resetTunerToLive() {
+    state.tuner.overrides = {};
+    if (state.tuner.config) {
+      renderTunerForm(state.tuner.config);
+    }
+    state.tuner.previewActive = false;
+    state.tuner.liveMarkers = [];
+    state.tuner.simulatedMarkers = [];
+    updateTunerStatus();
+    refreshChart().catch(handleRefreshError);
+  }
+
+  async function applyTunerConfig() {
+    if (!state.activeID || !tunerHasOverrides()) return;
+    const resp = await postJSON(
+      "/api/strategies/" + encodeURIComponent(state.activeID) + "/config",
+      { overrides: buildSimulateOverrides() }
+    );
+    if (resp.ok) {
+      resetTunerState();
+      await loadTunerConfig();
+      await refreshAll();
+      els.statusLabel.textContent = resp.restart_required ? "Apply OK — restart" : "Apply OK";
+    }
+  }
+
   function markerText(marker) {
     if (!marker.realized_pnl) return marker.text;
     const pnl = marker.realized_pnl >= 0 ? "+" + fmtMoney(marker.realized_pnl) : fmtMoney(marker.realized_pnl);
     return marker.text + " " + pnl;
+  }
+
+  function chartMarkersFromResponse(tradeResp) {
+    if (state.tuner.previewActive && state.tuner.simulatedMarkers.length) {
+      const faded = (state.tuner.liveMarkers || []).map(function (m) {
+        return {
+          time: m.time,
+          position: m.position,
+          color: "#9ca3af",
+          shape: m.shape,
+          text: markerText(m),
+        };
+      });
+      const bright = state.tuner.simulatedMarkers.map(function (m) {
+        return {
+          time: m.time,
+          position: m.position,
+          color: m.color,
+          shape: m.shape,
+          text: markerText(m),
+        };
+      });
+      return faded.concat(bright);
+    }
+    return (tradeResp.markers || []).map(function (m) {
+      return {
+        time: m.time,
+        position: m.position,
+        color: m.color,
+        shape: m.shape,
+        text: markerText(m),
+      };
+    });
   }
 
   async function refreshChart() {
@@ -394,15 +671,7 @@
     ]);
     const candles = candleResp.candles || [];
     state.series.setData(candles);
-    state.series.setMarkers((tradeResp.markers || []).map(function (m) {
-      return {
-        time: m.time,
-        position: m.position,
-        color: m.color,
-        shape: m.shape,
-        text: markerText(m),
-      };
-    }));
+    state.series.setMarkers(chartMarkersFromResponse(tradeResp));
     els.empty.style.display = candles.length ? "none" : "flex";
     if (candles.length) state.chart.timeScale().fitContent();
     renderTradeHistory(tradeResp.trades || tradeResp.markers || []);
@@ -649,6 +918,7 @@
       await Promise.all([
         refreshChart(),
         refreshStatus(),
+        loadTunerConfig(),
         loadSparklines(filteredStrategies().map(function (s) {
           return s.id;
         })),
@@ -719,6 +989,36 @@
   }
 
   initSidebar();
+  if (els.tunerForm) {
+    els.tunerForm.addEventListener("input", onTunerFieldChange);
+    els.tunerForm.addEventListener("change", onTunerFieldChange);
+  }
+  if (els.tunerReset) {
+    els.tunerReset.addEventListener("click", resetTunerToLive);
+  }
+  if (els.tunerApply) {
+    els.tunerApply.addEventListener("click", function () {
+      if (!state.tuner.config) return;
+      const restart = state.tuner.config.apply_requires_restart;
+      if (els.tunerConfirmText) {
+        els.tunerConfirmText.textContent = restart
+          ? "This writes tuned parameters to the live config file. Restart go-trader afterward — hot reload cannot apply most tuner fields."
+          : "This writes tuned parameters to the live config file. Send SIGHUP to reload when ready.";
+      }
+      if (els.tunerConfirmDialog && typeof els.tunerConfirmDialog.showModal === "function") {
+        els.tunerConfirmDialog.showModal();
+      } else if (window.confirm(els.tunerConfirmText ? els.tunerConfirmText.textContent : "Apply tuned config?")) {
+        applyTunerConfig().catch(handleRefreshError);
+      }
+    });
+  }
+  if (els.tunerConfirmDialog) {
+    els.tunerConfirmDialog.addEventListener("close", function () {
+      if (els.tunerConfirmDialog.returnValue === "apply") {
+        applyTunerConfig().catch(handleRefreshError);
+      }
+    });
+  }
   els.search.addEventListener("input", renderStrategies);
   els.darkToggle.addEventListener("click", function () {
     setDarkMode(!isDarkMode());

--- a/scheduler/static/ui/index.html
+++ b/scheduler/static/ui/index.html
@@ -138,7 +138,7 @@
                   <h3>Strategy tuner</h3>
                   <span id="tuner-status" class="tuner-status">Live config</span>
                 </div>
-                <p class="tuner-note">Preview signal changes without affecting the running strategy.</p>
+                <p class="tuner-note">Preview signal changes without affecting the running strategy. Gray markers replay the live config over fetched candles — not recorded trade history.</p>
                 <form id="tuner-form" class="tuner-form"></form>
                 <div class="tuner-actions">
                   <button id="tuner-reset" type="button" class="tuner-button secondary">Reset to live</button>

--- a/scheduler/static/ui/index.html
+++ b/scheduler/static/ui/index.html
@@ -133,12 +133,34 @@
                 <h3>Positions</h3>
                 <div id="positions-list"></div>
               </div>
+              <section id="tuner-panel" class="tuner-panel" hidden>
+                <div class="tuner-header">
+                  <h3>Strategy tuner</h3>
+                  <span id="tuner-status" class="tuner-status">Live config</span>
+                </div>
+                <p class="tuner-note">Preview signal changes without affecting the running strategy.</p>
+                <form id="tuner-form" class="tuner-form"></form>
+                <div class="tuner-actions">
+                  <button id="tuner-reset" type="button" class="tuner-button secondary">Reset to live</button>
+                  <button id="tuner-apply" type="button" class="tuner-button primary">Apply</button>
+                </div>
+              </section>
             </aside>
           </div>
         </section>
       </main>
     </div>
     <div id="sidebar-backdrop" class="sidebar-backdrop" aria-hidden="true"></div>
+    <dialog id="tuner-confirm-dialog" class="tuner-dialog">
+      <form method="dialog" class="tuner-dialog-body">
+        <h3>Apply tuned config?</h3>
+        <p id="tuner-confirm-text">This writes changes to the live config file. A restart may be required.</p>
+        <div class="tuner-dialog-actions">
+          <button value="cancel" type="submit" class="tuner-button secondary">Cancel</button>
+          <button id="tuner-confirm-apply" value="apply" type="submit" class="tuner-button primary">Apply</button>
+        </div>
+      </form>
+    </dialog>
     <script src="/dashboard/lightweight-charts.standalone.production.js"></script>
     <script src="/dashboard/app.js"></script>
   </body>

--- a/scheduler/static/ui/styles.css
+++ b/scheduler/static/ui/styles.css
@@ -808,6 +808,145 @@ h3 {
   color: var(--red);
 }
 
+.tuner-panel {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+}
+
+.tuner-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.tuner-header h3,
+.positions h3 {
+  margin: 0;
+  font-size: 14px;
+}
+
+.tuner-status {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.tuner-status.preview {
+  color: var(--amber);
+}
+
+.tuner-note {
+  margin: 0 0 12px;
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.tuner-form {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.tuner-field {
+  display: grid;
+  gap: 4px;
+}
+
+.tuner-field span {
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.tuner-field input,
+.tuner-field select {
+  width: 100%;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  padding: 8px 10px;
+  background: var(--panel);
+  color: var(--text);
+  font: inherit;
+}
+
+.tuner-field input[type="checkbox"] {
+  width: auto;
+  justify-self: start;
+}
+
+.tuner-group-label {
+  margin: 4px 0 0;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.tuner-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.tuner-button {
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.tuner-button.primary {
+  background: #2f6f51;
+  border-color: #2f6f51;
+  color: #fff;
+}
+
+.tuner-button.secondary {
+  background: transparent;
+  color: var(--text);
+}
+
+.tuner-dialog {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0;
+  max-width: 420px;
+  width: calc(100% - 32px);
+  background: var(--panel);
+  color: var(--text);
+  box-shadow: var(--shadow);
+}
+
+.tuner-dialog::backdrop {
+  background: rgba(29, 36, 31, 0.45);
+}
+
+.tuner-dialog-body {
+  padding: 18px;
+}
+
+.tuner-dialog-body h3 {
+  margin: 0 0 8px;
+}
+
+.tuner-dialog-body p {
+  margin: 0 0 16px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.tuner-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 .chart-panel,
 .content.content-table {
   grid-template-columns: minmax(0, 1fr);
@@ -823,3 +962,13 @@ h3 {
 
 .overview-panel {
   grid-column: 1 / -1;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  overflow: auto;
+}
+
+.overview-panel[hidden] {
+  display: none;
+}

--- a/scheduler/ui_server.go
+++ b/scheduler/ui_server.go
@@ -188,10 +188,6 @@ func (ss *StatusServer) handleAPIStrategy(w http.ResponseWriter, r *http.Request
 	if !ss.requireAPIAuth(w, r) {
 		return
 	}
-	if r.Method != http.MethodGet {
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		return
-	}
 	id, resource, ok := parseStrategyAPIPath(r.URL.Path)
 	if !ok {
 		http.NotFound(w, r)
@@ -199,13 +195,44 @@ func (ss *StatusServer) handleAPIStrategy(w http.ResponseWriter, r *http.Request
 	}
 	switch resource {
 	case "candles":
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
 		ss.handleAPIStrategyCandles(w, r, id)
 	case "trades":
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
 		ss.handleAPIStrategyTrades(w, r, id)
 	case "status":
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
 		ss.handleAPIStrategyStatus(w, r, id)
 	case "equity":
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
 		ss.handleAPIStrategyEquity(w, r, id)
+	case "config":
+		switch r.Method {
+		case http.MethodGet:
+			ss.handleAPIStrategyConfig(w, r, id)
+		case http.MethodPost:
+			ss.handleAPIStrategyApplyConfig(w, r, id)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	case "simulate":
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		ss.handleAPIStrategySimulate(w, r, id)
 	default:
 		http.NotFound(w, r)
 	}

--- a/scheduler/ui_tuner.go
+++ b/scheduler/ui_tuner.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -52,6 +53,7 @@ type UISimulateResponse struct {
 	Source           string          `json:"source,omitempty"`
 	LiveMarkers      []UITradeMarker `json:"live_markers"`
 	SimulatedMarkers []UITradeMarker `json:"simulated_markers"`
+	PreviewNote      string          `json:"preview_note,omitempty"`
 	Error            string          `json:"error,omitempty"`
 }
 
@@ -92,6 +94,9 @@ func (ss *StatusServer) handleAPIStrategyConfig(w http.ResponseWriter, r *http.R
 func (ss *StatusServer) handleAPIStrategySimulate(w http.ResponseWriter, r *http.Request, id string) {
 	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if !requireJSONContentType(w, r) {
 		return
 	}
 	sc, ok := ss.strategyConfig(id)
@@ -150,12 +155,22 @@ func (ss *StatusServer) handleAPIStrategySimulate(w http.ResponseWriter, r *http
 		Source:           source,
 		LiveMarkers:      markersByLabel["live"],
 		SimulatedMarkers: markersByLabel["simulated"],
+		PreviewNote:      "Gray markers replay the live config over fetched candles; they are not recorded trade history.",
 	})
 }
 
 func (ss *StatusServer) handleAPIStrategyApplyConfig(w http.ResponseWriter, r *http.Request, id string) {
 	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if !ss.requireMutatingAPIAuth(w, r) {
+		return
+	}
+	if !requireJSONContentType(w, r) {
+		return
+	}
+	if !requireSameOrigin(w, r) {
 		return
 	}
 	if strings.TrimSpace(ss.configPath) == "" {
@@ -186,7 +201,10 @@ func (ss *StatusServer) handleAPIStrategyApplyConfig(w http.ResponseWriter, r *h
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	restartRequired, err := applyStrategyConfigPatch(ss.configPath, id, merged)
+	hasOpen := ss.strategyHasOpenPosition(id)
+	ss.configWriteMu.Lock()
+	restartRequired, err := applyStrategyConfigPatch(ss.configPath, id, merged, req.Overrides, hasOpen)
+	ss.configWriteMu.Unlock()
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -244,6 +262,40 @@ func (ss *StatusServer) strategyHasOpenPosition(id string) bool {
 	return false
 }
 
+func (ss *StatusServer) requireMutatingAPIAuth(w http.ResponseWriter, r *http.Request) bool {
+	if strings.TrimSpace(ss.statusToken) == "" {
+		writeJSONError(w, http.StatusForbidden, "config apply requires status_token")
+		return false
+	}
+	return ss.requireAPIAuth(w, r)
+}
+
+func requireJSONContentType(w http.ResponseWriter, r *http.Request) bool {
+	ct := strings.ToLower(strings.TrimSpace(r.Header.Get("Content-Type")))
+	if strings.HasPrefix(ct, "application/json") {
+		return true
+	}
+	writeJSONError(w, http.StatusUnsupportedMediaType, "Content-Type must be application/json")
+	return false
+}
+
+func requireSameOrigin(w http.ResponseWriter, r *http.Request) bool {
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		return true
+	}
+	host := r.Host
+	if strings.HasSuffix(origin, "://"+host) {
+		return true
+	}
+	writeJSONError(w, http.StatusForbidden, "origin not allowed")
+	return false
+}
+
+type pythonErrorResponse struct {
+	Error string `json:"error,omitempty"`
+}
+
 func fetchStrategyDefaultParams(sc StrategyConfig) (map[string]interface{}, string, error) {
 	name := effectiveOpenStrategy(sc)
 	if name == "" {
@@ -254,19 +306,22 @@ func fetchStrategyDefaultParams(sc StrategyConfig) (map[string]interface{}, stri
 		"--strategy", name,
 	}
 	stdout, stderr, err := runPythonReadOnly("shared_scripts/strategy_tuner_schema.py", args)
-	if err != nil {
-		return nil, "", fmt.Errorf("strategy_tuner_schema: %w (stderr: %s)", err, strings.TrimSpace(string(stderr)))
-	}
 	var resp struct {
-		Error         string                 `json:"error,omitempty"`
+		pythonErrorResponse
 		Description   string                 `json:"description"`
 		DefaultParams map[string]interface{} `json:"default_params"`
 	}
-	if err := json.Unmarshal(stdout, &resp); err != nil {
-		return nil, "", fmt.Errorf("parse strategy schema: %w", err)
+	if parseErr := json.Unmarshal(stdout, &resp); parseErr != nil {
+		if err != nil {
+			return nil, "", fmt.Errorf("strategy_tuner_schema: %w (stderr: %s)", err, strings.TrimSpace(string(stderr)))
+		}
+		return nil, "", fmt.Errorf("parse strategy schema: %w", parseErr)
 	}
 	if resp.Error != "" {
 		return nil, "", fmt.Errorf("%s", resp.Error)
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("strategy_tuner_schema: %w (stderr: %s)", err, strings.TrimSpace(string(stderr)))
 	}
 	if resp.DefaultParams == nil {
 		resp.DefaultParams = map[string]interface{}{}
@@ -289,7 +344,7 @@ func buildUIStrategyConfig(sc StrategyConfig, defaults map[string]interface{}, _
 	}
 
 	fields := buildEditableFields(sc, openParams, defaults)
-	restart := tunerApplyRequiresRestart(sc, hasOpen)
+	restart := tunerApplyRequiresRestart(nil, hasOpen)
 
 	return UIStrategyConfigResponse{
 		StrategyID:           sc.ID,
@@ -378,12 +433,19 @@ func ptrFloatValue(v *float64) interface{} {
 	return *v
 }
 
-func tunerApplyRequiresRestart(sc StrategyConfig, hasOpen bool) bool {
+func tunerApplyRequiresRestart(overrides map[string]json.RawMessage, hasOpen bool) bool {
 	if hasOpen {
+		for key := range overrides {
+			switch key {
+			case "direction", "invert_signal", "leverage":
+				return true
+			}
+		}
+	}
+	if _, ok := overrides["htf_filter"]; ok {
 		return true
 	}
-	// Indicator params live in open_strategy.params / args — hot reload rejects script/args shape changes.
-	return true
+	return false
 }
 
 func mergeStrategyTunerOverrides(base StrategyConfig, overrides map[string]json.RawMessage) (StrategyConfig, error) {
@@ -432,6 +494,9 @@ func mergeStrategyTunerOverrides(base StrategyConfig, overrides map[string]json.
 			return out, fmt.Errorf("stop_loss_pct: %w", err)
 		}
 		out.StopLossPct = v
+		if _, keepATR := overrides["stop_loss_atr_mult"]; !keepATR {
+			out.StopLossATRMult = nil
+		}
 	}
 	if raw, ok := overrides["stop_loss_atr_mult"]; ok {
 		v, err := decodeOptionalFloat(raw)
@@ -439,6 +504,9 @@ func mergeStrategyTunerOverrides(base StrategyConfig, overrides map[string]json.
 			return out, fmt.Errorf("stop_loss_atr_mult: %w", err)
 		}
 		out.StopLossATRMult = v
+		if _, keepPct := overrides["stop_loss_pct"]; !keepPct {
+			out.StopLossPct = nil
+		}
 	}
 	if raw, ok := overrides["open_strategy"]; ok {
 		var ref StrategyRef
@@ -575,19 +643,22 @@ func runStrategySimulate(candles []UICandle, configs map[string]map[string]inter
 	if err != nil {
 		return nil, err
 	}
-	stdout, stderr, err := runPythonReadOnlyWithStdin("shared_scripts/simulate_strategy.py", nil, stdin)
-	if err != nil {
-		return nil, fmt.Errorf("simulate_strategy: %w (stderr: %s)", err, strings.TrimSpace(string(stderr)))
-	}
+	stdout, stderr, runErr := runPythonReadOnlyWithStdin("shared_scripts/simulate_strategy.py", nil, stdin)
 	var resp struct {
-		Error   string                     `json:"error,omitempty"`
+		pythonErrorResponse
 		Markers map[string][]UITradeMarker `json:"markers"`
 	}
 	if err := json.Unmarshal(stdout, &resp); err != nil {
+		if runErr != nil {
+			return nil, fmt.Errorf("simulate_strategy: %w (stderr: %s)", runErr, strings.TrimSpace(string(stderr)))
+		}
 		return nil, fmt.Errorf("parse simulate response: %w", err)
 	}
 	if resp.Error != "" {
 		return nil, fmt.Errorf("%s", resp.Error)
+	}
+	if runErr != nil {
+		return nil, fmt.Errorf("simulate_strategy: %w (stderr: %s)", runErr, strings.TrimSpace(string(stderr)))
 	}
 	if resp.Markers == nil {
 		resp.Markers = map[string][]UITradeMarker{}
@@ -595,7 +666,11 @@ func runStrategySimulate(candles []UICandle, configs map[string]map[string]inter
 	return resp.Markers, nil
 }
 
-func applyStrategyConfigPatch(configPath, strategyID string, merged StrategyConfig) (restartRequired bool, err error) {
+func applyStrategyConfigPatch(configPath, strategyID string, merged StrategyConfig, overrides map[string]json.RawMessage, hasOpen bool) (restartRequired bool, err error) {
+	if len(overrides) == 0 {
+		return false, fmt.Errorf("no overrides supplied")
+	}
+	restartRequired = tunerApplyRequiresRestart(overrides, hasOpen)
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		return false, err
@@ -626,11 +701,10 @@ func applyStrategyConfigPatch(configPath, strategyID string, merged StrategyConf
 		if err := json.Unmarshal(idRaw, &id); err != nil || id != strategyID {
 			continue
 		}
-		patched, restart, patchErr := patchStrategyJSON(item, merged)
+		patched, patchErr := patchStrategyJSON(item, merged, overrides)
 		if patchErr != nil {
 			return false, patchErr
 		}
-		restartRequired = restart
 		newRaw, err := json.Marshal(patched)
 		if err != nil {
 			return false, err
@@ -652,9 +726,20 @@ func applyStrategyConfigPatch(configPath, strategyID string, merged StrategyConf
 		return false, err
 	}
 	out = append(out, '\n')
-	tmpPath := configPath + ".tmp"
+	tmpFile, err := os.CreateTemp(filepath.Dir(configPath), "go-trader-config-*.json")
+	if err != nil {
+		return false, err
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
 	if err := os.WriteFile(tmpPath, out, 0o600); err != nil {
 		return false, err
+	}
+	if needsV13SchemaMigration(out) {
+		return false, fmt.Errorf("dashboard apply requires config_version >= 13; restart go-trader once to migrate the config file")
+	}
+	if _, err := LoadConfigForProbe(tmpPath); err != nil {
+		return false, fmt.Errorf("patched config invalid: %w", err)
 	}
 	if err := os.Rename(tmpPath, configPath); err != nil {
 		return false, err
@@ -662,8 +747,7 @@ func applyStrategyConfigPatch(configPath, strategyID string, merged StrategyConf
 	return restartRequired, nil
 }
 
-func patchStrategyJSON(item map[string]json.RawMessage, merged StrategyConfig) (map[string]json.RawMessage, bool, error) {
-	restartRequired := true
+func patchStrategyJSON(item map[string]json.RawMessage, merged StrategyConfig, overrides map[string]json.RawMessage) (map[string]json.RawMessage, error) {
 	set := func(key string, value interface{}) error {
 		raw, err := json.Marshal(value)
 		if err != nil {
@@ -672,48 +756,113 @@ func patchStrategyJSON(item map[string]json.RawMessage, merged StrategyConfig) (
 		item[key] = raw
 		return nil
 	}
-	if merged.IntervalSeconds > 0 {
+	deleteKey := func(key string) {
+		delete(item, key)
+	}
+
+	if _, ok := overrides["interval_seconds"]; ok && merged.IntervalSeconds > 0 {
 		if err := set("interval_seconds", merged.IntervalSeconds); err != nil {
-			return item, restartRequired, err
+			return item, err
 		}
 	}
-	if merged.Direction != "" {
+	if _, ok := overrides["direction"]; ok && merged.Direction != "" {
 		if err := set("direction", merged.Direction); err != nil {
-			return item, restartRequired, err
+			return item, err
 		}
 	}
-	if err := set("invert_signal", merged.InvertSignal); err != nil {
-		return item, restartRequired, err
+	if _, ok := overrides["invert_signal"]; ok {
+		if err := set("invert_signal", merged.InvertSignal); err != nil {
+			return item, err
+		}
 	}
-	if merged.Leverage > 0 {
+	if _, ok := overrides["leverage"]; ok && merged.Leverage > 0 {
 		if err := set("leverage", merged.Leverage); err != nil {
-			return item, restartRequired, err
+			return item, err
 		}
 	}
-	if merged.Type == "perps" {
+	if _, ok := overrides["htf_filter"]; ok && merged.Type == "perps" {
 		if err := set("htf_filter", merged.HTFFilter); err != nil {
-			return item, restartRequired, err
+			return item, err
 		}
 	}
-	if merged.StopLossPct != nil {
+	if _, ok := overrides["stop_loss_pct"]; ok {
 		if err := set("stop_loss_pct", merged.StopLossPct); err != nil {
-			return item, restartRequired, err
+			return item, err
+		}
+		if _, keep := overrides["stop_loss_atr_mult"]; !keep {
+			deleteKey("stop_loss_atr_mult")
 		}
 	}
-	if merged.StopLossATRMult != nil {
+	if _, ok := overrides["stop_loss_atr_mult"]; ok {
 		if err := set("stop_loss_atr_mult", merged.StopLossATRMult); err != nil {
-			return item, restartRequired, err
+			return item, err
+		}
+		if _, keep := overrides["stop_loss_pct"]; !keep {
+			deleteKey("stop_loss_pct")
 		}
 	}
-	openName := effectiveOpenStrategy(merged)
-	openRef := merged.OpenStrategy
-	if openName != "" {
-		openRef.Name = openName
+
+	paramOverrides := map[string]interface{}{}
+	for key, raw := range overrides {
+		if !strings.HasPrefix(key, "open_strategy.params.") {
+			continue
+		}
+		paramKey := strings.TrimPrefix(key, "open_strategy.params.")
+		if paramKey == "" {
+			continue
+		}
+		var v interface{}
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return item, fmt.Errorf("%s: %w", key, err)
+		}
+		paramOverrides[paramKey] = v
 	}
-	if openRef.Name != "" || len(openRef.Params) > 0 {
+	if raw, ok := overrides["open_strategy"]; ok {
+		var ref StrategyRef
+		if err := json.Unmarshal(raw, &ref); err != nil {
+			return item, fmt.Errorf("open_strategy: %w", err)
+		}
+		openRef := merged.OpenStrategy
+		if ref.Name != "" {
+			openRef.Name = ref.Name
+		}
+		if ref.Params != nil {
+			if openRef.Params == nil {
+				openRef.Params = map[string]interface{}{}
+			}
+			for k, v := range ref.Params {
+				openRef.Params[k] = v
+			}
+		}
+		if effectiveOpenStrategy(merged) != "" {
+			openRef.Name = effectiveOpenStrategy(merged)
+		}
 		if err := set("open_strategy", openRef); err != nil {
-			return item, restartRequired, err
+			return item, err
+		}
+	} else if len(paramOverrides) > 0 {
+		openRef := StrategyRef{}
+		if raw, ok := item["open_strategy"]; ok {
+			_ = json.Unmarshal(raw, &openRef)
+		}
+		if openRef.Name == "" {
+			openRef.Name = effectiveOpenStrategy(merged)
+		}
+		if openRef.Name == "" {
+			openRef.Name = merged.OpenStrategy.Name
+		}
+		if openRef.Params == nil {
+			openRef.Params = map[string]interface{}{}
+		}
+		for k, v := range merged.OpenStrategy.Params {
+			openRef.Params[k] = v
+		}
+		for k, v := range paramOverrides {
+			openRef.Params[k] = v
+		}
+		if err := set("open_strategy", openRef); err != nil {
+			return item, err
 		}
 	}
-	return item, restartRequired, nil
+	return item, nil
 }

--- a/scheduler/ui_tuner.go
+++ b/scheduler/ui_tuner.go
@@ -1,0 +1,719 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+)
+
+type UIEditableField struct {
+	Key     string      `json:"key"`
+	Label   string      `json:"label"`
+	Type    string      `json:"type"`
+	Value   interface{} `json:"value"`
+	Default interface{} `json:"default,omitempty"`
+	Options []string    `json:"options,omitempty"`
+	Group   string      `json:"group"`
+}
+
+type UIStrategyConfigResponse struct {
+	StrategyID           string                 `json:"strategy_id"`
+	Type                 string                 `json:"type"`
+	Platform             string                 `json:"platform"`
+	Symbol               string                 `json:"symbol"`
+	Timeframe            string                 `json:"timeframe"`
+	OpenStrategy         StrategyRef            `json:"open_strategy"`
+	CloseStrategies      []StrategyRef          `json:"close_strategies,omitempty"`
+	IntervalSeconds      int                    `json:"interval_seconds,omitempty"`
+	Direction            string                 `json:"direction,omitempty"`
+	InvertSignal         bool                   `json:"invert_signal,omitempty"`
+	Leverage             float64                `json:"leverage,omitempty"`
+	HTFFilter            bool                   `json:"htf_filter,omitempty"`
+	AllowedRegimes       []string               `json:"allowed_regimes,omitempty"`
+	StopLossPct          *float64               `json:"stop_loss_pct,omitempty"`
+	StopLossATRMult      *float64               `json:"stop_loss_atr_mult,omitempty"`
+	DefaultParams        map[string]interface{} `json:"default_params"`
+	EditableFields       []UIEditableField      `json:"editable_fields"`
+	HasOpenPosition      bool                   `json:"has_open_position"`
+	ApplyRequiresRestart bool                   `json:"apply_requires_restart"`
+}
+
+type UISimulateRequest struct {
+	Overrides map[string]json.RawMessage `json:"overrides"`
+	Limit     int                        `json:"limit"`
+}
+
+type UISimulateResponse struct {
+	StrategyID       string          `json:"strategy_id"`
+	Source           string          `json:"source,omitempty"`
+	LiveMarkers      []UITradeMarker `json:"live_markers"`
+	SimulatedMarkers []UITradeMarker `json:"simulated_markers"`
+	Error            string          `json:"error,omitempty"`
+}
+
+type UIApplyConfigRequest struct {
+	Overrides map[string]json.RawMessage `json:"overrides"`
+}
+
+type UIApplyConfigResponse struct {
+	OK              bool   `json:"ok"`
+	RestartRequired bool   `json:"restart_required"`
+	Message         string `json:"message"`
+}
+
+func (ss *StatusServer) SetConfigContext(configPath string, regime *RegimeConfig) {
+	if ss == nil {
+		return
+	}
+	ss.configPath = configPath
+	ss.regime = regime
+}
+
+func (ss *StatusServer) handleAPIStrategyConfig(w http.ResponseWriter, r *http.Request, id string) {
+	sc, ok := ss.strategyConfig(id)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "strategy not found")
+		return
+	}
+	defaults, desc, err := fetchStrategyDefaultParams(sc)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	hasOpen := ss.strategyHasOpenPosition(id)
+	resp := buildUIStrategyConfig(sc, defaults, desc, hasOpen)
+	writeJSON(w, resp)
+}
+
+func (ss *StatusServer) handleAPIStrategySimulate(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	sc, ok := ss.strategyConfig(id)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "strategy not found")
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "failed to read body")
+		return
+	}
+	var req UISimulateRequest
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid json body")
+			return
+		}
+	}
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 400
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+
+	liveCfg := sc
+	simCfg, err := mergeStrategyTunerOverrides(sc, req.Overrides)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	from, to, _ := parseUITimeQuery(r)
+	candleReq := UICandleRequest{Strategy: sc, From: from, To: to, Limit: limit}
+	candles, source, err := ss.fetchUICandlesForSimulate(candleReq)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+
+	livePayload := simulateConfigPayload(liveCfg, ss.regime)
+	simPayload := simulateConfigPayload(simCfg, ss.regime)
+	markersByLabel, simErr := runStrategySimulate(candles, map[string]map[string]interface{}{
+		"live":      livePayload,
+		"simulated": simPayload,
+	})
+	if simErr != nil {
+		writeJSONError(w, http.StatusBadGateway, simErr.Error())
+		return
+	}
+
+	writeJSON(w, UISimulateResponse{
+		StrategyID:       id,
+		Source:           source,
+		LiveMarkers:      markersByLabel["live"],
+		SimulatedMarkers: markersByLabel["simulated"],
+	})
+}
+
+func (ss *StatusServer) handleAPIStrategyApplyConfig(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if strings.TrimSpace(ss.configPath) == "" {
+		writeJSONError(w, http.StatusServiceUnavailable, "config path not configured")
+		return
+	}
+	sc, ok := ss.strategyConfig(id)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "strategy not found")
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "failed to read body")
+		return
+	}
+	var req UIApplyConfigRequest
+	if len(body) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "empty body")
+		return
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+	merged, err := mergeStrategyTunerOverrides(sc, req.Overrides)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	restartRequired, err := applyStrategyConfigPatch(ss.configPath, id, merged)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	msg := "Config updated."
+	if restartRequired {
+		msg += " Restart go-trader to apply indicator/script changes; some runtime fields may hot-reload on SIGHUP when flat."
+	} else {
+		msg += " Send SIGHUP or wait for the next reload to pick up changes."
+	}
+	writeJSON(w, UIApplyConfigResponse{
+		OK:              true,
+		RestartRequired: restartRequired,
+		Message:         msg,
+	})
+}
+
+func (ss *StatusServer) fetchUICandlesForSimulate(req UICandleRequest) ([]UICandle, string, error) {
+	cacheKey := req.CacheKey()
+	if ss.candleCache != nil {
+		if cached, ok := ss.candleCache.Get(cacheKey); ok {
+			return cached.Candles, cached.Source + ":cached", nil
+		}
+	}
+	if ss.candleFetcher == nil {
+		return nil, "", fmt.Errorf("candle fetcher unavailable")
+	}
+	candles, source, err := ss.candleFetcher(req)
+	if err != nil {
+		return nil, "", err
+	}
+	if ss.candleCache != nil {
+		ss.candleCache.Set(cacheKey, UICandleResponse{Candles: candles, Source: source})
+	}
+	return candles, source, nil
+}
+
+func (ss *StatusServer) strategyHasOpenPosition(id string) bool {
+	ss.mu.RLock()
+	defer ss.mu.RUnlock()
+	strat := ss.state.Strategies[id]
+	if strat == nil {
+		return false
+	}
+	for _, pos := range strat.Positions {
+		if pos != nil && pos.Quantity > 0 {
+			return true
+		}
+	}
+	for _, pos := range strat.OptionPositions {
+		if pos != nil && pos.Quantity > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func fetchStrategyDefaultParams(sc StrategyConfig) (map[string]interface{}, string, error) {
+	name := effectiveOpenStrategy(sc)
+	if name == "" {
+		return map[string]interface{}{}, "", nil
+	}
+	args := []string{
+		"--type", sc.Type,
+		"--strategy", name,
+	}
+	stdout, stderr, err := runPythonReadOnly("shared_scripts/strategy_tuner_schema.py", args)
+	if err != nil {
+		return nil, "", fmt.Errorf("strategy_tuner_schema: %w (stderr: %s)", err, strings.TrimSpace(string(stderr)))
+	}
+	var resp struct {
+		Error         string                 `json:"error,omitempty"`
+		Description   string                 `json:"description"`
+		DefaultParams map[string]interface{} `json:"default_params"`
+	}
+	if err := json.Unmarshal(stdout, &resp); err != nil {
+		return nil, "", fmt.Errorf("parse strategy schema: %w", err)
+	}
+	if resp.Error != "" {
+		return nil, "", fmt.Errorf("%s", resp.Error)
+	}
+	if resp.DefaultParams == nil {
+		resp.DefaultParams = map[string]interface{}{}
+	}
+	return resp.DefaultParams, resp.Description, nil
+}
+
+func buildUIStrategyConfig(sc StrategyConfig, defaults map[string]interface{}, _ string, hasOpen bool) UIStrategyConfigResponse {
+	openName := effectiveOpenStrategy(sc)
+	openParams := map[string]interface{}{}
+	for k, v := range defaults {
+		openParams[k] = v
+	}
+	for k, v := range sc.OpenStrategy.Params {
+		openParams[k] = v
+	}
+	openRef := StrategyRef{Name: openName, Params: openParams}
+	if sc.OpenStrategy.Name != "" {
+		openRef.Name = sc.OpenStrategy.Name
+	}
+
+	fields := buildEditableFields(sc, openParams, defaults)
+	restart := tunerApplyRequiresRestart(sc, hasOpen)
+
+	return UIStrategyConfigResponse{
+		StrategyID:           sc.ID,
+		Type:                 sc.Type,
+		Platform:             sc.Platform,
+		Symbol:               strategyDisplaySymbol(sc),
+		Timeframe:            strategyDisplayTimeframe(sc),
+		OpenStrategy:         openRef,
+		CloseStrategies:      append([]StrategyRef(nil), sc.CloseStrategies...),
+		IntervalSeconds:      sc.IntervalSeconds,
+		Direction:            EffectiveDirection(sc),
+		InvertSignal:         sc.InvertSignal,
+		Leverage:             EffectiveExchangeLeverage(sc),
+		HTFFilter:            sc.HTFFilter,
+		AllowedRegimes:       append([]string(nil), sc.AllowedRegimes...),
+		StopLossPct:          sc.StopLossPct,
+		StopLossATRMult:      sc.StopLossATRMult,
+		DefaultParams:        defaults,
+		EditableFields:       fields,
+		HasOpenPosition:      hasOpen,
+		ApplyRequiresRestart: restart,
+	}
+}
+
+func buildEditableFields(sc StrategyConfig, mergedParams, defaults map[string]interface{}) []UIEditableField {
+	fields := []UIEditableField{
+		{Key: "interval_seconds", Label: "Interval (seconds)", Type: "number", Value: sc.IntervalSeconds, Group: "runtime"},
+	}
+	if sc.Type == "perps" || sc.Type == "manual" {
+		fields = append(fields,
+			UIEditableField{Key: "direction", Label: "Direction", Type: "select", Value: EffectiveDirection(sc), Options: []string{DirectionLong, DirectionShort, DirectionBoth}, Group: "runtime"},
+			UIEditableField{Key: "invert_signal", Label: "Invert signal", Type: "boolean", Value: sc.InvertSignal, Group: "runtime"},
+			UIEditableField{Key: "leverage", Label: "Leverage", Type: "number", Value: EffectiveExchangeLeverage(sc), Group: "runtime"},
+		)
+	}
+	if sc.Type == "perps" || sc.Type == "manual" {
+		fields = append(fields,
+			UIEditableField{Key: "stop_loss_pct", Label: "Stop loss %", Type: "number", Value: ptrFloatValue(sc.StopLossPct), Group: "risk"},
+			UIEditableField{Key: "stop_loss_atr_mult", Label: "Stop loss ATR mult", Type: "number", Value: ptrFloatValue(sc.StopLossATRMult), Group: "risk"},
+		)
+	}
+	if sc.Type == "perps" {
+		fields = append(fields,
+			UIEditableField{Key: "htf_filter", Label: "HTF filter", Type: "boolean", Value: sc.HTFFilter, Group: "runtime"},
+		)
+	}
+
+	keys := make([]string, 0, len(mergedParams))
+	for k := range mergedParams {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		def := defaults[key]
+		fields = append(fields, UIEditableField{
+			Key:     "open_strategy.params." + key,
+			Label:   humanizeParamKey(key),
+			Type:    inferEditableFieldType(def),
+			Value:   mergedParams[key],
+			Default: def,
+			Group:   "open_params",
+		})
+	}
+	return fields
+}
+
+func humanizeParamKey(key string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(key, "_", " "), ".", " ")
+}
+
+func inferEditableFieldType(sample interface{}) string {
+	switch sample.(type) {
+	case bool:
+		return "boolean"
+	case float64, float32, int, int64, json.Number:
+		return "number"
+	default:
+		return "text"
+	}
+}
+
+func ptrFloatValue(v *float64) interface{} {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+func tunerApplyRequiresRestart(sc StrategyConfig, hasOpen bool) bool {
+	if hasOpen {
+		return true
+	}
+	// Indicator params live in open_strategy.params / args — hot reload rejects script/args shape changes.
+	return true
+}
+
+func mergeStrategyTunerOverrides(base StrategyConfig, overrides map[string]json.RawMessage) (StrategyConfig, error) {
+	out := base
+	if len(overrides) == 0 {
+		return out, nil
+	}
+	if raw, ok := overrides["interval_seconds"]; ok {
+		var v int
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return out, fmt.Errorf("interval_seconds: %w", err)
+		}
+		out.IntervalSeconds = v
+	}
+	if raw, ok := overrides["direction"]; ok {
+		var v string
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return out, fmt.Errorf("direction: %w", err)
+		}
+		out.Direction = strings.TrimSpace(v)
+	}
+	if raw, ok := overrides["invert_signal"]; ok {
+		var v bool
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return out, fmt.Errorf("invert_signal: %w", err)
+		}
+		out.InvertSignal = v
+	}
+	if raw, ok := overrides["leverage"]; ok {
+		var v float64
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return out, fmt.Errorf("leverage: %w", err)
+		}
+		out.Leverage = v
+	}
+	if raw, ok := overrides["htf_filter"]; ok {
+		var v bool
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return out, fmt.Errorf("htf_filter: %w", err)
+		}
+		out.HTFFilter = v
+	}
+	if raw, ok := overrides["stop_loss_pct"]; ok {
+		v, err := decodeOptionalFloat(raw)
+		if err != nil {
+			return out, fmt.Errorf("stop_loss_pct: %w", err)
+		}
+		out.StopLossPct = v
+	}
+	if raw, ok := overrides["stop_loss_atr_mult"]; ok {
+		v, err := decodeOptionalFloat(raw)
+		if err != nil {
+			return out, fmt.Errorf("stop_loss_atr_mult: %w", err)
+		}
+		out.StopLossATRMult = v
+	}
+	if raw, ok := overrides["open_strategy"]; ok {
+		var ref StrategyRef
+		if err := json.Unmarshal(raw, &ref); err != nil {
+			return out, fmt.Errorf("open_strategy: %w", err)
+		}
+		if ref.Name != "" {
+			out.OpenStrategy.Name = ref.Name
+		}
+		if ref.Params != nil {
+			if out.OpenStrategy.Params == nil {
+				out.OpenStrategy.Params = map[string]interface{}{}
+			}
+			for k, v := range ref.Params {
+				out.OpenStrategy.Params[k] = v
+			}
+		}
+	}
+	for key, raw := range overrides {
+		if !strings.HasPrefix(key, "open_strategy.params.") {
+			continue
+		}
+		paramKey := strings.TrimPrefix(key, "open_strategy.params.")
+		if paramKey == "" {
+			continue
+		}
+		if out.OpenStrategy.Params == nil {
+			out.OpenStrategy.Params = map[string]interface{}{}
+		}
+		var v interface{}
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return out, fmt.Errorf("%s: %w", key, err)
+		}
+		out.OpenStrategy.Params[paramKey] = v
+	}
+	return out, nil
+}
+
+func decodeOptionalFloat(raw json.RawMessage) (*float64, error) {
+	if string(raw) == "null" {
+		return nil, nil
+	}
+	var v float64
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func simulateConfigPayload(sc StrategyConfig, regime *RegimeConfig) map[string]interface{} {
+	payload := map[string]interface{}{
+		"type":               sc.Type,
+		"platform":           sc.Platform,
+		"symbol":             strategyDisplaySymbol(sc),
+		"timeframe":          strategyDisplayTimeframe(sc),
+		"strategy":           effectiveOpenStrategy(sc),
+		"open_strategy":      sc.OpenStrategy,
+		"close_strategies":   sc.CloseStrategies,
+		"htf_filter":         sc.HTFFilter,
+		"allowed_regimes":    sc.AllowedRegimes,
+		"initial_capital":    sc.InitialCapital,
+		"stop_loss_pct":      sc.StopLossPct,
+		"stop_loss_atr_mult": sc.StopLossATRMult,
+	}
+	if sc.StopLossMarginPct != nil {
+		payload["stop_loss_margin_pct"] = *sc.StopLossMarginPct
+	}
+	if sc.TrailingStopPct != nil {
+		payload["trailing_stop_pct"] = *sc.TrailingStopPct
+	}
+	if sc.TrailingStopATRMult != nil {
+		payload["trailing_stop_atr_mult"] = *sc.TrailingStopATRMult
+	}
+	if sc.StopLossATRRegime != nil {
+		payload["stop_loss_atr_regime"] = sc.StopLossATRRegime
+	}
+	if sc.TrailingStopATRRegime != nil {
+		payload["trailing_stop_atr_regime"] = sc.TrailingStopATRRegime
+	}
+	if regime != nil {
+		payload["regime"] = map[string]interface{}{
+			"enabled":       regime.Enabled,
+			"period":        regimePeriod(regime),
+			"adx_threshold": regimeADXThreshold(regime),
+		}
+	}
+	if sc.OpenStrategy.Name == "" && effectiveOpenStrategy(sc) != "" {
+		open := sc.OpenStrategy
+		open.Name = effectiveOpenStrategy(sc)
+		payload["open_strategy"] = open
+	}
+	return payload
+}
+
+func regimePeriod(regime *RegimeConfig) int {
+	if regime == nil {
+		return 14
+	}
+	if regime.Period > 0 {
+		return regime.Period
+	}
+	return 14
+}
+
+func regimeADXThreshold(regime *RegimeConfig) float64 {
+	if regime == nil {
+		return 20
+	}
+	if regime.ADXThreshold > 0 {
+		return regime.ADXThreshold
+	}
+	return 20
+}
+
+func runStrategySimulate(candles []UICandle, configs map[string]map[string]interface{}) (map[string][]UITradeMarker, error) {
+	type cfgItem struct {
+		Label  string                 `json:"label"`
+		Config map[string]interface{} `json:"config"`
+	}
+	items := make([]cfgItem, 0, len(configs))
+	labels := make([]string, 0, len(configs))
+	for label := range configs {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	for _, label := range labels {
+		items = append(items, cfgItem{Label: label, Config: configs[label]})
+	}
+	payload := map[string]interface{}{
+		"candles": candles,
+		"configs": items,
+	}
+	stdin, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	stdout, stderr, err := runPythonReadOnlyWithStdin("shared_scripts/simulate_strategy.py", nil, stdin)
+	if err != nil {
+		return nil, fmt.Errorf("simulate_strategy: %w (stderr: %s)", err, strings.TrimSpace(string(stderr)))
+	}
+	var resp struct {
+		Error   string                     `json:"error,omitempty"`
+		Markers map[string][]UITradeMarker `json:"markers"`
+	}
+	if err := json.Unmarshal(stdout, &resp); err != nil {
+		return nil, fmt.Errorf("parse simulate response: %w", err)
+	}
+	if resp.Error != "" {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+	if resp.Markers == nil {
+		resp.Markers = map[string][]UITradeMarker{}
+	}
+	return resp.Markers, nil
+}
+
+func applyStrategyConfigPatch(configPath, strategyID string, merged StrategyConfig) (restartRequired bool, err error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return false, err
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return false, fmt.Errorf("parse config: %w", err)
+	}
+	rawStrategies, ok := root["strategies"]
+	if !ok {
+		return false, fmt.Errorf("config has no strategies array")
+	}
+	var strategies []json.RawMessage
+	if err := json.Unmarshal(rawStrategies, &strategies); err != nil {
+		return false, fmt.Errorf("parse strategies: %w", err)
+	}
+	found := false
+	for i, raw := range strategies {
+		var item map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &item); err != nil {
+			continue
+		}
+		idRaw, ok := item["id"]
+		if !ok {
+			continue
+		}
+		var id string
+		if err := json.Unmarshal(idRaw, &id); err != nil || id != strategyID {
+			continue
+		}
+		patched, restart, patchErr := patchStrategyJSON(item, merged)
+		if patchErr != nil {
+			return false, patchErr
+		}
+		restartRequired = restart
+		newRaw, err := json.Marshal(patched)
+		if err != nil {
+			return false, err
+		}
+		strategies[i] = newRaw
+		found = true
+		break
+	}
+	if !found {
+		return false, fmt.Errorf("strategy %q not found in config", strategyID)
+	}
+	newStrategies, err := json.Marshal(strategies)
+	if err != nil {
+		return false, err
+	}
+	root["strategies"] = newStrategies
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return false, err
+	}
+	out = append(out, '\n')
+	tmpPath := configPath + ".tmp"
+	if err := os.WriteFile(tmpPath, out, 0o600); err != nil {
+		return false, err
+	}
+	if err := os.Rename(tmpPath, configPath); err != nil {
+		return false, err
+	}
+	return restartRequired, nil
+}
+
+func patchStrategyJSON(item map[string]json.RawMessage, merged StrategyConfig) (map[string]json.RawMessage, bool, error) {
+	restartRequired := true
+	set := func(key string, value interface{}) error {
+		raw, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		item[key] = raw
+		return nil
+	}
+	if merged.IntervalSeconds > 0 {
+		if err := set("interval_seconds", merged.IntervalSeconds); err != nil {
+			return item, restartRequired, err
+		}
+	}
+	if merged.Direction != "" {
+		if err := set("direction", merged.Direction); err != nil {
+			return item, restartRequired, err
+		}
+	}
+	if err := set("invert_signal", merged.InvertSignal); err != nil {
+		return item, restartRequired, err
+	}
+	if merged.Leverage > 0 {
+		if err := set("leverage", merged.Leverage); err != nil {
+			return item, restartRequired, err
+		}
+	}
+	if merged.Type == "perps" {
+		if err := set("htf_filter", merged.HTFFilter); err != nil {
+			return item, restartRequired, err
+		}
+	}
+	if merged.StopLossPct != nil {
+		if err := set("stop_loss_pct", merged.StopLossPct); err != nil {
+			return item, restartRequired, err
+		}
+	}
+	if merged.StopLossATRMult != nil {
+		if err := set("stop_loss_atr_mult", merged.StopLossATRMult); err != nil {
+			return item, restartRequired, err
+		}
+	}
+	openName := effectiveOpenStrategy(merged)
+	openRef := merged.OpenStrategy
+	if openName != "" {
+		openRef.Name = openName
+	}
+	if openRef.Name != "" || len(openRef.Params) > 0 {
+		if err := set("open_strategy", openRef); err != nil {
+			return item, restartRequired, err
+		}
+	}
+	return item, restartRequired, nil
+}

--- a/scheduler/ui_tuner_test.go
+++ b/scheduler/ui_tuner_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,6 +35,28 @@ func TestMergeStrategyTunerOverrides(t *testing.T) {
 	}
 }
 
+func TestMergeStrategyTunerOverridesClearsSiblingStop(t *testing.T) {
+	stop := 1.5
+	base := StrategyConfig{
+		ID:              "hl-btc",
+		Type:            "perps",
+		StopLossATRMult: &stop,
+	}
+	overrides := map[string]json.RawMessage{
+		"stop_loss_pct": json.RawMessage(`2`),
+	}
+	merged, err := mergeStrategyTunerOverrides(base, overrides)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if merged.StopLossPct == nil || *merged.StopLossPct != 2 {
+		t.Fatalf("stop_loss_pct = %v, want 2", merged.StopLossPct)
+	}
+	if merged.StopLossATRMult != nil {
+		t.Fatalf("stop_loss_atr_mult = %v, want nil", merged.StopLossATRMult)
+	}
+}
+
 func TestBuildUIStrategyConfigFields(t *testing.T) {
 	stop := 2.5
 	sc := StrategyConfig{
@@ -51,6 +75,9 @@ func TestBuildUIStrategyConfigFields(t *testing.T) {
 	if resp.OpenStrategy.Params["fast_period"] != 8 {
 		t.Fatalf("merged fast_period = %v, want 8", resp.OpenStrategy.Params["fast_period"])
 	}
+	if resp.ApplyRequiresRestart {
+		t.Fatal("expected apply_requires_restart=false with no overrides")
+	}
 	foundRuntime := false
 	foundParam := false
 	for _, field := range resp.EditableFields {
@@ -66,17 +93,33 @@ func TestBuildUIStrategyConfigFields(t *testing.T) {
 	}
 }
 
+func TestTunerApplyRequiresRestart(t *testing.T) {
+	if !tunerApplyRequiresRestart(map[string]json.RawMessage{"htf_filter": json.RawMessage(`true`)}, false) {
+		t.Fatal("htf_filter override should require restart")
+	}
+	if tunerApplyRequiresRestart(map[string]json.RawMessage{"interval_seconds": json.RawMessage(`60`)}, false) {
+		t.Fatal("interval_seconds alone should not require restart")
+	}
+	if !tunerApplyRequiresRestart(map[string]json.RawMessage{"leverage": json.RawMessage(`5`)}, true) {
+		t.Fatal("leverage override with open position should require restart")
+	}
+}
+
 func TestApplyStrategyConfigPatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
 	body := `{
+  "config_version": 14,
+  "interval_seconds": 60,
   "strategies": [
     {
       "id": "spot-btc",
       "type": "spot",
       "platform": "binanceus",
+      "script": "shared_scripts/check_strategy.py",
       "args": ["sma", "BTC/USDT", "1h"],
-      "open_strategy": {"name": "sma", "params": {"period": 20}}
+      "capital": 1000,
+      "open_strategy": {"name": "sma_crossover", "params": {"fast_period": 20, "slow_period": 50}}
     }
   ]
 }`
@@ -88,16 +131,20 @@ func TestApplyStrategyConfigPatch(t *testing.T) {
 		Type:            "spot",
 		IntervalSeconds: 7200,
 		OpenStrategy: StrategyRef{
-			Name:   "sma",
-			Params: map[string]interface{}{"period": 10},
+			Name:   "sma_crossover",
+			Params: map[string]interface{}{"fast_period": 10, "slow_period": 50},
 		},
 	}
-	restartRequired, err := applyStrategyConfigPatch(path, "spot-btc", merged)
+	overrides := map[string]json.RawMessage{
+		"interval_seconds":                 json.RawMessage(`7200`),
+		"open_strategy.params.fast_period": json.RawMessage(`10`),
+	}
+	restartRequired, err := applyStrategyConfigPatch(path, "spot-btc", merged, overrides, false)
 	if err != nil {
 		t.Fatalf("applyStrategyConfigPatch: %v", err)
 	}
-	if !restartRequired {
-		t.Fatal("expected restartRequired=true")
+	if restartRequired {
+		t.Fatal("expected restartRequired=false for interval/param overrides")
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -115,10 +162,99 @@ func TestApplyStrategyConfigPatch(t *testing.T) {
 	if root.Strategies[0]["interval_seconds"] != float64(7200) {
 		t.Fatalf("interval_seconds = %v, want 7200", root.Strategies[0]["interval_seconds"])
 	}
-	openRef := root.Strategies[0]["open_strategy"].(map[string]interface{})
-	params := openRef["params"].(map[string]interface{})
-	if params["period"] != float64(10) {
-		t.Fatalf("period = %v, want 10", params["period"])
+	rawOpen, ok := root.Strategies[0]["open_strategy"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("open_strategy = %v, want object", root.Strategies[0]["open_strategy"])
+	}
+	params, ok := rawOpen["params"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("open_strategy.params = %v, want object", rawOpen["params"])
+	}
+	if params["fast_period"] != float64(10) {
+		t.Fatalf("fast_period = %v, want 10", params["fast_period"])
+	}
+}
+
+func TestPatchStrategyJSONParamsPreserved(t *testing.T) {
+	item := map[string]json.RawMessage{
+		"open_strategy": mustRawJSON(t, map[string]interface{}{
+			"name":   "sma_crossover",
+			"params": map[string]interface{}{"fast_period": 20.0, "slow_period": 50.0},
+		}),
+	}
+	merged := StrategyConfig{
+		Type: "spot",
+		OpenStrategy: StrategyRef{
+			Name:   "sma_crossover",
+			Params: map[string]interface{}{"fast_period": 10, "slow_period": 50},
+		},
+	}
+	overrides := map[string]json.RawMessage{
+		"open_strategy.params.fast_period": json.RawMessage(`10`),
+	}
+	patched, err := patchStrategyJSON(item, merged, overrides)
+	if err != nil {
+		t.Fatalf("patchStrategyJSON: %v", err)
+	}
+	var ref StrategyRef
+	if err := json.Unmarshal(patched["open_strategy"], &ref); err != nil {
+		t.Fatalf("unmarshal open_strategy: %v", err)
+	}
+	if ref.Params["fast_period"] != float64(10) {
+		t.Fatalf("fast_period = %v, want 10", ref.Params["fast_period"])
+	}
+	if ref.Params["slow_period"] != float64(50) {
+		t.Fatalf("slow_period = %v, want 50 preserved", ref.Params["slow_period"])
+	}
+}
+
+func TestPatchStrategyJSONSkipsUntouched(t *testing.T) {
+	item := map[string]json.RawMessage{
+		"invert_signal": mustRawJSON(t, true),
+		"htf_filter":    mustRawJSON(t, false),
+	}
+	merged := StrategyConfig{
+		Type:         "perps",
+		InvertSignal: false,
+		HTFFilter:    true,
+		Leverage:     3,
+	}
+	overrides := map[string]json.RawMessage{
+		"leverage": json.RawMessage(`3`),
+	}
+	patched, err := patchStrategyJSON(item, merged, overrides)
+	if err != nil {
+		t.Fatalf("patchStrategyJSON: %v", err)
+	}
+	var invert bool
+	if err := json.Unmarshal(patched["invert_signal"], &invert); err != nil || !invert {
+		t.Fatalf("invert_signal = %v, want true preserved", invert)
+	}
+	if _, ok := patched["htf_filter"]; !ok {
+		t.Fatal("htf_filter should remain untouched")
+	}
+	var lev float64
+	if err := json.Unmarshal(patched["leverage"], &lev); err != nil || lev != 3 {
+		t.Fatalf("leverage = %v, want 3", lev)
+	}
+}
+
+func TestRequireMutatingAPIAuth(t *testing.T) {
+	ss := NewStatusServer(NewAppState(), nil, "", nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/strategies/x/config", nil)
+	w := httptest.NewRecorder()
+	if ss.requireMutatingAPIAuth(w, req) {
+		t.Fatal("expected auth failure when status_token unset")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+
+	ss = NewStatusServer(NewAppState(), nil, "secret", nil, nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	w = httptest.NewRecorder()
+	if !ss.requireMutatingAPIAuth(w, req) {
+		t.Fatal("expected auth success with matching token")
 	}
 }
 
@@ -136,4 +272,13 @@ func TestSimulateConfigPayloadOpenFallback(t *testing.T) {
 	if openRef.Name != "sma" {
 		t.Fatalf("open_strategy.name = %q, want sma", openRef.Name)
 	}
+}
+
+func mustRawJSON(t *testing.T, v interface{}) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return raw
 }

--- a/scheduler/ui_tuner_test.go
+++ b/scheduler/ui_tuner_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMergeStrategyTunerOverrides(t *testing.T) {
+	base := StrategyConfig{
+		ID:              "spot-btc",
+		Type:            "spot",
+		IntervalSeconds: 3600,
+		OpenStrategy: StrategyRef{
+			Name:   "sma",
+			Params: map[string]interface{}{"period": 20},
+		},
+	}
+	overrides := map[string]json.RawMessage{
+		"interval_seconds":            json.RawMessage(`7200`),
+		"open_strategy.params.period": json.RawMessage(`10`),
+	}
+	merged, err := mergeStrategyTunerOverrides(base, overrides)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if merged.IntervalSeconds != 7200 {
+		t.Fatalf("interval_seconds = %d, want 7200", merged.IntervalSeconds)
+	}
+	if merged.OpenStrategy.Params["period"] != float64(10) && merged.OpenStrategy.Params["period"] != 10 {
+		t.Fatalf("period = %v, want 10", merged.OpenStrategy.Params["period"])
+	}
+}
+
+func TestBuildUIStrategyConfigFields(t *testing.T) {
+	stop := 2.5
+	sc := StrategyConfig{
+		ID:              "hl-btc",
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		Args:            []string{"triple_ema", "BTC", "1h"},
+		IntervalSeconds: 3600,
+		Direction:       DirectionLong,
+		Leverage:        5,
+		StopLossATRMult: &stop,
+		OpenStrategy:    StrategyRef{Name: "triple_ema", Params: map[string]interface{}{"fast_period": 8}},
+	}
+	defaults := map[string]interface{}{"fast_period": 12, "slow_period": 26}
+	resp := buildUIStrategyConfig(sc, defaults, "", false)
+	if resp.OpenStrategy.Params["fast_period"] != 8 {
+		t.Fatalf("merged fast_period = %v, want 8", resp.OpenStrategy.Params["fast_period"])
+	}
+	foundRuntime := false
+	foundParam := false
+	for _, field := range resp.EditableFields {
+		if field.Key == "leverage" {
+			foundRuntime = true
+		}
+		if field.Key == "open_strategy.params.fast_period" {
+			foundParam = true
+		}
+	}
+	if !foundRuntime || !foundParam {
+		t.Fatalf("editable fields missing runtime/param: %+v", resp.EditableFields)
+	}
+}
+
+func TestApplyStrategyConfigPatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	body := `{
+  "strategies": [
+    {
+      "id": "spot-btc",
+      "type": "spot",
+      "platform": "binanceus",
+      "args": ["sma", "BTC/USDT", "1h"],
+      "open_strategy": {"name": "sma", "params": {"period": 20}}
+    }
+  ]
+}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	merged := StrategyConfig{
+		ID:              "spot-btc",
+		Type:            "spot",
+		IntervalSeconds: 7200,
+		OpenStrategy: StrategyRef{
+			Name:   "sma",
+			Params: map[string]interface{}{"period": 10},
+		},
+	}
+	restartRequired, err := applyStrategyConfigPatch(path, "spot-btc", merged)
+	if err != nil {
+		t.Fatalf("applyStrategyConfigPatch: %v", err)
+	}
+	if !restartRequired {
+		t.Fatal("expected restartRequired=true")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var root struct {
+		Strategies []map[string]interface{} `json:"strategies"`
+	}
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if len(root.Strategies) != 1 {
+		t.Fatalf("strategies len = %d, want 1", len(root.Strategies))
+	}
+	if root.Strategies[0]["interval_seconds"] != float64(7200) {
+		t.Fatalf("interval_seconds = %v, want 7200", root.Strategies[0]["interval_seconds"])
+	}
+	openRef := root.Strategies[0]["open_strategy"].(map[string]interface{})
+	params := openRef["params"].(map[string]interface{})
+	if params["period"] != float64(10) {
+		t.Fatalf("period = %v, want 10", params["period"])
+	}
+}
+
+func TestSimulateConfigPayloadOpenFallback(t *testing.T) {
+	sc := StrategyConfig{
+		Type:     "spot",
+		Platform: "binanceus",
+		Args:     []string{"sma", "BTC/USDT", "1h"},
+	}
+	payload := simulateConfigPayload(sc, nil)
+	if payload["strategy"] != "sma" {
+		t.Fatalf("strategy = %v, want sma", payload["strategy"])
+	}
+	openRef := payload["open_strategy"].(StrategyRef)
+	if openRef.Name != "sma" {
+		t.Fatalf("open_strategy.name = %q, want sma", openRef.Name)
+	}
+}

--- a/scheduler/version_probe.go
+++ b/scheduler/version_probe.go
@@ -81,6 +81,12 @@ var fetchCandlesProbeArgv = []string{
 	"--platform=binanceus", "--type=spot", "--symbol=BTC/USDT", "--timeframe=1h", "--limit=1", "--probe-only",
 }
 
+var strategyTunerSchemaProbeArgv = []string{
+	"--type=spot", "--strategy=sma", "--probe-only",
+}
+
+var simulateStrategyProbeArgv = []string{"--probe-only"}
+
 const probeTimeout = 15 * time.Second
 
 // probeCheckScripts invokes each unique check script configured in cfg
@@ -123,6 +129,12 @@ func probeCheckScripts(cfg *Config) error {
 	}
 	if len(scripts) > 0 {
 		if err := probeOneCheckScriptFn("shared_scripts/fetch_candles.py", fetchCandlesProbeArgv); err != nil {
+			return err
+		}
+		if err := probeOneCheckScriptFn("shared_scripts/strategy_tuner_schema.py", strategyTunerSchemaProbeArgv); err != nil {
+			return err
+		}
+		if err := probeOneCheckScriptFn("shared_scripts/simulate_strategy.py", simulateStrategyProbeArgv); err != nil {
 			return err
 		}
 	}

--- a/scheduler/version_probe_test.go
+++ b/scheduler/version_probe_test.go
@@ -56,6 +56,8 @@ exec /usr/bin/env python3 "$@"
 		t.Fatalf("mkdir shared_scripts: %v", err)
 	}
 	writeProbeStub(t, fetchDir, "fetch_candles.py", true)
+	writeProbeStub(t, fetchDir, "strategy_tuner_schema.py", true)
+	writeProbeStub(t, fetchDir, "simulate_strategy.py", true)
 
 	prevCwd, _ := os.Getwd()
 	if err := os.Chdir(tmp); err != nil {
@@ -175,6 +177,14 @@ func TestProbeRunsExtraArgvForHL(t *testing.T) {
 	candles := calls["shared_scripts/fetch_candles.py"]
 	if len(candles) != 1 || candles[0] != "signal" {
 		t.Errorf("dashboard candle helper should be probed once, got %v", candles)
+	}
+	schema := calls["shared_scripts/strategy_tuner_schema.py"]
+	if len(schema) != 1 || schema[0] != "signal" {
+		t.Errorf("strategy tuner schema helper should be probed once, got %v", schema)
+	}
+	simulate := calls["shared_scripts/simulate_strategy.py"]
+	if len(simulate) != 1 || simulate[0] != "signal" {
+		t.Errorf("simulate helper should be probed once, got %v", simulate)
 	}
 }
 

--- a/shared_scripts/simulate_strategy.py
+++ b/shared_scripts/simulate_strategy.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import os
 import sys
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import pandas as pd
 
@@ -20,7 +19,6 @@ sys.path.insert(0, os.path.join(ROOT, "backtest"))
 
 from atr import ensure_atr_indicator  # noqa: E402
 from backtester import Backtester  # noqa: E402
-from htf_filter import apply_htf_filter, get_default_htf  # noqa: E402
 from registry_loader import load_registry  # noqa: E402
 from run_backtest import _apply_htf_filter_to_df  # noqa: E402
 

--- a/shared_scripts/simulate_strategy.py
+++ b/shared_scripts/simulate_strategy.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Replay strategy signals over dashboard candles for what-if preview (#811)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, "shared_tools"))
+sys.path.insert(0, os.path.join(ROOT, "backtest"))
+
+from atr import ensure_atr_indicator  # noqa: E402
+from backtester import Backtester  # noqa: E402
+from htf_filter import apply_htf_filter, get_default_htf  # noqa: E402
+from registry_loader import load_registry  # noqa: E402
+from run_backtest import _apply_htf_filter_to_df  # noqa: E402
+
+
+def _registry_for_type(strategy_type: str) -> str:
+    if strategy_type in ("perps", "futures", "manual"):
+        return "futures"
+    return "spot"
+
+
+def _fee_platform(platform: str, strategy_type: str) -> str:
+    if strategy_type in ("perps", "manual") and platform == "hyperliquid":
+        return "hyperliquid"
+    if strategy_type == "perps" and platform == "okx":
+        return "okx-perps"
+    if platform in ("binanceus", "hyperliquid", "robinhood", "luno", "okx", "okx-perps"):
+        return platform
+    return "binanceus"
+
+
+def _candles_to_df(candles: List[dict]) -> pd.DataFrame:
+    if not candles:
+        return pd.DataFrame()
+    rows = []
+    index = []
+    for candle in candles:
+        ts = int(candle.get("time") or 0)
+        if ts <= 0:
+            continue
+        dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+        rows.append(
+            {
+                "open": float(candle.get("open") or 0),
+                "high": float(candle.get("high") or 0),
+                "low": float(candle.get("low") or 0),
+                "close": float(candle.get("close") or 0),
+                "volume": float(candle.get("volume") or 0),
+            }
+        )
+        index.append(dt)
+    if not rows:
+        return pd.DataFrame()
+    df = pd.DataFrame(rows, index=pd.DatetimeIndex(index, tz=timezone.utc))
+    return df.sort_index()
+
+
+def _trade_to_markers(trade: dict) -> List[dict]:
+    markers: List[dict] = []
+    entry_ts = _parse_ts(trade.get("entry_date"))
+    exit_ts = _parse_ts(trade.get("exit_date"))
+    side = str(trade.get("side") or "long").lower()
+    entry_price = float(trade.get("entry_price") or 0)
+    exit_price = float(trade.get("exit_price") or 0)
+    pnl = float(trade.get("pnl") or 0)
+
+    if entry_ts:
+        if side == "short":
+            markers.append(_marker(entry_ts, "sell", False, entry_price))
+        else:
+            markers.append(_marker(entry_ts, "buy", False, entry_price))
+    if exit_ts:
+        markers.append(_marker(exit_ts, "close", True, exit_price, pnl))
+    return markers
+
+
+def _parse_ts(raw: Any) -> int:
+    if raw is None or raw == "" or raw == "None":
+        return 0
+    if isinstance(raw, (int, float)):
+        return int(raw)
+    text = str(raw).strip()
+    if not text:
+        return 0
+    try:
+        if text.isdigit():
+            return int(text)
+        dt = pd.Timestamp(text)
+        if dt.tzinfo is None:
+            dt = dt.tz_localize("UTC")
+        else:
+            dt = dt.tz_convert("UTC")
+        return int(dt.timestamp())
+    except Exception:
+        return 0
+
+
+def _marker(time: int, kind: str, is_close: bool, price: float, pnl: float = 0.0) -> dict:
+    if kind == "buy":
+        return {
+            "time": time,
+            "position": "belowBar",
+            "color": "#059669",
+            "shape": "arrowUp",
+            "text": "BUY",
+            "side": "buy",
+            "is_close": False,
+            "price": price,
+        }
+    if kind == "sell":
+        return {
+            "time": time,
+            "position": "aboveBar",
+            "color": "#dc2626",
+            "shape": "arrowDown",
+            "text": "SELL",
+            "side": "sell",
+            "is_close": False,
+            "price": price,
+        }
+    return {
+        "time": time,
+        "position": "aboveBar",
+        "color": "#2563eb",
+        "shape": "circle",
+        "text": "CLOSE",
+        "side": "sell" if is_close else "buy",
+        "is_close": True,
+        "price": price,
+        "realized_pnl": pnl,
+    }
+
+
+def _simulate_one(cfg: dict, candles: List[dict]) -> List[dict]:
+    strategy_type = str(cfg.get("type") or "spot")
+    if strategy_type == "options":
+        raise ValueError("options strategies are not supported by the tuner preview yet")
+
+    platform = str(cfg.get("platform") or "binanceus")
+    symbol = str(cfg.get("symbol") or "")
+    timeframe = str(cfg.get("timeframe") or "")
+    open_ref = dict(cfg.get("open_strategy") or {})
+    open_name = str(open_ref.get("name") or cfg.get("strategy") or "").strip()
+    if not open_name:
+        raise ValueError("missing open strategy name")
+
+    reg = load_registry(_registry_for_type(strategy_type))
+    if open_name not in reg.STRATEGY_REGISTRY:
+        raise ValueError(f"unknown strategy {open_name!r}")
+
+    df = _candles_to_df(candles)
+    if df.empty or len(df) < 3:
+        return []
+
+    params = dict(open_ref.get("params") or {})
+    defaults = dict(reg.STRATEGY_REGISTRY[open_name].get("default_params") or {})
+    merged_params = {**defaults, **params}
+
+    df_signals = reg.apply_strategy(open_name, df, merged_params)
+    close_refs = [dict(r) for r in (cfg.get("close_strategies") or [])]
+    if close_refs:
+        df_signals = ensure_atr_indicator(df_signals)
+
+    if cfg.get("htf_filter"):
+        df_signals = _apply_htf_filter_to_df(df_signals, symbol, timeframe)
+
+    regime_cfg = dict(cfg.get("regime") or {})
+    regime_enabled = bool(regime_cfg.get("enabled"))
+    allowed = list(cfg.get("allowed_regimes") or [])
+
+    bt = Backtester(
+        initial_capital=float(cfg.get("initial_capital") or 1000),
+        platform=_fee_platform(platform, strategy_type),
+        open_strategy={"name": open_name, "params": merged_params},
+        close_strategies=close_refs,
+        regime_enabled=regime_enabled,
+        regime_period=int(regime_cfg.get("period") or 14),
+        regime_adx_threshold=float(regime_cfg.get("adx_threshold") or 20),
+        allowed_regimes=allowed,
+        stop_loss_atr_mult=cfg.get("stop_loss_atr_mult"),
+        stop_loss_pct=cfg.get("stop_loss_pct"),
+        stop_loss_margin_pct=cfg.get("stop_loss_margin_pct"),
+        trailing_stop_atr_mult=cfg.get("trailing_stop_atr_mult"),
+        trailing_stop_pct=cfg.get("trailing_stop_pct"),
+        stop_loss_atr_regime=cfg.get("stop_loss_atr_regime"),
+        trailing_stop_atr_regime=cfg.get("trailing_stop_atr_regime"),
+        strategy_type=strategy_type,
+    )
+    results = bt.run(
+        df_signals,
+        strategy_name=open_name,
+        symbol=symbol,
+        timeframe=timeframe,
+        params=merged_params,
+        save=False,
+    )
+    markers: List[dict] = []
+    for trade in results.get("trades") or []:
+        markers.extend(_trade_to_markers(trade))
+    markers.sort(key=lambda m: (m.get("time") or 0, m.get("text") or ""))
+    return markers
+
+
+def _run_payload(payload: dict) -> dict:
+    candles = list(payload.get("candles") or [])
+    configs = list(payload.get("configs") or [])
+    if not candles:
+        return {"error": "no candles supplied", "markers": {}}
+    if not configs:
+        return {"error": "no configs supplied", "markers": {}}
+
+    out: Dict[str, List[dict]] = {}
+    for item in configs:
+        label = str(item.get("label") or "default")
+        cfg = dict(item.get("config") or item)
+        try:
+            out[label] = _simulate_one(cfg, candles)
+        except Exception as exc:
+            return {"error": f"{label}: {exc}", "markers": out}
+    return {"markers": out}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--probe-only", action="store_true")
+    args = parser.parse_args()
+
+    if args.probe_only:
+        print(json.dumps({"ok": True}))
+        return
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print(json.dumps({"error": "empty stdin"}))
+        sys.exit(1)
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(json.dumps({"error": f"invalid json: {exc}"}))
+        sys.exit(1)
+
+    try:
+        result = _run_payload(payload)
+    except Exception as exc:
+        print(json.dumps({"error": str(exc), "markers": {}}))
+        sys.exit(1)
+
+    if result.get("error"):
+        print(json.dumps(result))
+        sys.exit(1)
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/shared_scripts/strategy_tuner_schema.py
+++ b/shared_scripts/strategy_tuner_schema.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Return open-strategy default params for the dashboard tuner (#811)."""
+
+import argparse
+import json
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(ROOT, "backtest"))
+
+from registry_loader import load_registry  # noqa: E402
+
+
+def _registry_for_type(strategy_type: str) -> str:
+    if strategy_type in ("perps", "futures", "manual"):
+        return "futures"
+    return "spot"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--type", default="spot")
+    parser.add_argument("--strategy", required=True)
+    parser.add_argument("--probe-only", action="store_true")
+    args = parser.parse_args()
+
+    if args.probe_only:
+        print(json.dumps({"ok": True}))
+        return
+
+    reg_key = _registry_for_type(args.type)
+    reg = load_registry(reg_key)
+    name = args.strategy.strip()
+    strat = reg.STRATEGY_REGISTRY.get(name)
+    if not strat:
+        print(json.dumps({"error": f"unknown strategy {name!r} in {reg_key} registry"}))
+        sys.exit(1)
+
+    print(
+        json.dumps(
+            {
+                "strategy": name,
+                "registry": reg_key,
+                "description": strat.get("description", ""),
+                "default_params": dict(strat.get("default_params") or {}),
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `/api/strategies/{id}/config` (GET), `/simulate` (POST), and config apply (POST) endpoints for read-only param preview and atomic config writes
- Introduces `strategy_tuner_schema.py` and `simulate_strategy.py` to derive registry defaults and replay signals over freshly fetched candles via the backtester
- Adds a Strategy tuner panel to the dashboard with debounced preview, faded live vs bright simulated markers, reset-to-live, and apply-with-confirmation

## Test plan
- [x] `go test ./...` in `scheduler/`
- [x] `uv run --no-sync python -m py_compile shared_scripts/simulate_strategy.py shared_scripts/strategy_tuner_schema.py`
- [x] Manual smoke: `simulate_strategy.py` returns markers for `sma_crossover` over sample candles
- [ ] Open `/dashboard`, select a strategy, tweak indicator params, confirm chart markers update
- [ ] Apply tuned config and verify `config.json` updates; restart when prompted

Closes #811

---
LLM: Composer | high