### PR TITLE
refactor(#1114): drop redundant [classifier] suffix from regime display

### DIFF
--- a/scheduler/regime_window_spec.go
+++ b/scheduler/regime_window_spec.go
@@ -434,8 +434,7 @@ func formatStrategyRegimeDisplay(ss *StrategyState, rc *RegimeConfig) string {
 			if label == "" {
 				continue
 			}
-			cls := regimeClassifierForWindow(rc, name)
-			parts = append(parts, fmt.Sprintf("%s=%s [%s]", name, label, cls))
+			parts = append(parts, fmt.Sprintf("%s=%s", name, label))
 		}
 		if len(parts) > 0 {
 			return strings.Join(parts, "; ")

--- a/scheduler/regime_window_spec_test.go
+++ b/scheduler/regime_window_spec_test.go
@@ -152,6 +152,17 @@ func TestFormatStrategyRegimeDisplay_DefaultShowsAllWindows(t *testing.T) {
 			t.Fatalf("unset DisplayWindows should render %q; got: %s", name, got)
 		}
 	}
+	// #1114: the redundant [classifier] suffix must not appear — the window
+	// naming convention and disjoint label vocabularies already encode it.
+	for _, suffix := range []string{"[adx]", "[composite]", "["} {
+		if strings.Contains(got, suffix) {
+			t.Fatalf("regime display should not carry a classifier suffix %q; got: %s", suffix, got)
+		}
+	}
+	// Spot-check the exact rendering of one window.
+	if !strings.Contains(got, "composite_long=ranging_directional") {
+		t.Fatalf("expected bare name=label rendering; got: %s", got)
+	}
 }
 
 func TestFormatStrategyRegimeDisplay_CompositeOnly(t *testing.T) {


### PR DESCRIPTION
## Summary

Removes the redundant `[classifier]` suffix from the multi-window regime summary line. The display rendered each window as `name=label [classifier]` (e.g. `composite_long=ranging_directional [composite]`); it now renders `name=label`.

The suffix carried no information:
- **Naming convention already encodes the classifier** — `composite_*` windows are composite, bare names (`long`/`medium`/`short`) are ADX, enforced by config validation so no ambiguous window name reaches runtime.
- **Label vocabularies are disjoint** — ADX produces 3 labels (`trending_up`/`trending_down`/`ranging`); composite produces 7 (`ranging_directional`, `trending_down_choppy`, …) — the classifier is inferrable from the label.

## Changes

- `scheduler/regime_window_spec.go` — `formatStrategyRegimeDisplay` format string `"%s=%s [%s]"` → `"%s=%s"`; dropped the now-unused `cls`/`regimeClassifierForWindow` call (the helper stays — still used by five other call sites).
- `scheduler/regime_window_spec_test.go` — added a regression assertion that no `[classifier]` suffix renders, plus an exact `name=label` spot-check.

Out of scope: the inspect/diagnostic surface (`formatRegimeWindowSpecInspect`) keeps `classifier=…` — that's a debug surface where it belongs. The single-window fallback (scalar `ss.Regime`) is untouched.

## Verification

- `go build .` — clean
- `go test .` (full scheduler suite) — pass (30.7s)
- `gofmt -w` applied

Closes #1114

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code
