### PR TITLE
Keep trailing stop ratcheting under a latched circuit breaker (#1046)

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1538,16 +1538,31 @@ func main() {
 						cbSnapshot = snapshotPerStrategyCircuitBreaker(stratState, prices)
 					}
 					mu.Unlock()
+					// #1046: a latched per-strategy circuit breaker on an HL perps
+					// strategy with an open position falls through in manage-only
+					// mode rather than skipping — the dispatch below forces the
+					// signal to hold (0), which suppresses every entry/add/flip/
+					// close path while still running the Signal==0 trailing-SL/TP
+					// management so a stranded (e.g. shared-coin) position keeps
+					// ratcheting its stop-loss. All other blocks skip as before.
+					cbManageOnly := false
 					if !allowed {
 						notifyPerStrategyCircuitBreakerWithSnapshot(sc, cbSnapshot, reason, pv, totalPV, stateDB, notifier, killSwitchFired)
 						logger.Warn("Risk block: %s (portfolio=$%.2f)", reason, pv)
-						logger.Close()
-						lastRun[sc.ID] = time.Now()
-						continue
+						if circuitBreakerPermitsManagement(reason, sc.Platform, sc.Type, hlPosQty) {
+							cbManageOnly = true
+							logger.Info("Circuit breaker latched — suppressing new entries but continuing trailing-SL/TP management for open position (#1046)")
+						} else {
+							logger.Close()
+							lastRun[sc.ID] = time.Now()
+							continue
+						}
 					}
 
-					// #42: Notional cap blocks new trades for this strategy.
-					if notionalBlocked {
+					// #42: Notional cap blocks new trades for this strategy. Under
+					// manage-only the position is never grown anyway, so let the
+					// trailing-SL/TP management run instead of skipping.
+					if !cbManageOnly && notionalBlocked {
 						logger.Warn("Notional cap exceeded — skipping new trades")
 						logger.Close()
 						lastRun[sc.ID] = time.Now()
@@ -1703,6 +1718,15 @@ func main() {
 							}
 						} else if result, signalStr, price, ok := runHyperliquidCheck(&sc, prices, hlPosCtx, cfg.Regime, notifier, logger); ok {
 							prices[result.Symbol] = price
+							// #1046: circuit breaker latched — force hold so no entry/
+							// add/flip/close executes (every execution path below gates
+							// on Signal != 0, and executePerpsSignalWithLeverage returns
+							// early on signal==0). The Signal==0 trailing-SL/TP-ratchet
+							// management blocks below still run, keeping the open
+							// position's stop-loss ratcheting through the latch window.
+							if cbManageOnly {
+								result.Signal = 0
+							}
 							// #879: single-source regime — read the global store for this
 							// strategy's signature instead of the check output, and point
 							// result.Regime at it so stamp-at-open inside execute* shares it.

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1354,6 +1354,28 @@ const (
 	RiskReasonConsecutiveLosses    = "5 consecutive losses"
 )
 
+// circuitBreakerPermitsManagement reports whether a CheckRisk block should still
+// run existing-position management (trailing SL ratchet, TP ratchet, protection
+// sync) for an open position instead of skipping the strategy outright. A
+// per-strategy circuit breaker exists to block NEW entries; it must not freeze
+// the stop-loss on a position that is already open — e.g. a shared-coin residual
+// the CB cannot force-close (shouldForceCloseAllPositionsOnCircuitBreaker is
+// false when the coin is shared), which then sits with a stale trailing SL for
+// the whole latch window and fails to lock in favorable movement (#1046).
+//
+// Scoped to the latched reason and to HL perps: only that path runs the
+// trailing-SL/TP-ratchet walker. Manual strategies are exempt from CheckRisk
+// entirely (returns allowed early), and other platforms/types have no equivalent
+// in-loop SL ratchet, so they keep the plain skip. The first-fire cycle (reason
+// "max drawdown exceeded" / "5 consecutive losses") is deliberately excluded:
+// that is the cycle that force-closes / enqueues the reduce-only drain, so the
+// position state is mid-transition; management resumes on the next (latched)
+// cycle, which is ~the entire latch window.
+func circuitBreakerPermitsManagement(reason, platform, stratType string, posQty float64) bool {
+	return reason == RiskReasonCircuitBreakerActive &&
+		platform == "hyperliquid" && stratType == "perps" && posQty > 0
+}
+
 // CheckRisk evaluates risk state and returns whether trading is allowed.
 // sc is the strategy config for this state (nil in some tests — platform
 // pending logic is skipped). assist carries pre-fetched per-platform state

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -3027,3 +3027,36 @@ func TestForceCloseAllPositions_TradeType_PerpsVsFutures(t *testing.T) {
 		})
 	}
 }
