### PR TITLE
fix(#1009): cap partial-close qty + reconcile force-close PnL on corrupt positions

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -3126,7 +3126,10 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	// inherited a short position would otherwise see prevPosQty=posQty here
 	// while perpsLiveOrderSize sized it as a fresh open without that offset,
 	// leaving net_new_sz negative and the SL silently undersized (#421 review).
-	flipping := EffectiveDirection(sc) == DirectionBoth && posQty > 0 && ((result.Signal == 1 && posSide == "short") || (result.Signal == -1 && posSide == "long"))
+	// #1009: also require CloseFraction == 0 — a close action (any fraction > 0)
+	// is close-only, never a flip; the sizer's flip branch carries the same
+	// guard, so this mirror must too or prevPosQty diverges from the order size.
+	flipping := EffectiveDirection(sc) == DirectionBoth && posQty > 0 && result.CloseFraction == 0 && ((result.Signal == 1 && posSide == "short") || (result.Signal == -1 && posSide == "long"))
 	var cancelOID int64
 	if existingStopLossOID > 0 && posQty > 0 && !partialClose {
 		cancelOID = existingStopLossOID

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -3106,13 +3106,7 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	// only when there's nothing to flip into (never true here — flips always
 	// open a new side). Direction="short" + signal=-1 with orphan long is
 	// blocked by PerpsOrderSkipReason so it never reaches this code (#656).
-	pureClose := false
-	if result.Signal == -1 && posSide == "long" && !PerpsAllowsShort(sc) {
-		pureClose = true
-	}
-	if result.Signal == 1 && posSide == "short" && !PerpsAllowsLong(sc) {
-		pureClose = true
-	}
+	pureClose := perpsCloseActionSuppressesNewSL(result.Signal, posSide, PerpsAllowsLong(sc), PerpsAllowsShort(sc), result.CloseFraction)
 	// Partial close (#519): a fractional close from the open/close registry
 	// must NOT cancel the resting stop-loss — the SL is reduce-only and will
 	// continue to protect the residual position; cancelling without

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -171,6 +171,28 @@ func recordClosedPosition(s *StrategyState, pos *Position, closePrice, realizedP
 	})
 }
 
+// closePositionIsCorrupt reports whether a position's structural fields make a
+// qty*(price-avgCost) realized-PnL meaningless (#1009). A non-positive quantity
+// (e.g. the negative residual a mis-sized direction reversal used to leave) or a
+// non-positive average cost (a zeroed/garbage entry that books the full notional
+// as PnL — the ~4884x overstatement folded in from PR #1008) must never feed a
+// PnL booking. A force/flatten close on such a position has to clear it with a
+// zero-PnL leg rather than inject a phantom realized_pnl that diverges from its
+// closed_positions row and drives a persistent shared-wallet drift alert.
+func closePositionIsCorrupt(pos *Position) bool {
+	return pos == nil || pos.Quantity <= 0 || pos.AvgCost <= 0
+}
+
+// absQty returns the magnitude of a (possibly corrupt, possibly negative)
+// position quantity for display on a reconciliation/close leg without pulling in
+// the math package at these hot call sites.
+func absQty(q float64) float64 {
+	if q < 0 {
+		return -q
+	}
+	return q
+}
+
 // bookPerpsClose is the shared close-booking path for perps: computes PnL at
 // closePx, deducts the platform taker fee, credits s.Cash, records a close
 // Trade + ClosedPosition, and removes the virtual position. detailsPrefix is
