### PR TITLE
feat(backtest): #1058 composite 7-state regime classification in the backtester

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -602,6 +602,7 @@ class Backtester:
                  regime_enabled: bool = False,
                  regime_period: int = 14,
                  regime_adx_threshold: float = 20.0,
+                 regime_windows_spec: Optional[dict] = None,
                  allowed_regimes: Optional[list[str]] = None,
                  stop_loss_atr_mult: Optional[float] = None,
                  stop_loss_pct: Optional[float] = None,
@@ -679,6 +680,15 @@ class Backtester:
         self.regime_enabled = regime_enabled
         self.regime_period = regime_period
         self.regime_adx_threshold = regime_adx_threshold
+        # #1058: optional composite (7-state) regime. When set, this is the live
+        # ``regime.windows`` spec map (already normalized: name -> {classifier,
+        # period, adx_threshold|thresholds}). The per-bar ``regime`` column and
+        # the close evaluator's ``_run_position_regime`` are then classified from
+        # the PRIMARY window — "medium" if present, else the first sorted key —
+        # mirroring live's REGIME_PRIMARY_WINDOW_KEY selection in
+        # regime_from_injected_payload. None keeps the legacy single-lookback ADX
+        # path (regime_period / regime_adx_threshold) byte-identical.
+        self.regime_windows_spec = dict(regime_windows_spec) if regime_windows_spec else None
         self.allowed_regimes = list(allowed_regimes or [])
         self.stop_loss_atr_mult = stop_loss_atr_mult
         self.stop_loss_pct = stop_loss_pct
@@ -1248,7 +1258,17 @@ class Backtester:
         # same OHLCV window → identical label by construction (same algorithm).
         if self.regime_enabled and "regime" not in df.columns:
             ensure_regime = _load_regime()
-            ensure_regime(df, period=self.regime_period, adx_threshold=self.regime_adx_threshold)
+            # #1058: when a composite windows spec is threaded, ensure_regime_columns
+            # classifies the PRIMARY window (medium-first) — composite (7-state) or
+            # ADX — exactly as live's regime store does for the strategy_regime that
+            # feeds close evaluators. Without it, the legacy single-lookback ADX
+            # (period / adx_threshold) path is unchanged.
+            ensure_regime(
+                df,
+                period=self.regime_period,
+                adx_threshold=self.regime_adx_threshold,
+                windows_spec=self.regime_windows_spec,
+            )
 
         # Snapshot the bar-close regime label before any shift so close
         # evaluators that re-resolve per bar (``tiered_tp_atr_live_regime``)

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -961,6 +961,20 @@ class Backtester:
         # thresholds once at init. When no sl_after is configured this is a
         # no-op and the per-bar SL machinery in run() short-circuits.
         self._sl_mod = _load_post_tp_sl()
