### PR TITLE
fix(perps): arm ATR-trailing stop-loss inline at open (#885)

### DIFF
--- a/scheduler/hyperliquid_open_trailing.go
+++ b/scheduler/hyperliquid_open_trailing.go
@@ -23,10 +23,13 @@ import (
 // Correctness over a single steady-state path: it reuses the exact walker
 // primitive (runHyperliquidTrailingStopUpdate) and result handler
 // (applyTrailingStopUpdateResult) the next-cycle walker uses, so the inline
-// trigger is byte-identical to what the deferred arming would have produced and
-// there is only one stop-placement implementation that can't drift. A fresh
-// position carries currentTrigger==0/currentOID==0, so the primitive computes
-// the initial trigger (AvgCost-seeded high-water) and rests a new SL without
+// trigger comes from the identical formula and code path the deferred arming
+// would have used — the only difference is this cycle's mark vs. the next
+// cycle's, and arming sooner is strictly safer. One stop-placement
+// implementation means the two can't drift. A fresh position carries
+// currentTrigger==0/currentOID==0, so the primitive computes the initial
+// trigger from a max(AvgCost, mark)-seeded high-water (the walker's own ratchet,
+// so positive open slippage is handled the same way) and rests a new SL without
 // needing forceResize.
 //
 // Idempotent and tightly scoped: it no-ops unless the position is a live

--- a/scheduler/hyperliquid_open_trailing.go
+++ b/scheduler/hyperliquid_open_trailing.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// armTrailingStopAtOpenNow places the initial TRAILING stop-loss on the SAME
+// cycle as a fresh open (or the open side of a flip), closing the #885 naked
+// window. The non-trailing ATR/regime/unified SL owners are already armed this
+// cycle by the post-trade protection sync (buildHyperliquidProtectionPlan
+// derives their trigger from the just-stamped EntryATR/Regime), and the scalar
+// owners (stop_loss_pct, stop_loss_margin_pct, trailing_stop_pct) are placed
+// inline at the execute order because EffectiveStopLossPct returns a positive
+// pct for them. The ATR-trailing owners (trailing_stop_atr_mult /
+// trailing_stop_atr_regime) are the gap: EffectiveStopLossPct defers to 0 (the
+// distance needs per-position EntryATR) and buildHyperliquidProtectionPlan never
+// reads the trailing fields, so the only path that arms them is the Signal==0
+// trailing walker — which first fires the cycle AFTER open. On a long strategy
+// interval that leaves the whole position with no exchange-side stop for up to a
+// full interval.
+//
+// Correctness over a single steady-state path: it reuses the exact walker
+// primitive (runHyperliquidTrailingStopUpdate) and result handler
+// (applyTrailingStopUpdateResult) the next-cycle walker uses, so the inline
+// trigger is byte-identical to what the deferred arming would have produced and
+// there is only one stop-placement implementation that can't drift. A fresh
+// position carries currentTrigger==0/currentOID==0, so the primitive computes
+// the initial trigger (AvgCost-seeded high-water) and rests a new SL without
+// needing forceResize.
+//
+// Idempotent and tightly scoped: it no-ops unless the position is a live
+// trailing owner with NO resting SL (StopLossOID==0 && StopLossTriggerPx==0).
+// That guard is what keeps it from double-placing on scalar trailing_stop_pct
+// (inline OID already stamped at the execute order, main.go), on fixed/regime
+// ATR (OID stamped by the post-trade sync), and on partial-close legs (the
+// reduce-only SL keeps resting). It also means the post-open walker no-ops next
+// cycle because the SL already exists.
+//
+// The #621 size cap uses the on-chain qty corrected with the just-confirmed open
+// fill (the per-cycle reconcile snapshot predates this open); if still capped
+// (e.g. shared-coin reconcile lag) it defers to the next walker cycle rather
+// than rest an undersized stop — never worse than the pre-#885 deferred path.
+func armTrailingStopAtOpenNow(
+	sc StrategyConfig,
+	stratState *StrategyState,
+	symbol string,
+	mark float64,
+	preOpenOnChainAbsQty map[string]float64,
+	filledQty float64,
+	mu *sync.RWMutex,
+	notifier *MultiNotifier,
+	logger *StrategyLogger,
+) (int, string) {
+	if !hyperliquidIsLive(sc.Args) || stratState == nil || symbol == "" || mark <= 0 {
+		return 0, ""
+	}
+	mu.RLock()
+	pos := stratState.Positions[symbol]
+	if pos == nil || pos.Quantity <= 0 || effectiveTrailingStopPct(sc, pos) <= 0 {
+		mu.RUnlock()
+		return 0, ""
+	}
+	// Only arm when no SL is resting yet. A fresh open / flip-open leaves
+	// StopLossOID==0 and StopLossTriggerPx==0; anything else (scalar SL placed
+	// inline, fixed/regime SL placed by the sync, a partial close keeping its
+	// reduce-only SL) is already protected and must not be double-placed.
+	if pos.StopLossOID != 0 || pos.StopLossTriggerPx != 0 {
+		mu.RUnlock()
+		return 0, ""
+	}
+	side := pos.Side
+	posSnap := *pos
+	mu.RUnlock()
+
+	// #621 size cap with the on-chain qty corrected for the just-confirmed open
+	// fill (the Phase-1 reconcile snapshot predates this open).
+	grownOnChain := map[string]float64{symbol: preOpenOnChainAbsQty[symbol] + filledQty}
+	slEffectiveQty, capped := hlSLEffectiveQty(symbol, posSnap.Quantity, grownOnChain)
+	if capped {
+		logger.Warn("open trailing SL arm: %s still capped (virtual %.6f > on-chain %.6f); deferring initial trailing SL to next walker cycle", symbol, posSnap.Quantity, slEffectiveQty)
+		return 0, ""
+	}
+
+	// currentTrigger==0 / currentOID==0: the primitive computes the initial
+	// trigger and rests a fresh SL (no forceResize needed).
+	newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, symbol, side, slEffectiveQty, &posSnap, mark, 0, 0, 0, false, notifier, logger)
+	mu.Lock()
+	defer mu.Unlock()
+	if immediateFill, fillPx := applyTrailingStopUpdateResult(stratState, symbol, side, 0, newHighWater, updateConfirmed, slUpdate, logger); immediateFill {
+		return 1, fmt.Sprintf("[%s] LIVE TRAILING SL %s @ $%.2f", sc.ID, symbol, fillPx)
+	}
+	if updateConfirmed && slUpdate != nil && slUpdate.StopLossOID > 0 {
+		logger.Info("Trailing SL armed inline at open for %s (qty=%.6f)", symbol, slEffectiveQty)
+	}
+	return 0, ""
+}

--- a/scheduler/hyperliquid_open_trailing_test.go
+++ b/scheduler/hyperliquid_open_trailing_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+// armTrailingStopAtOpenNow places the initial trailing SL on the SAME cycle as a
+// fresh open for an ATR-trailing owner (#885) — those owners get no inline SL at
+// the execute call (EffectiveStopLossPct defers to 0) and are not handled by the
+// post-trade protection sync (buildHyperliquidProtectionPlan never reads the
+// trailing fields), so without this they stay naked until the next Signal==0
+// walker cycle.
+func TestArmTrailingStopAtOpenNow(t *testing.T) {
+	old := runHyperliquidUpdateStopLossFunc
+	defer func() { runHyperliquidUpdateStopLossFunc = old }()
+
+	trail := 2.0
+	fixed := 1.5
+	liveArgs := []string{"x.py", "ETH", "1h", "--mode=live"}
+	mkState := func(oid int64, trigger float64) *StrategyState {
+		return &StrategyState{ID: "hl-eth", Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Side: "long", Quantity: 2, InitialQuantity: 2, AvgCost: 2000, EntryATR: 50, RiskAnchorPrice: 2000, StopLossOID: oid, StopLossTriggerPx: trigger},
+		}}
+	}
+	var mu sync.RWMutex
+
+	// Happy path: live ATR-trailing owner with no resting SL → arm inline at the
+	// AvgCost-seeded trigger (2000 * (1 - 5%) = 1900), full filled qty, no cancel.
+	var called bool
+	var gotSize, gotTrigger float64
+	var gotCancelOID int64
+	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+		called = true
+		gotSize, gotTrigger, gotCancelOID = size, triggerPx, cancelStopLossOID
+		return &HyperliquidStopLossUpdateResult{StopLossOID: 999, StopLossTriggerPx: triggerPx}, "", nil
+	}
+	sc := StrategyConfig{ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: liveArgs, TrailingStopATRMult: &trail}
+	st := mkState(0, 0)
+	if n, _ := armTrailingStopAtOpenNow(sc, st, "ETH", 2000, map[string]float64{"ETH": 0}, 2, &mu, nil, newTestLogger(t)); n != 0 {
+		t.Errorf("trades = %d, want 0 (resting placement is not an immediate fill)", n)
+	}
+	if !called {
+		t.Fatalf("expected a subprocess call to place the inline trailing SL")
+	}
+	if gotCancelOID != 0 {
+		t.Errorf("cancel OID = %d, want 0 (fresh open has nothing to cancel)", gotCancelOID)
+	}
+	if !approxEq(gotSize, 2) {
+		t.Errorf("size = %v, want 2 (full filled qty)", gotSize)
+	}
+	if !approxEq(gotTrigger, 1900) {
+		t.Errorf("trigger = %v, want 1900 (AvgCost 2000 less 5%% ATR-trailing)", gotTrigger)
+	}
+	if got := st.Positions["ETH"].StopLossOID; got != 999 {
+		t.Errorf("pos.StopLossOID = %d, want 999 (armed inline)", got)
+	}
+	if got := st.Positions["ETH"].StopLossTriggerPx; !approxEq(got, 1900) {
+		t.Errorf("pos.StopLossTriggerPx = %v, want 1900", got)
+	}
+
+	// Guard: a resting SL already exists — scalar trailing_stop_pct places it
+	// inline at the execute order, fixed/regime ATR via the post-trade sync — so
+	// arming again would double-place. No-op.
+	called = false
+	st = mkState(123, 1950)
+	if n, _ := armTrailingStopAtOpenNow(sc, st, "ETH", 2000, map[string]float64{"ETH": 0}, 2, &mu, nil, newTestLogger(t)); n != 0 || called {
+		t.Errorf("existing-SL: expected no-op, got trades=%d called=%v", n, called)
+	}
+
+	// Guard: not live (paper) → no subprocess call.
+	called = false
+	scPaper := sc
+	scPaper.Args = []string{"x.py", "ETH", "1h"}
+	st = mkState(0, 0)
+	armTrailingStopAtOpenNow(scPaper, st, "ETH", 2000, map[string]float64{"ETH": 0}, 2, &mu, nil, newTestLogger(t))
+	if called {
+		t.Errorf("not-live: expected no subprocess call")
+	}
+
+	// Guard: non-trailing owner (fixed ATR) — the post-trade protection sync
+	// already armed its SL — so this no-ops on the effectiveTrailingStopPct gate.
+	called = false
+	scFixed := StrategyConfig{ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: liveArgs, StopLossATRMult: &fixed}
+	st = mkState(0, 0)
+	armTrailingStopAtOpenNow(scFixed, st, "ETH", 2000, map[string]float64{"ETH": 0}, 2, &mu, nil, newTestLogger(t))
+	if called {
+		t.Errorf("fixed-ATR: expected no-op (post-trade sync owns the SL)")
+	}
+
+	// Guard: still size-capped after correcting on-chain qty (preOpen 0 + fill
+	// 0.5 < virtual 2) → defer to the next walker cycle, no placement.
+	called = false
+	st = mkState(0, 0)
+	armTrailingStopAtOpenNow(sc, st, "ETH", 2000, map[string]float64{"ETH": 0}, 0.5, &mu, nil, newTestLogger(t))
+	if called {
+		t.Errorf("capped: expected deferral, got a subprocess call")
+	}
+	if st.Positions["ETH"].StopLossOID != 0 {
+		t.Errorf("capped: SL OID set (%d) despite deferral", st.Positions["ETH"].StopLossOID)
+	}
+}

