### PR TITLE
Stop systemd restart loop on startup probe failure

### DIFF
--- a/go-trader.service
+++ b/go-trader.service
@@ -12,6 +12,8 @@ WorkingDirectory=/opt/go-trader
 ExecStart=/opt/go-trader/go-trader --config /opt/go-trader/scheduler/config.json
 Restart=always
 RestartSec=10
+# Probe/deploy failures exit 78 — do not restart until scripts are synced.
+RestartPreventExitStatus=78
 StandardOutput=journal
 StandardError=journal
 

--- a/scheduler/exit_codes.go
+++ b/scheduler/exit_codes.go
@@ -1,0 +1,7 @@
+package main
+
+// ExitProbeFailure is used when the startup compatibility probe fails (missing
+// Python scripts, argparse mismatch, probe timeout). systemd units should set
+// RestartPreventExitStatus=78 so the service stays down instead of restarting
+// every RestartSec and spamming Discord. (EX_CONFIG from sysexits.h.)
+const ExitProbeFailure = 78

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -400,17 +400,14 @@ func main() {
 	}
 
 	// #645: Verify each configured check script accepts the binary's argv
-	// shape before entering the trading loop. An asymmetric deploy (binary
-	// from one commit, Python scripts from an older one) caused 18h of
-	// silent argparse crashes after #642 — fail fast instead so the
-	// operator is paged immediately and systemd's restart loop makes the
-	// breakage visible in `systemctl status`.
+	// shape before entering the trading loop. Exit ExitProbeFailure so
+	// systemd RestartPreventExitStatus= stops restart spam (one DM, stay down).
 	if err := probeCheckScripts(cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "[startup] check-script compatibility probe failed: %v\n", err)
 		if notifier != nil && notifier.HasOwner() {
-			notifier.SendOwnerDM(fmt.Sprintf("**Startup probe failed** — check-script CLI mismatch:\n```\n%v\n```\nLikely cause: binary and Python scripts deployed from different commits. Refusing to start.", err))
+			notifier.SendOwnerDM(fmt.Sprintf("**Startup probe failed** — refusing to start (exit %d; fix deploy, then restart):\n```\n%v\n```", ExitProbeFailure, err))
 		}
-		os.Exit(1)
+		os.Exit(ExitProbeFailure)
 	}
 
 	// Track the last remote hash we notified about to avoid re-notifying on every cycle.

--- a/scheduler/probe_cmd.go
+++ b/scheduler/probe_cmd.go
@@ -26,7 +26,7 @@ func runProbe(args []string) int {
 
 	if err := probeCheckScripts(cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "probe: %v\n", err)
-		return 1
+		return ExitProbeFailure
 	}
 
 	fmt.Printf("probe: OK (%d unique check scripts, version=%s)\n", len(uniqueCheckScripts(cfg)), Version)

--- a/scheduler/probe_cmd_test.go
+++ b/scheduler/probe_cmd_test.go
@@ -19,6 +19,39 @@ func TestRunProbeMissingConfig(t *testing.T) {
 	}
 }
 
+// TestRunProbeReturnsExitProbeFailureOnScriptFailure locks the exit code
+// update.sh and systemd RestartPreventExitStatus= depend on.
+func TestRunProbeReturnsExitProbeFailureOnScriptFailure(t *testing.T) {
+	orig := probeOneCheckScriptFn
+	defer func() { probeOneCheckScriptFn = orig }()
+	probeOneCheckScriptFn = func(script string, argv []string) error {
+		return formatProbeFailure(script, os.ErrInvalid, "error: unrecognized arguments: --probe-only", "")
+	}
+
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.json")
+	body, _ := json.Marshal(map[string]any{
+		"interval_seconds": 60,
+		"strategies": []any{
+			map[string]any{
+				"id":               "spot-a",
+				"type":             "spot",
+				"script":           "shared_scripts/check_strategy.py",
+				"args":             []string{"sma", "BTC/USDT", "1h"},
+				"interval_seconds": 60,
+				"capital":          1000.0,
+			},
+		},
+	})
+	if err := os.WriteFile(cfgPath, body, 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+	rc := runProbe([]string{"--config", cfgPath})
+	if rc != ExitProbeFailure {
+		t.Fatalf("probe script failure should return %d, got %d", ExitProbeFailure, rc)
+	}
+}
+
 // TestRunProbeNoStrategies: an empty strategies list means no scripts to
 // probe, so probe trivially succeeds — this is acceptable: a config with no
 // configured strategies has no Python contract to validate.

--- a/scheduler/version_probe.go
+++ b/scheduler/version_probe.go
@@ -192,5 +192,14 @@ func formatProbeFailure(script string, runErr error, stderr, stdout string) erro
 	if detail == "" {
 		detail = runErr.Error()
 	}
+	if probeFailureScriptMissing(detail) {
+		return fmt.Errorf("%s missing from deploy tree (sync Python with binary, e.g. scripts/update.sh): %s", script, detail)
+	}
 	return fmt.Errorf("%s rejected --probe-only argv (binary/Python version mismatch?): %s", script, detail)
+}
+
+func probeFailureScriptMissing(detail string) bool {
+	return strings.Contains(detail, "can't open file") ||
+		strings.Contains(detail, "No such file or directory") ||
+		strings.Contains(detail, "No such file:")
 }

