### PR TITLE
Restructure @claude review output into verdict + categorized sections

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -162,7 +162,11 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: --model ${{ steps.resolve_model.outputs.model_id }} --effort ${{ steps.resolve_model.outputs.effort }} --allowedTools "Bash(go *),Bash(cd scheduler && go *),Bash(uv run *),Bash(python3 *),Bash(.venv/bin/python3 *),Bash(gofmt *),Bash(cd scheduler && gofmt *),Bash(git *),Bash(gh *)"
+          claude_args: >-
+            --model ${{ steps.resolve_model.outputs.model_id }}
+            --effort ${{ steps.resolve_model.outputs.effort }}
+            --append-system-prompt "PR review output format (this OVERRIDES any final-comment format the code-review skill specifies; keep its multi-agent review process, replace only the shape of the posted comment): The review comment must contain nothing except the structure that follows. Begin with a verdict line that is exactly one of: LGTM, or Needs Updates. Give LGTM only when there are zero findings across every category below; LGTM stands alone with no other text and signals the agent reading it may merge and close the PR. When any finding exists, the first line is Needs Updates, then list every finding under exactly one of these H3 sections, omitting any section that has no items: ### Needs Fixing, ### Recommended Optional, ### Create Follow-up Issue, ### Requires Human Review. Every finding belongs to exactly one section. Within a section use a numbered list; each item is a single bold one-sentence title that states the item, then a newline, then a short description containing only the critical details (file:line and why it matters). Write the entire comment as direct instructions for an agent that will read it and act on it. Do not add any preamble, summary, intro, header, emoji, or footer outside this structure."
+            --allowedTools "Bash(go *),Bash(cd scheduler && go *),Bash(uv run *),Bash(python3 *),Bash(.venv/bin/python3 *),Bash(gofmt *),Bash(cd scheduler && gofmt *),Bash(git *),Bash(gh *)"
 
       - name: Detect if Claude made commits
         if: steps.verify_invocation.outputs.invoked == 'true' && steps.claude.outcome == 'success'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,9 +85,11 @@ Other dirs:
 - **Commits and PR bodies:** end with `LLM: <model> | <effort> | Harness: <action>` (default Claude Code footer slot). Do **not** append any `Co-authored-by:` / `Co-Authored-By` trailer.
 
 ### PR review format (`@claude review`)
-Top-level review comment is one of two shapes — no preamble, no closing:
-1. **Approve:** `LGTM — ` + one-sentence rationale (what was checked + why safe to merge).
-2. **Changes requested:** numbered list (`1.`,`2.`,…), each item one sentence with `file:line` when applicable, ordered by severity. Nice-to-haves under a final `Optional:` line or dropped.
+The posted comment is written as instructions for an agent to act on, and contains **nothing outside this structure** (no preamble, intro, header, emoji, or footer). Enforced via `--append-system-prompt` in `.github/workflows/claude.yml` (overrides the code-review plugin's default comment shape; the multi-agent review process is unchanged).
+- First line is a verdict: exactly `LGTM` **or** `Needs Updates`.
+- `LGTM` stands alone with no explanation — given **only** when there are zero findings in every category. It signals the reading agent may merge and close the PR.
+- When findings exist, the first line is `Needs Updates`, then every finding goes under exactly one H3 section (omit empty sections): `### Needs Fixing`, `### Recommended Optional`, `### Create Follow-up Issue`, `### Requires Human Review`.
+- Each section is a numbered list; each item is a single **bold one-sentence title** stating the item, then a newline, then a description with only the critical details (`file:line` + why it matters).
 Inline review threads are exempt.
 
 ## Build & Deploy


### PR DESCRIPTION
## What

Restructures the output of `@claude review` into a single, predictable shape that a downstream agent can act on directly.

Every review now opens with a one-word verdict and sorts all findings into fixed categories:

- **Verdict line** — exactly `LGTM` or `Needs Updates`.
- **`LGTM`** stands alone with no commentary, and is given *only* when there are zero findings. It signals the reading agent may merge and close the PR.
- **`Needs Updates`** is followed by findings bucketed under exactly one H3 section (empty sections omitted):
  - `### Needs Fixing`
  - `### Recommended Optional`
  - `### Create Follow-up Issue`
  - `### Requires Human Review`
- Each item is a **bold one-sentence title** + a description with only the critical details (`file:line` and why it matters).
- No preamble, header, emoji, or footer outside this structure.

## Why

The prior output was wordy and inconsistent: the code-review plugin's hardcoded comment shape (`### Code review`, "Found N issues", 🤖 footer) conflicted with the terse format `CLAUDE.md` asked for, so reviews rendered non-deterministically. This makes the output machine-actionable and the verdict unambiguous.

## How

- **`.github/workflows/claude.yml`** — adds `--append-system-prompt` to the review step. This overrides only the *posted comment shape*; the plugin's multi-agent review process (5 Sonnet auditors + Haiku confidence scoring) is unchanged.
- **`CLAUDE.md`** — rewrites the PR-review-format section to match, so local/interactive reviews follow the same structure.

## Caveat

The plugin's own command file still instructs "follow this format precisely," so this is a best-effort override rather than a hard guarantee. If a review ever reverts to the old shape, the durable fix is to vendor a trimmed copy of the plugin command into the repo.

LLM: Opus 4.8 | high | Harness: Claude Code
