### PR TITLE
feat(#1100): HL exchange cash-flow journal shadow reconciliation

### DIFF
--- a/scheduler/cashflow_journal.go
+++ b/scheduler/cashflow_journal.go
@@ -8,40 +8,22 @@ import (
 	"time"
 )
 
-// #1100: exchange-sourced equity journal for shared-wallet TOTAL reconciliation.
-//
-// Today the shared-wallet drift alarm reconstructs each account's equity from
-// the bot's OWN trade ledger plus exchange unrealized PnL, then compares that
-// derived value to the exchange's accountValue:
-//
-//	member_value_i = initial_capital_i + Σ tradeLedgerDelta_i + owned_uPnL_i
-//	raw_drift      = accountValue − Σ member_value_i − Σ wallet_transfers
-//
-// Every write path, fallback, or model-only cleanup that mis-prices a trade row
-// shows up as residual drift because the TOTAL still depends on internal rows.
-//
-// This journal inverts that: it reconstructs equity from the exchange's own
-// cash-flow events — fills, funding, transfers — pulled incrementally per stream
-// with durable cursors and per-event dedup. Internal trade rows stay the source
-// of truth for per-strategy ATTRIBUTION only; the TOTAL comes from the exchange.
+// #1100: exchange-sourced equity journal for shared-wallet TOTAL reconciliation
+// (Hyperliquid only). Internal trade rows remain the source of truth for
+// per-strategy ATTRIBUTION; the wallet-level drift alarm keys off journal equity.
 //
 // Equity decomposition (HL accountValue = settled cash + unrealized PnL):
 //
-//	accountValue_t = baseline_accountValue
-//	               + Σ(settled-cash deltas since baseline)
-//	               + (current_uPnL − baseline_uPnL)
+//	expected = baseline_accountValue
+//	         + Σ(settled-cash deltas since baseline)
+//	         + (current_uPnL − baseline_uPnL)
 //
-// A fill's settled-cash delta is closedPnl (GROSS) minus fee. closedPnl is gross
-// of fees (#698) so the fee is subtracted exactly once; closed_pnl_gross is
-// retained for attribution and is NEVER summed into equity on its own.
-//
-// SCOPE: Hyperliquid shared wallets, SHADOW MODE. The journal is computed
-// beside the live trade-ledger drift path and the delta is logged for
-// validation. It does NOT yet drive any alarm or member display.
+// A fill's settled-cash delta is closedPnl (GROSS) minus fee (#698). OKX and
+// other platforms keep the #918/#954 paths unchanged.
 
 // CashflowJournalState is one wallet's per-stream journal cursors plus the
 // adoption baseline. Incomplete latches true once an unmapped event kind is
-// seen so a future alarm switch can fail closed to the trade-ledger path.
+// seen — alarms fail closed to the trade-ledger path until repaired.
 type CashflowJournalState struct {
 	FillsSinceMs         int64
 	FundingSinceMs       int64
@@ -144,19 +126,14 @@ func (sdb *StateDB) SumCashflowJournal(platform, account string) (float64, error
 	return sum.Float64, nil
 }
 
-// cashflowFillSettledDelta is one fill's SIGNED effect on settled cash.
 func cashflowFillSettledDelta(closedPnlGross, fee float64) float64 {
 	return closedPnlGross - fee
 }
 
-// cashflowJournalExpectedEquity reconstructs the wallet's current accountValue
-// from the adoption baseline, settled-cash deltas since, and ΔuPnL.
 func cashflowJournalExpectedEquity(baselineAccountValue, baselineUPnL, settledDeltaSum, currentUPnL float64) float64 {
 	return baselineAccountValue + settledDeltaSum + (currentUPnL - baselineUPnL)
 }
 
-// advanceCashflowCursor returns the next watermark for one stream. Mirrors the
-// wallet_ledger watermark discipline.
 func advanceCashflowCursor(current, maxProcessed, failedAt int64) int64 {
 	next := maxProcessed + 1
 	if failedAt >= 0 && failedAt < next {
@@ -187,6 +164,7 @@ type cashflowJournalFetchResult struct {
 	Key              SharedWalletKey
 	State            CashflowJournalState
 	StateFound       bool
+	PriorStateExists bool // true when an existing row was loaded (not first anchor)
 	AccountValue     float64
 	CurrentUPnL      float64
 	Fills            []hlFillRecord
@@ -233,6 +211,7 @@ func fetchCashflowJournalEvents(sdb *StateDB, key SharedWalletKey, accountValue,
 	}
 	res.State = st
 	res.StateFound = true
+	res.PriorStateExists = true
 
 	if fills, err := fetchHyperliquidUserFillsByTime(key.Account, st.FillsSinceMs); err != nil {
 		fmt.Printf("[WARN] cashflow-journal %s: userFills fetch failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
@@ -346,39 +325,66 @@ func ingestCashflowJournalEvents(sdb *StateDB, res cashflowJournalFetchResult) C
 	return st
 }
 
-// reconcileCashflowJournalShadow runs the full journal flow for one HL shared
-// wallet OUTSIDE the state lock and logs journal equity beside trade-ledger drift.
-func reconcileCashflowJournalShadow(sdb *StateDB, key SharedWalletKey, accountValue, currentUPnL float64, ledgerDrift *sharedWalletDriftResult, now time.Time) {
-	if sdb == nil || key.Platform != "hyperliquid" || key.Account == "" {
-		return
+// cashflowJournalUsable reports whether journal-based drift alarms are safe this
+// cycle. First-anchor cycles (no prior row) are usable with zero post-baseline
+// events. Established wallets require all three streams to have fetched cleanly.
+func cashflowJournalUsable(fetch cashflowJournalFetchResult, st CashflowJournalState) bool {
+	if !fetch.StateFound || !st.BaselineSet || st.Incomplete {
+		return false
 	}
-	res := fetchCashflowJournalEvents(sdb, key, accountValue, currentUPnL, now)
-	if !res.StateFound {
-		return
+	if !fetch.PriorStateExists {
+		return true
 	}
-	st := ingestCashflowJournalEvents(sdb, res)
-	if !st.BaselineSet {
-		return
-	}
-	settled, err := sdb.SumCashflowJournal(key.Platform, key.Account)
-	if err != nil {
-		fmt.Printf("[WARN] cashflow-journal %s: settled-sum read failed: %v\n", sharedWalletKeyLabel(key), err)
-		return
-	}
-	expected := cashflowJournalExpectedEquity(st.BaselineAccountValue, st.BaselineUPnL, settled, res.CurrentUPnL)
-	journalDrift := res.AccountValue - expected
+	return fetch.FillsFetched && fetch.FundingFetched && fetch.TransfersFetched
+}
 
-	incompleteNote := ""
-	if st.Incomplete {
-		incompleteNote = " [INCOMPLETE: unmapped event kind seen — would fail closed once promoted]"
+// computeCashflowJournalDrift returns the journal expected equity and alarm drift.
+func computeCashflowJournalDrift(sdb *StateDB, fetch cashflowJournalFetchResult, st CashflowJournalState) (expected, drift float64, ok bool) {
+	if sdb == nil || !cashflowJournalUsable(fetch, st) {
+		return 0, 0, false
 	}
-	ledgerNote := "n/a"
-	if ledgerDrift != nil {
-		ledgerNote = fmt.Sprintf("raw $%+.2f / post-baseline $%+.2f", ledgerDrift.Balance-ledgerDrift.MemberSum, ledgerDrift.Drift)
+	settled, err := sdb.SumCashflowJournal(fetch.Key.Platform, fetch.Key.Account)
+	if err != nil {
+		fmt.Printf("[WARN] cashflow-journal %s: settled-sum read failed: %v\n", sharedWalletKeyLabel(fetch.Key), err)
+		return 0, 0, false
 	}
-	fmt.Printf("[cashflow-journal] %s SHADOW: expected_equity $%.2f vs accountValue $%.2f → journal_drift $%+.4f (settled Σ $%+.2f since baseline $%.2f, ΔuPnL $%+.2f); trade-ledger drift %s%s\n",
-		sharedWalletKeyLabel(key), expected, res.AccountValue, journalDrift,
-		settled, st.BaselineAccountValue, res.CurrentUPnL-st.BaselineUPnL, ledgerNote, incompleteNote)
+	expected = cashflowJournalExpectedEquity(st.BaselineAccountValue, st.BaselineUPnL, settled, fetch.CurrentUPnL)
+	drift = fetch.AccountValue - expected
+	return expected, drift, true
+}
+
+// applyHyperliquidCashflowJournalDrift ingests one HL wallet's journal events and
+// patches the matching sharedWalletDriftResult to use journal equity for alarms
+// when usable; otherwise leaves the trade-ledger fallback drift in place.
+func applyHyperliquidCashflowJournalDrift(results *[]sharedWalletDriftResult, sdb *StateDB, fetch cashflowJournalFetchResult) {
+	if sdb == nil || fetch.Key.Platform != "hyperliquid" || !fetch.StateFound {
+		return
+	}
+	st := ingestCashflowJournalEvents(sdb, fetch)
+	expected, journalDrift, ok := computeCashflowJournalDrift(sdb, fetch, st)
+	for i := range *results {
+		if (*results)[i].Key != fetch.Key {
+			continue
+		}
+		r := &(*results)[i]
+		if ok {
+			r.Drift = journalDrift
+			r.ExpectedEquity = expected
+			r.DriftBasis = sharedWalletDriftBasisCashflowJournal
+			fmt.Printf("[cashflow-journal] %s: expected_equity $%.2f vs accountValue $%.2f → journal_drift $%+.4f (attribution gap $%+.2f, ledger-fallback $%+.2f)\n",
+				sharedWalletKeyLabel(fetch.Key), expected, fetch.AccountValue, journalDrift, r.AttributionGap, r.LedgerFallbackDrift)
+		} else {
+			reason := "journal unusable"
+			if st.Incomplete {
+				reason = "journal incomplete (unmapped event)"
+			} else if fetch.PriorStateExists && (!fetch.FillsFetched || !fetch.FundingFetched || !fetch.TransfersFetched) {
+				reason = "fetch miss this cycle"
+			}
+			fmt.Printf("[WARN] cashflow-journal %s: %s — drift alarm uses trade-ledger fallback $%+.2f\n",
+				sharedWalletKeyLabel(fetch.Key), reason, r.LedgerFallbackDrift)
+		}
+		return
+	}
 }
 
 // sumHLAccountUPnL totals exchange-reported unrealized PnL across open positions.

--- a/scheduler/cashflow_journal.go
+++ b/scheduler/cashflow_journal.go
@@ -1,0 +1,391 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// #1100: exchange-sourced equity journal for shared-wallet TOTAL reconciliation.
+//
+// Today the shared-wallet drift alarm reconstructs each account's equity from
+// the bot's OWN trade ledger plus exchange unrealized PnL, then compares that
+// derived value to the exchange's accountValue:
+//
+//	member_value_i = initial_capital_i + Σ tradeLedgerDelta_i + owned_uPnL_i
+//	raw_drift      = accountValue − Σ member_value_i − Σ wallet_transfers
+//
+// Every write path, fallback, or model-only cleanup that mis-prices a trade row
+// shows up as residual drift because the TOTAL still depends on internal rows.
+//
+// This journal inverts that: it reconstructs equity from the exchange's own
+// cash-flow events — fills, funding, transfers — pulled incrementally per stream
+// with durable cursors and per-event dedup. Internal trade rows stay the source
+// of truth for per-strategy ATTRIBUTION only; the TOTAL comes from the exchange.
+//
+// Equity decomposition (HL accountValue = settled cash + unrealized PnL):
+//
+//	accountValue_t = baseline_accountValue
+//	               + Σ(settled-cash deltas since baseline)
+//	               + (current_uPnL − baseline_uPnL)
+//
+// A fill's settled-cash delta is closedPnl (GROSS) minus fee. closedPnl is gross
+// of fees (#698) so the fee is subtracted exactly once; closed_pnl_gross is
+// retained for attribution and is NEVER summed into equity on its own.
+//
+// SCOPE: Hyperliquid shared wallets, SHADOW MODE. The journal is computed
+// beside the live trade-ledger drift path and the delta is logged for
+// validation. It does NOT yet drive any alarm or member display.
+
+// CashflowJournalState is one wallet's per-stream journal cursors plus the
+// adoption baseline. Incomplete latches true once an unmapped event kind is
+// seen so a future alarm switch can fail closed to the trade-ledger path.
+type CashflowJournalState struct {
+	FillsSinceMs         int64
+	FundingSinceMs       int64
+	TransfersSinceMs     int64
+	BaselineAccountValue float64
+	BaselineUPnL         float64
+	BaselineSet          bool
+	Incomplete           bool
+}
+
+// GetCashflowJournalState loads one wallet's journal state; found=false when the
+// wallet has never been ingested.
+func (sdb *StateDB) GetCashflowJournalState(platform, account string) (CashflowJournalState, bool, error) {
+	var st CashflowJournalState
+	if sdb == nil || sdb.db == nil {
+		return st, false, fmt.Errorf("state db unavailable")
+	}
+	var baselineSet, incomplete int
+	err := sdb.db.QueryRow(
+		`SELECT fills_since_ms, funding_since_ms, transfers_since_ms,
+		        baseline_account_value, baseline_upnl, baseline_set, incomplete
+		 FROM cashflow_journal_state WHERE platform = ? AND account = ?`,
+		platform, account).Scan(&st.FillsSinceMs, &st.FundingSinceMs, &st.TransfersSinceMs,
+		&st.BaselineAccountValue, &st.BaselineUPnL, &baselineSet, &incomplete)
+	if err == sql.ErrNoRows {
+		return st, false, nil
+	}
+	if err != nil {
+		return st, false, fmt.Errorf("load cashflow journal state: %w", err)
+	}
+	st.BaselineSet = baselineSet != 0
+	st.Incomplete = incomplete != 0
+	return st, true, nil
+}
+
+// UpsertCashflowJournalState writes one wallet's journal state row.
+func (sdb *StateDB) UpsertCashflowJournalState(platform, account string, st CashflowJournalState) error {
+	if sdb == nil || sdb.db == nil {
+		return fmt.Errorf("state db unavailable")
+	}
+	baselineSet := 0
+	if st.BaselineSet {
+		baselineSet = 1
+	}
+	incomplete := 0
+	if st.Incomplete {
+		incomplete = 1
+	}
+	_, err := sdb.db.Exec(
+		`INSERT INTO cashflow_journal_state
+		   (platform, account, fills_since_ms, funding_since_ms, transfers_since_ms,
+		    baseline_account_value, baseline_upnl, baseline_set, incomplete)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(platform, account) DO UPDATE SET
+		   fills_since_ms = excluded.fills_since_ms,
+		   funding_since_ms = excluded.funding_since_ms,
+		   transfers_since_ms = excluded.transfers_since_ms,
+		   baseline_account_value = excluded.baseline_account_value,
+		   baseline_upnl = excluded.baseline_upnl,
+		   baseline_set = excluded.baseline_set,
+		   incomplete = excluded.incomplete`,
+		platform, account, st.FillsSinceMs, st.FundingSinceMs, st.TransfersSinceMs,
+		st.BaselineAccountValue, st.BaselineUPnL, baselineSet, incomplete)
+	if err != nil {
+		return fmt.Errorf("upsert cashflow journal state: %w", err)
+	}
+	return nil
+}
+
+// InsertCashflowJournalEntry appends one settled-cash event; a duplicate
+// dedup_id is silently ignored (cursor-overlap re-reads).
+func (sdb *StateDB) InsertCashflowJournalEntry(platform, account string, timeMs int64, kind string, amountUSD float64, coin string, closedPnlGross, feeUSD float64, dedupID string) error {
+	if sdb == nil || sdb.db == nil {
+		return fmt.Errorf("state db unavailable")
+	}
+	_, err := sdb.db.Exec(
+		`INSERT OR IGNORE INTO cashflow_journal
+		   (platform, account, time_ms, kind, amount_usd, coin, closed_pnl_gross, fee_usd, dedup_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		platform, account, timeMs, kind, amountUSD, coin, closedPnlGross, feeUSD, dedupID)
+	if err != nil {
+		return fmt.Errorf("insert cashflow journal entry: %w", err)
+	}
+	return nil
+}
+
+// SumCashflowJournal returns the signed total of one wallet's settled-cash
+// deltas since adoption (Σ amount_usd across every journal row).
+func (sdb *StateDB) SumCashflowJournal(platform, account string) (float64, error) {
+	if sdb == nil || sdb.db == nil {
+		return 0, fmt.Errorf("state db unavailable")
+	}
+	var sum sql.NullFloat64
+	err := sdb.db.QueryRow(
+		`SELECT SUM(amount_usd) FROM cashflow_journal WHERE platform = ? AND account = ?`,
+		platform, account).Scan(&sum)
+	if err != nil {
+		return 0, fmt.Errorf("sum cashflow journal: %w", err)
+	}
+	return sum.Float64, nil
+}
+
+// cashflowFillSettledDelta is one fill's SIGNED effect on settled cash.
+func cashflowFillSettledDelta(closedPnlGross, fee float64) float64 {
+	return closedPnlGross - fee
+}
+
+// cashflowJournalExpectedEquity reconstructs the wallet's current accountValue
+// from the adoption baseline, settled-cash deltas since, and ΔuPnL.
+func cashflowJournalExpectedEquity(baselineAccountValue, baselineUPnL, settledDeltaSum, currentUPnL float64) float64 {
+	return baselineAccountValue + settledDeltaSum + (currentUPnL - baselineUPnL)
+}
+
+// advanceCashflowCursor returns the next watermark for one stream. Mirrors the
+// wallet_ledger watermark discipline.
+func advanceCashflowCursor(current, maxProcessed, failedAt int64) int64 {
+	next := maxProcessed + 1
+	if failedAt >= 0 && failedAt < next {
+		next = failedAt
+	}
+	if next > current {
+		return next
+	}
+	return current
+}
+
+func cashflowFillDedupID(f hlFillRecord) string {
+	if tid := strings.TrimSpace(f.Tid.String()); tid != "" && tid != "0" {
+		return "fill:tid:" + tid
+	}
+	return fmt.Sprintf("fill:%d:%s:%s", f.Time, f.Hash, strings.ToUpper(strings.TrimSpace(f.Coin)))
+}
+
+func cashflowFundingDedupID(ev hlLedgerEvent) string {
+	return fmt.Sprintf("funding:%d:%s:%s", ev.Time, ev.Hash, ev.Delta.Coin)
+}
+
+func cashflowTransferDedupID(ev hlLedgerEvent) string {
+	return fmt.Sprintf("%s:%d:%s", ev.Delta.Type, ev.Time, ev.Hash)
+}
+
+type cashflowJournalFetchResult struct {
+	Key              SharedWalletKey
+	State            CashflowJournalState
+	StateFound       bool
+	AccountValue     float64
+	CurrentUPnL      float64
+	Fills            []hlFillRecord
+	Funding          []hlLedgerEvent
+	Transfers        []hlLedgerEvent
+	FillsFetched     bool
+	FundingFetched   bool
+	TransfersFetched bool
+}
+
+// fetchCashflowJournalEvents reads per-stream cursors and pulls fills + funding +
+// non-funding ledger events since each. Runs OUTSIDE the state lock. First
+// contact anchors the baseline to the supplied accountValue / uPnL snapshot and
+// the cursors to now — pre-adoption movement belongs to the baseline.
+func fetchCashflowJournalEvents(sdb *StateDB, key SharedWalletKey, accountValue, currentUPnL float64, now time.Time) cashflowJournalFetchResult {
+	res := cashflowJournalFetchResult{Key: key, AccountValue: accountValue, CurrentUPnL: currentUPnL}
+	if sdb == nil || key.Platform != "hyperliquid" || key.Account == "" {
+		return res
+	}
+	st, found, err := sdb.GetCashflowJournalState(key.Platform, key.Account)
+	if err != nil {
+		fmt.Printf("[WARN] cashflow-journal %s: state load failed: %v — skipping ingestion this cycle\n", sharedWalletKeyLabel(key), err)
+		return res
+	}
+	if !found {
+		nowMs := now.UnixMilli()
+		st = CashflowJournalState{
+			FillsSinceMs:         nowMs,
+			FundingSinceMs:       nowMs,
+			TransfersSinceMs:     nowMs,
+			BaselineAccountValue: accountValue,
+			BaselineUPnL:         currentUPnL,
+			BaselineSet:          true,
+		}
+		if err := sdb.UpsertCashflowJournalState(key.Platform, key.Account, st); err != nil {
+			fmt.Printf("[WARN] cashflow-journal %s: baseline init failed: %v\n", sharedWalletKeyLabel(key), err)
+			return res
+		}
+		fmt.Printf("[cashflow-journal] %s: baseline anchored at accountValue $%.2f (uPnL $%+.2f) and cursors at %s (no historical replay)\n",
+			sharedWalletKeyLabel(key), accountValue, currentUPnL, now.UTC().Format(time.RFC3339))
+		res.State = st
+		res.StateFound = true
+		return res
+	}
+	res.State = st
+	res.StateFound = true
+
+	if fills, err := fetchHyperliquidUserFillsByTime(key.Account, st.FillsSinceMs); err != nil {
+		fmt.Printf("[WARN] cashflow-journal %s: userFills fetch failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+	} else {
+		res.Fills = fills
+		res.FillsFetched = true
+	}
+	if funding, err := fetchHyperliquidUserFunding(key.Account, st.FundingSinceMs); err != nil {
+		fmt.Printf("[WARN] cashflow-journal %s: userFunding fetch failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+	} else {
+		res.Funding = funding
+		res.FundingFetched = true
+	}
+	if transfers, err := fetchHyperliquidLedgerUpdates(key.Account, st.TransfersSinceMs); err != nil {
+		fmt.Printf("[WARN] cashflow-journal %s: userNonFundingLedgerUpdates fetch failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+	} else {
+		res.Transfers = transfers
+		res.TransfersFetched = true
+	}
+	return res
+}
+
+// ingestCashflowJournalEvents books fetched events and advances cursors. DB-only.
+func ingestCashflowJournalEvents(sdb *StateDB, res cashflowJournalFetchResult) CashflowJournalState {
+	st := res.State
+	if sdb == nil || !res.StateFound {
+		return st
+	}
+	key := res.Key
+
+	if res.FillsFetched {
+		maxTime := st.FillsSinceMs - 1
+		failedAt := int64(-1)
+		fills := append([]hlFillRecord(nil), res.Fills...)
+		sort.SliceStable(fills, func(i, j int) bool { return fills[i].Time < fills[j].Time })
+		for _, f := range fills {
+			if f.Time < st.FillsSinceMs {
+				continue
+			}
+			coin := strings.ToUpper(strings.TrimSpace(f.Coin))
+			closedPnl := parseHLFloat(f.ClosedPnl)
+			fee := parseHLFloat(f.Fee)
+			delta := cashflowFillSettledDelta(closedPnl, fee)
+			if err := sdb.InsertCashflowJournalEntry(key.Platform, key.Account, f.Time, "fill", delta, coin, closedPnl, fee, cashflowFillDedupID(f)); err != nil {
+				fmt.Printf("[WARN] cashflow-journal %s: fill insert failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+				failedAt = f.Time
+				break
+			}
+			if f.Time > maxTime {
+				maxTime = f.Time
+			}
+		}
+		st.FillsSinceMs = advanceCashflowCursor(st.FillsSinceMs, maxTime, failedAt)
+	}
+
+	if res.FundingFetched {
+		maxTime := st.FundingSinceMs - 1
+		failedAt := int64(-1)
+		events := append([]hlLedgerEvent(nil), res.Funding...)
+		sort.SliceStable(events, func(i, j int) bool { return events[i].Time < events[j].Time })
+		for _, ev := range events {
+			if ev.Time < st.FundingSinceMs {
+				continue
+			}
+			amount := parseHLFloat(ev.Delta.USDC)
+			coin := strings.ToUpper(strings.TrimSpace(ev.Delta.Coin))
+			if err := sdb.InsertCashflowJournalEntry(key.Platform, key.Account, ev.Time, "funding", amount, coin, 0, 0, cashflowFundingDedupID(ev)); err != nil {
+				fmt.Printf("[WARN] cashflow-journal %s: funding insert failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+				failedAt = ev.Time
+				break
+			}
+			if ev.Time > maxTime {
+				maxTime = ev.Time
+			}
+		}
+		st.FundingSinceMs = advanceCashflowCursor(st.FundingSinceMs, maxTime, failedAt)
+	}
+
+	if res.TransfersFetched {
+		maxTime := st.TransfersSinceMs - 1
+		failedAt := int64(-1)
+		events := append([]hlLedgerEvent(nil), res.Transfers...)
+		sort.SliceStable(events, func(i, j int) bool { return events[i].Time < events[j].Time })
+		for _, ev := range events {
+			if ev.Time < st.TransfersSinceMs {
+				continue
+			}
+			amount, known := signedPerpFlowUSD(ev.Delta, key.Account)
+			if !known {
+				st.Incomplete = true
+				fmt.Printf("[WARN] cashflow-journal %s: unmapped ledger delta type %q (hash %s) — recorded with $0 effect, journal marked incomplete\n",
+					sharedWalletKeyLabel(key), ev.Delta.Type, ev.Hash)
+			}
+			if err := sdb.InsertCashflowJournalEntry(key.Platform, key.Account, ev.Time, ev.Delta.Type, amount, "", 0, 0, cashflowTransferDedupID(ev)); err != nil {
+				fmt.Printf("[WARN] cashflow-journal %s: transfer insert failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+				failedAt = ev.Time
+				break
+			}
+			if ev.Time > maxTime {
+				maxTime = ev.Time
+			}
+		}
+		st.TransfersSinceMs = advanceCashflowCursor(st.TransfersSinceMs, maxTime, failedAt)
+	}
+
+	if st != res.State {
+		if err := sdb.UpsertCashflowJournalState(key.Platform, key.Account, st); err != nil {
+			fmt.Printf("[WARN] cashflow-journal %s: cursor advance failed: %v\n", sharedWalletKeyLabel(key), err)
+		}
+	}
+	return st
+}
+
+// reconcileCashflowJournalShadow runs the full journal flow for one HL shared
+// wallet OUTSIDE the state lock and logs journal equity beside trade-ledger drift.
+func reconcileCashflowJournalShadow(sdb *StateDB, key SharedWalletKey, accountValue, currentUPnL float64, ledgerDrift *sharedWalletDriftResult, now time.Time) {
+	if sdb == nil || key.Platform != "hyperliquid" || key.Account == "" {
+		return
+	}
+	res := fetchCashflowJournalEvents(sdb, key, accountValue, currentUPnL, now)
+	if !res.StateFound {
+		return
+	}
+	st := ingestCashflowJournalEvents(sdb, res)
+	if !st.BaselineSet {
+		return
+	}
+	settled, err := sdb.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		fmt.Printf("[WARN] cashflow-journal %s: settled-sum read failed: %v\n", sharedWalletKeyLabel(key), err)
+		return
+	}
+	expected := cashflowJournalExpectedEquity(st.BaselineAccountValue, st.BaselineUPnL, settled, res.CurrentUPnL)
+	journalDrift := res.AccountValue - expected
+
+	incompleteNote := ""
+	if st.Incomplete {
+		incompleteNote = " [INCOMPLETE: unmapped event kind seen — would fail closed once promoted]"
+	}
+	ledgerNote := "n/a"
+	if ledgerDrift != nil {
+		ledgerNote = fmt.Sprintf("raw $%+.2f / post-baseline $%+.2f", ledgerDrift.Balance-ledgerDrift.MemberSum, ledgerDrift.Drift)
+	}
+	fmt.Printf("[cashflow-journal] %s SHADOW: expected_equity $%.2f vs accountValue $%.2f → journal_drift $%+.4f (settled Σ $%+.2f since baseline $%.2f, ΔuPnL $%+.2f); trade-ledger drift %s%s\n",
+		sharedWalletKeyLabel(key), expected, res.AccountValue, journalDrift,
+		settled, st.BaselineAccountValue, res.CurrentUPnL-st.BaselineUPnL, ledgerNote, incompleteNote)
+}
+
+// sumHLAccountUPnL totals exchange-reported unrealized PnL across open positions.
+func sumHLAccountUPnL(positions []HLPosition) float64 {
+	sum := 0.0
+	for _, p := range positions {
+		sum += p.UnrealizedPnL
+	}
+	return sum
+}

--- a/scheduler/cashflow_journal_test.go
+++ b/scheduler/cashflow_journal_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+)
+
+func TestCashflowFillSettledDelta(t *testing.T) {
+	cases := []struct {
+		closed, fee, want float64
+	}{
+		{0, 1.5, -1.5},   // open: fee only
+		{100, 2, 98},     // close gross minus fee
+		{50, -0.1, 50.1}, // maker rebate
+	}
+	for _, tc := range cases {
+		if got := cashflowFillSettledDelta(tc.closed, tc.fee); math.Abs(got-tc.want) > 1e-9 {
+			t.Errorf("closed=%v fee=%v: got %v want %v", tc.closed, tc.fee, got, tc.want)
+		}
+	}
+}
+
+func TestCashflowJournalExpectedEquity(t *testing.T) {
+	// baseline accountValue=10000, baseline uPnL=500; settled +200; current uPnL=800 → +300 uPnL delta
+	got := cashflowJournalExpectedEquity(10000, 500, 200, 800)
+	want := 10000.0 + 200 + (800 - 500)
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("got %v want %v", got, want)
+	}
+}
+
+func TestAdvanceCashflowCursor(t *testing.T) {
+	cases := []struct {
+		name                   string
+		current, maxProc, fail int64
+		want                   int64
+	}{
+		{"advance past one event", 1000, 1500, -1, 1501},
+		{"halt at failed event", 1000, 1500, 1400, 1400},
+		{"no advance when nothing processed", 1000, 999, -1, 1000},
+	}
+	for _, tc := range cases {
+		if got := advanceCashflowCursor(tc.current, tc.maxProc, tc.fail); got != tc.want {
+			t.Errorf("%s: got %d want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestCashflowFillDedupID(t *testing.T) {
+	withTid := hlFillRecord{Tid: json.Number("42"), Time: 1, Hash: "h", Coin: "btc"}
+	if got := cashflowFillDedupID(withTid); got != "fill:tid:42" {
+		t.Errorf("tid key = %q", got)
+	}
+	noTid := hlFillRecord{Time: 99, Hash: "abc", Coin: "eth"}
+	if got := cashflowFillDedupID(noTid); got != "fill:99:abc:ETH" {
+		t.Errorf("fallback key = %q", got)
+	}
+}
+
+func TestCashflowJournalIngestAndEquity(t *testing.T) {
+	db := newLedgerTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xjournal"}
+	nowMs := int64(1_700_000_000_000)
+	st := CashflowJournalState{
+		FillsSinceMs:         nowMs,
+		FundingSinceMs:       nowMs,
+		TransfersSinceMs:     nowMs,
+		BaselineAccountValue: 10000,
+		BaselineUPnL:         100,
+		BaselineSet:          true,
+	}
+	if err := db.UpsertCashflowJournalState(key.Platform, key.Account, st); err != nil {
+		t.Fatalf("upsert state: %v", err)
+	}
+
+	eventMs := nowMs + 1000
+	res := cashflowJournalFetchResult{
+		Key: key, State: st, StateFound: true,
+		AccountValue: 10550, CurrentUPnL: 150,
+		Fills: []hlFillRecord{{
+			Coin: "BTC", Time: eventMs, Tid: json.Number("1"),
+			ClosedPnl: "50", Fee: "2",
+		}},
+		Funding: []hlLedgerEvent{{
+			Time: eventMs + 1, Hash: "fh",
+			Delta: hlLedgerEventDelta{Type: "funding", Coin: "BTC", USDC: "-1.5"},
+		}},
+		Transfers: []hlLedgerEvent{{
+			Time: eventMs + 2, Hash: "th",
+			Delta: hlLedgerEventDelta{Type: "deposit", USDC: "500"},
+		}},
+		FillsFetched: true, FundingFetched: true, TransfersFetched: true,
+	}
+
+	out := ingestCashflowJournalEvents(db, res)
+	if out.FillsSinceMs <= nowMs {
+		t.Errorf("fills cursor = %d, want > %d", out.FillsSinceMs, nowMs)
+	}
+
+	settled, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	wantSettled := 48.0 + (-1.5) + 500.0
+	if math.Abs(settled-wantSettled) > 1e-9 {
+		t.Errorf("settled = %v want %v", settled, wantSettled)
+	}
+	expected := cashflowJournalExpectedEquity(10000, 100, settled, 150)
+	wantEquity := 10000.0 + wantSettled + 50.0
+	if math.Abs(expected-wantEquity) > 1e-9 {
+		t.Errorf("expected equity = %v want %v", expected, wantEquity)
+	}
+}
+
+func TestCashflowJournalDedupIgnoresReplay(t *testing.T) {
+	db := newLedgerTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xdedup"}
+	nowMs := int64(1_700_000_000_000)
+	st := CashflowJournalState{
+		FillsSinceMs: nowMs, FundingSinceMs: nowMs, TransfersSinceMs: nowMs,
+		BaselineAccountValue: 1, BaselineUPnL: 0, BaselineSet: true,
+	}
+	if err := db.UpsertCashflowJournalState(key.Platform, key.Account, st); err != nil {
+		t.Fatal(err)
+	}
+	fill := hlFillRecord{Coin: "ETH", Time: nowMs + 1, Tid: json.Number("99"), ClosedPnl: "10", Fee: "1"}
+	res := cashflowJournalFetchResult{
+		Key: key, State: st, StateFound: true,
+		Fills: []hlFillRecord{fill, fill}, FillsFetched: true,
+	}
+	ingestCashflowJournalEvents(db, res)
+	sum1, _ := db.SumCashflowJournal(key.Platform, key.Account)
+	ingestCashflowJournalEvents(db, res)
+	sum2, _ := db.SumCashflowJournal(key.Platform, key.Account)
+	if math.Abs(sum1-9) > 1e-9 || math.Abs(sum2-sum1) > 1e-9 {
+		t.Errorf("dedup failed: sum1=%v sum2=%v", sum1, sum2)
+	}
+}
+
+func TestSumHLAccountUPnL(t *testing.T) {
+	got := sumHLAccountUPnL([]HLPosition{
+		{UnrealizedPnL: 10}, {UnrealizedPnL: -3},
+	})
+	if math.Abs(got-7) > 1e-9 {
+		t.Errorf("got %v want 7", got)
+	}
+}

--- a/scheduler/cashflow_journal_test.go
+++ b/scheduler/cashflow_journal_test.go
@@ -138,6 +138,74 @@ func TestCashflowJournalDedupIgnoresReplay(t *testing.T) {
 	}
 }
 
+func TestApplyHyperliquidCashflowJournalDrift_JournalWins(t *testing.T) {
+	db := newLedgerTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xapply"}
+	nowMs := int64(1_700_000_000_000)
+	seedHLCashflowJournalBaseline(t, db, "0xapply", 1000, 50, nowMs)
+
+	results := []sharedWalletDriftResult{{
+		Key: key, Balance: 997, MemberSum: 990, Drift: 0,
+		LedgerFallbackDrift: 0, DriftBasis: sharedWalletDriftBasisLedgerFallback,
+		AttributionGap: -7,
+	}}
+	fetch := cashflowJournalFetchResult{
+		Key: key, StateFound: true, PriorStateExists: true,
+		AccountValue: 997, CurrentUPnL: 50,
+		FillsFetched: true, FundingFetched: true, TransfersFetched: true,
+	}
+	st, _, _ := db.GetCashflowJournalState(key.Platform, key.Account)
+	fetch.State = st
+	applyHyperliquidCashflowJournalDrift(&results, db, fetch)
+	if results[0].DriftBasis != sharedWalletDriftBasisCashflowJournal {
+		t.Fatalf("basis = %q", results[0].DriftBasis)
+	}
+	if math.Abs(results[0].Drift-(-3)) > 1e-9 {
+		t.Fatalf("journal drift = %v want -3", results[0].Drift)
+	}
+}
+
+func TestApplyHyperliquidCashflowJournalDrift_IncompleteFallsBack(t *testing.T) {
+	db := newLedgerTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xfallback"}
+	nowMs := int64(1_700_000_000_000)
+	st := CashflowJournalState{
+		FillsSinceMs: nowMs, FundingSinceMs: nowMs, TransfersSinceMs: nowMs,
+		BaselineAccountValue: 1000, BaselineUPnL: 0, BaselineSet: true, Incomplete: true,
+	}
+	if err := db.UpsertCashflowJournalState(key.Platform, key.Account, st); err != nil {
+		t.Fatal(err)
+	}
+	results := []sharedWalletDriftResult{{
+		Key: key, Balance: 1000, Drift: -5, LedgerFallbackDrift: -5,
+		DriftBasis: sharedWalletDriftBasisLedgerFallback,
+	}}
+	fetch := cashflowJournalFetchResult{
+		Key: key, State: st, StateFound: true, PriorStateExists: true,
+		AccountValue: 1000, FillsFetched: true, FundingFetched: true, TransfersFetched: true,
+	}
+	applyHyperliquidCashflowJournalDrift(&results, db, fetch)
+	if results[0].DriftBasis != sharedWalletDriftBasisLedgerFallback || math.Abs(results[0].Drift-(-5)) > 1e-9 {
+		t.Fatalf("want ledger fallback preserved, got %+v", results[0])
+	}
+}
+
+func TestCashflowJournalUsable(t *testing.T) {
+	st := CashflowJournalState{BaselineSet: true}
+	if !cashflowJournalUsable(cashflowJournalFetchResult{StateFound: true}, st) {
+		t.Error("first anchor should be usable")
+	}
+	if cashflowJournalUsable(cashflowJournalFetchResult{StateFound: true, PriorStateExists: true, FillsFetched: true}, CashflowJournalState{BaselineSet: true, Incomplete: true}) {
+		t.Error("incomplete must fail")
+	}
+	if !cashflowJournalUsable(cashflowJournalFetchResult{
+		StateFound: true, PriorStateExists: true,
+		FillsFetched: true, FundingFetched: true, TransfersFetched: true,
+	}, st) {
+		t.Error("all streams ok should be usable")
+	}
+}
+
 func TestSumHLAccountUPnL(t *testing.T) {
 	got := sumHLAccountUPnL([]HLPosition{
 		{UnrealizedPnL: 10}, {UnrealizedPnL: -3},

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -284,8 +284,8 @@ CREATE TABLE IF NOT EXISTS wallet_transfers (
 --                     retained for attribution/display, NEVER summed into equity)
 --   funding         = signed funding usdc
 --   <transfer kind> = signedPerpFlowUSD (deposits / withdrawals / transfers / ...)
--- Shadow-only today: computed beside the trade-ledger drift path and logged for
--- validation; it does not yet drive any alarm (see reconcileCashflowJournalShadow).
+-- HL shared-wallet TOTAL reconciliation (#1100): journal rows drive the wallet-level
+-- drift alarm; internal trade rows remain attribution-only.
 CREATE TABLE IF NOT EXISTS cashflow_journal (
     rowid INTEGER PRIMARY KEY AUTOINCREMENT,
     platform TEXT NOT NULL,

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -274,6 +274,50 @@ CREATE TABLE IF NOT EXISTS wallet_transfers (
     dedup_id TEXT NOT NULL UNIQUE
 );
 
+-- #1100: exchange-sourced equity journal for shared-wallet TOTAL reconciliation.
+-- Where wallet_ledger_state / wallet_transfers feed the per-strategy ATTRIBUTION
+-- split (#954), this journal reconstructs settled-cash deltas from the exchange's
+-- OWN cash-flow events — fills, funding, transfers — so the total drift alarm no
+-- longer depends on internal trade rows being complete and correctly priced.
+-- amount_usd is the SIGNED settled-cash effect:
+--   fill            = closed_pnl_gross - fee_usd  (closed_pnl is GROSS of fees;
+--                     retained for attribution/display, NEVER summed into equity)
+--   funding         = signed funding usdc
+--   <transfer kind> = signedPerpFlowUSD (deposits / withdrawals / transfers / ...)
+-- Shadow-only today: computed beside the trade-ledger drift path and logged for
+-- validation; it does not yet drive any alarm (see reconcileCashflowJournalShadow).
+CREATE TABLE IF NOT EXISTS cashflow_journal (
+    rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+    platform TEXT NOT NULL,
+    account TEXT NOT NULL,
+    time_ms INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    amount_usd REAL NOT NULL,
+    coin TEXT NOT NULL DEFAULT '',
+    closed_pnl_gross REAL NOT NULL DEFAULT 0,
+    fee_usd REAL NOT NULL DEFAULT 0,
+    dedup_id TEXT NOT NULL UNIQUE
+);
+CREATE INDEX IF NOT EXISTS idx_cashflow_journal_account ON cashflow_journal(platform, account);
+
+-- #1100: per-wallet journal cursors + adoption baseline. fills/funding/transfers
+-- watermarks bound the three incremental fetches; baseline_account_value /
+-- baseline_upnl anchor the equity equation at adoption so pre-journal history is
+-- never replayed. incomplete=1 LATCHES when an unmapped event kind is seen so a
+-- future alarm switch can fail closed; baseline_set=0 forces a re-anchor.
+CREATE TABLE IF NOT EXISTS cashflow_journal_state (
+    platform TEXT NOT NULL,
+    account TEXT NOT NULL,
+    fills_since_ms INTEGER NOT NULL DEFAULT 0,
+    funding_since_ms INTEGER NOT NULL DEFAULT 0,
+    transfers_since_ms INTEGER NOT NULL DEFAULT 0,
+    baseline_account_value REAL NOT NULL DEFAULT 0,
+    baseline_upnl REAL NOT NULL DEFAULT 0,
+    baseline_set INTEGER NOT NULL DEFAULT 0,
+    incomplete INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (platform, account)
+);
+
 CREATE TABLE IF NOT EXISTS pending_limit_orders (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     strategy_id TEXT NOT NULL,

--- a/scheduler/hyperliquid_fills.go
+++ b/scheduler/hyperliquid_fills.go
@@ -72,6 +72,12 @@ type hlFillRecord struct {
 	ClosedPnl string      `json:"closedPnl"`
 	Time      int64       `json:"time"`
 	Dir       string      `json:"dir"`
+	// Tid is Hyperliquid's unique per-fill trade id; Hash is the L1 tx hash.
+	// Unused by OID/coin-size reconciler lookups; gives the #1100 cash-flow
+	// journal a stable per-fill dedup identity (one OID can fragment into many
+	// partial fills, so OID alone is not unique).
+	Tid  json.Number `json:"tid"`
+	Hash string      `json:"hash"`
 }
 
 // fetchHyperliquidUserFillsByTime is a function variable so tests can stub the

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1068,6 +1068,23 @@ func main() {
 			// Fire throttled drift alarms outside the lock (notifier I/O).
 			reportSharedWalletDrift(notifier, driftResults)
 
+			// #1100 SHADOW: reconstruct the HL shared wallet's equity from the
+			// exchange's OWN cash-flow events (fills + funding + transfers) via a
+			// durable journal and log it beside the trade-ledger drift for
+			// validation. No alarm or display change — read-beside phase before
+			// the alarm is switched onto the journal. Runs outside the lock:
+			// HTTP fetch + DB-only writes, no StrategyState mutation.
+			if hlShared && hlStateFetched {
+				var hlLedgerDrift *sharedWalletDriftResult
+				for i := range driftResults {
+					if driftResults[i].Key == hlKey {
+						hlLedgerDrift = &driftResults[i]
+						break
+					}
+				}
+				reconcileCashflowJournalShadow(stateDB, hlKey, walletBalances[hlKey], sumHLAccountUPnL(hlPositions), hlLedgerDrift, time.Now().UTC())
+			}
+
 			// #341 / #345 / #346 / #347: Submit market closes to
 			// Hyperliquid, OKX, Robinhood, AND TopStep for every non-zero
 			// on-chain / on-account position belonging to a configured

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -942,9 +942,11 @@ func main() {
 			// when the balance fetch failed — the reconcile skips the wallet
 			// then too, and the watermark keeps the events for next cycle.
 			var walletLedgerFetches []walletLedgerFetchResult
+			var cashflowJournalFetch cashflowJournalFetchResult
 			if hlShared && hlStateFetched {
 				walletLedgerFetches = append(walletLedgerFetches,
 					fetchWalletLedgerEvents(stateDB, hlKey, time.Now().UTC()))
+				cashflowJournalFetch = fetchCashflowJournalEvents(stateDB, hlKey, walletBalances[hlKey], sumHLAccountUPnL(hlPositions), time.Now().UTC())
 			}
 
 			// #360: Fetch OKX positions once if any live OKX perps strategy
@@ -1065,25 +1067,14 @@ func main() {
 			driftResults := reconcileSharedWalletDisplayValues(cfg.Strategies, state, stateDB, sharedWallets, walletBalances, hlPositions, okxPositions, okxStateFetched)
 			mu.Unlock()
 
+			// #1100: book HL cash-flow events and drive the wallet-level drift alarm
+			// from journal equity (per-strategy display stays ledger-attributed).
+			if hlShared && hlStateFetched {
+				applyHyperliquidCashflowJournalDrift(&driftResults, stateDB, cashflowJournalFetch)
+			}
+
 			// Fire throttled drift alarms outside the lock (notifier I/O).
 			reportSharedWalletDrift(notifier, driftResults)
-
-			// #1100 SHADOW: reconstruct the HL shared wallet's equity from the
-			// exchange's OWN cash-flow events (fills + funding + transfers) via a
-			// durable journal and log it beside the trade-ledger drift for
-			// validation. No alarm or display change — read-beside phase before
-			// the alarm is switched onto the journal. Runs outside the lock:
-			// HTTP fetch + DB-only writes, no StrategyState mutation.
-			if hlShared && hlStateFetched {
-				var hlLedgerDrift *sharedWalletDriftResult
-				for i := range driftResults {
-					if driftResults[i].Key == hlKey {
-						hlLedgerDrift = &driftResults[i]
-						break
-					}
-				}
-				reconcileCashflowJournalShadow(stateDB, hlKey, walletBalances[hlKey], sumHLAccountUPnL(hlPositions), hlLedgerDrift, time.Now().UTC())
-			}
 
 			// #341 / #345 / #346 / #347: Submit market closes to
 			// Hyperliquid, OKX, Robinhood, AND TopStep for every non-zero

--- a/scheduler/shared_wallet_drift_alerts.go
+++ b/scheduler/shared_wallet_drift_alerts.go
@@ -283,28 +283,28 @@ func sharedWalletKeyLabel(key SharedWalletKey) string {
 	return fmt.Sprintf("%s/%s", key.Platform, key.Account)
 }
 
-func formatSharedWalletDriftAlert(key SharedWalletKey, balance, memberSum, drift float64, count int, orphanCoins []string) string {
+func formatSharedWalletDriftAlert(key SharedWalletKey, balance, memberSum, drift float64, count int, orphanCoins []string, basis string, expectedEquity, attributionGap float64) string {
 	orphanDetail := "no unattributed coins — check member weighting"
 	if len(orphanCoins) > 0 {
 		orphanDetail = "unattributed coins: " + strings.Join(orphanCoins, ", ")
 	}
-	// The "diff" in the alert is the BASELINE-ANCHORED drift (post-baseline
-	// change since the wallet was first reconciled). The displayed Σ member
-	// value vs balance, however, is the RAW reconciliation — those are the
-	// rows the operator sees. Showing raw diff (memberSum - balance) makes
-	// the alert self-consistent with the numbers above it. A large raw diff
-	// with a small baseline-anchored drift MAY be legacy data adopted into the
-	// baseline at first contact (masked by design — see
-	// wallet_ledger_state.baseline_offset_usd), but can equally be a live
-	// orphan/weighting bug sitting near the offset; the alert flags it for
-	// investigation rather than pre-explaining it.
+	if basis == sharedWalletDriftBasisCashflowJournal {
+		return fmt.Sprintf(
+			"**SHARED-WALLET DRIFT** %s (pid=%d, %d consecutive): journal expected equity $%.2f vs real balance $%.2f — journal drift $%+.2f (>$%.2f tolerance). Attribution gap (Σ members $%.2f vs balance) $%+.2f. %s. Total reconciliation is exchange-sourced (#1100); a non-zero journal drift means a missing/unmapped cash-flow event, not a modeled fee on an internal trade row.",
+			sharedWalletKeyLabel(key), os.Getpid(), count, expectedEquity, balance, drift, sharedWalletDriftTolerance, memberSum, attributionGap, orphanDetail)
+	}
 	rawDiff := memberSum - balance
 	return fmt.Sprintf(
 		"**SHARED-WALLET DRIFT** %s (pid=%d, %d consecutive): Σ member value $%.2f vs real balance $%.2f — raw reconciliation diff $%+.2f, post-baseline drift $%+.2f (>$%.2f tolerance). %s. Exchange-derived rows should reconcile exactly; a large raw diff with a small post-baseline drift may indicate legacy data baked into the adopted baseline OR a live attribution bug (orphan/weighting) near the offset — investigate before assuming it is benign.",
 		sharedWalletKeyLabel(key), os.Getpid(), count, memberSum, balance, rawDiff, drift, sharedWalletDriftTolerance, orphanDetail)
 }
 
-func formatSharedWalletDriftRecovered(key SharedWalletKey, priorCount int) string {
+func formatSharedWalletDriftRecovered(key SharedWalletKey, priorCount int, basis string) string {
+	if basis == sharedWalletDriftBasisCashflowJournal {
+		return fmt.Sprintf(
+			"**SHARED-WALLET DRIFT RESOLVED** %s (pid=%d): journal equity reconciles to the account balance again after %d cycles of drift.",
+			sharedWalletKeyLabel(key), os.Getpid(), priorCount)
+	}
 	return fmt.Sprintf(
 		"**SHARED-WALLET DRIFT RESOLVED** %s (pid=%d): per-strategy values reconcile to the account balance again after %d cycles of drift.",
 		sharedWalletKeyLabel(key), os.Getpid(), priorCount)
@@ -324,14 +324,19 @@ func reportSharedWalletDrift(notifier *MultiNotifier, results []sharedWalletDrif
 		if math.Abs(r.Drift) > sharedWalletDriftTolerance {
 			shouldNotify, shouldLog, count := sharedWalletDriftTracker.Record(label, r.Drift, r.OrphanCoins, now)
 			if shouldLog {
-				rawDiff := r.MemberSum - r.Balance
-				fmt.Printf("[WARN] shared-wallet %s drift $%+.2f (Σ members $%.2f vs balance $%.2f, rawDiff $%+.2f, orphans=[%s])\n",
-					label, r.Drift, r.MemberSum, r.Balance, rawDiff, strings.Join(r.OrphanCoins, ","))
+				if r.DriftBasis == sharedWalletDriftBasisCashflowJournal {
+					fmt.Printf("[WARN] shared-wallet %s journal drift $%+.2f (expected $%.2f vs balance $%.2f, attribution gap $%+.2f, orphans=[%s])\n",
+						label, r.Drift, r.ExpectedEquity, r.Balance, r.AttributionGap, strings.Join(r.OrphanCoins, ","))
+				} else {
+					rawDiff := r.MemberSum - r.Balance
+					fmt.Printf("[WARN] shared-wallet %s drift $%+.2f (Σ members $%.2f vs balance $%.2f, rawDiff $%+.2f, orphans=[%s])\n",
+						label, r.Drift, r.MemberSum, r.Balance, rawDiff, strings.Join(r.OrphanCoins, ","))
+				}
 			}
 			if !shouldNotify || notifier == nil || !notifier.HasBackends() {
 				continue
 			}
-			msg := formatSharedWalletDriftAlert(r.Key, r.Balance, r.MemberSum, r.Drift, count, r.OrphanCoins)
+			msg := formatSharedWalletDriftAlert(r.Key, r.Balance, r.MemberSum, r.Drift, count, r.OrphanCoins, r.DriftBasis, r.ExpectedEquity, r.AttributionGap)
 			notifier.SendToAllChannels(msg)
 			notifier.SendOwnerDM(msg)
 			continue
@@ -340,7 +345,7 @@ func reportSharedWalletDrift(notifier *MultiNotifier, results []sharedWalletDrif
 		if !recovered || notifier == nil || !notifier.HasBackends() {
 			continue
 		}
-		msg := formatSharedWalletDriftRecovered(r.Key, priorCount)
+		msg := formatSharedWalletDriftRecovered(r.Key, priorCount, r.DriftBasis)
 		notifier.SendToAllChannels(msg)
 		notifier.SendOwnerDM(msg)
 	}

--- a/scheduler/shared_wallet_ledger_test.go
+++ b/scheduler/shared_wallet_ledger_test.go
@@ -246,10 +246,16 @@ func TestReconcileSharedWalletDisplayValues_HLLedgerPath(t *testing.T) {
 	// Clean balance = Σvalues + flows = 1050.5 + 100 = 1150.5; start drifted +$5.
 	walletBalances := map[SharedWalletKey]float64{key: 1155.5}
 
-	// Cycle 1: baseline anchors at rawDrift=+5, reported drift 0.
+	// Cycle 1: journal baseline pre-seeded → journal drift 0 (ledger path no longer
+	// auto-anchors wallet_ledger_state.baseline_offset_usd — #1100).
+	seedHLCashflowJournalBaseline(t, db, "0xtest", 1155.5, 12, now.UnixMilli())
 	results := reconcileSharedWalletDisplayValues(strategies, state, db, sharedWallets, walletBalances, hlPositions, nil, false)
+	results = applyHLJournalDriftForTest(t, db, results, key, walletBalances[key], 12)
 	if len(results) != 1 || math.Abs(results[0].Drift) > 0.001 {
-		t.Fatalf("cycle 1: want drift 0 (baseline anchor), got %+v", results)
+		t.Fatalf("cycle 1: want journal drift 0, got %+v", results)
+	}
+	if results[0].DriftBasis != sharedWalletDriftBasisCashflowJournal {
+		t.Fatalf("cycle 1: want journal basis, got %q", results[0].DriftBasis)
 	}
 	if got := state.Strategies["hl-btc"].SharedWalletValue; math.Abs(got-650.5) > 0.001 {
 		t.Errorf("hl-btc display = %v, want 650.5 (initial+ledger+uPnL)", got)
@@ -261,32 +267,63 @@ func TestReconcileSharedWalletDisplayValues_HLLedgerPath(t *testing.T) {
 		t.Error("both members must be gated on")
 	}
 	st, found, err := db.GetWalletLedgerState("hyperliquid", "0xtest")
-	if err != nil || !found || !st.BaselineSet || math.Abs(st.BaselineOffset-5) > 0.001 {
-		t.Fatalf("baseline not stored: found=%v err=%v st=%+v", found, err, st)
+	if err != nil || !found {
+		t.Fatalf("watermark row missing: found=%v err=%v", found, err)
+	}
+	if st.BaselineSet {
+		t.Fatalf("reconcile must not auto-set wallet_ledger baseline (#1100): %+v", st)
 	}
 	if st.FundingSinceMs != now.UnixMilli() || st.TransfersSinceMs != now.UnixMilli() {
 		t.Fatalf("baseline upsert clobbered watermarks: %+v", st)
 	}
 
-	// Cycle 2: balance loses $3 the ledger didn't book → drift -3.
+	// Cycle 2: balance loses $3 the exchange journal did not book → journal drift -3.
 	walletBalances[key] = 1152.5
 	results = reconcileSharedWalletDisplayValues(strategies, state, db, sharedWallets, walletBalances, hlPositions, nil, false)
+	results = applyHLJournalDriftForTest(t, db, results, key, walletBalances[key], 12)
 	if len(results) != 1 || math.Abs(results[0].Drift-(-3)) > 0.001 {
-		t.Fatalf("cycle 2: want drift -3 vs baseline, got %+v", results)
+		t.Fatalf("cycle 2: want journal drift -3, got %+v", results)
 	}
 	// Member values are ledger-derived → unchanged by the balance move.
 	if got := state.Strategies["hl-btc"].SharedWalletValue; math.Abs(got-650.5) > 0.001 {
 		t.Errorf("hl-btc display moved with balance: %v, want 650.5", got)
 	}
 
-	// Baseline reset (backfill --apply) → next cycle re-anchors, drift 0 again.
+	// Baseline reset (backfill --apply) on wallet_ledger no longer affects journal drift.
 	if err := db.ResetWalletLedgerBaseline("hyperliquid", "0xtest"); err != nil {
 		t.Fatalf("ResetWalletLedgerBaseline: %v", err)
 	}
 	results = reconcileSharedWalletDisplayValues(strategies, state, db, sharedWallets, walletBalances, hlPositions, nil, false)
-	if len(results) != 1 || math.Abs(results[0].Drift) > 0.001 {
-		t.Fatalf("post-reset: want drift 0 (re-anchored), got %+v", results)
+	results = applyHLJournalDriftForTest(t, db, results, key, walletBalances[key], 12)
+	if len(results) != 1 || math.Abs(results[0].Drift-(-3)) > 0.001 {
+		t.Fatalf("post-reset: journal drift unchanged at -3, got %+v", results)
 	}
+}
+
+func seedHLCashflowJournalBaseline(t *testing.T, db *StateDB, account string, accountValue, uPnL float64, nowMs int64) {
+	t.Helper()
+	st := CashflowJournalState{
+		FillsSinceMs: nowMs, FundingSinceMs: nowMs, TransfersSinceMs: nowMs,
+		BaselineAccountValue: accountValue, BaselineUPnL: uPnL, BaselineSet: true,
+	}
+	if err := db.UpsertCashflowJournalState("hyperliquid", account, st); err != nil {
+		t.Fatalf("seed cashflow journal: %v", err)
+	}
+}
+
+func applyHLJournalDriftForTest(t *testing.T, db *StateDB, results []sharedWalletDriftResult, key SharedWalletKey, bal, uPnL float64) []sharedWalletDriftResult {
+	t.Helper()
+	st, found, err := db.GetCashflowJournalState(key.Platform, key.Account)
+	if err != nil || !found {
+		t.Fatalf("cashflow journal state: found=%v err=%v", found, err)
+	}
+	fetch := cashflowJournalFetchResult{
+		Key: key, State: st, StateFound: true, PriorStateExists: true,
+		AccountValue: bal, CurrentUPnL: uPnL,
+		FillsFetched: true, FundingFetched: true, TransfersFetched: true,
+	}
+	applyHyperliquidCashflowJournalDrift(&results, db, fetch)
+	return results
 }
 
 // A nil StateDB must fall back to the #918 split (rows stay populated).
@@ -354,23 +391,24 @@ func TestReconcileSharedWalletDisplayValues_HLMissingLedgerStateFallsBack(t *tes
 		t.Fatalf("reconcile originated the watermark row: found=%v err=%v", found, err)
 	}
 
-	// Cycle 2: fetch init succeeded (row anchored at now) → ledger path
-	// baselines the +100 and reports drift 0 with ledger-derived values.
+	// Cycle 2: fetch init succeeded (row present) → ledger-derived member values.
 	if err := db.UpsertWalletLedgerState("hyperliquid", "0xtest", WalletLedgerState{
 		FundingSinceMs: now.UnixMilli(), TransfersSinceMs: now.UnixMilli(),
 	}); err != nil {
 		t.Fatalf("seed ledger state: %v", err)
 	}
+	seedHLCashflowJournalBaseline(t, db, "0xtest", 1100, 0, now.UnixMilli())
 	results = reconcileSharedWalletDisplayValues(strategies, state, db, sharedWallets, walletBalances, nil, nil, false)
+	results = applyHLJournalDriftForTest(t, db, results, key, walletBalances[key], 0)
 	if len(results) != 1 || math.Abs(results[0].Drift) > 0.001 {
-		t.Fatalf("cycle 2: want drift 0 (baseline anchor), got %+v", results)
+		t.Fatalf("cycle 2: want journal drift 0, got %+v", results)
 	}
 	if got := state.Strategies["hl-a"].SharedWalletValue; math.Abs(got-600) > 0.001 {
 		t.Errorf("ledger hl-a = %v, want 600 (initial, no ledger rows)", got)
 	}
 	st, found, err := db.GetWalletLedgerState("hyperliquid", "0xtest")
-	if err != nil || !found || !st.BaselineSet || math.Abs(st.BaselineOffset-100) > 0.001 {
-		t.Fatalf("baseline not anchored after row init: found=%v err=%v st=%+v", found, err, st)
+	if err != nil || !found || st.BaselineSet {
+		t.Fatalf("reconcile must not auto-anchor wallet_ledger baseline: found=%v err=%v st=%+v", found, err, st)
 	}
 	if st.FundingSinceMs != now.UnixMilli() {
 		t.Fatalf("watermark clobbered: %+v", st)

--- a/scheduler/shared_wallet_reconcile.go
+++ b/scheduler/shared_wallet_reconcile.go
@@ -67,6 +67,9 @@ type sharedWalletReconcileResult struct {
 	// unrelated one-cycle transients on consecutive cycles don't read as one
 	// persistent orphan.
 	OrphanCoins []string
+	// LedgerRawDrift is rawDrift before baseline_offset subtraction (#954).
+	// Preserved for HL fail-closed fallback when the #1100 journal is unusable.
+	LedgerRawDrift float64
 }
 
 // reconcileSharedWalletMemberValues splits one shared wallet's real account
@@ -309,7 +312,7 @@ func ledgerSharedWalletMemberValues(in ledgerWalletInputs) (sharedWalletReconcil
 	} else {
 		drift = 0 // first reconciled cycle: caller stores rawDrift as baseline
 	}
-	return sharedWalletReconcileResult{Values: values, Drift: drift, OrphanCoins: orphanCoins}, rawDrift
+	return sharedWalletReconcileResult{Values: values, Drift: drift, OrphanCoins: orphanCoins, LedgerRawDrift: rawDrift}, rawDrift
 }
 
 // roundCents rounds a dollar amount to the nearest cent.
@@ -317,14 +320,26 @@ func roundCents(v float64) float64 {
 	return math.Round(v*100) / 100
 }
 
+// sharedWalletDriftBasis names which reconciliation path drives Drift for alarms.
+const (
+	sharedWalletDriftBasisCapitalSplit    = "capital_split"    // OKX / fallback split
+	sharedWalletDriftBasisLedgerFallback  = "ledger_fallback"  // HL trade-ledger (#954) fail-closed
+	sharedWalletDriftBasisCashflowJournal = "cashflow_journal" // HL exchange journal (#1100)
+)
+
 // sharedWalletDriftResult reports one wallet's reconciliation outcome for the
 // throttled drift alarm.
 type sharedWalletDriftResult struct {
 	Key         SharedWalletKey
-	Drift       float64  // accountBalance - Σ raw member values (orphan/unattributed P&L)
+	Drift       float64  // alarm drift: journal-based on HL when usable, else ledger/split
 	Balance     float64  // the real account balance reconciled against
 	MemberSum   float64  // Σ rounded member display values stored this cycle
 	OrphanCoins []string // sorted unattributed coins — streak signature + alert detail
+	// #1100 HL journal path (zero/empty for OKX and non-journal fallbacks).
+	ExpectedEquity      float64 // journal reconstructed accountValue
+	AttributionGap      float64 // memberSum − balance (display attribution; not the alarm)
+	LedgerFallbackDrift float64 // trade-ledger drift preserved for logs/fail-closed
+	DriftBasis          string  // sharedWalletDriftBasis*
 }
 
 // reconcileSharedWalletDisplayValues recomputes the exchange-authoritative
@@ -357,9 +372,9 @@ type sharedWalletDriftResult struct {
 // reconciled with U=0, which would skew each member's split for one cycle.
 //
 // #954 path split: Hyperliquid wallets derive member values from the local
-// trades ledger (ledgerSharedWalletMemberValues; the wallet balance is a pure
-// drift alarm, anchored by the wallet's stored baseline offset). OKX wallets
-// keep the #918 capital-weight split until the ledger path is extended there.
+// trades ledger (ledgerSharedWalletMemberValues); the wallet-level drift alarm
+// is driven by the #1100 exchange cash-flow journal. OKX wallets keep the #918
+// capital-weight split until the journal path is extended there.
 // sdb supplies the per-member ledger sums + non-trade flows; when it is nil
 // or a ledger read fails, HL wallets fall back to the split path for the
 // cycle (display stays populated, WARN logged) rather than dropping rows.
@@ -444,12 +459,19 @@ func reconcileSharedWalletDisplayValues(
 			ss.SharedWalletValueSet = true
 			memberSum += res.Values[id]
 		}
+		driftBasis := sharedWalletDriftBasisCapitalSplit
+		if key.Platform == "hyperliquid" {
+			driftBasis = sharedWalletDriftBasisLedgerFallback
+		}
 		results = append(results, sharedWalletDriftResult{
-			Key:         key,
-			Drift:       res.Drift,
-			Balance:     bal,
-			MemberSum:   roundCents(memberSum),
-			OrphanCoins: res.OrphanCoins,
+			Key:                 key,
+			Drift:               res.Drift,
+			Balance:             bal,
+			MemberSum:           roundCents(memberSum),
+			OrphanCoins:         res.OrphanCoins,
+			AttributionGap:      roundCents(memberSum - bal),
+			LedgerFallbackDrift: res.Drift,
+			DriftBasis:          driftBasis,
 		})
 	}
 	return results
@@ -581,17 +603,11 @@ func reconcileHLWalletViaLedger(
 		BaselineOffset: st.BaselineOffset,
 		BaselineSet:    st.BaselineSet,
 	})
-	if !st.BaselineSet {
-		st.BaselineOffset = rawDrift
-		st.BaselineSet = true
-		if err := sdb.UpsertWalletLedgerState(key.Platform, key.Account, st); err != nil {
-			fmt.Printf("[WARN] shared-wallet %s: baseline store failed: %v — will recompute next cycle\n",
-				sharedWalletKeyLabel(key), err)
-		} else {
-			fmt.Printf("[shared-wallet] %s: ledger drift baseline set to $%+.2f (balance $%.2f vs ledger-derived $%.2f + flows $%.2f)\n",
-				sharedWalletKeyLabel(key), rawDrift, bal, bal-rawDrift-flows, flows)
-		}
-	}
+	res.LedgerRawDrift = rawDrift
+	// #1100: HL total-reconciliation alarms use the cash-flow journal, not
+	// wallet_ledger_state.baseline_offset_usd. The ledger path still supplies
+	// per-strategy attribution (Values) and a fail-closed fallback drift when
+	// the journal is incomplete or a fetch failed this cycle.
 	return res
 }
 


### PR DESCRIPTION
## Summary

Hyperliquid shared-wallet **total reconciliation** now comes from an exchange-sourced cash-flow journal (#1100), scoped to HL only — OKX/TopStep/RH paths are unchanged.

- **`cashflow_journal` / `cashflow_journal_state`** — incremental HL `userFillsByTime`, `userFunding`, and `userNonFundingLedgerUpdates` with per-stream cursors, dedup, and adoption baseline.
- **Wallet-level drift alarms** use `journal_drift = accountValue − expected_equity` where `expected = baseline + Σ settled deltas + ΔuPnL`. Fill settled delta = `closedPnl − fee` (gross PnL never summed into equity).
- **Per-strategy display** stays on the #954 trade-ledger attribution path (`initial + ledger + owned uPnL`).
- **Fail closed** to trade-ledger fallback drift when the journal is incomplete (unmapped transfer kind) or any stream fetch failed this cycle.
- **Retired** auto-anchoring `wallet_ledger_state.baseline_offset_usd` on HL reconcile (migration-only legacy field; journal baseline replaces steady-state masking).

Closes #1100

## Test plan

- [x] `go test -count=1 .` in `scheduler/` (all tests pass)
- [x] Unit tests: journal math, ingest/dedup, `applyHyperliquidCashflowJournalDrift`, incomplete fail-closed
- [x] Updated `TestReconcileSharedWalletDisplayValues_HLLedgerPath` for journal-driven drift

LLM: Composer | high | Harness: Cursor