### PR TITLE
feat(#1059): split ranging ratchet ladder into quiet/volatile/directional substates

### DIFF
--- a/scheduler/trailing_tp_ratchet.go
+++ b/scheduler/trailing_tp_ratchet.go
@@ -61,12 +61,26 @@ func defaultTrailingRatchetTiers() []trailingRatchetTier {
 	}
 }
 
-// ratchetTierGroupDefaults is the per-quality-group default ratchet ladder for
-// the regime variant (#870 C2). Trend groups (clean/choppy) are pure
-// let-it-ride (close_fraction 0); ranging scales out as ranges mean-revert.
+// ratchetTierGroupDefaults is the per-group default ratchet ladder for the
+// regime variant (#870 C2). Trend groups (clean/choppy) are pure let-it-ride
+// (close_fraction 0); the ranging family scales out as ranges mean-revert.
+// #1059 split the single ranging ladder into three composite substate ladders
+// keyed by ratchetCloseDefaultGroup (NOT the shared regimeCloseDefaultGroup,
+// which still collapses ranging* → "ranging" for the B2 ATR-TP path):
+//   - ranging_quiet keeps the pre-#1059 ranging geometry and is also the target
+//     for bare ADX "ranging" (no substate signal), so ADX behavior is unchanged.
+//   - ranging_volatile widens the triggers (0.75→1.0, 1.5→2.0, 2.0→3.0) to stop
+//     scaling out on wide-range noise; close fractions are unchanged.
+//   - ranging_directional scales out lighter early (25/50/75 vs 40/80/100) and
+//     adds a 4th let-ride rung that only tightens the trail (no extra close) so
+//     the runner survives a nascent breakout instead of being fully scaled out.
+//
 // Each group's first-rung trail couples to that group's opening trail in
