### PR TITLE
Fix risk-path double count for same-account live HL manual strategies

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -206,7 +206,7 @@ func main() {
 	// first risk-check cycle once current value drops to the surviving subset.
 	if pruned && state.PortfolioRisk.PeakValue > 0 {
 		oldPeak := state.PortfolioRisk.PeakValue
-		newPeak := rebaselinePortfolioPeakAfterPrune(state, cfg)
+		newPeak := rebaselinePortfolioPeakAfterPrune(state, cfg, nil)
 		if newPeak != oldPeak {
 			state.PortfolioRisk.PeakValue = newPeak
 			fmt.Printf("  Portfolio peak rebaselined after prune: $%.0f -> $%.0f\n", oldPeak, newPeak)

--- a/scheduler/shared_wallet.go
+++ b/scheduler/shared_wallet.go
@@ -304,7 +304,8 @@ func computeTotalPortfolioValue(
 // computeInitialPortfolioPeak returns the initial PortfolioRisk.PeakValue used
 // when no peak has been recorded yet. It uses real wallet balances for shared
 // wallets (#243) so the peak is not inflated by summing the same account
-// multiple times across strategies. Strategies that use capital_pct on a
+// multiple times across strategies. Same-account live HL manual strategies are
+// excluded from the standalone capital sum via riskPathWalletMemberIDs (#921). Strategies that use capital_pct on a
 // non-shared platform fall back to the legacy "wallet balance once per
 // platform" computation (Capital / CapitalPct) so existing single-strategy
 // setups are unaffected.
@@ -323,8 +324,8 @@ func computeInitialPortfolioPeak(strategies []StrategyConfig, fetcher WalletBala
 	}
 	sharedWallets := detectSharedWallets(strategies)
 	sharedStrategyIDs := make(map[string]bool)
-	for _, ids := range sharedWallets {
-		for _, id := range ids {
+	for key, ids := range sharedWallets {
+		for _, id := range riskPathWalletMemberIDs(key, ids, strategies) {
 			sharedStrategyIDs[id] = true
 		}
 	}
@@ -358,7 +359,7 @@ func computeInitialPortfolioPeak(strategies []StrategyConfig, fetcher WalletBala
 		if err != nil {
 			fmt.Printf("[WARN] shared-wallet peak init: balance fetch failed for %s/%s: %v — falling back to summed capital\n",
 				key.Platform, key.Account, err)
-			for _, id := range ids {
+			for _, id := range riskPathWalletMemberIDs(key, ids, strategies) {
 				if sc, ok := byID[id]; ok {
 					total += sc.Capital
 				}

--- a/scheduler/shared_wallet.go
+++ b/scheduler/shared_wallet.go
@@ -188,7 +188,8 @@ func fetchSharedWalletBalances(
 // contained within the subset. If a shared wallet straddles the subset
 // boundary (some members are outside the subset), that wallet's strategies
 // are virtual-summed rather than deduped — a single on-exchange balance
-// cannot be split across a partial subset (#915).
+// cannot be split across a partial subset (#915). Same-account live HL manual
+// strategies are folded into the dedup set via riskPathWalletMemberIDs (#921).
 //
 // accountShared is the shared-wallet map for the full account (all strategies),
 // used to detect straddle boundaries. Pass the result of
@@ -220,7 +221,7 @@ func computeSubsetPortfolioValue(
 	for key, subIDs := range subShared {
 		if len(subIDs) == len(accountShared[key]) {
 			fullyContainedKeys = append(fullyContainedKeys, key)
-			for _, id := range subIDs {
+			for _, id := range riskPathWalletMemberIDs(key, subIDs, subset) {
 				dedupeIDs[id] = true
 			}
 		}
@@ -250,7 +251,7 @@ func computeSubsetPortfolioValue(
 		}
 		usedFallback = true
 		sumPV := 0.0
-		for _, id := range subShared[key] {
+		for _, id := range riskPathWalletMemberIDs(key, subShared[key], subset) {
 			if s, ok := state.Strategies[id]; ok {
 				sumPV += PortfolioValue(s, prices)
 			}

--- a/scheduler/shared_wallet.go
+++ b/scheduler/shared_wallet.go
@@ -387,15 +387,24 @@ func computeInitialPortfolioPeak(strategies []StrategyConfig, fetcher WalletBala
 // rebaseline never drops below the sum-of-capitals baseline that a fresh
 // install would use — protects against under-baseline when most surviving
 // strategies are themselves cold-started.
-func rebaselinePortfolioPeakAfterPrune(state *AppState, cfg *Config) float64 {
+//
+// Same-account live HL manual strategies on a deduped shared wallet are
+// excluded from the per-strategy sum — CheckRisk never records their peak and
+// their collateral is inside the real balance (#921).
+func rebaselinePortfolioPeakAfterPrune(state *AppState, cfg *Config, fetcher WalletBalanceFetcher) float64 {
 	byID := make(map[string]StrategyConfig, len(cfg.Strategies))
 	for _, sc := range cfg.Strategies {
 		byID[sc.ID] = sc
 	}
 
+	dedupedManual := dedupedSameAccountLiveManualIDs(cfg.Strategies)
+
 	sum := 0.0
 	for id, ss := range state.Strategies {
 		if ss == nil {
+			continue
+		}
+		if dedupedManual[id] {
 			continue
 		}
 		if ss.RiskState.PeakValue > 0 {
@@ -407,7 +416,7 @@ func rebaselinePortfolioPeakAfterPrune(state *AppState, cfg *Config) float64 {
 		}
 	}
 
-	floor := computeInitialPortfolioPeak(cfg.Strategies, nil)
+	floor := computeInitialPortfolioPeak(cfg.Strategies, fetcher)
 	if sum < floor {
 		sum = floor
 	}

--- a/scheduler/shared_wallet_reconcile.go
+++ b/scheduler/shared_wallet_reconcile.go
@@ -459,6 +459,26 @@ func computeSubsetDisplayValue(
 	return gated + restVal, usedFallback
 }
 
+// riskPathWalletMemberIDs returns perps shared-wallet members plus same-account
+// live HL manual strategies in subset. detectSharedWallets is perps-only, but
+// a live manual on the same HYPERLIQUID_ACCOUNT_ADDRESS is already inside the
+// wallet real balance — exclude its modeled PortfolioValue from the risk-path
+// per-strategy sum when the wallet balance is contributed (#921).
+func riskPathWalletMemberIDs(key SharedWalletKey, perpsMemberIDs []string, subset []StrategyConfig) []string {
+	members := append([]string(nil), perpsMemberIDs...)
+	seen := make(map[string]bool, len(members))
+	for _, id := range members {
+		seen[id] = true
+	}
+	for _, id := range sameAccountLiveManualMembers(key, subset) {
+		if !seen[id] {
+			members = append(members, id)
+			seen[id] = true
+		}
+	}
+	return members
+}
+
 // sameAccountLiveManualMembers returns live HL `manual` strategy IDs that trade
 // from the same on-exchange account as key. detectSharedWallets recognizes only
 // perps (walletKeyRegistry), but a live manual strategy on the same

--- a/scheduler/shared_wallet_reconcile.go
+++ b/scheduler/shared_wallet_reconcile.go
@@ -459,6 +459,18 @@ func computeSubsetDisplayValue(
 	return gated + restVal, usedFallback
 }
 
+// dedupedSameAccountLiveManualIDs returns live HL manual strategy IDs whose
+// collateral is already inside a deduped shared-wallet balance (#921).
+func dedupedSameAccountLiveManualIDs(strategies []StrategyConfig) map[string]bool {
+	out := make(map[string]bool)
+	for key := range detectSharedWallets(strategies) {
+		for _, id := range sameAccountLiveManualMembers(key, strategies) {
+			out[id] = true
+		}
+	}
+	return out
+}
+
 // riskPathWalletMemberIDs returns perps shared-wallet members plus same-account
 // live HL manual strategies in subset. detectSharedWallets is perps-only, but
 // a live manual on the same HYPERLIQUID_ACCOUNT_ADDRESS is already inside the

--- a/scheduler/shared_wallet_test.go
+++ b/scheduler/shared_wallet_test.go
@@ -913,6 +913,78 @@ func TestComputeTotalPortfolioValue_DelegatesCorrectly(t *testing.T) {
 	}
 }
 
+// TestComputeInitialPortfolioPeak_SharedWalletManualNoDoubleCount verifies
+// peak init uses the real wallet balance once when a same-account live manual
+// shares the HL wallet with 2+ perps (#921).
+func TestComputeInitialPortfolioPeak_SharedWalletManualNoDoubleCount(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+	strategies := []StrategyConfig{
+		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: 200},
+	}
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
+	fetcher := stubFetcher(map[SharedWalletKey]float64{key: 1000}, nil)
+
+	got := computeInitialPortfolioPeak(strategies, fetcher)
+	if got != 1000 {
+		t.Errorf("peak init incl. manual: want 1000 (real balance, no double count), got %.2f", got)
+	}
+}
+
+// Peak init fallback sums perps + manual capital exactly once each.
+func TestComputeInitialPortfolioPeak_SharedWalletManualFallback(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+	strategies := []StrategyConfig{
+		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: 200},
+	}
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
+	fetcher := stubFetcher(nil, map[SharedWalletKey]error{key: errors.New("network down")})
+
+	got := computeInitialPortfolioPeak(strategies, fetcher)
+	if got != 1200 {
+		t.Errorf("peak init manual fallback: want 1200 (sum member capital once), got %.2f", got)
+	}
+}
+
+// Cold-start peak must match the first-cycle risk-path total so a flat account
+// shows 0% equity drawdown on cycle 1 (#921 review).
+func TestComputeInitialPortfolioPeak_MatchesRiskPathTotalOnColdStart(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+	strategies := []StrategyConfig{
+		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: 200},
+	}
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-btc":    {ID: "hl-btc", Cash: 350, Positions: map[string]*Position{}},
+		"hl-eth":    {ID: "hl-eth", Cash: 500, Positions: map[string]*Position{}},
+		"hl-manual": {ID: "hl-manual", Cash: 200, Positions: map[string]*Position{}},
+	}}
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
+	walletBalances := map[SharedWalletKey]float64{key: 1000}
+	fetcher := stubFetcher(walletBalances, nil)
+	accountShared := detectSharedWallets(strategies[:2])
+
+	peak := computeInitialPortfolioPeak(strategies, fetcher)
+	totalPV, fb := computeTotalPortfolioValue(strategies, state, nil, walletBalances, accountShared)
+	if peak != totalPV {
+		t.Fatalf("cold start: peak=%.2f totalPV=%.2f, want equal", peak, totalPV)
+	}
+	if fb {
+		t.Fatal("cold start: expected usedFallback=false")
+	}
+
+	prs := &PortfolioRiskState{PeakValue: peak}
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 20, WarnThresholdPct: 16}
+	allowed, _, warning, reason := CheckPortfolioRisk(prs, cfg, totalPV, 0, 0, 0)
+	if !allowed || warning || prs.CurrentDrawdownPct != 0 {
+		t.Errorf("flat cold start: allowed=%v warning=%v dd=%.2f reason=%q", allowed, warning, prs.CurrentDrawdownPct, reason)
+	}
+}
+
 // A same-account live manual strategy is outside detectSharedWallets membership
 // but inside the wallet real balance. Risk-path total must not add its modeled
 // PV on top of the balance (#921).
@@ -961,5 +1033,31 @@ func TestComputeTotalPortfolioValue_SharedWalletManualFallback(t *testing.T) {
 	}
 	if !fb {
 		t.Errorf("risk path manual fallback: expected usedFallback=true")
+	}
+}
+
+// Paper / record-only same-account manuals carry a separate virtual book and
+// must stay in the per-strategy sum — only live manuals are deduped (#921).
+func TestComputeTotalPortfolioValue_PaperManualNotDeduped(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+	strategies := []StrategyConfig{
+		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=paper"}, Capital: 200},
+	}
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-btc":    {ID: "hl-btc", Cash: 350, Positions: map[string]*Position{}},
+		"hl-eth":    {ID: "hl-eth", Cash: 500, Positions: map[string]*Position{}},
+		"hl-manual": {ID: "hl-manual", Cash: 200, Positions: map[string]*Position{}},
+	}}
+	walletBalances := map[SharedWalletKey]float64{{Platform: "hyperliquid", Account: "0xtest"}: 1000}
+	accountShared := detectSharedWallets(strategies[:2])
+
+	got, fb := computeTotalPortfolioValue(strategies, state, nil, walletBalances, accountShared)
+	if got != 1200 {
+		t.Errorf("paper manual: want 1200 (balance + manual PV), got %.2f", got)
+	}
+	if fb {
+		t.Errorf("paper manual: expected usedFallback=false")
 	}
 }

--- a/scheduler/shared_wallet_test.go
+++ b/scheduler/shared_wallet_test.go
@@ -912,3 +912,54 @@ func TestComputeTotalPortfolioValue_DelegatesCorrectly(t *testing.T) {
 		t.Errorf("delegation: expected usedFallback=false")
 	}
 }
+
+// A same-account live manual strategy is outside detectSharedWallets membership
+// but inside the wallet real balance. Risk-path total must not add its modeled
+// PV on top of the balance (#921).
+func TestComputeTotalPortfolioValue_SharedWalletManualNoDoubleCount(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+	strategies := []StrategyConfig{
+		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: 200},
+	}
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-btc":    {ID: "hl-btc", Cash: 350, Positions: map[string]*Position{}},
+		"hl-eth":    {ID: "hl-eth", Cash: 500, Positions: map[string]*Position{}},
+		"hl-manual": {ID: "hl-manual", Cash: 200, Positions: map[string]*Position{}},
+	}}
+	walletBalances := map[SharedWalletKey]float64{{Platform: "hyperliquid", Account: "0xtest"}: 1000}
+	accountShared := detectSharedWallets(strategies[:2])
+
+	got, fb := computeTotalPortfolioValue(strategies, state, nil, walletBalances, accountShared)
+	if got != 1000 {
+		t.Errorf("risk path incl. manual: want exactly 1000 (real balance, no double count), got %.2f", got)
+	}
+	if fb {
+		t.Errorf("risk path incl. manual: expected usedFallback=false")
+	}
+}
+
+// Missing balance: fallback sums perps + manual member PVs once each (no double count).
+func TestComputeTotalPortfolioValue_SharedWalletManualFallback(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+	strategies := []StrategyConfig{
+		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: 200},
+	}
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-btc":    {ID: "hl-btc", Cash: 400, Positions: map[string]*Position{}},
+		"hl-eth":    {ID: "hl-eth", Cash: 400, Positions: map[string]*Position{}},
+		"hl-manual": {ID: "hl-manual", Cash: 200, Positions: map[string]*Position{}},
+	}}
+	accountShared := detectSharedWallets(strategies[:2])
+
+	got, fb := computeTotalPortfolioValue(strategies, state, nil, nil, accountShared)
+	if got != 1000 {
+		t.Errorf("risk path manual fallback: want 1000 (sum member PVs once), got %.2f", got)
+	}
+	if !fb {
+		t.Errorf("risk path manual fallback: expected usedFallback=true")
+	}
+}

--- a/scheduler/shared_wallet_test.go
+++ b/scheduler/shared_wallet_test.go
@@ -673,7 +673,7 @@ func TestRebaselinePortfolioPeakAfterPrune_SumsRemainingPerStrategyPeaks(t *test
 		"spot-btc": {ID: "spot-btc", RiskState: RiskState{PeakValue: 7000}},
 	}}
 
-	got := rebaselinePortfolioPeakAfterPrune(state, cfg)
+	got := rebaselinePortfolioPeakAfterPrune(state, cfg, nil)
 	want := 7000.0
 	if got != want {
 		t.Errorf("expected rebaselined peak=%v; got %v", want, got)
@@ -696,7 +696,7 @@ func TestRebaselinePortfolioPeakAfterPrune_FloorAtCapitalSum(t *testing.T) {
 		"spot-eth": {ID: "spot-eth"},
 	}}
 
-	got := rebaselinePortfolioPeakAfterPrune(state, cfg)
+	got := rebaselinePortfolioPeakAfterPrune(state, cfg, nil)
 	want := 8000.0 // floor: 5000 + 3000
 	if got != want {
 		t.Errorf("expected floored peak=%v; got %v", want, got)
@@ -718,7 +718,7 @@ func TestRebaselinePortfolioPeakAfterPrune_FallbackToCapitalWhenPeakMissing(t *t
 		"spot-eth": {ID: "spot-eth"}, // no peak yet → use capital
 	}}
 
-	got := rebaselinePortfolioPeakAfterPrune(state, cfg)
+	got := rebaselinePortfolioPeakAfterPrune(state, cfg, nil)
 	want := 9000.0 // 6000 (peak) + 3000 (capital fallback)
 	if got != want {
 		t.Errorf("expected mixed peak=%v; got %v", want, got)
@@ -744,7 +744,7 @@ func TestRebaselinePortfolioPeakAfterPrune_PreventsImmediateKillSwitch(t *testin
 		PortfolioRisk: PortfolioRiskState{PeakValue: 15148.90}, // pre-prune peak
 	}
 
-	state.PortfolioRisk.PeakValue = rebaselinePortfolioPeakAfterPrune(state, cfg)
+	state.PortfolioRisk.PeakValue = rebaselinePortfolioPeakAfterPrune(state, cfg, nil)
 
 	prsCfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
 	allowed, _, _, reason := CheckPortfolioRisk(&state.PortfolioRisk, prsCfg, 9034.24, 0, 0, 0)
@@ -753,6 +753,82 @@ func TestRebaselinePortfolioPeakAfterPrune_PreventsImmediateKillSwitch(t *testin
 	}
 	if state.PortfolioRisk.KillSwitchActive {
 		t.Errorf("expected kill switch inactive after rebaseline; got active")
+	}
+}
+
+// Post-prune rebaseline must match the deduped per-cycle total when a live
+// manual shares a deduped HL wallet (#921 review).
+func TestRebaselinePortfolioPeakAfterPrune_MatchesRiskPathTotalWithManual(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+	cfg := &Config{Strategies: []StrategyConfig{
+		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: 200},
+	}}
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-btc":    {ID: "hl-btc", Cash: 350, Positions: map[string]*Position{}},
+		"hl-eth":    {ID: "hl-eth", Cash: 500, Positions: map[string]*Position{}},
+		"hl-manual": {ID: "hl-manual", Cash: 200, Positions: map[string]*Position{}},
+	}}
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
+	walletBalances := map[SharedWalletKey]float64{key: 1000}
+	fetcher := stubFetcher(walletBalances, nil)
+	accountShared := detectSharedWallets(cfg.Strategies[:2])
+
+	rebaseline := rebaselinePortfolioPeakAfterPrune(state, cfg, fetcher)
+	totalPV, fb := computeTotalPortfolioValue(cfg.Strategies, state, nil, walletBalances, accountShared)
+	if rebaseline != totalPV {
+		t.Fatalf("post-prune rebaseline: peak=%.2f totalPV=%.2f, want equal", rebaseline, totalPV)
+	}
+	if fb {
+		t.Fatal("post-prune rebaseline: expected usedFallback=false")
+	}
+
+	state.PortfolioRisk.PeakValue = rebaseline
+	prsCfg := &PortfolioRiskConfig{MaxDrawdownPct: 20, WarnThresholdPct: 16}
+	allowed, _, warning, reason := CheckPortfolioRisk(&state.PortfolioRisk, prsCfg, totalPV, 0, 0, 0)
+	if !allowed || warning || state.PortfolioRisk.CurrentDrawdownPct != 0 {
+		t.Errorf("flat post-prune: allowed=%v warning=%v dd=%.2f reason=%q", allowed, warning, state.PortfolioRisk.CurrentDrawdownPct, reason)
+	}
+}
+
+// Without a shared wallet (single perps), live manual capital must still count.
+func TestRebaselinePortfolioPeakAfterPrune_SinglePerpsPlusManualSumsManual(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+	cfg := &Config{Strategies: []StrategyConfig{
+		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: 200},
+	}}
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-btc":    {ID: "hl-btc"},
+		"hl-manual": {ID: "hl-manual"},
+	}}
+
+	got := rebaselinePortfolioPeakAfterPrune(state, cfg, nil)
+	if got != 700 {
+		t.Errorf("single perps + manual: want 700 (500+200 capital), got %.2f", got)
+	}
+}
+
+// Zero-capital live manual on a deduped wallet is a no-op for the sum.
+func TestRebaselinePortfolioPeakAfterPrune_DedupedManualZeroCapitalUnchanged(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+	cfg := &Config{Strategies: []StrategyConfig{
+		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
+		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: 0},
+	}}
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-btc":    {ID: "hl-btc"},
+		"hl-eth":    {ID: "hl-eth"},
+		"hl-manual": {ID: "hl-manual"},
+	}}
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
+	fetcher := stubFetcher(map[SharedWalletKey]float64{key: 1000}, nil)
+
+	got := rebaselinePortfolioPeakAfterPrune(state, cfg, fetcher)
+	if got != 1000 {
+		t.Errorf("zero-capital manual: want 1000, got %.2f", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fold same-account live HL `manual` strategies into `computeSubsetPortfolioValue` dedup via `riskPathWalletMemberIDs`, mirroring the #920 display-path fix
- Prevents modeled manual `PortfolioValue` from being summed on top of the real shared-wallet balance in `CheckPortfolioRisk` and cycle `LogSummary`
- Preserves `usedFallback` semantics on balance-fetch failure by including manual members in the fallback PV sum

Closes #921

## Test plan
- [x] `go test -run 'TestComputeTotalPortfolioValue_SharedWalletManual' ./scheduler/...`
- [x] `go test -run 'SharedWallet|ComputeTotal|ComputeSubset' ./scheduler/...`