### PR TITLE
audit(backtest): parity-diff tool + audit summary (#906)

### DIFF
--- a/backtest/AUDIT.md
+++ b/backtest/AUDIT.md
@@ -1,0 +1,128 @@
+# Backtest Subsystem Audit — 2026-06 (#906)
+
+Structured audit of correctness, parity, coverage, reporting, and debt across
+the backtesting subsystem (engine at the time of audit: 4,659 LOC across the
+8 core modules, 20 test files / ~1,180 passing tests). Findings were filed as
+cards #942–#945; this doc captures the verified state so future contributors
+don't re-derive it. Line numbers reference the audit-time tree — anchor on
+symbol names if they drift.
+
+## D1 — Look-ahead contract: INTACT
+
+The contract (`backtester.py` module docstring) holds for every decision
+input. Verified end to end:
+
+- `signal`, `_open_action`, `_close_fraction`, `regime` are all `shift(1)`'d
+  in the normalization blocks (`backtester.py:738, 748, 749, 780`) before the
+  per-bar loop reads them; fills use the current bar's `open` (contractual).
+- Close evaluators run end-of-bar against bar N's close mark and bar N's ATR
+  (`_evaluate_close_strategies`, dispatched at `backtester.py:1139`); their
+  output becomes `pending_close_fraction`, applied at bar N+1's open.
+- `_regime_bar_close` is snapshotted **before** the regime shift
+  (`backtester.py:762`) and is only fed to close evaluators as
+  `market_regime` — bar-N data for an end-of-bar decision, matching live.
+- Same-bar SL re-fire after a post-TP bump (the #715 class) is gated by
+  `sl_after_just_applied` (`backtester.py:1175`).
+- SL/TP intra-bar races resolve at bar close (no OHLC walking), documented in
+  the contract and deterministic: TP evaluators → SL bump → suppressed hit
+  check → next-bar fill.
+- Strategy sweep: no `shift(-n)`, `center=True` rolling, or forward `iloc`
+  in `shared_strategies/open/registry.py` or `shared_strategies/close/*.py`.
+  (Full-frame normalization — e.g. a signal keyed on the whole series' mean —
+  is *not* statically detectable; that class is what `parity_diff.py` exists
+  to catch.)
+- Composite (#861/#862) and shared-regime-bundle (#879) work did not bypass
+  the shift: only the `regime` column is a decision input; `adx`/`regime_score`
+  /±DI columns are display-only.
+
+Regression guards: `test_backtester_lookahead.py`, `test_post_tp_sl.py`
+(same-bar fire), `test_backtester_regime.py` (gate timing + live↔backtest
+label parity).
+
+## D2 — Parity with the live scheduler
+
+| Surface | State |
+|---|---|
+| Fees | ✅ `PLATFORM_FEE_PCT` matches `fees.go`; `test_platform_fees.py` scrapes the Go source so drift fails CI. deribit/ibkr/topstep flow through option/futures fee functions, not the spot table. |
+| Initial/trailing ATR SL (#885) | ✅ Same trigger formula (`entry ± mult×EntryATR`) and same-bar arming on both sides. |
+| Default tier ladders (#870/#887) | ✅ Values synced across Go and all three Python mirrors — but unpinned by tests (#944). |
+| Single close ref (#842) | ✅ `--config` rejects legacy `len>1` arrays with the same semantics live rejects them; the engine's max-wins multi-ref path remains for direct-constructor/test use only. |
+| `tiered_tp_atr_live_regime_dynamic` (#843) | ✅ Loudly rejected at config load (`run_backtest.py:193-196`); no evaluator registered under the name. |
+| `regime_directional_policy` (#822) | ✅ Loudly rejected (`run_backtest.py:160-166`). |
+| Regime-aware `sl_after` (#736) | ✅ Loudly rejected at `Backtester` init; scalar forms backtestable. |
+| `user_close_defaults` (#866) | ✅ `--defaults system\|user` mirrors the live three-layer resolution. |
+| Scale-in (#873), manual limit orders (#883) | Live-only **by design** (HL perps/manual execution mechanics, no signal-path component). Config keys are ignored by the backtest loader; acceptable while the features stay execution-side. |
+| **v13/v14 legacy close keys** | ❌ **#942** — the `--config` gate admits pre-v15 configs whose `tiers`/alias keys silently no-op in the Python evaluators while live canonicalizes them. |
+| **`direction` / `invert_signal` / `regime_window_divergence`** | ❌ **#943** — silently ignored by `--config`; the `regime_directional_policy` rejection message even recommends two of them. |
+
+## D3/D8 — Coverage
+
+- Every registered close strategy has at least one engine-level test except
+  the rejected dynamic variant (correct). `trailing_tp_ratchet_regime` and
+  `tiered_tp_atr_live_regime` are covered.
+- ADX 3-label vocabulary covered; **composite 7-label vocabulary has zero
+  backtest tests** (#944).
+- Sharpe annualization tested at 4 timeframes (1d/4h/1h/1w) — meets the ≥3 bar.
+- Variant depth: main engine ~strong (incl. shorts), pairs and options
+  moderate, **theta thin** (one force-close test, #944).
+- `DEFAULT_PARAM_RANGES` completeness is enforced by
+  `test_registry_loader.py::test_param_ranges_cover_every_registered_strategy`.
+- No property-based (`hypothesis`) tests anywhere; grid search is fully
+  deterministic so seed plumbing is moot.
+- Regression tests exist for every prior backtest bug: #302 (fills + vol
+  math), #303 (regime/BS parity), #304 M3/M5/L5 (annualization, calendar
+  days, theta force-close log), #715 (same-bar SL), #730 (look-ahead),
+  #824 (storage lazy-init).
+
+## D4/D5 — Reporting & optimizer
+
+- `periods_per_year()` drives Sharpe/volatility in the main engine; options
+  uses check-interval-aware sampling; pairs uses `bars_per_year`. Theta
+  hardcodes daily — valid only because theta data is always `1d` (#945).
+- Options annualized return uses elapsed calendar days (the #304 M5 fix is in
+  and commented).
+- Walk-forward separates train/test per fold and aggregates OOS-only stats
+  (`oos_mean_*`, `oos_std_return`). The boundary-bar inclusion at fold start
+  is **intentional** (its raw signal becomes row 1's shifted signal — matches
+  live) and is regression-tested in `test_walk_forward_warmup.py`; don't
+  "fix" it.
+- Optimizer is a deterministic grid; `optimize_metric` accepts any result-dict
+  key. No fold-to-fold robustness gate (param stability is reported via
+  `most_common_best_params`, not enforced).
+- Known gaps, not bugs: drawdown has no recovery-duration metric; the main
+  engine doesn't emit a separate `total_fees`; timestamps serialize as
+  `str(pd.Timestamp)` (space separator), not strict ISO-8601.
+
+## D6 — Debt
+
+- `close_registry_loader` shim is still required (open and close registries
+  both resolve as module name `registry`).
+- `backtest_options.py` exchange is configurable (`--exchange`, #304 L2 fixed).
+- HTF filter plumbs through the same `shared_tools/htf_filter.py` as live,
+  fed by cached candles; missing HTF cache fails open to neutral trend.
+- Residual items in **#945**: unused imports, dead close-name optimizer range
+  entries, theta daily-only comment.
+- Metrics/reporting logic is re-implemented per variant (~150–200 LOC
+  duplication across options/theta/pairs); extraction is optional until one
+  of them next drifts.
+
+## D7 — Observability
+
+- `parity_diff.py` (added by this audit, D7.4) replays the vectorized
+  backtest path and the trailing-window live path over the same candles and
+  emits a per-bar diff of signal / open_action / close_fraction / regime —
+  the tool to reach for first on any backtest-vs-paper mismatch. See its
+  module docstring for usage; `--csv` dumps the full frame.
+- Still absent (scope when needed): per-bar verbose trace inside
+  `Backtester.run`, equity-curve/trade-log CSV export, `exit_reason` and
+  entry/exit regime fields on `Trade`.
+
+## Known live-only surfaces (decision record)
+
+`scale_in` (#873), manual resting limit orders (#883), per-cycle regime
+hysteresis (`tiered_tp_atr_live_regime_dynamic`, #843),
+`regime_directional_policy` (#822), regime-aware `sl_after` (#736), and
+`regime_window_divergence` (#907) are execution/per-cycle mechanics with no
+bar-level equivalent; the first two are silently ignored by design (no signal
+path), the middle three are loudly rejected, and the last should be promoted
+to a loud rejection (#943).

--- a/backtest/parity_diff.py
+++ b/backtest/parity_diff.py
@@ -1,0 +1,274 @@
+"""Backtest-vs-live parity diff tool (#906 D7.4).
+
+The parity contract between the backtester and the live scheduler is:
+same ``compute_*`` function, same window, same params → same decision.
+The backtester evaluates a strategy ONCE over the full vectorized frame
+and reads decisions row-by-row; the live check scripts re-evaluate the
+strategy every cycle over a trailing fetch window (``--ohlcv-limit``,
+default 200 in ``shared_scripts/check_strategy.py``) and act on the LAST
+closed bar. Any strategy whose bar-N output depends on the frame it was
+computed in — full-series normalization, unseeded rolling state, warmup
+that never converges — silently diverges between the two paths, and no
+existing test catches it because both suites only exercise one path.
+
+This tool replays both paths over the same candles and emits a per-bar
+diff of the decision surface:
+
+  • ``signal``          — vectorized value at bar N  vs  last-bar value of a
+                          window ENDING at bar N (live semantics).
+  • ``open_action``     — same comparison when the strategy emits the
+                          open/close-split column.
+  • ``close_fraction``  — max across ``close_fraction*`` columns, same
+                          comparison.
+  • ``regime``          — full-frame ``compute_regime`` label at bar N vs
+                          ``latest_regime`` on the trailing window (the
+                          per-bar generalization of the last-bar parity
+                          test in ``test_backtester_regime.py``).
+
+Usage:
+  uv run --no-sync python backtest/parity_diff.py \
+      --strategy supertrend --symbol BTC/USDT --timeframe 1h \
+      [--since 2024-01-01] [--params '{"period": 10}'] \
+      [--registry spot|futures] [--window 200] [--stride 1] \
+      [--regime] [--csv /tmp/diff.csv]
+
+Exit code 0 when the paths agree on every compared bar, 1 when any bar
+differs (CI-friendly), 2 on usage/data errors.
+
+The per-bar loop re-runs the strategy O(N) times on trailing windows —
+this is a debugging tool, not a benchmark; bound the range with --since
+or thin the comparison with --stride for long histories.
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Optional
+
+import pandas as pd
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
+
+from registry_loader import load_registry
+from backtester import _max_close_fraction_series, _normalize_open_action
+
+# Mirror live: check_strategy.py refuses to evaluate fewer than 30 candles.
+LIVE_MIN_CANDLES = 30
+# Mirror live: check scripts fetch --ohlcv-limit candles (default 200).
+DEFAULT_WINDOW = 200
+
+
+def _normalize_signal(value) -> int:
+    """Collapse a raw strategy signal to the live {-1, 0, 1} domain."""
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return 0
+    if pd.isna(f):
+        return 0
+    if f > 0:
+        return 1
+    if f < 0:
+        return -1
+    return 0
+
+
+def _last_bar_decision(result_df: pd.DataFrame) -> dict:
+    """Extract the live-path decision surface from a strategy result frame."""
+    last = result_df.iloc[-1]
+    decision = {"signal": _normalize_signal(last.get("signal", 0))}
+    if "open_action" in result_df.columns:
+        decision["open_action"] = _normalize_open_action(last.get("open_action"))
+    frac_series = _max_close_fraction_series(result_df)
+    if frac_series.any():
+        decision["close_fraction"] = float(frac_series.iloc[-1])
+    elif any(c == "close_fraction" or c.startswith("close_fraction:")
+             for c in result_df.columns):
+        decision["close_fraction"] = 0.0
+    return decision
+
+
+def _full_frame_decisions(result_df: pd.DataFrame) -> pd.DataFrame:
+    """Extract the backtest-path decision surface for every bar."""
+    out = pd.DataFrame(index=result_df.index)
+    out["signal"] = result_df.get(
+        "signal", pd.Series(0, index=result_df.index)
+    ).map(_normalize_signal)
+    if "open_action" in result_df.columns:
+        out["open_action"] = result_df["open_action"].map(_normalize_open_action)
+    if any(c == "close_fraction" or c.startswith("close_fraction:")
+           for c in result_df.columns):
+        out["close_fraction"] = _max_close_fraction_series(result_df)
+    return out
+
+
+def compute_parity_frame(
+    df: pd.DataFrame,
+    strategy_name: str,
+    params: Optional[dict] = None,
+    registry: str = "spot",
+    window: Optional[int] = DEFAULT_WINDOW,
+    stride: int = 1,
+    regime_enabled: bool = False,
+    regime_period: int = 14,
+    regime_adx_threshold: float = 20.0,
+) -> pd.DataFrame:
+    """Replay both decision paths over ``df`` and return the per-bar diff.
+
+    Returns one row per compared bar with ``bt_*`` (vectorized full-frame)
+    and ``live_*`` (trailing-window last-bar) columns plus a ``match``
+    bool. Comparison starts at the first bar where the trailing window is
+    full (``window`` bars, or ``LIVE_MIN_CANDLES`` for expanding mode) so
+    every live evaluation sees the same window length it would in
+    production — earlier bars would diff on warmup, not on parity.
+    """
+    if stride < 1:
+        raise ValueError("stride must be >= 1")
+    if window is not None and window < LIVE_MIN_CANDLES:
+        raise ValueError(f"window must be >= {LIVE_MIN_CANDLES} (live minimum)")
+    reg = load_registry(registry)
+    full_result = reg.apply_strategy(strategy_name, df.copy(), dict(params or {}))
+    bt = _full_frame_decisions(full_result)
+
+    regime_full = None
+    if regime_enabled:
+        from regime import compute_regime, latest_regime
+        regime_full = compute_regime(
+            df, period=regime_period, adx_threshold=regime_adx_threshold
+        )["regime"]
+
+    start = (window - 1) if window is not None else (LIVE_MIN_CANDLES - 1)
+    rows = []
+    for i in range(start, len(df), stride):
+        lo = max(0, i + 1 - window) if window is not None else 0
+        win = df.iloc[lo:i + 1].copy()
+        live = _last_bar_decision(
+            reg.apply_strategy(strategy_name, win, dict(params or {}))
+        )
+        row = {
+            "ts": df.index[i],
+            "bt_signal": int(bt["signal"].iloc[i]),
+            "live_signal": live["signal"],
+        }
+        match = row["bt_signal"] == row["live_signal"]
+        if "open_action" in bt.columns:
+            row["bt_open_action"] = bt["open_action"].iloc[i]
+            row["live_open_action"] = live.get("open_action", "none")
+            match = match and row["bt_open_action"] == row["live_open_action"]
+        if "close_fraction" in bt.columns:
+            row["bt_close_fraction"] = float(bt["close_fraction"].iloc[i])
+            row["live_close_fraction"] = float(live.get("close_fraction", 0.0))
+            match = match and abs(
+                row["bt_close_fraction"] - row["live_close_fraction"]
+            ) < 1e-9
+        if regime_enabled:
+            from regime import latest_regime
+            row["bt_regime"] = str(regime_full.iloc[i])
+            row["live_regime"] = str(latest_regime(
+                win, period=regime_period, adx_threshold=regime_adx_threshold
+            )["regime"])
+            match = match and row["bt_regime"] == row["live_regime"]
+        row["match"] = match
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def summarize(frame: pd.DataFrame) -> dict:
+    """Aggregate a parity frame into a result summary."""
+    if frame.empty:
+        return {"bars_compared": 0, "mismatches": 0, "clean": True}
+    mismatched = frame[~frame["match"]]
+    summary = {
+        "bars_compared": int(len(frame)),
+        "mismatches": int(len(mismatched)),
+        "clean": bool(mismatched.empty),
+    }
+    if not mismatched.empty:
+        summary["first_mismatch"] = str(mismatched.iloc[0]["ts"])
+        summary["last_mismatch"] = str(mismatched.iloc[-1]["ts"])
+    return summary
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Per-bar backtest-vs-live decision diff (#906 D7.4)"
+    )
+    parser.add_argument("--strategy", required=True)
+    parser.add_argument("--symbol", default="BTC/USDT")
+    parser.add_argument("--timeframe", default="1h")
+    parser.add_argument("--since", default=None,
+                        help="Start date YYYY-MM-DD (bounds the replay)")
+    parser.add_argument("--params", default=None,
+                        help="JSON dict of strategy param overrides")
+    parser.add_argument("--registry", choices=["spot", "futures"],
+                        default="spot")
+    parser.add_argument("--window", type=int, default=DEFAULT_WINDOW,
+                        help=f"Trailing candle window for the live path "
+                             f"(default {DEFAULT_WINDOW}, matching the check "
+                             f"scripts' --ohlcv-limit); 0 = expanding window")
+    parser.add_argument("--stride", type=int, default=1,
+                        help="Compare every Nth bar (speeds up long ranges)")
+    parser.add_argument("--regime", action="store_true",
+                        help="Also diff the regime label per bar")
+    parser.add_argument("--regime-period", type=int, default=14)
+    parser.add_argument("--regime-adx-threshold", type=float, default=20.0)
+    parser.add_argument("--csv", default=None,
+                        help="Write the full per-bar frame to this CSV path")
+    parser.add_argument("--max-print", type=int, default=20,
+                        help="Max mismatching rows printed to stdout")
+    args = parser.parse_args(argv)
+
+    params = None
+    if args.params:
+        try:
+            params = json.loads(args.params)
+        except json.JSONDecodeError as e:
+            print(f"--params is not valid JSON: {e}", file=sys.stderr)
+            return 2
+        if not isinstance(params, dict):
+            print("--params must be a JSON object", file=sys.stderr)
+            return 2
+
+    from data_fetcher import load_cached_data
+    df = load_cached_data(args.symbol, args.timeframe, start_date=args.since)
+    if df is None or df.empty:
+        print(f"No cached data for {args.symbol} {args.timeframe} — run a "
+              f"backtest first to populate the cache.", file=sys.stderr)
+        return 2
+
+    window = args.window if args.window and args.window > 0 else None
+    frame = compute_parity_frame(
+        df, args.strategy, params=params, registry=args.registry,
+        window=window, stride=args.stride, regime_enabled=args.regime,
+        regime_period=args.regime_period,
+        regime_adx_threshold=args.regime_adx_threshold,
+    )
+    result = summarize(frame)
+
+    if args.csv:
+        frame.to_csv(args.csv, index=False)
+        print(f"Per-bar frame written to {args.csv}")
+
+    print(f"\nParity diff: {args.strategy} on {args.symbol} {args.timeframe} "
+          f"(window={'expanding' if window is None else window}, "
+          f"stride={args.stride})")
+    print(f"  Bars compared: {result['bars_compared']}")
+    print(f"  Mismatches:    {result['mismatches']}")
+    if result["clean"]:
+        print("  CLEAN — backtest and live paths agree on every compared bar.")
+        return 0
+
+    print(f"  First mismatch: {result['first_mismatch']}")
+    print(f"  Last mismatch:  {result['last_mismatch']}")
+    mismatched = frame[~frame["match"]]
+    with pd.option_context("display.max_columns", None, "display.width", 200):
+        print(mismatched.head(args.max_print).to_string(index=False))
+    if len(mismatched) > args.max_print:
+        print(f"  … {len(mismatched) - args.max_print} more "
+              f"(use --csv for the full frame)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backtest/tests/test_parity_diff.py
+++ b/backtest/tests/test_parity_diff.py
@@ -1,0 +1,135 @@
+"""Tests for the backtest-vs-live parity diff tool (#906 D7.4).
+
+The tool's job is to detect strategies whose bar-N decision depends on the
+frame they were computed in (full-frame vectorized vs trailing live window).
+These tests prove both directions: a window-invariant strategy diffs clean,
+and a deliberately frame-dependent strategy is caught.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from parity_diff import (
+    LIVE_MIN_CANDLES,
+    compute_parity_frame,
+    summarize,
+)
+from registry_loader import load_registry
+
+
+def _ohlcv(n: int = 300, seed: int = 7) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    drift = np.linspace(0, 12, n)
+    wave = 4.0 * np.sin(np.linspace(0, 14, n))
+    noise = rng.normal(0, 0.4, n)
+    close = 100.0 + drift + wave + noise
+    df = pd.DataFrame({
+        "open": close + rng.normal(0, 0.1, n),
+        "high": close + np.abs(rng.normal(0, 0.5, n)) + 0.2,
+        "low": close - np.abs(rng.normal(0, 0.5, n)) - 0.2,
+        "close": close,
+        "volume": rng.uniform(900, 1100, n),
+    }, index=pd.date_range("2024-01-01", periods=n, freq="1h"))
+    return df
+
+
+def test_window_invariant_strategy_diffs_clean():
+    """sma_crossover at bar N only needs the trailing slow-period bars, so
+    a full window evaluation must equal the full-frame vectorized value on
+    every compared bar."""
+    df = _ohlcv(260)
+    frame = compute_parity_frame(
+        df, "sma_crossover",
+        params={"fast_period": 10, "slow_period": 30},
+        window=120,
+    )
+    result = summarize(frame)
+    assert result["bars_compared"] > 100
+    assert result["clean"], (
+        f"window-invariant strategy should not diff: "
+        f"{frame[~frame['match']].head()}"
+    )
+
+
+def test_frame_dependent_strategy_is_caught():
+    """A strategy keyed on the FULL frame's mean (classic silent-parity
+    bug: full-series normalization) must produce mismatches — the live
+    window's mean differs from the backtest frame's mean."""
+    reg = load_registry("spot")
+
+    def full_frame_mean_strategy(df: pd.DataFrame) -> pd.DataFrame:
+        out = df.copy()
+        out["signal"] = (out["close"] > out["close"].mean()).astype(int)
+        return out
+
+    name = "_parity_diff_test_frame_dependent"
+    reg.STRATEGY_REGISTRY[name] = {
+        "fn": full_frame_mean_strategy,
+        "description": "test-only frame-dependent strategy",
+        "default_params": {},
+    }
+    try:
+        df = _ohlcv(260)
+        frame = compute_parity_frame(df, name, window=60)
+        result = summarize(frame)
+        assert result["mismatches"] > 0, (
+            "frame-dependent strategy must be detected by the parity diff"
+        )
+        assert "first_mismatch" in result
+    finally:
+        del reg.STRATEGY_REGISTRY[name]
+
+
+def test_regime_labels_diff_clean_per_bar():
+    """latest_regime on the trailing window must match compute_regime's
+    full-frame label on every bar — the per-bar generalization of the
+    last-bar parity test in test_backtester_regime.py."""
+    df = _ohlcv(220)
+    frame = compute_parity_frame(
+        df, "sma_crossover",
+        params={"fast_period": 10, "slow_period": 30},
+        window=120,
+        regime_enabled=True,
+    )
+    assert "bt_regime" in frame.columns and "live_regime" in frame.columns
+    regime_mismatch = frame[frame["bt_regime"] != frame["live_regime"]]
+    assert regime_mismatch.empty, regime_mismatch.head()
+
+
+def test_expanding_window_mode():
+    """window=None replays live with an ever-growing frame from bar
+    LIVE_MIN_CANDLES on; sma_crossover converges once the slow period is
+    seeded, so only the comparison start moves."""
+    df = _ohlcv(120)
+    frame = compute_parity_frame(
+        df, "sma_crossover",
+        params={"fast_period": 5, "slow_period": 15},
+        window=None,
+    )
+    assert len(frame) == len(df) - (LIVE_MIN_CANDLES - 1)
+    assert summarize(frame)["clean"]
+
+
+def test_stride_thins_comparison():
+    df = _ohlcv(200)
+    full = compute_parity_frame(
+        df, "sma_crossover", params={"fast_period": 5, "slow_period": 15},
+        window=60,
+    )
+    thinned = compute_parity_frame(
+        df, "sma_crossover", params={"fast_period": 5, "slow_period": 15},
+        window=60, stride=5,
+    )
+    assert len(thinned) == (len(full) + 4) // 5
+
+
+def test_window_below_live_minimum_rejected():
+    df = _ohlcv(100)
+    with pytest.raises(ValueError, match="window must be >="):
+        compute_parity_frame(df, "sma_crossover", window=10)


### PR DESCRIPTION
Closes #906

Delivers the audit's acceptance criteria:

## D1–D4 audited
Full pass over correctness, parity, coverage, and reporting; verified state recorded in `backtest/AUDIT.md`. Headline: the #730 look-ahead contract is **intact** for every decision input (signal / open_action / close_fraction / regime, incl. the composite + shared-bundle regime work), the #715 same-bar SL gate holds, and no forward-peeking patterns exist in the strategy registries.

## Findings filed as cards
- #942 — `--config` v13/v14 gate lets pre-v15 legacy close keys (`tiers`, aliases) silently no-op in Python while live canonicalizes them (parity, bug).
- #943 — `direction` / `invert_signal` / `regime_window_divergence` silently ignored by the backtest config path; the `regime_directional_policy` rejection message recommends two of them (parity, bug).
- #944 — coverage: default tier ladder values unpinned, composite 7-label regime untested, theta variant thin.
- #945 — debt: theta daily-only annualization hardcodes, unused imports, dead optimizer range entries.

## D7.4 parity-diff tool (shipped here)
`backtest/parity_diff.py` replays both decision paths over the same candles — vectorized full-frame (backtest) vs trailing 200-candle window with last-closed-bar reads (live check-script semantics) — and emits a per-bar diff of signal / open_action / close_fraction / regime, CSV-exportable, exit 1 on mismatch. This catches the frame-dependent strategy class (full-series normalization, unseeded rolling state) that `shift(1)` cannot, which is the silent-drift mechanism behind most historical parity bugs.

## D8.4 regression tests confirmed
Every prior backtest bug (#302/#303/#304/#715/#730/#824) has a test that would catch its class — mapping in `backtest/AUDIT.md`.

## Testing
- `backtest/tests/test_parity_diff.py`: 6 tests — clean diff on a window-invariant strategy, detection of a deliberately frame-dependent strategy, per-bar regime parity, expanding-window mode, stride, live-minimum window rejection.
- Full Python suite: 1178 passed.

---
Created with LLM: Fable 5 | high | Harness: Claude Code