### PR TITLE
feat(#1106): TopStep shared-wallet cash-flow journal (shadow)

### DIFF
--- a/platforms/topstep/adapter.py
+++ b/platforms/topstep/adapter.py
@@ -207,6 +207,79 @@ class TopStepExchangeAdapter:
             })
         return positions
 
+    def get_account_equity_and_upnl(self):
+        """Return ``(equity, unrealized_pnl)`` for the configured account, in USD.
+
+        Used by the shared-wallet cash-flow journal (#1106). ``equity`` is the
+        account value (settled cash + unrealized PnL); ``unrealized_pnl`` is
+        ``equity − cashBalance`` from the SAME balance read so the journal
+        reconciles a coherent equity/uPnL snapshot with no intra-cycle jitter
+        (mirrors OKX ``get_account_equity_and_upnl``). Live mode only.
+
+        NOTE: the ``/v1/account/balance`` shape mirrors this adapter's existing
+        (unverified) TopStepX REST contract; confirm against the live venue
+        before any Phase-4b alarm flip (#1106).
+        """
+        if not self.is_live:
+            raise RuntimeError("get_account_equity_and_upnl requires live mode")
+        resp = self._session.get(
+            f"{API_BASE_URL}/v1/account/balance",
+            params={"accountId": self._account_id},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        equity = float(data.get("equity", 0))
+        # cashBalance is the settled cash; fall back to "balance" then to equity
+        # (uPnL 0) so a feed without an explicit cash field degrades to cash==equity
+        # rather than mis-stating uPnL.
+        cash = float(data.get("cashBalance", data.get("balance", equity)))
+        return equity, equity - cash
+
+    def get_account_fills(self, since_ms=0, limit=1000):
+        """Return ``(fills, capped)`` — settled trade fills at or after
+        ``since_ms``, oldest first (#1106).
+
+        Each fill: ``{"fill_id", "ts_ms", "symbol", "kind", "realized_pnl",
+        "fee"}``. ``realized_pnl`` is GROSS (0 for entry fills); ``fee`` is the
+        commission charged. ``capped`` is true when the page limit was hit (the
+        Go journal treats that cycle as not-usable). Live mode only.
+
+        NOTE: the ``/v1/account/fills`` shape mirrors this adapter's existing
+        (unverified) TopStepX REST contract; confirm against the live venue
+        before any Phase-4b alarm flip (#1106).
+        """
+        if not self.is_live:
+            raise RuntimeError("get_account_fills requires live mode")
+        resp = self._session.get(
+            f"{API_BASE_URL}/v1/account/fills",
+            params={
+                "accountId": self._account_id,
+                "sinceMs": int(since_ms),
+                "limit": int(limit),
+            },
+            timeout=15,
+        )
+        resp.raise_for_status()
+        raw = resp.json().get("fills", []) or []
+        fills = []
+        for f in raw:
+            try:
+                ts_ms = int(f.get("timestamp", f.get("ts_ms", 0)))
+            except (TypeError, ValueError):
+                continue
+            fills.append({
+                "fill_id": str(f.get("id", f.get("fill_id", ""))),
+                "ts_ms": ts_ms,
+                "symbol": (f.get("symbol") or "").upper(),
+                "kind": (f.get("kind") or "").lower(),
+                "realized_pnl": float(f.get("realizedPnl", f.get("realized_pnl", 0)) or 0),
+                "fee": float(f.get("fee", f.get("commission", 0)) or 0),
+            })
+        fills.sort(key=lambda x: x["ts_ms"])
+        capped = len(raw) >= int(limit)
+        return fills, capped
+
     # ─────────────────────────────────────────────
     # Yahoo Finance helpers (paper mode)
     # ─────────────────────────────────────────────

--- a/platforms/topstep/adapter.py
+++ b/platforms/topstep/adapter.py
@@ -38,6 +38,25 @@ CONTRACT_SPECS = {
 }
 
 
+def _normalize_topstep_fill(f):
+    """Shape one raw TopStep fill into the cash-flow journal record, or None if
+    its timestamp is unparseable (#1106). ``realized_pnl`` is GROSS; ``fee`` is
+    the commission. Tolerant of both camelCase venue keys and the snake_case
+    journal keys."""
+    try:
+        ts_ms = int(f.get("timestamp", f.get("ts_ms", 0)))
+    except (TypeError, ValueError):
+        return None
+    return {
+        "fill_id": str(f.get("id", f.get("fill_id", ""))),
+        "ts_ms": ts_ms,
+        "symbol": (f.get("symbol") or "").upper(),
+        "kind": (f.get("kind") or "").lower(),
+        "realized_pnl": float(f.get("realizedPnl", f.get("realized_pnl", 0)) or 0),
+        "fee": float(f.get("fee", f.get("commission", 0)) or 0),
+    }
+
+
 class TopStepExchangeAdapter:
     """
     Exchange adapter for TopStep prop trading (CME futures).
@@ -229,6 +248,12 @@ class TopStepExchangeAdapter:
         )
         resp.raise_for_status()
         data = resp.json()
+        # A missing "equity" field means a shape-mismatched 200 (the contract is
+        # unverified). RAISE rather than coerce to 0 — the Go side treats a
+        # non-positive equity as a fetch miss anyway, but raising here makes the
+        # error envelope carry a clear cause instead of a silent $0 (#1106 review).
+        if "equity" not in data:
+            raise ValueError("TopStep /v1/account/balance response missing 'equity' field")
         equity = float(data.get("equity", 0))
         # cashBalance is the settled cash; fall back to "balance" then to equity
         # (uPnL 0) so a feed without an explicit cash field degrades to cash==equity
@@ -236,14 +261,25 @@ class TopStepExchangeAdapter:
         cash = float(data.get("cashBalance", data.get("balance", equity)))
         return equity, equity - cash
 
-    def get_account_fills(self, since_ms=0, limit=1000):
+    def get_account_fills(self, since_ms=0, page_limit=100, max_fills=10000):
         """Return ``(fills, capped)`` — settled trade fills at or after
         ``since_ms``, oldest first (#1106).
 
         Each fill: ``{"fill_id", "ts_ms", "symbol", "kind", "realized_pnl",
         "fee"}``. ``realized_pnl`` is GROSS (0 for entry fills); ``fee`` is the
-        commission charged. ``capped`` is true when the page limit was hit (the
-        Go journal treats that cycle as not-usable). Live mode only.
+        commission charged. Live mode only.
+
+        Pages FORWARD by the ``sinceMs`` cursor until the feed is DRAINED (a page
+        shorter than ``page_limit``) — mirroring ``OKXExchangeAdapter.
+        get_account_bills``. ``capped`` is True ONLY when the feed was NOT proven
+        drained: the ``max_fills`` safety cap was hit, a single-millisecond block
+        exceeded ``page_limit`` (timestamp paging cannot step through it), or the
+        per-cycle iteration budget ran out. A naive ``len(page) >= limit`` test
+        would mark a venue page-capped backlog ``Usable`` while fills at/before the
+        snapshot are still missing → phantom journal drift in the shadow log (the
+        exact Phase-4b promotion signal). The cursor advances with a one-ms OVERLAP
+        (cursor = page's last ts) so a same-ms fill beyond the page cut is re-read
+        next page; ``collected`` dedups the overlap by fill id.
 
         NOTE: the ``/v1/account/fills`` shape mirrors this adapter's existing
         (unverified) TopStepX REST contract; confirm against the live venue
@@ -251,33 +287,55 @@ class TopStepExchangeAdapter:
         """
         if not self.is_live:
             raise RuntimeError("get_account_fills requires live mode")
-        resp = self._session.get(
-            f"{API_BASE_URL}/v1/account/fills",
-            params={
-                "accountId": self._account_id,
-                "sinceMs": int(since_ms),
-                "limit": int(limit),
-            },
-            timeout=15,
-        )
-        resp.raise_for_status()
-        raw = resp.json().get("fills", []) or []
-        fills = []
-        for f in raw:
-            try:
-                ts_ms = int(f.get("timestamp", f.get("ts_ms", 0)))
-            except (TypeError, ValueError):
-                continue
-            fills.append({
-                "fill_id": str(f.get("id", f.get("fill_id", ""))),
-                "ts_ms": ts_ms,
-                "symbol": (f.get("symbol") or "").upper(),
-                "kind": (f.get("kind") or "").lower(),
-                "realized_pnl": float(f.get("realizedPnl", f.get("realized_pnl", 0)) or 0),
-                "fee": float(f.get("fee", f.get("commission", 0)) or 0),
-            })
-        fills.sort(key=lambda x: x["ts_ms"])
-        capped = len(raw) >= int(limit)
+        collected = {}
+        cursor = int(since_ms or 0)
+        capped = False
+        for _ in range(max(1, max_fills // max(1, page_limit)) + 2):
+            resp = self._session.get(
+                f"{API_BASE_URL}/v1/account/fills",
+                params={
+                    "accountId": self._account_id,
+                    "sinceMs": cursor,
+                    "limit": int(page_limit),
+                },
+                timeout=15,
+            )
+            resp.raise_for_status()
+            page = resp.json().get("fills", []) or []
+            if not page:
+                break
+            before = len(collected)
+            page_last_ts = cursor
+            for f in page:
+                fill = _normalize_topstep_fill(f)
+                if fill is None:
+                    continue
+                if fill["ts_ms"] > page_last_ts:
+                    page_last_ts = fill["ts_ms"]
+                key = fill["fill_id"] or f"{fill['kind']}:{fill['ts_ms']}:{fill['symbol']}"
+                collected[key] = fill
+            added = len(collected) - before
+            if len(collected) >= max_fills:
+                capped = True
+                break
+            if len(page) < int(page_limit):
+                break  # short page → feed exhausted
+            if page_last_ts <= cursor and added == 0:
+                # A FULL page that neither advanced the timestamp nor yielded any
+                # new fill: a single-millisecond block larger than page_limit, which
+                # timestamp paging cannot step through without dropping fills. Fail
+                # closed so the Go journal treats the cycle as not-usable.
+                capped = True
+                break
+            cursor = page_last_ts  # overlap on the boundary ms (dedup absorbs it)
+        else:
+            # Loop ran out of iterations without a drained/cap break: the returned
+            # set is an INCOMPLETE prefix → report capped so the Go cursor is not
+            # advanced past the unfetched tail.
+            capped = True
+        fills = sorted(collected.values(), key=lambda x: x["ts_ms"])
+        if len(fills) > max_fills:
+            fills = fills[:max_fills]
         return fills, capped
 
     # ─────────────────────────────────────────────

--- a/platforms/topstep/test_adapter.py
+++ b/platforms/topstep/test_adapter.py
@@ -115,6 +115,83 @@ class TestAccountData:
         assert adapter.get_open_positions() == []
 
 
+# ─── Cash-flow journal feeds (#1106) ──────────────
+
+def _live_adapter_with_session(session):
+    """Build a live adapter without real creds by injecting a mock session.
+
+    Bypasses __init__'s live-mode credential check / requests import so the
+    #1106 balance + fills methods can be unit-tested against a mocked HTTP layer.
+    """
+    adapter = TopStepExchangeAdapter(mode="paper")
+    adapter._mode = "live"
+    adapter._account_id = "acct-1"
+    adapter._session = session
+    assert adapter.is_live is True
+    return adapter
+
+
+class TestCashflowJournalFeeds:
+    def test_equity_and_upnl_derives_upnl_from_same_read(self):
+        session = MagicMock()
+        resp = MagicMock()
+        resp.json.return_value = {"equity": 50120.0, "cashBalance": 50000.0}
+        session.get.return_value = resp
+        adapter = _live_adapter_with_session(session)
+        equity, upnl = adapter.get_account_equity_and_upnl()
+        assert equity == 50120.0
+        # uPnL = equity − cashBalance from the SAME response (coherent snapshot).
+        assert upnl == pytest.approx(120.0)
+
+    def test_equity_and_upnl_missing_cash_degrades_to_zero_upnl(self):
+        session = MagicMock()
+        resp = MagicMock()
+        resp.json.return_value = {"equity": 1000.0}  # no cashBalance/balance field
+        session.get.return_value = resp
+        adapter = _live_adapter_with_session(session)
+        equity, upnl = adapter.get_account_equity_and_upnl()
+        assert equity == 1000.0
+        assert upnl == pytest.approx(0.0)
+
+    def test_equity_and_upnl_paper_raises(self):
+        adapter = TopStepExchangeAdapter(mode="paper")
+        with pytest.raises(RuntimeError, match="live mode"):
+            adapter.get_account_equity_and_upnl()
+
+    def test_get_account_fills_shapes_and_sorts(self):
+        session = MagicMock()
+        resp = MagicMock()
+        resp.json.return_value = {"fills": [
+            {"id": "f2", "timestamp": 200, "symbol": "es", "kind": "TRADE", "realizedPnl": 20, "fee": 0.3},
+            {"id": "f1", "timestamp": 100, "symbol": "ES", "kind": "", "realizedPnl": 0, "commission": 0.5},
+        ]}
+        session.get.return_value = resp
+        adapter = _live_adapter_with_session(session)
+        fills, capped = adapter.get_account_fills(since_ms=0, limit=1000)
+        assert capped is False
+        # Oldest-first.
+        assert [f["ts_ms"] for f in fills] == [100, 200]
+        assert fills[0] == {"fill_id": "f1", "ts_ms": 100, "symbol": "ES", "kind": "", "realized_pnl": 0.0, "fee": 0.5}
+        assert fills[1]["symbol"] == "ES" and fills[1]["kind"] == "trade" and fills[1]["realized_pnl"] == 20.0
+
+    def test_get_account_fills_capped_at_limit(self):
+        session = MagicMock()
+        resp = MagicMock()
+        resp.json.return_value = {"fills": [
+            {"id": "a", "timestamp": 1, "symbol": "ES", "kind": "trade", "realizedPnl": 1, "fee": 0},
+            {"id": "b", "timestamp": 2, "symbol": "ES", "kind": "trade", "realizedPnl": 1, "fee": 0},
+        ]}
+        session.get.return_value = resp
+        adapter = _live_adapter_with_session(session)
+        _, capped = adapter.get_account_fills(since_ms=0, limit=2)
+        assert capped is True
+
+    def test_get_account_fills_paper_raises(self):
+        adapter = TopStepExchangeAdapter(mode="paper")
+        with pytest.raises(RuntimeError, match="live mode"):
+            adapter.get_account_fills()
+
+
 # ─── Order Execution ──────────────────────────────
 
 class TestOrderExecution:

--- a/platforms/topstep/test_adapter.py
+++ b/platforms/topstep/test_adapter.py
@@ -153,6 +153,18 @@ class TestCashflowJournalFeeds:
         assert equity == 1000.0
         assert upnl == pytest.approx(0.0)
 
+    def test_equity_and_upnl_missing_equity_raises(self):
+        # #1106 review finding 1: a 200 with a shape-mismatched body (no "equity"
+        # field) must RAISE — never silently coerce to a $0 equity that the
+        # portfolio kill switch would consume.
+        session = MagicMock()
+        resp = MagicMock()
+        resp.json.return_value = {"cashBalance": 50000.0}  # no equity field
+        session.get.return_value = resp
+        adapter = _live_adapter_with_session(session)
+        with pytest.raises(ValueError, match="missing 'equity'"):
+            adapter.get_account_equity_and_upnl()
+
     def test_equity_and_upnl_paper_raises(self):
         adapter = TopStepExchangeAdapter(mode="paper")
         with pytest.raises(RuntimeError, match="live mode"):
@@ -167,23 +179,50 @@ class TestCashflowJournalFeeds:
         ]}
         session.get.return_value = resp
         adapter = _live_adapter_with_session(session)
-        fills, capped = adapter.get_account_fills(since_ms=0, limit=1000)
+        # Two fills < page_limit → short page → feed drained, single GET, not capped.
+        fills, capped = adapter.get_account_fills(since_ms=0, page_limit=1000)
         assert capped is False
+        assert session.get.call_count == 1
         # Oldest-first.
         assert [f["ts_ms"] for f in fills] == [100, 200]
         assert fills[0] == {"fill_id": "f1", "ts_ms": 100, "symbol": "ES", "kind": "", "realized_pnl": 0.0, "fee": 0.5}
         assert fills[1]["symbol"] == "ES" and fills[1]["kind"] == "trade" and fills[1]["realized_pnl"] == 20.0
 
-    def test_get_account_fills_capped_at_limit(self):
+    def test_get_account_fills_drains_across_pages(self):
+        # Full first page (== page_limit) must NOT be reported capped: the loop
+        # advances the cursor and pages forward until a short page drains the feed.
+        page1 = {"fills": [
+            {"id": "a", "timestamp": 100, "symbol": "ES", "kind": "trade", "realizedPnl": 1, "fee": 0},
+            {"id": "b", "timestamp": 200, "symbol": "ES", "kind": "trade", "realizedPnl": 2, "fee": 0},
+        ]}
+        page2 = {"fills": [  # boundary overlap (ts 200 re-read) + one new fill
+            {"id": "b", "timestamp": 200, "symbol": "ES", "kind": "trade", "realizedPnl": 2, "fee": 0},
+            {"id": "c", "timestamp": 300, "symbol": "ES", "kind": "trade", "realizedPnl": 3, "fee": 0},
+        ]}
+        page3 = {"fills": []}  # drained
+        session = MagicMock()
+        r1, r2, r3 = MagicMock(), MagicMock(), MagicMock()
+        r1.json.return_value, r2.json.return_value, r3.json.return_value = page1, page2, page3
+        session.get.side_effect = [r1, r2, r3]
+        adapter = _live_adapter_with_session(session)
+        fills, capped = adapter.get_account_fills(since_ms=0, page_limit=2)
+        assert capped is False  # feed drained, not page-capped
+        # Overlap fill b deduped → three distinct fills, oldest-first.
+        assert [f["fill_id"] for f in fills] == ["a", "b", "c"]
+
+    def test_get_account_fills_single_ms_overflow_caps(self):
+        # A FULL page whose fills all share one millisecond (timestamp paging can't
+        # step past it) must fail closed (capped) rather than loop or drop fills.
+        same_ms = {"fills": [
+            {"id": "x", "timestamp": 500, "symbol": "ES", "kind": "trade", "realizedPnl": 1, "fee": 0},
+            {"id": "y", "timestamp": 500, "symbol": "ES", "kind": "trade", "realizedPnl": 1, "fee": 0},
+        ]}
         session = MagicMock()
         resp = MagicMock()
-        resp.json.return_value = {"fills": [
-            {"id": "a", "timestamp": 1, "symbol": "ES", "kind": "trade", "realizedPnl": 1, "fee": 0},
-            {"id": "b", "timestamp": 2, "symbol": "ES", "kind": "trade", "realizedPnl": 1, "fee": 0},
-        ]}
+        resp.json.return_value = same_ms
         session.get.return_value = resp
         adapter = _live_adapter_with_session(session)
-        _, capped = adapter.get_account_fills(since_ms=0, limit=2)
+        _, capped = adapter.get_account_fills(since_ms=0, page_limit=2)
         assert capped is True
 
     def test_get_account_fills_paper_raises(self):

--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -830,6 +830,104 @@ func parseTopStepPositionsOutput(stdout []byte, stderrStr string, runErr error) 
 	}
 }
 
+// TopStepBalanceResult is the JSON output from fetch_topstep_balance.py (#1106).
+// Balance is the USD account equity (settled cash + uPnL) the shared-wallet
+// cash-flow journal reconciles; UnrealizedPnL is equity − cashBalance from the
+// SAME read so the journal's equity/uPnL snapshot is coherent (mirrors
+// OKXBalanceResult).
+type TopStepBalanceResult struct {
+	Balance       float64 `json:"balance"`
+	UnrealizedPnL float64 `json:"unrealized_pnl"`
+	Platform      string  `json:"platform"`
+	Timestamp     string  `json:"timestamp"`
+	Error         string  `json:"error,omitempty"`
+}
+
+// RunTopStepFetchBalance runs fetch_topstep_balance.py for the configured TopStep
+// account (#1106). Follows the same 5-case contract as the other TopStep fetch
+// runners: a non-nil error on ANY failure path so the cash-flow journal fails
+// closed (no shadow reading this cycle) rather than treating a fetch failure as a
+// real $0 equity.
+func RunTopStepFetchBalance(script string) (*TopStepBalanceResult, string, error) {
+	stdout, stderr, runErr := RunPythonScript(script, nil)
+	return parseTopStepBalanceOutput(stdout, string(stderr), runErr)
+}
+
+// parseTopStepBalanceOutput is the pure parser for RunTopStepFetchBalance,
+// extracted so the decision logic is testable without spawning Python. Mirrors
+// parseOKXBalanceOutput's 5-case matrix.
+func parseTopStepBalanceOutput(stdout []byte, stderrStr string, runErr error) (*TopStepBalanceResult, string, error) {
+	var result TopStepBalanceResult
+	parseErr := json.Unmarshal(stdout, &result)
+
+	switch {
+	case runErr == nil && parseErr == nil && result.Error == "":
+		return &result, stderrStr, nil
+
+	case runErr == nil && parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("fetch balance reported error despite exit 0: %s", result.Error)
+
+	case parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("fetch balance failed: %s", result.Error)
+
+	case parseErr == nil && runErr != nil:
+		return &result, stderrStr, fmt.Errorf("fetch balance subprocess exit %v with no error field (stderr: %s)", runErr, stderrStr)
+
+	default:
+		return nil, stderrStr, fmt.Errorf("parse balance output: %v (run err: %v, stdout: %s)", parseErr, runErr, string(stdout))
+	}
+}
+
+// TopStepFillsResult is the JSON output from fetch_topstep_fills.py (#1106). Fills
+// are the settled trade fills since the cursor; Capped is true when the script hit
+// its safety page cap (the journal treats that cycle as not-usable). Fills decode
+// straight into topstepFillRecord (json tags match), so the TopStep cash-flow
+// journal has no second representation.
+type TopStepFillsResult struct {
+	Fills     []topstepFillRecord `json:"fills"`
+	Capped    bool                `json:"capped"`
+	Platform  string              `json:"platform"`
+	Timestamp string              `json:"timestamp"`
+	Error     string              `json:"error,omitempty"`
+}
+
+// RunTopStepFetchFills runs fetch_topstep_fills.py for the configured TopStep
+// account, pulling every settled fill since sinceMs (#1106). Follows the same
+// 5-case contract as RunTopStepFetchPositions / RunTopStepFetchBalance: a non-nil
+// error on ANY failure path so the journal fails closed (no cursor advance, no
+// shadow reading) rather than silently treating a fetch failure as "no cash flow".
+func RunTopStepFetchFills(script string, sinceMs int64) (*TopStepFillsResult, string, error) {
+	args := []string{fmt.Sprintf("--since-ms=%d", sinceMs)}
+	stdout, stderr, runErr := RunPythonScript(script, args)
+	return parseTopStepFillsOutput(stdout, string(stderr), runErr)
+}
+
+// parseTopStepFillsOutput is the pure parser for RunTopStepFetchFills, extracted
+// so the decision logic is testable without spawning Python. Mirrors
+// parseOKXBillsOutput's 5-case matrix — contract drift across the TopStep fetch
+// parsers would be bad.
+func parseTopStepFillsOutput(stdout []byte, stderrStr string, runErr error) (*TopStepFillsResult, string, error) {
+	var result TopStepFillsResult
+	parseErr := json.Unmarshal(stdout, &result)
+
+	switch {
+	case runErr == nil && parseErr == nil && result.Error == "":
+		return &result, stderrStr, nil
+
+	case runErr == nil && parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("fetch fills reported error despite exit 0: %s", result.Error)
+
+	case parseErr == nil && result.Error != "":
+		return &result, stderrStr, fmt.Errorf("fetch fills failed: %s", result.Error)
+
+	case parseErr == nil && runErr != nil:
+		return &result, stderrStr, fmt.Errorf("fetch fills subprocess exit %v with no error field (stderr: %s)", runErr, stderrStr)
+
+	default:
+		return nil, stderrStr, fmt.Errorf("parse fills output: %v (run err: %v, stdout: %s)", parseErr, runErr, string(stdout))
+	}
+}
+
 // RobinhoodResult is the JSON output from check_robinhood.py (signal check mode).
 type RobinhoodResult struct {
 	StrategyDecisionFields

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1015,23 +1015,27 @@ func main() {
 			}
 			// #1106 phase 4 of #1100: fetch the TopStep account equity for the
 			// shared-wallet cash-flow journal when 2+ live TopStep futures strategies
-			// share an account. Mirrors the OKX block above: one fetch_topstep_balance.py
-			// read yields a COHERENT (equity, uPnL) pair — equity feeds walletBalances
-			// (dedup / portfolio value) and the same snapshot's uPnL (equity − cashBalance)
-			// bounds the journal so its expected-equity and reconciled equity cancel the
-			// uPnL term exactly. A fetch failure leaves walletBalances[tsKey] unset →
-			// computeTotalPortfolioValue falls back to the member-PV sum (no false-zero).
-			tsKey := SharedWalletKey{Platform: "topstep", Account: os.Getenv("TOPSTEP_ACCOUNT_ID")}
-			_, tsShared := sharedWallets[tsKey]
+			// share an account. One fetch_topstep_balance.py read yields a COHERENT
+			// (equity, uPnL) pair — both feed the SHADOW journal only.
+			//
+			// Unlike the HL/OKX blocks, the equity is NOT written into walletBalances:
+			// the TopStep /v1/account/balance feed is unverified, and routing it into
+			// computeTotalPortfolioValue would put it on the live all-platform kill
+			// switch (CheckPortfolioRisk) behind only a >0 check. The journal uses its
+			// own detectTopStepSharedWallet grouping (not the kill-switch sharedWallets
+			// map), so portfolio risk stays on the pre-PR per-strategy member-PV path
+			// until Phase 4b verifies the feed and promotes it.
+			tsKey, tsShared := detectTopStepSharedWallet(cfg.Strategies)
 			var tsBalanceFetched bool
+			var tsSnapshotEquity float64
 			var tsSnapshotUPnL float64
 			var tsSnapshotAt time.Time
 			if tsShared {
 				if eq, upnl, err := defaultTopStepEquitySnapshot(); err != nil {
-					fmt.Printf("[WARN] topstep balance fetch failed: %v — falling back to per-member PV sum this cycle\n", err)
+					fmt.Printf("[WARN] topstep balance fetch failed: %v — shadow cash-flow journal skipped this cycle\n", err)
 				} else {
-					walletBalances[tsKey] = eq
 					tsBalanceFetched = true
+					tsSnapshotEquity = eq
 					tsSnapshotUPnL = upnl
 					tsSnapshotAt = time.Now().UTC()
 				}
@@ -1151,7 +1155,7 @@ func main() {
 			// outside the lock (subprocess fetch + DB-only writes), bounded to the COHERENT
 			// equity/uPnL snapshot from the single balance read above.
 			if tsShared && tsBalanceFetched {
-				tsRec := reconcileTopStepCashflowJournal(stateDB, tsKey, walletBalances[tsKey], tsSnapshotUPnL, tsSnapshotAt)
+				tsRec := reconcileTopStepCashflowJournal(stateDB, tsKey, tsSnapshotEquity, tsSnapshotUPnL, tsSnapshotAt)
 				logTopStepCashflowJournalShadow(driftResults, tsKey, tsRec)
 			}
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1013,6 +1013,29 @@ func main() {
 					tsPositions = pos
 				}
 			}
+			// #1106 phase 4 of #1100: fetch the TopStep account equity for the
+			// shared-wallet cash-flow journal when 2+ live TopStep futures strategies
+			// share an account. Mirrors the OKX block above: one fetch_topstep_balance.py
+			// read yields a COHERENT (equity, uPnL) pair — equity feeds walletBalances
+			// (dedup / portfolio value) and the same snapshot's uPnL (equity − cashBalance)
+			// bounds the journal so its expected-equity and reconciled equity cancel the
+			// uPnL term exactly. A fetch failure leaves walletBalances[tsKey] unset →
+			// computeTotalPortfolioValue falls back to the member-PV sum (no false-zero).
+			tsKey := SharedWalletKey{Platform: "topstep", Account: os.Getenv("TOPSTEP_ACCOUNT_ID")}
+			_, tsShared := sharedWallets[tsKey]
+			var tsBalanceFetched bool
+			var tsSnapshotUPnL float64
+			var tsSnapshotAt time.Time
+			if tsShared {
+				if eq, upnl, err := defaultTopStepEquitySnapshot(); err != nil {
+					fmt.Printf("[WARN] topstep balance fetch failed: %v — falling back to per-member PV sum this cycle\n", err)
+				} else {
+					walletBalances[tsKey] = eq
+					tsBalanceFetched = true
+					tsSnapshotUPnL = upnl
+					tsSnapshotAt = time.Now().UTC()
+				}
+			}
 
 			mu.RLock()
 			totalPV, usedPVFallback = computeTotalPortfolioValue(cfg.Strategies, state, prices, walletBalances, sharedWallets)
@@ -1116,6 +1139,20 @@ func main() {
 			if okxShared && okxBalanceFetched {
 				okxRec := reconcileOKXCashflowJournal(stateDB, okxKey, walletBalances[okxKey], okxSnapshotUPnL, okxSnapshotAt)
 				logOKXCashflowJournalShadow(driftResults, okxKey, okxRec)
+			}
+
+			// #1106 phase 4 of #1100: TopStep cash-flow journal — SHADOW phase. The
+			// wallet equity is reconstructed from TopStep's settled fills (gross realized
+			// PnL − commission per fill) and reconciled against the account equity, exactly
+			// as the HL/OKX journals do, but it ONLY logs each cycle — there is no live
+			// TopStep shared-wallet alarm to drive (TopStep is display-skipped). Flipping a
+			// TopStep alarm onto the journal is Phase 4b, gated on this shadow log proving
+			// the feed/equity field AND the TopStepX endpoint contracts in production. Runs
+			// outside the lock (subprocess fetch + DB-only writes), bounded to the COHERENT
+			// equity/uPnL snapshot from the single balance read above.
+			if tsShared && tsBalanceFetched {
+				tsRec := reconcileTopStepCashflowJournal(stateDB, tsKey, walletBalances[tsKey], tsSnapshotUPnL, tsSnapshotAt)
+				logTopStepCashflowJournalShadow(driftResults, tsKey, tsRec)
 			}
 
 			// Fire throttled drift alarms outside the lock (notifier I/O). For HL

--- a/scheduler/shared_wallet.go
+++ b/scheduler/shared_wallet.go
@@ -96,15 +96,16 @@ func walletKeyFor(sc StrategyConfig) (SharedWalletKey, bool) {
 var platformsWithSharedWalletBalanceFetcher = map[string]bool{
 	"hyperliquid": true,
 	"okx":         true, // #360 phase 2 of #357 — fetch_okx_balance.py
-	// #1106 phase 4 of #1100: surfaces TopStep shared wallets in
-	// detectSharedWallets so the exchange-sourced cash-flow journal (shadow)
-	// runs. The coherent equity/uPnL snapshot is owned by the dedicated main-loop
-	// block (defaultTopStepEquitySnapshot → walletBalances), mirroring OKX;
-	// defaultSharedWalletFetcher intentionally has no topstep case. TopStep stays
-	// display-skipped in reconcileSharedWalletDisplayValues (no position source),
-	// so this enables the snapshot side without any capital-weight display
-	// mutation.
-	"topstep": true,
+	// #1106 phase 4 of #1100: TopStep is DELIBERATELY NOT listed here during the
+	// shadow phase. Its /v1/account/balance equity feed is unverified, and
+	// listing it would pull TopStep into detectSharedWallets → the live
+	// computeTotalPortfolioValue / CheckPortfolioRisk path (the all-platform kill
+	// switch), where a wrong-but-positive equity could crater totalPV behind only
+	// a >0 check and trip a cross-platform close — and a missing balance would set
+	// usedFallback every cycle, freezing the portfolio peak ratchet. The shadow
+	// cash-flow journal detects its own grouping via detectTopStepSharedWallet and
+	// consumes the equity directly, so portfolio risk stays on the pre-PR
+	// per-strategy member-PV behavior until Phase 4b verifies the feed.
 }
 
 // hasSharedWalletBalanceFetcher reports whether defaultSharedWalletFetcher can
@@ -151,6 +152,35 @@ func detectSharedWallets(strategies []StrategyConfig) map[SharedWalletKey][]stri
 		}
 	}
 	return shared
+}
+
+// detectTopStepSharedWallet reports whether 2+ live TopStep strategies share an
+// account, gating the #1106 shadow cash-flow journal. It is INTENTIONALLY
+// independent of detectSharedWallets / platformsWithSharedWalletBalanceFetcher:
+// the journal must be able to run without TopStep being a member of the
+// kill-switch sharedWallets map, so the unverified /v1/account/balance equity
+// never enters computeTotalPortfolioValue (the live all-platform portfolio kill
+// switch) during the shadow phase. Membership is derived the same way as
+// detectSharedWallets — walletKeyFor already filters to live mode and a present
+// TOPSTEP_ACCOUNT_ID — minus the fetcher-capability gate.
+func detectTopStepSharedWallet(strategies []StrategyConfig) (SharedWalletKey, bool) {
+	counts := make(map[SharedWalletKey]int)
+	for _, sc := range strategies {
+		if sc.Platform != "topstep" {
+			continue
+		}
+		key, ok := walletKeyFor(sc)
+		if !ok {
+			continue
+		}
+		counts[key]++
+	}
+	for key, n := range counts {
+		if n > 1 {
+			return key, true
+		}
+	}
+	return SharedWalletKey{}, false
 }
 
 // defaultSharedWalletFetcher dispatches to the platform-specific balance API.

--- a/scheduler/shared_wallet.go
+++ b/scheduler/shared_wallet.go
@@ -96,6 +96,15 @@ func walletKeyFor(sc StrategyConfig) (SharedWalletKey, bool) {
 var platformsWithSharedWalletBalanceFetcher = map[string]bool{
 	"hyperliquid": true,
 	"okx":         true, // #360 phase 2 of #357 — fetch_okx_balance.py
+	// #1106 phase 4 of #1100: surfaces TopStep shared wallets in
+	// detectSharedWallets so the exchange-sourced cash-flow journal (shadow)
+	// runs. The coherent equity/uPnL snapshot is owned by the dedicated main-loop
+	// block (defaultTopStepEquitySnapshot → walletBalances), mirroring OKX;
+	// defaultSharedWalletFetcher intentionally has no topstep case. TopStep stays
+	// display-skipped in reconcileSharedWalletDisplayValues (no position source),
+	// so this enables the snapshot side without any capital-weight display
+	// mutation.
+	"topstep": true,
 }
 
 // hasSharedWalletBalanceFetcher reports whether defaultSharedWalletFetcher can

--- a/scheduler/shared_wallet_test.go
+++ b/scheduler/shared_wallet_test.go
@@ -237,10 +237,13 @@ func TestDetectSharedWallets_OKXIncludedAfterFetcher(t *testing.T) {
 	}
 }
 
-// TestDetectSharedWallets_TopStepGroupedWithFetcher — #1106 phase 4 of #1100
-// added a TopStep balance fetcher, so two live TopStep futures strategies on one
-// account are now grouped as a single shared wallet (mirrors the OKX test above).
-func TestDetectSharedWallets_TopStepGroupedWithFetcher(t *testing.T) {
+// TestDetectSharedWallets_TopStepExcludedNoFetcher — #1106 phase 4 of #1100 runs
+// the TopStep cash-flow journal in SHADOW only and deliberately keeps TopStep OUT
+// of platformsWithSharedWalletBalanceFetcher, so its unverified equity feed never
+// reaches the live computeTotalPortfolioValue / kill-switch path. TopStep is
+// therefore still excluded from detectSharedWallets (the kill-switch grouping),
+// even though walletKeyFor recognizes the live wallet.
+func TestDetectSharedWallets_TopStepExcludedNoFetcher(t *testing.T) {
 	t.Setenv("TOPSTEP_ACCOUNT_ID", "ts-account-42")
 
 	strategies := []StrategyConfig{
@@ -249,13 +252,48 @@ func TestDetectSharedWallets_TopStepGroupedWithFetcher(t *testing.T) {
 	}
 
 	shared := detectSharedWallets(strategies)
-	if len(shared) != 1 {
-		t.Fatalf("expected TopStep to be grouped as one shared wallet (phase 4 #1106), got %d entries", len(shared))
+	if len(shared) != 0 {
+		t.Fatalf("expected TopStep to stay excluded from detectSharedWallets during the shadow phase (#1106); got %d entries", len(shared))
 	}
 	for _, sc := range strategies {
 		if _, ok := walletKeyFor(sc); !ok {
-			t.Errorf("walletKeyFor should recognize %s", sc.ID)
+			t.Errorf("walletKeyFor should still recognize live %s", sc.ID)
 		}
+	}
+}
+
+// TestDetectTopStepSharedWallet — the shadow cash-flow journal (#1106) detects
+// 2+ live TopStep strategies on one account INDEPENDENTLY of the kill-switch
+// sharedWallets map, so it can run without the equity touching portfolio risk.
+func TestDetectTopStepSharedWallet(t *testing.T) {
+	t.Setenv("TOPSTEP_ACCOUNT_ID", "ts-account-42")
+
+	// 2+ live → shared.
+	twoLive := []StrategyConfig{
+		{ID: "ts-sma-es", Platform: "topstep", Type: "futures", Args: []string{"sma", "ES", "15m", "--mode=live"}, Capital: 5000},
+		{ID: "ts-rsi-nq", Platform: "topstep", Type: "futures", Args: []string{"rsi", "NQ", "15m", "--mode=live"}, Capital: 5000},
+	}
+	if key, ok := detectTopStepSharedWallet(twoLive); !ok || key.Account != "ts-account-42" {
+		t.Fatalf("expected 2 live TopStep strategies to be a shared wallet, got ok=%v key=%+v", ok, key)
+	}
+	// Excluded from the kill-switch grouping at the same time.
+	if len(detectSharedWallets(twoLive)) != 0 {
+		t.Errorf("TopStep must stay out of detectSharedWallets (kill-switch path)")
+	}
+
+	// Single live → not shared.
+	oneLive := twoLive[:1]
+	if _, ok := detectTopStepSharedWallet(oneLive); ok {
+		t.Errorf("a single live TopStep strategy is not a shared wallet")
+	}
+
+	// Paper strategies → not recognized → not shared.
+	paper := []StrategyConfig{
+		{ID: "ts-sma-es", Platform: "topstep", Type: "futures", Args: []string{"sma", "ES", "15m", "--mode=paper"}, Capital: 5000},
+		{ID: "ts-rsi-nq", Platform: "topstep", Type: "futures", Args: []string{"rsi", "NQ", "15m", "--mode=paper"}, Capital: 5000},
+	}
+	if _, ok := detectTopStepSharedWallet(paper); ok {
+		t.Errorf("paper-mode TopStep strategies must not form a shared wallet")
 	}
 }
 
@@ -274,15 +312,17 @@ func TestDetectSharedWallets_RobinhoodExcludedNoFetcher(t *testing.T) {
 	}
 }
 
-// TestHasSharedWalletBalanceFetcher_HLAndOKX locks in the contract that HL,
-// OKX (#360 phase 2 of #357), and TopStep (#1106 phase 4 of #1100) have balance
-// fetchers today. When phase 4 (RH) adds a fetcher, this test should be updated
-// in the same PR as the fetcher wiring.
+// TestHasSharedWalletBalanceFetcher_HLAndOKX locks in the contract that HL and
+// OKX (#360 phase 2 of #357) have portfolio-value balance fetchers today.
+// TopStep is intentionally false during the #1106 shadow phase — its unverified
+// equity feeds the shadow journal only, never computeTotalPortfolioValue — and
+// flips true in Phase 4b alongside verification. When RH adds a fetcher, update
+// this in the same PR as the fetcher wiring.
 func TestHasSharedWalletBalanceFetcher_HLAndOKX(t *testing.T) {
 	cases := map[string]bool{
 		"hyperliquid": true,
 		"okx":         true,
-		"topstep":     true,
+		"topstep":     false,
 		"robinhood":   false,
 		"binanceus":   false,
 		"unknown":     false,

--- a/scheduler/shared_wallet_test.go
+++ b/scheduler/shared_wallet_test.go
@@ -237,8 +237,10 @@ func TestDetectSharedWallets_OKXIncludedAfterFetcher(t *testing.T) {
 	}
 }
 
-// TestDetectSharedWallets_TopStepExcludedNoFetcher — same as OKX, for TopStep.
-func TestDetectSharedWallets_TopStepExcludedNoFetcher(t *testing.T) {
+// TestDetectSharedWallets_TopStepGroupedWithFetcher — #1106 phase 4 of #1100
+// added a TopStep balance fetcher, so two live TopStep futures strategies on one
+// account are now grouped as a single shared wallet (mirrors the OKX test above).
+func TestDetectSharedWallets_TopStepGroupedWithFetcher(t *testing.T) {
 	t.Setenv("TOPSTEP_ACCOUNT_ID", "ts-account-42")
 
 	strategies := []StrategyConfig{
@@ -247,8 +249,13 @@ func TestDetectSharedWallets_TopStepExcludedNoFetcher(t *testing.T) {
 	}
 
 	shared := detectSharedWallets(strategies)
-	if len(shared) != 0 {
-		t.Errorf("expected TopStep to be excluded from detectSharedWallets until a balance fetcher exists; got %d entries", len(shared))
+	if len(shared) != 1 {
+		t.Fatalf("expected TopStep to be grouped as one shared wallet (phase 4 #1106), got %d entries", len(shared))
+	}
+	for _, sc := range strategies {
+		if _, ok := walletKeyFor(sc); !ok {
+			t.Errorf("walletKeyFor should recognize %s", sc.ID)
+		}
 	}
 }
 
@@ -267,15 +274,15 @@ func TestDetectSharedWallets_RobinhoodExcludedNoFetcher(t *testing.T) {
 	}
 }
 
-// TestHasSharedWalletBalanceFetcher_HLAndOKX locks in the contract that HL
-// and OKX have balance fetchers today (#360 phase 2 of #357). When phases
-// 3-4 add fetchers for TS / RH, this test should be updated in the same PR
-// as the fetcher wiring.
+// TestHasSharedWalletBalanceFetcher_HLAndOKX locks in the contract that HL,
+// OKX (#360 phase 2 of #357), and TopStep (#1106 phase 4 of #1100) have balance
+// fetchers today. When phase 4 (RH) adds a fetcher, this test should be updated
+// in the same PR as the fetcher wiring.
 func TestHasSharedWalletBalanceFetcher_HLAndOKX(t *testing.T) {
 	cases := map[string]bool{
 		"hyperliquid": true,
 		"okx":         true,
-		"topstep":     false,
+		"topstep":     true,
 		"robinhood":   false,
 		"binanceus":   false,
 		"unknown":     false,

--- a/scheduler/topstep_cashflow_journal.go
+++ b/scheduler/topstep_cashflow_journal.go
@@ -165,7 +165,26 @@ func defaultTopStepEquitySnapshot() (equity, upnl float64, err error) {
 	if err != nil {
 		return 0, 0, err
 	}
-	return result.Balance, result.UnrealizedPnL, nil
+	return validatedTopStepEquity(result.Balance, result.UnrealizedPnL)
+}
+
+// validatedTopStepEquity treats a non-positive (or NaN) equity as a fetch MISS
+// rather than a real $0 account value. A funded TopStep account always carries
+// positive equity, so equity ≤ 0 means the (unverified) /v1/account/balance
+// response was malformed or shape-mismatched — e.g. a 200 missing the "equity"
+// field, which the fetcher would otherwise coerce to 0 and report as success.
+// Returning an error keeps walletBalances[tsKey] UNSET so the portfolio-value
+// path falls back to the member-PV sum and freezes the portfolio peak, instead
+// of contributing a silent $0 that collapses the TopStep account's portfolio
+// value and could trip the all-platform portfolio kill switch (CheckPortfolioRisk
+// consumes a PRESENT walletBalances[key] directly via computeSubsetPortfolioValue,
+// with no member-PV fallback on a present zero). A genuinely good positive equity
+// flows through unchanged. Pure — unit-tested.
+func validatedTopStepEquity(balance, upnl float64) (equity, upnlOut float64, err error) {
+	if !(balance > 0) { // also rejects NaN
+		return 0, 0, fmt.Errorf("non-positive TopStep equity $%.2f — treating as a fetch miss (malformed /v1/account/balance response)", balance)
+	}
+	return balance, upnl, nil
 }
 
 // topstepCashflowJournalFetchResult carries one TopStep wallet's raw fills plus

--- a/scheduler/topstep_cashflow_journal.go
+++ b/scheduler/topstep_cashflow_journal.go
@@ -1,0 +1,365 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// #1106: exchange-sourced cash-flow journal for TopStep shared wallets — SHADOW
+// phase (Phase 4 of #1100), mirroring HL's #1103 shadow / #1104 flip two-step and
+// OKX's #1105 shadow.
+//
+// This reuses the platform-generic journal machinery built for Hyperliquid in
+// children 1–2 (cashflow_journal.go): the cashflow_journal / cashflow_journal_state
+// tables (keyed by (platform, account)), the durable per-wallet cursor + adoption
+// baseline, per-event dedup, halt-on-persist-failure, snapshot-bounded ingestion,
+// the incomplete fail-closed latch, and the shared equity equation
+// (cashflowJournalExpectedEquity). HL and OKX behavior are untouched.
+//
+// EVENT SHAPE — HL-LIKE, NOT OKX-LIKE. OKX exposes a single pre-netted balChg
+// per bill, so it needs no fee arithmetic. TopStep (CME futures via a prop
+// account) settles per fill in USD with a GROSS realized PnL and a separately-
+// reported commission, exactly like Hyperliquid's userFills. So a TopStep fill's
+// settled-cash delta is realized-PnL-GROSS minus the commission charged —
+// computed by the shared cashflowFillSettledDelta — and the gross value is
+// retained for attribution only and is NEVER summed into equity on its own
+// (same gross-PnL discipline as HL/OKX, #698). Entry fills carry realized PnL 0
+// and settle −commission; closing fills settle gross−commission.
+//
+// SINGLE STREAM. TopStep fills are the one settled-cash source modeled here
+// (CME futures have no perpetual funding, and prop-account payouts/resets are
+// not fills). Only the FillsSinceMs cursor of the shared CashflowJournalState is
+// used (as the fills watermark); FundingSinceMs / TransfersSinceMs stay 0 and
+// unused for TopStep wallets — same as OKX.
+//
+// RECONCILED FIELD: TopStep account EQUITY (settled USD cash balance + unrealized
+// PnL), USD-denominated. equity = cash + uPnL, decomposed identically to HL/OKX:
+//
+//	expected = baseline_equity
+//	         + Σ(fill settled deltas since baseline)   // gross − commission per fill
+//	         + (current_uPnL − baseline_uPnL)
+//
+// current_uPnL / baseline_uPnL come from the SAME balance read as equity
+// (uPnL = equity − cashBalance, not a separately-timed positions sum), so equity
+// and uPnL are one coherent snapshot: the uPnL term cancels against equity and
+// residual drift reduces to the pure settled-cash reconstruction error — no
+// intra-cycle uPnL jitter (same coherence guarantee as OKX).
+//
+// SHADOW ONLY. This phase NEVER drives a TopStep drift alarm — there is no live
+// TopStep shared-wallet alarm to drive (TopStep is display-skipped in
+// reconcileSharedWalletDisplayValues: no position source is wired, so it falls
+// through `default: continue`). logTopStepCashflowJournalShadow computes the
+// journal-derived expected equity and logs it every cycle for operator
+// comparison; it mutates nothing. Flipping any TopStep alarm onto the journal is
+// the follow-up (Phase 4b), gated on the shadow log proving the TopStep feed /
+// equity field in production AND on the TopStepX fill/balance endpoint contracts
+// (currently modeled on the existing adapter's unverified /v1/account/* shape)
+// being confirmed against the live venue. Nothing here mutates StrategyState, so
+// the whole flow runs OUTSIDE the state lock (DB writes are serialized by SQLite).
+
+// topstepFillRecord is one TopStep settled trade fill (the single settled-cash
+// event for TopStep). RealizedPnL is GROSS (0 for entry fills); Fee is the
+// commission actually charged. The settled-cash delta is RealizedPnL−Fee
+// (cashflowFillSettledDelta); RealizedPnL is retained as attribution metadata
+// only and is never summed into equity on its own. Decodes straight from
+// fetch_topstep_fills.py (json tags match) so there is no second representation.
+type topstepFillRecord struct {
+	FillID      string  `json:"fill_id"`
+	TimeMs      int64   `json:"ts_ms"`
+	Symbol      string  `json:"symbol"`
+	Kind        string  `json:"kind"`
+	RealizedPnL float64 `json:"realized_pnl"`
+	Fee         float64 `json:"fee"`
+}
+
+// topstepFillKindByType maps a TopStep fill's reported `kind` to a human-readable
+// journal kind. The settled-cash delta is RealizedPnL−Fee regardless of kind, so
+// this map drives operator-readable labels and fail-closed classification: an
+// UNMAPPED kind still books its authoritative gross−fee delta but latches the
+// journal incomplete so the shadow log flags the unclassified event for the
+// operator to extend this map before any Phase-4b alarm flip. An empty kind is a
+// plain trade fill (the fills feed returns trades).
+var topstepFillKindByType = map[string]string{
+	"":           "trade",      // unlabeled fill from the trades feed
+	"trade":      "trade",      // realized PnL + commission on a fill
+	"fill":       "trade",      // synonym
+	"commission": "commission", // standalone commission / fee
+	"fee":        "commission", // synonym
+}
+
+// topstepFillSettledDelta returns one fill's signed effect on settled cash, its
+// human-readable journal kind, and whether the event is fully classifiable. The
+// delta is the shared gross-minus-fee convention (cashflowFillSettledDelta) for
+// every record; the fill is "known" only when its kind is in
+// topstepFillKindByType. A not-known result latches the journal incomplete (fail
+// closed) but still books the gross−fee delta so the running drift surfaces it.
+// Pure — unit-tested.
+func topstepFillSettledDelta(f topstepFillRecord) (delta float64, kind string, known bool) {
+	delta = cashflowFillSettledDelta(f.RealizedPnL, f.Fee)
+	k := strings.ToLower(strings.TrimSpace(f.Kind))
+	if mapped, ok := topstepFillKindByType[k]; ok {
+		return delta, mapped, true
+	}
+	return delta, "kind_" + k, false
+}
+
+// topstepFillDedupID is a fill's stable journal identity. TopStep assigns each
+// fill a unique id; the kind:time:symbol form disambiguates the rare missing-id
+// case so two genuine fills never collide. Namespaced ("topstepfill:") so it can
+// never collide with the HL fill/funding/transfer or OKX bill dedup namespaces in
+// the shared cashflow_journal table.
+func topstepFillDedupID(f topstepFillRecord) string {
+	if id := strings.TrimSpace(f.FillID); id != "" && id != "0" {
+		return "topstepfill:" + id
+	}
+	return fmt.Sprintf("topstepfill:%s:%d:%s", strings.TrimSpace(f.Kind), f.TimeMs, strings.ToUpper(strings.TrimSpace(f.Symbol)))
+}
+
+// topstepFillsScript is the path to the Python fills fetcher (#1106). Exposed as
+// a var so tests can substitute — same pattern as okxFetchBillsScript /
+// topstepFetchPositionsScript.
+var topstepFillsScript = "shared_scripts/fetch_topstep_fills.py"
+
+// topstepBalanceScript is the path to the Python balance fetcher (#1106).
+var topstepBalanceScript = "shared_scripts/fetch_topstep_balance.py"
+
+// defaultTopStepFillsFetcher is the production fills fetch: shells out to
+// fetch_topstep_fills.py via RunTopStepFetchFills and returns the typed fills +
+// the page-cap flag. Any subprocess/parse failure surfaces as a non-nil error so
+// the journal fails closed (no cursor advance, no shadow reading this cycle).
+func defaultTopStepFillsFetcher(sinceMs int64) ([]topstepFillRecord, bool, error) {
+	result, stderr, err := RunTopStepFetchFills(topstepFillsScript, sinceMs)
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, "[topstep-cashflow-journal] fetch_fills stderr: %s\n", stderr)
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return result.Fills, result.Capped, nil
+}
+
+// fetchTopStepAccountFills is a function variable so tests can stub the TopStep
+// fills fetch without spawning Python. It pulls every fill settled since sinceMs
+// (ascending), returning capped=true when the safety page cap was hit.
+var fetchTopStepAccountFills = func(sinceMs int64) (fills []topstepFillRecord, capped bool, err error) {
+	return defaultTopStepFillsFetcher(sinceMs)
+}
+
+// defaultTopStepEquitySnapshot returns a COHERENT (equity, uPnL) snapshot for the
+// TopStep shared wallet from a SINGLE fetch_topstep_balance.py read (#1106).
+// equity is the USD account value the journal reconciles; uPnL is equity −
+// cashBalance from the same response, so the cash-flow journal's equity and uPnL
+// are one atomic snapshot. Any failure surfaces as a non-nil error so the journal
+// fails closed (no shadow reading this cycle).
+func defaultTopStepEquitySnapshot() (equity, upnl float64, err error) {
+	if os.Getenv("TOPSTEP_ACCOUNT_ID") == "" {
+		return 0, 0, fmt.Errorf("TOPSTEP_ACCOUNT_ID not set")
+	}
+	result, stderr, err := RunTopStepFetchBalance(topstepBalanceScript)
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, "[topstep-balance] stderr: %s\n", stderr)
+	}
+	if err != nil {
+		return 0, 0, err
+	}
+	return result.Balance, result.UnrealizedPnL, nil
+}
+
+// topstepCashflowJournalFetchResult carries one TopStep wallet's raw fills plus
+// the coherent equity / uPnL snapshot from the no-lock fetch phase to the no-lock
+// ingest+compare phase. Mirrors okxCashflowJournalFetchResult (single stream).
+type topstepCashflowJournalFetchResult struct {
+	Key          SharedWalletKey
+	State        CashflowJournalState
+	StateFound   bool
+	AccountValue float64 // TopStep equity (incl. uPnL) this cycle
+	CurrentUPnL  float64 // uPnL component of equity this cycle (equity − cashBalance, same balance read)
+	Fills        []topstepFillRecord
+	FillsFetched bool
+	Capped       bool
+}
+
+// fetchTopStepCashflowJournalEvents reads the wallet's fills cursor and pulls
+// every fill since it (one subprocess). Runs OUTSIDE the state lock. First contact
+// anchors the baseline to the supplied equity / uPnL snapshot and the cursor to
+// now, fetching no history — pre-adoption movement belongs to the baseline, not
+// the journal. Mirrors fetchOKXCashflowJournalEvents.
+func fetchTopStepCashflowJournalEvents(sdb *StateDB, key SharedWalletKey, accountValue, currentUPnL float64, now time.Time) topstepCashflowJournalFetchResult {
+	res := topstepCashflowJournalFetchResult{Key: key, AccountValue: accountValue, CurrentUPnL: currentUPnL}
+	if sdb == nil || key.Platform != "topstep" || key.Account == "" {
+		return res
+	}
+	st, found, err := sdb.GetCashflowJournalState(key.Platform, key.Account)
+	if err != nil {
+		fmt.Printf("[WARN] topstep-cashflow-journal %s: state load failed: %v — skipping ingestion this cycle\n", sharedWalletKeyLabel(key), err)
+		return res
+	}
+	if !found {
+		nowMs := now.UnixMilli()
+		// TopStep is single-stream: FillsSinceMs is the fills watermark;
+		// FundingSinceMs/TransfersSinceMs stay 0 (unused for TopStep).
+		st = CashflowJournalState{
+			FillsSinceMs:         nowMs,
+			BaselineAccountValue: accountValue,
+			BaselineUPnL:         currentUPnL,
+			BaselineSet:          true,
+		}
+		if err := sdb.UpsertCashflowJournalState(key.Platform, key.Account, st); err != nil {
+			fmt.Printf("[WARN] topstep-cashflow-journal %s: baseline init failed: %v\n", sharedWalletKeyLabel(key), err)
+			return res
+		}
+		fmt.Printf("[topstep-cashflow-journal] %s: baseline anchored at equity $%.2f (uPnL $%+.2f) and fills cursor at %s (no historical replay)\n",
+			sharedWalletKeyLabel(key), accountValue, currentUPnL, now.UTC().Format(time.RFC3339))
+		res.State = st
+		res.StateFound = true
+		return res
+	}
+	res.State = st
+	res.StateFound = true
+
+	fills, capped, err := fetchTopStepAccountFills(st.FillsSinceMs)
+	if err != nil {
+		fmt.Printf("[WARN] topstep-cashflow-journal %s: fills fetch failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+		return res
+	}
+	res.Fills = fills
+	res.FillsFetched = true
+	res.Capped = capped
+	return res
+}
+
+// ingestTopStepCashflowJournalEvents books the fetched fills into cashflow_journal
+// and advances the fills cursor. DB-only (no StrategyState mutation), so it runs
+// OUTSIDE the state lock. Returns the post-ingest state (cursor advanced,
+// incomplete latched if an unclassifiable fill was seen). Every insert halts the
+// cursor on persistence failure so a watermark never advances past an un-booked
+// event. cutoffMs bounds ingestion to fills settled AT OR BEFORE the equity /
+// uPnL snapshot — a fill settled after the snapshot is deferred to next cycle
+// (else it would inflate expected-equity but not equity and read as a full cycle
+// of false drift). Mirrors ingestOKXCashflowJournalEvents.
+func ingestTopStepCashflowJournalEvents(sdb *StateDB, res topstepCashflowJournalFetchResult, cutoffMs int64) CashflowJournalState {
+	st := res.State
+	if sdb == nil || !res.StateFound || !res.FillsFetched {
+		return st
+	}
+	key := res.Key
+
+	maxTime := st.FillsSinceMs - 1
+	failedAt := int64(-1)
+	fills := append([]topstepFillRecord(nil), res.Fills...)
+	sort.SliceStable(fills, func(i, j int) bool { return fills[i].TimeMs < fills[j].TimeMs })
+	for _, f := range fills {
+		if f.TimeMs < st.FillsSinceMs {
+			continue // cursor-overlap boundary; dedup also covers this
+		}
+		if f.TimeMs > cutoffMs {
+			continue // settled after the balance snapshot — defer to next cycle
+		}
+		delta, kind, known := topstepFillSettledDelta(f)
+		if !known {
+			// An unmapped fill kind means the journal cannot claim an exact total,
+			// so a future Phase-4b alarm flip must fail closed. The row is still
+			// booked (authoritative gross−fee delta) so it stays visible + deduped
+			// and the running drift surfaces it.
+			st.Incomplete = true
+			fmt.Printf("[WARN] topstep-cashflow-journal %s: unclassified fill kind=%q (fillId %s) — recorded kind %q, journal marked incomplete\n",
+				sharedWalletKeyLabel(key), f.Kind, f.FillID, kind)
+		}
+		coin := strings.ToUpper(strings.TrimSpace(f.Symbol))
+		if err := sdb.InsertCashflowJournalEntry(key.Platform, key.Account, f.TimeMs, kind, delta, coin, f.RealizedPnL, f.Fee, topstepFillDedupID(f)); err != nil {
+			fmt.Printf("[WARN] topstep-cashflow-journal %s: fill insert failed: %v — retrying next cycle\n", sharedWalletKeyLabel(key), err)
+			failedAt = f.TimeMs
+			break
+		}
+		if f.TimeMs > maxTime {
+			maxTime = f.TimeMs
+		}
+	}
+	// A capped/truncated fetch is NOT a safe contiguous prefix at its final
+	// millisecond: a same-ms group cut at maxTime would strand the un-returned
+	// siblings behind the cursor forever (a standing offset in SumCashflowJournal).
+	// When capped, advance only to maxTime so that boundary millisecond is
+	// re-fetched next cycle; topstepFillDedupID / INSERT OR IGNORE absorbs the
+	// re-read, and Usable stays false on every capped cycle. advanceCashflowCursor
+	// clamps to the current cursor, so this never moves the watermark backwards.
+	advanceMax := maxTime
+	if res.Capped {
+		advanceMax = maxTime - 1
+	}
+	st.FillsSinceMs = advanceCashflowCursor(st.FillsSinceMs, advanceMax, failedAt)
+
+	if st != res.State {
+		if err := sdb.UpsertCashflowJournalState(key.Platform, key.Account, st); err != nil {
+			fmt.Printf("[WARN] topstep-cashflow-journal %s: cursor advance failed: %v\n", sharedWalletKeyLabel(key), err)
+		}
+	}
+	return st
+}
+
+// reconcileTopStepCashflowJournal runs the full journal flow for one TopStep
+// shared wallet OUTSIDE the state lock: fetch the fills (subprocess), book them
+// (DB-only, bounded to the snapshot), and reconstruct the wallet's expected
+// equity. Pure of StrategyState. Returns nil when the wallet is not TopStep, the
+// state load/init failed, or the baseline was just anchored this cycle. Reuses the
+// HL cashflowJournalReconcile result shape. snapshotAt is the equity / uPnL sample
+// time and bounds journal ingestion. Mirrors reconcileOKXCashflowJournal.
+func reconcileTopStepCashflowJournal(sdb *StateDB, key SharedWalletKey, accountValue, currentUPnL float64, snapshotAt time.Time) *cashflowJournalReconcile {
+	if sdb == nil || key.Platform != "topstep" || key.Account == "" {
+		return nil
+	}
+	res := fetchTopStepCashflowJournalEvents(sdb, key, accountValue, currentUPnL, snapshotAt)
+	if !res.StateFound {
+		return nil // baseline just anchored (logged there) or fetch/load failed
+	}
+	st := ingestTopStepCashflowJournalEvents(sdb, res, snapshotAt.UnixMilli())
+	rec := &cashflowJournalReconcile{Key: key, AccountValue: res.AccountValue, Incomplete: st.Incomplete}
+	if !st.BaselineSet {
+		return rec // un-anchored: not usable
+	}
+	settled, err := sdb.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		fmt.Printf("[WARN] topstep-cashflow-journal %s: settled-sum read failed: %v\n", sharedWalletKeyLabel(key), err)
+		return rec
+	}
+	rec.SettledSum = settled
+	rec.DeltaUPnL = res.CurrentUPnL - st.BaselineUPnL
+	rec.ExpectedEquity = cashflowJournalExpectedEquity(st.BaselineAccountValue, st.BaselineUPnL, settled, res.CurrentUPnL)
+	rec.Drift = res.AccountValue - rec.ExpectedEquity
+	// Usable only when this cycle's reconstruction is complete: fills fetched, no
+	// page-cap truncation (a cap leaves newer fills un-booked → would read as
+	// drift), and no unclassifiable fill has latched the journal incomplete.
+	rec.Usable = res.FillsFetched && !res.Capped && !st.Incomplete
+	return rec
+}
+
+// logTopStepCashflowJournalShadow logs one TopStep wallet's journal-derived
+// expected equity every cycle (SHADOW phase). It NEVER mutates driftResults —
+// there is no live TopStep shared-wallet alarm (TopStep is display-skipped). The
+// splitNote is "n/a" unless a TopStep drift result is ever wired in. Phase 4b will
+// switch a real alarm onto the journal once this shadow log proves the TopStep
+// fills feed / equity field in production. Mirrors logOKXCashflowJournalShadow.
+func logTopStepCashflowJournalShadow(driftResults []sharedWalletDriftResult, key SharedWalletKey, rec *cashflowJournalReconcile) {
+	if rec == nil {
+		return
+	}
+	splitNote := "n/a"
+	for i := range driftResults {
+		if driftResults[i].Key == key {
+			d := driftResults[i]
+			splitNote = fmt.Sprintf("raw $%+.2f / drift $%+.2f", d.Balance-d.MemberSum, d.Drift)
+			break
+		}
+	}
+	state := "shadow-usable"
+	switch {
+	case rec.Incomplete:
+		state = "shadow-incomplete (unclassified fill — would fail closed)"
+	case !rec.Usable:
+		state = "shadow-pending (no usable reading this cycle)"
+	}
+	fmt.Printf("[topstep-cashflow-journal] %s: expected_equity $%.2f vs equity $%.2f → journal_drift $%+.4f (settled Σ $%+.2f, ΔuPnL $%+.2f); display %s; %s — SHADOW, no alarm\n",
+		sharedWalletKeyLabel(key), rec.ExpectedEquity, rec.AccountValue, rec.Drift, rec.SettledSum, rec.DeltaUPnL, splitNote, state)
+}

--- a/scheduler/topstep_cashflow_journal.go
+++ b/scheduler/topstep_cashflow_journal.go
@@ -173,13 +173,13 @@ func defaultTopStepEquitySnapshot() (equity, upnl float64, err error) {
 // positive equity, so equity ≤ 0 means the (unverified) /v1/account/balance
 // response was malformed or shape-mismatched — e.g. a 200 missing the "equity"
 // field, which the fetcher would otherwise coerce to 0 and report as success.
-// Returning an error keeps walletBalances[tsKey] UNSET so the portfolio-value
-// path falls back to the member-PV sum and freezes the portfolio peak, instead
-// of contributing a silent $0 that collapses the TopStep account's portfolio
-// value and could trip the all-platform portfolio kill switch (CheckPortfolioRisk
-// consumes a PRESENT walletBalances[key] directly via computeSubsetPortfolioValue,
-// with no member-PV fallback on a present zero). A genuinely good positive equity
-// flows through unchanged. Pure — unit-tested.
+// Returning an error makes the caller skip the shadow journal this cycle instead
+// of reconciling against a garbage $0 equity (which would emit phantom drift in
+// the shadow log and corrupt the persisted baseline). The TopStep equity is
+// shadow-only and never enters computeTotalPortfolioValue (see
+// detectTopStepSharedWallet), so this guards journal correctness, not the live
+// kill switch. A genuinely good positive equity flows through unchanged. Pure —
+// unit-tested.
 func validatedTopStepEquity(balance, upnl float64) (equity, upnlOut float64, err error) {
 	if !(balance > 0) { // also rejects NaN
 		return 0, 0, fmt.Errorf("non-positive TopStep equity $%.2f — treating as a fetch miss (malformed /v1/account/balance response)", balance)

--- a/scheduler/topstep_cashflow_journal_test.go
+++ b/scheduler/topstep_cashflow_journal_test.go
@@ -1,0 +1,356 @@
+package main
+
+import (
+	"errors"
+	"math"
+	"testing"
+	"time"
+)
+
+// #1106 TopStep exchange-sourced cash-flow journal (shadow phase): the fill
+// settled-cash convention (gross realized PnL − commission, HL-like), kind
+// classification + fail-closed on unmapped kinds, dedup, single-stream cursor
+// discipline, snapshot bounding, baseline anchoring, and usability gating.
+
+// A fill's settled-cash delta is gross realized PnL minus the commission charged.
+// A known kind is classifiable; an unknown kind still books gross−fee but is NOT
+// known (latches incomplete). An empty kind is a plain trade fill.
+func TestTopStepFillSettledDelta(t *testing.T) {
+	cases := []struct {
+		name      string
+		fill      topstepFillRecord
+		wantDelta float64
+		wantKind  string
+		wantKnown bool
+	}{
+		{"closing fill pnl-fee net", topstepFillRecord{Kind: "trade", RealizedPnL: 20, Fee: 0.3}, 19.7, "trade", true},
+		{"entry fill settles -commission", topstepFillRecord{Kind: "", RealizedPnL: 0, Fee: 0.5}, -0.5, "trade", true},
+		{"standalone commission", topstepFillRecord{Kind: "commission", RealizedPnL: 0, Fee: 1.0}, -1.0, "commission", true},
+		{"fee synonym maps to commission", topstepFillRecord{Kind: "fee", RealizedPnL: 0, Fee: 0.25}, -0.25, "commission", true},
+		{"maker rebate (negative fee → positive delta)", topstepFillRecord{Kind: "trade", RealizedPnL: 0, Fee: -0.1}, 0.1, "trade", true},
+		{"unknown kind books gross-fee but not known", topstepFillRecord{Kind: "payout", RealizedPnL: 0, Fee: 0}, 0, "kind_payout", false},
+	}
+	for _, tc := range cases {
+		gotDelta, gotKind, gotKnown := topstepFillSettledDelta(tc.fill)
+		if math.Abs(gotDelta-tc.wantDelta) > 1e-9 || gotKind != tc.wantKind || gotKnown != tc.wantKnown {
+			t.Errorf("%s: topstepFillSettledDelta = (%v,%q,%v), want (%v,%q,%v)",
+				tc.name, gotDelta, gotKind, gotKnown, tc.wantDelta, tc.wantKind, tc.wantKnown)
+		}
+	}
+}
+
+// fillId is the canonical key; the kind:ts:symbol form is the fallback when
+// fillId is absent or "0". Namespaced "topstepfill:" so it can never collide with
+// the HL fill/funding/transfer or OKX bill namespaces in the shared table.
+func TestTopStepFillDedupID(t *testing.T) {
+	withID := topstepFillRecord{FillID: "f1", Kind: "trade", TimeMs: 1700000000000, Symbol: "ES"}
+	if got, want := topstepFillDedupID(withID), "topstepfill:f1"; got != want {
+		t.Errorf("fillId present: got %q, want %q", got, want)
+	}
+	zeroID := topstepFillRecord{FillID: "0", Kind: "trade", TimeMs: 1700000000001, Symbol: "es"}
+	if got, want := topstepFillDedupID(zeroID), "topstepfill:trade:1700000000001:ES"; got != want {
+		t.Errorf("fillId zero: got %q, want %q", got, want)
+	}
+	emptyID := topstepFillRecord{Kind: "commission", TimeMs: 1700000000002, Symbol: "NQ"}
+	if got, want := topstepFillDedupID(emptyID), "topstepfill:commission:1700000000002:NQ"; got != want {
+		t.Errorf("fillId empty: got %q, want %q", got, want)
+	}
+}
+
+func newTopStepJournalKey() SharedWalletKey {
+	return SharedWalletKey{Platform: "topstep", Account: "ts-acct-123"}
+}
+
+// First contact anchors the baseline to the supplied equity/uPnL snapshot and the
+// fills cursor to now, fetching NO history; TopStep uses only the FillsSinceMs
+// cursor (funding/transfers stay 0).
+func TestTopStepCashflowJournalBaselineAnchor(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := newTopStepJournalKey()
+	now := time.UnixMilli(1700000000000).UTC()
+
+	res := fetchTopStepCashflowJournalEvents(db, key, 50000.0, 120.0, now)
+	if !res.StateFound || res.FillsFetched {
+		t.Fatalf("baseline cycle: StateFound=%v FillsFetched=%v, want true/false", res.StateFound, res.FillsFetched)
+	}
+	st, found, err := db.GetCashflowJournalState(key.Platform, key.Account)
+	if err != nil || !found {
+		t.Fatalf("state after baseline: found=%v err=%v", found, err)
+	}
+	if !st.BaselineSet || st.BaselineAccountValue != 50000.0 || st.BaselineUPnL != 120.0 {
+		t.Errorf("baseline not anchored: %+v", st)
+	}
+	if st.FillsSinceMs != now.UnixMilli() {
+		t.Errorf("fills cursor not anchored at now: %d, want %d", st.FillsSinceMs, now.UnixMilli())
+	}
+	if st.FundingSinceMs != 0 || st.TransfersSinceMs != 0 {
+		t.Errorf("TopStep must leave funding/transfers cursors unused: %+v", st)
+	}
+}
+
+// End-to-end fetch -> ingest -> sum with a stubbed fills feed. The settled sum is
+// Σ(gross − fee) over fills; the expected equity closes the loop against a
+// hand-computed equity.
+func TestTopStepCashflowJournalIngestAndExpectedEquity(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := newTopStepJournalKey()
+	t0 := time.UnixMilli(1700000000000).UTC()
+
+	// Anchor at equity=1000, uPnL=0, cursor t0.
+	if r := fetchTopStepCashflowJournalEvents(db, key, 1000.0, 0.0, t0); !r.StateFound {
+		t.Fatal("baseline init failed")
+	}
+
+	orig := fetchTopStepAccountFills
+	defer func() { fetchTopStepAccountFills = orig }()
+	fetchTopStepAccountFills = func(sinceMs int64) ([]topstepFillRecord, bool, error) {
+		return []topstepFillRecord{
+			{FillID: "f1", TimeMs: t0.UnixMilli() + 10, Symbol: "ES", Kind: "trade", RealizedPnL: 0, Fee: 0.5},   // entry: -0.5
+			{FillID: "f2", TimeMs: t0.UnixMilli() + 20, Symbol: "ES", Kind: "trade", RealizedPnL: 20, Fee: 0.3},  // close: 19.7
+			{FillID: "f3", TimeMs: t0.UnixMilli() + 5, Symbol: "NQ", Kind: "commission", RealizedPnL: 0, Fee: 1}, // -1.0
+		}, false, nil
+	}
+
+	snap := t0.Add(time.Minute)
+	// equity = 1000 + (−0.5 + 19.7 − 1.0) + (uPnL 5 − 0) = 1023.2
+	res := fetchTopStepCashflowJournalEvents(db, key, 1023.2, 5.0, snap)
+	if !res.FillsFetched || res.Capped {
+		t.Fatalf("expected fills fetched, not capped: %+v", res)
+	}
+	st := ingestTopStepCashflowJournalEvents(db, res, snap.UnixMilli())
+	if st.Incomplete {
+		t.Error("all fills classified — journal must not be marked incomplete")
+	}
+
+	settled, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	const wantSettled = -0.5 + 19.7 - 1.0 // 18.2
+	if math.Abs(settled-wantSettled) > 1e-9 {
+		t.Fatalf("settled sum = %v, want %v", settled, wantSettled)
+	}
+
+	expected := cashflowJournalExpectedEquity(st.BaselineAccountValue, st.BaselineUPnL, settled, res.CurrentUPnL)
+	if math.Abs(expected-1023.2) > 1e-9 {
+		t.Errorf("expected equity = %v, want 1023.2", expected)
+	}
+	if drift := res.AccountValue - expected; math.Abs(drift) > 1e-9 {
+		t.Errorf("journal drift = %v, want ~0", drift)
+	}
+	if st.FillsSinceMs != t0.UnixMilli()+20+1 {
+		t.Errorf("fills cursor = %d, want %d", st.FillsSinceMs, t0.UnixMilli()+21)
+	}
+}
+
+// A fill settled AFTER the equity snapshot is deferred to next cycle: not booked,
+// cursor not advanced past it.
+func TestTopStepCashflowJournalSnapshotBound(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := newTopStepJournalKey()
+	base := CashflowJournalState{FillsSinceMs: 100, BaselineSet: true}
+	if err := db.UpsertCashflowJournalState(key.Platform, key.Account, base); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	res := topstepCashflowJournalFetchResult{
+		Key: key, State: base, StateFound: true, FillsFetched: true,
+		Fills: []topstepFillRecord{
+			{FillID: "in", TimeMs: 150, Symbol: "ES", Kind: "trade", RealizedPnL: 10},
+			{FillID: "after", TimeMs: 250, Symbol: "ES", Kind: "trade", RealizedPnL: 999}, // settled after cutoff
+		},
+	}
+	st := ingestTopStepCashflowJournalEvents(db, res, 200) // cutoff 200
+	sum, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	if math.Abs(sum-10) > 1e-9 {
+		t.Errorf("post-cutoff fill leaked: sum = %v, want 10", sum)
+	}
+	if st.FillsSinceMs != 151 {
+		t.Errorf("cursor must stop before the deferred fill: got %d, want 151", st.FillsSinceMs)
+	}
+}
+
+// A NON-capped fetch advances the cursor past the last booked fill (maxTime+1),
+// but a CAPPED fetch advances only TO maxTime so the boundary millisecond is
+// re-read next cycle (cursor-side complement of the adapter's fail-closed cap).
+func TestTopStepCashflowJournalCappedAdvancesOnlyToMaxTime(t *testing.T) {
+	mk := func(capped bool) CashflowJournalState {
+		db := newCashflowJournalTestDB(t)
+		key := newTopStepJournalKey()
+		base := CashflowJournalState{FillsSinceMs: 100, BaselineSet: true}
+		if err := db.UpsertCashflowJournalState(key.Platform, key.Account, base); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		res := topstepCashflowJournalFetchResult{
+			Key: key, State: base, StateFound: true, FillsFetched: true, Capped: capped,
+			Fills: []topstepFillRecord{
+				{FillID: "a", TimeMs: 150, Symbol: "ES", Kind: "trade", RealizedPnL: 5},
+				{FillID: "b", TimeMs: 200, Symbol: "ES", Kind: "trade", RealizedPnL: 5}, // maxTime = 200
+			},
+		}
+		return ingestTopStepCashflowJournalEvents(db, res, cashflowCutoffAll)
+	}
+	if st := mk(false); st.FillsSinceMs != 201 {
+		t.Errorf("non-capped: cursor = %d, want 201 (maxTime+1)", st.FillsSinceMs)
+	}
+	if st := mk(true); st.FillsSinceMs != 200 {
+		t.Errorf("capped: cursor = %d, want 200 (maxTime — boundary ms re-read next cycle)", st.FillsSinceMs)
+	}
+}
+
+// An unclassified fill (unknown kind) latches incomplete AND still books its
+// authoritative gross−fee delta so the running drift surfaces it.
+func TestTopStepCashflowJournalUnclassifiedLatchesIncomplete(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := newTopStepJournalKey()
+	base := CashflowJournalState{FillsSinceMs: 100, BaselineSet: true}
+	if err := db.UpsertCashflowJournalState(key.Platform, key.Account, base); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	res := topstepCashflowJournalFetchResult{
+		Key: key, State: base, StateFound: true, FillsFetched: true,
+		Fills: []topstepFillRecord{
+			{FillID: "u1", TimeMs: 150, Symbol: "ES", Kind: "payout", RealizedPnL: 0, Fee: -7}, // unknown kind, balance change +7
+		},
+	}
+	st := ingestTopStepCashflowJournalEvents(db, res, cashflowCutoffAll)
+	if !st.Incomplete {
+		t.Error("unknown fill kind must latch incomplete")
+	}
+	sum, _ := db.SumCashflowJournal(key.Platform, key.Account)
+	if math.Abs(sum-7) > 1e-9 {
+		t.Errorf("unknown-kind gross−fee must still be booked (authoritative): sum = %v, want 7", sum)
+	}
+}
+
+// A fill insert failure halts the cursor at the failed fill so a crash can never
+// strand an un-booked event behind an advanced watermark.
+func TestTopStepCashflowJournalHaltsCursorOnPersistFailure(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := newTopStepJournalKey()
+	base := CashflowJournalState{FillsSinceMs: 100, BaselineSet: true}
+	if err := db.UpsertCashflowJournalState(key.Platform, key.Account, base); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	db.Close()
+	res := topstepCashflowJournalFetchResult{
+		Key: key, State: base, StateFound: true, FillsFetched: true,
+		Fills: []topstepFillRecord{{FillID: "b", TimeMs: 150, Symbol: "ES", Kind: "trade", RealizedPnL: 10}},
+	}
+	st := ingestTopStepCashflowJournalEvents(db, res, cashflowCutoffAll)
+	if st.FillsSinceMs != 100 {
+		t.Errorf("cursor advanced past an un-booked fill: got %d, want 100", st.FillsSinceMs)
+	}
+}
+
+// reconcile is usable only when fills fetched, not capped, and not incomplete.
+func TestTopStepCashflowJournalReconcileUsability(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := newTopStepJournalKey()
+	t0 := time.UnixMilli(1700000000000).UTC()
+	if r := fetchTopStepCashflowJournalEvents(db, key, 1000.0, 0.0, t0); !r.StateFound {
+		t.Fatal("baseline init failed")
+	}
+	orig := fetchTopStepAccountFills
+	defer func() { fetchTopStepAccountFills = orig }()
+
+	// Clean, classifiable fill → usable.
+	fetchTopStepAccountFills = func(int64) ([]topstepFillRecord, bool, error) {
+		return []topstepFillRecord{{FillID: "f1", TimeMs: t0.UnixMilli() + 10, Symbol: "ES", Kind: "trade", RealizedPnL: 5}}, false, nil
+	}
+	snap := t0.Add(time.Minute)
+	rec := reconcileTopStepCashflowJournal(db, key, 1005.0, 0.0, snap)
+	if rec == nil || !rec.Usable || rec.Incomplete {
+		t.Fatalf("clean cycle: rec=%+v, want usable & not incomplete", rec)
+	}
+	if math.Abs(rec.Drift) > 1e-9 {
+		t.Errorf("clean cycle drift = %v, want ~0", rec.Drift)
+	}
+
+	// Capped fetch → not usable even though a baseline exists.
+	fetchTopStepAccountFills = func(int64) ([]topstepFillRecord, bool, error) {
+		return []topstepFillRecord{{FillID: "f2", TimeMs: snap.UnixMilli() + 10, Symbol: "ES", Kind: "trade", RealizedPnL: 1}}, true, nil
+	}
+	snap2 := snap.Add(time.Minute)
+	rec2 := reconcileTopStepCashflowJournal(db, key, 1006.0, 0.0, snap2)
+	if rec2 == nil || rec2.Usable {
+		t.Fatalf("capped cycle: rec=%+v, want not usable", rec2)
+	}
+
+	// Fetch error → StateFound true but fills not fetched, not usable.
+	fetchTopStepAccountFills = func(int64) ([]topstepFillRecord, bool, error) {
+		return nil, false, errors.New("topstep fills 500")
+	}
+	snap3 := snap2.Add(time.Minute)
+	rec3 := reconcileTopStepCashflowJournal(db, key, 1007.0, 0.0, snap3)
+	if rec3 == nil || rec3.Usable {
+		t.Fatalf("fetch-error cycle: rec=%+v, want not usable", rec3)
+	}
+}
+
+// reconcile returns nil for a non-TopStep key (HL/OKX stay on their own paths).
+func TestTopStepCashflowJournalRejectsNonTopStepKey(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	okxKey := SharedWalletKey{Platform: "okx", Account: "okx-key"}
+	if rec := reconcileTopStepCashflowJournal(db, okxKey, 1000, 0, time.Now()); rec != nil {
+		t.Errorf("non-TopStep key must return nil, got %+v", rec)
+	}
+}
+
+// The shadow logger never mutates driftResults (TopStep has no live alarm).
+func TestTopStepCashflowJournalShadowDoesNotMutate(t *testing.T) {
+	key := newTopStepJournalKey()
+	results := []sharedWalletDriftResult{
+		{Key: key, Drift: 1.23, Balance: 50000, MemberSum: 49998.77},
+	}
+	rec := &cashflowJournalReconcile{Key: key, AccountValue: 50000, ExpectedEquity: 50002.5, Drift: -2.5, Usable: true}
+	logTopStepCashflowJournalShadow(results, key, rec)
+	if results[0].Drift != 1.23 || results[0].Basis != "" || results[0].ExpectedEquity != 0 {
+		t.Errorf("shadow log mutated the drift result: %+v", results[0])
+	}
+}
+
+// parseTopStepFillsOutput follows the 5-case matrix: clean success,
+// exit-0-with-error, exit-nonzero-with-error, exit-nonzero-no-error, unparseable.
+func TestParseTopStepFillsOutput(t *testing.T) {
+	clean := []byte(`{"fills":[{"fill_id":"f1","ts_ms":1700000000000,"symbol":"ES","kind":"trade","realized_pnl":19.7,"fee":0.3}],"capped":false,"platform":"topstep","timestamp":"t"}`)
+	res, _, err := parseTopStepFillsOutput(clean, "", nil)
+	if err != nil || res == nil || len(res.Fills) != 1 || res.Fills[0].FillID != "f1" || res.Fills[0].RealizedPnL != 19.7 {
+		t.Fatalf("clean: res=%+v err=%v", res, err)
+	}
+	if res.Capped {
+		t.Error("clean: capped should be false")
+	}
+
+	errEnvelope := []byte(`{"fills":[],"capped":false,"platform":"topstep","timestamp":"t","error":"not live"}`)
+	if _, _, err := parseTopStepFillsOutput(errEnvelope, "", errors.New("exit 1")); err == nil {
+		t.Error("error envelope must surface a non-nil error")
+	}
+	if _, _, err := parseTopStepFillsOutput(errEnvelope, "", nil); err == nil {
+		t.Error("exit-0-with-error must surface a non-nil error")
+	}
+	if _, _, err := parseTopStepFillsOutput([]byte(`{"fills":[]}`), "", errors.New("exit 1")); err == nil {
+		t.Error("exit-nonzero with no error field must be treated as failure")
+	}
+	if _, _, err := parseTopStepFillsOutput([]byte(`not json`), "boom", errors.New("exit 2")); err == nil {
+		t.Error("unparseable output must error")
+	}
+}
+
+// parseTopStepBalanceOutput follows the same 5-case matrix.
+func TestParseTopStepBalanceOutput(t *testing.T) {
+	clean := []byte(`{"balance":50000.5,"unrealized_pnl":12.5,"platform":"topstep","timestamp":"t"}`)
+	res, _, err := parseTopStepBalanceOutput(clean, "", nil)
+	if err != nil || res == nil || res.Balance != 50000.5 || res.UnrealizedPnL != 12.5 {
+		t.Fatalf("clean: res=%+v err=%v", res, err)
+	}
+	errEnvelope := []byte(`{"balance":0,"unrealized_pnl":0,"platform":"topstep","timestamp":"t","error":"not live"}`)
+	if _, _, err := parseTopStepBalanceOutput(errEnvelope, "", nil); err == nil {
+		t.Error("exit-0-with-error must surface a non-nil error")
+	}
+	if _, _, err := parseTopStepBalanceOutput([]byte(`nope`), "boom", errors.New("exit 2")); err == nil {
+		t.Error("unparseable output must error")
+	}
+}

--- a/scheduler/topstep_cashflow_journal_test.go
+++ b/scheduler/topstep_cashflow_journal_test.go
@@ -61,6 +61,23 @@ func newTopStepJournalKey() SharedWalletKey {
 	return SharedWalletKey{Platform: "topstep", Account: "ts-acct-123"}
 }
 
+// A non-positive (or NaN) equity must be treated as a fetch MISS (error), so the
+// snapshot never feeds walletBalances[tsKey] a silent $0 that could collapse the
+// account's portfolio value and trip the all-platform kill switch. A genuinely
+// positive equity flows through unchanged.
+func TestValidatedTopStepEquity(t *testing.T) {
+	// Good positive equity passes through with uPnL preserved.
+	if eq, upnl, err := validatedTopStepEquity(50000.0, 12.5); err != nil || eq != 50000.0 || upnl != 12.5 {
+		t.Errorf("positive equity: got (%v,%v,%v), want (50000,12.5,nil)", eq, upnl, err)
+	}
+	// Missing-equity-coerced-to-0, exact 0, negative, and NaN all become a miss.
+	for _, bad := range []float64{0, -1, math.NaN()} {
+		if _, _, err := validatedTopStepEquity(bad, 5.0); err == nil {
+			t.Errorf("equity %v must be treated as a fetch miss (error), got nil", bad)
+		}
+	}
+}
+
 // First contact anchors the baseline to the supplied equity/uPnL snapshot and the
 // fills cursor to now, fetching NO history; TopStep uses only the FillsSinceMs
 // cursor (funding/transfers stay 0).

--- a/scheduler/topstep_cashflow_journal_test.go
+++ b/scheduler/topstep_cashflow_journal_test.go
@@ -62,9 +62,9 @@ func newTopStepJournalKey() SharedWalletKey {
 }
 
 // A non-positive (or NaN) equity must be treated as a fetch MISS (error), so the
-// snapshot never feeds walletBalances[tsKey] a silent $0 that could collapse the
-// account's portfolio value and trip the all-platform kill switch. A genuinely
-// positive equity flows through unchanged.
+// shadow journal skips the cycle instead of reconciling against a garbage $0
+// equity (which would emit phantom drift and corrupt the persisted baseline). A
+// genuinely positive equity flows through unchanged.
 func TestValidatedTopStepEquity(t *testing.T) {
 	// Good positive equity passes through with uPnL preserved.
 	if eq, upnl, err := validatedTopStepEquity(50000.0, 12.5); err != nil || eq != 50000.0 || upnl != 12.5 {

--- a/shared_scripts/fetch_topstep_balance.py
+++ b/shared_scripts/fetch_topstep_balance.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+TopStep live account-balance fetcher (issue #1106 — exchange-sourced cash-flow
+journal, shadow phase / Phase 4 of #1100).
+
+Emits the USD account equity (settled cash + unrealized PnL) for the configured
+TopStep account, plus the unrealized-PnL component from the SAME read, so the Go
+cash-flow journal reconciles a coherent equity/uPnL snapshot (no intra-cycle
+jitter). Mirrors fetch_okx_balance.py.
+
+Requires TOPSTEP_API_KEY / TOPSTEP_API_SECRET / TOPSTEP_ACCOUNT_ID. Output:
+``{"balance": 1234.56, "unrealized_pnl": 5.0, "platform": "topstep",
+  "timestamp": ..., "error": "..."}``
+where ``balance`` is the USD equity and ``unrealized_pnl`` is equity − cashBalance.
+"""
+
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "platforms", "topstep"))
+
+
+def main():
+    try:
+        from adapter import TopStepExchangeAdapter
+        adapter = TopStepExchangeAdapter(mode="live")
+        if not adapter.is_live:
+            _emit_error("TopStep adapter not live — set TOPSTEP_API_KEY / TOPSTEP_API_SECRET / TOPSTEP_ACCOUNT_ID")
+            return
+        equity, upnl = adapter.get_account_equity_and_upnl()
+        balance = float(equity or 0.0)
+        unrealized_pnl = float(upnl or 0.0)
+    except Exception as e:
+        traceback.print_exc(file=sys.stderr)
+        _emit_error(str(e))
+        return
+
+    print(json.dumps({
+        "balance": balance,
+        "unrealized_pnl": unrealized_pnl,
+        "platform": "topstep",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }))
+
+
+def _emit_error(message):
+    print(json.dumps({
+        "balance": 0.0,
+        "unrealized_pnl": 0.0,
+        "platform": "topstep",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "error": message,
+    }))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/shared_scripts/fetch_topstep_fills.py
+++ b/shared_scripts/fetch_topstep_fills.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+TopStep live trade-fills fetcher (issue #1106 — exchange-sourced cash-flow
+journal, shadow phase / Phase 4 of #1100).
+
+Emits every settled TopStep trade fill since a cursor timestamp. A TopStep fill
+carries a GROSS realized PnL (0 for entry fills) and a separately-reported
+commission; the Go cash-flow journal computes each fill's settled-cash delta as
+realized-PnL-gross minus commission (mirroring Hyperliquid's userFills, NOT OKX's
+pre-netted balChg). This single feed is the settled-cash-flow source the journal
+reconstructs the wallet equity from.
+
+Thin pump: all mapping / summing / fail-closed logic lives in tested Go
+(topstep_cashflow_journal.go); this script only pages fills via the adapter and
+shapes them to JSON.
+
+Usage:
+    fetch_topstep_fills.py --since-ms <int>
+
+Requires TOPSTEP_API_KEY / TOPSTEP_API_SECRET / TOPSTEP_ACCOUNT_ID. Output:
+``{"fills": [{"fill_id","ts_ms","symbol","kind","realized_pnl","fee"}, ...],
+  "capped": false, "platform": "topstep", "timestamp": ...}``
+Fills are oldest-first; ``capped`` is true when the adapter hit its page limit
+before exhausting the feed (the Go journal treats that cycle as not-usable).
+"""
+
+import argparse
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "platforms", "topstep"))
+
+
+def _parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Fetch TopStep trade fills since a cursor.")
+    parser.add_argument(
+        "--since-ms",
+        type=int,
+        default=0,
+        help="Only return fills settled at or after this epoch-millisecond cursor.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = _parse_args(argv)
+    try:
+        from adapter import TopStepExchangeAdapter
+        adapter = TopStepExchangeAdapter(mode="live")
+        if not adapter.is_live:
+            _emit_error("TopStep adapter not live — set TOPSTEP_API_KEY / TOPSTEP_API_SECRET / TOPSTEP_ACCOUNT_ID")
+            return
+        fills, capped = adapter.get_account_fills(since_ms=args.since_ms)
+    except Exception as e:
+        traceback.print_exc(file=sys.stderr)
+        _emit_error(str(e))
+        return
+
+    print(json.dumps({
+        "fills": fills or [],
+        "capped": bool(capped),
+        "platform": "topstep",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }))
+
+
+def _emit_error(message):
+    print(json.dumps({
+        "fills": [],
+        "capped": False,
+        "platform": "topstep",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "error": message,
+    }))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Phase 4 of #1100. Brings TopStep into the exchange-sourced cash-flow journal as a **SHADOW** reconciler, reusing the HL (#1103/#1104) and OKX (#1105) machinery. **HL and OKX paths are untouched.**

## What this does

- **Enables the snapshot side first** (the issue's gating prerequisite): registers `topstep` in `platformsWithSharedWalletBalanceFetcher` so `detectSharedWallets` surfaces TopStep shared wallets. The coherent `(equity, uPnL)` snapshot is owned by a dedicated main-loop block (`defaultTopStepEquitySnapshot`), mirroring OKX — `defaultSharedWalletFetcher` intentionally has no topstep case.
- **No display mutation.** TopStep stays display-skipped in `reconcileSharedWalletDisplayValues` (no position source → `default: continue`), so enabling the fetcher does not activate any capital-weight split. A balance-fetch failure leaves `walletBalances[tsKey]` unset, so `computeTotalPortfolioValue` falls back to the member-PV sum — no false-zero equity that could trip a kill switch.
- **Single fill stream, HL-like settled-cash convention.** Each fill's settled-cash delta is GROSS realized PnL − commission (`cashflowFillSettledDelta`); the gross value is retained for attribution only and is never summed into equity (same #698 discipline). Reconciled field is named explicitly: **TopStep account EQUITY** (settled USD cash + unrealized PnL).
- **Fail-closed classification.** An unmapped fill `kind` books its authoritative gross−fee delta but latches the journal `incomplete` so a future Phase-4b alarm flip fails closed.
- Reuses the durable cursor, per-event dedup, halt-on-persist-failure, snapshot-bounded ingest, and the shared equity equation.

## ⚠️ Endpoint contracts are unverified (read before promoting)

TopStep has no balance/fills feed today, and the existing live adapter targets a speculative `X-API-Key` / `GET /v1/account/*` shape that does **not** match the real TopStepX/ProjectX gateway. The new `get_account_equity_and_upnl` / `get_account_fills` methods and `fetch_topstep_{balance,fills}.py` mirror that existing (unverified) contract. **These endpoint shapes MUST be confirmed against the live venue before any Phase-4b alarm flip.** This is safe to land now because the journal is **shadow-only** (logs, never drives an alarm) and inert unless 2+ live TopStep strategies share one account — which is not the case today.

## Verification

- `go build ./scheduler` ✅ · full `go test ./scheduler/...` ✅
- `platforms/` pytest: 318 passed; new topstep adapter feed tests: 21 passed ✅
- `py_compile` of both fetchers ✅; both emit a clean error envelope + exit 1 when not live ✅
- New Go journal unit tests: settled-delta, dedup, baseline anchor, ingest+expected-equity, snapshot bound, capped-cursor discipline, unclassified→incomplete, persist-failure halt, reconcile usability, non-key reject, shadow no-mutate, parsers. Existing `detect-shared-wallets` and fetcher-map tests updated for the new fetcher.

Closes #1106

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code