@@ -199,6 +221,41 @@ func bookPerpsCloseWithFillFee(s *StrategyState, symbol string, closePx, fillFee
 	pos, ok := s.Positions[symbol]
 	if !ok || pos == nil {
 		return false
+	}
+	// #1009: an executable flatten/drain/kill-switch close must never compute
+	// PnL off a structurally-corrupt position. Clear it with a zero-PnL leg so
+	// the booked realized_pnl reconciles with the closed_positions row instead
+	// of inventing a number that drives shared-wallet drift alerts.
+	if closePositionIsCorrupt(pos) {
+		now := time.Now().UTC()
+		if logger != nil {
+			logger.Warn("%s: refusing to book PnL for corrupt position %s (qty=%.6f avg_cost=%.4f); clearing with zero realized PnL (#1009)", logPrefix, symbol, pos.Quantity, pos.AvgCost)
+		}
+		positionID := ensurePositionTradeID(s.ID, symbol, pos)
+		trade := Trade{
+			Timestamp:       now,
+			StrategyID:      s.ID,
+			Symbol:          symbol,
+			PositionID:      positionID,
+			Side:            closeTradeSide(pos.Side),
+			Quantity:        absQty(pos.Quantity),
+			Price:           closePx,
+			Value:           0,
+			TradeType:       "perps",
+			Details:         fmt.Sprintf("%s (corrupt position qty=%.6f avg_cost=%.4f) — zero PnL booked", detailsPrefix, pos.Quantity, pos.AvgCost),
+			IsClose:         true,
+			RealizedPnL:     0,
+			PnLGross:        true,
+			ExchangeOrderID: exchangeOrderIDForTrade(exchangeOrderID, useFillFee),
+			FeeSource:       FeeSourceModeled,
+		}
+		trade.Regime = s.Regime
+		RecordTrade(s, trade)
+		RecordTradeResult(&s.RiskState, 0)
+		recordClosedPosition(s, pos, closePx, 0, reason+"_corrupt", now)
+		delete(s.Positions, symbol)
+		clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
+		return true
 	}
 	// #954 one-fill-one-row: a FULL close whose OID already produced a close
 	// row for this strategy (a circuit-breaker force-close and the
@@ -816,7 +873,14 @@ func perpsLiveOrderSize(signal int, price, cash, posQty, avgCost, sizingLeverage
 	// ("long"/"short") never flips because the opposite-direction signal is
 	// either a close-only (long-only sell on long, short-only buy on short)
 	// or has already been rejected by PerpsOrderSkipReason.
-	flipping := direction == DirectionBoth && posQty > 0 && ((isBuy && posSide == "short") || (!isBuy && posSide == "long"))
+	//
+	// #1009: a flip must also require closeFraction == 0. Any closeFraction > 0
+	// is a close action from the open/close registry — closeOnlyAction in the
+	// executor (ExecutePerpsSignalWithLeverage) skips the open leg entirely, so
+	// the sizer must NOT size a (posQty + newSize) reversal here. Without this
+	// guard a fractional/full close under "both" placed a flip-sized order whose
+	// fill (> posQty) drove the executor's close leg negative.
+	flipping := direction == DirectionBoth && posQty > 0 && closeFraction == 0 && ((isBuy && posSide == "short") || (!isBuy && posSide == "long"))
 	// Fresh open: a buy from flat under any direction that allows longs, or
 	// a sell from flat under any direction that allows shorts. Buy + short
 	// position under "long"-direction is the legacy-migrated-short edge case
@@ -1067,6 +1131,14 @@ func executePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 				} else {
 					closeQty = pos.Quantity * closeFraction
 				}
+				// #1009 backstop: a flip-sized fill must never close more than
+				// the position holds — else pos.Quantity -= closeQty goes
+				// negative and realized_pnl is booked against the over-large
+				// fill qty. perpsLiveOrderSize no longer flip-sizes a close, but
+				// cap here defensively across every caller (paper, OKX, manual).
+				if closeQty > pos.Quantity {
+					closeQty = pos.Quantity
+				}
 			}
 			// Flip semantics only under direction="both"; "short"-direction
 			// closes the short terminally (no open-long follows), and the
