### PR TITLE
feat(#1095): enriched-feature unsupervised vol-regime bake-off

### DIFF
--- a/backtest/regime_enriched_features.py
+++ b/backtest/regime_enriched_features.py
@@ -1,0 +1,191 @@
+"""Enriched feature matrix for the #1095 unsupervised vol-regime bake-off.
+
+The #1080 bake-off fit every candidate on exactly the hand-rule's own four inputs
+(``return_eff, range_eff, efficiency, adx`` from ``shared_tools/regime.composite_feature_matrix``).
+Clustering can only discover structure present in its inputs, so fitting on the rule's own
+features leaves little room to out-separate it. This module builds an ENRICHED matrix — the four
+canonical features (kept FIRST, in their canonical order) plus signals the hand-rule ignores:
+
+  * ``funding_rate``    — point-in-time Hyperliquid funding snapshot (``funding_fetcher``, #960
+                          backward ``merge_asof``; a future snapshot never reaches a past bar).
+  * ``volume_z``        — trailing rolling z-score of bar volume (turnover surprise vs the last
+                          ``vol_window`` bars, inclusive of the current bar — same causal window
+                          convention as the canonical features).
+  * ``htf_range_eff``   — a coarser-timeframe ``range_eff`` aligned so a base bar only ever sees a
+                          higher-timeframe bar that has already CLOSED at or before the base bar's
+                          open (strictly causal; conservatively staler than the canonical row,
+                          never leaking).
+
+Offline / research only. Live ``check_regime.py`` still builds only the canonical four-column
+matrix, so an enriched model is NOT drop-in for the live classifier — that delta is recorded for
+#1074 (see ``LIVE_WIRING_DELTA``), not solved here.
+
+DESIGN INVARIANT — canonical-first column order. ``map_latent_to_names`` names each state from the
+four canonical columns only; the extra signals shape cluster geometry, not the 7-label vocabulary.
+Keeping the canonical block first means ``canonical_indices=(0, 1, 2, 3)`` holds for every subset.
+``regime_hmm.forward_filter_labels`` is purely positional, so the SAME column order used at fit
+must be used at decode — ``assert_feature_contract`` / ``decode_with_model`` enforce that.
+"""
+from __future__ import annotations
+import os
+import sys
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+for _p in (_THIS_DIR, os.path.abspath(os.path.join(_THIS_DIR, "..")),
+           os.path.abspath(os.path.join(_THIS_DIR, "..", "shared_tools"))):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import numpy as np
+import pandas as pd
+
+from regime import composite_feature_matrix, _DEFAULT_COMPOSITE_THRESHOLDS
+
+# Canonical four, in the order composite_feature_matrix emits them. The naming path
+# (map_composite_label) consumes these by position; they MUST stay first and in this order.
+CANONICAL_COLUMNS = ["return_eff", "range_eff", "efficiency", "adx"]
+# Extra signals the hand-rule does not use. Appended AFTER the canonical block.
+ENRICHED_EXTRA_COLUMNS = ["funding_rate", "volume_z", "htf_range_eff"]
+ENRICHED_COLUMNS = CANONICAL_COLUMNS + ENRICHED_EXTRA_COLUMNS
+# Position of (return_eff, range_eff, efficiency, adx) inside any canonical-first matrix.
+CANONICAL_INDICES = (0, 1, 2, 3)
+
+# Recorded for #1074. An enriched model decodes from this column set on-cycle; live
+# check_regime.py builds only CANONICAL_COLUMNS, so live wiring would need to feed the same
+# enriched matrix (funding fetch + volume z-score + HTF resample) every cycle. Not solved here.
+LIVE_WIRING_DELTA = (
+    "Enriched models decode from ENRICHED_COLUMNS; live check_regime.py builds only "
+    "CANONICAL_COLUMNS. Live wiring (#1074) must feed funding_rate + volume_z + htf_range_eff "
+    "on-cycle in this exact order, or forward_filter_labels reads garbage."
+)
+
+
+def _infer_base_delta(index: pd.DatetimeIndex) -> pd.Timedelta:
+    """Median spacing of the bar index — the base timeframe as a Timedelta."""
+    if len(index) < 2:
+        raise ValueError("need >= 2 bars to infer the base timeframe")
+    diffs = pd.Series(index).diff().dropna()
+    med = diffs.median()
+    if not (pd.notna(med) and med > pd.Timedelta(0)):
+        raise ValueError("could not infer a positive base timeframe from the index")
+    return med
+
+
+def _volume_z_column(df: pd.DataFrame, window: int) -> np.ndarray:
+    """Trailing rolling z-score of volume over `window` bars, inclusive of the current bar.
+
+    Causal: the window ends at bar i and bar i's own volume is known at its close — the same
+    convention the canonical features use (their window i-period+1..i also includes bar i).
+    Warmup (fewer than `window` observations) is NaN. Zero-variance windows -> 0.0 (no surprise).
+    """
+    vol = df["volume"].astype(float)
+    roll = vol.rolling(window=window, min_periods=window)
+    mean = roll.mean()
+    std = roll.std(ddof=0)
+    z = (vol - mean) / std
+    z = z.where(std > 1e-12, 0.0)     # zero-variance window: defined surprise of 0.0, not inf/NaN
+    z = z.where(mean.notna(), np.nan)  # warmup (< window observations) stays NaN
+    return z.to_numpy(dtype=float)
+
+
+def _htf_range_eff_column(df: pd.DataFrame, period: int, thresholds: dict,
+                          htf_multiple: int) -> np.ndarray:
+    """Higher-timeframe range_eff aligned causally onto the base index.
+
+    Resample the base frame to `htf_multiple` x the base timeframe (OHLC + volume agg), compute
+    the canonical composite range_eff on the coarse frame, then assign each base bar the most
+    recent HTF bar that has already CLOSED at or before the base bar's OPEN time. A coarse bar
+    labelled T_open closes at T_open + htf_delta; matching on close <= base_open guarantees the
+    base bar never sees an in-progress HTF bar (no look-ahead). Warmup / no closed HTF bar -> NaN.
+    """
+    if htf_multiple < 2:
+        raise ValueError("htf_multiple must be >= 2 (a strictly coarser timeframe)")
+    if not isinstance(df.index, pd.DatetimeIndex):
+        raise TypeError("htf_range_eff needs a DatetimeIndex (timestamped bars)")
+    base_delta = _infer_base_delta(df.index)
+    htf_delta = base_delta * htf_multiple
+    agg = {"open": "first", "high": "max", "low": "min", "close": "last", "volume": "sum"}
+    htf = df.resample(htf_delta, closed="left", label="left").agg(agg).dropna(subset=["close"])
+    if len(htf) <= period:
+        return np.full(len(df), np.nan, dtype=float)
+    htf_feat = composite_feature_matrix(htf, period, thresholds)["range_eff"]
+    # Re-key to the HTF bar's CLOSE time; only closed bars may inform a base bar.
+    right = pd.DataFrame({
+        "ts": (htf_feat.index + htf_delta),
+        "htf_range_eff": htf_feat.to_numpy(dtype=float),
+    }).dropna(subset=["htf_range_eff"]).sort_values("ts").reset_index(drop=True)
+    if right.empty:
+        return np.full(len(df), np.nan, dtype=float)
+    left = pd.DataFrame({"ts": pd.DatetimeIndex(df.index)}).reset_index(drop=True)
+    merged = pd.merge_asof(left, right, on="ts", direction="backward")
+    return merged["htf_range_eff"].to_numpy(dtype=float)
+
+
+def enriched_feature_matrix(df: pd.DataFrame, period: int, thresholds: dict | None = None, *,
+                            funding: pd.DataFrame | None = None, vol_window: int | None = None,
+                            htf_multiple: int = 4,
+                            columns: list[str] | None = None) -> pd.DataFrame:
+    """Per-bar enriched feature matrix (canonical four FIRST, then the enabled extras).
+
+    All joins are causal — canonical window ends at the bar, funding/HTF use backward merges,
+    volume z-score uses a trailing window. Warmup and atr<=0 bars are NaN (dropped downstream by
+    the model's NaN mask). `funding` is the DataFrame(timestamp, rate) from
+    ``funding_fetcher.load_cached_funding``; when None/empty the funding column is all-NaN (the
+    model mask then drops every row, so a funding-bearing subset is effectively unavailable — the
+    bake-off harness detects and reports that rather than fitting on nothing).
+
+    `columns` selects a subset for ablations; the result preserves ENRICHED_COLUMNS order so the
+    canonical block stays first (canonical_indices == (0, 1, 2, 3)). Unknown names raise.
+    """
+    if thresholds is None:
+        thresholds = dict(_DEFAULT_COMPOSITE_THRESHOLDS)
+    if columns is None:
+        columns = list(ENRICHED_COLUMNS)
+    unknown = [c for c in columns if c not in ENRICHED_COLUMNS]
+    if unknown:
+        raise ValueError(f"unknown enriched columns {unknown}; known: {ENRICHED_COLUMNS}")
+    # Re-order to the canonical-first global order regardless of caller order, so the canonical
+    # block always leads (canonical_indices == (0, 1, 2, 3)) and the naming path stays positional.
+    columns = [c for c in ENRICHED_COLUMNS if c in columns]
+
+    vol_window = int(vol_window) if vol_window else int(period)
+    out = pd.DataFrame(index=df.index)
+    canon = composite_feature_matrix(df, period, thresholds)
+    for col in CANONICAL_COLUMNS:
+        out[col] = canon[col].to_numpy(dtype=float)
+    if "funding_rate" in columns:
+        from funding_fetcher import attach_funding_column
+        out["funding_rate"] = attach_funding_column(df, funding)["funding_rate"].to_numpy(dtype=float)
+    if "volume_z" in columns:
+        out["volume_z"] = _volume_z_column(df, vol_window)
+    if "htf_range_eff" in columns:
+        out["htf_range_eff"] = _htf_range_eff_column(df, period, thresholds, htf_multiple)
+    return out[columns]
+
+
+def canonical_indices_for(columns: list[str]) -> tuple[int, int, int, int]:
+    """Positions of (return_eff, range_eff, efficiency, adx) within `columns`. Requires all four
+    canonical columns present (naming needs them); raises otherwise."""
+    cols = list(columns)
+    missing = [c for c in CANONICAL_COLUMNS if c not in cols]
+    if missing:
+        raise ValueError(f"naming needs all canonical columns; missing {missing}")
+    return tuple(cols.index(c) for c in CANONICAL_COLUMNS)  # type: ignore[return-value]
+
+
+def assert_feature_contract(model: dict, columns: list[str]) -> None:
+    """Fail loudly when a decode matrix's columns don't match the model's fit columns exactly
+    (same names, same order). forward_filter_labels is positional, so a mismatch silently decodes
+    garbage — this turns it into an error at the boundary."""
+    fit_cols = list(model.get("features", []))
+    if list(columns) != fit_cols:
+        raise ValueError(
+            f"feature-order contract violated: model fit on {fit_cols} but decode matrix has "
+            f"{list(columns)} — forward_filter_labels needs identical column order")
+
+
+def decode_with_model(matrix: pd.DataFrame, model: dict):
+    """Decode causal labels for an enriched matrix, enforcing the column-order contract first."""
+    from regime_hmm import forward_filter_labels
+    assert_feature_contract(model, list(matrix.columns))
+    return forward_filter_labels(matrix.to_numpy(dtype=float), model)

--- a/backtest/regime_vol_model.py
+++ b/backtest/regime_vol_model.py
@@ -207,10 +207,17 @@ def fit_hmm(z, k, *, seed=0, iters=50, var_floor=1e-3, tol=1e-4):
 FITTERS = {"kmeans": fit_kmeans, "gmm": fit_gmm, "hmm": fit_hmm}
 
 
-def map_latent_to_names(em_mean_z, feature_means, feature_stds, thresholds):
+def map_latent_to_names(em_mean_z, feature_means, feature_stds, thresholds,
+                        *, canonical_indices=(0, 1, 2, 3)):
     """Name each latent state by un-standardizing its centroid to raw feature space and running
     the canonical map_composite_label on it. Uses only training-window centroids (no per-bar
-    hand-rule labels). volatility_rank orders states by centroid range_eff (ascending)."""
+    hand-rule labels). volatility_rank orders states by centroid range_eff (ascending).
+
+    DECOUPLES fit-features from naming-features (#1095): a model may be fit on an ENRICHED matrix
+    (canonical four + extra signals), but states are still named from only the four canonical
+    columns. `canonical_indices` = the positions of (return_eff, range_eff, efficiency, adx) within
+    the fit matrix; the extra dims shape cluster geometry, never the 7-label vocabulary. Defaults
+    to (0,1,2,3) so the legacy 4-column path is unchanged. `centroid_raw` carries ALL fit dims."""
     from regime import map_composite_label
     em_mean_z = np.asarray(em_mean_z, dtype=float)
     mean = np.asarray(feature_means, dtype=float)
@@ -219,13 +226,16 @@ def map_latent_to_names(em_mean_z, feature_means, feature_stds, thresholds):
     if mean.shape != (d,) or std.shape != (d,):     # a mis-shaped scalar/wrong-length std would
         raise ValueError(f"feature_means/stds must be shape ({d},); "  # silently broadcast garbage
                          f"got {mean.shape} and {std.shape}")
+    ri, gi, ei, ai = (int(x) for x in canonical_indices)  # return_eff, range_eff, efficiency, adx
+    if not all(0 <= x < d for x in (ri, gi, ei, ai)):
+        raise ValueError(f"canonical_indices {tuple(canonical_indices)} out of range for {d} dims")
     raw = em_mean_z * std + mean                       # un-standardize centroids -> raw features
-    order = sorted(range(len(raw)), key=lambda i: (raw[i, 1], i))   # by range_eff, stable on ties
+    order = sorted(range(len(raw)), key=lambda i: (raw[i, gi], i))  # by range_eff, stable on ties
     rank = {i: r for r, i in enumerate(order)}
     names, mapping = [], {}
     for i in range(len(raw)):
         # map_composite_label(return_eff, adx_val, range_eff, efficiency, thresholds)
-        name = map_composite_label(raw[i, 0], raw[i, 3], raw[i, 1], raw[i, 2], thresholds)
+        name = map_composite_label(raw[i, ri], raw[i, ai], raw[i, gi], raw[i, ei], thresholds)
         names.append(name)
         mapping[str(i)] = {"name": name, "centroid_raw": raw[i].tolist(),
                            "volatility_rank": int(rank[i])}
@@ -233,27 +243,40 @@ def map_latent_to_names(em_mean_z, feature_means, feature_stds, thresholds):
 
 
 def fit_unsupervised(features, *, family, k, filter_window, period=48,
-                     thresholds=None, seed=0, fitted_on=None):
+                     thresholds=None, seed=0, fitted_on=None,
+                     feature_names=None, canonical_indices=(0, 1, 2, 3)):
     """Fit one unsupervised family and assemble the forward_filter_labels-decodable model dict.
     Emissions come from the family fit; the transition table + init are always estimated
-    empirically from the training-window state sequence; states are named post-fit from centroids."""
+    empirically from the training-window state sequence; states are named post-fit from centroids.
+
+    #1095: `features` may be an ENRICHED matrix (canonical four + extra signals). The fit, the
+    standardization, and `feature_means/feature_stds/emissions` all span EVERY column; naming
+    reads only the canonical columns via `canonical_indices`. `feature_names` (defaults to the
+    canonical FEATURES) and `canonical_indices` are recorded in the schema so decode can enforce
+    the column-order contract — forward_filter_labels is positional and must see the SAME columns
+    in the SAME order used here."""
     if family not in FITTERS:
         raise ValueError(f"unknown family {family!r}; known: {sorted(FITTERS)}")
     if thresholds is None:
         from regime import _DEFAULT_COMPOSITE_THRESHOLDS
         thresholds = dict(_DEFAULT_COMPOSITE_THRESHOLDS)
     features = np.asarray(features, dtype=float)
+    names_out = list(feature_names) if feature_names is not None else list(FEATURES)
+    if features.ndim != 2 or features.shape[1] != len(names_out):
+        raise ValueError(f"feature matrix has {features.shape[1] if features.ndim == 2 else '?'} "
+                         f"columns but feature_names lists {len(names_out)}")
     mean, std, mask = standardize(features)
     z = (features[mask] - mean) / std
     assign_valid, em_mean, em_var, counts = FITTERS[family](z, k, seed=seed)
     transition = empirical_transition(assign_valid, mask, k)
     init = init_distribution(transition)
-    names, mapping = map_latent_to_names(em_mean, mean, std, thresholds)
+    names, mapping = map_latent_to_names(em_mean, mean, std, thresholds,
+                                         canonical_indices=canonical_indices)
     emissions = [{"mean": em_mean[i].tolist(), "var": em_var[i].tolist(),
                   "n": int(counts[i])} for i in range(k)]
     return {
         "type": MODEL_TYPE, "version": MODEL_VERSION, "fit_method": family,
-        "features": list(FEATURES),
+        "features": names_out, "canonical_indices": [int(x) for x in canonical_indices],
         "feature_means": mean.tolist(), "feature_stds": std.tolist(),
         "states": names, "latent_count": int(k), "emissions": emissions,
         "transition": transition.tolist(), "init": init.tolist(),

--- a/backtest/research/regime_1095_enriched_vol_model.py
+++ b/backtest/research/regime_1095_enriched_vol_model.py
@@ -1,0 +1,259 @@
+"""Reproducible evidence for #1095: extend the #1080 unsupervised vol-regime bake-off to fit on an
+ENRICHED feature matrix — the four canonical hand-rule inputs PLUS signals the hand-rule ignores
+(funding rate, volume z-score, a higher-timeframe range_eff) — and report whether any candidate now
+clears the same forward-volatility gate without degenerating, plus a feature-subset ABLATION that
+attributes any separation gain to a specific added feature.
+
+Why: the #1080 negative result (no unsupervised model beats the hand-rule) was produced fitting
+every candidate on exactly the hand-rule's OWN four features. Clustering can only find structure in
+its inputs, so that result is partly a consequence of the input set. This harness gives the models a
+genuine chance by feeding extra causal signals, then re-runs the unchanged #1080 gate + anti-gaming
+guards (forward-volatility separation, non-degeneracy locked from the hand-rule's worst window,
+Bonferroni-corrected selection across the WHOLE sweep, now including the ablation arms).
+
+Fairness: each subset's enriched matrix has its own NaN warmup (funding / HTF / volume), so the
+candidate AND the hand-rule baseline are BOTH scored on that subset's identical valid-bar mask —
+gate_verdict then compares like-for-like retained bars. Non-degeneracy thresholds stay locked from
+the CANONICAL hand-rule (the incumbent the candidate must beat).
+
+Run (needs the OHLCV cache; funding cache/network optional — funding-bearing subsets that can't be
+built are reported "unavailable", never fit on nothing):
+
+    uv run --no-sync python backtest/research/regime_1095_enriched_vol_model.py
+    uv run --no-sync python backtest/research/regime_1095_enriched_vol_model.py \
+        --symbol ETH/USDT --timeframe 1h --json /tmp/regime_1095_eth.json
+
+Parameterized by --symbol/--timeframe (so #1083 multi-asset can reuse it). Read-only; no live or Go
+path touched. Live wiring of an enriched model is #1074, not solved here (see LIVE_WIRING_DELTA).
+"""
+from __future__ import annotations
+import os, sys
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_BACKTEST = os.path.abspath(os.path.join(_THIS_DIR, ".."))
+_ROOT = os.path.abspath(os.path.join(_BACKTEST, ".."))
+for _p in (_BACKTEST, _ROOT, os.path.join(_ROOT, "shared_tools")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import importlib.util
+
+import numpy as np
+
+from regime import (compute_regime_composite, composite_feature_matrix,
+                    _DEFAULT_COMPOSITE_THRESHOLDS)
+from data_fetcher import load_cached_data
+from eval_windows import WINDOWS, PLATFORM
+from regime_diagnostics import score_labels
+from regime_calibrate import gate_verdict, SIGNIFICANCE_ALPHA
+import regime_vol_model as rvm
+from regime_enriched_features import (CANONICAL_COLUMNS, ENRICHED_COLUMNS, ENRICHED_EXTRA_COLUMNS,
+                                      LIVE_WIRING_DELTA, enriched_feature_matrix,
+                                      canonical_indices_for, decode_with_model)
+
+DEFAULT_WINDOWS = ("is", "oos", "2023", "2024", "2025H1")
+MIN_VALID_BARS = 50  # below this a subset's matrix is too warmed-out to fit/score -> "unavailable"
+
+# Feature subsets swept. Every subset keeps the canonical four FIRST so states still name from them.
+# "canonical" reproduces #1080 as a sanity arm; each single-feature arm isolates one added signal;
+# "all_enriched" stacks them. The ablation reads separation gain across these arms.
+SUBSETS = {
+    "canonical": list(CANONICAL_COLUMNS),
+    "funding": CANONICAL_COLUMNS + ["funding_rate"],
+    "volume": CANONICAL_COLUMNS + ["volume_z"],
+    "htf": CANONICAL_COLUMNS + ["htf_range_eff"],
+    "all_enriched": list(ENRICHED_COLUMNS),
+}
+
+
+def _load_1080():
+    """Reuse #1080's select_winner + bonferroni_alpha (SSoT for the family-wise correction) and its
+    canonical hand-rule streams for the non-degeneracy thresholds."""
+    path = os.path.join(_THIS_DIR, "regime_1080_unsupervised_vol_model.py")
+    spec = importlib.util.spec_from_file_location("regime_1080_for_1095", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _funding_for_window(coin, window):
+    """Hyperliquid funding history covering a window; None on any failure (no cache/network in CI)
+    so funding-bearing subsets degrade to 'unavailable' rather than crashing the sweep."""
+    try:
+        from funding_fetcher import load_cached_funding
+        start, end = WINDOWS[window]
+        return load_cached_funding(coin, start, end)
+    except Exception:  # noqa: BLE001 — research harness must not die on a funding miss
+        return None
+
+
+def _enriched(symbol, timeframe, window, period, th, columns, funding, *, htf_multiple, vol_window):
+    df = load_cached_data(symbol, timeframe, exchange_id=PLATFORM,
+                          start_date=WINDOWS[window][0], end_date=WINDOWS[window][1])
+    mat = enriched_feature_matrix(df, period, th, funding=funding, vol_window=vol_window,
+                                  htf_multiple=htf_multiple, columns=columns)
+    return df, mat
+
+
+def _score(df, labels, mat, target="volatility"):
+    """Score a label stream on the enriched subset's mask (mat carries the NaN warmup that defines
+    which bars both arms are judged on)."""
+    return score_labels(df["close"].to_numpy(), labels, mat.to_numpy(dtype=float), target=target)
+
+
+def _valid_count(mat):
+    arr = mat.to_numpy(dtype=float)
+    return int((~np.isnan(arr).any(axis=1)).sum())
+
+
+def run_bakeoff(symbol="BTC/USDT", timeframe="1h", *, in_sample="is", held_out="oos",
+                eval_windows=DEFAULT_WINDOWS, families=("hmm", "gmm", "kmeans"),
+                k_range=range(2, 8), subsets=None, period=48, filter_window=64,
+                htf_multiple=4, vol_window=None, seed=0):
+    subsets = dict(subsets) if subsets is not None else dict(SUBSETS)
+    m1080 = _load_1080()
+    th = dict(_DEFAULT_COMPOSITE_THRESHOLDS)
+    coin = symbol.split("/")[0]
+
+    # Non-degeneracy thresholds: locked from the CANONICAL incumbent's worst window (anti-gaming),
+    # identical reference for every subset (#1080's helper).
+    hr_streams = m1080._handrule_streams(symbol, timeframe, eval_windows, period, th)
+    thresholds = rvm.derive_thresholds(list(hr_streams.values()))
+
+    funding_by_window = {w: _funding_for_window(coin, w) for w in eval_windows}
+
+    candidates = []
+    subset_status = {}
+    for sub_name, columns in subsets.items():
+        cidx = canonical_indices_for(columns)
+        needs_funding = "funding_rate" in columns
+        # Build the held-out + fit matrices for this subset once.
+        fit_df, fit_mat = _enriched(symbol, timeframe, in_sample, period, th, columns,
+                                    funding_by_window.get(in_sample),
+                                    htf_multiple=htf_multiple, vol_window=vol_window)
+        held_df, held_mat = _enriched(symbol, timeframe, held_out, period, th, columns,
+                                      funding_by_window.get(held_out),
+                                      htf_multiple=htf_multiple, vol_window=vol_window)
+        if _valid_count(fit_mat) < MIN_VALID_BARS or _valid_count(held_mat) < MIN_VALID_BARS:
+            subset_status[sub_name] = ("unavailable: too few valid bars after warmup"
+                                       + (" (funding cache/network missing?)" if needs_funding else ""))
+            continue
+        subset_status[sub_name] = "ok"
+        # Hand-rule baseline scored on THIS subset's held-out mask (fair like-for-like).
+        hr_labels = compute_regime_composite(held_df, period=period, thresholds=th)["regime"].to_numpy()
+        hr_held = _score(held_df, hr_labels, held_mat)
+        hr_tr = hr_held["stability"]["transition_rate"]
+
+        fit_feats = fit_mat.to_numpy(dtype=float)
+        for family in families:
+            for k in k_range:
+                model = rvm.fit_unsupervised(fit_feats, family=family, k=k,
+                                             filter_window=filter_window, period=period,
+                                             thresholds=th, seed=seed,
+                                             feature_names=columns, canonical_indices=cidx,
+                                             fitted_on={"symbol": symbol, "timeframe": timeframe,
+                                                        "window": in_sample, "subset": sub_name})
+                labels, _ = decode_with_model(held_mat, model)
+                md = _score(held_df, labels, held_mat)
+                verdict = gate_verdict(hr_held, md)
+                nd = {}
+                for w in eval_windows:
+                    wdf, wmat = _enriched(symbol, timeframe, w, period, th, columns,
+                                          funding_by_window.get(w),
+                                          htf_multiple=htf_multiple, vol_window=vol_window)
+                    wlabels, _ = decode_with_model(wmat, model)
+                    valid = ~np.isnan(wmat.to_numpy(dtype=float)).any(axis=1)
+                    nd[w] = rvm.non_degeneracy(np.asarray(wlabels, dtype=object)[valid], thresholds)
+                candidates.append({
+                    "subset": sub_name, "columns": list(columns), "family": family, "k": k,
+                    "verdict": verdict,
+                    "model_kruskal_h": md["h4"]["separation"]["kruskal_h"],
+                    "model_p_value": md["h4"]["significance"]["p_value"],
+                    "handrule_kruskal_h": hr_held["h4"]["separation"]["kruskal_h"],
+                    "stability_gain": float(hr_tr - md["stability"]["transition_rate"]),
+                    "coverage": md["coverage"],
+                    "non_degeneracy": {w: nd[w] for w in eval_windows},
+                    "non_degenerate_all": all(nd[w]["ok"] for w in eval_windows),
+                    "states": model["states"], "mapping": model["mapping"],
+                })
+
+    alpha = m1080.bonferroni_alpha(len(candidates)) if candidates else SIGNIFICANCE_ALPHA
+    for c in candidates:
+        c["passes_bonferroni"] = (c["model_p_value"] is not None and c["model_p_value"] <= alpha)
+    winner = m1080.select_winner(candidates)
+
+    # Ablation: best held-out separation per subset among non-degenerate candidates, and the gain
+    # over the canonical arm — attributes any improvement to the added feature(s).
+    ablation = {}
+    for sub_name in subsets:
+        elig = [c for c in candidates if c["subset"] == sub_name and c["non_degenerate_all"]]
+        best = max(elig, key=lambda c: c["model_kruskal_h"], default=None)
+        ablation[sub_name] = {
+            "status": subset_status.get(sub_name, "unavailable"),
+            "best_kruskal_h": (best["model_kruskal_h"] if best else None),
+            "best_candidate": ({"family": best["family"], "k": best["k"]} if best else None),
+            "any_ships": any(c["subset"] == sub_name and c["verdict"].get("ship")
+                             and c["non_degenerate_all"] and c["passes_bonferroni"]
+                             for c in candidates),
+        }
+    canon_best = ablation.get("canonical", {}).get("best_kruskal_h")
+    for sub_name, info in ablation.items():
+        info["separation_gain_vs_canonical"] = (
+            (info["best_kruskal_h"] - canon_best)
+            if (info["best_kruskal_h"] is not None and canon_best is not None) else None)
+
+    return {
+        "issue": 1095, "symbol": symbol, "timeframe": timeframe, "in_sample": in_sample,
+        "held_out": held_out, "target": "volatility", "htf_multiple": htf_multiple,
+        "candidate_count": len(candidates),
+        "significance_alpha": SIGNIFICANCE_ALPHA, "bonferroni_alpha": alpha,
+        "non_degeneracy_thresholds": vars(thresholds),
+        "subset_status": subset_status,
+        "ablation": ablation,
+        "candidates": candidates,
+        "winner": ({"subset": winner["subset"], "family": winner["family"], "k": winner["k"]}
+                   if winner else None),
+        "live_wiring_delta": LIVE_WIRING_DELTA,
+    }
+
+
+def build_parser():
+    import argparse
+    p = argparse.ArgumentParser(description="#1095 enriched unsupervised vol-regime bake-off")
+    p.add_argument("--symbol", default="BTC/USDT")
+    p.add_argument("--timeframe", default="1h")
+    p.add_argument("--in-sample", default="is")
+    p.add_argument("--held-out", default="oos")
+    p.add_argument("--period", type=int, default=48)
+    p.add_argument("--filter-window", type=int, default=64)
+    p.add_argument("--htf-multiple", type=int, default=4)
+    p.add_argument("--vol-window", type=int, default=None, help="volume z-score window (default: period)")
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--json", default=None, help="write the bake-off report JSON here")
+    return p
+
+
+def main(argv=None):
+    import json
+    args = build_parser().parse_args(argv)
+    report = run_bakeoff(args.symbol, args.timeframe, in_sample=args.in_sample,
+                         held_out=args.held_out, period=args.period,
+                         filter_window=args.filter_window, htf_multiple=args.htf_multiple,
+                         vol_window=args.vol_window, seed=args.seed)
+    text = json.dumps(report, indent=2, default=float)
+    if args.json:
+        with open(args.json, "w") as fh:
+            fh.write(text)
+    print(text)
+    w = report["winner"]
+    if w:
+        print(f"\nWINNER: {w}", file=sys.stderr)
+    else:
+        print("\nWINNER: none eligible (no gate-passing, non-degenerate, Bonferroni-clearing "
+              "candidate on this window) — second negative result; see 'ablation' for whether any "
+              "added feature improved separation even without shipping.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backtest/tests/test_regime_enriched_features.py
+++ b/backtest/tests/test_regime_enriched_features.py
@@ -1,0 +1,276 @@
+"""Tests for the #1095 enriched feature matrix and the fit/decode column-order contract.
+
+Covers: canonical-first column order, causal joins (look-ahead regression mirroring
+test_backtester_lookahead.py — future bars never change a past feature row), funding backward-only,
+HTF causal alignment, the fit<->decode column-order contract, and the decouple of fit-features from
+naming-features (states named from the four canonical columns regardless of extra dims or position).
+"""
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+_THIS = os.path.dirname(os.path.abspath(__file__))
+_BACKTEST = os.path.abspath(os.path.join(_THIS, ".."))
+_ROOT = os.path.abspath(os.path.join(_BACKTEST, ".."))
+for _p in (_BACKTEST, _ROOT, os.path.join(_ROOT, "shared_tools")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import regime_enriched_features as ref
+import regime_vol_model as rvm
+
+
+def _synthetic_ohlcv(n=600, seed=0):
+    """Hourly OHLCV with a DatetimeIndex, alternating trending/ranging segments so the canonical
+    composite features are non-degenerate, plus a volume series with regime-correlated bursts."""
+    rng = np.random.default_rng(seed)
+    idx = pd.date_range("2022-01-01", periods=n, freq="1h")
+    drift = np.where((np.arange(n) // 50) % 2 == 0, 0.002, 0.0)   # alternating trend/range blocks
+    rets = drift + rng.normal(0, 0.01, size=n)
+    close = 100 * np.cumprod(1 + rets)
+    high = close * (1 + np.abs(rng.normal(0, 0.004, size=n)))
+    low = close * (1 - np.abs(rng.normal(0, 0.004, size=n)))
+    openp = np.concatenate([[close[0]], close[:-1]])
+    volume = np.abs(rng.normal(1000, 200, size=n)) + (np.arange(n) // 50 % 2) * 500
+    return pd.DataFrame({"open": openp, "high": np.maximum(high, np.maximum(openp, close)),
+                         "low": np.minimum(low, np.minimum(openp, close)), "close": close,
+                         "volume": volume}, index=idx)
+
+
+def _synthetic_funding(idx, seed=1):
+    """Hourly funding (timestamp ms, rate) covering [first_bar, last_bar], first snapshot exactly on
+    the first bar so the column is not all-NaN."""
+    rng = np.random.default_rng(seed)
+    ts = (idx.as_unit("ns").asi8 // 1_000_000).astype("int64")   # -> epoch ms
+    rate = rng.normal(0.0001, 0.00005, size=len(idx))
+    return pd.DataFrame({"timestamp": ts, "rate": rate})
+
+
+# ---------------------------------------------------------------- column contract / ordering
+
+def test_canonical_columns_lead_enriched_set():
+    assert ref.ENRICHED_COLUMNS[:4] == ref.CANONICAL_COLUMNS
+    assert ref.CANONICAL_INDICES == (0, 1, 2, 3)
+    assert set(ref.ENRICHED_EXTRA_COLUMNS).isdisjoint(ref.CANONICAL_COLUMNS)
+
+
+def test_builder_full_matrix_columns_and_order():
+    df = _synthetic_ohlcv()
+    fund = _synthetic_funding(df.index)
+    mat = ref.enriched_feature_matrix(df, period=48, funding=fund)
+    assert list(mat.columns) == ref.ENRICHED_COLUMNS
+    assert len(mat) == len(df)
+
+
+def test_subset_selection_preserves_canonical_first_order():
+    df = _synthetic_ohlcv()
+    fund = _synthetic_funding(df.index)
+    # request out of order; builder must re-order to canonical-first global order
+    mat = ref.enriched_feature_matrix(df, period=48, funding=fund,
+                                      columns=["htf_range_eff", "adx", "return_eff",
+                                               "funding_rate", "range_eff", "efficiency"])
+    assert list(mat.columns) == ["return_eff", "range_eff", "efficiency", "adx",
+                                 "funding_rate", "htf_range_eff"]
+
+
+def test_builder_rejects_unknown_column():
+    df = _synthetic_ohlcv()
+    with pytest.raises(ValueError, match="unknown enriched columns"):
+        ref.enriched_feature_matrix(df, period=48, columns=["return_eff", "rsi_14"])
+
+
+def test_canonical_indices_for():
+    assert ref.canonical_indices_for(ref.ENRICHED_COLUMNS) == (0, 1, 2, 3)
+    # canonical not first -> indices track their real positions
+    cols = ["funding_rate", "return_eff", "range_eff", "efficiency", "adx"]
+    assert ref.canonical_indices_for(cols) == (1, 2, 3, 4)
+    with pytest.raises(ValueError, match="missing"):
+        ref.canonical_indices_for(["return_eff", "range_eff", "adx"])  # efficiency missing
+
+
+# ---------------------------------------------------------------- look-ahead invariants
+
+def test_enriched_matrix_is_causal_future_bars_do_not_change_past_rows():
+    df = _synthetic_ohlcv(n=600)
+    fund = _synthetic_funding(df.index)
+    base = ref.enriched_feature_matrix(df, period=48, funding=fund, htf_multiple=4)
+    t = 400
+    mutated = df.copy()
+    # blow up every bar AFTER t (prices and volume); past rows must be byte-identical
+    mutated.iloc[t + 1:, mutated.columns.get_loc("close")] *= 3.0
+    mutated.iloc[t + 1:, mutated.columns.get_loc("high")] *= 3.0
+    mutated.iloc[t + 1:, mutated.columns.get_loc("low")] *= 3.0
+    mutated.iloc[t + 1:, mutated.columns.get_loc("open")] *= 3.0
+    mutated.iloc[t + 1:, mutated.columns.get_loc("volume")] *= 9.0
+    after = ref.enriched_feature_matrix(mutated, period=48, funding=fund, htf_multiple=4)
+    a = base.iloc[: t + 1].to_numpy(dtype=float)
+    b = after.iloc[: t + 1].to_numpy(dtype=float)
+    assert np.array_equal(np.nan_to_num(a, nan=-7.0), np.nan_to_num(b, nan=-7.0))
+
+
+def test_funding_column_is_backward_only():
+    df = _synthetic_ohlcv(n=120)
+    # one funding snapshot at bar 60, value 0.005; bars < 60 see the prior (none -> NaN/earlier),
+    # bars >= 60 see 0.005 until any later snapshot. Build a sparse funding series.
+    idx = df.index
+    ts = (idx.as_unit("ns").asi8 // 1_000_000).astype("int64")
+    fund = pd.DataFrame({"timestamp": [ts[0], ts[60]], "rate": [0.001, 0.005]})
+    mat = ref.enriched_feature_matrix(df, period=24, funding=fund, columns=ref.CANONICAL_COLUMNS + ["funding_rate"])
+    fr = mat["funding_rate"].to_numpy()
+    assert fr[59] == pytest.approx(0.001)    # before the bar-60 snapshot -> still the bar-0 value
+    assert fr[60] == pytest.approx(0.005)    # at/after the snapshot
+    assert fr[100] == pytest.approx(0.005)
+
+
+def test_htf_feature_does_not_leak_in_progress_bar():
+    df = _synthetic_ohlcv(n=600)
+    mat = ref.enriched_feature_matrix(df, period=20, columns=ref.CANONICAL_COLUMNS + ["htf_range_eff"],
+                                      htf_multiple=4)
+    htf = mat["htf_range_eff"].to_numpy()
+    # mutate only the LAST base bar's high (still inside the final, not-yet-closed HTF bucket);
+    # no earlier base row's htf value may move.
+    mutated = df.copy()
+    mutated.iloc[-1, mutated.columns.get_loc("high")] *= 5.0
+    htf2 = ref.enriched_feature_matrix(mutated, period=20,
+                                       columns=ref.CANONICAL_COLUMNS + ["htf_range_eff"],
+                                       htf_multiple=4)["htf_range_eff"].to_numpy()
+    assert np.array_equal(np.nan_to_num(htf[:-1], nan=-1.0), np.nan_to_num(htf2[:-1], nan=-1.0))
+
+
+def test_volume_z_is_trailing_and_warmup_nan():
+    df = _synthetic_ohlcv(n=200)
+    mat = ref.enriched_feature_matrix(df, period=48, columns=ref.CANONICAL_COLUMNS + ["volume_z"],
+                                      vol_window=24)
+    vz = mat["volume_z"].to_numpy()
+    assert np.isnan(vz[:23]).all()            # fewer than `vol_window` observations -> NaN
+    assert np.isfinite(vz[23])                # first full trailing window defined
+    # recompute the z-score at one bar by hand from the trailing window
+    vol = df["volume"].to_numpy()
+    i = 100
+    w = vol[i - 23: i + 1]
+    expected = (vol[i] - w.mean()) / w.std()
+    assert vz[i] == pytest.approx(expected, rel=1e-9)
+
+
+# ---------------------------------------------------------------- fit / decode contract
+
+def test_fit_unsupervised_enriched_schema_and_decode():
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH, VALID_LABELS_COMPOSITE
+    df = _synthetic_ohlcv()
+    fund = _synthetic_funding(df.index)
+    cols = ref.ENRICHED_COLUMNS
+    mat = ref.enriched_feature_matrix(df, period=48, funding=fund, columns=cols)
+    model = rvm.fit_unsupervised(mat.to_numpy(dtype=float), family="hmm", k=4, filter_window=32,
+                                 thresholds=dict(TH), seed=0, feature_names=cols,
+                                 canonical_indices=ref.canonical_indices_for(cols))
+    assert model["features"] == list(cols)
+    assert model["canonical_indices"] == [0, 1, 2, 3]
+    assert len(model["feature_means"]) == len(cols)             # ALL dims carried
+    assert all(len(e["mean"]) == len(cols) for e in model["emissions"])
+    assert all(s in VALID_LABELS_COMPOSITE for s in model["states"])  # named from canonical only
+    labels, conf = ref.decode_with_model(mat, model)
+    assert len(labels) == len(mat)
+    valid = ~np.isnan(mat.to_numpy(dtype=float)).any(1)
+    assert set(np.asarray(labels, dtype=object)[valid]).issubset(VALID_LABELS_COMPOSITE)
+
+
+def test_fit_unsupervised_rejects_feature_name_count_mismatch():
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    feats = np.random.default_rng(0).normal(size=(300, 5))
+    with pytest.raises(ValueError, match="columns but feature_names lists"):
+        rvm.fit_unsupervised(feats, family="kmeans", k=3, filter_window=16, thresholds=dict(TH),
+                             feature_names=["a", "b", "c"])  # 5 cols vs 3 names
+
+
+def test_decode_contract_rejects_column_reorder():
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    df = _synthetic_ohlcv()
+    fund = _synthetic_funding(df.index)
+    cols = ref.ENRICHED_COLUMNS
+    mat = ref.enriched_feature_matrix(df, period=48, funding=fund, columns=cols)
+    model = rvm.fit_unsupervised(mat.to_numpy(dtype=float), family="kmeans", k=4, filter_window=32,
+                                 thresholds=dict(TH), seed=0, feature_names=cols,
+                                 canonical_indices=(0, 1, 2, 3))
+    reordered = mat[list(reversed(cols))]
+    with pytest.raises(ValueError, match="feature-order contract violated"):
+        ref.decode_with_model(reordered, model)
+    with pytest.raises(ValueError, match="feature-order contract violated"):
+        ref.assert_feature_contract(model, list(reversed(cols)))
+
+
+def test_column_order_is_load_bearing_for_labels():
+    # Decoding the SAME bars in a different column order changes labels — proves the contract
+    # guards a real correctness hazard (forward_filter_labels is positional).
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    from regime_hmm import forward_filter_labels
+    df = _synthetic_ohlcv()
+    fund = _synthetic_funding(df.index)
+    cols = ref.ENRICHED_COLUMNS
+    mat = ref.enriched_feature_matrix(df, period=48, funding=fund, columns=cols)
+    model = rvm.fit_unsupervised(mat.to_numpy(dtype=float), family="hmm", k=5, filter_window=32,
+                                 thresholds=dict(TH), seed=0, feature_names=cols,
+                                 canonical_indices=(0, 1, 2, 3))
+    correct, _ = forward_filter_labels(mat.to_numpy(dtype=float), model)
+    swapped = mat[["adx", "range_eff", "efficiency", "return_eff", "funding_rate",
+                   "volume_z", "htf_range_eff"]]  # return_eff <-> adx swapped (very different scale)
+    wrong, _ = forward_filter_labels(swapped.to_numpy(dtype=float), model)
+    valid = ~np.isnan(mat.to_numpy(dtype=float)).any(1)
+    assert list(np.asarray(correct)[valid]) != list(np.asarray(wrong)[valid])
+
+
+# ---------------------------------------------------------------- naming decoupled from fit dims
+
+def test_naming_ignores_extra_dims_given_same_canonical_centroids():
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    mean = np.zeros(6); std = np.ones(6)
+    # two states: identical in canonical cols 0..3, differ only in the extra cols 4,5
+    em_a = np.array([[0.0, 0.02, 0.1, 8.0, 0.0, 0.0],
+                     [0.4, 0.5, 0.9, 40.0, 0.0, 0.0]], dtype=float)
+    em_b = em_a.copy(); em_b[:, 4:] = 99.0     # extra dims wildly different
+    names_a, _ = rvm.map_latent_to_names(em_a, mean, std, dict(TH), canonical_indices=(0, 1, 2, 3))
+    names_b, _ = rvm.map_latent_to_names(em_b, mean, std, dict(TH), canonical_indices=(0, 1, 2, 3))
+    assert names_a == names_b                  # extra signals shape geometry, not the label
+
+
+def test_naming_with_canonical_columns_not_first():
+    # canonical block placed AFTER an extra column; correct canonical_indices still names right.
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    mean = np.zeros(5); std = np.ones(5)
+    # layout: [funding, return_eff, range_eff, efficiency, adx]
+    em = np.array([[0.0, 0.0, 0.02, 0.1, 8.0],
+                   [0.0, 0.4, 0.5, 0.9, 40.0]], dtype=float)
+    names, _ = rvm.map_latent_to_names(em, mean, std, dict(TH), canonical_indices=(1, 2, 3, 4))
+    assert names == ["ranging_quiet", "trending_up_clean"]
+
+
+def test_map_latent_to_names_default_indices_unchanged_for_canonical_only():
+    # regression: the 4-column legacy path (default canonical_indices) is byte-identical.
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    mean = np.zeros(4); std = np.ones(4)
+    em = np.array([[0.0, 0.0, 0.1, 0.0], [0.5, 0.5, 0.9, 40.0]], dtype=float)
+    names, mapping = rvm.map_latent_to_names(em, mean, std, dict(TH))
+    assert names == ["ranging_quiet", "trending_up_clean"]
+    assert mapping["1"]["centroid_raw"] == [0.5, 0.5, 0.9, 40.0]
+
+
+# ---------------------------------------------------------------- harness smoke (skips without data)
+
+def test_enriched_bakeoff_smoke_if_data_available():
+    import importlib.util
+    path = os.path.join(_BACKTEST, "research", "regime_1095_enriched_vol_model.py")
+    spec = importlib.util.spec_from_file_location("regime_1095_smoke", path)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+        report = mod.run_bakeoff("BTC/USDT", "1h", families=("kmeans",), k_range=range(3, 4),
+                                 subsets={"canonical": list(ref.CANONICAL_COLUMNS),
+                                          "volume": ref.CANONICAL_COLUMNS + ["volume_z"]},
+                                 eval_windows=("is", "oos"))
+    except Exception as e:  # noqa: BLE001 — no cached OHLCV in CI -> skip, not fail
+        pytest.skip(f"no cached OHLCV / data path unavailable: {e}")
+    assert "ablation" in report and "candidates" in report
+    assert report["ablation"]["canonical"]["status"] in ("ok", "unavailable")
+    assert "live_wiring_delta" in report


### PR DESCRIPTION
## Summary

Extends the #1080 unsupervised vol-regime bake-off to fit on an **enriched** feature matrix — the four canonical hand-rule inputs (`return_eff, range_eff, efficiency, adx`) **plus** signals the hand-rule ignores — then re-runs the unchanged forward-volatility gate and anti-gaming guards, with a per-feature ablation attributing any separation gain to a specific added signal.

The #1080 negative result was produced fitting every candidate on exactly the hand-rule's own four features; clustering can only find structure in its inputs, so that result was partly a consequence of the input set. This gives the models a genuine chance.

## What changed

- **`backtest/regime_enriched_features.py` (new)** — enriched matrix builder. Canonical four kept FIRST, then:
  - `funding_rate` — Hyperliquid funding snapshot via `funding_fetcher.attach_funding_column` (#960 backward `merge_asof`).
  - `volume_z` — trailing rolling z-score of volume (turnover surprise; inclusive trailing window = same causal convention as the canonical features).
  - `htf_range_eff` — coarser-timeframe `range_eff`, aligned so a base bar only ever sees a higher-timeframe bar that has already **closed** at/before the base bar's open (strictly causal).
  - `assert_feature_contract` / `decode_with_model` enforce the fit↔decode column-order contract (`forward_filter_labels` is positional). `LIVE_WIRING_DELTA` records the #1074 delta — live `check_regime.py` builds only the canonical four, so an enriched model is **not** drop-in.
- **`backtest/regime_vol_model.py`** — decouple fit-features from naming-features. `fit_unsupervised` / `map_latent_to_names` fit, standardize, and emit over **all** enriched dims, but name states from only the four canonical columns via an explicit `canonical_indices` (default `(0,1,2,3)` keeps the legacy 4-column path byte-identical). Schema now carries `features` + `canonical_indices`.
- **`backtest/research/regime_1095_enriched_vol_model.py` (new)** — family × K × feature-subset sweep, reusing #1080's Bonferroni `select_winner` and the canonical-incumbent non-degeneracy thresholds. Each subset scores the candidate **and** the hand-rule on the same enriched valid-bar mask (fair like-for-like gate). Funding/HTF unavailable → subset reported `"unavailable"`, never fit on nothing. Emits a per-subset ablation with separation gain vs the canonical arm.

Research-only; no live or Go path touched. Out-of-scope items (#1074 live wiring, #1081 economic payoff, #1083 multi-asset, #1093 stats review) untouched.

## Verification

- `test_regime_enriched_features.py` (new) — canonical-first ordering, look-ahead regression (future bars never change a past feature row, mirroring `test_backtester_lookahead.py`), funding backward-only, HTF no-leak, `volume_z` trailing/warmup, the column-order contract (incl. a proof that order is load-bearing), and naming decoupled from extra dims / column position.
- Regime cluster suite (vol_model, bounded_window, calibrate, diagnostics, hmm, enriched): **122 passed**.
- `test_regime_1083_multi_asset_gate.py` (other `fit_unsupervised` caller): **33 passed** — confirms backward compatibility.
- Full `backtest/` collection: 855 tests, no import errors.

Closes #1095

LLM: Opus 4.8 | high | Harness: Claude Code
