### PR TITLE
feat(strategy): mtf_confluence — HTF trend gate over LTF pullback entries (#957)

### DIFF
--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -462,6 +462,18 @@ DEFAULT_PARAM_RANGES = {
         "rsi_oversold": [25.0, 30.0, 35.0],
         "rsi_overbought": [65.0, 70.0, 75.0],
     },
+    "mtf_confluence": {
+        "htf_factor": [3, 4, 6],
+        "htf_ema_fast": [10, 20, 26],
+        # NOTE: the real warmup need is ~htf_factor × htf_ema_slow NATIVE bars
+        # (the slow EMA counts HTF buckets), which max_indicator_lookback's
+        # raw-int heuristic can't see. Safe regardless: the strategy holds the
+        # HTF trend neutral until primed, so under-provisioned folds just
+        # trade less at the start — never on look-ahead or junk EMAs.
+        "htf_ema_slow": [40, 50],
+        "ltf_ema": [13, 20],
+        "pullback_window": [4, 6, 8],
+    },
     "consolidation_range": {
         "box_width_pct": [0.03, 0.05, 0.08, 0.10],
         "min_bars": [12, 16, 24],

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -75,6 +75,7 @@ var knownShortNames = map[string]string{
 	"momentum_pro":          "mompro",
 	"mean_reversion_pro":    "mrpro",
 	"consolidation_range":   "cr",
+	"mtf_confluence":        "mtfc",
 }
 
 // bidirectionalPerpsStrategies lists strategy IDs that emit signal=-1 as a
@@ -93,6 +94,7 @@ var bidirectionalPerpsStrategies = map[string]bool{
 	"momentum_pro":        true, // emits short on stacked-bearish-EMA trend-pullback breakdowns
 	"mean_reversion_pro":  true, // emits short on overbought reversion in no-trend regimes
 	"consolidation_range": true, // emits short at the top edge of a consolidation box (range-edge mean-reversion)
+	"mtf_confluence":      true, // futures variant (allow_short) shorts LTF pullback rallies in HTF downtrends (#957)
 }
 
 func isBidirectionalPerpsStrategy(id string) bool {
@@ -141,6 +143,7 @@ var defaultSpotStrategies = []stratDef{
 	{ID: "tema_cross", ShortName: "temac"},
 	{ID: "momentum_pro", ShortName: "mompro"},
 	{ID: "mean_reversion_pro", ShortName: "mrpro"},
+	{ID: "mtf_confluence", ShortName: "mtfc"},
 }
 
 var defaultOptionsStrategies = []stratDef{
@@ -164,6 +167,7 @@ var defaultPerpsStrategies = []stratDef{
 	{ID: "session_breakout", ShortName: "sbo"},
 	{ID: "momentum_pro", ShortName: "mompro"},
 	{ID: "mean_reversion_pro", ShortName: "mrpro"},
+	{ID: "mtf_confluence", ShortName: "mtfc"},
 }
 
 var defaultFuturesStrategies = []stratDef{
@@ -190,6 +194,7 @@ var defaultFuturesStrategies = []stratDef{
 	{ID: "tema_cross_bd", ShortName: "temacb"},
 	{ID: "momentum_pro", ShortName: "mompro"},
 	{ID: "mean_reversion_pro", ShortName: "mrpro"},
+	{ID: "mtf_confluence", ShortName: "mtfc"},
 }
 
 // Supported CME futures symbols for the init wizard.

--- a/shared_strategies/open/mtf_confluence.py
+++ b/shared_strategies/open/mtf_confluence.py
@@ -1,0 +1,254 @@
+"""
+MTF Confluence — higher-timeframe trend gate over lower-timeframe pullback
+entries (#957).
+
+The strategy audit (#956) showed the dominant failure mode across the registry
+was high-churn entries fighting the higher-timeframe trend, with 4h runs
+consistently beating their 1h twins. This strategy makes the multi-timeframe
+gate first-class instead of the bolt-on ``htf_filter`` — and it derives the
+higher-timeframe view from the SINGLE frame the framework already passes
+(resampled in-process; no extra data fetch).
+
+Rules (long; short is the mirror, gated by ``allow_short``)
+-----------------------------------------------------------
+1. HTF trend:  the native frame is resampled to ``htf_factor`` × the native
+               bar (e.g. 1h → 4h). Trend is up when HTF EMA(fast) exceeds
+               EMA(slow) by at least ``htf_sep_pct`` (epsilon wobble in a
+               flat market is not a trend) AND EMA(fast) is rising
+               bucket-over-bucket.
+2. LTF entry:  within an HTF uptrend, a recent prior bar pulled back to
+               (tagged) the native-frame EMA within ``pullback_window`` bars,
+               and the current bar resumes the trend: close reclaims the EMA
+               and breaks the prior bar's high.
+3. Exit:       hysteresis — entries require the strict gate (separation +
+               rising fast EMA) but a held position only exits when the HTF
+               EMAs actually cross against it (fast ≤ slow for longs). The
+               loose hold gate stops fee churn from bucket-to-bucket slope
+               flicker; ``signal`` emits the transition (-1 closes a long,
+               +1 closes a short).
+
+Anti-look-ahead contract (CRITICAL)
+-----------------------------------
+An HTF bucket is only readable from the native bar at which the bucket has
+fully CLOSED. Buckets are aligned to the epoch (window-start independent, the
+same parity lesson as regime windows) and a bucket labeled ``L`` spanning
+``[L, L+H)`` becomes visible at the native bar labeled ``L + H - native_period``
+— the bar whose own close coincides with the bucket close. The in-progress
+trailing bucket maps past the end of the frame and is never read. A signal at
+bar N may therefore use bar N's own close, matching the engine contract that
+the signal computed on bar N fills at bar N+1's open
+(see backtest/tests/test_backtester_lookahead.py).
+"""
+
+import numpy as np
+import pandas as pd
+
+_HTF_AGG = {"open": "first", "high": "max", "low": "min", "close": "last"}
+
+
+def _resample_htf(df: pd.DataFrame, htf_factor: int):
+    """Resample the native frame into HTF buckets without look-ahead.
+
+    Returns ``(htf, visible_at)`` where ``htf`` is the HTF OHLC frame (one row
+    per non-empty bucket) and ``visible_at`` is, for each HTF row, the native
+    index label at/after which that bucket is fully closed and may be read.
+
+    Datetime-indexed frames use a wall-clock ``resample`` (epoch-aligned, so
+    bucketing does not depend on where the fetch window starts). Frames
+    without a usable DatetimeIndex fall back to positional bucketing
+    (``htf_factor`` consecutive bars per bucket).
+    """
+    native_td = None
+    if isinstance(df.index, pd.DatetimeIndex) and len(df) >= 3:
+        diffs = df.index.to_series().diff().dropna()
+        if len(diffs) > 0:
+            cadence = diffs.mode()
+            if len(cadence) > 0 and cadence.iloc[0] > pd.Timedelta(0):
+                native_td = cadence.iloc[0]
+
+    if native_td is not None:
+        htf_td = native_td * htf_factor
+        htf = (
+            df[["open", "high", "low", "close"]]
+            .resample(htf_td, label="left", closed="left", origin="epoch")
+            .agg(_HTF_AGG)
+            .dropna(subset=["close"])
+        )
+        # Bucket [L, L+H) closes when the native bar labeled L+H-p closes.
+        visible_at = htf.index + htf_td - native_td
+        return htf, visible_at
+
+    # Positional fallback: buckets of htf_factor consecutive bars; a bucket is
+    # readable from its last constituent bar onward. The trailing partial
+    # bucket is dropped entirely (it has not closed).
+    n = len(df)
+    n_full = n // htf_factor
+    if n_full == 0:
+        empty = pd.DataFrame(columns=list(_HTF_AGG))
+        return empty, df.index[:0]
+    o = df["open"].to_numpy(dtype=float)[: n_full * htf_factor].reshape(n_full, htf_factor)
+    h = df["high"].to_numpy(dtype=float)[: n_full * htf_factor].reshape(n_full, htf_factor)
+    l = df["low"].to_numpy(dtype=float)[: n_full * htf_factor].reshape(n_full, htf_factor)
+    c = df["close"].to_numpy(dtype=float)[: n_full * htf_factor].reshape(n_full, htf_factor)
+    last_pos = np.arange(1, n_full + 1) * htf_factor - 1
+    visible_at = df.index[last_pos]
+    htf = pd.DataFrame(
+        {
+            "open": o[:, 0],
+            "high": h.max(axis=1),
+            "low": l.min(axis=1),
+            "close": c[:, -1],
+        },
+        index=visible_at,
+    )
+    return htf, visible_at
+
+
+def _project_to_native(values: pd.Series, visible_at, native_index) -> pd.Series:
+    """Forward-fill an HTF series onto the native index, where each HTF value
+    only becomes available at its bucket's ``visible_at`` native label."""
+    proj = pd.Series(values.to_numpy(), index=visible_at)
+    return proj.reindex(native_index, method="ffill")
+
+
+def mtf_confluence_core(
+    df: pd.DataFrame,
+    htf_factor: int = 4,
+    htf_ema_fast: int = 20,
+    htf_ema_slow: int = 40,
+    htf_sep_pct: float = 0.001,
+    ltf_ema: int = 20,
+    pullback_window: int = 6,
+    pullback_touch_buffer_pct: float = 0.0,
+    allow_short: bool = False,
+) -> pd.DataFrame:
+    """Generate MTF-confluence signals.
+
+    Parameters
+    ----------
+    df : DataFrame with open, high, low, close, volume columns
+    htf_factor : native bars per HTF bucket (e.g. 4 turns 1h into 4h)
+    htf_ema_fast / htf_ema_slow : EMAs (in HTF bars) defining the HTF trend
+    htf_sep_pct : minimum relative EMA separation (|fast/slow - 1|) for the
+        HTF trend to count; filters flat-market epsilon wobble
+    ltf_ema : native-frame EMA acting as the pullback magnet / reclaim level
+    pullback_window : native bars to look back for the EMA tag
+    pullback_touch_buffer_pct : fraction the bar must pierce the LTF EMA by to
+        count as a pullback tag (0 = a plain touch qualifies)
+    allow_short : mirror entries in HTF downtrends (futures variant)
+
+    Returns
+    -------
+    DataFrame with added columns:
+        signal      : 1 / -1 / 0 (position-state transitions, clamped)
+        position    : desired position state (1 long, -1 short, 0 flat)
+        htf_trend   : visible HTF trend at each native bar (1 up, -1 down, 0)
+        htf_ema_fast / htf_ema_slow : visible HTF EMAs (NaN during warmup)
+        ltf_ema     : native-frame EMA
+    """
+    htf_factor = max(int(htf_factor), 1)
+    result = df.copy()
+    result["signal"] = 0
+    result["position"] = 0
+    result["htf_trend"] = 0
+    result["htf_ema_fast"] = np.nan
+    result["htf_ema_slow"] = np.nan
+    result["ltf_ema"] = np.nan
+
+    n = len(result)
+    if n < htf_factor + 2:
+        return result
+
+    close = result["close"]
+    high = result["high"]
+    low = result["low"]
+
+    # ── HTF view (closed buckets only) ──────────────────────────────────────
+    htf, visible_at = _resample_htf(result, htf_factor)
+    if len(htf) == 0:
+        return result
+
+    htf_close = htf["close"]
+    ema_fast_htf = htf_close.ewm(span=htf_ema_fast, adjust=False).mean()
+    ema_slow_htf = htf_close.ewm(span=htf_ema_slow, adjust=False).mean()
+    # EMAs are defined from the first bucket but meaningless until the slow
+    # span has seen enough buckets; hold the trend neutral during warmup.
+    warm = np.arange(len(htf)) >= htf_ema_slow
+    rising = ema_fast_htf > ema_fast_htf.shift(1)
+    falling = ema_fast_htf < ema_fast_htf.shift(1)
+    # Strict ENTRY gate: separated EMAs + rising fast EMA. Loose HOLD gate:
+    # fast still on the right side of slow — slope flicker between buckets
+    # must not churn an open position out and back in (fee drag).
+    up_htf = (ema_fast_htf > ema_slow_htf * (1.0 + htf_sep_pct)) & rising & warm
+    down_htf = (ema_fast_htf < ema_slow_htf * (1.0 - htf_sep_pct)) & falling & warm
+    hold_up_htf = (ema_fast_htf > ema_slow_htf) & warm
+    hold_down_htf = (ema_fast_htf < ema_slow_htf) & warm
+    trend_htf = pd.Series(
+        np.where(up_htf, 1, np.where(down_htf, -1, 0)), index=htf.index
+    )
+
+    trend = (
+        _project_to_native(trend_htf, visible_at, result.index)
+        .fillna(0)
+        .astype(int)
+    )
+    hold_up = (
+        _project_to_native(hold_up_htf, visible_at, result.index)
+        .fillna(False)
+        .astype(bool)
+        .to_numpy()
+    )
+    hold_down = (
+        _project_to_native(hold_down_htf, visible_at, result.index)
+        .fillna(False)
+        .astype(bool)
+        .to_numpy()
+    )
+    result["htf_trend"] = trend
+    result["htf_ema_fast"] = _project_to_native(ema_fast_htf, visible_at, result.index)
+    result["htf_ema_slow"] = _project_to_native(ema_slow_htf, visible_at, result.index)
+
+    # ── LTF pullback + resumption triggers ──────────────────────────────────
+    ltf_ema_s = close.ewm(span=ltf_ema, adjust=False).mean()
+    result["ltf_ema"] = ltf_ema_s
+
+    # Positive buffer *tightens* the gate: the bar must pierce the EMA by the
+    # fraction (low below for longs, high above for shorts); 0 = plain touch.
+    long_touch = low < (ltf_ema_s * (1.0 - pullback_touch_buffer_pct))
+    long_pullback = (
+        long_touch.shift(1).rolling(window=pullback_window).max().fillna(0).astype(bool)
+    )
+    short_touch = high > (ltf_ema_s * (1.0 + pullback_touch_buffer_pct))
+    short_pullback = (
+        short_touch.shift(1).rolling(window=pullback_window).max().fillna(0).astype(bool)
+    )
+
+    prev_high = high.shift(1)
+    prev_low = low.shift(1)
+    long_trig = ((close > ltf_ema_s) & (close > prev_high) & long_pullback).to_numpy()
+    short_trig = ((close < ltf_ema_s) & (close < prev_low) & short_pullback).to_numpy()
+
+    # ── Position state machine ───────────────────────────────────────────────
+    # Enter only on a pullback-resumption trigger confirmed by the strict HTF
+    # entry gate; exit (to flat) when the loose HTF hold gate fails (the EMAs
+    # crossed against the position). Sequential because the exit condition
+    # depends on the held side.
+    trend_arr = trend.to_numpy()
+    pos = np.zeros(n, dtype=int)
+    state = 0
+    for i in range(n):
+        if state == 1 and not hold_up[i]:
+            state = 0
+        elif state == -1 and not hold_down[i]:
+            state = 0
+        if state == 0:
+            if long_trig[i] and trend_arr[i] == 1:
+                state = 1
+            elif allow_short and short_trig[i] and trend_arr[i] == -1:
+                state = -1
+        pos[i] = state
+
+    result["position"] = pos
+    # A direct flip would yield diff == ±2; clamp so downstream sees {-1, 0, 1}.
+    result["signal"] = np.clip(np.diff(pos, prepend=0), -1, 1)
+    return result

--- a/shared_strategies/open/registry.py
+++ b/shared_strategies/open/registry.py
@@ -45,6 +45,7 @@ from bear_pullback_st import bear_pullback_st_core
 from donchian_breakout import donchian_breakout_core
 from momentum_pro import momentum_pro_core
 from mean_reversion_pro import mean_reversion_pro_core
+from mtf_confluence import mtf_confluence_core
 from session_breakout import session_breakout_core
 from vwap_rejection_st import vwap_rejection_st_core
 
@@ -1052,6 +1053,25 @@ def consolidation_range_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
 
 
 @register(
+    "mtf_confluence",
+    "MTF Confluence — higher-timeframe EMA trend gate (resampled in-frame, no extra data) over native-frame pullback resumption entries; exits when the HTF trend flips",
+    {
+        "htf_factor": 4, "htf_ema_fast": 20, "htf_ema_slow": 40,
+        "htf_sep_pct": 0.001, "ltf_ema": 20, "pullback_window": 6,
+        "pullback_touch_buffer_pct": 0.0, "allow_short": False,
+    },
+    variants={
+        "futures": {
+            "description": "MTF Confluence — bidirectional: HTF EMA trend gate over native-frame pullback resumption entries; shorts mirror the logic in HTF downtrends",
+            "default_params": {"allow_short": True},
+        },
+    },
+)
+def mtf_confluence_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return mtf_confluence_core(df, **params)
+
+
+@register(
     "hold",
     "Hold — always returns signal=0; used internally by type=manual strategies for the close-evaluator loop (#569)",
     {},
@@ -1078,7 +1098,7 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "heikin_ashi_ema", "order_blocks", "vwap_reversion", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
         "sweep_squeeze_combo", "adx_trend", "donchian_breakout", "tema_cross",
-        "momentum_pro", "mean_reversion_pro",
+        "momentum_pro", "mean_reversion_pro", "mtf_confluence",
         "hold",
     ],
     "futures": [
@@ -1091,6 +1111,6 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "sweep_squeeze_combo", "adx_trend", "delta_neutral_funding",
         "donchian_breakout", "session_breakout", "bear_pullback_st",
         "vwap_rejection_st", "momentum_pro", "mean_reversion_pro",
-        "consolidation_range", "hold",
+        "consolidation_range", "mtf_confluence", "hold",
     ],
 }

--- a/shared_strategies/open/test_mtf_confluence.py
+++ b/shared_strategies/open/test_mtf_confluence.py
@@ -1,0 +1,230 @@
+"""Tests for mtf_confluence.py — HTF trend gate over LTF pullback entries (#957).
+
+Includes the look-ahead regression class required by the #955 validation bar:
+the in-frame HTF resample must never read the in-progress HTF bucket, proven
+via prefix-consistency and future-row perturbation.
+"""
+
+import numpy as np
+import pandas as pd
+
+from mtf_confluence import mtf_confluence_core, _resample_htf
+
+
+def make_ohlcv(closes, volume=None, noise=1.0, freq="1h", start="2024-01-01"):
+    closes = np.asarray(closes, dtype=float)
+    n = len(closes)
+    if volume is None:
+        volume = np.full(n, 100.0)
+    idx = pd.date_range(start, periods=n, freq=freq)
+    return pd.DataFrame(
+        {
+            "open": closes - noise * 0.3,
+            "high": closes + noise,
+            "low": closes - noise,
+            "close": closes,
+            "volume": np.asarray(volume, dtype=float),
+        },
+        index=idx,
+    )
+
+
+def build_uptrend_with_pullback(n_trend=900, dip=10.0):
+    """A steady 1h uptrend long enough to prime the 4h EMA(50) gate, then a
+    pullback that tags the LTF EMA(20), then a resumption bar that breaks the
+    prior bar's high."""
+    closes = list(np.linspace(100, 400, n_trend))
+    base = closes[-1]
+    # Pullback: drift down toward the LTF EMA over a few bars.
+    closes += [base - 2, base - 5, base - dip]
+    # Resumption: strong up bars breaking the prior highs.
+    closes += [base - 4, base + 4, base + 10]
+    return make_ohlcv(closes)
+
+
+def build_downtrend_with_rally(n_trend=900, pop=10.0):
+    closes = list(np.linspace(400, 100, n_trend))
+    base = closes[-1]
+    closes += [base + 2, base + 5, base + pop]   # rally into the LTF EMA
+    closes += [base + 4, base - 4, base - 10]    # breakdown
+    return make_ohlcv(closes)
+
+
+# ── Basic shape / safety ─────────────────────────────────────────────────────
+
+
+def test_columns_present():
+    out = mtf_confluence_core(build_uptrend_with_pullback())
+    for col in ("signal", "position", "htf_trend", "htf_ema_fast",
+                "htf_ema_slow", "ltf_ema"):
+        assert col in out.columns
+
+
+def test_empty_df_is_safe():
+    df = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+    out = mtf_confluence_core(df)
+    assert "signal" in out.columns
+    assert len(out) == 0
+
+
+def test_warmup_returns_no_signal():
+    """Too few bars to prime the HTF slow EMA → neutral everywhere."""
+    df = make_ohlcv(np.linspace(100, 200, 120))
+    out = mtf_confluence_core(df)
+    assert (out["signal"] == 0).all()
+    assert (out["htf_trend"] == 0).all()
+
+
+def test_range_index_fallback_is_safe():
+    """Non-datetime index falls back to positional bucketing, no crash."""
+    df = make_ohlcv(np.linspace(100, 400, 903)).reset_index(drop=True)
+    out = mtf_confluence_core(df)
+    assert "signal" in out.columns
+    assert out["htf_trend"].iloc[-1] == 1
+
+
+# ── Signal-value tests ───────────────────────────────────────────────────────
+
+
+def test_uptrend_pullback_fires_long_at_resumption_bar():
+    df = build_uptrend_with_pullback()
+    out = mtf_confluence_core(df)
+    fired = out.index[out["signal"] == 1]
+    assert len(fired) >= 1, "expected a long entry on a resumption bar"
+    # The engineered resumption sequence is the last 3 bars; the entry must
+    # land there (close reclaims the LTF EMA and breaks the prior high).
+    assert fired[-1] >= df.index[-3]
+    # And the HTF trend at the entry bar must be up.
+    assert (out.loc[fired, "htf_trend"] == 1).all()
+
+
+def test_long_only_default_suppresses_short_entries():
+    df = build_downtrend_with_rally()
+    out = mtf_confluence_core(df)  # allow_short defaults to False
+    assert (out["position"] >= 0).all()
+    assert not (out["signal"] == -1).any() or (out["position"] == 0).all()
+
+
+def test_downtrend_rally_fires_short_when_allowed():
+    df = build_downtrend_with_rally()
+    out = mtf_confluence_core(df, allow_short=True)
+    fired = out.index[(out["signal"] == -1) & (out["position"] == -1)]
+    assert len(fired) >= 1, "expected a short entry on the breakdown bar"
+    assert (out.loc[fired, "htf_trend"] == -1).all()
+
+
+def test_htf_downtrend_blocks_long_pullback_trigger():
+    """The same LTF pullback-resumption shape inside an HTF downtrend must not
+    produce a long: the HTF gate is the whole point."""
+    df = build_downtrend_with_rally()
+    out = mtf_confluence_core(df)
+    assert not (out["position"] == 1).any()
+
+
+def test_exit_emitted_when_htf_trend_flips():
+    """After a long entry, rolling the trend over hard must flatten the
+    position via signal=-1 once the HTF view registers the flip."""
+    up = build_uptrend_with_pullback()
+    base = up["close"].iloc[-1]
+    n_down = 240
+    down_closes = np.linspace(base, base - 250, n_down)
+    down = make_ohlcv(
+        down_closes, start=up.index[-1] + pd.Timedelta(hours=1))
+    df = pd.concat([up, down])
+    out = mtf_confluence_core(df)
+    assert (out["signal"] == 1).any(), "needs the long entry first"
+    entry_ts = out.index[out["signal"] == 1][-1]
+    after = out.loc[entry_ts:]
+    exits = after.index[after["signal"] == -1]
+    assert len(exits) >= 1, "expected an exit when the HTF trend flipped"
+    assert out["position"].iloc[-1] <= 0
+    # Exit reason is the gate, not a short trigger: position goes to 0 or -1
+    # only via the clamped transition.
+    assert set(out["signal"].unique()) <= {-1, 0, 1}
+
+
+def test_flat_market_no_signal():
+    n = 900
+    closes = 100.0 + np.random.RandomState(0).randn(n) * 0.05
+    df = make_ohlcv(closes, noise=0.2)
+    out = mtf_confluence_core(df)
+    assert (out["signal"] == 0).all()
+
+
+# ── HTF resample mechanics ───────────────────────────────────────────────────
+
+
+def test_resample_buckets_are_epoch_aligned_4h():
+    df = make_ohlcv(np.linspace(100, 110, 50), start="2024-01-01 03:00")
+    htf, visible_at = _resample_htf(df, 4)
+    # 1h bars from 03:00 → first bucket label is the epoch-aligned 00:00.
+    assert htf.index[0] == pd.Timestamp("2024-01-01 00:00")
+    assert (htf.index.hour % 4 == 0).all()
+    # Bucket [00:00, 04:00) is visible at the native bar labeled 03:00.
+    assert visible_at[0] == pd.Timestamp("2024-01-01 03:00")
+
+
+def test_incomplete_trailing_bucket_never_visible():
+    """A frame ending mid-bucket must not expose that bucket's aggregates:
+    its visible-at label lies beyond the end of the native index."""
+    # 1h bars 00:00..21:00 → last 4h bucket [20:00, 00:00) holds only 2 bars.
+    df = make_ohlcv(np.linspace(100, 110, 22))
+    htf, visible_at = _resample_htf(df, 4)
+    assert visible_at[-1] > df.index[-1]
+    proj = pd.Series(htf["close"].to_numpy(), index=visible_at).reindex(
+        df.index, method="ffill")
+    # The projected HTF close at the final native bar is the last COMPLETE
+    # bucket's close (the 19:00 bar), not the in-progress bucket's.
+    assert proj.iloc[-1] == df["close"].iloc[19]
+
+
+# ── Look-ahead regression (the #955 bar) ─────────────────────────────────────
+
+
+def test_prefix_consistency_no_lookahead():
+    """Gold standard: signals over df[:k] must equal the first k signals over
+    the full df, for cutoffs landing at every offset within an HTF bucket.
+    Any read of the in-progress HTF bucket (or any other future leak) breaks
+    this for some k."""
+    df = build_uptrend_with_pullback()
+    full = mtf_confluence_core(df)["signal"]
+    n = len(df)
+    for k in range(n - 9, n):  # covers all 4 intra-bucket offsets, twice
+        prefix = mtf_confluence_core(df.iloc[:k])["signal"]
+        pd.testing.assert_series_equal(
+            prefix, full.iloc[:k], check_names=False, obj=f"prefix k={k}"
+        )
+
+
+def test_future_rows_do_not_change_past_signals():
+    """Perturb rows after a cutoff (including bars inside the then-current
+    HTF bucket) wildly; signals at and before the cutoff must be unchanged."""
+    df = build_uptrend_with_pullback()
+    n = len(df)
+    cut = n - 6
+    base = mtf_confluence_core(df)["signal"].iloc[:cut]
+
+    crashed = df.copy()
+    crashed.loc[crashed.index[cut:], ["open", "high", "low", "close"]] = 1.0
+    out_crashed = mtf_confluence_core(crashed)["signal"].iloc[:cut]
+    pd.testing.assert_series_equal(base, out_crashed, check_names=False)
+
+    mooned = df.copy()
+    mooned.loc[mooned.index[cut:], ["open", "high", "low", "close"]] *= 10.0
+    out_mooned = mtf_confluence_core(mooned)["signal"].iloc[:cut]
+    pd.testing.assert_series_equal(base, out_mooned, check_names=False)
+
+
+def test_htf_trend_lags_not_leads_the_bucket():
+    """At a native bar mid-bucket, htf_trend must reflect only buckets that
+    already closed: rewriting the remainder of the current bucket cannot
+    change htf_trend at that bar."""
+    df = build_uptrend_with_pullback()
+    out = mtf_confluence_core(df)
+    # Pick a bar that is NOT the last bar of its 4h bucket (hour % 4 != 3).
+    mid_bucket = [ts for ts in df.index[-30:] if ts.hour % 4 != 3][0]
+    mutated = df.copy()
+    later = mutated.index > mid_bucket
+    mutated.loc[later, ["open", "high", "low", "close"]] = 1.0
+    out_mut = mtf_confluence_core(mutated)
+    assert out.loc[mid_bucket, "htf_trend"] == out_mut.loc[mid_bucket, "htf_trend"]


### PR DESCRIPTION
Closes #957. Part of #955.

## Design

- **One frame, two timeframes.** The framework passes a single OHLCV frame; the higher-timeframe (HTF) view is derived in-process via an epoch-aligned pandas `resample` to `htf_factor` × the native bar (1h → 4h by default). No extra data fetch. Non-datetime indexes fall back to positional bucketing.
- **HTF trend gate with hysteresis.** Strict *entry* gate: HTF EMA(20) > EMA(40) by ≥ `htf_sep_pct` AND the fast EMA rising bucket-over-bucket (mirror for down). Loose *hold* gate: fast still on the right side of slow. Hysteresis exists because the first iteration (exit on any slope flicker) churned 102 trades and -44% on BTC 1h; with it, trade count drops ~6× and the entry edge survives fees.
- **LTF pullback entry.** Within an HTF uptrend: a prior bar tagged the native EMA(20) within `pullback_window` bars, and the current bar resumes (close reclaims the EMA and breaks the prior bar's high). Short is the exact mirror.
- **Exit** when the HTF EMAs cross against the held side (position-state transition, clamped to {-1,0,1} like `tema_cross_bd`).
- **Long-only base + bidirectional futures variant** via `variants={"futures": {"default_params": {"allow_short": true}}}`.

### Anti-look-ahead mechanism

An HTF bucket labeled `L` spanning `[L, L+H)` becomes readable only at the native bar labeled `L+H-p` — the bar whose own close coincides with the bucket close. The HTF indicator series is re-indexed to those visible-at labels and forward-filled onto the native index, so the in-progress trailing bucket maps **past the end of the frame** and is never read. Buckets are epoch-aligned, so bucketing is independent of where the fetch window starts (live/backtest parity). A signal at bar N may use bar N's own close, matching the engine's fill-at-N+1-open contract (`backtest/tests/test_backtester_lookahead.py`).

Pinned by three regression tests: prefix-consistency (`core(df[:k]) == core(df)[:k]` for every intra-bucket offset), future-row perturbation (crash/moon all rows after a cutoff → signals at/before it unchanged), and a mid-bucket `htf_trend` immutability test.

## Wiring checklist (#955 validation bar)

- [x] `shared_strategies/open/registry.py` — `@register` + `PLATFORM_ORDER` (spot + futures, before `hold`)
- [x] `--list-json` byte-identical for existing strategies in both shims (verified before/after; the only change is the additive `mtf_confluence` entry)
- [x] `scheduler/init.go` — `knownShortNames` (`mtfc`), `defaultSpotStrategies`/`defaultPerpsStrategies`/`defaultFuturesStrategies`, `bidirectionalPerpsStrategies`
- [x] `backtest/optimizer.py` — `DEFAULT_PARAM_RANGES["mtf_confluence"]`
- [x] Signal-value tests (DatetimeIndex, actual values) + look-ahead tests — `shared_strategies/open/test_mtf_confluence.py` (15 tests)

## Test evidence

- `uv run --no-sync python -m pytest shared_strategies/ shared_tools/ platforms/ backtest/` — **1294 passed**
- `go -C scheduler build .` + `go -C scheduler test ./...` — **ok** (gofmt clean)

## Backtest report

Single mode, default params, `binanceus` fee model (audit-identical harness), long leg (spot config — see caveats). DDadj = return / |max DD|. Median incumbent = per-dataset median of the audit's OOS top 8 (`momentum_pro`, `chart_pattern`, `squeeze_momentum`, `mean_reversion_pro`, `donchian_breakout`, `ichimoku_cloud`, `range_scalper`, `sma_crossover`) re-run on the identical harness/window.

**In-sample (since 2025-06-10):**

| Dataset | Return | Sharpe | Max DD | DDadj | Trades | med-inc Sharpe | med-inc DDadj | B&H | Beats median? |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
| BTC 1h | -9.5% | -0.31 | -31.0% | -0.31 | 16 | -1.28 | -0.84 | -44.2% | yes |
| BTC 4h | -13.2% | -0.64 | -27.3% | -0.48 | 5 | -0.31 | -0.33 | -43.8% | no |
| ETH 1h | +11.5% | +0.48 | -38.4% | +0.30 | 16 | +0.40 | +0.22 | -39.8% | yes |
| ETH 4h | +16.7% | +0.64 | -27.2% | +0.61 | 4 | +0.16 | +0.01 | -39.5% | yes |
| SOL 1h | -34.9% | -0.80 | -51.0% | -0.68 | 20 | -0.98 | -0.76 | -60.9% | yes |
| SOL 4h | -12.2% | -0.15 | -42.9% | -0.28 | 5 | -0.17 | -0.38 | -60.6% | yes |
| **Mean** | **-6.9%** | **-0.13** | | **-0.14** | 66 | **-0.36** | **-0.35** | -48.1% | **5/6** |

**Out-of-sample (since 2026-01-01):**

| Dataset | Return | Sharpe | Max DD | DDadj | Trades | med-inc Sharpe | med-inc DDadj | B&H | Beats median? |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
| BTC 1h | +1.8% | +0.29 | -14.9% | +0.12 | 6 | -1.13 | -0.59 | -30.2% | yes |
| BTC 4h | +4.8% | +0.69 | -9.6% | +0.50 | 1 | -0.30 | -0.25 | -30.2% | yes |
| ETH 1h | -9.1% | -0.50 | -20.3% | -0.45 | 7 | -0.21 | -0.23 | -45.7% | no |
| ETH 4h | -9.3% | -0.80 | -10.9% | -0.86 | 2 | -0.42 | -0.44 | -45.7% | no |
| SOL 1h | -21.9% | -1.36 | -29.5% | -0.74 | 8 | -1.64 | -0.80 | -49.9% | yes |
| SOL 4h | -9.7% | -1.20 | -14.3% | -0.68 | 2 | -0.84 | -0.66 | -50.0% | no |
| **Mean** | **-7.2%** | **-0.48** | | **-0.35** | 26 | **-0.76** | **-0.49** | -42.0% | **3/6** |

### The bar (beat the median incumbent on OOS Sharpe + DD-adjusted return)

**Cleared on aggregate and on the audit's reference dataset; mixed per-dataset.**

- Aggregate OOS: Sharpe **-0.48 vs -0.76** and DDadj **-0.35 vs -0.49** — both clear.
- Audit's published OOS benchmark (#956, BTC 1h): median incumbent Sharpe **-1.155** / return **-15.15%**; mtf_confluence posts **+0.29** / **+1.8%** — clears decisively.
- Per-dataset OOS it wins 3/6 on both metrics (BTC 1h, BTC 4h, SOL 1h) and loses ETH 1h/4h + SOL 4h. ETH OOS is the weak spot: the Jan–Jun 2026 ETH bear had rallies just strong enough to flip the 4h gate up, then failed.
- Tuning hygiene: parameters were swept only on 2025-06-10 → 2025-12-31 (OOS window untouched); the chosen defaults sit in a flat neighborhood of the tuning surface (fast 20–26 / slow 40 / window 4–8 all within ±0.01 Sharpe).

### Caveats / deviations

1. **Long leg only, like the audit.** The plain backtest path is long/flat, so the report uses the long-only configuration (`allow_short=False`, the spot default). The futures variant's short leg — expected to be the stronger leg in this bear window — is unmeasured, the same caveat #956 applies to every `bidirectionalPerpsStrategies` member. Running the futures variant through the long/flat path scores it *worse* (OOS mean Sharpe -0.35 in result-dict scale) purely because `+1` close-short transitions get misread as long entries — an engine-representation artifact shared with `tema_cross_bd`/`triple_ema_bidir`, not a strategy property.
2. **Audit-table Sharpe scale.** `run_backtest.py` CLI prints timeframe-annualized Sharpe; all numbers above use that same scale for both mtf_confluence and the incumbent medians (recomputed on the identical harness rather than trusting cross-run drift).
3. `backtest/run_backtest.py` currently needs `PYTHONPATH=.` from the repo root (pre-existing on main, reproduced there: `post_tp_sl.py` does a `shared_strategies.…` absolute import at `Backtester.__init__`); not fixed here to keep the PR scoped.
4. `DEFAULT_PARAM_RANGES` warmup note: the slow-EMA lookback is in HTF *buckets* (real need ≈ `htf_factor × htf_ema_slow` native bars), which `max_indicator_lookback`'s raw-int heuristic can't see — safe because the strategy holds the HTF trend neutral until primed (documented in the grid entry).

---
Created with LLM: Fable 5 | high | Harness: agent