### PR TITLE
feat(#1048): per-strategy circuit-breaker enable/disable flag

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -242,6 +242,18 @@ func (c *Config) NotifyTPSLFillsEnabled() bool {
 	return *c.NotifyTPSLFills
 }
 
+// CircuitBreakerEnabled reports whether the per-strategy circuit breaker is
+// active. Nil pointer (missing field) defaults to true so existing configs keep
+// the auto-protective behavior without an explicit opt-in; an explicit false
+// disables both firing arms in CheckRisk (drawdown and consecutive-loss). Safe
+// on a nil receiver (treated as enabled). (#1048)
+func (sc *StrategyConfig) CircuitBreakerEnabled() bool {
+	if sc == nil || sc.CircuitBreaker == nil {
+		return true
+	}
+	return *sc.CircuitBreaker
+}
+
 // ParseSummaryFrequency converts a summary_frequency value to a duration.
 // Returns -1 to mean "use legacy default", 0 to mean "every channel run", or a
 // positive duration when caller should post every duration. An unrecognized
@@ -347,6 +359,7 @@ type StrategyConfig struct {
 	CapitalPct              float64                  `json:"capital_pct,omitempty"`     // 0-1; dynamic capital = wallet_balance * capital_pct (overrides capital)
 	InitialCapital          float64                  `json:"initial_capital,omitempty"` // fixed starting balance for PnL display (never overwritten by capital_pct)
 	MaxDrawdownPct          float64                  `json:"max_drawdown_pct"`
+	CircuitBreaker          *bool                    `json:"circuit_breaker,omitempty"`            // #1048 — per-strategy circuit-breaker opt-out. Nil/missing → enabled (the safe default); explicit false disables BOTH firing arms in CheckRisk (drawdown > max_drawdown_pct AND 5 consecutive losses), uniformly for live and paper (no platform/live gating). Hot-reloadable via SIGHUP including while a position is open: disabling only suppresses NEW fires — an already-latched CB and any pending circuit close still drain. No effect on type=manual (exempt from CheckRisk). Read via CircuitBreakerEnabled(), never directly.
 	IntervalSeconds         int                      `json:"interval_seconds,omitempty"`           // per-strategy override (0 = use global)
 	HTFFilter               bool                     `json:"htf_filter,omitempty"`                 // higher-timeframe trend filter
 	InvertSignal            bool                     `json:"invert_signal,omitempty"`              // HL perps/manual only: flip BUY<->SELL on a non-zero signal before execution (HOLD/0 is never flipped). Lets inverse variants reuse the same open/close refs. Composes with Direction — invert runs in the Go layer before direction interprets the resulting sign (e.g. direction="short" + invert_signal=true opens short on raw-BUY triggers, distinct from plain direction="short" which opens on raw-SELL). Rejected outside HL perps/manual.

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -59,6 +59,17 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 				ss.RiskState.MaxDrawdownPct = ns.MaxDrawdownPct
 			}
 		}
