### PR TITLE
feat(#1110): alert on trailing TP ratchet tier trigger

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -156,6 +156,7 @@ type Config struct {
 	RiskFreeRate           *float64                   `json:"risk_free_rate,omitempty"`             // #397 — annualized risk-free rate used in Sharpe-ratio calculations (e.g. 0.02 for 2%). Nil/missing falls back to DefaultAnnualRiskFreeRate; an explicit 0 is respected so backtest comparisons can pin to a 0% benchmark.
 	DefaultStopLossATRMult *float64                   `json:"default_stop_loss_atr_mult,omitempty"` // #605 — top-level default applied to HL perps/manual strategies that omit all stop_loss_* / trailing_stop_* fields. Nil/missing falls back to 1.0; explicit values let operators tune the ATR stop without recompiling.
 	NotifyTPSLFills        *bool                      `json:"notify_tp_sl_fills,omitempty"`         // #661 — owner DM when HL on-chain TP/SL fills are detected by the reconciler. Nil/missing → enabled; explicit false disables.
+	NotifyRatchetTriggers  *bool                      `json:"notify_ratchet_triggers,omitempty"`    // #1110 — owner DM when a trailing_tp_ratchet* tier clears and tightens the trail. Nil/missing → enabled; explicit false disables.
 	ManualDefaults         *ManualDefaultsConfig      `json:"manual_defaults,omitempty"`            // #696 — operator-tunable defaults for `manual-open` CLI and `type=manual` strategy auto-config. Each field optional; absent values fall back to the hardcoded defaults.
 	TradingViewExport      TradingViewExportConfig    `json:"tradingview_export,omitempty"`         // #3 — optional symbol overrides for TradingView portfolio CSV exports
 	UserCloseDefaults      CloseDefaultsMap           `json:"user_close_defaults,omitempty"`        // #866 — operator override layer for close-evaluator default tier ladders. Keyed by close evaluator name → {"tp_tiers": <list|regime-map>}. Injected into any close ref that omits tp_tiers at load; per-strategy tp_tiers still wins, and an absent entry falls through to the system default.
@@ -248,6 +249,17 @@ func (c *Config) NotifyTPSLFillsEnabled() bool {
 		return true
 	}
 	return *c.NotifyTPSLFills
+}
+
+// NotifyRatchetTriggersEnabled reports whether a trailing_tp_ratchet* tier
+// clearing (and tightening the trail) should trigger an owner DM. Nil pointer
+// (missing field) defaults to true so existing configs get the alert without an
+// explicit opt-in (mirrors NotifyTPSLFillsEnabled).
+func (c *Config) NotifyRatchetTriggersEnabled() bool {
+	if c == nil || c.NotifyRatchetTriggers == nil {
+		return true
+	}
+	return *c.NotifyRatchetTriggers
 }
 
 // CircuitBreakerEnabled reports whether the per-strategy circuit breaker is

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1874,7 +1874,8 @@ func main() {
 							var execResult *HyperliquidExecuteResult
 							liveExecFailed := false
 							if result.Signal == 0 && hlPosQty > 0 && strategyUsesTrailingTPRatchetClose(sc) {
-								applyTrailingTPRatchet(sc, stratState, result.Symbol, price, &mu, logger)
+								ratchetAlert := applyTrailingTPRatchet(sc, stratState, result.Symbol, price, &mu, logger)
+								notifyRatchetTrigger(notifier, cfg.NotifyRatchetTriggersEnabled(), ratchetAlert)
 								mu.RLock()
 								if pos, ok3 := stratState.Positions[result.Symbol]; ok3 && pos != nil {
 									hlPosSnapshot = hyperliquidProtectionPositionSnapshot(pos)
@@ -2065,12 +2066,17 @@ func main() {
 							if !liveExecFailed {
 								mu.Lock()
 								var openTrade *Trade
+								var ratchetAlert *RatchetTriggerAlert
 								if scaleInAddQty > 0 {
 									trades, detail, openTrade = executeHyperliquidScaleInDeferredOpen(sc, stratState, result, execResult, signalStr, price, scaleInAddQty, logger)
 								} else {
-									trades, detail, openTrade = executeHyperliquidResultDeferredOpen(sc, stratState, result, execResult, signalStr, price, cfg.Regime, logger)
+									trades, detail, openTrade, ratchetAlert = executeHyperliquidResultDeferredOpen(sc, stratState, result, execResult, signalStr, price, cfg.Regime, logger)
 								}
 								mu.Unlock()
+								// #1110: deliver any ratchet-tighten DM after releasing the lock
+								// (Discord/Telegram HTTP must not run under mu). Nil-safe no-op
+								// for the scale-in branch and when no tier tightened.
+								notifyRatchetTrigger(notifier, cfg.NotifyRatchetTriggersEnabled(), ratchetAlert)
 								if execResult != nil && trades > 0 {
 									runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced after trade", hlReconcileFillHintsJSON)
 									runPostTPStopLossAdjustment(sc, stratState, result.Symbol, price, cfg, &mu, notifier, logger, hlOnChainAbsQty)
@@ -2226,7 +2232,8 @@ func main() {
 							runPostTPStopLossAdjustment(sc, stratState, sc.Symbol, prices[sc.Symbol], cfg, &mu, notifier, logger, hlOnChainAbsQty)
 							mark := prices[sc.Symbol]
 							if mark > 0 && strategyUsesTrailingTPRatchetClose(sc) {
-								applyTrailingTPRatchet(sc, stratState, sc.Symbol, mark, &mu, logger)
+								ratchetAlert := applyTrailingTPRatchet(sc, stratState, sc.Symbol, mark, &mu, logger)
+								notifyRatchetTrigger(notifier, cfg.NotifyRatchetTriggersEnabled(), ratchetAlert)
 							}
 							mu.RLock()
 							pos = stratState.Positions[sc.Symbol]
@@ -3413,7 +3420,7 @@ func isHLOpenOrderCapRejection(errStr string) bool {
 }
 
 func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *HyperliquidResult, execResult *HyperliquidExecuteResult, signalStr string, price float64, regime *RegimeConfig, logger *StrategyLogger) (int, string) {
-	trades, detail, openTrade := executeHyperliquidResultDeferredOpen(sc, s, result, execResult, signalStr, price, regime, logger)
+	trades, detail, openTrade, _ := executeHyperliquidResultDeferredOpen(sc, s, result, execResult, signalStr, price, regime, logger)
 	if openTrade != nil {
 		var pos *Position
 		if p, ok := s.Positions[result.Symbol]; ok {
@@ -3428,7 +3435,7 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 // Must be called under Lock. execResult is non-nil for successful live orders;
 // nil for paper mode. Live open trades are returned so the caller can run
 // same-cycle protection sync before the single INSERT.
-func executeHyperliquidResultDeferredOpen(sc StrategyConfig, s *StrategyState, result *HyperliquidResult, execResult *HyperliquidExecuteResult, signalStr string, price float64, regime *RegimeConfig, logger *StrategyLogger) (int, string, *Trade) {
+func executeHyperliquidResultDeferredOpen(sc StrategyConfig, s *StrategyState, result *HyperliquidResult, execResult *HyperliquidExecuteResult, signalStr string, price float64, regime *RegimeConfig, logger *StrategyLogger) (int, string, *Trade, *RatchetTriggerAlert) {
 	fillPrice := price
 	var fillQty float64
 	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.AvgPx > 0 {
@@ -3459,7 +3466,7 @@ func executeHyperliquidResultDeferredOpen(sc StrategyConfig, s *StrategyState, r
 	exec, err := ExecutePerpsSignalWithLeverageDeferredOpen(s, result.Signal, result.Symbol, fillPrice, sizingLeverage, exchangeLeverage, marginPerTradeUSD, fillQty, fillOID, fillFee, EffectiveDirection(sc), result.CloseFraction, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
-		return 0, "", nil
+		return 0, "", nil, nil
 	}
 	trades := exec.TradesExecuted
 	openTrade := exec.OpenTrade
@@ -3469,9 +3476,12 @@ func executeHyperliquidResultDeferredOpen(sc StrategyConfig, s *StrategyState, r
 	if pos, ok := s.Positions[result.Symbol]; ok {
 		stampPositionProtectionSnapshot(pos, sc)
 	}
+	var ratchetAlert *RatchetTriggerAlert
 	if trades > 0 {
 		if pos, ok := s.Positions[result.Symbol]; ok {
-			applyTrailingTPRatchetToPosition(sc, pos, result.Symbol, price, logger)
+			// #1110: capture the tighten snapshot here (under the caller's lock) and
+			// return it so the caller can DM the owner after releasing mu.
+			_, ratchetAlert = applyTrailingTPRatchetToPosition(sc, pos, result.Symbol, price, logger)
 		}
 	}
 	if trades > 0 && fillOID != "" {
@@ -3544,7 +3554,7 @@ func executeHyperliquidResultDeferredOpen(sc StrategyConfig, s *StrategyState, r
 			openTrade = nil
 		}
 	}
-	return trades, detail, openTrade
+	return trades, detail, openTrade, ratchetAlert
 }
 
 // topstepIsLive reports whether --mode=live appears in strategy args.

--- a/scheduler/ratchet_trigger_alert.go
+++ b/scheduler/ratchet_trigger_alert.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RatchetTriggerAlert is the immutable snapshot of a trailing_tp_ratchet* tier
+// clearing and tightening the trail (#1110). It is captured at the instant the
+// ratchet state changes — inside the state lock — so the formatted owner DM can
+// be delivered AFTER the lock is released. Discord/Telegram HTTP must never run
+// while holding mu (see applyTrailingTPRatchet / executeHyperliquidResultDeferredOpen
+// callers). Mirrors the SLAdjustmentAlert / ProtectionFillAlert snapshot pattern.
+type RatchetTriggerAlert struct {
+	StrategyID string
+	Symbol     string
+	Side       string // "long" or "short" — the position side
+
+	TierIdx         int     // 0-based index of the highest tier cleared this event
+	TotalTiers      int     // total rungs in the resolved ladder
+	TierATRMultiple float64 // ATR multiple of the cleared tier (the trigger threshold)
+	TierTriggerPx   float64 // price level at the cleared tier (anchor ± mult×ATR)
+
+	MarkPrice   float64 // mark that cleared the tier
+	AnchorPrice float64 // frozen entry / risk-anchor the tier offsets measure from (#873)
+	EntryATR    float64
+
+	ProfitATR float64 // profit distance in ATR multiples at trigger
+	ProfitUSD float64 // profit in USD at trigger (qty × distance × multiplier)
+
+	OldTrailMult float64 // trail ATR mult before the tighten
+	NewTrailMult float64 // trail ATR mult after the tighten
+
+	HighWaterMark       float64 // HWM used for the intended-SL computation
+	IntendedSLTriggerPx float64 // computed SL trigger from HWM + new trail mult; "intended" until the trailing walker confirms the on-chain replacement. 0 when not computable.
+
+	HasNextTier         bool
+	NextTierATRMultiple float64
+	NextTierTrailAfter  float64
+	NextTierTriggerPx   float64
+
+	RegimeLabel          string // label used to resolve trailing_tp_ratchet_regime tiers
+	PositionRegimeAtOpen string // pos.Regime stamped at open; shown only when distinct from RegimeLabel
+}
+
+// formatRatchetTriggerAlert renders the owner DM body. Pure function so it's
+// testable without spinning a notifier. Prices use the codebase $%.4f / signed
+// USD conventions (see formatSLAdjustmentAlert / formatSignedUSD).
+func formatRatchetTriggerAlert(a RatchetTriggerAlert) string {
+	side := "long"
+	if strings.ToLower(strings.TrimSpace(a.Side)) == "short" {
+		side = "short"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "[%s] %s %s — Ratchet Tier %d/%d cleared\n",
+		a.StrategyID, a.Symbol, side, a.TierIdx+1, a.TotalTiers)
+	fmt.Fprintf(&b, "  Triggered at: %g×ATR ($%.4f) | Mark: $%.4f\n",
+		a.TierATRMultiple, a.TierTriggerPx, a.MarkPrice)
+	fmt.Fprintf(&b, "  Entry: $%.4f | ATR: $%.4f | Profit: %.2f×ATR (%s)\n",
+		a.AnchorPrice, a.EntryATR, a.ProfitATR, formatSignedUSD(a.ProfitUSD))
+	fmt.Fprintf(&b, "  Trail tightened: %g×ATR → %g×ATR\n", a.OldTrailMult, a.NewTrailMult)
+	if a.IntendedSLTriggerPx > 0 {
+		fmt.Fprintf(&b, "  Intended SL trigger: ~$%.4f (HWM $%.4f %s %g×$%.4f)\n",
+			a.IntendedSLTriggerPx, a.HighWaterMark, hwmTrailSign(side), a.NewTrailMult, a.EntryATR)
+	}
+	if a.HasNextTier {
+		fmt.Fprintf(&b, "  Next tier: %g×ATR ($%.4f) → trail tightens to %g×ATR\n",
+			a.NextTierATRMultiple, a.NextTierTriggerPx, a.NextTierTrailAfter)
+	}
+	if regime := strings.TrimSpace(a.RegimeLabel); regime != "" {
+		line := fmt.Sprintf("  Regime: %s", regime)
+		if posReg := strings.TrimSpace(a.PositionRegimeAtOpen); posReg != "" && posReg != regime {
+			line += fmt.Sprintf(" (stamped at open: %s)", posReg)
+		}
+		b.WriteString(line + "\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// hwmTrailSign returns the sign used in the intended-SL formula display: a long
+// trails BELOW the high-water mark (HWM − trail×ATR), a short trails ABOVE it.
+func hwmTrailSign(side string) string {
+	if side == "short" {
+		return "+"
+	}
+	return "-"
+}
+
+// notifyRatchetTrigger emits an owner DM for a ratchet tier-clearing event.
+// No-ops when the feature is disabled, the alert is nil (no tier tightened the
+// trail this cycle), the sender is a nil interface, or the underlying pointer is
+// nil. Mirrors notifyProtectionFill / notifySLAdjustment so the default route is
+// owner DM only (consistent with the other auto-protective-stop alerts).
+func notifyRatchetTrigger(sender ownerDMSender, enabled bool, alert *RatchetTriggerAlert) {
+	if !enabled || alert == nil || sender == nil || isNilSender(sender) {
+		return
+	}
+	sender.SendOwnerDM(formatRatchetTriggerAlert(*alert))
+}

--- a/scheduler/ratchet_trigger_alert_test.go
+++ b/scheduler/ratchet_trigger_alert_test.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+// ratchetAlertSC builds a scalar trailing_tp_ratchet strategy with the given
+// tier ladder and initial trail.
+func ratchetAlertSC(initialTrail float64, tiers ...map[string]interface{}) StrategyConfig {
+	items := make([]interface{}, len(tiers))
+	for i, t := range tiers {
+		items[i] = t
+	}
+	return StrategyConfig{
+		ID:       "hl-rmc-eth-live",
+		Type:     "perps",
+		Platform: "hyperliquid",
+		CloseStrategy: &StrategyRef{
+			Name:   "trailing_tp_ratchet",
+			Params: map[string]interface{}{"tp_tiers": items},
+		},
+		TrailingStopATRMult: &initialTrail,
+	}
+}
+
+func tier(mult, frac, after float64) map[string]interface{} {
+	return map[string]interface{}{"atr_multiple": mult, "close_fraction": frac, "trailing_mult_after": after}
+}
+
+func TestApplyTrailingTPRatchetToPosition_AlertLongMath(t *testing.T) {
+	sc := ratchetAlertSC(3.0, tier(1.0, 0, 2.0), tier(2.0, 0, 1.0))
+	pos := &Position{
+		Symbol: "ETH", Side: "long", Quantity: 2, InitialQuantity: 2,
+		AvgCost: 100, EntryATR: 10, Multiplier: 1, Regime: "ranging",
+	}
+	tightened, a := applyTrailingTPRatchetToPosition(sc, pos, "ETH", 115, nil)
+	if !tightened || a == nil {
+		t.Fatalf("expected tighten+alert, got tightened=%v alert=%v", tightened, a)
+	}
+	if a.TierIdx != 0 || a.TotalTiers != 2 {
+		t.Fatalf("tier=%d/%d want 0/2", a.TierIdx, a.TotalTiers)
+	}
+	if a.TierATRMultiple != 1.0 || a.TierTriggerPx != 110 {
+		t.Fatalf("tierATR=%g triggerPx=%g want 1.0,110", a.TierATRMultiple, a.TierTriggerPx)
+	}
+	if a.MarkPrice != 115 || a.AnchorPrice != 100 || a.EntryATR != 10 {
+		t.Fatalf("mark=%g anchor=%g atr=%g", a.MarkPrice, a.AnchorPrice, a.EntryATR)
+	}
+	if a.ProfitATR != 1.5 || a.ProfitUSD != 30 { // (115-100)*2*1
+		t.Fatalf("profitATR=%g profitUSD=%g want 1.5,30", a.ProfitATR, a.ProfitUSD)
+	}
+	if a.OldTrailMult != 3.0 || a.NewTrailMult != 2.0 {
+		t.Fatalf("trail %g->%g want 3->2", a.OldTrailMult, a.NewTrailMult)
+	}
+	// HWM unset → floors to mark; long trails below: 115 - 2.0*10 = 95.
+	if a.HighWaterMark != 115 || a.IntendedSLTriggerPx != 95 {
+		t.Fatalf("hwm=%g intendedSL=%g want 115,95", a.HighWaterMark, a.IntendedSLTriggerPx)
+	}
+	if !a.HasNextTier || a.NextTierATRMultiple != 2.0 || a.NextTierTrailAfter != 1.0 || a.NextTierTriggerPx != 120 {
+		t.Fatalf("next tier mismatch: %+v", a)
+	}
+}
+
+func TestApplyTrailingTPRatchetToPosition_AlertShortMath(t *testing.T) {
+	sc := ratchetAlertSC(3.0, tier(1.0, 0, 2.0), tier(2.0, 0, 1.0))
+	pos := &Position{
+		Symbol: "ETH", Side: "short", Quantity: 1, InitialQuantity: 1,
+		AvgCost: 100, EntryATR: 10, Multiplier: 1, Regime: "ranging",
+	}
+	tightened, a := applyTrailingTPRatchetToPosition(sc, pos, "ETH", 85, nil)
+	if !tightened || a == nil {
+		t.Fatalf("expected tighten+alert, got tightened=%v alert=%v", tightened, a)
+	}
+	if a.TierTriggerPx != 90 { // short: 100 - 1.0*10
+		t.Fatalf("triggerPx=%g want 90", a.TierTriggerPx)
+	}
+	if a.ProfitATR != 1.5 || a.ProfitUSD != 15 { // (100-85)*1*1
+		t.Fatalf("profitATR=%g profitUSD=%g want 1.5,15", a.ProfitATR, a.ProfitUSD)
+	}
+	// Short trails above: HWM 85 + 2.0*10 = 105.
+	if a.HighWaterMark != 85 || a.IntendedSLTriggerPx != 105 {
+		t.Fatalf("hwm=%g intendedSL=%g want 85,105", a.HighWaterMark, a.IntendedSLTriggerPx)
+	}
+	if a.NextTierTriggerPx != 80 { // short: 100 - 2.0*10
+		t.Fatalf("nextTriggerPx=%g want 80", a.NextTierTriggerPx)
+	}
+}
+
+// A mark that clears past more than one rung in a single cycle alerts ONCE for
+// the highest cleared tier (the watermark jumps directly), and the "next tier"
+// points to the rung beyond it — not the skipped intermediate.
+func TestApplyTrailingTPRatchetToPosition_MultiTierJump(t *testing.T) {
+	sc := ratchetAlertSC(3.0, tier(1.0, 0, 2.0), tier(2.0, 0, 1.5), tier(3.0, 0, 1.0))
+	pos := &Position{
+		Symbol: "ETH", Side: "long", Quantity: 1, InitialQuantity: 1,
+		AvgCost: 100, EntryATR: 10, Multiplier: 1, Regime: "ranging",
+	}
+	tightened, a := applyTrailingTPRatchetToPosition(sc, pos, "ETH", 125, nil) // atrProfit 2.5
+	if !tightened || a == nil {
+		t.Fatal("expected tighten+alert on multi-tier jump")
+	}
+	if a.TierIdx != 1 || a.NewTrailMult != 1.5 {
+		t.Fatalf("cleared tier=%d trail=%g want 1,1.5", a.TierIdx, a.NewTrailMult)
+	}
+	if pos.SLAdjustedTiersProcessed != 2 {
+		t.Fatalf("watermark=%d want 2 (jumped past tier0)", pos.SLAdjustedTiersProcessed)
+	}
+	if !a.HasNextTier || a.NextTierATRMultiple != 3.0 || a.NextTierTrailAfter != 1.0 {
+		t.Fatalf("next tier should be the 3.0 rung, got %+v", a)
+	}
+}
+
+// Re-evaluating a tier already processed, or one that wouldn't tighten the
+// trail, must return (false, nil) — no alert.
+func TestApplyTrailingTPRatchetToPosition_NoAlertCases(t *testing.T) {
+	// Already-processed: clear tier0 once, then re-run at the same mark.
+	sc := ratchetAlertSC(3.0, tier(1.0, 0, 2.0), tier(2.0, 0, 1.0))
+	pos := &Position{
+		Symbol: "ETH", Side: "long", Quantity: 1, InitialQuantity: 1,
+		AvgCost: 100, EntryATR: 10, Multiplier: 1, Regime: "ranging",
+	}
+	if tightened, _ := applyTrailingTPRatchetToPosition(sc, pos, "ETH", 115, nil); !tightened {
+		t.Fatal("setup: first clear should tighten")
+	}
+	if tightened, a := applyTrailingTPRatchetToPosition(sc, pos, "ETH", 115, nil); tightened || a != nil {
+		t.Fatalf("re-run on processed tier should not alert, got tightened=%v alert=%v", tightened, a)
+	}
+
+	// No-tighten: two rungs with equal trailing_mult_after. After tier0 the
+	// effective trail is 2.0; clearing tier1 (also 2.0) advances the watermark
+	// but does NOT tighten → no alert.
+	scEqual := ratchetAlertSC(3.0, tier(1.0, 0, 2.0), tier(2.0, 0, 2.0))
+	pos2 := &Position{
+		Symbol: "ETH", Side: "long", Quantity: 1, InitialQuantity: 1,
+		AvgCost: 100, EntryATR: 10, Multiplier: 1, Regime: "ranging",
+	}
+	if tightened, _ := applyTrailingTPRatchetToPosition(scEqual, pos2, "ETH", 110, nil); !tightened {
+		t.Fatal("setup: tier0 should tighten 3.0->2.0")
+	}
+	tightened, a := applyTrailingTPRatchetToPosition(scEqual, pos2, "ETH", 120, nil) // clears tier1
+	if tightened || a != nil {
+		t.Fatalf("equal-trail tier should advance watermark without alert, got tightened=%v alert=%v", tightened, a)
+	}
+	if pos2.SLAdjustedTiersProcessed != 2 {
+		t.Fatalf("watermark=%d want 2 (advanced even without tighten)", pos2.SLAdjustedTiersProcessed)
+	}
+}
+
+func TestNotifyRatchetTrigger_Gating(t *testing.T) {
+	alert := &RatchetTriggerAlert{StrategyID: "x", Symbol: "ETH", Side: "long", TotalTiers: 1}
+
+	// Untyped nil interface and typed nil *MultiNotifier must not panic.
+	notifyRatchetTrigger(nil, true, alert)
+	var mn *MultiNotifier
+	notifyRatchetTrigger(mn, true, alert)
+
+	// Disabled flag suppresses.
+	c := &countingDMSender{}
+	notifyRatchetTrigger(c, false, alert)
+	if c.count != 0 {
+		t.Fatalf("disabled flag should suppress, count=%d", c.count)
+	}
+
+	// Nil alert (no tier tightened) suppresses.
+	notifyRatchetTrigger(c, true, nil)
+	if c.count != 0 {
+		t.Fatalf("nil alert should suppress, count=%d", c.count)
+	}
+
+	// Enabled + alert delivers exactly once.
+	notifyRatchetTrigger(c, true, alert)
+	if c.count != 1 {
+		t.Fatalf("enabled+alert should send once, count=%d", c.count)
+	}
+}
+
+func TestFormatRatchetTriggerAlert_Rendering(t *testing.T) {
+	a := RatchetTriggerAlert{
+		StrategyID: "hl-rmc-eth-live", Symbol: "ETH", Side: "long",
+		TierIdx: 0, TotalTiers: 3, TierATRMultiple: 1.5, TierTriggerPx: 1611.98,
+		MarkPrice: 1619.25, AnchorPrice: 1579.50, EntryATR: 21.65,
+		ProfitATR: 1.83, ProfitUSD: 34.85,
+		OldTrailMult: 2.0, NewTrailMult: 1.5,
+		HighWaterMark: 1623.15, IntendedSLTriggerPx: 1590.74,
+		HasNextTier: true, NextTierATRMultiple: 2.0, NextTierTrailAfter: 1.25, NextTierTriggerPx: 1622.80,
+		RegimeLabel: "trending_down_choppy", PositionRegimeAtOpen: "trending_down_choppy",
+	}
+	out := formatRatchetTriggerAlert(a)
+	for _, want := range []string{
+		"[hl-rmc-eth-live] ETH long — Ratchet Tier 1/3 cleared",
+		"Triggered at: 1.5×ATR",
+		"Trail tightened: 2×ATR → 1.5×ATR",
+		"Intended SL trigger:",
+		"Next tier: 2×ATR",
+		"Regime: trending_down_choppy",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+	// Same regime at open should NOT duplicate into a "stamped at open" suffix.
+	if strings.Contains(out, "stamped at open") {
+		t.Errorf("identical regime should not render the stamped-at-open suffix:\n%s", out)
+	}
+}
+
+func TestFormatRatchetTriggerAlert_DistinctRegimeShowsStamp(t *testing.T) {
+	a := RatchetTriggerAlert{
+		StrategyID: "s", Symbol: "ETH", Side: "short", TotalTiers: 2,
+		RegimeLabel: "ranging_quiet", PositionRegimeAtOpen: "trending_up_clean",
+	}
+	out := formatRatchetTriggerAlert(a)
+	if !strings.Contains(out, "Regime: ranging_quiet (stamped at open: trending_up_clean)") {
+		t.Errorf("distinct open regime should be shown:\n%s", out)
+	}
+}
+
+// The mutation helpers carry the alert OUT as a return value rather than
+// sending — they take no notifier, so a DM can never be emitted while the state
+// lock is held. This guards the #1110 lock-discipline invariant structurally:
+// the position is already mutated when the snapshot is returned.
+func TestApplyTrailingTPRatchet_ReturnsSnapshotForDeferredSend(t *testing.T) {
+	sc := ratchetAlertSC(3.0, tier(1.0, 0, 2.0), tier(2.0, 0, 1.0))
+	state := &StrategyState{Positions: map[string]*Position{
+		"ETH": {Symbol: "ETH", Side: "long", Quantity: 1, InitialQuantity: 1, AvgCost: 100, EntryATR: 10, Multiplier: 1, Regime: "ranging"},
+	}}
+	var mu sync.RWMutex
+	a := applyTrailingTPRatchet(sc, state, "ETH", 115, &mu, nil)
+	if a == nil {
+		t.Fatal("wrapper should surface the alert snapshot")
+	}
+	if pos := state.Positions["ETH"]; pos.PostTPTrailingATRMult == nil || *pos.PostTPTrailingATRMult != 2.0 {
+		t.Fatalf("position must already be mutated before delivery, got %v", pos.PostTPTrailingATRMult)
+	}
+}

--- a/scheduler/trailing_tp_ratchet.go
+++ b/scheduler/trailing_tp_ratchet.go
@@ -539,35 +539,43 @@ func applyTrailingTPRatchet(
 	mark float64,
 	mu *sync.RWMutex,
 	logger *StrategyLogger,
-) {
+) *RatchetTriggerAlert {
 	if !strategyUsesTrailingTPRatchetClose(sc) || stratState == nil || symbol == "" || mark <= 0 {
-		return
+		return nil
 	}
 	mu.Lock()
+	var alert *RatchetTriggerAlert
 	pos, ok := stratState.Positions[symbol]
 	if ok {
-		applyTrailingTPRatchetToPosition(sc, pos, symbol, mark, logger)
+		_, alert = applyTrailingTPRatchetToPosition(sc, pos, symbol, mark, logger)
 	}
 	mu.Unlock()
+	return alert
 }
 
 // applyTrailingTPRatchetToPosition applies the same ratchet logic while the
-// caller already owns the state lock.
-func applyTrailingTPRatchetToPosition(sc StrategyConfig, pos *Position, symbol string, mark float64, logger *StrategyLogger) bool {
+// caller already owns the state lock. Returns (true, *RatchetTriggerAlert) ONLY
+// when a tier newly advances the watermark AND tightens the trail — the alert
+// snapshot carries the immutable details the owner DM needs, so the caller can
+// deliver it (notifyRatchetTrigger) after releasing the lock (#1110). Every
+// non-tightening path returns (false, nil), including a watermark-only advance
+// (tier cleared but the resulting trail is not tighter), so an already-processed
+// or no-tighten tier never alerts.
+func applyTrailingTPRatchetToPosition(sc StrategyConfig, pos *Position, symbol string, mark float64, logger *StrategyLogger) (bool, *RatchetTriggerAlert) {
 	if !strategyUsesTrailingTPRatchetClose(sc) || pos == nil || symbol == "" || mark <= 0 {
-		return false
+		return false, nil
 	}
 	if pos.Quantity <= 0 || pos.AvgCost <= 0 || pos.EntryATR <= 0 {
-		return false
+		return false, nil
 	}
 	side := strings.ToLower(strings.TrimSpace(pos.Side))
 	if side != "long" && side != "short" {
-		return false
+		return false, nil
 	}
 	regime := protectionATRRegimeLabel(pos, sc)
 	tiers := trailingRatchetTiersForRegime(sc, regime)
 	if len(tiers) == 0 {
-		return false
+		return false, nil
 	}
 	// #873: ratchet tier-clearing measures ATR profit distance from the FROZEN
 	// entry (riskAnchorPrice), not the blended AvgCost, so a scale-in keeps the
@@ -580,7 +588,7 @@ func applyTrailingTPRatchetToPosition(sc StrategyConfig, pos *Position, symbol s
 	atrProfit := profitDistance / pos.EntryATR
 	clearedIdx, clearedOK := findHighestMarkClearedRatchetTier(tiers, atrProfit, pos.SLAdjustedTiersProcessed)
 	if !clearedOK {
-		return false
+		return false, nil
 	}
 	newMult := tiers[clearedIdx].TrailingMultAfter
 	current := effectiveTrailingRatchetMult(pos, sc)
@@ -588,7 +596,7 @@ func applyTrailingTPRatchetToPosition(sc StrategyConfig, pos *Position, symbol s
 		if pos.SLAdjustedTiersProcessed <= clearedIdx {
 			pos.SLAdjustedTiersProcessed = clearedIdx + 1
 		}
-		return false
+		return false, nil
 	}
 	mult := newMult
 	pos.PostTPTrailingATRMult = &mult
@@ -597,7 +605,78 @@ func applyTrailingTPRatchetToPosition(sc StrategyConfig, pos *Position, symbol s
 		logger.Info("trailing_tp_ratchet: %s tier %d cleared — trail tightened to %.4g×ATR (from %.4g×ATR)",
 			symbol, clearedIdx, newMult, current)
 	}
-	return true
+	alert := buildRatchetTriggerAlert(sc, pos, symbol, side, regime, mark, anchor, atrProfit, tiers, clearedIdx, current, newMult)
+	return true, alert
+}
+
+// buildRatchetTriggerAlert assembles the immutable #1110 alert snapshot at the
+// instant a ratchet tier tightens the trail. All inputs are read while the
+// caller holds the state lock; the result carries no pointers into pos so it is
+// safe to hand to a post-unlock notifier. anchor / atrProfit are passed through
+// from the caller so the snapshot matches the exact values the tightening
+// decision used.
+func buildRatchetTriggerAlert(sc StrategyConfig, pos *Position, symbol, side, regime string, mark, anchor, atrProfit float64, tiers []trailingRatchetTier, clearedIdx int, oldMult, newMult float64) *RatchetTriggerAlert {
+	entryATR := pos.EntryATR
+	contractMult := 1.0
+	if pos.Multiplier > 0 {
+		contractMult = pos.Multiplier
+	}
+	profitDistance := mark - anchor
+	if side == "short" {
+		profitDistance = anchor - mark
+	}
+	// Effective HWM for the intended-SL display: the best mark seen while open,
+	// floored to the current mark so a stale/unset StopLossHighWaterPx (e.g. the
+	// walker hasn't run yet this open) still yields a sensible computed trigger.
+	hwm := pos.StopLossHighWaterPx
+	if side == "long" {
+		if hwm <= 0 || mark > hwm {
+			hwm = mark
+		}
+	} else {
+		if hwm <= 0 || mark < hwm {
+			hwm = mark
+		}
+	}
+	intendedSL := 0.0
+	if entryATR > 0 && hwm > 0 && newMult > 0 {
+		if side == "long" {
+			intendedSL = hwm - newMult*entryATR
+		} else {
+			intendedSL = hwm + newMult*entryATR
+		}
+		if intendedSL <= 0 {
+			intendedSL = 0
+		}
+	}
+	a := &RatchetTriggerAlert{
+		StrategyID:           sc.ID,
+		Symbol:               symbol,
+		Side:                 side,
+		TierIdx:              clearedIdx,
+		TotalTiers:           len(tiers),
+		TierATRMultiple:      tiers[clearedIdx].ATRMultiple,
+		TierTriggerPx:        atrTierTriggerPx(side, anchor, entryATR, tiers[clearedIdx].ATRMultiple),
+		MarkPrice:            mark,
+		AnchorPrice:          anchor,
+		EntryATR:             entryATR,
+		ProfitATR:            atrProfit,
+		ProfitUSD:            profitDistance * pos.Quantity * contractMult,
+		OldTrailMult:         oldMult,
+		NewTrailMult:         newMult,
+		HighWaterMark:        hwm,
+		IntendedSLTriggerPx:  intendedSL,
+		RegimeLabel:          regime,
+		PositionRegimeAtOpen: pos.Regime,
+	}
+	if clearedIdx+1 < len(tiers) {
+		nt := tiers[clearedIdx+1]
+		a.HasNextTier = true
+		a.NextTierATRMultiple = nt.ATRMultiple
+		a.NextTierTrailAfter = nt.TrailingMultAfter
+		a.NextTierTriggerPx = atrTierTriggerPx(side, anchor, entryATR, nt.ATRMultiple)
+	}
+	return a
 }
 
 func trailingRatchetRulesEqualForReload(a, b StrategyConfig) bool {

--- a/scheduler/trailing_tp_ratchet_test.go
+++ b/scheduler/trailing_tp_ratchet_test.go
@@ -112,7 +112,7 @@ func TestApplyTrailingTPRatchetToPosition_AfterScaleOut(t *testing.T) {
 		Symbol: "ETH", Side: "long", Quantity: 0.7, InitialQuantity: 1,
 		AvgCost: 100, EntryATR: 10,
 	}
-	if !applyTrailingTPRatchetToPosition(sc, pos, "ETH", 110, nil) {
+	if tightened, _ := applyTrailingTPRatchetToPosition(sc, pos, "ETH", 110, nil); !tightened {
 		t.Fatal("expected scale-out tier to tighten residual trail")
 	}
 	if pos.PostTPTrailingATRMult == nil || *pos.PostTPTrailingATRMult != 1.0 {


### PR DESCRIPTION
## Summary

Sends a proactive operator DM when a `trailing_tp_ratchet` / `trailing_tp_ratchet_regime` tier clears and tightens the trailing stop. Previously the tighten was durable (DB fields, exchange SL after the walker, position summaries) but never surfaced immediately.

The DM carries the cleared tier (`Tier N/M`), the ATR-multiple threshold + its price, the mark that cleared it, entry/risk-anchor + entry ATR, profit in ATR multiples and USD, `old → new` trail mult, the **intended** SL trigger computed from the high-water mark and new trail (labeled intended until the walker confirms the on-chain replacement), the next tier when present, and the regime used to resolve the ladder.

## Changes

- **`ratchet_trigger_alert.go` (new):** `RatchetTriggerAlert` immutable snapshot + pure `formatRatchetTriggerAlert` + `notifyRatchetTrigger` (owner DM only, nil/disabled/typed-nil-safe — mirrors `notifyProtectionFill` / `notifySLAdjustment`).
- **`trailing_tp_ratchet.go`:** `applyTrailingTPRatchetToPosition` now returns `(bool, *RatchetTriggerAlert)`; the snapshot is built at the tighten instant (under the lock) by `buildRatchetTriggerAlert`. The `applyTrailingTPRatchet` wrapper surfaces the alert to its caller.
- **`main.go`:** delivers the alert **after** releasing `mu` at all three ratchet sites — perps `Signal==0` management, manual live, and post-trade `executeHyperliquidResultDeferredOpen` (threaded out through a new 4th return value so the locked caller DMs post-unlock).
- **`config.go`:** `notify_ratchet_triggers` flag + `NotifyRatchetTriggersEnabled()` (nil → enabled), matching `NotifyTPSLFills`.

## Invariants

- **Lock discipline:** no notifier runs while holding `mu` — the mutation helpers take no notifier and carry the snapshot out; delivery is always post-unlock.
- **Idempotency:** alert fires only when a tier newly advances `SLAdjustedTiersProcessed` **and** tightens the trail. A watermark-only advance (equal-trail tier) and an already-processed tier return `(false, nil)` — no alert.
- A multi-tier jump alerts once for the highest cleared tier; "next tier" points beyond it.

## Verification

- `go build`, `go vet`, `gofmt` clean.
- `go test ./...` — full suite passes (incl. new `ratchet_trigger_alert_test.go`: long/short math, multi-tier jump, no-alert cases, notifier/config gating, formatting, deferred-send snapshot).

Closes #1110

---
Created with LLM: Opus 4.8 | high | Harness: work-on-issue
