### PR TITLE
parity(backtest): --config v15 gate + direction/invert_signal + regime_window_divergence

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -325,7 +325,9 @@ class Backtester:
                  trailing_stop_pct: Optional[float] = None,
                  stop_loss_atr_regime: Optional[dict] = None,
                  trailing_stop_atr_regime: Optional[dict] = None,
-                 strategy_type: str = "perps"):
+                 strategy_type: str = "perps",
+                 direction: Optional[str] = None,
+                 invert_signal: bool = False):
         """
         Args:
             initial_capital: Starting portfolio value.
@@ -397,6 +399,13 @@ class Backtester:
         self.trailing_stop_atr_mult = trailing_stop_atr_mult
         self.trailing_stop_pct = trailing_stop_pct
         self.strategy_type = strategy_type
+        # #942: live strategy-level entry transforms the backtester must mirror
+        # so --config doesn't silently diverge from the daemon. ``invert_signal``
+        # flips BUY<->SELL; ``direction`` gates which side may open. Both are
+        # applied to the raw signal in ``run()`` (see _apply_direction_invert),
+        # mirroring the live order (applySignalInversion before EffectiveDirection).
+        self.direction = (str(direction).strip().lower() if direction else None)
+        self.invert_signal = bool(invert_signal)
         self.stop_loss_atr_regime = (
             dict(stop_loss_atr_regime) if stop_loss_atr_regime else None
         )
@@ -689,6 +698,45 @@ class Backtester:
                         "stop_loss_atr_mult or stop_loss_pct."
                     )
 
+    def _apply_direction_invert(self, sig_int: pd.Series,
+                                uses_open_close: bool) -> pd.Series:
+        """Apply live ``invert_signal`` then ``direction`` gating to the raw
+        integer signal (#942).
+
+        Mirrors the live scheduler ordering: ``applySignalInversion`` flips
+        BUY<->SELL (scheduler/main.go) BEFORE ``EffectiveDirection`` /
+        ``PerpsOrderSkipReason`` gate which side may OPEN. Both are integer
+        frame transforms on ``{-1, 0, 1}``.
+
+        Direction masks the signal that would OPEN a disallowed side. The
+        signal's meaning is path-dependent, so masking is too:
+
+          - open/close path (``uses_open_close``): ``signal>0`` opens long,
+            ``signal<0`` opens short, and closes come from the close evaluator.
+            Masking the disallowed open side is exact and never suppresses a
+            close.
+          - plain long/flat path: ``signal=1`` opens long, ``signal=-1`` only
+            *closes* the long (a short is never opened). It is structurally
+            long-only, so ``direction="long"`` already matches live and needs
+            no mask; ``"short"``/``"both"`` are unmodelable here and are
+            rejected at config load (``run_backtest.load_strategy_config``).
+            Masking ``-1`` in this path would wrongly suppress long-closes, so
+            it is intentionally skipped.
+        """
+        sig = sig_int
+        if self.invert_signal:
+            # ``-sig`` keeps the {-1, 0, 1} domain (0 stays 0).
+            sig = -sig
+        d = self.direction or ""
+        if uses_open_close and d in ("long", "short"):
+            if d == "long":
+                # Disallow short opens: drop signal<0, keep long-opens/holds.
+                sig = sig.where(sig >= 0, 0)
+            else:  # "short"
+                # Disallow long opens: drop signal>0, keep short-opens/holds.
+                sig = sig.where(sig <= 0, 0)
+        return sig.astype(int)
+
     def run(self, df: pd.DataFrame, strategy_name: str = "Unknown",
             symbol: str = "BTC/USDT", timeframe: str = "1d",
             params: Optional[dict] = None, save: bool = True,
@@ -750,6 +798,12 @@ class Backtester:
                     f"signal column must be in {{-1, 0, 1}} — got "
                     f"unexpected values {sorted(bad.unique().tolist())}"
                 )
+            # #942: apply the live entry transforms (invert_signal, then
+            # direction gating) to the raw signal BEFORE the open snapshot and
+            # the look-ahead shift, so both ``signal_for_open`` and the shifted
+            # ``df["signal"]`` see the gated values. No-op unless --config wired
+            # direction/invert_signal from the live strategy entry.
+            sig_int = self._apply_direction_invert(sig_int, uses_open_close)
             signal_for_open = sig_int
             df["signal"] = sig_int.shift(1).fillna(0).astype(int)
         else:

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -116,6 +116,23 @@ def _apply_user_close_defaults(close_refs: list, user_defaults: Optional[dict]) 
             params["tp_tiers"] = tp
 
 
+def _effective_direction(sc: dict) -> str:
+    """Resolve a strategy entry's effective entry direction (#942).
+
+    Mirrors ``EffectiveDirection`` (scheduler/config.go): direction is
+    meaningful only for ``perps``/``manual`` (other types are long by
+    construction). An explicit ``"long"``/``"short"``/``"both"`` wins; otherwise
+    the legacy ``allow_shorts`` toggle maps absent->``"long"`` / true->``"both"``
+    so pre-v14 configs gate identically to live.
+    """
+    if str(sc.get("type") or "perps") not in ("perps", "manual"):
+        return "long"
+    d = str(sc.get("direction") or "").strip().lower()
+    if d in ("long", "short", "both"):
+        return d
+    return "both" if sc.get("allow_shorts") else "long"
+
+
 def load_strategy_config(config_path: str, strategy_id: str,
                          inject_user_defaults: bool = False) -> dict:
     """Load a single strategy's refs from a live go-trader config (#641).
@@ -136,11 +153,25 @@ def load_strategy_config(config_path: str, strategy_id: str,
     with open(config_path) as fh:
         cfg = _json.load(fh)
     version = int(cfg.get("config_version", 0) or 0)
-    if version < 13:
+    # #942 (D2.8): gate on v15, not v13. The v13 co-located ref shape (#640) is
+    # necessary but not sufficient — the v15 migration is what canonicalizes
+    # close-strategy params on disk (tiers->tp_tiers, atr/multiple/fraction->
+    # atr_multiple/close_fraction; config_migration_v15.go). The Python close
+    # evaluators read ONLY the canonical runtime keys (tier_list_from_params
+    # reads tp_tiers exclusively), so a pre-v15 config passes the old gate while
+    # its legacy close keys silently no-op: explicit tiers are dropped to the
+    # system-default ladder, and --defaults user injects user defaults over the
+    # operator's legacy tiers. Live is unaffected (Go canonicalizes on read), so
+    # backtest and live would silently diverge on the same file. Reject instead.
+    if version < 15:
         raise ValueError(
-            f"{config_path}: config_version={version} predates the co-located "
-            f"strategy ref shape (#640). Run go-trader once against this file "
-            f"to migrate it, then retry."
+            f"{config_path}: config_version={version} predates the v15 "
+            f"close-param canonicalization (tiers->tp_tiers, atr/multiple/"
+            f"fraction->atr_multiple/close_fraction). The backtest close "
+            f"evaluators read only the canonical runtime keys, so a pre-v15 "
+            f"config's legacy close params would silently no-op (diverging from "
+            f"live, which canonicalizes on read). Run go-trader once against "
+            f"this file to migrate it, then retry."
         )
     for sc in cfg.get("strategies", []) or []:
         if sc.get("id") != strategy_id:
@@ -162,6 +193,21 @@ def load_strategy_config(config_path: str, strategy_id: str,
                 f"{config_path}: strategy {strategy_id!r} uses "
                 f"regime_directional_policy, which is HL-live-only in this "
                 f"release (backtester parity deferred — see #779). Use the "
+                f"static `direction` / `invert_signal` fields for backtesting."
+            )
+        # #942 (D2.5): regime_window_divergence (#907) is HL-perps-live-only —
+        # it mutates sc.Direction per-cycle off a live short/medium regime
+        # split, which the bar-level backtester has no resolver hook to mirror.
+        # Unlike its rejected siblings (regime_directional_policy above,
+        # tiered_tp_atr_live_regime_dynamic below) it was silently ignored
+        # rather than rejected, so a divergence-driven flip would backtest the
+        # static config and diverge from live. Reject with the same wording
+        # pattern so the operator sees the gap.
+        if sc.get("regime_window_divergence"):
+            raise ValueError(
+                f"{config_path}: strategy {strategy_id!r} uses "
+                f"regime_window_divergence, which is HL-live-only in this "
+                f"release (backtester parity deferred — see #907). Use the "
                 f"static `direction` / `invert_signal` fields for backtesting."
             )
         # #842: a strategy has a single close_strategy ref. Still accept the
@@ -202,6 +248,27 @@ def load_strategy_config(config_path: str, strategy_id: str,
         # falling through to the evaluators' built-in defaults.
         if inject_user_defaults:
             _apply_user_close_defaults(close_refs, cfg.get("user_close_defaults"))
+        # #942 (D2.1): model the live entry transforms the backtester used to
+        # drop silently. ``invert_signal`` flips BUY<->SELL; ``direction`` gates
+        # which side may open. Both are applied to the signal in Backtester.run
+        # (see _apply_direction_invert), in the live order (invert then gate).
+        direction = _effective_direction(sc)
+        invert_signal = bool(sc.get("invert_signal"))
+        # The plain long/flat signal path (no close evaluator) is structurally
+        # long-only: signal=-1 *closes* a long rather than opening a short. A
+        # short/both direction there can't open the short side, so it would
+        # silently backtest long-only — the exact silent-divergence class this
+        # parity fix closes. Require the open/close engine path (a close
+        # evaluator, which models both open sides) or reject loudly.
+        if not close_refs and direction in ("short", "both"):
+            raise ValueError(
+                f"{config_path}: strategy {strategy_id!r} has "
+                f"direction={direction!r} but no close_strategy. The "
+                f"backtester's plain long/flat signal path cannot open shorts "
+                f"(signal=-1 only closes a long), so the short side would be "
+                f"silently dropped. Add a close_strategy (the open/close engine "
+                f"models both sides) or backtest a long-only variant."
+            )
         return {
             "open_strategy": {
                 "name": open_ref["name"],
@@ -216,6 +283,8 @@ def load_strategy_config(config_path: str, strategy_id: str,
             "stop_loss_atr_regime": sc.get("stop_loss_atr_regime"),
             "trailing_stop_atr_regime": sc.get("trailing_stop_atr_regime"),
             "strategy_type": str(sc.get("type") or "perps"),
+            "direction": direction,
+            "invert_signal": invert_signal,
         }
     raise ValueError(
         f"{config_path}: no strategy with id={strategy_id!r}. "
@@ -246,6 +315,8 @@ def run_single_backtest(
     stop_loss_atr_regime: Optional[dict] = None,
     trailing_stop_atr_regime: Optional[dict] = None,
     strategy_type: str = "perps",
+    direction: Optional[str] = None,
+    invert_signal: bool = False,
 ) -> Optional[dict]:
     """Run a single backtest and print results.
 
@@ -309,6 +380,8 @@ def run_single_backtest(
         stop_loss_atr_regime=stop_loss_atr_regime,
         trailing_stop_atr_regime=trailing_stop_atr_regime,
         strategy_type=strategy_type,
+        direction=direction,
+        invert_signal=invert_signal,
     )
     results = bt.run(
         df_signals,
@@ -615,6 +688,10 @@ def main():
             "stop_loss_atr_regime",
             "trailing_stop_atr_regime",
             "strategy_type",
+            # #942: direction / invert_signal entry transforms, applied to the
+            # signal inside Backtester.run (mirrors live invert-then-gate order).
+            "direction",
+            "invert_signal",
         )
         live_stop_kwargs = {k: live_kwargs[k] for k in stop_keys if k in live_kwargs}
 

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -254,6 +254,26 @@ def load_strategy_config(config_path: str, strategy_id: str,
         # (see _apply_direction_invert), in the live order (invert then gate).
         direction = _effective_direction(sc)
         invert_signal = bool(sc.get("invert_signal"))
+        strategy_type = str(sc.get("type") or "perps")
+        # #942 review: invert_signal is HL-perps/manual-only. LoadConfig
+        # (config.go) REJECTS the config at startup for any other type/platform
+        # because runHyperliquidCheck (applySignalInversion) is its only
+        # consumer — spot/options/futures check scripts emit their own buy/sell
+        # logic that the Go invert never sees. _effective_direction already
+        # forces non-perps types to long-by-construction; without the matching
+        # invert gate a stray invert_signal on a spot/futures --config would
+        # silently flip BUY<->SELL in the backtest (and then mask the inverted
+        # short), producing numbers for a config the live daemon would refuse to
+        # load. Reject it the same way, with the established loud-rejection
+        # pattern, instead of diverging silently.
+        if invert_signal and strategy_type not in ("perps", "manual"):
+            raise ValueError(
+                f"{config_path}: strategy {strategy_id!r} sets invert_signal "
+                f"on type={strategy_type!r}, but invert_signal is HL-perps/"
+                f"manual-only (the live daemon rejects this config at startup — "
+                f"config.go). Remove invert_signal or backtest a perps/manual "
+                f"strategy."
+            )
         # The plain long/flat signal path (no close evaluator) is structurally
         # long-only: signal=-1 *closes* a long rather than opening a short. A
         # short/both direction there can't open the short side, so it would
@@ -282,7 +302,7 @@ def load_strategy_config(config_path: str, strategy_id: str,
             "trailing_stop_pct": sc.get("trailing_stop_pct"),
             "stop_loss_atr_regime": sc.get("stop_loss_atr_regime"),
             "trailing_stop_atr_regime": sc.get("trailing_stop_atr_regime"),
-            "strategy_type": str(sc.get("type") or "perps"),
+            "strategy_type": strategy_type,
             "direction": direction,
             "invert_signal": invert_signal,
         }

--- a/backtest/tests/test_backtester_direction_invert.py
+++ b/backtest/tests/test_backtester_direction_invert.py
@@ -1,0 +1,141 @@
+"""#942: Backtester models the live `invert_signal` and `direction` entry
+transforms instead of silently dropping them.
+
+`_apply_direction_invert` is the single transform point. It mirrors the live
+scheduler ordering — `applySignalInversion` (BUY<->SELL) runs BEFORE
+`EffectiveDirection` / `PerpsOrderSkipReason` gate which side may open — and is
+path-aware because the raw signal means different things in the two engine
+paths:
+
+  • open/close path (a close evaluator drives exits): signal>0 opens long,
+    signal<0 opens short; masking the disallowed open side is exact.
+  • plain long/flat path: signal=1 opens long, signal=-1 only *closes* the long;
+    it is structurally long-only, so direction masking is skipped there (and
+    short/both is rejected at config load — see test_strategy_refs_641).
+"""
+import pandas as pd
+import pytest
+
+from backtester import Backtester
+
+
+# ─── _apply_direction_invert: pure transform mechanics ───────────────────────
+
+
+def _bt(direction=None, invert_signal=False):
+    return Backtester(initial_capital=1000, direction=direction,
+                      invert_signal=invert_signal)
+
+
+def test_invert_signal_negates_in_domain():
+    out = _bt(invert_signal=True)._apply_direction_invert(
+        pd.Series([1, -1, 0, 1]), uses_open_close=True)
+    assert out.tolist() == [-1, 1, 0, -1]
+
+
+def test_no_transform_when_unset():
+    # Default (non --config) callers must be a pure pass-through in both paths.
+    sig = pd.Series([1, -1, 0])
+    assert _bt()._apply_direction_invert(sig, uses_open_close=True).tolist() == [1, -1, 0]
+    assert _bt()._apply_direction_invert(sig, uses_open_close=False).tolist() == [1, -1, 0]
+
+
+def test_direction_long_masks_short_opens_in_open_close_path():
+    out = _bt(direction="long")._apply_direction_invert(
+        pd.Series([1, -1, 0]), uses_open_close=True)
+    assert out.tolist() == [1, 0, 0]  # the -1 short-open is dropped
+
+
+def test_direction_short_masks_long_opens_in_open_close_path():
+    out = _bt(direction="short")._apply_direction_invert(
+        pd.Series([1, -1, 0]), uses_open_close=True)
+    assert out.tolist() == [0, -1, 0]  # the +1 long-open is dropped
+
+
+def test_direction_both_never_masks():
+    out = _bt(direction="both")._apply_direction_invert(
+        pd.Series([1, -1, 0]), uses_open_close=True)
+    assert out.tolist() == [1, -1, 0]
+
+
+def test_direction_long_plain_path_preserves_close_signal():
+    # In the plain long/flat path signal=-1 CLOSES the long. Masking it would
+    # wrongly suppress the exit, so the plain path leaves the signal untouched.
+    out = _bt(direction="long")._apply_direction_invert(
+        pd.Series([1, -1, 0]), uses_open_close=False)
+    assert out.tolist() == [1, -1, 0]
+
+
+def test_invert_runs_before_direction_gating():
+    # Live order: invert flips first, THEN direction gates the resulting open
+    # side. With direction="long" + invert:
+    #   original BUY(+1)  -> invert -> SELL(-1) -> masked (no short open)
+    #   original SELL(-1) -> invert -> BUY(+1)  -> opens long
+    out = _bt(direction="long", invert_signal=True)._apply_direction_invert(
+        pd.Series([1, -1]), uses_open_close=True)
+    assert out.tolist() == [0, 1]
+
+
+# ─── End-to-end: realized trade side reflects the transform ──────────────────
+
+
+def _ohlc(signal):
+    n = len(signal)
+    # Flat prices: a pct close never fires, so the position survives to the
+    # end-of-run flush and the recorded trade carries its OPEN side.
+    return pd.DataFrame(
+        {
+            "open":   [100.0] * n,
+            "high":   [101.0] * n,
+            "low":    [99.0] * n,
+            "close":  [100.0] * n,
+            "volume": [1.0] * n,
+            "signal": signal,
+        },
+        index=pd.date_range("2024-01-01", periods=n, freq="D"),
+    )
+
+
+_NEVER_FIRES_CLOSE = [{"name": "tiered_tp_pct", "params": {"tp_tiers": [
+    {"profit_pct": 0.9, "close_fraction": 1.0},
+]}}]
+
+
+def _run(signal, **kw):
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0.0, slippage_pct=0.0,
+        close_strategies=_NEVER_FIRES_CLOSE, **kw,
+    )
+    return bt.run(_ohlc(signal), save=False)
+
+
+def test_invert_signal_flips_realized_trade_side():
+    # Same signal, opposite realized side once inversion is on (issue 944 #4).
+    base = _run([1, 0, 0, 0], invert_signal=False)
+    inv = _run([1, 0, 0, 0], invert_signal=True)
+    assert [t["side"] for t in base["trades"]] == ["long"]
+    assert [t["side"] for t in inv["trades"]] == ["short"]
+
+
+def test_direction_long_blocks_short_entry_end_to_end():
+    # A short-opening signal under direction="long" opens nothing.
+    blocked = _run([-1, 0, 0, 0], direction="long")
+    allowed = _run([-1, 0, 0, 0], direction="both")
+    assert blocked["trades"] == []
+    assert [t["side"] for t in allowed["trades"]] == ["short"]
+
+
+def test_direction_short_blocks_long_entry_end_to_end():
+    blocked = _run([1, 0, 0, 0], direction="short")
+    allowed = _run([1, 0, 0, 0], direction="both")
+    assert blocked["trades"] == []
+    assert [t["side"] for t in allowed["trades"]] == ["long"]
+
+
+def test_invert_then_direction_opens_long_from_inverted_sell():
+    # direction="long" + invert: original SELL(-1) inverts to BUY(+1) and opens
+    # a long; original BUY(+1) inverts to SELL(-1) and is gated out.
+    inverted_sell = _run([-1, 0, 0, 0], direction="long", invert_signal=True)
+    inverted_buy = _run([1, 0, 0, 0], direction="long", invert_signal=True)
+    assert [t["side"] for t in inverted_sell["trades"]] == ["long"]
+    assert inverted_buy["trades"] == []

--- a/backtest/tests/test_strategy_refs_641.py
+++ b/backtest/tests/test_strategy_refs_641.py
@@ -569,3 +569,117 @@ def test_load_strategy_config_both_with_close_is_allowed(tmp_path):
     ])
     kwargs = run_backtest.load_strategy_config(path, "hl-d-btc")
     assert kwargs["direction"] == "both"
+
+
+# ─── #942 review: spot/futures --config masks shorts (long-by-construction) ──
+#
+# Requires-Human-Review item on PR #951: a non-perps --config with a close
+# evaluator now forces direction='long' (_effective_direction), so the
+# open/close engine path masks short opens. The behavior is more correct (spot
+# can't short) but silently shifts pre-PR spot/futures --config numbers, where a
+# raw signal=-1 used to open an (erroneous) short. These tests pin the kept
+# behavior end-to-end and cover the compound case the masking exposes.
+
+
+_SPOT_NEVER_FIRES_CLOSE = {"name": "tiered_tp_pct", "params": {"tp_tiers": [
+    {"profit_pct": 0.9, "close_fraction": 1.0},
+]}}
+
+
+def _flat_ohlc(signal):
+    # Flat prices so the 90%-profit close never fires: the position survives to
+    # the end-of-run flush and the recorded trade carries its OPEN side.
+    n = len(signal)
+    return pd.DataFrame(
+        {
+            "open":   [100.0] * n,
+            "high":   [101.0] * n,
+            "low":    [99.0] * n,
+            "close":  [100.0] * n,
+            "volume": [1.0] * n,
+            "signal": signal,
+        },
+        index=pd.date_range("2024-01-01", periods=n, freq="D"),
+    )
+
+
+def _spot_close_cfg(tmp_path, strategy_type="spot", **extra):
+    strat = {
+        "id": "sc-x",
+        "type": strategy_type,
+        "open_strategy": {"name": "sma_crossover"},
+        "close_strategy": dict(_SPOT_NEVER_FIRES_CLOSE),
+    }
+    strat.update(extra)
+    return _write_config(tmp_path, version=15, strategies=[strat])
+
+
+def _run_config(path, strategy_id, signal):
+    kwargs = run_backtest.load_strategy_config(path, strategy_id)
+    bt = Backtester(initial_capital=1000, commission_pct=0.0,
+                    slippage_pct=0.0, **kwargs)
+    return bt.run(_flat_ohlc(signal), save=False)
+
+
+@pytest.mark.parametrize("strategy_type", ["spot", "futures"])
+def test_config_non_perps_masks_short_open_end_to_end(tmp_path, strategy_type):
+    # The flagged item: a non-perps --config with a close evaluator forces
+    # direction='long', so a short-opening signal opens NOTHING (not a short).
+    path = _spot_close_cfg(tmp_path, strategy_type=strategy_type)
+    assert _run_config(path, "sc-x", [-1, 0, 0, 0])["trades"] == []
+
+
+@pytest.mark.parametrize("strategy_type", ["spot", "futures"])
+def test_config_non_perps_allows_long_open_end_to_end(tmp_path, strategy_type):
+    # Inverse of the masked case: a long-opening signal is untouched and opens a
+    # long. The mask must not suppress the allowed side.
+    path = _spot_close_cfg(tmp_path, strategy_type=strategy_type)
+    result = _run_config(path, "sc-x", [1, 0, 0, 0])
+    assert [t["side"] for t in result["trades"]] == ["long"]
+
+
+def test_config_spot_stray_direction_short_is_ignored(tmp_path):
+    # A stray direction='short' on a spot strategy is ignored (long-by-
+    # construction, matching EffectiveDirection): a long signal still opens
+    # long, and a short signal is still masked. Direction never makes spot short.
+    path = _spot_close_cfg(tmp_path, direction="short")
+    assert [t["side"] for t in _run_config(path, "sc-x", [1, 0, 0, 0])["trades"]] == ["long"]
+    assert _run_config(path, "sc-x", [-1, 0, 0, 0])["trades"] == []
+
+
+@pytest.mark.parametrize("strategy_type", ["spot", "futures"])
+def test_load_strategy_config_rejects_invert_signal_on_non_perps(tmp_path, strategy_type):
+    # Compound case the masking exposes: invert_signal is HL-perps/manual-only —
+    # live (config.go) rejects the config at startup for any other type. Without
+    # a matching gate the backtester would flip BUY<->SELL (then mask the
+    # inverted short), producing numbers for a config the daemon won't load.
+    path = _write_config(tmp_path, version=15, strategies=[
+        {
+            "id": "inv-x",
+            "type": strategy_type,
+            "open_strategy": {"name": "sma_crossover"},
+            "close_strategy": dict(_SPOT_NEVER_FIRES_CLOSE),
+            "invert_signal": True,
+        },
+    ])
+    with pytest.raises(ValueError, match="invert_signal"):
+        run_backtest.load_strategy_config(path, "inv-x")
+
+
+@pytest.mark.parametrize("strategy_type", ["perps", "manual"])
+def test_load_strategy_config_allows_invert_signal_on_hl_types(tmp_path, strategy_type):
+    # The two HL types that honor invert_signal in live are accepted unchanged.
+    path = _write_config(tmp_path, version=15, strategies=[
+        {
+            "id": "inv-x",
+            "type": strategy_type,
+            "open_strategy": {"name": "tema_cross_bd"},
+            "close_strategy": {"name": "tiered_tp_atr", "params": {"tp_tiers": [
+                {"atr_multiple": 2.0, "close_fraction": 1.0},
+            ]}},
+            "invert_signal": True,
+        },
+    ])
+    kwargs = run_backtest.load_strategy_config(path, "inv-x")
+    assert kwargs["invert_signal"] is True
+    assert kwargs["strategy_type"] == strategy_type

--- a/backtest/tests/test_strategy_refs_641.py
+++ b/backtest/tests/test_strategy_refs_641.py
@@ -136,7 +136,7 @@ def _write_config(tmp_path, version, strategies):
 
 
 def test_load_strategy_config_extracts_refs(tmp_path):
-    path = _write_config(tmp_path, version=13, strategies=[
+    path = _write_config(tmp_path, version=15, strategies=[
         {
             "id": "hl-temacb-btc",
             "type": "perps",
@@ -282,7 +282,10 @@ def test_load_strategy_config_single_close_wins_over_legacy_array(tmp_path):
     assert [r["name"] for r in kwargs["close_strategies"]] == ["tiered_tp_pct"]
 
 
-def test_load_strategy_config_rejects_pre_v13(tmp_path):
+def test_load_strategy_config_rejects_pre_v15_gate(tmp_path):
+    # #942 (D2.8): the loader gates on v15 (not v13) because the v15 migration
+    # canonicalizes close params on disk. A pre-gate version raises before any
+    # ref parsing.
     path = _write_config(tmp_path, version=12, strategies=[
         # Pre-v13 flat shape: open_strategy is a string, params is flat.
         {"id": "hl-temacb-btc", "open_strategy": "tema_cross_bd",
@@ -292,8 +295,34 @@ def test_load_strategy_config_rejects_pre_v13(tmp_path):
         run_backtest.load_strategy_config(path, "hl-temacb-btc")
 
 
+@pytest.mark.parametrize("version", [13, 14])
+def test_load_strategy_config_rejects_pre_v15_with_legacy_tiers(tmp_path, version):
+    # #942 (D2.8) regression: a v13/v14 config still carries pre-canonicalization
+    # close keys (legacy `tiers` rather than `tp_tiers`, `atr_multiple` written
+    # as `atr`). The Python close evaluators read ONLY the canonical runtime
+    # keys, so these would silently no-op (explicit tiers dropped to the system
+    # default; --defaults user injecting over them) while live canonicalizes on
+    # read. The v15 gate must reject the file instead of running it.
+    path = _write_config(tmp_path, version=version, strategies=[
+        {
+            "id": "hl-temacb-btc",
+            "type": "perps",
+            "open_strategy": {"name": "tema_cross_bd"},
+            "close_strategy": {"name": "tiered_tp_atr", "params": {
+                # Legacy on-disk shape the v15 migration rewrites:
+                "tiers": [
+                    {"atr": 2.0, "fraction": 0.5},
+                    {"atr": 3.0, "fraction": 1.0},
+                ],
+            }},
+        },
+    ])
+    with pytest.raises(ValueError, match=f"config_version={version}"):
+        run_backtest.load_strategy_config(path, "hl-temacb-btc")
+
+
 def test_load_strategy_config_rejects_unknown_id(tmp_path):
-    path = _write_config(tmp_path, version=13, strategies=[
+    path = _write_config(tmp_path, version=15, strategies=[
         {"id": "hl-temacb-btc",
          "open_strategy": {"name": "tema_cross_bd"},
          "close_strategies": []},
@@ -303,7 +332,7 @@ def test_load_strategy_config_rejects_unknown_id(tmp_path):
 
 
 def test_load_strategy_config_rejects_dynamic_regime_close_single(tmp_path):
-    path = _write_config(tmp_path, version=13, strategies=[
+    path = _write_config(tmp_path, version=15, strategies=[
         {
             "id": "hl-dyn-btc",
             "open_strategy": {"name": "tema_cross_bd"},
@@ -315,7 +344,7 @@ def test_load_strategy_config_rejects_dynamic_regime_close_single(tmp_path):
 
 
 def test_load_strategy_config_rejects_dynamic_regime_close_legacy_array(tmp_path):
-    path = _write_config(tmp_path, version=13, strategies=[
+    path = _write_config(tmp_path, version=15, strategies=[
         {
             "id": "hl-dyn-btc",
             "open_strategy": {"name": "tema_cross_bd"},
@@ -331,7 +360,7 @@ def test_load_strategy_config_rejects_dynamic_regime_close_legacy_array(tmp_path
 def test_load_strategy_config_then_backtester_parity(tmp_path):
     """Same JSON block produces same Backtester wiring as constructing the
     refs by hand. This is the live↔backtest parity contract from the issue."""
-    path = _write_config(tmp_path, version=13, strategies=[
+    path = _write_config(tmp_path, version=15, strategies=[
         {
             "id": "hl-temacb-btc",
             "open_strategy": {"name": "tema_cross_bd", "params": {"short_period": 5}},
@@ -361,7 +390,7 @@ def test_config_flag_threads_live_open_params_to_result(tmp_path, monkeypatch):
     registry's default_params. Regression for #643 review #1.
     """
     # Real strategy that has overridable defaults: triple_ema (default short=8).
-    config_path = _write_config(tmp_path, version=13, strategies=[
+    config_path = _write_config(tmp_path, version=15, strategies=[
         {
             "id": "hl-triple-btc",
             "type": "perps",
@@ -411,7 +440,7 @@ def test_config_flag_rejects_non_single_modes(tmp_path):
     """--config loads exactly one strategy; rejecting compare/multi/optimize
     upfront prevents misleading reports where only the matched strategy gets
     the live close refs and the rest run with no close strategies (#643 review #4)."""
-    config_path = _write_config(tmp_path, version=13, strategies=[
+    config_path = _write_config(tmp_path, version=15, strategies=[
         {"id": "x", "open_strategy": {"name": "triple_ema"}, "close_strategies": []},
     ])
     import sys as _sys
@@ -424,3 +453,119 @@ def test_config_flag_rejects_non_single_modes(tmp_path):
                 run_backtest.main()
         finally:
             _sys.argv = old_argv
+
+
+# ─── #942: direction / invert_signal / regime_window_divergence parity ───────
+
+
+def _perps_strategy(strategy_id="hl-d-btc", **extra):
+    base = {
+        "id": strategy_id,
+        "type": "perps",
+        "open_strategy": {"name": "tema_cross_bd"},
+        "close_strategy": {"name": "tiered_tp_atr", "params": {"tp_tiers": [
+            {"atr_multiple": 2.0, "close_fraction": 1.0},
+        ]}},
+    }
+    base.update(extra)
+    return base
+
+
+def test_load_strategy_config_returns_direction_and_invert(tmp_path):
+    path = _write_config(tmp_path, version=15, strategies=[
+        _perps_strategy(direction="short", invert_signal=True),
+    ])
+    kwargs = run_backtest.load_strategy_config(path, "hl-d-btc")
+    assert kwargs["direction"] == "short"
+    assert kwargs["invert_signal"] is True
+
+
+def test_load_strategy_config_direction_defaults_long(tmp_path):
+    # No direction field on a perps strategy → effective "long" (matches
+    # EffectiveDirection); invert_signal defaults False.
+    path = _write_config(tmp_path, version=15, strategies=[_perps_strategy()])
+    kwargs = run_backtest.load_strategy_config(path, "hl-d-btc")
+    assert kwargs["direction"] == "long"
+    assert kwargs["invert_signal"] is False
+
+
+def test_load_strategy_config_allow_shorts_maps_to_both(tmp_path):
+    # Legacy pre-v14 toggle: allow_shorts=true with no explicit direction →
+    # "both" (mirrors EffectiveDirection's AllowShorts fallback).
+    path = _write_config(tmp_path, version=15, strategies=[
+        _perps_strategy(allow_shorts=True),
+    ])
+    kwargs = run_backtest.load_strategy_config(path, "hl-d-btc")
+    assert kwargs["direction"] == "both"
+
+
+def test_load_strategy_config_spot_direction_is_long(tmp_path):
+    # direction is meaningful only for perps/manual; a spot strategy is long by
+    # construction even if a stray direction field is present.
+    path = _write_config(tmp_path, version=15, strategies=[
+        {
+            "id": "spot-x",
+            "type": "spot",
+            "open_strategy": {"name": "sma_crossover"},
+            "direction": "short",
+        },
+    ])
+    kwargs = run_backtest.load_strategy_config(path, "spot-x")
+    assert kwargs["direction"] == "long"
+
+
+def test_load_strategy_config_rejects_regime_window_divergence(tmp_path):
+    # #942 (D2.5): regime_window_divergence (#907) is HL-live-only and was
+    # silently ignored; the loader must reject it loudly like its siblings.
+    path = _write_config(tmp_path, version=15, strategies=[
+        _perps_strategy(regime_window_divergence={
+            "short_window": "short", "medium_window": "medium",
+            "on_divergence": {"mode": "trust_short"},
+        }),
+    ])
+    with pytest.raises(ValueError, match="regime_window_divergence"):
+        run_backtest.load_strategy_config(path, "hl-d-btc")
+
+
+@pytest.mark.parametrize("direction", ["short", "both"])
+def test_load_strategy_config_rejects_short_or_both_without_close(tmp_path, direction):
+    # The plain long/flat signal path cannot open shorts, so a short/both
+    # direction with no close evaluator would silently drop the short side.
+    # Reject instead of backtesting long-only.
+    path = _write_config(tmp_path, version=15, strategies=[
+        {
+            "id": "hl-noclose",
+            "type": "perps",
+            "open_strategy": {"name": "tema_cross_bd"},
+            "direction": direction,
+            # No close_strategy → plain long/flat path.
+        },
+    ])
+    with pytest.raises(ValueError, match="cannot open shorts"):
+        run_backtest.load_strategy_config(path, "hl-noclose")
+
+
+def test_load_strategy_config_long_without_close_is_allowed(tmp_path):
+    # direction="long" + no close evaluator is fine: the plain long/flat path
+    # is already long-only and matches live (signal=-1 closes the long).
+    path = _write_config(tmp_path, version=15, strategies=[
+        {
+            "id": "hl-longnoclose",
+            "type": "perps",
+            "open_strategy": {"name": "tema_cross_bd"},
+            "direction": "long",
+        },
+    ])
+    kwargs = run_backtest.load_strategy_config(path, "hl-longnoclose")
+    assert kwargs["direction"] == "long"
+    assert kwargs["close_strategies"] == []
+
+
+def test_load_strategy_config_both_with_close_is_allowed(tmp_path):
+    # direction="both" WITH a close evaluator uses the open/close engine path,
+    # which opens both sides — allowed.
+    path = _write_config(tmp_path, version=15, strategies=[
+        _perps_strategy(direction="both"),
+    ])
+    kwargs = run_backtest.load_strategy_config(path, "hl-d-btc")
+    assert kwargs["direction"] == "both"


### PR DESCRIPTION
Closes #942 (consolidates #943).

**Part 1 (D2.8)**: bump the --config gate to config_version 15 so pre-v15 legacy close keys (tiers/atr/multiple/fraction) cannot silently no-op vs live.

**Part 2 (D2.1/D2.5)**: apply direction + invert_signal inside Backtester.run (invert before direction gating, path-aware masking); reject short/both with no close evaluator; reject regime_window_divergence (#907) loudly.

**Behavior-change note (spot/futures `--config`)**: `_effective_direction` returns `"long"` for non-perps types (they are long-by-construction in live, matching `EffectiveDirection`). For a spot/futures `--config` backtest that has a close evaluator (the open/close engine path), this now masks `signal<0` short-opens — those `-1`s previously opened erroneous shorts, so existing spot/futures `--config` numbers can shift. The new behavior is the correct one (spot can't short) and is pinned by end-to-end regression tests. The compound case this exposes — a stray `invert_signal` on a non-perps `--config` — is now rejected at load to mirror live, where `LoadConfig` (config.go) refuses such a config at startup (`invert_signal` is HL-perps/manual-only); previously the backtester would have silently applied the inversion.

All Python tests pass (`shared_strategies/ shared_tools/ backtest/`: 953 passed).

---
LLM: Claude Opus 4.8 (1M) | xhigh | Harness: anthropics/claude-code-action@v1
