### PR TITLE
[codex] add setup reversal strategies and RR exits

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -665,6 +665,15 @@ class Backtester:
             signal_for_open = pd.Series(0, index=df.index)
             df["signal"] = 0
 
+        entry_metadata_columns = (
+            "setup_kind",
+            "setup_trigger",
+            "setup_stop",
+            "three_candle_setup",
+            "three_candle_trigger",
+            "three_candle_stop",
+        )
+
         if uses_open_close:
             if "open_action" in df.columns:
                 open_actions = df["open_action"].map(_normalize_open_action)
@@ -672,6 +681,9 @@ class Backtester:
                 open_actions = signal_for_open.map(_open_action_from_signal)
             df["_open_action"] = open_actions.shift(1).fillna("none")
             df["_close_fraction"] = _max_close_fraction_series(df).shift(1).fillna(0.0)
+            for col in entry_metadata_columns:
+                if col in df.columns:
+                    df[f"_entry_meta_{col}"] = df[col].shift(1)
 
         # Regime: inject vectorized labels before the per-bar loop so each bar
         # can gate new entries. Mirrors the live path: latest_regime(df) on the
@@ -714,6 +726,24 @@ class Backtester:
         def _bar_close_regime(row) -> str:
             return str(row.get("_regime_bar_close", "") or "").strip()
 
+        def stamp_entry_metadata(row) -> dict:
+            metadata = {}
+            for col in entry_metadata_columns:
+                value = row.get(f"_entry_meta_{col}")
+                if value is None or pd.isna(value):
+                    continue
+                metadata[col] = value
+            return metadata
+
+        def _bar_extreme(row, key: str, fallback: float) -> float:
+            try:
+                value = float(row.get(key, fallback))
+            except (TypeError, ValueError):
+                return float(fallback)
+            if not (value > 0):
+                return float(fallback)
+            return value
+
         cash = self.initial_capital
         position = 0.0  # shares held
         trades = []
@@ -727,6 +757,9 @@ class Backtester:
         avg_cost = 0.0
         initial_quantity = 0.0
         entry_atr_value = 0.0
+        position_metadata: dict = {}
+        position_high_water = 0.0
+        position_low_water = 0.0
         pending_close_fraction = 0.0
 
         # Post-TP SL adjustment state (#709). Only meaningful when sl_after is
@@ -814,6 +847,9 @@ class Backtester:
                 seed_atr = 0.0
             if seed_atr > 0 and seed_atr <= 0.5 * effective_entry:
                 entry_atr_value = seed_atr
+            position_metadata = dict(starting_long.get("metadata") or {})
+            position_high_water = effective_entry
+            position_low_water = effective_entry
             stamp = str(starting_long.get("entry_regime", "") or "").strip()
             if not stamp:
                 stamp = _entry_stamp(df.iloc[0])
@@ -891,6 +927,9 @@ class Backtester:
                         avg_cost = 0.0
                         initial_quantity = 0.0
                         entry_atr_value = 0.0
+                        position_metadata = {}
+                        position_high_water = 0.0
+                        position_low_water = 0.0
                         # Reset post-TP SL state on full close so the next
                         # open starts clean.
                         sl_trigger_px = 0.0
@@ -954,6 +993,9 @@ class Backtester:
                     avg_cost = effective_price
                     initial_quantity = shares
                     entry_atr_value = self._stamp_entry_atr(atr_series, idx, effective_price)
+                    position_metadata = stamp_entry_metadata(row)
+                    position_high_water = effective_price
+                    position_low_water = effective_price
                     stamp_open_from_label(_entry_stamp(row))
                     # #716 item 3: seed the SL trigger only when sl_after has
                     # usable tier thresholds. Without thresholds, the post-TP
@@ -984,6 +1026,9 @@ class Backtester:
                     avg_cost = effective_price
                     initial_quantity = shares
                     entry_atr_value = self._stamp_entry_atr(atr_series, idx, effective_price)
