### PR TITLE
fix(#1067): backtester --config falls back to args[0] for open strategy name

### DIFF
--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -377,11 +377,29 @@ def load_strategy_config(config_path: str, strategy_id: str,
     for sc in cfg.get("strategies", []) or []:
         if sc.get("id") != strategy_id:
             continue
-        open_ref = sc.get("open_strategy") or {}
-        if not isinstance(open_ref, dict) or not open_ref.get("name"):
+        open_ref = sc.get("open_strategy")
+        if not isinstance(open_ref, dict):
+            open_ref = {}
+        # #1067: mirror the live daemon's open-strategy resolution
+        # (effectiveOpenStrategy, strategy_composition.go): prefer
+        # open_strategy.name, else fall back to the positional args[0] strategy
+        # arg. `go-trader init` emits the args-form (args[0]=concept name) with an
+        # empty open_strategy.name, and the v13->v15 migration only backfills
+        # open_strategy.name for pre-v13 files — so an init-stamped v15 config
+        # (and any hand-edited args-form config) reaches here name-less. The live
+        # daemon runs these fine via this same args[0] fallback, so the backtester
+        # must resolve the identical name instead of rejecting, or backtest and
+        # live silently diverge on a config the daemon accepts.
+        open_name = str(open_ref.get("name") or "").strip()
+        if not open_name:
+            args_list = sc.get("args")
+            if isinstance(args_list, list) and args_list:
+                open_name = str(args_list[0] or "").strip()
+        if not open_name:
             raise ValueError(
-                f"{config_path}: strategy {strategy_id!r} has no open_strategy.name; "
-                f"the migrated config should always populate it."
+                f"{config_path}: strategy {strategy_id!r} has neither "
+                f"open_strategy.name nor a positional args[0] strategy arg to "
+                f"resolve the open strategy from."
             )
         regime_cfg = cfg.get("regime") or {}
         if not isinstance(regime_cfg, dict):
@@ -551,7 +569,7 @@ def load_strategy_config(config_path: str, strategy_id: str,
             )
         return {
             "open_strategy": {
-                "name": open_ref["name"],
+                "name": open_name,
                 "params": dict(open_ref.get("params") or {}),
             },
             "close_strategies": close_refs,

--- a/backtest/tests/test_strategy_refs_641.py
+++ b/backtest/tests/test_strategy_refs_641.py
@@ -177,6 +177,91 @@ def test_load_strategy_config_reads_single_close_strategy(tmp_path):
     assert kwargs["close_strategies"][0]["params"]["tp_tiers"][1]["atr_multiple"] == 3.0
 
 
+# ─── #1067: open name falls back to args[0] (init/legacy args-form configs) ───
+#
+# `go-trader init` (and `init --json`) emit each strategy in the positional
+# args-form — args[0]=concept name, no open_strategy.name — and stamp the file
+# config_version=15. The v13->v15 migration only backfills open_strategy.name
+# for pre-v13 files, so init's v15 config reaches load_strategy_config with an
+# empty name. The live daemon runs these fine via effectiveOpenStrategy's
+# args[0] fallback (strategy_composition.go); the backtester --config reader
+# must resolve the identical name instead of rejecting, or backtest and live
+# diverge on a config the daemon accepts.
+
+
+def _init_shaped_strategy():
+    """The exact strategy shape emitted by generateConfig (init.go), captured
+    verbatim from `go-trader init --json '{...,"SpotStrategies":["momentum"]}'`:
+    args carry the concept name, open_strategy.name is empty."""
+    return {
+        "id": "momentum-btc",
+        "type": "spot",
+        "platform": "binanceus",
+        "script": "shared_scripts/check_strategy.py",
+        "args": ["momentum", "BTC/USDT", "1h"],
+        "open_strategy": {"name": ""},
+        "capital": 1000,
+        "max_drawdown_pct": 5,
+        "interval_seconds": 3600,
+    }
+
+
+def test_load_strategy_config_init_config_falls_back_to_args0(tmp_path):
+    # Round-trip the init-generated shape through the --config reader: an empty
+    # open_strategy.name must resolve to args[0] rather than raising.
+    path = _write_config(tmp_path, version=15, strategies=[_init_shaped_strategy()])
+    kwargs = run_backtest.load_strategy_config(path, "momentum-btc")
+    assert kwargs["open_strategy"]["name"] == "momentum"
+    assert kwargs["open_strategy"]["params"] == {}
+    assert kwargs["close_strategies"] == []
+
+
+def test_load_strategy_config_missing_open_strategy_key_falls_back(tmp_path):
+    # No open_strategy key at all (the inverse of the empty-name case) still
+    # resolves from args[0].
+    path = _write_config(tmp_path, version=15, strategies=[
+        {"id": "spot-x", "type": "spot",
+         "args": ["mean_reversion", "ETH/USDT", "1h"]},
+    ])
+    kwargs = run_backtest.load_strategy_config(path, "spot-x")
+    assert kwargs["open_strategy"]["name"] == "mean_reversion"
+
+
+def test_load_strategy_config_open_name_wins_over_args0(tmp_path):
+    # Precedence parity with effectiveOpenStrategy: when both are present and
+    # differ, the explicit open_strategy.name wins over the positional args[0].
+    path = _write_config(tmp_path, version=15, strategies=[
+        {"id": "hl-x", "type": "perps",
+         "args": ["legacy_positional", "BTC/USDT", "1h"],
+         "open_strategy": {"name": "tema_cross_bd", "params": {"short_period": 5}}},
+    ])
+    kwargs = run_backtest.load_strategy_config(path, "hl-x")
+    assert kwargs["open_strategy"]["name"] == "tema_cross_bd"
+    assert kwargs["open_strategy"]["params"]["short_period"] == 5
+
+
+def test_load_strategy_config_whitespace_open_name_falls_back(tmp_path):
+    # A whitespace-only name is not a name (effectiveOpenStrategy TrimSpaces it);
+    # fall through to args[0] rather than carrying " " as the open strategy.
+    path = _write_config(tmp_path, version=15, strategies=[
+        {"id": "spot-y", "type": "spot",
+         "args": ["momentum", "BTC/USDT", "1h"],
+         "open_strategy": {"name": "   "}},
+    ])
+    kwargs = run_backtest.load_strategy_config(path, "spot-y")
+    assert kwargs["open_strategy"]["name"] == "momentum"
+
+
+def test_load_strategy_config_rejects_when_no_open_name_and_no_args(tmp_path):
+    # Neither an open_strategy.name nor a positional args[0] to fall back to:
+    # the open strategy is genuinely unresolvable, so reject loudly.
+    path = _write_config(tmp_path, version=15, strategies=[
+        {"id": "spot-z", "type": "spot", "args": [], "open_strategy": {"name": ""}},
+    ])
+    with pytest.raises(ValueError, match="neither open_strategy.name nor"):
+        run_backtest.load_strategy_config(path, "spot-z")
+
+
 # ─── #866: --defaults system|user (user_close_defaults injection) ────────────
 
 


### PR DESCRIPTION
## Summary

`./go-trader init` (and `init --json`) emit each strategy in the positional **args-form** — `args[0]` is the concept name, `open_strategy.name` is empty — and stamp the file `config_version=15`. The v13→v15 migration only backfills `open_strategy.name` for **pre-v13** files, so an init-stamped v15 config reaches the backtester `--config` reader name-less and was hard-rejected:

```
ValueError: <config>: strategy 'momentum-btc' has no open_strategy.name; the migrated config should always populate it.
```

The **live daemon** runs these configs fine — every consumer resolves the open strategy via `effectiveOpenStrategy` (`scheduler/strategy_composition.go:51`), which prefers `open_strategy.name` and **falls back to `args[0]`**. The backtester `load_strategy_config` reader was the lone path lacking that fallback, so backtest diverged from live on a config the daemon accepts.

## Fix (Option 2 — parity with live)

`backtest/run_backtest.py` `load_strategy_config` now mirrors `effectiveOpenStrategy`: prefer `open_strategy.name`, else fall back to `args[0]`, and raise only when **neither** exists. The returned `open_strategy.name` uses the resolved value.

Chose Option 2 over Option 1 (emit `open_strategy.name` in `generateConfig`) because the live runtime already tolerates the args-form everywhere via the fallback — so Option 2 fixes init configs **and** any hand-edited/legacy args-form config, while Option 1 alone would leave that broader class still rejected (migration never re-touches a v15-stamped file).

## Tests

5 regression tests added to `backtest/tests/test_strategy_refs_641.py`:
1. Round-trips the verbatim `go-trader init` shape (`args:[name,…]`, `open_strategy:{"name":""}`) through `load_strategy_config` → resolves `args[0]`.
2. Missing `open_strategy` key entirely → falls back to `args[0]`.
3. Explicit `open_strategy.name` wins over `args[0]` (precedence parity).
4. Whitespace-only name → falls back (TrimSpace parity).
5. Neither name nor args → still raises.

Verified: reproduced the original failure against a real `init --json` config, confirmed it now backtests; full backtest suite green (598 passed).

Closes #1067

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code

https://claude.ai/code/session_01CnfoggdxDbHXCmA277WPbU