### PR TITLE
Perps: auto-resolve orphan positions from regime/direction flips

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -279,7 +279,7 @@ func fetchHyperliquidState(accountAddress string) (float64, []HLPosition, error)
 // cached resolver outside the lock and call
 // reconcileHyperliquidPositionsWithResolver.
 func reconcileHyperliquidPositions(stratState *StrategyState, sym string, positions []HLPosition, accountAddress string, logger *StrategyLogger) bool {
-	return reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, directHyperliquidReconcileFillResolver(accountAddress), logger, nil, StrategyConfig{})
+	return reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, directHyperliquidReconcileFillResolver(accountAddress), logger, nil, nil, StrategyConfig{})
 }
 
 // reconcileHyperliquidPositionsForStrategy is the production entry point with
@@ -308,6 +308,7 @@ func reconcileHyperliquidPositionsForStrategy(
 	resolveFee hlReconcileFillResolver,
 	logger *StrategyLogger,
 	pendingAlerts *[]ProtectionFillAlert,
+	pendingOrphanCloses *[]RegimeDirectionOrphanCloseJob,
 ) bool {
 	if stratState == nil || sym == "" {
 		return false
@@ -318,11 +319,11 @@ func reconcileHyperliquidPositionsForStrategy(
 		// by the booker; the legacy reconciler's qty/side/avgCost resync will
 		// no-op because virtual now matches on-chain. Continue through it for
 		// idempotent housekeeping (multiplier migration, leverage seed).
-		reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, resolveFee, logger, pendingAlerts, sc)
+		reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, resolveFee, logger, pendingAlerts, pendingOrphanCloses, sc)
 		return true
 	}
 
-	return reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, resolveFee, logger, pendingAlerts, sc)
+	return reconcileHyperliquidPositionsWithResolver(stratState, sym, positions, resolveFee, logger, pendingAlerts, pendingOrphanCloses, sc)
 }
 
 // stampSoleOwnerRecoveryTierConsumed mirrors post-protection-sync state for a
@@ -545,7 +546,7 @@ func tryBookSoleOwnerTPFill(
 // When pendingAlerts is non-nil, hlAttemptCloseFromTPFills appends TP fill
 // alerts here (same contract as tryBookSoleOwnerTPFill) for owner DM flush
 // after mu.Unlock (#757 re-review).
-func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym string, positions []HLPosition, resolveFee hlReconcileFillResolver, logger *StrategyLogger, pendingAlerts *[]ProtectionFillAlert, sc StrategyConfig) bool {
+func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym string, positions []HLPosition, resolveFee hlReconcileFillResolver, logger *StrategyLogger, pendingAlerts *[]ProtectionFillAlert, pendingOrphanCloses *[]RegimeDirectionOrphanCloseJob, sc StrategyConfig) bool {
 	changed := false
 
 	// Find the on-chain position for this strategy's symbol.
@@ -603,6 +604,21 @@ func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym st
 			logger.Info("hl-sync: %s leverage init → %v (from on-chain, legacy/zero-value position)", sym, onChainPos.Leverage)
 			statePos.Leverage = onChainPos.Leverage
 			changed = true
+		}
+		if pendingOrphanCloses != nil && sc.ID != "" {
+			if conflict, currentRegime, effectiveDir := perpsRegimeDirectionOrphanConflict(stratState, sc, statePos); conflict {
+				logger.Warn("hl-sync: %s regime/direction orphan — %s qty=%.6f conflicts with current regime %q (effective_direction=%q); queuing auto-close (#822)",
+					sym, statePos.Side, statePos.Quantity, currentRegime, effectiveDir)
+				*pendingOrphanCloses = append(*pendingOrphanCloses, RegimeDirectionOrphanCloseJob{
+					StrategyID:    sc.ID,
+					Symbol:        sym,
+					CloseQty:      statePos.Quantity,
+					CancelOIDs:    hyperliquidProtectionCancelOIDs(statePos),
+					PosSide:       statePos.Side,
+					CurrentRegime: currentRegime,
+					EffectiveDir:  effectiveDir,
+				})
+			}
 		}
 	} else if onChainPos == nil && statePos != nil {
 		// Position in state but not on-chain — closed externally.
@@ -691,7 +707,7 @@ func syncHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppSt
 	// PnL falls back to zero (legacy behavior pre-#584).
 	// This entry point is used by --once and tests; alerts are suppressed
 	// since no notifier is plumbed through here.
-	changed, _ := reconcileHyperliquidAccountPositions(hlStrategies, hlStrategies, state, mu, logMgr, positions, nil, accountAddr, nil, false)
+	changed, _, _ := reconcileHyperliquidAccountPositions(hlStrategies, hlStrategies, state, mu, logMgr, positions, nil, accountAddr, nil, false)
 	return changed
 }
 
@@ -721,7 +737,7 @@ func syncHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppSt
 // `notify_tp_sl_fills: false`.
 //
 // Must be called WITHOUT holding any lock; acquires Lock internally.
-func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager, positions []HLPosition, prices map[string]float64, accountAddress string, notifier *MultiNotifier, notifyTPSLFills bool) (bool, []HyperliquidProtectionFillHint) {
+func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager, positions []HLPosition, prices map[string]float64, accountAddress string, notifier *MultiNotifier, notifyTPSLFills bool) (bool, []HyperliquidProtectionFillHint, []RegimeDirectionOrphanCloseJob) {
 	// Resolve userFills BEFORE taking mu.Lock(): each lookup can sleep up
 	// to ~1.5s on indexer-lag retries, and holding the write lock blocks
 	// every reader of state (/status, /health, per-strategy phase RLocks).
@@ -734,6 +750,7 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 	// closure is registered first, so it fires LAST — after defer mu.Unlock()
 	// has already released the lock (defer runs LIFO).
 	var pendingAlerts []ProtectionFillAlert
+	var pendingOrphanCloses []RegimeDirectionOrphanCloseJob
 	defer func() {
 		for _, a := range pendingAlerts {
 			notifyProtectionFill(notifier, notifyTPSLFills, a)
@@ -788,9 +805,18 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 			fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", sc.ID, err)
 			continue
 		}
-		if reconcileHyperliquidPositionsForStrategy(sc, ss, sym, positions, resolveFee, logger, &pendingAlerts) {
+		if reconcileHyperliquidPositionsForStrategy(sc, ss, sym, positions, resolveFee, logger, &pendingAlerts, &pendingOrphanCloses) {
 			changed = true
 		}
+	}
+
+	if len(pendingOrphanCloses) > 0 {
+		sort.Slice(pendingOrphanCloses, func(i, j int) bool {
+			if pendingOrphanCloses[i].StrategyID != pendingOrphanCloses[j].StrategyID {
+				return pendingOrphanCloses[i].StrategyID < pendingOrphanCloses[j].StrategyID
+			}
+			return pendingOrphanCloses[i].Symbol < pendingOrphanCloses[j].Symbol
+		})
 	}
 
 	// For shared coins: apply non-destructive updates (multiplier migration,
@@ -1255,7 +1281,148 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 		}
 	}
 
