### PR TITLE
fix(regime): tighten composite clean-trend trailing default to 2.0

### DIFF
--- a/scheduler/regime_atr.go
+++ b/scheduler/regime_atr.go
@@ -222,15 +222,15 @@ var regimeATRDefaults = struct {
 		"ranging":       {ATR: 1.5},
 	},
 	// #870: the regime ratchet/trailing opening trail. ADX labels keep their
-	// pre-#870 values; composite labels resolve per quality group (clean=2.5,
+	// pre-#870 values; composite labels resolve per quality group (clean=2.0,
 	// choppy=2.0, ranging=1.0) so a trailing_stop_atr_regime use_defaults block
-	// differentiates clean trends (wide initial risk) from ranges (tight).
+	// differentiates trend groups from ranges (tight).
 	Trailing: map[string]RegimeATREntry{
 		"trending_up":          {ATR: 2.5},
 		"trending_down":        {ATR: 2.5},
 		"ranging":              {ATR: 2.0},
-		"trending_up_clean":    {ATR: 2.5},
-		"trending_down_clean":  {ATR: 2.5},
+		"trending_up_clean":    {ATR: 2.0},
+		"trending_down_clean":  {ATR: 2.0},
 		"trending_up_choppy":   {ATR: 2.0},
 		"trending_down_choppy": {ATR: 2.0},
 		"ranging_quiet":        {ATR: 1.0},

--- a/scheduler/regime_atr_composite_test.go
+++ b/scheduler/regime_atr_composite_test.go
@@ -121,6 +121,30 @@ func TestValidateRegimeATRConfig_CompositeTrailingExplicit(t *testing.T) {
 	}
 }
 
+// TestParseRegimeATRBlock_TrailingUseDefaultsCompositeClean (#940): fleet
+// baseline expansion for composite labels must resolve clean opening trails to
+// 2.0 ATR (aligned with choppy composite; ratchet/TP ladders unchanged).
+func TestParseRegimeATRBlock_TrailingUseDefaultsCompositeClean(t *testing.T) {
+	labels := regimeLabelsForClassifier(regimeClassifierComposite)
+	raw := map[string]interface{}{"use_defaults": true}
+	block, errs := parseRegimeATRBlock(raw, "trailing_stop_atr_regime", regimeSurfaceTrailing, labels)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	for _, label := range []string{"trending_up_clean", "trending_down_clean"} {
+		v, ok := resolveRegimeATR(block, label)
+		if !ok || v != 2.0 {
+			t.Fatalf("resolveRegimeATR(%s) = (%g, %v), want (2.0, true)", label, v, ok)
+		}
+	}
+	if v, ok := resolveRegimeATR(block, "trending_up_choppy"); !ok || v != 2.0 {
+		t.Fatalf("resolveRegimeATR(trending_up_choppy) = (%g, %v), want (2.0, true)", v, ok)
+	}
+	if v, ok := resolveRegimeATR(block, "ranging_quiet"); !ok || v != 1.0 {
+		t.Fatalf("resolveRegimeATR(ranging_quiet) = (%g, %v), want (1.0, true)", v, ok)
+	}
+}
+
 // TestValidateRegimeATRConfig_CompositeMissingLabelRejected ensures the
 // exhaustiveness check uses the composite vocabulary: an incomplete 7-state
 // map is rejected and the error names the composite labels (not ADX).

