### PR TITLE
feat(backtest): #988 funding data + carry booking for delta_neutral_funding

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -1382,6 +1382,14 @@ class Backtester:
         )
         active_profile = ""
 
+        # #988: carry strategies (delta_neutral_funding) attach a per-bar
+        # `funding_accrual` column — the total funding rate accrued over the bar.
+        # When present, book it each bar against the position carried into the
+        # bar. Auto-detected so no construction-site plumbing is needed; other
+        # strategies' frames have no such column and are unaffected.
+        book_funding = "funding_accrual" in df.columns
+        total_funding_pnl = 0.0
+
         for i, (idx, row) in enumerate(df.iterrows()):
             fill_price = row["open"] if has_open else row["close"]
             mark_price = row["close"]
@@ -1409,6 +1417,22 @@ class Backtester:
             # trail_from_here path inside _maybe_apply_sl_after already seeds
             # the HWM at the partial-close fill price. See #715.
             sl_after_just_applied = False
+
+            # #988: book funding carry on the position carried into this bar,
+            # over this bar's interval, before marking equity to the close. A
+            # long pays funding when the rate is positive, a short receives it:
+            #   funding_cash = -position * mark * rate
+            # (position is signed: + long, - short), which lands in `cash` and
+            # flows into the close-marked equity below. Newly opened positions
+            # this bar start accruing next bar; closed positions stop after
+            # their last full bar — the standard discrete one-bar convention.
+            if book_funding and position != 0:
+                accrual = row.get("funding_accrual", 0.0)
+                accrual = float(accrual) if accrual == accrual else 0.0  # NaN→0
+                if accrual != 0.0:
+                    funding_cash = -position * mark_price * accrual
+                    cash += funding_cash
+                    total_funding_pnl += funding_cash
 
             equity = cash + position * mark_price
             equity_curve.append({"date": idx, "equity": equity})
@@ -1981,6 +2005,7 @@ class Backtester:
             "end_date": str(df.index[-1]),
             "initial_capital": self.initial_capital,
             "final_capital": round(final_equity, 2),
+            "total_funding_pnl": round(total_funding_pnl, 4),
             "params": open_ref.get("params") or params or {},
             "open_strategy": open_ref,
             "close_strategies": [dict(r) for r in self._close_refs],

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -24,13 +24,24 @@ from data_fetcher import load_cached_data
 # merge_asof backward — see shared_tools/funding_fetcher). Without it these
 # strategies are fail-safe flat, which silently zeroes the backtest, so the
 # attach failure warns loudly.
-FUNDING_COLUMN_STRATEGIES = {"funding_skew"}
+FUNDING_COLUMN_STRATEGIES = {"funding_skew", "delta_neutral_funding"}
+
+# Strategies whose PnL is carry, not price direction (#988): they additionally
+# get a `funding_accrual` column (total funding over each bar's interval), which
+# the Backtester books against the held position. Without booking the carry, a
+# delta-neutral funding strategy's result is meaningless (it shorts to collect
+# funding, so its edge lives entirely in the accrual the engine would otherwise
+# ignore). funding_skew is intentionally excluded — its edge is the price move
+# and its M1 baseline was established without accrual; adding it here would move
+# that baseline. See the issue for the (separate) follow-up.
+FUNDING_ACCRUAL_STRATEGIES = {"delta_neutral_funding"}
 
 
 def _attach_funding_if_needed(df, strategy_name, symbol, since):
     if strategy_name not in FUNDING_COLUMN_STRATEGIES or df.empty:
         return df
-    from funding_fetcher import attach_funding_column, load_cached_funding
+    from funding_fetcher import (attach_funding_accrual_column,
+                                 attach_funding_column, load_cached_funding)
     coin = symbol.split("/")[0]
     try:
         # Pass the data's actual window end so a repeat run over the same
@@ -48,6 +59,10 @@ def _attach_funding_if_needed(df, strategy_name, symbol, since):
               f"'{strategy_name}' will produce zero entries.")
     else:
         print(f"  Funding: {have}/{len(out)} bars covered (HL hourly, coin={coin})")
+    if strategy_name in FUNDING_ACCRUAL_STRATEGIES:
+        # Carry to book against the held position (timeframe-correct sum, not
+        # the signal snapshot). The engine auto-detects the column.
+        out = attach_funding_accrual_column(out, funding)
     return out
 from htf_filter import get_default_htf, apply_htf_filter  # noqa: E402
 from registry_loader import load_registry