-	return changed, fillHints
+	return changed, fillHints, pendingOrphanCloses
+}
+
+// hyperliquidProtectionCancelOIDs collects resting SL/TP trigger OIDs to cancel
+// before a reduce-only flatten (#421).
+func hyperliquidProtectionCancelOIDs(pos *Position) []int64 {
+	if pos == nil {
+		return nil
+	}
+	var oids []int64
+	oids = appendUniquePositiveStopLossOID(oids, pos.StopLossOID)
+	for _, tpOID := range pos.TPOIDs {
+		oids = appendUniquePositiveStopLossOID(oids, tpOID)
+	}
+	return oids
+}
+
+// runRegimeDirectionOrphanCloses drains jobs queued by hl-sync reconcile when
+// a sole-owner position conflicts with the current regime direction (#822).
+// Must run without holding mu (subprocess I/O). Caller should invoke immediately
+// after reconcileHyperliquidAccountPositions returns.
+func runRegimeDirectionOrphanCloses(
+	ctx context.Context,
+	state *AppState,
+	strategies []StrategyConfig,
+	jobs []RegimeDirectionOrphanCloseJob,
+	positions []HLPosition,
+	closer HyperliquidLiveCloser,
+	mu *sync.RWMutex,
+	ownerDM func(string),
+) {
+	if ctx == nil || state == nil || closer == nil || len(jobs) == 0 {
+		return
+	}
+	ctxOverall, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+
+	strategyByID := make(map[string]StrategyConfig, len(strategies))
+	for _, sc := range strategies {
+		strategyByID[sc.ID] = sc
+	}
+
+	for _, job := range jobs {
+		if err := ctxOverall.Err(); err != nil {
+			fmt.Printf("[CRITICAL] hl-regime-orphan-close: budget exhausted: %v\n", err)
+			return
+		}
+		sc, ok := strategyByID[job.StrategyID]
+		if !ok || sc.Type != "perps" || !hyperliquidIsLive(sc.Args) {
+			continue
+		}
+		sym := job.Symbol
+		if sym == "" {
+			continue
+		}
+		var hlPeerScope []StrategyConfig
+		for _, s := range strategies {
+			if isHLLiveReconcilable(s) && hyperliquidSymbol(s.Args) == sym {
+				hlPeerScope = append(hlPeerScope, s)
+			}
+		}
+		if len(hlLiveStrategiesForCoin(sym, hlPeerScope)) > 1 {
+			fmt.Printf("[INFO] hl-regime-orphan-close: strategy %s coin %s shares wallet with peers — skipping auto-close (#822)\n",
+				job.StrategyID, sym)
+			continue
+		}
+
+		sz := job.CloseQty
+		var onChainSigned float64
+		for _, p := range positions {
+			if p.Coin != sym {
+				continue
+			}
+			onChainSigned = p.Size
+			absOC := math.Abs(p.Size)
+			if absOC <= 1e-15 {
+				sz = 0
+				break
+			}
+			if sz > absOC {
+				sz = absOC
+			}
+			break
+		}
+		if sz <= 1e-15 {
+			continue
+		}
+		partial := sz
+		result, err := closer(sym, &partial, job.CancelOIDs)
+		if err != nil {
+			msg := fmt.Sprintf("[CRITICAL] hl-regime-orphan-close: strategy %s %s %s qty=%.6f failed: %v (regime=%q effective_direction=%q)",
+				job.StrategyID, job.PosSide, sym, sz, err, job.CurrentRegime, job.EffectiveDir)
+			fmt.Println(msg)
+			if ownerDM != nil {
+				ownerDM(msg)
+			}
+			continue
+		}
+
+		var fillSz, fillPx, fillFee float64
+		alreadyFlat := false
+		if result != nil && result.Close != nil {
+			alreadyFlat = result.Close.AlreadyFlat
+			if result.Close.Fill != nil {
+				fillSz = result.Close.Fill.TotalSz
+				fillPx = result.Close.Fill.AvgPx
+				fillFee = result.Close.Fill.Fee
+			}
+		}
+
+		mu.Lock()
+		if ss := state.Strategies[job.StrategyID]; ss != nil && !alreadyFlat && fillSz > 1e-15 && fillPx > 0 {
+			applyHyperliquidCircuitCloseFill(ss, sym, fillSz, fillPx, fillFee, onChainSigned, "regime_direction_flip")
+		}
+		mu.Unlock()
+
+		info := fmt.Sprintf("hl-regime-orphan-close: strategy %s closed %s %s sz=%.6f (filled %.6f) — regime %q now expects %q (#822)",
+			job.StrategyID, job.PosSide, sym, sz, fillSz, job.CurrentRegime, job.EffectiveDir)
+		fmt.Println("[INFO] " + info)
+		if ownerDM != nil {
+			ownerDM(info)
+		}
+
+		if len(job.CancelOIDs) > 0 && result != nil && result.CancelStopLossSucceeded {
+			mu.Lock()
+			if ss := state.Strategies[job.StrategyID]; ss != nil {
+				if pos, ok := ss.Positions[sym]; ok && pos != nil {
+					for _, cancelOID := range job.CancelOIDs {
+						if cancelOID > 0 && pos.StopLossOID == cancelOID {
+							pos.StopLossOID = 0
+						}
+						for idx, tpOID := range pos.TPOIDs {
+							if cancelOID > 0 && tpOID == cancelOID {
+								pos.TPOIDs[idx] = 0
+							}
+						}
+					}
+				}
+			}
+			mu.Unlock()
+		}
+	}
 }
 
 func hyperliquidSharedPartialCloseDrift(virtualQty, onChainQty float64) (string, float64, bool) {
@@ -1898,7 +2065,7 @@ func applyHyperliquidKillSwitchCloseFill(s *StrategyState, sc StrategyConfig, fi
 	if fillSz <= 1e-15 {
 		return false
 	}
-	applyHyperliquidCircuitCloseFill(s, coin, fillSz, fill.AvgPx, fillFee, 0)
+	applyHyperliquidCircuitCloseFill(s, coin, fillSz, fill.AvgPx, fillFee, 0, "")
 	return true
 }
 
@@ -2179,7 +2346,7 @@ func runPendingHyperliquidCircuitCloses(
 			if !alreadyFlat && fillSz > 1e-15 {
 				mu.Lock()
 				if ss := state.Strategies[j.stratID]; ss != nil {
-					applyHyperliquidCircuitCloseFill(ss, c.Symbol, fillSz, fillPx, fillFee, onChainSigned)
+					applyHyperliquidCircuitCloseFill(ss, c.Symbol, fillSz, fillPx, fillFee, onChainSigned, "")
 				}
 				mu.Unlock()
 			}
@@ -2294,9 +2461,12 @@ func runPendingHyperliquidCircuitCloses(
 // (#418 review observation 4). Pass 0 if the on-chain side is unknown; the
 // trade then falls back to "sell".
 //
-// Caller must hold mu.Lock(). Reason is fixed to "circuit_breaker" for
-// clarity in trade history and closed-position rows.
-func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, fillPx, fillFee, onChainSigned float64) {
+// Caller must hold mu.Lock(). closeReason is stamped on Trade / ClosedPosition
+// rows (defaults to "circuit_breaker" when empty).
+func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, fillPx, fillFee, onChainSigned float64, closeReason string) {
+	if closeReason == "" {
+		closeReason = "circuit_breaker"
+	}
 	if s == nil || fillSz <= 0 || fillPx <= 0 {
 		return
 	}
@@ -2378,7 +2548,7 @@ func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, f
 		// remaining ≈ 0, the original ≈ qtyClosed, so recordClosedPosition's
 		// snapshot of pos.Quantity into ClosedPosition.Quantity captures the
 		// right amount. delete() runs after the snapshot.
-		recordClosedPosition(s, pos, fillPx, pnl, "circuit_breaker", now)
+		recordClosedPosition(s, pos, fillPx, pnl, closeReason, now)
 		delete(s.Positions, symbol)
 		clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
 	} else {

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -1298,6 +1298,25 @@ func hyperliquidProtectionCancelOIDs(pos *Position) []int64 {
 	return oids
 }
 
+// clearHyperliquidProtectionOIDsMatching zeroes resting SL/TP OIDs on the virtual
+// position after the exchange confirms cancel (must run before the position is
+// deleted by applyHyperliquidCircuitCloseFill on a full close).
+func clearHyperliquidProtectionOIDsMatching(pos *Position, cancelOIDs []int64) {
+	if pos == nil {
+		return
+	}
+	for _, cancelOID := range cancelOIDs {
+		if cancelOID > 0 && pos.StopLossOID == cancelOID {
+			pos.StopLossOID = 0
+		}
+		for idx, tpOID := range pos.TPOIDs {
+			if cancelOID > 0 && tpOID == cancelOID {
+				pos.TPOIDs[idx] = 0
+			}
+		}
+	}
+}
+
 // runRegimeDirectionOrphanCloses drains jobs queued by hl-sync reconcile when
 // a sole-owner position conflicts with the current regime direction (#822).
 // Must run without holding mu (subprocess I/O). Caller should invoke immediately
@@ -1392,8 +1411,15 @@ func runRegimeDirectionOrphanCloses(
 		}
 
 		mu.Lock()
-		if ss := state.Strategies[job.StrategyID]; ss != nil && !alreadyFlat && fillSz > 1e-15 && fillPx > 0 {
-			applyHyperliquidCircuitCloseFill(ss, sym, fillSz, fillPx, fillFee, onChainSigned, "regime_direction_flip")
+		if ss := state.Strategies[job.StrategyID]; ss != nil {
+			if pos, ok := ss.Positions[sym]; ok && pos != nil {
+				if len(job.CancelOIDs) > 0 && result != nil && result.CancelStopLossSucceeded {
+					clearHyperliquidProtectionOIDsMatching(pos, job.CancelOIDs)
+				}
+				if !alreadyFlat && fillSz > 1e-15 && fillPx > 0 {
+					applyHyperliquidCircuitCloseFill(ss, sym, fillSz, fillPx, fillFee, onChainSigned, "regime_direction_flip")
+				}
+			}
 		}
 		mu.Unlock()
 
@@ -1402,25 +1428,6 @@ func runRegimeDirectionOrphanCloses(
 		fmt.Println("[INFO] " + info)
 		if ownerDM != nil {
 			ownerDM(info)
-		}
-
-		if len(job.CancelOIDs) > 0 && result != nil && result.CancelStopLossSucceeded {
-			mu.Lock()
-			if ss := state.Strategies[job.StrategyID]; ss != nil {
-				if pos, ok := ss.Positions[sym]; ok && pos != nil {
-					for _, cancelOID := range job.CancelOIDs {
-						if cancelOID > 0 && pos.StopLossOID == cancelOID {
-							pos.StopLossOID = 0
-						}
-						for idx, tpOID := range pos.TPOIDs {
-							if cancelOID > 0 && tpOID == cancelOID {
-								pos.TPOIDs[idx] = 0
-							}
-						}
-					}
-				}
-			}
-			mu.Unlock()
 		}
 	}
 }

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -2461,12 +2461,28 @@ func runPendingHyperliquidCircuitCloses(
 // (#418 review observation 4). Pass 0 if the on-chain side is unknown; the
 // trade then falls back to "sell".
 //
+// hyperliquidOnChainCloseTradeLabel maps closeReason to operator-facing text
+// in Trade.Details (distinct from ClosedPosition.CloseReason).
+func hyperliquidOnChainCloseTradeLabel(closeReason string) string {
+	switch closeReason {
+	case "circuit_breaker":
+		return "Circuit breaker on-chain close"
+	case "regime_direction_flip":
+		return "Regime/direction flip auto-close"
+	case "":
+		return "On-chain close"
+	default:
+		return closeReason + " on-chain close"
+	}
+}
+
 // Caller must hold mu.Lock(). closeReason is stamped on Trade / ClosedPosition
 // rows (defaults to "circuit_breaker" when empty).
 func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, fillPx, fillFee, onChainSigned float64, closeReason string) {
 	if closeReason == "" {
 		closeReason = "circuit_breaker"
 	}
+	closeLabel := hyperliquidOnChainCloseTradeLabel(closeReason)
 	if s == nil || fillSz <= 0 || fillPx <= 0 {
 		return
 	}
@@ -2490,7 +2506,7 @@ func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, f
 			Price:       fillPx,
 			Value:       fillSz * fillPx,
 			TradeType:   "perps",
-			Details:     fmt.Sprintf("Circuit breaker on-chain close (no virtual position), fill=%.6f fee=$%.4f", fillSz, fillFee),
+			Details:     fmt.Sprintf("%s (no virtual position), fill=%.6f fee=$%.4f", closeLabel, fillSz, fillFee),
 			ExchangeFee: exchangeFeeForTrade(fillFee, true),
 			// No virtual position to derive PnL from. Still mark as a close
 			// leg so the lifetime round-trip count (#455) reflects that the
@@ -2529,7 +2545,7 @@ func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, f
 		Price:             fillPx,
 		Value:             qtyClosed * fillPx,
 		TradeType:         "perps",
-		Details:           fmt.Sprintf("Circuit breaker on-chain close, PnL: $%.2f (fee $%.4f)", pnl, fillFee),
+		Details:           fmt.Sprintf("%s, PnL: $%.2f (fee $%.4f)", closeLabel, pnl, fillFee),
 		ExchangeFee:       exchangeFeeForTrade(fillFee, true),
 		IsClose:           true,
 		RealizedPnL:       pnl,

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -989,7 +989,7 @@ func TestReconcileDueSubsetOfAllDetectsSharedCoins(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	_, _ = reconcileHyperliquidAccountPositions(dueStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(dueStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	// Even though only rmc is due, allStrategies reveals ETH is shared by 3
 	// strategies, so rmc's position must NOT be reconciled to on-chain.
@@ -1058,7 +1058,7 @@ func TestReconcileSharedCoinShortAndMixedPositions(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	// Positions should be unchanged.
 	longPos := state.Strategies["hl-long-eth"].Positions["ETH"]
@@ -1121,7 +1121,7 @@ func TestReconcileSharedCoinBothShort(t *testing.T) {
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 
-	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	gap := state.ReconciliationGaps["ETH"]
 	if gap == nil {
@@ -1185,7 +1185,7 @@ func TestReconcileSharedCoin_OwnerStopLossFired_ClosesOwnerOnly(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "0xtest", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "0xtest", nil, false)
 
 	// Owner position must be closed and recorded.
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
@@ -1259,7 +1259,7 @@ func TestReconcileSharedCoin_OwnerStopLossFired_Short(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "0xtest", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "0xtest", nil, false)
 
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
 		t.Error("owner short ETH position should be nil after SL reconciliation")
@@ -1314,7 +1314,7 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "0xtest", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "0xtest", nil, false)
 
 	if state.Strategies["hl-owner-eth"].Positions["ETH"] != nil {
 		t.Error("owner ETH position should be nil")
@@ -1387,7 +1387,7 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally_CreditsPeerCash(t *tes
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "0xtest", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "0xtest", nil, false)
 
 	peer := state.Strategies["hl-peer-eth"]
 	if peer.Positions["ETH"] != nil {
@@ -1489,7 +1489,7 @@ func TestReconcileSharedCoin_Detector1_WrongOIDInUserfillsBooksExternal(t *testi
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 	prices := map[string]float64{"BTC": mark}
-	_, _ = reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, nil, prices, "0xtest", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, nil, prices, "0xtest", nil, false)
 
 	owner := state.Strategies["hl-owner-btc"]
 	if len(owner.ClosedPositions) != 1 {
@@ -1547,7 +1547,7 @@ func TestReconcileSharedCoin_Detector2_WrongOIDInUserfillsBooksExternal(t *testi
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	_, _ = reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, positions, prices, "0xtest", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, positions, prices, "0xtest", nil, false)
 
 	owner := state.Strategies["hl-owner-eth"]
 	if len(owner.ClosedPositions) != 1 {
@@ -1604,7 +1604,7 @@ func TestReconcileSharedCoin_TPPartialFill_DecrementsOwnerAndBooksPnL(t *testing
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
 
 	owner := state.Strategies["hl-owner-eth"]
 	ownerPos := owner.Positions["ETH"]
@@ -1695,7 +1695,7 @@ func TestReconcileSharedCoin_TPPartialFill_Short(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
 
 	owner := state.Strategies["hl-owner-eth"]
 	ownerPos := owner.Positions["ETH"]
@@ -1759,7 +1759,7 @@ func TestReconcileSharedCoin_TPPartialFill_PaddedNeverPlacedTierDoesNotAttribute
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
 
 	owner := state.Strategies["hl-owner-eth"]
 	ownerPos := owner.Positions["ETH"]
@@ -1812,7 +1812,7 @@ func TestReconcileSharedCoin_TPPartialFill_MultipleCandidatesDoesNotAttribute(t 
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "", nil, false)
 
 	for id, ss := range state.Strategies {
 		pos := ss.Positions["ETH"]
@@ -1867,7 +1867,7 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally_NoMarkPrice_FallsBack(
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
 	// nil prices map → legacy zero-PnL path.
-	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	peer := state.Strategies["hl-peer-eth"]
 	if peer.Positions["ETH"] != nil {
@@ -1913,7 +1913,7 @@ func TestReconcileSharedCoin_GapWithoutSLOwner_LeavesPositionsAlone(t *testing.T
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	// Both positions must be untouched.
 	posA := state.Strategies["hl-a-eth"].Positions["ETH"]
@@ -1970,7 +1970,7 @@ func TestReconcileSharedCoin_ResidualMismatch_LeavesPositionsAlone(t *testing.T)
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, nil, "", nil, false)
 
 	// Both positions must be untouched.
 	ownerPos := state.Strategies["hl-owner-eth"].Positions["ETH"]
@@ -2855,7 +2855,7 @@ func TestApplyHyperliquidCircuitCloseFill_PartialPreservesAvgCost(t *testing.T) 
 			"BTC": {Symbol: "BTC", Quantity: 1.0, AvgCost: 50000, Side: "long", Multiplier: 1, Leverage: 5},
 		},
 	}
-	applyHyperliquidCircuitCloseFill(s, "BTC", 0.3, 49000, 1.5, 1.0)
+	applyHyperliquidCircuitCloseFill(s, "BTC", 0.3, 49000, 1.5, 1.0, "")
 
 	pos, ok := s.Positions["BTC"]
 	if !ok {
@@ -3045,7 +3045,7 @@ func TestApplyHyperliquidCircuitCloseFill_NoPositionShortCloseRecordsBuy(t *test
 		Positions: map[string]*Position{},
 	}
 	// On-chain shows a short (negative size); closer reports a buy fill.
-	applyHyperliquidCircuitCloseFill(s, "ETH", 0.5, 3000, 0.5, -0.5)
+	applyHyperliquidCircuitCloseFill(s, "ETH", 0.5, 3000, 0.5, -0.5, "")
 
 	if len(s.TradeHistory) != 1 {
 		t.Fatalf("expected 1 defensive trade, got %d", len(s.TradeHistory))
@@ -3062,7 +3062,7 @@ func TestApplyHyperliquidCircuitCloseFill_NoPositionLongCloseRecordsSell(t *test
 		Positions: map[string]*Position{},
 	}
 	// On-chain shows a long (positive size); closer reports a sell fill.
-	applyHyperliquidCircuitCloseFill(s, "ETH", 0.5, 3000, 0.5, 0.5)
+	applyHyperliquidCircuitCloseFill(s, "ETH", 0.5, 3000, 0.5, 0.5, "")
 
 	if len(s.TradeHistory) != 1 {
 		t.Fatalf("expected 1 defensive trade, got %d", len(s.TradeHistory))
@@ -3247,7 +3247,7 @@ func TestReconcileManualPositionExternalClose(t *testing.T) {
 	var mu sync.RWMutex
 
 	// Pass nil positions (on-chain flat).
-	_, _ = reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "", nil, false)
 
 	ss := state.Strategies["manual-eth"]
 	if _, ok := ss.Positions["ETH"]; ok {
@@ -3352,7 +3352,7 @@ func TestReconcilePositionSLClose_UsesFilledQtyFromLookup(t *testing.T) {
 	logger := newTestLogger(t)
 
 	// On-chain is flat → reconcileHyperliquidPositionsWithResolver closes position.
-	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, StrategyConfig{})
+	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, nil, StrategyConfig{})
 	if !changed {
 		t.Fatal("expected changed=true")
 	}
@@ -3401,7 +3401,7 @@ func TestReconcilePositionSLClose_NoFillFallsThroughToExternal(t *testing.T) {
 	})
 	logger := newTestLogger(t)
 	startCash := ss.Cash
-	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, StrategyConfig{})
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, nil, StrategyConfig{})
 
 	if len(ss.ClosedPositions) != 1 {
 		t.Fatalf("ClosedPositions = %d, want 1", len(ss.ClosedPositions))
@@ -3454,7 +3454,7 @@ func TestReconcileManualPositionSLFired(t *testing.T) {
 		return HLFillLookup{}, false
 	}
 
-	_, _ = reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "0xtest", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "0xtest", nil, false)
 
 	ss := state.Strategies["manual-eth"]
 	if _, ok := ss.Positions["ETH"]; ok {
@@ -3518,7 +3518,7 @@ func TestReconcilePosition_TPFillsAttributedNotSL(t *testing.T) {
 
 	var alerts []ProtectionFillAlert
 	startCash := ss.Cash
-	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, &alerts, StrategyConfig{})
+	changed := reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, &alerts, nil, StrategyConfig{})
 	if !changed {
 		t.Fatal("expected changed=true")
 	}
@@ -3576,7 +3576,7 @@ func TestReconcilePosition_SLFillStillTakesSLPath(t *testing.T) {
 		return HLFillLookup{}, false
 	})
 	logger := newTestLogger(t)
-	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, StrategyConfig{})
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, nil, StrategyConfig{})
 
 	if len(ss.ClosedPositions) != 1 || ss.ClosedPositions[0].CloseReason != "stop_loss" {
 		t.Fatalf("expected one ClosedPosition with reason=stop_loss, got %+v", ss.ClosedPositions)
@@ -3619,7 +3619,7 @@ func TestReconcilePosition_PartialTPFillResidualZeroPnL(t *testing.T) {
 	})
 	logger := newTestLogger(t)
 	startCash := ss.Cash
-	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, StrategyConfig{})
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, nil, StrategyConfig{})
 
 	if _, open := ss.Positions["ETH"]; open {
 		t.Fatal("ETH should be removed even when TP fills under-shoot")
@@ -3657,7 +3657,7 @@ func TestReconcilePosition_NoFillsFallsBackToZeroPnL(t *testing.T) {
 	resolver := noFillFeeResolver
 	logger := newTestLogger(t)
 	startCash := ss.Cash
-	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, StrategyConfig{})
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, nil, StrategyConfig{})
 
 	if _, open := ss.Positions["ETH"]; open {
 		t.Fatal("ETH should be removed even when no fills found")
@@ -3701,7 +3701,7 @@ func TestReconcilePosition_AllTPOIDsZeroedSLNotFilled(t *testing.T) {
 	})
 	logger := newTestLogger(t)
 	startCash := ss.Cash
-	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, StrategyConfig{})
+	reconcileHyperliquidPositionsWithResolver(ss, "ETH", nil, resolver, logger, nil, nil, StrategyConfig{})
 
 	if _, open := ss.Positions["ETH"]; open {
 		t.Fatal("ETH position should be removed after reconcile")

--- a/scheduler/hyperliquid_fills_test.go
+++ b/scheduler/hyperliquid_fills_test.go
@@ -294,7 +294,7 @@ func TestReconcileHyperliquidAccountPositions_DetectorOneUsesFillFee(t *testing.
 
 	prices := map[string]float64{"BTC": 59000}
 	// nil on-chain positions => Detector 1 fires for both peers.
-	_, _ = reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, nil, prices, "0xtest", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, nil, prices, "0xtest", nil, false)
 
 	ownerSS := state.Strategies["hl-owner"]
 	if _, open := ownerSS.Positions["BTC"]; open {

--- a/scheduler/hyperliquid_sole_owner_tp_test.go
+++ b/scheduler/hyperliquid_sole_owner_tp_test.go
@@ -57,7 +57,7 @@ func TestSoleOwnerTPPartial_BooksAtTPPriceFromTiers(t *testing.T) {
 	var alerts []ProtectionFillAlert
 	logger := newTestLogger(t)
 
-	changed := reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts)
+	changed := reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts, nil)
 	if !changed {
 		t.Fatal("expected changed=true")
 	}
@@ -152,7 +152,7 @@ func TestSoleOwnerTPPartial_PrefersUserFillsPxOverConfiguredTP(t *testing.T) {
 	var alerts []ProtectionFillAlert
 	logger := newTestLogger(t)
 
-	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts)
+	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts, nil)
 
 	if len(ss.TradeHistory) != 1 {
 		t.Fatalf("TradeHistory = %d, want 1", len(ss.TradeHistory))
@@ -209,7 +209,7 @@ func TestSoleOwnerTPFinal_FullCloseAtTPPrice_NotSL(t *testing.T) {
 	var alerts []ProtectionFillAlert
 	logger := newTestLogger(t)
 
-	changed := reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", nil, resolver, logger, &alerts)
+	changed := reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", nil, resolver, logger, &alerts, nil)
 	if !changed {
 		t.Fatal("expected changed=true")
 	}
@@ -267,7 +267,7 @@ func TestSoleOwnerTPFullClose_TPOIDsLag_EmitsProtectionDM(t *testing.T) {
 	var alerts []ProtectionFillAlert
 	logger := newTestLogger(t)
 
-	changed := reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", nil, resolver, logger, &alerts)
+	changed := reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", nil, resolver, logger, &alerts, nil)
 	if !changed {
 		t.Fatal("expected changed=true")
 	}
@@ -320,7 +320,7 @@ func TestSoleOwnerTPFinal_PartialCloseShort(t *testing.T) {
 	var alerts []ProtectionFillAlert
 	logger := newTestLogger(t)
 
-	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts)
+	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts, nil)
 
 	pos := ss.Positions["ETH"]
 	if pos == nil {
@@ -365,7 +365,7 @@ func TestSoleOwnerTP_SkipsWhenNoTierCleared(t *testing.T) {
 	var alerts []ProtectionFillAlert
 	logger := newTestLogger(t)
 
-	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts)
+	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts, nil)
 
 	if len(ss.TradeHistory) != 0 {
 		t.Errorf("TradeHistory = %d, want 0 (no TP cleared, legacy resync should be silent)", len(ss.TradeHistory))
@@ -398,7 +398,7 @@ func TestSoleOwnerTP_SkipsWhenAvgCostOrATRMissing(t *testing.T) {
 	var alerts []ProtectionFillAlert
 	logger := newTestLogger(t)
 
-	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts)
+	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts, nil)
 	if len(ss.TradeHistory) != 0 {
 		t.Errorf("TradeHistory = %d, want 0 (missing EntryATR)", len(ss.TradeHistory))
 	}
@@ -475,7 +475,7 @@ func TestSoleOwnerTPPartial_FallsBackToConfiguredTPWhenLookupPxZero(t *testing.T
 	var alerts []ProtectionFillAlert
 	logger := newTestLogger(t)
 
-	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts)
+	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts, nil)
 
 	if len(ss.TradeHistory) != 1 {
 		t.Fatalf("TradeHistory = %d, want 1", len(ss.TradeHistory))
@@ -532,7 +532,7 @@ func TestSoleOwnerTP_FullCloseWithStaleClearedTier_DefersToSL(t *testing.T) {
 	var alerts []ProtectionFillAlert
 	logger := newTestLogger(t)
 
-	changed := reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", nil, resolver, logger, &alerts)
+	changed := reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", nil, resolver, logger, &alerts, nil)
 	if !changed {
 		t.Fatal("expected changed=true (legacy SL-owner branch should still book)")
 	}
@@ -606,7 +606,7 @@ func TestSoleOwnerTP_TwoCycleSequence_BooksAfterProtectionSyncZerosTPOID(t *test
 	// behavior — the fix relies on protection-sync running first in the
 	// non-due cycle case to preserve the drift signal).
 	var alerts []ProtectionFillAlert
-	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts)
+	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts, nil)
 	if len(alerts) != 0 {
 		t.Errorf("cycle 1 alerts = %d, want 0 (no cleared TP tier, must not attribute)", len(alerts))
 	}
@@ -623,7 +623,7 @@ func TestSoleOwnerTP_TwoCycleSequence_BooksAfterProtectionSyncZerosTPOID(t *test
 	pos.TPOIDs = []int64{0, 222}
 
 	// Cycle 2: TPOIDs[0] cleared, drift visible → attribution fires.
-	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts)
+	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts, nil)
 	if len(ss.TradeHistory) != 1 {
 		t.Fatalf("cycle 2 trades = %d, want 1 (TP1 attribution after protection-sync)", len(ss.TradeHistory))
 	}
@@ -704,7 +704,7 @@ func TestSoleOwnerTP_CycleOrderingRecovery_BooksWhenUserFillsOIDMatchesTPOID(t *
 	var alerts []ProtectionFillAlert
 	logger := newTestLogger(t)
 
-	changed := reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts)
+	changed := reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts, nil)
 	if !changed {
 		t.Fatal("expected changed=true")
 	}
@@ -768,7 +768,7 @@ func TestSoleOwnerTP758_RecoveryStampsTierSoHlAttemptSkipsOID(t *testing.T) {
 		return HLFillLookup{}, false
 	})
 	logger := newTestLogger(t)
-	if !reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, nil) {
+	if !reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, nil, nil) {
 		t.Fatal("expected reconcile to return true")
 	}
 	if len(ss.TradeHistory) != 1 {
@@ -820,7 +820,7 @@ func TestSoleOwnerTP_CycleOrderingRecovery_DefersWhenUserFillsOIDDoesNotMatch(t 
 	var alerts []ProtectionFillAlert
 	logger := newTestLogger(t)
 
-	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts)
+	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", positions, resolver, logger, &alerts, nil)
 
 	if len(ss.TradeHistory) != 0 {
 		t.Errorf("TradeHistory = %d, want 0 (OID mismatch must not attribute to TP)", len(ss.TradeHistory))
@@ -875,7 +875,7 @@ func TestSoleOwnerTP_CycleOrderingRecovery_NotAppliedToFullClose(t *testing.T) {
 	var alerts []ProtectionFillAlert
 	logger := newTestLogger(t)
 
-	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", nil, resolver, logger, &alerts)
+	reconcileHyperliquidPositionsForStrategy(soleOwnerTPSC(), ss, "ETH", nil, resolver, logger, &alerts, nil)
 
 	if len(ss.TradeHistory) != 1 {
 		t.Fatalf("TradeHistory = %d, want 1", len(ss.TradeHistory))

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -550,7 +550,7 @@ func TestReconcileHyperliquidPositions_RestingStopLossFillBooksPnL(t *testing.T)
 	resolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
 		return HLFillLookup{Fee: 0.05, FilledQty: 0.1, Px: 3104, Count: 1, OID: oid}, true
 	})
-	changed := reconcileHyperliquidPositionsWithResolver(state, "ETH", nil, resolver, logger, nil, StrategyConfig{})
+	changed := reconcileHyperliquidPositionsWithResolver(state, "ETH", nil, resolver, logger, nil, nil, StrategyConfig{})
 	if !changed {
 		t.Fatalf("expected reconcile to report a state change")
 	}
@@ -609,7 +609,7 @@ func TestReconcileHyperliquidPositions_RestingStopLossFillClosesShortWithBuy(t *
 	resolver := hlReconcileFillResolver(func(_ string, oid int64, _ float64) (HLFillLookup, bool) {
 		return HLFillLookup{Fee: 0.05, FilledQty: 0.1, Px: 3296, Count: 1, OID: oid}, true
 	})
-	changed := reconcileHyperliquidPositionsWithResolver(state, "ETH", nil, resolver, logger, nil, StrategyConfig{})
+	changed := reconcileHyperliquidPositionsWithResolver(state, "ETH", nil, resolver, logger, nil, nil, StrategyConfig{})
 	if !changed {
 		t.Fatalf("expected reconcile to report a state change")
 	}

--- a/scheduler/hyperliquid_tp_dust_test.go
+++ b/scheduler/hyperliquid_tp_dust_test.go
@@ -78,7 +78,7 @@ func TestSoleOwnerTPDust_BooksBothTiersAtUserFills(t *testing.T) {
 	})
 	logger := newTestLogger(t)
 
-	changed := reconcileHyperliquidPositionsForStrategy(sc, ss, "BTC", positions, resolver, logger, nil)
+	changed := reconcileHyperliquidPositionsForStrategy(sc, ss, "BTC", positions, resolver, logger, nil, nil)
 	if !changed {
 		t.Fatal("expected changed=true")
 	}
@@ -141,7 +141,7 @@ func TestSoleOwnerTPDust_NeverPlaced_NoBook(t *testing.T) {
 	})
 	logger := newTestLogger(t)
 
-	reconcileHyperliquidPositionsForStrategy(sc, ss, "BTC", positions, resolver, logger, nil)
+	reconcileHyperliquidPositionsForStrategy(sc, ss, "BTC", positions, resolver, logger, nil, nil)
 
 	if len(ss.TradeHistory) != 0 {
 		t.Fatalf("TradeHistory = %d, want 0 close trades", len(ss.TradeHistory))
@@ -229,7 +229,7 @@ func TestReconcileSharedCoin_TPDust_BooksBothTiers(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	_, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, map[string]float64{"BTC": entryPx}, "0xtest", nil, false)
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, map[string]float64{"BTC": entryPx}, "0xtest", nil, false)
 
 	owner := state.Strategies[ownerID]
 	pos := owner.Positions["BTC"]

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1158,7 +1158,19 @@ func main() {
 				// pay two HL API round-trips per cycle.
 				var hlReconcileFillHintsJSON []byte
 				if len(hlReconcileDue) > 0 && hlStateFetched {
-					_, fillHints := reconcileHyperliquidAccountPositions(hlReconcileDue, hlReconcileAll, state, &mu, logMgr, hlPositions, prices, os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS"), notifier, cfg.NotifyTPSLFillsEnabled())
+					_, fillHints, orphanCloseJobs := reconcileHyperliquidAccountPositions(hlReconcileDue, hlReconcileAll, state, &mu, logMgr, hlPositions, prices, os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS"), notifier, cfg.NotifyTPSLFillsEnabled())
+					if len(orphanCloseJobs) > 0 {
+						runRegimeDirectionOrphanCloses(
+							shutdownSideEffectCtx,
+							state,
+							cfg.Strategies,
+							orphanCloseJobs,
+							hlPositions,
+							defaultHyperliquidLiveCloser,
+							&mu,
+							notifier.SendOwnerDM,
+						)
+					}
 					if len(fillHints) > 0 {
 						if b, err := json.Marshal(fillHints); err == nil {
 							hlReconcileFillHintsJSON = b

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -106,7 +106,7 @@ func TestPartialClosePreservesInitialQuantityAndEntryATR(t *testing.T) {
 		},
 	}
 
-	applyHyperliquidCircuitCloseFill(state, "ETH", 0.4, 3100, 1, 1)
+	applyHyperliquidCircuitCloseFill(state, "ETH", 0.4, 3100, 1, 1, "")
 	pos := state.Positions["ETH"]
 	if pos == nil {
 		t.Fatal("position should remain after partial close")

--- a/scheduler/regime_alerts_test.go
+++ b/scheduler/regime_alerts_test.go
@@ -303,7 +303,7 @@ func TestRegime_StampedAtProductionCallSites(t *testing.T) {
 	t.Run("hyperliquid_balance/applyHyperliquidCircuitCloseFill_normal", func(t *testing.T) {
 		s := newState("hyperliquid")
 		s.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 1.0, AvgCost: 50000, Side: "long", Multiplier: 1, Leverage: 5}
-		applyHyperliquidCircuitCloseFill(s, "BTC", 1.0, 49000, 1.5, 1.0)
+		applyHyperliquidCircuitCloseFill(s, "BTC", 1.0, 49000, 1.5, 1.0, "")
 		if got := lastRegime(s); got != want {
 			t.Errorf("Regime = %q; want %q", got, want)
 		}
@@ -312,7 +312,7 @@ func TestRegime_StampedAtProductionCallSites(t *testing.T) {
 	t.Run("hyperliquid_balance/applyHyperliquidCircuitCloseFill_noPosition", func(t *testing.T) {
 		s := newState("hyperliquid")
 		// Empty positions — exercises the defensive no-virtual-position branch.
-		applyHyperliquidCircuitCloseFill(s, "BTC", 1.0, 49000, 1.5, 1.0)
+		applyHyperliquidCircuitCloseFill(s, "BTC", 1.0, 49000, 1.5, 1.0, "")
 		if got := lastRegime(s); got != want {
 			t.Errorf("Regime = %q; want %q", got, want)
 		}

--- a/scheduler/regime_directional_policy.go
+++ b/scheduler/regime_directional_policy.go
@@ -21,11 +21,15 @@ package main
 // returns and result.Regime is known):
 //
 //   - When flat (posQty == 0): resolve from result.Regime (current cycle).
-//   - When a position is open (posQty > 0): resolve from pos.Regime —
-//     positions inherit the policy they were opened under and run to their
-//     natural exit (SL/TP/close evaluator). New entries opposite to the
-//     held side never fire because PerpsOrderSkipReason / perpsLiveOrderSize
-//     both gate on the resolved Direction; close evaluators always run.
+//   - When a position is open (posQty > 0): resolve from pos.Regime for
+//     signal/execution paths — positions inherit the policy they were opened
+//     under; new entries opposite the held side are blocked and close
+//     evaluators always run (PerpsOrderSkipReason / perpsLiveOrderSize).
+//   - Exception (#822): hl-sync reconcile may market-close a sole-owner live
+//     position when its side conflicts with the *current* regime direction
+//     (stratState.Regime, one cycle behind the in-flight check). That
+//     supersedes hold-on-transition for direction orphans so a regime flip
+//     cannot leave a stale side on-chain until manual intervention.
 //
 // HL perps only (mirrors invert_signal's surface, validated in config.go).
 // Static StrategyConfig.Direction / InvertSignal remain the BASE config —
@@ -389,7 +393,12 @@ func regimeDirectionOrphanEffectiveDir(stratState *StrategyState, sc StrategyCon
 
 // perpsRegimeDirectionOrphanConflict reports whether a live HL perps position
 // should be auto-closed because its side opposes what the current regime (or
-// base direction when no policy) expects now.
+// base direction when no policy) expects now. Intentionally uses current
+// regime, not pos.Regime — see package doc (#822 vs #779 hold-on-transition).
+//
+// "Current" reads stratState.Regime / RegimeWindows written in the prior
+// cycle's execute phase; reconcile runs before this cycle's check updates
+// them, so detection typically trails the flip by one scheduler cycle.
 func perpsRegimeDirectionOrphanConflict(stratState *StrategyState, sc StrategyConfig, pos *Position) (conflict bool, currentRegime, effectiveDir string) {
 	if stratState == nil || pos == nil || pos.Quantity <= 0 {
 		return false, "", ""

--- a/scheduler/regime_directional_policy.go
+++ b/scheduler/regime_directional_policy.go
@@ -396,6 +396,10 @@ func regimeDirectionOrphanEffectiveDir(stratState *StrategyState, sc StrategyCon
 // base direction when no policy) expects now. Intentionally uses current
 // regime, not pos.Regime — see package doc (#822 vs #779 hold-on-transition).
 //
+// Scope includes static-direction orphans (e.g. direction=long with a seeded
+// short) as well as regime-flip cases; regime.enabled is not required.
+// Direction="both" never conflicts via perpsPositionConflictsDirection.
+//
 // "Current" reads stratState.Regime / RegimeWindows written in the prior
 // cycle's execute phase; reconcile runs before this cycle's check updates
 // them, so detection typically trails the flip by one scheduler cycle.

--- a/scheduler/regime_directional_policy.go
+++ b/scheduler/regime_directional_policy.go
@@ -363,6 +363,51 @@ func policyAllowsPositionSide(sc StrategyConfig, posSide string) bool {
 	return false
 }
 
+// RegimeDirectionOrphanCloseJob is queued during hl-sync reconcile when a
+// sole-owner live perps position conflicts with the strategy's *current*
+// regime direction (not the stamped open regime). Drained after mu.Unlock via
+// runRegimeDirectionOrphanCloses (#822).
+type RegimeDirectionOrphanCloseJob struct {
+	StrategyID    string
+	Symbol        string
+	CloseQty      float64
+	CancelOIDs    []int64
+	PosSide       string
+	CurrentRegime string
+	EffectiveDir  string
+}
+
+// regimeDirectionOrphanEffectiveDir resolves direction from the current cycle
+// regime only — intentionally ignores pos.Regime hold-on-transition (#822).
+func regimeDirectionOrphanEffectiveDir(stratState *StrategyState, sc StrategyConfig) string {
+	current := strategyCurrentDirectionalRegime(stratState, sc)
+	if sc.RegimeDirectionalPolicy != nil && !sc.RegimeDirectionalPolicy.IsZero() {
+		return EffectiveDirectionForRegime(sc, current)
+	}
+	return EffectiveDirection(sc)
+}
+
+// perpsRegimeDirectionOrphanConflict reports whether a live HL perps position
+// should be auto-closed because its side opposes what the current regime (or
+// base direction when no policy) expects now.
+func perpsRegimeDirectionOrphanConflict(stratState *StrategyState, sc StrategyConfig, pos *Position) (conflict bool, currentRegime, effectiveDir string) {
+	if stratState == nil || pos == nil || pos.Quantity <= 0 {
+		return false, "", ""
+	}
+	if sc.Type != "perps" || !hyperliquidIsLive(sc.Args) {
+		return false, "", ""
+	}
+	if pos.OwnerStrategyID != "" && pos.OwnerStrategyID != sc.ID {
+		return false, "", ""
+	}
+	currentRegime = strategyCurrentDirectionalRegime(stratState, sc)
+	effectiveDir = regimeDirectionOrphanEffectiveDir(stratState, sc)
+	if !perpsPositionConflictsDirection(pos.Side, effectiveDir) {
+		return false, currentRegime, effectiveDir
+	}
+	return true, currentRegime, effectiveDir
+}
+
 // perpsPositionConflictsDirection reports whether an open position's side
 // conflicts with a resolved effective direction ("both" never conflicts).
 func perpsPositionConflictsDirection(posSide, effectiveDir string) bool {

--- a/scheduler/regime_directional_policy_orphan_test.go
+++ b/scheduler/regime_directional_policy_orphan_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestPerpsRegimeDirectionOrphanConflict_RegimeFlip(t *testing.T) {
+	sc := StrategyConfig{
+		ID:        "hl-test",
+		Type:      "perps",
+		Platform:  "hyperliquid",
+		Args:      []string{"vwap", "BTC", "1h", "--mode=live"},
+		Direction: DirectionLong,
+		RegimeDirectionalPolicy: &RegimeDirectionalPolicy{
+			TrendRegime: map[string]RegimeDirectionalEntry{
+				"trending_down": {Direction: DirectionShort},
+				"trending_up":   {Direction: DirectionLong},
+				"ranging":       {Direction: DirectionLong},
+			},
+		},
+	}
+	ss := &StrategyState{
+		ID:     sc.ID,
+		Regime: "trending_up",
+		Positions: map[string]*Position{
+			"BTC": {
+				Symbol:          "BTC",
+				Quantity:        0.01,
+				Side:            "short",
+				OwnerStrategyID: sc.ID,
+				Regime:          "trending_down",
+			},
+		},
+	}
+	conflict, current, eff := perpsRegimeDirectionOrphanConflict(ss, sc, ss.Positions["BTC"])
+	if !conflict {
+		t.Fatalf("want conflict when current regime is long and position is short; current=%q eff=%q", current, eff)
+	}
+	if current != "trending_up" || eff != DirectionLong {
+		t.Fatalf("got current=%q eff=%q", current, eff)
+	}
+}
+
+func TestPerpsRegimeDirectionOrphanConflict_HoldStampedNoConflict(t *testing.T) {
+	sc := StrategyConfig{
+		ID:        "hl-test",
+		Type:      "perps",
+		Platform:  "hyperliquid",
+		Args:      []string{"vwap", "BTC", "1h", "--mode=live"},
+		Direction: DirectionLong,
+		RegimeDirectionalPolicy: &RegimeDirectionalPolicy{
+			TrendRegime: map[string]RegimeDirectionalEntry{
+				"trending_down": {Direction: DirectionShort},
+				"trending_up":   {Direction: DirectionLong},
+				"ranging":       {Direction: DirectionLong},
+			},
+		},
+	}
+	ss := &StrategyState{
+		ID:     sc.ID,
+		Regime: "trending_down",
+		Positions: map[string]*Position{
+			"BTC": {
+				Symbol:          "BTC",
+				Quantity:        0.01,
+				Side:            "short",
+				OwnerStrategyID: sc.ID,
+				Regime:          "trending_down",
+			},
+		},
+	}
+	if conflict, _, _ := perpsRegimeDirectionOrphanConflict(ss, sc, ss.Positions["BTC"]); conflict {
+		t.Fatal("short under trending_down should not conflict with current regime")
+	}
+}
+
+func TestReconcileHyperliquidPositionsWithResolver_QueuesRegimeOrphanClose(t *testing.T) {
+	sc := StrategyConfig{
+		ID:        "hl-vwap-btc",
+		Type:      "perps",
+		Platform:  "hyperliquid",
+		Args:      []string{"vwap", "BTC", "1h", "--mode=live"},
+		Direction: DirectionLong,
+		RegimeDirectionalPolicy: &RegimeDirectionalPolicy{
+			TrendRegime: map[string]RegimeDirectionalEntry{
+				"trending_down": {Direction: DirectionShort},
+				"trending_up":   {Direction: DirectionLong},
+				"ranging":       {Direction: DirectionLong},
+			},
+		},
+	}
+	ss := &StrategyState{
+		ID:     sc.ID,
+		Regime: "trending_up",
+		Positions: map[string]*Position{
+			"BTC": {
+				Symbol:          "BTC",
+				Quantity:        0.01,
+				AvgCost:         50000,
+				Side:            "short",
+				Multiplier:      1,
+				OwnerStrategyID: sc.ID,
+				Regime:          "trending_down",
+			},
+		},
+	}
+	positions := []HLPosition{{Coin: "BTC", Size: -0.01, EntryPrice: 50000, Leverage: 2}}
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger(sc.ID)
+	defer logger.Close()
+	var jobs []RegimeDirectionOrphanCloseJob
+	reconcileHyperliquidPositionsWithResolver(ss, "BTC", positions, func(string, int64, float64) (HLFillLookup, bool) {
+		return HLFillLookup{}, false
+	}, logger, nil, &jobs, sc)
+	if len(jobs) != 1 {
+		t.Fatalf("jobs = %d, want 1", len(jobs))
+	}
+	if jobs[0].StrategyID != sc.ID || jobs[0].Symbol != "BTC" || jobs[0].EffectiveDir != DirectionLong {
+		t.Fatalf("job = %+v", jobs[0])
+	}
+}
+
+func TestRunRegimeDirectionOrphanCloses_BooksAndFlattens(t *testing.T) {
+	sc := StrategyConfig{
+		ID:        "hl-vwap-btc",
+		Type:      "perps",
+		Platform:  "hyperliquid",
+		Args:      []string{"vwap", "BTC", "1h", "--mode=live"},
+		Direction: DirectionLong,
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			sc.ID: {
+				ID:       sc.ID,
+				Cash:     1000,
+				Type:     "perps",
+				Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"BTC": {Symbol: "BTC", Quantity: 0.01, AvgCost: 50000, Side: "short", Multiplier: 1},
+				},
+			},
+		},
+	}
+	closer, calls := fakeCloser(nil)
+	jobs := []RegimeDirectionOrphanCloseJob{{
+		StrategyID: sc.ID, Symbol: "BTC", CloseQty: 0.01, PosSide: "short",
+		CurrentRegime: "trending_up", EffectiveDir: DirectionLong,
+	}}
+	runRegimeDirectionOrphanCloses(context.Background(), state, []StrategyConfig{sc}, jobs,
+		[]HLPosition{{Coin: "BTC", Size: -0.01}}, closer, &sync.RWMutex{}, nil)
+	if len(*calls) != 1 {
+		t.Fatalf("closer calls = %v", *calls)
+	}
+	ss := state.Strategies[sc.ID]
+	if pos := ss.Positions["BTC"]; pos != nil {
+		t.Fatal("position should be removed after orphan close")
+	}
+	if len(ss.TradeHistory) == 0 {
+		t.Fatal("expected close trade")
+	}
+	if ss.TradeHistory[len(ss.TradeHistory)-1].Details == "" {
+		t.Fatal("expected trade details")
+	}
+}
+
+func TestPerpsRegimeDirectionOrphanConflict_SkipsPaper(t *testing.T) {
+	sc := StrategyConfig{
+		ID:        "hl-paper",
+		Type:      "perps",
+		Platform:  "hyperliquid",
+		Args:      []string{"vwap", "BTC", "1h"},
+		Direction: DirectionShort,
+	}
+	ss := &StrategyState{
+		Positions: map[string]*Position{
+			"BTC": {Symbol: "BTC", Quantity: 1, Side: "long"},
+		},
+	}
+	if conflict, _, _ := perpsRegimeDirectionOrphanConflict(ss, sc, ss.Positions["BTC"]); conflict {
+		t.Fatal("paper mode must not queue orphan close")
+	}
+}

--- a/scheduler/regime_directional_policy_orphan_test.go
+++ b/scheduler/regime_directional_policy_orphan_test.go
@@ -169,6 +169,59 @@ func TestRunRegimeDirectionOrphanCloses_BooksAndFlattens(t *testing.T) {
 	}
 }
 
+func TestRunRegimeDirectionOrphanCloses_AlreadyFlatLeavesVirtual(t *testing.T) {
+	sc := StrategyConfig{
+		ID:       "hl-vwap-btc",
+		Type:     "perps",
+		Platform: "hyperliquid",
+		Args:     []string{"vwap", "BTC", "1h", "--mode=live"},
+	}
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			sc.ID: {
+				ID:       sc.ID,
+				Cash:     1000,
+				Type:     "perps",
+				Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"BTC": {
+						Symbol: "BTC", Quantity: 0.01, AvgCost: 50000, Side: "short",
+						Multiplier: 1, StopLossOID: 99,
+					},
+				},
+			},
+		},
+	}
+	var calls []string
+	closer := func(symbol string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
+		calls = append(calls, symbol)
+		return &HyperliquidCloseResult{
+			Close:                   &HyperliquidClose{Symbol: symbol, AlreadyFlat: true},
+			CancelStopLossSucceeded: true,
+		}, nil
+	}
+	jobs := []RegimeDirectionOrphanCloseJob{{
+		StrategyID: sc.ID, Symbol: "BTC", CloseQty: 0.01,
+		CancelOIDs: []int64{99},
+	}}
+	runRegimeDirectionOrphanCloses(context.Background(), state, []StrategyConfig{sc}, jobs,
+		[]HLPosition{{Coin: "BTC", Size: -0.01}}, closer, &sync.RWMutex{}, nil)
+	if len(calls) != 1 {
+		t.Fatalf("closer calls = %v", calls)
+	}
+	ss := state.Strategies[sc.ID]
+	pos := ss.Positions["BTC"]
+	if pos == nil {
+		t.Fatal("AlreadyFlat: virtual position kept for next reconcile")
+	}
+	if pos.StopLossOID != 0 {
+		t.Fatalf("StopLossOID = %d, want 0 after cancel succeeded before fill booking", pos.StopLossOID)
+	}
+	if len(ss.TradeHistory) != 0 {
+		t.Fatal("AlreadyFlat: no trade should be booked without a fill")
+	}
+}
+
 func TestPerpsRegimeDirectionOrphanConflict_SkipsPaper(t *testing.T) {
 	sc := StrategyConfig{
 		ID:        "hl-paper",

--- a/scheduler/regime_directional_policy_orphan_test.go
+++ b/scheduler/regime_directional_policy_orphan_test.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 )
 
+// Regime flip: short opened under trending_down is force-closed once current
+// regime is trending_up — intentional #822 behavior, not #779 hold-on-transition.
 func TestPerpsRegimeDirectionOrphanConflict_RegimeFlip(t *testing.T) {
 	sc := StrategyConfig{
 		ID:        "hl-test",
@@ -160,8 +163,9 @@ func TestRunRegimeDirectionOrphanCloses_BooksAndFlattens(t *testing.T) {
 	if len(ss.TradeHistory) == 0 {
 		t.Fatal("expected close trade")
 	}
-	if ss.TradeHistory[len(ss.TradeHistory)-1].Details == "" {
-		t.Fatal("expected trade details")
+	last := ss.TradeHistory[len(ss.TradeHistory)-1]
+	if !strings.Contains(last.Details, "Regime/direction flip") {
+		t.Fatalf("Details = %q, want regime-flip label", last.Details)
 	}
 }
 

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -226,10 +226,10 @@ func migrateLegacyPerpsPositionMultipliers(state *AppState, cfg *Config) int {
 // missing (legacy pre-#741 positions).
 //
 // In either case the strategy's next signal-driven order will desync virtual
-// state from the exchange. We warn-and-continue (matching ValidateState's
-// precedent) rather than force-closing — marks may be unavailable at startup
-// and silent auto-close of an operator-seeded position is worse than a loud
-// warning.
+// state from the exchange. At runtime, sole-owner live HL perps orphans are
+// auto-closed during hl-sync reconcile when the position conflicts with the
+// *current* regime direction (#822). Startup still warn-and-continues (marks
+// may be unavailable; reconcile has not run yet).
 //
 // Returns human-readable warnings so the caller can both log them and forward
 // to the operator via DM once the notifier is ready.

--- a/scheduler/trade_protection_snapshot_test.go
+++ b/scheduler/trade_protection_snapshot_test.go
@@ -225,7 +225,7 @@ func TestApplyHyperliquidCircuitCloseFill_StampsProtectionSnapshot(t *testing.T)
 			},
 		},
 	}
-	applyHyperliquidCircuitCloseFill(s, "BTC", 0.3, 49000, 1.5, 1.0)
+	applyHyperliquidCircuitCloseFill(s, "BTC", 0.3, 49000, 1.5, 1.0, "")
 
 	if len(s.TradeHistory) != 1 {
 		t.Fatalf("TradeHistory len = %d, want 1", len(s.TradeHistory))


### PR DESCRIPTION
## Summary
- During sole-owner HL hl-sync reconcile, detect when an open perps position conflicts with the **current** regime's effective direction (not the stamped open regime).
- Queue a reduce-only market close after `mu` unlock, book the fill with `regime_direction_flip`, and DM the operator.
- Skip shared-wallet coins, paper mode, and non-owner positions; startup `ValidatePerpsDirectionConfig` remains a safety net.

Closes #822

## Test plan
- [x] `go test -C scheduler ./...`
- [ ] Smoke on live HL perps with `regime_directional_policy` after a deliberate regime flip (verify DM + trade reason)

LLM: Composer | default | commit-and-create-pull-request