### PR TITLE
feat(#1016): Anchored VWAP (anchored_vwap) strategy

### DIFF
--- a/backtest/fee_audit.py
+++ b/backtest/fee_audit.py
@@ -94,7 +94,7 @@ LIVE_BIDIRECTIONAL_STRATEGIES = frozenset({
     "triple_ema_bidir", "tema_cross_bd", "session_breakout", "donchian_breakout",
     "chart_pattern", "liquidity_sweeps", "bear_pullback_st", "vwap_rejection_st",
     "momentum_pro", "mean_reversion_pro", "consolidation_range", "mtf_confluence",
-    "vol_momentum", "funding_skew", "regime_adaptive",
+    "vol_momentum", "funding_skew", "regime_adaptive", "anchored_vwap",
 })
 
 # The #956/#963 protocol windows; held-out windows overlap `is` and would

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -723,6 +723,11 @@ DEFAULT_PARAM_RANGES = {
         "entry_std": [1.0, 1.5, 2.0],
         "exit_std": [0.0, 0.2, 0.5],
     },
+    "anchored_vwap": {
+        "pivot_strength": [3, 5, 8],
+        "buffer_atr_mult": [0.1, 0.25, 0.5],
+        "confirm_bars": [1, 2, 3],
+    },
     "chart_pattern": {
         "pivot_lookback": [3, 5, 7],
         "tolerance": [0.02, 0.03, 0.05],

--- a/backtest/tests/test_backtester_lookahead.py
+++ b/backtest/tests/test_backtester_lookahead.py
@@ -304,23 +304,70 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / "shared_str
 from anchored_vwap import anchored_vwap_core  # noqa: E402
 
 
+_AVWAP_PARAMS = dict(pivot_strength=2, confirm_bars=2, atr_period=3)
+
+
+def _avwap_mixed_fixture() -> pd.DataFrame:
+    """OHLCV forming a strict swing LOW (idx 5) then a strict swing HIGH (idx 17).
+
+    The reclaim above the low-anchored AVWAP fires +1 (bar 11) and the breakdown
+    below the high-anchored AVWAP fires -1 (bar 20) — a non-trivial mix across a
+    re-anchor (anchors progress -1 -> 5 -> 9 -> 17). A smooth linspace fixture is
+    NOT usable here: equal lows/highs at a monotonic turn tie under the strict
+    pivot rule, so no pivot confirms, anchor_index stays -1, signal is all zeros,
+    and the truncation assertion would be vacuous (#1019 review).
+    """
+    seg = [110, 108, 106, 104, 102, 100, 100.5, 100.2, 99.8, 99.5,
+           103.5, 104, 104.5, 105, 105.5, 106, 108, 110, 109.5, 109,
+           108.5, 104.5, 104, 103.5, 103]
+    closes = np.array(seg, dtype=float)
+    idx = pd.date_range("2026-01-01", periods=len(closes), freq="1h")
+    return pd.DataFrame(
+        {"open": closes, "high": closes + 0.5, "low": closes - 0.5,
+         "close": closes, "volume": np.full(len(closes), 10.0)},
+        index=idx,
+    )
+
+
 def test_anchored_vwap_no_lookahead():
     """Truncating future bars must not change any signal at bars <= cut.
 
-    anchored_vwap_core anchors to *confirmed* pivots (needs pivot_strength bars
-    on each side) and computes AVWAP/ATR from prefix sums — all using only data
-    at or before the current bar. Appending future bars cannot retroactively
-    change an earlier signal.
+    anchored_vwap_core anchors to *confirmed* pivots (pivot_strength bars on each
+    side) and derives AVWAP/ATR from prefix sums — all using only data at or
+    before the current bar, so appending future bars cannot change an earlier
+    signal.
+
+    Guards against the #1019 review finding (a vacuous all-zero fixture): the
+    fixture must emit nonzero signals, and a deliberately forward-peeking variant
+    must make the invariance assertion FAIL (sensitivity check), proving the test
+    can actually detect look-ahead.
     """
-    closes = list(np.linspace(120, 100, 30)) + list(np.linspace(100, 115, 20))
-    idx = pd.date_range("2026-01-01", periods=len(closes), freq="1h")
-    df = pd.DataFrame(
-        {"open": closes, "high": np.array(closes) + 0.5,
-         "low": np.array(closes) - 0.5, "close": closes,
-         "volume": np.full(len(closes), 10.0)},
-        index=idx,
-    )
-    full = anchored_vwap_core(df, pivot_strength=3, confirm_bars=2)["signal"].to_numpy()
-    cut = 40
-    trunc = anchored_vwap_core(df.iloc[:cut], pivot_strength=3, confirm_bars=2)["signal"].to_numpy()
-    assert np.array_equal(full[:cut], trunc), "signals <= cut must not depend on future bars"
+    df = _avwap_mixed_fixture()
+    cut = 20  # straddles the confirm_bars window [19, 20]; bar 20 fires -1
+
+    def real(d):
+        return anchored_vwap_core(d, **_AVWAP_PARAMS)["signal"].to_numpy()
+
+    def forward_peeking(d):
+        # bar n adopts bar n+1's signal — a canonical look-ahead contamination.
+        s = anchored_vwap_core(d, **_AVWAP_PARAMS)["signal"].to_numpy().copy()
+        if len(s) > 1:
+            s[:-1] = s[1:]
+        return s
+
+    full = real(df)
+    # Non-vacuity: the fixture must actually produce signals (both directions).
+    assert (full != 0).any(), "fixture is vacuous — no signal to guard"
+    assert (full == 1).any() and (full == -1).any(), "expected a +1 and a -1"
+
+    # Invariant: signals at bars < cut are unchanged when future bars are dropped.
+    trunc = real(df.iloc[:cut])
+    assert np.array_equal(full[:cut], trunc), "signals < cut must not depend on future bars"
+
+    # Sensitivity: a forward-peeking core variant must NOT be truncation-invariant,
+    # else the assertion above proves nothing.
+    bf = forward_peeking(df)
+    bt = forward_peeking(df.iloc[:cut])
+    assert not np.array_equal(bf[:cut], bt), (
+        "forward-peeking variant should break truncation-invariance — the test "
+        "is not sensitive to look-ahead")

--- a/backtest/tests/test_backtester_lookahead.py
+++ b/backtest/tests/test_backtester_lookahead.py
@@ -297,3 +297,30 @@ def test_zscore_target_close_uses_closed_bar_z_and_fills_next_open():
         "(next-open fill, not intrabar)"
     )
     assert result["trades"][0]["exit_reason"].startswith("zscore_target:")
+
+
+# ─── anchored_vwap: signals at bars <= cut don't depend on future bars (#1016) ─
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / "shared_strategies" / "open"))
+from anchored_vwap import anchored_vwap_core  # noqa: E402
+
+
+def test_anchored_vwap_no_lookahead():
+    """Truncating future bars must not change any signal at bars <= cut.
+
+    anchored_vwap_core anchors to *confirmed* pivots (needs pivot_strength bars
+    on each side) and computes AVWAP/ATR from prefix sums — all using only data
+    at or before the current bar. Appending future bars cannot retroactively
+    change an earlier signal.
+    """
+    closes = list(np.linspace(120, 100, 30)) + list(np.linspace(100, 115, 20))
+    idx = pd.date_range("2026-01-01", periods=len(closes), freq="1h")
+    df = pd.DataFrame(
+        {"open": closes, "high": np.array(closes) + 0.5,
+         "low": np.array(closes) - 0.5, "close": closes,
+         "volume": np.full(len(closes), 10.0)},
+        index=idx,
+    )
+    full = anchored_vwap_core(df, pivot_strength=3, confirm_bars=2)["signal"].to_numpy()
+    cut = 40
+    trunc = anchored_vwap_core(df.iloc[:cut], pivot_strength=3, confirm_bars=2)["signal"].to_numpy()
+    assert np.array_equal(full[:cut], trunc), "signals <= cut must not depend on future bars"