--- a/backtest/tests/test_backtester_funding_accrual.py
+++ b/backtest/tests/test_backtester_funding_accrual.py
@@ -1,0 +1,131 @@
+"""#988: funding-carry booking in the engine.
+
+A ``funding_accrual`` column (total funding rate over each bar, attached for
+carry strategies like delta_neutral_funding) is booked each bar against the
+position carried into the bar:
+
+    funding_cash = -position * mark * accrual      (position signed: + long, - short)
+
+so a SHORT receives funding when the rate is positive and a LONG pays it. These
+tests pin the sign, magnitude, the one-bar open lag, NaN handling, and that
+strategies without the column are untouched.
+"""
+import sys
+import pathlib
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / "shared_tools"))
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from backtester import Backtester
+
+
+def _df(signals, accrual=None, price=100.0, n=6):
+    closes = np.full(n, float(price))
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame(
+        {
+            "open": closes,
+            "high": closes + 0.5,
+            "low": closes - 0.5,
+            "close": closes,
+            "volume": np.full(n, 1000.0),
+            "signal": np.asarray(signals, dtype=float),
+        },
+        index=idx,
+    )
+    if accrual is not None:
+        df["funding_accrual"] = np.asarray(accrual, dtype=float)
+    return df
+
+
+def _run(df, **kw):
+    kw.setdefault("commission_pct", 0.0)
+    kw.setdefault("slippage_pct", 0.0)
+    bt = Backtester(initial_capital=10000.0, **kw)
+    return bt.run(df.copy(), strategy_name="x", symbol="BTC/USDT",
+                  timeframe="1d", save=False)
+
+
+# ─── Short collects positive funding ──────────────────────────────────────────
+
+
+def test_short_collects_positive_funding_on_flat_price():
+    # Short opens at bar1 (signal at bar0 fills bar1 open), held to end of data.
+    # Price flat → zero price PnL → the entire return is collected funding.
+    # Funding accrues on the carried-in position: bars 2..5 (4 bars), the open
+    # bar (1) accrues nothing. notional=10000, accrual=1e-3 → +10/bar → +40.
+    df = _df([-1, 0, 0, 0, 0, 0], accrual=[1e-3] * 6)
+    res = _run(df, direction="short")
+    assert res["total_funding_pnl"] == pytest.approx(40.0)
+    assert res["final_capital"] == pytest.approx(10040.0)
+
+
+def test_short_pays_negative_funding():
+    # Negative funding = shorts pay longs → the short bleeds carry.
+    df = _df([-1, 0, 0, 0, 0, 0], accrual=[-1e-3] * 6)
+    res = _run(df, direction="short")
+    assert res["total_funding_pnl"] == pytest.approx(-40.0)
+    assert res["final_capital"] == pytest.approx(9960.0)
+
+
+# ─── Long is the mirror ───────────────────────────────────────────────────────
+
+
+def test_long_pays_positive_funding():
+    # Long pays funding when the rate is positive → flat-price return is the
+    # negated carry of the short case.
+    df = _df([1, 0, 0, 0, 0, 0], accrual=[1e-3] * 6)
+    res = _run(df, direction=None)
+    assert res["total_funding_pnl"] == pytest.approx(-40.0)
+    assert res["final_capital"] == pytest.approx(9960.0)
+
+
+# ─── Lag, NaN, opt-in ─────────────────────────────────────────────────────────
+
+
+def test_open_bar_accrues_nothing_one_interval_one_charge():
+    # The open bar accrues nothing (position not yet carried in); each carried
+    # interval is one charge. Open at bar1 (signal at bar0), close at bar2
+    # (signal +1 at bar1) → held over exactly one interval (1,2] → one charge.
+    df = _df([-1, 1, 0, 0, 0, 0], accrual=[1e-3] * 6)
+    res = _run(df, direction="short")
+    assert res["total_trades"] == 1
+    assert res["total_funding_pnl"] == pytest.approx(10.0)
+
+
+def test_charge_count_equals_intervals_held():
+    # Open bar1, close bar3 (signal +1 at bar2) → intervals (1,2] and (2,3] →
+    # two charges. Pins that the close bar still accrues (closed at its open,
+    # after the top-of-bar booking on the carried-in position).
+    df = _df([-1, 0, 1, 0, 0, 0], accrual=[1e-3] * 6)
+    res = _run(df, direction="short")
+    assert res["total_trades"] == 1
+    assert res["total_funding_pnl"] == pytest.approx(20.0)
+
+
+def test_nan_accrual_is_ignored():
+    # A NaN funding bar must not corrupt cash (treated as 0 carry).
+    df = _df([-1, 0, 0, 0, 0, 0], accrual=[1e-3, 1e-3, np.nan, 1e-3, 1e-3, 1e-3])
+    res = _run(df, direction="short")
+    # bars 2..5 carry funding; bar2 is NaN→0, bars 3,4,5 = +10 each → +30.
+    assert res["total_funding_pnl"] == pytest.approx(30.0)
+    assert np.isfinite(res["final_capital"])
+
+
+def test_no_funding_column_books_nothing():
+    df = _df([-1, 0, 0, 1, 0, 0])  # no funding_accrual column
+    res = _run(df, direction="short")
+    assert res["total_funding_pnl"] == 0.0
+
+
+def test_funding_not_booked_while_flat():
+    # All-flat signals → never in a position → no funding booked despite a
+    # populated accrual column.
+    df = _df([0, 0, 0, 0, 0, 0], accrual=[1e-3] * 6)
+    res = _run(df, direction="short")
+    assert res["total_funding_pnl"] == 0.0
+    assert res["final_capital"] == pytest.approx(10000.0)

