### PR TITLE
audit(backtest): synthesis parity tool — #946 base + #935 grafts (#906)

### DIFF
--- a/backtest/AUDIT.md
+++ b/backtest/AUDIT.md
@@ -1,0 +1,138 @@
+# Backtest Subsystem Audit — 2026-06 (#906)
+
+Structured audit of correctness, parity, coverage, reporting, and debt across
+the backtesting subsystem (engine at the time of audit: 4,659 LOC across the
+8 core modules, 20 test files / ~1,180 passing tests). Findings were filed as
+cards #942–#945; this doc captures the verified state so future contributors
+don't re-derive it. Line numbers reference the audit-time tree — anchor on
+symbol names if they drift.
+
+## D1 — Look-ahead contract: INTACT
+
+The contract (`backtester.py` module docstring) holds for every decision
+input. Verified end to end:
+
+- `signal`, `_open_action`, `_close_fraction`, `regime` are all `shift(1)`'d
+  in the normalization blocks (`backtester.py:738, 748, 749, 780`) before the
+  per-bar loop reads them; fills use the current bar's `open` (contractual).
+- Close evaluators run end-of-bar against bar N's close mark and bar N's ATR
+  (`_evaluate_close_strategies`, dispatched at `backtester.py:1139`); their
+  output becomes `pending_close_fraction`, applied at bar N+1's open.
+- `_regime_bar_close` is snapshotted **before** the regime shift
+  (`backtester.py:762`) and is only fed to close evaluators as
+  `market_regime` — bar-N data for an end-of-bar decision, matching live.
+- Same-bar SL re-fire after a post-TP bump (the #715 class) is gated by
+  `sl_after_just_applied` (`backtester.py:1175`).
+- SL/TP intra-bar races resolve at bar close (no OHLC walking), documented in
+  the contract and deterministic: TP evaluators → SL bump → suppressed hit
+  check → next-bar fill.
+- Strategy sweep: no `shift(-n)`, `center=True` rolling, or forward `iloc`
+  in `shared_strategies/open/registry.py` or `shared_strategies/close/*.py`.
+  (Full-frame normalization — e.g. a signal keyed on the whole series' mean —
+  is *not* statically detectable; that class is what `parity_diff.py` exists
+  to catch.)
+- Composite (#861/#862) and shared-regime-bundle (#879) work did not bypass
+  the shift: only the `regime` column is a decision input; `adx`/`regime_score`
+  /±DI columns are display-only.
+
+Regression guards: `test_backtester_lookahead.py`, `test_post_tp_sl.py`
+(same-bar fire), `test_backtester_regime.py` (gate timing + live↔backtest
+label parity).
+
+## D2 — Parity with the live scheduler
+
+| Surface | State |
+|---|---|
+| Fees | ✅ `PLATFORM_FEE_PCT` matches `fees.go`; `test_platform_fees.py` scrapes the Go source so drift fails CI. deribit/ibkr/topstep flow through option/futures fee functions, not the spot table. |
+| Initial/trailing ATR SL (#885) | ✅ Same trigger formula (`entry ± mult×EntryATR`) and same-bar arming on both sides. |
+| Default tier ladders (#870/#887) | ✅ Values synced across Go and all three Python mirrors — but unpinned by tests (#944). |
+| Single close ref (#842) | ✅ `--config` rejects legacy `len>1` arrays with the same semantics live rejects them; the engine's max-wins multi-ref path remains for direct-constructor/test use only. |
+| `tiered_tp_atr_live_regime_dynamic` (#843) | ✅ Loudly rejected at config load (`run_backtest.py:193-196`); no evaluator registered under the name. |
+| `regime_directional_policy` (#822) | ✅ Loudly rejected (`run_backtest.py:160-166`). |
+| Regime-aware `sl_after` (#736) | ✅ Loudly rejected at `Backtester` init; scalar forms backtestable. |
+| `user_close_defaults` (#866) | ✅ `--defaults system\|user` mirrors the live three-layer resolution. |
+| Scale-in (#873), manual limit orders (#883) | Live-only **by design** (HL perps/manual execution mechanics, no signal-path component). Config keys are ignored by the backtest loader; acceptable while the features stay execution-side. |
+| **v13/v14 legacy close keys** | ❌ **#942** — the `--config` gate admits pre-v15 configs whose `tiers`/alias keys silently no-op in the Python evaluators while live canonicalizes them. |
+| **`direction` / `invert_signal` / `regime_window_divergence`** | ❌ **#943** — silently ignored by `--config`; the `regime_directional_policy` rejection message even recommends two of them. |
+
+## D3/D8 — Coverage
+
+- Every registered close strategy has at least one engine-level test except
+  the rejected dynamic variant (correct). `trailing_tp_ratchet_regime` and
+  `tiered_tp_atr_live_regime` are covered.
+- ADX 3-label vocabulary covered; **composite 7-label vocabulary has zero
+  backtest tests** (#944).
+- Sharpe annualization tested at 4 timeframes (1d/4h/1h/1w) — meets the ≥3 bar.
+- Variant depth: main engine ~strong (incl. shorts), pairs and options
+  moderate, **theta thin** (one force-close test, #944).
+- `DEFAULT_PARAM_RANGES` completeness is enforced by
+  `test_registry_loader.py::test_param_ranges_cover_every_registered_strategy`.
+- No property-based (`hypothesis`) tests anywhere; grid search is fully
+  deterministic so seed plumbing is moot.
+- Regression tests exist for every prior backtest bug: #302 (fills + vol
+  math), #303 (regime/BS parity), #304 M3/M5/L5 (annualization, calendar
+  days, theta force-close log), #715 (same-bar SL), #730 (look-ahead),
+  #824 (storage lazy-init).
+
+## D4/D5 — Reporting & optimizer
+
+- `periods_per_year()` drives Sharpe/volatility in the main engine; options
+  uses check-interval-aware sampling; pairs uses `bars_per_year`. Theta
+  hardcodes daily — valid only because theta data is always `1d` (#945).
+- Options annualized return uses elapsed calendar days (the #304 M5 fix is in
+  and commented).
+- Walk-forward separates train/test per fold and aggregates OOS-only stats
+  (`oos_mean_*`, `oos_std_return`). The boundary-bar inclusion at fold start
+  is **intentional** (its raw signal becomes row 1's shifted signal — matches
+  live) and is regression-tested in `test_walk_forward_warmup.py`; don't
+  "fix" it.
+- Optimizer is a deterministic grid; `optimize_metric` accepts any result-dict
+  key. No fold-to-fold robustness gate (param stability is reported via
+  `most_common_best_params`, not enforced).
+- Known gaps, not bugs: drawdown has no recovery-duration metric; the main
+  engine doesn't emit a separate `total_fees`; timestamps serialize as
+  `str(pd.Timestamp)` (space separator), not strict ISO-8601.
+
+## D6 — Debt
+
+- `close_registry_loader` shim is still required (open and close registries
+  both resolve as module name `registry`).
+- `backtest_options.py` exchange is configurable (`--exchange`, #304 L2 fixed).
+- HTF filter plumbs through the same `shared_tools/htf_filter.py` as live,
+  fed by cached candles; missing HTF cache fails open to neutral trend.
+- Residual items in **#945**: unused imports, dead close-name optimizer range
+  entries, theta daily-only comment.
+- Metrics/reporting logic is re-implemented per variant (~150–200 LOC
+  duplication across options/theta/pairs); extraction is optional until one
+  of them next drifts.
+
+## D7 — Observability
+
+- `parity_diff.py` (added by this audit, D7.4) replays the vectorized
+  backtest path and the trailing-window live path over the same candles and
+  emits a per-bar diff of signal / open_action / close_fraction / regime —
+  the tool to reach for first on any backtest-vs-paper mismatch. The live
+  side calls the actual check-script helpers (`prepare_check_regime` →
+  `evaluate_open_close`/`finalize_decision` with
+  `close_registry_loader.evaluate`), not a model of them; registry close
+  evaluators are compared through the same evaluator on both sides with a
+  shared simulated position context, so a diff isolates window-derived
+  inputs (trailing-window ATR/regime vs full-frame). `--config
+  <live-config> --strategy-id <id>` replays the exact live refs via the
+  #641 loader; `--fills` lines the decision diff up against the engine's
+  simulated entry/exit fills; `--csv`/`--jsonl` dump the full frame, which
+  also carries the post-`shift(1)` `backtest_effective_*` engine inputs per
+  bar. See the module docstring for usage.
+- Still absent (scope when needed): per-bar verbose trace inside
+  `Backtester.run`, equity-curve/trade-log CSV export, `exit_reason` and
+  entry/exit regime fields on `Trade`.
+
+## Known live-only surfaces (decision record)
+
+`scale_in` (#873), manual resting limit orders (#883), per-cycle regime
+hysteresis (`tiered_tp_atr_live_regime_dynamic`, #843),
+`regime_directional_policy` (#822), regime-aware `sl_after` (#736), and
+`regime_window_divergence` (#907) are execution/per-cycle mechanics with no
+bar-level equivalent; the first two are silently ignored by design (no signal
+path), the middle three are loudly rejected, and the last should be promoted
+to a loud rejection (#943).

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -42,6 +42,22 @@ SL/TP intra-bar races
 Bar-level granularity — when an SL hit and a TP fill could both occur within
 the same bar, the engine resolves them at bar close, not by intra-bar OHLC
 walking. Documented under ``Backtest`` in CLAUDE.md.
+
+Live parity limitations (#906 audit)
+------------------------------------
+Surfaces intentionally **not** modeled here (use ``backtest/parity_diff.py`` for
+decision-layer parity checks; see ``backtest/AUDIT.md`` for the full matrix):
+
+  • **Scale-in / pyramiding** (#873) — HL perps + manual live-only; same-direction
+    adds are skipped in backtest.
+  • **Resting manual limit orders** (#883) — maker fills / partial OID reconcile
+    have no bar-level simulation.
+  • **``tiered_tp_atr_live_regime_dynamic``** (#843) — rejected at
+    ``run_backtest.load_strategy_config`` (on-chain regime hysteresis).
+  • **``regime_directional_policy``** (#822) — rejected at config load; use static
+    ``direction`` / ``invert_signal`` for backtests.
+  • **Inline trailing SL at open** (#885) — live arms same-cycle; backtest seeds
+    trailing/ratchet triggers on the bar after open (no naked-gap modeling).
 """
 
 import sys

--- a/backtest/parity_diff.py
+++ b/backtest/parity_diff.py
@@ -51,10 +51,15 @@ omission: it needs a second-timeframe fetch and is orthogonal to
 frame-dependence.)
 
 When close refs are configured, both sides share a single simulated
-position context (side / avg_cost / quantities / entry_atr / entry
-regime), seeded from the backtest-effective open/close decisions. The
-context is deliberately identical on both sides so it can never be the
-source of a diff — only the evaluator's window-derived inputs can.
+position lifecycle (side / avg_cost / quantities / entry values),
+seeded from the backtest-effective open/close decisions — shared so the
+position itself can never be the source of a diff. The dict shape each
+evaluator sees mirrors its real caller: the backtest side always passes
+``regime`` (possibly empty) and ``entry_atr``, exactly like
+``Backtester._evaluate_close_strategies`` (#747); the live side omits
+empty keys, exactly like the check scripts. The asymmetry is deliberate
+— a diff at empty-regime bars surfaces that genuine engine-vs-live
+shape divergence instead of masking it.
 
 Every row also carries ``backtest_effective_*`` columns — the post-
 ``shift(1)`` values the engine actually reads at bar N — informational
@@ -78,7 +83,10 @@ candles and reports the simulated entry/exit fills (price + modeled fee)
 so a decision-level diff can be lined up against the trades it produced.
 
 Exit code 0 when the paths agree on every compared bar, 1 when any bar
-differs (CI-friendly), 2 on usage/data errors.
+differs (CI-friendly), 2 on usage/data errors. A run that compares zero
+bars (data shorter than the trailing window, or --since/--stride
+leaving nothing to compare) is a data error — a vacuous comparison is
+not agreement.
 
 The per-bar loop re-runs the strategy O(N) times on trailing windows —
 this is a debugging tool, not a benchmark; bound the range with --since
@@ -107,7 +115,6 @@ from strategy_composition import (
     compose_signal,
     evaluate_open_close,
     finalize_decision,
-    normalize_signal,
     open_action_from_signal,
     rewrite_deprecated_close_ref,
 )
@@ -293,7 +300,10 @@ def _live_bar_decision(window: pd.DataFrame, cfg: ParityConfig, reg,
 
     result_df = reg.apply_strategy(cfg.strategy_name, window, params)
     last = result_df.iloc[-1]
-    decision["signal"] = normalize_signal(last.get("signal", 0))
+    # Same float-aware normalizer as the backtest side — both paths must
+    # collapse a raw signal to {-1, 0, 1} by identical rules so a signal
+    # diff reflects input drift, never the normalizer.
+    decision["signal"] = _normalize_signal(last.get("signal", 0))
     decision["open_action"] = open_action_from_signal(decision["signal"])
     if _has_close_fraction_columns(result_df):
         decision["close_fraction"] = float(
@@ -311,19 +321,34 @@ def _bt_close_evaluator_fraction(cfg: ParityConfig, i: int,
 
     Mirrors ``Backtester``'s close-evaluator inputs: bar-N close as the
     mark, full-frame closed-bar ATR at bar N, full-frame regime label at
-    bar N. Same ``close_registry_loader.evaluate``, same position context
-    as the live side — only the window-derived inputs differ.
+    bar N. Same ``close_registry_loader.evaluate``, same position
+    lifecycle as the live side — but the dict SHAPE mirrors the engine
+    (#747): ``regime`` always present (possibly empty) in both dicts,
+    ``entry_atr`` always a float. The live side omits empty keys like
+    the check scripts do; the asymmetry deliberately lets the tool
+    surface a genuine engine-vs-live shape divergence at empty-regime
+    bars instead of masking it.
     """
     if not position_ctx:
         return 0.0
-    market = {"mark_price": float(df["close"].iloc[i])}
+    position = {
+        "side": str(position_ctx.get("side", "")),
+        "avg_cost": float(position_ctx.get("avg_cost", 0.0) or 0.0),
+        "current_quantity": float(
+            position_ctx.get("current_quantity", 0.0) or 0.0),
+        "initial_quantity": float(
+            position_ctx.get("initial_quantity", 0.0) or 0.0),
+        "entry_atr": float(position_ctx.get("entry_atr", 0.0) or 0.0),
+        "regime": str(position_ctx.get("regime", "") or ""),
+    }
+    label = ""
+    if regime_full is not None:
+        raw_label = regime_full.iloc[i]
+        label = "" if pd.isna(raw_label) else str(raw_label)
+    market = {"mark_price": float(df["close"].iloc[i]), "regime": label}
     atr_val = float(atr_full.iloc[i]) if pd.notna(atr_full.iloc[i]) else 0.0
     if atr_val > 0:
         market["atr"] = atr_val
-    if regime_full is not None:
-        label = str(regime_full.iloc[i] or "")
-        if label:
-            market["regime"] = label
     params_by_name = _close_params_by_name(cfg.close_refs)
     best = 0.0
     for name in _close_names(cfg.close_refs):
@@ -332,7 +357,7 @@ def _bt_close_evaluator_fraction(cfg: ParityConfig, i: int,
         if ref_params is None and resolved == cfg.strategy_name:
             ref_params = dict(cfg.params or {})
         try:
-            result = close_evaluate(resolved, position_ctx, market, ref_params)
+            result = close_evaluate(resolved, position, market, ref_params)
         except ValueError:
             # Non-registry (signal-strategy) close refs are covered by the
             # column path on both sides; skip the evaluator comparison.
@@ -617,8 +642,10 @@ def main(argv: Optional[list] = None) -> int:
                         help="JSON dict of strategy param overrides")
     parser.add_argument("--registry", choices=["spot", "futures"],
                         default="spot")
-    parser.add_argument("--platform", default="binanceus",
-                        help="Fee platform for --fills (default binanceus)")
+    parser.add_argument("--platform", default=None,
+                        help="Fee platform for --fills (ad-hoc default "
+                             "binanceus; --config mode auto-detects from the "
+                             "strategy type unless explicitly set)")
     parser.add_argument("--close", action="append", default=[],
                         help="Close ref: name or name:{json params} "
                              "(repeatable; single ref since #842)")
@@ -655,8 +682,11 @@ def main(argv: Optional[list] = None) -> int:
             print("--strategy-id is required with --config", file=sys.stderr)
             return 2
         try:
+            # An unset --platform must never force binanceus here — the
+            # empty string lets the loader auto-detect from the strategy
+            # type (perps/manual → hyperliquid); an explicit flag wins.
             cfg = config_from_live_config(args.config, args.strategy_id,
-                                          platform=args.platform)
+                                          platform=args.platform or "")
         except (ValueError, OSError, json.JSONDecodeError) as e:
             print(f"--config: {e}", file=sys.stderr)
             return 2
@@ -686,7 +716,7 @@ def main(argv: Optional[list] = None) -> int:
             strategy_name=args.strategy,
             params=dict(params or {}),
             registry=args.registry,
-            platform=args.platform,
+            platform=args.platform or "binanceus",
             symbol=args.symbol,
             timeframe=args.timeframe,
             close_refs=close_refs,
@@ -707,6 +737,12 @@ def main(argv: Optional[list] = None) -> int:
     frame = compute_parity_frame(df, cfg=cfg, window=window,
                                  stride=args.stride)
     result = summarize(frame)
+    if result["bars_compared"] == 0:
+        print(f"No bars compared: {len(df)} candles loaded but the trailing "
+              f"window needs {window or LIVE_MIN_CANDLES} (after --since/"
+              f"--stride). A zero-bar comparison is a data error, not a pass.",
+              file=sys.stderr)
+        return 2
     fills = extract_fills(df, cfg) if args.fills else []
 
     if args.csv:

--- a/backtest/parity_diff.py
+++ b/backtest/parity_diff.py
@@ -60,7 +60,11 @@ would manufacture mismatches, so the tool fails loudly instead.
 When close refs are configured, both sides share a single simulated
 position lifecycle (side / avg_cost / quantities / entry values),
 seeded from the backtest-effective open/close decisions — shared so the
-position itself can never be the source of a diff. The dict shape each
+position itself can never be the source of a diff. The bt-side registry
+evaluator's fraction folds back into the next bar's quantity (the
+engine's ``pending_close_fraction``), so cumulative tier ladders advance
+exactly as the engine books them and each compared fraction is the
+per-bar increment, not a repeated cumulative value. The dict shape each
 evaluator sees mirrors its real caller: the backtest side always passes
 ``regime`` (possibly empty) and ``entry_atr``, exactly like
 ``Backtester._evaluate_close_strategies`` (#747); the live side omits
@@ -394,17 +398,33 @@ def _bt_close_evaluator_fraction(cfg: ParityConfig, i: int,
 
 def _simulate_position_contexts(bt: pd.DataFrame, df: pd.DataFrame,
                                 atr_full: pd.Series,
-                                regime_full: Optional[pd.Series]) -> list:
+                                regime_full: Optional[pd.Series],
+                                cfg: Optional[ParityConfig] = None) -> tuple:
     """Walk the backtest-effective decisions and track a scaffold position.
 
     The context exists so close evaluators see a plausible position on
     BOTH sides — it is shared, so it can never be the source of a diff.
     Entries/exits follow the engine's shift(1) semantics: bar N acts on
-    bar N-1's signal/open_action/close_fraction. The scaffold tracks the
-    column/signal surface only (registry-evaluator closes are the output
-    under test, not an input to the scaffold).
+    bar N-1's signal/open_action/close_fraction. ``contexts[i]`` is the
+    position AFTER bar i's open fills — the state the engine holds during
+    its end-of-bar close evaluation, and the position live's bar-i cycle
+    sees.
+
+    Registry close-evaluator output is folded back into the quantity the
+    NEXT bar — the engine's ``pending_close_fraction`` — so the cumulative
+    tier ladder advances exactly as the engine books it: 0.4 once, then 0,
+    then the increment to 0.8 at the next rung. Without the fold,
+    ``current_quantity`` would stay pinned at ``initial_quantity`` and
+    every post-tier-1 bar would repeat the cumulative fraction — a value
+    neither the engine nor live produces.
+
+    Returns ``(contexts, registry_fractions)``; ``registry_fractions[i]``
+    is the bt-side evaluator fraction at bar i computed with that shared
+    context — the same value ``compute_parity_frame`` compares, so the
+    scaffold's accounting and the comparison can never disagree.
     """
     contexts = []
+    registry_fractions = []
     side = ""
     avg_cost = 0.0
     qty = 0.0
@@ -413,6 +433,60 @@ def _simulate_position_contexts(bt: pd.DataFrame, df: pd.DataFrame,
     entry_regime = ""
 
     for i in range(len(df)):
+        if i > 0:
+            # Backtest-effective inputs at bar i = unshifted bar i-1 values;
+            # the registry-evaluator fraction from bar i-1 fills here too,
+            # exactly like the engine's pending_close_fraction (max-wins
+            # against the column path, same resolution as the comparison).
+            eff_signal = int(bt["signal"].iloc[i - 1])
+            eff_action = str(bt["open_action"].iloc[i - 1])
+            eff_close = max(float(bt["close_fraction"].iloc[i - 1]),
+                            registry_fractions[i - 1])
+            mark = float(df["close"].iloc[i])
+
+            if side and (eff_close > 0
+                         or (side == "long" and eff_signal < 0)
+                         or (side == "short" and eff_signal > 0)):
+                frac = eff_close if eff_close > 0 else 1.0
+                # Engine booking: qty_to_close = abs(position) * fraction —
+                # the fraction applies to the CURRENT position, not the
+                # initial size (Backtester.run's close-fraction fill).
+                qty = max(qty - qty * min(frac, 1.0), 0.0)
+                if qty <= 1e-12:
+                    side = ""
+                    avg_cost = qty = initial_qty = entry_atr = 0.0
+                    entry_regime = ""
+            elif not side and eff_action in ("long", "short"):
+                side = eff_action
+                # Engine fill semantics: an open fills at the fill bar's
+                # OPEN (fallback close), adjusted by the engine's default
+                # slippage — ``effective_price`` in Backtester.run, not the
+                # bar's close.
+                fill_price = (float(df["open"].iloc[i])
+                              if "open" in df.columns else mark)
+                if side == "long":
+                    avg_cost = fill_price * (1 + _ENGINE_SLIPPAGE_PCT)
+                else:
+                    avg_cost = fill_price * (1 - _ENGINE_SLIPPAGE_PCT)
+                qty = initial_qty = 1.0
+                atr_val = atr_full.iloc[i]
+                entry_atr = float(atr_val) if pd.notna(atr_val) else 0.0
+                # Engine plausibility guard (_stamp_entry_atr, mirroring
+                # Go's stampEntryATRIfOpened): non-positive or > 50% of the
+                # entry price (effective_price, same as the engine) stamps
+                # 0.0, so ATR-requiring close evaluators no-op.
+                if not (0.0 < entry_atr <= 0.5 * avg_cost):
+                    entry_atr = 0.0
+                if regime_full is not None:
+                    # Engine semantics: the position regime is stamped from
+                    # the SHIFTED regime column at the fill row — the
+                    # decision bar's (i-1) label, which is also what live
+                    # stamps at open (the label computed alongside the
+                    # signal). The fill bar's own label (i) would match
+                    # neither side.
+                    raw_label = regime_full.iloc[i - 1]
+                    entry_regime = "" if pd.isna(raw_label) else str(raw_label)
+
         ctx = None
         if side:
             ctx = {
@@ -426,53 +500,12 @@ def _simulate_position_contexts(bt: pd.DataFrame, df: pd.DataFrame,
             if entry_regime:
                 ctx["regime"] = entry_regime
         contexts.append(ctx)
-
-        if i == 0:
-            continue
-        # Backtest-effective inputs at bar i = unshifted bar i-1 values.
-        eff_signal = int(bt["signal"].iloc[i - 1])
-        eff_action = str(bt["open_action"].iloc[i - 1])
-        eff_close = float(bt["close_fraction"].iloc[i - 1])
-        mark = float(df["close"].iloc[i])
-
-        if side and (eff_close > 0
-                     or (side == "long" and eff_signal < 0)
-                     or (side == "short" and eff_signal > 0)):
-            frac = eff_close if eff_close > 0 else 1.0
-            qty = max(qty - initial_qty * frac, 0.0)
-            if qty <= 1e-12:
-                side = ""
-                avg_cost = qty = initial_qty = entry_atr = 0.0
-                entry_regime = ""
-        elif not side and eff_action in ("long", "short"):
-            side = eff_action
-            # Engine fill semantics: an open fills at the fill bar's OPEN
-            # (fallback close), adjusted by the engine's default slippage —
-            # ``effective_price`` in Backtester.run, not the bar's close.
-            fill_price = (float(df["open"].iloc[i])
-                          if "open" in df.columns else mark)
-            if side == "long":
-                avg_cost = fill_price * (1 + _ENGINE_SLIPPAGE_PCT)
-            else:
-                avg_cost = fill_price * (1 - _ENGINE_SLIPPAGE_PCT)
-            qty = initial_qty = 1.0
-            atr_val = atr_full.iloc[i]
-            entry_atr = float(atr_val) if pd.notna(atr_val) else 0.0
-            # Engine plausibility guard (_stamp_entry_atr, mirroring Go's
-            # stampEntryATRIfOpened): non-positive or > 50% of the entry
-            # price (effective_price, same as the engine) stamps 0.0, so
-            # ATR-requiring close evaluators no-op.
-            if not (0.0 < entry_atr <= 0.5 * avg_cost):
-                entry_atr = 0.0
-            if regime_full is not None:
-                # Engine semantics: the position regime is stamped from the
-                # SHIFTED regime column at the fill row — the decision bar's
-                # (i-1) label, which is also what live stamps at open (the
-                # label computed alongside the signal). The fill bar's own
-                # label (i) would match neither side.
-                raw_label = regime_full.iloc[i - 1]
-                entry_regime = "" if pd.isna(raw_label) else str(raw_label)
-    return contexts
+        registry_fractions.append(
+            _bt_close_evaluator_fraction(cfg, i, df, atr_full,
+                                         regime_full, ctx)
+            if (cfg is not None and ctx is not None) else 0.0
+        )
+    return contexts, registry_fractions
 
 
 def compute_parity_frame(
@@ -545,10 +578,11 @@ def compute_parity_frame(
                     f"no engine path to diff; the live signal-strategy close "
                     f"fallback is live-only. Available: {sorted(available)}"
                 )
-    contexts = (
-        _simulate_position_contexts(bt, df, atr_full, regime_full)
-        if has_close_refs else [None] * len(df)
-    )
+    if has_close_refs:
+        contexts, registry_fracs = _simulate_position_contexts(
+            bt, df, atr_full, regime_full, cfg)
+    else:
+        contexts, registry_fracs = [None] * len(df), [0.0] * len(df)
 
     start = (window - 1) if window is not None else (LIVE_MIN_CANDLES - 1)
     rows = []
@@ -563,8 +597,10 @@ def compute_parity_frame(
         bt_close = float(bt["close_fraction"].iloc[i])
         bt_signal = int(bt["signal"].iloc[i])
         if has_close_refs:
-            bt_close = max(bt_close, _bt_close_evaluator_fraction(
-                cfg, i, df, atr_full, regime_full, ctx))
+            # The scaffold already evaluated the bt-side registry close at
+            # bar i with this exact context — reuse it so the fraction
+            # compared here is the same one the ladder accounting applied.
+            bt_close = max(bt_close, registry_fracs[i])
             # The live decision composes open intent + close intent +
             # position side into one signal (finalize_decision). Compose
             # the backtest inputs identically so the signal column compares

--- a/backtest/parity_diff.py
+++ b/backtest/parity_diff.py
@@ -101,6 +101,7 @@ or thin the comparison with --stride for long histories.
 """
 
 import argparse
+import inspect
 import json
 import os
 import sys
@@ -139,6 +140,11 @@ from backtester import (
 
 # Mirror live: check_strategy.py refuses to evaluate fewer than 30 candles.
 LIVE_MIN_CANDLES = 30
+# Engine default slippage, read from the Backtester signature so the
+# scaffold's effective_price math can never drift out of sync with it.
+_ENGINE_SLIPPAGE_PCT = float(
+    inspect.signature(Backtester.__init__).parameters["slippage_pct"].default
+)
 # Mirror live: check scripts fetch --ohlcv-limit candles (default 200).
 DEFAULT_WINDOW = 200
 
@@ -440,14 +446,23 @@ def _simulate_position_contexts(bt: pd.DataFrame, df: pd.DataFrame,
                 entry_regime = ""
         elif not side and eff_action in ("long", "short"):
             side = eff_action
-            avg_cost = mark
+            # Engine fill semantics: an open fills at the fill bar's OPEN
+            # (fallback close), adjusted by the engine's default slippage —
+            # ``effective_price`` in Backtester.run, not the bar's close.
+            fill_price = (float(df["open"].iloc[i])
+                          if "open" in df.columns else mark)
+            if side == "long":
+                avg_cost = fill_price * (1 + _ENGINE_SLIPPAGE_PCT)
+            else:
+                avg_cost = fill_price * (1 - _ENGINE_SLIPPAGE_PCT)
             qty = initial_qty = 1.0
             atr_val = atr_full.iloc[i]
             entry_atr = float(atr_val) if pd.notna(atr_val) else 0.0
             # Engine plausibility guard (_stamp_entry_atr, mirroring Go's
             # stampEntryATRIfOpened): non-positive or > 50% of the entry
-            # price stamps 0.0, so ATR-requiring close evaluators no-op.
-            if not (0.0 < entry_atr <= 0.5 * mark):
+            # price (effective_price, same as the engine) stamps 0.0, so
+            # ATR-requiring close evaluators no-op.
+            if not (0.0 < entry_atr <= 0.5 * avg_cost):
                 entry_atr = 0.0
             if regime_full is not None:
                 # Engine semantics: the position regime is stamped from the

--- a/backtest/parity_diff.py
+++ b/backtest/parity_diff.py
@@ -188,18 +188,30 @@ def config_from_live_config(config_path: str, strategy_id: str,
 
 
 def _normalize_signal(value) -> int:
-    """Collapse a raw strategy signal to the live {-1, 0, 1} domain."""
+    """Collapse a raw signal to {-1, 0, 1}, mirroring the engine's contract.
+
+    NaN → 0 (the engine ``fillna(0)``s); any other value outside
+    {-1, 0, 1} is rejected the way ``Backtester.run`` rejects it. On such
+    a signal the engine raises while the live check script's
+    ``normalize_signal`` coerces (``int(0.5)`` → 0) — a real divergence.
+    Normalizing it identically on both tool paths would report CLEAN for
+    a value neither real path produces, so the tool surfaces the contract
+    violation loudly instead.
+    """
     try:
         f = float(value)
     except (TypeError, ValueError):
         return 0
     if pd.isna(f):
         return 0
-    if f > 0:
-        return 1
-    if f < 0:
-        return -1
-    return 0
+    if f not in (-1.0, 0.0, 1.0):
+        raise ValueError(
+            f"signal must be in {{-1, 0, 1}} — got {value!r}. The engine "
+            f"rejects this signal (Backtester.run) while the live check "
+            f"script would coerce it; fix the strategy rather than relying "
+            f"on either behavior."
+        )
+    return int(f)
 
 
 def _close_names(close_refs: Optional[list]) -> list:
@@ -300,9 +312,9 @@ def _live_bar_decision(window: pd.DataFrame, cfg: ParityConfig, reg,
 
     result_df = reg.apply_strategy(cfg.strategy_name, window, params)
     last = result_df.iloc[-1]
-    # Same float-aware normalizer as the backtest side — both paths must
-    # collapse a raw signal to {-1, 0, 1} by identical rules so a signal
-    # diff reflects input drift, never the normalizer.
+    # Same strict normalizer as the backtest side: in-contract signals
+    # collapse identically, out-of-contract signals raise (see
+    # _normalize_signal) instead of being coerced into a false CLEAN.
     decision["signal"] = _normalize_signal(last.get("signal", 0))
     decision["open_action"] = open_action_from_signal(decision["signal"])
     if _has_close_fraction_columns(result_df):
@@ -425,7 +437,13 @@ def _simulate_position_contexts(bt: pd.DataFrame, df: pd.DataFrame,
             atr_val = atr_full.iloc[i]
             entry_atr = float(atr_val) if pd.notna(atr_val) else 0.0
             if regime_full is not None:
-                entry_regime = str(regime_full.iloc[i] or "")
+                # Engine semantics: the position regime is stamped from the
+                # SHIFTED regime column at the fill row — the decision bar's
+                # (i-1) label, which is also what live stamps at open (the
+                # label computed alongside the signal). The fill bar's own
+                # label (i) would match neither side.
+                raw_label = regime_full.iloc[i - 1]
+                entry_regime = "" if pd.isna(raw_label) else str(raw_label)
     return contexts
 
 

--- a/backtest/parity_diff.py
+++ b/backtest/parity_diff.py
@@ -50,6 +50,13 @@ semantics, not a model of them. (The HTF filter is the one deliberate
 omission: it needs a second-timeframe fetch and is orthogonal to
 frame-dependence.)
 
+Non-registry (signal-strategy) close refs are rejected upfront with the
+engine's own error: ``Backtester`` refuses unknown close names at init,
+so there is no backtest path to diff against. The live composition's
+signal-strategy close fallback (``legacy_close_fraction_from_signal``)
+is a live-only surface; comparing it against a silent bt-side zero
+would manufacture mismatches, so the tool fails loudly instead.
+
 When close refs are configured, both sides share a single simulated
 position lifecycle (side / avg_cost / quantities / entry values),
 seeded from the backtest-effective open/close decisions — shared so the
@@ -118,7 +125,10 @@ from strategy_composition import (
     open_action_from_signal,
     rewrite_deprecated_close_ref,
 )
-from close_registry_loader import evaluate as close_evaluate
+from close_registry_loader import (
+    evaluate as close_evaluate,
+    list_strategies as close_list_strategies,
+)
 from backtester import (
     Backtester,
     _max_close_fraction_series,
@@ -368,12 +378,10 @@ def _bt_close_evaluator_fraction(cfg: ParityConfig, i: int,
             name, params_by_name.get(name))
         if ref_params is None and resolved == cfg.strategy_name:
             ref_params = dict(cfg.params or {})
-        try:
-            result = close_evaluate(resolved, position, market, ref_params)
-        except ValueError:
-            # Non-registry (signal-strategy) close refs are covered by the
-            # column path on both sides; skip the evaluator comparison.
-            continue
+        # Unknown names were rejected upfront (compute_parity_frame), so any
+        # ValueError here is a genuine evaluator error — propagate, exactly
+        # as the engine would.
+        result = close_evaluate(resolved, position, market, ref_params)
         best = max(best, float(result.get("close_fraction", 0.0) or 0.0))
     return best
 
@@ -436,6 +444,11 @@ def _simulate_position_contexts(bt: pd.DataFrame, df: pd.DataFrame,
             qty = initial_qty = 1.0
             atr_val = atr_full.iloc[i]
             entry_atr = float(atr_val) if pd.notna(atr_val) else 0.0
+            # Engine plausibility guard (_stamp_entry_atr, mirroring Go's
+            # stampEntryATRIfOpened): non-positive or > 50% of the entry
+            # price stamps 0.0, so ATR-requiring close evaluators no-op.
+            if not (0.0 < entry_atr <= 0.5 * mark):
+                entry_atr = 0.0
             if regime_full is not None:
                 # Engine semantics: the position regime is stamped from the
                 # SHIFTED regime column at the fill row — the decision bar's
@@ -502,6 +515,21 @@ def compute_parity_frame(
         )["regime"]
 
     has_close_refs = bool(_close_names(cfg.close_refs))
+    if has_close_refs:
+        # Mirror the engine: Backtester rejects non-registry close names at
+        # init, so a signal-strategy close ref has no backtest path to diff
+        # — fail with the same error instead of silently contributing 0 on
+        # the bt side while the live fallback fully evaluates it.
+        available = set(close_list_strategies())
+        for name in _close_names(cfg.close_refs):
+            resolved, _ = rewrite_deprecated_close_ref(name, None)
+            if resolved not in available:
+                raise ValueError(
+                    f"Unknown close strategy: {resolved}. The backtester "
+                    f"rejects non-registry close refs at init, so there is "
+                    f"no engine path to diff; the live signal-strategy close "
+                    f"fallback is live-only. Available: {sorted(available)}"
+                )
     contexts = (
         _simulate_position_contexts(bt, df, atr_full, regime_full)
         if has_close_refs else [None] * len(df)
@@ -752,8 +780,12 @@ def main(argv: Optional[list] = None) -> int:
         return 2
 
     window = args.window if args.window and args.window > 0 else None
-    frame = compute_parity_frame(df, cfg=cfg, window=window,
-                                 stride=args.stride)
+    try:
+        frame = compute_parity_frame(df, cfg=cfg, window=window,
+                                     stride=args.stride)
+    except ValueError as e:
+        print(f"parity: {e}", file=sys.stderr)
+        return 2
     result = summarize(frame)
     if result["bars_compared"] == 0:
         print(f"No bars compared: {len(df)} candles loaded but the trailing "

--- a/backtest/parity_diff.py
+++ b/backtest/parity_diff.py
@@ -1,0 +1,747 @@
+"""Backtest-vs-live parity diff tool (#906 D7.4).
+
+The parity contract between the backtester and the live scheduler is:
+same ``compute_*`` function, same window, same params → same decision.
+The backtester evaluates a strategy ONCE over the full vectorized frame
+and reads decisions row-by-row; the live check scripts re-evaluate the
+strategy every cycle over a trailing fetch window (``--ohlcv-limit``,
+default 200 in ``shared_scripts/check_strategy.py``) and act on the LAST
+closed bar. Any strategy whose bar-N output depends on the frame it was
+computed in — full-series normalization, unseeded rolling state, warmup
+that never converges — silently diverges between the two paths, and no
+existing test catches it because both suites only exercise one path.
+
+This tool replays both paths over the same candles and emits a per-bar
+diff of the decision surface:
+
+  • ``signal``          — vectorized value at bar N  vs  the decision a
+                          check-script run over a window ENDING at bar N
+                          would emit (live semantics — see below).
+  • ``open_action``     — backtester semantics (the ``open_action`` column
+                          when the strategy emits it, else derived from
+                          ``signal``)  vs  live semantics (always derived
+                          from the composed signal, exactly as
+                          ``finalize_decision`` does). A strategy whose
+                          column disagrees with ``sign(signal)`` is a real
+                          parity break and is flagged here.
+  • ``close_fraction``  — max across ``close_fraction*`` columns AND any
+                          configured close-strategy refs, same comparison.
+                          Registry close evaluators (``tiered_tp_atr`` …)
+                          are invoked through the SAME
+                          ``close_registry_loader.evaluate`` on both
+                          sides; the backtest side feeds bar-N close +
+                          full-frame closed-bar ATR + full-frame regime
+                          (engine semantics), the live side feeds
+                          ``latest_atr``/``prepare_check_regime`` on the
+                          trailing window (check-script semantics) — so a
+                          mismatch isolates window-dependent evaluator
+                          inputs.
+  • ``regime``          — full-frame ``compute_regime`` label at bar N vs
+                          the ``prepare_check_regime`` label on the
+                          trailing window (the per-bar generalization of
+                          the last-bar parity test in
+                          ``test_backtester_regime.py``).
+
+The live side is not a re-implementation: it calls the same helpers the
+live check script calls — ``prepare_check_regime`` → ``params["regime"]``
+injection → ``evaluate_open_close`` / ``finalize_decision`` with
+``close_registry_loader.evaluate`` — so the replay IS check-script
+semantics, not a model of them. (The HTF filter is the one deliberate
+omission: it needs a second-timeframe fetch and is orthogonal to
+frame-dependence.)
+
+When close refs are configured, both sides share a single simulated
+position context (side / avg_cost / quantities / entry_atr / entry
+regime), seeded from the backtest-effective open/close decisions. The
+context is deliberately identical on both sides so it can never be the
+source of a diff — only the evaluator's window-derived inputs can.
+
+Every row also carries ``backtest_effective_*`` columns — the post-
+``shift(1)`` values the engine actually reads at bar N — informational
+only, never part of the match.
+
+Usage (ad-hoc):
+  uv run --no-sync python backtest/parity_diff.py \
+      --strategy supertrend --symbol BTC/USDT --timeframe 1h \
+      [--since 2024-01-01] [--params '{"period": 10}'] \
+      [--registry spot|futures] [--window 200] [--stride 1] \
+      [--close tiered_tp_atr] [--close 'name:{"param": 1}'] \
+      [--regime] [--fills] [--csv /tmp/diff.csv] [--jsonl /tmp/diff.jsonl]
+
+Usage (exact live config, #641 loader):
+  uv run --no-sync python backtest/parity_diff.py \
+      --config scheduler/config.json --strategy-id hl-supertrend-btc \
+      [--since 2024-01-01] [--fills]
+
+``--fills`` additionally runs the full ``Backtester`` over the same
+candles and reports the simulated entry/exit fills (price + modeled fee)
+so a decision-level diff can be lined up against the trades it produced.
+
+Exit code 0 when the paths agree on every compared bar, 1 when any bar
+differs (CI-friendly), 2 on usage/data errors.
+
+The per-bar loop re-runs the strategy O(N) times on trailing windows —
+this is a debugging tool, not a benchmark; bound the range with --since
+or thin the comparison with --stride for long histories.
+"""
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pandas as pd
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Repo root: post_tp_sl.py (loaded lazily by Backtester) imports via the
+# `shared_strategies.` package path, which is only resolvable from the root.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from atr import ensure_atr_indicator, latest_atr
+from regime import prepare_check_regime
+from registry_loader import load_registry
+from strategy_composition import (
+    compose_signal,
+    evaluate_open_close,
+    finalize_decision,
+    normalize_signal,
+    open_action_from_signal,
+    rewrite_deprecated_close_ref,
+)
+from close_registry_loader import evaluate as close_evaluate
+from backtester import (
+    Backtester,
+    _max_close_fraction_series,
+    _normalize_open_action,
+    _open_action_from_signal,
+    fee_pct_for_platform,
+)
+
+# Mirror live: check_strategy.py refuses to evaluate fewer than 30 candles.
+LIVE_MIN_CANDLES = 30
+# Mirror live: check scripts fetch --ohlcv-limit candles (default 200).
+DEFAULT_WINDOW = 200
+
+
+@dataclass
+class ParityConfig:
+    """Everything both replay paths need to evaluate one strategy."""
+    strategy_name: str
+    params: dict = field(default_factory=dict)
+    registry: str = "spot"
+    platform: str = "binanceus"
+    symbol: str = "BTC/USDT"
+    timeframe: str = "1h"
+    # Close refs as ``[{"name": ..., "params": {...}}]`` — single-element in
+    # practice since #842; the list shape matches the Backtester kwarg.
+    close_refs: Optional[list] = None
+    regime_enabled: bool = False
+    regime_period: int = 14
+    regime_adx_threshold: float = 20.0
+
+
+def config_from_live_config(config_path: str, strategy_id: str,
+                            platform: str = "") -> ParityConfig:
+    """Build a ParityConfig from a live go-trader config (#641 loader).
+
+    Reuses ``run_backtest.load_strategy_config`` for the open/close refs
+    (so the same v13+ gate, #842 single-close collapse, and HL-live-only
+    rejections apply), then reads the raw strategy entry for the symbol /
+    timeframe / registry / regime settings the loader doesn't return.
+    """
+    from run_backtest import load_strategy_config
+    loaded = load_strategy_config(config_path, strategy_id)
+    with open(config_path) as fh:
+        raw = json.load(fh)
+    entry = next(
+        (sc for sc in raw.get("strategies", []) or []
+         if sc.get("id") == strategy_id),
+        {},
+    )
+    args = entry.get("args") or []
+    regime = entry.get("regime") or {}
+    open_ref = loaded["open_strategy"]
+    stype = str(entry.get("type", "spot"))
+    return ParityConfig(
+        strategy_name=open_ref["name"],
+        params=dict(open_ref.get("params") or {}),
+        registry="futures" if stype in ("perps", "futures", "manual") else "spot",
+        platform=platform or ("hyperliquid" if stype in ("perps", "manual")
+                              else "binanceus"),
+        symbol=str(args[1]) if len(args) > 1 else "BTC/USDT",
+        timeframe=str(args[2]) if len(args) > 2 else "1h",
+        close_refs=loaded.get("close_strategies") or None,
+        regime_enabled=bool(regime.get("enabled")),
+        regime_period=int(regime.get("period", 14) or 14),
+        regime_adx_threshold=float(regime.get("adx_threshold", 20.0) or 20.0),
+    )
+
+
+def _normalize_signal(value) -> int:
+    """Collapse a raw strategy signal to the live {-1, 0, 1} domain."""
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return 0
+    if pd.isna(f):
+        return 0
+    if f > 0:
+        return 1
+    if f < 0:
+        return -1
+    return 0
+
+
+def _close_names(close_refs: Optional[list]) -> list:
+    return [str(r.get("name", "")).strip() for r in (close_refs or [])
+            if r.get("name")]
+
+
+def _close_params_by_name(close_refs: Optional[list]) -> dict:
+    return {str(r["name"]).strip(): dict(r.get("params") or {})
+            for r in (close_refs or []) if r.get("name")}
+
+
+def _has_close_fraction_columns(result_df: pd.DataFrame) -> bool:
+    return any(c == "close_fraction" or str(c).startswith("close_fraction:")
+               for c in result_df.columns)
+
+
+def _full_frame_decisions(result_df: pd.DataFrame) -> pd.DataFrame:
+    """Extract the backtest-path decision surface for every bar.
+
+    ``open_action`` mirrors the engine's normalization: prefer the column
+    when the strategy emits it, else derive from the signal — the same
+    branch ``Backtester.run`` takes before shifting.
+    """
+    out = pd.DataFrame(index=result_df.index)
+    out["signal"] = result_df.get(
+        "signal", pd.Series(0, index=result_df.index)
+    ).map(_normalize_signal)
+    if "open_action" in result_df.columns:
+        out["open_action"] = result_df["open_action"].map(_normalize_open_action)
+    else:
+        out["open_action"] = out["signal"].map(_open_action_from_signal)
+    if _has_close_fraction_columns(result_df):
+        out["close_fraction"] = _max_close_fraction_series(result_df)
+    else:
+        out["close_fraction"] = 0.0
+    return out
+
+
+def _live_bar_decision(window: pd.DataFrame, cfg: ParityConfig, reg,
+                       position_side: str = "",
+                       position_ctx: Optional[dict] = None) -> dict:
+    """Run the check-script decision path on a window ending at the bar.
+
+    This is ``shared_scripts/check_strategy.py``'s flow with the fetch and
+    JSON plumbing removed: ``prepare_check_regime`` → ``params["regime"]``
+    injection → either ``evaluate_open_close``+``finalize_decision`` (when
+    close refs are configured) or a plain last-bar signal read.
+    """
+    _stdout_regime, live_regime, strategy_regime = prepare_check_regime(
+        window,
+        regime_enabled=cfg.regime_enabled,
+        period=cfg.regime_period,
+        adx_threshold=cfg.regime_adx_threshold,
+    )
+    params = dict(cfg.params or {})
+    # check_strategy.py injects the regime snapshot unconditionally;
+    # apply_strategy strips it for strategies that don't declare it (#720).
+    params["regime"] = strategy_regime
+
+    close_names = _close_names(cfg.close_refs)
+    decision = {"regime": str(live_regime or "")}
+    if close_names:
+        market_ctx = {"mark_price": float(window["close"].iloc[-1])}
+        atr_now = latest_atr(window)
+        if atr_now > 0:
+            market_ctx["atr"] = atr_now
+        if live_regime:
+            market_ctx["regime"] = live_regime
+        evaluation = evaluate_open_close(
+            reg.apply_strategy,
+            reg.get_strategy,
+            window,
+            cfg.strategy_name,
+            None,
+            close_names,
+            position_side,
+            params,
+            position_ctx or {},
+            close_evaluate=close_evaluate,
+            market_ctx=market_ctx,
+            close_params_by_name=_close_params_by_name(cfg.close_refs),
+        )
+        final = finalize_decision(evaluation, position_side,
+                                  evaluation.open_signal)
+        decision["signal"] = int(final["signal"])
+        decision["open_action"] = str(final["open_action"])
+        decision["close_fraction"] = float(final["close_fraction"])
+        # Column-emitting closes on the open result still count, exactly as
+        # the engine reads them — max-wins against the evaluator output.
+        if _has_close_fraction_columns(evaluation.open_result_df):
+            decision["close_fraction"] = max(
+                decision["close_fraction"],
+                float(_max_close_fraction_series(
+                    evaluation.open_result_df).iloc[-1]),
+            )
+        return decision
+
+    result_df = reg.apply_strategy(cfg.strategy_name, window, params)
+    last = result_df.iloc[-1]
+    decision["signal"] = normalize_signal(last.get("signal", 0))
+    decision["open_action"] = open_action_from_signal(decision["signal"])
+    if _has_close_fraction_columns(result_df):
+        decision["close_fraction"] = float(
+            _max_close_fraction_series(result_df).iloc[-1])
+    else:
+        decision["close_fraction"] = 0.0
+    return decision
+
+
+def _bt_close_evaluator_fraction(cfg: ParityConfig, i: int,
+                                 df: pd.DataFrame, atr_full: pd.Series,
+                                 regime_full: Optional[pd.Series],
+                                 position_ctx: Optional[dict]) -> float:
+    """Backtest-side registry close evaluation at bar ``i``.
+
+    Mirrors ``Backtester``'s close-evaluator inputs: bar-N close as the
+    mark, full-frame closed-bar ATR at bar N, full-frame regime label at
+    bar N. Same ``close_registry_loader.evaluate``, same position context
+    as the live side — only the window-derived inputs differ.
+    """
+    if not position_ctx:
+        return 0.0
+    market = {"mark_price": float(df["close"].iloc[i])}
+    atr_val = float(atr_full.iloc[i]) if pd.notna(atr_full.iloc[i]) else 0.0
+    if atr_val > 0:
+        market["atr"] = atr_val
+    if regime_full is not None:
+        label = str(regime_full.iloc[i] or "")
+        if label:
+            market["regime"] = label
+    params_by_name = _close_params_by_name(cfg.close_refs)
+    best = 0.0
+    for name in _close_names(cfg.close_refs):
+        resolved, ref_params = rewrite_deprecated_close_ref(
+            name, params_by_name.get(name))
+        if ref_params is None and resolved == cfg.strategy_name:
+            ref_params = dict(cfg.params or {})
+        try:
+            result = close_evaluate(resolved, position_ctx, market, ref_params)
+        except ValueError:
+            # Non-registry (signal-strategy) close refs are covered by the
+            # column path on both sides; skip the evaluator comparison.
+            continue
+        best = max(best, float(result.get("close_fraction", 0.0) or 0.0))
+    return best
+
+
+def _simulate_position_contexts(bt: pd.DataFrame, df: pd.DataFrame,
+                                atr_full: pd.Series,
+                                regime_full: Optional[pd.Series]) -> list:
+    """Walk the backtest-effective decisions and track a scaffold position.
+
+    The context exists so close evaluators see a plausible position on
+    BOTH sides — it is shared, so it can never be the source of a diff.
+    Entries/exits follow the engine's shift(1) semantics: bar N acts on
+    bar N-1's signal/open_action/close_fraction. The scaffold tracks the
+    column/signal surface only (registry-evaluator closes are the output
+    under test, not an input to the scaffold).
+    """
+    contexts = []
+    side = ""
+    avg_cost = 0.0
+    qty = 0.0
+    initial_qty = 0.0
+    entry_atr = 0.0
+    entry_regime = ""
+
+    for i in range(len(df)):
+        ctx = None
+        if side:
+            ctx = {
+                "side": side,
+                "avg_cost": avg_cost,
+                "current_quantity": qty,
+                "initial_quantity": initial_qty or qty,
+            }
+            if entry_atr > 0:
+                ctx["entry_atr"] = entry_atr
+            if entry_regime:
+                ctx["regime"] = entry_regime
+        contexts.append(ctx)
+
+        if i == 0:
+            continue
+        # Backtest-effective inputs at bar i = unshifted bar i-1 values.
+        eff_signal = int(bt["signal"].iloc[i - 1])
+        eff_action = str(bt["open_action"].iloc[i - 1])
+        eff_close = float(bt["close_fraction"].iloc[i - 1])
+        mark = float(df["close"].iloc[i])
+
+        if side and (eff_close > 0
+                     or (side == "long" and eff_signal < 0)
+                     or (side == "short" and eff_signal > 0)):
+            frac = eff_close if eff_close > 0 else 1.0
+            qty = max(qty - initial_qty * frac, 0.0)
+            if qty <= 1e-12:
+                side = ""
+                avg_cost = qty = initial_qty = entry_atr = 0.0
+                entry_regime = ""
+        elif not side and eff_action in ("long", "short"):
+            side = eff_action
+            avg_cost = mark
+            qty = initial_qty = 1.0
+            atr_val = atr_full.iloc[i]
+            entry_atr = float(atr_val) if pd.notna(atr_val) else 0.0
+            if regime_full is not None:
+                entry_regime = str(regime_full.iloc[i] or "")
+    return contexts
+
+
+def compute_parity_frame(
+    df: pd.DataFrame,
+    strategy_name: Optional[str] = None,
+    params: Optional[dict] = None,
+    registry: str = "spot",
+    window: Optional[int] = DEFAULT_WINDOW,
+    stride: int = 1,
+    regime_enabled: bool = False,
+    regime_period: int = 14,
+    regime_adx_threshold: float = 20.0,
+    close_refs: Optional[list] = None,
+    cfg: Optional[ParityConfig] = None,
+) -> pd.DataFrame:
+    """Replay both decision paths over ``df`` and return the per-bar diff.
+
+    Returns one row per compared bar with ``bt_*`` (vectorized full-frame /
+    engine semantics) and ``live_*`` (trailing-window check-script
+    semantics) columns, ``backtest_effective_*`` (post-shift(1) engine
+    inputs, informational) and a ``match`` bool. Comparison starts at the
+    first bar where the trailing window is full (``window`` bars, or
+    ``LIVE_MIN_CANDLES`` for expanding mode) so every live evaluation sees
+    the same window length it would in production — earlier bars would
+    diff on warmup, not on parity.
+    """
+    if cfg is None:
+        if not strategy_name:
+            raise ValueError("strategy_name or cfg is required")
+        cfg = ParityConfig(
+            strategy_name=strategy_name,
+            params=dict(params or {}),
+            registry=registry,
+            close_refs=close_refs,
+            regime_enabled=regime_enabled,
+            regime_period=regime_period,
+            regime_adx_threshold=regime_adx_threshold,
+        )
+    if stride < 1:
+        raise ValueError("stride must be >= 1")
+    if window is not None and window < LIVE_MIN_CANDLES:
+        raise ValueError(f"window must be >= {LIVE_MIN_CANDLES} (live minimum)")
+    reg = load_registry(cfg.registry)
+    full_result = reg.apply_strategy(
+        cfg.strategy_name, df.copy(), dict(cfg.params or {}))
+    bt = _full_frame_decisions(full_result)
+    atr_full = ensure_atr_indicator(df.copy())["atr"]
+
+    regime_full = None
+    if cfg.regime_enabled:
+        from regime import compute_regime
+        regime_full = compute_regime(
+            df, period=cfg.regime_period,
+            adx_threshold=cfg.regime_adx_threshold,
+        )["regime"]
+
+    has_close_refs = bool(_close_names(cfg.close_refs))
+    contexts = (
+        _simulate_position_contexts(bt, df, atr_full, regime_full)
+        if has_close_refs else [None] * len(df)
+    )
+
+    start = (window - 1) if window is not None else (LIVE_MIN_CANDLES - 1)
+    rows = []
+    for i in range(start, len(df), stride):
+        lo = max(0, i + 1 - window) if window is not None else 0
+        win = df.iloc[lo:i + 1].copy()
+        ctx = contexts[i]
+        side = str((ctx or {}).get("side", "") or "")
+        live = _live_bar_decision(win, cfg, reg,
+                                  position_side=side, position_ctx=ctx)
+
+        bt_close = float(bt["close_fraction"].iloc[i])
+        bt_signal = int(bt["signal"].iloc[i])
+        if has_close_refs:
+            bt_close = max(bt_close, _bt_close_evaluator_fraction(
+                cfg, i, df, atr_full, regime_full, ctx))
+            # The live decision composes open intent + close intent +
+            # position side into one signal (finalize_decision). Compose
+            # the backtest inputs identically so the signal column compares
+            # like-for-like — a diff then isolates input drift, never the
+            # composition itself.
+            bt_signal = compose_signal(
+                str(bt["open_action"].iloc[i]), bt_close, side)
+
+        row = {
+            "ts": df.index[i],
+            "bt_signal": bt_signal,
+            "live_signal": int(live["signal"]),
+            "bt_open_action": str(bt["open_action"].iloc[i]),
+            "live_open_action": str(live["open_action"]),
+            "bt_close_fraction": bt_close,
+            "live_close_fraction": float(live["close_fraction"]),
+        }
+        match = (
+            row["bt_signal"] == row["live_signal"]
+            and row["bt_open_action"] == row["live_open_action"]
+            and abs(row["bt_close_fraction"] - row["live_close_fraction"]) < 1e-9
+        )
+        if cfg.regime_enabled:
+            row["bt_regime"] = str(regime_full.iloc[i])
+            row["live_regime"] = str(live["regime"])
+            match = match and row["bt_regime"] == row["live_regime"]
+        # Post-shift(1) inputs the engine reads at bar i — informational.
+        if i > 0:
+            row["backtest_effective_signal"] = int(bt["signal"].iloc[i - 1])
+            row["backtest_effective_open_action"] = str(
+                bt["open_action"].iloc[i - 1])
+            row["backtest_effective_close_fraction"] = float(
+                bt["close_fraction"].iloc[i - 1])
+            if cfg.regime_enabled:
+                row["backtest_effective_regime"] = str(
+                    regime_full.iloc[i - 1])
+        row["match"] = match
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def extract_fills(df: pd.DataFrame, cfg: ParityConfig) -> list:
+    """Run the full Backtester over ``df`` and return simulated fills.
+
+    Lets a decision-level diff be lined up against the trades the engine
+    would actually book (entry/exit price + modeled fee per leg).
+    """
+    reg = load_registry(cfg.registry)
+    work = reg.apply_strategy(
+        cfg.strategy_name, df.copy(), dict(cfg.params or {}))
+    if cfg.close_refs:
+        work = ensure_atr_indicator(work)
+    bt = Backtester(
+        initial_capital=1000.0,
+        platform=cfg.platform,
+        open_strategy={"name": cfg.strategy_name,
+                       "params": dict(cfg.params or {})},
+        close_strategies=cfg.close_refs,
+        regime_enabled=cfg.regime_enabled,
+        regime_period=cfg.regime_period,
+        regime_adx_threshold=cfg.regime_adx_threshold,
+    )
+    metrics = bt.run(
+        work,
+        strategy_name=cfg.strategy_name,
+        symbol=cfg.symbol,
+        timeframe=cfg.timeframe,
+        params=dict(cfg.params or {}),
+        save=False,
+    )
+    fee_pct = fee_pct_for_platform(cfg.platform)
+    fills = []
+    for trade in metrics.get("trades", []) or []:
+        shares = abs(float(trade.get("shares", 0) or 0))
+        entry_px = float(trade.get("entry_price", 0) or 0)
+        fills.append({
+            "event": "entry",
+            "bar": str(trade.get("entry_date", "")),
+            "side": trade.get("side", "long"),
+            "fill_px": entry_px,
+            "fee": round(entry_px * shares * fee_pct, 6),
+        })
+        if trade.get("exit_date"):
+            exit_px = float(trade.get("exit_price", 0) or 0)
+            fills.append({
+                "event": "exit",
+                "bar": str(trade.get("exit_date", "")),
+                "side": trade.get("side", "long"),
+                "fill_px": exit_px,
+                "fee": round(exit_px * shares * fee_pct, 6),
+                "pnl": float(trade.get("pnl", 0) or 0),
+            })
+    return fills
+
+
+def summarize(frame: pd.DataFrame) -> dict:
+    """Aggregate a parity frame into a result summary."""
+    if frame.empty:
+        return {"bars_compared": 0, "mismatches": 0, "clean": True}
+    mismatched = frame[~frame["match"]]
+    summary = {
+        "bars_compared": int(len(frame)),
+        "mismatches": int(len(mismatched)),
+        "clean": bool(mismatched.empty),
+    }
+    if not mismatched.empty:
+        summary["first_mismatch"] = str(mismatched.iloc[0]["ts"])
+        summary["last_mismatch"] = str(mismatched.iloc[-1]["ts"])
+    return summary
+
+
+def _parse_close_refs(raw_list: list) -> list:
+    """Parse repeatable --close values: ``name`` or ``name:{json params}``."""
+    refs = []
+    for item in raw_list:
+        if ":" in item:
+            name, params_json = item.split(":", 1)
+            refs.append({"name": name.strip(),
+                         "params": json.loads(params_json)})
+        else:
+            refs.append({"name": item.strip(), "params": {}})
+    return refs
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Per-bar backtest-vs-live decision diff (#906 D7.4)"
+    )
+    parser.add_argument("--strategy", default=None,
+                        help="Open strategy name (ad-hoc mode)")
+    parser.add_argument("--symbol", default="BTC/USDT")
+    parser.add_argument("--timeframe", default="1h")
+    parser.add_argument("--since", default=None,
+                        help="Start date YYYY-MM-DD (bounds the replay)")
+    parser.add_argument("--params", default=None,
+                        help="JSON dict of strategy param overrides")
+    parser.add_argument("--registry", choices=["spot", "futures"],
+                        default="spot")
+    parser.add_argument("--platform", default="binanceus",
+                        help="Fee platform for --fills (default binanceus)")
+    parser.add_argument("--close", action="append", default=[],
+                        help="Close ref: name or name:{json params} "
+                             "(repeatable; single ref since #842)")
+    parser.add_argument("--config", default=None,
+                        help="Live go-trader config JSON (v13+); replaces "
+                             "--strategy/--params/--close with the exact "
+                             "live refs")
+    parser.add_argument("--strategy-id", default=None,
+                        help="Strategy id inside --config")
+    parser.add_argument("--window", type=int, default=DEFAULT_WINDOW,
+                        help=f"Trailing candle window for the live path "
+                             f"(default {DEFAULT_WINDOW}, matching the check "
+                             f"scripts' --ohlcv-limit); 0 = expanding window")
+    parser.add_argument("--stride", type=int, default=1,
+                        help="Compare every Nth bar (speeds up long ranges)")
+    parser.add_argument("--regime", action="store_true",
+                        help="Also diff the regime label per bar")
+    parser.add_argument("--regime-period", type=int, default=14)
+    parser.add_argument("--regime-adx-threshold", type=float, default=20.0)
+    parser.add_argument("--fills", action="store_true",
+                        help="Also run the full Backtester and report "
+                             "simulated entry/exit fills")
+    parser.add_argument("--csv", default=None,
+                        help="Write the full per-bar frame to this CSV path")
+    parser.add_argument("--jsonl", default=None,
+                        help="Write per-bar rows (and fills with --fills) "
+                             "as JSON lines to this path")
+    parser.add_argument("--max-print", type=int, default=20,
+                        help="Max mismatching rows printed to stdout")
+    args = parser.parse_args(argv)
+
+    if args.config:
+        if not args.strategy_id:
+            print("--strategy-id is required with --config", file=sys.stderr)
+            return 2
+        try:
+            cfg = config_from_live_config(args.config, args.strategy_id,
+                                          platform=args.platform)
+        except (ValueError, OSError, json.JSONDecodeError) as e:
+            print(f"--config: {e}", file=sys.stderr)
+            return 2
+        cfg.regime_enabled = cfg.regime_enabled or args.regime
+        symbol, timeframe = cfg.symbol, cfg.timeframe
+    else:
+        if not args.strategy:
+            print("--strategy is required (or use --config + --strategy-id)",
+                  file=sys.stderr)
+            return 2
+        params = None
+        if args.params:
+            try:
+                params = json.loads(args.params)
+            except json.JSONDecodeError as e:
+                print(f"--params is not valid JSON: {e}", file=sys.stderr)
+                return 2
+            if not isinstance(params, dict):
+                print("--params must be a JSON object", file=sys.stderr)
+                return 2
+        try:
+            close_refs = _parse_close_refs(args.close) or None
+        except json.JSONDecodeError as e:
+            print(f"--close params are not valid JSON: {e}", file=sys.stderr)
+            return 2
+        cfg = ParityConfig(
+            strategy_name=args.strategy,
+            params=dict(params or {}),
+            registry=args.registry,
+            platform=args.platform,
+            symbol=args.symbol,
+            timeframe=args.timeframe,
+            close_refs=close_refs,
+            regime_enabled=args.regime,
+            regime_period=args.regime_period,
+            regime_adx_threshold=args.regime_adx_threshold,
+        )
+        symbol, timeframe = args.symbol, args.timeframe
+
+    from data_fetcher import load_cached_data
+    df = load_cached_data(symbol, timeframe, start_date=args.since)
+    if df is None or df.empty:
+        print(f"No cached data for {symbol} {timeframe} — run a "
+              f"backtest first to populate the cache.", file=sys.stderr)
+        return 2
+
+    window = args.window if args.window and args.window > 0 else None
+    frame = compute_parity_frame(df, cfg=cfg, window=window,
+                                 stride=args.stride)
+    result = summarize(frame)
+    fills = extract_fills(df, cfg) if args.fills else []
+
+    if args.csv:
+        frame.to_csv(args.csv, index=False)
+        print(f"Per-bar frame written to {args.csv}")
+    if args.jsonl:
+        with open(args.jsonl, "w") as fh:
+            for rec in frame.to_dict(orient="records"):
+                rec["ts"] = str(rec["ts"])
+                fh.write(json.dumps(rec, sort_keys=True, default=str) + "\n")
+            for fill in fills:
+                fh.write(json.dumps({"fill": fill}, sort_keys=True) + "\n")
+        print(f"JSONL written to {args.jsonl}")
+
+    print(f"\nParity diff: {cfg.strategy_name} on {symbol} {timeframe} "
+          f"(window={'expanding' if window is None else window}, "
+          f"stride={args.stride})")
+    print(f"  Bars compared: {result['bars_compared']}")
+    print(f"  Mismatches:    {result['mismatches']}")
+    if args.fills:
+        print(f"  Fills:         {len(fills)}")
+    if result["clean"]:
+        print("  CLEAN — backtest and live paths agree on every compared bar.")
+        return 0
+
+    print(f"  First mismatch: {result['first_mismatch']}")
+    print(f"  Last mismatch:  {result['last_mismatch']}")
+    mismatched = frame[~frame["match"]]
+    with pd.option_context("display.max_columns", None, "display.width", 240):
+        print(mismatched.head(args.max_print).to_string(index=False))
+    if len(mismatched) > args.max_print:
+        print(f"  … {len(mismatched) - args.max_print} more "
+              f"(use --csv for the full frame)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backtest/tests/test_parity_diff.py
+++ b/backtest/tests/test_parity_diff.py
@@ -505,3 +505,29 @@ def test_entry_atr_plausibility_guard_matches_engine():
     contexts = parity_diff._simulate_position_contexts(bt, df, atr_full, None)
     assert contexts[21] is not None
     assert "entry_atr" not in contexts[21]
+
+def test_position_context_avg_cost_is_fill_bar_open_with_slippage():
+    """The scaffold must open at the fill bar's OPEN adjusted by the
+    engine's default slippage (Backtester's effective_price) — not the
+    bar's close — so tier triggers ((mark - avg_cost)/entry_atr) see the
+    same entry price the engine and live would on large-bodied bars."""
+    from atr import ensure_atr_indicator
+    n = 40
+    df = _ohlcv(n)
+    atr_full = ensure_atr_indicator(df.copy())["atr"]
+    slip = parity_diff._ENGINE_SLIPPAGE_PCT
+    assert slip == pytest.approx(0.0005)
+
+    for action, sign in (("long", 1), ("short", -1)):
+        bt = pd.DataFrame({
+            "signal": [0] * n,
+            "open_action": ["none"] * n,
+            "close_fraction": [0.0] * n,
+        }, index=df.index)
+        bt.iloc[19, bt.columns.get_loc("open_action")] = action  # fill @ 20
+        contexts = parity_diff._simulate_position_contexts(
+            bt, df, atr_full, None)
+        expected = float(df["open"].iloc[20]) * (1 + sign * slip)
+        assert contexts[21]["avg_cost"] == pytest.approx(expected), action
+        assert contexts[21]["avg_cost"] != pytest.approx(
+            float(df["close"].iloc[20]))

--- a/backtest/tests/test_parity_diff.py
+++ b/backtest/tests/test_parity_diff.py
@@ -362,11 +362,12 @@ def test_main_zero_bars_compared_is_data_error(monkeypatch):
     assert rc == 2
 
 
-def test_fractional_signal_normalized_identically_on_both_sides():
-    """A strategy emitting fractional signals (0.5/-0.5) must not diff on
-    normalization alone — both replay paths collapse to {-1, 0, 1} by the
-    same float-aware rule (int() truncation on one side would flag 0.5→0
-    vs 0.5→1 as drift)."""
+def test_out_of_contract_signal_rejected_loudly():
+    """A strategy emitting out-of-contract signals (0.5) must NOT diff
+    clean: the engine raises on non-integral signals while the live check
+    script truncates to 0 — a real divergence. The tool mirrors the
+    engine's strict {-1, 0, 1} rejection on both paths so the class is
+    surfaced, never normalized into a false CLEAN."""
     reg = load_registry("spot")
 
     def fractional_signal_strategy(df: pd.DataFrame) -> pd.DataFrame:
@@ -383,12 +384,48 @@ def test_fractional_signal_normalized_identically_on_both_sides():
     }
     try:
         df = _ohlcv(200)
-        frame = compute_parity_frame(df, name, window=60)
-        assert summarize(frame)["clean"], frame[~frame["match"]].head()
-        assert set(frame["bt_signal"].unique()) <= {-1, 0, 1}
-        assert (frame["bt_signal"] != 0).any()
+        with pytest.raises(ValueError, match="signal must be in"):
+            compute_parity_frame(df, name, window=60)
     finally:
         del reg.STRATEGY_REGISTRY[name]
+
+
+def test_normalize_signal_contract():
+    """In-contract values collapse identically on both paths; NaN → 0;
+    anything else (fractional, out-of-domain integer) raises."""
+    assert parity_diff._normalize_signal(np.float64(1.0)) == 1
+    assert parity_diff._normalize_signal(-1) == -1
+    assert parity_diff._normalize_signal(0.0) == 0
+    assert parity_diff._normalize_signal(float("nan")) == 0
+    assert parity_diff._normalize_signal(None) == 0
+    for bad in (0.5, -0.5, 2, -3):
+        with pytest.raises(ValueError, match="signal must be in"):
+            parity_diff._normalize_signal(bad)
+
+
+def test_position_context_entry_regime_is_decision_bar_label():
+    """The scaffold must stamp the entry regime from the DECISION bar
+    (i-1), mirroring the engine's shifted-regime ``_entry_stamp`` and the
+    live label computed alongside the signal — not the fill bar's label."""
+    from atr import ensure_atr_indicator
+    n = 40
+    df = _ohlcv(n)
+    bt = pd.DataFrame({
+        "signal": [0] * n,
+        "open_action": ["none"] * n,
+        "close_fraction": [0.0] * n,
+    }, index=df.index)
+    bt.iloc[9, bt.columns.get_loc("open_action")] = "long"
+    atr_full = ensure_atr_indicator(df.copy())["atr"]
+    regime_full = pd.Series([f"label{i}" for i in range(n)], index=df.index)
+    contexts = parity_diff._simulate_position_contexts(
+        bt, df, atr_full, regime_full)
+    assert contexts[10] is None  # fill happens AT bar 10; ctx visible after
+    assert contexts[11] is not None
+    assert contexts[11]["regime"] == "label9", (
+        "entry regime must be the decision bar's (9) label, "
+        "not the fill bar's (10)"
+    )
 
 
 def test_bt_close_evaluator_uses_engine_dict_shape(monkeypatch):

--- a/backtest/tests/test_parity_diff.py
+++ b/backtest/tests/test_parity_diff.py
@@ -15,12 +15,14 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import parity_diff
 from parity_diff import (
     LIVE_MIN_CANDLES,
     ParityConfig,
     compute_parity_frame,
     config_from_live_config,
     extract_fills,
+    main,
     summarize,
 )
 from registry_loader import load_registry
@@ -284,3 +286,135 @@ def test_backtest_effective_columns_are_prior_bar_inputs():
     got = frame["backtest_effective_signal"].iloc[1:].tolist()
     want = frame["bt_signal"].iloc[:-1].tolist()
     assert got == want
+
+def _live_config_json(stype: str = "perps") -> dict:
+    return {
+        "config_version": 15,
+        "strategies": [{
+            "id": "test-strat",
+            "type": stype,
+            "script": "shared_scripts/check_hyperliquid.py",
+            "args": ["sma_crossover", "BTC/USDT", "1h"],
+            "open_strategy": {
+                "name": "sma_crossover",
+                "params": {"fast_period": 5, "slow_period": 20},
+            },
+        }],
+    }
+
+
+@pytest.mark.parametrize("stype,want_platform", [
+    ("perps", "hyperliquid"),
+    ("manual", "hyperliquid"),
+    ("futures", "binanceus"),
+    ("spot", "binanceus"),
+])
+def test_config_mode_platform_autodetect(tmp_path, stype, want_platform):
+    """An unset --platform (empty string, as main passes it) must let the
+    strategy type drive the fee platform — perps/manual map to hyperliquid,
+    everything else to binanceus."""
+    import json as _json
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(_json.dumps(_live_config_json(stype)))
+    cfg = config_from_live_config(str(cfg_path), "test-strat", platform="")
+    assert cfg.platform == want_platform
+
+
+def test_config_mode_explicit_platform_overrides_autodetect(tmp_path):
+    import json as _json
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(_json.dumps(_live_config_json("spot")))
+    cfg = config_from_live_config(str(cfg_path), "test-strat",
+                                  platform="hyperliquid")
+    assert cfg.platform == "hyperliquid"
+
+
+def test_main_config_mode_fills_use_autodetected_platform(tmp_path, monkeypatch):
+    """Regression: the CLI's --platform default must not short-circuit the
+    --config auto-detect — an HL perps config run exactly as the CLI runs it
+    must reach extract_fills with platform=hyperliquid, not binanceus."""
+    import json as _json
+    import data_fetcher
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(_json.dumps(_live_config_json("perps")))
+    monkeypatch.setattr(data_fetcher, "load_cached_data",
+                        lambda *a, **k: _trending_ohlcv(200))
+    captured = {}
+
+    def spy_extract_fills(df, cfg):
+        captured["platform"] = cfg.platform
+        return []
+
+    monkeypatch.setattr(parity_diff, "extract_fills", spy_extract_fills)
+    rc = main(["--config", str(cfg_path), "--strategy-id", "test-strat",
+               "--fills", "--window", "60"])
+    assert rc in (0, 1)
+    assert captured["platform"] == "hyperliquid"
+
+
+def test_main_zero_bars_compared_is_data_error(monkeypatch):
+    """A run whose data is shorter than the trailing window compares zero
+    bars — that is a data error (exit 2), never a CLEAN pass (exit 0)."""
+    import data_fetcher
+    monkeypatch.setattr(data_fetcher, "load_cached_data",
+                        lambda *a, **k: _ohlcv(40))
+    rc = main(["--strategy", "sma_crossover", "--window", "200"])
+    assert rc == 2
+
+
+def test_fractional_signal_normalized_identically_on_both_sides():
+    """A strategy emitting fractional signals (0.5/-0.5) must not diff on
+    normalization alone — both replay paths collapse to {-1, 0, 1} by the
+    same float-aware rule (int() truncation on one side would flag 0.5→0
+    vs 0.5→1 as drift)."""
+    reg = load_registry("spot")
+
+    def fractional_signal_strategy(df: pd.DataFrame) -> pd.DataFrame:
+        out = df.copy()
+        sma = out["close"].rolling(10).mean()
+        out["signal"] = np.where(out["close"] > sma, 0.5, -0.5)
+        return out
+
+    name = "_parity_diff_test_fractional_signal"
+    reg.STRATEGY_REGISTRY[name] = {
+        "fn": fractional_signal_strategy,
+        "description": "test-only fractional-signal strategy",
+        "default_params": {},
+    }
+    try:
+        df = _ohlcv(200)
+        frame = compute_parity_frame(df, name, window=60)
+        assert summarize(frame)["clean"], frame[~frame["match"]].head()
+        assert set(frame["bt_signal"].unique()) <= {-1, 0, 1}
+        assert (frame["bt_signal"] != 0).any()
+    finally:
+        del reg.STRATEGY_REGISTRY[name]
+
+
+def test_bt_close_evaluator_uses_engine_dict_shape(monkeypatch):
+    """The backtest-side evaluator call must mirror the engine (#747):
+    ``regime`` always present (possibly empty) in BOTH dicts and
+    ``entry_atr`` always a float — even when regime is disabled and the
+    shared context omits the keys."""
+    from atr import ensure_atr_indicator
+    captured = {}
+
+    def fake_evaluate(name, position, market, params):
+        captured["position"] = position
+        captured["market"] = market
+        return {"close_fraction": 0.0}
+
+    monkeypatch.setattr(parity_diff, "close_evaluate", fake_evaluate)
+    df = _trending_ohlcv(80)
+    atr_full = ensure_atr_indicator(df.copy())["atr"]
+    cfg = ParityConfig(
+        strategy_name="sma_crossover",
+        close_refs=[{"name": "tiered_tp_atr", "params": {}}],
+    )
+    ctx = {"side": "long", "avg_cost": 100.0,
+           "current_quantity": 1.0, "initial_quantity": 1.0}
+    parity_diff._bt_close_evaluator_fraction(cfg, 60, df, atr_full, None, ctx)
+    assert captured["market"]["regime"] == ""
+    assert captured["position"]["regime"] == ""
+    assert isinstance(captured["position"]["entry_atr"], float)
+    assert captured["position"]["entry_atr"] == 0.0

--- a/backtest/tests/test_parity_diff.py
+++ b/backtest/tests/test_parity_diff.py
@@ -455,3 +455,53 @@ def test_bt_close_evaluator_uses_engine_dict_shape(monkeypatch):
     assert captured["position"]["regime"] == ""
     assert isinstance(captured["position"]["entry_atr"], float)
     assert captured["position"]["entry_atr"] == 0.0
+
+def test_non_registry_close_ref_rejected_like_engine():
+    """A signal-strategy close ref has no engine path (Backtester rejects
+    unknown close names at init), so the tool must fail with the same
+    error instead of silently scoring 0 on the bt side while the live
+    fallback fully evaluates it — a manufactured mismatch."""
+    df = _trending_ohlcv(120)
+    with pytest.raises(ValueError, match="Unknown close strategy"):
+        compute_parity_frame(
+            df, "sma_crossover",
+            params={"fast_period": 5, "slow_period": 20},
+            window=60,
+            close_refs=[{"name": "rsi_oversold", "params": {}}],
+        )
+    from backtester import Backtester
+    with pytest.raises(ValueError, match="Unknown close strategy"):
+        Backtester(
+            initial_capital=1000.0,
+            open_strategy={"name": "sma_crossover", "params": {}},
+            close_strategies=[{"name": "rsi_oversold", "params": {}}],
+        )
+
+
+def test_entry_atr_plausibility_guard_matches_engine():
+    """The scaffold must apply the engine's _stamp_entry_atr guard: an ATR
+    above 50% of the entry price stamps 0.0 (key omitted from the shared
+    context) so ATR-requiring close evaluators no-op, matching both the
+    engine and Go's stampEntryATRIfOpened."""
+    from atr import ensure_atr_indicator
+    n = 40
+    rng = np.random.default_rng(3)
+    close = 100.0 + rng.normal(0, 0.2, n)
+    df = pd.DataFrame({
+        "open": close,
+        "high": close + 90.0,   # huge bar ranges → ATR ≈ 180 > 50% of price
+        "low": close - 90.0,
+        "close": close,
+        "volume": [1000.0] * n,
+    }, index=pd.date_range("2024-01-01", periods=n, freq="1h"))
+    bt = pd.DataFrame({
+        "signal": [0] * n,
+        "open_action": ["none"] * n,
+        "close_fraction": [0.0] * n,
+    }, index=df.index)
+    bt.iloc[19, bt.columns.get_loc("open_action")] = "long"  # fill at bar 20
+    atr_full = ensure_atr_indicator(df.copy())["atr"]
+    assert float(atr_full.iloc[20]) > 0.5 * float(df["close"].iloc[20])
+    contexts = parity_diff._simulate_position_contexts(bt, df, atr_full, None)
+    assert contexts[21] is not None
+    assert "entry_atr" not in contexts[21]

--- a/backtest/tests/test_parity_diff.py
+++ b/backtest/tests/test_parity_diff.py
@@ -418,11 +418,11 @@ def test_position_context_entry_regime_is_decision_bar_label():
     bt.iloc[9, bt.columns.get_loc("open_action")] = "long"
     atr_full = ensure_atr_indicator(df.copy())["atr"]
     regime_full = pd.Series([f"label{i}" for i in range(n)], index=df.index)
-    contexts = parity_diff._simulate_position_contexts(
+    contexts, _ = parity_diff._simulate_position_contexts(
         bt, df, atr_full, regime_full)
-    assert contexts[10] is None  # fill happens AT bar 10; ctx visible after
-    assert contexts[11] is not None
-    assert contexts[11]["regime"] == "label9", (
+    assert contexts[9] is None  # decision bar — not yet filled
+    assert contexts[10] is not None  # fill bar: position visible end-of-bar
+    assert contexts[10]["regime"] == "label9", (
         "entry regime must be the decision bar's (9) label, "
         "not the fill bar's (10)"
     )
@@ -502,9 +502,10 @@ def test_entry_atr_plausibility_guard_matches_engine():
     bt.iloc[19, bt.columns.get_loc("open_action")] = "long"  # fill at bar 20
     atr_full = ensure_atr_indicator(df.copy())["atr"]
     assert float(atr_full.iloc[20]) > 0.5 * float(df["close"].iloc[20])
-    contexts = parity_diff._simulate_position_contexts(bt, df, atr_full, None)
-    assert contexts[21] is not None
-    assert "entry_atr" not in contexts[21]
+    contexts, _ = parity_diff._simulate_position_contexts(
+        bt, df, atr_full, None)
+    assert contexts[20] is not None
+    assert "entry_atr" not in contexts[20]
 
 def test_position_context_avg_cost_is_fill_bar_open_with_slippage():
     """The scaffold must open at the fill bar's OPEN adjusted by the
@@ -525,9 +526,50 @@ def test_position_context_avg_cost_is_fill_bar_open_with_slippage():
             "close_fraction": [0.0] * n,
         }, index=df.index)
         bt.iloc[19, bt.columns.get_loc("open_action")] = action  # fill @ 20
-        contexts = parity_diff._simulate_position_contexts(
+        contexts, _ = parity_diff._simulate_position_contexts(
             bt, df, atr_full, None)
         expected = float(df["open"].iloc[20]) * (1 + sign * slip)
-        assert contexts[21]["avg_cost"] == pytest.approx(expected), action
-        assert contexts[21]["avg_cost"] != pytest.approx(
+        assert contexts[20]["avg_cost"] == pytest.approx(expected), action
+        assert contexts[20]["avg_cost"] != pytest.approx(
             float(df["close"].iloc[20]))
+
+def test_registry_close_advances_quantity_ladder():
+    """The cumulative tier ladder must advance like the engine books it:
+    tier 1 fires its 0.4 ONCE, the next bar's quantity drops to 0.6 and
+    the evaluator returns 0, and tier 2 later contributes the 0.4
+    INCREMENT to the 0.8 cumulative — never a repeated cumulative value
+    that neither the engine nor live produces."""
+    from atr import ensure_atr_indicator
+    n = 60
+    close = np.array([100.0] * 30 + [104.0] * 10 + [108.0] * 20)
+    df = pd.DataFrame({
+        "open": close,
+        "high": close + 1.0,   # TR = 2 → entry ATR = 2.0
+        "low": close - 1.0,
+        "close": close,
+        "volume": [1000.0] * n,
+    }, index=pd.date_range("2024-01-01", periods=n, freq="1h"))
+    bt = pd.DataFrame({
+        "signal": [0] * n,
+        "open_action": ["none"] * n,
+        "close_fraction": [0.0] * n,
+    }, index=df.index)
+    bt.iloc[19, bt.columns.get_loc("open_action")] = "long"  # fill @ 20
+    atr_full = ensure_atr_indicator(df.copy())["atr"]
+    cfg = ParityConfig(
+        strategy_name="sma_crossover",
+        close_refs=[{"name": "tiered_tp_atr", "params": {}}],
+    )
+    contexts, fracs = parity_diff._simulate_position_contexts(
+        bt, df, atr_full, None, cfg)
+    # Bar 30: mark 104, avg_cost ~100.05, entry ATR 2 → ratio ~1.97 → tier 1.
+    assert fracs[30] == pytest.approx(0.4)
+    # Bar 31: quantity decremented, already_closed=0.4 → increment is 0.
+    assert contexts[31]["current_quantity"] == pytest.approx(0.6)
+    assert fracs[31] == pytest.approx(0.0)
+    # Bar 40: mark 108 → ratio ~3.97 → tier 2 cumulative 0.8. The increment
+    # is 0.4 of INITIAL size, expressed as a fraction of the CURRENT 0.6
+    # position (the evaluator's contract): 0.4/0.6 = 2/3.
+    assert fracs[40] == pytest.approx(2.0 / 3.0)
+    assert contexts[41]["current_quantity"] == pytest.approx(0.2)
+    assert fracs[41] == pytest.approx(0.0)

--- a/backtest/tests/test_parity_diff.py
+++ b/backtest/tests/test_parity_diff.py
@@ -1,0 +1,286 @@
+"""Tests for the backtest-vs-live parity diff tool (#906 D7.4).
+
+The tool's job is to detect strategies whose bar-N decision depends on the
+frame they were computed in (full-frame vectorized vs trailing live window).
+These tests prove both directions: a window-invariant strategy diffs clean,
+and a deliberately frame-dependent strategy is caught.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from parity_diff import (
+    LIVE_MIN_CANDLES,
+    ParityConfig,
+    compute_parity_frame,
+    config_from_live_config,
+    extract_fills,
+    summarize,
+)
+from registry_loader import load_registry
+
+
+def _ohlcv(n: int = 300, seed: int = 7) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    drift = np.linspace(0, 12, n)
+    wave = 4.0 * np.sin(np.linspace(0, 14, n))
+    noise = rng.normal(0, 0.4, n)
+    close = 100.0 + drift + wave + noise
+    df = pd.DataFrame({
+        "open": close + rng.normal(0, 0.1, n),
+        "high": close + np.abs(rng.normal(0, 0.5, n)) + 0.2,
+        "low": close - np.abs(rng.normal(0, 0.5, n)) - 0.2,
+        "close": close,
+        "volume": rng.uniform(900, 1100, n),
+    }, index=pd.date_range("2024-01-01", periods=n, freq="1h"))
+    return df
+
+
+def test_window_invariant_strategy_diffs_clean():
+    """sma_crossover at bar N only needs the trailing slow-period bars, so
+    a full window evaluation must equal the full-frame vectorized value on
+    every compared bar."""
+    df = _ohlcv(260)
+    frame = compute_parity_frame(
+        df, "sma_crossover",
+        params={"fast_period": 10, "slow_period": 30},
+        window=120,
+    )
+    result = summarize(frame)
+    assert result["bars_compared"] > 100
+    assert result["clean"], (
+        f"window-invariant strategy should not diff: "
+        f"{frame[~frame['match']].head()}"
+    )
+
+
+def test_frame_dependent_strategy_is_caught():
+    """A strategy keyed on the FULL frame's mean (classic silent-parity
+    bug: full-series normalization) must produce mismatches — the live
+    window's mean differs from the backtest frame's mean."""
+    reg = load_registry("spot")
+
+    def full_frame_mean_strategy(df: pd.DataFrame) -> pd.DataFrame:
+        out = df.copy()
+        out["signal"] = (out["close"] > out["close"].mean()).astype(int)
+        return out
+
+    name = "_parity_diff_test_frame_dependent"
+    reg.STRATEGY_REGISTRY[name] = {
+        "fn": full_frame_mean_strategy,
+        "description": "test-only frame-dependent strategy",
+        "default_params": {},
+    }
+    try:
+        df = _ohlcv(260)
+        frame = compute_parity_frame(df, name, window=60)
+        result = summarize(frame)
+        assert result["mismatches"] > 0, (
+            "frame-dependent strategy must be detected by the parity diff"
+        )
+        assert "first_mismatch" in result
+    finally:
+        del reg.STRATEGY_REGISTRY[name]
+
+
+def test_regime_labels_diff_clean_per_bar():
+    """latest_regime on the trailing window must match compute_regime's
+    full-frame label on every bar — the per-bar generalization of the
+    last-bar parity test in test_backtester_regime.py."""
+    df = _ohlcv(220)
+    frame = compute_parity_frame(
+        df, "sma_crossover",
+        params={"fast_period": 10, "slow_period": 30},
+        window=120,
+        regime_enabled=True,
+    )
+    assert "bt_regime" in frame.columns and "live_regime" in frame.columns
+    regime_mismatch = frame[frame["bt_regime"] != frame["live_regime"]]
+    assert regime_mismatch.empty, regime_mismatch.head()
+
+
+def test_expanding_window_mode():
+    """window=None replays live with an ever-growing frame from bar
+    LIVE_MIN_CANDLES on; sma_crossover converges once the slow period is
+    seeded, so only the comparison start moves."""
+    df = _ohlcv(120)
+    frame = compute_parity_frame(
+        df, "sma_crossover",
+        params={"fast_period": 5, "slow_period": 15},
+        window=None,
+    )
+    assert len(frame) == len(df) - (LIVE_MIN_CANDLES - 1)
+    assert summarize(frame)["clean"]
+
+
+def test_stride_thins_comparison():
+    df = _ohlcv(200)
+    full = compute_parity_frame(
+        df, "sma_crossover", params={"fast_period": 5, "slow_period": 15},
+        window=60,
+    )
+    thinned = compute_parity_frame(
+        df, "sma_crossover", params={"fast_period": 5, "slow_period": 15},
+        window=60, stride=5,
+    )
+    assert len(thinned) == (len(full) + 4) // 5
+
+
+def test_window_below_live_minimum_rejected():
+    df = _ohlcv(100)
+    with pytest.raises(ValueError, match="window must be >="):
+        compute_parity_frame(df, "sma_crossover", window=10)
+
+
+def _trending_ohlcv(n: int = 260, seed: int = 11) -> pd.DataFrame:
+    """Strongly trending series so ATR-tiered TPs actually fire."""
+    rng = np.random.default_rng(seed)
+    close = 100.0 + np.linspace(0, 80, n) + rng.normal(0, 0.5, n)
+    return pd.DataFrame({
+        "open": close + rng.normal(0, 0.1, n),
+        "high": close + np.abs(rng.normal(0, 0.6, n)) + 0.3,
+        "low": close - np.abs(rng.normal(0, 0.6, n)) - 0.3,
+        "close": close,
+        "volume": rng.uniform(900, 1100, n),
+    }, index=pd.date_range("2024-01-01", periods=n, freq="1h"))
+
+
+def test_close_evaluator_parity_clean_and_exercised():
+    """A registry close evaluator (tiered_tp_atr) runs through the SAME
+    close_registry_loader.evaluate on both sides with a shared position
+    context — so it must diff clean, and the test only counts if the
+    evaluator actually fired (close_fraction > 0 somewhere)."""
+    df = _trending_ohlcv(260)
+    frame = compute_parity_frame(
+        df, "sma_crossover",
+        params={"fast_period": 10, "slow_period": 30},
+        window=60,
+        close_refs=[{"name": "tiered_tp_atr", "params": {}}],
+    )
+    result = summarize(frame)
+    assert result["bars_compared"] > 100
+    assert result["clean"], frame[~frame["match"]].head()
+    assert (frame["live_close_fraction"] > 0).any(), (
+        "tiered_tp_atr never fired — the close-evaluator path is untested"
+    )
+    assert (frame["bt_close_fraction"] > 0).any()
+
+
+def test_composed_signal_with_close_refs_diffs_clean():
+    """With close refs the live signal is the composed finalize_decision
+    output (0 while positioned, ±1 on close); the bt side must compose
+    identically so signal never diffs on composition alone."""
+    df = _trending_ohlcv(220)
+    frame = compute_parity_frame(
+        df, "sma_crossover",
+        params={"fast_period": 5, "slow_period": 20},
+        window=60,
+        close_refs=[{"name": "tiered_tp_atr", "params": {}}],
+    )
+    assert (frame["bt_signal"] == frame["live_signal"]).all(), (
+        frame[frame["bt_signal"] != frame["live_signal"]].head()
+    )
+
+
+def test_frame_dependent_strategy_caught_with_close_refs_too():
+    """The detection guarantee must survive the close-ref code path —
+    composition and position simulation may not mask open-signal drift."""
+    reg = load_registry("spot")
+
+    def full_frame_mean_strategy(df: pd.DataFrame) -> pd.DataFrame:
+        out = df.copy()
+        out["signal"] = (out["close"] > out["close"].mean()).astype(int)
+        return out
+
+    name = "_parity_diff_test_frame_dependent_close"
+    reg.STRATEGY_REGISTRY[name] = {
+        "fn": full_frame_mean_strategy,
+        "description": "test-only frame-dependent strategy",
+        "default_params": {},
+    }
+    try:
+        df = _ohlcv(260)
+        frame = compute_parity_frame(
+            df, name, window=60,
+            close_refs=[{"name": "tiered_tp_atr", "params": {}}],
+        )
+        assert summarize(frame)["mismatches"] > 0
+    finally:
+        del reg.STRATEGY_REGISTRY[name]
+
+
+def test_config_mode_builds_parity_config(tmp_path):
+    """--config/--strategy-id must reuse the #641 loader semantics and
+    pull symbol/timeframe/registry/regime from the live strategy entry."""
+    import json as _json
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(_json.dumps({
+        "config_version": 15,
+        "strategies": [{
+            "id": "hl-sma-btc",
+            "type": "perps",
+            "script": "shared_scripts/check_hyperliquid.py",
+            "args": ["sma_crossover", "BTC/USDT", "4h"],
+            "regime": {"enabled": True, "period": 10, "adx_threshold": 25},
+            "open_strategy": {
+                "name": "sma_crossover",
+                "params": {"fast_period": 5, "slow_period": 20},
+            },
+            "close_strategy": {"name": "tiered_tp_atr", "params": {}},
+        }],
+    }))
+    cfg = config_from_live_config(str(cfg_path), "hl-sma-btc")
+    assert cfg.strategy_name == "sma_crossover"
+    assert cfg.params == {"fast_period": 5, "slow_period": 20}
+    assert cfg.registry == "futures"
+    assert cfg.platform == "hyperliquid"
+    assert cfg.symbol == "BTC/USDT" and cfg.timeframe == "4h"
+    assert cfg.close_refs == [{"name": "tiered_tp_atr", "params": {}}]
+    assert cfg.regime_enabled and cfg.regime_period == 10
+    assert cfg.regime_adx_threshold == 25.0
+
+    frame = compute_parity_frame(_trending_ohlcv(200), cfg=cfg, window=60)
+    assert summarize(frame)["bars_compared"] > 50
+
+
+def test_config_mode_unknown_strategy_id_raises(tmp_path):
+    import json as _json
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(_json.dumps({"config_version": 15, "strategies": []}))
+    with pytest.raises(ValueError):
+        config_from_live_config(str(cfg_path), "missing-id")
+
+
+def test_extract_fills_reports_entry_and_exit_legs():
+    df = _trending_ohlcv(220)
+    cfg = ParityConfig(
+        strategy_name="sma_crossover",
+        params={"fast_period": 5, "slow_period": 20},
+    )
+    fills = extract_fills(df, cfg)
+    assert fills, "trending data + sma crossover must produce fills"
+    entries = [f for f in fills if f["event"] == "entry"]
+    exits = [f for f in fills if f["event"] == "exit"]
+    assert entries and all(f["fill_px"] > 0 and f["fee"] >= 0 for f in entries)
+    assert all("pnl" in f for f in exits)
+
+
+def test_backtest_effective_columns_are_prior_bar_inputs():
+    """backtest_effective_* must be the shift(1) inputs the engine reads —
+    i.e. the previous row's unshifted bt values (stride=1, no close refs
+    so bt_signal is the raw column)."""
+    df = _ohlcv(200)
+    frame = compute_parity_frame(
+        df, "sma_crossover", params={"fast_period": 5, "slow_period": 15},
+        window=60,
+    )
+    assert "backtest_effective_signal" in frame.columns
+    got = frame["backtest_effective_signal"].iloc[1:].tolist()
+    want = frame["bt_signal"].iloc[:-1].tolist()
+    assert got == want


### PR DESCRIPTION
## Summary

Best-of-N synthesis of the three #906 bake-off PRs. Base is PR 946 (scored 90/100: genuine two-path tool, least code, zero production-code risk, found real bugs #942/#943); grafted on top are the strengths that made PR 935 the runner-up (88/100); nothing was taken from PR 936's single-path tool. Supersedes PRs 946, 935, and 936.

## What's from where

**From #946 (base):** `parity_diff.py` trailing-window replay (default 200 = live `--ohlcv-limit`), stride/expanding-window/CSV/exit-code CLI, `AUDIT.md` (D1–D8 verified findings incl. bugs #942/#943), behavior-asserting tests (clean on window-invariant strategy, catches a full-frame-normalization strategy).

**From #935 (grafts):**
1. **Faithful live path** — the live side now calls the actual check-script helpers (`prepare_check_regime` → `params["regime"]` injection → `evaluate_open_close`/`finalize_decision` with `close_registry_loader.evaluate`) rather than modeling them. This was #935's standout strength and #946's one acknowledged gap.
2. **`--config <live-config> --strategy-id <id>`** — replays the exact live refs via the #641 loader (v13+ gate, #842 single-close collapse, HL-live-only rejections all inherited); symbol/timeframe/registry/regime pulled from the strategy entry.
3. **`--fills`** — full `Backtester` run reporting simulated entry/exit fills (price + modeled fee) to line the decision diff up against booked trades.
4. **`--jsonl`** output + per-bar `backtest_effective_*` (post-`shift(1)`) engine-input columns.
5. **`backtester.py` docstring** — live-parity-limitations decision record (#873/#883/#843/#822/#885).

**New in the synthesis (neither PR had it):**
- **Close-evaluator parity** — registry closes (`tiered_tp_atr` …) run through the same `close_registry_loader.evaluate` on BOTH sides with a shared simulated position context (side/avg_cost/quantities/entry_atr/entry regime). Backtest side feeds engine semantics (bar-N close, full-frame closed-bar ATR/regime); live side feeds check-script semantics (`latest_atr`/`prepare_check_regime` on the trailing window). A diff therefore isolates window-derived evaluator inputs; the shared context can never be the source.
- **Composed-signal comparison** — with close refs, the bt side composes `open_action` + `close_fraction` + position side exactly as `finalize_decision` does, so signal diffs isolate input drift, never the composition.

**Deliberately excluded:** #935's regression-index tests (they assert a test file exists and mentions a bug number, not that behavior is caught); #936's BYO-CSV single-path tool and its silent no-op `--regime-classifier` flag.

## Verification

- 13 `test_parity_diff.py` tests incl. new ones: close-evaluator parity clean **and exercised** (asserts the evaluator actually fired), composed-signal clean, frame-dependent detection survives the close-ref path, config-mode loader fields, fills legs, `backtest_effective_*` = prior-bar inputs.
- Full Python suite: **1190 passed**.
- Real cached data (BTC/USDT 1h): ad-hoc and config modes clean over 521 strided bars with `tiered_tp_atr` + 44 fills, exit 0; a `supertrend --regime` run over 1081 bars surfaced **1 genuine mismatch** — a trailing-window-vs-full-frame ADX boundary flip (`trending_down` vs `ranging`) — exactly the drift class the tool exists to catch.

Closes #906

---
Created with LLM: Fable 5 | high | Harness: Claude Code