+        # #1058: reject a tiered_tp_atr_regime / tiered_tp_atr_live_regime tier set
+        # keyed by labels the primary window's classifier can never emit (e.g. an
+        # ADX-keyed block under a composite primary, or the inverse) — live
+        # rejects it at config-load (regime_atr.go parseRegimeTPTiers with the
+        # ATR-window classifier labels). Without this the tier-fraction parser
+        # infers labels from the keys and resolve_regime_tier silently misses on
+        # every stamped label, disabling all take-profit tiers (a silent 0-TP run).
+        _tier_vocab_errs = self._sl_mod.validate_regime_tiered_tp_labels(
+            self._close_refs, labels=self._regime_primary_labels,
+        )
+        if _tier_vocab_errs:
+            raise ValueError(
+                "Invalid regime tiered-TP configuration: " + "; ".join(_tier_vocab_errs)
+            )
         self._sl_after_rules_static, _sl_parse_errs = (
             self._sl_mod.parse_strategy_tp_sl_after_rules(
                 self._close_refs, labels=self._regime_primary_labels)

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -105,6 +105,42 @@ def _load_regime():
     return _ensure_regime_fn
 
 
+def _regime_primary_labels(spec: Optional[dict]) -> Optional[tuple]:
+    """Valid regime labels for the PRIMARY (medium-first) window's classifier —
+    the vocabulary the backtester's single stamped regime label uses (#1058).
+
+    The regime-keyed exit consumers (``stop_loss_atr_regime`` /
+    ``trailing_stop_atr_regime`` / the ``sl_after`` regime block) validate and
+    resolve their per-label entries against this set, mirroring live's
+    ``regimeLabelsForStrategyWindow`` -> ``regimeLabelsForClassifier`` thread into
+    ``parseRegimeATRBlock`` / ``validatePostTPStopLossRulesWithLabels``. Without
+    it a composite-primary config would either be falsely rejected ("unknown
+    regime label 'ranging_quiet'") or, for an ADX-keyed block, silently resolve
+    to the default stop under a composite stamp.
+
+    Returns ``None`` for the legacy ADX path (no spec, or an ADX primary window)
+    so the parsers fall back to their canonical 3-label ADX default and the ADX
+    path stays byte-identical. Returns the sorted composite label tuple only when
+    the primary window is composite.
+    """
+    if not spec:
+        return None
+    from regime import (
+        valid_labels_for_classifier,
+        REGIME_PRIMARY_WINDOW_KEY,
+        CLASSIFIER_ADX,
+    )
+    primary_key = (
+        REGIME_PRIMARY_WINDOW_KEY
+        if REGIME_PRIMARY_WINDOW_KEY in spec
+        else sorted(spec.keys())[0]
+    )
+    classifier = str(spec[primary_key].get("classifier") or CLASSIFIER_ADX).strip().lower()
+    if classifier == CLASSIFIER_ADX:
+        return None
+    return tuple(sorted(valid_labels_for_classifier(classifier)))
+
+
 def _normalize_regime_directional_policy(policy: Optional[dict]) -> Optional[dict]:
     """Validate and compact ``regime_directional_policy`` for replay (#1025).
 
@@ -689,6 +725,11 @@ class Backtester:
         # regime_from_injected_payload. None keeps the legacy single-lookback ADX
         # path (regime_period / regime_adx_threshold) byte-identical.
         self.regime_windows_spec = dict(regime_windows_spec) if regime_windows_spec else None
+        # #1058: vocabulary the regime-keyed exit consumers (SL/trailing/sl_after)
+        # validate + resolve against — the primary window's classifier labels, so
+        # composite substates parse and resolve instead of being rejected or
+        # silently falling back to the default stop. None = legacy ADX (canonical).
+        self._regime_primary_labels = _regime_primary_labels(self.regime_windows_spec)
         self.allowed_regimes = list(allowed_regimes or [])
         self.stop_loss_atr_mult = stop_loss_atr_mult
         self.stop_loss_pct = stop_loss_pct
@@ -807,6 +848,7 @@ class Backtester:
                     self.stop_loss_atr_regime,
                     "stop_loss_atr_regime",
                     SURFACE_STOP_LOSS,
+                    labels=self._regime_primary_labels,
                 )
                 regime_errs.extend(errs)
                 self._stop_loss_regime_block = blk
@@ -815,6 +857,7 @@ class Backtester:
                     self.trailing_stop_atr_regime,
                     "trailing_stop_atr_regime",
                     SURFACE_TRAILING,
+                    labels=self._regime_primary_labels,
                 )
                 regime_errs.extend(errs)
                 self._trailing_stop_regime_block = blk
@@ -919,7 +962,8 @@ class Backtester:
         # no-op and the per-bar SL machinery in run() short-circuits.
         self._sl_mod = _load_post_tp_sl()
         self._sl_after_rules_static, _sl_parse_errs = (
-            self._sl_mod.parse_strategy_tp_sl_after_rules(self._close_refs)
+            self._sl_mod.parse_strategy_tp_sl_after_rules(
+                self._close_refs, labels=self._regime_primary_labels)
         )
         self._tp_tier_thresholds_static = self._sl_mod.parse_tp_tier_close_fractions(
             self._close_refs,
@@ -971,6 +1015,7 @@ class Backtester:
                 trailing_stop_pct=self.trailing_stop_pct,
                 stop_loss_atr_regime=self.stop_loss_atr_regime,
                 strategy_type=self.strategy_type,
+                labels=self._regime_primary_labels,
             )
             if errs:
                 raise ValueError(
@@ -1388,6 +1433,7 @@ class Backtester:
             if self._uses_regime_tiered_close:
                 rules_rt, _ = self._sl_mod.parse_strategy_tp_sl_after_rules(
                     self._close_refs, regime=lab,
+                    labels=self._regime_primary_labels,
                 )
                 self._active_sl_after_rules = rules_rt
                 self._run_tp_tier_thresholds = self._sl_mod.parse_tp_tier_close_fractions(

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -1134,6 +1134,14 @@ def main():
         args.allowed_regimes = live_kwargs.get(
             "allowed_regimes", args.allowed_regimes,
         )
+        # #1058 review: the backtester reads the config JSON directly and never
+        # runs the Go validateStrategyRegimeVocabulary, so a hand-edited / never-
+        # daemon-loaded config that switches the primary window to composite but
+        # leaves allowed_regimes as bare ADX labels would silently block every
+        # entry (0-trade run) — the same failure the by-name guard above rejects.
+        # Validate the config-threaded pair against its own primary classifier.
+        _validate_allowed_regimes_vocabulary(
+            args.allowed_regimes, live_kwargs.get("regime_windows_spec"))
 
     # CLI ATR-stop flags apply in single mode too; --config refs win on collision.
     if args.stop_loss_atr_mult is not None:

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -74,7 +74,11 @@ from reporter import (
     format_multi_asset_report, format_walk_forward_report,
     generate_full_report,
 )
-from regime import compute_regime, compute_regime_composite  # noqa: E402
+from regime import (  # noqa: E402
+    compute_regime,
+    compute_regime_composite,
+    parse_regime_windows_spec_json,
+)
 
 
 def _normalize_regime_window_spec(spec) -> dict:
@@ -90,6 +94,62 @@ def _normalize_regime_window_spec(spec) -> dict:
     else:
         out["thresholds"] = dict(spec.get("thresholds") or {})
     return out
+
+
+def _resolve_regime_windows_spec(regime_cfg: dict) -> Optional[dict]:
+    """Build the normalized composite-capable windows spec the Backtester threads
+    into ``ensure_regime_columns`` (#1058), sourced from the live config's
+    ``regime.windows``.
+
+    Mirrors the Go scheduler's ``regimeWindowsSpecJSON`` + ``resolvedForEmit`` so
+    the backtester classifies the SAME primary-window (medium-first) label the
+    live regime store feeds close evaluators:
+
+      - period defaults to the window's value, else the top-level
+        ``regime.period`` (Go ``resolvedForEmit``);
+      - ADX windows: ``adx_threshold`` defaults to the window's value, else the
+        top-level ``regime.adx_threshold``, else 20.0 (Go ``adxThreshold``);
+      - composite windows: ``thresholds`` are merged over
+        ``_DEFAULT_COMPOSITE_THRESHOLDS`` downstream by ``_normalize_spec``.
+
+    Returns ``None`` when regime is disabled or no ``regime.windows`` is
+    configured. The empty-``windows`` case is left to the existing
+    ``regime_period`` / ``regime_adx_threshold`` threading, which is behaviorally
+    identical to a synthesized ``{"default": adx}`` window — so the legacy
+    single-lookback ADX backtest stays byte-identical.
+    """
+    if not regime_cfg or not regime_cfg.get("enabled"):
+        return None
+    windows = regime_cfg.get("windows") or {}
+    if not windows:
+        return None
+    top_period = int(regime_cfg.get("period", 14) or 14)
+    top_adx = float(regime_cfg.get("adx_threshold", 20.0) or 20.0)
+    raw: dict = {}
+    for name, spec in windows.items():
+        if isinstance(spec, (int, float)) and not isinstance(spec, bool):
+            entry: dict = {"classifier": "adx", "period": int(spec)}
+        else:
+            entry = dict(spec or {})
+        classifier = str(entry.get("classifier") or "adx").strip().lower() or "adx"
+        period = int(entry.get("period") or 0)
+        if period <= 0:
+            period = top_period
+        out_entry: dict = {"classifier": classifier, "period": period}
+        if classifier == "adx":
+            adx_th = float(entry.get("adx_threshold") or 0.0)
+            if adx_th <= 0:
+                adx_th = top_adx if top_adx > 0 else 20.0
+            out_entry["adx_threshold"] = adx_th
+        else:
+            th = dict(entry.get("thresholds") or {})
+            if th:
+                out_entry["thresholds"] = th
+        raw[str(name)] = out_entry
+    import json as _json
+    # parse_regime_windows_spec_json validates (period >= 2, reserved names) and
+    # normalizes to the exact shape ensure_regime_columns indexes.
+    return parse_regime_windows_spec_json(_json.dumps(raw))
 
 
 def _build_profile_label_series(df: pd.DataFrame, window_spec: dict) -> pd.Series:
@@ -447,6 +507,9 @@ def load_strategy_config(config_path: str, strategy_id: str,
             "regime_enabled": bool(regime_cfg.get("enabled")),
             "regime_period": int(regime_cfg.get("period", 14) or 14),
             "regime_adx_threshold": float(regime_cfg.get("adx_threshold", 20.0) or 20.0),
+            # #1058: composite (7-state) regime from regime.windows. None when no
+            # windows are configured → legacy single-lookback ADX path unchanged.
+            "regime_windows_spec": _resolve_regime_windows_spec(regime_cfg),
             "allowed_regimes": allowed_regimes,
             "profile_allocation": profile_allocation,
         }
@@ -470,6 +533,7 @@ def run_single_backtest(
     regime_enabled: bool = False,
     regime_period: int = 14,
     regime_adx_threshold: float = 20.0,
+    regime_windows_spec: Optional[dict] = None,
     allowed_regimes: Optional[List[str]] = None,
     stop_loss_atr_mult: Optional[float] = None,
     stop_loss_pct: Optional[float] = None,
@@ -563,6 +627,7 @@ def run_single_backtest(
         regime_enabled=regime_enabled,
         regime_period=regime_period,
         regime_adx_threshold=regime_adx_threshold,
+        regime_windows_spec=regime_windows_spec,
         allowed_regimes=allowed_regimes,
         stop_loss_atr_mult=stop_loss_atr_mult,
         stop_loss_pct=stop_loss_pct,
@@ -809,6 +874,14 @@ def _build_parser() -> argparse.ArgumentParser:
                         help="ADX lookback period for regime detection (default: 14).")
     parser.add_argument("--regime-adx-threshold", type=float, default=20.0,
                         help="ADX threshold below which market is 'ranging' (default: 20.0).")
+    parser.add_argument("--regime-windows-spec-json", default=None,
+                        dest="regime_windows_spec_json", metavar="JSON",
+                        help="Composite (7-state) regime windows spec, same shape as the live "
+                             "--regime-windows-spec-json arg: a JSON object mapping window name "
+                             "-> {classifier,period,...} (bare int = ADX period). The PRIMARY "
+                             "window (medium-first) is classified into the per-bar regime label "
+                             "the entry gate and close evaluators read (#1058). Mutually exclusive "
+                             "with --config (the config's regime.windows owns it). Single mode only.")
     parser.add_argument("--allowed-regimes", action="append", dest="allowed_regimes",
                         default=None, choices=["trending_up", "trending_down", "ranging"],
                         metavar="LABEL",
@@ -880,6 +953,24 @@ def main():
     if args.close_strategies:
         close_refs = [_parse_close_strategy_arg(v) for v in args.close_strategies]
 
+    # #1058: parse the composite regime windows spec once. Reuses the same
+    # validator the live --regime-windows-spec-json arg uses, so a malformed
+    # spec fails loudly here rather than silently no-opping into the ADX path.
+    args.regime_windows_spec = None
+    if args.regime_windows_spec_json:
+        try:
+            args.regime_windows_spec = parse_regime_windows_spec_json(
+                args.regime_windows_spec_json)
+        except (ValueError, TypeError) as exc:
+            print(f"--regime-windows-spec-json: {exc}")
+            sys.exit(1)
+        # Only single mode threads the spec into the Backtester (compare/multi/
+        # optimize don't accept it). Reject other modes loudly rather than
+        # silently classifying with the legacy ADX path.
+        if args.mode != "single":
+            print("--regime-windows-spec-json is only valid with --mode single")
+            sys.exit(1)
+
     # #866: --defaults user only has an effect via the config's user_close_defaults.
     if args.defaults == "user" and not args.config:
         print("--defaults user requires --config (user_close_defaults lives in the config); "
@@ -920,6 +1011,14 @@ def main():
                   "live config's `allowed_regimes` field owns the regime gate); "
                   "edit the config or backtest the strategy by name")
             sys.exit(1)
+        # #1058: the config's regime.windows owns the composite spec; a CLI
+        # --regime-windows-spec-json alongside --config would lose to it on the
+        # thread below and silently mislead. Reject loudly, like the gates above.
+        if args.regime_windows_spec is not None:
+            print("--regime-windows-spec-json is not allowed alongside --config "
+                  "(the live config's `regime.windows` owns the composite spec); "
+                  "edit the config or backtest the strategy by name")
+            sys.exit(1)
         close_refs = live_kwargs["close_strategies"]
         # Open strategy name + params come from the live config. Threading
         # params through to run_single_backtest is required — without it,
@@ -943,6 +1042,11 @@ def main():
             "regime_directional_policy",
             # #998: regime-profile allocation switch block (None when unused).
             "profile_allocation",
+            # #1058: composite (7-state) regime windows spec (None when the
+            # config has no regime.windows → legacy ADX path). Only single mode
+            # consumes live_stop_kwargs; optimize/compare/multi stay ADX, as they
+            # already drop the other config-sourced close fields here.
+            "regime_windows_spec",
         )
         live_stop_kwargs = {k: live_kwargs[k] for k in stop_keys if k in live_kwargs}
         args.regime_enabled = live_kwargs.get("regime_enabled", args.regime_enabled)
@@ -961,6 +1065,12 @@ def main():
         live_stop_kwargs.setdefault("stop_loss_atr_mult", args.stop_loss_atr_mult)
     if args.trailing_stop_atr_mult is not None:
         live_stop_kwargs.setdefault("trailing_stop_atr_mult", args.trailing_stop_atr_mult)
+
+    # #1058: by-name single backtest can supply the composite spec via the CLI.
+    # --config + this flag was rejected above, so the key can't collide. Only
+    # single mode threads live_stop_kwargs into run_single_backtest.
+    if args.regime_windows_spec is not None:
+        live_stop_kwargs["regime_windows_spec"] = args.regime_windows_spec
 
     # #989 review: --direction was parsed for every mode but forwarded only to
     # optimize — single/compare/multi silently scored the long leg of a

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -78,6 +78,11 @@ from regime import (  # noqa: E402
     compute_regime,
     compute_regime_composite,
     parse_regime_windows_spec_json,
+    valid_labels_for_classifier,
+    CLASSIFIER_ADX,
+    CLASSIFIER_COMPOSITE,
+    REGIME_PRIMARY_WINDOW_KEY,
+    VALID_LABELS_COMPOSITE,
 )
 
 
@@ -150,6 +155,63 @@ def _resolve_regime_windows_spec(regime_cfg: dict) -> Optional[dict]:
     # parse_regime_windows_spec_json validates (period >= 2, reserved names) and
     # normalizes to the exact shape ensure_regime_columns indexes.
     return parse_regime_windows_spec_json(_json.dumps(raw))
+
+
+def _primary_window_classifier(spec: Optional[dict]) -> str:
+    """Classifier of the PRIMARY (medium-first) window — the one whose label the
+    backtester's single ``regime`` column carries and the entry gate reads (#1058).
+
+    Mirrors ``ensure_regime_columns`` / ``regime_from_injected_payload`` primary
+    selection (``REGIME_PRIMARY_WINDOW_KEY`` else ``sorted(keys)[0]``). ``None``
+    spec (no ``regime.windows``) is the legacy single-lookback ADX path, so the
+    gate vocabulary is the 3 ADX labels.
+    """
+    if not spec:
+        return CLASSIFIER_ADX
+    primary_key = (
+        REGIME_PRIMARY_WINDOW_KEY
+        if REGIME_PRIMARY_WINDOW_KEY in spec
+        else sorted(spec.keys())[0]
+    )
+    return str(spec[primary_key].get("classifier") or CLASSIFIER_ADX).strip().lower()
+
+
+def _validate_allowed_regimes_vocabulary(
+    allowed_regimes: Optional[List[str]],
+    windows_spec: Optional[dict],
+) -> None:
+    """Reject ``--allowed-regimes`` labels the primary window's classifier can
+    never emit (#1058 review). The entry gate compares each per-bar regime label
+    (the primary window's output) against this set, so a label outside that
+    classifier's vocabulary blocks every entry silently — exactly the divergence
+    class the live ``validateStrategyRegimeVocabulary`` guards on the Go side.
+
+    Vocabulary tracks the SUPPLIED spec's primary classifier, NOT an
+    unconditional widen: an ADX-only (or no-windows) by-name backtest still
+    rejects composite substates; a composite-primary spec still rejects bare ADX
+    labels (which its classifier never emits). On error, exits with status 1.
+    """
+    if not allowed_regimes:
+        return
+    classifier = _primary_window_classifier(windows_spec)
+    valid = valid_labels_for_classifier(classifier)
+    invalid = [lab for lab in allowed_regimes if lab not in valid]
+    if not invalid:
+        return
+    msg = (
+        f"--allowed-regimes {invalid!r}: not valid label(s) for the primary "
+        f"regime window's {classifier!r} classifier. Valid: "
+        f"{', '.join(sorted(valid))}."
+    )
+    # Most common slip: composite substates supplied without a composite spec.
+    if classifier == CLASSIFIER_ADX and any(lab in VALID_LABELS_COMPOSITE for lab in invalid):
+        msg += (
+            " (Composite 7-state labels require a composite primary window — "
+            "supply --regime-windows-spec-json with a composite classifier, or "
+            "use --config.)"
+        )
+    print(msg)
+    sys.exit(1)
 
 
 def _build_profile_label_series(df: pd.DataFrame, window_spec: dict) -> pd.Series:
@@ -883,10 +945,13 @@ def _build_parser() -> argparse.ArgumentParser:
                              "the entry gate and close evaluators read (#1058). Mutually exclusive "
                              "with --config (the config's regime.windows owns it). Single mode only.")
     parser.add_argument("--allowed-regimes", action="append", dest="allowed_regimes",
-                        default=None, choices=["trending_up", "trending_down", "ranging"],
-                        metavar="LABEL",
+                        default=None, metavar="LABEL",
                         help="Regime label to allow entries for (repeat for multiple). "
-                             "Empty = allow all. Valid: trending_up, trending_down, ranging.")
+                             "Empty = allow all. Validated against the PRIMARY regime "
+                             "window's classifier vocabulary (#1058): ADX (default / no "
+                             "--regime-windows-spec-json) accepts trending_up, "
+                             "trending_down, ranging; a composite primary window accepts "
+                             "the 7-state substates (trending_up_clean, ranging_quiet, ...).")
     parser.add_argument("--stop-loss-atr-mult", type=float, default=None,
                         dest="stop_loss_atr_mult", metavar="MULT",
                         help="Fixed ATR-multiple stop loss (e.g. 2.0). Applied in "
@@ -970,6 +1035,16 @@ def main():
         if args.mode != "single":
             print("--regime-windows-spec-json is only valid with --mode single")
             sys.exit(1)
+
+    # #1058 review: a composite primary window classifies 7-state substates the
+    # entry gate must be able to filter on; validate the by-name --allowed-regimes
+    # against that classifier's vocabulary so a label the classifier can never emit
+    # (which would silently block every entry) is rejected loudly. The --config
+    # path threads the live config's allowed_regimes (validated upstream by the Go
+    # validateStrategyRegimeVocabulary) and rejects the CLI flag below, so skip it.
+    if not args.config:
+        _validate_allowed_regimes_vocabulary(
+            args.allowed_regimes, args.regime_windows_spec)
 
     # #866: --defaults user only has an effect via the config's user_close_defaults.
     if args.defaults == "user" and not args.config:

--- a/backtest/tests/test_backtester_composite_regime_wiring.py
+++ b/backtest/tests/test_backtester_composite_regime_wiring.py
@@ -792,3 +792,67 @@ def test_validate_regime_tiered_tp_labels_helper():
             {"atr_multiple": 2.0, "close_fraction": 0.5},
             {"atr_multiple": 3.0, "close_fraction": 1.0}]}}],
         labels=_COMPOSITE_TP_LABELS) == []
+
+
+# --- Missing-label exhaustiveness (#1058 review 5) ----------------------------
+# Live rejects a non-exhaustive per-tier trend_regime block: parseRegimeATRBlock
+# ("missing required regime labels … must be exhaustive — no silent fallback"),
+# invoked per tier from parseRegimeTPTiers. The backtester must match — a
+# partially-keyed tier passes the unknown-label arm but, left unchecked, makes
+# resolve_regime_tier silently no-op TP on every un-keyed substate.
+
+def _partial_tiered_ref(labels, omit):
+    kept = [l for l in labels if l != omit]
+    return {"name": "tiered_tp_atr_regime", "params": {"tp_tiers": [
+        _regime_tp_tier(kept, 2.0, 0.5),
+        _regime_tp_tier(kept, 3.0, 1.0),
+    ]}}
+
+
+def _bt_with_tiered_ref(spec, ref):
+    return Backtester(initial_capital=1000.0, regime_enabled=True,
+                      regime_windows_spec=spec, close_strategies=[ref])
+
+
+def test_composite_primary_non_exhaustive_tiered_tp_rejects():
+    # Composite primary + composite-keyed tiers omitting one substate → reject at
+    # load, never a silent no-op on the omitted substate.
+    ref = _partial_tiered_ref(_COMPOSITE_TP_LABELS, "ranging_directional")
+    with pytest.raises(ValueError) as exc:
+        _bt_with_tiered_ref(COMPOSITE_SPEC, ref)
+    msg = str(exc.value)
+    assert "tiered-TP" in msg
+    assert "missing required regime labels" in msg
+    assert "ranging_directional" in msg
+
+
+def test_adx_primary_non_exhaustive_tiered_tp_rejects():
+    # Inverse vocabulary: ADX primary (legacy no-spec, labels=None) + ADX-keyed
+    # tiers omitting one of the 3 labels → still rejected as non-exhaustive.
+    ref = _partial_tiered_ref(_ADX_TP_LABELS, "ranging")
+    with pytest.raises(ValueError) as exc:
+        _bt_with_tiered_ref(None, ref)
+    msg = str(exc.value)
+    assert "missing required regime labels" in msg
+    assert "ranging" in msg
+
+
+def test_validate_regime_tiered_tp_labels_exhaustiveness_unit():
+    # Direct unit on the missing-label arm and the use_defaults exemption.
+    _sl = _bt_with_tiered_regime(None, _ADX_TP_LABELS)._sl_mod
+    # Composite vocabulary, tier omits one composite substate → flagged missing.
+    errs = _sl.validate_regime_tiered_tp_labels(
+        [_partial_tiered_ref(_COMPOSITE_TP_LABELS, "ranging_volatile")],
+        labels=_COMPOSITE_TP_LABELS)
+    assert errs and any("missing required regime labels" in e for e in errs)
+    assert any("ranging_volatile" in e for e in errs)
+    # A tier-level use_defaults carries no operator keys → exempt (expands to the
+    # full vocabulary at the resolver, mirroring live's early-return).
+    use_defaults_ref = {"name": "tiered_tp_atr_regime", "params": {"tp_tiers": [
+        {"use_defaults": True, "close_fraction": 1.0}]}}
+    assert _sl.validate_regime_tiered_tp_labels(
+        [use_defaults_ref], labels=_COMPOSITE_TP_LABELS) == []
+    # Exhaustive composite tiers still accepted (no false positive from the arm).
+    assert _sl.validate_regime_tiered_tp_labels(
+        [_regime_tiered_ref(_COMPOSITE_TP_LABELS)],
+        labels=_COMPOSITE_TP_LABELS) == []

--- a/backtest/tests/test_backtester_composite_regime_wiring.py
+++ b/backtest/tests/test_backtester_composite_regime_wiring.py
@@ -1,0 +1,354 @@
+"""#1058: the Backtester CLASSIFIES composite (7-state) regime labels from OHLCV
+when threaded a ``regime_windows_spec``, and feeds those substate labels to the
+entry gate AND the close evaluator's position regime.
+
+The sibling ``test_backtester_composite_regime.py`` covers the entry GATE with a
+*pre-supplied* ``regime`` column — it never exercises the backtester computing
+composite labels itself. These tests cover the new wiring: ``ensure_regime_columns``
+threaded with the live ``regime.windows`` spec, picking the PRIMARY window
+(medium-first) exactly as the live regime store's ``regime_from_injected_payload``
+does, so ``_run_position_regime`` (the label close evaluators consume) carries the
+composite substate instead of the ADX 3-state label.
+
+Ground truth for the per-bar labels is the SAME ``ensure_regime_columns`` call the
+backtester makes internally, so assertions track the classifier instead of
+hard-coding synthetic-OHLCV buckets.
+"""
+import sys
+import pathlib
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / "shared_tools"))
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+import run_backtest
+from backtester import Backtester
+from regime import (
+    ensure_regime_columns,
+    VALID_LABELS_COMPOSITE,
+    VALID_LABELS_ADX,
+    _DEFAULT_COMPOSITE_THRESHOLDS,
+)
+
+COMPOSITE_SPEC = {"medium": {"classifier": "composite", "period": 20}}
+
+
+def _mixed_regime_ohlcv(n: int = 160, seed: int = 1) -> pd.DataFrame:
+    """Chop for the first half, clean uptrend for the second — guarantees a mix
+    of composite substates (ranging_* and trending_*) within one series."""
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    rng = np.random.default_rng(seed)
+    close = np.empty(n)
+    half = n // 2
+    close[:half] = 100.0 + np.cumsum(rng.normal(0.0, 0.5, half))
+    close[half:] = close[half - 1] + np.cumsum(np.abs(rng.normal(1.0, 0.15, n - half)))
+    return pd.DataFrame(
+        {"open": close, "high": close + 0.6, "low": close - 0.6,
+         "close": close, "volume": 1000.0},
+        index=idx,
+    )
+
+
+def _ground_truth_labels(df: pd.DataFrame, spec=COMPOSITE_SPEC) -> pd.Series:
+    """The exact per-bar bar-close labels the backtester computes internally:
+    the same ``ensure_regime_columns`` + windows_spec (medium-first primary)."""
+    truth = df.copy()
+    ensure_regime_columns(truth, windows_spec=spec)
+    return truth["regime"]
+
+
+def _buy_at(df: pd.DataFrame, bar: int) -> pd.DataFrame:
+    out = df.copy()
+    out["signal"] = 0
+    out.iloc[bar, out.columns.get_loc("signal")] = 1
+    return out
+
+
+# ─── The classifier the backtester threads is composite, not ADX ─────────────
+
+
+def test_windows_spec_computes_composite_substates_from_ohlcv():
+    labels = set(_ground_truth_labels(_mixed_regime_ohlcv()).unique())
+    # Every emitted label is from the 7-state composite vocabulary…
+    assert labels <= VALID_LABELS_COMPOSITE
+    # …and the ADX (3-state) and composite vocabularies are disjoint, so a
+    # composite substate could never be produced by the legacy ADX path.
+    assert labels & VALID_LABELS_ADX == set()
+    assert labels, "expected non-empty composite labels"
+
+
+# ─── Close-evaluator position regime carries the composite substate ──────────
+
+
+def test_position_regime_is_composite_substate():
+    """``_run_position_regime`` is the label fed to close evaluators
+    (``position_regime=`` in the per-bar loop). With a composite windows_spec it
+    must be the substate computed at the open bar — not an ADX label."""
+    df = _mixed_regime_ohlcv()
+    truth = _ground_truth_labels(df)
+    entry = 130
+    expected = truth.iloc[entry]
+    assert expected in VALID_LABELS_COMPOSITE
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, regime_windows_spec=COMPOSITE_SPEC,
+    )
+    result = bt.run(_buy_at(df, entry), save=False)
+    assert result["total_trades"] == 1  # opened, held to the end
+    # Signal at bar N fills at N+1, stamping bar N's regime (shift parity).
+    assert bt._run_position_regime == expected
+    assert bt._run_position_regime in VALID_LABELS_COMPOSITE
+
+
+def test_default_path_stays_adx_without_windows_spec():
+    """No windows_spec → the legacy single-lookback ADX path is unchanged: the
+    stamped position regime is a 3-state ADX label, never a composite substate."""
+    df = _mixed_regime_ohlcv()
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True,  # regime_windows_spec defaults to None
+    )
+    bt.run(_buy_at(df, 130), save=False)
+    assert bt._run_position_regime in VALID_LABELS_ADX
+    assert bt._run_position_regime not in VALID_LABELS_COMPOSITE
+
+
+# ─── The computed composite label gates entries ──────────────────────────────
+
+
+def test_composite_gate_allows_matching_blocks_mismatching():
+    """The backtester gates entries on the COMPUTED composite label: an
+    allowed_regimes naming the entry bar's substate permits the fill; naming a
+    different substate blocks it."""
+    df = _mixed_regime_ohlcv()
+    truth = _ground_truth_labels(df)
+    entry = 130
+    label = truth.iloc[entry]
+    assert label in VALID_LABELS_COMPOSITE
+    other = next(l for l in sorted(VALID_LABELS_COMPOSITE) if l != label)
+
+    bt_ok = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, regime_windows_spec=COMPOSITE_SPEC,
+        allowed_regimes=[label],
+    )
+    assert bt_ok.run(_buy_at(df, entry), save=False)["total_trades"] == 1
+
+    bt_no = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, regime_windows_spec=COMPOSITE_SPEC,
+        allowed_regimes=[other],
+    )
+    assert bt_no.run(_buy_at(df, entry), save=False)["total_trades"] == 0
+
+
+# ─── Look-ahead: the gate reads the DECISION bar's label, never the fill bar's ─
+
+
+def test_composite_label_respects_lookahead_shift():
+    """The composite label is consumed under the same N→N+1 shift as ADX: the
+    position regime is stamped from the entry-DECISION bar (N), so a label that
+    changes between bar N and the fill bar N+1 proves no look-ahead."""
+    df = _mixed_regime_ohlcv()
+    truth = _ground_truth_labels(df)
+    # A bar whose composite label differs from the next bar's — reading the
+    # wrong bar would stamp a different regime.
+    entry = next(
+        i for i in range(60, len(df) - 2)
+        if truth.iloc[i] != truth.iloc[i + 1]
+        and truth.iloc[i] in VALID_LABELS_COMPOSITE
+    )
+    decision_label = truth.iloc[entry]
+    fill_label = truth.iloc[entry + 1]
+    assert decision_label != fill_label
+
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, regime_windows_spec=COMPOSITE_SPEC,
+    )
+    bt.run(_buy_at(df, entry), save=False)
+    assert bt._run_position_regime == decision_label
+    assert bt._run_position_regime != fill_label
+
+
+# ─── run_backtest._resolve_regime_windows_spec: config → normalized spec ──────
+
+
+def test_resolve_windows_spec_none_when_disabled_or_no_windows():
+    assert run_backtest._resolve_regime_windows_spec(None) is None
+    assert run_backtest._resolve_regime_windows_spec({}) is None
+    assert run_backtest._resolve_regime_windows_spec({"enabled": False, "windows": {"medium": 20}}) is None
+    # Enabled but no windows → None (legacy single-lookback ADX path handles it).
+    assert run_backtest._resolve_regime_windows_spec({"enabled": True, "period": 14}) is None
+
+
+def test_resolve_windows_spec_composite_medium():
+    spec = run_backtest._resolve_regime_windows_spec({
+        "enabled": True,
+        "windows": {"medium": {"classifier": "composite", "period": 30}},
+    })
+    assert spec is not None
+    assert spec["medium"]["classifier"] == "composite"
+    assert spec["medium"]["period"] == 30
+    # Composite thresholds default-merged to the shared defaults.
+    assert spec["medium"]["thresholds"] == _DEFAULT_COMPOSITE_THRESHOLDS
+
+
+def test_resolve_windows_spec_adx_inherits_top_level_threshold_and_period():
+    """resolvedForEmit parity: an ADX window missing adx_threshold/period inherits
+    the top-level regime.adx_threshold / regime.period (Go RegimeWindowSpec)."""
+    spec = run_backtest._resolve_regime_windows_spec({
+        "enabled": True,
+        "period": 21,
+        "adx_threshold": 28.0,
+        # Bare int = ADX shorthand; an explicit object missing period/threshold.
+        "windows": {"medium": {"classifier": "adx"}},
+    })
+    assert spec["medium"]["classifier"] == "adx"
+    assert spec["medium"]["period"] == 21        # inherited from top-level period
+    assert spec["medium"]["adx_threshold"] == 28.0  # inherited from top-level adx_threshold
+
+
+def test_resolve_windows_spec_keeps_explicit_window_values():
+    spec = run_backtest._resolve_regime_windows_spec({
+        "enabled": True,
+        "period": 14,
+        "adx_threshold": 20.0,
+        "windows": {"short": {"classifier": "adx", "period": 7, "adx_threshold": 30.0}},
+    })
+    assert spec["short"]["period"] == 7
+    assert spec["short"]["adx_threshold"] == 30.0
+
+
+# ─── load_strategy_config threads regime_windows_spec from --config ──────────
+
+
+def _write_config(tmp_path, cfg):
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps(cfg, indent=2))
+    return str(p)
+
+
+def _composite_config(tmp_path):
+    return _write_config(tmp_path, {
+        "config_version": 15,
+        "regime": {
+            "enabled": True,
+            "period": 14,
+            "adx_threshold": 20.0,
+            "windows": {"medium": {"classifier": "composite", "period": 30}},
+        },
+        "strategies": [{
+            "id": "hl-temacb-btc",
+            "type": "perps",
+            "platform": "hyperliquid",
+            "open_strategy": {"name": "tema_cross_bd"},
+            "close_strategy": {"name": "tiered_tp_atr", "params": {"tp_tiers": [
+                {"atr_multiple": 2.0, "close_fraction": 0.5},
+                {"atr_multiple": 3.0, "close_fraction": 1.0},
+            ]}},
+        }],
+    })
+
+
+def test_load_strategy_config_includes_composite_windows_spec(tmp_path):
+    kwargs = run_backtest.load_strategy_config(_composite_config(tmp_path), "hl-temacb-btc")
+    spec = kwargs["regime_windows_spec"]
+    assert spec is not None
+    assert spec["medium"]["classifier"] == "composite"
+    assert spec["medium"]["period"] == 30
+
+
+def test_load_strategy_config_no_windows_yields_none(tmp_path):
+    path = _write_config(tmp_path, {
+        "config_version": 15,
+        "regime": {"enabled": True, "period": 14, "adx_threshold": 20.0},
+        "strategies": [{
+            "id": "hl-temacb-btc", "type": "perps", "platform": "hyperliquid",
+            "open_strategy": {"name": "tema_cross_bd"},
+            "close_strategy": {"name": "tiered_tp_atr", "params": {"tp_tiers": [
+                {"atr_multiple": 2.0, "close_fraction": 1.0},
+            ]}},
+        }],
+    })
+    kwargs = run_backtest.load_strategy_config(path, "hl-temacb-btc")
+    assert kwargs["regime_windows_spec"] is None
+
+
+# ─── CLI: --regime-windows-spec-json parsing + rejections ────────────────────
+
+
+def _run_main(monkeypatch, argv):
+    monkeypatch.setattr(sys, "argv", ["run_backtest.py", *argv])
+    return run_backtest.main()
+
+
+def test_cli_rejects_windows_spec_with_non_single_mode(monkeypatch):
+    with pytest.raises(SystemExit):
+        _run_main(monkeypatch, [
+            "--mode", "compare", "--strategy", "sma_crossover",
+            "--regime-windows-spec-json", json.dumps(COMPOSITE_SPEC),
+        ])
+
+
+def test_cli_rejects_malformed_windows_spec(monkeypatch):
+    with pytest.raises(SystemExit):
+        _run_main(monkeypatch, [
+            "--mode", "single", "--strategy", "sma_crossover",
+            "--regime-windows-spec-json", "{not valid json",
+        ])
+
+
+def test_cli_rejects_windows_spec_with_config(monkeypatch, tmp_path):
+    with pytest.raises(SystemExit):
+        _run_main(monkeypatch, [
+            "--mode", "single", "--strategy", "hl-temacb-btc",
+            "--config", _composite_config(tmp_path),
+            "--regime-windows-spec-json", json.dumps(COMPOSITE_SPEC),
+        ])
+
+
+def test_cli_by_name_threads_windows_spec_to_backtester(monkeypatch):
+    """End-to-end: --regime-windows-spec-json on a by-name single backtest must
+    reach the Backtester constructor (parse → main → run_single_backtest →
+    Backtester), not stop at argparse."""
+    seen = {}
+
+    class SpyBacktester:
+        def __init__(self, *args, regime_windows_spec=None, **kwargs):
+            seen["regime_windows_spec"] = regime_windows_spec
+
+        def run(self, df, **kwargs):
+            return {
+                "strategy_name": "sma_crossover", "symbol": "BTC/USDT",
+                "timeframe": "1d", "start_date": str(df.index[0]),
+                "end_date": str(df.index[-1]), "initial_capital": 1000.0,
+                "final_capital": 1000.0, "total_return_pct": 0.0,
+                "annual_return_pct": 0.0, "sharpe_ratio": 0.0,
+                "sortino_ratio": 0.0, "max_drawdown_pct": 0.0,
+                "calmar_ratio": 0.0, "volatility_pct": 0.0, "win_rate": 0.0,
+                "profit_factor": 0.0, "total_trades": 0, "avg_win_pct": 0.0,
+                "avg_loss_pct": 0.0, "trades": [], "params": {},
+            }
+
+    df = pd.DataFrame(
+        {"open": [100.0] * 60, "high": [101.0] * 60, "low": [99.0] * 60,
+         "close": [100.0] * 60, "volume": [1000.0] * 60},
+        index=pd.date_range("2024-01-01", periods=60, freq="D"),
+    )
+    monkeypatch.setattr(run_backtest, "Backtester", SpyBacktester)
+    monkeypatch.setattr(run_backtest, "load_cached_data", lambda *a, **kw: df)
+
+    _run_main(monkeypatch, [
+        "--mode", "single", "--strategy", "sma_crossover",
+        "--regime-enabled",
+        "--regime-windows-spec-json", json.dumps(COMPOSITE_SPEC),
+    ])
+    spec = seen.get("regime_windows_spec")
+    assert spec is not None, "windows spec did not thread to the Backtester"
+    assert spec["medium"]["classifier"] == "composite"
+    assert spec["medium"]["period"] == 20

--- a/backtest/tests/test_backtester_composite_regime_wiring.py
+++ b/backtest/tests/test_backtester_composite_regime_wiring.py
@@ -486,3 +486,109 @@ def test_cli_composite_label_rejected_without_spec(monkeypatch):
             "--regime-enabled",
             "--allowed-regimes", "ranging_quiet",
         ])
+
+
+# ─── --config path enforces the SAME vocabulary check (#1058 review 2) ────────
+# The backtester reads config JSON directly and never runs the Go
+# validateStrategyRegimeVocabulary, so the --config path must validate the
+# config-threaded (allowed_regimes, regime_windows_spec) pair itself — else a
+# hand-edited config silently blocks every entry (0-trade run).
+
+
+def _config_with_regime(tmp_path, *, classifier, allowed_regimes=None):
+    strat = {
+        "id": "hl-temacb-btc", "type": "perps", "platform": "hyperliquid",
+        # sma_crossover (a registry strategy) so the accept-path tests reach the
+        # Backtester; the open name is irrelevant to the vocabulary check itself.
+        "open_strategy": {"name": "sma_crossover"},
+        "close_strategy": {"name": "tiered_tp_atr", "params": {"tp_tiers": [
+            {"atr_multiple": 2.0, "close_fraction": 1.0}]}},
+    }
+    if allowed_regimes is not None:
+        strat["allowed_regimes"] = allowed_regimes
+    return _write_config(tmp_path, {
+        "config_version": 15,
+        "regime": {
+            "enabled": True, "period": 14, "adx_threshold": 20.0,
+            "windows": {"medium": {"classifier": classifier, "period": 30}},
+        },
+        "strategies": [strat],
+    })
+
+
+def test_config_rejects_adx_label_under_composite_primary(monkeypatch, tmp_path):
+    # Must-survive (a): composite primary window + config allowed_regimes holding
+    # a bare ADX label → reject, not a silent 0-trade run.
+    cfg = _config_with_regime(tmp_path, classifier="composite", allowed_regimes=["ranging"])
+    with pytest.raises(SystemExit):
+        _run_main(monkeypatch, [
+            "--mode", "single", "--strategy", "hl-temacb-btc", "--config", cfg,
+        ])
+
+
+def test_config_rejects_composite_label_under_adx_primary(monkeypatch, tmp_path):
+    # Must-survive (b): inverse — ADX primary + config allowed_regimes holding a
+    # composite substate → reject.
+    cfg = _config_with_regime(tmp_path, classifier="adx", allowed_regimes=["ranging_quiet"])
+    with pytest.raises(SystemExit):
+        _run_main(monkeypatch, [
+            "--mode", "single", "--strategy", "hl-temacb-btc", "--config", cfg,
+        ])
+
+
+def _spy_backtester_seen(monkeypatch, df):
+    seen = {}
+
+    class SpyBacktester:
+        def __init__(self, *args, regime_windows_spec=None, allowed_regimes=None, **kwargs):
+            seen["regime_windows_spec"] = regime_windows_spec
+            seen["allowed_regimes"] = allowed_regimes
+
+        def run(self, df, **kwargs):
+            return {
+                "strategy_name": "tema_cross_bd", "symbol": "BTC/USDT",
+                "timeframe": "1d", "start_date": str(df.index[0]),
+                "end_date": str(df.index[-1]), "initial_capital": 1000.0,
+                "final_capital": 1000.0, "total_return_pct": 0.0,
+                "annual_return_pct": 0.0, "sharpe_ratio": 0.0,
+                "sortino_ratio": 0.0, "max_drawdown_pct": 0.0,
+                "calmar_ratio": 0.0, "volatility_pct": 0.0, "win_rate": 0.0,
+                "profit_factor": 0.0, "total_trades": 0, "avg_win_pct": 0.0,
+                "avg_loss_pct": 0.0, "trades": [], "params": {},
+            }
+
+    monkeypatch.setattr(run_backtest, "Backtester", SpyBacktester)
+    monkeypatch.setattr(run_backtest, "load_cached_data", lambda *a, **kw: df)
+    return seen
+
+
+def test_config_matching_composite_label_runs(monkeypatch, tmp_path):
+    # Composite primary + matching composite label → no false rejection; threads.
+    df = pd.DataFrame(
+        {"open": [100.0] * 60, "high": [101.0] * 60, "low": [99.0] * 60,
+         "close": [100.0] * 60, "volume": [1000.0] * 60},
+        index=pd.date_range("2024-01-01", periods=60, freq="D"),
+    )
+    seen = _spy_backtester_seen(monkeypatch, df)
+    cfg = _config_with_regime(tmp_path, classifier="composite", allowed_regimes=["ranging_quiet"])
+    _run_main(monkeypatch, [
+        "--mode", "single", "--strategy", "hl-temacb-btc", "--config", cfg,
+    ])
+    assert seen["allowed_regimes"] == ["ranging_quiet"]
+    assert seen["regime_windows_spec"]["medium"]["classifier"] == "composite"
+
+
+def test_config_absent_allowed_regimes_runs(monkeypatch, tmp_path):
+    # Must-survive (c): empty/absent allowed_regimes must NOT be falsely rejected.
+    df = pd.DataFrame(
+        {"open": [100.0] * 60, "high": [101.0] * 60, "low": [99.0] * 60,
+         "close": [100.0] * 60, "volume": [1000.0] * 60},
+        index=pd.date_range("2024-01-01", periods=60, freq="D"),
+    )
+    seen = _spy_backtester_seen(monkeypatch, df)
+    cfg = _config_with_regime(tmp_path, classifier="composite", allowed_regimes=None)
+    _run_main(monkeypatch, [
+        "--mode", "single", "--strategy", "hl-temacb-btc", "--config", cfg,
+    ])
+    assert seen["allowed_regimes"] is None
+    assert seen["regime_windows_spec"]["medium"]["classifier"] == "composite"

--- a/backtest/tests/test_backtester_composite_regime_wiring.py
+++ b/backtest/tests/test_backtester_composite_regime_wiring.py
@@ -352,3 +352,137 @@ def test_cli_by_name_threads_windows_spec_to_backtester(monkeypatch):
     assert spec is not None, "windows spec did not thread to the Backtester"
     assert spec["medium"]["classifier"] == "composite"
     assert spec["medium"]["period"] == 20
+
+
+# ─── --allowed-regimes vocabulary tracks the primary window's classifier ──────
+# (#1058 review: composite primary → 7-state gate labels; ADX primary → 3 labels.
+# The gate must be expressible through the SAME surface that computes the label.)
+
+
+_ADX_SPEC = {"medium": {"classifier": "adx", "period": 14}}
+_COMPOSITE_PRIMARY_WITH_ADX = {
+    "medium": {"classifier": "composite", "period": 30},
+    "short": {"classifier": "adx", "period": 7},
+}
+_COMPOSITE_NO_MEDIUM = {"slow": {"classifier": "composite", "period": 40}}
+
+
+def test_primary_classifier_none_spec_is_adx():
+    assert run_backtest._primary_window_classifier(None) == "adx"
+    assert run_backtest._primary_window_classifier({}) == "adx"
+
+
+def test_primary_classifier_medium_first():
+    assert run_backtest._primary_window_classifier(COMPOSITE_SPEC) == "composite"
+
+
+def test_primary_classifier_mixed_spec_uses_medium_not_other_window():
+    # Must-survive (c): medium is the primary even when an ADX window coexists.
+    assert run_backtest._primary_window_classifier(
+        _COMPOSITE_PRIMARY_WITH_ADX) == "composite"
+
+
+def test_primary_classifier_no_medium_uses_sorted_first():
+    assert run_backtest._primary_window_classifier(_COMPOSITE_NO_MEDIUM) == "composite"
+    assert run_backtest._primary_window_classifier(
+        {"z": {"classifier": "composite"}, "a": {"classifier": "adx"}}) == "adx"
+
+
+def test_validate_accepts_adx_label_no_spec():
+    # Preserves the old argparse choices behavior for the legacy ADX path.
+    run_backtest._validate_allowed_regimes_vocabulary(["trending_up", "ranging"], None)
+
+
+def test_validate_accepts_composite_label_with_composite_spec():
+    # Must-survive (a): composite gate label with a composite primary is valid.
+    run_backtest._validate_allowed_regimes_vocabulary(["ranging_quiet"], COMPOSITE_SPEC)
+    run_backtest._validate_allowed_regimes_vocabulary(
+        ["trending_up_clean", "ranging_directional"], COMPOSITE_SPEC)
+
+
+def test_validate_rejects_composite_label_without_spec():
+    # Must-survive (b): the inverse — ADX primary must NOT accept composite labels.
+    with pytest.raises(SystemExit):
+        run_backtest._validate_allowed_regimes_vocabulary(["ranging_quiet"], None)
+    with pytest.raises(SystemExit):
+        run_backtest._validate_allowed_regimes_vocabulary(["trending_up_clean"], _ADX_SPEC)
+
+
+def test_validate_rejects_bare_adx_label_with_composite_primary():
+    # Must-survive (c): a composite classifier never emits bare "trending_up",
+    # so gating on it would silently block every entry — reject loudly.
+    with pytest.raises(SystemExit):
+        run_backtest._validate_allowed_regimes_vocabulary(["trending_up"], COMPOSITE_SPEC)
+    with pytest.raises(SystemExit):
+        run_backtest._validate_allowed_regimes_vocabulary(
+            ["trending_up"], _COMPOSITE_PRIMARY_WITH_ADX)
+
+
+def test_validate_rejects_garbage_label():
+    with pytest.raises(SystemExit):
+        run_backtest._validate_allowed_regimes_vocabulary(["not_a_regime"], None)
+
+
+def test_validate_noop_on_empty():
+    run_backtest._validate_allowed_regimes_vocabulary(None, COMPOSITE_SPEC)
+    run_backtest._validate_allowed_regimes_vocabulary([], COMPOSITE_SPEC)
+
+
+def test_validate_compound_partial_invalid_rejects():
+    # One valid + one invalid → reject (graded by the weakest member).
+    with pytest.raises(SystemExit):
+        run_backtest._validate_allowed_regimes_vocabulary(
+            ["ranging_quiet", "trending_up"], COMPOSITE_SPEC)
+
+
+def test_cli_composite_label_reaches_backtester_with_spec(monkeypatch):
+    """Must-survive (a) end-to-end: --allowed-regimes <composite> no longer
+    argparse-rejects when a composite spec is supplied; it threads through."""
+    seen = {}
+
+    class SpyBacktester:
+        def __init__(self, *args, regime_windows_spec=None, allowed_regimes=None, **kwargs):
+            seen["regime_windows_spec"] = regime_windows_spec
+            seen["allowed_regimes"] = allowed_regimes
+
+        def run(self, df, **kwargs):
+            return {
+                "strategy_name": "sma_crossover", "symbol": "BTC/USDT",
+                "timeframe": "1d", "start_date": str(df.index[0]),
+                "end_date": str(df.index[-1]), "initial_capital": 1000.0,
+                "final_capital": 1000.0, "total_return_pct": 0.0,
+                "annual_return_pct": 0.0, "sharpe_ratio": 0.0,
+                "sortino_ratio": 0.0, "max_drawdown_pct": 0.0,
+                "calmar_ratio": 0.0, "volatility_pct": 0.0, "win_rate": 0.0,
+                "profit_factor": 0.0, "total_trades": 0, "avg_win_pct": 0.0,
+                "avg_loss_pct": 0.0, "trades": [], "params": {},
+            }
+
+    df = pd.DataFrame(
+        {"open": [100.0] * 60, "high": [101.0] * 60, "low": [99.0] * 60,
+         "close": [100.0] * 60, "volume": [1000.0] * 60},
+        index=pd.date_range("2024-01-01", periods=60, freq="D"),
+    )
+    monkeypatch.setattr(run_backtest, "Backtester", SpyBacktester)
+    monkeypatch.setattr(run_backtest, "load_cached_data", lambda *a, **kw: df)
+
+    _run_main(monkeypatch, [
+        "--mode", "single", "--strategy", "sma_crossover",
+        "--regime-enabled",
+        "--regime-windows-spec-json", json.dumps(COMPOSITE_SPEC),
+        "--allowed-regimes", "ranging_quiet",
+        "--allowed-regimes", "trending_up_clean",
+    ])
+    assert seen.get("allowed_regimes") == ["ranging_quiet", "trending_up_clean"]
+    assert seen["regime_windows_spec"]["medium"]["classifier"] == "composite"
+
+
+def test_cli_composite_label_rejected_without_spec(monkeypatch):
+    """Must-survive (b) end-to-end: composite label on an ADX (no-spec) by-name
+    backtest is rejected by our validator (not silently accepted)."""
+    with pytest.raises(SystemExit):
+        _run_main(monkeypatch, [
+            "--mode", "single", "--strategy", "sma_crossover",
+            "--regime-enabled",
+            "--allowed-regimes", "ranging_quiet",
+        ])

--- a/backtest/tests/test_backtester_composite_regime_wiring.py
+++ b/backtest/tests/test_backtester_composite_regime_wiring.py
@@ -708,3 +708,87 @@ def test_validator_accepts_composite_sl_with_sl_after():
         close_strategies=[close_ref],
     )
     assert bt._stop_loss_regime_block.resolve("ranging_volatile").atr == 1.5
+
+
+# ─── tiered_tp_atr_regime tier vocabulary validated at load (#1058 review 4) ──
+# A tier set keyed by labels the primary classifier can never emit must be
+# rejected at construction (mirroring live regime_atr.go parseRegimeTPTiers),
+# not silently no-op every take-profit tier at runtime.
+
+_ADX_TP_LABELS = ["trending_up", "trending_down", "ranging"]
+_COMPOSITE_TP_LABELS = list(VALID_LABELS_COMPOSITE)
+
+
+def _regime_tp_tier(labels, atr, frac):
+    return {"trend_regime": {l: {"atr_multiple": atr, "close_fraction": frac} for l in labels}}
+
+
+def _regime_tiered_ref(labels):
+    return {"name": "tiered_tp_atr_regime", "params": {"tp_tiers": [
+        _regime_tp_tier(labels, 2.0, 0.5),
+        _regime_tp_tier(labels, 3.0, 1.0),
+    ]}}
+
+
+def _bt_with_tiered_regime(spec, labels):
+    return Backtester(initial_capital=1000.0, regime_enabled=True,
+                      regime_windows_spec=spec,
+                      close_strategies=[_regime_tiered_ref(labels)])
+
+
+def test_composite_keyed_tiered_tp_resolves():
+    # Must-survive (c): composite primary + composite-keyed tiers → constructs and
+    # the per-substate close fractions resolve.
+    bt = _bt_with_tiered_regime(COMPOSITE_SPEC, _COMPOSITE_TP_LABELS)
+    fr = bt._sl_mod.parse_tp_tier_close_fractions(
+        [_regime_tiered_ref(_COMPOSITE_TP_LABELS)], regime="ranging_quiet")
+    assert fr == [0.5, 1.0]
+
+
+def test_composite_primary_adx_keyed_tiered_tp_rejects():
+    # Must-survive (a): ADX-keyed tiers under a composite primary → reject at load,
+    # never a silent 0-TP run.
+    with pytest.raises(ValueError) as exc:
+        _bt_with_tiered_regime(COMPOSITE_SPEC, _ADX_TP_LABELS)
+    assert "tiered-TP" in str(exc.value) and "unknown regime label" in str(exc.value)
+
+
+def test_adx_primary_composite_keyed_tiered_tp_rejects():
+    # Must-survive (b): inverse — composite-keyed tiers under an ADX primary →
+    # reject, not a silent no-op.
+    with pytest.raises(ValueError):
+        _bt_with_tiered_regime({"medium": {"classifier": "adx", "period": 14}},
+                               _COMPOSITE_TP_LABELS)
+
+
+def test_adx_keyed_tiered_tp_byte_identical():
+    # Must-survive (c): ADX primary + ADX-keyed and legacy no-spec + ADX-keyed
+    # both construct and resolve exactly as before.
+    bt_adx = _bt_with_tiered_regime({"medium": {"classifier": "adx", "period": 14}},
+                                    _ADX_TP_LABELS)
+    assert bt_adx._sl_mod.parse_tp_tier_close_fractions(
+        [_regime_tiered_ref(_ADX_TP_LABELS)], regime="ranging") == [0.5, 1.0]
+    bt_legacy = _bt_with_tiered_regime(None, _ADX_TP_LABELS)
+    assert bt_legacy._sl_mod.parse_tp_tier_close_fractions(
+        [_regime_tiered_ref(_ADX_TP_LABELS)], regime="trending_up") == [0.5, 1.0]
+
+
+def test_validate_regime_tiered_tp_labels_helper():
+    # Direct unit on the shared-module validator: labels=None (legacy) accepts ADX
+    # keys; composite labels reject ADX keys; composite labels accept composite.
+    # Reach the close module via a constructed Backtester so the close-strategies
+    # path is on sys.path regardless of test ordering.
+    _sl = _bt_with_tiered_regime(None, _ADX_TP_LABELS)._sl_mod
+    assert _sl.validate_regime_tiered_tp_labels([_regime_tiered_ref(_ADX_TP_LABELS)]) == []
+    assert _sl.validate_regime_tiered_tp_labels(
+        [_regime_tiered_ref(_ADX_TP_LABELS)],
+        labels=_COMPOSITE_TP_LABELS) != []
+    assert _sl.validate_regime_tiered_tp_labels(
+        [_regime_tiered_ref(_COMPOSITE_TP_LABELS)],
+        labels=_COMPOSITE_TP_LABELS) == []
+    # A non-regime close ref is ignored (no false positive).
+    assert _sl.validate_regime_tiered_tp_labels(
+        [{"name": "tiered_tp_atr", "params": {"tp_tiers": [
+            {"atr_multiple": 2.0, "close_fraction": 0.5},
+            {"atr_multiple": 3.0, "close_fraction": 1.0}]}}],
+        labels=_COMPOSITE_TP_LABELS) == []

--- a/backtest/tests/test_backtester_composite_regime_wiring.py
+++ b/backtest/tests/test_backtester_composite_regime_wiring.py
@@ -592,3 +592,119 @@ def test_config_absent_allowed_regimes_runs(monkeypatch, tmp_path):
     ])
     assert seen["allowed_regimes"] is None
     assert seen["regime_windows_spec"]["medium"]["classifier"] == "composite"
+
+
+# ─── Regime-keyed exit consumers resolve composite labels (#1058 review 3) ────
+# The composite label now feeds _run_position_regime, so the regime-keyed
+# stop_loss_atr_regime / trailing_stop_atr_regime / sl_after blocks must validate
+# and resolve against the PRIMARY window's classifier vocabulary — mirroring live
+# regimeLabelsForStrategyWindow -> parseRegimeATRBlock. Else a composite-keyed
+# block is falsely rejected, and an ADX-keyed block silently resolves to the
+# default stop under a composite stamp.
+
+
+from backtester import _regime_primary_labels  # noqa: E402
+
+_COMPOSITE_SL_BLOCK = {"trend_regime": {
+    "trending_up_clean": {"atr_multiple": 2.0},
+    "trending_up_choppy": {"atr_multiple": 1.8},
+    "trending_down_clean": {"atr_multiple": 2.0},
+    "trending_down_choppy": {"atr_multiple": 1.8},
+    "ranging_quiet": {"atr_multiple": 1.2},
+    "ranging_volatile": {"atr_multiple": 1.5},
+    "ranging_directional": {"atr_multiple": 1.4},
+}}
+_ADX_SL_BLOCK = {"trend_regime": {
+    "trending_up": {"atr_multiple": 2.0},
+    "trending_down": {"atr_multiple": 2.0},
+    "ranging": {"atr_multiple": 1.5},
+}}
+_COMPOSITE_TRAIL_BLOCK = {"trend_regime": {
+    k: {"atr_multiple": v["atr_multiple"] + 0.5}
+    for k, v in _COMPOSITE_SL_BLOCK["trend_regime"].items()
+}}
+
+
+def test_regime_primary_labels_helper():
+    labels = _regime_primary_labels(COMPOSITE_SPEC)
+    assert set(labels) == set(VALID_LABELS_COMPOSITE)
+    # ADX-primary and no-spec both fall back to the canonical ADX default (None).
+    assert _regime_primary_labels({"medium": {"classifier": "adx", "period": 14}}) is None
+    assert _regime_primary_labels(None) is None
+    # Mixed spec: primary is medium (composite) even with an ADX sibling window.
+    assert set(_regime_primary_labels({
+        "medium": {"classifier": "composite", "period": 30},
+        "short": {"classifier": "adx", "period": 7},
+    })) == set(VALID_LABELS_COMPOSITE)
+
+
+def _bt_with_sl_regime(spec, block, *, trailing=False):
+    kw = {"trailing_stop_atr_regime": block} if trailing else {"stop_loss_atr_regime": block}
+    return Backtester(initial_capital=1000.0, regime_enabled=True,
+                      regime_windows_spec=spec, **kw)
+
+
+def test_composite_keyed_sl_regime_parses_and_resolves():
+    # Must-survive (a): composite primary + exhaustive composite-keyed SL block
+    # parses and resolves per substate (not rejected, not defaulted).
+    bt = _bt_with_sl_regime(COMPOSITE_SPEC, _COMPOSITE_SL_BLOCK)
+    assert bt._stop_loss_regime_block.resolve("ranging_quiet").atr == 1.2
+    assert bt._stop_loss_regime_block.resolve("trending_up_clean").atr == 2.0
+
+
+def test_composite_primary_adx_keyed_sl_regime_rejects():
+    # Must-survive (b): ADX-keyed block under a composite primary is rejected
+    # loudly — never a silent fall-back to the default stop.
+    with pytest.raises(ValueError) as exc:
+        _bt_with_sl_regime(COMPOSITE_SPEC, _ADX_SL_BLOCK)
+    msg = str(exc.value)
+    assert "unknown regime label" in msg
+    # The message names the composite vocabulary, not the misleading ADX one.
+    assert "ranging_quiet" in msg or "trending_up_clean" in msg
+
+
+def test_adx_primary_adx_keyed_sl_regime_byte_identical():
+    # Must-survive (c): ADX primary + ADX-keyed and the legacy no-spec path both
+    # resolve the 3 ADX labels exactly as before.
+    bt_adx = _bt_with_sl_regime({"medium": {"classifier": "adx", "period": 14}}, _ADX_SL_BLOCK)
+    assert bt_adx._stop_loss_regime_block.resolve("ranging").atr == 1.5
+    bt_legacy = _bt_with_sl_regime(None, _ADX_SL_BLOCK)
+    assert bt_legacy._stop_loss_regime_block.resolve("trending_up").atr == 2.0
+
+
+def test_composite_primary_adx_keyed_sl_regime_does_not_silently_default():
+    # The pre-fix bug: ADX-keyed block under composite parsed, then resolve of the
+    # composite stamp returned None → default stop. Assert it now raises instead
+    # of producing a block that silently misses on every composite label.
+    with pytest.raises(ValueError):
+        _bt_with_sl_regime(COMPOSITE_SPEC, _ADX_SL_BLOCK)
+
+
+def test_composite_keyed_trailing_regime_parses_and_resolves():
+    # Same guarantee on the trailing-stop surface.
+    bt = _bt_with_sl_regime(COMPOSITE_SPEC, _COMPOSITE_TRAIL_BLOCK, trailing=True)
+    assert bt._trailing_stop_regime_block.resolve("ranging_quiet").atr == 1.7
+
+
+def test_composite_primary_adx_keyed_trailing_rejects():
+    with pytest.raises(ValueError):
+        _bt_with_sl_regime(COMPOSITE_SPEC, _ADX_SL_BLOCK, trailing=True)
+
+
+def test_validator_accepts_composite_sl_with_sl_after():
+    # Exercises validate_post_tp_stop_loss_rules' threaded labels: a composite SL
+    # block paired with a tiered close carrying sl_after must NOT be falsely
+    # rejected (the validator re-parses stop_loss_atr_regime with the labels).
+    close_ref = {"name": "tiered_tp_atr", "params": {
+        "tp_tiers": [
+            {"atr_multiple": 2.0, "close_fraction": 0.5},
+            {"atr_multiple": 3.0, "close_fraction": 1.0, "sl_after": {"kind": "breakeven"}},
+        ],
+    }}
+    bt = Backtester(
+        initial_capital=1000.0, regime_enabled=True,
+        regime_windows_spec=COMPOSITE_SPEC,
+        stop_loss_atr_regime=_COMPOSITE_SL_BLOCK,
+        close_strategies=[close_ref],
+    )
+    assert bt._stop_loss_regime_block.resolve("ranging_volatile").atr == 1.5

--- a/shared_strategies/close/post_tp_sl.py
+++ b/shared_strategies/close/post_tp_sl.py
@@ -720,8 +720,9 @@ def validate_post_tp_stop_loss_rules(
     trailing_stop_pct: Optional[float] = None,
     stop_loss_atr_regime: Optional[Any] = None,
     strategy_type: str = "perps",
+    labels: Optional[Iterable[str]] = None,
 ) -> List[str]:
-    """Mirror ``validatePostTPStopLossRules`` in scheduler/post_tp_sl.go.
+    """Mirror ``validatePostTPStopLossRulesWithLabels`` in scheduler/post_tp_sl.go.
 
     Conditions enforced:
       - shape/field-level errors from parsing
@@ -730,9 +731,16 @@ def validate_post_tp_stop_loss_rules(
       - reject combination with a strategy-level trailing stop
       - require a fixed stop-loss to adjust
       - reject trail_from_here on manual strategies (perps-only in v1)
+
+    ``labels`` is the regime vocabulary the strategy's primary/ATR window
+    classifier emits (#1058): live threads ``regimeLabelsForStrategyWindow`` here
+    so a composite-keyed ``stop_loss_atr_regime`` / ``sl_after`` block validates
+    against the 7-state substates instead of the 3 ADX labels. ``None`` keeps the
+    legacy ADX behavior byte-identical (``parse_regime_atr_block`` defaults to the
+    canonical ADX labels; ``parse_strategy_tp_sl_after_rules`` infers from keys).
     """
     close_refs = list(close_refs)
-    rules, parse_errs = parse_strategy_tp_sl_after_rules(close_refs)
+    rules, parse_errs = parse_strategy_tp_sl_after_rules(close_refs, labels=labels)
     out: List[str] = list(parse_errs)
     for ref in close_refs:
         name = (ref.get("name") or "").strip().lower()
@@ -763,6 +771,7 @@ def validate_post_tp_stop_loss_rules(
         )
     blk_sl_regime, sl_regime_errs = parse_regime_atr_block(
         stop_loss_atr_regime, "stop_loss_atr_regime", SURFACE_STOP_LOSS,
+        labels=tuple(labels) if labels is not None else None,
     )
     if stop_loss_atr_regime is not None and sl_regime_errs:
         out.extend(sl_regime_errs)

--- a/shared_strategies/close/post_tp_sl.py
+++ b/shared_strategies/close/post_tp_sl.py
@@ -829,10 +829,17 @@ def validate_regime_tiered_tp_labels(
     ``trend_regime`` keys, never re-parsing tier shape/count/sibling keys
     (``sl_after``, ``tp_atr_fraction``, scalar ``close_fraction``), which the
     backtester's existing machinery and the HL-live-only guards already handle.
-    A tier key not in the expected vocabulary is the only thing flagged, so a
-    single-tier or partially-keyed regime config that was valid before is not
-    newly rejected. ``labels=None`` resolves to the canonical 3 ADX labels, so the
-    ADX/legacy path is byte-identical AND an ADX-primary strategy still rejects
+    Each per-regime tier must be EXHAUSTIVE over the expected vocabulary: a key
+    the classifier can never emit is flagged as unknown, and an omitted label is
+    flagged as missing — mirroring live ``parseRegimeATRBlock`` (regime_atr.go),
+    which rejects a non-exhaustive ``trend_regime`` block per tier ("must be
+    exhaustive — no silent fallback"). Without the missing-label arm a
+    composite-primary config with a partially-keyed tier passes the backtester
+    but is rejected live, and ``resolve_regime_tier`` silently no-ops TP on every
+    un-keyed substate. A tier-level ``use_defaults`` expands to the full
+    vocabulary at the resolver, so it is exempt (like live's early-return).
+    ``labels=None`` resolves to the canonical 3 ADX labels, so the ADX/legacy
+    path is byte-identical AND an ADX-primary strategy still rejects
     composite-keyed tiers (must-survive (b)). Returns error strings (empty=valid).
     """
     expected = set(labels) if labels is not None else set(CANONICAL_TREND_REGIME_LABELS)
@@ -852,6 +859,11 @@ def validate_regime_tiered_tp_labels(
         for i, tier in enumerate(tiers_raw):
             if not isinstance(tier, dict):
                 continue
+            if bool(tier.get("use_defaults")):
+                # Tier-level use_defaults expands to the full vocabulary at the
+                # resolver (mirrors live parseRegimeATRBlock early-return) — no
+                # operator-supplied keys to mis-vocabulary or omit.
+                continue
             block = tier.get(REGIME_CLASSIFIER_KEY)
             if not isinstance(block, dict):
                 continue
@@ -859,6 +871,13 @@ def validate_regime_tiered_tp_labels(
                 errs.append(
                     f"{name}.tiers[{i}].{REGIME_CLASSIFIER_KEY}: unknown regime "
                     f"label {key!r} (expected one of: {', '.join(sorted(expected))})"
+                )
+            missing = [label for label in sorted(expected) if label not in block]
+            if missing:
+                errs.append(
+                    f"{name}.tiers[{i}].{REGIME_CLASSIFIER_KEY}: missing required "
+                    f"regime labels: {', '.join(missing)} "
+                    f"(must be exhaustive — no silent fallback)"
                 )
     return errs
 

--- a/shared_strategies/close/post_tp_sl.py
+++ b/shared_strategies/close/post_tp_sl.py
@@ -809,6 +809,60 @@ def validate_post_tp_stop_loss_rules(
     return out
 
 
+def validate_regime_tiered_tp_labels(
+    close_refs: Iterable[dict],
+    labels: Optional[Iterable[str]] = None,
+) -> List[str]:
+    """Validate ``tiered_tp_atr_regime`` / ``tiered_tp_atr_live_regime`` tier-key
+    vocabularies against the strategy's primary-window classifier ``labels`` (#1058).
+
+    Mirrors the intent of the live config-load check in scheduler/regime_atr.go
+    (``parseRegimeTPTiers`` keyed by ``regimeLabelsForStrategyWindow``): a tier's
+    ``trend_regime`` block keyed by labels the primary window's classifier can
+    never emit — an ADX-keyed tier under a composite primary window, or the
+    inverse — is rejected loudly at load. Without it the backtester's
+    ``parse_tp_tier_close_fractions`` infers labels from the tier keys and then
+    ``resolve_regime_tier`` silently misses on every stamped label, disabling all
+    take-profit tiers (a 0-TP run that reads as "never hit TP", not "bad config").
+
+    Guards the tier-key VOCABULARY only — by inspecting each tier's
+    ``trend_regime`` keys, never re-parsing tier shape/count/sibling keys
+    (``sl_after``, ``tp_atr_fraction``, scalar ``close_fraction``), which the
+    backtester's existing machinery and the HL-live-only guards already handle.
+    A tier key not in the expected vocabulary is the only thing flagged, so a
+    single-tier or partially-keyed regime config that was valid before is not
+    newly rejected. ``labels=None`` resolves to the canonical 3 ADX labels, so the
+    ADX/legacy path is byte-identical AND an ADX-primary strategy still rejects
+    composite-keyed tiers (must-survive (b)). Returns error strings (empty=valid).
+    """
+    expected = set(labels) if labels is not None else set(CANONICAL_TREND_REGIME_LABELS)
+    errs: List[str] = []
+    for ref in close_refs:
+        name = (ref.get("name") or "").strip().lower()
+        if name not in ("tiered_tp_atr_regime", "tiered_tp_atr_live_regime"):
+            continue
+        params = ref.get("params") or {}
+        if bool(params.get("use_defaults")):
+            # Baseline ladder carries no operator-supplied keys to mis-vocabulary;
+            # validated at the default-tier resolver, like live.
+            continue
+        tiers_raw = tier_list_from_params(params)
+        if not isinstance(tiers_raw, list):
+            continue
+        for i, tier in enumerate(tiers_raw):
+            if not isinstance(tier, dict):
+                continue
+            block = tier.get(REGIME_CLASSIFIER_KEY)
+            if not isinstance(block, dict):
+                continue
+            for key in sorted(k for k in block.keys() if k not in expected):
+                errs.append(
+                    f"{name}.tiers[{i}].{REGIME_CLASSIFIER_KEY}: unknown regime "
+                    f"label {key!r} (expected one of: {', '.join(sorted(expected))})"
+                )
+    return errs
+
+
 def parse_tp_tier_close_fractions(
     close_refs: Iterable[dict],
     regime: Optional[str] = None,


### PR DESCRIPTION
Closes #1058

## Problem
The backtester only ran the 3-label ADX classifier, so backtests could not model close/exit behavior keyed on the live composite (7-state) substates — the three ranging substates (`ranging_quiet` / `ranging_volatile` / `ranging_directional`) and the clean/choppy trend splits. The close evaluator's regime label (`_run_position_regime`) was fed from the ADX column and never saw substates. `ensure_regime_columns` already supported `compute_regime_composite` via a `windows_spec`; the Backtester just never threaded it.

## Change
- **`backtester.py`** — new `regime_windows_spec` param. When set, `ensure_regime_columns` classifies the **primary window (medium-first)** — composite or ADX — into the per-bar `regime` column and `_run_position_regime`, exactly mirroring live's `regime_from_injected_payload` primary-window selection (`REGIME_PRIMARY_WINDOW_KEY`). `None` keeps the legacy single-lookback ADX path (`regime_period` / `regime_adx_threshold`) byte-identical. Look-ahead invariants are preserved by the existing N→N+1 shift + `_regime_bar_close` snapshot, which are classifier-agnostic.
- **`run_backtest.py`** — `_resolve_regime_windows_spec` sources `regime.windows` from `--config` with Go `resolvedForEmit` parity (period defaults to top-level `regime.period`; ADX `adx_threshold` defaults to top-level `regime.adx_threshold`; composite thresholds merge over `_DEFAULT_COMPOSITE_THRESHOLDS`). Threaded through `load_strategy_config` → `run_single_backtest` → `Backtester`. Added a `--regime-windows-spec-json` CLI flag for by-name backtests, rejected alongside `--config` (the config's `regime.windows` owns it) and in non-single modes.

## Behavior change (flagged)
An ADX-windows config backtested via `--config` now sources the **medium window** (was the top-level `regime.period`) — a live-parity correctness fix that shifts those backtests' numbers. Harness-only; no live/close behavior or default-ladder change. The ranging-ladder consumer is tracked in #1059.

## Tests
New `test_backtester_composite_regime_wiring.py` (15 tests): composite computation from OHLCV, substate feed to the close evaluator, look-ahead shift, ADX-default-path invariance, resolver/`resolvedForEmit` parity, `load_strategy_config` sourcing, and CLI parsing/rejections + end-to-end threading. Full Python suite green (1636 passed).

https://claude.ai/code/session_01H97jfHLUkHYUodpzoqsxog

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code