### PR TITLE
fix(hl): book shared-wallet external closes at userFills price when available

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -500,10 +500,7 @@ func tryBookSoleOwnerTPFill(
 		tpPrice = tpPrices[tierIdx]
 	}
 
-	closePx := tpPrice
-	if useFillFee && lookup.Px > 0 {
-		closePx = lookup.Px
-	}
+	closePx := hlReconcileExternalClosePx(tpPrice, lookup, useFillFee)
 	if closePx <= 0 {
 		return false
 	}
@@ -1010,14 +1007,15 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 						}
 					}
 				} else if mark, ok := prices[coin]; ok && mark > 0 {
-					// #584: credit s.Cash with mark-based PnL so the per-strategy
+					// #584: credit s.Cash with close-based PnL so the per-strategy
 					// PortfolioValue (and the summary TOTAL) match the real HL
-					// account after an external close. The mark is fetched at
-					// cycle start, so cp.RealizedPnL is an *approximation* — it
-					// will drift from the true on-chain fill price (which can be
-					// minutes earlier). Do not treat the resulting Trade /
-					// ClosedPosition rows as authoritative for tax or reporting;
-					// they exist to keep cash bookkeeping in sync.
+					// account after an external close. When userFills matches the
+					// close (#909), hlReconcileExternalClosePx books at the fill
+					// VWAP; otherwise the cycle-start mark is an approximation that
+					// can drift from the true on-chain fill price. Do not treat
+					// the resulting Trade / ClosedPosition rows as authoritative
+					// for tax or reporting; they exist to keep cash bookkeeping
+					// in sync.
 					lookup, useFillFee := resolveFee(coin, 0, pos.Quantity)
 					logHyperliquidReconcileFillLookup(logger, coin, 0, pos.Quantity, lookup, useFillFee)
 					closePx := hlReconcileExternalClosePx(mark, lookup, useFillFee)

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -56,6 +56,15 @@ func hlReconcileSLFillConfirmed(lookup HLFillLookup, useFillFee bool, stopLossOI
 	return useFillFee && lookup.OID == stopLossOID && lookup.FilledQty > 1e-9
 }
 
+// hlReconcileExternalClosePx prefers the matched userFills price when available
+// (#909), otherwise falls back to mark.
+func hlReconcileExternalClosePx(mark float64, lookup HLFillLookup, useFillFee bool) float64 {
+	if useFillFee && lookup.Px > 0 {
+		return lookup.Px
+	}
+	return mark
+}
+
 var hlMainnetURL = "https://api.hyperliquid.xyz"
 
 // hyperliquidLiveCloseScript is the path to the Python close helper. Exposed as
@@ -986,7 +995,8 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 						if mark, ok := prices[coin]; ok && mark > 0 {
 							lookupExt, useFillFeeExt := resolveFee(coin, 0, pos.Quantity)
 							logHyperliquidReconcileFillLookup(logger, coin, 0, pos.Quantity, lookupExt, useFillFeeExt)
-							if recordPerpsExternalCloseWithFillFee(ss, coin, mark, lookupExt.Fee, useFillFeeExt, "", "hl_sync_external", logger) {
+							closePx := hlReconcileExternalClosePx(mark, lookupExt, useFillFeeExt)
+							if recordPerpsExternalCloseWithFillFee(ss, coin, closePx, lookupExt.Fee, useFillFeeExt, "", "hl_sync_external", logger) {
 								changed = true
 							}
 						} else {
@@ -1010,7 +1020,8 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 					// they exist to keep cash bookkeeping in sync.
 					lookup, useFillFee := resolveFee(coin, 0, pos.Quantity)
 					logHyperliquidReconcileFillLookup(logger, coin, 0, pos.Quantity, lookup, useFillFee)
-					if recordPerpsExternalCloseWithFillFee(ss, coin, mark, lookup.Fee, useFillFee, "", "hl_sync_external", logger) {
+					closePx := hlReconcileExternalClosePx(mark, lookup, useFillFee)
+					if recordPerpsExternalCloseWithFillFee(ss, coin, closePx, lookup.Fee, useFillFee, "", "hl_sync_external", logger) {
 						changed = true
 					}
 				} else {
@@ -1112,7 +1123,8 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 							if mark, ok := prices[coin]; ok && mark > 0 {
 								lookupExt, useFillFeeExt := resolveFee(coin, 0, slOwnerPos.Quantity)
 								logHyperliquidReconcileFillLookup(logger, coin, 0, slOwnerPos.Quantity, lookupExt, useFillFeeExt)
-								if recordPerpsExternalCloseWithFillFee(ownerSS, coin, mark, lookupExt.Fee, useFillFeeExt, "", "hl_sync_external", logger) {
+								closePx := hlReconcileExternalClosePx(mark, lookupExt, useFillFeeExt)
+								if recordPerpsExternalCloseWithFillFee(ownerSS, coin, closePx, lookupExt.Fee, useFillFeeExt, "", "hl_sync_external", logger) {
 									changed = true
 									virtualQty = expectedResidual
 									delta = virtualQty - onChainQty
@@ -1204,7 +1216,8 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 							if useFillFee && lookup.OID > 0 {
 								detector3OID = strconv.FormatInt(lookup.OID, 10)
 							}
-							if recordPerpsExternalPartialCloseWithFillFee(candidateSS, coin, closeQty, mark, lookup.Fee, useFillFee, detector3OID, "hl_sync_external_partial", logger) {
+							closePx := hlReconcileExternalClosePx(mark, lookup, useFillFee)
+							if recordPerpsExternalPartialCloseWithFillFee(candidateSS, coin, closeQty, closePx, lookup.Fee, useFillFee, detector3OID, "hl_sync_external_partial", logger) {
 								changed = true
 								if closeSide == "long" {
 									virtualQty -= closeQty

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -746,7 +746,7 @@ func syncHyperliquidAccountPositions(hlStrategies []StrategyConfig, state *AppSt
 // `notify_tp_sl_fills: false`.
 //
 // Must be called WITHOUT holding any lock; acquires Lock internally.
-func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager, positions []HLPosition, prices map[string]float64, accountAddress string, notifier *MultiNotifier, notifyTPSLFills bool) (bool, []HyperliquidProtectionFillHint, []RegimeDirectionOrphanCloseJob) {
+func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []StrategyConfig, state *AppState, mu *sync.RWMutex, logMgr *LogManager, positions []HLPosition, prices map[string]float64, accountAddress string, notifier ownerDMSender, notifyTPSLFills bool) (bool, []HyperliquidProtectionFillHint, []RegimeDirectionOrphanCloseJob) {
 	// Resolve userFills BEFORE taking mu.Lock(): each lookup can sleep up
 	// to ~1.5s on indexer-lag retries, and holding the write lock blocks
 	// every reader of state (/status, /health, per-strategy phase RLocks).
@@ -1240,7 +1240,7 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 									Side:            closeSide,
 									FillType:        tpTierLabel(candidateTierIdx),
 									IsPartial:       true,
-									FillPrice:       mark,
+									FillPrice:       closePx,
 									CloseQty:        closeQty,
 									RemainingQty:    remaining,
 									RealizedPnL:     lastBookedTradePnL(candidateSS),

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1447,6 +1447,93 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally_CreditsPeerCash(t *tes
 	}
 }
 
+func TestHlReconcileExternalClosePx(t *testing.T) {
+	const mark = 63564.5
+	const fillPx = 63597.0
+	lookup := HLFillLookup{Px: fillPx, Fee: 1.2, Count: 1}
+
+	if got := hlReconcileExternalClosePx(mark, lookup, true); got != fillPx {
+		t.Errorf("with fill Px = %v, got %v", fillPx, got)
+	}
+	if got := hlReconcileExternalClosePx(mark, HLFillLookup{Fee: 1.2, Count: 1}, true); got != mark {
+		t.Errorf("missing Px should fall back to mark %v, got %v", mark, got)
+	}
+	if got := hlReconcileExternalClosePx(mark, lookup, false); got != mark {
+		t.Errorf("useFillFee=false should fall back to mark %v, got %v", mark, got)
+	}
+}
+
+// TestReconcileSharedCoin_ExternalCloseUsesFillPriceWhenAvailable is the #909
+// regression: when userFills matches an external close and returns Px, book at
+// the fill price instead of the cycle mark.
+func TestReconcileSharedCoin_ExternalCloseUsesFillPriceWhenAvailable(t *testing.T) {
+	const peerStartCash = 500.0
+	const peerQty = 0.5
+	const peerAvgCost = 63000.0
+	const mark = 63564.5
+	const fillPx = 63597.0
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-btc": {
+				ID: "hl-owner-btc", Cash: 10000, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"BTC": {Symbol: "BTC", Quantity: 1.0, AvgCost: 63000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-btc",
+						StopLossOID: 7, StopLossTriggerPx: 62000},
+				},
+			},
+			"hl-peer-btc": {
+				ID: "hl-peer-btc", Cash: peerStartCash, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"BTC": {Symbol: "BTC", Quantity: peerQty, AvgCost: peerAvgCost, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-peer-btc"},
+				},
+			},
+		},
+	}
+
+	allStrategies := []StrategyConfig{
+		{ID: "hl-owner-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "BTC", "1h", "--mode=live"}},
+		{ID: "hl-peer-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{}
+	prices := map[string]float64{"BTC": mark}
+	wantPeerFee := 0.42
+
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(_, coin string, oid int64, qty float64) (HLFillLookup, bool) {
+		if oid == 7 && coin == "BTC" {
+			return HLFillLookup{Fee: 0.02, FilledQty: 1.0, Px: 62000, Count: 1, OID: 7}, true
+		}
+		if oid == 0 && coin == "BTC" && math.Abs(qty-peerQty) < 1e-9 {
+			return HLFillLookup{Fee: wantPeerFee, Px: fillPx, Count: 1, OID: 4242}, true
+		}
+		return HLFillLookup{}, false
+	}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "0xtest", nil, false)
+
+	peer := state.Strategies["hl-peer-btc"]
+	if len(peer.ClosedPositions) != 1 {
+		t.Fatalf("peer ClosedPositions = %d, want 1", len(peer.ClosedPositions))
+	}
+	cp := peer.ClosedPositions[0]
+	if cp.ClosePrice != fillPx {
+		t.Errorf("ClosePrice = %v, want fill %v (not mark %v)", cp.ClosePrice, fillPx, mark)
+	}
+	wantPnL := peerQty*(fillPx-peerAvgCost) - wantPeerFee
+	if math.Abs(cp.RealizedPnL-wantPnL) > 1e-6 {
+		t.Errorf("RealizedPnL = %v, want %v", cp.RealizedPnL, wantPnL)
+	}
+	if math.Abs(peer.Cash-(peerStartCash+wantPnL)) > 1e-6 {
+		t.Errorf("peer Cash = %v, want %v", peer.Cash, peerStartCash+wantPnL)
+	}
+}
+
 // TestReconcileSharedCoin_Detector1_WrongOIDInUserfillsBooksExternal is a #756
 // regression: userFills hit for the SL lookup query but with a non-matching OID
 // must not book hl_sync_stop_loss — fall back to mark-based hl_sync_external.

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1534,6 +1534,202 @@ func TestReconcileSharedCoin_ExternalCloseUsesFillPriceWhenAvailable(t *testing.
 	}
 }
 
+// TestReconcileSharedCoin_Detector1_ExternalFallbackUsesFillPrice verifies
+// Detector 1's SL-unfilled external path books at userFills Px (#909).
+func TestReconcileSharedCoin_Detector1_ExternalFallbackUsesFillPrice(t *testing.T) {
+	const mark = 61000.0
+	const fillPx = 60800.0
+	const ownerQty = 0.2
+	const ownerAvgCost = 60000.0
+	const wantFee = 0.85
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-btc": {
+				ID: "hl-owner-btc", Cash: 10000, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"BTC": {Symbol: "BTC", Quantity: ownerQty, AvgCost: ownerAvgCost, Side: "long",
+						Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-owner-btc",
+						StopLossOID: 5005, StopLossTriggerPx: 58000},
+				},
+			},
+			"hl-peer-btc": {
+				ID: "hl-peer-btc", Cash: 10000, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"BTC": {Symbol: "BTC", Quantity: 0.1, AvgCost: 60500, Side: "long",
+						Multiplier: 1, Leverage: 5, OwnerStrategyID: "hl-peer-btc"},
+				},
+			},
+		},
+	}
+	scs := []StrategyConfig{
+		{ID: "hl-owner-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"hold", "BTC", "1h", "--mode=live"}, Leverage: 5},
+		{ID: "hl-peer-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"hold", "BTC", "1h", "--mode=live"}, Leverage: 5},
+	}
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(_, coin string, oid int64, qty float64) (HLFillLookup, bool) {
+		if oid == 5005 {
+			return HLFillLookup{Fee: 1.0, FilledQty: ownerQty, Count: 1, OID: 9999}, true
+		}
+		if oid == 0 && coin == "BTC" && math.Abs(qty-ownerQty) < 1e-9 {
+			return HLFillLookup{Fee: wantFee, Px: fillPx, Count: 1, OID: 8888}, true
+		}
+		return HLFillLookup{}, false
+	}
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	prices := map[string]float64{"BTC": mark}
+	_, _, _ = reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, nil, prices, "0xtest", nil, false)
+
+	owner := state.Strategies["hl-owner-btc"]
+	if len(owner.ClosedPositions) != 1 {
+		t.Fatalf("owner ClosedPositions = %d, want 1", len(owner.ClosedPositions))
+	}
+	cp := owner.ClosedPositions[0]
+	if cp.ClosePrice != fillPx {
+		t.Errorf("owner ClosePrice = %v, want fill %v (not mark %v)", cp.ClosePrice, fillPx, mark)
+	}
+	wantPnL := ownerQty*(fillPx-ownerAvgCost) - wantFee
+	if math.Abs(cp.RealizedPnL-wantPnL) > 1e-6 {
+		t.Errorf("owner RealizedPnL = %v, want %v", cp.RealizedPnL, wantPnL)
+	}
+}
+
+// TestReconcileSharedCoin_Detector2_ExternalFallbackUsesFillPrice verifies
+// Detector 2's SL-unfilled external path books at userFills Px (#909).
+func TestReconcileSharedCoin_Detector2_ExternalFallbackUsesFillPrice(t *testing.T) {
+	const mark = 3020.0
+	const fillPx = 3010.0
+	const ownerQty = 1.0
+	const ownerAvgCost = 3000.0
+	const wantFee = 1.05
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-eth": {
+				ID: "hl-owner-eth", Cash: 1000, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: ownerQty, AvgCost: ownerAvgCost, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth",
+						StopLossOID: 4242, StopLossTriggerPx: 2900},
+				},
+			},
+			"hl-peer-eth": {
+				ID: "hl-peer-eth", Cash: 500, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-peer-eth"},
+				},
+			},
+		},
+	}
+	scs := []StrategyConfig{
+		{ID: "hl-owner-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-peer-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 0.5, EntryPrice: 3000, Leverage: 10}}
+	prices := map[string]float64{"ETH": mark}
+
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(_, coin string, oid int64, qty float64) (HLFillLookup, bool) {
+		if oid == 4242 {
+			return HLFillLookup{Fee: 0.1, FilledQty: ownerQty, Count: 1, OID: 9999}, true
+		}
+		if oid == 0 && coin == "ETH" && math.Abs(qty-ownerQty) < 1e-9 {
+			return HLFillLookup{Fee: wantFee, Px: fillPx, Count: 1, OID: 7777}, true
+		}
+		return HLFillLookup{}, false
+	}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	_, _, _ = reconcileHyperliquidAccountPositions(scs, scs, state, &mu, logMgr, positions, prices, "0xtest", nil, false)
+
+	owner := state.Strategies["hl-owner-eth"]
+	if len(owner.ClosedPositions) != 1 {
+		t.Fatalf("owner ClosedPositions = %d, want 1", len(owner.ClosedPositions))
+	}
+	cp := owner.ClosedPositions[0]
+	if cp.ClosePrice != fillPx {
+		t.Errorf("owner ClosePrice = %v, want fill %v (not mark %v)", cp.ClosePrice, fillPx, mark)
+	}
+	wantPnL := ownerQty*(fillPx-ownerAvgCost) - wantFee
+	if math.Abs(cp.RealizedPnL-wantPnL) > 1e-6 {
+		t.Errorf("owner RealizedPnL = %v, want %v", cp.RealizedPnL, wantPnL)
+	}
+}
+
+// TestReconcileSharedCoin_Detector3_PartialUsesFillPrice verifies Detector 3's
+// external partial path books at userFills Px (#909).
+func TestReconcileSharedCoin_Detector3_PartialUsesFillPrice(t *testing.T) {
+	const ownerStartCash = 1000.0
+	const ownerQty = 0.5
+	const peerQty = 0.5
+	const avgCost = 3000.0
+	const mark = 3200.0
+	const fillPx = 3185.0
+	const closeQty = 0.25
+	const wantFee = 0.28
+
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-eth": {
+				ID: "hl-owner-eth", Cash: ownerStartCash, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: ownerQty, InitialQuantity: ownerQty, AvgCost: avgCost, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth",
+						EntryATR: 100, StopLossOID: 77, StopLossTriggerPx: 2900,
+						TPOIDs: []int64{0, 222, 333}},
+				},
+			},
+			"hl-peer-eth": {
+				ID: "hl-peer-eth", Cash: 500, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: peerQty, InitialQuantity: peerQty, AvgCost: avgCost, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-peer-eth"},
+				},
+			},
+		},
+	}
+	allStrategies := []StrategyConfig{
+		{ID: "hl-owner-eth", Platform: "hyperliquid", Type: "perps", CloseStrategy: &StrategyRef{Name: "tiered_tp_atr_live"}, Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-peer-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 0.75, EntryPrice: avgCost, Leverage: 10}}
+	prices := map[string]float64{"ETH": mark}
+
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(_, coin string, oid int64, qty float64) (HLFillLookup, bool) {
+		if oid == 0 && coin == "ETH" && math.Abs(qty-closeQty) < 1e-9 {
+			return HLFillLookup{Fee: wantFee, Px: fillPx, Count: 1, OID: 5555}, true
+		}
+		return HLFillLookup{}, false
+	}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "0xtest", nil, false)
+
+	owner := state.Strategies["hl-owner-eth"]
+	if len(owner.TradeHistory) != 1 {
+		t.Fatalf("owner close trades = %d, want 1", len(owner.TradeHistory))
+	}
+	tr := owner.TradeHistory[0]
+	if !tr.IsClose || math.Abs(tr.Quantity-closeQty) > 1e-9 || tr.Price != fillPx {
+		t.Errorf("close trade = %+v, want close %.2f @ fill %v", tr, closeQty, fillPx)
+	}
+	wantPnL := closeQty*(fillPx-avgCost) - wantFee
+	if math.Abs(tr.RealizedPnL-wantPnL) > 1e-6 {
+		t.Errorf("trade RealizedPnL = %v, want %v", tr.RealizedPnL, wantPnL)
+	}
+	if math.Abs(owner.Cash-(ownerStartCash+wantPnL)) > 1e-6 {
+		t.Errorf("owner Cash = %v, want %v", owner.Cash, ownerStartCash+wantPnL)
+	}
+}
+
 // TestReconcileSharedCoin_Detector1_WrongOIDInUserfillsBooksExternal is a #756
 // regression: userFills hit for the SL lookup query but with a non-matching OID
 // must not book hl_sync_stop_loss — fall back to mark-based hl_sync_external.

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1711,7 +1712,8 @@ func TestReconcileSharedCoin_Detector3_PartialUsesFillPrice(t *testing.T) {
 
 	logMgr, _ := NewLogManager(t.TempDir())
 	var mu sync.RWMutex
-	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "0xtest", nil, false)
+	dm := &countingDMSender{}
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, positions, prices, "0xtest", dm, true)
 
 	owner := state.Strategies["hl-owner-eth"]
 	if len(owner.TradeHistory) != 1 {
@@ -1727,6 +1729,16 @@ func TestReconcileSharedCoin_Detector3_PartialUsesFillPrice(t *testing.T) {
 	}
 	if math.Abs(owner.Cash-(ownerStartCash+wantPnL)) > 1e-6 {
 		t.Errorf("owner Cash = %v, want %v", owner.Cash, ownerStartCash+wantPnL)
+	}
+	if dm.count != 1 {
+		t.Fatalf("protection fill DM = %d, want 1", dm.count)
+	}
+	wantPriceInDM := fmt.Sprintf("@ $%.4f", fillPx)
+	if !strings.Contains(dm.last, wantPriceInDM) {
+		t.Errorf("DM should report fill price %s, got:\n%s", wantPriceInDM, dm.last)
+	}
+	if strings.Contains(dm.last, fmt.Sprintf("@ $%.4f", mark)) {
+		t.Errorf("DM should not report mark %v, got:\n%s", mark, dm.last)
 	}
 }
 