--- a/scheduler/hyperliquid_open_trailing_test.go
+++ b/scheduler/hyperliquid_open_trailing_test.go
@@ -99,4 +99,59 @@ func TestArmTrailingStopAtOpenNow(t *testing.T) {
 	if st.Positions["ETH"].StopLossOID != 0 {
 		t.Errorf("capped: SL OID set (%d) despite deferral", st.Positions["ETH"].StopLossOID)
 	}
+
+	// Immediate-fill path: price was already through the just-computed trigger at
+	// submit (HL fills it on placement) → book a trailing_stop_loss_immediate
+	// close now, returning trades=1 + detail rather than leaving a phantom open
+	// position for a later reconcile to mislabel.
+	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+		return &HyperliquidStopLossUpdateResult{StopLossFilledImmediately: true, StopLossTriggerPx: triggerPx}, "", nil
+	}
+	st = mkState(0, 0)
+	n, d := armTrailingStopAtOpenNow(sc, st, "ETH", 2000, map[string]float64{"ETH": 0}, 2, &mu, nil, newTestLogger(t))
+	if n != 1 {
+		t.Errorf("immediate-fill: trades = %d, want 1 (close booked)", n)
+	}
+	if d == "" {
+		t.Errorf("immediate-fill: expected a non-empty detail string")
+	}
+	if pos := st.Positions["ETH"]; pos != nil && pos.Quantity > 0 {
+		t.Errorf("immediate-fill: position still open (qty=%.4f), want flat", pos.Quantity)
+	}
+}
+
+// A regime-aware trailing owner (trailing_stop_atr_regime) resolves its distance
+// from the stamped pos.Regime and arms inline at open the same way the scalar
+// trailing_stop_atr_mult owner does — exercising the regime branch of
+// effectiveTrailingStopPct.
+func TestArmTrailingStopAtOpenNowRegime(t *testing.T) {
+	old := runHyperliquidUpdateStopLossFunc
+	defer func() { runHyperliquidUpdateStopLossFunc = old }()
+
+	var gotSize, gotTrigger float64
+	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+		gotSize, gotTrigger = size, triggerPx
+		return &HyperliquidStopLossUpdateResult{StopLossOID: 777, StopLossTriggerPx: triggerPx}, "", nil
+	}
+	// "trending" → 2.0× ATR; same geometry as the scalar test: 2.0*50/2000 = 5%,
+	// trigger 2000 * 0.95 = 1900.
+	regimeBlock := &RegimeATRBlock{TrendRegime: map[string]RegimeATREntry{
+		"trending": {ATR: 2.0},
+		"ranging":  {ATR: 1.0},
+	}}
+	sc := StrategyConfig{ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"x.py", "ETH", "1h", "--mode=live"}, TrailingStopATRRegime: regimeBlock}
+	st := &StrategyState{ID: "hl-eth", Positions: map[string]*Position{
+		"ETH": {Symbol: "ETH", Side: "long", Quantity: 2, InitialQuantity: 2, AvgCost: 2000, EntryATR: 50, RiskAnchorPrice: 2000, Regime: "trending"},
+	}}
+	var mu sync.RWMutex
+	armTrailingStopAtOpenNow(sc, st, "ETH", 2000, map[string]float64{"ETH": 0}, 2, &mu, nil, newTestLogger(t))
+	if !approxEq(gotSize, 2) {
+		t.Errorf("size = %v, want 2", gotSize)
+	}
+	if !approxEq(gotTrigger, 1900) {
+		t.Errorf("trigger = %v, want 1900 (regime trending 2.0x ATR)", gotTrigger)
+	}
+	if got := st.Positions["ETH"].StopLossOID; got != 777 {
+		t.Errorf("pos.StopLossOID = %d, want 777 (regime owner armed inline)", got)
+	}
 }

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1768,6 +1768,24 @@ func main() {
 											trades += extraTrades
 											detail = slDetail
 										}
