### PR TITLE
feat(#1118): per-strategy notify_ratchet_triggers override

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -350,6 +350,18 @@ func (c *Config) NotifyRatchetTriggersEnabled() bool {
 	return *c.NotifyRatchetTriggers
 }
 
+// NotifyRatchetTriggersEnabled reports whether THIS strategy's ratchet-tighten
+// owner DM (#1110) is enabled, using a two-layer resolve: the per-strategy
+// notify_ratchet_triggers (#1118) wins when set, else it inherits the global
+// Config.NotifyRatchetTriggersEnabled(). A nil strategy field therefore
+// preserves existing behavior for anyone who never sets it.
+func (sc *StrategyConfig) NotifyRatchetTriggersEnabled(cfg *Config) bool {
+	if sc != nil && sc.NotifyRatchetTriggers != nil {
+		return *sc.NotifyRatchetTriggers
+	}
+	return cfg.NotifyRatchetTriggersEnabled()
+}
+
 // CircuitBreakerEnabled reports whether the per-strategy circuit breaker is
 // active. Nil pointer (missing field) defaults to true so existing configs keep
 // the auto-protective behavior without an explicit opt-in; an explicit false
@@ -468,6 +480,7 @@ type StrategyConfig struct {
 	InitialCapital          float64                  `json:"initial_capital,omitempty"` // fixed starting balance for PnL display (never overwritten by capital_pct)
 	MaxDrawdownPct          float64                  `json:"max_drawdown_pct"`
 	CircuitBreaker          *bool                    `json:"circuit_breaker,omitempty"`            // #1048 — per-strategy circuit-breaker opt-out. Nil/missing → enabled (the safe default); explicit false disables BOTH firing arms in CheckRisk (drawdown > max_drawdown_pct AND 5 consecutive losses), uniformly for live and paper (no platform/live gating). Hot-reloadable via SIGHUP including while a position is open: disabling only suppresses NEW fires — an already-latched CB and any pending circuit close still drain. No effect on type=manual (exempt from CheckRisk). Read via CircuitBreakerEnabled(), never directly.
+	NotifyRatchetTriggers   *bool                    `json:"notify_ratchet_triggers,omitempty"`    // #1118 — per-strategy override of the global notify_ratchet_triggers (#1110) ratchet-tighten owner DM. Nil/missing → inherit the global Config.NotifyRatchetTriggersEnabled(); explicit value wins. Notification-only (never affects position/order state), so SIGHUP hot-reloads it unconditionally even while a position is open. Read via NotifyRatchetTriggersEnabled(cfg), never directly.
 	IntervalSeconds         int                      `json:"interval_seconds,omitempty"`           // per-strategy override (0 = use global)
 	HTFFilter               bool                     `json:"htf_filter,omitempty"`                 // higher-timeframe trend filter
 	InvertSignal            bool                     `json:"invert_signal,omitempty"`              // HL perps/manual only: flip BUY<->SELL on a non-zero signal before execution (HOLD/0 is never flipped). Lets inverse variants reuse the same open/close refs. Composes with Direction — invert runs in the Go layer before direction interprets the resulting sign (e.g. direction="short" + invert_signal=true opens short on raw-BUY triggers, distinct from plain direction="short" which opens on raw-SELL). Rejected outside HL perps/manual.

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -79,6 +79,15 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 			addChange("strategy[%s].circuit_breaker: %s -> %s", sc.ID, formatCircuitBreaker(sc.CircuitBreaker), formatCircuitBreaker(ns.CircuitBreaker))
 			sc.CircuitBreaker = ns.CircuitBreaker
 		}
+		// #1118: per-strategy notify_ratchet_triggers override is hot-reloadable
+		// always, including while a position is open — it only changes whether the
+		// ratchet-tighten owner DM is sent, never position/order state. The next
+		// cycle's notifyRatchetTrigger call reads the new value via
+		// sc.NotifyRatchetTriggersEnabled(cfg), so no state mutation is needed.
+		if !boolPtrEqual(sc.NotifyRatchetTriggers, ns.NotifyRatchetTriggers) {
+			addChange("strategy[%s].notify_ratchet_triggers: %s -> %s", sc.ID, formatNotifyRatchetTriggers(sc.NotifyRatchetTriggers), formatNotifyRatchetTriggers(ns.NotifyRatchetTriggers))
+			sc.NotifyRatchetTriggers = ns.NotifyRatchetTriggers
+		}
 		if sc.CapitalPct == 0 && sc.Capital != ns.Capital {
 			addChange("strategy[%s].capital: $%.2f -> $%.2f", sc.ID, sc.Capital, ns.Capital)
 			sc.Capital = ns.Capital
@@ -619,7 +628,8 @@ func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error 
 
 func strategyRestartShape(sc StrategyConfig) StrategyConfig {
 	sc.MaxDrawdownPct = 0
-	sc.CircuitBreaker = nil // #1048: hot-reloadable always, including while open. No state-compat guard — disabling only suppresses new fires; an already-latched CB and pending close still drain, and re-enabling just resumes evaluation on the next cycle.
+	sc.CircuitBreaker = nil        // #1048: hot-reloadable always, including while open. No state-compat guard — disabling only suppresses new fires; an already-latched CB and pending close still drain, and re-enabling just resumes evaluation on the next cycle.
+	sc.NotifyRatchetTriggers = nil // #1118: hot-reloadable always, including while open — notification preference only, never touches position/order state. Masked here so a pure notify_ratchet_triggers toggle isn't flagged "restart required"; applied in applyHotReloadConfig.
 	sc.Capital = 0
 	sc.Leverage = 0
 	sc.SizingLeverage = 0
@@ -701,6 +711,20 @@ func boolPtrEqual(a, b *bool) bool {
 func formatCircuitBreaker(p *bool) string {
 	if p == nil {
 		return "default(on)"
+	}
+	if *p {
+		return "on"
+	}
+	return "off"
+}
+
+// formatNotifyRatchetTriggers renders the per-strategy notify_ratchet_triggers
+// override for reload change logs. nil → "inherit-global" so an operator sees the
+// strategy is falling through to Config.NotifyRatchetTriggersEnabled() rather than
+// pinning a value; explicit true/false → "on"/"off". (#1118)
+func formatNotifyRatchetTriggers(p *bool) string {
+	if p == nil {
+		return "inherit-global"
 	}
 	if *p {
 		return "on"

--- a/scheduler/config_reload_test.go
+++ b/scheduler/config_reload_test.go
@@ -1508,3 +1508,68 @@ func TestStrategyRestartShape_CircuitBreakerOnlyChange(t *testing.T) {
 		t.Fatal("circuit_breaker set-vs-nil should not affect restart shape")
 	}
 }
+
+// #1118: per-strategy notify_ratchet_triggers is notification-only, so a change
+// must hot-reload even while a position is open (accepted, applied, logged).
+func TestApplyHotReloadConfig_NotifyRatchetTriggersWhileOpen(t *testing.T) {
+	falseVal, trueVal := false, true
+	base := func(nrt *bool) []StrategyConfig {
+		return []StrategyConfig{{
+			ID: "hl-eth", Type: "perps", Platform: "hyperliquid",
+			Script:  "shared_scripts/check_hyperliquid.py",
+			Args:    []string{"momentum", "ETH", "1h", "--mode=paper"},
+			Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, Direction: DirectionLong,
+			NotifyRatchetTriggers: nrt,
+		}}
+	}
+	openState := func() *AppState {
+		return &AppState{Strategies: map[string]*StrategyState{
+			"hl-eth": {
+				ID: "hl-eth", Cash: 900,
+				RiskState: RiskState{MaxDrawdownPct: 10},
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 1, Side: "long", AvgCost: 3000, Leverage: 2},
+				},
+			},
+		}}
+	}
+
+	// inherit-global (nil) → off while open: accepted, value applied, change logged.
+	cfg := minimalReloadConfig(base(nil))
+	next := minimalReloadConfig(base(&falseVal))
+	changes, err := applyHotReloadConfig(cfg, next, openState(), nil, nil)
+	if err != nil {
+		t.Fatalf("notify_ratchet_triggers nil->off while open should be hot-reloadable: %v", err)
+	}
+	if cfg.Strategies[0].NotifyRatchetTriggers == nil || *cfg.Strategies[0].NotifyRatchetTriggers {
+		t.Fatal("expected notify_ratchet_triggers=false after reload")
+	}
+	if !strings.Contains(strings.Join(changes, "\n"), "notify_ratchet_triggers") {
+		t.Fatalf("expected a notify_ratchet_triggers change entry, got %v", changes)
+	}
+
+	// off → on while open: accepted, value applied.
+	cfg = minimalReloadConfig(base(&falseVal))
+	next = minimalReloadConfig(base(&trueVal))
+	if _, err := applyHotReloadConfig(cfg, next, openState(), nil, nil); err != nil {
+		t.Fatalf("notify_ratchet_triggers off->on while open should be hot-reloadable: %v", err)
+	}
+	if cfg.Strategies[0].NotifyRatchetTriggers == nil || !*cfg.Strategies[0].NotifyRatchetTriggers {
+		t.Fatal("expected notify_ratchet_triggers=true after reload")
+	}
+}
+
+// #1118: a notify_ratchet_triggers-only change must not register in the restart
+// shape (else validateHotReloadCompatible would flag it as restart-required).
+func TestStrategyRestartShape_NotifyRatchetTriggersOnlyChange(t *testing.T) {
+	on, off := true, false
+	a := StrategyConfig{ID: "hl-a", NotifyRatchetTriggers: &on}
+	b := StrategyConfig{ID: "hl-a", NotifyRatchetTriggers: &off}
+	c := StrategyConfig{ID: "hl-a", NotifyRatchetTriggers: nil}
+	if !reflect.DeepEqual(strategyRestartShape(a), strategyRestartShape(b)) {
+		t.Fatal("notify_ratchet_triggers on/off change should not affect restart shape")
+	}
+	if !reflect.DeepEqual(strategyRestartShape(a), strategyRestartShape(c)) {
+		t.Fatal("notify_ratchet_triggers set-vs-nil should not affect restart shape")
+	}
+}

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -2698,3 +2698,31 @@ func TestCircuitBreakerEnabled_DefaultsToTrue(t *testing.T) {
 		t.Fatal("explicit true should report enabled")
 	}
 }
+
+func TestStrategyNotifyRatchetTriggersEnabled_TwoLayerResolve(t *testing.T) {
+	tr := true
+	f := false
+	globalFalse := &Config{NotifyRatchetTriggers: &f}
+	globalTrue := &Config{NotifyRatchetTriggers: &tr}
+	globalDefault := &Config{} // nil field → global resolves to true
+
+	cases := []struct {
+		name     string
+		sc       *StrategyConfig
+		cfg      *Config
+		expected bool
+	}{
+		{"nil strategy field inherits global default (true)", &StrategyConfig{}, globalDefault, true},
+		{"nil strategy field inherits global false", &StrategyConfig{}, globalFalse, false},
+		{"nil strategy field inherits global true", &StrategyConfig{}, globalTrue, true},
+		{"strategy false overrides global true", &StrategyConfig{NotifyRatchetTriggers: &f}, globalTrue, false},
+		{"strategy true overrides global false", &StrategyConfig{NotifyRatchetTriggers: &tr}, globalFalse, true},
+		{"nil receiver inherits global false", nil, globalFalse, false},
+		{"nil receiver inherits global default (true)", nil, globalDefault, true},
+	}
+	for _, c := range cases {
+		if got := c.sc.NotifyRatchetTriggersEnabled(c.cfg); got != c.expected {
+			t.Errorf("%s: got %v, want %v", c.name, got, c.expected)
+		}
+	}
+}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1875,7 +1875,7 @@ func main() {
 							liveExecFailed := false
 							if result.Signal == 0 && hlPosQty > 0 && strategyUsesTrailingTPRatchetClose(sc) {
 								ratchetAlert := applyTrailingTPRatchet(sc, stratState, result.Symbol, price, &mu, logger)
-								notifyRatchetTrigger(notifier, cfg.NotifyRatchetTriggersEnabled(), ratchetAlert)
+								notifyRatchetTrigger(notifier, sc.NotifyRatchetTriggersEnabled(cfg), ratchetAlert)
 								mu.RLock()
 								if pos, ok3 := stratState.Positions[result.Symbol]; ok3 && pos != nil {
 									hlPosSnapshot = hyperliquidProtectionPositionSnapshot(pos)
@@ -2076,7 +2076,7 @@ func main() {
 								// #1110: deliver any ratchet-tighten DM after releasing the lock
 								// (Discord/Telegram HTTP must not run under mu). Nil-safe no-op
 								// for the scale-in branch and when no tier tightened.
-								notifyRatchetTrigger(notifier, cfg.NotifyRatchetTriggersEnabled(), ratchetAlert)
+								notifyRatchetTrigger(notifier, sc.NotifyRatchetTriggersEnabled(cfg), ratchetAlert)
 								if execResult != nil && trades > 0 {
 									runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced after trade", hlReconcileFillHintsJSON)
 									runPostTPStopLossAdjustment(sc, stratState, result.Symbol, price, cfg, &mu, notifier, logger, hlOnChainAbsQty)
@@ -2256,7 +2256,7 @@ func main() {
 							mark := prices[sc.Symbol]
 							if mark > 0 && strategyUsesTrailingTPRatchetClose(sc) {
 								ratchetAlert := applyTrailingTPRatchet(sc, stratState, sc.Symbol, mark, &mu, logger)
-								notifyRatchetTrigger(notifier, cfg.NotifyRatchetTriggersEnabled(), ratchetAlert)
+								notifyRatchetTrigger(notifier, sc.NotifyRatchetTriggersEnabled(cfg), ratchetAlert)
 							}
 							mu.RLock()
 							pos = stratState.Positions[sc.Symbol]


### PR DESCRIPTION
Closes #1118

## What

Adds a per-strategy `notify_ratchet_triggers *bool` on `StrategyConfig` that shadows the global #1110 flag. Two-layer resolve: the strategy value wins when set, otherwise it inherits `Config.NotifyRatchetTriggersEnabled()`. Omitting it (nil) preserves today's behavior. Operators running mixed strategies can now silence the ratchet-tighten owner DM on a noisy strategy while keeping it on a high-conviction one (or override a global `false` for one strategy).

## Changes

1. `config.go` — `NotifyRatchetTriggers *bool` field (mirrors the `CircuitBreaker *bool` opt-out pattern) + `(*StrategyConfig).NotifyRatchetTriggersEnabled(cfg)` two-layer resolver.
2. `main.go` — all three `notifyRatchetTrigger` call sites (perps Signal==0 manage, deferred-open, manual live) now read `sc.NotifyRatchetTriggersEnabled(cfg)` instead of the global.
3. `config_reload.go` — **correction vs the issue's sketch.** The issue claimed the field would hot-reload "automatically" by living on `StrategyConfig`. It does not: the SIGHUP path applies fields **explicitly, one by one**, and `strategyRestartShape` flags any unmasked field change as restart-required. So this PR (a) masks the field in `strategyRestartShape` so a toggle isn't rejected as restart-required, and (b) applies + logs it in `applyHotReloadConfig`. No `validateHotReloadStateCompatible` guard is added — it's notification-only and never touches position/order state, so it reloads even while a position is open.

Additive + `omitempty`, so no `config_version` bump. Not exposed in the init wizard / `generateConfig`, matching the `circuit_breaker` precedent (Go-only opt-out `*bool` with a safe nil default).

## Verification

- `go build .` and `go vet .` clean.
- Full suite `go test ./...` passes.
- New tests: `TestStrategyNotifyRatchetTriggersEnabled_TwoLayerResolve` (all inherit/override/nil-receiver combinations), `TestApplyHotReloadConfig_NotifyRatchetTriggersWhileOpen` (nil→off and off→on accepted, applied, and logged while a position is open), `TestStrategyRestartShape_NotifyRatchetTriggersOnlyChange` (a toggle stays out of the restart shape).

## Acceptance criteria

- [x] `notify_ratchet_triggers: false` on one strategy silences its alerts without affecting others.
- [x] `notify_ratchet_triggers: true` overrides a global `false`.
- [x] Omitting the field inherits the global setting (nil → fall through).
- [x] SIGHUP hot-reloads the per-strategy value without restart (incl. while open).
- [x] Existing configs with no per-strategy field behave identically to today.

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code
