### PR TITLE
feat: add regime to per-strategy status log line

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1808,10 +1808,10 @@ func main() {
 					pv = PortfolioValue(stratState, prices)
 					posCount := len(stratState.Positions) + len(stratState.OptionPositions)
 					cash := stratState.Cash
+					regimeLabel := stratState.Regime
 					mu.RUnlock()
 
-					logger.Info("Status: cash=$%.2f | positions=%d | value=$%.2f | trades=%d",
-						cash, posCount, pv, trades)
+					logger.Info("%s", formatStatusLine(cash, posCount, pv, trades, regimeLabel))
 
 					logger.Close()
 					lastRun[sc.ID] = time.Now()

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -525,6 +525,17 @@ func exchangeOrderIDForTrade(fillOID string, useFillMetadata bool) string {
 }
 
 // PortfolioValue calculates total value of a strategy's portfolio.
+// formatStatusLine renders the per-strategy Phase 6 status log line. regime is
+// the strategy's most recent primary regime label; an empty label (spot/options
+// or strategies without regime detection) is shown as "-".
+func formatStatusLine(cash float64, posCount int, value float64, trades int, regime string) string {
+	if regime == "" {
+		regime = "-"
+	}
+	return fmt.Sprintf("Status: cash=$%.2f | positions=%d | value=$%.2f | trades=%d | regime=%s",
+		cash, posCount, value, trades, regime)
+}
+
 func PortfolioValue(s *StrategyState, prices map[string]float64) float64 {
 	total := s.Cash
 	for sym, pos := range s.Positions {

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -524,7 +524,6 @@ func exchangeOrderIDForTrade(fillOID string, useFillMetadata bool) string {
 	return ""
 }
 
-// PortfolioValue calculates total value of a strategy's portfolio.
 // formatStatusLine renders the per-strategy Phase 6 status log line. regime is
 // the strategy's most recent primary regime label; an empty label (spot/options
 // or strategies without regime detection) is shown as "-".
@@ -536,6 +535,7 @@ func formatStatusLine(cash float64, posCount int, value float64, trades int, reg
 		cash, posCount, value, trades, regime)
 }
 
+// PortfolioValue calculates total value of a strategy's portfolio.
 func PortfolioValue(s *StrategyState, prices map[string]float64) float64 {
 	total := s.Cash
 	for sym, pos := range s.Positions {

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -2360,3 +2360,30 @@ func TestStopLossCloseDetailsPrefix(t *testing.T) {
 		}
 	}
 }
+
+func TestFormatStatusLine(t *testing.T) {
+	cases := []struct {
+		name   string
+		regime string
+		want   string
+	}{
+		{
+			name:   "with regime",
+			regime: "trending_up",
+			want:   "Status: cash=$100.50 | positions=2 | value=$250.00 | trades=3 | regime=trending_up",
+		},
+		{
+			name:   "empty regime renders dash",
+			regime: "",
+			want:   "Status: cash=$100.50 | positions=2 | value=$250.00 | trades=3 | regime=-",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatStatusLine(100.50, 2, 250.0, 3, tc.regime)
+			if got != tc.want {
+				t.Errorf("formatStatusLine = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds the current primary regime label to the per-strategy Phase 6 status log line (`scheduler/main.go`), so the regime classification is visible at a glance without digging into Python check-script output or the trade log.

Before:
```
Status: cash=$100.50 | positions=2 | value=$250.00 | trades=3
```
After:
```
Status: cash=$100.50 | positions=2 | value=$250.00 | trades=3 | regime=trending_up
```

`stratState.Regime` is already populated by `syncStrategyRegimeState` (and the options branch) across every execute dispatch before Phase 6, so this reads existing state under the existing RLock — no new locking. Strategies without regime detection (spot/options, or no regime config) leave the label empty and render `regime=-`.

## Implementation

- Extracted `formatStatusLine` as a pure helper in `portfolio.go` (empty label → `-`), keeping the format unit-testable per repo testing guidance.
- Added `TestFormatStatusLine` covering the populated and empty-regime cases.

## Testing

- `go test ./...` (full scheduler suite) — pass
- `go build` — pass

Closes #826

---
LLM: Claude Opus 4.8 (1M) | high | Harness: Claude Code