+									} else {
+										// #885: arm the initial trailing SL inline on the open
+										// cycle for ATR-trailing owners. They get no inline SL at
+										// the execute order (EffectiveStopLossPct defers to 0) and
+										// the sync above doesn't place one (the plan never reads
+										// the trailing fields), so without this they stay naked
+										// until the next Signal==0 walker cycle. No-op for every
+										// other owner and for close/partial-close legs (the
+										// helper's internal guards: live + trailing owner + no
+										// resting SL).
+										filledQty := 0.0
+										if execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.TotalSz > 0 {
+											filledQty = execResult.Execution.Fill.TotalSz
+										}
+										if extraTrades, slDetail := armTrailingStopAtOpenNow(sc, stratState, result.Symbol, price, hlOnChainAbsQty, filledQty, &mu, notifier, logger); extraTrades > 0 {
+											trades += extraTrades
+											detail = slDetail
+										}
 									}
 									mu.Lock()
 									var pos *Position


### PR DESCRIPTION
## Problem
On HL **live perps**, a strategy whose stop-loss is **ATR-based trailing** (`trailing_stop_atr_mult` / `trailing_stop_atr_regime`) opened with **no exchange-side stop** and only armed it on the next `Signal == 0` trailing-walker cycle — the entire position naked for up to a full strategy interval.

