### PR TITLE
[codex] Enrich portfolio warning payload

### DIFF
--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -192,7 +192,12 @@ CREATE TABLE IF NOT EXISTS portfolio_risk (
     current_margin_drawdown_pct REAL NOT NULL DEFAULT 0,
     kill_switch_active INTEGER NOT NULL DEFAULT 0,
     kill_switch_at TEXT NOT NULL DEFAULT '',
-    warning_sent INTEGER NOT NULL DEFAULT 0
+    warning_sent INTEGER NOT NULL DEFAULT 0,
+    warn_band_entered_at TEXT NOT NULL DEFAULT '',
+    last_warning_equity_dd_pct REAL NOT NULL DEFAULT 0,
+    last_warning_margin_dd_pct REAL NOT NULL DEFAULT 0,
+    warning_equity_delta_pct REAL NOT NULL DEFAULT 0,
+    warning_margin_delta_pct REAL NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS kill_switch_events (
@@ -301,6 +306,12 @@ func (sdb *StateDB) migrateSchema() error {
 		// Portfolio margin drawdown + kill-switch source tracking (#296 review).
 		"ALTER TABLE portfolio_risk ADD COLUMN current_margin_drawdown_pct REAL NOT NULL DEFAULT 0",
 		"ALTER TABLE kill_switch_events ADD COLUMN source TEXT NOT NULL DEFAULT ''",
+		// Portfolio warning diagnostics (#904).
+		"ALTER TABLE portfolio_risk ADD COLUMN warn_band_entered_at TEXT NOT NULL DEFAULT ''",
+		"ALTER TABLE portfolio_risk ADD COLUMN last_warning_equity_dd_pct REAL NOT NULL DEFAULT 0",
+		"ALTER TABLE portfolio_risk ADD COLUMN last_warning_margin_dd_pct REAL NOT NULL DEFAULT 0",
+		"ALTER TABLE portfolio_risk ADD COLUMN warning_equity_delta_pct REAL NOT NULL DEFAULT 0",
+		"ALTER TABLE portfolio_risk ADD COLUMN warning_margin_delta_pct REAL NOT NULL DEFAULT 0",
 		// Per-leaderboard-summary last-post timestamps stored as JSON (#308).
 		"ALTER TABLE app_state ADD COLUMN last_leaderboard_summaries TEXT NOT NULL DEFAULT ''",
 		// Per-channel regular summary last-post timestamps stored as JSON (#474).
@@ -701,6 +712,47 @@ func (sdb *StateDB) InsertTrade(strategyID string, trade Trade) error {
 	return nil
 }
 
+// RecentTrades returns the newest trade rows since a cutoff, newest first.
+func (sdb *StateDB) RecentTrades(since time.Time, limit int) ([]Trade, error) {
+	if sdb == nil || sdb.db == nil {
+		return nil, fmt.Errorf("state db unavailable")
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+	rows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime, COALESCE(entry_atr, 0) AS entry_atr, COALESCE(stop_loss_oid, 0) AS stop_loss_oid, COALESCE(stop_loss_trigger_px, 0) AS stop_loss_trigger_px, COALESCE(tp_oids_json, '') AS tp_oids_json, COALESCE(manual, 0) AS manual, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json
+		FROM trades WHERE timestamp >= ? ORDER BY timestamp DESC, rowid DESC LIMIT ?`, formatTime(since), limit)
+	if err != nil {
+		return nil, fmt.Errorf("query recent trades: %w", err)
+	}
+	defer rows.Close()
+	var out []Trade
+	for rows.Next() {
+		var tr Trade
+		var tsStr string
+		var isCloseInt, isManualInt int
+		var tpOIDsJSON string
+		var slATRMult sql.NullFloat64
+		if err := rows.Scan(&tsStr, &tr.StrategyID, &tr.Symbol, &tr.PositionID, &tr.Side, &tr.Quantity, &tr.Price, &tr.Value, &tr.TradeType, &tr.Details, &tr.ExchangeOrderID, &tr.ExchangeFee, &isCloseInt, &tr.RealizedPnL, &tr.Regime, &tr.EntryATR, &tr.StopLossOID, &tr.StopLossTriggerPx, &tpOIDsJSON, &isManualInt, &slATRMult, &tr.TPTiersJSON); err != nil {
+			return nil, fmt.Errorf("scan recent trade: %w", err)
+		}
+		tr.Timestamp = parseTime(tsStr)
+		tr.IsClose = isCloseInt != 0
+		tr.Manual = isManualInt != 0
+		tr.TPOIDs = parseTPOIDsJSON(tpOIDsJSON, 0, 0)
+		if slATRMult.Valid {
+			v := slATRMult.Float64
+			tr.StopLossATRMult = &v
+		}
+		tr.persisted = true
+		out = append(out, tr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate recent trades: %w", err)
+	}
+	return out, nil
+}
+
 // UpdateTradeStampedFields updates open-trade snapshot fields on an existing
 // trade row identified by (strategy_id, timestamp). The normal same-cycle open
 // path writes these fields in InsertTrade; this remains for fallback arming
@@ -1051,10 +1103,12 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	if state.PortfolioRisk.WarningSent {
 		warnSent = 1
 	}
-	if _, err := tx.Exec(`INSERT OR REPLACE INTO portfolio_risk (id, peak_value, current_drawdown_pct, current_margin_drawdown_pct, kill_switch_active, kill_switch_at, warning_sent)
-		VALUES (1, ?, ?, ?, ?, ?, ?)`,
+	if _, err := tx.Exec(`INSERT OR REPLACE INTO portfolio_risk (id, peak_value, current_drawdown_pct, current_margin_drawdown_pct, kill_switch_active, kill_switch_at, warning_sent, warn_band_entered_at, last_warning_equity_dd_pct, last_warning_margin_dd_pct, warning_equity_delta_pct, warning_margin_delta_pct)
+		VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		state.PortfolioRisk.PeakValue, state.PortfolioRisk.CurrentDrawdownPct, state.PortfolioRisk.CurrentMarginDrawdownPct,
-		ksActive, formatTime(state.PortfolioRisk.KillSwitchAt), warnSent,
+		ksActive, formatTime(state.PortfolioRisk.KillSwitchAt), warnSent, formatTime(state.PortfolioRisk.WarnBandEnteredAt),
+		state.PortfolioRisk.LastWarningEquityDDPct, state.PortfolioRisk.LastWarningMarginDDPct,
+		state.PortfolioRisk.WarningEquityDeltaPct, state.PortfolioRisk.WarningMarginDeltaPct,
 	); err != nil {
 		return fmt.Errorf("upsert portfolio_risk: %w", err)
 	}
@@ -1443,16 +1497,18 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 
 	// 6. Load portfolio_risk.
 	var ksActiveInt, warnSentInt int
-	var ksAtStr string
-	err = sdb.db.QueryRow("SELECT peak_value, current_drawdown_pct, current_margin_drawdown_pct, kill_switch_active, kill_switch_at, warning_sent FROM portfolio_risk WHERE id = 1").
+	var ksAtStr, warnBandEnteredAtStr string
+	err = sdb.db.QueryRow("SELECT peak_value, current_drawdown_pct, current_margin_drawdown_pct, kill_switch_active, kill_switch_at, warning_sent, COALESCE(warn_band_entered_at, '') AS warn_band_entered_at, COALESCE(last_warning_equity_dd_pct, 0) AS last_warning_equity_dd_pct, COALESCE(last_warning_margin_dd_pct, 0) AS last_warning_margin_dd_pct, COALESCE(warning_equity_delta_pct, 0) AS warning_equity_delta_pct, COALESCE(warning_margin_delta_pct, 0) AS warning_margin_delta_pct FROM portfolio_risk WHERE id = 1").
 		Scan(&state.PortfolioRisk.PeakValue, &state.PortfolioRisk.CurrentDrawdownPct, &state.PortfolioRisk.CurrentMarginDrawdownPct,
-			&ksActiveInt, &ksAtStr, &warnSentInt)
+			&ksActiveInt, &ksAtStr, &warnSentInt, &warnBandEnteredAtStr, &state.PortfolioRisk.LastWarningEquityDDPct,
+			&state.PortfolioRisk.LastWarningMarginDDPct, &state.PortfolioRisk.WarningEquityDeltaPct, &state.PortfolioRisk.WarningMarginDeltaPct)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, fmt.Errorf("load portfolio_risk: %w", err)
 	}
 	state.PortfolioRisk.KillSwitchActive = ksActiveInt != 0
 	state.PortfolioRisk.KillSwitchAt = parseTime(ksAtStr)
 	state.PortfolioRisk.WarningSent = warnSentInt != 0
+	state.PortfolioRisk.WarnBandEnteredAt = parseTime(warnBandEnteredAtStr)
 
 	// 7. Load kill switch events.
 	evtRows, err := sdb.db.Query("SELECT timestamp, type, source, drawdown_pct, portfolio_value, peak_value, details FROM kill_switch_events ORDER BY rowid ASC")

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -158,8 +158,13 @@ func makeTestState() *AppState {
 		},
 		PortfolioRisk: PortfolioRiskState{
 			PeakValue: 2050, CurrentDrawdownPct: 1.5, CurrentMarginDrawdownPct: 18.7,
-			KillSwitchActive: false,
-			WarningSent:      true,
+			KillSwitchActive:       false,
+			WarningSent:            true,
+			WarnBandEnteredAt:      now.Add(-20 * time.Minute),
+			LastWarningEquityDDPct: 1.5,
+			LastWarningMarginDDPct: 18.7,
+			WarningEquityDeltaPct:  0.3,
+			WarningMarginDeltaPct:  -0.2,
 			Events: []KillSwitchEvent{
 				{Timestamp: now.Add(-3 * time.Hour), Type: "warning", Source: "margin", DrawdownPct: 18.7, PortfolioValue: 1950, PeakValue: 2050, Details: "approaching threshold"},
 			},
@@ -279,6 +284,21 @@ func TestSaveAndLoadDBRoundTrip(t *testing.T) {
 	}
 	if !loaded.PortfolioRisk.WarningSent {
 		t.Error("PortfolioRisk.WarningSent should be true")
+	}
+	if loaded.PortfolioRisk.WarnBandEnteredAt.IsZero() {
+		t.Error("PortfolioRisk.WarnBandEnteredAt should round-trip")
+	}
+	if loaded.PortfolioRisk.LastWarningEquityDDPct != 1.5 {
+		t.Errorf("PortfolioRisk.LastWarningEquityDDPct = %f, want 1.5", loaded.PortfolioRisk.LastWarningEquityDDPct)
+	}
+	if loaded.PortfolioRisk.LastWarningMarginDDPct != 18.7 {
+		t.Errorf("PortfolioRisk.LastWarningMarginDDPct = %f, want 18.7", loaded.PortfolioRisk.LastWarningMarginDDPct)
+	}
+	if loaded.PortfolioRisk.WarningEquityDeltaPct != 0.3 {
+		t.Errorf("PortfolioRisk.WarningEquityDeltaPct = %f, want 0.3", loaded.PortfolioRisk.WarningEquityDeltaPct)
+	}
+	if loaded.PortfolioRisk.WarningMarginDeltaPct != -0.2 {
+		t.Errorf("PortfolioRisk.WarningMarginDeltaPct = %f, want -0.2", loaded.PortfolioRisk.WarningMarginDeltaPct)
 	}
 	if len(loaded.PortfolioRisk.Events) != 1 {
 		t.Fatalf("kill switch events = %d, want 1", len(loaded.PortfolioRisk.Events))

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1081,6 +1081,16 @@ func main() {
 
 			// Warning alert: drawdown approaching kill switch threshold.
 			if portfolioWarning && notifier.HasBackends() {
+				warnNow := time.Now().UTC()
+				var recentTrades []Trade
+				if stateDB != nil {
+					if rows, err := stateDB.RecentTrades(warnNow.Add(-portfolioWarningRecentWindow), portfolioWarningMaxRows); err != nil {
+						fmt.Printf("[WARN] portfolio warning recent-trade lookup failed: %v\n", err)
+					} else {
+						recentTrades = rows
+					}
+				}
+				var warnMsg string
 				mu.Lock()
 				// Source mirrors CheckPortfolioRisk's tie-break: margin wins
 				// ties so the newer #296 signal is surfaced preferentially.
@@ -1097,8 +1107,18 @@ func main() {
 				if portfolioWarnBandEntered {
 					addKillSwitchEvent(&state.PortfolioRisk, "warning", source, warnDD, totalPV, state.PortfolioRisk.PeakValue, portfolioReason)
 				}
+				warnMsg = BuildPortfolioWarningMessage(PortfolioWarningMessageInputs{
+					Reason:      portfolioReason,
+					Config:      cfg.PortfolioRisk,
+					State:       state,
+					Prices:      prices,
+					TotalValue:  totalPV,
+					PerpsLoss:   perpsLoss,
+					PerpsMargin: perpsMargin,
+					Recent:      recentTrades,
+					Now:         warnNow,
+				})
 				mu.Unlock()
-				warnMsg := fmt.Sprintf("**PORTFOLIO WARNING**\n%s", portfolioReason)
 				notifier.SendToAllChannels(warnMsg)
 				notifier.SendOwnerDM(warnMsg)
 				fmt.Printf("[WARN] %s\n", portfolioReason)

--- a/scheduler/portfolio_warning.go
+++ b/scheduler/portfolio_warning.go
@@ -28,6 +28,7 @@ type PortfolioWarningMessageInputs struct {
 
 type portfolioWarningContributor struct {
 	ID             string
+	PnLLabel       string
 	PnL            float64
 	DrawdownPct    float64
 	PositionLine   string
@@ -84,25 +85,22 @@ func BuildPortfolioWarningMessage(in PortfolioWarningMessageInputs) string {
 
 	if len(contribs) > 0 {
 		b.WriteString("\nTop contributors:\n")
-		for i, c := range contribs {
-			if i >= portfolioWarningMaxRows {
-				break
-			}
-			b.WriteString(fmt.Sprintf("  %-20s P&L %s  dd %.1f%%  %s\n",
-				truncateWarningField(c.ID, 20), formatSignedDollar(c.PnL), c.DrawdownPct, c.PositionLine))
+		b.WriteString("```\n")
+		for _, c := range contribs {
+			b.WriteString(fmt.Sprintf("%-20s %-9s %s  dd %.1f%%  %s\n",
+				truncateWarningField(c.ID, 20), c.PnLLabel, formatSignedDollar(c.PnL), c.DrawdownPct, c.PositionLine))
 		}
+		b.WriteString("```\n")
 	}
 
 	if len(in.Recent) > 0 {
 		b.WriteString("\nRecent activity (last 15m):\n")
-		for i, tr := range in.Recent {
-			if i >= portfolioWarningMaxRows {
-				break
-			}
-			b.WriteString("  ")
+		b.WriteString("```\n")
+		for _, tr := range in.Recent {
 			b.WriteString(formatPortfolioWarningTrade(tr))
 			b.WriteByte('\n')
 		}
+		b.WriteString("```\n")
 	}
 
 	if rec := portfolioWarningRecommendation(contribs); rec != "" {
@@ -112,10 +110,7 @@ func BuildPortfolioWarningMessage(in PortfolioWarningMessageInputs) string {
 	}
 
 	msg := strings.TrimRight(b.String(), "\n")
-	if len(msg) <= portfolioWarningMaxChars {
-		return msg
-	}
-	return msg[:portfolioWarningMaxChars-3] + "..."
+	return truncateWarningField(msg, portfolioWarningMaxChars)
 }
 
 func portfolioWarningContributors(state *AppState, prices map[string]float64) []portfolioWarningContributor {
@@ -136,8 +131,10 @@ func portfolioWarningContributors(state *AppState, prices map[string]float64) []
 		}
 		pv := PortfolioValue(ss, prices)
 		initCap := ss.InitialCapital
+		pnlLabel := "P&L"
 		if initCap <= 0 {
 			initCap = pv - ss.RiskState.DailyPnL
+			pnlLabel = "daily P&L"
 		}
 		pnl := pv - initCap
 		if pnl < 0 {
@@ -145,6 +142,7 @@ func portfolioWarningContributors(state *AppState, prices map[string]float64) []
 		}
 		out = append(out, portfolioWarningContributor{
 			ID:           id,
+			PnLLabel:     pnlLabel,
 			PnL:          pnl,
 			DrawdownPct:  ss.RiskState.CurrentDrawdownPct,
 			PositionLine: formatPortfolioWarningPosition(ss, prices),
@@ -327,11 +325,15 @@ func formatWarningPrice(v float64) string {
 }
 
 func truncateWarningField(s string, max int) string {
-	if len(s) <= max {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
 		return s
 	}
 	if max <= 3 {
-		return s[:max]
+		return string(runes[:max])
 	}
-	return s[:max-3] + "..."
+	return string(runes[:max-3]) + "..."
 }

--- a/scheduler/portfolio_warning.go
+++ b/scheduler/portfolio_warning.go
@@ -258,7 +258,7 @@ func portfolioWarningRecommendation(contribs []portfolioWarningContributor) stri
 		return "review portfolio exposure and recent fills before adding risk."
 	}
 	if contribs[0].PnL < 0 && contribs[0].NegativeWeight >= 0.5 {
-		return fmt.Sprintf("review open positions above; consider manual close on %s if the signal does not recover next cycle.", contribs[0].ID)
+		return fmt.Sprintf("review open positions above; consider manually closing %s if the signal does not recover next cycle.", contribs[0].ID)
 	}
 	return "review open positions above and avoid adding risk until the drawdown recovers."
 }

--- a/scheduler/portfolio_warning.go
+++ b/scheduler/portfolio_warning.go
@@ -1,0 +1,337 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	portfolioWarningRecentWindow = 15 * time.Minute
+	portfolioWarningMaxRows      = 5
+	portfolioWarningMaxChars     = 1900
+)
+
+type PortfolioWarningMessageInputs struct {
+	Reason      string
+	Config      *PortfolioRiskConfig
+	State       *AppState
+	Prices      map[string]float64
+	TotalValue  float64
+	PerpsLoss   float64
+	PerpsMargin float64
+	Recent      []Trade
+	Now         time.Time
+}
+
+type portfolioWarningContributor struct {
+	ID             string
+	PnL            float64
+	DrawdownPct    float64
+	PositionLine   string
+	NegativeWeight float64
+}
+
+// BuildPortfolioWarningMessage expands the single-line portfolio risk reason
+// into the operator triage block used by Discord warnings.
+func BuildPortfolioWarningMessage(in PortfolioWarningMessageInputs) string {
+	now := in.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	var prs PortfolioRiskState
+	if in.State != nil {
+		prs = in.State.PortfolioRisk
+	}
+	contribs := portfolioWarningContributors(in.State, in.Prices)
+
+	var b strings.Builder
+	b.WriteString("**PORTFOLIO WARNING**")
+	if lead := portfolioWarningLead(contribs); lead != "" {
+		b.WriteString(" - ")
+		b.WriteString(lead)
+	}
+	b.WriteByte('\n')
+
+	maxDD := 0.0
+	warnDD := 0.0
+	if in.Config != nil {
+		maxDD = in.Config.MaxDrawdownPct
+		warnDD = maxDD * in.Config.WarnThresholdPct / 100
+	}
+	entered := prs.WarnBandEnteredAt.UTC()
+	if entered.IsZero() {
+		entered = now
+	}
+	b.WriteString(fmt.Sprintf("Kill switch: %.1f%% drawdown | Warn threshold: %.1f%% | In band since: %s (%s)\n",
+		maxDD, warnDD, entered.Format("2006-01-02 15:04 UTC"), formatWarningDuration(now.Sub(entered))))
+
+	b.WriteString(fmt.Sprintf("Current: equity=%.1f%% ($%.0f / peak $%.0f)", prs.CurrentDrawdownPct, in.TotalValue, prs.PeakValue))
+	if in.PerpsMargin > 0 {
+		b.WriteString(fmt.Sprintf(" | perps margin=%.1f%% ($%.0f loss on $%.0f margin)", prs.CurrentMarginDrawdownPct, in.PerpsLoss, in.PerpsMargin))
+	}
+	b.WriteByte('\n')
+
+	b.WriteString(fmt.Sprintf("Distance to kill switch: %.1f%% equity", positiveDistance(maxDD, prs.CurrentDrawdownPct)))
+	if in.PerpsMargin > 0 {
+		b.WriteString(fmt.Sprintf(" / %.1f%% margin", positiveDistance(maxDD, prs.CurrentMarginDrawdownPct)))
+	}
+	b.WriteByte('\n')
+	b.WriteString(formatPortfolioWarningTrend(prs, in.PerpsMargin > 0))
+	b.WriteByte('\n')
+
+	if len(contribs) > 0 {
+		b.WriteString("\nTop contributors:\n")
+		for i, c := range contribs {
+			if i >= portfolioWarningMaxRows {
+				break
+			}
+			b.WriteString(fmt.Sprintf("  %-20s P&L %s  dd %.1f%%  %s\n",
+				truncateWarningField(c.ID, 20), formatSignedDollar(c.PnL), c.DrawdownPct, c.PositionLine))
+		}
+	}
+
+	if len(in.Recent) > 0 {
+		b.WriteString("\nRecent activity (last 15m):\n")
+		for i, tr := range in.Recent {
+			if i >= portfolioWarningMaxRows {
+				break
+			}
+			b.WriteString("  ")
+			b.WriteString(formatPortfolioWarningTrade(tr))
+			b.WriteByte('\n')
+		}
+	}
+
+	if rec := portfolioWarningRecommendation(contribs); rec != "" {
+		b.WriteString("\nRecommended: ")
+		b.WriteString(rec)
+		b.WriteByte('\n')
+	}
+
+	msg := strings.TrimRight(b.String(), "\n")
+	if len(msg) <= portfolioWarningMaxChars {
+		return msg
+	}
+	return msg[:portfolioWarningMaxChars-3] + "..."
+}
+
+func portfolioWarningContributors(state *AppState, prices map[string]float64) []portfolioWarningContributor {
+	if state == nil {
+		return nil
+	}
+	totalNegative := 0.0
+	out := make([]portfolioWarningContributor, 0, len(state.Strategies))
+	ids := make([]string, 0, len(state.Strategies))
+	for id := range state.Strategies {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		ss := state.Strategies[id]
+		if ss == nil {
+			continue
+		}
+		pv := PortfolioValue(ss, prices)
+		initCap := ss.InitialCapital
+		if initCap <= 0 {
+			initCap = pv - ss.RiskState.DailyPnL
+		}
+		pnl := pv - initCap
+		if pnl < 0 {
+			totalNegative += -pnl
+		}
+		out = append(out, portfolioWarningContributor{
+			ID:           id,
+			PnL:          pnl,
+			DrawdownPct:  ss.RiskState.CurrentDrawdownPct,
+			PositionLine: formatPortfolioWarningPosition(ss, prices),
+		})
+	}
+	if totalNegative > 0 {
+		for i := range out {
+			if out[i].PnL < 0 {
+				out[i].NegativeWeight = -out[i].PnL / totalNegative
+			}
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].PnL == out[j].PnL {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].PnL < out[j].PnL
+	})
+	if len(out) > portfolioWarningMaxRows {
+		out = out[:portfolioWarningMaxRows]
+	}
+	return out
+}
+
+func portfolioWarningLead(contribs []portfolioWarningContributor) string {
+	if len(contribs) == 0 || contribs[0].PnL >= 0 {
+		return "portfolio is in the warn band"
+	}
+	return fmt.Sprintf("%s (dd=%.1f%%) is leading portfolio drawdown", contribs[0].ID, contribs[0].DrawdownPct)
+}
+
+func formatPortfolioWarningTrend(prs PortfolioRiskState, includeMargin bool) string {
+	eq := prs.WarningEquityDeltaPct
+	margin := prs.WarningMarginDeltaPct
+	trend := "STABLE"
+	primary := eq
+	if includeMargin && math.Abs(margin) >= math.Abs(eq) {
+		primary = margin
+	}
+	if primary > 0.05 {
+		trend = "WORSENING"
+	} else if primary < -0.05 {
+		trend = "RECOVERING"
+	}
+	parts := []string{fmt.Sprintf("equity dd %s since last cycle", formatSignedPct(eq))}
+	if includeMargin {
+		parts = append(parts, fmt.Sprintf("margin dd %s", formatSignedPct(margin)))
+	}
+	return "Trend: " + trend + " - " + strings.Join(parts, "; ")
+}
+
+func formatPortfolioWarningPosition(ss *StrategyState, prices map[string]float64) string {
+	if ss == nil {
+		return "(flat)"
+	}
+	symbols := make([]string, 0, len(ss.Positions))
+	for sym, pos := range ss.Positions {
+		if pos != nil && pos.Quantity > 0 {
+			symbols = append(symbols, sym)
+		}
+	}
+	sort.Strings(symbols)
+	if len(symbols) == 0 {
+		return "(flat)"
+	}
+	sym := symbols[0]
+	pos := ss.Positions[sym]
+	price := prices[sym]
+	if price <= 0 {
+		price = pos.AvgCost
+	}
+	pnl := positionUnrealizedPnL(pos, price)
+	line := fmt.Sprintf("pos: %s %s %s @ $%s (%s unrealized)", pos.Side, formatWarningQty(pos.Quantity), sym, formatWarningPrice(pos.AvgCost), formatSignedDollar(pnl))
+	if len(symbols) > 1 {
+		line += fmt.Sprintf(" +%d more", len(symbols)-1)
+	}
+	return line
+}
+
+func positionUnrealizedPnL(pos *Position, price float64) float64 {
+	if pos == nil {
+		return 0
+	}
+	mult := pos.Multiplier
+	if mult <= 0 {
+		mult = 1
+	}
+	if pos.Side == "short" {
+		return pos.Quantity * mult * (pos.AvgCost - price)
+	}
+	return pos.Quantity * mult * (price - pos.AvgCost)
+}
+
+func formatPortfolioWarningTrade(tr Trade) string {
+	kind := "fill"
+	if tr.IsClose {
+		kind = "close"
+	} else if tr.Manual {
+		kind = "manual"
+	} else if tr.TradeType != "" {
+		kind = tr.TradeType
+	}
+	details := strings.TrimSpace(tr.Details)
+	if details != "" {
+		details = " (" + truncateWarningField(details, 42) + ")"
+	}
+	return fmt.Sprintf("%s  %s  %s  %s %s @ $%s%s",
+		tr.Timestamp.UTC().Format("15:04"), kind, truncateWarningField(tr.StrategyID, 20), tr.Side, formatWarningQty(tr.Quantity), formatWarningPrice(tr.Price), details)
+}
+
+func portfolioWarningRecommendation(contribs []portfolioWarningContributor) string {
+	if len(contribs) == 0 {
+		return "review portfolio exposure and recent fills before adding risk."
+	}
+	if contribs[0].PnL < 0 && contribs[0].NegativeWeight >= 0.5 {
+		return fmt.Sprintf("review open positions above; consider manual close on %s if the signal does not recover next cycle.", contribs[0].ID)
+	}
+	return "review open positions above and avoid adding risk until the drawdown recovers."
+}
+
+func positiveDistance(limit, current float64) float64 {
+	d := limit - current
+	if d < 0 {
+		return 0
+	}
+	return d
+}
+
+func formatWarningDuration(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		h := int(d.Hours())
+		m := int(d.Minutes()) % 60
+		return fmt.Sprintf("%dh%dm", h, m)
+	}
+	days := int(d.Hours()) / 24
+	hours := int(d.Hours()) % 24
+	return fmt.Sprintf("%dd%dh", days, hours)
+}
+
+func formatSignedDollar(v float64) string {
+	if v < 0 {
+		return fmt.Sprintf("-$%.0f", math.Abs(v))
+	}
+	return fmt.Sprintf("$%.0f", v)
+}
+
+func formatSignedPct(v float64) string {
+	if v > 0 {
+		return fmt.Sprintf("+%.1f%%", v)
+	}
+	if v < 0 {
+		return fmt.Sprintf("%.1f%%", v)
+	}
+	return "+0.0%"
+}
+
+func formatWarningQty(v float64) string {
+	return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.6f", v), "0"), ".")
+}
+
+func formatWarningPrice(v float64) string {
+	abs := math.Abs(v)
+	switch {
+	case abs >= 1000:
+		return fmt.Sprintf("%.0f", v)
+	case abs >= 1:
+		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.4f", v), "0"), ".")
+	default:
+		return fmt.Sprintf("%.6g", v)
+	}
+}
+
+func truncateWarningField(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
+}

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -222,6 +222,11 @@ type PortfolioRiskState struct {
 	KillSwitchActive         bool              `json:"kill_switch_active"`
 	KillSwitchAt             time.Time         `json:"kill_switch_at,omitempty"`
 	WarningSent              bool              `json:"warning_sent,omitempty"`
+	WarnBandEnteredAt        time.Time         `json:"warn_band_entered_at,omitempty"`
+	LastWarningEquityDDPct   float64           `json:"last_warning_equity_dd_pct,omitempty"`
+	LastWarningMarginDDPct   float64           `json:"last_warning_margin_dd_pct,omitempty"`
+	WarningEquityDeltaPct    float64           `json:"warning_equity_delta_pct,omitempty"`
+	WarningMarginDeltaPct    float64           `json:"warning_margin_delta_pct,omitempty"`
 	Events                   []KillSwitchEvent `json:"events,omitempty"`
 }
 
@@ -308,6 +313,11 @@ func ClearLatchedKillSwitchSharedWallet(state *AppState, strategies []StrategyCo
 	state.PortfolioRisk.KillSwitchActive = false
 	state.PortfolioRisk.KillSwitchAt = time.Time{}
 	state.PortfolioRisk.WarningSent = false
+	state.PortfolioRisk.WarnBandEnteredAt = time.Time{}
+	state.PortfolioRisk.LastWarningEquityDDPct = 0
+	state.PortfolioRisk.LastWarningMarginDDPct = 0
+	state.PortfolioRisk.WarningEquityDeltaPct = 0
+	state.PortfolioRisk.WarningMarginDeltaPct = 0
 	// Re-baseline peak to the verified on-chain total so CheckPortfolioRisk
 	// does not immediately re-latch on the first tick using the stale
 	// (potentially double-counted) peak.
@@ -349,6 +359,11 @@ func AutoResetConfirmedFlatKillSwitch(prs *PortfolioRiskState, rebaselineValue f
 	prs.KillSwitchActive = false
 	prs.KillSwitchAt = time.Time{}
 	prs.WarningSent = false
+	prs.WarnBandEnteredAt = time.Time{}
+	prs.LastWarningEquityDDPct = 0
+	prs.LastWarningMarginDDPct = 0
+	prs.WarningEquityDeltaPct = 0
+	prs.WarningMarginDeltaPct = 0
 	prs.PeakValue = rebaselineValue
 	prs.CurrentDrawdownPct = 0
 	prs.CurrentMarginDrawdownPct = 0
@@ -480,6 +495,12 @@ func CheckPortfolioRisk(prs *PortfolioRiskState, cfg *PortfolioRiskConfig, total
 	if equityDD > cfg.MaxDrawdownPct || marginDD > cfg.MaxDrawdownPct {
 		prs.KillSwitchActive = true
 		prs.KillSwitchAt = time.Now().UTC()
+		prs.WarningSent = false
+		prs.WarnBandEnteredAt = time.Time{}
+		prs.LastWarningEquityDDPct = 0
+		prs.LastWarningMarginDDPct = 0
+		prs.WarningEquityDeltaPct = 0
+		prs.WarningMarginDeltaPct = 0
 		var r, source string
 		var dd float64
 		// Tie-break to margin when the two signals are equal: the margin
@@ -506,6 +527,17 @@ func CheckPortfolioRisk(prs *PortfolioRiskState, cfg *PortfolioRiskConfig, total
 		equityWarn := equityDD > warnDrawdownPct
 		marginWarn := marginDD > warnDrawdownPct
 		if equityWarn || marginWarn {
+			now := time.Now().UTC()
+			if !prs.WarningSent {
+				prs.WarnBandEnteredAt = now
+				prs.WarningEquityDeltaPct = 0
+				prs.WarningMarginDeltaPct = 0
+			} else {
+				prs.WarningEquityDeltaPct = equityDD - prs.LastWarningEquityDDPct
+				prs.WarningMarginDeltaPct = marginDD - prs.LastWarningMarginDDPct
+			}
+			prs.LastWarningEquityDDPct = equityDD
+			prs.LastWarningMarginDDPct = marginDD
 			prs.WarningSent = true
 			warning = true
 			switch {
@@ -525,6 +557,11 @@ func CheckPortfolioRisk(prs *PortfolioRiskState, cfg *PortfolioRiskConfig, total
 		} else {
 			// Recovered below warning threshold — no active warning band.
 			prs.WarningSent = false
+			prs.WarnBandEnteredAt = time.Time{}
+			prs.LastWarningEquityDDPct = 0
+			prs.LastWarningMarginDDPct = 0
+			prs.WarningEquityDeltaPct = 0
+			prs.WarningMarginDeltaPct = 0
 		}
 	}
 

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -822,6 +822,9 @@ func TestCheckPortfolioRisk_WarningFires(t *testing.T) {
 	if !prs.WarningSent {
 		t.Error("expected WarningSent=true after warning fires")
 	}
+	if prs.WarnBandEnteredAt.IsZero() {
+		t.Error("expected WarnBandEnteredAt to be stamped after warning fires")
+	}
 
 	// Second call at same drawdown — warning should fire again so operators get
 	// a reminder each cycle while the account remains in the warning band.
@@ -831,6 +834,12 @@ func TestCheckPortfolioRisk_WarningFires(t *testing.T) {
 	}
 	if reason == "" {
 		t.Error("expected non-empty reason for repeated warning")
+	}
+	if prs.LastWarningEquityDDPct < 20.9 || prs.LastWarningEquityDDPct > 21.1 {
+		t.Errorf("LastWarningEquityDDPct = %.2f, want about 21", prs.LastWarningEquityDDPct)
+	}
+	if math.Abs(prs.WarningEquityDeltaPct) > 0.01 {
+		t.Errorf("WarningEquityDeltaPct = %.2f, want 0 for unchanged drawdown", prs.WarningEquityDeltaPct)
 	}
 }
 
@@ -908,6 +917,9 @@ func TestCheckPortfolioRisk_WarningResetOnRecovery(t *testing.T) {
 	CheckPortfolioRisk(prs, cfg, 8500.0, 0, 0, 0)
 	if prs.WarningSent {
 		t.Error("expected WarningSent=false after recovery below warn threshold")
+	}
+	if !prs.WarnBandEnteredAt.IsZero() {
+		t.Error("expected WarnBandEnteredAt reset after recovery below warn threshold")
 	}
 
 	// Cross warning threshold again — should warn again.
@@ -2353,6 +2365,77 @@ func TestCheckPortfolioRisk_BothSignalsBreachWarn_ReasonIncludesBoth(t *testing.
 	}
 	if !strings.Contains(reason, "equity=") || !strings.Contains(reason, "margin=") {
 		t.Errorf("expected reason to mention both equity= and margin=; got %q", reason)
+	}
+}
+
+func TestBuildPortfolioWarningMessage_IncludesTriageSections(t *testing.T) {
+	now := time.Date(2026, 6, 6, 6, 5, 0, 0, time.UTC)
+	state := &AppState{
+		PortfolioRisk: PortfolioRiskState{
+			PeakValue:                10060,
+			CurrentDrawdownPct:       16.5,
+			CurrentMarginDrawdownPct: 18.2,
+			WarningSent:              true,
+			WarnBandEnteredAt:        now.Add(-18 * time.Minute),
+			WarningEquityDeltaPct:    1.2,
+			WarningMarginDeltaPct:    0.8,
+		},
+		Strategies: map[string]*StrategyState{
+			"hl-btc-sma-30": {
+				ID:             "hl-btc-sma-30",
+				Type:           "perps",
+				Cash:           1000,
+				InitialCapital: 1500,
+				RiskState:      RiskState{CurrentDrawdownPct: 9.1},
+				Positions: map[string]*Position{
+					"BTC": {Symbol: "BTC", Quantity: 0.5, AvgCost: 67800, Side: "short", Multiplier: 1},
+				},
+				OptionPositions: map[string]*OptionPosition{},
+			},
+			"hl-eth-ema-30": {
+				ID:              "hl-eth-ema-30",
+				Type:            "perps",
+				Cash:            905,
+				InitialCapital:  1000,
+				RiskState:       RiskState{CurrentDrawdownPct: 4.1},
+				Positions:       map[string]*Position{},
+				OptionPositions: map[string]*OptionPosition{},
+			},
+		},
+	}
+	msg := BuildPortfolioWarningMessage(PortfolioWarningMessageInputs{
+		Config:      &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 60},
+		State:       state,
+		Prices:      map[string]float64{"BTC": 68080},
+		TotalValue:  8400,
+		PerpsLoss:   250,
+		PerpsMargin: 1500,
+		Recent: []Trade{
+			{Timestamp: now.Add(-14 * time.Minute), StrategyID: "hl-btc-sma-30", Symbol: "BTC", Side: "sell", Quantity: 0.5, Price: 67800, TradeType: "perps", Details: "signal flip"},
+		},
+		Now: now,
+	})
+
+	for _, want := range []string{
+		"**PORTFOLIO WARNING**",
+		"Kill switch: 25.0% drawdown | Warn threshold: 15.0%",
+		"In band since: 2026-06-06 05:47 UTC (18m)",
+		"Current: equity=16.5% ($8400 / peak $10060) | perps margin=18.2% ($250 loss on $1500 margin)",
+		"Distance to kill switch: 8.5% equity / 6.8% margin",
+		"Trend: WORSENING - equity dd +1.2% since last cycle; margin dd +0.8%",
+		"Top contributors:",
+		"hl-btc-sma-30",
+		"pos: short 0.5 BTC @ $67800 (-$140 unrealized)",
+		"Recent activity (last 15m):",
+		"05:51  perps  hl-btc-sma-30",
+		"Recommended:",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("warning message missing %q:\n%s", want, msg)
+		}
+	}
+	if len(msg) >= 2000 {
+		t.Fatalf("warning message len = %d, want under Discord limit; msg:\n%s", len(msg), msg)
 	}
 }
 

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 // yesterday returns the UTC date string for one day before today.
@@ -2424,6 +2425,7 @@ func TestBuildPortfolioWarningMessage_IncludesTriageSections(t *testing.T) {
 		"Distance to kill switch: 8.5% equity / 6.8% margin",
 		"Trend: WORSENING - equity dd +1.2% since last cycle; margin dd +0.8%",
 		"Top contributors:",
+		"```",
 		"hl-btc-sma-30",
 		"pos: short 0.5 BTC @ $67800 (-$140 unrealized)",
 		"Recent activity (last 15m):",
@@ -2436,6 +2438,47 @@ func TestBuildPortfolioWarningMessage_IncludesTriageSections(t *testing.T) {
 	}
 	if len(msg) >= 2000 {
 		t.Fatalf("warning message len = %d, want under Discord limit; msg:\n%s", len(msg), msg)
+	}
+}
+
+func TestBuildPortfolioWarningMessage_DailyPnLFallbackLabel(t *testing.T) {
+	now := time.Date(2026, 6, 6, 6, 5, 0, 0, time.UTC)
+	state := &AppState{
+		PortfolioRisk: PortfolioRiskState{
+			PeakValue:          1000,
+			CurrentDrawdownPct: 20,
+			WarningSent:        true,
+			WarnBandEnteredAt:  now.Add(-5 * time.Minute),
+		},
+		Strategies: map[string]*StrategyState{
+			"no-initial-cap": {
+				ID:              "no-initial-cap",
+				Cash:            900,
+				InitialCapital:  0,
+				RiskState:       RiskState{DailyPnL: -75, CurrentDrawdownPct: 7.5},
+				Positions:       map[string]*Position{},
+				OptionPositions: map[string]*OptionPosition{},
+			},
+		},
+	}
+	msg := BuildPortfolioWarningMessage(PortfolioWarningMessageInputs{
+		Config:     &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 60},
+		State:      state,
+		TotalValue: 800,
+		Now:        now,
+	})
+	if !strings.Contains(msg, "daily P&L -$75") {
+		t.Fatalf("expected daily P&L fallback label in warning message:\n%s", msg)
+	}
+}
+
+func TestTruncateWarningField_UTF8Safe(t *testing.T) {
+	got := truncateWarningField("alpha-éclair", 9)
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncateWarningField returned invalid UTF-8: %q", got)
+	}
+	if got != "alpha-..." {
+		t.Fatalf("truncateWarningField = %q, want %q", got, "alpha-...")
 	}
 }
 


### PR DESCRIPTION
Fixes #904

## Summary
- Add persisted portfolio warning band timing and per-cycle trend deltas
- Send Discord portfolio warnings as a multi-line operator triage block with top contributors, open exposure, distance to kill switch, and recent fills
- Add recent-trade lookup and tests for persistence and warning formatting

## Tests
- env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...