### PR TITLE
ci: drop ccusage token/cost line from Claude comment footer

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -251,16 +251,7 @@ jobs:
           # the real --effort value, so it guesses). The workflow is authoritative.
           BODY=$(printf '%s' "$BODY" | python3 .github/scripts/strip_llm_footer.py)
 
-          TODAY=$(date -u +%Y%m%d)
-
-          USAGE=$(npx --yes ccusage@latest session --json --since "$TODAY" --order desc 2>/tmp/ccusage-err || echo "[]")
-          [ -s /tmp/ccusage-err ] && echo "ccusage stderr: $(cat /tmp/ccusage-err)"
-          COST=$(printf '%s' "$USAGE" | jq -r 'if .sessions and (.sessions | length) > 0 then .sessions[0] | "Tokens: \(.inputTokens // 0) in / \(.outputTokens // 0) out | Cache: \(.cacheReadTokens // 0) read / \(.cacheCreationTokens // 0) written | Cost: $\(.totalCost // 0 | . * 100 | round / 100)" else "" end' 2>/dev/null || true)
-
           FOOTER="---"$'\n'"LLM: ${MODEL_NAME} | ${EFFORT} | Harness: ${CLAUDE_HARNESS}"
-          if [ -n "$COST" ]; then
-            FOOTER="${FOOTER} | ${COST}"
-          fi
 
           NEW_BODY="${BODY}"$'\n\n'"${FOOTER}"
 


### PR DESCRIPTION
## Summary
Removes the `ccusage` block from the "Append LLM footer" step in `claude.yml`. The footer now strips any stale footer Claude wrote and appends `LLM: <model> | <effort> | Harness: <harness>` directly — no `npx ccusage@latest` fetch on each run.

## Why
The `ccusage` call only enriched the footer with a best-effort token/cost line. It was wrapped to fail safe (error → `[]` → empty `COST` → footer appended without the line), so it had no functional role. Dropping it removes a per-run npm fetch; the authoritative model/effort/harness attribution is unchanged.

## Verification
- `grep` confirms no remaining `ccusage` / `COST` / `USAGE` / `TODAY` references.
- Workflow YAML parses clean.

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code