### PR TITLE
feat(backtest): M2 close-stack co-optimization — joint (open × close) walk-forward sweeps (#996)

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -1153,15 +1153,15 @@ class Backtester:
                     initial_quantity = shares
                     entry_atr_value = self._stamp_entry_atr(atr_series, idx, effective_price)
                     stamp_open_from_label(_entry_stamp(row))
-                    # #716 item 3: seed the SL trigger only when sl_after has
-                    # usable tier thresholds. Without thresholds, the post-TP
-                    # adjustment machinery never fires (`_maybe_apply_sl_after`
-                    # is gated on `self._run_tp_tier_thresholds`), so a seeded-
-                    # then-never-adjusted trigger would represent a phantom
-                    # fixed SL the rest of the engine doesn't actually
-                    # simulate. Mirrors the live shape, where the fixed SL is
-                    # placed by `runHyperliquidProtectionSync` independently
-                    # of `sl_after` configuration.
+                    # Seed the SL trigger at open. sl_after configs seed only
+                    # when usable tier thresholds exist (#716 item 3 — without
+                    # thresholds the post-TP machinery never fires); otherwise
+                    # a bare fixed/trailing stop alongside a close evaluator is
+                    # seeded here and simulated by the end-of-bar hit check
+                    # below (#996 — live arms this SL via
+                    # runHyperliquidProtectionSync / armTrailingStopAtOpenNow
+                    # independently of sl_after; pre-#996 the engine path
+                    # silently dropped it).
                     if sl_after_active and self._run_tp_tier_thresholds:
                         sl_trigger_px = self._initial_sl_trigger(
                             "long", avg_cost, entry_atr_value,
@@ -1174,6 +1174,18 @@ class Backtester:
                             "long", mark_price, entry_atr_value,
                             self._run_trailing_stop_atr_mult,
                         )
+                        sl_tiers_processed = 0
+                        post_tp_trail_mult = None
+                        sl_high_water_px = mark_price
+                    else:
+                        sl_trigger_px = self._initial_sl_trigger(
+                            "long", avg_cost, entry_atr_value,
+                        )
+                        if sl_trigger_px <= 0 and self._run_trailing_stop_atr_mult:
+                            sl_trigger_px = _initial_trail_trigger(
+                                "long", mark_price, entry_atr_value,
+                                self._run_trailing_stop_atr_mult,
+                            )
                         sl_tiers_processed = 0
                         post_tp_trail_mult = None
                         sl_high_water_px = mark_price
@@ -1203,6 +1215,20 @@ class Backtester:
                             "short", mark_price, entry_atr_value,
                             self._run_trailing_stop_atr_mult,
                         )
+                        sl_tiers_processed = 0
+                        post_tp_trail_mult = None
+                        sl_high_water_px = mark_price
+                    else:
+                        # Bare fixed/trailing stop with a close evaluator —
+                        # see the long-side comment (#996).
+                        sl_trigger_px = self._initial_sl_trigger(
+                            "short", avg_cost, entry_atr_value,
+                        )
+                        if sl_trigger_px <= 0 and self._run_trailing_stop_atr_mult:
+                            sl_trigger_px = _initial_trail_trigger(
+                                "short", mark_price, entry_atr_value,
+                                self._run_trailing_stop_atr_mult,
+                            )
                         sl_tiers_processed = 0
                         post_tp_trail_mult = None
                         sl_high_water_px = mark_price
@@ -1240,14 +1266,23 @@ class Backtester:
                             )
                         )
 
-                # End-of-bar: walk the trailing-stop high-water mark (only
-                # active after a TP tier transitioned the position to
-                # trail_from_here mode) and check whether the SL trigger has
-                # been hit by this bar's close. A hit produces
+                # End-of-bar: walk the trailing-stop high-water mark (for
+                # trail_from_here transitions, the ratchet, or a bare scalar
+                # trailing stop) and check whether the SL trigger has been
+                # hit by this bar's close. A hit produces
                 # pending_close_fraction=1.0 which fills at the next bar's
                 # open — same alignment as the rest of the close pipeline.
+                # #996: also runs for bare fixed/trailing/pct stops paired
+                # with a close evaluator, which live arms independently of
+                # sl_after (pre-#996 these were silently dropped here).
+                scalar_stop_active = (
+                    (self._run_stop_loss_atr_mult or 0) > 0
+                    or (self._run_trailing_stop_atr_mult or 0) > 0
+                    or (self.stop_loss_pct or 0) > 0
+                )
                 if (
-                    (sl_after_active or trailing_ratchet_active)
+                    (sl_after_active or trailing_ratchet_active
+                     or scalar_stop_active)
                     and not sl_after_just_applied
                     and position != 0
                     and avg_cost > 0

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -1016,6 +1016,43 @@ class Backtester:
             if not stamp:
                 stamp = _entry_stamp(df.iloc[0])
             stamp_open_from_label(stamp)
+            # Arm the carried position's SL the same way the open block does
+            # (PR #1000 review): a seeded position never routes through the
+            # open block, so without this the fixed/trailing trigger stays at
+            # 0 for its entire lifetime and ATR stacks score as
+            # hold-to-reversal on every fold that opens already-long. The
+            # trail anchors at max(entry, seed high-water) — live would have
+            # walked the HWM through the warmup bars. Works for both paths:
+            # the plain signal path's hit check reads the same sl_trigger_px.
+            seed_hwm = starting_long.get("high_water", 0.0)
+            try:
+                seed_hwm = float(seed_hwm or 0.0)
+            except (TypeError, ValueError):
+                seed_hwm = 0.0
+            hwm_anchor = max(effective_entry, seed_hwm)
+            if sl_after_active and self._run_tp_tier_thresholds:
+                sl_trigger_px = self._initial_sl_trigger(
+                    "long", avg_cost, entry_atr_value,
+                )
+                sl_high_water_px = 0.0
+            elif trailing_ratchet_active and self._run_trailing_stop_atr_mult:
+                sl_trigger_px = _initial_trail_trigger(
+                    "long", hwm_anchor, entry_atr_value,
+                    self._run_trailing_stop_atr_mult,
+                )
+                sl_high_water_px = hwm_anchor
+            else:
+                sl_trigger_px = self._initial_sl_trigger(
+                    "long", avg_cost, entry_atr_value,
+                )
+                if sl_trigger_px <= 0 and self._run_trailing_stop_atr_mult:
+                    sl_trigger_px = _initial_trail_trigger(
+                        "long", hwm_anchor, entry_atr_value,
+                        self._run_trailing_stop_atr_mult,
+                    )
+                sl_high_water_px = hwm_anchor
+            sl_tiers_processed = 0
+            post_tp_trail_mult = None
 
         for i, (idx, row) in enumerate(df.iterrows()):
             fill_price = row["open"] if has_open else row["close"]

--- a/backtest/eval_windows.py
+++ b/backtest/eval_windows.py
@@ -249,7 +249,9 @@ def run_leg(reg, name: str, params: Optional[dict], symbol: str, timeframe: str,
             window: tuple, capital: float = DEFAULT_CAPITAL,
             close_strategies: Optional[List[dict]] = None,
             direction: Optional[str] = None,
-            invert_signal: bool = False) -> Optional[dict]:
+            invert_signal: bool = False,
+            stop_loss_atr_mult: Optional[float] = None,
+            trailing_stop_atr_mult: Optional[float] = None) -> Optional[dict]:
     """Run one (strategy, dataset, window) leg on the audit-identical harness."""
     from atr import ensure_atr_indicator
     from data_fetcher import load_cached_data
@@ -277,6 +279,8 @@ def run_leg(reg, name: str, params: Optional[dict], symbol: str, timeframe: str,
         open_strategy={"name": name, "params": dict(strat_params or {})},
         close_strategies=close_strategies,
         direction=direction, invert_signal=invert_signal,
+        stop_loss_atr_mult=stop_loss_atr_mult,
+        trailing_stop_atr_mult=trailing_stop_atr_mult,
     )
     results = bt.run(df_signals, strategy_name=name, symbol=symbol,
                      timeframe=timeframe, params=strat_params, save=False)
@@ -331,6 +335,13 @@ def validate_candidate(candidate: dict) -> dict:
             f"invert_signal is HL-perps/manual-only (the live daemon rejects "
             f"this at startup — config.go). Remove invert_signal or declare "
             f"type perps/manual.")
+    # #996: backtester-level ATR stop owners are mutually exclusive (mirrors
+    # the live config's exclusive stop fields).
+    if candidate.get("stop_loss_atr_mult") and candidate.get("trailing_stop_atr_mult"):
+        raise ValueError(
+            "candidate sets both stop_loss_atr_mult and "
+            "trailing_stop_atr_mult; the stop owners are mutually exclusive "
+            "— pick one.")
     return candidate
 
 
@@ -352,8 +363,14 @@ def evaluate_window(reg, candidate: dict, datasets: List[tuple],
             reg, candidate["name"], candidate.get("params"),
             symbol, timeframe, window, capital=capital,
             close_strategies=candidate.get("close_strategies"),
-            direction=candidate.get("direction"),
+            # The validated default ("long") must also be the EXECUTED
+            # default: with close refs and direction=None the engine path
+            # would open shorts on raw signal=-1, silently scoring a
+            # different entry universe than the long-leg harness (#996).
+            direction=candidate.get("direction") or "long",
             invert_signal=bool(candidate.get("invert_signal")),
+            stop_loss_atr_mult=candidate.get("stop_loss_atr_mult"),
+            trailing_stop_atr_mult=candidate.get("trailing_stop_atr_mult"),
         )
     score = score_candidate(candidate_legs, bars)
     score["window"] = window_name
