### PR TITLE
feat(close): trailing_tp_ratchet — per-tier trailing ATR ratchet (#844)

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -373,6 +373,15 @@ class Backtester:
         self._uses_regime_tiered_close = _close_refs_use_regime_tiered_tp(
             self._close_refs,
         )
+        # #844: trailing_tp_ratchet drives a strategy-level trailing ATR stop
+        # whose distance tightens each time a cleared TP tier returns a
+        # post_tp_trailing_atr_mult. The initial (loose) trail is the
+        # strategy-level trailing_stop_atr_mult resolved at open.
+        self._uses_trailing_tp_ratchet = any(
+            (r.get("name") or "").strip().lower()
+            in ("trailing_tp_ratchet", "trailing_tp_ratchet_regime")
+            for r in self._close_refs
+        )
         _needs_regime_atr = (
             self.stop_loss_atr_regime is not None
             or self.trailing_stop_atr_regime is not None
@@ -755,6 +764,9 @@ class Backtester:
         sl_trigger_px = 0.0
         sl_tiers_processed = 0
         post_tp_trail_mult: Optional[float] = None
+        # #844: trail tightening detected at a bar's close, applied at the next
+        # bar (mirrors live's stamp-this-cycle / walk-next-cycle ordering).
+        pending_post_tp_trail: Optional[float] = None
         sl_high_water_px = 0.0
         self._active_sl_after_rules = self._sl_after_rules_static
         self._run_tp_tier_thresholds = list(self._tp_tier_thresholds_static)
@@ -762,6 +774,7 @@ class Backtester:
         self._run_trailing_stop_atr_mult: Optional[float] = None
         self._run_position_regime = ""
         sl_after_active = self._sl_after_pipeline_enabled
+        trailing_ratchet_active = self._uses_trailing_tp_ratchet
 
         atr_series = df["atr"] if "atr" in df.columns else None
 
@@ -879,6 +892,12 @@ class Backtester:
                 col_close_fraction = float(row.get("_close_fraction", 0.0))
                 close_fraction = max(col_close_fraction, pending_close_fraction)
                 pending_close_fraction = 0.0
+                # #844: apply the trail tightening detected at the prior bar's
+                # close (monotonic — never loosen).
+                if pending_post_tp_trail is not None and pending_post_tp_trail > 0:
+                    if post_tp_trail_mult is None or pending_post_tp_trail < post_tp_trail_mult:
+                        post_tp_trail_mult = pending_post_tp_trail
+                pending_post_tp_trail = None
                 open_action = row.get("_open_action", "none")
 
                 if close_fraction > 0 and position != 0:
@@ -916,6 +935,7 @@ class Backtester:
                         sl_trigger_px = 0.0
                         sl_tiers_processed = 0
                         post_tp_trail_mult = None
+                        pending_post_tp_trail = None
                         sl_high_water_px = 0.0
                         sl_after_just_applied = False
                         self._active_sl_after_rules = self._sl_after_rules_static
@@ -991,6 +1011,19 @@ class Backtester:
                         sl_tiers_processed = 0
                         post_tp_trail_mult = None
                         sl_high_water_px = 0.0
+                    # #844: arm the initial (loose) trailing stop from the
+                    # strategy-level trailing_stop_atr_mult; the first end-of-bar
+                    # walk establishes the trigger from the seeded high-water mark.
+                    if (
+                        trailing_ratchet_active
+                        and self._run_trailing_stop_atr_mult is not None
+                        and self._run_trailing_stop_atr_mult > 0
+                    ):
+                        post_tp_trail_mult = self._run_trailing_stop_atr_mult
+                        sl_high_water_px = avg_cost
+                        sl_trigger_px = 0.0
+                        sl_tiers_processed = 0
+                        pending_post_tp_trail = None
                 elif open_action == "short" and position == 0 and not regime_blocked:
                     effective_price = fill_price * (1 - self.slippage_pct)
                     commission = cash * self.commission_pct
@@ -1012,18 +1045,34 @@ class Backtester:
                         sl_tiers_processed = 0
                         post_tp_trail_mult = None
                         sl_high_water_px = 0.0
+                    # #844: arm the initial (loose) trailing stop (short).
+                    if (
+                        trailing_ratchet_active
+                        and self._run_trailing_stop_atr_mult is not None
+                        and self._run_trailing_stop_atr_mult > 0
+                    ):
+                        post_tp_trail_mult = self._run_trailing_stop_atr_mult
+                        sl_high_water_px = avg_cost
+                        sl_trigger_px = 0.0
+                        sl_tiers_processed = 0
+                        pending_post_tp_trail = None
 
                 # End-of-bar: evaluate close strategies against the now-current
                 # position using this bar's close as the mark. The result is
                 # applied at the NEXT bar's open (mirrors live: eval at end of
                 # bar, fill at next open).
                 if self.close_strategies and position != 0 and avg_cost > 0:
-                    pending_close_fraction = self._evaluate_close_strategies(
+                    pending_close_fraction, eval_trail = self._evaluate_close_strategies(
                         position, avg_cost, initial_quantity, entry_atr_value,
                         mark_price, atr_series, idx,
                         position_regime=self._run_position_regime,
                         market_regime=_bar_close_regime(row),
                     )
+                    # #844: defer the trail tightening to the next bar (consumed
+                    # at the top of the loop) so it never fires an SL on the same
+                    # bar the tier cleared — matches live's one-cycle delay.
+                    if eval_trail is not None and eval_trail > 0:
+                        pending_post_tp_trail = eval_trail
 
                 # End-of-bar: walk the trailing-stop high-water mark (only
                 # active after a TP tier transitioned the position to
@@ -1032,7 +1081,7 @@ class Backtester:
                 # pending_close_fraction=1.0 which fills at the next bar's
                 # open — same alignment as the rest of the close pipeline.
                 if (
-                    sl_after_active
+                    (sl_after_active or trailing_ratchet_active)
                     and not sl_after_just_applied
                     and position != 0
                     and avg_cost > 0
@@ -1162,10 +1211,13 @@ class Backtester:
                                    idx,
                                    *,
                                    position_regime: str = "",
-                                   market_regime: str = "") -> float:
+                                   market_regime: str = "") -> tuple[float, Optional[float]]:
         """Run every configured close evaluator against the simulated position
-        and return the max ``close_fraction``. Same max-wins resolution as the
-        live composition flow in shared_tools/strategy_composition.py.
+        and return ``(max_close_fraction, post_tp_trailing_atr_mult)``. The
+        close fraction uses the same max-wins resolution as the live composition
+        flow in shared_tools/strategy_composition.py; the trail multiple is the
+        tightest (smallest positive) emitted by any evaluator (#844 — only the
+        trailing_tp_ratchet family emits one; None otherwise).
         """
         evaluate, _list_strategies = _load_close_registry()
         side = "long" if position > 0 else "short"
@@ -1203,16 +1255,22 @@ class Backtester:
                 market_dict["atr"] = live_atr
 
         best = 0.0
+        best_trail: Optional[float] = None
         for name in self.close_strategies:
             params = self.close_params.get(name)
             result = evaluate(name, position_dict, market_dict, params)
             fraction = float(result.get("close_fraction", 0.0) or 0.0)
             if fraction > best:
                 best = fraction
-                if best >= 1.0:
-                    # Full close already wins — remaining evaluators can't change the outcome.
-                    return 1.0
-        return min(max(best, 0.0), 1.0)
+            trail_raw = result.get("post_tp_trailing_atr_mult")
+            if trail_raw is not None:
+                try:
+                    trail = float(trail_raw)
+                except (TypeError, ValueError):
+                    trail = 0.0
+                if trail > 0 and (best_trail is None or trail < best_trail):
+                    best_trail = trail
+        return min(max(best, 0.0), 1.0), best_trail
 
     def _initial_sl_trigger(self, side: str, avg_cost: float,
                             entry_atr: float) -> float:

--- a/backtest/tests/test_trailing_tp_ratchet.py
+++ b/backtest/tests/test_trailing_tp_ratchet.py
@@ -1,0 +1,90 @@
+"""End-to-end backtester parity for the trailing_tp_ratchet close (#844).
+
+Each cleared TP tier tightens the trailing ATR multiple (and optionally scales
+out); the remainder exits via the trailing stop once price reverses. ATR is a
+fixed 10 and entry is $100 throughout, so trail triggers are easy to reason
+about: for a long, trigger = high_water_mark - trail_mult * 10.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+from backtester import Backtester
+
+
+def _df_open_then_hold(opens, closes, atrs):
+    n = len(closes)
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    return pd.DataFrame(
+        {
+            "open": opens,
+            "close": closes,
+            "atr": atrs,
+            "open_action": ["long"] + ["none"] * (n - 1),
+        },
+        index=idx,
+    )
+
+
+def _bt(tiers, trailing_mult=3.0):
+    return Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        platform="hyperliquid", strategy_type="perps",
+        trailing_stop_atr_mult=trailing_mult,
+        close_strategies=[{"name": "trailing_tp_ratchet", "params": {"tp_tiers": tiers}}],
+    )
+
+
+def test_ratchet_scale_out_then_trail_exit():
+    # tier1 @1.5×ATR: trail-only → tighten 3.0→2.0. tier2 @3.0×ATR: close 30%,
+    # tighten →1.0. Remainder rides the 1.0×ATR trail (hwm 140 → trigger 130).
+    df = _df_open_then_hold(
+        opens=[100, 100, 116, 131, 140, 140, 140, 130],
+        closes=[100, 115, 131, 140, 140, 140, 130, 130],
+        atrs=[10] * 8,
+    )
+    bt = _bt([
+        {"atr_multiple": 1.5, "close_fraction": 0.0, "trailing_mult_after": 2.0},
+        {"atr_multiple": 3.0, "close_fraction": 0.3, "trailing_mult_after": 1.0},
+    ])
+    trades = bt.run(df, save=False)["trades"]
+    prices = [(t["side"], t["exit_price"]) for t in trades]
+    assert ("long", 131.0) in prices, prices   # 30% scale-out at tier2
+    assert ("long", 130.0) in prices, prices   # remainder on the tightened trail
+    assert len(trades) == 2, prices
+    # Remainder is the larger leg (0.7 of initial vs 0.3 scaled out).
+    by_exit = {t["exit_price"]: t["shares"] for t in trades}
+    assert by_exit[130.0] > by_exit[131.0]
+
+
+def test_pure_trailing_all_zero_single_exit():
+    # Every tier close_fraction 0 → no scale-out; the trail tightens 3.0→2.0→1.0
+    # and the whole position exits on one trailing-stop fire.
+    df = _df_open_then_hold(
+        opens=[100, 100, 121, 130, 120],
+        closes=[100, 110, 121, 130, 120],
+        atrs=[10] * 5,
+    )
+    bt = _bt([
+        {"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 2.0},
+        {"atr_multiple": 2.0, "close_fraction": 0.0, "trailing_mult_after": 1.0},
+    ])
+    trades = bt.run(df, save=False)["trades"]
+    assert len(trades) == 1, [(t["side"], t["exit_price"]) for t in trades]
+    assert trades[0]["exit_price"] == 120.0  # hwm 130 - 1.0×ATR
+
+
+def test_tp_atr_fraction_trail_form():
+    # tp_atr_fraction 0.5 at a 2.0×ATR tier → trail = 1.0×ATR. Distinguishes the
+    # relative form from the absolute one: a wrong reading (0.5×ATR) would exit
+    # at 125, the correct 1.0×ATR exits at 120 (hwm 130 - 1.0×ATR).
+    df = _df_open_then_hold(
+        opens=[100, 100, 121, 130, 130, 120],
+        closes=[100, 121, 121, 130, 120, 120],
+        atrs=[10] * 6,
+    )
+    bt = _bt([{"atr_multiple": 2.0, "close_fraction": 0.3, "tp_atr_fraction": 0.5}])
+    trades = bt.run(df, save=False)["trades"]
+    prices = [(t["side"], t["exit_price"]) for t in trades]
+    assert ("long", 121.0) in prices, prices  # 30% scale-out
+    assert ("long", 120.0) in prices, prices  # remainder at 1.0×ATR trail

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -569,6 +569,12 @@ var closeStrategyOwnedKeys = map[string]map[string]struct{}{
 	"tiered_tp_atr_live_regime_dynamic": {"trend_regime": {}, "atr_source": {}, "regime_confirm_cycles": {}},
 	"tiered_tp_pct":                     {"tp_tiers": {}, "tiers": {}},
 	"tp_at_pct":                         {"pct": {}}, // v15 migrates to tiered_tp_pct; kept for v13 legacy param routing only
+	// #844: trailing_tp_ratchet — tp_tiers is either a flat list (plain) or a
+	// regime-keyed {label: [tiers]} map (the _regime variant). Both are post-v13;
+	// listed for unknown-key symmetry. The initial trail is the strategy-level
+	// trailing_stop_atr_mult, not a close param.
+	"trailing_tp_ratchet":        {"tp_tiers": {}, "tiers": {}},
+	"trailing_tp_ratchet_regime": {"tp_tiers": {}, "tiers": {}},
 }
 
 // migrateV14Direction translates the legacy boolean `allow_shorts` field on

--- a/scheduler/config_migration_v15.go
+++ b/scheduler/config_migration_v15.go
@@ -233,7 +233,21 @@ func canonicalizeCloseParams(params map[string]interface{}) map[string]interface
 	for k, v := range params {
 		switch k {
 		case "tiers", "tp_tiers":
-			out["tp_tiers"] = canonicalizeTierList(v)
+			if tbl, ok := v.(map[string]interface{}); ok {
+				// #844 trailing_tp_ratchet_regime: tp_tiers is a regime-keyed
+				// {label: [tiers]} map; canonicalize each regime's tier list.
+				canon := make(map[string]interface{}, len(tbl))
+				for label, lst := range tbl {
+					if _, isList := lst.([]interface{}); isList {
+						canon[label] = canonicalizeTierList(lst)
+					} else {
+						canon[label] = lst
+					}
+				}
+				out["tp_tiers"] = canon
+			} else {
+				out["tp_tiers"] = canonicalizeTierList(v)
+			}
 		case "trend_regime":
 			out["trend_regime"] = canonicalizeUnifiedTrendRegime(v)
 		default:

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -483,6 +483,14 @@ func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error 
 				errs = append(errs, fmt.Sprintf("strategy[%s] unified per-regime close block changed with open positions (flatten first or restart after close)",
 					sc.ID))
 			}
+			// #844: the trailing_tp_ratchet tier table (per-tier triggers, close
+			// fractions, and trail-tightening) is frozen at open. Block tier-table
+			// edits while open; allowed when flat (trailing_stop_atr_mult numeric
+			// changes stay hot-reloadable as before).
+			if !trailingTPRatchetParamsEqualForReload(sc, ns) {
+				errs = append(errs, fmt.Sprintf("strategy[%s] trailing_tp_ratchet tp_tiers changed with open positions (flatten first or restart after close)",
+					sc.ID))
+			}
 		}
 	}
 	if len(errs) > 0 {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1722,7 +1722,16 @@ func main() {
 							runHyperliquidProtectionSync(sc, stratState, stateDB, sc.Symbol, &mu, notifier, logger, "HL manual protection synced", hlReconcileFillHintsJSON)
 							runPostTPStopLossAdjustment(sc, stratState, sc.Symbol, prices[sc.Symbol], cfg, &mu, notifier, logger, hlOnChainAbsQty)
 						}
-						if closeFraction, _, ok := runManualCloseEval(sc, stratState, cfg, notifier, logger); ok && closeFraction > 0 {
+						closeFraction, _, trailMult, ceOK := runManualCloseEval(sc, stratState, cfg, notifier, logger)
+						if ceOK && trailMult != nil {
+							// #844: stamp the trailing_tp_ratchet trail tightening even on
+							// a trail-only rung (closeFraction==0); the next cycle's trailing
+							// loop arms the tighter on-chain trigger.
+							mu.Lock()
+							applyTrailingTPRatchet(stratState, sc.Symbol, trailMult)
+							mu.Unlock()
+						}
+						if ceOK && closeFraction > 0 {
 							mu.RLock()
 							pos = stratState.Positions[sc.Symbol]
 							mu.RUnlock()
@@ -2880,6 +2889,10 @@ func executeHyperliquidResultDeferredOpen(sc StrategyConfig, s *StrategyState, r
 	openTrade := exec.OpenTrade
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
 	stampPositionRegimeIfOpened(s, result.Symbol, regimePayloadValue(result.Regime), sc, regime)
+	// #844: stamp the trailing_tp_ratchet trail tightening (monotonic). Runs even
+	// when the close evaluator took no profit (trail-only rung, signal==0) — the
+	// trailing-stop walker picks up the tighter distance on the next cycle.
+	applyTrailingTPRatchet(s, result.Symbol, result.PostTPTrailingATRMult)
 	if pos, ok := s.Positions[result.Symbol]; ok {
 		stampPositionProtectionSnapshot(pos, sc)
 	}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1722,16 +1722,7 @@ func main() {
 							runHyperliquidProtectionSync(sc, stratState, stateDB, sc.Symbol, &mu, notifier, logger, "HL manual protection synced", hlReconcileFillHintsJSON)
 							runPostTPStopLossAdjustment(sc, stratState, sc.Symbol, prices[sc.Symbol], cfg, &mu, notifier, logger, hlOnChainAbsQty)
 						}
-						closeFraction, _, trailMult, ceOK := runManualCloseEval(sc, stratState, cfg, notifier, logger)
-						if ceOK && trailMult != nil {
-							// #844: stamp the trailing_tp_ratchet trail tightening even on
-							// a trail-only rung (closeFraction==0); the next cycle's trailing
-							// loop arms the tighter on-chain trigger.
-							mu.Lock()
-							applyTrailingTPRatchet(stratState, sc.Symbol, trailMult)
-							mu.Unlock()
-						}
-						if ceOK && closeFraction > 0 {
+						if closeFraction, _, ok := runManualCloseEval(sc, stratState, cfg, notifier, logger); ok && closeFraction > 0 {
 							mu.RLock()
 							pos = stratState.Positions[sc.Symbol]
 							mu.RUnlock()

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -881,17 +881,16 @@ func openTradeSide(posSide string) string {
 // runManualCloseEval runs the close-evaluator loop for a single type=manual
 // strategy that has an open position. Called from the main scheduler loop.
 // Returns (closeFraction, closePrice, ok).
-func runManualCloseEval(sc StrategyConfig, ss *StrategyState, cfg *Config, notifier *MultiNotifier, logger *StrategyLogger) (float64, float64, *float64, bool) {
+func runManualCloseEval(sc StrategyConfig, ss *StrategyState, cfg *Config, notifier *MultiNotifier, logger *StrategyLogger) (float64, float64, bool) {
 	pos := ss.Positions[sc.Symbol]
 	if pos == nil {
-		return 0, 0, nil, true // flat — nothing to do
+		return 0, 0, true // flat — nothing to do
 	}
 
 	posCtx := positionCtxFromPosition(pos)
 	result, _, price, ok := runHyperliquidCheck(&sc, nil, posCtx, cfg.Regime, notifier, logger)
 	if !ok {
-		return 0, 0, nil, false
+		return 0, 0, false
 	}
-	// PostTPTrailingATRMult is set only by the trailing_tp_ratchet close family (#844).
-	return result.CloseFraction, price, result.PostTPTrailingATRMult, true
+	return result.CloseFraction, price, true
 }

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -881,16 +881,17 @@ func openTradeSide(posSide string) string {
 // runManualCloseEval runs the close-evaluator loop for a single type=manual
 // strategy that has an open position. Called from the main scheduler loop.
 // Returns (closeFraction, closePrice, ok).
-func runManualCloseEval(sc StrategyConfig, ss *StrategyState, cfg *Config, notifier *MultiNotifier, logger *StrategyLogger) (float64, float64, bool) {
+func runManualCloseEval(sc StrategyConfig, ss *StrategyState, cfg *Config, notifier *MultiNotifier, logger *StrategyLogger) (float64, float64, *float64, bool) {
 	pos := ss.Positions[sc.Symbol]
 	if pos == nil {
-		return 0, 0, true // flat — nothing to do
+		return 0, 0, nil, true // flat — nothing to do
 	}
 
 	posCtx := positionCtxFromPosition(pos)
 	result, _, price, ok := runHyperliquidCheck(&sc, nil, posCtx, cfg.Regime, notifier, logger)
 	if !ok {
-		return 0, 0, false
+		return 0, 0, nil, false
 	}
-	return result.CloseFraction, price, true
+	// PostTPTrailingATRMult is set only by the trailing_tp_ratchet close family (#844).
+	return result.CloseFraction, price, result.PostTPTrailingATRMult, true
 }

--- a/scheduler/regime_atr.go
+++ b/scheduler/regime_atr.go
@@ -862,6 +862,16 @@ func validateRegimeATRConfig(cfg *Config) []string {
 			}
 		}
 
+		// #844: trailing_tp_ratchet / trailing_tp_ratchet_regime close validation.
+		// Uses the same regime_atr_window classifier vocabulary (atrLabels) so a
+		// composite window accepts the 7-state labels and an adx window the
+		// 3-state ones. The _regime variant requires regime.enabled.
+		ratchetErrs, ratchetRegime := validateTrailingTPRatchetClose(sc, atrLabels, prefix)
+		errs = append(errs, ratchetErrs...)
+		if ratchetRegime {
+			usesRegime = true
+		}
+
 		if usesRegime && !regimeEnabled {
 			errs = append(errs, fmt.Sprintf("%s: regime-aware stop/TP fields require top-level regime.enabled=true", prefix))
 		}

--- a/scheduler/strategy_composition.go
+++ b/scheduler/strategy_composition.go
@@ -18,6 +18,11 @@ type StrategyDecisionFields struct {
 	CloseFraction   float64        `json:"close_fraction"`
 	CloseStrategy   string         `json:"close_strategy,omitempty"`
 	Regime          *RegimePayload `json:"regime,omitempty"`
+	// PostTPTrailingATRMult is set only by the trailing_tp_ratchet close family
+	// (#844): the tightened trailing ATR multiple for the highest cleared tier.
+	// The runtime stamps it onto Position.PostTPTrailingATRMult (tighten-only)
+	// and the trailing-stop walker takes over at that distance. nil otherwise.
+	PostTPTrailingATRMult *float64 `json:"post_tp_trailing_atr_mult,omitempty"`
 }
 
 // PositionCtx is the optional state snapshot threaded into close evaluators

--- a/scheduler/trailing_tp_ratchet.go
+++ b/scheduler/trailing_tp_ratchet.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// trailing_tp_ratchet (#844): a close strategy built on the strategy-level
+// trailing ATR stop, where each cleared TP tier (a) tightens the trailing ATR
+// multiple and (b) optionally scales out a fraction at that tier's price. The
+// Python evaluator detects tier-fills by profit-distance (it places NO on-chain
+// TPs) and returns post_tp_trailing_atr_mult; the runtime stamps it onto
+// Position.PostTPTrailingATRMult (tighten-only) and the existing trailing-stop
+// walker (effectiveTrailingStopPct / runHyperliquidTrailingStopUpdate) takes
+// over at the new distance — no new live path.
+
+const (
+	trailingTPRatchetName       = "trailing_tp_ratchet"
+	trailingTPRatchetRegimeName = "trailing_tp_ratchet_regime"
+)
+
+// isTrailingTPRatchetCloseName reports whether name is one of the two registered
+// trailing-TP-ratchet close evaluators.
+func isTrailingTPRatchetCloseName(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case trailingTPRatchetName, trailingTPRatchetRegimeName:
+		return true
+	}
+	return false
+}
+
+// isTrailingTPRatchetRegimeCloseName reports whether name is the regime-keyed
+// variant (tp_tiers is a {label: [tiers]} map).
+func isTrailingTPRatchetRegimeCloseName(name string) bool {
+	return strings.ToLower(strings.TrimSpace(name)) == trailingTPRatchetRegimeName
+}
+
+// strategyUsesTrailingTPRatchet reports whether the strategy's close ref is a
+// trailing-TP-ratchet evaluator.
+func strategyUsesTrailingTPRatchet(sc StrategyConfig) bool {
+	for _, ref := range sc.closeRefs() {
+		if isTrailingTPRatchetCloseName(ref.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+// stampTrailingTPRatchetMult applies a monotonic (tighten-only) update of
+// pos.PostTPTrailingATRMult. A tighter trail is a strictly SMALLER multiple, so
+// a looser (>=) candidate — or a stale repeat — is ignored. Returns true when
+// the stamp changed. Caller must hold the state lock.
+func stampTrailingTPRatchetMult(pos *Position, newMult *float64) bool {
+	if pos == nil || pos.Quantity <= 0 || newMult == nil || *newMult <= 0 {
+		return false
+	}
+	if pos.PostTPTrailingATRMult != nil && *pos.PostTPTrailingATRMult <= *newMult {
+		return false
+	}
+	m := *newMult
+	pos.PostTPTrailingATRMult = &m
+	return true
+}
+
+// applyTrailingTPRatchet stamps the trail multiple carried on a close result
+// onto the live position. No-ops unless the evaluator returned one (only the
+// trailing_tp_ratchet family does), so it is safe to call after every perps /
+// manual execute. Caller must hold the state lock.
+func applyTrailingTPRatchet(s *StrategyState, symbol string, mult *float64) bool {
+	if s == nil || mult == nil {
+		return false
+	}
+	pos, ok := s.Positions[symbol]
+	if !ok {
+		return false
+	}
+	return stampTrailingTPRatchetMult(pos, mult)
+}
+
+// trailingTPRatchetReloadKey returns a deterministic fingerprint of the
+// trailing-TP-ratchet close ref (name + tp_tiers shape) and whether one is
+// configured. json.Marshal sorts map keys, so the key is stable across reloads.
+func trailingTPRatchetReloadKey(sc StrategyConfig) (string, bool) {
+	for _, ref := range sc.closeRefs() {
+		if !isTrailingTPRatchetCloseName(ref.Name) {
+			continue
+		}
+		b, err := json.Marshal(ref.Params["tp_tiers"])
+		if err != nil {
+			b = []byte(fmt.Sprintf("%v", ref.Params["tp_tiers"]))
+		}
+		return strings.ToLower(strings.TrimSpace(ref.Name)) + "|" + string(b), true
+	}
+	return "", false
+}
+
+// trailingTPRatchetParamsEqualForReload reports whether the trailing-TP-ratchet
+// tier table is unchanged between two configs. A tier-table (or name) edit is a
+// shape change that must be blocked while a position is open (#844) — the trail
+// ratchet schedule was frozen at open.
+func trailingTPRatchetParamsEqualForReload(a, b StrategyConfig) bool {
+	ka, ua := trailingTPRatchetReloadKey(a)
+	kb, ub := trailingTPRatchetReloadKey(b)
+	if ua != ub {
+		return false
+	}
+	if !ua {
+		return true
+	}
+	return ka == kb
+}
+
+// validateTrailingTPRatchetClose validates a strategy's trailing-TP-ratchet
+// close ref at config load. atrLabels is the regime vocabulary resolved from the
+// strategy's regime_atr_window classifier (3-state adx or 7-state composite).
+// Returns accumulated errors and whether the regime-keyed variant is in use (so
+// the caller can enforce regime.enabled).
+func validateTrailingTPRatchetClose(sc *StrategyConfig, atrLabels []string, prefix string) (errs []string, usesRegime bool) {
+	if sc == nil {
+		return nil, false
+	}
+	if len(atrLabels) == 0 {
+		atrLabels = canonicalTrendRegimeLabels
+	}
+	for _, ref := range sc.closeRefs() {
+		name := strings.ToLower(strings.TrimSpace(ref.Name))
+		if !isTrailingTPRatchetCloseName(name) {
+			continue
+		}
+		sub := fmt.Sprintf("%s.close_strategy(%s)", prefix, ref.Name)
+		regimeVariant := isTrailingTPRatchetRegimeCloseName(name)
+		if regimeVariant {
+			usesRegime = true
+		}
+
+		// HL perps / manual only — the trailing-stop walker is HL-only.
+		if sc.Platform != "hyperliquid" || (sc.Type != "perps" && sc.Type != "manual") {
+			errs = append(errs, fmt.Sprintf("%s: %s is HL perps/manual only (got platform=%q type=%q)", sub, ref.Name, sc.Platform, sc.Type))
+		}
+
+		// The strategy-level trailing_stop_atr_mult is the initial (loose) trail
+		// in effect before any tier fires.
+		if sc.TrailingStopATRMult == nil || *sc.TrailingStopATRMult <= 0 {
+			errs = append(errs, fmt.Sprintf("%s: requires a positive trailing_stop_atr_mult (the initial trail distance before any tier fires)", sub))
+		}
+
+		// Unknown-key guard: tp_tiers is the only owned param.
+		for k := range ref.Params {
+			if k != "tp_tiers" {
+				errs = append(errs, fmt.Sprintf("%s: unknown param %q (allowed: tp_tiers)", sub, k))
+			}
+		}
+
+		raw, ok := ref.Params["tp_tiers"]
+		if !ok || raw == nil {
+			errs = append(errs, fmt.Sprintf("%s: missing tp_tiers", sub))
+			continue
+		}
+
+		if regimeVariant {
+			tableRaw, ok := raw.(map[string]interface{})
+			if !ok {
+				errs = append(errs, fmt.Sprintf("%s.tp_tiers: must be a regime-keyed object {label: [tiers]}, got %T", sub, raw))
+				continue
+			}
+			if len(tableRaw) == 0 {
+				errs = append(errs, fmt.Sprintf("%s.tp_tiers: must define at least one regime", sub))
+				continue
+			}
+			allowed := make(map[string]bool, len(atrLabels))
+			for _, l := range atrLabels {
+				allowed[l] = true
+			}
+			labels := make([]string, 0, len(tableRaw))
+			for k := range tableRaw {
+				labels = append(labels, k)
+			}
+			sort.Strings(labels)
+			for _, label := range labels {
+				if !allowed[label] {
+					errs = append(errs, fmt.Sprintf("%s.tp_tiers: unknown regime label %q (expected one of: %s)", sub, label, strings.Join(atrLabels, ", ")))
+					continue
+				}
+				errs = append(errs, validateRatchetTierList(tableRaw[label], fmt.Sprintf("%s.tp_tiers.%s", sub, label))...)
+			}
+			continue
+		}
+
+		// Plain variant: a flat list (or a {"default": [...]} map).
+		if m, ok := raw.(map[string]interface{}); ok {
+			def, hasDefault := m["default"]
+			if !hasDefault {
+				errs = append(errs, fmt.Sprintf("%s.tp_tiers: object form requires a \"default\" key for %s (use %s for regime-keyed tables)", sub, trailingTPRatchetName, trailingTPRatchetRegimeName))
+				continue
+			}
+			errs = append(errs, validateRatchetTierList(def, fmt.Sprintf("%s.tp_tiers.default", sub))...)
+			continue
+		}
+		errs = append(errs, validateRatchetTierList(raw, fmt.Sprintf("%s.tp_tiers", sub))...)
+	}
+	return errs, usesRegime
+}
+
+// validateRatchetTierList validates one tier list (the per-regime list for the
+// regime variant, or the flat list for the plain variant).
+func validateRatchetTierList(raw interface{}, ctx string) []string {
+	var errs []string
+	items, ok := raw.([]interface{})
+	if !ok {
+		return []string{fmt.Sprintf("%s: must be a list of tiers, got %T", ctx, raw)}
+	}
+	if len(items) == 0 {
+		return []string{fmt.Sprintf("%s: must have at least one tier", ctx)}
+	}
+	for idx, item := range items {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			errs = append(errs, fmt.Sprintf("%s[%d]: must be an object, got %T", ctx, idx, item))
+			continue
+		}
+		tctx := fmt.Sprintf("%s[%d]", ctx, idx)
+		for k := range m {
+			switch k {
+			case "atr_multiple", "atr", "multiple", "close_fraction", "fraction",
+				"trailing_mult_after", "tp_atr_fraction":
+				// known (legacy atr/multiple/fraction aliases accepted at runtime)
+			default:
+				errs = append(errs, fmt.Sprintf("%s: unknown key %q (allowed: atr_multiple, close_fraction, trailing_mult_after, tp_atr_fraction)", tctx, k))
+			}
+		}
+
+		trigRaw, hasTrig := firstNonNil(m, "atr_multiple", "atr", "multiple")
+		if !hasTrig {
+			errs = append(errs, fmt.Sprintf("%s: missing required 'atr_multiple'", tctx))
+		} else if trig, err := floatFromAnyChecked(trigRaw); err != nil {
+			errs = append(errs, fmt.Sprintf("%s.atr_multiple: %v", tctx, err))
+		} else if trig <= 0 {
+			errs = append(errs, fmt.Sprintf("%s.atr_multiple: must be > 0, got %g", tctx, trig))
+		}
+
+		if fracRaw, has := firstNonNil(m, "close_fraction", "fraction"); has {
+			if frac, err := floatFromAnyChecked(fracRaw); err != nil {
+				errs = append(errs, fmt.Sprintf("%s.close_fraction: %v", tctx, err))
+			} else if frac < 0 || frac > 1 {
+				errs = append(errs, fmt.Sprintf("%s.close_fraction: must be in [0, 1], got %g", tctx, frac))
+			}
+		}
+
+		_, hasAbs := m["trailing_mult_after"]
+		_, hasFrac := m["tp_atr_fraction"]
+		if hasAbs && hasFrac {
+			errs = append(errs, fmt.Sprintf("%s: trailing_mult_after and tp_atr_fraction are mutually exclusive (pick one trail-spec form)", tctx))
+		}
+		if hasAbs {
+			if v, err := floatFromAnyChecked(m["trailing_mult_after"]); err != nil {
+				errs = append(errs, fmt.Sprintf("%s.trailing_mult_after: %v", tctx, err))
+			} else if v <= 0 {
+				errs = append(errs, fmt.Sprintf("%s.trailing_mult_after: must be > 0, got %g", tctx, v))
+			}
+		}
+		if hasFrac {
+			if v, err := floatFromAnyChecked(m["tp_atr_fraction"]); err != nil {
+				errs = append(errs, fmt.Sprintf("%s.tp_atr_fraction: %v", tctx, err))
+			} else if v <= 0 {
+				errs = append(errs, fmt.Sprintf("%s.tp_atr_fraction: must be > 0, got %g", tctx, v))
+			}
+		}
+	}
+	return errs
+}

--- a/scheduler/trailing_tp_ratchet.go
+++ b/scheduler/trailing_tp_ratchet.go
@@ -135,9 +135,15 @@ func validateTrailingTPRatchetClose(sc *StrategyConfig, atrLabels []string, pref
 			usesRegime = true
 		}
 
-		// HL perps / manual only — the trailing-stop walker is HL-only.
-		if sc.Platform != "hyperliquid" || (sc.Type != "perps" && sc.Type != "manual") {
-			errs = append(errs, fmt.Sprintf("%s: %s is HL perps/manual only (got platform=%q type=%q)", sub, ref.Name, sc.Platform, sc.Type))
+		// HL perps only. The trailing walker (effectiveTrailingStopPct /
+		// runHyperliquidTrailingStopUpdate) early-returns for non-perps and the
+		// manual dispatch never runs it, so a stamped trail would be a silent
+		// no-op on manual — same reason sl_after: trail_from_here is rejected on
+		// manual. Scale-out-only tiers would still work via runManualCloseEval,
+		// but a pure-trailing manual config would never exit via the ratchet, so
+		// reject the whole family on manual rather than half-support it.
+		if sc.Platform != "hyperliquid" || sc.Type != "perps" {
+			errs = append(errs, fmt.Sprintf("%s: %s is HL perps only (got platform=%q type=%q)", sub, ref.Name, sc.Platform, sc.Type))
 		}
 
 		// The strategy-level trailing_stop_atr_mult is the initial (loose) trail
@@ -184,6 +190,19 @@ func validateTrailingTPRatchetClose(sc *StrategyConfig, atrLabels []string, pref
 					continue
 				}
 				errs = append(errs, validateRatchetTierList(tableRaw[label], fmt.Sprintf("%s.tp_tiers.%s", sub, label))...)
+			}
+			// Require exhaustive coverage of the classifier vocabulary (matching
+			// the unified per-regime close validator). An unconfigured regime
+			// would otherwise resolve to no tiers at runtime and silently never
+			// ratchet — the position would ride only the initial loose trail.
+			var missing []string
+			for _, l := range atrLabels {
+				if _, ok := tableRaw[l]; !ok {
+					missing = append(missing, l)
+				}
+			}
+			if len(missing) > 0 {
+				errs = append(errs, fmt.Sprintf("%s.tp_tiers: missing required regime labels: %s (must be exhaustive over the classifier vocabulary: %s)", sub, strings.Join(missing, ", "), strings.Join(atrLabels, ", ")))
 			}
 			continue
 		}

--- a/scheduler/trailing_tp_ratchet_test.go
+++ b/scheduler/trailing_tp_ratchet_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func ratchetFloatPtr(v float64) *float64 { return &v }
+
+func TestStampTrailingTPRatchetMult_MonotonicTighten(t *testing.T) {
+	pos := &Position{Quantity: 1.0}
+
+	// First stamp installs the multiple.
+	if !stampTrailingTPRatchetMult(pos, ratchetFloatPtr(2.0)) {
+		t.Fatalf("expected first stamp to apply")
+	}
+	if pos.PostTPTrailingATRMult == nil || *pos.PostTPTrailingATRMult != 2.0 {
+		t.Fatalf("got %v, want 2.0", pos.PostTPTrailingATRMult)
+	}
+
+	// A tighter (smaller) multiple wins.
+	if !stampTrailingTPRatchetMult(pos, ratchetFloatPtr(1.0)) {
+		t.Fatalf("expected tighter stamp to apply")
+	}
+	if *pos.PostTPTrailingATRMult != 1.0 {
+		t.Fatalf("got %v, want 1.0", *pos.PostTPTrailingATRMult)
+	}
+
+	// A looser (larger) multiple is ignored.
+	if stampTrailingTPRatchetMult(pos, ratchetFloatPtr(1.5)) {
+		t.Fatalf("expected looser stamp to be ignored")
+	}
+	if *pos.PostTPTrailingATRMult != 1.0 {
+		t.Fatalf("got %v, want 1.0 (unchanged)", *pos.PostTPTrailingATRMult)
+	}
+
+	// Equal multiple is ignored (no churn).
+	if stampTrailingTPRatchetMult(pos, ratchetFloatPtr(1.0)) {
+		t.Fatalf("expected equal stamp to be ignored")
+	}
+}
+
+func TestStampTrailingTPRatchetMult_Guards(t *testing.T) {
+	if stampTrailingTPRatchetMult(nil, ratchetFloatPtr(1.0)) {
+		t.Fatalf("nil position must no-op")
+	}
+	if stampTrailingTPRatchetMult(&Position{Quantity: 0}, ratchetFloatPtr(1.0)) {
+		t.Fatalf("flat position must no-op")
+	}
+	if stampTrailingTPRatchetMult(&Position{Quantity: 1}, nil) {
+		t.Fatalf("nil mult must no-op")
+	}
+	if stampTrailingTPRatchetMult(&Position{Quantity: 1}, ratchetFloatPtr(0)) {
+		t.Fatalf("non-positive mult must no-op")
+	}
+}
+
+func TestIsTrailingTPRatchetCloseName(t *testing.T) {
+	for _, n := range []string{"trailing_tp_ratchet", "trailing_tp_ratchet_regime", " TRAILING_TP_RATCHET "} {
+		if !isTrailingTPRatchetCloseName(n) {
+			t.Errorf("expected %q to be a trailing-TP-ratchet name", n)
+		}
+	}
+	for _, n := range []string{"tiered_tp_atr", "tiered_tp_atr_regime", ""} {
+		if isTrailingTPRatchetCloseName(n) {
+			t.Errorf("expected %q NOT to be a trailing-TP-ratchet name", n)
+		}
+	}
+	if !isTrailingTPRatchetRegimeCloseName("trailing_tp_ratchet_regime") {
+		t.Errorf("regime variant not detected")
+	}
+	if isTrailingTPRatchetRegimeCloseName("trailing_tp_ratchet") {
+		t.Errorf("plain variant misclassified as regime")
+	}
+}
+
+func ratchetSC(name string, params map[string]interface{}, trail *float64) *StrategyConfig {
+	return &StrategyConfig{
+		ID:                  "s1",
+		Platform:            "hyperliquid",
+		Type:                "perps",
+		TrailingStopATRMult: trail,
+		CloseStrategy:       &StrategyRef{Name: name, Params: params},
+	}
+}
+
+func plainTiers() map[string]interface{} {
+	return map[string]interface{}{
+		"tp_tiers": []interface{}{
+			map[string]interface{}{"atr_multiple": 1.5, "close_fraction": 0.0, "trailing_mult_after": 2.0},
+			map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 0.3, "tp_atr_fraction": 0.33},
+		},
+	}
+}
+
+func TestValidateTrailingTPRatchetClose_PlainOK(t *testing.T) {
+	sc := ratchetSC("trailing_tp_ratchet", plainTiers(), ratchetFloatPtr(3.0))
+	errs, usesRegime := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels, "strategy[s1]")
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+	if usesRegime {
+		t.Fatalf("plain variant must not set usesRegime")
+	}
+}
+
+func TestValidateTrailingTPRatchetClose_RegimeOK(t *testing.T) {
+	params := map[string]interface{}{
+		"tp_tiers": map[string]interface{}{
+			"trending_up":   []interface{}{map[string]interface{}{"atr_multiple": 1.5, "close_fraction": 0.0, "trailing_mult_after": 2.0}},
+			"ranging":       []interface{}{map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.25, "trailing_mult_after": 1.5}},
+			"trending_down": []interface{}{map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 1.0}},
+		},
+	}
+	sc := ratchetSC("trailing_tp_ratchet_regime", params, ratchetFloatPtr(3.0))
+	errs, usesRegime := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels, "strategy[s1]")
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+	if !usesRegime {
+		t.Fatalf("regime variant must set usesRegime")
+	}
+}
+
+func TestValidateTrailingTPRatchetClose_MissingTrailingStop(t *testing.T) {
+	sc := ratchetSC("trailing_tp_ratchet", plainTiers(), nil)
+	errs, _ := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels, "strategy[s1]")
+	if !hasErrContaining(errs, "positive trailing_stop_atr_mult") {
+		t.Fatalf("expected trailing_stop_atr_mult error, got %v", errs)
+	}
+}
+
+func TestValidateTrailingTPRatchetClose_BothTrailForms(t *testing.T) {
+	params := map[string]interface{}{
+		"tp_tiers": []interface{}{
+			map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 2.0, "tp_atr_fraction": 0.5},
+		},
+	}
+	sc := ratchetSC("trailing_tp_ratchet", params, ratchetFloatPtr(3.0))
+	errs, _ := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels, "strategy[s1]")
+	if !hasErrContaining(errs, "mutually exclusive") {
+		t.Fatalf("expected mutual-exclusivity error, got %v", errs)
+	}
+}
+
+func TestValidateTrailingTPRatchetClose_BadRegimeLabel(t *testing.T) {
+	params := map[string]interface{}{
+		"tp_tiers": map[string]interface{}{
+			"trending_up_clean": []interface{}{map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 2.0}},
+		},
+	}
+	sc := ratchetSC("trailing_tp_ratchet_regime", params, ratchetFloatPtr(3.0))
+	// adx vocabulary rejects the composite label.
+	errs, _ := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels, "strategy[s1]")
+	if !hasErrContaining(errs, "unknown regime label") {
+		t.Fatalf("expected unknown-label error, got %v", errs)
+	}
+}
+
+func TestValidateTrailingTPRatchetClose_CompositeLabelsOK(t *testing.T) {
+	params := map[string]interface{}{
+		"tp_tiers": map[string]interface{}{
+			"trending_up_clean": []interface{}{map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.0, "trailing_mult_after": 2.0}},
+			"ranging_volatile":  []interface{}{map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.5, "trailing_mult_after": 0.5}},
+		},
+	}
+	sc := ratchetSC("trailing_tp_ratchet_regime", params, ratchetFloatPtr(3.0))
+	composite := []string{
+		"trending_up_clean", "trending_up_choppy", "trending_down_clean",
+		"trending_down_choppy", "ranging_quiet", "ranging_volatile", "ranging_directional",
+	}
+	errs, _ := validateTrailingTPRatchetClose(sc, composite, "strategy[s1]")
+	if len(errs) != 0 {
+		t.Fatalf("expected composite labels to validate, got %v", errs)
+	}
+}
+
+func TestValidateTrailingTPRatchetClose_UnknownParam(t *testing.T) {
+	params := plainTiers()
+	params["use_defaults"] = true
+	sc := ratchetSC("trailing_tp_ratchet", params, ratchetFloatPtr(3.0))
+	errs, _ := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels, "strategy[s1]")
+	if !hasErrContaining(errs, "unknown param") {
+		t.Fatalf("expected unknown-param error, got %v", errs)
+	}
+}
+
+func TestValidateTrailingTPRatchetClose_WrongPlatform(t *testing.T) {
+	sc := ratchetSC("trailing_tp_ratchet", plainTiers(), ratchetFloatPtr(3.0))
+	sc.Platform = "binanceus"
+	sc.Type = "spot"
+	errs, _ := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels, "strategy[s1]")
+	if !hasErrContaining(errs, "HL perps/manual only") {
+		t.Fatalf("expected platform error, got %v", errs)
+	}
+}
+
+func TestTrailingTPRatchetParamsEqualForReload(t *testing.T) {
+	a := ratchetSC("trailing_tp_ratchet", plainTiers(), ratchetFloatPtr(3.0))
+	b := ratchetSC("trailing_tp_ratchet", plainTiers(), ratchetFloatPtr(3.0))
+	if !trailingTPRatchetParamsEqualForReload(*a, *b) {
+		t.Fatalf("identical tier tables must compare equal")
+	}
+
+	// A tier-table edit is a shape change.
+	c := ratchetSC("trailing_tp_ratchet", map[string]interface{}{
+		"tp_tiers": []interface{}{map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.5, "trailing_mult_after": 1.0}},
+	}, ratchetFloatPtr(3.0))
+	if trailingTPRatchetParamsEqualForReload(*a, *c) {
+		t.Fatalf("changed tier table must compare unequal")
+	}
+
+	// Non-ratchet configs compare equal (no gating).
+	d := &StrategyConfig{Platform: "hyperliquid", Type: "perps", CloseStrategy: &StrategyRef{Name: "tiered_tp_atr"}}
+	e := &StrategyConfig{Platform: "hyperliquid", Type: "perps", CloseStrategy: &StrategyRef{Name: "tiered_tp_atr"}}
+	if !trailingTPRatchetParamsEqualForReload(*d, *e) {
+		t.Fatalf("non-ratchet configs must compare equal")
+	}
+}
+
+func hasErrContaining(errs []string, sub string) bool {
+	for _, e := range errs {
+		if strings.Contains(e, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/scheduler/trailing_tp_ratchet_test.go
+++ b/scheduler/trailing_tp_ratchet_test.go
@@ -158,20 +158,43 @@ func TestValidateTrailingTPRatchetClose_BadRegimeLabel(t *testing.T) {
 }
 
 func TestValidateTrailingTPRatchetClose_CompositeLabelsOK(t *testing.T) {
-	params := map[string]interface{}{
-		"tp_tiers": map[string]interface{}{
-			"trending_up_clean": []interface{}{map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.0, "trailing_mult_after": 2.0}},
-			"ranging_volatile":  []interface{}{map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.5, "trailing_mult_after": 0.5}},
-		},
-	}
-	sc := ratchetSC("trailing_tp_ratchet_regime", params, ratchetFloatPtr(3.0))
 	composite := []string{
 		"trending_up_clean", "trending_up_choppy", "trending_down_clean",
 		"trending_down_choppy", "ranging_quiet", "ranging_volatile", "ranging_directional",
 	}
+	// Exhaustive coverage over all 7 composite labels.
+	tiers := map[string]interface{}{}
+	for _, l := range composite {
+		tiers[l] = []interface{}{map[string]interface{}{"atr_multiple": 1.5, "close_fraction": 0.0, "trailing_mult_after": 1.0}}
+	}
+	sc := ratchetSC("trailing_tp_ratchet_regime", map[string]interface{}{"tp_tiers": tiers}, ratchetFloatPtr(3.0))
 	errs, _ := validateTrailingTPRatchetClose(sc, composite, "strategy[s1]")
 	if len(errs) != 0 {
 		t.Fatalf("expected composite labels to validate, got %v", errs)
+	}
+}
+
+func TestValidateTrailingTPRatchetClose_MissingRegimeLabel(t *testing.T) {
+	// Only 2 of the 3 adx labels supplied → exhaustiveness error.
+	params := map[string]interface{}{
+		"tp_tiers": map[string]interface{}{
+			"trending_up": []interface{}{map[string]interface{}{"atr_multiple": 1.5, "close_fraction": 0.0, "trailing_mult_after": 2.0}},
+			"ranging":     []interface{}{map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.25, "trailing_mult_after": 1.5}},
+		},
+	}
+	sc := ratchetSC("trailing_tp_ratchet_regime", params, ratchetFloatPtr(3.0))
+	errs, _ := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels, "strategy[s1]")
+	if !hasErrContaining(errs, "missing required regime labels") {
+		t.Fatalf("expected missing-labels error, got %v", errs)
+	}
+}
+
+func TestValidateTrailingTPRatchetClose_ManualRejected(t *testing.T) {
+	sc := ratchetSC("trailing_tp_ratchet", plainTiers(), ratchetFloatPtr(3.0))
+	sc.Type = "manual"
+	errs, _ := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels, "strategy[s1]")
+	if !hasErrContaining(errs, "HL perps only") {
+		t.Fatalf("expected perps-only error for manual, got %v", errs)
 	}
 }
 
@@ -190,7 +213,7 @@ func TestValidateTrailingTPRatchetClose_WrongPlatform(t *testing.T) {
 	sc.Platform = "binanceus"
 	sc.Type = "spot"
 	errs, _ := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels, "strategy[s1]")
-	if !hasErrContaining(errs, "HL perps/manual only") {
+	if !hasErrContaining(errs, "HL perps only") {
 		t.Fatalf("expected platform error, got %v", errs)
 	}
 }

--- a/shared_strategies/close/registry.py
+++ b/shared_strategies/close/registry.py
@@ -17,6 +17,7 @@ from tiered_tp_atr_live import evaluate as tiered_tp_atr_live_evaluate
 from tiered_tp_atr_regime import evaluate as tiered_tp_atr_regime_evaluate
 from tiered_tp_atr_live_regime import evaluate as tiered_tp_atr_live_regime_evaluate
 from tiered_tp_atr_live_regime_dynamic import evaluate as tiered_tp_atr_live_regime_dynamic_evaluate
+from trailing_tp_ratchet import evaluate as trailing_tp_ratchet_evaluate
 from tiered_tp_pct import DEFAULT_TIERS as DEFAULT_PCT_TIERS
 from tiered_tp_pct import evaluate as tiered_tp_pct_evaluate
 
@@ -80,7 +81,19 @@ def _normalize_result(name: str, result: Optional[dict]) -> dict:
         close_fraction = 0.0
     close_fraction = min(max(close_fraction, 0.0), 1.0)
     reason = str(result.get("reason") or f"{name}:no_reason")
-    return {"close_fraction": close_fraction, "reason": reason}
+    out = {"close_fraction": close_fraction, "reason": reason}
+    # #844: trailing_tp_ratchet emits the tightened trailing ATR multiple for the
+    # highest cleared tier. Pass it through (positive only) so the composition
+    # layer can surface it to the Go runtime.
+    trail = result.get("post_tp_trailing_atr_mult")
+    if trail is not None:
+        try:
+            trail = float(trail)
+        except (TypeError, ValueError):
+            trail = None
+        if trail is not None and trail > 0:
+            out["post_tp_trailing_atr_mult"] = trail
+    return out
 
 
 def _rewrite_deprecated_close(name: str, params: Optional[dict]) -> tuple[str, dict]:
@@ -149,3 +162,17 @@ register(
     "Unified per-regime TP/SL — live ATR-regime re-resolution (#843; HL live uses on-chain sync)",
     {"atr_source": "live", "regime_confirm_cycles": 2},
 )(tiered_tp_atr_live_regime_dynamic_evaluate)
+
+register(
+    "trailing_tp_ratchet",
+    "Trailing ATR stop ratcheted by cleared TP tiers — close_fraction 0 = trail-only rung (#844)",
+    # default_params intentionally empty: the operator supplies tp_tiers (each
+    # tier carries its own trail tightening). Tier triggers use frozen entry ATR.
+    {},
+)(trailing_tp_ratchet_evaluate)
+
+register(
+    "trailing_tp_ratchet_regime",
+    "Regime-keyed trailing-TP ratchet — tp_tiers table frozen at open via Position.Regime (#844)",
+    {},
+)(trailing_tp_ratchet_evaluate)

--- a/shared_strategies/close/test_close_registry.py
+++ b/shared_strategies/close/test_close_registry.py
@@ -28,6 +28,8 @@ def test_build_close_registry_filters_valid_platforms(registry):
             "tiered_tp_atr_regime",
             "tiered_tp_atr_live_regime",
             "tiered_tp_atr_live_regime_dynamic",
+            "trailing_tp_ratchet",
+            "trailing_tp_ratchet_regime",
         }
 
 

--- a/shared_strategies/close/test_trailing_tp_ratchet.py
+++ b/shared_strategies/close/test_trailing_tp_ratchet.py
@@ -1,0 +1,137 @@
+"""Tests for the trailing_tp_ratchet close evaluator (#844)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_evaluator():
+    here = Path(__file__).resolve().parent
+    if str(here) not in sys.path:
+        sys.path.insert(0, str(here))  # so the module's `from _helpers import ...` resolves
+    path = here / "trailing_tp_ratchet.py"
+    spec = importlib.util.spec_from_file_location("_trailing_tp_ratchet_under_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def ev():
+    return _load_evaluator()
+
+
+def _pos(qty=1.0, initial=1.0, regime="trending_up", side="long", avg=100.0, atr=10.0):
+    return {
+        "side": side,
+        "avg_cost": avg,
+        "current_quantity": qty,
+        "initial_quantity": initial,
+        "entry_atr": atr,
+        "regime": regime,
+    }
+
+
+REGIME_PARAMS = {
+    "tp_tiers": {
+        "trending_up": [
+            {"atr_multiple": 1.5, "close_fraction": 0.0, "trailing_mult_after": 2.0},
+            {"atr_multiple": 3.0, "close_fraction": 0.3, "tp_atr_fraction": 0.33},
+        ],
+        "ranging": [
+            {"atr_multiple": 1.0, "close_fraction": 0.25, "trailing_mult_after": 1.5},
+        ],
+    }
+}
+
+
+def test_trail_only_rung_no_close(ev):
+    # +1.6 ATR clears tier1 (close_fraction 0) → trail tightens, no scale-out.
+    out = ev.evaluate(_pos(), {"mark_price": 116.0}, REGIME_PARAMS)
+    assert out["close_fraction"] == 0.0
+    assert out["post_tp_trailing_atr_mult"] == 2.0
+
+
+def test_scale_out_and_tighten(ev):
+    # +3.1 ATR clears tier2 → close 0.3 and trail = 0.33 * 3.0 ≈ 0.99 (tightest cleared).
+    out = ev.evaluate(_pos(), {"mark_price": 131.0}, REGIME_PARAMS)
+    assert out["close_fraction"] == pytest.approx(0.3)
+    assert out["post_tp_trailing_atr_mult"] == pytest.approx(0.99)
+
+
+def test_double_close_guard(ev):
+    # Already scaled out 0.3 of initial (qty 0.7 of initial 1.0); re-hitting tier2
+    # closes nothing more, but the trail still reports tightest cleared.
+    out = ev.evaluate(_pos(qty=0.7, initial=1.0), {"mark_price": 131.0}, REGIME_PARAMS)
+    assert out["close_fraction"] == 0.0
+    assert out["post_tp_trailing_atr_mult"] == pytest.approx(0.99)
+
+
+def test_not_hit_noop(ev):
+    out = ev.evaluate(_pos(), {"mark_price": 105.0}, REGIME_PARAMS)
+    assert out == {"close_fraction": 0.0, "reason": "noop:not_hit"}
+
+
+def test_regime_selection(ev):
+    # ranging table: +1.1 ATR clears its single tier (close 0.25, trail 1.5).
+    out = ev.evaluate(_pos(regime="ranging"), {"mark_price": 111.0}, REGIME_PARAMS)
+    assert out["close_fraction"] == pytest.approx(0.25)
+    assert out["post_tp_trailing_atr_mult"] == 1.5
+
+
+def test_unknown_regime_noop(ev):
+    out = ev.evaluate(_pos(regime="trending_down"), {"mark_price": 131.0}, REGIME_PARAMS)
+    assert out["close_fraction"] == 0.0
+    assert out["reason"] == "noop:no_tiers"
+
+
+def test_plain_list_form(ev):
+    params = {"tp_tiers": [{"atr_multiple": 1.0, "close_fraction": 0.25, "trailing_mult_after": 1.5}]}
+    out = ev.evaluate(_pos(regime=""), {"mark_price": 111.0}, params)
+    assert out["close_fraction"] == pytest.approx(0.25)
+    assert out["post_tp_trailing_atr_mult"] == 1.5
+
+
+def test_pure_trailing_all_zero(ev):
+    # Every tier close_fraction 0 → never scales out; only the trail tightens.
+    params = {"tp_tiers": [
+        {"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 2.0},
+        {"atr_multiple": 2.0, "close_fraction": 0.0, "trailing_mult_after": 1.0},
+    ]}
+    out = ev.evaluate(_pos(regime=""), {"mark_price": 125.0}, params)
+    assert out["close_fraction"] == 0.0
+    assert out["post_tp_trailing_atr_mult"] == 1.0  # tightest of the two cleared
+
+
+def test_monotonic_tightest_among_cleared(ev):
+    # Mis-ordered trails: higher tier looser. Evaluator returns the tightest.
+    params = {"tp_tiers": [
+        {"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 1.0},
+        {"atr_multiple": 2.0, "close_fraction": 0.0, "trailing_mult_after": 3.0},
+    ]}
+    out = ev.evaluate(_pos(regime=""), {"mark_price": 125.0}, params)
+    assert out["post_tp_trailing_atr_mult"] == 1.0
+
+
+def test_short_side(ev):
+    params = {"tp_tiers": [{"atr_multiple": 1.0, "close_fraction": 0.5, "trailing_mult_after": 1.5}]}
+    # short: profit when mark < avg. mark 88 = -1.2 ATR profit → tier clears.
+    out = ev.evaluate(_pos(regime="", side="short"), {"mark_price": 88.0}, params)
+    assert out["close_fraction"] == pytest.approx(0.5)
+    assert out["post_tp_trailing_atr_mult"] == 1.5
+
+
+def test_missing_entry_atr_noop(ev):
+    out = ev.evaluate(_pos(atr=0.0, regime=""), {"mark_price": 131.0},
+                      {"tp_tiers": [{"atr_multiple": 1.0, "close_fraction": 0.5}]})
+    assert out == {"close_fraction": 0.0, "reason": "noop:missing_entry_atr"}
+
+
+def test_tier_without_trail_spec(ev):
+    # A tier with neither trailing_mult_after nor tp_atr_fraction: closes, no trail key.
+    params = {"tp_tiers": [{"atr_multiple": 1.0, "close_fraction": 0.5}]}
+    out = ev.evaluate(_pos(regime=""), {"mark_price": 115.0}, params)
+    assert out["close_fraction"] == pytest.approx(0.5)
+    assert "post_tp_trailing_atr_mult" not in out

--- a/shared_strategies/close/trailing_tp_ratchet.py
+++ b/shared_strategies/close/trailing_tp_ratchet.py
@@ -1,0 +1,148 @@
+"""Trailing-stop ratchet close evaluator (#844).
+
+A trailing ATR stop where each cleared TP tier (a) tightens the trailing ATR
+multiple and (b) optionally scales out a fraction at that tier's price. A tier
+with ``close_fraction == 0`` is a pure trail-tightener; the position's remainder
+exits via the trailing stop once price reverses. The "pure trailing" strategy is
+just the special case where every tier sets ``close_fraction: 0``.
+
+Frozen-at-open: the tier table is resolved once from ``position["regime"]`` (the
+label stamped on the Go-side Position at entry) and held for the life of the
+trade — it does not re-resolve if the regime flips mid-position. Two registered
+names share this evaluator:
+
+  - ``trailing_tp_ratchet``        — ``tp_tiers`` is a plain list (regime ignored,
+                                      or selected via a ``"default"`` key)
+  - ``trailing_tp_ratchet_regime`` — ``tp_tiers`` is a ``{regime_label: [tiers]}`` map
+
+Each tier is ``{atr_multiple, close_fraction, trailing_mult_after | tp_atr_fraction}``
+where ``close_fraction`` is the *cumulative* target closed fraction at that tier
+(same semantics as ``tiered_tp_atr``; the double-close guard converts it to the
+incremental fraction-of-current-quantity). The new trail distance is either
+``trailing_mult_after`` (absolute ATR multiple) or ``tp_atr_fraction`` (relative:
+``fraction × tier.atr_multiple``) — mutually exclusive per tier.
+
+Output adds ``post_tp_trailing_atr_mult``: the tightest trailing ATR multiple
+among the cleared tiers. The Go runtime stamps it onto
+``Position.PostTPTrailingATRMult`` (monotonically tightening only) and the
+trailing-stop walker takes over at that distance. Unlike ``tiered_tp_atr``, the
+final tier's ``close_fraction`` is NOT coerced to 1.0 — the remainder is meant
+to ride the trail to exit.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from _helpers import (
+    current_close_fraction,
+    float_from,
+    tier_list_from_params,
+)
+
+
+def _resolve_tier_list(raw, regime: str):
+    """Select the concrete tier list for this position.
+
+    ``raw`` is either a plain list (``trailing_tp_ratchet``) or a regime-keyed
+    map (``trailing_tp_ratchet_regime``). For the map form, select the list under
+    the position's regime label, falling back to a ``"default"`` key.
+    """
+    if isinstance(raw, dict):
+        if regime and isinstance(raw.get(regime), list):
+            return raw.get(regime)
+        return raw.get("default")
+    return raw
+
+
+def _resolve_tier_trail(tier: dict, trigger: float) -> Optional[float]:
+    """Resolve a tier's new trailing ATR multiple.
+
+    ``trailing_mult_after`` (absolute) takes precedence over ``tp_atr_fraction``
+    (relative to the firing tier). Returns None when the tier specifies neither
+    (the trail is left unchanged at that tier) or the value is non-positive.
+    """
+    mult_after = tier.get("trailing_mult_after")
+    if mult_after is not None:
+        try:
+            value = float(mult_after)
+        except (TypeError, ValueError):
+            return None
+        return value if value > 0 else None
+    tp_frac = tier.get("tp_atr_fraction")
+    if tp_frac is not None and trigger > 0:
+        try:
+            frac = float(tp_frac)
+        except (TypeError, ValueError):
+            return None
+        return frac * trigger if frac > 0 else None
+    return None
+
+
+def _parse_tiers(raw) -> List[Tuple[float, float, Optional[float]]]:
+    """Parse a tier list into sorted ``(atr_multiple, close_fraction, trail)``
+    tuples. Malformed tiers are skipped; the list is sorted by ascending
+    ``atr_multiple``."""
+    parsed: List[Tuple[float, float, Optional[float]]] = []
+    for tier in raw or []:
+        if not isinstance(tier, dict):
+            continue
+        trigger_raw = tier.get("atr_multiple", tier.get("atr", tier.get("multiple")))
+        try:
+            trigger = float(trigger_raw)
+        except (TypeError, ValueError):
+            continue
+        if trigger < 0:
+            continue
+        frac_raw = tier.get("close_fraction", tier.get("fraction"))
+        try:
+            frac = float(frac_raw) if frac_raw is not None else 0.0
+        except (TypeError, ValueError):
+            frac = 0.0
+        frac = min(max(frac, 0.0), 1.0)
+        parsed.append((trigger, frac, _resolve_tier_trail(tier, trigger)))
+    parsed.sort(key=lambda item: item[0])
+    return parsed
+
+
+def evaluate(position: dict, market: dict, params: dict) -> dict:
+    avg_cost = float_from(position, "avg_cost")
+    current_quantity = float_from(position, "current_quantity")
+    entry_atr = float_from(position, "entry_atr")
+    side = str(position.get("side", "") or "").strip().lower()
+    regime = str(position.get("regime", "") or "").strip()
+    mark_price = float_from(market, "mark_price")
+
+    if mark_price <= 0:
+        return {"close_fraction": 0.0, "reason": "noop:missing_mark_price"}
+    if avg_cost <= 0 or current_quantity <= 0 or side not in ("long", "short"):
+        return {"close_fraction": 0.0, "reason": "noop:missing_position"}
+    if entry_atr <= 0:
+        return {"close_fraction": 0.0, "reason": "noop:missing_entry_atr"}
+
+    tiers = _parse_tiers(_resolve_tier_list(tier_list_from_params(params), regime))
+    if not tiers:
+        return {"close_fraction": 0.0, "reason": "noop:no_tiers"}
+
+    # Profit distance in ATR units, using the frozen entry ATR (tier triggers
+    # never re-scale with live ATR — matches tiered_tp_atr.py:51-53).
+    profit_distance = mark_price - avg_cost if side == "long" else avg_cost - mark_price
+    atr_profit = profit_distance / entry_atr
+    cleared = [(m, f, t) for (m, f, t) in tiers if atr_profit >= m]
+    if not cleared:
+        return {"close_fraction": 0.0, "reason": "noop:not_hit"}
+
+    multiple, cumulative_fraction, _ = cleared[-1]
+    # Tightest trail among the cleared tiers — Go monotonic-guards the stamp so a
+    # mis-ordered table (looser trail on a higher tier) can never loosen.
+    trail_candidates = [t for (_, _, t) in cleared if t is not None and t > 0]
+    new_trail = min(trail_candidates) if trail_candidates else None
+
+    close_fraction = current_close_fraction(position, cumulative_fraction)
+    result = {
+        "close_fraction": close_fraction,
+        "reason": f"trailing_tp_ratchet:{regime or 'default'}:{multiple:g}",
+    }
+    if new_trail is not None:
+        result["post_tp_trailing_atr_mult"] = new_trail
+    return result

--- a/shared_strategies/close/trailing_tp_ratchet.py
+++ b/shared_strategies/close/trailing_tp_ratchet.py
@@ -22,6 +22,14 @@ incremental fraction-of-current-quantity). The new trail distance is either
 ``trailing_mult_after`` (absolute ATR multiple) or ``tp_atr_fraction`` (relative:
 ``fraction × tier.atr_multiple``) — mutually exclusive per tier.
 
+Note on ``tp_atr_fraction``: because the trail is ``fraction × atr_multiple``, a
+*constant* fraction across tiers yields a *larger* (looser) absolute trail at
+higher tiers. Since the runtime only ever tightens (Go monotonic-stamps and this
+evaluator returns the tightest trail among cleared tiers), such a table pins the
+trail at the lowest cleared tier's value rather than tightening further. If you
+want each successive tier to tighten the trail, either use ``trailing_mult_after``
+with explicitly decreasing values, or shrink ``tp_atr_fraction`` as tiers rise.
+
 Output adds ``post_tp_trailing_atr_mult``: the tightest trailing ATR multiple
 among the cleared tiers. The Go runtime stamps it onto
 ``Position.PostTPTrailingATRMult`` (monotonically tightening only) and the

--- a/shared_tools/strategy_composition.py
+++ b/shared_tools/strategy_composition.py
@@ -25,6 +25,10 @@ POSITION_CONTEXT_PARAM_KEYS = {"side", "avg_cost", "current_quantity", "initial_
 class CloseEvaluation:
     strategy: str
     close_fraction: float
+    # #844: trailing_tp_ratchet emits the tightened trailing ATR multiple for
+    # the highest cleared tier. None for every other close evaluator. The Go
+    # runtime stamps it onto Position.PostTPTrailingATRMult (monotonic tighten).
+    post_tp_trailing_atr_mult: Optional[float] = None
 
 
 @dataclass
@@ -355,6 +359,7 @@ def evaluate_open_close(
                 close_evals.append(CloseEvaluation(
                     strategy=resolved,
                     close_fraction=result.get("close_fraction", 0.0),
+                    post_tp_trailing_atr_mult=result.get("post_tp_trailing_atr_mult"),
                 ))
                 continue
             except ValueError as exc:
@@ -385,7 +390,7 @@ def finalize_decision(
     signal = evaluation.open_signal if open_signal is None else normalize_signal(open_signal)
     open_action = open_action_from_signal(signal)
     close_fraction, close_strategy = max_close_fraction(evaluation.close_evaluations)
-    return {
+    decision = {
         "open_strategy": evaluation.open_strategy,
         "close_strategies": evaluation.close_strategies,
         "open_action": open_action,
@@ -393,3 +398,20 @@ def finalize_decision(
         "close_strategy": close_strategy,
         "signal": compose_signal(open_action, close_fraction, position_side),
     }
+    # #844: surface the tightest trail-ratchet multiple across close evaluators.
+    # close_fraction may be 0 on a trail-only rung, so this is independent of the
+    # max-close winner. The Go runtime monotonic-tightens from this value.
+    trailing_mult: Optional[float] = None
+    for ev in evaluation.close_evaluations:
+        m = ev.post_tp_trailing_atr_mult
+        if m is None:
+            continue
+        try:
+            m = float(m)
+        except (TypeError, ValueError):
+            continue
+        if m > 0 and (trailing_mult is None or m < trailing_mult):
+            trailing_mult = m
+    if trailing_mult is not None:
+        decision["post_tp_trailing_atr_mult"] = trailing_mult
+    return decision


### PR DESCRIPTION
## Summary

Adds `trailing_tp_ratchet` and `trailing_tp_ratchet_regime` close evaluators: a trailing ATR stop where each cleared TP tier (a) tightens the trailing ATR multiple and (b) optionally scales out a fraction. `close_fraction: 0` is a pure trail-tightening rung; all-zero tiers = a pure trailing strategy. Per-tier values are regime-keyed and frozen at open.

**Key design:** No on-chain TPs are placed. The Python evaluator detects tier-fills by profit-distance (frozen entry ATR) and returns `post_tp_trailing_atr_mult`; Go stamps it onto `Position.PostTPTrailingATRMult` (monotonically tighten-only), and the existing `effectiveTrailingStopPct` / `runHyperliquidTrailingStopUpdate` trails at the new distance — no new live path.

## Changes

- **`shared_strategies/close/trailing_tp_ratchet.py`** (new): evaluator shared by both names; plain list and regime-keyed `{label: [tiers]}` `tp_tiers`; both `trailing_mult_after` (absolute) and `tp_atr_fraction` (relative) trail specs; double-close guard; returns tightest trail among all cleared tiers.
- **`shared_strategies/close/registry.py`**: register both names; make `_normalize_result` pass through `post_tp_trailing_atr_mult`.
- **`shared_tools/strategy_composition.py`**: thread trail field through `CloseEvaluation` → `finalize_decision` → JSON output.
- **`scheduler/trailing_tp_ratchet.go`** (new): name classification, `stampTrailingTPRatchetMult` (monotonic), `validateTrailingTPRatchetClose` (HL perps/manual only, requires `trailing_stop_atr_mult`, regime-label check vs adx/composite vocabulary, unknown-key guard), hot-reload equality helper.
- **`scheduler/strategy_composition.go`**: add `PostTPTrailingATRMult` to `StrategyDecisionFields`.
- **`scheduler/main.go`**: call `applyTrailingTPRatchet` in `executeHyperliquidResultDeferredOpen` (perps paper+live, even on trail-only rungs) and in the manual close path.
- **`scheduler/manual.go`**: extend `runManualCloseEval` to return the trail multiple.
- **`scheduler/regime_atr.go`**: dispatch both names to `validateTrailingTPRatchetClose` in `validateRegimeATRConfig`.
- **`scheduler/config_migration.go`**: add both names to `closeStrategyOwnedKeys`.
- **`scheduler/config_migration_v15.go`**: handle regime-keyed `tp_tiers` dict in `canonicalizeCloseParams`.
- **`scheduler/config_reload.go`**: block tier-table shape changes while a position is open.
- **`backtest/backtester.py`**: parity — seed initial trail from `trailing_stop_atr_mult` at open, ratchet per bar with one-bar delay, reuse `_walk_trail` / `_sl_hit`.

## Test plan

- [x] 12 Python evaluator unit tests (`test_trailing_tp_ratchet.py`): trail-only rung, scale-out+tighten, double-close guard, monotonic tightest-trail, `tp_atr_fraction` vs `trailing_mult_after`, regime-map selection, pure-trailing, short side, missing ATR no-op
- [x] 14 Go tests (`trailing_tp_ratchet_test.go`): monotonic stamp, guards, name classification, accept/reject validation (missing trail, both trail forms, bad/composite regime labels, wrong platform, unknown param, hot-reload equality)
- [x] 3 backtest regression tests: scale-out→trail-exit, pure-trailing single-exit, `tp_atr_fraction` trail form
- [x] Full Go suite: `ok 25.5s`; full Python suite: **846 passed**
- [x] `go-trader probe` smoke: adx (3-state) and composite (7-state) configs load/validate; missing `trailing_stop_atr_mult` and composite label on adx window both reject with clear errors

Closes #844

---
LLM: Claude Opus 4.8 (1M) | high