### PR TITLE
fix(strategies): seed supertrend band recursion from first non-NaN ATR row

### DIFF
--- a/shared_strategies/open/registry.py
+++ b/shared_strategies/open/registry.py
@@ -474,7 +474,18 @@ def supertrend_strategy(df: pd.DataFrame, atr_period: int = 10, multiplier: floa
     final_lower = basic_lower.copy()
     direction = pd.Series(0, index=result.index, dtype=int)
 
-    for i in range(1, n):
+    # Seed the recursion from the first non-NaN ATR row; the rolling ATR is NaN
+    # for the first atr_period-1 bars and NaN comparisons are always False, so
+    # starting at i=1 would carry NaN bands forward forever and never emit a signal.
+    atr_valid = atr.notna().to_numpy()
+    if not atr_valid.any():
+        result["supertrend"] = np.nan
+        result["st_direction"] = direction
+        result["signal"] = 0
+        return result
+    start = int(atr_valid.argmax())
+
+    for i in range(start + 1, n):
         if basic_upper.iloc[i] < final_upper.iloc[i-1] or result["close"].iloc[i-1] > final_upper.iloc[i-1]:
             final_upper.iloc[i] = basic_upper.iloc[i]
         else:

--- a/shared_strategies/open/test_supertrend.py
+++ b/shared_strategies/open/test_supertrend.py
@@ -1,0 +1,101 @@
+"""Regression tests for supertrend_strategy in registry.py.
+
+Issue #961: the supertrend band recursion seeded from the NaN rows of the
+rolling ATR warmup; NaN comparisons are always False, so the bands carried
+NaN forward forever and the strategy emitted zero signals on any data.
+These tests pin the fixed behavior: the recursion seeds from the first
+non-NaN ATR row and emits direction-flip signals on trending data.
+"""
+
+import importlib.util
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_registry():
+    spec = importlib.util.spec_from_file_location(
+        "_registry_supertrend", os.path.join(_HERE, "registry.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def registry():
+    return _load_registry()
+
+
+def make_ohlcv(closes, index=None, noise=0.5):
+    closes = np.array(closes, dtype=float)
+    n = len(closes)
+    df = pd.DataFrame({
+        "open": closes - noise * 0.3,
+        "high": closes + noise,
+        "low": closes - noise,
+        "close": closes,
+        "volume": np.full(n, 100.0),
+    })
+    if index is not None:
+        df.index = index
+    return df
+
+
+def _three_leg_trend_df():
+    """Deterministic up -> down -> up trend with a DatetimeIndex (300 bars)."""
+    closes = np.concatenate([
+        np.linspace(100, 200, 100),
+        np.linspace(200, 120, 100),
+        np.linspace(120, 220, 100),
+    ])
+    idx = pd.date_range("2025-01-01", periods=len(closes), freq="1h")
+    return make_ohlcv(closes, index=idx)
+
+
+def test_supertrend_emits_signals_on_trending_data(registry):
+    """Regression for #961: must emit nonzero buy AND sell signals."""
+    res = registry.supertrend_strategy(_three_leg_trend_df())
+    signals = res["signal"].to_numpy()
+    assert (signals == 1).sum() > 0, "no buy signals on trending data"
+    assert (signals == -1).sum() > 0, "no sell signals on trending data"
+
+
+def test_supertrend_exact_signal_values_and_positions(registry):
+    """Assert the actual signal values: one flip per trend leg, at known bars."""
+    res = registry.supertrend_strategy(_three_leg_trend_df())
+    signals = res["signal"].to_numpy()
+    buy_idx = list(np.where(signals == 1)[0])
+    sell_idx = list(np.where(signals == -1)[0])
+    # Uptrend confirms after the 10-bar ATR warmup, the downtrend leg flips
+    # short, the second uptrend flips long again.
+    assert buy_idx == [14, 204]
+    assert sell_idx == [106]
+    assert res["signal"].iloc[14] == 1
+    assert res["signal"].iloc[106] == -1
+    assert res["signal"].iloc[204] == 1
+    # Direction tracks each leg between flips.
+    assert res["st_direction"].iloc[50] == 1
+    assert res["st_direction"].iloc[150] == -1
+    assert res["st_direction"].iloc[280] == 1
+
+
+def test_supertrend_bands_escape_nan_warmup(registry):
+    """The supertrend line must be NaN only during the ATR warmup (atr_period-1
+    bars), not forever — the pre-fix failure mode was an all-NaN band."""
+    res = registry.supertrend_strategy(_three_leg_trend_df())
+    st = res["supertrend"]
+    assert int(st.isna().sum()) == 9  # atr_period=10 -> 9 warmup bars
+    assert st.iloc[9:].notna().all()
+
+
+def test_supertrend_all_nan_atr_returns_no_signals(registry):
+    """Inputs shorter than the ATR window must return cleanly with zero signals."""
+    df = make_ohlcv(np.linspace(100, 110, 5))
+    res = registry.supertrend_strategy(df)
+    assert (res["signal"] == 0).all()
+    assert res["supertrend"].isna().all()


### PR DESCRIPTION
Closes #961

## Bug
`supertrend_strategy` (shared_strategies/open/registry.py) emitted zero signals on any data. The band recursion started at `i=1`, where `final_upper`/`final_lower` are NaN (rolling ATR warmup, `atr_period-1` bars). NaN comparisons are always False, so both update conditions failed and the "carry previous band" branch propagated NaN forward forever: bands stayed NaN on every bar, `close > NaN` was always False, direction locked at -1, and no flip ever fired.

## Reproduction
On 300 bars of synthetic three-leg trend data (up 100→200, down 200→120, up 120→220, DatetimeIndex): **0 buys, 0 sells, `supertrend` column 100% NaN, direction values `{0, -1}`**.

## Fix
Seed the recursion from the first non-NaN ATR row (skip-forward initialization): find the first valid ATR index, keep the basic-band values as the seed there, and start the carry-forward loop from the next bar. Inputs shorter than the ATR window return cleanly with zero signals. Standard supertrend semantics, function signature, and registry metadata unchanged.

After the fix, the same synthetic data yields buy at bar 14, sell at bar 106, buy at bar 204 — one flip per trend leg — and the `supertrend` line is NaN only during the 9-bar ATR warmup.

## Registry contract
Spot and futures `--list-json` snapshots taken before and after: **byte-identical** (verified with `diff`).

## Tests
New `shared_strategies/open/test_supertrend.py` (4 tests): nonzero buy AND sell signals on trending data, exact signal values/positions and direction per leg, NaN-warmup escape (`isna().sum() == 9`, all valid after), short-input edge case (all-NaN ATR → zero signals). The existing registry parity smoke test iterates every registered strategy (supertrend included) and now exercises the fixed path.

Full suite: `uv run --no-sync python -m pytest shared_strategies/ shared_tools/ platforms/ backtest/` → **1283 passed**.

## Sanity backtest
`backtest/run_backtest.py --strategy supertrend --symbol BTC/USDT --timeframe 4h --since 2025-06-10 --mode single` (was 0 trades everywhere pre-fix):

- Total Trades: 30
- Total Return: -26.05% (final capital $739.49 on $1,000)
- Win Rate: 43.3% | Profit Factor: 0.583
- Sharpe: -1.013 | Max Drawdown: -35.42%

The strategy now trades; raw single-mode performance on this window is poor, which is a tuning question, not a correctness one. Note: the backtest run needed `PYTHONPATH=.` because `post_tp_sl.py`'s absolute `shared_strategies.*` import isn't on `sys.path` when invoking `backtest/run_backtest.py` directly — pre-existing on main, untouched here.

---
Created with LLM: Fable 5 | high | Harness: agent