### PR TITLE
fix(regime): unit-consistent composite (7-state) classifier via ATR-efficiency

### DIFF
--- a/scheduler/regime_window_spec.go
+++ b/scheduler/regime_window_spec.go
@@ -14,16 +14,20 @@ const (
 
 // Default composite thresholds (#795); operators may override per window.
 var defaultCompositeThresholds = RegimeCompositeThresholds{
-	ReturnPct: 0.05,
-	RangePct:  0.03,
-	ADX:       25.0,
+	ReturnPct:  0.05,
+	RangePct:   0.03,
+	ADX:        25.0,
+	Efficiency: 0.5,
 }
 
-// RegimeCompositeThresholds tunes the 3-tuple mapper for classifier=composite.
+// RegimeCompositeThresholds tunes the composite metric mapper. ReturnPct/RangePct
+// gate the ATR-efficiency net-move/range; Efficiency is the Kaufman efficiency
+// ratio (∈ (0,1]) that splits clean vs choppy trends; ADX corroborates.
 type RegimeCompositeThresholds struct {
-	ReturnPct float64 `json:"return_pct"`
-	RangePct  float64 `json:"range_pct"`
-	ADX       float64 `json:"adx"`
+	ReturnPct  float64 `json:"return_pct"`
+	RangePct   float64 `json:"range_pct"`
+	ADX        float64 `json:"adx"`
+	Efficiency float64 `json:"efficiency"`
 }
 
 func (t RegimeCompositeThresholds) withDefaults() RegimeCompositeThresholds {
@@ -36,6 +40,9 @@ func (t RegimeCompositeThresholds) withDefaults() RegimeCompositeThresholds {
 	}
 	if t.ADX > 0 {
 		out.ADX = t.ADX
+	}
+	if t.Efficiency > 0 {
+		out.Efficiency = t.Efficiency
 	}
 	return out
 }
@@ -179,6 +186,9 @@ func validateRegimeWindowSpec(name string, spec RegimeWindowSpec, rc *RegimeConf
 		if th.ADX <= 0 || th.ADX > 100 {
 			errs = append(errs, fmt.Sprintf("%s: thresholds.adx must be in (0, 100], got %g", prefix, th.ADX))
 		}
+		if th.Efficiency <= 0 || th.Efficiency > 1 {
+			errs = append(errs, fmt.Sprintf("%s: thresholds.efficiency must be in (0, 1], got %g", prefix, th.Efficiency))
+		}
 	default:
 		errs = append(errs, fmt.Sprintf("%s: classifier must be %q or %q, got %q", prefix, regimeClassifierADX, regimeClassifierComposite, spec.Classifier))
 	}
@@ -306,8 +316,8 @@ func formatRegimeWindowSpecInspect(name string, spec RegimeWindowSpec, rc *Regim
 	cls := resolved.effectiveClassifier()
 	if cls == regimeClassifierComposite && resolved.Thresholds != nil {
 		th := resolved.Thresholds
-		return fmt.Sprintf("%s: classifier=%s period=%d thresholds(return_pct=%g range_pct=%g adx=%g)",
-			name, cls, resolved.Period, th.ReturnPct, th.RangePct, th.ADX)
+		return fmt.Sprintf("%s: classifier=%s period=%d thresholds(return_pct=%g range_pct=%g adx=%g efficiency=%g)",
+			name, cls, resolved.Period, th.ReturnPct, th.RangePct, th.ADX, th.Efficiency)
 	}
 	return fmt.Sprintf("%s: classifier=%s period=%d adx_threshold=%g", name, cls, resolved.Period, resolved.ADXThreshold)
 }

--- a/shared_tools/regime.py
+++ b/shared_tools/regime.py
@@ -64,6 +64,7 @@ _DEFAULT_COMPOSITE_THRESHOLDS = {
     "return_pct": 0.05,
     "range_pct": 0.03,
     "adx": 25.0,
+    "efficiency": 0.5,
 }
 
 _REGIME_COLUMNS = ("regime", "regime_score", "adx", "plus_di", "minus_di")
@@ -112,37 +113,66 @@ def _atr_at_end(df: pd.DataFrame, period: int) -> float:
     return atr_val if atr_val > 0 else 0.0
 
 
+def _composite_efficiency_metrics(window: pd.DataFrame, atr_val: float, period: int) -> dict:
+    """ATR-efficiency metrics for one window (shared by live + backtest paths).
+
+    `atr_val` is the per-bar ATR; the window spans `period` bars, so the
+    straight-line ATR travel denominator is atr_val * period.
+    """
+    denom = atr_val * period
+    close_end = float(window["close"].iloc[-1])
+    close_start = float(window["close"].iloc[0])
+    net = close_end - close_start
+    hi = float(window["high"].max())
+    lo = float(window["low"].min())
+    # Kaufman efficiency ratio: net travel / summed bar-to-bar travel ∈ [0, 1].
+    path = float(window["close"].diff().abs().sum())
+    return {
+        "return_eff": net / denom if denom > 0 else 0.0,
+        "range_eff": (hi - lo) / denom if denom > 0 else 0.0,
+        "efficiency": abs(net) / path if path > 0 else 0.0,
+        "close_end": close_end,
+    }
+
+
 def map_composite_label(
-    return_atr_norm: float,
+    return_eff: float,
     adx_val: float,
-    range_atr_norm: float,
+    range_eff: float,
+    efficiency: float,
     thresholds: dict[str, float],
 ) -> str:
-    """Map the 3-tuple to one of seven composite labels (#795)."""
+    """Map the composite metric tuple to one of seven labels (#795).
+
+    Inputs are ATR-efficiency normalized so the thresholds are unit-consistent:
+      return_eff — window net move / (per-bar ATR * period), signed, ~[-1, 1]
+      range_eff  — window high-low / (per-bar ATR * period), ~[0, 1]
+      efficiency — Kaufman efficiency ratio |net move| / summed bar-to-bar
+                   travel, ∈ [0, 1]; high = clean directional move, low = chop.
+    `adx_val` corroborates the efficiency-based clean/choppy split.
+    """
     ret_th = float(thresholds.get("return_pct", _DEFAULT_COMPOSITE_THRESHOLDS["return_pct"]))
     range_th = float(thresholds.get("range_pct", _DEFAULT_COMPOSITE_THRESHOLDS["range_pct"]))
     adx_th = float(thresholds.get("adx", _DEFAULT_COMPOSITE_THRESHOLDS["adx"]))
+    eff_th = float(thresholds.get("efficiency", _DEFAULT_COMPOSITE_THRESHOLDS["efficiency"]))
 
-    big_move = abs(return_atr_norm) >= ret_th
-    up = return_atr_norm > 0
+    big_move = abs(return_eff) >= ret_th
+    up = return_eff > 0
     high_adx = adx_val >= adx_th
-    wide = range_atr_norm >= range_th
+    wide = range_eff >= range_th
+    clean = efficiency >= eff_th and high_adx
 
-    if big_move and up:
-        if high_adx and wide:
-            return "trending_up_clean"
-        return "trending_up_choppy"
-    if big_move and not up:
-        if high_adx and wide:
-            return "trending_down_clean"
-        return "trending_down_choppy"
-    if not big_move:
-        if high_adx and wide:
-            return "ranging_directional"
-        if wide:
-            return "ranging_volatile"
-        return "ranging_quiet"
-    return "ranging_volatile"
+    if big_move:
+        if up:
+            return "trending_up_clean" if clean else "trending_up_choppy"
+        return "trending_down_clean" if clean else "trending_down_choppy"
+    # No decisive net move → ranging family.
+    if high_adx:
+        # Directional pressure without net follow-through.
+        return "ranging_directional"
+    if wide:
+        return "ranging_volatile"
+    return "ranging_quiet"
 
 
 def latest_regime_composite(
@@ -155,7 +185,8 @@ def latest_regime_composite(
         return {**_DEFAULT_RESULT, "metrics": dict(_DEFAULT_METRICS), "classifier": CLASSIFIER_COMPOSITE}
 
     window = _window_slice(df, period)
-    # Return/range numerators span the full window; ATR denominator matches that horizon.
+    # Numerators span the full window; ATR-efficiency divides by the window's
+    # straight-line ATR travel (per-bar ATR * period) so thresholds are unit-consistent.
     atr_val = _atr_at_end(df, period)
     if atr_val <= 0:
         return {
@@ -165,28 +196,24 @@ def latest_regime_composite(
             "metrics": dict(_DEFAULT_METRICS),
         }
 
-    close_end = float(window["close"].iloc[-1])
-    close_start = float(window["close"].iloc[0])
-    return_atr_norm = (close_end - close_start) / atr_val
-
-    hi = float(window["high"].max())
-    lo = float(window["low"].min())
-    range_atr_norm = (hi - lo) / atr_val
+    eff = _composite_efficiency_metrics(window, atr_val, period)
 
     adx_period = min(period, COMPOSITE_ADX_PERIOD_CAP)
     reg_df = compute_regime(df, period=adx_period, adx_threshold=th["adx"])
     adx_val = float(reg_df["adx"].iloc[-1]) if len(reg_df) else 0.0
 
-    label = map_composite_label(return_atr_norm, adx_val, range_atr_norm, th)
+    label = map_composite_label(eff["return_eff"], adx_val, eff["range_eff"], eff["efficiency"], th)
     score = min(adx_val / 100.0, 1.0)
+    close_end = eff["close_end"]
     return {
         "regime": label,
         "score": score,
         "classifier": CLASSIFIER_COMPOSITE,
         "metrics": {
             "adx": adx_val,
-            "return_atr_norm": round(return_atr_norm, 4),
-            "range_atr_norm": round(range_atr_norm, 4),
+            "return_eff": round(eff["return_eff"], 4),
+            "range_eff": round(eff["range_eff"], 4),
+            "efficiency": round(eff["efficiency"], 4),
             "atr_pct": round(atr_val / close_end * 100.0, 4) if close_end else 0.0,
         },
     }
@@ -292,14 +319,9 @@ def compute_regime_composite(
         atr_val = float(atr_series.iloc[i]) if i < len(atr_series) else 0.0
         if not (atr_val > 0):
             continue
-        close_end = float(window["close"].iloc[-1])
-        close_start = float(window["close"].iloc[0])
-        return_atr_norm = (close_end - close_start) / atr_val
-        hi = float(window["high"].max())
-        lo = float(window["low"].min())
-        range_atr_norm = (hi - lo) / atr_val
+        eff = _composite_efficiency_metrics(window, atr_val, period)
         adx_val = float(result["adx"].iloc[i])
-        label = map_composite_label(return_atr_norm, adx_val, range_atr_norm, th)
+        label = map_composite_label(eff["return_eff"], adx_val, eff["range_eff"], eff["efficiency"], th)
         result.iat[i, result.columns.get_loc("regime")] = label
         result.iat[i, result.columns.get_loc("regime_score")] = min(adx_val / 100.0, 1.0)
     return result

--- a/shared_tools/test_regime.py
+++ b/shared_tools/test_regime.py
@@ -381,12 +381,47 @@ def test_parse_regime_windows_json_rejects_reserved_name():
 
 
 def test_map_composite_label_states():
-    th = {"return_pct": 0.05, "range_pct": 0.03, "adx": 25}
-    assert _regime_mod.map_composite_label(0.10, 30, 0.10, th) == "trending_up_clean"
-    assert _regime_mod.map_composite_label(0.10, 10, 0.10, th) == "trending_up_choppy"
-    assert _regime_mod.map_composite_label(-0.10, 30, 0.10, th) == "trending_down_clean"
-    assert _regime_mod.map_composite_label(0.01, 10, 0.01, th) == "ranging_quiet"
-    assert _regime_mod.map_composite_label(0.01, 30, 0.10, th) == "ranging_directional"
+    th = {"return_pct": 0.05, "range_pct": 0.03, "adx": 25, "efficiency": 0.5}
+    m = _regime_mod.map_composite_label
+    # (return_eff, adx, range_eff, efficiency, thresholds)
+    # Clean trend: big net move + high efficiency + high ADX.
+    assert m(0.10, 30, 0.10, 0.7, th) == "trending_up_clean"
+    # Choppy trend: big net move but ADX too low to confirm clean.
+    assert m(0.10, 10, 0.10, 0.7, th) == "trending_up_choppy"
+    # Choppy trend: big net move, high ADX, but low efficiency (lots of churn).
+    assert m(0.10, 30, 0.10, 0.2, th) == "trending_up_choppy"
+    assert m(-0.10, 30, 0.10, 0.7, th) == "trending_down_clean"
+    assert m(-0.10, 10, 0.10, 0.7, th) == "trending_down_choppy"
+    # Ranging family: no decisive net move.
+    assert m(0.01, 10, 0.01, 0.0, th) == "ranging_quiet"
+    assert m(0.01, 10, 0.10, 0.0, th) == "ranging_volatile"
+    assert m(0.01, 30, 0.10, 0.0, th) == "ranging_directional"
+
+
+def test_latest_regime_composite_ranging_not_trending():
+    """Regression: a mean-reverting market must not be labeled trending.
+
+    Pre-fix the metric divided whole-window numerators by a single-bar ATR, so
+    `big_move`/`wide` were always true and ranging labels were unreachable.
+    """
+    import numpy as np
+
+    n = 200
+    period = 50
+    idx = pd.date_range("2024-01-01", periods=n, freq="h")
+    rng = np.random.default_rng(0)
+    prices = 100 + 2 * np.sin(np.linspace(0, 8 * np.pi, n)) + rng.normal(0, 0.3, n)
+    df = pd.DataFrame(
+        {
+            "open": prices,
+            "high": prices * 1.003,
+            "low": prices * 0.997,
+            "close": prices,
+        },
+        index=idx,
+    )
+    snap = _regime_mod.latest_regime_composite(df, period=period)
+    assert snap["regime"].startswith("ranging"), snap
 
 
 def test_parse_regime_windows_spec_json_composite():


### PR DESCRIPTION
## Summary

Fixes a unit mismatch in the composite (7-state) regime classifier (`shared_tools/regime.py`) that made the three **ranging** states unreachable on real data — a pure mean-reverting market was mislabeled as trending.

## Root cause

`map_composite_label` thresholds are per-bar **fractions** (`return_pct=0.05`, `range_pct=0.03`), but the metric computation fed it **ATR-multiples**: whole-window numerators (`close_end-close_start`, `high-low`) divided by a **single-bar** `standard_atr(period)`. Those values run 1-2 orders of magnitude above the thresholds, so `big_move`/`wide` were always true. Identical bug in the live snapshot (`latest_regime_composite`) and the backtest per-bar path (`compute_regime_composite`).

Reproduction (period=50): pure ranging sine → `return_atr_norm=0.31`, `range_atr_norm=7.46`, label `trending_up_choppy` ❌.

Secondary bug: once `wide` is meaningful again, "clean trend requires `wide`" is backwards — a clean trend is a *narrow* range relative to net travel.

## Fix

ATR-efficiency normalization:

1. `return_eff = (close_end - close_start) / (atr * period)` — signed, ~[-1, 1]
1. `range_eff  = (high - low) / (atr * period)` — ~[0, 1]
1. `efficiency = |net move| / sum(|bar-to-bar move|)` — Kaufman efficiency ratio ∈ [0, 1], the clean-vs-choppy discriminator (ADX corroborates)

New tunable `efficiency` threshold (default `0.5`) added to both the Python composite defaults and the Go `RegimeCompositeThresholds` struct (default / merge / validation `(0,1]` / inspect format) so operators can tune it without tripping the config unknown-key guard. A shared `_composite_efficiency_metrics` helper keeps the live and backtest paths identical.

All 7 labels are now reachable; clean trends classify as `trending_*_clean` (efficiency ~0.5, ADX ~52), and pure ranging no longer reads as trending.

## Behavior change ⚠️

This changes live classification consumed by `*_atr_regime`, `regime_directional_policy`, and unified per-regime closes. Markets that previously always read as trending will now correctly show ranging states, so strategies tuned against the old (broken) behavior will gate differently.

## Testing

- `shared_tools/test_regime.py`: updated `test_map_composite_label_states` for the new signature with all-7-label coverage; added `test_latest_regime_composite_ranging_not_trending` regression.
- 472 Python tests pass (`shared_tools/`, `backtest/`, `shared_strategies/close/`); full Go package passes; build + gofmt clean.

Closes #861

---
LLM: Claude Opus 4.8 (1M) | high