### PR TITLE
fix(hl): resolve spotMeta tokens by index, not list position (#831)

### DIFF
--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -179,6 +179,80 @@ def _save_meta_cache(spot_meta, meta, path: str = META_CACHE_PATH) -> None:
                 pass
 
 
+def _normalize_spot_meta(spot_meta):
+    """Make ``spot_meta`` safe for the SDK's positional ``tokens[idx]`` lookup.
+
+    The SDK's ``Info`` constructor resolves each spot pair's base/quote tokens
+    via ``spot_meta["tokens"][idx]`` (info.py:47-49), treating the token's
+    ``index`` as a LIST POSITION. Hyperliquid's token indices used to be dense
+    (position == index) but have become sparse — e.g. token index 479 ("WARS")
+    now lives at list position 459 — so the SDK's ``tokens[479]`` raises
+    ``IndexError`` and kills ``HLInfo`` init for every strategy (#831). The
+    token data is all present; only the positional assumption is wrong.
+
+    We rebuild ``tokens`` into an index-aligned (dense) list so positional
+    lookup resolves the correct token for every referenced index, and drop any
+    spot pair whose token indices can't be resolved at all (defends against a
+    genuinely truncated payload). Returns a shallow copy; the original is left
+    untouched. Non-dict/list inputs pass through unchanged so a malformed
+    payload still reaches the SDK's own validation.
+    """
+    if not isinstance(spot_meta, dict):
+        return spot_meta
+    tokens = spot_meta.get("tokens")
+    universe = spot_meta.get("universe")
+    if not isinstance(tokens, list) or not isinstance(universe, list):
+        return spot_meta
+
+    by_index = {}
+    max_index = -1
+    for tok in tokens:
+        if isinstance(tok, dict) and isinstance(tok.get("index"), int):
+            idx = tok["index"]
+            by_index[idx] = tok
+            if idx > max_index:
+                max_index = idx
+
+    # Drop spot pairs whose base/quote indices aren't resolvable.
+    clean_universe = []
+    dropped = []
+    for entry in universe:
+        pair = entry.get("tokens") if isinstance(entry, dict) else None
+        if (
+            isinstance(pair, list)
+            and len(pair) == 2
+            and all(isinstance(x, int) and x in by_index for x in pair)
+        ):
+            clean_universe.append(entry)
+        else:
+            dropped.append(entry.get("name") if isinstance(entry, dict) else None)
+
+    # Fast path: already dense + index-aligned (position == index) and nothing
+    # to drop → return the original untouched so the cache round-trip is exact.
+    aligned = max_index + 1 == len(tokens) and all(
+        isinstance(t, dict) and t.get("index") == i for i, t in enumerate(tokens)
+    )
+    if aligned and not dropped:
+        return spot_meta
+
+    # Dense, index-aligned token list. Gap slots get a harmless placeholder
+    # that no surviving pair references (unresolvable pairs were dropped above).
+    placeholder = {"name": "", "szDecimals": 0, "index": -1}
+    dense_tokens = [by_index.get(i, placeholder) for i in range(max_index + 1)]
+
+    if dropped:
+        print(
+            f"[WARN] hl spotMeta: dropped {len(dropped)} unresolvable spot "
+            f"pair(s): {dropped[:5]}",
+            file=sys.stderr,
+        )
+
+    normalized = dict(spot_meta)
+    normalized["tokens"] = dense_tokens
+    normalized["universe"] = clean_universe
+    return normalized
+
+
 def _fetch_raw_meta(base_url: str):
     """POST /info {type:spotMeta} + {type:meta} via the SDK's API base class.
 
@@ -254,11 +328,13 @@ class HyperliquidExchangeAdapter:
         cached = _load_meta_cache() if allow_cache else None
         if cached is not None:
             spot_meta, meta = cached
-            return _HLInfo(base_url=base_url, skip_ws=True, meta=meta, spot_meta=spot_meta)
+            return _HLInfo(base_url=base_url, skip_ws=True, meta=meta,
+                           spot_meta=_normalize_spot_meta(spot_meta))
         try:
             spot_meta, meta = _fetch_raw_meta(base_url)
             _save_meta_cache(spot_meta, meta)
-            return _HLInfo(base_url=base_url, skip_ws=True, meta=meta, spot_meta=spot_meta)
+            return _HLInfo(base_url=base_url, skip_ws=True, meta=meta,
+                           spot_meta=_normalize_spot_meta(spot_meta))
         except Exception as exc:
             # Last-resort fallback: let the SDK's constructor fetch fresh.
             # Costs the same 2 /info as before this change; cache write failed

--- a/platforms/hyperliquid/test_meta_cache.py
+++ b/platforms/hyperliquid/test_meta_cache.py
@@ -317,6 +317,126 @@ def test_sz_decimals_returns_3_when_still_missing_after_refresh(adapter_mod, mon
     assert a._sz_decimals("UNLISTED") == 3
 
 
+# ─── _normalize_spot_meta: sparse token index guard (#831) ─────────
+
+
+def _sdk_universe_loop(spot_meta):
+    """Re-implementation of the SDK's Info.__init__ spot loop (info.py:43-49).
+
+    Used to prove that, after normalization, the exact positional lookup the
+    SDK performs no longer raises IndexError. Returns {asset: szDecimals}.
+    """
+    asset_to_sz_decimals = {}
+    for spot_info in spot_meta["universe"]:
+        asset = spot_info["index"] + 10000
+        base, quote = spot_info["tokens"]
+        base_info = spot_meta["tokens"][base]  # positional — the crashy line
+        spot_meta["tokens"][quote]
+        asset_to_sz_decimals[asset] = base_info["szDecimals"]
+    return asset_to_sz_decimals
+
+
+def _sparse_spot_meta():
+    """Mirror the real #831 shape: token index 479 ('WARS') lives at list
+    position 459 (sparse), and spot pair '@367' references it as base.
+    """
+    tokens = [{"name": f"T{i}", "szDecimals": 0, "index": i} for i in range(458)]
+    # Sparse tail: a gap (indices 458-477 missing), then high-index tokens
+    # packed at positions 458+.
+    tokens += [
+        {"name": "WARS", "szDecimals": 2, "index": 479},
+        {"name": "ZZZ", "szDecimals": 1, "index": 513},
+    ]
+    universe = [
+        {"index": 0, "name": "PURR/USDC", "tokens": [1, 0]},
+        {"index": 367, "name": "@367", "tokens": [479, 0]},  # base at sparse idx
+    ]
+    return {"universe": universe, "tokens": tokens}
+
+
+def test_normalize_makes_sdk_positional_lookup_not_crash(adapter_mod):
+    spot_meta = _sparse_spot_meta()
+    # Sanity: the raw meta crashes the SDK's positional loop.
+    with pytest.raises(IndexError):
+        _sdk_universe_loop(spot_meta)
+
+    normalized = adapter_mod._normalize_spot_meta(spot_meta)
+    # After normalization the same loop resolves cleanly.
+    result = _sdk_universe_loop(normalized)
+    # @367's base token (index 479 = WARS, szDecimals 2) resolves correctly.
+    assert result[367 + 10000] == 2
+    # PURR/USDC base (index 1) still resolves.
+    assert (0 + 10000) in result
+
+
+def test_normalize_resolves_token_by_index_not_position(adapter_mod):
+    spot_meta = _sparse_spot_meta()
+    normalized = adapter_mod._normalize_spot_meta(spot_meta)
+    # The dense list is index-aligned: position 479 IS the WARS token.
+    assert normalized["tokens"][479]["name"] == "WARS"
+    assert normalized["tokens"][513]["name"] == "ZZZ"
+    # Original input is left untouched (shallow-copy semantics).
+    assert len(spot_meta["tokens"]) == 460
+
+
+def test_normalize_drops_unresolvable_pairs(adapter_mod):
+    spot_meta = {
+        "universe": [
+            {"index": 0, "name": "GOOD/USDC", "tokens": [1, 0]},
+            {"index": 1, "name": "BAD/USDC", "tokens": [999, 0]},  # 999 absent
+            {"index": 2, "name": "MALFORMED"},                     # no tokens
+        ],
+        "tokens": [
+            {"name": "USDC", "szDecimals": 8, "index": 0},
+            {"name": "GOOD", "szDecimals": 2, "index": 1},
+        ],
+    }
+    normalized = adapter_mod._normalize_spot_meta(spot_meta)
+    names = [u["name"] for u in normalized["universe"]]
+    assert names == ["GOOD/USDC"]
+    # Surviving pair still resolves under the SDK loop.
+    assert _sdk_universe_loop(normalized)[0 + 10000] == 2
+
+
+def test_normalize_passes_through_aligned_meta_unchanged(adapter_mod):
+    spot_meta = {
+        "universe": [{"index": 0, "name": "P/USDC", "tokens": [1, 0]}],
+        "tokens": [
+            {"name": "USDC", "szDecimals": 8, "index": 0},
+            {"name": "P", "szDecimals": 2, "index": 1},
+        ],
+    }
+    normalized = adapter_mod._normalize_spot_meta(spot_meta)
+    # Already dense + index-aligned with no drops → identity (same object).
+    assert normalized is spot_meta
+
+
+def test_normalize_passes_through_malformed_input(adapter_mod):
+    assert adapter_mod._normalize_spot_meta(None) is None
+    bad = {"universe": "nope", "tokens": []}
+    assert adapter_mod._normalize_spot_meta(bad) is bad
+
+
+def test_build_info_normalizes_before_sdk(adapter_mod, monkeypatch):
+    """_build_info must hand the SDK a normalized spot_meta so the crashy
+    positional loop never sees a sparse token list (cache-hit path)."""
+    spot_meta = _sparse_spot_meta()
+    monkeypatch.setattr(adapter_mod, "_load_meta_cache",
+                        lambda *a, **kw: (spot_meta, {"universe": [{"name": "BTC", "szDecimals": 5}]}))
+
+    captured = {}
+
+    def fake_info(base_url, skip_ws, meta=None, spot_meta=None):
+        captured["spot_meta"] = spot_meta
+        # Prove the SDK's own loop would survive on what it was handed.
+        _sdk_universe_loop(spot_meta)
+        return MagicMock()
+
+    monkeypatch.setattr(adapter_mod, "_HLInfo", fake_info)
+    adapter_mod.HyperliquidExchangeAdapter()
+    assert captured["spot_meta"]["tokens"][479]["name"] == "WARS"
+
+
 def test_sz_decimals_uses_cached_value_without_refresh(adapter_mod, monkeypatch):
     monkeypatch.setattr(adapter_mod, "_load_meta_cache",
                         lambda *a, **kw: (


### PR DESCRIPTION
## Problem

`check_hyperliquid.py` crashes on every cycle with `IndexError: list index out of range` at `hyperliquid/info.py:48` — the SDK's `Info` constructor dies during adapter init, taking down **every** HL strategy.

Root cause (confirmed via a live `spotMeta` fetch): Hyperliquid's spot **token indices are now sparse**. Token index `479` (`WARS`) sits at list **position 459**, but the SDK resolves tokens positionally — `spot_meta["tokens"][479]` on a 464-element list → out of range. The token data is all present; only the SDK's positional assumption is wrong. Spot pair `@367` (`tokens: [479, 0]`) is the trigger.

This is not a response-format change and not a missing token — earlier hypotheses (dict→list, `universe` losing its `tokens` field) are ruled out; those would raise different errors at different lines.

## Fix

`_normalize_spot_meta(spot_meta)` (`platforms/hyperliquid/adapter.py`):
- Rebuilds `tokens` into an **index-aligned (dense)** list so the SDK's positional `tokens[idx]` resolves the correct token for every referenced index (including sparse high indices).
- Drops any spot pair whose base/quote indices are unresolvable (defends against a genuinely truncated payload), logging what was dropped.
- Fast-path identity return when the payload is already dense + aligned, so the common case and cache round-trip are unchanged.

Wired into `_build_info` at the **SDK boundary** on both the cache-hit and fresh-fetch paths, so a poisoned cache is normalized too. The raw upstream payload is still cached verbatim.

Why index-alignment over just dropping `@367`: dropping is whack-a-mole — every new sparse-indexed pair would recur the crash. Resolving by index is correct for any sparse/gapped token list HL ships.

## Verification

- New tests in `platforms/hyperliquid/test_meta_cache.py` re-implement the SDK's exact spot loop to prove the raw payload crashes and the normalized one doesn't, plus drop/identity/malformed cases.
- End-to-end against a live `spotMeta`: raw payload `IndexError`; normalized resolves **all 301 pairs, zero dropped**, `@367`→`WARS` szDecimals correct, `tokens[479].name == "WARS"`.
- `pytest platforms/ shared_tools/ shared_strategies/` → 843 passed.

Closes #831

---
LLM: Claude Opus 4.8 (1M) | high | Harness: Claude Code