--- a/shared_strategies/open/futures/test_strategies.py
+++ b/shared_strategies/open/futures/test_strategies.py
@@ -508,6 +508,60 @@ class TestDeltaNeutralFunding:
                        {"avg_funding_rate_7d": 0.0})
         assert (result["signal"] == 0).all()
 
+    # ── #988: per-bar funding-column path (backtest) ──
+    # A 4h DatetimeIndex makes the 7d window 42 bars, so warmup is the first 41
+    # bars; signals begin at bar 41.
+
+    @staticmethod
+    def _series_df(funding_values, freq="4h"):
+        n = len(funding_values)
+        idx = pd.date_range("2026-01-01", periods=n, freq=freq, tz="UTC")
+        df = make_ohlcv(make_flat(n), index=idx)
+        df["funding_rate"] = np.asarray(funding_values, dtype=float)
+        return df
+
+    def test_series_shorts_after_full_window_when_funding_rich(self):
+        df = self._series_df([0.0005] * 60)  # > entry_threshold every hour
+        out = apply_strategy("delta_neutral_funding", df,
+                             {"entry_threshold": 0.0001, "exit_threshold": 0.00005})
+        assert (out["signal"].iloc[:41] == 0).all()   # warmup, no full window yet
+        assert out["signal"].iloc[41] == -1
+        assert out["signal"].iloc[-1] == -1
+
+    def test_series_exits_when_funding_cheap(self):
+        df = self._series_df([0.00003] * 60)  # < exit_threshold
+        out = apply_strategy("delta_neutral_funding", df,
+                             {"entry_threshold": 0.0001, "exit_threshold": 0.00005})
+        assert out["signal"].iloc[-1] == 1
+
+    def test_series_holds_in_hysteresis_band(self):
+        df = self._series_df([0.00007] * 60)  # between exit and entry
+        out = apply_strategy("delta_neutral_funding", df,
+                             {"entry_threshold": 0.0001, "exit_threshold": 0.00005})
+        assert (out["signal"] == 0).all()
+
+    def test_series_warmup_waits_for_full_window_of_real_data(self):
+        # NaN funding (pre-listing) for the first 10 bars, then rich funding.
+        # A full 42-bar non-NaN window completes at bar 10+41 = 51.
+        df = self._series_df([np.nan] * 10 + [0.0005] * 50)
+        out = apply_strategy("delta_neutral_funding", df,
+                             {"entry_threshold": 0.0001, "exit_threshold": 0.00005})
+        assert (out["signal"].iloc[:51] == 0).all()
+        assert out["signal"].iloc[51] == -1
+
+    def test_series_column_overrides_live_scalar(self):
+        # Presence of the per-bar column takes the series path even if a live
+        # scalar avg is also supplied (the scalar is the live-only input).
+        df = self._series_df([0.0005] * 60)
+        out = apply_strategy("delta_neutral_funding", df,
+                             {"avg_funding_rate_7d": 0.0})
+        assert out["signal"].iloc[-1] == -1
+
+    def test_series_signals_are_valid(self):
+        df = self._series_df([0.0005] * 30 + [0.00001] * 30)
+        out = apply_strategy("delta_neutral_funding", df)
+        assert set(out["signal"].unique()).issubset({-1, 0, 1})
+
 
 # ─── Chart Pattern (wrapper) ────────────────
 

