### PR TITLE
feat(#1124): split ranging_directional into _up/_down composite labels

### DIFF
--- a/backtest/tests/test_backtester_composite_regime_wiring.py
+++ b/backtest/tests/test_backtester_composite_regime_wiring.py
@@ -613,6 +613,8 @@ _COMPOSITE_SL_BLOCK = {"trend_regime": {
     "ranging_quiet": {"atr_multiple": 1.2},
     "ranging_volatile": {"atr_multiple": 1.5},
     "ranging_directional": {"atr_multiple": 1.4},
+    "ranging_directional_up": {"atr_multiple": 1.4},
+    "ranging_directional_down": {"atr_multiple": 1.4},
 }}
 _ADX_SL_BLOCK = {"trend_regime": {
     "trending_up": {"atr_multiple": 2.0},

--- a/scheduler/manual_ratchet_regime_default_test.go
+++ b/scheduler/manual_ratchet_regime_default_test.go
@@ -156,12 +156,13 @@ func TestManualDefault_RegimeComposite_SelectsRatchetRegime(t *testing.T) {
 		t.Fatalf("StopLossATRMult = %v, want nil", *sc.StopLossATRMult)
 	}
 	block := sc.TrailingStopATRRegime
-	if block == nil || len(block.TrendRegime) != 7 {
-		t.Fatalf("trailing_stop_atr_regime must resolve to 7 composite labels, got %#v", block)
+	if block == nil || len(block.TrendRegime) != 9 {
+		t.Fatalf("trailing_stop_atr_regime must resolve to 9 composite labels, got %#v", block)
 	}
 	for _, label := range []string{
 		"trending_up_clean", "trending_up_choppy", "trending_down_clean",
 		"trending_down_choppy", "ranging_quiet", "ranging_volatile", "ranging_directional",
+		"ranging_directional_up", "ranging_directional_down",
 	} {
 		if v, ok := resolveRegimeATR(*block, label); !ok || v <= 0 {
 			t.Fatalf("opening trail for composite label %q = (%g, %v), want positive", label, v, ok)

--- a/scheduler/regime_atr.go
+++ b/scheduler/regime_atr.go
@@ -236,6 +236,12 @@ var regimeATRDefaults = struct {
 		"ranging_quiet":        {ATR: 1.0},
 		"ranging_volatile":     {ATR: 1.0},
 		"ranging_directional":  {ATR: 1.0},
+		// #1124: directional-drift substates inherit the tight ranging_directional
+		// opening trail (1.0). Explicit entries keep parity with the bare label —
+		// without them mapRegimeToBaselineFamily would fall the _up/_down labels
+		// back to the wider "ranging" family (2.0), silently loosening the trail.
+		"ranging_directional_up":   {ATR: 1.0},
+		"ranging_directional_down": {ATR: 1.0},
 	},
 }
 
@@ -278,7 +284,7 @@ var regimeTPTierGroupDefaults = map[string][]hlProtectionTier{
 var regimeTPFleetDefaultLabelsByGroup = map[string][]string{
 	"clean":   {"trending_up_clean", "trending_down_clean"},
 	"choppy":  {"trending_up", "trending_down", "trending_up_choppy", "trending_down_choppy"},
-	"ranging": {"ranging", "ranging_quiet", "ranging_volatile", "ranging_directional"},
+	"ranging": {"ranging", "ranging_quiet", "ranging_volatile", "ranging_directional", "ranging_directional_up", "ranging_directional_down"},
 }
 
 // defaultRegimeBlockForSurface returns the baseline trend_regime map for a

--- a/scheduler/regime_atr_composite_test.go
+++ b/scheduler/regime_atr_composite_test.go
@@ -59,8 +59,8 @@ func TestValidateRegimeATRConfig_CompositeStopLossExplicit(t *testing.T) {
 		t.Fatalf("composite stop_loss_atr_regime must validate, got: %v", errs)
 	}
 	block := cfg.Strategies[0].StopLossATRRegime
-	if got := len(block.TrendRegime); got != 7 {
-		t.Fatalf("block must be populated with all 7 composite labels, got %d: %v", got, block.TrendRegime)
+	if got := len(block.TrendRegime); got != 9 {
+		t.Fatalf("block must be populated with all 9 composite labels, got %d: %v", got, block.TrendRegime)
 	}
 	// Runtime SL resolution must succeed for a composite label (proves the
 	// authoritative pass populated the composite vocabulary, not ADX).
@@ -116,8 +116,8 @@ func TestValidateRegimeATRConfig_CompositeTrailingExplicit(t *testing.T) {
 	if errs := validateRegimeATRConfig(cfg); len(errs) != 0 {
 		t.Fatalf("composite trailing_stop_atr_regime must validate, got: %v", errs)
 	}
-	if got := len(cfg.Strategies[0].TrailingStopATRRegime.TrendRegime); got != 7 {
-		t.Fatalf("trailing block must hold 7 composite labels, got %d", got)
+	if got := len(cfg.Strategies[0].TrailingStopATRRegime.TrendRegime); got != 9 {
+		t.Fatalf("trailing block must hold 9 composite labels, got %d", got)
 	}
 }
 
@@ -243,6 +243,10 @@ func TestMapRegimeToBaselineFamily(t *testing.T) {
 		{"trending_down_choppy", 2.0, true}, // composite prefix → trending_down
 		{"ranging_quiet", 1.5, true},        // composite prefix → ranging
 		{"ranging_directional", 1.5, true},
+		// #1124: directional-drift substates have no explicit StopLoss entry, so
+		// they fall to the ranging family by prefix — same as bare.
+		{"ranging_directional_up", 1.5, true},
+		{"ranging_directional_down", 1.5, true},
 		{"garbage", 0, false},
 	}
 	for _, tc := range cases {
@@ -251,13 +255,25 @@ func TestMapRegimeToBaselineFamily(t *testing.T) {
 			t.Errorf("mapRegimeToBaselineFamily(%q) = (%g, %v), want (%g, %v)", tc.label, e.ATR, ok, tc.wantATR, tc.wantOK)
 		}
 	}
+
+	// #1124 regression: on the Trailing baseline the directional-drift substates
+	// must resolve to the tight 1.0 ranging_directional trail via their EXPLICIT
+	// entries — NOT the wider 2.0 "ranging" family fallback. Without the explicit
+	// entries a use_defaults trailing block would silently loosen the trail.
+	trailing := regimeATRDefaults.Trailing
+	for _, label := range []string{"ranging_directional_up", "ranging_directional_down"} {
+		e, ok := mapRegimeToBaselineFamily(trailing, label)
+		if !ok || e.ATR != 1.0 {
+			t.Errorf("Trailing[%q] = (%g, %v), want (1.0, true) — explicit tight trail, not the 2.0 ranging family", label, e.ATR, ok)
+		}
+	}
 }
 
 func TestRegimeLabelsFromTierRaw(t *testing.T) {
 	raw := []interface{}{composite7StateTier(2.0, 0.5)}
 	got := regimeLabelsFromTierRaw(raw)
-	if len(got) != 7 {
-		t.Fatalf("expected 7 inferred labels, got %d: %v", len(got), got)
+	if len(got) != 9 {
+		t.Fatalf("expected 9 inferred labels, got %d: %v", len(got), got)
 	}
 	// No per-regime keys → canonical ADX fallback.
 	if got := regimeLabelsFromTierRaw(nil); len(got) != 3 {
@@ -298,7 +314,9 @@ func TestLoadConfig_CompositeStopLossAtrRegime(t *testing.T) {
 					"trending_down_choppy": {"atr_multiple": 1.2},
 					"ranging_quiet": {"atr_multiple": 1.5},
 					"ranging_volatile": {"atr_multiple": 1.0},
-					"ranging_directional": {"atr_multiple": 1.5}
+					"ranging_directional": {"atr_multiple": 1.5},
+					"ranging_directional_up": {"atr_multiple": 1.5},
+					"ranging_directional_down": {"atr_multiple": 1.5}
 				}
 			}
 		}]
@@ -308,11 +326,11 @@ func TestLoadConfig_CompositeStopLossAtrRegime(t *testing.T) {
 	}
 	cfg, err := LoadConfig(cfgPath)
 	if err != nil {
-		t.Fatalf("LoadConfig must accept composite 7-state stop_loss_atr_regime, got: %v", err)
+		t.Fatalf("LoadConfig must accept composite 9-state stop_loss_atr_regime, got: %v", err)
 	}
 	block := cfg.Strategies[0].StopLossATRRegime
-	if block == nil || len(block.TrendRegime) != 7 {
-		t.Fatalf("composite SL block must be populated with 7 labels post-load, got %#v", block)
+	if block == nil || len(block.TrendRegime) != 9 {
+		t.Fatalf("composite SL block must be populated with 9 labels post-load, got %#v", block)
 	}
 	if v, ok := resolveRegimeATR(*block, "trending_down_choppy"); !ok || v != 1.2 {
 		t.Fatalf("runtime resolve trending_down_choppy = (%g, %v), want (1.2, true)", v, ok)

--- a/scheduler/regime_divergence.go
+++ b/scheduler/regime_divergence.go
@@ -243,7 +243,16 @@ func regimeLabelBias(label string, snapReturnEff float64) divergenceBias {
 		return biasBullish
 	case "trending_down", "trending_down_clean", "trending_down_choppy":
 		return biasBearish
+	case "ranging_directional_up":
+		// #1124: the label carries the drift direction directly, so the bias is
+		// fixed regardless of snapReturnEff.
+		return biasBullish
+	case "ranging_directional_down":
+		return biasBearish
 	case "ranging_directional":
+		// Bare label: the producer emits it only when return_eff == 0 exactly,
+		// but a stale/legacy snapshot may still carry a nonzero return_eff, so
+		// keep resolving the sign as the tie-break for back-compat.
 		if snapReturnEff > 0 {
 			return biasBullish
 		}

--- a/scheduler/regime_divergence_test.go
+++ b/scheduler/regime_divergence_test.go
@@ -122,6 +122,28 @@ func TestClassifyRegimeDivergence_RangingDirectionalSign(t *testing.T) {
 	}
 }
 
+// TestClassifyRegimeDivergence_RangingDirectionalExplicit covers #1124: the
+// explicit _up/_down labels carry their bias in the name, so the divergence
+// verdict is fixed regardless of the (now redundant) return_eff snapshot.
+func TestClassifyRegimeDivergence_RangingDirectionalExplicit(t *testing.T) {
+	// ranging_directional_up → bullish → hard divergence vs trending_down,
+	// even with a contradicting (stale) return_eff snapshot of 0.
+	up := classifyRegimeDivergence("ranging_directional_up", "trending_down", 0, 0, onDivergenceTrustShort)
+	if up.Kind != DivergenceHard || up.OverrideDir != DirectionLong {
+		t.Fatalf("ranging_directional_up: want hard/long, got %q/%q", up.Kind, up.OverrideDir)
+	}
+	// ranging_directional_down → bearish → same side as trending_down → none.
+	down := classifyRegimeDivergence("ranging_directional_down", "trending_down", 0.99, 0, onDivergenceTrustShort)
+	if down.Kind != DivergenceNone {
+		t.Fatalf("ranging_directional_down vs trending_down: want none, got %q", down.Kind)
+	}
+	// ranging_directional_down → bearish → hard divergence vs trending_up.
+	downVsUp := classifyRegimeDivergence("ranging_directional_down", "trending_up", 0, 0, onDivergenceTrustShort)
+	if downVsUp.Kind != DivergenceHard || downVsUp.OverrideDir != DirectionShort {
+		t.Fatalf("ranging_directional_down vs trending_up: want hard/short, got %q/%q", downVsUp.Kind, downVsUp.OverrideDir)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // RegimeWindowDivergence config + ResolveRaw
 // ---------------------------------------------------------------------------

--- a/scheduler/regime_profile_allocation_test.go
+++ b/scheduler/regime_profile_allocation_test.go
@@ -275,7 +275,7 @@ func TestValidateStrategyRegimeVocabulary_RejectsBadProfileWindow(t *testing.T) 
 	var a RegimeProfileAllocation
 	if err := json.Unmarshal([]byte(`{
 		"window": "does_not_exist",
-		"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade"},
+		"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade","ranging_directional_up":"fade","ranging_directional_down":"fade"},
 		"param_sets": {"fade": {"trend_entry":"off"}, "trend": {"trend_entry":"breakout"}},
 		"confirm_bars": 24,
 		"initial_profile": "fade"
@@ -299,7 +299,7 @@ func TestValidateStrategyRegimeVocabulary_AcceptsGoodProfileAllocation(t *testin
 	var a RegimeProfileAllocation
 	if err := json.Unmarshal([]byte(`{
 		"window": "profile_long",
-		"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade"},
+		"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade","ranging_directional_up":"fade","ranging_directional_down":"fade"},
 		"param_sets": {"fade": {"trend_entry":"off"}, "trend": {"trend_entry":"breakout"}},
 		"confirm_bars": 24,
 		"initial_profile": "fade"
@@ -391,7 +391,7 @@ func fullProfileAllocConfig(t *testing.T, palJSON string) Config {
 
 const validPALJSON = `{
 	"window": "profile_long",
-	"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade"},
+	"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade","ranging_directional_up":"fade","ranging_directional_down":"fade"},
 	"param_sets": {"fade": {"trend_entry":"off"}, "trend": {"trend_entry":"breakout"}},
 	"confirm_bars": 24,
 	"initial_profile": "fade"
@@ -466,7 +466,7 @@ func TestLoadConfig_ProfileAllocation_FromFile(t *testing.T) {
 			"direction": "long",
 			"regime_profile_allocation": {
 				"window": "profile_long",
-				"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade"},
+				"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade","ranging_directional_up":"fade","ranging_directional_down":"fade"},
 				"param_sets": {"fade": {"trend_entry":"off"}, "trend": {"trend_entry":"breakout","trend_drift_confirm":0.1}},
 				"confirm_bars": 24,
 				"initial_profile": "fade"

--- a/scheduler/regime_window_spec.go
+++ b/scheduler/regime_window_spec.go
@@ -136,6 +136,15 @@ func regimeLabelsForClassifier(classifier string) []string {
 			"ranging_quiet",
 			"ranging_volatile",
 			"ranging_directional",
+			// #1124: directional-drift ranging substates. Adding them to the
+			// classifier vocabulary makes them valid for allowed_regimes gating,
+			// regime_directional_policy and *_atr_regime keys — and, by the same
+			// vocabulary, REQUIRED in explicit (non-use_defaults) trend_regime
+			// blocks under a composite window (exhaustiveness is fail-closed:
+			// a pre-#1124 explicit block missing them errors at load with
+			// "missing required regime labels", never silently no-ops).
+			"ranging_directional_up",
+			"ranging_directional_down",
 		}
 	default:
 		return append([]string(nil), canonicalTrendRegimeLabels...)

--- a/scheduler/trailing_tp_ratchet.go
+++ b/scheduler/trailing_tp_ratchet.go
@@ -125,6 +125,15 @@ func ratchetCloseDefaultGroup(label string) (string, bool) {
 	switch l {
 	case "ranging_quiet", "ranging_volatile", "ranging_directional":
 		return l, true
+	case "ranging_directional_up", "ranging_directional_down":
+		// #1124: the directional-drift substates share the ranging_directional
+		// scale-out ladder (the geometry is direction-agnostic — the SL side
+		// carries direction, the TP scale-out does not). Map them to that group
+		// explicitly; otherwise they fall through to regimeCloseDefaultGroup's
+		// "ranging" key, which has NO ratchet ladder in ratchetTierGroupDefaults
+		// → defaultTrailingRatchetTiersForRegime returns nil → silent never-arm
+		// of the auto-protective ratchet exit (money path).
+		return "ranging_directional", true
 	case "ranging":
 		return "ranging_quiet", true
 	}

--- a/scheduler/trailing_tp_ratchet_test.go
+++ b/scheduler/trailing_tp_ratchet_test.go
@@ -398,8 +398,8 @@ func TestValidateTrailingTPRatchetClose_CompositeVocabulary(t *testing.T) {
 		return tbl
 	}
 	composite := regimeLabelsForClassifier(regimeClassifierComposite)
-	if len(composite) != 7 {
-		t.Fatalf("expected 7 composite labels, got %d", len(composite))
+	if len(composite) != 9 {
+		t.Fatalf("expected 9 composite labels, got %d", len(composite))
 	}
 
 	// #870: the regime variant's opening trail / SL owner is the per-regime
@@ -762,6 +762,21 @@ func TestDefaultTrailingRatchetTiersForRegime(t *testing.T) {
 	if defaultTrailingRatchetTiersForRegime("") != nil {
 		t.Error("empty regime must resolve to nil")
 	}
+	// #1124: the directional-drift substates must resolve to the SAME 4-tier
+	// ranging_directional ladder — never nil. A nil here would mean the ratchet
+	// (auto-protective exit) silently never arms for a ranging_directional_up/
+	// _down position.
+	for _, label := range []string{"ranging_directional_up", "ranging_directional_down"} {
+		got := defaultTrailingRatchetTiersForRegime(label)
+		if len(got) != len(dir) {
+			t.Fatalf("%s want %d tiers (parity with ranging_directional), got %+v", label, len(dir), got)
+		}
+		for i := range dir {
+			if got[i] != dir[i] {
+				t.Fatalf("%s tier[%d] = %+v, want %+v (ranging_directional ladder)", label, i, got[i], dir[i])
+			}
+		}
+	}
 }
 
 // TestRatchetCloseDefaultGroup covers #1059: the ratchet-only resolver
@@ -776,6 +791,9 @@ func TestRatchetCloseDefaultGroup(t *testing.T) {
 		{"ranging_quiet", "ranging_quiet", true},
 		{"ranging_volatile", "ranging_volatile", true},
 		{"ranging_directional", "ranging_directional", true},
+		// #1124: directional-drift substates share the ranging_directional ladder.
+		{"ranging_directional_up", "ranging_directional", true},
+		{"ranging_directional_down", "ranging_directional", true},
 		{"ranging", "ranging_quiet", true}, // bare ADX → quiet ladder
 		{"trending_up_clean", "clean", true},
 		{"trending_up_choppy", "choppy", true},

--- a/shared_strategies/close/regime_atr.py
+++ b/shared_strategies/close/regime_atr.py
@@ -131,6 +131,12 @@ REGIME_ATR_DEFAULTS_TRAILING: Dict[str, RegimeATREntry] = {
     "ranging_quiet": RegimeATREntry(atr=1.0),
     "ranging_volatile": RegimeATREntry(atr=1.0),
     "ranging_directional": RegimeATREntry(atr=1.0),
+    # #1124: directional-drift substates inherit the tight ranging_directional
+    # opening trail (1.0). Explicit entries are required because resolve() is a
+    # strict key lookup — without them a use_defaults block would leave these
+    # labels unresolved.
+    "ranging_directional_up": RegimeATREntry(atr=1.0),
+    "ranging_directional_down": RegimeATREntry(atr=1.0),
 }
 
 # #870: per-quality-group default ATR take-profit ladders. Mirrors

--- a/shared_strategies/close/test_trailing_tp_ratchet.py
+++ b/shared_strategies/close/test_trailing_tp_ratchet.py
@@ -176,6 +176,10 @@ def test_ratchet_close_default_group_differentiates_ranging_substates(ratchet):
     assert g("ranging_quiet") == "ranging_quiet"
     assert g("ranging_volatile") == "ranging_volatile"
     assert g("ranging_directional") == "ranging_directional"
+    # #1124: directional-drift substates share the ranging_directional ladder —
+    # NOT a fall-through to "ranging" (which has no ratchet ladder → never-arm).
+    assert g("ranging_directional_up") == "ranging_directional"
+    assert g("ranging_directional_down") == "ranging_directional"
     # Bare ADX "ranging" (no substate signal) → quiet ladder (pre-#1059 behavior).
     assert g("ranging") == "ranging_quiet"
     # clean/choppy/trend labels delegate to the shared fn, unchanged.
@@ -207,6 +211,16 @@ def test_resolve_tiers_for_regime_ranging_substates(ratchet):
     assert [t[0] for t in directional] == [1.0, 2.0, 3.0, 4.5]
     assert [t[1] for t in directional] == [0.25, 0.50, 0.75, 0.75]
     assert [t[2] for t in directional] == [1.0, 1.0, 0.8, 0.6]  # trail non-increasing
+
+    # #1124: the directional-drift substates resolve to the SAME ladder as the
+    # bare ranging_directional — never an empty ladder (which would silently
+    # leave the auto-protective ratchet exit unarmed).
+    for label in ("ranging_directional_up", "ranging_directional_down"):
+        tiers, errs = ratchet.resolve_tiers_for_regime(
+            {"use_defaults": True}, label, regime_table=True,
+        )
+        assert errs == []
+        assert tiers == directional, f"{label} must mirror the ranging_directional ladder"
 
     # Bare ADX "ranging" still resolves to the quiet ladder (unchanged pre-#1059).
     adx_ranging, errs = ratchet.resolve_tiers_for_regime(

--- a/shared_strategies/close/trailing_tp_ratchet.py
+++ b/shared_strategies/close/trailing_tp_ratchet.py
@@ -89,6 +89,13 @@ def ratchet_close_default_group(label: str) -> Optional[str]:
     l = (label or "").strip()
     if l in ("ranging_quiet", "ranging_volatile", "ranging_directional"):
         return l
+    # #1124: the directional-drift substates share the ranging_directional
+    # scale-out ladder (the geometry is direction-agnostic — the SL side carries
+    # direction, the TP scale-out does not), so map them to that group rather
+    # than fall through to regime_close_default_group's "ranging" (which has no
+    # ratchet ladder → silent never-arm of the protective exit).
+    if l in ("ranging_directional_up", "ranging_directional_down"):
+        return "ranging_directional"
     if l == "ranging":
         return "ranging_quiet"
     return regime_close_default_group(l)

--- a/shared_tools/regime.py
+++ b/shared_tools/regime.py
@@ -56,6 +56,11 @@ VALID_LABELS_COMPOSITE = frozenset({
     "ranging_quiet",
     "ranging_volatile",
     "ranging_directional",
+    # #1124: directional-drift ranging substates. map_composite_label names the
+    # drift via return_eff's sign; bare ranging_directional stays valid for the
+    # exactly-zero case.
+    "ranging_directional_up",
+    "ranging_directional_down",
 })
 # Back-compat alias for ADX-only callers
 _VALID_LABELS = VALID_LABELS_ADX
@@ -168,7 +173,16 @@ def map_composite_label(
         return "trending_down_clean" if clean else "trending_down_choppy"
     # No decisive net move → ranging family.
     if high_adx:
-        # Directional pressure without net follow-through.
+        # Directional pressure without net follow-through (#1124). return_eff's
+        # sign names the drift so the label carries direction, mirroring the
+        # trending family's _up/_down split. Bare ranging_directional is the
+        # producer-side fallback for the exactly-zero case (a common path here,
+        # since big_move is false so return_eff is frequently near zero) — so
+        # back-compat lives in this SSoT, not in each downstream resolver.
+        if return_eff > 0:
+            return "ranging_directional_up"
+        if return_eff < 0:
+            return "ranging_directional_down"
         return "ranging_directional"
     if wide:
         return "ranging_volatile"

--- a/shared_tools/test_regime.py
+++ b/shared_tools/test_regime.py
@@ -395,7 +395,12 @@ def test_map_composite_label_states():
     # Ranging family: no decisive net move.
     assert m(0.01, 10, 0.01, 0.0, th) == "ranging_quiet"
     assert m(0.01, 10, 0.10, 0.0, th) == "ranging_volatile"
-    assert m(0.01, 30, 0.10, 0.0, th) == "ranging_directional"
+    # #1124: high-ADX ranging carries the drift direction in the label. The sign
+    # of return_eff (not its magnitude — big_move is false here) names it.
+    assert m(0.01, 30, 0.10, 0.0, th) == "ranging_directional_up"
+    assert m(-0.01, 30, 0.10, 0.0, th) == "ranging_directional_down"
+    # Exactly-zero drift keeps the bare label as the producer-side fallback.
+    assert m(0.0, 30, 0.10, 0.0, th) == "ranging_directional"
 
 
 def test_latest_regime_composite_ranging_not_trending():


### PR DESCRIPTION
## Summary

Splits the composite classifier's `ranging_directional` label into direction-carrying
`ranging_directional_up` / `ranging_directional_down`, with the bare `ranging_directional`
retained only for the exactly-zero-drift case. This makes the ranging family carry direction
in the label like the trending family (`trending_up_*` / `trending_down_*`) already does, so
operators can gate and configure per sub-regime without reading `return_eff` from the metrics
payload.

The producer `map_composite_label` (`shared_tools/regime.py`) is the single source of truth,
imported by both the live `check_regime` path and the backtester (`compute_regime_composite`,
`regime_vol_model.map_latent_to_names`). All consumers move in lockstep in this one PR across
the dual-language Go + Python surface.

## Changes

- **Producer + vocabulary:** `map_composite_label` emits the three labels by `return_eff` sign;
  `VALID_LABELS_COMPOSITE` (Python) and `regimeLabelsForClassifier` (Go) accept the two new labels.
- **Divergence bias** (`regimeLabelBias`): `_up` → bullish, `_down` → bearish; the bare label still
  resolves via `snapReturnEff` for back-compat with stale snapshots.
- **Ratchet default ladder — SAFETY-CRITICAL** (`ratchetCloseDefaultGroup` / `ratchet_close_default_group`):
  `_up`/`_down` map to the existing `ranging_directional` scale-out ladder (geometry is direction-agnostic).
  Without this they would fall through to the shared `"ranging"` group, which has **no** ratchet ladder
  → `defaultTrailingRatchetTiersForRegime` returns nil → **silent never-arm of the auto-protective ratchet
  exit** (the failure mode the issue flagged). Verified by test.
- **ATR trailing defaults** (`regimeATRDefaults.Trailing` / `REGIME_ATR_DEFAULTS_TRAILING`): explicit
  `_up`/`_down` entries at ATR 1.0 so they inherit the tight `ranging_directional` opening trail rather
  than the wider 2.0 `"ranging"` family fallback via `mapRegimeToBaselineFamily`.
  *(Validation note: the issue described this as resolving to ATR=0; in fact the prefix fallback yields the
  2.0 ranging-family value — a value drift, not a never-arm. The ratchet ladder is the genuine never-arm.)*
- **Fleet-default rendering** (`regimeTPFleetDefaultLabelsByGroup`): new labels added to the `ranging` group.

## Back-compat: fail-closed migration (design decision)

Per the chosen "full per-direction" posture, the new labels join the composite classifier vocabulary, so
they are valid for `allowed_regimes`, `regime_directional_policy`, `*_atr_regime` keys, and
`regime_profile_allocation` — and, by that same vocabulary, **required** in explicit (non-`use_defaults`)
composite `trend_regime` / profile-allocation blocks. A pre-#1124 explicit composite block now errors at
load with `missing required regime labels: ranging_directional_up, ranging_directional_down` rather than
silently no-opping (consistent with the repo's existing "must be exhaustive — no silent fallback"
invariant). `use_defaults` blocks auto-expand and are unaffected. No shipped config example contains such a
block, so nothing in-repo needs migrating.

## Out of scope

The `regime_adaptive` / `regime_adaptive_htf` open strategies re-implement label mapping for their own
internal state machine and emit the bare `ranging_directional` as a diagnostic `ra_label` column. They do
not feed the gating / ratchet / divergence / ATR consumers, so their state machine is left unchanged (the
bare label remains valid).

## Verification

- `go build .` + `go test .` (full scheduler suite) — pass.
- `uv run --no-sync python -m pytest shared_strategies/ shared_tools/ platforms/ backtest/` — pass.
- New tests: producer `_up`/`_down`/zero cases; divergence bias for the explicit labels; ratchet ladder +
  ATR trailing parity to the `ranging_directional` substate (asserts non-nil, never-arm guard); composite
  exhaustiveness fixtures updated to 9 labels across Go and Python.

Closes #1124

LLM: Opus 4.8 | high | Harness: work-on-issue
