### PR TITLE
fix(manual): stamp regime onto manual positions so regime-keyed closes arm (#872)

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1726,17 +1726,21 @@ func main() {
 							break
 						}
 						if pos != nil && hyperliquidIsLive(sc.Args) {
+							// Protection-sync must run before the close evaluator so
+							// the latter sees on-chain-reconciled qty. Post-TP SL
+							// adjustment is deferred to the post-stamp block below so
+							// regime-keyed *_atr_regime SL sees pos.Regime (#878 review).
 							runHyperliquidProtectionSync(sc, stratState, stateDB, sc.Symbol, &mu, notifier, logger, "HL manual protection synced", hlReconcileFillHintsJSON)
-							runPostTPStopLossAdjustment(sc, stratState, sc.Symbol, prices[sc.Symbol], cfg, &mu, notifier, logger, hlOnChainAbsQty)
 						}
 						// #872: run the close evaluator and stamp the regime BEFORE
-						// arming the ratchet/trailing walker below. The regime is the
-						// close-eval's classifier output, and the regime-keyed close
-						// features (trailing_tp_ratchet_regime, *_atr_regime SL/TP)
-						// resolve their tier table / trail distance from pos.Regime.
-						// Arming first (the previous order) left pos.Regime == "" on
-						// the first post-open cycle, so the regime trail no-op'd for
-						// one interval; stamping first arms it correctly on cycle 1.
+						// arming the post-TP SL / ratchet / trailing walker below. The
+						// regime is the close-eval's classifier output, and the
+						// regime-keyed close features (trailing_tp_ratchet_regime,
+						// *_atr_regime SL/TP) resolve their tier table / trail distance
+						// from pos.Regime. Arming first (the previous order) left
+						// pos.Regime == "" on the first post-open cycle, so the regime
+						// trail no-op'd for one interval; stamping first arms it
+						// correctly on cycle 1.
 						closeFraction, _, manualRegime, manualOK := runManualCloseEval(sc, stratState, cfg, notifier, logger)
 						if manualOK {
 							mu.Lock()
@@ -1761,7 +1765,9 @@ func main() {
 							// tool, so a record-only manual config intentionally does
 							// not ratchet (unlike perps, which also runs a paper
 							// trailing path at main.go ~1537). Runs after the stamp
-							// above so regime-keyed trails see pos.Regime on cycle 1.
+							// above so regime-keyed trails / post-TP SL see pos.Regime
+							// on cycle 1.
+							runPostTPStopLossAdjustment(sc, stratState, sc.Symbol, prices[sc.Symbol], cfg, &mu, notifier, logger, hlOnChainAbsQty)
 							mark := prices[sc.Symbol]
 							if mark > 0 && strategyUsesTrailingTPRatchetClose(sc) {
 								applyTrailingTPRatchet(sc, stratState, sc.Symbol, mark, &mu, logger)

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1728,11 +1728,34 @@ func main() {
 						if pos != nil && hyperliquidIsLive(sc.Args) {
 							runHyperliquidProtectionSync(sc, stratState, stateDB, sc.Symbol, &mu, notifier, logger, "HL manual protection synced", hlReconcileFillHintsJSON)
 							runPostTPStopLossAdjustment(sc, stratState, sc.Symbol, prices[sc.Symbol], cfg, &mu, notifier, logger, hlOnChainAbsQty)
-							// Manual ratchet + trailing walker run live-only by design (this
-							// whole block is gated on hyperliquidIsLive above): manual is a
-							// live trading tool, so a record-only manual config intentionally
-							// does not ratchet (unlike perps, which also runs a paper trailing
-							// path at main.go ~1537).
+						}
+						// #872: run the close evaluator and stamp the regime BEFORE
+						// arming the ratchet/trailing walker below. The regime is the
+						// close-eval's classifier output, and the regime-keyed close
+						// features (trailing_tp_ratchet_regime, *_atr_regime SL/TP)
+						// resolve their tier table / trail distance from pos.Regime.
+						// Arming first (the previous order) left pos.Regime == "" on
+						// the first post-open cycle, so the regime trail no-op'd for
+						// one interval; stamping first arms it correctly on cycle 1.
+						closeFraction, _, manualRegime, manualOK := runManualCloseEval(sc, stratState, cfg, notifier, logger)
+						if manualOK {
+							// Stamp the current regime onto the position the first
+							// time we observe one. Idempotent — stampPosition-
+							// RegimeFromPayload only writes when pos.Regime == "" (and
+							// pos.RegimeWindows is empty) — so this fires exactly once,
+							// on the first close-eval cycle after open, regardless of
+							// live vs --record-only.
+							mu.Lock()
+							stampPositionRegimeIfOpened(stratState, sc.Symbol, manualRegime, sc, cfg.Regime)
+							mu.Unlock()
+						}
+						if pos != nil && hyperliquidIsLive(sc.Args) {
+							// Manual ratchet + trailing walker run live-only by design
+							// (gated on hyperliquidIsLive): manual is a live trading
+							// tool, so a record-only manual config intentionally does
+							// not ratchet (unlike perps, which also runs a paper
+							// trailing path at main.go ~1537). Runs after the stamp
+							// above so regime-keyed trails see pos.Regime on cycle 1.
 							mark := prices[sc.Symbol]
 							if mark > 0 && strategyUsesTrailingTPRatchetClose(sc) {
 								applyTrailingTPRatchet(sc, stratState, sc.Symbol, mark, &mu, logger)
@@ -1756,20 +1779,6 @@ func main() {
 								}
 								mu.Unlock()
 							}
-						}
-						closeFraction, _, manualRegime, manualOK := runManualCloseEval(sc, stratState, cfg, notifier, logger)
-						if manualOK {
-							// #872: manual positions have no open signal, so the
-							// frozen-label close features (trailing_tp_ratchet_regime,
-							// *_atr_regime SL/TP) never see a regime and silently
-							// no-op. Stamp the current regime onto the position the
-							// first time we observe one. Idempotent — stampPosition-
-							// RegimeFromPayload only writes when pos.Regime == "" — so
-							// this fires exactly once, on the first close-eval cycle
-							// after open, regardless of live vs --record-only.
-							mu.Lock()
-							stampPositionRegimeIfOpened(stratState, sc.Symbol, manualRegime, sc, cfg.Regime)
-							mu.Unlock()
 						}
 						if manualOK && closeFraction > 0 {
 							mu.RLock()

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1739,13 +1739,19 @@ func main() {
 						// one interval; stamping first arms it correctly on cycle 1.
 						closeFraction, _, manualRegime, manualOK := runManualCloseEval(sc, stratState, cfg, notifier, logger)
 						if manualOK {
+							mu.Lock()
+							// Refresh the strategy-level live regime every cycle, like
+							// the other five dispatches do — this is what the Phase 6
+							// status line and dashboard read (stratState.Regime). Without
+							// it a manual strategy reports regime=- even with an open,
+							// correctly-stamped position (#872 review).
+							syncStrategyRegimeState(stratState, manualRegime, cfg.Regime)
 							// Stamp the current regime onto the position the first
 							// time we observe one. Idempotent — stampPosition-
 							// RegimeFromPayload only writes when pos.Regime == "" (and
 							// pos.RegimeWindows is empty) — so this fires exactly once,
 							// on the first close-eval cycle after open, regardless of
 							// live vs --record-only.
-							mu.Lock()
 							stampPositionRegimeIfOpened(stratState, sc.Symbol, manualRegime, sc, cfg.Regime)
 							mu.Unlock()
 						}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1757,7 +1757,21 @@ func main() {
 								mu.Unlock()
 							}
 						}
-						if closeFraction, _, ok := runManualCloseEval(sc, stratState, cfg, notifier, logger); ok && closeFraction > 0 {
+						closeFraction, _, manualRegime, manualOK := runManualCloseEval(sc, stratState, cfg, notifier, logger)
+						if manualOK {
+							// #872: manual positions have no open signal, so the
+							// frozen-label close features (trailing_tp_ratchet_regime,
+							// *_atr_regime SL/TP) never see a regime and silently
+							// no-op. Stamp the current regime onto the position the
+							// first time we observe one. Idempotent — stampPosition-
+							// RegimeFromPayload only writes when pos.Regime == "" — so
+							// this fires exactly once, on the first close-eval cycle
+							// after open, regardless of live vs --record-only.
+							mu.Lock()
+							stampPositionRegimeIfOpened(stratState, sc.Symbol, manualRegime, sc, cfg.Regime)
+							mu.Unlock()
+						}
+						if manualOK && closeFraction > 0 {
 							mu.RLock()
 							pos = stratState.Positions[sc.Symbol]
 							mu.RUnlock()

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -880,17 +880,19 @@ func openTradeSide(posSide string) string {
 
 // runManualCloseEval runs the close-evaluator loop for a single type=manual
 // strategy that has an open position. Called from the main scheduler loop.
-// Returns (closeFraction, closePrice, ok).
-func runManualCloseEval(sc StrategyConfig, ss *StrategyState, cfg *Config, notifier *MultiNotifier, logger *StrategyLogger) (float64, float64, bool) {
+// Returns (closeFraction, closePrice, regimePayload, ok). The regime payload is
+// the classifier output from this cycle's check; the caller stamps it onto the
+// position once (#872) so frozen-label close features arm on manual positions.
+func runManualCloseEval(sc StrategyConfig, ss *StrategyState, cfg *Config, notifier *MultiNotifier, logger *StrategyLogger) (float64, float64, RegimePayload, bool) {
 	pos := ss.Positions[sc.Symbol]
 	if pos == nil {
-		return 0, 0, true // flat — nothing to do
+		return 0, 0, RegimePayload{}, true // flat — nothing to do
 	}
 
 	posCtx := positionCtxFromPosition(pos)
 	result, _, price, ok := runHyperliquidCheck(&sc, nil, posCtx, cfg.Regime, notifier, logger)
 	if !ok {
-		return 0, 0, false
+		return 0, 0, RegimePayload{}, false
 	}
-	return result.CloseFraction, price, true
+	return result.CloseFraction, price, regimePayloadValue(result.Regime), true
 }

--- a/scheduler/manual_test.go
+++ b/scheduler/manual_test.go
@@ -795,3 +795,78 @@ func TestResolveManualOpenOrderSize(t *testing.T) {
 		}
 	})
 }
+
+// TestManualCloseEval_FlatReturnsEmptyPayload covers the #872 signature change:
+// runManualCloseEval now returns the cycle's regime payload as a fourth value.
+// The flat (no open position) early-return must yield an empty payload and not
+// spawn a subprocess.
+func TestManualCloseEval_FlatReturnsEmptyPayload(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-manual-eth-live", Type: "manual", Platform: "hyperliquid", Symbol: "ETH"}
+	ss := &StrategyState{ID: sc.ID, Positions: map[string]*Position{}}
+	cfg := &Config{Regime: &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20}}
+
+	cf, px, payload, ok := runManualCloseEval(sc, ss, cfg, nil, nil)
+	if !ok {
+		t.Fatalf("flat manual close-eval ok = false, want true")
+	}
+	if cf != 0 || px != 0 {
+		t.Errorf("flat manual close-eval = (cf=%v, px=%v), want (0, 0)", cf, px)
+	}
+	if !payload.IsEmpty() {
+		t.Errorf("flat manual close-eval payload = %+v, want empty", payload)
+	}
+}
+
+// TestManualStampRegimeOnPosition is the #872 regression: manual positions have
+// no open signal, so the per-cycle close-eval is the only place to stamp the
+// regime onto the position. The manual dispatch feeds the runManualCloseEval
+// payload into stampPositionRegimeIfOpened; verify it stamps exactly once and
+// never overwrites a label already set, and that an empty payload (regime
+// disabled / no classifier output) leaves the position unstamped.
+func TestManualStampRegimeOnPosition(t *testing.T) {
+	rc := &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20}
+	sc := StrategyConfig{ID: "hl-manual-eth-live", Type: "manual", Platform: "hyperliquid", Symbol: "ETH"}
+
+	newState := func(regime string) *StrategyState {
+		return &StrategyState{
+			ID: sc.ID,
+			Positions: map[string]*Position{
+				"ETH": {
+					Symbol:          "ETH",
+					Quantity:        0.5,
+					InitialQuantity: 0.5,
+					AvgCost:         2000,
+					Side:            "long",
+					Regime:          regime,
+					OwnerStrategyID: sc.ID,
+				},
+			},
+		}
+	}
+
+	// Fresh position (empty regime) gets stamped from the cycle's payload.
+	ss := newState("")
+	stampPositionRegimeIfOpened(ss, sc.Symbol, RegimePayload{Legacy: "trending_up"}, sc, rc)
+	if got := ss.Positions["ETH"].Regime; got != "trending_up" {
+		t.Fatalf("expected regime stamped to trending_up, got %q", got)
+	}
+	if got := ss.Positions["ETH"].RegimeWindows[regimeWindowDefaultKey]; got != "trending_up" {
+		t.Errorf("expected default window label trending_up, got %q", got)
+	}
+
+	// Idempotent: a later close-eval cycle with a different regime must not
+	// overwrite the frozen-at-first-observation label.
+	stampPositionRegimeIfOpened(ss, sc.Symbol, RegimePayload{Legacy: "ranging"}, sc, rc)
+	if got := ss.Positions["ETH"].Regime; got != "trending_up" {
+		t.Errorf("regime must not be overwritten once set, got %q", got)
+	}
+
+	// Empty payload (regime disabled or no classifier output) leaves the
+	// position unstamped — record-only behaves identically since both paths
+	// run the same helper.
+	ssEmpty := newState("")
+	stampPositionRegimeIfOpened(ssEmpty, sc.Symbol, RegimePayload{}, sc, rc)
+	if got := ssEmpty.Positions["ETH"].Regime; got != "" {
+		t.Errorf("empty payload must not stamp a regime, got %q", got)
+	}
+}


### PR DESCRIPTION
Implements Option A from #872: `runManualCloseEval` now returns the cycle's regime payload, and the manual dispatch stamps it once via the idempotent `stampPositionRegimeIfOpened` under the state lock so frozen-label close features (`trailing_tp_ratchet_regime`, `*_atr_regime` SL/TP) arm on manual positions. Stamp fires on any successful close-eval (not gated on `closeFraction > 0`) so live and --record-only behave identically.

Adds `TestManualStampRegimeOnPosition` and `TestManualCloseEval_FlatReturnsEmptyPayload`.

Closes #872

---
LLM: Claude Opus 4.8 (1M) | xhigh | Harness: anthropics/claude-code-action@v1