--- a/scheduler/version_probe.go
+++ b/scheduler/version_probe.go
@@ -199,7 +199,8 @@ func formatProbeFailure(script string, runErr error, stderr, stdout string) erro
 }
 
 func probeFailureScriptMissing(detail string) bool {
-	return strings.Contains(detail, "can't open file") ||
-		strings.Contains(detail, "No such file or directory") ||
-		strings.Contains(detail, "No such file:")
+	// Python reports a missing probe script as "can't open file '…': [Errno 2] …".
+	// Avoid broader ENOENT substrings so internal FileNotFoundError from a real
+	// script is not mislabeled as a deploy-tree gap.
+	return strings.Contains(detail, "can't open file")
 }

--- a/scheduler/version_probe_test.go
+++ b/scheduler/version_probe_test.go
@@ -205,3 +205,14 @@ func TestFormatProbeFailureFallsBackThroughChannels(t *testing.T) {
 		t.Errorf("should fall back to runErr; got %q", err.Error())
 	}
 }
+
+func TestFormatProbeFailureScriptMissing(t *testing.T) {
+	stderr := ".venv/bin/python3: can't open file 'shared_scripts/strategy_tuner_schema.py': [Errno 2] No such file or directory"
+	err := formatProbeFailure("shared_scripts/strategy_tuner_schema.py", os.ErrInvalid, stderr, "")
+	if !strings.Contains(err.Error(), "missing from deploy tree") {
+		t.Errorf("want missing-script wording; got %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "rejected --probe-only") {
+		t.Errorf("should not label missing file as CLI mismatch; got %q", err.Error())
+	}
+}

--- a/systemd/go-trader@.service
+++ b/systemd/go-trader@.service
@@ -12,6 +12,8 @@ WorkingDirectory=/opt/go-trader-%i
 ExecStart=/opt/go-trader-%i/go-trader --config /opt/go-trader-%i/scheduler/config.json
 Restart=always
 RestartSec=10
+# Probe/deploy failures exit 78 — do not restart until scripts are synced.
+RestartPreventExitStatus=78
 # Drain budget: shutdown.go caps in-flight side-effecting subprocesses at 15s
 # (shutdownDrainCap), then the deferred state save + notifier flush + DB
 # close run. 20s gives the binary the full drain plus a 5s buffer before


### PR DESCRIPTION
## Summary

- Exit **78** (`ExitProbeFailure`) when the startup compatibility probe fails so operators get one failure, not a `Restart=always` loop every 10s.
- Add `RestartPreventExitStatus=78` to `go-trader.service` and `systemd/go-trader@.service`.
- Report missing probe scripts (`can't open file`) as deploy-tree gaps, not "CLI mismatch".
- `go-trader probe` returns 78 on failure (update.sh still treats any non-zero as abort).

Closes #820

## Test plan

- [x] `go test ./scheduler/ -run 'Probe|FormatProbe'`
- [ ] After deploy: induce probe failure (rename `strategy_tuner_schema.py`); confirm exit 78, single DM, `systemctl status` shows **failed (Result: exit-code)** — not activating in a loop
- [ ] `sudo systemctl daemon-reload` after installing updated unit file
- [ ] Fix deploy with `scripts/update.sh`; confirm probe passes and service starts