### PR TITLE
Add state-DB singleton lock so a duplicate go-trader refuses to start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 trading_bot.db
 *.db-wal
 *.db-shm
+*.db.lock
 .env
 trading-scheduler
 # Compiled binaries

--- a/go-trader.service
+++ b/go-trader.service
@@ -13,7 +13,10 @@ ExecStart=/opt/go-trader/go-trader --config /opt/go-trader/scheduler/config.json
 Restart=always
 RestartSec=10
 # Probe/deploy failures exit 78 — do not restart until scripts are synced.
-RestartPreventExitStatus=78
+# Singleton-lock refusals exit 79 (#849): another live go-trader already holds
+# the state-DB lock, so staying down (one DM, no restart-loop) is correct — the
+# kernel flock auto-releases on exit, so a legitimate restart is unaffected.
+RestartPreventExitStatus=78 79
 StandardOutput=journal
 StandardError=journal
 

--- a/scheduler/exit_codes.go
+++ b/scheduler/exit_codes.go
@@ -5,3 +5,17 @@ package main
 // RestartPreventExitStatus=78 so the service stays down instead of restarting
 // every RestartSec and spamming Discord. (EX_CONFIG from sysexits.h.)
 const ExitProbeFailure = 78
+
+// ExitSingletonLock is used when the daemon refuses to start because another
+// live go-trader already holds the exclusive lock on the resolved state-DB
+// path (#849). A duplicate against the same state.db/exchange account would
+// double-trade and desync state, so the second process exits here instead.
+//
+// Both service files set RestartPreventExitStatus=79 alongside 78: under a
+// normal `systemctl restart` the managed daemon is the lock holder, so it can
+// only hit this code when an out-of-cgroup duplicate is alive — in that case
+// systemd should stay down (one DM, no restart-loop) rather than respawn every
+// RestartSec into the same refusal. The kernel auto-releases the flock when the
+// holder dies, so this never permanently blocks a legitimate restart. 79 sits
+// just past the sysexits.h range (64–78) to avoid colliding with those codes.
+const ExitSingletonLock = 79

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -408,6 +409,49 @@ func main() {
 			notifier.SendOwnerDM(fmt.Sprintf("**Startup probe failed** — refusing to start (exit %d; fix deploy, then restart):\n```\n%v\n```", ExitProbeFailure, err))
 		}
 		os.Exit(ExitProbeFailure)