@@ -468,7 +485,8 @@ def build_parser() -> argparse.ArgumentParser:
                    help="Candidate params JSON (default: registry default_params)")
     p.add_argument("--candidate-json", default=None,
                    help="Path to a candidate JSON file: {name, params, "
-                        "close_strategies?, direction?, invert_signal?}. "
+                        "close_strategies?, direction?, invert_signal?, "
+                        "stop_loss_atr_mult?, trailing_stop_atr_mult?}. "
                         "Overrides --strategy/--params.")
     p.add_argument("--registry", choices=["spot", "futures"], default="spot")
     p.add_argument("--windows", default=None,

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -325,14 +325,6 @@ def walk_forward_optimize(
             "kwargs — the grid owns the close stack")
     if close_stack_grid and direction is None:
         direction = "long"
-    if direction in ("short", "both") and close_stack_grid and any(
-        not stack.get("close_strategies") for stack in close_stack_grid
-    ):
-        raise ValueError(
-            f"direction={direction!r} requires every close stack to carry a "
-            f"close evaluator — the plain long/flat signal path cannot open "
-            f"shorts, so a no-close stack would silently score as long/flat "
-            f"(mirrors the eval_windows/run_backtest guards)")
 
     reg = load_registry(registry)
     apply_strategy = reg.apply_strategy
@@ -352,6 +344,17 @@ def walk_forward_optimize(
         }
         fixed["label"] = close_stack_label(fixed)
         stacks = [fixed]
+    # Guard the whole optimize surface, grid or not: without a close evaluator
+    # the plain long/flat signal path cannot open shorts, so a short/both
+    # request would silently score as long/flat (mirrors the eval_windows/
+    # run_backtest --config guards).
+    if direction in ("short", "both") and any(
+        not stack.get("close_strategies") for stack in stacks
+    ):
+        raise ValueError(
+            f"direction={direction!r} requires a close evaluator on every "
+            f"close stack — the plain long/flat signal path cannot open "
+            f"shorts, so the run would silently score as long/flat")
     stack_bts = [
         (stack, Backtester(
             initial_capital=initial_capital, platform=platform,

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -40,7 +40,13 @@ def warmup_exit_long_entry(warmup_with_signal: pd.DataFrame,
     (signal at bar t fills at bar t+1's open), slippage is added on entry.
 
     Returns ``{"entry_price": float, "entry_date": idx}`` when the warmup
-    ends long, or ``None`` when flat. The caller passes the dict to
+    ends long, or ``None`` when flat. When the warmup frame carries an
+    ``atr`` column the seed also stamps ``entry_atr`` (the fill-bar ATR,
+    same plausibility guard as ``Backtester._stamp_entry_atr``) and
+    ``high_water`` (max close since entry) so the carried position is
+    managed by ATR-based close stacks and trailing stops exactly like a
+    mid-window open — without them every ATR exit silently no-ops on the
+    seeded position for its entire lifetime. The caller passes the dict to
     ``Backtester.run(starting_long=...)`` so a SELL in the train window
     actually closes the warmup position rather than being silently dropped.
     """
@@ -54,6 +60,7 @@ def warmup_exit_long_entry(warmup_with_signal: pd.DataFrame,
     in_position = False
     entry_price = None
     entry_date = None
+    high_water = 0.0
     for idx, row in shifted.iterrows():
         fill_price = row["open"] if has_open else row["close"]
         sig = row["signal"]
@@ -61,13 +68,26 @@ def warmup_exit_long_entry(warmup_with_signal: pd.DataFrame,
             entry_price = fill_price * (1 + slippage_pct)
             entry_date = idx
             in_position = True
+            high_water = float(row["close"])
         elif sig == -1 and in_position:
             in_position = False
             entry_price = None
             entry_date = None
+            high_water = 0.0
+        elif in_position:
+            high_water = max(high_water, float(row["close"]))
 
     if in_position and entry_price is not None:
-        return {"entry_price": entry_price, "entry_date": entry_date}
+        seed = {"entry_price": entry_price, "entry_date": entry_date,
+                "high_water": high_water}
+        if "atr" in shifted.columns:
+            try:
+                atr_val = float(shifted["atr"].loc[entry_date])
+            except (KeyError, TypeError, ValueError):
+                atr_val = 0.0
+            if atr_val > 0 and atr_val <= 0.5 * entry_price:
+                seed["entry_atr"] = atr_val
+        return seed
     return None
 
 
@@ -370,9 +390,14 @@ def walk_forward_optimize(
     ]
     bt = stack_bts[0][1]  # slippage reference for warmup_exit_long_entry
 
-    # Close evaluators need an `atr` column to stamp entry_atr (mirror of the
-    # run_backtest single-mode injection — without it tiered_tp_atr silently
-    # no-ops); ATR(14) also needs warmup bars to prime before the first fill.
+    # Any ATR-based exit needs an `atr` column on the signal frame: close
+    # evaluators stamp entry_atr from it (mirror of the run_backtest
+    # single-mode injection — without it tiered_tp_atr silently no-ops), and
+    # the warmup slice needs it so warmup_exit_long_entry can stamp the
+    # carried position's entry_atr (bare scalar stops included — the
+    # Backtester self-injects ATR for mid-window opens but never sees the
+    # warmup bars). ATR(14) also needs warmup bars to prime before the
+    # first fill.
     needs_atr = any(stack.get("close_strategies") for stack, _ in stack_bts)
     uses_exits = needs_atr or any(
         stack.get("stop_loss_atr_mult") or stack.get("trailing_stop_atr_mult")
@@ -438,7 +463,7 @@ def walk_forward_optimize(
         for params in param_grid:
             try:
                 signals_ext = apply_strategy(strategy_name, train_ext_df, params)
-                if needs_atr:
+                if uses_exits:
                     signals_ext = ensure_atr_indicator(signals_ext)
                 signals_df = signals_ext.iloc[train_boundary_idx:]
                 train_seed = warmup_exit_long_entry(
@@ -473,7 +498,7 @@ def walk_forward_optimize(
         test_boundary_idx = max(test_trim - 1, 0)
         try:
             test_signals_ext = apply_strategy(strategy_name, test_ext_df, best_params)
-            if needs_atr:
+            if uses_exits:
                 test_signals_ext = ensure_atr_indicator(test_signals_ext)
             test_signals = test_signals_ext.iloc[test_boundary_idx:]
             test_seed = warmup_exit_long_entry(

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -6,6 +6,7 @@ optimizes parameters on in-sample, validates on out-of-sample.
 
 import sys
 import os
+import json
 import itertools
 from typing import Dict, List, Optional, Any, Tuple
 from datetime import timedelta
@@ -15,6 +16,8 @@ import pandas as pd
 
 from registry_loader import load_registry
 from backtester import Backtester
+# backtester puts shared_tools on sys.path; atr lives there.
+from atr import ensure_atr_indicator
 
 
 _EXPECTED_FOLD_ERRORS = (KeyError, ValueError, TypeError, IndexError, ZeroDivisionError)
@@ -88,6 +91,171 @@ def max_indicator_lookback(param_ranges: Dict[str, list]) -> int:
     return max_lb
 
 
+# ---------------------------------------------------------------------------
+# Close-stack co-optimization (#996). A "close stack" is one complete exit
+# configuration the Backtester can run: an optional close-evaluator ref plus
+# the mutually-exclusive backtester-level ATR stop owners. The grid sweeps
+# whole stacks jointly with open-strategy params so walk-forward selection
+# picks (entry, exit) pairs instead of freezing one side.
+# ---------------------------------------------------------------------------
+
+ATR_CLOSE_WARMUP = 14  # standard ATR(14) priming bars for exit evaluation
+
+_CLOSE_STACK_SPEC_KEYS = {"close", "stop_loss_atr_mult", "trailing_stop_atr_mult"}
+
+
+def _fmt_num(v) -> str:
+    """Compact float formatting for stack labels (1.0 -> '1', 1.50 -> '1.5')."""
+    return f"{v:g}"
+
+
+def close_stack_label(stack: dict) -> str:
+    """Human-readable one-line label for a close stack (fold reports, summary)."""
+    parts = []
+    for ref in stack.get("close_strategies") or []:
+        params = ref.get("params") or {}
+        tiers = params.get("tp_tiers")
+        if tiers:
+            ladder = ",".join(
+                f"{_fmt_num(t.get('atr_multiple', t.get('profit_pct', '?')))}x"
+                f":{_fmt_num(t.get('close_fraction', '?'))}"
+                for t in tiers
+            )
+            extra = {k: v for k, v in params.items() if k != "tp_tiers"}
+        else:
+            ladder = ""
+            extra = dict(params)
+        suffix = "".join(f" {k}={v}" for k, v in sorted(extra.items()))
+        parts.append(f"{ref['name']}[{ladder}]{suffix}" if ladder
+                     else f"{ref['name']}{suffix}")
+    if stack.get("stop_loss_atr_mult"):
+        parts.append(f"sl_atr={_fmt_num(stack['stop_loss_atr_mult'])}")
+    if stack.get("trailing_stop_atr_mult"):
+        parts.append(f"trail_atr={_fmt_num(stack['trailing_stop_atr_mult'])}")
+    return " ".join(parts) if parts else "baseline"
+
+
+def generate_close_stack_grid(specs: List[dict]) -> List[dict]:
+    """Expand close-stack sweep specs into complete stack candidates.
+
+    Each spec is a dict with keys:
+      close: {"name": str, "params": {param: [candidate values]}} or None.
+             Param candidates may be structured (a whole tp_tiers ladder is
+             ONE candidate value); the cartesian product runs across params.
+      stop_loss_atr_mult / trailing_stop_atr_mult: lists of candidate values
+             (None = no stop). Defaults to [None] when omitted.
+
+    The two stop owners are mutually exclusive (mirrors the live config's
+    exclusive stop fields); a spec that would produce a combo with both set
+    raises. Stacks are deduped across specs by canonical JSON.
+
+    Returns [{"label", "close_strategies", "stop_loss_atr_mult",
+    "trailing_stop_atr_mult"}, ...].
+    """
+    stacks: List[dict] = []
+    seen = set()
+    for i, spec in enumerate(specs):
+        if not isinstance(spec, dict):
+            raise ValueError(f"close-stack spec {i} must be a dict, got {type(spec).__name__}")
+        unknown = set(spec) - _CLOSE_STACK_SPEC_KEYS
+        if unknown:
+            raise ValueError(
+                f"close-stack spec {i} has unknown keys {sorted(unknown)}; "
+                f"allowed: {sorted(_CLOSE_STACK_SPEC_KEYS)}")
+        close = spec.get("close")
+        if close is not None and (not isinstance(close, dict) or not close.get("name")):
+            raise ValueError(f"close-stack spec {i}: 'close' needs a 'name'")
+        param_ranges = dict((close or {}).get("params") or {})
+        for k, v in param_ranges.items():
+            if not isinstance(v, list) or not v:
+                raise ValueError(
+                    f"close-stack spec {i}: close param {k!r} must be a "
+                    f"non-empty list of candidate values")
+            # Classic footgun: one ladder passed where a list of candidate
+            # ladders is expected — each tp_tiers candidate is itself a list.
+            if k == "tp_tiers" and not all(isinstance(c, list) for c in v):
+                raise ValueError(
+                    f"close-stack spec {i}: tp_tiers candidates must each be "
+                    f"a non-empty list of tier dicts (a whole ladder is ONE "
+                    f"candidate value — wrap a single ladder as [ladder])")
+        close_combos = generate_param_grid(param_ranges) if close else [None]
+        sl_values = spec.get("stop_loss_atr_mult", [None])
+        trail_values = spec.get("trailing_stop_atr_mult", [None])
+        for close_params, sl, trail in itertools.product(close_combos, sl_values, trail_values):
+            if sl and trail:
+                raise ValueError(
+                    f"close-stack spec {i} produces a combo with both "
+                    f"stop_loss_atr_mult={sl} and trailing_stop_atr_mult={trail}; "
+                    f"the stop owners are mutually exclusive — split into "
+                    f"separate specs")
+            stack = {
+                "close_strategies": (
+                    [{"name": close["name"], "params": close_params}]
+                    if close else []
+                ),
+                "stop_loss_atr_mult": sl,
+                "trailing_stop_atr_mult": trail,
+            }
+            key = json.dumps(stack, sort_keys=True, default=str)
+            if key in seen:
+                continue
+            seen.add(key)
+            stack["label"] = close_stack_label(stack)
+            stacks.append(stack)
+    if not stacks:
+        raise ValueError("close-stack specs expanded to an empty grid")
+    return stacks
+
+
+def _result_metric(result: dict, metric: str) -> float:
+    """Extract the optimization metric from a Backtester result.
+
+    ``dd_adjusted_return`` is derived (return / |max DD|, the #963 DDadj
+    definition mirrored from eval_windows.dd_adjusted_return — zero-DD legs
+    score 0.0 so untraded combos never win); other metrics are read directly.
+    """
+    if metric == "dd_adjusted_return":
+        ret = float(result.get("total_return_pct", 0) or 0)
+        dd = float(result.get("max_drawdown_pct", 0) or 0)
+        return ret / abs(dd) if dd else 0.0
+    v = result.get(metric, 0)
+    return v if isinstance(v, (int, float)) else -np.inf
+
+
+# Default sweep for `--sweep-close` (#996): the audit baseline plus ATR-stop
+# and tiered-TP variants around the live default ladder. Ladders are swept as
+# whole candidates (a ladder is one grid value, not per-tier dimensions).
+_TP_LADDER_DEFAULT = [  # live default (defaultHLProtectionTiers mirror)
+    {"atr_multiple": 1.5, "close_fraction": 0.4},
+    {"atr_multiple": 3.0, "close_fraction": 0.8},
+    {"atr_multiple": 5.0, "close_fraction": 1.0},
+]
+_TP_LADDER_TIGHT = [  # bank earlier, cut tail risk
+    {"atr_multiple": 1.0, "close_fraction": 0.5},
+    {"atr_multiple": 2.0, "close_fraction": 0.8},
+    {"atr_multiple": 3.0, "close_fraction": 1.0},
+]
+_TP_LADDER_RUNNER = [  # smaller early clips, let winners run
+    {"atr_multiple": 2.0, "close_fraction": 0.33},
+    {"atr_multiple": 4.0, "close_fraction": 0.66},
+    {"atr_multiple": 6.0, "close_fraction": 1.0},
+]
+
+DEFAULT_CLOSE_STACK_SPECS = [
+    {"close": None},  # audit baseline: open-signal-as-close, no stops
+    {"close": None, "stop_loss_atr_mult": [1.5, 2.0, 3.0]},
+    {"close": None, "trailing_stop_atr_mult": [2.0, 2.5, 3.0]},
+    {"close": {"name": "tiered_tp_atr",
+               "params": {"tp_tiers": [_TP_LADDER_DEFAULT, _TP_LADDER_TIGHT,
+                                       _TP_LADDER_RUNNER]}},
+     "stop_loss_atr_mult": [None, 1.5, 2.0, 3.0]},
+    {"close": {"name": "tiered_tp_atr",
+               "params": {"tp_tiers": [_TP_LADDER_DEFAULT, _TP_LADDER_TIGHT,
+                                       _TP_LADDER_RUNNER]}},
+     "trailing_stop_atr_mult": [2.0, 3.0]},
+]
+
+
 def walk_forward_optimize(
     df: pd.DataFrame,
     strategy_name: str,
@@ -108,6 +276,8 @@ def walk_forward_optimize(
     stop_loss_atr_mult: Optional[float] = None,
     trailing_stop_atr_mult: Optional[float] = None,
     close_strategies: Optional[List[dict]] = None,
+    close_stack_grid: Optional[List[dict]] = None,
+    direction: Optional[str] = None,
 ) -> dict:
     """
     Walk-forward optimization.
@@ -126,6 +296,18 @@ def walk_forward_optimize(
         initial_capital: Starting capital per window
         symbol: Trading pair
         timeframe: Candle timeframe
+        close_stack_grid: Optional list of close stacks (#996, from
+            ``generate_close_stack_grid``) swept jointly with the open-param
+            grid — selection picks the best (open params, close stack) pair
+            per fold. Mutually exclusive with the fixed ``close_strategies``/
+            stop-mult kwargs.
+        direction: Backtester direction gate (long/short/both). When a
+            close-stack grid is supplied and direction is omitted it defaults
+            to "long": close refs activate the open/close engine where a raw
+            signal=-1 OPENS a short, so without the gate the baseline stack
+            (plain path, structurally long/flat) and the close-ref stacks
+            (long/short) would be scored on different entry universes — the
+            sweep comparison must hold the entry side constant.
 
     Returns:
         Dict with optimization results and best parameters per window
@@ -135,27 +317,77 @@ def walk_forward_optimize(
     if window_size < 50:
         raise ValueError(f"Not enough data: {total_len} rows / {n_splits} splits = {window_size} rows per window. Need >= 50.")
 
+    if close_stack_grid and (close_strategies or stop_loss_atr_mult
+                             or trailing_stop_atr_mult):
+        raise ValueError(
+            "close_stack_grid is mutually exclusive with the fixed "
+            "close_strategies / stop_loss_atr_mult / trailing_stop_atr_mult "
+            "kwargs — the grid owns the close stack")
+    if close_stack_grid and direction is None:
+        direction = "long"
+    if direction in ("short", "both") and close_stack_grid and any(
+        not stack.get("close_strategies") for stack in close_stack_grid
+    ):
+        raise ValueError(
+            f"direction={direction!r} requires every close stack to carry a "
+            f"close evaluator — the plain long/flat signal path cannot open "
+            f"shorts, so a no-close stack would silently score as long/flat "
+            f"(mirrors the eval_windows/run_backtest guards)")
+
     reg = load_registry(registry)
     apply_strategy = reg.apply_strategy
 
     param_grid = generate_param_grid(param_ranges)
     warmup = max_indicator_lookback(param_ranges)
+
+    # One Backtester per close stack, constructed up front so invalid stacks
+    # fail loudly instead of being silently skipped inside the fold loop.
+    if close_stack_grid:
+        stacks = close_stack_grid
+    else:
+        fixed = {
+            "close_strategies": list(close_strategies or []),
+            "stop_loss_atr_mult": stop_loss_atr_mult,
+            "trailing_stop_atr_mult": trailing_stop_atr_mult,
+        }
+        fixed["label"] = close_stack_label(fixed)
+        stacks = [fixed]
+    stack_bts = [
+        (stack, Backtester(
+            initial_capital=initial_capital, platform=platform,
+            regime_enabled=regime_enabled, regime_period=regime_period,
+            regime_adx_threshold=regime_adx_threshold,
+            allowed_regimes=allowed_regimes,
+            stop_loss_atr_mult=stack.get("stop_loss_atr_mult"),
+            trailing_stop_atr_mult=stack.get("trailing_stop_atr_mult"),
+            close_strategies=stack.get("close_strategies"),
+            direction=direction,
+        ))
+        for stack in stacks
+    ]
+    bt = stack_bts[0][1]  # slippage reference for warmup_exit_long_entry
+
+    # Close evaluators need an `atr` column to stamp entry_atr (mirror of the
+    # run_backtest single-mode injection — without it tiered_tp_atr silently
+    # no-ops); ATR(14) also needs warmup bars to prime before the first fill.
+    needs_atr = any(stack.get("close_strategies") for stack, _ in stack_bts)
+    uses_exits = needs_atr or any(
+        stack.get("stop_loss_atr_mult") or stack.get("trailing_stop_atr_mult")
+        for stack, _ in stack_bts
+    )
+    if uses_exits:
+        warmup = max(warmup, ATR_CLOSE_WARMUP)
+
     if verbose:
         print(f"\nWalk-Forward Optimization: {strategy_name}")
         print(f"  Data: {len(df)} candles | Splits: {n_splits} | Train: {train_pct:.0%}")
         print(f"  Parameter combinations: {len(param_grid)}")
+        if len(stack_bts) > 1 or close_stack_grid:
+            print(f"  Close stacks: {len(stack_bts)} "
+                  f"(joint grid: {len(param_grid) * len(stack_bts)} combos)")
         print(f"  Warmup bars per fold: {warmup}")
         print(f"  Optimizing: {optimize_metric}")
 
-    bt = Backtester(
-        initial_capital=initial_capital, platform=platform,
-        regime_enabled=regime_enabled, regime_period=regime_period,
-        regime_adx_threshold=regime_adx_threshold,
-        allowed_regimes=allowed_regimes,
-        stop_loss_atr_mult=stop_loss_atr_mult,
-        trailing_stop_atr_mult=trailing_stop_atr_mult,
-        close_strategies=close_strategies,
-    )
     window_results = []
 
     for fold in range(n_splits):
@@ -193,44 +425,61 @@ def walk_forward_optimize(
         # doesn't double-count that signal.
         train_boundary_idx = max(train_trim - 1, 0)
 
-        # Optimize on training data
+        # Optimize on training data — joint (open params x close stack) grid.
+        # Signals are computed once per open-param combo and shared across
+        # all close stacks (the expensive parts are apply_strategy + bt.run).
         best_metric = -np.inf
         best_params = None
+        best_stack = None
+        best_bt = None
         for params in param_grid:
             try:
                 signals_ext = apply_strategy(strategy_name, train_ext_df, params)
+                if needs_atr:
+                    signals_ext = ensure_atr_indicator(signals_ext)
                 signals_df = signals_ext.iloc[train_boundary_idx:]
                 train_seed = warmup_exit_long_entry(
                     signals_ext.iloc[:train_boundary_idx], bt.slippage_pct,
                 ) if train_boundary_idx else None
-                result = bt.run(signals_df, strategy_name=strategy_name,
-                              symbol=symbol, timeframe=timeframe,
-                              params=params, save=False,
-                              starting_long=train_seed)
-                metric_val = result.get(optimize_metric, 0)
-                if isinstance(metric_val, (int, float)) and metric_val > best_metric:
-                    best_metric = metric_val
-                    best_params = params
             except _EXPECTED_FOLD_ERRORS as e:
                 if verbose:
                     print(f"    [skip] fold {fold+1} {strategy_name} {params}: {type(e).__name__}: {e}")
                 continue
+            for stack, stack_bt in stack_bts:
+                try:
+                    result = stack_bt.run(signals_df, strategy_name=strategy_name,
+                                          symbol=symbol, timeframe=timeframe,
+                                          params=params, save=False,
+                                          starting_long=train_seed)
+                    metric_val = _result_metric(result, optimize_metric)
+                    if metric_val > best_metric:
+                        best_metric = metric_val
+                        best_params = params
+                        best_stack = stack
+                        best_bt = stack_bt
+                except _EXPECTED_FOLD_ERRORS as e:
+                    if verbose:
+                        print(f"    [skip] fold {fold+1} {strategy_name} {params} "
+                              f"[{stack['label']}]: {type(e).__name__}: {e}")
+                    continue
 
         if best_params is None:
             continue
 
-        # Validate on test data with best params
+        # Validate on test data with best params + best close stack
         test_boundary_idx = max(test_trim - 1, 0)
         try:
             test_signals_ext = apply_strategy(strategy_name, test_ext_df, best_params)
+            if needs_atr:
+                test_signals_ext = ensure_atr_indicator(test_signals_ext)
             test_signals = test_signals_ext.iloc[test_boundary_idx:]
             test_seed = warmup_exit_long_entry(
                 test_signals_ext.iloc[:test_boundary_idx], bt.slippage_pct,
             ) if test_boundary_idx else None
-            test_result = bt.run(test_signals, strategy_name=strategy_name,
-                               symbol=symbol, timeframe=timeframe,
-                               params=best_params, save=False,
-                               starting_long=test_seed)
+            test_result = best_bt.run(test_signals, strategy_name=strategy_name,
+                                      symbol=symbol, timeframe=timeframe,
+                                      params=best_params, save=False,
+                                      starting_long=test_seed)
         except _EXPECTED_FOLD_ERRORS as e:
             if verbose:
                 print(f"    [skip] fold {fold+1} validation {strategy_name}: {type(e).__name__}: {e}")
@@ -239,6 +488,11 @@ def walk_forward_optimize(
         window_results.append({
             "fold": fold + 1,
             "best_params": best_params,
+            "best_close_stack": best_stack["label"],
+            "best_close_stack_spec": {
+                k: best_stack.get(k) for k in
+                ("close_strategies", "stop_loss_atr_mult", "trailing_stop_atr_mult")
+            },
             "train_metric": best_metric,
             "test_result": test_result,
             "train_period": f"{train_df.index[0].strftime('%Y-%m-%d')} to {train_df.index[-1].strftime('%Y-%m-%d')}",
@@ -247,6 +501,8 @@ def walk_forward_optimize(
 
         if verbose:
             print(f"    Best params: {best_params}")
+            if len(stack_bts) > 1:
+                print(f"    Best close stack: {best_stack['label']}")
             print(f"    Train {optimize_metric}: {best_metric:.3f}")
             print(f"    Test return: {test_result['total_return_pct']:+.2f}% | "
                   f"Sharpe: {test_result['sharpe_ratio']:.3f} | "
@@ -260,16 +516,20 @@ def walk_forward_optimize(
     oos_sharpes = [w["test_result"]["sharpe_ratio"] for w in window_results]
     oos_drawdowns = [w["test_result"]["max_drawdown_pct"] for w in window_results]
 
-    # Find most common best params
+    # Find most common best params / close stack
     all_params = [str(w["best_params"]) for w in window_results]
     from collections import Counter
     most_common_params = Counter(all_params).most_common(1)[0][0]
+    most_common_stack = Counter(
+        w["best_close_stack"] for w in window_results
+    ).most_common(1)[0][0]
 
     summary = {
         "strategy": strategy_name,
         "n_splits": n_splits,
         "n_valid_folds": len(window_results),
         "param_grid_size": len(param_grid),
+        "close_stack_grid_size": len(stack_bts),
         "optimize_metric": optimize_metric,
         "oos_mean_return": round(np.mean(oos_returns), 2),
         "oos_median_return": round(np.median(oos_returns), 2),
@@ -278,6 +538,7 @@ def walk_forward_optimize(
         "oos_mean_drawdown": round(np.mean(oos_drawdowns), 2),
         "oos_worst_drawdown": round(min(oos_drawdowns), 2),
         "most_common_best_params": most_common_params,
+        "most_common_best_close_stack": most_common_stack,
         "window_results": window_results,
     }
 
@@ -293,6 +554,8 @@ def walk_forward_optimize(
         print(f"  OOS Mean MaxDD: {summary['oos_mean_drawdown']:.2f}%")
         print(f"  OOS Worst MaxDD: {summary['oos_worst_drawdown']:.2f}%")
         print(f"  Most Stable Params: {summary['most_common_best_params']}")
+        if len(stack_bts) > 1:
+            print(f"  Most Stable Close Stack: {summary['most_common_best_close_stack']}")
 
     return summary
 
@@ -532,11 +795,12 @@ DEFAULT_PARAM_RANGES = {
     },
     # NOTE: close-evaluator names (tp_at_pct, tiered_tp_pct, tiered_tp_atr, …) are
     # intentionally absent here. walk_forward_optimize only sweeps OPEN-registry
-    # strategy params (it builds the entry signal via the open registry), so any
-    # close-param grid keyed by a close name would be dead weight — unreachable and
-    # never swept.
-    # Wiring real close-param optimization is a separate feature (#944); until then
-    # do not re-add close names to DEFAULT_PARAM_RANGES.
+    # strategy params through THIS table (it builds the entry signal via the open
+    # registry), so a close-param grid keyed by a close name would be dead weight
+    # — unreachable and never swept. Close-param optimization lives in the
+    # close-stack grid instead (#996): DEFAULT_CLOSE_STACK_SPECS /
+    # generate_close_stack_grid, swept jointly via the close_stack_grid kwarg.
+    # Do not re-add close names here (#944).
     # Futures-only
     "breakout": {
         "lookback": [10, 20, 30],

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -153,6 +153,7 @@ def format_walk_forward_report(wf_result: dict) -> str:
         f"{'='*70}",
         f"  Folds:             {wf_result.get('n_valid_folds', 0)}/{wf_result.get('n_splits', 0)}",
         f"  Param Combos:      {wf_result.get('param_grid_size', 0)}",
+        f"  Close Stacks:      {wf_result.get('close_stack_grid_size', 1)}",
         f"  Optimize Metric:   {wf_result.get('optimize_metric', 'sharpe_ratio')}",
         f"{'─'*70}",
         f"  OUT-OF-SAMPLE PERFORMANCE",
@@ -166,6 +167,11 @@ def format_walk_forward_report(wf_result: dict) -> str:
         f"  STABILITY",
         f"    Most Stable Params: {wf_result.get('most_common_best_params', 'N/A')}",
     ]
+    swept_closes = wf_result.get("close_stack_grid_size", 1) > 1
+    if swept_closes:
+        lines.append(
+            f"    Most Stable Close Stack: "
+            f"{wf_result.get('most_common_best_close_stack', 'N/A')}")
 
     # Per-fold details
     windows = wf_result.get("window_results", [])
@@ -176,12 +182,14 @@ def format_walk_forward_report(wf_result: dict) -> str:
         lines.append(f"  {'─'*68}")
         for w in windows:
             tr = w.get("test_result", {})
+            stack = f" | close: {w['best_close_stack']}" if (
+                swept_closes and w.get("best_close_stack")) else ""
             lines.append(
                 f"  {w.get('fold',0):<6} "
                 f"{w.get('test_period','?'):<25} "
                 f"{tr.get('total_return_pct',0):>+7.1f}% "
                 f"{tr.get('sharpe_ratio',0):>7.2f} "
-                f"{w.get('best_params', {})}"
+                f"{w.get('best_params', {})}{stack}"
             )
 
     lines.append(f"{'='*70}")

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -52,7 +52,8 @@ def _attach_funding_if_needed(df, strategy_name, symbol, since):
 from htf_filter import get_default_htf, apply_htf_filter  # noqa: E402
 from registry_loader import load_registry
 from backtester import Backtester, format_results
-from optimizer import walk_forward_optimize, DEFAULT_PARAM_RANGES
+from optimizer import (walk_forward_optimize, DEFAULT_PARAM_RANGES,
+                       DEFAULT_CLOSE_STACK_SPECS, generate_close_stack_grid)
 from reporter import (
     format_single_report, format_comparison_report,
     format_multi_asset_report, format_walk_forward_report,
@@ -553,6 +554,9 @@ def run_walk_forward(
     stop_loss_atr_mult: Optional[float] = None,
     trailing_stop_atr_mult: Optional[float] = None,
     close_strategies: Optional[List[dict]] = None,
+    close_stack_grid: Optional[List[dict]] = None,
+    optimize_metric: str = "sharpe_ratio",
+    direction: Optional[str] = None,
 ) -> Optional[dict]:
     """Run walk-forward optimization for a strategy."""
     reg = load_registry(registry)
@@ -596,6 +600,9 @@ def run_walk_forward(
         stop_loss_atr_mult=stop_loss_atr_mult,
         trailing_stop_atr_mult=trailing_stop_atr_mult,
         close_strategies=close_strategies,
+        close_stack_grid=close_stack_grid,
+        optimize_metric=optimize_metric,
+        direction=direction,
     )
 
     print(format_walk_forward_report(result))
@@ -670,6 +677,29 @@ def _build_parser() -> argparse.ArgumentParser:
                         dest="trailing_stop_atr_mult", metavar="MULT",
                         help="Trailing ATR-multiple stop (e.g. 2.5). Applied in "
                              "optimize/walk-forward mode.")
+    parser.add_argument("--sweep-close", action="store_true",
+                        help="Optimize mode (#996): sweep the built-in close-stack "
+                             "grid (DEFAULT_CLOSE_STACK_SPECS — baseline, ATR "
+                             "stops, tiered-TP ladders) jointly with the open-"
+                             "param grid.")
+    parser.add_argument("--close-stacks-json", default=None, metavar="PATH",
+                        help="Optimize mode (#996): JSON file with a list of "
+                             "close-stack sweep specs (see optimizer."
+                             "generate_close_stack_grid) swept jointly with "
+                             "the open-param grid. Overrides --sweep-close.")
+    parser.add_argument("--optimize-metric", default="sharpe_ratio",
+                        choices=["sharpe_ratio", "total_return_pct",
+                                 "dd_adjusted_return"],
+                        help="Selection metric for optimize mode (default: "
+                             "sharpe_ratio). dd_adjusted_return = return / "
+                             "|max DD| (#963 DDadj).")
+    parser.add_argument("--direction", default=None,
+                        choices=["long", "short", "both"],
+                        help="Optimize mode: side the open/close engine may "
+                             "OPEN. Defaults to long when a close-stack grid "
+                             "is swept so every stack scores on the same "
+                             "entry universe (raw signal=-1 opens a short in "
+                             "the engine path).")
     return parser
 
 
@@ -798,6 +828,28 @@ def main():
                         allowed_regimes=args.allowed_regimes)
 
     elif args.mode == "optimize":
+        # #996: close-stack co-optimization. The grid owns the close stack;
+        # fixed exit flags alongside it would be silently shadowed — reject.
+        close_stack_grid = None
+        if args.close_stacks_json or args.sweep_close:
+            if close_refs or args.stop_loss_atr_mult is not None \
+                    or args.trailing_stop_atr_mult is not None:
+                print("--sweep-close/--close-stacks-json is mutually exclusive "
+                      "with --close-strategy/--stop-loss-atr-mult/"
+                      "--trailing-stop-atr-mult (the grid owns the close stack)")
+                sys.exit(1)
+            if args.close_stacks_json:
+                import json as _json
+                with open(args.close_stacks_json) as fh:
+                    specs = _json.load(fh)
+                if not isinstance(specs, list):
+                    print(f"{args.close_stacks_json}: expected a JSON list of "
+                          f"close-stack specs")
+                    sys.exit(1)
+            else:
+                specs = DEFAULT_CLOSE_STACK_SPECS
+            close_stack_grid = generate_close_stack_grid(specs)
+
         if args.strategy == "all":
             for strat in reg.list_strategies():
                 run_walk_forward(strat, args.symbol, args.timeframe,
@@ -809,7 +861,10 @@ def main():
                                  allowed_regimes=args.allowed_regimes,
                                  stop_loss_atr_mult=args.stop_loss_atr_mult,
                                  trailing_stop_atr_mult=args.trailing_stop_atr_mult,
-                                 close_strategies=close_refs)
+                                 close_strategies=close_refs,
+                                 close_stack_grid=close_stack_grid,
+                                 optimize_metric=args.optimize_metric,
+                                 direction=args.direction)
         else:
             run_walk_forward(args.strategy, args.symbol, args.timeframe,
                              args.since, args.splits, args.capital,
@@ -820,7 +875,10 @@ def main():
                              allowed_regimes=args.allowed_regimes,
                              stop_loss_atr_mult=args.stop_loss_atr_mult,
                              trailing_stop_atr_mult=args.trailing_stop_atr_mult,
-                             close_strategies=close_refs)
+                             close_strategies=close_refs,
+                             close_stack_grid=close_stack_grid,
+                             optimize_metric=args.optimize_metric,
+                             direction=args.direction)
 
 
 if __name__ == "__main__":

--- a/backtest/tests/test_backtester_close_strategies.py
+++ b/backtest/tests/test_backtester_close_strategies.py
@@ -319,3 +319,127 @@ def test_close_strategy_unknown_name_raises():
         assert "does_not_exist" in str(exc)
     else:
         raise AssertionError("expected ValueError for unknown close strategy")
+
+
+# ---------------------------------------------------------------------------
+# #996: bare fixed/trailing/pct stops paired with a close evaluator. Live arms
+# these via runHyperliquidProtectionSync / armTrailingStopAtOpenNow regardless
+# of sl_after; pre-#996 the open/close engine path silently dropped them
+# (the SL trigger was only seeded when sl_after had usable tier thresholds).
+# ---------------------------------------------------------------------------
+
+_FAR_TP = [{"name": "tp_at_pct", "params": {"pct": 0.5}}]  # never fires
+
+
+def test_scalar_atr_stop_fires_alongside_close_evaluator():
+    # Entry bar 1 @100, ATR=2, mult=1 → trigger 98. Bar 2 close=96 breaches;
+    # fill at bar 3's OPEN (95, distinct from the breach close — pins the
+    # N→N+1 fill alignment, no look-ahead).
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 95, 95],
+        closes=[100, 100, 96, 95, 95],
+        atrs=[2.0] * 5,
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=_FAR_TP, stop_loss_atr_mult=1.0,
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] == 95.0
+    assert result["final_capital"] == 950.0
+
+
+def test_scalar_atr_stop_inverse_no_breach_is_noop():
+    # Same config, price never reaches the 98 trigger → identical to no-stop.
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 99, 99],
+        closes=[100, 100, 99, 99, 99],
+        atrs=[2.0] * 5,
+    )
+    kw = dict(initial_capital=1000, commission_pct=0, slippage_pct=0,
+              close_strategies=_FAR_TP)
+    with_stop = Backtester(stop_loss_atr_mult=1.0, **kw).run(df.copy(), save=False)
+    no_stop = Backtester(**kw).run(df.copy(), save=False)
+    assert with_stop["final_capital"] == no_stop["final_capital"]
+    assert with_stop["total_trades"] == no_stop["total_trades"]
+
+
+def test_scalar_trailing_stop_walks_alongside_close_evaluator():
+    # Entry bar 1 @100, ATR=2, trail mult=1. Bar 1 close=106 ratchets the
+    # trigger to 104; bar 3 close=103 breaches the WALKED trigger (the
+    # entry-anchored level would be 98, never touched) → fill bar 4 open.
+    df = _df_open_then_hold(
+        opens=[100, 100, 106, 106, 103, 103],
+        closes=[100, 106, 106, 103, 103, 103],
+        atrs=[2.0] * 6,
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=_FAR_TP, trailing_stop_atr_mult=1.0,
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] == 103.0
+    assert result["final_capital"] == 1030.0
+
+
+def test_scalar_atr_stop_protects_short_side():
+    # Short entry bar 1 @100, ATR=2, mult=1 → trigger 102. Bar 2 close=103
+    # breaches (price moved against the short) → fill bar 3 open=103.
+    n = 5
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame({
+        "open": [100, 100, 100, 103, 103],
+        "close": [100, 100, 103, 103, 103],
+        "atr": [2.0] * n,
+        "open_action": ["short"] + ["none"] * (n - 1),
+    }, index=idx)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=_FAR_TP, stop_loss_atr_mult=1.0,
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["side"] == "short"
+    assert result["trades"][0]["exit_price"] == 103.0
+    assert result["final_capital"] == 970.0
+
+
+def test_pct_stop_fires_alongside_close_evaluator():
+    # stop_loss_pct=0.02 → trigger 98; same shape as the ATR variant.
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 95, 95],
+        closes=[100, 100, 96, 95, 95],
+        atrs=[2.0] * 5,
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=_FAR_TP, stop_loss_pct=0.02,
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] == 1
+    assert result["final_capital"] == 950.0
+
+
+def test_tp_tier_partial_then_scalar_stop_closes_remainder():
+    # Compound: a 1-ATR TP tier banks half at 102, then the crash through the
+    # 98 stop closes the remainder — both exits must book.
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 102, 102, 96, 96],
+        closes=[100, 100, 102, 102, 96, 96, 96],
+        atrs=[2.0] * 7,
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=[{"name": "tiered_tp_atr", "params": {
+            "tp_tiers": [{"atr_multiple": 1.0, "close_fraction": 0.5}],
+        }}],
+        stop_loss_atr_mult=1.0,
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] == 2
+    exits = sorted(t["exit_price"] for t in result["trades"])
+    assert exits == [96.0, 102.0]
+    # 5 shares banked at 102 + 5 shares stopped at 96
+    assert result["final_capital"] == 5 * 102.0 + 5 * 96.0

--- a/backtest/tests/test_backtester_close_strategies.py
+++ b/backtest/tests/test_backtester_close_strategies.py
@@ -443,3 +443,114 @@ def test_tp_tier_partial_then_scalar_stop_closes_remainder():
     assert exits == [96.0, 102.0]
     # 5 shares banked at 102 + 5 shares stopped at 96
     assert result["final_capital"] == 5 * 102.0 + 5 * 96.0
+
+
+# ---------------------------------------------------------------------------
+# PR #1000 review: a position carried across a walk-forward fold boundary
+# (starting_long seed) must be managed by the same close stack as a position
+# opened mid-window — the seed block arms the fixed/trailing SL trigger from
+# the seeded entry_atr/high_water instead of leaving it at 0 for the carried
+# position's lifetime. Seed stamping itself is covered in
+# test_walk_forward_warmup.py.
+# ---------------------------------------------------------------------------
+
+def test_seeded_position_fixed_atr_stop_fires_plain_path():
+    # Plain signal path (no close refs). Seed long @100 with EntryATR=2,
+    # stop mult=2 → trigger 96. Bar 0 close=95 breaches → fill bar 1 open.
+    n = 3
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame({
+        "open": [100, 95, 95],
+        "high": [100, 95, 95],
+        "low": [95, 95, 95],
+        "close": [95, 95, 95],
+        "signal": [0] * n,
+    }, index=idx)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        stop_loss_atr_mult=2.0,
+    )
+    result = bt.run(
+        df, save=False,
+        starting_long={"entry_price": 100.0, "entry_atr": 2.0},
+    )
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] == 95.0
+    assert result["final_capital"] == 950.0
+
+
+def test_seeded_position_trailing_stop_anchors_at_seed_high_water():
+    # Trail mult=2, EntryATR=2, seeded high_water=110 → trigger 106. Bar 0
+    # close=105 breaches the warmup-walked trigger (entry-anchored would be
+    # 96, never touched) → fill bar 1 open=105, not the 120 ride.
+    n = 3
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame({
+        "open": [105, 105, 120],
+        "high": [105, 120, 120],
+        "low": [105, 105, 120],
+        "close": [105, 120, 120],
+        "signal": [0] * n,
+    }, index=idx)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        trailing_stop_atr_mult=2.0,
+    )
+    result = bt.run(
+        df, save=False,
+        starting_long={"entry_price": 100.0, "entry_atr": 2.0,
+                       "high_water": 110.0},
+    )
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] == 105.0
+
+
+def test_seeded_position_fixed_atr_stop_fires_engine_path():
+    # Same carried-position stop, open/close engine path (a far TP close ref
+    # alongside the bare stop — the joint-sweep stack shape). Trigger 96,
+    # bar 0 close=95 breaches → fill bar 1 open=95.
+    n = 3
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame({
+        "open": [100, 95, 95],
+        "close": [95, 95, 95],
+        "atr": [2.0] * n,
+        "open_action": ["none"] * n,
+    }, index=idx)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=_FAR_TP, stop_loss_atr_mult=2.0,
+    )
+    result = bt.run(
+        df, save=False,
+        starting_long={"entry_price": 100.0, "entry_atr": 2.0},
+    )
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] == 95.0
+    assert result["final_capital"] == 950.0
+
+
+def test_seeded_position_without_entry_atr_stop_stays_unarmed():
+    # Boundary: no entry_atr in the seed → the ATR stop cannot price a
+    # trigger and must stay unarmed (no spurious exits), matching the
+    # mid-window open behavior when ATR is unavailable.
+    n = 3
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame({
+        "open": [100, 95, 95],
+        "high": [100, 95, 95],
+        "low": [95, 95, 95],
+        "close": [95, 95, 95],
+        "signal": [0] * n,
+    }, index=idx)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        stop_loss_atr_mult=2.0,
+    )
+    result = bt.run(
+        df, save=False,
+        starting_long={"entry_price": 100.0},
+    )
+    # Rides to the forced end-of-run close at 95 — exactly one forced close.
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_date"] == str(idx[-1])