--- a/shared_strategies/open/registry.py
+++ b/shared_strategies/open/registry.py
@@ -947,6 +947,27 @@ def adx_trend_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
     return adx_trend_core(df, **params)
 
 
+# Trailing window for the delta_neutral_funding average, in days. Named "7d" in
+# the strategy description and the live scalar (avg_funding_rate_7d); kept as a
+# module constant rather than a registered param so the registry's --list-json
+# output (and Go's discoverStrategies) stays byte-identical (#988).
+_DELTA_FUNDING_WINDOW_DAYS = 7.0
+
+
+def _funding_window_bars(index: pd.Index) -> int:
+    """Bars spanning the funding window, inferred from the index spacing so the
+    average is the same ~7 days regardless of timeframe (168 1h bars, 42 4h
+    bars). Falls back to hourly when spacing can't be inferred."""
+    bar_hours = 1.0
+    if isinstance(index, pd.DatetimeIndex) and len(index) >= 2:
+        deltas = index.to_series().diff().dropna()
+        if not deltas.empty:
+            secs = deltas.median().total_seconds()
+            if secs and secs > 0:
+                bar_hours = secs / 3600.0
+    return max(1, int(round(_DELTA_FUNDING_WINDOW_DAYS * 24.0 / bar_hours)))
+
+
 @register(
     "delta_neutral_funding",
     "Delta-Neutral Funding \u2014 enter when 7d avg funding rate exceeds threshold, exit when below",
@@ -960,17 +981,48 @@ def delta_neutral_funding_strategy(df: pd.DataFrame,
                                    drift_threshold: float = 2.0,
                                    current_funding_rate: float = 0.0,
                                    avg_funding_rate_7d: float = 0.0) -> pd.DataFrame:
+    """SHORT the perp to collect funding when the trailing 7d-average funding
+    rate is rich; exit when it decays. Positive funding = longs pay shorts (#102).
+
+    Two input paths:
+
+    * **Backtest** — when a per-bar ``funding_rate`` column is attached (#988,
+      ``FUNDING_COLUMN_STRATEGIES``), the trailing average is computed from it
+      and a *per-bar* signal series is emitted, so the engine can replay
+      entries/exits across the whole window. The 7d window is converted to a
+      bar count from the index spacing (timeframe-correct) and requires a full
+      window before any signal (warmup → 0), mirroring the live 7d average.
+    * **Live / paper** — when no column is present, the scalar
+      ``avg_funding_rate_7d`` injected by ``check_hyperliquid.py`` drives a
+      single decision on the latest bar (unchanged behavior).
+    """
     result = df.copy()
+    result["delta_drift_pct"] = 0.0
+    result["rebalance_needed"] = 0.0
+
+    has_series = "funding_rate" in df.columns and pd.to_numeric(
+        df["funding_rate"], errors="coerce").notna().any()
+    if has_series:
+        funding = pd.to_numeric(df["funding_rate"], errors="coerce")
+        window_bars = _funding_window_bars(result.index)
+        avg = funding.rolling(window_bars, min_periods=window_bars).mean()
+        result["funding_rate"] = funding
+        result["avg_funding_7d"] = avg
+        result["funding_apy"] = avg * 24 * 365 * 100  # HL funding is hourly
+        sig = pd.Series(0, index=result.index, dtype=int)
+        sig[avg > entry_threshold] = -1   # enter / hold short to collect
+        sig[avg < exit_threshold] = 1     # exit short
+        sig[avg.isna()] = 0               # warmup / missing funding → no signal
+        result["signal"] = sig.values
+        return result
+
     avg = avg_funding_rate_7d
     result["funding_rate"] = current_funding_rate
     result["avg_funding_7d"] = avg
     result["funding_apy"] = avg * 3 * 365 * 100
-    result["delta_drift_pct"] = 0.0
-    result["rebalance_needed"] = 0.0
     result["signal"] = 0
     if avg == 0.0:
         return result
-    # Positive avg funding = longs pay shorts → SHORT perp to collect (#102)
     if avg > entry_threshold:
         result.iloc[-1, result.columns.get_loc("signal")] = -1  # enter short
     elif avg < exit_threshold:

--- a/shared_tools/funding_fetcher.py
+++ b/shared_tools/funding_fetcher.py
@@ -16,6 +16,7 @@ import sys
 import time
 from typing import Optional
 
+import numpy as np
 import pandas as pd
 
 from storage import (
@@ -124,4 +125,45 @@ def attach_funding_column(df: pd.DataFrame, funding: pd.DataFrame) -> pd.DataFra
     }).sort_values("ts")
     merged = pd.merge_asof(left, right, on="ts", direction="backward")
     out["funding_rate"] = merged["funding_rate"].values
