### PR TITLE
[codex] Fix paper regime trailing SL snapshot

### DIFF
--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -1798,6 +1798,40 @@ func TestRunHyperliquidTrailingStopPaper(t *testing.T) {
 	}
 }
 
+func TestRunHyperliquidTrailingStopPaper_RegimeSnapshotArms(t *testing.T) {
+	regimeBlock := &RegimeATRBlock{TrendRegime: map[string]RegimeATREntry{
+		"trending": {ATR: 2.0},
+		"ranging":  {ATR: 1.0},
+	}}
+	sc := StrategyConfig{
+		ID:                    "hl-regime-paper",
+		Platform:              "hyperliquid",
+		Type:                  "perps",
+		RegimeATRWindow:       "medium",
+		TrailingStopATRRegime: regimeBlock,
+	}
+	pos := &Position{
+		AvgCost:         2100,
+		EntryATR:        50,
+		RiskAnchorPrice: 2000,
+		Regime:          "ranging",
+		RegimeWindows:   map[string]string{"medium": "trending"},
+	}
+
+	incomplete := &Position{AvgCost: pos.AvgCost, EntryATR: pos.EntryATR}
+	_, gotTrig, gotBreach, gotPx := runHyperliquidTrailingStopPaper(sc, "long", incomplete, 2000, 0, 0)
+	if gotTrig != 0 || gotBreach || gotPx != 0 {
+		t.Fatalf("incomplete snapshot unexpectedly armed: trig=%v breach=%v px=%v", gotTrig, gotBreach, gotPx)
+	}
+
+	snapshot := hyperliquidProtectionPositionSnapshot(pos)
+	gotHW, gotTrig, gotBreach, gotPx := runHyperliquidTrailingStopPaper(sc, "long", snapshot, 2000, 0, 0)
+	if !approxEq(gotHW, 2000) || !approxEq(gotTrig, 1900) || gotBreach || gotPx != 0 {
+		t.Fatalf("regime snapshot paper trail = (hw=%v trig=%v breach=%v px=%v), want (2000, 1900, false, 0)",
+			gotHW, gotTrig, gotBreach, gotPx)
+	}
+}
+
 // #532: paper-mode trailing stop close must operate only on the strategy's
 // own virtual position. Two strategies on the same symbol with independent
 // StrategyState maps must remain isolated when one breaches.

--- a/scheduler/hyperliquid_trailing_stop.go
+++ b/scheduler/hyperliquid_trailing_stop.go
@@ -15,6 +15,29 @@ var (
 	hlTrailingUpdateLocks   = make(map[string]*sync.Mutex)
 )
 
