### PR TITLE
fix(shared-wallet): classify perps force-closes as 'perps' not 'futures'

### DIFF
--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1133,10 +1133,13 @@ func forceCloseKillSwitchPositions(s *StrategyState, sc StrategyConfig, prices m
 // for circuit-breaker / kill-switch close records. HL perps and OKX perps
 // carry pos.Multiplier=1 (#254/#497 perps PnL valuation convention — NOT a
 // contract multiplier), so the legacy "Multiplier>0 → futures" classifier
-// mislabels every perps force-close as "futures" and leaks phantom PnL into
-// the #954 shared-wallet trade ledger. TopStep/CME futures keep pos.Multiplier
-// as the real contract multiplier; that is the only branch where "futures"
-// is correct.
+// mislabels every perps force-close as "futures". This is an operator-facing
+// label fix only: tradeLedgerDeltaSQL (trade_pnl.go) keys on
+// is_close/pnl_gross/realized_pnl/exchange_fee and never reads trade_type, so
+// the label does NOT affect any ledger sum — relabeling here changes what an
+// operator sees (Discord/leaderboard/audit), not the #954 ledger math.
+// TopStep/CME futures keep pos.Multiplier as the real contract multiplier;
+// that is the only branch where "futures" is correct.
 func classifyPositionTradeType(s *StrategyState, pos *Position) string {
 	if pos == nil {
 		return "spot"
@@ -1169,8 +1172,9 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 		// PnL branch is the same for perps (Multiplier=1) and futures
 		// (Multiplier=contract size) — qty*multiplier*price_delta. Only the
 		// trade_type LABEL differs by venue, classified via
-		// classifyPositionTradeType so perps force-closes no longer leak into
-		// the "futures" trade_ledger bucket.
+		// classifyPositionTradeType so perps force-closes carry an accurate
+		// operator-facing label. The label does not feed any ledger sum
+		// (tradeLedgerDeltaSQL ignores trade_type); it is display-only.
 		tradeType := classifyPositionTradeType(s, pos)
 		if pos.Multiplier > 0 {
 			if pos.Side == "long" {

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1129,6 +1129,32 @@ func forceCloseKillSwitchPositions(s *StrategyState, sc StrategyConfig, prices m
 	forceCloseAllPositions(s, prices, logger)
 }
 
+// classifyPositionTradeType maps a position to the correct trade_type label
+// for circuit-breaker / kill-switch close records. HL perps and OKX perps
+// carry pos.Multiplier=1 (#254/#497 perps PnL valuation convention — NOT a
+// contract multiplier), so the legacy "Multiplier>0 → futures" classifier
+// mislabels every perps force-close as "futures" and leaks phantom PnL into
+// the #954 shared-wallet trade ledger. TopStep/CME futures keep pos.Multiplier
+// as the real contract multiplier; that is the only branch where "futures"
+// is correct.
+func classifyPositionTradeType(s *StrategyState, pos *Position) string {
+	if pos == nil {
+		return "spot"
+	}
+	if pos.Multiplier > 0 {
+		if s != nil {
+			switch {
+			case s.Platform == "hyperliquid" && (s.Type == "perps" || s.Type == "manual"):
+				return "perps"
+			case s.Platform == "okx" && s.Type == "perps":
+				return "perps"
+			}
+		}
+		return "futures"
+	}
+	return "spot"
+}
+
 // forceCloseAllPositions liquidates all open positions at current prices.
 // Called when any circuit breaker fires.
 func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger *StrategyLogger) {
@@ -1140,10 +1166,13 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 			price = pos.AvgCost
 		}
 		var pnl, value float64
-		tradeType := "spot"
+		// PnL branch is the same for perps (Multiplier=1) and futures
+		// (Multiplier=contract size) — qty*multiplier*price_delta. Only the
+		// trade_type LABEL differs by venue, classified via
+		// classifyPositionTradeType so perps force-closes no longer leak into
+		// the "futures" trade_ledger bucket.
+		tradeType := classifyPositionTradeType(s, pos)
 		if pos.Multiplier > 0 {
-			// Futures: PnL-based (contracts * multiplier * price delta)
-			tradeType = "futures"
 			if pos.Side == "long" {
 				pnl = pos.Quantity * pos.Multiplier * (price - pos.AvgCost)
 			} else {

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -2828,10 +2828,11 @@ func TestCircuitBreakerStrategyLabel_StripsSpotQuoteSuffix(t *testing.T) {
 // label for circuit-breaker / kill-switch force-closes: HL perps and OKX perps
 // carry pos.Multiplier=1 (#254/#497 perps PnL valuation convention, NOT a
 // contract multiplier), so the legacy "Multiplier>0 → futures" classifier
-// mislabeled every perps force-close as "futures" and leaked phantom PnL into
-// the #954 shared-wallet trade ledger. TopStep/legacy futures keep
-// pos.Multiplier as the real contract multiplier and keep the "futures" label.
-// Spot (Multiplier=0) stays "spot".
+// mislabeled every perps force-close as "futures". The label is operator-facing
+// only — tradeLedgerDeltaSQL ignores trade_type, so it never affected a ledger
+// sum — but an accurate label keeps display/audit surfaces honest. TopStep/legacy
+// futures keep pos.Multiplier as the real contract multiplier and keep the
+// "futures" label. Spot (Multiplier=0) stays "spot".
 func TestForceCloseAllPositions_TradeType_PerpsVsFutures(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -2823,3 +2823,50 @@ func TestCircuitBreakerStrategyLabel_StripsSpotQuoteSuffix(t *testing.T) {
 		t.Fatalf("strategy label should not render raw spot pair: %q", got)
 	}
 }
+
+// TestForceCloseAllPositions_TradeType_PerpsVsFutures pins the trade_type
+// label for circuit-breaker / kill-switch force-closes: HL perps and OKX perps
+// carry pos.Multiplier=1 (#254/#497 perps PnL valuation convention, NOT a
+// contract multiplier), so the legacy "Multiplier>0 → futures" classifier
+// mislabeled every perps force-close as "futures" and leaked phantom PnL into
+// the #954 shared-wallet trade ledger. TopStep/legacy futures keep
+// pos.Multiplier as the real contract multiplier and keep the "futures" label.
+// Spot (Multiplier=0) stays "spot".
+func TestForceCloseAllPositions_TradeType_PerpsVsFutures(t *testing.T) {
+	cases := []struct {
+		name      string
+		platform  string
+		stratType string
+		multiplier float64
+		want      string
+	}{
+		{"hl-perps-multiplier-1", "hyperliquid", "perps", 1, "perps"},
+		{"hl-manual-multiplier-1", "hyperliquid", "manual", 1, "perps"},
+		{"okx-perps-multiplier-1", "okx", "perps", 1, "perps"},
+		{"hl-perps-multiplier-0", "hyperliquid", "perps", 0, "spot"},
+		{"spot-multiplier-0", "binanceus", "spot", 0, "spot"},
+		{"topstep-futures-multiplier-50", "topstep", "futures", 50, "futures"},
+		{"legacy-futures-multiplier-5", "ibkr", "futures", 5, "futures"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &StrategyState{
+				ID:       "test-" + tc.name,
+				Platform: tc.platform,
+				Type:     tc.stratType,
+				Positions: map[string]*Position{
+					"BTC": {Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "long", Multiplier: tc.multiplier},
+				},
+				TradeHistory: []Trade{},
+				RiskState:    RiskState{},
+			}
+			forceCloseAllPositions(s, map[string]float64{"BTC": 51000}, nil)
+			if len(s.TradeHistory) != 1 {
+				t.Fatalf("TradeHistory len = %d, want 1", len(s.TradeHistory))
+			}
+			if got := s.TradeHistory[0].TradeType; got != tc.want {
+				t.Errorf("TradeType = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -2834,11 +2834,11 @@ func TestCircuitBreakerStrategyLabel_StripsSpotQuoteSuffix(t *testing.T) {
 // Spot (Multiplier=0) stays "spot".
 func TestForceCloseAllPositions_TradeType_PerpsVsFutures(t *testing.T) {
 	cases := []struct {
-		name      string
-		platform  string
-		stratType string
+		name       string
+		platform   string
+		stratType  string
 		multiplier float64
-		want      string
+		want       string
 	}{
 		{"hl-perps-multiplier-1", "hyperliquid", "perps", 1, "perps"},
 		{"hl-manual-multiplier-1", "hyperliquid", "manual", 1, "perps"},

--- a/scheduler/shared_wallet_drift_alerts.go
+++ b/scheduler/shared_wallet_drift_alerts.go
@@ -237,12 +237,14 @@ func formatSharedWalletDriftAlert(key SharedWalletKey, balance, memberSum, drift
 	// value vs balance, however, is the RAW reconciliation — those are the
 	// rows the operator sees. Showing raw diff (memberSum - balance) makes
 	// the alert self-consistent with the numbers above it. A large raw diff
-	// with a small baseline-anchored drift = legacy phantom ledger data
-	// adopted into the baseline at first contact (the alert is masked by
-	// design — see wallet_ledger_state.baseline_offset_usd).
+	// with a small baseline-anchored drift MAY be legacy data adopted into the
+	// baseline at first contact (masked by design — see
+	// wallet_ledger_state.baseline_offset_usd), but can equally be a live
+	// orphan/weighting bug sitting near the offset; the alert flags it for
+	// investigation rather than pre-explaining it.
 	rawDiff := memberSum - balance
 	return fmt.Sprintf(
-		"**SHARED-WALLET DRIFT** %s (pid=%d, %d consecutive): Σ member value $%.2f vs real balance $%.2f — raw reconciliation diff $%+.2f, post-baseline drift $%+.2f (>$%.2f tolerance). %s. Exchange-derived rows should reconcile exactly; a large raw diff with a small post-baseline drift means legacy phantom ledger data is baked into the adopted baseline — values will re-reconcile once phantom rows are cleared.",
+		"**SHARED-WALLET DRIFT** %s (pid=%d, %d consecutive): Σ member value $%.2f vs real balance $%.2f — raw reconciliation diff $%+.2f, post-baseline drift $%+.2f (>$%.2f tolerance). %s. Exchange-derived rows should reconcile exactly; a large raw diff with a small post-baseline drift may indicate legacy data baked into the adopted baseline OR a live attribution bug (orphan/weighting) near the offset — investigate before assuming it is benign.",
 		sharedWalletKeyLabel(key), os.Getpid(), count, memberSum, balance, rawDiff, drift, sharedWalletDriftTolerance, orphanDetail)
 }
 

--- a/scheduler/shared_wallet_drift_alerts.go
+++ b/scheduler/shared_wallet_drift_alerts.go
@@ -232,9 +232,18 @@ func formatSharedWalletDriftAlert(key SharedWalletKey, balance, memberSum, drift
 	if len(orphanCoins) > 0 {
 		orphanDetail = "unattributed coins: " + strings.Join(orphanCoins, ", ")
 	}
+	// The "diff" in the alert is the BASELINE-ANCHORED drift (post-baseline
+	// change since the wallet was first reconciled). The displayed Σ member
+	// value vs balance, however, is the RAW reconciliation — those are the
+	// rows the operator sees. Showing raw diff (memberSum - balance) makes
+	// the alert self-consistent with the numbers above it. A large raw diff
+	// with a small baseline-anchored drift = legacy phantom ledger data
+	// adopted into the baseline at first contact (the alert is masked by
+	// design — see wallet_ledger_state.baseline_offset_usd).
+	rawDiff := memberSum - balance
 	return fmt.Sprintf(
-		"**SHARED-WALLET DRIFT** %s (pid=%d, %d consecutive): Σ member value $%.2f vs real balance $%.2f — diff $%+.2f exceeds $%.2f tolerance (%s). Exchange-derived rows should reconcile exactly; this indicates an attribution/accounting bug (orphan position or weighting).",
-		sharedWalletKeyLabel(key), os.Getpid(), count, memberSum, balance, drift, sharedWalletDriftTolerance, orphanDetail)
+		"**SHARED-WALLET DRIFT** %s (pid=%d, %d consecutive): Σ member value $%.2f vs real balance $%.2f — raw reconciliation diff $%+.2f, post-baseline drift $%+.2f (>$%.2f tolerance). %s. Exchange-derived rows should reconcile exactly; a large raw diff with a small post-baseline drift means legacy phantom ledger data is baked into the adopted baseline — values will re-reconcile once phantom rows are cleared.",
+		sharedWalletKeyLabel(key), os.Getpid(), count, memberSum, balance, rawDiff, drift, sharedWalletDriftTolerance, orphanDetail)
 }
 
 func formatSharedWalletDriftRecovered(key SharedWalletKey, priorCount int) string {
@@ -256,8 +265,9 @@ func reportSharedWalletDrift(notifier *MultiNotifier, results []sharedWalletDrif
 		label := sharedWalletKeyLabel(r.Key)
 		if math.Abs(r.Drift) > sharedWalletDriftTolerance {
 			shouldNotify, count := sharedWalletDriftTracker.Record(label, r.Drift, r.OrphanCoins, now)
-			fmt.Printf("[WARN] shared-wallet %s drift $%+.2f (Σ members $%.2f vs balance $%.2f, orphans=[%s])\n",
-				label, r.Drift, r.MemberSum, r.Balance, strings.Join(r.OrphanCoins, ","))
+			rawDiff := r.MemberSum - r.Balance
+			fmt.Printf("[WARN] shared-wallet %s drift $%+.2f (Σ members $%.2f vs balance $%.2f, rawDiff $%+.2f, orphans=[%s])\n",
+				label, r.Drift, r.MemberSum, r.Balance, rawDiff, strings.Join(r.OrphanCoins, ","))
 			if !shouldNotify || notifier == nil || !notifier.HasBackends() {
 				continue
 			}


### PR DESCRIPTION
## Summary

`forceCloseAllPositions` labeled any `pos.Multiplier>0` close as `futures` (the legacy OkxPerps/TopStep convention). HL perps and OKX perps carry `pos.Multiplier=1` as the canonical perps PnL valuation value (#254/#497 — NOT a contract multiplier), so every perps circuit-breaker / kill-switch close was recorded with the wrong `trade_type` label (`futures` instead of `perps`).

**Correction (was overstated in an earlier draft):** this label is cosmetic for accounting. `tradeLedgerDeltaSQL` (`trade_pnl.go:48`) computes a row's ledger contribution from `is_close` / `pnl_gross` / `realized_pnl` / `exchange_fee` only — it never reads `trade_type`. The sole `trade_type` filtering anywhere (`db.go:1695`, `db.go:1770`) excludes `scale_in`/`funding` from open-counting, not from value sums. So relabeling `futures`→`perps` leaves every `LedgerByID` sum, `displayStrategyValue`, and drift number byte-identical. This PR does **not** by itself change the drift math.

**What actually caused the live drift** (hyperliquid/0x736dD10faf3CaE88199Dab551dBe0713fe68cc86: Σ member value $2024.89 vs real balance $1149.76, $875.13 raw reconciliation diff): the rowid-54 `realized_pnl` corruption ($1074.52 vs the source-of-truth `closed_positions` value of $0.22) plus phantom close rows. Those were repaired by the out-of-band `state.db` mitigation below — not by the code in this diff. The mechanism that booked a force-close leg's `realized_pnl` ~4884× its `closed_positions` row is **not yet root-caused** (see Follow-up).

## What this PR changes (observability + correctness-of-label only)

- **Add `classifyPositionTradeType` helper**: HL perps / HL manual / OKX perps with `pos.Multiplier=1` → `perps`; TopStep / legacy futures keep `futures`; `pos.Multiplier=0` → `spot`. Makes future perps force-close rows carry an accurate label.
- **Wire `forceCloseAllPositions` through the helper.** PnL branch is unchanged (qty × multiplier × price_delta works for both perps and futures); only the label string differs.
- **Add `TestForceCloseAllPositions_TradeType_PerpsVsFutures`** pinning the per-platform label mapping.
- **Make `formatSharedWalletDriftAlert` show BOTH the raw reconciliation diff** (memberSum - balance, consistent with the numbers above it) **AND the post-baseline drift**, so an operator can distinguish new drift from legacy data baked into the adopted baseline.

## Live mitigation (applied to scheduler/state.db — not in this diff)

- Reclassify the 12 `futures` phantom trades on hl-rmc-eth-live / hl-tema-eth-live / manual-eth as `perps` (correct label, no PnL/ledger change).
- Fix trade rowid 54 `realized_pnl`: 1074.52 → 0.216 (matches the source-of-truth `closed_positions` row and the Details string 'PnL: $0.22'). Only rowid 54 had a `realized_pnl` vs `closed_positions` mismatch; the other 11 phantom trades' PnL was internally consistent. **This edit — not the relabel — is what removed the inflation.**
- Reset `wallet_ledger_state.baseline_set` to 0; new baseline re-anchors on the next reconcile at **+$199.17** (the remaining legacy cash adjustments, ~17% of balance — non-trivial but no longer dwarfed by the $1074 bug).

## Follow-up (root cause, not addressed here)

The source that booked rowid-54's `realized_pnl=1074.52` against a `closed_positions` row of 0.22 is unaddressed; if it is code rather than a one-off, drift can recur. Tracked in #1009 (perps close-leg quantity/PnL corruption) — acceptance criterion: a close leg's `realized_pnl` must reconcile with its `closed_positions` row across all close paths (signal + force-close), with a regression test.

## Test plan

- [x] `go test ./scheduler -run TestForceCloseAllPositions_TradeType_PerpsVsFutures`
- [x] `go test ./scheduler -run TestReconcile` (full reconcile + drift surface)
- [x] Deployed to live (pid 39970); cycle 119311 reports Total value $1148.16, no SHARED-WALLET DRIFT alerts after baseline re-anchor

## Reference only: LLM model used: MiniMax M3
