### PR TITLE
feat: atr_band_revert strategy + composite 7-state ranging default

### DIFF
--- a/backtest/fee_audit.py
+++ b/backtest/fee_audit.py
@@ -95,6 +95,7 @@ LIVE_BIDIRECTIONAL_STRATEGIES = frozenset({
     "chart_pattern", "liquidity_sweeps", "bear_pullback_st", "vwap_rejection_st",
     "momentum_pro", "mean_reversion_pro", "consolidation_range", "mtf_confluence",
     "vol_momentum", "funding_skew", "regime_adaptive", "anchored_vwap",
+    "atr_band_revert",
 })
 
 # The #956/#963 protocol windows; held-out windows overlap `is` and would

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -831,6 +831,11 @@ DEFAULT_PARAM_RANGES = {
         "min_bars": [12, 16, 24],
         "edge_entry_frac": [0.1, 0.2, 0.33],
     },
+    "atr_band_revert": {
+        "period": [14, 20, 30],
+        "atr_period": [10, 14, 20],
+        "k_entry": [1.0, 1.5, 2.0],
+    },
     "bear_pullback_st": {
         "ema_short": [13, 20, 26],
         "ema_mid": [34, 50, 80],

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -77,6 +77,7 @@ var knownShortNames = map[string]string{
 	"momentum_pro":          "mompro",
 	"mean_reversion_pro":    "mrpro",
 	"consolidation_range":   "cr",
+	"atr_band_revert":       "abr",
 	"mtf_confluence":        "mtfc",
 	"vol_momentum":          "volmom",
 	"regime_adaptive":       "regad",
@@ -100,6 +101,7 @@ var bidirectionalPerpsStrategies = map[string]bool{
 	"momentum_pro":        true, // emits short on stacked-bearish-EMA trend-pullback breakdowns
 	"mean_reversion_pro":  true, // emits short on overbought reversion in no-trend regimes
 	"consolidation_range": true, // emits short at the top edge of a consolidation box (range-edge mean-reversion)
+	"atr_band_revert":     true, // futures variant (allow_short) shorts the upper ATR band in ranging conditions
 	"mtf_confluence":      true, // futures variant (allow_short) shorts LTF pullback rallies in HTF downtrends (#957)
 	"vol_momentum":        true, // emits short on ATR-normalized negative momentum with efficiency confirmation (#959)
 	"funding_skew":        true, // shorts crowded-long funding extremes on EMA breakdown (#960)
@@ -108,6 +110,30 @@ var bidirectionalPerpsStrategies = map[string]bool{
 
 func isBidirectionalPerpsStrategy(id string) bool {
 	return bidirectionalPerpsStrategies[id]
+}
+
+// strategiesDefaultingToCompositeRangingGate maps strategy IDs that init should
+// ship pre-gated to the composite (7-state) ranging regime. atr_band_revert is a
+// ranging mean-reversion strategy whose edge depends on the regime filter, so the
+// wizard wires the gate plus a composite "medium" regime window by default rather
+// than leaving it to manual post-init editing. ranging_directional is intentionally
+// excluded — that substate carries directional pressure with no follow-through,
+// i.e. the range most likely about to break into a trend (mean reversion's worst
+// case). Operators can widen/narrow allowed_regimes post-init.
+var strategiesDefaultingToCompositeRangingGate = map[string][]string{
+	"atr_band_revert": {"ranging_quiet", "ranging_volatile"},
+}
+
+// defaultCompositeRangingGate returns a fresh copy of the default composite
+// ranging allowed_regimes for stratID, or nil when the strategy is not gated.
+func defaultCompositeRangingGate(stratID string) []string {
+	labels, ok := strategiesDefaultingToCompositeRangingGate[stratID]
+	if !ok {
+		return nil
+	}
+	out := make([]string, len(labels))
+	copy(out, labels)
+	return out
 }
 
 // deriveShortName returns a short abbreviation for a strategy ID.
@@ -152,6 +178,7 @@ var defaultSpotStrategies = []stratDef{
 	{ID: "tema_cross", ShortName: "temac"},
 	{ID: "momentum_pro", ShortName: "mompro"},
 	{ID: "mean_reversion_pro", ShortName: "mrpro"},
+	{ID: "atr_band_revert", ShortName: "abr"},
 	{ID: "mtf_confluence", ShortName: "mtfc"},
 	{ID: "regime_adaptive", ShortName: "regad"},
 	{ID: "regime_adaptive_htf", ShortName: "rahtf"},
@@ -178,6 +205,7 @@ var defaultPerpsStrategies = []stratDef{
 	{ID: "donchian_breakout", ShortName: "dbo"},
 	{ID: "momentum_pro", ShortName: "mompro"},
 	{ID: "mean_reversion_pro", ShortName: "mrpro"},
+	{ID: "atr_band_revert", ShortName: "abr"},
 	{ID: "mtf_confluence", ShortName: "mtfc"},
 	{ID: "regime_adaptive", ShortName: "regad"},
 	{ID: "regime_adaptive_htf", ShortName: "rahtf"},
@@ -207,6 +235,7 @@ var defaultFuturesStrategies = []stratDef{
 	{ID: "tema_cross_bd", ShortName: "temacb"},
 	{ID: "momentum_pro", ShortName: "mompro"},
 	{ID: "mean_reversion_pro", ShortName: "mrpro"},
+	{ID: "atr_band_revert", ShortName: "abr"},
 	{ID: "mtf_confluence", ShortName: "mtfc"},
 	{ID: "regime_adaptive", ShortName: "regad"},
 	{ID: "regime_adaptive_htf", ShortName: "rahtf"},
@@ -756,6 +785,35 @@ func generateConfig(opts InitOptions) *Config {
 	if opts.CapitalPct > 0 {
 		for i := range cfg.Strategies {
 			cfg.Strategies[i].CapitalPct = opts.CapitalPct
+		}
+	}
+
+	// Pre-gate ranging mean-reversion strategies to the composite (7-state)
+	// regime. The underlying strategy ID is Args[0] for every platform loop
+	// (check_*.py <strategy> <symbol> ...), so post-process uniformly instead of
+	// touching each loop. allowed_regimes is a no-op (and rejected) for options,
+	// so the gate is never applied there. When any gated strategy is present,
+	// enable a global composite "medium" regime window so the labels resolve —
+	// without it the gate validates against the ADX vocabulary and never matches.
+	needsCompositeRangingRegime := false
+	for i := range cfg.Strategies {
+		sc := &cfg.Strategies[i]
+		if sc.Type == "options" || len(sc.Args) == 0 || len(sc.AllowedRegimes) > 0 {
+			continue
+		}
+		if gate := defaultCompositeRangingGate(sc.Args[0]); gate != nil {
+			sc.AllowedRegimes = gate
+			needsCompositeRangingRegime = true
+		}
+	}
+	if needsCompositeRangingRegime && cfg.Regime == nil {
+		cfg.Regime = &RegimeConfig{
+			Enabled:      true,
+			Period:       14,
+			ADXThreshold: 20.0,
+			Windows: RegimeWindowsMap{
+				"medium": {Classifier: regimeClassifierComposite, Period: 20},
+			},
 		}
 	}
 

--- a/scheduler/init_atr_band_revert_test.go
+++ b/scheduler/init_atr_band_revert_test.go
@@ -1,0 +1,107 @@
+package main
+
+import "testing"
+
+// atr_band_revert is a ranging mean-reversion strategy whose edge depends on the
+// regime filter, so init wires it to the composite (7-state) ranging gate by
+// default: a composite "medium" regime window plus allowed_regimes restricted to
+// the quiet/volatile ranging substates (ranging_directional is excluded — that
+// substate is the range most likely about to break into a trend).
+
+func findStrategy(cfg *Config, id string) (StrategyConfig, bool) {
+	for _, s := range cfg.Strategies {
+		if s.ID == id {
+			return s, true
+		}
+	}
+	return StrategyConfig{}, false
+}
+
+func TestGenerateConfig_ATRBandRevert_DefaultsToCompositeRangingGate(t *testing.T) {
+	opts := baseOpts()
+	opts.Assets = []string{"BTC"}
+	opts.SpotStrategies = []string{"atr_band_revert"}
+
+	cfg := generateConfig(opts)
+
+	// 1. The strategy is gated to the composite ranging family.
+	sc, ok := findStrategy(cfg, "abr-btc")
+	if !ok {
+		t.Fatalf("expected strategy abr-btc, got %v", cfg.Strategies)
+	}
+	want := []string{"ranging_quiet", "ranging_volatile"}
+	if len(sc.AllowedRegimes) != len(want) {
+		t.Fatalf("allowed_regimes = %v, want %v", sc.AllowedRegimes, want)
+	}
+	for i, l := range want {
+		if sc.AllowedRegimes[i] != l {
+			t.Fatalf("allowed_regimes[%d] = %q, want %q", i, sc.AllowedRegimes[i], l)
+		}
+	}
+
+	// 2. A composite "medium" regime window is enabled globally.
+	if cfg.Regime == nil || !cfg.Regime.Enabled {
+		t.Fatalf("expected cfg.Regime enabled, got %+v", cfg.Regime)
+	}
+	win, ok := cfg.Regime.Windows["medium"]
+	if !ok {
+		t.Fatalf("expected a composite 'medium' window, got windows %+v", cfg.Regime.Windows)
+	}
+	if win.effectiveClassifier() != regimeClassifierComposite {
+		t.Fatalf("medium window classifier = %q, want composite", win.effectiveClassifier())
+	}
+
+	// 3. The generated config passes validation, incl. regime vocabulary
+	//    (composite labels resolve against the composite primary window).
+	if vErrs := validateStrategyRegimeVocabulary(cfg); len(vErrs) != 0 {
+		t.Fatalf("regime vocabulary errors: %v", vErrs)
+	}
+	if err := validateConfig(cfg, true); err != nil {
+		t.Fatalf("generated config failed validation: %v", err)
+	}
+}
+
+func TestGenerateConfig_WithoutATRBandRevert_NoForcedRegime(t *testing.T) {
+	// A config that doesn't select atr_band_revert must NOT silently enable
+	// global regime detection.
+	opts := baseOpts()
+	opts.Assets = []string{"BTC"}
+	opts.SpotStrategies = []string{"momentum"}
+
+	cfg := generateConfig(opts)
+
+	if cfg.Regime != nil && cfg.Regime.Enabled {
+		t.Fatalf("regime should stay disabled when atr_band_revert is not selected, got %+v", cfg.Regime)
+	}
+	sc, ok := findStrategy(cfg, "momentum-btc")
+	if !ok {
+		t.Fatalf("expected momentum-btc")
+	}
+	if len(sc.AllowedRegimes) != 0 {
+		t.Fatalf("momentum should not be regime-gated, got %v", sc.AllowedRegimes)
+	}
+}
+
+func TestGenerateConfig_ATRBandRevert_Perps_DefaultsToCompositeRangingGate(t *testing.T) {
+	opts := baseOpts()
+	opts.Assets = []string{"BTC"}
+	opts.EnableSpot = false
+	opts.EnablePerps = true
+	opts.PerpsStrategies = []string{"atr_band_revert"}
+
+	cfg := generateConfig(opts)
+
+	sc, ok := findStrategy(cfg, "hl-abr-btc")
+	if !ok {
+		t.Fatalf("expected strategy hl-abr-btc, got %v", cfg.Strategies)
+	}
+	if len(sc.AllowedRegimes) == 0 {
+		t.Fatalf("perps atr_band_revert should be regime-gated, got none")
+	}
+	if cfg.Regime == nil || !cfg.Regime.Enabled {
+		t.Fatalf("expected cfg.Regime enabled for perps atr_band_revert")
+	}
+	if err := validateConfig(cfg, true); err != nil {
+		t.Fatalf("generated perps config failed validation: %v", err)
+	}
+}

--- a/shared_strategies/open/atr_band_revert.py
+++ b/shared_strategies/open/atr_band_revert.py
@@ -1,0 +1,80 @@
+"""
+ATR Band Reversion — entry side.
+
+Ranging-market mean reversion on ATR-scaled bands around a simple moving
+average. With ``mid = SMA(close, period)`` and ``ATR`` the average true range:
+
+    band_lower = mid - k_entry * ATR
+    band_upper = mid + k_entry * ATR
+
+Entries fade the stretch back toward the mean:
+  * long  when ``close <= band_lower`` (price sank a chunk below average),
+  * short when ``close >= band_upper`` (price stretched a chunk above) —
+    only when ``allow_short`` (spot can't short, so it defaults off; the
+    futures variant turns it on).
+
+This module emits ENTRIES ONLY, exactly like ``consolidation_range``. The exit
+is owned by the close+stop machinery and is configuration, not code — at entry
+``mid ≈ entry ± k_entry*ATR``, so the take-profit targets map onto the existing
+ATR close evaluators (no new close code):
+
+  * Take profit AT MID  → ``tiered_tp_atr`` tier at ``atr_multiple ≈ k_entry``.
+  * Take profit AT THE OPPOSITE BAND → leave the close strategy nil
+    (open-as-close): when price reaches the far band the entry signal flips and
+    closes the position; equivalently a ``tiered_tp_atr`` tier at ``2*k_entry``.
+  * SPLIT (half at mid, runner to the opposite band) → a two-tier
+    ``tiered_tp_atr`` (e.g. 50% at ``k_entry``, remainder at ``2*k_entry``).
+  * The range-break STOP is the framework ATR stop
+    (``stop_loss_atr_mult ≈ k_entry + k_stop``) — if price keeps going past the
+    band the range broke and the position is cut.
+
+RANGING GATE: restrict entries to ranging conditions with config
+``allowed_regimes`` (e.g. ``["ranging"]`` for the adx classifier, or
+``["ranging_quiet","ranging_volatile"]`` for the composite classifier — exclude
+``ranging_directional``, the danger zone where a range is about to break). The
+strategy core stays regime-agnostic; the Go regime gate enforces it.
+
+STATUS: a tunable mean-reversion baseline. Mean reversion's failure mode is a
+range that breaks into a trend (worst fill right before the stop) — keep the
+stop tight and the regime gate honest before any live use.
+
+Defaults: period=20 (mid/SMA), atr_period=14, k_entry=1.5.
+"""
+
+import numpy as np
+import pandas as pd
+
+
+def atr_band_revert_core(
+    df: pd.DataFrame,
+    period: int = 20,
+    atr_period: int = 14,
+    k_entry: float = 1.5,
+    allow_short: bool = False,
+) -> pd.DataFrame:
+    result = df.copy()
+
+    mid = result["close"].rolling(window=period).mean()
+
+    # True range -> ATR (rolling mean), matching the repo's ATR convention:
+    # keep full precision below 100, round to int at/above 100 (atr.py).
+    tr = pd.concat([
+        result["high"] - result["low"],
+        (result["high"] - result["close"].shift(1)).abs(),
+        (result["low"] - result["close"].shift(1)).abs(),
+    ], axis=1).max(axis=1)
+    _atr = tr.rolling(window=atr_period).mean()
+    atr = _atr.where(_atr < 100, _atr.round(0))
+
+    result["atr"] = atr
+    result["band_mid"] = mid
+    result["band_lower"] = mid - k_entry * atr
+    result["band_upper"] = mid + k_entry * atr
+
+    result["signal"] = 0
+    long_entry = result["close"] <= result["band_lower"]
+    result.loc[long_entry.fillna(False), "signal"] = 1
+    if allow_short:
+        short_entry = result["close"] >= result["band_upper"]
+        result.loc[short_entry.fillna(False), "signal"] = -1
+    return result

--- a/shared_strategies/open/registry.py
+++ b/shared_strategies/open/registry.py
@@ -40,6 +40,7 @@ from chart_patterns import chart_pattern_core
 from liquidity_sweeps import liquidity_sweep_core
 from range_scalper import range_scalper_core
 from consolidation_range import consolidation_range_core
+from atr_band_revert import atr_band_revert_core
 from sweep_squeeze_combo import sweep_squeeze_combo_core
 from adx_trend import adx_trend_core
 from bear_pullback_st import bear_pullback_st_core
@@ -1169,6 +1170,21 @@ def consolidation_range_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
 
 
 @register(
+    "atr_band_revert",
+    "ATR Band Reversion — ranging-market mean reversion: fade ATR-scaled bands around an SMA (long below mid-k*ATR; short above mid+k*ATR on futures). Entries only — pair with allowed_regimes=ranging and tiered_tp_atr / stop_loss_atr_mult for the take-profit-at-mid and range-break exit (see atr_band_revert.py)",
+    {"period": 20, "atr_period": 14, "k_entry": 1.5, "allow_short": False},
+    variants={
+        "futures": {
+            "description": "ATR Band Reversion — bidirectional ranging mean reversion: fade ATR-scaled bands around an SMA (long below mid-k*ATR, short above mid+k*ATR). Entries only — pair with allowed_regimes=ranging and tiered_tp_atr / stop_loss_atr_mult for exit",
+            "default_params": {"allow_short": True},
+        },
+    },
+)
+def atr_band_revert_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return atr_band_revert_core(df, **params)
+
+
+@register(
     "mtf_confluence",
     "MTF Confluence — higher-timeframe EMA trend gate (resampled in-frame, no extra data) over native-frame pullback resumption entries; exits when the HTF trend flips",
     {
@@ -1292,7 +1308,7 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "heikin_ashi_ema", "order_blocks", "vwap_reversion", "anchored_vwap", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
         "sweep_squeeze_combo", "adx_trend", "donchian_breakout", "tema_cross",
-        "momentum_pro", "mean_reversion_pro", "mtf_confluence",
+        "momentum_pro", "mean_reversion_pro", "atr_band_revert", "mtf_confluence",
         "vol_momentum", "regime_adaptive", "regime_adaptive_htf",
         "hold",
     ],
@@ -1306,7 +1322,7 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "sweep_squeeze_combo", "adx_trend", "delta_neutral_funding",
         "funding_skew", "donchian_breakout", "session_breakout", "bear_pullback_st",
         "vwap_rejection_st", "momentum_pro", "mean_reversion_pro",
-        "consolidation_range", "mtf_confluence", "vol_momentum",
+        "consolidation_range", "atr_band_revert", "mtf_confluence", "vol_momentum",
         "regime_adaptive", "regime_adaptive_htf", "hold",
     ],
 }

--- a/shared_strategies/open/test_atr_band_revert.py
+++ b/shared_strategies/open/test_atr_band_revert.py
@@ -1,0 +1,87 @@
+"""Tests for the atr_band_revert open strategy — ATR-band mean reversion.
+
+Entry-only core: long when close sinks to/below ``mid - k_entry*ATR``, short
+(when ``allow_short``) when close stretches to/above ``mid + k_entry*ATR``.
+Exit (TP at mid / opposite band / split) is owned by the close+stop machinery
+and is config, not code — see the module docstring.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from atr_band_revert import atr_band_revert_core
+
+
+def _box(n=60, level=100.0, top=101.0, bottom=99.0):
+    """A flat range around ``level`` so mid≈level and ATR is stable."""
+    idx = pd.date_range("2024-01-01", periods=n, freq="1h")
+    c = np.full(n, level)
+    return pd.DataFrame(
+        {"open": c, "high": np.full(n, top), "low": np.full(n, bottom),
+         "close": c, "volume": [1.0] * n},
+        index=idx,
+    )
+
+
+def test_columns_exposed():
+    r = atr_band_revert_core(_box())
+    for col in ("signal", "atr", "band_mid", "band_lower", "band_upper"):
+        assert col in r.columns
+
+
+def test_long_entry_below_lower_band():
+    df = _box()
+    # Drive the last close well beneath the lower band.
+    df.iloc[-1, df.columns.get_loc("close")] = 90.0
+    df.iloc[-1, df.columns.get_loc("low")] = 89.5
+    r = atr_band_revert_core(df, period=20, atr_period=14, k_entry=1.5)
+    assert r["signal"].iloc[-1] == 1
+
+
+def test_short_entry_above_upper_band_when_allowed():
+    df = _box()
+    df.iloc[-1, df.columns.get_loc("close")] = 110.0
+    df.iloc[-1, df.columns.get_loc("high")] = 110.5
+    r = atr_band_revert_core(df, period=20, atr_period=14, k_entry=1.5, allow_short=True)
+    assert r["signal"].iloc[-1] == -1
+
+
+def test_short_suppressed_when_allow_short_false():
+    df = _box()
+    df.iloc[-1, df.columns.get_loc("close")] = 110.0
+    df.iloc[-1, df.columns.get_loc("high")] = 110.5
+    r = atr_band_revert_core(df, period=20, atr_period=14, k_entry=1.5, allow_short=False)
+    assert r["signal"].iloc[-1] == 0
+
+
+def test_hold_inside_bands():
+    # Flat box: every close sits at mid, never reaching a band.
+    r = atr_band_revert_core(_box(), period=20, atr_period=14, k_entry=1.5, allow_short=True)
+    assert r["signal"].iloc[-1] == 0
+
+
+def test_no_signal_during_warmup():
+    # Before the SMA/ATR windows fill, bands are NaN -> no spurious entries.
+    r = atr_band_revert_core(_box(), period=20, atr_period=14)
+    warm = r.iloc[:19]
+    assert (warm["signal"] == 0).all()
+
+
+def test_long_invariant_holds_everywhere():
+    # Property: any bar at/below the lower band is a long; any non-band bar is flat.
+    rng = np.random.RandomState(7)
+    n = 200
+    closes = 100.0 + np.cumsum(rng.randn(n) * 0.5)
+    idx = pd.date_range("2024-01-01", periods=n, freq="1h")
+    df = pd.DataFrame({"open": closes, "high": closes + 1.0, "low": closes - 1.0,
+                       "close": closes, "volume": [1.0] * n}, index=idx)
+    r = atr_band_revert_core(df, period=20, atr_period=14, k_entry=1.5, allow_short=False)
+    valid = r["band_lower"].notna()
+    below = valid & (r["close"] <= r["band_lower"])
+    assert (r.loc[below, "signal"] == 1).all()
+    assert (r.loc[valid & (r["close"] > r["band_lower"]), "signal"] == 0).all()


### PR DESCRIPTION
Closes #1070

## What

Adds `atr_band_revert` — an ATR-band mean-reversion open strategy for ranging markets — and defaults it to the composite (7-state) ranging regime.

**Strategy.** Fades ATR-scaled bands around a simple moving average: long when `close ≤ mid − k·ATR`, short when `close ≥ mid + k·ATR` (futures/perps via the `allow_short` variant). Entries only, exactly like `consolidation_range`. The exit is configuration, not new code — at entry `mid ≈ entry + k·ATR`, so the take-profit targets map onto existing close evaluators:

- **TP at mid** → a `tiered_tp_atr` tier at `atr_multiple ≈ k_entry`.
- **Opposite band** → open-as-close (the entry signal flips at the far band).
- **Split** → a two-tier `tiered_tp_atr`.
- **Range-break stop** → `stop_loss_atr_mult`.

**7-state default.** When selected via `init`, `generateConfig` emits the strategy pre-gated: `allowed_regimes = [ranging_quiet, ranging_volatile]` plus a global composite `medium` regime window. Applied uniformly over `Args[0]` across spot/perps/futures (never options, where `allowed_regimes` is rejected). `ranging_directional` is intentionally excluded — the substate most likely to break into a trend.

## Touchpoints

- `shared_strategies/open/atr_band_revert.py` (new) + open registry (both platforms, futures `allow_short` variant).
- `scheduler/init.go` — short name `abr`, bidirectional-perps set, discovery-fallback lists, and the composite-ranging-gate default wiring.
- `backtest/optimizer.py` — `DEFAULT_PARAM_RANGES` (period / atr_period / k_entry).
- `backtest/fee_audit.py` — Go↔Python bidirectional-set parity mirror.

## Test plan

- New strategy unit tests (`test_atr_band_revert.py`) + Go init tests (`init_atr_band_revert_test.go`): spot + perps gate, composite window emitted, full `validateConfig` passes; a negative test pins regime **off** when the strategy isn't selected.
- Full Go suite + full Python suite (1677) green; gofmt clean.
- End-to-end backtest gated to composite `ranging_quiet`+`ranging_volatile`: 117 trades vs 516 ungated, best bare return of the three gate variants.

## Notes

`atr_band_revert` ships as a tunable, regime-gated baseline — like `consolidation_range`, it loses bare at default params (mean reversion's range-break failure mode); the regime gate and ATR stop are what make it viable, and `k_entry` / regime labels want per-market tuning before live use.

Surfaced (not fixed here) a pre-existing, orthogonal gap — #1067: `init`-generated configs omit `open_strategy.name`, so `run_backtest.py --config` rejects them (affects all strategies; CLI `--strategy` backtests are unaffected).

---
LLM: Opus 4.8 | high | Harness: Claude Code

https://claude.ai/code/session_012aQdrU6dFr7rc4MZjEtxiJ
