### PR TITLE
feat(regime): global per-cycle regime store with dedicated subprocess + payload injection

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -746,6 +746,13 @@ func main() {
 		if saveFailures >= 3 {
 			fmt.Println("[CRITICAL] State save failed 3x, skipping trades this cycle")
 		} else {
+			// #879: build the per-cycle global regime store BEFORE the check
+			// fan-out — one regime subprocess per distinct (platform, symbol,
+			// timeframe, spec) signature among due strategies. Every regime
+			// consumer this cycle (entry gates, stratState sync, stamp-at-open,
+			// check-script injection, flat manual, options, dashboard) reads
+			// this map; check scripts no longer compute regime inline.
+			populateRegimeStore(globalRegimeStore, dueStrategies, cfg.Regime, notifier)
 			// #42 / #243: Portfolio-level risk check before running any strategy.
 			//
 			// Fetch live Hyperliquid clearinghouseState ONCE per cycle (outside
@@ -1455,12 +1462,17 @@ func main() {
 						if sc.Platform == "okx" {
 							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, cfg.Regime, notifier, logger); ok {
 								prices[result.Symbol] = price
-								if gateRegime, regimeBlocked := applyRegimeGate(sc, regimePayloadValue(result.Regime), cfg.Regime, okxPosQty); regimeBlocked {
+								// #879: single-source regime — read the global store for this
+								// strategy's signature instead of the check output, and point
+								// result.Regime at it so stamp-at-open inside execute* shares it.
+								storeRegime := globalRegimeStore.PayloadForStrategy(sc, cfg.Regime)
+								result.Regime = &storeRegime
+								if gateRegime, regimeBlocked := applyRegimeGate(sc, storeRegime, cfg.Regime, okxPosQty); regimeBlocked {
 									logger.Info("Regime gate: open signal blocked (regime=%s)", gateRegime)
 									result.Signal = 0
 								}
 								mu.Lock()
-								syncStrategyRegimeState(stratState, regimePayloadValue(result.Regime), cfg.Regime)
+								syncStrategyRegimeState(stratState, storeRegime, cfg.Regime)
 								mu.Unlock()
 								var execResult *OKXExecuteResult
 								liveExecFailed := false
@@ -1480,12 +1492,17 @@ func main() {
 						} else if sc.Platform == "robinhood" {
 							if result, signalStr, price, ok := runRobinhoodCheck(sc, prices, rhPosCtx, cfg.Regime, notifier, logger); ok {
 								prices[result.Symbol] = price
-								if gateRegime, regimeBlocked := applyRegimeGate(sc, regimePayloadValue(result.Regime), cfg.Regime, rhPosQty); regimeBlocked {
+								// #879: single-source regime — read the global store for this
+								// strategy's signature instead of the check output, and point
+								// result.Regime at it so stamp-at-open inside execute* shares it.
+								storeRegime := globalRegimeStore.PayloadForStrategy(sc, cfg.Regime)
+								result.Regime = &storeRegime
+								if gateRegime, regimeBlocked := applyRegimeGate(sc, storeRegime, cfg.Regime, rhPosQty); regimeBlocked {
 									logger.Info("Regime gate: open signal blocked (regime=%s)", gateRegime)
 									result.Signal = 0
 								}
 								mu.Lock()
-								syncStrategyRegimeState(stratState, regimePayloadValue(result.Regime), cfg.Regime)
+								syncStrategyRegimeState(stratState, storeRegime, cfg.Regime)
 								mu.Unlock()
 								var execResult *RobinhoodExecuteResult
 								liveExecFailed := false
@@ -1503,19 +1520,29 @@ func main() {
 								}
 							}
 						} else if result, signalStr, price, ok := runSpotCheck(sc, prices, spotPosCtx, cfg.Regime, notifier, logger); ok {
-							if gateRegime, regimeBlocked := applyRegimeGate(sc, regimePayloadValue(result.Regime), cfg.Regime, spotPosCtx.Quantity); regimeBlocked {
+							// #879: single-source regime — read the global store for this
+							// strategy's signature instead of the check output, and point
+							// result.Regime at it so stamp-at-open inside execute* shares it.
+							storeRegime := globalRegimeStore.PayloadForStrategy(sc, cfg.Regime)
+							result.Regime = &storeRegime
+							if gateRegime, regimeBlocked := applyRegimeGate(sc, storeRegime, cfg.Regime, spotPosCtx.Quantity); regimeBlocked {
 								logger.Info("Regime gate: open signal blocked (regime=%s)", gateRegime)
 								result.Signal = 0
 							}
 							mu.Lock()
-							syncStrategyRegimeState(stratState, regimePayloadValue(result.Regime), cfg.Regime)
+							syncStrategyRegimeState(stratState, storeRegime, cfg.Regime)
 							trades, detail = executeSpotResult(sc, stratState, stateDB, result, signalStr, price, cfg.Regime, logger)
 							mu.Unlock()
 						}
 					case "options":
 						if result, signalStr, ok := runOptionsCheck(sc, posJSON, notifier, logger); ok {
+							// #879: options regime now comes from the global store's
+							// (underlying, 4h, ADX-default) bundle instead of the
+							// check script's inline fetch; the injected payload keeps
+							// the script's own emitted label identical.
+							optionsRegime := globalRegimeStore.PayloadForStrategy(sc, cfg.Regime)
 							mu.Lock()
-							stratState.Regime = result.Regime
+							stratState.Regime = optionsRegime.PrimaryLabel(nil)
 							var harvestDetails []string
 							trades, detail, harvestDetails = executeOptionsResult(sc, stratState, result, signalStr, logger)
 							mu.Unlock()
@@ -1528,12 +1555,17 @@ func main() {
 						if sc.Platform == "okx" {
 							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, cfg.Regime, notifier, logger); ok {
 								prices[result.Symbol] = price
-								if gateRegime, regimeBlocked := applyRegimeGate(sc, regimePayloadValue(result.Regime), cfg.Regime, okxPosQty); regimeBlocked {
+								// #879: single-source regime — read the global store for this
+								// strategy's signature instead of the check output, and point
+								// result.Regime at it so stamp-at-open inside execute* shares it.
+								storeRegime := globalRegimeStore.PayloadForStrategy(sc, cfg.Regime)
+								result.Regime = &storeRegime
+								if gateRegime, regimeBlocked := applyRegimeGate(sc, storeRegime, cfg.Regime, okxPosQty); regimeBlocked {
 									logger.Info("Regime gate: open signal blocked (regime=%s)", gateRegime)
 									result.Signal = 0
 								}
 								mu.Lock()
-								syncStrategyRegimeState(stratState, regimePayloadValue(result.Regime), cfg.Regime)
+								syncStrategyRegimeState(stratState, storeRegime, cfg.Regime)
 								mu.Unlock()
 								var execResult *OKXExecuteResult
 								liveExecFailed := false
@@ -1552,12 +1584,17 @@ func main() {
 							}
 						} else if result, signalStr, price, ok := runHyperliquidCheck(&sc, prices, hlPosCtx, cfg.Regime, notifier, logger); ok {
 							prices[result.Symbol] = price
-							if gateRegime, regimeBlocked := applyRegimeGate(sc, regimePayloadValue(result.Regime), cfg.Regime, hlPosQty); regimeBlocked {
+							// #879: single-source regime — read the global store for this
+							// strategy's signature instead of the check output, and point
+							// result.Regime at it so stamp-at-open inside execute* shares it.
+							storeRegime := globalRegimeStore.PayloadForStrategy(sc, cfg.Regime)
+							result.Regime = &storeRegime
+							if gateRegime, regimeBlocked := applyRegimeGate(sc, storeRegime, cfg.Regime, hlPosQty); regimeBlocked {
 								logger.Info("Regime gate: open signal blocked (regime=%s)", gateRegime)
 								result.Signal = 0
 							}
 							mu.Lock()
-							syncStrategyRegimeState(stratState, regimePayloadValue(result.Regime), cfg.Regime)
+							syncStrategyRegimeState(stratState, storeRegime, cfg.Regime)
 							mu.Unlock()
 							var execResult *HyperliquidExecuteResult
 							liveExecFailed := false
@@ -1813,12 +1850,17 @@ func main() {
 					case "futures":
 						if result, signalStr, price, ok := runTopStepCheck(sc, prices, tsPosCtx, cfg.Regime, notifier, logger); ok {
 							prices[result.Symbol] = price
-							if gateRegime, regimeBlocked := applyRegimeGate(sc, regimePayloadValue(result.Regime), cfg.Regime, tsContracts); regimeBlocked {
+							// #879: single-source regime — read the global store for this
+							// strategy's signature instead of the check output, and point
+							// result.Regime at it so stamp-at-open inside execute* shares it.
+							storeRegime := globalRegimeStore.PayloadForStrategy(sc, cfg.Regime)
+							result.Regime = &storeRegime
+							if gateRegime, regimeBlocked := applyRegimeGate(sc, storeRegime, cfg.Regime, tsContracts); regimeBlocked {
 								logger.Info("Regime gate: open signal blocked (regime=%s)", gateRegime)
 								result.Signal = 0
 							}
 							mu.Lock()
-							syncStrategyRegimeState(stratState, regimePayloadValue(result.Regime), cfg.Regime)
+							syncStrategyRegimeState(stratState, storeRegime, cfg.Regime)
 							mu.Unlock()
 							var execResult *TopStepExecuteResult
 							liveExecFailed := false
@@ -1861,7 +1903,12 @@ func main() {
 						// pos.Regime == "" on the first post-open cycle, so the regime
 						// trail no-op'd for one interval; stamping first arms it
 						// correctly on cycle 1.
-						closeFraction, _, manualRegime, manualOK := runManualCloseEval(sc, stratState, cfg, notifier, logger)
+						closeFraction, _, manualOK := runManualCloseEval(sc, stratState, cfg, notifier, logger)
+						// #879: the live regime comes from the global store, not the
+						// close-eval's check output — so a FLAT manual strategy now
+						// shows a live regime too (pre-#879 the HL check only ran
+						// with an open position, leaving regime=- while flat).
+						manualRegime := globalRegimeStore.PayloadForStrategy(sc, cfg.Regime)
 						if manualOK {
 							mu.Lock()
 							// Refresh the strategy-level live regime every cycle, like
@@ -2403,6 +2450,7 @@ func runSpotCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionC
 	}
 	args = appendRegimeArgs(args, regime)
 	args = appendStrategyRegimeWindowArgs(args, sc, regime)
+	args = appendRegimePayloadArg(args, sc, regime)
 	if refsArgs, err := buildStrategyRefsArg(sc); err != nil {
 		logger.Warn("Failed to marshal strategy refs: %v", err)
 	} else if len(refsArgs) > 0 {
@@ -2529,9 +2577,16 @@ func indicatorFloat(indicators map[string]interface{}, key string) (float64, boo
 // runOptionsCheck runs the options check subprocess and returns the parsed result.
 // No state access. Returns (result, signalStr, ok); ok=false means skip execution.
 func runOptionsCheck(sc StrategyConfig, posJSON string, notifier *MultiNotifier, logger *StrategyLogger) (*OptionsResult, string, bool) {
-	logger.Info("Running: python3 %s %v", sc.Script, sc.Args)
+	args := append([]string{}, sc.Args...)
+	// #879: inject the global store's (underlying, 4h, ADX-default) bundle so
+	// check_options.py skips its inline regime fetch. The options signature
+	// ignores cfg.Regime — the inline path was never gated on it.
+	if raw, ok := globalRegimeStore.InjectionJSONForStrategy(sc, nil); ok {
+		args = append(args, "--regime-payload-json="+raw)
+	}
+	logger.Info("Running: python3 %s %v", sc.Script, args)
 
-	result, stderr, err := RunOptionsCheckWithStdin(sc.Script, sc.Args, posJSON)
+	result, stderr, err := RunOptionsCheckWithStdin(sc.Script, args, posJSON)
 	if err != nil {
 		logger.Error("Script failed: %v", err)
 		if stderr != "" {
@@ -2714,6 +2769,7 @@ func runHyperliquidCheck(sc *StrategyConfig, prices map[string]float64, posCtx P
 	}
 	args = appendRegimeArgs(args, regime)
 	args = appendStrategyRegimeWindowArgs(args, *sc, regime)
+	args = appendRegimePayloadArg(args, *sc, regime)
 	if refsArgs, err := buildStrategyRefsArg(scForCheck); err != nil {
 		logger.Warn("Failed to marshal strategy refs: %v", err)
 	} else if len(refsArgs) > 0 {
@@ -3186,6 +3242,7 @@ func runTopStepCheck(sc StrategyConfig, prices map[string]float64, posCtx Positi
 	}
 	args = appendRegimeArgs(args, regime)
 	args = appendStrategyRegimeWindowArgs(args, sc, regime)
+	args = appendRegimePayloadArg(args, sc, regime)
 	if refsArgs, err := buildStrategyRefsArg(sc); err != nil {
 		logger.Warn("Failed to marshal strategy refs: %v", err)
 	} else if len(refsArgs) > 0 {
@@ -3387,6 +3444,7 @@ func runRobinhoodCheck(sc StrategyConfig, prices map[string]float64, posCtx Posi
 	}
 	args = appendRegimeArgs(args, regime)
 	args = appendStrategyRegimeWindowArgs(args, sc, regime)
+	args = appendRegimePayloadArg(args, sc, regime)
 	if refsArgs, err := buildStrategyRefsArg(sc); err != nil {
 		logger.Warn("Failed to marshal strategy refs: %v", err)
 	} else if len(refsArgs) > 0 {
@@ -3566,6 +3624,7 @@ func runOKXCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCt
 	}
 	args = appendRegimeArgs(args, regime)
 	args = appendStrategyRegimeWindowArgs(args, sc, regime)
+	args = appendRegimePayloadArg(args, sc, regime)
 	if refsArgs, err := buildStrategyRefsArg(sc); err != nil {
 		logger.Warn("Failed to marshal strategy refs: %v", err)
 	} else if len(refsArgs) > 0 {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -745,14 +745,22 @@ func main() {
 		// Process only due strategies
 		if saveFailures >= 3 {
 			fmt.Println("[CRITICAL] State save failed 3x, skipping trades this cycle")
+			// #879: the fan-out below is skipped, so clear the regime store —
+			// /api/regime must not keep serving the prior cycle's labels as
+			// fake-live while trading is suspended.
+			globalRegimeStore.resetForCycle(time.Now().UTC())
 		} else {
-			// #879: build the per-cycle global regime store BEFORE the check
-			// fan-out — one regime subprocess per distinct (platform, symbol,
-			// timeframe, spec) signature among due strategies. Every regime
-			// consumer this cycle (entry gates, stratState sync, stamp-at-open,
-			// check-script injection, flat manual, options, dashboard) reads
-			// this map; check scripts no longer compute regime inline.
-			populateRegimeStore(globalRegimeStore, dueStrategies, cfg.Regime, notifier)
+			// #879: kick off the per-cycle global regime store — one regime
+			// subprocess per distinct (platform, symbol, timeframe, spec)
+			// signature among due strategies. Runs CONCURRENTLY with the
+			// portfolio risk / kill-switch phase below so a regime hang can
+			// never delay risk management; regimeStoreReady() blocks (with a
+			// phase budget) right before the check fan-out, the first store
+			// consumer. Every regime consumer this cycle (entry gates,
+			// stratState sync, stamp-at-open, check-script injection, flat
+			// manual, options, dashboard) reads this map; check scripts no
+			// longer compute regime inline.
+			regimeStoreReady := startRegimeStorePopulation(globalRegimeStore, dueStrategies, cfg.Regime, notifier)
 			// #42 / #243: Portfolio-level risk check before running any strategy.
 			//
 			// Fetch live Hyperliquid clearinghouseState ONCE per cycle (outside
@@ -1281,6 +1289,10 @@ func main() {
 					}
 				}
 
+				// #879: the dispatch loop below is the first regime-store
+				// consumer — wait (bounded by regimeStorePhaseBudget) for the
+				// population kicked off before the risk phase.
+				regimeStoreReady()
 				for _, sc := range dueStrategies {
 					stratState := state.Strategies[sc.ID]
 					if stratState == nil {
@@ -1908,6 +1920,11 @@ func main() {
 						// close-eval's check output — so a FLAT manual strategy now
 						// shows a live regime too (pre-#879 the HL check only ran
 						// with an open position, leaving regime=- while flat).
+						// If the bundle failed on the very cycle a manual position
+						// opened, the stamp below is an empty no-op and regime-keyed
+						// closes stay unarmed until a later cycle's bundle succeeds —
+						// the stamp is idempotent on pos.Regime == "", so it
+						// self-heals (documented fail-open tradeoff).
 						manualRegime := globalRegimeStore.PayloadForStrategy(sc, cfg.Regime)
 						if manualOK {
 							mu.Lock()

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -1185,19 +1185,21 @@ func openTradeSide(posSide string) string {
 
 // runManualCloseEval runs the close-evaluator loop for a single type=manual
 // strategy that has an open position. Called from the main scheduler loop.
-// Returns (closeFraction, closePrice, regimePayload, ok). The regime payload is
-// the classifier output from this cycle's check; the caller stamps it onto the
-// position once (#872) so frozen-label close features arm on manual positions.
-func runManualCloseEval(sc StrategyConfig, ss *StrategyState, cfg *Config, notifier *MultiNotifier, logger *StrategyLogger) (float64, float64, RegimePayload, bool) {
+// Returns (closeFraction, closePrice, ok). The live regime no longer rides on
+// the check output (#879): the caller reads the global regime store for this
+// strategy's signature directly, which also covers the flat case — this eval
+// doesn't even spawn a subprocess then — so status/dashboard show a regime
+// for manual strategies without a position.
+func runManualCloseEval(sc StrategyConfig, ss *StrategyState, cfg *Config, notifier *MultiNotifier, logger *StrategyLogger) (float64, float64, bool) {
 	pos := ss.Positions[sc.Symbol]
 	if pos == nil {
-		return 0, 0, RegimePayload{}, true // flat — nothing to do
+		return 0, 0, true // flat — nothing to do
 	}
 
 	posCtx := positionCtxFromPosition(pos)
 	result, _, price, ok := runHyperliquidCheck(&sc, nil, posCtx, cfg.Regime, notifier, logger)
 	if !ok {
-		return 0, 0, RegimePayload{}, false
+		return 0, 0, false
 	}
-	return result.CloseFraction, price, regimePayloadValue(result.Regime), true
+	return result.CloseFraction, price, true
 }

--- a/scheduler/manual_test.go
+++ b/scheduler/manual_test.go
@@ -880,24 +880,21 @@ func TestResolveManualOpenOrderSize(t *testing.T) {
 	})
 }
 
-// TestManualCloseEval_FlatReturnsEmptyPayload covers the #872 signature change:
-// runManualCloseEval now returns the cycle's regime payload as a fourth value.
-// The flat (no open position) early-return must yield an empty payload and not
-// spawn a subprocess.
-func TestManualCloseEval_FlatReturnsEmptyPayload(t *testing.T) {
+// TestManualCloseEval_FlatShortCircuits covers the flat early-return: no open
+// position means no subprocess spawn and ok=true. (#879 moved the live regime
+// off this eval's return — the dispatch reads the global regime store, which
+// is what gives FLAT manual strategies a live regime at all.)
+func TestManualCloseEval_FlatShortCircuits(t *testing.T) {
 	sc := StrategyConfig{ID: "hl-manual-eth-live", Type: "manual", Platform: "hyperliquid", Symbol: "ETH"}
 	ss := &StrategyState{ID: sc.ID, Positions: map[string]*Position{}}
 	cfg := &Config{Regime: &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20}}
 
-	cf, px, payload, ok := runManualCloseEval(sc, ss, cfg, nil, nil)
+	cf, px, ok := runManualCloseEval(sc, ss, cfg, nil, nil)
 	if !ok {
 		t.Fatalf("flat manual close-eval ok = false, want true")
 	}
 	if cf != 0 || px != 0 {
 		t.Errorf("flat manual close-eval = (cf=%v, px=%v), want (0, 0)", cf, px)
-	}
-	if !payload.IsEmpty() {
-		t.Errorf("flat manual close-eval payload = %+v, want empty", payload)
 	}
 }
 

--- a/scheduler/probe_cmd_test.go
+++ b/scheduler/probe_cmd_test.go
@@ -146,13 +146,14 @@ func TestRunProbeHappyPath(t *testing.T) {
 	if rc != 0 {
 		t.Fatalf("happy-path probe should return 0, got %d", rc)
 	}
-	// Expect 9 invocations: HL signal-check (adx+composite), HL --fetch-atr (#689),
-	// HL --execute (PR #769), spot signal-check (adx+composite), dashboard helpers.
-	// 9 prior shapes + 3 #883 limit-order shapes (limit-open/limit-status/cancel-order).
-	if len(probed) != 12 {
-		t.Fatalf("expected 12 probe invocations, got %d: %v", len(probed), probed)
+	// Expect 13 invocations: HL signal-check (adx+composite), HL --fetch-atr (#689),
+	// HL --execute (PR #769), spot signal-check (adx+composite), dashboard helpers,
+	// 3 #883 limit-order shapes (limit-open/limit-status/cancel-order), and the
+	// #879 check_regime.py bundle helper.
+	if len(probed) != 13 {
+		t.Fatalf("expected 13 probe invocations, got %d: %v", len(probed), probed)
 	}
-	var hlSignal, hlFetchATR, hlExecute, hlLimitOpen, hlLimitStatus, hlCancelOrder, spotSignal, candleHelper, schemaHelper, simulateHelper int
+	var hlSignal, hlFetchATR, hlExecute, hlLimitOpen, hlLimitStatus, hlCancelOrder, spotSignal, candleHelper, schemaHelper, simulateHelper, regimeHelper int
 	for _, p := range probed {
 		switch {
 		case p.script == "shared_scripts/check_hyperliquid.py" && p.mode == "signal":
@@ -175,11 +176,13 @@ func TestRunProbeHappyPath(t *testing.T) {
 			schemaHelper++
 		case p.script == "shared_scripts/simulate_strategy.py" && p.mode == "signal":
 			simulateHelper++
+		case p.script == "shared_scripts/check_regime.py" && p.mode == "signal":
+			regimeHelper++
 		}
 	}
-	if hlSignal != 2 || hlFetchATR != 1 || hlExecute != 1 || hlLimitOpen != 1 || hlLimitStatus != 1 || hlCancelOrder != 1 || spotSignal != 2 || candleHelper != 1 || schemaHelper != 1 || simulateHelper != 1 {
-		t.Fatalf("expected hl-signal=2, hl-fetch-atr=1, hl-execute=1, hl-limit-open=1, hl-limit-status=1, hl-cancel-order=1, spot-signal=2, candle-helper=1, schema=1, simulate=1; got %d/%d/%d/%d/%d/%d/%d/%d/%d/%d (probed=%v)",
-			hlSignal, hlFetchATR, hlExecute, hlLimitOpen, hlLimitStatus, hlCancelOrder, spotSignal, candleHelper, schemaHelper, simulateHelper, probed)
+	if hlSignal != 2 || hlFetchATR != 1 || hlExecute != 1 || hlLimitOpen != 1 || hlLimitStatus != 1 || hlCancelOrder != 1 || spotSignal != 2 || candleHelper != 1 || schemaHelper != 1 || simulateHelper != 1 || regimeHelper != 1 {
+		t.Fatalf("expected hl-signal=2, hl-fetch-atr=1, hl-execute=1, hl-limit-open=1, hl-limit-status=1, hl-cancel-order=1, spot-signal=2, candle-helper=1, schema=1, simulate=1, regime=1; got %d/%d/%d/%d/%d/%d/%d/%d/%d/%d/%d (probed=%v)",
+			hlSignal, hlFetchATR, hlExecute, hlLimitOpen, hlLimitStatus, hlCancelOrder, spotSignal, candleHelper, schemaHelper, simulateHelper, regimeHelper, probed)
 	}
 }
 

--- a/scheduler/regime_store.go
+++ b/scheduler/regime_store.go
@@ -1,0 +1,478 @@
+package main
+
+// regime_store.go — global per-cycle regime calculator + store (#879).
+//
+// One dedicated regime subprocess (shared_scripts/check_regime.py) runs per
+// distinct (data platform, symbol, timeframe, windows-spec) signature per
+// scheduler cycle; every due strategy sharing that signature — including
+// type=manual while flat and type=options — reads the same bundle from this
+// store instead of recomputing regime inline in its check subprocess. The
+// computed payload is injected into each check script via
+// --regime-payload-json (presence disables inline prepare_check_regime).
+//
+// The store is in-memory only and rebuilt every cycle (like the pre-#879
+// stratState.Regime refresh); pos.Regime stays the frozen-at-open stamp.
+// Failure policy (issue #879, option b): a failed/missing bundle yields an
+// EMPTY payload — the entry gate fails open, syncStrategyRegimeState shows
+// regime=-, and there is no reuse-last or inline-recompute fallback. Open
+// positions are unaffected because regime-keyed life-of-position features
+// read pos.Regime, not this store.
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const regimeCheckScript = "shared_scripts/check_regime.py"
+
+// regimeBundleMinBars mirrors the five check scripts' insufficient-data guard
+// (len(candles) < 30 → error), so a signature the check would refuse to trade
+// on also produces no bundle.
+const regimeBundleMinBars = 30
+
+// Options regime signature constants mirror check_options.py's hardcoded
+// inline computation (REGIME_TIMEFRAME/REGIME_LIMIT/REGIME_MIN_BARS and
+// latest_regime's period=14 / adx_threshold=20 defaults) so the migrated
+// label is byte-identical to the pre-#879 inline one. Options regime is
+// intentionally NOT gated on cfg.Regime.Enabled — the inline path never was.
+const (
+	optionsRegimeTimeframe       = "4h"
+	optionsRegimeOhlcvLimit      = 100
+	optionsRegimeMinBars         = 30
+	optionsRegimeWindowsSpecJSON = `{"default":{"classifier":"adx","period":14,"adx_threshold":20}}`
+)
+
+// regimeBundleKey identifies one regime computation signature. Platform is
+// the DATA SOURCE the strategy's check script fetches OHLCV from (derived
+// from the dispatch branch, not sc.Platform — the default spot dispatch
+// fetches BinanceUS data regardless of platform). SpecJSON is the resolved
+// windows-spec JSON (deterministic: encoding/json sorts map keys), so a
+// different spec — e.g. the options ADX/4h default vs the global windows —
+// is a different raw computation.
+type regimeBundleKey struct {
+	Platform  string
+	Symbol    string
+	Timeframe string
+	SpecJSON  string
+}
+
+func (k regimeBundleKey) String() string {
+	return k.Platform + "/" + k.Symbol + "/" + k.Timeframe
+}
+
+// regimeBundleRequest is the work order for one check_regime.py invocation.
+type regimeBundleRequest struct {
+	Key               regimeBundleKey
+	OhlcvLimit        int
+	MinBars           int
+	AllowSpotFallback bool // options platforms: adapter-or-BinanceUS fallback (parity with check_options)
+}
+
+// RegimeBundleViews carries both classifier vocabularies for one window —
+// the dashboard's uniform 3-state/7-state portfolio view. adx3 is the real
+// ADX classifier at the window's full period (exact parity with a standalone
+// ADX window even past COMPOSITE_ADX_PERIOD_CAP), never a prefix-collapse.
+type RegimeBundleViews struct {
+	ADX3       string `json:"adx3"`
+	Composite7 string `json:"composite7"`
+}
+
+// RegimeBundle is one computed store entry. RawRegimeJSON preserves the
+// subprocess's exact `regime` object bytes for --regime-payload-json
+// injection (re-marshaling the Go-side RegimePayload would drop snapshot
+// fields Go doesn't model, e.g. per-window "classifier").
+type RegimeBundle struct {
+	Key           regimeBundleKey
+	Payload       RegimePayload
+	RawRegimeJSON string
+	Views         map[string]RegimeBundleViews
+	BarTime       string
+	Err           string
+	At            time.Time
+}
+
+// regimeBundleOutput is the JSON contract of check_regime.py.
+type regimeBundleOutput struct {
+	Platform  string                       `json:"platform"`
+	Symbol    string                       `json:"symbol"`
+	Timeframe string                       `json:"timeframe"`
+	BarTime   string                       `json:"bar_time"`
+	Regime    json.RawMessage              `json:"regime"`
+	Views     map[string]RegimeBundleViews `json:"views"`
+	Error     string                       `json:"error"`
+}
+
+// RegimeStore is the two-layer global store, rebuilt empty every cycle.
+// Guarded by its own mutex: writes happen on the main loop goroutine before
+// the check fan-out; reads come from the same goroutine plus the dashboard
+// HTTP handlers.
+type RegimeStore struct {
+	mu      sync.RWMutex
+	entries map[regimeBundleKey]*RegimeBundle
+	builtAt time.Time
+}
+
+// globalRegimeStore is the process-wide store. Package-level (like the other
+// cross-cutting singletons in this package) so run*Check arg builders, the
+// manual path, and the dashboard handler read it without threading a handle
+// through every dispatch signature.
+var globalRegimeStore = &RegimeStore{}
+
+func (s *RegimeStore) resetForCycle(now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = make(map[regimeBundleKey]*RegimeBundle)
+	s.builtAt = now
+}
+
+func (s *RegimeStore) set(b *RegimeBundle) {
+	if b == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.entries == nil {
+		s.entries = make(map[regimeBundleKey]*RegimeBundle)
+	}
+	s.entries[b.Key] = b
+}
+
+func (s *RegimeStore) get(key regimeBundleKey) (*RegimeBundle, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	b, ok := s.entries[key]
+	return b, ok
+}
+
+// Snapshot returns the cycle's bundles sorted by key for operator-facing
+// output (Go map iteration is randomized).
+func (s *RegimeStore) Snapshot() ([]*RegimeBundle, time.Time) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]*RegimeBundle, 0, len(s.entries))
+	for _, b := range s.entries {
+		out = append(out, b)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i].Key, out[j].Key
+		if a.Platform != b.Platform {
+			return a.Platform < b.Platform
+		}
+		if a.Symbol != b.Symbol {
+			return a.Symbol < b.Symbol
+		}
+		if a.Timeframe != b.Timeframe {
+			return a.Timeframe < b.Timeframe
+		}
+		return a.SpecJSON < b.SpecJSON
+	})
+	return out, s.builtAt
+}
+
+// strategyRegimeDataPlatform maps a strategy to the data source its check
+// script fetches OHLCV from. Mirrors the dispatch switch in the main loop.
+func strategyRegimeDataPlatform(sc StrategyConfig) string {
+	switch sc.Type {
+	case "spot":
+		switch sc.Platform {
+		case "okx":
+			return "okx"
+		case "robinhood":
+			return "robinhood"
+		default:
+			// Default spot dispatch runs check_strategy.py, which fetches
+			// BinanceUS via shared_tools/data_fetcher for every platform.
+			return "binanceus"
+		}
+	case "perps":
+		if sc.Platform == "okx" {
+			return "okx"
+		}
+		return "hyperliquid"
+	case "futures":
+		return "topstep"
+	case "manual":
+		return "hyperliquid"
+	case "options":
+		return strings.TrimSpace(sc.Platform)
+	}
+	return ""
+}
+
+// strategyArgSymbolTimeframe extracts the positional <symbol> <timeframe>
+// pair shared by every check-script argv shape (manual auto-fills the same
+// layout: ["hold", symbol, timeframe, ...]).
+func strategyArgSymbolTimeframe(args []string) (string, string) {
+	if len(args) < 3 {
+		return "", ""
+	}
+	symbol := strings.TrimSpace(args[1])
+	timeframe := strings.TrimSpace(args[2])
+	if symbol == "" || timeframe == "" || strings.HasPrefix(symbol, "-") || strings.HasPrefix(timeframe, "-") {
+		return "", ""
+	}
+	return symbol, timeframe
+}
+
+// strategyRegimeBundleRequest resolves sc's regime signature for this cycle.
+// ok=false means the strategy reads no bundle (regime disabled for non-options
+// types, or an unresolvable symbol/timeframe) and its check script receives no
+// --regime-payload-json flag.
+func strategyRegimeBundleRequest(sc StrategyConfig, rc *RegimeConfig) (regimeBundleRequest, bool) {
+	if sc.Type == "options" {
+		platform := strategyRegimeDataPlatform(sc)
+		if platform == "" || len(sc.Args) < 2 {
+			return regimeBundleRequest{}, false
+		}
+		underlying := strings.TrimSpace(sc.Args[1])
+		if underlying == "" || strings.HasPrefix(underlying, "-") {
+			return regimeBundleRequest{}, false
+		}
+		return regimeBundleRequest{
+			Key: regimeBundleKey{
+				Platform:  platform,
+				Symbol:    strings.ToUpper(underlying), // check_options upper-cases the underlying
+				Timeframe: optionsRegimeTimeframe,
+				SpecJSON:  optionsRegimeWindowsSpecJSON,
+			},
+			OhlcvLimit:        optionsRegimeOhlcvLimit,
+			MinBars:           optionsRegimeMinBars,
+			AllowSpotFallback: true,
+		}, true
+	}
+	if rc == nil || !rc.Enabled {
+		return regimeBundleRequest{}, false
+	}
+	specJSON := regimeWindowsSpecJSON(rc)
+	if specJSON == "" {
+		return regimeBundleRequest{}, false
+	}
+	platform := strategyRegimeDataPlatform(sc)
+	if platform == "" {
+		return regimeBundleRequest{}, false
+	}
+	symbol, timeframe := strategyArgSymbolTimeframe(sc.Args)
+	if symbol == "" || timeframe == "" {
+		return regimeBundleRequest{}, false
+	}
+	return regimeBundleRequest{
+		Key: regimeBundleKey{
+			Platform:  platform,
+			Symbol:    symbol,
+			Timeframe: timeframe,
+			SpecJSON:  specJSON,
+		},
+		OhlcvLimit: regimeRequiredOhlcvLimit(rc),
+		MinBars:    regimeBundleMinBars,
+	}, true
+}
+
+// collectRegimeBundleRequests unions the distinct signatures of the due
+// strategies — the per-cycle population step. Deterministic order so logs
+// and tests are stable.
+func collectRegimeBundleRequests(due []StrategyConfig, rc *RegimeConfig) []regimeBundleRequest {
+	seen := make(map[regimeBundleKey]bool)
+	out := make([]regimeBundleRequest, 0, len(due))
+	for _, sc := range due {
+		req, ok := strategyRegimeBundleRequest(sc, rc)
+		if !ok || seen[req.Key] {
+			continue
+		}
+		seen[req.Key] = true
+		out = append(out, req)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i].Key, out[j].Key
+		if a.Platform != b.Platform {
+			return a.Platform < b.Platform
+		}
+		if a.Symbol != b.Symbol {
+			return a.Symbol < b.Symbol
+		}
+		if a.Timeframe != b.Timeframe {
+			return a.Timeframe < b.Timeframe
+		}
+		return a.SpecJSON < b.SpecJSON
+	})
+	return out
+}
+
+// regimeBundleCheckArgs builds the check_regime.py argv for one request.
+func regimeBundleCheckArgs(req regimeBundleRequest) []string {
+	args := []string{
+		"--platform", req.Key.Platform,
+		"--symbol", req.Key.Symbol,
+		"--timeframe", req.Key.Timeframe,
+		"--regime-windows-spec-json", req.Key.SpecJSON,
+		"--ohlcv-limit", strconv.Itoa(req.OhlcvLimit),
+		"--min-bars", strconv.Itoa(req.MinBars),
+	}
+	if req.AllowSpotFallback {
+		args = append(args, "--allow-spot-fallback")
+	}
+	return args
+}
+
+// parseRegimeBundleOutput parses check_regime.py stdout into a bundle. Pure
+// helper so Go CI exercises the contract without spawning Python.
+func parseRegimeBundleOutput(key regimeBundleKey, data []byte, now time.Time) (*RegimeBundle, error) {
+	var out regimeBundleOutput
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("regime bundle %s: bad JSON: %w", key, err)
+	}
+	if out.Error != "" {
+		return nil, fmt.Errorf("regime bundle %s: %s", key, out.Error)
+	}
+	if len(out.Regime) == 0 || string(out.Regime) == "null" {
+		return nil, fmt.Errorf("regime bundle %s: missing regime payload", key)
+	}
+	var payload RegimePayload
+	if err := json.Unmarshal(out.Regime, &payload); err != nil {
+		return nil, fmt.Errorf("regime bundle %s: bad regime payload: %w", key, err)
+	}
+	if payload.IsEmpty() {
+		return nil, fmt.Errorf("regime bundle %s: empty regime payload", key)
+	}
+	return &RegimeBundle{
+		Key:           key,
+		Payload:       payload,
+		RawRegimeJSON: string(out.Regime),
+		Views:         out.Views,
+		BarTime:       out.BarTime,
+		At:            now,
+	}, nil
+}
+
+// runRegimeBundleCheckFn is the subprocess invoker — package var so tests can
+// stub the Python boundary (Go CI must not depend on spawning Python).
+var runRegimeBundleCheckFn = runRegimeBundleCheck
+
+func runRegimeBundleCheck(req regimeBundleRequest) (*RegimeBundle, error) {
+	stdout, stderr, err := runPythonReadOnly(regimeCheckScript, regimeBundleCheckArgs(req))
+	now := time.Now().UTC()
+	// Subprocess contract: JSON on stdout even on error; parse regardless of
+	// exit code and prefer the script's structured error over the exit error.
+	if bundle, perr := parseRegimeBundleOutput(req.Key, stdout, now); perr == nil {
+		return bundle, nil
+	} else if err == nil {
+		return nil, perr
+	}
+	detail := strings.TrimSpace(string(stderr))
+	if msg := regimeBundleErrorMessage(stdout); msg != "" {
+		detail = msg
+	}
+	if detail == "" {
+		detail = err.Error()
+	}
+	return nil, fmt.Errorf("regime bundle %s: %s", req.Key, detail)
+}
+
+// regimeBundleErrorMessage extracts the structured "error" field when the
+// script crashed with a JSON error body.
+func regimeBundleErrorMessage(stdout []byte) string {
+	var out regimeBundleOutput
+	if err := json.Unmarshal(stdout, &out); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out.Error)
+}
+
+// regimeBundleAlertConfig is the synthetic StrategyConfig identity used to
+// thread regime-subprocess failures through the existing per-key
+// scriptFailureTracker throttling (#829 pattern).
+func regimeBundleAlertConfig(key regimeBundleKey) StrategyConfig {
+	return StrategyConfig{
+		ID:       "regime[" + key.String() + "]",
+		Platform: key.Platform,
+		Script:   regimeCheckScript,
+	}
+}
+
+// populateRegimeStore rebuilds the global store for this cycle: clear, union
+// due-strategy signatures, one subprocess per distinct signature (parallel;
+// pythonSemaphore caps concurrency at 4), project entries. Runs on the main
+// loop goroutine BEFORE the per-strategy check fan-out, without holding the
+// state mutex. A failed signature leaves NO entry — consumers see an empty
+// payload and fail open (issue #879 failure policy b).
+func populateRegimeStore(store *RegimeStore, due []StrategyConfig, rc *RegimeConfig, notifier *MultiNotifier) {
+	store.resetForCycle(time.Now().UTC())
+	reqs := collectRegimeBundleRequests(due, rc)
+	if len(reqs) == 0 {
+		return
+	}
+	var wg sync.WaitGroup
+	for _, req := range reqs {
+		req := req
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			bundle, err := runRegimeBundleCheckFn(req)
+			if err != nil {
+				fmt.Printf("[WARN] regime store: %v\n", err)
+				notifyScriptFailure(notifier, regimeBundleAlertConfig(req.Key), scriptFailureError, err.Error())
+				return
+			}
+			store.set(bundle)
+			clearScriptFailure(notifier, regimeBundleAlertConfig(req.Key))
+		}()
+	}
+	wg.Wait()
+	if summary := regimeStoreSummary(store); summary != "" {
+		fmt.Printf("Regime: %s\n", summary)
+	}
+}
+
+// regimeStoreSummary renders one line of primary labels for the cycle log,
+// e.g. "hyperliquid/BTC/1h=trending_up; deribit/ETH/4h=ranging". Sorted by
+// key (map iteration is randomized).
+func regimeStoreSummary(store *RegimeStore) string {
+	bundles, _ := store.Snapshot()
+	parts := make([]string, 0, len(bundles))
+	for _, b := range bundles {
+		label := b.Payload.PrimaryLabel(nil)
+		if label == "" {
+			label = "-"
+		}
+		parts = append(parts, b.Key.String()+"="+label)
+	}
+	return strings.Join(parts, "; ")
+}
+
+// PayloadForStrategy returns the live regime payload for sc's signature this
+// cycle. Empty when sc has no signature (regime disabled) or the bundle is
+// missing/failed — every consumer's existing empty-case behavior is the
+// fail-open path.
+func (s *RegimeStore) PayloadForStrategy(sc StrategyConfig, rc *RegimeConfig) RegimePayload {
+	req, ok := strategyRegimeBundleRequest(sc, rc)
+	if !ok {
+		return RegimePayload{}
+	}
+	b, found := s.get(req.Key)
+	if !found || b == nil {
+		return RegimePayload{}
+	}
+	return b.Payload
+}
+
+// InjectionJSONForStrategy returns (raw payload JSON, true) when sc's check
+// script should receive --regime-payload-json this cycle. The flag is passed
+// whenever sc HAS a signature — with an EMPTY value after a bundle failure,
+// which tells the script "do not recompute inline; resolve empty/fail-open"
+// (regime_from_injected_payload). ok=false omits the flag entirely (regime
+// disabled), leaving the script's inline path untouched for manual CLI runs.
+func (s *RegimeStore) InjectionJSONForStrategy(sc StrategyConfig, rc *RegimeConfig) (string, bool) {
+	req, ok := strategyRegimeBundleRequest(sc, rc)
+	if !ok {
+		return "", false
+	}
+	b, found := s.get(req.Key)
+	if !found || b == nil {
+		return "", true
+	}
+	return b.RawRegimeJSON, true
+}

--- a/scheduler/regime_store.go
+++ b/scheduler/regime_store.go
@@ -19,7 +19,9 @@ package main
 // read pos.Regime, not this store.
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -117,14 +119,20 @@ var regimeStorePhaseBudget = scriptTimeout + 15*time.Second
 // RegimeStore is the two-layer global store, rebuilt empty every cycle.
 // Guarded by its own mutex: writes happen on the population goroutines before
 // the check fan-out; reads come from the main loop plus the dashboard HTTP
-// handlers. Once sealed (phase budget exceeded), straggler results are
-// discarded so every strategy in the cycle reads the same — possibly empty,
-// fail-open — view instead of a mid-cycle mix.
+// handlers. Two write guards keep the per-cycle view consistent:
+//   - sealed (phase budget exceeded): straggler results are discarded so every
+//     strategy in the cycle reads the same — possibly empty, fail-open — view
+//     instead of a mid-cycle mix.
+//   - generation: each resetForCycle bumps it and writes carry the generation
+//     captured at population start, so a straggler from a budget-exceeded
+//     cycle N that completes after cycle N+1 unsealed the store cannot write
+//     its stale cycle-N bundle into N+1's map ("no reuse-last across cycles").
 type RegimeStore struct {
 	mu      sync.RWMutex
 	entries map[regimeBundleKey]*RegimeBundle
 	builtAt time.Time
 	sealed  bool
+	gen     uint64
 }
 
 // globalRegimeStore is the process-wide store. Package-level (like the other
@@ -133,24 +141,31 @@ type RegimeStore struct {
 // through every dispatch signature.
 var globalRegimeStore = &RegimeStore{}
 
-func (s *RegimeStore) resetForCycle(now time.Time) {
+// resetForCycle clears the store for a new cycle and returns the new
+// generation; writes carrying any other generation are dropped.
+func (s *RegimeStore) resetForCycle(now time.Time) uint64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.entries = make(map[regimeBundleKey]*RegimeBundle)
 	s.builtAt = now
 	s.sealed = false
+	s.gen++
+	return s.gen
 }
 
-func (s *RegimeStore) set(b *RegimeBundle) {
+func (s *RegimeStore) set(b *RegimeBundle, gen uint64) {
 	if b == nil {
 		return
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.sealed {
-		// Phase budget already expired: the cycle is consuming the store, so
-		// a late bundle must not flip a signature mid-cycle. Dropped, not
-		// deferred — the next cycle recomputes from scratch anyway.
+	if s.sealed || gen != s.gen {
+		// sealed: the phase budget already expired and the cycle is consuming
+		// the store — a late bundle must not flip a signature mid-cycle.
+		// gen mismatch: the bundle belongs to a PREVIOUS cycle's population
+		// (resetForCycle unsealed the store since); writing it would smuggle
+		// a stale label into the current cycle. Dropped, not deferred — the
+		// current population recomputes the signature from scratch anyway.
 		return
 	}
 	if s.entries == nil {
@@ -375,11 +390,15 @@ func parseRegimeBundleOutput(key regimeBundleKey, data []byte, now time.Time) (*
 }
 
 // runRegimeBundleCheckFn is the subprocess invoker — package var so tests can
-// stub the Python boundary (Go CI must not depend on spawning Python).
+// stub the Python boundary (Go CI must not depend on spawning Python). ctx is
+// the population context: cancelled at the phase-budget seal so in-flight
+// stragglers are killed and queued ones fast-fail, releasing their
+// pythonSemaphore slots instead of starving the check fan-out for up to a
+// full scriptTimeout each.
 var runRegimeBundleCheckFn = runRegimeBundleCheck
 
-func runRegimeBundleCheck(req regimeBundleRequest) (*RegimeBundle, error) {
-	stdout, stderr, err := runPythonReadOnly(regimeCheckScript, regimeBundleCheckArgs(req))
+func runRegimeBundleCheck(ctx context.Context, req regimeBundleRequest) (*RegimeBundle, error) {
+	stdout, stderr, err := runPython(ctx, regimeCheckScript, regimeBundleCheckArgs(req), nil)
 	now := time.Now().UTC()
 	// Subprocess contract: JSON on stdout even on error; parse regardless of
 	// exit code and prefer the script's structured error over the exit error.
@@ -438,11 +457,16 @@ func regimeBundleAlertConfig(key regimeBundleKey) StrategyConfig {
 // on the sequential main loop, so the populate goroutines must not fan sends
 // out concurrently.
 func startRegimeStorePopulation(store *RegimeStore, due []StrategyConfig, rc *RegimeConfig, notifier *MultiNotifier) func() {
-	store.resetForCycle(time.Now().UTC())
+	gen := store.resetForCycle(time.Now().UTC())
 	reqs := collectRegimeBundleRequests(due, rc)
 	if len(reqs) == 0 {
 		return func() {}
 	}
+	// Population context: derived from the read-only shutdown context like
+	// every other check subprocess, and cancelled at the phase-budget seal so
+	// stragglers release their pythonSemaphore slots instead of carrying
+	// prior-cycle regime work into the next cycle's fan-out.
+	popCtx, popCancel := context.WithCancel(shutdownReadOnlyCtx)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -453,19 +477,28 @@ func startRegimeStorePopulation(store *RegimeStore, due []StrategyConfig, rc *Re
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				bundle, err := runRegimeBundleCheckFn(req)
+				bundle, err := runRegimeBundleCheckFn(popCtx, req)
 				if err != nil {
 					errs[i] = err
 					return
 				}
-				store.set(bundle)
+				store.set(bundle, gen)
 			}()
 		}
 		wg.Wait()
+		// Alerts fire after the parallel wave, off the population goroutine
+		// only (never fanned out across the per-request goroutines). A
+		// budget-cancelled request still records a failure — its signature
+		// failed open this cycle, and the 3-strike streak should surface a
+		// chronically starved signature — with a message naming the cause.
 		for i, req := range reqs {
 			if errs[i] != nil {
-				fmt.Printf("[WARN] regime store: %v\n", errs[i])
-				notifyScriptFailure(notifier, regimeBundleAlertConfig(req.Key), scriptFailureError, errs[i].Error())
+				msg := errs[i].Error()
+				if errors.Is(errs[i], context.Canceled) {
+					msg = fmt.Sprintf("cancelled at phase-budget seal (%s); signature failed open this cycle", regimeStorePhaseBudget)
+				}
+				fmt.Printf("[WARN] regime store %s: %s\n", req.Key, msg)
+				notifyScriptFailure(notifier, regimeBundleAlertConfig(req.Key), scriptFailureError, msg)
 			} else {
 				clearScriptFailure(notifier, regimeBundleAlertConfig(req.Key))
 			}
@@ -474,8 +507,13 @@ func startRegimeStorePopulation(store *RegimeStore, due []StrategyConfig, rc *Re
 	return func() {
 		select {
 		case <-done:
+			popCancel()
 		case <-time.After(regimeStorePhaseBudget):
 			kept := store.seal()
+			// Seal first (no mid-cycle flips), then cancel: in-flight
+			// subprocesses are SIGKILLed and queued ones fast-fail on the
+			// dead context, freeing semaphore slots for the check fan-out.
+			popCancel()
 			fmt.Printf("[WARN] regime store: phase budget %s exceeded; sealed with %d/%d bundles — missing signatures fail open this cycle\n",
 				regimeStorePhaseBudget, kept, len(reqs))
 		}

--- a/scheduler/regime_store.go
+++ b/scheduler/regime_store.go
@@ -107,14 +107,24 @@ type regimeBundleOutput struct {
 	Error     string                       `json:"error"`
 }
 
+// regimeStorePhaseBudget caps the wall-clock the main loop will wait for the
+// regime-population phase before proceeding with whatever bundles landed.
+// One full subprocess timeout wave plus headroom: without a cap, a storm of
+// N distinct hanging signatures would serialize to ceil(N/4)×scriptTimeout
+// ahead of the check fan-out. Var (not const) so tests can shrink it.
+var regimeStorePhaseBudget = scriptTimeout + 15*time.Second
+
 // RegimeStore is the two-layer global store, rebuilt empty every cycle.
-// Guarded by its own mutex: writes happen on the main loop goroutine before
-// the check fan-out; reads come from the same goroutine plus the dashboard
-// HTTP handlers.
+// Guarded by its own mutex: writes happen on the population goroutines before
+// the check fan-out; reads come from the main loop plus the dashboard HTTP
+// handlers. Once sealed (phase budget exceeded), straggler results are
+// discarded so every strategy in the cycle reads the same — possibly empty,
+// fail-open — view instead of a mid-cycle mix.
 type RegimeStore struct {
 	mu      sync.RWMutex
 	entries map[regimeBundleKey]*RegimeBundle
 	builtAt time.Time
+	sealed  bool
 }
 
 // globalRegimeStore is the process-wide store. Package-level (like the other
@@ -128,6 +138,7 @@ func (s *RegimeStore) resetForCycle(now time.Time) {
 	defer s.mu.Unlock()
 	s.entries = make(map[regimeBundleKey]*RegimeBundle)
 	s.builtAt = now
+	s.sealed = false
 }
 
 func (s *RegimeStore) set(b *RegimeBundle) {
@@ -136,10 +147,25 @@ func (s *RegimeStore) set(b *RegimeBundle) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.sealed {
+		// Phase budget already expired: the cycle is consuming the store, so
+		// a late bundle must not flip a signature mid-cycle. Dropped, not
+		// deferred — the next cycle recomputes from scratch anyway.
+		return
+	}
 	if s.entries == nil {
 		s.entries = make(map[regimeBundleKey]*RegimeBundle)
 	}
 	s.entries[b.Key] = b
+}
+
+// seal freezes the store for the remainder of the cycle and reports how many
+// bundles made it in before the phase budget expired.
+func (s *RegimeStore) seal() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sealed = true
+	return len(s.entries)
 }
 
 func (s *RegimeStore) get(key regimeBundleKey) (*RegimeBundle, bool) {
@@ -393,38 +419,75 @@ func regimeBundleAlertConfig(key regimeBundleKey) StrategyConfig {
 	}
 }
 
-// populateRegimeStore rebuilds the global store for this cycle: clear, union
-// due-strategy signatures, one subprocess per distinct signature (parallel;
-// pythonSemaphore caps concurrency at 4), project entries. Runs on the main
-// loop goroutine BEFORE the per-strategy check fan-out, without holding the
-// state mutex. A failed signature leaves NO entry — consumers see an empty
-// payload and fail open (issue #879 failure policy b).
-func populateRegimeStore(store *RegimeStore, due []StrategyConfig, rc *RegimeConfig, notifier *MultiNotifier) {
+// startRegimeStorePopulation rebuilds the global store for this cycle: clear,
+// union due-strategy signatures, one subprocess per distinct signature
+// (parallel; pythonSemaphore caps concurrency at 4). It kicks the work off on
+// a background goroutine and returns a wait func, so the main loop can run
+// the once-per-cycle portfolio risk / kill-switch phase CONCURRENTLY and a
+// regime hang can never delay risk management — call the wait func right
+// before the per-strategy check fan-out (the first store consumer).
+//
+// The wait func blocks until population completes or regimeStorePhaseBudget
+// elapses; on budget exhaustion the store is sealed — straggler subprocesses
+// keep their semaphore slots until their own scriptTimeout fires, but their
+// results are discarded and the affected signatures fail open this cycle.
+//
+// A failed signature leaves NO entry — consumers see an empty payload and
+// fail open (issue #879 failure policy b). Failure/recovery alerts fire
+// sequentially after the parallel wave: MultiNotifier's other callers are all
+// on the sequential main loop, so the populate goroutines must not fan sends
+// out concurrently.
+func startRegimeStorePopulation(store *RegimeStore, due []StrategyConfig, rc *RegimeConfig, notifier *MultiNotifier) func() {
 	store.resetForCycle(time.Now().UTC())
 	reqs := collectRegimeBundleRequests(due, rc)
 	if len(reqs) == 0 {
-		return
+		return func() {}
 	}
-	var wg sync.WaitGroup
-	for _, req := range reqs {
-		req := req
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			bundle, err := runRegimeBundleCheckFn(req)
-			if err != nil {
-				fmt.Printf("[WARN] regime store: %v\n", err)
-				notifyScriptFailure(notifier, regimeBundleAlertConfig(req.Key), scriptFailureError, err.Error())
-				return
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		errs := make([]error, len(reqs))
+		var wg sync.WaitGroup
+		for i, req := range reqs {
+			i, req := i, req
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				bundle, err := runRegimeBundleCheckFn(req)
+				if err != nil {
+					errs[i] = err
+					return
+				}
+				store.set(bundle)
+			}()
+		}
+		wg.Wait()
+		for i, req := range reqs {
+			if errs[i] != nil {
+				fmt.Printf("[WARN] regime store: %v\n", errs[i])
+				notifyScriptFailure(notifier, regimeBundleAlertConfig(req.Key), scriptFailureError, errs[i].Error())
+			} else {
+				clearScriptFailure(notifier, regimeBundleAlertConfig(req.Key))
 			}
-			store.set(bundle)
-			clearScriptFailure(notifier, regimeBundleAlertConfig(req.Key))
-		}()
+		}
+	}()
+	return func() {
+		select {
+		case <-done:
+		case <-time.After(regimeStorePhaseBudget):
+			kept := store.seal()
+			fmt.Printf("[WARN] regime store: phase budget %s exceeded; sealed with %d/%d bundles — missing signatures fail open this cycle\n",
+				regimeStorePhaseBudget, kept, len(reqs))
+		}
+		if summary := regimeStoreSummary(store); summary != "" {
+			fmt.Printf("Regime: %s\n", summary)
+		}
 	}
-	wg.Wait()
-	if summary := regimeStoreSummary(store); summary != "" {
-		fmt.Printf("Regime: %s\n", summary)
-	}
+}
+
+// populateRegimeStore is the synchronous form (tests, single-shot callers).
+func populateRegimeStore(store *RegimeStore, due []StrategyConfig, rc *RegimeConfig, notifier *MultiNotifier) {
+	startRegimeStorePopulation(store, due, rc, notifier)()
 }
 
 // regimeStoreSummary renders one line of primary labels for the cycle log,

--- a/scheduler/regime_store_test.go
+++ b/scheduler/regime_store_test.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testRegimeConfig() *RegimeConfig {
+	return &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20}
+}
+
+// ─── signature derivation ────────────────────────────────────────────────────
+
+func TestStrategyRegimeBundleRequestPlatformMapping(t *testing.T) {
+	rc := testRegimeConfig()
+	cases := []struct {
+		name         string
+		sc           StrategyConfig
+		wantPlatform string
+		wantSymbol   string
+		wantTF       string
+	}{
+		{"hl perps", StrategyConfig{ID: "hl-a", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}}, "hyperliquid", "BTC", "1h"},
+		{"okx perps", StrategyConfig{ID: "okx-a", Type: "perps", Platform: "okx", Args: []string{"momentum", "BTC-USDT-SWAP", "1h"}}, "okx", "BTC-USDT-SWAP", "1h"},
+		{"okx spot", StrategyConfig{ID: "okx-s", Type: "spot", Platform: "okx", Args: []string{"sma", "BTC-USDT", "4h"}}, "okx", "BTC-USDT", "4h"},
+		{"robinhood spot", StrategyConfig{ID: "rh-a", Type: "spot", Platform: "robinhood", Args: []string{"sma", "BTC", "1d"}}, "robinhood", "BTC", "1d"},
+		// Default spot dispatch fetches BinanceUS data regardless of platform.
+		{"default spot", StrategyConfig{ID: "spot-a", Type: "spot", Args: []string{"sma", "BTC/USDT", "1h"}}, "binanceus", "BTC/USDT", "1h"},
+		{"luno spot uses binanceus data", StrategyConfig{ID: "luno-a", Type: "spot", Platform: "luno", Args: []string{"sma", "BTC/USDT", "1h"}}, "binanceus", "BTC/USDT", "1h"},
+		{"futures", StrategyConfig{ID: "ts-a", Type: "futures", Platform: "topstep", Args: []string{"momentum", "MES", "15m"}}, "topstep", "MES", "15m"},
+		{"manual", StrategyConfig{ID: "hl-manual", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Args: []string{"hold", "ETH", "1h", "--mode=live"}}, "hyperliquid", "ETH", "1h"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, ok := strategyRegimeBundleRequest(tc.sc, rc)
+			if !ok {
+				t.Fatalf("expected a bundle request")
+			}
+			if req.Key.Platform != tc.wantPlatform || req.Key.Symbol != tc.wantSymbol || req.Key.Timeframe != tc.wantTF {
+				t.Errorf("key = %+v, want %s/%s/%s", req.Key, tc.wantPlatform, tc.wantSymbol, tc.wantTF)
+			}
+			if req.Key.SpecJSON != regimeWindowsSpecJSON(rc) {
+				t.Errorf("spec = %q, want global windows spec", req.Key.SpecJSON)
+			}
+			if req.AllowSpotFallback {
+				t.Errorf("non-options requests must not allow cross-venue fallback")
+			}
+			if req.MinBars != regimeBundleMinBars {
+				t.Errorf("min bars = %d, want %d", req.MinBars, regimeBundleMinBars)
+			}
+		})
+	}
+}
+
+func TestStrategyRegimeBundleRequestDisabled(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-a", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}}
+	if _, ok := strategyRegimeBundleRequest(sc, nil); ok {
+		t.Error("nil regime config must yield no signature")
+	}
+	if _, ok := strategyRegimeBundleRequest(sc, &RegimeConfig{Enabled: false}); ok {
+		t.Error("disabled regime must yield no signature")
+	}
+	bad := StrategyConfig{ID: "hl-b", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum"}}
+	if _, ok := strategyRegimeBundleRequest(bad, testRegimeConfig()); ok {
+		t.Error("missing symbol/timeframe args must yield no signature")
+	}
+}
+
+func TestStrategyRegimeBundleRequestOptions(t *testing.T) {
+	// Options regime is NOT gated on cfg.Regime.Enabled — the inline
+	// check_options path never was. Signature mirrors the hardcoded 4h/ADX
+	// defaults and upper-cases the underlying like the script does.
+	sc := StrategyConfig{ID: "deribit-theta", Type: "options", Platform: "deribit", Args: []string{"theta_harvest", "btc", "--platform=deribit"}}
+	req, ok := strategyRegimeBundleRequest(sc, nil)
+	if !ok {
+		t.Fatalf("options strategy must always have a regime signature")
+	}
+	if req.Key.Platform != "deribit" || req.Key.Symbol != "BTC" || req.Key.Timeframe != optionsRegimeTimeframe {
+		t.Errorf("options key = %+v", req.Key)
+	}
+	if req.Key.SpecJSON != optionsRegimeWindowsSpecJSON {
+		t.Errorf("options spec = %q", req.Key.SpecJSON)
+	}
+	if !req.AllowSpotFallback {
+		t.Error("options requests must allow the BinanceUS fallback (parity with check_options)")
+	}
+	if req.OhlcvLimit != optionsRegimeOhlcvLimit || req.MinBars != optionsRegimeMinBars {
+		t.Errorf("options limits = %d/%d", req.OhlcvLimit, req.MinBars)
+	}
+}
+
+func TestCollectRegimeBundleRequestsDedupesPeers(t *testing.T) {
+	rc := testRegimeConfig()
+	due := []StrategyConfig{
+		{ID: "hl-a", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}},
+		{ID: "hl-b", Type: "perps", Platform: "hyperliquid", Args: []string{"mean_reversion", "BTC", "1h"}}, // same signature
+		{ID: "hl-c", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "ETH", "1h"}},
+		{ID: "hl-manual", Type: "manual", Platform: "hyperliquid", Symbol: "BTC", Args: []string{"hold", "BTC", "1h"}}, // same as hl-a/hl-b
+		{ID: "deribit-theta", Type: "options", Platform: "deribit", Args: []string{"theta_harvest", "BTC"}},
+	}
+	reqs := collectRegimeBundleRequests(due, rc)
+	if len(reqs) != 3 {
+		t.Fatalf("expected 3 distinct signatures, got %d: %+v", len(reqs), reqs)
+	}
+	// Deterministic order: sorted by platform/symbol/timeframe/spec.
+	if reqs[0].Key.Platform != "deribit" || reqs[1].Key.Symbol != "BTC" || reqs[2].Key.Symbol != "ETH" {
+		t.Errorf("unexpected order: %+v", reqs)
+	}
+}
+
+func TestCollectRegimeBundleRequestsDisabledKeepsOptions(t *testing.T) {
+	due := []StrategyConfig{
+		{ID: "hl-a", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}},
+		{ID: "deribit-theta", Type: "options", Platform: "deribit", Args: []string{"theta_harvest", "BTC"}},
+	}
+	reqs := collectRegimeBundleRequests(due, nil)
+	if len(reqs) != 1 || reqs[0].Key.Platform != "deribit" {
+		t.Fatalf("disabled regime must keep only the options signature, got %+v", reqs)
+	}
+}
+
+// ─── subprocess output parsing ───────────────────────────────────────────────
+
+func TestParseRegimeBundleOutput(t *testing.T) {
+	key := regimeBundleKey{Platform: "hyperliquid", Symbol: "BTC", Timeframe: "1h", SpecJSON: "{}"}
+	now := time.Now().UTC()
+	raw := `{"platform":"hyperliquid","symbol":"BTC","timeframe":"1h","bar_time":"2026-06-09T12:00:00+00:00",` +
+		`"regime":{"default":{"regime":"trending_up","score":0.42,"classifier":"adx","metrics":{"adx":31.5}}},` +
+		`"views":{"default":{"adx3":"trending_up","composite7":"trending_up_choppy"}}}`
+	b, err := parseRegimeBundleOutput(key, []byte(raw), now)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := b.Payload.Label("default", nil); got != "trending_up" {
+		t.Errorf("label = %q", got)
+	}
+	// RawRegimeJSON must preserve the subprocess's exact bytes (incl. fields
+	// Go doesn't model, e.g. "classifier") for --regime-payload-json.
+	if !strings.Contains(b.RawRegimeJSON, `"classifier":"adx"`) {
+		t.Errorf("raw payload lost subprocess fields: %s", b.RawRegimeJSON)
+	}
+	if b.Views["default"].Composite7 != "trending_up_choppy" {
+		t.Errorf("views = %+v", b.Views)
+	}
+	if b.BarTime != "2026-06-09T12:00:00+00:00" {
+		t.Errorf("bar_time = %q", b.BarTime)
+	}
+}
+
+func TestParseRegimeBundleOutputErrors(t *testing.T) {
+	key := regimeBundleKey{Platform: "hyperliquid", Symbol: "BTC", Timeframe: "1h"}
+	now := time.Now().UTC()
+	cases := map[string]string{
+		"script error":   `{"regime":null,"error":"Insufficient data: 3 candles (need 30)"}`,
+		"missing regime": `{"platform":"hyperliquid"}`,
+		"empty regime":   `{"regime":{}}`,
+		"bad json":       `not-json`,
+	}
+	for name, raw := range cases {
+		if _, err := parseRegimeBundleOutput(key, []byte(raw), now); err == nil {
+			t.Errorf("%s: expected error", name)
+		}
+	}
+}
+
+// ─── store population + failure policy ───────────────────────────────────────
+
+func stubRegimeBundleCheck(t *testing.T, fn func(regimeBundleRequest) (*RegimeBundle, error)) {
+	t.Helper()
+	orig := runRegimeBundleCheckFn
+	runRegimeBundleCheckFn = fn
+	t.Cleanup(func() { runRegimeBundleCheckFn = orig })
+}
+
+func TestPopulateRegimeStoreSharesBundleAcrossPeers(t *testing.T) {
+	rc := testRegimeConfig()
+	due := []StrategyConfig{
+		{ID: "hl-a", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}},
+		{ID: "hl-b", Type: "perps", Platform: "hyperliquid", Args: []string{"mean_reversion", "BTC", "1h"}},
+	}
+	var calls int
+	stubRegimeBundleCheck(t, func(req regimeBundleRequest) (*RegimeBundle, error) {
+		calls++
+		payload := RegimePayload{Legacy: "trending_up"}
+		return &RegimeBundle{Key: req.Key, Payload: payload, RawRegimeJSON: `"trending_up"`, At: time.Now().UTC()}, nil
+	})
+	store := &RegimeStore{}
+	populateRegimeStore(store, due, rc, nil)
+	if calls != 1 {
+		t.Fatalf("two peers sharing a signature must compute ONCE, got %d calls", calls)
+	}
+	for _, sc := range due {
+		if got := store.PayloadForStrategy(sc, rc).Label("", rc); got != "trending_up" {
+			t.Errorf("%s: label = %q, want trending_up", sc.ID, got)
+		}
+	}
+}
+
+func TestPopulateRegimeStoreFailureYieldsEmptyPayload(t *testing.T) {
+	// Issue #879 failure policy (b): a failed bundle leaves no entry — the
+	// payload is empty (gate fails open, regime=-) and the check script still
+	// receives the flag with an EMPTY value so it never recomputes inline.
+	rc := testRegimeConfig()
+	sc := StrategyConfig{ID: "hl-a", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}}
+	stubRegimeBundleCheck(t, func(req regimeBundleRequest) (*RegimeBundle, error) {
+		return nil, fmt.Errorf("regime bundle %s: boom", req.Key)
+	})
+	store := &RegimeStore{}
+	populateRegimeStore(store, []StrategyConfig{sc}, rc, nil)
+
+	if payload := store.PayloadForStrategy(sc, rc); !payload.IsEmpty() {
+		t.Errorf("failed bundle must yield an empty payload, got %+v", payload)
+	}
+	if label, blocked := applyRegimeGate(StrategyConfig{AllowedRegimes: []string{"trending_up"}}, store.PayloadForStrategy(sc, rc), rc, 0); blocked {
+		t.Errorf("entry gate must FAIL OPEN on empty label, blocked with label %q", label)
+	}
+	raw, ok := store.InjectionJSONForStrategy(sc, rc)
+	if !ok || raw != "" {
+		t.Errorf("injection = (%q, %v), want empty-value flag presence", raw, ok)
+	}
+}
+
+func TestInjectionJSONOmittedWhenRegimeDisabled(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-a", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}}
+	store := &RegimeStore{}
+	if _, ok := store.InjectionJSONForStrategy(sc, nil); ok {
+		t.Error("no signature (regime disabled) must omit the flag so manual CLI runs keep the inline path")
+	}
+}
+
+func TestPopulateRegimeStoreClearsPriorCycle(t *testing.T) {
+	rc := testRegimeConfig()
+	sc := StrategyConfig{ID: "hl-a", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}}
+	ok := true
+	stubRegimeBundleCheck(t, func(req regimeBundleRequest) (*RegimeBundle, error) {
+		if !ok {
+			return nil, fmt.Errorf("outage")
+		}
+		return &RegimeBundle{Key: req.Key, Payload: RegimePayload{Legacy: "trending_up"}, RawRegimeJSON: `"trending_up"`, At: time.Now().UTC()}, nil
+	})
+	store := &RegimeStore{}
+	populateRegimeStore(store, []StrategyConfig{sc}, rc, nil)
+	if store.PayloadForStrategy(sc, rc).IsEmpty() {
+		t.Fatal("first cycle should have a payload")
+	}
+	// Next cycle the subprocess fails: NO reuse-last — the store is rebuilt
+	// empty (a strategy must not open against a stale label during an outage).
+	ok = false
+	populateRegimeStore(store, []StrategyConfig{sc}, rc, nil)
+	if !store.PayloadForStrategy(sc, rc).IsEmpty() {
+		t.Error("failed cycle must not serve the previous cycle's label")
+	}
+}
+
+func TestRegimeBundleCheckArgs(t *testing.T) {
+	req := regimeBundleRequest{
+		Key:        regimeBundleKey{Platform: "hyperliquid", Symbol: "BTC", Timeframe: "1h", SpecJSON: `{"default":{"period":14}}`},
+		OhlcvLimit: 200,
+		MinBars:    30,
+	}
+	args := strings.Join(regimeBundleCheckArgs(req), " ")
+	for _, want := range []string{"--platform hyperliquid", "--symbol BTC", "--timeframe 1h", "--ohlcv-limit 200", "--min-bars 30"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("args missing %q: %s", want, args)
+		}
+	}
+	if strings.Contains(args, "--allow-spot-fallback") {
+		t.Error("non-options request must not allow spot fallback")
+	}
+	req.AllowSpotFallback = true
+	if !strings.Contains(strings.Join(regimeBundleCheckArgs(req), " "), "--allow-spot-fallback") {
+		t.Error("options request must pass --allow-spot-fallback")
+	}
+}
+
+// ─── dashboard projection ────────────────────────────────────────────────────
+
+func TestUIRegimeEntriesProjection(t *testing.T) {
+	store := &RegimeStore{}
+	store.resetForCycle(time.Now().UTC())
+	payloadJSON := `{"medium":{"regime":"trending_up","score":0.4,"metrics":{"adx":28.0}}}`
+	var payload RegimePayload
+	if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	store.set(&RegimeBundle{
+		Key:           regimeBundleKey{Platform: "hyperliquid", Symbol: "BTC", Timeframe: "1h"},
+		Payload:       payload,
+		RawRegimeJSON: payloadJSON,
+		Views:         map[string]RegimeBundleViews{"medium": {ADX3: "trending_up", Composite7: "trending_up_clean"}},
+		BarTime:       "2026-06-09T12:00:00+00:00",
+		At:            time.Now().UTC(),
+	})
+	entries, _ := uiRegimeEntries(store)
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d", len(entries))
+	}
+	w := entries[0].Windows["medium"]
+	if w.Regime != "trending_up" || w.ADX3 != "trending_up" || w.Composite7 != "trending_up_clean" {
+		t.Errorf("window = %+v", w)
+	}
+	if entries[0].Platform != "hyperliquid" || entries[0].BarTime == "" {
+		t.Errorf("entry = %+v", entries[0])
+	}
+}

--- a/scheduler/regime_store_test.go
+++ b/scheduler/regime_store_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -168,7 +169,7 @@ func TestParseRegimeBundleOutputErrors(t *testing.T) {
 
 // ─── store population + failure policy ───────────────────────────────────────
 
-func stubRegimeBundleCheck(t *testing.T, fn func(regimeBundleRequest) (*RegimeBundle, error)) {
+func stubRegimeBundleCheck(t *testing.T, fn func(context.Context, regimeBundleRequest) (*RegimeBundle, error)) {
 	t.Helper()
 	orig := runRegimeBundleCheckFn
 	runRegimeBundleCheckFn = fn
@@ -182,7 +183,7 @@ func TestPopulateRegimeStoreSharesBundleAcrossPeers(t *testing.T) {
 		{ID: "hl-b", Type: "perps", Platform: "hyperliquid", Args: []string{"mean_reversion", "BTC", "1h"}},
 	}
 	var calls int
-	stubRegimeBundleCheck(t, func(req regimeBundleRequest) (*RegimeBundle, error) {
+	stubRegimeBundleCheck(t, func(_ context.Context, req regimeBundleRequest) (*RegimeBundle, error) {
 		calls++
 		payload := RegimePayload{Legacy: "trending_up"}
 		return &RegimeBundle{Key: req.Key, Payload: payload, RawRegimeJSON: `"trending_up"`, At: time.Now().UTC()}, nil
@@ -205,7 +206,7 @@ func TestPopulateRegimeStoreFailureYieldsEmptyPayload(t *testing.T) {
 	// receives the flag with an EMPTY value so it never recomputes inline.
 	rc := testRegimeConfig()
 	sc := StrategyConfig{ID: "hl-a", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}}
-	stubRegimeBundleCheck(t, func(req regimeBundleRequest) (*RegimeBundle, error) {
+	stubRegimeBundleCheck(t, func(_ context.Context, req regimeBundleRequest) (*RegimeBundle, error) {
 		return nil, fmt.Errorf("regime bundle %s: boom", req.Key)
 	})
 	store := &RegimeStore{}
@@ -235,7 +236,7 @@ func TestPopulateRegimeStoreClearsPriorCycle(t *testing.T) {
 	rc := testRegimeConfig()
 	sc := StrategyConfig{ID: "hl-a", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}}
 	ok := true
-	stubRegimeBundleCheck(t, func(req regimeBundleRequest) (*RegimeBundle, error) {
+	stubRegimeBundleCheck(t, func(_ context.Context, req regimeBundleRequest) (*RegimeBundle, error) {
 		if !ok {
 			return nil, fmt.Errorf("outage")
 		}
@@ -257,20 +258,42 @@ func TestPopulateRegimeStoreClearsPriorCycle(t *testing.T) {
 
 func TestRegimeStoreSetAfterSealDiscards(t *testing.T) {
 	store := &RegimeStore{}
-	store.resetForCycle(time.Now().UTC())
+	gen := store.resetForCycle(time.Now().UTC())
 	key := regimeBundleKey{Platform: "hyperliquid", Symbol: "BTC", Timeframe: "1h"}
 	if kept := store.seal(); kept != 0 {
 		t.Fatalf("seal kept = %d", kept)
 	}
-	store.set(&RegimeBundle{Key: key, Payload: RegimePayload{Legacy: "trending_up"}})
+	store.set(&RegimeBundle{Key: key, Payload: RegimePayload{Legacy: "trending_up"}}, gen)
 	if _, ok := store.get(key); ok {
 		t.Error("a sealed store must discard late bundles (no mid-cycle flips)")
 	}
-	// A new cycle unseals.
-	store.resetForCycle(time.Now().UTC())
-	store.set(&RegimeBundle{Key: key, Payload: RegimePayload{Legacy: "trending_up"}})
+	// A new cycle unseals — but only same-generation writes land.
+	gen2 := store.resetForCycle(time.Now().UTC())
+	store.set(&RegimeBundle{Key: key, Payload: RegimePayload{Legacy: "trending_up"}}, gen2)
 	if _, ok := store.get(key); !ok {
-		t.Error("resetForCycle must clear the seal")
+		t.Error("resetForCycle must clear the seal for the new generation")
+	}
+}
+
+func TestRegimeStoreStaleGenerationWriteDropped(t *testing.T) {
+	// Cross-cycle regression: a straggler from a budget-exceeded cycle N that
+	// completes AFTER cycle N+1 unsealed the store must not write its stale
+	// cycle-N bundle into N+1's map ("no reuse-last across cycles").
+	store := &RegimeStore{}
+	genN := store.resetForCycle(time.Now().UTC())
+	store.seal() // cycle N exceeded its budget
+	genN1 := store.resetForCycle(time.Now().UTC())
+	if genN1 == genN {
+		t.Fatal("resetForCycle must advance the generation")
+	}
+	key := regimeBundleKey{Platform: "hyperliquid", Symbol: "BTC", Timeframe: "1h"}
+	store.set(&RegimeBundle{Key: key, Payload: RegimePayload{Legacy: "trending_up"}}, genN)
+	if _, ok := store.get(key); ok {
+		t.Error("stale-generation straggler write must be dropped after the next cycle's reset")
+	}
+	store.set(&RegimeBundle{Key: key, Payload: RegimePayload{Legacy: "trending_down"}}, genN1)
+	if b, ok := store.get(key); !ok || b.Payload.Legacy != "trending_down" {
+		t.Error("current-generation write must land")
 	}
 }
 
@@ -286,7 +309,7 @@ func TestRegimeStorePhaseBudgetSealsStragglers(t *testing.T) {
 	fast := StrategyConfig{ID: "hl-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}}
 	slow := StrategyConfig{ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "ETH", "1h"}}
 	release := make(chan struct{})
-	stubRegimeBundleCheck(t, func(req regimeBundleRequest) (*RegimeBundle, error) {
+	stubRegimeBundleCheck(t, func(_ context.Context, req regimeBundleRequest) (*RegimeBundle, error) {
 		if req.Key.Symbol == "ETH" {
 			<-release // hung subprocess
 		}
@@ -338,7 +361,7 @@ func TestRegimeBundleCheckArgs(t *testing.T) {
 
 func TestUIRegimeEntriesProjection(t *testing.T) {
 	store := &RegimeStore{}
-	store.resetForCycle(time.Now().UTC())
+	gen := store.resetForCycle(time.Now().UTC())
 	payloadJSON := `{"medium":{"regime":"trending_up","score":0.4,"metrics":{"adx":28.0}}}`
 	var payload RegimePayload
 	if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
@@ -351,7 +374,7 @@ func TestUIRegimeEntriesProjection(t *testing.T) {
 		Views:         map[string]RegimeBundleViews{"medium": {ADX3: "trending_up", Composite7: "trending_up_clean"}},
 		BarTime:       "2026-06-09T12:00:00+00:00",
 		At:            time.Now().UTC(),
-	})
+	}, gen)
 	entries, _ := uiRegimeEntries(store)
 	if len(entries) != 1 {
 		t.Fatalf("entries = %d", len(entries))

--- a/scheduler/regime_store_test.go
+++ b/scheduler/regime_store_test.go
@@ -255,6 +255,64 @@ func TestPopulateRegimeStoreClearsPriorCycle(t *testing.T) {
 	}
 }
 
+func TestRegimeStoreSetAfterSealDiscards(t *testing.T) {
+	store := &RegimeStore{}
+	store.resetForCycle(time.Now().UTC())
+	key := regimeBundleKey{Platform: "hyperliquid", Symbol: "BTC", Timeframe: "1h"}
+	if kept := store.seal(); kept != 0 {
+		t.Fatalf("seal kept = %d", kept)
+	}
+	store.set(&RegimeBundle{Key: key, Payload: RegimePayload{Legacy: "trending_up"}})
+	if _, ok := store.get(key); ok {
+		t.Error("a sealed store must discard late bundles (no mid-cycle flips)")
+	}
+	// A new cycle unseals.
+	store.resetForCycle(time.Now().UTC())
+	store.set(&RegimeBundle{Key: key, Payload: RegimePayload{Legacy: "trending_up"}})
+	if _, ok := store.get(key); !ok {
+		t.Error("resetForCycle must clear the seal")
+	}
+}
+
+func TestRegimeStorePhaseBudgetSealsStragglers(t *testing.T) {
+	// A hanging signature must not stall the cycle past the phase budget, and
+	// its late result must be discarded — the signature fails open this cycle
+	// instead of flipping mid-fan-out.
+	origBudget := regimeStorePhaseBudget
+	regimeStorePhaseBudget = 50 * time.Millisecond
+	t.Cleanup(func() { regimeStorePhaseBudget = origBudget })
+
+	rc := testRegimeConfig()
+	fast := StrategyConfig{ID: "hl-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}}
+	slow := StrategyConfig{ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "ETH", "1h"}}
+	release := make(chan struct{})
+	stubRegimeBundleCheck(t, func(req regimeBundleRequest) (*RegimeBundle, error) {
+		if req.Key.Symbol == "ETH" {
+			<-release // hung subprocess
+		}
+		return &RegimeBundle{Key: req.Key, Payload: RegimePayload{Legacy: "trending_up"}, RawRegimeJSON: `"trending_up"`, At: time.Now().UTC()}, nil
+	})
+
+	store := &RegimeStore{}
+	wait := startRegimeStorePopulation(store, []StrategyConfig{fast, slow}, rc, nil)
+	start := time.Now()
+	wait()
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("wait exceeded the phase budget by far: %s", elapsed)
+	}
+	if store.PayloadForStrategy(fast, rc).IsEmpty() {
+		t.Error("fast signature should have landed before the budget expired")
+	}
+	if !store.PayloadForStrategy(slow, rc).IsEmpty() {
+		t.Error("hung signature must fail open this cycle")
+	}
+	close(release) // straggler completes after the seal
+	time.Sleep(100 * time.Millisecond)
+	if !store.PayloadForStrategy(slow, rc).IsEmpty() {
+		t.Error("straggler result after seal must be discarded, not applied mid-cycle")
+	}
+}
+
 func TestRegimeBundleCheckArgs(t *testing.T) {
 	req := regimeBundleRequest{
 		Key:        regimeBundleKey{Platform: "hyperliquid", Symbol: "BTC", Timeframe: "1h", SpecJSON: `{"default":{"period":14}}`},

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -195,6 +195,7 @@ func (ss *StatusServer) Start(port int) {
 	mux.HandleFunc("/dashboard/", ss.handleDashboard)
 	mux.HandleFunc("/api/strategies", ss.handleAPIStrategies)
 	mux.HandleFunc("/api/strategies/overview", ss.handleAPIStrategiesOverview)
+	mux.HandleFunc("/api/regime", ss.handleAPIRegime)
 	mux.HandleFunc("/api/strategies/", ss.handleAPIStrategy)
 
 	listener, boundPort, err := bindWithFallback(port, statusPortMaxAttempts)

--- a/scheduler/strategy_composition.go
+++ b/scheduler/strategy_composition.go
@@ -134,6 +134,19 @@ func appendRegimeArgs(args []string, regime *RegimeConfig) []string {
 	return out
 }
 
+// appendRegimePayloadArg injects the per-cycle global-store regime payload
+// (#879). Presence of the flag — even with an EMPTY value after a bundle
+// failure — tells the check script to skip inline regime computation and
+// resolve fail-open; omitting it (regime disabled / no signature) leaves the
+// script's inline path untouched for manual CLI invocations.
+func appendRegimePayloadArg(args []string, sc StrategyConfig, regime *RegimeConfig) []string {
+	raw, ok := globalRegimeStore.InjectionJSONForStrategy(sc, regime)
+	if !ok {
+		return args
+	}
+	return append(args, "--regime-payload-json", raw)
+}
+
 func appendStrategyRegimeWindowArgs(args []string, sc StrategyConfig, regime *RegimeConfig) []string {
 	if regime == nil || !regime.Enabled || !regimeMultiWindowEnabled(regime) {
 		return args

--- a/scheduler/ui_regime.go
+++ b/scheduler/ui_regime.go
@@ -1,0 +1,87 @@
+package main
+
+// ui_regime.go — portfolio-level regime view (#879).
+//
+// GET /api/regime serves the current cycle's global regime store: one entry
+// per distinct (data platform, symbol, timeframe, spec) signature, with the
+// per-window classifier snapshots plus both-vocabulary views (adx3 always
+// from the real full-period ADX classifier). This is the market-property
+// regime surface the per-strategy dashboard endpoints can't provide — it
+// exists even for flat manual strategies and is identical across peers.
+
+import (
+	"net/http"
+	"time"
+)
+
+// UIRegimeWindow is one window's snapshot in the API response.
+type UIRegimeWindow struct {
+	Regime     string             `json:"regime"`
+	Score      float64            `json:"score"`
+	Metrics    map[string]float64 `json:"metrics,omitempty"`
+	ADX3       string             `json:"adx3,omitempty"`
+	Composite7 string             `json:"composite7,omitempty"`
+}
+
+// UIRegimeEntry is one store bundle in the API response.
+type UIRegimeEntry struct {
+	Platform  string                    `json:"platform"`
+	Symbol    string                    `json:"symbol"`
+	Timeframe string                    `json:"timeframe"`
+	BarTime   string                    `json:"bar_time,omitempty"`
+	Windows   map[string]UIRegimeWindow `json:"windows"`
+	At        time.Time                 `json:"at"`
+}
+
+// uiRegimeEntries projects the store snapshot into the API shape.
+func uiRegimeEntries(store *RegimeStore) ([]UIRegimeEntry, time.Time) {
+	bundles, builtAt := store.Snapshot()
+	out := make([]UIRegimeEntry, 0, len(bundles))
+	for _, b := range bundles {
+		windows := make(map[string]UIRegimeWindow)
+		if b.Payload.MultiMode {
+			for name, snap := range b.Payload.Windows {
+				windows[name] = UIRegimeWindow{Regime: snap.Regime, Score: snap.Score, Metrics: snap.Metrics}
+			}
+		} else if b.Payload.Legacy != "" {
+			windows[regimeWindowDefaultKey] = UIRegimeWindow{Regime: b.Payload.Legacy}
+		}
+		for name, views := range b.Views {
+			w := windows[name]
+			w.ADX3 = views.ADX3
+			w.Composite7 = views.Composite7
+			windows[name] = w
+		}
+		out = append(out, UIRegimeEntry{
+			Platform:  b.Key.Platform,
+			Symbol:    b.Key.Symbol,
+			Timeframe: b.Key.Timeframe,
+			BarTime:   b.BarTime,
+			Windows:   windows,
+			At:        b.At,
+		})
+	}
+	return out, builtAt
+}
+
+func (ss *StatusServer) handleAPIRegime(w http.ResponseWriter, r *http.Request) {
+	if ss.rejectIfDraining(w) {
+		return
+	}
+	if !ss.requireAPIAuth(w, r) {
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if r.URL.Path != "/api/regime" && r.URL.Path != "/api/regime/" {
+		http.NotFound(w, r)
+		return
+	}
+	entries, builtAt := uiRegimeEntries(globalRegimeStore)
+	writeJSON(w, map[string]interface{}{
+		"built_at": builtAt,
+		"regimes":  entries,
+	})
+}

--- a/scheduler/version_probe.go
+++ b/scheduler/version_probe.go
@@ -36,6 +36,9 @@ var probeArgv = []string{
 	"--ohlcv-limit", "200",
 	"--regime-windows-spec-json", `{"default":{"classifier":"adx","period":14,"adx_threshold":20}}`,
 	"--regime-atr-window", "",
+	// #879: new Go injects the global-store regime payload on every check;
+	// probe it so a stale Python that rejects the flag fails startup loudly.
+	"--regime-payload-json", `{"default":{"regime":"trending_up","score":0.5,"classifier":"adx","metrics":{"adx":25.0,"plus_di":20.0,"minus_di":10.0,"atr_pct":1.0}}}`,
 	"--probe-only",
 }
 
@@ -48,6 +51,7 @@ var probeCompositeArgv = []string{
 	"--ohlcv-limit", "200",
 	"--regime-windows-spec-json", `{"macro":{"classifier":"composite","period":14,"thresholds":{"return_pct":0.05,"range_pct":0.03,"adx":25}}}`,
 	"--regime-atr-window", "",
+	"--regime-payload-json", `{"macro":{"regime":"trending_up_clean","score":0.5,"classifier":"composite","metrics":{"adx":30.0}}}`,
 	"--probe-only",
 }
 
@@ -100,6 +104,17 @@ var cancelOrderProbeArgv = []string{
 // catch stale Python deploys before the dashboard starts returning 500s.
 var fetchCandlesProbeArgv = []string{
 	"--platform=binanceus", "--type=spot", "--symbol=BTC/USDT", "--timeframe=1h", "--limit=1", "--probe-only",
+}
+
+// checkRegimeProbeArgv probes the #879 dedicated regime-bundle subprocess.
+// Probed whenever any strategy is configured (mirrors the tuner-schema
+// precedent): the scheduler spawns it per distinct regime signature each
+// cycle, so a missing/stale script must fail at startup, not mid-cycle.
+var checkRegimeProbeArgv = []string{
+	"--platform=binanceus", "--symbol=BTC/USDT", "--timeframe=1h",
+	"--regime-windows-spec-json", `{"default":{"classifier":"adx","period":14,"adx_threshold":20}}`,
+	"--ohlcv-limit", "200", "--min-bars", "30",
+	"--probe-only",
 }
 
 var strategyTunerSchemaProbeArgv = []string{
@@ -165,6 +180,9 @@ func probeCheckScripts(cfg *Config) error {
 			return err
 		}
 		if err := probeOneCheckScriptFn("shared_scripts/strategy_tuner_schema.py", strategyTunerSchemaProbeArgv); err != nil {
+			return err
+		}
+		if err := probeOneCheckScriptFn(regimeCheckScript, checkRegimeProbeArgv); err != nil {
 			return err
 		}
 		if err := probeOneCheckScriptFn("shared_scripts/simulate_strategy.py", simulateStrategyProbeArgv); err != nil {

--- a/scheduler/version_probe_test.go
+++ b/scheduler/version_probe_test.go
@@ -58,6 +58,7 @@ exec /usr/bin/env python3 "$@"
 	writeProbeStub(t, fetchDir, "fetch_candles.py", true)
 	writeProbeStub(t, fetchDir, "strategy_tuner_schema.py", true)
 	writeProbeStub(t, fetchDir, "simulate_strategy.py", true)
+	writeProbeStub(t, fetchDir, "check_regime.py", true)
 
 	prevCwd, _ := os.Getwd()
 	if err := os.Chdir(tmp); err != nil {

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -99,6 +99,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
                      close_strategies=None,
                      position_side="", position_ctx=None,
                      regime_enabled=False, regime_windows_spec=None, ohlcv_limit=200, regime_atr_window="",
+                     regime_payload_json=None,
                      close_params_by_name=None,
                      mark_price=0.0):
     """Run strategy signal check using Hyperliquid OHLCV data."""
@@ -171,6 +172,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             regime_enabled=regime_enabled,
             windows_spec=regime_windows_spec,
             atr_window=regime_atr_window,
+            injected_payload_json=regime_payload_json,
         )
         strategy_params["regime"] = strategy_regime
         if strategy_params_override:
@@ -1641,6 +1643,9 @@ def main():
         parser.add_argument("--regime-windows-spec-json", default="")
         parser.add_argument("--ohlcv-limit", type=int, default=200)
         parser.add_argument("--regime-atr-window", default="")
+        # #879: precomputed global-store regime payload; presence (even empty)
+        # disables inline regime computation.
+        parser.add_argument("--regime-payload-json", default=None)
         parser.add_argument("--regime-directional-window", default="")
         parser.add_argument("--params", default=None)
         parser.add_argument("--open-strategy", default=None)
@@ -1678,6 +1683,7 @@ def main():
             regime_windows_spec=regime_windows_spec,
             ohlcv_limit=args.ohlcv_limit,
             regime_atr_window=args.regime_atr_window,
+            regime_payload_json=args.regime_payload_json,
             close_params_by_name=close_params_by_name,
             mark_price=args.mark_price,
         )

--- a/shared_scripts/check_okx.py
+++ b/shared_scripts/check_okx.py
@@ -91,6 +91,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
                      open_strategy=None, close_strategies=None,
                      position_side="", position_ctx=None,
                      regime_enabled=False, regime_windows_spec=None, ohlcv_limit=200, regime_atr_window="",
+                     regime_payload_json=None,
                      close_params_by_name=None):
     """Run strategy signal check using OKX OHLCV data."""
     try:
@@ -165,6 +166,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             regime_enabled=regime_enabled,
             windows_spec=regime_windows_spec,
             atr_window=regime_atr_window,
+            injected_payload_json=regime_payload_json,
         )
         strategy_params["regime"] = strategy_regime
         if strategy_params_override:
@@ -371,6 +373,9 @@ def main():
         parser.add_argument("--regime-windows-spec-json", default="")
         parser.add_argument("--ohlcv-limit", type=int, default=200)
         parser.add_argument("--regime-atr-window", default="")
+        # #879: precomputed global-store regime payload; presence (even empty)
+        # disables inline regime computation.
+        parser.add_argument("--regime-payload-json", default=None)
         parser.add_argument("--regime-directional-window", default="")
         parser.add_argument("--inst-type", default="swap", choices=["spot", "swap"])
         parser.add_argument("--params", default=None)
@@ -406,6 +411,7 @@ def main():
             regime_windows_spec=regime_windows_spec,
             ohlcv_limit=args.ohlcv_limit,
             regime_atr_window=args.regime_atr_window,
+            regime_payload_json=args.regime_payload_json,
             close_params_by_name=close_params_by_name,
         )
 

--- a/shared_scripts/check_options.py
+++ b/shared_scripts/check_options.py
@@ -20,7 +20,7 @@ _REPO_ROOT = os.path.dirname(_THIS_DIR)
 sys.path.insert(0, _REPO_ROOT)
 sys.path.insert(0, os.path.join(_REPO_ROOT, "shared_tools"))
 
-from regime import latest_regime
+from regime import latest_regime, regime_from_injected_payload
 
 MAX_POSITIONS_PER_STRATEGY = 4
 MIN_SCORE_THRESHOLD = 0.3
@@ -409,15 +409,22 @@ def main():
     # #645: startup compatibility probe — exit 0 without running the strategy.
     if "--probe-only" in sys.argv:
         sys.exit(0)
-    # Parse args: strip --platform= before positional parsing
+    # Parse args: strip --platform= / --regime-payload-json= before positional parsing
     args = sys.argv[1:]
     platform = "deribit"
+    # #879: precomputed global-store regime payload; presence (even empty)
+    # disables the inline 4h regime fetch. None when the flag is absent.
+    regime_payload_json = None
     remaining = []
     for arg in args:
         if arg.startswith("--platform="):
             platform = arg.split("=", 1)[1]
         elif arg.startswith("--platform"):
             pass  # bare flag without value, ignore
+        elif arg.startswith("--regime-payload-json="):
+            regime_payload_json = arg.split("=", 1)[1]
+        elif arg.startswith("--regime-payload-json"):
+            regime_payload_json = ""
         else:
             remaining.append(arg)
 
@@ -498,9 +505,17 @@ def main():
 
         vol_annual, iv_rank = adapter.get_vol_metrics(underlying)
 
-        regime_df = _fetch_ohlcv_df(underlying, REGIME_TIMEFRAME, REGIME_LIMIT,
-                                    REGIME_MIN_BARS, adapter=adapter)
-        regime_label = _regime_label_from_df(regime_df)
+        if regime_payload_json is not None:
+            # #879: Go injected the precomputed bundle for this underlying's
+            # (4h, ADX) signature — never refetch/recompute inline. An empty
+            # injection (regime-subprocess failure) resolves to None, the same
+            # value the inline path emits on a failed fetch.
+            _, _, regime_snap = regime_from_injected_payload(regime_payload_json)
+            regime_label = str(regime_snap.get("regime") or "") or None
+        else:
+            regime_df = _fetch_ohlcv_df(underlying, REGIME_TIMEFRAME, REGIME_LIMIT,
+                                        REGIME_MIN_BARS, adapter=adapter)
+            regime_label = _regime_label_from_df(regime_df)
 
         evaluate_fn = STRATEGY_MAP[strategy_name]
         signal, actions, iv_rank = evaluate_fn(

--- a/shared_scripts/check_regime.py
+++ b/shared_scripts/check_regime.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Dedicated regime-bundle subprocess for the Go scheduler (#879).
+
+Computes the market regime once per distinct (platform, symbol, timeframe,
+windows-spec) signature per scheduler cycle. The Go scheduler stores the
+emitted bundle in its per-cycle global regime store and injects it into each
+check script via --regime-payload-json, so peer strategies sharing a signature
+never recompute regime math inline.
+
+Usage:
+    check_regime.py --platform hyperliquid --symbol BTC --timeframe 1h \
+        --regime-windows-spec-json '{"default":{"classifier":"adx","period":14,"adx_threshold":20}}' \
+        --ohlcv-limit 200
+
+Output (stdout, JSON):
+    {
+      "platform": "...", "symbol": "...", "timeframe": "...",
+      "bar_time": "<ISO timestamp of the last bar in the fetched frame>",
+      "regime": {"<window>": {"regime","score","classifier","metrics"}, ...},
+      "views":  {"<window>": {"adx3": "...", "composite7": "..."}, ...},
+      "timestamp": "<now>"
+    }
+
+The "regime" map is byte-compatible with the multi-window payload check
+scripts emit from prepare_check_regime, so RegimePayload on the Go side and
+regime_from_injected_payload on the Python side both consume it unchanged.
+The "views" map adds both classifier vocabularies per window for the
+portfolio/dashboard regime surface: "adx3" always runs the real ADX
+classifier at the window's FULL period (exact parity with a standalone ADX
+window even when period > COMPOSITE_ADX_PERIOD_CAP), never a prefix-collapse
+of the composite label.
+
+Errors follow the subprocess contract: JSON with "error" on stdout, exit 1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(_REPO_ROOT, "shared_tools"))
+
+from regime import (  # noqa: E402
+    CLASSIFIER_ADX,
+    CLASSIFIER_COMPOSITE,
+    _DEFAULT_COMPOSITE_THRESHOLDS,
+    compute_multi_regime,
+    latest_regime,
+    latest_regime_composite,
+    parse_regime_windows_spec_json,
+)
+
+
+def _emit_error(args, message: str) -> None:
+    print(json.dumps({
+        "platform": getattr(args, "platform", ""),
+        "symbol": getattr(args, "symbol", ""),
+        "timeframe": getattr(args, "timeframe", ""),
+        "regime": None,
+        "error": message,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }))
+    sys.exit(1)
+
+
+def _load_adapter(platform: str):
+    """Load ExchangeAdapter from platforms/<platform>/adapter.py (one per file).
+
+    Mirrors check_options.py: insert the platform dir into sys.path before
+    exec (the HL adapter needs its dir first to win the SDK name clash).
+    """
+    adapter_path = os.path.join(_REPO_ROOT, "platforms", platform, "adapter.py")
+    if not os.path.exists(adapter_path):
+        raise ImportError(f"No adapter found for platform '{platform}' at {adapter_path}")
+    platform_dir = os.path.dirname(adapter_path)
+    if platform_dir not in sys.path:
+        sys.path.insert(0, platform_dir)
+    spec = importlib.util.spec_from_file_location(f"{platform}_adapter", adapter_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    for name in dir(module):
+        if name.endswith("ExchangeAdapter"):
+            return getattr(module, name)()
+    raise AttributeError(f"No ExchangeAdapter class found in {adapter_path}")
+
+
+def _make_dataframe(candles):
+    """Raw OHLCV rows -> DataFrame; mirrors the per-platform check scripts."""
+    import pandas as pd
+
+    df = pd.DataFrame(candles, columns=["timestamp", "open", "high", "low", "close", "volume"])
+    df["datetime"] = pd.to_datetime(df["timestamp"], unit="ms", utc=True)
+    df = df.set_index("datetime")
+    df.sort_index(inplace=True)
+    return df
+
+
+def _fetch_dataframe(args):
+    """Fetch OHLCV from the same source the strategy's check script uses.
+
+    binanceus -> shared_tools data_fetcher (default-spot check_strategy.py
+    path); every other platform -> its ExchangeAdapter.get_ohlcv. When
+    --allow-spot-fallback is set (options strategies), an adapter without
+    get_ohlcv or a failed adapter fetch falls back to BinanceUS ccxt with
+    "<symbol>/USDT", mirroring check_options._fetch_ohlcv_df. Without the
+    flag there is NO cross-venue fallback: wrong-feed data is worse than an
+    empty bundle (the consumers fail open on empty).
+    """
+    platform = args.platform.strip().lower()
+    if platform == "binanceus":
+        from data_fetcher import fetch_ohlcv
+
+        return fetch_ohlcv(symbol=args.symbol, timeframe=args.timeframe,
+                           limit=args.ohlcv_limit, store=False)
+
+    rows = None
+    adapter_err = None
+    try:
+        adapter = _load_adapter(platform)
+        ohlcv_fn = getattr(adapter, "get_ohlcv", None)
+        if ohlcv_fn is not None:
+            rows = ohlcv_fn(args.symbol, interval=args.timeframe, limit=args.ohlcv_limit)
+        elif not args.allow_spot_fallback:
+            raise AttributeError(f"adapter for '{platform}' has no get_ohlcv")
+    except Exception as e:  # noqa: BLE001 - converted to bundle error or fallback
+        if not args.allow_spot_fallback:
+            raise
+        adapter_err = e
+        rows = None
+
+    if not rows and args.allow_spot_fallback:
+        if adapter_err is not None:
+            print(f"adapter.get_ohlcv failed: {adapter_err}", file=sys.stderr)
+        import ccxt
+
+        exchange = ccxt.binanceus({"enableRateLimit": True})
+        rows = exchange.fetch_ohlcv(f"{args.symbol}/USDT", args.timeframe, limit=args.ohlcv_limit)
+
+    if not rows:
+        return None
+    return _make_dataframe(rows)
+
+
+def _window_adx_threshold(spec: dict) -> float:
+    """ADX threshold for the 3-state view of one window spec."""
+    if spec.get("classifier") == CLASSIFIER_COMPOSITE:
+        th = spec.get("thresholds") or {}
+        return float(th.get("adx") or _DEFAULT_COMPOSITE_THRESHOLDS["adx"])
+    return float(spec.get("adx_threshold") or 20.0)
+
+
+def compute_regime_bundle(df, windows_spec: dict) -> dict:
+    """Compute the per-window snapshots + both-classifier views for one frame.
+
+    Pure (no I/O) so tests can assert parity against prepare_check_regime.
+    Snapshots come from the SAME compute_multi_regime call the check scripts
+    used pre-#879, so a consumer's label is unchanged by the migration. Views
+    run the alternate classifier per window: adx3 at the window's full period
+    (exact ADX parity past COMPOSITE_ADX_PERIOD_CAP), composite7 at the
+    window's period with its composite thresholds (defaults when the window
+    is ADX-classified).
+    """
+    snapshots = compute_multi_regime(df, windows_spec)
+    views: dict[str, dict[str, str]] = {}
+    for name in sorted(windows_spec.keys()):
+        spec = windows_spec[name]
+        period = int(spec["period"])
+        snap = snapshots.get(name) or {}
+        if spec.get("classifier") == CLASSIFIER_COMPOSITE:
+            composite7 = str(snap.get("regime") or "")
+            adx3 = str(latest_regime(df, period=period,
+                                     adx_threshold=_window_adx_threshold(spec)).get("regime") or "")
+        else:
+            adx3 = str(snap.get("regime") or "")
+            composite7 = str(latest_regime_composite(
+                df, period, spec.get("thresholds")).get("regime") or "")
+        views[name] = {"adx3": adx3, "composite7": composite7}
+    return {"regime": snapshots, "views": views}
+
+
+def main() -> None:
+    # #645-style startup compatibility probe — exit 0 before any work.
+    if "--probe-only" in sys.argv:
+        sys.exit(0)
+
+    parser = argparse.ArgumentParser(description="Compute one regime bundle (#879)")
+    parser.add_argument("--platform", required=True,
+                        help="data source: binanceus | hyperliquid | okx | topstep | robinhood | <options platform>")
+    parser.add_argument("--symbol", required=True)
+    parser.add_argument("--timeframe", required=True)
+    parser.add_argument("--regime-windows-spec-json", required=True,
+                        help="resolved window specs from Go regimeWindowsSpecJSON")
+    parser.add_argument("--ohlcv-limit", type=int, default=200)
+    parser.add_argument("--min-bars", type=int, default=30,
+                        help="insufficient-data floor; mirrors the check scripts' candle guard")
+    parser.add_argument("--allow-spot-fallback", action="store_true", default=False,
+                        help="options platforms: fall back to BinanceUS <symbol>/USDT when the adapter has no OHLCV")
+    parser.add_argument("--probe-only", action="store_true", default=False)
+    args = parser.parse_args()
+
+    try:
+        windows_spec = parse_regime_windows_spec_json(args.regime_windows_spec_json)
+        if not windows_spec:
+            _emit_error(args, "empty --regime-windows-spec-json")
+
+        df = _fetch_dataframe(args)
+        if df is None or len(df) < args.min_bars:
+            got = 0 if df is None else len(df)
+            _emit_error(args, f"Insufficient data: {got} candles (need {args.min_bars})")
+
+        bundle = compute_regime_bundle(df, windows_spec)
+
+        bar_time = ""
+        try:
+            idx_last = df.index[-1]
+            bar_time = idx_last.isoformat() if hasattr(idx_last, "isoformat") else str(idx_last)
+        except Exception:  # noqa: BLE001 - bar_time is informational only
+            bar_time = ""
+
+        print(json.dumps({
+            "platform": args.platform,
+            "symbol": args.symbol,
+            "timeframe": args.timeframe,
+            "bar_time": bar_time,
+            "regime": bundle["regime"],
+            "views": bundle["views"],
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }))
+    except SystemExit:
+        raise
+    except Exception as e:  # noqa: BLE001 - subprocess contract: JSON + exit 1
+        import traceback
+
+        traceback.print_exc(file=sys.stderr)
+        _emit_error(args, str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/shared_scripts/check_robinhood.py
+++ b/shared_scripts/check_robinhood.py
@@ -119,6 +119,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
                      close_strategies=None,
                      position_side="", position_ctx=None,
                      regime_enabled=False, regime_windows_spec=None, ohlcv_limit=200, regime_atr_window="",
+                     regime_payload_json=None,
                      close_params_by_name=None):
     """Run strategy signal check using yfinance OHLCV data."""
     try:
@@ -175,6 +176,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             regime_enabled=regime_enabled,
             windows_spec=regime_windows_spec,
             atr_window=regime_atr_window,
+            injected_payload_json=regime_payload_json,
         )
         strategy_params = (strategy_params or {})
         strategy_params["regime"] = strategy_regime
@@ -381,6 +383,9 @@ def main():
         parser.add_argument("--regime-windows-spec-json", default="")
         parser.add_argument("--ohlcv-limit", type=int, default=200)
         parser.add_argument("--regime-atr-window", default="")
+        # #879: precomputed global-store regime payload; presence (even empty)
+        # disables inline regime computation.
+        parser.add_argument("--regime-payload-json", default=None)
         parser.add_argument("--regime-directional-window", default="")
         parser.add_argument("--params", default=None)
         parser.add_argument("--open-strategy", default=None)
@@ -415,6 +420,7 @@ def main():
             regime_windows_spec=regime_windows_spec,
             ohlcv_limit=args.ohlcv_limit,
             regime_atr_window=args.regime_atr_window,
+            regime_payload_json=args.regime_payload_json,
             close_params_by_name=close_params_by_name,
         )
 

--- a/shared_scripts/check_strategy.py
+++ b/shared_scripts/check_strategy.py
@@ -78,6 +78,9 @@ def main():
     regime_windows_spec = parse_regime_windows_spec_json(_arg_value("--regime-windows-spec-json"))
     ohlcv_limit = int(_arg_value("--ohlcv-limit") or 200)
     regime_atr_window = (_arg_value("--regime-atr-window") or "").strip()
+    # #879: precomputed global-store regime payload; presence (even empty)
+    # disables inline regime computation. None when the flag is absent.
+    regime_payload_json = _arg_value("--regime-payload-json")
     open_strategy = _arg_value("--open-strategy")
     close_strategies_raw = _arg_value("--close-strategies")
     position_side = (_arg_value("--position-side", "") or "").lower()
@@ -114,6 +117,7 @@ def main():
             "--position-regime",
             "--regime-windows-spec-json", "--ohlcv-limit",
             "--regime-atr-window", "--regime-directional-window",
+            "--regime-payload-json",
         ):
             skip_next = True
             continue
@@ -213,6 +217,7 @@ def main():
             regime_enabled=regime_enabled,
             windows_spec=regime_windows_spec,
             atr_window=regime_atr_window,
+            injected_payload_json=regime_payload_json,
         )
         strategy_params = (strategy_params or {})
         strategy_params["regime"] = strategy_regime

--- a/shared_scripts/check_topstep.py
+++ b/shared_scripts/check_topstep.py
@@ -107,6 +107,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
                      close_strategies=None,
                      position_side="", position_ctx=None,
                      regime_enabled=False, regime_windows_spec=None, ohlcv_limit=200, regime_atr_window="",
+                     regime_payload_json=None,
                      close_params_by_name=None):
     """Run strategy signal check using TopStep market data."""
     try:
@@ -183,6 +184,7 @@ def run_signal_check(strategy_name, symbol, timeframe, mode, htf_filter_enabled=
             regime_enabled=regime_enabled,
             windows_spec=regime_windows_spec,
             atr_window=regime_atr_window,
+            injected_payload_json=regime_payload_json,
         )
         strategy_params = (strategy_params or {})
         strategy_params["regime"] = strategy_regime
@@ -384,6 +386,9 @@ def main():
         parser.add_argument("--regime-windows-spec-json", default="")
         parser.add_argument("--ohlcv-limit", type=int, default=200)
         parser.add_argument("--regime-atr-window", default="")
+        # #879: precomputed global-store regime payload; presence (even empty)
+        # disables inline regime computation.
+        parser.add_argument("--regime-payload-json", default=None)
         parser.add_argument("--regime-directional-window", default="")
         parser.add_argument("--params", default=None)
         parser.add_argument("--open-strategy", default=None)
@@ -418,6 +423,7 @@ def main():
             regime_windows_spec=regime_windows_spec,
             ohlcv_limit=args.ohlcv_limit,
             regime_atr_window=args.regime_atr_window,
+            regime_payload_json=args.regime_payload_json,
             close_params_by_name=close_params_by_name,
         )
 

--- a/shared_tools/regime.py
+++ b/shared_tools/regime.py
@@ -440,6 +440,59 @@ def required_ohlcv_limit(
     return max(base_limit, warmup + margin)
 
 
+def regime_from_injected_payload(
+    raw: str | None,
+    *,
+    atr_window: str = "",
+) -> tuple[dict | str, str, dict]:
+    """Resolve the (stdout_regime, live_regime, strategy_regime) triple from a
+    Go-injected precomputed payload (#879) instead of computing inline.
+
+    `raw` is the --regime-payload-json value: the multi-window snapshot map the
+    Go scheduler's global regime store holds for this strategy's signature
+    (same shape compute_multi_regime returns). Empty/blank/invalid payloads —
+    including the deliberate empty injection after a regime-subprocess failure
+    — resolve to the disabled triple so every consumer falls back to its
+    existing empty-case behavior (entry gate fails open, status shows
+    regime=-). There is NO inline recompute fallback by design.
+    """
+    disabled = {"regime": "", "score": 0.0, "metrics": dict(_DEFAULT_METRICS)}
+    text = str(raw or "").strip()
+    if not text:
+        return "", "", disabled
+    try:
+        payload = json.loads(text)
+    except (ValueError, TypeError):
+        return "", "", disabled
+    if isinstance(payload, str):
+        label = payload.strip()
+        snap = dict(disabled, regime=label) if label else disabled
+        return label, label, snap
+    if not isinstance(payload, dict) or not payload:
+        return "", "", disabled
+
+    windows: dict[str, dict] = {}
+    for name, snap in payload.items():
+        key = str(name).strip()
+        if key and isinstance(snap, dict):
+            windows[key] = snap
+    if not windows:
+        return "", "", disabled
+
+    # Primary/atr selection mirrors prepare_check_regime's multi branch: the
+    # payload keys are exactly the windows-spec keys the Go side resolved.
+    primary_key = (
+        REGIME_PRIMARY_WINDOW_KEY
+        if REGIME_PRIMARY_WINDOW_KEY in windows
+        else sorted(windows.keys())[0]
+    )
+    strategy_payload = windows.get(primary_key, disabled)
+    atr_key = (atr_window or primary_key).strip() or primary_key
+    atr_entry = windows.get(atr_key, strategy_payload)
+    live_atr = str(atr_entry.get("regime") or "")
+    return windows, live_atr, strategy_payload
+
+
 def prepare_check_regime(
     df: pd.DataFrame,
     *,
@@ -449,10 +502,16 @@ def prepare_check_regime(
     windows: dict[str, dict[str, Any]] | None = None,
     windows_spec: dict[str, dict[str, Any]] | None = None,
     atr_window: str = "",
+    injected_payload_json: str | None = None,
 ) -> tuple[dict | str, str, dict]:
     disabled = {"regime": "", "score": 0.0, "metrics": dict(_DEFAULT_METRICS)}
     if not regime_enabled:
         return "", "", disabled
+    # #879: when the Go scheduler injects the precomputed global-store payload,
+    # never recompute inline — even when the injected payload is empty (that is
+    # the explicit fail-open signal after a regime-subprocess failure).
+    if injected_payload_json is not None:
+        return regime_from_injected_payload(injected_payload_json, atr_window=atr_window)
 
     spec_map = windows_spec if windows_spec is not None else windows
     if spec_map:

--- a/shared_tools/test_regime_injection.py
+++ b/shared_tools/test_regime_injection.py
@@ -1,0 +1,190 @@
+"""Tests for #879: injected-regime payloads and the check_regime.py bundle.
+
+Parity contract: a check script receiving --regime-payload-json (the Go
+global store's bundle, computed by shared_scripts/check_regime.py) must
+resolve the exact same (stdout_regime, live_regime, strategy_regime) triple
+that prepare_check_regime computed inline pre-migration, for the same frame
+and windows spec.
+"""
+
+import importlib.util
+import json
+import pathlib
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+_spec = importlib.util.spec_from_file_location(
+    "regime", pathlib.Path(__file__).parent / "regime.py"
+)
+_regime_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_regime_mod)
+
+prepare_check_regime = _regime_mod.prepare_check_regime
+regime_from_injected_payload = _regime_mod.regime_from_injected_payload
+compute_multi_regime = _regime_mod.compute_multi_regime
+latest_regime = _regime_mod.latest_regime
+latest_regime_composite = _regime_mod.latest_regime_composite
+
+_CHECK_REGIME_PATH = (
+    pathlib.Path(__file__).parent.parent / "shared_scripts" / "check_regime.py"
+)
+_cr_spec = importlib.util.spec_from_file_location("check_regime", _CHECK_REGIME_PATH)
+_check_regime_mod = importlib.util.module_from_spec(_cr_spec)
+_cr_spec.loader.exec_module(_check_regime_mod)
+compute_regime_bundle = _check_regime_mod.compute_regime_bundle
+
+
+def _make_uptrend(n: int = 120, noise: float = 0.5) -> pd.DataFrame:
+    close = np.linspace(100.0, 200.0, n)
+    return pd.DataFrame({
+        "open": close - noise * 0.3,
+        "high": close + noise,
+        "low": close - noise,
+        "close": close,
+        "volume": np.ones(n) * 1000.0,
+    })
+
+
+_SPEC_MULTI = {
+    "short": {"classifier": "adx", "period": 10, "adx_threshold": 20.0},
+    "medium": {"classifier": "adx", "period": 14, "adx_threshold": 20.0},
+    "macro": {
+        "classifier": "composite",
+        "period": 30,
+        "thresholds": {"return_pct": 0.05, "range_pct": 0.03, "adx": 25.0, "efficiency": 0.5},
+    },
+}
+
+
+# ─── regime_from_injected_payload parity ─────────────────────────────────────
+
+
+def test_injected_payload_matches_inline_triple():
+    """Injecting the bundle the global store computed for this signature must
+    resolve the identical triple prepare_check_regime computed inline."""
+    df = _make_uptrend()
+    inline = prepare_check_regime(
+        df, regime_enabled=True, windows_spec=_SPEC_MULTI, atr_window="macro"
+    )
+    payload = compute_multi_regime(df, _SPEC_MULTI)
+    injected = regime_from_injected_payload(json.dumps(payload), atr_window="macro")
+    assert injected == inline
+
+
+def test_injected_payload_primary_window_selection():
+    """Primary snapshot picks 'medium' when present, else first sorted key —
+    mirroring prepare_check_regime's multi branch."""
+    df = _make_uptrend()
+    payload = compute_multi_regime(df, _SPEC_MULTI)
+    _, _, strategy_regime = regime_from_injected_payload(json.dumps(payload))
+    assert strategy_regime == payload["medium"]
+
+    no_medium = {k: v for k, v in payload.items() if k != "medium"}
+    _, _, strategy_regime = regime_from_injected_payload(json.dumps(no_medium))
+    assert strategy_regime == no_medium["macro"]  # sorted: macro < short
+
+
+def test_injected_payload_atr_window_label():
+    df = _make_uptrend()
+    payload = compute_multi_regime(df, _SPEC_MULTI)
+    _, live, _ = regime_from_injected_payload(json.dumps(payload), atr_window="short")
+    assert live == payload["short"]["regime"]
+    # Unknown atr window falls back to the primary snapshot's label.
+    _, live, _ = regime_from_injected_payload(json.dumps(payload), atr_window="nope")
+    assert live == payload["medium"]["regime"]
+
+
+def test_injected_payload_empty_fails_open():
+    """The Go side injects an EMPTY value after a bundle failure: the script
+    must resolve the disabled triple (fail-open), never recompute inline."""
+    for raw in ("", "   ", "{}", "null", "not-json", "[1,2]"):
+        stdout_regime, live, snap = regime_from_injected_payload(raw)
+        assert stdout_regime == ""
+        assert live == ""
+        assert snap["regime"] == ""
+
+
+def test_prepare_check_regime_skips_compute_when_injected():
+    """Presence of injected_payload_json must short-circuit before any frame
+    math — df=None would crash if the inline path ran."""
+    payload = {"default": {"regime": "trending_up", "score": 0.4, "metrics": {}}}
+    stdout_regime, live, snap = prepare_check_regime(
+        None,
+        regime_enabled=True,
+        windows_spec={"default": {"classifier": "adx", "period": 14}},
+        injected_payload_json=json.dumps(payload),
+    )
+    assert stdout_regime == payload
+    assert live == "trending_up"
+    assert snap["regime"] == "trending_up"
+    # Empty injection also short-circuits (fail-open), still no compute.
+    stdout_regime, live, snap = prepare_check_regime(
+        None, regime_enabled=True, windows_spec=_SPEC_MULTI, injected_payload_json=""
+    )
+    assert (stdout_regime, live, snap["regime"]) == ("", "", "")
+
+
+def test_prepare_check_regime_disabled_ignores_injection():
+    out = prepare_check_regime(
+        None, regime_enabled=False, injected_payload_json='{"default":{"regime":"x"}}'
+    )
+    assert out[0] == "" and out[1] == ""
+
+
+# ─── check_regime.py bundle parity ───────────────────────────────────────────
+
+
+def test_bundle_snapshots_match_compute_multi_regime():
+    """The bundle's per-window snapshots come from the same compute path the
+    check scripts used inline — consumer labels are unchanged by #879."""
+    df = _make_uptrend()
+    bundle = compute_regime_bundle(df, _SPEC_MULTI)
+    assert bundle["regime"] == compute_multi_regime(df, _SPEC_MULTI)
+
+
+def test_bundle_adx3_view_is_full_period_classifier():
+    """adx3 for a composite window must run the REAL ADX classifier at the
+    window's full period — exact parity with a standalone ADX window even past
+    COMPOSITE_ADX_PERIOD_CAP (=14), never a prefix-collapse of the composite
+    label."""
+    df = _make_uptrend()
+    spec = {
+        "macro": {
+            "classifier": "composite",
+            "period": 30,  # > COMPOSITE_ADX_PERIOD_CAP
+            "thresholds": {"return_pct": 0.05, "range_pct": 0.03, "adx": 25.0, "efficiency": 0.5},
+        }
+    }
+    bundle = compute_regime_bundle(df, spec)
+    expected = latest_regime(df, period=30, adx_threshold=25.0)["regime"]
+    assert bundle["views"]["macro"]["adx3"] == expected
+    assert bundle["views"]["macro"]["composite7"] == bundle["regime"]["macro"]["regime"]
+
+
+def test_bundle_composite7_view_for_adx_window():
+    df = _make_uptrend()
+    spec = {"short": {"classifier": "adx", "period": 10, "adx_threshold": 20.0}}
+    bundle = compute_regime_bundle(df, spec)
+    assert bundle["views"]["short"]["adx3"] == bundle["regime"]["short"]["regime"]
+    expected = latest_regime_composite(df, 10, None)["regime"]
+    assert bundle["views"]["short"]["composite7"] == expected
+
+
+def test_bundle_roundtrip_through_injection():
+    """End-to-end: bundle JSON → --regime-payload-json → identical triple to
+    the inline path. This is the wire the Go store actually carries."""
+    df = _make_uptrend()
+    bundle = compute_regime_bundle(df, _SPEC_MULTI)
+    raw = json.dumps(bundle["regime"])
+    injected = prepare_check_regime(
+        df, regime_enabled=True, windows_spec=_SPEC_MULTI,
+        atr_window="short", injected_payload_json=raw,
+    )
+    inline = prepare_check_regime(
+        df, regime_enabled=True, windows_spec=_SPEC_MULTI, atr_window="short"
+    )
+    assert injected == inline


### PR DESCRIPTION
Closes #879

## What

A single global regime calculator now owns all regime computation. Each cycle the Go scheduler builds a fresh in-memory store — one dedicated regime subprocess per distinct `(data platform, symbol, timeframe, windows-spec)` signature among **due** strategies — and every consumer reads that map. Check scripts no longer compute regime inline: the bundle is injected via a new `--regime-payload-json` flag.

## Design notes vs the issue sketch

- **Signature space collapsed:** classifier/period/thresholds live on the global `regime.windows` config, not per strategy (strategies only select windows), so the two-layer raw/label split degenerates: one bundle per `(platform, symbol, timeframe, spec)` carries every window's snapshot, and per-strategy "projection" is just window selection (`RegimePayload.Label`). The spec string stays in the key so the options ADX/4h signature coexists with the global one.
- **Data-source keying:** the key's platform is the *data source the check script fetches from* (default spot dispatch = BinanceUS regardless of `sc.Platform`), so the bundle is computed on exactly the frame the strategy trades on.
- **3-state view = exact (option 1):** `views.adx3` runs the real ADX classifier at the window's **full** period (exact past `COMPOSITE_ADX_PERIOD_CAP`); `views.composite7` is the complementary view. Consumer labels still come from the configured classifier's snapshot — unchanged by migration (regression-tested).
- **Full migration, not Phase 1:** injection landed in all five check scripts + `check_options.py`, so there is no double computation and `result.Regime` echoes the store payload; the six dispatch gate/sync sites additionally read the store directly and point `result.Regime` at it for the stamp-at-open path.

## Failure policy (option b, as specified)

Failed/missing bundle → no store entry → empty payload everywhere: entry gate fails open, `regime=-` on status, check scripts receive an **empty** `--regime-payload-json` (skip inline compute, resolve empty) — no reuse-last, no inline fallback. Open positions are untouched (`pos.Regime` frozen stamp). Sustained failures alert through the existing `scriptFailureTracker` throttling keyed `regime[<platform>/<symbol>/<tf>]`. **Accepted semantic delta** (stated in the issue): a regime-data failure no longer fails the whole check, so fresh opens fail open instead of skipping the cycle.

## Consumer migration

- Six `syncStrategyRegimeState` dispatches + `applyRegimeGate` + `stampPositionRegimeIfOpened`: store-backed.
- `manual`: flat strategies now show a live regime (pre-#879: `regime=-` without a position); the close-eval no longer returns a regime payload.
- `options`: migrated to the store's `(underlying, 4h, ADX-default)` signature — same hardcoded params as the old inline path, still **not** gated on `regime.enabled`; the injected payload keeps the script's emitted label identical.
- `strategyCurrentATRRegime` / `applyRegimeDirectionalPolicy`: read `stratState` / the echoed-injected payload, both store-sourced now.
- Backtest: no change needed — live and backtest already share `_composite_efficiency_metrics` / `compute_regime`; the bundle uses the same `compute_multi_regime` entry point (parity-tested).

## Latency

The new phase runs before the fan-out, parallel across signatures under `pythonSemaphore=4`, so added wall-clock ≈ one subprocess generation per cycle (peers dedupe to one). For HL, the bundle's OHLCV fetch lands in the #839 `/tmp` cache with the **same limit** the check scripts use (`regimeRequiredOhlcvLimit`), so the subsequent check reads the cache instead of re-hitting `/info` — regime-enabled HL deployments net out to roughly the same `/info` load with strictly less duplicated math.

## Surfaces

- `GET /api/regime`: portfolio-level view — per-signature windows with snapshots + both-vocabulary views, `bar_time`, `built_at`.
- One `Regime: <platform>/<sym>/<tf>=<label>; …` line per cycle in the scheduler log.
- Probe: `check_regime.py` probed at startup; `--regime-payload-json` added to the signal probe argvs (stale-Python asymmetric deploys fail at startup, exit 78).

## Tests

- Go: signature derivation per type/platform (incl. manual, options, luno-on-binanceus-data), peer dedupe, one-compute-per-signature, failure→empty→gate-fails-open, no reuse-last across cycles, injection flag presence semantics, output parsing (raw bytes preserved), probe counts, dashboard projection.
- Python: injected-vs-inline triple parity (multi-window, primary/atr selection), empty-injection fail-open, inline-skip proof (df=None), bundle snapshots == `compute_multi_regime`, full-period `adx3` parity at period>14, end-to-end bundle→injection round-trip.
- Suites: `go vet` + `go test ./...` green; pytest 1172 passed + `shared_scripts/` 148 passed. Live smoke: `check_regime.py` against BinanceUS/HL/OKX; injected + empty payloads through `check_strategy.py`, `check_hyperliquid.py`, `check_okx.py`.

---
Created with LLM: Fable 5 | high | Harness: Claude Code