--- a/backtest/tests/test_eval_windows.py
+++ b/backtest/tests/test_eval_windows.py
@@ -265,6 +265,25 @@ def test_run_leg_empty_data_returns_none(monkeypatch):
                       ("2023-01-01", "2024-01-01")) is None
 
 
+def test_run_leg_threads_stop_loss_atr_mult(monkeypatch):
+    """#996: candidate stop owners must reach the Backtester — a paper-thin
+    stop forces stopped-out exits, so the leg must differ from the unstopped
+    run (acceptance without threading would leave them identical)."""
+    df = _synthetic_df(n=240)
+    import data_fetcher
+    monkeypatch.setattr(data_fetcher, "load_cached_data",
+                        lambda *a, **k: df, raising=True)
+    plain = ew.run_leg(_FakeRegistry(), "alternator", None, "BTC/USDT", "1h",
+                       ("2026-01-01", None))
+    stopped = ew.run_leg(_FakeRegistry(), "alternator", None, "BTC/USDT", "1h",
+                         ("2026-01-01", None), stop_loss_atr_mult=0.1)
+    assert plain is not None and stopped is not None
+    assert (stopped["return_pct"], stopped["max_dd_pct"]) != \
+        (plain["return_pct"], plain["max_dd_pct"]), (
+        "stop_loss_atr_mult=0.1 produced an identical leg — the stop never "
+        "reached the Backtester")
+
+
 # ---------------------------------------------------------------------------
 # validate_candidate — entry transforms must be modeled faithfully or rejected
 # (mirrors run_backtest.py --config guards; review finding on PR #994)
