### PR TITLE
feat(#1078): re-target the regime gate to forward-volatility separation (PR1)

### DIFF
--- a/backtest/regime_calibrate.py
+++ b/backtest/regime_calibrate.py
@@ -19,20 +19,29 @@ def gate_verdict(handrule_report: dict, model_report: dict, primary: str = "h4")
     md_p = model_report[primary]["significance"]["p_value"]
     hr_tr = handrule_report["stability"]["transition_rate"]
     md_tr = model_report["stability"]["transition_rate"]
+    # The forward target the reports were scored on (#1078 re-targets this from "returns" to
+    # "volatility"). The gate logic is target-agnostic — it scores between-state separation of
+    # whatever forward variable score_labels stamped — but we surface it so a verdict can never
+    # be misread as a directional (return) result when it is a volatility result.
+    target = model_report.get("target") or handrule_report.get("target")
     # Absolute floor: the relative KW-H tolerance is meaningless when the incumbent itself
     # separates ~nothing (threshold collapses toward 0, and any model — including a
     # near-constant-label one that also maximizes the stability arm — passes). So require
-    # the model's OWN forward-return separation to be statistically real (block-shuffle
+    # the model's OWN forward separation to be statistically real (block-shuffle
     # permutation p <= alpha), not merely "not much worse than a weak incumbent".
     model_separation_real = md_p <= SIGNIFICANCE_ALPHA
     # Abstain when the incumbent shows no significant separation on this window: there is
     # no trustworthy baseline to validate a live-classifier replacement against, so we must
-    # not ship off it regardless of how the model scores.
+    # not ship off it regardless of how the model scores. On the forward-return target the
+    # hand-rule is never significant (#1073), so this abstained on every window; on the
+    # forward-volatility target it is significant on 4/5 windows (PR #1077), so the gate can
+    # now honestly ship a stability-improved model.
     incumbent_trustworthy = hr_p <= SIGNIFICANCE_ALPHA
     separation_ok = (md_h >= hr_h * (1.0 - SEPARATION_TOLERANCE)) and model_separation_real
     stability_ok = (hr_tr - md_tr) >= STABILITY_MIN_GAIN
     ship = separation_ok and stability_ok and incumbent_trustworthy
     return {
+        "target": target,
         "separation_ok": bool(separation_ok),
         "stability_ok": bool(stability_ok),
         "model_separation_real": bool(model_separation_real),
@@ -73,6 +82,8 @@ def build_parser():
     p.add_argument("--held-out", default="oos")
     p.add_argument("--period", type=int, default=48)
     p.add_argument("--filter-window", type=int, default=64)
+    p.add_argument("--target", default="volatility", choices=("returns", "volatility"),
+                   help="forward variable the gate scores separation on (default: volatility, #1078)")
     p.add_argument("--seed", type=int, default=0)
     p.add_argument("--out", default=None, help="write fitted model JSON here")
     p.add_argument("--json", default=None, help="write validation report JSON here")
@@ -88,10 +99,12 @@ def main(argv=None) -> int:
     if args.out:
         with open(args.out, "w") as fh:
             json.dump({"model": model}, fh, indent=2, default=float)
-    hr = run_window(args.symbol, args.timeframe, args.held_out, model=None, seed=args.seed)
-    md = run_window(args.symbol, args.timeframe, args.held_out, model=model, seed=args.seed)
+    hr = run_window(args.symbol, args.timeframe, args.held_out, model=None,
+                    seed=args.seed, target=args.target)
+    md = run_window(args.symbol, args.timeframe, args.held_out, model=model,
+                    seed=args.seed, target=args.target)
     verdict = gate_verdict(hr, md)
-    payload = {"symbol": args.symbol, "timeframe": args.timeframe,
+    payload = {"symbol": args.symbol, "timeframe": args.timeframe, "target": args.target,
                "in_sample": args.in_sample, "held_out": args.held_out,
                "verdict": verdict, "handrule": hr, "model": md}
     text = json.dumps(payload, indent=2, default=float)

--- a/backtest/regime_diagnostics.py
+++ b/backtest/regime_diagnostics.py
@@ -21,6 +21,33 @@ def forward_returns(close: np.ndarray, horizon: int) -> np.ndarray:
     return fwd
 
 
+def forward_realized_vol(close: np.ndarray, horizon: int) -> np.ndarray:
+    """Cumulative realized volatility over the FORWARD `horizon` bars.
+
+    For bar i: sqrt(sum of squared 1-bar log returns over bars (i, i+horizon]).
+    The last `horizon` bars are NaN (no full forward window). This is the signal the
+    ATR-scaled SL/TP ladders actually consume, and the target #1073/PR #1077 showed the
+    composite classifier separates strongly — so it is the gate's separation axis (#1078).
+    Single definition shared with the #1073 research script.
+    """
+    close = np.asarray(close, dtype=float)
+    n = len(close)
+    out = np.full(n, np.nan)
+    h = int(horizon)
+    if n < 2 or h < 1 or h >= n:
+        return out
+    log_ret = np.diff(np.log(close), prepend=np.log(close[0]))
+    for i in range(n - h):
+        out[i] = np.sqrt(np.sum(log_ret[i + 1 : i + 1 + h] ** 2))
+    return out
+
+
+# Forward-target registry: the variable whose between-state separation the gate scores.
+# "returns" is the directional axis (#1073/#1076 reproductions); "volatility" is the
+# axis the regime really carries and the one the gate is re-founded on (#1078).
+FORWARD_TARGETS = {"returns": forward_returns, "volatility": forward_realized_vol}
+
+
 def coverage(labels: np.ndarray) -> dict:
     labels = np.asarray(labels, dtype=object)
     n = len(labels)
@@ -177,9 +204,14 @@ def kmeans_yardstick(features, fwd, k_range=(2, 3, 4, 5, 6, 7), seed=0) -> dict:
     return out
 
 
-def score_labels(close, labels, features, horizons=(1, 4, 12), block_mult=3, seed=0) -> dict:
+def score_labels(close, labels, features, horizons=(1, 4, 12), block_mult=3, seed=0,
+                 target="returns") -> dict:
     labels = np.asarray(labels, dtype=object)
     features = np.asarray(features, dtype=float)
+    try:
+        fwd_fn = FORWARD_TARGETS[target]
+    except KeyError:
+        raise ValueError(f"unknown forward target {target!r}; known: {sorted(FORWARD_TARGETS)}")
     # Identical NaN-mask on both label streams: warmup + low-ATR bars (NaN feature rows)
     # are excluded from coverage/stability/separation so neither the hand-rule's
     # ranging_quiet nor the model's default_label for those bars biases the comparison.
@@ -187,11 +219,11 @@ def score_labels(close, labels, features, horizons=(1, 4, 12), block_mult=3, see
     vlabels = labels[valid]
     st = stability(vlabels)
     mean_dwell = float(np.mean(list(st["mean_dwell"].values()))) if st["mean_dwell"] else 1.0
-    out = {"coverage": coverage(vlabels), "stability": st, "horizons": {}}
+    out = {"target": target, "coverage": coverage(vlabels), "stability": st, "horizons": {}}
     for h in horizons:
-        # Forward returns computed on the FULL close (index-aligned); then subset by valid
-        # so each retained bar keeps its true h-ahead return.
-        fwd_full = forward_returns(close, h)
+        # Forward target (returns or realized vol) computed on the FULL close (index-aligned);
+        # then subset by valid so each retained bar keeps its true h-ahead value.
+        fwd_full = fwd_fn(close, h)
         fwd = fwd_full[valid]
         block_len = max(int(block_mult * mean_dwell), h)
         out["horizons"][f"h{h}"] = {
@@ -206,7 +238,8 @@ def score_labels(close, labels, features, horizons=(1, 4, 12), block_mult=3, see
     return out
 
 
-def run_window(symbol, timeframe, window, *, model=None, horizons=(1, 4, 12), seed=0) -> dict:
+def run_window(symbol, timeframe, window, *, model=None, horizons=(1, 4, 12), seed=0,
+               target="returns") -> dict:
     from regime import compute_regime_composite, composite_feature_matrix, _DEFAULT_COMPOSITE_THRESHOLDS
     from data_fetcher import load_cached_data
     from eval_windows import WINDOWS, PLATFORM
@@ -221,7 +254,8 @@ def run_window(symbol, timeframe, window, *, model=None, horizons=(1, 4, 12), se
     else:
         from regime_hmm import forward_filter_labels
         labels, _conf = forward_filter_labels(features, model)
-    return score_labels(df["close"].to_numpy(), labels, features, horizons=horizons, seed=seed)
+    return score_labels(df["close"].to_numpy(), labels, features, horizons=horizons,
+                        seed=seed, target=target)
 
 
 def build_parser() -> "argparse.ArgumentParser":
@@ -233,6 +267,8 @@ def build_parser() -> "argparse.ArgumentParser":
     p.add_argument("--windows", default="is,oos", help=f"known: {', '.join(WINDOWS)}")
     p.add_argument("--model-json", default=None, help="score a fitted model instead of the hand-rule")
     p.add_argument("--horizons", default="1,4,12")
+    p.add_argument("--target", default="returns", choices=("returns", "volatility"),
+                   help="forward variable the separation is scored on (default: returns)")
     p.add_argument("--seed", type=int, default=0)
     p.add_argument("--json", default=None, help="write report JSON to this path")
     return p
@@ -253,8 +289,8 @@ def main(argv=None) -> int:
         if w not in WINDOWS:
             raise SystemExit(f"unknown window {w}; known: {list(WINDOWS)}")
         report[w] = run_window(args.symbol, args.timeframe, w, model=model,
-                               horizons=horizons, seed=args.seed)
-    payload = {"symbol": args.symbol, "timeframe": args.timeframe,
+                               horizons=horizons, seed=args.seed, target=args.target)
+    payload = {"symbol": args.symbol, "timeframe": args.timeframe, "target": args.target,
                "source": "model" if model else "hand_rule", "windows": report}
     text = json.dumps(payload, indent=2, default=float)
     if args.json:

--- a/backtest/regime_hmm.py
+++ b/backtest/regime_hmm.py
@@ -39,11 +39,13 @@ def fit_label_anchored_hmm(features, labels, states, *, filter_window,
     si = {s: i for i, s in enumerate(states)}
     k = len(states)
     A = np.full((k, k), float(laplace))
-    # Consecutive pairs counted on the NaN-dropped sequence: a mid-series NaN (low-ATR)
-    # bar produces a spurious adjacency between its pre- and post-NaN neighbours.
-    # Effect is small after Laplace smoothing; revisit when the fit is ported live in PR2.
-    for a, b in zip(y[:-1], y[1:]):
-        A[si[a], si[b]] += 1.0
+    # Transition counts only between bars adjacent in the ORIGINAL series AND both retained
+    # (non-NaN features). The old NaN-dropped zip spliced a mid-series NaN (low-ATR) bar's
+    # pre- and post-NaN neighbours into a spurious adjacency; pairs spanning a dropped bar
+    # are now skipped so the fitted transition matrix matches true bar-to-bar dynamics (#1078).
+    for i in range(len(mask) - 1):
+        if mask[i] and mask[i + 1]:
+            A[si[labels[i]], si[labels[i + 1]]] += 1.0
     A = A / A.sum(1, keepdims=True)
     return {
         "type": MODEL_TYPE, "version": MODEL_VERSION, "features": list(FEATURES),

--- a/backtest/research/regime_1073_directional_negative_result.py
+++ b/backtest/research/regime_1073_directional_negative_result.py
@@ -44,6 +44,7 @@ from data_fetcher import load_cached_data
 from eval_windows import WINDOWS, PLATFORM
 from regime_diagnostics import (
     forward_returns,
+    forward_realized_vol,
     separation,
     stability,
     block_shuffle_pvalue,
@@ -75,14 +76,6 @@ def _load(symbol, timeframe, window, thresholds):
         "mean_dwell": mean_dwell,
         "transition_rate": st["transition_rate"],
     }
-
-
-def _fwd_realized_vol(close, h):
-    log_ret = np.diff(np.log(close), prepend=np.log(close[0]))
-    out = np.full(len(close), np.nan)
-    for i in range(len(close) - h):
-        out[i] = np.sqrt(np.sum(log_ret[i + 1: i + 1 + h] ** 2))
-    return out
 
 
 def diag_windows(symbol, timeframe, windows, th, horizon=4):
@@ -138,7 +131,7 @@ def diag_vol(symbol, timeframe, windows, th):
         loaded[w] = d
         row = f"{w:8s} |"
         for h in (4, 24):
-            fv = _fwd_realized_vol(d["close"], h)[d["valid"]]
+            fv = forward_realized_vol(d["close"], h)[d["valid"]]
             bl = max(int(3 * d["mean_dwell"]), h)
             sig = block_shuffle_pvalue(d["vlabels"], fv, bl, seed=0)
             flag = "*" if sig["p_value"] <= 0.05 else " "

--- a/backtest/tests/test_regime_calibrate.py
+++ b/backtest/tests/test_regime_calibrate.py
@@ -1,4 +1,5 @@
 # backtest/tests/test_regime_calibrate.py
+import math
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from regime_calibrate import gate_verdict, SIGNIFICANCE_ALPHA, STABILITY_MIN_GAIN
@@ -144,13 +145,54 @@ def test_engaged_gate_blocks_model_that_keeps_separation_but_loses_stability_gai
 
 def test_engaged_gate_ships_at_inclusive_floor_boundaries():
     # (3) Boundary: model exactly AT both floors — md_p == SIGNIFICANCE_ALPHA and stability gain
-    # == STABILITY_MIN_GAIN — must still ship, pinning that both comparisons are inclusive
-    # (<= / >=). A future edit flipping either to a strict bound would break this.
-    hr = _report(90.0, 0.45, p_value=0.005, target="volatility")
-    md = _report(90.0, 0.45 - STABILITY_MIN_GAIN, p_value=SIGNIFICANCE_ALPHA, target="volatility")
+    # == STABILITY_MIN_GAIN — must still ship, pinning that BOTH comparisons are inclusive
+    # (<= / >=). The gain must land bit-exactly on the floor or the test fails to distinguish
+    # >= from >: `0.45 - (0.45 - 0.02)` is 0.020000000000000018 in IEEE-754 double (one ulp ABOVE
+    # 0.02), which passes a strict `>` too, so a `>=`->`>` regression would slip through (bot
+    # review #1079). `STABILITY_MIN_GAIN - 0.0` is exactly the double 0.02, so a strict-bound
+    # regression on EITHER arm turns this red. incumbent_trustworthy keys off hr_p (not the
+    # transition-rate magnitude), so the small hr_tr keeps the engaged (non-abstaining) path.
+    hr = _report(90.0, STABILITY_MIN_GAIN, p_value=0.005, target="volatility")
+    md = _report(90.0, 0.0, p_value=SIGNIFICANCE_ALPHA, target="volatility")
+    assert (hr["stability"]["transition_rate"] - md["stability"]["transition_rate"]) == STABILITY_MIN_GAIN
     v = gate_verdict(hr, md)
     assert v["incumbent_trustworthy"] is True
+    assert v["abstained"] is False
     assert v["model_separation_real"] is True   # md_p == alpha is inside the floor
     assert v["separation_ok"] is True
     assert v["stability_ok"] is True            # gain == STABILITY_MIN_GAIN is inside the floor
     assert v["ship"] is True
+
+
+def test_engaged_gate_blocks_stability_gain_one_ulp_below_floor():
+    # (4) Must-survive inverse of the boundary: a stability gain one ULP below STABILITY_MIN_GAIN
+    # must block, isolating the stability arm (separation kept within tolerance + significant).
+    # Constructed exactly: hr_tr = nextafter(floor, 0), md_tr = 0.0, so the gain (subtracting 0.0
+    # is exact) is exactly one ulp under the floor — `>=` correctly rejects it.
+    hr_tr = math.nextafter(STABILITY_MIN_GAIN, 0.0)
+    hr = _report(90.0, hr_tr, p_value=0.005, target="volatility")
+    md = _report(90.0, 0.0, p_value=0.005, target="volatility")
+    assert (hr_tr - 0.0) < STABILITY_MIN_GAIN
+    v = gate_verdict(hr, md)
+    assert v["incumbent_trustworthy"] is True
+    assert v["abstained"] is False
+    assert v["separation_ok"] is True           # separation arm green — only stability blocks
+    assert v["stability_ok"] is False
+    assert v["ship"] is False
+
+
+def test_engaged_gate_blocks_model_p_one_ulp_above_alpha():
+    # (5) Symmetric must-survive on the significance floor: a model p one ULP above
+    # SIGNIFICANCE_ALPHA is NOT real separation and must block, isolating the separation arm
+    # (stability gain large + green). Pins that model_separation_real uses an inclusive `<=`.
+    md_p = math.nextafter(SIGNIFICANCE_ALPHA, 1.0)
+    hr = _report(90.0, 0.45, p_value=0.005, target="volatility")
+    md = _report(90.0, 0.0, p_value=md_p, target="volatility")
+    assert md_p > SIGNIFICANCE_ALPHA
+    v = gate_verdict(hr, md)
+    assert v["incumbent_trustworthy"] is True
+    assert v["abstained"] is False
+    assert v["stability_ok"] is True            # stability arm green — only separation blocks
+    assert v["model_separation_real"] is False
+    assert v["separation_ok"] is False
+    assert v["ship"] is False

--- a/backtest/tests/test_regime_calibrate.py
+++ b/backtest/tests/test_regime_calibrate.py
@@ -4,12 +4,15 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from regime_calibrate import gate_verdict
 
 
-def _report(kw_h, transition_rate, p_value=0.005):
+def _report(kw_h, transition_rate, p_value=0.005, target=None):
     # p_value defaults to "significant" so existing separation/stability cases are
     # exercised in isolation; cases that probe the significance floor set it explicitly.
-    return {"stability": {"transition_rate": transition_rate},
-            "h4": {"separation": {"kruskal_h": kw_h},
-                   "significance": {"p_value": p_value}}}
+    r = {"stability": {"transition_rate": transition_rate},
+         "h4": {"separation": {"kruskal_h": kw_h},
+                "significance": {"p_value": p_value}}}
+    if target is not None:
+        r["target"] = target
+    return r
 
 
 def test_gate_ships_when_stability_better_and_separation_kept():
@@ -76,3 +79,27 @@ def test_gate_abstains_when_incumbent_not_significant():
     assert v["incumbent_trustworthy"] is False
     assert v["abstained"] is True
     assert v["ship"] is False
+
+
+# --- #1078: gate re-founded on the forward-VOLATILITY target -----------------------------
+
+def test_gate_surfaces_target_from_reports():
+    # The verdict must echo the forward target the reports were scored on, so a volatility
+    # result can never be misread as a directional (return) one.
+    hr = _report(13.0, 0.40, p_value=0.005, target="volatility")
+    md = _report(12.4, 0.25, p_value=0.005, target="volatility")
+    assert gate_verdict(hr, md)["target"] == "volatility"
+
+
+def test_gate_ships_on_trustworthy_volatility_incumbent():
+    # The crux of #1078: on the forward-VOLATILITY axis the hand-rule IS significant
+    # (PR #1077: 4/5 windows p <= 0.01), so a stability-improved model that keeps the
+    # separation now ships honestly — exactly the path that was impossible on the return
+    # target, where the incumbent was never significant (#1073) and the gate always abstained.
+    hr = _report(90.0, 0.45, p_value=0.005, target="volatility")  # strong, real vol incumbent
+    md = _report(88.0, 0.30, p_value=0.005, target="volatility")  # within tol, whipsaw down
+    v = gate_verdict(hr, md)
+    assert v["incumbent_trustworthy"] is True
+    assert v["abstained"] is False
+    assert v["separation_ok"] and v["stability_ok"]
+    assert v["ship"] is True

--- a/backtest/tests/test_regime_calibrate.py
+++ b/backtest/tests/test_regime_calibrate.py
@@ -1,7 +1,7 @@
 # backtest/tests/test_regime_calibrate.py
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from regime_calibrate import gate_verdict
+from regime_calibrate import gate_verdict, SIGNIFICANCE_ALPHA, STABILITY_MIN_GAIN
 
 
 def _report(kw_h, transition_rate, p_value=0.005, target=None):
@@ -102,4 +102,55 @@ def test_gate_ships_on_trustworthy_volatility_incumbent():
     assert v["incumbent_trustworthy"] is True
     assert v["abstained"] is False
     assert v["separation_ok"] and v["stability_ok"]
+    assert v["ship"] is True
+
+
+# --- #1078 engaged-gate separation floor (bot review #1079) ------------------------------
+# These pin the auto-protective behavior the volatility re-target newly unlocks: now that the
+# incumbent CAN be trustworthy, a model must still independently clear the block-shuffle
+# separation floor and must not ship on the stability arm alone. Invariant: incumbent
+# trustworthy (significant) => ship requires (md_p <= SIGNIFICANCE_ALPHA) AND a stability gain
+# of at least STABILITY_MIN_GAIN, both independently.
+
+def test_engaged_gate_rejects_degenerate_but_perfectly_stable_model():
+    # (1) Strong, significant vol incumbent (engaged, not abstaining) + a constant-label model
+    # (kruskal_h~0, transition_rate=0): the stability arm is maximally green, but separation is
+    # nil and not significant -> must NOT ship. This is the high-value path the PR smoke showed
+    # and the floor that stops a bad model shipping now that incumbent_trustworthy can be true.
+    hr = _report(90.0, 0.45, p_value=0.005, target="volatility")
+    md = _report(0.0, 0.0, p_value=1.0, target="volatility")  # perfect stability, zero separation
+    v = gate_verdict(hr, md)
+    assert v["incumbent_trustworthy"] is True
+    assert v["abstained"] is False           # engaged, NOT the weak-incumbent abstain path
+    assert v["stability_ok"] is True          # the trap: stability looks perfect
+    assert v["model_separation_real"] is False
+    assert v["separation_ok"] is False
+    assert v["ship"] is False
+
+
+def test_engaged_gate_blocks_model_that_keeps_separation_but_loses_stability_gain():
+    # (2) Inverse of (1): engaged gate + a model that keeps the separation (within tolerance,
+    # significant) but whose stability gain is below STABILITY_MIN_GAIN -> must NOT ship. Pins
+    # that the two arms are independent; a strong separator cannot ship without the whipsaw win.
+    hr = _report(90.0, 0.45, p_value=0.005, target="volatility")
+    md = _report(88.0, 0.44, p_value=0.005, target="volatility")  # gain 0.01 < STABILITY_MIN_GAIN
+    v = gate_verdict(hr, md)
+    assert v["incumbent_trustworthy"] is True
+    assert v["abstained"] is False
+    assert v["separation_ok"] is True
+    assert v["stability_ok"] is False
+    assert v["ship"] is False
+
+
+def test_engaged_gate_ships_at_inclusive_floor_boundaries():
+    # (3) Boundary: model exactly AT both floors — md_p == SIGNIFICANCE_ALPHA and stability gain
+    # == STABILITY_MIN_GAIN — must still ship, pinning that both comparisons are inclusive
+    # (<= / >=). A future edit flipping either to a strict bound would break this.
+    hr = _report(90.0, 0.45, p_value=0.005, target="volatility")
+    md = _report(90.0, 0.45 - STABILITY_MIN_GAIN, p_value=SIGNIFICANCE_ALPHA, target="volatility")
+    v = gate_verdict(hr, md)
+    assert v["incumbent_trustworthy"] is True
+    assert v["model_separation_real"] is True   # md_p == alpha is inside the floor
+    assert v["separation_ok"] is True
+    assert v["stability_ok"] is True            # gain == STABILITY_MIN_GAIN is inside the floor
     assert v["ship"] is True

--- a/backtest/tests/test_regime_diagnostics.py
+++ b/backtest/tests/test_regime_diagnostics.py
@@ -2,7 +2,9 @@
 import os, sys
 import numpy as np
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from regime_diagnostics import forward_returns, coverage, separation, stability
+from regime_diagnostics import (
+    forward_returns, forward_realized_vol, coverage, separation, stability,
+)
 
 
 def test_forward_returns_horizon():
@@ -10,6 +12,37 @@ def test_forward_returns_horizon():
     fr = forward_returns(close, 1)
     np.testing.assert_allclose(fr[:2], [0.10, 0.10])
     assert np.isnan(fr[-1])
+
+
+def test_forward_realized_vol_horizon1():
+    # log prices [0, 0.1, 0.3, 0.6] -> 1-bar log returns [0, 0.1, 0.2, 0.3].
+    # forward realized vol at h=1 is |next log return|: [0.1, 0.2, 0.3, NaN].
+    close = np.exp(np.array([0.0, 0.1, 0.3, 0.6]))
+    fv = forward_realized_vol(close, 1)
+    np.testing.assert_allclose(fv[:3], [0.1, 0.2, 0.3], atol=1e-12)
+    assert np.isnan(fv[-1])
+
+
+def test_forward_realized_vol_horizon2_sums_squared_log_returns():
+    close = np.exp(np.array([0.0, 0.1, 0.3, 0.6]))
+    fv = forward_realized_vol(close, 2)
+    # out[0] = sqrt(0.1^2 + 0.2^2) = sqrt(0.05); out[1] = sqrt(0.2^2 + 0.3^2) = sqrt(0.13)
+    np.testing.assert_allclose(fv[:2], [np.sqrt(0.05), np.sqrt(0.13)], atol=1e-12)
+    assert np.isnan(fv[2]) and np.isnan(fv[3])  # last `horizon` bars have no full window
+
+
+def test_forward_realized_vol_separates_quiet_from_volatile():
+    # A quiet leg (tiny moves) then a volatile leg (large moves): forward vol must rank
+    # the volatile-state bars far above the quiet-state bars (the regime's real signal).
+    rng = np.random.default_rng(0)
+    quiet = rng.normal(0, 0.001, 200)
+    loud = rng.normal(0, 0.02, 200)
+    close = 100 * np.exp(np.cumsum(np.concatenate([quiet, loud])))
+    labels = np.array(["quiet"] * 200 + ["loud"] * 200, dtype=object)
+    fv = forward_realized_vol(close, 4)
+    sep = separation(labels, fv)
+    assert sep["per_state"]["loud"]["mean"] > sep["per_state"]["quiet"]["mean"]
+    assert sep["kruskal_h"] > 5.0
 
 
 def test_coverage_counts():
@@ -98,6 +131,34 @@ def test_score_labels_masks_warmup():
     assert out_a["coverage"] == out_b["coverage"]
     assert out_a["stability"] == out_b["stability"]
     assert out_a["h4"]["significance"]["p_value"] == out_b["h4"]["significance"]["p_value"]
+
+
+def test_score_labels_target_volatility_stamped_and_distinct():
+    from regime_diagnostics import score_labels
+    rng = np.random.default_rng(1)
+    # Quiet then volatile leg so the vol target genuinely separates the two label groups.
+    steps = np.concatenate([rng.normal(0, 0.001, 150), rng.normal(0, 0.02, 150)])
+    close = 100 * np.exp(np.cumsum(steps))
+    labels = np.array(["quiet"] * 150 + ["loud"] * 150, dtype=object)
+    feats = rng.normal(0, 1, (300, 4))
+
+    vol = score_labels(close, labels, feats, horizons=(4,), seed=0, target="volatility")
+    ret = score_labels(close, labels, feats, horizons=(4,), seed=0, target="returns")
+    assert vol["target"] == "volatility" and ret["target"] == "returns"
+    # Different forward variable -> different separation statistic on the same labels.
+    assert vol["h4"]["separation"]["kruskal_h"] != ret["h4"]["separation"]["kruskal_h"]
+    # Vol target strongly separates quiet vs loud; the gate reads this KW-H.
+    assert vol["h4"]["separation"]["kruskal_h"] > 5.0
+
+
+def test_score_labels_rejects_unknown_target():
+    from regime_diagnostics import score_labels
+    import pytest
+    close = 100 * np.cumprod(1 + np.zeros(50))
+    labels = np.array(["a"] * 50, dtype=object)
+    feats = np.zeros((50, 4))
+    with pytest.raises(ValueError):
+        score_labels(close, labels, feats, horizons=(4,), target="sharpe")
 
 
 def test_per_state_significance():

--- a/backtest/tests/test_regime_hmm.py
+++ b/backtest/tests/test_regime_hmm.py
@@ -35,6 +35,30 @@ def test_fit_drops_nan_rows():
     assert m["emissions"][0]["n"] == 1  # the NaN s0 row was dropped
 
 
+def test_fit_no_spurious_transition_across_midseries_nan():
+    # #1078: a mid-series NaN (low-ATR) bar between a pure s0 run and a pure s1 run must NOT
+    # be counted as an s0->s1 transition. Layout: s0 s0 s0 [NaN] s1 s1 s1.
+    feats = np.array([[0.0], [0.0], [0.0], [np.nan], [1.0], [1.0], [1.0]])
+    labels = np.array(["s0", "s0", "s0", "s0", "s1", "s1", "s1"], dtype=object)
+    m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=4, laplace=1.0)
+    A = np.array(m["transition"])
+    # Raw counts with the gap skipped: s0->s0 = 2, s0->s1 = 0. With laplace=1 the s0 row is
+    # [3, 1] -> [0.75, 0.25]. The buggy NaN-dropped zip would have counted one s0->s1 (-> 0.4).
+    assert abs(A[0][1] - 0.25) < 1e-9
+    assert abs(A[0][0] - 0.75) < 1e-9
+
+
+def test_fit_counts_genuine_adjacent_transition():
+    # Control for the fix above: with NO NaN gap the s0->s1 boundary transition IS counted,
+    # so the fix suppresses only spurious NaN-spanned adjacencies, not real ones.
+    feats = np.array([[0.0], [0.0], [0.0], [1.0], [1.0], [1.0]])
+    labels = np.array(["s0", "s0", "s0", "s1", "s1", "s1"], dtype=object)
+    m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=4, laplace=1.0)
+    A = np.array(m["transition"])
+    # Raw s0->s0 = 2, s0->s1 = 1 -> s0 row [3, 2] -> [0.6, 0.4].
+    assert abs(A[0][1] - 0.4) < 1e-9
+
+
 def test_forward_filter_look_ahead_safe():
     from regime_hmm import forward_filter_labels
     rng = np.random.default_rng(0)

--- a/backtest/tests/test_regime_stats.py
+++ b/backtest/tests/test_regime_stats.py
@@ -20,6 +20,23 @@ def test_kruskal_h_large_when_separated():
     assert kruskal_h([a, b]) > 5.0  # strongly separated -> large H
 
 
+def test_kruskal_h_reference_value_no_ties():
+    # Two perfectly-ordered tie-free groups: [1,2,3] vs [4,5,6]. Ranks are 1..6, so
+    # R1=6, R2=15; H = 12/(N(N+1)) * (R1^2/n1 + R2^2/n2) - 3(N+1) with N=6
+    #   = (12/42) * (36/3 + 225/3) - 21 = (2/7)*87 - 21 = 27/7. No ties -> correction c=1.
+    h = kruskal_h([np.array([1.0, 2, 3]), np.array([4.0, 5, 6])])
+    assert abs(h - 27.0 / 7.0) < 1e-9
+
+
+def test_kruskal_h_reference_value_with_tie_correction():
+    # Tied groups [1,1,2] vs [2,3,3]. Sorted values 1,1,2,2,3,3 -> avg ranks
+    # 1.5,1.5,3.5,3.5,5.5,5.5; R1=6.5, R2=14.5 -> H_uncorrected = 64/21.
+    # Tie correction c = 1 - sum(t^3 - t)/(N^3 - N) = 1 - 18/210 = 32/35.
+    # Corrected H = (64/21)/(32/35) = 10/3 exactly -> pins the tie-correction branch.
+    h = kruskal_h([np.array([1.0, 1, 2]), np.array([2.0, 3, 3])])
+    assert abs(h - 10.0 / 3.0) < 1e-9
+
+
 def test_benjamini_hochberg_basic():
     # one clearly significant, rest null
     flags = benjamini_hochberg([0.001, 0.4, 0.6, 0.8], alpha=0.05)


### PR DESCRIPTION
## Summary
Closes #1078 (re-scoped to one issue ↔ one PR). Re-founds the regime calibration gate on the signal the classifier actually carries — **forward realized volatility** — and lands the two concrete deferred harness items. Backtest/research only; no live or Go path touched.

The gate scored between-state separation of forward **returns**, where the hand-rule is never block-shuffle significant (#1073, evidence PR #1077), so `incumbent_trustworthy` was false on every window and the gate could **never** ship a model. On forward volatility the hand-rule **is** significant (PR #1077: 4/5 windows p ≤ 0.01), so a stability-improved model can now clear the gate honestly.

## Changes
1. **Re-target the separation metric.** `regime_diagnostics.py` gains `forward_realized_vol` — promoted from the #1073 research script's private copy to the single shared definition — and a `FORWARD_TARGETS` registry. `score_labels`/`run_window` and the diagnostics CLI take a `target` arg (`returns|volatility`, **default `returns`** so the directional #1073/#1076 reproductions are byte-unchanged). Every report stamps its `target`.
2. **Gate re-founded on volatility.** `regime_calibrate.py` defaults `--target volatility` and surfaces `target` in the verdict so a volatility result can never be misread as directional. Gate logic is **unchanged and target-agnostic** — the axis flip is the entire mechanism that lets `incumbent_trustworthy` become true.
3. **Deferred item — mid-series-NaN transition gap.** `fit_label_anchored_hmm` now counts transitions only between bars adjacent in the **original** series and both retained, so a dropped low-ATR (NaN-feature) bar no longer splices its pre/post neighbours into a spurious adjacency.
4. **Deferred item — `kruskal_h` reference-value test.** Pins the statistic to exact hand-derived values: `27/7` tie-free and `10/3` exercising the tie-correction branch.

## Verification
- `backtest/tests/` full suite green (624 passed); regime suite 27 → 38 tests (+11).
- End-to-end gate smoke (BTC/USDT 1h, live data): hand-rule OOS forward-vol KW-H **60.8, p=0.030** → gate **engages** (`abstained=False`, was always-abstain on the return axis) and correctly **rejects** the degenerate label-anchored HMM (collapses to a constant label, KW-H 0) despite a perfect stability arm.

## Follow-ups (split out per one-issue-one-PR)
The remaining #1078 program goals moved to dedicated issues, each its own PR:
1. #1080 — Unsupervised vol-state model + 7-name signature mapping (directly motivated by the degenerate HMM above)
1. #1081 — Economic walk-forward gate: regime-conditioned ATR sizing vs flat-ATR
1. #1082 — Bounded-window ADX re-validation before promotion
1. #1083 — Multi-asset validation (extends the #1076 harness to the vol/economic axis)

#1074 (live wiring) is unblocked once a model clears #1080 + #1081.

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code