+func hyperliquidProtectionPositionSnapshot(pos *Position) *Position {
+	if pos == nil {
+		return nil
+	}
+	snap := &Position{
+		AvgCost:                  pos.AvgCost,
+		EntryATR:                 pos.EntryATR,
+		RiskAnchorPrice:          pos.RiskAnchorPrice,
+		Regime:                   pos.Regime,
+		RegimeWindows:            cloneStringMap(pos.RegimeWindows),
+		RegimeAppliedLabel:       pos.RegimeAppliedLabel,
+		RegimePendingLabel:       pos.RegimePendingLabel,
+		RegimePendingCount:       pos.RegimePendingCount,
+		PostTPTrailingATRMult:    nil,
+		SLAdjustedTiersProcessed: pos.SLAdjustedTiersProcessed,
+	}
+	if pos.PostTPTrailingATRMult != nil {
+		v := *pos.PostTPTrailingATRMult
+		snap.PostTPTrailingATRMult = &v
+	}
+	return snap
+}
+
 func lockHyperliquidTrailingUpdate(symbol string) func() {
 	hlTrailingUpdateLocksMu.Lock()
 	m := hlTrailingUpdateLocks[symbol]

--- a/scheduler/hyperliquid_trailing_stop.go
+++ b/scheduler/hyperliquid_trailing_stop.go
@@ -15,6 +15,14 @@ var (
 	hlTrailingUpdateLocks   = make(map[string]*sync.Mutex)
 )
 
+// hyperliquidProtectionPositionSnapshot builds an isolated, lock-free copy of a
+// Position for the HL perps trailing/fixed protection walkers. It deliberately
+// carries the full protection surface — regime label + windows, the frozen risk
+// anchor, and post-TP/regime transition state — so effectiveTrailingStopPct can
+// resolve a regime-keyed distance (trailing_stop_atr_regime) and the frozen
+// #873 anchor off the snapshot. The earlier partial snapshot dropped the regime
+// fields, which left paper regime trailing SLs unarmed (#1015). RegimeWindows is
+// deep-copied so the lock-free walker never reads a map the main loop may mutate.
 func hyperliquidProtectionPositionSnapshot(pos *Position) *Position {
 	if pos == nil {
 		return nil
@@ -28,7 +36,6 @@ func hyperliquidProtectionPositionSnapshot(pos *Position) *Position {
 		RegimeAppliedLabel:       pos.RegimeAppliedLabel,
 		RegimePendingLabel:       pos.RegimePendingLabel,
 		RegimePendingCount:       pos.RegimePendingCount,
-		PostTPTrailingATRMult:    nil,
 		SLAdjustedTiersProcessed: pos.SLAdjustedTiersProcessed,
 	}
 	if pos.PostTPTrailingATRMult != nil {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1414,7 +1414,7 @@ func main() {
 					var hlTPOIDs []int64
 					var hlStopLossTriggerPx float64
 					var hlStopLossHighWaterPx float64
-					var hlPostTPTrailingATRMult *float64
+					var hlPosSnapshot *Position
 					var hlScaleInCount int
 					var hlLastAddPrice float64
 					var hlAddedNotionalUSD float64
@@ -1449,7 +1449,7 @@ func main() {
 								hlTPOIDs = cloneInt64s(pos.TPOIDs)
 								hlStopLossTriggerPx = pos.StopLossTriggerPx
 								hlStopLossHighWaterPx = pos.StopLossHighWaterPx
-								hlPostTPTrailingATRMult = pos.PostTPTrailingATRMult
+								hlPosSnapshot = hyperliquidProtectionPositionSnapshot(pos)
 								hlScaleInCount = pos.ScaleInCount
 								hlLastAddPrice = pos.LastAddPrice
 								hlAddedNotionalUSD = pos.AddedNotionalUSD
@@ -1721,13 +1721,11 @@ func main() {
 							mu.Unlock()
 							var execResult *HyperliquidExecuteResult
 							liveExecFailed := false
-							hlPosSnapshot := &Position{AvgCost: hlAvgCost, EntryATR: hlEntryATR, PostTPTrailingATRMult: hlPostTPTrailingATRMult}
 							if result.Signal == 0 && hlPosQty > 0 && strategyUsesTrailingTPRatchetClose(sc) {
 								applyTrailingTPRatchet(sc, stratState, result.Symbol, price, &mu, logger)
 								mu.RLock()
 								if pos, ok3 := stratState.Positions[result.Symbol]; ok3 && pos != nil {
-									hlPostTPTrailingATRMult = pos.PostTPTrailingATRMult
-									hlPosSnapshot.PostTPTrailingATRMult = hlPostTPTrailingATRMult
+									hlPosSnapshot = hyperliquidProtectionPositionSnapshot(pos)
 								}
 								mu.RUnlock()
 							}


### PR DESCRIPTION
## Summary

- Add a Hyperliquid protection position snapshot helper that carries regime labels, regime windows, post-TP trailing state, and the frozen risk anchor.
- Use that snapshot for the lock-free HL perps trailing/fixed protection walkers, including after trailing TP ratchet refresh.
- Add a regression proving the old incomplete snapshot cannot arm a regime trailing paper SL, while the fixed snapshot resolves the regime and arms at the frozen-anchor trigger.

## Root Cause

Paper-mode `trailing_stop_atr_regime` protection used `hlPosSnapshot`, but that snapshot only carried `AvgCost`, `EntryATR`, and `PostTPTrailingATRMult`. Without `Regime`/`RegimeWindows`, `effectiveTrailingStopPct` returned `0`, so the paper trailing walker never armed `stop_loss_trigger_px` on HOLD cycles.

Closes #1015

## Validation

- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test -run 'TestRunHyperliquidTrailingStopPaper|TestArmTrailingStopAtOpenNowRegime|TestEffectiveTrailingStopPct_ATRMult'`
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...`

LLM: GPT-5 Codex | high | Harness: go test ./...