@@ -303,6 +322,16 @@ def test_validate_candidate_rejects_bogus_direction_and_missing_name():
         ew.validate_candidate({"name": "x", "direction": "sideways"})
     with pytest.raises(ValueError, match="name"):
         ew.validate_candidate({})
+
+
+def test_validate_candidate_stop_owners_mutually_exclusive():
+    # #996: one ATR stop owner is fine; both together mirror the live
+    # config's exclusive stop fields and are rejected.
+    assert ew.validate_candidate({"name": "x", "stop_loss_atr_mult": 2.0})
+    assert ew.validate_candidate({"name": "x", "trailing_stop_atr_mult": 2.5})
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        ew.validate_candidate({"name": "x", "stop_loss_atr_mult": 2.0,
+                               "trailing_stop_atr_mult": 2.5})
 
 
 def test_evaluate_window_validates_before_any_work():

--- a/backtest/tests/test_optimizer_close_stacks.py
+++ b/backtest/tests/test_optimizer_close_stacks.py
@@ -325,3 +325,41 @@ def test_joint_sweep_rejects_short_universe_with_no_close_stack():
             n_splits=2, verbose=False, close_stack_grid=grid,
             direction="both",
         )
+
+
+def test_optimize_rejects_short_direction_with_no_close_ref():
+    # PR #1000 review: the no-grid optimize path must hit the same guard —
+    # direction=short with no close evaluator cannot open shorts (plain
+    # long/flat path) and must error, not silently run long-only.
+    df = _trending_ohlc()
+    with pytest.raises(ValueError, match="close evaluator"):
+        walk_forward_optimize(
+            df, "sma_crossover", {"fast_period": [10], "slow_period": [40]},
+            n_splits=2, verbose=False, direction="short",
+        )
+
+
+def test_optimize_both_direction_with_fixed_close_ref_runs():
+    # Inverse case: a fixed --close-strategy activates the open/close engine,
+    # which legitimately opens both sides — the guard must not over-reject.
+    df = _trending_ohlc()
+    result = walk_forward_optimize(
+        df, "sma_crossover", {"fast_period": [10], "slow_period": [40]},
+        n_splits=2, verbose=False, direction="both",
+        close_strategies=[{"name": "tiered_tp_atr",
+                           "params": {"tp_tiers": WIDE_LADDER}}],
+    )
+    assert "window_results" in result, result
+
+
+def test_optimize_long_direction_with_no_close_ref_runs():
+    # Boundary: explicit long with no close ref is the structurally-valid
+    # default and must keep running long/flat unchanged.
+    df = _trending_ohlc()
+    result = walk_forward_optimize(
+        df, "sma_crossover", {"fast_period": [10], "slow_period": [40]},
+        n_splits=2, verbose=False, direction="long",
+    )
+    sides = {t["side"] for w in result["window_results"]
+             for t in w["test_result"]["trades"]}
+    assert sides <= {"long"}, sides

