### PR TITLE
Split ranging_directional into explicit _up/_down labels (#1124)

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -88,6 +88,7 @@ _close_registry = None
 # Regime helper imported lazily so backtests without regime_enabled=True
 # don't pay the import cost.
 _ensure_regime_fn = None
+_regime_allows_entry_fn = None
 
 # Post-TP SL helpers (#709). Loaded via spec_from_file_location to avoid the
 # same registry-name collision that close_registry_loader works around — this
@@ -98,11 +99,27 @@ _trailing_ratchet_module = None
 
 
 def _load_regime():
-    global _ensure_regime_fn
+    global _ensure_regime_fn, _regime_allows_entry_fn
     if _ensure_regime_fn is None:
         from regime import ensure_regime_columns as _ensure_regime_columns
+        from regime import regime_label_allows_entry as _allows_entry
         _ensure_regime_fn = _ensure_regime_columns
+        _regime_allows_entry_fn = _allows_entry
     return _ensure_regime_fn
+
+
+def _regime_allows_entry(allowed, bar_regime: str) -> bool:
+    """#1124 entry-gate with the one-directional directional family rule.
+
+    A bare ``ranging_directional`` in ``allowed`` matches its ``_up``/``_down``
+    sub-labels, mirroring the Go ``regimeAllowsEntry`` gate for live/backtest
+    parity. Falls back to plain membership if the regime module isn't loaded.
+    """
+    if _regime_allows_entry_fn is None:
+        _load_regime()
+    if _regime_allows_entry_fn is None:
+        return (not allowed) or (not bar_regime) or (bar_regime in allowed)
+    return _regime_allows_entry_fn(allowed, bar_regime)
 
 
 def _regime_primary_labels(spec: Optional[dict]) -> Optional[tuple]:
@@ -1725,7 +1742,7 @@ class Backtester:
             regime_blocked = (
                 self.regime_enabled
                 and bool(self.allowed_regimes)
-                and bar_regime not in self.allowed_regimes
+                and not _regime_allows_entry(self.allowed_regimes, bar_regime)
             )
 
             if uses_open_close:

--- a/backtest/tests/test_backtester_composite_regime.py
+++ b/backtest/tests/test_backtester_composite_regime.py
@@ -74,8 +74,14 @@ def test_composite_label_allows_entry_when_gate_matches(label):
 
 @pytest.mark.parametrize("label", COMPOSITE_LABELS)
 def test_composite_label_blocks_entry_when_gate_mismatches(label):
-    # Pick any distinct label to gate on — the bar is ``label`` so it must block.
-    other = next(l for l in COMPOSITE_LABELS if l != label)
+    # Pick a label that does NOT cover ``label`` under the #1124 family rule.
+    # For the _up/_down sub-labels the bare ranging_directional covers them, so
+    # a gate on bare would (correctly) allow — exclude the bare parent here too.
+    covered_by = {"ranging_directional_up", "ranging_directional_down"}
+    if label in covered_by:
+        other = next(l for l in COMPOSITE_LABELS if l != label and l != "ranging_directional")
+    else:
+        other = next(l for l in COMPOSITE_LABELS if l != label)
     df = _gated_df(label)
     bt = Backtester(
         initial_capital=1000, commission_pct=0, slippage_pct=0,
@@ -160,3 +166,35 @@ def test_composite_regime_flip_does_not_close_open_position():
     result = bt.run(df, save=False)
     assert result["total_trades"] == 1
     assert result["trades"][0]["exit_price"] > 0
+
+
+# ─── #1124: bare ranging_directional covers its _up/_down sub-labels ─────────
+
+
+@pytest.mark.parametrize("sub", ["ranging_directional_up", "ranging_directional_down"])
+def test_bare_ranging_directional_covers_sub_label_entry(sub):
+    """#1124 family rule on the entry gate: an allowed_regimes listing only the
+    bare ``ranging_directional`` must still permit entries on ``_up``/``_down``
+    bars (the producer relabels non-zero drift). Mirrors the Go gate for parity.
+    """
+    df = _gated_df(sub)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, allowed_regimes=["ranging_directional"],
+    )
+    assert bt.run(df, save=False)["total_trades"] >= 1
+
+
+def test_explicit_sub_label_does_not_cover_bare_or_sibling_entry():
+    """#1124: the family expansion is one-directional (bare→subs). An operator
+    listing only ``ranging_directional_up`` gates OUT the bare label and the
+    ``_down`` sibling — never the reverse."""
+    for bar in ["ranging_directional", "ranging_directional_down"]:
+        df = _gated_df(bar)
+        bt = Backtester(
+            initial_capital=1000, commission_pct=0, slippage_pct=0,
+            regime_enabled=True, allowed_regimes=["ranging_directional_up"],
+        )
+        assert bt.run(df, save=False)["total_trades"] == 0, (
+            f"explicit _up must NOT cover bar '{bar}'"
+        )

--- a/scheduler/manual_ratchet_regime_default_test.go
+++ b/scheduler/manual_ratchet_regime_default_test.go
@@ -156,12 +156,14 @@ func TestManualDefault_RegimeComposite_SelectsRatchetRegime(t *testing.T) {
 		t.Fatalf("StopLossATRMult = %v, want nil", *sc.StopLossATRMult)
 	}
 	block := sc.TrailingStopATRRegime
-	if block == nil || len(block.TrendRegime) != 7 {
-		t.Fatalf("trailing_stop_atr_regime must resolve to 7 composite labels, got %#v", block)
+	wantN := len(regimeLabelsForClassifier(regimeClassifierComposite))
+	if block == nil || len(block.TrendRegime) != wantN {
+		t.Fatalf("trailing_stop_atr_regime must resolve to %d composite labels, got %#v", wantN, block)
 	}
 	for _, label := range []string{
 		"trending_up_clean", "trending_up_choppy", "trending_down_clean",
 		"trending_down_choppy", "ranging_quiet", "ranging_volatile", "ranging_directional",
+		"ranging_directional_up", "ranging_directional_down",
 	} {
 		if v, ok := resolveRegimeATR(*block, label); !ok || v <= 0 {
 			t.Fatalf("opening trail for composite label %q = (%g, %v), want positive", label, v, ok)

--- a/scheduler/post_tp_sl.go
+++ b/scheduler/post_tp_sl.go
@@ -81,8 +81,8 @@ func (b *RegimeFloatBlock) Resolve(regime string) (float64, bool) {
 		return v, true
 	}
 	// #1124: sub-label stamp falls back to the bare ranging_directional entry.
-	if r == "ranging_directional_up" || r == "ranging_directional_down" {
-		if v, ok := b.TrendRegime["ranging_directional"]; ok {
+	if regimeDirectionalSubs[r] {
+		if v, ok := b.TrendRegime[regimeDirectionalBare]; ok {
 			return v, true
 		}
 	}
@@ -536,12 +536,12 @@ func parseRegimeFloatBlock(raw map[string]interface{}, ctxLabel string, labels [
 	missing := make([]string, 0)
 	// #1124: bare `ranging_directional` covers its _up/_down sub-labels for
 	// exhaustiveness (back-compat — resolves the whole family at runtime).
-	bareDirectional := trend["ranging_directional"] != nil
+	bareDirectional := trend[regimeDirectionalBare] != nil
 	for _, label := range labels {
 		if _, ok := trend[label]; ok {
 			continue
 		}
-		if (label == "ranging_directional_up" || label == "ranging_directional_down") && bareDirectional {
+		if regimeLabelFamilyCovered(label, bareDirectional) {
 			continue
 		}
 		missing = append(missing, label)

--- a/scheduler/post_tp_sl.go
+++ b/scheduler/post_tp_sl.go
@@ -76,8 +76,17 @@ func (b *RegimeFloatBlock) Resolve(regime string) (float64, bool) {
 	if b == nil || len(b.TrendRegime) == 0 {
 		return 0, false
 	}
-	v, ok := b.TrendRegime[strings.TrimSpace(regime)]
-	return v, ok
+	r := strings.TrimSpace(regime)
+	if v, ok := b.TrendRegime[r]; ok {
+		return v, true
+	}
+	// #1124: sub-label stamp falls back to the bare ranging_directional entry.
+	if r == "ranging_directional_up" || r == "ranging_directional_down" {
+		if v, ok := b.TrendRegime["ranging_directional"]; ok {
+			return v, true
+		}
+	}
+	return 0, false
 }
 
 func (b *RegimeFloatBlock) EqualForReload(other *RegimeFloatBlock) bool {
@@ -525,10 +534,17 @@ func parseRegimeFloatBlock(raw map[string]interface{}, ctxLabel string, labels [
 			ctxLabel, regimeClassifierKey, label, strings.Join(labels, ", ")))
 	}
 	missing := make([]string, 0)
+	// #1124: bare `ranging_directional` covers its _up/_down sub-labels for
+	// exhaustiveness (back-compat — resolves the whole family at runtime).
+	bareDirectional := trend["ranging_directional"] != nil
 	for _, label := range labels {
-		if _, ok := trend[label]; !ok {
-			missing = append(missing, label)
+		if _, ok := trend[label]; ok {
+			continue
 		}
+		if (label == "ranging_directional_up" || label == "ranging_directional_down") && bareDirectional {
+			continue
+		}
+		missing = append(missing, label)
 	}
 	if len(missing) > 0 {
 		errs = append(errs, fmt.Sprintf("%s.%s: missing required regime labels: %s (must be exhaustive — no silent fallback)",

--- a/scheduler/regime.go
+++ b/scheduler/regime.go
@@ -1,5 +1,7 @@
 package main
 
+import "strings"
+
 // regimeAllowsEntry reports whether the current market regime permits a new
 // entry for a strategy. Returns true when:
 //   - allowed is empty (no gate configured), OR
@@ -8,13 +10,29 @@ package main
 //
 // This is the core regime check; callers gate it on "is this an open?" via
 // regimeBlocksOpen so close legs always pass through.
+//
+// #1124: a bare `ranging_directional` in `allowed` matches its `_up`/`_down`
+// sub-labels (the producer relabels non-zero drift). The expansion is
+// one-directional — bare→subs — so an operator listing an explicit `_up`
+// still gates out `_down`. This mirrors the family rule applied to the
+// regime-keyed blocks so the producer relabeling never silently re-gates a
+// previously-entering strategy.
 func regimeAllowsEntry(allowed []string, current string) bool {
 	if len(allowed) == 0 || current == "" {
 		return true
 	}
+	cur := strings.TrimSpace(current)
 	for _, label := range allowed {
-		if label == current {
+		if label == cur {
 			return true
+		}
+	}
+	// bare ranging_directional covers its #1124 sub-labels.
+	if regimeDirectionalSubs[cur] {
+		for _, label := range allowed {
+			if label == regimeDirectionalBare {
+				return true
+			}
 		}
 	}
 	return false

--- a/scheduler/regime_atr.go
+++ b/scheduler/regime_atr.go
@@ -37,6 +37,46 @@ import (
 // use_defaults, every label here must appear in the trend_regime map.
 var canonicalTrendRegimeLabels = []string{"trending_up", "trending_down", "ranging"}
 
+// regimeDirectionalBare is the bare ranging-directional label, whose
+// `ranging_directional_up`/`_down` sub-labels the producer (#1124) splits out
+// by drift sign. The bare label remains the exact-zero neutral fallback the
+// producer emits at return_eff == 0, so it is the parent of the family.
+const regimeDirectionalBare = "ranging_directional"
+
+// regimeDirectionalSubs is the set of #1124 directional sub-labels that the
+// bare `ranging_directional` label covers for exhaustiveness and runtime
+// resolution. Kept as a helper so every consumer applies the family rule
+// symmetrically (a missed consumer is a silent never-arm of an auto-protective
+// SL/exit — see #1124 review).
+var regimeDirectionalSubs = map[string]bool{
+	"ranging_directional_up":   true,
+	"ranging_directional_down": true,
+}
+
+// regimeLabelWithFamilyFallback returns the regime label a runtime resolver
+// should look up: the sub-label's bare `ranging_directional` parent when the
+// sub-label itself isn't keyed (back-compat — a bare-only block covers the
+// whole #1124 directional family at runtime), otherwise the label as-is.
+// Callers that have already exact-matched the label need not call this.
+func regimeLabelWithFamilyFallback(regime string) string {
+	r := strings.TrimSpace(regime)
+	if regimeDirectionalSubs[r] {
+		return regimeDirectionalBare
+	}
+	return r
+}
+
+// regimeLabelFamilyCovered reports whether an omitted `label` is nevertheless
+// satisfied for exhaustiveness because the bare `ranging_directional` parent
+// is present (`bareDirectionalPresent`). This is the back-compat rule: a
+// 7-label composite block keyed on bare `ranging_directional` still covers
+// the `_up`/`_down` sub-labels, so it must not be rejected as non-exhaustive.
+// Sub-labels-only (no bare parent) is NOT covered — the producer still emits
+// the bare label at return_eff == 0, so omitting it leaves a naked-SL hole.
+func regimeLabelFamilyCovered(label string, bareDirectionalPresent bool) bool {
+	return bareDirectionalPresent && regimeDirectionalSubs[strings.TrimSpace(label)]
+}
+
 // regimeClassifierKey is the wrapper key required around per-label blocks.
 // Reserves space for future classifiers (e.g. "vol_regime") to land as
 // sibling keys without renaming.
@@ -216,8 +256,9 @@ func (b RegimeATRBlock) Resolve(regime string) (RegimeATREntry, bool) {
 	if entry, ok := b.TrendRegime[r]; ok {
 		return entry, true
 	}
-	if r == "ranging_directional_up" || r == "ranging_directional_down" {
-		if entry, ok := b.TrendRegime["ranging_directional"]; ok {
+	// #1124: sub-label stamp falls back to the bare ranging_directional entry.
+	if regimeDirectionalSubs[r] {
+		if entry, ok := b.TrendRegime[regimeDirectionalBare]; ok {
 			return entry, true
 		}
 	}
@@ -474,12 +515,12 @@ func parseRegimeATRBlock(raw map[string]interface{}, ctxLabel string, surface re
 	// exhaustive (the neutral case would resolve to nil → silent never-arm of
 	// an auto-protective exit). So a present bare label covers its sub-labels,
 	// and a missing bare label is flagged even when both sub-labels exist.
-	bareDirectional := trendMap["ranging_directional"] != nil
+	bareDirectional := trendMap[regimeDirectionalBare] != nil
 	for _, l := range labels {
 		if _, ok := trendMap[l]; ok {
 			continue
 		}
-		if (l == "ranging_directional_up" || l == "ranging_directional_down") && bareDirectional {
+		if regimeLabelFamilyCovered(l, bareDirectional) {
 			// bare label covers this sub-label
 			continue
 		}

--- a/scheduler/regime_atr.go
+++ b/scheduler/regime_atr.go
@@ -202,12 +202,26 @@ func (b *RegimeATRBlock) IsConfigured() bool {
 // Resolve returns the per-label entry for the given regime. The caller is
 // responsible for validating the block at config-load time so this can
 // assume label presence. Returns (entry, true) on hit, (zero, false) on miss.
+//
+// #1124: a `ranging_directional_up`/`_down` regime stamp falls back to the bare
+// `ranging_directional` entry when the block doesn't carry an explicit sub-label
+// key (the back-compat shape — bare label covers the whole directional family).
+// This keeps the runtime resolution aligned with the exhaustiveness rule: a
+// bare-only block is exhaustive, so it must also resolve at runtime.
 func (b RegimeATRBlock) Resolve(regime string) (RegimeATREntry, bool) {
 	if b.TrendRegime == nil {
 		return RegimeATREntry{}, false
 	}
-	entry, ok := b.TrendRegime[strings.TrimSpace(regime)]
-	return entry, ok
+	r := strings.TrimSpace(regime)
+	if entry, ok := b.TrendRegime[r]; ok {
+		return entry, true
+	}
+	if r == "ranging_directional_up" || r == "ranging_directional_down" {
+		if entry, ok := b.TrendRegime["ranging_directional"]; ok {
+			return entry, true
+		}
+	}
+	return RegimeATREntry{}, false
 }
 
 // regimeATRDefaults holds the per-surface baseline expansions for
@@ -226,16 +240,18 @@ var regimeATRDefaults = struct {
 	// choppy=2.0, ranging=1.0) so a trailing_stop_atr_regime use_defaults block
 	// differentiates trend groups from ranges (tight).
 	Trailing: map[string]RegimeATREntry{
-		"trending_up":          {ATR: 2.5},
-		"trending_down":        {ATR: 2.5},
-		"ranging":              {ATR: 2.0},
-		"trending_up_clean":    {ATR: 2.0},
-		"trending_down_clean":  {ATR: 2.0},
-		"trending_up_choppy":   {ATR: 2.0},
-		"trending_down_choppy": {ATR: 2.0},
-		"ranging_quiet":        {ATR: 1.0},
-		"ranging_volatile":     {ATR: 1.0},
-		"ranging_directional":  {ATR: 1.0},
+		"trending_up":              {ATR: 2.5},
+		"trending_down":            {ATR: 2.5},
+		"ranging":                  {ATR: 2.0},
+		"trending_up_clean":        {ATR: 2.0},
+		"trending_down_clean":      {ATR: 2.0},
+		"trending_up_choppy":       {ATR: 2.0},
+		"trending_down_choppy":     {ATR: 2.0},
+		"ranging_quiet":            {ATR: 1.0},
+		"ranging_volatile":         {ATR: 1.0},
+		"ranging_directional":      {ATR: 1.0},
+		"ranging_directional_up":   {ATR: 1.0}, // #1124
+		"ranging_directional_down": {ATR: 1.0}, // #1124
 	},
 }
 
@@ -278,7 +294,7 @@ var regimeTPTierGroupDefaults = map[string][]hlProtectionTier{
 var regimeTPFleetDefaultLabelsByGroup = map[string][]string{
 	"clean":   {"trending_up_clean", "trending_down_clean"},
 	"choppy":  {"trending_up", "trending_down", "trending_up_choppy", "trending_down_choppy"},
-	"ranging": {"ranging", "ranging_quiet", "ranging_volatile", "ranging_directional"},
+	"ranging": {"ranging", "ranging_quiet", "ranging_volatile", "ranging_directional", "ranging_directional_up", "ranging_directional_down"},
 }
 
 // defaultRegimeBlockForSurface returns the baseline trend_regime map for a
@@ -450,10 +466,24 @@ func parseRegimeATRBlock(raw map[string]interface{}, ctxLabel string, surface re
 	}
 
 	missingLabels := []string{}
+	// #1124: the ranging_directional family — bare `ranging_directional` plus
+	// its `ranging_directional_up`/`_down` sub-labels — is satisfied for
+	// exhaustiveness when the bare label is present (it covers all three at
+	// runtime, including the return_eff==0 neutral case the producer still
+	// emits). Providing only the sub-labels without the bare label is NOT
+	// exhaustive (the neutral case would resolve to nil → silent never-arm of
+	// an auto-protective exit). So a present bare label covers its sub-labels,
+	// and a missing bare label is flagged even when both sub-labels exist.
+	bareDirectional := trendMap["ranging_directional"] != nil
 	for _, l := range labels {
-		if _, ok := trendMap[l]; !ok {
-			missingLabels = append(missingLabels, l)
+		if _, ok := trendMap[l]; ok {
+			continue
 		}
+		if (l == "ranging_directional_up" || l == "ranging_directional_down") && bareDirectional {
+			// bare label covers this sub-label
+			continue
+		}
+		missingLabels = append(missingLabels, l)
 	}
 	if len(missingLabels) > 0 {
 		errs = append(errs, fmt.Sprintf("%s.%s: missing required regime labels: %s (must be exhaustive — no silent fallback)", ctxLabel, regimeClassifierKey, strings.Join(missingLabels, ", ")))

--- a/scheduler/regime_atr_composite_test.go
+++ b/scheduler/regime_atr_composite_test.go
@@ -59,8 +59,9 @@ func TestValidateRegimeATRConfig_CompositeStopLossExplicit(t *testing.T) {
 		t.Fatalf("composite stop_loss_atr_regime must validate, got: %v", errs)
 	}
 	block := cfg.Strategies[0].StopLossATRRegime
-	if got := len(block.TrendRegime); got != 7 {
-		t.Fatalf("block must be populated with all 7 composite labels, got %d: %v", got, block.TrendRegime)
+	wantN := len(regimeLabelsForClassifier(regimeClassifierComposite))
+	if got := len(block.TrendRegime); got != wantN {
+		t.Fatalf("block must be populated with all %d composite labels, got %d: %v", wantN, got, block.TrendRegime)
 	}
 	// Runtime SL resolution must succeed for a composite label (proves the
 	// authoritative pass populated the composite vocabulary, not ADX).
@@ -116,8 +117,8 @@ func TestValidateRegimeATRConfig_CompositeTrailingExplicit(t *testing.T) {
 	if errs := validateRegimeATRConfig(cfg); len(errs) != 0 {
 		t.Fatalf("composite trailing_stop_atr_regime must validate, got: %v", errs)
 	}
-	if got := len(cfg.Strategies[0].TrailingStopATRRegime.TrendRegime); got != 7 {
-		t.Fatalf("trailing block must hold 7 composite labels, got %d", got)
+	if got := len(cfg.Strategies[0].TrailingStopATRRegime.TrendRegime); got != len(regimeLabelsForClassifier(regimeClassifierComposite)) {
+		t.Fatalf("trailing block must hold all composite labels, got %d", got)
 	}
 }
 
@@ -168,6 +169,83 @@ func TestValidateRegimeATRConfig_CompositeMissingLabelRejected(t *testing.T) {
 	}
 	if !strings.Contains(joined, "classifier \"composite\"") {
 		t.Fatalf("error should carry composite classifier context, got: %v", errs)
+	}
+}
+
+// #1124: the ranging_directional family — bare label covers _up/_down for
+// exhaustiveness, so a legacy 7-label explicit block (no sub-label keys) still
+// validates under the now-9-label composite vocabulary (back-compat).
+func TestValidateRegimeATRConfig_CompositeBareDirectionalCoversSubLabels(t *testing.T) {
+	// 7-label block: every composite label except the new _up/_down, WITH bare
+	// ranging_directional present → the bare label covers the sub-labels.
+	raw := composite7StateATR(2.0)
+	// composite7StateATR already includes ranging_directional (bare) plus the
+	// other 6; it does NOT include _up/_down. Confirm bare is present.
+	if _, ok := raw["trend_regime"].(map[string]interface{})["ranging_directional"]; !ok {
+		t.Fatal("test fixture: expected bare ranging_directional key")
+	}
+	sc := StrategyConfig{
+		ID:                "hl-test",
+		Type:              "perps",
+		Platform:          "hyperliquid",
+		RegimeATRWindow:   "daily",
+		StopLossATRRegime: &RegimeATRBlock{raw: raw},
+	}
+	if errs := validateRegimeATRConfig(compositeRegimeCfg(sc)); len(errs) != 0 {
+		t.Fatalf("legacy 7-label block with bare ranging_directional must still validate, got: %v", errs)
+	}
+}
+
+// #1124: sub-labels-only (no bare ranging_directional) is NOT exhaustive — the
+// producer still emits the bare label at return_eff==0, so a block missing it
+// would silently never-arm on the neutral case. Must be rejected.
+func TestValidateRegimeATRConfig_CompositeSubLabelsWithoutBareRejected(t *testing.T) {
+	labels := regimeLabelsForClassifier(regimeClassifierComposite)
+	tr := make(map[string]interface{}, len(labels))
+	for _, l := range labels {
+		if l == "ranging_directional" {
+			continue // omit the bare label
+		}
+		tr[l] = map[string]interface{}{"atr_multiple": 2.0}
+	}
+	raw := map[string]interface{}{"trend_regime": tr}
+	sc := StrategyConfig{
+		ID:                "hl-test",
+		Type:              "perps",
+		Platform:          "hyperliquid",
+		RegimeATRWindow:   "daily",
+		StopLossATRRegime: &RegimeATRBlock{raw: raw},
+	}
+	errs := validateRegimeATRConfig(compositeRegimeCfg(sc))
+	joined := strings.Join(errs, "\n")
+	if !strings.Contains(joined, "ranging_directional") || !strings.Contains(joined, "missing required regime labels") {
+		t.Fatalf("expected missing bare ranging_directional error, got: %v", errs)
+	}
+}
+
+// #1124: runtime Resolve falls back from a _up/_down stamp to the bare
+// ranging_directional entry when the block carries no explicit sub-label key.
+func TestRegimeATRBlock_ResolveSubLabelFallsBackToBare(t *testing.T) {
+	raw := composite7StateATR(1.5)
+	sc := StrategyConfig{
+		ID:                "hl-test",
+		Type:              "perps",
+		Platform:          "hyperliquid",
+		RegimeATRWindow:   "daily",
+		StopLossATRRegime: &RegimeATRBlock{raw: raw},
+	}
+	if errs := validateRegimeATRConfig(compositeRegimeCfg(sc)); len(errs) != 0 {
+		t.Fatalf("fixture must validate, got: %v", errs)
+	}
+	block := *sc.StopLossATRRegime
+	if v, ok := block.Resolve("ranging_directional"); !ok || v.ATR != 1.5 {
+		t.Fatalf("bare resolve: got (%g, %v), want (1.5, true)", v.ATR, ok)
+	}
+	for _, sub := range []string{"ranging_directional_up", "ranging_directional_down"} {
+		v, ok := block.Resolve(sub)
+		if !ok || v.ATR != 1.5 {
+			t.Errorf("Resolve(%q): got (%g, %v), want (1.5, true) via bare fallback", sub, v.ATR, ok)
+		}
 	}
 }
 
@@ -256,8 +334,8 @@ func TestMapRegimeToBaselineFamily(t *testing.T) {
 func TestRegimeLabelsFromTierRaw(t *testing.T) {
 	raw := []interface{}{composite7StateTier(2.0, 0.5)}
 	got := regimeLabelsFromTierRaw(raw)
-	if len(got) != 7 {
-		t.Fatalf("expected 7 inferred labels, got %d: %v", len(got), got)
+	if len(got) != len(regimeLabelsForClassifier(regimeClassifierComposite)) {
+		t.Fatalf("expected all composite labels, got %d: %v", len(got), got)
 	}
 	// No per-regime keys → canonical ADX fallback.
 	if got := regimeLabelsFromTierRaw(nil); len(got) != 3 {

--- a/scheduler/regime_directional_policy.go
+++ b/scheduler/regime_directional_policy.go
@@ -101,8 +101,17 @@ func (p *RegimeDirectionalPolicy) Resolve(regime string) (RegimeDirectionalEntry
 	if p == nil || len(p.TrendRegime) == 0 {
 		return RegimeDirectionalEntry{}, false
 	}
-	entry, ok := p.TrendRegime[strings.TrimSpace(regime)]
-	return entry, ok
+	r := strings.TrimSpace(regime)
+	if entry, ok := p.TrendRegime[r]; ok {
+		return entry, true
+	}
+	// #1124: sub-label stamp falls back to the bare ranging_directional entry.
+	if r == "ranging_directional_up" || r == "ranging_directional_down" {
+		if entry, ok := p.TrendRegime["ranging_directional"]; ok {
+			return entry, true
+		}
+	}
+	return RegimeDirectionalEntry{}, false
 }
 
 // IsConfigured reports whether the operator supplied any value. Safe to
@@ -258,11 +267,18 @@ func (p *RegimeDirectionalPolicy) ResolveRawWithLabels(label string, labels []st
 	// fallback at runtime. Operators who want the static config to apply
 	// for one regime can spell it out explicitly. Uses `seen` (not `parsed`)
 	// so a label that's present-but-invalid isn't also reported as missing.
+	// #1124: a present bare `ranging_directional` covers its _up/_down
+	// sub-labels (back-compat — resolves the whole family at runtime).
+	bareDirectional := seen["ranging_directional"]
 	missing := []string{}
 	for _, l := range labels {
-		if !seen[l] {
-			missing = append(missing, l)
+		if seen[l] {
+			continue
 		}
+		if (l == "ranging_directional_up" || l == "ranging_directional_down") && bareDirectional {
+			continue
+		}
+		missing = append(missing, l)
 	}
 	if len(missing) > 0 {
 		errs = append(errs, fmt.Sprintf("%s: missing required regime labels: %s", label, strings.Join(missing, ", ")))

--- a/scheduler/regime_directional_policy.go
+++ b/scheduler/regime_directional_policy.go
@@ -106,8 +106,8 @@ func (p *RegimeDirectionalPolicy) Resolve(regime string) (RegimeDirectionalEntry
 		return entry, true
 	}
 	// #1124: sub-label stamp falls back to the bare ranging_directional entry.
-	if r == "ranging_directional_up" || r == "ranging_directional_down" {
-		if entry, ok := p.TrendRegime["ranging_directional"]; ok {
+	if regimeDirectionalSubs[r] {
+		if entry, ok := p.TrendRegime[regimeDirectionalBare]; ok {
 			return entry, true
 		}
 	}
@@ -269,13 +269,13 @@ func (p *RegimeDirectionalPolicy) ResolveRawWithLabels(label string, labels []st
 	// so a label that's present-but-invalid isn't also reported as missing.
 	// #1124: a present bare `ranging_directional` covers its _up/_down
 	// sub-labels (back-compat — resolves the whole family at runtime).
-	bareDirectional := seen["ranging_directional"]
+	bareDirectional := seen[regimeDirectionalBare]
 	missing := []string{}
 	for _, l := range labels {
 		if seen[l] {
 			continue
 		}
-		if (l == "ranging_directional_up" || l == "ranging_directional_down") && bareDirectional {
+		if regimeLabelFamilyCovered(l, bareDirectional) {
 			continue
 		}
 		missing = append(missing, l)

--- a/scheduler/regime_divergence.go
+++ b/scheduler/regime_divergence.go
@@ -237,11 +237,14 @@ func (d *RegimeWindowDivergence) ResolveRaw(label string) []string {
 // regimeLabelBias returns the directional bias of a composite or ADX regime label.
 // ranging_directional uses snapReturnEff (from RegimeSnapshot.Metrics["return_eff"])
 // to break the bullish/bearish tie when provided; otherwise treated as neutral.
+// #1124: ranging_directional_up/_down carry the drift sign in the label itself and
+// resolve bullish/bearish directly, independent of snapReturnEff. The bare
+// ranging_directional label (return_eff == 0) keeps the snapReturnEff resolution.
 func regimeLabelBias(label string, snapReturnEff float64) divergenceBias {
 	switch strings.TrimSpace(label) {
-	case "trending_up", "trending_up_clean", "trending_up_choppy":
+	case "trending_up", "trending_up_clean", "trending_up_choppy", "ranging_directional_up":
 		return biasBullish
-	case "trending_down", "trending_down_clean", "trending_down_choppy":
+	case "trending_down", "trending_down_clean", "trending_down_choppy", "ranging_directional_down":
 		return biasBearish
 	case "ranging_directional":
 		if snapReturnEff > 0 {

--- a/scheduler/regime_divergence_test.go
+++ b/scheduler/regime_divergence_test.go
@@ -441,6 +441,42 @@ func TestClassifyRegimeDivergence_TrustMediumRangingDirectional(t *testing.T) {
 	}
 }
 
+// #1124: ranging_directional_up/down carry the drift sign in the label itself,
+// so regimeLabelBias resolves them bullish/bearish directly — independent of
+// snapReturnEff. The bare ranging_directional label keeps snapReturnEff
+// resolution (zero → neutral).
+func TestClassifyRegimeDivergence_RangingDirectionalUpDownLabelsCarrySign(t *testing.T) {
+	// up label → bullish regardless of snapReturnEff (here passed 0, and even
+	// a contradicting negative sign must NOT flip a label that carries +).
+	rUp := classifyRegimeDivergence("ranging_directional_up", "trending_down", 0, 0, onDivergenceTrustShort)
+	if rUp.Kind != DivergenceHard {
+		t.Fatalf("ranging_directional_up: expected hard vs trending_down, got %q", rUp.Kind)
+	}
+	if rUp.OverrideDir != DirectionLong {
+		t.Errorf("ranging_directional_up: expected long, got %q", rUp.OverrideDir)
+	}
+	// A contradicting snapReturnEff must not override the label's own sign.
+	rUpNeg := classifyRegimeDivergence("ranging_directional_up", "trending_down", -0.05, 0, onDivergenceTrustShort)
+	if rUpNeg.Kind != DivergenceHard || rUpNeg.OverrideDir != DirectionLong {
+		t.Errorf("ranging_directional_up with negative snapReturnEff: label sign must win, got %+v", rUpNeg)
+	}
+
+	// down label → bearish, same direction as trending_down → none.
+	rDown := classifyRegimeDivergence("ranging_directional_down", "trending_down", 0, 0, onDivergenceTrustShort)
+	if rDown.Kind != DivergenceNone {
+		t.Errorf("ranging_directional_down vs trending_down: expected none (same bearish), got %q", rDown.Kind)
+	}
+
+	// up vs down labels → hard opposite.
+	rOpp := classifyRegimeDivergence("ranging_directional_up", "ranging_directional_down", 0, 0, onDivergenceTrustShort)
+	if rOpp.Kind != DivergenceHard {
+		t.Fatalf("up vs down: expected hard, got %q", rOpp.Kind)
+	}
+	if rOpp.OverrideDir != DirectionLong {
+		t.Errorf("up vs down trust_short: expected long, got %q", rOpp.OverrideDir)
+	}
+}
+
 // PR #916 fix 2: a typo'd window name must be rejected at validation time,
 // not silently no-op at runtime. The existence check runs in
 // validateStrategyRegimeVocabulary (after ResolveRaw), so this exercises the

--- a/scheduler/regime_profile_allocation.go
+++ b/scheduler/regime_profile_allocation.go
@@ -263,10 +263,21 @@ func (a *RegimeProfileAllocation) ResolveRaw(label string, labels []string) []st
 		errs = append(errs, fmt.Sprintf("%s.initial_profile=%q is not a param_sets profile (valid: %s)", label, initialProfile, strings.Join(sortedKeys(paramSets), ", ")))
 	}
 	// Every classifier label must be covered by profiles.
+	// #1124: a present bare `ranging_directional` mapping covers its _up/_down
+	// sub-labels (back-compat — the bare profile resolves the whole family at
+	// runtime, including the return_eff==0 neutral case the producer emits).
+	bareDirectional := false
+	if _, ok := profiles["ranging_directional"]; ok {
+		bareDirectional = true
+	}
 	for _, l := range labels {
-		if _, ok := profiles[l]; !ok {
-			errs = append(errs, fmt.Sprintf("%s.profiles: missing mapping for regime label %q (every label of the window classifier must map to a profile)", label, l))
+		if _, ok := profiles[l]; ok {
+			continue
 		}
+		if (l == "ranging_directional_up" || l == "ranging_directional_down") && bareDirectional {
+			continue
+		}
+		errs = append(errs, fmt.Sprintf("%s.profiles: missing mapping for regime label %q (every label of the window classifier must map to a profile)", label, l))
 	}
 
 	if len(errs) > 0 {
@@ -390,6 +401,11 @@ func resolveRegimeProfile(alloc *RegimeProfileAllocation, label, barTime string,
 	desired := ""
 	if label != "" {
 		desired = alloc.Profiles[label]
+		// #1124: sub-label stamp falls back to the bare ranging_directional
+		// mapping when no explicit sub-label profile is configured.
+		if desired == "" && (label == "ranging_directional_up" || label == "ranging_directional_down") {
+			desired = alloc.Profiles["ranging_directional"]
+		}
 	}
 
 	barAdvanced := barTime != "" && barTime != next.LastBarTime

--- a/scheduler/regime_profile_allocation.go
+++ b/scheduler/regime_profile_allocation.go
@@ -267,14 +267,14 @@ func (a *RegimeProfileAllocation) ResolveRaw(label string, labels []string) []st
 	// sub-labels (back-compat — the bare profile resolves the whole family at
 	// runtime, including the return_eff==0 neutral case the producer emits).
 	bareDirectional := false
-	if _, ok := profiles["ranging_directional"]; ok {
+	if _, ok := profiles[regimeDirectionalBare]; ok {
 		bareDirectional = true
 	}
 	for _, l := range labels {
 		if _, ok := profiles[l]; ok {
 			continue
 		}
-		if (l == "ranging_directional_up" || l == "ranging_directional_down") && bareDirectional {
+		if regimeLabelFamilyCovered(l, bareDirectional) {
 			continue
 		}
 		errs = append(errs, fmt.Sprintf("%s.profiles: missing mapping for regime label %q (every label of the window classifier must map to a profile)", label, l))
@@ -403,8 +403,8 @@ func resolveRegimeProfile(alloc *RegimeProfileAllocation, label, barTime string,
 		desired = alloc.Profiles[label]
 		// #1124: sub-label stamp falls back to the bare ranging_directional
 		// mapping when no explicit sub-label profile is configured.
-		if desired == "" && (label == "ranging_directional_up" || label == "ranging_directional_down") {
-			desired = alloc.Profiles["ranging_directional"]
+		if desired == "" && regimeDirectionalSubs[label] {
+			desired = alloc.Profiles[regimeDirectionalBare]
 		}
 	}
 

--- a/scheduler/regime_test.go
+++ b/scheduler/regime_test.go
@@ -129,6 +129,38 @@ func TestRegimeAllowsEntry_NonMatchingLabel(t *testing.T) {
 	}
 }
 
+// TestRegimeAllowsEntry_BareDirectionalCoversSubLabels: #1124 family rule on
+// the entry gate — a bare ranging_directional in allowed matches its _up/_down
+// sub-labels (one-directional bare→subs).
+func TestRegimeAllowsEntry_BareDirectionalCoversSubLabels(t *testing.T) {
+	allowed := []string{"ranging_directional"}
+	if !regimeAllowsEntry(allowed, "ranging_directional_up") {
+		t.Error("bare ranging_directional should allow ranging_directional_up")
+	}
+	if !regimeAllowsEntry(allowed, "ranging_directional_down") {
+		t.Error("bare ranging_directional should allow ranging_directional_down")
+	}
+	if !regimeAllowsEntry(allowed, "ranging_directional") {
+		t.Error("bare ranging_directional should allow itself")
+	}
+}
+
+// TestRegimeAllowsEntry_ExplicitSubLabelDoesNotCoverBareOrSibling: the family
+// expansion is one-directional — an explicit _up does NOT match bare or _down.
+func TestRegimeAllowsEntry_ExplicitSubLabelDoesNotCoverBareOrSibling(t *testing.T) {
+	allowed := []string{"ranging_directional_up"}
+	if regimeAllowsEntry(allowed, "ranging_directional") {
+		t.Error("explicit _up should NOT cover bare ranging_directional")
+	}
+	if regimeAllowsEntry(allowed, "ranging_directional_down") {
+		t.Error("explicit _up should NOT cover ranging_directional_down")
+	}
+	// Still matches itself.
+	if !regimeAllowsEntry(allowed, "ranging_directional_up") {
+		t.Error("explicit _up should match itself")
+	}
+}
+
 func TestRegimeAllowsEntry_EmptyCurrentAllowsWhenListNonEmpty(t *testing.T) {
 	// When regime field is empty (script disabled / not available), allow entry
 	// so existing strategies without regime are unaffected.

--- a/scheduler/regime_unified.go
+++ b/scheduler/regime_unified.go
@@ -54,9 +54,19 @@ func unifiedRegimeScalarParams(params map[string]interface{}, regime string) (sc
 	if !isMap {
 		return nil, 0, false
 	}
-	labelRaw, isMap := trendRaw[strings.TrimSpace(regime)].(map[string]interface{})
+	r := strings.TrimSpace(regime)
+	labelRaw, isMap := trendRaw[r].(map[string]interface{})
 	if !isMap {
-		return nil, 0, false
+		// #1124: sub-label stamp falls back to the bare ranging_directional
+		// entry. The unified close is the sole SL owner, so without this
+		// fallback a bare-only block yields no SL *and* no TPs for an
+		// _up/_down stamp → a naked HL perps position.
+		if regimeDirectionalSubs[r] {
+			labelRaw, isMap = trendRaw[regimeDirectionalBare].(map[string]interface{})
+		}
+		if !isMap {
+			return nil, 0, false
+		}
 	}
 	tiers, hasTiers := labelRaw["tp_tiers"]
 	if !hasTiers {
@@ -200,9 +210,16 @@ func validateUnifiedRegimeClose(params map[string]interface{}, labels []string, 
 			ctxLabel, regimeClassifierKey, l, strings.Join(labels, ", ")))
 	}
 
+	bareDirectional := trendRaw[regimeDirectionalBare] != nil
 	for _, l := range labels {
 		lr, ok := trendRaw[l]
 		if !ok {
+			// #1124 family rule: a present bare ranging_directional covers
+			// the _up/_down sub-labels for exhaustiveness, so a 7-label
+			// composite block (the pre-#1124 shape) still loads.
+			if regimeLabelFamilyCovered(l, bareDirectional) {
+				continue
+			}
 			errs = append(errs, fmt.Sprintf("%s.%s: missing required regime label %q (must be exhaustive — no silent fallback)",
 				ctxLabel, regimeClassifierKey, l))
 			continue

--- a/scheduler/regime_unified_test.go
+++ b/scheduler/regime_unified_test.go
@@ -300,3 +300,95 @@ func TestUnifiedCloseParamsEqualForReload(t *testing.T) {
 		t.Fatal("two non-unified strategies should compare equal")
 	}
 }
+
+// unifiedCompositeBlock is a 9-label composite unified block keyed on bare
+// ranging_directional (no _up/_down keys) — the pre-#1124 shape that the
+// family rule must keep valid and keep resolving for _up/_down stamps.
+func unifiedCompositeBlock() map[string]interface{} {
+	tiers := func(a, b float64) []interface{} {
+		return []interface{}{
+			map[string]interface{}{"atr_multiple": a, "close_fraction": 0.5},
+			map[string]interface{}{"atr_multiple": b, "close_fraction": 1.0},
+		}
+	}
+	return map[string]interface{}{
+		regimeClassifierKey: map[string]interface{}{
+			"trending_up_clean":    map[string]interface{}{"stop_loss_atr": 1.5, "tp_tiers": tiers(2.0, 4.0)},
+			"trending_up_choppy":   map[string]interface{}{"stop_loss_atr": 1.3, "tp_tiers": tiers(1.8, 3.0)},
+			"trending_down_clean":  map[string]interface{}{"stop_loss_atr": 1.5, "tp_tiers": tiers(2.0, 4.0)},
+			"trending_down_choppy": map[string]interface{}{"stop_loss_atr": 1.3, "tp_tiers": tiers(1.8, 3.0)},
+			"ranging_quiet":        map[string]interface{}{"stop_loss_atr": 1.0, "tp_tiers": tiers(1.2, 2.4)},
+			"ranging_volatile":     map[string]interface{}{"stop_loss_atr": 1.2, "tp_tiers": tiers(1.5, 3.0)},
+			"ranging_directional":  map[string]interface{}{"stop_loss_atr": 1.1, "tp_tiers": tiers(1.3, 2.6)},
+		},
+	}
+}
+
+// TestValidateUnifiedRegimeClose_CompositeBareDirectionalCoversSubLabels:
+// the #1124 family rule — a bare ranging_directional covers its _up/_down
+// sub-labels for exhaustiveness, so the 7-label pre-#1124 shape still loads.
+func TestValidateUnifiedRegimeClose_CompositeBareDirectionalCoversSubLabels(t *testing.T) {
+	labels := regimeLabelsForClassifier(regimeClassifierComposite)
+	if errs := validateUnifiedRegimeClose(unifiedCompositeBlock(), labels, "close.params"); len(errs) > 0 {
+		t.Fatalf("7-label composite block keyed on bare ranging_directional rejected: %v", errs)
+	}
+}
+
+// TestValidateUnifiedRegimeClose_CompositeSubLabelsWithoutBareRejected:
+// sub-labels-only (no bare parent) is still non-exhaustive because the
+// producer emits bare ranging_directional at exactly return_eff == 0.
+func TestValidateUnifiedRegimeClose_CompositeSubLabelsWithoutBareRejected(t *testing.T) {
+	labels := regimeLabelsForClassifier(regimeClassifierComposite)
+	m := unifiedCompositeBlock()
+	tr := m[regimeClassifierKey].(map[string]interface{})
+	delete(tr, "ranging_directional")
+	tr["ranging_directional_up"] = map[string]interface{}{"stop_loss_atr": 1.1, "tp_tiers": []interface{}{
+		map[string]interface{}{"atr_multiple": 1.3, "close_fraction": 0.5},
+		map[string]interface{}{"atr_multiple": 2.6, "close_fraction": 1.0},
+	}}
+	tr["ranging_directional_down"] = tr["ranging_directional_up"]
+	errs := validateUnifiedRegimeClose(m, labels, "close.params")
+	joined := strings.Join(errs, " | ")
+	if !strings.Contains(joined, `missing required regime label "ranging_directional"`) {
+		t.Fatalf("sub-labels-only block must be rejected as missing bare ranging_directional, got: %v", errs)
+	}
+}
+
+// TestUnifiedRegimeScalarParams_SubLabelFallsBackToBare: a _up/_down stamp
+// resolves to the bare ranging_directional block at runtime, returning its
+// SL and TP ladder (the sole-owner safety guarantee — no naked position).
+func TestUnifiedRegimeScalarParams_SubLabelFallsBackToBare(t *testing.T) {
+	for _, stamp := range []string{"ranging_directional_up", "ranging_directional_down"} {
+		scalar, sl, ok := unifiedRegimeScalarParams(unifiedCompositeBlock(), stamp)
+		if !ok {
+			t.Fatalf("%s: expected ok via bare fallback", stamp)
+		}
+		if sl != 1.1 {
+			t.Fatalf("%s: stop_loss_atr = %g, want 1.1 (bare)", stamp, sl)
+		}
+		if tiers, ok := scalar["tp_tiers"].([]interface{}); !ok || len(tiers) != 2 {
+			t.Fatalf("%s: tp_tiers = %v, want bare 2-tier ladder", stamp, scalar["tp_tiers"])
+		}
+	}
+}
+
+// TestUnifiedRegimeSLFolding_SubLabelStampPlacesSL: end-to-end #1124 safety —
+// a composite unified close keyed on bare ranging_directional places an SL
+// (via the on-chain protection plan) when the producer stamps _up/_down.
+func TestUnifiedRegimeSLFolding_SubLabelStampPlacesSL(t *testing.T) {
+	sc := StrategyConfig{
+		ID: "hl-unified-sub", Platform: "hyperliquid", Type: "perps",
+		MaxDrawdownPct: 25,
+		CloseStrategy:  &StrategyRef{Name: "tiered_tp_atr_live_regime", Params: unifiedCompositeBlock()},
+	}
+	for _, stamp := range []string{"ranging_directional_up", "ranging_directional_down"} {
+		pos := &Position{Symbol: "ETH", Quantity: 1, AvgCost: 100, EntryATR: 5, Side: "long", Regime: stamp}
+		plan, ok := buildHyperliquidProtectionPlan(sc, pos)
+		if !ok {
+			t.Fatalf("%s: protection plan not built (naked position)", stamp)
+		}
+		if plan.StopLossATRMult != 1.1 {
+			t.Fatalf("%s: plan.StopLossATRMult = %g, want 1.1 (bare fallback)", stamp, plan.StopLossATRMult)
+		}
+	}
+}

--- a/scheduler/regime_window_spec.go
+++ b/scheduler/regime_window_spec.go
@@ -136,6 +136,8 @@ func regimeLabelsForClassifier(classifier string) []string {
 			"ranging_quiet",
 			"ranging_volatile",
 			"ranging_directional",
+			"ranging_directional_up",
+			"ranging_directional_down",
 		}
 	default:
 		return append([]string(nil), canonicalTrendRegimeLabels...)

--- a/scheduler/trailing_tp_ratchet.go
+++ b/scheduler/trailing_tp_ratchet.go
@@ -273,9 +273,17 @@ func trailingRatchetTiersForRegime(sc StrategyConfig, regime string) []trailingR
 			if !ok || strings.TrimSpace(regime) == "" {
 				return nil
 			}
-			block, ok := table[strings.TrimSpace(regime)]
+			key := strings.TrimSpace(regime)
+			block, ok := table[key]
 			if !ok {
-				return nil
+				// #1124: sub-label stamp falls back to the bare
+				// ranging_directional tier ladder.
+				if regimeDirectionalSubs[key] {
+					block, ok = table[regimeDirectionalBare]
+				}
+				if !ok {
+					return nil
+				}
 			}
 			tiers, _ := parseTrailingRatchetTierList(block, ref.Name+".tp_tiers."+regime)
 			return tiers
@@ -419,9 +427,15 @@ func validateTrailingTPRatchetClose(sc StrategyConfig, labels []string, regimeEn
 					errs = append(errs, fmt.Sprintf("%s.tp_tiers: unknown regime key %q (valid: %s)", sub, key, strings.Join(labels, ", ")))
 				}
 			}
+			bareDirectional := table[regimeDirectionalBare] != nil
 			for _, key := range labels {
 				block, ok := table[key]
 				if !ok {
+					// #1124 family rule: bare ranging_directional covers the
+					// _up/_down sub-labels for exhaustiveness.
+					if regimeLabelFamilyCovered(key, bareDirectional) {
+						continue
+					}
 					errs = append(errs, fmt.Sprintf("%s.tp_tiers: missing required regime key %q", sub, key))
 					continue
 				}

--- a/scheduler/trailing_tp_ratchet.go
+++ b/scheduler/trailing_tp_ratchet.go
@@ -123,7 +123,17 @@ var ratchetTierGroupDefaults = map[string][]trailingRatchetTier{
 func ratchetCloseDefaultGroup(label string) (string, bool) {
 	l := strings.TrimSpace(label)
 	switch l {
-	case "ranging_quiet", "ranging_volatile", "ranging_directional":
+	case "ranging_quiet", "ranging_volatile", "ranging_directional",
+		"ranging_directional_up", "ranging_directional_down":
+		// #1124: the directional sub-labels share the single ranging_directional
+		// ratchet ladder by default. Routing them anywhere else (or letting them
+		// fall through to regimeCloseDefaultGroup → "ranging", which is ABSENT
+		// from ratchetTierGroupDefaults) silently never-arms the auto-protective
+		// ratchet exit. Operators wanting distinct geometry set explicit
+		// tp_tiers keys for the new labels.
+		if l == "ranging_directional_up" || l == "ranging_directional_down" {
+			return "ranging_directional", true
+		}
 		return l, true
 	case "ranging":
 		return "ranging_quiet", true

--- a/scheduler/trailing_tp_ratchet_test.go
+++ b/scheduler/trailing_tp_ratchet_test.go
@@ -398,8 +398,11 @@ func TestValidateTrailingTPRatchetClose_CompositeVocabulary(t *testing.T) {
 		return tbl
 	}
 	composite := regimeLabelsForClassifier(regimeClassifierComposite)
-	if len(composite) != 7 {
-		t.Fatalf("expected 7 composite labels, got %d", len(composite))
+	// #1124: the composite vocabulary grew from 7 to 9 labels
+	// (ranging_directional_up/_down added).
+	wantLabels := len(composite)
+	if wantLabels != 9 {
+		t.Fatalf("expected 9 composite labels, got %d", wantLabels)
 	}
 
 	// #870: the regime variant's opening trail / SL owner is the per-regime
@@ -759,6 +762,20 @@ func TestDefaultTrailingRatchetTiersForRegime(t *testing.T) {
 	if dir[3].ATRMultiple != 4.5 || dir[3].TrailingMultAfter != 0.6 {
 		t.Fatalf("ranging_directional let-ride rung mismatch: %+v", dir[3])
 	}
+	// #1124: the directional sub-labels must resolve to the SAME ladder as the
+	// bare directional label — never nil. A nil resolution means the ratchet
+	// exit silently never arms (auto-protective money path).
+	for _, sub := range []string{"ranging_directional_up", "ranging_directional_down"} {
+		got := defaultTrailingRatchetTiersForRegime(sub)
+		if len(got) != len(dir) {
+			t.Fatalf("%s: want %d tiers (mirrors ranging_directional), got %d: %+v", sub, len(dir), len(got), got)
+		}
+		for i := range got {
+			if got[i] != dir[i] {
+				t.Fatalf("%s tier[%d] = %+v, want %+v (mirrors ranging_directional)", sub, i, got[i], dir[i])
+			}
+		}
+	}
 	if defaultTrailingRatchetTiersForRegime("") != nil {
 		t.Error("empty regime must resolve to nil")
 	}
@@ -776,6 +793,11 @@ func TestRatchetCloseDefaultGroup(t *testing.T) {
 		{"ranging_quiet", "ranging_quiet", true},
 		{"ranging_volatile", "ranging_volatile", true},
 		{"ranging_directional", "ranging_directional", true},
+		// #1124: directional sub-labels collapse to the directional ladder so
+		// they never fall through to "ranging" (absent from the ratchet tier
+		// defaults → silent never-arm of the auto-protective exit).
+		{"ranging_directional_up", "ranging_directional", true},
+		{"ranging_directional_down", "ranging_directional", true},
 		{"ranging", "ranging_quiet", true}, // bare ADX → quiet ladder
 		{"trending_up_clean", "clean", true},
 		{"trending_up_choppy", "choppy", true},

--- a/scheduler/trailing_tp_ratchet_test.go
+++ b/scheduler/trailing_tp_ratchet_test.go
@@ -842,3 +842,84 @@ func errListContains(errs []string, needle string) bool {
 	}
 	return false
 }
+
+// TestValidateTrailingTPRatchetClose_CompositeBareDirectionalCoversSubLabels:
+// #1124 family rule — a trailing_tp_ratchet_regime with explicit tp_tiers keyed
+// on bare ranging_directional (no _up/_down keys) still validates against the
+// 9-label composite vocabulary, and arms for _up/_down stamps at runtime.
+func TestValidateTrailingTPRatchetClose_CompositeBareDirectionalCoversSubLabels(t *testing.T) {
+	tierList := []interface{}{
+		map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 1.0},
+	}
+	labels := regimeLabelsForClassifier(regimeClassifierComposite)
+	tpTiers := map[string]interface{}{}
+	for _, l := range labels {
+		if l == "ranging_directional_up" || l == "ranging_directional_down" {
+			continue // bare ranging_directional covers these
+		}
+		tpTiers[l] = tierList
+	}
+	sc := StrategyConfig{
+		ID: "s1", Type: "perps", Platform: "hyperliquid",
+		TrailingStopATRRegime: &RegimeATRBlock{TrendRegime: map[string]RegimeATREntry{
+			"trending_up_clean":    {ATR: 2.0},
+			"trending_up_choppy":   {ATR: 2.0},
+			"trending_down_clean":  {ATR: 2.0},
+			"trending_down_choppy": {ATR: 2.0},
+			"ranging_quiet":        {ATR: 1.0},
+			"ranging_volatile":     {ATR: 1.2},
+			"ranging_directional":  {ATR: 1.0},
+		}},
+		CloseStrategy: &StrategyRef{
+			Name:   "trailing_tp_ratchet_regime",
+			Params: map[string]interface{}{"tp_tiers": tpTiers},
+		},
+	}
+	if errs := validateTrailingTPRatchetClose(sc, labels, true); len(errs) > 0 {
+		t.Fatalf("composite bare-ranging_directional ratchet must validate, got: %v", errs)
+	}
+	// Sub-label stamp resolves to the bare tier ladder at runtime.
+	for _, stamp := range []string{"ranging_directional_up", "ranging_directional_down"} {
+		tiers := trailingRatchetTiersForRegime(sc, stamp)
+		if len(tiers) != 1 || tiers[0].ATRMultiple != 1.0 {
+			t.Fatalf("%s: resolved tiers = %+v, want bare 1.0 ladder via fallback", stamp, tiers)
+		}
+	}
+}
+
+// TestValidateTrailingTPRatchetClose_CompositeSubLabelsWithoutBareRejected:
+// sub-labels-only (no bare parent) is still non-exhaustive.
+func TestValidateTrailingTPRatchetClose_CompositeSubLabelsWithoutBareRejected(t *testing.T) {
+	tierList := []interface{}{
+		map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 1.0},
+	}
+	labels := regimeLabelsForClassifier(regimeClassifierComposite)
+	tpTiers := map[string]interface{}{}
+	for _, l := range labels {
+		if l == "ranging_directional" {
+			continue // omit bare — only _up/_down present
+		}
+		tpTiers[l] = tierList
+	}
+	sc := StrategyConfig{
+		ID: "s1", Type: "perps", Platform: "hyperliquid",
+		TrailingStopATRRegime: &RegimeATRBlock{TrendRegime: map[string]RegimeATREntry{
+			"trending_up_clean":        {ATR: 2.0},
+			"trending_up_choppy":       {ATR: 2.0},
+			"trending_down_clean":      {ATR: 2.0},
+			"trending_down_choppy":     {ATR: 2.0},
+			"ranging_quiet":            {ATR: 1.0},
+			"ranging_volatile":         {ATR: 1.2},
+			"ranging_directional_up":   {ATR: 1.0},
+			"ranging_directional_down": {ATR: 1.0},
+		}},
+		CloseStrategy: &StrategyRef{
+			Name:   "trailing_tp_ratchet_regime",
+			Params: map[string]interface{}{"tp_tiers": tpTiers},
+		},
+	}
+	errs := validateTrailingTPRatchetClose(sc, labels, true)
+	if !errListContains(errs, `missing required regime key "ranging_directional"`) {
+		t.Fatalf("sub-labels-only ratchet must be rejected as missing bare, got: %v", errs)
+	}
+}

--- a/shared_strategies/close/post_tp_sl.py
+++ b/shared_strategies/close/post_tp_sl.py
@@ -53,7 +53,14 @@ class RegimeFloatBlock:
     trend_regime: Dict[str, float] = field(default_factory=dict)
 
     def resolve(self, regime: str) -> Optional[float]:
-        return self.trend_regime.get((regime or "").strip())
+        r = (regime or "").strip()
+        v = self.trend_regime.get(r)
+        if v is not None:
+            return v
+        # #1124: sub-label stamp falls back to the bare ranging_directional entry.
+        if r in ("ranging_directional_up", "ranging_directional_down"):
+            return self.trend_regime.get("ranging_directional")
+        return None
 
 
 @dataclass(frozen=True)
@@ -389,7 +396,14 @@ def _parse_regime_float_block(
             f"{ctx_label}.{REGIME_CLASSIFIER_KEY}: unknown regime label {label!r} "
             f"(expected one of: {', '.join(labels)})"
         )
-    missing = [label for label in labels if label not in trend_raw]
+    missing = [
+        label for label in labels
+        if label not in trend_raw
+        and not (
+            label in ("ranging_directional_up", "ranging_directional_down")
+            and "ranging_directional" in trend_raw
+        )
+    ]
     if missing:
         errs.append(
             f"{ctx_label}.{REGIME_CLASSIFIER_KEY}: missing required regime labels: "
@@ -872,7 +886,20 @@ def validate_regime_tiered_tp_labels(
                     f"{name}.tiers[{i}].{REGIME_CLASSIFIER_KEY}: unknown regime "
                     f"label {key!r} (expected one of: {', '.join(sorted(expected))})"
                 )
-            missing = [label for label in sorted(expected) if label not in block]
+            # #1124: a present bare `ranging_directional` covers its _up/_down
+            # sub-labels for exhaustiveness (back-compat — the bare label
+            # resolves the whole family at runtime, including the return_eff==0
+            # neutral case the producer still emits). Providing only the
+            # sub-labels without the bare label is NOT exhaustive.
+            bare_directional_present = "ranging_directional" in block
+            missing = [
+                label for label in sorted(expected)
+                if label not in block
+                and not (
+                    label in ("ranging_directional_up", "ranging_directional_down")
+                    and bare_directional_present
+                )
+            ]
             if missing:
                 errs.append(
                     f"{name}.tiers[{i}].{REGIME_CLASSIFIER_KEY}: missing required "

--- a/shared_strategies/close/regime_atr.py
+++ b/shared_strategies/close/regime_atr.py
@@ -107,7 +107,17 @@ class RegimeATRBlock:
     def resolve(self, regime: str) -> Optional[RegimeATREntry]:
         if not self.trend_regime:
             return None
-        return self.trend_regime.get((regime or "").strip())
+        r = (regime or "").strip()
+        entry = self.trend_regime.get(r)
+        if entry is not None:
+            return entry
+        # #1124: a ranging_directional_up/_down stamp falls back to the bare
+        # ranging_directional entry when no explicit sub-label key is present
+        # (the back-compat shape — bare label covers the whole family). Mirrors
+        # RegimeATRBlock.Resolve in scheduler/regime_atr.go.
+        if r in ("ranging_directional_up", "ranging_directional_down"):
+            return self.trend_regime.get("ranging_directional")
+        return None
 
 
 # Mirrors regimeATRDefaults in scheduler/regime_atr.go — keep values in sync.
@@ -131,6 +141,12 @@ REGIME_ATR_DEFAULTS_TRAILING: Dict[str, RegimeATREntry] = {
     "ranging_quiet": RegimeATREntry(atr=1.0),
     "ranging_volatile": RegimeATREntry(atr=1.0),
     "ranging_directional": RegimeATREntry(atr=1.0),
+    # #1124: directional sub-labels share the ranging_directional opening trail
+    # so use_defaults exact-matches them instead of falling back to "ranging"
+    # (atr=2.0). Without these entries the new labels would resolve to 2.0,
+    # diverging from the bare directional label.
+    "ranging_directional_up": RegimeATREntry(atr=1.0),
+    "ranging_directional_down": RegimeATREntry(atr=1.0),
 }
 
 # #870: per-quality-group default ATR take-profit ladders. Mirrors
@@ -252,7 +268,20 @@ def parse_regime_atr_block(
             f"(expected one of: {', '.join(labels)})"
         )
 
-    missing_labels = [l for l in labels if l not in trend_raw]
+    # #1124: a present bare `ranging_directional` covers its _up/_down sub-labels
+    # for exhaustiveness (back-compat — the bare label resolves the whole family
+    # at runtime, including the return_eff==0 neutral case the producer still
+    # emits). Providing only the sub-labels without the bare label is NOT
+    # exhaustive (the neutral case would resolve to None → silent never-arm).
+    bare_directional_present = "ranging_directional" in trend_raw
+    missing_labels = [
+        l for l in labels
+        if l not in trend_raw
+        and not (
+            l in ("ranging_directional_up", "ranging_directional_down")
+            and bare_directional_present
+        )
+    ]
     if missing_labels:
         errs.append(
             f"{ctx_label}.{REGIME_CLASSIFIER_KEY}: missing required regime labels: "

--- a/shared_strategies/close/test_regime_atr.py
+++ b/shared_strategies/close/test_regime_atr.py
@@ -195,3 +195,67 @@ def test_atr_multiple_canonical_only(regime_atr):
         both, "stop_loss_atr_regime", regime_atr.SURFACE_STOP_LOSS
     )
     assert errs, "expected error when both atr_multiple and atr are set"
+
+
+# #1124: ranging_directional family — bare label covers _up/_down for
+# exhaustiveness; sub-labels-only is rejected; runtime Resolve falls back.
+_COMPOSITE_LABELS_1124 = (
+    "trending_up_clean",
+    "trending_up_choppy",
+    "trending_down_clean",
+    "trending_down_choppy",
+    "ranging_quiet",
+    "ranging_volatile",
+    "ranging_directional",
+    "ranging_directional_up",
+    "ranging_directional_down",
+)
+
+
+def _composite_block_atr(atr, omit=()):
+    return {
+        "trend_regime": {
+            l: {"atr_multiple": atr} for l in _COMPOSITE_LABELS_1124 if l not in omit
+        }
+    }
+
+
+def test_composite_bare_directional_covers_sublabels(regime_atr):
+    # 7-label block (bare ranging_directional present, no _up/_down keys) →
+    # the bare label covers the sub-labels → validates (back-compat).
+    raw = _composite_block_atr(1.5, omit=("ranging_directional_up", "ranging_directional_down"))
+    block, errs = regime_atr.parse_regime_atr_block(
+        raw, "stop_loss_atr_regime", regime_atr.SURFACE_STOP_LOSS,
+        labels=_COMPOSITE_LABELS_1124,
+    )
+    assert errs == [], errs
+    # Runtime: a _up/_down stamp resolves via the bare fallback.
+    assert block.resolve("ranging_directional").atr == 1.5
+    assert block.resolve("ranging_directional_up").atr == 1.5
+    assert block.resolve("ranging_directional_down").atr == 1.5
+
+
+def test_composite_sublabels_without_bare_rejected(regime_atr):
+    # Sub-labels present but bare ranging_directional omitted → NOT exhaustive
+    # (the producer still emits the bare label at return_eff==0).
+    raw = _composite_block_atr(1.5, omit=("ranging_directional",))
+    _, errs = regime_atr.parse_regime_atr_block(
+        raw, "stop_loss_atr_regime", regime_atr.SURFACE_STOP_LOSS,
+        labels=_COMPOSITE_LABELS_1124,
+    )
+    assert any(
+        "missing required regime labels" in e and "ranging_directional" in e for e in errs
+    ), errs
+
+
+def test_composite_explicit_sublabel_wins_over_bare(regime_atr):
+    # When an explicit sub-label key is present, it wins over the bare fallback.
+    raw = _composite_block_atr(1.5)
+    raw[regime_atr.REGIME_CLASSIFIER_KEY]["ranging_directional_up"] = {"atr_multiple": 0.9}
+    block, errs = regime_atr.parse_regime_atr_block(
+        raw, "stop_loss_atr_regime", regime_atr.SURFACE_STOP_LOSS,
+        labels=_COMPOSITE_LABELS_1124,
+    )
+    assert errs == [], errs
+    assert block.resolve("ranging_directional_up").atr == 0.9
+    assert block.resolve("ranging_directional_down").atr == 1.5  # bare fallback

--- a/shared_strategies/close/test_trailing_tp_ratchet.py
+++ b/shared_strategies/close/test_trailing_tp_ratchet.py
@@ -187,6 +187,14 @@ def test_ratchet_close_default_group_differentiates_ranging_substates(ratchet):
     # the B2 ATR-TP use_defaults path would miss its map and never-arm (#1059).
     assert ratchet.regime_close_default_group("ranging_directional") == "ranging"
     assert ratchet.regime_close_default_group("ranging_volatile") == "ranging"
+    # #1124: directional sub-labels collapse to the directional ratchet ladder
+    # (never fall through to "ranging", which is absent from the ratchet tier
+    # defaults → silent never-arm of the auto-protective exit). The shared fn
+    # still collapses them to "ranging" for the B2 ATR-TP path.
+    assert g("ranging_directional_up") == "ranging_directional"
+    assert g("ranging_directional_down") == "ranging_directional"
+    assert ratchet.regime_close_default_group("ranging_directional_up") == "ranging"
+    assert ratchet.regime_close_default_group("ranging_directional_down") == "ranging"
 
 
 def test_resolve_tiers_for_regime_ranging_substates(ratchet):

--- a/shared_strategies/close/trailing_tp_ratchet.py
+++ b/shared_strategies/close/trailing_tp_ratchet.py
@@ -85,10 +85,19 @@ def ratchet_close_default_group(label: str) -> Optional[str]:
     three composite ranging substates. Bare ADX "ranging" maps to the quiet
     ladder (pre-#1059 behavior). clean/choppy and ADX-trend labels delegate
     unchanged to regime_close_default_group. Mirrors ratchetCloseDefaultGroup in
-    scheduler/trailing_tp_ratchet.go."""
+    scheduler/trailing_tp_ratchet.go.
+
+    #1124: ranging_directional_up/down share the single ranging_directional
+    ratchet ladder by default. Routing them anywhere else (or letting them fall
+    through to regime_close_default_group → "ranging", which is ABSENT from
+    DEFAULT_RATCHET_TIERS_BY_GROUP) silently never-arms the auto-protective
+    ratchet exit. Operators wanting distinct geometry set explicit tp_tiers
+    keys for the new labels."""
     l = (label or "").strip()
     if l in ("ranging_quiet", "ranging_volatile", "ranging_directional"):
         return l
+    if l in ("ranging_directional_up", "ranging_directional_down"):
+        return "ranging_directional"
     if l == "ranging":
         return "ranging_quiet"
     return regime_close_default_group(l)

--- a/shared_tools/regime.py
+++ b/shared_tools/regime.py
@@ -62,6 +62,34 @@ VALID_LABELS_COMPOSITE = frozenset({
 # Back-compat alias for ADX-only callers
 _VALID_LABELS = VALID_LABELS_ADX
 
+# #1124: the bare `ranging_directional` label is the parent of the directional
+# family — the producer emits the bare label only at exactly return_eff == 0
+# (rare on real price data) and the `_up`/`_down` sub-labels for any non-zero
+# drift. The family rule is one-directional for entry gates and exhaustiveness:
+# a bare `ranging_directional` covers its `_up`/`_down` sub-labels, never the
+# reverse. Mirrors the Go `regimeLabelFamilyCovered` / `regimeDirectionalSubs`.
+RANGING_DIRECTIONAL_BARE = "ranging_directional"
+RANGING_DIRECTIONAL_SUBS = frozenset({"ranging_directional_up", "ranging_directional_down"})
+
+
+def regime_label_allows_entry(allowed, current: str) -> bool:
+    """#1124 entry-gate family match.
+
+    True when ``current`` is explicitly in ``allowed`` OR when ``current`` is a
+    directional sub-label (``_up``/``_down``) and the bare ``ranging_directional``
+    parent is in ``allowed``. Expansion is one-directional (bare→subs), so an
+    operator listing an explicit ``_up`` still gates out ``_down``. Empty
+    ``allowed`` (no gate) or empty ``current`` (no regime available) allow entry,
+    matching the Go ``regimeAllowsEntry`` contract for parity.
+    """
+    if not allowed or not current:
+        return True
+    if current in allowed:
+        return True
+    if current in RANGING_DIRECTIONAL_SUBS and RANGING_DIRECTIONAL_BARE in allowed:
+        return True
+    return False
+
 _DEFAULT_COMPOSITE_THRESHOLDS = {
     "return_pct": 0.05,
     "range_pct": 0.03,
@@ -156,10 +184,12 @@ def map_composite_label(
     #1124: the ranging-directional drift sign is baked into the label —
     `ranging_directional_up` when return_eff > 0, `ranging_directional_down`
     when return_eff < 0, and the bare `ranging_directional` when return_eff
-    is exactly zero. Because `ranging_directional` fires only when there is
-    no decisive net move (big_move false), return_eff is frequently near
-    zero, so the bare label is the neutral/back-compat fallback, not an edge
-    case. Existing configs keyed on bare `ranging_directional` keep working.
+    is exactly zero. The bare label fires only at exact zero, which is rare
+    on real price data, so configs keyed on bare `ranging_directional` rely on
+    the one-directional family rule (bare covers its `_up`/`_down` sub-labels
+    for exhaustiveness, runtime resolution, and entry gating) rather than on
+    the bare label being frequently emitted. Existing configs keyed on bare
+    `ranging_directional` keep working via that rule.
     """
     ret_th = float(thresholds.get("return_pct", _DEFAULT_COMPOSITE_THRESHOLDS["return_pct"]))
     range_th = float(thresholds.get("range_pct", _DEFAULT_COMPOSITE_THRESHOLDS["range_pct"]))

--- a/shared_tools/regime.py
+++ b/shared_tools/regime.py
@@ -56,6 +56,8 @@ VALID_LABELS_COMPOSITE = frozenset({
     "ranging_quiet",
     "ranging_volatile",
     "ranging_directional",
+    "ranging_directional_up",
+    "ranging_directional_down",
 })
 # Back-compat alias for ADX-only callers
 _VALID_LABELS = VALID_LABELS_ADX
@@ -142,7 +144,7 @@ def map_composite_label(
     efficiency: float,
     thresholds: dict[str, float],
 ) -> str:
-    """Map the composite metric tuple to one of seven labels (#795).
+    """Map the composite metric tuple to one of nine labels (#795, #1124).
 
     Inputs are ATR-efficiency normalized so the thresholds are unit-consistent:
       return_eff — window net move / (per-bar ATR * period), signed, ~[-1, 1]
@@ -150,6 +152,14 @@ def map_composite_label(
       efficiency — Kaufman efficiency ratio |net move| / summed bar-to-bar
                    travel, ∈ [0, 1]; high = clean directional move, low = chop.
     `adx_val` corroborates the efficiency-based clean/choppy split.
+
+    #1124: the ranging-directional drift sign is baked into the label —
+    `ranging_directional_up` when return_eff > 0, `ranging_directional_down`
+    when return_eff < 0, and the bare `ranging_directional` when return_eff
+    is exactly zero. Because `ranging_directional` fires only when there is
+    no decisive net move (big_move false), return_eff is frequently near
+    zero, so the bare label is the neutral/back-compat fallback, not an edge
+    case. Existing configs keyed on bare `ranging_directional` keep working.
     """
     ret_th = float(thresholds.get("return_pct", _DEFAULT_COMPOSITE_THRESHOLDS["return_pct"]))
     range_th = float(thresholds.get("range_pct", _DEFAULT_COMPOSITE_THRESHOLDS["range_pct"]))
@@ -168,7 +178,13 @@ def map_composite_label(
         return "trending_down_clean" if clean else "trending_down_choppy"
     # No decisive net move → ranging family.
     if high_adx:
-        # Directional pressure without net follow-through.
+        # Directional pressure without net follow-through. Sign of the
+        # drift is baked into the label (#1124); exact-zero stays bare so
+        # the neutral/back-compat fallback is owned by the producer.
+        if return_eff > 0:
+            return "ranging_directional_up"
+        if return_eff < 0:
+            return "ranging_directional_down"
         return "ranging_directional"
     if wide:
         return "ranging_volatile"

--- a/shared_tools/test_regime.py
+++ b/shared_tools/test_regime.py
@@ -441,3 +441,27 @@ def test_latest_regime_composite_downtrend():
     snap = _regime_mod.latest_regime_composite(df, period=50, thresholds={"return_pct": 0.02, "range_pct": 0.02, "adx": 15})
     assert snap["regime"] in _regime_mod.VALID_LABELS_COMPOSITE
     assert "trending_down" in snap["regime"]
+
+
+def test_regime_label_allows_entry_bare_covers_subs():
+    """#1124: a bare ranging_directional in allowed covers its _up/_down subs."""
+    allowed = ["ranging_directional"]
+    assert _regime_mod.regime_label_allows_entry(allowed, "ranging_directional_up")
+    assert _regime_mod.regime_label_allows_entry(allowed, "ranging_directional_down")
+    assert _regime_mod.regime_label_allows_entry(allowed, "ranging_directional")
+
+
+def test_regime_label_allows_entry_explicit_sub_does_not_cover_bare_or_sibling():
+    """#1124: family expansion is one-directional (bare→subs), never subs→bare/sibling."""
+    allowed = ["ranging_directional_up"]
+    assert not _regime_mod.regime_label_allows_entry(allowed, "ranging_directional")
+    assert not _regime_mod.regime_label_allows_entry(allowed, "ranging_directional_down")
+    assert _regime_mod.regime_label_allows_entry(allowed, "ranging_directional_up")
+
+
+def test_regime_label_allows_entry_empty_and_exact_match():
+    """#1124: empty allowed / empty current allow entry; exact match wins."""
+    assert _regime_mod.regime_label_allows_entry([], "ranging_directional_up")
+    assert _regime_mod.regime_label_allows_entry(["trending_up"], "")
+    assert _regime_mod.regime_label_allows_entry(["trending_up_clean"], "trending_up_clean")
+    assert not _regime_mod.regime_label_allows_entry(["trending_up_clean"], "ranging_quiet")

--- a/shared_tools/test_regime.py
+++ b/shared_tools/test_regime.py
@@ -395,7 +395,11 @@ def test_map_composite_label_states():
     # Ranging family: no decisive net move.
     assert m(0.01, 10, 0.01, 0.0, th) == "ranging_quiet"
     assert m(0.01, 10, 0.10, 0.0, th) == "ranging_volatile"
-    assert m(0.01, 30, 0.10, 0.0, th) == "ranging_directional"
+    # #1124: directional drift sign is baked into the label; high ADX, no big move.
+    assert m(0.01, 30, 0.10, 0.0, th) == "ranging_directional_up"
+    assert m(-0.01, 30, 0.10, 0.0, th) == "ranging_directional_down"
+    # Exact-zero return_eff stays bare (neutral/back-compat fallback).
+    assert m(0.0, 30, 0.10, 0.0, th) == "ranging_directional"
 
 
 def test_latest_regime_composite_ranging_not_trending():


### PR DESCRIPTION
## Summary

Implements #1124 — splits the composite regime producer's direction-neutral `ranging_directional` bucket into explicit `ranging_directional_up` / `ranging_directional_down` labels, baking the drift sign into the label itself (mirroring how trending labels already split `_up`/`_down`).

- **Producer** (`shared_tools/regime.py`): `map_composite_label` now emits `ranging_directional_up` when `return_eff > 0`, `ranging_directional_down` when `return_eff < 0`, and keeps the bare `ranging_directional` as the exact-zero neutral fallback. `VALID_LABELS_COMPOSITE` grows 7 → 9.
- **Back-compat via a directional-family rule** applied uniformly across every exhaustiveness check and runtime resolver (Go + Python): a present bare `ranging_directional` covers its `_up`/`_down` sub-labels, so every existing config keyed on the 7-label composite vocabulary still validates and still resolves at runtime (sub-label stamps fall back to the bare entry). Sub-labels-only (no bare label) is rejected as non-exhaustive because the producer still emits the bare label at `return_eff == 0`.
- **Go consumers**: `regimeLabelsForClassifier` (vocab source), `regimeLabelBias` (`_up`/`_down` resolve bullish/bearish directly; bare keeps `snapReturnEff`), `ratchetCloseDefaultGroup` (sub-labels → directional ladder, avoiding a silent never-arm of the auto-protective ratchet exit), `regimeATRDefaults.Trailing` + `regimeTPFleetDefaultLabelsByGroup`, and the `RegimeATRBlock` / `RegimeFloatBlock` (sl_after) / `RegimeDirectionalPolicy` / `RegimeProfileAllocation` parse + Resolve paths — all gain the family exhaustiveness rule and the sub-label→bare runtime fallback.
- **Python mirrors**: `shared_strategies/close/{regime_atr,post_tp_sl,trailing_tp_ratchet}.py` (`REGIME_ATR_DEFAULTS_TRAILING`, `ratchet_close_default_group`, `RegimeATRBlock`/`RegimeFloatBlock` resolve, exhaustiveness arms).
- **Backtest parity**: the composite gate / TP-tier / SL-regime validators and resolvers inherit the family rule; `VALID_LABELS_COMPOSITE`-driven parametrized tests auto-cover the new labels.

## Safety notes

- The `ratchetCloseDefaultGroup` routing is the safety-critical path: routing the new sub-labels anywhere other than the existing `ranging_directional` ladder (or letting them fall through to `regimeCloseDefaultGroup` → `"ranging"`, which is absent from `ratchetTierGroupDefaults`) would silently never-arm the auto-protective ratchet exit. Verified by `TestDefaultTrailingRatchetTiersForRegime` (sub-labels resolve to the same 4-tier directional ladder, never nil).
- The #1085 directional-certification gate is default-OFF and the cert artifact is empty (#1076), so the new labels resolve to base direction in live and backtest until certified — no behavior change for uncertified configs.

## Test plan

- [x] `go build` + `go vet` (scheduler)
- [x] `go test ./...` (scheduler) — full suite green, incl. new tests for the family exhaustiveness rule, sub-label→bare Resolve fallback, divergence sign-carrying labels, and the ratchet never-arm guard
- [x] `py_compile` of all edited Python files
- [x] `pytest shared_strategies/ shared_tools/ backtest/` — 1641 passed
- [x] Existing 7-label composite configs still validate (bare `ranging_directional` covers the new sub-labels)
- [x] Sub-labels-only block (no bare label) is rejected as non-exhaustive

Closes #1124

---
LLM: GLM 5.2 | high | Harness: Cursor
