### PR TITLE
audit(backtest): complete #906 parity tool, audit doc, and regression index

### DIFF
--- a/backtest/AUDIT.md
+++ b/backtest/AUDIT.md
@@ -1,0 +1,172 @@
+# Backtest subsystem audit (#906)
+
+Audit completed: 2026-06-09. Branch: `cursor/issue-906-backtest-audit`.
+
+Structured audit of the eight core backtest modules and 21 test files (19 prior +
+`test_parity_diff.py`, `test_backtest_parity_regression.py`, `test_audit_regression_index.py`).
+Actionable code gaps are filed as linked issues; this card is complete.
+
+## Acceptance criteria
+
+| Criterion | Status |
+|-----------|--------|
+| D1–D4 fully audited | **Done** — sections below |
+| Findings filed as linked cards | **Done** — #925–#929 |
+| D7.4 parity-debug helper | **Done** — `parity_diff.py` |
+| D8.4 regression tests confirmed | **Done** — `test_audit_regression_index.py`, `test_backtest_parity_regression.py` |
+| Audit summary doc | **Done** — this file |
+
+## Executive summary
+
+| Dimension | Status | Notes |
+|-----------|--------|-------|
+| D1 Correctness | **Pass** | All four `shift(1)` guards intact |
+| D2 Parity | **Pass + documented gaps** | Live-only surfaces rejected; limitations in `backtester.py` docstring |
+| D3 Coverage | **Partial** | 2 close evaluators lack dedicated backtest cases → #926 |
+| D4 Reporting | **Partial** | Theta Sharpe gap → #925; recovery duration → #927 |
+| D5 Optimizer | **Pass** | All 69 registry strategies have `DEFAULT_PARAM_RANGES`; WF heuristics → #928 |
+| D6 Code health | **Debt** | Duplication quantified; refactor → #929 |
+| D7 Observability | **Shipped D7.4** | Verbose trace deferred → #930 |
+| D8 Regression | **Pass** | #302/#304/#715/#730 explicit; #303 umbrella; #824 out of scope |
+
+## D1 — Correctness (#730) ✅
+
+| Item | Result |
+|------|--------|
+| D1.1 `shift(1)` on signal, `_open_action`, `_close_fraction`, regime | Verified ~L738–780; no bypass columns |
+| D1.2 Close evaluators end-of-bar → next open | Verified ~L1139, ~L1368 |
+| D1.3 Intra-bar SL/TP races | Bar-close resolution; module docstring + CLAUDE.md |
+| D1.4 Upstream `shift(-1)` in strategies | `rg` — no matches in `shared_strategies/` |
+| D1.5 Regime shift vs #879 bundle | `_regime_bar_close` snapshot + shifted `regime` column |
+
+## D2 — Parity ✅ (gaps documented)
+
+### D2.1 Recent PRs (backtest=N features)
+
+| PR | Feature | Backtest status |
+|----|---------|-----------------|
+| #842 | Single `close_strategy` ref | **Parity** — `run_backtest.py` rejects len>1; `test_strategy_refs_641.py` |
+| #857 | `trailing_tp_ratchet_regime` | **Parity** — `test_backtester_close_strategies.py` |
+| #866 | `user_close_defaults` | **Parity** — `_apply_user_close_defaults` + `--defaults user` |
+| #870 | Default HL protection tier retune | **Parity** — flows through close evaluators / `DEFAULT_ATR_TIERS` |
+| #872 | Manual regime stamp | **Live-only** — manual path; backtest uses static regime injection |
+| #880 | Manual trade alert DMs | **Live-only** — notifier surface |
+| #882 / #873 | Scale-in / pyramiding | **Live-only** — documented in `backtester.py` |
+| #883 | Resting manual limit orders | **Live-only** — documented in `backtester.py` |
+| #885 | `armTrailingStopAtOpenNow` | **Partial** — backtest arms trailing on bar after open |
+| #887 | Ratchet final-tier 0.8× trail | **Parity** — `DEFAULT_RATCHET_TIERS` in close registry tests |
+
+### D2.2–D2.10
+
+| Item | Result |
+|------|--------|
+| D2.2 Scale-in (#873) | Permanent live-only constraint; documented |
+| D2.3 Resting limits (#883) | Not modeled; documented |
+| D2.4 `tiered_tp_atr_live_regime_dynamic` | Rejected at `run_backtest.py:193-196` — correct |
+| D2.5 `regime_directional_policy` | Rejected at `run_backtest.py:160-166` — correct |
+| D2.6 Inline trailing SL at open (#885) | Partial — see limitations docstring |
+| D2.7 Default tier retune (#870/#887) | Close registry `DEFAULT_ATR_TIERS` / ratchet tiers updated |
+| D2.8 v15 `tiers` in optimizer | Legacy emit at `optimizer.py:487,494`; Go `LoadConfig` canonicalizes |
+| D2.9 Single close ref (#842) | No length-N iteration in backtest; 0-or-1 list only |
+| D2.10 Platform fees | 6 platforms in `PLATFORM_FEE_PCT`; `test_platform_fees.py` scrapes `fees.go`; deribit/ibkr/topstep use variant fee fns — documented exclusion |
+
+### Parity tool (D7.4)
+
+```bash
+python backtest/parity_diff.py sma_crossover BTC/USDT 1d --since 2024-01-01
+python backtest/parity_diff.py --config config.json --strategy-id <id> --regime-enabled
+```
+
+## D3 — Engine coverage ✅ (minor gaps → #926)
+
+### D3.1 Close strategies
+
+All 8 registered evaluators audited. Missing dedicated backtest cases:
+`tiered_tp_atr_regime`, `tiered_tp_atr_live_regime` → **#926**.
+
+### D3.2 Composite 7-state labels
+
+`test_ensure_regime_columns_composite_labels` asserts `trending_up*` only.
+Not every label (`ranging_quiet`, `ranging_volatile`, …) has an explicit fixture → **#931** (optional).
+
+### D3.3 Variant backtesters
+
+spot/perps (`backtester.py`), options (`test_options_*`), theta (`test_backtest_reporting` L5), pairs (`test_pairs.py`) — non-trivial coverage confirmed.
+
+### D3.4 Sharpe timeframes
+
+`test_backtest_reporting.py` M3: 1d, 4h, 1h ratio tests + `periods_per_year` table.
+
+## D4 — Reporting ✅ (gaps filed)
+
+| Item | Result |
+|------|--------|
+| D4.1 Sharpe/Sortino all backtesters | Main + pairs + options OK; **theta hardcodes `sqrt(365)`** → #925 |
+| D4.2 Options annualized return | Calendar days — `test_backtest_reporting.py` M5 |
+| D4.3 Legacy max-fraction | Removed; single ref only (#842) |
+| D4.4 ISO timestamps | `start_date`/`end_date` via `str(index)`; trade `to_dict` uses `str(entry_date)` |
+| D4.5 Drawdown recovery duration | **Not emitted** → #927 |
+| D4.6 Theta force-close trade log | Fixed — `test_backtest_reporting.py` L5 |
+| D4.7 Net vs gross fees | Commission in metrics; reporter shows totals, not split gross/net |
+| D4.8 Walk-forward OOS | Per-fold `test_result` in optimizer; `oos_mean_sharpe` aggregate — warmup labeling could be clearer (acceptable) |
+
+## D5 — Optimizer ✅
+
+| Item | Result |
+|------|--------|
+| D5.1 Param ranges | **31/31 spot + 38/38 futures** have `DEFAULT_PARAM_RANGES` entries |
+| D5.2 Min-data heuristic | None — `splits=5` fixed → #928 |
+| D5.3 Overfit detection | No fold Sharpe std / param stability → #928 |
+| D5.4 `optimize_metric` | Configurable; default `sharpe_ratio` |
+| D5.5 `random_seed` | Honored in grid shuffle |
+
+## D6 — Code health ✅
+
+| Item | Result |
+|------|--------|
+| D6.1 Dead imports | No stale `fetch_full_history` in `run_backtest.py` |
+| D6.2 Duplication | 4 backtesters each own fill/fee/equity — ~35% overlap → #929 |
+| D6.3 Options exchange | `--exchange` flag exists (`backtest_options.py`); defaults binanceus |
+| D6.4 HTF filter | `_htf_trend_series` mirrors live EMA (#304 M2) |
+| D6.5 `close_registry_loader` | Collision still real; shim required |
+| D6.6 Magic numbers | Fees centralized; slippage is backtester param |
+
+## D7 — Observability
+
+| Item | Status |
+|------|--------|
+| D7.1 Verbose trace | Not implemented → #930 |
+| D7.2 Equity CSV export | JSON/`store_backtest_result` only |
+| D7.3 Trade log CSV | Trades in metrics dict only |
+| D7.4 Parity helper | **`parity_diff.py`** ✅ |
+
+## D8 — Regression index ✅
+
+| Issue | Regression | Guard |
+|-------|------------|-------|
+| #302 | `test_backtester_end_to_end`, `test_backtester_fills`, `test_options_vol_math`, `test_options_iv_rank` | `test_audit_regression_index.py` |
+| #303 | Distributed + `test_backtest_parity_regression.py` | Umbrella meta-test |
+| #304 | `test_backtest_reporting.py` | Index test |
+| #715 | `test_post_tp_sl.py` | Index test |
+| #730 | `test_backtester_lookahead.py` | Index test |
+| #824 | `shared_tools/storage.py` + `--probe-only` | **Out of backtest scope** — documented |
+
+No `hypothesis` usage in backtest tests → optional starter card not filed (low priority).
+
+## Follow-up issues (linked cards)
+
+| Issue | Topic |
+|-------|-------|
+| [#925](https://github.com/richkuo/go-trader/issues/925) | Theta Sharpe annualization |
+| [#926](https://github.com/richkuo/go-trader/issues/926) | Close-strategy test gaps |
+| [#927](https://github.com/richkuo/go-trader/issues/927) | Drawdown recovery metric |
+| [#928](https://github.com/richkuo/go-trader/issues/928) | Walk-forward robustness heuristics |
+| [#929](https://github.com/richkuo/go-trader/issues/929) | Backtester dedup refactor |
+| [#930](https://github.com/richkuo/go-trader/issues/930) | Verbose per-bar trace mode |
+| [#931](https://github.com/richkuo/go-trader/issues/931) | Composite regime label fixtures (optional) |
+
+## References
+
+- Look-ahead contract: `backtest/backtester.py` module docstring
+- Parity tool: `backtest/parity_diff.py`
+- Prior audits: #302, #303, #304

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -42,6 +42,22 @@ SL/TP intra-bar races
 Bar-level granularity — when an SL hit and a TP fill could both occur within
 the same bar, the engine resolves them at bar close, not by intra-bar OHLC
 walking. Documented under ``Backtest`` in CLAUDE.md.
+
+Live parity limitations (#906 audit)
+------------------------------------
+Surfaces intentionally **not** modeled here (use ``backtest/parity_diff.py`` for
+decision-layer parity checks; see ``backtest/AUDIT.md`` for the full matrix):
+
+  • **Scale-in / pyramiding** (#873) — HL perps + manual live-only; same-direction
+    adds are skipped in backtest.
+  • **Resting manual limit orders** (#883) — maker fills / partial OID reconcile
+    have no bar-level simulation.
+  • **``tiered_tp_atr_live_regime_dynamic``** (#843) — rejected at
+    ``run_backtest.load_strategy_config`` (on-chain regime hysteresis).
+  • **``regime_directional_policy``** (#822) — rejected at config load; use static
+    ``direction`` / ``invert_signal`` for backtests.
+  • **Inline trailing SL at open** (#885) — live arms same-cycle; backtest seeds
+    trailing/ratchet triggers on the bar after open (no naked-gap modeling).
 """
 
 import sys

--- a/backtest/parity_diff.py
+++ b/backtest/parity_diff.py
@@ -1,0 +1,637 @@
+#!/usr/bin/env python3
+"""
+Backtest vs live decision parity diff (#906 D7.4).
+
+Compares per-bar strategy decisions between:
+  - **vector** — full-history ``apply_strategy`` (what the backtester ingests)
+  - **live** — per-bar sliding-window replay using check-script semantics
+    (``prepare_check_regime`` + ``evaluate_open_close`` / last-bar signal)
+
+Also reports **backtest_effective** columns (post-``shift(1)`` inputs the engine
+reads at each bar) and optional simulated **fills** (entry/exit price + fee)
+from ``Backtester.run``.
+
+Usage::
+
+    python backtest/parity_diff.py sma_crossover BTC/USDT 1d \\
+        --since 2024-01-01 --limit 120
+
+    python backtest/parity_diff.py --config config.json --strategy-id btc-4h \\
+        --since 2024-01-01 --output diff.jsonl
+
+Exit code 0 when vector/live decision columns match on every compared bar;
+exit 1 when any mismatch is found (or on fatal error).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Optional
+
+import numpy as np
+import pandas as pd
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_TOOLS = os.path.join(_ROOT, "shared_tools")
+_BACKTEST = os.path.join(_ROOT, "backtest")
+for _p in (_TOOLS, _BACKTEST):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from atr import ensure_atr_indicator, latest_atr  # noqa: E402
+from regime import prepare_check_regime  # noqa: E402
+from registry_loader import load_registry  # noqa: E402
+from strategy_composition import (  # noqa: E402
+    evaluate_open_close,
+    finalize_decision,
+    normalize_signal,
+    open_action_from_signal,
+    parse_close_strategies,
+)
+from close_registry_loader import evaluate as close_evaluate  # noqa: E402
+from backtester import (  # noqa: E402
+    Backtester,
+    _max_close_fraction_series,
+    _normalize_open_action,
+    _open_action_from_signal,
+    fee_pct_for_platform,
+)
+from run_backtest import load_strategy_config  # noqa: E402
+
+
+DECISION_COLS = ("signal", "regime", "open_action", "close_fraction")
+
+
+@dataclass
+class ParityConfig:
+    strategy_name: str
+    symbol: str
+    timeframe: str
+    params: dict
+    registry: str = "spot"
+    platform: str = "binanceus"
+    open_strategy: Optional[str] = None
+    close_strategies: Optional[list[dict]] = None
+    regime_enabled: bool = False
+    regime_period: int = 14
+    regime_adx_threshold: float = 20.0
+    min_warmup: int = 30
+
+
+@dataclass
+class ParityDiffResult:
+    rows: list[dict] = field(default_factory=list)
+    mismatches: int = 0
+    bars_compared: int = 0
+    fills: list[dict] = field(default_factory=list)
+
+
+def _iso(ts) -> str:
+    if ts is None or (isinstance(ts, float) and math.isnan(ts)):
+        return ""
+    stamp = pd.Timestamp(ts)
+    if stamp.tzinfo is None:
+        stamp = stamp.tz_localize("UTC")
+    else:
+        stamp = stamp.tz_convert("UTC")
+    return stamp.isoformat()
+
+
+def _close_names(close_strategies: Optional[list[dict]]) -> list[str]:
+    if not close_strategies:
+        return []
+    return [str(r.get("name", "")).strip() for r in close_strategies if r.get("name")]
+
+
+def _close_params_by_name(close_strategies: Optional[list[dict]]) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    if not close_strategies:
+        return out
+    for ref in close_strategies:
+        name = str(ref.get("name", "")).strip()
+        if name:
+            out[name] = dict(ref.get("params") or {})
+    return out
+
+
+def _extract_row_decision(
+    result_df: pd.DataFrame,
+    idx,
+    *,
+    regime_label: str = "",
+    decision: Optional[dict] = None,
+) -> dict[str, Any]:
+    if decision:
+        return {
+            "signal": int(decision.get("signal", 0) or 0),
+            "regime": str(regime_label or decision.get("regime") or ""),
+            "open_action": str(decision.get("open_action", "none") or "none"),
+            "close_fraction": float(decision.get("close_fraction", 0.0) or 0.0),
+        }
+    if result_df.empty:
+        return {"signal": 0, "regime": "", "open_action": "none", "close_fraction": 0.0}
+    row = result_df.loc[idx] if idx in result_df.index else result_df.iloc[-1]
+    signal = normalize_signal(row.get("signal", 0))
+    regime = str(regime_label or row.get("regime", "") or "")
+    if "open_action" in result_df.columns:
+        open_action = _normalize_open_action(row.get("open_action"))
+    else:
+        open_action = _open_action_from_signal(signal)
+    if "close_fraction" in result_df.columns or any(
+        str(c).startswith("close_fraction:") for c in result_df.columns
+    ):
+        close_fraction = float(_max_close_fraction_series(result_df.loc[[idx]]).iloc[0])
+    else:
+        close_fraction = 0.0
+    return {
+        "signal": signal,
+        "regime": regime,
+        "open_action": open_action,
+        "close_fraction": close_fraction,
+    }
+
+
+def live_bar_decision(
+    window: pd.DataFrame,
+    cfg: ParityConfig,
+    *,
+    apply_strategy: Callable,
+    get_strategy: Callable,
+    position_side: str = "",
+    position_ctx: Optional[dict] = None,
+) -> dict[str, Any]:
+    """Mirror ``check_strategy.py`` decision for a window ending at the current bar."""
+    _stdout_regime, live_regime, strategy_regime = prepare_check_regime(
+        window,
+        regime_enabled=cfg.regime_enabled,
+        period=cfg.regime_period,
+        adx_threshold=cfg.regime_adx_threshold,
+    )
+    params = dict(cfg.params or {})
+    if cfg.regime_enabled:
+        params["regime"] = strategy_regime
+
+    open_name = (cfg.open_strategy or cfg.strategy_name).strip()
+    close_names = _close_names(cfg.close_strategies)
+    close_csv = ",".join(close_names) if close_names else None
+    open_close_enabled = bool(cfg.open_strategy or close_names)
+
+    if open_close_enabled:
+        market_ctx: dict[str, Any] = {"mark_price": float(window["close"].iloc[-1])}
+        atr_now = latest_atr(window)
+        if atr_now > 0:
+            market_ctx["atr"] = atr_now
+        if live_regime:
+            market_ctx["regime"] = live_regime
+        evaluation = evaluate_open_close(
+            apply_strategy,
+            get_strategy,
+            window,
+            cfg.strategy_name,
+            cfg.open_strategy,
+            parse_close_strategies(close_csv),
+            position_side,
+            params,
+            position_ctx or {},
+            close_evaluate=close_evaluate,
+            market_ctx=market_ctx,
+            close_params_by_name=_close_params_by_name(cfg.close_strategies),
+        )
+        decision = finalize_decision(evaluation, position_side, evaluation.open_signal)
+        regime_out = live_regime if cfg.regime_enabled else ""
+        if isinstance(_stdout_regime, dict):
+            regime_out = str(live_regime or "")
+        elif cfg.regime_enabled:
+            regime_out = str(_stdout_regime or "")
+        return _extract_row_decision(
+            evaluation.open_result_df,
+            window.index[-1],
+            regime_label=regime_out,
+            decision=decision,
+        )
+
+    result_df = apply_strategy(cfg.strategy_name, window, params)
+    regime_out = ""
+    if cfg.regime_enabled:
+        if isinstance(_stdout_regime, str):
+            regime_out = _stdout_regime
+        elif isinstance(strategy_regime, dict):
+            regime_out = str(strategy_regime.get("regime") or "")
+    return _extract_row_decision(result_df, window.index[-1], regime_label=regime_out)
+
+
+def vector_frame(
+    df: pd.DataFrame,
+    cfg: ParityConfig,
+    *,
+    apply_strategy: Callable,
+    ensure_regime_columns: Callable,
+) -> pd.DataFrame:
+    """Full-history vectorized decisions (pre-shift) at each bar."""
+    work = df.copy()
+    if cfg.regime_enabled and "regime" not in work.columns:
+        ensure_regime_columns(
+            work,
+            period=cfg.regime_period,
+            adx_threshold=cfg.regime_adx_threshold,
+        )
+
+    params = dict(cfg.params or {})
+    if cfg.regime_enabled and "regime" in work.columns:
+        params["regime"] = str(work["regime"].iloc[-1] or "")
+
+    open_name = (cfg.open_strategy or cfg.strategy_name).strip()
+    result = apply_strategy(open_name, work, params)
+    out = pd.DataFrame(index=work.index)
+    if "close" in work.columns:
+        out["close"] = work["close"].astype(float)
+    out["signal"] = result.get("signal", pd.Series(0, index=work.index)).fillna(0).map(normalize_signal)
+    if "open_action" in result.columns:
+        out["open_action"] = result["open_action"].map(_normalize_open_action)
+    else:
+        out["open_action"] = out["signal"].map(_open_action_from_signal)
+    out["close_fraction"] = _max_close_fraction_series(result).reindex(work.index).fillna(0.0)
+    if cfg.regime_enabled and "regime" in work.columns:
+        out["regime"] = work["regime"].fillna("").astype(str)
+    else:
+        out["regime"] = ""
+    return out
+
+
+def backtest_effective_frame(vector: pd.DataFrame) -> pd.DataFrame:
+    """Post-``shift(1)`` inputs the backtester reads at each bar."""
+    eff = vector.copy()
+    for col in ("signal", "open_action", "close_fraction", "regime"):
+        if col in eff.columns:
+            eff[col] = eff[col].shift(1)
+    eff["signal"] = eff.get("signal", pd.Series(0, index=vector.index)).fillna(0).astype(int)
+    eff["open_action"] = eff.get("open_action", "none").fillna("none")
+    eff["close_fraction"] = eff.get("close_fraction", 0.0).fillna(0.0).astype(float)
+    eff["regime"] = eff.get("regime", "").fillna("").astype(str)
+    return eff
+
+
+def _simulate_position_context(
+    vector: pd.DataFrame,
+    live_rows: list[dict],
+) -> list[Optional[dict]]:
+    """Lightweight position tracker so live close evaluators see plausible context."""
+    contexts: list[Optional[dict]] = []
+    side = ""
+    avg_cost = 0.0
+    qty = 0.0
+    initial_qty = 0.0
+    entry_regime = ""
+
+    for i, idx in enumerate(vector.index):
+        ctx: Optional[dict] = None
+        if side:
+            ctx = {
+                "side": side,
+                "avg_cost": avg_cost,
+                "current_quantity": qty,
+                "initial_quantity": initial_qty or qty,
+                "regime": entry_regime,
+            }
+        contexts.append(ctx)
+
+        live = live_rows[i] if i < len(live_rows) else {}
+        eff_signal = int(live.get("backtest_effective_signal", 0) or 0)
+        eff_close = float(live.get("backtest_effective_close_fraction", 0.0) or 0.0)
+        eff_open = str(live.get("backtest_effective_open_action", "none") or "none")
+
+        mark = float(vector.loc[idx, "close"]) if "close" in vector.columns else 0.0
+        if eff_close > 0 and side:
+            closed = qty * eff_close
+            qty = max(qty - closed, 0.0)
+            if qty <= 1e-12:
+                side = ""
+                avg_cost = 0.0
+                qty = 0.0
+                initial_qty = 0.0
+                entry_regime = ""
+        elif eff_open in ("long", "short") and not side:
+            side = eff_open
+            avg_cost = mark
+            qty = 1.0
+            initial_qty = 1.0
+            entry_regime = str(live.get("live_regime", "") or "")
+        elif eff_signal > 0 and not side:
+            side = "long"
+            avg_cost = mark
+            qty = 1.0
+            initial_qty = 1.0
+            entry_regime = str(live.get("live_regime", "") or "")
+        elif eff_signal < 0 and not side:
+            side = "short"
+            avg_cost = mark
+            qty = 1.0
+            initial_qty = 1.0
+            entry_regime = str(live.get("live_regime", "") or "")
+
+    return contexts
+
+
+def compare_parity(
+    df: pd.DataFrame,
+    cfg: ParityConfig,
+    *,
+    apply_strategy: Callable,
+    get_strategy: Callable,
+    ensure_regime_columns: Callable,
+    include_fills: bool = True,
+) -> ParityDiffResult:
+    """Build per-bar diff rows between vector and live replay paths."""
+    if len(df) < cfg.min_warmup:
+        raise ValueError(
+            f"Need at least {cfg.min_warmup} bars for warmup; got {len(df)}"
+        )
+
+    vec = vector_frame(df, cfg, apply_strategy=apply_strategy, ensure_regime_columns=ensure_regime_columns)
+    effective = backtest_effective_frame(vec)
+
+    # Seed position contexts from backtest-effective opens/closes when close
+    # evaluators need a position snapshot (mirrors check_strategy --position-*).
+    scaffold: list[dict] = []
+    for end in range(cfg.min_warmup, len(df)):
+        idx = df.index[end]
+        scaffold.append({
+            "backtest_effective_signal": int(effective.loc[idx, "signal"]),
+            "backtest_effective_open_action": str(effective.loc[idx, "open_action"]),
+            "backtest_effective_close_fraction": float(effective.loc[idx, "close_fraction"]),
+            "live_regime": str(vec.loc[idx, "regime"]),
+        })
+    position_contexts = (
+        _simulate_position_context(vec.iloc[cfg.min_warmup:], scaffold)
+        if cfg.close_strategies
+        else [None] * len(scaffold)
+    )
+
+    live_rows: list[dict] = []
+    for j, end in enumerate(range(cfg.min_warmup, len(df))):
+        window = df.iloc[: end + 1]
+        ctx = position_contexts[j] if j < len(position_contexts) else None
+        side = str((ctx or {}).get("side", "") or "")
+        live = live_bar_decision(
+            window,
+            cfg,
+            apply_strategy=apply_strategy,
+            get_strategy=get_strategy,
+            position_side=side,
+            position_ctx=ctx if side else None,
+        )
+        idx = df.index[end]
+        row = {
+            "bar": _iso(idx),
+            "close": float(df["close"].iloc[end]),
+            "vector_signal": int(vec.loc[idx, "signal"]),
+            "live_signal": int(live["signal"]),
+            "vector_regime": str(vec.loc[idx, "regime"]),
+            "live_regime": str(live["regime"]),
+            "vector_open_action": str(vec.loc[idx, "open_action"]),
+            "live_open_action": str(live["open_action"]),
+            "vector_close_fraction": float(vec.loc[idx, "close_fraction"]),
+            "live_close_fraction": float(live["close_fraction"]),
+            "backtest_effective_signal": int(effective.loc[idx, "signal"]),
+            "backtest_effective_open_action": str(effective.loc[idx, "open_action"]),
+            "backtest_effective_close_fraction": float(effective.loc[idx, "close_fraction"]),
+            "backtest_effective_regime": str(effective.loc[idx, "regime"]),
+        }
+        row["decision_match"] = all(
+            row[f"vector_{c}"] == row[f"live_{c}"] for c in DECISION_COLS
+        )
+        live_rows.append(row)
+
+    result = ParityDiffResult(
+        rows=live_rows,
+        mismatches=sum(1 for r in live_rows if not r["decision_match"]),
+        bars_compared=len(live_rows),
+    )
+
+    if include_fills:
+        result.fills = _extract_fills(df, cfg, apply_strategy=apply_strategy, ensure_regime_columns=ensure_regime_columns)
+    return result
+
+
+def _extract_fills(
+    df: pd.DataFrame,
+    cfg: ParityConfig,
+    *,
+    apply_strategy: Callable,
+    ensure_regime_columns: Callable,
+) -> list[dict]:
+    work = df.copy()
+    open_name = (cfg.open_strategy or cfg.strategy_name).strip()
+    params = dict(cfg.params or {})
+    work = apply_strategy(open_name, work, params)
+    if cfg.close_strategies:
+        work = ensure_atr_indicator(work)
+    if cfg.regime_enabled and "regime" not in work.columns:
+        ensure_regime_columns(
+            work,
+            period=cfg.regime_period,
+            adx_threshold=cfg.regime_adx_threshold,
+        )
+
+    bt = Backtester(
+        initial_capital=1000.0,
+        platform=cfg.platform,
+        open_strategy={"name": open_name, "params": params},
+        close_strategies=cfg.close_strategies,
+        regime_enabled=cfg.regime_enabled,
+        regime_period=cfg.regime_period,
+        regime_adx_threshold=cfg.regime_adx_threshold,
+    )
+    metrics = bt.run(
+        work,
+        strategy_name=cfg.strategy_name,
+        symbol=cfg.symbol,
+        timeframe=cfg.timeframe,
+        params=params,
+        save=False,
+    )
+    fee_pct = fee_pct_for_platform(cfg.platform)
+    fills: list[dict] = []
+    for trade in metrics.get("trades", []) or []:
+        entry_fee = float(trade.get("entry_price", 0) or 0) * abs(float(trade.get("shares", 0) or 0)) * fee_pct
+        exit_fee = float(trade.get("exit_price", 0) or 0) * abs(float(trade.get("shares", 0) or 0)) * fee_pct
+        fills.append({
+            "event": "entry",
+            "bar": _iso(trade.get("entry_date")),
+            "side": trade.get("side", "long"),
+            "fill_px": float(trade.get("entry_price", 0) or 0),
+            "fee": round(entry_fee, 6),
+        })
+        if trade.get("exit_date"):
+            fills.append({
+                "event": "exit",
+                "bar": _iso(trade.get("exit_date")),
+                "side": trade.get("side", "long"),
+                "fill_px": float(trade.get("exit_price", 0) or 0),
+                "fee": round(exit_fee, 6),
+                "pnl": float(trade.get("pnl", 0) or 0),
+            })
+    return fills
+
+
+def format_summary(result: ParityDiffResult) -> str:
+    lines = [
+        f"Bars compared: {result.bars_compared}",
+        f"Mismatches:    {result.mismatches}",
+        f"Fills:         {len(result.fills)}",
+    ]
+    if result.mismatches:
+        lines.append("")
+        lines.append("First mismatches:")
+        shown = 0
+        for row in result.rows:
+            if row.get("decision_match"):
+                continue
+            lines.append(
+                f"  {row['bar']}: "
+                f"signal {row['vector_signal']}≠{row['live_signal']} "
+                f"regime {row['vector_regime']!r}≠{row['live_regime']!r} "
+                f"open {row['vector_open_action']}≠{row['live_open_action']} "
+                f"close {row['vector_close_fraction']}≠{row['live_close_fraction']}"
+            )
+            shown += 1
+            if shown >= 5:
+                break
+    return "\n".join(lines)
+
+
+def run_from_dataframe(df: pd.DataFrame, cfg: ParityConfig, **kwargs) -> ParityDiffResult:
+    reg = load_registry(cfg.registry)
+    from regime import ensure_regime_columns
+
+    return compare_parity(
+        df,
+        cfg,
+        apply_strategy=reg.apply_strategy,
+        get_strategy=reg.get_strategy,
+        ensure_regime_columns=ensure_regime_columns,
+        **kwargs,
+    )
+
+
+def _parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Per-bar backtest vs live decision parity diff (#906 D7.4)",
+    )
+    parser.add_argument("strategy", nargs="?", help="Open strategy name")
+    parser.add_argument("symbol", nargs="?", default="BTC/USDT")
+    parser.add_argument("timeframe", nargs="?", default="1d")
+    parser.add_argument("--since", default="2022-01-01", help="Start date (cached data)")
+    parser.add_argument("--until", default="", help="Optional end date (inclusive)")
+    parser.add_argument("--limit", type=int, default=0, help="Max bars after warmup")
+    parser.add_argument("--registry", default="spot", choices=("spot", "futures"))
+    parser.add_argument("--platform", default="binanceus")
+    parser.add_argument("--params", default="", help="JSON strategy params override")
+    parser.add_argument("--config", default="", help="Live config JSON (v13+)")
+    parser.add_argument("--strategy-id", default="", help="Strategy id inside --config")
+    parser.add_argument("--close", action="append", default=[], help="Close ref as name or name:json")
+    parser.add_argument("--regime-enabled", action="store_true")
+    parser.add_argument("--regime-period", type=int, default=14)
+    parser.add_argument("--regime-adx-threshold", type=float, default=20.0)
+    parser.add_argument("--no-fills", action="store_true", help="Skip backtester fill extraction")
+    parser.add_argument("--output", default="", help="Write JSONL diff to this path")
+    parser.add_argument("--summary-only", action="store_true")
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def _parse_close_refs(raw_list: list[str]) -> list[dict]:
+    refs: list[dict] = []
+    for item in raw_list:
+        if ":" in item:
+            name, params_json = item.split(":", 1)
+            refs.append({"name": name.strip(), "params": json.loads(params_json)})
+        else:
+            refs.append({"name": item.strip(), "params": {}})
+    return refs
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = _parse_args(argv)
+
+    if args.config:
+        if not args.strategy_id:
+            print("error: --strategy-id is required with --config", file=sys.stderr)
+            return 2
+        loaded = load_strategy_config(args.config, args.strategy_id)
+        open_ref = loaded["open_strategy"]
+        cfg = ParityConfig(
+            strategy_name=open_ref["name"],
+            symbol=args.symbol,
+            timeframe=args.timeframe,
+            params=dict(open_ref.get("params") or {}),
+            registry="futures" if loaded.get("strategy_type") in ("perps", "futures", "manual") else "spot",
+            platform=args.platform,
+            open_strategy=open_ref["name"],
+            close_strategies=loaded.get("close_strategies") or None,
+            regime_enabled=args.regime_enabled,
+            regime_period=args.regime_period,
+            regime_adx_threshold=args.regime_adx_threshold,
+        )
+    else:
+        if not args.strategy:
+            print("error: strategy name required (or use --config + --strategy-id)", file=sys.stderr)
+            return 2
+        params = json.loads(args.params) if args.params else None
+        reg = load_registry(args.registry)
+        strat = reg.STRATEGY_REGISTRY.get(args.strategy)
+        if not strat:
+            print(f"error: unknown strategy {args.strategy!r}", file=sys.stderr)
+            return 2
+        cfg = ParityConfig(
+            strategy_name=args.strategy,
+            symbol=args.symbol,
+            timeframe=args.timeframe,
+            params=params or dict(strat.get("default_params") or {}),
+            registry=args.registry,
+            platform=args.platform,
+            close_strategies=_parse_close_refs(args.close) or None,
+            regime_enabled=args.regime_enabled,
+            regime_period=args.regime_period,
+            regime_adx_threshold=args.regime_adx_threshold,
+        )
+
+    from data_fetcher import load_cached_data
+
+    df = load_cached_data(cfg.symbol, cfg.timeframe, start_date=args.since)
+    if df.empty:
+        print("error: no cached data — run data fetch first", file=sys.stderr)
+        return 2
+    if args.until:
+        until = pd.Timestamp(args.until, tz="UTC")
+        df = df[df.index <= until]
+    if args.limit > 0:
+        df = df.iloc[-(args.limit + cfg.min_warmup) :]
+
+    try:
+        result = run_from_dataframe(df, cfg, include_fills=not args.no_fills)
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    print(format_summary(result), file=sys.stderr)
+
+    if args.output:
+        with open(args.output, "w") as fh:
+            for row in result.rows:
+                fh.write(json.dumps(row, sort_keys=True) + "\n")
+            for fill in result.fills:
+                fh.write(json.dumps({"fill": fill}, sort_keys=True) + "\n")
+    elif not args.summary_only:
+        for row in result.rows:
+            print(json.dumps(row, sort_keys=True))
+
+    return 1 if result.mismatches else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backtest/tests/test_audit_regression_index.py
+++ b/backtest/tests/test_audit_regression_index.py
@@ -1,0 +1,35 @@
+"""
+D8.4 regression index for closed backtest bug issues (#906).
+
+Each closed issue that shipped a backtest-specific bug must retain at least one
+test file that cites the issue and would have caught the original failure class.
+"""
+from __future__ import annotations
+
+import os
+
+_TESTS_DIR = os.path.join(os.path.dirname(__file__))
+
+_CLOSED_ISSUE_TESTS: dict[str, list[str]] = {
+    "#302": [
+        "test_backtester_end_to_end.py",
+        "test_backtester_fills.py",
+        "test_options_vol_math.py",
+        "test_options_iv_rank.py",
+    ],
+    "#304": ["test_backtest_reporting.py"],
+    "#715": ["test_post_tp_sl.py"],
+    "#730": ["test_backtester_lookahead.py"],
+}
+
+
+def test_closed_backtest_issues_have_regression_files():
+    for issue, files in _CLOSED_ISSUE_TESTS.items():
+        for fname in files:
+            path = os.path.join(_TESTS_DIR, fname)
+            assert os.path.isfile(path), f"{issue}: missing {fname}"
+            body = open(path, encoding="utf-8").read()
+            num = issue.replace("#", "")
+            assert num in body or issue in body, (
+                f"{fname} should cite {issue}"
+            )

--- a/backtest/tests/test_backtest_parity_regression.py
+++ b/backtest/tests/test_backtest_parity_regression.py
@@ -1,0 +1,58 @@
+"""
+Regression umbrella for issue #303 — backtest ↔ live parity.
+
+#303 fixed distributed parity gaps (fees, regime, options pricing, sl_after).
+Coverage is intentionally spread across multiple modules rather than one golden
+file. This meta-test pins the contract: each module below must exist and cite
+#303 or a child parity issue so future refactors don't drop the net.
+
+#824 (storage.py startup probe under ProtectSystem=strict) is **out of backtest
+scope** per #906 — enforced by shared_tools tests + ``--probe-only`` scripts, not
+the backtest engine.
+"""
+from __future__ import annotations
+
+import os
+import re
+
+_TESTS_DIR = os.path.join(os.path.dirname(__file__))
+
+
+# module → acceptable issue citations (at least one must appear in file body)
+_PARITY_REGRESSION_MODULES: dict[str, tuple[str, ...]] = {
+    "test_backtester_regime.py": ("#303", "#543", "parity", "Parity"),
+    "test_options_adapter_parity.py": ("parity", "Parity", "adapter"),
+    "test_platform_fees.py": ("fees.go", "parity", "Parity"),
+    "test_post_tp_sl.py": ("#709", "#715", "parity", "Parity"),
+    "test_regime_backtester_737.py": ("#737", "#733", "parity", "Parity"),
+    "test_strategy_refs_641.py": ("#641", "#640"),
+    "test_parity_diff.py": ("#906", "parity"),
+}
+
+
+def test_parity_regression_modules_exist_and_cite_contract():
+    """#303 / #906 D8.4 — distributed parity regression index."""
+    for fname, markers in _PARITY_REGRESSION_MODULES.items():
+        path = os.path.join(_TESTS_DIR, fname)
+        assert os.path.isfile(path), f"missing parity regression module: {fname}"
+        body = open(path, encoding="utf-8").read()
+        assert any(m in body for m in markers), (
+            f"{fname} should cite one of {markers} (parity contract)"
+        )
+
+
+def test_platform_fees_scrapes_scheduler_fees_go():
+    """#303 H-item: backtest fee table stays tied to scheduler/fees.go."""
+    path = os.path.join(_TESTS_DIR, "test_platform_fees.py")
+    body = open(path, encoding="utf-8").read()
+    assert "fees.go" in body
+    assert re.search(r"PLATFORM_FEE_PCT|fee_pct", body)
+
+
+def test_issue_824_documented_out_of_backtest_scope():
+    """#824 is closed but lives in shared_tools — not a backtest regression."""
+    audit_path = os.path.join(os.path.dirname(_TESTS_DIR), "AUDIT.md")
+    assert os.path.isfile(audit_path)
+    audit = open(audit_path, encoding="utf-8").read()
+    assert "#824" in audit
+    assert "out of backtest" in audit.lower() or "Out of backtest" in audit

--- a/backtest/tests/test_parity_diff.py
+++ b/backtest/tests/test_parity_diff.py
@@ -1,0 +1,144 @@
+"""Tests for backtest/parity_diff.py (#906 D7.4)."""
+import json
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+_BACKTEST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _BACKTEST_DIR not in sys.path:
+    sys.path.insert(0, _BACKTEST_DIR)
+
+from parity_diff import (  # noqa: E402
+    ParityConfig,
+    backtest_effective_frame,
+    compare_parity,
+    format_summary,
+    live_bar_decision,
+    vector_frame,
+)
+
+
+def _flat_df(n: int = 60) -> pd.DataFrame:
+    idx = pd.date_range("2024-01-01", periods=n, freq="D", tz="UTC")
+    close = np.full(n, 100.0)
+    return pd.DataFrame(
+        {"open": close, "high": close + 1, "low": close - 1, "close": close, "volume": 1000.0},
+        index=idx,
+    )
+
+
+def _registry_stub():
+  class Reg:
+      def get_strategy(self, name):
+          return {"default_params": {}}
+
+      def apply_strategy(self, name, df, params=None):
+          out = df.copy()
+          # Causal signal: bar i is 1 once i >= 34 in *this* window (matches
+          # both full-history vector reads and sliding-window live replay).
+          out["signal"] = [1 if i >= 34 else 0 for i in range(len(df))]
+          return out
+
+  return Reg()
+
+
+def test_backtest_effective_shift_aligns_decision_to_next_bar():
+    vec = pd.DataFrame(
+        {
+            "signal": [0, 1, 0, -1, 0],
+            "open_action": ["none", "long", "none", "short", "none"],
+            "close_fraction": [0.0, 0.0, 0.5, 0.0, 0.0],
+            "regime": ["", "ranging", "ranging", "trending_up", ""],
+        },
+        index=pd.date_range("2024-01-01", periods=5, freq="D"),
+    )
+    eff = backtest_effective_frame(vec)
+    assert eff.iloc[2]["signal"] == 1
+    assert eff.iloc[2]["open_action"] == "long"
+    assert eff.iloc[3]["close_fraction"] == 0.5
+    assert eff.iloc[3]["regime"] == "ranging"
+
+
+def test_vector_and_live_replay_agree_on_constant_strategy():
+    df = _flat_df(60)
+    cfg = ParityConfig(
+        strategy_name="stub",
+        symbol="BTC/USDT",
+        timeframe="1d",
+        params={},
+        min_warmup=30,
+    )
+    reg = _registry_stub()
+
+    from regime import ensure_regime_columns
+
+    result = compare_parity(
+        df,
+        cfg,
+        apply_strategy=reg.apply_strategy,
+        get_strategy=reg.get_strategy,
+        ensure_regime_columns=ensure_regime_columns,
+        include_fills=False,
+    )
+    assert result.bars_compared == 30
+    assert result.mismatches == 0
+
+
+def test_live_bar_decision_matches_vector_last_row():
+    df = _flat_df(40)
+    cfg = ParityConfig(strategy_name="stub", symbol="X", timeframe="1d", params={}, min_warmup=30)
+    reg = _registry_stub()
+    vec = vector_frame(
+        df, cfg, apply_strategy=reg.apply_strategy, ensure_regime_columns=lambda d, **_: d,
+    )
+    live = live_bar_decision(
+        df, cfg, apply_strategy=reg.apply_strategy, get_strategy=reg.get_strategy,
+    )
+    idx = df.index[-1]
+    assert int(vec.loc[idx, "signal"]) == live["signal"]
+
+
+def test_format_summary_reports_mismatch():
+    result = type("R", (), {
+        "bars_compared": 2,
+        "mismatches": 1,
+        "fills": [],
+        "rows": [{
+            "decision_match": False,
+            "bar": "2024-01-02T00:00:00+00:00",
+            "vector_signal": 1,
+            "live_signal": 0,
+            "vector_regime": "a",
+            "live_regime": "b",
+            "vector_open_action": "long",
+            "live_open_action": "none",
+            "vector_close_fraction": 0.0,
+            "live_close_fraction": 0.0,
+        }],
+    })()
+    text = format_summary(result)
+    assert "Mismatches:    1" in text
+    assert "signal 1≠0" in text
+
+
+def test_regression_issue_index_documents_closed_bug_tests():
+    """D8.4 — every closed backtest bug issue has a named regression test file."""
+    tests_dir = os.path.join(_BACKTEST_DIR, "tests")
+    index = {
+        "#302": ["test_backtester_end_to_end.py", "test_backtester_fills.py",
+                 "test_options_vol_math.py", "test_options_iv_rank.py"],
+        "#304": ["test_backtest_reporting.py"],
+        "#715": ["test_post_tp_sl.py"],  # cited on regression test functions, not module doc
+        "#730": ["test_backtester_lookahead.py"],
+    }
+    for issue, files in index.items():
+        for fname in files:
+            path = os.path.join(tests_dir, fname)
+            assert os.path.isfile(path), f"{issue} regression file missing: {fname}"
+            with open(path) as fh:
+                body = fh.read()
+            assert issue.replace("#", "") in body or issue in body, (
+                f"{fname} should cite {issue} somewhere in the file"
+            )


### PR DESCRIPTION
## Summary

- Completes the #906 backtest subsystem audit: D1–D8 checklist documented in `backtest/AUDIT.md`
- Ships **`parity_diff.py`** (D7.4) — per-bar vector vs live decision diff CLI with optional fill extraction
- Documents live-only parity gaps in `backtester.py` (scale-in, resting limits, dynamic regime close, directional policy, inline SL at open)
- Adds regression meta-tests for closed issues #302/#303/#304/#715/#730; #824 documented out of backtest scope

Follow-up work filed as #925–#931 (theta Sharpe, close-strategy tests, drawdown recovery, WF heuristics, dedup refactor, verbose trace, composite regime fixtures).

Closes #906

## Test plan

- [x] `uv run pytest backtest/tests/test_parity_diff.py backtest/tests/test_backtest_parity_regression.py backtest/tests/test_audit_regression_index.py`
- [ ] `python backtest/parity_diff.py sma_crossover BTC/USDT 1d --since 2024-01-01` (requires cached OHLCV)

LLM: Composer 2.5 | high | Harness: Cursor Agent