@@ -1271,6 +1343,12 @@ func executePerpsSignalWithLeverage(s *StrategyState, signal int, symbol string,
 					closeQty = fillQty
 				} else {
 					closeQty = pos.Quantity * closeFraction
+				}
+				// #1009 backstop: see the symmetric close-short branch above —
+				// cap a flip-sized fill at the held quantity so the residual
+				// never goes negative and PnL is not overstated.
+				if closeQty > pos.Quantity {
+					closeQty = pos.Quantity
 				}
 			}
 			if bidirectional {

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -944,6 +944,40 @@ func perpsLiveOrderSize(signal int, price, cash, posQty, avgCost, sizingLeverage
 	return posQty, true, ""
 }
 
+// perpsCloseActionSuppressesNewSL reports whether a perps order is a close-only
+// action that opens no new position, so the HL execute path must NOT arm a new
+// reduce-only stop-loss (it may still cancel the existing one — that is gated
+// separately on !partialClose). It is the `pureClose` decision in
+// runHyperliquidExecuteOrder, extracted as a pure helper for testability.
+//
+// True when:
+//   - a directional gate closes only: signal=-1 on a long with shorts disallowed,
+//     or signal=1 on a short with longs disallowed (legacy long/short-only exits); or
+//   - a FULL close-action from the open/close registry (closeFraction == 1.0) —
+//     the executor's closeOnlyAction returns before any open leg, so no new side
+//     exists to protect. Before #1009 this case was masked by `flipping == true`
+//     (which set prev_pos_qty = posQty → net_new_sz = 0 → SL skipped); once the
+//     flip predicate correctly required closeFraction == 0, the suppression had
+//     to move here or a fresh SL leaked onto a just-closed position.
+//
+// False for a genuine reversal flip (direction="both", opposite side,
+// closeFraction == 0): that opens a new side and MUST arm its stop-loss. A
+// partial close (0 < frac < 1) is handled by the caller's separate partialClose
+// guard (which suppresses BOTH cancel and new-SL), so it is intentionally not
+// folded in here.
+func perpsCloseActionSuppressesNewSL(signal int, posSide string, allowsLong, allowsShort bool, closeFraction float64) bool {
+	if signal == -1 && posSide == "long" && !allowsShort {
+		return true
+	}
+	if signal == 1 && posSide == "short" && !allowsLong {
+		return true
+	}
+	if closeFraction == 1.0 {
+		return true
+	}
+	return false
+}
+
 // SpotOrderSkipReason mirrors PerpsOrderSkipReason for spot. ExecuteSpotSignal's
 // side-based skip branches ("already long, skipping buy" at signal=1,
 // "No long position to sell, skipping" at signal=-1) must be consulted BEFORE

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -2213,6 +2213,124 @@ func TestExecutePerpsSignal_PartialCloseLongLiveUsesFillQty(t *testing.T) {
 	}
 }
 