+
+// TestCircuitBreakerPermitsManagement verifies the #1046 gate that lets a
+// latched per-strategy circuit breaker keep running trailing-SL/TP management
+// on an open HL perps position while still skipping every other CB-blocked case.
+func TestCircuitBreakerPermitsManagement(t *testing.T) {
+	cases := []struct {
+		name      string
+		reason    string
+		platform  string
+		stratType string
+		posQty    float64
+		want      bool
+	}{
+		{"latched CB, open HL perps -> manage", RiskReasonCircuitBreakerActive, "hyperliquid", "perps", 0.5, true},
+		{"latched CB, no open position -> skip", RiskReasonCircuitBreakerActive, "hyperliquid", "perps", 0, false},
+		{"latched CB, flat-ish negative qty guard -> skip", RiskReasonCircuitBreakerActive, "hyperliquid", "perps", -0.1, false},
+		{"first-fire max drawdown -> skip (mid-transition)", RiskReasonMaxDrawdownExceeded, "hyperliquid", "perps", 0.5, false},
+		{"first-fire max drawdown formatted -> skip", RiskReasonMaxDrawdownExceeded + " (40.0% > 18.0%)", "hyperliquid", "perps", 0.5, false},
+		{"first-fire consecutive losses -> skip", RiskReasonConsecutiveLosses, "hyperliquid", "perps", 0.5, false},
+		{"latched CB, OKX perps -> skip (no HL walker)", RiskReasonCircuitBreakerActive, "okx", "perps", 0.5, false},
+		{"latched CB, HL futures -> skip", RiskReasonCircuitBreakerActive, "hyperliquid", "futures", 0.5, false},
+		{"latched CB, HL spot -> skip", RiskReasonCircuitBreakerActive, "hyperliquid", "spot", 0.5, false},
+		{"empty reason (allowed) -> skip", "", "hyperliquid", "perps", 0.5, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := circuitBreakerPermitsManagement(tc.reason, tc.platform, tc.stratType, tc.posQty); got != tc.want {
+				t.Errorf("circuitBreakerPermitsManagement(%q, %q, %q, %v) = %v, want %v",
+					tc.reason, tc.platform, tc.stratType, tc.posQty, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1046

## Problem

A latched per-strategy circuit breaker returns `(false, RiskReasonCircuitBreakerActive)` from `CheckRisk` (`risk.go:1374-1376`), and the per-strategy loop `continue`s past the entire body (`main.go:1546`). That skips the `Signal==0` position-management blocks — the trailing-SL update, TP ratchet, and protection sync — so an open position's stop-loss stops ratcheting for the whole latch window (up to 24h), leaving a stale trigger that fails to lock in favorable movement.

The gap bites **shared-coin HL perps** positions specifically: on those, the CB skips force-close (`shouldForceCloseAllPositionsOnCircuitBreaker` returns `!hyperliquidCircuitBreakerHasSharedCoin`, `risk.go:949-950`), so the position survives the latch instead of being flattened — and then sits unprotected.

## Fix

When a **latched** CB blocks an **HL perps** strategy that still has an **open position**, fall through in manage-only mode instead of skipping, then force `result.Signal = 0` right after the HL check returns.

Forcing the hold signal provably suppresses every position-changing path:
- scale-in and live execute gate on `result.Signal != 0` → skipped
- `executePerpsSignalWithLeverage` returns `(0, nil)` immediately on `signal == 0` (`portfolio.go:1116-1118`) → paper/deferred open is a no-op

…while the existing `Signal==0` blocks (trailing-SL update, TP ratchet, protection sync) run normally.

**Safety:** the change only *adds* protective management under a latched CB; it removes nothing that previously ran (the whole loop was skipped before), and `Signal=0` can never open a position. So it is strictly safer than current behavior and cannot regress entry-blocking.

## Scope decisions

- **Latched CB only.** The first-fire cycle (`max drawdown exceeded` / `5 consecutive losses`) is excluded — that is the cycle that force-closes / enqueues the reduce-only drain, so position state is mid-transition. Management resumes the next cycle, i.e. ~the entire latch window.
- **Live shared-coin HL perps only.** Manual is exempt from `CheckRisk` (`risk.go:1365-1367`); futures/OKX have no in-loop HL trailing-SL walker. Paper does **not** benefit: the shared-coin force-close skip is live-only (`hyperliquidCircuitBreakerHasSharedCoin` gated on `hyperliquidIsLive`, `risk.go:939`), so paper positions are force-closed on the first-fire cycle and none survive the latch to manage. Paper shared-coin coverage would require a separate change.
- The notional-cap skip is bypassed under manage-only (the position is never grown anyway).

## Changes

- `risk.go` — new pure helper `circuitBreakerPermitsManagement(reason, platform, type, posQty)`.
- `main.go` — manage-only fall-through + `Signal=0` force in the HL check branch.
- `risk_test.go` — 10-case table test for the gate.

## Testing

- `go build .` clean, `gofmt` clean.
- Full scheduler Go test suite passes (`go test .`).
- New `TestCircuitBreakerPermitsManagement` covers: latched-CB open perps → manage; no position / negative qty → skip; first-fire reasons (plain + formatted) → skip; OKX/futures/spot → skip; empty reason → skip.

---
Updated with LLM: Opus 4.8 | xhigh | Harness: Claude Code
