### PR TITLE
Handle shared-wallet aggregate fills in reconciles and backfills

### DIFF
--- a/scheduler/backfill_trade_ledger.go
+++ b/scheduler/backfill_trade_ledger.go
@@ -77,12 +77,27 @@ type tradeLedgerRowNewValues struct {
 	FeeSource              string
 }
 
+type tradeLedgerOIDTotals struct {
+	FeeQty   float64
+	CloseQty float64
+}
+
 // planTradeLedgerForStrategy is the pure planner (no I/O).
 func planTradeLedgerForStrategy(
 	strategyID string,
 	trades []TradeBackfillRow,
 	fillMap map[string]HLFillSummary,
 	initialCapital, oldCash float64,
+) TradeLedgerPlan {
+	return planTradeLedgerForStrategyWithOIDTotals(strategyID, trades, fillMap, initialCapital, oldCash, nil)
+}
+
+func planTradeLedgerForStrategyWithOIDTotals(
+	strategyID string,
+	trades []TradeBackfillRow,
+	fillMap map[string]HLFillSummary,
+	initialCapital, oldCash float64,
+	oidTotals map[string]tradeLedgerOIDTotals,
 ) TradeLedgerPlan {
 	plan := TradeLedgerPlan{StrategyID: strategyID, OldCash: oldCash}
 
@@ -114,13 +129,13 @@ func planTradeLedgerForStrategy(
 		plan.CashBaselineDivergent = true
 	}
 
-	// Quantity totals per OID across THIS strategy's rows. A userFills
-	// aggregate spans every leg of the OID — partial TP legs, resting-limit
-	// partial adds, and the close+open legs of a bidirectional flip order —
-	// so apportion by qty share instead of letting each leg absorb the full
-	// aggregate. The FEE was charged on the whole order (all legs); the
-	// closedPnl accrues only on close legs, so the two use different
-	// denominators.
+	// Quantity totals per OID across this strategy's rows, optionally widened
+	// to shared-wallet peers. A userFills aggregate spans every leg of the OID
+	// — partial TP legs, resting-limit partial adds, bidirectional flip legs,
+	// and shared-wallet external closes — so apportion by qty share instead
+	// of letting each leg absorb the full aggregate. The fee was charged on
+	// the whole order (all legs); closedPnl accrues only on close legs, so the
+	// two use different denominators.
 	feeQtyByOID := make(map[string]float64)
 	closeQtyByOID := make(map[string]float64)
 	for _, t := range sorted {
@@ -131,6 +146,20 @@ func planTradeLedgerForStrategy(
 		if t.IsClose {
 			closeQtyByOID[t.ExchangeOrderID] += t.Quantity
 		}
+	}
+	feeQtyTotal := func(oid string) float64 {
+		total := feeQtyByOID[oid]
+		if oidTotals != nil && oidTotals[oid].FeeQty > total {
+			total = oidTotals[oid].FeeQty
+		}
+		return total
+	}
+	closeQtyTotal := func(oid string) float64 {
+		total := closeQtyByOID[oid]
+		if oidTotals != nil && oidTotals[oid].CloseQty > total {
+			total = oidTotals[oid].CloseQty
+		}
+		return total
 	}
 
 	cash := initialCapital
@@ -180,7 +209,7 @@ func planTradeLedgerForStrategy(
 			})
 		default:
 			feeShare := 1.0
-			if total := feeQtyByOID[t.ExchangeOrderID]; total > 0 && t.Quantity > 0 {
+			if total := feeQtyTotal(t.ExchangeOrderID); total > 0 && t.Quantity > 0 {
 				feeShare = t.Quantity / total
 			}
 			nv.Fee = summary.Fee * feeShare
@@ -191,7 +220,7 @@ func planTradeLedgerForStrategy(
 			}
 			if t.IsClose {
 				pnlShare := 1.0
-				if total := closeQtyByOID[t.ExchangeOrderID]; total > 0 && t.Quantity > 0 {
+				if total := closeQtyTotal(t.ExchangeOrderID); total > 0 && t.Quantity > 0 {
 					pnlShare = t.Quantity / total
 				}
 				// Exchange-reported gross closedPnl. For shared-coin peers HL
@@ -305,6 +334,77 @@ func (sdb *StateDB) ApplyTradeLedgerPlan(plan TradeLedgerPlan) error {
 	return tx.Commit()
 }
 
+func tradeLedgerDenominatorStrategies(strategies, targets []StrategyConfig) []StrategyConfig {
+	byID := make(map[string]StrategyConfig, len(strategies))
+	for _, sc := range strategies {
+		byID[sc.ID] = sc
+	}
+	targetIDs := make(map[string]bool, len(targets))
+	denomIDs := make(map[string]bool, len(targets))
+	for _, sc := range targets {
+		targetIDs[sc.ID] = true
+		denomIDs[sc.ID] = true
+	}
+	for key, memberIDs := range detectSharedWallets(strategies) {
+		members := sharedWalletMembersWithManual(key, memberIDs, strategies)
+		selected := false
+		for _, id := range members {
+			if targetIDs[id] {
+				selected = true
+				break
+			}
+		}
+		if !selected {
+			continue
+		}
+		for _, id := range members {
+			sc, ok := byID[id]
+			if !ok || sc.Platform != "hyperliquid" || (sc.Type != "perps" && sc.Type != "manual") {
+				continue
+			}
+			denomIDs[id] = true
+		}
+	}
+	out := make([]StrategyConfig, 0, len(denomIDs))
+	for id := range denomIDs {
+		if sc, ok := byID[id]; ok {
+			out = append(out, sc)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+func tradeLedgerSharedWalletOIDTotals(strategies []StrategyConfig, tradesByID map[string][]TradeBackfillRow) map[string]map[string]tradeLedgerOIDTotals {
+	out := make(map[string]map[string]tradeLedgerOIDTotals)
+	for key, memberIDs := range detectSharedWallets(strategies) {
+		members := sharedWalletMembersWithManual(key, memberIDs, strategies)
+		totals := make(map[string]tradeLedgerOIDTotals)
+		for _, id := range members {
+			for _, t := range tradesByID[id] {
+				if t.ExchangeOrderID == "" || t.TradeType == TradeTypeFunding {
+					continue
+				}
+				total := totals[t.ExchangeOrderID]
+				total.FeeQty += t.Quantity
+				if t.IsClose {
+					total.CloseQty += t.Quantity
+				}
+				totals[t.ExchangeOrderID] = total
+			}
+		}
+		if len(totals) == 0 {
+			continue
+		}
+		for _, id := range members {
+			if _, loaded := tradesByID[id]; loaded {
+				out[id] = totals
+			}
+		}
+	}
+	return out
+}
+
 // runBackfillTradeLedger implements `go-trader backfill trade-ledger`.
 // Dry-run by default; --apply commits and resets the per-wallet ledger drift
 // baselines so the next reconcile re-anchors on the repaired ledger.
@@ -375,8 +475,9 @@ func runBackfillTradeLedger(args []string) int {
 		return 1
 	}
 	sort.Slice(targets, func(i, j int) bool { return targets[i].ID < targets[j].ID })
+	denomStrategies := tradeLedgerDenominatorStrategies(cfg.Strategies, targets)
 
-	earliest, err := stateDB.EarliestTradeTimestamp(strategyIDsOf(targets))
+	earliest, err := stateDB.EarliestTradeTimestamp(strategyIDsOf(denomStrategies))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to read earliest trade timestamp: %v\n", err)
 		return 1
@@ -400,6 +501,17 @@ func runBackfillTradeLedger(args []string) int {
 	fmt.Printf("Fetched %d fills across %d pages (account=%s)\n",
 		fillResult.FillCount, fillResult.PageCount, fillResult.AccountAddress)
 
+	tradesByID := make(map[string][]TradeBackfillRow, len(denomStrategies))
+	for _, sc := range denomStrategies {
+		trades, err := stateDB.ListTradesForBackfill(sc.ID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[%s] failed to list trades: %v\n", sc.ID, err)
+			return 1
+		}
+		tradesByID[sc.ID] = trades
+	}
+	sharedOIDTotalsByID := tradeLedgerSharedWalletOIDTotals(cfg.Strategies, tradesByID)
+
 	mode := "DRY-RUN"
 	if *apply {
 		mode = "APPLY"
@@ -419,12 +531,7 @@ func runBackfillTradeLedger(args []string) int {
 			initialCapital = sc.Capital
 		}
 
-		trades, err := stateDB.ListTradesForBackfill(sc.ID)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "[%s] failed to list trades: %v\n", sc.ID, err)
-			exitCode = 1
-			continue
-		}
+		trades := tradesByID[sc.ID]
 		closedRows, err := stateDB.LoadClosedPositionRows(sc.ID)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[%s] failed to load closed_positions: %v\n", sc.ID, err)
@@ -432,7 +539,7 @@ func runBackfillTradeLedger(args []string) int {
 			continue
 		}
 
-		plan := planTradeLedgerForStrategy(sc.ID, trades, fillResult.ByOID, initialCapital, oldCash)
+		plan := planTradeLedgerForStrategyWithOIDTotals(sc.ID, trades, fillResult.ByOID, initialCapital, oldCash, sharedOIDTotalsByID[sc.ID])
 		plan.ClosedPositions = planClosedPositionRecomputes(tradeLedgerCorrectedNetRows(trades, plan), closedRows)
 		printTradeLedgerReport(plan)
 

--- a/scheduler/backfill_trade_ledger.go
+++ b/scheduler/backfill_trade_ledger.go
@@ -334,34 +334,48 @@ func (sdb *StateDB) ApplyTradeLedgerPlan(plan TradeLedgerPlan) error {
 	return tx.Commit()
 }
 
-func tradeLedgerDenominatorStrategies(strategies, targets []StrategyConfig) []StrategyConfig {
+func tradeLedgerDenominatorIDsByTarget(strategies, targets []StrategyConfig) map[string][]string {
 	byID := make(map[string]StrategyConfig, len(strategies))
 	for _, sc := range strategies {
 		byID[sc.ID] = sc
 	}
 	targetIDs := make(map[string]bool, len(targets))
-	denomIDs := make(map[string]bool, len(targets))
+	out := make(map[string][]string, len(targets))
 	for _, sc := range targets {
 		targetIDs[sc.ID] = true
-		denomIDs[sc.ID] = true
+		out[sc.ID] = []string{sc.ID}
 	}
 	for key, memberIDs := range detectSharedWallets(strategies) {
 		members := sharedWalletMembersWithManual(key, memberIDs, strategies)
-		selected := false
-		for _, id := range members {
-			if targetIDs[id] {
-				selected = true
-				break
-			}
-		}
-		if !selected {
-			continue
-		}
+		var sharedIDs []string
 		for _, id := range members {
 			sc, ok := byID[id]
 			if !ok || sc.Platform != "hyperliquid" || (sc.Type != "perps" && sc.Type != "manual") {
 				continue
 			}
+			sharedIDs = append(sharedIDs, id)
+		}
+		sort.Strings(sharedIDs)
+		for _, id := range members {
+			if targetIDs[id] {
+				out[id] = append([]string(nil), sharedIDs...)
+			}
+		}
+	}
+	for id := range out {
+		sort.Strings(out[id])
+	}
+	return out
+}
+
+func tradeLedgerDenominatorStrategies(strategies, targets []StrategyConfig) []StrategyConfig {
+	byID := make(map[string]StrategyConfig, len(strategies))
+	for _, sc := range strategies {
+		byID[sc.ID] = sc
+	}
+	denomIDs := make(map[string]bool, len(targets))
+	for _, ids := range tradeLedgerDenominatorIDsByTarget(strategies, targets) {
+		for _, id := range ids {
 			denomIDs[id] = true
 		}
 	}
@@ -476,6 +490,7 @@ func runBackfillTradeLedger(args []string) int {
 	}
 	sort.Slice(targets, func(i, j int) bool { return targets[i].ID < targets[j].ID })
 	denomStrategies := tradeLedgerDenominatorStrategies(cfg.Strategies, targets)
+	denomIDsByTarget := tradeLedgerDenominatorIDsByTarget(cfg.Strategies, targets)
 
 	earliest, err := stateDB.EarliestTradeTimestamp(strategyIDsOf(denomStrategies))
 	if err != nil {
@@ -502,11 +517,12 @@ func runBackfillTradeLedger(args []string) int {
 		fillResult.FillCount, fillResult.PageCount, fillResult.AccountAddress)
 
 	tradesByID := make(map[string][]TradeBackfillRow, len(denomStrategies))
+	tradeLoadErrors := make(map[string]error)
 	for _, sc := range denomStrategies {
 		trades, err := stateDB.ListTradesForBackfill(sc.ID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "[%s] failed to list trades: %v\n", sc.ID, err)
-			return 1
+			tradeLoadErrors[sc.ID] = err
+			continue
 		}
 		tradesByID[sc.ID] = trades
 	}
@@ -531,6 +547,22 @@ func runBackfillTradeLedger(args []string) int {
 			initialCapital = sc.Capital
 		}
 
+		if err := tradeLoadErrors[sc.ID]; err != nil {
+			fmt.Fprintf(os.Stderr, "[%s] failed to list trades: %v\n", sc.ID, err)
+			exitCode = 1
+			continue
+		}
+		denomLoadOK := true
+		for _, id := range denomIDsByTarget[sc.ID] {
+			if err := tradeLoadErrors[id]; err != nil {
+				fmt.Fprintf(os.Stderr, "[%s] failed to list shared-wallet peer trades for %s: %v\n", sc.ID, id, err)
+				exitCode = 1
+				denomLoadOK = false
+			}
+		}
+		if !denomLoadOK {
+			continue
+		}
 		trades := tradesByID[sc.ID]
 		closedRows, err := stateDB.LoadClosedPositionRows(sc.ID)
 		if err != nil {

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -954,16 +954,37 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 		if math.Abs(onChainQty) < 1e-6 && math.Abs(virtualQty) > 1e-6 {
 			// Detector 1: everything gone on-chain — close all peers.
 			//
-			// Fee-lookup caveat for the multi-peer case: a single aggregated
-			// UI close produces one userFills row sized at the *aggregate*
-			// quantity, while each non-owner peer here queries with its own
-			// per-strategy pos.Quantity. The hlReconcileFillSizeTolerance
-			// (1e-4) won't accept that mismatch, so peers fall back to the
-			// modeled fee. SL attribution additionally requires an OID-keyed
-			// userFills hit matching Position.StopLossOID (#756); otherwise the
-			// peer is closed as hl_sync_external (mark or zero PnL). Per-peer fee
-			// accuracy on external closes is only achievable when each peer's qty
-			// happens to equal the aggregate close size.
+			// Multi-peer external closes usually have one userFills row sized
+			// at the coin-level virtual quantity. Split that aggregate fill
+			// across peers by virtual qty when a per-strategy lookup misses so
+			// each Trade row carries a real fee, fill price, and OID for later
+			// ledger true-up (#1029).
+			detector1ShareDenom := 0.0
+			for _, id := range stratIDs {
+				ss := state.Strategies[id]
+				if ss == nil {
+					continue
+				}
+				pos := ss.Positions[coin]
+				if pos != nil && pos.Quantity > 0 {
+					detector1ShareDenom += pos.Quantity
+				}
+			}
+			detector1AggregateLookup, detector1AggregateUseFill := resolveFee(coin, 0, math.Abs(virtualQty))
+			detector1AggregateOID := ""
+			if detector1AggregateUseFill && detector1AggregateLookup.OID > 0 {
+				detector1AggregateOID = strconv.FormatInt(detector1AggregateLookup.OID, 10)
+			}
+			detector1AggregateShare := func(qty float64) (HLFillLookup, bool, string) {
+				if !detector1AggregateUseFill || detector1ShareDenom <= 0 {
+					return HLFillLookup{}, false, ""
+				}
+				lookup, ok := splitHyperliquidFillLookupByQty(detector1AggregateLookup, qty, detector1ShareDenom)
+				if !ok {
+					return HLFillLookup{}, false, ""
+				}
+				return lookup, true, detector1AggregateOID
+			}
 			for _, id := range stratIDs {
 				ss := state.Strategies[id]
 				if ss == nil {
@@ -1020,6 +1041,17 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 							logger.Info("hl-sync: %s Detector 1 SL OID %s unfilled — routing external (userFills miss)", coin, oidStr)
 						}
 						lookupExt, useFillFeeExt := resolveFee(coin, 0, pos.Quantity)
+						oidExt := ""
+						if useFillFeeExt && lookupExt.OID > 0 {
+							oidExt = strconv.FormatInt(lookupExt.OID, 10)
+						}
+						if !useFillFeeExt {
+							if sharedLookup, sharedUseFill, sharedOID := detector1AggregateShare(pos.Quantity); sharedUseFill {
+								lookupExt = sharedLookup
+								useFillFeeExt = true
+								oidExt = sharedOID
+							}
+						}
 						logHyperliquidReconcileFillLookup(logger, coin, 0, pos.Quantity, lookupExt, useFillFeeExt)
 						closePx := hlReconcileExternalClosePx(prices[coin], lookupExt, useFillFeeExt)
 						if closePx <= 0 {
@@ -1030,7 +1062,7 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 								logger.Info("hl-sync: %s Detector 1 external close has no price source — booking at avg cost $%.4f (zero PnL)", coin, closePx)
 							}
 						}
-						if recordPerpsExternalCloseWithFillFee(ss, coin, closePx, lookupExt.Fee, useFillFeeExt, "", "hl_sync_external", logger) {
+						if recordPerpsExternalCloseWithFillFee(ss, coin, closePx, lookupExt.Fee, useFillFeeExt, oidExt, "hl_sync_external", logger) {
 							changed = true
 						}
 					}
@@ -1047,6 +1079,17 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 					// Trade / ClosedPosition rows as authoritative for tax or
 					// reporting; they exist to keep cash bookkeeping in sync.
 					lookup, useFillFee := resolveFee(coin, 0, pos.Quantity)
+					oidStr := ""
+					if useFillFee && lookup.OID > 0 {
+						oidStr = strconv.FormatInt(lookup.OID, 10)
+					}
+					if !useFillFee {
+						if sharedLookup, sharedUseFill, sharedOID := detector1AggregateShare(pos.Quantity); sharedUseFill {
+							lookup = sharedLookup
+							useFillFee = true
+							oidStr = sharedOID
+						}
+					}
 					logHyperliquidReconcileFillLookup(logger, coin, 0, pos.Quantity, lookup, useFillFee)
 					closePx := hlReconcileExternalClosePx(prices[coin], lookup, useFillFee)
 					if closePx <= 0 {
@@ -1055,7 +1098,7 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 							logger.Info("hl-sync: %s external close has no price source — booking at avg cost $%.4f (zero PnL)", coin, closePx)
 						}
 					}
-					if recordPerpsExternalCloseWithFillFee(ss, coin, closePx, lookup.Fee, useFillFee, "", "hl_sync_external", logger) {
+					if recordPerpsExternalCloseWithFillFee(ss, coin, closePx, lookup.Fee, useFillFee, oidStr, "hl_sync_external", logger) {
 						changed = true
 					}
 				}

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -1040,16 +1040,11 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 						} else if logger != nil {
 							logger.Info("hl-sync: %s Detector 1 SL OID %s unfilled — routing external (userFills miss)", coin, oidStr)
 						}
-						lookupExt, useFillFeeExt := resolveFee(coin, 0, pos.Quantity)
-						oidExt := ""
-						if useFillFeeExt && lookupExt.OID > 0 {
-							oidExt = strconv.FormatInt(lookupExt.OID, 10)
-						}
+						lookupExt, useFillFeeExt, oidExt := detector1AggregateShare(pos.Quantity)
 						if !useFillFeeExt {
-							if sharedLookup, sharedUseFill, sharedOID := detector1AggregateShare(pos.Quantity); sharedUseFill {
-								lookupExt = sharedLookup
-								useFillFeeExt = true
-								oidExt = sharedOID
+							lookupExt, useFillFeeExt = resolveFee(coin, 0, pos.Quantity)
+							if useFillFeeExt && lookupExt.OID > 0 {
+								oidExt = strconv.FormatInt(lookupExt.OID, 10)
 							}
 						}
 						logHyperliquidReconcileFillLookup(logger, coin, 0, pos.Quantity, lookupExt, useFillFeeExt)
@@ -1078,16 +1073,11 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 					// every fill to land in trades. Do not treat the resulting
 					// Trade / ClosedPosition rows as authoritative for tax or
 					// reporting; they exist to keep cash bookkeeping in sync.
-					lookup, useFillFee := resolveFee(coin, 0, pos.Quantity)
-					oidStr := ""
-					if useFillFee && lookup.OID > 0 {
-						oidStr = strconv.FormatInt(lookup.OID, 10)
-					}
+					lookup, useFillFee, oidStr := detector1AggregateShare(pos.Quantity)
 					if !useFillFee {
-						if sharedLookup, sharedUseFill, sharedOID := detector1AggregateShare(pos.Quantity); sharedUseFill {
-							lookup = sharedLookup
-							useFillFee = true
-							oidStr = sharedOID
+						lookup, useFillFee = resolveFee(coin, 0, pos.Quantity)
+						if useFillFee && lookup.OID > 0 {
+							oidStr = strconv.FormatInt(lookup.OID, 10)
 						}
 					}
 					logHyperliquidReconcileFillLookup(logger, coin, 0, pos.Quantity, lookup, useFillFee)

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1692,6 +1692,110 @@ func TestReconcileSharedCoin_Detector1SplitsAggregateFillAcrossPeers(t *testing.
 	assertClose("hl-peer-eth", peerCash, peerQty, aggFee*(peerQty/(ownerQty+peerQty)))
 }
 
+func TestReconcileSharedCoin_Detector1BidirectionalAggregateSplitWinsOverPeerQtyMatch(t *testing.T) {
+	const (
+		fillPx    = 3200.0
+		aggFee    = 6.0
+		aggOID    = int64(87654)
+		longQty   = 1.0
+		shortQty  = 0.5
+		avgCost   = 3000.0
+		longCash  = 1000.0
+		shortCash = 600.0
+	)
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-long-eth": {
+				ID: "hl-long-eth", Cash: longCash, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: longQty, AvgCost: avgCost, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-long-eth"},
+				},
+			},
+			"hl-short-eth": {
+				ID: "hl-short-eth", Cash: shortCash, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: shortQty, AvgCost: avgCost, Side: "short",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-short-eth"},
+				},
+			},
+		},
+	}
+	allStrategies := []StrategyConfig{
+		{ID: "hl-long-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"longer", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-short-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"shorter", "ETH", "1h", "--mode=live"}},
+	}
+
+	aggregateQty := math.Abs(longQty - shortQty)
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(_, coin string, oid int64, qty float64) (HLFillLookup, bool) {
+		if oid == 0 && coin == "ETH" && math.Abs(qty-aggregateQty) < 1e-9 {
+			return HLFillLookup{
+				Fee:            aggFee,
+				ClosedPnLGross: aggregateQty * (fillPx - avgCost),
+				FilledQty:      aggregateQty,
+				Px:             fillPx,
+				Count:          1,
+				OID:            aggOID,
+			}, true
+		}
+		return HLFillLookup{}, false
+	}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, nil, map[string]float64{"ETH": 3100}, "0xtest", nil, false)
+
+	denom := longQty + shortQty
+	assertClose := func(id, wantTradeSide string, startCash, qty, wantGrossPnL, wantFee float64) {
+		t.Helper()
+		ss := state.Strategies[id]
+		if ss.Positions["ETH"] != nil {
+			t.Fatalf("%s ETH position should be nil", id)
+		}
+		if len(ss.ClosedPositions) != 1 {
+			t.Fatalf("%s ClosedPositions = %d, want 1", id, len(ss.ClosedPositions))
+		}
+		wantNetPnL := wantGrossPnL - wantFee
+		if math.Abs(ss.ClosedPositions[0].RealizedPnL-wantNetPnL) > 1e-9 {
+			t.Errorf("%s ClosedPosition net PnL = %v, want %v", id, ss.ClosedPositions[0].RealizedPnL, wantNetPnL)
+		}
+		if math.Abs(ss.Cash-(startCash+wantNetPnL)) > 1e-9 {
+			t.Errorf("%s Cash = %v, want %v", id, ss.Cash, startCash+wantNetPnL)
+		}
+		if len(ss.TradeHistory) != 1 {
+			t.Fatalf("%s TradeHistory = %d, want 1 (%+v)", id, len(ss.TradeHistory), ss.TradeHistory)
+		}
+		tr := ss.TradeHistory[0]
+		if tr.ExchangeOrderID != "87654" {
+			t.Errorf("%s ExchangeOrderID = %q, want 87654", id, tr.ExchangeOrderID)
+		}
+		if tr.Side != wantTradeSide {
+			t.Errorf("%s Side = %q, want %q", id, tr.Side, wantTradeSide)
+		}
+		if math.Abs(tr.ExchangeFee-wantFee) > 1e-9 {
+			t.Errorf("%s ExchangeFee = %v, want %v", id, tr.ExchangeFee, wantFee)
+		}
+		if tr.Price != fillPx {
+			t.Errorf("%s Price = %v, want %v", id, tr.Price, fillPx)
+		}
+		if math.Abs(tr.RealizedPnL-wantGrossPnL) > 1e-9 {
+			t.Errorf("%s gross PnL = %v, want %v", id, tr.RealizedPnL, wantGrossPnL)
+		}
+	}
+
+	longFee := aggFee * (longQty / denom)
+	shortFee := aggFee * (shortQty / denom)
+	assertClose("hl-long-eth", "sell", longCash, longQty, longQty*(fillPx-avgCost), longFee)
+	assertClose("hl-short-eth", "buy", shortCash, shortQty, shortQty*(avgCost-fillPx), shortFee)
+
+	totalFee := state.Strategies["hl-long-eth"].TradeHistory[0].ExchangeFee + state.Strategies["hl-short-eth"].TradeHistory[0].ExchangeFee
+	if math.Abs(totalFee-aggFee) > 1e-9 {
+		t.Errorf("total split fee = %v, want aggregate fee %v", totalFee, aggFee)
+	}
+}
+
 func TestHlReconcileExternalClosePx(t *testing.T) {
 	const mark = 63564.5
 	const fillPx = 63597.0

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1581,6 +1581,117 @@ func TestReconcileSharedCoin_AllPositionsClosedExternally_CreditsPeerCash(t *tes
 	}
 }
 
+func TestReconcileSharedCoin_Detector1SplitsAggregateFillAcrossPeers(t *testing.T) {
+	const (
+		fillPx    = 3200.0
+		aggFee    = 4.0
+		aggOID    = int64(98765)
+		ownerQty  = 1.5
+		peerQty   = 0.5
+		avgCost   = 3000.0
+		ownerCash = 1000.0
+		peerCash  = 500.0
+	)
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-eth": {
+				ID: "hl-owner-eth", Cash: ownerCash, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: ownerQty, AvgCost: avgCost, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth"},
+				},
+			},
+			"hl-peer-eth": {
+				ID: "hl-peer-eth", Cash: peerCash, Platform: "hyperliquid",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: peerQty, AvgCost: avgCost, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-peer-eth"},
+				},
+			},
+		},
+	}
+	allStrategies := []StrategyConfig{
+		{ID: "hl-owner-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-peer-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(_, coin string, oid int64, qty float64) (HLFillLookup, bool) {
+		if oid == 0 && coin == "ETH" && math.Abs(qty-(ownerQty+peerQty)) < 1e-9 {
+			return HLFillLookup{
+				Fee:            aggFee,
+				ClosedPnLGross: (ownerQty + peerQty) * (fillPx - avgCost),
+				FilledQty:      ownerQty + peerQty,
+				Px:             fillPx,
+				Count:          1,
+				OID:            aggOID,
+			}, true
+		}
+		return HLFillLookup{}, false
+	}
+
+	logMgr, _ := NewLogManager(t.TempDir())
+	var mu sync.RWMutex
+	_, _, _ = reconcileHyperliquidAccountPositions(allStrategies, allStrategies, state, &mu, logMgr, nil, map[string]float64{"ETH": 3100}, "0xtest", nil, false)
+
+	assertClose := func(id string, startCash, qty, wantFee float64) {
+		t.Helper()
+		ss := state.Strategies[id]
+		if ss.Positions["ETH"] != nil {
+			t.Fatalf("%s ETH position should be nil", id)
+		}
+		if len(ss.ClosedPositions) != 1 {
+			t.Fatalf("%s ClosedPositions = %d, want 1", id, len(ss.ClosedPositions))
+		}
+		cp := ss.ClosedPositions[0]
+		if cp.CloseReason != "hl_sync_external" {
+			t.Errorf("%s CloseReason = %q, want hl_sync_external", id, cp.CloseReason)
+		}
+		if cp.ClosePrice != fillPx {
+			t.Errorf("%s ClosePrice = %v, want fill %v", id, cp.ClosePrice, fillPx)
+		}
+		wantNetPnL := qty*(fillPx-avgCost) - wantFee
+		if math.Abs(cp.RealizedPnL-wantNetPnL) > 1e-9 {
+			t.Errorf("%s ClosedPosition net PnL = %v, want %v", id, cp.RealizedPnL, wantNetPnL)
+		}
+		if math.Abs(ss.Cash-(startCash+wantNetPnL)) > 1e-9 {
+			t.Errorf("%s Cash = %v, want %v", id, ss.Cash, startCash+wantNetPnL)
+		}
+		var closeTrades []Trade
+		for _, tr := range ss.TradeHistory {
+			if tr.IsClose {
+				closeTrades = append(closeTrades, tr)
+			}
+		}
+		if len(closeTrades) != 1 {
+			t.Fatalf("%s close trades = %d, want 1 (history=%+v)", id, len(closeTrades), ss.TradeHistory)
+		}
+		tr := closeTrades[0]
+		if tr.ExchangeOrderID != "98765" {
+			t.Errorf("%s ExchangeOrderID = %q, want 98765", id, tr.ExchangeOrderID)
+		}
+		if tr.FeeSource != FeeSourceUserFills {
+			t.Errorf("%s FeeSource = %q, want %q", id, tr.FeeSource, FeeSourceUserFills)
+		}
+		if math.Abs(tr.ExchangeFee-wantFee) > 1e-9 {
+			t.Errorf("%s ExchangeFee = %v, want %v", id, tr.ExchangeFee, wantFee)
+		}
+		if tr.Price != fillPx {
+			t.Errorf("%s trade Price = %v, want %v", id, tr.Price, fillPx)
+		}
+		if math.Abs(tr.RealizedPnL-qty*(fillPx-avgCost)) > 1e-9 {
+			t.Errorf("%s trade gross PnL = %v, want %v", id, tr.RealizedPnL, qty*(fillPx-avgCost))
+		}
+		if math.Abs(tradeNetPnL(tr)-wantNetPnL) > 1e-9 {
+			t.Errorf("%s trade net PnL = %v, want %v", id, tradeNetPnL(tr), wantNetPnL)
+		}
+	}
+
+	assertClose("hl-owner-eth", ownerCash, ownerQty, aggFee*(ownerQty/(ownerQty+peerQty)))
+	assertClose("hl-peer-eth", peerCash, peerQty, aggFee*(peerQty/(ownerQty+peerQty)))
+}
+
 func TestHlReconcileExternalClosePx(t *testing.T) {
 	const mark = 63564.5
 	const fillPx = 63597.0

--- a/scheduler/hyperliquid_fills.go
+++ b/scheduler/hyperliquid_fills.go
@@ -41,6 +41,26 @@ type HLFillLookup struct {
 	OID            int64
 }
 
+func splitHyperliquidFillLookupByQty(lookup HLFillLookup, qty, totalQty float64) (HLFillLookup, bool) {
+	if qty <= 0 || totalQty <= 0 {
+		return HLFillLookup{}, false
+	}
+	share := qty / totalQty
+	if share <= 0 {
+		return HLFillLookup{}, false
+	}
+	if share > 1 {
+		share = 1
+	}
+	out := lookup
+	out.Fee = lookup.Fee * share
+	out.ClosedPnLGross = lookup.ClosedPnLGross * share
+	if lookup.FilledQty > 0 {
+		out.FilledQty = lookup.FilledQty * share
+	}
+	return out, true
+}
+
 // hlFillRecord is the trimmed userFills payload we care about. The HL indexer
 // returns numeric fields as strings; ParseFloat tolerates missing/empty.
 type hlFillRecord struct {
@@ -487,9 +507,10 @@ func buildCachedHyperliquidReconcileFillResolver(accountAddress string, allStrat
 			}
 		}
 	}
-	// Shared-coin Detector 3 partial: prefetch the aggregate virtual/on-chain
-	// drift qty. Per-strategy prefetch above uses each strategy's own qty, but
-	// Detector 3 books the coin-level delta (sum of peers minus on-chain).
+	// Shared-coin aggregate paths: prefetch Detector 1's full-flat coin-level
+	// virtual qty and Detector 3's virtual/on-chain drift qty. Per-strategy
+	// prefetch above uses each strategy's own qty, but these detectors book
+	// against a wallet-level userFills row.
 	coinStratCount := make(map[string]int)
 	coinVirtualQty := make(map[string]float64)
 	for _, sc := range allStrategies {
@@ -518,6 +539,9 @@ func buildCachedHyperliquidReconcileFillResolver(accountAddress string, allStrat
 			continue
 		}
 		onChainQty := onChainByCoin[coin]
+		if math.Abs(onChainQty) < 1e-6 && math.Abs(coinVirtualQty[coin]) > 1e-6 {
+			addCandidate(coin, 0, math.Abs(coinVirtualQty[coin]))
+		}
 		if _, closeQty, ok := hyperliquidSharedPartialCloseDrift(coinVirtualQty[coin], onChainQty); ok {
 			addCandidate(coin, 0, closeQty)
 		}

--- a/scheduler/hyperliquid_fills_test.go
+++ b/scheduler/hyperliquid_fills_test.go
@@ -248,7 +248,8 @@ func TestReconcileHyperliquidPositions_ExternalCloseUsesFillFee(t *testing.T) {
 
 func TestReconcileHyperliquidAccountPositions_DetectorOneUsesFillFee(t *testing.T) {
 	// Detector 1 (Full external close on shared coin): SL owner gets OID-keyed
-	// fee lookup; non-owner peer gets coin+size match.
+	// fee lookup; non-owner peer gets the coin-level external fill split by
+	// virtual qty.
 	origLookup := lookupHyperliquidReconcileFillFee
 	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
 	lookupHyperliquidReconcileFillFee = func(addr, coin string, oid int64, qty float64) (HLFillLookup, bool) {
@@ -314,8 +315,8 @@ func TestReconcileHyperliquidAccountPositions_DetectorOneUsesFillFee(t *testing.
 	if len(peerSS.TradeHistory) != 1 {
 		t.Fatalf("peer TradeHistory = %d, want 1", len(peerSS.TradeHistory))
 	}
-	if peerSS.TradeHistory[0].ExchangeFee < 0.749 || peerSS.TradeHistory[0].ExchangeFee > 0.751 {
-		t.Errorf("peer ExchangeFee = %g, want ~0.75 (coin+size fallback)", peerSS.TradeHistory[0].ExchangeFee)
+	if peerSS.TradeHistory[0].ExchangeFee < 0.249 || peerSS.TradeHistory[0].ExchangeFee > 0.251 {
+		t.Errorf("peer ExchangeFee = %g, want ~0.25 (aggregate split)", peerSS.TradeHistory[0].ExchangeFee)
 	}
 }
 

--- a/scheduler/shared_wallet_ledger_test.go
+++ b/scheduler/shared_wallet_ledger_test.go
@@ -850,6 +850,53 @@ func TestPlanTradeLedgerForStrategy_SharedOIDApportionsByQty(t *testing.T) {
 	}
 }
 
+func TestPlanTradeLedgerForStrategy_SharedWalletOIDTotalsAcrossStrategies(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xabc")
+	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	tradesA := []TradeBackfillRow{
+		{RowID: 1, Timestamp: base, Symbol: "ETH", Side: "sell", Quantity: 1.5, Price: 3100, Value: 4650,
+			IsClose: true, RealizedPnL: 150, ExchangeFee: 0, PnLGross: true, ExchangeOrderID: "98765"},
+	}
+	tradesB := []TradeBackfillRow{
+		{RowID: 2, Timestamp: base, Symbol: "ETH", Side: "sell", Quantity: 0.5, Price: 3100, Value: 1550,
+			IsClose: true, RealizedPnL: 50, ExchangeFee: 0, PnLGross: true, ExchangeOrderID: "98765"},
+	}
+	strategies := []StrategyConfig{
+		{ID: "hl-a", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-b", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	totalsByID := tradeLedgerSharedWalletOIDTotals(strategies, map[string][]TradeBackfillRow{
+		"hl-a": tradesA,
+		"hl-b": tradesB,
+	})
+	fills := map[string]HLFillSummary{
+		"98765": {Fee: 4, ClosedPnLGross: 400, Qty: 2, Px: 3200},
+	}
+
+	planA := planTradeLedgerForStrategyWithOIDTotals("hl-a", tradesA, fills, 1000, 0, totalsByID["hl-a"])
+	planB := planTradeLedgerForStrategyWithOIDTotals("hl-b", tradesB, fills, 500, 0, totalsByID["hl-b"])
+
+	if len(planA.Changes) != 1 || len(planB.Changes) != 1 {
+		t.Fatalf("changes A/B = %d/%d, want 1/1", len(planA.Changes), len(planB.Changes))
+	}
+	a, b := planA.Changes[0], planB.Changes[0]
+	if math.Abs(a.NewFee-3) > 1e-9 || math.Abs(a.NewPnL-300) > 1e-9 {
+		t.Errorf("strategy A share = fee %v pnl %v, want 3 / 300", a.NewFee, a.NewPnL)
+	}
+	if math.Abs(b.NewFee-1) > 1e-9 || math.Abs(b.NewPnL-100) > 1e-9 {
+		t.Errorf("strategy B share = fee %v pnl %v, want 1 / 100", b.NewFee, b.NewPnL)
+	}
+	if math.Abs(a.NewFee+b.NewFee-4) > 1e-9 {
+		t.Errorf("fee sum = %v, want aggregate 4", a.NewFee+b.NewFee)
+	}
+	if math.Abs(a.NewPnL+b.NewPnL-400) > 1e-9 {
+		t.Errorf("pnl sum = %v, want aggregate 400", a.NewPnL+b.NewPnL)
+	}
+	if math.Abs(planA.NewCash-1297) > 1e-9 || math.Abs(planB.NewCash-599) > 1e-9 {
+		t.Errorf("cash A/B = %v/%v, want 1297/599", planA.NewCash, planB.NewCash)
+	}
+}
+
 // A flip order's close and open legs share one OID: the fee apportions
 // across BOTH legs (the exchange charged it on the whole order) while the
 // closedPnl lands entirely on the close leg.


### PR DESCRIPTION
## Summary
- Split detector 1 aggregate Hyperliquid fills across shared-wallet peers by virtual quantity when per-strategy fee lookups miss
- Carry the aggregate OID into external close records so shared-wallet trades can be true-uped consistently
- Extend trade-ledger backfill to widen OID denominators across shared-wallet peers and reuse shared totals during planning
- Add unit coverage for shared-wallet detector 1 reconciliation and backfill OID apportioning

## Testing
- Added unit tests covering shared-wallet external close fee/PnL splitting and backfill ledger OID total apportioning
- Not run (not requested)