+// #1009 — a close action (closeFraction > 0) under direction="both" must NOT
+// flip-size the live order. perpsLiveOrderSize's flip branch ignored
+// closeFraction, so a fractional/full close on a "both" strategy sized the
+// order as (posQty + newSize) — a full reversal — while the executor treated
+// the same signal as close-only. The flip-sized fill then drove the close
+// leg's qty negative. The sizer must mirror closeOnlyAction: any closeFraction
+// > 0 is close-only, never a flip.
+func TestPerpsLiveOrderSize_CloseActionUnderBothDoesNotFlipSize(t *testing.T) {
+	cases := []struct {
+		name     string
+		signal   int
+		posSide  string
+		frac     float64
+		wantSize float64
+	}{
+		// long 0.4 @ 2000, sell partial 0.5 under "both" → 0.2, not a flip.
+		{"partial close long", -1, "long", 0.5, 0.2},
+		// short 0.4 @ 2000, buy partial 0.5 under "both" → 0.2, not a flip.
+		{"partial close short", 1, "short", 0.5, 0.2},
+		// final-tier full close (frac=1.0) under "both" → full posQty 0.4.
+		{"full close long", -1, "long", 1.0, 0.4},
+		{"full close short", 1, "short", 1.0, 0.4},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			size, ok, reason := perpsLiveOrderSize(tc.signal, 2000, 1000, 0.4, 2000, 1.0, 1.0, 0, tc.posSide, DirectionBoth, tc.frac)
+			if !ok {
+				t.Fatalf("expected ok, got reason=%q", reason)
+			}
+			if math.Abs(size-tc.wantSize) > 1e-9 {
+				t.Errorf("size = %g, want %g (close-only, must not flip-size posQty+newSize)", size, tc.wantSize)
+			}
+		})
+	}
+}
+
+// #1009 — a genuine flip (closeFraction == 0) under direction="both" must still
+// flip-size (posQty + newSize). Guards against the fix over-reaching and
+// breaking legitimate same-cycle reversals.
+func TestPerpsLiveOrderSize_GenuineFlipStillFlipSizes(t *testing.T) {
+	// long 0.4 @ 2000, sell reversal (frac=0) → posQty + newSize > posQty.
+	size, ok, _ := perpsLiveOrderSize(-1, 2000, 1000, 0.4, 2000, 1.0, 1.0, 0, "long", DirectionBoth, 0)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if size <= 0.4 {
+		t.Errorf("size = %g, want > 0.4 (flip = closeQty + newSize)", size)
+	}
+}
+
+// #1009 — backstop: even if a flip-sized fill (fillQty > pos.Quantity) reaches
+// the partial-close executor, closeQty must be capped at pos.Quantity so the
+// residual never goes negative and the close-leg PnL is not overstated.
+// Without the cap, pos.Quantity -= fillQty stored a negative-quantity position
+// and booked realized_pnl against the full (over-large) fill qty.
+func TestExecutePerpsSignal_PartialCloseCapsCloseQtyAtPosQuantity(t *testing.T) {
+	cases := []struct {
+		name    string
+		signal  int
+		posSide string
+	}{
+		{"close long oversized fill", -1, "long"},
+		{"close short oversized fill", 1, "short"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pos := &Position{
+				Symbol:          "ETH",
+				TradePositionID: "etrip-cap",
+				Quantity:        0.597,
+				InitialQuantity: 0.597,
+				AvgCost:         2000,
+				Side:            tc.posSide,
+				Multiplier:      1,
+				Leverage:        1,
+			}
+			s := &StrategyState{
+				ID:              "hl-cap",
+				Cash:            990,
+				Platform:        "hyperliquid",
+				Type:            "perps",
+				Positions:       map[string]*Position{"ETH": pos},
+				OptionPositions: make(map[string]*OptionPosition),
+				TradeHistory:    []Trade{},
+				RiskState:       RiskState{PeakValue: 1000},
+			}
+			lm, _ := NewLogManager("")
+			logger, _ := lm.GetStrategyLogger("test")
+			defer logger.Close()
+
+			// fillQty 1.192 simulates a flip-sized fill landing on the
+			// partial-close path (the pre-fix corruption scenario). Close at
+			// avgCost so the closed-leg PnL is ~0 — a capped close leg books
+			// ~0, an uncapped one would book against 1.192 qty.
+			_, err := ExecutePerpsSignalWithLeverage(s, tc.signal, "ETH", 2000, 1, 1, 0, 1.192, "oid", 0, DirectionBoth, 0.5, logger)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := s.Positions["ETH"]
+			if got == nil {
+				t.Fatal("position should remain (zero or residual), not be dropped")
+			}
+			if got.Quantity < 0 {
+				t.Errorf("Quantity = %g, must never be negative (cap closeQty at pos.Quantity)", got.Quantity)
+			}
+			if got.Quantity > 1e-9 {
+				t.Errorf("Quantity = %g, want ~0 (closeQty capped at 0.597 fully closes)", got.Quantity)
+			}
+			if len(s.TradeHistory) != 1 {
+				t.Fatalf("history = %d, want 1", len(s.TradeHistory))
+			}
+			if math.Abs(s.TradeHistory[0].Quantity-0.597) > 1e-9 {
+				t.Errorf("trade.Quantity = %g, want 0.597 (capped close leg, not 1.192)", s.TradeHistory[0].Quantity)
+			}
+		})
+	}
+}
+
 // #519 — paper partial close on a spot long must keep the position with
 // the residual quantity and realize PnL only on the closed slice.
 func TestExecuteSpotSignal_PartialCloseLongPaperPreservesRemainder(t *testing.T) {

--- a/scheduler/portfolio_test.go
+++ b/scheduler/portfolio_test.go
@@ -2331,6 +2331,47 @@ func TestExecutePerpsSignal_PartialCloseCapsCloseQtyAtPosQuantity(t *testing.T) 
 	}
 }
 
