### PR TITLE
feat(#1105): OKX shared-wallet cash-flow journal (shadow)

### DIFF
--- a/platforms/okx/adapter.py
+++ b/platforms/okx/adapter.py
@@ -31,6 +31,23 @@ def _bill_float(value) -> float:
         return 0.0
 
 
+def _okx_usdt_cash_balance(info):
+    """Pull the USDT ``cashBal`` from a raw OKX fetch_balance ``info`` payload
+    (``data[0].details[]``). Returns a float, or None when the field is absent
+    or unparseable. Pure — unit-tested without a live exchange."""
+    try:
+        details = ((info or {}).get("data") or [{}])[0].get("details") or []
+    except (AttributeError, IndexError, TypeError):
+        return None
+    for d in details:
+        try:
+            if str(d.get("ccy") or "").upper() == "USDT":
+                return float(d.get("cashBal"))
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
 def _normalize_okx_bill(entry: dict) -> dict:
     """Normalize one ccxt fetch_ledger entry into the #1105 journal bill shape.
 
@@ -296,6 +313,39 @@ class OKXExchangeAdapter:
         except (TypeError, ValueError):
             return 0.0
 
+    def get_account_equity_and_upnl(self) -> Tuple[float, float]:
+        """Return a COHERENT ``(equity, unrealized_pnl)`` snapshot from ONE
+        ``fetch_balance`` call, for the #1105 cash-flow journal.
+
+        ``equity`` is the USDT account value (ccxt ``total["USDT"]`` == OKX
+        ``eq`` — the same field ``get_account_balance`` returns and the #918
+        capital-weight split reconciles). ``unrealized_pnl`` is derived as
+        ``eq - cashBal`` for USDT from the SAME response, so eq and uPnL are one
+        atomic snapshot: in the journal's equity equation the uPnL term then
+        cancels exactly against ``eq``, leaving residual drift = settled-cash
+        reconstruction error only. Pairing eq with a uPnL sampled from a SEPARATE
+        ``fetch_positions`` call (a different instant) would inject intra-cycle
+        uPnL jitter — dollars on a leveraged position — into the shadow drift,
+        the very signal Phase 3b must evaluate.
+
+        Falls back to uPnL ``0.0`` when the USDT ``cashBal`` is absent/unparseable
+        (the shadow drift then conservatively carries uPnL — visible, never a
+        false "clean"). Only available in live mode; raises in paper mode.
+        """
+        if not self._is_live:
+            raise RuntimeError(
+                "get_account_equity_and_upnl requires live mode (set OKX_API_KEY, OKX_API_SECRET, OKX_PASSPHRASE)"
+            )
+        bal = self._exchange.fetch_balance()
+        total = bal.get("total") or {}
+        try:
+            eq = float(total.get("USDT") or 0.0)
+        except (TypeError, ValueError):
+            eq = 0.0
+        cash_bal = _okx_usdt_cash_balance(bal.get("info"))
+        upnl = (eq - cash_bal) if cash_bal is not None else 0.0
+        return eq, upnl
+
     def get_account_bills(self, since_ms: int = 0, page_limit: int = 100,
                           max_bills: int = 10000) -> Tuple[list, bool]:
         """Fetch OKX account bills (settled cash-flow events) since ``since_ms``
@@ -321,6 +371,13 @@ class OKXExchangeAdapter:
         older bills fall outside it and surface as journal drift in the shadow
         log (visible to the operator before any Phase-3b alarm flip).
 
+        Ordering assumption: this pages FORWARD by timestamp and relies on ccxt's
+        unified ``fetch_ledger`` returning entries ascending-from-``since`` (ccxt
+        ``parse_ledger`` sorts by timestamp). That contract — and that the
+        millisecond ``ts`` matches the live feed — is offline-unverifiable; confirm
+        the settled-Σ tracks eq to ~0 over a multi-cycle live window before any
+        Phase-3b alarm flip.
+
         Only available in live mode; raises RuntimeError in paper mode.
         """
         if not self._is_live:
@@ -330,30 +387,40 @@ class OKXExchangeAdapter:
         collected = {}
         cursor = int(since_ms or 0)
         capped = False
-        # Page FORWARD from the cursor: ccxt fetch_ledger returns unified entries
-        # ascending and `since` filters from that point; advance `since` past the
-        # newest entry each page until the feed is exhausted (short page) or the
-        # safety cap is hit. The page-loop bound is a belt-and-suspenders guard
-        # against a non-advancing cursor.
+        # Page FORWARD from the cursor, advancing the `since` watermark with a
+        # one-millisecond OVERLAP (cursor = page's last ts, NOT last_ts + 1) so a
+        # bill that shares the boundary millisecond but fell beyond the page cut
+        # is re-fetched on the next page — the `collected` dedup absorbs the
+        # re-read. Advancing past last_ts would permanently skip such a same-ms
+        # bill (a standing offset in the settled sum, not a transient miss). The
+        # page-loop bound caps total iterations.
         for _ in range(max(1, max_bills // max(1, page_limit)) + 2):
             page = self._exchange.fetch_ledger(code=None, since=cursor, limit=page_limit) or []
             if not page:
                 break
+            before = len(collected)
             for entry in page:
                 bill = _normalize_okx_bill(entry)
                 key = bill["bill_id"] or f"{bill['type']}:{bill['ts_ms']}:{bill['trade_id']}"
                 collected[key] = bill
+            added = len(collected) - before
             if len(collected) >= max_bills:
                 capped = True
                 break
             if len(page) < page_limit:
+                break  # short page → feed exhausted
+            page_last_ts = max((int(e.get("timestamp") or 0) for e in page), default=cursor)
+            if page_last_ts <= cursor and added == 0:
+                # A FULL page that neither advanced the timestamp nor yielded any
+                # new bill: a single-millisecond block larger than page_limit, which
+                # timestamp paging cannot step through without dropping bills. Fail
+                # closed — the Go journal treats `capped` as not-usable for the
+                # cycle rather than silently advancing past the undelivered tail.
+                capped = True
                 break
-            last_ts = max((int(e.get("timestamp") or 0) for e in page), default=cursor)
-            if last_ts <= cursor:
-                break  # no forward progress — stop rather than loop forever
-            cursor = last_ts + 1
+            cursor = page_last_ts  # overlap on the boundary ms (dedup absorbs it)
         bills = sorted(collected.values(), key=lambda b: b["ts_ms"])
-        if capped:
+        if len(bills) > max_bills:
             bills = bills[:max_bills]
         return bills, capped
 

--- a/platforms/okx/adapter.py
+++ b/platforms/okx/adapter.py
@@ -392,8 +392,20 @@ class OKXExchangeAdapter:
         # bill that shares the boundary millisecond but fell beyond the page cut
         # is re-fetched on the next page — the `collected` dedup absorbs the
         # re-read. Advancing past last_ts would permanently skip such a same-ms
-        # bill (a standing offset in the settled sum, not a transient miss). The
-        # page-loop bound caps total iterations.
+        # bill (a standing offset in the settled sum, not a transient miss).
+        #
+        # INVARIANT: capped=False must mean the feed was DRAINED (a short/empty
+        # page), never that the per-cycle iteration budget ran out. The overlap
+        # re-read makes net-new-per-page < page_limit when bills cluster on the
+        # boundary millisecond (a fill emits a trade + a fee bill at the same ms;
+        # settlements batch), so a dense backlog can exhaust the budget before the
+        # feed drains AND before the max_bills cap trips. The `for…else` makes that
+        # budget-exhaustion fall-through report capped=True: every feed-drained or
+        # cap exit above uses `break` (so `else` does NOT run), and only a loop that
+        # runs out of iterations reaches `else`. The Go journal then treats the
+        # cycle as not-usable and re-reads forward from maxTime next cycle
+        # (okxBillDedupID / INSERT OR IGNORE absorbs the re-reads) instead of
+        # advancing the cursor past the unfetched tail.
         for _ in range(max(1, max_bills // max(1, page_limit)) + 2):
             page = self._exchange.fetch_ledger(code=None, since=cursor, limit=page_limit) or []
             if not page:
@@ -419,6 +431,11 @@ class OKXExchangeAdapter:
                 capped = True
                 break
             cursor = page_last_ts  # overlap on the boundary ms (dedup absorbs it)
+        else:
+            # Loop ran out of iterations without a feed-drained/cap break: the
+            # returned set is an INCOMPLETE prefix of the feed. Report capped so the
+            # cursor is not advanced past the unfetched tail.
+            capped = True
         bills = sorted(collected.values(), key=lambda b: b["ts_ms"])
         if len(bills) > max_bills:
             bills = bills[:max_bills]

--- a/platforms/okx/adapter.py
+++ b/platforms/okx/adapter.py
@@ -23,6 +23,40 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'
 import ccxt
 
 
+def _bill_float(value) -> float:
+    """Parse an OKX bill numeric field; missing/blank/garbage → 0.0."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _normalize_okx_bill(entry: dict) -> dict:
+    """Normalize one ccxt fetch_ledger entry into the #1105 journal bill shape.
+
+    Pulls the raw OKX bill from ``entry["info"]`` (authoritative field names —
+    billId/balChg/etc.) and falls back to the ccxt-unified ``timestamp`` for the
+    millisecond time when the raw ``ts`` is absent. Pure — unit-tested without a
+    live exchange.
+    """
+    info = entry.get("info") or {}
+    ts = info.get("ts")
+    if ts in (None, ""):
+        ts = entry.get("timestamp")
+    return {
+        "bill_id": str(info.get("billId") or entry.get("id") or ""),
+        "ts_ms": int(_bill_float(ts)),
+        "ccy": str(info.get("ccy") or ""),
+        "type": str(info.get("type") or ""),
+        "sub_type": str(info.get("subType") or ""),
+        "bal_chg": _bill_float(info.get("balChg")),
+        "pnl": _bill_float(info.get("pnl")),
+        "fee": _bill_float(info.get("fee")),
+        "inst_id": str(info.get("instId") or ""),
+        "trade_id": str(info.get("tradeId") or ""),
+    }
+
+
 class OKXExchangeAdapter:
     """
     Exchange adapter for OKX — spot, perpetual swaps, and options.
@@ -261,6 +295,67 @@ class OKXExchangeAdapter:
             return float(total.get("USDT") or 0.0)
         except (TypeError, ValueError):
             return 0.0
+
+    def get_account_bills(self, since_ms: int = 0, page_limit: int = 100,
+                          max_bills: int = 10000) -> Tuple[list, bool]:
+        """Fetch OKX account bills (settled cash-flow events) since ``since_ms``
+        for the #1105 exchange-sourced cash-flow journal (shadow phase).
+
+        Every OKX balance change is an account bill carrying ``balChg`` (the
+        signed change to the settled cash balance), so this single feed is the
+        COMPLETE settled-cash-flow source — trade PnL, fees, funding, transfers,
+        deposits and withdrawals are all bills. ``balChg`` already nets every
+        component, so the consumer needs no per-fill fee arithmetic; ``pnl`` /
+        ``fee`` are returned as attribution metadata only.
+
+        Returns ``(bills, capped)`` where ``bills`` is oldest-first, each a dict:
+        ``{"bill_id","ts_ms","ccy","type","sub_type","bal_chg","pnl","fee",
+        "inst_id","trade_id"}`` sourced from the raw OKX bill
+        (ccxt ``fetch_ledger`` entry ``info``). ``capped`` is True when the
+        ``max_bills`` safety cap was hit before the feed was exhausted — the Go
+        journal then treats that cycle as not-usable but still advances its
+        cursor past the contiguous oldest prefix.
+
+        Horizon: ccxt ``fetch_ledger`` reads OKX ``/account/bills`` (~7 days). In
+        steady per-cycle operation the window is ample; after a multi-day outage
+        older bills fall outside it and surface as journal drift in the shadow
+        log (visible to the operator before any Phase-3b alarm flip).
+
+        Only available in live mode; raises RuntimeError in paper mode.
+        """
+        if not self._is_live:
+            raise RuntimeError(
+                "get_account_bills requires live mode (set OKX_API_KEY, OKX_API_SECRET, OKX_PASSPHRASE)"
+            )
+        collected = {}
+        cursor = int(since_ms or 0)
+        capped = False
+        # Page FORWARD from the cursor: ccxt fetch_ledger returns unified entries
+        # ascending and `since` filters from that point; advance `since` past the
+        # newest entry each page until the feed is exhausted (short page) or the
+        # safety cap is hit. The page-loop bound is a belt-and-suspenders guard
+        # against a non-advancing cursor.
+        for _ in range(max(1, max_bills // max(1, page_limit)) + 2):
+            page = self._exchange.fetch_ledger(code=None, since=cursor, limit=page_limit) or []
+            if not page:
+                break
+            for entry in page:
+                bill = _normalize_okx_bill(entry)
+                key = bill["bill_id"] or f"{bill['type']}:{bill['ts_ms']}:{bill['trade_id']}"
+                collected[key] = bill
+            if len(collected) >= max_bills:
+                capped = True
+                break
+            if len(page) < page_limit:
+                break
+            last_ts = max((int(e.get("timestamp") or 0) for e in page), default=cursor)
+            if last_ts <= cursor:
+                break  # no forward progress — stop rather than loop forever
+            cursor = last_ts + 1
+        bills = sorted(collected.values(), key=lambda b: b["ts_ms"])
+        if capped:
+            bills = bills[:max_bills]
+        return bills, capped
 
     # ─────────────────────────────────────────────
     # Options Protocol methods

--- a/platforms/okx/test_adapter.py
+++ b/platforms/okx/test_adapter.py
@@ -357,3 +357,172 @@ class TestOptionsProtocol:
         assert pct == 0.05
         assert usd == 0.05 * 67000
         assert greeks["delta"] == 0.45
+
+
+# ─── #1105 account bills + coherent equity/uPnL (cash-flow journal) ─────────
+
+def _ledger_entry(bill_id, ts, balchg="1", ccy="USDT", btype="2", sub="",
+                  pnl="0", fee="0", inst="BTC-USDT-SWAP", trade="t1"):
+    """A ccxt fetch_ledger entry carrying a raw OKX bill in `info`."""
+    return {
+        "id": bill_id,
+        "timestamp": ts,
+        "info": {
+            "billId": bill_id, "ts": str(ts), "ccy": ccy, "type": btype,
+            "subType": sub, "balChg": str(balchg), "pnl": str(pnl),
+            "fee": str(fee), "instId": inst, "tradeId": trade,
+        },
+    }
+
+
+class TestNormalizeOKXBill:
+    def test_full_bill(self):
+        out = _mod._normalize_okx_bill(_ledger_entry("b1", 1700000000000, "19.7", pnl="20", fee="0.3"))
+        assert out == {
+            "bill_id": "b1", "ts_ms": 1700000000000, "ccy": "USDT", "type": "2",
+            "sub_type": "", "bal_chg": 19.7, "pnl": 20.0, "fee": 0.3,
+            "inst_id": "BTC-USDT-SWAP", "trade_id": "t1",
+        }
+
+    def test_falls_back_to_unified_timestamp(self):
+        entry = {"id": "b2", "timestamp": 1700000000999, "info": {"billId": "b2", "balChg": "1.0"}}
+        out = _mod._normalize_okx_bill(entry)
+        assert out["ts_ms"] == 1700000000999
+        assert out["bal_chg"] == 1.0
+
+    def test_garbage_numbers_default_zero(self):
+        entry = {"id": "b3", "timestamp": 1, "info": {"billId": "b3", "balChg": "", "pnl": None, "fee": "x"}}
+        out = _mod._normalize_okx_bill(entry)
+        assert out["bal_chg"] == 0.0 and out["pnl"] == 0.0 and out["fee"] == 0.0
+
+
+class TestOKXUSDTCashBalance:
+    def _info(self, details):
+        return {"code": "0", "data": [{"details": details}]}
+
+    def test_reads_usdt_cash_bal(self):
+        info = self._info([{"ccy": "BTC", "cashBal": "0.5"}, {"ccy": "USDT", "cashBal": "900.25"}])
+        assert _mod._okx_usdt_cash_balance(info) == 900.25
+
+    def test_missing_details_returns_none(self):
+        assert _mod._okx_usdt_cash_balance({"data": [{}]}) is None
+        assert _mod._okx_usdt_cash_balance({}) is None
+        assert _mod._okx_usdt_cash_balance(None) is None
+
+    def test_no_usdt_entry_returns_none(self):
+        assert _mod._okx_usdt_cash_balance(self._info([{"ccy": "BTC", "cashBal": "0.5"}])) is None
+
+    def test_unparseable_cash_bal_returns_none(self):
+        assert _mod._okx_usdt_cash_balance(self._info([{"ccy": "USDT", "cashBal": "n/a"}])) is None
+
+
+class TestGetAccountEquityAndUPnL:
+    def test_paper_mode_raises(self, adapter):
+        a, _ = adapter
+        with pytest.raises(RuntimeError, match="live mode"):
+            a.get_account_equity_and_upnl()
+
+    def test_coherent_eq_and_upnl(self, adapter):
+        a, mock_ex = adapter
+        a._is_live = True
+        mock_ex.fetch_balance.return_value = {
+            "total": {"USDT": 1000.0},
+            "info": {"data": [{"details": [{"ccy": "USDT", "cashBal": "900.0"}]}]},
+        }
+        eq, upnl = a.get_account_equity_and_upnl()
+        assert eq == 1000.0
+        assert upnl == 100.0  # eq - cashBal, one coherent snapshot
+
+    def test_missing_cash_bal_defaults_upnl_zero(self, adapter):
+        a, mock_ex = adapter
+        a._is_live = True
+        mock_ex.fetch_balance.return_value = {"total": {"USDT": 1000.0}, "info": {}}
+        eq, upnl = a.get_account_equity_and_upnl()
+        assert eq == 1000.0 and upnl == 0.0
+
+
+class TestGetAccountBills:
+    def test_paper_mode_raises(self, adapter):
+        a, _ = adapter
+        with pytest.raises(RuntimeError, match="live mode"):
+            a.get_account_bills(since_ms=0)
+
+    def test_single_page_ascending(self, adapter):
+        a, mock_ex = adapter
+        a._is_live = True
+        mock_ex.fetch_ledger.return_value = [
+            _ledger_entry("b2", 200, "19.7"),
+            _ledger_entry("b1", 100, "-0.5"),
+        ]
+        bills, capped = a.get_account_bills(since_ms=50)
+        assert capped is False
+        assert [b["bill_id"] for b in bills] == ["b1", "b2"]
+        assert [b["ts_ms"] for b in bills] == [100, 200]
+
+    def test_full_page_advances_with_overlap_not_plus_one(self, adapter):
+        a, mock_ex = adapter
+        a._is_live = True
+        page1 = [_ledger_entry(f"p1-{i}", 100 + i, "1") for i in range(100)]  # ts 100..199
+        page2 = [_ledger_entry("p2-0", 500, "2")]  # short → stop
+        mock_ex.fetch_ledger.side_effect = [page1, page2]
+        bills, capped = a.get_account_bills(since_ms=0, page_limit=100)
+        assert capped is False
+        assert len(bills) == 101
+        assert mock_ex.fetch_ledger.call_count == 2
+        # Overlap: next cursor is the page's last ts (199), NOT last_ts + 1.
+        assert mock_ex.fetch_ledger.call_args_list[1].kwargs["since"] == 199
+
+    def test_same_ms_straddle_across_page_boundary_is_captured(self, adapter):
+        a, mock_ex = adapter
+        a._is_live = True
+        # page1 fills exactly 100 entries, the last (p-99) at ts=199. A SECOND bill
+        # at ts=199 (p-100) falls beyond the cut. cursor=199 (overlap) re-fetches it.
+        page1 = [_ledger_entry(f"p-{i}", 100 + i, "1") for i in range(100)]  # p-99 @ 199
+        page2 = [_ledger_entry("p-99", 199, "1"),       # dup (deduped)
+                 _ledger_entry("p-100", 199, "1"),      # the straddling bill
+                 _ledger_entry("p-105", 205, "1")]      # short page → stop
+        mock_ex.fetch_ledger.side_effect = [page1, page2]
+        bills, capped = a.get_account_bills(since_ms=0, page_limit=100)
+        ids = [b["bill_id"] for b in bills]
+        assert "p-100" in ids                      # same-ms straddler NOT skipped
+        assert ids.count("p-99") == 1              # dedup absorbed the overlap
+        assert capped is False
+
+    def test_same_ms_block_larger_than_page_fails_closed(self, adapter):
+        a, mock_ex = adapter
+        a._is_live = True
+        # Every bill shares ts=100 and the page is always full → cannot advance by
+        # timestamp without dropping the tail, so the adapter caps (fail closed).
+        page = [_ledger_entry(f"x-{i}", 100, "1") for i in range(10)]
+        mock_ex.fetch_ledger.return_value = page  # same full page every call
+        bills, capped = a.get_account_bills(since_ms=0, page_limit=10, max_bills=10000)
+        assert capped is True
+        assert len(bills) == 10
+        assert mock_ex.fetch_ledger.call_count == 2  # second call detects no progress
+
+    def test_capped_on_max_bills_truncates_oldest_prefix(self, adapter):
+        a, mock_ex = adapter
+        a._is_live = True
+        calls = {"n": 0}
+
+        def side_effect(*args, **kwargs):
+            calls["n"] += 1
+            base = calls["n"] * 1000
+            return [_ledger_entry(f"c-{base+i}", base + i, "1") for i in range(10)]
+
+        mock_ex.fetch_ledger.side_effect = side_effect
+        bills, capped = a.get_account_bills(since_ms=0, page_limit=10, max_bills=25)
+        assert capped is True
+        assert len(bills) == 25
+        assert all(bills[i]["ts_ms"] <= bills[i + 1]["ts_ms"] for i in range(len(bills) - 1))
+
+    def test_dedup_across_overlapping_pages(self, adapter):
+        a, mock_ex = adapter
+        a._is_live = True
+        page1 = [_ledger_entry(f"d-{i}", 100 + i, "1") for i in range(100)]
+        page2 = [_ledger_entry("d-99", 199, "1"), _ledger_entry("d-new", 250, "1")]
+        mock_ex.fetch_ledger.side_effect = [page1, page2]
+        bills, capped = a.get_account_bills(since_ms=0, page_limit=100)
+        ids = [b["bill_id"] for b in bills]
+        assert len(ids) == len(set(ids))
+        assert "d-new" in ids and ids.count("d-99") == 1

--- a/platforms/okx/test_adapter.py
+++ b/platforms/okx/test_adapter.py
@@ -526,3 +526,43 @@ class TestGetAccountBills:
         ids = [b["bill_id"] for b in bills]
         assert len(ids) == len(set(ids))
         assert "d-new" in ids and ids.count("d-99") == 1
+
+    def test_loop_budget_exhaustion_reports_capped(self, adapter):
+        # A backlog larger than the iteration budget, with same-ms clustering so
+        # the overlap re-read makes net-new-per-page < page_limit. The loop must
+        # exhaust its budget and report capped=True (NOT fall through to False with
+        # an incomplete prefix that the Go journal would treat as complete).
+        a, mock_ex = adapter
+        a._is_live = True
+        # 400 bills, 2 per ms (ts 0,0,1,1,2,2,...,199,199); page_limit 10,
+        # max_bills 100 → budget = 100//10 + 2 = 12 iterations. Overlap nets ~8
+        # new/page, so 12 pages can't reach 100 → budget runs out while the feed
+        # still has bills, below the max_bills cap.
+        all_bills = [_ledger_entry(f"x-{i}", i // 2, "1") for i in range(400)]
+
+        def side_effect(*args, **kwargs):
+            since = kwargs.get("since", 0)
+            window = [e for e in all_bills if e["timestamp"] >= since]
+            return window[:10]
+
+        mock_ex.fetch_ledger.side_effect = side_effect
+        bills, capped = a.get_account_bills(since_ms=0, page_limit=10, max_bills=100)
+        assert capped is True, "budget exhaustion must report capped=True, not False"
+        assert len(bills) < 400  # an incomplete prefix, correctly flagged
+
+    def test_drained_distinct_ts_not_spuriously_capped(self, adapter):
+        # The inverse: a fully-drained feed of distinct timestamps that exits on a
+        # short page must stay capped=False (no spurious cap from the for…else).
+        a, mock_ex = adapter
+        a._is_live = True
+        all_bills = [_ledger_entry(f"d-{i}", 100 + i, "1") for i in range(25)]  # < max_bills
+
+        def side_effect(*args, **kwargs):
+            since = kwargs.get("since", 0)
+            window = [e for e in all_bills if e["timestamp"] >= since]
+            return window[:10]
+
+        mock_ex.fetch_ledger.side_effect = side_effect
+        bills, capped = a.get_account_bills(since_ms=0, page_limit=10, max_bills=100)
+        assert capped is False
+        assert len(bills) == 25  # whole feed drained

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -1195,6 +1195,56 @@ func parseOKXBalanceOutput(stdout []byte, stderrStr string, runErr error) (*OKXB
 	}
 }
 
+// OKXBillsResult is the JSON output from fetch_okx_bills.py (#1105). Bills are
+// the OKX account-bill cash-flow events since the cursor; Capped is true when
+// the script hit its safety page cap (a pathological backlog — the journal
+// treats that cycle as not-usable). Bills decodes straight into okxBillRecord
+// (json tags match), so the OKX cash-flow journal has no second representation.
+type OKXBillsResult struct {
+	Bills     []okxBillRecord `json:"bills"`
+	Capped    bool            `json:"capped"`
+	Platform  string          `json:"platform"`
+	Timestamp string          `json:"timestamp"`
+	Error     string          `json:"error,omitempty"`
+}
+
+// RunOKXFetchBills runs fetch_okx_bills.py for one OKX account, pulling every
+// settled cash-flow bill since sinceMs (#1105). Follows the same 5-case
+// contract as RunOKXFetchPositions / RunOKXFetchBalance: a non-nil error on ANY
+// failure path so the journal fails closed (no cursor advance, no shadow
+// reading) rather than silently treating a fetch failure as "no cash flow".
+func RunOKXFetchBills(script string, sinceMs int64) (*OKXBillsResult, string, error) {
+	args := []string{fmt.Sprintf("--since-ms=%d", sinceMs)}
+	stdout, stderr, runErr := RunPythonScript(script, args)
+	return parseOKXBillsOutput(stdout, string(stderr), runErr)
+}
+
+// parseOKXBillsOutput is the pure parser for RunOKXFetchBills, extracted so the
+// decision logic is testable without spawning Python. Mirrors
+// parseOKXPositionsOutput / parseOKXBalanceOutput's 5-case matrix — contract
+// drift across the OKX fetch parsers would be bad.
+func parseOKXBillsOutput(stdout []byte, stderrStr string, runErr error) (*OKXBillsResult, string, error) {
+	var result OKXBillsResult
+	parseErr := json.Unmarshal(stdout, &result)
+
+	switch {
+	case runErr == nil && parseErr == nil && result.Error == "":
+		return &result, stderrStr, nil
+
+	case runErr == nil && parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("fetch bills reported error despite exit 0: %s", result.Error)
+
+	case parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("fetch bills failed: %s", result.Error)
+
+	case parseErr == nil && runErr != nil:
+		return &result, stderrStr, fmt.Errorf("fetch bills subprocess exit %v with no error field (stderr: %s)", runErr, stderrStr)
+
+	default:
+		return nil, stderrStr, fmt.Errorf("parse bills output: %v (run err: %v, stdout: %s)", parseErr, runErr, string(stdout))
+	}
+}
+
 // RobinhoodCloseFill is the parsed fill block from close_robinhood_position.py.
 // Mirrors OKXCloseFill. OID is a string (robin_stocks order IDs are opaque
 // UUIDs), fields are optional — empty {} means the adapter found no position

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -1152,11 +1152,16 @@ func parseOKXPositionsOutput(stdout []byte, stderrStr string, runErr error) (*OK
 }
 
 // OKXBalanceResult is the JSON output from fetch_okx_balance.py (#360).
+// UnrealizedPnL (#1105) is eq − cashBal from the SAME fetch_balance read, so the
+// cash-flow journal can reconcile a coherent eq/uPnL snapshot; it is 0 for older
+// scripts that don't emit the field (the journal then conservatively carries
+// uPnL into the shadow drift). Balance keeps its #360 meaning (USDT eq).
 type OKXBalanceResult struct {
-	Balance   float64 `json:"balance"`
-	Platform  string  `json:"platform"`
-	Timestamp string  `json:"timestamp"`
-	Error     string  `json:"error,omitempty"`
+	Balance       float64 `json:"balance"`
+	UnrealizedPnL float64 `json:"unrealized_pnl"`
+	Platform      string  `json:"platform"`
+	Timestamp     string  `json:"timestamp"`
+	Error         string  `json:"error,omitempty"`
 }
 
 // RunOKXFetchBalance runs fetch_okx_balance.py and returns the parsed result

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -182,6 +182,27 @@ func defaultSharedWalletBalance(platform string) (float64, error) {
 	return 0, fmt.Errorf("no shared-wallet balance fetcher for platform %q", platform)
 }
 
+// defaultOKXEquitySnapshot returns a COHERENT (eq, uPnL) snapshot for the OKX
+// shared wallet from a SINGLE fetch_okx_balance.py read (#1105). eq is the USDT
+// account value the #918 split reconciles; uPnL is eq − cashBal from the same
+// response, so the cash-flow journal's eq and uPnL are one atomic snapshot
+// instead of eq (balance read) paired with a uPnL from a separately-timed
+// fetch_positions call. Any failure surfaces as a non-nil error so the journal
+// fails closed (no shadow reading this cycle).
+func defaultOKXEquitySnapshot() (eq, upnl float64, err error) {
+	if os.Getenv("OKX_API_KEY") == "" {
+		return 0, 0, fmt.Errorf("OKX_API_KEY not set")
+	}
+	result, stderr, err := RunOKXFetchBalance(okxBalanceScript)
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, "[okx-balance] stderr: %s\n", stderr)
+	}
+	if err != nil {
+		return 0, 0, err
+	}
+	return result.Balance, result.UnrealizedPnL, nil
+}
+
 // syncHyperliquidLiveCapital is a no-op kept for backward compatibility.
 // Capital is now managed per-strategy via config (Capital field) or capital_pct.
 // With multiple strategies on one account, overriding each strategy's capital

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -965,6 +965,7 @@ func main() {
 			// the #1105 OKX cash-flow journal bounds its bill ingestion to the eq
 			// snapshot instant so an in-flight bill cannot read as drift.
 			var okxBalanceFetched bool
+			var okxSnapshotUPnL float64
 			var okxSnapshotAt time.Time
 			if okxHasCreds && len(okxLivePerps) > 0 {
 				pos, err := defaultOKXPositionsFetcher()
@@ -980,11 +981,17 @@ func main() {
 			// an API key. Independent subprocess so a fetch_positions outage
 			// doesn't starve the balance read.
 			if okxHasCreds && okxShared {
-				if bal, err := defaultSharedWalletBalance("okx"); err != nil {
+				// #1105: one fetch_balance read yields a COHERENT (eq, uPnL) pair —
+				// eq feeds the #918 split (walletBalances) unchanged, and the same
+				// snapshot's uPnL (eq − cashBal) feeds the cash-flow journal, so its
+				// expected-equity and reconciled eq cancel the uPnL term exactly
+				// (no jitter from a separately-timed fetch_positions read).
+				if eq, upnl, err := defaultOKXEquitySnapshot(); err != nil {
 					fmt.Printf("[WARN] okx balance fetch failed: %v — falling back to per-wallet max this cycle\n", err)
 				} else {
-					walletBalances[okxKey] = bal
+					walletBalances[okxKey] = eq
 					okxBalanceFetched = true
+					okxSnapshotUPnL = upnl
 					okxSnapshotAt = time.Now().UTC()
 				}
 			}
@@ -1103,10 +1110,11 @@ func main() {
 			// Flipping the OKX alarm onto the journal is Phase 3b, gated on this
 			// shadow log proving the OKX bills feed / eq field in production. Runs
 			// outside the lock (subprocess fetch + DB-only writes) and is bounded to
-			// the eq/uPnL snapshot (walletBalances[okxKey] + okxPositions @
-			// okxSnapshotAt). Requires both the eq balance and positions this cycle.
-			if okxShared && okxBalanceFetched && okxStateFetched {
-				okxRec := reconcileOKXCashflowJournal(stateDB, okxKey, walletBalances[okxKey], sumOKXAccountUPnL(okxPositions), okxSnapshotAt)
+			// the COHERENT eq/uPnL snapshot from the single balance read above
+			// (walletBalances[okxKey] + okxSnapshotUPnL @ okxSnapshotAt) — no
+			// positions dependency, so eq and uPnL share one instant.
+			if okxShared && okxBalanceFetched {
+				okxRec := reconcileOKXCashflowJournal(stateDB, okxKey, walletBalances[okxKey], okxSnapshotUPnL, okxSnapshotAt)
 				logOKXCashflowJournalShadow(driftResults, okxKey, okxRec)
 			}
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -961,6 +961,11 @@ func main() {
 			_, okxShared := sharedWallets[okxKey]
 			var okxPositions []OKXPosition
 			var okxStateFetched bool
+			// okxBalanceFetched / okxSnapshotAt mirror hlStateFetched / hlSnapshotAt:
+			// the #1105 OKX cash-flow journal bounds its bill ingestion to the eq
+			// snapshot instant so an in-flight bill cannot read as drift.
+			var okxBalanceFetched bool
+			var okxSnapshotAt time.Time
 			if okxHasCreds && len(okxLivePerps) > 0 {
 				pos, err := defaultOKXPositionsFetcher()
 				if err != nil {
@@ -979,6 +984,8 @@ func main() {
 					fmt.Printf("[WARN] okx balance fetch failed: %v — falling back to per-wallet max this cycle\n", err)
 				} else {
 					walletBalances[okxKey] = bal
+					okxBalanceFetched = true
+					okxSnapshotAt = time.Now().UTC()
 				}
 			}
 			// #362: Fetch TopStep positions once per cycle when any live TS
@@ -1085,6 +1092,22 @@ func main() {
 			if hlShared && hlStateFetched {
 				rec := reconcileCashflowJournal(stateDB, hlKey, walletBalances[hlKey], sumHLAccountUPnL(hlPositions), hlSnapshotAt)
 				applyCashflowJournalDriftBasis(driftResults, hlKey, rec, cashflowJournalAlarmEnabled())
+			}
+
+			// #1105: OKX cash-flow journal — SHADOW phase (Phase 3a of #1100). The
+			// wallet TOTAL is reconstructed from OKX's account-bills feed (every
+			// settled-cash movement is a bill carrying balChg) and reconciled
+			// against eq, exactly as the HL journal does, but it ONLY logs the
+			// journal-vs-capital-weight comparison each cycle — it never drives the
+			// OKX drift alarm, which stays on the #918 capital-weight split.
+			// Flipping the OKX alarm onto the journal is Phase 3b, gated on this
+			// shadow log proving the OKX bills feed / eq field in production. Runs
+			// outside the lock (subprocess fetch + DB-only writes) and is bounded to
+			// the eq/uPnL snapshot (walletBalances[okxKey] + okxPositions @
+			// okxSnapshotAt). Requires both the eq balance and positions this cycle.
+			if okxShared && okxBalanceFetched && okxStateFetched {
+				okxRec := reconcileOKXCashflowJournal(stateDB, okxKey, walletBalances[okxKey], sumOKXAccountUPnL(okxPositions), okxSnapshotAt)
+				logOKXCashflowJournalShadow(driftResults, okxKey, okxRec)
 			}
 
 			// Fire throttled drift alarms outside the lock (notifier I/O). For HL

--- a/scheduler/okx_cashflow_journal.go
+++ b/scheduler/okx_cashflow_journal.go
@@ -62,10 +62,14 @@ func defaultOKXAccountBillsFetcher(sinceMs int64) ([]okxBillRecord, bool, error)
 //
 // The reconciled field is OKX `eq` (ccxt balance["total"]["USDT"], equity =
 // cash + uPnL — the same field fetch_okx_balance.py already reports and the
-// #918 capital-weight split already reconciles against). The journal is
-// USDT-settlement only: a non-USDT bill with a non-zero balChg cannot be
-// reconciled against the USDT-denominated eq, so it contributes $0 and latches
-// the journal incomplete (fail closed).
+// #918 capital-weight split already reconciles against). current_uPnL /
+// baseline_uPnL come from the SAME balance read as eq (uPnL = eq − cashBal,
+// not a separately-timed fetch_positions sum), so eq and uPnL are one coherent
+// snapshot: the uPnL term cancels against eq and residual drift reduces to the
+// pure settled-cash reconstruction error (cashBal − baseline_cashBal − Σ balChg)
+// — no intra-cycle uPnL jitter. The journal is USDT-settlement only: a non-USDT
+// bill with a non-zero balChg cannot be reconciled against the USDT-denominated
+// eq, so it contributes $0 and latches the journal incomplete (fail closed).
 //
 // SHADOW ONLY. This phase NEVER drives the OKX drift alarm — the live OKX alarm
 // stays on the #918 capital-weight split (reconcileSharedWalletMemberValues).
@@ -155,17 +159,6 @@ func okxBillDedupID(b okxBillRecord) string {
 	return fmt.Sprintf("okxbill:%s:%d:%s", strings.TrimSpace(b.Type), b.TimeMs, strings.TrimSpace(b.TradeID))
 }
 
-// sumOKXAccountUPnL totals the exchange-reported unrealized PnL across an OKX
-// account's open positions — the uPnL component of eq the journal equity
-// equation needs. Mirrors sumHLAccountUPnL.
-func sumOKXAccountUPnL(positions []OKXPosition) float64 {
-	sum := 0.0
-	for _, p := range positions {
-		sum += p.UnrealizedPnL
-	}
-	return sum
-}
-
 // fetchOKXAccountBills is a function variable so tests can stub the OKX bills
 // fetch without spawning Python. It pulls every account bill settled since
 // sinceMs (ascending), returning capped=true when the safety page cap was hit
@@ -184,7 +177,7 @@ type okxCashflowJournalFetchResult struct {
 	State        CashflowJournalState
 	StateFound   bool
 	AccountValue float64 // OKX eq (equity incl. uPnL) this cycle
-	CurrentUPnL  float64 // Σ exchange unrealized PnL across the account this cycle
+	CurrentUPnL  float64 // uPnL component of eq this cycle (eq − cashBal, same balance read)
 	Bills        []okxBillRecord
 	BillsFetched bool
 	Capped       bool

--- a/scheduler/okx_cashflow_journal.go
+++ b/scheduler/okx_cashflow_journal.go
@@ -280,7 +280,23 @@ func ingestOKXCashflowJournalEvents(sdb *StateDB, res okxCashflowJournalFetchRes
 			maxTime = b.TimeMs
 		}
 	}
-	st.FillsSinceMs = advanceCashflowCursor(st.FillsSinceMs, maxTime, failedAt)
+	// A capped/truncated fetch is NOT a safe contiguous prefix at its final
+	// millisecond: BOTH the single-ms-overflow cap (returns only the first
+	// page_limit of a >page_limit same-ms block) AND the max_bills bills[:N]
+	// truncation can cut a same-ms group at maxTime. Advancing to maxTime+1 would
+	// then strand the un-returned siblings behind the cursor forever — a standing
+	// offset in SumCashflowJournal that survives into a Phase-3b alarm flip. When
+	// capped, advance only to maxTime so that boundary millisecond is re-fetched
+	// next cycle; the okxBillDedupID / INSERT OR IGNORE dedup absorbs the re-read,
+	// and a genuinely un-pageable >page_limit same-ms block pins fail-closed at
+	// that ms (Usable stays false on every capped cycle) instead of corrupting the
+	// sum. advanceCashflowCursor still clamps to the current cursor, so this never
+	// moves the watermark backwards.
+	advanceMax := maxTime
+	if res.Capped {
+		advanceMax = maxTime - 1
+	}
+	st.FillsSinceMs = advanceCashflowCursor(st.FillsSinceMs, advanceMax, failedAt)
 
 	if st != res.State {
 		if err := sdb.UpsertCashflowJournalState(key.Platform, key.Account, st); err != nil {

--- a/scheduler/okx_cashflow_journal.go
+++ b/scheduler/okx_cashflow_journal.go
@@ -1,0 +1,363 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// okxFetchBillsScript is the path to the Python account-bills fetcher (#1105).
+// Exposed as a var so tests can substitute — same pattern as
+// okxFetchPositionsScript / okxBalanceScript.
+var okxFetchBillsScript = "shared_scripts/fetch_okx_bills.py"
+
+// defaultOKXAccountBillsFetcher is the production bills fetch: shells out to
+// fetch_okx_bills.py via RunOKXFetchBills and returns the typed bills + the
+// page-cap flag. Any subprocess/parse failure surfaces as a non-nil error so
+// the journal fails closed (no cursor advance, no shadow reading this cycle).
+func defaultOKXAccountBillsFetcher(sinceMs int64) ([]okxBillRecord, bool, error) {
+	result, stderr, err := RunOKXFetchBills(okxFetchBillsScript, sinceMs)
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, "[okx-cashflow-journal] fetch_bills stderr: %s\n", stderr)
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return result.Bills, result.Capped, nil
+}
+
+// #1105: exchange-sourced cash-flow journal for OKX shared wallets — SHADOW phase
+// (Phase 3a of #1100, mirroring HL's #1103 shadow / #1104 flip two-step).
+//
+// This reuses the platform-generic journal machinery built for Hyperliquid in
+// children 1–2 (cashflow_journal.go): the cashflow_journal / cashflow_journal_state
+// tables (keyed by (platform, account)), the durable per-wallet cursor + adoption
+// baseline, per-event dedup, halt-on-persist-failure, snapshot-bounded ingestion,
+// the incomplete fail-closed latch, and the shared equity equation
+// (cashflowJournalExpectedEquity). HL behavior is untouched.
+//
+// DELIBERATE DIVERGENCE FROM HL'S THREE-STREAM SHAPE. HL reconstructs settled
+// cash from three separate streams (userFills + userFunding + ledgerUpdates) and
+// must compute each fill's cash delta as realized-PnL-gross minus the fee
+// actually charged (#698 convention). OKX exposes a SINGLE settled-cash-flow
+// source — the account bills feed (ccxt fetch_ledger → /api/v5/account/bills):
+// EVERY balance change is a bill carrying `balChg`, the signed change to the
+// settled cash balance, already netting trade PnL, fees, funding, transfers,
+// deposits and withdrawals. So OKX needs no per-fill fee arithmetic and no
+// gross-PnL handling at all — `balChg` IS the settled-cash delta. The
+// venue-reported `pnl`/`fee` fields are retained as attribution metadata only
+// and are NEVER summed into equity (same gross-PnL discipline as HL).
+//
+// Because OKX is single-stream, only the FillsSinceMs cursor of the shared
+// CashflowJournalState is used (as the bills watermark); FundingSinceMs /
+// TransfersSinceMs stay 0 and unused for OKX wallets.
+//
+// Equity decomposition is identical to HL (eq = settled cash + unrealized PnL):
+//
+//	expected = baseline_eq
+//	         + Σ(balChg since baseline)        // every settled-cash movement
+//	         + (current_uPnL − baseline_uPnL)
+//
+// The reconciled field is OKX `eq` (ccxt balance["total"]["USDT"], equity =
+// cash + uPnL — the same field fetch_okx_balance.py already reports and the
+// #918 capital-weight split already reconciles against). The journal is
+// USDT-settlement only: a non-USDT bill with a non-zero balChg cannot be
+// reconciled against the USDT-denominated eq, so it contributes $0 and latches
+// the journal incomplete (fail closed).
+//
+// SHADOW ONLY. This phase NEVER drives the OKX drift alarm — the live OKX alarm
+// stays on the #918 capital-weight split (reconcileSharedWalletMemberValues).
+// logOKXCashflowJournalShadow computes the journal-derived expected equity and
+// logs it next to the capital-weight drift every cycle for operator comparison;
+// it does not mutate any driftResult. Flipping the OKX alarm onto the journal is
+// the follow-up (Phase 3b), gated on the shadow log proving the OKX feed/field
+// in production first. Nothing here mutates StrategyState, so the whole flow runs
+// OUTSIDE the state lock (DB writes are serialized by SQLite).
+
+// okxJournalSettlementCcy is the only bill currency the OKX journal reconciles.
+// OKX-USDT-margined perps settle in USDT and the reconciled eq is USDT-
+// denominated, so a bill in any other currency (e.g. an OKB fee discount)
+// cannot be summed against eq — it contributes $0 and latches incomplete.
+const okxJournalSettlementCcy = "USDT"
+
+// okxBillRecord is one OKX account-bill (a ccxt fetch_ledger entry's raw
+// `info`), the single settled-cash-flow event for OKX. BalChg is the signed
+// change to the settled cash balance and is authoritative; Pnl/Fee are
+// attribution metadata only (never summed into equity).
+type okxBillRecord struct {
+	BillID  string  `json:"bill_id"`
+	TimeMs  int64   `json:"ts_ms"`
+	Ccy     string  `json:"ccy"`
+	Type    string  `json:"type"`
+	SubType string  `json:"sub_type"`
+	BalChg  float64 `json:"bal_chg"`
+	Pnl     float64 `json:"pnl"`
+	Fee     float64 `json:"fee"`
+	InstID  string  `json:"inst_id"`
+	TradeID string  `json:"trade_id"`
+}
+
+// okxBillKindByType maps OKX bill `type` codes to human-readable journal kinds
+// (OKX /api/v5/account/bills `type` enum). The settled-cash delta comes from
+// `balChg` regardless of type, so this map is for operator-readable labels and
+// drift visibility; an UNMAPPED type still books its authoritative balChg but
+// latches the journal incomplete so the shadow log flags the unclassified event
+// for the operator to extend this map before any Phase-3b alarm flip.
+var okxBillKindByType = map[string]string{
+	"1":  "transfer",          // funding-account ⇄ trading-account transfer
+	"2":  "trade",             // realized trade pnl / fee on a fill
+	"3":  "delivery",          // futures/options delivery
+	"4":  "auto_margin_buy",   // forced margin replenishment
+	"5":  "liquidation",       // forced liquidation
+	"6":  "margin_transfer",   // margin add/remove
+	"7":  "interest_deduct",   // interest deduction
+	"8":  "funding_fee",       // perp funding payment/receipt
+	"9":  "adl",               // auto-deleveraging
+	"10": "clawback",          // socialized loss clawback
+	"11": "system_token_conv", // system token conversion
+	"12": "strategy_transfer", // strategy account transfer
+	"13": "ddh",               // delta dynamic hedging
+	"14": "settlement",        // position settlement
+	"22": "repay_forced",      // forced repayment
+}
+
+// okxBillSettledDelta returns one bill's signed effect on settled cash, its
+// human-readable journal kind, and whether the event is fully classifiable.
+// For a USDT bill the delta is its authoritative balChg; the bill is "known"
+// only when its type is in okxBillKindByType. A non-USDT bill contributes $0
+// (it cannot reconcile against the USDT eq) and is never known. A not-known
+// result latches the journal incomplete (fail closed). Pure — unit-tested.
+func okxBillSettledDelta(b okxBillRecord) (delta float64, kind string, known bool) {
+	ccy := strings.ToUpper(strings.TrimSpace(b.Ccy))
+	if ccy != "" && ccy != okxJournalSettlementCcy {
+		// Cross-currency: cannot be expressed against the USDT-denominated eq.
+		return 0, "nonsettle_" + strings.ToLower(ccy), false
+	}
+	if mapped, ok := okxBillKindByType[strings.TrimSpace(b.Type)]; ok {
+		return b.BalChg, mapped, true
+	}
+	// Unknown type: balChg is still authoritative so it is booked and summed,
+	// but the event is unclassified → latch incomplete for operator review.
+	return b.BalChg, "type_" + strings.TrimSpace(b.Type), false
+}
+
+// okxBillDedupID is a bill's stable journal identity. OKX assigns each bill a
+// unique billId; the type:time:tradeId form disambiguates the rare missing-id
+// case so two genuine bills never collide. Namespaced ("okxbill:") so it can
+// never collide with the HL fill/funding/transfer dedup namespaces in the
+// shared cashflow_journal table.
+func okxBillDedupID(b okxBillRecord) string {
+	if id := strings.TrimSpace(b.BillID); id != "" && id != "0" {
+		return "okxbill:" + id
+	}
+	return fmt.Sprintf("okxbill:%s:%d:%s", strings.TrimSpace(b.Type), b.TimeMs, strings.TrimSpace(b.TradeID))
+}
+
+// sumOKXAccountUPnL totals the exchange-reported unrealized PnL across an OKX
+// account's open positions — the uPnL component of eq the journal equity
+// equation needs. Mirrors sumHLAccountUPnL.
+func sumOKXAccountUPnL(positions []OKXPosition) float64 {
+	sum := 0.0
+	for _, p := range positions {
+		sum += p.UnrealizedPnL
+	}
+	return sum
+}
+
+// fetchOKXAccountBills is a function variable so tests can stub the OKX bills
+// fetch without spawning Python. It pulls every account bill settled since
+// sinceMs (ascending), returning capped=true when the safety page cap was hit
+// (a pathological backlog — the caller treats that cycle as not-usable but
+// still advances past the contiguous prefix it did receive).
+var fetchOKXAccountBills = func(sinceMs int64) (bills []okxBillRecord, capped bool, err error) {
+	return defaultOKXAccountBillsFetcher(sinceMs)
+}
+
+// okxCashflowJournalFetchResult carries one OKX wallet's raw bills plus the
+// coherent eq / uPnL snapshot from the no-lock fetch phase to the no-lock
+// ingest+compare phase. Mirrors cashflowJournalFetchResult (HL) but single
+// stream.
+type okxCashflowJournalFetchResult struct {
+	Key          SharedWalletKey
+	State        CashflowJournalState
+	StateFound   bool
+	AccountValue float64 // OKX eq (equity incl. uPnL) this cycle
+	CurrentUPnL  float64 // Σ exchange unrealized PnL across the account this cycle
+	Bills        []okxBillRecord
+	BillsFetched bool
+	Capped       bool
+}
+
+// fetchOKXCashflowJournalEvents reads the wallet's bills cursor and pulls every
+// account bill since it (one subprocess). Runs OUTSIDE the state lock. First
+// contact anchors the baseline to the supplied eq / uPnL snapshot and the
+// cursor to now, fetching no history — pre-adoption movement belongs to the
+// baseline, not the journal. Mirrors fetchCashflowJournalEvents (HL).
+func fetchOKXCashflowJournalEvents(sdb *StateDB, key SharedWalletKey, accountValue, currentUPnL float64, now time.Time) okxCashflowJournalFetchResult {
+	res := okxCashflowJournalFetchResult{Key: key, AccountValue: accountValue, CurrentUPnL: currentUPnL}
+	if sdb == nil || key.Platform != "okx" || key.Account == "" {
+		return res
+	}
+	st, found, err := sdb.GetCashflowJournalState(key.Platform, key.Account)
+	if err != nil {
+		fmt.Printf("[WARN] okx-cashflow-journal %s: state load failed: %v — skipping ingestion this cycle\n", sharedWalletKeyLabel(key), err)
+		return res
+	}
+	if !found {
+		nowMs := now.UnixMilli()
+		// OKX is single-stream: FillsSinceMs is the bills watermark;
+		// FundingSinceMs/TransfersSinceMs stay 0 (unused for OKX).
+		st = CashflowJournalState{
+			FillsSinceMs:         nowMs,
+			BaselineAccountValue: accountValue,
+			BaselineUPnL:         currentUPnL,
+			BaselineSet:          true,
+		}
+		if err := sdb.UpsertCashflowJournalState(key.Platform, key.Account, st); err != nil {
+			fmt.Printf("[WARN] okx-cashflow-journal %s: baseline init failed: %v\n", sharedWalletKeyLabel(key), err)
+			return res
+		}
+		fmt.Printf("[okx-cashflow-journal] %s: baseline anchored at eq $%.2f (uPnL $%+.2f) and bills cursor at %s (no historical replay)\n",
+			sharedWalletKeyLabel(key), accountValue, currentUPnL, now.UTC().Format(time.RFC3339))
+		res.State = st
+		res.StateFound = true
+		return res
+	}
+	res.State = st
+	res.StateFound = true
+
+	bills, capped, err := fetchOKXAccountBills(st.FillsSinceMs)
+	if err != nil {
+		fmt.Printf("[WARN] okx-cashflow-journal %s: account-bills fetch failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+		return res
+	}
+	res.Bills = bills
+	res.BillsFetched = true
+	res.Capped = capped
+	return res
+}
+
+// ingestOKXCashflowJournalEvents books the fetched bills into cashflow_journal
+// and advances the bills cursor. DB-only (no StrategyState mutation), so it
+// runs OUTSIDE the state lock. Returns the post-ingest state (cursor advanced,
+// incomplete latched if an unclassifiable bill was seen). Every insert halts
+// the cursor on persistence failure so a watermark never advances past an
+// un-booked event. cutoffMs bounds ingestion to bills settled AT OR BEFORE the
+// eq / uPnL snapshot — a bill settled after the snapshot is deferred to next
+// cycle (else it would inflate expected-equity but not eq and read as a full
+// cycle of false drift). Mirrors ingestCashflowJournalEvents (HL).
+func ingestOKXCashflowJournalEvents(sdb *StateDB, res okxCashflowJournalFetchResult, cutoffMs int64) CashflowJournalState {
+	st := res.State
+	if sdb == nil || !res.StateFound || !res.BillsFetched {
+		return st
+	}
+	key := res.Key
+
+	maxTime := st.FillsSinceMs - 1
+	failedAt := int64(-1)
+	bills := append([]okxBillRecord(nil), res.Bills...)
+	sort.SliceStable(bills, func(i, j int) bool { return bills[i].TimeMs < bills[j].TimeMs })
+	for _, b := range bills {
+		if b.TimeMs < st.FillsSinceMs {
+			continue // cursor-overlap boundary; dedup also covers this
+		}
+		if b.TimeMs > cutoffMs {
+			continue // settled after the balance snapshot — defer to next cycle
+		}
+		delta, kind, known := okxBillSettledDelta(b)
+		if !known {
+			// An unmapped bill type or a non-USDT bill means the journal cannot
+			// claim an exact total, so a future Phase-3b alarm flip must fail
+			// closed. The row is still booked (authoritative balChg for a known
+			// currency, $0 for cross-currency) so it stays visible + deduped and
+			// the running drift surfaces it.
+			st.Incomplete = true
+			fmt.Printf("[WARN] okx-cashflow-journal %s: unclassified bill type=%q subType=%q ccy=%q (billId %s) — recorded kind %q, journal marked incomplete\n",
+				sharedWalletKeyLabel(key), b.Type, b.SubType, b.Ccy, b.BillID, kind)
+		}
+		coin := strings.ToUpper(strings.TrimSpace(b.InstID))
+		if err := sdb.InsertCashflowJournalEntry(key.Platform, key.Account, b.TimeMs, kind, delta, coin, b.Pnl, b.Fee, okxBillDedupID(b)); err != nil {
+			fmt.Printf("[WARN] okx-cashflow-journal %s: bill insert failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+			failedAt = b.TimeMs
+			break
+		}
+		if b.TimeMs > maxTime {
+			maxTime = b.TimeMs
+		}
+	}
+	st.FillsSinceMs = advanceCashflowCursor(st.FillsSinceMs, maxTime, failedAt)
+
+	if st != res.State {
+		if err := sdb.UpsertCashflowJournalState(key.Platform, key.Account, st); err != nil {
+			fmt.Printf("[WARN] okx-cashflow-journal %s: cursor advance failed: %v\n", sharedWalletKeyLabel(key), err)
+		}
+	}
+	return st
+}
+
+// reconcileOKXCashflowJournal runs the full journal flow for one OKX shared
+// wallet OUTSIDE the state lock: fetch the account bills (subprocess), book them
+// (DB-only, bounded to the snapshot), and reconstruct the wallet's expected
+// equity. Pure of StrategyState. Returns nil when the wallet is not OKX, the
+// state load/init failed, or the baseline was just anchored this cycle. Reuses
+// the HL cashflowJournalReconcile result shape. snapshotAt is the eq / uPnL
+// sample time and bounds journal ingestion. Mirrors reconcileCashflowJournal.
+func reconcileOKXCashflowJournal(sdb *StateDB, key SharedWalletKey, accountValue, currentUPnL float64, snapshotAt time.Time) *cashflowJournalReconcile {
+	if sdb == nil || key.Platform != "okx" || key.Account == "" {
+		return nil
+	}
+	res := fetchOKXCashflowJournalEvents(sdb, key, accountValue, currentUPnL, snapshotAt)
+	if !res.StateFound {
+		return nil // baseline just anchored (logged there) or fetch/load failed
+	}
+	st := ingestOKXCashflowJournalEvents(sdb, res, snapshotAt.UnixMilli())
+	rec := &cashflowJournalReconcile{Key: key, AccountValue: res.AccountValue, Incomplete: st.Incomplete}
+	if !st.BaselineSet {
+		return rec // un-anchored: not usable
+	}
+	settled, err := sdb.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		fmt.Printf("[WARN] okx-cashflow-journal %s: settled-sum read failed: %v\n", sharedWalletKeyLabel(key), err)
+		return rec
+	}
+	rec.SettledSum = settled
+	rec.DeltaUPnL = res.CurrentUPnL - st.BaselineUPnL
+	rec.ExpectedEquity = cashflowJournalExpectedEquity(st.BaselineAccountValue, st.BaselineUPnL, settled, res.CurrentUPnL)
+	rec.Drift = res.AccountValue - rec.ExpectedEquity
+	// Usable only when this cycle's reconstruction is complete: bills fetched, no
+	// page-cap truncation (a cap leaves newer bills un-booked → would read as
+	// drift), and no unclassifiable bill has latched the journal incomplete.
+	rec.Usable = res.BillsFetched && !res.Capped && !st.Incomplete
+	return rec
+}
+
+// logOKXCashflowJournalShadow logs one OKX wallet's journal-derived expected
+// equity next to the live capital-weight drift every cycle (SHADOW phase). It
+// NEVER mutates driftResults — the OKX drift alarm stays on the #918 capital-
+// weight split. Phase 3b will switch the alarm onto the journal once this shadow
+// log proves the OKX bills feed / eq field in production. Mirrors the per-cycle
+// comparison log of applyCashflowJournalDriftBasis (HL) without the basis flip.
+func logOKXCashflowJournalShadow(driftResults []sharedWalletDriftResult, key SharedWalletKey, rec *cashflowJournalReconcile) {
+	if rec == nil {
+		return
+	}
+	splitNote := "n/a"
+	for i := range driftResults {
+		if driftResults[i].Key == key {
+			d := driftResults[i]
+			splitNote = fmt.Sprintf("raw $%+.2f / drift $%+.2f", d.Balance-d.MemberSum, d.Drift)
+			break
+		}
+	}
+	state := "shadow-usable"
+	switch {
+	case rec.Incomplete:
+		state = "shadow-incomplete (unclassified bill — would fail closed)"
+	case !rec.Usable:
+		state = "shadow-pending (no usable reading this cycle)"
+	}
+	fmt.Printf("[okx-cashflow-journal] %s: expected_equity $%.2f vs eq $%.2f → journal_drift $%+.4f (settled Σ $%+.2f, ΔuPnL $%+.2f); capital-weight %s; %s — SHADOW, alarm unchanged\n",
+		sharedWalletKeyLabel(key), rec.ExpectedEquity, rec.AccountValue, rec.Drift, rec.SettledSum, rec.DeltaUPnL, splitNote, state)
+}

--- a/scheduler/okx_cashflow_journal_test.go
+++ b/scheduler/okx_cashflow_journal_test.go
@@ -176,6 +176,92 @@ func TestOKXCashflowJournalSnapshotBound(t *testing.T) {
 	}
 }
 
+// A NON-capped fetch advances the cursor past the last booked bill (maxTime+1),
+// but a CAPPED fetch advances only TO maxTime so the boundary millisecond — which
+// the cap may have split across a same-ms group — is re-read next cycle. This is
+// the cursor-side complement of the adapter's fail-closed cap: a capped/truncated
+// page is not a safe contiguous prefix at its final millisecond.
+func TestOKXCashflowJournalCappedAdvancesOnlyToMaxTime(t *testing.T) {
+	mk := func(capped bool) CashflowJournalState {
+		db := newCashflowJournalTestDB(t)
+		key := newOKXJournalKey()
+		base := CashflowJournalState{FillsSinceMs: 100, BaselineSet: true}
+		if err := db.UpsertCashflowJournalState(key.Platform, key.Account, base); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		res := okxCashflowJournalFetchResult{
+			Key: key, State: base, StateFound: true, BillsFetched: true, Capped: capped,
+			Bills: []okxBillRecord{
+				{BillID: "a", TimeMs: 150, Ccy: "USDT", Type: "2", BalChg: 5},
+				{BillID: "b", TimeMs: 200, Ccy: "USDT", Type: "2", BalChg: 5}, // maxTime = 200
+			},
+		}
+		return ingestOKXCashflowJournalEvents(db, res, cashflowCutoffAll)
+	}
+	if st := mk(false); st.FillsSinceMs != 201 {
+		t.Errorf("non-capped: cursor = %d, want 201 (maxTime+1)", st.FillsSinceMs)
+	}
+	if st := mk(true); st.FillsSinceMs != 200 {
+		t.Errorf("capped: cursor = %d, want 200 (maxTime — boundary ms re-read next cycle)", st.FillsSinceMs)
+	}
+}
+
+// A capped cycle whose booked bills all share one millisecond must NOT strand the
+// truncated same-ms siblings: the cursor stays at that ms, and a later non-capped
+// cycle re-reads it and books the previously-truncated sibling (dedup absorbs the
+// re-read of the already-booked ones). Covers the single-ms-overflow and
+// max_bills-truncation must-survive cases end to end.
+func TestOKXCashflowJournalCappedSameMsSiblingNotStranded(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := newOKXJournalKey()
+	base := CashflowJournalState{FillsSinceMs: 100, BaselineSet: true}
+	if err := db.UpsertCashflowJournalState(key.Platform, key.Account, base); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Cycle 1: a capped fetch returns only the first slice of a >page_limit block
+	// all at ts=150. The cursor must stay at 150, not advance to 151.
+	c1 := okxCashflowJournalFetchResult{
+		Key: key, State: base, StateFound: true, BillsFetched: true, Capped: true,
+		Bills: []okxBillRecord{
+			{BillID: "s1", TimeMs: 150, Ccy: "USDT", Type: "2", BalChg: 1},
+			{BillID: "s2", TimeMs: 150, Ccy: "USDT", Type: "2", BalChg: 1},
+			{BillID: "s3", TimeMs: 150, Ccy: "USDT", Type: "2", BalChg: 1},
+		},
+	}
+	st1 := ingestOKXCashflowJournalEvents(db, c1, cashflowCutoffAll)
+	if st1.FillsSinceMs != 150 {
+		t.Fatalf("capped cycle: cursor = %d, want 150 (must re-read the boundary ms)", st1.FillsSinceMs)
+	}
+
+	// Cycle 2: the block has cleared (no longer capped). Re-fetch from 150 returns
+	// the three already-booked siblings (deduped) PLUS the previously-truncated
+	// sibling s4 (also ts=150) and a newer bill at 200. s4 must be booked — it was
+	// stranded behind cursor 151 under the pre-fix maxTime+1 advance.
+	c2 := okxCashflowJournalFetchResult{
+		Key: key, State: st1, StateFound: true, BillsFetched: true, Capped: false,
+		Bills: []okxBillRecord{
+			{BillID: "s1", TimeMs: 150, Ccy: "USDT", Type: "2", BalChg: 1}, // dup
+			{BillID: "s2", TimeMs: 150, Ccy: "USDT", Type: "2", BalChg: 1}, // dup
+			{BillID: "s3", TimeMs: 150, Ccy: "USDT", Type: "2", BalChg: 1}, // dup
+			{BillID: "s4", TimeMs: 150, Ccy: "USDT", Type: "2", BalChg: 1}, // the stranded sibling
+			{BillID: "n1", TimeMs: 200, Ccy: "USDT", Type: "2", BalChg: 7},
+		},
+	}
+	st2 := ingestOKXCashflowJournalEvents(db, c2, cashflowCutoffAll)
+	if st2.FillsSinceMs != 201 {
+		t.Errorf("cleared cycle: cursor = %d, want 201", st2.FillsSinceMs)
+	}
+	sum, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	// 4 same-ms siblings (each +1, dedup keeps each once) + 1 newer (+7) = 11.
+	if math.Abs(sum-11) > 1e-9 {
+		t.Errorf("same-ms sibling stranded or double-counted: sum = %v, want 11", sum)
+	}
+}
+
 // An unclassified bill (unknown type) latches incomplete AND still books its
 // authoritative balChg so the running drift surfaces it.
 func TestOKXCashflowJournalUnclassifiedLatchesIncomplete(t *testing.T) {

--- a/scheduler/okx_cashflow_journal_test.go
+++ b/scheduler/okx_cashflow_journal_test.go
@@ -59,20 +59,6 @@ func TestOKXBillDedupID(t *testing.T) {
 	}
 }
 
-func TestSumOKXAccountUPnL(t *testing.T) {
-	positions := []OKXPosition{
-		{Coin: "BTC", UnrealizedPnL: 12.5},
-		{Coin: "ETH", UnrealizedPnL: -4.0},
-		{Coin: "SOL", UnrealizedPnL: 0},
-	}
-	if got, want := sumOKXAccountUPnL(positions), 8.5; math.Abs(got-want) > 1e-9 {
-		t.Errorf("sumOKXAccountUPnL = %v, want %v", got, want)
-	}
-	if got := sumOKXAccountUPnL(nil); got != 0 {
-		t.Errorf("nil positions = %v, want 0", got)
-	}
-}
-
 func newOKXJournalKey() SharedWalletKey {
 	return SharedWalletKey{Platform: "okx", Account: "okx-api-key-123"}
 }

--- a/scheduler/okx_cashflow_journal_test.go
+++ b/scheduler/okx_cashflow_journal_test.go
@@ -262,6 +262,57 @@ func TestOKXCashflowJournalCappedSameMsSiblingNotStranded(t *testing.T) {
 	}
 }
 
+// Budget-exhaustion case: a capped fetch can return an incomplete prefix whose
+// UNFETCHED tail is at NEWER timestamps (ts > maxTime), not just same-ms. The
+// cursor must not advance to maxTime+1, and a later cleared cycle must re-read
+// from maxTime and book that newer tail. (The adapter now reports capped=True on
+// loop-budget exhaustion; the Go side only sees res.Capped, so the cursor
+// discipline is identical regardless of WHY the fetch was capped.)
+func TestOKXCashflowJournalCappedNewerTailNotStranded(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := newOKXJournalKey()
+	base := CashflowJournalState{FillsSinceMs: 100, BaselineSet: true}
+	if err := db.UpsertCashflowJournalState(key.Platform, key.Account, base); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Cycle 1: capped prefix ending at ts=160. The feed actually has more bills at
+	// ts=170/180 (the budget-exhausted tail) not returned this cycle.
+	c1 := okxCashflowJournalFetchResult{
+		Key: key, State: base, StateFound: true, BillsFetched: true, Capped: true,
+		Bills: []okxBillRecord{
+			{BillID: "a", TimeMs: 150, Ccy: "USDT", Type: "2", BalChg: 2},
+			{BillID: "b", TimeMs: 160, Ccy: "USDT", Type: "2", BalChg: 2},
+		},
+	}
+	st1 := ingestOKXCashflowJournalEvents(db, c1, cashflowCutoffAll)
+	if st1.FillsSinceMs != 160 {
+		t.Fatalf("capped cycle: cursor = %d, want 160 (must not pass the unfetched newer tail)", st1.FillsSinceMs)
+	}
+
+	// Cycle 2: feed drained (not capped). Re-fetch from 160 returns the boundary
+	// bill b (dup) plus the previously-stranded newer tail at 170/180.
+	c2 := okxCashflowJournalFetchResult{
+		Key: key, State: st1, StateFound: true, BillsFetched: true, Capped: false,
+		Bills: []okxBillRecord{
+			{BillID: "b", TimeMs: 160, Ccy: "USDT", Type: "2", BalChg: 2}, // dup
+			{BillID: "c", TimeMs: 170, Ccy: "USDT", Type: "2", BalChg: 3}, // stranded tail
+			{BillID: "d", TimeMs: 180, Ccy: "USDT", Type: "2", BalChg: 4}, // stranded tail
+		},
+	}
+	st2 := ingestOKXCashflowJournalEvents(db, c2, cashflowCutoffAll)
+	if st2.FillsSinceMs != 181 {
+		t.Errorf("drained cycle: cursor = %d, want 181", st2.FillsSinceMs)
+	}
+	sum, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	if math.Abs(sum-11) > 1e-9 { // 2 + 2 + 3 + 4, b booked once
+		t.Errorf("newer tail stranded or double-counted: sum = %v, want 11", sum)
+	}
+}
+
 // An unclassified bill (unknown type) latches incomplete AND still books its
 // authoritative balChg so the running drift surfaces it.
 func TestOKXCashflowJournalUnclassifiedLatchesIncomplete(t *testing.T) {

--- a/scheduler/okx_cashflow_journal_test.go
+++ b/scheduler/okx_cashflow_journal_test.go
@@ -1,0 +1,359 @@
+package main
+
+import (
+	"errors"
+	"math"
+	"testing"
+	"time"
+)
+
+// #1105 OKX exchange-sourced cash-flow journal (shadow phase): the bills
+// settled-cash convention (balChg authoritative, USDT-only, fail-closed on
+// unclassified bills), dedup, single-stream cursor discipline, snapshot
+// bounding, baseline anchoring, and usability gating.
+
+// A USDT bill's settled-cash delta is its authoritative balChg (already nets
+// pnl/fee/funding/transfer). A known type is classifiable; an unknown type
+// still books balChg but is NOT known (latches incomplete); a non-USDT bill
+// contributes $0 and is never known.
+func TestOKXBillSettledDelta(t *testing.T) {
+	cases := []struct {
+		name      string
+		bill      okxBillRecord
+		wantDelta float64
+		wantKind  string
+		wantKnown bool
+	}{
+		{"USDT trade pnl-fee net", okxBillRecord{Ccy: "USDT", Type: "2", BalChg: 19.7, Pnl: 20, Fee: 0.3}, 19.7, "trade", true},
+		{"USDT funding receipt", okxBillRecord{Ccy: "USDT", Type: "8", BalChg: -1.25}, -1.25, "funding_fee", true},
+		{"USDT transfer in", okxBillRecord{Ccy: "USDT", Type: "1", BalChg: 100}, 100, "transfer", true},
+		{"USDT maker rebate (positive balChg)", okxBillRecord{Ccy: "USDT", Type: "2", BalChg: 0.1, Fee: -0.1}, 0.1, "trade", true},
+		{"empty ccy treated as settlement", okxBillRecord{Ccy: "", Type: "8", BalChg: -2}, -2, "funding_fee", true},
+		{"unknown type books balChg but not known", okxBillRecord{Ccy: "USDT", Type: "999", BalChg: 5}, 5, "type_999", false},
+		{"non-USDT bill contributes 0 and not known", okxBillRecord{Ccy: "BTC", Type: "2", BalChg: 0.001}, 0, "nonsettle_btc", false},
+	}
+	for _, tc := range cases {
+		gotDelta, gotKind, gotKnown := okxBillSettledDelta(tc.bill)
+		if math.Abs(gotDelta-tc.wantDelta) > 1e-9 || gotKind != tc.wantKind || gotKnown != tc.wantKnown {
+			t.Errorf("%s: okxBillSettledDelta = (%v,%q,%v), want (%v,%q,%v)",
+				tc.name, gotDelta, gotKind, gotKnown, tc.wantDelta, tc.wantKind, tc.wantKnown)
+		}
+	}
+}
+
+// billId is the canonical key; the type:ts:tradeId form is the fallback when
+// billId is absent or "0". Namespaced "okxbill:" so it can never collide with
+// the HL fill/funding/transfer namespaces in the shared table.
+func TestOKXBillDedupID(t *testing.T) {
+	withID := okxBillRecord{BillID: "374241568037822465", Type: "2", TimeMs: 1700000000000, TradeID: "tx1"}
+	if got, want := okxBillDedupID(withID), "okxbill:374241568037822465"; got != want {
+		t.Errorf("billId present: got %q, want %q", got, want)
+	}
+	zeroID := okxBillRecord{BillID: "0", Type: "8", TimeMs: 1700000000001, TradeID: "tx2"}
+	if got, want := okxBillDedupID(zeroID), "okxbill:8:1700000000001:tx2"; got != want {
+		t.Errorf("billId zero: got %q, want %q", got, want)
+	}
+	emptyID := okxBillRecord{Type: "1", TimeMs: 1700000000002}
+	if got, want := okxBillDedupID(emptyID), "okxbill:1:1700000000002:"; got != want {
+		t.Errorf("billId empty: got %q, want %q", got, want)
+	}
+}
+
+func TestSumOKXAccountUPnL(t *testing.T) {
+	positions := []OKXPosition{
+		{Coin: "BTC", UnrealizedPnL: 12.5},
+		{Coin: "ETH", UnrealizedPnL: -4.0},
+		{Coin: "SOL", UnrealizedPnL: 0},
+	}
+	if got, want := sumOKXAccountUPnL(positions), 8.5; math.Abs(got-want) > 1e-9 {
+		t.Errorf("sumOKXAccountUPnL = %v, want %v", got, want)
+	}
+	if got := sumOKXAccountUPnL(nil); got != 0 {
+		t.Errorf("nil positions = %v, want 0", got)
+	}
+}
+
+func newOKXJournalKey() SharedWalletKey {
+	return SharedWalletKey{Platform: "okx", Account: "okx-api-key-123"}
+}
+
+// First contact anchors the baseline to the supplied eq/uPnL snapshot and the
+// bills cursor to now, fetching NO history; OKX uses only the FillsSinceMs
+// cursor (funding/transfers stay 0).
+func TestOKXCashflowJournalBaselineAnchor(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := newOKXJournalKey()
+	now := time.UnixMilli(1700000000000).UTC()
+
+	res := fetchOKXCashflowJournalEvents(db, key, 5000.0, 12.5, now)
+	if !res.StateFound || res.BillsFetched {
+		t.Fatalf("baseline cycle: StateFound=%v BillsFetched=%v, want true/false", res.StateFound, res.BillsFetched)
+	}
+	st, found, err := db.GetCashflowJournalState(key.Platform, key.Account)
+	if err != nil || !found {
+		t.Fatalf("state after baseline: found=%v err=%v", found, err)
+	}
+	if !st.BaselineSet || st.BaselineAccountValue != 5000.0 || st.BaselineUPnL != 12.5 {
+		t.Errorf("baseline not anchored: %+v", st)
+	}
+	if st.FillsSinceMs != now.UnixMilli() {
+		t.Errorf("bills cursor not anchored at now: %d, want %d", st.FillsSinceMs, now.UnixMilli())
+	}
+	if st.FundingSinceMs != 0 || st.TransfersSinceMs != 0 {
+		t.Errorf("OKX must leave funding/transfers cursors unused: %+v", st)
+	}
+}
+
+// End-to-end fetch -> ingest -> sum with a stubbed bills feed. The settled sum
+// is Σ balChg over USDT bills; the expected equity closes the loop against a
+// hand-computed eq.
+func TestOKXCashflowJournalIngestAndExpectedEquity(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := newOKXJournalKey()
+	t0 := time.UnixMilli(1700000000000).UTC()
+
+	// Anchor at eq=1000, uPnL=0, cursor t0.
+	if r := fetchOKXCashflowJournalEvents(db, key, 1000.0, 0.0, t0); !r.StateFound {
+		t.Fatal("baseline init failed")
+	}
+
+	orig := fetchOKXAccountBills
+	defer func() { fetchOKXAccountBills = orig }()
+	fetchOKXAccountBills = func(sinceMs int64) ([]okxBillRecord, bool, error) {
+		return []okxBillRecord{
+			{BillID: "b1", TimeMs: t0.UnixMilli() + 10, Ccy: "USDT", Type: "2", BalChg: -0.5, Pnl: 0, Fee: 0.5}, // open fee
+			{BillID: "b2", TimeMs: t0.UnixMilli() + 20, Ccy: "USDT", Type: "2", BalChg: 19.7, Pnl: 20, Fee: 0.3},
+			{BillID: "b3", TimeMs: t0.UnixMilli() + 5, Ccy: "USDT", Type: "8", BalChg: -1.0}, // funding
+			{BillID: "b4", TimeMs: t0.UnixMilli() + 6, Ccy: "USDT", Type: "1", BalChg: 100},  // transfer in
+			{BillID: "b5", TimeMs: t0.UnixMilli() + 7, Ccy: "USDT", Type: "1", BalChg: -51},  // transfer out
+		}, false, nil
+	}
+
+	snap := t0.Add(time.Minute)
+	res := fetchOKXCashflowJournalEvents(db, key, 1072.2, 5.0, snap)
+	if !res.BillsFetched || res.Capped {
+		t.Fatalf("expected bills fetched, not capped: %+v", res)
+	}
+	st := ingestOKXCashflowJournalEvents(db, res, snap.UnixMilli())
+	if st.Incomplete {
+		t.Error("all bills classified — journal must not be marked incomplete")
+	}
+
+	settled, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	const wantSettled = -0.5 + 19.7 - 1.0 + 100 - 51 // 67.2
+	if math.Abs(settled-wantSettled) > 1e-9 {
+		t.Fatalf("settled sum = %v, want %v", settled, wantSettled)
+	}
+
+	expected := cashflowJournalExpectedEquity(st.BaselineAccountValue, st.BaselineUPnL, settled, res.CurrentUPnL)
+	if math.Abs(expected-1072.2) > 1e-9 {
+		t.Errorf("expected equity = %v, want 1072.2", expected)
+	}
+	if drift := res.AccountValue - expected; math.Abs(drift) > 1e-9 {
+		t.Errorf("journal drift = %v, want ~0", drift)
+	}
+	// Single cursor advanced past the latest bill (t0+20).
+	if st.FillsSinceMs != t0.UnixMilli()+20+1 {
+		t.Errorf("bills cursor = %d, want %d", st.FillsSinceMs, t0.UnixMilli()+21)
+	}
+}
+
+// A bill settled AFTER the eq snapshot is deferred to next cycle: not booked,
+// cursor not advanced past it.
+func TestOKXCashflowJournalSnapshotBound(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := newOKXJournalKey()
+	base := CashflowJournalState{FillsSinceMs: 100, BaselineSet: true}
+	if err := db.UpsertCashflowJournalState(key.Platform, key.Account, base); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	res := okxCashflowJournalFetchResult{
+		Key: key, State: base, StateFound: true, BillsFetched: true,
+		Bills: []okxBillRecord{
+			{BillID: "in", TimeMs: 150, Ccy: "USDT", Type: "2", BalChg: 10},
+			{BillID: "after", TimeMs: 250, Ccy: "USDT", Type: "2", BalChg: 999}, // settled after cutoff
+		},
+	}
+	st := ingestOKXCashflowJournalEvents(db, res, 200) // cutoff 200
+	sum, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	if math.Abs(sum-10) > 1e-9 {
+		t.Errorf("post-cutoff bill leaked: sum = %v, want 10", sum)
+	}
+	if st.FillsSinceMs != 151 {
+		t.Errorf("cursor must stop before the deferred bill: got %d, want 151", st.FillsSinceMs)
+	}
+}
+
+// An unclassified bill (unknown type) latches incomplete AND still books its
+// authoritative balChg so the running drift surfaces it.
+func TestOKXCashflowJournalUnclassifiedLatchesIncomplete(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := newOKXJournalKey()
+	base := CashflowJournalState{FillsSinceMs: 100, BaselineSet: true}
+	if err := db.UpsertCashflowJournalState(key.Platform, key.Account, base); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	res := okxCashflowJournalFetchResult{
+		Key: key, State: base, StateFound: true, BillsFetched: true,
+		Bills: []okxBillRecord{
+			{BillID: "u1", TimeMs: 150, Ccy: "USDT", Type: "999", BalChg: 7}, // unknown type
+		},
+	}
+	st := ingestOKXCashflowJournalEvents(db, res, cashflowCutoffAll)
+	if !st.Incomplete {
+		t.Error("unknown bill type must latch incomplete")
+	}
+	sum, _ := db.SumCashflowJournal(key.Platform, key.Account)
+	if math.Abs(sum-7) > 1e-9 {
+		t.Errorf("unknown-type balChg must still be booked (authoritative): sum = %v, want 7", sum)
+	}
+}
+
+// A non-USDT bill cannot reconcile against the USDT eq: it contributes $0,
+// latches incomplete, and does NOT corrupt the USDT settled sum.
+func TestOKXCashflowJournalNonSettlementCcyFailsClosed(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := newOKXJournalKey()
+	base := CashflowJournalState{FillsSinceMs: 100, BaselineSet: true}
+	if err := db.UpsertCashflowJournalState(key.Platform, key.Account, base); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	res := okxCashflowJournalFetchResult{
+		Key: key, State: base, StateFound: true, BillsFetched: true,
+		Bills: []okxBillRecord{
+			{BillID: "usdt", TimeMs: 150, Ccy: "USDT", Type: "2", BalChg: 10},
+			{BillID: "btcfee", TimeMs: 151, Ccy: "BTC", Type: "2", BalChg: 0.001},
+		},
+	}
+	st := ingestOKXCashflowJournalEvents(db, res, cashflowCutoffAll)
+	if !st.Incomplete {
+		t.Error("non-USDT bill must latch incomplete")
+	}
+	sum, _ := db.SumCashflowJournal(key.Platform, key.Account)
+	if math.Abs(sum-10) > 1e-9 {
+		t.Errorf("non-USDT balChg must not enter the USDT sum: sum = %v, want 10", sum)
+	}
+}
+
+// A bill insert failure halts the cursor at the failed bill so a crash can never
+// strand an un-booked event behind an advanced watermark.
+func TestOKXCashflowJournalHaltsCursorOnPersistFailure(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := newOKXJournalKey()
+	base := CashflowJournalState{FillsSinceMs: 100, BaselineSet: true}
+	if err := db.UpsertCashflowJournalState(key.Platform, key.Account, base); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Close the DB so every insert fails; the cursor must not advance.
+	db.Close()
+	res := okxCashflowJournalFetchResult{
+		Key: key, State: base, StateFound: true, BillsFetched: true,
+		Bills: []okxBillRecord{{BillID: "b", TimeMs: 150, Ccy: "USDT", Type: "2", BalChg: 10}},
+	}
+	st := ingestOKXCashflowJournalEvents(db, res, cashflowCutoffAll)
+	if st.FillsSinceMs != 100 {
+		t.Errorf("cursor advanced past an un-booked bill: got %d, want 100", st.FillsSinceMs)
+	}
+}
+
+// reconcile is usable only when bills fetched, not capped, and not incomplete.
+func TestOKXCashflowJournalReconcileUsability(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := newOKXJournalKey()
+	t0 := time.UnixMilli(1700000000000).UTC()
+	if r := fetchOKXCashflowJournalEvents(db, key, 1000.0, 0.0, t0); !r.StateFound {
+		t.Fatal("baseline init failed")
+	}
+	orig := fetchOKXAccountBills
+	defer func() { fetchOKXAccountBills = orig }()
+
+	// Clean, classifiable bill → usable.
+	fetchOKXAccountBills = func(int64) ([]okxBillRecord, bool, error) {
+		return []okxBillRecord{{BillID: "b1", TimeMs: t0.UnixMilli() + 10, Ccy: "USDT", Type: "2", BalChg: 5}}, false, nil
+	}
+	snap := t0.Add(time.Minute)
+	rec := reconcileOKXCashflowJournal(db, key, 1005.0, 0.0, snap)
+	if rec == nil || !rec.Usable || rec.Incomplete {
+		t.Fatalf("clean cycle: rec=%+v, want usable & not incomplete", rec)
+	}
+	if math.Abs(rec.Drift) > 1e-9 {
+		t.Errorf("clean cycle drift = %v, want ~0", rec.Drift)
+	}
+
+	// Capped fetch → not usable even though a baseline exists.
+	fetchOKXAccountBills = func(int64) ([]okxBillRecord, bool, error) {
+		return []okxBillRecord{{BillID: "b2", TimeMs: snap.UnixMilli() + 10, Ccy: "USDT", Type: "2", BalChg: 1}}, true, nil
+	}
+	snap2 := snap.Add(time.Minute)
+	rec2 := reconcileOKXCashflowJournal(db, key, 1006.0, 0.0, snap2)
+	if rec2 == nil || rec2.Usable {
+		t.Fatalf("capped cycle: rec=%+v, want not usable", rec2)
+	}
+
+	// Fetch error → nil-ish: StateFound true but bills not fetched, not usable.
+	fetchOKXAccountBills = func(int64) ([]okxBillRecord, bool, error) {
+		return nil, false, errors.New("okx bills 500")
+	}
+	snap3 := snap2.Add(time.Minute)
+	rec3 := reconcileOKXCashflowJournal(db, key, 1007.0, 0.0, snap3)
+	if rec3 == nil || rec3.Usable {
+		t.Fatalf("fetch-error cycle: rec=%+v, want not usable", rec3)
+	}
+}
+
+// reconcile returns nil for a non-OKX key (HL stays on its own path).
+func TestOKXCashflowJournalRejectsNonOKXKey(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	hlKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	if rec := reconcileOKXCashflowJournal(db, hlKey, 1000, 0, time.Now()); rec != nil {
+		t.Errorf("non-OKX key must return nil, got %+v", rec)
+	}
+}
+
+// The shadow logger never mutates driftResults — the OKX alarm stays on the
+// capital-weight split.
+func TestOKXCashflowJournalShadowDoesNotMutate(t *testing.T) {
+	key := newOKXJournalKey()
+	results := []sharedWalletDriftResult{
+		{Key: key, Drift: 1.23, Balance: 1000, MemberSum: 998.77},
+	}
+	rec := &cashflowJournalReconcile{Key: key, AccountValue: 1000, ExpectedEquity: 1002.5, Drift: -2.5, Usable: true}
+	logOKXCashflowJournalShadow(results, key, rec)
+	if results[0].Drift != 1.23 || results[0].Basis != "" || results[0].ExpectedEquity != 0 {
+		t.Errorf("shadow log mutated the drift result: %+v", results[0])
+	}
+}
+
+// parseOKXBillsOutput follows the same 5-case matrix as the other OKX fetch
+// parsers: clean success, exit-0-with-error, exit-nonzero-with-error,
+// exit-nonzero-no-error, and unparseable.
+func TestParseOKXBillsOutput(t *testing.T) {
+	clean := []byte(`{"bills":[{"bill_id":"b1","ts_ms":1700000000000,"ccy":"USDT","type":"2","bal_chg":19.7,"pnl":20,"fee":0.3}],"capped":false,"platform":"okx","timestamp":"t"}`)
+	res, _, err := parseOKXBillsOutput(clean, "", nil)
+	if err != nil || res == nil || len(res.Bills) != 1 || res.Bills[0].BillID != "b1" || res.Bills[0].BalChg != 19.7 {
+		t.Fatalf("clean: res=%+v err=%v", res, err)
+	}
+	if res.Capped {
+		t.Error("clean: capped should be false")
+	}
+
+	errEnvelope := []byte(`{"bills":[],"capped":false,"platform":"okx","timestamp":"t","error":"not live"}`)
+	if _, _, err := parseOKXBillsOutput(errEnvelope, "", errors.New("exit 1")); err == nil {
+		t.Error("error envelope must surface a non-nil error")
+	}
+	if _, _, err := parseOKXBillsOutput(errEnvelope, "", nil); err == nil {
+		t.Error("exit-0-with-error must surface a non-nil error")
+	}
+	if _, _, err := parseOKXBillsOutput([]byte(`{"bills":[]}`), "", errors.New("exit 1")); err == nil {
+		t.Error("exit-nonzero with no error field must be treated as failure")
+	}
+	if _, _, err := parseOKXBillsOutput([]byte(`not json`), "boom", errors.New("exit 2")); err == nil {
+		t.Error("unparseable output must error")
+	}
+}

--- a/shared_scripts/fetch_okx_balance.py
+++ b/shared_scripts/fetch_okx_balance.py
@@ -32,7 +32,13 @@ def main():
         if not adapter.is_live:
             _emit_error("OKX adapter not live — set OKX_API_KEY / OKX_API_SECRET / OKX_PASSPHRASE")
             return
-        balance = float(adapter.get_account_balance() or 0.0)
+        # #1105: equity AND unrealized PnL from a SINGLE fetch_balance read so the
+        # cash-flow journal reconciles a coherent eq/uPnL snapshot (no intra-cycle
+        # jitter from a separately-timed fetch_positions call). `balance` keeps its
+        # #360 meaning (USDT eq) so the existing shared-wallet split is unchanged.
+        eq, upnl = adapter.get_account_equity_and_upnl()
+        balance = float(eq or 0.0)
+        unrealized_pnl = float(upnl or 0.0)
     except Exception as e:
         traceback.print_exc(file=sys.stderr)
         _emit_error(str(e))
@@ -40,6 +46,7 @@ def main():
 
     print(json.dumps({
         "balance": balance,
+        "unrealized_pnl": unrealized_pnl,
         "platform": "okx",
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }))
@@ -48,6 +55,7 @@ def main():
 def _emit_error(message):
     print(json.dumps({
         "balance": 0.0,
+        "unrealized_pnl": 0.0,
         "platform": "okx",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "error": message,

--- a/shared_scripts/fetch_okx_bills.py
+++ b/shared_scripts/fetch_okx_bills.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+OKX live account-bills fetcher (issue #1105 — exchange-sourced cash-flow journal,
+shadow phase / Phase 3a of #1100).
+
+Emits every OKX account bill settled since a cursor timestamp. An OKX account
+bill is the venue's record of a single settled-cash movement — trade PnL, fee,
+funding, transfer, deposit, withdrawal — each carrying ``balChg`` (the signed
+change to the settled cash balance). This single feed is therefore the COMPLETE
+settled-cash-flow source the Go cash-flow journal reconstructs the wallet total
+from (mirroring the HL journal, but single-stream because ``balChg`` already
+nets every component — no per-fill fee arithmetic).
+
+Thin pump: all mapping / summing / fail-closed logic lives in tested Go
+(okx_cashflow_journal.go); this script only pages OKX bills via the adapter and
+shapes them to JSON.
+
+Usage:
+    fetch_okx_bills.py --since-ms <int>
+
+Requires OKX_API_KEY / OKX_API_SECRET / OKX_PASSPHRASE. Output:
+``{"bills": [{"bill_id","ts_ms","ccy","type","sub_type","bal_chg","pnl","fee",
+  "inst_id","trade_id"}, ...], "capped": false, "platform": "okx",
+  "timestamp": ...}``
+Bills are oldest-first; ``capped`` is true when the adapter hit its safety page
+cap before exhausting the feed (the Go journal treats that cycle as not-usable).
+"""
+
+import argparse
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "platforms", "okx"))
+
+
+def _parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Fetch OKX account bills since a cursor.")
+    parser.add_argument(
+        "--since-ms",
+        type=int,
+        default=0,
+        help="Only return bills settled at or after this epoch-millisecond cursor.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = _parse_args(argv)
+    try:
+        from adapter import OKXExchangeAdapter
+        adapter = OKXExchangeAdapter()
+        if not adapter.is_live:
+            _emit_error("OKX adapter not live — set OKX_API_KEY / OKX_API_SECRET / OKX_PASSPHRASE")
+            return
+        bills, capped = adapter.get_account_bills(since_ms=args.since_ms)
+    except Exception as e:
+        traceback.print_exc(file=sys.stderr)
+        _emit_error(str(e))
+        return
+
+    print(json.dumps({
+        "bills": bills or [],
+        "capped": bool(capped),
+        "platform": "okx",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }))
+
+
+def _emit_error(message):
+    print(json.dumps({
+        "bills": [],
+        "capped": False,
+        "platform": "okx",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "error": message,
+    }))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/shared_scripts/test_fetch_okx_bills.py
+++ b/shared_scripts/test_fetch_okx_bills.py
@@ -1,0 +1,128 @@
+"""Tests for fetch_okx_bills.py — OKX account-bills fetcher feeding the #1105
+exchange-sourced cash-flow journal (shadow phase / Phase 3a of #1100).
+
+The journal reconstructs the wallet TOTAL from this feed, so the script must
+relay the adapter's bills + cap flag truthfully and emit a JSON envelope on
+every path (success and error), exit 1 on error — the Go-side parser reads the
+envelope regardless of exit code.
+"""
+
+import builtins
+import importlib.util
+import json
+import os
+import sys
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _run_script(bills_or_exc, capped=False, is_live=True, argv=None):
+    """Invoke fetch_okx_bills.main() with a mocked adapter.
+
+    bills_or_exc may be a list of bill dicts (returned by
+    adapter.get_account_bills as (bills, capped)) or an Exception. Returns
+    (parsed_stdout_json, exit_code).
+    """
+    script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               "fetch_okx_bills.py")
+    spec = importlib.util.spec_from_file_location("fetch_okx_bills", script_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    mock_adapter_cls = MagicMock()
+    mock_adapter = MagicMock()
+    mock_adapter.is_live = is_live
+    mock_adapter_cls.return_value = mock_adapter
+    if isinstance(bills_or_exc, Exception):
+        mock_adapter.get_account_bills.side_effect = bills_or_exc
+    else:
+        mock_adapter.get_account_bills.return_value = (bills_or_exc, capped)
+
+    captured = StringIO()
+    exit_code = {"value": 0}
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "adapter":
+            fake_mod = MagicMock()
+            fake_mod.OKXExchangeAdapter = mock_adapter_cls
+            return fake_mod
+        return original_import(name, *args, **kwargs)
+
+    def mock_exit(code=0):
+        exit_code["value"] = code
+        raise SystemExit(code)
+
+    with patch("builtins.__import__", side_effect=mock_import), \
+         patch("sys.stdout", captured), \
+         patch("sys.argv", argv or ["fetch_okx_bills.py", "--since-ms=123"]), \
+         patch.object(mod.sys, "exit", side_effect=mock_exit):
+        try:
+            mod.main()
+        except SystemExit:
+            pass
+
+    raw = captured.getvalue().strip()
+    parsed = json.loads(raw) if raw else {}
+    return parsed, exit_code["value"], mock_adapter
+
+
+class TestSuccess:
+    def test_relays_bills(self):
+        bills = [
+            {"bill_id": "b1", "ts_ms": 100, "ccy": "USDT", "type": "2", "bal_chg": 19.7},
+            {"bill_id": "b2", "ts_ms": 200, "ccy": "USDT", "type": "8", "bal_chg": -1.0},
+        ]
+        out, code, _ = _run_script(bills)
+        assert code == 0
+        assert out["bills"] == bills
+        assert out["capped"] is False
+        assert "error" not in out
+
+    def test_passes_since_ms_to_adapter(self):
+        out, code, adapter = _run_script([], argv=["fetch_okx_bills.py", "--since-ms=987654321"])
+        assert code == 0
+        adapter.get_account_bills.assert_called_once_with(since_ms=987654321)
+
+    def test_capped_flag_relayed(self):
+        out, code, _ = _run_script([{"bill_id": "b", "ts_ms": 1, "bal_chg": 1.0}], capped=True)
+        assert code == 0
+        assert out["capped"] is True
+
+    def test_empty_bills(self):
+        out, code, _ = _run_script([])
+        assert code == 0
+        assert out["bills"] == []
+        assert out["capped"] is False
+        assert "error" not in out
+
+
+class TestFailurePaths:
+    def test_non_live_adapter(self):
+        out, code, _ = _run_script([], is_live=False)
+        assert code == 1
+        assert "OKX_API_KEY" in out["error"]
+        assert out["bills"] == []
+
+    def test_adapter_raises(self):
+        out, code, _ = _run_script(RuntimeError("OKX 503 Service Unavailable"))
+        assert code == 1
+        assert "OKX 503" in out["error"]
+        assert out["bills"] == []
+        assert out["capped"] is False
+
+
+class TestArgParsing:
+    def test_since_ms_defaults_to_zero(self):
+        mod_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fetch_okx_bills.py")
+        spec = importlib.util.spec_from_file_location("fetch_okx_bills_args", mod_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        assert mod._parse_args([]).since_ms == 0
+        assert mod._parse_args(["--since-ms=42"]).since_ms == 42
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What & why

Phase 3a of #1100. Extends the exchange-sourced cash-flow journal from Hyperliquid to **OKX shared wallets in SHADOW mode**. The OKX wallet TOTAL is reconstructed from OKX's account-bills feed and reconciled against `eq`, logged next to the live capital-weight drift every cycle — but it **never drives the OKX alarm**, which stays on the #918 capital-weight split. Flipping the OKX alarm onto the journal is **Phase 3b**, gated on this shadow log proving the OKX feed/field in production first (mirrors HL's #1103 shadow → #1104 flip two-step). **HL and TopStep paths untouched.**

This scoping matches the issue's "per-cycle shadow log before flipping its alarm" criterion and keeps a money-path reconciliation on a second venue, with feed semantics that can't be verified offline, fully fail-closed until an operator validates it.

## Design

Reuses the platform-generic journal machinery built for HL (children 1–2): the `cashflow_journal` / `cashflow_journal_state` tables (keyed by `(platform, account)`), durable cursor, adoption baseline, per-event dedup, halt-on-persist-failure, snapshot-bounded ingestion, the `incomplete` fail-closed latch, and the shared equity equation. **No schema change.**

**Deliberate divergence from HL's three-stream shape.** HL reconstructs settled cash from three streams (fills + funding + transfers) and computes each fill's delta as gross-PnL minus the fee actually charged. OKX exposes a **single** settled-cash-flow source — the account-bills feed — where every balance change carries `balChg`, the signed settled-cash delta already netting trade PnL, fees, funding, transfers, deposits and withdrawals. So OKX needs no per-fill fee arithmetic: `balChg` IS the settled delta. Venue `pnl`/`fee` are attribution metadata only, never summed (same gross-PnL discipline as HL). Because OKX is single-stream, only the `FillsSinceMs` cursor is used (funding/transfers unused).

**Reconciled field is OKX `eq`** (ccxt `balance["total"]["USDT"]`, equity = cash + uPnL — the same field `fetch_okx_balance.py` reports and the #918 split already reconciles). The journal is **USDT-settlement only**: a non-USDT bill with non-zero `balChg`, or an unmapped bill `type`, latches the journal `incomplete` (fail closed) so the shadow log flags it for operator review before any Phase-3b flip. `balChg` is still booked for an unknown USDT type (authoritative) so the running drift surfaces it.

**Fail-closed fallback for OKX is the #918 capital-weight split** — OKX has no trade-ledger basis to fall back to (unlike HL). Unchanged this phase.

## Changes

- `platforms/okx/adapter.py`: `get_account_bills(since_ms)` — pages OKX bills via ccxt `fetch_ledger`, oldest-first, with a safety page cap (`capped` → not-usable that cycle); `_normalize_okx_bill` pure shaper.
- `shared_scripts/fetch_okx_bills.py`: thin ccxt-bills→JSON pump (`--since-ms`); all mapping/summing/fail-closed logic lives in tested Go.
- `scheduler/okx_cashflow_journal.go`: bill kind mapping, `balChg` settled-delta, dedup, fetch/ingest/reconcile, and the shadow logger (never mutates a `driftResult`).
- `scheduler/executor.go`: `RunOKXFetchBills` + `parseOKXBillsOutput` (same 5-case matrix as the other OKX fetch parsers).
- `scheduler/main.go`: per-cycle shadow call after the HL journal block, bounded to the eq/uPnL snapshot.

## Verification

- `go build` (binary, with ldflags), `go vet`, `gofmt -l` clean.
- `go test ./...` (full suite) and `go test -race` on the journal/executor: pass.
- New Go units: settled-delta convention (USDT/unknown-type/non-USDT), dedup, ingest cursor-advance + halt-on-persist-failure + snapshot cutoff, incomplete latch, non-USDT fail-closed, reconcile usability gating (clean/capped/fetch-error), shadow no-mutate, parser 5-case.
- Python (42 passed): adapter bills pagination / overlap-dedup / cap-truncation / no-forward-progress guard / paper-mode raise, normalizer shaping, and the fetcher-script JSON envelope on success + error paths.

## Notes / limits

- ccxt `fetch_ledger` reads OKX `/account/bills` (~7-day horizon). Steady per-cycle operation is well inside it; after a multi-day outage older bills fall outside the window and surface as journal drift in the shadow log (visible before any Phase-3b flip).
- The fetcher is a runtime subprocess (not a probed check script), so a Go/Python SHA skew degrades to a fail-closed fetch error (shadow logs it, OKX alarm unaffected) rather than a startup probe failure.

Closes #1105

LLM: Opus 4.8 | high | Harness: work-on-issue
