### PR TITLE
test+debt(backtest): pin tier ladders, composite regime labels, theta coverage (#944)

### DIFF
--- a/backtest/backtest_theta.py
+++ b/backtest/backtest_theta.py
@@ -282,6 +282,15 @@ class ThetaHarvestBacktester:
 
         win_rate = (self.winning_trades / self.total_trades * 100) if self.total_trades > 0 else 0
 
+        # DAILY-SAMPLING CONSTRAINT: this metrics block assumes one equity-curve
+        # point per calendar day. That holds because ``main`` always feeds
+        # ``fetch_historical_data`` which returns 1d candles, and ``run`` appends
+        # exactly one equity point per candle. So ``len(self.equity_curve)`` IS the
+        # day count, and the ``sqrt(365)`` Sharpe annualization below is correct.
+        # If this backtester is ever switched to a sub-daily timeframe, replace
+        # ``days = len(...)`` with calendar-day elapsed and ``sqrt(365)`` with
+        # ``sqrt(periods_per_year(timeframe))`` — mirror backtest_options.py's
+        # ``_elapsed_days`` / ``periods_per_year`` approach. See issue #944.
         days = len(self.equity_curve)
         years = days / 365
         ann_return = ((final_value / self.initial_capital) ** (1 / years) - 1) * 100 if years > 0 and final_value > 0 else 0
@@ -298,6 +307,7 @@ class ThetaHarvestBacktester:
             if rets:
                 avg = sum(rets) / len(rets)
                 std = math.sqrt(sum((r - avg)**2 for r in rets) / len(rets))
+                # sqrt(365): daily returns → annualized (see daily-sampling note above).
                 sharpe = (avg / std * math.sqrt(365)) if std > 0 else 0
 
         return {

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -62,10 +62,8 @@ decision-layer parity checks; see ``backtest/AUDIT.md`` for the full matrix):
 
 import sys
 import os
-import json
 import math
-from datetime import datetime
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Optional, Tuple
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
 

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -480,23 +480,12 @@ DEFAULT_PARAM_RANGES = {
         "rally_window": [3, 5, 8],
         "rally_touch_buffer_pct": [0.0005, 0.001, 0.002],
     },
-    "tp_at_pct": {
-        "pct": [0.01, 0.03, 0.05],
-    },
-    "tiered_tp_pct": {
-        "tiers": [
-            [{"profit_pct": 0.02, "close_fraction": 0.5}, {"profit_pct": 0.04, "close_fraction": 1.0}],
-            [{"profit_pct": 0.03, "close_fraction": 0.5}, {"profit_pct": 0.06, "close_fraction": 1.0}],
-            [{"profit_pct": 0.05, "close_fraction": 0.5}, {"profit_pct": 0.1, "close_fraction": 1.0}],
-        ],
-    },
-    "tiered_tp_atr": {
-        "tiers": [
-            [{"atr_multiple": 1.0, "close_fraction": 0.5}, {"atr_multiple": 2.0, "close_fraction": 1.0}],
-            [{"atr_multiple": 1.5, "close_fraction": 0.5}, {"atr_multiple": 3.0, "close_fraction": 1.0}],
-            [{"atr_multiple": 2.0, "close_fraction": 0.5}, {"atr_multiple": 4.0, "close_fraction": 1.0}],
-        ],
-    },
+    # NOTE: close-evaluator names (tp_at_pct, tiered_tp_pct, tiered_tp_atr, …) are
+    # intentionally absent here. run_optimize only sweeps OPEN-registry strategy
+    # params (it builds the entry signal via the open registry), so any close-param
+    # grid keyed by a close name would be dead weight — unreachable and never swept.
+    # Wiring real close-param optimization is a separate feature (#944); until then
+    # do not re-add close names to DEFAULT_PARAM_RANGES.
     # Futures-only
     "breakout": {
         "lookback": [10, 20, 30],

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -481,9 +481,10 @@ DEFAULT_PARAM_RANGES = {
         "rally_touch_buffer_pct": [0.0005, 0.001, 0.002],
     },
     # NOTE: close-evaluator names (tp_at_pct, tiered_tp_pct, tiered_tp_atr, …) are
-    # intentionally absent here. run_optimize only sweeps OPEN-registry strategy
-    # params (it builds the entry signal via the open registry), so any close-param
-    # grid keyed by a close name would be dead weight — unreachable and never swept.
+    # intentionally absent here. walk_forward_optimize only sweeps OPEN-registry
+    # strategy params (it builds the entry signal via the open registry), so any
+    # close-param grid keyed by a close name would be dead weight — unreachable and
+    # never swept.
     # Wiring real close-param optimization is a separate feature (#944); until then
     # do not re-add close names to DEFAULT_PARAM_RANGES.
     # Futures-only

--- a/backtest/tests/test_backtest_theta_branches.py
+++ b/backtest/tests/test_backtest_theta_branches.py
@@ -1,0 +1,213 @@
+"""Branch coverage for ThetaHarvestBacktester early-exit + metrics (issue #944).
+
+Before this, the only theta test was ``test_theta_force_close_emits_trade_log_entries``
+(end-of-run force-close). The three early-exit branches in ``_check_early_exit``
+— profit target, stop loss, DTE floor — and the ``_report`` metrics block had
+no coverage. These tests drive ``_check_early_exit`` directly with constructed
+``OptionPosition`` objects so each branch is hit deterministically (no reliance
+on synthetic price paths landing in a particular regime), and exercise
+``_report`` with a known equity curve to pin the metrics arithmetic.
+"""
+import os
+import sys
+from datetime import datetime, timedelta
+
+import pytest
+
+_BACKTEST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _BACKTEST_DIR not in sys.path:
+    sys.path.insert(0, _BACKTEST_DIR)
+
+from backtest_options import OptionPosition  # noqa: E402
+from backtest_theta import ThetaHarvestBacktester  # noqa: E402
+
+
+_HIST_VOL = 0.6
+_DATE = "2023-06-01"
+
+
+def _bt(**kw) -> ThetaHarvestBacktester:
+    base = dict(
+        initial_capital=10_000.0, max_positions=2,
+        profit_target_pct=0, stop_loss_pct=0, min_dte_close=0, label="t",
+    )
+    base.update(kw)
+    return ThetaHarvestBacktester(**base)
+
+
+# ─── Profit-target (theta harvest) branch ────────────────────────────────────
+
+
+def test_profit_target_branch_closes_and_logs_theta_harvest():
+    """A sold deep-OTM call near expiry buys back for ~0 → ~100% profit, which
+    clears a 60% profit target. The early-close branch must fire, count an
+    ``early_close`` win, and append a ``theta_harvest`` trade-log entry."""
+    bt = _bt(profit_target_pct=60)
+    # strike 60k vs spot 20k, 2 days left → buyback ≈ 0 (confirmed via BS probe).
+    pos = OptionPosition("call", "sell", 60_000.0, expiry_idx=2,
+                         premium=0.005, premium_usd=100.0, opened_idx=0)
+    closed = bt._check_early_exit(pos, spot=20_000.0, current_idx=0,
+                                  hist_vol=_HIST_VOL, date=_DATE)
+    assert closed is True
+    assert bt.early_closes == 1
+    assert bt.stop_losses == 0 and bt.dte_closes == 0
+    assert bt.total_trades == 1 and bt.winning_trades == 1
+    entry = bt.trade_log[-1]
+    assert entry["event"] == "theta_harvest"
+    assert entry["action"] == "close_sell"
+    assert entry["reason"].startswith("profit_target")
+    assert entry["profit_pct"] >= 60
+
+
+# ─── Stop-loss branch ────────────────────────────────────────────────────────
+
+
+def test_stop_loss_branch_closes_and_logs_stop_loss():
+    """A sold deep-ITM call buys back far above the premium collected → a large
+    loss that clears the 150% stop. The stop branch must fire (the profit-target
+    branch is checked first but a negative profit can't satisfy it), count a
+    loss, and log a ``stop_loss`` event."""
+    bt = _bt(profit_target_pct=60, stop_loss_pct=150)
+    # strike 12k vs spot 20k, 20 days left → buyback ≈ 8033 ≫ premium 200.
+    pos = OptionPosition("call", "sell", 12_000.0, expiry_idx=20,
+                         premium=0.01, premium_usd=200.0, opened_idx=0)
+    closed = bt._check_early_exit(pos, spot=20_000.0, current_idx=0,
+                                  hist_vol=_HIST_VOL, date=_DATE)
+    assert closed is True
+    assert bt.stop_losses == 1
+    assert bt.early_closes == 0 and bt.dte_closes == 0
+    assert bt.total_trades == 1 and bt.losing_trades == 1
+    entry = bt.trade_log[-1]
+    assert entry["event"] == "stop_loss"
+    assert entry["reason"].startswith("stop_loss")
+    assert entry["loss_pct"] >= 150
+    assert entry["pnl"] < 0
+
+
+# ─── DTE-floor branch ────────────────────────────────────────────────────────
+
+
+def test_dte_floor_branch_closes_and_logs_dte_close():
+    """With profit-target and stop disabled, a position inside the DTE floor
+    must close via the DTE branch only."""
+    bt = _bt(profit_target_pct=0, stop_loss_pct=0, min_dte_close=5)
+    # 2 days left ≤ 5-day floor.
+    pos = OptionPosition("call", "sell", 25_000.0, expiry_idx=2,
+                         premium=0.005, premium_usd=100.0, opened_idx=0)
+    closed = bt._check_early_exit(pos, spot=20_000.0, current_idx=0,
+                                  hist_vol=_HIST_VOL, date=_DATE)
+    assert closed is True
+    assert bt.dte_closes == 1
+    assert bt.early_closes == 0 and bt.stop_losses == 0
+    assert bt.total_trades == 1
+    assert bt.winning_trades + bt.losing_trades == 1
+    entry = bt.trade_log[-1]
+    assert entry["event"] == "dte_close"
+    assert entry["reason"].startswith("dte_floor")
+    assert entry["days_left"] == 2
+
+
+# ─── No-exit / guard paths ───────────────────────────────────────────────────
+
+
+def test_no_branch_fires_when_within_bounds_leaves_position_open():
+    """Modest profit below target, no stop, no DTE floor → position stays open
+    and no counters move."""
+    bt = _bt(profit_target_pct=90, stop_loss_pct=300, min_dte_close=0)
+    # ATM-ish call with time left → buyback meaningfully > 0 but < entry premium.
+    pos = OptionPosition("call", "sell", 21_000.0, expiry_idx=30,
+                         premium=0.02, premium_usd=2_000.0, opened_idx=0)
+    closed = bt._check_early_exit(pos, spot=20_000.0, current_idx=0,
+                                  hist_vol=_HIST_VOL, date=_DATE)
+    assert closed is False
+    assert bt.total_trades == 0 and not bt.trade_log
+
+
+def test_bought_option_is_never_early_closed():
+    """``_check_early_exit`` only manages sold premium — a bought leg returns
+    False immediately regardless of price."""
+    bt = _bt(profit_target_pct=10, stop_loss_pct=10, min_dte_close=100)
+    pos = OptionPosition("call", "buy", 60_000.0, expiry_idx=2,
+                         premium=0.005, premium_usd=100.0, opened_idx=0)
+    closed = bt._check_early_exit(pos, spot=20_000.0, current_idx=0,
+                                  hist_vol=_HIST_VOL, date=_DATE)
+    assert closed is False
+    assert bt.total_trades == 0
+
+
+def test_zero_premium_position_is_skipped():
+    """A degenerate sold leg with zero entry premium can't compute a profit
+    percentage → guarded out, returns False."""
+    bt = _bt(profit_target_pct=60, stop_loss_pct=150, min_dte_close=5)
+    pos = OptionPosition("call", "sell", 60_000.0, expiry_idx=2,
+                         premium=0.0, premium_usd=0.0, opened_idx=0)
+    closed = bt._check_early_exit(pos, spot=20_000.0, current_idx=0,
+                                  hist_vol=_HIST_VOL, date=_DATE)
+    assert closed is False
+    assert bt.total_trades == 0
+
+
+# ─── Metrics block (_report) ─────────────────────────────────────────────────
+
+
+def test_report_metrics_block_computes_expected_fields():
+    """Pin the ``_report`` arithmetic against a known equity curve and tallies.
+    Daily sampling (one equity point per calendar day) makes ``days`` the curve
+    length — the constraint documented in backtest_theta.py's metrics block."""
+    bt = _bt(initial_capital=10_000.0, profit_target_pct=60,
+             stop_loss_pct=150, min_dte_close=2)
+    bt.cash = 11_000.0  # +10% final
+    bt.total_trades = 4
+    bt.winning_trades = 3
+    bt.losing_trades = 1
+    bt.early_closes = 2
+    bt.stop_losses = 1
+    bt.dte_closes = 1
+    bt.total_premium_collected = 500.0
+
+    start = datetime(2023, 1, 1)
+    n = 366  # one point per day across a ~1-year span
+    bt.equity_curve = [
+        ((start + timedelta(days=i)).strftime("%Y-%m-%d"),
+         10_000.0 + (1_000.0 * i / (n - 1)))
+        for i in range(n)
+    ]
+    start_date = bt.equity_curve[0][0]
+    end_date = bt.equity_curve[-1][0]
+
+    report = bt._report("BTC", start_date, end_date, 20_000.0, 22_000.0)
+
+    assert report["label"] == "t"
+    assert report["underlying"] == "BTC"
+    assert report["days"] == n  # daily-sampling: curve length == day count
+    assert report["initial_capital"] == 10_000.0
+    assert report["final_value"] == pytest.approx(11_000.0)
+    assert report["total_return_pct"] == pytest.approx(10.0)
+    assert report["buy_hold_return_pct"] == pytest.approx(10.0)
+    assert report["annualized_return_pct"] == pytest.approx(10.0, abs=0.5)
+    assert report["win_rate_pct"] == pytest.approx(75.0)
+    assert report["total_trades"] == 4
+    assert report["winning_trades"] == 3
+    assert report["losing_trades"] == 1
+    assert report["early_closes"] == 2
+    assert report["stop_losses"] == 1
+    assert report["dte_closes"] == 1
+    assert report["total_premium_collected"] == pytest.approx(500.0)
+    assert report["max_drawdown_pct"] == pytest.approx(0.0)  # monotonic curve
+    # Daily Sharpe: positive on a monotone-up curve, and finite.
+    assert isinstance(report["sharpe_ratio"], float)
+    assert report["sharpe_ratio"] >= 0
+    # Config echo-back preserved.
+    assert report["profit_target_pct"] == 60
+    assert report["stop_loss_pct"] == 150
+    assert report["min_dte_close"] == 2
+
+
+def test_report_zero_trades_yields_zero_win_rate():
+    """No trades → win-rate divisor guard returns 0, not a ZeroDivisionError."""
+    bt = _bt()
+    bt.cash = 10_000.0
+    bt.equity_curve = [("2023-01-01", 10_000.0), ("2023-01-02", 10_000.0)]
+    report = bt._report("BTC", "2023-01-01", "2023-01-02", 20_000.0, 20_000.0)
+    assert report["win_rate_pct"] == 0
+    assert report["total_trades"] == 0

--- a/backtest/tests/test_backtester_composite_regime.py
+++ b/backtest/tests/test_backtester_composite_regime.py
@@ -1,0 +1,162 @@
+"""Per-label entry-gate coverage for the composite (7-state) regime vocabulary.
+
+Issue #944 D3.2: ``backtest/tests/`` had ZERO references to the composite
+labels (``ranging_quiet``, ``ranging_volatile``, ``ranging_directional``,
+``trending_{up,down}_{clean,choppy}``). The ADX (3-state) gate is covered in
+test_backtester_regime.py, but the composite labels — the only ones a strategy
+can name in ``allowed_regimes`` when ``classifier="composite"`` — were never
+exercised through ``Backtester(regime_enabled=True)``.
+
+These tests drive the gate directly off a pre-supplied ``regime`` column (the
+same mechanism live uses: ``ensure_regime_columns`` writes the label, the
+backtester only gates on it). That keeps the per-label assertions deterministic
+instead of hoping synthetic OHLCV lands on a particular composite bucket.
+
+Gate contract (backtester.py): with ``regime_enabled=True`` and a non-empty
+``allowed_regimes``, an entry signal is blocked when the bar's (shifted) regime
+label is not in ``allowed_regimes``; closes are never gated. Signals shift +1
+bar, and the regime column shifts +1 in lockstep, so a column set uniformly to
+one label gates every entry on that label.
+"""
+import sys
+import pathlib
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / "shared_tools"))
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from backtester import Backtester
+from regime import VALID_LABELS_COMPOSITE
+
+
+# Stable ordering for parametrization / picking a distinct "other" label.
+COMPOSITE_LABELS = sorted(VALID_LABELS_COMPOSITE)
+
+
+def _gated_df(label: str, n: int = 100, buy_at: int = 50) -> pd.DataFrame:
+    """Uptrend OHLCV with a single buy signal at ``buy_at`` and the ``regime``
+    column pinned uniformly to ``label`` (so the shifted gate reads ``label``
+    at the entry bar)."""
+    close = np.linspace(100.0, 200.0, n)
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame(
+        {"open": close, "high": close + 0.5, "low": close - 0.5,
+         "close": close, "volume": 1000.0},
+        index=idx,
+    )
+    df["signal"] = 0
+    df.iloc[buy_at, df.columns.get_loc("signal")] = 1
+    df["regime"] = label
+    return df
+
+
+# ─── Each composite label: matching gate ALLOWS the entry ────────────────────
+
+
+@pytest.mark.parametrize("label", COMPOSITE_LABELS)
+def test_composite_label_allows_entry_when_gate_matches(label):
+    df = _gated_df(label)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, allowed_regimes=[label],
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] >= 1, (
+        f"Composite label '{label}' in allowed_regimes should permit the entry"
+    )
+
+
+# ─── Each composite label: a DIFFERENT gate BLOCKS the entry ─────────────────
+
+
+@pytest.mark.parametrize("label", COMPOSITE_LABELS)
+def test_composite_label_blocks_entry_when_gate_mismatches(label):
+    # Pick any distinct label to gate on — the bar is ``label`` so it must block.
+    other = next(l for l in COMPOSITE_LABELS if l != label)
+    df = _gated_df(label)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, allowed_regimes=[other],
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] == 0, (
+        f"Bar regime '{label}' must be blocked when only '{other}' is allowed"
+    )
+
+
+# ─── Multi-label allow-list: any member permits the entry ────────────────────
+
+
+@pytest.mark.parametrize("label", COMPOSITE_LABELS)
+def test_composite_label_allowed_within_multi_label_gate(label):
+    """A realistic ``allowed_regimes`` names several composite buckets; the bar's
+    label being any one of them permits the entry."""
+    allow = [label] + [l for l in COMPOSITE_LABELS if l != label][:2]
+    df = _gated_df(label)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, allowed_regimes=allow,
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] >= 1
+
+
+# ─── Trend-family separation: trending_up_clean ≠ trending_up_choppy ──────────
+
+
+def test_clean_and_choppy_variants_are_distinct_gates():
+    """``trending_up_clean`` and ``trending_up_choppy`` are SEPARATE labels —
+    a gate naming only the clean variant must block a choppy bar (and vice
+    versa). Guards against any prefix/substring matching creeping into the gate.
+    """
+    df_choppy = _gated_df("trending_up_choppy")
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, allowed_regimes=["trending_up_clean"],
+    )
+    assert bt.run(df_choppy, save=False)["total_trades"] == 0
+
+    df_clean = _gated_df("trending_up_clean")
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, allowed_regimes=["trending_up_choppy"],
+    )
+    assert bt.run(df_clean, save=False)["total_trades"] == 0
+
+
+# ─── ranging_directional is gated independently of the trending labels ───────
+
+
+def test_ranging_directional_blocked_by_trending_gate():
+    """``ranging_directional`` carries direction in its name but is a RANGING
+    bucket — a trending-only gate must still block it."""
+    df = _gated_df("ranging_directional")
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True,
+        allowed_regimes=["trending_up_clean", "trending_down_clean"],
+    )
+    assert bt.run(df, save=False)["total_trades"] == 0
+
+
+# ─── Open position is held across a composite-regime flip (closes not gated) ──
+
+
+def test_composite_regime_flip_does_not_close_open_position():
+    """Once long, a flip from an allowed composite label to a disallowed one
+    must NOT force a close — the gate is entry-only."""
+    df = _gated_df("trending_up_clean", n=100)
+    # Signal at bar 50 → fills at bar 51; keep the allowed label through bar 51,
+    # then flip to a disallowed ranging label from bar 52 onward.
+    df["regime"] = "trending_up_clean"
+    df.iloc[52:, df.columns.get_loc("regime")] = "ranging_volatile"
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, allowed_regimes=["trending_up_clean"],
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] > 0

