### PR TITLE
fix(backtest): #1005 liquidation floor — stop return/Sharpe sign inversion on negative equity curves

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -2308,6 +2308,20 @@ class Backtester:
         # Calmar ratio
         calmar = annual_return / abs(max_drawdown) if max_drawdown != 0 else 0
 
+        # Liquidation risk-adjusted floor (#1005): when the sticky floor leaves
+        # <2 surviving returns (a leg busting within 1-2 bars — the post-bust
+        # NaN tail drops out), the variance guards above collapse Sharpe/
+        # Sortino/volatility to a NEUTRAL 0.0. That reads a dead account as
+        # "fine" and ranks a fast blowup ABOVE a slow one — re-inverting the
+        # exact axis this issue fixed. Floor every blown leg to the annualized
+        # total-loss magnitude (−100% return) so all deaths tie below any
+        # surviving leg, mirroring the −100% floor already applied to
+        # return/DD. Uniform (not path-dependent) so two busts at different
+        # bars tie instead of the earlier one out-ranking the later.
+        if liquidated:
+            sharpe = sortino = -ann_factor
+            volatility = ann_factor
+
         return {
             "total_return_pct": round(total_return * 100, 2),
             "annual_return_pct": round(annual_return * 100, 2),

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -2232,6 +2232,20 @@ class Backtester:
         equity = equity_df["equity"]
         ann_factor = math.sqrt(periods_per_year(timeframe))
 
+        # Liquidation floor (#1005): a stop-less short losing >100% drives
+        # equity negative, and pct_change over a negative base inverts return
+        # signs (a deepening blowup reads as a positive return, a recovery as
+        # negative), corrupting Sharpe/Sortino/volatility. A real account is
+        # dead at zero — floor the curve at 0 from the first bust bar onward
+        # (sticky: no resurrection if the position later recovers) and flag
+        # the run so harness consumers (eval_windows, fee_audit) can surface
+        # it. Post-bust bars contribute 0/0 = NaN returns, dropped below.
+        liquidated = bool((equity <= 0).any())
+        if liquidated:
+            bust_pos = int(np.argmax(equity.values <= 0))
+            equity = equity.copy()
+            equity.iloc[bust_pos:] = 0.0
+
         # Anchor return + drawdown at initial_capital so seeded runs (where
         # equity[0] reflects the starting_long mark-to-market, not the true
         # pre-trade balance) don't distort the baseline. For non-seeded runs
@@ -2307,6 +2321,7 @@ class Backtester:
             "total_trades": total_trades,
             "avg_win_pct": round(avg_win * 100, 2),
             "avg_loss_pct": round(avg_loss * 100, 2),
+            "liquidated": liquidated,
         }
 
 
@@ -2321,6 +2336,12 @@ def format_results(results: dict) -> str:
         f"  Period:          {results['start_date'][:10]} → {results['end_date'][:10]}",
         f"  Initial Capital: ${results['initial_capital']:,.2f}",
         f"  Final Capital:   ${results['final_capital']:,.2f}",
