### PR TITLE
feat(close): trailing TP ratchet — per-tier trail tighten (#844)

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -73,6 +73,7 @@ _ensure_regime_fn = None
 # module lives in shared_strategies/close/ but isn't a registered strategy,
 # so we import it directly without going through the registry.
 _post_tp_sl_module = None
+_trailing_ratchet_module = None
 
 
 def _load_regime():
@@ -99,6 +100,23 @@ def _load_post_tp_sl():
     sys.modules[name] = mod
     spec.loader.exec_module(mod)
     _post_tp_sl_module = mod
+    return mod
+
+
+def _load_trailing_ratchet():
+    global _trailing_ratchet_module
+    if _trailing_ratchet_module is not None:
+        return _trailing_ratchet_module
+    import importlib.util
+    name = "_go_trader_trailing_ratchet"
+    path = os.path.abspath(os.path.join(
+        os.path.dirname(__file__), "..", "shared_strategies", "close", "trailing_tp_ratchet.py",
+    ))
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    _trailing_ratchet_module = mod
     return mod
 
 
@@ -373,6 +391,32 @@ class Backtester:
         self._uses_regime_tiered_close = _close_refs_use_regime_tiered_tp(
             self._close_refs,
         )
+        self._uses_trailing_ratchet_close = any(
+            (r.get("name") or "").strip().lower()
+            in ("trailing_tp_ratchet", "trailing_tp_ratchet_regime")
+            for r in self._close_refs
+        )
+        self._ratchet_mod = None
+        self._ratchet_ref: Optional[dict] = None
+        self._ratchet_tiers_run: list = []
+        if self._uses_trailing_ratchet_close:
+            self._ratchet_mod = _load_trailing_ratchet()
+            for ref in self._close_refs:
+                n = (ref.get("name") or "").strip().lower()
+                if n in ("trailing_tp_ratchet", "trailing_tp_ratchet_regime"):
+                    self._ratchet_ref = ref
+                    break
+            if (
+                self.trailing_stop_atr_mult is None
+                or self.trailing_stop_atr_mult <= 0
+            ):
+                raise ValueError(
+                    "trailing_tp_ratchet* requires trailing_stop_atr_mult > 0"
+                )
+            if self.trailing_stop_pct is not None and self.trailing_stop_pct > 0:
+                raise ValueError(
+                    "trailing_tp_ratchet* cannot combine with trailing_stop_pct"
+                )
         _needs_regime_atr = (
             self.stop_loss_atr_regime is not None
             or self.trailing_stop_atr_regime is not None
@@ -762,8 +806,19 @@ class Backtester:
         self._run_trailing_stop_atr_mult: Optional[float] = None
         self._run_position_regime = ""
         sl_after_active = self._sl_after_pipeline_enabled
+        trailing_ratchet_active = self._uses_trailing_ratchet_close
 
         atr_series = df["atr"] if "atr" in df.columns else None
+
+        def _initial_trail_trigger(side: str, mark: float, entry_atr: float,
+                                    trail_mult: float) -> float:
+            if mark <= 0 or entry_atr <= 0 or trail_mult <= 0:
+                return 0.0
+            if side == "long":
+                return mark - trail_mult * entry_atr
+            if side == "short":
+                return mark + trail_mult * entry_atr
+            return 0.0
 
         def stamp_open_from_label(stamp: str) -> None:
             lab = (stamp or "").strip()
@@ -779,6 +834,24 @@ class Backtester:
             else:
                 self._active_sl_after_rules = self._sl_after_rules_static
                 self._run_tp_tier_thresholds = list(self._tp_tier_thresholds_static)
+
+            self._ratchet_tiers_run = []
+            if self._uses_trailing_ratchet_close and self._ratchet_mod and self._ratchet_ref:
+                regime_table = (
+                    (self._ratchet_ref.get("name") or "").strip().lower()
+                    == "trailing_tp_ratchet_regime"
+                )
+                tiers, terr = self._ratchet_mod.resolve_tiers_for_regime(
+                    self._ratchet_ref.get("params") or {},
+                    lab,
+                    regime_table=regime_table,
+                )
+                if terr:
+                    raise ValueError(
+                        "trailing_tp_ratchet tier resolution failed: "
+                        + "; ".join(terr)
+                    )
+                self._ratchet_tiers_run = tiers
 
             self._run_stop_loss_atr_mult = None
             self._run_trailing_stop_atr_mult = None
@@ -991,6 +1064,14 @@ class Backtester:
                         sl_tiers_processed = 0
                         post_tp_trail_mult = None
                         sl_high_water_px = 0.0
+                    elif trailing_ratchet_active and self._run_trailing_stop_atr_mult:
+                        sl_trigger_px = _initial_trail_trigger(
+                            "long", mark_price, entry_atr_value,
+                            self._run_trailing_stop_atr_mult,
+                        )
+                        sl_tiers_processed = 0
+                        post_tp_trail_mult = None
+                        sl_high_water_px = mark_price
                 elif open_action == "short" and position == 0 and not regime_blocked:
                     effective_price = fill_price * (1 - self.slippage_pct)
                     commission = cash * self.commission_pct
@@ -1012,6 +1093,14 @@ class Backtester:
                         sl_tiers_processed = 0
                         post_tp_trail_mult = None
                         sl_high_water_px = 0.0
+                    elif trailing_ratchet_active and self._run_trailing_stop_atr_mult:
+                        sl_trigger_px = _initial_trail_trigger(
+                            "short", mark_price, entry_atr_value,
+                            self._run_trailing_stop_atr_mult,
+                        )
+                        sl_tiers_processed = 0
+                        post_tp_trail_mult = None
+                        sl_high_water_px = mark_price
 
                 # End-of-bar: evaluate close strategies against the now-current
                 # position using this bar's close as the mark. The result is
@@ -1024,6 +1113,27 @@ class Backtester:
                         position_regime=self._run_position_regime,
                         market_regime=_bar_close_regime(row),
                     )
+                    if (
+                        trailing_ratchet_active
+                        and self._ratchet_mod
+                        and self._ratchet_tiers_run
+                        and position != 0
+                        and entry_atr_value > 0
+                    ):
+                        side_now = "long" if position > 0 else "short"
+                        base_trail = self._run_trailing_stop_atr_mult or 0.0
+                        sl_tiers_processed, post_tp_trail_mult = (
+                            self._ratchet_mod.maybe_apply_mark_ratchet(
+                                self._ratchet_tiers_run,
+                                watermark=sl_tiers_processed,
+                                mark_price=mark_price,
+                                avg_cost=avg_cost,
+                                entry_atr=entry_atr_value,
+                                side=side_now,
+                                post_tp_trail_mult=post_tp_trail_mult,
+                                trailing_stop_atr_mult=base_trail,
+                            )
+                        )
 
                 # End-of-bar: walk the trailing-stop high-water mark (only
                 # active after a TP tier transitioned the position to
@@ -1032,22 +1142,25 @@ class Backtester:
                 # pending_close_fraction=1.0 which fills at the next bar's
                 # open — same alignment as the rest of the close pipeline.
                 if (
-                    sl_after_active
+                    (sl_after_active or trailing_ratchet_active)
                     and not sl_after_just_applied
                     and position != 0
                     and avg_cost > 0
                 ):
                     side_now = "long" if position > 0 else "short"
+                    trail_mult = post_tp_trail_mult
+                    if trail_mult is None or trail_mult <= 0:
+                        trail_mult = self._run_trailing_stop_atr_mult
                     if (
-                        post_tp_trail_mult is not None
-                        and post_tp_trail_mult > 0
+                        trail_mult is not None
+                        and trail_mult > 0
                         and entry_atr_value > 0
                     ):
                         sl_trigger_px, sl_high_water_px = self._walk_trail(
                             side=side_now,
                             mark_price=mark_price,
                             entry_atr=entry_atr_value,
-                            trail_mult=post_tp_trail_mult,
+                            trail_mult=trail_mult,
                             sl_trigger_px=sl_trigger_px,
                             sl_high_water_px=sl_high_water_px,
                         )

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -567,6 +567,8 @@ var closeStrategyOwnedKeys = map[string]map[string]struct{}{
 	"tiered_tp_atr_regime":              {"tp_tiers": {}, "tiers": {}, "use_defaults": {}, "sl_after": {}},
 	"tiered_tp_atr_live_regime":         {"tp_tiers": {}, "tiers": {}, "use_defaults": {}, "atr_source": {}, "sl_after": {}},
 	"tiered_tp_atr_live_regime_dynamic": {"trend_regime": {}, "atr_source": {}, "regime_confirm_cycles": {}},
+	"trailing_tp_ratchet":               {"tp_tiers": {}, "tiers": {}, "use_defaults": {}},
+	"trailing_tp_ratchet_regime":        {"tp_tiers": {}, "tiers": {}, "use_defaults": {}},
 	"tiered_tp_pct":                     {"tp_tiers": {}, "tiers": {}},
 	"tp_at_pct":                         {"pct": {}}, // v15 migrates to tiered_tp_pct; kept for v13 legacy param routing only
 }

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -567,8 +567,8 @@ var closeStrategyOwnedKeys = map[string]map[string]struct{}{
 	"tiered_tp_atr_regime":              {"tp_tiers": {}, "tiers": {}, "use_defaults": {}, "sl_after": {}},
 	"tiered_tp_atr_live_regime":         {"tp_tiers": {}, "tiers": {}, "use_defaults": {}, "atr_source": {}, "sl_after": {}},
 	"tiered_tp_atr_live_regime_dynamic": {"trend_regime": {}, "atr_source": {}, "regime_confirm_cycles": {}},
-	"trailing_tp_ratchet":               {"tp_tiers": {}, "tiers": {}, "use_defaults": {}},
-	"trailing_tp_ratchet_regime":        {"tp_tiers": {}, "tiers": {}, "use_defaults": {}},
+	"trailing_tp_ratchet":               {"tp_tiers": {}, "use_defaults": {}},
+	"trailing_tp_ratchet_regime":        {"tp_tiers": {}, "use_defaults": {}},
 	"tiered_tp_pct":                     {"tp_tiers": {}, "tiers": {}},
 	"tp_at_pct":                         {"pct": {}}, // v15 migrates to tiered_tp_pct; kept for v13 legacy param routing only
 }

--- a/scheduler/config_migration_v15.go
+++ b/scheduler/config_migration_v15.go
@@ -195,6 +195,16 @@ func migrateV15CloseRef(ref map[string]interface{}, slRegime map[string]interfac
 				return true
 			}
 		}