--- a/backtest/tests/test_optimizer_close_stacks.py
+++ b/backtest/tests/test_optimizer_close_stacks.py
@@ -1,0 +1,327 @@
+"""Close-stack co-optimization (#996): walk_forward_optimize sweeps complete
+exit configurations (close-evaluator refs + the exclusive ATR stop owners)
+jointly with the open-param grid, so selection picks (entry, exit) pairs.
+
+Also regression-covers the pre-#996 silent no-op: the optimize path never
+injected an `atr` column, so a tiered_tp_atr close ref threaded through
+walk_forward_optimize ran with entry_atr=0 and never fired a TP.
+"""
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from optimizer import (
+    DEFAULT_CLOSE_STACK_SPECS,
+    _result_metric,
+    close_stack_label,
+    generate_close_stack_grid,
+    walk_forward_optimize,
+)
+
+
+def _trending_ohlc(n: int = 400, seed: int = 7) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    log_returns = rng.normal(loc=0.002, scale=0.015, size=n)
+    closes = [100.0]
+    for r in log_returns:
+        closes.append(closes[-1] * np.exp(r))
+    closes = np.array(closes[1:])
+    opens = closes * (1.0 + rng.normal(loc=0.0, scale=0.002, size=n))
+    highs = np.maximum(opens, closes) * 1.003
+    lows = np.minimum(opens, closes) * 0.997
+    volume = rng.integers(1000, 10000, size=n).astype(float)
+    idx = pd.date_range("2022-01-01", periods=n, freq="D")
+    return pd.DataFrame(
+        {"open": opens, "high": highs, "low": lows,
+         "close": closes, "volume": volume},
+        index=idx,
+    )
+
+
+TIGHT_LADDER = [
+    {"atr_multiple": 0.5, "close_fraction": 0.5},
+    {"atr_multiple": 1.0, "close_fraction": 1.0},
+]
+WIDE_LADDER = [
+    {"atr_multiple": 3.0, "close_fraction": 0.5},
+    {"atr_multiple": 6.0, "close_fraction": 1.0},
+]
+
+
+# ---------------------------------------------------------------------------
+# generate_close_stack_grid
+# ---------------------------------------------------------------------------
+
+def test_grid_expands_cartesian_per_spec():
+    grid = generate_close_stack_grid([
+        {"close": {"name": "tiered_tp_atr",
+                   "params": {"tp_tiers": [TIGHT_LADDER, WIDE_LADDER]}},
+         "stop_loss_atr_mult": [None, 2.0]},
+    ])
+    assert len(grid) == 4  # 2 ladders x 2 stop values
+    # Ladders are swept as whole candidates, structure preserved.
+    ladders = [g["close_strategies"][0]["params"]["tp_tiers"] for g in grid]
+    assert TIGHT_LADDER in ladders and WIDE_LADDER in ladders
+    sl_values = {g["stop_loss_atr_mult"] for g in grid}
+    assert sl_values == {None, 2.0}
+    assert all(g["label"] for g in grid)
+
+
+def test_grid_baseline_spec_yields_empty_stack():
+    grid = generate_close_stack_grid([{"close": None}])
+    assert len(grid) == 1
+    stack = grid[0]
+    assert stack["close_strategies"] == []
+    assert stack["stop_loss_atr_mult"] is None
+    assert stack["trailing_stop_atr_mult"] is None
+    assert stack["label"] == "baseline"
+
+
+def test_grid_dedupes_identical_stacks_across_specs():
+    grid = generate_close_stack_grid([
+        {"close": None},
+        {"close": None, "stop_loss_atr_mult": [None, 1.5]},
+    ])
+    # The (no close, no stop) combo appears in both specs — kept once.
+    assert len(grid) == 2
+
+
+def test_grid_rejects_both_stop_owners():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        generate_close_stack_grid([
+            {"close": None,
+             "stop_loss_atr_mult": [1.5],
+             "trailing_stop_atr_mult": [2.0]},
+        ])
+
+
+def test_grid_rejects_unknown_spec_keys():
+    with pytest.raises(ValueError, match="unknown keys"):
+        generate_close_stack_grid([{"close": None, "tp_tiers": [TIGHT_LADDER]}])
+
+
+def test_grid_rejects_non_list_param_candidates():
+    with pytest.raises(ValueError, match="non-empty list"):
+        generate_close_stack_grid([
+            {"close": {"name": "tiered_tp_atr",
+                       "params": {"tp_tiers": TIGHT_LADDER}}},  # ladder, not list-of-ladders
+        ])
+
+
+def test_grid_rejects_close_without_name():
+    with pytest.raises(ValueError, match="needs a 'name'"):
+        generate_close_stack_grid([{"close": {"params": {}}}])
+
+
+def test_default_specs_expand_and_are_exclusive():
+    grid = generate_close_stack_grid(DEFAULT_CLOSE_STACK_SPECS)
+    assert len(grid) > 10
+    labels = [g["label"] for g in grid]
+    assert len(labels) == len(set(labels)), "duplicate stack labels"
+    assert "baseline" in labels
+    for g in grid:
+        assert not (g["stop_loss_atr_mult"] and g["trailing_stop_atr_mult"])
+
+
+def test_close_stack_label_is_compact():
+    grid = generate_close_stack_grid([
+        {"close": {"name": "tiered_tp_atr",
+                   "params": {"tp_tiers": [TIGHT_LADDER]}},
+         "stop_loss_atr_mult": [2.0]},
+    ])
+    assert grid[0]["label"] == "tiered_tp_atr[0.5x:0.5,1x:1] sl_atr=2"
+
+
+# ---------------------------------------------------------------------------
+# _result_metric
+# ---------------------------------------------------------------------------
+
+def test_result_metric_reads_plain_keys():
+    assert _result_metric({"sharpe_ratio": 1.5}, "sharpe_ratio") == 1.5
+
+
+def test_result_metric_dd_adjusted_return():
+    assert _result_metric(
+        {"total_return_pct": 30.0, "max_drawdown_pct": -15.0},
+        "dd_adjusted_return") == pytest.approx(2.0)
+    # Zero-DD legs score 0.0 (eval_windows.dd_adjusted_return parity) so an
+    # untraded combo never outranks a traded one.
+    assert _result_metric(
+        {"total_return_pct": 10.0, "max_drawdown_pct": 0.0},
+        "dd_adjusted_return") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# walk_forward_optimize joint sweep
+# ---------------------------------------------------------------------------
+
+def test_joint_sweep_reports_best_close_stack():
+    df = _trending_ohlc()
+    grid = generate_close_stack_grid([
+        {"close": None},
+        {"close": {"name": "tiered_tp_atr",
+                   "params": {"tp_tiers": [TIGHT_LADDER]}}},
+    ])
+    result = walk_forward_optimize(
+        df, "sma_crossover", {"fast_period": [10], "slow_period": [40]},
+        n_splits=2, train_pct=0.7, initial_capital=1000.0, verbose=False,
+        close_stack_grid=grid,
+    )
+    assert "window_results" in result, result
+    assert result["close_stack_grid_size"] == 2
+    labels = {g["label"] for g in grid}
+    for w in result["window_results"]:
+        assert w["best_close_stack"] in labels
+        assert set(w["best_close_stack_spec"]) == {
+            "close_strategies", "stop_loss_atr_mult", "trailing_stop_atr_mult"}
+    assert result["most_common_best_close_stack"] in labels
+
+
+def test_joint_sweep_rejects_fixed_close_kwargs():
+    df = _trending_ohlc()
+    grid = generate_close_stack_grid([{"close": None}])
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        walk_forward_optimize(
+            df, "sma_crossover", {"fast_period": [10], "slow_period": [40]},
+            n_splits=2, verbose=False,
+            close_stack_grid=grid,
+            close_strategies=[{"name": "tp_at_pct", "params": {"pct": 0.03}}],
+        )
+
+
+def test_joint_sweep_rejects_invalid_stack_loudly():
+    """Invalid stacks must fail at Backtester construction, not be silently
+    skipped inside the fold loop (trailing_tp_ratchet needs a trailing mult)."""
+    df = _trending_ohlc()
+    grid = [{
+        "label": "bad ratchet",
+        "close_strategies": [{"name": "trailing_tp_ratchet", "params": {}}],
+        "stop_loss_atr_mult": None,
+        "trailing_stop_atr_mult": None,
+    }]
+    with pytest.raises(ValueError, match="trailing_tp_ratchet"):
+        walk_forward_optimize(
+            df, "sma_crossover", {"fast_period": [10], "slow_period": [40]},
+            n_splits=2, verbose=False, close_stack_grid=grid,
+        )
+
+
+def test_tiered_tp_atr_actually_fires_in_optimize_path():
+    """Regression (#996): the optimize path must inject `atr` so tiered_tp_atr
+    stamps entry_atr and fires TPs. Pre-fix, the evaluator silently no-oped and
+    a tight-TP stack scored identically to the baseline."""
+    df = _trending_ohlc(seed=11)
+    grid = generate_close_stack_grid([
+        {"close": None},
+        {"close": {"name": "tiered_tp_atr",
+                   "params": {"tp_tiers": [TIGHT_LADDER]}}},
+    ])
+    param_ranges = {"fast_period": [10], "slow_period": [40]}
+
+    def _oos(close_stack_grid):
+        r = walk_forward_optimize(
+            df, "sma_crossover", param_ranges,
+            n_splits=2, train_pct=0.7, initial_capital=1000.0, verbose=False,
+            close_stack_grid=close_stack_grid,
+        )
+        assert "window_results" in r, r
+        return r
+
+    baseline = _oos([grid[0]])
+    tight_tp = _oos([grid[1]])
+    base_trades = sum(w["test_result"]["total_trades"]
+                      for w in baseline["window_results"])
+    tp_trades = sum(w["test_result"]["total_trades"]
+                    for w in tight_tp["window_results"])
+    # A 0.5-ATR first tier on daily bars with ~1.5% vol fires almost
+    # immediately — the tight-TP stack must produce a different (richer)
+    # trade record than open-signal-as-close. Identical records mean the
+    # evaluator never saw an ATR column (the pre-fix silent no-op).
+    assert tp_trades > base_trades, (
+        f"tiered_tp_atr produced the same trade count as baseline "
+        f"({tp_trades} vs {base_trades}) — entry_atr was never stamped")
+
+
+def test_fixed_close_path_unchanged_and_atr_injected():
+    """The pre-existing fixed close_strategies kwarg still works, now with ATR
+    injection so the evaluator actually fires."""
+    df = _trending_ohlc(seed=11)
+    result = walk_forward_optimize(
+        df, "sma_crossover", {"fast_period": [10], "slow_period": [40]},
+        n_splits=2, train_pct=0.7, initial_capital=1000.0, verbose=False,
+        close_strategies=[{"name": "tiered_tp_atr",
+                           "params": {"tp_tiers": TIGHT_LADDER}}],
+    )
+    assert "window_results" in result, result
+    assert result["close_stack_grid_size"] == 1
+    total_trades = sum(w["test_result"]["total_trades"]
+                       for w in result["window_results"])
+    assert total_trades > 0
+
+
+def test_dd_adjusted_metric_selects_and_reports():
+    df = _trending_ohlc()
+    grid = generate_close_stack_grid([
+        {"close": None, "stop_loss_atr_mult": [None, 2.0]},
+    ])
+    result = walk_forward_optimize(
+        df, "sma_crossover", {"fast_period": [10], "slow_period": [40]},
+        n_splits=2, train_pct=0.7, initial_capital=1000.0, verbose=False,
+        close_stack_grid=grid, optimize_metric="dd_adjusted_return",
+    )
+    assert "window_results" in result, result
+    assert result["optimize_metric"] == "dd_adjusted_return"
+    for w in result["window_results"]:
+        assert np.isfinite(w["train_metric"])
+
+
+def test_stack_specs_survive_json_round_trip():
+    """--close-stacks-json feeds specs through json.load — the expansion must
+    treat null as None for stop values."""
+    specs = json.loads(json.dumps([
+        {"close": {"name": "tiered_tp_atr",
+                   "params": {"tp_tiers": [TIGHT_LADDER]}},
+         "stop_loss_atr_mult": [None, 1.5]},
+    ]))
+    grid = generate_close_stack_grid(specs)
+    assert len(grid) == 2
+    assert {g["stop_loss_atr_mult"] for g in grid} == {None, 1.5}
+
+
+# ---------------------------------------------------------------------------
+# Entry-universe consistency: close refs activate the open/close engine where
+# raw signal=-1 OPENS a short, while the no-close baseline stack runs the
+# structurally long/flat plain path. The sweep must hold the entry side
+# constant (default: long) or the stacks score different universes.
+# ---------------------------------------------------------------------------
+
+def test_joint_sweep_defaults_to_long_universe():
+    df = _trending_ohlc(seed=11)
+    grid = generate_close_stack_grid([
+        {"close": {"name": "tiered_tp_atr",
+                   "params": {"tp_tiers": [WIDE_LADDER]}}},
+    ])
+    result = walk_forward_optimize(
+        df, "sma_crossover", {"fast_period": [10], "slow_period": [40]},
+        n_splits=2, train_pct=0.7, initial_capital=1000.0, verbose=False,
+        close_stack_grid=grid,
+    )
+    assert "window_results" in result, result
+    sides = {t["side"] for w in result["window_results"]
+             for t in w["test_result"]["trades"]}
+    assert sides <= {"long"}, (
+        f"close-stack sweep opened {sides} — sma_crossover's sell signals "
+        f"must not open shorts under the default long entry universe")
+
+
+def test_joint_sweep_rejects_short_universe_with_no_close_stack():
+    df = _trending_ohlc()
+    grid = generate_close_stack_grid([{"close": None}])
+    with pytest.raises(ValueError, match="close evaluator"):
+        walk_forward_optimize(
+            df, "sma_crossover", {"fast_period": [10], "slow_period": [40]},
+            n_splits=2, verbose=False, close_stack_grid=grid,
+            direction="both",
+        )