+		// #1048: per-strategy circuit-breaker toggle is hot-reloadable always,
+		// including while a position is open (no state-compat guard). Disabling
+		// only suppresses NEW fires from the next cycle; an already-latched CB
+		// and any pending circuit close continue to drain. Re-enabling resumes
+		// evaluation next cycle and may fire immediately if already past a
+		// threshold — intended re-arming. The next CheckRisk reads sc.CircuitBreaker
+		// directly, so no state mutation is needed here.
+		if !boolPtrEqual(sc.CircuitBreaker, ns.CircuitBreaker) {
+			addChange("strategy[%s].circuit_breaker: %s -> %s", sc.ID, formatCircuitBreaker(sc.CircuitBreaker), formatCircuitBreaker(ns.CircuitBreaker))
+			sc.CircuitBreaker = ns.CircuitBreaker
+		}
 		if sc.CapitalPct == 0 && sc.Capital != ns.Capital {
 			addChange("strategy[%s].capital: $%.2f -> $%.2f", sc.ID, sc.Capital, ns.Capital)
 			sc.Capital = ns.Capital
@@ -579,6 +590,7 @@ func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error 
 
 func strategyRestartShape(sc StrategyConfig) StrategyConfig {
 	sc.MaxDrawdownPct = 0
+	sc.CircuitBreaker = nil // #1048: hot-reloadable always, including while open. No state-compat guard — disabling only suppresses new fires; an already-latched CB and pending close still drain, and re-enabling just resumes evaluation on the next cycle.
 	sc.Capital = 0
 	sc.Leverage = 0
 	sc.SizingLeverage = 0
@@ -645,6 +657,26 @@ func formatFloatPtrUSD(p *float64) string {
 		return "<nil>"
 	}
 	return fmt.Sprintf("$%.2f", *p)
+}
+
+func boolPtrEqual(a, b *bool) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+// formatCircuitBreaker renders the per-strategy circuit-breaker flag for reload
+// change logs. nil → "default(on)" so an operator sees the implicit-enabled
+// state explicitly; explicit true/false → "on"/"off". (#1048)
+func formatCircuitBreaker(p *bool) string {
+	if p == nil {
+		return "default(on)"
+	}
+	if *p {
+		return "on"
+	}
+	return "off"
 }
 
 func strategyConfigByID(strategies []StrategyConfig) map[string]StrategyConfig {

--- a/scheduler/config_reload_test.go
+++ b/scheduler/config_reload_test.go
@@ -1369,3 +1369,69 @@ func TestValidateHotReloadCompatible_RegimeWindowOnlyChange(t *testing.T) {
 		t.Fatalf("pure regime_gate_window change should be hot-reloadable: %v", err)
 	}
 }
+
+// #1048: the circuit-breaker toggle is hot-reloadable always, including while a
+// position is open — it must NOT be rejected by the reload validators, and the
+// new value must actually be applied to the running config.
+func TestApplyHotReloadConfig_CircuitBreakerToggleWhileOpen(t *testing.T) {
+	falseVal, trueVal := false, true
+	base := func(cb *bool) []StrategyConfig {
+		return []StrategyConfig{{
+			ID: "hl-eth", Type: "perps", Platform: "hyperliquid",
+			Script:  "shared_scripts/check_hyperliquid.py",
+			Args:    []string{"momentum", "ETH", "1h", "--mode=paper"},
+			Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, Direction: DirectionLong,
+			CircuitBreaker: cb,
+		}}
+	}
+	openState := func() *AppState {
+		return &AppState{Strategies: map[string]*StrategyState{
+			"hl-eth": {
+				ID: "hl-eth", Cash: 900,
+				RiskState: RiskState{MaxDrawdownPct: 10},
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 1, Side: "long", AvgCost: 3000, Leverage: 2},
+				},
+			},
+		}}
+	}
+
+	// on (nil) → off while a position is open: accepted, value applied, change logged.
+	cfg := minimalReloadConfig(base(nil))
+	next := minimalReloadConfig(base(&falseVal))
+	changes, err := applyHotReloadConfig(cfg, next, openState(), nil, nil)
+	if err != nil {
+		t.Fatalf("circuit_breaker on->off while open should be hot-reloadable: %v", err)
+	}
+	if cfg.Strategies[0].CircuitBreakerEnabled() {
+		t.Fatal("expected circuit breaker disabled after reload")
+	}
+	if !strings.Contains(strings.Join(changes, "\n"), "circuit_breaker") {
+		t.Fatalf("expected a circuit_breaker change entry, got %v", changes)
+	}
+
+	// off → on (re-arm) while a position is open: accepted, value applied.
+	cfg = minimalReloadConfig(base(&falseVal))
+	next = minimalReloadConfig(base(&trueVal))
+	if _, err := applyHotReloadConfig(cfg, next, openState(), nil, nil); err != nil {
+		t.Fatalf("circuit_breaker off->on while open should be hot-reloadable: %v", err)
+	}
+	if !cfg.Strategies[0].CircuitBreakerEnabled() {
+		t.Fatal("expected circuit breaker re-enabled after reload")
+	}
+}
+
+// #1048: a circuit_breaker-only change must not register in the restart shape
+// (else validateHotReloadCompatible would flag it as restart-required).
+func TestStrategyRestartShape_CircuitBreakerOnlyChange(t *testing.T) {
+	on, off := true, false
+	a := StrategyConfig{ID: "hl-a", CircuitBreaker: &on}
+	b := StrategyConfig{ID: "hl-a", CircuitBreaker: &off}
+	c := StrategyConfig{ID: "hl-a", CircuitBreaker: nil}
+	if !reflect.DeepEqual(strategyRestartShape(a), strategyRestartShape(b)) {
+		t.Fatal("circuit_breaker on/off change should not affect restart shape")
+	}
+	if !reflect.DeepEqual(strategyRestartShape(a), strategyRestartShape(c)) {
+		t.Fatal("circuit_breaker set-vs-nil should not affect restart shape")
+	}
+}

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -2675,3 +2675,26 @@ func TestLoadConfigForProbeSkipsLiveCredentialChecks(t *testing.T) {
 		t.Fatalf("LoadConfigForProbe should skip live credential checks: %v", err)
 	}
 }
+
+// #1048: CircuitBreakerEnabled defaults to true (safe default) for nil receiver
+// and nil field; explicit true/false are honored.
+func TestCircuitBreakerEnabled_DefaultsToTrue(t *testing.T) {
+	var nilSC *StrategyConfig
+	if !nilSC.CircuitBreakerEnabled() {
+		t.Fatal("nil receiver should report enabled")
+	}
+	sc := &StrategyConfig{}
+	if !sc.CircuitBreakerEnabled() {
+		t.Fatal("nil CircuitBreaker field should report enabled")
+	}
+	f := false
+	sc.CircuitBreaker = &f
+	if sc.CircuitBreakerEnabled() {
+		t.Fatal("explicit false should report disabled")
+	}
+	tr := true
+	sc.CircuitBreaker = &tr
+	if !sc.CircuitBreakerEnabled() {
+		t.Fatal("explicit true should report enabled")
+	}
+}

