### PR TITLE
fix: make storage.py import side-effect free for read-only startup probe

### DIFF
--- a/shared_tools/storage.py
+++ b/shared_tools/storage.py
@@ -12,17 +12,29 @@ import pandas as pd
 
 DB_PATH = os.path.join(os.path.dirname(__file__), "trading_bot.db")
 
+# Paths whose schema has already been ensured this process. Lets us create
+# tables lazily on first real use instead of at import time — importing this
+# module must stay side-effect free so it works under read-only sandboxes
+# (e.g. systemd ProtectSystem=strict during the startup probe).
+_SCHEMA_READY: set = set()
 
-def get_connection(db_path: str = DB_PATH) -> sqlite3.Connection:
+
+def _connect(db_path: str) -> sqlite3.Connection:
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA foreign_keys=ON")
     return conn
 
 
+def get_connection(db_path: str = DB_PATH) -> sqlite3.Connection:
+    if db_path not in _SCHEMA_READY:
+        init_db(db_path)
+    return _connect(db_path)
+
+
 def init_db(db_path: str = DB_PATH):
     """Create tables if they don't exist."""
-    conn = get_connection(db_path)
+    conn = _connect(db_path)
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS ohlcv (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -65,6 +77,7 @@ def init_db(db_path: str = DB_PATH):
     """)
     conn.commit()
     conn.close()
+    _SCHEMA_READY.add(db_path)
 
 
 def store_ohlcv(df: pd.DataFrame, exchange: str, symbol: str, timeframe: str,
@@ -164,7 +177,3 @@ def get_backtest_results(strategy_name: Optional[str] = None,
     df = pd.read_sql_query(query, conn, params=params)
     conn.close()
     return df
-
-
-# Initialize DB on import
-init_db()


### PR DESCRIPTION
## Problem

After update, `go-trader` refused to start (exit 78):

```
sqlite3.OperationalError: unable to open database file
  File ".../shared_tools/storage.py", line 18, in get_connection
    conn.execute("PRAGMA journal_mode=WAL")
```

`simulate_strategy.py` is in the unconditional startup probe set. Its import chain (`simulate_strategy.py` → `backtester` → `storage`) reached `storage.py`, which ran `init_db()` **at import time**, creating a SQLite WAL DB inside the deploy dir `/opt/go-trader-live/`. Under systemd `ProtectSystem=strict` that path is read-only, so the write failed at *import* — before `--probe-only` could return `{"ok": true}` — and the probe exited 78 (`RestartPreventExitStatus=78` then keeps the service down).

## Fix

Make `storage.py` import side-effect-free by initializing the schema lazily:

- Remove the module-level `init_db()` call.
- `get_connection()` ensures the schema once per DB path (`_SCHEMA_READY`) before returning a connection.
- `init_db()` records the path to avoid recursion.

All public functions already route through `get_connection`, so tables are still created on first real use at runtime. The probe only imports `storage` and never calls a storage function, so no write is attempted.

## Verification

- `_SCHEMA_READY` is empty right after `import storage` (no write at import).
- Importing `backtester` from a read-only copy of the dirs now succeeds (reproduced the original error before the fix).
- Lazy first-write still creates tables; `simulate_strategy.py --probe-only` → `{"ok": true}`.
- `shared_tools/test_storage.py` (25 tests) passes.

This is a Python-only change — no Go/argv contract impact.

Closes #824

---
LLM: Claude Opus 4.8 (1M) | high | Harness: Claude Code