+    return out
+
+
+def attach_funding_accrual_column(df: pd.DataFrame, funding: pd.DataFrame) -> pd.DataFrame:
+    """Attach a ``funding_accrual`` column: the TOTAL funding rate accrued over
+    each bar's holding interval — the sum of the hourly funding snapshots in
+    ``(previous_bar, this_bar]`` (#988).
+
+    This is distinct from ``attach_funding_column``: that returns a
+    point-in-time snapshot used as a *signal* input (the current rate level);
+    this returns the per-bar *carry* to BOOK against a held position. It is
+    timeframe-correct — a 4h bar sums the ~4 hourly funding events inside it
+    where the snapshot would capture only one. Purely backward-looking (a bar's
+    accrual covers the closed interval ending at the bar), preserving the
+    look-ahead invariant. The first bar (and any bar before the first funding
+    event) accrues 0.0.
+    """
+    out = df.copy()
+    if funding is None or funding.empty or len(out) == 0:
+        out["funding_accrual"] = 0.0
+        return out
+
+    bar_ts = pd.to_datetime(out.index)
+    if bar_ts.tz is None:
+        bar_ts = bar_ts.tz_localize("UTC")
+    bar_ts = bar_ts.tz_convert("UTC")
+
+    f_ts = pd.to_datetime(funding["timestamp"], unit="ms", utc=True)
+    order = np.argsort(f_ts.values)
+    ev_t = f_ts.values[order]
+    ev_cum = np.cumsum(funding["rate"].astype(float).values[order])
+
+    bt = bar_ts.values
+    # Count of funding events at or before each bar (right-closed interval),
+    # then the cumulative funding up to that point.
+    pos = np.searchsorted(ev_t, bt, side="right")
+    cum_at_bar = np.where(pos > 0, ev_cum[np.clip(pos - 1, 0, len(ev_cum) - 1)], 0.0)
+
+    accrual = np.zeros(len(bt), dtype=float)
+    accrual[1:] = cum_at_bar[1:] - cum_at_bar[:-1]
+    out["funding_accrual"] = accrual
     return out

--- a/shared_tools/test_funding_fetcher.py
+++ b/shared_tools/test_funding_fetcher.py
@@ -6,10 +6,15 @@ import tempfile
 
 import numpy as np
 import pandas as pd
+import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from funding_fetcher import attach_funding_column, load_cached_funding  # noqa: E402
+from funding_fetcher import (  # noqa: E402
+    attach_funding_accrual_column,
+    attach_funding_column,
+    load_cached_funding,
+)
 
 _HOUR_MS = 3_600_000
 _BASE_MS = int(pd.Timestamp("2026-01-01", tz="UTC").timestamp() * 1000)
@@ -191,3 +196,60 @@ def test_attach_tz_naive_bars():
     f = _funding_frame([_BASE_MS], [3e-5])
     out = attach_funding_column(df, f)
     assert out["funding_rate"].iloc[0] == 3e-5
