### PR TITLE
feat(#1104): switch HL shared-wallet drift alarm onto the cash-flow journal

### DIFF
--- a/scheduler/agent_info.go
+++ b/scheduler/agent_info.go
@@ -87,6 +87,7 @@ var agentInfoEnvVars = []agentEnvVar{
 	{Name: "DISCORD_OWNER_ID", Purpose: "Discord user ID that receives owner-only DMs and mutating commands.", Secret: false},
 	{Name: "GITHUB_TOKEN", Purpose: "GitHub token for the self-updater (fallback to GO_TRADER_GITHUB_TOKEN).", Secret: true},
 	{Name: "GO_TRADER_ALLOW_MISSING_STATE", Purpose: "Set to 1 to allow startup with no existing state DB (CheckStatePresence bypass).", Secret: false},
+	{Name: "GO_TRADER_CASHFLOW_JOURNAL_ALARM", Purpose: "Set to 0/off/false/no to force the legacy trade-ledger drift basis for HL shared wallets instead of the #1100 exchange-sourced cash-flow journal (default on).", Secret: false},
 	{Name: "GO_TRADER_DIRECTIONAL_CERT_PATH", Purpose: "Override path to the regime directional-certification artifact (#1085); default backtest/research/regime_directional_certifications.json.", Secret: false},
 	{Name: "GO_TRADER_GITHUB_TOKEN", Purpose: "GitHub token for the self-updater (preferred over GITHUB_TOKEN).", Secret: true},
 	{Name: "GO_TRADER_SERVICE", Purpose: "systemd unit name used by the updater's restart path.", Secret: false},

--- a/scheduler/cashflow_journal.go
+++ b/scheduler/cashflow_journal.go
@@ -14,6 +14,12 @@ import (
 // string is the legacy trade-ledger basis.
 const driftBasisJournal = "journal"
 
+// journalDriftStreakKeySuffix namespaces the journal-basis drift streak so it is
+// a DISTINCT confirmation series from the trade-ledger basis (#1107): a cycle on
+// (or transiently falling back to) the trade-ledger basis must never reset the
+// journal's 2-cycle confirmation, and vice-versa.
+const journalDriftStreakKeySuffix = ":journal"
+
 // #1100: exchange-sourced equity journal for shared-wallet TOTAL reconciliation.
 //
 // Today the shared-wallet drift alarm reconstructs each account's equity from
@@ -539,13 +545,41 @@ func applyCashflowJournalDriftBasis(results []sharedWalletDriftResult, key Share
 	fmt.Printf("[cashflow-journal] %s: expected_equity $%.2f vs accountValue $%.2f → journal_drift $%+.4f (settled Σ $%+.2f, ΔuPnL $%+.2f); trade-ledger %s; alarm %s\n",
 		sharedWalletKeyLabel(key), rec.ExpectedEquity, rec.AccountValue, rec.Drift, rec.SettledSum, rec.DeltaUPnL, ledgerNote, switchNote)
 
-	if !enabled || !rec.Usable || ledger == nil {
-		return // keep the trade-ledger basis
+	if ledger == nil {
+		return
+	}
+	if !enabled {
+		return // operator opted out → the trade-ledger basis governs (unchanged)
+	}
+	if !rec.Usable {
+		if rec.Incomplete {
+			// A latched unmapped event means a real, unclassified balance movement
+			// may be hiding. Fail closed to the trade-ledger basis (it governs
+			// under the wallet's own streak key) so SOME alarm still runs while the
+			// journal is un-trustworthy; the distinct journal streak key keeps this
+			// from perturbing the journal's confirmation series.
+			return
+		}
+		// Transient: a stream-fetch miss, or the baseline was just anchored this
+		// cycle. The journal is the governing basis but has no reading — mark it
+		// pending so reportSharedWalletDrift PRESERVES the journal streak instead
+		// of resetting the 2-cycle confirmation off the within-tolerance trade-
+		// ledger fallback (#1107). A transient feed miss during a real journal-gap
+		// episode must not delay or suppress the operator alarm.
+		ledger.JournalPending = true
+		return
 	}
 	ledger.Drift = rec.Drift
 	ledger.Basis = driftBasisJournal
 	ledger.ExpectedEquity = rec.ExpectedEquity
-	ledger.OrphanCoins = nil // journal drift is a wallet total, not coin-attributed
+	// OrphanCoins is deliberately PRESERVED (not nil'd): the journal total
+	// reconciles an unowned position to ~0 (its fill AND uPnL both count toward
+	// the exchange accountValue), so the orphan-exposure signal is absent from the
+	// journal total drift. Keeping it lets reportSharedWalletDrift still alarm on
+	// real unmanaged on-chain exposure independent of the (noise-free) total
+	// (#1107 / #1100 review). Pure per-member value mis-attribution with a correct
+	// total and no orphan position is the intentional, non-safety detection loss
+	// of the journal basis (visible in the per-cycle journal-vs-ledger log above).
 }
 
 // sumHLAccountUPnL totals the exchange-reported unrealized PnL across an

--- a/scheduler/cashflow_journal.go
+++ b/scheduler/cashflow_journal.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -510,6 +511,44 @@ func cashflowJournalAlarmEnabled() bool {
 	return true
 }
 
+// cashflowJournalPendingTracker counts CONSECUTIVE cycles a wallet's journal was
+// the governing basis but produced no usable reading (a transient stream-fetch
+// miss or a just-anchored baseline). It bounds how long the drift alarm may stay
+// suppressed: a short transient (≤ sharedWalletDriftAlertThreshold cycles)
+// preserves the journal confirmation streak and stays quiet, but a PERSISTENT
+// outage fails closed to the trade-ledger basis so the money-path safety net
+// never goes dark for the whole duration of a multi-cycle exchange-feed outage
+// (#1107). In-memory; resets on process restart, exactly like
+// sharedWalletDriftTracker.
+type cashflowJournalPendingTracker struct {
+	mu      sync.Mutex
+	streaks map[string]int
+}
+
+// mark records one more consecutive pending cycle for label and returns the new
+// streak length (post-increment).
+func (t *cashflowJournalPendingTracker) mark(label string) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.streaks == nil {
+		t.streaks = make(map[string]int)
+	}
+	t.streaks[label]++
+	return t.streaks[label]
+}
+
+// reset clears label's consecutive-pending streak (the journal produced a
+// reading, latched incomplete, or was operator-disabled this cycle — the outage,
+// if any, is broken).
+func (t *cashflowJournalPendingTracker) reset(label string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.streaks, label)
+}
+
+// cashflowJournalPendingStreaks is the package-level singleton; resets on restart.
+var cashflowJournalPendingStreaks = &cashflowJournalPendingTracker{}
+
 // applyCashflowJournalDriftBasis switches one HL wallet's drift-alarm basis to
 // the exchange-sourced journal when the journal is usable and the operator has
 // not disabled it; otherwise the trade-ledger drift stands (fail closed). It
@@ -526,6 +565,24 @@ func applyCashflowJournalDriftBasis(results []sharedWalletDriftResult, key Share
 			break
 		}
 	}
+
+	// Track CONSECUTIVE transient-pending cycles (journal is the governing basis
+	// but produced no usable reading — a stream-fetch miss or just-anchored
+	// baseline). A short transient stays suppressed (journal streak preserved);
+	// once the streak passes the confirmation window the outage is treated like an
+	// incomplete latch and fails closed to the trade-ledger basis so the alarm
+	// keeps running (#1107). Every other path (usable / incomplete / disabled)
+	// breaks the outage and resets the streak.
+	label := sharedWalletKeyLabel(key)
+	transientPending := enabled && !rec.Incomplete && !rec.Usable
+	pendingStreak := 0
+	if transientPending {
+		pendingStreak = cashflowJournalPendingStreaks.mark(label)
+	} else {
+		cashflowJournalPendingStreaks.reset(label)
+	}
+	suppressPending := transientPending && pendingStreak <= sharedWalletDriftAlertThreshold
+
 	ledgerNote := "n/a"
 	if ledger != nil {
 		// raw diff = balance − Σ member values; Drift is the post-baseline drift.
@@ -537,8 +594,10 @@ func applyCashflowJournalDriftBasis(results []sharedWalletDriftResult, key Share
 		switchNote = "OFF (operator-disabled via GO_TRADER_CASHFLOW_JOURNAL_ALARM)"
 	case rec.Incomplete:
 		switchNote = "OFF (journal incomplete — failing closed to trade-ledger)"
+	case !rec.Usable && suppressPending:
+		switchNote = fmt.Sprintf("PENDING (journal not usable — transient miss %d/%d, journal streak preserved)", pendingStreak, sharedWalletDriftAlertThreshold)
 	case !rec.Usable:
-		switchNote = "OFF (journal not usable this cycle — trade-ledger basis)"
+		switchNote = fmt.Sprintf("OFF (journal not usable for %d cycles — failing closed to trade-ledger)", pendingStreak)
 	default:
 		switchNote = "ON (journal is the drift-alarm basis)"
 	}
@@ -560,13 +619,25 @@ func applyCashflowJournalDriftBasis(results []sharedWalletDriftResult, key Share
 			// from perturbing the journal's confirmation series.
 			return
 		}
-		// Transient: a stream-fetch miss, or the baseline was just anchored this
-		// cycle. The journal is the governing basis but has no reading — mark it
-		// pending so reportSharedWalletDrift PRESERVES the journal streak instead
-		// of resetting the 2-cycle confirmation off the within-tolerance trade-
-		// ledger fallback (#1107). A transient feed miss during a real journal-gap
-		// episode must not delay or suppress the operator alarm.
-		ledger.JournalPending = true
+		if suppressPending {
+			// Transient (within the confirmation window): a stream-fetch miss, or
+			// the baseline was just anchored this cycle. The journal is the
+			// governing basis but has no reading — mark it pending so
+			// reportSharedWalletDrift PRESERVES the journal streak instead of
+			// resetting the 2-cycle confirmation off the within-tolerance trade-
+			// ledger fallback (#1107). A transient feed miss during a real
+			// journal-gap episode must not delay or suppress the operator alarm.
+			ledger.JournalPending = true
+			return
+		}
+		// PERSISTENT outage (pending streak past the confirmation window): the
+		// journal has been unreadable for too many consecutive cycles to keep
+		// trusting it will recover. Fail closed to the trade-ledger basis under the
+		// wallet's own streak key — exactly like the incomplete latch — so a real
+		// trade-ledger drift (or an orphan position) still alarms within a bounded
+		// window instead of staying dark for the whole exchange-feed outage
+		// (#1107). The journal streak (label:journal) is left untouched and resumes
+		// when the journal recovers.
 		return
 	}
 	ledger.Drift = rec.Drift

--- a/scheduler/cashflow_journal.go
+++ b/scheduler/cashflow_journal.go
@@ -3,10 +3,16 @@ package main
 import (
 	"database/sql"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
 )
+
+// driftBasisJournal marks a sharedWalletDriftResult whose alarm drift was
+// switched onto the exchange-sourced cash-flow journal (#1100). The empty
+// string is the legacy trade-ledger basis.
+const driftBasisJournal = "journal"
 
 // #1100: exchange-sourced equity journal for shared-wallet TOTAL reconciliation.
 //
@@ -308,7 +314,15 @@ func fetchCashflowJournalEvents(sdb *StateDB, key SharedWalletKey, accountValue,
 // incomplete latched if an unmapped kind was seen). Every insert path halts its
 // cursor on persistence failure so a watermark never advances past an un-booked
 // event.
-func ingestCashflowJournalEvents(sdb *StateDB, res cashflowJournalFetchResult) CashflowJournalState {
+//
+// cutoffMs bounds ingestion to events settled AT OR BEFORE the accountValue /
+// uPnL snapshot the equity equation reconciles against: an event after the
+// snapshot is NOT booked and the cursor is NOT advanced past it, so it is picked
+// up next cycle once the snapshot includes its balance impact. Without this an
+// in-flight fill (settled on-chain between the balance snapshot and the journal
+// fetch) would be counted in expected-equity but not in accountValue and read as
+// a full cycle of false drift.
+func ingestCashflowJournalEvents(sdb *StateDB, res cashflowJournalFetchResult, cutoffMs int64) CashflowJournalState {
 	st := res.State
 	if sdb == nil || !res.StateFound {
 		return st
@@ -323,6 +337,9 @@ func ingestCashflowJournalEvents(sdb *StateDB, res cashflowJournalFetchResult) C
 		for _, f := range fills {
 			if f.Time < st.FillsSinceMs {
 				continue // cursor-overlap boundary; dedup also covers this
+			}
+			if f.Time > cutoffMs {
+				continue // settled after the balance snapshot — defer to next cycle
 			}
 			coin := strings.ToUpper(strings.TrimSpace(f.Coin))
 			closedPnl := parseHLFloat(f.ClosedPnl)
@@ -361,6 +378,9 @@ func ingestCashflowJournalEvents(sdb *StateDB, res cashflowJournalFetchResult) C
 			if ev.Time < st.FundingSinceMs {
 				continue
 			}
+			if ev.Time > cutoffMs {
+				continue // settled after the balance snapshot — defer to next cycle
+			}
 			// Full funding amount moves the balance regardless of which member
 			// (if any) owns the coin — the journal is the TOTAL, with no
 			// attribution split. Signed: + = balance increased.
@@ -386,6 +406,9 @@ func ingestCashflowJournalEvents(sdb *StateDB, res cashflowJournalFetchResult) C
 		for _, ev := range events {
 			if ev.Time < st.TransfersSinceMs {
 				continue
+			}
+			if ev.Time > cutoffMs {
+				continue // settled after the balance snapshot — defer to next cycle
 			}
 			amount, known := signedPerpFlowUSD(ev.Delta, key.Account)
 			if !known {
@@ -417,45 +440,112 @@ func ingestCashflowJournalEvents(sdb *StateDB, res cashflowJournalFetchResult) C
 	return st
 }
 
-// reconcileCashflowJournalShadow runs the full journal flow for one HL shared
-// wallet OUTSIDE the state lock: fetch the cash-flow events, book them, then log
-// the journal's reconstructed equity beside the live trade-ledger drift for
-// validation. SHADOW MODE — it drives no alarm and mutates no display value.
-// ledgerDrift (may be nil) is the matching trade-ledger drift result this cycle,
-// logged alongside so an operator can compare the two reconciliation bases.
-func reconcileCashflowJournalShadow(sdb *StateDB, key SharedWalletKey, accountValue, currentUPnL float64, ledgerDrift *sharedWalletDriftResult, now time.Time) {
+// cashflowJournalReconcile is one HL wallet's journal-derived total
+// reconciliation for a cycle. Usable=true means the journal may DRIVE the drift
+// alarm this cycle (baseline anchored, all three streams fetched, not
+// incomplete); otherwise the caller fails closed to the trade-ledger drift.
+type cashflowJournalReconcile struct {
+	Key            SharedWalletKey
+	AccountValue   float64
+	ExpectedEquity float64
+	Drift          float64 // accountValue − expectedEquity
+	SettledSum     float64
+	DeltaUPnL      float64
+	Incomplete     bool
+	Usable         bool
+}
+
+// reconcileCashflowJournal runs the full journal flow for one HL shared wallet
+// OUTSIDE the state lock: fetch the cash-flow events (HTTP), book them (DB-only,
+// bounded to the snapshot), and reconstruct the wallet's expected equity. Pure
+// of StrategyState. Returns nil when the wallet is not HL, the state load/init
+// failed, or the baseline was just anchored this cycle — in every such case the
+// caller keeps the trade-ledger drift basis. snapshotAt is the accountValue /
+// uPnL sample time and bounds journal ingestion (see ingestCashflowJournalEvents).
+func reconcileCashflowJournal(sdb *StateDB, key SharedWalletKey, accountValue, currentUPnL float64, snapshotAt time.Time) *cashflowJournalReconcile {
 	if sdb == nil || key.Platform != "hyperliquid" || key.Account == "" {
-		return
+		return nil
 	}
-	res := fetchCashflowJournalEvents(sdb, key, accountValue, currentUPnL, now)
+	res := fetchCashflowJournalEvents(sdb, key, accountValue, currentUPnL, snapshotAt)
 	if !res.StateFound {
-		return // baseline just anchored (logged there) or fetch/load failed
+		return nil // baseline just anchored (logged there) or fetch/load failed
 	}
-	st := ingestCashflowJournalEvents(sdb, res)
+	st := ingestCashflowJournalEvents(sdb, res, snapshotAt.UnixMilli())
+	rec := &cashflowJournalReconcile{Key: key, AccountValue: res.AccountValue, Incomplete: st.Incomplete}
 	if !st.BaselineSet {
-		return // defensive: never compute against an un-anchored baseline
+		return rec // un-anchored: not usable
 	}
 	settled, err := sdb.SumCashflowJournal(key.Platform, key.Account)
 	if err != nil {
 		fmt.Printf("[WARN] cashflow-journal %s: settled-sum read failed: %v\n", sharedWalletKeyLabel(key), err)
+		return rec
+	}
+	rec.SettledSum = settled
+	rec.DeltaUPnL = res.CurrentUPnL - st.BaselineUPnL
+	rec.ExpectedEquity = cashflowJournalExpectedEquity(st.BaselineAccountValue, st.BaselineUPnL, settled, res.CurrentUPnL)
+	rec.Drift = res.AccountValue - rec.ExpectedEquity
+	// Usable only when this cycle's reconstruction is complete: all three streams
+	// fetched (a stream miss leaves its events un-booked → would read as drift)
+	// and no unmapped event has latched the journal incomplete.
+	rec.Usable = res.FillsFetched && res.FundingFetched && res.TransfersFetched && !st.Incomplete
+	return rec
+}
+
+// cashflowJournalAlarmEnabled reports whether the HL drift alarm may switch onto
+// the exchange-sourced journal. Default ON; an operator can force the legacy
+// trade-ledger basis without a redeploy by setting
+// GO_TRADER_CASHFLOW_JOURNAL_ALARM to 0/off/false/no — a safety hatch for this
+// money-path reconciliation switch.
+func cashflowJournalAlarmEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("GO_TRADER_CASHFLOW_JOURNAL_ALARM"))) {
+	case "0", "off", "false", "no":
+		return false
+	}
+	return true
+}
+
+// applyCashflowJournalDriftBasis switches one HL wallet's drift-alarm basis to
+// the exchange-sourced journal when the journal is usable and the operator has
+// not disabled it; otherwise the trade-ledger drift stands (fail closed). It
+// always logs the journal-vs-ledger comparison so operators see both bases every
+// cycle, and mutates results IN PLACE (the matching HL wallet's alarm fields).
+func applyCashflowJournalDriftBasis(results []sharedWalletDriftResult, key SharedWalletKey, rec *cashflowJournalReconcile, enabled bool) {
+	if rec == nil {
 		return
 	}
-	expected := cashflowJournalExpectedEquity(st.BaselineAccountValue, st.BaselineUPnL, settled, res.CurrentUPnL)
-	journalDrift := res.AccountValue - expected
-
-	incompleteNote := ""
-	if st.Incomplete {
-		incompleteNote = " [INCOMPLETE: unmapped event kind seen — would fail closed once promoted]"
+	var ledger *sharedWalletDriftResult
+	for i := range results {
+		if results[i].Key == key {
+			ledger = &results[i]
+			break
+		}
 	}
 	ledgerNote := "n/a"
-	if ledgerDrift != nil {
-		// The trade-ledger result carries the post-baseline Drift and the raw
-		// reconciliation inputs; raw diff = balance − Σ member values.
-		ledgerNote = fmt.Sprintf("raw $%+.2f / post-baseline $%+.2f", ledgerDrift.Balance-ledgerDrift.MemberSum, ledgerDrift.Drift)
+	if ledger != nil {
+		// raw diff = balance − Σ member values; Drift is the post-baseline drift.
+		ledgerNote = fmt.Sprintf("raw $%+.2f / post-baseline $%+.2f", ledger.Balance-ledger.MemberSum, ledger.Drift)
 	}
-	fmt.Printf("[cashflow-journal] %s SHADOW: expected_equity $%.2f vs accountValue $%.2f → journal_drift $%+.4f (settled Σ $%+.2f since baseline $%.2f, ΔuPnL $%+.2f); trade-ledger drift %s%s\n",
-		sharedWalletKeyLabel(key), expected, res.AccountValue, journalDrift,
-		settled, st.BaselineAccountValue, res.CurrentUPnL-st.BaselineUPnL, ledgerNote, incompleteNote)
+	var switchNote string
+	switch {
+	case !enabled:
+		switchNote = "OFF (operator-disabled via GO_TRADER_CASHFLOW_JOURNAL_ALARM)"
+	case rec.Incomplete:
+		switchNote = "OFF (journal incomplete — failing closed to trade-ledger)"
+	case !rec.Usable:
+		switchNote = "OFF (journal not usable this cycle — trade-ledger basis)"
+	default:
+		switchNote = "ON (journal is the drift-alarm basis)"
+	}
+	fmt.Printf("[cashflow-journal] %s: expected_equity $%.2f vs accountValue $%.2f → journal_drift $%+.4f (settled Σ $%+.2f, ΔuPnL $%+.2f); trade-ledger %s; alarm %s\n",
+		sharedWalletKeyLabel(key), rec.ExpectedEquity, rec.AccountValue, rec.Drift, rec.SettledSum, rec.DeltaUPnL, ledgerNote, switchNote)
+
+	if !enabled || !rec.Usable || ledger == nil {
+		return // keep the trade-ledger basis
+	}
+	ledger.Drift = rec.Drift
+	ledger.Basis = driftBasisJournal
+	ledger.ExpectedEquity = rec.ExpectedEquity
+	ledger.OrphanCoins = nil // journal drift is a wallet total, not coin-attributed
 }
 
 // sumHLAccountUPnL totals the exchange-reported unrealized PnL across an

--- a/scheduler/cashflow_journal.go
+++ b/scheduler/cashflow_journal.go
@@ -58,16 +58,19 @@ const journalDriftStreakKeySuffix = ":journal"
 // exactly once here; closed_pnl_gross is retained for attribution and is NEVER
 // summed into equity on its own.
 //
-// SCOPE: Hyperliquid shared wallets, SHADOW MODE. The journal is computed
-// beside the live trade-ledger drift path and the delta is logged for
-// validation. It does NOT yet drive any alarm or member display — that switch,
-// plus OKX/TopStep extension and baseline-offset retirement, are later phases
-// of #1100. Nothing here mutates StrategyState, so the whole flow runs OUTSIDE
-// the state lock (DB writes are serialized by SQLite).
+// SCOPE: Hyperliquid shared wallets. The journal is the LIVE total-drift-alarm
+// basis for HL wallets (applyCashflowJournalDriftBasis): the total drift alarm is
+// driven by the exchange-sourced expected-equity, and both bases are logged every
+// cycle for comparison. The trade-ledger drift is retained as the fail-closed
+// fallback (operator opt-out via GO_TRADER_CASHFLOW_JOURNAL_ALARM, a latched
+// journal-incomplete, or a persistent feed outage) and remains the per-strategy
+// attribution / member-display source. OKX/TopStep extension and baseline-offset
+// retirement are later phases of #1100. Nothing here mutates StrategyState, so the
+// whole flow runs OUTSIDE the state lock (DB writes are serialized by SQLite).
 
 // CashflowJournalState is one wallet's per-stream journal cursors plus the
 // adoption baseline. Incomplete latches true once an unmapped event kind is
-// seen so a future alarm switch can fail closed to the trade-ledger path.
+// seen so the live alarm switch fails closed to the trade-ledger path.
 type CashflowJournalState struct {
 	FillsSinceMs         int64
 	FundingSinceMs       int64

--- a/scheduler/cashflow_journal_test.go
+++ b/scheduler/cashflow_journal_test.go
@@ -445,33 +445,51 @@ func TestApplyCashflowJournalDriftBasis(t *testing.T) {
 	usable := &cashflowJournalReconcile{Key: hlKey, AccountValue: 1000, ExpectedEquity: 1000.0, Drift: 0.0, Usable: true}
 
 	// Enabled + usable -> HL switches to journal drift (0.0), OKX untouched.
+	// #1107: OrphanCoins is PRESERVED (not nil'd) so an unowned position still
+	// alarms even though the journal total reconciles.
 	res := mk()
 	applyCashflowJournalDriftBasis(res, hlKey, usable, true)
-	if res[0].Basis != driftBasisJournal || math.Abs(res[0].Drift) > 1e-9 || res[0].OrphanCoins != nil {
+	if res[0].Basis != driftBasisJournal || math.Abs(res[0].Drift) > 1e-9 {
 		t.Errorf("HL should switch to journal basis: %+v", res[0])
+	}
+	if len(res[0].OrphanCoins) != 1 || res[0].OrphanCoins[0] != "BTC" {
+		t.Errorf("#1107: OrphanCoins must be preserved under the journal basis: %+v", res[0].OrphanCoins)
+	}
+	if res[0].JournalPending {
+		t.Errorf("usable cycle must not be journal-pending: %+v", res[0])
 	}
 	if res[1].Basis != "" || res[1].Drift != 0.05 {
 		t.Errorf("OKX must be untouched: %+v", res[1])
 	}
 
-	// Operator-disabled -> HL stays on trade-ledger drift.
+	// Operator-disabled -> HL stays fully on the trade-ledger drift (not pending).
 	res = mk()
 	applyCashflowJournalDriftBasis(res, hlKey, usable, false)
-	if res[0].Basis != "" || res[0].Drift != 0.40 {
-		t.Errorf("disabled: HL must keep trade-ledger drift: %+v", res[0])
+	if res[0].Basis != "" || res[0].Drift != 0.40 || res[0].JournalPending {
+		t.Errorf("disabled: HL must keep trade-ledger drift, not pending: %+v", res[0])
 	}
 
-	// Not usable -> HL stays on trade-ledger drift even when enabled.
+	// #1107: enabled but TRANSIENTLY not usable (a stream-fetch miss, NOT
+	// incomplete) -> marked JournalPending so reportSharedWalletDrift preserves
+	// the journal streak instead of resetting it off the clean ledger fallback.
+	res = mk()
+	applyCashflowJournalDriftBasis(res, hlKey, &cashflowJournalReconcile{Key: hlKey, Usable: false}, true)
+	if !res[0].JournalPending || res[0].Basis != "" {
+		t.Errorf("transient not-usable must be journal-pending (no basis switch): %+v", res[0])
+	}
+
+	// #1107: enabled but INCOMPLETE (latched unmapped event) -> fail closed to the
+	// trade-ledger basis so SOME alarm runs; NOT pending (the ledger governs).
 	res = mk()
 	applyCashflowJournalDriftBasis(res, hlKey, &cashflowJournalReconcile{Key: hlKey, Usable: false, Incomplete: true}, true)
-	if res[0].Basis != "" || res[0].Drift != 0.40 {
-		t.Errorf("not usable: HL must keep trade-ledger drift: %+v", res[0])
+	if res[0].Basis != "" || res[0].Drift != 0.40 || res[0].JournalPending {
+		t.Errorf("incomplete must fail closed to trade-ledger (not pending): %+v", res[0])
 	}
 
 	// nil rec -> no-op.
 	res = mk()
 	applyCashflowJournalDriftBasis(res, hlKey, nil, true)
-	if res[0].Basis != "" || res[0].Drift != 0.40 {
+	if res[0].Basis != "" || res[0].Drift != 0.40 || res[0].JournalPending {
 		t.Errorf("nil rec must be a no-op: %+v", res[0])
 	}
 }

--- a/scheduler/cashflow_journal_test.go
+++ b/scheduler/cashflow_journal_test.go
@@ -434,6 +434,10 @@ var errTestFetch = errors.New("simulated fetch failure")
 // journal drift ONLY when enabled and usable; it leaves other wallets and the
 // fallback cases on the trade-ledger basis.
 func TestApplyCashflowJournalDriftBasis(t *testing.T) {
+	prevPending := cashflowJournalPendingStreaks
+	cashflowJournalPendingStreaks = &cashflowJournalPendingTracker{}
+	defer func() { cashflowJournalPendingStreaks = prevPending }()
+
 	hlKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
 	okxKey := SharedWalletKey{Platform: "okx", Account: "k"}
 	mk := func() []sharedWalletDriftResult {
@@ -472,11 +476,33 @@ func TestApplyCashflowJournalDriftBasis(t *testing.T) {
 	// #1107: enabled but TRANSIENTLY not usable (a stream-fetch miss, NOT
 	// incomplete) -> marked JournalPending so reportSharedWalletDrift preserves
 	// the journal streak instead of resetting it off the clean ledger fallback.
+	// A short transient (within the confirmation window) stays suppressed; a
+	// PERSISTENT outage past the window must fail closed to the trade-ledger basis.
+	cashflowJournalPendingStreaks.reset(sharedWalletKeyLabel(hlKey))
+	for cycle := 1; cycle <= sharedWalletDriftAlertThreshold; cycle++ {
+		res = mk()
+		applyCashflowJournalDriftBasis(res, hlKey, &cashflowJournalReconcile{Key: hlKey, Usable: false}, true)
+		if !res[0].JournalPending || res[0].Basis != "" {
+			t.Errorf("transient miss cycle %d (within window) must be journal-pending: %+v", cycle, res[0])
+		}
+	}
+	// One cycle past the confirmation window -> the outage is now persistent; fail
+	// closed to the trade-ledger basis (drift 0.40, NOT pending) so the alarm runs.
 	res = mk()
 	applyCashflowJournalDriftBasis(res, hlKey, &cashflowJournalReconcile{Key: hlKey, Usable: false}, true)
-	if !res[0].JournalPending || res[0].Basis != "" {
-		t.Errorf("transient not-usable must be journal-pending (no basis switch): %+v", res[0])
+	if res[0].JournalPending || res[0].Basis != "" || res[0].Drift != 0.40 {
+		t.Errorf("persistent miss must fail closed to trade-ledger (drift 0.40, not pending): %+v", res[0])
 	}
+	// A single usable cycle breaks the outage and resets the streak: a later
+	// transient miss is suppressed again from cycle 1 (no carry-over).
+	res = mk()
+	applyCashflowJournalDriftBasis(res, hlKey, usable, true)
+	res = mk()
+	applyCashflowJournalDriftBasis(res, hlKey, &cashflowJournalReconcile{Key: hlKey, Usable: false}, true)
+	if !res[0].JournalPending {
+		t.Errorf("a usable cycle must reset the pending streak (next miss suppressed again): %+v", res[0])
+	}
+	cashflowJournalPendingStreaks.reset(sharedWalletKeyLabel(hlKey))
 
 	// #1107: enabled but INCOMPLETE (latched unmapped event) -> fail closed to the
 	// trade-ledger basis so SOME alarm runs; NOT pending (the ledger governs).

--- a/scheduler/cashflow_journal_test.go
+++ b/scheduler/cashflow_journal_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"math"
 	"path/filepath"
 	"testing"
@@ -196,11 +197,12 @@ func TestCashflowJournalIngestAndExpectedEquity(t *testing.T) {
 		}, nil
 	}
 
-	res := fetchCashflowJournalEvents(db, key, 1072.2, 5.0, t0.Add(time.Minute))
+	snap := t0.Add(time.Minute)
+	res := fetchCashflowJournalEvents(db, key, 1072.2, 5.0, snap)
 	if !res.FillsFetched || !res.FundingFetched || !res.TransfersFetched {
 		t.Fatalf("expected all three streams fetched: %+v", res)
 	}
-	st := ingestCashflowJournalEvents(db, res)
+	st := ingestCashflowJournalEvents(db, res, snap.UnixMilli())
 	if st.Incomplete {
 		t.Error("all kinds mapped — journal must not be marked incomplete")
 	}
@@ -272,9 +274,9 @@ func TestCashflowJournalIngestIdempotentOnReplay(t *testing.T) {
 			Fills: []hlFillRecord{{Coin: "BTC", Time: 150, Tid: json.Number("7"), ClosedPnl: "10", Fee: "0.2"}},
 		}
 	}
-	st1 := ingestCashflowJournalEvents(db, mkRes(base))
+	st1 := ingestCashflowJournalEvents(db, mkRes(base), cashflowCutoffAll)
 	// Re-fetch returns the same fill (overlap); cursor already advanced past it.
-	st2 := ingestCashflowJournalEvents(db, mkRes(st1))
+	st2 := ingestCashflowJournalEvents(db, mkRes(st1), cashflowCutoffAll)
 	sum, err := db.SumCashflowJournal(key.Platform, key.Account)
 	if err != nil {
 		t.Fatalf("sum: %v", err)
@@ -300,7 +302,7 @@ func TestCashflowJournalUnmappedKindLatchesIncomplete(t *testing.T) {
 			{Time: 150, Hash: "0xq", Delta: hlLedgerEventDelta{Type: "someBrandNewKind"}},
 		},
 	}
-	st := ingestCashflowJournalEvents(db, res)
+	st := ingestCashflowJournalEvents(db, res, cashflowCutoffAll)
 	if !st.Incomplete {
 		t.Fatal("unmapped kind must latch Incomplete")
 	}
@@ -331,9 +333,156 @@ func TestCashflowJournalCursorHaltsOnPersistFailure(t *testing.T) {
 	}
 	// Force every insert to fail by closing the DB first.
 	db.Close()
-	st := ingestCashflowJournalEvents(db, res)
+	st := ingestCashflowJournalEvents(db, res, cashflowCutoffAll)
 	if st.FillsSinceMs != 100 {
 		t.Errorf("cursor advanced past a failed insert: %d, want 100 (held)", st.FillsSinceMs)
+	}
+}
+
+// cashflowCutoffAll is a far-future ingest cutoff for tests that are not
+// exercising the snapshot-boundary deferral.
+const cashflowCutoffAll = int64(1) << 62
+
+// Events settled AFTER the snapshot cutoff are NOT booked and the cursor is NOT
+// advanced past them, so they are picked up next cycle once accountValue
+// includes their impact — preventing an in-flight fill from reading as drift.
+func TestCashflowJournalIngestRespectsCutoff(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	base := CashflowJournalState{FillsSinceMs: 100, BaselineSet: true}
+	res := cashflowJournalFetchResult{
+		Key: key, State: base, StateFound: true, FillsFetched: true,
+		Fills: []hlFillRecord{
+			{Coin: "BTC", Time: 150, Tid: json.Number("1"), ClosedPnl: "10", Fee: "0.2"}, // <= cutoff: booked
+			{Coin: "BTC", Time: 250, Tid: json.Number("2"), ClosedPnl: "30", Fee: "0.5"}, // > cutoff: deferred
+		},
+	}
+	st := ingestCashflowJournalEvents(db, res, 200)
+	sum, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	if math.Abs(sum-9.8) > 1e-9 {
+		t.Errorf("post-cutoff event booked: sum = %v, want 9.8 (only the <=cutoff fill)", sum)
+	}
+	if st.FillsSinceMs != 151 {
+		t.Errorf("cursor advanced past the cutoff: %d, want 151 (one past the booked fill)", st.FillsSinceMs)
+	}
+
+	// Next cycle: same events, cutoff now includes the deferred fill -> it books.
+	res2 := res
+	res2.State = st
+	st2 := ingestCashflowJournalEvents(db, res2, 300)
+	sum2, _ := db.SumCashflowJournal(key.Platform, key.Account)
+	if math.Abs(sum2-(9.8+29.5)) > 1e-9 {
+		t.Errorf("deferred fill not booked next cycle: sum = %v, want 39.3", sum2)
+	}
+	if st2.FillsSinceMs != 251 {
+		t.Errorf("cursor = %d, want 251", st2.FillsSinceMs)
+	}
+}
+
+// reconcileCashflowJournal returns Usable only when the baseline is anchored,
+// all three streams fetched, and the journal is not incomplete; first contact
+// (baseline just set, no fetch) is NOT usable.
+func TestReconcileCashflowJournalUsability(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	t0 := time.UnixMilli(1700000000000).UTC()
+
+	// First contact: baseline anchored, returns rec but NOT usable (drives no alarm).
+	rec := reconcileCashflowJournal(db, key, 1000.0, 0.0, t0)
+	if rec == nil {
+		t.Fatal("first contact should still return a rec (baseline anchored)")
+	}
+	if rec.Usable {
+		t.Error("first contact must not be usable")
+	}
+
+	// Next cycle: stub all three streams empty -> usable, drift ~0 (no movement).
+	origFills := fetchHyperliquidUserFillsByTime
+	origFunding := fetchHyperliquidUserFunding
+	origTransfers := fetchHyperliquidLedgerUpdates
+	defer func() {
+		fetchHyperliquidUserFillsByTime = origFills
+		fetchHyperliquidUserFunding = origFunding
+		fetchHyperliquidLedgerUpdates = origTransfers
+	}()
+	fetchHyperliquidUserFillsByTime = func(string, int64) ([]hlFillRecord, error) { return nil, nil }
+	fetchHyperliquidUserFunding = func(string, int64) ([]hlLedgerEvent, error) { return nil, nil }
+	fetchHyperliquidLedgerUpdates = func(string, int64) ([]hlLedgerEvent, error) { return nil, nil }
+
+	rec2 := reconcileCashflowJournal(db, key, 1000.0, 0.0, t0.Add(time.Minute))
+	if rec2 == nil || !rec2.Usable {
+		t.Fatalf("steady cycle should be usable: %+v", rec2)
+	}
+	if math.Abs(rec2.Drift) > 1e-9 {
+		t.Errorf("no movement should reconcile to ~0 drift, got %v", rec2.Drift)
+	}
+
+	// A funding fetch failure makes the cycle not usable (events missing).
+	fetchHyperliquidUserFunding = func(string, int64) ([]hlLedgerEvent, error) { return nil, errTestFetch }
+	rec3 := reconcileCashflowJournal(db, key, 1000.0, 0.0, t0.Add(2*time.Minute))
+	if rec3 == nil || rec3.Usable {
+		t.Errorf("a stream fetch failure must make the cycle not usable: %+v", rec3)
+	}
+}
+
+var errTestFetch = errors.New("simulated fetch failure")
+
+// applyCashflowJournalDriftBasis overrides the HL wallet's alarm drift with the
+// journal drift ONLY when enabled and usable; it leaves other wallets and the
+// fallback cases on the trade-ledger basis.
+func TestApplyCashflowJournalDriftBasis(t *testing.T) {
+	hlKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	okxKey := SharedWalletKey{Platform: "okx", Account: "k"}
+	mk := func() []sharedWalletDriftResult {
+		return []sharedWalletDriftResult{
+			{Key: hlKey, Drift: 0.40, Balance: 1000, MemberSum: 999.6, OrphanCoins: []string{"BTC"}},
+			{Key: okxKey, Drift: 0.05, Balance: 500, MemberSum: 499.95},
+		}
+	}
+	usable := &cashflowJournalReconcile{Key: hlKey, AccountValue: 1000, ExpectedEquity: 1000.0, Drift: 0.0, Usable: true}
+
+	// Enabled + usable -> HL switches to journal drift (0.0), OKX untouched.
+	res := mk()
+	applyCashflowJournalDriftBasis(res, hlKey, usable, true)
+	if res[0].Basis != driftBasisJournal || math.Abs(res[0].Drift) > 1e-9 || res[0].OrphanCoins != nil {
+		t.Errorf("HL should switch to journal basis: %+v", res[0])
+	}
+	if res[1].Basis != "" || res[1].Drift != 0.05 {
+		t.Errorf("OKX must be untouched: %+v", res[1])
+	}
+
+	// Operator-disabled -> HL stays on trade-ledger drift.
+	res = mk()
+	applyCashflowJournalDriftBasis(res, hlKey, usable, false)
+	if res[0].Basis != "" || res[0].Drift != 0.40 {
+		t.Errorf("disabled: HL must keep trade-ledger drift: %+v", res[0])
+	}
+
+	// Not usable -> HL stays on trade-ledger drift even when enabled.
+	res = mk()
+	applyCashflowJournalDriftBasis(res, hlKey, &cashflowJournalReconcile{Key: hlKey, Usable: false, Incomplete: true}, true)
+	if res[0].Basis != "" || res[0].Drift != 0.40 {
+		t.Errorf("not usable: HL must keep trade-ledger drift: %+v", res[0])
+	}
+
+	// nil rec -> no-op.
+	res = mk()
+	applyCashflowJournalDriftBasis(res, hlKey, nil, true)
+	if res[0].Basis != "" || res[0].Drift != 0.40 {
+		t.Errorf("nil rec must be a no-op: %+v", res[0])
+	}
+}
+
+func TestCashflowJournalAlarmEnabled(t *testing.T) {
+	cases := map[string]bool{"": true, "1": true, "yes": true, "on": true, "0": false, "off": false, "false": false, "no": false, "  OFF  ": false}
+	for v, want := range cases {
+		t.Setenv("GO_TRADER_CASHFLOW_JOURNAL_ALARM", v)
+		if got := cashflowJournalAlarmEnabled(); got != want {
+			t.Errorf("value %q: enabled = %v, want %v", v, got, want)
+		}
 	}
 }
 
@@ -374,7 +523,7 @@ func TestCashflowJournalExcludesSpotFills(t *testing.T) {
 			{Coin: "PURR/USDC", Time: t0 + 25, Tid: json.Number("4"), ClosedPnl: "0", Fee: "-0.1"}, // SPOT maker rebate (negative fee)
 		},
 	}
-	st := ingestCashflowJournalEvents(db, res)
+	st := ingestCashflowJournalEvents(db, res, cashflowCutoffAll)
 
 	// (a)+(c): the perps settled sum is byte-identical to the perps-only sum; the
 	// spot fee does NOT cancel the real perps gain (no masking), and the spot

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -285,8 +285,9 @@ CREATE TABLE IF NOT EXISTS wallet_transfers (
 --                     NEVER summed into equity on its own — #698 / #954 invariant)
 --   funding         = signed funding usdc
 --   <transfer kind> = signedPerpFlowUSD (deposits / withdrawals / transfers / ...)
--- Shadow-only today: computed beside the trade-ledger drift path and logged for
--- validation; it does not yet drive any alarm (see reconcileCashflowJournalShadow).
+-- This is the LIVE total-drift-alarm basis for HL wallets (the drift alarm is
+-- driven by the exchange-sourced expected-equity); the trade-ledger drift path is
+-- retained as the fail-closed fallback and the per-strategy attribution source.
 CREATE TABLE IF NOT EXISTS cashflow_journal (
     rowid INTEGER PRIMARY KEY AUTOINCREMENT,
     platform TEXT NOT NULL,

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -919,6 +919,10 @@ func main() {
 			// walletBalances is declared at cycle scope (above) and populated here.
 			var hlPositions []HLPosition
 			var hlStateFetched bool
+			// hlSnapshotAt stamps when the accountValue/uPnL snapshot below was
+			// taken; the #1100 cash-flow journal bounds its settled-event
+			// ingestion to this instant so an in-flight fill cannot read as drift.
+			var hlSnapshotAt time.Time
 			// Fetch clearinghouseState whenever any live HL strategy exists (#356
 			// per-strategy circuit closes need fresh positions even if no HL
 			// strategy is due this cycle).
@@ -928,6 +932,7 @@ func main() {
 					fmt.Printf("[WARN] hyperliquid clearinghouseState fetch failed: %v — falling back to per-wallet max and skipping position sync this cycle\n", err)
 				} else {
 					hlStateFetched = true
+					hlSnapshotAt = time.Now().UTC()
 					hlPositions = pos
 					if hlShared {
 						walletBalances[hlKey] = bal
@@ -1065,27 +1070,26 @@ func main() {
 			driftResults := reconcileSharedWalletDisplayValues(cfg.Strategies, state, stateDB, sharedWallets, walletBalances, hlPositions, okxPositions, okxStateFetched)
 			mu.Unlock()
 
-			// Fire throttled drift alarms outside the lock (notifier I/O).
-			reportSharedWalletDrift(notifier, driftResults)
-
-			// #1100 SHADOW: reconstruct the HL shared wallet's equity from the
-			// exchange's OWN cash-flow events (fills + funding + transfers) via a
-			// durable journal and log it beside the trade-ledger drift for
-			// validation. No alarm or display change — this is the read-beside
-			// phase before the alarm is switched onto the journal. Runs outside
-			// the lock: HTTP fetch + DB-only writes, no StrategyState mutation.
-			// Reuses the coherent accountValue / position snapshot the reconcile
-			// just consumed (walletBalances[hlKey] + hlPositions).
+			// #1100: switch the HL shared-wallet drift alarm onto the
+			// exchange-sourced cash-flow journal — the wallet TOTAL is
+			// reconstructed from on-chain fills + funding + transfers instead of
+			// the internal trade ledger, so modeled-fee / fallback-price / model-
+			// only-cleanup rows no longer read as drift. Fails closed to the
+			// trade-ledger drift when the journal is not usable (incomplete,
+			// fetch miss, or operator opt-out via GO_TRADER_CASHFLOW_JOURNAL_ALARM).
+			// Runs outside the lock: HTTP fetch + DB-only journal writes, no
+			// StrategyState mutation. Reuses the reconcile's coherent accountValue
+			// / position snapshot (walletBalances[hlKey] + hlPositions @
+			// hlSnapshotAt) and bounds the journal to that snapshot. OKX/TopStep
+			// keep the trade-ledger / capital-weight path untouched.
 			if hlShared && hlStateFetched {
-				var hlLedgerDrift *sharedWalletDriftResult
-				for i := range driftResults {
-					if driftResults[i].Key == hlKey {
-						hlLedgerDrift = &driftResults[i]
-						break
-					}
-				}
-				reconcileCashflowJournalShadow(stateDB, hlKey, walletBalances[hlKey], sumHLAccountUPnL(hlPositions), hlLedgerDrift, time.Now().UTC())
+				rec := reconcileCashflowJournal(stateDB, hlKey, walletBalances[hlKey], sumHLAccountUPnL(hlPositions), hlSnapshotAt)
+				applyCashflowJournalDriftBasis(driftResults, hlKey, rec, cashflowJournalAlarmEnabled())
 			}
+
+			// Fire throttled drift alarms outside the lock (notifier I/O). For HL
+			// this keys off the journal drift when the switch above applied it.
+			reportSharedWalletDrift(notifier, driftResults)
 
 			// #341 / #345 / #346 / #347: Submit market closes to
 			// Hyperliquid, OKX, Robinhood, AND TopStep for every non-zero

--- a/scheduler/shared_wallet_drift_alerts.go
+++ b/scheduler/shared_wallet_drift_alerts.go
@@ -393,7 +393,22 @@ func reportSharedWalletDrift(notifier *MultiNotifier, results []sharedWalletDrif
 		// the orphan's uPnL drift, so this only widens the journal path.
 		orphanExposure := r.Basis == driftBasisJournal && len(r.OrphanCoins) > 0
 		if math.Abs(r.Drift) > sharedWalletDriftTolerance || orphanExposure {
-			shouldNotify, shouldLog, count := sharedWalletDriftTracker.Record(trackerKey, r.Drift, r.OrphanCoins, now)
+			// Confirmation continuity is keyed PER orphan coin (Record): a stable
+			// orphan confirms while a churning transient set is suppressed. Under the
+			// journal basis, though, an over-tolerance TOTAL drift is a journal gap (a
+			// missing/lagging funding/transfer event) that is causally INDEPENDENT of
+			// which positions are momentarily orphaned — keying its continuity on the
+			// orphan coins lets a churning orphan set (BTC→ETH→…) hold maxStreak below
+			// the threshold and mask a real, persistent gap (#1107). Give the gap its
+			// own stable continuity via the "" pseudo-coin ALONGSIDE any orphan coins,
+			// so it confirms on its own persistence while a stable orphan still
+			// confirms on its coin. The trade-ledger basis is untouched: there the
+			// drift IS the orphan's uPnL, so per-coin continuity is correct.
+			recordCoins := r.OrphanCoins
+			if r.Basis == driftBasisJournal && math.Abs(r.Drift) > sharedWalletDriftTolerance {
+				recordCoins = append(append([]string{}, r.OrphanCoins...), "")
+			}
+			shouldNotify, shouldLog, count := sharedWalletDriftTracker.Record(trackerKey, r.Drift, recordCoins, now)
 			if shouldLog {
 				switch {
 				case r.Basis == driftBasisJournal && math.Abs(r.Drift) > sharedWalletDriftTolerance:

--- a/scheduler/shared_wallet_drift_alerts.go
+++ b/scheduler/shared_wallet_drift_alerts.go
@@ -315,6 +315,18 @@ func formatSharedWalletJournalDriftAlert(key SharedWalletKey, balance, expectedE
 		sharedWalletKeyLabel(key), os.Getpid(), count, balance, expectedEquity, drift, sharedWalletDriftTolerance)
 }
 
+// formatSharedWalletJournalOrphanAlert fires under the #1100 journal basis when
+// the exchange total reconciles to the journal (no total-equity drift) BUT one
+// or more on-chain positions are owned by NO strategy. The journal total is
+// account-level and nets an orphan's fill + uPnL to ~0, so the orphan-exposure
+// signal would otherwise be silenced by the basis switch (#1107) — this keeps
+// the real-unmanaged-exposure alarm alive independent of the total drift.
+func formatSharedWalletJournalOrphanAlert(key SharedWalletKey, balance, expectedEquity, drift float64, count int, orphanCoins []string) string {
+	return fmt.Sprintf(
+		"**SHARED-WALLET ORPHAN POSITION** %s (pid=%d, %d consecutive): exchange accountValue $%.2f reconciles to cash-flow-journal expected-equity $%.2f (total drift $%+.2f, within tolerance) BUT %d on-chain position(s) are owned by NO strategy: %s. The exchange total is correct, so this is unmanaged/un-attributed on-chain exposure — NOT a journal gap. Investigate the unowned position(s) before assuming it is benign.",
+		sharedWalletKeyLabel(key), os.Getpid(), count, balance, expectedEquity, drift, len(orphanCoins), strings.Join(orphanCoins, ", "))
+}
+
 func formatSharedWalletDriftRecovered(key SharedWalletKey, priorCount int) string {
 	return fmt.Sprintf(
 		"**SHARED-WALLET DRIFT RESOLVED** %s (pid=%d): per-strategy values reconcile to the account balance again after %d cycles of drift.",
@@ -332,15 +344,41 @@ func reportSharedWalletDrift(notifier *MultiNotifier, results []sharedWalletDrif
 	now := time.Now().UTC()
 	for _, r := range results {
 		label := sharedWalletKeyLabel(r.Key)
-		if math.Abs(r.Drift) > sharedWalletDriftTolerance {
-			shouldNotify, shouldLog, count := sharedWalletDriftTracker.Record(label, r.Drift, r.OrphanCoins, now)
+		// #1107: the journal is the governing basis but produced no reading this
+		// cycle (a transient feed miss / a just-anchored baseline). Treat it as
+		// "no info" and PRESERVE the journal streak rather than resetting it off
+		// the within-tolerance trade-ledger fallback — matching the "absent from
+		// results → streak preserved" rule above. A transient miss during a real
+		// journal-gap episode must not delay or suppress the operator alarm.
+		if r.JournalPending {
+			continue
+		}
+		// The journal basis tracks a DISTINCT confirmation series from the
+		// trade-ledger basis so neither resets the other across basis switches.
+		trackerKey := label
+		if r.Basis == driftBasisJournal {
+			trackerKey += journalDriftStreakKeySuffix
+		}
+		// Under the journal basis the exchange total reconciles an unowned
+		// position to ~0 (its fill AND uPnL both count), so orphan exposure is not
+		// in the total drift — trip on an orphan coin regardless so real unmanaged
+		// exposure still alarms (#1107). The trade-ledger basis already trips via
+		// the orphan's uPnL drift, so this only widens the journal path.
+		orphanExposure := r.Basis == driftBasisJournal && len(r.OrphanCoins) > 0
+		if math.Abs(r.Drift) > sharedWalletDriftTolerance || orphanExposure {
+			shouldNotify, shouldLog, count := sharedWalletDriftTracker.Record(trackerKey, r.Drift, r.OrphanCoins, now)
 			if shouldLog {
-				if r.Basis == driftBasisJournal {
+				switch {
+				case r.Basis == driftBasisJournal && len(r.OrphanCoins) > 0:
+					// Journal total reconciles but a position is unowned (#1107).
+					fmt.Printf("[WARN] shared-wallet %s JOURNAL orphan exposure: total reconciles (drift $%+.2f, accountValue $%.2f vs expected-equity $%.2f) but unowned coins=[%s]\n",
+						label, r.Drift, r.Balance, r.ExpectedEquity, strings.Join(r.OrphanCoins, ","))
+				case r.Basis == driftBasisJournal:
 					// #1100: journal basis — drift is accountValue vs the
 					// exchange-sourced expected-equity, not a member-sum diff.
 					fmt.Printf("[WARN] shared-wallet %s JOURNAL drift $%+.2f (accountValue $%.2f vs exchange-sourced expected-equity $%.2f)\n",
 						label, r.Drift, r.Balance, r.ExpectedEquity)
-				} else {
+				default:
 					rawDiff := r.MemberSum - r.Balance
 					fmt.Printf("[WARN] shared-wallet %s drift $%+.2f (Σ members $%.2f vs balance $%.2f, rawDiff $%+.2f, orphans=[%s])\n",
 						label, r.Drift, r.MemberSum, r.Balance, rawDiff, strings.Join(r.OrphanCoins, ","))
@@ -350,16 +388,19 @@ func reportSharedWalletDrift(notifier *MultiNotifier, results []sharedWalletDrif
 				continue
 			}
 			var msg string
-			if r.Basis == driftBasisJournal {
+			switch {
+			case r.Basis == driftBasisJournal && len(r.OrphanCoins) > 0:
+				msg = formatSharedWalletJournalOrphanAlert(r.Key, r.Balance, r.ExpectedEquity, r.Drift, count, r.OrphanCoins)
+			case r.Basis == driftBasisJournal:
 				msg = formatSharedWalletJournalDriftAlert(r.Key, r.Balance, r.ExpectedEquity, r.Drift, count)
-			} else {
+			default:
 				msg = formatSharedWalletDriftAlert(r.Key, r.Balance, r.MemberSum, r.Drift, count, r.OrphanCoins)
 			}
 			notifier.SendToAllChannels(msg)
 			notifier.SendOwnerDM(msg)
 			continue
 		}
-		recovered, priorCount := sharedWalletDriftTracker.Clear(label)
+		recovered, priorCount := sharedWalletDriftTracker.Clear(trackerKey)
 		if !recovered || notifier == nil || !notifier.HasBackends() {
 			continue
 		}

--- a/scheduler/shared_wallet_drift_alerts.go
+++ b/scheduler/shared_wallet_drift_alerts.go
@@ -309,10 +309,20 @@ func formatSharedWalletDriftAlert(key SharedWalletKey, balance, memberSum, drift
 // (fills/funding/transfers) rather than the internal trade ledger, so a non-zero
 // drift is a journal gap (a missing or lagging exchange event) or an
 // unaccounted balance movement — not an attribution/weighting bug.
-func formatSharedWalletJournalDriftAlert(key SharedWalletKey, balance, expectedEquity, drift float64, count int) string {
+func formatSharedWalletJournalDriftAlert(key SharedWalletKey, balance, expectedEquity, drift float64, count int, orphanCoins []string) string {
+	// An over-tolerance journal drift can co-occur with an unowned position: the
+	// two are separate concerns (a missing/lagging event vs unmanaged exposure),
+	// so when both are present this alert reports the drift truthfully and folds
+	// the orphan in as additional context rather than ever claiming the total is
+	// "within tolerance" (#1107).
+	orphanNote := ""
+	if len(orphanCoins) > 0 {
+		orphanNote = fmt.Sprintf(" Additionally, %d on-chain position(s) are owned by NO strategy (%s) — investigate that unmanaged exposure as a possibly-separate issue alongside the journal gap.",
+			len(orphanCoins), strings.Join(orphanCoins, ", "))
+	}
 	return fmt.Sprintf(
-		"**SHARED-WALLET DRIFT (exchange journal)** %s (pid=%d, %d consecutive): exchange accountValue $%.2f vs cash-flow-journal expected-equity $%.2f — drift $%+.2f (>$%.2f tolerance). The total is reconstructed from on-chain fills/funding/transfers; a persistent drift means a journal gap (missing/lagging exchange event, or an unmapped balance movement), not a strategy-attribution bug — investigate the exchange event feed before assuming it is benign.",
-		sharedWalletKeyLabel(key), os.Getpid(), count, balance, expectedEquity, drift, sharedWalletDriftTolerance)
+		"**SHARED-WALLET DRIFT (exchange journal)** %s (pid=%d, %d consecutive): exchange accountValue $%.2f vs cash-flow-journal expected-equity $%.2f — drift $%+.2f (>$%.2f tolerance). The total is reconstructed from on-chain fills/funding/transfers; a persistent drift means a journal gap (missing/lagging exchange event, or an unmapped balance movement), not a strategy-attribution bug — investigate the exchange event feed before assuming it is benign.%s",
+		sharedWalletKeyLabel(key), os.Getpid(), count, balance, expectedEquity, drift, sharedWalletDriftTolerance, orphanNote)
 }
 
 // formatSharedWalletJournalOrphanAlert fires under the #1100 journal basis when
@@ -369,15 +379,23 @@ func reportSharedWalletDrift(notifier *MultiNotifier, results []sharedWalletDrif
 			shouldNotify, shouldLog, count := sharedWalletDriftTracker.Record(trackerKey, r.Drift, r.OrphanCoins, now)
 			if shouldLog {
 				switch {
-				case r.Basis == driftBasisJournal && len(r.OrphanCoins) > 0:
-					// Journal total reconciles but a position is unowned (#1107).
+				case r.Basis == driftBasisJournal && math.Abs(r.Drift) > sharedWalletDriftTolerance:
+					// #1100: journal basis — drift is accountValue vs the
+					// exchange-sourced expected-equity, not a member-sum diff. An
+					// over-tolerance drift takes precedence over the orphan wording so
+					// the log never claims the total reconciles when it does not
+					// (#1107); any co-occurring orphan is noted as context.
+					orphanNote := ""
+					if len(r.OrphanCoins) > 0 {
+						orphanNote = fmt.Sprintf("; unowned coins=[%s]", strings.Join(r.OrphanCoins, ","))
+					}
+					fmt.Printf("[WARN] shared-wallet %s JOURNAL drift $%+.2f (accountValue $%.2f vs exchange-sourced expected-equity $%.2f)%s\n",
+						label, r.Drift, r.Balance, r.ExpectedEquity, orphanNote)
+				case r.Basis == driftBasisJournal:
+					// Journal total reconciles (within tolerance) but a position is
+					// unowned (#1107) — only reachable with an orphan present.
 					fmt.Printf("[WARN] shared-wallet %s JOURNAL orphan exposure: total reconciles (drift $%+.2f, accountValue $%.2f vs expected-equity $%.2f) but unowned coins=[%s]\n",
 						label, r.Drift, r.Balance, r.ExpectedEquity, strings.Join(r.OrphanCoins, ","))
-				case r.Basis == driftBasisJournal:
-					// #1100: journal basis — drift is accountValue vs the
-					// exchange-sourced expected-equity, not a member-sum diff.
-					fmt.Printf("[WARN] shared-wallet %s JOURNAL drift $%+.2f (accountValue $%.2f vs exchange-sourced expected-equity $%.2f)\n",
-						label, r.Drift, r.Balance, r.ExpectedEquity)
 				default:
 					rawDiff := r.MemberSum - r.Balance
 					fmt.Printf("[WARN] shared-wallet %s drift $%+.2f (Σ members $%.2f vs balance $%.2f, rawDiff $%+.2f, orphans=[%s])\n",
@@ -389,10 +407,16 @@ func reportSharedWalletDrift(notifier *MultiNotifier, results []sharedWalletDrif
 			}
 			var msg string
 			switch {
-			case r.Basis == driftBasisJournal && len(r.OrphanCoins) > 0:
-				msg = formatSharedWalletJournalOrphanAlert(r.Key, r.Balance, r.ExpectedEquity, r.Drift, count, r.OrphanCoins)
+			case r.Basis == driftBasisJournal && math.Abs(r.Drift) > sharedWalletDriftTolerance:
+				// A real over-tolerance journal drift (a gap) — report it truthfully
+				// and fold any co-occurring orphan in as context. NEVER select the
+				// orphan alert (which asserts "within tolerance") when the drift
+				// magnitude exceeds the tolerance (#1107).
+				msg = formatSharedWalletJournalDriftAlert(r.Key, r.Balance, r.ExpectedEquity, r.Drift, count, r.OrphanCoins)
 			case r.Basis == driftBasisJournal:
-				msg = formatSharedWalletJournalDriftAlert(r.Key, r.Balance, r.ExpectedEquity, r.Drift, count)
+				// Total reconciles (within tolerance) but a position is unowned
+				// (#1107) — only reachable with an orphan present.
+				msg = formatSharedWalletJournalOrphanAlert(r.Key, r.Balance, r.ExpectedEquity, r.Drift, count, r.OrphanCoins)
 			default:
 				msg = formatSharedWalletDriftAlert(r.Key, r.Balance, r.MemberSum, r.Drift, count, r.OrphanCoins)
 			}

--- a/scheduler/shared_wallet_drift_alerts.go
+++ b/scheduler/shared_wallet_drift_alerts.go
@@ -368,6 +368,23 @@ func reportSharedWalletDrift(notifier *MultiNotifier, results []sharedWalletDrif
 		trackerKey := label
 		if r.Basis == driftBasisJournal {
 			trackerKey += journalDriftStreakKeySuffix
+			// The journal (authoritative) basis is governing this cycle, so any
+			// trade-ledger fallback episode under the bare label key — left by a
+			// persistent journal-feed outage (#1107 persistent fallback) — is now
+			// OVER: the authoritative basis superseded it. Clear that stale entry so
+			// the basis switch fires its RESOLVED notice and never strands an
+			// already-alerted entry that would skip recovery AND let the NEXT outage
+			// re-alert on its first over-tolerance cycle (bypassing the 2-cycle
+			// confirmation via the e.alerted && sigChanged arm). Directional by
+			// design: the inverse — clearing label:journal from the trade-ledger
+			// basis — is NOT done, because the journal streak is deliberately
+			// preserved across journal unavailability (JournalPending / persistent
+			// outage) and resumes when the journal recovers.
+			if recovered, priorCount := sharedWalletDriftTracker.Clear(label); recovered && notifier != nil && notifier.HasBackends() {
+				msg := formatSharedWalletDriftRecovered(r.Key, priorCount)
+				notifier.SendToAllChannels(msg)
+				notifier.SendOwnerDM(msg)
+			}
 		}
 		// Under the journal basis the exchange total reconciles an unowned
 		// position to ~0 (its fill AND uPnL both count), so orphan exposure is not

--- a/scheduler/shared_wallet_drift_alerts.go
+++ b/scheduler/shared_wallet_drift_alerts.go
@@ -304,6 +304,17 @@ func formatSharedWalletDriftAlert(key SharedWalletKey, balance, memberSum, drift
 		sharedWalletKeyLabel(key), os.Getpid(), count, memberSum, balance, rawDiff, drift, sharedWalletDriftTolerance, orphanDetail)
 }
 
+// formatSharedWalletJournalDriftAlert is the #1100 journal-basis drift alert:
+// the wallet's total is reconstructed from the exchange's own cash-flow events
+// (fills/funding/transfers) rather than the internal trade ledger, so a non-zero
+// drift is a journal gap (a missing or lagging exchange event) or an
+// unaccounted balance movement — not an attribution/weighting bug.
+func formatSharedWalletJournalDriftAlert(key SharedWalletKey, balance, expectedEquity, drift float64, count int) string {
+	return fmt.Sprintf(
+		"**SHARED-WALLET DRIFT (exchange journal)** %s (pid=%d, %d consecutive): exchange accountValue $%.2f vs cash-flow-journal expected-equity $%.2f — drift $%+.2f (>$%.2f tolerance). The total is reconstructed from on-chain fills/funding/transfers; a persistent drift means a journal gap (missing/lagging exchange event, or an unmapped balance movement), not a strategy-attribution bug — investigate the exchange event feed before assuming it is benign.",
+		sharedWalletKeyLabel(key), os.Getpid(), count, balance, expectedEquity, drift, sharedWalletDriftTolerance)
+}
+
 func formatSharedWalletDriftRecovered(key SharedWalletKey, priorCount int) string {
 	return fmt.Sprintf(
 		"**SHARED-WALLET DRIFT RESOLVED** %s (pid=%d): per-strategy values reconcile to the account balance again after %d cycles of drift.",
@@ -324,14 +335,26 @@ func reportSharedWalletDrift(notifier *MultiNotifier, results []sharedWalletDrif
 		if math.Abs(r.Drift) > sharedWalletDriftTolerance {
 			shouldNotify, shouldLog, count := sharedWalletDriftTracker.Record(label, r.Drift, r.OrphanCoins, now)
 			if shouldLog {
-				rawDiff := r.MemberSum - r.Balance
-				fmt.Printf("[WARN] shared-wallet %s drift $%+.2f (Σ members $%.2f vs balance $%.2f, rawDiff $%+.2f, orphans=[%s])\n",
-					label, r.Drift, r.MemberSum, r.Balance, rawDiff, strings.Join(r.OrphanCoins, ","))
+				if r.Basis == driftBasisJournal {
+					// #1100: journal basis — drift is accountValue vs the
+					// exchange-sourced expected-equity, not a member-sum diff.
+					fmt.Printf("[WARN] shared-wallet %s JOURNAL drift $%+.2f (accountValue $%.2f vs exchange-sourced expected-equity $%.2f)\n",
+						label, r.Drift, r.Balance, r.ExpectedEquity)
+				} else {
+					rawDiff := r.MemberSum - r.Balance
+					fmt.Printf("[WARN] shared-wallet %s drift $%+.2f (Σ members $%.2f vs balance $%.2f, rawDiff $%+.2f, orphans=[%s])\n",
+						label, r.Drift, r.MemberSum, r.Balance, rawDiff, strings.Join(r.OrphanCoins, ","))
+				}
 			}
 			if !shouldNotify || notifier == nil || !notifier.HasBackends() {
 				continue
 			}
-			msg := formatSharedWalletDriftAlert(r.Key, r.Balance, r.MemberSum, r.Drift, count, r.OrphanCoins)
+			var msg string
+			if r.Basis == driftBasisJournal {
+				msg = formatSharedWalletJournalDriftAlert(r.Key, r.Balance, r.ExpectedEquity, r.Drift, count)
+			} else {
+				msg = formatSharedWalletDriftAlert(r.Key, r.Balance, r.MemberSum, r.Drift, count, r.OrphanCoins)
+			}
 			notifier.SendToAllChannels(msg)
 			notifier.SendOwnerDM(msg)
 			continue

--- a/scheduler/shared_wallet_reconcile.go
+++ b/scheduler/shared_wallet_reconcile.go
@@ -324,13 +324,19 @@ type sharedWalletDriftResult struct {
 	Drift       float64  // alarm drift: trade-ledger post-baseline drift, OR the journal drift when Basis==journal (#1100)
 	Balance     float64  // the real account balance (accountValue) reconciled against
 	MemberSum   float64  // Σ rounded member display values stored this cycle (attribution; always trade-ledger)
-	OrphanCoins []string // sorted unattributed coins — streak signature + alert detail (nil under journal basis)
+	OrphanCoins []string // sorted unattributed coins — streak signature + alert detail (PRESERVED under the journal basis as the noise-free orphan-exposure signal, #1107)
 	// Basis is "" (trade-ledger) or driftBasisJournal when applyCashflowJournalDriftBasis
 	// switched Drift onto the exchange-sourced cash-flow journal (#1100).
 	Basis string
 	// ExpectedEquity is the journal's reconstructed accountValue; only meaningful
 	// when Basis==driftBasisJournal (Drift == Balance − ExpectedEquity).
 	ExpectedEquity float64
+	// JournalPending is set when the journal is the governing basis (operator-
+	// enabled) but produced no trustworthy total this cycle — a transient stream-
+	// fetch miss or a just-anchored baseline. reportSharedWalletDrift treats it as
+	// "no info" and PRESERVES the journal streak instead of resetting the 2-cycle
+	// confirmation off the within-tolerance trade-ledger fallback (#1107).
+	JournalPending bool
 }
 
 // reconcileSharedWalletDisplayValues recomputes the exchange-authoritative

--- a/scheduler/shared_wallet_reconcile.go
+++ b/scheduler/shared_wallet_reconcile.go
@@ -321,10 +321,16 @@ func roundCents(v float64) float64 {
 // throttled drift alarm.
 type sharedWalletDriftResult struct {
 	Key         SharedWalletKey
-	Drift       float64  // accountBalance - Σ raw member values (orphan/unattributed P&L)
-	Balance     float64  // the real account balance reconciled against
-	MemberSum   float64  // Σ rounded member display values stored this cycle
-	OrphanCoins []string // sorted unattributed coins — streak signature + alert detail
+	Drift       float64  // alarm drift: trade-ledger post-baseline drift, OR the journal drift when Basis==journal (#1100)
+	Balance     float64  // the real account balance (accountValue) reconciled against
+	MemberSum   float64  // Σ rounded member display values stored this cycle (attribution; always trade-ledger)
+	OrphanCoins []string // sorted unattributed coins — streak signature + alert detail (nil under journal basis)
+	// Basis is "" (trade-ledger) or driftBasisJournal when applyCashflowJournalDriftBasis
+	// switched Drift onto the exchange-sourced cash-flow journal (#1100).
+	Basis string
+	// ExpectedEquity is the journal's reconstructed accountValue; only meaningful
+	// when Basis==driftBasisJournal (Drift == Balance − ExpectedEquity).
+	ExpectedEquity float64
 }
 
 // reconcileSharedWalletDisplayValues recomputes the exchange-authoritative

--- a/scheduler/shared_wallet_reconcile_cycle_test.go
+++ b/scheduler/shared_wallet_reconcile_cycle_test.go
@@ -718,3 +718,127 @@ func TestFormatSharedWalletJournalOrphanAlert(t *testing.T) {
 		}
 	}
 }
+
+// #1107 (Needs Fixing): a PERSISTENT journal feed outage must not suppress the
+// money-path drift alarm indefinitely. A short transient stays suppressed
+// (journal streak preserved), but once the consecutive-pending streak passes the
+// confirmation window, applyCashflowJournalDriftBasis fails closed to the
+// trade-ledger basis — exactly like the incomplete latch — so a real drift still
+// confirms and alarms within a bounded window during the outage.
+func TestCashflowJournalPersistentPendingFallsBackToLedgerAlarm(t *testing.T) {
+	prevTracker := sharedWalletDriftTracker
+	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
+	defer func() { sharedWalletDriftTracker = prevTracker }()
+	prevPending := cashflowJournalPendingStreaks
+	cashflowJournalPendingStreaks = &cashflowJournalPendingTracker{}
+	defer func() { cashflowJournalPendingStreaks = prevPending }()
+
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	label := sharedWalletKeyLabel(key)
+	jkey := label + journalDriftStreakKeySuffix
+	// A real, persistent trade-ledger drift sits under the wallet the entire time.
+	mk := func() []sharedWalletDriftResult {
+		return []sharedWalletDriftResult{
+			{Key: key, Drift: 5.00, Balance: 1000, MemberSum: 1005, OrphanCoins: []string{"BTC"}},
+		}
+	}
+	notUsable := &cashflowJournalReconcile{Key: key, Usable: false}
+
+	// Transient window: each miss is suppressed (JournalPending) — nothing is
+	// recorded under any streak key, so the alarm stays quiet (and the journal
+	// streak is preserved for a journal-gap episode).
+	for cycle := 1; cycle <= sharedWalletDriftAlertThreshold; cycle++ {
+		res := mk()
+		applyCashflowJournalDriftBasis(res, key, notUsable, true)
+		if !res[0].JournalPending {
+			t.Fatalf("cycle %d within the window must stay pending: %+v", cycle, res[0])
+		}
+		reportSharedWalletDrift(nil, res)
+		if sharedWalletDriftTracker.entries[label] != nil {
+			t.Fatalf("a suppressed transient cycle must not touch the trade-ledger streak (cycle %d)", cycle)
+		}
+	}
+
+	// First persistent cycle (past the window): fail closed to the trade-ledger
+	// basis → Records the real drift under the bare label key (count 1, no alert).
+	res := mk()
+	applyCashflowJournalDriftBasis(res, key, notUsable, true)
+	if res[0].JournalPending || res[0].Basis != "" || res[0].Drift != 5.00 {
+		t.Fatalf("first persistent cycle must fall back to the trade-ledger drift: %+v", res[0])
+	}
+	reportSharedWalletDrift(nil, res)
+	if e := sharedWalletDriftTracker.entries[label]; e == nil || e.cycles != 1 {
+		t.Fatalf("persistent fallback must Record the trade-ledger drift under the bare key: %+v", e)
+	}
+
+	// Second persistent cycle: the trade-ledger streak confirms within the
+	// 2-cycle window → the alarm fires despite the ongoing journal outage. The
+	// alarm is bounded, not dark for the outage's duration.
+	res = mk()
+	applyCashflowJournalDriftBasis(res, key, notUsable, true)
+	reportSharedWalletDrift(nil, res)
+	if e := sharedWalletDriftTracker.entries[label]; e == nil || e.cycles != 2 || !e.alerted {
+		t.Fatalf("trade-ledger alarm must confirm within a bounded window during a persistent outage: %+v", e)
+	}
+	if sharedWalletDriftTracker.entries[jkey] != nil {
+		t.Error("the trade-ledger fallback must not touch the journal streak key")
+	}
+}
+
+// #1107 (Optional): when the journal basis carries BOTH an over-tolerance total
+// drift AND an unowned position, reportSharedWalletDrift must emit the
+// journal-DRIFT alert (reporting the real drift) and must NEVER select the orphan
+// alert, whose wording asserts the total is "within tolerance". The orphan is
+// folded in as context.
+func TestReportSharedWalletDrift_CompoundOrphanAndDriftReportsDrift(t *testing.T) {
+	prev := sharedWalletDriftTracker
+	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
+	defer func() { sharedWalletDriftTracker = prev }()
+
+	mock := &mockNotifier{}
+	notifier := NewMultiNotifier(notifierBackend{
+		notifier: mock,
+		channels: map[string]string{"hyperliquid": "chan"},
+		ownerID:  "owner",
+	})
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	compound := func() []sharedWalletDriftResult {
+		return []sharedWalletDriftResult{
+			{Key: key, Drift: 5.00, Balance: 1000, ExpectedEquity: 995, Basis: driftBasisJournal, OrphanCoins: []string{"BTC"}},
+		}
+	}
+	// Two consecutive cycles confirm and fire the alert on the second.
+	reportSharedWalletDrift(notifier, compound())
+	reportSharedWalletDrift(notifier, compound())
+	if len(mock.dms) == 0 {
+		t.Fatal("compound over-tolerance drift + orphan must alarm after confirmation")
+	}
+	msg := mock.dms[len(mock.dms)-1].content
+	if strings.Contains(msg, "within tolerance") {
+		t.Errorf("compound state must NOT claim the total is within tolerance: %s", msg)
+	}
+	for _, want := range []string{"DRIFT (exchange journal)", "BTC", "NO strategy"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("compound drift alert missing %q: %s", want, msg)
+		}
+	}
+}
+
+// #1107 (Optional): the journal-drift alert formatter folds an orphan in as
+// context when present and omits the clause otherwise — and never claims "within
+// tolerance" (it is the over-tolerance alert).
+func TestFormatSharedWalletJournalDriftAlert_OrphanContext(t *testing.T) {
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	with := formatSharedWalletJournalDriftAlert(key, 1000, 995, 5.00, 2, []string{"BTC"})
+	if strings.Contains(with, "within tolerance") {
+		t.Errorf("over-tolerance drift alert must never claim within tolerance: %s", with)
+	}
+	for _, want := range []string{"DRIFT (exchange journal)", "BTC", "NO strategy"} {
+		if !strings.Contains(with, want) {
+			t.Errorf("drift alert with orphan missing %q: %s", want, with)
+		}
+	}
+	if without := formatSharedWalletJournalDriftAlert(key, 1000, 995, 5.00, 2, nil); strings.Contains(without, "NO strategy") {
+		t.Errorf("no-orphan drift alert must not mention orphans: %s", without)
+	}
+}

--- a/scheduler/shared_wallet_reconcile_cycle_test.go
+++ b/scheduler/shared_wallet_reconcile_cycle_test.go
@@ -824,6 +824,103 @@ func TestReportSharedWalletDrift_CompoundOrphanAndDriftReportsDrift(t *testing.T
 	}
 }
 
+// #1107 (Optional): a basis switch must not strand a stale trade-ledger tracker
+// entry. After a persistent journal outage alarms under the bare label key, a
+// return to the journal basis must clear that entry (firing its RESOLVED notice),
+// so the operator's alert resolves AND a LATER outage still requires the full
+// 2-cycle confirmation rather than re-firing off the stale alerted entry.
+func TestReportSharedWalletDrift_BasisSwitchClearsStaleTradeLedgerEntry(t *testing.T) {
+	prev := sharedWalletDriftTracker
+	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
+	defer func() { sharedWalletDriftTracker = prev }()
+
+	mock := &mockNotifier{}
+	notifier := NewMultiNotifier(notifierBackend{
+		notifier: mock,
+		channels: map[string]string{"hyperliquid": "chan"},
+		ownerID:  "owner",
+	})
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	label := sharedWalletKeyLabel(key)
+	jkey := label + journalDriftStreakKeySuffix
+
+	// Trade-ledger basis (Basis == "") — the persistent-outage fallback path.
+	ledgerDrift := func(d float64) []sharedWalletDriftResult {
+		return []sharedWalletDriftResult{{Key: key, Drift: d, Balance: 1000, MemberSum: 1000 + d}}
+	}
+	// Journal basis, within tolerance — the authoritative basis governing cleanly.
+	journalClean := func() []sharedWalletDriftResult {
+		return []sharedWalletDriftResult{{Key: key, Drift: 0.0, Balance: 1000, ExpectedEquity: 1000, Basis: driftBasisJournal}}
+	}
+
+	// Persistent outage on the trade-ledger basis: confirm + alert under `label`.
+	reportSharedWalletDrift(notifier, ledgerDrift(5.00))
+	reportSharedWalletDrift(notifier, ledgerDrift(5.00))
+	if e := sharedWalletDriftTracker.entries[label]; e == nil || !e.alerted {
+		t.Fatalf("trade-ledger outage must alert under the bare label key: %+v", e)
+	}
+	mock.dms = nil // drop the alert DMs; the RESOLVED notice is what we assert next
+
+	// (a) Journal recovers clean → the stale `label` entry is cleared and a
+	// RESOLVED notice fires; the bare-label entry is gone.
+	reportSharedWalletDrift(notifier, journalClean())
+	if sharedWalletDriftTracker.entries[label] != nil {
+		t.Error("a return to the journal basis must clear the stale trade-ledger entry")
+	}
+	if len(mock.dms) == 0 || !strings.Contains(mock.dms[len(mock.dms)-1].content, "RESOLVED") {
+		t.Errorf("a stranded trade-ledger alert must fire a RESOLVED notice on recovery: %+v", mock.dms)
+	}
+
+	// (b) A SECOND outage (materially different drift, so a stale alerted entry
+	// would re-fire on cycle 1 via the e.alerted && sigChanged arm) must instead
+	// require the full 2-cycle confirmation — proving the stale entry was cleared.
+	mock.dms = nil
+	reportSharedWalletDrift(notifier, ledgerDrift(10.00))
+	if e := sharedWalletDriftTracker.entries[label]; e == nil || e.cycles != 1 || e.alerted {
+		t.Fatalf("second outage cycle 1 must start fresh (count 1, not alerted): %+v", e)
+	}
+	if len(mock.dms) != 0 {
+		t.Errorf("second outage must NOT alert on its first cycle (no early fire off a stale entry): %+v", mock.dms)
+	}
+	reportSharedWalletDrift(notifier, ledgerDrift(10.00))
+	if e := sharedWalletDriftTracker.entries[label]; e == nil || !e.alerted {
+		t.Fatalf("second outage must alert only after the 2-cycle confirmation: %+v", e)
+	}
+
+	// (c) sanity: the journal streak key was never touched by the trade-ledger path.
+	if sharedWalletDriftTracker.entries[jkey] != nil {
+		t.Error("the trade-ledger path must never create the journal streak key")
+	}
+}
+
+// #1107 (Optional): the directional clear must NOT touch the journal streak from
+// the trade-ledger basis — the journal streak is deliberately preserved across
+// journal unavailability and resumes on recovery (inverse of the stranding fix).
+func TestReportSharedWalletDrift_TradeLedgerBasisPreservesJournalStreak(t *testing.T) {
+	prev := sharedWalletDriftTracker
+	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
+	defer func() { sharedWalletDriftTracker = prev }()
+
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	jkey := sharedWalletKeyLabel(key) + journalDriftStreakKeySuffix
+
+	// A journal-basis episode confirms (count 1).
+	reportSharedWalletDrift(nil, []sharedWalletDriftResult{
+		{Key: key, Drift: 5.00, Balance: 1000, ExpectedEquity: 995, Basis: driftBasisJournal},
+	})
+	if e := sharedWalletDriftTracker.entries[jkey]; e == nil || e.cycles != 1 {
+		t.Fatalf("journal episode should record under the journal key: %+v", e)
+	}
+	// A within-tolerance trade-ledger cycle (persistent-outage fallback that
+	// happens to be clean) must NOT clear the journal streak.
+	reportSharedWalletDrift(nil, []sharedWalletDriftResult{
+		{Key: key, Drift: 0.0, Balance: 1000, MemberSum: 1000},
+	})
+	if e := sharedWalletDriftTracker.entries[jkey]; e == nil || e.cycles != 1 {
+		t.Fatalf("trade-ledger basis must preserve the journal streak (not clear it): %+v", e)
+	}
+}
+
 // #1107 (Optional): the journal-drift alert formatter folds an orphan in as
 // context when present and omits the clause otherwise — and never claims "within
 // tolerance" (it is the over-tolerance alert).

--- a/scheduler/shared_wallet_reconcile_cycle_test.go
+++ b/scheduler/shared_wallet_reconcile_cycle_test.go
@@ -824,6 +824,83 @@ func TestReportSharedWalletDrift_CompoundOrphanAndDriftReportsDrift(t *testing.T
 	}
 }
 
+// #1107 (Optional): under the journal basis, a persistent over-tolerance TOTAL
+// drift (a journal gap) must confirm on its OWN continuity, independent of which
+// positions are momentarily orphaned. A churning transient-orphan set must not
+// hold the gap's confirmation streak below the threshold and mask the alarm; a
+// persistent gap with NO orphans must still confirm (no regression).
+func TestReportSharedWalletDrift_JournalGapConfirmsDespiteOrphanChurn(t *testing.T) {
+	prev := sharedWalletDriftTracker
+	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
+	defer func() { sharedWalletDriftTracker = prev }()
+
+	mock := &mockNotifier{}
+	notifier := NewMultiNotifier(notifierBackend{
+		notifier: mock,
+		channels: map[string]string{"hyperliquid": "chan"},
+		ownerID:  "owner",
+	})
+
+	// (a) Churning orphans: a DIFFERENT orphan coin each cycle while the total
+	// drift stays over tolerance → confirms within the 2-cycle window via the
+	// gap's own pseudo-coin continuity.
+	churnKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xchurn"}
+	churnJKey := sharedWalletKeyLabel(churnKey) + journalDriftStreakKeySuffix
+	gap := func(orphan string) []sharedWalletDriftResult {
+		return []sharedWalletDriftResult{
+			{Key: churnKey, Drift: 5.00, Balance: 1000, ExpectedEquity: 995, Basis: driftBasisJournal, OrphanCoins: []string{orphan}},
+		}
+	}
+	reportSharedWalletDrift(notifier, gap("BTC"))
+	if len(mock.dms) != 0 {
+		t.Fatalf("cycle 1 must not confirm yet: %+v", mock.dms)
+	}
+	reportSharedWalletDrift(notifier, gap("ETH"))
+	if e := sharedWalletDriftTracker.entries[churnJKey]; e == nil || !e.alerted {
+		t.Fatalf("a persistent journal gap must confirm despite orphan churn: %+v", e)
+	}
+	if len(mock.dms) == 0 || !strings.Contains(mock.dms[len(mock.dms)-1].content, "DRIFT (exchange journal)") {
+		t.Errorf("the journal-gap alarm must fire on confirmation: %+v", mock.dms)
+	}
+
+	// (b) No orphans: a persistent over-tolerance drift still confirms via the
+	// pseudo-coin — unchanged by the fix.
+	mock.dms = nil
+	noOrphanKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xclean"}
+	noOrphanJKey := sharedWalletKeyLabel(noOrphanKey) + journalDriftStreakKeySuffix
+	clean := []sharedWalletDriftResult{{Key: noOrphanKey, Drift: 5.00, Balance: 1000, ExpectedEquity: 995, Basis: driftBasisJournal}}
+	reportSharedWalletDrift(notifier, clean)
+	reportSharedWalletDrift(notifier, clean)
+	if e := sharedWalletDriftTracker.entries[noOrphanJKey]; e == nil || !e.alerted {
+		t.Fatalf("a no-orphan persistent journal gap must still confirm: %+v", e)
+	}
+}
+
+// #1107 (Optional): the inverse — a SINGLE-cycle over-tolerance blip with churning
+// orphans must still NOT confirm (the pseudo-coin key must not introduce a new
+// false alarm).
+func TestReportSharedWalletDrift_JournalGapBlipDoesNotConfirm(t *testing.T) {
+	prev := sharedWalletDriftTracker
+	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
+	defer func() { sharedWalletDriftTracker = prev }()
+
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	jkey := sharedWalletKeyLabel(key) + journalDriftStreakKeySuffix
+
+	// Cycle 1: over-tolerance drift + orphan BTC.
+	reportSharedWalletDrift(nil, []sharedWalletDriftResult{
+		{Key: key, Drift: 5.00, Balance: 1000, ExpectedEquity: 995, Basis: driftBasisJournal, OrphanCoins: []string{"BTC"}},
+	})
+	// Cycle 2: drift back within tolerance, a DIFFERENT orphan (orphan-only trip):
+	// the blip's pseudo-coin drops out, so nothing confirms.
+	reportSharedWalletDrift(nil, []sharedWalletDriftResult{
+		{Key: key, Drift: 0.0, Balance: 1000, ExpectedEquity: 1000, Basis: driftBasisJournal, OrphanCoins: []string{"ETH"}},
+	})
+	if e := sharedWalletDriftTracker.entries[jkey]; e != nil && e.alerted {
+		t.Fatalf("a single-cycle total-drift blip with churning orphans must NOT confirm: %+v", e)
+	}
+}
+
 // #1107 (Optional): a basis switch must not strand a stale trade-ledger tracker
 // entry. After a persistent journal outage alarms under the bare label key, a
 // return to the journal basis must clear that entry (firing its RESOLVED notice),

--- a/scheduler/shared_wallet_reconcile_cycle_test.go
+++ b/scheduler/shared_wallet_reconcile_cycle_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -626,5 +627,94 @@ func TestSharedWalletDriftTracker_StableDriftRealertsHourlyNotEveryTenth(t *test
 	// Past one hour since the last notification → the hourly back-off re-alerts.
 	if notify, _, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, base.Add(time.Hour+time.Second)); !notify {
 		t.Fatal("stable drift must re-alert once the hourly back-off elapses")
+	}
+}
+
+// #1107 (Optional #1): a transient not-usable journal cycle (JournalPending)
+// must PRESERVE the journal streak — never reset the 2-cycle confirmation off
+// the within-tolerance trade-ledger fallback — and the journal basis must track
+// a DISTINCT streak key from the trade-ledger basis so neither resets the other.
+func TestReportSharedWalletDrift_JournalStreakPreservedOnPending(t *testing.T) {
+	prev := sharedWalletDriftTracker
+	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
+	defer func() { sharedWalletDriftTracker = prev }()
+
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	jkey := sharedWalletKeyLabel(key) + journalDriftStreakKeySuffix
+
+	// Cycle 1: journal basis, total drift over tolerance -> recorded under the
+	// DISTINCT journal key, NOT the bare trade-ledger label.
+	reportSharedWalletDrift(nil, []sharedWalletDriftResult{
+		{Key: key, Drift: 5.00, Balance: 1000, ExpectedEquity: 995, Basis: driftBasisJournal},
+	})
+	if e := sharedWalletDriftTracker.entries[jkey]; e == nil || e.cycles != 1 {
+		t.Fatalf("journal streak should record under %q: %+v", jkey, e)
+	}
+	if sharedWalletDriftTracker.entries[sharedWalletKeyLabel(key)] != nil {
+		t.Error("journal basis must NOT touch the bare trade-ledger streak key")
+	}
+
+	// Cycle 2: journal transiently not usable -> JournalPending. The streak is
+	// PRESERVED (no Record, no Clear), so the confirmation window survives the
+	// feed miss instead of resetting off a clean trade-ledger fallback.
+	reportSharedWalletDrift(nil, []sharedWalletDriftResult{
+		{Key: key, Drift: 0.0, Balance: 1000, JournalPending: true},
+	})
+	if e := sharedWalletDriftTracker.entries[jkey]; e == nil || e.cycles != 1 {
+		t.Fatalf("JournalPending must preserve the journal streak unchanged: %+v", e)
+	}
+
+	// Cycle 3: journal usable and over tolerance again -> the preserved streak
+	// confirms within the 2-cycle window despite the intervening transient miss.
+	reportSharedWalletDrift(nil, []sharedWalletDriftResult{
+		{Key: key, Drift: 5.00, Balance: 1000, ExpectedEquity: 995, Basis: driftBasisJournal},
+	})
+	if e := sharedWalletDriftTracker.entries[jkey]; e == nil || e.cycles != 2 {
+		t.Fatalf("streak must continue across the transient, reaching confirmation: %+v", e)
+	}
+}
+
+// #1107 (Optional #2): under the journal basis the exchange total reconciles an
+// unowned position to ~0, so orphan exposure is absent from the total drift. The
+// alarm must TRIP on an orphan coin regardless (real unmanaged exposure), confirm
+// across cycles, and reset only when the orphan is gone AND the total reconciles.
+func TestReportSharedWalletDrift_JournalOrphanTripsWithoutTotalDrift(t *testing.T) {
+	prev := sharedWalletDriftTracker
+	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
+	defer func() { sharedWalletDriftTracker = prev }()
+
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	jkey := sharedWalletKeyLabel(key) + journalDriftStreakKeySuffix
+	orphan := func() []sharedWalletDriftResult {
+		return []sharedWalletDriftResult{
+			{Key: key, Drift: 0.0, Balance: 1000, ExpectedEquity: 1000, Basis: driftBasisJournal, OrphanCoins: []string{"BTC"}},
+		}
+	}
+
+	reportSharedWalletDrift(nil, orphan())
+	if e := sharedWalletDriftTracker.entries[jkey]; e == nil || e.cycles != 1 {
+		t.Fatalf("orphan with ~0 total drift must still record (trip): %+v", e)
+	}
+	reportSharedWalletDrift(nil, orphan())
+	if e := sharedWalletDriftTracker.entries[jkey]; e == nil || e.cycles != 2 {
+		t.Fatalf("a persistent journal orphan must keep confirming: %+v", e)
+	}
+
+	// Orphan resolved AND total reconciles -> within tolerance, streak clears.
+	reportSharedWalletDrift(nil, []sharedWalletDriftResult{
+		{Key: key, Drift: 0.0, Balance: 1000, ExpectedEquity: 1000, Basis: driftBasisJournal},
+	})
+	if sharedWalletDriftTracker.entries[jkey] != nil {
+		t.Error("a clean journal cycle (no orphan, no total drift) must clear the streak")
+	}
+}
+
+func TestFormatSharedWalletJournalOrphanAlert(t *testing.T) {
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	msg := formatSharedWalletJournalOrphanAlert(key, 1000, 1000, 0.0, 2, []string{"BTC", "ETH"})
+	for _, want := range []string{"ORPHAN POSITION", "hyperliquid/0xabc", "BTC, ETH", "NO strategy"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("orphan alert missing %q: %s", want, msg)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Phase 2 of the Hyperliquid scope of epic #1100. Promotes the exchange-sourced cash-flow journal (built in #1103) from **shadow** to the **actual drift-alarm basis** for Hyperliquid shared wallets: the wallet TOTAL is reconstructed from on-chain fills + funding + transfers and the drift alarm fires on `accountValue` vs the journal's expected-equity — so modeled-fee, fallback-price, and model-only force-close rows no longer read as residual drift. Per-strategy member display values stay on the trade ledger (attribution). OKX (#1105) / TopStep (#1106) are left entirely on their existing path.

`Closes #1104`. Part of epic #1100.

> **Stacked on #1101 (#1103, journal + shadow).** Merge #1101 first — this PR's base is the journal branch, so its diff is **only** the alarm-switch commit (`dc81b49`). GitHub auto-retargets this PR's base to `main` once #1101 merges.

## How it reconciles

HL `accountValue` = settled cash + unrealized PnL, so:

```
expected = baseline_accountValue + Σ(settled-cash deltas since baseline) + (uPnL_now − uPnL_baseline)
```

The drift alarm now fires on `accountValue` vs the journal's expected-equity for HL wallets, replacing the trade-ledger drift. `closedPnl` is **gross** of fees (#698): the fee is subtracted exactly once in the settled delta; the gross value is kept in `closed_pnl_gross` for attribution and is **never** summed into equity on its own.

## Fail-closed safety (epic failure policy)

- The journal drives the alarm only when **usable**: baseline anchored, all three streams fetched this cycle, and not `incomplete`. Otherwise the alarm **falls back to the trade-ledger drift**, preserving the drift streak.
- Feed fetch miss → cursor not advanced; persist failure → cursor halted at the failed event; unmapped event kind → `incomplete` latch → fail closed.
- **Operator kill-switch** `GO_TRADER_CASHFLOW_JOURNAL_ALARM=0/off/false/no` forces the legacy trade-ledger basis with no redeploy (registered in `agent-info`).
- The journal-vs-ledger comparison is logged every cycle, so both bases stay visible after the switch.

## Snapshot-bounded ingestion

Journal events are booked only up to the `accountValue`/uPnL snapshot instant (`hlSnapshotAt`). A fill settled on-chain between the balance snapshot and the (seconds-later) journal fetch is **deferred to next cycle** rather than counted in expected-equity-but-not-accountValue — which would otherwise read as a full cycle of false drift during active trading. Indexer-lag transients are absorbed by the existing 2-cycle drift confirmation.

## Baseline-offset retirement (epic phase 6)

The journal's adoption baseline (`baseline_account_value` / `baseline_upnl`) is migration-only by construction — anchored once at first contact, never re-zeroed. The trade-ledger `baseline_offset_usd` now only silences the **fail-closed fallback**, not the steady-state alarm.

## Changes

- `scheduler/cashflow_journal.go` — `reconcileCashflowJournal` (usability-gated), `applyCashflowJournalDriftBasis` (overrides HL drift when usable+enabled, logs journal-vs-ledger every cycle), `cashflowJournalAlarmEnabled` kill-switch, and a snapshot cutoff in `ingestCashflowJournalEvents`.
- `scheduler/shared_wallet_reconcile.go` — `sharedWalletDriftResult` gains `Basis` + `ExpectedEquity`.
- `scheduler/shared_wallet_drift_alerts.go` — basis-aware drift log + `formatSharedWalletJournalDriftAlert`.
- `scheduler/main.go` — capture `hlSnapshotAt`; compute the journal + apply the basis before `reportSharedWalletDrift`.
- `scheduler/agent_info.go` — register `GO_TRADER_CASHFLOW_JOURNAL_ALARM`.

## Verification

- Full `scheduler` `go test` green; build clean; `gofmt` clean; `agent-info` env-coverage test passes.
- Tests: snapshot-cutoff deferral; usability gating (first contact / stream-miss / incomplete); basis switch (enabled+usable overrides; disabled/not-usable/nil keep trade-ledger; other wallets untouched); env kill-switch parser.
- No Python changes — reuses Go-native HL fetchers, no Go↔Python argv contract touched.

LLM: Opus 4.8 | high | Harness: work-on-issue