+	}
+
+	// #849: Singleton guard — claim an exclusive lock on the resolved state-DB
+	// path so a second daemon (e.g. an operator manually launching the binary
+	// alongside the systemd-managed instance, or an out-of-cgroup process from a
+	// signal-mode update) refuses to start instead of silently double-trading
+	// against the same state.db / exchange account.
+	//
+	// Scoped to the persistent daemon loop only: CLI subcommands and --summary /
+	// --leaderboard have already exited above, and --once is intentionally left
+	// unguarded (it's update.sh's post-deploy smoke and the operator's
+	// responsibility). The probe ran first because update.sh invokes the
+	// `probe` subcommand against the still-live old daemon during a deploy;
+	// that path never reaches here. The lock is a kernel flock the OS releases
+	// on exit/crash, so a SIGKILLed daemon leaves nothing stale to block the
+	// next start (see singleton_lock.go).
+	if !*once {
+		lock, lockErr := acquireStateDBLock(cfg.DBFile)
+		if lockErr != nil {
+			var locked *stateDBLockedError
+			if errors.As(lockErr, &locked) {
+				msg := fmt.Sprintf("CRITICAL: %s — refusing to start so this process can't double-trade against the same state DB. If no other go-trader is actually running, the lock auto-releases on exit; check `pgrep -af go-trader`.", locked.Error())
+				fmt.Fprintln(os.Stderr, "[singleton] "+msg)
+				if notifier != nil && notifier.HasOwner() {
+					notifier.SendOwnerDM("**Singleton guard** — " + msg)
+				}
+			} else {
+				fmt.Fprintf(os.Stderr, "[singleton] CRITICAL: could not acquire state DB lock: %v — refusing to start.\n", lockErr)
+				if notifier != nil && notifier.HasOwner() {
+					notifier.SendOwnerDM(fmt.Sprintf("**Singleton guard** — could not acquire state DB lock, refusing to start: %v", lockErr))
+				}
+			}
+			os.Exit(ExitSingletonLock)
+		}
+		// Hold for the entire process lifetime. We deliberately do NOT release
+		// on the happy path: the OS drops the flock when the process exits,
+		// which is strictly after the deferred final SaveState + stateDB.Close
+		// have run. Releasing earlier (e.g. via defer) would run BEFORE those
+		// in LIFO order and open a window where a duplicate could grab the lock
+		// and start trading while we're still flushing state. Stashing it in a
+		// package var also keeps the fd reachable so its os.File finalizer
+		// can't close (and release) it mid-run.
+		heldStateDBLock = lock
 	}
 
 	// Track the last remote hash we notified about to avoid re-notifying on every cycle.

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -204,8 +205,12 @@ func (ss *StatusServer) Start(port int) {
 	if boundPort != port {
 		// Prominent fallback notice: operators running `--once` next to a
 		// live instance used to get a hard port-collision error; now the
-		// bind silently advances, so make the advance itself visible.
-		fmt.Printf("[server] NOTICE: requested port %d was in use, bound to %d instead\n", port, boundPort)
+		// bind silently advances, so make the advance itself visible. A
+		// fallback on the daemon path can also mean a duplicate instance is
+		// already bound to the configured port — the #849 state-DB lock is the
+		// authoritative guard, but flag it loudly here too and point at the
+		// /health pid as the external detection signal.
+		fmt.Printf("[server] WARNING: requested port %d was in use, bound to %d instead — another go-trader may already be running on %d; compare /health pid across ports\n", port, boundPort, port)
 	}
 	fmt.Printf("[server] Status endpoint at http://localhost:%d/status\n", boundPort)
 	fmt.Printf("[server] Dashboard at http://localhost:%d/dashboard\n", boundPort)
@@ -222,12 +227,19 @@ func (ss *StatusServer) Start(port int) {
 func (ss *StatusServer) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
+	// `pid` (#849) lets external monitoring detect a duplicate from the
+	// outside: alert when health.pid != systemd MainPID, or when two ports
+	// (8099/8100) both report healthy with different pids. It complements the
+	// state-DB flock — a cheap detection aid, not a replacement. Included on
+	// every branch (incl. draining) so the signal is always available.
+	pid := os.Getpid()
+
 	// 503 once SIGTERM has fired so any future load-balancer-style probe
 	// stops sending traffic immediately. Returns before the staleness check
 	// since the daemon is intentionally winding down.
 	if isDraining() {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte(`{"status":"draining"}`))
+		json.NewEncoder(w).Encode(map[string]any{"status": "draining", "pid": pid})
 		return
 	}
 
@@ -237,10 +249,13 @@ func (ss *StatusServer) handleHealth(w http.ResponseWriter, r *http.Request) {
 
 	// `version` is the build-stamped Version (#682) so scripts/update.sh can
 	// confirm the post-restart process matches the just-built binary before
-	// declaring the update successful (and rolling back otherwise).
-	resp := map[string]string{
+	// declaring the update successful (and rolling back otherwise). update.sh
+	// matches the `"version":"<ver>"` substring, which the sorted-key JSON
+	// encoding preserves regardless of the added pid field.
+	resp := map[string]any{
 		"status":  "ok",
 		"version": Version,
+		"pid":     pid,
 	}
 	if !lastCycle.IsZero() && time.Since(lastCycle) > 30*time.Minute {
 		resp["status"] = "unhealthy"

--- a/scheduler/server_test.go
+++ b/scheduler/server_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -24,8 +26,16 @@ func TestHandleHealth(t *testing.T) {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
 	}
 
-	var resp map[string]string
-	json.NewDecoder(w.Body).Decode(&resp)
+	// Capture the raw body before decoding drains the buffer — update.sh
+	// matches the literal `"version":"<ver>"` substring, so assert the added
+	// #849 pid field didn't disturb it.
+	body := w.Body.String()
+	if !strings.Contains(body, "\"version\":\""+Version+"\"") {
+		t.Errorf("body %q missing literal version substring update.sh greps for", body)
+	}
+
+	var resp map[string]any
+	json.Unmarshal([]byte(body), &resp)
 	if resp["status"] != "ok" {
 		t.Errorf("status = %q, want %q", resp["status"], "ok")
 	}
@@ -33,6 +43,11 @@ func TestHandleHealth(t *testing.T) {
 	// the post-restart process matches the just-built binary.
 	if resp["version"] != Version {
 		t.Errorf("version = %q, want %q", resp["version"], Version)
+	}
+	// #849: pid lets external monitoring detect a duplicate (health.pid !=
+	// systemd MainPID). JSON numbers decode to float64 into map[string]any.
+	if pid, ok := resp["pid"].(float64); !ok || int(pid) != os.Getpid() {
+		t.Errorf("pid = %v, want %d", resp["pid"], os.Getpid())
 	}
 }
 
@@ -53,7 +68,7 @@ func TestHandleHealthStale(t *testing.T) {
 	// Even when stale, the version field should be present so a rolling
 	// update can still distinguish old from new during the brief window
 	// between restart and the first completed cycle.
-	var resp map[string]string
+	var resp map[string]any
 	json.NewDecoder(w.Body).Decode(&resp)
 	if resp["version"] != Version {
 		t.Errorf("version = %q, want %q", resp["version"], Version)

--- a/scheduler/singleton_lock.go
+++ b/scheduler/singleton_lock.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -55,9 +56,29 @@ func (e *stateDBLockedError) Error() string {
 // stateDBLockPath returns the lock-file path for a given state-DB path. The
 // lock sits next to the DB so per-DB-file isolation is automatic: genuinely
 // separate instances (sub-accounts / distinct DBFile) resolve to distinct lock
-// files and never contend.
+// files and never contend. The DB path is first canonicalized so two launches
+// that name the same DB through different strings (relative vs absolute, or via
+// a symlink) collapse to one lock file and actually contend.
 func stateDBLockPath(dbPath string) string {
-	return dbPath + ".lock"
+	return canonicalDBPath(dbPath) + ".lock"
+}
+
+// canonicalDBPath resolves dbPath to an absolute, symlink-free form so distinct
+// strings naming the same file map to the same lock path. Resolution is
+// best-effort and degrades to the most-resolved form available: if the DB file
+// (or a path component) doesn't exist yet, EvalSymlinks fails and we keep the
+// Abs form; if even Abs fails we keep the raw string. The guard must never
+// refuse to start merely because the path couldn't be canonicalized — the
+// fallback just reverts to the pre-hardening raw-string behavior.
+func canonicalDBPath(dbPath string) string {
+	resolved := dbPath
+	if abs, err := filepath.Abs(resolved); err == nil {
+		resolved = abs
+	}
+	if eval, err := filepath.EvalSymlinks(resolved); err == nil {
+		resolved = eval
+	}
+	return resolved
 }
 
 // acquireStateDBLock takes an exclusive, non-blocking flock on <dbPath>.lock.

--- a/scheduler/singleton_lock.go
+++ b/scheduler/singleton_lock.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// stateDBLock holds an exclusive advisory lock on <DBFile>.lock for the
+// lifetime of the daemon process (#849). It exists to stop a second go-trader
+// from silently running against the same state DB / exchange account, which
+// would book duplicate trades and desync on-chain positions.
+//
+// The lock is a kernel flock() on an open file descriptor — never a
+// "write PID to a file, refuse if the file exists" scheme. The distinction is
+// load-bearing for deploy safety: the OS auto-releases an fd lock when the
+// process dies (including SIGKILL/crash), so a hard-killed daemon leaves no
+// stale lock and the next start always succeeds. A pidfile-content check would
+// survive a crash and permanently block restart, causing update.sh to roll
+// back every deploy. update.sh's `systemctl restart` is sequential (old daemon
+// fully drains and exits → lock released → new daemon starts), so there is no
+// steady-state overlap window and no false "already running" failure.
+type stateDBLock struct {
+	f    *os.File
+	path string
+}
+
+// heldStateDBLock keeps the daemon's singleton lock reachable for the whole
+// process lifetime so the underlying *os.File isn't garbage-collected and
+// finalized (which would close the fd and silently release the flock) while
+// the daemon is still trading. main() assigns it on the daemon path; it is
+// never read back — the OS releases the lock on process exit.
+var heldStateDBLock *stateDBLock
+
+// stateDBLockedError is returned by acquireStateDBLock when the lock is already
+// held by another live process. PID is the value the holder recorded in the
+// lock file (best-effort, for the operator message only — the lock decision is
+// always the kernel flock, never this file content); it is 0 when unreadable.
+type stateDBLockedError struct {
+	path string
+	pid  int
+}
+
+func (e *stateDBLockedError) Error() string {
+	if e.pid > 0 {
+		return fmt.Sprintf("another go-trader is already running (pid %d); lock held on %s", e.pid, e.path)
+	}
+	return fmt.Sprintf("another go-trader is already running; lock held on %s", e.path)
+}
+
+// stateDBLockPath returns the lock-file path for a given state-DB path. The
+// lock sits next to the DB so per-DB-file isolation is automatic: genuinely
+// separate instances (sub-accounts / distinct DBFile) resolve to distinct lock
+// files and never contend.
+func stateDBLockPath(dbPath string) string {
+	return dbPath + ".lock"
+}
+
+// acquireStateDBLock takes an exclusive, non-blocking flock on <dbPath>.lock.
+// On success it returns a *stateDBLock that must be kept alive for the process
+// lifetime (closing the fd, or process exit, releases the lock). When the lock
+// is already held it returns a *stateDBLockedError; other failures (cannot
+// create the lock file, unexpected flock errno) return a wrapped error.
+func acquireStateDBLock(dbPath string) (*stateDBLock, error) {
+	lockPath := stateDBLockPath(dbPath)
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file %s: %w", lockPath, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		// LOCK_NB returns EWOULDBLOCK (== EAGAIN on Linux) when another process
+		// holds the lock. Read the holder's recorded PID for the message, then
+		// release our fd so we don't leak it on the exit path.
+		pid := readLockPID(f)
+		f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, &stateDBLockedError{path: lockPath, pid: pid}
+		}
+		return nil, fmt.Errorf("flock %s: %w", lockPath, err)
+	}
+	// We hold the lock. Record our PID for human inspection / external
+	// monitoring; failure here is non-fatal because the kernel flock — not the
+	// file content — is what enforces exclusivity.
+	if err := writeLockPID(f, os.Getpid()); err != nil {
+		fmt.Fprintf(os.Stderr, "[singleton] WARN: could not write pid to %s: %v\n", lockPath, err)
+	}
+	return &stateDBLock{f: f, path: lockPath}, nil
+}
+
+// Release drops the lock by closing the fd. Safe to call on a nil receiver.
+// The OS also releases the lock on process exit, so this is only needed for the
+// graceful-return path where the process keeps running afterwards (tests).
+func (l *stateDBLock) Release() {
+	if l == nil || l.f == nil {
+		return
+	}
+	l.f.Close()
+	l.f = nil
+}
+
+// writeLockPID overwrites the lock file with the given PID (decimal, one line)
+// and fsyncs so a contending process can read it back immediately.
+func writeLockPID(f *os.File, pid int) error {
+	if err := f.Truncate(0); err != nil {
+		return err
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(f, "%d\n", pid); err != nil {
+		return err
+	}
+	return f.Sync()
+}
+
+// readLockPID best-effort reads the PID the lock holder recorded. Returns 0 on
+// any error (empty file, malformed content, read failure) — callers treat 0 as
+// "unknown" and degrade the message gracefully.
+func readLockPID(f *os.File) int {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return 0
+	}
+	buf := make([]byte, 32)
+	n, err := f.Read(buf)
+	if (err != nil && err != io.EOF) || n <= 0 {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
+	if err != nil {
+		return 0
+	}
+	return pid
+}

--- a/scheduler/singleton_lock_test.go
+++ b/scheduler/singleton_lock_test.go
@@ -20,7 +20,7 @@ func TestAcquireStateDBLock_Basic(t *testing.T) {
 	}
 
 	// The lock file sits next to the DB and records our PID.
-	wantPath := dbPath + ".lock"
+	wantPath := stateDBLockPath(dbPath)
 	if lock.path != wantPath {
 		t.Errorf("lock.path = %q, want %q", lock.path, wantPath)
 	}
@@ -97,9 +97,44 @@ func TestAcquireStateDBLock_DistinctPaths(t *testing.T) {
 	defer b.Release()
 }
 
+func TestAcquireStateDBLock_SymlinkedPathContends(t *testing.T) {
+	dir := t.TempDir()
+	realDB := filepath.Join(dir, "state.db")
+	// The DB file must exist for EvalSymlinks to resolve the path (in production
+	// the state DB is opened before the lock is taken).
+	if err := os.WriteFile(realDB, nil, 0o644); err != nil {
+		t.Fatalf("create db file: %v", err)
+	}
+	// A file-level symlink under a different name. The ".lock" suffix is appended
+	// to the symlink's *own* path, so without canonicalization the alias resolves
+	// to a different lock file (state-alias.db.lock vs state.db.lock) and a
+	// duplicate could start trading. EvalSymlinks collapses both to one lock.
+	linkedDB := filepath.Join(dir, "state-alias.db")
+	if err := os.Symlink(realDB, linkedDB); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	first, err := acquireStateDBLock(realDB)
+	if err != nil {
+		t.Fatalf("acquire via real path failed: %v", err)
+	}
+	defer first.Release()
+
+	// The same DB reached through the symlink must contend, not get its own lock.
+	second, err := acquireStateDBLock(linkedDB)
+	if err == nil {
+		second.Release()
+		t.Fatal("acquire via symlinked path succeeded — canonicalization is not collapsing symlinks")
+	}
+	var locked *stateDBLockedError
+	if !errors.As(err, &locked) {
+		t.Fatalf("error = %v (%T), want *stateDBLockedError", err, err)
+	}
+}
+
 func TestAcquireStateDBLock_StaleFdReleasesOnClose(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "state.db")
-	lockPath := dbPath + ".lock"
+	lockPath := stateDBLockPath(dbPath)
 
 	// Simulate a crashed holder: open the lock file, flock it, then close the
 	// fd WITHOUT calling Release — closing the fd is exactly what the kernel

--- a/scheduler/singleton_lock_test.go
+++ b/scheduler/singleton_lock_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestAcquireStateDBLock_Basic(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+
+	lock, err := acquireStateDBLock(dbPath)
+	if err != nil {
+		t.Fatalf("first acquire failed: %v", err)
+	}
+	if lock == nil || lock.f == nil {
+		t.Fatal("expected a held lock")
+	}
+
+	// The lock file sits next to the DB and records our PID.
+	wantPath := dbPath + ".lock"
+	if lock.path != wantPath {
+		t.Errorf("lock.path = %q, want %q", lock.path, wantPath)
+	}
+	if got := readLockFileContent(t, wantPath); got != os.Getpid() {
+		t.Errorf("recorded pid = %d, want %d", got, os.Getpid())
+	}
+
+	lock.Release()
+	// Release nils the fd; a second Release must be a safe no-op.
+	lock.Release()
+}
+
+func TestAcquireStateDBLock_Contended(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+
+	first, err := acquireStateDBLock(dbPath)
+	if err != nil {
+		t.Fatalf("first acquire failed: %v", err)
+	}
+	defer first.Release()
+
+	// A second acquire against the same path must fail (not silently succeed),
+	// and the error must carry the holder's recorded PID for the operator
+	// message.
+	second, err := acquireStateDBLock(dbPath)
+	if err == nil {
+		second.Release()
+		t.Fatal("second acquire unexpectedly succeeded — singleton guard is not exclusive")
+	}
+	var locked *stateDBLockedError
+	if !errors.As(err, &locked) {
+		t.Fatalf("error = %v (%T), want *stateDBLockedError", err, err)
+	}
+	if locked.pid != os.Getpid() {
+		t.Errorf("locked.pid = %d, want %d", locked.pid, os.Getpid())
+	}
+}
+
+func TestAcquireStateDBLock_ReleaseAllowsReacquire(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+
+	first, err := acquireStateDBLock(dbPath)
+	if err != nil {
+		t.Fatalf("first acquire failed: %v", err)
+	}
+	first.Release()
+
+	// After Release the lock is free, so the same path acquires cleanly again.
+	// This mirrors the normal `systemctl restart` sequence (old daemon exits →
+	// lock released → new daemon starts).
+	second, err := acquireStateDBLock(dbPath)
+	if err != nil {
+		t.Fatalf("reacquire after release failed: %v", err)
+	}
+	second.Release()
+}
+
+func TestAcquireStateDBLock_DistinctPaths(t *testing.T) {
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a.db")
+	pathB := filepath.Join(dir, "b.db")
+
+	// Genuinely separate instances (distinct DBFile, e.g. sub-accounts) resolve
+	// to distinct lock files and must both hold their lock at once.
+	a, err := acquireStateDBLock(pathA)
+	if err != nil {
+		t.Fatalf("acquire A failed: %v", err)
+	}
+	defer a.Release()
+	b, err := acquireStateDBLock(pathB)
+	if err != nil {
+		t.Fatalf("acquire B failed (distinct paths must not contend): %v", err)
+	}
+	defer b.Release()
+}
+
+func TestAcquireStateDBLock_StaleFdReleasesOnClose(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	lockPath := dbPath + ".lock"
+
+	// Simulate a crashed holder: open the lock file, flock it, then close the
+	// fd WITHOUT calling Release — closing the fd is exactly what the kernel
+	// does when a process dies (incl. SIGKILL), so no stale lock should remain.
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatalf("open lock file: %v", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("seed flock: %v", err)
+	}
+	f.Close() // kernel releases the flock here
+
+	lock, err := acquireStateDBLock(dbPath)
+	if err != nil {
+		t.Fatalf("acquire after simulated crash failed — stale lock blocked restart: %v", err)
+	}
+	lock.Release()
+}
+
+// readLockFileContent reads the lock file directly (a separate fd, not holding
+// the flock) and parses the recorded PID.
+func readLockFileContent(t *testing.T, path string) int {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open lock file for read: %v", err)
+	}
+	defer f.Close()
+	return readLockPID(f)
+}

--- a/systemd/go-trader@.service
+++ b/systemd/go-trader@.service
@@ -13,7 +13,10 @@ ExecStart=/opt/go-trader-%i/go-trader --config /opt/go-trader-%i/scheduler/confi
 Restart=always
 RestartSec=10
 # Probe/deploy failures exit 78 — do not restart until scripts are synced.
-RestartPreventExitStatus=78
+# Singleton-lock refusals exit 79 (#849): another live go-trader already holds
+# the state-DB lock, so staying down (one DM, no restart-loop) is correct — the
+# kernel flock auto-releases on exit, so a legitimate restart is unaffected.
+RestartPreventExitStatus=78 79
 # Drain budget: shutdown.go caps in-flight side-effecting subprocesses at 15s
 # (shutdownDrainCap), then the deferred state save + notifier flush + DB
 # close run. 20s gives the binary the full drain plus a 5s buffer before


### PR DESCRIPTION
Closes #849.

Acquires an exclusive kernel `flock` on `<DBFile>.lock` for the daemon process lifetime, so a second instance against the same state DB/account refuses to start (exit 79, CRITICAL log + owner DM) instead of silently double-trading. Also exposes `pid` in /health for external duplicate detection, upgrades the port-fallback warning, and registers exit 79 in both service files.

Guard is scoped to the persistent daemon loop only; `--once`, `--probe-only`, and one-off CLI are unaffected. The fd flock auto-releases on crash/SIGKILL, so no stale lock blocks a restart.

---
LLM: Claude Opus 4.8 (1M) | xhigh | Harness: anthropics/claude-code-action@v1