--- a/docs/superpowers/plans/2026-06-15-anchored-vwap.md
+++ b/docs/superpowers/plans/2026-06-15-anchored-vwap.md
@@ -1,0 +1,757 @@
+# Anchored VWAP (`anchored_vwap`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a new open strategy `anchored_vwap` that anchors a single VWAP to the most recent confirmed swing pivot and trades it as a buffered support/resistance flip (bidirectional, perps-live + spot + backtest).
+
+**Architecture:** Pure pandas core in `shared_strategies/open/anchored_vwap.py` (`anchored_vwap_core`), registered through `open/registry.py` and surfaced to Go via `--list-json`. Go wiring (`scheduler/init.go`) makes it discoverable and bidirectional-perps capable. ATR is inlined (open-strategy convention). No custom close evaluator — the opposite flip is the exit/reversal.
+
+**Tech Stack:** Python 3 / pandas / numpy (strategy + pytest), Go (`scheduler/`), uv for env.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-anchored-vwap-strategy-design.md`. Read it before starting.
+
+**Conventions:**
+- Run all commands from the worktree root: `/Users/richardkuo/Work/go-trader/.claude/worktrees/anchored-vwap`.
+- Python: `uv run --no-sync python ...`. Go: `/opt/homebrew/bin/go -C scheduler ...`.
+- Pytest for `shared_strategies/open/` runs from that dir's import context; the repo convention is `uv run --no-sync python -m pytest shared_strategies/open/test_anchored_vwap.py -v`.
+- `gofmt -w <file>.go` after every Go edit.
+
+---
+
+## File Structure
+
+- **Create** `shared_strategies/open/anchored_vwap.py` — `anchored_vwap_core(df, pivot_strength, buffer_atr_mult, confirm_bars, atr_period)` + private `_inline_atr`. Sole owner of the AVWAP math, pivot detection, and trigger.
+- **Create** `shared_strategies/open/test_anchored_vwap.py` — unit tests for the core.
+- **Modify** `shared_strategies/open/registry.py` — import + `@register` wrapper + `PLATFORM_ORDER` (spot & futures).
+- **Modify** `scheduler/init.go` — `knownShortNames`, `bidirectionalPerpsStrategies`, and the three default fallback lists.
+- **Modify** `backtest/optimizer.py` — `DEFAULT_PARAM_RANGES["anchored_vwap"]`.
+- **Modify** `backtest/tests/test_backtester_lookahead.py` — add an `anchored_vwap` look-ahead case.
+
+---
+
+## Task 1: Core module scaffold + guards
+
+**Files:**
+- Create: `shared_strategies/open/anchored_vwap.py`
+- Test: `shared_strategies/open/test_anchored_vwap.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Tests for anchored_vwap.py — Anchored VWAP S/R-flip strategy."""
+
+import numpy as np
+import pandas as pd
+
+from anchored_vwap import anchored_vwap_core
+
+
+def _hourly_index(n, start="2026-01-01 00:00:00"):
+    return pd.date_range(start, periods=n, freq="1h")
+
+
+def _ohlcv(closes, highs=None, lows=None, opens=None, volume=100.0):
+    closes = np.asarray(closes, dtype=float)
+    n = len(closes)
+    highs = closes + 0.5 if highs is None else np.asarray(highs, dtype=float)
+    lows = closes - 0.5 if lows is None else np.asarray(lows, dtype=float)
+    opens = closes if opens is None else np.asarray(opens, dtype=float)
+    vol = np.full(n, float(volume)) if np.isscalar(volume) else np.asarray(volume, dtype=float)
+    return pd.DataFrame(
+        {"open": opens, "high": highs, "low": lows, "close": closes, "volume": vol},
+        index=_hourly_index(n),
+    )
+
+
+def test_empty_and_short_df_return_zero_signal():
+    empty = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+    out = anchored_vwap_core(empty)
+    assert list(out["signal"]) == []
+    assert "avwap" in out.columns and "anchor_index" in out.columns and "atr" in out.columns
+
+    short = _ohlcv(np.linspace(100, 101, 6))  # < 2*5+1+2
+    out = anchored_vwap_core(short)
+    assert (out["signal"] == 0).all()
+    assert (out["anchor_index"] == -1).all()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-sync python -m pytest shared_strategies/open/test_anchored_vwap.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'anchored_vwap'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `shared_strategies/open/anchored_vwap.py`:
+
+```python
+"""Anchored VWAP (AVWAP) — single VWAP anchored to the most recent *confirmed*
+swing pivot, traded as a buffered support/resistance flip.
+
+Design: docs/superpowers/specs/2026-06-15-anchored-vwap-strategy-design.md
+
+ATR is inlined (rolling-mean True Range, integer-round only when atr >= 100)
+to match standard_atr without importing shared_tools — open strategies cannot
+assume shared_tools is on sys.path at module load (the registry parity test
+loads registry.py via importlib without it).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def _inline_atr(df: pd.DataFrame, period: int) -> pd.Series:
+    high = df["high"].astype(float)
+    low = df["low"].astype(float)
+    prev_close = df["close"].astype(float).shift(1)
+    tr = pd.concat(
+        [high - low, (high - prev_close).abs(), (low - prev_close).abs()],
+        axis=1,
+    ).max(axis=1)
+    atr = tr.rolling(window=period).mean()
+    return atr.where(atr < 100, atr.round(0))
+
+
+def anchored_vwap_core(
+    df: pd.DataFrame,
+    pivot_strength: int = 5,
+    buffer_atr_mult: float = 0.25,
+    confirm_bars: int = 2,
+    atr_period: int = 14,
+) -> pd.DataFrame:
+    result = df.copy()
+    n = len(result)
+    result["signal"] = 0
+    result["avwap"] = np.nan
+    result["anchor_index"] = -1
+    result["atr"] = _inline_atr(result, atr_period)
+    if n < 2 * pivot_strength + 1 + confirm_bars:
+        return result
+    return result  # full logic added in later tasks
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --no-sync python -m pytest shared_strategies/open/test_anchored_vwap.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared_strategies/open/anchored_vwap.py shared_strategies/open/test_anchored_vwap.py
+git commit -m "feat(#1016): anchored_vwap core scaffold + guards
+
+LLM: Opus 4.8 | xhigh | Harness: Claude Code"
+```
+
+---
+
+## Task 2: Pivot detection + anchor_index
+
+**Files:**
+- Modify: `shared_strategies/open/anchored_vwap.py`
+- Test: `shared_strategies/open/test_anchored_vwap.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the test file:
+
+```python
+def test_strict_pivot_and_confirmed_anchor_index():
+    # pivot_strength=2: a strict swing LOW at index 5, with 2 bars each side.
+    # Bars: descend to a unique trough at 5, then ascend.
+    closes = [110, 108, 106, 104, 102, 100, 102, 104, 106, 108, 110, 112]
+    df = _ohlcv(closes, highs=np.array(closes) + 0.5, lows=np.array(closes) - 0.5)
+    out = anchored_vwap_core(df, pivot_strength=2, confirm_bars=2)
+    anchor = out["anchor_index"].to_numpy()
+    # Trough index 5 is a strict low; confirmed at 5+2=7. Bars 0..6 have no anchor.
+    assert (anchor[:7] == -1).all()
+    assert (anchor[7:] == 5).all()
+
+
+def test_flat_top_plateau_is_not_a_pivot():
+    # Two equal highs at the top (indices 4,5) -> plateau -> no pivot there.
+    closes = [100, 102, 104, 106, 108, 108, 106, 104, 102, 100, 98, 96]
+    highs = np.array(closes) + 0.2
+    highs[4] = highs[5] = 110.0  # equal plateau highs
+    df = _ohlcv(closes, highs=highs, lows=np.array(closes) - 0.5)
+    out = anchored_vwap_core(df, pivot_strength=2, confirm_bars=2)
+    # No bar's anchor should ever equal 4 or 5 (plateau bars not pivots).
+    assert not np.isin(out["anchor_index"].to_numpy(), [4, 5]).any()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-sync python -m pytest shared_strategies/open/test_anchored_vwap.py::test_strict_pivot_and_confirmed_anchor_index -v`
+Expected: FAIL — anchor stays -1 (logic not implemented).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the trailing `return result  # full logic added in later tasks` with:
+
+```python
+    high = result["high"].astype(float).to_numpy()
+    low = result["low"].astype(float).to_numpy()
+
+    # --- strict swing pivots (unique max high / unique min low in window) ---
+    k = pivot_strength
+    is_pivot = np.zeros(n, dtype=bool)
+    for i in range(k, n - k):
+        wh = high[i - k:i + k + 1]
+        wl = low[i - k:i + k + 1]
+        wmax = wh.max()
+        wmin = wl.min()
+        is_high = high[i] == wmax and int((wh == wmax).sum()) == 1
+        is_low = low[i] == wmin and int((wl == wmin).sum()) == 1
+        if is_high or is_low:
+            is_pivot[i] = True
+
+    # --- anchor in effect at each bar: most recent pivot confirmed by then.
+    # A pivot at p becomes knowable at bar p + k.
+    anchor = np.full(n, -1, dtype=int)
+    last = -1
+    for b in range(n):
+        p = b - k
+        if p >= 0 and is_pivot[p]:
+            last = p
+        anchor[b] = last
+    result["anchor_index"] = anchor
+
+    return result
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run --no-sync python -m pytest shared_strategies/open/test_anchored_vwap.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared_strategies/open/anchored_vwap.py shared_strategies/open/test_anchored_vwap.py
+git commit -m "feat(#1016): anchored_vwap strict pivot detection + anchor_index
+
+LLM: Opus 4.8 | xhigh | Harness: Claude Code"
+```
+
+---
+
+## Task 3: AVWAP prefix-sum computation
+
+**Files:**
+- Modify: `shared_strategies/open/anchored_vwap.py`
+- Test: `shared_strategies/open/test_anchored_vwap.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```python
+def test_avwap_matches_hand_computed_prefix_sum():
+    closes = [110, 108, 106, 104, 102, 100, 102, 104, 106, 108, 110, 112]
+    highs = np.array(closes) + 0.0   # tp == close when high==low==close
+    lows = np.array(closes) + 0.0
+    df = _ohlcv(closes, highs=highs, lows=lows, volume=10.0)
+    out = anchored_vwap_core(df, pivot_strength=2, confirm_bars=2)
+    # Anchor = index 5 from bar 7 on. With tp==close and constant volume,
+    # AVWAP[n] = mean(close[5..n]).
+    avwap = out["avwap"].to_numpy()
+    for nbar in (7, 8, 9, 10, 11):
+        expected = np.mean(closes[5:nbar + 1])
+        assert abs(avwap[nbar] - expected) < 1e-9, (nbar, avwap[nbar], expected)
+    assert np.isnan(avwap[:7]).all()  # no anchor yet
+
+
+def test_avwap_zero_volume_window_falls_back_to_typical():
+    closes = [110, 108, 106, 104, 102, 100, 102, 104, 106, 108, 110, 112]
+    df = _ohlcv(closes, volume=0.0)  # zero volume everywhere
+    out = anchored_vwap_core(df, pivot_strength=2, confirm_bars=2)
+    avwap = out["avwap"].to_numpy()
+    tp = (df["high"] + df["low"] + df["close"]).to_numpy() / 3.0
+    for nbar in range(7, 12):
+        assert abs(avwap[nbar] - tp[nbar]) < 1e-9
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-sync python -m pytest shared_strategies/open/test_anchored_vwap.py::test_avwap_matches_hand_computed_prefix_sum -v`
+Expected: FAIL — `avwap` is all NaN.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Immediately before the final `return result` (after the anchor block), insert:
+
+```python
+    # --- AVWAP via global prefix sums (exact across re-anchors) ---
+    tp = ((result["high"] + result["low"] + result["close"]) / 3.0).to_numpy()
+    vol = result["volume"].astype(float).to_numpy()
+    pref_tpvol = np.concatenate([[0.0], np.cumsum(tp * vol)])  # pref[i] = sum first i
+    pref_vol = np.concatenate([[0.0], np.cumsum(vol)])
+    avwap = np.full(n, np.nan)
+    for b in range(n):
+        a = anchor[b]
+        if a < 0:
+            continue
+        num = pref_tpvol[b + 1] - pref_tpvol[a]
+        den = pref_vol[b + 1] - pref_vol[a]
+        avwap[b] = tp[b] if den <= 0 else num / den
+    result["avwap"] = avwap
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run --no-sync python -m pytest shared_strategies/open/test_anchored_vwap.py -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared_strategies/open/anchored_vwap.py shared_strategies/open/test_anchored_vwap.py
+git commit -m "feat(#1016): anchored_vwap prefix-sum AVWAP + zero-volume fallback
+
+LLM: Opus 4.8 | xhigh | Harness: Claude Code"
+```
+
+---
+
+## Task 4: Trigger — buffered S/R flip (fire-once, symmetric)
+
+**Files:**
+- Modify: `shared_strategies/open/anchored_vwap.py`
+- Test: `shared_strategies/open/test_anchored_vwap.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```python
+def _long_reclaim_df():
+    # Descend to a strict swing low (idx 5), drift below the AVWAP, then
+    # decisively reclaim and hold above it. pivot_strength=2, confirm_bars=2.
+    closes = [110, 108, 106, 104, 102, 100,   # trough at idx 5
+              100.5, 100.2, 99.8, 99.5,        # chop below the rising AVWAP
+              103.5, 104.0, 104.5, 105.0]      # buffered reclaim + hold
+    return _ohlcv(closes, volume=10.0)
+
+
+def test_long_signal_fires_once_on_completing_bar():
+    df = _long_reclaim_df()
+    out = anchored_vwap_core(df, pivot_strength=2, buffer_atr_mult=0.0, confirm_bars=2)
+    sig = out["signal"].to_numpy()
+    longs = np.where(sig == 1)[0]
+    assert len(longs) == 1, longs               # fire-once
+    b = longs[0]
+    # the bar before the window must have been below the line (fresh crossing)
+    win_start = b - 2 + 1
+    assert out["close"].to_numpy()[win_start - 1] < out["avwap"].to_numpy()[win_start - 1]
+
+
+def test_no_signal_before_first_anchor():
+    df = _long_reclaim_df()
+    out = anchored_vwap_core(df, pivot_strength=2, buffer_atr_mult=0.0, confirm_bars=2)
+    # bars before anchor confirmation (idx < 7) never signal
+    assert (out["signal"].to_numpy()[:7] == 0).all()
+
+
+def test_short_signal_mirrors():
+    # Ascend to a strict swing high (idx 5), drift above AVWAP, then break below.
+    closes = [90, 92, 94, 96, 98, 100,
+              99.5, 99.8, 100.2, 100.5,
+              96.5, 96.0, 95.5, 95.0]
+    df = _ohlcv(closes, volume=10.0)
+    out = anchored_vwap_core(df, pivot_strength=2, buffer_atr_mult=0.0, confirm_bars=2)
+    sig = out["signal"].to_numpy()
+    assert (sig == -1).sum() == 1
+    assert (sig == 1).sum() == 0
+
+
+def test_nan_atr_warmup_yields_no_signal():
+    df = _long_reclaim_df()
+    # atr_period longer than the series -> ATR all NaN -> buffer NaN -> no fire
+    out = anchored_vwap_core(df, pivot_strength=2, buffer_atr_mult=0.25, confirm_bars=2, atr_period=99)
+    assert (out["signal"] == 0).all()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-sync python -m pytest shared_strategies/open/test_anchored_vwap.py -k "signal or anchor or warmup" -v`
+Expected: FAIL — no signals emitted yet.
+
+> Note (executor): the `_long_reclaim_df` / short fixtures are hand-built. If the exact `signal==1` bar count differs, adjust the close path so there is exactly one fresh buffered reclaim held for `confirm_bars` (the invariant under test), not the literal prices. Keep `buffer_atr_mult=0.0` for the basic crossing tests to isolate the flip from ATR scale.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Before the final `return result`, insert:
+
+```python
+    # --- trigger: buffered S/R flip, fire-once via fresh-crossing clause ---
+    close = result["close"].astype(float).to_numpy()
+    atr_arr = result["atr"].to_numpy()
+    cb = int(confirm_bars)
+    sig = np.zeros(n, dtype=int)
+    for nbar in range(n):
+        b = nbar - cb + 1                       # window start
+        if b - 1 < 0 or anchor[b] < 0:
+            continue
+        if np.isnan(avwap[b - 1]) or np.isnan(atr_arr[b]):
+            continue
+        buf = buffer_atr_mult * atr_arr[b]
+        win_c = close[b:nbar + 1]
+        win_v = avwap[b:nbar + 1]
+        # LONG: held above, buffered breach on window-start, prior bar below.
+        if (np.all(win_c >= win_v)
+                and close[b] >= avwap[b] + buf
+                and close[b - 1] < avwap[b - 1]):
+            sig[nbar] = 1
+            continue
+        # SHORT: mirror.
+        if (np.all(win_c <= win_v)
+                and close[b] <= avwap[b] - buf
+                and close[b - 1] > avwap[b - 1]):
+            sig[nbar] = -1
+    result["signal"] = sig
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run --no-sync python -m pytest shared_strategies/open/test_anchored_vwap.py -v`
+Expected: PASS (all tests). Fix fixtures per the Step-2 note if a count assertion is off.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared_strategies/open/anchored_vwap.py shared_strategies/open/test_anchored_vwap.py
+git commit -m "feat(#1016): anchored_vwap buffered S/R-flip trigger (fire-once)
+
+LLM: Opus 4.8 | xhigh | Harness: Claude Code"
+```
+
+---
+
+## Task 5: Register in the open registry
+
+**Files:**
+- Modify: `shared_strategies/open/registry.py` (import ~line 53; `@register` near the other VWAP blocks; `PLATFORM_ORDER` line 1254)
+- Test: `shared_strategies/open/test_anchored_vwap.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```python
+import importlib.util
+import os
+
+
+def _load_registry():
+    here = os.path.dirname(os.path.abspath(__file__))
+    spec = importlib.util.spec_from_file_location(
+        "_reg_under_test_avwap", os.path.join(here, "registry.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_registered_for_spot_and_futures():
+    reg = _load_registry()
+    for platform in ("spot", "futures"):
+        names = [s["name"] for s in reg.list_strategies(platform)]
+        assert "anchored_vwap" in names, (platform, names)
+
+
+def test_registered_fn_applies_via_registry():
+    reg = _load_registry()
+    entry = reg.STRATEGIES["anchored_vwap"]
+    df = _long_reclaim_df()
+    out = entry["fn"](df, **entry["default_params"])
+    assert "signal" in out.columns
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-sync python -m pytest shared_strategies/open/test_anchored_vwap.py -k registered -v`
+Expected: FAIL — `KeyError: 'anchored_vwap'` / not in list.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `registry.py`, add near the other module imports (~line 53, after `from vwap_rejection_st import vwap_rejection_st_core`):
+
+```python
+from anchored_vwap import anchored_vwap_core
+```
+
+Add a registration block beside the `vwap_rejection_st` block (~line 1099):
+
+```python
+@register(
+    "anchored_vwap",
+    "Anchored VWAP — single VWAP anchored to the last confirmed swing pivot as dynamic S/R; long on a buffered reclaim above, short on a buffered breakdown below",
+    {
+        "pivot_strength": 5,
+        "buffer_atr_mult": 0.25,
+        "confirm_bars": 2,
+        "atr_period": 14,
+    },
+)
+def anchored_vwap_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return anchored_vwap_core(df, **params)
+```
+
+In `PLATFORM_ORDER` (line 1254), append `"anchored_vwap"` to **both** lists. Spot list — add after `"vwap_reversion", "chart_pattern",`:
+
+```python
+        "heikin_ashi_ema", "order_blocks", "vwap_reversion", "anchored_vwap", "chart_pattern",
+```
+
+Futures list — same insertion after `"vwap_reversion", "chart_pattern",`:
+
+```python
+        "heikin_ashi_ema", "order_blocks", "vwap_reversion", "anchored_vwap", "chart_pattern",
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+uv run --no-sync python -m pytest shared_strategies/open/test_anchored_vwap.py -v
+uv run --no-sync python -m pytest shared_strategies/ -q
+```
+Expected: PASS — the new tests and the full `shared_strategies/` suite (parity tests included).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared_strategies/open/registry.py shared_strategies/open/test_anchored_vwap.py
+git commit -m "feat(#1016): register anchored_vwap (spot + futures)
+
+LLM: Opus 4.8 | xhigh | Harness: Claude Code"
+```
+
+---
+
+## Task 6: Go wiring — discovery + bidirectional perps
+
+**Files:**
+- Modify: `scheduler/init.go` (`knownShortNames` ~line 37; `bidirectionalPerpsStrategies` ~line 89; `defaultSpotStrategies` ~line 128; `defaultPerpsStrategies` ~line 166; `defaultFuturesStrategies` ~line 187)
+
+- [ ] **Step 1: Write the failing test**
+
+Create/append to `scheduler/init_anchored_vwap_test.go`:
+
+```go
+package main
+
+import "testing"
+
+func TestAnchoredVWAPWiring(t *testing.T) {
+	if got := deriveShortName("anchored_vwap"); got != "avwap" {
+		t.Fatalf("deriveShortName(anchored_vwap) = %q, want avwap", got)
+	}
+	if !isBidirectionalPerpsStrategy("anchored_vwap") {
+		t.Fatal("anchored_vwap must be a bidirectional perps strategy")
+	}
+	for _, list := range [][]stratDef{defaultSpotStrategies, defaultPerpsStrategies, defaultFuturesStrategies} {
+		found := false
+		for _, s := range list {
+			if s.ID == "anchored_vwap" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatal("anchored_vwap missing from a default fallback list")
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/opt/homebrew/bin/go -C scheduler test -run TestAnchoredVWAPWiring ./...`
+Expected: FAIL — short name `"av"` (first-letters fallback), not bidirectional, missing from lists.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `scheduler/init.go`:
+
+- `knownShortNames` (after the `"vwap_reversion": "vwap",` line):
+```go
+	"anchored_vwap":         "avwap",
+```
+- `bidirectionalPerpsStrategies` (add an entry):
+```go
+	"anchored_vwap":       true, // single-AVWAP S/R flip; emits short on a buffered breakdown below the line (#1016)
+```
+- `defaultSpotStrategies` (after the `vwap_reversion` entry):
+```go
+	{ID: "anchored_vwap", ShortName: "avwap"},
+```
+- `defaultPerpsStrategies` (append before the regime entries):
+```go
+	{ID: "anchored_vwap", ShortName: "avwap"},
+```
+- `defaultFuturesStrategies` (after the `vwap_reversion` entry):
+```go
+	{ID: "anchored_vwap", ShortName: "avwap"},
+```
+
+Then: `gofmt -w scheduler/init.go`.
+
+- [ ] **Step 4: Run tests + build to verify they pass**
+
+Run:
+```bash
+/opt/homebrew/bin/go -C scheduler test -run TestAnchoredVWAPWiring ./...
+/opt/homebrew/bin/go -C scheduler build -ldflags "-X main.Version=$(git describe --tags --always --dirty=-mod)" -o /tmp/gt-avwap .
+/opt/homebrew/bin/go -C scheduler test ./...
+```
+Expected: PASS + clean build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scheduler/init.go scheduler/init_anchored_vwap_test.go
+git commit -m "feat(#1016): wire anchored_vwap into Go discovery + bidirectional perps
+
+LLM: Opus 4.8 | xhigh | Harness: Claude Code"
+```
+
+---
+
+## Task 7: Optimizer ranges + look-ahead regression
+
+**Files:**
+- Modify: `backtest/optimizer.py` (`DEFAULT_PARAM_RANGES` ~line 614)
+- Modify: `backtest/tests/test_backtester_lookahead.py`
+
+- [ ] **Step 1: Write the failing test**
+
+First inspect the existing look-ahead test to match its harness/fixture style:
+
+Run: `sed -n '1,80p' backtest/tests/test_backtester_lookahead.py`
+
+Then append a parametrization/case for `anchored_vwap` mirroring the existing pattern (the existing test asserts signals at bars `≤ N` are unchanged when future bars are appended). Use the file's existing helper(s); a representative shape:
+
+```python
+def test_anchored_vwap_no_lookahead():
+    from anchored_vwap import anchored_vwap_core  # path set up by this test module
+    import numpy as np, pandas as pd
+    closes = list(np.linspace(120, 100, 30)) + list(np.linspace(100, 115, 20))
+    idx = pd.date_range("2026-01-01", periods=len(closes), freq="1h")
+    df = pd.DataFrame({"open": closes, "high": np.array(closes) + 0.5,
+                       "low": np.array(closes) - 0.5, "close": closes,
+                       "volume": np.full(len(closes), 10.0)}, index=idx)
+    full = anchored_vwap_core(df, pivot_strength=3, confirm_bars=2)["signal"].to_numpy()
+    cut = 40
+    trunc = anchored_vwap_core(df.iloc[:cut], pivot_strength=3, confirm_bars=2)["signal"].to_numpy()
+    assert np.array_equal(full[:cut], trunc), "signals <= cut must not depend on future bars"
+```
+
+(If `test_backtester_lookahead.py` uses an `importlib`/sys.path harness to import open strategies, follow that mechanism instead of the bare import.)
+
+- [ ] **Step 2: Run test to verify it fails or passes**
+
+Run: `uv run --no-sync python -m pytest backtest/tests/test_backtester_lookahead.py -k anchored -v`
+Expected: PASS (the core is already look-ahead safe by construction). If it FAILS, that is a real look-ahead bug in the core — fix the core, not the test.
+
+- [ ] **Step 3: Add optimizer ranges**
+
+In `backtest/optimizer.py`, add to `DEFAULT_PARAM_RANGES` (beside `"vwap_reversion"`):
+
+```python
+    "anchored_vwap": {
+        "pivot_strength": [3, 5, 8],
+        "buffer_atr_mult": [0.1, 0.25, 0.5],
+        "confirm_bars": [1, 2, 3],
+    },
+```
+
+- [ ] **Step 4: Verify**
+
+Run:
+```bash
+uv run --no-sync python -m py_compile backtest/optimizer.py
+uv run --no-sync python -m pytest backtest/tests/test_backtester_lookahead.py -k anchored -v
+```
+Expected: compile clean; look-ahead test PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backtest/optimizer.py backtest/tests/test_backtester_lookahead.py
+git commit -m "feat(#1016): anchored_vwap optimizer ranges + look-ahead regression
+
+LLM: Opus 4.8 | xhigh | Harness: Claude Code"
+```
+
+---
+
+## Task 8: Integration verification — list-json parity, full suite, backtest
+
+**Files:** none (verification only; record outputs in the PR).
+
+- [ ] **Step 1: `--list-json` byte-identical parity**
+
+```bash
+uv run --no-sync python shared_strategies/open/spot/strategies.py --list-json > /tmp/spot_after.json
+uv run --no-sync python shared_strategies/open/futures/strategies.py --list-json > /tmp/fut_after.json
+python -c "import json,sys; json.load(open('/tmp/spot_after.json')); json.load(open('/tmp/fut_after.json')); print('valid json')"
+```
+Expected: valid JSON; both lists include `anchored_vwap`. (Go `discoverStrategies` consumes this.)
+
+- [ ] **Step 2: Full Python suite (registry/sys.path coverage)**
+
+```bash
+uv run --no-sync python -m pytest shared_strategies/ shared_tools/ backtest/ -q
+```
+Expected: all PASS (isolated runs mask open-vs-close `registry.py` import-order conflicts — run the full suite).
+
+- [ ] **Step 3: Full Go suite + build**
+
+```bash
+/opt/homebrew/bin/go -C scheduler test ./...
+/opt/homebrew/bin/go -C scheduler build -ldflags "-X main.Version=$(git describe --tags --always --dirty=-mod)" -o /tmp/gt-avwap .
+```
+Expected: PASS + clean build.
+
+- [ ] **Step 4: Backtest validation — two legs (per spec §11)**
+
+```bash
+# Long leg (default direction):
+uv run --no-sync python backtest/run_backtest.py \
+  --strategy anchored_vwap --symbol BTC/USDT --timeframe 1h --mode single
+
+# Short leg (explicit):
+uv run --no-sync python backtest/run_backtest.py \
+  --strategy anchored_vwap --symbol BTC/USDT --timeframe 1h --mode single \
+  --direction short
+```
+Expected: both runs complete; non-trivial trade counts. Do **not** use `--config` (hard-fails with no close evaluator). Record metrics in the PR.
+
+- [ ] **Step 5: Smoke the binary discovers the strategy**
+
+```bash
+./go-trader init --json '{"platform":"hyperliquid","strategy":"anchored_vwap","symbol":"BTC","capital":1000}' --output /tmp/avwap_init.json 2>&1 | tail -5 || true
+```
+(Adjust init JSON to the wizard's required keys; goal is to confirm `anchored_vwap` is an accepted strategy ID end-to-end.)
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+git push -u origin cc/anchored-vwap
+gh pr create --repo richkuo/go-trader --title "feat(#1016): Anchored VWAP strategy" \
+  --body "Closes #1016. Single-AVWAP S/R-flip strategy anchored to the most recent confirmed swing pivot; bidirectional perps + spot + backtest. Design: docs/superpowers/specs/2026-06-15-anchored-vwap-strategy-design.md. Follow-ups: #1017.
+
+LLM: Opus 4.8 | xhigh | Harness: Claude Code"
+```
+
+---
+
+## Self-Review notes (resolved)
+
+- **Spec coverage:** §3 pivot/anchor → Task 2; §4 AVWAP → Task 3; §5 trigger → Task 4; §6 params → Tasks 1/7; §7 look-ahead → Task 7; §8 wiring → Tasks 5/6; §9 perps obligations → verified via Go test + backtest (Tasks 6/8); §10 tests → Tasks 1-5; §11 backtest → Task 8.
+- **Inline ATR** decision (not `import standard_atr`) is reflected in Task 1 and the corrected spec §5.
+- **Naming consistency:** `anchored_vwap_core` / `anchored_vwap_strategy` / short name `avwap` / param names `pivot_strength,buffer_atr_mult,confirm_bars,atr_period` are identical across all tasks.
+- **Fixture caveat:** Task 4's hand-built price fixtures assert the *invariant* (exactly one fresh buffered-and-held flip), and the Step-2 note tells the executor to tune the price path, not the invariant, if a count is off.

--- a/docs/superpowers/specs/2026-06-15-anchored-vwap-strategy-design.md
+++ b/docs/superpowers/specs/2026-06-15-anchored-vwap-strategy-design.md
@@ -1,0 +1,187 @@
+# Anchored VWAP (`anchored_vwap`) — Strategy Design
+
+**Issue:** [#1016](https://github.com/richkuo/go-trader/issues/1016)
+**Follow-ups (out of scope):** [#1017](https://github.com/richkuo/go-trader/issues/1017)
+**Date:** 2026-06-15
+**Status:** Approved design — ready for implementation plan.
+
+## 1. Goal
+
+Add a new open strategy that trades a **single Anchored VWAP (AVWAP)** line as a
+dynamic support/resistance level. Unlike the two existing VWAP strategies
+(`vwap_reversion`, `vwap_rejection_st`), which reset the cumulative
+volume×price accumulation at each **calendar-day session boundary**, AVWAP
+accumulates from a **meaningful market event** (a confirmed swing pivot) and
+re-anchors only when a newer pivot confirms. The line represents the
+volume-weighted average price since the last structural turn, which traders
+read as support (anchored from a low) or resistance (anchored from a high).
+
+## 2. Core design decisions (locked)
+
+| Decision | Choice |
+|---|---|
+| Anchor event | Most recent **confirmed** swing pivot (high *or* low), type-agnostic |
+| Anchor count | **Single** AVWAP line (not dual support/resistance) |
+| Signal logic | **Support/resistance flip** — reclaim above → long, break below → short |
+| Trigger filter | **ATR buffer + N-bar hold** (whipsaw guard) |
+| Direction / platform | **Bidirectional perps live** + spot + backtest |
+| Exit | Opposite flip is the exit / reversal — no custom close evaluator |
+
+## 3. Anchor: confirmed swing pivot
+
+A swing high at bar *p* requires `high[p] == max(high[p-strength : p+strength+1])`;
+a swing low mirrors on `low`. Because confirmation needs `strength` bars **on
+each side**, a pivot at *p* is only *knowable* at bar `p + strength` — this is
+the look-ahead guarantee.
+
+- `pivot_strength` (default **5**) — bars required on each side.
+- At any bar *n*, the **active anchor** = bar index of the most recent pivot
+  whose confirmation bar `p + strength ≤ n`. Type (high vs low) does **not**
+  affect logic — a single line is anchored from that bar regardless.
+- The anchor **re-anchors forward** each time a newer pivot confirms.
+- Before the first pivot confirms there is **no anchor → no signal** (signal 0).
+  Do **not** fall back to a session/global VWAP.
+
+### Anchor selection (implementation note)
+Compute boolean pivot-high / pivot-low masks, OR them into a single
+`is_pivot` mask, then shift each pivot's *known-at* index to `p + strength`.
+Forward-fill the pivot **bar index** along the known-at timeline to produce
+`anchor_index[n]` for every bar. Ties (a high and a low confirming on the same
+bar) resolve to the **later bar index**; if equal, prefer the pivot **low**
+(documented, deterministic — only matters for the AVWAP start bar).
+
+## 4. AVWAP computation
+
+Anchored VWAP from anchor bar *a* to current bar *n*, using typical price
+`tp = (high + low + close) / 3`:
+
+```
+AVWAP[n] = (Σ tp·vol [a..n]) / (Σ vol [a..n])
+```
+
+Implemented with **global prefix sums** so it is O(n) and exact across arbitrary
+anchor resets:
+
+```
+AVWAP[n] = (prefix_tpvol[n] - prefix_tpvol[a-1]) / (prefix_vol[n] - prefix_vol[a-1])
+```
+
+- `a = anchor_index[n]`; when `a == 0`, the `[a-1]` term is 0.
+- **Div-by-zero guard:** if the denominator (window volume) is 0, fall back to
+  `tp[n]` (matches `vwap_rejection_st._session_vwap`'s `replace(0, NaN).fillna(typical)`).
+- The anchor activates `strength` bars after the pivot bar but the accumulation
+  **starts at the pivot bar** — the prefix-sum form handles the lag region
+  naturally because it always sums `a..n`.
+
+## 5. Trigger: ATR buffer + N-bar hold (symmetric)
+
+ATR comes from `shared_tools/atr.py:standard_atr(df, period)` — **do not add a
+5th inline ATR copy** (CLAUDE.md: ATR has 4 sites already).
+
+```
+buffer = buffer_atr_mult × ATR[n]          # price units
+```
+
+**Long (+1):** price was below the line, then `close ≥ AVWAP + buffer`, and
+`close ≥ AVWAP` holds for `confirm_bars` consecutive bars. Fire **+1 only on the
+bar that completes the hold** (the transition), not continuously while held —
+mirrors `vwap_reversion`'s cross-once pattern (`buy_cross` = condition true now
+& false on prior bar).
+
+**Short (−1):** mirror — `close ≤ AVWAP − buffer` and `close ≤ AVWAP` held for
+`confirm_bars`. Fire −1 on the completing transition.
+
+**Reversal/exit:** the opposite flip emits the opposite signal. On bidirectional
+perps this flips the position; on spot/backtest the −1 is an exit (or short per
+backtester support).
+
+### Whipsaw / state notes
+- A new anchor confirming mid-trade resets the "was below/above" reference to
+  the new line; the next qualifying buffered-and-held cross of the **new** line
+  fires. This is intended (the level the market respects has moved).
+- `confirm_bars` counts bars strictly **after** the buffered breach bar,
+  inclusive of the breach bar itself = 1; default `confirm_bars=2` means breach
+  bar + 1 confirming bar.
+
+## 6. Parameters
+
+| Param | Default | Range (optimizer) |
+|---|---|---|
+| `pivot_strength` | 5 | [3, 5, 8] |
+| `buffer_atr_mult` | 0.25 | [0.1, 0.25, 0.5] |
+| `confirm_bars` | 2 | [1, 2, 3] |
+| `atr_period` | 14 | (fixed; not swept) |
+
+## 7. Look-ahead safety
+
+- Pivot confirmation, `anchor_index[n]`, AVWAP[n], and ATR[n] use **only bars ≤ n**
+  (the `strength` bars after a pivot are themselves ≤ n at confirmation time).
+- Signal at bar N fills at N+1 open (backtester invariant).
+- Add an `anchored_vwap` case to `backtest/tests/test_backtester_lookahead.py`
+  asserting that injecting future bars after N does not change `signal[≤N]`.
+
+## 8. File-by-file wiring
+
+1. **`shared_strategies/open/anchored_vwap.py`** (new) — `anchored_vwap_core(df, pivot_strength=5, buffer_atr_mult=0.25, confirm_bars=2, atr_period=14)` returning the df with added `signal`, `avwap`, `anchor_index`, `atr` columns. Logic non-trivial → its own module, imported like `vwap_rejection_st` (`from vwap_rejection_st import vwap_rejection_st_core`).
+2. **`shared_strategies/open/registry.py`**:
+   - `from anchored_vwap import anchored_vwap_core` (top imports, ~line 53).
+   - `@register("anchored_vwap", "Anchored VWAP — single VWAP anchored to the last confirmed swing pivot as dynamic S/R; long on a buffered reclaim above, short on a buffered breakdown below", {"pivot_strength": 5, "buffer_atr_mult": 0.25, "confirm_bars": 2, "atr_period": 14})` wrapping `anchored_vwap_core`. Default `platforms=("spot","futures")`.
+   - Add `"anchored_vwap"` to **both** `PLATFORM_ORDER["spot"]` and `["futures"]` (line 1254). Append near the other VWAP entries.
+3. **`scheduler/init.go`**:
+   - `knownShortNames["anchored_vwap"] = "avwap"` (line 37 map).
+   - `bidirectionalPerpsStrategies["anchored_vwap"] = true` (line 89 map) — sets `AllowShorts=true` so `ExecutePerpsSignal` opens shorts from flat on −1 instead of skipping.
+   - Add to `defaultSpotStrategies` / futures fallback lists for discovery-failure parity.
+4. **`backtest/optimizer.py`** — `DEFAULT_PARAM_RANGES["anchored_vwap"]` (line 614 dict) per §6.
+
+## 9. Bidirectional perps live — existing machinery to satisfy
+
+Registering in `bidirectionalPerpsStrategies` flips on `AllowShorts`. The flip
+path is **existing** code; the spec's obligation is to confirm the strategy
+plays by its rules (CLAUDE.md "Bidirectional perps" + #1009):
+
+- A flip (long→short / short→long) requires `closeFraction == 0`; `perpsLiveOrderSize`
+  and its `runHyperliquidExecuteOrder` mirror must agree on `net_new_sz`.
+- `perpsCloseActionSuppressesNewSL` gates arming a new reduce-only SL on the flip.
+- `executePerpsSignalWithLeverage` caps `closeQty` at `pos.Quantity`.
+- No custom close evaluator: SL/TP come from config defaults (manual/perps default
+  `tiered_tp_atr_live` + SL@1.5×ATR). The strategy only emits entry signals.
+
+These are **verification** items, not new code, unless a gap is found.
+
+## 10. Test plan
+
+- **`shared_strategies/open/test_anchored_vwap.py`** (new):
+  - Construct a `DatetimeIndex` OHLCV fixture with a deliberate swing low, a
+    decline below the resulting AVWAP, then a buffered reclaim held for
+    `confirm_bars` → assert `signal == +1` on the exact completing bar and 0
+    elsewhere. Mirror fixture for −1.
+  - Assert **no signal before the first pivot confirms**.
+  - Assert anchor **re-anchors** when a newer pivot forms (AVWAP value jumps to
+    the new-anchor computation).
+  - Div-by-zero: zero-volume window → AVWAP falls back to typical price, no crash.
+  - Assert **actual** `avwap` values against a hand-computed prefix-sum (not just
+    "signal nonzero").
+- **Registry parity:** snapshot `open/{spot,futures}/strategies.py --list-json`
+  **before** the change, diff **after** — Go `discoverStrategies` needs
+  byte-identical output (run the FULL pytest suite, not isolated, per CLAUDE.md).
+- **Look-ahead:** add the case to `test_backtester_lookahead.py` (§7).
+- **Go:** `go -C scheduler test ./...` after `init.go` edits.
+
+## 11. Backtest validation
+
+```
+uv run --no-sync python backtest/run_backtest.py \
+  --strategy anchored_vwap --symbol BTC/USDT --timeframe 1h --mode single
+```
+
+Vanilla bidirectional signal strategy → backtestable (unlike
+`regime_directional_policy`). The perps-specific live flip path is **not**
+backtested; signal generation (long+short) is. Entry ATR guard (50%-of-AvgCost)
+applies. Sanity-check trade count and that both long and short legs fire.
+
+## 12. Out of scope (tracked in #1017)
+
+- Dual-anchor channel strategy (`anchored_vwap_channel`).
+- Mean-reversion-to-line strategy (`anchored_vwap_reversion`).
+- Optional momentum/regime gate on `anchored_vwap`.
+- AVWAP-anchored close evaluator (`close/registry.py`).

--- a/docs/superpowers/specs/2026-06-15-anchored-vwap-strategy-design.md
+++ b/docs/superpowers/specs/2026-06-15-anchored-vwap-strategy-design.md
@@ -29,10 +29,15 @@ read as support (anchored from a low) or resistance (anchored from a high).
 
 ## 3. Anchor: confirmed swing pivot
 
-A swing high at bar *p* requires `high[p] == max(high[p-strength : p+strength+1])`;
-a swing low mirrors on `low`. Because confirmation needs `strength` bars **on
-each side**, a pivot at *p* is only *knowable* at bar `p + strength` — this is
-the look-ahead guarantee.
+A swing high at bar *p* requires `high[p]` to be the **strict** maximum of the
+window `high[p-strength : p+strength+1]` (strict `>` against every other bar).
+Strictness is deliberate: existing pivot code uses `==`/`max()` (e.g.
+`liquidity_sweeps.py:21`), which flags every bar of a flat-top plateau as a
+pivot; strict `>` flags none on a plateau, keeping anchor selection
+deterministic — we simply don't anchor on a flat top, the next clean pivot
+anchors instead. A swing low mirrors on `low` with strict `<`. Because
+confirmation needs `strength` bars **on each side**, a pivot at *p* is only
+*knowable* at bar `p + strength` — this is the look-ahead guarantee.
 
 - `pivot_strength` (default **5**) — bars required on each side.
 - At any bar *n*, the **active anchor** = bar index of the most recent pivot
@@ -41,6 +46,17 @@ the look-ahead guarantee.
 - The anchor **re-anchors forward** each time a newer pivot confirms.
 - Before the first pivot confirms there is **no anchor → no signal** (signal 0).
   Do **not** fall back to a session/global VWAP.
+- **Re-anchor frequency** is governed entirely by `pivot_strength`: a wider
+  window confirms fewer, more significant pivots and re-anchors less often.
+  Because the type-agnostic "most recent pivot" alternates high/low, the line
+  can be jumpy at low `pivot_strength` — but this is a **tuning** concern owned
+  by the swept `pivot_strength` range, **not** a separate `min_anchor_bars`
+  param (which would be redundant). Measure re-anchor cadence during backtest.
+- **Warmup / guards:** while a bar has no confirmed anchor, or `ATR[n]` is NaN
+  (pre-`atr_period` warmup), emit `signal = 0`. Add an empty / short-df early
+  return mirroring `vwap_rejection_st.py:91-98` — return the df with `signal=0`
+  and helper columns populated where possible — so smoke tests that iterate
+  every registered strategy don't index out of range.
 
 ### Anchor selection (implementation note)
 Compute boolean pivot-high / pivot-low masks, OR them into a single
@@ -82,26 +98,38 @@ ATR comes from `shared_tools/atr.py:standard_atr(df, period)` — **do not add a
 buffer = buffer_atr_mult × ATR[n]          # price units
 ```
 
-**Long (+1):** price was below the line, then `close ≥ AVWAP + buffer`, and
-`close ≥ AVWAP` holds for `confirm_bars` consecutive bars. Fire **+1 only on the
-bar that completes the hold** (the transition), not continuously while held —
-mirrors `vwap_reversion`'s cross-once pattern (`buy_cross` = condition true now
-& false on prior bar).
+The window length is `confirm_bars` (default 2, inclusive of the breach bar:
+`confirm_bars=2` = breach bar + 1 confirming bar). Define, for the window
+`W = [n-confirm_bars+1, n]` ending at the current bar `n`:
 
-**Short (−1):** mirror — `close ≤ AVWAP − buffer` and `close ≤ AVWAP` held for
-`confirm_bars`. Fire −1 on the completing transition.
+**Long (+1) fires at bar `n`** iff **all** hold:
+1. **Hold (bare line, no buffer):** `close[k] ≥ AVWAP[k]` for every `k ∈ W`.
+2. **Buffered breach on the window's first bar:** at `b = n-confirm_bars+1`,
+   `close[b] ≥ AVWAP[b] + buffer[b]`. The buffer applies to the **breach bar
+   only** — hold bars use the bare line.
+3. **Fresh crossing:** the bar immediately before the window was below the line,
+   `close[b-1] < AVWAP[b-1]`.
+
+Clause 3 is the multi-bar analogue of `vwap_reversion`'s `shift(1)` cross idiom
+(`registry.py:818`): it makes the fire **local and unique**, so the column is
+`+1` only on the completing bar and `0` elsewhere — *without* relying on the
+backtester/live position dedup downstream (that dedup exists, but the signal
+column must be deterministic on its own, per §10's "0 elsewhere" assertion).
+This is a transition condition, **not** a stateful "must return below after a
+fire" rule.
+
+**Short (−1)** mirrors with `≤`, `AVWAP − buffer`, and `close[b-1] > AVWAP[b-1]`.
 
 **Reversal/exit:** the opposite flip emits the opposite signal. On bidirectional
-perps this flips the position; on spot/backtest the −1 is an exit (or short per
-backtester support).
+perps this flips the position; on spot / long-only backtest the −1 flattens.
 
 ### Whipsaw / state notes
-- A new anchor confirming mid-trade resets the "was below/above" reference to
-  the new line; the next qualifying buffered-and-held cross of the **new** line
-  fires. This is intended (the level the market respects has moved).
-- `confirm_bars` counts bars strictly **after** the buffered breach bar,
-  inclusive of the breach bar itself = 1; default `confirm_bars=2` means breach
-  bar + 1 confirming bar.
+- A new anchor confirming inside a window: each bar `k` compares `close[k]` to
+  *its own* live-anchor `AVWAP[k]`, so the window naturally re-references the new
+  line, and a fresh crossing (clause 3) of the new line must then form. Intended
+  — the level the market respects has moved.
+- Where the window or its `b-1` reference extends before the first valid bar
+  (anchor / ATR warmup), no signal (clauses can't be evaluated → 0).
 
 ## 6. Parameters
 
@@ -169,15 +197,30 @@ These are **verification** items, not new code, unless a gap is found.
 
 ## 11. Backtest validation
 
+The backtester measures **one direction per run**. On the default long/flat path
+`signal=-1` only flattens a long — it **never opens a short**
+(`backtester.py:1800-1806`). Shorts open only under `direction="short"`
+(`:1063`, `:1813`). So validate the two legs with **two separate runs**, and do
+**not** use `--config`: the live config maps `allow_shorts → direction="both"`
+(`run_backtest.py:209-212`), which the plain path rejects (`backtester.py:1055-1062`),
+and a `--config` run with no close evaluator (this design has none, §2)
+hard-fails at `run_backtest.py:364-373`.
+
 ```
+# Long leg (default direction):
 uv run --no-sync python backtest/run_backtest.py \
   --strategy anchored_vwap --symbol BTC/USDT --timeframe 1h --mode single
+
+# Short leg (explicit):
+uv run --no-sync python backtest/run_backtest.py \
+  --strategy anchored_vwap --symbol BTC/USDT --timeframe 1h --mode single \
+  --direction short
 ```
 
-Vanilla bidirectional signal strategy → backtestable (unlike
-`regime_directional_policy`). The perps-specific live flip path is **not**
-backtested; signal generation (long+short) is. Entry ATR guard (50%-of-AvgCost)
-applies. Sanity-check trade count and that both long and short legs fire.
+This is backtestable (unlike `regime_directional_policy`): each run exercises one
+leg's **signal generation**. The perps-specific live flip path is **not**
+backtested — it is validated by unit tests + paper (§9). Entry ATR guard
+(50%-of-AvgCost) applies. Sanity-check trade counts on each run.
 
 ## 12. Out of scope (tracked in #1017)
 

--- a/docs/superpowers/specs/2026-06-15-anchored-vwap-strategy-design.md
+++ b/docs/superpowers/specs/2026-06-15-anchored-vwap-strategy-design.md
@@ -91,8 +91,14 @@ AVWAP[n] = (prefix_tpvol[n] - prefix_tpvol[a-1]) / (prefix_vol[n] - prefix_vol[a
 
 ## 5. Trigger: ATR buffer + N-bar hold (symmetric)
 
-ATR comes from `shared_tools/atr.py:standard_atr(df, period)` — **do not add a
-5th inline ATR copy** (CLAUDE.md: ATR has 4 sites already).
+ATR is computed **inline** in the module (rolling mean of True Range,
+integer-round only when `atr ≥ 100`), mirroring `vol_momentum.py:88-95` and
+`regime_adaptive.py` — the established open-strategy convention. Do **not**
+`from atr import standard_atr`: open strategies cannot assume `shared_tools` is
+on `sys.path` at module-load time (the registry parity test loads `registry.py`
+via `importlib` without it, so a top-level import there raises `ModuleNotFoundError`).
+The inline copy is byte-identical to `standard_atr`'s formula. Emit it as the
+`atr` column.
 
 ```
 buffer = buffer_atr_mult × ATR[n]          # price units

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -58,6 +58,7 @@ var knownShortNames = map[string]string{
 	"ichimoku_cloud":        "ichi",
 	"order_blocks":          "ob",
 	"vwap_reversion":        "vwap",
+	"anchored_vwap":         "avwap",
 	"chart_pattern":         "cpat",
 	"liquidity_sweeps":      "liqsw",
 	"parabolic_sar":         "psar",
@@ -95,6 +96,7 @@ var bidirectionalPerpsStrategies = map[string]bool{
 	"liquidity_sweeps":    true, // emits short on stop-hunt wicks above swing highs (#649)
 	"bear_pullback_st":    true, // dedicated short-only strategy for bear-market rally rejections (#651)
 	"vwap_rejection_st":   true, // dedicated short-only strategy for VWAP/EMA rally rejections in bearish regime (#652)
+	"anchored_vwap":       true, // single-AVWAP S/R flip; emits short on a buffered breakdown below the line (#1016)
 	"momentum_pro":        true, // emits short on stacked-bearish-EMA trend-pullback breakdowns
 	"mean_reversion_pro":  true, // emits short on overbought reversion in no-trend regimes
 	"consolidation_range": true, // emits short at the top edge of a consolidation box (range-edge mean-reversion)
@@ -140,6 +142,7 @@ var defaultSpotStrategies = []stratDef{
 	{ID: "ichimoku_cloud", ShortName: "ichi"},
 	{ID: "order_blocks", ShortName: "ob"},
 	{ID: "vwap_reversion", ShortName: "vwap"},
+	{ID: "anchored_vwap", ShortName: "avwap"},
 	{ID: "chart_pattern", ShortName: "cpat"},
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 	{ID: "parabolic_sar", ShortName: "psar"},
@@ -169,6 +172,7 @@ var defaultPerpsStrategies = []stratDef{
 	{ID: "tema_cross_bd", ShortName: "temacb"},
 	{ID: "chart_pattern", ShortName: "cpat"},
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
+	{ID: "anchored_vwap", ShortName: "avwap"},
 	{ID: "delta_neutral_funding", ShortName: "dnf"},
 	{ID: "funding_skew", ShortName: "fskew"},
 	{ID: "range_scalper", ShortName: "rs"},
@@ -195,6 +199,7 @@ var defaultFuturesStrategies = []stratDef{
 	{ID: "ichimoku_cloud", ShortName: "ichi"},
 	{ID: "order_blocks", ShortName: "ob"},
 	{ID: "vwap_reversion", ShortName: "vwap"},
+	{ID: "anchored_vwap", ShortName: "avwap"},
 	{ID: "chart_pattern", ShortName: "cpat"},
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 	{ID: "parabolic_sar", ShortName: "psar"},

--- a/scheduler/init_anchored_vwap_test.go
+++ b/scheduler/init_anchored_vwap_test.go
@@ -1,0 +1,31 @@
+package main
+
+import "testing"
+
+func TestAnchoredVWAPWiring(t *testing.T) {
+	if got := deriveShortName("anchored_vwap"); got != "avwap" {
+		t.Fatalf("deriveShortName(anchored_vwap) = %q, want avwap", got)
+	}
+	if !isBidirectionalPerpsStrategy("anchored_vwap") {
+		t.Fatal("anchored_vwap must be a bidirectional perps strategy")
+	}
+	lists := map[string][]stratDef{
+		"spot":    defaultSpotStrategies,
+		"perps":   defaultPerpsStrategies,
+		"futures": defaultFuturesStrategies,
+	}
+	for name, list := range lists {
+		found := false
+		for _, s := range list {
+			if s.ID == "anchored_vwap" {
+				found = true
+				if s.ShortName != "avwap" {
+					t.Fatalf("%s list: anchored_vwap short name = %q, want avwap", name, s.ShortName)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("anchored_vwap missing from default %s list", name)
+		}
+	}
+}

--- a/shared_strategies/open/anchored_vwap.py
+++ b/shared_strategies/open/anchored_vwap.py
@@ -1,0 +1,143 @@
+"""Anchored VWAP (AVWAP) — single VWAP anchored to the most recent *confirmed*
+swing pivot, traded as a buffered support/resistance flip.
+
+Design: docs/superpowers/specs/2026-06-15-anchored-vwap-strategy-design.md
+
+Unlike the session-reset VWAP strategies (vwap_reversion, vwap_rejection_st),
+this accumulates the volume-weighted price from a structural event (a confirmed
+swing pivot) forward and re-anchors only when a newer pivot confirms.
+
+ATR is inlined (rolling-mean True Range, integer-round only when atr >= 100) to
+match standard_atr WITHOUT importing shared_tools — open strategies cannot
+assume shared_tools is on sys.path at module-load time (the registry parity test
+loads registry.py via importlib without it, so a top-level import would raise
+ModuleNotFoundError). The inline copy is byte-identical to standard_atr.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def _inline_atr(df: pd.DataFrame, period: int) -> pd.Series:
+    """ATR via simple rolling mean of True Range (standard_atr convention)."""
+    high = df["high"].astype(float)
+    low = df["low"].astype(float)
+    prev_close = df["close"].astype(float).shift(1)
+    tr = pd.concat(
+        [high - low, (high - prev_close).abs(), (low - prev_close).abs()],
+        axis=1,
+    ).max(axis=1)
+    atr = tr.rolling(window=period).mean()
+    return atr.where(atr < 100, atr.round(0))
+
+
+def anchored_vwap_core(
+    df: pd.DataFrame,
+    pivot_strength: int = 5,
+    buffer_atr_mult: float = 0.25,
+    confirm_bars: int = 2,
+    atr_period: int = 14,
+) -> pd.DataFrame:
+    """Single-AVWAP support/resistance-flip signals.
+
+    Parameters
+    ----------
+    df : OHLCV DataFrame (open, high, low, close, volume).
+    pivot_strength : bars required on EACH side of a swing pivot to confirm it
+        (strict max high / strict min low). A pivot at bar p is only knowable at
+        bar p + pivot_strength — the look-ahead guarantee.
+    buffer_atr_mult : the buffered breach must clear the AVWAP by
+        buffer_atr_mult * ATR on the breach bar.
+    confirm_bars : bars the close must hold on the correct side of the AVWAP
+        (inclusive of the breach bar) before a signal fires.
+    atr_period : lookback for the inline ATR.
+
+    Returns
+    -------
+    DataFrame with added columns:
+        signal       : +1 (long reclaim), -1 (short breakdown), 0 otherwise
+        avwap        : anchored VWAP (NaN before the first confirmed anchor)
+        anchor_index : bar index of the active anchor (-1 before the first one)
+        atr          : inline ATR
+    """
+    result = df.copy()
+    n = len(result)
+    result["signal"] = 0
+    result["avwap"] = np.nan
+    result["anchor_index"] = -1
+    result["atr"] = _inline_atr(result, atr_period)
+    if n < 2 * pivot_strength + 1 + confirm_bars:
+        return result
+
+    high = result["high"].astype(float).to_numpy()
+    low = result["low"].astype(float).to_numpy()
+
+    # --- strict swing pivots (unique max high / unique min low in window) ---
+    k = int(pivot_strength)
+    is_pivot = np.zeros(n, dtype=bool)
+    for i in range(k, n - k):
+        wh = high[i - k:i + k + 1]
+        wl = low[i - k:i + k + 1]
+        wmax = wh.max()
+        wmin = wl.min()
+        is_high = high[i] == wmax and int((wh == wmax).sum()) == 1
+        is_low = low[i] == wmin and int((wl == wmin).sum()) == 1
+        if is_high or is_low:
+            is_pivot[i] = True
+
+    # --- anchor in effect at each bar: most recent pivot confirmed by then.
+    # A pivot at p becomes knowable at bar p + k.
+    anchor = np.full(n, -1, dtype=int)
+    last = -1
+    for b in range(n):
+        p = b - k
+        if p >= 0 and is_pivot[p]:
+            last = p
+        anchor[b] = last
+    result["anchor_index"] = anchor
+
+    # --- AVWAP via global prefix sums (exact across re-anchors) ---
+    tp = ((result["high"] + result["low"] + result["close"]) / 3.0).to_numpy()
+    vol = result["volume"].astype(float).to_numpy()
+    pref_tpvol = np.concatenate([[0.0], np.cumsum(tp * vol)])  # pref[i] = sum first i
+    pref_vol = np.concatenate([[0.0], np.cumsum(vol)])
+    avwap = np.full(n, np.nan)
+    for b in range(n):
+        a = anchor[b]
+        if a < 0:
+            continue
+        num = pref_tpvol[b + 1] - pref_tpvol[a]
+        den = pref_vol[b + 1] - pref_vol[a]
+        avwap[b] = tp[b] if den <= 0 else num / den
+    result["avwap"] = avwap
+
+    # --- trigger: buffered S/R flip, fire-once via fresh-crossing clause ---
+    close = result["close"].astype(float).to_numpy()
+    atr_arr = result["atr"].to_numpy()
+    cb = int(confirm_bars)
+    sig = np.zeros(n, dtype=int)
+    for nbar in range(n):
+        b = nbar - cb + 1                       # window start
+        if b - 1 < 0 or anchor[b] < 0:
+            continue
+        if np.isnan(avwap[b - 1]) or np.isnan(atr_arr[b]):
+            continue
+        buf = buffer_atr_mult * atr_arr[b]
+        win_c = close[b:nbar + 1]
+        win_v = avwap[b:nbar + 1]
+        # LONG: held above, buffered breach on window-start, prior bar below.
+        if (np.all(win_c >= win_v)
+                and close[b] >= avwap[b] + buf
+                and close[b - 1] < avwap[b - 1]):
+            sig[nbar] = 1
+            continue
+        # SHORT: mirror.
+        if (np.all(win_c <= win_v)
+                and close[b] <= avwap[b] - buf
+                and close[b - 1] > avwap[b - 1]):
+            sig[nbar] = -1
+    result["signal"] = sig
+
+    return result

--- a/shared_strategies/open/registry.py
+++ b/shared_strategies/open/registry.py
@@ -52,6 +52,7 @@ from regime_adaptive_htf import regime_adaptive_htf_core
 from session_breakout import session_breakout_core
 from vwap_rejection_st import vwap_rejection_st_core
 from vol_momentum import vol_momentum_core
+from anchored_vwap import anchored_vwap_core
 
 
 VALID_PLATFORMS: Tuple[str, ...] = ("spot", "futures")
@@ -1099,6 +1100,20 @@ def vwap_rejection_st_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
 
 
 @register(
+    "anchored_vwap",
+    "Anchored VWAP — single VWAP anchored to the last confirmed swing pivot as dynamic S/R; long on a buffered reclaim above, short on a buffered breakdown below",
+    {
+        "pivot_strength": 5,
+        "buffer_atr_mult": 0.25,
+        "confirm_bars": 2,
+        "atr_period": 14,
+    },
+)
+def anchored_vwap_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return anchored_vwap_core(df, **params)
+
+
+@register(
     "momentum_pro",
     "Momentum Pro — trend-pullback entries in a stacked-EMA trend, ADX-confirmed, on a volume-backed resumption",
     {
@@ -1257,7 +1272,7 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "mean_reversion", "momentum", "volume_weighted", "triple_ema",
         "rsi_macd_combo", "stoch_rsi", "supertrend", "ichimoku_cloud",
         "pairs_spread", "squeeze_momentum", "atr_breakout", "amd_ifvg",
-        "heikin_ashi_ema", "order_blocks", "vwap_reversion", "chart_pattern",
+        "heikin_ashi_ema", "order_blocks", "vwap_reversion", "anchored_vwap", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
         "sweep_squeeze_combo", "adx_trend", "donchian_breakout", "tema_cross",
         "momentum_pro", "mean_reversion_pro", "mtf_confluence",
@@ -1269,7 +1284,7 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "triple_ema", "triple_ema_bidir", "tema_cross", "tema_cross_bd", "rsi_macd_combo", "momentum",
         "mean_reversion", "rsi", "macd", "breakout", "stoch_rsi", "supertrend",
         "squeeze_momentum", "ichimoku_cloud", "atr_breakout", "amd_ifvg",
-        "heikin_ashi_ema", "order_blocks", "vwap_reversion", "chart_pattern",
+        "heikin_ashi_ema", "order_blocks", "vwap_reversion", "anchored_vwap", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
         "sweep_squeeze_combo", "adx_trend", "delta_neutral_funding",
         "funding_skew", "donchian_breakout", "session_breakout", "bear_pullback_st",

--- a/shared_strategies/open/test_anchored_vwap.py
+++ b/shared_strategies/open/test_anchored_vwap.py
@@ -1,0 +1,156 @@
+"""Tests for anchored_vwap.py — Anchored VWAP S/R-flip strategy."""
+
+import importlib.util
+import os
+
+import numpy as np
+import pandas as pd
+
+from anchored_vwap import anchored_vwap_core
+
+
+def _hourly_index(n, start="2026-01-01 00:00:00"):
+    return pd.date_range(start, periods=n, freq="1h")
+
+
+def _ohlcv(closes, highs=None, lows=None, opens=None, volume=100.0):
+    closes = np.asarray(closes, dtype=float)
+    n = len(closes)
+    highs = closes + 0.5 if highs is None else np.asarray(highs, dtype=float)
+    lows = closes - 0.5 if lows is None else np.asarray(lows, dtype=float)
+    opens = closes if opens is None else np.asarray(opens, dtype=float)
+    vol = np.full(n, float(volume)) if np.isscalar(volume) else np.asarray(volume, dtype=float)
+    return pd.DataFrame(
+        {"open": opens, "high": highs, "low": lows, "close": closes, "volume": vol},
+        index=_hourly_index(n),
+    )
+
+
+# --- Task 1: scaffold + guards -------------------------------------------------
+
+def test_empty_and_short_df_return_zero_signal():
+    empty = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+    out = anchored_vwap_core(empty)
+    assert list(out["signal"]) == []
+    assert "avwap" in out.columns and "anchor_index" in out.columns and "atr" in out.columns
+
+    short = _ohlcv(np.linspace(100, 101, 6))  # < 2*5+1+2
+    out = anchored_vwap_core(short)
+    assert (out["signal"] == 0).all()
+    assert (out["anchor_index"] == -1).all()
+
+
+# --- Task 2: pivots + anchor_index ---------------------------------------------
+
+def test_strict_pivot_and_confirmed_anchor_index():
+    closes = [110, 108, 106, 104, 102, 100, 102, 104, 106, 108, 110, 112]
+    df = _ohlcv(closes, highs=np.array(closes) + 0.5, lows=np.array(closes) - 0.5)
+    out = anchored_vwap_core(df, pivot_strength=2, confirm_bars=2)
+    anchor = out["anchor_index"].to_numpy()
+    # Trough index 5 is a strict low; confirmed at 5+2=7. Bars 0..6 have no anchor.
+    assert (anchor[:7] == -1).all()
+    assert (anchor[7:] == 5).all()
+
+
+def test_flat_top_plateau_is_not_a_pivot():
+    closes = [100, 102, 104, 106, 108, 108, 106, 104, 102, 100, 98, 96]
+    highs = np.array(closes) + 0.2
+    highs[4] = highs[5] = 110.0  # equal plateau highs
+    df = _ohlcv(closes, highs=highs, lows=np.array(closes) - 0.5)
+    out = anchored_vwap_core(df, pivot_strength=2, confirm_bars=2)
+    assert not np.isin(out["anchor_index"].to_numpy(), [4, 5]).any()
+
+
+# --- Task 3: AVWAP -------------------------------------------------------------
+
+def test_avwap_matches_hand_computed_prefix_sum():
+    closes = [110, 108, 106, 104, 102, 100, 102, 104, 106, 108, 110, 112]
+    highs = np.array(closes) + 0.0   # tp == close when high==low==close
+    lows = np.array(closes) + 0.0
+    df = _ohlcv(closes, highs=highs, lows=lows, volume=10.0)
+    out = anchored_vwap_core(df, pivot_strength=2, confirm_bars=2)
+    avwap = out["avwap"].to_numpy()
+    for nbar in (7, 8, 9, 10, 11):
+        expected = np.mean(closes[5:nbar + 1])
+        assert abs(avwap[nbar] - expected) < 1e-9, (nbar, avwap[nbar], expected)
+    assert np.isnan(avwap[:7]).all()
+
+
+def test_avwap_zero_volume_window_falls_back_to_typical():
+    closes = [110, 108, 106, 104, 102, 100, 102, 104, 106, 108, 110, 112]
+    df = _ohlcv(closes, volume=0.0)
+    out = anchored_vwap_core(df, pivot_strength=2, confirm_bars=2)
+    avwap = out["avwap"].to_numpy()
+    tp = (df["high"] + df["low"] + df["close"]).to_numpy() / 3.0
+    for nbar in range(7, 12):
+        assert abs(avwap[nbar] - tp[nbar]) < 1e-9
+
+
+# --- Task 4: trigger -----------------------------------------------------------
+
+def _long_reclaim_df():
+    closes = [110, 108, 106, 104, 102, 100,   # trough at idx 5
+              100.5, 100.2, 99.8, 99.5,        # chop below the rising AVWAP
+              103.5, 104.0, 104.5, 105.0]      # buffered reclaim + hold
+    return _ohlcv(closes, volume=10.0)
+
+
+def test_long_signal_fires_once_on_completing_bar():
+    df = _long_reclaim_df()
+    out = anchored_vwap_core(df, pivot_strength=2, buffer_atr_mult=0.0, confirm_bars=2, atr_period=3)
+    sig = out["signal"].to_numpy()
+    longs = np.where(sig == 1)[0]
+    assert len(longs) == 1, longs               # fire-once
+    b = longs[0]
+    win_start = b - 2 + 1
+    assert out["close"].to_numpy()[win_start - 1] < out["avwap"].to_numpy()[win_start - 1]
+
+
+def test_no_signal_before_first_anchor():
+    df = _long_reclaim_df()
+    out = anchored_vwap_core(df, pivot_strength=2, buffer_atr_mult=0.0, confirm_bars=2, atr_period=3)
+    assert (out["signal"].to_numpy()[:7] == 0).all()
+
+
+def test_short_signal_mirrors():
+    closes = [90, 92, 94, 96, 98, 100,
+              99.5, 99.8, 100.2, 100.5,
+              96.5, 96.0, 95.5, 95.0]
+    df = _ohlcv(closes, volume=10.0)
+    out = anchored_vwap_core(df, pivot_strength=2, buffer_atr_mult=0.0, confirm_bars=2, atr_period=3)
+    sig = out["signal"].to_numpy()
+    assert (sig == -1).sum() == 1
+    assert (sig == 1).sum() == 0
+
+
+def test_nan_atr_warmup_yields_no_signal():
+    df = _long_reclaim_df()
+    out = anchored_vwap_core(df, pivot_strength=2, buffer_atr_mult=0.25, confirm_bars=2, atr_period=99)
+    assert (out["signal"] == 0).all()
+
+
+# --- Task 5: registry ----------------------------------------------------------
+
+def _load_registry():
+    here = os.path.dirname(os.path.abspath(__file__))
+    spec = importlib.util.spec_from_file_location(
+        "_reg_under_test_avwap", os.path.join(here, "registry.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_registered_for_spot_and_futures():
+    reg = _load_registry()
+    for platform in ("spot", "futures"):
+        assert "anchored_vwap" in reg.build_registry(platform), platform
+        assert "anchored_vwap" in reg.PLATFORM_ORDER[platform], platform
+
+
+def test_registered_fn_applies_via_registry():
+    reg = _load_registry()
+    entry = reg.STRATEGIES["anchored_vwap"]
+    df = _long_reclaim_df()
+    out = entry["fn"](df, **entry["default_params"])
+    assert "signal" in out.columns


### PR DESCRIPTION
Closes #1016.

## What

New open strategy **`anchored_vwap`**: a single Anchored VWAP anchored to the most recent **confirmed** swing pivot, traded as a buffered support/resistance flip. Unlike `vwap_reversion` / `vwap_rejection_st` (which reset per calendar-day session), this accumulates the volume-weighted price from a structural event forward and re-anchors only when a newer pivot confirms.

## Mechanics

- **Anchor:** strict-`>` swing high / strict-`<` swing low, `pivot_strength` bars each side (default 5) → confirmed only at `p + pivot_strength`, so look-ahead safe. Type-agnostic single line; re-anchors forward; no signal before the first anchor. Flat-top plateaus flag no pivot (strict comparison) for determinism.
- **AVWAP:** global prefix sums — `(Σtp·vol[n] − Σtp·vol[a−1]) / (Σvol[n] − Σvol[a−1])` — exact across re-anchors; zero-volume window falls back to typical price.
- **Trigger (symmetric, fire-once):** long `+1` when the close holds `≥ AVWAP` for `confirm_bars` with a buffered breach (`buffer_atr_mult × ATR`) on the window's first bar **and** the prior bar was below the line (fresh crossing); short `−1` mirrors. The fresh-crossing clause makes the signal column deterministic without relying on downstream dedup. Opposite flip is the exit/reversal — no custom close evaluator.
- **ATR** is inlined (rolling-mean TR, round-when-`≥100`), matching `standard_atr` without importing `shared_tools` (the registry parity test loads `registry.py` without it on `sys.path`).
- **Scope:** bidirectional perps live + spot + backtest. Registered for spot & futures; added to `bidirectionalPerpsStrategies` → init generates `direction: "both"`.

## Wiring

`shared_strategies/open/anchored_vwap.py` (+ `@register` in `registry.py`, both `PLATFORM_ORDER` lists); `scheduler/init.go` (`knownShortNames=avwap`, `bidirectionalPerpsStrategies`, spot/perps/futures fallback lists); `backtest/optimizer.py` `DEFAULT_PARAM_RANGES`; `backtest/fee_audit.py` `LIVE_BIDIRECTIONAL_STRATEGIES` (Go↔Python parity).

## Tests / verification

- 11 unit tests (`test_anchored_vwap.py`): guards, strict pivots, plateau rejection, hand-computed AVWAP, zero-volume fallback, fire-once long, short mirror, no-signal-pre-anchor, NaN-ATR warmup, registry registration.
- Look-ahead regression in `test_backtester_lookahead.py` (truncation invariance).
- Go `TestAnchoredVWAPWiring`; full Go suite + build green.
- Full Python suite green (`shared_strategies/`, `shared_tools/`, `backtest/`).
- `--list-json` includes `anchored_vwap` for spot & futures (valid JSON).
- Backtest both legs run end-to-end on BTC/USDT 1h (long 1156 trades, short 1155). Note: **unprofitable at default params** (PF 0.84 long / 0.89 short) — defaults are a starting point for the optimizer sweep, not a tuned config.
- `init` generates `hl-avwap-btc` with `direction: "both"`.

## Out of scope (tracked in #1017)

Dual-anchor channel, mean-reversion-to-line, optional momentum/regime gate, AVWAP-anchored close evaluator.

Design spec: `docs/superpowers/specs/2026-06-15-anchored-vwap-strategy-design.md` · Plan: `docs/superpowers/plans/2026-06-15-anchored-vwap.md`

---
Created with LLM: Opus 4.8 | xhigh | Harness: Claude Code
