### PR TITLE
feat(discord): name close strategy in cycle-summary position lines

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1071,6 +1071,20 @@ func strategyUsesTieredTPATRClose(sc StrategyConfig) bool {
 	return false
 }
 
+// closeStrategySummaryName returns the configured close evaluator's name for the
+// position summary line, or "" when the strategy uses open-as-close (nil
+// CloseStrategy) — there the open strategy is already implied by the strategy ID.
+// Surfacing the name lets operators see how a position will be managed (trailing
+// stop, tiered TP, ratchet, …) at a glance without opening the config or DMs.
+// Manual positions in particular auto-fill their close, so the name is otherwise
+// invisible in summaries (#863).
+func closeStrategySummaryName(sc StrategyConfig) string {
+	if sc.CloseStrategy == nil {
+		return ""
+	}
+	return strings.TrimSpace(sc.CloseStrategy.Name)
+}
+
 // collectPositions returns human-readable position lines for a strategy.
 func collectPositions(sc StrategyConfig, ss *StrategyState, prices map[string]float64) []string {
 	var lines []string
@@ -1094,6 +1108,9 @@ func collectPositions(sc StrategyConfig, ss *StrategyState, prices map[string]fl
 			dateStr = fmt.Sprintf(" [%s]", pos.OpenedAt.Format("Jan 02 15:04"))
 		}
 		extras := ""
+		if name := closeStrategySummaryName(sc); name != "" {
+			extras += fmt.Sprintf(" | close: %s", name)
+		}
 		if pos.EntryATR > 0 {
 			extras += fmt.Sprintf(" | ATR: $%s", fmtComma2(pos.EntryATR))
 		}

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -1576,6 +1576,50 @@ func TestCollectPositions_TrailingTPRatchetShowsRatchetState(t *testing.T) {
 	}
 }
 
+// TestCollectPositions_ShowsCloseStrategyName verifies the summary line names the
+// configured close evaluator so operators can see how a (manual or otherwise)
+// position will be managed without checking the config (#863). The label precedes
+// the derived close params (ATR/SL/TP/ratchet).
+func TestCollectPositions_ShowsCloseStrategyName(t *testing.T) {
+	sc := StrategyConfig{
+		ID:            "manual-eth",
+		CloseStrategy: &StrategyRef{Name: "trailing_tp_ratchet"},
+	}
+	ss := &StrategyState{
+		Positions: map[string]*Position{
+			"ETH/USDT": {Symbol: "ETH/USDT", Quantity: 0.516, AvgCost: 1938, Side: "short", EntryATR: 30},
+		},
+	}
+	lines := collectPositions(sc, ss, map[string]float64{"ETH/USDT": 1938})
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	if !strings.Contains(lines[0], "| close: trailing_tp_ratchet") {
+		t.Errorf("expected close-strategy name fragment, got: %s", lines[0])
+	}
+	// The name must precede the derived ATR param so it reads name-then-params.
+	closeIdx := strings.Index(lines[0], "| close:")
+	atrIdx := strings.Index(lines[0], "| ATR:")
+	if closeIdx < 0 || atrIdx < 0 || closeIdx > atrIdx {
+		t.Errorf("expected close label before ATR param, got: %s", lines[0])
+	}
+}
+
+// TestCollectPositions_OmitsCloseLabelWhenOpenAsClose verifies open-as-close (nil
+// CloseStrategy) adds no close label — the open strategy is implied by the ID.
+func TestCollectPositions_OmitsCloseLabelWhenOpenAsClose(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-rsi-btc"}
+	ss := &StrategyState{
+		Positions: map[string]*Position{
+			"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.025, AvgCost: 63500, Side: "long"},
+		},
+	}
+	lines := collectPositions(sc, ss, map[string]float64{"BTC/USDT": 63500})
+	if strings.Contains(lines[0], "close:") {
+		t.Errorf("open-as-close should add no close label, got: %s", lines[0])
+	}
+}
+
 func TestCollectPositions_TieredTPATR_OmittedWithoutCloseStrategy(t *testing.T) {
 	sc := StrategyConfig{ID: "hl-rsi-btc", CloseStrategy: &StrategyRef{Name: "tiered_tp_pct"}}
 	ss := &StrategyState{


### PR DESCRIPTION
## Summary

Cycle-summary position lines surfaced close-*derived* params (SL/TP/Ratchet/RT) but never named the close evaluator itself. Manual positions auto-fill their close, so operators couldn't tell from a summary whether a position is managed by a trailing stop, tiered TP, or ratchet without opening the config or DMs.

`collectPositions` (`scheduler/discord.go`) now prepends `| close: <name>` to each position line, before the derived params:

```
manual-eth SHORT ETH/USDT x0.516 @ $1,938.00 (...) | close: trailing_tp_ratchet | Ratchet: 0/2 | Trail: 1.5x ATR | RT1: ... | 20x ($50 margin) [Jun 02 14:40]
```

## Notes

1. Universal, not manual-gated — `collectPositions` is the shared builder for all strategy types; the name is useful everywhere.
2. Open-as-close strategies (nil `CloseStrategy`) stay unlabeled — the open strategy is already implied by the strategy ID, avoiding noise.
3. No duplication — the label only names the evaluator; the existing `Ratchet`/`RT`/`TP`/`SL` extras render unchanged.
4. No Telegram-specific change — the summary `posLines` string is built once and sent to both channels verbatim (unlike trade-alert DMs).

## Tests

- `TestCollectPositions_ShowsCloseStrategyName` — label present and ordered before ATR param.
- `TestCollectPositions_OmitsCloseLabelWhenOpenAsClose` — nil close adds no label.
- Full `scheduler` suite passes.

Closes #863

LLM: Claude Opus 4.8 (1M) | high | Harness: Claude Code