### PR TITLE
Include scheduler PID in signal-script failure/recovery alerts

### DIFF
--- a/scheduler/script_failure_alerts.go
+++ b/scheduler/script_failure_alerts.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"sync"
 	"time"
 )
@@ -123,18 +124,21 @@ func (t *ScriptFailureTracker) Clear(strategyID string) (bool, int) {
 var scriptFailureTracker = &ScriptFailureTracker{}
 
 // formatScriptFailureAlert builds the operator message for a failing signal
-// script. count is the consecutive-failure count after incrementing.
+// script. count is the consecutive-failure count after incrementing. The
+// scheduler PID is included so operators can tell which process is producing
+// the errors when duplicate go-trader processes are suspected (#845).
 func formatScriptFailureAlert(sc StrategyConfig, mode scriptFailureMode, errMsg string, count int) string {
-	return fmt.Sprintf("**SIGNAL SCRIPT FAILING** [%s] %s %s (%s, %d consecutive failures): %s",
-		sc.ID, sc.Platform, sc.Script, scriptFailureModeLabel(mode), count, errMsg)
+	return fmt.Sprintf("**SIGNAL SCRIPT FAILING** [%s] %s %s (pid=%d, %s, %d consecutive failures): %s",
+		sc.ID, sc.Platform, sc.Script, os.Getpid(), scriptFailureModeLabel(mode), count, errMsg)
 }
 
 // formatScriptRecoveredAlert builds the operator message for a signal script
 // that succeeded after having alerted as dead. priorCount is the streak length
-// that just ended.
+// that just ended. The scheduler PID is included to match the failing alert so
+// operators can correlate the recovery with the process that was failing (#845).
 func formatScriptRecoveredAlert(sc StrategyConfig, priorCount int) string {
-	return fmt.Sprintf("**SIGNAL SCRIPT RECOVERED** [%s] %s %s: succeeded after %d consecutive failures",
-		sc.ID, sc.Platform, sc.Script, priorCount)
+	return fmt.Sprintf("**SIGNAL SCRIPT RECOVERED** [%s] %s %s (pid=%d): succeeded after %d consecutive failures",
+		sc.ID, sc.Platform, sc.Script, os.Getpid(), priorCount)
 }
 
 // notifyScriptFailure records a signal-script failure for sc and fires a

--- a/scheduler/script_failure_alerts_test.go
+++ b/scheduler/script_failure_alerts_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -134,9 +136,11 @@ func TestScriptFailureTracker_IndependentPerStrategy(t *testing.T) {
 
 func TestFormatScriptFailureAlert_NamesModeAndCount(t *testing.T) {
 	sc := StrategyConfig{ID: "hl-rmc-eth-live", Platform: "hyperliquid", Script: "check_hyperliquid.py"}
+	pidTag := fmt.Sprintf("pid=%d", os.Getpid())
 	crash := formatScriptFailureAlert(sc, scriptFailureCrash, "signal: killed", 4)
 	if !strings.Contains(crash, "hard crash") || !strings.Contains(crash, "4 consecutive") ||
-		!strings.Contains(crash, "hl-rmc-eth-live") || !strings.Contains(crash, "check_hyperliquid.py") {
+		!strings.Contains(crash, "hl-rmc-eth-live") || !strings.Contains(crash, "check_hyperliquid.py") ||
+		!strings.Contains(crash, pidTag) {
 		t.Fatalf("crash alert missing fields: %q", crash)
 	}
 	soft := formatScriptFailureAlert(sc, scriptFailureError, "list index out of range", 3)
@@ -147,8 +151,10 @@ func TestFormatScriptFailureAlert_NamesModeAndCount(t *testing.T) {
 
 func TestFormatScriptRecoveredAlert(t *testing.T) {
 	sc := StrategyConfig{ID: "hl-x", Platform: "hyperliquid", Script: "check_hyperliquid.py"}
+	pidTag := fmt.Sprintf("pid=%d", os.Getpid())
 	msg := formatScriptRecoveredAlert(sc, 7)
-	if !strings.Contains(msg, "RECOVERED") || !strings.Contains(msg, "7 consecutive") {
+	if !strings.Contains(msg, "RECOVERED") || !strings.Contains(msg, "7 consecutive") ||
+		!strings.Contains(msg, pidTag) {
 		t.Fatalf("recovery alert missing fields: %q", msg)
 	}
 }


### PR DESCRIPTION
Adds `os.Getpid()` to `formatScriptFailureAlert` and `formatScriptRecoveredAlert` so operators can identify which go-trader process is producing errors when duplicate processes are suspected.

Closes #845

---
LLM: Claude Opus 4.8 (1M) | xhigh | Harness: anthropics/claude-code-action@v1