+
+
+# ---- funding accrual (#988) ----
+
+def test_accrual_1h_is_per_bar_event():
+    """On 1h bars each bar accrues the single hourly funding event landing in
+    its (prev, this] interval; the first bar accrues nothing."""
+    df = _bars(4, freq="1h")
+    rates = [1e-5, 2e-5, 3e-5, 4e-5]
+    times = [_BASE_MS + i * _HOUR_MS for i in range(4)]
+    out = attach_funding_accrual_column(df, _funding_frame(times, rates))
+    acc = out["funding_accrual"].tolist()
+    assert acc[0] == 0.0
+    assert acc[1] == pytest.approx(2e-5)
+    assert acc[2] == pytest.approx(3e-5)
+    assert acc[3] == pytest.approx(4e-5)
+
+
+def test_accrual_4h_sums_the_interval():
+    """A 4h bar accrues the SUM of the ~4 hourly events inside it — the whole
+    point of accrual vs the signal snapshot (which would take only one)."""
+    df = _bars(3, freq="4h")
+    times = [_BASE_MS + i * _HOUR_MS for i in range(9)]  # 00:00..08:00
+    rates = [1e-5] * 9
+    out = attach_funding_accrual_column(df, _funding_frame(times, rates))
+    acc = out["funding_accrual"].tolist()
+    assert acc[0] == 0.0
+    assert acc[1] == pytest.approx(4e-5)  # events in (00:00, 04:00]
+    assert acc[2] == pytest.approx(4e-5)  # events in (04:00, 08:00]
+
+
+def test_accrual_total_equals_held_funding():
+    """Summed accrual over the held span equals the total funding paid — the
+    invariant the engine relies on to book carry without double-count or gap."""
+    df = _bars(5, freq="1h")
+    times = [_BASE_MS + i * _HOUR_MS for i in range(5)]
+    rates = [1e-5, 2e-5, 3e-5, 4e-5, 5e-5]
+    out = attach_funding_accrual_column(df, _funding_frame(times, rates))
+    # Held from bar0 through bar4 → accrues events at bars 1..4.
+    assert out["funding_accrual"].sum() == pytest.approx(2e-5 + 3e-5 + 4e-5 + 5e-5)
+
+
+def test_accrual_empty_funding_is_zero():
+    assert (attach_funding_accrual_column(_bars(3), None)["funding_accrual"] == 0.0).all()
+    empty = attach_funding_accrual_column(_bars(3), _funding_frame([], []))
+    assert (empty["funding_accrual"] == 0.0).all()
+
+
+def test_accrual_event_at_bar_is_right_closed():
+    """An event landing exactly on a bar timestamp belongs to that bar's
+    interval (right-closed), not the next."""
+    df = _bars(3, freq="1h")
+    out = attach_funding_accrual_column(
+        df, _funding_frame([_BASE_MS + _HOUR_MS], [9e-5]))  # exactly at bar1
+    acc = out["funding_accrual"].tolist()
+    assert acc[1] == pytest.approx(9e-5)
+    assert acc[2] == 0.0


### PR DESCRIPTION
Closes #988

## Problem

The audit could not evaluate `delta_neutral_funding` (0 trades). Validated against `main`, the cause was two-fold, not just "no funding data":

1. The backtest path attached a per-bar `funding_rate` column only for `funding_skew` (`run_backtest.py`), never delta.
1. The strategy was structurally un-backtestable: it read **scalar** funding params and emitted a signal **only on the last bar** (`registry.py`), so even with a column attached it produced at most one terminal signal.
1. The engine booked only price PnL — `backtester.py` had zero funding awareness, so the strategy's entire carry edge was invisible.

## Changes

- **Strategy (`registry.py`)** — when a per-bar `funding_rate` column is present (backtest), compute the trailing 7d-average funding and emit a **per-bar** short/exit signal series; the 7d window is inferred from index spacing so it's the same ~7 days on 1h and 4h bars, with full-window warmup gating early signals. The **live/paper scalar path is preserved unchanged** (no column → last-bar decision). No registered params added, so `--list-json` stays byte-identical.
- **Plumbing (`run_backtest.py`, `funding_fetcher.py`)** — add `delta_neutral_funding` to `FUNDING_COLUMN_STRATEGIES` (reuses the #960 fetch/cache) and attach a new **timeframe-correct** `funding_accrual` column: the sum of hourly funding over each bar's interval, backward-looking (preserves the look-ahead invariant; a 4h bar sums its ~4 hourly events where the signal snapshot would take one).
- **Engine (`backtester.py`)** — auto-detect `funding_accrual` and book carry each bar against the position carried in: `funding_cash = -position * mark * rate` (a short receives positive funding, a long pays it). Opt-in via column presence, so no other strategy is touched; `funding_skew` intentionally excluded to preserve its established M1 baseline. Surfaces `total_funding_pnl` in results.

## Tests

- Accrual column: 1h per-bar, 4h interval-sum, right-closed boundary, total-equals-held invariant, empty-funding.
- Strategy series path: warmup gating, hysteresis hold band, column-overrides-live-scalar, valid signals; existing scalar tests unchanged.
- Engine booking: short collects/pays, long mirror, one-bar open lag, NaN-safe, no-column no-op, flat no-op.
- Full Python suite green (1569 passed; 19 new tests across the three areas).

## Follow-up (not in this PR)

The first M1 baseline run itself — `eval_windows.py --strategy delta_neutral_funding --registry futures --direction short` on the protocol windows — needs network funding fetch; this PR lands the tooling + carry model that unblocks it. Per the verdict gate in #988: bottom-tier → deprecate; mid-tier or better → open an M1 application child.

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code