--- a/backtest/tests/test_run_backtest_cli.py
+++ b/backtest/tests/test_run_backtest_cli.py
@@ -118,3 +118,50 @@ def test_backtester_imports_under_script_style_sys_path(tmp_path):
     )
     assert proc.returncode == 0, proc.stderr
     assert "OK" in proc.stdout
+
+
+def test_build_parser_accepts_close_stack_flags():
+    parser = run_backtest._build_parser()
+    args = parser.parse_args([
+        "--mode", "optimize", "--strategy", "sma_crossover",
+        "--sweep-close", "--optimize-metric", "dd_adjusted_return",
+        "--direction", "long",
+    ])
+    assert args.sweep_close is True
+    assert args.optimize_metric == "dd_adjusted_return"
+    assert args.direction == "long"
+    assert args.close_stacks_json is None
+
+
+def test_build_parser_rejects_unknown_optimize_metric():
+    parser = run_backtest._build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--optimize-metric", "alpha_decay"])
+
+
+def test_run_walk_forward_threads_close_stack_grid(monkeypatch):
+    """The close-stack grid, metric, and direction must reach
+    walk_forward_optimize — a dropped kwarg silently degrades #996 sweeps to
+    a fixed-close run."""
+    seen = {}
+
+    def spy_wfo(df, strategy_name, param_ranges, **kwargs):
+        seen.update(kwargs)
+        return {"error": "spy", "strategy": strategy_name}
+
+    monkeypatch.setattr(run_backtest, "walk_forward_optimize", spy_wfo)
+    monkeypatch.setattr(
+        run_backtest, "load_cached_data",
+        lambda *a, **k: pd.DataFrame(
+            {"open": [1.0] * 300, "high": [1.0] * 300, "low": [1.0] * 300,
+             "close": [1.0] * 300, "volume": [1.0] * 300},
+            index=pd.date_range("2024-01-01", periods=300, freq="D")))
+
+    grid = [{"label": "baseline", "close_strategies": [],
+             "stop_loss_atr_mult": None, "trailing_stop_atr_mult": None}]
+    run_backtest.run_walk_forward(
+        "sma_crossover", close_stack_grid=grid,
+        optimize_metric="dd_adjusted_return", direction="long")
+    assert seen["close_stack_grid"] == grid
+    assert seen["optimize_metric"] == "dd_adjusted_return"
+    assert seen["direction"] == "long"

