### PR TITLE
feat(#1065): regime-accuracy measurement harness + label-anchored HMM (PR1)

### DIFF
--- a/backtest/regime_calibrate.py
+++ b/backtest/regime_calibrate.py
@@ -9,20 +9,38 @@ for _p in (_THIS_DIR, os.path.abspath(os.path.join(_THIS_DIR, "..")),
 
 SEPARATION_TOLERANCE = 0.05   # model KW-H may dip at most 5% below the hand-rule
 STABILITY_MIN_GAIN = 0.02     # transition-rate must drop by >= this (absolute)
+SIGNIFICANCE_ALPHA = 0.05     # block-shuffle permutation p ceiling for "real" separation
 
 
 def gate_verdict(handrule_report: dict, model_report: dict, primary: str = "h4") -> dict:
     hr_h = handrule_report[primary]["separation"]["kruskal_h"]
     md_h = model_report[primary]["separation"]["kruskal_h"]
+    hr_p = handrule_report[primary]["significance"]["p_value"]
+    md_p = model_report[primary]["significance"]["p_value"]
     hr_tr = handrule_report["stability"]["transition_rate"]
     md_tr = model_report["stability"]["transition_rate"]
-    separation_ok = md_h >= hr_h * (1.0 - SEPARATION_TOLERANCE)
+    # Absolute floor: the relative KW-H tolerance is meaningless when the incumbent itself
+    # separates ~nothing (threshold collapses toward 0, and any model — including a
+    # near-constant-label one that also maximizes the stability arm — passes). So require
+    # the model's OWN forward-return separation to be statistically real (block-shuffle
+    # permutation p <= alpha), not merely "not much worse than a weak incumbent".
+    model_separation_real = md_p <= SIGNIFICANCE_ALPHA
+    # Abstain when the incumbent shows no significant separation on this window: there is
+    # no trustworthy baseline to validate a live-classifier replacement against, so we must
+    # not ship off it regardless of how the model scores.
+    incumbent_trustworthy = hr_p <= SIGNIFICANCE_ALPHA
+    separation_ok = (md_h >= hr_h * (1.0 - SEPARATION_TOLERANCE)) and model_separation_real
     stability_ok = (hr_tr - md_tr) >= STABILITY_MIN_GAIN
+    ship = separation_ok and stability_ok and incumbent_trustworthy
     return {
         "separation_ok": bool(separation_ok),
         "stability_ok": bool(stability_ok),
-        "ship": bool(separation_ok and stability_ok),
+        "model_separation_real": bool(model_separation_real),
+        "incumbent_trustworthy": bool(incumbent_trustworthy),
+        "abstained": bool(not incumbent_trustworthy),
+        "ship": bool(ship),
         "detail": {"handrule_kruskal_h": hr_h, "model_kruskal_h": md_h,
+                   "handrule_p_value": hr_p, "model_p_value": md_p,
                    "handrule_transition_rate": hr_tr, "model_transition_rate": md_tr},
     }
 

--- a/backtest/regime_calibrate.py
+++ b/backtest/regime_calibrate.py
@@ -1,0 +1,88 @@
+"""Fit + walk-forward validate the label-anchored regime HMM (#1065 PR1)."""
+from __future__ import annotations
+import os, sys
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+for _p in (_THIS_DIR, os.path.abspath(os.path.join(_THIS_DIR, "..")),
+           os.path.abspath(os.path.join(_THIS_DIR, "..", "shared_tools"))):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+SEPARATION_TOLERANCE = 0.05   # model KW-H may dip at most 5% below the hand-rule
+STABILITY_MIN_GAIN = 0.02     # transition-rate must drop by >= this (absolute)
+
+
+def gate_verdict(handrule_report: dict, model_report: dict, primary: str = "h4") -> dict:
+    hr_h = handrule_report[primary]["separation"]["kruskal_h"]
+    md_h = model_report[primary]["separation"]["kruskal_h"]
+    hr_tr = handrule_report["stability"]["transition_rate"]
+    md_tr = model_report["stability"]["transition_rate"]
+    separation_ok = md_h >= hr_h * (1.0 - SEPARATION_TOLERANCE)
+    stability_ok = (hr_tr - md_tr) >= STABILITY_MIN_GAIN
+    return {
+        "separation_ok": bool(separation_ok),
+        "stability_ok": bool(stability_ok),
+        "ship": bool(separation_ok and stability_ok),
+        "detail": {"handrule_kruskal_h": hr_h, "model_kruskal_h": md_h,
+                   "handrule_transition_rate": hr_tr, "model_transition_rate": md_tr},
+    }
+
+
+def fit_on_window(symbol, timeframe, window, *, period=48, filter_window=64):
+    from regime import (compute_regime_composite, composite_feature_matrix,
+                        VALID_LABELS_COMPOSITE, _DEFAULT_COMPOSITE_THRESHOLDS)
+    from regime_hmm import fit_label_anchored_hmm
+    from data_fetcher import load_cached_data
+    from eval_windows import WINDOWS, PLATFORM
+    start, end = WINDOWS[window]
+    df = load_cached_data(symbol, timeframe, exchange_id=PLATFORM, start_date=start, end_date=end)
+    th = dict(_DEFAULT_COMPOSITE_THRESHOLDS)
+    feats = composite_feature_matrix(df, period, th).to_numpy()
+    labels = compute_regime_composite(df, period=period, thresholds=th)["regime"].to_numpy()
+    states = sorted(VALID_LABELS_COMPOSITE)
+    model = fit_label_anchored_hmm(feats, labels, states, filter_window=filter_window,
+                                   fitted_on={"symbol": symbol, "timeframe": timeframe, "window": window})
+    model["period"] = period
+    return model
+
+
+def build_parser():
+    import argparse
+    from eval_windows import WINDOWS
+    p = argparse.ArgumentParser(description="Fit + validate the regime HMM (#1065)")
+    p.add_argument("--symbol", default="BTC/USDT")
+    p.add_argument("--timeframe", default="1h")
+    p.add_argument("--in-sample", default="is", help=f"known: {', '.join(WINDOWS)}")
+    p.add_argument("--held-out", default="oos")
+    p.add_argument("--period", type=int, default=48)
+    p.add_argument("--filter-window", type=int, default=64)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--out", default=None, help="write fitted model JSON here")
+    p.add_argument("--json", default=None, help="write validation report JSON here")
+    return p
+
+
+def main(argv=None) -> int:
+    import json
+    from regime_diagnostics import run_window
+    args = build_parser().parse_args(argv)
+    model = fit_on_window(args.symbol, args.timeframe, args.in_sample,
+                          period=args.period, filter_window=args.filter_window)
+    if args.out:
+        with open(args.out, "w") as fh:
+            json.dump({"model": model}, fh, indent=2, default=float)
+    hr = run_window(args.symbol, args.timeframe, args.held_out, model=None, seed=args.seed)
+    md = run_window(args.symbol, args.timeframe, args.held_out, model=model, seed=args.seed)
+    verdict = gate_verdict(hr, md)
+    payload = {"symbol": args.symbol, "timeframe": args.timeframe,
+               "in_sample": args.in_sample, "held_out": args.held_out,
+               "verdict": verdict, "handrule": hr, "model": md}
+    text = json.dumps(payload, indent=2, default=float)
+    if args.json:
+        with open(args.json, "w") as fh:
+            fh.write(text)
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backtest/regime_diagnostics.py
+++ b/backtest/regime_diagnostics.py
@@ -1,5 +1,5 @@
-from __future__ import annotations
 """7-state regime quality diagnostics (#1065 PR1). Pure scorers; CLI at bottom."""
+from __future__ import annotations
 import os, sys
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 if _THIS_DIR not in sys.path:

--- a/backtest/regime_diagnostics.py
+++ b/backtest/regime_diagnostics.py
@@ -1,5 +1,14 @@
-"""7-state regime quality diagnostics (#1065 PR1). Pure scorers; CLI at bottom."""
 from __future__ import annotations
+"""7-state regime quality diagnostics (#1065 PR1). Pure scorers; CLI at bottom."""
+import os, sys
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+_ROOT = os.path.abspath(os.path.join(_THIS_DIR, ".."))
+for _p in (_ROOT, os.path.join(_ROOT, "shared_tools")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
 import numpy as np
 from regime_stats import kruskal_h, benjamini_hochberg  # noqa: F401 (BH used in Task 7)
 
@@ -114,3 +123,85 @@ def kmeans_yardstick(features, fwd, k_range=(2, 3, 4, 5, 6, 7), seed=0) -> dict:
         groups = [fr[cl == j] for j in range(k) if (cl == j).any()]
         out[k] = {"kruskal_h": kruskal_h(groups)}
     return out
+
+
+def score_labels(close, labels, features, horizons=(1, 4, 12), block_mult=3, seed=0) -> dict:
+    labels = np.asarray(labels, dtype=object)
+    features = np.asarray(features, dtype=float)
+    st = stability(labels)
+    mean_dwell = float(np.mean(list(st["mean_dwell"].values()))) if st["mean_dwell"] else 1.0
+    out = {"coverage": coverage(labels), "stability": st, "horizons": {}}
+    for h in horizons:
+        fwd = forward_returns(close, h)
+        block_len = max(int(block_mult * mean_dwell), h)
+        out["horizons"][f"h{h}"] = {
+            "separation": separation(labels, fwd),
+            "significance": block_shuffle_pvalue(labels, fwd, block_len, seed=seed),
+            "yardstick": kmeans_yardstick(features, fwd, seed=seed),
+        }
+    # flat aliases for the pre-registered primary (h=4)
+    if "h4" in out["horizons"]:
+        out["h4"] = out["horizons"]["h4"]
+    return out
+
+
+def run_window(symbol, timeframe, window, *, model=None, horizons=(1, 4, 12), seed=0) -> dict:
+    from regime import compute_regime_composite, composite_feature_matrix, _DEFAULT_COMPOSITE_THRESHOLDS
+    from data_fetcher import load_cached_data
+    from eval_windows import WINDOWS, PLATFORM
+    start, end = WINDOWS[window]
+    df = load_cached_data(symbol, timeframe, exchange_id=PLATFORM, start_date=start, end_date=end)
+    period = int(model["period"]) if model and "period" in model else 48
+    th = dict(_DEFAULT_COMPOSITE_THRESHOLDS)
+    feats_df = composite_feature_matrix(df, period, th)
+    features = feats_df.to_numpy()
+    if model is None:
+        labels = compute_regime_composite(df, period=period, thresholds=th)["regime"].to_numpy()
+    else:
+        from regime_hmm import forward_filter_labels
+        labels, _conf = forward_filter_labels(features, model)
+    return score_labels(df["close"].to_numpy(), labels, features, horizons=horizons, seed=seed)
+
+
+def build_parser() -> "argparse.ArgumentParser":
+    import argparse
+    from eval_windows import WINDOWS, DATASETS
+    p = argparse.ArgumentParser(description="7-state regime quality diagnostics (#1065)")
+    p.add_argument("--symbol", default="BTC/USDT")
+    p.add_argument("--timeframe", default="1h")
+    p.add_argument("--windows", default="is,oos", help=f"known: {', '.join(WINDOWS)}")
+    p.add_argument("--model-json", default=None, help="score a fitted model instead of the hand-rule")
+    p.add_argument("--horizons", default="1,4,12")
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--json", default=None, help="write report JSON to this path")
+    return p
+
+
+def main(argv=None) -> int:
+    import argparse, json
+    args = build_parser().parse_args(argv)
+    from eval_windows import WINDOWS
+    model = None
+    if args.model_json:
+        with open(args.model_json) as fh:
+            loaded = json.load(fh)
+        model = loaded.get("model", loaded) if isinstance(loaded, dict) else loaded
+    horizons = tuple(int(x) for x in args.horizons.split(","))
+    report = {}
+    for w in args.windows.split(","):
+        if w not in WINDOWS:
+            raise SystemExit(f"unknown window {w}; known: {list(WINDOWS)}")
+        report[w] = run_window(args.symbol, args.timeframe, w, model=model,
+                               horizons=horizons, seed=args.seed)
+    payload = {"symbol": args.symbol, "timeframe": args.timeframe,
+               "source": "model" if model else "hand_rule", "windows": report}
+    text = json.dumps(payload, indent=2, default=float)
+    if args.json:
+        with open(args.json, "w") as fh:
+            fh.write(text)
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backtest/regime_diagnostics.py
+++ b/backtest/regime_diagnostics.py
@@ -10,7 +10,7 @@ for _p in (_ROOT, os.path.join(_ROOT, "shared_tools")):
         sys.path.insert(0, _p)
 
 import numpy as np
-from regime_stats import kruskal_h, benjamini_hochberg  # noqa: F401 (BH used in Task 7)
+from regime_stats import kruskal_h, benjamini_hochberg
 
 
 def forward_returns(close: np.ndarray, horizon: int) -> np.ndarray:
@@ -83,12 +83,64 @@ def block_shuffle_pvalue(labels, fwd, block_len, n_perm=200, seed=0) -> dict:
     ge = 0
     for _ in range(n_perm):
         perm = rng.permutation(len(starts))
-        shuffled = np.concatenate([labels[s : s + block_len] for s in (starts[i] for i in perm)])
+        shuffled = np.concatenate([labels[b : b + block_len] for b in (starts[i] for i in perm)])
         shuffled = shuffled[:n]
         if separation(shuffled, fwd)["kruskal_h"] >= h_obs:
             ge += 1
     return {"kruskal_h": float(h_obs), "p_value": float((ge + 1) / (n_perm + 1)),
             "block_len": block_len, "n_perm": int(n_perm)}
+
+
+def per_state_significance(labels, fwd, block_len, n_perm=200, seed=0) -> dict:
+    """Per-state forward-return significance with Benjamini-Hochberg FDR correction.
+
+    Returns {state: {"gap": float, "p_value": float, "fdr_reject": bool}}.
+    States with no in-group or no out-group bars are skipped.
+    """
+    labels = np.asarray(labels, dtype=object)
+    fwd = np.asarray(fwd, dtype=float)
+    valid = ~np.isnan(fwd)
+    labels, fwd = labels[valid], fwd[valid]
+    states = sorted(set(labels.tolist()))
+
+    gap_obs: dict[str, float] = {}
+    for s in states:
+        in_group = fwd[labels == s]
+        out_group = fwd[labels != s]
+        if len(in_group) == 0 or len(out_group) == 0:
+            continue
+        gap_obs[s] = float(in_group.mean() - out_group.mean())
+
+    if not gap_obs:
+        return {}
+
+    active_states = sorted(gap_obs.keys())
+    ge: dict[str, int] = {s: 0 for s in active_states}
+
+    n = len(labels)
+    block_len = max(1, int(block_len))
+    starts = list(range(0, n, block_len))
+    rng = np.random.default_rng(seed)
+
+    for _ in range(n_perm):
+        perm = rng.permutation(len(starts))
+        shuffled = np.concatenate([labels[b : b + block_len] for b in (starts[i] for i in perm)])
+        shuffled = shuffled[:n]
+        for s in active_states:
+            in_perm = fwd[shuffled == s]
+            out_perm = fwd[shuffled != s]
+            if len(in_perm) == 0 or len(out_perm) == 0:
+                continue
+            gap_perm = float(in_perm.mean() - out_perm.mean())
+            if abs(gap_perm) >= abs(gap_obs[s]):
+                ge[s] += 1
+
+    p_vals = {s: float((ge[s] + 1) / (n_perm + 1)) for s in active_states}
+    bh_results = benjamini_hochberg([p_vals[s] for s in active_states])
+    return {
+        s: {"gap": gap_obs[s], "p_value": p_vals[s], "fdr_reject": bool(reject)}
+        for s, reject in zip(active_states, bh_results)
+    }
 
 
 def _kmeans(z, k, seed, iters=50):
@@ -128,16 +180,25 @@ def kmeans_yardstick(features, fwd, k_range=(2, 3, 4, 5, 6, 7), seed=0) -> dict:
 def score_labels(close, labels, features, horizons=(1, 4, 12), block_mult=3, seed=0) -> dict:
     labels = np.asarray(labels, dtype=object)
     features = np.asarray(features, dtype=float)
-    st = stability(labels)
+    # Identical NaN-mask on both label streams: warmup + low-ATR bars (NaN feature rows)
+    # are excluded from coverage/stability/separation so neither the hand-rule's
+    # ranging_quiet nor the model's default_label for those bars biases the comparison.
+    valid = ~np.isnan(features).any(axis=1)
+    vlabels = labels[valid]
+    st = stability(vlabels)
     mean_dwell = float(np.mean(list(st["mean_dwell"].values()))) if st["mean_dwell"] else 1.0
-    out = {"coverage": coverage(labels), "stability": st, "horizons": {}}
+    out = {"coverage": coverage(vlabels), "stability": st, "horizons": {}}
     for h in horizons:
-        fwd = forward_returns(close, h)
+        # Forward returns computed on the FULL close (index-aligned); then subset by valid
+        # so each retained bar keeps its true h-ahead return.
+        fwd_full = forward_returns(close, h)
+        fwd = fwd_full[valid]
         block_len = max(int(block_mult * mean_dwell), h)
         out["horizons"][f"h{h}"] = {
-            "separation": separation(labels, fwd),
-            "significance": block_shuffle_pvalue(labels, fwd, block_len, seed=seed),
-            "yardstick": kmeans_yardstick(features, fwd, seed=seed),
+            "separation": separation(vlabels, fwd),
+            "significance": block_shuffle_pvalue(vlabels, fwd, block_len, seed=seed),
+            "yardstick": kmeans_yardstick(features, fwd_full, seed=seed),
+            "per_state_fdr": per_state_significance(vlabels, fwd, block_len, seed=seed),
         }
     # flat aliases for the pre-registered primary (h=4)
     if "h4" in out["horizons"]:
@@ -165,7 +226,7 @@ def run_window(symbol, timeframe, window, *, model=None, horizons=(1, 4, 12), se
 
 def build_parser() -> "argparse.ArgumentParser":
     import argparse
-    from eval_windows import WINDOWS, DATASETS
+    from eval_windows import WINDOWS
     p = argparse.ArgumentParser(description="7-state regime quality diagnostics (#1065)")
     p.add_argument("--symbol", default="BTC/USDT")
     p.add_argument("--timeframe", default="1h")

--- a/backtest/regime_diagnostics.py
+++ b/backtest/regime_diagnostics.py
@@ -1,0 +1,63 @@
+"""7-state regime quality diagnostics (#1065 PR1). Pure scorers; CLI at bottom."""
+from __future__ import annotations
+import numpy as np
+from regime_stats import kruskal_h, benjamini_hochberg  # noqa: F401 (BH used in Task 7)
+
+
+def forward_returns(close: np.ndarray, horizon: int) -> np.ndarray:
+    close = np.asarray(close, dtype=float)
+    fwd = np.full(len(close), np.nan)
+    if horizon < len(close):
+        fwd[:-horizon] = close[horizon:] / close[:-horizon] - 1.0
+    return fwd
+
+
+def coverage(labels: np.ndarray) -> dict:
+    labels = np.asarray(labels, dtype=object)
+    n = len(labels)
+    states, counts = np.unique(labels, return_counts=True)
+    return {str(s): {"count": int(c), "pct": float(c / n) if n else 0.0}
+            for s, c in zip(states, counts)}
+
+
+def separation(labels: np.ndarray, fwd: np.ndarray) -> dict:
+    labels = np.asarray(labels, dtype=object)
+    fwd = np.asarray(fwd, dtype=float)
+    valid = ~np.isnan(fwd)
+    labels, fwd = labels[valid], fwd[valid]
+    per_state, groups = {}, []
+    for s in sorted(set(labels.tolist())):
+        r = fwd[labels == s]
+        if len(r) == 0:
+            continue
+        groups.append(r)
+        per_state[str(s)] = {
+            "n": int(len(r)),
+            "mean": float(r.mean()),
+            "std": float(r.std()),
+            "hit_rate": float((r > 0).mean()),
+        }
+    return {"kruskal_h": kruskal_h(groups), "per_state": per_state}
+
+
+def stability(labels: np.ndarray) -> dict:
+    labels = np.asarray(labels, dtype=object)
+    n = len(labels)
+    if n < 2:
+        return {"transition_rate": 0.0, "flips": 0, "mean_dwell": {}}
+    changes = labels[1:] != labels[:-1]
+    flips = int(changes.sum())
+    runs: dict[str, list[int]] = {}
+    cur, length = labels[0], 1
+    for x in labels[1:]:
+        if x == cur:
+            length += 1
+        else:
+            runs.setdefault(str(cur), []).append(length)
+            cur, length = x, 1
+    runs.setdefault(str(cur), []).append(length)
+    return {
+        "transition_rate": float(flips / (n - 1)),
+        "flips": flips,
+        "mean_dwell": {s: float(np.mean(v)) for s, v in sorted(runs.items())},
+    }

--- a/backtest/regime_diagnostics.py
+++ b/backtest/regime_diagnostics.py
@@ -61,3 +61,56 @@ def stability(labels: np.ndarray) -> dict:
         "flips": flips,
         "mean_dwell": {s: float(np.mean(v)) for s, v in sorted(runs.items())},
     }
+
+
+def block_shuffle_pvalue(labels, fwd, block_len, n_perm=200, seed=0) -> dict:
+    labels = np.asarray(labels, dtype=object)
+    fwd = np.asarray(fwd, dtype=float)
+    h_obs = separation(labels, fwd)["kruskal_h"]
+    n = len(labels)
+    block_len = max(1, int(block_len))
+    starts = list(range(0, n, block_len))
+    rng = np.random.default_rng(seed)
+    ge = 0
+    for _ in range(n_perm):
+        perm = rng.permutation(len(starts))
+        shuffled = np.concatenate([labels[s : s + block_len] for s in (starts[i] for i in perm)])
+        shuffled = shuffled[:n]
+        if separation(shuffled, fwd)["kruskal_h"] >= h_obs:
+            ge += 1
+    return {"kruskal_h": float(h_obs), "p_value": float((ge + 1) / (n_perm + 1)),
+            "block_len": block_len, "n_perm": int(n_perm)}
+
+
+def _kmeans(z, k, seed, iters=50):
+    rng = np.random.default_rng(seed)
+    centers = z[rng.choice(len(z), size=k, replace=False)]
+    labels = np.zeros(len(z), dtype=int)
+    for _ in range(iters):
+        d = ((z[:, None, :] - centers[None, :, :]) ** 2).sum(-1)
+        new = d.argmin(1)
+        if np.array_equal(new, labels):
+            break
+        labels = new
+        for j in range(k):
+            if (labels == j).any():
+                centers[j] = z[labels == j].mean(0)
+    return labels
+
+
+def kmeans_yardstick(features, fwd, k_range=(2, 3, 4, 5, 6, 7), seed=0) -> dict:
+    features = np.asarray(features, dtype=float)
+    fwd = np.asarray(fwd, dtype=float)
+    mask = ~np.isnan(features).any(1) & ~np.isnan(fwd)
+    x, fr = features[mask], fwd[mask]
+    mean, std = x.mean(0), x.std(0)
+    std[std < 1e-8] = 1.0
+    z = (x - mean) / std
+    out = {}
+    for k in k_range:
+        if k > len(z):
+            continue
+        cl = _kmeans(z, k, seed)
+        groups = [fr[cl == j] for j in range(k) if (cl == j).any()]
+        out[k] = {"kruskal_h": kruskal_h(groups)}
+    return out

--- a/backtest/regime_hmm.py
+++ b/backtest/regime_hmm.py
@@ -39,6 +39,9 @@ def fit_label_anchored_hmm(features, labels, states, *, filter_window,
     si = {s: i for i, s in enumerate(states)}
     k = len(states)
     A = np.full((k, k), float(laplace))
+    # Consecutive pairs counted on the NaN-dropped sequence: a mid-series NaN (low-ATR)
+    # bar produces a spurious adjacency between its pre- and post-NaN neighbours.
+    # Effect is small after Laplace smoothing; revisit when the fit is ported live in PR2.
     for a, b in zip(y[:-1], y[1:]):
         A[si[a], si[b]] += 1.0
     A = A / A.sum(1, keepdims=True)

--- a/backtest/regime_hmm.py
+++ b/backtest/regime_hmm.py
@@ -49,3 +49,47 @@ def fit_label_anchored_hmm(features, labels, states, *, filter_window,
         "transition": A.tolist(), "init": stationary_distribution(A).tolist(),
         "filter_window": int(filter_window), "fitted_on": fitted_on or {},
     }
+
+
+def _logsumexp(v: np.ndarray) -> float:
+    m = float(np.max(v))
+    return m + float(np.log(np.exp(v - m).sum()))
+
+
+def forward_filter_labels(features: np.ndarray, model: dict):
+    features = np.asarray(features, dtype=float)
+    n = len(features)
+    states = list(model["states"])
+    k = len(states)
+    mean = np.asarray(model["feature_means"], dtype=float)
+    std = np.asarray(model["feature_stds"], dtype=float)
+    em_mean = np.array([e["mean"] for e in model["emissions"]], dtype=float)
+    em_var = np.array([e["var"] for e in model["emissions"]], dtype=float)
+    log_init = np.log(np.asarray(model["init"], dtype=float) + 1e-300)
+    log_A = np.log(np.asarray(model["transition"], dtype=float) + 1e-300)
+    w = int(model["filter_window"])
+    default_label = states[int(np.argmax(model["init"]))]
+
+    labels = np.array([default_label] * n, dtype=object)
+    conf = np.zeros(n, dtype=float)
+    for i in range(n):
+        lo = max(0, i - w + 1)
+        alpha = log_init.copy()
+        seen = False
+        for t in range(lo, i + 1):
+            x = features[t]
+            # predict: alpha'_j = logsumexp_i(alpha_i + log_A[i,j])
+            pred = np.array([_logsumexp(alpha + log_A[:, j]) for j in range(k)])
+            if np.isnan(x).any():
+                alpha = pred  # carry: transition only, no emission
+                continue
+            z = (x - mean) / std
+            log_emit = -0.5 * (np.log(2 * np.pi * em_var) + (z - em_mean) ** 2 / em_var).sum(1)
+            alpha = pred + log_emit
+            alpha -= _logsumexp(alpha)  # normalize
+            seen = True
+        if seen:
+            j = int(np.argmax(alpha))
+            labels[i] = states[j]
+            conf[i] = float(np.exp(alpha[j] - _logsumexp(alpha)))
+    return labels, conf

--- a/backtest/regime_hmm.py
+++ b/backtest/regime_hmm.py
@@ -1,0 +1,51 @@
+# backtest/regime_hmm.py
+"""Label-anchored Gaussian HMM: closed-form fit + causal forward-filter (#1065)."""
+from __future__ import annotations
+import numpy as np
+
+MODEL_TYPE = "label_anchored_hmm"
+MODEL_VERSION = 1
+FEATURES = ["return_eff", "range_eff", "efficiency", "adx"]
+
+
+def stationary_distribution(transition: np.ndarray) -> np.ndarray:
+    A = np.asarray(transition, dtype=float)
+    vals, vecs = np.linalg.eig(A.T)
+    i = int(np.argmin(np.abs(vals - 1.0)))
+    v = np.abs(np.real(vecs[:, i]))
+    s = v.sum()
+    return v / s if s > 0 else np.full(len(A), 1.0 / len(A))
+
+
+def fit_label_anchored_hmm(features, labels, states, *, filter_window,
+                           var_floor=1e-3, laplace=1.0, fitted_on=None) -> dict:
+    features = np.asarray(features, dtype=float)
+    labels = np.asarray(labels, dtype=object)
+    mask = ~np.isnan(features).any(1)
+    x, y = features[mask], labels[mask]
+    mean = x.mean(0) if len(x) else np.zeros(features.shape[1])
+    std = x.std(0) if len(x) else np.ones(features.shape[1])
+    std = np.where(std < 1e-8, 1.0, std)
+    z = (x - mean) / std
+    emissions = []
+    for s in states:
+        zs = z[y == s]
+        if len(zs) >= 2:
+            em_mean, em_var = zs.mean(0), zs.var(0)
+        else:  # degenerate: anchor at standardized origin, unit variance (flagged by n)
+            em_mean, em_var = np.zeros(z.shape[1]), np.ones(z.shape[1])
+        em_var = np.maximum(em_var, var_floor)
+        emissions.append({"mean": em_mean.tolist(), "var": em_var.tolist(), "n": int(len(zs))})
+    si = {s: i for i, s in enumerate(states)}
+    k = len(states)
+    A = np.full((k, k), float(laplace))
+    for a, b in zip(y[:-1], y[1:]):
+        A[si[a], si[b]] += 1.0
+    A = A / A.sum(1, keepdims=True)
+    return {
+        "type": MODEL_TYPE, "version": MODEL_VERSION, "features": list(FEATURES),
+        "feature_means": mean.tolist(), "feature_stds": std.tolist(),
+        "states": list(states), "emissions": emissions,
+        "transition": A.tolist(), "init": stationary_distribution(A).tolist(),
+        "filter_window": int(filter_window), "fitted_on": fitted_on or {},
+    }

--- a/backtest/regime_stats.py
+++ b/backtest/regime_stats.py
@@ -1,0 +1,54 @@
+"""Dependency-free statistics for regime diagnostics (#1065). numpy only."""
+from __future__ import annotations
+import numpy as np
+
+
+def rank_data(x: np.ndarray) -> np.ndarray:
+    x = np.asarray(x, dtype=float)
+    n = len(x)
+    ranks = np.empty(n, dtype=float)
+    order = np.argsort(x, kind="mergesort")
+    sx = x[order]
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and sx[j + 1] == sx[i]:
+            j += 1
+        ranks[order[i : j + 1]] = (i + j) / 2.0 + 1.0  # 1-based average rank
+        i = j + 1
+    return ranks
+
+
+def kruskal_h(groups: list[np.ndarray]) -> float:
+    gs = [np.asarray(g, dtype=float) for g in groups if len(g) > 0]
+    if len(gs) < 2:
+        return 0.0
+    allx = np.concatenate(gs)
+    n = len(allx)
+    if n < 2:
+        return 0.0
+    ranks = rank_data(allx)
+    h = 0.0
+    idx = 0
+    for g in gs:
+        r = ranks[idx : idx + len(g)]
+        idx += len(g)
+        h += (r.sum() ** 2) / len(g)
+    h = 12.0 / (n * (n + 1)) * h - 3.0 * (n + 1)
+    _, counts = np.unique(allx, return_counts=True)
+    ties = float((counts ** 3 - counts).sum())
+    c = 1.0 - ties / (n ** 3 - n) if n > 1 else 1.0
+    return float(h / c) if c > 0 else float(h)
+
+
+def benjamini_hochberg(pvals: list[float], alpha: float = 0.05) -> list[bool]:
+    p = np.asarray(pvals, dtype=float)
+    m = len(p)
+    if m == 0:
+        return []
+    order = np.argsort(p)
+    ranked = p[order]
+    thresh = (np.arange(1, m + 1) / m) * alpha
+    passed = ranked <= thresh
+    cut = ranked[np.max(np.where(passed)[0])] if passed.any() else -1.0
+    return (p <= cut).tolist()

--- a/backtest/tests/test_regime_calibrate.py
+++ b/backtest/tests/test_regime_calibrate.py
@@ -4,14 +4,17 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from regime_calibrate import gate_verdict
 
 
-def _report(kw_h, transition_rate):
+def _report(kw_h, transition_rate, p_value=0.005):
+    # p_value defaults to "significant" so existing separation/stability cases are
+    # exercised in isolation; cases that probe the significance floor set it explicitly.
     return {"stability": {"transition_rate": transition_rate},
-            "h4": {"separation": {"kruskal_h": kw_h}}}
+            "h4": {"separation": {"kruskal_h": kw_h},
+                   "significance": {"p_value": p_value}}}
 
 
 def test_gate_ships_when_stability_better_and_separation_kept():
     hr = _report(10.0, 0.40)
-    md = _report(9.6, 0.25)  # sep within 5% tolerance, whipsaw down
+    md = _report(9.6, 0.25)  # sep within 5% tolerance, whipsaw down, both significant
     v = gate_verdict(hr, md)
     assert v["ship"] is True and v["separation_ok"] and v["stability_ok"]
 
@@ -26,3 +29,50 @@ def test_gate_blocks_when_no_stability_gain():
     hr = _report(10.0, 0.40)
     md = _report(10.0, 0.42)  # whipsaw not improved
     assert gate_verdict(hr, md)["ship"] is False
+
+
+# --- absolute separation floor (bot review #1071) -------------------------------------
+
+def test_gate_blocks_useless_model_when_incumbent_also_useless():
+    # (a) hr_h ~ 0 and md_h ~ 0: relative tolerance passes (0.1 >= 0.1*0.95) but the model
+    # separates nothing (p high) -> must NOT ship, and must abstain on the weak incumbent.
+    hr = _report(0.1, 0.40, p_value=0.90)
+    md = _report(0.1, 0.05, p_value=0.95)
+    v = gate_verdict(hr, md)
+    assert v["ship"] is False
+    assert v["model_separation_real"] is False
+    assert v["abstained"] is True
+
+
+def test_gate_blocks_degenerate_constant_label_model():
+    # (b) degenerate constant-label model (transition_rate=0, kruskal_h=0) vs a weak
+    # incumbent: stability arm is maximally green, but separation is nil -> must NOT ship.
+    hr = _report(2.0, 0.40, p_value=0.20)   # incumbent not significant
+    md = _report(0.0, 0.0, p_value=1.0)     # constant label: no separation, no flips
+    v = gate_verdict(hr, md)
+    assert v["ship"] is False
+    assert v["stability_ok"] is True        # the trap: stability looks perfect
+    assert v["model_separation_real"] is False
+    assert v["abstained"] is True
+
+
+def test_gate_ships_strong_incumbent_with_model_within_tolerance():
+    # (c) no regression: strong, significant incumbent and a model within tolerance and
+    # itself significant must still ship.
+    hr = _report(13.0, 0.40, p_value=0.005)
+    md = _report(12.4, 0.25, p_value=0.005)
+    v = gate_verdict(hr, md)
+    assert v["ship"] is True
+    assert v["abstained"] is False
+
+
+def test_gate_abstains_when_incumbent_not_significant():
+    # A strong, significant model cannot ship off a window where the incumbent baseline
+    # shows no significant separation — there is nothing trustworthy to validate against.
+    hr = _report(0.5, 0.40, p_value=0.30)   # incumbent separation not significant
+    md = _report(5.0, 0.20, p_value=0.01)   # model strong and significant
+    v = gate_verdict(hr, md)
+    assert v["model_separation_real"] is True
+    assert v["incumbent_trustworthy"] is False
+    assert v["abstained"] is True
+    assert v["ship"] is False

--- a/backtest/tests/test_regime_calibrate.py
+++ b/backtest/tests/test_regime_calibrate.py
@@ -1,0 +1,28 @@
+# backtest/tests/test_regime_calibrate.py
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from regime_calibrate import gate_verdict
+
+
+def _report(kw_h, transition_rate):
+    return {"stability": {"transition_rate": transition_rate},
+            "h4": {"separation": {"kruskal_h": kw_h}}}
+
+
+def test_gate_ships_when_stability_better_and_separation_kept():
+    hr = _report(10.0, 0.40)
+    md = _report(9.6, 0.25)  # sep within 5% tolerance, whipsaw down
+    v = gate_verdict(hr, md)
+    assert v["ship"] is True and v["separation_ok"] and v["stability_ok"]
+
+
+def test_gate_blocks_when_separation_collapses():
+    hr = _report(10.0, 0.40)
+    md = _report(4.0, 0.20)  # separation lost
+    assert gate_verdict(hr, md)["ship"] is False
+
+
+def test_gate_blocks_when_no_stability_gain():
+    hr = _report(10.0, 0.40)
+    md = _report(10.0, 0.42)  # whipsaw not improved
+    assert gate_verdict(hr, md)["ship"] is False

--- a/backtest/tests/test_regime_diagnostics.py
+++ b/backtest/tests/test_regime_diagnostics.py
@@ -31,3 +31,29 @@ def test_stability_transition_rate():
     st = stability(labels)
     assert abs(st["transition_rate"] - 0.5) < 1e-9  # 2 flips over 4 transitions
     assert st["flips"] == 2
+
+
+def test_block_shuffle_pvalue_separated_is_significant():
+    from regime_diagnostics import block_shuffle_pvalue
+    labels = np.array(["up"] * 60 + ["down"] * 60)
+    fwd = np.concatenate([np.full(60, 0.02), np.full(60, -0.02)])
+    out = block_shuffle_pvalue(labels, fwd, block_len=5, n_perm=100, seed=0)
+    assert out["p_value"] < 0.05 and out["kruskal_h"] > 5.0
+
+
+def test_block_shuffle_pvalue_noise_not_significant():
+    from regime_diagnostics import block_shuffle_pvalue
+    rng = np.random.default_rng(0)
+    labels = np.array(["a", "b"])[rng.integers(0, 2, 200)]
+    fwd = rng.normal(0, 0.01, 200)
+    out = block_shuffle_pvalue(labels, fwd, block_len=10, n_perm=100, seed=0)
+    assert out["p_value"] > 0.05
+
+
+def test_kmeans_yardstick_runs():
+    from regime_diagnostics import kmeans_yardstick
+    rng = np.random.default_rng(0)
+    feats = np.vstack([rng.normal(0, 1, (100, 4)), rng.normal(5, 1, (100, 4))])
+    fwd = np.concatenate([np.full(100, 0.02), np.full(100, -0.02)])
+    out = kmeans_yardstick(feats, fwd, k_range=(2, 3), seed=0)
+    assert out[2]["kruskal_h"] > 5.0

--- a/backtest/tests/test_regime_diagnostics.py
+++ b/backtest/tests/test_regime_diagnostics.py
@@ -69,3 +69,53 @@ def test_score_labels_bundle():
     assert "h4" in out and "kruskal_h" in out["h4"]["separation"]
     assert "coverage" in out and "stability" in out
     assert "p_value" in out["h4"]["significance"]
+
+
+def test_score_labels_masks_warmup():
+    """NaN feature rows are excluded: labeling them 'ranging_quiet' vs 'default_label' is irrelevant."""
+    from regime_diagnostics import score_labels
+    rng = np.random.default_rng(42)
+    n = 120
+    close = 100 * np.cumprod(1 + rng.normal(0, 0.005, n))
+    base_labels = np.array(
+        ["up" if r >= 0 else "down" for r in np.diff(close, prepend=close[0])], dtype=object
+    )
+    feats = rng.normal(0, 1, (n, 4))
+    feats[:10] = np.nan  # warmup bars have NaN features
+
+    labels_a = base_labels.copy()
+    labels_a[:10] = "ranging_quiet"
+    labels_b = base_labels.copy()
+    labels_b[:10] = "default_label"
+
+    out_a = score_labels(close, labels_a, feats, horizons=(4,), seed=0)
+    out_b = score_labels(close, labels_b, feats, horizons=(4,), seed=0)
+
+    # warmup-label variants must not appear in coverage
+    assert "ranging_quiet" not in out_a["coverage"]
+    assert "default_label" not in out_b["coverage"]
+    # scoring is identical regardless of which label the warmup bars carry
+    assert out_a["coverage"] == out_b["coverage"]
+    assert out_a["stability"] == out_b["stability"]
+    assert out_a["h4"]["significance"]["p_value"] == out_b["h4"]["significance"]["p_value"]
+
+
+def test_per_state_significance():
+    from regime_diagnostics import per_state_significance
+
+    # Clearly separated returns → both states should reject at FDR level
+    labels_sep = np.array(["up"] * 100 + ["down"] * 100)
+    fwd_sep = np.concatenate([np.full(100, 0.02), np.full(100, -0.02)])
+    result = per_state_significance(labels_sep, fwd_sep, block_len=5, n_perm=200, seed=0)
+    assert result["up"]["fdr_reject"] is True
+    assert result["down"]["fdr_reject"] is True
+    assert result["up"]["gap"] > 0  # up mean > global mean
+    assert result["down"]["gap"] < 0
+
+    # All-noise: random labels, random returns → few/no rejects expected
+    rng = np.random.default_rng(7)
+    labels_noise = np.array(["a", "b"])[rng.integers(0, 2, 300)]
+    fwd_noise = rng.normal(0, 0.01, 300)
+    result_noise = per_state_significance(labels_noise, fwd_noise, block_len=10, n_perm=200, seed=0)
+    n_reject = sum(1 for v in result_noise.values() if v["fdr_reject"])
+    assert n_reject <= 1  # at most 1 false positive under noise

--- a/backtest/tests/test_regime_diagnostics.py
+++ b/backtest/tests/test_regime_diagnostics.py
@@ -1,0 +1,33 @@
+# backtest/tests/test_regime_diagnostics.py
+import os, sys
+import numpy as np
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from regime_diagnostics import forward_returns, coverage, separation, stability
+
+
+def test_forward_returns_horizon():
+    close = np.array([100.0, 110, 121])
+    fr = forward_returns(close, 1)
+    np.testing.assert_allclose(fr[:2], [0.10, 0.10])
+    assert np.isnan(fr[-1])
+
+
+def test_coverage_counts():
+    labels = np.array(["a", "a", "b", "a"])
+    cov = coverage(labels)
+    assert cov["a"]["count"] == 3 and abs(cov["a"]["pct"] - 0.75) < 1e-9
+
+
+def test_separation_directional():
+    labels = np.array(["up"] * 50 + ["down"] * 50)
+    fwd = np.concatenate([np.full(50, 0.02), np.full(50, -0.02)])
+    sep = separation(labels, fwd)
+    assert sep["per_state"]["up"]["mean"] > 0 > sep["per_state"]["down"]["mean"]
+    assert sep["kruskal_h"] > 5.0
+
+
+def test_stability_transition_rate():
+    labels = np.array(["a", "a", "b", "b", "a"])
+    st = stability(labels)
+    assert abs(st["transition_rate"] - 0.5) < 1e-9  # 2 flips over 4 transitions
+    assert st["flips"] == 2

--- a/backtest/tests/test_regime_diagnostics.py
+++ b/backtest/tests/test_regime_diagnostics.py
@@ -57,3 +57,15 @@ def test_kmeans_yardstick_runs():
     fwd = np.concatenate([np.full(100, 0.02), np.full(100, -0.02)])
     out = kmeans_yardstick(feats, fwd, k_range=(2, 3), seed=0)
     assert out[2]["kruskal_h"] > 5.0
+
+
+def test_score_labels_bundle():
+    from regime_diagnostics import score_labels
+    rng = np.random.default_rng(0)
+    close = 100 * np.cumprod(1 + rng.normal(0, 0.005, 300))
+    labels = np.array(["up" if r >= 0 else "down" for r in np.diff(close, prepend=close[0])], dtype=object)
+    feats = rng.normal(0, 1, (300, 4))
+    out = score_labels(close, labels, feats, horizons=(1, 4), block_mult=3, seed=0)
+    assert "h4" in out and "kruskal_h" in out["h4"]["separation"]
+    assert "coverage" in out and "stability" in out
+    assert "p_value" in out["h4"]["significance"]

--- a/backtest/tests/test_regime_hmm.py
+++ b/backtest/tests/test_regime_hmm.py
@@ -33,3 +33,38 @@ def test_fit_drops_nan_rows():
     labels = np.array(["s0", "s0", "s1"], dtype=object)
     m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=2)
     assert m["emissions"][0]["n"] == 1  # the NaN s0 row was dropped
+
+
+def test_forward_filter_look_ahead_safe():
+    from regime_hmm import forward_filter_labels
+    rng = np.random.default_rng(0)
+    feats = np.vstack([rng.normal(0, 1, (60, 4)), rng.normal(4, 1, (60, 4))])
+    labels = np.array(["s0"] * 60 + ["s1"] * 60, dtype=object)
+    m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=8)
+    lab_a, _ = forward_filter_labels(feats, m)
+    perturbed = feats.copy()
+    perturbed[80:] += 100.0  # mutate the FUTURE relative to bar 70
+    lab_b, _ = forward_filter_labels(perturbed, m)
+    assert list(lab_a[:71]) == list(lab_b[:71])  # labels <=70 unchanged by future
+
+
+def test_forward_filter_recovers_regime():
+    from regime_hmm import forward_filter_labels
+    rng = np.random.default_rng(1)
+    feats = np.vstack([rng.normal(0, 1, (60, 4)), rng.normal(4, 1, (60, 4))])
+    labels = np.array(["s0"] * 60 + ["s1"] * 60, dtype=object)
+    m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=8)
+    lab, conf = forward_filter_labels(feats, m)
+    assert (lab[20:55] == "s0").mean() > 0.8 and (lab[80:115] == "s1").mean() > 0.8
+    assert (conf >= 0).all() and (conf <= 1.0 + 1e-9).all()
+
+
+def test_forward_filter_nan_carry():
+    from regime_hmm import forward_filter_labels
+    rng = np.random.default_rng(2)
+    feats = np.vstack([rng.normal(0, 1, (40, 4)), rng.normal(4, 1, (40, 4))])
+    labels = np.array(["s0"] * 40 + ["s1"] * 40, dtype=object)
+    m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=6)
+    feats[50] = np.nan  # a low-ATR bar inside the s1 stretch
+    lab, _ = forward_filter_labels(feats, m)
+    assert lab[50] in STATES  # no crash; carried, not undefined