+	case trailingTPRatchetRegimeCloseName:
+		if len(params) > 0 {
+			ref["params"] = canonicalizeTrailingRatchetRegimeParams(params)
+		}
+		return false
+	case trailingTPRatchetCloseName:
+		if len(params) > 0 {
+			ref["params"] = canonicalizeTrailingRatchetScalarParams(params)
+		}
+		return false
 	}
 
 	if len(params) > 0 {
@@ -226,6 +236,44 @@ func v15TierListRaw(params map[string]interface{}) (interface{}, bool) {
 		return v, true
 	}
 	return nil, false
+}
+
+// canonicalizeTrailingRatchetRegimeParams preserves the regime→tier-list map
+// shape for trailing_tp_ratchet_regime (#844). The generic canonicalizeTierList
+// path only accepts []interface{} and would wipe a keyed table.
+func canonicalizeTrailingRatchetRegimeParams(params map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(params))
+	for k, v := range params {
+		switch k {
+		case "tp_tiers":
+			table, ok := v.(map[string]interface{})
+			if !ok {
+				out["tp_tiers"] = v
+				continue
+			}
+			tableOut := make(map[string]interface{}, len(table))
+			for label, block := range table {
+				tableOut[label] = canonicalizeTierList(block)
+			}
+			out["tp_tiers"] = tableOut
+		default:
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func canonicalizeTrailingRatchetScalarParams(params map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(params))
+	for k, v := range params {
+		switch k {
+		case "tp_tiers", "tiers":
+			out["tp_tiers"] = canonicalizeTierList(v)
+		default:
+			out[k] = v
+		}
+	}
+	return out
 }
 
 func canonicalizeCloseParams(params map[string]interface{}) map[string]interface{} {

--- a/scheduler/config_migration_v15_test.go
+++ b/scheduler/config_migration_v15_test.go
@@ -318,8 +318,8 @@ func TestMigrateV15CloseKeys_TrailingTPRatchetRegimeTable(t *testing.T) {
 						"tp_tiers": map[string]interface{}{
 							"trending_up": []interface{}{
 								map[string]interface{}{
-									"atr":      1.5,
-									"fraction": 0.0,
+									"atr":                 1.5,
+									"fraction":            0.0,
 									"trailing_mult_after": 2.0,
 								},
 							},

--- a/scheduler/config_migration_v15_test.go
+++ b/scheduler/config_migration_v15_test.go
@@ -303,3 +303,58 @@ func TestLoadConfig_V15_MigratesCloseKeysOnDisk(t *testing.T) {
 		t.Errorf("tp_tiers = %#v, want %#v", tiersRaw, want)
 	}
 }
+
+func TestMigrateV15CloseKeys_TrailingTPRatchetRegimeTable(t *testing.T) {
+	raw := map[string]interface{}{
+		"config_version": 14,
+		"strategies": []interface{}{
+			map[string]interface{}{
+				"id":       "s1",
+				"type":     "perps",
+				"platform": "hyperliquid",
+				"close_strategy": map[string]interface{}{
+					"name": "trailing_tp_ratchet_regime",
+					"params": map[string]interface{}{
+						"tp_tiers": map[string]interface{}{
+							"trending_up": []interface{}{
+								map[string]interface{}{
+									"atr":      1.5,
+									"fraction": 0.0,
+									"trailing_mult_after": 2.0,
+								},
+							},
+							"trending_down": []interface{}{
+								map[string]interface{}{
+									"multiple":            1.0,
+									"close_fraction":      0.25,
+									"trailing_mult_after": 1.5,
+								},
+							},
+							"ranging": []interface{}{
+								map[string]interface{}{
+									"atr_multiple":        1.0,
+									"close_fraction":      0.0,
+									"trailing_mult_after": 2.5,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	migrateV15CloseKeys(raw)
+	ref := raw["strategies"].([]interface{})[0].(map[string]interface{})["close_strategy"].(map[string]interface{})
+	params := ref["params"].(map[string]interface{})
+	table, ok := params["tp_tiers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("tp_tiers = %#v, want regime-keyed map", params["tp_tiers"])
+	}
+	up := table["trending_up"].([]interface{})[0].(map[string]interface{})
+	if up["atr_multiple"].(float64) != 1.5 || up["close_fraction"].(float64) != 0 {
+		t.Errorf("trending_up tier = %#v", up)
+	}
+	if up["trailing_mult_after"].(float64) != 2.0 {
+		t.Errorf("trailing_mult_after = %v", up["trailing_mult_after"])
+	}
+}

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -483,6 +483,10 @@ func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error 
 				errs = append(errs, fmt.Sprintf("strategy[%s] unified per-regime close block changed with open positions (flatten first or restart after close)",
 					sc.ID))
 			}
+			if strategyUsesTrailingTPRatchetClose(sc) && !trailingRatchetRulesEqualForReload(sc, ns) {
+				errs = append(errs, fmt.Sprintf("strategy[%s] trailing_tp_ratchet tier table changed with open positions (flatten first or restart after close)",
+					sc.ID))
+			}
 		}
 	}
 	if len(errs) > 0 {

--- a/scheduler/hyperliquid_trailing_stop.go
+++ b/scheduler/hyperliquid_trailing_stop.go
@@ -45,7 +45,19 @@ func hlSLEffectiveQty(symbol string, virtualQty float64, onChainQtyMap map[strin
 // expect a strictly fixed distance for the life of a position should not
 // edit the multiplier while a position is active.
 func effectiveTrailingStopPct(sc StrategyConfig, pos *Position) float64 {
-	if sc.Platform != "hyperliquid" || (sc.Type != "perps" && sc.Type != "manual") {
+	if sc.Platform != "hyperliquid" {
+		return 0
+	}
+	switch sc.Type {
+	case "perps":
+	case "manual":
+		// Manual strategies only run the on-chain trailing walker when the
+		// close evaluator is trailing_tp_ratchet* (#844). Other manual configs
+		// (e.g. tiered_tp_atr_live) keep the historical no-trailing behavior.
+		if !strategyUsesTrailingTPRatchetClose(sc) {
+			return 0
+		}
+	default:
 		return 0
 	}
 	// #708: Post-TP trailing transition — `sl_after: trail_from_here` stamps

--- a/scheduler/hyperliquid_trailing_stop.go
+++ b/scheduler/hyperliquid_trailing_stop.go
@@ -45,7 +45,7 @@ func hlSLEffectiveQty(symbol string, virtualQty float64, onChainQtyMap map[strin
 // expect a strictly fixed distance for the life of a position should not
 // edit the multiplier while a position is active.
 func effectiveTrailingStopPct(sc StrategyConfig, pos *Position) float64 {
-	if sc.Platform != "hyperliquid" || sc.Type != "perps" {
+	if sc.Platform != "hyperliquid" || (sc.Type != "perps" && sc.Type != "manual") {
 		return 0
 	}
 	// #708: Post-TP trailing transition — `sl_after: trail_from_here` stamps

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1282,6 +1282,7 @@ func main() {
 					var hlTPOIDs []int64
 					var hlStopLossTriggerPx float64
 					var hlStopLossHighWaterPx float64
+					var hlPostTPTrailingATRMult *float64
 					if sc.Type == "perps" && sc.Platform == "hyperliquid" {
 						if hlLiveStrategy {
 							hlCash = stratState.Cash
@@ -1300,6 +1301,7 @@ func main() {
 								hlTPOIDs = cloneInt64s(pos.TPOIDs)
 								hlStopLossTriggerPx = pos.StopLossTriggerPx
 								hlStopLossHighWaterPx = pos.StopLossHighWaterPx
+								hlPostTPTrailingATRMult = pos.PostTPTrailingATRMult
 							}
 						}
 					}
@@ -1510,7 +1512,16 @@ func main() {
 							mu.Unlock()
 							var execResult *HyperliquidExecuteResult
 							liveExecFailed := false
-							hlPosSnapshot := &Position{AvgCost: hlAvgCost, EntryATR: hlEntryATR}
+							hlPosSnapshot := &Position{AvgCost: hlAvgCost, EntryATR: hlEntryATR, PostTPTrailingATRMult: hlPostTPTrailingATRMult}
+							if result.Signal == 0 && hlPosQty > 0 && strategyUsesTrailingTPRatchetClose(sc) {
+								applyTrailingTPRatchet(sc, stratState, result.Symbol, price, &mu, logger)
+								mu.RLock()
+								if pos, ok3 := stratState.Positions[result.Symbol]; ok3 && pos != nil {
+									hlPostTPTrailingATRMult = pos.PostTPTrailingATRMult
+									hlPosSnapshot.PostTPTrailingATRMult = hlPostTPTrailingATRMult
+								}
+								mu.RUnlock()
+							}
 							if result.Signal == 0 && hlPosQty > 0 && atrMultMissingEntryATR(sc, hlPosSnapshot) {
 								// ATR-mult is configured but the position is missing EntryATR — the
 								// open candle did not produce an ATR indicator, so the trailing loop
@@ -1721,6 +1732,31 @@ func main() {
 						if pos != nil && hyperliquidIsLive(sc.Args) {
 							runHyperliquidProtectionSync(sc, stratState, stateDB, sc.Symbol, &mu, notifier, logger, "HL manual protection synced", hlReconcileFillHintsJSON)
 							runPostTPStopLossAdjustment(sc, stratState, sc.Symbol, prices[sc.Symbol], cfg, &mu, notifier, logger, hlOnChainAbsQty)
+							mark := prices[sc.Symbol]
+							if mark > 0 && strategyUsesTrailingTPRatchetClose(sc) {
+								applyTrailingTPRatchet(sc, stratState, sc.Symbol, mark, &mu, logger)
+							}
+							mu.RLock()
+							pos = stratState.Positions[sc.Symbol]
+							mu.RUnlock()
+							if pos != nil && mark > 0 && effectiveTrailingStopPct(sc, pos) > 0 {
+								slEffectiveQty, capped := hlSLEffectiveQty(sc.Symbol, pos.Quantity, hlOnChainAbsQty)
+								if capped {
+									logger.Warn("manual trailing SL: virtual qty %.6f > on-chain %.6f for %s; capping (#621)", pos.Quantity, slEffectiveQty, sc.Symbol)
+								}
+								newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, sc.Symbol, pos.Side, slEffectiveQty, pos, mark, pos.StopLossHighWaterPx, pos.StopLossTriggerPx, pos.StopLossOID, notifier, logger)
+								mu.Lock()
+								if p, ok2 := stratState.Positions[sc.Symbol]; ok2 && p != nil && p.Quantity > 0 {
+									if newHighWater > 0 && updateConfirmed {
+										p.StopLossHighWaterPx = newHighWater
+									}
+									if slUpdate != nil && slUpdate.StopLossOID > 0 {
+										p.StopLossOID = slUpdate.StopLossOID
+										p.StopLossTriggerPx = slUpdate.StopLossTriggerPx
+									}
+								}
+								mu.Unlock()
+							}
 						}
 						if closeFraction, _, ok := runManualCloseEval(sc, stratState, cfg, notifier, logger); ok && closeFraction > 0 {
 							mu.RLock()

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1739,7 +1739,7 @@ func main() {
 							mu.RLock()
 							pos = stratState.Positions[sc.Symbol]
 							mu.RUnlock()
-							if pos != nil && mark > 0 && effectiveTrailingStopPct(sc, pos) > 0 {
+							if pos != nil && mark > 0 && strategyUsesTrailingTPRatchetClose(sc) && effectiveTrailingStopPct(sc, pos) > 0 {
 								slEffectiveQty, capped := hlSLEffectiveQty(sc.Symbol, pos.Quantity, hlOnChainAbsQty)
 								if capped {
 									logger.Warn("manual trailing SL: virtual qty %.6f > on-chain %.6f for %s; capping (#621)", pos.Quantity, slEffectiveQty, sc.Symbol)

--- a/scheduler/post_tp_sl.go
+++ b/scheduler/post_tp_sl.go
@@ -954,6 +954,12 @@ func validatePostTPStopLossRulesWithLabels(sc StrategyConfig, labels []string) [
 		if isTieredTPATRCloseName(n) {
 			continue
 		}
+		if isTrailingTPRatchetCloseName(n) {
+			if _, ok := ref.Params["sl_after"]; ok {
+				out = append(out, fmt.Sprintf("sl_after is not used with %q — use per-tier trailing_mult_after / tp_atr_fraction instead", ref.Name))
+			}
+			continue
+		}
 		if _, ok := ref.Params["sl_after"]; ok {
 			out = append(out, fmt.Sprintf("sl_after is only honored on tiered_tp_atr / tiered_tp_atr_live close refs; found on %q", ref.Name))
 		}

--- a/scheduler/regime_atr.go
+++ b/scheduler/regime_atr.go
@@ -866,6 +866,7 @@ func validateRegimeATRConfig(cfg *Config) []string {
 			errs = append(errs, fmt.Sprintf("%s: regime-aware stop/TP fields require top-level regime.enabled=true", prefix))
 		}
 		errs = append(errs, validateUnifiedCloseSoleOwner(*sc, prefix)...)
+		errs = append(errs, validateTrailingTPRatchetClose(*sc, atrLabels)...)
 	}
 	return errs
 }

--- a/scheduler/trailing_tp_ratchet.go
+++ b/scheduler/trailing_tp_ratchet.go
@@ -1,0 +1,354 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+const (
+	trailingTPRatchetCloseName       = "trailing_tp_ratchet"
+	trailingTPRatchetRegimeCloseName = "trailing_tp_ratchet_regime"
+)
+
+// trailingRatchetTier is one rung of a trailing_tp_ratchet* close ref.
+type trailingRatchetTier struct {
+	ATRMultiple       float64
+	CloseFraction     float64
+	TrailingMultAfter float64
+}
+
+func isTrailingTPRatchetCloseName(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case trailingTPRatchetCloseName, trailingTPRatchetRegimeCloseName:
+		return true
+	}
+	return false
+}
+
+func strategyUsesTrailingTPRatchetClose(sc StrategyConfig) bool {
+	for _, ref := range sc.closeRefs() {
+		if isTrailingTPRatchetCloseName(ref.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveTrailingMultAfter(tier map[string]interface{}, firingMultiple float64) (float64, error) {
+	_, hasAbs := tier["trailing_mult_after"]
+	_, hasFrac := tier["tp_atr_fraction"]
+	if hasAbs && hasFrac {
+		return 0, fmt.Errorf("cannot combine trailing_mult_after with tp_atr_fraction")
+	}
+	if hasAbs {
+		mult, err := floatFromAnyChecked(tier["trailing_mult_after"])
+		if err != nil || mult <= 0 {
+			return 0, fmt.Errorf("trailing_mult_after must be > 0")
+		}
+		return mult, nil
+	}
+	if hasFrac {
+		frac, err := floatFromAnyChecked(tier["tp_atr_fraction"])
+		if err != nil || frac <= 0 {
+			return 0, fmt.Errorf("tp_atr_fraction must be > 0")
+		}
+		if firingMultiple <= 0 {
+			return 0, fmt.Errorf("firing tier atr_multiple must be > 0 for tp_atr_fraction")
+		}
+		return frac * firingMultiple, nil
+	}
+	return 0, fmt.Errorf("requires exactly one of trailing_mult_after or tp_atr_fraction")
+}
+
+func parseTrailingRatchetTier(m map[string]interface{}, ctxLabel string, idx int) (trailingRatchetTier, []string) {
+	var errs []string
+	mult, err := floatFromAnyChecked(firstPresent(m, "atr_multiple", "multiple", "atr"))
+	if err != nil || mult <= 0 {
+		errs = append(errs, fmt.Sprintf("%s[%d].atr_multiple: must be > 0", ctxLabel, idx))
+		return trailingRatchetTier{}, errs
+	}
+	frac := 0.0
+	if raw := firstPresent(m, "close_fraction", "fraction"); raw != nil {
+		frac, err = floatFromAnyChecked(raw)
+		if err != nil || frac < 0 || frac > 1 {
+			errs = append(errs, fmt.Sprintf("%s[%d].close_fraction: must be in [0, 1]", ctxLabel, idx))
+			return trailingRatchetTier{}, errs
+		}
+	}
+	trail, terr := resolveTrailingMultAfter(m, mult)
+	if terr != nil {
+		errs = append(errs, fmt.Sprintf("%s[%d]: %v", ctxLabel, idx, terr))
+		return trailingRatchetTier{}, errs
+	}
+	allowed := map[string]bool{
+		"atr_multiple": true, "multiple": true, "atr": true,
+		"close_fraction": true, "fraction": true,
+		"trailing_mult_after": true, "tp_atr_fraction": true,
+	}
+	for k := range m {
+		if !allowed[k] {
+			errs = append(errs, fmt.Sprintf("%s[%d]: unknown key %q", ctxLabel, idx, k))
+		}
+	}
+	return trailingRatchetTier{
+		ATRMultiple:       mult,
+		CloseFraction:     frac,
+		TrailingMultAfter: trail,
+	}, errs
+}
+
+func parseTrailingRatchetTierList(raw interface{}, ctxLabel string) ([]trailingRatchetTier, []string) {
+	items, ok := raw.([]interface{})
+	if !ok {
+		return nil, []string{fmt.Sprintf("%s: must be a list, got %T", ctxLabel, raw)}
+	}
+	var errs []string
+	out := make([]trailingRatchetTier, 0, len(items))
+	for idx, item := range items {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			errs = append(errs, fmt.Sprintf("%s[%d]: must be an object", ctxLabel, idx))
+			continue
+		}
+		tier, sub := parseTrailingRatchetTier(m, ctxLabel, idx)
+		errs = append(errs, sub...)
+		if len(sub) == 0 {
+			out = append(out, tier)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ATRMultiple < out[j].ATRMultiple })
+	if len(out) == 0 && len(errs) == 0 {
+		errs = append(errs, fmt.Sprintf("%s: must contain at least one valid tier", ctxLabel))
+	}
+	return out, errs
+}
+
+func trailingRatchetTiersForRegime(sc StrategyConfig, regime string) []trailingRatchetTier {
+	if !strategyUsesTrailingTPRatchetClose(sc) {
+		return nil
+	}
+	for _, ref := range sc.closeRefs() {
+		name := strings.ToLower(strings.TrimSpace(ref.Name))
+		if !isTrailingTPRatchetCloseName(name) {
+			continue
+		}
+		raw, ok := closeTierListParam(ref.Params)
+		if !ok {
+			return nil
+		}
+		if name == trailingTPRatchetRegimeCloseName {
+			table, ok := raw.(map[string]interface{})
+			if !ok || strings.TrimSpace(regime) == "" {
+				return nil
+			}
+			block, ok := table[strings.TrimSpace(regime)]
+			if !ok {
+				return nil
+			}
+			tiers, _ := parseTrailingRatchetTierList(block, ref.Name+".tp_tiers."+regime)
+			return tiers
+		}
+		if table, ok := raw.(map[string]interface{}); ok {
+			block := table["default"]
+			if block == nil {
+				block = table["ranging"]
+			}
+			tiers, _ := parseTrailingRatchetTierList(block, ref.Name+".tp_tiers")
+			return tiers
+		}
+		tiers, _ := parseTrailingRatchetTierList(raw, ref.Name+".tp_tiers")
+		return tiers
+	}
+	return nil
+}
+
+func validateTrailingTPRatchetClose(sc StrategyConfig, labels []string) []string {
+	if !strategyUsesTrailingTPRatchetClose(sc) {
+		return nil
+	}
+	prefix := fmt.Sprintf("strategy[%s]", sc.ID)
+	var errs []string
+	if sc.Platform != "hyperliquid" || (sc.Type != "perps" && sc.Type != "manual") {
+		errs = append(errs, fmt.Sprintf("%s: trailing_tp_ratchet* is HL perps/manual only", prefix))
+	}
+	if sc.TrailingStopATRMult == nil || *sc.TrailingStopATRMult <= 0 {
+		errs = append(errs, fmt.Sprintf("%s: trailing_tp_ratchet* requires trailing_stop_atr_mult > 0 (initial trail distance)", prefix))
+	}
+	if sc.TrailingStopPct != nil && *sc.TrailingStopPct > 0 {
+		errs = append(errs, fmt.Sprintf("%s: trailing_tp_ratchet* cannot combine with trailing_stop_pct", prefix))
+	}
+	if sc.TrailingStopATRRegime != nil && !sc.TrailingStopATRRegime.IsZero() {
+		errs = append(errs, fmt.Sprintf("%s: trailing_tp_ratchet* cannot combine with trailing_stop_atr_regime", prefix))
+	}
+	for _, ref := range sc.closeRefs() {
+		if !isTrailingTPRatchetCloseName(ref.Name) {
+			continue
+		}
+		sub := fmt.Sprintf("%s.close_strategy(%s)", prefix, ref.Name)
+		name := strings.ToLower(strings.TrimSpace(ref.Name))
+		raw, hasTiers := closeTierListParam(ref.Params)
+		if !hasTiers {
+			errs = append(errs, fmt.Sprintf("%s: missing tp_tiers", sub))
+			continue
+		}
+		for k := range ref.Params {
+			switch k {
+			case "tp_tiers", "tiers", "use_defaults":
+			default:
+				errs = append(errs, fmt.Sprintf("%s: unknown param %q (allowed: tp_tiers, use_defaults)", sub, k))
+			}
+		}
+		if name == trailingTPRatchetRegimeCloseName {
+			table, ok := raw.(map[string]interface{})
+			if !ok {
+				errs = append(errs, fmt.Sprintf("%s.tp_tiers: must be a regime-keyed object", sub))
+				continue
+			}
+			labelSet := make(map[string]bool, len(labels))
+			for _, l := range labels {
+				labelSet[l] = true
+			}
+			for key := range table {
+				if !labelSet[key] {
+					errs = append(errs, fmt.Sprintf("%s.tp_tiers: unknown regime key %q (valid: %s)", sub, key, strings.Join(labels, ", ")))
+				}
+			}
+			for _, key := range labels {
+				block, ok := table[key]
+				if !ok {
+					errs = append(errs, fmt.Sprintf("%s.tp_tiers: missing required regime key %q", sub, key))
+					continue
+				}
+				_, subErrs := parseTrailingRatchetTierList(block, sub+".tp_tiers."+key)
+				errs = append(errs, subErrs...)
+			}
+			continue
+		}
+		if table, ok := raw.(map[string]interface{}); ok {
+			block := table["default"]
+			if block == nil {
+				errs = append(errs, fmt.Sprintf("%s.tp_tiers: object form requires a \"default\" key", sub))
+				continue
+			}
+			_, subErrs := parseTrailingRatchetTierList(block, sub+".tp_tiers")
+			errs = append(errs, subErrs...)
+			continue
+		}
+		_, subErrs := parseTrailingRatchetTierList(raw, sub+".tp_tiers")
+		errs = append(errs, subErrs...)
+	}
+	return errs
+}
+
+func effectiveTrailingRatchetMult(pos *Position, sc StrategyConfig) float64 {
+	if pos != nil && pos.PostTPTrailingATRMult != nil && *pos.PostTPTrailingATRMult > 0 {
+		return *pos.PostTPTrailingATRMult
+	}
+	if sc.TrailingStopATRMult != nil && *sc.TrailingStopATRMult > 0 {
+		return *sc.TrailingStopATRMult
+	}
+	return 0
+}
+
+func findHighestMarkClearedRatchetTier(tiers []trailingRatchetTier, atrProfit float64, fromIdx int) (int, bool) {
+	if fromIdx < 0 {
+		fromIdx = 0
+	}
+	highest := -1
+	for i := fromIdx; i < len(tiers); i++ {
+		if atrProfit+1e-12 >= tiers[i].ATRMultiple {
+			highest = i
+		}
+	}
+	return highest, highest >= 0
+}
+
+// applyTrailingTPRatchet stamps a tighter PostTPTrailingATRMult when mark-based
+// tier thresholds are newly cleared. Reuses SLAdjustedTiersProcessed as the
+// idempotency watermark (ratchet closes do not use on-chain TP OIDs or sl_after).
+func applyTrailingTPRatchet(
+	sc StrategyConfig,
+	stratState *StrategyState,
+	symbol string,
+	mark float64,
+	mu *sync.RWMutex,
+	logger *StrategyLogger,
+) {
+	if !strategyUsesTrailingTPRatchetClose(sc) || stratState == nil || symbol == "" || mark <= 0 {
+		return
+	}
+	mu.Lock()
+	pos, ok := stratState.Positions[symbol]
+	if !ok || pos == nil || pos.Quantity <= 0 || pos.AvgCost <= 0 || pos.EntryATR <= 0 {
+		mu.Unlock()
+		return
+	}
+	side := pos.Side
+	avgCost := pos.AvgCost
+	entryATR := pos.EntryATR
+	regime := protectionATRRegimeLabel(pos, sc)
+	watermark := pos.SLAdjustedTiersProcessed
+	mu.Unlock()
+
+	tiers := trailingRatchetTiersForRegime(sc, regime)
+	if len(tiers) == 0 {
+		return
+	}
+	profitDistance := mark - avgCost
+	if side == "short" {
+		profitDistance = avgCost - mark
+	}
+	atrProfit := profitDistance / entryATR
+	clearedIdx, clearedOK := findHighestMarkClearedRatchetTier(tiers, atrProfit, watermark)
+	if !clearedOK {
+		return
+	}
+	newMult := tiers[clearedIdx].TrailingMultAfter
+	current := effectiveTrailingRatchetMult(pos, sc)
+	if newMult >= current-1e-12 {
+		mu.Lock()
+		if p, ok := stratState.Positions[symbol]; ok && p != nil && p.SLAdjustedTiersProcessed <= clearedIdx {
+			p.SLAdjustedTiersProcessed = clearedIdx + 1
+		}
+		mu.Unlock()
+		return
+	}
+	mu.Lock()
+	p, ok := stratState.Positions[symbol]
+	if !ok || p == nil {
+		mu.Unlock()
+		return
+	}
+	mult := newMult
+	p.PostTPTrailingATRMult = &mult
+	if mark > 0 {
+		p.StopLossHighWaterPx = mark
+	}
+	p.SLAdjustedTiersProcessed = clearedIdx + 1
+	mu.Unlock()
+	if logger != nil {
+		logger.Info("trailing_tp_ratchet: %s tier %d cleared — trail tightened to %.4g×ATR (from %.4g×ATR)",
+			symbol, clearedIdx, newMult, current)
+	}
+}
+
+func trailingRatchetRulesEqualForReload(a, b StrategyConfig) bool {
+	return trailingRatchetFingerprint(a) == trailingRatchetFingerprint(b)
+}
+
+func trailingRatchetFingerprint(sc StrategyConfig) string {
+	for _, ref := range sc.closeRefs() {
+		if !isTrailingTPRatchetCloseName(ref.Name) {
+			continue
+		}
+		b, err := json.Marshal(ref.Params)
+		if err != nil {
+			return fmt.Sprintf("%s:%v", ref.Name, ref.Params)
+		}
+		return ref.Name + ":" + string(b)
+	}
+	return ""
+}

--- a/scheduler/trailing_tp_ratchet.go
+++ b/scheduler/trailing_tp_ratchet.go
@@ -196,7 +196,9 @@ func validateTrailingTPRatchetClose(sc StrategyConfig, labels []string) []string
 		}
 		for k := range ref.Params {
 			switch k {
-			case "tp_tiers", "tiers", "use_defaults":
+			case "tp_tiers", "use_defaults":
+			case "tiers":
+				errs = append(errs, fmt.Sprintf("%s: legacy param %q is not supported — use tp_tiers (#841)", sub, k))
 			default:
 				errs = append(errs, fmt.Sprintf("%s: unknown param %q (allowed: tp_tiers, use_defaults)", sub, k))
 			}
@@ -222,8 +224,9 @@ func validateTrailingTPRatchetClose(sc StrategyConfig, labels []string) []string
 					errs = append(errs, fmt.Sprintf("%s.tp_tiers: missing required regime key %q", sub, key))
 					continue
 				}
-				_, subErrs := parseTrailingRatchetTierList(block, sub+".tp_tiers."+key)
+				tiers, subErrs := parseTrailingRatchetTierList(block, sub+".tp_tiers."+key)
 				errs = append(errs, subErrs...)
+				errs = append(errs, validateTrailingRatchetTierMonotonicity(tiers, sub+".tp_tiers."+key)...)
 			}
 			continue
 		}
@@ -233,12 +236,33 @@ func validateTrailingTPRatchetClose(sc StrategyConfig, labels []string) []string
 				errs = append(errs, fmt.Sprintf("%s.tp_tiers: object form requires a \"default\" key", sub))
 				continue
 			}
-			_, subErrs := parseTrailingRatchetTierList(block, sub+".tp_tiers")
+			tiers, subErrs := parseTrailingRatchetTierList(block, sub+".tp_tiers")
 			errs = append(errs, subErrs...)
+			errs = append(errs, validateTrailingRatchetTierMonotonicity(tiers, sub+".tp_tiers")...)
 			continue
 		}
-		_, subErrs := parseTrailingRatchetTierList(raw, sub+".tp_tiers")
+		tiers, subErrs := parseTrailingRatchetTierList(raw, sub+".tp_tiers")
 		errs = append(errs, subErrs...)
+		errs = append(errs, validateTrailingRatchetTierMonotonicity(tiers, sub+".tp_tiers")...)
+	}
+	return errs
+}
+
+func validateTrailingRatchetTierMonotonicity(tiers []trailingRatchetTier, ctxLabel string) []string {
+	if len(tiers) < 2 {
+		return nil
+	}
+	var errs []string
+	prev := tiers[0].TrailingMultAfter
+	for i := 1; i < len(tiers); i++ {
+		cur := tiers[i].TrailingMultAfter
+		if cur > prev+1e-12 {
+			errs = append(errs, fmt.Sprintf(
+				"%s[%d].trailing distance %.4g×ATR must be <= tier[%d] (%.4g×ATR) — ratchet tiers tighten monotonically",
+				ctxLabel, i, cur, i-1, prev,
+			))
+		}
+		prev = cur
 	}
 	return errs
 }
@@ -324,9 +348,6 @@ func applyTrailingTPRatchet(
 	}
 	mult := newMult
 	p.PostTPTrailingATRMult = &mult
-	if mark > 0 {
-		p.StopLossHighWaterPx = mark
-	}
 	p.SLAdjustedTiersProcessed = clearedIdx + 1
 	mu.Unlock()
 	if logger != nil {

--- a/scheduler/trailing_tp_ratchet_test.go
+++ b/scheduler/trailing_tp_ratchet_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestResolveTrailingMultAfter_AbsoluteAndFraction(t *testing.T) {
+	tier := map[string]interface{}{
+		"atr_multiple":        3.0,
+		"close_fraction":      0.0,
+		"trailing_mult_after": 1.5,
+	}
+	mult, err := resolveTrailingMultAfter(tier, 3.0)
+	if err != nil || mult != 1.5 {
+		t.Fatalf("absolute: mult=%v err=%v want 1.5", mult, err)
+	}
+	tier2 := map[string]interface{}{
+		"atr_multiple":    2.0,
+		"close_fraction":  0.0,
+		"tp_atr_fraction": 0.5,
+	}
+	mult2, err := resolveTrailingMultAfter(tier2, 2.0)
+	if err != nil || mult2 != 1.0 {
+		t.Fatalf("fraction: mult=%v err=%v want 1.0", mult2, err)
+	}
+}
+
+func TestFindHighestMarkClearedRatchetTier(t *testing.T) {
+	tiers := []trailingRatchetTier{
+		{ATRMultiple: 1.0, TrailingMultAfter: 2.0},
+		{ATRMultiple: 2.0, TrailingMultAfter: 1.0},
+	}
+	idx, ok := findHighestMarkClearedRatchetTier(tiers, 1.5, 0)
+	if !ok || idx != 0 {
+		t.Fatalf("idx=%d ok=%v want 0,true", idx, ok)
+	}
+	idx, ok = findHighestMarkClearedRatchetTier(tiers, 2.5, 0)
+	if !ok || idx != 1 {
+		t.Fatalf("idx=%d ok=%v want 1,true", idx, ok)
+	}
+	idx, ok = findHighestMarkClearedRatchetTier(tiers, 2.5, 2)
+	if ok {
+		t.Fatalf("from watermark 2: idx=%d ok=%v want false", idx, ok)
+	}
+}
+
+func TestApplyTrailingTPRatchet_MonotonicTighten(t *testing.T) {
+	trailInit := 3.0
+	sc := StrategyConfig{
+		ID:       "s1",
+		Type:     "perps",
+		Platform: "hyperliquid",
+		CloseStrategy: &StrategyRef{
+			Name: "trailing_tp_ratchet",
+			Params: map[string]interface{}{
+				"tp_tiers": []interface{}{
+					map[string]interface{}{
+						"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 2.0,
+					},
+					map[string]interface{}{
+						"atr_multiple": 2.0, "close_fraction": 0.0, "trailing_mult_after": 1.0,
+					},
+				},
+			},
+		},
+		TrailingStopATRMult: &trailInit,
+	}
+	state := &StrategyState{
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol: "ETH", Side: "long", Quantity: 1, InitialQuantity: 1,
+				AvgCost: 100, EntryATR: 10, Regime: "ranging",
+			},
+		},
+	}
+	var mu sync.RWMutex
+	applyTrailingTPRatchet(sc, state, "ETH", 110, &mu, nil)
+	pos := state.Positions["ETH"]
+	if pos.PostTPTrailingATRMult == nil || *pos.PostTPTrailingATRMult != 2.0 {
+		t.Fatalf("after tier0: PostTPTrailingATRMult=%v want 2.0", pos.PostTPTrailingATRMult)
+	}
+	if pos.SLAdjustedTiersProcessed != 1 {
+		t.Fatalf("watermark=%d want 1", pos.SLAdjustedTiersProcessed)
+	}
+	applyTrailingTPRatchet(sc, state, "ETH", 120, &mu, nil)
+	if pos.PostTPTrailingATRMult == nil || *pos.PostTPTrailingATRMult != 1.0 {
+		t.Fatalf("after tier1: PostTPTrailingATRMult=%v want 1.0", pos.PostTPTrailingATRMult)
+	}
+}
+
+func TestValidateTrailingTPRatchetClose_RequiresTrailingMult(t *testing.T) {
+	sc := StrategyConfig{
+		ID: "s1", Type: "perps", Platform: "hyperliquid",
+		CloseStrategy: &StrategyRef{
+			Name: "trailing_tp_ratchet",
+			Params: map[string]interface{}{
+				"tp_tiers": []interface{}{
+					map[string]interface{}{
+						"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 1.0,
+					},
+				},
+			},
+		},
+	}
+	errs := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels)
+	if len(errs) == 0 {
+		t.Fatal("expected error when trailing_stop_atr_mult missing")
+	}
+}

--- a/scheduler/trailing_tp_ratchet_test.go
+++ b/scheduler/trailing_tp_ratchet_test.go
@@ -89,6 +89,48 @@ func TestApplyTrailingTPRatchet_MonotonicTighten(t *testing.T) {
 	}
 }
 
+func TestValidateTrailingTPRatchetClose_RejectsNonMonotonicTrail(t *testing.T) {
+	trail := 2.0
+	sc := StrategyConfig{
+		ID: "s1", Type: "perps", Platform: "hyperliquid",
+		TrailingStopATRMult: &trail,
+		CloseStrategy: &StrategyRef{
+			Name: "trailing_tp_ratchet",
+			Params: map[string]interface{}{
+				"tp_tiers": []interface{}{
+					map[string]interface{}{
+						"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 2.0,
+					},
+					map[string]interface{}{
+						"atr_multiple": 2.0, "close_fraction": 0.0, "trailing_mult_after": 3.0,
+					},
+				},
+			},
+		},
+	}
+	errs := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels)
+	if len(errs) == 0 {
+		t.Fatal("expected monotonic trail validation error")
+	}
+}
+
+func TestEffectiveTrailingStopPct_ManualNonRatchetReturnsZero(t *testing.T) {
+	trail := 2.0
+	sc := StrategyConfig{
+		ID: "m1", Type: "manual", Platform: "hyperliquid",
+		TrailingStopATRMult: &trail,
+		CloseStrategy:       &StrategyRef{Name: "tiered_tp_atr_live"},
+	}
+	pos := &Position{AvgCost: 100, EntryATR: 5}
+	if got := effectiveTrailingStopPct(sc, pos); got != 0 {
+		t.Fatalf("manual non-ratchet effectiveTrailingStopPct = %v, want 0", got)
+	}
+	sc.CloseStrategy = &StrategyRef{Name: "trailing_tp_ratchet"}
+	if got := effectiveTrailingStopPct(sc, pos); got <= 0 {
+		t.Fatalf("manual ratchet effectiveTrailingStopPct = %v, want > 0", got)
+	}
+}
+
 func TestValidateTrailingTPRatchetClose_RequiresTrailingMult(t *testing.T) {
 	sc := StrategyConfig{
 		ID: "s1", Type: "perps", Platform: "hyperliquid",

--- a/shared_strategies/close/registry.py
+++ b/shared_strategies/close/registry.py
@@ -17,6 +17,8 @@ from tiered_tp_atr_live import evaluate as tiered_tp_atr_live_evaluate
 from tiered_tp_atr_regime import evaluate as tiered_tp_atr_regime_evaluate
 from tiered_tp_atr_live_regime import evaluate as tiered_tp_atr_live_regime_evaluate
 from tiered_tp_atr_live_regime_dynamic import evaluate as tiered_tp_atr_live_regime_dynamic_evaluate
+from trailing_tp_ratchet import evaluate_regime as trailing_tp_ratchet_regime_evaluate
+from trailing_tp_ratchet import evaluate_scalar as trailing_tp_ratchet_evaluate
 from tiered_tp_pct import DEFAULT_TIERS as DEFAULT_PCT_TIERS
 from tiered_tp_pct import evaluate as tiered_tp_pct_evaluate
 
@@ -149,3 +151,15 @@ register(
     "Unified per-regime TP/SL — live ATR-regime re-resolution (#843; HL live uses on-chain sync)",
     {"atr_source": "live", "regime_confirm_cycles": 2},
 )(tiered_tp_atr_live_regime_dynamic_evaluate)
+
+register(
+    "trailing_tp_ratchet",
+    "Tiered trail ratchet — tightens trailing_stop_atr_mult at each ATR tier (close_fraction may be 0)",
+    {"tp_tiers": [{"atr_multiple": 1.5, "close_fraction": 0.0, "trailing_mult_after": 2.0}]},
+)(trailing_tp_ratchet_evaluate)
+
+register(
+    "trailing_tp_ratchet_regime",
+    "Regime-keyed tiered trail ratchet — frozen at open via Position.Regime (#844)",
+    {},
+)(trailing_tp_ratchet_regime_evaluate)

--- a/shared_strategies/close/test_close_registry.py
+++ b/shared_strategies/close/test_close_registry.py
@@ -28,6 +28,8 @@ def test_build_close_registry_filters_valid_platforms(registry):
             "tiered_tp_atr_regime",
             "tiered_tp_atr_live_regime",
             "tiered_tp_atr_live_regime_dynamic",
+            "trailing_tp_ratchet",
+            "trailing_tp_ratchet_regime",
         }
 
 

--- a/shared_strategies/close/test_trailing_tp_ratchet.py
+++ b/shared_strategies/close/test_trailing_tp_ratchet.py
@@ -1,0 +1,98 @@
+"""Tests for trailing_tp_ratchet close evaluators (#844)."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+_THIS_DIR = os.path.dirname(__file__)
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+
+def _load(name: str, path: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def ratchet():
+    return _load("_ratchet_under_test", os.path.join(_THIS_DIR, "trailing_tp_ratchet.py"))
+
+
+@pytest.fixture(scope="module")
+def registry():
+    return _load("_close_registry_ratchet", os.path.join(_THIS_DIR, "registry.py"))
+
+
+def test_trail_only_tier_returns_zero_close_fraction(ratchet):
+    params = {
+        "tp_tiers": [
+            {"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 2.0},
+            {"atr_multiple": 2.0, "close_fraction": 0.3, "trailing_mult_after": 1.0},
+        ]
+    }
+    pos = {
+        "side": "long",
+        "avg_cost": 100,
+        "current_quantity": 1,
+        "initial_quantity": 1,
+        "entry_atr": 10,
+    }
+    hit0 = ratchet.evaluate_scalar(pos, {"mark_price": 105}, params)
+    assert hit0["close_fraction"] == 0.0
+    hit1 = ratchet.evaluate_scalar(pos, {"mark_price": 125}, params)
+    assert hit1["close_fraction"] == pytest.approx(0.3)
+
+
+def test_double_close_guard(ratchet):
+    params = {
+        "tp_tiers": [
+            {"atr_multiple": 1.0, "close_fraction": 0.5, "trailing_mult_after": 1.5},
+        ]
+    }
+    pos = {
+        "side": "long",
+        "avg_cost": 100,
+        "current_quantity": 0.5,
+        "initial_quantity": 1,
+        "entry_atr": 10,
+    }
+    out = ratchet.evaluate_scalar(pos, {"mark_price": 115}, params)
+    assert out["close_fraction"] == 0.0
+    assert "already_taken" in out["reason"]
+
+
+def test_tp_atr_fraction_trail_spec(ratchet):
+    tier = {"atr_multiple": 2.0, "close_fraction": 0.0, "tp_atr_fraction": 0.5}
+    assert ratchet.resolve_trailing_mult_after(tier, 2.0) == pytest.approx(1.0)
+
+
+def test_regime_table_resolution(ratchet):
+    params = {
+        "tp_tiers": {
+            "trending_up": [
+                {"atr_multiple": 1.0, "close_fraction": 0.25, "trailing_mult_after": 1.5},
+            ],
+            "ranging": [
+                {"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 2.0},
+            ],
+        }
+    }
+    tiers, errs = ratchet.resolve_tiers_for_regime(
+        params, "ranging", regime_table=True,
+    )
+    assert errs == []
+    assert len(tiers) == 1
+    assert tiers[0][2] == 2.0
+
+
+def test_registry_lists_new_strategies(registry):
+    built = registry.build_close_registry("futures")
+    assert "trailing_tp_ratchet" in built
+    assert "trailing_tp_ratchet_regime" in built

--- a/shared_strategies/close/trailing_tp_ratchet.py
+++ b/shared_strategies/close/trailing_tp_ratchet.py
@@ -1,0 +1,197 @@
+"""Trailing-stop tier ratchet close evaluators (#844).
+
+Each tier tightens the trailing ATR distance and may scale out (``close_fraction``
+may be 0 for trail-only rungs). Regime is frozen at open via ``position["regime"]``.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from _helpers import (
+    clamp_fraction,
+    current_close_fraction,
+    float_from,
+    tier_list_from_params,
+)
+from regime_atr import CANONICAL_TREND_REGIME_LABELS
+
+
+def _first_present(d: dict, *keys: str):
+    for k in keys:
+        if k in d:
+            return d[k]
+    return None
+
+
+def resolve_trailing_mult_after(tier: dict, firing_multiple: float) -> Optional[float]:
+    """Return the new trail distance in ATR units for a firing tier."""
+    has_abs = "trailing_mult_after" in tier
+    has_frac = "tp_atr_fraction" in tier
+    if has_abs and has_frac:
+        return None
+    if has_abs:
+        try:
+            mult = float(tier["trailing_mult_after"])
+        except (TypeError, ValueError):
+            return None
+        return mult if mult > 0 else None
+    if has_frac:
+        try:
+            frac = float(tier["tp_atr_fraction"])
+        except (TypeError, ValueError):
+            return None
+        if frac <= 0 or firing_multiple <= 0:
+            return None
+        return frac * firing_multiple
+    return None
+
+
+def _parse_tier_dict(tier: dict) -> Optional[Tuple[float, float, Optional[float]]]:
+    """Return (atr_multiple, close_fraction, trailing_mult) or None when invalid."""
+    if not isinstance(tier, dict):
+        return None
+    mult_raw = _first_present(tier, "atr_multiple", "multiple", "atr")
+    frac_raw = _first_present(tier, "close_fraction", "fraction")
+    try:
+        mult = float(mult_raw)
+        frac = float(frac_raw if frac_raw is not None else 0.0)
+    except (TypeError, ValueError):
+        return None
+    if mult <= 0 or frac < 0 or frac > 1:
+        return None
+    trail = resolve_trailing_mult_after(tier, mult)
+    if trail is None or trail <= 0:
+        return None
+    return mult, clamp_fraction(frac), trail
+
+
+def _parse_scalar_tiers(raw) -> Tuple[List[Tuple[float, float, float]], List[str]]:
+    if not isinstance(raw, list):
+        return [], ["tp_tiers must be a list for trailing_tp_ratchet"]
+    parsed: List[Tuple[float, float, float]] = []
+    for idx, item in enumerate(raw):
+        row = _parse_tier_dict(item) if isinstance(item, dict) else None
+        if row is None:
+            continue
+        parsed.append(row)
+    parsed.sort(key=lambda p: p[0])
+    if not parsed:
+        return [], ["tp_tiers must contain at least one valid tier"]
+    return parsed, []
+
+
+def _parse_regime_table(raw, labels) -> Tuple[List[Tuple[float, float, float]], List[str]]:
+    if not isinstance(raw, dict):
+        return [], ["tp_tiers must be a regime-keyed object for trailing_tp_ratchet_regime"]
+    label_set = set(labels or CANONICAL_TREND_REGIME_LABELS)
+    errs: List[str] = []
+    for key in raw:
+        if key not in label_set:
+            errs.append(f"tp_tiers: unknown regime key {key!r}")
+    if errs:
+        return [], errs
+    # Validation-only path may pass regime="" — caller supplies table per open.
+    return [], []
+
+
+def resolve_tiers_for_regime(
+    params: dict, regime: str, *, regime_table: bool
+) -> Tuple[List[Tuple[float, float, float]], List[str]]:
+    """Resolve concrete tiers for the stamped regime label."""
+    raw = tier_list_from_params(params)
+    if regime_table:
+        if not isinstance(raw, dict):
+            return [], ["tp_tiers must be a regime-keyed object"]
+        label = (regime or "").strip()
+        if not label:
+            return [], ["noop:missing_position_regime"]
+        block = raw.get(label)
+        if block is None:
+            return [], [f"tp_tiers: missing regime key {label!r}"]
+        tiers, terr = _parse_scalar_tiers(block)
+        return tiers, terr
+    if isinstance(raw, dict):
+        block = raw.get("default", raw.get("ranging"))
+        if block is None:
+            return [], ["tp_tiers: expected list or object with 'default' key"]
+        tiers, terr = _parse_scalar_tiers(block)
+        return tiers, terr
+    return _parse_scalar_tiers(raw)
+
+
+def evaluate_scalar(position: dict, market: dict, params: dict) -> dict:
+    return _evaluate(position, market, params, regime_table=False)
+
+
+def evaluate_regime(position: dict, market: dict, params: dict) -> dict:
+    return _evaluate(position, market, params, regime_table=True)
+
+
+def _evaluate(position: dict, market: dict, params: dict, *, regime_table: bool) -> dict:
+    avg_cost = float_from(position, "avg_cost")
+    current_quantity = float_from(position, "current_quantity")
+    entry_atr = float_from(position, "entry_atr")
+    side = str(position.get("side", "") or "").strip().lower()
+    regime = str(position.get("regime", "") or "").strip()
+    mark_price = float_from(market, "mark_price")
+
+    if mark_price <= 0:
+        return {"close_fraction": 0.0, "reason": "noop:missing_mark_price"}
+    if avg_cost <= 0 or current_quantity <= 0 or side not in ("long", "short"):
+        return {"close_fraction": 0.0, "reason": "noop:missing_position"}
+    if entry_atr <= 0:
+        return {"close_fraction": 0.0, "reason": "noop:missing_entry_atr"}
+    if regime_table and not regime:
+        return {"close_fraction": 0.0, "reason": "noop:missing_position_regime"}
+
+    tiers, errs = resolve_tiers_for_regime(params, regime, regime_table=regime_table)
+    if errs or not tiers:
+        return {"close_fraction": 0.0, "reason": "noop:tier_resolution_failed"}
+
+    profit_distance = mark_price - avg_cost if side == "long" else avg_cost - mark_price
+    atr_profit = profit_distance / entry_atr
+    hit = [(m, f, t) for m, f, t in tiers if atr_profit >= m]
+    if not hit:
+        return {"close_fraction": 0.0, "reason": "noop:not_hit"}
+
+    multiple, cumulative_fraction, _trail = hit[-1]
+    close_fraction = current_close_fraction(position, cumulative_fraction)
+    if close_fraction <= 0:
+        return {"close_fraction": 0.0, "reason": "noop:already_taken"}
+    tag = "trailing_tp_ratchet_regime" if regime_table else "trailing_tp_ratchet"
+    suffix = f":{regime}" if regime_table else ""
+    return {
+        "close_fraction": close_fraction,
+        "reason": f"{tag}{suffix}:{multiple:g}",
+    }
+
+
+def maybe_apply_mark_ratchet(
+    tiers: List[Tuple[float, float, float]],
+    *,
+    watermark: int,
+    mark_price: float,
+    avg_cost: float,
+    entry_atr: float,
+    side: str,
+    post_tp_trail_mult: Optional[float],
+    trailing_stop_atr_mult: float,
+) -> tuple[int, Optional[float]]:
+    """Return (new_watermark, new_post_tp_trail_mult) after mark-based tier clears."""
+    if not tiers or mark_price <= 0 or avg_cost <= 0 or entry_atr <= 0:
+        return watermark, post_tp_trail_mult
+    profit_distance = mark_price - avg_cost if side == "long" else avg_cost - mark_price
+    atr_profit = profit_distance / entry_atr
+    hit_idx = -1
+    for i in range(watermark, len(tiers)):
+        if atr_profit + 1e-12 >= tiers[i][0]:
+            hit_idx = i
+    if hit_idx < 0:
+        return watermark, post_tp_trail_mult
+    new_mult = tiers[hit_idx][2]
+    current = post_tp_trail_mult if post_tp_trail_mult and post_tp_trail_mult > 0 else trailing_stop_atr_mult
+    out_mult = post_tp_trail_mult
+    if new_mult < current - 1e-12:
+        out_mult = new_mult
+    return hit_idx + 1, out_mult


### PR DESCRIPTION
## Summary
- Adds `trailing_tp_ratchet` and `trailing_tp_ratchet_regime` close evaluators where each ATR tier can scale out (`close_fraction` may be 0) and monotonically tighten the trailing stop via `trailing_mult_after` or `tp_atr_fraction`.
- HL live + manual: mark-based ratchet stamps `PostTPTrailingATRMult`; existing trailing-stop cancel/replace picks up the tighter distance. No on-chain TP orders.
- Backtester simulates tier ratcheting and trailing walk from `trailing_stop_atr_mult`.

## Test plan
- [x] `go test -run TrailingTPRatchet ./scheduler`
- [x] `pytest shared_strategies/close/test_trailing_tp_ratchet.py`
- [ ] Load a strategy config with `trailing_tp_ratchet_regime` + `trailing_stop_atr_mult` and `--probe-only`
- [ ] Paper/live: verify trail tightens at tier thresholds without double-closing `close_fraction: 0` rungs