Validation narrowed the issue's original scope: the non-trailing ATR/regime/unified owners are **not** affected — the post-trade protection sync (`main.go:1752`) already places their SL the same cycle as the open (`buildHyperliquidProtectionPlan` derives the trigger from the just-stamped `EntryATR`/`Regime`), and scalar-pct owners (including `trailing_stop_pct`) are placed inline at the execute order because `EffectiveStopLossPct` returns a positive pct. The gap is specific to **ATR-trailing** owners, whose `EffectiveStopLossPct` defers to `0` and which the protection plan never reads.

## Fix
`armTrailingStopAtOpenNow` runs right after the post-trade protection sync on the open cycle and arms the initial trailing SL by **reusing the exact walker primitive** (`runHyperliquidTrailingStopUpdate`) and result handler (`applyTrailingStopUpdateResult`) the next-cycle walker uses — one stop-placement path, so the inline trigger uses the **same formula and code path** the deferred walker would have — the only difference is this cycle's mark vs. the next cycle's, and arming sooner is strictly safer. A fresh open carries `currentTrigger==0`, so the primitive computes and rests the initial trigger from a `max(AvgCost, mark)`-seeded high-water (the walker's own ratchet) without `forceResize`.

**Idempotent / tightly scoped** — no-ops unless the position is a live trailing owner with no resting SL (`StopLossOID==0 && StopLossTriggerPx==0`):
- scalar `trailing_stop_pct` → OID already stamped inline at the execute order (`main.go:3082`)
- fixed/regime ATR → OID stamped by the post-trade sync
- partial-close legs → reduce-only SL keeps resting
- the post-open walker no-ops next cycle because the SL now exists

The #621 size cap uses the on-chain qty corrected with the confirmed open fill (the per-cycle reconcile snapshot predates this open); if still capped (shared-coin reconcile lag) it defers to the next walker cycle — never worse than the pre-fix behavior.

This mirrors how `scaleInResizeTrailingSLNow` (#882) already arms/resizes the trailing SL on a non-walker cycle for scale-in adds.

## Scope
- HL **live perps** ATR-trailing owners only. No Python changes (open-side Go decision). Paper, manual, scalar-pct, and fixed/regime ATR behavior all unchanged.

## Tests
- `TestArmTrailingStopAtOpenNow` — asserts inline placement at the correct AvgCost-seeded trigger/qty, plus the no-op guards (existing SL, not-live, non-trailing owner, size-capped deferral).
- Full `scheduler` suite green; `go vet` clean.

Closes #885

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code
