### PR TITLE
feat(hl-reconcile): active operator alerts for persistent shared-coin SL gaps (#971)

### DIFF
--- a/scheduler/hl_reconcile_gap_alerts.go
+++ b/scheduler/hl_reconcile_gap_alerts.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// #971: Active operator alerting for persistent Hyperliquid shared-coin
+// reconciliation gaps.
+//
+// When a shared coin's on-chain position drops but the reconciler cannot
+// confirm the residual via an exact stop-loss/TP OID (user-fills miss or a
+// wrong OID), it fails closed (#964/#965): it does NOT guess an owner or book
+// an SL close, leaving a `ReconciliationGap` and a phantom virtual position
+// that keeps feeding drawdown/kill-switch math. The reconciler already
+// auto-heals such a gap WITHIN a later cycle the moment a user-fills lookup
+// confirms the exact OID (the confirmedSLFills / Detector paths re-run every
+// reconcile with a freshly-built fill resolver). So a transient miss self-heals
+// silently; this layer only surfaces a gap that stays stuck — the lookup never
+// confirms — so an operator can reconcile it manually. It deliberately does NOT
+// book or guess anything: the fail-closed invariant is preserved.
+
+// hlReconcileGapTolerance is the absolute signed-qty drift below which a
+// shared-coin reconciliation gap is treated as float noise rather than a real
+// stuck gap. Mirrors the 1e-6 qty epsilon used throughout the reconciler.
+const hlReconcileGapTolerance = 1e-6
+
+// hlReconcileGapAlertThreshold is the number of CONSECUTIVE reconcile cycles a
+// coin's gap must persist before the first operator alert fires. A recorded gap
+// already means THIS cycle's user-fills lookup could not explain the residual
+// (the reconciler books and clears the gap in-cycle the moment a lookup
+// confirms the exact OID), so a gap surviving several consecutive lookups is
+// genuinely stuck — a permanently missing or wrong OID — not the brief HL
+// indexer lag that clears once the fill is indexed. Three absorbs a couple of
+// lagged cycles while still surfacing a real stuck gap within a few cycles.
+const hlReconcileGapAlertThreshold = 3
+
+// hlReconcileGapRealertRatio gates re-alerts on an already-alerted coin to a
+// material change in the residual qty (relative to the qty at the LAST
+// notification), so a gap whose residual drifts slightly (a peer partial fill,
+// a small re-open) does not spam; combined with the every-10th-cycle / hourly
+// back-off below.
+const hlReconcileGapRealertRatio = 0.10
+
+// hlReconcileGapEntry is one slot in the per-coin gap tracker.
+type hlReconcileGapEntry struct {
+	// cycles counts CONSECUTIVE over-tolerance reconcile cycles for this coin.
+	// It is the duration shown in operator messages and the base of the
+	// every-10th-cycle cadence.
+	cycles int
+	// alerted marks that the confirmation window has been crossed and an alert
+	// has fired, so subsequent cycles re-throttle instead of re-confirming.
+	alerted bool
+	// lastNotifiedAt anchors the hourly back-off.
+	lastNotifiedAt time.Time
+	// lastNotifiedDelta is the residual qty at the LAST NOTIFICATION (not the
+	// previous cycle) — the anchor for the materially-changed re-alert gate.
+	lastNotifiedDelta float64
+}
+
+// HLReconcileGapTracker throttles operator alerts for persistent Hyperliquid
+// shared-coin reconciliation gaps (#971). State is per-coin and in-memory;
+// it resets on restart. A gap must persist hlReconcileGapAlertThreshold
+// consecutive cycles before the first alert; thereafter it re-alerts only on a
+// materially changed residual, every 10th cycle, or once an hour, until the
+// gap clears (Clear).
+type HLReconcileGapTracker struct {
+	mu      sync.Mutex
+	entries map[string]*hlReconcileGapEntry
+}
+
+// Record registers an over-tolerance gap for coin and reports whether this
+// cycle should fire an operator alert, along with the coin's post-increment
+// consecutive over-tolerance cycle count (the duration shown in messages). No
+// alert fires until the streak reaches hlReconcileGapAlertThreshold; the first
+// alert fires on that crossing, then re-throttles while the gap persists.
+func (t *HLReconcileGapTracker) Record(coin string, delta float64, now time.Time) (bool, int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.entries == nil {
+		t.entries = make(map[string]*hlReconcileGapEntry)
+	}
+	e := t.entries[coin]
+	if e == nil {
+		e = &hlReconcileGapEntry{}
+		t.entries[coin] = e
+	}
+	e.cycles++
+
+	// Confirmation window: a transient one- or two-cycle gap (indexer lag that
+	// resolves once the fill is indexed) never reaches the threshold — it
+	// clears via Clear first — so it never alerts.
+	if e.cycles < hlReconcileGapAlertThreshold {
+		return false, e.cycles
+	}
+
+	// "Materially changed" = the residual moved, since the LAST NOTIFICATION,
+	// by more than the qty epsilon AND more than hlReconcileGapRealertRatio of
+	// the notified magnitude — so a growing/sign-flipping gap re-surfaces while
+	// small per-cycle wiggle stays inside the backed-off cadence.
+	deltaMove := math.Abs(delta - e.lastNotifiedDelta)
+	sigChanged := deltaMove > hlReconcileGapTolerance &&
+		deltaMove > hlReconcileGapRealertRatio*math.Abs(e.lastNotifiedDelta)
+
+	shouldNotify := false
+	switch {
+	case !e.alerted:
+		shouldNotify = true // first crossing of the confirmation window
+	case sigChanged:
+		shouldNotify = true
+	case e.cycles%10 == 0:
+		shouldNotify = true
+	case !e.lastNotifiedAt.IsZero() && now.Sub(e.lastNotifiedAt) >= time.Hour:
+		shouldNotify = true
+	}
+	if shouldNotify {
+		e.alerted = true
+		e.lastNotifiedAt = now
+		e.lastNotifiedDelta = delta
+	}
+	return shouldNotify, e.cycles
+}
+
+// Clear resets the streak for coin after a within-tolerance (or vanished)
+// cycle and reports whether the coin had alerted (a recovery notice is
+// warranted) plus the consecutive over-tolerance cycle count that just ended.
+func (t *HLReconcileGapTracker) Clear(coin string) (bool, int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.entries == nil {
+		return false, 0
+	}
+	e := t.entries[coin]
+	if e == nil {
+		return false, 0
+	}
+	recovered := e.alerted
+	priorCount := e.cycles
+	delete(t.entries, coin)
+	return recovered, priorCount
+}
+
+// trackedCoins returns the sorted set of coins with a live streak.
+func (t *HLReconcileGapTracker) trackedCoins() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	coins := make([]string, 0, len(t.entries))
+	for c := range t.entries {
+		coins = append(coins, c)
+	}
+	sort.Strings(coins)
+	return coins
+}
+
+// hlReconcileGapTracker is the package-level singleton; resets on restart.
+var hlReconcileGapTracker = &HLReconcileGapTracker{}
+
+// hlReconcileGapResult is a snapshot of one shared coin's reconciliation gap
+// for a cycle, built from state.ReconciliationGaps under the read lock before
+// the (blocking) DM emission.
+type hlReconcileGapResult struct {
+	Coin       string
+	DeltaQty   float64
+	VirtualQty float64
+	OnChainQty float64
+	Strategies []string
+}
+
+func formatHLReconcileGapAlert(r hlReconcileGapResult, count int) string {
+	strats := "—"
+	if len(r.Strategies) > 0 {
+		strats = strings.Join(r.Strategies, ", ")
+	}
+	return fmt.Sprintf(
+		"**HL RECONCILE GAP** %s (pid=%d, %d consecutive cycles): virtual=%.6f vs on-chain=%.6f, residual=%+.6f could not be explained by an exact-OID fill. A phantom virtual position is feeding drawdown/kill-switch math. Strategies: %s. Verify the on-chain fill in HL user-fills and reconcile manually if needed — fail-closed by design: no SL close is booked or owner guessed without exact-OID confirmation.",
+		r.Coin, os.Getpid(), count, r.VirtualQty, r.OnChainQty, r.DeltaQty, strats)
+}
+
+func formatHLReconcileGapRecovered(coin string, priorCount int) string {
+	return fmt.Sprintf(
+		"**HL RECONCILE GAP RESOLVED** %s (pid=%d): the shared-coin reconciliation gap cleared after %d cycles of drift.",
+		coin, os.Getpid(), priorCount)
+}
+
+// reportHLReconcileGaps evaluates each shared coin's post-reconcile gap against
+// the qty tolerance and fires throttled owner alerts (first detection after the
+// confirmation window, then backed off) or a one-shot recovery notice when a
+// previously-alerting gap clears. Gaps are always recorded so counts and
+// recovery state stay accurate even with no notifier. It must be called every
+// cycle the reconciler ran (so cycle counts equal reconcile invocations), with
+// results built from state.ReconciliationGaps; coins no longer present in the
+// gap map (no longer shared, or reconciled away) are swept and recovery-cleared.
+//
+// It never books, guesses, or mutates positions — alerting only — so the
+// fail-closed reconciliation invariant is preserved.
+func reportHLReconcileGaps(notifier ownerDMSender, results []hlReconcileGapResult) {
+	now := time.Now().UTC()
+	emit := func(msg string) {
+		if notifier == nil || isNilSender(notifier) {
+			return
+		}
+		notifier.SendOwnerDM(msg)
+	}
+	present := make(map[string]bool, len(results))
+	// Sort for deterministic alert ordering across the cycle.
+	sort.Slice(results, func(i, j int) bool { return results[i].Coin < results[j].Coin })
+	for _, r := range results {
+		present[r.Coin] = true
+		if math.Abs(r.DeltaQty) > hlReconcileGapTolerance {
+			shouldNotify, count := hlReconcileGapTracker.Record(r.Coin, r.DeltaQty, now)
+			fmt.Printf("[WARN] hl-sync: %s reconciliation gap residual=%+.6f persists (virtual=%.6f on-chain=%.6f, strategies: %v)\n",
+				r.Coin, r.DeltaQty, r.VirtualQty, r.OnChainQty, r.Strategies)
+			if shouldNotify {
+				emit(formatHLReconcileGapAlert(r, count))
+			}
+			continue
+		}
+		if recovered, prior := hlReconcileGapTracker.Clear(r.Coin); recovered {
+			emit(formatHLReconcileGapRecovered(r.Coin, prior))
+		}
+	}
+	// Sweep coins tracked from a prior cycle that are absent this cycle (no
+	// longer shared, or reconciled away): treat as resolved.
+	for _, coin := range hlReconcileGapTracker.trackedCoins() {
+		if present[coin] {
+			continue
+		}
+		if recovered, prior := hlReconcileGapTracker.Clear(coin); recovered {
+			emit(formatHLReconcileGapRecovered(coin, prior))
+		}
+	}
+}
+
+// collectHLReconcileGapResults snapshots state.ReconciliationGaps under the
+// read lock into a slice safe to use after the lock is released.
+func collectHLReconcileGapResults(state *AppState, mu *sync.RWMutex) []hlReconcileGapResult {
+	mu.RLock()
+	defer mu.RUnlock()
+	if len(state.ReconciliationGaps) == 0 {
+		return nil
+	}
+	results := make([]hlReconcileGapResult, 0, len(state.ReconciliationGaps))
+	for coin, g := range state.ReconciliationGaps {
+		if g == nil {
+			continue
+		}
+		strats := make([]string, len(g.Strategies))
+		copy(strats, g.Strategies)
+		results = append(results, hlReconcileGapResult{
+			Coin:       coin,
+			DeltaQty:   g.DeltaQty,
+			VirtualQty: g.VirtualQty,
+			OnChainQty: g.OnChainQty,
+			Strategies: strats,
+		})
+	}
+	return results
+}

