### PR TITLE
Treat manual strategies as perps for Discord summary cadence

### DIFF
--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -233,10 +233,10 @@ func isFuturesType(strats []StrategyConfig) bool {
 	return false
 }
 
-// isPerpsType returns true if any strategy in the list is a perps strategy.
+// isPerpsType returns true if any strategy in the list is a perps or manual strategy.
 func isPerpsType(strats []StrategyConfig) bool {
 	for _, sc := range strats {
-		if sc.Type == "perps" {
+		if sc.Type == "perps" || sc.Type == "manual" {
 			return true
 		}
 	}

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -95,6 +95,22 @@ func TestIsOptionsType(t *testing.T) {
 	}
 }
 
+func TestIsPerpsType(t *testing.T) {
+	spotFutures := []StrategyConfig{{Type: "spot"}, {Type: "futures"}}
+	spotManual := []StrategyConfig{{Type: "spot"}, {Type: "manual"}}
+	spotPerps := []StrategyConfig{{Type: "spot"}, {Type: "perps"}}
+
+	if isPerpsType(spotFutures) {
+		t.Error("expected false for spot/futures only")
+	}
+	if !isPerpsType(spotManual) {
+		t.Error("expected true when manual present")
+	}
+	if !isPerpsType(spotPerps) {
+		t.Error("expected true when perps present")
+	}
+}
+
 func TestExtractAsset(t *testing.T) {
 	cases := []struct {
 		sc   StrategyConfig

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2118,7 +2118,7 @@ func main() {
 				}
 				chTrades := channelTrades[chKey]
 				// Per-channel summary cadence (#30). Legacy default: continuous
-				// channel types (options/perps/futures) post every channel run; spot
+				// channel types (options/perps/futures/manual) post every channel run; spot
 				// posts hourly. Override per channel via cfg.SummaryFrequency.
 				// Trades always force a post so operators see executions
 				// immediately regardless of cadence.

--- a/scheduler/summary_frequency_test.go
+++ b/scheduler/summary_frequency_test.go
@@ -91,7 +91,7 @@ func TestShouldPostSummary_LegacyContinuousPostsEveryRun(t *testing.T) {
 	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
 	lastPost := now
 
-	// Empty freq + continuous (options/perps/futures) = every channel run.
+	// Empty freq + continuous (options/perps/futures/manual) = every channel run.
 	for i := 0; i < 5; i++ {
 		if !ShouldPostSummary("", true, false, lastPost, now.Add(time.Duration(i)*time.Second)) {
 			t.Errorf("continuous legacy default should post every run; iteration %d did not", i)


### PR DESCRIPTION
## Summary
Manual Hyperliquid positions share the same live summary cadence and channel semantics as perps. This fix classifies manual alongside perps so continuous summary posting applies to both, instead of manual defaulting to hourly spot cadence.

## Changes
- Updated `isPerpsType()` in `scheduler/discord.go` to return true for either `perps` or `manual` strategy types
- Added `TestIsPerpsType` to verify the three cases: spot+futures (false), spot+manual (true), spot+perps (true)
- Updated legacy comment in `summary_frequency_test.go` to document manual alongside other continuous types

## Test Coverage
All existing tests pass, including new `TestIsPerpsType` covering the required cases.

Closes #889

---
Created with LLM: Haiku 4.5 | high | Harness: Claude Code