### PR TITLE
feat(#1076): regime→direction premise is a negative result; warn on the directional surface

### DIFF
--- a/backtest/research/README_1076_directional_premise.md
+++ b/backtest/research/README_1076_directional_premise.md
@@ -1,0 +1,157 @@
+# #1076 — Does the regime label predict forward DIRECTION? (Negative result)
+
+**Validates the edge premise behind `regime_directional_policy` (#779) and regime
+directional entry-gating (`allowed_regimes`).** Those surfaces bet a live HL-perps
+strategy long/short on the *current* regime label (long in `trending_up`, short in
+`trending_down` — `scheduler/regime_directional_policy.go:5-16`). The entire premise is
+**regime → forward-direction**. #1073 finding 1 refuted it for the 7-state composite
+classifier on BTC/USDT 1h; this issue generalizes the test across assets, timeframes,
+both classifiers, and an economic walk-forward — statistically and economically.
+
+## Verdict
+
+**Negative across the entire tested universe.** The regime → direction premise has **no
+statistically real, multiplicity-honest forward-return separation** and **no economic edge
+over its own shuffled-label null** anywhere tested. The directional-gating surface is
+choosing long vs short on noise; its only realized effect is a change in market exposure
+(defensive beta), not a directional forecast.
+
+## Universe tested
+
+| Axis | Values |
+|---|---|
+| Exchange / fee model | `binanceus` (eval_windows audit platform) |
+| Assets | BTC, ETH, SOL (1h + 4h); BTC also 15m/30m/2h; BNB, XRP (4h) |
+| Windows | `is`, `oos` (2025-06→2026, the held-out forward split), `2023`, `2024`, `2025H1` |
+| Classifiers | `adx` (3-state, period 14, the policy-doc default) **and** `composite` (7-state, period 48, the #1073 surface) |
+| Horizons | 1, 4, 8, 12, 24, 48, 72 bars |
+| Block-shuffle perms | 1000 (scope 1), 300 (scope 2 placebo) |
+
+## Scope 1 — per-state forward-return significance
+
+`regime_1076_directional_premise.py` reuses `regime_diagnostics.py:per_state_significance`
+(block-shuffle + Benjamini-Hochberg FDR). For each (classifier, asset, timeframe, window,
+horizon, state) it tests whether that state's forward return separates from the rest, and
+flags a **candidate edge** only when the state is FDR-significant **and** its gap sign
+matches the side the policy bets (long states want gap > 0, short states gap < 0).
+
+`per_state_significance` corrects FDR only *within* a cell. Running ~300 cells is a family
+of **2121 directional-state tests**, so within-cell hits are expected by chance.
+`regime_1076_aggregate.py` pools every test and corrects **once**, globally.
+
+```
+total directional-state tests pooled: 2121
+  within-cell candidate edges (uncorrected):           20  (held-out is/oos: 1, oos: 1)
+  GLOBAL Benjamini-Hochberg FDR q=0.05:    0 survive (0 policy-aligned)
+  GLOBAL Bonferroni  (p <= 2.36e-05):      0 survive (0 policy-aligned)
+```
+
+- **0 of 2121** states survive global correction (BH or Bonferroni).
+- The 20 within-cell candidate edges cluster in single historical windows (mostly SOL 4h
+  2023) and at correlated overlapping horizons — exactly multiple-comparisons noise. Only
+  **one** lands in a held-out forward window (BTC 4h `oos`, `trending_down_clean`, h1,
+  p=0.004), a single-bar artifact that no multi-bar policy can bank.
+- For the composite classifier, FDR-significant states are **wrong-signed as often as
+  aligned** (e.g. core: 6 aligned vs 9 wrong-signed) — a state "predicting" direction
+  opposite to the policy's bet is noise, not signal.
+
+## Scope 2 — economic walk-forward (the real arbiter)
+
+`regime_1076_economic_sim.py` is a look-ahead-safe regime-timing portfolio: three books on
+identical bars, each side decided from the regime known at the **prior** bar close
+(mirrors the backtester's regime `shift(1)`, #730):
+
+- `policy` — long in `trending_up*`, **short** in `trending_down*`, flat (or long) in `ranging*`
+- `long_only` — long in `trending_up*`, flat otherwise (isolates "short the downtrend" value)
+- `buyhold` — long every bar (the regime-agnostic base)
+
+It prices the bare directional premise with **no strategy-signal confound** — if even
+continuously applying the regime's directional call can't beat buy-and-hold risk-adjusted
+out-of-sample, the premise confers no economic value on any strategy that uses it for side
+selection. Shorting funding cost is omitted (favors `policy`, so a loss is conservative);
+fees are charged on turnover (10 bps/side default).
+
+**The naive read is a trap.** `policy` "beats buyhold on Sharpe AND DDadj 12/12 in `oos`."
+But `oos` (2026 H1) was a *down* market — buy-and-hold is negative in every `oos` cell —
+and `policy` only "wins" by being defensively flat/short. In the *bull* windows it is
+destroyed (e.g. SOL 1h 2023: buy-and-hold **+937%** vs policy **−32%**; BTC 1h 2024:
+**+121%** vs **−58%**), and its *absolute* Sharpe is negative in most cells. A book whose
+sign-of-outperformance flips entirely on the sample's drift is reduced beta, not direction
+skill.
+
+**Placebo control settles it.** Block-shuffle the policy's per-bar side decisions
+(preserving the long/short/flat mix and dwell, destroying the alignment with price) and ask
+whether the real policy's Sharpe beats its own shuffled null:
+
+```
+ranging=flat:  cells beating shuffled null  raw p<=0.05: 7/60   after BH FDR: 0/60
+ranging=long:  cells beating shuffled null  raw p<=0.05: 3/60   after BH FDR: 0/60
+```
+
+**0 of 60** cells (either ranging mode) show regime timing beating its own shuffled null
+after FDR. The economic "wins" are the exposure mix (defensive beta in a down sample), not
+regime → direction skill.
+
+## Reproduce
+
+```bash
+# Scope 1 — per-state significance (per-battery global correction in each run)
+uv run --no-sync python backtest/research/regime_1076_directional_premise.py \
+    --symbols BTC/USDT,ETH/USDT,SOL/USDT --timeframes 1h,4h --n-perm 1000 --out /tmp/core.json
+uv run --no-sync python backtest/research/regime_1076_directional_premise.py \
+    --symbols BTC/USDT --timeframes 15m,30m,2h --n-perm 1000 --out /tmp/btc_extra.json
+uv run --no-sync python backtest/research/regime_1076_directional_premise.py \
+    --symbols BNB/USDT,XRP/USDT --timeframes 4h --n-perm 1000 --out /tmp/alt4h.json
+# Unified global correction across the FULL battery
+uv run --no-sync python backtest/research/regime_1076_aggregate.py \
+    /tmp/core.json /tmp/btc_extra.json /tmp/alt4h.json
+
+# Scope 2 — economic isolation + placebo control
+uv run --no-sync python backtest/research/regime_1076_economic_sim.py \
+    --symbols BTC/USDT,ETH/USDT,SOL/USDT --timeframes 1h,4h --ranging-mode flat --placebo-perm 300
+```
+
+Read-only; no live or Go path touched. (A look-ahead bug in the first economic-sim draft —
+using `labels[t]` to trade the move *into* bar `t` — produced impossible Sharpe ~9; the
+committed `_book` decides the side at bar `t` and holds it over `t→t+1`, verified by a
+buy-and-hold book reproducing the asset return exactly.)
+
+## Action taken (#1076 scope 3)
+
+The premise holds **nowhere** in the tested universe, so the directional-gating surface must
+not be deployed believing it has validated directional edge.
+
+**Implemented: a non-breaking operator warning** (`regimeDirectionalPolicyWarnings`,
+`scheduler/config.go`) — every strategy that configures `regime_directional_policy` prints a
+`[WARN]` at config load citing this negative result and pointing operators to ATR-scaled
+sizing (#1078). Existing live configs still load.
+
+**Why warn, not deprecate/restrict — a verified safety inversion.** Hard-rejecting the keys
+or auto-disabling is the *less* safe option for the money path. Disabling the policy on a
+strategy with an open position relies on the #822 orphan auto-close
+(`perpsRegimeDirectionOrphanConflict` → `runRegimeDirectionOrphanCloses`,
+`scheduler/hyperliquid_balance.go`), which fires **only for sole-owner coins** — a shared-coin
+live short would be **stranded** for manual close. SIGHUP already blocks adding/removing the
+policy while a position is open (`scheduler/config_reload.go`), so the safe disable path is
+operator-driven **from flat**. A warning prompts exactly that without forcing an unsafe state
+transition; a blanket reject would not.
+
+**Deliberate follow-up (recommended new issue):** an evidence-gated, default-off migration —
+the directional surface activates only where a per-(asset, timeframe) validation gate
+certifies real edge (none currently qualifies), mirroring the #1073/#1078 `gate_verdict`
+"abstain unless trustworthy" philosophy. That is a live-money-behavior change deserving its
+own design (shared-coin orphan handling + hot-reload + a from-flat migration), not a bolt-on
+to this validation.
+
+The regime classifier's real, validated signal is forward **volatility**, not direction
+(#1073 finding + #1078) — regime should drive ATR-scaled SL/TP sizing, not side selection.
+
+### Note on the economic method
+Scope 2 uses a look-ahead-safe regime-timing **isolation** (always-in-market, side from the
+prior bar's regime) rather than the literal `Backtester` + `regime_directional_policy` config.
+This is deliberate: the isolation removes the strategy-signal confound and, critically,
+supports the **block-shuffle placebo** that actually separates regime-timing skill from
+defensive beta — a control the strategy-confounded backtester cannot cleanly provide. A
+literal-`Backtester` run is feasible (`run_backtest.py --config` threads the policy via the
+#1025 resolver) and remains available as corroboration of the real-usage entry pattern; given
+the statistical screen (0/2121) and the placebo (0/60), it is not expected to differ.

--- a/backtest/research/regime_1076_aggregate.py
+++ b/backtest/research/regime_1076_aggregate.py
@@ -1,0 +1,79 @@
+"""Aggregate the #1076 scope-1 battery JSON dumps and apply ONE global multiple-comparisons
+correction across the entire (classifier, asset, timeframe, window, horizon, state) family.
+
+per_state_significance corrects FDR only within a single cell; each separate battery run
+corrects only within its own universe. The honest family-wide screen pools every directional
+test from every dump and corrects once. Run after the battery dumps exist:
+
+    uv run --no-sync python backtest/research/regime_1076_aggregate.py \
+        /tmp/wf1076_core.json /tmp/wf1076_btc_extra.json /tmp/wf1076_alt4h.json
+"""
+from __future__ import annotations
+import json
+import os
+import sys
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_BACKTEST = os.path.abspath(os.path.join(_THIS_DIR, ".."))
+sys.path.insert(0, _BACKTEST)
+from regime_stats import benjamini_hochberg
+
+HELD_OUT_FORWARD = ("is", "oos")
+
+
+def main(argv=None) -> int:
+    paths = argv if argv is not None else sys.argv[1:]
+    if not paths:
+        raise SystemExit("usage: regime_1076_aggregate.py <dump.json> [<dump.json> ...]")
+    rows = []
+    universe = []
+    for p in paths:
+        with open(p) as fh:
+            d = json.load(fh)
+        rows.extend(d["rows"])
+        u = d.get("universe", {})
+        universe.append(f"{os.path.basename(p)}: {u.get('symbols')} x {u.get('timeframes')} "
+                        f"(n_perm={u.get('n_perm')})")
+
+    directional = [r for r in rows if r["policy_dir"] != 0]
+    n = len(directional)
+    pvals = [r["p_value"] for r in directional]
+    bh = benjamini_hochberg(pvals, alpha=0.05)
+    bonf = 0.05 / n if n else 0.0
+
+    n_bh = sum(bh)
+    n_bonf = sum(p <= bonf for p in pvals)
+    bh_aligned = sum(b and r["sign_aligned"] for b, r in zip(bh, directional))
+    bonf_aligned = sum((r["p_value"] <= bonf) and r["sign_aligned"] for r in directional)
+    within = [r for r in directional if r["candidate_edge"]]
+    within_held = [r for r in within if r["window"] in HELD_OUT_FORWARD]
+    within_oos = [r for r in within if r["window"] == "oos"]
+
+    print("=" * 80)
+    print("UNIFIED #1076 SCOPE-1 SCREEN — global correction across the FULL battery")
+    print("=" * 80)
+    for u in universe:
+        print(f"  {u}")
+    print(f"\ntotal directional-state tests pooled: {n}")
+    print(f"  within-cell candidate edges (uncorrected family-wide): {len(within)} "
+          f"(held-out is/oos {len(within_held)}, oos {len(within_oos)})")
+    print(f"  GLOBAL Benjamini-Hochberg q=0.05:  {n_bh} survive ({bh_aligned} policy-aligned)")
+    print(f"  GLOBAL Bonferroni p<= {bonf:.2e}:  {n_bonf} survive ({bonf_aligned} policy-aligned)")
+    print()
+    survivors = [r for b, r in zip(bh, directional) if b]
+    if survivors:
+        print("GLOBAL-BH SURVIVORS:")
+        for r in sorted(survivors, key=lambda x: x["p_value"]):
+            print(f"  {r['classifier']:10s} {r['symbol']:9s} {r['timeframe']:4s} "
+                  f"{r['window']:7s} h{r['horizon']:<3d} {r['state']:22s} "
+                  f"p={r['p_value']:.4f} gap={r['gap']:+.5f} aligned={r['sign_aligned']}")
+    else:
+        print("NO directional state survives global correction anywhere in the tested universe.")
+        print("=> the regime->direction premise has no statistically real, multiplicity-")
+        print("   honest forward-return separation on any (classifier, asset, timeframe,")
+        print("   window, horizon) tested. Consistent with #1073 finding 1, now generalized.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backtest/research/regime_1076_directional_premise.py
+++ b/backtest/research/regime_1076_directional_premise.py
@@ -1,0 +1,272 @@
+"""Scope-1 evidence for #1076: does the regime label predict forward DIRECTION?
+
+``regime_directional_policy`` (#779, scheduler/regime_directional_policy.go:5-16) bets a
+live HL perps strategy long/short on the CURRENT regime label (long in ``trending_up``,
+short in ``trending_down``). Its entire edge premise is regime -> forward-direction, and
+``allowed_regimes`` directional entry-gating shares it. #1073 finding 1 refuted that premise
+for the 7-state composite classifier on BTC/USDT 1h (0/35 block-shuffle tests).
+
+This script generalizes the test so the premise is judged on the surface the policy actually
+keys on, across a multi-asset / multi-timeframe universe:
+
+  - BOTH classifiers a policy can key on: ``adx`` (3-state -- the policy-doc default form,
+    ``trending_up``/``trending_down``/``ranging``) and ``composite`` (7-state -- the #1073
+    surface).
+  - per-STATE block-shuffle significance with Benjamini-Hochberg FDR (reuses
+    backtest/regime_diagnostics.py:per_state_significance) so one state with real directional
+    separation is not masked by a null group-level statistic.
+  - per-state mean forward return + sign-vs-policy-direction, so a "significant but
+    wrong-signed" state (separation that would LOSE money under the policy mapping) is
+    distinguished from a genuine long/short edge.
+
+A state is a candidate edge only when it is FDR-significant AND its gap sign matches the
+policy's bet for that state (long states want gap > 0, short states gap < 0). The economic
+walk-forward test (#1076 scope 2) is the real arbiter; this is the statistical screen.
+
+Read-only; no live or Go path touched. Universe is fully CLI-parameterized.
+
+Run (needs the trading_bot.db OHLCV cache reachable from shared_tools/):
+
+    uv run --no-sync python backtest/research/regime_1076_directional_premise.py
+    uv run --no-sync python backtest/research/regime_1076_directional_premise.py \
+        --symbols BTC/USDT,ETH/USDT,SOL/USDT --timeframes 1h,4h --classifiers adx,composite
+"""
+from __future__ import annotations
+import os
+import sys
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_BACKTEST = os.path.abspath(os.path.join(_THIS_DIR, ".."))
+_ROOT = os.path.abspath(os.path.join(_BACKTEST, ".."))
+for _p in (_BACKTEST, _ROOT, os.path.join(_ROOT, "shared_tools")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import numpy as np
+
+from regime import (
+    compute_regime,
+    compute_regime_composite,
+    composite_feature_matrix,
+    _DEFAULT_COMPOSITE_THRESHOLDS,
+)
+from data_fetcher import load_cached_data
+from eval_windows import WINDOWS, PLATFORM
+from regime_diagnostics import forward_returns, separation, stability, per_state_significance
+from regime_stats import benjamini_hochberg
+
+# eval_windows split: "is"/"oos" are the recent forward-looking protocol windows
+# (2025-06 -> 2026); the 2023/2024/2025H1 windows are historical. A durable, tradeable
+# regime->direction edge must persist into the held-out forward windows, above all "oos"
+# (2026-) — a state significant only in a historical window is in-sample/regime-specific
+# overfit, not an edge the live policy can bank on today.
+HELD_OUT_FORWARD = ("is", "oos")
+
+DEFAULT_SYMBOLS = ("BTC/USDT", "ETH/USDT", "SOL/USDT")
+DEFAULT_TIMEFRAMES = ("1h", "4h")
+DEFAULT_WINDOWS = ("is", "oos", "2023", "2024", "2025H1")
+DEFAULT_HORIZONS = (1, 4, 8, 12, 24, 48, 72)
+DEFAULT_CLASSIFIERS = ("adx", "composite")
+COMPOSITE_PERIOD = 48        # matches #1073 / the live composite default lookback
+ADX_PERIOD = 14              # Wilder standard for the 3-state directional classifier
+ADX_THRESHOLD = 20.0         # compute_regime / _normalize_spec default
+
+
+def _policy_direction(label: str) -> int:
+    """The side regime_directional_policy bets for a state: +1 long, -1 short, 0 neutral."""
+    if label.startswith("trending_up"):
+        return +1
+    if label.startswith("trending_down"):
+        return -1
+    return 0
+
+
+def _label_stream(close_df, classifier, th):
+    """Return (close array, per-bar label array, valid mask dropping warmup bars)."""
+    if classifier == "composite":
+        labels = compute_regime_composite(close_df, period=COMPOSITE_PERIOD,
+                                          thresholds=th)["regime"].to_numpy()
+        features = composite_feature_matrix(close_df, COMPOSITE_PERIOD, th).to_numpy()
+        valid = ~np.isnan(features).any(axis=1)
+    elif classifier == "adx":
+        labels = compute_regime(close_df, period=ADX_PERIOD,
+                                adx_threshold=ADX_THRESHOLD)["regime"].to_numpy()
+        valid = np.ones(len(labels), dtype=bool)
+        valid[:ADX_PERIOD] = False     # Wilder ADX warmup -> default 'ranging', not a real read
+    else:
+        raise SystemExit(f"unknown classifier {classifier!r}")
+    return close_df["close"].to_numpy(), labels, valid
+
+
+def _load(symbol, timeframe, window, classifier, th):
+    start, end = WINDOWS[window]
+    df = load_cached_data(symbol, timeframe, exchange_id=PLATFORM,
+                          start_date=start, end_date=end)
+    if len(df) <= max(COMPOSITE_PERIOD, ADX_PERIOD) + 5:
+        return None
+    close, labels, valid = _label_stream(df, classifier, th)
+    vlabels = labels[valid]
+    st = stability(vlabels)
+    mean_dwell = (float(np.mean(list(st["mean_dwell"].values())))
+                  if st["mean_dwell"] else 1.0)
+    return {"close": close, "valid": valid, "vlabels": vlabels, "mean_dwell": mean_dwell}
+
+
+def run(symbols, timeframes, windows, horizons, classifiers, th, n_perm, seed):
+    """Returns a flat list of per-(classifier,symbol,tf,window,horizon,state) result rows."""
+    rows = []
+    for classifier in classifiers:
+        for symbol in symbols:
+            for timeframe in timeframes:
+                for window in windows:
+                    d = _load(symbol, timeframe, window, classifier, th)
+                    if d is None:
+                        continue
+                    for h in horizons:
+                        fwd = forward_returns(d["close"], h)[d["valid"]]
+                        if np.isnan(fwd).all():
+                            continue
+                        bl = max(int(3 * d["mean_dwell"]), h)
+                        per_state = per_state_significance(d["vlabels"], fwd, bl,
+                                                           n_perm=n_perm, seed=seed)
+                        sep = separation(d["vlabels"], fwd)["per_state"]
+                        for state, r in per_state.items():
+                            pol = _policy_direction(state)
+                            gap = float(r["gap"])
+                            # candidate edge: FDR-significant AND gap sign matches policy bet.
+                            # bool() casts numpy bool_ -> Python bool so the row JSON-dumps.
+                            aligned = bool(pol != 0 and np.sign(gap) == pol)
+                            rows.append({
+                                "classifier": classifier, "symbol": symbol,
+                                "timeframe": timeframe, "window": window, "horizon": int(h),
+                                "state": str(state), "gap": gap,
+                                "mean_fwd": float(sep.get(state, {}).get("mean", float("nan"))),
+                                "p_value": float(r["p_value"]),
+                                "fdr_reject": bool(r["fdr_reject"]),
+                                "policy_dir": int(pol), "sign_aligned": aligned,
+                                "candidate_edge": bool(r["fdr_reject"] and aligned),
+                            })
+    return rows
+
+
+def report(rows, classifiers):
+    directional = [r for r in rows if r["policy_dir"] != 0]   # trending_* states only
+    n_dir = len(directional)
+    n_fdr = sum(r["fdr_reject"] for r in directional)
+    candidates = [r for r in directional if r["candidate_edge"]]
+
+    print("=" * 78)
+    print("PER-STATE DIRECTIONAL SIGNIFICANCE SUMMARY (#1076 scope 1)")
+    print("=" * 78)
+    print(f"directional-state tests (trending_up*/trending_down* only): {n_dir}")
+    print(f"  FDR-significant (any sign):                {n_fdr}")
+    print(f"  FDR-significant AND policy-sign-aligned:   {len(candidates)}  <- candidate edges")
+    print()
+
+    # per-classifier breakdown
+    for c in classifiers:
+        cr = [r for r in directional if r["classifier"] == c]
+        if not cr:
+            continue
+        cf = sum(r["fdr_reject"] for r in cr)
+        cc = sum(r["candidate_edge"] for r in cr)
+        wrong = sum(r["fdr_reject"] and not r["sign_aligned"] for r in cr)
+        print(f"[{c:9s}] {len(cr):4d} tests | FDR-sig {cf:3d} "
+              f"(aligned {cc}, wrong-signed {wrong})")
+    print()
+
+    # GLOBAL multiple-comparisons correction. per_state_significance applies BH only
+    # WITHIN a (classifier,symbol,tf,window,horizon) cell. Running ~N such cells is a
+    # family of N*states tests, so within-cell "significant" hits are expected by chance.
+    # The honest screen corrects across the WHOLE directional family.
+    pvals = [r["p_value"] for r in directional]
+    n = len(pvals)
+    global_bh = benjamini_hochberg(pvals, alpha=0.05) if pvals else []
+    bonf_thresh = 0.05 / n if n else 0.0
+    n_global_bh = sum(global_bh)
+    n_bonf = sum(p <= bonf_thresh for p in pvals)
+    # aligned survivors under each global correction
+    bh_aligned = sum(b and r["sign_aligned"] for b, r in zip(global_bh, directional))
+    bonf_aligned = sum((r["p_value"] <= bonf_thresh) and r["sign_aligned"]
+                       for r in directional)
+    print("GLOBAL multiple-comparisons correction across ALL "
+          f"{n} directional-state tests:")
+    print(f"  Benjamini-Hochberg FDR q=0.05:  {n_global_bh:3d} survive "
+          f"({bh_aligned} policy-aligned)")
+    print(f"  Bonferroni  (p<= {bonf_thresh:.2e}): {n_bonf:3d} survive "
+          f"({bonf_aligned} policy-aligned)")
+    print()
+
+    # Held-out-forward persistence: candidate edges that land in is/oos (2025-06->2026),
+    # the windows the live policy must work in. Historical-only hits are overfit.
+    held = [r for r in candidates if r["window"] in HELD_OUT_FORWARD]
+    oos = [r for r in candidates if r["window"] == "oos"]
+    print("Within-cell candidate edges by window class:")
+    print(f"  held-out forward (is/oos): {len(held):2d}    of which oos(2026-): {len(oos):2d}")
+    print(f"  historical (2023/2024/2025H1): {len(candidates) - len(held):2d}")
+    print()
+
+    if candidates:
+        print("WITHIN-CELL candidate edges (FDR-sig + policy-aligned; NOT globally corrected):")
+        print(f"{'clf':10s} {'sym':9s} {'tf':4s} {'win':7s} {'h':>3s} {'state':22s} "
+              f"{'gap':>10s} {'mean_fwd':>10s} {'p':>7s} {'gBH':>4s}")
+        print("-" * 100)
+        bh_set = {id(r) for b, r in zip(global_bh, directional) if b}
+        for r in sorted(candidates, key=lambda x: x["p_value"]):
+            print(f"{r['classifier']:10s} {r['symbol']:9s} {r['timeframe']:4s} "
+                  f"{r['window']:7s} {r['horizon']:3d} {r['state']:22s} "
+                  f"{r['gap']:10.5f} {r['mean_fwd']:10.5f} {r['p_value']:7.3f} "
+                  f"{'Y' if id(r) in bh_set else '.':>4s}")
+        print("(gBH = survives GLOBAL Benjamini-Hochberg across the whole battery.)")
+    else:
+        print("NO within-cell candidate edges on any tested cell. The premise holds nowhere here.")
+    print()
+
+
+def build_parser():
+    import argparse
+    p = argparse.ArgumentParser(description="#1076 scope-1: regime->direction premise screen")
+    p.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
+    p.add_argument("--timeframes", default=",".join(DEFAULT_TIMEFRAMES))
+    p.add_argument("--windows", default=",".join(DEFAULT_WINDOWS),
+                   help=f"comma-separated; known: {', '.join(WINDOWS)}")
+    p.add_argument("--horizons", default=",".join(str(h) for h in DEFAULT_HORIZONS))
+    p.add_argument("--classifiers", default=",".join(DEFAULT_CLASSIFIERS),
+                   help="comma-separated subset of: adx, composite")
+    p.add_argument("--n-perm", type=int, default=500)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--out", default="", help="optional path to dump all result rows as JSON")
+    return p
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    th = dict(_DEFAULT_COMPOSITE_THRESHOLDS)
+    symbols = tuple(s.strip() for s in args.symbols.split(",") if s.strip())
+    timeframes = tuple(t.strip() for t in args.timeframes.split(",") if t.strip())
+    windows = tuple(w.strip() for w in args.windows.split(",") if w.strip())
+    for w in windows:
+        if w not in WINDOWS:
+            raise SystemExit(f"unknown window {w}; known: {list(WINDOWS)}")
+    horizons = tuple(int(h) for h in args.horizons.split(","))
+    classifiers = tuple(c.strip() for c in args.classifiers.split(",") if c.strip())
+
+    print(f"# universe: {list(symbols)} x {list(timeframes)} x {list(windows)}")
+    print(f"# classifiers={list(classifiers)} horizons={list(horizons)} "
+          f"n_perm={args.n_perm} platform={PLATFORM}\n")
+    rows = run(symbols, timeframes, windows, horizons, classifiers, th,
+               args.n_perm, args.seed)
+    report(rows, classifiers)
+    if args.out:
+        import json
+        with open(args.out, "w") as fh:
+            json.dump({"universe": {"symbols": list(symbols), "timeframes": list(timeframes),
+                                    "windows": list(windows), "horizons": list(horizons),
+                                    "classifiers": list(classifiers), "n_perm": args.n_perm,
+                                    "platform": PLATFORM}, "rows": rows}, fh, indent=2)
+        print(f"# wrote {len(rows)} rows -> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backtest/research/regime_1076_economic_sim.py
+++ b/backtest/research/regime_1076_economic_sim.py
@@ -1,0 +1,320 @@
+"""Scope-2 (economic, isolation form) evidence for #1076: does choosing trade SIDE by the
+current regime label earn risk-adjusted PnL the regime-agnostic base does not?
+
+``regime_directional_policy`` (#779) overrides a live strategy's long/short side from the
+current regime label. Scope 1 (regime_1076_directional_premise.py) screens whether the label
+*statistically* separates forward returns. This is the economic complement: a look-ahead-safe
+regime-timing portfolio that prices the bare directional premise with no strategy-signal
+confound.
+
+Three always-in-market (or in/flat) books on identical bars, each side decided from the
+regime label known at the PRIOR bar close (mirrors the backtester's regime shift(1), #730):
+
+  policy      long in trending_up*, SHORT in trending_down*, flat (or long) in ranging*
+  long_only   long in trending_up*, flat otherwise        (isolates "short the downtrend" value)
+  buyhold     long every bar                              (regime-agnostic base)
+
+If `policy` does not beat `buyhold`/`long_only` on BOTH Sharpe and DDadj on the held-out
+forward windows (is/oos, 2025-06->2026), the regime->direction premise has no economic value
+to confer. Shorting funding cost is omitted, which FAVORS `policy` — so a `policy` loss here
+is conservative. Fees are charged on turnover (taker bps per unit side change).
+
+This is the transparent isolation; the live-faithful confirmation runs the actual Backtester +
+regime_directional_policy config (separate harness). Read-only; no live/Go path touched.
+
+    uv run --no-sync python backtest/research/regime_1076_economic_sim.py
+    uv run --no-sync python backtest/research/regime_1076_economic_sim.py \
+        --symbols BTC/USDT --timeframes 1h --classifiers adx --ranging-mode long
+"""
+from __future__ import annotations
+import os
+import sys
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_BACKTEST = os.path.abspath(os.path.join(_THIS_DIR, ".."))
+_ROOT = os.path.abspath(os.path.join(_BACKTEST, ".."))
+for _p in (_BACKTEST, _ROOT, os.path.join(_ROOT, "shared_tools")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import numpy as np
+
+from regime import (compute_regime, compute_regime_composite,
+                    composite_feature_matrix, _DEFAULT_COMPOSITE_THRESHOLDS)
+from data_fetcher import load_cached_data
+from eval_windows import WINDOWS, PLATFORM, dd_adjusted_return
+from regime_stats import benjamini_hochberg
+
+DEFAULT_SYMBOLS = ("BTC/USDT", "ETH/USDT", "SOL/USDT")
+DEFAULT_TIMEFRAMES = ("1h", "4h")
+DEFAULT_WINDOWS = ("is", "oos", "2023", "2024", "2025H1")
+DEFAULT_CLASSIFIERS = ("adx", "composite")
+HELD_OUT_FORWARD = ("is", "oos")
+COMPOSITE_PERIOD = 48
+ADX_PERIOD = 14
+ADX_THRESHOLD = 20.0
+BARS_PER_YEAR = {"15m": 4 * 24 * 365, "30m": 2 * 24 * 365, "1h": 24 * 365,
+                 "2h": 12 * 365, "4h": 6 * 365, "1d": 365}
+
+
+def _policy_side(label: str, ranging_mode: str) -> int:
+    if label.startswith("trending_up"):
+        return +1
+    if label.startswith("trending_down"):
+        return -1
+    return +1 if ranging_mode == "long" else 0
+
+
+def _labels(df, classifier, th):
+    if classifier == "composite":
+        labels = compute_regime_composite(df, period=COMPOSITE_PERIOD,
+                                          thresholds=th)["regime"].to_numpy()
+        feats = composite_feature_matrix(df, COMPOSITE_PERIOD, th).to_numpy()
+        valid = ~np.isnan(feats).any(axis=1)
+    else:
+        labels = compute_regime(df, period=ADX_PERIOD,
+                                adx_threshold=ADX_THRESHOLD)["regime"].to_numpy()
+        valid = np.ones(len(labels), dtype=bool)
+        valid[:ADX_PERIOD] = False
+    return labels, valid
+
+
+def _book(close, decision_side, fee_rate):
+    """Equity metrics for a book. ``decision_side[t]`` is the side chosen at the CLOSE of
+    bar t from the regime known at bar t (labels[t]); it is held over the next move
+    close[t] -> close[t+1]. Mirrors the backtester's "decide at N, fill the N->N+1 move"
+    convention (#730) so the position never sees the return it is about to capture — the
+    look-ahead-free alignment that makes this consistent with the scope-1 forward-return
+    test. (Using decision_side[1:] here instead would let labels[t+1], which is computed
+    from close[t+1], pick the side for the t->t+1 move = look-ahead, and inflates Sharpe to
+    physically impossible levels.)"""
+    ret = close[1:] / close[:-1] - 1.0           # move t->t+1, indexed t in 0..N-2
+    pos = decision_side[:-1]                      # side decided at bar t, held over that move
+    prev = np.concatenate([[0.0], pos[:-1]])     # side held over the PRIOR move (flat at t=0)
+    gross = pos * ret
+    turnover = np.abs(pos - prev)                # unit side change entering the move at t
+    net = gross - turnover * fee_rate
+    eq = np.cumprod(1.0 + net)
+    if len(eq) == 0:
+        return None
+    total_ret = float(eq[-1] - 1.0) * 100.0
+    peak = np.maximum.accumulate(eq)
+    max_dd = float(np.min(eq / peak - 1.0)) * 100.0
+    mu, sd = float(np.mean(net)), float(np.std(net))
+    return {
+        "total_return_pct": total_ret,
+        "max_drawdown_pct": max_dd,
+        "sharpe": 0.0, "_mu": mu, "_sd": sd,
+        "ddadj": round(dd_adjusted_return(total_ret, max_dd), 3),
+        "exposure": float(np.mean(pos != 0)),
+        "n_flips": int(np.sum(turnover > 0)),
+    }
+
+
+def _annualize_sharpe(book, timeframe):
+    if book is None or book["_sd"] == 0:
+        return 0.0
+    bpy = BARS_PER_YEAR.get(timeframe, 365)
+    return round(book["_mu"] / book["_sd"] * np.sqrt(bpy), 3)
+
+
+def _sides(labels, valid, ranging_mode):
+    """Per-bar DECISION side arrays: entry[t] is the side chosen at bar t's close from
+    labels[t]; _book holds it over the t->t+1 move (the 1-bar lag lives in _book). A
+    warmup/invalid bar is forced flat for all books."""
+    n = len(labels)
+    pol = np.zeros(n); lon = np.zeros(n); buy = np.zeros(n)
+    for i in range(n):
+        if not valid[i]:
+            continue
+        lab = str(labels[i])
+        pol[i] = _policy_side(lab, ranging_mode)
+        lon[i] = 1 if lab.startswith("trending_up") else 0
+        buy[i] = 1
+    return pol, lon, buy
+
+
+def _mean_dwell(side):
+    """Average run length of the side series (its persistence / dwell)."""
+    n = len(side)
+    if n < 2:
+        return 1.0
+    boundaries = int(np.count_nonzero(side[1:] != side[:-1])) + 1
+    return n / boundaries
+
+
+def _block_shuffle(arr, block_len, rng):
+    n = len(arr)
+    block_len = max(1, int(block_len))
+    starts = list(range(0, n, block_len))
+    perm = rng.permutation(len(starts))
+    out = np.concatenate([arr[s:s + block_len] for s in (starts[i] for i in perm)])
+    return out[:n]
+
+
+def _placebo_pvalue(close, decision_side, timeframe, fee_rate, n_perm, seed):
+    """Block-shuffle the policy's per-bar SIDE decisions (preserving the long/short/flat mix
+    and dwell, destroying the alignment with price) and ask how often the shuffled book's
+    Sharpe matches/beats the real one. Small p => the regime label's TIMING carries economic
+    value beyond its marginal exposure; large p => the apparent edge is just the exposure mix
+    (e.g. defensive beta in a down sample), not regime->direction skill."""
+    real = _book(close, decision_side, fee_rate)
+    if real is None:
+        return None, None
+    real_sharpe = _annualize_sharpe(real, timeframe)
+    bl = max(int(3 * _mean_dwell(decision_side)), 1)
+    rng = np.random.default_rng(seed)
+    ge = 0
+    for _ in range(n_perm):
+        shuf = _block_shuffle(decision_side, bl, rng)
+        b = _book(close, shuf, fee_rate)
+        if b is not None and _annualize_sharpe(b, timeframe) >= real_sharpe:
+            ge += 1
+    return float((ge + 1) / (n_perm + 1)), real_sharpe
+
+
+def run(symbols, timeframes, windows, classifiers, th, ranging_mode, fee_rate,
+        placebo_perm=0, seed=0):
+    rows = []
+    for classifier in classifiers:
+        for symbol in symbols:
+            for timeframe in timeframes:
+                for window in windows:
+                    start, end = WINDOWS[window]
+                    df = load_cached_data(symbol, timeframe, exchange_id=PLATFORM,
+                                          start_date=start, end_date=end)
+                    if len(df) <= max(COMPOSITE_PERIOD, ADX_PERIOD) + 5:
+                        continue
+                    close = df["close"].to_numpy()
+                    labels, valid = _labels(df, classifier, th)
+                    pol_s, lon_s, buy_s = _sides(labels, valid, ranging_mode)
+                    books = {}
+                    for name, side in (("policy", pol_s), ("long_only", lon_s),
+                                       ("buyhold", buy_s)):
+                        b = _book(close, side, fee_rate)
+                        if b is not None:
+                            b["sharpe"] = _annualize_sharpe(b, timeframe)
+                        books[name] = b
+                    if books["policy"] is None or books["buyhold"] is None:
+                        continue
+                    p, bh, lo = books["policy"], books["buyhold"], books["long_only"]
+                    placebo_p = None
+                    if placebo_perm > 0:
+                        placebo_p, _ = _placebo_pvalue(close, pol_s, timeframe, fee_rate,
+                                                       placebo_perm, seed)
+                    rows.append({
+                        "classifier": classifier, "symbol": symbol, "timeframe": timeframe,
+                        "window": window,
+                        "policy": p, "long_only": lo, "buyhold": bh,
+                        "beats_buyhold": bool(p["sharpe"] > bh["sharpe"]
+                                              and p["ddadj"] > bh["ddadj"]),
+                        "beats_long_only": bool(lo is not None
+                                                and p["sharpe"] > lo["sharpe"]
+                                                and p["ddadj"] > lo["ddadj"]),
+                        "placebo_p": placebo_p,
+                    })
+    return rows
+
+
+def report(rows, ranging_mode, fee_rate):
+    print("=" * 96)
+    print(f"REGIME-TIMING ECONOMIC ISOLATION (#1076 scope 2) | ranging={ranging_mode} "
+          f"fee={fee_rate*1e4:.0f}bps/side")
+    print("=" * 96)
+    hdr = (f"{'clf':9s} {'sym':9s} {'tf':4s} {'win':7s} | "
+           f"{'pol_shrp':>8s} {'pol_ret':>8s} {'pol_dda':>8s} | "
+           f"{'bh_shrp':>8s} {'bh_ret':>8s} | {'>BH':>4s} {'>LO':>4s}")
+    print(hdr); print("-" * len(hdr))
+    for r in rows:
+        p, bh = r["policy"], r["buyhold"]
+        print(f"{r['classifier']:9s} {r['symbol']:9s} {r['timeframe']:4s} {r['window']:7s} | "
+              f"{p['sharpe']:8.2f} {p['total_return_pct']:8.1f} {p['ddadj']:8.2f} | "
+              f"{bh['sharpe']:8.2f} {bh['total_return_pct']:8.1f} | "
+              f"{'Y' if r['beats_buyhold'] else '.':>4s} "
+              f"{'Y' if r['beats_long_only'] else '.':>4s}")
+
+    held = [r for r in rows if r["window"] in HELD_OUT_FORWARD]
+    oos = [r for r in rows if r["window"] == "oos"]
+    print()
+    print("SUMMARY — policy beats regime-agnostic base on BOTH Sharpe AND DDadj:")
+    print(f"  all cells:           beats buyhold {sum(r['beats_buyhold'] for r in rows):3d}"
+          f"/{len(rows):<3d}   beats long_only {sum(r['beats_long_only'] for r in rows):3d}"
+          f"/{len(rows)}")
+    print(f"  held-out (is/oos):   beats buyhold {sum(r['beats_buyhold'] for r in held):3d}"
+          f"/{len(held):<3d}   beats long_only {sum(r['beats_long_only'] for r in held):3d}"
+          f"/{len(held)}")
+    print(f"  oos (2026-) only:    beats buyhold {sum(r['beats_buyhold'] for r in oos):3d}"
+          f"/{len(oos):<3d}   beats long_only {sum(r['beats_long_only'] for r in oos):3d}"
+          f"/{len(oos)}")
+    print()
+
+    # Placebo control: does the regime label's TIMING add economic value over its own
+    # block-shuffled null (same long/short/flat mix + dwell, randomized alignment)? Without
+    # this, "beats buyhold" in a down sample is indistinguishable from defensive beta.
+    placebo_rows = [r for r in rows if r.get("placebo_p") is not None]
+    if placebo_rows:
+        pvals = [r["placebo_p"] for r in placebo_rows]
+        rej = benjamini_hochberg(pvals, alpha=0.05)
+        n_raw = sum(p <= 0.05 for p in pvals)
+        n_bh = sum(rej)
+        print("PLACEBO CONTROL — real policy Sharpe vs its block-shuffled-label null:")
+        print(f"  cells where regime TIMING beats shuffled null (raw p<=0.05):     "
+              f"{n_raw:3d}/{len(placebo_rows)}")
+        print(f"  ... surviving Benjamini-Hochberg FDR q=0.05 across cells:        "
+              f"{n_bh:3d}/{len(placebo_rows)}")
+        survivors = [(r, p) for r, p, b in zip(placebo_rows, pvals, rej) if b]
+        for r, p in sorted(survivors, key=lambda x: x[1]):
+            print(f"    {r['classifier']:9s} {r['symbol']:9s} {r['timeframe']:4s} "
+                  f"{r['window']:7s}  placebo_p={p:.3f}  pol_sharpe={r['policy']['sharpe']:.2f}")
+        if n_bh == 0:
+            print("  => no cell's regime timing beats its own shuffled null after FDR: the")
+            print("     economic 'wins' are the exposure mix (defensive beta), NOT regime")
+            print("     direction skill. The premise has no economic edge to confer.")
+        print()
+
+
+def build_parser():
+    import argparse
+    p = argparse.ArgumentParser(description="#1076 scope-2: regime-timing economic isolation")
+    p.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
+    p.add_argument("--timeframes", default=",".join(DEFAULT_TIMEFRAMES))
+    p.add_argument("--windows", default=",".join(DEFAULT_WINDOWS))
+    p.add_argument("--classifiers", default=",".join(DEFAULT_CLASSIFIERS))
+    p.add_argument("--ranging-mode", default="flat", choices=("flat", "long"),
+                   help="side in ranging regimes: flat (default) or long")
+    p.add_argument("--fee-bps", type=float, default=10.0, help="taker fee bps per unit turnover")
+    p.add_argument("--placebo-perm", type=int, default=0,
+                   help="block-shuffle placebo permutations per cell (0=off; 300 for rigor)")
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--out", default="")
+    return p
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    th = dict(_DEFAULT_COMPOSITE_THRESHOLDS)
+    symbols = tuple(s.strip() for s in args.symbols.split(",") if s.strip())
+    timeframes = tuple(t.strip() for t in args.timeframes.split(",") if t.strip())
+    windows = tuple(w.strip() for w in args.windows.split(",") if w.strip())
+    for w in windows:
+        if w not in WINDOWS:
+            raise SystemExit(f"unknown window {w}; known: {list(WINDOWS)}")
+    classifiers = tuple(c.strip() for c in args.classifiers.split(",") if c.strip())
+    fee_rate = args.fee_bps / 1e4
+
+    print(f"# universe: {list(symbols)} x {list(timeframes)} x {list(windows)} "
+          f"classifiers={list(classifiers)} platform={PLATFORM}\n")
+    rows = run(symbols, timeframes, windows, classifiers, th, args.ranging_mode, fee_rate,
+               placebo_perm=args.placebo_perm, seed=args.seed)
+    report(rows, args.ranging_mode, fee_rate)
+    if args.out:
+        import json
+        with open(args.out, "w") as fh:
+            json.dump({"ranging_mode": args.ranging_mode, "fee_bps": args.fee_bps,
+                       "placebo_perm": args.placebo_perm, "rows": rows}, fh, indent=2)
+        print(f"# wrote {len(rows)} rows -> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backtest/tests/test_regime_1076_economic_sim.py
+++ b/backtest/tests/test_regime_1076_economic_sim.py
@@ -1,0 +1,81 @@
+"""Regression tests for the #1076 regime-timing economic isolation (backtest/research).
+
+The load-bearing invariant is the look-ahead-safe alignment in ``_book``: the side decided
+at the close of bar t is held over the NEXT move (t -> t+1), never the move into bar t. A
+draft that used ``decision_side[t]`` for the t-1 -> t move produced impossible Sharpe ~9;
+these tests pin the corrected alignment so it cannot silently regress.
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+_RESEARCH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "research"))
+if _RESEARCH not in sys.path:
+    sys.path.insert(0, _RESEARCH)
+
+from regime_1076_economic_sim import (  # noqa: E402
+    _book, _block_shuffle, _mean_dwell, _policy_side,
+)
+
+
+def test_buyhold_book_equals_asset_return():
+    # An always-long book must reproduce the asset's buy-and-hold return exactly — proves
+    # the equity/alignment math has no off-by-one.
+    close = np.array([100.0, 110.0, 99.0, 108.0, 120.0])
+    bh = _book(close, np.ones(5), fee_rate=0.0)
+    assert bh["total_return_pct"] == pytest.approx((120.0 / 100.0 - 1) * 100)
+
+
+def test_no_lookahead_long_decided_after_jump_earns_nothing():
+    # close jumps 100 -> 200 over the bar1 -> bar2 move. A long decided AT bar 2 (the bar
+    # whose close already printed 200) must NOT capture that move: side at bar 2 governs the
+    # 2 -> 3 move (200 -> 200 = flat). Capturing it would be look-ahead.
+    close = np.array([100.0, 100.0, 200.0, 200.0, 200.0])
+    side_at_jump = np.array([0.0, 0.0, 1.0, 0.0, 0.0])
+    assert _book(close, side_at_jump, fee_rate=0.0)["total_return_pct"] == pytest.approx(0.0)
+
+
+def test_long_decided_before_jump_earns_it():
+    # The mirror: a long decided at bar 1 (prior to the jump) governs the 1 -> 2 move and
+    # earns the full +100%.
+    close = np.array([100.0, 100.0, 200.0, 200.0, 200.0])
+    side_prior = np.array([0.0, 1.0, 0.0, 0.0, 0.0])
+    assert _book(close, side_prior, fee_rate=0.0)["total_return_pct"] == pytest.approx(100.0)
+
+
+def test_short_earns_downmove_with_prior_decision():
+    # A short decided at bar 1 governs the 1 -> 2 down-move (-50%) and earns +50%.
+    close = np.array([100.0, 100.0, 50.0, 50.0])
+    side = np.array([0.0, -1.0, 0.0, 0.0])
+    assert _book(close, side, fee_rate=0.0)["total_return_pct"] == pytest.approx(50.0)
+
+
+def test_fee_charged_on_turnover():
+    # Flat market; flip flat->long then long->flat. Two unit turnovers at 1% each compound
+    # the equity to 0.99 * 0.99, independent of price (which never moves).
+    close = np.array([100.0, 100.0, 100.0])
+    side = np.array([1.0, 0.0, 0.0])
+    got = _book(close, side, fee_rate=0.01)["total_return_pct"]
+    assert got == pytest.approx((0.99 * 0.99 - 1) * 100)
+
+
+def test_block_shuffle_preserves_multiset_and_length():
+    rng = np.random.default_rng(0)
+    arr = np.array([1.0, 1.0, 0.0, -1.0, -1.0, 0.0, 1.0, 0.0, -1.0, 1.0])
+    sh = _block_shuffle(arr, 2, rng)
+    assert len(sh) == len(arr)
+    assert sorted(sh.tolist()) == sorted(arr.tolist())
+
+
+def test_mean_dwell_constant_series():
+    assert _mean_dwell(np.ones(10)) == pytest.approx(10.0)        # never changes -> one run
+    assert _mean_dwell(np.array([1.0, -1.0, 1.0, -1.0])) == pytest.approx(1.0)  # flips every bar
+
+
+def test_policy_side_mapping():
+    assert _policy_side("trending_up_clean", "flat") == 1
+    assert _policy_side("trending_down_choppy", "flat") == -1
+    assert _policy_side("ranging_quiet", "flat") == 0
+    assert _policy_side("ranging_quiet", "long") == 1

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -1267,6 +1267,33 @@ func ValidateConfig(cfg *Config) error {
 	return validateConfig(cfg, false)
 }
 
+// regimeDirectionalPolicyWarnings returns one operator warning per strategy that selects
+// trade side from the regime label (regime_directional_policy, #779). #1076 validated that
+// premise — regime -> forward DIRECTION — and found it empirically false across BTC/ETH/SOL/
+// BNB/XRP and five timeframes: 0 of 2121 per-state forward-return tests survive global
+// Benjamini-Hochberg/Bonferroni correction, and a look-ahead-safe regime-timing book never
+// beats its own block-shuffled-label null (0/60 after FDR). So this surface chooses long vs
+// short on noise; its only realized effect is a change in exposure (defensive beta in a down
+// sample), not a directional forecast. The warning is advisory and NON-BREAKING — existing
+// live configs still load — because hard-rejecting the keys is the less safe option: a forced
+// disable relies on the #822 orphan auto-close, which fires only for sole-owner coins
+// (hyperliquid_balance.go), so a shared-coin live short would be stranded for manual close.
+// Operators should disable from FLAT (SIGHUP blocks the change while a position is open,
+// config_reload.go) and use the regime for ATR-scaled SL/TP sizing (#1078), its real signal.
+// Returned (not printed) so the set is unit-testable; validateConfig prints them.
+func regimeDirectionalPolicyWarnings(cfg *Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	var out []string
+	for _, sc := range cfg.Strategies {
+		if sc.RegimeDirectionalPolicy.IsConfigured() {
+			out = append(out, fmt.Sprintf("[WARN] %s: regime_directional_policy selects long/short by regime, but the regime→forward-direction premise is empirically unvalidated (#1076 negative result) — it changes exposure, not a directional forecast. Prefer the regime for ATR-scaled SL/TP sizing (#1078); disable from flat.", sc.ID))
+		}
+	}
+	return out
+}
+
 func validateConfig(cfg *Config, skipLiveCredentialChecks bool) error {
 	var errs []string
 	seenIDs := make(map[string]bool)
@@ -1927,6 +1954,11 @@ func validateConfig(cfg *Config, skipLiveCredentialChecks bool) error {
 				fmt.Printf("[WARN] %s: allowed_regimes is set but regime.enabled=false — gate is a no-op until regime detection is enabled\n", sc.ID)
 			}
 		}
+	}
+
+	// #1076: warn on the regime→direction selection surface (premise empirically refuted).
+	for _, w := range regimeDirectionalPolicyWarnings(cfg) {
+		fmt.Println(w)
 	}
 
 	knownPlatforms := make(map[string]bool)

--- a/scheduler/config_regime_directional_warn_test.go
+++ b/scheduler/config_regime_directional_warn_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// #1076: regimeDirectionalPolicyWarnings must emit exactly one advisory per strategy that
+// configures the regime→direction selection surface, and stay silent otherwise. The warning
+// is the non-breaking guard chosen after the premise was empirically refuted; hard-rejecting
+// the keys was rejected as less safe (a forced disable can strand a shared-coin live short).
+func TestRegimeDirectionalPolicyWarnings(t *testing.T) {
+	cfg := &Config{Strategies: []StrategyConfig{
+		{ID: "plain-long"}, // no policy → no warning
+		{ID: "dir-policy", RegimeDirectionalPolicy: &RegimeDirectionalPolicy{
+			TrendRegime: map[string]RegimeDirectionalEntry{
+				"trending_up":   {Direction: "long"},
+				"trending_down": {Direction: "short"},
+				"ranging":       {Direction: "long"},
+			},
+		}},
+		{ID: "allowed-only", AllowedRegimes: []string{"trending_up"}}, // entry-gating, not direction
+	}}
+
+	warns := regimeDirectionalPolicyWarnings(cfg)
+	if len(warns) != 1 {
+		t.Fatalf("want exactly 1 warning (only the regime_directional_policy strategy), got %d: %v",
+			len(warns), warns)
+	}
+	w := warns[0]
+	if !strings.Contains(w, "dir-policy") {
+		t.Errorf("warning must name the offending strategy id; got %q", w)
+	}
+	if !strings.Contains(w, "#1076") {
+		t.Errorf("warning must cite the #1076 evidence; got %q", w)
+	}
+	if !strings.HasPrefix(w, "[WARN]") {
+		t.Errorf("warning must use the [WARN] operator prefix; got %q", w)
+	}
+}
+
+// IsConfigured keys off TrendRegime/raw, so a strategy with the policy present but no other
+// trigger still warns — and a nil config must not panic.
+func TestRegimeDirectionalPolicyWarningsEdgeCases(t *testing.T) {
+	if got := regimeDirectionalPolicyWarnings(nil); got != nil {
+		t.Errorf("nil config must yield no warnings, got %v", got)
+	}
+	empty := &Config{Strategies: []StrategyConfig{{ID: "a"}, {ID: "b"}}}
+	if got := regimeDirectionalPolicyWarnings(empty); len(got) != 0 {
+		t.Errorf("strategies without the policy must yield no warnings, got %v", got)
+	}
+	// Policy present via TrendRegime → IsConfigured true → one warning.
+	one := &Config{Strategies: []StrategyConfig{{ID: "x", RegimeDirectionalPolicy: &RegimeDirectionalPolicy{
+		TrendRegime: map[string]RegimeDirectionalEntry{"trending_up": {Direction: "long"}},
+	}}}}
+	if got := regimeDirectionalPolicyWarnings(one); len(got) != 1 {
+		t.Fatalf("configured policy must yield 1 warning, got %d", len(got))
+	}
+}


### PR DESCRIPTION
## Summary

Validates the edge premise behind `regime_directional_policy` (#779) and regime directional entry-gating — **regime label → forward DIRECTION** — and generalizes #1073 finding 1 (BTC/USDT 1h) across assets, timeframes, both classifiers, statistically **and** economically. **The premise is false everywhere tested.**

Closes #1076.

## Scope 1 — per-state forward-return significance (statistical)

`regime_1076_directional_premise.py` reuses `regime_diagnostics.per_state_significance` (block-shuffle + Benjamini-Hochberg FDR) over **BTC/ETH/SOL/BNB/XRP × {15m,30m,1h,2h,4h} × 5 eval_windows × 7 horizons × {adx, composite}**. `regime_1076_aggregate.py` pools every test and corrects **once**, globally.

- **0 of 2121** directional-state tests survive global Benjamini-Hochberg **or** Bonferroni correction.
- The 20 within-cell candidate edges are multiplicity noise — they cluster in single historical windows at correlated horizons; only **one** lands in a held-out window (BTC 4h `oos`, h1 — a single-bar artifact).
- For the composite classifier, FDR-significant states are **wrong-signed as often as aligned** (noise, not signal).

## Scope 2 — economic walk-forward (the real arbiter)

`regime_1076_economic_sim.py` is a look-ahead-safe regime-timing book (side from the **prior** bar's regime, mirroring the backtester's `shift(1)`) vs buy-and-hold.

- The naive read is a trap: `policy` "beats buy-and-hold 12/12 in `oos`" only because `oos` (2026) was a down market and the policy is defensively flat/short — it is **destroyed** in bull windows (SOL 1h 2023: buy-and-hold +937% vs policy −32%).
- **Placebo control settles it:** block-shuffle the policy's side decisions (preserving the long/short/flat mix + dwell, destroying timing) → **0/60 cells** (both ranging modes) beat their own shuffled-label null after FDR. The "wins" are exposure mix (defensive beta), not regime→direction skill.

A look-ahead bug in the first draft (using `labels[t]` to trade the move *into* bar `t`) produced impossible Sharpe ~9; the committed `_book` decides the side at bar `t` and holds it over `t→t+1`, pinned by `backtest/tests/test_regime_1076_economic_sim.py` (a buy-and-hold book reproduces the asset return exactly).

## Guard (scope 3) — warn, not deprecate

`regimeDirectionalPolicyWarnings` (`scheduler/config.go`) emits a **non-breaking** `[WARN]` at config load for every strategy configuring `regime_directional_policy`. Warn is the **safer money-path choice**, a verified safety inversion:

1. A forced disable relies on the #822 orphan auto-close (`perpsRegimeDirectionOrphanConflict` → `runRegimeDirectionOrphanCloses`), which fires **only for sole-owner coins** — a shared-coin live short would be **stranded** for manual close.
1. SIGHUP already blocks adding/removing the policy while a position is open (`config_reload.go`), so the safe disable path is operator-driven **from flat**. A warning prompts exactly that; a blanket reject forces an unsafe transition.

Regime's real, validated signal is forward **volatility** (#1078), not direction — it should drive ATR-scaled SL/TP sizing, not side selection.

**Recommended follow-up (separate issue):** an evidence-gated, default-off migration that activates the directional surface only where a per-(asset, timeframe) validation gate certifies real edge — a live-money-behavior change deserving its own design.

## Deliverables

- `backtest/research/regime_1076_directional_premise.py` — scope-1 per-state significance battery
- `backtest/research/regime_1076_aggregate.py` — unified global multiple-comparisons correction
- `backtest/research/regime_1076_economic_sim.py` — scope-2 economic isolation + block-shuffle placebo
- `backtest/research/README_1076_directional_premise.md` — findings, method, reproduction
- `scheduler/config.go` + `scheduler/config_regime_directional_warn_test.go` — the warn guard + test
- `backtest/tests/test_regime_1076_economic_sim.py` — look-ahead-alignment regression tests

All research is read-only; the only runtime change is the advisory warning. Go + Python tests green.

---
LLM: Opus 4.8 | high | Harness: Claude Code
https://claude.ai/code/session_01AmxievGcAnzRxsDvdnCNyZ