--- a/scheduler/hl_reconcile_gap_alerts_test.go
+++ b/scheduler/hl_reconcile_gap_alerts_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// recordingDMSender captures every owner DM for assertions.
+type recordingDMSender struct {
+	msgs []string
+}
+
+func (r *recordingDMSender) SendOwnerDM(content string) { r.msgs = append(r.msgs, content) }
+
+func gapResult(coin string, delta float64) hlReconcileGapResult {
+	return hlReconcileGapResult{
+		Coin:       coin,
+		DeltaQty:   delta,
+		VirtualQty: 1.0,
+		OnChainQty: 1.0 - delta,
+		Strategies: []string{"hl-owner-" + coin, "hl-peer-" + coin},
+	}
+}
+
+// TestHLReconcileGapTracker_ConfirmationWindow verifies no alert fires until a
+// gap persists hlReconcileGapAlertThreshold consecutive cycles, then exactly
+// one alert on the crossing.
+func TestHLReconcileGapTracker_ConfirmationWindow(t *testing.T) {
+	tr := &HLReconcileGapTracker{}
+	now := time.Now().UTC()
+	for i := 1; i < hlReconcileGapAlertThreshold; i++ {
+		if notify, count := tr.Record("ETH", 1.0, now); notify {
+			t.Fatalf("cycle %d: alerted before confirmation window (count=%d)", i, count)
+		}
+	}
+	notify, count := tr.Record("ETH", 1.0, now)
+	if !notify {
+		t.Fatalf("expected alert on threshold crossing (count=%d)", count)
+	}
+	if count != hlReconcileGapAlertThreshold {
+		t.Fatalf("count = %d, want %d", count, hlReconcileGapAlertThreshold)
+	}
+}
+
+// TestHLReconcileGapTracker_TransientSelfHeals verifies a gap that clears before
+// the confirmation window never alerts (and re-arms its streak afterward).
+func TestHLReconcileGapTracker_TransientSelfHeals(t *testing.T) {
+	tr := &HLReconcileGapTracker{}
+	now := time.Now().UTC()
+	if notify, _ := tr.Record("ETH", 1.0, now); notify {
+		t.Fatalf("cycle 1 should not alert")
+	}
+	if recovered, prior := tr.Clear("ETH"); recovered {
+		t.Fatalf("transient clear should not be a recovery (alerted=false), prior=%d", prior)
+	}
+	// Streak fully reset: a fresh gap starts the window over.
+	if notify, count := tr.Record("ETH", 1.0, now); notify || count != 1 {
+		t.Fatalf("post-clear Record = (%v, %d), want (false, 1)", notify, count)
+	}
+}
+
+// TestHLReconcileGapTracker_ThrottleAndRealert verifies that after the first
+// alert the tracker re-throttles, re-alerts on a materially changed residual,
+// and otherwise only on the every-10th-cycle cadence.
+func TestHLReconcileGapTracker_ThrottleAndRealert(t *testing.T) {
+	tr := &HLReconcileGapTracker{}
+	now := time.Now().UTC()
+	var firstAlertCycle int
+	for i := 0; i < hlReconcileGapAlertThreshold; i++ {
+		notify, count := tr.Record("ETH", 1.0, now)
+		if notify {
+			firstAlertCycle = count
+		}
+	}
+	if firstAlertCycle != hlReconcileGapAlertThreshold {
+		t.Fatalf("first alert at cycle %d, want %d", firstAlertCycle, hlReconcileGapAlertThreshold)
+	}
+	// Same residual next cycle: throttled (not 10th, not materially changed).
+	if notify, _ := tr.Record("ETH", 1.0, now); notify {
+		t.Fatalf("steady gap should be throttled immediately after first alert")
+	}
+	// Materially changed residual (>10% move): re-alert.
+	if notify, _ := tr.Record("ETH", 1.5, now); !notify {
+		t.Fatalf("materially changed residual should re-alert")
+	}
+	// Back to throttled for a steady residual.
+	if notify, _ := tr.Record("ETH", 1.5, now); notify {
+		t.Fatalf("steady residual after re-alert should throttle")
+	}
+}
+
+// TestHLReconcileGapTracker_Recovery verifies Clear reports recovery only once
+// a gap actually alerted.
+func TestHLReconcileGapTracker_Recovery(t *testing.T) {
+	tr := &HLReconcileGapTracker{}
+	now := time.Now().UTC()
+	for i := 0; i < hlReconcileGapAlertThreshold; i++ {
+		tr.Record("ETH", 1.0, now)
+	}
+	recovered, prior := tr.Clear("ETH")
+	if !recovered {
+		t.Fatalf("alerted gap should report recovery on Clear")
+	}
+	if prior != hlReconcileGapAlertThreshold {
+		t.Fatalf("recovery prior count = %d, want %d", prior, hlReconcileGapAlertThreshold)
+	}
+}
+
+// TestReportHLReconcileGaps_AlertsAfterWindow drives the report entrypoint over
+// several cycles and asserts exactly one alert DM fires on the confirmation
+// crossing, none before, and that the message carries the residual + fail-closed
+// language.
+func TestReportHLReconcileGaps_AlertsAfterWindow(t *testing.T) {
+	hlReconcileGapTracker = &HLReconcileGapTracker{}
+	dm := &recordingDMSender{}
+	for i := 1; i < hlReconcileGapAlertThreshold; i++ {
+		reportHLReconcileGaps(dm, []hlReconcileGapResult{gapResult("ETH", 1.0)})
+		if len(dm.msgs) != 0 {
+			t.Fatalf("cycle %d: %d DMs before window, want 0", i, len(dm.msgs))
+		}
+	}
+	reportHLReconcileGaps(dm, []hlReconcileGapResult{gapResult("ETH", 1.0)})
+	if len(dm.msgs) != 1 {
+		t.Fatalf("expected 1 alert DM at window crossing, got %d", len(dm.msgs))
+	}
+	got := dm.msgs[0]
+	if !strings.Contains(got, "HL RECONCILE GAP") || !strings.Contains(got, "ETH") {
+		t.Errorf("alert missing header/coin: %q", got)
+	}
+	if !strings.Contains(got, "fail-closed") {
+		t.Errorf("alert should state fail-closed invariant: %q", got)
+	}
+}
+
+// TestReportHLReconcileGaps_RecoveryWhenGapClears verifies a within-tolerance
+// cycle after an alerting gap emits exactly one recovery DM.
+func TestReportHLReconcileGaps_RecoveryWhenGapClears(t *testing.T) {
+	hlReconcileGapTracker = &HLReconcileGapTracker{}
+	dm := &recordingDMSender{}
+	for i := 0; i < hlReconcileGapAlertThreshold; i++ {
+		reportHLReconcileGaps(dm, []hlReconcileGapResult{gapResult("ETH", 1.0)})
+	}
+	if len(dm.msgs) != 1 {
+		t.Fatalf("setup: want 1 alert, got %d", len(dm.msgs))
+	}
+	// Gap clears (residual within tolerance) → recovery.
+	reportHLReconcileGaps(dm, []hlReconcileGapResult{gapResult("ETH", 0.0)})
+	if len(dm.msgs) != 2 {
+		t.Fatalf("want recovery DM, total = %d", len(dm.msgs))
+	}
+	if !strings.Contains(dm.msgs[1], "RESOLVED") {
+		t.Errorf("second DM should be recovery: %q", dm.msgs[1])
+	}
+	// A subsequent clean cycle emits nothing further.
+	reportHLReconcileGaps(dm, []hlReconcileGapResult{gapResult("ETH", 0.0)})
+	if len(dm.msgs) != 2 {
+		t.Fatalf("clean cycle should be silent, total = %d", len(dm.msgs))
+	}
+}
+
+// TestReportHLReconcileGaps_VanishedCoinRecovers verifies a coin that drops out
+// of the gap map entirely (no longer shared) recovers via the sweep.
+func TestReportHLReconcileGaps_VanishedCoinRecovers(t *testing.T) {
+	hlReconcileGapTracker = &HLReconcileGapTracker{}
+	dm := &recordingDMSender{}
+	for i := 0; i < hlReconcileGapAlertThreshold; i++ {
+		reportHLReconcileGaps(dm, []hlReconcileGapResult{gapResult("ETH", 1.0)})
+	}
+	if len(dm.msgs) != 1 {
+		t.Fatalf("setup: want 1 alert, got %d", len(dm.msgs))
+	}
+	// ETH no longer present in the gap map (peer closed → not shared).
+	reportHLReconcileGaps(dm, nil)
+	if len(dm.msgs) != 2 || !strings.Contains(dm.msgs[1], "RESOLVED") {
+		t.Fatalf("vanished coin should recover, msgs=%v", dm.msgs)
+	}
+	if len(hlReconcileGapTracker.trackedCoins()) != 0 {
+		t.Fatalf("tracker should be empty after sweep, got %v", hlReconcileGapTracker.trackedCoins())
+	}
+}
+
+// TestReportHLReconcileGaps_NilNotifierStillTracks verifies recording proceeds
+// without a notifier (so counts/recovery stay correct) and does not panic on a
+// nil sender.
+func TestReportHLReconcileGaps_NilNotifierStillTracks(t *testing.T) {
+	hlReconcileGapTracker = &HLReconcileGapTracker{}
+	for i := 0; i < hlReconcileGapAlertThreshold; i++ {
+		reportHLReconcileGaps(nil, []hlReconcileGapResult{gapResult("ETH", 1.0)})
+	}
+	if coins := hlReconcileGapTracker.trackedCoins(); len(coins) != 1 || coins[0] != "ETH" {
+		t.Fatalf("nil-notifier path should still track, got %v", coins)
+	}
+	// Nil *MultiNotifier (typed nil) must also be safe.
+	reportHLReconcileGaps((*MultiNotifier)(nil), []hlReconcileGapResult{gapResult("ETH", 1.0)})
+}
+
+// TestReportHLReconcileGaps_BelowToleranceNoAlert verifies sub-epsilon residuals
+// are treated as noise (no streak, no alert).
+func TestReportHLReconcileGaps_BelowToleranceNoAlert(t *testing.T) {
+	hlReconcileGapTracker = &HLReconcileGapTracker{}
+	dm := &recordingDMSender{}
+	for i := 0; i < hlReconcileGapAlertThreshold+2; i++ {
+		reportHLReconcileGaps(dm, []hlReconcileGapResult{gapResult("ETH", hlReconcileGapTolerance/2)})
+	}
+	if len(dm.msgs) != 0 {
+		t.Fatalf("sub-tolerance residual should never alert, got %d DMs", len(dm.msgs))
+	}
+	if len(hlReconcileGapTracker.trackedCoins()) != 0 {
+		t.Fatalf("sub-tolerance residual should not create a streak, got %v", hlReconcileGapTracker.trackedCoins())
+	}
+}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1344,6 +1344,12 @@ func main() {
 							fmt.Fprintf(os.Stderr, "[WARN] hl-sync: json.Marshal(fillHints): %v\n", err)
 						}
 					}
