### PR TITLE
feat(regime): shared regime bundle per (asset, interval) signature (#879)

### DIFF
--- a/backtest/tests/test_regime_bundle_parity.py
+++ b/backtest/tests/test_regime_bundle_parity.py
@@ -1,0 +1,65 @@
+"""#879: parity between the live regime subprocess (fetch_regime.compute_payload)
+and the backtest regime path (ensure_regime_columns / compute_regime_composite)
+for the same candles. Backtest code is unchanged by #879; this guards that the
+relocated live computation stays label-identical to the backtest.
+"""
+import importlib.util
+import pathlib
+import sys
+
+import numpy as np
+import pandas as pd
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "shared_tools"))
+sys.path.insert(0, str(ROOT))
+
+from regime import ensure_regime_columns  # noqa: E402
+
+
+def _load_fetch_regime():
+    spec = importlib.util.spec_from_file_location(
+        "fetch_regime", ROOT / "shared_scripts" / "fetch_regime.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _df(n=160, slope=0.7):
+    close = np.linspace(100.0, 100.0 + slope * n, n)
+    return pd.DataFrame({
+        "timestamp": range(n), "open": close - 0.2, "high": close + 0.6,
+        "low": close - 0.6, "close": close, "volume": np.ones(n),
+    })
+
+
+def _last_label(df, **kwargs):
+    out = ensure_regime_columns(df.copy(), **kwargs)
+    return str(out["regime"].iloc[-1])
+
+
+def test_adx_bundle_matches_backtest_period14():
+    fr = _load_fetch_regime()
+    df = _df()
+    spec = {"w": {"classifier": "adx", "period": 14, "adx_threshold": 20}}
+    bundle = fr.compute_payload(df, spec)["w"]["regime"]
+    assert bundle == _last_label(df, period=14, adx_threshold=20)
+
+
+def test_adx_bundle_matches_backtest_full_period_over_14():
+    """period>14 must use the full ADX period in both paths (no COMPOSITE cap)."""
+    fr = _load_fetch_regime()
+    df = _df(200)
+    spec = {"w": {"classifier": "adx", "period": 30, "adx_threshold": 20}}
+    bundle = fr.compute_payload(df, spec)["w"]["regime"]
+    assert bundle == _last_label(df, period=30, adx_threshold=20)
+
+
+def test_composite_bundle_matches_backtest():
+    fr = _load_fetch_regime()
+    df = _df(180)
+    spec = {"w": {"classifier": "composite", "period": 30}}
+    bundle = fr.compute_payload(df, spec)["w"]["regime"]
+    backtest_label = _last_label(
+        df, windows_spec={"w": {"classifier": "composite", "period": 30}}, gate_window="w")
+    assert bundle == backtest_label

--- a/docs/superpowers/plans/2026-06-05-shared-regime-bundle.md
+++ b/docs/superpowers/plans/2026-06-05-shared-regime-bundle.md
@@ -1,0 +1,853 @@
+# Shared Regime Bundle (issue #879) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move regime computation out of each strategy's per-cycle Python check subprocess into a single Go-scheduler-owned global regime store, computed once per distinct `(symbol, interval, windows-spec)` signature per cycle, injected into every check, and read directly by flat-`manual`, `options`, and the dashboard.
+
+**Architecture:** A per-cycle in-memory two-layer store in the Go scheduler (`regime_calculator.go`). Before Phase 3, the scheduler collects the distinct regime signatures of due strategies (+ flat `manual`/`options`), runs one dedicated read-only regime subprocess (`shared_scripts/fetch_regime.py`) per distinct signature (concurrent, gated by `pythonSemaphore`), and stores the resulting `RegimePayload` keyed by signature. Each check dispatch **injects** the precomputed payload into the check script via `--regime-injected --regime-payload-json <json>`; the check skips `prepare_check_regime` and echoes the payload back as `result.Regime`, so existing Go consumers (`applyRegimeGate`, `syncStrategyRegimeState`, `stampPositionRegimeIfOpened`, `strategyCurrentATRRegime`, `applyRegimeDirectionalPolicy`) are unchanged — the *source* of `result.Regime` is now the store. Flat `manual`, `options`, and the dashboard read the store directly. Failure policy: a failed regime subprocess clears that signature to empty; every consumer falls back to its existing empty-case (fail-open) behavior.
+
+**Why parity holds:** Regime windows live in **global** `cfg.Regime.Windows` (one spec for all strategies; per-strategy fields are only *selectors* — gate/atr/directional window, `allowed_regimes`, ATR-regime blocks). So the dedup unit is `(symbol, interval)` + a fingerprint of the resolved global windows spec. The subprocess computes each configured window with **its own classifier/period** via the existing `compute_multi_regime`/`classify_window` — identical to what each check computes inline today. An ADX window at `period=20` already uses full-period ADX; the `COMPOSITE_ADX_PERIOD_CAP=14` only applies *inside* composite windows. No single-pass prefix-collapse is used, so labels are byte-identical pre/post migration for the same candles.
+
+**Tech Stack:** Go (scheduler, `modernc.org/sqlite`), Python 3 (`shared_tools/regime.py`, platform adapters via `importlib`), subprocess contract (JSON stdout, exit 1 on error), systemd `PrivateTmp` `/tmp` OHLCV cache (#839).
+
+---
+
+## Key invariants (must hold across every task)
+
+1. **No behavior change for any strategy's label** for the same candles — inline-computed `result.Regime` (pre) == store-injected `result.Regime` (post). Enforced by parity tests.
+2. **`pos.Regime` stays the frozen-at-open stamp** (coordination with #873). `stampPositionRegimeIfOpened` semantics unchanged — only the payload source changes.
+3. **Failure = clear-to-empty (policy b).** Regime subprocess failure → store empty for that signature → consumers fall open. Open positions read frozen `pos.Regime`/`pos.RegimeAppliedLabel`, never the live store, so they are unaffected.
+4. **One documented semantic delta:** post-split a check can succeed while regime is empty, so a fresh open fires **fail-open instead of skip** on a regime-data outage. Accepted.
+5. **Look-ahead unchanged:** the subprocess computes on the same closed candles the check would fetch; gate reads the resolved label exactly as today.
+6. **Go+Python same-SHA deploy:** every new required CLI flag is appended to `version_probe.go`.
+
+---
+
+## File Structure
+
+**New files:**
+- `scheduler/regime_calculator.go` — `RegimeSignature`, `RegimeStore`, signature collection, per-cycle build orchestration, store reads.
+- `scheduler/regime_calculator_test.go` — store dedup, failure-clear, signature collection, payload reads.
+- `shared_scripts/fetch_regime.py` — platform-aware OHLCV fetch + `compute_multi_regime` + emit payload JSON. Read-only.
+- `shared_scripts/test_fetch_regime.py` — subprocess output shape + parity vs `prepare_check_regime`.
+
+**Modified files:**
+- `scheduler/main.go` — build store before Phase 3; inject store payload into each `runXxxCheck`; flat-`manual` + `options` read store; dashboard wiring.
+- `scheduler/strategy_composition.go` — `appendInjectedRegimeArgs(args, payload)` builder; keep `appendRegimeArgs` for the windows-spec the subprocess uses.
+- `scheduler/regime_run.go` (new, or in regime_calculator.go) — `runRegimeSubprocess(platform, symbol, interval, specJSON) (RegimePayload, error)`.
+- `scheduler/version_probe.go` — probe `fetch_regime.py`; probe `--regime-injected`/`--regime-payload-json` on each check script.
+- `scheduler/script_failure_alerts.go` — reuse `scriptFailureTracker` for regime subprocess failures (per-signature key).
+- `shared_scripts/check_hyperliquid.py`, `check_strategy.py`, `check_options.py`, `check_okx.py`, `check_robinhood.py`, `check_topstep.py` — accept `--regime-injected`/`--regime-payload-json`; skip `prepare_check_regime` when injected; echo payload back.
+- `shared_tools/regime.py` — `resolve_injected_regime(payload, *, primary_key, atr_window)` helper returning `(stdout_payload, live_atr_label, strategy_params_snapshot)` from an injected multi-window payload (mirrors `prepare_check_regime`'s return contract without recomputing).
+- `scheduler/ui_server.go` / dashboard — portfolio-level regime view from the store.
+- `backtest/` — **no functional change**; add parity test only.
+
+---
+
+## Task sequence (build order)
+
+Phase A (Tasks 1-5): Go store + subprocess + injection helper, fully tested in isolation.
+Phase B (Tasks 6-9): wire HL as the reference platform end-to-end (inject + echo + store reads), parity test.
+Phase C (Tasks 10-13): replicate injection to spot/okx/robinhood/topstep; options; flat-manual.
+Phase D (Tasks 14-16): dashboard view; backtest parity test; probe argv + smoke + full parity matrix.
+
+---
+
+### Task 1: Regime signature + store types (Go)
+
+**Files:**
+- Create: `scheduler/regime_calculator.go`
+- Test: `scheduler/regime_calculator_test.go`
+
+- [ ] **Step 1: Write failing test** for signature derivation + store get/put.
+
+```go
+package main
+
+import "testing"
+
+func TestRegimeSignatureForStrategy(t *testing.T) {
+    rc := &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20}
+    sc := StrategyConfig{ID: "hl-btc", Symbol: "BTC", Args: []string{"momentum", "BTC", "1h"}, Platform: "hyperliquid"}
+    sig := regimeSignatureForStrategy(sc, rc)
+    if sig.Symbol != "BTC" || sig.Interval != "1h" {
+        t.Fatalf("got %+v", sig)
+    }
+    // Two strategies, same asset/interval/global-spec → identical signature.
+    sc2 := StrategyConfig{ID: "hl-btc-2", Symbol: "BTC", Args: []string{"meanrev", "BTC", "1h"}, Platform: "hyperliquid"}
+    if regimeSignatureForStrategy(sc2, rc) != sig {
+        t.Fatal("peers on same asset/interval must share a signature")
+    }
+}
+
+func TestRegimeStorePutGet(t *testing.T) {
+    s := newRegimeStore()
+    sig := RegimeSignature{Symbol: "BTC", Interval: "1h", SpecHash: "abc"}
+    pl := RegimePayload{Legacy: "trending_up"}
+    s.put(sig, pl, nil)
+    got, ok := s.get(sig)
+    if !ok || got.PrimaryLabel(nil) != "trending_up" {
+        t.Fatalf("get failed: %+v ok=%v", got, ok)
+    }
+}
+
+func TestRegimeStoreFailureClears(t *testing.T) {
+    s := newRegimeStore()
+    sig := RegimeSignature{Symbol: "BTC", Interval: "1h", SpecHash: "abc"}
+    s.put(sig, RegimePayload{}, errSentinel)
+    got, ok := s.get(sig)
+    if !ok {
+        t.Fatal("failed signature must still be present (empty), to signal fail-open not missing")
+    }
+    if !got.IsEmpty() {
+        t.Fatal("failed signature payload must be empty")
+    }
+    if !s.failed(sig) {
+        t.Fatal("failed() must report the failure for alerting")
+    }
+}
+
+var errSentinel = errString("boom")
+type errString string
+func (e errString) Error() string { return string(e) }
+```
+
+- [ ] **Step 2: Run test, verify FAIL** (`go test ./scheduler/ -run TestRegime -v`) — undefined symbols.
+
+- [ ] **Step 3: Implement** `regime_calculator.go`:
+
+```go
+package main
+
+import (
+    "crypto/sha256"
+    "encoding/hex"
+    "sync"
+)
+
+// RegimeSignature dedups regime computation. Windows live in global
+// cfg.Regime, so the unit is (symbol, interval) + a fingerprint of the
+// resolved global windows-spec JSON (constant today, future-proof if
+// per-strategy specs are ever added).
+type RegimeSignature struct {
+    Symbol   string
+    Interval string
+    SpecHash string
+}
+
+func regimeSignatureForStrategy(sc StrategyConfig, rc *RegimeConfig) RegimeSignature {
+    return RegimeSignature{
+        Symbol:   regimeSignatureSymbol(sc),
+        Interval: strategyTimeframe(sc),
+        SpecHash: regimeSpecHash(rc),
+    }
+}
+
+// regimeSignatureSymbol returns the bare asset symbol used by the platform's
+// OHLCV fetch (e.g. "BTC" for HL, "BTC/USDT" for spot). Mirrors the symbol the
+// check script passes to adapter.get_ohlcv.
+func regimeSignatureSymbol(sc StrategyConfig) string {
+    if len(sc.Args) >= 2 {
+        return sc.Args[1]
+    }
+    return sc.Symbol
+}
+
+func strategyTimeframe(sc StrategyConfig) string {
+    if len(sc.Args) >= 3 {
+        return sc.Args[2]
+    }
+    return ""
+}
+
+func regimeSpecHash(rc *RegimeConfig) string {
+    blob := regimeWindowsSpecJSON(rc)
+    sum := sha256.Sum256([]byte(blob))
+    return hex.EncodeToString(sum[:8])
+}
+
+type regimeStoreEntry struct {
+    payload RegimePayload
+    failed  bool
+}
+
+// RegimeStore is the per-cycle two-layer store. Rebuilt every cycle (empty at
+// loop start), never persisted. A failed signature is present-but-empty so
+// reads fail-open rather than treating "missing" as "compute inline".
+type RegimeStore struct {
+    mu      sync.RWMutex
+    entries map[RegimeSignature]regimeStoreEntry
+}
+
+func newRegimeStore() *RegimeStore {
+    return &RegimeStore{entries: make(map[RegimeSignature]regimeStoreEntry)}
+}
+
+func (s *RegimeStore) put(sig RegimeSignature, pl RegimePayload, err error) {
+    s.mu.Lock()
+    defer s.mu.Unlock()
+    if err != nil {
+        s.entries[sig] = regimeStoreEntry{payload: RegimePayload{}, failed: true}
+        return
+    }
+    s.entries[sig] = regimeStoreEntry{payload: pl}
+}
+
+func (s *RegimeStore) get(sig RegimeSignature) (RegimePayload, bool) {
+    s.mu.RLock()
+    defer s.mu.RUnlock()
+    e, ok := s.entries[sig]
+    return e.payload, ok
+}
+
+func (s *RegimeStore) failed(sig RegimeSignature) bool {
+    s.mu.RLock()
+    defer s.mu.RUnlock()
+    return s.entries[sig].failed
+}
+
+// payloadForStrategy is the consumer entry point: returns the store payload for
+// a strategy's signature (empty payload when missing/failed → fail-open).
+func (s *RegimeStore) payloadForStrategy(sc StrategyConfig, rc *RegimeConfig) RegimePayload {
+    if rc == nil || !rc.Enabled {
+        return RegimePayload{}
+    }
+    pl, _ := s.get(regimeSignatureForStrategy(sc, rc))
+    return pl
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS.**
+
+- [ ] **Step 5: Commit.**
+```bash
+git add scheduler/regime_calculator.go scheduler/regime_calculator_test.go
+git commit -m "feat(regime): per-cycle global regime store + signature (#879)"
+```
+
+> **NOTE for implementer:** confirm `regimeSignatureSymbol`/`strategyTimeframe` against each platform's actual `sc.Args` layout (HL: `[strategy, SYMBOL, tf, ...]`). If any platform deviates, add a platform switch here. Verify with a unit test per platform before relying on it.
+
+---
+
+### Task 2: Regime subprocess invoker (Go)
+
+**Files:**
+- Modify: `scheduler/regime_calculator.go`
+- Test: `scheduler/regime_calculator_test.go`
+
+- [ ] **Step 1: Write failing test** for argv construction (pure, no subprocess — mirror `version_probe.go` stub pattern).
+
+```go
+func TestRegimeSubprocessArgv(t *testing.T) {
+    argv := regimeSubprocessArgv("hyperliquid", "BTC", "1h",
+        `{"default":{"classifier":"adx","period":14,"adx_threshold":20}}`, 200)
+    joined := strings.Join(argv, " ")
+    for _, want := range []string{"--platform=hyperliquid", "--symbol=BTC", "--interval=1h",
+        "--regime-windows-spec-json", "--ohlcv-limit=200"} {
+        if !strings.Contains(joined, want) {
+            t.Fatalf("argv missing %q: %v", want, argv)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test, verify FAIL.**
+
+- [ ] **Step 3: Implement** the argv builder + a subprocess runner that reuses the existing `runPython` (read-only — NOT `runPythonSideEffect`) path. Parse stdout JSON `{"regime": <payload>, "bar_time": <int>}` into `RegimePayload`.
+
+```go
+const regimeFetchScript = "shared_scripts/fetch_regime.py"
+
+func regimeSubprocessArgv(platform, symbol, interval, specJSON string, ohlcvLimit int) []string {
+    return []string{
+        "--platform=" + platform,
+        "--symbol=" + symbol,
+        "--interval=" + interval,
+        "--regime-windows-spec-json", specJSON,
+        fmt.Sprintf("--ohlcv-limit=%d", ohlcvLimit),
+    }
+}
+
+type regimeSubprocessOutput struct {
+    Regime  RegimePayload `json:"regime"`
+    BarTime int64         `json:"bar_time"`
+    Error   string        `json:"error"`
+}
+
+// runRegimeSubprocessFn is a package var so tests stub it (Go CI has no .venv).
+var runRegimeSubprocessFn = runRegimeSubprocess
+
+func runRegimeSubprocess(platform, symbol, interval, specJSON string, ohlcvLimit int) (RegimePayload, error) {
+    argv := regimeSubprocessArgv(platform, symbol, interval, specJSON, ohlcvLimit)
+    stdout, stderr, err := runPython(regimeFetchScript, argv) // read-only; respects pythonSemaphore/scriptTimeout
+    if err != nil {
+        return RegimePayload{}, fmt.Errorf("regime subprocess %s/%s/%s: %w (stderr: %s)", platform, symbol, interval, err, strings.TrimSpace(stderr))
+    }
+    var out regimeSubprocessOutput
+    if jerr := json.Unmarshal([]byte(stdout), &out); jerr != nil {
+        return RegimePayload{}, fmt.Errorf("regime subprocess %s/%s/%s: bad json: %w", platform, symbol, interval, jerr)
+    }
+    if out.Error != "" {
+        return RegimePayload{}, fmt.Errorf("regime subprocess %s/%s/%s: %s", platform, symbol, interval, out.Error)
+    }
+    return out.Regime, nil
+}
+```
+
+> **Implementer:** confirm the exact signature of the existing `runPython` wrapper in `executor.go` (it may return `(stdout string, stderr string, err error)` or a struct). Match it. Do NOT use `runPythonSideEffect`. Add `regimePlatformForStrategy(sc)` returning the `--platform` token each adapter expects (`hyperliquid`, `binanceus`, `okx`, `robinhood`, `topstep`); derive from `sc.Platform`.
+
+- [ ] **Step 4: Run test, verify PASS.**
+- [ ] **Step 5: Commit.** `feat(regime): regime subprocess invoker (#879)`
+
+---
+
+### Task 3: Per-cycle store build orchestration (Go)
+
+**Files:**
+- Modify: `scheduler/regime_calculator.go`
+- Test: `scheduler/regime_calculator_test.go`
+
+- [ ] **Step 1: Write failing test** — collect distinct signatures from due strategies, dedup peers, stub the runner, assert one call per distinct signature and failure-clear.
+
+```go
+func TestBuildRegimeStoreDedupsAndClearsFailures(t *testing.T) {
+    rc := &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20}
+    due := []StrategyConfig{
+        {ID: "a", Symbol: "BTC", Platform: "hyperliquid", Args: []string{"m", "BTC", "1h"}},
+        {ID: "b", Symbol: "BTC", Platform: "hyperliquid", Args: []string{"r", "BTC", "1h"}}, // peer → dedup
+        {ID: "c", Symbol: "ETH", Platform: "hyperliquid", Args: []string{"m", "ETH", "1h"}},
+        {ID: "d", Symbol: "ETH", Platform: "hyperliquid", Args: []string{"m", "ETH", "4h"}}, // distinct interval
+    }
+    var calls int32
+    orig := runRegimeSubprocessFn
+    defer func() { runRegimeSubprocessFn = orig }()
+    runRegimeSubprocessFn = func(platform, symbol, interval, spec string, limit int) (RegimePayload, error) {
+        atomic.AddInt32(&calls, 1)
+        if symbol == "ETH" && interval == "4h" {
+            return RegimePayload{}, errSentinel // failure path
+        }
+        return RegimePayload{Legacy: "trending_up"}, nil
+    }
+    store := buildRegimeStore(due, rc)
+    if calls != 3 {
+        t.Fatalf("expected 3 distinct signatures, got %d", calls)
+    }
+    if lbl := store.payloadForStrategy(due[0], rc).PrimaryLabel(rc); lbl != "trending_up" {
+        t.Fatalf("BTC/1h label = %q", lbl)
+    }
+    sigFail := regimeSignatureForStrategy(due[3], rc)
+    if !store.failed(sigFail) {
+        t.Fatal("ETH/4h must be marked failed")
+    }
+    if !store.payloadForStrategy(due[3], rc).IsEmpty() {
+        t.Fatal("failed signature must read empty (fail-open)")
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL.**
+- [ ] **Step 3: Implement** `buildRegimeStore` — concurrent fan-out gated by the existing `pythonSemaphore` (do NOT exceed it; reuse the same semaphore the check fan-out uses so total concurrency is bounded). One subprocess per distinct signature.
+
+```go
+func collectRegimeSignatures(due []StrategyConfig, rc *RegimeConfig) map[RegimeSignature]StrategyConfig {
+    out := make(map[RegimeSignature]StrategyConfig)
+    if rc == nil || !rc.Enabled {
+        return out
+    }
+    for _, sc := range due {
+        if !strategyParticipatesInRegime(sc) {
+            continue
+        }
+        sig := regimeSignatureForStrategy(sc, rc)
+        if sig.Symbol == "" || sig.Interval == "" {
+            continue
+        }
+        if _, seen := out[sig]; !seen {
+            out[sig] = sc // representative strategy supplies platform
+        }
+    }
+    return out
+}
+
+func buildRegimeStore(due []StrategyConfig, rc *RegimeConfig) *RegimeStore {
+    store := newRegimeStore()
+    sigs := collectRegimeSignatures(due, rc)
+    if len(sigs) == 0 {
+        return store
+    }
+    specJSON := regimeWindowsSpecJSON(rc)
+    limit := regimeRequiredOhlcvLimit(rc)
+    var wg sync.WaitGroup
+    for sig, rep := range sigs {
+        wg.Add(1)
+        go func(sig RegimeSignature, rep StrategyConfig) {
+            defer wg.Done()
+            pythonSemaphore <- struct{}{}
+            defer func() { <-pythonSemaphore }()
+            pl, err := runRegimeSubprocessFn(regimePlatformForStrategy(rep), sig.Symbol, sig.Interval, specJSON, limit)
+            store.put(sig, pl, err)
+        }(sig, rep)
+    }
+    wg.Wait()
+    return store
+}
+```
+
+> **Implementer:** `strategyParticipatesInRegime(sc)` = strategy is a regime consumer (any spot/perps/futures/manual/options whose platform fetches OHLCV at a timeframe). Include flat `manual` and `options` here so they get a store entry without a position. Confirm `pythonSemaphore` is the package-level buffered channel in `executor.go`; reuse it, don't make a new one.
+
+- [ ] **Step 4: Run, verify PASS.**
+- [ ] **Step 5: Commit.** `feat(regime): per-cycle store build orchestration (#879)`
+
+---
+
+### Task 4: `fetch_regime.py` subprocess (Python)
+
+**Files:**
+- Create: `shared_scripts/fetch_regime.py`
+- Test: `shared_scripts/test_fetch_regime.py`
+
+- [ ] **Step 1: Write failing test** — call the module's `compute()` with a synthetic DataFrame and a windows spec; assert payload equals `prepare_check_regime(...)[0]` (parity), and JSON shape.
+
+```python
+# test_fetch_regime.py
+import importlib.util, json
+from pathlib import Path
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); return mod
+
+def _df():
+    import numpy as np
+    n = 120
+    close = pd.Series(range(100, 100 + n)).astype(float)  # clean uptrend
+    return pd.DataFrame({"timestamp": range(n), "open": close, "high": close + 1,
+                         "low": close - 1, "close": close, "volume": [1.0]*n})
+
+def test_fetch_regime_matches_prepare_check_regime():
+    fr = _load("fetch_regime", ROOT / "shared_scripts" / "fetch_regime.py")
+    regime = _load("regime_mod", ROOT / "shared_tools" / "regime.py")
+    spec = {"default": {"classifier": "adx", "period": 14, "adx_threshold": 20}}
+    df = _df()
+    payload = fr.compute_payload(df, spec)
+    expected, _, _ = regime.prepare_check_regime(df, regime_enabled=True, windows_spec=spec)
+    assert payload == expected
+```
+
+- [ ] **Step 2: Run, verify FAIL** (`uv run --no-sync python -m pytest shared_scripts/test_fetch_regime.py -v`).
+
+- [ ] **Step 3: Implement** `fetch_regime.py`. It mirrors the OHLCV-fetch + DataFrame construction of the check scripts (`_make_dataframe`, `adapter.get_ohlcv`), then computes the multi-window payload with `compute_multi_regime`. `--probe-only` short-circuits before any adapter call (per probe contract). Platform dispatch reuses the `importlib` adapter-loading convention (class `endswith("ExchangeAdapter")`). Emits `{"regime": <payload>, "bar_time": <ts>}` to stdout, JSON on error with exit 1.
+
+```python
+#!/usr/bin/env python3
+"""#879: dedicated read-only regime subprocess.
+
+Fetches OHLCV for one (platform, symbol, interval), computes the multi-window
+regime payload via shared_tools/regime.py, and emits it. The scheduler runs this
+ONCE per distinct (symbol, interval, windows-spec) signature per cycle and
+injects the payload into every check via --regime-payload-json, so checks no
+longer compute regime inline. Read-only: never places orders.
+"""
+import argparse, json, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "shared_tools"))
+sys.path.insert(0, str(ROOT))
+
+import pandas as pd
+from regime import compute_multi_regime, parse_regime_windows_spec_json, required_ohlcv_limit
+
+
+def _make_dataframe(candles):
+    df = pd.DataFrame(candles, columns=["timestamp", "open", "high", "low", "close", "volume"])
+    for col in ("open", "high", "low", "close", "volume"):
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+    return df
+
+
+def compute_payload(df: pd.DataFrame, spec: dict) -> dict:
+    """Multi-window payload identical to prepare_check_regime(..., windows_spec=spec)[0]."""
+    return compute_multi_regime(df, spec)
+
+
+def _load_adapter(platform: str):
+    # Mirrors the check-script importlib convention: one *ExchangeAdapter per file.
+    import importlib.util, inspect
+    plat_dir = ROOT / "platforms" / platform
+    if platform == "hyperliquid":
+        sys.path.insert(0, str(plat_dir))  # SDK clash workaround (see CLAUDE.md)
+    spec = importlib.util.spec_from_file_location(f"{platform}_adapter", plat_dir / "adapter.py")
+    mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+    for _, obj in inspect.getmembers(mod, inspect.isclass):
+        if obj.__name__.endswith("ExchangeAdapter"):
+            return obj()
+    raise RuntimeError(f"no adapter class for platform {platform!r}")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--platform", required=True)
+    p.add_argument("--symbol", required=True)
+    p.add_argument("--interval", required=True)
+    p.add_argument("--regime-windows-spec-json", default="")
+    p.add_argument("--ohlcv-limit", type=int, default=200)
+    p.add_argument("--probe-only", action="store_true")
+    args = p.parse_args()
+
+    if args.probe_only:
+        print(json.dumps({"regime": "", "bar_time": 0}))
+        return 0
+
+    try:
+        spec = parse_regime_windows_spec_json(args.regime_windows_spec_json or None)
+        if not spec:
+            print(json.dumps({"regime": "", "bar_time": 0}))
+            return 0
+        limit = max(args.ohlcv_limit, required_ohlcv_limit(windows=spec))
+        adapter = _load_adapter(args.platform)
+        candles = adapter.get_ohlcv(args.symbol, interval=args.interval, limit=limit)
+        if not candles or len(candles) < 30:
+            print(json.dumps({"error": f"insufficient candles: {len(candles) if candles else 0}"}))
+            return 1
+        df = _make_dataframe(candles)
+        payload = compute_payload(df, spec)
+        bar_time = int(df["timestamp"].iloc[-1]) if len(df) else 0
+        print(json.dumps({"regime": payload, "bar_time": bar_time}))
+        return 0
+    except Exception as exc:  # subprocess contract: JSON on stdout, exit 1
+        print(json.dumps({"error": str(exc)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+> **Implementer:** verify each adapter's `get_ohlcv(symbol, interval=, limit=)` signature matches (HL uses `interval=`/`limit=`; confirm okx `--inst-type`, robinhood, topstep, binanceus signatures — some may need a market-type arg). If a platform needs extra args (e.g. OKX `inst_type`, options underlying), thread them through from Go via the representative strategy's args. **Compile-check:** `uv run --no-sync python -m py_compile shared_scripts/fetch_regime.py`.
+
+- [ ] **Step 4: Run test, verify PASS.**
+- [ ] **Step 5: Commit.** `feat(regime): fetch_regime.py read-only regime subprocess (#879)`
+
+---
+
+### Task 5: `resolve_injected_regime` helper (Python)
+
+**Files:**
+- Modify: `shared_tools/regime.py`
+- Test: `shared_tools/test_regime.py` (add cases)
+
+- [ ] **Step 1: Write failing test** — injected payload reproduces `prepare_check_regime`'s 3-tuple exactly.
+
+```python
+def test_resolve_injected_regime_matches_prepare():
+    from regime import prepare_check_regime, resolve_injected_regime
+    import pandas as pd
+    n = 120
+    close = pd.Series(range(100, 100 + n)).astype(float)
+    df = pd.DataFrame({"timestamp": range(n), "open": close, "high": close+1,
+                       "low": close-1, "close": close, "volume": [1.0]*n})
+    spec = {"medium": {"classifier": "adx", "period": 14, "adx_threshold": 20},
+            "macro": {"classifier": "composite", "period": 30}}
+    want_payload, want_live, want_strat = prepare_check_regime(df, regime_enabled=True, windows_spec=spec, atr_window="macro")
+    inj_payload, inj_live, inj_strat = resolve_injected_regime(want_payload, primary_key="medium", atr_window="macro")
+    assert inj_payload == want_payload
+    assert inj_live == want_live
+    assert inj_strat == want_strat
+```
+
+- [ ] **Step 2: Run, verify FAIL.**
+- [ ] **Step 3: Implement** in `regime.py` — pure projection over the injected multi-window payload (or legacy string), no recomputation:
+
+```python
+def resolve_injected_regime(
+    payload: dict | str,
+    *,
+    primary_key: str = "",
+    atr_window: str = "",
+) -> tuple[dict | str, str, dict]:
+    """#879: reconstruct prepare_check_regime's 3-tuple from a scheduler-injected
+    payload WITHOUT recomputing. `payload` is either the multi-window map
+    {window: snapshot} or a legacy single snapshot/label string."""
+    disabled = {"regime": "", "score": 0.0, "metrics": dict(_DEFAULT_METRICS)}
+    if not payload:
+        return "", "", disabled
+    if isinstance(payload, str):
+        legacy = {"regime": payload, "score": 0.0, "metrics": dict(_DEFAULT_METRICS), "classifier": CLASSIFIER_ADX}
+        return payload, payload, legacy
+    # multi-window map
+    keys = sorted(payload.keys())
+    pkey = primary_key if (primary_key and primary_key in payload) else (
+        REGIME_PRIMARY_WINDOW_KEY if REGIME_PRIMARY_WINDOW_KEY in payload else (keys[0] if keys else ""))
+    strategy_payload = payload.get(pkey, disabled)
+    akey = (atr_window or pkey).strip() or pkey
+    atr_entry = payload.get(akey, strategy_payload)
+    live_atr = str(atr_entry.get("regime") or "") if isinstance(atr_entry, dict) else ""
+    return payload, live_atr, strategy_payload
+```
+
+> **Parity check:** the `pkey`/`akey`/`live_atr` selection logic above must match `prepare_check_regime` (regime.py:457-469) line-for-line. Diff them.
+
+- [ ] **Step 4: Run, verify PASS.**
+- [ ] **Step 5: Commit.** `feat(regime): resolve_injected_regime projection helper (#879)`
+
+---
+
+### Task 6: Injection args builder (Go)
+
+**Files:**
+- Modify: `scheduler/strategy_composition.go`
+- Test: `scheduler/strategy_composition_test.go`
+
+- [ ] **Step 1: Write failing test:**
+
+```go
+func TestAppendInjectedRegimeArgs(t *testing.T) {
+    pl := RegimePayload{MultiMode: true, Windows: map[string]RegimeSnapshot{
+        "default": {Regime: "trending_up", Score: 0.4}}}
+    got := appendInjectedRegimeArgs(nil, pl)
+    j := strings.Join(got, " ")
+    if !strings.Contains(j, "--regime-injected") || !strings.Contains(j, "--regime-payload-json") {
+        t.Fatalf("missing injection flags: %v", got)
+    }
+    // empty payload still injects (fail-open: do NOT recompute inline)
+    got2 := appendInjectedRegimeArgs(nil, RegimePayload{})
+    if !strings.Contains(strings.Join(got2, " "), "--regime-injected") {
+        t.Fatal("empty payload must still set --regime-injected to suppress inline compute")
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL.**
+- [ ] **Step 3: Implement:**
+
+```go
+// appendInjectedRegimeArgs (#879) forwards the scheduler-computed regime payload
+// to a check script. --regime-injected ALWAYS set (even on empty payload) so the
+// check skips prepare_check_regime — an empty payload means fail-open, never
+// "recompute inline".
+func appendInjectedRegimeArgs(args []string, payload RegimePayload) []string {
+    out := append(args, "--regime-injected")
+    blob, err := json.Marshal(payload)
+    if err != nil || string(blob) == "null" {
+        blob = []byte(`""`)
+    }
+    return append(out, "--regime-payload-json", string(blob))
+}
+```
+
+- [ ] **Step 4: Run, verify PASS.**
+- [ ] **Step 5: Commit.** `feat(regime): injected-regime args builder (#879)`
+
+---
+
+### Task 7: `check_hyperliquid.py` accepts injection
+
+**Files:**
+- Modify: `shared_scripts/check_hyperliquid.py`
+- Test: `shared_scripts/test_check_hyperliquid.py` (or new) — injected vs inline parity.
+
+- [ ] **Step 1: Write failing test** — run the regime branch with injection and assert `strategy_params["regime"]`, `market_ctx["regime"]`, and `stdout_regime` equal the inline path for the same candles.
+
+```python
+def test_injected_regime_matches_inline(monkeypatch):
+    # Build df + spec, compute inline payload, then feed it back via the injected
+    # path; assert the three derived values match. (Exact harness mirrors the
+    # check's existing test scaffolding — call the regime resolution block with
+    # args.regime_injected=True and args.regime_payload_json=<inline payload>.)
+    ...
+```
+
+- [ ] **Step 2: Run, verify FAIL.**
+- [ ] **Step 3: Implement** — add argparse flags and branch the regime block (check_hyperliquid.py ~169-189):
+
+```python
+# argparse (near line 1640)
+parser.add_argument("--regime-injected", action="store_true", default=False)
+parser.add_argument("--regime-payload-json", default="")
+
+# regime block (replacing the prepare_check_regime call ~169)
+if args.regime_injected:
+    injected = json.loads(args.regime_payload_json) if args.regime_payload_json.strip() else ""
+    stdout_regime, live_regime, strategy_regime = resolve_injected_regime(
+        injected,
+        primary_key=_primary_window_key(regime_windows_spec),
+        atr_window=regime_atr_window,
+    )
+else:
+    stdout_regime, live_regime, strategy_regime = prepare_check_regime(
+        df, regime_enabled=regime_enabled, windows_spec=regime_windows_spec, atr_window=regime_atr_window,
+    )
+strategy_params["regime"] = strategy_regime
+```
+
+Import `resolve_injected_regime` at the top (line 64) alongside the others. `_primary_window_key` = `"medium" if "medium" in spec else sorted(spec)[0]` (or empty when spec is None).
+
+> **Critical:** when `--regime-injected` is set, the check MUST NOT call `prepare_check_regime` even on empty payload (that is the fail-open contract). Keep `--probe-only` working: injection flags must parse under probe argv.
+
+- [ ] **Step 4: Run test, verify PASS.** Also `py_compile`.
+- [ ] **Step 5: Commit.** `feat(regime): check_hyperliquid.py accepts injected regime (#879)`
+
+---
+
+### Task 8: Wire HL dispatch to store (Go)
+
+**Files:**
+- Modify: `scheduler/main.go` (build store before Phase 3; pass payload into `runHyperliquidCheck`)
+- Test: covered by Task 9 integration parity + existing HL tests must stay green.
+
+- [ ] **Step 1:** Add store build in the main loop before the Phase 3 dispatch block (after `dueStrategies` is finalized, near main.go:630/771). Store is a cycle-local var:
+
+```go
+regimeStore := buildRegimeStore(dueStrategies, cfg.Regime)
+```
+
+- [ ] **Step 2:** Thread `regimeStore` into `runHyperliquidCheck` (add a `payload RegimePayload` param or look it up inside). Inside, replace `args = appendRegimeArgs(...)`-fed inline compute by also appending injection:
+
+```go
+injected := regimeStore.payloadForStrategy(*sc, regime)
+args = appendInjectedRegimeArgs(args, injected)
+```
+
+Keep `appendRegimeArgs`/`appendStrategyRegimeWindowArgs` (the script still needs the windows spec + atr-window selector to RESOLVE the injected payload). The check now echoes `injected` back as `result.Regime`, so the downstream `applyRegimeGate`/`syncStrategyRegimeState`/directional-policy code at main.go:1555-1560 is unchanged.
+
+- [ ] **Step 3:** `go -C scheduler build .` then `go test ./scheduler/ -run 'HL|Hyperliquid|Regime' -v` — all green.
+- [ ] **Step 4: Commit.** `feat(regime): HL dispatch injects store payload (#879)`
+
+---
+
+### Task 9: HL end-to-end parity test (Go + Python)
+
+**Files:**
+- Test: `scheduler/regime_calculator_test.go` (Go) + a Python parity assertion.
+
+- [ ] **Step 1:** Add a Go test that stubs `runRegimeSubprocessFn` to return a known payload and asserts `runHyperliquidCheck`'s downstream gate/sync see that exact label. (Stub `RunHyperliquidCheck` too — see existing HL test scaffolding.)
+- [ ] **Step 2:** Add an integration parity script/test: for a fixed candle fixture, assert `fetch_regime.py compute_payload` == `check_hyperliquid.py` inline `stdout_regime`. Run full pytest suite (registry/sys.path requirement).
+- [ ] **Step 3: Commit.** `test(regime): HL injected-vs-inline parity (#879)`
+
+---
+
+### Task 10: Replicate injection to spot/okx/robinhood/topstep
+
+**Files:**
+- Modify: `shared_scripts/check_strategy.py`, `check_okx.py`, `check_robinhood.py`, `check_topstep.py`
+- Modify: `scheduler/main.go` (`runSpotCheck`, `runOKXCheck`, `runRobinhoodCheck`, `runTopStepCheck`)
+- Test: per-script `py_compile` + one parity test each (reuse Task 7 harness).
+
+Repeat Task 7 + Task 8 mechanically for each platform. For each:
+- [ ] Add `--regime-injected`/`--regime-payload-json`, import `resolve_injected_regime`, branch the regime block, echo payload back.
+- [ ] In the Go `runXxxCheck`, append `appendInjectedRegimeArgs(args, regimeStore.payloadForStrategy(*sc, regime))`.
+- [ ] `check_strategy.py` (spot/manual) uses positional argv + `--probe-only` short-circuit — confirm it currently has NO regime flags (per the explore map) and add them in the same argparse section; verify the manual path still works.
+- [ ] Build + targeted tests green. Commit per platform: `feat(regime): <platform> dispatch injects store payload (#879)`.
+
+> **Implementer:** these are argparse-strict scripts (HL/TopStep/RH/OKX) — the new flags MUST be added before they can be probed. Update `version_probe.go` in Task 15, but you can add the flags here and probe-test locally.
+
+---
+
+### Task 11: Options migration
+
+**Files:**
+- Modify: `scheduler/main.go` (~1515-1526, the `stratState.Regime = result.Regime` options branch)
+- Modify: `shared_scripts/check_options.py` (regime at hardcoded `REGIME_TIMEFRAME="4h"`, `latest_regime` 3-state)
+- Test: options regime parity.
+
+- [ ] **Step 1:** Decide the options signature: `(underlying, "4h", adx-spec)` — options use a fixed 4h ADX regime independent of `regime.windows`. Add an options-specific signature so `buildRegimeStore` computes it (the representative options strategy contributes `(underlying, 4h)` with an ADX-14 spec). Confirm `check_options.py`'s underlying symbol maps to the adapter's `get_ohlcv` symbol.
+- [ ] **Step 2:** Inject the 4h payload into `check_options.py` (add `--regime-injected`/`--regime-payload-json`; when set, skip `latest_regime`, use injected label). Go: `stratState.Regime = regimeStore.payloadForStrategy(sc, ...).PrimaryLabel(...)` instead of `result.Regime`.
+- [ ] **Step 3:** Parity test: injected 4h-ADX label == inline `latest_regime` for the same candles. Build + test. Commit. `feat(regime): options reads regime store (#879)`
+
+> **Decision to confirm with maintainer:** whether options should adopt the global `regime.windows` or keep its hardcoded 4h-ADX. Plan keeps 4h-ADX (no behavior change) and stores it under a distinct options signature.
+
+---
+
+### Task 12: Flat-`manual` reads store
+
+**Files:**
+- Modify: `scheduler/main.go` (manual dispatch ~1860-1879)
+- Test: manual flat regime visibility test.
+
+- [ ] **Step 1: Write failing test** — a flat manual strategy (no position) has `stratState.Regime` populated from the store after a cycle (today it is empty while flat because `runManualCloseEval` only computes when open).
+- [ ] **Step 2:** In the manual dispatch, when flat (no open position so `runManualCloseEval` is skipped or returns empty), read `regimeStore.payloadForStrategy(sc, cfg.Regime)` and call `syncStrategyRegimeState(stratState, payload, cfg.Regime)`. When open, keep the existing `runManualCloseEval` path BUT prefer injecting the store payload there too (so the manual HL check echoes the store rather than recomputing). Preserve `stampPositionRegimeIfOpened` (frozen-at-open; #873 coordination — do not re-stamp).
+- [ ] **Step 3:** Build + test. Commit. `feat(regime): flat manual reads regime store (#879)`
+
+> **#873 coordination:** if #873 merged first, preserve its `manual-add` branch; the add path must thread the store payload like the open path and never re-stamp. If #879 merges first, #873 rebases its add branch onto the store read.
+
+---
+
+### Task 13: Manual close-eval injection
+
+**Files:**
+- Modify: `scheduler/main.go` (`runManualCloseEval`) + `check_strategy.py`/`check_hyperliquid.py` manual path.
+- [ ] Inject store payload into the manual HL check (`runManualCloseEval` calls `runHyperliquidCheck`-style path) so `manualRegime` comes from the store, not an inline recompute. Build + test. Commit. `feat(regime): manual close-eval injects store payload (#879)`
+
+---
+
+### Task 14: Dashboard portfolio regime view
+
+**Files:**
+- Modify: `scheduler/ui_server.go` (+ `static/ui/*` if a new field is surfaced) and/or `/api/strategies/overview`.
+- Test: `scheduler/ui_server_test.go`.
+
+- [ ] **Step 1: Write failing test** for a new `/api/regime` (or field on overview) returning the per-signature store snapshot: `[{symbol, interval, adx3, comp7|windows}]`.
+- [ ] **Step 2:** Persist the latest built store into `AppState` (cycle-local → store a snapshot under `mu` at end of build, like marks) so the HTTP handler (different goroutine) can read it. Expose a read-only JSON endpoint. Respect lock order `mu → strategiesMu`; loopback-only.
+- [ ] **Step 3:** Build + test. Commit. `feat(regime): dashboard portfolio regime view (#879)`
+
+> **Implementer:** the store is currently cycle-local. To serve the dashboard, store an immutable snapshot on `AppState` (e.g. `state.RegimeSnapshot`) under `mu.Lock` at the end of `buildRegimeStore`/end of cycle. Do NOT share the live map across goroutines without a copy.
+
+---
+
+### Task 15: Probe argv + same-SHA deploy guard
+
+**Files:**
+- Modify: `scheduler/version_probe.go`
+- Test: `scheduler/version_probe_test.go`
+
+- [ ] **Step 1:** Add `fetch_regime.py` probe argv + invocation:
+
+```go
+var fetchRegimeProbeArgv = []string{
+    "--platform=hyperliquid", "--symbol=BTC", "--interval=1h",
+    "--regime-windows-spec-json", `{"default":{"classifier":"adx","period":14,"adx_threshold":20}}`,
+    "--ohlcv-limit=200", "--probe-only",
+}
+```
+Invoke it once in `probeCheckScripts` when any strategy is configured (like `fetch_candles.py`).
+
+- [ ] **Step 2:** Append `--regime-injected` + `--regime-payload-json` to `probeArgv` and `probeCompositeArgv` (and the composite variant) so a stale check script that doesn't accept the injection flags fails startup:
+
+```go
+// in probeArgv / probeCompositeArgv
+"--regime-injected", "--regime-payload-json", `{"default":{"regime":"trending_up","score":0.4}}`,
+```
+
+- [ ] **Step 3:** Update `version_probe_test.go` expectations. Build + test. Commit. `feat(regime): probe fetch_regime + injection flags (#879)`
+
+---
+
+### Task 16: Backtest parity test + script-failure alert + final matrix
+
+**Files:**
+- Modify: `scheduler/script_failure_alerts.go` (regime subprocess failure → throttled alert)
+- Test: `backtest/tests/test_regime_bundle_parity.py` (new), full Go + pytest suites, `--once` smoke.
+
+- [ ] **Step 1:** Backtest parity test: assert `fetch_regime.compute_payload(df, spec)` per-window label == `ensure_regime_columns(df, ...)` / `compute_regime_composite` last-bar label for the same candles (ADX and composite, incl. `period>14` full-period ADX). Backtest code itself is unchanged.
+- [ ] **Step 2:** Wire regime-subprocess failures through `scriptFailureTracker` keyed by signature (reuse `notifyScriptFailure` pattern at `scriptFailureAlertThreshold=3`), per the issue's failure policy. Test the throttle.
+- [ ] **Step 3:** Full parity matrix test (per consumer: gate, sync, stamp, ATR-regime, directional) — default-param label unchanged pre/post for HL/spot/okx/rh/topstep/options/manual.
+- [ ] **Step 4:** `go build` + `go test ./...` + `uv run --no-sync python -m pytest shared_strategies/ shared_tools/ platforms/ backtest/` + `shared_scripts/test_*.py` + `./go-trader --config scheduler/config.json --once` smoke.
+- [ ] **Step 5: Commit.** `test(regime): backtest parity + failure alerts + full matrix (#879)`
+
+---
+
+## Latency analysis (issue requirement — do before merging)
+
+The store build adds one serial phase before Phase 3: N distinct `(symbol, interval, spec)` regime subprocesses, run **concurrently** under the shared `pythonSemaphore=4` with `scriptTimeout=30s`. Each subprocess fetches OHLCV that lands in the #839 `/tmp` cache, so the subsequent check reads cache (no double network fetch). Net added wall-clock ≈ `ceil(N_distinct / 4) × (spawn + ADX compute)`, not `N_strategies`. Quantify on the real config (`--once` with timing) and record in the PR body. If unacceptable, the concurrent fan-out already bounds it; a further option is to skip the store build for cycles where no due strategy has `regime.enabled`.
+
+## Self-review checklist (run after drafting)
+
+- Spec items 1-7 mapped: store+subprocess (T1-4), load-time validation reused not duplicated (existing `validateStrategyRegimeVocabulary`, no change), raw+labels one pass via per-window classify (T4), strategy resolution from store (T8/T10), dashboard (T14), migrate every consumer incl. options/manual/backtest (T10-13,16), parity tests (T9,T16).
+- Failure policy (b) implemented as present-but-empty store entry (T1,T3) + fail-open reads + throttled alert (T16).
+- `pos.Regime` frozen-at-open untouched; #873 coordination noted (T12,T13).
+- Same-SHA deploy: probe argv updated (T15).
+- Type consistency: `RegimePayload`, `RegimeSignature`, `RegimeStore`, `resolve_injected_regime`, `appendInjectedRegimeArgs`, `buildRegimeStore`, `runRegimeSubprocessFn` used consistently across tasks.

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2084,6 +2084,12 @@ func main() {
 					logger.Close()
 					lastRun[sc.ID] = time.Now()
 				}
+				// #879: snapshot the per-cycle regime store onto state for the
+				// dashboard portfolio view, after the dispatch loop so options'
+				// store-from-result contributions are included. Ephemeral.
+				mu.Lock()
+				state.RegimePortfolio = regimeStore.snapshot()
+				mu.Unlock()
 			} // end if !killSwitchFired
 		}
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1460,7 +1460,7 @@ func main() {
 					switch sc.Type {
 					case "spot":
 						if sc.Platform == "okx" {
-							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, cfg.Regime, notifier, logger); ok {
+							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, cfg.Regime, regimeStore.payloadForStrategy(sc, cfg.Regime), notifier, logger); ok {
 								prices[result.Symbol] = price
 								if gateRegime, regimeBlocked := applyRegimeGate(sc, regimePayloadValue(result.Regime), cfg.Regime, okxPosQty); regimeBlocked {
 									logger.Info("Regime gate: open signal blocked (regime=%s)", gateRegime)
@@ -1485,7 +1485,7 @@ func main() {
 								}
 							}
 						} else if sc.Platform == "robinhood" {
-							if result, signalStr, price, ok := runRobinhoodCheck(sc, prices, rhPosCtx, cfg.Regime, notifier, logger); ok {
+							if result, signalStr, price, ok := runRobinhoodCheck(sc, prices, rhPosCtx, cfg.Regime, regimeStore.payloadForStrategy(sc, cfg.Regime), notifier, logger); ok {
 								prices[result.Symbol] = price
 								if gateRegime, regimeBlocked := applyRegimeGate(sc, regimePayloadValue(result.Regime), cfg.Regime, rhPosQty); regimeBlocked {
 									logger.Info("Regime gate: open signal blocked (regime=%s)", gateRegime)
@@ -1509,7 +1509,7 @@ func main() {
 									mu.Unlock()
 								}
 							}
-						} else if result, signalStr, price, ok := runSpotCheck(sc, prices, spotPosCtx, cfg.Regime, notifier, logger); ok {
+						} else if result, signalStr, price, ok := runSpotCheck(sc, prices, spotPosCtx, cfg.Regime, regimeStore.payloadForStrategy(sc, cfg.Regime), notifier, logger); ok {
 							if gateRegime, regimeBlocked := applyRegimeGate(sc, regimePayloadValue(result.Regime), cfg.Regime, spotPosCtx.Quantity); regimeBlocked {
 								logger.Info("Regime gate: open signal blocked (regime=%s)", gateRegime)
 								result.Signal = 0
@@ -1533,7 +1533,7 @@ func main() {
 						}
 					case "perps":
 						if sc.Platform == "okx" {
-							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, cfg.Regime, notifier, logger); ok {
+							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, cfg.Regime, regimeStore.payloadForStrategy(sc, cfg.Regime), notifier, logger); ok {
 								prices[result.Symbol] = price
 								if gateRegime, regimeBlocked := applyRegimeGate(sc, regimePayloadValue(result.Regime), cfg.Regime, okxPosQty); regimeBlocked {
 									logger.Info("Regime gate: open signal blocked (regime=%s)", gateRegime)
@@ -1818,7 +1818,7 @@ func main() {
 							}
 						}
 					case "futures":
-						if result, signalStr, price, ok := runTopStepCheck(sc, prices, tsPosCtx, cfg.Regime, notifier, logger); ok {
+						if result, signalStr, price, ok := runTopStepCheck(sc, prices, tsPosCtx, cfg.Regime, regimeStore.payloadForStrategy(sc, cfg.Regime), notifier, logger); ok {
 							prices[result.Symbol] = price
 							if gateRegime, regimeBlocked := applyRegimeGate(sc, regimePayloadValue(result.Regime), cfg.Regime, tsContracts); regimeBlocked {
 								logger.Info("Regime gate: open signal blocked (regime=%s)", gateRegime)
@@ -2410,7 +2410,7 @@ func spotSymbol(args []string) string {
 
 // runSpotCheck runs the spot check subprocess and returns the parsed result.
 // No state access. Returns (result, signalStr, price, ok); ok=false means skip execution.
-func runSpotCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, notifier *MultiNotifier, logger *StrategyLogger) (*SpotResult, string, float64, bool) {
+func runSpotCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, injectedRegime RegimePayload, notifier *MultiNotifier, logger *StrategyLogger) (*SpotResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
 	args = appendOpenCloseArgs(args, sc, posCtx)
 	if sc.HTFFilter {
@@ -2418,6 +2418,7 @@ func runSpotCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionC
 	}
 	args = appendRegimeArgs(args, regime)
 	args = appendStrategyRegimeWindowArgs(args, sc, regime)
+	args = appendInjectedRegimeArgs(args, injectedRegime)
 	if refsArgs, err := buildStrategyRefsArg(sc); err != nil {
 		logger.Warn("Failed to marshal strategy refs: %v", err)
 	} else if len(refsArgs) > 0 {
@@ -3197,7 +3198,7 @@ func topstepSymbol(args []string) string {
 }
 
 // runTopStepCheck runs check_topstep.py signal-check mode (Phase 3, no lock).
-func runTopStepCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, notifier *MultiNotifier, logger *StrategyLogger) (*TopStepResult, string, float64, bool) {
+func runTopStepCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, injectedRegime RegimePayload, notifier *MultiNotifier, logger *StrategyLogger) (*TopStepResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
 	args = appendOpenCloseArgs(args, sc, posCtx)
 	if sc.HTFFilter {
@@ -3205,6 +3206,7 @@ func runTopStepCheck(sc StrategyConfig, prices map[string]float64, posCtx Positi
 	}
 	args = appendRegimeArgs(args, regime)
 	args = appendStrategyRegimeWindowArgs(args, sc, regime)
+	args = appendInjectedRegimeArgs(args, injectedRegime)
 	if refsArgs, err := buildStrategyRefsArg(sc); err != nil {
 		logger.Warn("Failed to marshal strategy refs: %v", err)
 	} else if len(refsArgs) > 0 {
@@ -3398,7 +3400,7 @@ func robinhoodSymbol(args []string) string {
 }
 
 // runRobinhoodCheck runs check_robinhood.py signal-check mode (Phase 3, no lock).
-func runRobinhoodCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, notifier *MultiNotifier, logger *StrategyLogger) (*RobinhoodResult, string, float64, bool) {
+func runRobinhoodCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, injectedRegime RegimePayload, notifier *MultiNotifier, logger *StrategyLogger) (*RobinhoodResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
 	args = appendOpenCloseArgs(args, sc, posCtx)
 	if sc.HTFFilter {
@@ -3406,6 +3408,7 @@ func runRobinhoodCheck(sc StrategyConfig, prices map[string]float64, posCtx Posi
 	}
 	args = appendRegimeArgs(args, regime)
 	args = appendStrategyRegimeWindowArgs(args, sc, regime)
+	args = appendInjectedRegimeArgs(args, injectedRegime)
 	if refsArgs, err := buildStrategyRefsArg(sc); err != nil {
 		logger.Warn("Failed to marshal strategy refs: %v", err)
 	} else if len(refsArgs) > 0 {
@@ -3577,7 +3580,7 @@ func okxInstType(args []string) string {
 }
 
 // runOKXCheck runs check_okx.py signal-check mode (Phase 3, no lock).
-func runOKXCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, notifier *MultiNotifier, logger *StrategyLogger) (*OKXResult, string, float64, bool) {
+func runOKXCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, injectedRegime RegimePayload, notifier *MultiNotifier, logger *StrategyLogger) (*OKXResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
 	args = appendOpenCloseArgs(args, sc, posCtx)
 	if sc.HTFFilter {
@@ -3585,6 +3588,7 @@ func runOKXCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCt
 	}
 	args = appendRegimeArgs(args, regime)
 	args = appendStrategyRegimeWindowArgs(args, sc, regime)
+	args = appendInjectedRegimeArgs(args, injectedRegime)
 	if refsArgs, err := buildStrategyRefsArg(sc); err != nil {
 		logger.Warn("Failed to marshal strategy refs: %v", err)
 	} else if len(refsArgs) > 0 {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1279,7 +1279,7 @@ func main() {
 				// distinct (symbol, interval, windows-spec) signature; peers
 				// share the result. Failed signatures clear to empty (fail-open).
 				// Injected into each check below so checks skip inline compute.
-				regimeStore := buildRegimeStore(dueStrategies, cfg.Regime)
+				regimeStore := buildRegimeStore(dueStrategies, cfg.Regime, notifier)
 
 				for _, sc := range dueStrategies {
 					stratState := state.Strategies[sc.ID]

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1527,7 +1527,7 @@ func main() {
 							// Options computes regime inline (advisory 4h ADX, embedded in its
 							// evaluators); populate from the result so options behavior is unchanged.
 							if cfg.Regime != nil && cfg.Regime.Enabled && strings.TrimSpace(result.Regime) != "" {
-								regimeStore.put(optionsRegimeSignature(result.Underlying, cfg.Regime), RegimePayload{Legacy: result.Regime}, nil)
+								regimeStore.put(optionsRegimeSignature(sc, result.Underlying, cfg.Regime), RegimePayload{Legacy: result.Regime}, nil)
 							}
 							var harvestDetails []string
 							trades, detail, harvestDetails = executeOptionsResult(sc, stratState, result, signalStr, logger)
@@ -2088,7 +2088,7 @@ func main() {
 				// dashboard portfolio view, after the dispatch loop so options'
 				// store-from-result contributions are included. Ephemeral.
 				mu.Lock()
-				state.RegimePortfolio = regimeStore.snapshot()
+				state.RegimePortfolio = regimeStore.snapshot(cfg.Regime)
 				mu.Unlock()
 			} // end if !killSwitchFired
 		}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1274,6 +1274,13 @@ func main() {
 					}
 				}
 
+				// #879: build the per-cycle global regime store once before the
+				// per-strategy dispatch fan-out. One read-only subprocess per
+				// distinct (symbol, interval, windows-spec) signature; peers
+				// share the result. Failed signatures clear to empty (fail-open).
+				// Injected into each check below so checks skip inline compute.
+				regimeStore := buildRegimeStore(dueStrategies, cfg.Regime)
+
 				for _, sc := range dueStrategies {
 					stratState := state.Strategies[sc.ID]
 					if stratState == nil {
@@ -1550,7 +1557,7 @@ func main() {
 									mu.Unlock()
 								}
 							}
-						} else if result, signalStr, price, ok := runHyperliquidCheck(&sc, prices, hlPosCtx, cfg.Regime, notifier, logger); ok {
+						} else if result, signalStr, price, ok := runHyperliquidCheck(&sc, prices, hlPosCtx, cfg.Regime, regimeStore.payloadForStrategy(sc, cfg.Regime), notifier, logger); ok {
 							prices[result.Symbol] = price
 							if gateRegime, regimeBlocked := applyRegimeGate(sc, regimePayloadValue(result.Regime), cfg.Regime, hlPosQty); regimeBlocked {
 								logger.Info("Regime gate: open signal blocked (regime=%s)", gateRegime)
@@ -1861,7 +1868,15 @@ func main() {
 						// pos.Regime == "" on the first post-open cycle, so the regime
 						// trail no-op'd for one interval; stamping first arms it
 						// correctly on cycle 1.
-						closeFraction, _, manualRegime, manualOK := runManualCloseEval(sc, stratState, cfg, notifier, logger)
+						manualInjectedRegime := regimeStore.payloadForStrategy(sc, cfg.Regime)
+						closeFraction, _, manualRegime, manualOK := runManualCloseEval(sc, stratState, cfg, manualInjectedRegime, notifier, logger)
+						// #879: when flat, runManualCloseEval returns an empty
+						// regime (no position to evaluate). Read the global store
+						// directly so status/dashboard show the live regime without
+						// an open position.
+						if manualRegime.IsEmpty() && !manualInjectedRegime.IsEmpty() {
+							manualRegime = manualInjectedRegime
+						}
 						if manualOK {
 							mu.Lock()
 							// Refresh the strategy-level live regime every cycle, like
@@ -2701,7 +2716,7 @@ func isHLLiveReconcilable(sc StrategyConfig) bool {
 // result.Regime is known, so downstream EffectiveDirection / perpsLiveOrderSize
 // / PerpsOrderSkipReason calls in execute paths see the effective values.
 // Mutation is scoped to the loop-local sc; cfg.Strategies is never touched.
-func runHyperliquidCheck(sc *StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, notifier *MultiNotifier, logger *StrategyLogger) (*HyperliquidResult, string, float64, bool) {
+func runHyperliquidCheck(sc *StrategyConfig, prices map[string]float64, posCtx PositionCtx, regime *RegimeConfig, injectedRegime RegimePayload, notifier *MultiNotifier, logger *StrategyLogger) (*HyperliquidResult, string, float64, bool) {
 	args := append([]string{}, sc.Args...)
 	// Suppress in-process close evaluators that overlap on-chain reduce-only
 	// protection — running both races on the shared on-chain position
@@ -2712,8 +2727,12 @@ func runHyperliquidCheck(sc *StrategyConfig, prices map[string]float64, posCtx P
 	if sc.HTFFilter {
 		args = append(args, "--htf-filter")
 	}
+	// appendRegimeArgs still forwards the windows-spec/atr-window so the check
+	// can RESOLVE the injected payload; #879 appendInjectedRegimeArgs supplies
+	// the scheduler-computed payload and suppresses inline regime compute.
 	args = appendRegimeArgs(args, regime)
 	args = appendStrategyRegimeWindowArgs(args, *sc, regime)
+	args = appendInjectedRegimeArgs(args, injectedRegime)
 	if refsArgs, err := buildStrategyRefsArg(scForCheck); err != nil {
 		logger.Warn("Failed to marshal strategy refs: %v", err)
 	} else if len(refsArgs) > 0 {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1523,6 +1523,12 @@ func main() {
 						if result, signalStr, ok := runOptionsCheck(sc, posJSON, notifier, logger); ok {
 							mu.Lock()
 							stratState.Regime = result.Regime
+							// #879: surface options regime in the portfolio/dashboard store.
+							// Options computes regime inline (advisory 4h ADX, embedded in its
+							// evaluators); populate from the result so options behavior is unchanged.
+							if cfg.Regime != nil && cfg.Regime.Enabled && strings.TrimSpace(result.Regime) != "" {
+								regimeStore.put(optionsRegimeSignature(result.Underlying, cfg.Regime), RegimePayload{Legacy: result.Regime}, nil)
+							}
 							var harvestDetails []string
 							trades, detail, harvestDetails = executeOptionsResult(sc, stratState, result, signalStr, logger)
 							mu.Unlock()

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -1188,14 +1188,14 @@ func openTradeSide(posSide string) string {
 // Returns (closeFraction, closePrice, regimePayload, ok). The regime payload is
 // the classifier output from this cycle's check; the caller stamps it onto the
 // position once (#872) so frozen-label close features arm on manual positions.
-func runManualCloseEval(sc StrategyConfig, ss *StrategyState, cfg *Config, notifier *MultiNotifier, logger *StrategyLogger) (float64, float64, RegimePayload, bool) {
+func runManualCloseEval(sc StrategyConfig, ss *StrategyState, cfg *Config, injectedRegime RegimePayload, notifier *MultiNotifier, logger *StrategyLogger) (float64, float64, RegimePayload, bool) {
 	pos := ss.Positions[sc.Symbol]
 	if pos == nil {
 		return 0, 0, RegimePayload{}, true // flat — nothing to do
 	}
 
 	posCtx := positionCtxFromPosition(pos)
-	result, _, price, ok := runHyperliquidCheck(&sc, nil, posCtx, cfg.Regime, notifier, logger)
+	result, _, price, ok := runHyperliquidCheck(&sc, nil, posCtx, cfg.Regime, injectedRegime, notifier, logger)
 	if !ok {
 		return 0, 0, RegimePayload{}, false
 	}

--- a/scheduler/manual_test.go
+++ b/scheduler/manual_test.go
@@ -889,7 +889,7 @@ func TestManualCloseEval_FlatReturnsEmptyPayload(t *testing.T) {
 	ss := &StrategyState{ID: sc.ID, Positions: map[string]*Position{}}
 	cfg := &Config{Regime: &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20}}
 
-	cf, px, payload, ok := runManualCloseEval(sc, ss, cfg, nil, nil)
+	cf, px, payload, ok := runManualCloseEval(sc, ss, cfg, RegimePayload{}, nil, nil)
 	if !ok {
 		t.Fatalf("flat manual close-eval ok = false, want true")
 	}

--- a/scheduler/probe_cmd_test.go
+++ b/scheduler/probe_cmd_test.go
@@ -148,9 +148,9 @@ func TestRunProbeHappyPath(t *testing.T) {
 	}
 	// Expect 9 invocations: HL signal-check (adx+composite), HL --fetch-atr (#689),
 	// HL --execute (PR #769), spot signal-check (adx+composite), dashboard helpers.
-	// 9 prior shapes + 3 #883 limit-order shapes (limit-open/limit-status/cancel-order).
-	if len(probed) != 12 {
-		t.Fatalf("expected 12 probe invocations, got %d: %v", len(probed), probed)
+	// 9 prior shapes + 3 #883 limit-order shapes + 1 #879 fetch_regime.py.
+	if len(probed) != 13 {
+		t.Fatalf("expected 13 probe invocations, got %d: %v", len(probed), probed)
 	}
 	var hlSignal, hlFetchATR, hlExecute, hlLimitOpen, hlLimitStatus, hlCancelOrder, spotSignal, candleHelper, schemaHelper, simulateHelper int
 	for _, p := range probed {

--- a/scheduler/regime_calculator.go
+++ b/scheduler/regime_calculator.go
@@ -16,6 +16,7 @@ package main
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -123,4 +124,34 @@ func (s *RegimeStore) payloadForStrategy(sc StrategyConfig, rc *RegimeConfig) Re
 	}
 	pl, _ := s.get(regimeSignatureForStrategy(sc, rc))
 	return pl
+}
+
+// snapshot returns a deterministic (sorted) copy of the store for the dashboard
+// portfolio view. Safe to hand to another goroutine — no shared map.
+func (s *RegimeStore) snapshot() []RegimePortfolioEntry {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]RegimePortfolioEntry, 0, len(s.entries))
+	for sig, e := range s.entries {
+		entry := RegimePortfolioEntry{
+			Symbol:   sig.Symbol,
+			Interval: sig.Interval,
+			Regime:   e.payload.PrimaryLabel(nil),
+			Failed:   e.failed,
+		}
+		if labels := e.payload.WindowLabels(); len(labels) > 0 {
+			entry.Windows = cloneStringMap(labels)
+		}
+		out = append(out, entry)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Symbol != out[j].Symbol {
+			return out[i].Symbol < out[j].Symbol
+		}
+		return out[i].Interval < out[j].Interval
+	})
+	return out
 }

--- a/scheduler/regime_calculator.go
+++ b/scheduler/regime_calculator.go
@@ -1,0 +1,126 @@
+package main
+
+// #879: per-cycle global regime store. Regime is computed once per distinct
+// regime signature per cycle in the Go scheduler (via a dedicated read-only
+// subprocess), stored here, and injected into every check script so checks no
+// longer compute regime inline. Flat manual, options, and the dashboard read
+// this store directly.
+//
+// Regime windows live in GLOBAL cfg.Regime.Windows (per-strategy fields are
+// only selectors), so the dedup unit is (symbol, interval) + a fingerprint of
+// the resolved global windows-spec JSON. The subprocess computes each window
+// with its own classifier/period via the existing compute_multi_regime, so
+// labels are byte-identical to the pre-migration inline path for the same
+// candles.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"sync"
+)
+
+// RegimeSignature dedups regime computation across peer strategies.
+type RegimeSignature struct {
+	Symbol   string
+	Interval string
+	SpecHash string
+}
+
+func regimeSignatureForStrategy(sc StrategyConfig, rc *RegimeConfig) RegimeSignature {
+	return RegimeSignature{
+		Symbol:   regimeSignatureSymbol(sc),
+		Interval: regimeSignatureInterval(sc),
+		SpecHash: regimeSpecHash(rc),
+	}
+}
+
+// regimeSignatureSymbol returns the asset symbol the platform's OHLCV fetch
+// uses — args[1] for every signal-check script (HL/OKX/RH/TopStep/spot all take
+// "<strategy> <symbol> <timeframe>"). Manual strategies fall back to sc.Symbol.
+func regimeSignatureSymbol(sc StrategyConfig) string {
+	if s := positionalArg(sc.Args, 1); s != "" {
+		return s
+	}
+	return strings.TrimSpace(sc.Symbol)
+}
+
+// regimeSignatureInterval returns the candle timeframe — args[2] when it is a
+// positional (not a flag). Empty when the strategy has no timeframe argument.
+func regimeSignatureInterval(sc StrategyConfig) string {
+	return positionalArg(sc.Args, 2)
+}
+
+// positionalArg returns args[idx] when it exists and is not a "--flag".
+func positionalArg(args []string, idx int) string {
+	if idx < 0 || idx >= len(args) {
+		return ""
+	}
+	v := strings.TrimSpace(args[idx])
+	if v == "" || strings.HasPrefix(v, "--") {
+		return ""
+	}
+	return v
+}
+
+func regimeSpecHash(rc *RegimeConfig) string {
+	blob := regimeWindowsSpecJSON(rc)
+	sum := sha256.Sum256([]byte(blob))
+	return hex.EncodeToString(sum[:8])
+}
+
+type regimeStoreEntry struct {
+	payload RegimePayload
+	failed  bool
+}
+
+// RegimeStore is the per-cycle two-layer store. Rebuilt every cycle (empty at
+// loop start), never persisted. A failed signature is present-but-empty so
+// reads fail-open rather than treating "missing" as "compute inline".
+type RegimeStore struct {
+	mu      sync.RWMutex
+	entries map[RegimeSignature]regimeStoreEntry
+}
+
+func newRegimeStore() *RegimeStore {
+	return &RegimeStore{entries: make(map[RegimeSignature]regimeStoreEntry)}
+}
+
+func (s *RegimeStore) put(sig RegimeSignature, pl RegimePayload, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err != nil {
+		s.entries[sig] = regimeStoreEntry{payload: RegimePayload{}, failed: true}
+		return
+	}
+	s.entries[sig] = regimeStoreEntry{payload: pl}
+}
+
+func (s *RegimeStore) get(sig RegimeSignature) (RegimePayload, bool) {
+	if s == nil {
+		return RegimePayload{}, false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	e, ok := s.entries[sig]
+	return e.payload, ok
+}
+
+func (s *RegimeStore) failed(sig RegimeSignature) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.entries[sig].failed
+}
+
+// payloadForStrategy is the consumer entry point: the store payload for a
+// strategy's signature (empty payload when missing/failed → fail-open).
+func (s *RegimeStore) payloadForStrategy(sc StrategyConfig, rc *RegimeConfig) RegimePayload {
+	if s == nil || rc == nil || !rc.Enabled {
+		return RegimePayload{}
+	}
+	pl, _ := s.get(regimeSignatureForStrategy(sc, rc))
+	return pl
+}

--- a/scheduler/regime_calculator.go
+++ b/scheduler/regime_calculator.go
@@ -21,18 +21,38 @@ import (
 	"sync"
 )
 
-// RegimeSignature dedups regime computation across peer strategies.
+// Regime signature kinds keep two store entries that share
+// (platform, symbol, interval, spec) from clobbering each other:
+//   - bundle:  the per-cycle multi-window payload from the fetch_regime.py
+//     subprocess, READ by every participating strategy's gate/ATR/directional.
+//   - options: the advisory 3-state ADX label populated FROM the options check
+//     result (write-only, dashboard display). Without a distinct kind an
+//     options strategy on underlying BTC at 4h would overwrite a real BTC/4h
+//     bundle that a later-dispatched peer then reads (#901 review #1).
+const (
+	regimeSignatureKindBundle  = "bundle"
+	regimeSignatureKindOptions = "options"
+)
+
+// RegimeSignature dedups regime computation across peer strategies. Platform is
+// part of the key because two exchanges' candles for the same symbol string
+// differ (#901 review #2); Kind separates the bundle from the advisory options
+// entry (#901 review #1).
 type RegimeSignature struct {
+	Platform string
 	Symbol   string
 	Interval string
 	SpecHash string
+	Kind     string
 }
 
 func regimeSignatureForStrategy(sc StrategyConfig, rc *RegimeConfig) RegimeSignature {
 	return RegimeSignature{
+		Platform: regimePlatformForStrategy(sc),
 		Symbol:   regimeSignatureSymbol(sc),
 		Interval: regimeSignatureInterval(sc),
 		SpecHash: regimeSpecHash(rc),
+		Kind:     regimeSignatureKindBundle,
 	}
 }
 
@@ -127,8 +147,10 @@ func (s *RegimeStore) payloadForStrategy(sc StrategyConfig, rc *RegimeConfig) Re
 }
 
 // snapshot returns a deterministic (sorted) copy of the store for the dashboard
-// portfolio view. Safe to hand to another goroutine — no shared map.
-func (s *RegimeStore) snapshot() []RegimePortfolioEntry {
+// portfolio view. Safe to hand to another goroutine — no shared map. rc is
+// threaded so the top-level label honors the configured primary window
+// (medium) instead of the lexicographically-first one (#901 review #3).
+func (s *RegimeStore) snapshot(rc *RegimeConfig) []RegimePortfolioEntry {
 	if s == nil {
 		return nil
 	}
@@ -139,7 +161,7 @@ func (s *RegimeStore) snapshot() []RegimePortfolioEntry {
 		entry := RegimePortfolioEntry{
 			Symbol:   sig.Symbol,
 			Interval: sig.Interval,
-			Regime:   e.payload.PrimaryLabel(nil),
+			Regime:   e.payload.PrimaryLabel(rc),
 			Failed:   e.failed,
 		}
 		if labels := e.payload.WindowLabels(); len(labels) > 0 {

--- a/scheduler/regime_calculator_test.go
+++ b/scheduler/regime_calculator_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+var errSentinel = errString("boom")
+
+func TestRegimeSignatureForStrategy(t *testing.T) {
+	rc := &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20}
+	sc := StrategyConfig{ID: "hl-btc", Symbol: "BTC", Args: []string{"momentum", "BTC", "1h"}, Platform: "hyperliquid"}
+	sig := regimeSignatureForStrategy(sc, rc)
+	if sig.Symbol != "BTC" || sig.Interval != "1h" {
+		t.Fatalf("got %+v", sig)
+	}
+	sc2 := StrategyConfig{ID: "hl-btc-2", Symbol: "BTC", Args: []string{"meanrev", "BTC", "1h"}, Platform: "hyperliquid"}
+	if regimeSignatureForStrategy(sc2, rc) != sig {
+		t.Fatal("peers on same asset/interval must share a signature")
+	}
+	// distinct interval → distinct signature
+	sc3 := StrategyConfig{ID: "hl-btc-4h", Symbol: "BTC", Args: []string{"momentum", "BTC", "4h"}, Platform: "hyperliquid"}
+	if regimeSignatureForStrategy(sc3, rc) == sig {
+		t.Fatal("distinct interval must produce distinct signature")
+	}
+}
+
+func TestPositionalArgSkipsFlags(t *testing.T) {
+	if got := positionalArg([]string{"strat", "BTC", "--mode=paper"}, 2); got != "" {
+		t.Fatalf("flag at idx 2 must yield empty, got %q", got)
+	}
+	if got := positionalArg([]string{"strat", "BTC", "1h"}, 2); got != "1h" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestRegimeStorePutGet(t *testing.T) {
+	s := newRegimeStore()
+	sig := RegimeSignature{Symbol: "BTC", Interval: "1h", SpecHash: "abc"}
+	s.put(sig, RegimePayload{Legacy: "trending_up"}, nil)
+	got, ok := s.get(sig)
+	if !ok || got.PrimaryLabel(nil) != "trending_up" {
+		t.Fatalf("get failed: %+v ok=%v", got, ok)
+	}
+}
+
+func TestRegimeStoreFailureClears(t *testing.T) {
+	s := newRegimeStore()
+	sig := RegimeSignature{Symbol: "BTC", Interval: "1h", SpecHash: "abc"}
+	s.put(sig, RegimePayload{Legacy: "ignored"}, errSentinel)
+	got, ok := s.get(sig)
+	if !ok {
+		t.Fatal("failed signature must still be present (empty), to signal fail-open not missing")
+	}
+	if !got.IsEmpty() {
+		t.Fatal("failed signature payload must be empty")
+	}
+	if !s.failed(sig) {
+		t.Fatal("failed() must report the failure for alerting")
+	}
+}
+
+func TestPayloadForStrategyDisabledRegime(t *testing.T) {
+	s := newRegimeStore()
+	sc := StrategyConfig{Args: []string{"m", "BTC", "1h"}}
+	if !s.payloadForStrategy(sc, &RegimeConfig{Enabled: false}).IsEmpty() {
+		t.Fatal("disabled regime must yield empty payload")
+	}
+	if !s.payloadForStrategy(sc, nil).IsEmpty() {
+		t.Fatal("nil regime must yield empty payload")
+	}
+}
+
+func TestRegimeSubprocessArgv(t *testing.T) {
+	argv := regimeSubprocessArgv("hyperliquid", "BTC", "1h",
+		`{"default":{"classifier":"adx","period":14,"adx_threshold":20}}`, 200, "")
+	joined := strings.Join(argv, " ")
+	for _, want := range []string{"--platform=hyperliquid", "--symbol=BTC", "--interval=1h",
+		"--regime-windows-spec-json", "--ohlcv-limit=200"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("argv missing %q: %v", want, argv)
+		}
+	}
+}
+
+func TestRegimeSubprocessArgvInstType(t *testing.T) {
+	argv := regimeSubprocessArgv("okx", "BTC", "1h", `{}`, 200, "swap")
+	if !strings.Contains(strings.Join(argv, " "), "--inst-type=swap") {
+		t.Fatalf("expected --inst-type=swap: %v", argv)
+	}
+	argv2 := regimeSubprocessArgv("hyperliquid", "BTC", "1h", `{}`, 200, "")
+	if strings.Contains(strings.Join(argv2, " "), "--inst-type") {
+		t.Fatalf("empty inst-type must be omitted: %v", argv2)
+	}
+}
+
+func TestBuildRegimeStoreDedupsAndClearsFailures(t *testing.T) {
+	rc := &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20}
+	due := []StrategyConfig{
+		{ID: "a", Symbol: "BTC", Type: "perps", Platform: "hyperliquid", Args: []string{"m", "BTC", "1h"}},
+		{ID: "b", Symbol: "BTC", Type: "perps", Platform: "hyperliquid", Args: []string{"r", "BTC", "1h"}}, // peer → dedup
+		{ID: "c", Symbol: "ETH", Type: "perps", Platform: "hyperliquid", Args: []string{"m", "ETH", "1h"}},
+		{ID: "d", Symbol: "ETH", Type: "perps", Platform: "hyperliquid", Args: []string{"m", "ETH", "4h"}}, // distinct interval, fails
+	}
+	var calls int32
+	orig := runRegimeSubprocessFn
+	defer func() { runRegimeSubprocessFn = orig }()
+	runRegimeSubprocessFn = func(platform, symbol, interval, spec string, limit int, instType string) (RegimePayload, error) {
+		atomic.AddInt32(&calls, 1)
+		if symbol == "ETH" && interval == "4h" {
+			return RegimePayload{}, errSentinel
+		}
+		return RegimePayload{Legacy: "trending_up"}, nil
+	}
+	store := buildRegimeStore(due, rc)
+	if calls != 3 {
+		t.Fatalf("expected 3 distinct signatures, got %d", calls)
+	}
+	if lbl := store.payloadForStrategy(due[0], rc).PrimaryLabel(rc); lbl != "trending_up" {
+		t.Fatalf("BTC/1h label = %q", lbl)
+	}
+	sigFail := regimeSignatureForStrategy(due[3], rc)
+	if !store.failed(sigFail) {
+		t.Fatal("ETH/4h must be marked failed")
+	}
+	if !store.payloadForStrategy(due[3], rc).IsEmpty() {
+		t.Fatal("failed signature must read empty (fail-open)")
+	}
+}
+
+func TestBuildRegimeStoreDisabledSkips(t *testing.T) {
+	due := []StrategyConfig{{ID: "a", Type: "perps", Platform: "hyperliquid", Args: []string{"m", "BTC", "1h"}}}
+	orig := runRegimeSubprocessFn
+	defer func() { runRegimeSubprocessFn = orig }()
+	var calls int32
+	runRegimeSubprocessFn = func(platform, symbol, interval, spec string, limit int, instType string) (RegimePayload, error) {
+		atomic.AddInt32(&calls, 1)
+		return RegimePayload{}, nil
+	}
+	buildRegimeStore(due, &RegimeConfig{Enabled: false})
+	if calls != 0 {
+		t.Fatalf("disabled regime must not spawn subprocesses, got %d", calls)
+	}
+}

--- a/scheduler/regime_calculator_test.go
+++ b/scheduler/regime_calculator_test.go
@@ -78,7 +78,7 @@ func TestPayloadForStrategyDisabledRegime(t *testing.T) {
 
 func TestRegimeSubprocessArgv(t *testing.T) {
 	argv := regimeSubprocessArgv("hyperliquid", "BTC", "1h",
-		`{"default":{"classifier":"adx","period":14,"adx_threshold":20}}`, 200, "")
+		`{"default":{"classifier":"adx","period":14,"adx_threshold":20}}`, 200, "", "")
 	joined := strings.Join(argv, " ")
 	for _, want := range []string{"--platform=hyperliquid", "--symbol=BTC", "--interval=1h",
 		"--regime-windows-spec-json", "--ohlcv-limit=200"} {
@@ -89,11 +89,11 @@ func TestRegimeSubprocessArgv(t *testing.T) {
 }
 
 func TestRegimeSubprocessArgvInstType(t *testing.T) {
-	argv := regimeSubprocessArgv("okx", "BTC", "1h", `{}`, 200, "swap")
+	argv := regimeSubprocessArgv("okx", "BTC", "1h", `{}`, 200, "swap", "")
 	if !strings.Contains(strings.Join(argv, " "), "--inst-type=swap") {
 		t.Fatalf("expected --inst-type=swap: %v", argv)
 	}
-	argv2 := regimeSubprocessArgv("hyperliquid", "BTC", "1h", `{}`, 200, "")
+	argv2 := regimeSubprocessArgv("hyperliquid", "BTC", "1h", `{}`, 200, "", "")
 	if strings.Contains(strings.Join(argv2, " "), "--inst-type") {
 		t.Fatalf("empty inst-type must be omitted: %v", argv2)
 	}
@@ -110,7 +110,7 @@ func TestBuildRegimeStoreDedupsAndClearsFailures(t *testing.T) {
 	var calls int32
 	orig := runRegimeSubprocessFn
 	defer func() { runRegimeSubprocessFn = orig }()
-	runRegimeSubprocessFn = func(platform, symbol, interval, spec string, limit int, instType string) (RegimePayload, error) {
+	runRegimeSubprocessFn = func(platform, symbol, interval, spec string, limit int, instType, mode string) (RegimePayload, error) {
 		atomic.AddInt32(&calls, 1)
 		if symbol == "ETH" && interval == "4h" {
 			return RegimePayload{}, errSentinel
@@ -138,7 +138,7 @@ func TestBuildRegimeStoreDisabledSkips(t *testing.T) {
 	orig := runRegimeSubprocessFn
 	defer func() { runRegimeSubprocessFn = orig }()
 	var calls int32
-	runRegimeSubprocessFn = func(platform, symbol, interval, spec string, limit int, instType string) (RegimePayload, error) {
+	runRegimeSubprocessFn = func(platform, symbol, interval, spec string, limit int, instType, mode string) (RegimePayload, error) {
 		atomic.AddInt32(&calls, 1)
 		return RegimePayload{}, nil
 	}

--- a/scheduler/regime_calculator_test.go
+++ b/scheduler/regime_calculator_test.go
@@ -147,3 +147,18 @@ func TestBuildRegimeStoreDisabledSkips(t *testing.T) {
 		t.Fatalf("disabled regime must not spawn subprocesses, got %d", calls)
 	}
 }
+
+func TestOptionsRegimeSignature(t *testing.T) {
+	rc := &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20}
+	sig := optionsRegimeSignature("BTC", rc)
+	if sig.Symbol != "BTC" || sig.Interval != "4h" {
+		t.Fatalf("got %+v", sig)
+	}
+	// store round-trips an options-sourced label
+	s := newRegimeStore()
+	s.put(sig, RegimePayload{Legacy: "trending_up"}, nil)
+	got, ok := s.get(sig)
+	if !ok || got.PrimaryLabel(rc) != "trending_up" {
+		t.Fatalf("options store read failed: %+v ok=%v", got, ok)
+	}
+}

--- a/scheduler/regime_calculator_test.go
+++ b/scheduler/regime_calculator_test.go
@@ -162,3 +162,24 @@ func TestOptionsRegimeSignature(t *testing.T) {
 		t.Fatalf("options store read failed: %+v ok=%v", got, ok)
 	}
 }
+
+func TestRegimeStoreSnapshotSorted(t *testing.T) {
+	s := newRegimeStore()
+	s.put(RegimeSignature{Symbol: "ETH", Interval: "1h", SpecHash: "x"}, RegimePayload{Legacy: "ranging"}, nil)
+	s.put(RegimeSignature{Symbol: "BTC", Interval: "4h", SpecHash: "x"}, RegimePayload{Legacy: "trending_up"}, nil)
+	s.put(RegimeSignature{Symbol: "BTC", Interval: "1h", SpecHash: "x"}, RegimePayload{}, errSentinel)
+	snap := s.snapshot()
+	if len(snap) != 3 {
+		t.Fatalf("want 3 entries, got %d", len(snap))
+	}
+	// sorted by symbol then interval: BTC/1h, BTC/4h, ETH/1h
+	if snap[0].Symbol != "BTC" || snap[0].Interval != "1h" || !snap[0].Failed {
+		t.Fatalf("entry0 = %+v", snap[0])
+	}
+	if snap[1].Symbol != "BTC" || snap[1].Interval != "4h" || snap[1].Regime != "trending_up" {
+		t.Fatalf("entry1 = %+v", snap[1])
+	}
+	if snap[2].Symbol != "ETH" || snap[2].Regime != "ranging" {
+		t.Fatalf("entry2 = %+v", snap[2])
+	}
+}

--- a/scheduler/regime_calculator_test.go
+++ b/scheduler/regime_calculator_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 type errString string
@@ -117,7 +118,7 @@ func TestBuildRegimeStoreDedupsAndClearsFailures(t *testing.T) {
 		}
 		return RegimePayload{Legacy: "trending_up"}, nil
 	}
-	store := buildRegimeStore(due, rc)
+	store := buildRegimeStore(due, rc, nil)
 	if calls != 3 {
 		t.Fatalf("expected 3 distinct signatures, got %d", calls)
 	}
@@ -142,7 +143,7 @@ func TestBuildRegimeStoreDisabledSkips(t *testing.T) {
 		atomic.AddInt32(&calls, 1)
 		return RegimePayload{}, nil
 	}
-	buildRegimeStore(due, &RegimeConfig{Enabled: false})
+	buildRegimeStore(due, &RegimeConfig{Enabled: false}, nil)
 	if calls != 0 {
 		t.Fatalf("disabled regime must not spawn subprocesses, got %d", calls)
 	}
@@ -181,5 +182,24 @@ func TestRegimeStoreSnapshotSorted(t *testing.T) {
 	}
 	if snap[2].Symbol != "ETH" || snap[2].Regime != "ranging" {
 		t.Fatalf("entry2 = %+v", snap[2])
+	}
+}
+
+func TestRegimeFailureThrottleCrossesThreshold(t *testing.T) {
+	regimeFailureTracker = &ScriptFailureTracker{} // isolate
+	sig := RegimeSignature{Symbol: "BTC", Interval: "1h", SpecHash: "z"}
+	key := regimeSignatureKey(sig)
+	now := time.Now().UTC()
+	for i := 1; i < scriptFailureAlertThreshold; i++ {
+		if notify, _ := regimeFailureTracker.Record(key, "boom", now); notify {
+			t.Fatalf("alert fired early at failure %d", i)
+		}
+	}
+	if notify, count := regimeFailureTracker.Record(key, "boom", now); !notify || count != scriptFailureAlertThreshold {
+		t.Fatalf("expected alert at threshold, notify=%v count=%d", notify, count)
+	}
+	// recovery clears
+	if recovered, _ := regimeFailureTracker.Clear(key); !recovered {
+		t.Fatal("expected recovery flag after alerted streak")
 	}
 }

--- a/scheduler/regime_calculator_test.go
+++ b/scheduler/regime_calculator_test.go
@@ -151,7 +151,7 @@ func TestBuildRegimeStoreDisabledSkips(t *testing.T) {
 
 func TestOptionsRegimeSignature(t *testing.T) {
 	rc := &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20}
-	sig := optionsRegimeSignature("BTC", rc)
+	sig := optionsRegimeSignature(StrategyConfig{Platform: "deribit", Type: "options"}, "BTC", rc)
 	if sig.Symbol != "BTC" || sig.Interval != "4h" {
 		t.Fatalf("got %+v", sig)
 	}
@@ -169,7 +169,7 @@ func TestRegimeStoreSnapshotSorted(t *testing.T) {
 	s.put(RegimeSignature{Symbol: "ETH", Interval: "1h", SpecHash: "x"}, RegimePayload{Legacy: "ranging"}, nil)
 	s.put(RegimeSignature{Symbol: "BTC", Interval: "4h", SpecHash: "x"}, RegimePayload{Legacy: "trending_up"}, nil)
 	s.put(RegimeSignature{Symbol: "BTC", Interval: "1h", SpecHash: "x"}, RegimePayload{}, errSentinel)
-	snap := s.snapshot()
+	snap := s.snapshot(nil)
 	if len(snap) != 3 {
 		t.Fatalf("want 3 entries, got %d", len(snap))
 	}
@@ -201,5 +201,53 @@ func TestRegimeFailureThrottleCrossesThreshold(t *testing.T) {
 	// recovery clears
 	if recovered, _ := regimeFailureTracker.Clear(key); !recovered {
 		t.Fatal("expected recovery flag after alerted streak")
+	}
+}
+
+func TestOptionsSignatureCannotClobberBundle(t *testing.T) {
+	rc := &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20}
+	// A perps strategy on BTC at 4h and an options strategy on underlying BTC at
+	// the hardcoded 4h interval must NOT collapse to the same store key (#901 #1).
+	perps := StrategyConfig{ID: "hl-btc-4h", Symbol: "BTC", Type: "perps", Platform: "hyperliquid", Args: []string{"m", "BTC", "4h"}}
+	bundleSig := regimeSignatureForStrategy(perps, rc)
+	optSig := optionsRegimeSignature(StrategyConfig{Platform: "deribit", Type: "options"}, "BTC", rc)
+	if bundleSig == optSig {
+		t.Fatalf("options and bundle signatures collided: %+v", bundleSig)
+	}
+
+	store := newRegimeStore()
+	store.put(bundleSig, RegimePayload{MultiMode: true, Windows: map[string]RegimeSnapshot{
+		"medium": {Regime: "trending_up", Score: 0.5}}}, nil)
+	// Options put must not overwrite the real bundle.
+	store.put(optSig, RegimePayload{Legacy: "ranging"}, nil)
+	if lbl := store.payloadForStrategy(perps, rc).PrimaryLabel(rc); lbl != "trending_up" {
+		t.Fatalf("bundle was clobbered by options put: got %q", lbl)
+	}
+}
+
+func TestRegimeSignatureIncludesPlatform(t *testing.T) {
+	rc := &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20}
+	// Same symbol string + interval on different platforms must differ (#901 #2).
+	hl := StrategyConfig{Type: "perps", Platform: "hyperliquid", Args: []string{"m", "BTC", "1h"}}
+	okx := StrategyConfig{Type: "perps", Platform: "okx", Args: []string{"m", "BTC", "1h"}}
+	if regimeSignatureForStrategy(hl, rc) == regimeSignatureForStrategy(okx, rc) {
+		t.Fatal("cross-platform same-symbol signatures must differ")
+	}
+}
+
+func TestSnapshotHonorsPrimaryWindow(t *testing.T) {
+	rc := &RegimeConfig{Enabled: true, Windows: RegimeWindowsMap{
+		"macro":  {Classifier: "adx", Period: 50},
+		"medium": {Classifier: "adx", Period: 14},
+	}}
+	s := newRegimeStore()
+	sig := RegimeSignature{Platform: "hyperliquid", Symbol: "BTC", Interval: "1h", Kind: regimeSignatureKindBundle}
+	s.put(sig, RegimePayload{MultiMode: true, Windows: map[string]RegimeSnapshot{
+		"macro":  {Regime: "ranging"},
+		"medium": {Regime: "trending_up"},
+	}}, nil)
+	snap := s.snapshot(rc)
+	if len(snap) != 1 || snap[0].Regime != "trending_up" {
+		t.Fatalf("snapshot should honor primary window 'medium', got %+v", snap)
 	}
 }

--- a/scheduler/regime_run.go
+++ b/scheduler/regime_run.go
@@ -20,11 +20,13 @@ const regimeFetchScript = "shared_scripts/fetch_regime.py"
 // regime in the portfolio/dashboard view.
 const optionsRegimeInterval = "4h"
 
-func optionsRegimeSignature(underlying string, rc *RegimeConfig) RegimeSignature {
+func optionsRegimeSignature(sc StrategyConfig, underlying string, rc *RegimeConfig) RegimeSignature {
 	return RegimeSignature{
+		Platform: regimePlatformForStrategy(sc),
 		Symbol:   strings.TrimSpace(underlying),
 		Interval: optionsRegimeInterval,
 		SpecHash: regimeSpecHash(rc),
+		Kind:     regimeSignatureKindOptions,
 	}
 }
 
@@ -157,7 +159,7 @@ func collectRegimeSignatures(due []StrategyConfig, rc *RegimeConfig) map[RegimeS
 var regimeFailureTracker = &ScriptFailureTracker{}
 
 func regimeSignatureKey(sig RegimeSignature) string {
-	return sig.Symbol + "/" + sig.Interval + "/" + sig.SpecHash
+	return sig.Platform + "/" + sig.Symbol + "/" + sig.Interval + "/" + sig.SpecHash + "/" + sig.Kind
 }
 
 func notifyRegimeSubprocessFailure(notifier *MultiNotifier, sig RegimeSignature, errMsg string) {

--- a/scheduler/regime_run.go
+++ b/scheduler/regime_run.go
@@ -11,6 +11,21 @@ import (
 
 const regimeFetchScript = "shared_scripts/fetch_regime.py"
 
+// optionsRegimeInterval mirrors check_options.py REGIME_TIMEFRAME. Options
+// regime is advisory (3-state ADX, no gate) and computed inside the options
+// evaluators, so #879 populates the store FROM the check result rather than
+// injecting — preserving exact options behavior while still surfacing options
+// regime in the portfolio/dashboard view.
+const optionsRegimeInterval = "4h"
+
+func optionsRegimeSignature(underlying string, rc *RegimeConfig) RegimeSignature {
+	return RegimeSignature{
+		Symbol:   strings.TrimSpace(underlying),
+		Interval: optionsRegimeInterval,
+		SpecHash: regimeSpecHash(rc),
+	}
+}
+
 // regimeSubprocessArgv builds the argv for the dedicated read-only regime
 // subprocess. instType/mode are forwarded only when non-empty (OKX inst-type;
 // RH/TopStep adapter mode).

--- a/scheduler/regime_run.go
+++ b/scheduler/regime_run.go
@@ -1,0 +1,146 @@
+package main
+
+// #879: regime subprocess invocation + per-cycle store build orchestration.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+const regimeFetchScript = "shared_scripts/fetch_regime.py"
+
+// regimeSubprocessArgv builds the argv for the dedicated read-only regime
+// subprocess. instType is forwarded only when non-empty (OKX swap/spot).
+func regimeSubprocessArgv(platform, symbol, interval, specJSON string, ohlcvLimit int, instType string) []string {
+	argv := []string{
+		"--platform=" + platform,
+		"--symbol=" + symbol,
+		"--interval=" + interval,
+		"--regime-windows-spec-json", specJSON,
+		fmt.Sprintf("--ohlcv-limit=%d", ohlcvLimit),
+	}
+	if strings.TrimSpace(instType) != "" {
+		argv = append(argv, "--inst-type="+instType)
+	}
+	return argv
+}
+
+type regimeSubprocessOutput struct {
+	Regime  RegimePayload `json:"regime"`
+	BarTime int64         `json:"bar_time"`
+	Error   string        `json:"error"`
+}
+
+// runRegimeSubprocessFn is a package var so tests stub it (Go CI has no .venv).
+var runRegimeSubprocessFn = runRegimeSubprocess
+
+// runRegimeSubprocess runs fetch_regime.py read-only (runPythonReadOnly acquires
+// pythonSemaphore + scriptTimeout internally) and parses its payload.
+func runRegimeSubprocess(platform, symbol, interval, specJSON string, ohlcvLimit int, instType string) (RegimePayload, error) {
+	argv := regimeSubprocessArgv(platform, symbol, interval, specJSON, ohlcvLimit, instType)
+	stdout, stderr, err := runPythonReadOnly(regimeFetchScript, argv)
+	if err != nil {
+		return RegimePayload{}, fmt.Errorf("regime subprocess %s/%s/%s: %w (stderr: %s)", platform, symbol, interval, err, strings.TrimSpace(string(stderr)))
+	}
+	var out regimeSubprocessOutput
+	if jerr := json.Unmarshal(stdout, &out); jerr != nil {
+		return RegimePayload{}, fmt.Errorf("regime subprocess %s/%s/%s: bad json: %w (out: %s)", platform, symbol, interval, jerr, strings.TrimSpace(string(stdout)))
+	}
+	if out.Error != "" {
+		return RegimePayload{}, fmt.Errorf("regime subprocess %s/%s/%s: %s", platform, symbol, interval, out.Error)
+	}
+	return out.Regime, nil
+}
+
+// regimePlatformForStrategy maps a strategy to the --platform token fetch_regime.py
+// dispatches on. BinanceUS spot strategies have no explicit Platform; default to
+// "binanceus" so the subprocess uses data_fetcher.fetch_ohlcv (same source as
+// check_strategy.py).
+func regimePlatformForStrategy(sc StrategyConfig) string {
+	p := strings.TrimSpace(strings.ToLower(sc.Platform))
+	switch p {
+	case "hyperliquid", "okx", "robinhood", "topstep", "binanceus":
+		return p
+	case "":
+		return "binanceus"
+	default:
+		return p
+	}
+}
+
+// regimeInstTypeForStrategy returns the OKX inst-type (swap/spot); empty for
+// other platforms.
+func regimeInstTypeForStrategy(sc StrategyConfig) string {
+	if strings.EqualFold(sc.Platform, "okx") {
+		return okxInstType(sc.Args)
+	}
+	return ""
+}
+
+// strategyParticipatesInRegime reports whether a strategy reads the regime store
+// this cycle. Spot/perps/futures/manual all fetch OHLCV at a timeframe and run
+// the per-window regime gate/ATR/directional features. Options use a separate
+// signature (4h ADX) handled by collectRegimeSignatures directly.
+func strategyParticipatesInRegime(sc StrategyConfig) bool {
+	switch sc.Type {
+	case "spot", "perps", "futures", "manual":
+		return true
+	default:
+		return false
+	}
+}
+
+// collectRegimeSignatures returns the distinct regime signatures among due
+// strategies, each mapped to a representative strategy (supplies platform +
+// inst-type for the subprocess). Peers on the same asset/interval/spec collapse
+// to one signature.
+func collectRegimeSignatures(due []StrategyConfig, rc *RegimeConfig) map[RegimeSignature]StrategyConfig {
+	out := make(map[RegimeSignature]StrategyConfig)
+	if rc == nil || !rc.Enabled {
+		return out
+	}
+	for _, sc := range due {
+		if !strategyParticipatesInRegime(sc) {
+			continue
+		}
+		sig := regimeSignatureForStrategy(sc, rc)
+		if sig.Symbol == "" || sig.Interval == "" {
+			continue
+		}
+		if _, seen := out[sig]; !seen {
+			out[sig] = sc
+		}
+	}
+	return out
+}
+
+// buildRegimeStore computes the per-cycle global regime store: one read-only
+// subprocess per distinct signature, fanned out concurrently (bounded by the
+// shared pythonSemaphore inside runPythonReadOnly). A failed subprocess clears
+// that signature to empty (fail-open).
+func buildRegimeStore(due []StrategyConfig, rc *RegimeConfig) *RegimeStore {
+	store := newRegimeStore()
+	sigs := collectRegimeSignatures(due, rc)
+	if len(sigs) == 0 {
+		return store
+	}
+	specJSON := regimeWindowsSpecJSON(rc)
+	limit := regimeRequiredOhlcvLimit(rc)
+	var wg sync.WaitGroup
+	for sig, rep := range sigs {
+		wg.Add(1)
+		go func(sig RegimeSignature, rep StrategyConfig) {
+			defer wg.Done()
+			pl, err := runRegimeSubprocessFn(
+				regimePlatformForStrategy(rep),
+				sig.Symbol, sig.Interval, specJSON, limit,
+				regimeInstTypeForStrategy(rep),
+			)
+			store.put(sig, pl, err)
+		}(sig, rep)
+	}
+	wg.Wait()
+	return store
+}

--- a/scheduler/regime_run.go
+++ b/scheduler/regime_run.go
@@ -5,8 +5,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
+	"time"
 )
 
 const regimeFetchScript = "shared_scripts/fetch_regime.py"
@@ -148,11 +150,41 @@ func collectRegimeSignatures(due []StrategyConfig, rc *RegimeConfig) map[RegimeS
 	return out
 }
 
+// regimeFailureTracker throttles operator alerts for sustained regime-subprocess
+// failures, keyed by signature (separate from the per-strategy signal-script
+// tracker so a regime outage doesn't perturb signal-script alert state). #879
+// failure policy: fail-open + log + throttled alert.
+var regimeFailureTracker = &ScriptFailureTracker{}
+
+func regimeSignatureKey(sig RegimeSignature) string {
+	return sig.Symbol + "/" + sig.Interval + "/" + sig.SpecHash
+}
+
+func notifyRegimeSubprocessFailure(notifier *MultiNotifier, sig RegimeSignature, errMsg string) {
+	shouldNotify, count := regimeFailureTracker.Record(regimeSignatureKey(sig), errMsg, time.Now().UTC())
+	fmt.Fprintf(os.Stderr, "[WARN] regime subprocess failed for %s/%s (%d consecutive): %s\n", sig.Symbol, sig.Interval, count, errMsg)
+	if !shouldNotify || notifier == nil || !notifier.HasBackends() {
+		return
+	}
+	msg := fmt.Sprintf("**REGIME SUBPROCESS FAILING** %s/%s (pid=%d, %d consecutive): regime cleared to empty (fail-open): %s",
+		sig.Symbol, sig.Interval, os.Getpid(), count, errMsg)
+	notifier.SendOwnerDM(msg)
+}
+
+func clearRegimeSubprocessFailure(notifier *MultiNotifier, sig RegimeSignature) {
+	recovered, priorCount := regimeFailureTracker.Clear(regimeSignatureKey(sig))
+	if !recovered || notifier == nil || !notifier.HasBackends() {
+		return
+	}
+	notifier.SendOwnerDM(fmt.Sprintf("**REGIME SUBPROCESS RECOVERED** %s/%s (pid=%d): succeeded after %d consecutive failures",
+		sig.Symbol, sig.Interval, os.Getpid(), priorCount))
+}
+
 // buildRegimeStore computes the per-cycle global regime store: one read-only
 // subprocess per distinct signature, fanned out concurrently (bounded by the
 // shared pythonSemaphore inside runPythonReadOnly). A failed subprocess clears
-// that signature to empty (fail-open).
-func buildRegimeStore(due []StrategyConfig, rc *RegimeConfig) *RegimeStore {
+// that signature to empty (fail-open) and fires a throttled operator alert.
+func buildRegimeStore(due []StrategyConfig, rc *RegimeConfig, notifier *MultiNotifier) *RegimeStore {
 	store := newRegimeStore()
 	sigs := collectRegimeSignatures(due, rc)
 	if len(sigs) == 0 {
@@ -172,6 +204,11 @@ func buildRegimeStore(due []StrategyConfig, rc *RegimeConfig) *RegimeStore {
 				regimeModeForStrategy(rep),
 			)
 			store.put(sig, pl, err)
+			if err != nil {
+				notifyRegimeSubprocessFailure(notifier, sig, err.Error())
+			} else {
+				clearRegimeSubprocessFailure(notifier, sig)
+			}
 		}(sig, rep)
 	}
 	wg.Wait()

--- a/scheduler/regime_run.go
+++ b/scheduler/regime_run.go
@@ -12,8 +12,9 @@ import (
 const regimeFetchScript = "shared_scripts/fetch_regime.py"
 
 // regimeSubprocessArgv builds the argv for the dedicated read-only regime
-// subprocess. instType is forwarded only when non-empty (OKX swap/spot).
-func regimeSubprocessArgv(platform, symbol, interval, specJSON string, ohlcvLimit int, instType string) []string {
+// subprocess. instType/mode are forwarded only when non-empty (OKX inst-type;
+// RH/TopStep adapter mode).
+func regimeSubprocessArgv(platform, symbol, interval, specJSON string, ohlcvLimit int, instType, mode string) []string {
 	argv := []string{
 		"--platform=" + platform,
 		"--symbol=" + symbol,
@@ -23,6 +24,9 @@ func regimeSubprocessArgv(platform, symbol, interval, specJSON string, ohlcvLimi
 	}
 	if strings.TrimSpace(instType) != "" {
 		argv = append(argv, "--inst-type="+instType)
+	}
+	if strings.TrimSpace(mode) != "" {
+		argv = append(argv, "--mode="+mode)
 	}
 	return argv
 }
@@ -38,8 +42,8 @@ var runRegimeSubprocessFn = runRegimeSubprocess
 
 // runRegimeSubprocess runs fetch_regime.py read-only (runPythonReadOnly acquires
 // pythonSemaphore + scriptTimeout internally) and parses its payload.
-func runRegimeSubprocess(platform, symbol, interval, specJSON string, ohlcvLimit int, instType string) (RegimePayload, error) {
-	argv := regimeSubprocessArgv(platform, symbol, interval, specJSON, ohlcvLimit, instType)
+func runRegimeSubprocess(platform, symbol, interval, specJSON string, ohlcvLimit int, instType, mode string) (RegimePayload, error) {
+	argv := regimeSubprocessArgv(platform, symbol, interval, specJSON, ohlcvLimit, instType, mode)
 	stdout, stderr, err := runPythonReadOnly(regimeFetchScript, argv)
 	if err != nil {
 		return RegimePayload{}, fmt.Errorf("regime subprocess %s/%s/%s: %w (stderr: %s)", platform, symbol, interval, err, strings.TrimSpace(string(stderr)))
@@ -77,6 +81,19 @@ func regimeInstTypeForStrategy(sc StrategyConfig) string {
 		return okxInstType(sc.Args)
 	}
 	return ""
+}
+
+// regimeModeForStrategy extracts --mode= (paper/live) from the strategy args;
+// needed only for RH/TopStep adapter instantiation. Defaults to "paper".
+func regimeModeForStrategy(sc StrategyConfig) string {
+	for _, a := range sc.Args {
+		if strings.HasPrefix(a, "--mode=") {
+			if m := strings.TrimSpace(strings.TrimPrefix(a, "--mode=")); m != "" {
+				return m
+			}
+		}
+	}
+	return "paper"
 }
 
 // strategyParticipatesInRegime reports whether a strategy reads the regime store
@@ -137,6 +154,7 @@ func buildRegimeStore(due []StrategyConfig, rc *RegimeConfig) *RegimeStore {
 				regimePlatformForStrategy(rep),
 				sig.Symbol, sig.Interval, specJSON, limit,
 				regimeInstTypeForStrategy(rep),
+				regimeModeForStrategy(rep),
 			)
 			store.put(sig, pl, err)
 		}(sig, rep)

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -195,6 +195,7 @@ func (ss *StatusServer) Start(port int) {
 	mux.HandleFunc("/dashboard/", ss.handleDashboard)
 	mux.HandleFunc("/api/strategies", ss.handleAPIStrategies)
 	mux.HandleFunc("/api/strategies/overview", ss.handleAPIStrategiesOverview)
+	mux.HandleFunc("/api/regime", ss.handleAPIRegime)
 	mux.HandleFunc("/api/strategies/", ss.handleAPIStrategy)
 
 	listener, boundPort, err := bindWithFallback(port, statusPortMaxAttempts)

--- a/scheduler/server_test.go
+++ b/scheduler/server_test.go
@@ -676,3 +676,29 @@ func TestUpdateStrategiesDoesNotDeadlockUnderStateLock(t *testing.T) {
 		t.Fatalf("uiStrategies len = %d, want 2 (%+v)", len(got), got)
 	}
 }
+
+func TestHandleAPIRegime(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{},
+		RegimePortfolio: []RegimePortfolioEntry{
+			{Symbol: "BTC", Interval: "1h", Regime: "trending_up", Windows: map[string]string{"default": "trending_up"}},
+		},
+	}
+	var mu sync.RWMutex
+	ss := NewStatusServer(state, &mu, "", nil, nil)
+	req := httptest.NewRequest("GET", "/api/regime", nil)
+	w := httptest.NewRecorder()
+	ss.handleAPIRegime(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp struct {
+		Regime []RegimePortfolioEntry `json:"regime"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Regime) != 1 || resp.Regime[0].Symbol != "BTC" || resp.Regime[0].Regime != "trending_up" {
+		t.Fatalf("resp = %+v", resp.Regime)
+	}
+}

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -94,6 +94,20 @@ type AppState struct {
 	LastLeaderboardSummaries map[string]time.Time `json:"last_leaderboard_summaries,omitempty"`
 	// LastSummaryPost tracks the last regular summary post per notification channel key.
 	LastSummaryPost map[string]time.Time `json:"last_summary_post,omitempty"`
+	// RegimePortfolio is the per-cycle global regime store snapshot for the
+	// dashboard portfolio view (#879). Ephemeral — rebuilt every cycle, never
+	// persisted (json:"-").
+	RegimePortfolio []RegimePortfolioEntry `json:"-"`
+}
+
+// RegimePortfolioEntry is one (symbol, interval) signature's regime from the
+// per-cycle global store, surfaced to the dashboard portfolio view (#879).
+type RegimePortfolioEntry struct {
+	Symbol   string            `json:"symbol"`
+	Interval string            `json:"interval"`
+	Regime   string            `json:"regime"`
+	Windows  map[string]string `json:"windows,omitempty"`
+	Failed   bool              `json:"failed,omitempty"`
 }
 
 // StrategyState is the per-strategy persistent state.

--- a/scheduler/strategy_composition.go
+++ b/scheduler/strategy_composition.go
@@ -134,6 +134,20 @@ func appendRegimeArgs(args []string, regime *RegimeConfig) []string {
 	return out
 }
 
+// appendInjectedRegimeArgs (#879) forwards the scheduler-computed regime payload
+// to a check script. --regime-injected is ALWAYS set (even on an empty payload)
+// so the check skips prepare_check_regime — an empty payload means fail-open,
+// never "recompute inline". The check echoes the payload back as result.Regime,
+// so Go consumers keep reading result.Regime with the store as the source.
+func appendInjectedRegimeArgs(args []string, payload RegimePayload) []string {
+	out := append(args, "--regime-injected")
+	blob, err := json.Marshal(payload)
+	if err != nil || string(blob) == "null" {
+		blob = []byte(`""`)
+	}
+	return append(out, "--regime-payload-json", string(blob))
+}
+
 func appendStrategyRegimeWindowArgs(args []string, sc StrategyConfig, regime *RegimeConfig) []string {
 	if regime == nil || !regime.Enabled || !regimeMultiWindowEnabled(regime) {
 		return args

--- a/scheduler/strategy_composition_test.go
+++ b/scheduler/strategy_composition_test.go
@@ -280,3 +280,20 @@ func TestComposeOpenCloseSignal(t *testing.T) {
 		})
 	}
 }
+
+func TestAppendInjectedRegimeArgs(t *testing.T) {
+	pl := RegimePayload{MultiMode: true, Windows: map[string]RegimeSnapshot{
+		"default": {Regime: "trending_up", Score: 0.4}}}
+	got := appendInjectedRegimeArgs(nil, pl)
+	j := strings.Join(got, " ")
+	if !strings.Contains(j, "--regime-injected") || !strings.Contains(j, "--regime-payload-json") {
+		t.Fatalf("missing injection flags: %v", got)
+	}
+	if !strings.Contains(j, "trending_up") {
+		t.Fatalf("payload not marshaled: %v", got)
+	}
+	got2 := appendInjectedRegimeArgs(nil, RegimePayload{})
+	if !strings.Contains(strings.Join(got2, " "), "--regime-injected") {
+		t.Fatal("empty payload must still set --regime-injected to suppress inline compute")
+	}
+}

--- a/scheduler/ui_server.go
+++ b/scheduler/ui_server.go
@@ -181,6 +181,34 @@ func (ss *StatusServer) handleAPIStrategiesOverview(w http.ResponseWriter, r *ht
 	writeJSON(w, map[string][]UIStrategyOverview{"strategies": out})
 }
 
+// handleAPIRegime serves the per-cycle global regime store snapshot (#879):
+// one entry per distinct (symbol, interval) signature, with the primary label
+// and per-window labels. Portfolio-level regime view, independent of any single
+// strategy. Loopback-only like the rest of the dashboard API.
+func (ss *StatusServer) handleAPIRegime(w http.ResponseWriter, r *http.Request) {
+	if ss.rejectIfDraining(w) {
+		return
+	}
+	if !ss.requireAPIAuth(w, r) {
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if r.URL.Path != "/api/regime" && r.URL.Path != "/api/regime/" {
+		http.NotFound(w, r)
+		return
+	}
+	ss.mu.RLock()
+	snapshot := append([]RegimePortfolioEntry(nil), ss.state.RegimePortfolio...)
+	ss.mu.RUnlock()
+	if snapshot == nil {
+		snapshot = []RegimePortfolioEntry{}
+	}
+	writeJSON(w, map[string][]RegimePortfolioEntry{"regime": snapshot})
+}
+
 func (ss *StatusServer) handleAPIStrategy(w http.ResponseWriter, r *http.Request) {
 	if ss.rejectIfDraining(w) {
 		return

--- a/scheduler/version_probe.go
+++ b/scheduler/version_probe.go
@@ -36,6 +36,10 @@ var probeArgv = []string{
 	"--ohlcv-limit", "200",
 	"--regime-windows-spec-json", `{"default":{"classifier":"adx","period":14,"adx_threshold":20}}`,
 	"--regime-atr-window", "",
+	// #879: scheduler injects the precomputed regime payload; probe the new
+	// flags so a stale check script that doesn't accept them fails startup
+	// instead of every cycle's argv rejecting the injection.
+	"--regime-injected", "--regime-payload-json", `{"default":{"regime":"trending_up","score":0.4}}`,
 	"--probe-only",
 }
 
@@ -48,7 +52,17 @@ var probeCompositeArgv = []string{
 	"--ohlcv-limit", "200",
 	"--regime-windows-spec-json", `{"macro":{"classifier":"composite","period":14,"thresholds":{"return_pct":0.05,"range_pct":0.03,"adx":25}}}`,
 	"--regime-atr-window", "",
+	"--regime-injected", "--regime-payload-json", `{"macro":{"regime":"ranging_quiet","score":0.1}}`,
 	"--probe-only",
+}
+
+// fetchRegimeProbeArgv probes the #879 dedicated regime subprocess. Like
+// fetch_candles.py it is not a configured strategy script, so it needs its own
+// probe to catch stale Python before the trading loop's per-cycle store build.
+var fetchRegimeProbeArgv = []string{
+	"--platform=hyperliquid", "--symbol=BTC", "--interval=1h",
+	"--regime-windows-spec-json", `{"default":{"classifier":"adx","period":14,"adx_threshold":20}}`,
+	"--ohlcv-limit=200", "--probe-only",
 }
 
 // fetchATRProbeArgv probes check_hyperliquid.py's --fetch-atr mode (#689) so a
@@ -162,6 +176,12 @@ func probeCheckScripts(cfg *Config) error {
 	}
 	if len(scripts) > 0 {
 		if err := probeOneCheckScriptFn("shared_scripts/fetch_candles.py", fetchCandlesProbeArgv); err != nil {
+			return err
+		}
+		// #879: probe the dedicated regime subprocess so an asymmetric deploy
+		// (new Go binary invoking fetch_regime.py against a stale/missing Python)
+		// fails at startup rather than on the first per-cycle store build.
+		if err := probeOneCheckScriptFn("shared_scripts/fetch_regime.py", fetchRegimeProbeArgv); err != nil {
 			return err
 		}
 		if err := probeOneCheckScriptFn("shared_scripts/strategy_tuner_schema.py", strategyTunerSchemaProbeArgv); err != nil {

--- a/scheduler/version_probe_test.go
+++ b/scheduler/version_probe_test.go
@@ -56,6 +56,7 @@ exec /usr/bin/env python3 "$@"
 		t.Fatalf("mkdir shared_scripts: %v", err)
 	}
 	writeProbeStub(t, fetchDir, "fetch_candles.py", true)
+	writeProbeStub(t, fetchDir, "fetch_regime.py", true)
 	writeProbeStub(t, fetchDir, "strategy_tuner_schema.py", true)
 	writeProbeStub(t, fetchDir, "simulate_strategy.py", true)
 

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -61,7 +61,21 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools')
 
 from atr import ensure_atr_indicator, latest_atr
 from hl_user_fills import apply_user_fills_lookup
-from regime import latest_regime, parse_regime_windows_spec_json, prepare_check_regime
+from regime import (
+    latest_regime,
+    parse_regime_windows_spec_json,
+    prepare_check_regime,
+    resolve_injected_regime,
+)
+
+
+def _primary_window_key(windows_spec):
+    """#879: primary window key for an injected payload, matching prepare_check_regime."""
+    if not windows_spec:
+        return ""
+    if "medium" in windows_spec:
+        return "medium"
+    return sorted(windows_spec.keys())[0]
 
 
 def _make_dataframe(candles):
@@ -99,6 +113,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
                      close_strategies=None,
                      position_side="", position_ctx=None,
                      regime_enabled=False, regime_windows_spec=None, ohlcv_limit=200, regime_atr_window="",
+                     regime_injected=False, regime_payload=None,
                      close_params_by_name=None,
                      mark_price=0.0):
     """Run strategy signal check using Hyperliquid OHLCV data."""
@@ -166,12 +181,21 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             sys.exit(1)
 
         df = _make_dataframe(candles)
-        stdout_regime, live_regime, strategy_regime = prepare_check_regime(
-            df,
-            regime_enabled=regime_enabled,
-            windows_spec=regime_windows_spec,
-            atr_window=regime_atr_window,
-        )
+        if regime_injected:
+            # #879: regime is computed once per signature by the scheduler and
+            # injected; do NOT recompute inline. Empty payload → fail-open empty.
+            stdout_regime, live_regime, strategy_regime = resolve_injected_regime(
+                regime_payload,
+                primary_key=_primary_window_key(regime_windows_spec),
+                atr_window=regime_atr_window,
+            )
+        else:
+            stdout_regime, live_regime, strategy_regime = prepare_check_regime(
+                df,
+                regime_enabled=regime_enabled,
+                windows_spec=regime_windows_spec,
+                atr_window=regime_atr_window,
+            )
         strategy_params["regime"] = strategy_regime
         if strategy_params_override:
             merged = {**strategy_params_override, **strategy_params}
@@ -1642,6 +1666,9 @@ def main():
         parser.add_argument("--ohlcv-limit", type=int, default=200)
         parser.add_argument("--regime-atr-window", default="")
         parser.add_argument("--regime-directional-window", default="")
+        parser.add_argument("--regime-injected", action="store_true", default=False,
+            help="#879: regime payload is injected by the scheduler; skip inline compute.")
+        parser.add_argument("--regime-payload-json", default="")
         parser.add_argument("--params", default=None)
         parser.add_argument("--open-strategy", default=None)
         parser.add_argument("--close-strategies", default=None)
@@ -1669,6 +1696,11 @@ def main():
         close_params_by_name = refs["close_params_by_name"] if refs else None
         position_ctx = _position_ctx_from_args(args)
         regime_windows_spec = parse_regime_windows_spec_json(args.regime_windows_spec_json or None)
+        regime_payload = (
+            json.loads(args.regime_payload_json)
+            if args.regime_injected and args.regime_payload_json.strip()
+            else None
+        )
         run_signal_check(
             args.strategy, args.symbol, args.timeframe, args.mode,
             args.htf_filter, params_override, open_strategy_name,
@@ -1678,6 +1710,8 @@ def main():
             regime_windows_spec=regime_windows_spec,
             ohlcv_limit=args.ohlcv_limit,
             regime_atr_window=args.regime_atr_window,
+            regime_injected=args.regime_injected,
+            regime_payload=regime_payload,
             close_params_by_name=close_params_by_name,
             mark_price=args.mark_price,
         )

--- a/shared_scripts/check_okx.py
+++ b/shared_scripts/check_okx.py
@@ -22,7 +22,21 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'platforms', 'o
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
 from atr import ensure_atr_indicator, latest_atr
-from regime import latest_regime, parse_regime_windows_spec_json, prepare_check_regime
+from regime import (
+    latest_regime,
+    parse_regime_windows_spec_json,
+    prepare_check_regime,
+    resolve_injected_regime,
+)
+
+
+def _primary_window_key(windows_spec):
+    """#879: primary window key for an injected payload, matching prepare_check_regime."""
+    if not windows_spec:
+        return ""
+    if "medium" in windows_spec:
+        return "medium"
+    return sorted(windows_spec.keys())[0]
 
 # Use futures registry for perps (swap), spot registry for spot.
 # Default is swap, matching argparse defaults below.
@@ -91,6 +105,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
                      open_strategy=None, close_strategies=None,
                      position_side="", position_ctx=None,
                      regime_enabled=False, regime_windows_spec=None, ohlcv_limit=200, regime_atr_window="",
+                     regime_injected=False, regime_payload=None,
                      close_params_by_name=None):
     """Run strategy signal check using OKX OHLCV data."""
     try:
@@ -160,12 +175,21 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             sys.exit(1)
 
         df = _make_dataframe(candles)
-        stdout_regime, live_regime, strategy_regime = prepare_check_regime(
-            df,
-            regime_enabled=regime_enabled,
-            windows_spec=regime_windows_spec,
-            atr_window=regime_atr_window,
-        )
+        if regime_injected:
+            # #879: regime computed once per signature by the scheduler and
+            # injected; do NOT recompute inline. Empty payload → fail-open empty.
+            stdout_regime, live_regime, strategy_regime = resolve_injected_regime(
+                regime_payload,
+                primary_key=_primary_window_key(regime_windows_spec),
+                atr_window=regime_atr_window,
+            )
+        else:
+            stdout_regime, live_regime, strategy_regime = prepare_check_regime(
+                df,
+                regime_enabled=regime_enabled,
+                windows_spec=regime_windows_spec,
+                atr_window=regime_atr_window,
+            )
         strategy_params["regime"] = strategy_regime
         if strategy_params_override:
             merged = {**strategy_params_override, **strategy_params}
@@ -372,6 +396,9 @@ def main():
         parser.add_argument("--ohlcv-limit", type=int, default=200)
         parser.add_argument("--regime-atr-window", default="")
         parser.add_argument("--regime-directional-window", default="")
+        parser.add_argument("--regime-injected", action="store_true", default=False,
+            help="#879: regime payload injected by the scheduler; skip inline compute.")
+        parser.add_argument("--regime-payload-json", default="")
         parser.add_argument("--inst-type", default="swap", choices=["spot", "swap"])
         parser.add_argument("--params", default=None)
         parser.add_argument("--open-strategy", default=None)
@@ -397,6 +424,11 @@ def main():
         close_params_by_name = refs["close_params_by_name"] if refs else None
         position_ctx = _position_ctx_from_args(args)
         regime_windows_spec = parse_regime_windows_spec_json(args.regime_windows_spec_json or None)
+        regime_payload = (
+            json.loads(args.regime_payload_json)
+            if args.regime_injected and args.regime_payload_json.strip()
+            else None
+        )
         run_signal_check(
             args.strategy, args.symbol, args.timeframe, args.mode,
             args.htf_filter, args.inst_type, params_override,
@@ -406,6 +438,8 @@ def main():
             regime_windows_spec=regime_windows_spec,
             ohlcv_limit=args.ohlcv_limit,
             regime_atr_window=args.regime_atr_window,
+            regime_injected=args.regime_injected,
+            regime_payload=regime_payload,
             close_params_by_name=close_params_by_name,
         )
 

--- a/shared_scripts/check_robinhood.py
+++ b/shared_scripts/check_robinhood.py
@@ -25,7 +25,21 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strateg
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
 from atr import ensure_atr_indicator, latest_atr
-from regime import latest_regime, parse_regime_windows_spec_json, prepare_check_regime
+from regime import (
+    latest_regime,
+    parse_regime_windows_spec_json,
+    prepare_check_regime,
+    resolve_injected_regime,
+)
+
+
+def _primary_window_key(windows_spec):
+    """#879: primary window key for an injected payload, matching prepare_check_regime."""
+    if not windows_spec:
+        return ""
+    if "medium" in windows_spec:
+        return "medium"
+    return sorted(windows_spec.keys())[0]
 
 
 def _make_dataframe(candles):
@@ -119,6 +133,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
                      close_strategies=None,
                      position_side="", position_ctx=None,
                      regime_enabled=False, regime_windows_spec=None, ohlcv_limit=200, regime_atr_window="",
+                     regime_injected=False, regime_payload=None,
                      close_params_by_name=None):
     """Run strategy signal check using yfinance OHLCV data."""
     try:
@@ -170,12 +185,21 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             sys.exit(1)
 
         df = _make_dataframe(candles)
-        stdout_regime, live_regime, strategy_regime = prepare_check_regime(
-            df,
-            regime_enabled=regime_enabled,
-            windows_spec=regime_windows_spec,
-            atr_window=regime_atr_window,
-        )
+        if regime_injected:
+            # #879: regime computed once per signature by the scheduler and
+            # injected; do NOT recompute inline. Empty payload → fail-open empty.
+            stdout_regime, live_regime, strategy_regime = resolve_injected_regime(
+                regime_payload,
+                primary_key=_primary_window_key(regime_windows_spec),
+                atr_window=regime_atr_window,
+            )
+        else:
+            stdout_regime, live_regime, strategy_regime = prepare_check_regime(
+                df,
+                regime_enabled=regime_enabled,
+                windows_spec=regime_windows_spec,
+                atr_window=regime_atr_window,
+            )
         strategy_params = (strategy_params or {})
         strategy_params["regime"] = strategy_regime
         decision = None
@@ -382,6 +406,9 @@ def main():
         parser.add_argument("--ohlcv-limit", type=int, default=200)
         parser.add_argument("--regime-atr-window", default="")
         parser.add_argument("--regime-directional-window", default="")
+        parser.add_argument("--regime-injected", action="store_true", default=False,
+            help="#879: regime payload injected by the scheduler; skip inline compute.")
+        parser.add_argument("--regime-payload-json", default="")
         parser.add_argument("--params", default=None)
         parser.add_argument("--open-strategy", default=None)
         parser.add_argument("--close-strategies", default=None)
@@ -406,6 +433,11 @@ def main():
         close_params_by_name = refs["close_params_by_name"] if refs else None
         position_ctx = _position_ctx_from_args(args)
         regime_windows_spec = parse_regime_windows_spec_json(args.regime_windows_spec_json or None)
+        regime_payload = (
+            json.loads(args.regime_payload_json)
+            if args.regime_injected and args.regime_payload_json.strip()
+            else None
+        )
         run_signal_check(
             args.strategy, args.symbol, args.timeframe, args.mode,
             args.htf_filter, params_parsed, open_strategy_name,
@@ -415,6 +447,8 @@ def main():
             regime_windows_spec=regime_windows_spec,
             ohlcv_limit=args.ohlcv_limit,
             regime_atr_window=args.regime_atr_window,
+            regime_injected=args.regime_injected,
+            regime_payload=regime_payload,
             close_params_by_name=close_params_by_name,
         )
 

--- a/shared_scripts/check_strategy.py
+++ b/shared_scripts/check_strategy.py
@@ -23,7 +23,21 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strateg
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
 from atr import ensure_atr_indicator, latest_atr
-from regime import latest_regime, parse_regime_windows_spec_json, prepare_check_regime
+from regime import (
+    latest_regime,
+    parse_regime_windows_spec_json,
+    prepare_check_regime,
+    resolve_injected_regime,
+)
+
+
+def _primary_window_key(windows_spec):
+    """#879: primary window key for an injected payload, matching prepare_check_regime."""
+    if not windows_spec:
+        return ""
+    if "medium" in windows_spec:
+        return "medium"
+    return sorted(windows_spec.keys())[0]
 
 
 def _arg_value(flag, default=None):
@@ -78,6 +92,12 @@ def main():
     regime_windows_spec = parse_regime_windows_spec_json(_arg_value("--regime-windows-spec-json"))
     ohlcv_limit = int(_arg_value("--ohlcv-limit") or 200)
     regime_atr_window = (_arg_value("--regime-atr-window") or "").strip()
+    regime_injected = "--regime-injected" in sys.argv
+    regime_payload = (
+        json.loads(_arg_value("--regime-payload-json"))
+        if regime_injected and (_arg_value("--regime-payload-json") or "").strip()
+        else None
+    )
     open_strategy = _arg_value("--open-strategy")
     close_strategies_raw = _arg_value("--close-strategies")
     position_side = (_arg_value("--position-side", "") or "").lower()
@@ -114,6 +134,7 @@ def main():
             "--position-regime",
             "--regime-windows-spec-json", "--ohlcv-limit",
             "--regime-atr-window", "--regime-directional-window",
+            "--regime-payload-json",
         ):
             skip_next = True
             continue
@@ -208,12 +229,21 @@ def main():
             }))
             return
 
-        stdout_regime, live_regime, strategy_regime = prepare_check_regime(
-            df,
-            regime_enabled=regime_enabled,
-            windows_spec=regime_windows_spec,
-            atr_window=regime_atr_window,
-        )
+        if regime_injected:
+            # #879: regime computed once per signature by the scheduler and
+            # injected; do NOT recompute inline. Empty payload → fail-open empty.
+            stdout_regime, live_regime, strategy_regime = resolve_injected_regime(
+                regime_payload,
+                primary_key=_primary_window_key(regime_windows_spec),
+                atr_window=regime_atr_window,
+            )
+        else:
+            stdout_regime, live_regime, strategy_regime = prepare_check_regime(
+                df,
+                regime_enabled=regime_enabled,
+                windows_spec=regime_windows_spec,
+                atr_window=regime_atr_window,
+            )
         strategy_params = (strategy_params or {})
         strategy_params["regime"] = strategy_regime
 

--- a/shared_scripts/check_topstep.py
+++ b/shared_scripts/check_topstep.py
@@ -23,7 +23,21 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_strateg
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 
 from atr import ensure_atr_indicator, latest_atr
-from regime import latest_regime, parse_regime_windows_spec_json, prepare_check_regime
+from regime import (
+    latest_regime,
+    parse_regime_windows_spec_json,
+    prepare_check_regime,
+    resolve_injected_regime,
+)
+
+
+def _primary_window_key(windows_spec):
+    """#879: primary window key for an injected payload, matching prepare_check_regime."""
+    if not windows_spec:
+        return ""
+    if "medium" in windows_spec:
+        return "medium"
+    return sorted(windows_spec.keys())[0]
 
 
 def _make_dataframe(candles):
@@ -107,6 +121,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
                      close_strategies=None,
                      position_side="", position_ctx=None,
                      regime_enabled=False, regime_windows_spec=None, ohlcv_limit=200, regime_atr_window="",
+                     regime_injected=False, regime_payload=None,
                      close_params_by_name=None):
     """Run strategy signal check using TopStep market data."""
     try:
@@ -178,12 +193,21 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             sys.exit(1)
 
         df = _make_dataframe(candles)
-        stdout_regime, live_regime, strategy_regime = prepare_check_regime(
-            df,
-            regime_enabled=regime_enabled,
-            windows_spec=regime_windows_spec,
-            atr_window=regime_atr_window,
-        )
+        if regime_injected:
+            # #879: regime computed once per signature by the scheduler and
+            # injected; do NOT recompute inline. Empty payload → fail-open empty.
+            stdout_regime, live_regime, strategy_regime = resolve_injected_regime(
+                regime_payload,
+                primary_key=_primary_window_key(regime_windows_spec),
+                atr_window=regime_atr_window,
+            )
+        else:
+            stdout_regime, live_regime, strategy_regime = prepare_check_regime(
+                df,
+                regime_enabled=regime_enabled,
+                windows_spec=regime_windows_spec,
+                atr_window=regime_atr_window,
+            )
         strategy_params = (strategy_params or {})
         strategy_params["regime"] = strategy_regime
         decision = None
@@ -385,6 +409,9 @@ def main():
         parser.add_argument("--ohlcv-limit", type=int, default=200)
         parser.add_argument("--regime-atr-window", default="")
         parser.add_argument("--regime-directional-window", default="")
+        parser.add_argument("--regime-injected", action="store_true", default=False,
+            help="#879: regime payload injected by the scheduler; skip inline compute.")
+        parser.add_argument("--regime-payload-json", default="")
         parser.add_argument("--params", default=None)
         parser.add_argument("--open-strategy", default=None)
         parser.add_argument("--close-strategies", default=None)
@@ -409,6 +436,11 @@ def main():
         close_params_by_name = refs["close_params_by_name"] if refs else None
         position_ctx = _position_ctx_from_args(args)
         regime_windows_spec = parse_regime_windows_spec_json(args.regime_windows_spec_json or None)
+        regime_payload = (
+            json.loads(args.regime_payload_json)
+            if args.regime_injected and args.regime_payload_json.strip()
+            else None
+        )
         run_signal_check(
             args.strategy, args.symbol, args.timeframe, args.mode,
             args.htf_filter, params_parsed, open_strategy_name,
@@ -418,6 +450,8 @@ def main():
             regime_windows_spec=regime_windows_spec,
             ohlcv_limit=args.ohlcv_limit,
             regime_atr_window=args.regime_atr_window,
+            regime_injected=args.regime_injected,
+            regime_payload=regime_payload,
             close_params_by_name=close_params_by_name,
         )
 

--- a/shared_scripts/fetch_regime.py
+++ b/shared_scripts/fetch_regime.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""#879: dedicated read-only regime subprocess.
+
+Fetches OHLCV for one (platform, symbol, interval), computes the multi-window
+regime payload via shared_tools/regime.py, and emits it. The Go scheduler runs
+this ONCE per distinct (symbol, interval, windows-spec) signature per cycle and
+injects the payload into every check via --regime-payload-json, so checks no
+longer compute regime inline.
+
+Read-only: never places orders. Per-platform fetch mirrors each check script's
+exact adapter + method so candles (and therefore labels) are identical to the
+pre-migration inline path. Subprocess contract: JSON on stdout even on error,
+exit 1 on failure.
+
+Usage:
+  fetch_regime.py --platform hyperliquid --symbol BTC --interval 1h \
+      --regime-windows-spec-json '{"default":{"classifier":"adx","period":14}}' \
+      --ohlcv-limit 200 [--inst-type swap] [--mode paper]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "shared_tools"))
+sys.path.insert(0, str(ROOT))
+
+import pandas as pd  # noqa: E402
+
+from regime import (  # noqa: E402
+    compute_multi_regime,
+    parse_regime_windows_spec_json,
+    required_ohlcv_limit,
+)
+
+
+class SafeEncoder(json.JSONEncoder):
+    def default(self, o):
+        try:
+            import numpy as np
+
+            if isinstance(o, np.integer):
+                return int(o)
+            if isinstance(o, np.floating):
+                return float(o)
+            if isinstance(o, np.ndarray):
+                return o.tolist()
+        except ImportError:
+            pass
+        return super().default(o)
+
+
+def _make_dataframe(candles) -> pd.DataFrame:
+    df = pd.DataFrame(candles, columns=["timestamp", "open", "high", "low", "close", "volume"])
+    for col in ("open", "high", "low", "close", "volume"):
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+    return df
+
+
+def compute_payload(df: pd.DataFrame, spec: dict) -> dict:
+    """Multi-window payload identical to prepare_check_regime(..., windows_spec=spec)[0]."""
+    return compute_multi_regime(df, spec)
+
+
+def _fetch_dataframe(platform: str, symbol: str, interval: str, limit: int,
+                     inst_type: str, mode: str) -> pd.DataFrame:
+    """Per-platform OHLCV fetch, mirroring the matching check_*.py exactly."""
+    plat = (platform or "").strip().lower()
+
+    if plat in ("binanceus", ""):
+        # check_strategy.py spot path: data_fetcher.fetch_ohlcv → DataFrame.
+        from data_fetcher import fetch_ohlcv
+
+        return fetch_ohlcv(symbol=symbol, timeframe=interval, limit=limit, store=False)
+
+    if plat == "hyperliquid":
+        # SDK clash workaround (see CLAUDE.md): add platforms/hyperliquid first.
+        sys.path.insert(0, str(ROOT / "platforms" / "hyperliquid"))
+        from adapter import HyperliquidExchangeAdapter
+
+        adapter = HyperliquidExchangeAdapter()
+        candles = adapter.get_ohlcv(symbol, interval=interval, limit=limit)
+        return _make_dataframe(candles)
+
+    if plat == "okx":
+        sys.path.insert(0, str(ROOT / "platforms" / "okx"))
+        from adapter import OKXExchangeAdapter
+
+        adapter = OKXExchangeAdapter()
+        if (inst_type or "swap").strip().lower() == "swap":
+            candles = adapter.get_perp_ohlcv(symbol, interval=interval, limit=limit)
+        else:
+            candles = adapter.get_ohlcv(symbol, interval=interval, limit=limit)
+        return _make_dataframe(candles)
+
+    if plat == "robinhood":
+        sys.path.insert(0, str(ROOT / "platforms" / "robinhood"))
+        from adapter import RobinhoodExchangeAdapter
+
+        adapter = RobinhoodExchangeAdapter(mode=mode or "paper")
+        candles = adapter.get_ohlcv(symbol, interval=interval, limit=limit)
+        return _make_dataframe(candles)
+
+    if plat == "topstep":
+        sys.path.insert(0, str(ROOT / "platforms" / "topstep"))
+        from adapter import TopStepExchangeAdapter
+
+        adapter = TopStepExchangeAdapter(mode=mode or "paper")
+        candles = adapter.get_ohlcv(symbol, interval=interval, limit=limit)
+        return _make_dataframe(candles)
+
+    raise ValueError(f"unsupported platform for regime fetch: {platform!r}")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--platform", required=False, default="")
+    p.add_argument("--symbol", required=False, default="")
+    p.add_argument("--interval", required=False, default="")
+    p.add_argument("--regime-windows-spec-json", default="")
+    p.add_argument("--ohlcv-limit", type=int, default=200)
+    p.add_argument("--inst-type", default="")
+    p.add_argument("--mode", default="paper")
+    p.add_argument("--probe-only", action="store_true")
+    args = p.parse_args()
+
+    # --probe-only short-circuits before any adapter/network call (probe contract).
+    if args.probe_only:
+        print(json.dumps({"regime": "", "bar_time": 0}))
+        return 0
+
+    try:
+        spec = parse_regime_windows_spec_json(args.regime_windows_spec_json or None)
+        if not spec:
+            print(json.dumps({"regime": "", "bar_time": 0}))
+            return 0
+        limit = max(int(args.ohlcv_limit or 0), required_ohlcv_limit(windows=spec))
+        df = _fetch_dataframe(args.platform, args.symbol, args.interval, limit,
+                              args.inst_type, args.mode)
+        if df is None or len(df) < 30:
+            print(json.dumps({"error": f"insufficient candles: {0 if df is None else len(df)}"}))
+            return 1
+        payload = compute_payload(df, spec)
+        bar_time = int(df["timestamp"].iloc[-1]) if len(df) else 0
+        print(json.dumps({"regime": payload, "bar_time": bar_time}, cls=SafeEncoder))
+        return 0
+    except Exception as exc:  # subprocess contract: JSON on stdout, exit 1
+        print(json.dumps({"error": str(exc)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shared_scripts/test_check_hyperliquid_regime.py
+++ b/shared_scripts/test_check_hyperliquid_regime.py
@@ -1,0 +1,44 @@
+"""#879: check_hyperliquid.py injected-regime wiring parity."""
+import importlib.util
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(name, rel):
+    sys.path.insert(0, str(ROOT / "shared_tools"))
+    sys.path.insert(0, str(ROOT / "shared_scripts"))
+    spec = importlib.util.spec_from_file_location(name, ROOT / rel)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_primary_window_key_matches_prepare():
+    chl = _load("check_hl", "shared_scripts/check_hyperliquid.py")
+    assert chl._primary_window_key(None) == ""
+    assert chl._primary_window_key({"medium": {}, "macro": {}}) == "medium"
+    assert chl._primary_window_key({"alpha": {}, "beta": {}}) == "alpha"
+
+
+def test_injected_regime_block_matches_inline():
+    chl = _load("check_hl2", "shared_scripts/check_hyperliquid.py")
+    regime = _load("regime_hl", "shared_tools/regime.py")
+    n = 120
+    close = pd.Series(range(100, 100 + n)).astype(float)
+    df = pd.DataFrame({"timestamp": range(n), "open": close, "high": close + 1,
+                       "low": close - 1, "close": close, "volume": [1.0] * n})
+    spec = {"medium": {"classifier": "adx", "period": 14, "adx_threshold": 20},
+            "macro": {"classifier": "composite", "period": 30}}
+    # inline path
+    s_payload, s_live, s_strat = regime.prepare_check_regime(
+        df, regime_enabled=True, windows_spec=spec, atr_window="macro")
+    # injected path as wired in the check
+    i_payload, i_live, i_strat = regime.resolve_injected_regime(
+        s_payload, primary_key=chl._primary_window_key(spec), atr_window="macro")
+    assert i_payload == s_payload
+    assert i_live == s_live
+    assert i_strat == s_strat

--- a/shared_scripts/test_fetch_regime.py
+++ b/shared_scripts/test_fetch_regime.py
@@ -1,0 +1,82 @@
+"""#879: fetch_regime.py parity with prepare_check_regime + output shape."""
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(ROOT / "shared_tools"))
+    sys.path.insert(0, str(ROOT))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _uptrend_df(n=120):
+    close = pd.Series(range(100, 100 + n)).astype(float)
+    return pd.DataFrame({
+        "timestamp": range(n), "open": close, "high": close + 1,
+        "low": close - 1, "close": close, "volume": [1.0] * n,
+    })
+
+
+def test_compute_payload_matches_prepare_check_regime_adx():
+    fr = _load("fetch_regime", ROOT / "shared_scripts" / "fetch_regime.py")
+    regime = _load("regime_mod", ROOT / "shared_tools" / "regime.py")
+    spec = {"default": {"classifier": "adx", "period": 14, "adx_threshold": 20}}
+    df = _uptrend_df()
+    payload = fr.compute_payload(df, spec)
+    expected, _, _ = regime.prepare_check_regime(df, regime_enabled=True, windows_spec=spec)
+    assert payload == expected
+
+
+def test_compute_payload_matches_prepare_check_regime_multi_window():
+    fr = _load("fetch_regime2", ROOT / "shared_scripts" / "fetch_regime.py")
+    regime = _load("regime_mod2", ROOT / "shared_tools" / "regime.py")
+    spec = {
+        "medium": {"classifier": "adx", "period": 14, "adx_threshold": 20},
+        "macro": {"classifier": "composite", "period": 30},
+    }
+    df = _uptrend_df()
+    payload = fr.compute_payload(df, spec)
+    expected, _, _ = regime.prepare_check_regime(df, regime_enabled=True, windows_spec=spec)
+    assert payload == expected
+
+
+def test_full_period_adx_not_capped():
+    """period>14 ADX window must use the full period (not COMPOSITE cap)."""
+    fr = _load("fetch_regime3", ROOT / "shared_scripts" / "fetch_regime.py")
+    regime = _load("regime_mod3", ROOT / "shared_tools" / "regime.py")
+    spec = {"slow": {"classifier": "adx", "period": 30, "adx_threshold": 20}}
+    df = _uptrend_df(150)
+    payload = fr.compute_payload(df, spec)
+    expected, _, _ = regime.prepare_check_regime(df, regime_enabled=True, windows_spec=spec)
+    assert payload == expected
+
+
+def test_probe_only_short_circuits():
+    out = subprocess.run(
+        [sys.executable, str(ROOT / "shared_scripts" / "fetch_regime.py"), "--probe-only"],
+        capture_output=True, text=True,
+    )
+    assert out.returncode == 0
+    parsed = json.loads(out.stdout)
+    assert parsed["regime"] == ""
+
+
+def test_empty_spec_yields_empty_regime():
+    out = subprocess.run(
+        [sys.executable, str(ROOT / "shared_scripts" / "fetch_regime.py"),
+         "--platform=hyperliquid", "--symbol=BTC", "--interval=1h",
+         "--regime-windows-spec-json=", "--ohlcv-limit=200"],
+        capture_output=True, text=True,
+    )
+    assert out.returncode == 0
+    assert json.loads(out.stdout)["regime"] == ""

--- a/shared_tools/regime.py
+++ b/shared_tools/regime.py
@@ -477,6 +477,62 @@ def prepare_check_regime(
     return label, label, legacy
 
 
+def resolve_injected_regime(
+    payload: dict | str,
+    *,
+    primary_key: str = "",
+    atr_window: str = "",
+) -> tuple[dict | str, str, dict]:
+    """#879: reconstruct prepare_check_regime's 3-tuple from a scheduler-injected
+    payload WITHOUT recomputing.
+
+    `payload` is either the multi-window map {window: snapshot}, a legacy single
+    snapshot dict, or a legacy label string. The selection logic mirrors
+    prepare_check_regime's multi-window branch line-for-line so the injected and
+    inline paths produce identical (stdout_payload, live_atr_label,
+    strategy_params_snapshot) for the same windows.
+
+    An empty payload means regime is unavailable (disabled or a failed scheduler
+    subprocess) → fail-open empty, never recompute inline.
+    """
+    disabled = {"regime": "", "score": 0.0, "metrics": dict(_DEFAULT_METRICS)}
+    if not payload:
+        return "", "", disabled
+
+    if isinstance(payload, str):
+        legacy = {
+            "regime": payload,
+            "score": 0.0,
+            "metrics": dict(_DEFAULT_METRICS),
+            "classifier": CLASSIFIER_ADX,
+        }
+        return payload, payload, legacy
+
+    if not isinstance(payload, dict):
+        return "", "", disabled
+
+    # Legacy single snapshot dict ({"regime":..., "score"/"metrics":...}).
+    if isinstance(payload.get("regime"), str) and ("score" in payload or "metrics" in payload):
+        label = str(payload.get("regime") or "")
+        return payload, label, payload
+
+    # Multi-window map.
+    keys = sorted(payload.keys())
+    if primary_key and primary_key in payload:
+        pkey = primary_key
+    elif REGIME_PRIMARY_WINDOW_KEY in payload:
+        pkey = REGIME_PRIMARY_WINDOW_KEY
+    elif keys:
+        pkey = keys[0]
+    else:
+        return "", "", disabled
+    strategy_payload = payload.get(pkey, disabled)
+    atr_key = (atr_window or pkey).strip() or pkey
+    atr_entry = payload.get(atr_key, strategy_payload)
+    live_atr = str(atr_entry.get("regime") or "") if isinstance(atr_entry, dict) else ""
+    return payload, live_atr, strategy_payload
+
+
 def parse_regime_windows_spec_json(raw: str | None) -> dict[str, dict[str, Any]] | None:
     """Parse --regime-windows-spec-json from Go (#795). Bare ints → ADX specs."""
     if raw is None:

--- a/shared_tools/test_regime.py
+++ b/shared_tools/test_regime.py
@@ -28,6 +28,8 @@ regime_label_from_payload = _regime_mod.regime_label_from_payload
 required_ohlcv_limit = _regime_mod.required_ohlcv_limit
 parse_regime_windows_json = _regime_mod.parse_regime_windows_json
 ensure_regime_columns = _regime_mod.ensure_regime_columns
+prepare_check_regime = _regime_mod.prepare_check_regime
+resolve_injected_regime = _regime_mod.resolve_injected_regime
 
 
 # ─── Fixtures ────────────────────────────────────────────────────────────────
@@ -437,3 +439,54 @@ def test_latest_regime_composite_downtrend():
     snap = _regime_mod.latest_regime_composite(df, period=50, thresholds={"return_pct": 0.02, "range_pct": 0.02, "adx": 15})
     assert snap["regime"] in _regime_mod.VALID_LABELS_COMPOSITE
     assert "trending_down" in snap["regime"]
+
+
+# ─── #879 resolve_injected_regime parity ─────────────────────────────────────
+
+
+def test_resolve_injected_regime_matches_prepare_multi_window():
+    n = 120
+    close = pd.Series(range(100, 100 + n)).astype(float)
+    df = pd.DataFrame({"timestamp": range(n), "open": close, "high": close + 1,
+                       "low": close - 1, "close": close, "volume": [1.0] * n})
+    spec = {"medium": {"classifier": "adx", "period": 14, "adx_threshold": 20},
+            "macro": {"classifier": "composite", "period": 30}}
+    want_payload, want_live, want_strat = prepare_check_regime(
+        df, regime_enabled=True, windows_spec=spec, atr_window="macro")
+    inj_payload, inj_live, inj_strat = resolve_injected_regime(
+        want_payload, primary_key="medium", atr_window="macro")
+    assert inj_payload == want_payload
+    assert inj_live == want_live
+    assert inj_strat == want_strat
+
+
+def test_resolve_injected_regime_legacy_string():
+    payload, live, strat = resolve_injected_regime("trending_up")
+    assert payload == "trending_up"
+    assert live == "trending_up"
+    assert strat["regime"] == "trending_up"
+
+
+def test_resolve_injected_regime_empty_fail_open():
+    payload, live, strat = resolve_injected_regime("")
+    assert payload == ""
+    assert live == ""
+    assert strat["regime"] == ""
+    payload2, live2, strat2 = resolve_injected_regime({})
+    assert payload2 == ""
+    assert live2 == ""
+
+
+def test_resolve_injected_regime_default_primary_when_no_medium():
+    n = 120
+    close = pd.Series(range(100, 100 + n)).astype(float)
+    df = pd.DataFrame({"timestamp": range(n), "open": close, "high": close + 1,
+                       "low": close - 1, "close": close, "volume": [1.0] * n})
+    spec = {"alpha": {"classifier": "adx", "period": 14, "adx_threshold": 20},
+            "beta": {"classifier": "adx", "period": 20, "adx_threshold": 20}}
+    want_payload, want_live, want_strat = prepare_check_regime(
+        df, regime_enabled=True, windows_spec=spec)
+    inj_payload, inj_live, inj_strat = resolve_injected_regime(want_payload)
+    assert inj_payload == want_payload
+    assert inj_live == want_live
+    assert inj_strat == want_strat


### PR DESCRIPTION
## Summary

Moves regime computation out of each strategy's per-cycle Python check subprocess into a single **Go-scheduler-owned global regime store**, computed once per distinct `(symbol, interval, windows-spec)` signature per cycle, injected into every check, and read directly by flat-`manual`, `options`, and the dashboard.

Closes #879.

## Why parity holds (no behavior change)

Regime windows live in **global** `cfg.Regime.Windows` (per-strategy fields are only *selectors*), so the dedup unit is `(symbol, interval)` + a fingerprint of the resolved windows spec. The subprocess computes each window with **its own classifier/period** via the existing `compute_multi_regime`, so labels are byte-identical to the pre-migration inline path for the same candles. An ADX window at `period=20` already uses full-period ADX; `COMPOSITE_ADX_PERIOD_CAP=14` only applies inside composite windows.

I deliberately **rejected the issue's "one composite pass → prefix-collapse for the 3-state view"** sketch — computing each window with its own classifier is exact and avoids the trending/ranging boundary drift that approach risked.

## Mechanism

1. New Go store (`regime_calculator.go`, `regime_run.go`): before Phase 3, collect distinct signatures of due strategies (+ flat `manual`), run one read-only subprocess (`fetch_regime.py`) per signature (concurrent, bounded by the shared `pythonSemaphore`), store the `RegimePayload`.
2. Each check dispatch **injects** the precomputed payload via `--regime-injected --regime-payload-json`; the check skips `prepare_check_regime` (new `resolve_injected_regime` projection helper) and **echoes the payload back** as `result.Regime`. Existing Go consumers (`applyRegimeGate`, `syncStrategyRegimeState`, `stampPositionRegimeIfOpened`, `strategyCurrentATRRegime`, `applyRegimeDirectionalPolicy`) are unchanged — only the *source* of `result.Regime` changes.
3. Flat `manual` reads the store while flat (regime visible without a position). `options` populates the store from its check result (advisory 4h-ADX, embedded in evaluators — store-from-result preserves exact options behavior). Dashboard `/api/regime` serves a per-signature portfolio view.

## Failure policy

A failed regime subprocess clears that signature to **present-but-empty** → every consumer falls back to its existing empty-case (fail-open) behavior. Open positions read the frozen `pos.Regime`/`pos.RegimeAppliedLabel`, never the live store, so a transient outage can't disturb them. Throttled operator alert via a regime-specific `ScriptFailureTracker` (separate key space from signal-script alerts).

**One documented semantic delta:** post-split a check can succeed while regime is empty, so a fresh open fires **fail-open instead of skip** on a regime-data outage (an advisory overlay should not block trading).

## Coordination with #873

No design conflict — `pos.Regime` stays the frozen-at-open stamp. Whichever merges second rebases the shared `main.go` perps/manual dispatch blocks. The manual path already threads the store payload through `runManualCloseEval` without re-stamping.

## Deploy safety

`fetch_regime.py` and the `--regime-injected`/`--regime-payload-json` flags are appended to `version_probe.go` (`probeArgv`, `probeCompositeArgv`, new `fetchRegimeProbeArgv`) so a stale Python fails startup (exit 78) instead of mid-cycle. Go+Python must deploy at the same SHA.

## Latency

The store build adds one serial phase before Phase 3: N distinct `(symbol, interval)` subprocesses, concurrent under `pythonSemaphore=4`. Each fetch lands in the #839 `/tmp` OHLCV cache so the subsequent check reads cache (no double network fetch). Added wall-clock ≈ `ceil(N_distinct/4) × (spawn + ADX compute)`, not `N_strategies`.

## Tests

- Go: store dedup/failure-clear/signature/snapshot, injected-args builder, `/api/regime` endpoint, regime-failure throttle. Full `go test ./...` green.
- Python: `fetch_regime.compute_payload` == `prepare_check_regime` (ADX, multi-window, full-period ADX > 14); `resolve_injected_regime` == `prepare_check_regime` 3-tuple; HL injected-vs-inline wiring; backtest parity (`fetch_regime` vs `ensure_regime_columns`/`compute_regime_composite`). Full pytest suite green (1169 + new).
- Smoke: `--once` with two paper HL strategies + regime enabled — store computed `trending_down` per signature, injected, echoed, `regime=trending_down` on status. No errors.

## Follow-ups (not in this PR)

- Per-script injected-vs-inline parity tests for okx/robinhood/topstep (wiring is byte-identical to HL, covered by shared `resolve_injected_regime` tests + probe).
- Dashboard UI surfacing of `/api/regime` (endpoint added; front-end widget deferred).
- CLAUDE.md/SKILL.md file-ownership entries for the new regime files.

---
Created with LLM: Opus 4.8 (1M) | high | Harness: Claude Code