--- a/scheduler/trailing_tp_ratchet.go
+++ b/scheduler/trailing_tp_ratchet.go
@@ -65,7 +65,7 @@ func defaultTrailingRatchetTiers() []trailingRatchetTier {
 // the regime variant (#870 C2). Trend groups (clean/choppy) are pure
 // let-it-ride (close_fraction 0); ranging scales out as ranges mean-revert.
 // Each group's first-rung trail couples to that group's opening trail in
-// regimeATRDefaults.Trailing (clean 2.5 / choppy 2.0 / ranging 1.0). Mirrors
+// regimeATRDefaults.Trailing (clean 2.0 / choppy 2.0 / ranging 1.0). Mirrors
 // DEFAULT_RATCHET_TIERS_BY_GROUP in shared_strategies/close/trailing_tp_ratchet.py.
 var ratchetTierGroupDefaults = map[string][]trailingRatchetTier{
 	"clean": {

--- a/scheduler/trailing_tp_ratchet_test.go
+++ b/scheduler/trailing_tp_ratchet_test.go
@@ -723,7 +723,7 @@ func TestDefaultTrailingRatchetTiersForRegime(t *testing.T) {
 // TestValidateRegimeRatchet_AllDefaultsCompositeValidates is the #870
 // integration case: trailing_stop_atr_regime + trailing_tp_ratchet_regime both
 // on use_defaults under a composite classifier. The full validateRegimeATRConfig
-// path expands the per-group opening trails (clean 2.5 / choppy 2.0 / ranging
+// path expands the per-group opening trails (clean 2.0 / choppy 2.0 / ranging
 // 1.0) and per-group ratchet ladders, and the per-key initial-trail coupling
 // must hold for every label (each group's first rung ≤ its open).
 func TestValidateRegimeRatchet_AllDefaultsCompositeValidates(t *testing.T) {

--- a/shared_strategies/close/regime_atr.py
+++ b/shared_strategies/close/regime_atr.py
@@ -121,11 +121,11 @@ REGIME_ATR_DEFAULTS_TRAILING: Dict[str, RegimeATREntry] = {
     "trending_up": RegimeATREntry(atr=2.5),
     "trending_down": RegimeATREntry(atr=2.5),
     "ranging": RegimeATREntry(atr=2.0),
-    # #870: composite group opening trails (clean=2.5, choppy=2.0, ranging=1.0).
+    # #870: composite group opening trails (clean=2.0, choppy=2.0, ranging=1.0).
     # ADX labels keep their pre-#870 values; resolve() exact-matches keys so the
     # extra composite entries are inert for an ADX strategy.
-    "trending_up_clean": RegimeATREntry(atr=2.5),
-    "trending_down_clean": RegimeATREntry(atr=2.5),
+    "trending_up_clean": RegimeATREntry(atr=2.0),
+    "trending_down_clean": RegimeATREntry(atr=2.0),
     "trending_up_choppy": RegimeATREntry(atr=2.0),
     "trending_down_choppy": RegimeATREntry(atr=2.0),
     "ranging_quiet": RegimeATREntry(atr=1.0),

--- a/shared_strategies/close/test_regime_atr.py
+++ b/shared_strategies/close/test_regime_atr.py
@@ -44,6 +44,18 @@ def test_use_defaults_expands(regime_atr):
     assert block.trend_regime["trending_up"].atr == 2.0
 
 
+def test_trailing_use_defaults_composite_clean(regime_atr):
+    # #940: fleet baseline must resolve clean composite opening trails to 2.0.
+    block, errs = regime_atr.parse_regime_atr_block(
+        {"use_defaults": True}, "trailing_stop_atr_regime", regime_atr.SURFACE_TRAILING
+    )
+    assert errs == []
+    for label in ("trending_up_clean", "trending_down_clean"):
+        assert regime_atr.resolve_regime_atr(block, label) == 2.0
+    assert regime_atr.resolve_regime_atr(block, "trending_up_choppy") == 2.0
+    assert regime_atr.resolve_regime_atr(block, "ranging_quiet") == 1.0
+
+
 def test_rejects_bare_label_keys(regime_atr):
     raw = {
         "trending_up": {"atr_multiple": 2.0},

--- a/shared_strategies/close/trailing_tp_ratchet.py
+++ b/shared_strategies/close/trailing_tp_ratchet.py
@@ -34,7 +34,7 @@ DEFAULT_RATCHET_TIERS = [
 # Mirrors ratchetTierGroupDefaults in scheduler/trailing_tp_ratchet.go. Trend
 # groups (clean/choppy) are pure let-it-ride (close_fraction 0); ranging scales
 # out. Each group's first rung couples to that group's opening trail in
-# REGIME_ATR_DEFAULTS_TRAILING (clean 2.5 / choppy 2.0 / ranging 1.0).
+# REGIME_ATR_DEFAULTS_TRAILING (clean 2.0 / choppy 2.0 / ranging 1.0).
 DEFAULT_RATCHET_TIERS_BY_GROUP = {
     "clean": [
         {"atr_multiple": 3.0, "trailing_mult_after": 1.5, "close_fraction": 0.0},


### PR DESCRIPTION
## Summary
- Reduce composite `trending_up_clean` / `trending_down_clean` opening trailing ATR default from 2.5 to 2.0 in Go and Python `use_defaults` tables
- Sync comments describing the clean/choppy/ranging opening-trail ladder
- Add Go/Python regression tests for fleet-baseline expansion on clean composite labels

Closes #940

## Behavior change
Composite strategies using `trailing_stop_atr_regime: { use_defaults: true }` get tighter initial trailing stops in clean-trend regimes (2.5× → 2.0× ATR). ADX legacy trailing defaults, clean ratchet ladder, and clean TP tier ladder are unchanged.

## Test plan
- [x] `go test -run 'TestParseRegimeATRBlock_TrailingUseDefaultsCompositeClean|TestValidateRegimeRatchet_AllDefaultsCompositeValidates' ./scheduler/...`
- [x] `go test -run 'Regime|Ratchet|Trailing' ./scheduler/...`
- [x] `uv run python -m pytest shared_strategies/close/test_regime_atr.py::test_trailing_use_defaults_composite_clean`

LLM: Composer | medium | Harness: commit-and-create-pull-request