### PR TITLE
feat(strategies): M4 regime-profile allocation — slow regime switch between two validated profiles (#998)

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -234,6 +234,91 @@ def _open_action_from_signal(signal: int) -> str:
     return "none"
 
 
+def _parse_profile_allocation(alloc: Optional[dict]) -> Optional[dict]:
+    """Validate and compact a regime_profile_allocation block for the engine
+    (#998). Returns None when unset; raises ValueError on a malformed block so
+    a misconfigured --config fails loudly rather than silently single-profile.
+
+    The compact form mirrors the Go RegimeProfileAllocation: profiles (label ->
+    profile name), param_sets (profile -> params), confirm_bars, initial_profile.
+    The window key and per-profile signal computation live in run_backtest.py;
+    the engine only replays the switch over the supplied ``signal__<profile>``
+    columns.
+    """
+    if not alloc:
+        return None
+    profiles = dict(alloc.get("profiles") or {})
+    param_sets = dict(alloc.get("param_sets") or {})
+    confirm_bars = int(alloc.get("confirm_bars") or 0)
+    initial_profile = str(alloc.get("initial_profile") or "").strip()
+    if len(param_sets) != 2:
+        raise ValueError(
+            f"regime_profile_allocation.param_sets must define exactly 2 "
+            f"profiles (the M4 two-profile model), got {len(param_sets)}"
+        )
+    if confirm_bars < 1:
+        raise ValueError("regime_profile_allocation.confirm_bars must be >= 1")
+    if initial_profile not in param_sets:
+        raise ValueError(
+            f"regime_profile_allocation.initial_profile={initial_profile!r} "
+            f"is not a param_sets profile {sorted(param_sets)}"
+        )
+    for lbl, prof in profiles.items():
+        if prof not in param_sets:
+            raise ValueError(
+                f"regime_profile_allocation.profiles[{lbl!r}]={prof!r} is not "
+                f"a param_sets profile {sorted(param_sets)}"
+            )
+    return {
+        "profiles": profiles,
+        "param_sets": param_sets,
+        "confirm_bars": confirm_bars,
+        "initial_profile": initial_profile,
+        "names": sorted(param_sets),
+    }
+
+
+class _ProfileSwitcher:
+    """Per-bar flat-only, confirm_bars hysteresis profile switch — the exact
+    state machine resolveRegimeProfile replays live (#998). The backtester is
+    bar-cadenced, so every ``step`` is a closed-bar advance.
+    """
+
+    def __init__(self, alloc: dict):
+        self._profiles = alloc["profiles"]
+        self._confirm_bars = alloc["confirm_bars"]
+        self.active = alloc["initial_profile"]
+        self._pending = ""
+        self._seen = 0
+
+    def step(self, label: str, flat: bool) -> str:
+        """Advance one closed bar and return the profile governing THIS bar's
+        open decision. ``flat`` is the position state at decision time (the
+        backtester's position carried into this bar)."""
+        desired = self._profiles.get((label or "").strip(), "")
+        if desired == "":
+            # Fail-open / unknown label: freeze the counter, hold active.
+            return self.active
+        if desired == self.active:
+            self._pending = ""
+            self._seen = 0
+            return self.active
+        # Desired differs from active: accrue hysteresis.
+        if self._pending == desired:
+            self._seen += 1
+        else:
+            self._pending = desired
+            self._seen = 1
+        # Commit only when flat AND the desired profile has persisted long
+        # enough. While a position is open the counter keeps growing but the
+        # switch is deferred to the first flat bar.
+        if flat and self._seen >= self._confirm_bars:
+            self.active = desired
+            self._pending = ""
+            self._seen = 0
+        return self.active
+
+
 def _close_refs_use_regime_tiered_tp(refs: list[dict]) -> bool:
     for ref in refs:
         n = (ref.get("name") or "").strip().lower()
@@ -424,7 +509,8 @@ class Backtester:
                  trailing_stop_atr_regime: Optional[dict] = None,
                  strategy_type: str = "perps",
                  direction: Optional[str] = None,
-                 invert_signal: bool = False):
+                 invert_signal: bool = False,
+                 profile_allocation: Optional[dict] = None):
         """
         Args:
             initial_capital: Starting portfolio value.
@@ -503,6 +589,12 @@ class Backtester:
         # mirroring the live order (applySignalInversion before EffectiveDirection).
         self.direction = (str(direction).strip().lower() if direction else None)
         self.invert_signal = bool(invert_signal)
+        # #998: regime-profile allocation. When set, run() expects per-profile
+        # signal columns ("signal__<profile>") plus a "_profile_label" column
+        # (the long-window regime label per bar) and replays the live flat-only,
+        # confirm_bars hysteresis switch inside the per-bar loop. None = single
+        # profile (the normal path). Validated into a compact dict.
+        self._profile_alloc = _parse_profile_allocation(profile_allocation)
         self.stop_loss_atr_regime = (
             dict(stop_loss_atr_regime) if stop_loss_atr_regime else None
         )
@@ -858,6 +950,47 @@ class Backtester:
                 sig = sig.where(sig <= 0, 0)
         return sig.astype(int)
 
+    def _normalize_profile_signals(self, df: pd.DataFrame, uses_open_close: bool) -> None:
+        """Normalize each profile's ``signal__<p>`` column exactly like the
+        single-signal path (domain check → invert/direction gate → look-ahead
+        shift) and shift ``_profile_label`` so the per-bar switch reads bar N's
+        label to govern the N+1 fill (#998). Mutates ``df`` in place.
+
+        Each profile differs only in the OPEN signal; closes come from the shared
+        close evaluator, so the engine derives ``_open_action__<p>`` from each
+        profile's signal but keeps a single (profile-independent) ``_close_fraction``.
+        """
+        for p in self._profile_alloc["names"]:
+            col = "signal__" + p
+            sig_raw = df[col].fillna(0).astype(float)
+            non_integral = sig_raw[sig_raw != sig_raw.round()]
+            if not non_integral.empty:
+                raise ValueError(
+                    f"{col} must be in {{-1, 0, 1}} — got non-integral values "
+                    f"{sorted(set(non_integral.unique().tolist()))}"
+                )
+            sig_int = sig_raw.astype(int)
+            bad = sig_int[~sig_int.isin([-1, 0, 1])]
+            if not bad.empty:
+                raise ValueError(
+                    f"{col} must be in {{-1, 0, 1}} — got unexpected values "
+                    f"{sorted(bad.unique().tolist())}"
+                )
+            sig_int = self._apply_direction_invert(sig_int, uses_open_close)
+            if uses_open_close:
+                df["_open_action__" + p] = (
+                    sig_int.map(_open_action_from_signal).shift(1).fillna("none")
+                )
+            df[col] = sig_int.shift(1).fillna(0).astype(int)
+        # Dummy single-signal column so downstream code that references
+        # ``df["signal"]`` doesn't KeyError; the per-bar loop overrides ``signal``
+        # (and ``open_action``) from the active profile each bar.
+        df["signal"] = 0
+        if uses_open_close:
+            df["_open_action"] = "none"
+            df["_close_fraction"] = _max_close_fraction_series(df).shift(1).fillna(0.0)
+        df["_profile_label"] = df["_profile_label"].shift(1).fillna("")
+
     def run(self, df: pd.DataFrame, strategy_name: str = "Unknown",
             symbol: str = "BTC/USDT", timeframe: str = "1d",
             params: Optional[dict] = None, save: bool = True,
@@ -897,11 +1030,28 @@ class Backtester:
             or bool(_close_fraction_columns(df))
             or bool(self.close_strategies)
         )
-        if "signal" not in df.columns and not uses_open_close:
+        has_profile_alloc = self._profile_alloc is not None
+        if has_profile_alloc:
+            if "_profile_label" not in df.columns:
+                raise ValueError(
+                    "regime_profile_allocation backtest requires a '_profile_label' column"
+                )
+            missing = [
+                p for p in self._profile_alloc["names"]
+                if ("signal__" + p) not in df.columns
+            ]
+            if missing:
+                raise ValueError(
+                    f"regime_profile_allocation backtest is missing signal columns "
+                    f"for profiles {missing} (expected 'signal__<profile>')"
+                )
+        if "signal" not in df.columns and not uses_open_close and not has_profile_alloc:
             raise ValueError("DataFrame must have a 'signal' column or open_action/close_fraction columns")
 
         df = df.copy()
-        if "signal" in df.columns:
+        if has_profile_alloc:
+            self._normalize_profile_signals(df, uses_open_close)
+        elif "signal" in df.columns:
             # Contract: signal ∈ {-1, 0, 1}. position.diff() emits ±1.0 floats
             # and some strategies emit ints; coerce NaN → 0, reject non-integral
             # floats before casting, and then reject any out-of-domain integer.
@@ -931,7 +1081,7 @@ class Backtester:
             signal_for_open = pd.Series(0, index=df.index)
             df["signal"] = 0
 
-        if uses_open_close:
+        if uses_open_close and not has_profile_alloc:
             if "open_action" in df.columns:
                 open_actions = df["open_action"].map(_normalize_open_action)
             else:
@@ -1190,10 +1340,24 @@ class Backtester:
             sl_tiers_processed = 0
             post_tp_trail_mult = None
 
+        profile_switcher = (
+            _ProfileSwitcher(self._profile_alloc) if has_profile_alloc else None
+        )
+        active_profile = ""
+
         for i, (idx, row) in enumerate(df.iterrows()):
             fill_price = row["open"] if has_open else row["close"]
             mark_price = row["close"]
             signal = row["signal"]
+            # #998: regime-profile allocation — advance the flat-only, confirm_bars
+            # hysteresis switch and read the active profile's signal for this bar.
+            # ``flat`` is the position carried into the bar (= the position state at
+            # the decision time the shifted columns correspond to).
+            if profile_switcher is not None:
+                active_profile = profile_switcher.step(
+                    str(row.get("_profile_label", "") or ""), position == 0
+                )
+                signal = row["signal__" + active_profile]
 
             # Per-bar reset: when _maybe_apply_sl_after bumps the SL trigger on
             # this bar, the end-of-bar block (both the trail-walker HWM update
@@ -1239,7 +1403,10 @@ class Backtester:
                     close_reason = pending_close_reason
                 pending_close_fraction = 0.0
                 pending_close_reason = ""
-                open_action = row.get("_open_action", "none")
+                if profile_switcher is not None:
+                    open_action = row.get("_open_action__" + active_profile, "none")
+                else:
+                    open_action = row.get("_open_action", "none")
 
                 if close_fraction > 0 and position != 0:
                     qty_to_close = abs(position) * min(close_fraction, 1.0)

--- a/backtest/eval_windows.py
+++ b/backtest/eval_windows.py
@@ -251,12 +251,14 @@ def run_leg(reg, name: str, params: Optional[dict], symbol: str, timeframe: str,
             direction: Optional[str] = None,
             invert_signal: bool = False,
             stop_loss_atr_mult: Optional[float] = None,
-            trailing_stop_atr_mult: Optional[float] = None) -> Optional[dict]:
+            trailing_stop_atr_mult: Optional[float] = None,
+            profile_allocation: Optional[dict] = None) -> Optional[dict]:
     """Run one (strategy, dataset, window) leg on the audit-identical harness."""
     from atr import ensure_atr_indicator
     from data_fetcher import load_cached_data
     from backtester import Backtester
-    from run_backtest import FUNDING_COLUMN_STRATEGIES, _attach_funding_if_needed
+    from run_backtest import (FUNDING_COLUMN_STRATEGIES, _attach_funding_if_needed,
+                              _build_profile_label_series)
 
     start, end = window
     df = load_cached_data(symbol, timeframe, start_date=start, end_date=end)
@@ -270,9 +272,26 @@ def run_leg(reg, name: str, params: Optional[dict], symbol: str, timeframe: str,
         raise SystemExit(f"Unknown strategy {name!r}; available: {reg.list_strategies()}")
     strat_params = params if params is not None else strat["default_params"]
 
-    df_signals = reg.apply_strategy(name, df, strat_params)
-    if close_strategies:
-        df_signals = ensure_atr_indicator(df_signals)
+    if profile_allocation:
+        # #998: per-profile signals + long-window label, then engine replays the switch.
+        param_sets = profile_allocation["param_sets"]
+        df_signals = None
+        for p in sorted(param_sets):
+            p_params = {**(strat_params or {}), **(param_sets[p] or {})}
+            res = reg.apply_strategy(name, df, p_params)
+            if df_signals is None:
+                df_signals = res.copy()
+                df_signals["signal__" + p] = df_signals.pop("signal")
+            else:
+                df_signals["signal__" + p] = res["signal"].values
+        if close_strategies:
+            df_signals = ensure_atr_indicator(df_signals)
+        df_signals["_profile_label"] = _build_profile_label_series(
+            df_signals, profile_allocation["window_spec"]).values
+    else:
+        df_signals = reg.apply_strategy(name, df, strat_params)
+        if close_strategies:
+            df_signals = ensure_atr_indicator(df_signals)
 
     bt = Backtester(
         initial_capital=capital, platform=PLATFORM,
@@ -281,6 +300,7 @@ def run_leg(reg, name: str, params: Optional[dict], symbol: str, timeframe: str,
         direction=direction, invert_signal=invert_signal,
         stop_loss_atr_mult=stop_loss_atr_mult,
         trailing_stop_atr_mult=trailing_stop_atr_mult,
+        profile_allocation=profile_allocation,
     )
     results = bt.run(df_signals, strategy_name=name, symbol=symbol,
                      timeframe=timeframe, params=strat_params, save=False)
@@ -342,6 +362,18 @@ def validate_candidate(candidate: dict) -> dict:
             "candidate sets both stop_loss_atr_mult and "
             "trailing_stop_atr_mult; the stop owners are mutually exclusive "
             "— pick one.")
+    # #998: regime-profile allocation is backtestable; validate the block shape
+    # and require an inline window_spec so the harness can compute the label
+    # series (eval_windows has no live regime store / config).
+    pal = candidate.get("profile_allocation")
+    if pal:
+        from backtester import _parse_profile_allocation
+        _parse_profile_allocation(pal)  # raises on bad param_sets/confirm/initial
+        if not pal.get("window_spec"):
+            raise ValueError(
+                "candidate.profile_allocation needs an inline 'window_spec' "
+                "({classifier, period[, thresholds|adx_threshold]}) so the "
+                "harness can compute the switch label series.")
     return candidate
 
 
@@ -371,6 +403,7 @@ def evaluate_window(reg, candidate: dict, datasets: List[tuple],
             invert_signal=bool(candidate.get("invert_signal")),
             stop_loss_atr_mult=candidate.get("stop_loss_atr_mult"),
             trailing_stop_atr_mult=candidate.get("trailing_stop_atr_mult"),
+            profile_allocation=candidate.get("profile_allocation"),
         )
     score = score_candidate(candidate_legs, bars)
     score["window"] = window_name
@@ -500,6 +533,11 @@ def build_parser() -> argparse.ArgumentParser:
                    help="Plateau sweep over a param (repeatable; cartesian)")
     p.add_argument("--sweep-window", default="oos", choices=list(WINDOWS),
                    help="Window the sweep is scored on (default: oos)")
+    p.add_argument("--profile-allocation", default=None,
+                   help="#998 regime-profile allocation JSON: {window_spec:"
+                        "{classifier,period,...}, profiles:{label:profile}, "
+                        "param_sets:{profile:{...}}, confirm_bars, initial_profile}. "
+                        "Scores the switched composite on the same harness.")
     p.add_argument("--json", default=None, dest="json_out",
                    help="Write the full structured result to this path")
     return p
@@ -519,6 +557,9 @@ def main(argv: Optional[List[str]] = None) -> int:
             candidate["params"] = json.loads(args.params)
     else:
         raise SystemExit("supply --strategy or --candidate-json")
+
+    if args.profile_allocation:
+        candidate["profile_allocation"] = json.loads(args.profile_allocation)
 
     try:
         validate_candidate(candidate)

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -59,6 +59,38 @@ from reporter import (
     format_multi_asset_report, format_walk_forward_report,
     generate_full_report,
 )
+from regime import compute_regime, compute_regime_composite  # noqa: E402
+
+
+def _normalize_regime_window_spec(spec) -> dict:
+    """Normalize a regime.windows entry into a {classifier, period, ...} dict.
+    A bare int is ADX shorthand (mirrors Go RegimeWindowsMap.UnmarshalJSON)."""
+    if isinstance(spec, (int, float)) and not isinstance(spec, bool):
+        return {"classifier": "adx", "period": int(spec)}
+    spec = dict(spec or {})
+    classifier = str(spec.get("classifier") or "adx").strip().lower() or "adx"
+    out = {"classifier": classifier, "period": int(spec.get("period") or 0)}
+    if classifier == "adx":
+        out["adx_threshold"] = float(spec.get("adx_threshold") or 20.0)
+    else:
+        out["thresholds"] = dict(spec.get("thresholds") or {})
+    return out
+
+
+def _build_profile_label_series(df: pd.DataFrame, window_spec: dict) -> pd.Series:
+    """Compute the per-bar regime label at the switch window's classifier/period
+    (#998). Mirrors the live regime store: composite via compute_regime_composite,
+    ADX via compute_regime. The result is the bar-close label; Backtester shifts
+    it by one so bar N's label governs the N+1 fill (look-ahead guard)."""
+    classifier = window_spec.get("classifier", "adx")
+    period = int(window_spec.get("period") or 14)
+    if classifier == "composite":
+        reg = compute_regime_composite(df, period=period,
+                                       thresholds=window_spec.get("thresholds") or None)
+    else:
+        reg = compute_regime(df, period=period,
+                             adx_threshold=float(window_spec.get("adx_threshold") or 20.0))
+    return reg["regime"].astype(str)
 
 
 def _htf_trend_series(symbol: str, timeframe: str, ltf_index: pd.Index,
@@ -321,6 +353,38 @@ def load_strategy_config(config_path: str, strategy_id: str,
                 f"silently dropped. Add a close_strategy (the open/close engine "
                 f"models both sides) or backtest a long-only variant."
             )
+        # #998: regime_profile_allocation is backtestable (unlike its rejected
+        # siblings) — the slow long-window switch is a pure function of closed-bar
+        # OHLCV, so Backtester replays it. Resolve the referenced switch window's
+        # spec from the config's regime.windows so run_single_backtest can compute
+        # the per-bar label series; reject loudly if the window is absent.
+        profile_allocation = None
+        pal = sc.get("regime_profile_allocation")
+        if pal:
+            window = str(pal.get("window") or "").strip()
+            regime_cfg = cfg.get("regime") or {}
+            windows = regime_cfg.get("windows") or {}
+            spec = windows.get(window)
+            if not regime_cfg.get("enabled"):
+                raise ValueError(
+                    f"{config_path}: strategy {strategy_id!r} uses "
+                    f"regime_profile_allocation but regime.enabled is not true."
+                )
+            if spec is None:
+                raise ValueError(
+                    f"{config_path}: regime_profile_allocation.window={window!r} "
+                    f"not found in regime.windows (have: {sorted(windows)})."
+                )
+            profile_allocation = {
+                "window": window,
+                "window_spec": _normalize_regime_window_spec(spec),
+                "profiles": dict(pal.get("profiles") or {}),
+                "param_sets": {
+                    k: dict(v or {}) for k, v in (pal.get("param_sets") or {}).items()
+                },
+                "confirm_bars": int(pal.get("confirm_bars") or 0),
+                "initial_profile": str(pal.get("initial_profile") or "").strip(),
+            }
         return {
             "open_strategy": {
                 "name": open_ref["name"],
@@ -337,6 +401,7 @@ def load_strategy_config(config_path: str, strategy_id: str,
             "strategy_type": strategy_type,
             "direction": direction,
             "invert_signal": invert_signal,
+            "profile_allocation": profile_allocation,
         }
     raise ValueError(
         f"{config_path}: no strategy with id={strategy_id!r}. "
@@ -369,6 +434,7 @@ def run_single_backtest(
     strategy_type: str = "perps",
     direction: Optional[str] = None,
     invert_signal: bool = False,
+    profile_allocation: Optional[dict] = None,
 ) -> Optional[dict]:
     """Run a single backtest and print results.
 
@@ -404,14 +470,39 @@ def run_single_backtest(
 
     print(f"  Data: {len(df)} candles from {df.index[0]} to {df.index[-1]}")
 
-    df_signals = reg.apply_strategy(strategy_name, df, strat_params)
+    if profile_allocation:
+        # #998: compute one signal series per profile (base params overlaid with
+        # the profile's param_set) plus the long-window label series, then hand
+        # the multi-profile frame to the engine, which replays the switch.
+        param_sets = profile_allocation["param_sets"]
+        names = sorted(param_sets)
+        df_signals = None
+        for p in names:
+            p_params = {**(strat_params or {}), **(param_sets[p] or {})}
+            res = reg.apply_strategy(strategy_name, df, p_params)
+            if df_signals is None:
+                # Seed from the first profile's full frame (OHLCV + indicators)
+                # and rename its signal; later profiles contribute only signals.
+                df_signals = res.copy()
+                df_signals["signal__" + p] = df_signals.pop("signal")
+            else:
+                df_signals["signal__" + p] = res["signal"].values
+        if close_strategies:
+            df_signals = ensure_atr_indicator(df_signals)
+        df_signals["_profile_label"] = _build_profile_label_series(
+            df_signals, profile_allocation["window_spec"]
+        ).values
+        print(f"  Profile allocation: window={profile_allocation['window']} "
+              f"profiles={names} confirm_bars={profile_allocation['confirm_bars']}")
+    else:
+        df_signals = reg.apply_strategy(strategy_name, df, strat_params)
 
-    # Mirror the runtime check-script contract: inject ATR(14) when the
-    # open strategy doesn't emit `atr`, so close evaluators that require
-    # `entry_atr` (tiered_tp_atr) and `market.atr` (tiered_tp_atr_live)
-    # see consistent volatility input. Idempotent when `atr` already exists.
-    if close_strategies:
-        df_signals = ensure_atr_indicator(df_signals)
+        # Mirror the runtime check-script contract: inject ATR(14) when the
+        # open strategy doesn't emit `atr`, so close evaluators that require
+        # `entry_atr` (tiered_tp_atr) and `market.atr` (tiered_tp_atr_live)
+        # see consistent volatility input. Idempotent when `atr` already exists.
+        if close_strategies:
+            df_signals = ensure_atr_indicator(df_signals)
 
     if htf_filter:
         df_signals = _apply_htf_filter_to_df(df_signals, symbol, timeframe)
@@ -435,6 +526,7 @@ def run_single_backtest(
         strategy_type=strategy_type,
         direction=direction,
         invert_signal=invert_signal,
+        profile_allocation=profile_allocation,
     )
     results = bt.run(
         df_signals,
@@ -775,6 +867,8 @@ def main():
             # signal inside Backtester.run (mirrors live invert-then-gate order).
             "direction",
             "invert_signal",
+            # #998: regime-profile allocation switch block (None when unused).
+            "profile_allocation",
         )
         live_stop_kwargs = {k: live_kwargs[k] for k in stop_keys if k in live_kwargs}
 

--- a/backtest/tests/test_backtester_profile_allocation.py
+++ b/backtest/tests/test_backtester_profile_allocation.py
@@ -1,0 +1,132 @@
+"""Backtester regime-profile allocation (#998) parity tests.
+
+These exercise the in-engine switch replay: per-profile ``signal__<p>`` columns,
+the ``_profile_label`` shift, and the flat-only / confirm_bars hysteresis state
+machine that mirrors the Go ``resolveRegimeProfile``.
+"""
+
+import sys
+import pathlib
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / "shared_tools"))
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from backtester import Backtester, _ProfileSwitcher, _parse_profile_allocation
+
+
+def _alloc(confirm_bars=2):
+    return {
+        "profiles": {"up": "trend", "down": "fade"},
+        "param_sets": {"trend": {"k": 1}, "fade": {"k": 0}},
+        "confirm_bars": confirm_bars,
+        "initial_profile": "fade",
+    }
+
+
+# ─── State machine (mirrors Go resolveRegimeProfile) ─────────────────────────
+
+def test_switcher_flat_switch_after_confirm():
+    sw = _ProfileSwitcher(_parse_profile_allocation(_alloc(confirm_bars=2)))
+    assert sw.step("up", flat=True) == "fade"   # bar 1: pending, not confirmed
+    assert sw.step("up", flat=True) == "trend"  # bar 2: confirmed → switch
+    assert sw.active == "trend"
+
+
+def test_switcher_open_freezes_then_commits_on_first_flat():
+    sw = _ProfileSwitcher(_parse_profile_allocation(_alloc(confirm_bars=2)))
+    # Position open the whole time; counter accrues but no commit.
+    for _ in range(4):
+        assert sw.step("up", flat=False) == "fade"
+    assert sw.active == "fade"
+    # First flat bar commits immediately (counter already satisfied).
+    assert sw.step("up", flat=True) == "trend"
+
+
+def test_switcher_empty_label_freezes():
+    sw = _ProfileSwitcher(_parse_profile_allocation(_alloc(confirm_bars=2)))
+    sw.step("up", flat=True)  # pending=trend seen=1
+    sw.step("", flat=True)    # freeze — no change
+    assert sw.active == "fade"
+    # The frozen counter resumes; one more "up" confirms.
+    assert sw.step("up", flat=True) == "trend"
+
+
+def test_switcher_desired_equals_active_resets_pending():
+    sw = _ProfileSwitcher(_parse_profile_allocation(_alloc(confirm_bars=3)))
+    sw.step("up", flat=True)            # pending=trend seen=1
+    sw.step("down", flat=True)          # desired==active(fade) → reset
+    # Now it takes a full confirm window again.
+    assert sw.step("up", flat=True) == "fade"
+    assert sw.step("up", flat=True) == "fade"
+    assert sw.step("up", flat=True) == "trend"
+
+
+def test_parse_rejects_wrong_profile_count():
+    bad = _alloc()
+    bad["param_sets"] = {"a": {}, "b": {}, "c": {}}
+    try:
+        _parse_profile_allocation(bad)
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "exactly 2" in str(e)
+
+
+# ─── End-to-end engine replay ────────────────────────────────────────────────
+
+def _flat_df(n=40):
+    close = np.full(n, 100.0)
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    return pd.DataFrame(
+        {"open": close, "high": close + 0.01, "low": close - 0.01,
+         "close": close, "volume": 1000.0},
+        index=idx,
+    )
+
+
+def test_engine_selects_active_profile_signal():
+    """Profile 'trend' fires a buy; profile 'fade' never does. With the label
+    held at 'up' and confirm_bars=2, the engine switches to 'trend' and the
+    trend profile's buy opens a position; the fade profile alone would not."""
+    df = _flat_df(40)
+    # trend profile buys on bar 5; fade profile is always flat.
+    sig_trend = pd.Series(0, index=df.index)
+    sig_trend.iloc[5] = 1
+    sig_fade = pd.Series(0, index=df.index)
+    df["signal__trend"] = sig_trend.values
+    df["signal__fade"] = sig_fade.values
+    df["_profile_label"] = "up"  # sustained trending regime
+
+    bt = Backtester(initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0,
+                    profile_allocation=_alloc(confirm_bars=2))
+    result = bt.run(df, save=False)
+    assert result["total_trades"] >= 1, "trend profile buy should have opened a trade"
+
+
+def test_engine_no_switch_when_label_stays_fade():
+    """With the label held at 'down' (→ fade), the engine never switches to
+    'trend', so the trend profile's buy is never read and no trade opens."""
+    df = _flat_df(40)
+    sig_trend = pd.Series(0, index=df.index)
+    sig_trend.iloc[5] = 1
+    df["signal__trend"] = sig_trend.values
+    df["signal__fade"] = pd.Series(0, index=df.index).values
+    df["_profile_label"] = "down"  # fade regime throughout
+
+    bt = Backtester(initial_capital=1000.0, commission_pct=0.0, slippage_pct=0.0,
+                    profile_allocation=_alloc(confirm_bars=2))
+    result = bt.run(df, save=False)
+    assert result["total_trades"] == 0, "fade profile should never fire the trend buy"
+
+
+def test_engine_requires_profile_columns():
+    df = _flat_df(10)
+    df["_profile_label"] = "up"
+    bt = Backtester(initial_capital=1000.0, profile_allocation=_alloc())
+    try:
+        bt.run(df, save=False)
+        assert False, "expected ValueError for missing signal columns"
+    except ValueError as e:
+        assert "missing signal columns" in str(e)

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -368,6 +368,7 @@ type StrategyConfig struct {
 	FuturesConfig           *FuturesConfig           `json:"futures,omitempty"`
 	RegimeDirectionalPolicy *RegimeDirectionalPolicy `json:"regime_directional_policy,omitempty"` // HL perps only: regime-aware override for Direction + InvertSignal. When set, runHyperliquidCheck resolves the effective pair per-cycle from the current regime (when flat) or pos.Regime (when an open position is held — "hold until natural exit" semantics). Static Direction/InvertSignal are the base; the policy overrides per regime. Requires regime detection enabled at top-level cfg.Regime. (#779)
 	RegimeWindowDivergence  *RegimeWindowDivergence  `json:"regime_window_divergence,omitempty"`  // HL perps live only: detect divergence between two regime windows (short vs medium) and optionally override effective direction when they hard-diverge. Builds on regime_directional_policy surface (#907).
+	RegimeProfileAllocation *RegimeProfileAllocation `json:"regime_profile_allocation,omitempty"` // HL perps only: slow regime switch between two validated open_strategy param profiles. A long-window regime label (from the #879 store) selects the active profile; switching is hysteretic (confirm_bars closed bars) and flat-only. Requires regime.enabled=true. Backtester replays the switch. (#998)
 	AllowScaleIn            bool                     `json:"allow_scale_in,omitempty"`            // HL perps/manual only: opt in to scale-in / pyramiding — a same-direction signal on an open position ADDS size (blends price+size, freezes EntryATR/regime/TP geometry) instead of being skipped. Default false preserves the legacy skip-on-same-direction behavior for every strategy that does not opt in. Gated by ScaleIn caps + spacing. (#873)
 	ScaleIn                 *ScaleInConfig           `json:"scale_in,omitempty"`                  // scale-in tuning; only consulted when AllowScaleIn is true. Nil = defaults (unlimited adds/notional, no spacing, per-add size = standard open notional). (#873)
 }
@@ -1598,6 +1599,20 @@ func validateConfig(cfg *Config, skipLiveCredentialChecks bool) error {
 			}
 			if cfg.Regime != nil && cfg.Regime.Enabled && len(cfg.Regime.Windows) < 2 {
 				errs = append(errs, fmt.Sprintf("%s: regime_window_divergence requires at least two windows in regime.windows", prefix))
+			}
+		}
+
+		// regime_profile_allocation: HL perps only (live + paper). Requires
+		// regime.enabled=true — the switch reads the global regime store, which
+		// is only populated when regime detection is on. Shape validation
+		// (param_sets count, label coverage, window existence) runs in
+		// validateStrategyRegimeVocabulary (ResolveRaw). (#998)
+		if sc.RegimeProfileAllocation.IsConfigured() {
+			if sc.Platform != "hyperliquid" || sc.Type != "perps" {
+				errs = append(errs, fmt.Sprintf("%s: regime_profile_allocation is only supported for HL perps strategies (got platform=%q type=%q)", prefix, sc.Platform, sc.Type))
+			}
+			if cfg.Regime == nil || !cfg.Regime.Enabled {
+				errs = append(errs, fmt.Sprintf("%s: regime_profile_allocation requires top-level regime.enabled=true", prefix))
 			}
 		}
 

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -169,6 +169,22 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 			addChange("strategy[%s].regime_window_divergence: shape updated", sc.ID)
 			sc.RegimeWindowDivergence = ns.RegimeWindowDivergence
 		}
+		// #998: regime_profile_allocation mutation when flat. State-compat gate
+		// blocks the reshape while a position is open; reaching here flat means
+		// the next cycle resolves against the new profiles. A reshape invalidates
+		// the running switch state machine, so reset the active profile to the
+		// new initial and zero the pending counter.
+		if !sc.RegimeProfileAllocation.EqualForReload(ns.RegimeProfileAllocation) {
+			addChange("strategy[%s].regime_profile_allocation: shape updated", sc.ID)
+			sc.RegimeProfileAllocation = ns.RegimeProfileAllocation
+			if stratState := stateStrategy(state, sc.ID); stratState != nil {
+				if ns.RegimeProfileAllocation.IsConfigured() {
+					stratState.RegimeProfile = &RegimeProfileState{ActiveProfile: ns.RegimeProfileAllocation.InitialProfile}
+				} else {
+					stratState.RegimeProfile = nil
+				}
+			}
+		}
 		if !regimeWindowFieldsEqual(*sc, ns) {
 			addChange("strategy[%s].regime_*_window: gate=%q atr=%q directional=%q updated",
 				sc.ID, ns.RegimeGateWindow, ns.RegimeATRWindow, ns.RegimeDirectionalWindow)
@@ -485,6 +501,21 @@ func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error 
 					sc.ID))
 			}
 		}
+		// #998: regime_profile_allocation shape changes while a position is open
+		// would re-bind the frozen active profile (pos.OpenProfile governs the
+		// held position by design). Block the reshape; changes when flat take
+		// effect on the next cycle.
+		if sc.Type == "perps" && sc.Platform == "hyperliquid" && strategyHasOpenPositions(stateStrategy(state, sc.ID)) {
+			oldPALConfigured := sc.RegimeProfileAllocation.IsConfigured()
+			newPALConfigured := ns.RegimeProfileAllocation.IsConfigured()
+			if oldPALConfigured != newPALConfigured {
+				errs = append(errs, fmt.Sprintf("strategy[%s] regime_profile_allocation mode changed with open positions (flatten first or restart after close)",
+					sc.ID))
+			} else if oldPALConfigured && !sc.RegimeProfileAllocation.EqualForReload(ns.RegimeProfileAllocation) {
+				errs = append(errs, fmt.Sprintf("strategy[%s] regime_profile_allocation shape changed with open positions (flatten first or restart after close)",
+					sc.ID))
+			}
+		}
 		// #792: per-feature regime window selectors route live gate/ATR/policy
 		// lookups; changing them while open would rebind stamped semantics.
 		if strategyHasOpenPositions(stateStrategy(state, sc.ID)) && !regimeWindowFieldsEqual(sc, ns) {
@@ -568,6 +599,7 @@ func strategyRestartShape(sc StrategyConfig) StrategyConfig {
 	sc.AllowShorts = false           // #656: legacy field — direction change is what gates hot reload
 	sc.InvertSignal = false          // #775: hot-reloadable; state-compat blocks change while open. Needed in shape mask so the immutable-fields DeepEqual doesn't flag a pure invert_signal toggle as "restart required" (parallel to Direction above).
 	sc.RegimeDirectionalPolicy = nil // #779: hot-reloadable; state-compat blocks add/remove/reshape while open
+	sc.RegimeProfileAllocation = nil // #998: hot-reloadable when flat; state-compat blocks add/remove/reshape while open
 	sc.RegimeGateWindow = ""         // #792: hot-reloadable when flat; state-compat blocks change while open
 	sc.RegimeATRWindow = ""          // #792: hot-reloadable when flat; state-compat blocks change while open
 	sc.RegimeDirectionalWindow = ""  // #792: hot-reloadable when flat; state-compat blocks change while open

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -55,7 +55,9 @@ CREATE TABLE IF NOT EXISTS strategies (
     -- risk_pending_circuit_closes_json. Keeping the legacy name in CREATE
     -- TABLE so fresh installs land on the same rename path as post-#356
     -- DBs — one code path, no schema fork (#359).
-    risk_pending_hl_close_json TEXT NOT NULL DEFAULT ''
+    risk_pending_hl_close_json TEXT NOT NULL DEFAULT '',
+    -- #998: regime-profile allocation active profile (flat-switch persistence).
+    active_profile TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS positions (
@@ -88,6 +90,7 @@ CREATE TABLE IF NOT EXISTS positions (
     added_notional_usd REAL NOT NULL DEFAULT 0,
     risk_anchor_price REAL NOT NULL DEFAULT 0,
     scale_in_resize_pending INTEGER NOT NULL DEFAULT 0,
+    open_profile TEXT NOT NULL DEFAULT '',
     PRIMARY KEY (strategy_id, symbol)
 );
 
@@ -433,6 +436,11 @@ func (sdb *StateDB) migrateSchema() error {
 		// `backfill trade-ledger` targets modeled rows for repair.
 		"ALTER TABLE trades ADD COLUMN pnl_gross INTEGER NOT NULL DEFAULT 0",
 		"ALTER TABLE trades ADD COLUMN fee_source TEXT NOT NULL DEFAULT ''",
+		// #998: regime-profile allocation persistence. open_profile freezes the
+		// profile for the life of a position; active_profile keeps the flat
+		// switch state across restarts.
+		"ALTER TABLE positions ADD COLUMN open_profile TEXT NOT NULL DEFAULT ''",
+		"ALTER TABLE strategies ADD COLUMN active_profile TEXT NOT NULL DEFAULT ''",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -1002,15 +1010,15 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	stmtStrat, err := tx.Prepare(`INSERT OR REPLACE INTO strategies (id, type, platform, cash, initial_capital,
 		risk_peak_value, risk_max_drawdown_pct, risk_current_drawdown_pct,
 		risk_daily_pnl, risk_daily_pnl_date, risk_consecutive_losses,
-		risk_circuit_breaker, risk_circuit_breaker_until, risk_pending_circuit_closes_json)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		risk_circuit_breaker, risk_circuit_breaker_until, risk_pending_circuit_closes_json, active_profile)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare strategy insert: %w", err)
 	}
 	defer stmtStrat.Close()
 
-	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, tp1_oid, tp2_oid, tp_oids_json, tp_armed_tiers_json, stop_loss_atr_mult, tp_tiers_json, sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, regime, regime_windows_json, regime_pending_label, regime_pending_count, regime_applied_label, scale_in_count, last_add_price, added_notional_usd, risk_anchor_price, scale_in_resize_pending)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, tp1_oid, tp2_oid, tp_oids_json, tp_armed_tiers_json, stop_loss_atr_mult, tp_tiers_json, sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, regime, regime_windows_json, regime_pending_label, regime_pending_count, regime_applied_label, scale_in_count, last_add_price, added_notional_usd, risk_anchor_price, scale_in_resize_pending, open_profile)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare position insert: %w", err)
 	}
@@ -1054,6 +1062,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 			s.RiskState.DailyPnL, s.RiskState.DailyPnLDate, s.RiskState.ConsecutiveLosses,
 			cbInt, formatTime(s.RiskState.CircuitBreakerUntil),
 			s.RiskState.MarshalPendingCircuitClosesJSON(),
+			strategyActiveProfile(s),
 		); err != nil {
 			return fmt.Errorf("insert strategy %s: %w", s.ID, err)
 		}
@@ -1065,7 +1074,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 			if pos.ScaleInResizePending {
 				scaleInResizePending = 1
 			}
-			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx, tp1OID, tp2OID, marshalTPOIDsJSON(pos.TPOIDs), marshalTPArmedTiersJSON(pos.TPArmedTiers), nullableFloat64(pos.StopLossATRMult), pos.TPTiersJSON, pos.SLAdjustedTiersProcessed, nullableFloat64(pos.PostTPTrailingATRMult), pos.Regime, marshalRegimeWindowsJSON(pos.RegimeWindows), pos.RegimePendingLabel, pos.RegimePendingCount, pos.RegimeAppliedLabel, pos.ScaleInCount, pos.LastAddPrice, pos.AddedNotionalUSD, pos.RiskAnchorPrice, scaleInResizePending); err != nil {
+			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx, tp1OID, tp2OID, marshalTPOIDsJSON(pos.TPOIDs), marshalTPArmedTiersJSON(pos.TPArmedTiers), nullableFloat64(pos.StopLossATRMult), pos.TPTiersJSON, pos.SLAdjustedTiersProcessed, nullableFloat64(pos.PostTPTrailingATRMult), pos.Regime, marshalRegimeWindowsJSON(pos.RegimeWindows), pos.RegimePendingLabel, pos.RegimePendingCount, pos.RegimeAppliedLabel, pos.ScaleInCount, pos.LastAddPrice, pos.AddedNotionalUSD, pos.RiskAnchorPrice, scaleInResizePending, pos.OpenProfile); err != nil {
 				return fmt.Errorf("insert position %s/%s: %w", s.ID, pos.Symbol, err)
 			}
 		}
@@ -1446,7 +1455,8 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	rows, err := sdb.db.Query(`SELECT id, type, platform, cash, initial_capital,
 		risk_peak_value, risk_max_drawdown_pct, risk_current_drawdown_pct,
 		risk_daily_pnl, risk_daily_pnl_date, risk_consecutive_losses,
-		risk_circuit_breaker, risk_circuit_breaker_until, risk_pending_circuit_closes_json
+		risk_circuit_breaker, risk_circuit_breaker_until, risk_pending_circuit_closes_json,
+		COALESCE(active_profile, '') AS active_profile
 		FROM strategies`)
 	if err != nil {
 		return nil, fmt.Errorf("load strategies: %w", err)
@@ -1456,18 +1466,23 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	for rows.Next() {
 		var s StrategyState
 		var cbInt int
-		var cbUntilStr, pendingCircuitClosesJSON string
+		var cbUntilStr, pendingCircuitClosesJSON, activeProfile string
 		if err := rows.Scan(
 			&s.ID, &s.Type, &s.Platform, &s.Cash, &s.InitialCapital,
 			&s.RiskState.PeakValue, &s.RiskState.MaxDrawdownPct, &s.RiskState.CurrentDrawdownPct,
 			&s.RiskState.DailyPnL, &s.RiskState.DailyPnLDate, &s.RiskState.ConsecutiveLosses,
-			&cbInt, &cbUntilStr, &pendingCircuitClosesJSON,
+			&cbInt, &cbUntilStr, &pendingCircuitClosesJSON, &activeProfile,
 		); err != nil {
 			return nil, fmt.Errorf("scan strategy: %w", err)
 		}
 		s.RiskState.CircuitBreaker = cbInt != 0
 		s.RiskState.CircuitBreakerUntil = parseTime(cbUntilStr)
 		s.RiskState.UnmarshalPendingCircuitClosesJSON(pendingCircuitClosesJSON)
+		// #998: restore the flat-switch active profile; the pending counter
+		// re-arms from zero on restart (a restart can only delay a switch).
+		if activeProfile != "" {
+			s.RegimeProfile = &RegimeProfileState{ActiveProfile: activeProfile}
+		}
 		s.Positions = make(map[string]*Position)
 		s.OptionPositions = make(map[string]*OptionPosition)
 		s.TradeHistory = []Trade{}
@@ -1478,7 +1493,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	}
 
 	// 3. Load positions for each strategy.
-	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, COALESCE(tp1_oid, 0) AS tp1_oid, COALESCE(tp2_oid, 0) AS tp2_oid, COALESCE(tp_oids_json, '') AS tp_oids_json, COALESCE(tp_armed_tiers_json, '') AS tp_armed_tiers_json, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json, COALESCE(sl_adjusted_tiers_processed, 0) AS sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, COALESCE(regime, '') AS regime, COALESCE(regime_windows_json, '') AS regime_windows_json, COALESCE(regime_pending_label, '') AS regime_pending_label, COALESCE(regime_pending_count, 0) AS regime_pending_count, COALESCE(regime_applied_label, '') AS regime_applied_label, COALESCE(scale_in_count, 0) AS scale_in_count, COALESCE(last_add_price, 0) AS last_add_price, COALESCE(added_notional_usd, 0) AS added_notional_usd, COALESCE(risk_anchor_price, 0) AS risk_anchor_price, COALESCE(scale_in_resize_pending, 0) AS scale_in_resize_pending FROM positions")
+	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, COALESCE(tp1_oid, 0) AS tp1_oid, COALESCE(tp2_oid, 0) AS tp2_oid, COALESCE(tp_oids_json, '') AS tp_oids_json, COALESCE(tp_armed_tiers_json, '') AS tp_armed_tiers_json, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json, COALESCE(sl_adjusted_tiers_processed, 0) AS sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, COALESCE(regime, '') AS regime, COALESCE(regime_windows_json, '') AS regime_windows_json, COALESCE(regime_pending_label, '') AS regime_pending_label, COALESCE(regime_pending_count, 0) AS regime_pending_count, COALESCE(regime_applied_label, '') AS regime_applied_label, COALESCE(scale_in_count, 0) AS scale_in_count, COALESCE(last_add_price, 0) AS last_add_price, COALESCE(added_notional_usd, 0) AS added_notional_usd, COALESCE(risk_anchor_price, 0) AS risk_anchor_price, COALESCE(scale_in_resize_pending, 0) AS scale_in_resize_pending, COALESCE(open_profile, '') AS open_profile FROM positions")
 	if err != nil {
 		return nil, fmt.Errorf("load positions: %w", err)
 	}
@@ -1494,7 +1509,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		var slATRMult sql.NullFloat64
 		var postTPTrailingMult sql.NullFloat64
 		var scaleInResizePending int
-		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx, &tp1OID, &tp2OID, &tpOIDsJSON, &tpArmedTiersJSON, &slATRMult, &pos.TPTiersJSON, &pos.SLAdjustedTiersProcessed, &postTPTrailingMult, &pos.Regime, &regimeWindowsJSON, &pos.RegimePendingLabel, &pos.RegimePendingCount, &pos.RegimeAppliedLabel, &pos.ScaleInCount, &pos.LastAddPrice, &pos.AddedNotionalUSD, &pos.RiskAnchorPrice, &scaleInResizePending); err != nil {
+		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx, &tp1OID, &tp2OID, &tpOIDsJSON, &tpArmedTiersJSON, &slATRMult, &pos.TPTiersJSON, &pos.SLAdjustedTiersProcessed, &postTPTrailingMult, &pos.Regime, &regimeWindowsJSON, &pos.RegimePendingLabel, &pos.RegimePendingCount, &pos.RegimeAppliedLabel, &pos.ScaleInCount, &pos.LastAddPrice, &pos.AddedNotionalUSD, &pos.RiskAnchorPrice, &scaleInResizePending, &pos.OpenProfile); err != nil {
 			return nil, fmt.Errorf("scan position: %w", err)
 		}
 		pos.ScaleInResizePending = scaleInResizePending != 0

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1262,6 +1262,9 @@ func tradeAlertExtras(sc StrategyConfig, trade Trade, isClose bool) []string {
 	if trade.RegimeDivergenceNote != "" {
 		extras = append(extras, trade.RegimeDivergenceNote)
 	}
+	if trade.RegimeProfileNote != "" {
+		extras = append(extras, trade.RegimeProfileNote)
+	}
 	direction := strings.ToLower(tradeDirectionLabel(trade))
 	var tiers []hlProtectionTier
 	var tps []float64

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1420,9 +1420,16 @@ func main() {
 					var hlAddedNotionalUSD float64
 					var hlScaleInCash float64
 					var hlScaleInResizePending bool
+					var hlProfileState *RegimeProfileState
 					if sc.Type == "perps" && sc.Platform == "hyperliquid" {
 						if hlLiveStrategy {
 							hlCash = stratState.Cash
+						}
+						// #998: snapshot the regime-profile switch state under the
+						// Phase-1 RLock so the lock-free resolution reads a stable copy.
+						if stratState.RegimeProfile != nil {
+							cp := *stratState.RegimeProfile
+							hlProfileState = &cp
 						}
 						// #873: scale-in's default per-add notional uses the
 						// strategy cash like a fresh open — captured for paper too
@@ -1645,6 +1652,25 @@ func main() {
 							}
 						}
 					case "perps":
+						// #998: regime-profile allocation resolves BEFORE the check
+						// subprocess so the active profile's params shape the signal
+						// itself (the merged params ride the --strategy-refs JSON).
+						// HL perps only; the switch reads the global regime store at
+						// the configured long window and the closed-bar hysteresis
+						// counter advances only when the bundle's BarTime moves.
+						var hlProfileNext RegimeProfileState
+						var hlProfileActive string
+						hlProfileResolved := false
+						if sc.Platform == "hyperliquid" && sc.RegimeProfileAllocation.IsConfigured() {
+							palPayload := globalRegimeStore.PayloadForStrategy(sc, cfg.Regime)
+							palBarTime := globalRegimeStore.BarTimeForStrategy(sc, cfg.Regime)
+							palLabel := palPayload.Label(sc.RegimeProfileAllocation.Window, cfg.Regime)
+							hlProfileActive, hlProfileNext = resolveRegimeProfile(sc.RegimeProfileAllocation, palLabel, palBarTime, hlProfileState, hlPosQty, hlPosCtx.Profile)
+							applyRegimeProfileParams(&sc, sc.RegimeProfileAllocation, hlProfileActive)
+							hlProfileResolved = true
+							logger.Info("Regime profile: window=%s label=%s active=%q (pending=%q seen=%d)",
+								sc.RegimeProfileAllocation.Window, palLabel, hlProfileActive, hlProfileNext.PendingProfile, hlProfileNext.PendingBarsSeen)
+						}
 						if sc.Platform == "okx" {
 							if result, signalStr, price, ok := runOKXCheck(sc, prices, okxPosCtx, cfg.Regime, notifier, logger); ok {
 								prices[result.Symbol] = price
@@ -1942,6 +1968,17 @@ func main() {
 									recordPositionOpen(stratState, sc, openTrade, pos)
 									mu.Unlock()
 								}
+							}
+							// #998: stamp the active profile on a freshly opened
+							// position (freezes it for the position's life) and commit
+							// the resolved switch state. Runs whenever the check
+							// succeeded — independent of whether a trade executed — so
+							// the flat hysteresis counter advances every cycle.
+							if hlProfileResolved {
+								mu.Lock()
+								stampPositionProfileIfOpened(stratState, result.Symbol, hlProfileActive)
+								updateStrategyProfileState(stratState, hlProfileNext)
+								mu.Unlock()
 							}
 						}
 					case "futures":

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -34,6 +34,7 @@ type Position struct {
 	TPTiersJSON     string            `json:"tp_tiers_json,omitempty"`      // HL perps: JSON snapshot of [{atr_multiple,close_fraction},...] resolved at fill time; "" = strategy doesn't use tiered_tp_atr* (#669)
 	Regime          string            `json:"regime,omitempty"`             // regime label stamped at position open via stampPositionRegimeIfOpened. Drives regime-aware tier/SL multipliers for the life of the position (#733). Distinct from StrategyState.Regime which tracks the most recent classifier output.
 	RegimeWindows   map[string]string `json:"regime_windows,omitempty"`     // per-window regime labels stamped at open (#792)
+	OpenProfile     string            `json:"open_profile,omitempty"`       // regime-profile allocation: profile active when this position opened, frozen for its life (hold-on-transition). Read by resolveRegimeProfile when a position is open. (#998)
 	// #843 dynamic close: confirm-cycle state for live ATR-regime re-resolution.
 	RegimePendingLabel string `json:"regime_pending_label,omitempty"`
 	RegimePendingCount int    `json:"regime_pending_count,omitempty"`
@@ -509,6 +510,10 @@ type Trade struct {
 	// when a regime_window_divergence override was active at entry (#907). Not
 	// persisted to SQLite — set transiently when a trade is recorded.
 	RegimeDivergenceNote string `json:"-"`
+	// RegimeProfileNote carries a pre-formatted active-profile line for trade
+	// DMs when a regime_profile_allocation block is active (#998). Not persisted
+	// to SQLite — set transiently when a trade is recorded.
+	RegimeProfileNote string `json:"-"`
 
 	EntryATR          float64 `json:"entry_atr,omitempty"`
 	StopLossOID       int64   `json:"stop_loss_oid,omitempty"`
@@ -1232,6 +1237,7 @@ func executePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 		}
 		trade.Regime = s.Regime
 		trade.RegimeDivergenceNote = formatDivergenceDMLine(s.RegimeDivergence)
+		trade.RegimeProfileNote = formatProfileDMLine(s.RegimeProfile)
 		recordOpen(trade)
 		logger.Info("BUY %s: %.6f @ $%.2f (%s, notional $%.2f, fee $%.2f)", symbol, qty, execPrice, leverageLabel, notional, fee)
 		tradesExecuted++
@@ -1421,6 +1427,7 @@ func executePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 		}
 		trade.Regime = s.Regime
 		trade.RegimeDivergenceNote = formatDivergenceDMLine(s.RegimeDivergence)
+		trade.RegimeProfileNote = formatProfileDMLine(s.RegimeProfile)
 		recordOpen(trade)
 		logger.Info("SELL %s: %.6f @ $%.2f (%s, notional $%.2f, fee $%.2f) [open short]", symbol, qty, execPrice, leverageLabel, notional, fee)
 		tradesExecuted++

--- a/scheduler/regime_profile_allocation.go
+++ b/scheduler/regime_profile_allocation.go
@@ -1,0 +1,502 @@
+package main
+
+// Regime-profile allocation (#998) — slow regime switch between two validated
+// profiles of one strategy.
+//
+// Instead of shipping one compromise default, an operator runs TWO validated
+// param profiles of the same open strategy and lets a slow regime classifier
+// decide which profile is active. Reference case (#976): regime_adaptive_htf —
+// a fade-only profile wins grind/ranging windows, a breakout+drift-confirm
+// profile dominates trending years. The two regimes are disjoint, so a slow
+// switch between the profiles can beat either single default.
+//
+// Mechanism (HL perps only, live + paper):
+//   - The classifier is the global per-cycle regime store (#879) read at a slow
+//     long-window spec named by `window`. Its label is mapped through `profiles`
+//     to one of the `param_sets`.
+//   - Switching is HYSTERETIC and FLAT-ONLY: a switch commits only after the
+//     desired profile has persisted for `confirm_bars` closed bars AND the
+//     strategy is flat. While a position is open the active profile is FROZEN
+//     to the profile stamped at open (pos.OpenProfile) — hold-on-transition,
+//     same contract as regime_directional_policy / pos.Regime. The hysteresis
+//     counter keeps accruing while open, so a regime that flipped during a long
+//     hold switches on the first flat bar.
+//   - The active profile's params merge OVER the base open_strategy.params on
+//     the loop-local sc before the check subprocess runs, so the profile shapes
+//     the signal itself (not just a post-script direction gate).
+//
+// Hysteresis counts CLOSED BARS, not scheduler cycles: the counter advances
+// only when the regime bundle's BarTime moves, so live cadence matches the
+// per-bar backtester exactly (parity, not a cycle-vs-bar approximation).
+//
+// Backtest parity: the switch rule is a pure function of closed-bar OHLCV, so
+// backtest/backtester.py replays it (NOT rejected at --config load like
+// regime_window_divergence). Validation requires each profile to clear the M1
+// bar on its own regime's windows and the switched composite to beat the better
+// single profile on the full multi-window table (#998 point 4).
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+)
+
+// regimeProfileMinConfirmBars is the foot-gun floor for confirm_bars: switching
+// faster than the profiles' own signals curve-fits the regime boundary (#998 /
+// M1 step-8 warning). Below this we WARN (not reject) so research can probe it.
+const regimeProfileMinConfirmBars = 12
+
+// regimeProfileExactProfiles is the M4 definition: exactly two validated
+// profiles. param_sets with any other count is rejected at load.
+const regimeProfileExactProfiles = 2
+
+// RegimeProfileAllocation is the per-strategy config block. HL perps only.
+type RegimeProfileAllocation struct {
+	Window         string                            // long-window key in regime.windows that drives the switch
+	Profiles       map[string]string                 // regime label -> profile name (must cover the window classifier's full vocabulary)
+	ParamSets      map[string]map[string]interface{} // profile name -> open_strategy param overrides (exactly two)
+	ConfirmBars    int                               // closed bars the desired profile must persist before a flat switch commits
+	InitialProfile string                            // profile active before any switch / on cold start with no persisted active
+
+	raw map[string]interface{}
+}
+
+// RegimeProfileState is the per-strategy mutable switch state. ActiveProfile is
+// persisted (strategies.active_profile) so a flat restart keeps the last active
+// profile; the pending counter is in-memory and re-arms from zero on restart
+// (conservative — a restart can only DELAY a switch, never fast-track one).
+type RegimeProfileState struct {
+	ActiveProfile   string `json:"active_profile,omitempty"`
+	PendingProfile  string `json:"pending_profile,omitempty"`
+	PendingBarsSeen int    `json:"pending_bars_seen,omitempty"`
+	LastBarTime     string `json:"last_bar_time,omitempty"`
+}
+
+// UnmarshalJSON captures the raw shape for strategy-scoped validation in
+// LoadConfig (deferred-resolve pattern, mirrors RegimeWindowDivergence).
+func (a *RegimeProfileAllocation) UnmarshalJSON(data []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("regime_profile_allocation: %w", err)
+	}
+	a.raw = raw
+	return nil
+}
+
+// MarshalJSON renders the canonical form for hot-reload diff logging.
+func (a RegimeProfileAllocation) MarshalJSON() ([]byte, error) {
+	if a.IsZero() {
+		return json.Marshal(a.raw)
+	}
+	return json.Marshal(map[string]interface{}{
+		"window":          a.Window,
+		"profiles":        a.Profiles,
+		"param_sets":      a.ParamSets,
+		"confirm_bars":    a.ConfirmBars,
+		"initial_profile": a.InitialProfile,
+	})
+}
+
+// IsConfigured reports whether the operator supplied any value. Safe before
+// ResolveRaw (reads captured raw).
+func (a *RegimeProfileAllocation) IsConfigured() bool {
+	if a == nil {
+		return false
+	}
+	if a.Window != "" || len(a.Profiles) > 0 || len(a.ParamSets) > 0 || a.InitialProfile != "" {
+		return true
+	}
+	return len(a.raw) > 0
+}
+
+// IsZero reports whether the block is empty after resolution.
+func (a *RegimeProfileAllocation) IsZero() bool {
+	if a == nil {
+		return true
+	}
+	return a.Window == "" && len(a.Profiles) == 0 && len(a.ParamSets) == 0 &&
+		a.ConfirmBars == 0 && a.InitialProfile == ""
+}
+
+// EqualForReload reports shape equality for hot-reload state-compat checks. Any
+// difference in window, profiles, param_sets, confirm_bars, or initial_profile
+// is a reshape (blocked while open, applied when flat).
+func (a *RegimeProfileAllocation) EqualForReload(other *RegimeProfileAllocation) bool {
+	aZero := a == nil || a.IsZero()
+	bZero := other == nil || other.IsZero()
+	if aZero != bZero {
+		return false
+	}
+	if aZero {
+		return true
+	}
+	if a.Window != other.Window || a.ConfirmBars != other.ConfirmBars || a.InitialProfile != other.InitialProfile {
+		return false
+	}
+	if !stringMapEqual(a.Profiles, other.Profiles) {
+		return false
+	}
+	return paramSetsEqual(a.ParamSets, other.ParamSets)
+}
+
+func stringMapEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// paramSetsEqual compares two profile->params maps structurally via canonical
+// JSON so a numeric/string param tweak counts as a reshape.
+func paramSetsEqual(a, b map[string]map[string]interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for name, pa := range a {
+		pb, ok := b[name]
+		if !ok {
+			return false
+		}
+		ja, errA := canonicalJSON(pa)
+		jb, errB := canonicalJSON(pb)
+		if errA != nil || errB != nil || ja != jb {
+			return false
+		}
+	}
+	return true
+}
+
+func canonicalJSON(m map[string]interface{}) (string, error) {
+	blob, err := json.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+	return string(blob), nil
+}
+
+// regimeProfileAllocationWindow returns the configured switch window key from
+// the raw or resolved block (the classifier vocabulary is keyed on it, and the
+// labels are needed BEFORE ResolveRaw populates a.Window). Returns "" when
+// absent or unconfigured.
+func regimeProfileAllocationWindow(sc StrategyConfig) string {
+	a := sc.RegimeProfileAllocation
+	if a == nil {
+		return ""
+	}
+	if a.Window != "" {
+		return a.Window
+	}
+	if w, ok := a.raw["window"].(string); ok {
+		return strings.TrimSpace(w)
+	}
+	return ""
+}
+
+// ResolveRaw parses the captured raw JSON into typed fields with strategy-scoped
+// errors. `labels` is the full vocabulary of the configured window's classifier
+// — every label must map to a profile so no regime is left unhandled. Validates:
+//   - required keys: window, profiles, param_sets, confirm_bars, initial_profile
+//   - exactly two param_sets entries (the M4 two-profile definition)
+//   - every label in `labels` present in profiles; every profiles value and
+//     initial_profile names a param_sets key
+//   - confirm_bars >= 1 (WARN when < regimeProfileMinConfirmBars)
+//   - no unknown keys
+//
+// Pass labels=nil to skip the label-coverage check (used when the classifier
+// vocabulary isn't resolvable yet — window-existence validation handles that).
+func (a *RegimeProfileAllocation) ResolveRaw(label string, labels []string) []string {
+	var errs []string
+	if a == nil || len(a.raw) == 0 {
+		return errs
+	}
+
+	knownKeys := map[string]bool{
+		"window":          true,
+		"profiles":        true,
+		"param_sets":      true,
+		"confirm_bars":    true,
+		"initial_profile": true,
+	}
+	for k := range a.raw {
+		if !knownKeys[k] {
+			errs = append(errs, fmt.Sprintf("%s: unknown key %q (valid: window, profiles, param_sets, confirm_bars, initial_profile)", label, k))
+		}
+	}
+
+	window, werrs := rawString(a.raw, "window", label)
+	errs = append(errs, werrs...)
+	initialProfile, ierrs := rawString(a.raw, "initial_profile", label)
+	errs = append(errs, ierrs...)
+
+	profiles, perrs := rawStringMap(a.raw, "profiles", label)
+	errs = append(errs, perrs...)
+	paramSets, pserrs := rawParamSets(a.raw, "param_sets", label)
+	errs = append(errs, pserrs...)
+
+	confirmBars, cerrs := rawInt(a.raw, "confirm_bars", label)
+	errs = append(errs, cerrs...)
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	if confirmBars < 1 {
+		errs = append(errs, fmt.Sprintf("%s.confirm_bars: must be >= 1, got %d", label, confirmBars))
+	}
+	if len(paramSets) != regimeProfileExactProfiles {
+		errs = append(errs, fmt.Sprintf("%s.param_sets: must define exactly %d profiles (the M4 two-profile model), got %d", label, regimeProfileExactProfiles, len(paramSets)))
+	}
+	// Every profiles value must name a param_sets key.
+	for lbl, prof := range profiles {
+		if _, ok := paramSets[prof]; !ok {
+			errs = append(errs, fmt.Sprintf("%s.profiles[%q]=%q is not a param_sets profile (valid: %s)", label, lbl, prof, strings.Join(sortedKeys(paramSets), ", ")))
+		}
+	}
+	if _, ok := paramSets[initialProfile]; !ok {
+		errs = append(errs, fmt.Sprintf("%s.initial_profile=%q is not a param_sets profile (valid: %s)", label, initialProfile, strings.Join(sortedKeys(paramSets), ", ")))
+	}
+	// Every classifier label must be covered by profiles.
+	for _, l := range labels {
+		if _, ok := profiles[l]; !ok {
+			errs = append(errs, fmt.Sprintf("%s.profiles: missing mapping for regime label %q (every label of the window classifier must map to a profile)", label, l))
+		}
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	a.Window = window
+	a.Profiles = profiles
+	a.ParamSets = paramSets
+	a.ConfirmBars = confirmBars
+	a.InitialProfile = initialProfile
+
+	if confirmBars < regimeProfileMinConfirmBars {
+		fmt.Printf("[WARN] %s.confirm_bars=%d is below %d — switching faster than the profiles' own signals curve-fits the regime boundary (#998). Prefer a slow long-window switch.\n",
+			label, confirmBars, regimeProfileMinConfirmBars)
+	}
+	return errs
+}
+
+func rawString(raw map[string]interface{}, key, label string) (string, []string) {
+	v, ok := raw[key]
+	if !ok {
+		return "", []string{fmt.Sprintf("%s: missing required key %q", label, key)}
+	}
+	s, ok := v.(string)
+	if !ok || strings.TrimSpace(s) == "" {
+		return "", []string{fmt.Sprintf("%s.%s: must be a non-empty string", label, key)}
+	}
+	return strings.TrimSpace(s), nil
+}
+
+func rawInt(raw map[string]interface{}, key, label string) (int, []string) {
+	v, ok := raw[key]
+	if !ok {
+		return 0, []string{fmt.Sprintf("%s: missing required key %q", label, key)}
+	}
+	f, ok := v.(float64) // encoding/json decodes numbers as float64
+	if !ok || f != math.Trunc(f) {
+		return 0, []string{fmt.Sprintf("%s.%s: must be an integer", label, key)}
+	}
+	return int(f), nil
+}
+
+func rawStringMap(raw map[string]interface{}, key, label string) (map[string]string, []string) {
+	v, ok := raw[key]
+	if !ok {
+		return nil, []string{fmt.Sprintf("%s: missing required key %q", label, key)}
+	}
+	m, ok := v.(map[string]interface{})
+	if !ok || len(m) == 0 {
+		return nil, []string{fmt.Sprintf("%s.%s: must be a non-empty object", label, key)}
+	}
+	out := make(map[string]string, len(m))
+	var errs []string
+	for k, val := range m {
+		s, ok := val.(string)
+		if !ok || strings.TrimSpace(s) == "" {
+			errs = append(errs, fmt.Sprintf("%s.%s[%q]: must be a non-empty string", label, key, k))
+			continue
+		}
+		out[strings.TrimSpace(k)] = strings.TrimSpace(s)
+	}
+	return out, errs
+}
+
+func rawParamSets(raw map[string]interface{}, key, label string) (map[string]map[string]interface{}, []string) {
+	v, ok := raw[key]
+	if !ok {
+		return nil, []string{fmt.Sprintf("%s: missing required key %q", label, key)}
+	}
+	m, ok := v.(map[string]interface{})
+	if !ok || len(m) == 0 {
+		return nil, []string{fmt.Sprintf("%s.%s: must be a non-empty object", label, key)}
+	}
+	out := make(map[string]map[string]interface{}, len(m))
+	var errs []string
+	for k, val := range m {
+		params, ok := val.(map[string]interface{})
+		if !ok {
+			errs = append(errs, fmt.Sprintf("%s.%s[%q]: must be a params object", label, key, k))
+			continue
+		}
+		out[strings.TrimSpace(k)] = params
+	}
+	return out, errs
+}
+
+func sortedKeys(m map[string]map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// resolveRegimeProfile is the PURE switch state machine (unit-testable without
+// Python). It returns the profile that governs THIS cycle's params plus the
+// next persisted state.
+//
+//   - label:      the current long-window regime label (empty = bundle failure
+//     / fail-open → freeze the counter, keep ActiveProfile).
+//   - barTime:    the regime bundle's closed-bar timestamp; the hysteresis
+//     counter advances only when this moves (closed-bar cadence).
+//   - prev:       prior persisted+in-memory state (nil = cold start).
+//   - posQty:     open position size; >0 freezes the active profile to posProfile
+//     (hold-on-transition) and BLOCKS a switch commit, but the
+//     counter still accrues so a flat bar commits immediately.
+//   - posProfile: the profile stamped on the open position (pos.OpenProfile);
+//     "" for legacy positions → fall back to ActiveProfile.
+func resolveRegimeProfile(alloc *RegimeProfileAllocation, label, barTime string, prev *RegimeProfileState, posQty float64, posProfile string) (string, RegimeProfileState) {
+	next := RegimeProfileState{}
+	if prev != nil {
+		next = *prev
+	}
+	if next.ActiveProfile == "" {
+		next.ActiveProfile = alloc.InitialProfile
+	}
+
+	label = strings.TrimSpace(label)
+	desired := ""
+	if label != "" {
+		desired = alloc.Profiles[label]
+	}
+
+	barAdvanced := barTime != "" && barTime != next.LastBarTime
+	if barAdvanced {
+		next.LastBarTime = barTime
+		switch {
+		case desired == "":
+			// Fail-open / unknown label: freeze the counter, hold ActiveProfile.
+		case desired == next.ActiveProfile:
+			// Regime agrees with the active profile: clear any pending switch.
+			next.PendingProfile = ""
+			next.PendingBarsSeen = 0
+		default:
+			// Desired differs from active: accrue hysteresis.
+			if next.PendingProfile == desired {
+				next.PendingBarsSeen++
+			} else {
+				next.PendingProfile = desired
+				next.PendingBarsSeen = 1
+			}
+			// Commit only when flat AND the desired profile has persisted for
+			// confirm_bars. While a position is open the counter keeps growing
+			// but the switch is deferred to the first flat bar.
+			if posQty <= 0 && next.PendingBarsSeen >= alloc.ConfirmBars {
+				next.ActiveProfile = desired
+				next.PendingProfile = ""
+				next.PendingBarsSeen = 0
+			}
+		}
+	}
+
+	active := next.ActiveProfile
+	if posQty > 0 {
+		// Position open: the profile is frozen to whatever opened it.
+		if p := strings.TrimSpace(posProfile); p != "" {
+			active = p
+		}
+	}
+	return active, next
+}
+
+// applyRegimeProfileParams merges the active profile's param overrides OVER a
+// COPY of the loop-local sc.OpenStrategy.Params. It allocates a fresh map so the
+// shared cfg.Strategies params map is never mutated (the loop-local sc is a
+// value copy, but its Params map field still aliases cfg). No-op when the
+// profile has no param_sets entry.
+func applyRegimeProfileParams(sc *StrategyConfig, alloc *RegimeProfileAllocation, profile string) {
+	if sc == nil || alloc == nil {
+		return
+	}
+	overrides, ok := alloc.ParamSets[profile]
+	if !ok {
+		return
+	}
+	merged := make(map[string]interface{}, len(sc.OpenStrategy.Params)+len(overrides))
+	for k, v := range sc.OpenStrategy.Params {
+		merged[k] = v
+	}
+	for k, v := range overrides {
+		merged[k] = v
+	}
+	sc.OpenStrategy.Params = merged
+}
+
+// updateStrategyProfileState commits the resolved next state onto the strategy
+// state after a cycle. Clears the state when the strategy has no allocation
+// block configured (mirrors updateStrategyDivergenceState's unconfigured guard).
+func updateStrategyProfileState(s *StrategyState, next RegimeProfileState) {
+	if s == nil {
+		return
+	}
+	cp := next
+	s.RegimeProfile = &cp
+}
+
+// stampPositionProfileIfOpened stamps the active profile on the position the
+// first time we observe one without a stamp, freezing the profile for the life
+// of the position (hold-on-transition). No-op when the position is absent,
+// already stamped, or the profile is empty.
+func stampPositionProfileIfOpened(s *StrategyState, symbol, profile string) {
+	if s == nil || strings.TrimSpace(profile) == "" {
+		return
+	}
+	pos, ok := s.Positions[symbol]
+	if !ok || pos == nil || strings.TrimSpace(pos.OpenProfile) != "" {
+		return
+	}
+	pos.OpenProfile = profile
+}
+
+// strategyActiveProfile returns the persisted active-profile name for the
+// strategies table, or "" when no allocation state exists.
+func strategyActiveProfile(s *StrategyState) string {
+	if s == nil || s.RegimeProfile == nil {
+		return ""
+	}
+	return s.RegimeProfile.ActiveProfile
+}
+
+// formatProfileDMLine formats the trade DM line for the active profile. Returns
+// "" when no allocation state is present.
+func formatProfileDMLine(ps *RegimeProfileState) string {
+	if ps == nil || strings.TrimSpace(ps.ActiveProfile) == "" {
+		return ""
+	}
+	if ps.PendingProfile != "" && ps.PendingProfile != ps.ActiveProfile {
+		return fmt.Sprintf("◆ regime profile: active=%s (pending %s: %d bars)", ps.ActiveProfile, ps.PendingProfile, ps.PendingBarsSeen)
+	}
+	return fmt.Sprintf("◆ regime profile: active=%s", ps.ActiveProfile)
+}

--- a/scheduler/regime_profile_allocation_test.go
+++ b/scheduler/regime_profile_allocation_test.go
@@ -1,0 +1,506 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// twoProfileAlloc builds a resolved allocation with two profiles for the
+// composite vocabulary used by most tests.
+func twoProfileAlloc(confirm int) *RegimeProfileAllocation {
+	return &RegimeProfileAllocation{
+		Window: "profile_long",
+		Profiles: map[string]string{
+			"trending_up_clean":    "trend",
+			"trending_up_choppy":   "trend",
+			"trending_down_clean":  "trend",
+			"trending_down_choppy": "trend",
+			"ranging_quiet":        "fade",
+			"ranging_volatile":     "fade",
+			"ranging_directional":  "fade",
+		},
+		ParamSets: map[string]map[string]interface{}{
+			"fade":  {"trend_entry": "off"},
+			"trend": {"trend_entry": "breakout", "trend_drift_confirm": 0.1},
+		},
+		ConfirmBars:    3,
+		InitialProfile: "fade",
+	}
+}
+
+func TestResolveRegimeProfile_ColdStartNoInstantSwitch(t *testing.T) {
+	alloc := twoProfileAlloc(3)
+	// Cold start (prev=nil), flat, regime says "trend" — must NOT switch this
+	// bar; active stays at initial fade and the counter starts at 1.
+	active, next := resolveRegimeProfile(alloc, "trending_up_clean", "t0", nil, 0, "")
+	if active != "fade" {
+		t.Fatalf("cold start active=%q, want fade", active)
+	}
+	if next.ActiveProfile != "fade" || next.PendingProfile != "trend" || next.PendingBarsSeen != 1 {
+		t.Fatalf("cold start next=%+v, want active=fade pending=trend seen=1", next)
+	}
+}
+
+func TestResolveRegimeProfile_FlatSwitchAfterConfirmBars(t *testing.T) {
+	alloc := twoProfileAlloc(3)
+	state := &RegimeProfileState{ActiveProfile: "fade"}
+	bars := []string{"t1", "t2", "t3"}
+	var active string
+	for i, bt := range bars {
+		active, *state = resolveRegimeProfile(alloc, "trending_up_clean", bt, state, 0, "")
+		if i < 2 && active != "fade" {
+			t.Fatalf("bar %d active=%q, want fade (not yet confirmed)", i, active)
+		}
+	}
+	// Third confirming bar commits the switch.
+	if active != "trend" {
+		t.Fatalf("after 3 confirm bars active=%q, want trend", active)
+	}
+	if state.ActiveProfile != "trend" || state.PendingProfile != "" || state.PendingBarsSeen != 0 {
+		t.Fatalf("post-switch state=%+v, want active=trend pending='' seen=0", *state)
+	}
+}
+
+func TestResolveRegimeProfile_BarNotAdvancedDoesNotCount(t *testing.T) {
+	alloc := twoProfileAlloc(3)
+	state := &RegimeProfileState{ActiveProfile: "fade"}
+	// Same barTime across three scheduler cycles: counter must not advance.
+	for i := 0; i < 3; i++ {
+		_, *state = resolveRegimeProfile(alloc, "trending_up_clean", "t1", state, 0, "")
+	}
+	if state.PendingBarsSeen != 1 {
+		t.Fatalf("within-bar cycles advanced counter to %d, want 1", state.PendingBarsSeen)
+	}
+}
+
+func TestResolveRegimeProfile_OpenPositionFreezesAndDefers(t *testing.T) {
+	alloc := twoProfileAlloc(3)
+	state := &RegimeProfileState{ActiveProfile: "fade"}
+	// Position open the whole time; regime is trend for many bars. The active
+	// profile must stay frozen to the position's open profile (fade), but the
+	// counter accrues so the first flat bar commits immediately.
+	for i, bt := range []string{"t1", "t2", "t3", "t4"} {
+		active, ns := resolveRegimeProfile(alloc, "trending_up_clean", bt, state, 1, "fade")
+		*state = ns
+		if active != "fade" {
+			t.Fatalf("bar %d open active=%q, want frozen fade", i, active)
+		}
+		if state.ActiveProfile != "fade" {
+			t.Fatalf("bar %d committed a switch while open: %+v", i, *state)
+		}
+	}
+	if state.PendingBarsSeen < 3 {
+		t.Fatalf("counter did not accrue while open: seen=%d", state.PendingBarsSeen)
+	}
+	// Now flat on the next bar: switch commits immediately.
+	active, ns := resolveRegimeProfile(alloc, "trending_up_clean", "t5", state, 0, "")
+	*state = ns
+	if active != "trend" || state.ActiveProfile != "trend" {
+		t.Fatalf("first flat bar did not commit: active=%q state=%+v", active, *state)
+	}
+}
+
+func TestResolveRegimeProfile_EmptyLabelFreezes(t *testing.T) {
+	alloc := twoProfileAlloc(3)
+	state := &RegimeProfileState{ActiveProfile: "fade", PendingProfile: "trend", PendingBarsSeen: 2}
+	// Bundle failure → empty label → freeze; counter and active unchanged.
+	active, next := resolveRegimeProfile(alloc, "", "t9", state, 0, "")
+	if active != "fade" {
+		t.Fatalf("empty-label active=%q, want fade", active)
+	}
+	if next.PendingBarsSeen != 2 || next.PendingProfile != "trend" {
+		t.Fatalf("empty label disturbed counter: %+v", next)
+	}
+}
+
+func TestResolveRegimeProfile_DesiredEqualsActiveResetsPending(t *testing.T) {
+	alloc := twoProfileAlloc(3)
+	state := &RegimeProfileState{ActiveProfile: "fade", PendingProfile: "trend", PendingBarsSeen: 2}
+	// Regime flips back to the active profile's regime → clear pending switch.
+	_, next := resolveRegimeProfile(alloc, "ranging_quiet", "t2", state, 0, "")
+	if next.PendingProfile != "" || next.PendingBarsSeen != 0 {
+		t.Fatalf("desired==active did not reset pending: %+v", next)
+	}
+}
+
+func TestApplyRegimeProfileParams_MergesAndDoesNotMutateBase(t *testing.T) {
+	alloc := twoProfileAlloc(3)
+	base := map[string]interface{}{"trend_entry": "default_value", "shared": 1}
+	sc := StrategyConfig{OpenStrategy: StrategyRef{Name: "regime_adaptive_htf", Params: base}}
+	applyRegimeProfileParams(&sc, alloc, "trend")
+	if got := sc.OpenStrategy.Params["trend_entry"]; got != "breakout" {
+		t.Fatalf("override not applied: trend_entry=%v", got)
+	}
+	if got := sc.OpenStrategy.Params["shared"]; got != 1 {
+		t.Fatalf("base param lost: shared=%v", got)
+	}
+	// The shared base map must be untouched (loop-local sc aliases cfg's map).
+	if base["trend_entry"] != "default_value" {
+		t.Fatalf("base map mutated: trend_entry=%v", base["trend_entry"])
+	}
+}
+
+func TestApplyRegimeProfileParams_MissingProfileNoOp(t *testing.T) {
+	alloc := twoProfileAlloc(3)
+	base := map[string]interface{}{"x": 1}
+	sc := StrategyConfig{OpenStrategy: StrategyRef{Params: base}}
+	applyRegimeProfileParams(&sc, alloc, "nonexistent")
+	if len(sc.OpenStrategy.Params) != 1 || sc.OpenStrategy.Params["x"] != 1 {
+		t.Fatalf("missing-profile apply changed params: %+v", sc.OpenStrategy.Params)
+	}
+}
+
+// resolveRawFromJSON unmarshals a regime_profile_allocation block and resolves
+// it against the given classifier labels, returning the errors.
+func resolveRawFromJSON(t *testing.T, raw string, labels []string) (*RegimeProfileAllocation, []string) {
+	t.Helper()
+	var a RegimeProfileAllocation
+	if err := json.Unmarshal([]byte(raw), &a); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return &a, a.ResolveRaw("strategy[x].regime_profile_allocation", labels)
+}
+
+var compositeLabels = []string{
+	"trending_up_clean", "trending_up_choppy", "trending_down_clean",
+	"trending_down_choppy", "ranging_quiet", "ranging_volatile", "ranging_directional",
+}
+
+func TestResolveRaw_Valid(t *testing.T) {
+	raw := `{
+		"window": "profile_long",
+		"profiles": {
+			"trending_up_clean": "trend", "trending_up_choppy": "trend",
+			"trending_down_clean": "trend", "trending_down_choppy": "trend",
+			"ranging_quiet": "fade", "ranging_volatile": "fade", "ranging_directional": "fade"
+		},
+		"param_sets": {"fade": {"trend_entry": "off"}, "trend": {"trend_entry": "breakout"}},
+		"confirm_bars": 24,
+		"initial_profile": "fade"
+	}`
+	a, errs := resolveRawFromJSON(t, raw, compositeLabels)
+	if len(errs) != 0 {
+		t.Fatalf("valid block rejected: %v", errs)
+	}
+	if a.Window != "profile_long" || a.ConfirmBars != 24 || a.InitialProfile != "fade" {
+		t.Fatalf("resolved fields wrong: %+v", a)
+	}
+}
+
+func TestResolveRaw_WrongParamSetCount(t *testing.T) {
+	raw := `{
+		"window": "w", "confirm_bars": 24, "initial_profile": "a",
+		"profiles": {"trending_up_clean":"a","trending_up_choppy":"a","trending_down_clean":"a","trending_down_choppy":"a","ranging_quiet":"a","ranging_volatile":"a","ranging_directional":"a"},
+		"param_sets": {"a": {}, "b": {}, "c": {}}
+	}`
+	_, errs := resolveRawFromJSON(t, raw, compositeLabels)
+	if !containsSubstr(errs, "exactly 2 profiles") {
+		t.Fatalf("expected param_sets count error, got %v", errs)
+	}
+}
+
+func TestResolveRaw_MissingLabelCoverage(t *testing.T) {
+	raw := `{
+		"window": "w", "confirm_bars": 24, "initial_profile": "fade",
+		"profiles": {"trending_up_clean":"trend","ranging_quiet":"fade"},
+		"param_sets": {"fade": {}, "trend": {}}
+	}`
+	_, errs := resolveRawFromJSON(t, raw, compositeLabels)
+	if !containsSubstr(errs, "missing mapping for regime label") {
+		t.Fatalf("expected label-coverage error, got %v", errs)
+	}
+}
+
+func TestResolveRaw_BadInitialProfile(t *testing.T) {
+	raw := `{
+		"window": "w", "confirm_bars": 24, "initial_profile": "ghost",
+		"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade"},
+		"param_sets": {"fade": {}, "trend": {}}
+	}`
+	_, errs := resolveRawFromJSON(t, raw, compositeLabels)
+	if !containsSubstr(errs, "initial_profile") {
+		t.Fatalf("expected initial_profile error, got %v", errs)
+	}
+}
+
+func TestResolveRaw_UnknownKeyAndMissingRequired(t *testing.T) {
+	raw := `{"window": "w", "bogus": 1}`
+	_, errs := resolveRawFromJSON(t, raw, nil)
+	if !containsSubstr(errs, "unknown key") {
+		t.Fatalf("expected unknown-key error, got %v", errs)
+	}
+	if !containsSubstr(errs, "missing required key") {
+		t.Fatalf("expected missing-required error, got %v", errs)
+	}
+}
+
+func TestResolveRaw_ProfileValueNotInParamSets(t *testing.T) {
+	raw := `{
+		"window": "w", "confirm_bars": 24, "initial_profile": "fade",
+		"profiles": {"trending_up_clean":"ghost","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade"},
+		"param_sets": {"fade": {}, "trend": {}}
+	}`
+	_, errs := resolveRawFromJSON(t, raw, compositeLabels)
+	if !containsSubstr(errs, "is not a param_sets profile") {
+		t.Fatalf("expected profile-reference error, got %v", errs)
+	}
+}
+
+func TestRegimeProfileAllocation_EqualForReload(t *testing.T) {
+	a := twoProfileAlloc(3)
+	b := twoProfileAlloc(3)
+	if !a.EqualForReload(b) {
+		t.Fatal("identical allocations should be equal")
+	}
+	b.ConfirmBars = 5
+	if a.EqualForReload(b) {
+		t.Fatal("confirm_bars change should differ")
+	}
+	c := twoProfileAlloc(3)
+	c.ParamSets["trend"]["trend_drift_confirm"] = 0.2
+	if a.EqualForReload(c) {
+		t.Fatal("param tweak should differ")
+	}
+	var nilA *RegimeProfileAllocation
+	var nilB *RegimeProfileAllocation
+	if !nilA.EqualForReload(nilB) {
+		t.Fatal("nil==nil should be equal")
+	}
+	if nilA.EqualForReload(a) {
+		t.Fatal("nil vs configured should differ")
+	}
+}
+
+func TestValidateStrategyRegimeVocabulary_RejectsBadProfileWindow(t *testing.T) {
+	var a RegimeProfileAllocation
+	if err := json.Unmarshal([]byte(`{
+		"window": "does_not_exist",
+		"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade"},
+		"param_sets": {"fade": {"trend_entry":"off"}, "trend": {"trend_entry":"breakout"}},
+		"confirm_bars": 24,
+		"initial_profile": "fade"
+	}`), &a); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	cfg := &Config{
+		Regime: &RegimeConfig{Enabled: true, Windows: RegimeWindowsMap{
+			"profile_long":     {Classifier: regimeClassifierComposite, Period: 200},
+			"composite_medium": {Classifier: regimeClassifierComposite, Period: 50},
+		}},
+		Strategies: []StrategyConfig{{ID: "hl-test", RegimeProfileAllocation: &a}},
+	}
+	errs := validateStrategyRegimeVocabulary(cfg)
+	if !containsSubstr(errs, "not found in regime.windows") {
+		t.Fatalf("expected window-not-found error, got %v", errs)
+	}
+}
+
+func TestValidateStrategyRegimeVocabulary_AcceptsGoodProfileAllocation(t *testing.T) {
+	var a RegimeProfileAllocation
+	if err := json.Unmarshal([]byte(`{
+		"window": "profile_long",
+		"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade"},
+		"param_sets": {"fade": {"trend_entry":"off"}, "trend": {"trend_entry":"breakout"}},
+		"confirm_bars": 24,
+		"initial_profile": "fade"
+	}`), &a); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	cfg := &Config{
+		Regime: &RegimeConfig{Enabled: true, Windows: RegimeWindowsMap{
+			"profile_long":     {Classifier: regimeClassifierComposite, Period: 200},
+			"composite_medium": {Classifier: regimeClassifierComposite, Period: 50},
+		}},
+		Strategies: []StrategyConfig{{ID: "hl-test", RegimeProfileAllocation: &a}},
+	}
+	for _, e := range validateStrategyRegimeVocabulary(cfg) {
+		if indexOf(e, "regime_profile_allocation") >= 0 {
+			t.Errorf("unexpected profile-allocation validation error: %s", e)
+		}
+	}
+}
+
+// DB round-trip: open_profile on a position and active_profile on a strategy
+// survive a save+load cycle.
+func TestProfileAllocation_DBRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	sdb, err := OpenStateDB(dir + "/state.db")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer sdb.Close()
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-x": {
+			ID: "hl-x", Type: "perps", Platform: "hyperliquid", Cash: 1000,
+			RegimeProfile: &RegimeProfileState{ActiveProfile: "trend", PendingProfile: "fade", PendingBarsSeen: 2},
+			Positions: map[string]*Position{
+				"BTC": {Symbol: "BTC", Quantity: 1, AvgCost: 50000, Side: "long", OpenProfile: "trend"},
+			},
+			OptionPositions: map[string]*OptionPosition{},
+		},
+	}}
+	if err := sdb.SaveState(state); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded, err := sdb.LoadState()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	s := loaded.Strategies["hl-x"]
+	if s == nil || s.RegimeProfile == nil || s.RegimeProfile.ActiveProfile != "trend" {
+		t.Fatalf("active_profile not restored: %+v", s)
+	}
+	// The pending counter is intentionally NOT persisted (re-arms on restart).
+	if s.RegimeProfile.PendingBarsSeen != 0 {
+		t.Fatalf("pending counter should not persist, got %d", s.RegimeProfile.PendingBarsSeen)
+	}
+	if pos := s.Positions["BTC"]; pos == nil || pos.OpenProfile != "trend" {
+		t.Fatalf("open_profile not restored: %+v", pos)
+	}
+}
+
+// fullProfileAllocConfig builds a complete HL-perps + regime config with a
+// valid regime_profile_allocation for ValidateConfig integration tests.
+func fullProfileAllocConfig(t *testing.T, palJSON string) Config {
+	t.Helper()
+	var a RegimeProfileAllocation
+	if err := json.Unmarshal([]byte(palJSON), &a); err != nil {
+		t.Fatalf("unmarshal pal: %v", err)
+	}
+	return Config{
+		Strategies: []StrategyConfig{{
+			ID:                      "hl-test-btc",
+			Type:                    "perps",
+			Platform:                "hyperliquid",
+			Script:                  "shared_scripts/check_hyperliquid.py",
+			Args:                    []string{"regime_adaptive_htf", "BTC", "1h", "--mode=paper"},
+			Capital:                 1000,
+			Leverage:                5,
+			MaxDrawdownPct:          60,
+			Direction:               "long",
+			OpenStrategy:            StrategyRef{Name: "regime_adaptive_htf"},
+			RegimeProfileAllocation: &a,
+		}},
+		Regime: &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20, Windows: RegimeWindowsMap{
+			"profile_long":     {Classifier: regimeClassifierComposite, Period: 200},
+			"composite_medium": {Classifier: regimeClassifierComposite, Period: 50},
+		}},
+		PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+	}
+}
+
+const validPALJSON = `{
+	"window": "profile_long",
+	"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade"},
+	"param_sets": {"fade": {"trend_entry":"off"}, "trend": {"trend_entry":"breakout"}},
+	"confirm_bars": 24,
+	"initial_profile": "fade"
+}`
+
+func TestValidateConfig_ProfileAllocation_Valid(t *testing.T) {
+	cfg := fullProfileAllocConfig(t, validPALJSON)
+	if err := ValidateConfig(&cfg); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidateConfig_ProfileAllocation_RejectsRegimeDisabled(t *testing.T) {
+	cfg := fullProfileAllocConfig(t, validPALJSON)
+	cfg.Regime.Enabled = false
+	err := ValidateConfig(&cfg)
+	if err == nil || !indexOfErr(err, "regime_profile_allocation requires top-level regime.enabled=true") {
+		t.Fatalf("expected regime-enabled error, got: %v", err)
+	}
+}
+
+func TestValidateConfig_ProfileAllocation_RejectsNonHL(t *testing.T) {
+	cfg := fullProfileAllocConfig(t, validPALJSON)
+	cfg.Strategies[0].Platform = "okx"
+	cfg.Strategies[0].Args = []string{"regime_adaptive_htf", "BTC-USDT-SWAP", "1h"}
+	cfg.Strategies[0].Script = "shared_scripts/check_okx.py"
+	err := ValidateConfig(&cfg)
+	if err == nil || !indexOfErr(err, "regime_profile_allocation is only supported for HL perps") {
+		t.Fatalf("expected HL-perps-only error, got: %v", err)
+	}
+}
+
+func TestValidateConfig_ProfileAllocation_RejectsThreeProfiles(t *testing.T) {
+	cfg := fullProfileAllocConfig(t, `{
+		"window": "profile_long",
+		"profiles": {"trending_up_clean":"a","trending_up_choppy":"a","trending_down_clean":"a","trending_down_choppy":"a","ranging_quiet":"b","ranging_volatile":"b","ranging_directional":"c"},
+		"param_sets": {"a": {}, "b": {}, "c": {}},
+		"confirm_bars": 24,
+		"initial_profile": "a"
+	}`)
+	err := ValidateConfig(&cfg)
+	if err == nil || !indexOfErr(err, "exactly 2 profiles") {
+		t.Fatalf("expected param_sets count error, got: %v", err)
+	}
+}
+
+func indexOfErr(err error, sub string) bool {
+	return err != nil && indexOf(err.Error(), sub) >= 0
+}
+
+// TestLoadConfig_ProfileAllocation_FromFile exercises the full JSON path:
+// UnmarshalJSON capture, the StrategyConfig unknown-key guard, and validation.
+func TestLoadConfig_ProfileAllocation_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `{
+		"config_version": 15,
+		"regime": {"enabled": true, "windows": {
+			"profile_long": {"classifier": "composite", "period": 200},
+			"composite_medium": {"classifier": "composite", "period": 50}
+		}},
+		"portfolio_risk": {"max_drawdown_pct": 25, "warn_threshold_pct": 80},
+		"strategies": [{
+			"id": "hl-radhtf-btc",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["regime_adaptive_htf", "BTC", "1h", "--mode=paper"],
+			"open_strategy": {"name": "regime_adaptive_htf"},
+			"capital": 1000,
+			"leverage": 5,
+			"max_drawdown_pct": 60,
+			"direction": "long",
+			"regime_profile_allocation": {
+				"window": "profile_long",
+				"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade"},
+				"param_sets": {"fade": {"trend_entry":"off"}, "trend": {"trend_entry":"breakout","trend_drift_confirm":0.1}},
+				"confirm_bars": 24,
+				"initial_profile": "fade"
+			}
+		}]
+	}`
+	path := writeTestConfig(t, dir, cfg)
+	loaded, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig rejected a valid regime_profile_allocation: %v", err)
+	}
+	sc := loaded.Strategies[0]
+	if !sc.RegimeProfileAllocation.IsConfigured() {
+		t.Fatal("regime_profile_allocation not parsed onto the strategy")
+	}
+	if sc.RegimeProfileAllocation.ConfirmBars != 24 || sc.RegimeProfileAllocation.InitialProfile != "fade" {
+		t.Fatalf("resolved fields wrong: %+v", sc.RegimeProfileAllocation)
+	}
+}
+
+func containsSubstr(errs []string, sub string) bool {
+	for _, e := range errs {
+		if len(sub) > 0 && indexOf(e, sub) >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/scheduler/regime_store.go
+++ b/scheduler/regime_store.go
@@ -560,6 +560,22 @@ func (s *RegimeStore) PayloadForStrategy(sc StrategyConfig, rc *RegimeConfig) Re
 	return b.Payload
 }
 
+// BarTimeForStrategy returns the closed-bar timestamp of sc's regime bundle
+// this cycle, or "" when sc has no signature or the bundle is missing/failed.
+// Used by regime_profile_allocation to advance the closed-bar hysteresis counter
+// only when the bar moves (#998).
+func (s *RegimeStore) BarTimeForStrategy(sc StrategyConfig, rc *RegimeConfig) string {
+	req, ok := strategyRegimeBundleRequest(sc, rc)
+	if !ok {
+		return ""
+	}
+	b, found := s.get(req.Key)
+	if !found || b == nil {
+		return ""
+	}
+	return b.BarTime
+}
+
 // InjectionJSONForStrategy returns (raw payload JSON, true) when sc's check
 // script should receive --regime-payload-json this cycle. The flag is passed
 // whenever sc HAS a signature — with an EMPTY value after a bundle failure,

--- a/scheduler/regime_window_spec.go
+++ b/scheduler/regime_window_spec.go
@@ -346,6 +346,32 @@ func validateStrategyRegimeVocabulary(cfg *Config) []string {
 				}
 			}
 		}
+		// #998: regime_profile_allocation shape validation (param_sets count,
+		// label coverage, profile references) AND window existence. Check window
+		// existence FIRST: a typo'd window otherwise resolves to the ADX-default
+		// classifier and surfaces a confusing label-coverage error instead of the
+		// real "window not found" cause. When the window is bad we still run
+		// ResolveRaw with nil labels so param_sets/initial_profile shape errors
+		// are not masked.
+		if sc.RegimeProfileAllocation.IsConfigured() {
+			windowRaw := regimeProfileAllocationWindow(sc)
+			windowKey := normalizeRegimeWindowKey(windowRaw)
+			windowOK := true
+			if rc != nil && rc.Enabled && windowKey != "" && windowKey != regimeWindowDefaultKey {
+				if !regimeMultiWindowEnabled(rc) {
+					errs = append(errs, fmt.Sprintf("%s: regime_profile_allocation.window=%q requires regime.windows to be configured", prefix, windowRaw))
+					windowOK = false
+				} else if !regimeWindowExists(rc, windowKey) {
+					errs = append(errs, fmt.Sprintf("%s: regime_profile_allocation.window=%q not found in regime.windows (valid: %s)", prefix, windowRaw, strings.Join(sortedRegimeWindowNamesFromConfig(rc.Windows), ", ")))
+					windowOK = false
+				}
+			}
+			var labels []string
+			if windowOK && rc != nil && rc.Enabled {
+				labels = regimeLabelsForClassifier(regimeClassifierForWindow(rc, windowKey))
+			}
+			errs = append(errs, sc.RegimeProfileAllocation.ResolveRaw(prefix+".regime_profile_allocation", labels)...)
+		}
 		// stop_loss_atr_regime / trailing_stop_atr_regime vocabulary is resolved
 		// authoritatively in validateRegimeATRConfig (which also populates the
 		// typed runtime fields and runs the mutex checks) using the same

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -305,6 +305,7 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 		RegimeDirectionalPolicy bool                       `json:"regime_directional_policy,omitempty"` // #779: true when strategy has a policy block configured
 		EffectivePolicyRegime   string                     `json:"effective_policy_regime,omitempty"`   // #779: regime key the resolver used (pos.Regime while open, current regime when flat); shown only when policy is configured
 		RegimeDivergence        *RegimeDivergenceState     `json:"regime_divergence,omitempty"`         // #907: active window-divergence state; nil when none
+		RegimeProfile           *RegimeProfileState        `json:"regime_profile,omitempty"`            // #998: active regime-profile allocation switch state; nil when none
 	}
 
 	type StatusResp struct {
@@ -401,6 +402,7 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 			RegimeDirectionalPolicy: policyConfigured,
 			EffectivePolicyRegime:   effRegimeKey,
 			RegimeDivergence:        s.RegimeDivergence,
+			RegimeProfile:           s.RegimeProfile,
 		}
 	}
 

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -110,6 +110,7 @@ type StrategyState struct {
 	Regime           string                     `json:"regime,omitempty"`         // most recent primary regime label from check script (#482)
 	RegimeWindows    map[string]string          `json:"regime_windows,omitempty"` // latest per-window labels from check script (#792)
 	RegimeDivergence *RegimeDivergenceState     `json:"-"`                        // in-memory divergence state; not persisted (self-heals on restart within 1 cycle) (#907)
+	RegimeProfile    *RegimeProfileState        `json:"regime_profile,omitempty"` // regime-profile allocation switch state (#998). ActiveProfile is persisted (strategies.active_profile); the pending counter is in-memory and re-arms on restart.
 	// ClosedPositions is an in-memory buffer of positions closed during the
 	// current cycle. SaveState appends these to the closed_positions table and
 	// clears the buffer on successful commit. Not serialized to JSON state

--- a/scheduler/strategy_composition.go
+++ b/scheduler/strategy_composition.go
@@ -34,6 +34,7 @@ type PositionCtx struct {
 	Regime            string
 	DirectionalRegime string
 	RegimeWindows     map[string]string
+	Profile           string // regime-profile allocation: pos.OpenProfile frozen at open (#998)
 }
 
 func usesOpenCloseConfig(sc StrategyConfig) bool {
@@ -179,6 +180,7 @@ func positionCtxFromPosition(pos *Position) PositionCtx {
 		Regime:            pos.Regime,
 		DirectionalRegime: pos.Regime,
 		RegimeWindows:     cloneStringMap(pos.RegimeWindows),
+		Profile:           pos.OpenProfile,
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements **M4 regime-profile allocation** (#998): run two validated open-strategy param profiles of one strategy and let a slow long-window regime classifier (the #879 store) decide which is active, instead of shipping one compromise default. Generalizes the #976 `regime_adaptive_htf` two-profile case (fade-only in grind windows, breakout+drift-confirm in trending years).

Closes #998.

## Mechanism (HL perps only, live + paper)

1. New optional `regime_profile_allocation` block — `window`, `profiles` (label → profile), `param_sets` (exactly two), `confirm_bars`, `initial_profile`. **No config-version bump** (additive/optional). Validated at load: HL-perps + `regime.enabled` gating (`config.go`); param_sets count, label coverage, window existence (`regime_window_spec.go`).
2. Switch is **hysteretic and flat-only**: commits only after the desired profile persists for `confirm_bars` **closed bars** and the strategy is flat. While a position is open the active profile is frozen to `pos.OpenProfile` (hold-on-transition); the counter keeps accruing so the first flat bar commits. Pure state machine `resolveRegimeProfile`.
3. The active profile's params merge **over** the loop-local `open_strategy.params` **before** the check subprocess, so the profile shapes the signal itself. Rides the existing `--strategy-refs` JSON — **no new CLI flag, no `probeArgv` change** (symmetric deploy).
4. Hysteresis counts **closed bars** (regime bundle `BarTime`), so live cadence matches the per-bar backtester exactly.

## Persistence & lifecycle

- `positions.open_profile` (frozen for the position's life) and `strategies.active_profile` (flat-switch state across restarts); the pending counter re-arms on restart — a restart can only **delay** a switch, never fast-track one.
- SIGHUP: reshape blocked while open; applied + state-reset when flat.
- Surfacing: `/status` + trade DMs.

## Backtest parity

The switch rule is a pure function of closed-bar OHLCV, so the backtester **replays it** (NOT rejected at `--config` load like `regime_window_divergence`). `backtester.py` selects per-bar among `signal__<profile>` columns driven by a shifted `_profile_label`; `run_backtest.py --config` and `eval_windows.py --profile-allocation` build the per-profile legs + label series. Look-ahead invariants preserved (signal + label both `shift(1)`).

## Validation

The full protocol (each profile clears the M1 bar on its own regime's windows; the switched composite beats the better single profile on the full 5-window × 6-dataset table) is the operator's research step that decides ship vs negative finding. Preliminary check on 2024 BTC/USDT 1h:

1. fade single — Sharpe 0.01
2. trend single — Sharpe 1.12
3. switched composite — Sharpe 1.12 (the long-window classifier selects the trend profile throughout the trending window, exactly matching the better single profile)

confirming the switch tracks regime and picks the regime-appropriate profile.

## Tests

- **Go:** state-machine table tests (hysteresis, flat-only, open-freeze-then-commit, empty-label freeze, cold start), config validation, hot-reload `EqualForReload`, ValidateConfig integration, full LoadConfig-from-file, DB round-trip of `open_profile`/`active_profile`.
- **Python:** switcher state machine, engine replay (active-profile selection, no-switch-when-fade), missing-column guards.
- Full Go suite and full Python suite (1180) pass.

## Notes for reviewers

- `closeStrategyOwnedKeys` is **not applicable** — this is an open-strategy-level feature, not a close evaluator.
- Profiles swap `open_strategy.params` only; `close_strategy`, stops, leverage, direction are shared between profiles.

---
Created with LLM: Opus 4.8 | high | Harness: commit-push-pr