--- a/backtest/tests/test_regime_hmm.py
+++ b/backtest/tests/test_regime_hmm.py
@@ -1,0 +1,35 @@
+# backtest/tests/test_regime_hmm.py
+import os, sys
+import numpy as np
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from regime_hmm import fit_label_anchored_hmm, stationary_distribution
+
+STATES = ["s0", "s1"]
+
+
+def test_stationary_distribution_sums_to_one():
+    A = np.array([[0.9, 0.1], [0.2, 0.8]])
+    pi = stationary_distribution(A)
+    assert abs(pi.sum() - 1.0) < 1e-9 and (pi > 0).all()
+    np.testing.assert_allclose(pi @ A, pi, atol=1e-9)  # stationary
+
+
+def test_fit_shapes_and_determinism():
+    rng = np.random.default_rng(0)
+    feats = np.vstack([rng.normal(0, 1, (80, 4)), rng.normal(4, 1, (80, 4))])
+    labels = np.array(["s0"] * 80 + ["s1"] * 80, dtype=object)
+    m1 = fit_label_anchored_hmm(feats, labels, STATES, filter_window=16)
+    m2 = fit_label_anchored_hmm(feats, labels, STATES, filter_window=16)
+    assert m1["states"] == STATES
+    assert len(m1["emissions"]) == 2
+    assert np.array(m1["transition"]).shape == (2, 2)
+    assert m1["emissions"][0]["mean"] == m2["emissions"][0]["mean"]  # deterministic
+    # standardized means: s0 cluster ~ negative, s1 ~ positive on each feature
+    assert m1["emissions"][0]["mean"][0] < m1["emissions"][1]["mean"][0]
+
+
+def test_fit_drops_nan_rows():
+    feats = np.array([[np.nan, np.nan, np.nan, np.nan], [0.0, 0, 0, 0], [1.0, 1, 1, 1]])
+    labels = np.array(["s0", "s0", "s1"], dtype=object)
+    m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=2)
+    assert m["emissions"][0]["n"] == 1  # the NaN s0 row was dropped