--- a/backtest/tests/test_default_tier_ladders.py
+++ b/backtest/tests/test_default_tier_ladders.py
@@ -1,0 +1,146 @@
+"""Default tiered-TP ATR ladder must agree across all three sources of truth.
+
+The fallback ladder used when a ``tiered_tp_atr*`` close ref omits explicit
+tiers lives in THREE places that must stay byte-for-byte identical:
+
+  • Go   — ``defaultHLProtectionTiers()`` in scheduler/hyperliquid_protection.go
+           (the on-chain reduce-only TP source of truth; #870)
+  • Py   — ``DEFAULT_TIERS`` in shared_strategies/close/tiered_tp_atr.py
+           (paper + backtest scale-out for tiered_tp_atr / tiered_tp_atr_live)
+  • Py   — ``_DEFAULT_SCALAR_TP_TIERS`` in shared_strategies/close/post_tp_sl.py
+           (the ``tp_atr_fraction`` firing-tier multiple is derived from this)
+
+Today all three are 1.5×/3×/5× @ 40%/80%/100% cumulative. A retune that
+updates one mirror but misses another silently desyncs live on-chain TP
+placement from paper/backtest scale-outs. This test (mirroring the parity
+style of test_platform_fees.py) pins the literal and cross-checks all three
+so the suite fails the moment they drift. If you intentionally retune the
+ladder, update ALL THREE sources AND the ``EXPECTED_LADDER`` below together.
+"""
+import importlib.util
+import os
+import re
+import sys
+
+import pytest
+
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+_CLOSE_DIR = os.path.join(_REPO_ROOT, "shared_strategies", "close")
+_HYPERLIQUID_PROTECTION_GO = os.path.join(
+    _REPO_ROOT, "scheduler", "hyperliquid_protection.go"
+)
+
+# The canonical ladder as (atr_multiple, cumulative_close_fraction) pairs.
+# Mirror of #870's patient 3-rung scale-out. If a real retune lands, change
+# this AND all three sources scraped/imported below in the same commit.
+EXPECTED_LADDER = (
+    (1.5, 0.40),
+    (3.0, 0.80),
+    (5.0, 1.00),
+)
+
+
+def _load_close_module(filename: str, attr: str, mod_name: str):
+    """Load a module under shared_strategies/close via spec_from_file_location
+    (sidesteps the open/close registry.py name collision) with both the repo
+    root and the close dir on sys.path so absolute/relative imports resolve."""
+    for p in (_REPO_ROOT, _CLOSE_DIR):
+        if p not in sys.path:
+            sys.path.insert(0, p)
+    path = os.path.join(_CLOSE_DIR, filename)
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return getattr(mod, attr)
+
+
+def _python_tiered_tp_atr_ladder():
+    """``DEFAULT_TIERS`` from tiered_tp_atr.py as (mult, frac) pairs."""
+    raw = _load_close_module(
+        "tiered_tp_atr.py", "DEFAULT_TIERS", "_ladder_probe_tiered_tp_atr"
+    )
+    return tuple(
+        (float(t["atr_multiple"]), float(t["close_fraction"])) for t in raw
+    )
+
+
+def _python_scalar_tp_ladder():
+    """``_DEFAULT_SCALAR_TP_TIERS`` from post_tp_sl.py as (mult, frac) pairs."""
+    raw = _load_close_module(
+        "post_tp_sl.py", "_DEFAULT_SCALAR_TP_TIERS", "_ladder_probe_post_tp_sl"
+    )
+    return tuple((float(m), float(f)) for m, f in raw)
+
+
+def _go_default_protection_tiers():
+    """Scrape ``defaultHLProtectionTiers()`` from hyperliquid_protection.go and
+    parse its ``{Multiple: X, Fraction: Y}`` rows into (mult, frac) pairs."""
+    text = open(_HYPERLIQUID_PROTECTION_GO, encoding="utf-8").read()
+    body = re.search(
+        r"func defaultHLProtectionTiers\(\)\s*\[\]hlProtectionTier\s*\{(.*?)\n\}",
+        text,
+        re.DOTALL,
+    )
+    assert body, "defaultHLProtectionTiers() not found in hyperliquid_protection.go"
+    rows = re.findall(
+        r"\{\s*Multiple:\s*([0-9.]+),\s*Fraction:\s*([0-9.]+)\s*\}", body.group(1)
+    )
+    assert rows, "no {Multiple:..,Fraction:..} rows parsed from the Go ladder"
+    return tuple((float(m), float(f)) for m, f in rows)
+
+
+# ─── Each source matches the pinned expectation ──────────────────────────────
+
+
+def test_python_tiered_tp_atr_default_tiers_match_expected():
+    assert _python_tiered_tp_atr_ladder() == EXPECTED_LADDER
+
+
+def test_python_scalar_tp_tiers_match_expected():
+    assert _python_scalar_tp_ladder() == EXPECTED_LADDER
+
+
+def test_go_default_protection_tiers_match_expected():
+    assert _go_default_protection_tiers() == EXPECTED_LADDER
+
+
+# ─── Cross-source parity (the actual desync guard) ───────────────────────────
+
+
+def test_all_three_default_tier_ladders_agree():
+    go = _go_default_protection_tiers()
+    py_atr = _python_tiered_tp_atr_ladder()
+    py_scalar = _python_scalar_tp_ladder()
+    assert go == py_atr == py_scalar, (
+        "Default tier ladder desync — retune one of "
+        "defaultHLProtectionTiers() (Go), DEFAULT_TIERS (tiered_tp_atr.py), "
+        "_DEFAULT_SCALAR_TP_TIERS (post_tp_sl.py) and you MUST update all three "
+        f"together. Go={go} tiered_tp_atr={py_atr} scalar={py_scalar}"
+    )
+
+
+def test_final_tier_closes_everything_remaining():
+    """The final rung is a full exit (cumulative fraction == 1.0); finalize
+    coerces it to 1.0 live, so the default must already encode that."""
+    for ladder in (
+        _go_default_protection_tiers(),
+        _python_tiered_tp_atr_ladder(),
+        _python_scalar_tp_ladder(),
+    ):
+        assert ladder[-1][1] == pytest.approx(1.0)
+
+
+def test_tier_multiples_and_fractions_are_monotonic():
+    """ATR triggers strictly increase and cumulative fractions are
+    non-decreasing — a retune that breaks this would mis-order the scale-out."""
+    for ladder in (
+        _go_default_protection_tiers(),
+        _python_tiered_tp_atr_ladder(),
+        _python_scalar_tp_ladder(),
+    ):
+        mults = [m for m, _ in ladder]
+        fracs = [f for _, f in ladder]
+        assert mults == sorted(mults) and len(set(mults)) == len(mults)
+        assert fracs == sorted(fracs)