+					// #971: surface persistent shared-coin reconciliation gaps
+					// (fail-closed residuals the reconciler could not confirm by
+					// exact OID, leaving a phantom virtual position) to the
+					// operator after a short confirmation window. Alerting only —
+					// never books or guesses, so the fail-closed invariant holds.
+					reportHLReconcileGaps(notifier, collectHLReconcileGapResults(state, &mu))
 				}
 
 				// #621: Build a coin→|on-chain qty| map from the pre-fetched positions


### PR DESCRIPTION
## Summary
Adds active operator alerting for persistent Hyperliquid shared-coin reconciliation gaps. When a shared-coin position partially drops but the reconciler cannot confirm the residual via an exact stop-loss/TP OID (user-fills miss or wrong OID), it fails closed (#964/#965): no owner is guessed, no SL close is booked — leaving a `ReconciliationGap` and a phantom virtual position that keeps feeding drawdown/kill-switch math. Previously this was visible only via `/status` and stderr `[WARN]`; there was no active alert.

## What changed
- **`scheduler/hl_reconcile_gap_alerts.go`** — `HLReconcileGapTracker` (in-memory, per-coin, resets on restart). A gap must persist **3 consecutive reconcile cycles** before the first owner DM, then re-throttles (re-alert only on a materially-changed residual, every 10th cycle, or hourly), with a one-shot recovery notice when it clears or the coin stops being shared. Modeled on `SharedWalletDriftTracker` (#918).
- **`scheduler/main.go`** — calls `reportHLReconcileGaps(...)` as a separate main-loop step right after the reconcile pass (analogous to `reportSharedWalletDrift`), reading the already-populated `state.ReconciliationGaps`.

## Design notes
- **Alerting only.** It never books, guesses an owner, or mutates a position — the fail-closed invariant is fully preserved.
- **Placed outside `reconcileHyperliquidAccountPositions`** (not inside it) to mirror the existing drift-alert pattern and to avoid contaminating the 24 reconcile tests' exact-DM-count assertions via the global tracker.
- **Auto-heal intentionally dropped.** As surfaced during issue validation, the reconciler already heals a gap within a later cycle the moment a user-fills lookup confirms the exact OID (the `confirmedSLFills` / Detector paths re-run every cycle with a freshly-built fill resolver). A transient miss self-heals; only a permanently-unconfirmable gap persists — for which alerting, not healing, is the correct response.
- **Confirmation window = 3** (vs the drift tracker's 2): a recorded gap already means this cycle's lookup failed, so 3 absorbs brief HL indexer lag while still surfacing a genuinely stuck gap within a few cycles.

## Tests
`scheduler/hl_reconcile_gap_alerts_test.go` — confirmation window, transient self-heal, throttle/re-alert, recovery, vanished-coin sweep, nil-notifier safety, sub-tolerance noise. Full scheduler suite green; build clean.

Closes #971

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code