--- a/backtest/tests/test_regime_hmm.py
+++ b/backtest/tests/test_regime_hmm.py
@@ -38,14 +38,16 @@ def test_fit_drops_nan_rows():
 def test_forward_filter_look_ahead_safe():
     from regime_hmm import forward_filter_labels
     rng = np.random.default_rng(0)
+    # 120-bar series; filter_window=8; assert through bar k=70, mutate from k+1=71
+    # so even a +1 look-ahead from bar 70 would hit the mutated region.
     feats = np.vstack([rng.normal(0, 1, (60, 4)), rng.normal(4, 1, (60, 4))])
     labels = np.array(["s0"] * 60 + ["s1"] * 60, dtype=object)
     m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=8)
     lab_a, _ = forward_filter_labels(feats, m)
     perturbed = feats.copy()
-    perturbed[80:] += 100.0  # mutate the FUTURE relative to bar 70
+    perturbed[71:] += 100.0  # mutate from bar 71, immediately after the last asserted bar
     lab_b, _ = forward_filter_labels(perturbed, m)
-    assert list(lab_a[:71]) == list(lab_b[:71])  # labels <=70 unchanged by future
+    assert list(lab_a[:71]) == list(lab_b[:71])  # labels 0..70 unchanged by future
 
 
 def test_forward_filter_recovers_regime():

--- a/backtest/tests/test_regime_stats.py
+++ b/backtest/tests/test_regime_stats.py
@@ -1,0 +1,26 @@
+# backtest/tests/test_regime_stats.py
+import os, sys
+import numpy as np
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from regime_stats import rank_data, kruskal_h, benjamini_hochberg
+
+
+def test_rank_data_averages_ties():
+    # values [10, 20, 20, 40] -> ranks [1, 2.5, 2.5, 4]
+    np.testing.assert_allclose(rank_data(np.array([10, 20, 20, 40.0])), [1, 2.5, 2.5, 4])
+
+
+def test_kruskal_h_zero_when_identical():
+    g = np.array([1.0, 2, 3])
+    assert abs(kruskal_h([g, g.copy(), g.copy()])) < 1e-9
+
+
+def test_kruskal_h_large_when_separated():
+    a = np.array([1.0, 2, 3, 4]); b = np.array([100.0, 101, 102, 103])
+    assert kruskal_h([a, b]) > 5.0  # strongly separated -> large H
+
+
+def test_benjamini_hochberg_basic():
+    # one clearly significant, rest null
+    flags = benjamini_hochberg([0.001, 0.4, 0.6, 0.8], alpha=0.05)
+    assert flags == [True, False, False, False]

