### PR TITLE
fix(manual): emit trade alerts for adopted manual fills (#880)

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -573,8 +573,15 @@ func main() {
 		// #569: Drain pending manual-open / manual-close actions before the
 		// dueStrategies loop so newly-materialised positions are visible this cycle.
 		mu.Lock()
-		drainPendingManualActions(state, cfg, stateDB)
+		manualAlerts := drainPendingManualActions(state, cfg, stateDB)
 		mu.Unlock()
+		// #880: Emit trade alerts for adopted manual fills AFTER releasing mu.
+		// sendTradeAlerts re-acquires mu.RLock, so alerting inside the drain
+		// (which runs under mu.Lock) would self-deadlock. This gives manual fills
+		// the same DM/channel routing as normal live trades.
+		for _, ma := range manualAlerts {
+			sendTradeAlerts(ma.sc, ma.ss, ma.trades, &mu, notifier)
+		}
 
 		// #87: Resolve capital_pct → capital for strategies with dynamic sizing.
 		// Must run on cfg.Strategies (not dueStrategies) so resolved capital persists

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -548,20 +548,33 @@ func runManualClose(args []string) int {
 	return 0
 }
 
-// drainPendingManualActions reads all rows from pending_manual_actions and
-// applies them to the in-memory AppState, then deletes the drained rows.
-// Called at the top of each scheduler cycle before dueStrategies is built.
-func drainPendingManualActions(state *AppState, cfg *Config, stateDB *StateDB) {
+// manualAlert captures one strategy's successfully drained manual actions so the
+// caller can emit trade alerts AFTER releasing mu. drainPendingManualActions runs
+// under mu.Lock and sendTradeAlerts re-acquires mu.RLock; since sync.RWMutex is
+// not reentrant, alerting inside the drain would self-deadlock (#880).
+type manualAlert struct {
+	sc     StrategyConfig
+	ss     *StrategyState
+	trades int // count of trades appended this drain for this strategy
+}
+
+// drainPendingManualActions reads all rows from pending_manual_actions, applies
+// them to the in-memory AppState, then deletes the drained rows. It returns one
+// manualAlert per strategy that had >=1 action successfully applied (with the
+// aggregated trade count) so the caller can fire sendTradeAlerts outside the
+// state write lock (#880). Called at the top of each scheduler cycle before
+// dueStrategies is built.
+func drainPendingManualActions(state *AppState, cfg *Config, stateDB *StateDB) []manualAlert {
 	if stateDB == nil {
-		return
+		return nil
 	}
 	actions, err := stateDB.LoadPendingManualActions()
 	if err != nil {
 		fmt.Printf("[manual] failed to load pending actions: %v\n", err)
-		return
+		return nil
 	}
 	if len(actions) == 0 {
-		return
+		return nil
 	}
 
 	scByID := make(map[string]StrategyConfig, len(cfg.Strategies))
@@ -570,6 +583,8 @@ func drainPendingManualActions(state *AppState, cfg *Config, stateDB *StateDB) {
 	}
 
 	var maxDrained int64
+	applied := make(map[string]*manualAlert)
+	var order []string // preserves id-sorted insertion order for deterministic alert emission
 	for _, a := range actions {
 		if err := applyManualAction(state, scByID, a); err != nil {
 			fmt.Printf("[manual] failed to apply action %d (%s %s): %v\n", a.ID, a.Action, a.StrategyID, err)
@@ -578,6 +593,16 @@ func drainPendingManualActions(state *AppState, cfg *Config, stateDB *StateDB) {
 		if a.ID > maxDrained {
 			maxDrained = a.ID
 		}
+		// applyManualAction appends exactly one trade per successful apply (open
+		// via recordPositionOpen, close via RecordTrade); aggregate per strategy
+		// so sendTradeAlerts alerts the correct tail slice of TradeHistory.
+		ma := applied[a.StrategyID]
+		if ma == nil {
+			ma = &manualAlert{sc: scByID[a.StrategyID], ss: state.Strategies[a.StrategyID]}
+			applied[a.StrategyID] = ma
+			order = append(order, a.StrategyID)
+		}
+		ma.trades++
 	}
 
 	if maxDrained > 0 {
@@ -585,6 +610,12 @@ func drainPendingManualActions(state *AppState, cfg *Config, stateDB *StateDB) {
 			fmt.Printf("[manual] failed to delete drained actions: %v\n", err)
 		}
 	}
+
+	alerts := make([]manualAlert, 0, len(order))
+	for _, id := range order {
+		alerts = append(alerts, *applied[id])
+	}
+	return alerts
 }
 
 // applyManualAction materialises one pending_manual_actions row into AppState.

--- a/scheduler/manual_test.go
+++ b/scheduler/manual_test.go
@@ -453,7 +453,7 @@ func TestDrainPendingManualActions(t *testing.T) {
 		CreatedAt: time.Now().UTC(),
 	})
 
-	drainPendingManualActions(state, cfg, db)
+	alerts := drainPendingManualActions(state, cfg, db)
 
 	pos := state.Strategies[stratID].Positions["ETH"]
 	if pos == nil {
@@ -463,7 +463,91 @@ func TestDrainPendingManualActions(t *testing.T) {
 		t.Errorf("pos.Quantity = %g, want 0.5", pos.Quantity)
 	}
 
+	// #880: drain returns one alert (1 trade) so the caller fires sendTradeAlerts
+	// outside the state write lock.
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 manual alert, got %d", len(alerts))
+	}
+	if alerts[0].sc.ID != stratID {
+		t.Errorf("alert sc.ID = %q, want %q", alerts[0].sc.ID, stratID)
+	}
+	if alerts[0].trades != 1 {
+		t.Errorf("alert trades = %d, want 1", alerts[0].trades)
+	}
+	if alerts[0].ss != state.Strategies[stratID] {
+		t.Error("alert ss should point at the drained strategy state")
+	}
+
 	// Queue should be empty after drain.
+	remaining, _ := db.LoadPendingManualActions()
+	if len(remaining) != 0 {
+		t.Errorf("expected empty queue after drain, got %d rows", len(remaining))
+	}
+}
+
+// TestDrainPendingManualActionsAlerts verifies the #880 alert-collection
+// contract: drain aggregates the per-strategy trade count, the returned ss/trades
+// align with TradeHistory so sendTradeAlerts alerts the correct tail slice, and a
+// failed apply contributes no alert.
+func TestDrainPendingManualActionsAlerts(t *testing.T) {
+	db, err := OpenStateDB(":memory:")
+	if err != nil {
+		t.Fatalf("open state db: %v", err)
+	}
+	defer db.Close()
+
+	openID := "hl-manual-eth-live"  // open then full close → 2 trades, 0 open positions
+	otherID := "hl-manual-btc-live" // single open → 1 trade
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			openID:  {ID: openID, Platform: "hyperliquid", Type: "manual", Positions: map[string]*Position{}, Cash: 10000},
+			otherID: {ID: otherID, Platform: "hyperliquid", Type: "manual", Positions: map[string]*Position{}, Cash: 10000},
+		},
+	}
+	cfg := &Config{Strategies: []StrategyConfig{
+		{ID: openID, Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 10},
+		{ID: otherID, Type: "manual", Platform: "hyperliquid", Symbol: "BTC", Leverage: 10},
+	}}
+
+	origRecorder := tradeRecorder
+	tradeRecorder = func(_ string, _ Trade) error { return nil }
+	defer func() { tradeRecorder = origRecorder }()
+
+	now := time.Now().UTC()
+	// A close with no open position fails to apply → no alert, no trade.
+	// Inserted first so its id sits below maxDrained and it's still cleaned up.
+	_ = db.InsertPendingManualAction(PendingManualAction{StrategyID: otherID, Action: "close", Symbol: "DOGE", Side: "long", Quantity: 1, FillPrice: 0.1, IsFullClose: true, CreatedAt: now})
+	// ETH: open then full close (2 trades on one strategy).
+	_ = db.InsertPendingManualAction(PendingManualAction{StrategyID: openID, Action: "open", Symbol: "ETH", Side: "long", Quantity: 0.5, FillPrice: 2000, FillFee: 0.7, EntryATR: 50, CreatedAt: now})
+	_ = db.InsertPendingManualAction(PendingManualAction{StrategyID: openID, Action: "close", Symbol: "ETH", Side: "long", Quantity: 0.5, FillPrice: 2100, FillFee: 0.7, RealizedPnL: 49.3, IsFullClose: true, CreatedAt: now})
+	// BTC: single open (1 trade).
+	_ = db.InsertPendingManualAction(PendingManualAction{StrategyID: otherID, Action: "open", Symbol: "BTC", Side: "short", Quantity: 0.01, FillPrice: 60000, FillFee: 0.3, EntryATR: 500, CreatedAt: now})
+
+	alerts := drainPendingManualActions(state, cfg, db)
+
+	if len(alerts) != 2 {
+		t.Fatalf("expected 2 strategy alerts, got %d", len(alerts))
+	}
+	byID := map[string]manualAlert{}
+	for _, a := range alerts {
+		byID[a.sc.ID] = a
+	}
+	if got := byID[openID].trades; got != 2 {
+		t.Errorf("%s alert trades = %d, want 2 (open + close)", openID, got)
+	}
+	if got := byID[otherID].trades; got != 1 {
+		t.Errorf("%s alert trades = %d, want 1 (failed DOGE close excluded)", otherID, got)
+	}
+	// trades must not exceed the strategy's TradeHistory length, else
+	// sendTradeAlerts would slice a negative start.
+	for _, a := range alerts {
+		if a.trades > len(a.ss.TradeHistory) {
+			t.Errorf("%s alert trades=%d exceeds TradeHistory len=%d", a.sc.ID, a.trades, len(a.ss.TradeHistory))
+		}
+	}
+
+	// All non-failing rows drained and deleted; the failed DOGE close is also
+	// deleted (it sits below maxDrained), matching existing drain semantics.
 	remaining, _ := db.LoadPendingManualActions()
 	if len(remaining) != 0 {
 		t.Errorf("expected empty queue after drain, got %d rows", len(remaining))


### PR DESCRIPTION
## Problem

`manual-open` / `manual-close` exchange fills are adopted into scheduler state via the `pending_manual_actions` drain, but that path never emitted an operator-facing trade alert. The position appeared on-exchange and later in the dashboard with **no Discord/Telegram DM or channel notification**, making it easy to miss that a manual position actually opened or closed.

## Root cause

Normal trade alerts fire from the main strategy loop (`main.go:1898`, gated on `trades > 0 && detail != ""`). Manual fills bypass that loop: they're applied by `drainPendingManualActions` → `applyManualAction`, which records the trade and mutates state but never calls `sendTradeAlerts`. The drain didn't even receive a `*MultiNotifier`.

The naive fix (alert from inside the drain) deadlocks: `drainPendingManualActions` runs under `mu.Lock()` (`main.go:575-577`) and `sendTradeAlerts` re-acquires `mu.RLock()` (`main.go:2500`). `sync.RWMutex` is not reentrant.

## Fix

- `drainPendingManualActions` now **collects** one `manualAlert` per strategy that had ≥1 action successfully applied (with the aggregated trade count) and returns the slice — it no longer alerts inline.
- The call site fires `sendTradeAlerts` for each returned alert **after** `mu.Unlock()`, giving manual fills the same DM/channel routing (`tradeAlertRoutes`, respecting `dm_channels` / `trade_alert_channels`) as normal live trades.
- Emission order is deterministic (id-sorted insertion order), and each action is alerted exactly once since drained rows are deleted after a successful drain.

## Tests

- Extended `TestDrainPendingManualActions` to assert the returned alert (strategy, count, ss pointer).
- New `TestDrainPendingManualActionsAlerts`: per-strategy count aggregation (open + full close = 2 trades), a failed apply contributes no alert, and `trades ≤ len(TradeHistory)` so the alert tail-slice can't underflow.
- Full `go test ./...` passes.

Closes #880

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code