### PR TITLE
feat(#1103): exchange-sourced cash-flow equity journal for HL shared wallets (shadow)

### DIFF
--- a/scheduler/cashflow_journal.go
+++ b/scheduler/cashflow_journal.go
@@ -169,6 +169,18 @@ func cashflowFillSettledDelta(closedPnlGross, fee float64) float64 {
 	return closedPnlGross - fee
 }
 
+// hlFillIsSpot reports whether a userFills coin is a SPOT market identifier
+// rather than a perps asset. HL spot fills settle against a separate spot USDC
+// balance and do NOT move the perps marginSummary.accountValue this journal
+// reconciles, so they must contribute $0 to the perps settled-cash sum — the
+// same spot exclusion signedPerpFlowUSD already applies on the transfer stream.
+// HL spot coins are an index form ("@107") or a named pair ("PURR/USDC"); perps
+// assets ("BTC", "kPEPE", "HYPE") never contain "/" or start with "@".
+func hlFillIsSpot(coin string) bool {
+	c := strings.TrimSpace(coin)
+	return strings.HasPrefix(c, "@") || strings.Contains(c, "/")
+}
+
 // cashflowJournalExpectedEquity reconstructs the wallet's current accountValue
 // from the adoption baseline, the settled-cash deltas booked since, and the
 // change in exchange unrealized PnL since baseline. Pure — unit-tested.
@@ -315,8 +327,20 @@ func ingestCashflowJournalEvents(sdb *StateDB, res cashflowJournalFetchResult) C
 			coin := strings.ToUpper(strings.TrimSpace(f.Coin))
 			closedPnl := parseHLFloat(f.ClosedPnl)
 			fee := parseHLFloat(f.Fee)
+			// A spot fill settles against the separate spot USDC balance, NOT the
+			// perps marginSummary.accountValue this journal reconciles, so it
+			// contributes $0 to the perps settled-cash sum — mirroring the spot
+			// exclusion signedPerpFlowUSD already applies on the transfer stream.
+			// The row is still booked (kind "fill_spot", amount 0) so it stays
+			// visible + deduped and the cursor still advances past it; closedPnl
+			// and fee are retained as attribution metadata only, never summed.
+			kind := "fill"
 			delta := cashflowFillSettledDelta(closedPnl, fee)
-			if err := sdb.InsertCashflowJournalEntry(key.Platform, key.Account, f.Time, "fill", delta, coin, closedPnl, fee, cashflowFillDedupID(f)); err != nil {
+			if hlFillIsSpot(coin) {
+				kind = "fill_spot"
+				delta = 0
+			}
+			if err := sdb.InsertCashflowJournalEntry(key.Platform, key.Account, f.Time, kind, delta, coin, closedPnl, fee, cashflowFillDedupID(f)); err != nil {
 				fmt.Printf("[WARN] cashflow-journal %s: fill insert failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
 				failedAt = f.Time
 				break

--- a/scheduler/cashflow_journal.go
+++ b/scheduler/cashflow_journal.go
@@ -1,0 +1,446 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// #1100: exchange-sourced equity journal for shared-wallet TOTAL reconciliation.
+//
+// Today the shared-wallet drift alarm reconstructs each account's equity from
+// the bot's OWN trade ledger plus exchange unrealized PnL, then compares that
+// derived value to the exchange's accountValue:
+//
+//	member_value_i = initial_capital_i + Σ tradeLedgerDelta_i + owned_uPnL_i
+//	raw_drift      = accountValue − Σ member_value_i − Σ wallet_transfers
+//
+// Every write path, fallback, or model-only cleanup that mis-prices a trade row
+// (modeled fee when userFills missed, mark-priced force-close, kill-switch
+// residual) shows up as residual drift, because the TOTAL still depends on
+// internal rows for realized PnL, fees, and fill prices.
+//
+// This journal inverts that: it reconstructs the wallet's SETTLED-CASH balance
+// from the exchange's own cash-flow events — fills, funding, transfers — pulled
+// incrementally per stream with durable cursors and per-event dedup. The
+// internal trade rows stay the source of truth for per-strategy ATTRIBUTION
+// only; the TOTAL comes from the exchange.
+//
+// Equity decomposition (HL accountValue = settled cash + unrealized PnL):
+//
+//	accountValue_t = cash_t + uPnL_t
+//	             = baseline_accountValue + (cash_t − cash_0) + (uPnL_t − uPnL_0)
+//
+// so the journal's reconstruction is:
+//
+//	expected = baseline_accountValue
+//	         + Σ(settled-cash deltas since baseline)   // fills + funding + transfers
+//	         + (current_uPnL − baseline_uPnL)
+//
+// A fill's settled-cash delta is realized PnL (GROSS) minus the fee actually
+// charged: opening fills settle −fee (closedPnl=0), closing fills settle
+// closedPnl−fee. closedPnl is gross of fees (#698) so the fee is subtracted
+// exactly once here; closed_pnl_gross is retained for attribution and is NEVER
+// summed into equity on its own.
+//
+// SCOPE: Hyperliquid shared wallets, SHADOW MODE. The journal is computed
+// beside the live trade-ledger drift path and the delta is logged for
+// validation. It does NOT yet drive any alarm or member display — that switch,
+// plus OKX/TopStep extension and baseline-offset retirement, are later phases
+// of #1100. Nothing here mutates StrategyState, so the whole flow runs OUTSIDE
+// the state lock (DB writes are serialized by SQLite).
+
+// CashflowJournalState is one wallet's per-stream journal cursors plus the
+// adoption baseline. Incomplete latches true once an unmapped event kind is
+// seen so a future alarm switch can fail closed to the trade-ledger path.
+type CashflowJournalState struct {
+	FillsSinceMs         int64
+	FundingSinceMs       int64
+	TransfersSinceMs     int64
+	BaselineAccountValue float64
+	BaselineUPnL         float64
+	BaselineSet          bool
+	Incomplete           bool
+}
+
+// GetCashflowJournalState loads one wallet's journal state; found=false when the
+// wallet has never been ingested.
+func (sdb *StateDB) GetCashflowJournalState(platform, account string) (CashflowJournalState, bool, error) {
+	var st CashflowJournalState
+	if sdb == nil || sdb.db == nil {
+		return st, false, fmt.Errorf("state db unavailable")
+	}
+	var baselineSet, incomplete int
+	err := sdb.db.QueryRow(
+		`SELECT fills_since_ms, funding_since_ms, transfers_since_ms,
+		        baseline_account_value, baseline_upnl, baseline_set, incomplete
+		 FROM cashflow_journal_state WHERE platform = ? AND account = ?`,
+		platform, account).Scan(&st.FillsSinceMs, &st.FundingSinceMs, &st.TransfersSinceMs,
+		&st.BaselineAccountValue, &st.BaselineUPnL, &baselineSet, &incomplete)
+	if err == sql.ErrNoRows {
+		return st, false, nil
+	}
+	if err != nil {
+		return st, false, fmt.Errorf("load cashflow journal state: %w", err)
+	}
+	st.BaselineSet = baselineSet != 0
+	st.Incomplete = incomplete != 0
+	return st, true, nil
+}
+
+// UpsertCashflowJournalState writes one wallet's journal state row.
+func (sdb *StateDB) UpsertCashflowJournalState(platform, account string, st CashflowJournalState) error {
+	if sdb == nil || sdb.db == nil {
+		return fmt.Errorf("state db unavailable")
+	}
+	baselineSet := 0
+	if st.BaselineSet {
+		baselineSet = 1
+	}
+	incomplete := 0
+	if st.Incomplete {
+		incomplete = 1
+	}
+	_, err := sdb.db.Exec(
+		`INSERT INTO cashflow_journal_state
+		   (platform, account, fills_since_ms, funding_since_ms, transfers_since_ms,
+		    baseline_account_value, baseline_upnl, baseline_set, incomplete)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(platform, account) DO UPDATE SET
+		   fills_since_ms = excluded.fills_since_ms,
+		   funding_since_ms = excluded.funding_since_ms,
+		   transfers_since_ms = excluded.transfers_since_ms,
+		   baseline_account_value = excluded.baseline_account_value,
+		   baseline_upnl = excluded.baseline_upnl,
+		   baseline_set = excluded.baseline_set,
+		   incomplete = excluded.incomplete`,
+		platform, account, st.FillsSinceMs, st.FundingSinceMs, st.TransfersSinceMs,
+		st.BaselineAccountValue, st.BaselineUPnL, baselineSet, incomplete)
+	if err != nil {
+		return fmt.Errorf("upsert cashflow journal state: %w", err)
+	}
+	return nil
+}
+
+// InsertCashflowJournalEntry appends one settled-cash event; a duplicate
+// dedup_id is silently ignored (cursor-overlap re-reads). A non-nil error is a
+// genuine persistence failure — the caller halts the cursor at that event so a
+// crash can never strand an un-booked event behind an advanced watermark.
+func (sdb *StateDB) InsertCashflowJournalEntry(platform, account string, timeMs int64, kind string, amountUSD float64, coin string, closedPnlGross, feeUSD float64, dedupID string) error {
+	if sdb == nil || sdb.db == nil {
+		return fmt.Errorf("state db unavailable")
+	}
+	_, err := sdb.db.Exec(
+		`INSERT OR IGNORE INTO cashflow_journal
+		   (platform, account, time_ms, kind, amount_usd, coin, closed_pnl_gross, fee_usd, dedup_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		platform, account, timeMs, kind, amountUSD, coin, closedPnlGross, feeUSD, dedupID)
+	if err != nil {
+		return fmt.Errorf("insert cashflow journal entry: %w", err)
+	}
+	return nil
+}
+
+// SumCashflowJournal returns the signed total of one wallet's settled-cash
+// deltas since adoption (Σ amount_usd across every journal row).
+func (sdb *StateDB) SumCashflowJournal(platform, account string) (float64, error) {
+	if sdb == nil || sdb.db == nil {
+		return 0, fmt.Errorf("state db unavailable")
+	}
+	var sum sql.NullFloat64
+	err := sdb.db.QueryRow(
+		`SELECT SUM(amount_usd) FROM cashflow_journal WHERE platform = ? AND account = ?`,
+		platform, account).Scan(&sum)
+	if err != nil {
+		return 0, fmt.Errorf("sum cashflow journal: %w", err)
+	}
+	return sum.Float64, nil
+}
+
+// cashflowFillSettledDelta is one fill's SIGNED effect on settled cash: realized
+// PnL (GROSS) minus the fee actually charged. closedPnl is gross of fees (#698),
+// so the fee — which may be a negative maker rebate — is subtracted exactly once
+// here. Opening fills (closedPnl=0) settle −fee; closing fills settle
+// closedPnl−fee. The gross value is retained separately for attribution and is
+// never summed into equity on its own.
+func cashflowFillSettledDelta(closedPnlGross, fee float64) float64 {
+	return closedPnlGross - fee
+}
+
+// cashflowJournalExpectedEquity reconstructs the wallet's current accountValue
+// from the adoption baseline, the settled-cash deltas booked since, and the
+// change in exchange unrealized PnL since baseline. Pure — unit-tested.
+func cashflowJournalExpectedEquity(baselineAccountValue, baselineUPnL, settledDeltaSum, currentUPnL float64) float64 {
+	return baselineAccountValue + settledDeltaSum + (currentUPnL - baselineUPnL)
+}
+
+// advanceCashflowCursor returns the next watermark for one stream: one past the
+// highest processed event time, except never AT or AFTER a failed event's
+// timestamp (so a same-ms sibling that persisted can't strand the failed event
+// behind the cursor). maxProcessed starts at current−1; failedAt is −1 when no
+// event failed. Mirrors the wallet_ledger watermark discipline.
+func advanceCashflowCursor(current, maxProcessed, failedAt int64) int64 {
+	next := maxProcessed + 1
+	if failedAt >= 0 && failedAt < next {
+		next = failedAt // re-fetch from the failed event; dedup absorbs same-ms re-reads
+	}
+	if next > current {
+		return next
+	}
+	return current
+}
+
+// cashflowFillDedupID is a fill's stable journal identity. A single OID can
+// fragment into many partial fills, so the per-fill trade id (tid) is the
+// canonical key; the L1 hash + coin + time disambiguate the rare missing-tid
+// case so two genuine fills never collide.
+func cashflowFillDedupID(f hlFillRecord) string {
+	if tid := strings.TrimSpace(f.Tid.String()); tid != "" && tid != "0" {
+		return "fill:tid:" + tid
+	}
+	return fmt.Sprintf("fill:%d:%s:%s", f.Time, f.Hash, strings.ToUpper(strings.TrimSpace(f.Coin)))
+}
+
+// cashflowFundingDedupID / cashflowTransferDedupID key the journal's funding and
+// non-funding rows. The journal namespaces are independent of the #954
+// attribution dedup keys (which live in the trades / wallet_transfers tables).
+func cashflowFundingDedupID(ev hlLedgerEvent) string {
+	return fmt.Sprintf("funding:%d:%s:%s", ev.Time, ev.Hash, ev.Delta.Coin)
+}
+
+func cashflowTransferDedupID(ev hlLedgerEvent) string {
+	return fmt.Sprintf("%s:%d:%s", ev.Delta.Type, ev.Time, ev.Hash)
+}
+
+// cashflowJournalFetchResult carries one wallet's raw cash-flow events plus the
+// coherent accountValue / uPnL snapshot from the no-lock fetch phase to the
+// no-lock ingest+compare phase.
+type cashflowJournalFetchResult struct {
+	Key              SharedWalletKey
+	State            CashflowJournalState
+	StateFound       bool
+	AccountValue     float64 // exchange accountValue (equity incl. uPnL) this cycle
+	CurrentUPnL      float64 // Σ exchange unrealized PnL across the account this cycle
+	Fills            []hlFillRecord
+	Funding          []hlLedgerEvent
+	Transfers        []hlLedgerEvent
+	FillsFetched     bool
+	FundingFetched   bool
+	TransfersFetched bool
+}
+
+// fetchCashflowJournalEvents reads the wallet's per-stream cursors and pulls
+// fills + funding + non-funding ledger events since each (three HTTP POSTs).
+// Runs OUTSIDE the state lock. First contact anchors the baseline to the
+// supplied accountValue / uPnL snapshot and the cursors to now, fetching no
+// history — pre-adoption movement belongs to the baseline, not the journal.
+func fetchCashflowJournalEvents(sdb *StateDB, key SharedWalletKey, accountValue, currentUPnL float64, now time.Time) cashflowJournalFetchResult {
+	res := cashflowJournalFetchResult{Key: key, AccountValue: accountValue, CurrentUPnL: currentUPnL}
+	if sdb == nil || key.Platform != "hyperliquid" || key.Account == "" {
+		return res
+	}
+	st, found, err := sdb.GetCashflowJournalState(key.Platform, key.Account)
+	if err != nil {
+		fmt.Printf("[WARN] cashflow-journal %s: state load failed: %v — skipping ingestion this cycle\n", sharedWalletKeyLabel(key), err)
+		return res
+	}
+	if !found {
+		nowMs := now.UnixMilli()
+		st = CashflowJournalState{
+			FillsSinceMs:         nowMs,
+			FundingSinceMs:       nowMs,
+			TransfersSinceMs:     nowMs,
+			BaselineAccountValue: accountValue,
+			BaselineUPnL:         currentUPnL,
+			BaselineSet:          true,
+		}
+		if err := sdb.UpsertCashflowJournalState(key.Platform, key.Account, st); err != nil {
+			fmt.Printf("[WARN] cashflow-journal %s: baseline init failed: %v\n", sharedWalletKeyLabel(key), err)
+			return res
+		}
+		fmt.Printf("[cashflow-journal] %s: baseline anchored at accountValue $%.2f (uPnL $%+.2f) and cursors at %s (no historical replay)\n",
+			sharedWalletKeyLabel(key), accountValue, currentUPnL, now.UTC().Format(time.RFC3339))
+		res.State = st
+		res.StateFound = true
+		return res
+	}
+	res.State = st
+	res.StateFound = true
+
+	if fills, err := fetchHyperliquidUserFillsByTime(key.Account, st.FillsSinceMs); err != nil {
+		fmt.Printf("[WARN] cashflow-journal %s: userFills fetch failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+	} else {
+		res.Fills = fills
+		res.FillsFetched = true
+	}
+	if funding, err := fetchHyperliquidUserFunding(key.Account, st.FundingSinceMs); err != nil {
+		fmt.Printf("[WARN] cashflow-journal %s: userFunding fetch failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+	} else {
+		res.Funding = funding
+		res.FundingFetched = true
+	}
+	if transfers, err := fetchHyperliquidLedgerUpdates(key.Account, st.TransfersSinceMs); err != nil {
+		fmt.Printf("[WARN] cashflow-journal %s: userNonFundingLedgerUpdates fetch failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+	} else {
+		res.Transfers = transfers
+		res.TransfersFetched = true
+	}
+	return res
+}
+
+// ingestCashflowJournalEvents books the fetched events into cashflow_journal and
+// advances each stream's cursor. DB-only (no StrategyState mutation), so it runs
+// OUTSIDE the state lock. Returns the post-ingest state (cursors advanced,
+// incomplete latched if an unmapped kind was seen). Every insert path halts its
+// cursor on persistence failure so a watermark never advances past an un-booked
+// event.
+func ingestCashflowJournalEvents(sdb *StateDB, res cashflowJournalFetchResult) CashflowJournalState {
+	st := res.State
+	if sdb == nil || !res.StateFound {
+		return st
+	}
+	key := res.Key
+
+	if res.FillsFetched {
+		maxTime := st.FillsSinceMs - 1
+		failedAt := int64(-1)
+		fills := append([]hlFillRecord(nil), res.Fills...)
+		sort.SliceStable(fills, func(i, j int) bool { return fills[i].Time < fills[j].Time })
+		for _, f := range fills {
+			if f.Time < st.FillsSinceMs {
+				continue // cursor-overlap boundary; dedup also covers this
+			}
+			coin := strings.ToUpper(strings.TrimSpace(f.Coin))
+			closedPnl := parseHLFloat(f.ClosedPnl)
+			fee := parseHLFloat(f.Fee)
+			delta := cashflowFillSettledDelta(closedPnl, fee)
+			if err := sdb.InsertCashflowJournalEntry(key.Platform, key.Account, f.Time, "fill", delta, coin, closedPnl, fee, cashflowFillDedupID(f)); err != nil {
+				fmt.Printf("[WARN] cashflow-journal %s: fill insert failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+				failedAt = f.Time
+				break
+			}
+			if f.Time > maxTime {
+				maxTime = f.Time
+			}
+		}
+		st.FillsSinceMs = advanceCashflowCursor(st.FillsSinceMs, maxTime, failedAt)
+	}
+
+	if res.FundingFetched {
+		maxTime := st.FundingSinceMs - 1
+		failedAt := int64(-1)
+		events := append([]hlLedgerEvent(nil), res.Funding...)
+		sort.SliceStable(events, func(i, j int) bool { return events[i].Time < events[j].Time })
+		for _, ev := range events {
+			if ev.Time < st.FundingSinceMs {
+				continue
+			}
+			// Full funding amount moves the balance regardless of which member
+			// (if any) owns the coin — the journal is the TOTAL, with no
+			// attribution split. Signed: + = balance increased.
+			amount := parseHLFloat(ev.Delta.USDC)
+			coin := strings.ToUpper(strings.TrimSpace(ev.Delta.Coin))
+			if err := sdb.InsertCashflowJournalEntry(key.Platform, key.Account, ev.Time, "funding", amount, coin, 0, 0, cashflowFundingDedupID(ev)); err != nil {
+				fmt.Printf("[WARN] cashflow-journal %s: funding insert failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+				failedAt = ev.Time
+				break
+			}
+			if ev.Time > maxTime {
+				maxTime = ev.Time
+			}
+		}
+		st.FundingSinceMs = advanceCashflowCursor(st.FundingSinceMs, maxTime, failedAt)
+	}
+
+	if res.TransfersFetched {
+		maxTime := st.TransfersSinceMs - 1
+		failedAt := int64(-1)
+		events := append([]hlLedgerEvent(nil), res.Transfers...)
+		sort.SliceStable(events, func(i, j int) bool { return events[i].Time < events[j].Time })
+		for _, ev := range events {
+			if ev.Time < st.TransfersSinceMs {
+				continue
+			}
+			amount, known := signedPerpFlowUSD(ev.Delta, key.Account)
+			if !known {
+				// Latch incomplete: an unmapped kind means the journal cannot
+				// claim an exact total, so a future alarm switch must fail
+				// closed to the trade-ledger path. The $0 row keeps the event
+				// visible and the running drift surfaces it.
+				st.Incomplete = true
+				fmt.Printf("[WARN] cashflow-journal %s: unmapped ledger delta type %q (hash %s) — recorded with $0 effect, journal marked incomplete\n",
+					sharedWalletKeyLabel(key), ev.Delta.Type, ev.Hash)
+			}
+			if err := sdb.InsertCashflowJournalEntry(key.Platform, key.Account, ev.Time, ev.Delta.Type, amount, "", 0, 0, cashflowTransferDedupID(ev)); err != nil {
+				fmt.Printf("[WARN] cashflow-journal %s: transfer insert failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+				failedAt = ev.Time
+				break
+			}
+			if ev.Time > maxTime {
+				maxTime = ev.Time
+			}
+		}
+		st.TransfersSinceMs = advanceCashflowCursor(st.TransfersSinceMs, maxTime, failedAt)
+	}
+
+	if st != res.State {
+		if err := sdb.UpsertCashflowJournalState(key.Platform, key.Account, st); err != nil {
+			fmt.Printf("[WARN] cashflow-journal %s: cursor advance failed: %v\n", sharedWalletKeyLabel(key), err)
+		}
+	}
+	return st
+}
+
+// reconcileCashflowJournalShadow runs the full journal flow for one HL shared
+// wallet OUTSIDE the state lock: fetch the cash-flow events, book them, then log
+// the journal's reconstructed equity beside the live trade-ledger drift for
+// validation. SHADOW MODE — it drives no alarm and mutates no display value.
+// ledgerDrift (may be nil) is the matching trade-ledger drift result this cycle,
+// logged alongside so an operator can compare the two reconciliation bases.
+func reconcileCashflowJournalShadow(sdb *StateDB, key SharedWalletKey, accountValue, currentUPnL float64, ledgerDrift *sharedWalletDriftResult, now time.Time) {
+	if sdb == nil || key.Platform != "hyperliquid" || key.Account == "" {
+		return
+	}
+	res := fetchCashflowJournalEvents(sdb, key, accountValue, currentUPnL, now)
+	if !res.StateFound {
+		return // baseline just anchored (logged there) or fetch/load failed
+	}
+	st := ingestCashflowJournalEvents(sdb, res)
+	if !st.BaselineSet {
+		return // defensive: never compute against an un-anchored baseline
+	}
+	settled, err := sdb.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		fmt.Printf("[WARN] cashflow-journal %s: settled-sum read failed: %v\n", sharedWalletKeyLabel(key), err)
+		return
+	}
+	expected := cashflowJournalExpectedEquity(st.BaselineAccountValue, st.BaselineUPnL, settled, res.CurrentUPnL)
+	journalDrift := res.AccountValue - expected
+
+	incompleteNote := ""
+	if st.Incomplete {
+		incompleteNote = " [INCOMPLETE: unmapped event kind seen — would fail closed once promoted]"
+	}
+	ledgerNote := "n/a"
+	if ledgerDrift != nil {
+		// The trade-ledger result carries the post-baseline Drift and the raw
+		// reconciliation inputs; raw diff = balance − Σ member values.
+		ledgerNote = fmt.Sprintf("raw $%+.2f / post-baseline $%+.2f", ledgerDrift.Balance-ledgerDrift.MemberSum, ledgerDrift.Drift)
+	}
+	fmt.Printf("[cashflow-journal] %s SHADOW: expected_equity $%.2f vs accountValue $%.2f → journal_drift $%+.4f (settled Σ $%+.2f since baseline $%.2f, ΔuPnL $%+.2f); trade-ledger drift %s%s\n",
+		sharedWalletKeyLabel(key), expected, res.AccountValue, journalDrift,
+		settled, st.BaselineAccountValue, res.CurrentUPnL-st.BaselineUPnL, ledgerNote, incompleteNote)
+}
+
+// sumHLAccountUPnL totals the exchange-reported unrealized PnL across an
+// account's open positions — the uPnL component of accountValue the journal
+// equity equation needs.
+func sumHLAccountUPnL(positions []HLPosition) float64 {
+	sum := 0.0
+	for _, p := range positions {
+		sum += p.UnrealizedPnL
+	}
+	return sum
+}

--- a/scheduler/cashflow_journal_test.go
+++ b/scheduler/cashflow_journal_test.go
@@ -336,3 +336,86 @@ func TestCashflowJournalCursorHaltsOnPersistFailure(t *testing.T) {
 		t.Errorf("cursor advanced past a failed insert: %d, want 100 (held)", st.FillsSinceMs)
 	}
 }
+
+// HL spot coins are an index ("@107") or a named pair ("PURR/USDC"); perps
+// assets never contain "/" or start with "@".
+func TestHLFillIsSpot(t *testing.T) {
+	spot := []string{"@107", "@1", "PURR/USDC", "ETH/USDC", " @5 ", "BTC/USDC"}
+	perps := []string{"BTC", "ETH", "kPEPE", "HYPE", "SOL", "", " BTC "}
+	for _, c := range spot {
+		if !hlFillIsSpot(c) {
+			t.Errorf("hlFillIsSpot(%q) = false, want true (spot)", c)
+		}
+	}
+	for _, c := range perps {
+		if hlFillIsSpot(c) {
+			t.Errorf("hlFillIsSpot(%q) = true, want false (perps)", c)
+		}
+	}
+}
+
+// HL userFillsByTime returns SPOT fills too, but the journal reconciles the
+// PERPS marginSummary.accountValue — a spot fill settles against the separate
+// spot USDC balance and must contribute $0, exactly as signedPerpFlowUSD
+// excludes spot on the transfer stream. Mixing spot into the perps settled sum
+// injects spurious drift and can MASK a real perps drift of opposite sign.
+func TestCashflowJournalExcludesSpotFills(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	t0 := int64(1700000000000)
+	res := cashflowJournalFetchResult{
+		Key:        key,
+		State:      CashflowJournalState{FillsSinceMs: t0, BaselineSet: true},
+		StateFound: true, FillsFetched: true,
+		Fills: []hlFillRecord{
+			{Coin: "BTC", Time: t0 + 10, Tid: json.Number("1"), ClosedPnl: "0", Fee: "0.5"},        // perps open: -0.5
+			{Coin: "@107", Time: t0 + 15, Tid: json.Number("2"), ClosedPnl: "0", Fee: "9.8"},       // SPOT: would mask the perps gain
+			{Coin: "BTC", Time: t0 + 20, Tid: json.Number("3"), ClosedPnl: "10", Fee: "0.2"},       // perps close: +9.8
+			{Coin: "PURR/USDC", Time: t0 + 25, Tid: json.Number("4"), ClosedPnl: "0", Fee: "-0.1"}, // SPOT maker rebate (negative fee)
+		},
+	}
+	st := ingestCashflowJournalEvents(db, res)
+
+	// (a)+(c): the perps settled sum is byte-identical to the perps-only sum; the
+	// spot fee does NOT cancel the real perps gain (no masking), and the spot
+	// maker rebate adds nothing.
+	sum, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	const wantPerpsOnly = -0.5 + 9.8 // 9.3; with the bug it would be 9.3 - 9.8 + 0.1 = -0.4
+	if math.Abs(sum-wantPerpsOnly) > 1e-9 {
+		t.Fatalf("spot leaked into perps settled sum: got %v, want %v (perps-only)", sum, wantPerpsOnly)
+	}
+
+	// (b): spot rows are still booked (visible + deduped) but at $0 amount under a
+	// distinct kind, with closedPnl/fee retained as metadata only.
+	var spotRows, spotNonZero int
+	rows, err := db.db.Query(`SELECT amount_usd FROM cashflow_journal WHERE kind = 'fill_spot' AND platform = ? AND account = ?`, key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("query spot rows: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var amt float64
+		if err := rows.Scan(&amt); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		spotRows++
+		if math.Abs(amt) > 1e-9 {
+			spotNonZero++
+		}
+	}
+	if spotRows != 2 {
+		t.Errorf("expected 2 spot rows booked, got %d", spotRows)
+	}
+	if spotNonZero != 0 {
+		t.Errorf("%d spot rows carried a non-zero perps amount", spotNonZero)
+	}
+
+	// Spot fills still advance the cursor (the latest event is a spot fill), so
+	// they are booked once and not re-fetched forever.
+	if st.FillsSinceMs != t0+25+1 {
+		t.Errorf("cursor = %d, want %d (advanced past the latest spot fill)", st.FillsSinceMs, t0+26)
+	}
+}

--- a/scheduler/cashflow_journal_test.go
+++ b/scheduler/cashflow_journal_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// #1100 exchange-sourced equity journal: settled-cash convention, the equity
+// equation, cursor discipline, dedup, baseline anchoring, and unmapped-kind
+// fail-closed latching.
+
+func newCashflowJournalTestDB(t *testing.T) *StateDB {
+	t.Helper()
+	db, err := OpenStateDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("OpenStateDB: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// A fill's settled-cash delta is realized PnL (GROSS) minus the fee actually
+// charged: opens settle -fee, closes settle closedPnl-fee, and a maker rebate
+// (negative fee) ADDS to cash. closedPnl is gross of fees (#698) so the fee is
+// subtracted exactly once — never twice, never zero times.
+func TestCashflowFillSettledDelta(t *testing.T) {
+	cases := []struct {
+		name      string
+		closedPnl float64
+		fee       float64
+		want      float64
+	}{
+		{"open: closedPnl 0, fee 0.5 -> -0.5", 0, 0.5, -0.5},
+		{"profitable close: 20 gross - 0.3 fee", 20, 0.3, 19.7},
+		{"losing close: -15 gross - 0.3 fee", -15, 0.3, -15.3},
+		{"maker rebate adds to cash", 20, -0.1, 20.1},
+		{"open with maker rebate", 0, -0.2, 0.2},
+	}
+	for _, tc := range cases {
+		if got := cashflowFillSettledDelta(tc.closedPnl, tc.fee); math.Abs(got-tc.want) > 1e-9 {
+			t.Errorf("%s: cashflowFillSettledDelta(%v,%v) = %v, want %v", tc.name, tc.closedPnl, tc.fee, got, tc.want)
+		}
+	}
+}
+
+// expected = baseline_accountValue + Σ settled deltas + (current_uPnL - baseline_uPnL).
+func TestCashflowJournalExpectedEquity(t *testing.T) {
+	cases := []struct {
+		name                               string
+		baseAV, baseUPnL, settled, curUPnL float64
+		want                               float64
+	}{
+		{"flat: no deltas, uPnL unchanged", 1000, 0, 0, 0, 1000},
+		{"settled cash moved, uPnL flat", 1000, 0, 67.2, 0, 1067.2},
+		{"uPnL rose since baseline", 1000, 0, 0, 25, 1025},
+		{"uPnL fell since a positive baseline", 1000, 30, 0, 5, 975},
+		{"combined", 1000, 30, 67.2, 5, 1042.2},
+	}
+	for _, tc := range cases {
+		got := cashflowJournalExpectedEquity(tc.baseAV, tc.baseUPnL, tc.settled, tc.curUPnL)
+		if math.Abs(got-tc.want) > 1e-9 {
+			t.Errorf("%s: = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// The watermark advances one past the highest processed event, EXCEPT it never
+// lands at/after a failed event's timestamp — so a same-ms sibling that
+// persisted cannot strand the failed event behind the cursor.
+func TestAdvanceCashflowCursor(t *testing.T) {
+	cases := []struct {
+		name         string
+		current      int64
+		maxProcessed int64
+		failedAt     int64
+		want         int64
+	}{
+		{"no events: maxProcessed=current-1, no fail -> unchanged", 100, 99, -1, 100},
+		{"clean advance past last event", 100, 250, -1, 251},
+		{"failure on the only event -> cursor unchanged", 100, 99, 200, 100},
+		{"failure after some successes -> halt at failed ts", 100, 300, 300, 300},
+		{"same-ms sibling succeeded then failed -> never skip failed", 100, 300, 300, 300},
+		{"failure strictly after advance still clamps to failed", 100, 150, 200, 151},
+	}
+	for _, tc := range cases {
+		if got := advanceCashflowCursor(tc.current, tc.maxProcessed, tc.failedAt); got != tc.want {
+			t.Errorf("%s: advanceCashflowCursor(%d,%d,%d) = %d, want %d", tc.name, tc.current, tc.maxProcessed, tc.failedAt, got, tc.want)
+		}
+	}
+}
+
+// tid is the canonical per-fill key (one OID fragments into many fills); the
+// time:hash:coin form is the fallback when tid is absent or zero.
+func TestCashflowFillDedupID(t *testing.T) {
+	withTid := hlFillRecord{Coin: "BTC", Time: 1700000000000, Hash: "0xabc", Tid: json.Number("987654321")}
+	if got, want := cashflowFillDedupID(withTid), "fill:tid:987654321"; got != want {
+		t.Errorf("tid present: got %q, want %q", got, want)
+	}
+	noTid := hlFillRecord{Coin: "eth", Time: 1700000000001, Hash: "0xdef", Tid: json.Number("0")}
+	if got, want := cashflowFillDedupID(noTid), "fill:1700000000001:0xdef:ETH"; got != want {
+		t.Errorf("tid zero: got %q, want %q", got, want)
+	}
+	emptyTid := hlFillRecord{Coin: "SOL", Time: 1700000000002, Hash: "0xfff"}
+	if got, want := cashflowFillDedupID(emptyTid), "fill:1700000000002:0xfff:SOL"; got != want {
+		t.Errorf("tid empty: got %q, want %q", got, want)
+	}
+}
+
+func TestCashflowJournalStateRoundTrip(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	if _, found, err := db.GetCashflowJournalState("hyperliquid", "0xabc"); err != nil || found {
+		t.Fatalf("fresh wallet: found=%v err=%v, want found=false err=nil", found, err)
+	}
+	st := CashflowJournalState{
+		FillsSinceMs: 111, FundingSinceMs: 222, TransfersSinceMs: 333,
+		BaselineAccountValue: 1234.5, BaselineUPnL: -6.7, BaselineSet: true, Incomplete: true,
+	}
+	if err := db.UpsertCashflowJournalState("hyperliquid", "0xabc", st); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got, found, err := db.GetCashflowJournalState("hyperliquid", "0xabc")
+	if err != nil || !found {
+		t.Fatalf("reload: found=%v err=%v", found, err)
+	}
+	if got != st {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", got, st)
+	}
+}
+
+// First contact anchors the baseline to the supplied snapshot, sets the cursors
+// to now, and fetches NO history — pre-adoption movement belongs to the baseline.
+func TestCashflowJournalBaselineAnchorsOnFirstContact(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	now := time.UnixMilli(1700000000000).UTC()
+
+	res := fetchCashflowJournalEvents(db, key, 5000.0, 12.5, now)
+	if !res.StateFound {
+		t.Fatal("first contact should report StateFound after baseline init")
+	}
+	if res.FillsFetched || res.FundingFetched || res.TransfersFetched {
+		t.Error("first contact must not replay history")
+	}
+	st, found, err := db.GetCashflowJournalState(key.Platform, key.Account)
+	if err != nil || !found {
+		t.Fatalf("state after baseline: found=%v err=%v", found, err)
+	}
+	if !st.BaselineSet || st.BaselineAccountValue != 5000.0 || st.BaselineUPnL != 12.5 {
+		t.Errorf("baseline not anchored: %+v", st)
+	}
+	if st.FillsSinceMs != now.UnixMilli() || st.FundingSinceMs != now.UnixMilli() || st.TransfersSinceMs != now.UnixMilli() {
+		t.Errorf("cursors not anchored at now: %+v", st)
+	}
+}
+
+// End-to-end fetch -> ingest -> sum with stubbed HTTP. Reconstructed settled sum
+// must equal Σ(fill settled deltas) + funding + transfers, and the expected
+// equity must close the loop against a hand-computed accountValue.
+func TestCashflowJournalIngestAndExpectedEquity(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+
+	// Anchor baseline at AV=1000, uPnL=0, cursors at t0.
+	t0 := time.UnixMilli(1700000000000).UTC()
+	if r := fetchCashflowJournalEvents(db, key, 1000.0, 0.0, t0); !r.StateFound {
+		t.Fatal("baseline init failed")
+	}
+
+	// Stub the three event streams for the next cycle.
+	origFills := fetchHyperliquidUserFillsByTime
+	origFunding := fetchHyperliquidUserFunding
+	origTransfers := fetchHyperliquidLedgerUpdates
+	defer func() {
+		fetchHyperliquidUserFillsByTime = origFills
+		fetchHyperliquidUserFunding = origFunding
+		fetchHyperliquidLedgerUpdates = origTransfers
+	}()
+	fetchHyperliquidUserFillsByTime = func(addr string, sinceMs int64) ([]hlFillRecord, error) {
+		return []hlFillRecord{
+			{Coin: "BTC", Time: t0.UnixMilli() + 10, Tid: json.Number("1"), ClosedPnl: "0", Fee: "0.5"},  // open: -0.5
+			{Coin: "BTC", Time: t0.UnixMilli() + 20, Tid: json.Number("2"), ClosedPnl: "20", Fee: "0.3"}, // close: +19.7
+		}, nil
+	}
+	fetchHyperliquidUserFunding = func(addr string, sinceMs int64) ([]hlLedgerEvent, error) {
+		return []hlLedgerEvent{
+			{Time: t0.UnixMilli() + 5, Hash: "0xf1", Delta: hlLedgerEventDelta{Type: "funding", Coin: "BTC", USDC: "-1.0"}},
+		}, nil
+	}
+	fetchHyperliquidLedgerUpdates = func(addr string, sinceMs int64) ([]hlLedgerEvent, error) {
+		return []hlLedgerEvent{
+			{Time: t0.UnixMilli() + 6, Hash: "0xd1", Delta: hlLedgerEventDelta{Type: "deposit", USDC: "100"}},           // +100
+			{Time: t0.UnixMilli() + 7, Hash: "0xw1", Delta: hlLedgerEventDelta{Type: "withdraw", USDC: "50", Fee: "1"}}, // -(50+1)=-51
+		}, nil
+	}
+
+	res := fetchCashflowJournalEvents(db, key, 1072.2, 5.0, t0.Add(time.Minute))
+	if !res.FillsFetched || !res.FundingFetched || !res.TransfersFetched {
+		t.Fatalf("expected all three streams fetched: %+v", res)
+	}
+	st := ingestCashflowJournalEvents(db, res)
+	if st.Incomplete {
+		t.Error("all kinds mapped — journal must not be marked incomplete")
+	}
+
+	settled, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	const wantSettled = -0.5 + 19.7 - 1.0 + 100 - 51 // 67.2
+	if math.Abs(settled-wantSettled) > 1e-9 {
+		t.Fatalf("settled sum = %v, want %v", settled, wantSettled)
+	}
+
+	expected := cashflowJournalExpectedEquity(st.BaselineAccountValue, st.BaselineUPnL, settled, res.CurrentUPnL)
+	// baseline 1000 + 67.2 settled + (5 - 0) uPnL = 1072.2; accountValue snapshot
+	// was 1072.2 so the journal closes the loop with ~0 drift.
+	if math.Abs(expected-1072.2) > 1e-9 {
+		t.Errorf("expected equity = %v, want 1072.2", expected)
+	}
+	if drift := res.AccountValue - expected; math.Abs(drift) > 1e-9 {
+		t.Errorf("journal drift = %v, want ~0", drift)
+	}
+
+	// Cursors advanced past the latest event of each stream.
+	if st.FillsSinceMs != t0.UnixMilli()+20+1 {
+		t.Errorf("fills cursor = %d, want %d", st.FillsSinceMs, t0.UnixMilli()+21)
+	}
+	if st.FundingSinceMs != t0.UnixMilli()+5+1 {
+		t.Errorf("funding cursor = %d, want %d", st.FundingSinceMs, t0.UnixMilli()+6)
+	}
+	if st.TransfersSinceMs != t0.UnixMilli()+7+1 {
+		t.Errorf("transfers cursor = %d, want %d", st.TransfersSinceMs, t0.UnixMilli()+8)
+	}
+}
+
+// A duplicate dedup_id (cursor-overlap re-read) is booked once, so re-ingesting
+// the same events must not double-count the settled sum.
+func TestCashflowJournalDedup(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	if err := db.InsertCashflowJournalEntry(key.Platform, key.Account, 1700000000000, "fill", 19.7, "BTC", 20, 0.3, "fill:tid:42"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	// Same dedup_id again (e.g. a re-fetch over the cursor boundary).
+	if err := db.InsertCashflowJournalEntry(key.Platform, key.Account, 1700000000000, "fill", 19.7, "BTC", 20, 0.3, "fill:tid:42"); err != nil {
+		t.Fatalf("dup insert should be ignored, not error: %v", err)
+	}
+	sum, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	if math.Abs(sum-19.7) > 1e-9 {
+		t.Errorf("dedup failed: sum = %v, want 19.7 (booked once)", sum)
+	}
+}
+
+// An ingest pass that re-reads events at/below the watermark (overlap) must not
+// re-book them, AND the DB UNIQUE guard backs that up.
+func TestCashflowJournalIngestIdempotentOnReplay(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	base := CashflowJournalState{FillsSinceMs: 100, FundingSinceMs: 100, TransfersSinceMs: 100, BaselineSet: true}
+	if err := db.UpsertCashflowJournalState(key.Platform, key.Account, base); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	mkRes := func(st CashflowJournalState) cashflowJournalFetchResult {
+		return cashflowJournalFetchResult{
+			Key: key, State: st, StateFound: true, FillsFetched: true,
+			Fills: []hlFillRecord{{Coin: "BTC", Time: 150, Tid: json.Number("7"), ClosedPnl: "10", Fee: "0.2"}},
+		}
+	}
+	st1 := ingestCashflowJournalEvents(db, mkRes(base))
+	// Re-fetch returns the same fill (overlap); cursor already advanced past it.
+	st2 := ingestCashflowJournalEvents(db, mkRes(st1))
+	sum, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	if math.Abs(sum-9.8) > 1e-9 {
+		t.Errorf("replay double-booked: sum = %v, want 9.8", sum)
+	}
+	if st2.FillsSinceMs != 151 {
+		t.Errorf("cursor regressed on replay: %d, want 151", st2.FillsSinceMs)
+	}
+}
+
+// An unmapped ledger delta type latches Incomplete (so a future alarm switch
+// fails closed) and still records a $0-effect row so the event stays visible.
+func TestCashflowJournalUnmappedKindLatchesIncomplete(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	res := cashflowJournalFetchResult{
+		Key:        key,
+		State:      CashflowJournalState{TransfersSinceMs: 100, BaselineSet: true},
+		StateFound: true, TransfersFetched: true,
+		Transfers: []hlLedgerEvent{
+			{Time: 150, Hash: "0xq", Delta: hlLedgerEventDelta{Type: "someBrandNewKind"}},
+		},
+	}
+	st := ingestCashflowJournalEvents(db, res)
+	if !st.Incomplete {
+		t.Fatal("unmapped kind must latch Incomplete")
+	}
+	sum, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	if math.Abs(sum) > 1e-9 {
+		t.Errorf("unmapped row must record $0 effect, sum = %v", sum)
+	}
+	// And it persisted the latch.
+	got, _, _ := db.GetCashflowJournalState(key.Platform, key.Account)
+	if !got.Incomplete {
+		t.Error("Incomplete latch not persisted")
+	}
+}
+
+// A persistence failure must HALT the cursor at the failed event so a crash
+// can never strand an un-booked event behind an advanced watermark.
+func TestCashflowJournalCursorHaltsOnPersistFailure(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	res := cashflowJournalFetchResult{
+		Key:        key,
+		State:      CashflowJournalState{FillsSinceMs: 100, BaselineSet: true},
+		StateFound: true, FillsFetched: true,
+		Fills: []hlFillRecord{{Coin: "BTC", Time: 200, Tid: json.Number("1"), ClosedPnl: "10", Fee: "0.2"}},
+	}
+	// Force every insert to fail by closing the DB first.
+	db.Close()
+	st := ingestCashflowJournalEvents(db, res)
+	if st.FillsSinceMs != 100 {
+		t.Errorf("cursor advanced past a failed insert: %d, want 100 (held)", st.FillsSinceMs)
+	}
+}

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -274,6 +274,51 @@ CREATE TABLE IF NOT EXISTS wallet_transfers (
     dedup_id TEXT NOT NULL UNIQUE
 );
 
+-- #1100: exchange-sourced equity journal for shared-wallet TOTAL reconciliation.
+-- Where wallet_ledger_state / wallet_transfers feed the per-strategy ATTRIBUTION
+-- split (#954), this journal reconstructs the wallet's settled-cash balance from
+-- the exchange's OWN cash-flow events — fills, funding, transfers — so the total
+-- drift alarm no longer depends on internal trade rows being complete and
+-- correctly priced. amount_usd is the SIGNED settled-cash effect on accountValue:
+--   fill            = closed_pnl_gross - fee_usd  (closed_pnl is GROSS of fees;
+--                     the gross value is retained for attribution/display and is
+--                     NEVER summed into equity on its own — #698 / #954 invariant)
+--   funding         = signed funding usdc
+--   <transfer kind> = signedPerpFlowUSD (deposits / withdrawals / transfers / ...)
+-- Shadow-only today: computed beside the trade-ledger drift path and logged for
+-- validation; it does not yet drive any alarm (see reconcileCashflowJournalShadow).
+CREATE TABLE IF NOT EXISTS cashflow_journal (
+    rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+    platform TEXT NOT NULL,
+    account TEXT NOT NULL,
+    time_ms INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    amount_usd REAL NOT NULL,
+    coin TEXT NOT NULL DEFAULT '',
+    closed_pnl_gross REAL NOT NULL DEFAULT 0,
+    fee_usd REAL NOT NULL DEFAULT 0,
+    dedup_id TEXT NOT NULL UNIQUE
+);
+CREATE INDEX IF NOT EXISTS idx_cashflow_journal_account ON cashflow_journal(platform, account);
+
+-- #1100: per-wallet journal cursors + adoption baseline. fills/funding/transfers
+-- watermarks bound the three incremental fetches; baseline_account_value /
+-- baseline_upnl anchor the equity equation at adoption so pre-journal history is
+-- never replayed. incomplete=1 LATCHES when an unmapped event kind is seen so a
+-- future alarm switch can fail closed; baseline_set=0 forces a re-anchor.
+CREATE TABLE IF NOT EXISTS cashflow_journal_state (
+    platform TEXT NOT NULL,
+    account TEXT NOT NULL,
+    fills_since_ms INTEGER NOT NULL DEFAULT 0,
+    funding_since_ms INTEGER NOT NULL DEFAULT 0,
+    transfers_since_ms INTEGER NOT NULL DEFAULT 0,
+    baseline_account_value REAL NOT NULL DEFAULT 0,
+    baseline_upnl REAL NOT NULL DEFAULT 0,
+    baseline_set INTEGER NOT NULL DEFAULT 0,
+    incomplete INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (platform, account)
+);
+
 CREATE TABLE IF NOT EXISTS pending_limit_orders (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     strategy_id TEXT NOT NULL,

--- a/scheduler/hyperliquid_fills.go
+++ b/scheduler/hyperliquid_fills.go
@@ -72,6 +72,12 @@ type hlFillRecord struct {
 	ClosedPnl string      `json:"closedPnl"`
 	Time      int64       `json:"time"`
 	Dir       string      `json:"dir"`
+	// Tid is Hyperliquid's unique per-fill trade id; Hash is the L1 tx hash.
+	// Unused by the OID/coin-size reconciler lookups, they give the #1100
+	// cash-flow journal a stable per-fill dedup identity (a single OID can
+	// fragment into many partial fills, so OID alone is not unique).
+	Tid  json.Number `json:"tid"`
+	Hash string      `json:"hash"`
 }
 
 // fetchHyperliquidUserFillsByTime is a function variable so tests can stub the

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1068,6 +1068,25 @@ func main() {
 			// Fire throttled drift alarms outside the lock (notifier I/O).
 			reportSharedWalletDrift(notifier, driftResults)
 
+			// #1100 SHADOW: reconstruct the HL shared wallet's equity from the
+			// exchange's OWN cash-flow events (fills + funding + transfers) via a
+			// durable journal and log it beside the trade-ledger drift for
+			// validation. No alarm or display change — this is the read-beside
+			// phase before the alarm is switched onto the journal. Runs outside
+			// the lock: HTTP fetch + DB-only writes, no StrategyState mutation.
+			// Reuses the coherent accountValue / position snapshot the reconcile
+			// just consumed (walletBalances[hlKey] + hlPositions).
+			if hlShared && hlStateFetched {
+				var hlLedgerDrift *sharedWalletDriftResult
+				for i := range driftResults {
+					if driftResults[i].Key == hlKey {
+						hlLedgerDrift = &driftResults[i]
+						break
+					}
+				}
+				reconcileCashflowJournalShadow(stateDB, hlKey, walletBalances[hlKey], sumHLAccountUPnL(hlPositions), hlLedgerDrift, time.Now().UTC())
+			}
+
 			// #341 / #345 / #346 / #347: Submit market closes to
 			// Hyperliquid, OKX, Robinhood, AND TopStep for every non-zero
 			// on-chain / on-account position belonging to a configured


### PR DESCRIPTION
## Summary

Phase 1 of the Hyperliquid scope of epic #1100. Reconstructs each Hyperliquid shared wallet's settled-cash balance from the exchange's **own** cash-flow events (fills + funding + transfers) via a durable, per-stream journal, instead of deriving the wallet total from the bot's internal trade ledger. **Shadow mode** — the expected-equity calculation runs **beside** the live trade-ledger drift path and logs the delta; **no alarm, display, or member-value change.**

`Closes #1103`. Part of epic #1100.

> **This is the base of a 2-PR stack.** The alarm switch that promotes this journal to the actual drift basis is #1107 (#1104), stacked on top. This PR must land and bake on live shadow data before #1107 flips the alarm.

## Why

Today the drift alarm rebuilds equity from the bot's trade rows plus exchange uPnL (`member_value = initial_capital + Σ tradeLedgerDelta + owned_uPnL`), so any modeled fee, fallback fill price, or model-only force-close / kill-switch row shows up as residual drift. The journal makes the **total** come from the exchange; internal rows stay the source of truth for per-strategy **attribution** only.

## How it reconciles

HL `accountValue` = settled cash + unrealized PnL, so:

```
expected = baseline_accountValue + Σ(settled-cash deltas since baseline) + (uPnL_now − uPnL_baseline)
```

- **fill** settled delta = `closedPnl_gross − fee` (opens settle `−fee`; maker rebate adds to cash)
- **funding** = signed `usdc`
- **transfer kinds** = `signedPerpFlowUSD` (deposits / withdrawals / class·internal·sub-account transfers / …)

`closedPnl` is **gross** of fees (#698): the fee is subtracted exactly once in the settled delta, and the gross value is kept in `closed_pnl_gross` for attribution — **never** summed into equity on its own. The uPnL term and the fill settled-delta hand off cleanly across an open→accrue→close lifecycle (no double-count).

## Durability / correctness

- Durable per-stream cursors/watermarks; per-event dedup (`INSERT OR IGNORE` on UNIQUE `dedup_id`); halt-cursor-on-persist-failure (mirrors `wallet_ledger.go`).
- Baseline anchored once at first contact (no historical replay); unmapped event kind → `incomplete` latch (wired for the fail-closed gate the alarm switch consumes).
- Journal mutates no `StrategyState` → the whole flow runs **outside** `mu.Lock`.

## Changes

- `scheduler/db.go` — `cashflow_journal` + `cashflow_journal_state` tables (idempotent `IF NOT EXISTS`).
- `scheduler/cashflow_journal.go` (new) — journal DB methods; three-stream incremental fetch reusing the existing Go fetchers (`fetchHyperliquidUserFillsByTime` / `userFunding` / `ledgerUpdates`); DB-only ingest with durable cursors, per-event dedup, halt-on-persist-failure, and the unmapped-kind `incomplete` latch; the shadow compute + per-cycle journal-vs-ledger delta log.
- `scheduler/hyperliquid_fills.go` — `hlFillRecord` gains `tid`/`hash` for stable per-fill dedup.
- `scheduler/main.go` — shadow call after `reportSharedWalletDrift`, reusing the reconcile's coherent `accountValue`/position snapshot.

## Verification

- Full `scheduler` `go test` green; build clean; `gofmt` clean.
- Tests: settled-cash convention incl. maker rebate; the equity equation; cursor advance/halt incl. same-ms sibling; dedup; baseline anchoring (no replay); full fetch→ingest→expected-equity loop; unmapped-kind latching.
- No Python changes — reuses Go-native HL fetchers, no Go↔Python argv contract touched.

## Not in this PR

- The alarm-basis switch, fail-closed gate, snapshot cutoff, and env kill-switch → #1107 (#1104).
- OKX (#1105) / TopStep (#1106) — gated on per-venue feed verification.

LLM: Opus 4.8 | high | Harness: work-on-issue