### PR DESCRIPTION
Closes #944.

## Test pins
1. `test_default_tier_ladders.py` — cross-source parity for the default tiered-TP ATR ladder (Go `defaultHLProtectionTiers` ↔ Python `DEFAULT_TIERS` ↔ `_DEFAULT_SCALAR_TP_TIERS`); a retune that misses one mirror now fails the suite.
2. `test_backtester_composite_regime.py` — per-label entry-gate allow/block coverage for all 7 composite regime labels (previously zero references in backtest/tests), plus clean/choppy separation and held-position-on-flip.
3. `test_backtest_theta_branches.py` — profit-target, stop-loss, DTE-floor early exits, buy/zero-premium guards, and the `_report` metrics block.

## Debt cleanup (no behavior change)
4. `backtest_theta.py`: documented the daily-sampling constraint behind `days=len(equity_curve)` and `sqrt(365)` Sharpe annualization.
5. `backtester.py`: dropped unused imports (`json`, `datetime`, `Callable`).
6. `optimizer.py`: removed dead `DEFAULT_PARAM_RANGES` close-evaluator entries (unreachable — `run_optimize` rejects non-open-registry names).

Full suite: 1248 passed; `go build` ✓.

---
LLM: Claude Opus 4.8 (1M) | xhigh | Harness: anthropics/claude-code-action@v1