### PR TITLE
fix(#1012): extension-based .db protection in gitignore + update.sh rsync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 __pycache__/
 *.pyc
 *.pyo
+# State databases — never commit. Generic *.db plus the SQLite sidecar/lock
+# globs so a renamed or per-instance DB at any path stays protected (#1012).
+*.db
 trading_bot.db
 *.db-wal
 *.db-shm

--- a/scripts/test_update_helpers.sh
+++ b/scripts/test_update_helpers.sh
@@ -69,4 +69,19 @@ assert_eq "$(update_should_sweep_proc go-trader /opt/go-trader '')" \
 assert_eq "$(update_should_sweep_proc go-trader '' /opt/go-trader)" \
     "" "unreadable proc cwd -> spare"
 
+# --- #1012: extension-based DB rsync excludes --------------------------------
+db_globs=$(update_db_rsync_excludes)
+assert_eq "$db_globs" $'*.db\n*.db-wal\n*.db-shm\n*.db.lock' \
+    "db rsync excludes emit the full .db family, one glob per line"
+# Globs must be unanchored (no leading slash) so rsync matches at any depth.
+if printf '%s\n' "$db_globs" | grep -q '^/'; then
+    echo "FAIL: db rsync globs must be unanchored (no leading slash)" >&2
+    exit 1
+fi
+# Each suffix is distinct: *.db must NOT cover *.db-wal / *.db.lock (different
+# trailing chars), which is why all four globs are required.
+case "stale_instance.db" in *.db) ;; *) echo "FAIL: *.db should match stale_instance.db" >&2; exit 1;; esac
+case "state.db-wal" in *.db) echo "FAIL: *.db must not match state.db-wal" >&2; exit 1;; esac
+case "state.db.lock" in *.db) echo "FAIL: *.db must not match state.db.lock" >&2; exit 1;; esac
+
 echo "OK: update_helpers tests passed"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -399,6 +399,15 @@ run_rsync_from() {
         --exclude='scheduler/config.json'
         --exclude="${db_excl}*"
         --exclude='trading_bot.db*'
+    )
+    # Extension-based DB protection (#1012): any *.db (+ SQLite sidecar/lock) at
+    # any path survives --delete, even if it isn't the config-resolved db_file.
+    # db_excl above stays as belt-and-suspenders for non-.db-suffixed DB paths.
+    local db_glob
+    while IFS= read -r db_glob; do
+        [[ -n "$db_glob" ]] && rsync_excludes+=(--exclude="$db_glob")
+    done < <(update_db_rsync_excludes)
+    rsync_excludes+=(
         --exclude='.venv/'
         --exclude='node_modules/'
         --exclude='__pycache__/'
@@ -750,6 +759,10 @@ if [[ -n "$rsync_from" ]]; then
     end_phase
 else
     begin_phase pull
+    # DB protection on the pull path (#1012): a fast-forward only advances tracked
+    # files. Every *.db is gitignored (untracked), and git never overwrites or
+    # deletes untracked/ignored files on a fast-forward, so state DBs at any path
+    # survive `pull --ff-only` unchanged — the guarantee is explicit, not incidental.
     git pull --ff-only
     post_pull_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
     if [[ -n "$pre_pull_sha" && -n "$post_pull_sha" && "$pre_pull_sha" != "$post_pull_sha" ]]; then

--- a/scripts/update_helpers.sh
+++ b/scripts/update_helpers.sh
@@ -72,3 +72,13 @@ update_should_sweep_proc() {
     [[ -n "$repo_abs" && "$pid_cwd" == "$repo_abs" ]] || { printf ''; return 0; }
     printf 'sweep'
 }
+
+# Static, extension-based DB rsync excludes (#1012). Emits one glob per line so
+# any .db / SQLite sidecar / lock file at ANY path survives --rsync-from's
+# --delete, independent of the config-resolved db_file. These globs are
+# unanchored (no leading slash), so rsync matches them at every directory depth.
+# Defense-in-depth: run_rsync_from still adds the config-resolved db_excl for
+# DBs whose name doesn't end in .db. Keep in sync with .gitignore's *.db family.
+update_db_rsync_excludes() {
+    printf '%s\n' '*.db' '*.db-wal' '*.db-shm' '*.db.lock'
+}


### PR DESCRIPTION
## Summary
State databases were protected by enumerated filename only, so a renamed or per-instance `.db` at an arbitrary path silently fell outside both safeguards — trackable by git and `--delete`'d/overwritten by `--rsync-from`. This makes DB protection extension-based and defense-in-depth.

## Changes
1. **`.gitignore`** — add generic `*.db` (keep existing named entries + WAL/SHM/lock globs). No currently-tracked `.db` (`git ls-files | grep '\.db'` is empty).
2. **`scripts/update_helpers.sh`** — new pure helper `update_db_rsync_excludes` emitting the static `*.db` / `*.db-wal` / `*.db-shm` / `*.db.lock` globs (unanchored → rsync matches at any depth).
3. **`scripts/update.sh`** — `run_rsync_from` appends those globs; the config-resolved `db_excl` stays as belt-and-suspenders for non-`.db`-suffixed paths. Inline comment documents that `pull --ff-only` never touches untracked/ignored files (guarantee made explicit, not incidental).
4. **`scripts/test_update_helpers.sh`** — regression test asserting the full glob set, unanchored form, and that `*.db` deliberately does **not** cover `.db-wal`/`.db.lock` (why all four globs are required).

## Verification
- `bash -n` clean; `test_update_helpers.sh` → `OK`; Go `TestUpdateShell*`/`TestUpdateHelpers*` → `ok`.
- `git check-ignore` matches a `.db` at nested arbitrary paths.
- Functional rsync test: stray `.db`/`.db-wal`/`.db.lock` at root **and** nested `instances/i2/per_instance.db` all survived `--delete`, while source code synced normally.

## Acceptance
- ✅ A `.db` at an arbitrary path is git-ignored and survives both `--rsync-from` and `pull --ff-only`.
- ✅ Existing named exclusions (`trading_bot.db` / configured `db_file`) remain — no regression.

Closes #1012

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code