--- a/scheduler/hyperliquid_fills.go
+++ b/scheduler/hyperliquid_fills.go
@@ -487,6 +487,41 @@ func buildCachedHyperliquidReconcileFillResolver(accountAddress string, allStrat
 			}
 		}
 	}
+	// Shared-coin Detector 3 partial: prefetch the aggregate virtual/on-chain
+	// drift qty. Per-strategy prefetch above uses each strategy's own qty, but
+	// Detector 3 books the coin-level delta (sum of peers minus on-chain).
+	coinStratCount := make(map[string]int)
+	coinVirtualQty := make(map[string]float64)
+	for _, sc := range allStrategies {
+		ss := state.Strategies[sc.ID]
+		if ss == nil {
+			continue
+		}
+		sym := hyperliquidSymbol(sc.Args)
+		if sym == "" {
+			continue
+		}
+		coinStratCount[sym]++
+		pos := ss.Positions[sym]
+		if pos == nil || pos.Quantity <= 0 {
+			continue
+		}
+		switch pos.Side {
+		case "long":
+			coinVirtualQty[sym] += pos.Quantity
+		case "short":
+			coinVirtualQty[sym] -= pos.Quantity
+		}
+	}
+	for coin, count := range coinStratCount {
+		if count < 2 {
+			continue
+		}
+		onChainQty := onChainByCoin[coin]
+		if _, closeQty, ok := hyperliquidSharedPartialCloseDrift(coinVirtualQty[coin], onChainQty); ok {
+			addCandidate(coin, 0, closeQty)
+		}
+	}
 	mu.RUnlock()
 
 	if len(candidates) == 0 {


### PR DESCRIPTION
## Summary
- Prefer matched `userFills` `Px` over cycle mark when booking `hl_sync_external` and `hl_sync_external_partial` closes in shared-wallet reconciliation
- Add `hlReconcileExternalClosePx` helper and wire it into Detector 1/2 external fallbacks, the flat external-close path, and Detector 3 partial closes
- Regression tests cover the reported live drift (fill `63597.0` vs mark `63564.5`)

Closes #909

## Test plan
- [x] `go test -run 'TestHlReconcileExternalClosePx|TestReconcileSharedCoin_ExternalCloseUsesFillPriceWhenAvailable|TestReconcileSharedCoin' ./scheduler`

LLM: composer-2.5 | medium | Harness: cursor