### PR TITLE
feat(backtest): eval_windows.py — M1 multi-window incumbent-relative validation harness (#977)

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -66,6 +66,14 @@ import math
 from typing import Any, Optional, Tuple
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
+# Repo root, so `from shared_strategies.close... import` (post_tp_sl.py,
+# trailing_tp_ratchet.py — loaded unconditionally in __init__) resolves under
+# script-style invocation (`python backtest/run_backtest.py`), where only the
+# script's own directory is on sys.path. pytest masks this by inserting the
+# root during collection of the shared_strategies package tests.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 import numpy as np
 import pandas as pd

--- a/backtest/eval_windows.py
+++ b/backtest/eval_windows.py
@@ -298,10 +298,47 @@ def compute_incumbent_legs(reg, datasets: List[tuple], window: tuple,
     return out
 
 
+def validate_candidate(candidate: dict) -> dict:
+    """Reject candidate configs the harness cannot faithfully model.
+
+    Mirrors the run_backtest.py --config guards: the plain long/flat signal
+    path (no close evaluator) cannot open shorts (signal=-1 only closes a
+    long), so a short/both direction there would silently score as long/flat
+    — a misleading verdict, not an error. Likewise invert_signal is
+    HL-perps/manual-only live (config.go rejects it elsewhere at startup), so
+    a candidate declaring another type must not have signals flipped on a
+    path the live daemon would refuse to load.
+    """
+    if not isinstance(candidate, dict) or not candidate.get("name"):
+        raise ValueError("candidate needs a 'name'")
+    direction = str(candidate.get("direction") or "long").strip().lower()
+    if direction not in ("long", "short", "both"):
+        raise ValueError(
+            f"candidate direction must be long/short/both, got "
+            f"{candidate.get('direction')!r}")
+    close_refs = candidate.get("close_strategies")
+    if direction in ("short", "both") and not close_refs:
+        raise ValueError(
+            f"candidate has direction={direction!r} but no close_strategies. "
+            f"The plain long/flat signal path cannot open shorts (signal=-1 "
+            f"only closes a long), so the short side would be silently "
+            f"dropped. Add close_strategies (the open/close engine models "
+            f"both sides) or evaluate a long-only variant.")
+    ctype = str(candidate.get("type") or "perps").strip().lower()
+    if candidate.get("invert_signal") and ctype not in ("perps", "manual"):
+        raise ValueError(
+            f"candidate sets invert_signal on type={ctype!r}, but "
+            f"invert_signal is HL-perps/manual-only (the live daemon rejects "
+            f"this at startup — config.go). Remove invert_signal or declare "
+            f"type perps/manual.")
+    return candidate
+
+
 def evaluate_window(reg, candidate: dict, datasets: List[tuple],
                     window_name: str, capital: float,
                     bars_memo: dict) -> dict:
     """Candidate legs + incumbent bars + verdict for one window."""
+    validate_candidate(candidate)
     window = WINDOWS[window_name]
     if window_name not in bars_memo:
         bars_memo[window_name] = incumbent_bars(
@@ -464,6 +501,11 @@ def main(argv: Optional[List[str]] = None) -> int:
             candidate["params"] = json.loads(args.params)
     else:
         raise SystemExit("supply --strategy or --candidate-json")
+
+    try:
+        validate_candidate(candidate)
+    except ValueError as exc:
+        raise SystemExit(str(exc))
 
     if args.windows:
         window_names = [w.strip() for w in args.windows.split(",") if w.strip()]

--- a/backtest/eval_windows.py
+++ b/backtest/eval_windows.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+"""
+eval_windows.py — M1 multi-window incumbent-relative validation harness (#977).
+
+One command per application issue (#979-#993): runs a candidate strategy config
+across the audit datasets and protocol/held-out windows, recomputes the
+incumbent-median bar per (window, dataset) on the identical harness, and emits
+per-dataset Sharpe / return / max-DD / DD-adjusted-return / trades, pass/fail
+verdicts, and optional plateau sweeps.
+
+Harness is audit-identical (#956/#963/#976): registry default or supplied
+params, single mode, binanceus fee model, long-leg signal path unless the
+candidate config supplies close refs / direction. Sharpe uses the Backtester's
+timeframe-annualized scale, the same scale on both sides of the bar.
+
+The incumbent set and window definitions are versioned HERE so bars stay
+reproducible as data accrues — change them only with a corresponding note on
+#977.
+
+Examples:
+  # Full protocol + held-out verdict table for a candidate with default params
+  uv run --no-sync python backtest/eval_windows.py --strategy regime_adaptive_htf
+
+  # Explicit params, futures registry, OOS window only
+  uv run --no-sync python backtest/eval_windows.py --strategy breakout \\
+      --registry futures --params '{"period": 20}' --windows oos
+
+  # Plateau sweep (M1 step 6) over htf_factor on the protocol OOS window
+  uv run --no-sync python backtest/eval_windows.py --strategy regime_adaptive_htf \\
+      --sweep htf_factor=4,5,6,8,10,12
+"""
+
+import argparse
+import itertools
+import json
+import math
+import os
+import statistics
+import sys
+from typing import List, Optional
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
+
+# ---------------------------------------------------------------------------
+# Versioned harness definitions (#977). The incumbent set is the #963/#976
+# eight: the #956 audit's OOS top-8 with futures-only `breakout` excluded from
+# the long-leg harness and `sma_crossover` (next-ranked "both" strategy) in its
+# slot. All eight exist byte-identical in both registries, so the bar is valid
+# for spot and futures candidates alike.
+# ---------------------------------------------------------------------------
+INCUMBENTS = [
+    "momentum_pro",
+    "chart_pattern",
+    "squeeze_momentum",
+    "mean_reversion_pro",
+    "donchian_breakout",
+    "ichimoku_cloud",
+    "range_scalper",
+    "sma_crossover",
+]
+
+# The six audit datasets (#956): BTC/ETH/SOL x 1h/4h.
+DATASETS = [
+    ("BTC/USDT", "1h"),
+    ("BTC/USDT", "4h"),
+    ("ETH/USDT", "1h"),
+    ("ETH/USDT", "4h"),
+    ("SOL/USDT", "1h"),
+    ("SOL/USDT", "4h"),
+]
+
+# (start, end) date strings; end=None means "latest cached bar". The protocol
+# split mirrors #963/#976 (IS since 2025-06-10, OOS since 2026-01-01); the
+# held-out windows (M1 step 7) were never used during any incumbent's design.
+WINDOWS = {
+    "is":     ("2025-06-10", "2026-01-01"),
+    "oos":    ("2026-01-01", None),
+    "2023":   ("2023-01-01", "2024-01-01"),
+    "2024":   ("2024-01-01", "2025-01-01"),
+    "2025H1": ("2025-01-01", "2025-07-01"),
+}
+PROTOCOL_WINDOWS = ("is", "oos")
+HELD_OUT_WINDOWS = ("2023", "2024", "2025H1")
+
+DEFAULT_CAPITAL = 1000.0
+PLATFORM = "binanceus"  # audit fee model; fixed, not a knob
+
+
+# ---------------------------------------------------------------------------
+# Pure scoring helpers (unit-tested without data access).
+# ---------------------------------------------------------------------------
+
+def dd_adjusted_return(return_pct: float, max_dd_pct: float) -> float:
+    """DDadj = total return / |max drawdown| (#963 definition).
+
+    A leg with zero drawdown carries no risk denominator; return 0.0 so an
+    untraded leg never inflates the mean (zero-trade legs are additionally
+    flagged degenerate in score_candidate).
+    """
+    if not max_dd_pct:
+        return 0.0
+    return return_pct / abs(max_dd_pct)
+
+
+def leg_from_results(results: dict, bh_return_pct: Optional[float] = None) -> dict:
+    """Collapse a Backtester result dict to the per-leg metrics M1 reports."""
+    ret = float(results["total_return_pct"])
+    dd = float(results["max_drawdown_pct"])
+    return {
+        "sharpe": float(results["sharpe_ratio"]),
+        "return_pct": ret,
+        "max_dd_pct": dd,
+        "ddadj": round(dd_adjusted_return(ret, dd), 3),
+        "trades": int(results["total_trades"]),
+        "bh_return_pct": bh_return_pct,
+    }
+
+
+def incumbent_bars(incumbent_legs: dict) -> dict:
+    """Per-dataset incumbent-median bars (M1 step 2).
+
+    ``incumbent_legs``: {dataset_key: {incumbent_name: leg | None}}.
+    Returns {dataset_key: {"sharpe": median, "ddadj": median, "n": count}}
+    over incumbents that produced a leg; a dataset where no incumbent ran
+    yields None (no bar — the candidate leg is reported but unscored).
+    """
+    bars = {}
+    for ds, legs in incumbent_legs.items():
+        present = [leg for leg in legs.values() if leg is not None]
+        if not present:
+            bars[ds] = None
+            continue
+        bars[ds] = {
+            "sharpe": round(statistics.median(l["sharpe"] for l in present), 3),
+            "ddadj": round(statistics.median(l["ddadj"] for l in present), 3),
+            "n": len(present),
+        }
+    return bars
+
+
+def score_candidate(candidate_legs: dict, bars: dict) -> dict:
+    """Verdict for one window (M1 steps 2 + 5).
+
+    Pass = candidate mean beats the mean per-dataset bar on BOTH Sharpe and
+    DDadj, across datasets where both sides ran, AND the result is not
+    degenerate (must trade on a majority of scored datasets — #976 rejected
+    zero-trade-leg passes as meaningless).
+    """
+    rows = []
+    for ds in candidate_legs:
+        leg = candidate_legs[ds]
+        bar = bars.get(ds)
+        row = {"dataset": ds, "leg": leg, "bar": bar,
+               "beats_sharpe": None, "beats_ddadj": None}
+        if leg is not None and bar is not None:
+            row["beats_sharpe"] = leg["sharpe"] > bar["sharpe"]
+            row["beats_ddadj"] = leg["ddadj"] > bar["ddadj"]
+        rows.append(row)
+
+    scored = [r for r in rows if r["leg"] is not None and r["bar"] is not None]
+    if not scored:
+        return {"rows": rows, "scored_datasets": 0, "verdict": "no data"}
+
+    mean_sharpe = statistics.mean(r["leg"]["sharpe"] for r in scored)
+    mean_ddadj = statistics.mean(r["leg"]["ddadj"] for r in scored)
+    mean_bar_sharpe = statistics.mean(r["bar"]["sharpe"] for r in scored)
+    mean_bar_ddadj = statistics.mean(r["bar"]["ddadj"] for r in scored)
+    traded = sum(1 for r in scored if r["leg"]["trades"] > 0)
+    degenerate = traded < math.ceil(len(scored) / 2)
+    beats_both = (mean_sharpe > mean_bar_sharpe) and (mean_ddadj > mean_bar_ddadj)
+
+    if degenerate:
+        verdict = "degenerate"
+    elif beats_both:
+        verdict = "pass"
+    else:
+        verdict = "fail"
+
+    return {
+        "rows": rows,
+        "scored_datasets": len(scored),
+        "traded_datasets": traded,
+        "mean_sharpe": round(mean_sharpe, 3),
+        "mean_ddadj": round(mean_ddadj, 3),
+        "mean_bar_sharpe": round(mean_bar_sharpe, 3),
+        "mean_bar_ddadj": round(mean_bar_ddadj, 3),
+        "beats_sharpe_count": sum(1 for r in scored if r["beats_sharpe"]),
+        "beats_ddadj_count": sum(1 for r in scored if r["beats_ddadj"]),
+        "degenerate": degenerate,
+        "verdict": verdict,
+    }
+
+
+def parse_sweep_arg(raw: str) -> tuple:
+    """Parse 'param=v1,v2,v3' into (param, [values]) with numeric coercion."""
+    if "=" not in raw:
+        raise ValueError(f"--sweep expects param=v1,v2,...  got: {raw!r}")
+    param, _, values = raw.partition("=")
+    param = param.strip()
+    if not param or not values.strip():
+        raise ValueError(f"--sweep expects param=v1,v2,...  got: {raw!r}")
+    out = []
+    for v in values.split(","):
+        v = v.strip()
+        try:
+            out.append(int(v))
+        except ValueError:
+            try:
+                out.append(float(v))
+            except ValueError:
+                out.append(v)
+    return param, out
+
+
+def expand_sweep(base_params: dict, sweep_specs: List[tuple]) -> List[tuple]:
+    """Cartesian product of sweep values over base params.
+
+    Returns [(label, params), ...]; label names only the swept params so the
+    plateau table stays readable.
+    """
+    names = [s[0] for s in sweep_specs]
+    grids = [s[1] for s in sweep_specs]
+    combos = []
+    for values in itertools.product(*grids):
+        params = dict(base_params)
+        params.update(dict(zip(names, values)))
+        label = " ".join(f"{n}={v}" for n, v in zip(names, values))
+        combos.append((label, params))
+    return combos
+
+
+def dataset_key(symbol: str, timeframe: str) -> str:
+    return f"{symbol} {timeframe}"
+
+
+def parse_dataset_arg(raw: str) -> tuple:
+    """Parse 'BTC/USDT:1h' into (symbol, timeframe)."""
+    sym, sep, tf = raw.rpartition(":")
+    if not sep or not sym or not tf:
+        raise ValueError(f"--datasets expects SYMBOL:TIMEFRAME, got: {raw!r}")
+    return sym.strip(), tf.strip()
+
+
+# ---------------------------------------------------------------------------
+# Leg execution (I/O; everything above stays pure for tests).
+# ---------------------------------------------------------------------------
+
+def run_leg(reg, name: str, params: Optional[dict], symbol: str, timeframe: str,
+            window: tuple, capital: float = DEFAULT_CAPITAL,
+            close_strategies: Optional[List[dict]] = None,
+            direction: Optional[str] = None,
+            invert_signal: bool = False) -> Optional[dict]:
+    """Run one (strategy, dataset, window) leg on the audit-identical harness."""
+    from atr import ensure_atr_indicator
+    from data_fetcher import load_cached_data
+    from backtester import Backtester
+    from run_backtest import FUNDING_COLUMN_STRATEGIES, _attach_funding_if_needed
+
+    start, end = window
+    df = load_cached_data(symbol, timeframe, start_date=start, end_date=end)
+    if df.empty:
+        return None
+    if name in FUNDING_COLUMN_STRATEGIES:
+        df = _attach_funding_if_needed(df, name, symbol, start)
+
+    strat = reg.STRATEGY_REGISTRY.get(name)
+    if strat is None:
+        raise SystemExit(f"Unknown strategy {name!r}; available: {reg.list_strategies()}")
+    strat_params = params if params is not None else strat["default_params"]
+
+    df_signals = reg.apply_strategy(name, df, strat_params)
+    if close_strategies:
+        df_signals = ensure_atr_indicator(df_signals)
+
+    bt = Backtester(
+        initial_capital=capital, platform=PLATFORM,
+        open_strategy={"name": name, "params": dict(strat_params or {})},
+        close_strategies=close_strategies,
+        direction=direction, invert_signal=invert_signal,
+    )
+    results = bt.run(df_signals, strategy_name=name, symbol=symbol,
+                     timeframe=timeframe, params=strat_params, save=False)
+    closes = df["close"].astype(float)
+    bh = round((closes.iloc[-1] - closes.iloc[0]) / closes.iloc[0] * 100, 2)
+    return leg_from_results(results, bh_return_pct=bh)
+
+
+def compute_incumbent_legs(reg, datasets: List[tuple], window: tuple,
+                           capital: float) -> dict:
+    """All incumbent legs for one window: {dataset_key: {name: leg|None}}."""
+    out = {}
+    for symbol, timeframe in datasets:
+        ds = dataset_key(symbol, timeframe)
+        out[ds] = {}
+        for name in INCUMBENTS:
+            out[ds][name] = run_leg(reg, name, None, symbol, timeframe,
+                                    window, capital=capital)
+    return out
+
+
+def evaluate_window(reg, candidate: dict, datasets: List[tuple],
+                    window_name: str, capital: float,
+                    bars_memo: dict) -> dict:
+    """Candidate legs + incumbent bars + verdict for one window."""
+    window = WINDOWS[window_name]
+    if window_name not in bars_memo:
+        bars_memo[window_name] = incumbent_bars(
+            compute_incumbent_legs(reg, datasets, window, capital))
+    bars = bars_memo[window_name]
+
+    candidate_legs = {}
+    for symbol, timeframe in datasets:
+        ds = dataset_key(symbol, timeframe)
+        candidate_legs[ds] = run_leg(
+            reg, candidate["name"], candidate.get("params"),
+            symbol, timeframe, window, capital=capital,
+            close_strategies=candidate.get("close_strategies"),
+            direction=candidate.get("direction"),
+            invert_signal=bool(candidate.get("invert_signal")),
+        )
+    score = score_candidate(candidate_legs, bars)
+    score["window"] = window_name
+    score["window_range"] = list(window)
+    score["bars"] = bars
+    return score
+
+
+# ---------------------------------------------------------------------------
+# Reporting.
+# ---------------------------------------------------------------------------
+
+def _fmt(v, width=8, prec=2):
+    if v is None:
+        return " " * (width - 1) + "-"
+    return f"{v:>{width}.{prec}f}"
+
+
+def format_window_report(score: dict) -> str:
+    start, end = score["window_range"]
+    lines = [
+        f"\n== window {score['window']} ({start} → {end or 'latest'}) ==",
+        f"{'dataset':<14} {'Sharpe':>8} {'bar':>8} {'DDadj':>8} {'bar':>8} "
+        f"{'ret%':>8} {'maxDD%':>8} {'B&H%':>8} {'trades':>6}  beats",
+    ]
+    for row in score["rows"]:
+        leg, bar = row["leg"], row["bar"]
+        if leg is None:
+            lines.append(f"{row['dataset']:<14} {'(no data)'}")
+            continue
+        beats = ""
+        if row["beats_sharpe"] is not None:
+            beats = ("S" if row["beats_sharpe"] else "-") + \
+                    ("D" if row["beats_ddadj"] else "-")
+        lines.append(
+            f"{row['dataset']:<14} {_fmt(leg['sharpe'])} "
+            f"{_fmt(bar['sharpe'] if bar else None)} {_fmt(leg['ddadj'])} "
+            f"{_fmt(bar['ddadj'] if bar else None)} {_fmt(leg['return_pct'])} "
+            f"{_fmt(leg['max_dd_pct'])} {_fmt(leg['bh_return_pct'])} "
+            f"{leg['trades']:>6}  {beats}"
+        )
+    if score.get("verdict") == "no data":
+        lines.append("verdict: NO DATA")
+        return "\n".join(lines)
+    lines.append(
+        f"{'mean':<14} {_fmt(score['mean_sharpe'])} {_fmt(score['mean_bar_sharpe'])} "
+        f"{_fmt(score['mean_ddadj'])} {_fmt(score['mean_bar_ddadj'])}"
+    )
+    lines.append(
+        f"verdict: {score['verdict'].upper()} — beats bar on "
+        f"{score['beats_sharpe_count']}/{score['scored_datasets']} (Sharpe), "
+        f"{score['beats_ddadj_count']}/{score['scored_datasets']} (DDadj); "
+        f"traded {score['traded_datasets']}/{score['scored_datasets']}"
+        + (" [degenerate: majority of legs zero-trade]" if score["degenerate"] else "")
+    )
+    return "\n".join(lines)
+
+
+def format_summary(window_scores: List[dict]) -> str:
+    lines = [f"\n== summary ==",
+             f"{'window':<10} {'Sharpe':>8} {'bar':>8} {'DDadj':>8} {'bar':>8}  verdict"]
+    for s in window_scores:
+        if s.get("verdict") == "no data":
+            lines.append(f"{s['window']:<10} {'(no data)'}")
+            continue
+        lines.append(
+            f"{s['window']:<10} {_fmt(s['mean_sharpe'])} {_fmt(s['mean_bar_sharpe'])} "
+            f"{_fmt(s['mean_ddadj'])} {_fmt(s['mean_bar_ddadj'])}  {s['verdict'].upper()}"
+        )
+    protocol = [s for s in window_scores if s["window"] in PROTOCOL_WINDOWS]
+    held_out = [s for s in window_scores if s["window"] in HELD_OUT_WINDOWS]
+    oos = next((s for s in window_scores if s["window"] == "oos"), None)
+    if oos is not None and oos.get("verdict") != "no data":
+        held_pass = sum(1 for s in held_out if s.get("verdict") == "pass")
+        lines.append(
+            f"\nprotocol OOS: {oos['verdict'].upper()}"
+            + (f"; held-out windows passed: {held_pass}/{len(held_out)}"
+               if held_out else "")
+        )
+    return "\n".join(lines)
+
+
+def format_sweep_report(sweep_rows: List[dict], window_name: str) -> str:
+    lines = [f"\n== plateau sweep (window {window_name}) ==",
+             f"{'combo':<32} {'Sharpe':>8} {'bar':>8} {'DDadj':>8} "
+             f"{'traded':>7}  verdict"]
+    for r in sweep_rows:
+        s = r["score"]
+        if s.get("verdict") == "no data":
+            lines.append(f"{r['label']:<32} {'(no data)'}")
+            continue
+        lines.append(
+            f"{r['label']:<32} {_fmt(s['mean_sharpe'])} {_fmt(s['mean_bar_sharpe'])} "
+            f"{_fmt(s['mean_ddadj'])} "
+            f"{s['traded_datasets']:>3}/{s['scored_datasets']:<3}  "
+            f"{s['verdict'].upper()}"
+        )
+    lines.append("(M1 step 6: the chosen combo must sit on a broad plateau, "
+                 "not a single-param spike.)")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="M1 multi-window incumbent-relative validation (#977)")
+    p.add_argument("--strategy", help="Candidate open-strategy name")
+    p.add_argument("--params", default=None,
+                   help="Candidate params JSON (default: registry default_params)")
+    p.add_argument("--candidate-json", default=None,
+                   help="Path to a candidate JSON file: {name, params, "
+                        "close_strategies?, direction?, invert_signal?}. "
+                        "Overrides --strategy/--params.")
+    p.add_argument("--registry", choices=["spot", "futures"], default="spot")
+    p.add_argument("--windows", default=None,
+                   help=f"Comma list of windows (default: all). "
+                        f"Known: {', '.join(WINDOWS)}")
+    p.add_argument("--datasets", default=None,
+                   help="Comma list of SYMBOL:TIMEFRAME (default: the six "
+                        "audit datasets)")
+    p.add_argument("--capital", type=float, default=DEFAULT_CAPITAL)
+    p.add_argument("--sweep", action="append", default=None, metavar="P=V1,V2",
+                   help="Plateau sweep over a param (repeatable; cartesian)")
+    p.add_argument("--sweep-window", default="oos", choices=list(WINDOWS),
+                   help="Window the sweep is scored on (default: oos)")
+    p.add_argument("--json", default=None, dest="json_out",
+                   help="Write the full structured result to this path")
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.candidate_json:
+        with open(args.candidate_json) as fh:
+            candidate = json.load(fh)
+        if not isinstance(candidate, dict) or not candidate.get("name"):
+            raise SystemExit(f"{args.candidate_json}: candidate JSON needs a 'name'")
+    elif args.strategy:
+        candidate = {"name": args.strategy}
+        if args.params:
+            candidate["params"] = json.loads(args.params)
+    else:
+        raise SystemExit("supply --strategy or --candidate-json")
+
+    if args.windows:
+        window_names = [w.strip() for w in args.windows.split(",") if w.strip()]
+        unknown = [w for w in window_names if w not in WINDOWS]
+        if unknown:
+            raise SystemExit(f"unknown windows {unknown}; known: {list(WINDOWS)}")
+    else:
+        window_names = list(WINDOWS)
+
+    if args.datasets:
+        datasets = [parse_dataset_arg(d) for d in args.datasets.split(",") if d.strip()]
+    else:
+        datasets = list(DATASETS)
+
+    from registry_loader import load_registry
+    reg = load_registry(args.registry)
+
+    print(f"candidate: {candidate['name']} "
+          f"(params: {candidate.get('params') or 'registry defaults'}, "
+          f"registry: {args.registry})")
+    print(f"incumbent bar: median of {len(INCUMBENTS)} incumbents, "
+          f"recomputed per (window, dataset)")
+
+    bars_memo: dict = {}
+    window_scores = []
+    for wname in window_names:
+        score = evaluate_window(reg, candidate, datasets, wname,
+                                args.capital, bars_memo)
+        window_scores.append(score)
+        print(format_window_report(score))
+
+    print(format_summary(window_scores))
+
+    sweep_rows = []
+    if args.sweep:
+        specs = [parse_sweep_arg(s) for s in args.sweep]
+        base = dict(candidate.get("params") or {})
+        for label, params in expand_sweep(base, specs):
+            combo = dict(candidate)
+            combo["params"] = params
+            score = evaluate_window(reg, combo, datasets, args.sweep_window,
+                                    args.capital, bars_memo)
+            sweep_rows.append({"label": label, "params": params, "score": score})
+        print(format_sweep_report(sweep_rows, args.sweep_window))
+
+    if args.json_out:
+        payload = {
+            "candidate": candidate,
+            "registry": args.registry,
+            "incumbents": INCUMBENTS,
+            "datasets": [dataset_key(s, t) for s, t in datasets],
+            "windows": {w: list(WINDOWS[w]) for w in window_names},
+            "window_scores": window_scores,
+            "sweep": sweep_rows,
+        }
+        with open(args.json_out, "w") as fh:
+            json.dump(payload, fh, indent=2, default=str)
+        print(f"\nwrote {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backtest/tests/test_eval_windows.py
+++ b/backtest/tests/test_eval_windows.py
@@ -1,0 +1,265 @@
+"""Tests for backtest/eval_windows.py (#977 M1 harness) — pure scoring layer.
+
+Leg execution (run_leg) is exercised end-to-end against the Backtester with a
+synthetic frame; everything else (bars, verdicts, sweeps, parsing) is tested
+without data access.
+"""
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import eval_windows as ew
+
+
+def _leg(sharpe, ddadj=0.0, trades=5, return_pct=-1.0, max_dd_pct=-10.0):
+    return {"sharpe": sharpe, "ddadj": ddadj, "trades": trades,
+            "return_pct": return_pct, "max_dd_pct": max_dd_pct,
+            "bh_return_pct": -30.0}
+
+
+# ---------------------------------------------------------------------------
+# dd_adjusted_return
+# ---------------------------------------------------------------------------
+
+def test_ddadj_definition():
+    # #963: DDadj = return / |max DD|
+    assert ew.dd_adjusted_return(-10.0, -50.0) == pytest.approx(-0.2)
+    assert ew.dd_adjusted_return(5.0, -2.5) == pytest.approx(2.0)
+
+
+def test_ddadj_zero_drawdown_is_zero():
+    # No drawdown (typically zero-trade leg) must not inflate the mean.
+    assert ew.dd_adjusted_return(0.0, 0.0) == 0.0
+    assert ew.dd_adjusted_return(12.0, 0.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# leg_from_results
+# ---------------------------------------------------------------------------
+
+def test_leg_from_results_collapses_backtester_dict():
+    results = {"total_return_pct": -12.5, "max_drawdown_pct": -25.0,
+               "sharpe_ratio": -0.9, "total_trades": 17}
+    leg = ew.leg_from_results(results, bh_return_pct=-44.3)
+    assert leg["sharpe"] == -0.9
+    assert leg["return_pct"] == -12.5
+    assert leg["max_dd_pct"] == -25.0
+    assert leg["ddadj"] == pytest.approx(-0.5)
+    assert leg["trades"] == 17
+    assert leg["bh_return_pct"] == -44.3
+
+
+# ---------------------------------------------------------------------------
+# incumbent_bars
+# ---------------------------------------------------------------------------
+
+def test_incumbent_bars_per_dataset_median():
+    legs = {
+        "BTC/USDT 1h": {
+            "a": _leg(-1.0, ddadj=-0.5),
+            "b": _leg(-2.0, ddadj=-1.0),
+            "c": _leg(-3.0, ddadj=-1.5),
+        },
+    }
+    bars = ew.incumbent_bars(legs)
+    assert bars["BTC/USDT 1h"]["sharpe"] == pytest.approx(-2.0)
+    assert bars["BTC/USDT 1h"]["ddadj"] == pytest.approx(-1.0)
+    assert bars["BTC/USDT 1h"]["n"] == 3
+
+
+def test_incumbent_bars_skips_missing_legs_and_empty_datasets():
+    legs = {
+        "BTC/USDT 1h": {"a": _leg(-1.0), "b": None, "c": _leg(-3.0)},
+        "SOL/USDT 4h": {"a": None, "b": None},
+    }
+    bars = ew.incumbent_bars(legs)
+    # median over the two present legs only
+    assert bars["BTC/USDT 1h"]["sharpe"] == pytest.approx(-2.0)
+    assert bars["BTC/USDT 1h"]["n"] == 2
+    # no incumbent ran → no bar for that dataset
+    assert bars["SOL/USDT 4h"] is None
+
+
+# ---------------------------------------------------------------------------
+# score_candidate
+# ---------------------------------------------------------------------------
+
+def _bars(sharpe=-1.0, ddadj=-0.5, datasets=("d1", "d2", "d3", "d4")):
+    return {ds: {"sharpe": sharpe, "ddadj": ddadj, "n": 8} for ds in datasets}
+
+
+def test_score_pass_when_means_beat_bar_on_both_metrics():
+    legs = {ds: _leg(-0.3, ddadj=-0.2) for ds in ("d1", "d2", "d3", "d4")}
+    score = ew.score_candidate(legs, _bars())
+    assert score["verdict"] == "pass"
+    assert score["mean_sharpe"] == pytest.approx(-0.3)
+    assert score["mean_bar_sharpe"] == pytest.approx(-1.0)
+    assert score["beats_sharpe_count"] == 4
+    assert score["beats_ddadj_count"] == 4
+    assert not score["degenerate"]
+
+
+def test_score_fail_when_only_one_metric_beats_bar():
+    # Sharpe beats the bar, DDadj does not → fail (the #955 bar is BOTH).
+    legs = {ds: _leg(-0.3, ddadj=-0.9) for ds in ("d1", "d2", "d3", "d4")}
+    score = ew.score_candidate(legs, _bars(ddadj=-0.5))
+    assert score["verdict"] == "fail"
+
+
+def test_score_degenerate_zero_trade_majority_rejected():
+    # Means beat the bar, but 3/4 legs never traded — #976 rejects these
+    # (htf_factor 5/8 cleared the bar while going zero-trade on 4/6 datasets).
+    legs = {
+        "d1": _leg(-0.3, ddadj=-0.2, trades=4),
+        "d2": _leg(0.0, ddadj=0.0, trades=0),
+        "d3": _leg(0.0, ddadj=0.0, trades=0),
+        "d4": _leg(0.0, ddadj=0.0, trades=0),
+    }
+    score = ew.score_candidate(legs, _bars())
+    assert score["degenerate"]
+    assert score["verdict"] == "degenerate"
+
+
+def test_score_trading_exactly_half_is_not_degenerate():
+    # boundary: ceil(4/2)=2 traded datasets suffice
+    legs = {
+        "d1": _leg(-0.3, ddadj=-0.2, trades=4),
+        "d2": _leg(-0.3, ddadj=-0.2, trades=1),
+        "d3": _leg(0.0, ddadj=0.0, trades=0),
+        "d4": _leg(0.0, ddadj=0.0, trades=0),
+    }
+    score = ew.score_candidate(legs, _bars())
+    assert not score["degenerate"]
+    assert score["verdict"] == "pass"
+
+
+def test_score_unscored_datasets_excluded_from_means():
+    legs = {
+        "d1": _leg(-0.3, ddadj=-0.2),
+        "d2": None,                      # candidate had no data
+        "d3": _leg(-0.5, ddadj=-0.3),
+    }
+    bars = _bars(datasets=("d1", "d3"))
+    bars["d2"] = None                    # incumbents had no data either
+    score = ew.score_candidate(legs, bars)
+    assert score["scored_datasets"] == 2
+    assert score["mean_sharpe"] == pytest.approx(-0.4)
+
+
+def test_score_no_data_verdict():
+    score = ew.score_candidate({"d1": None}, {"d1": None})
+    assert score["verdict"] == "no data"
+
+
+# ---------------------------------------------------------------------------
+# sweep helpers
+# ---------------------------------------------------------------------------
+
+def test_parse_sweep_arg_coerces_numbers():
+    assert ew.parse_sweep_arg("period=10,14,20") == ("period", [10, 14, 20])
+    assert ew.parse_sweep_arg("z=1.75,2.0") == ("z", [1.75, 2.0])
+    assert ew.parse_sweep_arg("mode=fade,breakout") == ("mode", ["fade", "breakout"])
+
+
+def test_parse_sweep_arg_rejects_malformed():
+    with pytest.raises(ValueError):
+        ew.parse_sweep_arg("period")
+    with pytest.raises(ValueError):
+        ew.parse_sweep_arg("=1,2")
+    with pytest.raises(ValueError):
+        ew.parse_sweep_arg("period=")
+
+
+def test_expand_sweep_cartesian_preserves_base_params():
+    combos = ew.expand_sweep({"keep": 1}, [("a", [1, 2]), ("b", ["x"])])
+    assert len(combos) == 2
+    labels = [c[0] for c in combos]
+    assert labels == ["a=1 b=x", "a=2 b=x"]
+    for _, params in combos:
+        assert params["keep"] == 1
+        assert "a" in params and params["b"] == "x"
+
+
+# ---------------------------------------------------------------------------
+# dataset / window definitions
+# ---------------------------------------------------------------------------
+
+def test_parse_dataset_arg():
+    assert ew.parse_dataset_arg("BTC/USDT:1h") == ("BTC/USDT", "1h")
+    with pytest.raises(ValueError):
+        ew.parse_dataset_arg("BTC-USDT-1h")
+
+
+def test_versioned_definitions_match_protocol():
+    # #963/#976 incumbent eight — breakout excluded (futures-only on the
+    # long-leg harness), sma_crossover in its slot.
+    assert len(ew.INCUMBENTS) == 8
+    assert "breakout" not in ew.INCUMBENTS
+    assert "sma_crossover" in ew.INCUMBENTS
+    # six audit datasets, five windows, protocol + held-out partition exact
+    assert len(ew.DATASETS) == 6
+    assert set(ew.PROTOCOL_WINDOWS) | set(ew.HELD_OUT_WINDOWS) == set(ew.WINDOWS)
+    assert ew.WINDOWS["is"] == ("2025-06-10", "2026-01-01")
+    assert ew.WINDOWS["oos"] == ("2026-01-01", None)
+    # held-out windows are bounded (never run to "latest" — they must stay
+    # frozen as data accrues)
+    for w in ew.HELD_OUT_WINDOWS:
+        assert ew.WINDOWS[w][1] is not None
+
+
+# ---------------------------------------------------------------------------
+# run_leg end-to-end on a synthetic frame (no network/cache access)
+# ---------------------------------------------------------------------------
+
+class _FakeRegistry:
+    STRATEGY_REGISTRY = {"alternator": {"default_params": {"period": 2},
+                                        "description": "test"}}
+
+    @staticmethod
+    def list_strategies():
+        return ["alternator"]
+
+    @staticmethod
+    def apply_strategy(name, df, params):
+        out = df.copy()
+        sig = np.zeros(len(out), dtype=int)
+        sig[10::20] = 1   # buy
+        sig[20::20] = -1  # sell
+        out["signal"] = sig
+        return out
+
+
+def _synthetic_df(n=120):
+    idx = pd.date_range("2026-01-01", periods=n, freq="1h")
+    base = 100 + np.cumsum(np.sin(np.arange(n) / 5.0))
+    return pd.DataFrame({
+        "open": base, "high": base * 1.01, "low": base * 0.99,
+        "close": base, "volume": np.full(n, 1000.0),
+    }, index=idx)
+
+
+def test_run_leg_returns_leg_metrics(monkeypatch):
+    df = _synthetic_df()
+    import data_fetcher
+    monkeypatch.setattr(data_fetcher, "load_cached_data",
+                        lambda *a, **k: df, raising=True)
+    leg = ew.run_leg(_FakeRegistry(), "alternator", None, "BTC/USDT", "1h",
+                     ("2026-01-01", None))
+    assert leg is not None
+    assert leg["trades"] > 0
+    for key in ("sharpe", "return_pct", "max_dd_pct", "ddadj",
+                "trades", "bh_return_pct"):
+        assert key in leg
+    # B&H over the synthetic frame: close[-1] vs close[0]
+    expected_bh = (df["close"].iloc[-1] - df["close"].iloc[0]) / df["close"].iloc[0] * 100
+    assert leg["bh_return_pct"] == pytest.approx(expected_bh, abs=0.01)
+
+
+def test_run_leg_empty_data_returns_none(monkeypatch):
+    import data_fetcher
+    monkeypatch.setattr(data_fetcher, "load_cached_data",
+                        lambda *a, **k: pd.DataFrame(), raising=True)
+    assert ew.run_leg(_FakeRegistry(), "alternator", None, "BTC/USDT", "1h",
+                      ("2023-01-01", "2024-01-01")) is None

--- a/backtest/tests/test_eval_windows.py
+++ b/backtest/tests/test_eval_windows.py
@@ -263,3 +263,50 @@ def test_run_leg_empty_data_returns_none(monkeypatch):
                         lambda *a, **k: pd.DataFrame(), raising=True)
     assert ew.run_leg(_FakeRegistry(), "alternator", None, "BTC/USDT", "1h",
                       ("2023-01-01", "2024-01-01")) is None
+
+
+# ---------------------------------------------------------------------------
+# validate_candidate — entry transforms must be modeled faithfully or rejected
+# (mirrors run_backtest.py --config guards; review finding on PR #994)
+# ---------------------------------------------------------------------------
+
+def test_validate_candidate_rejects_short_without_close_refs():
+    with pytest.raises(ValueError, match="silently dropped"):
+        ew.validate_candidate({"name": "x", "direction": "short"})
+
+
+def test_validate_candidate_rejects_both_without_close_refs():
+    # "both" is the sneakier case: _apply_direction_invert never masks it,
+    # so without this guard it runs long/flat with zero indication.
+    with pytest.raises(ValueError, match="silently dropped"):
+        ew.validate_candidate({"name": "x", "direction": "both"})
+
+
+def test_validate_candidate_allows_short_with_close_refs():
+    c = {"name": "x", "direction": "short",
+         "close_strategies": [{"name": "tp_at_pct", "params": {}}]}
+    assert ew.validate_candidate(c) is c
+
+
+def test_validate_candidate_invert_signal_gated_by_type():
+    # default type is perps → allowed; declared non-perps type → rejected
+    assert ew.validate_candidate({"name": "x", "invert_signal": True})
+    assert ew.validate_candidate(
+        {"name": "x", "invert_signal": True, "type": "manual"})
+    with pytest.raises(ValueError, match="invert_signal"):
+        ew.validate_candidate(
+            {"name": "x", "invert_signal": True, "type": "spot"})
+
+
+def test_validate_candidate_rejects_bogus_direction_and_missing_name():
+    with pytest.raises(ValueError, match="direction"):
+        ew.validate_candidate({"name": "x", "direction": "sideways"})
+    with pytest.raises(ValueError, match="name"):
+        ew.validate_candidate({})
+
+
+def test_evaluate_window_validates_before_any_work():
+    # Bad candidate must fail at the gate — reg=None proves nothing ran.
+    with pytest.raises(ValueError, match="silently dropped"):
+        ew.evaluate_window(None, {"name": "x", "direction": "both"},
+                           [("BTC/USDT", "1h")], "oos", 1000.0, {})

--- a/backtest/tests/test_run_backtest_cli.py
+++ b/backtest/tests/test_run_backtest_cli.py
@@ -91,3 +91,30 @@ def test_run_single_backtest_threads_platform_to_backtester(monkeypatch):
         f"platform did not thread through to Backtester — got {seen}"
     )
     assert seen["capital"] == 777.0
+
+
+def test_backtester_imports_under_script_style_sys_path(tmp_path):
+    """Script-style invocation (`python backtest/run_backtest.py`) puts only
+    backtest/ on sys.path. Backtester.__init__ unconditionally loads
+    post_tp_sl.py, whose absolute `shared_strategies.close...` import needs the
+    repo root — backtester.py must insert it itself (pytest masks the gap by
+    inserting the root during shared_strategies package collection)."""
+    import os
+    import subprocess
+    import sys
+
+    backtest_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    snippet = tmp_path / "script_style_import.py"
+    snippet.write_text(
+        "import sys\n"
+        f"sys.path.insert(0, {backtest_dir!r})\n"
+        "import backtester\n"
+        "backtester.Backtester()\n"
+        "print('OK')\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, str(snippet)],
+        cwd=tmp_path, capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "OK" in proc.stdout


### PR DESCRIPTION
Closes #995 (M1 shared-tooling deliverable). Part of the #977 umbrella.

## What

`backtest/eval_windows.py` — the M1 harness, one command per application issue (#979–#993):

- Runs a candidate (`--strategy` + `--params`, or `--candidate-json` with optional `close_strategies` / `direction` / `invert_signal` for M2/M3 reuse) across the six audit datasets (BTC/ETH/SOL × 1h/4h) and five windows: protocol IS (2025-06-10 → 2026-01-01), protocol OOS (2026-01-01 → latest), held-out 2023 / 2024 / 2025H1.
- Recomputes the incumbent-median bar per (window, dataset) on the audit-identical harness (single mode, binanceus fees, timeframe-annualized Sharpe — same scale both sides, per #963).
- Emits per-dataset Sharpe / return / max DD / DDadj / trades / B&H, per-window pass/fail verdicts, a protocol-vs-held-out summary, optional plateau sweeps (`--sweep p=v1,v2`, cartesian, M1 step 6), and `--json` structured output.
- Versioned in-script per #977: the #963/#976 incumbent eight (futures-only `breakout` excluded from the long-leg harness, `sma_crossover` in its slot), datasets, and window definitions.
- Verdict rules mirror #976: pass = candidate mean beats the mean per-dataset bar on BOTH Sharpe and DDadj; results where a majority of legs are zero-trade are flagged `degenerate`, never passed (M1 step 5).

## Drive-by fix the harness surfaced

`Backtester.__init__` unconditionally loads `post_tp_sl.py`, whose absolute `shared_strategies.close...` import requires the repo root on `sys.path`. Script-style invocation (`python backtest/run_backtest.py --mode single`) crashes at init on current main; pytest masked it by inserting the root while collecting the `shared_strategies` package tests. `backtester.py` now inserts the repo root itself (one insert, next to the existing `shared_tools` insert).

## Tests

- `backtest/tests/test_eval_windows.py` — 18 tests: DDadj definition (#963), per-dataset median bars (missing-leg/empty-dataset handling), verdicts (pass / fail-on-one-metric / degenerate zero-trade-majority + half-traded boundary / no-data), sweep parsing + cartesian expansion, versioned-definition pins (incumbent eight, bounded held-out windows), and `run_leg` end-to-end on a synthetic frame (monkeypatched data, no network).
- `backtest/tests/test_run_backtest_cli.py` — subprocess regression for the script-style `sys.path` fix (imports `backtester` and constructs `Backtester` from a foreign cwd).
- Full suite: 1397 passed.
- Smoke (BTC/USDT 4h, OOS window): verdict table + sweep + JSON all working; the sweep output incidentally demonstrates the single-param-spike overfit tell M1 step 6 exists to catch.

---
Created with LLM: Fable 5 | high | Harness: Claude Code
