### PR TITLE
feat(close): retune default close ladders + per-regime group defaults (#870)

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -406,12 +406,22 @@ class Backtester:
                 if n in ("trailing_tp_ratchet", "trailing_tp_ratchet_regime"):
                     self._ratchet_ref = ref
                     break
-            if (
+            _regime_ratchet = (
+                (self._ratchet_ref or {}).get("name") or ""
+            ).strip().lower() == "trailing_tp_ratchet_regime"
+            if _regime_ratchet:
+                # #870: the regime variant's opening trail / SL owner is the
+                # per-regime trailing_stop_atr_regime block (scalar mult rejected).
+                if self.trailing_stop_atr_regime is None:
+                    raise ValueError(
+                        "trailing_tp_ratchet_regime requires trailing_stop_atr_regime"
+                    )
+            elif (
                 self.trailing_stop_atr_mult is None
                 or self.trailing_stop_atr_mult <= 0
             ):
                 raise ValueError(
-                    "trailing_tp_ratchet* requires trailing_stop_atr_mult > 0"
+                    "trailing_tp_ratchet requires trailing_stop_atr_mult > 0"
                 )
             if self.trailing_stop_pct is not None and self.trailing_stop_pct > 0:
                 raise ValueError(

--- a/backtest/tests/test_backtester_close_strategies.py
+++ b/backtest/tests/test_backtester_close_strategies.py
@@ -71,7 +71,7 @@ def test_tiered_tp_atr_partial_then_full_close():
     bt = Backtester(
         initial_capital=1000, commission_pct=0, slippage_pct=0,
         close_strategies=[
-            {"name": "tiered_tp_atr", "params": {"tiers": [
+            {"name": "tiered_tp_atr", "params": {"tp_tiers": [
             {"atr_multiple": 1.0, "close_fraction": 0.5},
             {"atr_multiple": 2.0, "close_fraction": 1.0},
         ]}},
@@ -102,7 +102,7 @@ def test_tiered_tp_atr_live_uses_live_atr_from_market():
         close_strategies=[
             {"name": "tiered_tp_atr_live", "params": {
             "atr_source": "live",
-            "tiers": [
+            "tp_tiers": [
                 {"atr_multiple": 1.0, "close_fraction": 0.5},
                 {"atr_multiple": 2.0, "close_fraction": 1.0},
             ],
@@ -128,7 +128,7 @@ def test_max_close_fraction_wins_between_two_evaluators():
         initial_capital=1000, commission_pct=0, slippage_pct=0,
         close_strategies=[
             {"name": "tp_at_pct", "params": {"pct": 0.02}},
-            {"name": "tiered_tp_pct", "params": {"tiers": [
+            {"name": "tiered_tp_pct", "params": {"tp_tiers": [
                 {"profit_pct": 0.05, "close_fraction": 1.0},
             ]}},
         ],
@@ -198,7 +198,7 @@ def test_starting_long_seed_with_entry_atr_lets_tiered_tp_atr_fire():
     bt = Backtester(
         initial_capital=1000, commission_pct=0, slippage_pct=0,
         close_strategies=[
-            {"name": "tiered_tp_atr", "params": {"tiers": [
+            {"name": "tiered_tp_atr", "params": {"tp_tiers": [
             {"atr_multiple": 1.0, "close_fraction": 0.5},
             {"atr_multiple": 2.0, "close_fraction": 1.0},
         ]}},
@@ -292,7 +292,14 @@ def test_trailing_tp_ratchet_regime_uses_open_time_regime():
     }
     bt = Backtester(
         initial_capital=1000, commission_pct=0, slippage_pct=0,
-        trailing_stop_atr_mult=3.0,
+        # #870: the regime variant's opening trail / SL owner is the per-regime
+        # trailing_stop_atr_regime block (scalar trailing_stop_atr_mult rejected).
+        # Open 3.0 preserves the prior initial trail distance.
+        trailing_stop_atr_regime={"trend_regime": {
+            "ranging": {"atr_multiple": 3.0},
+            "trending_up": {"atr_multiple": 3.0},
+            "trending_down": {"atr_multiple": 3.0},
+        }},
         close_strategies=[close_ref],
     )
     result = bt.run(df, save=False)

--- a/backtest/tests/test_post_tp_sl.py
+++ b/backtest/tests/test_post_tp_sl.py
@@ -526,7 +526,11 @@ def test_backtester_tp_atr_fraction_uses_firing_tier_multiple():
 
 
 def test_backtester_tp_atr_fraction_uses_default_tier_multiple():
-    """Default TP1 is 1×ATR, so tp_atr_fraction=0.5 resolves to 0.5×ATR."""
+    """#870: default TP1 is 1.5×ATR, so tp_atr_fraction=0.5 resolves to 0.75×ATR.
+
+    With ATR=10 the first tier fires at +15 (mark 115), scaling out 40%; the
+    remainder rides to the forced close at 112.
+    """
     df = _df_open_then_hold(
         opens=[100, 100, 100, 110, 115, 118, 112],
         closes=[100, 100, 110, 115, 118, 112, 112],
@@ -545,7 +549,7 @@ def test_backtester_tp_atr_fraction_uses_default_tier_multiple():
     )
     result = bt.run(df, save=False)
     sides_prices = [(t["side"], t["exit_price"]) for t in result["trades"]]
-    assert ("long", 110.0) in sides_prices, sides_prices
+    assert ("long", 115.0) in sides_prices, sides_prices
     assert ("long", 112.0) in sides_prices, sides_prices
 
 

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -1740,8 +1740,11 @@ func validateConfig(cfg *Config, skipLiveCredentialChecks bool) error {
 			if sc.TrailingStopATRMult != nil {
 				atrMult = *sc.TrailingStopATRMult
 			}
-			if fixedTrailingPct <= 0 && atrMult <= 0 {
-				errs = append(errs, fmt.Sprintf("%s: trailing_stop_min_move_pct requires trailing_stop_pct > 0 or trailing_stop_atr_mult > 0", prefix))
+			// #870: the regime ratchet owns its trail via trailing_stop_atr_regime
+			// rather than the scalar trailing_stop_atr_mult, so accept that too.
+			regimeTrail := sc.TrailingStopATRRegime != nil && !sc.TrailingStopATRRegime.IsZero()
+			if fixedTrailingPct <= 0 && atrMult <= 0 && !regimeTrail {
+				errs = append(errs, fmt.Sprintf("%s: trailing_stop_min_move_pct requires trailing_stop_pct > 0, trailing_stop_atr_mult > 0, or trailing_stop_atr_regime", prefix))
 			}
 		}
 

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -1484,7 +1484,7 @@ func TestCollectPositions_TieredTPATR_Long(t *testing.T) {
 	if !strings.Contains(lines[0], "| ATR: $1,000.00") {
 		t.Errorf("expected ATR fragment, got: %s", lines[0])
 	}
-	if !strings.Contains(lines[0], "| TP1: $64,500.00 (+1.6%) (1x) | TP2: $65,500.00 (+3.1%) (2x)") {
+	if !strings.Contains(lines[0], "| TP1: $65,000.00 (+2.4%) (1.5x) | TP2: $66,500.00 (+4.7%) (3x)") {
 		t.Errorf("expected tiered TP fragments for long, got: %s", lines[0])
 	}
 }
@@ -1503,7 +1503,7 @@ func TestCollectPositions_TieredTPATR_Short(t *testing.T) {
 	if !strings.Contains(lines[0], "| ATR: $1,000.00") {
 		t.Errorf("expected ATR fragment, got: %s", lines[0])
 	}
-	if !strings.Contains(lines[0], "| TP1: $62,500.00 (+1.6%) (1x) | TP2: $61,500.00 (+3.1%) (2x)") {
+	if !strings.Contains(lines[0], "| TP1: $62,000.00 (+2.4%) (1.5x) | TP2: $60,500.00 (+4.7%) (3x)") {
 		t.Errorf("expected tiered TP fragments for short, got: %s", lines[0])
 	}
 }
@@ -1527,7 +1527,7 @@ func TestCollectPositions_TieredTPATRLive_Long(t *testing.T) {
 	if !strings.Contains(lines[0], "| ATR: $1,000.00") {
 		t.Errorf("expected ATR fragment, got: %s", lines[0])
 	}
-	want := "| TP1: $64,500.00 (+1.6%) (1x) | TP2: $65,500.00 (+3.1%) (2x)"
+	want := "| TP1: $65,000.00 (+2.4%) (1.5x) | TP2: $66,500.00 (+4.7%) (3x)"
 	if !strings.Contains(lines[0], want) {
 		t.Errorf("expected tiered TP fragments for tiered_tp_atr_live long, got: %s", lines[0])
 	}
@@ -1669,10 +1669,11 @@ func TestCollectPositions_TieredTPATR_FilledTierMarked(t *testing.T) {
 		},
 	}
 	lines := collectPositions(sc, ss, map[string]float64{"BTC/USDT": 63500})
-	if !strings.Contains(lines[0], "| TP1: $64,500.00 (1x) ✓") {
+	// #870: default ladder retuned to 1.5×/3×/5×.
+	if !strings.Contains(lines[0], "| TP1: $65,000.00 (1.5x) ✓") {
 		t.Errorf("expected TP1 marked filled, got: %s", lines[0])
 	}
-	if !strings.Contains(lines[0], "| TP2: $65,500.00 (+3.1%) (2x)") {
+	if !strings.Contains(lines[0], "| TP2: $66,500.00 (+4.7%) (3x)") {
 		t.Errorf("expected TP2 still pending, got: %s", lines[0])
 	}
 }
@@ -1702,7 +1703,8 @@ func TestCollectPositions_TieredTPATR_NoFillBeforeProtectionSync(t *testing.T) {
 	if strings.Contains(lines[0], "✓") {
 		t.Errorf("filled marker leaked before any TP fill, got: %s", lines[0])
 	}
-	if !strings.Contains(lines[0], "| TP1: $64,500.00 (+1.6%) (1x) | TP2: $65,500.00 (+3.1%) (2x)") {
+	// #870: default ladder retuned to 1.5×/3×/5×.
+	if !strings.Contains(lines[0], "| TP1: $65,000.00 (+2.4%) (1.5x) | TP2: $66,500.00 (+4.7%) (3x)") {
 		t.Errorf("expected both tiers pending, got: %s", lines[0])
 	}
 }
@@ -1730,7 +1732,8 @@ func TestCollectPositions_TieredTPATRRegime_StampedRegime(t *testing.T) {
 		},
 	}
 	lines := collectPositions(sc, ss, map[string]float64{"BTC/USDT": 63500})
-	if !strings.Contains(lines[0], "| TP1: $65,500.00") || !strings.Contains(lines[0], "| TP2: $67,500.00") {
+	// #870: trending_up → choppy group (1.5×/3×/5× ATR).
+	if !strings.Contains(lines[0], "| TP1: $65,000.00") || !strings.Contains(lines[0], "| TP2: $66,500.00") {
 		t.Errorf("expected regime-resolved TP prices, got: %s", lines[0])
 	}
 }
@@ -2353,11 +2356,11 @@ func TestFormatTradeDM_OpenWithATRAndTP(t *testing.T) {
 	if !strings.Contains(msg, "ATR: $1,000.00") {
 		t.Errorf("expected 'ATR: $1,000.00' in DM, got:\n%s", msg)
 	}
-	if !strings.Contains(msg, "TP1: $64,500.00") {
-		t.Errorf("expected 'TP1: $64,500.00' in DM, got:\n%s", msg)
+	if !strings.Contains(msg, "TP1: $65,000.00") {
+		t.Errorf("expected 'TP1: $65,000.00' in DM, got:\n%s", msg)
 	}
-	if !strings.Contains(msg, "TP2: $65,500.00") {
-		t.Errorf("expected 'TP2: $65,500.00' in DM, got:\n%s", msg)
+	if !strings.Contains(msg, "TP2: $66,500.00") {
+		t.Errorf("expected 'TP2: $66,500.00' in DM, got:\n%s", msg)
 	}
 }
 
@@ -2619,11 +2622,11 @@ func TestFormatTradeDM_TPATRMultipliers(t *testing.T) {
 		Details:  "Open long 0.010000 @ $63500.00",
 	}
 	msg := FormatTradeDM(sc, trade, "live")
-	if !strings.Contains(msg, "TP1: $64,500.00 (1x)") {
-		t.Errorf("expected TP1 with 1× multiplier, got:\n%s", msg)
+	if !strings.Contains(msg, "TP1: $65,000.00 (1.5x)") {
+		t.Errorf("expected TP1 with 1.5× multiplier, got:\n%s", msg)
 	}
-	if !strings.Contains(msg, "TP2: $65,500.00 (2x)") {
-		t.Errorf("expected TP2 with 2× multiplier, got:\n%s", msg)
+	if !strings.Contains(msg, "TP2: $66,500.00 (3x)") {
+		t.Errorf("expected TP2 with 3× multiplier, got:\n%s", msg)
 	}
 }
 
@@ -2682,7 +2685,8 @@ func TestFormatTradeDM_TieredTPATRRegime(t *testing.T) {
 		Details:  "Open long 0.010000 @ $63500.00",
 	}
 	msg := FormatTradeDM(sc, trade, "live")
-	if !strings.Contains(msg, "TP1: $65,500.00") || !strings.Contains(msg, "TP2: $67,500.00") {
+	// #870: trending_up → choppy group (1.5×/3×/5× ATR).
+	if !strings.Contains(msg, "TP1: $65,000.00") || !strings.Contains(msg, "TP2: $66,500.00") {
 		t.Errorf("expected regime-resolved TP lines in DM, got:\n%s", msg)
 	}
 }
@@ -2750,7 +2754,7 @@ func TestFormatTradeDMPlain_IncludesOID(t *testing.T) {
 	if !strings.Contains(msg, "SL: $2,285.00 (-0.7%) (1x)") {
 		t.Errorf("expected SL with mult on Telegram DM, got:\n%s", msg)
 	}
-	if !strings.Contains(msg, "TP1: $2,315.00 (1x)") {
+	if !strings.Contains(msg, "TP1: $2,322.50 (1.5x)") {
 		t.Errorf("expected TP1 with mult on Telegram DM, got:\n%s", msg)
 	}
 }

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1582,7 +1582,8 @@ func TestReconcileSharedCoin_TPPartialFill_DecrementsOwnerAndBooksPnL(t *testing
 					"ETH": {Symbol: "ETH", Quantity: ownerQty, InitialQuantity: ownerQty, AvgCost: avgCost, Side: "long",
 						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth",
 						EntryATR: 100, StopLossOID: 77, StopLossTriggerPx: 2900,
-						TPOIDs: []int64{0, 222}},
+						// 3-element OID slice matches the #870 3-tier default (TP1 cleared).
+						TPOIDs: []int64{0, 222, 333}},
 				},
 			},
 			"hl-peer-eth": {
@@ -1673,7 +1674,8 @@ func TestReconcileSharedCoin_TPPartialFill_Short(t *testing.T) {
 				Positions: map[string]*Position{
 					"ETH": {Symbol: "ETH", Quantity: ownerQty, InitialQuantity: ownerQty, AvgCost: avgCost, Side: "short",
 						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth",
-						TPOIDs: []int64{0, 222}},
+						// 3-element OID slice matches the #870 3-tier default (TP1 cleared).
+						TPOIDs: []int64{0, 222, 333}},
 				},
 			},
 			"hl-peer-eth": {

--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -161,15 +161,19 @@ func strategyTPTiersForRegime(sc StrategyConfig, regime string) []hlProtectionTi
 }
 
 // defaultHLProtectionTiers is the canonical fallback tier ladder used when a
-// tiered_tp_atr* close ref omits explicit tiers ({1×,0.5},{2×,1.0}). Single
+// tiered_tp_atr* close ref omits explicit tiers. #870 retuned it from the eager
+// 1×/2× to a patient 3-rung 1.5×/3×/5× ladder (40%/80%/100% cumulative). Single
 // source of truth for the scalar default — post_tp_sl.go derives
 // tp_atr_fraction's default tier multiples from this (so the firing-tier
 // multiple stays in sync if the ladder ever changes), and post_tp_sl.py mirrors
-// it as _DEFAULT_SCALAR_TP_TIERS.
+// it as _DEFAULT_SCALAR_TP_TIERS. NOTE: this also seeds HL on-chain reduce-only
+// TP placement for every tiered_tp_atr* strategy on defaults — changing it
+// moves live TP orders (#870 ⚠️ on-chain).
 func defaultHLProtectionTiers() []hlProtectionTier {
 	return []hlProtectionTier{
-		{Multiple: 1, Fraction: 0.5},
-		{Multiple: 2, Fraction: 1},
+		{Multiple: 1.5, Fraction: 0.40},
+		{Multiple: 3.0, Fraction: 0.80},
+		{Multiple: 5.0, Fraction: 1.00},
 	}
 }
 

--- a/scheduler/hyperliquid_protection_test.go
+++ b/scheduler/hyperliquid_protection_test.go
@@ -33,12 +33,14 @@ func TestBuildHyperliquidProtectionPlanUsesDefaultTieredATR(t *testing.T) {
 	if plan.StopLossATRMult != 1 {
 		t.Errorf("StopLossATRMult = %g, want 1", plan.StopLossATRMult)
 	}
-	wantTiers := []hlProtectionTier{{Multiple: 1, Fraction: 0.5}, {Multiple: 2, Fraction: 1}}
+	// #870: default ladder retuned to a patient 3-rung 1.5×/3×/5× (40/80/100%).
+	wantTiers := []hlProtectionTier{{Multiple: 1.5, Fraction: 0.4}, {Multiple: 3, Fraction: 0.8}, {Multiple: 5, Fraction: 1}}
 	if !reflect.DeepEqual(plan.Tiers, wantTiers) {
 		t.Errorf("tiers = %+v, want %+v", plan.Tiers, wantTiers)
 	}
-	if !reflect.DeepEqual(plan.TPOIDs, []int64{101, 202}) {
-		t.Errorf("TP OIDs = %v, want [101 202]", plan.TPOIDs)
+	// 3-tier default pads the 2 existing OIDs with a fresh 0 slot (#870).
+	if !reflect.DeepEqual(plan.TPOIDs, []int64{101, 202, 0}) {
+		t.Errorf("TP OIDs = %v, want [101 202 0]", plan.TPOIDs)
 	}
 }
 
@@ -67,8 +69,8 @@ func TestBuildHyperliquidProtectionPlanManualStrategy(t *testing.T) {
 	if plan.Symbol != "ETH" || plan.Size != 0.4 || plan.StopLossATRMult != 1.5 {
 		t.Errorf("manual plan = %+v", plan)
 	}
-	if !reflect.DeepEqual(plan.TPOIDs, []int64{456, 789}) {
-		t.Errorf("manual TP OIDs = %v, want [456 789]", plan.TPOIDs)
+	if !reflect.DeepEqual(plan.TPOIDs, []int64{456, 789, 0}) {
+		t.Errorf("manual TP OIDs = %v, want [456 789 0]", plan.TPOIDs)
 	}
 }
 
@@ -676,10 +678,11 @@ func TestBuildHyperliquidProtectionPlanPadsTPArmedTiers(t *testing.T) {
 	if !ok {
 		t.Fatal("expected plan ok=true")
 	}
-	if want := []bool{true, true}; !reflect.DeepEqual(plan.TPArmedTiers, want) {
+	// #870: 3-tier default pads the 2-element armed/OID slices with a fresh slot.
+	if want := []bool{true, true, false}; !reflect.DeepEqual(plan.TPArmedTiers, want) {
 		t.Errorf("TPArmedTiers = %v, want %v", plan.TPArmedTiers, want)
 	}
-	if want := []int64{0, 300}; !reflect.DeepEqual(plan.TPOIDs, want) {
+	if want := []int64{0, 300, 0}; !reflect.DeepEqual(plan.TPOIDs, want) {
 		t.Errorf("TPOIDs = %v, want %v", plan.TPOIDs, want)
 	}
 	// Shorter TPArmedTiers slice pads with false (#749 / #716 contract).
@@ -688,7 +691,7 @@ func TestBuildHyperliquidProtectionPlanPadsTPArmedTiers(t *testing.T) {
 	if !ok {
 		t.Fatal("expected plan ok=true (padded armed tiers)")
 	}
-	if want := []bool{true, false}; !reflect.DeepEqual(plan.TPArmedTiers, want) {
+	if want := []bool{true, false, false}; !reflect.DeepEqual(plan.TPArmedTiers, want) {
 		t.Errorf("padded TPArmedTiers = %v, want %v", plan.TPArmedTiers, want)
 	}
 }
@@ -791,7 +794,7 @@ func TestTieredTPATRPricesForRegimeUsesFleetDefaults(t *testing.T) {
 		},
 	}
 	got := tieredTPATRPricesForRegime(sc, "long", 100, 10, "trending_up")
-	want := []float64{120, 140} // 2× and 4× ATR @ trending_up fleet baseline
+	want := []float64{115, 130, 150} // #870: ADX trending_up → choppy group (1.5×/3×/5× ATR)
 	if len(got) != len(want) {
 		t.Fatalf("len(prices)=%d, want %d; got=%v", len(got), len(want), got)
 	}

--- a/scheduler/inspect_cmd.go
+++ b/scheduler/inspect_cmd.go
@@ -299,7 +299,7 @@ func resolveTP(sc StrategyConfig, explicit map[string]bool) tpResolution {
 			if hasTiers {
 				res.TiersFrom = "explicit on close ref"
 			} else {
-				res.TiersFrom = "default (canonical [1×@50%, 2×@100%])"
+				res.TiersFrom = "default (canonical [1.5×@40%, 3×@80%, 5×@100%])"
 			}
 		}
 		return res

--- a/scheduler/inspect_cmd_test.go
+++ b/scheduler/inspect_cmd_test.go
@@ -184,8 +184,8 @@ func TestFormatStrategyInspectionShowsResolvedTPSource(t *testing.T) {
 		"source:            stop_loss_atr_mult (explicit)",
 		"take_profit:",
 		"source:            close_strategy tiered_tp_atr",
-		"tiers:             [1× ATR @ 50%, 2× ATR @ 100%]",
-		"default (canonical [1×@50%, 2×@100%])",
+		"tiers:             [1.5× ATR @ 40%, 3× ATR @ 80%, 5× ATR @ 100%]",
+		"default (canonical [1.5×@40%, 3×@80%, 5×@100%])",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q.\nfull:\n%s", want, out)
@@ -247,7 +247,7 @@ func TestFormatStrategySummaryLineCompressesEverything(t *testing.T) {
 		"open=range_mean_revert",
 		"close=tiered_tp_atr",
 		"sl=stop_loss_atr_mult (explicit)",
-		"tp=tiered_tp_atr[2-tier]",
+		"tp=tiered_tp_atr[3-tier]",
 	} {
 		if !strings.Contains(line, want) {
 			t.Errorf("summary line missing %q: %s", want, line)
@@ -379,8 +379,10 @@ func TestFormatStrategySummaryLineRegimeTPTierCount(t *testing.T) {
 		StopLossATRMult: &mult,
 	}
 	line := formatStrategySummaryLine(sc, nil)
-	if !strings.Contains(line, "tp=tiered_tp_atr_regime[2-tier]") {
-		t.Errorf("expected 2-tier regime TP summary, got: %s", line)
+	// #870: fleet default is ragged per group (2/3/4 tiers); the summary reports
+	// the fleet maximum (clean group = 4 tiers).
+	if !strings.Contains(line, "tp=tiered_tp_atr_regime[4-tier]") {
+		t.Errorf("expected 4-tier regime TP summary, got: %s", line)
 	}
 }
 

--- a/scheduler/post_tp_sl_test.go
+++ b/scheduler/post_tp_sl_test.go
@@ -908,12 +908,13 @@ func TestRunPostTPStopLossAdjustment_TPATRFractionUsesDefaultTierMultiple(t *tes
 	if !runPostTPStopLossAdjustment(sc, state, "ETH", 110, nil, &mu, nil, nil, nil) {
 		t.Fatal("expected runPostTPStopLossAdjustment to apply")
 	}
-	// Default TP1 is 1×ATR; tp_atr_fraction=0.5 resolves to a 0.5×ATR trail.
-	if gotTrigger != 107.5 {
-		t.Fatalf("trigger=%v, want 107.5", gotTrigger)
+	// #870: default TP1 is 1.5×ATR; tp_atr_fraction=0.5 resolves to a 0.75×ATR
+	// trail → trigger = 110 - 0.75×5 = 106.25.
+	if gotTrigger != 106.25 {
+		t.Fatalf("trigger=%v, want 106.25", gotTrigger)
 	}
-	if pos.PostTPTrailingATRMult == nil || *pos.PostTPTrailingATRMult != 0.5 {
-		t.Fatalf("PostTPTrailingATRMult=%v, want 0.5", pos.PostTPTrailingATRMult)
+	if pos.PostTPTrailingATRMult == nil || *pos.PostTPTrailingATRMult != 0.75 {
+		t.Fatalf("PostTPTrailingATRMult=%v, want 0.75", pos.PostTPTrailingATRMult)
 	}
 }
 

--- a/scheduler/regime_atr.go
+++ b/scheduler/regime_atr.go
@@ -215,33 +215,70 @@ func (b RegimeATRBlock) Resolve(regime string) (RegimeATREntry, bool) {
 var regimeATRDefaults = struct {
 	StopLoss map[string]RegimeATREntry
 	Trailing map[string]RegimeATREntry
-	// TPTiers is a tier list — each entry is one tier's regime map. Tier
-	// indices are positional and the final close_fraction is coerced to 1.0
-	// by the consumer to match the live `strategyTPTiers` contract.
-	TPTiers []RegimeATRBlock
 }{
 	StopLoss: map[string]RegimeATREntry{
 		"trending_up":   {ATR: 2.0},
 		"trending_down": {ATR: 2.0},
 		"ranging":       {ATR: 1.5},
 	},
+	// #870: the regime ratchet/trailing opening trail. ADX labels keep their
+	// pre-#870 values; composite labels resolve per quality group (clean=2.5,
+	// choppy=2.0, ranging=1.0) so a trailing_stop_atr_regime use_defaults block
+	// differentiates clean trends (wide initial risk) from ranges (tight).
 	Trailing: map[string]RegimeATREntry{
-		"trending_up":   {ATR: 2.5},
-		"trending_down": {ATR: 2.5},
-		"ranging":       {ATR: 2.0},
+		"trending_up":          {ATR: 2.5},
+		"trending_down":        {ATR: 2.5},
+		"ranging":              {ATR: 2.0},
+		"trending_up_clean":    {ATR: 2.5},
+		"trending_down_clean":  {ATR: 2.5},
+		"trending_up_choppy":   {ATR: 2.0},
+		"trending_down_choppy": {ATR: 2.0},
+		"ranging_quiet":        {ATR: 1.0},
+		"ranging_volatile":     {ATR: 1.0},
+		"ranging_directional":  {ATR: 1.0},
 	},
-	TPTiers: []RegimeATRBlock{
-		{TrendRegime: map[string]RegimeATREntry{
-			"trending_up":   {ATR: 2.0, CloseFraction: 0.5, HasCloseFrac: true},
-			"trending_down": {ATR: 2.0, CloseFraction: 0.5, HasCloseFrac: true},
-			"ranging":       {ATR: 1.5, CloseFraction: 0.5, HasCloseFrac: true},
-		}},
-		{TrendRegime: map[string]RegimeATREntry{
-			"trending_up":   {ATR: 4.0, CloseFraction: 1.0, HasCloseFrac: true},
-			"trending_down": {ATR: 4.0, CloseFraction: 1.0, HasCloseFrac: true},
-			"ranging":       {ATR: 2.5, CloseFraction: 1.0, HasCloseFrac: true},
-		}},
-	},
+}
+
+// regimeCloseDefaultGroup classifies a classifier label into one of three
+// default-ladder quality groups (#870). Composite quality suffixes win; bare
+// ADX trends fall to choppy (ADX exposes no clean/choppy signal); the
+// ranging-family (ADX `ranging` + composite `ranging_*`) maps to ranging.
+// Shared by the regime ATR-TP defaults (B2) and the regime ratchet defaults
+// (C2) so both differentiate identically.
+func regimeCloseDefaultGroup(label string) (string, bool) {
+	l := strings.TrimSpace(label)
+	switch {
+	case l == "":
+		return "", false
+	case strings.HasSuffix(l, "_clean"):
+		return "clean", true
+	case strings.HasSuffix(l, "_choppy"):
+		return "choppy", true
+	case strings.HasPrefix(l, "ranging"):
+		return "ranging", true
+	case strings.HasPrefix(l, "trending_up"), strings.HasPrefix(l, "trending_down"):
+		return "choppy", true
+	}
+	return "", false
+}
+
+// regimeTPTierGroupDefaults is the per-group default ATR take-profit ladder for
+// the regime ATR-TP evaluators (#870 B2). Tier counts are ragged by design:
+// clean lets trends run (4 patient rungs), choppy mirrors the scalar default (3
+// rungs), ranging scales out fast (2 rungs). Cumulative close fractions; the
+// final rung is coerced to 1.0 by finalizeProtectionTiers.
+var regimeTPTierGroupDefaults = map[string][]hlProtectionTier{
+	"clean":   {{Multiple: 2.5, Fraction: 0.25}, {Multiple: 4.0, Fraction: 0.50}, {Multiple: 5.5, Fraction: 0.75}, {Multiple: 7.0, Fraction: 1.00}},
+	"choppy":  {{Multiple: 1.5, Fraction: 0.40}, {Multiple: 3.0, Fraction: 0.80}, {Multiple: 5.0, Fraction: 1.00}},
+	"ranging": {{Multiple: 0.5, Fraction: 0.50}, {Multiple: 1.0, Fraction: 1.00}},
+}
+
+// regimeTPFleetDefaultLabelsByGroup is the full classifier vocabulary (ADX +
+// composite) grouped for inspect-time fleet-default rendering (#870).
+var regimeTPFleetDefaultLabelsByGroup = map[string][]string{
+	"clean":   {"trending_up_clean", "trending_down_clean"},
+	"choppy":  {"trending_up", "trending_down", "trending_up_choppy", "trending_down_choppy"},
+	"ranging": {"ranging", "ranging_quiet", "ranging_volatile", "ranging_directional"},
 }
 
 // defaultRegimeBlockForSurface returns the baseline trend_regime map for a
@@ -323,9 +360,11 @@ func mapRegimeToBaselineFamily(baseline map[string]RegimeATREntry, label string)
 }
 
 func expandRegimeATRDefaultsForLabels(baseline map[string]RegimeATREntry, labels []string) map[string]RegimeATREntry {
-	if labelsAreCanonicalADX(labels) {
-		return cloneRegimeMap(baseline)
-	}
+	// Always filter to exactly the requested labels. The baseline may carry
+	// extra keys (#870 added composite opening-trail entries to Trailing), so a
+	// blanket clone would leak composite keys into an ADX strategy's block.
+	// mapRegimeToBaselineFamily exact-matches a present label and otherwise
+	// falls back to the ADX family, so ADX vocab still resolves to its 3 entries.
 	out := make(map[string]RegimeATREntry, len(labels))
 	for _, label := range labels {
 		if e, ok := mapRegimeToBaselineFamily(baseline, label); ok {
@@ -793,8 +832,11 @@ func validateRegimeATRConfig(cfg *Config) []string {
 				if sc.StopLossATRMult != nil {
 					errs = append(errs, fmt.Sprintf("%s: trailing_stop_atr_regime is mutually exclusive with stop_loss_atr_mult", prefix))
 				}
-				if sc.Platform != "hyperliquid" || sc.Type != "perps" {
-					errs = append(errs, fmt.Sprintf("%s: trailing_stop_atr_regime is HL perps only", prefix))
+				// #870: HL perps, plus HL manual when it owns a regime ratchet
+				// (trailing_tp_ratchet_regime's per-regime opening trail / SL).
+				manualRatchet := sc.Type == "manual" && strategyUsesTrailingTPRatchetClose(*sc)
+				if sc.Platform != "hyperliquid" || (sc.Type != "perps" && !manualRatchet) {
+					errs = append(errs, fmt.Sprintf("%s: trailing_stop_atr_regime is HL perps only (or HL manual trailing_tp_ratchet_regime)", prefix))
 				}
 			}
 		}
@@ -879,30 +921,46 @@ func defaultRegimeTPTiersForRegime(regime string) []hlProtectionTier {
 	if regime == "" {
 		return nil
 	}
-	out := make([]hlProtectionTier, 0, len(regimeATRDefaults.TPTiers))
-	for _, block := range regimeATRDefaults.TPTiers {
-		// Map composite labels (e.g. trending_up_clean) onto the ADX-family
-		// baseline so use_defaults tier lists resolve under either classifier.
-		entry, ok := mapRegimeToBaselineFamily(block.TrendRegime, regime)
-		if !ok || entry.ATR <= 0 {
-			return nil
-		}
-		frac := entry.CloseFraction
-		if !entry.HasCloseFrac || frac <= 0 {
-			return nil
-		}
-		out = append(out, hlProtectionTier{Multiple: entry.ATR, Fraction: frac})
+	// #870: resolve the per-quality-group ladder (clean/choppy/ranging) rather
+	// than a single positional baseline, so tier counts differ per group.
+	group, ok := regimeCloseDefaultGroup(regime)
+	if !ok {
+		return nil
 	}
+	ladder := regimeTPTierGroupDefaults[group]
+	if len(ladder) < 2 {
+		return nil
+	}
+	out := make([]hlProtectionTier, len(ladder))
+	copy(out, ladder)
 	return finalizeProtectionTiers(out)
 }
 
 // InspectRegimeTPFleetDefaultBlocks returns deep copies of the fleet baseline
 // tier blocks used when a tiered_tp_atr{_live}_regime close ref sets
-// use_defaults:true. For go-trader inspect provenance (#738).
+// use_defaults:true. For go-trader inspect provenance (#738). #870: the
+// per-group ladders are ragged, so this renders the positional union across the
+// full classifier vocabulary — block[i] only carries the labels whose group
+// defines tier i (e.g. only clean labels appear in the 4th block).
 func InspectRegimeTPFleetDefaultBlocks() []RegimeATRBlock {
-	out := make([]RegimeATRBlock, len(regimeATRDefaults.TPTiers))
-	for i, b := range regimeATRDefaults.TPTiers {
-		out[i] = RegimeATRBlock{UseDefaults: true, TrendRegime: cloneRegimeMap(b.TrendRegime)}
+	maxTiers := 0
+	for _, ladder := range regimeTPTierGroupDefaults {
+		if len(ladder) > maxTiers {
+			maxTiers = len(ladder)
+		}
+	}
+	out := make([]RegimeATRBlock, maxTiers)
+	for i := 0; i < maxTiers; i++ {
+		tr := map[string]RegimeATREntry{}
+		for group, ladder := range regimeTPTierGroupDefaults {
+			if i >= len(ladder) {
+				continue
+			}
+			for _, label := range regimeTPFleetDefaultLabelsByGroup[group] {
+				tr[label] = RegimeATREntry{ATR: ladder[i].Multiple, CloseFraction: ladder[i].Fraction, HasCloseFrac: true}
+			}
+		}
+		out[i] = RegimeATRBlock{UseDefaults: true, TrendRegime: tr}
 	}
 	return out
 }

--- a/scheduler/regime_atr_composite_test.go
+++ b/scheduler/regime_atr_composite_test.go
@@ -197,12 +197,12 @@ func TestStrategyTPTiersForRegime_CompositeUseDefaults(t *testing.T) {
 		CloseStrategy: &StrategyRef{Name: "tiered_tp_atr_regime", Params: map[string]interface{}{"use_defaults": true}},
 	}
 	tiers := strategyTPTiersForRegime(sc, "trending_up_clean")
-	if len(tiers) != 2 {
-		t.Fatalf("use_defaults composite must resolve 2 tiers, got %d: %v", len(tiers), tiers)
+	if len(tiers) != 4 {
+		t.Fatalf("use_defaults composite clean must resolve 4 tiers, got %d: %v", len(tiers), tiers)
 	}
-	// trending_up_clean maps to the trending_up baseline family (2.0, 4.0).
-	if tiers[0].Multiple != 2.0 || tiers[1].Multiple != 4.0 {
-		t.Fatalf("composite use_defaults baseline mismatch: %v", tiers)
+	// #870: trending_up_clean → clean group (2.5/4.0/5.5/7.0, cumulative).
+	if tiers[0].Multiple != 2.5 || tiers[3].Multiple != 7.0 {
+		t.Fatalf("composite use_defaults clean baseline mismatch: %v", tiers)
 	}
 }
 

--- a/scheduler/regime_atr_test.go
+++ b/scheduler/regime_atr_test.go
@@ -142,15 +142,33 @@ func TestResolveRegimeATR_ReturnsLabeledMultiplier(t *testing.T) {
 }
 
 func TestDefaultRegimeTPTiersForRegime(t *testing.T) {
-	tiers := defaultRegimeTPTiersForRegime("ranging")
-	if len(tiers) != 2 {
-		t.Fatalf("expected 2 default tiers, got %d", len(tiers))
+	// #870: per-group ragged ladders (ranging=2, choppy=3, clean=4 tiers).
+	cases := []struct {
+		regime    string
+		wantMults []float64
+	}{
+		{"ranging", []float64{0.5, 1.0}},
+		{"ranging_quiet", []float64{0.5, 1.0}},
+		{"trending_up", []float64{1.5, 3.0, 5.0}},          // ADX trend → choppy group
+		{"trending_down_choppy", []float64{1.5, 3.0, 5.0}}, // composite choppy
+		{"trending_up_clean", []float64{2.5, 4.0, 5.5, 7.0}},
 	}
-	if tiers[0].Multiple != 1.5 || tiers[1].Multiple != 2.5 {
-		t.Fatalf("baseline mult mismatch: got %v", tiers)
+	for _, tc := range cases {
+		tiers := defaultRegimeTPTiersForRegime(tc.regime)
+		if len(tiers) != len(tc.wantMults) {
+			t.Fatalf("%s: got %d tiers, want %d: %v", tc.regime, len(tiers), len(tc.wantMults), tiers)
+		}
+		for i, m := range tc.wantMults {
+			if tiers[i].Multiple != m {
+				t.Errorf("%s: tier[%d] mult = %g, want %g", tc.regime, i, tiers[i].Multiple, m)
+			}
+		}
+		if tiers[len(tiers)-1].Fraction != 1.0 {
+			t.Errorf("%s: final tier fraction must be coerced to 1.0, got %g", tc.regime, tiers[len(tiers)-1].Fraction)
+		}
 	}
-	if tiers[len(tiers)-1].Fraction != 1.0 {
-		t.Fatalf("final tier fraction must be coerced to 1.0, got %g", tiers[len(tiers)-1].Fraction)
+	if defaultRegimeTPTiersForRegime("") != nil {
+		t.Error("empty regime must resolve to nil (SL-only until stamped)")
 	}
 }
 

--- a/scheduler/trailing_tp_ratchet.go
+++ b/scheduler/trailing_tp_ratchet.go
@@ -61,6 +61,48 @@ func defaultTrailingRatchetTiers() []trailingRatchetTier {
 	}
 }
 
+// ratchetTierGroupDefaults is the per-quality-group default ratchet ladder for
+// the regime variant (#870 C2). Trend groups (clean/choppy) are pure
+// let-it-ride (close_fraction 0); ranging scales out as ranges mean-revert.
+// Each group's first-rung trail couples to that group's opening trail in
+// regimeATRDefaults.Trailing (clean 2.5 / choppy 2.0 / ranging 1.0). Mirrors
+// DEFAULT_RATCHET_TIERS_BY_GROUP in shared_strategies/close/trailing_tp_ratchet.py.
+var ratchetTierGroupDefaults = map[string][]trailingRatchetTier{
+	"clean": {
+		{ATRMultiple: 3.0, CloseFraction: 0, TrailingMultAfter: 1.5},
+		{ATRMultiple: 4.5, CloseFraction: 0, TrailingMultAfter: 1.0},
+		{ATRMultiple: 6.0, CloseFraction: 0, TrailingMultAfter: 0.5},
+	},
+	"choppy": {
+		{ATRMultiple: 2.0, CloseFraction: 0, TrailingMultAfter: 1.5},
+		{ATRMultiple: 2.5, CloseFraction: 0, TrailingMultAfter: 1.0},
+		{ATRMultiple: 3.0, CloseFraction: 0, TrailingMultAfter: 0.5},
+	},
+	"ranging": {
+		{ATRMultiple: 0.75, CloseFraction: 0.4, TrailingMultAfter: 1.0},
+		{ATRMultiple: 1.5, CloseFraction: 0.8, TrailingMultAfter: 0.75},
+		{ATRMultiple: 2.0, CloseFraction: 1.0, TrailingMultAfter: 0.5},
+	},
+}
+
+// defaultTrailingRatchetTiersForRegime resolves the per-group default ratchet
+// ladder for a stamped regime label (#870 C2 use_defaults / omitted tp_tiers on
+// trailing_tp_ratchet_regime). Returns nil for an empty/unknown label so the
+// caller emits only the SL until the position regime is stamped.
+func defaultTrailingRatchetTiersForRegime(regime string) []trailingRatchetTier {
+	group, ok := regimeCloseDefaultGroup(regime)
+	if !ok {
+		return nil
+	}
+	src := ratchetTierGroupDefaults[group]
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]trailingRatchetTier, len(src))
+	copy(out, src)
+	return out
+}
+
 func resolveTrailingMultAfter(tier map[string]interface{}, firingMultiple float64) (float64, error) {
 	_, hasAbs := tier["trailing_mult_after"]
 	_, hasFrac := tier["tp_atr_fraction"]
@@ -161,9 +203,13 @@ func trailingRatchetTiersForRegime(sc StrategyConfig, regime string) []trailingR
 		}
 		raw, ok := closeTierListParam(ref.Params)
 		if !ok {
-			// #866: omitted tp_tiers (or use_defaults:true) resolves to the
-			// system default ladder, broadcast across every regime for the
-			// regime variant.
+			// Omitted tp_tiers (or use_defaults:true) resolves to the system
+			// default ladder. #870: the regime variant resolves the per-group
+			// ladder for the stamped regime; the scalar variant broadcasts the
+			// single #866 default.
+			if name == trailingTPRatchetRegimeCloseName {
+				return defaultTrailingRatchetTiersForRegime(regime)
+			}
 			return defaultTrailingRatchetTiers()
 		}
 		if name == trailingTPRatchetRegimeCloseName {
@@ -201,14 +247,36 @@ func validateTrailingTPRatchetClose(sc StrategyConfig, labels []string, regimeEn
 	if sc.Platform != "hyperliquid" || (sc.Type != "perps" && sc.Type != "manual") {
 		errs = append(errs, fmt.Sprintf("%s: trailing_tp_ratchet* is HL perps/manual only", prefix))
 	}
-	if sc.TrailingStopATRMult == nil || *sc.TrailingStopATRMult <= 0 {
-		errs = append(errs, fmt.Sprintf("%s: trailing_tp_ratchet* requires trailing_stop_atr_mult > 0 (initial trail distance)", prefix))
+	// #870: the SL owner + initial trail differs by variant. The scalar
+	// trailing_tp_ratchet owns it via trailing_stop_atr_mult; the regime
+	// trailing_tp_ratchet_regime owns it via the per-regime trailing_stop_atr_regime
+	// block, so per-trade initial risk scales with the stamped regime (tight in
+	// ranges, wide in clean trends).
+	regimeVariant := false
+	for _, ref := range sc.closeRefs() {
+		if strings.ToLower(strings.TrimSpace(ref.Name)) == trailingTPRatchetRegimeCloseName {
+			regimeVariant = true
+			break
+		}
+	}
+	hasRegimeBlock := sc.TrailingStopATRRegime != nil && !sc.TrailingStopATRRegime.IsZero()
+	if regimeVariant {
+		if !hasRegimeBlock {
+			errs = append(errs, fmt.Sprintf("%s: trailing_tp_ratchet_regime requires trailing_stop_atr_regime (the per-regime opening trail / SL owner)", prefix))
+		}
+		if sc.TrailingStopATRMult != nil && *sc.TrailingStopATRMult > 0 {
+			errs = append(errs, fmt.Sprintf("%s: trailing_tp_ratchet_regime cannot combine with scalar trailing_stop_atr_mult (the trailing_stop_atr_regime block owns the trail)", prefix))
+		}
+	} else {
+		if sc.TrailingStopATRMult == nil || *sc.TrailingStopATRMult <= 0 {
+			errs = append(errs, fmt.Sprintf("%s: trailing_tp_ratchet requires trailing_stop_atr_mult > 0 (initial trail distance)", prefix))
+		}
+		if hasRegimeBlock {
+			errs = append(errs, fmt.Sprintf("%s: trailing_tp_ratchet cannot combine with trailing_stop_atr_regime (use trailing_tp_ratchet_regime)", prefix))
+		}
 	}
 	if sc.TrailingStopPct != nil && *sc.TrailingStopPct > 0 {
 		errs = append(errs, fmt.Sprintf("%s: trailing_tp_ratchet* cannot combine with trailing_stop_pct", prefix))
-	}
-	if sc.TrailingStopATRRegime != nil && !sc.TrailingStopATRRegime.IsZero() {
-		errs = append(errs, fmt.Sprintf("%s: trailing_tp_ratchet* cannot combine with trailing_stop_atr_regime", prefix))
 	}
 	if sc.StopLossPct != nil && *sc.StopLossPct > 0 {
 		errs = append(errs, fmt.Sprintf("%s: trailing_tp_ratchet* cannot combine with stop_loss_pct", prefix))
@@ -222,9 +290,22 @@ func validateTrailingTPRatchetClose(sc StrategyConfig, labels []string, regimeEn
 	if sc.StopLossATRRegime.IsConfigured() {
 		errs = append(errs, fmt.Sprintf("%s: trailing_tp_ratchet* cannot combine with stop_loss_atr_regime", prefix))
 	}
-	initialTrail := 0.0
-	if sc.TrailingStopATRMult != nil {
-		initialTrail = *sc.TrailingStopATRMult
+	// scalarInitialTrail couples the scalar variant's first rung to
+	// trailing_stop_atr_mult; the regime variant resolves the open per regime
+	// key from the trailing_stop_atr_regime block (populated upstream by
+	// ResolveSurfaceWithLabels).
+	scalarInitialTrail := 0.0
+	if !regimeVariant && sc.TrailingStopATRMult != nil {
+		scalarInitialTrail = *sc.TrailingStopATRMult
+	}
+	regimeKeyOpen := func(key string) float64 {
+		if sc.TrailingStopATRRegime == nil {
+			return 0
+		}
+		if v, ok := resolveRegimeATR(*sc.TrailingStopATRRegime, key); ok {
+			return v
+		}
+		return 0
 	}
 	for _, ref := range sc.closeRefs() {
 		if !isTrailingTPRatchetCloseName(ref.Name) {
@@ -249,14 +330,22 @@ func validateTrailingTPRatchetClose(sc StrategyConfig, labels []string, regimeEn
 		}
 		raw, hasTiers := closeTierListParam(ref.Params)
 		if !hasTiers {
-			// #866: omitted tp_tiers (or use_defaults:true) resolves to the
-			// system default ladder — broadcast across every regime label for
-			// the regime variant, so exhaustiveness is satisfied automatically.
-			// The default is internally valid (monotonic, ascending); the only
-			// load-time check that still applies is the initial-trail coupling
-			// against the operator's trailing_stop_atr_mult.
-			def := defaultTrailingRatchetTiers()
-			errs = append(errs, validateTrailingRatchetInitialTrail(def, initialTrail, sub+".tp_tiers(default)")...)
+			// Omitted tp_tiers (or use_defaults:true) resolves to the system
+			// default ladder. The default is internally valid (monotonic,
+			// ascending); the only load-time check that still applies is the
+			// initial-trail coupling against the opening trail. #870: the regime
+			// variant resolves a per-group ladder per regime key and couples each
+			// against that key's opening trail; the scalar variant uses the
+			// single #866 default against trailing_stop_atr_mult.
+			if isRegime {
+				for _, key := range labels {
+					def := defaultTrailingRatchetTiersForRegime(key)
+					errs = append(errs, validateTrailingRatchetInitialTrail(def, regimeKeyOpen(key), sub+".tp_tiers(default)."+key)...)
+				}
+			} else {
+				def := defaultTrailingRatchetTiers()
+				errs = append(errs, validateTrailingRatchetInitialTrail(def, scalarInitialTrail, sub+".tp_tiers(default)")...)
+			}
 			continue
 		}
 		if isRegime {
@@ -283,7 +372,7 @@ func validateTrailingTPRatchetClose(sc StrategyConfig, labels []string, regimeEn
 				tiers, subErrs := parseTrailingRatchetTierList(block, sub+".tp_tiers."+key)
 				errs = append(errs, subErrs...)
 				errs = append(errs, validateTrailingRatchetTierMonotonicity(tiers, sub+".tp_tiers."+key)...)
-				errs = append(errs, validateTrailingRatchetInitialTrail(tiers, initialTrail, sub+".tp_tiers."+key)...)
+				errs = append(errs, validateTrailingRatchetInitialTrail(tiers, regimeKeyOpen(key), sub+".tp_tiers."+key)...)
 			}
 			continue
 		}
@@ -299,13 +388,13 @@ func validateTrailingTPRatchetClose(sc StrategyConfig, labels []string, regimeEn
 			tiers, subErrs := parseTrailingRatchetTierList(block, sub+".tp_tiers")
 			errs = append(errs, subErrs...)
 			errs = append(errs, validateTrailingRatchetTierMonotonicity(tiers, sub+".tp_tiers")...)
-			errs = append(errs, validateTrailingRatchetInitialTrail(tiers, initialTrail, sub+".tp_tiers")...)
+			errs = append(errs, validateTrailingRatchetInitialTrail(tiers, scalarInitialTrail, sub+".tp_tiers")...)
 			continue
 		}
 		tiers, subErrs := parseTrailingRatchetTierList(raw, sub+".tp_tiers")
 		errs = append(errs, subErrs...)
 		errs = append(errs, validateTrailingRatchetTierMonotonicity(tiers, sub+".tp_tiers")...)
-		errs = append(errs, validateTrailingRatchetInitialTrail(tiers, initialTrail, sub+".tp_tiers")...)
+		errs = append(errs, validateTrailingRatchetInitialTrail(tiers, scalarInitialTrail, sub+".tp_tiers")...)
 	}
 	return errs
 }
@@ -364,6 +453,14 @@ func effectiveTrailingRatchetMult(pos *Position, sc StrategyConfig) float64 {
 	}
 	if sc.TrailingStopATRMult != nil && *sc.TrailingStopATRMult > 0 {
 		return *sc.TrailingStopATRMult
+	}
+	// #870: the regime ratchet's initial loose trail is the per-regime opening
+	// trail from trailing_stop_atr_regime, not a scalar mult — resolve it so the
+	// first rung is correctly seen as a tightening (not a no-op against 0).
+	if sc.TrailingStopATRRegime != nil && !sc.TrailingStopATRRegime.IsZero() && pos != nil {
+		if v, ok := resolveRegimeATR(*sc.TrailingStopATRRegime, protectionATRRegimeLabel(pos, sc)); ok {
+			return v
+		}
 	}
 	return 0
 }

--- a/scheduler/trailing_tp_ratchet_test.go
+++ b/scheduler/trailing_tp_ratchet_test.go
@@ -402,11 +402,12 @@ func TestValidateTrailingTPRatchetClose_CompositeVocabulary(t *testing.T) {
 		t.Fatalf("expected 7 composite labels, got %d", len(composite))
 	}
 
-	trail := 3.0
+	// #870: the regime variant's opening trail / SL owner is the per-regime
+	// trailing_stop_atr_regime block (scalar trailing_stop_atr_mult rejected).
 	scOK := StrategyConfig{
 		ID: "hl-comp", Type: "perps", Platform: "hyperliquid",
-		RegimeATRWindow:     "daily",
-		TrailingStopATRMult: &trail,
+		RegimeATRWindow:       "daily",
+		TrailingStopATRRegime: &RegimeATRBlock{raw: composite7StateATR(3.0)},
 		CloseStrategy: &StrategyRef{
 			Name:   "trailing_tp_ratchet_regime",
 			Params: map[string]interface{}{"tp_tiers": compositeTable(composite)},
@@ -419,11 +420,10 @@ func TestValidateTrailingTPRatchetClose_CompositeVocabulary(t *testing.T) {
 	// A 3-state ADX label under a composite window must be rejected.
 	bad := compositeTable(composite)
 	bad["ranging"] = tierList // not a composite label
-	trail2 := 3.0
 	scBad := StrategyConfig{
 		ID: "hl-comp-bad", Type: "perps", Platform: "hyperliquid",
-		RegimeATRWindow:     "daily",
-		TrailingStopATRMult: &trail2,
+		RegimeATRWindow:       "daily",
+		TrailingStopATRRegime: &RegimeATRBlock{raw: composite7StateATR(3.0)},
 		CloseStrategy: &StrategyRef{
 			Name:   "trailing_tp_ratchet_regime",
 			Params: map[string]interface{}{"tp_tiers": bad},
@@ -549,15 +549,21 @@ func TestValidateTrailingTPRatchetClose_DefaultRespectsInitialTrail(t *testing.T
 }
 
 func TestValidateTrailingTPRatchetClose_RegimeOmittedTiersUsesDefault(t *testing.T) {
-	trail := 2.0
+	// #870: the regime variant's opening trail / SL owner is the per-regime
+	// block; each ADX label's open must clear its group's first ratchet rung
+	// (trending_* → choppy first rung 1.5; ranging → ranging first rung 1.0).
 	sc := StrategyConfig{
 		ID: "s1", Type: "perps", Platform: "hyperliquid",
-		TrailingStopATRMult: &trail,
-		CloseStrategy:       &StrategyRef{Name: "trailing_tp_ratchet_regime", Params: map[string]interface{}{"use_defaults": true}},
+		TrailingStopATRRegime: &RegimeATRBlock{TrendRegime: map[string]RegimeATREntry{
+			"trending_up":   {ATR: 2.0},
+			"trending_down": {ATR: 2.0},
+			"ranging":       {ATR: 1.5},
+		}},
+		CloseStrategy: &StrategyRef{Name: "trailing_tp_ratchet_regime", Params: map[string]interface{}{"use_defaults": true}},
 	}
-	// regime.enabled=true: the broadcast default satisfies exhaustiveness for all labels.
+	// regime.enabled=true: the per-group default satisfies exhaustiveness for all labels.
 	if errs := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels, true); len(errs) > 0 {
-		t.Fatalf("regime ratchet use_defaults should validate via broadcast default, got: %v", errs)
+		t.Fatalf("regime ratchet use_defaults should validate via per-group default, got: %v", errs)
 	}
 	// regime.enabled=false still rejected (independent of tier source).
 	if errs := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels, false); !errListContains(errs, "requires top-level regime.enabled=true") {
@@ -567,12 +573,21 @@ func TestValidateTrailingTPRatchetClose_RegimeOmittedTiersUsesDefault(t *testing
 
 func TestTrailingRatchetTiersForRegime_OmittedReturnsDefault(t *testing.T) {
 	trail := 2.0
-	want := defaultTrailingRatchetTiers()
 	cases := []struct {
 		name, closeName, regime string
+		want                    []trailingRatchetTier
 	}{
-		{"scalar", "trailing_tp_ratchet", ""},
-		{"regime-broadcast", "trailing_tp_ratchet_regime", "trending_up"},
+		{"scalar", "trailing_tp_ratchet", "", defaultTrailingRatchetTiers()},
+		// #870: the regime variant resolves the per-quality-group ladder.
+		{"regime-clean", "trailing_tp_ratchet_regime", "trending_up_clean", []trailingRatchetTier{
+			{ATRMultiple: 3.0, TrailingMultAfter: 1.5}, {ATRMultiple: 4.5, TrailingMultAfter: 1.0}, {ATRMultiple: 6.0, TrailingMultAfter: 0.5},
+		}},
+		{"regime-choppy", "trailing_tp_ratchet_regime", "trending_up", []trailingRatchetTier{
+			{ATRMultiple: 2.0, TrailingMultAfter: 1.5}, {ATRMultiple: 2.5, TrailingMultAfter: 1.0}, {ATRMultiple: 3.0, TrailingMultAfter: 0.5},
+		}},
+		{"regime-ranging", "trailing_tp_ratchet_regime", "ranging_quiet", []trailingRatchetTier{
+			{ATRMultiple: 0.75, CloseFraction: 0.4, TrailingMultAfter: 1.0}, {ATRMultiple: 1.5, CloseFraction: 0.8, TrailingMultAfter: 0.75}, {ATRMultiple: 2.0, CloseFraction: 1.0, TrailingMultAfter: 0.5},
+		}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -582,15 +597,139 @@ func TestTrailingRatchetTiersForRegime_OmittedReturnsDefault(t *testing.T) {
 				CloseStrategy:       &StrategyRef{Name: tc.closeName, Params: map[string]interface{}{"use_defaults": true}},
 			}
 			got := trailingRatchetTiersForRegime(sc, tc.regime)
-			if len(got) != len(want) {
-				t.Fatalf("resolved %d tiers want %d (%+v)", len(got), len(want), got)
+			if len(got) != len(tc.want) {
+				t.Fatalf("resolved %d tiers want %d (%+v)", len(got), len(tc.want), got)
 			}
-			for i := range want {
-				if got[i] != want[i] {
-					t.Fatalf("tier[%d]=%+v want %+v", i, got[i], want[i])
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("tier[%d]=%+v want %+v", i, got[i], tc.want[i])
 				}
 			}
 		})
+	}
+}
+
+func TestRegimeCloseDefaultGroup(t *testing.T) {
+	cases := []struct {
+		label, group string
+		ok           bool
+	}{
+		{"trending_up_clean", "clean", true},
+		{"trending_down_clean", "clean", true},
+		{"trending_up_choppy", "choppy", true},
+		{"trending_down_choppy", "choppy", true},
+		{"trending_up", "choppy", true},   // ADX trend → choppy (no clean/choppy signal)
+		{"trending_down", "choppy", true}, // ADX trend → choppy
+		{"ranging", "ranging", true},
+		{"ranging_quiet", "ranging", true},
+		{"ranging_volatile", "ranging", true},
+		{"ranging_directional", "ranging", true},
+		{"", "", false},
+		{"bogus", "", false},
+	}
+	for _, tc := range cases {
+		g, ok := regimeCloseDefaultGroup(tc.label)
+		if ok != tc.ok || g != tc.group {
+			t.Errorf("regimeCloseDefaultGroup(%q) = (%q, %v), want (%q, %v)", tc.label, g, ok, tc.group, tc.ok)
+		}
+	}
+}
+
+// TestValidateTrailingTPRatchetClose_RegimeRejectsScalarMult covers #870: the
+// regime variant's trail is owned by trailing_stop_atr_regime, so a scalar
+// trailing_stop_atr_mult is rejected.
+func TestValidateTrailingTPRatchetClose_RegimeRejectsScalarMult(t *testing.T) {
+	trail := 2.0
+	sc := StrategyConfig{
+		ID: "s1", Type: "perps", Platform: "hyperliquid",
+		TrailingStopATRMult: &trail,
+		TrailingStopATRRegime: &RegimeATRBlock{TrendRegime: map[string]RegimeATREntry{
+			"trending_up": {ATR: 2.0}, "trending_down": {ATR: 2.0}, "ranging": {ATR: 1.5},
+		}},
+		CloseStrategy: &StrategyRef{Name: "trailing_tp_ratchet_regime", Params: map[string]interface{}{"use_defaults": true}},
+	}
+	errs := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels, true)
+	if !errListContains(errs, "cannot combine with scalar trailing_stop_atr_mult") {
+		t.Fatalf("expected scalar-mult rejection for regime ratchet, got: %v", errs)
+	}
+}
+
+// TestValidateTrailingTPRatchetClose_RegimePerKeyInitialTrail covers #870: the
+// initial-trail coupling is checked against each regime key's own opening trail,
+// so a too-loose first rung is rejected scoped to that key only.
+func TestValidateTrailingTPRatchetClose_RegimePerKeyInitialTrail(t *testing.T) {
+	tier := func(mult, trailAfter float64) map[string]interface{} {
+		return map[string]interface{}{"atr_multiple": mult, "close_fraction": 0.0, "trailing_mult_after": trailAfter}
+	}
+	table := map[string]interface{}{
+		"trending_up":   []interface{}{tier(3.0, 1.5), tier(4.0, 1.0)},
+		"trending_down": []interface{}{tier(3.0, 1.5), tier(4.0, 1.0)},
+		"ranging":       []interface{}{tier(3.0, 2.0), tier(4.0, 1.0)}, // first trail 2.0 > ranging open 1.0
+	}
+	sc := StrategyConfig{
+		ID: "s1", Type: "perps", Platform: "hyperliquid",
+		TrailingStopATRRegime: &RegimeATRBlock{TrendRegime: map[string]RegimeATREntry{
+			"trending_up": {ATR: 3.0}, "trending_down": {ATR: 3.0}, "ranging": {ATR: 1.0},
+		}},
+		CloseStrategy: &StrategyRef{Name: "trailing_tp_ratchet_regime", Params: map[string]interface{}{"tp_tiers": table}},
+	}
+	errs := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels, true)
+	if !errListContains(errs, "tp_tiers.ranging") || !errListContains(errs, "can only tighten") {
+		t.Fatalf("expected per-key initial-trail error scoped to ranging, got: %v", errs)
+	}
+	if errListContains(errs, "tp_tiers.trending_up[0]") {
+		t.Fatalf("trending_up (open 3.0) should pass the initial-trail check, got: %v", errs)
+	}
+}
+
+// TestValidateTrailingTPRatchetClose_ManualRegimeRatchet covers #870: HL manual
+// may own a regime ratchet via trailing_stop_atr_regime (gate widened).
+func TestValidateTrailingTPRatchetClose_ManualRegimeRatchet(t *testing.T) {
+	sc := StrategyConfig{
+		ID: "hl-man", Type: "manual", Platform: "hyperliquid",
+		TrailingStopATRRegime: &RegimeATRBlock{TrendRegime: map[string]RegimeATREntry{
+			"trending_up": {ATR: 2.0}, "trending_down": {ATR: 2.0}, "ranging": {ATR: 1.5},
+		}},
+		CloseStrategy: &StrategyRef{Name: "trailing_tp_ratchet_regime", Params: map[string]interface{}{"use_defaults": true}},
+	}
+	if errs := validateTrailingTPRatchetClose(sc, canonicalTrendRegimeLabels, true); len(errs) > 0 {
+		t.Fatalf("manual regime ratchet should validate, got: %v", errs)
+	}
+}
+
+// TestDefaultTrailingRatchetTiersForRegime covers #870 per-group ratchet ladders.
+func TestDefaultTrailingRatchetTiersForRegime(t *testing.T) {
+	clean := defaultTrailingRatchetTiersForRegime("trending_up_clean")
+	if len(clean) != 3 || clean[0].ATRMultiple != 3.0 || clean[0].TrailingMultAfter != 1.5 || clean[2].ATRMultiple != 6.0 {
+		t.Fatalf("clean group mismatch: %+v", clean)
+	}
+	ranging := defaultTrailingRatchetTiersForRegime("ranging_volatile")
+	if len(ranging) != 3 || ranging[0].CloseFraction != 0.4 || ranging[2].CloseFraction != 1.0 {
+		t.Fatalf("ranging group mismatch: %+v", ranging)
+	}
+	if defaultTrailingRatchetTiersForRegime("") != nil {
+		t.Error("empty regime must resolve to nil")
+	}
+}
+
+// TestValidateRegimeRatchet_AllDefaultsCompositeValidates is the #870
+// integration case: trailing_stop_atr_regime + trailing_tp_ratchet_regime both
+// on use_defaults under a composite classifier. The full validateRegimeATRConfig
+// path expands the per-group opening trails (clean 2.5 / choppy 2.0 / ranging
+// 1.0) and per-group ratchet ladders, and the per-key initial-trail coupling
+// must hold for every label (each group's first rung ≤ its open).
+func TestValidateRegimeRatchet_AllDefaultsCompositeValidates(t *testing.T) {
+	sc := StrategyConfig{
+		ID: "hl-allc", Type: "perps", Platform: "hyperliquid",
+		RegimeATRWindow:       "daily",
+		TrailingStopATRRegime: &RegimeATRBlock{raw: map[string]interface{}{"use_defaults": true}},
+		CloseStrategy: &StrategyRef{
+			Name:   "trailing_tp_ratchet_regime",
+			Params: map[string]interface{}{"use_defaults": true},
+		},
+	}
+	if errs := validateRegimeATRConfig(compositeRegimeCfg(sc)); len(errs) != 0 {
+		t.Fatalf("all-defaults composite regime ratchet must validate, got: %v", errs)
 	}
 }
 

--- a/shared_strategies/close/post_tp_sl.py
+++ b/shared_strategies/close/post_tp_sl.py
@@ -39,10 +39,12 @@ _TIERED_TP_NAMES = (
 # Canonical fallback tier ladder when a tiered_tp_atr* close ref omits explicit
 # tiers. MUST stay in sync with the Go source of truth
 # `defaultHLProtectionTiers()` in scheduler/hyperliquid_protection.go
-# ({1×,0.5},{2×,1.0}); tp_atr_fraction derives its firing-tier multiple from it.
+# (#870: 1.5×/3×/5× @ 40%/80%/100%); tp_atr_fraction derives its firing-tier
+# multiple from it.
 _DEFAULT_SCALAR_TP_TIERS: Tuple[Tuple[float, float], ...] = (
-    (1.0, 0.5),
-    (2.0, 1.0),
+    (1.5, 0.40),
+    (3.0, 0.80),
+    (5.0, 1.00),
 )
 
 

--- a/shared_strategies/close/regime_atr.py
+++ b/shared_strategies/close/regime_atr.py
@@ -121,27 +121,47 @@ REGIME_ATR_DEFAULTS_TRAILING: Dict[str, RegimeATREntry] = {
     "trending_up": RegimeATREntry(atr=2.5),
     "trending_down": RegimeATREntry(atr=2.5),
     "ranging": RegimeATREntry(atr=2.0),
+    # #870: composite group opening trails (clean=2.5, choppy=2.0, ranging=1.0).
+    # ADX labels keep their pre-#870 values; resolve() exact-matches keys so the
+    # extra composite entries are inert for an ADX strategy.
+    "trending_up_clean": RegimeATREntry(atr=2.5),
+    "trending_down_clean": RegimeATREntry(atr=2.5),
+    "trending_up_choppy": RegimeATREntry(atr=2.0),
+    "trending_down_choppy": RegimeATREntry(atr=2.0),
+    "ranging_quiet": RegimeATREntry(atr=1.0),
+    "ranging_volatile": RegimeATREntry(atr=1.0),
+    "ranging_directional": RegimeATREntry(atr=1.0),
 }
 
-# Tier defaults: positional list. Each entry is one tier's regime block with
-# per-regime close_fraction. Final tier close_fraction is coerced to 1.0 by
-# downstream consumers.
-REGIME_ATR_DEFAULTS_TP_TIERS: List[RegimeATRBlock] = [
-    RegimeATRBlock(
-        trend_regime={
-            "trending_up": RegimeATREntry(atr=2.0, close_fraction=0.5, has_close_frac=True),
-            "trending_down": RegimeATREntry(atr=2.0, close_fraction=0.5, has_close_frac=True),
-            "ranging": RegimeATREntry(atr=1.5, close_fraction=0.5, has_close_frac=True),
-        }
-    ),
-    RegimeATRBlock(
-        trend_regime={
-            "trending_up": RegimeATREntry(atr=4.0, close_fraction=1.0, has_close_frac=True),
-            "trending_down": RegimeATREntry(atr=4.0, close_fraction=1.0, has_close_frac=True),
-            "ranging": RegimeATREntry(atr=2.5, close_fraction=1.0, has_close_frac=True),
-        }
-    ),
-]
+# #870: per-quality-group default ATR take-profit ladders. Mirrors
+# regimeTPTierGroupDefaults in scheduler/regime_atr.go. (atr_multiple,
+# cumulative_close_fraction); the final rung is coerced to 1.0 by the consumer.
+# Tier counts are ragged by design: clean lets trends run (4 rungs), choppy
+# mirrors the scalar default (3), ranging scales out fast (2).
+REGIME_TP_TIER_GROUP_DEFAULTS: Dict[str, List[Tuple[float, float]]] = {
+    "clean": [(2.5, 0.25), (4.0, 0.50), (5.5, 0.75), (7.0, 1.00)],
+    "choppy": [(1.5, 0.40), (3.0, 0.80), (5.0, 1.00)],
+    "ranging": [(0.5, 0.50), (1.0, 1.00)],
+}
+
+
+def regime_close_default_group(label: str) -> Optional[str]:
+    """Classify a classifier label into one of three default-ladder quality
+    groups (#870). Mirrors regimeCloseDefaultGroup in
+    scheduler/regime_atr.go: composite quality suffixes win, bare ADX trends
+    fall to choppy, the ranging-family maps to ranging."""
+    label = (label or "").strip()
+    if not label:
+        return None
+    if label.endswith("_clean"):
+        return "clean"
+    if label.endswith("_choppy"):
+        return "choppy"
+    if label.startswith("ranging"):
+        return "ranging"
+    if label.startswith("trending_up") or label.startswith("trending_down"):
+        return "choppy"
+    return None
 
 
 def _default_block_for_surface(surface: str) -> Optional[Dict[str, RegimeATREntry]]:
@@ -149,21 +169,6 @@ def _default_block_for_surface(surface: str) -> Optional[Dict[str, RegimeATREntr
         return dict(REGIME_ATR_DEFAULTS_STOP_LOSS)
     if surface == SURFACE_TRAILING:
         return dict(REGIME_ATR_DEFAULTS_TRAILING)
-    return None
-
-
-def _default_entry_for_label(
-    baseline: Dict[str, RegimeATREntry],
-    label: str,
-) -> Optional[RegimeATREntry]:
-    if label in baseline:
-        return baseline[label]
-    if label.startswith("trending_up"):
-        return baseline.get("trending_up")
-    if label.startswith("trending_down"):
-        return baseline.get("trending_down")
-    if label.startswith("ranging"):
-        return baseline.get("ranging")
     return None
 
 
@@ -382,22 +387,37 @@ def parse_regime_tp_tiers(
                 "tiers (use_defaults is all-or-nothing)"
             )
             return [], errs
-        # Use the default tier list. Each default tier carries per-regime
-        # close_fraction (HasCloseFrac=True).
+        # #870: per-quality-group default ladders (clean 4 / choppy 3 / ranging
+        # 2 tiers). Build positional specs as the union across the requested
+        # labels — block[i] only carries the labels whose group defines tier i.
+        # Callers that resolve a single regime (sl_after) get exactly that
+        # group's tier count; resolve_regime_tier skips labels absent from a
+        # block. Mirrors Go's defaultRegimeTPTiersForRegime / InspectRegimeTP.
+        label_ladders: Dict[str, List[Tuple[float, float]]] = {}
+        max_tiers = 0
+        for label in labels:
+            group = regime_close_default_group(label)
+            ladder = REGIME_TP_TIER_GROUP_DEFAULTS.get(group) if group else None
+            if not ladder:
+                continue
+            label_ladders[label] = ladder
+            if len(ladder) > max_tiers:
+                max_tiers = len(ladder)
         out: List[RegimeTierSpec] = []
-        for default_block in REGIME_ATR_DEFAULTS_TP_TIERS:
-            # Deep copy and expand composite labels onto their ADX-family
-            # defaults so Python mirrors Go's defaultRegimeTPTiersForRegime.
-            expanded: Dict[str, RegimeATREntry] = {}
-            for label in labels:
-                entry = _default_entry_for_label(default_block.trend_regime, label)
-                if entry is not None:
-                    expanded[label] = entry
-            block_copy = RegimeATRBlock(
-                use_defaults=True,
-                trend_regime=expanded,
+        for i in range(max_tiers):
+            trend: Dict[str, RegimeATREntry] = {}
+            for label, ladder in label_ladders.items():
+                if i < len(ladder):
+                    mult, frac = ladder[i]
+                    trend[label] = RegimeATREntry(
+                        atr=mult, close_fraction=frac, has_close_frac=True
+                    )
+            out.append(
+                RegimeTierSpec(
+                    block=RegimeATRBlock(use_defaults=True, trend_regime=trend),
+                    tier_close_fraction=None,
+                )
             )
-            out.append(RegimeTierSpec(block=block_copy, tier_close_fraction=None))
         return out, errs
 
     if not isinstance(raw_tiers, list):

--- a/shared_strategies/close/test_close_registry.py
+++ b/shared_strategies/close/test_close_registry.py
@@ -62,31 +62,33 @@ def test_tp_at_pct_deprecated_shim(registry):
 
 
 def test_tiered_tp_pct_closes_only_unfilled_tier_amount(registry):
+    # #870: default ladder is 0.01/0.02/0.03/0.04 → 0.25/0.50/0.75/1.00.
     first = registry.evaluate(
         "tiered_tp_pct",
         {"side": "long", "avg_cost": 100, "current_quantity": 1, "initial_quantity": 1},
-        {"mark_price": 103},
+        {"mark_price": 102},  # +2% → cumulative target 0.50
         {},
     )
     already_taken = registry.evaluate(
         "tiered_tp_pct",
         {"side": "long", "avg_cost": 100, "current_quantity": 0.5, "initial_quantity": 1},
-        {"mark_price": 103},
+        {"mark_price": 102},
         {},
     )
     final = registry.evaluate(
         "tiered_tp_pct",
         {"side": "long", "avg_cost": 100, "current_quantity": 0.5, "initial_quantity": 1},
-        {"mark_price": 106},
+        {"mark_price": 104},  # +4% → cumulative target 1.00
         {},
     )
 
-    assert first == {"close_fraction": 0.5, "reason": "tiered_tp_pct:0.03"}
+    assert first == {"close_fraction": 0.5, "reason": "tiered_tp_pct:0.02"}
     assert already_taken == {"close_fraction": 0.0, "reason": "noop:already_taken"}
-    assert final == {"close_fraction": 1.0, "reason": "tiered_tp_pct:0.06"}
+    assert final == {"close_fraction": 1.0, "reason": "tiered_tp_pct:0.04"}
 
 
 def test_tiered_tp_atr_uses_entry_atr_multiple(registry):
+    # #870: default ladder is 1.5×/3×/5× → 40%/80%/100%.
     missing_atr = registry.evaluate(
         "tiered_tp_atr",
         {"side": "long", "avg_cost": 100, "current_quantity": 1, "initial_quantity": 1},
@@ -96,34 +98,34 @@ def test_tiered_tp_atr_uses_entry_atr_multiple(registry):
     hit = registry.evaluate(
         "tiered_tp_atr",
         {"side": "long", "avg_cost": 100, "current_quantity": 1, "initial_quantity": 1, "entry_atr": 2},
-        {"mark_price": 104},
+        {"mark_price": 110},  # +10 = 5 ATR → final tier, full close
         {},
     )
 
     assert missing_atr == {"close_fraction": 0.0, "reason": "noop:missing_entry_atr"}
-    assert hit == {"close_fraction": 1.0, "reason": "tiered_tp_atr:2"}
+    assert hit == {"close_fraction": 1.0, "reason": "tiered_tp_atr:5"}
 
 
 def test_tiered_tp_atr_live_uses_market_atr(registry):
-    # Live ATR (3.0) means 104 mark = 1.33 ATR profit, hits the 1.0x tier (50%).
+    # #870: Live ATR (3.0) means 105 mark = 1.67 ATR profit, hits the 1.5x tier (40%).
     live_hit = registry.evaluate(
         "tiered_tp_atr_live",
         {"side": "long", "avg_cost": 100, "current_quantity": 1, "initial_quantity": 1, "entry_atr": 2},
-        {"mark_price": 104, "atr": 3},
+        {"mark_price": 105, "atr": 3},
         {},
     )
-    assert live_hit == {"close_fraction": 0.5, "reason": "tiered_tp_atr_live:live:1"}
+    assert live_hit == {"close_fraction": 0.4, "reason": "tiered_tp_atr_live:live:1.5"}
 
 
 def test_tiered_tp_atr_live_falls_back_to_entry_atr(registry):
-    # Live ATR missing -> falls back to entry_atr (2.0); 104 mark = 2 ATR -> 1.0x and 2.0x both hit.
+    # #870: Live ATR missing -> falls back to entry_atr (2.0); 110 mark = 5 ATR -> all tiers hit.
     fallback = registry.evaluate(
         "tiered_tp_atr_live",
         {"side": "long", "avg_cost": 100, "current_quantity": 1, "initial_quantity": 1, "entry_atr": 2},
-        {"mark_price": 104},
+        {"mark_price": 110},
         {},
     )
-    assert fallback == {"close_fraction": 1.0, "reason": "tiered_tp_atr_live:entry_fallback:2"}
+    assert fallback == {"close_fraction": 1.0, "reason": "tiered_tp_atr_live:entry_fallback:5"}
 
 
 def test_tiered_tp_atr_live_zero_live_atr_falls_back(registry):
@@ -149,24 +151,25 @@ def test_tiered_tp_atr_live_missing_all_atr_noop(registry):
 
 def test_tiered_tp_atr_live_entry_source_ignores_market_atr(registry):
     # atr_source=entry must use entry_atr even when market.atr is present.
+    # #870: mark 110 = 5 ATR on entry_atr=2 → final tier, full close.
     result = registry.evaluate(
         "tiered_tp_atr_live",
         {"side": "long", "avg_cost": 100, "current_quantity": 1, "initial_quantity": 1, "entry_atr": 2},
-        {"mark_price": 104, "atr": 10},
+        {"mark_price": 110, "atr": 10},
         {"atr_source": "entry"},
     )
-    assert result == {"close_fraction": 1.0, "reason": "tiered_tp_atr_live:entry:2"}
+    assert result == {"close_fraction": 1.0, "reason": "tiered_tp_atr_live:entry:5"}
 
 
 def test_tiered_tp_atr_live_short_side(registry):
     result = registry.evaluate(
         "tiered_tp_atr_live",
         {"side": "short", "avg_cost": 100, "current_quantity": 1, "initial_quantity": 1, "entry_atr": 5},
-        {"mark_price": 96, "atr": 2},
+        {"mark_price": 90, "atr": 2},
         {},
     )
-    # profit_distance = 4, atr=2 -> 2.0 atr_profit -> hits both tiers, full close.
-    assert result == {"close_fraction": 1.0, "reason": "tiered_tp_atr_live:live:2"}
+    # #870: profit_distance = 10, atr=2 -> 5.0 atr_profit -> hits all tiers, full close.
+    assert result == {"close_fraction": 1.0, "reason": "tiered_tp_atr_live:live:5"}
 
 
 def test_market_atr_wiring_end_to_end(registry):
@@ -201,9 +204,9 @@ def test_market_atr_wiring_end_to_end(registry):
     if atr_value > 0:
         market_ctx["atr"] = atr_value
 
-    # Mark moves $4 above avg_cost; with live ATR=$3 that's 1.33 ATR profit
-    # → hits 1.0x tier (50%). Reason must reflect `live` source, not `entry_fallback`.
-    market_ctx["mark_price"] = 104  # mark moved up after market_ctx was built
+    # Mark moves $6 above avg_cost; with live ATR≈$3 that's ~2 ATR profit
+    # → hits 1.5x tier (#870). Reason must reflect `live` source, not `entry_fallback`.
+    market_ctx["mark_price"] = 106  # mark moved up after market_ctx was built
     result = registry.evaluate(
         "tiered_tp_atr_live",
         {

--- a/shared_strategies/close/test_post_tp_sl.py
+++ b/shared_strategies/close/test_post_tp_sl.py
@@ -331,7 +331,8 @@ def test_parse_tp_tier_close_fractions_use_defaults_composite_label():
         close_refs,
         regime="trending_up_clean",
     )
-    assert got == [0.5, 1.0]
+    # #870: trending_up_clean → clean group (4 cumulative fractions).
+    assert got == [0.25, 0.5, 0.75, 1.0]
 
 
 # --- Manual rejection: trail_from_here regime variant ----------------------

--- a/shared_strategies/close/test_trailing_tp_ratchet.py
+++ b/shared_strategies/close/test_trailing_tp_ratchet.py
@@ -130,3 +130,41 @@ def test_registry_lists_new_strategies(registry):
     built = registry.build_close_registry("futures")
     assert "trailing_tp_ratchet" in built
     assert "trailing_tp_ratchet_regime" in built
+
+
+def test_regime_close_default_group_mapping(ratchet):
+    # #870: composite quality suffixes win; ADX trends fall to choppy.
+    g = ratchet.regime_close_default_group
+    assert g("trending_up_clean") == "clean"
+    assert g("trending_down_clean") == "clean"
+    assert g("trending_up_choppy") == "choppy"
+    assert g("trending_up") == "choppy"  # ADX trend → choppy
+    assert g("trending_down") == "choppy"
+    assert g("ranging") == "ranging"
+    assert g("ranging_volatile") == "ranging"
+    assert g("") is None
+    assert g("bogus") is None
+
+
+def test_resolve_tiers_for_regime_group_defaults(ratchet):
+    # #870: regime variant + omitted tp_tiers → per-quality-group ladder.
+    clean, errs = ratchet.resolve_tiers_for_regime(
+        {"use_defaults": True}, "trending_up_clean", regime_table=True,
+    )
+    assert errs == []
+    assert [t[0] for t in clean] == [3.0, 4.5, 6.0]
+    assert all(t[1] == 0.0 for t in clean)  # trend group: no scale-out
+
+    ranging, errs = ratchet.resolve_tiers_for_regime(
+        {"use_defaults": True}, "ranging_quiet", regime_table=True,
+    )
+    assert errs == []
+    assert [t[0] for t in ranging] == [0.75, 1.5, 2.0]
+    assert [t[1] for t in ranging] == [0.4, 0.8, 1.0]  # ranging scales out
+
+    # Scalar variant still broadcasts the single #866 default.
+    scalar, errs = ratchet.resolve_tiers_for_regime(
+        {"use_defaults": True}, "", regime_table=False,
+    )
+    assert errs == []
+    assert [t[0] for t in scalar] == [2.0, 2.5, 3.0]

--- a/shared_strategies/close/tiered_tp_atr.py
+++ b/shared_strategies/close/tiered_tp_atr.py
@@ -9,9 +9,15 @@ from _helpers import (
     tier_list_from_params,
 )
 
+# #870: patient 3-rung scale-out (40%/80%/100% cumulative). Single Python source
+# for tiered_tp_atr + tiered_tp_atr_live (the _live evaluator imports _tiers from
+# here) and the registry default_params. MUST stay in sync with the Go on-chain
+# source of truth defaultHLProtectionTiers() so paper/backtest scale-outs match
+# the live reduce-only TP ladder.
 DEFAULT_TIERS = (
-    {"atr_multiple": 1.0, "close_fraction": 0.5},
-    {"atr_multiple": 2.0, "close_fraction": 1.0},
+    {"atr_multiple": 1.5, "close_fraction": 0.40},
+    {"atr_multiple": 3.0, "close_fraction": 0.80},
+    {"atr_multiple": 5.0, "close_fraction": 1.00},
 )
 
 

--- a/shared_strategies/close/tiered_tp_atr_regime.py
+++ b/shared_strategies/close/tiered_tp_atr_regime.py
@@ -19,9 +19,11 @@ from _helpers import (
     tier_list_from_params,
 )
 from regime_atr import (
+    REGIME_TP_TIER_GROUP_DEFAULTS,
     RegimeTierSpec,
     close_params_are_unified_regime,
     parse_regime_tp_tiers,
+    regime_close_default_group,
     resolve_regime_tier,
     unified_regime_scalar_params,
 )
@@ -63,6 +65,19 @@ def _resolve_tiers_for_regime(
 
     use_defaults = bool(params.get("use_defaults"))
     raw_tiers = tier_list_from_params(params)
+    if use_defaults and raw_tiers is None:
+        # #870: resolve the per-quality-group default ladder for the stamped
+        # regime directly. The ragged tier counts (clean 4 / choppy 3 / ranging
+        # 2) can't round-trip the positional spec union when the evaluator is
+        # invoked with the default ADX vocabulary, and the regime here may be a
+        # composite label. Mirrors Go's defaultRegimeTPTiersForRegime.
+        group = regime_close_default_group(regime)
+        ladder = REGIME_TP_TIER_GROUP_DEFAULTS.get(group) if group else None
+        if not ladder:
+            return [], []
+        resolved = sorted(((m, clamp_fraction(f)) for m, f in ladder), key=lambda p: p[0])
+        resolved[-1] = (resolved[-1][0], 1.0)
+        return resolved, []
     specs, errs = parse_regime_tp_tiers(raw_tiers, "tiered_tp_atr_regime", use_defaults)
     if errs:
         return [], errs

--- a/shared_strategies/close/tiered_tp_pct.py
+++ b/shared_strategies/close/tiered_tp_pct.py
@@ -9,9 +9,14 @@ from _helpers import (
     tier_list_from_params,
 )
 
+# #870: even-quarter price-move ladder (pure price move from entry, no leverage
+# term — evaluator math unchanged). Each tier closes another 25% as the position
+# advances 1% in price.
 DEFAULT_TIERS = (
-    {"profit_pct": 0.03, "close_fraction": 0.5},
-    {"profit_pct": 0.06, "close_fraction": 1.0},
+    {"profit_pct": 0.01, "close_fraction": 0.25},
+    {"profit_pct": 0.02, "close_fraction": 0.50},
+    {"profit_pct": 0.03, "close_fraction": 0.75},
+    {"profit_pct": 0.04, "close_fraction": 1.00},
 )
 
 

--- a/shared_strategies/close/trailing_tp_ratchet.py
+++ b/shared_strategies/close/trailing_tp_ratchet.py
@@ -14,21 +14,44 @@ from _helpers import (
     float_from,
     tier_list_from_params,
 )
-from regime_atr import CANONICAL_TREND_REGIME_LABELS
+from regime_atr import CANONICAL_TREND_REGIME_LABELS, regime_close_default_group
 
-# DEFAULT_RATCHET_TIERS is the conservative fallback ladder (#866) used when a
-# trailing_tp_ratchet* close ref omits tp_tiers (or sets use_defaults:true). It
+# DEFAULT_RATCHET_TIERS is the conservative fallback ladder (#866) used when the
+# SCALAR trailing_tp_ratchet omits tp_tiers (or sets use_defaults:true). It
 # mirrors the Go single source of truth defaultTrailingRatchetTiers() in
-# scheduler/trailing_tp_ratchet.go — keep the two in sync. The regime variant
-# broadcasts this same ladder across every classifier label (per-regime
-# differentiation lands in #870). Precondition: the first rung tightens to
-# 1.5xATR, so a strategy using this default must set trailing_stop_atr_mult >=
-# 1.5 (else the Go loader rejects it via validateTrailingRatchetInitialTrail).
+# scheduler/trailing_tp_ratchet.go — keep the two in sync. Precondition: the
+# first rung tightens to 1.5xATR, so a strategy using this default must set
+# trailing_stop_atr_mult >= 1.5 (else the Go loader rejects it via
+# validateTrailingRatchetInitialTrail).
 DEFAULT_RATCHET_TIERS = [
     {"atr_multiple": 2.0, "trailing_mult_after": 1.5, "close_fraction": 0.0},
     {"atr_multiple": 2.5, "trailing_mult_after": 1.0, "close_fraction": 0.0},
     {"atr_multiple": 3.0, "trailing_mult_after": 0.5, "close_fraction": 0.0},
 ]
+
+# #870: per-quality-group default ratchet ladders for the REGIME variant
+# (trailing_tp_ratchet_regime) when tp_tiers is omitted / use_defaults:true.
+# Mirrors ratchetTierGroupDefaults in scheduler/trailing_tp_ratchet.go. Trend
+# groups (clean/choppy) are pure let-it-ride (close_fraction 0); ranging scales
+# out. Each group's first rung couples to that group's opening trail in
+# REGIME_ATR_DEFAULTS_TRAILING (clean 2.5 / choppy 2.0 / ranging 1.0).
+DEFAULT_RATCHET_TIERS_BY_GROUP = {
+    "clean": [
+        {"atr_multiple": 3.0, "trailing_mult_after": 1.5, "close_fraction": 0.0},
+        {"atr_multiple": 4.5, "trailing_mult_after": 1.0, "close_fraction": 0.0},
+        {"atr_multiple": 6.0, "trailing_mult_after": 0.5, "close_fraction": 0.0},
+    ],
+    "choppy": [
+        {"atr_multiple": 2.0, "trailing_mult_after": 1.5, "close_fraction": 0.0},
+        {"atr_multiple": 2.5, "trailing_mult_after": 1.0, "close_fraction": 0.0},
+        {"atr_multiple": 3.0, "trailing_mult_after": 0.5, "close_fraction": 0.0},
+    ],
+    "ranging": [
+        {"atr_multiple": 0.75, "trailing_mult_after": 1.0, "close_fraction": 0.4},
+        {"atr_multiple": 1.5, "trailing_mult_after": 0.75, "close_fraction": 0.8},
+        {"atr_multiple": 2.0, "trailing_mult_after": 0.5, "close_fraction": 1.0},
+    ],
+}
 
 
 def _first_present(d: dict, *keys: str):
@@ -136,8 +159,15 @@ def resolve_tiers_for_regime(
     """Resolve concrete tiers for the stamped regime label."""
     raw = tier_list_from_params(params)
     if raw is None:
-        # #866: omitted tp_tiers (or use_defaults:true) resolves to the system
-        # default ladder, broadcast across regimes for the regime variant.
+        # Omitted tp_tiers (or use_defaults:true) resolves to the system default
+        # ladder. #870: the regime variant resolves the per-quality-group ladder
+        # for the stamped regime; the scalar variant uses the single #866 default.
+        if regime_table:
+            group = regime_close_default_group(regime)
+            ladder = DEFAULT_RATCHET_TIERS_BY_GROUP.get(group) if group else None
+            if not ladder:
+                return [], []
+            return _parse_scalar_tiers([dict(t) for t in ladder])
         return _parse_scalar_tiers([dict(t) for t in DEFAULT_RATCHET_TIERS])
     if regime_table:
         if not isinstance(raw, dict):


### PR DESCRIPTION
Builds on #866's three-layer close-default resolver. This issue retunes the actual default **values** and adds per-regime quality-group differentiation, split out from #866 because it changes live behavior.

## ⚠️ On-chain behavior change (B1)
The default `tiered_tp_atr*` ladder moves from `1×@50%, 2×@100%` to `1.5×@40%, 3×@80%, 5×@100%`. Every existing HL `tiered_tp_atr*` strategy running on defaults will have its reduce-only take-profit orders re-placed at the new levels on the next protection-sync. **Validate with a live smoke before deploying.**

## Scopes
- **A — `tiered_tp_pct`**: default ladder is now 4 even quarters (1/2/3/4% → 25/50/75/100%).
- **B1 — scalar ATR TP (on-chain)**: `defaultHLProtectionTiers()` + Python `_DEFAULT_SCALAR_TP_TIERS` → `1.5×/3×/5× @ 40/80/100%`. Also retuned `tiered_tp_atr.py` `DEFAULT_TIERS` (the paper/backtest scale-out source the issue didn't name) so paper/backtest match the live on-chain ladder.
- **B2 — regime ATR-TP group model**: built the clean/choppy/ranging label→group resolver and ragged per-group ladders (clean 4-tier, choppy 3-tier ≡ scalar, ranging 2-tier) on both Go and Python sides. This machinery did **not** exist from #866 (it explicitly excluded these evaluators); it replaces the old positional 2-tier baseline.
- **C2 — regime ratchet + per-regime opening trail**: lifted the `trailing_stop_atr_regime` ban so `trailing_tp_ratchet_regime` owns its trail via the per-regime block (scalar `trailing_stop_atr_mult` rejected); per-regime-key initial-trail validation; per-group ratchet ladders + group opening trails (clean 2.5 / choppy 2.0 / ranging 1.0); widened manual-ratchet config gates; fixed `effectiveTrailingRatchetMult` to use the regime open as the baseline (it returned 0 for the regime variant, which would no-op the first rung).

## Decisions
- **Scalar TP final tier = 5.0× everywhere** (per maintainer call), resolving the issue's 5.0-vs-4.5 self-contradiction; the choppy group equals the scalar default.
- ADX-classifier trends map to the **choppy** group (no clean/choppy signal); existing ADX trailing-open defaults left intact, composite labels added.

## Tests
- Full Go suite passes; 1117 pytest + 79 shared_scripts tests pass.
- New tests: group resolver mapping, per-group ATR-TP/ratchet ladders, regime-ratchet validation (ban lift, scalar rejection, per-regime-key initial trail, manual variant), all-defaults composite integration.
- Backtest smoke runs clean on the new ladders.

Closes #870

---
LLM: Opus 4.8 | xhigh | Harness: Claude Code
