### PR TITLE
[codex] Enrich circuit breaker alerts

### DIFF
--- a/scheduler/circuit_breaker_alert.go
+++ b/scheduler/circuit_breaker_alert.go
@@ -281,9 +281,6 @@ func circuitBreakerStrategyLabel(sc StrategyConfig) string {
 	if sc.Type != "" {
 		parts = append(parts, sc.Type)
 	}
-	if sc.Type == "perps" && sc.Leverage > 0 {
-		parts = append(parts, fmt.Sprintf("%sx leverage", formatCBNumber(sc.Leverage)))
-	}
 	filtered := parts[:0]
 	for _, p := range parts {
 		p = strings.TrimSpace(p)

--- a/scheduler/circuit_breaker_alert.go
+++ b/scheduler/circuit_breaker_alert.go
@@ -170,15 +170,6 @@ func snapshotPerStrategyCircuitBreaker(s *StrategyState, prices map[string]float
 	return snap
 }
 
-func formatPerStrategyCircuitBreakerMessage(strategyID, reason string, portfolioValue float64) string {
-	sc := StrategyConfig{ID: strategyID}
-	return formatPerStrategyCircuitBreakerBlock(perStrategyCircuitBreakerFormatInput{
-		Strategy:      sc,
-		Reason:        reason,
-		StrategyValue: portfolioValue,
-	})
-}
-
 func formatPerStrategyCircuitBreakerBlock(in perStrategyCircuitBreakerFormatInput) string {
 	now := in.Snapshot.Now.UTC()
 	if now.IsZero() {
@@ -343,7 +334,7 @@ func circuitBreakerTimeframe(sc StrategyConfig) string {
 	if sc.Timeframe != "" {
 		return sc.Timeframe
 	}
-	if len(sc.Args) > 2 {
+	if len(sc.Args) > 2 && !strings.HasPrefix(sc.Args[2], "--") {
 		return sc.Args[2]
 	}
 	return ""

--- a/scheduler/circuit_breaker_alert.go
+++ b/scheduler/circuit_breaker_alert.go
@@ -1,0 +1,539 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	circuitBreakerAlertMaxRows  = 5
+	circuitBreakerAlertMaxChars = 1900
+)
+
+type perStrategyCircuitBreakerSnapshot struct {
+	Risk          RiskState
+	Closed        []circuitBreakerPositionLine
+	Open          []circuitBreakerPositionLine
+	Pending       []circuitBreakerPendingLine
+	RemainingLoss int
+	Now           time.Time
+}
+
+type circuitBreakerPositionLine struct {
+	Symbol   string
+	Side     string
+	Quantity float64
+	Price    float64
+	PnL      float64
+	Status   string
+}
+
+type circuitBreakerPendingLine struct {
+	Platform         string
+	Symbol           string
+	Size             float64
+	OperatorRequired bool
+}
+
+type perStrategyCircuitBreakerFormatInput struct {
+	Strategy            StrategyConfig
+	Snapshot            perStrategyCircuitBreakerSnapshot
+	Reason              string
+	StrategyValue       float64
+	TotalPortfolioValue float64
+	RecentTrades        []Trade
+}
+
+var cbMaxDrawdownReasonRE = regexp.MustCompile(`\(([0-9.]+)% > ([0-9.]+)%, portfolio=\$([0-9.]+) peak=\$([0-9.]+), denom=([^=]+)=\$([0-9.]+)\)`)
+
+func snapshotPerStrategyCircuitBreaker(s *StrategyState, prices map[string]float64) perStrategyCircuitBreakerSnapshot {
+	snap := perStrategyCircuitBreakerSnapshot{Now: time.Now().UTC()}
+	if s == nil {
+		return snap
+	}
+	snap.Risk = s.RiskState
+
+	for i := len(s.ClosedPositions) - 1; i >= 0 && len(snap.Closed) < circuitBreakerAlertMaxRows; i-- {
+		cp := s.ClosedPositions[i]
+		if cp.CloseReason != "circuit_breaker" {
+			continue
+		}
+		snap.Closed = append(snap.Closed, circuitBreakerPositionLine{
+			Symbol:   cp.Symbol,
+			Side:     cp.Side,
+			Quantity: cp.Quantity,
+			Price:    cp.ClosePrice,
+			PnL:      cp.RealizedPnL,
+			Status:   "virtual close recorded",
+		})
+	}
+	for i := len(s.ClosedOptionPositions) - 1; i >= 0 && len(snap.Closed) < circuitBreakerAlertMaxRows; i-- {
+		cp := s.ClosedOptionPositions[i]
+		if cp.CloseReason != "circuit_breaker" {
+			continue
+		}
+		symbol := cp.PositionID
+		if symbol == "" {
+			symbol = cp.Underlying
+		}
+		snap.Closed = append(snap.Closed, circuitBreakerPositionLine{
+			Symbol:   symbol,
+			Side:     cp.Action,
+			Quantity: cp.Quantity,
+			Price:    cp.ClosePriceUSD,
+			PnL:      cp.RealizedPnL,
+			Status:   "virtual close recorded",
+		})
+	}
+
+	symbols := make([]string, 0, len(s.Positions))
+	for sym, pos := range s.Positions {
+		if pos != nil && pos.Quantity > 0 {
+			symbols = append(symbols, sym)
+		}
+	}
+	sort.Strings(symbols)
+	for _, sym := range symbols {
+		if len(snap.Open) >= circuitBreakerAlertMaxRows {
+			snap.RemainingLoss++
+			continue
+		}
+		pos := s.Positions[sym]
+		price := prices[sym]
+		if price <= 0 {
+			price = pos.AvgCost
+		}
+		snap.Open = append(snap.Open, circuitBreakerPositionLine{
+			Symbol:   sym,
+			Side:     pos.Side,
+			Quantity: pos.Quantity,
+			Price:    price,
+			PnL:      circuitBreakerPositionPnL(pos, price),
+			Status:   "still open",
+		})
+	}
+
+	optionIDs := make([]string, 0, len(s.OptionPositions))
+	for id, pos := range s.OptionPositions {
+		if pos != nil && pos.Quantity > 0 {
+			optionIDs = append(optionIDs, id)
+		}
+	}
+	sort.Strings(optionIDs)
+	for _, id := range optionIDs {
+		if len(snap.Open) >= circuitBreakerAlertMaxRows {
+			snap.RemainingLoss++
+			continue
+		}
+		pos := s.OptionPositions[id]
+		pnl := pos.CurrentValueUSD - pos.EntryPremiumUSD
+		if pos.Action == "sell" {
+			pnl = pos.EntryPremiumUSD - pos.CurrentValueUSD
+		}
+		snap.Open = append(snap.Open, circuitBreakerPositionLine{
+			Symbol:   id,
+			Side:     pos.Action,
+			Quantity: pos.Quantity,
+			Price:    pos.CurrentValueUSD,
+			PnL:      pnl,
+			Status:   "still open",
+		})
+	}
+
+	if len(s.RiskState.PendingCircuitCloses) > 0 {
+		platforms := make([]string, 0, len(s.RiskState.PendingCircuitCloses))
+		for platform := range s.RiskState.PendingCircuitCloses {
+			platforms = append(platforms, platform)
+		}
+		sort.Strings(platforms)
+		for _, platform := range platforms {
+			pending := s.RiskState.PendingCircuitCloses[platform]
+			if pending == nil {
+				continue
+			}
+			legs := append([]PendingCircuitCloseSymbol(nil), pending.Symbols...)
+			sort.Slice(legs, func(i, j int) bool { return legs[i].Symbol < legs[j].Symbol })
+			for _, leg := range legs {
+				snap.Pending = append(snap.Pending, circuitBreakerPendingLine{
+					Platform:         platform,
+					Symbol:           leg.Symbol,
+					Size:             leg.Size,
+					OperatorRequired: pending.OperatorRequired,
+				})
+			}
+		}
+	}
+	return snap
+}
+
+func formatPerStrategyCircuitBreakerMessage(strategyID, reason string, portfolioValue float64) string {
+	sc := StrategyConfig{ID: strategyID}
+	return formatPerStrategyCircuitBreakerBlock(perStrategyCircuitBreakerFormatInput{
+		Strategy:      sc,
+		Reason:        reason,
+		StrategyValue: portfolioValue,
+	})
+}
+
+func formatPerStrategyCircuitBreakerBlock(in perStrategyCircuitBreakerFormatInput) string {
+	now := in.Snapshot.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	sc := in.Strategy
+	if sc.ID == "" {
+		sc.ID = "unknown-strategy"
+	}
+	trigger := circuitBreakerTriggerLine(in.Reason)
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("**CIRCUIT BREAKER** [%s] - %s\n", sc.ID, circuitBreakerStrategyLabel(sc)))
+	b.WriteString("Trigger: ")
+	b.WriteString(trigger)
+	b.WriteByte('\n')
+	b.WriteString("Cooldown: ")
+	b.WriteString(formatCircuitBreakerCooldown(in.Snapshot.Risk.CircuitBreakerUntil, now))
+	b.WriteByte('\n')
+	b.WriteString("Portfolio impact: ")
+	b.WriteString(formatCircuitBreakerPortfolioImpact(sc, in.StrategyValue, in.TotalPortfolioValue))
+	b.WriteByte('\n')
+	if perps := formatCircuitBreakerPerpsContext(sc, in.Reason); perps != "" {
+		b.WriteString(perps)
+		b.WriteByte('\n')
+	}
+	if in.Snapshot.Risk.CurrentDrawdownPct > 0 || in.Snapshot.Risk.PeakValue > 0 {
+		b.WriteString(fmt.Sprintf("\nStrategy drawdown: %.1f%% (peak $%s -> current $%s)\n",
+			in.Snapshot.Risk.CurrentDrawdownPct, formatCBMoney(in.Snapshot.Risk.PeakValue), formatCBMoney(in.StrategyValue)))
+	}
+
+	if len(in.Snapshot.Closed) > 0 {
+		b.WriteString("Positions force-closed:\n")
+		for i, line := range in.Snapshot.Closed {
+			if i >= circuitBreakerAlertMaxRows {
+				break
+			}
+			b.WriteString("  ")
+			b.WriteString(formatCircuitBreakerPositionLine(line))
+			b.WriteByte('\n')
+		}
+	}
+	if len(in.Snapshot.Open) > 0 {
+		b.WriteString("Open positions still exposed:\n")
+		for i, line := range in.Snapshot.Open {
+			if i >= circuitBreakerAlertMaxRows {
+				break
+			}
+			b.WriteString("  ")
+			b.WriteString(formatCircuitBreakerPositionLine(line))
+			b.WriteByte('\n')
+		}
+		if in.Snapshot.RemainingLoss > 0 {
+			b.WriteString(fmt.Sprintf("  +%d more\n", in.Snapshot.RemainingLoss))
+		}
+	}
+	b.WriteString(formatCircuitBreakerPending(in.Snapshot.Pending))
+
+	if len(in.RecentTrades) > 0 {
+		if strings.HasPrefix(in.Reason, RiskReasonConsecutiveLosses) {
+			b.WriteString("\nLast 5 trades:\n")
+		} else {
+			b.WriteString("\nRecent trades:\n")
+		}
+		for i, tr := range in.RecentTrades {
+			if i >= circuitBreakerAlertMaxRows {
+				break
+			}
+			b.WriteString("  ")
+			b.WriteString(formatCircuitBreakerTrade(tr))
+			b.WriteByte('\n')
+		}
+		if strings.HasPrefix(in.Reason, RiskReasonConsecutiveLosses) && in.Snapshot.Risk.ConsecutiveLosses > 0 {
+			b.WriteString(fmt.Sprintf("Consecutive loss run: %d/5\n", in.Snapshot.Risk.ConsecutiveLosses))
+		}
+	}
+
+	b.WriteString("\nReason: ")
+	b.WriteString(circuitBreakerRecommendation(in.Reason))
+
+	msg := strings.TrimRight(b.String(), "\n")
+	if len(msg) <= circuitBreakerAlertMaxChars {
+		return msg
+	}
+	return msg[:circuitBreakerAlertMaxChars-3] + "..."
+}
+
+func circuitBreakerTriggerLine(reason string) string {
+	if m := cbMaxDrawdownReasonRE.FindStringSubmatch(reason); len(m) == 7 {
+		return fmt.Sprintf("%s - %s%% > %s%% (denom: %s=$%s)", RiskReasonMaxDrawdownExceeded, m[1], m[2], m[5], m[6])
+	}
+	if strings.HasPrefix(reason, RiskReasonConsecutiveLosses) {
+		return RiskReasonConsecutiveLosses
+	}
+	return reason
+}
+
+func circuitBreakerStrategyLabel(sc StrategyConfig) string {
+	parts := []string{humanPlatformName(sc.Platform)}
+	if asset := circuitBreakerAsset(sc); asset != "" {
+		parts = append(parts, asset)
+	}
+	if tf := circuitBreakerTimeframe(sc); tf != "" {
+		parts = append(parts, tf)
+	}
+	if name := circuitBreakerStrategyName(sc); name != "" {
+		parts = append(parts, name)
+	}
+	if sc.Type != "" {
+		parts = append(parts, sc.Type)
+	}
+	if sc.Type == "perps" && sc.Leverage > 0 {
+		parts = append(parts, fmt.Sprintf("%sx leverage", formatCBNumber(sc.Leverage)))
+	}
+	filtered := parts[:0]
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			filtered = append(filtered, p)
+		}
+	}
+	if len(filtered) == 0 {
+		return sc.ID
+	}
+	return strings.Join(filtered, ", ")
+}
+
+func humanPlatformName(platform string) string {
+	switch platform {
+	case "hyperliquid":
+		return "Hyperliquid"
+	case "binanceus":
+		return "BinanceUS"
+	case "topstep":
+		return "TopStep"
+	case "robinhood":
+		return "Robinhood"
+	case "deribit":
+		return "Deribit"
+	case "ibkr":
+		return "IBKR"
+	case "okx":
+		return "OKX"
+	case "luno":
+		return "Luno"
+	default:
+		return platform
+	}
+}
+
+func circuitBreakerAsset(sc StrategyConfig) string {
+	if sc.Symbol != "" {
+		return sc.Symbol
+	}
+	if len(sc.Args) > 1 {
+		return sc.Args[1]
+	}
+	return extractAsset(sc)
+}
+
+func circuitBreakerTimeframe(sc StrategyConfig) string {
+	if sc.Timeframe != "" {
+		return sc.Timeframe
+	}
+	if len(sc.Args) > 2 {
+		return sc.Args[2]
+	}
+	return ""
+}
+
+func circuitBreakerStrategyName(sc StrategyConfig) string {
+	if sc.OpenStrategy.Name != "" {
+		return sc.OpenStrategy.Name
+	}
+	if len(sc.Args) > 0 {
+		return sc.Args[0]
+	}
+	return ""
+}
+
+func formatCircuitBreakerCooldown(until time.Time, now time.Time) string {
+	if until.IsZero() {
+		return "unknown"
+	}
+	until = until.UTC()
+	remaining := until.Sub(now)
+	if remaining < 0 {
+		remaining = 0
+	}
+	return fmt.Sprintf("%s (until %s)", formatCBDuration(remaining), until.Format("2006-01-02 15:04 UTC"))
+}
+
+func formatCircuitBreakerPortfolioImpact(sc StrategyConfig, strategyValue, totalValue float64) string {
+	if totalValue > 0 {
+		impact := strategyValue
+		pct := strategyValue / totalValue * 100
+		if sc.CapitalPct > 0 {
+			impact = sc.CapitalPct * totalValue
+			pct = sc.CapitalPct * 100
+		}
+		return fmt.Sprintf("~$%s of ~$%s (%.1f%%)", formatCBMoney(impact), formatCBMoney(totalValue), pct)
+	}
+	return fmt.Sprintf("strategy value ~$%s", formatCBMoney(strategyValue))
+}
+
+func formatCircuitBreakerPerpsContext(sc StrategyConfig, reason string) string {
+	if sc.Type != "perps" {
+		return ""
+	}
+	parts := []string{}
+	if sc.Leverage > 0 {
+		parts = append(parts, fmt.Sprintf("%sx leverage", formatCBNumber(sc.Leverage)))
+	}
+	if m := cbMaxDrawdownReasonRE.FindStringSubmatch(reason); len(m) == 7 && m[5] == "margin" {
+		parts = append(parts, fmt.Sprintf("margin deployed=$%s", m[6]))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "Perps context: " + strings.Join(parts, ", ")
+}
+
+func formatCircuitBreakerPositionLine(line circuitBreakerPositionLine) string {
+	return fmt.Sprintf("%-5s %s %s @ $%s  P&L %s  (%s)",
+		line.Side, formatCBQty(line.Quantity), line.Symbol, formatCBPrice(line.Price), formatCBSignedMoney(line.PnL), line.Status)
+}
+
+func formatCircuitBreakerPending(lines []circuitBreakerPendingLine) string {
+	if len(lines) == 0 {
+		return "Pending operator closes: none\n"
+	}
+	sort.SliceStable(lines, func(i, j int) bool {
+		if lines[i].OperatorRequired != lines[j].OperatorRequired {
+			return lines[i].OperatorRequired
+		}
+		if lines[i].Platform == lines[j].Platform {
+			return lines[i].Symbol < lines[j].Symbol
+		}
+		return lines[i].Platform < lines[j].Platform
+	})
+	var b strings.Builder
+	var wroteOperator, wroteAuto bool
+	for _, line := range lines {
+		if line.OperatorRequired {
+			if !wroteOperator {
+				b.WriteString("Pending operator closes:\n")
+				wroteOperator = true
+			}
+			b.WriteString(fmt.Sprintf("  %s %s size %s (manual flatten required)\n", line.Platform, line.Symbol, formatCBQty(line.Size)))
+			continue
+		}
+		if !wroteAuto {
+			b.WriteString("Pending automated closes:\n")
+			wroteAuto = true
+		}
+		b.WriteString(fmt.Sprintf("  %s %s size %s (close submitted)\n", line.Platform, line.Symbol, formatCBQty(line.Size)))
+	}
+	return b.String()
+}
+
+func formatCircuitBreakerTrade(tr Trade) string {
+	kind := "open"
+	if tr.IsClose {
+		kind = "close"
+	}
+	details := strings.TrimSpace(tr.Details)
+	if details != "" {
+		details = " (" + truncateCircuitBreakerField(details, 44) + ")"
+	}
+	pnl := ""
+	if tr.IsClose || tr.RealizedPnL != 0 {
+		pnl = " P&L " + formatCBSignedMoney(tr.RealizedPnL)
+	}
+	return fmt.Sprintf("%s  %s  %s %s %s @ $%s%s%s",
+		tr.Timestamp.UTC().Format("15:04"), kind, tr.Side, formatCBQty(tr.Quantity), tr.Symbol, formatCBPrice(tr.Price), pnl, details)
+}
+
+func circuitBreakerRecommendation(reason string) string {
+	if strings.HasPrefix(reason, RiskReasonConsecutiveLosses) {
+		return "Strategy may have lost edge in the current regime; consider extending cooldown or pausing manually."
+	}
+	return "Investigate whether the signal is still valid or the regime has flipped."
+}
+
+func circuitBreakerPositionPnL(pos *Position, price float64) float64 {
+	if pos == nil {
+		return 0
+	}
+	mult := pos.Multiplier
+	if mult <= 0 {
+		mult = 1
+	}
+	if pos.Side == "short" {
+		return pos.Quantity * mult * (pos.AvgCost - price)
+	}
+	return pos.Quantity * mult * (price - pos.AvgCost)
+}
+
+func formatCBDuration(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		h := int(d.Hours())
+		m := int(d.Minutes()) % 60
+		return fmt.Sprintf("%dh%dm", h, m)
+	}
+	days := int(d.Hours()) / 24
+	hours := int(d.Hours()) % 24
+	return fmt.Sprintf("%dd%dh", days, hours)
+}
+
+func formatCBMoney(v float64) string {
+	return fmt.Sprintf("%.0f", math.Abs(v))
+}
+
+func formatCBSignedMoney(v float64) string {
+	if v < 0 {
+		return fmt.Sprintf("-$%s", formatCBMoney(v))
+	}
+	return fmt.Sprintf("$%s", formatCBMoney(v))
+}
+
+func formatCBNumber(v float64) string {
+	return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.2f", v), "0"), ".")
+}
+
+func formatCBQty(v float64) string {
+	return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.6f", v), "0"), ".")
+}
+
+func formatCBPrice(v float64) string {
+	abs := math.Abs(v)
+	switch {
+	case abs >= 1000:
+		return fmt.Sprintf("%.0f", v)
+	case abs >= 1:
+		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.4f", v), "0"), ".")
+	default:
+		return fmt.Sprintf("%.6g", v)
+	}
+}
+
+func truncateCircuitBreakerField(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
+}

--- a/scheduler/circuit_breaker_alert.go
+++ b/scheduler/circuit_breaker_alert.go
@@ -324,9 +324,6 @@ func circuitBreakerAsset(sc StrategyConfig) string {
 	if sc.Symbol != "" {
 		return sc.Symbol
 	}
-	if len(sc.Args) > 1 {
-		return sc.Args[1]
-	}
 	return extractAsset(sc)
 }
 

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -701,6 +701,50 @@ func (sdb *StateDB) InsertTrade(strategyID string, trade Trade) error {
 	return nil
 }
 
+// RecentTradesForStrategy returns the newest trade rows for one strategy.
+func (sdb *StateDB) RecentTradesForStrategy(strategyID string, limit int) ([]Trade, error) {
+	if sdb == nil || sdb.db == nil {
+		return nil, fmt.Errorf("state db unavailable")
+	}
+	if strings.TrimSpace(strategyID) == "" {
+		return nil, fmt.Errorf("strategy id required")
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+	rows, err := sdb.db.Query(`SELECT timestamp, strategy_id, symbol, COALESCE(position_id, '') AS position_id, side, quantity, price, value, trade_type, details, exchange_order_id, exchange_fee, is_close, realized_pnl, COALESCE(regime, '') AS regime, COALESCE(entry_atr, 0) AS entry_atr, COALESCE(stop_loss_oid, 0) AS stop_loss_oid, COALESCE(stop_loss_trigger_px, 0) AS stop_loss_trigger_px, COALESCE(tp_oids_json, '') AS tp_oids_json, COALESCE(manual, 0) AS manual, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json
+		FROM trades WHERE strategy_id = ? ORDER BY timestamp DESC, rowid DESC LIMIT ?`, strategyID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query recent trades for %s: %w", strategyID, err)
+	}
+	defer rows.Close()
+	var out []Trade
+	for rows.Next() {
+		var tr Trade
+		var tsStr string
+		var isCloseInt, isManualInt int
+		var tpOIDsJSON string
+		var slATRMult sql.NullFloat64
+		if err := rows.Scan(&tsStr, &tr.StrategyID, &tr.Symbol, &tr.PositionID, &tr.Side, &tr.Quantity, &tr.Price, &tr.Value, &tr.TradeType, &tr.Details, &tr.ExchangeOrderID, &tr.ExchangeFee, &isCloseInt, &tr.RealizedPnL, &tr.Regime, &tr.EntryATR, &tr.StopLossOID, &tr.StopLossTriggerPx, &tpOIDsJSON, &isManualInt, &slATRMult, &tr.TPTiersJSON); err != nil {
+			return nil, fmt.Errorf("scan recent trade for %s: %w", strategyID, err)
+		}
+		tr.Timestamp = parseTime(tsStr)
+		tr.IsClose = isCloseInt != 0
+		tr.Manual = isManualInt != 0
+		tr.TPOIDs = parseTPOIDsJSON(tpOIDsJSON, 0, 0)
+		if slATRMult.Valid {
+			v := slATRMult.Float64
+			tr.StopLossATRMult = &v
+		}
+		tr.persisted = true
+		out = append(out, tr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate recent trades for %s: %w", strategyID, err)
+	}
+	return out, nil
+}
+
 // UpdateTradeStampedFields updates open-trade snapshot fields on an existing
 // trade row identified by (strategy_id, timestamp). The normal same-cycle open
 // path writes these fields in InsertTrade; this remains for fallback arming

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1449,9 +1449,13 @@ func main() {
 					}
 					mu.Lock()
 					allowed, reason := CheckRisk(&sc, stratState, pv, prices, logger, riskAssist)
+					cbSnapshot := perStrategyCircuitBreakerSnapshot{}
+					if !allowed {
+						cbSnapshot = snapshotPerStrategyCircuitBreaker(stratState, prices)
+					}
 					mu.Unlock()
 					if !allowed {
-						notifyPerStrategyCircuitBreaker(sc, reason, pv, notifier, killSwitchFired)
+						notifyPerStrategyCircuitBreakerWithSnapshot(sc, cbSnapshot, reason, pv, totalPV, stateDB, notifier, killSwitchFired)
 						logger.Warn("Risk block: %s (portfolio=$%.2f)", reason, pv)
 						logger.Close()
 						lastRun[sc.ID] = time.Now()
@@ -2667,10 +2671,30 @@ func shouldSkipZeroCapital(sc StrategyConfig) bool {
 }
 
 func notifyPerStrategyCircuitBreaker(sc StrategyConfig, reason string, portfolioValue float64, notifier *MultiNotifier, portfolioKillSwitchFired bool) {
+	notifyPerStrategyCircuitBreakerWithSnapshot(sc, perStrategyCircuitBreakerSnapshot{}, reason, portfolioValue, 0, nil, notifier, portfolioKillSwitchFired)
+}
+
+func notifyPerStrategyCircuitBreakerWithSnapshot(sc StrategyConfig, snap perStrategyCircuitBreakerSnapshot, reason string, strategyValue, totalPortfolioValue float64, sdb *StateDB, notifier *MultiNotifier, portfolioKillSwitchFired bool) {
 	if notifier == nil || !notifier.HasBackends() || portfolioKillSwitchFired || !isFreshPerStrategyCircuitBreaker(reason) {
 		return
 	}
-	msg := formatPerStrategyCircuitBreakerMessage(sc.ID, reason, portfolioValue)
+	var recent []Trade
+	if sdb != nil {
+		rows, err := sdb.RecentTradesForStrategy(sc.ID, circuitBreakerAlertMaxRows)
+		if err != nil {
+			fmt.Printf("[WARN] circuit-breaker recent-trade lookup failed for %s: %v\n", sc.ID, err)
+		} else {
+			recent = rows
+		}
+	}
+	msg := formatPerStrategyCircuitBreakerBlock(perStrategyCircuitBreakerFormatInput{
+		Strategy:            sc,
+		Snapshot:            snap,
+		Reason:              reason,
+		StrategyValue:       strategyValue,
+		TotalPortfolioValue: totalPortfolioValue,
+		RecentTrades:        recent,
+	})
 	notifier.SendToAllChannels(msg)
 	notifier.SendOwnerDM(msg)
 }
@@ -2681,16 +2705,6 @@ func isFreshPerStrategyCircuitBreaker(reason string) bool {
 	}
 	return strings.HasPrefix(reason, RiskReasonMaxDrawdownExceeded) ||
 		strings.HasPrefix(reason, RiskReasonConsecutiveLosses)
-}
-
-func formatPerStrategyCircuitBreakerMessage(strategyID, reason string, portfolioValue float64) string {
-	// The max-drawdown reason already embeds a portfolio=$... token, so don't
-	// append a duplicate trailing value. Consecutive-losses reasons carry no
-	// portfolio context, so include it there.
-	if strings.Contains(reason, "portfolio=$") {
-		return fmt.Sprintf("**CIRCUIT BREAKER** [%s] %s", strategyID, reason)
-	}
-	return fmt.Sprintf("**CIRCUIT BREAKER** [%s] %s (portfolio=$%.2f)", strategyID, reason, portfolioValue)
 }
 
 // sendTradeAlerts sends trade alerts via DM and/or channel for all configured backends.

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1450,7 +1450,7 @@ func main() {
 					mu.Lock()
 					allowed, reason := CheckRisk(&sc, stratState, pv, prices, logger, riskAssist)
 					cbSnapshot := perStrategyCircuitBreakerSnapshot{}
-					if !allowed {
+					if !allowed && isFreshPerStrategyCircuitBreaker(reason) {
 						cbSnapshot = snapshotPerStrategyCircuitBreaker(stratState, prices)
 					}
 					mu.Unlock()

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -742,6 +742,9 @@ func main() {
 			fmt.Println()
 		}
 
+		totalPV := 0.0
+		sharedWallets := detectSharedWallets(cfg.Strategies)
+
 		// Process only due strategies
 		if saveFailures >= 3 {
 			fmt.Println("[CRITICAL] State save failed 3x, skipping trades this cycle")
@@ -749,6 +752,9 @@ func main() {
 			// /api/regime must not keep serving the prior cycle's labels as
 			// fake-live while trading is suspended.
 			globalRegimeStore.resetForCycle(time.Now().UTC())
+			mu.RLock()
+			totalPV, _ = computeTotalPortfolioValue(cfg.Strategies, state, prices, nil, sharedWallets)
+			mu.RUnlock()
 		} else {
 			// #879: kick off the per-cycle global regime store — one regime
 			// subprocess per distinct (platform, symbol, timeframe, spec)
@@ -772,6 +778,7 @@ func main() {
 			// perps strategies on the same account don't get double-counted.
 			killSwitchFired := false
 			notionalBlocked := false
+			usedPVFallback := false
 
 			// Partition HL live strategies up-front: shared-wallet detection
 			// must see all strategies in cfg, while position sync only touches
@@ -851,7 +858,6 @@ func main() {
 				}
 			}
 
-			sharedWallets := detectSharedWallets(cfg.Strategies)
 			hlAddr := os.Getenv("HYPERLIQUID_ACCOUNT_ADDRESS")
 			hlKey := SharedWalletKey{Platform: "hyperliquid", Account: hlAddr}
 			_, hlShared := sharedWallets[hlKey]
@@ -927,7 +933,7 @@ func main() {
 			}
 
 			mu.RLock()
-			totalPV, usedPVFallback := computeTotalPortfolioValue(cfg.Strategies, state, prices, walletBalances, sharedWallets)
+			totalPV, usedPVFallback = computeTotalPortfolioValue(cfg.Strategies, state, prices, walletBalances, sharedWallets)
 			totalNotional := PortfolioNotional(state.Strategies, prices)
 			// #296: aggregate perps margin drawdown inputs alongside the
 			// equity total so the portfolio kill switch can fire on a
@@ -2134,16 +2140,16 @@ func main() {
 			} // end if !killSwitchFired
 		}
 
-		// Calculate total portfolio value and per-channel values/strategies.
+		// Calculate per-channel values/strategies. totalPV above already uses
+		// shared-wallet-aware aggregation; summing per-strategy PV here would
+		// double-count live strategies sharing one exchange account.
 		// Group by logical channel key (platform or type) so summaries work with any backend.
 		mu.RLock()
-		totalValue := 0.0
 		channelValue := make(map[string]float64)
 		channelStrats := make(map[string][]StrategyConfig)
 		for _, sc := range cfg.Strategies {
 			if s, ok := state.Strategies[sc.ID]; ok {
 				pv := PortfolioValue(s, prices)
-				totalValue += pv
 				if chKey := notifier.resolveChannelKey(sc.Platform, sc.Type); chKey != "" {
 					channelValue[chKey] += pv
 					channelStrats[chKey] = append(channelStrats[chKey], sc)
@@ -2153,7 +2159,7 @@ func main() {
 		mu.RUnlock()
 
 		elapsed := time.Since(cycleStart)
-		logMgr.LogSummary(cycle, elapsed, len(dueStrategies), totalTrades, totalValue)
+		logMgr.LogSummary(cycle, elapsed, len(dueStrategies), totalTrades, totalPV)
 
 		// Pre-compute closed-position history once per cycle so per-channel /
 		// per-asset Sharpe calls (and the later ComputeSharpeByStrategy for

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -76,22 +76,17 @@ func TestApplySignalInversion(t *testing.T) {
 
 func TestNotifyPerStrategyCircuitBreaker_BroadcastsFreshTriggers(t *testing.T) {
 	cases := []struct {
-		name                string
-		reason              string
-		wantTrailingPortVal bool
+		name   string
+		reason string
 	}{
 		{
 			name: "max drawdown",
 			reason: RiskReasonMaxDrawdownExceeded +
 				" (30.0% > 25.0%, portfolio=$700.00 peak=$1000.00, denom=peak=$1000.00)",
-			// Reason already embeds portfolio=$700.00 — formatter must not
-			// duplicate the value with a trailing (portfolio=$1234.56).
-			wantTrailingPortVal: false,
 		},
 		{
-			name:                "consecutive losses",
-			reason:              RiskReasonConsecutiveLosses,
-			wantTrailingPortVal: true,
+			name:   "consecutive losses",
+			reason: RiskReasonConsecutiveLosses,
 		},
 	}
 
@@ -110,7 +105,7 @@ func TestNotifyPerStrategyCircuitBreaker_BroadcastsFreshTriggers(t *testing.T) {
 					},
 				},
 			}
-			sc := StrategyConfig{ID: "test-strategy", Platform: "binanceus", Type: "spot"}
+			sc := StrategyConfig{ID: "test-strategy", Platform: "binanceus", Type: "spot", Args: []string{"sma_cross", "BTC/USDT", "30m"}}
 
 			notifyPerStrategyCircuitBreaker(sc, tc.reason, 1234.56, notifier, false)
 
@@ -123,15 +118,16 @@ func TestNotifyPerStrategyCircuitBreaker_BroadcastsFreshTriggers(t *testing.T) {
 			for _, msg := range []string{mock.messages[0].content, mock.messages[1].content, mock.dms[0].content} {
 				if !strings.Contains(msg, "**CIRCUIT BREAKER**") ||
 					!strings.Contains(msg, "[test-strategy]") ||
-					!strings.Contains(msg, tc.reason) {
+					!strings.Contains(msg, "Trigger:") ||
+					!strings.Contains(msg, "Portfolio impact:") ||
+					!strings.Contains(msg, "BinanceUS, BTC/USDT, 30m, sma_cross, spot") {
 					t.Fatalf("notification missing required context: %q", msg)
 				}
-				hasTrailing := strings.Contains(msg, "(portfolio=$1234.56)")
-				if tc.wantTrailingPortVal && !hasTrailing {
-					t.Fatalf("expected trailing (portfolio=$1234.56) in %q", msg)
+				if tc.reason == RiskReasonConsecutiveLosses && !strings.Contains(msg, "5 consecutive losses") {
+					t.Fatalf("expected consecutive-loss trigger in %q", msg)
 				}
-				if !tc.wantTrailingPortVal && hasTrailing {
-					t.Fatalf("portfolio value duplicated when reason already embeds one: %q", msg)
+				if strings.HasPrefix(tc.reason, RiskReasonMaxDrawdownExceeded) && !strings.Contains(msg, "30.0% > 25.0%") {
+					t.Fatalf("expected parsed max-drawdown numbers in %q", msg)
 				}
 			}
 		})

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -120,7 +120,7 @@ func TestNotifyPerStrategyCircuitBreaker_BroadcastsFreshTriggers(t *testing.T) {
 					!strings.Contains(msg, "[test-strategy]") ||
 					!strings.Contains(msg, "Trigger:") ||
 					!strings.Contains(msg, "Portfolio impact:") ||
-					!strings.Contains(msg, "BinanceUS, BTC/USDT, 30m, sma_cross, spot") {
+					!strings.Contains(msg, "BinanceUS, BTC, 30m, sma_cross, spot") {
 					t.Fatalf("notification missing required context: %q", msg)
 				}
 				if tc.reason == RiskReasonConsecutiveLosses && !strings.Contains(msg, "5 consecutive losses") {

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -2639,7 +2639,7 @@ func TestFormatPerStrategyCircuitBreakerBlock_IncludesTriageSections(t *testing.
 	})
 
 	for _, want := range []string{
-		"**CIRCUIT BREAKER** [hl-btc-sma-30] - Hyperliquid, BTC, 30m, sma_cross, perps, 5x leverage",
+		"**CIRCUIT BREAKER** [hl-btc-sma-30] - Hyperliquid, BTC, 30m, sma_cross, perps",
 		"Trigger: max drawdown exceeded - 8.2% > 5.0% (denom: margin=$300.00)",
 		"Cooldown: 1d0h (until 2026-06-07 06:08 UTC)",
 		"Portfolio impact: ~$4195 of ~$10060 (41.7%)",
@@ -2655,6 +2655,9 @@ func TestFormatPerStrategyCircuitBreakerBlock_IncludesTriageSections(t *testing.
 		if !strings.Contains(msg, want) {
 			t.Errorf("circuit-breaker message missing %q:\n%s", want, msg)
 		}
+	}
+	if header, _, _ := strings.Cut(msg, "\n"); strings.Contains(header, "leverage") {
+		t.Fatalf("circuit-breaker header should not duplicate leverage context: %q", header)
 	}
 	if len(msg) >= 2000 {
 		t.Fatalf("circuit-breaker message len = %d, want under Discord limit; msg:\n%s", len(msg), msg)

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -2588,3 +2588,75 @@ func TestRiskState_PendingCircuitClose_LegacyShapeDefaultsZeroConsecutiveFailure
 		t.Errorf("legacy row must default LastNotifiedAt=zero, got %v", got.LastNotifiedAt)
 	}
 }
+
+func TestFormatPerStrategyCircuitBreakerBlock_IncludesTriageSections(t *testing.T) {
+	now := time.Date(2026, 6, 6, 6, 8, 0, 0, time.UTC)
+	sc := StrategyConfig{
+		ID:         "hl-btc-sma-30",
+		Type:       "perps",
+		Platform:   "hyperliquid",
+		Args:       []string{"sma_cross", "BTC", "30m", "--mode=live"},
+		Leverage:   5,
+		CapitalPct: 0.417,
+	}
+	state := &StrategyState{
+		ID:              sc.ID,
+		Type:            sc.Type,
+		Platform:        sc.Platform,
+		Cash:            4200,
+		InitialCapital:  4500,
+		Positions:       map[string]*Position{},
+		OptionPositions: map[string]*OptionPosition{},
+		RiskState: RiskState{
+			PeakValue:           4500,
+			CurrentDrawdownPct:  8.2,
+			MaxDrawdownPct:      5,
+			ConsecutiveLosses:   5,
+			CircuitBreaker:      true,
+			CircuitBreakerUntil: now.Add(24 * time.Hour),
+			PendingCircuitCloses: map[string]*PendingCircuitClose{
+				PlatformPendingCloseOKXSpot: {
+					Symbols:          []PendingCircuitCloseSymbol{{Symbol: "BTC-USDT", Size: 0.5}},
+					OperatorRequired: true,
+				},
+			},
+		},
+		ClosedPositions: []ClosedPosition{
+			{StrategyID: sc.ID, Symbol: "BTC", Quantity: 0.5, Side: "short", ClosePrice: 67800, RealizedPnL: -180, CloseReason: "circuit_breaker"},
+		},
+	}
+	snap := snapshotPerStrategyCircuitBreaker(state, map[string]float64{"BTC": 67800})
+	snap.Now = now
+	msg := formatPerStrategyCircuitBreakerBlock(perStrategyCircuitBreakerFormatInput{
+		Strategy:            sc,
+		Snapshot:            snap,
+		Reason:              RiskReasonMaxDrawdownExceeded + " (8.2% > 5.0%, portfolio=$4200.00 peak=$4500.00, denom=margin=$300.00)",
+		StrategyValue:       4200,
+		TotalPortfolioValue: 10060,
+		RecentTrades: []Trade{
+			{Timestamp: now.Add(-7 * time.Minute), StrategyID: sc.ID, Symbol: "BTC", Side: "buy", Quantity: 0.5, Price: 67800, IsClose: true, RealizedPnL: -180, Details: "Circuit breaker close short, PnL: $-180.00"},
+		},
+	})
+
+	for _, want := range []string{
+		"**CIRCUIT BREAKER** [hl-btc-sma-30] - Hyperliquid, BTC, 30m, sma_cross, perps, 5x leverage",
+		"Trigger: max drawdown exceeded - 8.2% > 5.0% (denom: margin=$300.00)",
+		"Cooldown: 1d0h (until 2026-06-07 06:08 UTC)",
+		"Portfolio impact: ~$4195 of ~$10060 (41.7%)",
+		"Perps context: 5x leverage, margin deployed=$300.00",
+		"Positions force-closed:",
+		"short 0.5 BTC @ $67800  P&L -$180",
+		"Pending operator closes:",
+		"okx_spot BTC-USDT size 0.5 (manual flatten required)",
+		"Recent trades:",
+		"06:01  close  buy 0.5 BTC @ $67800 P&L -$180",
+		"Reason: Investigate whether the signal is still valid or the regime has flipped.",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("circuit-breaker message missing %q:\n%s", want, msg)
+		}
+	}
+	if len(msg) >= 2000 {
+		t.Fatalf("circuit-breaker message len = %d, want under Discord limit; msg:\n%s", len(msg), msg)
+	}
+}

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -2660,3 +2660,21 @@ func TestFormatPerStrategyCircuitBreakerBlock_IncludesTriageSections(t *testing.
 		t.Fatalf("circuit-breaker message len = %d, want under Discord limit; msg:\n%s", len(msg), msg)
 	}
 }
+
+func TestCircuitBreakerStrategyLabel_SkipsFlagTimeframe(t *testing.T) {
+	sc := StrategyConfig{
+		ID:       "deribit-btc-options",
+		Type:     "options",
+		Platform: "deribit",
+		Args:     []string{"wheel", "BTC", "--platform=deribit"},
+	}
+	got := circuitBreakerStrategyLabel(sc)
+	if strings.Contains(got, "--platform=deribit") {
+		t.Fatalf("strategy label rendered flag as timeframe: %q", got)
+	}
+	for _, want := range []string{"Deribit", "BTC", "wheel", "options"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("strategy label missing %q: %q", want, got)
+		}
+	}
+}

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -2678,3 +2678,19 @@ func TestCircuitBreakerStrategyLabel_SkipsFlagTimeframe(t *testing.T) {
 		}
 	}
 }
+
+func TestCircuitBreakerStrategyLabel_StripsSpotQuoteSuffix(t *testing.T) {
+	sc := StrategyConfig{
+		ID:       "spot-btc",
+		Type:     "spot",
+		Platform: "binanceus",
+		Args:     []string{"sma_cross", "BTC/USDT", "30m"},
+	}
+	got := circuitBreakerStrategyLabel(sc)
+	if !strings.Contains(got, "BinanceUS, BTC, 30m, sma_cross, spot") {
+		t.Fatalf("strategy label = %q, want normalized BTC asset", got)
+	}
+	if strings.Contains(got, "BTC/USDT") {
+		t.Fatalf("strategy label should not render raw spot pair: %q", got)
+	}
+}


### PR DESCRIPTION
Fixes #905

## Summary
- Add multi-line per-strategy circuit-breaker alert formatting with strategy label, trigger details, cooldown, portfolio impact, perps context, force-closed/open exposure, pending operator closes, recent trades, and deterministic recommendation
- Snapshot circuit-breaker state after CheckRisk and query recent strategy trades for notification context
- Preserve the existing one-line CheckRisk reason and the existing notifyPerStrategyCircuitBreaker wrapper signature

## Tests
- env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...