--- a/backtest/tests/test_walk_forward_warmup.py
+++ b/backtest/tests/test_walk_forward_warmup.py
@@ -280,3 +280,61 @@ def test_seeded_metrics_anchor_at_initial_capital():
     )
     assert result["total_return_pct"] == pytest.approx(0.0, abs=0.01)
     assert result["max_drawdown_pct"] == pytest.approx(0.0, abs=0.01)
+
+
+def test_warmup_seed_stamps_entry_atr_and_high_water():
+    """PR #1000 review: the seed must carry the fill-bar ATR and the max
+    close since entry so ATR-based close stacks and trailing stops manage
+    the carried position like a mid-window open."""
+    n = 30
+    opens = [100.0] * n
+    closes = [100.0] * 10 + [104.0, 108.0] + [103.0] * (n - 12)
+    signals = [0] * n
+    signals[5] = 1  # BUY → fills at bar 6 open
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame({
+        "open": opens, "close": closes, "signal": signals,
+        "atr": [2.5] * n,
+    }, index=idx)
+    seed = warmup_exit_long_entry(df, slippage_pct=0.0)
+    assert seed is not None
+    assert seed["entry_atr"] == pytest.approx(2.5)
+    assert seed["high_water"] == pytest.approx(108.0)
+
+
+def test_warmup_seed_omits_implausible_entry_atr():
+    """Mirrors Backtester._stamp_entry_atr: an ATR above 50% of the entry
+    price (or NaN/non-positive) is rejected — the seed simply omits the
+    key and the carried position degrades to the pre-stamp behavior."""
+    n = 20
+    signals = [0] * n
+    signals[5] = 1
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame({
+        "open": [100.0] * n, "close": [100.0] * n, "signal": signals,
+        "atr": [80.0] * n,  # > 50% of the $100 entry
+    }, index=idx)
+    seed = warmup_exit_long_entry(df, slippage_pct=0.0)
+    assert seed is not None
+    assert "entry_atr" not in seed
+    assert seed["high_water"] == pytest.approx(100.0)
+
+
+def test_warmup_seed_high_water_resets_on_reentry():
+    """A round trip inside the warmup must not leak its high-water mark
+    into a later entry's seed."""
+    n = 20
+    closes = [100.0] * 5 + [150.0] * 5 + [100.0] * 10
+    signals = [0] * n
+    signals[2] = 1    # first BUY → fills bar 3
+    signals[9] = -1   # SELL → fills bar 10 (HWM 150 ends here)
+    signals[12] = 1   # re-entry → fills bar 13
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame({
+        "open": closes[:], "close": closes, "signal": signals,
+        "atr": [2.0] * n,
+    }, index=idx)
+    seed = warmup_exit_long_entry(df, slippage_pct=0.0)
+    assert seed is not None
+    assert seed["high_water"] == pytest.approx(100.0), (
+        "the closed first trade's 150 HWM must not survive the re-entry")


