### PR TITLE
feat(discord): add /report-an-issue slash command to file GitHub issues (#5)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -433,6 +433,13 @@ in the handler by `authorizeCommand`):
   (5-min timeout via `runPythonWithTimeout` + `shutdownReadOnlyCtx`; holds one of 4
   `pythonSemaphore` slots while running); replies with a summary and attaches the full
   report as `backtest.txt`.
+- `/report-an-issue <title> <body> [label]` — files a GitHub issue against `discord.report_repo`
+  (default `richkuo/go-trader`) via the REST API (`discord_report.go`: `buildIssueRequest`
+  builds the payload + a "Filed via /report-an-issue" footer; `createGitHubIssue` POSTs and returns
+  the issue URL). Defers the ACK because the GitHub round-trip can exceed Discord's 3s
+  deadline. Token resolves from `GO_TRADER_GITHUB_TOKEN`, then `GITHUB_TOKEN`, then
+  `discord.report_github_token` (env preferred; keep the secret in `/opt/go-trader/.env`).
+  Replies that reporting is not configured when no token is set.
 
 Auth lives in `authorizeCommand`; command set in `slashCommands()`; pure response builders
 (`format*Response`) are unit-tested in `discord_commands_test.go`. Registration failure is

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -22,11 +22,11 @@ type DiscordConfig struct {
 	LeaderboardTopN    int               `json:"leaderboard_top_n,omitempty"`    // number of entries shown in leaderboard messages (default 5)
 	LeaderboardChannel string            `json:"leaderboard_channel,omitempty"`  // dedicated Discord channel ID for leaderboard posts; when set, all leaderboards route here instead of being broadcast across platform channels
 	EphemeralReplies   bool              `json:"ephemeral_replies,omitempty"`    // when true, read-only slash-command replies (/status, /pnl, etc.) are ephemeral (visible only to the invoker); default false (public in channel)
-	ReportRepo         string            `json:"report_repo,omitempty"`          // GitHub repo (owner/name) the /report command files issues against; defaults to richkuo/go-trader
-	ReportGitHubToken  string            `json:"report_github_token,omitempty"`  // GitHub token for /report; prefer the GO_TRADER_GITHUB_TOKEN / GITHUB_TOKEN env var over storing it here
+	ReportRepo         string            `json:"report_repo,omitempty"`          // GitHub repo (owner/name) the /report-an-issue command files issues against; defaults to richkuo/go-trader
+	ReportGitHubToken  string            `json:"report_github_token,omitempty"`  // GitHub token for /report-an-issue; prefer the GO_TRADER_GITHUB_TOKEN / GITHUB_TOKEN env var over storing it here
 }
 
-// reportRepo returns the owner/name repo for the /report command, defaulting to
+// reportRepo returns the owner/name repo for the /report-an-issue command, defaulting to
 // this project's repo when unset.
 func (c DiscordConfig) reportRepo() string {
 	if r := strings.TrimSpace(c.ReportRepo); r != "" {
@@ -35,7 +35,7 @@ func (c DiscordConfig) reportRepo() string {
 	return defaultReportRepo
 }
 
-// reportToken resolves the GitHub token for /report. Env vars win over the config
+// reportToken resolves the GitHub token for /report-an-issue. Env vars win over the config
 // field so the secret can live in /opt/go-trader/.env rather than the config JSON.
 func (c DiscordConfig) reportToken() string {
 	if t := strings.TrimSpace(os.Getenv("GO_TRADER_GITHUB_TOKEN")); t != "" {

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -22,6 +22,29 @@ type DiscordConfig struct {
 	LeaderboardTopN    int               `json:"leaderboard_top_n,omitempty"`    // number of entries shown in leaderboard messages (default 5)
 	LeaderboardChannel string            `json:"leaderboard_channel,omitempty"`  // dedicated Discord channel ID for leaderboard posts; when set, all leaderboards route here instead of being broadcast across platform channels
 	EphemeralReplies   bool              `json:"ephemeral_replies,omitempty"`    // when true, read-only slash-command replies (/status, /pnl, etc.) are ephemeral (visible only to the invoker); default false (public in channel)
+	ReportRepo         string            `json:"report_repo,omitempty"`          // GitHub repo (owner/name) the /report command files issues against; defaults to richkuo/go-trader
+	ReportGitHubToken  string            `json:"report_github_token,omitempty"`  // GitHub token for /report; prefer the GO_TRADER_GITHUB_TOKEN / GITHUB_TOKEN env var over storing it here
+}
+
+// reportRepo returns the owner/name repo for the /report command, defaulting to
+// this project's repo when unset.
+func (c DiscordConfig) reportRepo() string {
+	if r := strings.TrimSpace(c.ReportRepo); r != "" {
+		return r
+	}
+	return defaultReportRepo
+}
+
+// reportToken resolves the GitHub token for /report. Env vars win over the config
+// field so the secret can live in /opt/go-trader/.env rather than the config JSON.
+func (c DiscordConfig) reportToken() string {
+	if t := strings.TrimSpace(os.Getenv("GO_TRADER_GITHUB_TOKEN")); t != "" {
+		return t
+	}
+	if t := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); t != "" {
+		return t
+	}
+	return strings.TrimSpace(c.ReportGitHubToken)
 }
 
 // TelegramConfig holds Telegram notification settings.

--- a/scheduler/discord_commands.go
+++ b/scheduler/discord_commands.go
@@ -29,9 +29,10 @@ var readOnlyCommandNames = map[string]bool{
 // output; restricted to the owner in a DM. `logs` is here (not read-only)
 // because journalctl can carry wallet addresses and error payloads.
 var opsCommandNames = map[string]bool{
-	"restart":  true,
-	"backtest": true,
-	"logs":     true,
+	"restart":         true,
+	"backtest":        true,
+	"logs":            true,
+	"report-an-issue": true,
 }
 
 // authorizeCommand decides whether invokerID may run command `name`. Read-only
@@ -390,6 +391,11 @@ func slashCommands() []*discordgo.ApplicationCommand {
 			{Type: discordgo.ApplicationCommandOptionInteger, Name: "n", Description: "Number of lines (default 50, max 200)"},
 		}},
 		{Name: "restart", Description: "Restart the go-trader service (owner DM only)", Contexts: dmContext()},
+		{Name: "report-an-issue", Description: "File a GitHub issue (owner DM only)", Contexts: dmContext(), Options: []*discordgo.ApplicationCommandOption{
+			{Type: discordgo.ApplicationCommandOptionString, Name: "title", Description: "Issue title", Required: true},
+			{Type: discordgo.ApplicationCommandOptionString, Name: "body", Description: "Issue description", Required: true},
+			{Type: discordgo.ApplicationCommandOptionString, Name: "label", Description: "Optional label (applied if it exists on the repo)"},
+		}},
 		{Name: "backtest", Description: "Run a single backtest (owner DM only)", Contexts: dmContext(), Options: []*discordgo.ApplicationCommandOption{
 			{Type: discordgo.ApplicationCommandOptionString, Name: "strategy", Description: "Strategy name", Required: true},
 			{Type: discordgo.ApplicationCommandOptionString, Name: "symbol", Description: "Symbol, e.g. BTC/USDT", Required: true},
@@ -459,6 +465,8 @@ func (d *DiscordNotifier) interactionCreate(s *discordgo.Session, i *discordgo.I
 		d.handleRestart(s, i)
 	case "backtest":
 		d.handleBacktest(s, i, data)
+	case "report-an-issue":
+		d.handleReport(s, i, data)
 	default:
 		respondEphemeral(s, i, "unknown command")
 	}

--- a/scheduler/discord_report.go
+++ b/scheduler/discord_report.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// defaultReportRepo is the GitHub repo the /report-an-issue command files issues against
+// when discord.report_repo is unset.
+const defaultReportRepo = "richkuo/go-trader"
+
+// githubAPIBaseURL is the GitHub REST API root; var (not const) so tests can point
+// it at an httptest server.
+var githubAPIBaseURL = "https://api.github.com"
+
+// githubIssueRequest is the JSON body for POST /repos/{owner}/{repo}/issues.
+type githubIssueRequest struct {
+	Title  string   `json:"title"`
+	Body   string   `json:"body"`
+	Labels []string `json:"labels,omitempty"`
+}
+
+// buildIssueRequest assembles the GitHub issue payload from the slash-command
+// inputs, appending a footer that records who filed it via /report-an-issue. label is
+// applied only when non-empty (GitHub silently ignores labels that don't exist
+// on the repo).
+func buildIssueRequest(title, body, label, reporter string) githubIssueRequest {
+	footer := "Filed via `/report-an-issue`"
+	if r := strings.TrimSpace(reporter); r != "" {
+		footer += " by " + r
+	}
+	footer += "."
+	fullBody := strings.TrimRight(body, "\n") + "\n\n---\n" + footer
+	req := githubIssueRequest{Title: strings.TrimSpace(title), Body: fullBody}
+	if l := strings.TrimSpace(label); l != "" {
+		req.Labels = []string{l}
+	}
+	return req
+}
+
+// createGitHubIssue POSTs a new issue and returns its html_url and number.
+// repo is "owner/name". The caller is responsible for supplying a non-empty token.
+func createGitHubIssue(ctx context.Context, client *http.Client, repo, token string, payload githubIssueRequest) (htmlURL string, number int, err error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", 0, fmt.Errorf("marshal issue: %w", err)
+	}
+	url := fmt.Sprintf("%s/repos/%s/issues", strings.TrimRight(githubAPIBaseURL, "/"), repo)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return "", 0, fmt.Errorf("build request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("Accept", "application/vnd.github+json")
+	httpReq.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("User-Agent", "go-trader")
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return "", 0, fmt.Errorf("github request: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusCreated {
+		return "", 0, fmt.Errorf("github returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	var parsed struct {
+		HTMLURL string `json:"html_url"`
+		Number  int    `json:"number"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", 0, fmt.Errorf("parse github response: %w", err)
+	}
+	return parsed.HTMLURL, parsed.Number, nil
+}
+
+// interactionUserLabel renders a human-readable reporter label from the invoking
+// user (works in both guild and DM interactions).
+func interactionUserLabel(i *discordgo.InteractionCreate) string {
+	var u *discordgo.User
+	if i.Member != nil && i.Member.User != nil {
+		u = i.Member.User
+	}
+	if i.User != nil {
+		u = i.User
+	}
+	if u == nil {
+		return ""
+	}
+	if u.Username != "" {
+		return fmt.Sprintf("%s (Discord ID %s)", u.Username, u.ID)
+	}
+	return "Discord ID " + u.ID
+}
+
+// handleReport files a GitHub issue from the /report-an-issue slash command. Owner-DM-gated
+// in authorizeCommand. Defers the ACK because the GitHub round-trip can exceed
+// Discord's 3s deadline, then delivers the issue URL (or an error) as a follow-up.
+func (d *DiscordNotifier) handleReport(s *discordgo.Session, i *discordgo.InteractionCreate, data discordgo.ApplicationCommandInteractionData) {
+	title := optionString(data.Options, "title", "")
+	body := optionString(data.Options, "body", "")
+	label := optionString(data.Options, "label", "")
+	deferAck(s, i)
+
+	followup := func(msg string) {
+		_, _ = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+			Content: truncateForDiscord(msg),
+		})
+	}
+
+	if title == "" || body == "" {
+		followup("Both `title` and `body` are required.")
+		return
+	}
+
+	var dcfg DiscordConfig
+	if d.cfg != nil {
+		dcfg = d.cfg.Discord
+	}
+	token := dcfg.reportToken()
+	if token == "" {
+		followup("Issue reporting is not configured: set a GitHub token via the GO_TRADER_GITHUB_TOKEN env var (or discord.report_github_token).")
+		return
+	}
+
+	payload := buildIssueRequest(title, body, label, interactionUserLabel(i))
+	ctx, cancel := context.WithTimeout(shutdownReadOnlyCtx, 20*time.Second)
+	defer cancel()
+	url, number, err := createGitHubIssue(ctx, http.DefaultClient, dcfg.reportRepo(), token, payload)
+	if err != nil {
+		followup(fmt.Sprintf("Failed to file issue: %v", err))
+		return
+	}
+	followup(fmt.Sprintf("✅ Opened issue #%d: %s", number, url))
+}

--- a/scheduler/discord_report_test.go
+++ b/scheduler/discord_report_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBuildIssueRequest(t *testing.T) {
+	req := buildIssueRequest("  Bug in /status  ", "It crashes\n", "bug", "alice (Discord ID 42)")
+	if req.Title != "Bug in /status" {
+		t.Fatalf("title not trimmed: %q", req.Title)
+	}
+	if len(req.Labels) != 1 || req.Labels[0] != "bug" {
+		t.Fatalf("expected label [bug], got %v", req.Labels)
+	}
+	if !strings.Contains(req.Body, "It crashes") {
+		t.Fatalf("body missing original text: %q", req.Body)
+	}
+	if !strings.Contains(req.Body, "Filed via `/report-an-issue` by alice (Discord ID 42).") {
+		t.Fatalf("body missing reporter footer: %q", req.Body)
+	}
+	if !strings.Contains(req.Body, "\n---\n") {
+		t.Fatalf("body missing footer separator: %q", req.Body)
+	}
+}
+
+func TestBuildIssueRequestNoLabelNoReporter(t *testing.T) {
+	req := buildIssueRequest("t", "b", "  ", "")
+	if req.Labels != nil {
+		t.Fatalf("expected no labels, got %v", req.Labels)
+	}
+	if !strings.HasSuffix(strings.TrimRight(req.Body, "\n"), "Filed via `/report-an-issue`.") {
+		t.Fatalf("footer should omit reporter when unknown: %q", req.Body)
+	}
+}
+
+func TestCreateGitHubIssueSuccess(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/repos/richkuo/go-trader/issues" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer tok123" {
+			t.Errorf("missing/incorrect auth header: %q", got)
+		}
+		var body githubIssueRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		if body.Title != "hello" {
+			t.Errorf("unexpected title %q", body.Title)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"html_url":"https://github.com/richkuo/go-trader/issues/99","number":99}`)
+	}))
+	defer ts.Close()
+
+	orig := githubAPIBaseURL
+	githubAPIBaseURL = ts.URL
+	defer func() { githubAPIBaseURL = orig }()
+
+	url, num, err := createGitHubIssue(context.Background(), ts.Client(), "richkuo/go-trader", "tok123",
+		buildIssueRequest("hello", "world", "", "bob"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if num != 99 {
+		t.Fatalf("expected number 99, got %d", num)
+	}
+	if url != "https://github.com/richkuo/go-trader/issues/99" {
+		t.Fatalf("unexpected url %q", url)
+	}
+}
+
+func TestCreateGitHubIssueErrorStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"message":"Bad credentials"}`)
+	}))
+	defer ts.Close()
+
+	orig := githubAPIBaseURL
+	githubAPIBaseURL = ts.URL
+	defer func() { githubAPIBaseURL = orig }()
+
+	_, _, err := createGitHubIssue(context.Background(), ts.Client(), "richkuo/go-trader", "bad",
+		buildIssueRequest("t", "b", "", ""))
+	if err == nil {
+		t.Fatal("expected error on 401, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") || !strings.Contains(err.Error(), "Bad credentials") {
+		t.Fatalf("error should surface status + body: %v", err)
+	}
+}
+
+func TestReportCommandIsOwnerDMGated(t *testing.T) {
+	// Non-owner is rejected.
+	if ok, _ := authorizeCommand("report-an-issue", "intruder", "", "owner"); ok {
+		t.Fatal("report must reject non-owner")
+	}
+	// Owner in a guild (guildID != "") is rejected.
+	if ok, _ := authorizeCommand("report-an-issue", "owner", "guild1", "owner"); ok {
+		t.Fatal("report must reject guild context")
+	}
+	// Owner in a DM is allowed.
+	if ok, _ := authorizeCommand("report-an-issue", "owner", "", "owner"); !ok {
+		t.Fatal("owner DM should be allowed to report")
+	}
+}
+
+func TestReportTokenResolution(t *testing.T) {
+	t.Setenv("GO_TRADER_GITHUB_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	c := DiscordConfig{ReportGitHubToken: "cfgtok"}
+	if got := c.reportToken(); got != "cfgtok" {
+		t.Fatalf("expected config token, got %q", got)
+	}
+	t.Setenv("GITHUB_TOKEN", "envtok")
+	if got := c.reportToken(); got != "envtok" {
+		t.Fatalf("env should win over config, got %q", got)
+	}
+	t.Setenv("GO_TRADER_GITHUB_TOKEN", "primary")
+	if got := c.reportToken(); got != "primary" {
+		t.Fatalf("GO_TRADER_GITHUB_TOKEN should win, got %q", got)
+	}
+}
+
+func TestReportRepoDefault(t *testing.T) {
+	if got := (DiscordConfig{}).reportRepo(); got != defaultReportRepo {
+		t.Fatalf("expected default repo, got %q", got)
+	}
+	if got := (DiscordConfig{ReportRepo: "me/x"}).reportRepo(); got != "me/x" {
+		t.Fatalf("expected override, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `/report-an-issue` Discord slash command that files a GitHub issue against the repo without leaving Discord.

- Registered in `slashCommands()` with `dmContext()` + required `title`/`body` and optional `label`; added to `opsCommandNames`, dispatched in `interactionCreate`.
- **Owner-DM-only** (via existing `authorizeCommand`), like `/logs` and `/restart`, since it writes to a public repo.
- `discord_report.go`: `buildIssueRequest` builds the payload + a "Filed via `/report-an-issue` by <user>" footer; `createGitHubIssue` POSTs to the GitHub REST API and returns the issue URL/number. `githubAPIBaseURL` is a `var` for httptest repointing.
- **Deferred ACK** — the GitHub round-trip can exceed Discord's 3s interaction deadline.
- **Token resolution**: `GO_TRADER_GITHUB_TOKEN` → `GITHUB_TOKEN` → `discord.report_github_token` (env preferred; keep the secret in `/opt/go-trader/.env`). No token → command replies it is not configured (token presence is the enable switch).
- **Repo** defaults to `richkuo/go-trader`, overridable via `discord.report_repo`.

## Decisions

- No separate enable flag — having a token = enabled.
- No explicit throttle — owner-DM gating already prevents spam (same rationale as `/backtest`).

## Testing

- `discord_report_test.go`: payload builder (footer/label/trim), GitHub success + error-status via `httptest`, owner-DM auth gate, token-resolution precedence, repo default. No Python subprocess dependency.
- `go build` + full `go test ./...` (scheduler) pass; `SKILL.md` updated.

Closes #5

---
LLM: Opus 4.8 | high | Harness: commit-push-pr