-// regimeATRDefaults.Trailing (clean 2.0 / choppy 2.0 / ranging 1.0). Mirrors
-// DEFAULT_RATCHET_TIERS_BY_GROUP in shared_strategies/close/trailing_tp_ratchet.py.
+// regimeATRDefaults.Trailing (clean 2.0 / choppy 2.0 / ranging family 1.0), so
+// every first rung is <= 1.0 for the ranging substates. The split values are
+// starting priors — validate via the #1058 7-state backtester (item 4) before
+// relying on the exact geometry. Mirrors DEFAULT_RATCHET_TIERS_BY_GROUP in
+// shared_strategies/close/trailing_tp_ratchet.py.
 var ratchetTierGroupDefaults = map[string][]trailingRatchetTier{
 	"clean": {
 		{ATRMultiple: 3.0, CloseFraction: 0, TrailingMultAfter: 1.5},
@@ -78,11 +92,43 @@ var ratchetTierGroupDefaults = map[string][]trailingRatchetTier{
 		{ATRMultiple: 2.5, CloseFraction: 0, TrailingMultAfter: 1.0},
 		{ATRMultiple: 3.0, CloseFraction: 0, TrailingMultAfter: 0.8},
 	},
-	"ranging": {
+	"ranging_quiet": {
 		{ATRMultiple: 0.75, CloseFraction: 0.4, TrailingMultAfter: 1.0},
 		{ATRMultiple: 1.5, CloseFraction: 0.8, TrailingMultAfter: 0.75},
 		{ATRMultiple: 2.0, CloseFraction: 1.0, TrailingMultAfter: 0.75},
 	},
+	"ranging_volatile": {
+		{ATRMultiple: 1.0, CloseFraction: 0.4, TrailingMultAfter: 1.0},
+		{ATRMultiple: 2.0, CloseFraction: 0.8, TrailingMultAfter: 0.75},
+		{ATRMultiple: 3.0, CloseFraction: 1.0, TrailingMultAfter: 0.75},
+	},
+	"ranging_directional": {
+		{ATRMultiple: 1.0, CloseFraction: 0.25, TrailingMultAfter: 1.0},
+		{ATRMultiple: 2.0, CloseFraction: 0.50, TrailingMultAfter: 1.0},
+		{ATRMultiple: 3.0, CloseFraction: 0.75, TrailingMultAfter: 0.8},
+		{ATRMultiple: 4.5, CloseFraction: 0.75, TrailingMultAfter: 0.6},
+	},
+}
+
+// ratchetCloseDefaultGroup resolves a classifier label to a ratchet default-
+// ladder group key (#1059). Unlike the shared regimeCloseDefaultGroup — which
+// collapses every ranging* → "ranging" for the B2 ATR-TP path — the ratchet
+// ladder differentiates the three composite ranging substates, so each gets its
+// own scale-out geometry. Bare ADX "ranging" (no substate signal) maps to the
+// quiet ladder, preserving pre-#1059 behavior. clean/choppy and ADX-trend
+// labels delegate unchanged to regimeCloseDefaultGroup. Routing the substates
+// back through the shared fn would make the B2 regimeTPTierGroupDefaults lookup
+// miss and silently emit no TP tiers (never-arm of an auto-protective exit) —
+// keep this resolver ratchet-only.
+func ratchetCloseDefaultGroup(label string) (string, bool) {
+	l := strings.TrimSpace(label)
+	switch l {
+	case "ranging_quiet", "ranging_volatile", "ranging_directional":
+		return l, true
+	case "ranging":
+		return "ranging_quiet", true
+	}
+	return regimeCloseDefaultGroup(l)
 }
 
 // defaultTrailingRatchetTiersForRegime resolves the per-group default ratchet
@@ -90,7 +136,7 @@ var ratchetTierGroupDefaults = map[string][]trailingRatchetTier{
 // trailing_tp_ratchet_regime). Returns nil for an empty/unknown label so the
 // caller emits only the SL until the position regime is stamped.
 func defaultTrailingRatchetTiersForRegime(regime string) []trailingRatchetTier {
-	group, ok := regimeCloseDefaultGroup(regime)
+	group, ok := ratchetCloseDefaultGroup(regime)
 	if !ok {
 		return nil
 	}

--- a/scheduler/trailing_tp_ratchet_test.go
+++ b/scheduler/trailing_tp_ratchet_test.go
@@ -596,6 +596,17 @@ func TestTrailingRatchetTiersForRegime_OmittedReturnsDefault(t *testing.T) {
 		{"regime-ranging", "trailing_tp_ratchet_regime", "ranging_quiet", []trailingRatchetTier{
 			{ATRMultiple: 0.75, CloseFraction: 0.4, TrailingMultAfter: 1.0}, {ATRMultiple: 1.5, CloseFraction: 0.8, TrailingMultAfter: 0.75}, {ATRMultiple: 2.0, CloseFraction: 1.0, TrailingMultAfter: 0.75},
 		}},
+		// #1059: ranging substates resolve to distinct ladders.
+		{"regime-ranging-volatile", "trailing_tp_ratchet_regime", "ranging_volatile", []trailingRatchetTier{
+			{ATRMultiple: 1.0, CloseFraction: 0.4, TrailingMultAfter: 1.0}, {ATRMultiple: 2.0, CloseFraction: 0.8, TrailingMultAfter: 0.75}, {ATRMultiple: 3.0, CloseFraction: 1.0, TrailingMultAfter: 0.75},
+		}},
+		{"regime-ranging-directional", "trailing_tp_ratchet_regime", "ranging_directional", []trailingRatchetTier{
+			{ATRMultiple: 1.0, CloseFraction: 0.25, TrailingMultAfter: 1.0}, {ATRMultiple: 2.0, CloseFraction: 0.50, TrailingMultAfter: 1.0}, {ATRMultiple: 3.0, CloseFraction: 0.75, TrailingMultAfter: 0.8}, {ATRMultiple: 4.5, CloseFraction: 0.75, TrailingMultAfter: 0.6},
+		}},
+		// Bare ADX "ranging" still resolves to the quiet ladder (#1059).
+		{"regime-ranging-adx", "trailing_tp_ratchet_regime", "ranging", []trailingRatchetTier{
+			{ATRMultiple: 0.75, CloseFraction: 0.4, TrailingMultAfter: 1.0}, {ATRMultiple: 1.5, CloseFraction: 0.8, TrailingMultAfter: 0.75}, {ATRMultiple: 2.0, CloseFraction: 1.0, TrailingMultAfter: 0.75},
+		}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -705,18 +716,72 @@ func TestValidateTrailingTPRatchetClose_ManualRegimeRatchet(t *testing.T) {
 	}
 }
 
-// TestDefaultTrailingRatchetTiersForRegime covers #870 per-group ratchet ladders.
+// TestDefaultTrailingRatchetTiersForRegime covers #870 per-group ratchet ladders
+// and the #1059 ranging-substate split.
 func TestDefaultTrailingRatchetTiersForRegime(t *testing.T) {
 	clean := defaultTrailingRatchetTiersForRegime("trending_up_clean")
 	if len(clean) != 3 || clean[0].ATRMultiple != 3.0 || clean[0].TrailingMultAfter != 1.5 || clean[2].ATRMultiple != 6.0 {
 		t.Fatalf("clean group mismatch: %+v", clean)
 	}
-	ranging := defaultTrailingRatchetTiersForRegime("ranging_volatile")
-	if len(ranging) != 3 || ranging[0].CloseFraction != 0.4 || ranging[2].CloseFraction != 1.0 {
-		t.Fatalf("ranging group mismatch: %+v", ranging)
+	// #1059: ranging_quiet keeps the pre-split geometry; bare ADX "ranging" maps
+	// to it too, so ADX behavior is unchanged.
+	quiet := defaultTrailingRatchetTiersForRegime("ranging_quiet")
+	if len(quiet) != 3 || quiet[0].ATRMultiple != 0.75 || quiet[0].CloseFraction != 0.4 || quiet[2].CloseFraction != 1.0 {
+		t.Fatalf("ranging_quiet mismatch: %+v", quiet)
+	}
+	adx := defaultTrailingRatchetTiersForRegime("ranging")
+	if len(adx) != 3 || adx[0].ATRMultiple != 0.75 || adx[2].CloseFraction != 1.0 {
+		t.Fatalf("bare ADX ranging must map to the quiet ladder: %+v", adx)
+	}
+	// #1059: ranging_volatile widens triggers, close fractions unchanged.
+	volatile := defaultTrailingRatchetTiersForRegime("ranging_volatile")
+	if len(volatile) != 3 ||
+		volatile[0].ATRMultiple != 1.0 || volatile[2].ATRMultiple != 3.0 ||
+		volatile[0].CloseFraction != 0.4 || volatile[2].CloseFraction != 1.0 {
+		t.Fatalf("ranging_volatile mismatch: %+v", volatile)
+	}
+	// #1059: ranging_directional rides further — 4 tiers, 25/50/75/75 with a
+	// let-ride final rung (no extra close, tighter trail).
+	dir := defaultTrailingRatchetTiersForRegime("ranging_directional")
+	if len(dir) != 4 {
+		t.Fatalf("ranging_directional want 4 tiers, got %+v", dir)
+	}
+	if dir[0].CloseFraction != 0.25 || dir[1].CloseFraction != 0.50 ||
+		dir[2].CloseFraction != 0.75 || dir[3].CloseFraction != 0.75 {
+		t.Fatalf("ranging_directional close fractions mismatch: %+v", dir)
+	}
+	if dir[3].ATRMultiple != 4.5 || dir[3].TrailingMultAfter != 0.6 {
+		t.Fatalf("ranging_directional let-ride rung mismatch: %+v", dir[3])
 	}
 	if defaultTrailingRatchetTiersForRegime("") != nil {
 		t.Error("empty regime must resolve to nil")
+	}
+}
+
+// TestRatchetCloseDefaultGroup covers #1059: the ratchet-only resolver
+// differentiates the composite ranging substates, while regimeCloseDefaultGroup
+// (the shared B2 ATR-TP fn) keeps collapsing them — verified in
+// TestRegimeCloseDefaultGroup.
+func TestRatchetCloseDefaultGroup(t *testing.T) {
+	cases := []struct {
+		label, group string
+		ok           bool
+	}{
+		{"ranging_quiet", "ranging_quiet", true},
+		{"ranging_volatile", "ranging_volatile", true},
+		{"ranging_directional", "ranging_directional", true},
+		{"ranging", "ranging_quiet", true}, // bare ADX → quiet ladder
+		{"trending_up_clean", "clean", true},
+		{"trending_up_choppy", "choppy", true},
+		{"trending_up", "choppy", true},
+		{"", "", false},
+		{"bogus", "", false},
+	}
+	for _, tc := range cases {
+		g, ok := ratchetCloseDefaultGroup(tc.label)
+		if ok != tc.ok || g != tc.group {
+			t.Errorf("ratchetCloseDefaultGroup(%q) = (%q, %v), want (%q, %v)", tc.label, g, ok, tc.group, tc.ok)
+		}
 	}
 }
 

--- a/shared_strategies/close/test_trailing_tp_ratchet.py
+++ b/shared_strategies/close/test_trailing_tp_ratchet.py
@@ -168,3 +168,50 @@ def test_resolve_tiers_for_regime_group_defaults(ratchet):
     )
     assert errs == []
     assert [t[0] for t in scalar] == [2.0, 2.5, 3.0]
+
+
+def test_ratchet_close_default_group_differentiates_ranging_substates(ratchet):
+    # #1059: the ratchet-only resolver splits the composite ranging substates.
+    g = ratchet.ratchet_close_default_group
+    assert g("ranging_quiet") == "ranging_quiet"
+    assert g("ranging_volatile") == "ranging_volatile"
+    assert g("ranging_directional") == "ranging_directional"
+    # Bare ADX "ranging" (no substate signal) → quiet ladder (pre-#1059 behavior).
+    assert g("ranging") == "ranging_quiet"
+    # clean/choppy/trend labels delegate to the shared fn, unchanged.
+    assert g("trending_up_clean") == "clean"
+    assert g("trending_up") == "choppy"
+    assert g("") is None
+    assert g("bogus") is None
+    # The shared regime_close_default_group MUST still collapse the substates, or
+    # the B2 ATR-TP use_defaults path would miss its map and never-arm (#1059).
+    assert ratchet.regime_close_default_group("ranging_directional") == "ranging"
+    assert ratchet.regime_close_default_group("ranging_volatile") == "ranging"
+
+
+def test_resolve_tiers_for_regime_ranging_substates(ratchet):
+    # #1059 ranging_volatile: widened triggers, close fractions unchanged vs quiet.
+    volatile, errs = ratchet.resolve_tiers_for_regime(
+        {"use_defaults": True}, "ranging_volatile", regime_table=True,
+    )
+    assert errs == []
+    assert [t[0] for t in volatile] == [1.0, 2.0, 3.0]
+    assert [t[1] for t in volatile] == [0.4, 0.8, 1.0]
+
+    # #1059 ranging_directional: lighter early scale-out (25/50/75) + a 4th
+    # let-ride rung adding no close (cumulative stays 0.75) but tightening trail.
+    directional, errs = ratchet.resolve_tiers_for_regime(
+        {"use_defaults": True}, "ranging_directional", regime_table=True,
+    )
+    assert errs == []
+    assert [t[0] for t in directional] == [1.0, 2.0, 3.0, 4.5]
+    assert [t[1] for t in directional] == [0.25, 0.50, 0.75, 0.75]
+    assert [t[2] for t in directional] == [1.0, 1.0, 0.8, 0.6]  # trail non-increasing
+
+    # Bare ADX "ranging" still resolves to the quiet ladder (unchanged pre-#1059).
+    adx_ranging, errs = ratchet.resolve_tiers_for_regime(
+        {"use_defaults": True}, "ranging", regime_table=True,
+    )
+    assert errs == []
+    assert [t[0] for t in adx_ranging] == [0.75, 1.5, 2.0]
+    assert [t[1] for t in adx_ranging] == [0.4, 0.8, 1.0]

--- a/shared_strategies/close/trailing_tp_ratchet.py
+++ b/shared_strategies/close/trailing_tp_ratchet.py
@@ -29,12 +29,24 @@ DEFAULT_RATCHET_TIERS = [
     {"atr_multiple": 3.0, "trailing_mult_after": 0.8, "close_fraction": 0.0},
 ]
 
-# #870: per-quality-group default ratchet ladders for the REGIME variant
+# #870: per-group default ratchet ladders for the REGIME variant
 # (trailing_tp_ratchet_regime) when tp_tiers is omitted / use_defaults:true.
 # Mirrors ratchetTierGroupDefaults in scheduler/trailing_tp_ratchet.go. Trend
-# groups (clean/choppy) are pure let-it-ride (close_fraction 0); ranging scales
-# out. Each group's first rung couples to that group's opening trail in
-# REGIME_ATR_DEFAULTS_TRAILING (clean 2.0 / choppy 2.0 / ranging 1.0).
+# groups (clean/choppy) are pure let-it-ride (close_fraction 0). #1059 split the
+# single ranging ladder into three composite substate ladders keyed by
+# ratchet_close_default_group (NOT the shared regime_close_default_group, which
+# still collapses ranging* → "ranging" for the B2 ATR-TP path):
+#   - ranging_quiet keeps the pre-#1059 ranging geometry and is also the target
+#     for bare ADX "ranging", so ADX behavior is unchanged.
+#   - ranging_volatile widens the triggers (avoid scaling out on wide-range
+#     noise); close fractions unchanged.
+#   - ranging_directional scales out lighter early (25/50/75) and adds a 4th
+#     let-ride rung that only tightens the trail (no extra close) so a nascent
+#     breakout's runner survives.
+# Each group's first rung couples to that group's opening trail in
+# REGIME_ATR_DEFAULTS_TRAILING (clean 2.0 / choppy 2.0 / ranging family 1.0).
+# Split values are starting priors — validate via the #1058 7-state backtester
+# before relying on the exact geometry.
 DEFAULT_RATCHET_TIERS_BY_GROUP = {
     "clean": [
         {"atr_multiple": 3.0, "trailing_mult_after": 1.5, "close_fraction": 0.0},
@@ -46,12 +58,40 @@ DEFAULT_RATCHET_TIERS_BY_GROUP = {
         {"atr_multiple": 2.5, "trailing_mult_after": 1.0, "close_fraction": 0.0},
         {"atr_multiple": 3.0, "trailing_mult_after": 0.8, "close_fraction": 0.0},
     ],
-    "ranging": [
+    "ranging_quiet": [
         {"atr_multiple": 0.75, "trailing_mult_after": 1.0, "close_fraction": 0.4},
         {"atr_multiple": 1.5, "trailing_mult_after": 0.75, "close_fraction": 0.8},
         {"atr_multiple": 2.0, "trailing_mult_after": 0.75, "close_fraction": 1.0},
     ],
+    "ranging_volatile": [
+        {"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.4},
+        {"atr_multiple": 2.0, "trailing_mult_after": 0.75, "close_fraction": 0.8},
+        {"atr_multiple": 3.0, "trailing_mult_after": 0.75, "close_fraction": 1.0},
+    ],
+    "ranging_directional": [
+        {"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.25},
+        {"atr_multiple": 2.0, "trailing_mult_after": 1.0, "close_fraction": 0.50},
+        {"atr_multiple": 3.0, "trailing_mult_after": 0.8, "close_fraction": 0.75},
+        {"atr_multiple": 4.5, "trailing_mult_after": 0.6, "close_fraction": 0.75},
+    ],
 }
+
+
+def ratchet_close_default_group(label: str) -> Optional[str]:
+    """Resolve a classifier label to a ratchet default-ladder group key (#1059).
+
+    Unlike the shared regime_close_default_group (which collapses every ranging*
+    → "ranging" for the B2 ATR-TP path), the ratchet ladder differentiates the
+    three composite ranging substates. Bare ADX "ranging" maps to the quiet
+    ladder (pre-#1059 behavior). clean/choppy and ADX-trend labels delegate
+    unchanged to regime_close_default_group. Mirrors ratchetCloseDefaultGroup in
+    scheduler/trailing_tp_ratchet.go."""
+    l = (label or "").strip()
+    if l in ("ranging_quiet", "ranging_volatile", "ranging_directional"):
+        return l
+    if l == "ranging":
+        return "ranging_quiet"
+    return regime_close_default_group(l)
 
 
 def _first_present(d: dict, *keys: str):
@@ -163,7 +203,7 @@ def resolve_tiers_for_regime(
         # ladder. #870: the regime variant resolves the per-quality-group ladder
         # for the stamped regime; the scalar variant uses the single #866 default.
         if regime_table:
-            group = regime_close_default_group(regime)
+            group = ratchet_close_default_group(regime)
             ladder = DEFAULT_RATCHET_TIERS_BY_GROUP.get(group) if group else None
             if not ladder:
                 return [], []


### PR DESCRIPTION
Closes #1059.

## What
Splits the single regime **ratchet** default ranging ladder into the three composite ranging substates, via a new **ratchet-only** group resolver. The shared `regimeCloseDefaultGroup` (the B2 ATR-TP path) is left untouched — it keeps collapsing `ranging*` → `ranging`, so the B2 `use_defaults` defaults still arm. This is the issue's preferred Option 1 and avoids the named silent-never-arm trap.

Ladders (starting priors, backtest-supported below):
- `ranging_quiet` — **unchanged**; also the resolve target for bare ADX `ranging`, so ADX-classifier users see zero behavior change.
- `ranging_volatile` — triggers widened `0.75/1.5/2.0` → `1.0/2.0/3.0`×ATR; close fractions unchanged (40/80/100%).
- `ranging_directional` — 25/50/75% over `1.0/2.0/3.0`×ATR + a 4th **let-ride** rung (`4.5`×ATR, no extra close, trail tightens to `0.6`×) so a nascent breakout's runner survives.

Go (`ratchetTierGroupDefaults`) and Python (`DEFAULT_RATCHET_TIERS_BY_GROUP`) mirrors kept in sync; tests added/updated on both sides. Load-time trail-coupling + monotonicity validators satisfied (every ranging first-rung trail ≤ the 1.0 opening trail).

## Validation (regime-conditioned backtest A/B)
Entries gated per substate so the **only** variable is the ranging ladder. Treatment = new split (`use_defaults`); control = old single ranging ladder replayed across substates. Bollinger mean-reversion, BTC + ETH, 4h, since 2022-01-01, composite 7-state (period 20).

Treatment − control deltas:

| Substate | Symbol | Net return | Win rate | Max DD | Avg win | Mean MAE |
|---|---|---|---|---|---|---|
| volatile | BTC | +0.97pp | +0.87pp | +1.46pp better | +0.45pp | better |
| volatile | ETH | +3.69pp | +4.67pp | +3.71pp better | +0.70pp | better |
| directional | BTC | +4.29pp | +3.67pp | flat | +0.86pp | +0.29pp better |
| directional | ETH | −0.21pp | +10.07pp | +0.42pp better | +0.72pp | better |
| all-ranging | BTC | +0.17pp | +2.44pp | better | +0.60pp | better |
| all-ranging | ETH | +3.37pp | +5.22pp | +3.60pp better | +0.89pp | better |

Neutral-to-positive on every metric, no material regression. The directional "ride-more + let-ride" lifts avg-win in every cell (winners run further, as designed).

**Caveats (honest scope):** one open strategy (mean-reversion, which is *adversarial* to the directional ladder — so these gains are a conservative floor), 4h, 2 symbols. Trade counts differ per arm (the exit policy shifts re-entry timing), so these are policy-outcome comparisons, not paired. `ranging_quiet` had 0 entries with Bollinger (its unchanged-ladder invariant is instead covered by the unit tests, which assert control/treatment resolve byte-identical tiers).

The A/B was run via a throwaway script (not committed). Follow-up **#1066** proposes generalizing it into a reusable incumbent-relative, regime-conditioned exit-policy validator (~M6).

## Tests
- Go: `go test ./...` green (full suite).
- Python: `pytest shared_strategies/ shared_tools/` — 786 passed.

---
LLM: Opus 4.8 | high | Harness: Claude Code

https://claude.ai/code/session_011Wfn7RqCmRcpwZwbZAvgo4