--- a/scheduler/config_unknown_keys_test.go
+++ b/scheduler/config_unknown_keys_test.go
@@ -115,12 +115,21 @@ func TestValidateStrategyJSONKeysAcceptsAllKnownFields(t *testing.T) {
 				"stop_loss_atr_mult": 1.5,
 				"trailing_stop_min_move_pct": 0.5,
 				"direction": "long",
-				"max_drawdown_pct": 50
+				"max_drawdown_pct": 50,
+				"circuit_breaker": false
 			}
 		]
 	}`)
 	if errs := validateStrategyJSONKeys(raw); len(errs) != 0 {
 		t.Fatalf("expected no errors for known fields, got: %v", errs)
+	}
+}
+
+// #1048: the reflection-derived known-key set must include the new
+// circuit_breaker field so configs carrying it validate.
+func TestKnownStrategyConfigKeysIncludesCircuitBreaker(t *testing.T) {
+	if !knownStrategyConfigKeys()["circuit_breaker"] {
+		t.Fatal("circuit_breaker should be a known strategy config key")
 	}
 }
 

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -381,6 +381,7 @@ type InitOptions struct {
 	OKXDrawdown             float64
 	CapitalPct              float64 `json:"capitalPct,omitempty"` // 0-1; global capital_pct applied to all strategies
 	HTFFilter               bool    // higher-timeframe trend filter for all strategies
+	DisableCircuitBreaker   bool    `json:"disableCircuitBreaker,omitempty"` // #1048 — when true, stamp circuit_breaker:false on every generated non-manual strategy (fleet-wide opt-out of the per-strategy circuit breaker). Default false keeps the safe default (CB on). Exposed for the JSON-driven `init --json` path; the interactive wizard leaves it false (disabling an auto-protective halt at setup is a footgun — operators opt out per-strategy via config edit + SIGHUP instead).
 	// Risk settings — prompted explicitly during live-mode setup (#85) so operators
 	// don't hit the post-launch migration DM for portfolio_risk fields.
 	PortfolioMaxDrawdownPct   float64 `json:"portfolioMaxDrawdownPct,omitempty"`   // kill switch threshold; 0 → default 25
@@ -734,6 +735,20 @@ func generateConfig(opts InitOptions) *Config {
 			if cfg.Strategies[i].Type != "options" && (len(cfg.Strategies[i].Args) == 0 || cfg.Strategies[i].Args[0] != "delta_neutral_funding") {
 				cfg.Strategies[i].HTFFilter = true
 			}
+		}
+	}
+
+	// #1048: fleet-wide circuit-breaker opt-out. Default (false) leaves
+	// CircuitBreaker nil → enabled (the safe default). When set, stamp explicit
+	// false on every non-manual strategy; manual is exempt from CheckRisk so the
+	// flag is a no-op there and is skipped to avoid implying otherwise.
+	if opts.DisableCircuitBreaker {
+		cbOff := false
+		for i := range cfg.Strategies {
+			if cfg.Strategies[i].Type == "manual" {
+				continue
+			}
+			cfg.Strategies[i].CircuitBreaker = &cbOff
 		}
 	}
 

--- a/scheduler/init_test.go
+++ b/scheduler/init_test.go
@@ -1612,3 +1612,61 @@ func TestRunInitFromJSON_WriteError(t *testing.T) {
 		t.Errorf("expected exit code 1 when writing to a directory, got %d", code)
 	}
 }
+
+// #1048: DisableCircuitBreaker stamps circuit_breaker:false on every generated
+// non-manual strategy; manual is exempt from CheckRisk so it is skipped (left
+// nil). Default (false) leaves every strategy nil → enabled.
+func TestGenerateConfig_DisableCircuitBreaker(t *testing.T) {
+	opts := InitOptions{
+		Assets:          []string{"BTC", "ETH"},
+		EnableSpot:      true,
+		EnablePerps:     true,
+		PerpsMode:       "paper",
+		SpotStrategies:  []string{"momentum"},
+		PerpsStrategies: []string{"momentum"},
+		SpotCapital:     1000,
+		PerpsCapital:    1000,
+		SpotDrawdown:    5,
+		PerpsDrawdown:   5,
+		// #569 manual tracking strategy — must stay nil (CB no-op for manual).
+		EnableManual:    true,
+		ManualSymbol:    "ETH",
+		ManualTimeframe: "1h",
+		ManualCapital:   1000,
+		ManualDrawdown:  20,
+		ManualLeverage:  20,
+	}
+
+	// Default: no stamping — every strategy stays nil → enabled.
+	def := generateConfig(opts)
+	for _, s := range def.Strategies {
+		if s.CircuitBreaker != nil {
+			t.Fatalf("default generateConfig should leave circuit_breaker nil; %s has %v", s.ID, *s.CircuitBreaker)
+		}
+	}
+
+	// Opt-out: every non-manual strategy gets explicit false; manual stays nil.
+	opts.DisableCircuitBreaker = true
+	cfg := generateConfig(opts)
+	sawNonManual := false
+	sawManual := false
+	for _, s := range cfg.Strategies {
+		if s.Type == "manual" {
+			sawManual = true
+			if s.CircuitBreaker != nil {
+				t.Fatalf("manual strategy %s should be skipped (CB no-op), got %v", s.ID, *s.CircuitBreaker)
+			}
+			continue
+		}
+		sawNonManual = true
+		if s.CircuitBreaker == nil || *s.CircuitBreaker {
+			t.Fatalf("non-manual strategy %s should have circuit_breaker:false, got %v", s.ID, s.CircuitBreaker)
+		}
+	}
+	if !sawNonManual {
+		t.Fatal("expected at least one non-manual strategy")
+	}
+	if !sawManual {
+		t.Fatal("expected the manual tracking strategy to be generated")
+	}
+}

--- a/scheduler/inspect_cmd.go
+++ b/scheduler/inspect_cmd.go
@@ -496,6 +496,12 @@ func formatStrategyInspection(sc StrategyConfig, explicit map[string]bool, cfg *
 	}
 
 	fmt.Fprintf(&b, "  max_drawdown_pct:    %g%s\n", sc.MaxDrawdownPct, markIfDefault(explicit, "max_drawdown_pct"))
+	// #1048: circuit-breaker state (skip manual — exempt from CheckRisk). Surface
+	// only when explicitly disabled so the unprotected case is visible; the
+	// default-on state stays uncluttered.
+	if sc.Type != "manual" && !sc.CircuitBreakerEnabled() {
+		fmt.Fprintf(&b, "  circuit_breaker:     off (explicit) — drawdown + consecutive-loss halt disabled\n")
+	}
 	if sc.IntervalSeconds > 0 {
 		fmt.Fprintf(&b, "  interval_seconds:    %d\n", sc.IntervalSeconds)
 	} else if cfg != nil {
@@ -548,6 +554,13 @@ func formatStrategySummaryLine(sc StrategyConfig, explicit map[string]bool) stri
 			parts = append(parts, "tp=none")
 		}
 	}
+	// #1048: surface an explicitly disabled circuit breaker so a strategy
+	// trading live without the auto-protective drawdown/loss-streak halt is not
+	// silently unprotected. Manual is exempt from CheckRisk, so the flag is a
+	// no-op there and not shown.
+	if sc.Type != "manual" && !sc.CircuitBreakerEnabled() {
+		parts = append(parts, "cb=off")
+	}
 	return fmt.Sprintf("[config] %s: %s", sc.ID, strings.Join(parts, " "))
 }
 
@@ -578,6 +591,12 @@ func buildStrategyInspectionJSON(sc StrategyConfig, explicit map[string]bool, cf
 		"close_strategy_explicit":   explicit["close_strategy"],
 		"max_drawdown_pct":          sc.MaxDrawdownPct,
 		"max_drawdown_pct_explicit": explicit["max_drawdown_pct"],
+	}
+	// #1048: circuit-breaker enable state. Manual is exempt from CheckRisk, so
+	// the flag is meaningless there and omitted.
+	if sc.Type != "manual" {
+		out["circuit_breaker_enabled"] = sc.CircuitBreakerEnabled()
+		out["circuit_breaker_explicit"] = explicit["circuit_breaker"]
 	}
 	if cfg != nil && cfg.Regime != nil && len(cfg.Regime.Windows) > 0 {
 		out["regime_windows"] = cfg.Regime.Windows

--- a/scheduler/inspect_cmd_test.go
+++ b/scheduler/inspect_cmd_test.go
@@ -434,3 +434,34 @@ func TestFormatStrategyInspectionPositionOrderDeterministic(t *testing.T) {
 		t.Errorf("positions should be sorted by symbol (BTC before ETH), got BTC@%d ETH@%d", btc, eth)
 	}
 }
+
+// #1048: a strategy with the circuit breaker explicitly disabled surfaces
+// "cb=off" in the startup summary so it isn't silently unprotected; an enabled
+// (default) strategy and a manual strategy (CB no-op) show nothing.
+func TestFormatStrategySummaryLineShowsCircuitBreakerOff(t *testing.T) {
+	off := false
+	disabled := StrategyConfig{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid",
+		OpenStrategy: StrategyRef{Name: "momentum"}, CircuitBreaker: &off,
+	}
+	if line := formatStrategySummaryLine(disabled, nil); !strings.Contains(line, "cb=off") {
+		t.Errorf("disabled CB should show cb=off: %s", line)
+	}
+
+	enabled := StrategyConfig{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid",
+		OpenStrategy: StrategyRef{Name: "momentum"},
+	}
+	if line := formatStrategySummaryLine(enabled, nil); strings.Contains(line, "cb=") {
+		t.Errorf("default CB should not mention cb=: %s", line)
+	}
+
+	// Manual is exempt from CheckRisk — the flag is a no-op, so don't surface it.
+	manual := StrategyConfig{
+		ID: "manual-eth", Type: "manual", Platform: "hyperliquid",
+		OpenStrategy: StrategyRef{Name: "hold"}, CircuitBreaker: &off,
+	}
+	if line := formatStrategySummaryLine(manual, nil); strings.Contains(line, "cb=") {
+		t.Errorf("manual strategy should not mention cb=: %s", line)
+	}
+}

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
+	"sync"
 	"time"
 )
 
@@ -1408,6 +1410,14 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 	// ungated), and CurrentDrawdownPct/peak still update for the status UI. Manual
 	// is already exempt via the early return at the top of CheckRisk.
 	cbEnabled := sc.CircuitBreakerEnabled()
+	if cbEnabled {
+		// Clear any sticky suppression-warning throttle eagerly: while the
+		// breaker is enabled the warning never applies, and an enabled+breached
+		// cycle fires (returning before recordCircuitBreakerSuppression below),
+		// so this is the only place a re-enable reliably resets the throttle —
+		// ensuring a later re-disable warns afresh. (#1048)
+		circuitBreakerSuppressedWarned.Delete(s.ID)
+	}
 
 	// Update peak
 	if portfolioValue > r.PeakValue {
@@ -1488,7 +1498,56 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 		return false, RiskReasonConsecutiveLosses
 	}
 
+	// #1048: if the circuit breaker is disabled and a halt threshold was just
+	// crossed, the two arms above fell through silently. Leave a runtime trace
+	// (a WARNING, not a halt) so the missing auto-protection is observable in
+	// logs at the cycle it matters — not only at startup / on-demand inspect.
+	recordCircuitBreakerSuppression(s, cbEnabled, logger)
+
 	return true, ""
+}
+
+// circuitBreakerSuppressedWarned throttles the "circuit breaker disabled but a
+// halt threshold was crossed" warning to once per strategy per suppression
+// episode. The key is cleared by recordCircuitBreakerSuppression when the
+// breaker is re-enabled or the breach clears, so a fresh crossing — or a later
+// re-disable — warns again. (#1048)
+var circuitBreakerSuppressedWarned sync.Map
+
+// recordCircuitBreakerSuppression emits a one-shot WARNING when a strategy with
+// the circuit breaker explicitly disabled (circuit_breaker:false) crosses a
+// halt threshold that WOULD have fired. It makes the absence of the
+// auto-protective halt observable at the cycle it matters, not only via the
+// startup summary / inspect surfaces. It is a warning, never a halt: nothing is
+// closed and trading continues. The notice is deduped to once per suppression
+// episode and cleared when the breaker is re-enabled or all thresholds clear —
+// so a later genuine fire (once re-enabled) still alerts through the normal
+// circuit-breaker path, and a subsequent re-disable warns afresh. (#1048)
+func recordCircuitBreakerSuppression(s *StrategyState, cbEnabled bool, logger *StrategyLogger) {
+	if s == nil {
+		return
+	}
+	r := &s.RiskState
+	drawdownBreached := r.PeakValue > 0 && r.CurrentDrawdownPct > r.MaxDrawdownPct
+	lossBreached := r.ConsecutiveLosses >= 5
+	if cbEnabled || (!drawdownBreached && !lossBreached) {
+		circuitBreakerSuppressedWarned.Delete(s.ID)
+		return
+	}
+	if _, loaded := circuitBreakerSuppressedWarned.LoadOrStore(s.ID, struct{}{}); loaded {
+		return // already warned this episode — do not repeat every cycle
+	}
+	var reasons []string
+	if drawdownBreached {
+		reasons = append(reasons, fmt.Sprintf("drawdown %.1f%% > %.1f%%", r.CurrentDrawdownPct, r.MaxDrawdownPct))
+	}
+	if lossBreached {
+		reasons = append(reasons, fmt.Sprintf("%d consecutive losses", r.ConsecutiveLosses))
+	}
+	if logger != nil {
+		logger.Warn("WARNING: circuit breaker is DISABLED (circuit_breaker:false) and a halt threshold was crossed (%s) — NO circuit breaker fired. This strategy is trading WITHOUT the drawdown/consecutive-loss auto-halt and positions are NOT being auto-closed on this condition. This is a warning only (nothing was closed); re-enable circuit_breaker to restore protection.",
+			strings.Join(reasons, "; "))
+	}
 }
 
 // RecordTradeResult updates risk state with realized PnL for daily limits and

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1401,6 +1401,14 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 		r.ConsecutiveLosses = 0
 	}
 
+	// #1048: per-strategy circuit-breaker opt-out. When explicitly disabled, both
+	// firing arms below are suppressed so the strategy never latches a NEW circuit
+	// break. The gate sits BELOW the latch check and the drawdown computation on
+	// purpose: an already-latched CB still blocks/drains (the latch check above is
+	// ungated), and CurrentDrawdownPct/peak still update for the status UI. Manual
+	// is already exempt via the early return at the top of CheckRisk.
+	cbEnabled := sc.CircuitBreakerEnabled()
+
 	// Update peak
 	if portfolioValue > r.PeakValue {
 		r.PeakValue = portfolioValue
@@ -1449,7 +1457,7 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 		} else {
 			r.CurrentDrawdownPct = 0
 		}
-		if r.CurrentDrawdownPct > r.MaxDrawdownPct {
+		if r.CurrentDrawdownPct > r.MaxDrawdownPct && cbEnabled {
 			r.CircuitBreaker = true
 			r.CircuitBreakerUntil = now.Add(24 * time.Hour)
 			setHyperliquidCircuitBreakerPending(sc, s, assist)
@@ -1466,7 +1474,7 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 	}
 
 	// Consecutive losses circuit breaker (5 in a row → pause 1h, close positions)
-	if r.ConsecutiveLosses >= 5 {
+	if r.ConsecutiveLosses >= 5 && cbEnabled {
 		r.CircuitBreaker = true
 		r.CircuitBreakerUntil = now.Add(1 * time.Hour)
 		setHyperliquidCircuitBreakerPending(sc, s, assist)

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1528,7 +1528,10 @@ func recordCircuitBreakerSuppression(s *StrategyState, cbEnabled bool, logger *S
 		return
 	}
 	r := &s.RiskState
-	drawdownBreached := r.PeakValue > 0 && r.CurrentDrawdownPct > r.MaxDrawdownPct
+	// Mirror the drawdown arm's condition exactly (risk.go ~1470) so the warning
+	// stays in sync if that gate is later edited — the PeakValue>0 guard is
+	// implicit there (CurrentDrawdownPct is 0 when PeakValue is 0). (#1048)
+	drawdownBreached := r.CurrentDrawdownPct > r.MaxDrawdownPct
 	lossBreached := r.ConsecutiveLosses >= 5
 	if cbEnabled || (!drawdownBreached && !lossBreached) {
 		circuitBreakerSuppressedWarned.Delete(s.ID)

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"strings"
@@ -3181,5 +3182,123 @@ func TestCheckRisk_CircuitBreakerDisabled_StillHonorsExistingLatch(t *testing.T)
 	}
 	if reason != RiskReasonCircuitBreakerActive {
 		t.Fatalf("reason = %q, want %q", reason, RiskReasonCircuitBreakerActive)
+	}
+}
+
+// #1048: a strategy with the circuit breaker disabled that crosses a halt
+// threshold must leave a runtime WARNING — once per suppression episode, not
+// every cycle — clearly stating there is NO circuit breaker and that it is only
+// a warning (nothing closed). Re-enabling or clearing the breach resets the
+// throttle so a later episode warns again.
+func TestCheckRisk_CircuitBreakerDisabled_WarnsOncePerEpisode(t *testing.T) {
+	off, on := false, true
+	id := "hl-cb-suppress-warn"
+	circuitBreakerSuppressedWarned.Delete(id) // isolate from other tests
+
+	newState := func() *StrategyState {
+		// drawdown 23% > 20% AND 5 consecutive losses → both arms would fire.
+		return &StrategyState{
+			ID:   id,
+			Type: "perps",
+			Cash: 7700,
+			RiskState: RiskState{
+				PeakValue:         10000,
+				MaxDrawdownPct:    20,
+				ConsecutiveLosses: 5,
+				DailyPnLDate:      todayUTC(),
+			},
+			Positions:       map[string]*Position{},
+			OptionPositions: map[string]*OptionPosition{},
+			TradeHistory:    []Trade{},
+		}
+	}
+	scWith := func(cb *bool) *StrategyConfig {
+		return &StrategyConfig{
+			ID: id, Type: "perps", Platform: "hyperliquid",
+			Args: []string{"momentum", "ETH", "1h", "--mode=live"}, MaxDrawdownPct: 20, CircuitBreaker: cb,
+		}
+	}
+	// run executes one CheckRisk cycle against a fresh breached state and returns
+	// (allowed, logOutput).
+	run := func(cb *bool) (bool, string) {
+		var buf bytes.Buffer
+		logger := &StrategyLogger{stratID: id, writer: &buf}
+		s := newState()
+		allowed, _ := CheckRisk(scWith(cb), s, PortfolioValue(s, nil), nil, logger, nil)
+		return allowed, buf.String()
+	}
+
+	// First disabled cycle that breaches: trading is allowed (no halt), and the
+	// warning names the missing protection on both arms.
+	allowed, out := run(&off)
+	if !allowed {
+		t.Fatal("disabled CB should allow trading")
+	}
+	for _, want := range []string{"WARN", "DISABLED", "NO circuit breaker", "warning only", "drawdown 23.0% > 20.0%", "5 consecutive losses"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("first suppression cycle missing %q in: %s", want, out)
+		}
+	}
+
+	// Second disabled+breached cycle: deduped — no new warning.
+	if _, out := run(&off); strings.Contains(out, "circuit breaker is DISABLED") {
+		t.Fatalf("expected dedup (no repeat warning) on the second cycle, got: %s", out)
+	}
+
+	// Re-enable while still breached: the genuine circuit breaker FIRES (normal
+	// path, allowed=false), does NOT emit the suppression warning, and the
+	// throttle is cleared so a later re-disable warns afresh.
+	allowed, out = run(&on)
+	if allowed {
+		t.Fatal("re-enabled CB on a breached state should fire")
+	}
+	if strings.Contains(out, "circuit breaker is DISABLED") {
+		t.Fatalf("enabled CB must not emit a suppression warning, got: %s", out)
+	}
+	if _, ok := circuitBreakerSuppressedWarned.Load(id); ok {
+		t.Fatal("re-enabling should clear the suppression throttle")
+	}
+
+	// Disable again after the re-enable: a fresh episode warns again.
+	if _, out := run(&off); !strings.Contains(out, "circuit breaker is DISABLED") {
+		t.Fatalf("a fresh suppression episode after re-enable should warn again, got: %s", out)
+	}
+
+	circuitBreakerSuppressedWarned.Delete(id)
+}
+
+// #1048: when the breach clears while still disabled, the throttle resets so a
+// later re-breach warns again (episode-scoped, not strategy-lifetime).
+func TestCheckRisk_CircuitBreakerDisabled_ThrottleClearsWhenBreachClears(t *testing.T) {
+	off := false
+	id := "hl-cb-suppress-clear"
+	circuitBreakerSuppressedWarned.Delete(id)
+	defer circuitBreakerSuppressedWarned.Delete(id)
+
+	sc := &StrategyConfig{
+		ID: id, Type: "perps", Platform: "hyperliquid",
+		Args: []string{"momentum", "ETH", "1h", "--mode=live"}, MaxDrawdownPct: 20, CircuitBreaker: &off,
+	}
+	breached := &StrategyState{
+		ID: id, Type: "perps", Cash: 7700,
+		RiskState:       RiskState{PeakValue: 10000, MaxDrawdownPct: 20, DailyPnLDate: todayUTC()},
+		Positions:       map[string]*Position{},
+		OptionPositions: map[string]*OptionPosition{},
+	}
+	CheckRisk(sc, breached, PortfolioValue(breached, nil), nil, &StrategyLogger{stratID: id, writer: &bytes.Buffer{}}, nil)
+	if _, ok := circuitBreakerSuppressedWarned.Load(id); !ok {
+		t.Fatal("expected throttle set after a breached disabled cycle")
+	}
+
+	// No breach this cycle (portfolio back at peak) → throttle cleared.
+	healthy := &StrategyState{
+		ID: id, Type: "perps", Cash: 10000,
+		RiskState:       RiskState{PeakValue: 10000, MaxDrawdownPct: 20, DailyPnLDate: todayUTC()},
+		Positions:       map[string]*Position{},
+		OptionPositions: map[string]*OptionPosition{},
+	}
+	CheckRisk(sc, healthy, PortfolioValue(healthy, nil), nil, &StrategyLogger{stratID: id, writer: &bytes.Buffer{}}, nil)
+	if _, ok := circuitBreakerSuppressedWarned.Load(id); ok {
+		t.Fatal("throttle should clear once the breach clears")
 	}
 }

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -3060,3 +3060,126 @@ func TestCircuitBreakerPermitsManagement(t *testing.T) {
 		})
 	}
 }
+
+// #1048: an explicit circuit_breaker:false suppresses BOTH firing arms (drawdown
+// and 5-consecutive-losses) for any non-manual strategy, uniformly for live and
+// paper — CheckRisk has no platform/live gating. nil and explicit true still
+// fire (regression). The display drawdown is computed regardless of the gate.
+func TestCheckRisk_CircuitBreakerDisabled_SuppressesBothArms(t *testing.T) {
+	falseVal, trueVal := false, true
+	liveArgs := []string{"momentum", "ETH", "1h", "--mode=live"}
+	paperArgs := []string{"momentum", "ETH", "1h", "--mode=paper"}
+
+	newDrawdownState := func() *StrategyState {
+		// peak 10000, portfolio 7700 → peak-relative drawdown 23% > 20% threshold.
+		// No open positions, so the perps margin branch falls back to peak-relative
+		// and a fire's force-close is a no-op (keeps the test focused on the gate).
+		return &StrategyState{
+			ID:   "hl-eth",
+			Type: "perps",
+			Cash: 7700,
+			RiskState: RiskState{
+				PeakValue:      10000,
+				MaxDrawdownPct: 20,
+				DailyPnLDate:   todayUTC(),
+			},
+			Positions:       map[string]*Position{},
+			OptionPositions: map[string]*OptionPosition{},
+			TradeHistory:    []Trade{},
+		}
+	}
+	newLossState := func() *StrategyState {
+		// No drawdown (portfolio == peak) so only the consecutive-loss arm is live.
+		return &StrategyState{
+			ID:   "hl-eth",
+			Type: "perps",
+			Cash: 10000,
+			RiskState: RiskState{
+				PeakValue:         10000,
+				MaxDrawdownPct:    20,
+				ConsecutiveLosses: 5,
+				DailyPnLDate:      todayUTC(),
+			},
+			Positions:       map[string]*Position{},
+			OptionPositions: map[string]*OptionPosition{},
+			TradeHistory:    []Trade{},
+		}
+	}
+
+	cases := []struct {
+		name     string
+		cb       *bool
+		args     []string
+		wantFire bool
+	}{
+		{"disabled-live", &falseVal, liveArgs, false},
+		{"disabled-paper", &falseVal, paperArgs, false},
+		{"nil-live", nil, liveArgs, true},
+		{"nil-paper", nil, paperArgs, true},
+		{"explicitTrue-live", &trueVal, liveArgs, true},
+		{"explicitTrue-paper", &trueVal, paperArgs, true},
+	}
+
+	for _, tc := range cases {
+		sc := func(args []string) *StrategyConfig {
+			return &StrategyConfig{
+				ID: "hl-eth", Type: "perps", Platform: "hyperliquid",
+				Args: args, MaxDrawdownPct: 20, CircuitBreaker: tc.cb,
+			}
+		}
+
+		t.Run("drawdown/"+tc.name, func(t *testing.T) {
+			s := newDrawdownState()
+			allowed, reason := CheckRisk(sc(tc.args), s, PortfolioValue(s, nil), nil, nil, nil)
+			if fired := !allowed; fired != tc.wantFire {
+				t.Fatalf("drawdown fire = %v (reason=%q), want %v", fired, reason, tc.wantFire)
+			}
+			// Display drawdown is always computed (suppress only the fire, not the math).
+			if got := s.RiskState.CurrentDrawdownPct; got < 22.9 || got > 23.1 {
+				t.Fatalf("CurrentDrawdownPct = %.2f, want ~23 even when CB disabled", got)
+			}
+		})
+
+		t.Run("losses/"+tc.name, func(t *testing.T) {
+			s := newLossState()
+			allowed, reason := CheckRisk(sc(tc.args), s, PortfolioValue(s, nil), nil, nil, nil)
+			if fired := !allowed; fired != tc.wantFire {
+				t.Fatalf("consecutive-loss fire = %v (reason=%q), want %v", fired, reason, tc.wantFire)
+			}
+		})
+	}
+}
+
+// #1048: disabling the circuit breaker must NOT bypass a CB that has already
+// latched. The latch check sits above the gate, so an in-flight circuit close
+// keeps draining (no new fire, but the existing block stands until its window
+// expires). This is the on→off-while-open contract.
+func TestCheckRisk_CircuitBreakerDisabled_StillHonorsExistingLatch(t *testing.T) {
+	off := false
+	s := &StrategyState{
+		ID:   "hl-eth",
+		Type: "perps",
+		Cash: 1000,
+		RiskState: RiskState{
+			PeakValue:           1000,
+			MaxDrawdownPct:      20,
+			CircuitBreaker:      true,
+			CircuitBreakerUntil: time.Now().UTC().Add(time.Hour),
+			DailyPnLDate:        todayUTC(),
+		},
+		Positions:       map[string]*Position{},
+		OptionPositions: map[string]*OptionPosition{},
+		TradeHistory:    []Trade{},
+	}
+	sc := &StrategyConfig{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid",
+		Args: []string{"momentum", "ETH", "1h", "--mode=live"}, MaxDrawdownPct: 20, CircuitBreaker: &off,
+	}
+	allowed, reason := CheckRisk(sc, s, PortfolioValue(s, nil), nil, nil, nil)
+	if allowed {
+		t.Fatal("disabling CB must not bypass an already-latched circuit breaker")
+	}
+	if reason != RiskReasonCircuitBreakerActive {
+		t.Fatalf("reason = %q, want %q", reason, RiskReasonCircuitBreakerActive)
+	}
+}


### PR DESCRIPTION
## Summary
Adds a per-strategy opt-out for the circuit breaker (CB). Today CB fires for every non-`manual` strategy with no off-switch: the drawdown arm can be neutered via a high `max_drawdown_pct`, but the hardcoded 5-consecutive-losses arm cannot be disabled at all. This adds `circuit_breaker *bool` on `StrategyConfig` (json `circuit_breaker`) — nil/missing → enabled (the safe default), explicit `false` → disabled. Applies uniformly to live and paper (CheckRisk has no platform/live gating). Closes #1048.

## Behavior
- **Gate** (`risk.go`): when disabled, both firing arms are suppressed (`r.CurrentDrawdownPct > MaxDrawdownPct` AND `ConsecutiveLosses >= 5`). The gate sits **below** the latch check and the drawdown computation: an already-latched CB and any pending circuit close still drain, and `CurrentDrawdownPct`/peak still update for display. `manual` stays exempt via the existing early return.
- **Hot reload** (`config_reload.go`): the toggle is hot-reloadable via SIGHUP **including while a position is open**. Mechanically this required adding `CircuitBreaker` to the `strategyRestartShape` allow-mask (otherwise the immutable-fields `DeepEqual` would flag a toggle as restart-required) plus an apply block so the new value is actually written; no state-compat guard. Disabling suppresses **new** fires only; re-enabling resumes evaluation next cycle and may fire immediately if already past a threshold.
- **Visibility** (`inspect_cmd.go`): `cb=off` in the `#704` startup summary line, plus text and JSON `inspect` surfaces, so a strategy trading without the auto-protective halt isn't silently unprotected (matters since disable is allowed on live money).
- **Init** (`init.go`): `DisableCircuitBreaker` on `InitOptions` is honored by `generateConfig` for non-manual strategies; the interactive wizard keeps the safe default (no "disable safety" prompt).
- Unknown-key guard is reflection-derived, so the field auto-registers. No config-version bump (optional nil-default field, precedent `NotifyTPSLFills`).

## Tests
`CheckRisk` both arms × {live, paper} with `circuit_breaker:false` (no fire) vs nil/true (fire, regression); display drawdown still computed when disabled; an already-latched CB still blocks when disabled; hot-reload toggle on↔off while a position is open is accepted and applied; restart-shape neutrality; `CircuitBreakerEnabled()` default; unknown-key acceptance; `generateConfig` stamping (non-manual only); startup-summary `cb=off`. Full Go suite green; `init --json` + `inspect` smoke confirms end-to-end.

Closes #1048

---
Created with LLM: Opus 4.8 | xhigh | Harness: Claude Code
https://claude.ai/code/session_01MCPJBFkFgrx2keUm65Q72n