+                    position_metadata = stamp_entry_metadata(row)
+                    position_high_water = effective_price
+                    position_low_water = effective_price
                     stamp_open_from_label(_entry_stamp(row))
                     if sl_after_active and self._run_tp_tier_thresholds:
                         sl_trigger_px = self._initial_sl_trigger(
@@ -998,9 +1043,18 @@ class Backtester:
                 # applied at the NEXT bar's open (mirrors live: eval at end of
                 # bar, fill at next open).
                 if self.close_strategies and position != 0 and avg_cost > 0:
+                    bar_high = _bar_extreme(row, "high", mark_price)
+                    bar_low = _bar_extreme(row, "low", mark_price)
+                    position_high_water = max(position_high_water or bar_high, bar_high)
+                    position_low_water = min(position_low_water or bar_low, bar_low)
                     pending_close_fraction = self._evaluate_close_strategies(
                         position, avg_cost, initial_quantity, entry_atr_value,
                         mark_price, atr_series, idx,
+                        metadata=position_metadata,
+                        bar_high=bar_high,
+                        bar_low=bar_low,
+                        high_water=position_high_water,
+                        low_water=position_low_water,
                         position_regime=self._run_position_regime,
                         market_regime=_bar_close_regime(row),
                     )
@@ -1141,6 +1195,11 @@ class Backtester:
                                    atr_series: Optional[pd.Series],
                                    idx,
                                    *,
+                                   metadata: Optional[dict] = None,
+                                   bar_high: Optional[float] = None,
+                                   bar_low: Optional[float] = None,
+                                   high_water: float = 0.0,
+                                   low_water: float = 0.0,
                                    position_regime: str = "",
                                    market_regime: str = "") -> float:
         """Run every configured close evaluator against the simulated position
@@ -1157,6 +1216,10 @@ class Backtester:
             "entry_atr": float(entry_atr_value),
             "regime": str(position_regime or ""),
         }
+        if metadata:
+            position_dict.update(metadata)
+        position_dict["high_water"] = float(high_water or mark_price)
+        position_dict["low_water"] = float(low_water or mark_price)
         # Always pass ``regime`` (possibly empty) so live-regime evaluators see
         # the same key shape as live check scripts — empty/NaN bars no-op with
         # an explicit label instead of a missing dict key (#747 review).
@@ -1164,6 +1227,10 @@ class Backtester:
             "mark_price": float(mark_price),
             "regime": str(market_regime or ""),
         }
+        if bar_high is not None:
+            market_dict["bar_high"] = float(bar_high)
+        if bar_low is not None:
+            market_dict["bar_low"] = float(bar_low)
         if atr_series is not None:
             # Current-bar ATR access is intentional and matches live (#730):
             # close evaluators run end-of-bar with this bar's closed mark and

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -310,6 +310,19 @@ DEFAULT_PARAM_RANGES = {
         "overbought": [65, 70, 75],
         "oversold": [25, 30, 35],
     },
+    "three_candle_rsi_reversal": {
+        "rsi_period": [10, 14],
+        "oversold": [25, 30, 35],
+        "overbought": [65, 70, 75],
+        "threshold_lookback": [4, 8, 12],
+        "entry_valid_bars": [2, 3, 5],
+    },
+    "four_hour_range_fakeout": {
+        "range_hours": [3, 4],
+        "max_breakout_bars": [12, 24, 48],
+        "min_range_pct": [0.0, 0.005, 0.01],
+        "max_range_pct": [0.0, 0.03, 0.05],
+    },
     "bollinger_bands": {
         "period": [15, 20, 25, 30],
         "num_std": [1.5, 2.0, 2.5],

--- a/backtest/tests/test_backtester_close_strategies.py
+++ b/backtest/tests/test_backtester_close_strategies.py
@@ -11,12 +11,16 @@ import pandas as pd
 from backtester import Backtester
 
 
-def _df_open_then_hold(opens, closes, atrs=None):
+def _df_open_then_hold(opens, closes, atrs=None, highs=None, lows=None):
     """Build a df where bar 0 emits open_action=long; remaining bars hold."""
     n = len(closes)
     idx = pd.date_range("2024-01-01", periods=n, freq="D")
     open_actions = ["long"] + ["none"] * (n - 1)
     data = {"open": opens, "close": closes, "open_action": open_actions}
+    if highs is not None:
+        data["high"] = highs
+    if lows is not None:
+        data["low"] = lows
     if atrs is not None:
         data["atr"] = atrs
     return pd.DataFrame(data, index=idx)
@@ -180,6 +184,54 @@ def test_close_strategy_short_position_long_take_profit():
     assert result["trades"][0]["exit_price"] == 97.0
     # Short 10 @ $100 → cash 2000; close 10 @ $97 → cash 2000 - 970 = 1030.
     assert result["final_capital"] == 1030.0
+
+
+def test_setup_rr_uses_shifted_entry_metadata_and_bar_extremes():
+    # Setup metadata is emitted with the open signal on bar 0, then stamped
+    # onto the position opened at bar 1. Bar 2 reaches 3R intrabar, so the
+    # close signal fills at bar 3's open.
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 130],
+        closes=[100, 100, 125, 130],
+        highs=[100, 105, 130, 130],
+        lows=[100, 99, 124, 130],
+    )
+    df["three_candle_setup"] = ["long", None, None, None]
+    df["three_candle_trigger"] = [105, None, None, None]
+    df["three_candle_stop"] = [90, None, None, None]
+
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=[{"name": "setup_rr"}],
+    )
+    result = bt.run(df, save=False)
+
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["entry_price"] == 100.0
+    assert result["trades"][0]["exit_price"] == 130.0
+    assert result["final_capital"] == 1300.0
+
+
+def test_setup_rr_promotes_stop_to_breakeven_after_two_r():
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 100],
+        closes=[100, 100, 99, 100],
+        highs=[100, 105, 121, 100],
+        lows=[100, 99, 99, 100],
+    )
+    df["three_candle_setup"] = ["long", None, None, None]
+    df["three_candle_trigger"] = [105, None, None, None]
+    df["three_candle_stop"] = [90, None, None, None]
+
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=[{"name": "setup_rr"}],
+    )
+    result = bt.run(df, save=False)
+
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] == 100.0
+    assert result["final_capital"] == 1000.0
 
 
 def test_starting_long_seed_with_entry_atr_lets_tiered_tp_atr_fire():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Crypto trading bot — backtesting, paper trading, live trading w
 requires-python = ">=3.12"
 dependencies = [
     "ccxt>=4.5.37",
-    "hyperliquid-python-sdk>=0.4.0",
+    "hyperliquid-python-sdk>=0.23.0",
     "numpy>=2.4.2",
     "pandas>=3.0.0",
     "robin-stocks>=3.0.0",

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -549,6 +549,7 @@ var closeStrategyOwnedKeys = map[string]map[string]struct{}{
 	"tiered_tp_atr_live_regime": {"tiers": {}, "use_defaults": {}, "atr_source": {}, "sl_after": {}},
 	"tiered_tp_pct":             {"tiers": {}},
 	"tp_at_pct":                 {"pct": {}},
+	"setup_rr":                  {"target_r": {}, "breakeven_r": {}, "same_bar_priority": {}},
 }
 
 // migrateV14Direction translates the legacy boolean `allow_shorts` field on

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -66,6 +66,8 @@ CREATE TABLE IF NOT EXISTS positions (
     initial_quantity REAL NOT NULL DEFAULT 0,
     avg_cost REAL NOT NULL,
     entry_atr REAL NOT NULL DEFAULT 0,
+    setup_stop REAL NOT NULL DEFAULT 0,
+    setup_trigger REAL NOT NULL DEFAULT 0,
     side TEXT NOT NULL,
     multiplier REAL NOT NULL DEFAULT 0,
     owner_strategy_id TEXT NOT NULL DEFAULT '',
@@ -301,6 +303,8 @@ func (sdb *StateDB) migrateSchema() error {
 		// Position-aware close evaluator context (#496).
 		"ALTER TABLE positions ADD COLUMN initial_quantity REAL NOT NULL DEFAULT 0",
 		"ALTER TABLE positions ADD COLUMN entry_atr REAL NOT NULL DEFAULT 0",
+		"ALTER TABLE positions ADD COLUMN setup_stop REAL NOT NULL DEFAULT 0",
+		"ALTER TABLE positions ADD COLUMN setup_trigger REAL NOT NULL DEFAULT 0",
 		// Market regime label at trade time (#482).
 		"ALTER TABLE trades ADD COLUMN regime TEXT NOT NULL DEFAULT ''",
 		"ALTER TABLE trades ADD COLUMN entry_atr REAL NOT NULL DEFAULT 0",
@@ -826,8 +830,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	}
 	defer stmtStrat.Close()
 
-	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, tp1_oid, tp2_oid, tp_oids_json, tp_armed_tiers_json, stop_loss_atr_mult, tp_tiers_json, sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, regime, regime_windows_json)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, setup_stop, setup_trigger, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, tp1_oid, tp2_oid, tp_oids_json, tp_armed_tiers_json, stop_loss_atr_mult, tp_tiers_json, sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, regime, regime_windows_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare position insert: %w", err)
 	}
@@ -878,7 +882,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		for _, pos := range s.Positions {
 			positionID := ensurePositionTradeID(s.ID, pos.Symbol, pos)
 			tp1OID, tp2OID := firstTwoTPOIDs(pos.TPOIDs)
-			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx, tp1OID, tp2OID, marshalTPOIDsJSON(pos.TPOIDs), marshalTPArmedTiersJSON(pos.TPArmedTiers), nullableFloat64(pos.StopLossATRMult), pos.TPTiersJSON, pos.SLAdjustedTiersProcessed, nullableFloat64(pos.PostTPTrailingATRMult), pos.Regime, marshalRegimeWindowsJSON(pos.RegimeWindows)); err != nil {
+			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.SetupStop, pos.SetupTrigger, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx, tp1OID, tp2OID, marshalTPOIDsJSON(pos.TPOIDs), marshalTPArmedTiersJSON(pos.TPArmedTiers), nullableFloat64(pos.StopLossATRMult), pos.TPTiersJSON, pos.SLAdjustedTiersProcessed, nullableFloat64(pos.PostTPTrailingATRMult), pos.Regime, marshalRegimeWindowsJSON(pos.RegimeWindows)); err != nil {
 				return fmt.Errorf("insert position %s/%s: %w", s.ID, pos.Symbol, err)
 			}
 		}
@@ -1289,7 +1293,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	}
 
 	// 3. Load positions for each strategy.
-	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, COALESCE(tp1_oid, 0) AS tp1_oid, COALESCE(tp2_oid, 0) AS tp2_oid, COALESCE(tp_oids_json, '') AS tp_oids_json, COALESCE(tp_armed_tiers_json, '') AS tp_armed_tiers_json, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json, COALESCE(sl_adjusted_tiers_processed, 0) AS sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, COALESCE(regime, '') AS regime, COALESCE(regime_windows_json, '') AS regime_windows_json FROM positions")
+	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, COALESCE(setup_stop, 0) AS setup_stop, COALESCE(setup_trigger, 0) AS setup_trigger, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, COALESCE(tp1_oid, 0) AS tp1_oid, COALESCE(tp2_oid, 0) AS tp2_oid, COALESCE(tp_oids_json, '') AS tp_oids_json, COALESCE(tp_armed_tiers_json, '') AS tp_armed_tiers_json, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json, COALESCE(sl_adjusted_tiers_processed, 0) AS sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, COALESCE(regime, '') AS regime, COALESCE(regime_windows_json, '') AS regime_windows_json FROM positions")
 	if err != nil {
 		return nil, fmt.Errorf("load positions: %w", err)
 	}
@@ -1304,7 +1308,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		var regimeWindowsJSON string
 		var slATRMult sql.NullFloat64
 		var postTPTrailingMult sql.NullFloat64
-		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx, &tp1OID, &tp2OID, &tpOIDsJSON, &tpArmedTiersJSON, &slATRMult, &pos.TPTiersJSON, &pos.SLAdjustedTiersProcessed, &postTPTrailingMult, &pos.Regime, &regimeWindowsJSON); err != nil {
+		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.SetupStop, &pos.SetupTrigger, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx, &tp1OID, &tp2OID, &tpOIDsJSON, &tpArmedTiersJSON, &slATRMult, &pos.TPTiersJSON, &pos.SLAdjustedTiersProcessed, &postTPTrailingMult, &pos.Regime, &regimeWindowsJSON); err != nil {
 			return nil, fmt.Errorf("scan position: %w", err)
 		}
 		pos.OpenedAt = parseTime(openedAtStr)

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -119,7 +119,7 @@ func makeTestState() *AppState {
 				Cash:           950.50,
 				InitialCapital: 1000.0,
 				Positions: map[string]*Position{
-					"BTC": {Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "long", Multiplier: 0, OwnerStrategyID: "hl-momentum-btc", OpenedAt: now.Add(-12 * time.Hour)},
+					"BTC": {Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, SetupStop: 49250, SetupTrigger: 50125, Side: "long", Multiplier: 0, OwnerStrategyID: "hl-momentum-btc", OpenedAt: now.Add(-12 * time.Hour)},
 				},
 				OptionPositions: map[string]*OptionPosition{
 					"opt-1": {
@@ -222,6 +222,9 @@ func TestSaveAndLoadDBRoundTrip(t *testing.T) {
 	}
 	if btcPos.Quantity != 0.1 || btcPos.AvgCost != 50000 || btcPos.Side != "long" {
 		t.Errorf("position mismatch: %+v", btcPos)
+	}
+	if btcPos.SetupStop != 49250 || btcPos.SetupTrigger != 50125 {
+		t.Errorf("setup metadata = stop %g trigger %g, want 49250/50125", btcPos.SetupStop, btcPos.SetupTrigger)
 	}
 	if btcPos.OwnerStrategyID != "hl-momentum-btc" {
 		t.Errorf("OwnerStrategyID = %q, want %q", btcPos.OwnerStrategyID, "hl-momentum-btc")

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -35,43 +35,45 @@ type stratDef struct {
 
 // knownShortNames maps strategy IDs to abbreviated config ID prefixes.
 var knownShortNames = map[string]string{
-	"sma_crossover":         "sma",
-	"ema_crossover":         "ema",
-	"momentum":              "momentum",
-	"rsi":                   "rsi",
-	"bollinger_bands":       "bb",
-	"macd":                  "macd",
-	"mean_reversion":        "mr",
-	"volume_weighted":       "vw",
-	"triple_ema":            "tema",
-	"triple_ema_bidir":      "temab",
-	"tema_cross":            "temac",
-	"tema_cross_bd":         "temacb",
-	"rsi_macd_combo":        "rmc",
-	"vol_mean_reversion":    "vol",
-	"momentum_options":      "mom",
-	"protective_puts":       "pput",
-	"covered_calls":         "ccall",
-	"breakout":              "bo",
-	"atr_breakout":          "atrbo",
-	"stoch_rsi":             "stochrsi",
-	"ichimoku_cloud":        "ichi",
-	"order_blocks":          "ob",
-	"vwap_reversion":        "vwap",
-	"chart_pattern":         "cpat",
-	"liquidity_sweeps":      "liqsw",
-	"parabolic_sar":         "psar",
-	"delta_neutral_funding": "dnf",
-	"supertrend":            "st",
-	"squeeze_momentum":      "sqm",
-	"heikin_ashi_ema":       "hae",
-	"range_scalper":         "rs",
-	"sweep_squeeze_combo":   "ssc",
-	"adx_trend":             "adxt",
-	"donchian_breakout":     "dbo",
-	"session_breakout":      "sbo",
-	"bear_pullback_st":      "bps",
-	"vwap_rejection_st":     "vrs",
+	"sma_crossover":             "sma",
+	"ema_crossover":             "ema",
+	"momentum":                  "momentum",
+	"rsi":                       "rsi",
+	"three_candle_rsi_reversal": "tcrr",
+	"four_hour_range_fakeout":   "fhrf",
+	"bollinger_bands":           "bb",
+	"macd":                      "macd",
+	"mean_reversion":            "mr",
+	"volume_weighted":           "vw",
+	"triple_ema":                "tema",
+	"triple_ema_bidir":          "temab",
+	"tema_cross":                "temac",
+	"tema_cross_bd":             "temacb",
+	"rsi_macd_combo":            "rmc",
+	"vol_mean_reversion":        "vol",
+	"momentum_options":          "mom",
+	"protective_puts":           "pput",
+	"covered_calls":             "ccall",
+	"breakout":                  "bo",
+	"atr_breakout":              "atrbo",
+	"stoch_rsi":                 "stochrsi",
+	"ichimoku_cloud":            "ichi",
+	"order_blocks":              "ob",
+	"vwap_reversion":            "vwap",
+	"chart_pattern":             "cpat",
+	"liquidity_sweeps":          "liqsw",
+	"parabolic_sar":             "psar",
+	"delta_neutral_funding":     "dnf",
+	"supertrend":                "st",
+	"squeeze_momentum":          "sqm",
+	"heikin_ashi_ema":           "hae",
+	"range_scalper":             "rs",
+	"sweep_squeeze_combo":       "ssc",
+	"adx_trend":                 "adxt",
+	"donchian_breakout":         "dbo",
+	"session_breakout":          "sbo",
+	"bear_pullback_st":          "bps",
+	"vwap_rejection_st":         "vrs",
 }
 
 // bidirectionalPerpsStrategies lists strategy IDs that emit signal=-1 as a
@@ -79,14 +81,16 @@ var knownShortNames = map[string]string{
 // set AllowShorts=true so ExecutePerpsSignal opens shorts from flat instead
 // of skipping the signal (#328).
 var bidirectionalPerpsStrategies = map[string]bool{
-	"triple_ema_bidir":  true,
-	"tema_cross_bd":     true,
-	"session_breakout":  true,
-	"donchian_breakout": true, // emits short on lower-channel breakdown (#649)
-	"chart_pattern":     true, // emits short on bearish patterns (double top, H&S, bear flag) (#649)
-	"liquidity_sweeps":  true, // emits short on stop-hunt wicks above swing highs (#649)
-	"bear_pullback_st":  true, // dedicated short-only strategy for bear-market rally rejections (#651)
-	"vwap_rejection_st": true, // dedicated short-only strategy for VWAP/EMA rally rejections in bearish regime (#652)
+	"triple_ema_bidir":          true,
+	"tema_cross_bd":             true,
+	"session_breakout":          true,
+	"three_candle_rsi_reversal": true,
+	"four_hour_range_fakeout":   true,
+	"donchian_breakout":         true, // emits short on lower-channel breakdown (#649)
+	"chart_pattern":             true, // emits short on bearish patterns (double top, H&S, bear flag) (#649)
+	"liquidity_sweeps":          true, // emits short on stop-hunt wicks above swing highs (#649)
+	"bear_pullback_st":          true, // dedicated short-only strategy for bear-market rally rejections (#651)
+	"vwap_rejection_st":         true, // dedicated short-only strategy for VWAP/EMA rally rejections in bearish regime (#652)
 }
 
 func isBidirectionalPerpsStrategy(id string) bool {
@@ -115,6 +119,8 @@ var defaultSpotStrategies = []stratDef{
 	{ID: "ema_crossover", ShortName: "ema"},
 	{ID: "momentum", ShortName: "momentum"},
 	{ID: "rsi", ShortName: "rsi"},
+	{ID: "three_candle_rsi_reversal", ShortName: "tcrr"},
+	{ID: "four_hour_range_fakeout", ShortName: "fhrf"},
 	{ID: "bollinger_bands", ShortName: "bb"},
 	{ID: "macd", ShortName: "macd"},
 	{ID: "mean_reversion", ShortName: "mr"},
@@ -146,6 +152,8 @@ var defaultPerpsStrategies = []stratDef{
 	{ID: "momentum", ShortName: "momentum"},
 	{ID: "triple_ema_bidir", ShortName: "temab"},
 	{ID: "tema_cross_bd", ShortName: "temacb"},
+	{ID: "three_candle_rsi_reversal", ShortName: "tcrr"},
+	{ID: "four_hour_range_fakeout", ShortName: "fhrf"},
 	{ID: "chart_pattern", ShortName: "cpat"},
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 	{ID: "delta_neutral_funding", ShortName: "dnf"},
@@ -160,6 +168,8 @@ var defaultFuturesStrategies = []stratDef{
 	{ID: "momentum", ShortName: "momentum"},
 	{ID: "mean_reversion", ShortName: "mr"},
 	{ID: "rsi", ShortName: "rsi"},
+	{ID: "three_candle_rsi_reversal", ShortName: "tcrr"},
+	{ID: "four_hour_range_fakeout", ShortName: "fhrf"},
 	{ID: "macd", ShortName: "macd"},
 	{ID: "breakout", ShortName: "bo"},
 	{ID: "triple_ema_bidir", ShortName: "temab"},

--- a/scheduler/init_test.go
+++ b/scheduler/init_test.go
@@ -732,6 +732,8 @@ func TestDeriveShortName(t *testing.T) {
 		{"ema_crossover", "ema"},
 		{"momentum", "momentum"},
 		{"bollinger_bands", "bb"},
+		{"three_candle_rsi_reversal", "tcrr"},
+		{"four_hour_range_fakeout", "fhrf"},
 		{"mean_reversion", "mr"},
 		{"volume_weighted", "vw"},
 		{"triple_ema", "tema"},
@@ -764,6 +766,8 @@ func TestGenerateConfig_PerpsDirectionWiring(t *testing.T) {
 		"triple_ema",
 		"rsi_macd_combo",
 		"session_breakout",
+		"three_candle_rsi_reversal",
+		"four_hour_range_fakeout",
 		"donchian_breakout",
 		"chart_pattern",
 		"liquidity_sweeps",
@@ -776,6 +780,8 @@ func TestGenerateConfig_PerpsDirectionWiring(t *testing.T) {
 		"hl-tema-eth":  DirectionLong, // long-only — must NOT allow shorts
 		"hl-rmc-eth":   DirectionLong, // long-only — must NOT allow shorts
 		"hl-sbo-eth":   DirectionBoth, // bidirectional — must allow shorts (#371)
+		"hl-tcrr-eth":  DirectionBoth, // bidirectional; can open reversal shorts
+		"hl-fhrf-eth":  DirectionBoth, // bidirectional; fades failed range breaks both ways
 		"hl-dbo-eth":   DirectionBoth, // bidirectional — emits short on lower-channel breakdown (#649)
 		"hl-cpat-eth":  DirectionBoth, // bidirectional — emits short on bearish patterns (#649)
 		"hl-liqsw-eth": DirectionBoth, // bidirectional — emits short on stop-hunt wicks (#649)

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2201,6 +2201,7 @@ func executeSpotResult(sc StrategyConfig, s *StrategyState, db *StateDB, result 
 	}
 	trades := exec.TradesExecuted
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
+	stampSetupMetadataIfOpened(s, result.Symbol, result.Indicators)
 	stampPositionRegimeIfOpened(s, result.Symbol, regimePayloadValue(result.Regime), sc, regime)
 	if pos, ok := s.Positions[result.Symbol]; ok {
 		recordPositionOpen(s, sc, exec.OpenTrade, pos)
@@ -2237,6 +2238,40 @@ func stampEntryATRIfOpened(s *StrategyState, symbol string, indicators map[strin
 		return
 	}
 	pos.EntryATR = atr
+}
+
+func stampSetupMetadataIfOpened(s *StrategyState, symbol string, indicators map[string]interface{}) {
+	if s == nil {
+		return
+	}
+	pos, exists := s.Positions[symbol]
+	if !exists || pos == nil {
+		return
+	}
+	if pos.SetupStop == 0 {
+		if stop, ok := indicatorFloat(indicators, "setup_stop"); ok && validSetupPrice(stop, pos.AvgCost) {
+			pos.SetupStop = stop
+		} else if stop, ok := indicatorFloat(indicators, "three_candle_stop"); ok && validSetupPrice(stop, pos.AvgCost) {
+			pos.SetupStop = stop
+		}
+	}
+	if pos.SetupTrigger == 0 {
+		if trigger, ok := indicatorFloat(indicators, "setup_trigger"); ok && validSetupPrice(trigger, pos.AvgCost) {
+			pos.SetupTrigger = trigger
+		} else if trigger, ok := indicatorFloat(indicators, "three_candle_trigger"); ok && validSetupPrice(trigger, pos.AvgCost) {
+			pos.SetupTrigger = trigger
+		}
+	}
+}
+
+func validSetupPrice(value float64, avgCost float64) bool {
+	if value <= 0 || value != value {
+		return false
+	}
+	if avgCost > 0 && value > avgCost*5 {
+		return false
+	}
+	return true
 }
 
 func indicatorFloat(indicators map[string]interface{}, key string) (float64, bool) {
@@ -2814,6 +2849,7 @@ func executeHyperliquidResultDeferredOpen(sc StrategyConfig, s *StrategyState, r
 	trades := exec.TradesExecuted
 	openTrade := exec.OpenTrade
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
+	stampSetupMetadataIfOpened(s, result.Symbol, result.Indicators)
 	stampPositionRegimeIfOpened(s, result.Symbol, regimePayloadValue(result.Regime), sc, regime)
 	if pos, ok := s.Positions[result.Symbol]; ok {
 		stampPositionProtectionSnapshot(pos, sc)
@@ -3073,6 +3109,7 @@ func executeTopStepResult(sc StrategyConfig, s *StrategyState, db *StateDB, resu
 	}
 	trades := exec.TradesExecuted
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
+	stampSetupMetadataIfOpened(s, result.Symbol, result.Indicators)
 	stampPositionRegimeIfOpened(s, result.Symbol, regimePayloadValue(result.Regime), sc, regime)
 	if pos, ok := s.Positions[result.Symbol]; ok {
 		recordPositionOpen(s, sc, exec.OpenTrade, pos)
@@ -3239,6 +3276,7 @@ func executeRobinhoodResult(sc StrategyConfig, s *StrategyState, db *StateDB, re
 	}
 	trades := exec.TradesExecuted
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
+	stampSetupMetadataIfOpened(s, result.Symbol, result.Indicators)
 	stampPositionRegimeIfOpened(s, result.Symbol, regimePayloadValue(result.Regime), sc, regime)
 	if pos, ok := s.Positions[result.Symbol]; ok {
 		recordPositionOpen(s, sc, exec.OpenTrade, pos)
@@ -3453,6 +3491,7 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *
 	}
 	trades := exec.TradesExecuted
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
+	stampSetupMetadataIfOpened(s, result.Symbol, result.Indicators)
 	stampPositionRegimeIfOpened(s, result.Symbol, regimePayloadValue(result.Regime), sc, regime)
 	if pos, ok := s.Positions[result.Symbol]; ok {
 		recordPositionOpen(s, sc, exec.OpenTrade, pos)

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -1075,6 +1075,47 @@ func TestStampEntryATRIfOpened(t *testing.T) {
 	}
 }
 
+func TestStampSetupMetadataIfOpened(t *testing.T) {
+	newState := func(existingStop, existingTrigger float64) *StrategyState {
+		return &StrategyState{Positions: map[string]*Position{
+			"BTC": {AvgCost: 50000, SetupStop: existingStop, SetupTrigger: existingTrigger},
+		}}
+	}
+
+	cases := []struct {
+		name        string
+		s           *StrategyState
+		symbol      string
+		inds        map[string]interface{}
+		wantStop    float64
+		wantTrigger float64
+	}{
+		{"stamps setup metadata", newState(0, 0), "BTC", map[string]interface{}{"setup_stop": 49250.0, "setup_trigger": 50125.0}, 49250, 50125},
+		{"falls back to three candle metadata", newState(0, 0), "BTC", map[string]interface{}{"three_candle_stop": 49100.0, "three_candle_trigger": 50200.0}, 49100, 50200},
+		{"keeps existing values", newState(49000, 50100), "BTC", map[string]interface{}{"setup_stop": 49250.0, "setup_trigger": 50125.0}, 49000, 50100},
+		{"rejects invalid setup prices", newState(0, 0), "BTC", map[string]interface{}{"setup_stop": math.NaN(), "setup_trigger": math.Inf(1)}, 0, 0},
+		{"rejects implausibly large setup prices", newState(0, 0), "BTC", map[string]interface{}{"setup_stop": 300000.0, "setup_trigger": 300000.0}, 0, 0},
+		{"no-op for missing symbol", newState(0, 0), "ETH", map[string]interface{}{"setup_stop": 49250.0, "setup_trigger": 50125.0}, 0, 0},
+		{"no-op for nil state", nil, "BTC", map[string]interface{}{"setup_stop": 49250.0, "setup_trigger": 50125.0}, 0, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stampSetupMetadataIfOpened(tc.s, tc.symbol, tc.inds)
+			if tc.s == nil {
+				return
+			}
+			pos := tc.s.Positions["BTC"]
+			if pos == nil {
+				t.Fatal("missing BTC position")
+			}
+			if pos.SetupStop != tc.wantStop || pos.SetupTrigger != tc.wantTrigger {
+				t.Fatalf("setup metadata = stop %g trigger %g, want %g/%g", pos.SetupStop, pos.SetupTrigger, tc.wantStop, tc.wantTrigger)
+			}
+		})
+	}
+}
+
 func TestExecuteTopStepResult_StampsExchangeData(t *testing.T) {
 	s := &StrategyState{
 		ID:              "ts-momentum-es",

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -14,6 +14,8 @@ type Position struct {
 	InitialQuantity     float64   `json:"initial_quantity,omitempty"` // original open size; partial closes must not rewrite it (#496)
 	AvgCost             float64   `json:"avg_cost"`
 	EntryATR            float64   `json:"entry_atr,omitempty"`               // ATR value from the entry strategy's open candle when available (#496)
+	SetupStop           float64   `json:"setup_stop,omitempty"`              // Entry-strategy stop level used by setup-aware close evaluators.
+	SetupTrigger        float64   `json:"setup_trigger,omitempty"`           // Entry-strategy trigger level retained for audit/debug context.
 	Side                string    `json:"side"`                              // "long" or "short"
 	Multiplier          float64   `json:"multiplier,omitempty"`              // contract multiplier (0 = spot, >0 = futures/perps PnL branch; canonical perps value is 1 — do NOT set to leverage)
 	Leverage            float64   `json:"leverage,omitempty"`                // perps exchange leverage (informational; PnL is not scaled by leverage) (#254/#497)

--- a/scheduler/strategy_composition.go
+++ b/scheduler/strategy_composition.go
@@ -31,6 +31,8 @@ type PositionCtx struct {
 	Quantity          float64
 	InitialQuantity   float64
 	EntryATR          float64
+	SetupStop         float64
+	SetupTrigger      float64
 	Regime            string
 	DirectionalRegime string
 	RegimeWindows     map[string]string
@@ -82,6 +84,8 @@ func appendOpenCloseArgs(args []string, sc StrategyConfig, pos PositionCtx) []st
 	out = appendPositionFloatArg(out, "--position-qty", pos.Quantity)
 	out = appendPositionFloatArg(out, "--position-initial-qty", pos.InitialQuantity)
 	out = appendPositionFloatArg(out, "--position-entry-atr", pos.EntryATR)
+	out = appendPositionFloatArg(out, "--position-setup-stop", pos.SetupStop)
+	out = appendPositionFloatArg(out, "--position-setup-trigger", pos.SetupTrigger)
 	if r := strings.TrimSpace(pos.Regime); r != "" {
 		out = append(out, "--position-regime", r)
 	}
@@ -159,6 +163,8 @@ func positionCtxFromPosition(pos *Position) PositionCtx {
 		Quantity:          pos.Quantity,
 		InitialQuantity:   pos.InitialQuantity,
 		EntryATR:          pos.EntryATR,
+		SetupStop:         pos.SetupStop,
+		SetupTrigger:      pos.SetupTrigger,
 		Regime:            pos.Regime,
 		DirectionalRegime: pos.Regime,
 		RegimeWindows:     cloneStringMap(pos.RegimeWindows),

--- a/scheduler/strategy_composition_test.go
+++ b/scheduler/strategy_composition_test.go
@@ -165,6 +165,8 @@ func TestAppendOpenCloseArgsPositionCtx(t *testing.T) {
 				Quantity:        0.4,
 				InitialQuantity: 0.4,
 				EntryATR:        750.25,
+				SetupStop:       49800,
+				SetupTrigger:    51100,
 			},
 			want: []string{
 				"triple_ema", "ETH", "1h",
@@ -173,6 +175,8 @@ func TestAppendOpenCloseArgsPositionCtx(t *testing.T) {
 				"--position-qty=0.4",
 				"--position-initial-qty=0.4",
 				"--position-entry-atr=750.25",
+				"--position-setup-stop=49800",
+				"--position-setup-trigger=51100",
 			},
 		},
 	}
@@ -194,10 +198,12 @@ func TestPositionCtxForSymbol(t *testing.T) {
 			InitialQuantity: 1,
 			AvgCost:         3000,
 			EntryATR:        125,
+			SetupStop:       2925,
+			SetupTrigger:    3010,
 		},
 	}}
 	got := positionCtxForSymbol(s, "ETH", StrategyConfig{}, nil)
-	want := PositionCtx{Side: "long", AvgCost: 3000, Quantity: 0.5, InitialQuantity: 1, EntryATR: 125}
+	want := PositionCtx{Side: "long", AvgCost: 3000, Quantity: 0.5, InitialQuantity: 1, EntryATR: 125, SetupStop: 2925, SetupTrigger: 3010}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("positionCtxForSymbol() = %#v, want %#v", got, want)
 	}

--- a/scheduler/version_probe.go
+++ b/scheduler/version_probe.go
@@ -33,6 +33,8 @@ var probeArgv = []string{
 	// so a stale Python that doesn't accept the flag fails startup loudly
 	// instead of every cycle's argparse rejecting the cycle's argv.
 	"--mark-price=0",
+	"--position-setup-stop=0",
+	"--position-setup-trigger=0",
 	"--ohlcv-limit", "200",
 	"--regime-windows-spec-json", `{"default":{"classifier":"adx","period":14,"adx_threshold":20}}`,
 	"--regime-atr-window", "",

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -84,6 +84,8 @@ def _position_ctx_from_args(args):
         ("position_qty", "current_quantity"),
         ("position_initial_qty", "initial_quantity"),
         ("position_entry_atr", "entry_atr"),
+        ("position_setup_stop", "setup_stop"),
+        ("position_setup_trigger", "setup_trigger"),
     ):
         value = getattr(args, attr, None)
         if value is not None:
@@ -1228,6 +1230,8 @@ def main():
         parser.add_argument("--position-qty", type=float, default=None)
         parser.add_argument("--position-initial-qty", type=float, default=None)
         parser.add_argument("--position-entry-atr", type=float, default=None)
+        parser.add_argument("--position-setup-stop", type=float, default=None)
+        parser.add_argument("--position-setup-trigger", type=float, default=None)
         parser.add_argument("--position-regime", default="")
         parser.add_argument("--mark-price", type=float, default=0.0,
             help="Optional mid from Go's fetchHyperliquidMids cycle; when >0 skips adapter.get_spot_price's duplicate /info allMids call (#768).")

--- a/shared_scripts/check_okx.py
+++ b/shared_scripts/check_okx.py
@@ -57,6 +57,8 @@ def _position_ctx_from_args(args):
         ("position_qty", "current_quantity"),
         ("position_initial_qty", "initial_quantity"),
         ("position_entry_atr", "entry_atr"),
+        ("position_setup_stop", "setup_stop"),
+        ("position_setup_trigger", "setup_trigger"),
     ):
         value = getattr(args, attr, None)
         if value is not None:
@@ -382,6 +384,8 @@ def main():
         parser.add_argument("--position-qty", type=float, default=None)
         parser.add_argument("--position-initial-qty", type=float, default=None)
         parser.add_argument("--position-entry-atr", type=float, default=None)
+        parser.add_argument("--position-setup-stop", type=float, default=None)
+        parser.add_argument("--position-setup-trigger", type=float, default=None)
         parser.add_argument("--position-regime", default="")
         parser.add_argument("--mark-price", type=float, default=0.0, help="Accepted for argv-shape compatibility with check_hyperliquid.py (#768); ignored on this platform.")
         parser.add_argument("--probe-only", action="store_true",

--- a/shared_scripts/check_robinhood.py
+++ b/shared_scripts/check_robinhood.py
@@ -48,6 +48,8 @@ def _position_ctx_from_args(args):
         ("position_qty", "current_quantity"),
         ("position_initial_qty", "initial_quantity"),
         ("position_entry_atr", "entry_atr"),
+        ("position_setup_stop", "setup_stop"),
+        ("position_setup_trigger", "setup_trigger"),
     ):
         value = getattr(args, attr, None)
         if value is not None:
@@ -391,6 +393,8 @@ def main():
         parser.add_argument("--position-qty", type=float, default=None)
         parser.add_argument("--position-initial-qty", type=float, default=None)
         parser.add_argument("--position-entry-atr", type=float, default=None)
+        parser.add_argument("--position-setup-stop", type=float, default=None)
+        parser.add_argument("--position-setup-trigger", type=float, default=None)
         parser.add_argument("--position-regime", default="")
         parser.add_argument("--mark-price", type=float, default=0.0, help="Accepted for argv-shape compatibility with check_hyperliquid.py (#768); ignored on this platform.")
         parser.add_argument("--probe-only", action="store_true",

--- a/shared_scripts/check_strategy.py
+++ b/shared_scripts/check_strategy.py
@@ -58,6 +58,8 @@ def _position_ctx(position_side):
         ("--position-qty", "current_quantity"),
         ("--position-initial-qty", "initial_quantity"),
         ("--position-entry-atr", "entry_atr"),
+        ("--position-setup-stop", "setup_stop"),
+        ("--position-setup-trigger", "setup_trigger"),
     ):
         value = _arg_float(flag)
         if value is not None:
@@ -111,6 +113,7 @@ def main():
             "--params", "--open-strategy", "--close-strategies", "--strategy-refs",
             "--position-side", "--position-avg-cost", "--position-qty",
             "--position-initial-qty", "--position-entry-atr",
+            "--position-setup-stop", "--position-setup-trigger",
             "--position-regime",
             "--regime-windows-spec-json", "--ohlcv-limit",
             "--regime-atr-window", "--regime-directional-window",

--- a/shared_scripts/check_topstep.py
+++ b/shared_scripts/check_topstep.py
@@ -46,6 +46,8 @@ def _position_ctx_from_args(args):
         ("position_qty", "current_quantity"),
         ("position_initial_qty", "initial_quantity"),
         ("position_entry_atr", "entry_atr"),
+        ("position_setup_stop", "setup_stop"),
+        ("position_setup_trigger", "setup_trigger"),
     ):
         value = getattr(args, attr, None)
         if value is not None:
@@ -394,6 +396,8 @@ def main():
         parser.add_argument("--position-qty", type=float, default=None)
         parser.add_argument("--position-initial-qty", type=float, default=None)
         parser.add_argument("--position-entry-atr", type=float, default=None)
+        parser.add_argument("--position-setup-stop", type=float, default=None)
+        parser.add_argument("--position-setup-trigger", type=float, default=None)
         parser.add_argument("--position-regime", default="")
         parser.add_argument("--mark-price", type=float, default=0.0, help="Accepted for argv-shape compatibility with check_hyperliquid.py (#768); ignored on this platform.")
         parser.add_argument("--probe-only", action="store_true",

--- a/shared_strategies/close/registry.py
+++ b/shared_strategies/close/registry.py
@@ -18,6 +18,7 @@ from tiered_tp_atr_live_regime import evaluate as tiered_tp_atr_live_regime_eval
 from tiered_tp_pct import DEFAULT_TIERS as DEFAULT_PCT_TIERS
 from tiered_tp_pct import evaluate as tiered_tp_pct_evaluate
 from tp_at_pct import evaluate as tp_at_pct_evaluate
+from setup_rr import evaluate as setup_rr_evaluate
 
 VALID_PLATFORMS: Tuple[str, ...] = ("spot", "futures", "options")
 
@@ -128,3 +129,9 @@ register(
     "Position-aware percentage take-profit close",
     {"pct": 0.03},
 )(tp_at_pct_evaluate)
+
+register(
+    "setup_rr",
+    "Setup stop with R-multiple target and breakeven promotion",
+    {"target_r": 3.0, "breakeven_r": 2.0, "same_bar_priority": "stop"},
+)(setup_rr_evaluate)

--- a/shared_strategies/close/setup_rr.py
+++ b/shared_strategies/close/setup_rr.py
@@ -1,0 +1,75 @@
+"""Close setup-based positions at stop, breakeven, or R-multiple target."""
+
+from __future__ import annotations
+
+from _helpers import float_from
+
+
+def _positive_param(params: dict, key: str, default: float) -> float:
+    try:
+        value = float(params.get(key, default))
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def _reason(name: str, suffix: str) -> dict:
+    return {"close_fraction": 1.0, "reason": f"{name}:{suffix}"}
+
+
+def evaluate(position: dict, market: dict, params: dict) -> dict:
+    """Evaluate a setup stop, target, and breakeven rule.
+
+    The entry strategy must stamp ``setup_stop`` or ``three_candle_stop`` onto
+    the position. The backtester also passes bar high/low and high/low-water
+    fields so the breakeven condition can persist after price first reaches
+    ``breakeven_r``.
+    """
+    avg_cost = float_from(position, "avg_cost")
+    current_quantity = float_from(position, "current_quantity")
+    side = str(position.get("side", "") or "").strip().lower()
+    stop = float_from(position, "setup_stop") or float_from(position, "three_candle_stop")
+
+    if avg_cost <= 0 or current_quantity <= 0 or side not in ("long", "short"):
+        return {"close_fraction": 0.0, "reason": "noop:missing_position"}
+    if stop <= 0:
+        return {"close_fraction": 0.0, "reason": "noop:missing_setup_stop"}
+
+    target_r = _positive_param(params, "target_r", 3.0)
+    breakeven_r = _positive_param(params, "breakeven_r", 2.0)
+    priority = str(params.get("same_bar_priority", "stop") or "stop").strip().lower()
+
+    mark_price = float_from(market, "mark_price")
+    bar_high = float_from(market, "bar_high") or mark_price
+    bar_low = float_from(market, "bar_low") or mark_price
+    high_water = float_from(position, "high_water") or max(mark_price, bar_high)
+    low_water = float_from(position, "low_water") or min(mark_price, bar_low)
+
+    if side == "long":
+        risk = avg_cost - stop
+        if risk <= 0:
+            return {"close_fraction": 0.0, "reason": "noop:invalid_setup_stop"}
+        target = avg_cost + target_r * risk
+        breakeven_active = high_water >= avg_cost + breakeven_r * risk
+        active_stop = max(stop, avg_cost) if breakeven_active else stop
+        stop_hit = bar_low <= active_stop
+        target_hit = bar_high >= target
+    else:
+        risk = stop - avg_cost
+        if risk <= 0:
+            return {"close_fraction": 0.0, "reason": "noop:invalid_setup_stop"}
+        target = avg_cost - target_r * risk
+        breakeven_active = low_water <= avg_cost - breakeven_r * risk
+        active_stop = min(stop, avg_cost) if breakeven_active else stop
+        stop_hit = bar_high >= active_stop
+        target_hit = bar_low <= target
+
+    if stop_hit and target_hit:
+        if priority == "target":
+            return _reason("setup_rr", "target")
+        return _reason("setup_rr", "breakeven" if breakeven_active else "stop")
+    if stop_hit:
+        return _reason("setup_rr", "breakeven" if breakeven_active else "stop")
+    if target_hit:
+        return _reason("setup_rr", "target")
+    return {"close_fraction": 0.0, "reason": "noop:not_hit"}

--- a/shared_strategies/close/test_close_registry.py
+++ b/shared_strategies/close/test_close_registry.py
@@ -28,6 +28,7 @@ def test_build_close_registry_filters_valid_platforms(registry):
             "tiered_tp_atr_regime",
             "tiered_tp_atr_live_regime",
             "tp_at_pct",
+            "setup_rr",
         }
 
 
@@ -56,6 +57,74 @@ def test_tp_at_pct_hits_for_long_and_short(registry):
     )
     assert long_hit == {"close_fraction": 1.0, "reason": "tp_at_pct:hit"}
     assert short_hit == {"close_fraction": 1.0, "reason": "tp_at_pct:hit"}
+
+
+def test_setup_rr_hits_long_target_and_breakeven(registry):
+    target = registry.evaluate(
+        "setup_rr",
+        {
+            "side": "long",
+            "avg_cost": 100,
+            "current_quantity": 1,
+            "initial_quantity": 1,
+            "three_candle_stop": 90,
+            "high_water": 130,
+            "low_water": 100,
+        },
+        {"mark_price": 125, "bar_high": 130, "bar_low": 124},
+        {"target_r": 3, "breakeven_r": 2},
+    )
+    breakeven = registry.evaluate(
+        "setup_rr",
+        {
+            "side": "long",
+            "avg_cost": 100,
+            "current_quantity": 1,
+            "initial_quantity": 1,
+            "three_candle_stop": 90,
+            "high_water": 121,
+            "low_water": 100,
+        },
+        {"mark_price": 99, "bar_high": 101, "bar_low": 99},
+        {"target_r": 3, "breakeven_r": 2},
+    )
+
+    assert target == {"close_fraction": 1.0, "reason": "setup_rr:target"}
+    assert breakeven == {"close_fraction": 1.0, "reason": "setup_rr:breakeven"}
+
+
+def test_setup_rr_hits_short_target_and_stop(registry):
+    target = registry.evaluate(
+        "setup_rr",
+        {
+            "side": "short",
+            "avg_cost": 100,
+            "current_quantity": 1,
+            "initial_quantity": 1,
+            "three_candle_stop": 110,
+            "high_water": 100,
+            "low_water": 70,
+        },
+        {"mark_price": 75, "bar_high": 76, "bar_low": 70},
+        {"target_r": 3, "breakeven_r": 2},
+    )
+    stop = registry.evaluate(
+        "setup_rr",
+        {
+            "side": "short",
+            "avg_cost": 100,
+            "current_quantity": 1,
+            "initial_quantity": 1,
+            "three_candle_stop": 110,
+            "high_water": 111,
+            "low_water": 100,
+        },
+        {"mark_price": 111, "bar_high": 111, "bar_low": 105},
+        {"target_r": 3, "breakeven_r": 2},
+    )
+
+    assert target == {"close_fraction": 1.0, "reason": "setup_rr:target"}
+    assert stop == {"close_fraction": 1.0, "reason": "setup_rr:stop"}
 
 
 def test_tiered_tp_pct_closes_only_unfilled_tier_amount(registry):

--- a/shared_strategies/open/futures/test_strategies.py
+++ b/shared_strategies/open/futures/test_strategies.py
@@ -49,7 +49,8 @@ class TestFuturesRegistry:
         for expected in ["sma_crossover", "ema_crossover", "bollinger_bands",
                          "volume_weighted", "triple_ema", "triple_ema_bidir",
                          "rsi_macd_combo",
-                         "momentum", "mean_reversion", "rsi", "macd", "breakout",
+                         "momentum", "mean_reversion", "rsi", "three_candle_rsi_reversal",
+                         "four_hour_range_fakeout", "macd", "breakout",
                          "stoch_rsi", "supertrend", "squeeze_momentum",
                          "ichimoku_cloud", "atr_breakout", "heikin_ashi_ema",
                          "order_blocks", "parabolic_sar", "delta_neutral_funding"]:
@@ -563,7 +564,7 @@ class TestEdgeCases:
     @pytest.mark.parametrize("name", [
         "sma_crossover", "ema_crossover", "bollinger_bands",
         "volume_weighted", "triple_ema", "triple_ema_bidir", "rsi_macd_combo",
-        "momentum", "mean_reversion", "rsi", "macd", "breakout",
+        "momentum", "mean_reversion", "rsi", "three_candle_rsi_reversal", "four_hour_range_fakeout", "macd", "breakout",
         "stoch_rsi", "supertrend", "squeeze_momentum",
         "atr_breakout", "heikin_ashi_ema", "parabolic_sar",
         "ichimoku_cloud", "order_blocks", "delta_neutral_funding",
@@ -577,7 +578,7 @@ class TestEdgeCases:
     @pytest.mark.parametrize("name", [
         "sma_crossover", "ema_crossover", "bollinger_bands",
         "volume_weighted", "triple_ema", "triple_ema_bidir", "rsi_macd_combo",
-        "momentum", "mean_reversion", "rsi", "macd", "breakout",
+        "momentum", "mean_reversion", "rsi", "three_candle_rsi_reversal", "four_hour_range_fakeout", "macd", "breakout",
         "stoch_rsi", "atr_breakout", "heikin_ashi_ema",
         "supertrend", "squeeze_momentum", "ichimoku_cloud",
         "order_blocks", "delta_neutral_funding",

--- a/shared_strategies/open/registry.py
+++ b/shared_strategies/open/registry.py
@@ -193,6 +193,253 @@ def rsi_strategy(df: pd.DataFrame, period: int = 14, overbought: float = 70, ove
 
 
 @register(
+    "three_candle_rsi_reversal",
+    "Three-Candle RSI Reversal — liquidity sweep reversal confirmed by RSI exhaustion",
+    {
+        "rsi_period": 14,
+        "oversold": 30,
+        "overbought": 70,
+        "threshold_lookback": 8,
+        "entry_valid_bars": 3,
+    },
+)
+def three_candle_rsi_reversal_strategy(
+    df: pd.DataFrame,
+    rsi_period: int = 14,
+    oversold: float = 30,
+    overbought: float = 70,
+    threshold_lookback: int = 8,
+    entry_valid_bars: int = 3,
+) -> pd.DataFrame:
+    """Detect the setup on closed candles, then wait for the entry trigger."""
+    result = df.copy()
+    result["signal"] = 0
+    result["rsi"] = np.nan
+    result["three_candle_setup"] = ""
+    result["three_candle_trigger"] = np.nan
+    result["three_candle_stop"] = np.nan
+
+    required_columns = {"high", "low", "close"}
+    if result.empty or not required_columns.issubset(result.columns):
+        return result
+
+    rsi_period = max(int(rsi_period), 1)
+    threshold_lookback = max(int(threshold_lookback), 1)
+    entry_valid_bars = max(int(entry_valid_bars), 1)
+
+    delta = result["close"].diff()
+    gain = delta.clip(lower=0)
+    loss = (-delta).clip(lower=0)
+    avg_gain = gain.ewm(alpha=1 / rsi_period, min_periods=rsi_period, adjust=False).mean()
+    avg_loss = loss.ewm(alpha=1 / rsi_period, min_periods=rsi_period, adjust=False).mean()
+    rs = avg_gain / avg_loss.replace(0, np.nan)
+    result["rsi"] = 100 - (100 / (1 + rs))
+    result.loc[(avg_loss == 0) & (avg_gain > 0), "rsi"] = 100.0
+    result.loc[(avg_gain == 0) & (avg_loss > 0), "rsi"] = 0.0
+
+    pending: Optional[dict] = None
+    highs = result["high"].to_numpy(dtype=float)
+    lows = result["low"].to_numpy(dtype=float)
+    closes = result["close"].to_numpy(dtype=float)
+    rsi_values = result["rsi"].to_numpy(dtype=float)
+    index = result.index
+
+    for i in range(len(result)):
+        if pending is not None:
+            invalidated = (
+                lows[i] <= pending["stop"] if pending["side"] == "long"
+                else highs[i] >= pending["stop"]
+            )
+            if i > pending["expires_at"] or invalidated:
+                pending = None
+            elif pending["side"] == "long" and highs[i] >= pending["trigger"]:
+                result.at[index[i], "signal"] = 1
+                result.at[index[i], "three_candle_trigger"] = pending["trigger"]
+                result.at[index[i], "three_candle_stop"] = pending["stop"]
+                pending = None
+            elif pending["side"] == "short" and lows[i] <= pending["trigger"]:
+                result.at[index[i], "signal"] = -1
+                result.at[index[i], "three_candle_trigger"] = pending["trigger"]
+                result.at[index[i], "three_candle_stop"] = pending["stop"]
+                pending = None
+
+        if i < 2 or pending is not None:
+            continue
+
+        c1, c2, c3 = i - 2, i - 1, i
+        recent_start = max(0, c1 - threshold_lookback + 1)
+        recent_rsi = rsi_values[recent_start : c3 + 1]
+        has_rsi = not np.isnan(recent_rsi).all()
+        recent_oversold = bool(has_rsi and np.nanmin(recent_rsi) < oversold)
+        recent_overbought = bool(has_rsi and np.nanmax(recent_rsi) > overbought)
+
+        long_setup = (
+            recent_oversold
+            and lows[c2] < lows[c1]
+            and closes[c2] > lows[c1]
+            and lows[c3] >= lows[c2]
+        )
+        short_setup = (
+            recent_overbought
+            and highs[c2] > highs[c1]
+            and closes[c2] < highs[c1]
+            and highs[c3] <= highs[c2]
+        )
+
+        if long_setup:
+            trigger = max(highs[c1], highs[c2], highs[c3])
+            stop = min(lows[c1], lows[c2], lows[c3])
+            if trigger > stop:
+                result.at[index[i], "three_candle_setup"] = "long"
+                result.at[index[i], "three_candle_trigger"] = trigger
+                result.at[index[i], "three_candle_stop"] = stop
+                pending = {"side": "long", "trigger": trigger, "stop": stop, "expires_at": i + entry_valid_bars}
+        elif short_setup:
+            trigger = min(lows[c1], lows[c2], lows[c3])
+            stop = max(highs[c1], highs[c2], highs[c3])
+            if trigger < stop:
+                result.at[index[i], "three_candle_setup"] = "short"
+                result.at[index[i], "three_candle_trigger"] = trigger
+                result.at[index[i], "three_candle_stop"] = stop
+                pending = {"side": "short", "trigger": trigger, "stop": stop, "expires_at": i + entry_valid_bars}
+
+    return result
+
+
+@register(
+    "four_hour_range_fakeout",
+    "Four-Hour Range Fakeout — fade same-day NY range breaks that close back inside",
+    {
+        "range_hours": 4,
+        "timezone": "America/New_York",
+        "max_breakout_bars": 48,
+        "min_range_pct": 0.0,
+        "max_range_pct": 0.0,
+    },
+)
+def four_hour_range_fakeout_strategy(
+    df: pd.DataFrame,
+    range_hours: int = 4,
+    timezone: str = "America/New_York",
+    max_breakout_bars: int = 48,
+    min_range_pct: float = 0.0,
+    max_range_pct: float = 0.0,
+) -> pd.DataFrame:
+    """Fade failed breaks of the first NY-session range of each day."""
+    result = df.copy()
+    result["signal"] = 0
+    result["setup_kind"] = ""
+    result["setup_trigger"] = np.nan
+    result["setup_stop"] = np.nan
+    result["range_high"] = np.nan
+    result["range_low"] = np.nan
+
+    required_columns = {"high", "low", "close"}
+    if result.empty or not required_columns.issubset(result.columns):
+        return result
+
+    range_hours = max(int(range_hours), 1)
+    max_breakout_bars = max(int(max_breakout_bars), 1)
+    min_range_pct = max(float(min_range_pct or 0.0), 0.0)
+    max_range_pct = max(float(max_range_pct or 0.0), 0.0)
+
+    index = result.index
+    if not isinstance(index, pd.DatetimeIndex):
+        return result
+    if index.tz is None:
+        local_index = index.tz_localize("UTC").tz_convert(timezone)
+    else:
+        local_index = index.tz_convert(timezone)
+
+    local_midnight = local_index.normalize()
+    minutes_from_midnight = (
+        (local_index - local_midnight).total_seconds() / 60
+    ).astype(int)
+    ny_dates = local_index.date
+
+    highs = result["high"].to_numpy(dtype=float)
+    lows = result["low"].to_numpy(dtype=float)
+    closes = result["close"].to_numpy(dtype=float)
+    out_index = result.index
+
+    for day in pd.unique(ny_dates):
+        day_mask = ny_dates == day
+        day_positions = np.flatnonzero(day_mask)
+        range_positions = [
+            pos for pos in day_positions
+            if 0 <= minutes_from_midnight[pos] < range_hours * 60
+        ]
+        trade_positions = [
+            pos for pos in day_positions
+            if minutes_from_midnight[pos] >= range_hours * 60
+        ]
+        if not range_positions or not trade_positions:
+            continue
+
+        range_high = float(np.nanmax(highs[range_positions]))
+        range_low = float(np.nanmin(lows[range_positions]))
+        if not (range_high > range_low > 0):
+            continue
+
+        result.loc[out_index[day_positions], "range_high"] = range_high
+        result.loc[out_index[day_positions], "range_low"] = range_low
+
+        pending: Optional[dict] = None
+        for pos in trade_positions:
+            close = closes[pos]
+            range_pct = (range_high - range_low) / close if close > 0 else 0.0
+            if min_range_pct > 0 and range_pct < min_range_pct:
+                continue
+            if max_range_pct > 0 and range_pct > max_range_pct:
+                continue
+
+            if pending is None:
+                if close > range_high:
+                    pending = {
+                        "side": "short",
+                        "extreme": highs[pos],
+                        "trigger": range_high,
+                        "bars": 0,
+                    }
+                elif close < range_low:
+                    pending = {
+                        "side": "long",
+                        "extreme": lows[pos],
+                        "trigger": range_low,
+                        "bars": 0,
+                    }
+                continue
+
+            pending["bars"] += 1
+            if pending["side"] == "short":
+                pending["extreme"] = max(pending["extreme"], highs[pos])
+                if close < range_high:
+                    stop = float(pending["extreme"])
+                    if stop > close:
+                        result.at[out_index[pos], "signal"] = -1
+                        result.at[out_index[pos], "setup_kind"] = "four_hour_range_short"
+                        result.at[out_index[pos], "setup_trigger"] = pending["trigger"]
+                        result.at[out_index[pos], "setup_stop"] = stop
+                    pending = None
+                elif pending["bars"] >= max_breakout_bars:
+                    pending = None
+            else:
+                pending["extreme"] = min(pending["extreme"], lows[pos])
+                if close > range_low:
+                    stop = float(pending["extreme"])
+                    if close > stop:
+                        result.at[out_index[pos], "signal"] = 1
+                        result.at[out_index[pos], "setup_kind"] = "four_hour_range_long"
+                        result.at[out_index[pos], "setup_trigger"] = pending["trigger"]
+                        result.at[out_index[pos], "setup_stop"] = stop
+                    pending = None
+                elif pending["bars"] >= max_breakout_bars:
+                    pending = None
+
+    return result
+
+
+@register(
     "bollinger_bands",
     "Bollinger Bands \u2014 mean reversion at band touches",
     {"period": 20, "num_std": 2.0},
@@ -1028,7 +1275,7 @@ def hold_strategy(df: pd.DataFrame) -> pd.DataFrame:
 
 PLATFORM_ORDER: Dict[str, List[str]] = {
     "spot": [
-        "sma_crossover", "ema_crossover", "rsi", "bollinger_bands", "macd",
+        "sma_crossover", "ema_crossover", "rsi", "three_candle_rsi_reversal", "four_hour_range_fakeout", "bollinger_bands", "macd",
         "mean_reversion", "momentum", "volume_weighted", "triple_ema",
         "rsi_macd_combo", "stoch_rsi", "supertrend", "ichimoku_cloud",
         "pairs_spread", "squeeze_momentum", "atr_breakout", "amd_ifvg",
@@ -1040,7 +1287,7 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
     "futures": [
         "sma_crossover", "ema_crossover", "bollinger_bands", "volume_weighted",
         "triple_ema", "triple_ema_bidir", "tema_cross", "tema_cross_bd", "rsi_macd_combo", "momentum",
-        "mean_reversion", "rsi", "macd", "breakout", "stoch_rsi", "supertrend",
+        "mean_reversion", "rsi", "three_candle_rsi_reversal", "four_hour_range_fakeout", "macd", "breakout", "stoch_rsi", "supertrend",
         "squeeze_momentum", "ichimoku_cloud", "atr_breakout", "amd_ifvg",
         "heikin_ashi_ema", "order_blocks", "vwap_reversion", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",

--- a/shared_strategies/open/spot/test_strategies.py
+++ b/shared_strategies/open/spot/test_strategies.py
@@ -46,8 +46,10 @@ class TestRegistry:
         names = list_strategies()
         assert len(names) >= 20
         # Spot-check a few
-        for expected in ["sma_crossover", "ema_crossover", "rsi", "macd", "momentum",
-                         "bollinger_bands", "mean_reversion", "supertrend", "parabolic_sar"]:
+        for expected in ["sma_crossover", "ema_crossover", "rsi", "three_candle_rsi_reversal",
+                         "four_hour_range_fakeout",
+                         "macd", "momentum", "bollinger_bands", "mean_reversion",
+                         "supertrend", "parabolic_sar"]:
             assert expected in names, f"{expected} not registered"
 
     def test_get_unknown_strategy_raises(self):
@@ -157,6 +159,136 @@ class TestRSI:
 
     def test_flat_no_signal(self):
         result = _run_strategy("rsi", make_flat(50))
+        assert (result["signal"] == 0).all()
+
+
+def _three_candle_df(rows):
+    """Build deterministic OHLCV rows for stop-entry pattern tests."""
+    index = pd.date_range("2024-01-01", periods=len(rows), freq="5min")
+    return pd.DataFrame(rows, index=index)
+
+
+class TestThreeCandleRSIReversal:
+    def test_buy_signal_after_sweep_and_trigger_break(self):
+        rows = [
+            {"open": 100, "high": 101, "low": 99, "close": 100, "volume": 100},
+            {"open": 100, "high": 100, "low": 97, "close": 98, "volume": 100},
+            {"open": 98, "high": 98, "low": 95, "close": 96, "volume": 100},
+            {"open": 96, "high": 96, "low": 93, "close": 94, "volume": 100},
+            {"open": 94, "high": 94, "low": 91, "close": 92, "volume": 100},
+            {"open": 92, "high": 92, "low": 89, "close": 90, "volume": 100},
+            {"open": 90, "high": 91, "low": 89, "close": 90, "volume": 100},
+            {"open": 90, "high": 90.5, "low": 88, "close": 89.5, "volume": 100},
+            {"open": 89.5, "high": 90, "low": 88.2, "close": 89.2, "volume": 100},
+            {"open": 89.2, "high": 91.2, "low": 89, "close": 91, "volume": 100},
+        ]
+        result = apply_strategy("three_candle_rsi_reversal", _three_candle_df(rows), {"rsi_period": 2})
+        assert result.iloc[8]["three_candle_setup"] == "long"
+        assert result.iloc[9]["signal"] == 1
+        assert result.iloc[9]["three_candle_trigger"] == 91
+        assert result.iloc[9]["three_candle_stop"] == 88
+
+    def test_sell_signal_after_sweep_and_trigger_break(self):
+        rows = [
+            {"open": 100, "high": 101, "low": 99, "close": 100, "volume": 100},
+            {"open": 100, "high": 103, "low": 100, "close": 102, "volume": 100},
+            {"open": 102, "high": 105, "low": 102, "close": 104, "volume": 100},
+            {"open": 104, "high": 107, "low": 104, "close": 106, "volume": 100},
+            {"open": 106, "high": 109, "low": 106, "close": 108, "volume": 100},
+            {"open": 108, "high": 111, "low": 108, "close": 110, "volume": 100},
+            {"open": 110, "high": 111, "low": 109, "close": 110, "volume": 100},
+            {"open": 110, "high": 112, "low": 109.5, "close": 110.5, "volume": 100},
+            {"open": 110.5, "high": 111.8, "low": 110, "close": 110.2, "volume": 100},
+            {"open": 110.2, "high": 111, "low": 108.8, "close": 109, "volume": 100},
+        ]
+        result = apply_strategy("three_candle_rsi_reversal", _three_candle_df(rows), {"rsi_period": 2})
+        assert result.iloc[8]["three_candle_setup"] == "short"
+        assert result.iloc[9]["signal"] == -1
+        assert result.iloc[9]["three_candle_trigger"] == 109
+        assert result.iloc[9]["three_candle_stop"] == 112
+
+    def test_third_candle_breaking_sweep_extreme_invalidates_setup(self):
+        rows = [
+            {"open": 100, "high": 101, "low": 99, "close": 100, "volume": 100},
+            {"open": 100, "high": 100, "low": 97, "close": 98, "volume": 100},
+            {"open": 98, "high": 98, "low": 95, "close": 96, "volume": 100},
+            {"open": 96, "high": 96, "low": 93, "close": 94, "volume": 100},
+            {"open": 94, "high": 94, "low": 91, "close": 92, "volume": 100},
+            {"open": 92, "high": 92, "low": 89, "close": 90, "volume": 100},
+            {"open": 90, "high": 91, "low": 89, "close": 90, "volume": 100},
+            {"open": 90, "high": 90.5, "low": 88, "close": 89.5, "volume": 100},
+            {"open": 89.5, "high": 90, "low": 87.9, "close": 89.2, "volume": 100},
+            {"open": 89.2, "high": 90.2, "low": 88.5, "close": 89, "volume": 100},
+        ]
+        result = apply_strategy("three_candle_rsi_reversal", _three_candle_df(rows), {"rsi_period": 2})
+        assert result.iloc[8]["three_candle_setup"] == ""
+        assert (result["signal"] == 0).all()
+
+
+def _four_hour_range_df(rows):
+    """Build deterministic 5m OHLCV rows from NY midnight onward."""
+    index = pd.date_range("2024-01-02 05:00:00", periods=len(rows), freq="5min")
+    return pd.DataFrame(rows, index=index)
+
+
+class TestFourHourRangeFakeout:
+    def test_long_signal_after_range_low_break_and_reentry(self):
+        rows = []
+        for _ in range(48):
+            rows.append({"open": 100, "high": 101, "low": 99, "close": 100, "volume": 100})
+        rows.extend([
+            {"open": 100, "high": 100.5, "low": 97.5, "close": 98.5, "volume": 100},
+            {"open": 98.5, "high": 100.2, "low": 97.0, "close": 99.5, "volume": 100},
+        ])
+
+        result = apply_strategy("four_hour_range_fakeout", _four_hour_range_df(rows))
+
+        assert result.iloc[49]["signal"] == 1
+        assert result.iloc[49]["setup_kind"] == "four_hour_range_long"
+        assert result.iloc[49]["setup_trigger"] == 99
+        assert result.iloc[49]["setup_stop"] == 97
+
+    def test_short_signal_after_range_high_break_and_reentry(self):
+        rows = []
+        for _ in range(48):
+            rows.append({"open": 100, "high": 101, "low": 99, "close": 100, "volume": 100})
+        rows.extend([
+            {"open": 100, "high": 102.5, "low": 100, "close": 101.5, "volume": 100},
+            {"open": 101.5, "high": 103.0, "low": 100.5, "close": 100.5, "volume": 100},
+        ])
+
+        result = apply_strategy("four_hour_range_fakeout", _four_hour_range_df(rows))
+
+        assert result.iloc[49]["signal"] == -1
+        assert result.iloc[49]["setup_kind"] == "four_hour_range_short"
+        assert result.iloc[49]["setup_trigger"] == 101
+        assert result.iloc[49]["setup_stop"] == 103
+
+    def test_wick_only_break_does_not_signal(self):
+        rows = []
+        for _ in range(48):
+            rows.append({"open": 100, "high": 101, "low": 99, "close": 100, "volume": 100})
+        rows.append({"open": 100, "high": 103, "low": 100, "close": 100.5, "volume": 100})
+
+        result = apply_strategy("four_hour_range_fakeout", _four_hour_range_df(rows))
+
+        assert (result["signal"] == 0).all()
+
+    def test_range_size_filter_blocks_out_of_bounds_setups(self):
+        rows = []
+        for _ in range(48):
+            rows.append({"open": 100, "high": 101, "low": 99, "close": 100, "volume": 100})
+        rows.extend([
+            {"open": 100, "high": 102.5, "low": 100, "close": 101.5, "volume": 100},
+            {"open": 101.5, "high": 103.0, "low": 100.5, "close": 100.5, "volume": 100},
+        ])
+
+        result = apply_strategy(
+            "four_hour_range_fakeout",
+            _four_hour_range_df(rows),
+            {"min_range_pct": 0.05},
+        )
+
         assert (result["signal"] == 0).all()
 
 
@@ -680,7 +812,7 @@ class TestRangeScalper:
 
 class TestEdgeCases:
     @pytest.mark.parametrize("name", [
-        "sma_crossover", "ema_crossover", "rsi", "bollinger_bands", "macd",
+        "sma_crossover", "ema_crossover", "rsi", "three_candle_rsi_reversal", "four_hour_range_fakeout", "bollinger_bands", "macd",
         "mean_reversion", "momentum", "volume_weighted", "triple_ema",
         "rsi_macd_combo", "stoch_rsi", "supertrend", "atr_breakout",
         "heikin_ashi_ema", "parabolic_sar", "amd_ifvg", "range_scalper",
@@ -692,7 +824,7 @@ class TestEdgeCases:
         assert len(result) == 0
 
     @pytest.mark.parametrize("name", [
-        "sma_crossover", "ema_crossover", "rsi", "bollinger_bands", "macd",
+        "sma_crossover", "ema_crossover", "rsi", "three_candle_rsi_reversal", "four_hour_range_fakeout", "bollinger_bands", "macd",
         "mean_reversion", "momentum", "volume_weighted", "triple_ema",
         "rsi_macd_combo", "stoch_rsi", "atr_breakout",
         "heikin_ashi_ema", "amd_ifvg", "range_scalper",

--- a/shared_tools/strategy_composition.py
+++ b/shared_tools/strategy_composition.py
@@ -18,7 +18,16 @@ import pandas as pd
 
 VALID_POSITION_SIDES = {"", "long", "short"}
 VALID_OPEN_ACTIONS = {"long", "short", "none"}
-POSITION_CONTEXT_PARAM_KEYS = {"side", "avg_cost", "current_quantity", "initial_quantity", "entry_atr", "regime"}
+POSITION_CONTEXT_PARAM_KEYS = {
+    "side",
+    "avg_cost",
+    "current_quantity",
+    "initial_quantity",
+    "entry_atr",
+    "setup_stop",
+    "setup_trigger",
+    "regime",
+}
 
 
 @dataclass

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "ccxt", specifier = ">=4.5.37" },
-    { name = "hyperliquid-python-sdk", specifier = ">=0.4.0" },
+    { name = "hyperliquid-python-sdk", specifier = ">=0.23.0" },
     { name = "numpy", specifier = ">=2.4.2" },
     { name = "pandas", specifier = ">=3.0.0" },
     { name = "pyotp", specifier = ">=2.9.0" },
@@ -899,7 +899,7 @@ wheels = [
 
 [[package]]
 name = "hyperliquid-python-sdk"
-version = "0.22.0"
+version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eth-account" },
@@ -908,9 +908,9 @@ dependencies = [
     { name = "requests" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/7a/f0497091909094a722a3fda64a3fbf180adfacbda3c628b04c5267f230b0/hyperliquid_python_sdk-0.22.0.tar.gz", hash = "sha256:a26e3e015e050c094c411196e689ffaac4ff942fb0ef63bb2863502f63b33e5b", size = 25119, upload-time = "2026-02-04T19:06:13.886Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/ad/12b4559a953e26fc56677de5bf689023e11213196b802b991a6e6db94814/hyperliquid_python_sdk-0.23.0.tar.gz", hash = "sha256:14df0b62511a0cf08ca5a73f73f03656868ee67845ed3362539a79674511bb51", size = 25255, upload-time = "2026-04-14T21:51:24.646Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/74/f8f229f2c659cbf477539a6dccc24452ebe4130d960ba75f7485ee6c0551/hyperliquid_python_sdk-0.22.0-py3-none-any.whl", hash = "sha256:d47432d5dc5ea33cd6c60e01dcb0d773e822ee29c6b299042e59a8cd2c4e2c9f", size = 24529, upload-time = "2026-02-04T19:06:12.46Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e9/b7b23aefc319727f670992904b1defd7aee5fc3f59a51c141a87db05f7da/hyperliquid_python_sdk-0.23.0-py3-none-any.whl", hash = "sha256:5b4f9f7ab8c0b1ad9848f2222901dc047c8f97a6e6fe3fd7286b7b34337f80cb", size = 24638, upload-time = "2026-04-14T21:51:23.27Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `three_candle_rsi_reversal` and `four_hour_range_fakeout` open strategies with optimizer ranges, spot/futures registry coverage, and scheduler init fallback wiring.
- Add `setup_rr` as a setup-stop close evaluator with target, breakeven, and same-bar priority handling.
- Persist setup stop/trigger metadata through live positions, SQLite state, subprocess position context, and backtester close evaluation.
- Bump `hyperliquid-python-sdk` requirement and lockfile resolution to `0.23.0`.

## Validation

- `go test ./...` from `scheduler/`
- `PYTHONPATH=. uv run --no-sync python -m pytest shared_strategies/ shared_tools/ platforms/ backtest/`
- `go build -ldflags "-X main.Version=$(git describe --tags --always --dirty=-mod)" -o /tmp/go-trader-build-check .` from `scheduler/`
- `uv run --no-sync python shared_strategies/open/spot/strategies.py --list-json`
- `uv run --no-sync python shared_strategies/open/futures/strategies.py --list-json`
- `PYTHONPATH=. uv run --no-sync python backtest/run_backtest.py --strategy three_candle_rsi_reversal --symbol BTC/USDT --timeframe 1h --mode single`
- `PYTHONPATH=. uv run --no-sync python backtest/run_backtest.py --strategy four_hour_range_fakeout --symbol BTC/USDT --timeframe 1h --mode single`

## Backtest Smoke Notes

The new strategies produce trades on BTC/USDT 1h, but raw defaults are not ready for live allocation without tuning:

- `three_candle_rsi_reversal`: final capital `$772.04`, 102 trades, max drawdown `-54.34%`.
- `four_hour_range_fakeout`: final capital `$413.37`, 495 trades, max drawdown `-64.12%`.

LLM: GPT-5 | Effort: medium | Harness: local tests, build, registry smoke, backtest smoke