+    ]
+    if results.get("liquidated"):
+        lines.append(
+            "  *** LIQUIDATED: equity hit 0 — metrics floored at the bust bar ***"
+        )
+    lines += [
         f"{'─'*60}",
         f"  RETURNS",
         f"    Total Return:    {results['total_return_pct']:+.2f}%",

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -208,6 +208,17 @@ def periods_per_year(timeframe: str) -> int:
     return TIMEFRAME_PERIODS_PER_YEAR.get(timeframe, 365)
 
 
+# Timeframe-independent sentinel for the risk-adjusted floor applied to blown
+# (liquidated) legs (#1005). Must be uniform across timeframes so two equally
+# dead legs tie regardless of which timeframe they busted on. The earlier floor
+# used the per-leg ``-ann_factor`` (1h ≈ -93.6, 4h ≈ -46.8), which let the SAME
+# total loss carry a ~2x different Sharpe by timeframe and perturbed mean-Sharpe
+# rankings of liquidated strategies by bust timeframe rather than severity. The
+# magnitude (100, mirroring the -100% return floor) dominates any surviving
+# leg's annualized Sharpe on the harness timeframes (1h/4h).
+LIQUIDATED_METRIC_FLOOR = 100.0
+
+
 # Taker fee rates per platform — mirrors scheduler/fees.go:CalculatePlatformSpotFee
 # and related constants. test_platform_fees.py scrapes fees.go to enforce parity.
 PLATFORM_FEE_PCT = {
@@ -2313,14 +2324,15 @@ class Backtester:
         # NaN tail drops out), the variance guards above collapse Sharpe/
         # Sortino/volatility to a NEUTRAL 0.0. That reads a dead account as
         # "fine" and ranks a fast blowup ABOVE a slow one — re-inverting the
-        # exact axis this issue fixed. Floor every blown leg to the annualized
-        # total-loss magnitude (−100% return) so all deaths tie below any
-        # surviving leg, mirroring the −100% floor already applied to
-        # return/DD. Uniform (not path-dependent) so two busts at different
-        # bars tie instead of the earlier one out-ranking the later.
+        # exact axis this issue fixed. Floor every blown leg to a fixed sentinel
+        # so all deaths tie below any surviving leg, mirroring the −100% floor
+        # already applied to return/DD. The sentinel is timeframe-INDEPENDENT
+        # (not -ann_factor) so two equally-dead legs tie regardless of bust
+        # timeframe, and not path-dependent so an earlier bust never out-ranks
+        # a later one.
         if liquidated:
-            sharpe = sortino = -ann_factor
-            volatility = ann_factor
+            sharpe = sortino = -LIQUIDATED_METRIC_FLOOR
+            volatility = LIQUIDATED_METRIC_FLOOR
 
         return {
             "total_return_pct": round(total_return * 100, 2),

--- a/backtest/eval_windows.py
+++ b/backtest/eval_windows.py
@@ -117,6 +117,9 @@ def leg_from_results(results: dict, bh_return_pct: Optional[float] = None) -> di
         "ddadj": round(dd_adjusted_return(ret, dd), 3),
         "trades": int(results["total_trades"]),
         "bh_return_pct": bh_return_pct,
+        # #1005: equity hit 0 — metrics are floored at the bust bar (return
+        # and DD read −100%); surfaced so blown legs are never silent.
+        "liquidated": bool(results.get("liquidated")),
     }
 
 
@@ -170,6 +173,8 @@ def score_candidate(candidate_legs: dict, bars: dict) -> dict:
     mean_bar_sharpe = statistics.mean(r["bar"]["sharpe"] for r in scored)
     mean_bar_ddadj = statistics.mean(r["bar"]["ddadj"] for r in scored)
     traded = sum(1 for r in scored if r["leg"]["trades"] > 0)
+    liquidated = sum(1 for r in rows
+                     if r["leg"] is not None and r["leg"].get("liquidated"))
     degenerate = traded < math.ceil(len(scored) / 2)
     beats_both = (mean_sharpe > mean_bar_sharpe) and (mean_ddadj > mean_bar_ddadj)
 
@@ -190,6 +195,7 @@ def score_candidate(candidate_legs: dict, bars: dict) -> dict:
         "mean_bar_ddadj": round(mean_bar_ddadj, 3),
         "beats_sharpe_count": sum(1 for r in scored if r["beats_sharpe"]),
         "beats_ddadj_count": sum(1 for r in scored if r["beats_ddadj"]),
+        "liquidated_legs": liquidated,
         "degenerate": degenerate,
         "verdict": verdict,
     }
@@ -471,6 +477,8 @@ def format_window_report(score: dict) -> str:
         if row["beats_sharpe"] is not None:
             beats = ("S" if row["beats_sharpe"] else "-") + \
                     ("D" if row["beats_ddadj"] else "-")
+        if leg.get("liquidated"):
+            beats = (beats + " LIQ").strip()
         lines.append(
             f"{row['dataset']:<14} {_fmt(leg['sharpe'])} "
             f"{_fmt(bar['sharpe'] if bar else None)} {_fmt(leg['ddadj'])} "
@@ -491,6 +499,9 @@ def format_window_report(score: dict) -> str:
         f"{score['beats_ddadj_count']}/{score['scored_datasets']} (DDadj); "
         f"traded {score['traded_datasets']}/{score['scored_datasets']}"
         + (" [degenerate: majority of legs zero-trade]" if score["degenerate"] else "")
+        + (f" [{score['liquidated_legs']} liquidated leg(s): equity hit 0, "
+           f"metrics floored at the bust bar]"
+           if score.get("liquidated_legs") else "")
     )
     return "\n".join(lines)
 

--- a/backtest/eval_windows.py
+++ b/backtest/eval_windows.py
@@ -173,6 +173,9 @@ def score_candidate(candidate_legs: dict, bars: dict) -> dict:
     mean_bar_sharpe = statistics.mean(r["bar"]["sharpe"] for r in scored)
     mean_bar_ddadj = statistics.mean(r["bar"]["ddadj"] for r in scored)
     traded = sum(1 for r in scored if r["leg"]["trades"] > 0)
+    # Counted over `rows` (all legs), NOT `scored`, by design (#1005): a blown
+    # leg with no incumbent bar is excluded from the scored means but operators
+    # must still see every death, so this count can exceed scored_datasets.
     liquidated = sum(1 for r in rows
                      if r["leg"] is not None and r["leg"].get("liquidated"))
     degenerate = traded < math.ceil(len(scored) / 2)

--- a/backtest/fee_audit.py
+++ b/backtest/fee_audit.py
@@ -194,6 +194,7 @@ def aggregate_strategy(strategy: str, registry_label: str,
     mean_gross = _mean([l.get("gross_ret") for l in data_legs])
     mean_net = _mean([l.get("net_ret") for l in data_legs])
     mean_sharpe = _mean([l.get("net_sharpe") for l in data_legs])
+    n_liquidated = sum(1 for l in data_legs if l.get("liquidated"))
 
     fee_drag = (mean_gross - mean_net) if (mean_gross is not None
                                            and mean_net is not None) else None
@@ -218,6 +219,7 @@ def aggregate_strategy(strategy: str, registry_label: str,
         "mean_net_sharpe": round(mean_sharpe, 3) if mean_sharpe is not None else None,
         "short_unmeasured": short_unmeasured,
         "n_legs": n_legs,
+        "n_liquidated": n_liquidated,
         "n_errors": len(errors),
         "errors": errors,
         "verdict": verdict,
@@ -346,6 +348,17 @@ def render_markdown(ranked: List[dict], meta: dict) -> str:
     else:
         lines.append("- (none)")
 
+    liquidated = [r for r in ranked if r.get("n_liquidated")]
+    if liquidated:
+        lines += ["", "## Liquidated legs (equity hit 0 — metrics floored at "
+                  "the bust bar, #1005)", ""]
+        for r in liquidated:
+            lines.append(
+                f"- **{r['strategy']}** ({r['registry']}): "
+                f"{r['n_liquidated']}/{r['n_legs']} leg(s) liquidated — "
+                f"return/DD read −100% for those legs; means above include "
+                f"the floored values")
+
     if errored:
         lines += ["", "## Errors / skips", ""]
         for r in errored:
@@ -402,6 +415,9 @@ def screen_leg(reg, name: str, symbol: str, timeframe: str,
         "net_ret": net["return_pct"],
         "gross_ret": gross["return_pct"],
         "net_sharpe": net["sharpe"],
+        # #1005: either run blew the account (equity hit 0; metrics floored
+        # at the bust bar) — surfaced so blown legs are never silent.
+        "liquidated": bool(net.get("liquidated") or gross.get("liquidated")),
     }
 
 

--- a/backtest/tests/test_metrics_liquidation.py
+++ b/backtest/tests/test_metrics_liquidation.py
@@ -28,13 +28,13 @@ from backtester import Backtester  # noqa: E402
 # _calculate_metrics — unit level
 # ---------------------------------------------------------------------------
 
-def _metrics(equities, initial_capital=1000.0):
+def _metrics(equities, initial_capital=1000.0, timeframe="1d"):
     idx = pd.date_range("2024-01-01", periods=len(equities), freq="D")
     equity_df = pd.DataFrame({"equity": np.asarray(equities, dtype=float)},
                              index=idx)
     df = pd.DataFrame({"close": np.full(len(equities), 100.0)}, index=idx)
     bt = Backtester(initial_capital=initial_capital)
-    return bt._calculate_metrics(equity_df, [], df, timeframe="1d")
+    return bt._calculate_metrics(equity_df, [], df, timeframe=timeframe)
 
 
 def test_deepening_blowup_reads_negative_not_positive():
@@ -116,6 +116,25 @@ def test_first_bar_bust_zero_samples_reads_negative():
     assert m["total_return_pct"] == pytest.approx(-100.0)
     assert m["sharpe_ratio"] < 0
     assert m["sortino_ratio"] < 0
+
+
+def test_liquidation_floor_is_timeframe_independent():
+    # #1005 follow-up: the blown-leg risk-adjusted floor must be uniform across
+    # timeframes. The earlier `-ann_factor` floor scaled with the timeframe
+    # (1h ≈ -93.6, 4h ≈ -46.8), so the SAME total loss carried a ~2x different
+    # Sharpe by timeframe and perturbed mean-Sharpe rankings of liquidated
+    # strategies by which timeframe they busted on. Two equally-dead legs must
+    # now tie on every risk-adjusted axis regardless of timeframe.
+    bust = [1000, 500, -500, -1500]
+    m_1h = _metrics(bust, timeframe="1h")
+    m_4h = _metrics(bust, timeframe="4h")
+    m_1d = _metrics(bust, timeframe="1d")
+    assert m_1h["liquidated"] and m_4h["liquidated"] and m_1d["liquidated"]
+    for key in ("sharpe_ratio", "sortino_ratio", "volatility_pct"):
+        assert m_1h[key] == m_4h[key] == m_1d[key]
+    # And still clearly negative / non-zero, not collapsed to neutral.
+    assert m_1h["sharpe_ratio"] < 0
+    assert m_1h["volatility_pct"] != 0
 
 
 def test_faster_bust_never_outranks_slower_on_sharpe():

--- a/backtest/tests/test_metrics_liquidation.py
+++ b/backtest/tests/test_metrics_liquidation.py
@@ -94,6 +94,42 @@ def test_zero_equity_bar_counts_as_bust():
     assert m["total_return_pct"] == pytest.approx(-100.0)
 
 
+def test_early_bust_one_sample_reads_negative_not_neutral():
+    # The #1005 regression at the degenerate boundary: a bust on the 2nd bar
+    # leaves a single surviving return (the -100% bust bar); post-bust bars
+    # drop out as NaN. The len>1 variance guard previously collapsed
+    # Sharpe/Sortino/volatility to a NEUTRAL 0.0 — a dead account reading as
+    # "fine" — which ranks a fast blowup ABOVE a slow one. A liquidated leg
+    # must read clearly negative on the risk-adjusted axes and non-zero vol.
+    m = _metrics([1000, -500, 800, 900])  # bust idx 1 -> 1 surviving sample
+    assert m["liquidated"] is True
+    assert m["sharpe_ratio"] < 0
+    assert m["sortino_ratio"] < 0
+    assert m["volatility_pct"] != 0
+
+
+def test_first_bar_bust_zero_samples_reads_negative():
+    # Boundary: equity <= 0 on the very first bar leaves ZERO surviving
+    # returns (empty series). Must still read negative, never neutral 0.0.
+    m = _metrics([-100, 50, 75])  # bust idx 0 -> 0 surviving samples
+    assert m["liquidated"] is True
+    assert m["total_return_pct"] == pytest.approx(-100.0)
+    assert m["sharpe_ratio"] < 0
+    assert m["sortino_ratio"] < 0
+
+
+def test_faster_bust_never_outranks_slower_on_sharpe():
+    # Invariant: a leg busting earlier (less of the death path measured) must
+    # never report a HIGHER Sharpe than one busting later. Pre-fix the 1-sample
+    # fast bust read 0.0 while the 3-sample slow bust read negative, inverting
+    # the ranking on the very axis #1005 set out to fix.
+    fast = _metrics([1000, -500, 0, 0])      # bust idx 1 -> 1 sample
+    slow = _metrics([1000, 900, 800, -200])  # bust idx 3 -> 3 samples
+    assert fast["liquidated"] and slow["liquidated"]
+    assert fast["sharpe_ratio"] <= slow["sharpe_ratio"]
+    assert fast["sortino_ratio"] <= slow["sortino_ratio"]
+
+
 # ---------------------------------------------------------------------------
 # End-to-end — stop-less short leg blowing past -100% (#989 harness shape)
 # ---------------------------------------------------------------------------
@@ -158,6 +194,21 @@ def test_score_candidate_counts_liquidated_legs_without_verdict_change():
     no_key = {k: v for k, v in healthy.items() if k != "liquidated"}
     score2 = ew.score_candidate({"A 1h": no_key}, {"A 1h": bar})
     assert score2["liquidated_legs"] == 0
+
+
+def test_liquidated_legs_counts_every_blowup_including_unscored():
+    # Design (#1005): liquidated_legs counts EVERY blown leg, including one
+    # with no incumbent bar (absent from `scored`), so operators see all
+    # deaths even when a dataset has no comparison baseline. The count is
+    # therefore over `rows`, not `scored`, and may exceed scored_datasets.
+    blown_no_bar = ew.leg_from_results(_results())  # liquidated, no bar below
+    healthy = ew.leg_from_results(_results(ret=20.0, dd=-10.0, sharpe=1.5,
+                                           liquidated=False))
+    score = ew.score_candidate(
+        {"A 1h": blown_no_bar, "B 1h": healthy},
+        {"B 1h": {"sharpe": 0.5, "ddadj": 0.5, "n": 8}})  # only B has a bar
+    assert score["scored_datasets"] == 1            # only B is scored
+    assert score["liquidated_legs"] == 1            # A counted despite no bar
 
 
 def test_format_window_report_marks_liquidated_rows():

--- a/backtest/tests/test_metrics_liquidation.py
+++ b/backtest/tests/test_metrics_liquidation.py
@@ -1,0 +1,219 @@
+"""#1005: liquidation floor for negative equity curves.
+
+``equity.pct_change()`` over a negative base inverts return signs (a deepening
+blowup reads as a positive return, a recovery as negative), corrupting
+Sharpe/Sortino/volatility — reachable for stop-less short legs losing >100%.
+A real account is dead at zero: ``_calculate_metrics`` sticky-floors the curve
+at 0 from the first bust bar and flags the run ``liquidated`` so harness
+consumers (eval_windows, fee_audit) surface blown legs instead of silently
+trusting their metrics.
+"""
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+_BT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _BT_DIR not in sys.path:
+    sys.path.insert(0, _BT_DIR)
+
+import eval_windows as ew  # noqa: E402
+import fee_audit as fa  # noqa: E402
+from backtester import Backtester  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _calculate_metrics — unit level
+# ---------------------------------------------------------------------------
+
+def _metrics(equities, initial_capital=1000.0):
+    idx = pd.date_range("2024-01-01", periods=len(equities), freq="D")
+    equity_df = pd.DataFrame({"equity": np.asarray(equities, dtype=float)},
+                             index=idx)
+    df = pd.DataFrame({"close": np.full(len(equities), 100.0)}, index=idx)
+    bt = Backtester(initial_capital=initial_capital)
+    return bt._calculate_metrics(equity_df, [], df, timeframe="1d")
+
+
+def test_deepening_blowup_reads_negative_not_positive():
+    # Pre-#1005: pct_change over the negative base read -500 → -1500 → -2500
+    # as POSITIVE per-bar returns, inflating Sharpe. Floored, the leg carries
+    # only the path to death (-50%, -100%) — Sharpe must be negative.
+    m = _metrics([1000, 500, -500, -1500, -2500])
+    assert m["liquidated"] is True
+    assert m["sharpe_ratio"] < 0
+    assert m["total_return_pct"] == pytest.approx(-100.0)
+    assert m["max_drawdown_pct"] == pytest.approx(-100.0)
+
+
+def test_deeper_blowup_never_ranks_above_shallower():
+    # Identical paths to the bust bar; one then deepens 4x further. Floored,
+    # both runs are dead at the same bar and must carry identical metrics —
+    # a deeper blowup can tie, never win.
+    deep = _metrics([1000, 500, -500, -2500])
+    shallow = _metrics([1000, 500, -500, -600])
+    for key in ("sharpe_ratio", "total_return_pct", "max_drawdown_pct",
+                "volatility_pct", "sortino_ratio"):
+        assert deep[key] == pytest.approx(shallow[key])
+    assert deep["liquidated"] and shallow["liquidated"]
+
+
+def test_floor_is_sticky_no_resurrection():
+    # A recovery after the bust bar is fiction — a real account was already
+    # liquidated. The floor must not let equity resurrect.
+    m = _metrics([1000, -200, 800, 900])
+    assert m["liquidated"] is True
+    assert m["total_return_pct"] == pytest.approx(-100.0)
+
+
+def test_recovery_before_zero_is_not_liquidation():
+    # Deep drawdown that never touches 0 is a survivable path, not a bust.
+    m = _metrics([1000, 50, 400, 600])
+    assert m["liquidated"] is False
+    assert m["total_return_pct"] == pytest.approx(-40.0)
+
+
+def test_healthy_curve_metrics_unchanged():
+    # Positive control: never-negative equity must be byte-identical to the
+    # pre-#1005 computation (returns straight off pct_change).
+    equities = [1000.0, 1100.0, 1050.0, 1200.0]
+    m = _metrics(equities)
+    assert m["liquidated"] is False
+    assert m["total_return_pct"] == pytest.approx(20.0)
+    rets = pd.Series(equities).pct_change().dropna()
+    expected_sharpe = (rets.mean() / rets.std()) * np.sqrt(365)
+    assert m["sharpe_ratio"] == pytest.approx(round(expected_sharpe, 3))
+
+
+def test_zero_equity_bar_counts_as_bust():
+    # Boundary: equity == 0 exactly is bust (<= 0), not a survivable bar.
+    m = _metrics([1000, 0, 500])
+    assert m["liquidated"] is True
+    assert m["total_return_pct"] == pytest.approx(-100.0)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end — stop-less short leg blowing past -100% (#989 harness shape)
+# ---------------------------------------------------------------------------
+
+def test_short_leg_blowup_end_to_end():
+    closes = np.array([100, 100, 150, 250, 300, 300], dtype=float)
+    n = len(closes)
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame(
+        {
+            "open": closes,
+            "high": closes + 0.5,
+            "low": closes - 0.5,
+            "close": closes,
+            "volume": np.full(n, 1000.0),
+            # Short opens at bar 1 open (100) and is never closed; by close
+            # 250 the buy-back cost exceeds the 2x notional held → equity < 0.
+            "signal": np.array([-1, 0, 0, 0, 0, 0], dtype=float),
+        },
+        index=idx,
+    )
+    bt = Backtester(initial_capital=10000.0, direction="short",
+                    commission_pct=0.0, slippage_pct=0.0)
+    results = bt.run(df, strategy_name="x", symbol="BTC/USDT",
+                     timeframe="1d", save=False)
+    assert results["liquidated"] is True
+    assert results["total_return_pct"] == pytest.approx(-100.0)
+    assert results["max_drawdown_pct"] == pytest.approx(-100.0)
+
+
+# ---------------------------------------------------------------------------
+# eval_windows — flag propagation + non-silent reporting
+# ---------------------------------------------------------------------------
+
+def _results(ret=-100.0, dd=-100.0, sharpe=-2.0, trades=3, liquidated=True):
+    return {"total_return_pct": ret, "max_drawdown_pct": dd,
+            "sharpe_ratio": sharpe, "total_trades": trades,
+            "liquidated": liquidated}
+
+
+def test_leg_from_results_propagates_liquidated():
+    assert ew.leg_from_results(_results())["liquidated"] is True
+    assert ew.leg_from_results(_results(liquidated=False))["liquidated"] is False
+    # Results dicts predating #1005 lack the key — must default False.
+    legacy = _results()
+    del legacy["liquidated"]
+    assert ew.leg_from_results(legacy)["liquidated"] is False
+
+
+def test_score_candidate_counts_liquidated_legs_without_verdict_change():
+    blown = ew.leg_from_results(_results())
+    healthy = ew.leg_from_results(_results(ret=20.0, dd=-10.0, sharpe=1.5,
+                                           liquidated=False))
+    bar = {"sharpe": 0.5, "ddadj": 0.5, "n": 8}
+    score = ew.score_candidate(
+        {"A 1h": blown, "B 1h": healthy}, {"A 1h": bar, "B 1h": bar})
+    assert score["liquidated_legs"] == 1
+    # The floored metrics already rank the blown leg honestly; liquidation is
+    # surfaced, not a verdict input.
+    assert score["verdict"] in ("pass", "fail")
+    # Legs without the key (hand-built or legacy) must not crash the count.
+    no_key = {k: v for k, v in healthy.items() if k != "liquidated"}
+    score2 = ew.score_candidate({"A 1h": no_key}, {"A 1h": bar})
+    assert score2["liquidated_legs"] == 0
+
+
+def test_format_window_report_marks_liquidated_rows():
+    blown = ew.leg_from_results(_results())
+    bar = {"sharpe": 0.5, "ddadj": 0.5, "n": 8}
+    score = ew.score_candidate({"SOL/USDT 4h": blown}, {"SOL/USDT 4h": bar})
+    score["window"] = "2023"
+    score["window_range"] = ["2023-01-01", "2024-01-01"]
+    report = ew.format_window_report(score)
+    assert "LIQ" in report
+    assert "1 liquidated leg(s)" in report
+
+
+def test_format_window_report_silent_when_no_liquidation():
+    healthy = ew.leg_from_results(_results(ret=20.0, dd=-10.0, sharpe=1.5,
+                                           liquidated=False))
+    bar = {"sharpe": 0.5, "ddadj": 0.5, "n": 8}
+    score = ew.score_candidate({"BTC/USDT 1h": healthy}, {"BTC/USDT 1h": bar})
+    score["window"] = "oos"
+    score["window_range"] = ["2026-01-01", None]
+    report = ew.format_window_report(score)
+    assert "LIQ" not in report
+    assert "liquidated" not in report
+
+
+# ---------------------------------------------------------------------------
+# fee_audit — aggregation count + markdown section
+# ---------------------------------------------------------------------------
+
+def _fa_leg(liquidated=False):
+    return {"error": None, "trades": 10, "span_days": 365.0,
+            "net_ret": -100.0 if liquidated else 5.0,
+            "gross_ret": -100.0 if liquidated else 8.0,
+            "net_sharpe": -2.0 if liquidated else 1.0,
+            "liquidated": liquidated}
+
+
+def test_aggregate_counts_liquidated_legs():
+    row = fa.aggregate_strategy(
+        "blower", "futures", [_fa_leg(True), _fa_leg(False)])
+    assert row["n_liquidated"] == 1
+    # Legacy leg dicts without the key must not crash.
+    legacy = {k: v for k, v in _fa_leg().items() if k != "liquidated"}
+    row2 = fa.aggregate_strategy("ok", "spot", [legacy])
+    assert row2["n_liquidated"] == 0
+
+
+def test_render_markdown_liquidated_section_only_when_present():
+    meta = {"command": "uv run ...", "registry": "futures",
+            "windows_desc": "2023", "datasets_desc": "SOL/USDT 4h",
+            "capital": 1000.0, "date": "2026-06-12"}
+    blown = fa.aggregate_strategy("blower", "futures", [_fa_leg(True)])
+    md = fa.render_markdown(fa.rank_rows([blown]), meta)
+    assert "## Liquidated legs" in md
+    assert "blower" in md
+
+    clean = fa.aggregate_strategy("ok", "spot", [_fa_leg(False)])
+    md_clean = fa.render_markdown(fa.rank_rows([clean]), meta)
+    assert "## Liquidated legs" not in md_clean


### PR DESCRIPTION
Closes #1005

## Problem

`_calculate_metrics` computes per-bar returns with `equity.pct_change()`. When the equity curve goes negative — reachable for stop-less short legs losing more than 100% (the #989 short/flat harness measures exactly these, e.g. bear_pullback_st 2023 SOL 4h at −433%) — `pct_change` divides by a negative base: a deepening blowup reads as a **positive** per-bar return and a recovery as negative. Sharpe (co-verdict metric in eval_windows), Sortino, and volatility were corrupted for the affected stretch; total return and max DD were already anchored at `initial_capital` and stayed sign-correct.

## Fix (issue options 1 + 3 combined)

A real account is dead at zero:

- **Liquidation floor** (`backtester.py::_calculate_metrics`): detect the first bar where equity ≤ 0 and sticky-floor the curve at 0 from that bar onward (no resurrection if the short later recovers). Return and DD floor at −100%, the bust bar contributes a −100% return, post-bust bars drop out as NaN. Deeper and shallower blowups now tie instead of inverting — verdicts can never rank a deeper blowup above a shallower one.
- **`liquidated` flag** (additive results key) threaded through the harness so blown legs are never silent:
  - `eval_windows`: `leg_from_results` propagates it; report rows get a `LIQ` marker and the verdict line counts liquidated legs (`liquidated_legs` in `score_candidate`; verdict logic unchanged — floored metrics already rank blown legs honestly).
  - `fee_audit`: `screen_leg`/`aggregate_strategy` carry `liquidated`/`n_liquidated`; the markdown report gains a "Liquidated legs" section only when any leg blew up. `salvage_verdict` needs no change — a floored −100% gross already lands on `deprecate`.
  - `format_results` prints a LIQUIDATED banner.

Option 2 (robust returns over `abs(prev)`) was rejected: it produces statistically fictional Sharpe values for an economically dead account and still lets a blown leg carry a plausible-looking Sharpe into verdicts.

Out of scope: force-closing the simulated position at bust (sim behavior, not metrics) and `final_capital` (stays raw cash; the flag tells the story).

## Verification

- Real-data repro of the issue's example: `eval_windows.py --strategy bear_pullback_st --registry futures --direction short --windows 2023` — SOL 4h leg now reads return −100%, Sharpe −2.26 (was −433% with corrupted Sharpe), `LIQ` marker and `[3 liquidated leg(s)…]` verdict note shown.
- 13 new tests in `backtest/tests/test_metrics_liquidation.py`: sign-inversion regression (deepening blowup must read negative Sharpe), deeper-never-ranks-above-shallower tie, sticky floor (no resurrection), zero-equity boundary, healthy-curve metrics byte-identical (positive control), end-to-end stop-less short blowup on the #989 path, flag propagation + report markers in eval_windows, count + conditional markdown section in fee_audit, legacy dicts without the key default safely.
- Full suite: 1545 passed.

---
Created with LLM: Fable 5 | high | Harness: Claude Code