### PR TITLE
fix(#1111): use IsConfigured for pre-resolution regime-stop checks

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -1100,31 +1100,6 @@ func loadConfig(path string, skipLiveCredentialChecks bool) (*Config, error) {
 func normalizeHyperliquidPeerStopLosses(strategies []StrategyConfig) {
 }
 
-// hasHyperliquidStopLossOwnership reports whether sc would place a reduce-only
-// HL trigger at any point in its lifecycle. It is the peer-conflict predicate
-// rather than the runtime price-% predicate: TrailingStopATRMult arms an
-// initial trigger only on the cycle after the position opens (EntryATR must be
-// stamped first), so EffectiveStopLossPct returns 0 at order-placement time.
-// Peer validation must still treat that strategy as the trigger owner.
-func hasHyperliquidStopLossOwnership(sc StrategyConfig) bool {
-	if EffectiveStopLossPct(sc) > 0 {
-		return true
-	}
-	if sc.TrailingStopATRMult != nil && *sc.TrailingStopATRMult > 0 {
-		return true
-	}
-	if sc.StopLossATRMult != nil && *sc.StopLossATRMult > 0 {
-		return true
-	}
-	if sc.StopLossATRRegime != nil && !sc.StopLossATRRegime.IsZero() {
-		return true
-	}
-	if sc.TrailingStopATRRegime != nil && !sc.TrailingStopATRRegime.IsZero() {
-		return true
-	}
-	return false
-}
-
 // hyperliquidPeerStrategyErrors returns validation messages for HL wallet
 // strategies that share a coin but disagree on MarginMode or exchange Leverage (#491/#619).
 // Returns an empty slice when no peer conflicts exist.

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -1854,7 +1854,11 @@ func validateConfig(cfg *Config, skipLiveCredentialChecks bool) error {
 			}
 			// #870: the regime ratchet owns its trail via trailing_stop_atr_regime
 			// rather than the scalar trailing_stop_atr_mult, so accept that too.
-			regimeTrail := sc.TrailingStopATRRegime != nil && !sc.TrailingStopATRRegime.IsZero()
+			// #1111: use IsConfigured (raw-aware), NOT !IsZero() — this check runs
+			// before validateRegimeATRConfig resolves the raw block, and IsZero()
+			// reports true on an unresolved-but-configured block (see its doc), so
+			// !IsZero() would wrongly reject a strategy that did set the regime trail.
+			regimeTrail := sc.TrailingStopATRRegime.IsConfigured()
 			if fixedTrailingPct <= 0 && atrMult <= 0 && !regimeTrail {
 				errs = append(errs, fmt.Sprintf("%s: trailing_stop_min_move_pct requires trailing_stop_pct > 0, trailing_stop_atr_mult > 0, or trailing_stop_atr_regime", prefix))
 			}

--- a/scheduler/regime_atr.go
+++ b/scheduler/regime_atr.go
@@ -802,7 +802,12 @@ func validateRegimeATRConfig(cfg *Config) []string {
 				if sc.TrailingStopATRMult != nil {
 					errs = append(errs, fmt.Sprintf("%s: stop_loss_atr_regime is mutually exclusive with trailing_stop_atr_mult", prefix))
 				}
-				if sc.TrailingStopATRRegime != nil && !sc.TrailingStopATRRegime.IsZero() {
+				// #1111: IsConfigured (raw-aware), NOT !IsZero() — the trailing block
+				// is resolved further below in the `if sc.TrailingStopATRRegime != nil`
+				// branch, so here it is still unresolved and IsZero() would report it
+				// absent, silently skipping this (sole) mutex check when both regime
+				// stops are set.
+				if sc.TrailingStopATRRegime.IsConfigured() {
 					errs = append(errs, fmt.Sprintf("%s: stop_loss_atr_regime is mutually exclusive with trailing_stop_atr_regime", prefix))
 				}
 				if sc.Platform != "hyperliquid" || sc.Type != "perps" {

--- a/scheduler/regime_iszero_resolution_test.go
+++ b/scheduler/regime_iszero_resolution_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// #1111 regression suite. Several config-load-time validators read a regime ATR
+// block (trailing_stop_atr_regime / stop_loss_atr_regime) via IsZero() BEFORE
+// the block has been resolved. RegimeATRBlock.UnmarshalJSON captures only raw
+// JSON; the typed TrendRegime/UseDefaults fields are populated later, by
+// validateRegimeATRConfig. IsZero() returns true on an unresolved-but-configured
+// block, so a pre-resolution !IsZero() read treats a configured block as absent.
+// The blocks below are constructed raw-only (no resolved TrendRegime) to
+// reproduce that exact production state — a struct with TrendRegime already set
+// would not exercise the bug, which is why it shipped.
+
+const (
+	minMoveRequiresErr = "trailing_stop_min_move_pct requires"
+	regimeStopMutexErr = "stop_loss_atr_regime is mutually exclusive with trailing_stop_atr_regime"
+)
+
+// adx3StateATR builds a trend_regime raw map covering the 3 canonical ADX labels
+// with the given ATR multiplier — the shape RegimeATRBlock.UnmarshalJSON leaves
+// in b.raw before ResolveSurface runs.
+func adx3StateATR(atr float64) map[string]interface{} {
+	tr := make(map[string]interface{}, len(canonicalTrendRegimeLabels))
+	for _, l := range canonicalTrendRegimeLabels {
+		tr[l] = map[string]interface{}{"atr_multiple": atr}
+	}
+	return map[string]interface{}{"trend_regime": tr}
+}
+
+// adxRegimeCfg wraps strategies in a config with ADX regime detection enabled so
+// regime-aware stop blocks resolve against the canonical 3-state vocabulary.
+func adxRegimeCfg(scs ...StrategyConfig) *Config {
+	return &Config{
+		IntervalSeconds: 60,
+		Regime: &RegimeConfig{
+			Enabled:      true,
+			Period:       14,
+			ADXThreshold: 20,
+			Windows: RegimeWindowsMap{
+				"daily": {Classifier: regimeClassifierADX, Period: 14},
+			},
+		},
+		Strategies:    scs,
+		PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 60},
+	}
+}
+
+// Instance 1 — false reject. trailing_stop_min_move_pct must be accepted when
+// the strategy supplies trailing_stop_atr_regime, even though at the min-move
+// check the block is still raw. Covers both the explicit trend_regime shape and
+// the use_defaults shape (both leave a non-empty raw, empty TrendRegime).
+func TestValidateConfig_MinMoveAcceptsUnresolvedRegimeTrail(t *testing.T) {
+	minMove := 0.1
+	for _, tc := range []struct {
+		name string
+		raw  map[string]interface{}
+	}{
+		{"explicit trend_regime", adx3StateATR(2.0)},
+		{"use_defaults", map[string]interface{}{"use_defaults": true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := StrategyConfig{
+				ID:                     "hl-rmc-eth-live",
+				Type:                   "perps",
+				Platform:               "hyperliquid",
+				Script:                 "shared_scripts/check_hyperliquid.py",
+				Capital:                1000,
+				MaxDrawdownPct:         10,
+				Leverage:               10,
+				MarginMode:             "isolated",
+				RegimeATRWindow:        "daily",
+				TrailingStopATRRegime:  &RegimeATRBlock{raw: tc.raw},
+				TrailingStopMinMovePct: &minMove,
+			}
+			err := ValidateConfig(adxRegimeCfg(sc))
+			if err != nil && strings.Contains(err.Error(), minMoveRequiresErr) {
+				t.Fatalf("trailing_stop_min_move_pct wrongly rejected alongside trailing_stop_atr_regime: %v", err)
+			}
+		})
+	}
+}
+
+// Instance 1 inverse — the fix must not turn the validator into a no-op. A
+// strategy with trailing_stop_min_move_pct but no trailing mode at all must
+// still be rejected.
+func TestValidateConfig_MinMoveStillRequiresATrailingMode(t *testing.T) {
+	minMove := 0.1
+	sc := StrategyConfig{
+		ID:                     "hl-rmc-eth-live",
+		Type:                   "perps",
+		Platform:               "hyperliquid",
+		Script:                 "shared_scripts/check_hyperliquid.py",
+		Capital:                1000,
+		MaxDrawdownPct:         10,
+		Leverage:               10,
+		MarginMode:             "isolated",
+		TrailingStopMinMovePct: &minMove,
+	}
+	err := ValidateConfig(adxRegimeCfg(sc))
+	if err == nil || !strings.Contains(err.Error(), minMoveRequiresErr) {
+		t.Fatalf("trailing_stop_min_move_pct without any trailing mode must be rejected, got: %v", err)
+	}
+}
+
+// Instance 2 — false accept. stop_loss_atr_regime and trailing_stop_atr_regime
+// are mutually exclusive, but the sole enforcement read the trailing block via
+// IsZero() before it was resolved, so the mutex never fired when both were set.
+func TestValidateRegimeATRConfig_RegimeStopMutexEnforced(t *testing.T) {
+	sc := StrategyConfig{
+		ID:                    "hl-test",
+		Type:                  "perps",
+		Platform:              "hyperliquid",
+		RegimeATRWindow:       "daily",
+		StopLossATRRegime:     &RegimeATRBlock{raw: adx3StateATR(2.0)},
+		TrailingStopATRRegime: &RegimeATRBlock{raw: adx3StateATR(2.0)},
+	}
+	errs := validateRegimeATRConfig(adxRegimeCfg(sc))
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e, regimeStopMutexErr) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("config with both stop_loss_atr_regime and trailing_stop_atr_regime must be rejected as mutually exclusive, got: %v", errs)
+	}
+}
+
+// Instance 2 control — a single regime stop (only trailing) must NOT trip the
+// mutex; guards against the fix over-firing.
+func TestValidateRegimeATRConfig_SingleRegimeStopNoMutex(t *testing.T) {
+	sc := StrategyConfig{
+		ID:                    "hl-test",
+		Type:                  "perps",
+		Platform:              "hyperliquid",
+		RegimeATRWindow:       "daily",
+		TrailingStopATRRegime: &RegimeATRBlock{raw: adx3StateATR(2.0)},
+	}
+	for _, e := range validateRegimeATRConfig(adxRegimeCfg(sc)) {
+		if strings.Contains(e, regimeStopMutexErr) {
+			t.Fatalf("single trailing_stop_atr_regime must not trip the stop mutex, got: %v", e)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a config-load-time bug class: two validators read a regime ATR block (`trailing_stop_atr_regime` / `stop_loss_atr_regime`) via `!IsZero()` **before** `validateRegimeATRConfig` resolves it. `RegimeATRBlock.UnmarshalJSON` captures only raw JSON, and `IsZero()` returns `true` on an unresolved-but-configured block, so each read treated a configured block as absent.

Two confirmed instances of one root cause:

1. **False reject** (the reported symptom) — `trailing_stop_min_move_pct` was rejected when the strategy used `trailing_stop_atr_regime`, blocking the service on startup (`main.go`) and on SIGHUP reload.
2. **False accept** — the `stop_loss_atr_regime` ⟷ `trailing_stop_atr_regime` mutex (whose sole enforcement lives in `regime_atr.go`) silently never fired when both were set, because it read the trailing block before that block was resolved.

## Fix

Swap both pre-resolution sites to the raw-aware, nil-safe `IsConfigured()` — already the convention in the defaults loop (`config.go:983/1024`):

- `scheduler/config.go` — min-move trailing-mode check
- `scheduler/regime_atr.go` — the regime-stop mutex gate

`IsConfigured()` is purpose-built for pre-resolution checks (true when `raw` is non-empty; nil-guards internally). All other `!IsZero()` sites run at runtime, after resolution, and are unaffected.

## Tests

New `scheduler/regime_iszero_resolution_test.go`, constructing blocks raw-only to reproduce the production pre-resolution state (a resolved struct never exercises the bug — which is why it shipped):

1. instance 1 accept — explicit `trend_regime` and `use_defaults` shapes
1. instance 1 inverse — no trailing mode still rejected (fix is not a no-op)
1. instance 2 — both regime stops rejected as mutually exclusive
1. instance 2 control — a single regime stop does not trip the mutex

Verified the new tests fail without the fix and pass with it; full `go test ./...` for `scheduler/` passes.

Note: the issue body's line numbers were against the pre-#1110 commit; on current `main` the sites are `config.go:1857` and `regime_atr.go:805`.

Closes #1111

---
LLM: Opus 4.8 | xhigh | Harness: Claude Code