--- a/docs/superpowers/plans/2026-06-19-regime-accuracy-pr1-harness.md
+++ b/docs/superpowers/plans/2026-06-19-regime-accuracy-pr1-harness.md
@@ -1,0 +1,1106 @@
+# Regime Accuracy PR1 — Measurement Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the read-only measurement + calibration harness that quantifies 7-state regime quality (forward-return separation, stability, significance) and fits a label-anchored HMM offline — so we can decide, on data, whether the PR2 classifier change is worth building.
+
+**Architecture:** Pure numpy/pandas scorers and a closed-form label-anchored HMM live in `backtest/`, reusing the versioned `DATASETS`/`WINDOWS` and `load_cached_data` data path from the existing `eval_windows.py`/`exit_diagnostics.py` harness. One additive feature-extraction function is added to `shared_tools/regime.py` (no change to existing behavior) so offline features are byte-consistent with the live labeler. Two CLIs (`regime_diagnostics.py`, `regime_calibrate.py`) tie it together with `--json` output. No live code path, no Go changes, no parity risk — that is all PR2.
+
+**Tech Stack:** Python 3.12 (`uv run --no-sync python`), numpy 2.4 + pandas 3.0 only (no scipy/sklearn), pytest.
+
+## Global Constraints
+
+- **Dependencies:** numpy + pandas ONLY. No scipy, no sklearn, no new dependency. Significance comes from the block-shuffle permutation null (empirical p), not an analytic distribution. The unsupervised yardstick is numpy k-means.
+- **Pure aggregation:** every scorer/fit/filter function operates on numpy arrays / dicts and is unit-tested WITHOUT data access (same architecture as `exit_diagnostics.py`). Only the two CLI `main()`s touch `load_cached_data`.
+- **Determinism:** any randomness uses an explicit `numpy.random.default_rng(seed)` with a `--seed` flag (default `0`). No bare `np.random.*`.
+- **Read-only / no parity risk:** PR1 does not modify any existing function in `shared_tools/regime.py`, any live path, the backtester, or any Go file. The only `regime.py` change is ONE additive new function.
+- **Pre-registered gate:** the primary separation metric is **Kruskal–Wallis H at horizon h=4**; per-state stats are exploratory and Benjamini–Hochberg corrected.
+- **Commands run from repo root:** `uv run --no-sync python ...`; `uv run --no-sync python -m pytest ...`; `py_compile` after each Python file.
+- **Footer:** every commit message ends with `LLM: Opus 4.8 | high | Harness: subagent-driven-development` (or `executing-plans` if inline). No `Co-authored-by` trailer.
+
+---
+
+### Task 1: Additive per-bar feature matrix in `regime.py`
+
+Extract the per-bar composite feature tuple (`return_eff`, `range_eff`, `efficiency`, `adx`) the hand-rule consumes, as a new pure function — so the offline HMM fits on features byte-consistent with `map_composite_label`'s inputs. Additive only; `compute_regime_composite` is untouched.
+
+**Files:**
+- Modify: `shared_tools/regime.py` (append one function near `compute_regime_composite`, ~line 289)
+- Test: `shared_tools/test_regime_features.py` (create)
+
+**Interfaces:**
+- Consumes: existing `_composite_efficiency_metrics`, `compute_regime`, `standard_atr`, `COMPOSITE_ADX_PERIOD_CAP`, `_DEFAULT_COMPOSITE_THRESHOLDS`, `map_composite_label`.
+- Produces: `composite_feature_matrix(df: pd.DataFrame, period: int, thresholds: dict | None = None) -> pd.DataFrame` with columns `["return_eff", "range_eff", "efficiency", "adx"]`, same index as `df`, `NaN` rows for warmup (`i < period`) and `atr<=0` bars.
+
+- [ ] **Step 1: Write the failing test** — features fed back through `map_composite_label` must reproduce `compute_regime_composite`'s labels exactly (consistency), and warmup rows are NaN.
+
+```python
+# shared_tools/test_regime_features.py
+import numpy as np
+import pandas as pd
+from regime import (
+    composite_feature_matrix,
+    compute_regime_composite,
+    map_composite_label,
+    _DEFAULT_COMPOSITE_THRESHOLDS,
+)
+
+
+def _synth(n=300, seed=1):
+    rng = np.random.default_rng(seed)
+    steps = rng.normal(0, 1, n).cumsum()
+    close = 100 + steps
+    high = close + np.abs(rng.normal(0, 0.5, n))
+    low = close - np.abs(rng.normal(0, 0.5, n))
+    idx = pd.date_range("2024-01-01", periods=n, freq="1h")
+    return pd.DataFrame({"open": close, "high": high, "low": low, "close": close}, index=idx)
+
+
+def test_feature_matrix_reproduces_handrule_labels():
+    df = _synth()
+    period = 48
+    th = dict(_DEFAULT_COMPOSITE_THRESHOLDS)
+    feats = composite_feature_matrix(df, period, th)
+    labels = compute_regime_composite(df, period=period, thresholds=th)["regime"]
+    assert list(feats.columns) == ["return_eff", "range_eff", "efficiency", "adx"]
+    assert feats.iloc[:period].isna().all().all()  # warmup is NaN
+    for i in range(period, len(df)):
+        row = feats.iloc[i]
+        if row.isna().any():
+            continue  # atr<=0 bar: labeler leaves default, matrix is NaN — consistent
+        got = map_composite_label(row["return_eff"], row["adx"], row["range_eff"], row["efficiency"], th)
+        assert got == labels.iloc[i], f"bar {i}: {got} != {labels.iloc[i]}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest shared_tools/test_regime_features.py -v`
+Expected: FAIL — `ImportError: cannot import name 'composite_feature_matrix'`.
+
+- [ ] **Step 3: Write minimal implementation** — append to `shared_tools/regime.py` after `compute_regime_composite`.
+
+```python
+def composite_feature_matrix(
+    df: pd.DataFrame,
+    period: int,
+    thresholds: dict[str, float] | None = None,
+) -> pd.DataFrame:
+    """Per-bar composite feature tuple (return_eff, range_eff, efficiency, adx).
+
+    Additive, offline-only (#1065 PR1). Mirrors compute_regime_composite's loop
+    but emits the features map_composite_label consumes instead of the label, so
+    an offline model fits on byte-consistent inputs. Warmup (i < period) and
+    atr<=0 bars are NaN.
+    """
+    th = {**_DEFAULT_COMPOSITE_THRESHOLDS, **(thresholds or {})}
+    cols = ["return_eff", "range_eff", "efficiency", "adx"]
+    out = pd.DataFrame(float("nan"), index=df.index, columns=cols)
+    n = len(df)
+    if n == 0:
+        return out
+    adx_period = min(period, COMPOSITE_ADX_PERIOD_CAP)
+    adx_df = compute_regime(df, period=adx_period, adx_threshold=th["adx"])
+    atr_series = standard_atr(df, period=period)
+    for i in range(period, n):
+        window = df.iloc[i - period + 1 : i + 1]
+        atr_val = float(atr_series.iloc[i]) if i < len(atr_series) else 0.0
+        if not (atr_val > 0):
+            continue
+        eff = _composite_efficiency_metrics(window, atr_val, period)
+        out.iat[i, 0] = eff["return_eff"]
+        out.iat[i, 1] = eff["range_eff"]
+        out.iat[i, 2] = eff["efficiency"]
+        out.iat[i, 3] = float(adx_df["adx"].iloc[i])
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest shared_tools/test_regime_features.py -v`
+Expected: PASS. Then `uv run --no-sync python -m py_compile shared_tools/regime.py`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/richardkuo/Work/go-trader
+git add shared_tools/regime.py shared_tools/test_regime_features.py
+git commit -m "feat(#1065): composite_feature_matrix — additive per-bar feature extraction
+
+LLM: Opus 4.8 | high | Harness: subagent-driven-development"
+```
+
+---
+
+### Task 2: Pure stats primitives `backtest/regime_stats.py`
+
+Dependency-free numpy implementations of the statistics the diagnostic needs: average-rank, Kruskal–Wallis H (with tie correction), and Benjamini–Hochberg. No scipy.
+
+**Files:**
+- Create: `backtest/regime_stats.py`
+- Test: `backtest/tests/test_regime_stats.py`
+
+**Interfaces:**
+- Produces:
+  - `rank_data(x: np.ndarray) -> np.ndarray` — 1-based average ranks, ties averaged.
+  - `kruskal_h(groups: list[np.ndarray]) -> float` — tie-corrected H statistic (NOT a p-value; significance is permutation-based downstream).
+  - `benjamini_hochberg(pvals: list[float], alpha: float = 0.05) -> list[bool]` — per-test reject flags at FDR `alpha`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backtest/tests/test_regime_stats.py
+import os, sys
+import numpy as np
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from regime_stats import rank_data, kruskal_h, benjamini_hochberg
+
+
+def test_rank_data_averages_ties():
+    # values [10, 20, 20, 40] -> ranks [1, 2.5, 2.5, 4]
+    np.testing.assert_allclose(rank_data(np.array([10, 20, 20, 40.0])), [1, 2.5, 2.5, 4])
+
+
+def test_kruskal_h_zero_when_identical():
+    g = np.array([1.0, 2, 3])
+    assert abs(kruskal_h([g, g.copy(), g.copy()])) < 1e-9
+
+
+def test_kruskal_h_large_when_separated():
+    a = np.array([1.0, 2, 3, 4]); b = np.array([100.0, 101, 102, 103])
+    assert kruskal_h([a, b]) > 5.0  # strongly separated -> large H
+
+
+def test_benjamini_hochberg_basic():
+    # one clearly significant, rest null
+    flags = benjamini_hochberg([0.001, 0.4, 0.6, 0.8], alpha=0.05)
+    assert flags == [True, False, False, False]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest backtest/tests/test_regime_stats.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'regime_stats'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# backtest/regime_stats.py
+"""Dependency-free statistics for regime diagnostics (#1065). numpy only."""
+from __future__ import annotations
+import numpy as np
+
+
+def rank_data(x: np.ndarray) -> np.ndarray:
+    x = np.asarray(x, dtype=float)
+    n = len(x)
+    ranks = np.empty(n, dtype=float)
+    order = np.argsort(x, kind="mergesort")
+    sx = x[order]
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and sx[j + 1] == sx[i]:
+            j += 1
+        ranks[order[i : j + 1]] = (i + j) / 2.0 + 1.0  # 1-based average rank
+        i = j + 1
+    return ranks
+
+
+def kruskal_h(groups: list[np.ndarray]) -> float:
+    gs = [np.asarray(g, dtype=float) for g in groups if len(g) > 0]
+    if len(gs) < 2:
+        return 0.0
+    allx = np.concatenate(gs)
+    n = len(allx)
+    if n < 2:
+        return 0.0
+    ranks = rank_data(allx)
+    h = 0.0
+    idx = 0
+    for g in gs:
+        r = ranks[idx : idx + len(g)]
+        idx += len(g)
+        h += (r.sum() ** 2) / len(g)
+    h = 12.0 / (n * (n + 1)) * h - 3.0 * (n + 1)
+    _, counts = np.unique(allx, return_counts=True)
+    ties = float((counts ** 3 - counts).sum())
+    c = 1.0 - ties / (n ** 3 - n) if n > 1 else 1.0
+    return float(h / c) if c > 0 else float(h)
+
+
+def benjamini_hochberg(pvals: list[float], alpha: float = 0.05) -> list[bool]:
+    p = np.asarray(pvals, dtype=float)
+    m = len(p)
+    if m == 0:
+        return []
+    order = np.argsort(p)
+    ranked = p[order]
+    thresh = (np.arange(1, m + 1) / m) * alpha
+    passed = ranked <= thresh
+    cut = ranked[np.max(np.where(passed)[0])] if passed.any() else -1.0
+    return (p <= cut).tolist()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest backtest/tests/test_regime_stats.py -v`
+Expected: PASS. Then `uv run --no-sync python -m py_compile backtest/regime_stats.py`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/richardkuo/Work/go-trader
+git add backtest/regime_stats.py backtest/tests/test_regime_stats.py
+git commit -m "feat(#1065): pure-numpy regime stats (rank, kruskal-h, BH-FDR)
+
+LLM: Opus 4.8 | high | Harness: subagent-driven-development"
+```
+
+---
+
+### Task 3: Core diagnostic scorers `backtest/regime_diagnostics.py` (coverage / separation / stability)
+
+The pure aggregation core: forward returns, coverage, per-state separation with the primary KW-H metric, and stability.
+
+**Files:**
+- Create: `backtest/regime_diagnostics.py` (scorers only this task; CLI in Task 7)
+- Test: `backtest/tests/test_regime_diagnostics.py`
+
+**Interfaces:**
+- Consumes: `regime_stats.kruskal_h`, `regime_stats.benjamini_hochberg`.
+- Produces:
+  - `forward_returns(close: np.ndarray, horizon: int) -> np.ndarray` — `close[t+h]/close[t]-1`, NaN at the tail.
+  - `coverage(labels: np.ndarray) -> dict` — `{state: {"count": int, "pct": float}}`.
+  - `separation(labels: np.ndarray, fwd: np.ndarray) -> dict` — `{"kruskal_h": float, "per_state": {state: {"n","mean","std","hit_rate"}}}`. Bars with NaN `fwd` dropped.
+  - `stability(labels: np.ndarray) -> dict` — `{"transition_rate": float, "flips": int, "mean_dwell": {state: float}}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backtest/tests/test_regime_diagnostics.py
+import os, sys
+import numpy as np
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from regime_diagnostics import forward_returns, coverage, separation, stability
+
+
+def test_forward_returns_horizon():
+    close = np.array([100.0, 110, 121])
+    fr = forward_returns(close, 1)
+    np.testing.assert_allclose(fr[:2], [0.10, 0.10])
+    assert np.isnan(fr[-1])
+
+
+def test_coverage_counts():
+    labels = np.array(["a", "a", "b", "a"])
+    cov = coverage(labels)
+    assert cov["a"]["count"] == 3 and abs(cov["a"]["pct"] - 0.75) < 1e-9
+
+
+def test_separation_directional():
+    labels = np.array(["up"] * 50 + ["down"] * 50)
+    fwd = np.concatenate([np.full(50, 0.02), np.full(50, -0.02)])
+    sep = separation(labels, fwd)
+    assert sep["per_state"]["up"]["mean"] > 0 > sep["per_state"]["down"]["mean"]
+    assert sep["kruskal_h"] > 5.0
+
+
+def test_stability_transition_rate():
+    labels = np.array(["a", "a", "b", "b", "a"])
+    st = stability(labels)
+    assert abs(st["transition_rate"] - 0.5) < 1e-9  # 2 flips over 4 transitions
+    assert st["flips"] == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest backtest/tests/test_regime_diagnostics.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'regime_diagnostics'`.
+
+- [ ] **Step 3: Write minimal implementation** (scorers only; module header + CLI added in Task 7).
+
+```python
+# backtest/regime_diagnostics.py
+"""7-state regime quality diagnostics (#1065 PR1). Pure scorers; CLI at bottom."""
+from __future__ import annotations
+import numpy as np
+from regime_stats import kruskal_h, benjamini_hochberg  # noqa: F401 (BH used in Task 7)
+
+
+def forward_returns(close: np.ndarray, horizon: int) -> np.ndarray:
+    close = np.asarray(close, dtype=float)
+    fwd = np.full(len(close), np.nan)
+    if horizon < len(close):
+        fwd[:-horizon] = close[horizon:] / close[:-horizon] - 1.0
+    return fwd
+
+
+def coverage(labels: np.ndarray) -> dict:
+    labels = np.asarray(labels, dtype=object)
+    n = len(labels)
+    states, counts = np.unique(labels, return_counts=True)
+    return {str(s): {"count": int(c), "pct": float(c / n) if n else 0.0}
+            for s, c in zip(states, counts)}
+
+
+def separation(labels: np.ndarray, fwd: np.ndarray) -> dict:
+    labels = np.asarray(labels, dtype=object)
+    fwd = np.asarray(fwd, dtype=float)
+    valid = ~np.isnan(fwd)
+    labels, fwd = labels[valid], fwd[valid]
+    per_state, groups = {}, []
+    for s in sorted(set(labels.tolist())):
+        r = fwd[labels == s]
+        if len(r) == 0:
+            continue
+        groups.append(r)
+        per_state[str(s)] = {
+            "n": int(len(r)),
+            "mean": float(r.mean()),
+            "std": float(r.std()),
+            "hit_rate": float((r > 0).mean()),
+        }
+    return {"kruskal_h": kruskal_h(groups), "per_state": per_state}
+
+
+def stability(labels: np.ndarray) -> dict:
+    labels = np.asarray(labels, dtype=object)
+    n = len(labels)
+    if n < 2:
+        return {"transition_rate": 0.0, "flips": 0, "mean_dwell": {}}
+    changes = labels[1:] != labels[:-1]
+    flips = int(changes.sum())
+    runs: dict[str, list[int]] = {}
+    cur, length = labels[0], 1
+    for x in labels[1:]:
+        if x == cur:
+            length += 1
+        else:
+            runs.setdefault(str(cur), []).append(length)
+            cur, length = x, 1
+    runs.setdefault(str(cur), []).append(length)
+    return {
+        "transition_rate": float(flips / (n - 1)),
+        "flips": flips,
+        "mean_dwell": {s: float(np.mean(v)) for s, v in sorted(runs.items())},
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest backtest/tests/test_regime_diagnostics.py -v`
+Expected: PASS. Then `uv run --no-sync python -m py_compile backtest/regime_diagnostics.py`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/richardkuo/Work/go-trader
+git add backtest/regime_diagnostics.py backtest/tests/test_regime_diagnostics.py
+git commit -m "feat(#1065): regime diagnostic scorers (coverage/separation/stability)
+
+LLM: Opus 4.8 | high | Harness: subagent-driven-development"
+```
+
+---
+
+### Task 4: Significance control + yardstick (block-shuffle null, numpy k-means)
+
+Add the permutation null that turns KW-H into an empirical p-value, and the dependency-free k-means yardstick that bounds the separation ceiling the 7-named-state anchoring forgoes.
+
+**Files:**
+- Modify: `backtest/regime_diagnostics.py` (append functions)
+- Test: `backtest/tests/test_regime_diagnostics.py` (append tests)
+
+**Interfaces:**
+- Consumes: `separation` (Task 3).
+- Produces:
+  - `block_shuffle_pvalue(labels, fwd, block_len, n_perm=200, seed=0) -> dict` — `{"kruskal_h": float, "p_value": float, "block_len": int, "n_perm": int}`. Shuffles label blocks of `block_len`, recomputes KW-H, empirical `p = mean(H_perm >= H_obs)`.
+  - `kmeans_yardstick(features, fwd, k_range=(2,3,4,5,6,7), seed=0) -> dict` — `{k: {"kruskal_h": float}}`; numpy Lloyd's k-means on standardized features (NaN rows dropped), KW-H of forward returns by cluster.
+
+- [ ] **Step 1: Write the failing test** (append).
+
+```python
+def test_block_shuffle_pvalue_separated_is_significant():
+    from regime_diagnostics import block_shuffle_pvalue
+    labels = np.array(["up"] * 60 + ["down"] * 60)
+    fwd = np.concatenate([np.full(60, 0.02), np.full(60, -0.02)])
+    out = block_shuffle_pvalue(labels, fwd, block_len=5, n_perm=100, seed=0)
+    assert out["p_value"] < 0.05 and out["kruskal_h"] > 5.0
+
+
+def test_block_shuffle_pvalue_noise_not_significant():
+    from regime_diagnostics import block_shuffle_pvalue
+    rng = np.random.default_rng(0)
+    labels = np.array(["a", "b"])[rng.integers(0, 2, 200)]
+    fwd = rng.normal(0, 0.01, 200)
+    out = block_shuffle_pvalue(labels, fwd, block_len=10, n_perm=100, seed=0)
+    assert out["p_value"] > 0.05
+
+
+def test_kmeans_yardstick_runs():
+    from regime_diagnostics import kmeans_yardstick
+    rng = np.random.default_rng(0)
+    feats = np.vstack([rng.normal(0, 1, (100, 4)), rng.normal(5, 1, (100, 4))])
+    fwd = np.concatenate([np.full(100, 0.02), np.full(100, -0.02)])
+    out = kmeans_yardstick(feats, fwd, k_range=(2, 3), seed=0)
+    assert out[2]["kruskal_h"] > 5.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest backtest/tests/test_regime_diagnostics.py -k "shuffle or yardstick" -v`
+Expected: FAIL — `ImportError: cannot import name 'block_shuffle_pvalue'`.
+
+- [ ] **Step 3: Write minimal implementation** (append to `regime_diagnostics.py`).
+
+```python
+def block_shuffle_pvalue(labels, fwd, block_len, n_perm=200, seed=0) -> dict:
+    labels = np.asarray(labels, dtype=object)
+    fwd = np.asarray(fwd, dtype=float)
+    h_obs = separation(labels, fwd)["kruskal_h"]
+    n = len(labels)
+    block_len = max(1, int(block_len))
+    starts = list(range(0, n, block_len))
+    rng = np.random.default_rng(seed)
+    ge = 0
+    for _ in range(n_perm):
+        perm = rng.permutation(len(starts))
+        shuffled = np.concatenate([labels[s : s + block_len] for s in (starts[i] for i in perm)])
+        shuffled = shuffled[:n]
+        if separation(shuffled, fwd)["kruskal_h"] >= h_obs:
+            ge += 1
+    return {"kruskal_h": float(h_obs), "p_value": float((ge + 1) / (n_perm + 1)),
+            "block_len": block_len, "n_perm": int(n_perm)}
+
+
+def _kmeans(z, k, seed, iters=50):
+    rng = np.random.default_rng(seed)
+    centers = z[rng.choice(len(z), size=k, replace=False)]
+    labels = np.zeros(len(z), dtype=int)
+    for _ in range(iters):
+        d = ((z[:, None, :] - centers[None, :, :]) ** 2).sum(-1)
+        new = d.argmin(1)
+        if np.array_equal(new, labels):
+            break
+        labels = new
+        for j in range(k):
+            if (labels == j).any():
+                centers[j] = z[labels == j].mean(0)
+    return labels
+
+
+def kmeans_yardstick(features, fwd, k_range=(2, 3, 4, 5, 6, 7), seed=0) -> dict:
+    features = np.asarray(features, dtype=float)
+    fwd = np.asarray(fwd, dtype=float)
+    mask = ~np.isnan(features).any(1) & ~np.isnan(fwd)
+    x, fr = features[mask], fwd[mask]
+    mean, std = x.mean(0), x.std(0)
+    std[std < 1e-8] = 1.0
+    z = (x - mean) / std
+    out = {}
+    for k in k_range:
+        if k > len(z):
+            continue
+        cl = _kmeans(z, k, seed)
+        groups = [fr[cl == j] for j in range(k) if (cl == j).any()]
+        out[k] = {"kruskal_h": kruskal_h(groups)}
+    return out
+```
+
+Add `from regime_stats import kruskal_h` to the existing import line if not already present (it is imported in Task 3).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest backtest/tests/test_regime_diagnostics.py -v`
+Expected: PASS (all). Then `uv run --no-sync python -m py_compile backtest/regime_diagnostics.py`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/richardkuo/Work/go-trader
+git add backtest/regime_diagnostics.py backtest/tests/test_regime_diagnostics.py
+git commit -m "feat(#1065): block-shuffle significance + numpy k-means yardstick
+
+LLM: Opus 4.8 | high | Harness: subagent-driven-development"
+```
+
+---
+
+### Task 5: Label-anchored HMM fit `backtest/regime_hmm.py`
+
+Closed-form fit: standardize features, per-state diagonal-Gaussian MLE on hand-rule labels (variance floor for degenerate states), Laplace-smoothed transition counts, stationary init. No EM.
+
+**Files:**
+- Create: `backtest/regime_hmm.py` (fit + stationary this task; filter in Task 6)
+- Test: `backtest/tests/test_regime_hmm.py`
+
+**Interfaces:**
+- Produces:
+  - `stationary_distribution(transition: np.ndarray) -> np.ndarray` — left eigenvector for eigenvalue 1, normalized.
+  - `fit_label_anchored_hmm(features, labels, states, *, filter_window, var_floor=1e-3, laplace=1.0, fitted_on=None) -> dict` — returns the `model` dict matching the spec schema (`feature_means`, `feature_stds`, `states`, `emissions` [{"mean","var","n"}], `transition`, `init`, `filter_window`, `type`, `version`, `features`, `fitted_on`). NaN feature rows dropped before fitting.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backtest/tests/test_regime_hmm.py
+import os, sys
+import numpy as np
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from regime_hmm import fit_label_anchored_hmm, stationary_distribution
+
+STATES = ["s0", "s1"]
+
+
+def test_stationary_distribution_sums_to_one():
+    A = np.array([[0.9, 0.1], [0.2, 0.8]])
+    pi = stationary_distribution(A)
+    assert abs(pi.sum() - 1.0) < 1e-9 and (pi > 0).all()
+    np.testing.assert_allclose(pi @ A, pi, atol=1e-9)  # stationary
+
+
+def test_fit_shapes_and_determinism():
+    rng = np.random.default_rng(0)
+    feats = np.vstack([rng.normal(0, 1, (80, 4)), rng.normal(4, 1, (80, 4))])
+    labels = np.array(["s0"] * 80 + ["s1"] * 80, dtype=object)
+    m1 = fit_label_anchored_hmm(feats, labels, STATES, filter_window=16)
+    m2 = fit_label_anchored_hmm(feats, labels, STATES, filter_window=16)
+    assert m1["states"] == STATES
+    assert len(m1["emissions"]) == 2
+    assert np.array(m1["transition"]).shape == (2, 2)
+    assert m1["emissions"][0]["mean"] == m2["emissions"][0]["mean"]  # deterministic
+    # standardized means: s0 cluster ~ negative, s1 ~ positive on each feature
+    assert m1["emissions"][0]["mean"][0] < m1["emissions"][1]["mean"][0]
+
+
+def test_fit_drops_nan_rows():
+    feats = np.array([[np.nan, np.nan, np.nan, np.nan], [0.0, 0, 0, 0], [1.0, 1, 1, 1]])
+    labels = np.array(["s0", "s0", "s1"], dtype=object)
+    m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=2)
+    assert m["emissions"][0]["n"] == 1  # the NaN s0 row was dropped
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest backtest/tests/test_regime_hmm.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'regime_hmm'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# backtest/regime_hmm.py
+"""Label-anchored Gaussian HMM: closed-form fit + causal forward-filter (#1065)."""
+from __future__ import annotations
+import numpy as np
+
+MODEL_TYPE = "label_anchored_hmm"
+MODEL_VERSION = 1
+FEATURES = ["return_eff", "range_eff", "efficiency", "adx"]
+
+
+def stationary_distribution(transition: np.ndarray) -> np.ndarray:
+    A = np.asarray(transition, dtype=float)
+    vals, vecs = np.linalg.eig(A.T)
+    i = int(np.argmin(np.abs(vals - 1.0)))
+    v = np.abs(np.real(vecs[:, i]))
+    s = v.sum()
+    return v / s if s > 0 else np.full(len(A), 1.0 / len(A))
+
+
+def fit_label_anchored_hmm(features, labels, states, *, filter_window,
+                           var_floor=1e-3, laplace=1.0, fitted_on=None) -> dict:
+    features = np.asarray(features, dtype=float)
+    labels = np.asarray(labels, dtype=object)
+    mask = ~np.isnan(features).any(1)
+    x, y = features[mask], labels[mask]
+    mean = x.mean(0) if len(x) else np.zeros(features.shape[1])
+    std = x.std(0) if len(x) else np.ones(features.shape[1])
+    std = np.where(std < 1e-8, 1.0, std)
+    z = (x - mean) / std
+    emissions = []
+    for s in states:
+        zs = z[y == s]
+        if len(zs) >= 2:
+            em_mean, em_var = zs.mean(0), zs.var(0)
+        else:  # degenerate: anchor at standardized origin, unit variance (flagged by n)
+            em_mean, em_var = np.zeros(z.shape[1]), np.ones(z.shape[1])
+        em_var = np.maximum(em_var, var_floor)
+        emissions.append({"mean": em_mean.tolist(), "var": em_var.tolist(), "n": int(len(zs))})
+    si = {s: i for i, s in enumerate(states)}
+    k = len(states)
+    A = np.full((k, k), float(laplace))
+    for a, b in zip(y[:-1], y[1:]):
+        A[si[a], si[b]] += 1.0
+    A = A / A.sum(1, keepdims=True)
+    return {
+        "type": MODEL_TYPE, "version": MODEL_VERSION, "features": list(FEATURES),
+        "feature_means": mean.tolist(), "feature_stds": std.tolist(),
+        "states": list(states), "emissions": emissions,
+        "transition": A.tolist(), "init": stationary_distribution(A).tolist(),
+        "filter_window": int(filter_window), "fitted_on": fitted_on or {},
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest backtest/tests/test_regime_hmm.py -v`
+Expected: PASS. Then `uv run --no-sync python -m py_compile backtest/regime_hmm.py`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/richardkuo/Work/go-trader
+git add backtest/regime_hmm.py backtest/tests/test_regime_hmm.py
+git commit -m "feat(#1065): closed-form label-anchored HMM fit + stationary init
+
+LLM: Opus 4.8 | high | Harness: subagent-driven-development"
+```
+
+---
+
+### Task 6: Causal forward-filter inference (windowed-from-init, NaN carry, look-ahead safe)
+
+The inference math: a windowed forward-filter that produces a per-bar label + confidence. This is the function PR2 will port into `regime.py`; here it is proven in isolation with look-ahead and NaN-carry tests.
+
+**Files:**
+- Modify: `backtest/regime_hmm.py` (append filter)
+- Test: `backtest/tests/test_regime_hmm.py` (append)
+
+**Interfaces:**
+- Consumes: model dict from `fit_label_anchored_hmm`.
+- Produces: `forward_filter_labels(features: np.ndarray, model: dict) -> tuple[np.ndarray, np.ndarray]` — `(labels[object], confidence[float])`. For each bar `i`, runs the filter over `[max(0,i-filter_window+1), i]` from `init`; NaN feature rows apply the transition step with no emission update (carry); the pre-warmup leading bars (where the whole window is NaN) get `model["states"][argmax(init)]`.
+
+- [ ] **Step 1: Write the failing test** (append).
+
+```python
+def test_forward_filter_look_ahead_safe():
+    from regime_hmm import forward_filter_labels
+    rng = np.random.default_rng(0)
+    feats = np.vstack([rng.normal(0, 1, (60, 4)), rng.normal(4, 1, (60, 4))])
+    labels = np.array(["s0"] * 60 + ["s1"] * 60, dtype=object)
+    m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=8)
+    lab_a, _ = forward_filter_labels(feats, m)
+    perturbed = feats.copy()
+    perturbed[80:] += 100.0  # mutate the FUTURE relative to bar 70
+    lab_b, _ = forward_filter_labels(perturbed, m)
+    assert list(lab_a[:71]) == list(lab_b[:71])  # labels <=70 unchanged by future
+
+
+def test_forward_filter_recovers_regime():
+    from regime_hmm import forward_filter_labels
+    rng = np.random.default_rng(1)
+    feats = np.vstack([rng.normal(0, 1, (60, 4)), rng.normal(4, 1, (60, 4))])
+    labels = np.array(["s0"] * 60 + ["s1"] * 60, dtype=object)
+    m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=8)
+    lab, conf = forward_filter_labels(feats, m)
+    assert (lab[20:55] == "s0").mean() > 0.8 and (lab[80:115] == "s1").mean() > 0.8
+    assert (conf >= 0).all() and (conf <= 1.0 + 1e-9).all()
+
+
+def test_forward_filter_nan_carry():
+    from regime_hmm import forward_filter_labels
+    rng = np.random.default_rng(2)
+    feats = np.vstack([rng.normal(0, 1, (40, 4)), rng.normal(4, 1, (40, 4))])
+    labels = np.array(["s0"] * 40 + ["s1"] * 40, dtype=object)
+    m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=6)
+    feats[50] = np.nan  # a low-ATR bar inside the s1 stretch
+    lab, _ = forward_filter_labels(feats, m)
+    assert lab[50] in STATES  # no crash; carried, not undefined
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest backtest/tests/test_regime_hmm.py -k forward_filter -v`
+Expected: FAIL — `ImportError: cannot import name 'forward_filter_labels'`.
+
+- [ ] **Step 3: Write minimal implementation** (append to `regime_hmm.py`).
+
+```python
+def _logsumexp(v: np.ndarray) -> float:
+    m = float(np.max(v))
+    return m + float(np.log(np.exp(v - m).sum()))
+
+
+def forward_filter_labels(features: np.ndarray, model: dict):
+    features = np.asarray(features, dtype=float)
+    n = len(features)
+    states = list(model["states"])
+    k = len(states)
+    mean = np.asarray(model["feature_means"], dtype=float)
+    std = np.asarray(model["feature_stds"], dtype=float)
+    em_mean = np.array([e["mean"] for e in model["emissions"]], dtype=float)
+    em_var = np.array([e["var"] for e in model["emissions"]], dtype=float)
+    log_init = np.log(np.asarray(model["init"], dtype=float) + 1e-300)
+    log_A = np.log(np.asarray(model["transition"], dtype=float) + 1e-300)
+    w = int(model["filter_window"])
+    default_label = states[int(np.argmax(model["init"]))]
+
+    labels = np.array([default_label] * n, dtype=object)
+    conf = np.zeros(n, dtype=float)
+    for i in range(n):
+        lo = max(0, i - w + 1)
+        alpha = log_init.copy()
+        seen = False
+        for t in range(lo, i + 1):
+            x = features[t]
+            # predict: alpha'_j = logsumexp_i(alpha_i + log_A[i,j])
+            pred = np.array([_logsumexp(alpha + log_A[:, j]) for j in range(k)])
+            if np.isnan(x).any():
+                alpha = pred  # carry: transition only, no emission
+                continue
+            z = (x - mean) / std
+            log_emit = -0.5 * (np.log(2 * np.pi * em_var) + (z - em_mean) ** 2 / em_var).sum(1)
+            alpha = pred + log_emit
+            alpha -= _logsumexp(alpha)  # normalize
+            seen = True
+        if seen:
+            j = int(np.argmax(alpha))
+            labels[i] = states[j]
+            conf[i] = float(np.exp(alpha[j] - _logsumexp(alpha)))
+    return labels, conf
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest backtest/tests/test_regime_hmm.py -v`
+Expected: PASS (all). Then `uv run --no-sync python -m py_compile backtest/regime_hmm.py`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/richardkuo/Work/go-trader
+git add backtest/regime_hmm.py backtest/tests/test_regime_hmm.py
+git commit -m "feat(#1065): causal windowed forward-filter (look-ahead safe, NaN carry)
+
+LLM: Opus 4.8 | high | Harness: subagent-driven-development"
+```
+
+---
+
+### Task 7: `regime_diagnostics.py` CLI — load data, score hand-rule or model, `--json`
+
+Wire the scorers to the data path. Loads a (symbol, timeframe, window) via `load_cached_data`, computes hand-rule labels (or model labels from `--model-json`), reports coverage/separation/stability/significance/yardstick.
+
+**Files:**
+- Modify: `backtest/regime_diagnostics.py` (add header bootstrap + `run_window` + `build_parser` + `main`)
+- Test: `backtest/tests/test_regime_diagnostics.py` (append a pure `run_window`-on-arrays test; no data access)
+
+**Interfaces:**
+- Consumes: `eval_windows.{DATASETS,WINDOWS,dataset_key,parse_dataset_arg}`, `shared_tools.regime.{compute_regime_composite,composite_feature_matrix,_DEFAULT_COMPOSITE_THRESHOLDS}`, `data_fetcher.load_cached_data`, `regime_hmm.forward_filter_labels`.
+- Produces: `score_labels(close, labels, features, horizons, block_mult, seed) -> dict` (pure: bundles coverage/separation/stability/significance/yardstick for each horizon); CLI `main(argv) -> int`.
+
+- [ ] **Step 1: Write the failing test** (append — pure, array-level).
+
+```python
+def test_score_labels_bundle():
+    from regime_diagnostics import score_labels
+    rng = np.random.default_rng(0)
+    close = 100 * np.cumprod(1 + rng.normal(0, 0.005, 300))
+    labels = np.array(["up" if r >= 0 else "down" for r in np.diff(close, prepend=close[0])], dtype=object)
+    feats = rng.normal(0, 1, (300, 4))
+    out = score_labels(close, labels, feats, horizons=(1, 4), block_mult=3, seed=0)
+    assert "h4" in out and "kruskal_h" in out["h4"]["separation"]
+    assert "coverage" in out and "stability" in out
+    assert "p_value" in out["h4"]["significance"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest backtest/tests/test_regime_diagnostics.py -k score_labels -v`
+Expected: FAIL — `ImportError: cannot import name 'score_labels'`.
+
+- [ ] **Step 3: Write minimal implementation.** Prepend the sys.path bootstrap to the TOP of `regime_diagnostics.py` (above the existing `from regime_stats import ...`):
+
+```python
+import os, sys
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+_ROOT = os.path.abspath(os.path.join(_THIS_DIR, ".."))
+for _p in (_ROOT, os.path.join(_ROOT, "shared_tools")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+```
+
+Append `score_labels`, `run_window`, parser and `main`:
+
+```python
+def score_labels(close, labels, features, horizons=(1, 4, 12), block_mult=3, seed=0) -> dict:
+    labels = np.asarray(labels, dtype=object)
+    features = np.asarray(features, dtype=float)
+    st = stability(labels)
+    mean_dwell = float(np.mean(list(st["mean_dwell"].values()))) if st["mean_dwell"] else 1.0
+    out = {"coverage": coverage(labels), "stability": st, "horizons": {}}
+    for h in horizons:
+        fwd = forward_returns(close, h)
+        block_len = max(int(block_mult * mean_dwell), h)
+        out["horizons"][f"h{h}"] = {
+            "separation": separation(labels, fwd),
+            "significance": block_shuffle_pvalue(labels, fwd, block_len, seed=seed),
+            "yardstick": kmeans_yardstick(features, fwd, seed=seed),
+        }
+    # flat aliases for the pre-registered primary (h=4)
+    if "h4" in out["horizons"]:
+        out["h4"] = out["horizons"]["h4"]
+    return out
+
+
+def run_window(symbol, timeframe, window, *, model=None, horizons=(1, 4, 12), seed=0) -> dict:
+    from regime import compute_regime_composite, composite_feature_matrix, _DEFAULT_COMPOSITE_THRESHOLDS
+    from data_fetcher import load_cached_data
+    from eval_windows import WINDOWS, PLATFORM
+    start, end = WINDOWS[window]
+    df = load_cached_data(symbol, timeframe, exchange_id=PLATFORM, start_date=start, end_date=end)
+    period = int(model["period"]) if model and "period" in model else 48
+    th = dict(_DEFAULT_COMPOSITE_THRESHOLDS)
+    feats_df = composite_feature_matrix(df, period, th)
+    features = feats_df.to_numpy()
+    if model is None:
+        labels = compute_regime_composite(df, period=period, thresholds=th)["regime"].to_numpy()
+    else:
+        from regime_hmm import forward_filter_labels
+        labels, _conf = forward_filter_labels(features, model)
+    return score_labels(df["close"].to_numpy(), labels, features, horizons=horizons, seed=seed)
+
+
+def build_parser() -> "argparse.ArgumentParser":
+    import argparse
+    from eval_windows import WINDOWS, DATASETS
+    p = argparse.ArgumentParser(description="7-state regime quality diagnostics (#1065)")
+    p.add_argument("--symbol", default="BTC/USDT")
+    p.add_argument("--timeframe", default="1h")
+    p.add_argument("--windows", default="is,oos", help=f"known: {', '.join(WINDOWS)}")
+    p.add_argument("--model-json", default=None, help="score a fitted model instead of the hand-rule")
+    p.add_argument("--horizons", default="1,4,12")
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--json", default=None, help="write report JSON to this path")
+    return p
+
+
+def main(argv=None) -> int:
+    import argparse, json
+    args = build_parser().parse_args(argv)
+    from eval_windows import WINDOWS
+    model = None
+    if args.model_json:
+        with open(args.model_json) as fh:
+            loaded = json.load(fh)
+        model = loaded.get("model", loaded) if isinstance(loaded, dict) else loaded
+    horizons = tuple(int(x) for x in args.horizons.split(","))
+    report = {}
+    for w in args.windows.split(","):
+        if w not in WINDOWS:
+            raise SystemExit(f"unknown window {w}; known: {list(WINDOWS)}")
+        report[w] = run_window(args.symbol, args.timeframe, w, model=model,
+                               horizons=horizons, seed=args.seed)
+    payload = {"symbol": args.symbol, "timeframe": args.timeframe,
+               "source": "model" if model else "hand_rule", "windows": report}
+    text = json.dumps(payload, indent=2, default=float)
+    if args.json:
+        with open(args.json, "w") as fh:
+            fh.write(text)
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run test to verify it passes; smoke the CLI against cached data**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest backtest/tests/test_regime_diagnostics.py -v`
+Expected: PASS. Then `uv run --no-sync python -m py_compile backtest/regime_diagnostics.py`.
+Smoke (uses cached BTC data — may fetch if cold): `uv run --no-sync python backtest/regime_diagnostics.py --symbol BTC/USDT --timeframe 1h --windows is --horizons 1,4`
+Expected: JSON with `windows.is.h4.separation.kruskal_h` and `...significance.p_value`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/richardkuo/Work/go-trader
+git add backtest/regime_diagnostics.py backtest/tests/test_regime_diagnostics.py
+git commit -m "feat(#1065): regime_diagnostics CLI — score hand-rule or model, --json
+
+LLM: Opus 4.8 | high | Harness: subagent-driven-development"
+```
+
+---
+
+### Task 8: `regime_calibrate.py` CLI — fit IS, score held-out, gate verdict
+
+Fit the label-anchored HMM on an in-sample window, save the model JSON, score it against the hand-rule on a held-out window, and emit the ship/no-ship gate verdict (separation not worse AND stability improved).
+
+**Files:**
+- Create: `backtest/regime_calibrate.py`
+- Test: `backtest/tests/test_regime_calibrate.py`
+
+**Interfaces:**
+- Consumes: `regime_hmm.{fit_label_anchored_hmm}`, `regime_diagnostics.{run_window,score_labels}`, `shared_tools.regime.{composite_feature_matrix,compute_regime_composite,VALID_LABELS_COMPOSITE,_DEFAULT_COMPOSITE_THRESHOLDS}`, `eval_windows.WINDOWS`, `data_fetcher.load_cached_data`.
+- Produces: `gate_verdict(handrule_report: dict, model_report: dict, primary="h4") -> dict` (pure: `{"separation_ok","stability_ok","ship": bool, "detail": {...}}`); CLI `main(argv) -> int`.
+
+- [ ] **Step 1: Write the failing test** (pure gate logic, no data).
+
+```python
+# backtest/tests/test_regime_calibrate.py
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from regime_calibrate import gate_verdict
+
+
+def _report(kw_h, transition_rate):
+    return {"stability": {"transition_rate": transition_rate},
+            "h4": {"separation": {"kruskal_h": kw_h}}}
+
+
+def test_gate_ships_when_stability_better_and_separation_kept():
+    hr = _report(10.0, 0.40)
+    md = _report(9.6, 0.25)  # sep within 5% tolerance, whipsaw down
+    v = gate_verdict(hr, md)
+    assert v["ship"] is True and v["separation_ok"] and v["stability_ok"]
+
+
+def test_gate_blocks_when_separation_collapses():
+    hr = _report(10.0, 0.40)
+    md = _report(4.0, 0.20)  # separation lost
+    assert gate_verdict(hr, md)["ship"] is False
+
+
+def test_gate_blocks_when_no_stability_gain():
+    hr = _report(10.0, 0.40)
+    md = _report(10.0, 0.42)  # whipsaw not improved
+    assert gate_verdict(hr, md)["ship"] is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest backtest/tests/test_regime_calibrate.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'regime_calibrate'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# backtest/regime_calibrate.py
+"""Fit + walk-forward validate the label-anchored regime HMM (#1065 PR1)."""
+from __future__ import annotations
+import os, sys
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+for _p in (_THIS_DIR, os.path.abspath(os.path.join(_THIS_DIR, "..")),
+           os.path.abspath(os.path.join(_THIS_DIR, "..", "shared_tools"))):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+SEPARATION_TOLERANCE = 0.05   # model KW-H may dip at most 5% below the hand-rule
+STABILITY_MIN_GAIN = 0.02     # transition-rate must drop by >= this (absolute)
+
+
+def gate_verdict(handrule_report: dict, model_report: dict, primary: str = "h4") -> dict:
+    hr_h = handrule_report[primary]["separation"]["kruskal_h"]
+    md_h = model_report[primary]["separation"]["kruskal_h"]
+    hr_tr = handrule_report["stability"]["transition_rate"]
+    md_tr = model_report["stability"]["transition_rate"]
+    separation_ok = md_h >= hr_h * (1.0 - SEPARATION_TOLERANCE)
+    stability_ok = (hr_tr - md_tr) >= STABILITY_MIN_GAIN
+    return {
+        "separation_ok": bool(separation_ok),
+        "stability_ok": bool(stability_ok),
+        "ship": bool(separation_ok and stability_ok),
+        "detail": {"handrule_kruskal_h": hr_h, "model_kruskal_h": md_h,
+                   "handrule_transition_rate": hr_tr, "model_transition_rate": md_tr},
+    }
+
+
+def fit_on_window(symbol, timeframe, window, *, period=48, filter_window=64):
+    from regime import (compute_regime_composite, composite_feature_matrix,
+                        VALID_LABELS_COMPOSITE, _DEFAULT_COMPOSITE_THRESHOLDS)
+    from regime_hmm import fit_label_anchored_hmm
+    from data_fetcher import load_cached_data
+    from eval_windows import WINDOWS, PLATFORM
+    start, end = WINDOWS[window]
+    df = load_cached_data(symbol, timeframe, exchange_id=PLATFORM, start_date=start, end_date=end)
+    th = dict(_DEFAULT_COMPOSITE_THRESHOLDS)
+    feats = composite_feature_matrix(df, period, th).to_numpy()
+    labels = compute_regime_composite(df, period=period, thresholds=th)["regime"].to_numpy()
+    states = sorted(VALID_LABELS_COMPOSITE)
+    model = fit_label_anchored_hmm(feats, labels, states, filter_window=filter_window,
+                                   fitted_on={"symbol": symbol, "timeframe": timeframe, "window": window})
+    model["period"] = period
+    return model
+
+
+def build_parser():
+    import argparse
+    from eval_windows import WINDOWS
+    p = argparse.ArgumentParser(description="Fit + validate the regime HMM (#1065)")
+    p.add_argument("--symbol", default="BTC/USDT")
+    p.add_argument("--timeframe", default="1h")
+    p.add_argument("--in-sample", default="is", help=f"known: {', '.join(WINDOWS)}")
+    p.add_argument("--held-out", default="oos")
+    p.add_argument("--period", type=int, default=48)
+    p.add_argument("--filter-window", type=int, default=64)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--out", default=None, help="write fitted model JSON here")
+    p.add_argument("--json", default=None, help="write validation report JSON here")
+    return p
+
+
+def main(argv=None) -> int:
+    import json
+    from regime_diagnostics import run_window
+    args = build_parser().parse_args(argv)
+    model = fit_on_window(args.symbol, args.timeframe, args.in_sample,
+                          period=args.period, filter_window=args.filter_window)
+    if args.out:
+        with open(args.out, "w") as fh:
+            json.dump({"model": model}, fh, indent=2, default=float)
+    hr = run_window(args.symbol, args.timeframe, args.held_out, model=None, seed=args.seed)
+    md = run_window(args.symbol, args.timeframe, args.held_out, model=model, seed=args.seed)
+    verdict = gate_verdict(hr, md)
+    payload = {"symbol": args.symbol, "timeframe": args.timeframe,
+               "in_sample": args.in_sample, "held_out": args.held_out,
+               "verdict": verdict, "handrule": hr, "model": md}
+    text = json.dumps(payload, indent=2, default=float)
+    if args.json:
+        with open(args.json, "w") as fh:
+            fh.write(text)
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run test to verify it passes; smoke the full walk-forward**
+
+Run: `cd /Users/richardkuo/Work/go-trader && uv run --no-sync python -m pytest backtest/tests/test_regime_calibrate.py -v`
+Expected: PASS. Then `uv run --no-sync python -m py_compile backtest/regime_calibrate.py`.
+Smoke: `uv run --no-sync python backtest/regime_calibrate.py --symbol BTC/USDT --timeframe 1h --in-sample is --held-out oos --out /tmp/regime_model.json`
+Expected: JSON with `verdict.ship` (bool) and both `handrule`/`model` held-out reports; `/tmp/regime_model.json` written.
+
+- [ ] **Step 5: Commit + full PR1 suite**
+
+```bash
+cd /Users/richardkuo/Work/go-trader
+uv run --no-sync python -m pytest shared_tools/test_regime_features.py backtest/tests/test_regime_stats.py backtest/tests/test_regime_diagnostics.py backtest/tests/test_regime_hmm.py backtest/tests/test_regime_calibrate.py -v
+git add backtest/regime_calibrate.py backtest/tests/test_regime_calibrate.py
+git commit -m "feat(#1065): regime_calibrate CLI — fit IS, walk-forward gate verdict
+
+LLM: Opus 4.8 | high | Harness: subagent-driven-development"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (PR1 portions):**
+- Measurement: coverage/separation/stability → Task 3; KW-H primary h=4 → Tasks 3,7; FDR exploratory → Task 2 (`benjamini_hochberg`, surfaced in per-state reporting via Task 7 `separation`); block-shuffle control w/ length ≥ max(h, mean dwell) → Task 4 + `score_labels` block_len; unsupervised yardstick → Task 4 (numpy k-means). ✓
+- Calibration: closed-form label-anchored fit → Task 5; walk-forward IS→held-out + gate → Task 8; degenerate-state variance floor → Task 5. ✓
+- Inference (needed by calibrate to score the model) → Task 6 forward-filter; look-ahead + NaN carry tests → Task 6. ✓
+- Feature consistency with live labeler → Task 1 (`composite_feature_matrix` + reproduction test). ✓
+- Pure/unit-tested-without-data, numpy-only, deterministic-seed, read-only → Global Constraints, honored per task. ✓
+- **Deferred to PR2 (correctly out of PR1 scope):** `regime.py` live inference wiring, the `model` block on `RegimeWindowSpec`, Go structural validation/fail-closed, `filter_window` in OHLCV fetch sizing, bounded-window ADX parity. PR1's forward-filter is offline-only; the spec's parity invariants attach to PR2's live integration. ✓
+
+**Placeholder scan:** no TBD/TODO; every code step is complete. ✓
+
+**Type consistency:** `score_labels`/`run_window` produce `report["h4"]` consumed by `gate_verdict`; model dict keys (`states`,`emissions`,`transition`,`init`,`filter_window`,`feature_means/stds`,`period`) written by `fit_label_anchored_hmm`/`fit_on_window` and read by `forward_filter_labels`/`run_window` — consistent. `kruskal_h` returns a float (not a tuple) everywhere. ✓
+
+**Note for the implementer:** the `--model-json` loader in Task 7 `main` accepts both calibrate's `{"model": {...}}` wrapper (its `--out` shape) and a bare model dict.

--- a/docs/superpowers/specs/2026-06-19-regime-accuracy-design.md
+++ b/docs/superpowers/specs/2026-06-19-regime-accuracy-design.md
@@ -1,136 +1,167 @@
 # 7-State Regime Accuracy: Measurement + Label-Anchored HMM Classifier
 
 **Issue:** #1065
-**Status:** Design approved, pending spec review
-**Approach:** B — model with named states (keep the 7 semantic labels; replace hand-thresholds + per-bar independence with a fitted transition-prior model)
+**Status:** Design v2 (review findings folded in), pending spec review
+**Approach:** B — model with named states (keep the 7 semantic labels; replace
+hand-thresholds + per-bar independence with a fitted transition-prior model)
+
+**Delivery:** two phases, **harness-first**.
+- **PR1 (measurement, read-only, no parity risk):** `regime_diagnostics.py` +
+  `regime_calibrate.py`. Tells us whether a fitted model is even worth building.
+- **PR2 (classifier, parity-sensitive):** the forward-filter inference path in
+  `regime.py` + the Go spec surface. Built **only if PR1 shows the model beats the
+  hand-rule** on the pre-registered gate.
 
 ## Problem
 
-The composite 7-state regime classifier (#795 / #1058) labels each bar one of
+The composite 7-state classifier (#795 / #1058) labels each bar one of
 `trending_up_clean`, `trending_up_choppy`, `trending_down_clean`,
 `trending_down_choppy`, `ranging_quiet`, `ranging_volatile`,
 `ranging_directional`. It is a hand-tuned decision tree (`map_composite_label`)
 over four ATR-normalized features — `return_eff`, `range_eff`, `efficiency`,
 `adx` — with global constant thresholds (`_DEFAULT_COMPOSITE_THRESHOLDS`).
 
-Two gaps:
 1. **Accuracy is never measured.** No validation harness, no forward-return
-   separation test, no stability/whipsaw metric. "Accuracy" is undefined today.
+   separation test, no stability/whipsaw metric.
 2. **The classifier is structurally weak.** Thresholds are global constants (not
-   calibrated per asset/timeframe), and each bar is classified independently with
-   no persistence model, so labels can whipsaw bar-to-bar.
+   calibrated per asset/timeframe); each bar is classified independently with no
+   persistence model, so labels can whipsaw.
 
 ## Goal
 
 Define and measure regime quality, then improve it — without breaking the
 semantic-label contract that config-keyed SL/TP/gate ladders depend on.
 
-Two notions of "accuracy", both measured:
-- **Separation** (the economic notion): do the 7 states have distinct forward
-  return / volatility distributions, and in the right direction? Is that
-  separation real signal or an autocorrelation artifact?
-- **Stability:** does the label persist sensibly, or whipsaw?
+Two measured notions:
+- **Separation** (economic): do the 7 states have distinct, correctly-signed
+  forward return / volatility distributions, and is that separation real signal
+  vs an autocorrelation artifact?
+- **Stability:** does the label persist sensibly or whipsaw?
 
-## Approach: label-anchored Gaussian HMM
+### Honest expectation (sets the gate)
 
-Keep the 7 semantic labels and the existing four features. Replace the hand
-decision tree and per-bar independence with a Hidden Markov Model whose states
-are **pinned to the 7 labels** (so state identity stays semantic and config keys
-keep working):
+Emissions are MLE-fit on bars the **hand-rule itself labels** as each state, so
+the model largely relearns the hand-rule's boundaries. Held-out *separation* lift
+is therefore structurally bounded to boundary-softening; the material gain is
+**whipsaw reduction** from the data-fit transition matrix. The ship/no-ship gate
+is keyed accordingly (below): the model must not *lose* separation and must
+*improve* stability. A null separation result is expected, not a failure.
 
-- **Emissions** — per-state Gaussian, fit by maximum likelihood on the
-  (standardized) feature vectors of bars the *current hand-rule* labels as that
-  state. The hand-rule becomes the labeling prior; the model refines hard cutoffs
-  into soft, data-fit boundaries. Diagonal covariance (4 features, keep params
-  low and the fit robust).
-- **Transitions** — the 7×7 matrix counted from the hand-rule label sequence,
-  Laplace-smoothed and row-normalized. This *is* the persistence layer:
-  data-calibrated, replacing the arbitrary smoothing-window hack.
-- **Inference** — causal **forward-filter** only (never Viterbi / forward-
-  backward, which peek at the future). At bar *t*:
-  `alpha_t(j) ∝ emission(x_t | j) · Σ_i alpha_{t-1}(i) · A[i,j]`, normalized.
-  `label_t = argmax_j alpha_t(j)`; `confidence_t = max_j alpha_t(j)` (a new
-  output that lets downstream gate on uncertainty).
+## Approach: label-anchored Gaussian HMM (PR2)
 
-Fitting is **closed-form** (Gaussian MLE + transition counts) because the states
-are supervised by the hand-rule labels — no EM, no `hmmlearn`, no new dependency.
+Keep the 7 semantic labels and the four features. Pin HMM states to the 7 labels:
+- **Emissions** — per-state diagonal Gaussian, MLE on the standardized feature
+  vectors of bars the current hand-rule labels as that state.
+- **Transitions** — 7×7 matrix counted from the hand-rule label sequence,
+  Laplace-smoothed, row-normalized. This is the persistence layer (replaces any
+  smoothing-window hack).
+- **Inference** — causal **forward-filter** only:
+  `alpha_t(j) ∝ emission(x_t|j) · Σ_i alpha_{t-1}(i)·A[i,j]`, normalized;
+  `label_t = argmax_j alpha_t(j)`, `confidence_t = max_j alpha_t(j)`.
 
-### Parity & look-ahead (the load-bearing invariants)
+Fit is **closed-form** (Gaussian MLE + transition counts), no EM, no new
+dependency.
 
-- **Canonical inference is the *windowed* forward-filter:** run the filter over a
-  fixed trailing window of `filter_window` bars, initialized at the model's
-  stationary distribution. This produces the label for the window's last bar.
-  - **Backtest** (`compute_regime_composite`): for each bar *i*, run the windowed
-    filter over bars `[i-filter_window+1, i]`.
-  - **Live** (`latest_regime_composite`): run the windowed filter over the last
-    `filter_window` bars of the trailing df.
-  - Both call **one shared helper** with identical inputs → labels are identical
-    by construction. No cross-cycle state is needed (the #879 cycle-reset store
-    stays empty-per-cycle); persistence comes from the transition matrix applied
-    across the window, not from remembered emitted labels.
-  - `filter_window` must be long enough for the init to wash out (HMM geometric
-    forgetting); calibration picks and validates it.
-- **Look-ahead safety:** the filter at bar *t* uses only bars ≤ *t*. The existing
-  N→N+1 gate shift and `_regime_bar_close` snapshot are classifier-agnostic and
-  unchanged. Covered by `backtest/tests/test_backtester_lookahead.py`.
-- **Features are unchanged:** the HMM consumes the same per-bar feature tuple the
-  hand-rule consumes (`return_eff`, `range_eff`, `efficiency`, `adx`, with the
-  `COMPOSITE_ADX_PERIOD_CAP` ADX and full-`period` efficiency). Only the
-  tuple→label mapping changes.
+### Parity & look-ahead — the load-bearing invariants
+
+1. **One shared helper, identical bounded-window features on both paths.** The
+   forward-filter helper recomputes **all** features — including ADX — over the
+   **same bounded `[i-filter_window+1, i]` window from the same start** on both
+   live and backtest. This is required because ADX uses Wilder recursive
+   smoothing (`_compute_adx_components`), which only converges geometrically:
+   backtest's full-series ADX column and live's trailing-df ADX differ by a
+   seed-forgetting epsilon that a forward-filter can amplify into a flipped
+   near-tie posterior. Computing ADX over an identical bounded window on both
+   sides removes the epsilon. (This changes ADX values *only on the model path*;
+   the hand-rule default path is untouched and stays byte-identical.) Parity claim
+   is "identical **given identical feature inputs**," with the bounded-window rule
+   making the inputs identical — not "identical by construction."
+2. **Windowed-from-init forward-filter is canonical.** Both paths run the filter
+   over a fixed trailing window of `filter_window` bars from the model's
+   stationary init; persistence comes from the transition matrix across the
+   window, not cross-cycle memory (the #879 cycle-reset store stays empty). The
+   backtest cost is **O(n·filter_window)** per window — intentionally, for live
+   parity; a future reader must NOT "optimize" it into a single full-sequential
+   filter (that breaks parity). `filter_window` must wash out the init; calibration
+   picks and validates it.
+3. **`filter_window` drives the OHLCV fetch limit.** The warmed-bar requirement
+   is `filter_window + period + ADX-warmup`. Both fetch-sizing paths —
+   `required_ohlcv_limit` (`shared_tools/regime.py`) and `regimeRequiredOhlcvLimit`
+   (`scheduler/regime_multi_window.go`), plus the store's `OhlcvLimit`
+   (`regime_store.go`) — must add a `filter_window` term (taking the **max across
+   windows**). Without this, live filters over fewer warmed bars than backtest and
+   labels diverge.
+4. **Low-ATR / undefined-feature bars are handled identically.** Today both paths
+   degrade to `ranging_quiet` when `atr<=0` (`regime.py` latest + per-bar loop).
+   Inside a filter window such a bar gets a **defined rule: skip its emission
+   update and carry alpha forward** (apply the transition step, no emission),
+   specified identically in the shared helper so both paths behave the same on
+   exactly these bars.
+5. **Look-ahead safety.** Filter at bar *t* uses only bars ≤ *t*. Standardization
+   `feature_means`/`feature_stds` are **frozen in the model block from the fit
+   window and never recomputed** live or in backtest (recompute = fit-apply
+   look-ahead). The existing N→N+1 gate shift / `_regime_bar_close` snapshot are
+   classifier-agnostic and unchanged; extend `test_backtester_lookahead.py`.
 
 ## Components
 
-### 1. `backtest/regime_diagnostics.py` — measurement harness
+### PR1 — `backtest/regime_diagnostics.py` (measurement)
 
-Follows the `exit_diagnostics.py` / `eval_windows.py` pattern: imports the
-versioned `DATASETS` / `WINDOWS` from `eval_windows.py` for byte-identical
-slices; all aggregation is **pure** (operates on label arrays + return arrays) so
-it is unit-tested without data access. `--json` output.
+Follows the `exit_diagnostics.py` / `eval_windows.py` pattern: imports versioned
+`DATASETS` / `WINDOWS` from `eval_windows.py` for byte-identical slices; all
+aggregation **pure** (label arrays + return arrays) and unit-tested without data;
+`--json`. Computes labels via `compute_regime_composite` under the hand-rule or a
+supplied model, then reports:
+- **Coverage** — count and % of bars per state.
+- **Separation** — forward-return distribution per state at h ∈ {1,4,12}.
+  **Pre-registered primary metric: Kruskal–Wallis H at h=4** (one declared test
+  for the gate). Per-state means / t-stats / hit-rates are **exploratory**,
+  reported with **FDR (Benjamini–Hochberg)** correction — dozens of state×horizon
+  comparisons otherwise manufacture false "significant" states.
+- **Stability** — transition rate, mean dwell per state, total flips.
+- **Significance control** — **block-shuffle** permutation with block length
+  **≥ max(h, mean dwell)** (shorter blocks leave autocorrelation intact and the
+  control falsely reports "real signal"); recompute separation, report collapse.
+- **Yardstick** — unsupervised GMM/HMM on the same features; reports the ceiling
+  the 7-named-state anchoring forgoes (measured, not shipped).
 
-Computes labels for a window via `compute_regime_composite` (no strategy needed —
-labels are a pure function of OHLCV) under either the hand-rule or a supplied
-model, then reports:
-- **Coverage** — count and % of bars per state (catches dead/degenerate states).
-- **Separation** — per state, the forward-return distribution at horizons
-  h ∈ {1, 4, 12} bars: mean, std, t-stat, directional hit-rate; plus one overall
-  cross-state statistic (Kruskal–Wallis H). Correctness check: do `trending_up_*`
-  precede positive returns, `trending_down_*` negative, `ranging_*` near-zero /
-  high-vol?
-- **Stability** — transition rate (% bars the label flips), mean dwell length per
-  state, total flips.
-- **Significance control** — block-shuffle permutation: shuffle labels in blocks
-  (preserving marginal frequencies and local autocorrelation), recompute
-  separation, report how much collapses. Tells us whether separation is real
-  signal or an artifact.
-- **Yardstick** — fit an *unsupervised* GMM (and/or HMM) on the same features,
-  report its separation. Quantifies the cost of anchoring to 7 named states vs
-  letting the data choose — even though we ship the anchored model, we measure
-  against this ceiling.
-
-CLI (no strategy): `--symbol` / `--timeframe` or dataset selection, `--windows`,
+CLI: `--symbol`/`--timeframe` or dataset selection, `--windows`,
 `--model-json <path>` (optional; default = hand-rule), `--horizons`, `--json`.
 
-### 2. `backtest/regime_calibrate.py` — fit + walk-forward validation
+### PR1 — `backtest/regime_calibrate.py` (fit + walk-forward validation)
 
-Fits the label-anchored HMM (closed-form) on an **in-sample** window and emits
-the model JSON. Validates separation + stability on a **held-out** window against
-the hand-rule and the shuffle baseline (walk-forward; the model never sees the
-held-out window). Emits the proposed model for review; does **not** mutate live
-defaults. Reuses `regime_diagnostics.py`'s pure scorers so fit and score share
-identical logic.
+Closed-form fit of the label-anchored HMM on an **in-sample** window; emits the
+model JSON. Validates on a **held-out** window (model never sees it) against the
+hand-rule and shuffle baselines, reusing `regime_diagnostics.py`'s pure scorers.
+Emits the proposed model for review; does **not** mutate live defaults.
 
-CLI: `--symbol` / `--timeframe`, `--in-sample` / `--held-out` windows,
-`--filter-window`, `--out <model.json>`, `--json` (validation report).
+**Degenerate states:** a hand-rule state with too few bars to fit a stable
+Gaussian gets a **variance floor + shrinkage**; if still degenerate the state is
+flagged and its emission likelihood is set to a **calibrated constant on the same
+log-density scale** as the Gaussian emissions (an unscaled 0/1 indicator would
+make the state either never- or always-selected against unbounded Gaussian
+densities). Calibration warns and reports per-state bar counts.
 
-### 3. `shared_tools/regime.py` — forward-filter inference path
+CLI: `--symbol`/`--timeframe`, `--in-sample`/`--held-out`, `--filter-window`,
+`--out <model.json>`, `--json`.
 
-- New inference helper (the windowed forward-filter) shared by
-  `latest_regime_composite` (live) and `compute_regime_composite` (backtest).
-- **Opt-in** via an optional `model` block on the composite windows spec. When
-  the block is **absent, behavior is byte-identical to today's hand-rule** (live
-  and backtest) — preserves #1058 parity and de-risks rollout.
-- Validation: when present, the `model` block's `states` must equal
-  `VALID_LABELS_COMPOSITE`; feature list must match; matrix shapes consistent.
+**Ship/no-ship gate (decision criterion):** adopt a fitted model for a
+strategy/window **only if**, on the held-out window, it (a) does **not** reduce
+the primary separation metric (KW-H at h=4) beyond noise, **and** (b) **improves
+stability** (lower transition rate / longer mean dwell) materially. Otherwise the
+hand-rule stands.
+
+### PR2 — `shared_tools/regime.py` (forward-filter inference path)
+
+- New windowed-forward-filter helper, shared by `latest_regime_composite` (live)
+  and `compute_regime_composite` (backtest), computing bounded-window features per
+  invariant 1.
+- **Opt-in** via an optional `model` block on the composite windows spec.
+  **Absent → byte-identical to today's hand-rule**, live and backtest (#1058
+  parity preserved).
+- `fitted_on` guard: when a strategy's `(symbol, timeframe)` ≠ the model's
+  `fitted_on`, **warn loudly** (mis-applied model = silent systematic mislabel
+  into the SL/TP/gate money path).
 
 #### `model` block schema (additive, opt-in)
 
@@ -138,80 +169,75 @@ CLI: `--symbol` / `--timeframe`, `--in-sample` / `--held-out` windows,
 {
   "classifier": "composite",
   "period": 48,
-  "thresholds": { /* unchanged; still used to generate anchor labels at fit time */ },
+  "thresholds": { /* unchanged; generates anchor labels at fit time */ },
   "model": {
-    "type": "label_anchored_hmm",
-    "version": 1,
-    "features": ["return_eff", "range_eff", "efficiency", "adx"],
-    "feature_means": [/* 4, standardization */],
-    "feature_stds":  [/* 4 */],
+    "type": "label_anchored_hmm", "version": 1,
+    "features": ["return_eff","range_eff","efficiency","adx"],
+    "feature_means": [/*4, frozen from fit*/], "feature_stds": [/*4*/],
     "states": [/* the 7 labels, fixed order */],
     "emissions": [ { "mean": [/*4*/], "var": [/*4 diag*/] }, /* ...7 */ ],
-    "transition": [ [/*7*/], /* ...7 rows */ ],
-    "init": [/*7 stationary dist*/],
+    "transition": [ [/*7*/], /* ...7 */ ], "init": [/*7 stationary*/],
     "filter_window": 64,
     "fitted_on": { "symbol": "BTC/USDT", "timeframe": "1h", "window": "is" }
   }
 }
 ```
 
-### Go side (sync surface)
+### PR2 — Go spec surface (corrected hook points)
 
-The composite spec/threshold surface must carry the `model` block opaquely:
-- Add the `model` field to the Go composite-window/threshold struct (the
-  `RegimeCompositeThresholds` neighborhood), carried as opaque JSON
-  (`json.RawMessage`) — Go does **not** reimplement inference.
-- Register `model` so the **unknown-key guard** accepts it (else config load
-  rejects it).
-- Include `model` in `resolvedForEmit` so `--config` backtests receive the same
-  block live uses (the #1058 / #1025 parity path).
-- Default-absent → zero behavior change; no `config_version` bump required (the
-  field is additive and optional, mirroring #1048's `CircuitBreaker` pattern).
+- Add `Model json.RawMessage` to **`RegimeWindowSpec`** (`scheduler/regime_window_spec.go`,
+  sibling of `Thresholds`) — **not** the `RegimeCompositeThresholds` struct.
+  Rationale: `RegimeWindowsMap.UnmarshalJSON` does **not** set
+  `DisallowUnknownFields`, so an unregistered `model` key is **silently dropped**,
+  and the unknown-key guard (`validateStrategyJSONKeys`) only covers `strategies[]`,
+  never `regime.windows`. A dropped `model` → live runs the hand-rule while
+  backtest runs the model = silent parity break.
+- **Fail-closed structural validation at config load** (resolves the #879
+  fail-open trap): Go validates the block's *structure* — `states` ==
+  `VALID_LABELS_COMPOSITE`, `transition` is 7×7, `emissions` length 7, vector
+  lengths match `features` — and **rejects** a malformed block at load. This is
+  shape-checking, not reimplementing inference; without it a mis-shaped block
+  becomes a Python parse failure that routes through the #879 store → empty
+  payload → **entries fail open (ungated)**, the inverse of safe for a money-path
+  classifier.
+- Thread `model` into the emitted windows spec (`resolvedForEmit` /
+  `regimeWindowsSpecJSON`) so `--config` backtests receive the same block live
+  uses, and into the fetch-limit sizing (invariant 3).
+- Default-absent → zero behavior change; additive/optional field, **no
+  `config_version` bump** (mirrors #1048 `CircuitBreaker *bool`).
 
-## Decision criterion
+## Edge cases / fail-closed
 
-Ship the fitted model into a strategy's config **only if** it beats the hand-rule
-on held-out separation **and** stability (lower whipsaw, separation not worse).
-Otherwise the hand-rule stands. The harness decides — not faith. The model is
-opt-in per strategy/window via the `model` block; nothing changes for configs
-that don't adopt it.
-
-## Error handling / edge cases
-
-- Empty / too-short window (`len < filter_window` or `< period`) → fall back to
-  the hand-rule label (or `ranging_quiet` as today when ATR ≤ 0); never raise.
-- Degenerate emission (a hand-rule state with too few bars to fit a Gaussian) →
-  Laplace/shrinkage on variance; if still degenerate, that state's emission falls
-  back to the hand-rule region indicator. Calibration warns and reports coverage.
-- Malformed `model` block (wrong `states`, shape mismatch) → reject at config
-  load with a clear message (fail closed; do not silently run the hand-rule).
+- Empty/short window (`len < filter_window+period`) → hand-rule label (or
+  `ranging_quiet` when ATR ≤ 0); never raise.
 - Singular covariance avoided by diagonal cov + variance floor.
+- Malformed `model` block → **rejected at Go config load** (fail closed), not
+  silently degraded.
 
 ## Testing
 
 Python:
-- `shared_tools/` — windowed forward-filter unit tests; **live/backtest parity**
-  (same model + OHLCV → identical label sequence); **default-absent byte-identical**
-  to the hand-rule; look-ahead (filter at *t* independent of bars > *t*); fit
-  determinism (closed-form, no RNG); degenerate-state fallback.
-- `backtest/tests/` — `test_regime_diagnostics.py` (pure scorers on synthetic
-  label/return arrays: separation, shuffle control, stability); calibrate
-  walk-forward smoke; extend `test_backtester_lookahead.py` coverage for the
-  model path.
+- `shared_tools/` — windowed forward-filter units; **live/backtest parity** (same
+  model + OHLCV → identical label sequence, incl. bounded-window ADX);
+  **default-absent byte-identical** to the hand-rule; look-ahead (filter at *t*
+  independent of bars > *t*; standardization frozen); low-ATR carry-alpha on both
+  paths; fit determinism; degenerate-state fallback scaling.
+- `backtest/tests/` — `test_regime_diagnostics.py` (pure scorers: KW-H, FDR,
+  block-shuffle with the length rule, stability) on synthetic arrays; calibrate
+  walk-forward smoke; extend `test_backtester_lookahead.py` for the model path.
 
 Go:
-- `model` block round-trips spec parse + unknown-key guard accepts it +
-  `resolvedForEmit` includes it; malformed block rejected; default-absent config
-  unchanged (existing composite tests stay green).
+- `Model` round-trips `RegimeWindowSpec` parse and survives `resolvedForEmit`;
+  malformed block (bad `states`, wrong shapes) **rejected at load**; fetch-limit
+  includes `filter_window` (max across windows); default-absent config unchanged
+  (existing composite tests stay green).
 
 ## Out of scope (deferred)
 
-- Full unsupervised re-derivation that lets the data choose the number/shape of
-  states (Approach C) — measured as a yardstick only.
-- Auto-adopting a fitted model into live defaults — this ships the *tooling* and
-  the opt-in path; promoting a specific model per strategy is a follow-up.
-- Online/cross-cycle posterior carry — the windowed-from-init filter makes it
-  unnecessary for parity.
+- Full unsupervised re-derivation (Approach C) — yardstick only.
+- Auto-promoting a fitted model into live defaults — PR2 ships the opt-in path;
+  per-strategy adoption is a follow-up gated on the harness result.
+- Online/cross-cycle posterior carry — windowed-from-init makes it unnecessary.
 
 ---
 LLM: Opus 4.8 | high | Harness: Claude Code

--- a/docs/superpowers/specs/2026-06-19-regime-accuracy-design.md
+++ b/docs/superpowers/specs/2026-06-19-regime-accuracy-design.md
@@ -1,0 +1,217 @@
+# 7-State Regime Accuracy: Measurement + Label-Anchored HMM Classifier
+
+**Issue:** #1065
+**Status:** Design approved, pending spec review
+**Approach:** B — model with named states (keep the 7 semantic labels; replace hand-thresholds + per-bar independence with a fitted transition-prior model)
+
+## Problem
+
+The composite 7-state regime classifier (#795 / #1058) labels each bar one of
+`trending_up_clean`, `trending_up_choppy`, `trending_down_clean`,
+`trending_down_choppy`, `ranging_quiet`, `ranging_volatile`,
+`ranging_directional`. It is a hand-tuned decision tree (`map_composite_label`)
+over four ATR-normalized features — `return_eff`, `range_eff`, `efficiency`,
+`adx` — with global constant thresholds (`_DEFAULT_COMPOSITE_THRESHOLDS`).
+
+Two gaps:
+1. **Accuracy is never measured.** No validation harness, no forward-return
+   separation test, no stability/whipsaw metric. "Accuracy" is undefined today.
+2. **The classifier is structurally weak.** Thresholds are global constants (not
+   calibrated per asset/timeframe), and each bar is classified independently with
+   no persistence model, so labels can whipsaw bar-to-bar.
+
+## Goal
+
+Define and measure regime quality, then improve it — without breaking the
+semantic-label contract that config-keyed SL/TP/gate ladders depend on.
+
+Two notions of "accuracy", both measured:
+- **Separation** (the economic notion): do the 7 states have distinct forward
+  return / volatility distributions, and in the right direction? Is that
+  separation real signal or an autocorrelation artifact?
+- **Stability:** does the label persist sensibly, or whipsaw?
+
+## Approach: label-anchored Gaussian HMM
+
+Keep the 7 semantic labels and the existing four features. Replace the hand
+decision tree and per-bar independence with a Hidden Markov Model whose states
+are **pinned to the 7 labels** (so state identity stays semantic and config keys
+keep working):
+
+- **Emissions** — per-state Gaussian, fit by maximum likelihood on the
+  (standardized) feature vectors of bars the *current hand-rule* labels as that
+  state. The hand-rule becomes the labeling prior; the model refines hard cutoffs
+  into soft, data-fit boundaries. Diagonal covariance (4 features, keep params
+  low and the fit robust).
+- **Transitions** — the 7×7 matrix counted from the hand-rule label sequence,
+  Laplace-smoothed and row-normalized. This *is* the persistence layer:
+  data-calibrated, replacing the arbitrary smoothing-window hack.
+- **Inference** — causal **forward-filter** only (never Viterbi / forward-
+  backward, which peek at the future). At bar *t*:
+  `alpha_t(j) ∝ emission(x_t | j) · Σ_i alpha_{t-1}(i) · A[i,j]`, normalized.
+  `label_t = argmax_j alpha_t(j)`; `confidence_t = max_j alpha_t(j)` (a new
+  output that lets downstream gate on uncertainty).
+
+Fitting is **closed-form** (Gaussian MLE + transition counts) because the states
+are supervised by the hand-rule labels — no EM, no `hmmlearn`, no new dependency.
+
+### Parity & look-ahead (the load-bearing invariants)
+
+- **Canonical inference is the *windowed* forward-filter:** run the filter over a
+  fixed trailing window of `filter_window` bars, initialized at the model's
+  stationary distribution. This produces the label for the window's last bar.
+  - **Backtest** (`compute_regime_composite`): for each bar *i*, run the windowed
+    filter over bars `[i-filter_window+1, i]`.
+  - **Live** (`latest_regime_composite`): run the windowed filter over the last
+    `filter_window` bars of the trailing df.
+  - Both call **one shared helper** with identical inputs → labels are identical
+    by construction. No cross-cycle state is needed (the #879 cycle-reset store
+    stays empty-per-cycle); persistence comes from the transition matrix applied
+    across the window, not from remembered emitted labels.
+  - `filter_window` must be long enough for the init to wash out (HMM geometric
+    forgetting); calibration picks and validates it.
+- **Look-ahead safety:** the filter at bar *t* uses only bars ≤ *t*. The existing
+  N→N+1 gate shift and `_regime_bar_close` snapshot are classifier-agnostic and
+  unchanged. Covered by `backtest/tests/test_backtester_lookahead.py`.
+- **Features are unchanged:** the HMM consumes the same per-bar feature tuple the
+  hand-rule consumes (`return_eff`, `range_eff`, `efficiency`, `adx`, with the
+  `COMPOSITE_ADX_PERIOD_CAP` ADX and full-`period` efficiency). Only the
+  tuple→label mapping changes.
+
+## Components
+
+### 1. `backtest/regime_diagnostics.py` — measurement harness
+
+Follows the `exit_diagnostics.py` / `eval_windows.py` pattern: imports the
+versioned `DATASETS` / `WINDOWS` from `eval_windows.py` for byte-identical
+slices; all aggregation is **pure** (operates on label arrays + return arrays) so
+it is unit-tested without data access. `--json` output.
+
+Computes labels for a window via `compute_regime_composite` (no strategy needed —
+labels are a pure function of OHLCV) under either the hand-rule or a supplied
+model, then reports:
+- **Coverage** — count and % of bars per state (catches dead/degenerate states).
+- **Separation** — per state, the forward-return distribution at horizons
+  h ∈ {1, 4, 12} bars: mean, std, t-stat, directional hit-rate; plus one overall
+  cross-state statistic (Kruskal–Wallis H). Correctness check: do `trending_up_*`
+  precede positive returns, `trending_down_*` negative, `ranging_*` near-zero /
+  high-vol?
+- **Stability** — transition rate (% bars the label flips), mean dwell length per
+  state, total flips.
+- **Significance control** — block-shuffle permutation: shuffle labels in blocks
+  (preserving marginal frequencies and local autocorrelation), recompute
+  separation, report how much collapses. Tells us whether separation is real
+  signal or an artifact.
+- **Yardstick** — fit an *unsupervised* GMM (and/or HMM) on the same features,
+  report its separation. Quantifies the cost of anchoring to 7 named states vs
+  letting the data choose — even though we ship the anchored model, we measure
+  against this ceiling.
+
+CLI (no strategy): `--symbol` / `--timeframe` or dataset selection, `--windows`,
+`--model-json <path>` (optional; default = hand-rule), `--horizons`, `--json`.
+
+### 2. `backtest/regime_calibrate.py` — fit + walk-forward validation
+
+Fits the label-anchored HMM (closed-form) on an **in-sample** window and emits
+the model JSON. Validates separation + stability on a **held-out** window against
+the hand-rule and the shuffle baseline (walk-forward; the model never sees the
+held-out window). Emits the proposed model for review; does **not** mutate live
+defaults. Reuses `regime_diagnostics.py`'s pure scorers so fit and score share
+identical logic.
+
+CLI: `--symbol` / `--timeframe`, `--in-sample` / `--held-out` windows,
+`--filter-window`, `--out <model.json>`, `--json` (validation report).
+
+### 3. `shared_tools/regime.py` — forward-filter inference path
+
+- New inference helper (the windowed forward-filter) shared by
+  `latest_regime_composite` (live) and `compute_regime_composite` (backtest).
+- **Opt-in** via an optional `model` block on the composite windows spec. When
+  the block is **absent, behavior is byte-identical to today's hand-rule** (live
+  and backtest) — preserves #1058 parity and de-risks rollout.
+- Validation: when present, the `model` block's `states` must equal
+  `VALID_LABELS_COMPOSITE`; feature list must match; matrix shapes consistent.
+
+#### `model` block schema (additive, opt-in)
+
+```jsonc
+{
+  "classifier": "composite",
+  "period": 48,
+  "thresholds": { /* unchanged; still used to generate anchor labels at fit time */ },
+  "model": {
+    "type": "label_anchored_hmm",
+    "version": 1,
+    "features": ["return_eff", "range_eff", "efficiency", "adx"],
+    "feature_means": [/* 4, standardization */],
+    "feature_stds":  [/* 4 */],
+    "states": [/* the 7 labels, fixed order */],
+    "emissions": [ { "mean": [/*4*/], "var": [/*4 diag*/] }, /* ...7 */ ],
+    "transition": [ [/*7*/], /* ...7 rows */ ],
+    "init": [/*7 stationary dist*/],
+    "filter_window": 64,
+    "fitted_on": { "symbol": "BTC/USDT", "timeframe": "1h", "window": "is" }
+  }
+}
+```
+
+### Go side (sync surface)
+
+The composite spec/threshold surface must carry the `model` block opaquely:
+- Add the `model` field to the Go composite-window/threshold struct (the
+  `RegimeCompositeThresholds` neighborhood), carried as opaque JSON
+  (`json.RawMessage`) — Go does **not** reimplement inference.
+- Register `model` so the **unknown-key guard** accepts it (else config load
+  rejects it).
+- Include `model` in `resolvedForEmit` so `--config` backtests receive the same
+  block live uses (the #1058 / #1025 parity path).
+- Default-absent → zero behavior change; no `config_version` bump required (the
+  field is additive and optional, mirroring #1048's `CircuitBreaker` pattern).
+
+## Decision criterion
+
+Ship the fitted model into a strategy's config **only if** it beats the hand-rule
+on held-out separation **and** stability (lower whipsaw, separation not worse).
+Otherwise the hand-rule stands. The harness decides — not faith. The model is
+opt-in per strategy/window via the `model` block; nothing changes for configs
+that don't adopt it.
+
+## Error handling / edge cases
+
+- Empty / too-short window (`len < filter_window` or `< period`) → fall back to
+  the hand-rule label (or `ranging_quiet` as today when ATR ≤ 0); never raise.
+- Degenerate emission (a hand-rule state with too few bars to fit a Gaussian) →
+  Laplace/shrinkage on variance; if still degenerate, that state's emission falls
+  back to the hand-rule region indicator. Calibration warns and reports coverage.
+- Malformed `model` block (wrong `states`, shape mismatch) → reject at config
+  load with a clear message (fail closed; do not silently run the hand-rule).
+- Singular covariance avoided by diagonal cov + variance floor.
+
+## Testing
+
+Python:
+- `shared_tools/` — windowed forward-filter unit tests; **live/backtest parity**
+  (same model + OHLCV → identical label sequence); **default-absent byte-identical**
+  to the hand-rule; look-ahead (filter at *t* independent of bars > *t*); fit
+  determinism (closed-form, no RNG); degenerate-state fallback.
+- `backtest/tests/` — `test_regime_diagnostics.py` (pure scorers on synthetic
+  label/return arrays: separation, shuffle control, stability); calibrate
+  walk-forward smoke; extend `test_backtester_lookahead.py` coverage for the
+  model path.
+
+Go:
+- `model` block round-trips spec parse + unknown-key guard accepts it +
+  `resolvedForEmit` includes it; malformed block rejected; default-absent config
+  unchanged (existing composite tests stay green).
+
+## Out of scope (deferred)
+
+- Full unsupervised re-derivation that lets the data choose the number/shape of
+  states (Approach C) — measured as a yardstick only.
+- Auto-adopting a fitted model into live defaults — this ships the *tooling* and
+  the opt-in path; promoting a specific model per strategy is a follow-up.
+- Online/cross-cycle posterior carry — the windowed-from-init filter makes it
+  unnecessary for parity.
+
+---
+LLM: Opus 4.8 | high | Harness: Claude Code

--- a/shared_tools/regime.py
+++ b/shared_tools/regime.py
@@ -327,6 +327,40 @@ def compute_regime_composite(
     return result
 
 
+def composite_feature_matrix(
+    df: pd.DataFrame,
+    period: int,
+    thresholds: dict[str, float] | None = None,
+) -> pd.DataFrame:
+    """Per-bar composite feature tuple (return_eff, range_eff, efficiency, adx).
+
+    Additive, offline-only (#1065 PR1). Mirrors compute_regime_composite's loop
+    but emits the features map_composite_label consumes instead of the label, so
+    an offline model fits on byte-consistent inputs. Warmup (i < period) and
+    atr<=0 bars are NaN.
+    """
+    th = {**_DEFAULT_COMPOSITE_THRESHOLDS, **(thresholds or {})}
+    cols = ["return_eff", "range_eff", "efficiency", "adx"]
+    out = pd.DataFrame(float("nan"), index=df.index, columns=cols)
+    n = len(df)
+    if n == 0:
+        return out
+    adx_period = min(period, COMPOSITE_ADX_PERIOD_CAP)
+    adx_df = compute_regime(df, period=adx_period, adx_threshold=th["adx"])
+    atr_series = standard_atr(df, period=period)
+    for i in range(period, n):
+        window = df.iloc[i - period + 1 : i + 1]
+        atr_val = float(atr_series.iloc[i]) if i < len(atr_series) else 0.0
+        if not (atr_val > 0):
+            continue
+        eff = _composite_efficiency_metrics(window, atr_val, period)
+        out.iat[i, 0] = eff["return_eff"]
+        out.iat[i, 1] = eff["range_eff"]
+        out.iat[i, 2] = eff["efficiency"]
+        out.iat[i, 3] = float(adx_df["adx"].iloc[i])
+    return out
+
+
 def latest_regime(
     df: pd.DataFrame,
     period: int = 14,

--- a/shared_tools/test_regime_features.py
+++ b/shared_tools/test_regime_features.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pandas as pd
+from regime import (
+    composite_feature_matrix,
+    compute_regime_composite,
+    map_composite_label,
+    _DEFAULT_COMPOSITE_THRESHOLDS,
+)
+
+
+def _synth(n=300, seed=1):
+    rng = np.random.default_rng(seed)
+    steps = rng.normal(0, 1, n).cumsum()
+    close = 100 + steps
+    high = close + np.abs(rng.normal(0, 0.5, n))
+    low = close - np.abs(rng.normal(0, 0.5, n))
+    idx = pd.date_range("2024-01-01", periods=n, freq="1h")
+    return pd.DataFrame({"open": close, "high": high, "low": low, "close": close}, index=idx)
+
+
+def test_feature_matrix_reproduces_handrule_labels():
+    df = _synth()
+    period = 48
+    th = dict(_DEFAULT_COMPOSITE_THRESHOLDS)
+    feats = composite_feature_matrix(df, period, th)
+    labels = compute_regime_composite(df, period=period, thresholds=th)["regime"]
+    assert list(feats.columns) == ["return_eff", "range_eff", "efficiency", "adx"]
+    assert feats.iloc[:period].isna().all().all()  # warmup is NaN
+    for i in range(period, len(df)):
+        row = feats.iloc[i]
+        if row.isna().any():
+            continue  # atr<=0 bar: labeler leaves default, matrix is NaN — consistent
+        got = map_composite_label(row["return_eff"], row["adx"], row["range_eff"], row["efficiency"], th)
+        assert got == labels.iloc[i], f"bar {i}: {got} != {labels.iloc[i]}"


### PR DESCRIPTION
## What this is

PR1 of #1065 (harness-first split). It ships the **read-only measurement + calibration harness** for the 7-state composite regime classifier, plus the offline machinery for a label-anchored Gaussian HMM. **Nothing live or Go-side is touched** — all parity-sensitive integration is deferred to PR2.

Motivation: the composite 7-state classifier (#795/#1058) is a hand-tuned decision tree whose accuracy was **never measured** — no forward-return separation test, no stability/whipsaw metric, global constant thresholds, per-bar independence. This PR builds the instrument to measure it and to fit a candidate model, so the decision to change the live classifier is made on data, not faith.

## What's in it

- `shared_tools/regime.py` — **one additive** function `composite_feature_matrix` (per-bar `return_eff`/`range_eff`/`efficiency`/`adx`); consistency-tested to reproduce the existing labeler's labels exactly. No existing function modified.
- `backtest/regime_stats.py` — pure-numpy `rank_data`, `kruskal_h` (tie-corrected statistic), `benjamini_hochberg`. No scipy/sklearn.
- `backtest/regime_diagnostics.py` — pure scorers (coverage, forward-return **separation** at h∈{1,4,12}, **stability**, **block-shuffle permutation significance**, **per-state FDR**, numpy **k-means yardstick**) + CLI.
- `backtest/regime_hmm.py` — closed-form `fit_label_anchored_hmm` (Gaussian MLE on hand-rule labels + Laplace-smoothed transition matrix + stationary init; no EM, no new dependency) and a **causal windowed forward-filter** (look-ahead-safe, NaN-carry).
- `backtest/regime_calibrate.py` — walk-forward fit (in-sample) → score (held-out) → **ship/no-ship gate** (`gate_verdict`): adopt a model only if held-out separation is not materially worse AND stability improves.

## Result from the live smoke

Run on real BTC/USDT 1h (is→oos): **`ship: false`** — model KW-H 3.25 vs hand-rule 13.40 (separation collapsed out-of-sample; stability did improve). The gate correctly declines to ship. This is consistent with the spec's pre-registered **circularity ceiling**: emissions are fit on the hand-rule's own labels, so separation lift is structurally bounded and the only material gain is whipsaw reduction. The harness works; whether a model is worth promoting is now an empirical question PR2 answers.

## Scope boundary (PR2)

Deferred, by design: the live forward-filter wiring in `regime.py`, the opt-in `model` block on `RegimeWindowSpec`, **Go fail-closed structural validation** (a malformed block must reject at load, not fail-open through the #879 store), `filter_window` in the OHLCV fetch sizing, **bounded-window ADX parity** between live and backtest, and identical low-ATR handling on both paths. Also tracked for PR2: a `kruskal_h` reference-value test, the HMM fit's mid-series-NaN transition-gap, and re-validating any fitted model under bounded-window ADX before promotion.

## Testing

24/24 tests across five files (pure scorers/fit/filter unit-tested without data access; live/backtest-relevant invariants — look-ahead safety, NaN-carry, feature/label consistency, warmup-mask fairness — covered). numpy+pandas only; deterministic (seeded RNG); read-only.

Built via brainstorming → spec (v2, after an adversarial spec review folded in 5 blockers) → plan → subagent-driven execution with per-task and a whole-branch review.

Part of #1065 (does not close it — PR2 delivers the live classifier).

---
LLM: Opus 4.8 | high | Harness: Claude Code