+// #1009 (PR #1010 review) — a full close-action (closeFraction == 1.0) under
+// direction="both" must suppress the NEW stop-loss; before this the corrected
+// flip predicate (flipping requires frac==0) flipped prev_pos_qty to 0 and a
+// fresh reduce-only stop leaked onto the just-closed position. Covers the
+// reviewer's must-survive cases on the pure SL-suppression decision.
+func TestPerpsCloseActionSuppressesNewSL(t *testing.T) {
+	cases := []struct {
+		name                    string
+		signal                  int
+		posSide                 string
+		allowsLong, allowsShort bool
+		frac                    float64
+		want                    bool
+	}{
+		// The reported regression: full close-action under "both" → suppress.
+		{"full close long under both", -1, "long", true, true, 1.0, true},
+		{"full close short under both", 1, "short", true, true, 1.0, true},
+		// Must survive (a): a genuine reversal flip (frac==0) opens a new side
+		// and MUST arm its SL → not suppressed.
+		{"flip long-to-short under both", -1, "long", true, true, 0, false},
+		{"flip short-to-long under both", 1, "short", true, true, 0, false},
+		// Must survive (c): a partial close is handled by the caller's separate
+		// partialClose guard, so the pure-close helper does NOT suppress here.
+		{"partial close under both not pureClose", -1, "long", true, true, 0.5, false},
+		// Legacy directional-gate close-only exits still suppress.
+		{"long-only sell on long", -1, "long", true, false, 0, true},
+		{"short-only buy on short", 1, "short", false, true, 0, true},
+		// A long-only fresh sell-from-flat shape (no short pos) is not a
+		// close-only here and should not suppress on its own.
+		{"both-direction long open arms SL", 1, "", true, true, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := perpsCloseActionSuppressesNewSL(tc.signal, tc.posSide, tc.allowsLong, tc.allowsShort, tc.frac)
+			if got != tc.want {
+				t.Errorf("perpsCloseActionSuppressesNewSL = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // #519 — paper partial close on a spot long must keep the position with
 // the residual quantity and realize PnL only on the closed slice.
 func TestExecuteSpotSignal_PartialCloseLongPaperPreservesRemainder(t *testing.T) {

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1142,8 +1142,25 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 		var pnl, value float64
 		tradeType := "spot"
 		if pos.Multiplier > 0 {
-			// Futures: PnL-based (contracts * multiplier * price delta)
 			tradeType = "futures"
+		}
+		reason := "circuit_breaker"
+		details := ""
+		// #1009: a force-close must never book PnL off a structurally-corrupt
+		// position. A non-positive quantity (the negative residual a mis-sized
+		// direction reversal used to leave) or a non-positive avg cost (a zeroed
+		// entry that books the full notional as PnL — the ~4884x overstatement
+		// folded in from PR #1008) makes qty*(price-avgCost) meaningless. Clear
+		// it with a zero-PnL leg and leave cash untouched so the booked
+		// realized_pnl reconciles with the closed_positions row.
+		if closePositionIsCorrupt(pos) {
+			reason = "circuit_breaker_corrupt"
+			details = fmt.Sprintf("Circuit breaker close %s (corrupt qty=%.6f avg_cost=%.4f) — zero PnL booked", pos.Side, pos.Quantity, pos.AvgCost)
+			if logger != nil {
+				logger.Warn("Circuit breaker: corrupt %s position %s (qty=%.6f avg_cost=%.4f) — booking zero realized PnL, not qty*(price-avgCost)", pos.Side, symbol, pos.Quantity, pos.AvgCost)
+			}
+		} else if pos.Multiplier > 0 {
+			// Futures/perps: PnL-based (contracts * multiplier * price delta)
 			if pos.Side == "long" {
 				pnl = pos.Quantity * pos.Multiplier * (price - pos.AvgCost)
 			} else {
@@ -1161,6 +1178,9 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 			s.Cash += pos.Quantity*pos.AvgCost - pos.Quantity*price
 			value = pos.Quantity * price
 		}
+		if details == "" {
+			details = fmt.Sprintf("Circuit breaker close %s, PnL: $%.2f", pos.Side, pnl)
+		}
 		if logger != nil {
 			logger.Warn("Circuit breaker: force-closing %s %s @ $%.2f (PnL: $%.2f)", pos.Side, symbol, price, pnl)
 		}
@@ -1171,11 +1191,11 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 			Symbol:            symbol,
 			PositionID:        positionID,
 			Side:              closeTradeSide(pos.Side),
-			Quantity:          pos.Quantity,
+			Quantity:          absQty(pos.Quantity),
 			Price:             price,
 			Value:             value,
 			TradeType:         tradeType,
-			Details:           fmt.Sprintf("Circuit breaker close %s, PnL: $%.2f", pos.Side, pnl),
+			Details:           details,
 			IsClose:           true,
 			RealizedPnL:       pnl,
 			PnLGross:          true, // no fee modeled on paper force-close: gross == net
@@ -1187,7 +1207,7 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 		}
 		RecordTrade(s, trade)
 		RecordTradeResult(&s.RiskState, pnl)
-		recordClosedPosition(s, pos, price, pnl, "circuit_breaker", now)
+		recordClosedPosition(s, pos, price, pnl, reason, now)
 		delete(s.Positions, symbol)
 		clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
 	}

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -805,6 +805,99 @@ func TestForceCloseAllPositionsRecordsDirectionalTradeSides(t *testing.T) {
 	}
 }
 
+// #1009 (acceptance criterion folded in from PR #1008): a force-close fired on
+// a structurally-corrupt position must NOT book an inflated realized_pnl. The
+// booked Trade.RealizedPnL must reconcile (within rounding) with its
+// closed_positions row, and cash must not absorb a phantom number. Covers both
+// corruption shapes the criterion calls out: a negative quantity (the mis-sized
+// reversal residual) and a zeroed avg cost (which booked ~full notional as PnL,
+// the ~4884x rowid-54 overstatement).
+func TestForceCloseAllPositions_CorruptPositionBooksZeroPnL(t *testing.T) {
+	cases := []struct {
+		name string
+		pos  *Position
+	}{
+		{"negative qty long", &Position{Symbol: "ETH", Quantity: -0.595, AvgCost: 2000, Side: "long", Multiplier: 1, Leverage: 1}},
+		{"negative qty short", &Position{Symbol: "ETH", Quantity: -0.595, AvgCost: 2000, Side: "short", Multiplier: 1, Leverage: 1}},
+		{"zero avg cost long", &Position{Symbol: "ETH", Quantity: 0.5, AvgCost: 0, Side: "long", Multiplier: 1, Leverage: 1}},
+		{"zero avg cost spot long", &Position{Symbol: "BTC", Quantity: 0.5, AvgCost: 0, Side: "long"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			startCash := 10000.0
+			s := &StrategyState{
+				ID:              "corrupt-strat",
+				Cash:            startCash,
+				Positions:       map[string]*Position{tc.pos.Symbol: tc.pos},
+				OptionPositions: map[string]*OptionPosition{},
+				TradeHistory:    []Trade{},
+				ClosedPositions: []ClosedPosition{},
+				RiskState:       RiskState{},
+			}
+
+			// price far from avgCost so a non-zero PnL WOULD be booked if the
+			// corrupt fields were used (e.g. 0.5 * 2150 = 1075, the rowid-54
+			// magnitude). The guard must keep it at zero.
+			forceCloseAllPositions(s, map[string]float64{tc.pos.Symbol: 2150}, nil)
+
+			if len(s.TradeHistory) != 1 {
+				t.Fatalf("TradeHistory len = %d, want 1", len(s.TradeHistory))
+			}
+			tr := s.TradeHistory[0]
+			if tr.RealizedPnL != 0 {
+				t.Errorf("Trade.RealizedPnL = %g, want 0 (corrupt position must book zero PnL)", tr.RealizedPnL)
+			}
+			if tr.Quantity < 0 {
+				t.Errorf("Trade.Quantity = %g, must not be negative", tr.Quantity)
+			}
+			if len(s.ClosedPositions) != 1 {
+				t.Fatalf("ClosedPositions len = %d, want 1", len(s.ClosedPositions))
+			}
+			cp := s.ClosedPositions[0]
+			// The invariant: the trade leg and the closed_positions row agree.
+			if math.Abs(tr.RealizedPnL-cp.RealizedPnL) > 1e-9 {
+				t.Errorf("Trade.RealizedPnL %g != ClosedPosition.RealizedPnL %g (must reconcile)", tr.RealizedPnL, cp.RealizedPnL)
+			}
+			if cp.CloseReason != "circuit_breaker_corrupt" {
+				t.Errorf("CloseReason = %q, want circuit_breaker_corrupt", cp.CloseReason)
+			}
+			if s.Cash != startCash {
+				t.Errorf("Cash = %g, want %g (no phantom PnL/proceeds credited)", s.Cash, startCash)
+			}
+			if _, ok := s.Positions[tc.pos.Symbol]; ok {
+				t.Error("corrupt position should be cleared")
+			}
+		})
+	}
+}
+
+// #1009: a healthy position force-close is unchanged — books true PnL and that
+// PnL reconciles with the closed_positions row. Guards the corrupt-path change
+// from leaking into the normal path.
+func TestForceCloseAllPositions_HealthyPositionReconciles(t *testing.T) {
+	s := &StrategyState{
+		ID:              "healthy-strat",
+		Cash:            10000,
+		Positions:       map[string]*Position{"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2000, Side: "long", Multiplier: 1, Leverage: 1}},
+		OptionPositions: map[string]*OptionPosition{},
+		TradeHistory:    []Trade{},
+		ClosedPositions: []ClosedPosition{},
+		RiskState:       RiskState{},
+	}
+	forceCloseAllPositions(s, map[string]float64{"ETH": 2100}, nil)
+	if len(s.TradeHistory) != 1 || len(s.ClosedPositions) != 1 {
+		t.Fatalf("history=%d closed=%d, want 1/1", len(s.TradeHistory), len(s.ClosedPositions))
+	}
+	wantPnL := 0.5 * (2100.0 - 2000.0) // 50
+	tr := s.TradeHistory[0]
+	if math.Abs(tr.RealizedPnL-wantPnL) > 1e-9 {
+		t.Errorf("Trade.RealizedPnL = %g, want %g", tr.RealizedPnL, wantPnL)
+	}
+	if math.Abs(tr.RealizedPnL-s.ClosedPositions[0].RealizedPnL) > 1e-9 {
+		t.Errorf("trade PnL %g != closed_positions PnL %g", tr.RealizedPnL, s.ClosedPositions[0].RealizedPnL)
+	}
+}
+
 // TestCheckPortfolioRisk_WarningFires verifies that drawdown at 80% of limit
 // triggers a warning on every call while the portfolio remains in the warning
 // band.


### PR DESCRIPTION
Closes #1009

## Problem

The reported negative-quantity corruption had two independent roots, both surfaced during validation/review of this issue.

### 1. Sizer-vs-executor intent mismatch (signal close path)

`perpsLiveOrderSize`'s `flipping` predicate ignored `CloseFraction`, so a fractional/full close on a `direction="both"` strategy sized a **full reversal** (`posQty + newSize`) while the executor (`executePerpsSignalWithLeverage`) treated `CloseFraction > 0` as close-only and returned **before** the open leg. The flip-sized fill (`> posQty`) then drove `pos.Quantity -= closeQty` negative, persisting a negative-quantity position that:

- is deleted on restart (`invalid quantity`, `state.go:180`), orphaning the on-chain position;
- is excluded from `buildSharedWalletBooks` (`Quantity > 0` filter), leaving uPnL unattributed;
- spams `SHARED-WALLET DRIFT` every cycle.

This only triggers under `direction="both"` (a directional gate never flip-sizes).

### 2. Force-close PnL overstatement (acceptance criterion folded in from PR #1008)

`forceCloseAllPositions` and the executable flatten/drain path (`bookPerpsCloseWithFillFee`) computed `qty*(price-avgCost)` off whatever fields the position carried. A corrupt position — negative quantity, or a zeroed avg cost that books the **full notional** as PnL (the ~4884x rowid-54 overstatement: `realized_pnl=1074.52` vs a `$0.22` closed-position row) — injected a phantom `realized_pnl` that diverged from its `closed_positions` row and drove a persistent drift alert.

## Fix

- **Flip requires `CloseFraction == 0`** in both `perpsLiveOrderSize` (`portfolio.go`) and the mirrored predicate (`main.go:3129`) — a close action is close-only, never a flip, so the sizer and executor agree on intent.
- **Backstop cap**: `closeQty` capped at `pos.Quantity` in both partial-close branches, across every caller (paper, OKX, manual).
- **Corrupt-position guard** (`closePositionIsCorrupt`): a force/flatten close on a structurally-corrupt position (`Quantity <= 0` or `AvgCost <= 0`) clears it with a **zero-PnL leg** (reason `*_corrupt`), leaving cash untouched, so the booked `realized_pnl` reconciles with the `closed_positions` row across `forceCloseAllPositions` (circuit-breaker + paper kill-switch) and `bookPerpsCloseWithFillFee` (live flatten/drain/kill-switch).

## Tests

- Sizer must not flip-size a close under `both` (both directions, partial and full close).
- Genuine flip (`frac == 0`) still flip-sizes.
- Executor caps an oversized fill — no negative residual, close-leg PnL uses capped qty.
- Force-close on corrupt positions (negative qty + zero avgcost, both directions) books zero **reconciled** PnL with no cash change; healthy force-close unchanged.

Full `go test ./scheduler/...` green.

## Reconciliation invariant (acceptance criterion)

> A close leg's booked `realized_pnl` reconciles with its `closed_positions` row (within rounding) across signal close, partial close, direction-reversal flip, and circuit-breaker/kill-switch force-close.

Holds: signal/partial/flip paths pass the same `pnl` to both the Trade and `recordClosedPosition`, and the cap prevents an over-large close qty; force/flatten paths refuse to book a divergent leg on a corrupt position.

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code