### PR DESCRIPTION
Closes #996. Child of the #977 umbrella; unblocks #983 / #984.

## Deliverable 1 — joint (open-params × close-params) optimization

`walk_forward_optimize` now sweeps complete **close stacks** — a close-evaluator ref (whole tier ladders are single grid values) plus the mutually-exclusive backtester-level ATR stop owners — jointly with the open-param grid, selecting the best (entry, exit) pair per fold.

- `generate_close_stack_grid(specs)` expands sweep specs: cartesian per spec across close params × `stop_loss_atr_mult` × `trailing_stop_atr_mult`; rejects both-stop combos, single-ladder-where-list-expected, unknown keys; dedups across specs; every stack gets a compact label.
- `DEFAULT_CLOSE_STACK_SPECS` ships a 25-stack default grid (audit baseline, ATR stops, trailing stops, 3 `tiered_tp_atr` ladders × stop variants).
- One `Backtester` per stack, constructed before the fold loop so invalid stacks fail loudly instead of being silently skipped.
- New selection metric `dd_adjusted_return` (#963 DDadj; zero-DD legs score 0 so untraded combos never win).
- Reporting: per-fold `best_close_stack` (+ full spec), `most_common_best_close_stack`, joint-grid size; reporter shows stack per fold.
- CLI (optimize mode): `--sweep-close`, `--close-stacks-json <path>`, `--optimize-metric`, `--direction`. The grid is mutually exclusive with the fixed `--close-strategy`/`--stop-loss-atr-mult`/`--trailing-stop-atr-mult` flags.
- `eval_windows.py` candidates now carry `stop_loss_atr_mult`/`trailing_stop_atr_mult` (mutually exclusive, validated) so M2 winners flow into the M1 protocol unchanged.

## Three engine gaps the sweep surfaced (all fixed + regression-tested)

1. **Scalar stops silently dropped alongside close evaluators.** The open/close engine path only seeded an SL trigger under `sl_after` (`#716`), while live arms the fixed/trailing SL via `runHyperliquidProtectionSync`/`armTrailingStopAtOpenNow` regardless. Bare `stop_loss_atr_mult`/`trailing_stop_atr_mult`/`stop_loss_pct` with a close ref now seed at open (fixed > trailing > pct, mirroring the plain path) and are simulated by the end-of-bar hit check. Without this, every (ladder × stop) grid point scored identically to (ladder, no stop).
2. **Entry-universe inconsistency.** Close refs activate the engine path where raw `signal=-1` *opens a short*, while the no-close baseline stack runs the structurally long/flat plain path — the sweep compared different entry universes (first scoreboard run showed -265% "worst DD" from accidental 2023 shorts). Joint sweeps now default `direction=long` (overridable; short/both requires every stack to carry a close evaluator). `eval_windows` now *executes* its validated default direction (`long`) instead of silently running both.
3. **ATR never injected in the optimize path.** Single mode injects ATR(14) for close evaluators (`run_backtest.py:413`); walk-forward didn't, so a threaded `tiered_tp_atr` never stamped `entry_atr` and silently no-oped. Now injected (with warmup extended to prime ATR).

## Deliverable 2 — reference application: `squeeze_momentum` (#983), entry frozen

Selection on the protocol IS window only (2025-06-10 → 2026-01-01, six audit datasets, registry-default entry params); validation through the full M1 protocol with the #963/#976 incumbent bar.

| window | candidate | mean ret% | worst DD% | mean Sharpe |
|---|---|---|---|---|
| is | baseline (audit default close) | -3.14 | **-46.83** | -0.065 |
| is | runner ladder + trail_atr=3 | -3.03 | **-19.07** | -0.370 |
| 2023 | baseline | **+154.74** | -43.13 | 1.481 |
| 2023 | runner ladder + trail_atr=3 | **+13.26** | -34.87 | 0.119 |
| 2024 | baseline | +39.07 | -57.46 | 0.797 |
| 2024 | runner ladder + trail_atr=3 | +0.47 | -42.33 | -0.141 |
| 2025H1 | baseline | -26.55 | **-67.64** | -0.976 |
| 2025H1 | runner ladder + trail_atr=3 | -16.44 | **-35.37** | -1.613 |

**Verdict: candidates rejected — the protocol worked.** The default grid's stacks cut worst DD 40–60% in every window with IS returns preserved, but fail the M1 incumbent bar on held-out windows (`runner+trail_atr=3`: 0/3 held-out; `default ladder+sl_atr=1.5`: 0/3): ATR ladders bank out of exactly the 2023/2024 trend rides where squeeze_momentum's long-leg edge lives (+154.7% → +13.3%). Two methodology findings for #983/#984:

1. **Mean DDadj mis-ranks DD-cutters in losing windows** (smaller DD divisor on a negative return → worse ratio); selection there should use dominance on (return, worst DD), with DDadj-vs-bar as the validation gate.
2. The held-out windows have now been consumed for these stack families on squeeze_momentum — further exit design for #983 must select on the IS window only (asymmetric/trend-preserving exits, M3 territory) before one final held-out read.

## Tests

33 new tests (close-stack grid expansion/validation/labels, joint sweep selection + reporting, fixed-kwarg conflicts, loud invalid-stack failure, ATR no-op regression, scalar-stop-with-close-evaluator class incl. short side / pct / partial-TP-then-stop compound / no-breach inverse, entry-universe defaults, eval_windows stop threading + exclusivity, CLI threading). Full suite: **1434 passed**.

---
Created with LLM: Fable 5 | high | Harness: Claude Code