### PR TITLE
Add directional ranging regime aliases and fallbacks

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -89,6 +89,24 @@ _close_registry = None
 # don't pay the import cost.
 _ensure_regime_fn = None
 
+
+def _regime_lookup_label(label: str) -> str:
+    label = (label or "").strip()
+    if label in ("ranging_directional_up", "ranging_directional_down"):
+        return "ranging_directional"
+    return label
+
+
+def _regime_label_allowed(allowed: list[str], current: str) -> bool:
+    current = (current or "").strip()
+    for label in allowed:
+        configured = (label or "").strip()
+        if configured == current:
+            return True
+        if configured == "ranging_directional" and _regime_lookup_label(current) == configured:
+            return True
+    return False
+
 # Post-TP SL helpers (#709). Loaded via spec_from_file_location to avoid the
 # same registry-name collision that close_registry_loader works around — this
 # module lives in shared_strategies/close/ but isn't a registered strategy,
@@ -1725,7 +1743,7 @@ class Backtester:
             regime_blocked = (
                 self.regime_enabled
                 and bool(self.allowed_regimes)
-                and bar_regime not in self.allowed_regimes
+                and not _regime_label_allowed(self.allowed_regimes, bar_regime)
             )
 
             if uses_open_close:

--- a/backtest/tests/test_backtester_composite_regime.py
+++ b/backtest/tests/test_backtester_composite_regime.py
@@ -75,7 +75,13 @@ def test_composite_label_allows_entry_when_gate_matches(label):
 @pytest.mark.parametrize("label", COMPOSITE_LABELS)
 def test_composite_label_blocks_entry_when_gate_mismatches(label):
     # Pick any distinct label to gate on — the bar is ``label`` so it must block.
-    other = next(l for l in COMPOSITE_LABELS if l != label)
+    other = next(
+        l for l in COMPOSITE_LABELS
+        if l != label and not (
+            l == "ranging_directional"
+            and label in {"ranging_directional_up", "ranging_directional_down"}
+        )
+    )
     df = _gated_df(label)
     bt = Backtester(
         initial_capital=1000, commission_pct=0, slippage_pct=0,
@@ -140,6 +146,15 @@ def test_ranging_directional_blocked_by_trending_gate():
         allowed_regimes=["trending_up_clean", "trending_down_clean"],
     )
     assert bt.run(df, save=False)["total_trades"] == 0
+
+
+def test_ranging_directional_family_falls_back_to_bare_gate():
+    df = _gated_df("ranging_directional_up")
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, allowed_regimes=["ranging_directional"],
+    )
+    assert bt.run(df, save=False)["total_trades"] >= 1
 
 
 # ─── Open position is held across a composite-regime flip (closes not gated) ──

--- a/scheduler/manual_ratchet_regime_default_test.go
+++ b/scheduler/manual_ratchet_regime_default_test.go
@@ -156,12 +156,13 @@ func TestManualDefault_RegimeComposite_SelectsRatchetRegime(t *testing.T) {
 		t.Fatalf("StopLossATRMult = %v, want nil", *sc.StopLossATRMult)
 	}
 	block := sc.TrailingStopATRRegime
-	if block == nil || len(block.TrendRegime) != 7 {
-		t.Fatalf("trailing_stop_atr_regime must resolve to 7 composite labels, got %#v", block)
+	if block == nil || len(block.TrendRegime) != len(regimeLabelsForClassifier(regimeClassifierComposite)) {
+		t.Fatalf("trailing_stop_atr_regime must resolve to all composite labels, got %#v", block)
 	}
 	for _, label := range []string{
 		"trending_up_clean", "trending_up_choppy", "trending_down_clean",
 		"trending_down_choppy", "ranging_quiet", "ranging_volatile", "ranging_directional",
+		"ranging_directional_up", "ranging_directional_down",
 	} {
 		if v, ok := resolveRegimeATR(*block, label); !ok || v <= 0 {
 			t.Fatalf("opening trail for composite label %q = (%g, %v), want positive", label, v, ok)

--- a/scheduler/post_tp_sl.go
+++ b/scheduler/post_tp_sl.go
@@ -76,7 +76,14 @@ func (b *RegimeFloatBlock) Resolve(regime string) (float64, bool) {
 	if b == nil || len(b.TrendRegime) == 0 {
 		return 0, false
 	}
-	v, ok := b.TrendRegime[strings.TrimSpace(regime)]
+	label := strings.TrimSpace(regime)
+	v, ok := b.TrendRegime[label]
+	if !ok {
+		fallback := regimeLookupLabel(label)
+		if fallback != label {
+			v, ok = b.TrendRegime[fallback]
+		}
+	}
 	return v, ok
 }
 
@@ -513,8 +520,10 @@ func parseRegimeFloatBlock(raw map[string]interface{}, ctxLabel string, labels [
 	for _, label := range labels {
 		valid[label] = true
 	}
+	seen := make(map[string]bool, len(trend))
 	unknown := make([]string, 0)
 	for label := range trend {
+		seen[label] = true
 		if !valid[label] {
 			unknown = append(unknown, label)
 		}
@@ -527,6 +536,9 @@ func parseRegimeFloatBlock(raw map[string]interface{}, ctxLabel string, labels [
 	missing := make([]string, 0)
 	for _, label := range labels {
 		if _, ok := trend[label]; !ok {
+			if regimeLabelCoveredBySeen(label, seen) {
+				continue
+			}
 			missing = append(missing, label)
 		}
 	}

--- a/scheduler/post_tp_sl_test.go
+++ b/scheduler/post_tp_sl_test.go
@@ -1348,6 +1348,35 @@ func TestParseSLAfterRule_TPATRFractionScalar(t *testing.T) {
 	}
 }
 
+func TestParseSLAfterRule_CompositeTPATRFractionRegimeFallback(t *testing.T) {
+	labels := regimeLabelsForClassifier(regimeClassifierComposite)
+	raw := map[string]interface{}{
+		"trail_from_here": map[string]interface{}{
+			"tp_atr_fraction": map[string]interface{}{
+				"trend_regime": map[string]interface{}{
+					"trending_up_clean":    0.5,
+					"trending_up_choppy":   0.5,
+					"trending_down_clean":  0.5,
+					"trending_down_choppy": 0.5,
+					"ranging_quiet":        0.4,
+					"ranging_volatile":     0.3,
+					"ranging_directional":  0.25,
+				},
+			},
+		},
+	}
+	got, err := parseSLAfterRuleWithLabels(raw, labels)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Kind != "trail_from_here" || got.TPATRFractionRegime == nil {
+		t.Fatalf("got %+v, want trail_from_here tp_atr_fraction_regime", got)
+	}
+	if frac, ok := got.TPATRFractionRegime.Resolve("ranging_directional_down"); !ok || frac != 0.25 {
+		t.Fatalf("resolve ranging_directional_down = (%g, %v), want (0.25, true)", frac, ok)
+	}
+}
+
 func TestParseSLAfterRule_RegimeExplicitKindAtROffset(t *testing.T) {
 	raw := map[string]interface{}{
 		"kind": "atr_offset",

--- a/scheduler/regime.go
+++ b/scheduler/regime.go
@@ -1,5 +1,40 @@
 package main
 
+import "strings"
+
+const (
+	regimeLabelRangingDirectional     = "ranging_directional"
+	regimeLabelRangingDirectionalUp   = "ranging_directional_up"
+	regimeLabelRangingDirectionalDown = "ranging_directional_down"
+)
+
+func regimeLookupLabel(label string) string {
+	label = strings.TrimSpace(label)
+	switch label {
+	case regimeLabelRangingDirectionalUp, regimeLabelRangingDirectionalDown:
+		return regimeLabelRangingDirectional
+	default:
+		return label
+	}
+}
+
+func regimeLabelCoveredBySeen(label string, seen map[string]bool) bool {
+	label = strings.TrimSpace(label)
+	if seen[label] {
+		return true
+	}
+	return regimeLookupLabel(label) != label && seen[regimeLookupLabel(label)]
+}
+
+func regimeLabelMatchesConfig(configured, current string) bool {
+	configured = strings.TrimSpace(configured)
+	current = strings.TrimSpace(current)
+	if configured == current {
+		return true
+	}
+	return configured == regimeLabelRangingDirectional && regimeLookupLabel(current) == configured
+}
+
 // regimeAllowsEntry reports whether the current market regime permits a new
 // entry for a strategy. Returns true when:
 //   - allowed is empty (no gate configured), OR
@@ -13,7 +48,7 @@ func regimeAllowsEntry(allowed []string, current string) bool {
 		return true
 	}
 	for _, label := range allowed {
-		if label == current {
+		if regimeLabelMatchesConfig(label, current) {
 			return true
 		}
 	}

--- a/scheduler/regime_atr.go
+++ b/scheduler/regime_atr.go
@@ -207,6 +207,9 @@ func (b RegimeATRBlock) Resolve(regime string) (RegimeATREntry, bool) {
 		return RegimeATREntry{}, false
 	}
 	entry, ok := b.TrendRegime[strings.TrimSpace(regime)]
+	if !ok {
+		entry, ok = b.TrendRegime[regimeLookupLabel(regime)]
+	}
 	return entry, ok
 }
 
@@ -226,16 +229,18 @@ var regimeATRDefaults = struct {
 	// choppy=2.0, ranging=1.0) so a trailing_stop_atr_regime use_defaults block
 	// differentiates trend groups from ranges (tight).
 	Trailing: map[string]RegimeATREntry{
-		"trending_up":          {ATR: 2.5},
-		"trending_down":        {ATR: 2.5},
-		"ranging":              {ATR: 2.0},
-		"trending_up_clean":    {ATR: 2.0},
-		"trending_down_clean":  {ATR: 2.0},
-		"trending_up_choppy":   {ATR: 2.0},
-		"trending_down_choppy": {ATR: 2.0},
-		"ranging_quiet":        {ATR: 1.0},
-		"ranging_volatile":     {ATR: 1.0},
-		"ranging_directional":  {ATR: 1.0},
+		"trending_up":              {ATR: 2.5},
+		"trending_down":            {ATR: 2.5},
+		"ranging":                  {ATR: 2.0},
+		"trending_up_clean":        {ATR: 2.0},
+		"trending_down_clean":      {ATR: 2.0},
+		"trending_up_choppy":       {ATR: 2.0},
+		"trending_down_choppy":     {ATR: 2.0},
+		"ranging_quiet":            {ATR: 1.0},
+		"ranging_volatile":         {ATR: 1.0},
+		"ranging_directional":      {ATR: 1.0},
+		"ranging_directional_up":   {ATR: 1.0},
+		"ranging_directional_down": {ATR: 1.0},
 	},
 }
 
@@ -278,7 +283,7 @@ var regimeTPTierGroupDefaults = map[string][]hlProtectionTier{
 var regimeTPFleetDefaultLabelsByGroup = map[string][]string{
 	"clean":   {"trending_up_clean", "trending_down_clean"},
 	"choppy":  {"trending_up", "trending_down", "trending_up_choppy", "trending_down_choppy"},
-	"ranging": {"ranging", "ranging_quiet", "ranging_volatile", "ranging_directional"},
+	"ranging": {"ranging", "ranging_quiet", "ranging_volatile", "ranging_directional", "ranging_directional_up", "ranging_directional_down"},
 }
 
 // defaultRegimeBlockForSurface returns the baseline trend_regime map for a
@@ -439,7 +444,9 @@ func parseRegimeATRBlock(raw map[string]interface{}, ctxLabel string, surface re
 	}
 
 	unknownLabels := []string{}
+	seenLabels := make(map[string]bool, len(trendMap))
 	for k := range trendMap {
+		seenLabels[k] = true
 		if !validLabels[k] {
 			unknownLabels = append(unknownLabels, k)
 		}
@@ -451,7 +458,7 @@ func parseRegimeATRBlock(raw map[string]interface{}, ctxLabel string, surface re
 
 	missingLabels := []string{}
 	for _, l := range labels {
-		if _, ok := trendMap[l]; !ok {
+		if !regimeLabelCoveredBySeen(l, seenLabels) {
 			missingLabels = append(missingLabels, l)
 		}
 	}

--- a/scheduler/regime_atr_composite_test.go
+++ b/scheduler/regime_atr_composite_test.go
@@ -313,11 +313,17 @@ func TestLoadConfig_CompositeStopLossAtrRegime(t *testing.T) {
 		t.Fatalf("LoadConfig must accept composite stop_loss_atr_regime, got: %v", err)
 	}
 	block := cfg.Strategies[0].StopLossATRRegime
-	if block == nil || len(block.TrendRegime) != len(regimeLabelsForClassifier(regimeClassifierComposite)) {
-		t.Fatalf("composite SL block must be populated with all labels post-load, got %#v", block)
+	if block == nil || len(block.TrendRegime) != 7 {
+		t.Fatalf("composite SL block must store the 7 provided labels post-load, got %#v", block)
 	}
 	if v, ok := resolveRegimeATR(*block, "trending_down_choppy"); !ok || v != 1.2 {
 		t.Fatalf("runtime resolve trending_down_choppy = (%g, %v), want (1.2, true)", v, ok)
+	}
+	if v, ok := resolveRegimeATR(*block, "ranging_directional_up"); !ok || v != 1.5 {
+		t.Fatalf("runtime resolve ranging_directional_up = (%g, %v), want (1.5, true)", v, ok)
+	}
+	if v, ok := resolveRegimeATR(*block, "ranging_directional_down"); !ok || v != 1.5 {
+		t.Fatalf("runtime resolve ranging_directional_down = (%g, %v), want (1.5, true)", v, ok)
 	}
 }
 

--- a/scheduler/regime_atr_composite_test.go
+++ b/scheduler/regime_atr_composite_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// composite7StateATR builds a trend_regime raw map covering all 7 composite
+// composite7StateATR builds a trend_regime raw map covering all composite
 // labels with the given ATR multiplier (close_fraction omitted — SL/trailing
 // surfaces).
 func composite7StateATR(atr float64) map[string]interface{} {
@@ -19,7 +19,7 @@ func composite7StateATR(atr float64) map[string]interface{} {
 	return map[string]interface{}{"trend_regime": tr}
 }
 
-// composite7StateTier builds one tiered_tp_atr_regime tier covering all 7
+// composite7StateTier builds one tiered_tp_atr_regime tier covering all
 // composite labels with per-regime close_fraction.
 func composite7StateTier(atr, frac float64) map[string]interface{} {
 	labels := regimeLabelsForClassifier(regimeClassifierComposite)
@@ -43,7 +43,7 @@ func compositeRegimeCfg(scs ...StrategyConfig) *Config {
 }
 
 // TestValidateRegimeATRConfig_CompositeStopLossExplicit is the #802 regression:
-// an explicit 7-state stop_loss_atr_regime under a composite regime_atr_window
+// an explicit composite stop_loss_atr_regime under a composite regime_atr_window
 // must validate cleanly (previously rejected because the resolver hardcoded the
 // ADX 3-state vocabulary).
 func TestValidateRegimeATRConfig_CompositeStopLossExplicit(t *testing.T) {
@@ -59,8 +59,8 @@ func TestValidateRegimeATRConfig_CompositeStopLossExplicit(t *testing.T) {
 		t.Fatalf("composite stop_loss_atr_regime must validate, got: %v", errs)
 	}
 	block := cfg.Strategies[0].StopLossATRRegime
-	if got := len(block.TrendRegime); got != 7 {
-		t.Fatalf("block must be populated with all 7 composite labels, got %d: %v", got, block.TrendRegime)
+	if got, want := len(block.TrendRegime), len(regimeLabelsForClassifier(regimeClassifierComposite)); got != want {
+		t.Fatalf("block must be populated with all composite labels, got %d want %d: %v", got, want, block.TrendRegime)
 	}
 	// Runtime SL resolution must succeed for a composite label (proves the
 	// authoritative pass populated the composite vocabulary, not ADX).
@@ -116,8 +116,8 @@ func TestValidateRegimeATRConfig_CompositeTrailingExplicit(t *testing.T) {
 	if errs := validateRegimeATRConfig(cfg); len(errs) != 0 {
 		t.Fatalf("composite trailing_stop_atr_regime must validate, got: %v", errs)
 	}
-	if got := len(cfg.Strategies[0].TrailingStopATRRegime.TrendRegime); got != 7 {
-		t.Fatalf("trailing block must hold 7 composite labels, got %d", got)
+	if got, want := len(cfg.Strategies[0].TrailingStopATRRegime.TrendRegime), len(regimeLabelsForClassifier(regimeClassifierComposite)); got != want {
+		t.Fatalf("trailing block must hold all composite labels, got %d want %d", got, want)
 	}
 }
 
@@ -243,6 +243,8 @@ func TestMapRegimeToBaselineFamily(t *testing.T) {
 		{"trending_down_choppy", 2.0, true}, // composite prefix → trending_down
 		{"ranging_quiet", 1.5, true},        // composite prefix → ranging
 		{"ranging_directional", 1.5, true},
+		{"ranging_directional_up", 1.5, true},
+		{"ranging_directional_down", 1.5, true},
 		{"garbage", 0, false},
 	}
 	for _, tc := range cases {
@@ -256,8 +258,8 @@ func TestMapRegimeToBaselineFamily(t *testing.T) {
 func TestRegimeLabelsFromTierRaw(t *testing.T) {
 	raw := []interface{}{composite7StateTier(2.0, 0.5)}
 	got := regimeLabelsFromTierRaw(raw)
-	if len(got) != 7 {
-		t.Fatalf("expected 7 inferred labels, got %d: %v", len(got), got)
+	if len(got) != len(regimeLabelsForClassifier(regimeClassifierComposite)) {
+		t.Fatalf("expected inferred composite labels, got %d: %v", len(got), got)
 	}
 	// No per-regime keys → canonical ADX fallback.
 	if got := regimeLabelsFromTierRaw(nil); len(got) != 3 {
@@ -308,11 +310,11 @@ func TestLoadConfig_CompositeStopLossAtrRegime(t *testing.T) {
 	}
 	cfg, err := LoadConfig(cfgPath)
 	if err != nil {
-		t.Fatalf("LoadConfig must accept composite 7-state stop_loss_atr_regime, got: %v", err)
+		t.Fatalf("LoadConfig must accept composite stop_loss_atr_regime, got: %v", err)
 	}
 	block := cfg.Strategies[0].StopLossATRRegime
-	if block == nil || len(block.TrendRegime) != 7 {
-		t.Fatalf("composite SL block must be populated with 7 labels post-load, got %#v", block)
+	if block == nil || len(block.TrendRegime) != len(regimeLabelsForClassifier(regimeClassifierComposite)) {
+		t.Fatalf("composite SL block must be populated with all labels post-load, got %#v", block)
 	}
 	if v, ok := resolveRegimeATR(*block, "trending_down_choppy"); !ok || v != 1.2 {
 		t.Fatalf("runtime resolve trending_down_choppy = (%g, %v), want (1.2, true)", v, ok)

--- a/scheduler/regime_directional_policy.go
+++ b/scheduler/regime_directional_policy.go
@@ -102,6 +102,9 @@ func (p *RegimeDirectionalPolicy) Resolve(regime string) (RegimeDirectionalEntry
 		return RegimeDirectionalEntry{}, false
 	}
 	entry, ok := p.TrendRegime[strings.TrimSpace(regime)]
+	if !ok {
+		entry, ok = p.TrendRegime[regimeLookupLabel(regime)]
+	}
 	return entry, ok
 }
 
@@ -260,7 +263,7 @@ func (p *RegimeDirectionalPolicy) ResolveRawWithLabels(label string, labels []st
 	// so a label that's present-but-invalid isn't also reported as missing.
 	missing := []string{}
 	for _, l := range labels {
-		if !seen[l] {
+		if !regimeLabelCoveredBySeen(l, seen) {
 			missing = append(missing, l)
 		}
 	}
@@ -350,7 +353,11 @@ func gatedDirectionalEntry(sc StrategyConfig, regime string, certStates map[stri
 	if sc.RegimeDirectionalPolicy == nil || sc.RegimeDirectionalPolicy.IsZero() {
 		return RegimeDirectionalEntry{}, false
 	}
-	certDir, certOK := certStates[strings.TrimSpace(regime)]
+	regime = strings.TrimSpace(regime)
+	certDir, certOK := certStates[regime]
+	if !certOK {
+		certDir, certOK = certStates[regimeLookupLabel(regime)]
+	}
 	if !certOK {
 		return RegimeDirectionalEntry{}, false
 	}

--- a/scheduler/regime_divergence.go
+++ b/scheduler/regime_divergence.go
@@ -2,7 +2,7 @@ package main
 
 // Regime window divergence detection and trust-short override (#907).
 //
-// The composite (7-state) regime can be evaluated at multiple windows —
+// The composite regime can be evaluated at multiple windows —
 // typically a "medium" window (slow, for open/position policy) and a "short"
 // window (fast, for tactical/gate logic). They can disagree by design: the
 // medium window lags to reduce whipsaw, the short window reacts quickly.
@@ -242,6 +242,10 @@ func regimeLabelBias(label string, snapReturnEff float64) divergenceBias {
 	case "trending_up", "trending_up_clean", "trending_up_choppy":
 		return biasBullish
 	case "trending_down", "trending_down_clean", "trending_down_choppy":
+		return biasBearish
+	case "ranging_directional_up":
+		return biasBullish
+	case "ranging_directional_down":
 		return biasBearish
 	case "ranging_directional":
 		if snapReturnEff > 0 {

--- a/scheduler/regime_divergence_test.go
+++ b/scheduler/regime_divergence_test.go
@@ -120,6 +120,15 @@ func TestClassifyRegimeDivergence_RangingDirectionalSign(t *testing.T) {
 	if r3.Kind != DivergenceSoft {
 		t.Errorf("zero return_eff: expected soft, got %q", r3.Kind)
 	}
+
+	r4 := classifyRegimeDivergence("ranging_directional_up", "trending_down", 0, 0, onDivergenceTrustShort)
+	if r4.Kind != DivergenceHard || r4.OverrideDir != DirectionLong {
+		t.Errorf("ranging_directional_up: got kind=%q dir=%q, want hard/long", r4.Kind, r4.OverrideDir)
+	}
+	r5 := classifyRegimeDivergence("ranging_directional_down", "trending_up", 0, 0, onDivergenceTrustShort)
+	if r5.Kind != DivergenceHard || r5.OverrideDir != DirectionShort {
+		t.Errorf("ranging_directional_down: got kind=%q dir=%q, want hard/short", r5.Kind, r5.OverrideDir)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/scheduler/regime_profile_allocation.go
+++ b/scheduler/regime_profile_allocation.go
@@ -263,8 +263,12 @@ func (a *RegimeProfileAllocation) ResolveRaw(label string, labels []string) []st
 		errs = append(errs, fmt.Sprintf("%s.initial_profile=%q is not a param_sets profile (valid: %s)", label, initialProfile, strings.Join(sortedKeys(paramSets), ", ")))
 	}
 	// Every classifier label must be covered by profiles.
+	seenProfiles := make(map[string]bool, len(profiles))
+	for lbl := range profiles {
+		seenProfiles[lbl] = true
+	}
 	for _, l := range labels {
-		if _, ok := profiles[l]; !ok {
+		if !regimeLabelCoveredBySeen(l, seenProfiles) {
 			errs = append(errs, fmt.Sprintf("%s.profiles: missing mapping for regime label %q (every label of the window classifier must map to a profile)", label, l))
 		}
 	}
@@ -390,6 +394,9 @@ func resolveRegimeProfile(alloc *RegimeProfileAllocation, label, barTime string,
 	desired := ""
 	if label != "" {
 		desired = alloc.Profiles[label]
+		if desired == "" {
+			desired = alloc.Profiles[regimeLookupLabel(label)]
+		}
 	}
 
 	barAdvanced := barTime != "" && barTime != next.LastBarTime

--- a/scheduler/regime_test.go
+++ b/scheduler/regime_test.go
@@ -122,6 +122,19 @@ func TestRegimeAllowsEntry_MatchingLabel(t *testing.T) {
 	}
 }
 
+func TestRegimeAllowsEntry_RangingDirectionalFamilyFallback(t *testing.T) {
+	allowed := []string{"ranging_directional"}
+	if !regimeAllowsEntry(allowed, "ranging_directional_up") {
+		t.Error("bare ranging_directional should allow ranging_directional_up")
+	}
+	if !regimeAllowsEntry(allowed, "ranging_directional_down") {
+		t.Error("bare ranging_directional should allow ranging_directional_down")
+	}
+	if regimeAllowsEntry([]string{"ranging_directional_up"}, "ranging_directional_down") {
+		t.Error("explicit ranging_directional_up must not allow ranging_directional_down")
+	}
+}
+
 func TestRegimeAllowsEntry_NonMatchingLabel(t *testing.T) {
 	allowed := []string{"trending_up", "trending_down"}
 	if regimeAllowsEntry(allowed, "ranging") {

--- a/scheduler/regime_unified.go
+++ b/scheduler/regime_unified.go
@@ -54,7 +54,14 @@ func unifiedRegimeScalarParams(params map[string]interface{}, regime string) (sc
 	if !isMap {
 		return nil, 0, false
 	}
-	labelRaw, isMap := trendRaw[strings.TrimSpace(regime)].(map[string]interface{})
+	label := strings.TrimSpace(regime)
+	labelRaw, isMap := trendRaw[label].(map[string]interface{})
+	if !isMap {
+		fallback := regimeLookupLabel(label)
+		if fallback != label {
+			labelRaw, isMap = trendRaw[fallback].(map[string]interface{})
+		}
+	}
 	if !isMap {
 		return nil, 0, false
 	}
@@ -188,8 +195,10 @@ func validateUnifiedRegimeClose(params map[string]interface{}, labels []string, 
 		valid[l] = true
 	}
 
+	seen := make(map[string]bool, len(trendRaw))
 	unknown := make([]string, 0)
 	for l := range trendRaw {
+		seen[l] = true
 		if !valid[l] {
 			unknown = append(unknown, l)
 		}
@@ -203,6 +212,9 @@ func validateUnifiedRegimeClose(params map[string]interface{}, labels []string, 
 	for _, l := range labels {
 		lr, ok := trendRaw[l]
 		if !ok {
+			if regimeLabelCoveredBySeen(l, seen) {
+				continue
+			}
 			errs = append(errs, fmt.Sprintf("%s.%s: missing required regime label %q (must be exhaustive — no silent fallback)",
 				ctxLabel, regimeClassifierKey, l))
 			continue

--- a/scheduler/regime_unified_test.go
+++ b/scheduler/regime_unified_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -87,6 +89,108 @@ func TestValidateUnifiedRegimeClose_Valid(t *testing.T) {
 	labels := []string{"trending_up", "trending_down", "ranging"}
 	if errs := validateUnifiedRegimeClose(unifiedBlock(), labels, "close.params"); len(errs) > 0 {
 		t.Fatalf("unexpected errors: %v", errs)
+	}
+}
+
+func compositeUnifiedBlock(includeSplit bool) map[string]interface{} {
+	tiers := []interface{}{
+		map[string]interface{}{"atr_multiple": 1.5, "close_fraction": 0.4},
+		map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
+	}
+	trend := map[string]interface{}{
+		"trending_up_clean":    map[string]interface{}{"stop_loss_atr": 1.5, "tp_tiers": tiers},
+		"trending_up_choppy":   map[string]interface{}{"stop_loss_atr": 1.2, "tp_tiers": tiers},
+		"trending_down_clean":  map[string]interface{}{"stop_loss_atr": 1.5, "tp_tiers": tiers},
+		"trending_down_choppy": map[string]interface{}{"stop_loss_atr": 1.2, "tp_tiers": tiers},
+		"ranging_quiet":        map[string]interface{}{"stop_loss_atr": 0.9, "tp_tiers": tiers},
+		"ranging_volatile":     map[string]interface{}{"stop_loss_atr": 0.8, "tp_tiers": tiers},
+		"ranging_directional":  map[string]interface{}{"stop_loss_atr": 0.7, "tp_tiers": tiers},
+	}
+	if includeSplit {
+		trend["ranging_directional_up"] = map[string]interface{}{"stop_loss_atr": 0.6, "tp_tiers": tiers}
+		trend["ranging_directional_down"] = map[string]interface{}{"stop_loss_atr": 0.5, "tp_tiers": tiers}
+	}
+	return map[string]interface{}{regimeClassifierKey: trend}
+}
+
+func TestValidateUnifiedRegimeClose_CompositeRangingDirectionalFallback(t *testing.T) {
+	labels := regimeLabelsForClassifier(regimeClassifierComposite)
+	block := compositeUnifiedBlock(false)
+	if errs := validateUnifiedRegimeClose(block, labels, "close.params"); len(errs) > 0 {
+		t.Fatalf("bare ranging_directional must cover split labels, got: %v", errs)
+	}
+	trend := block[regimeClassifierKey].(map[string]interface{})
+	if len(trend) != 7 {
+		t.Fatalf("fallback validation must not expand stored keys, got %d", len(trend))
+	}
+	for _, label := range []string{"ranging_directional_up", "ranging_directional_down"} {
+		scalar, sl, ok := unifiedRegimeScalarParams(block, label)
+		if !ok || sl != 0.7 {
+			t.Fatalf("resolve %s = (sl=%g ok=%v), want (0.7 true)", label, sl, ok)
+		}
+		if tiers := scalar["tp_tiers"].([]interface{}); len(tiers) != 2 {
+			t.Fatalf("resolve %s tiers len = %d, want 2", label, len(tiers))
+		}
+	}
+
+	upOnly := compositeUnifiedBlock(false)
+	upTrend := upOnly[regimeClassifierKey].(map[string]interface{})
+	upTrend["ranging_directional_up"] = upTrend["ranging_directional"]
+	delete(upTrend, "ranging_directional")
+	errs := validateUnifiedRegimeClose(upOnly, labels, "close.params")
+	if joined := strings.Join(errs, " | "); !strings.Contains(joined, "ranging_directional") || !strings.Contains(joined, "ranging_directional_down") {
+		t.Fatalf("up-only split config must not cover bare/down labels, got: %v", errs)
+	}
+}
+
+func TestLoadConfig_CompositeUnifiedCloseBareRangingDirectional(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+	dbPath := filepath.Join(dir, "state.db")
+	cfgBody := `{
+		"db_file": "` + strings.ReplaceAll(dbPath, "\\", "\\\\") + `",
+		"regime": {
+			"enabled": true, "period": 14, "adx_threshold": 20,
+			"windows": {
+				"daily": {"classifier": "composite", "period": 24, "thresholds": {"return_pct": 0.05, "range_pct": 0.03, "adx": 20}}
+			}
+		},
+		"strategies": [{
+			"id": "hl-unified",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["donchian_breakout", "BTC", "1h", "--mode=paper"],
+			"capital": 1000,
+			"max_drawdown_pct": 25,
+			"leverage": 1,
+			"regime_atr_window": "daily",
+			"close_strategy": {
+				"name": "tiered_tp_atr_live_regime",
+				"params": {
+					"trend_regime": {
+						"trending_up_clean": {"stop_loss_atr": 1.5, "tp_tiers": [{"atr_multiple": 1.5, "close_fraction": 0.4}, {"atr_multiple": 3.0, "close_fraction": 1.0}]},
+						"trending_up_choppy": {"stop_loss_atr": 1.2, "tp_tiers": [{"atr_multiple": 1.5, "close_fraction": 0.4}, {"atr_multiple": 3.0, "close_fraction": 1.0}]},
+						"trending_down_clean": {"stop_loss_atr": 1.5, "tp_tiers": [{"atr_multiple": 1.5, "close_fraction": 0.4}, {"atr_multiple": 3.0, "close_fraction": 1.0}]},
+						"trending_down_choppy": {"stop_loss_atr": 1.2, "tp_tiers": [{"atr_multiple": 1.5, "close_fraction": 0.4}, {"atr_multiple": 3.0, "close_fraction": 1.0}]},
+						"ranging_quiet": {"stop_loss_atr": 0.9, "tp_tiers": [{"atr_multiple": 1.5, "close_fraction": 0.4}, {"atr_multiple": 3.0, "close_fraction": 1.0}]},
+						"ranging_volatile": {"stop_loss_atr": 0.8, "tp_tiers": [{"atr_multiple": 1.5, "close_fraction": 0.4}, {"atr_multiple": 3.0, "close_fraction": 1.0}]},
+						"ranging_directional": {"stop_loss_atr": 0.7, "tp_tiers": [{"atr_multiple": 1.5, "close_fraction": 0.4}, {"atr_multiple": 3.0, "close_fraction": 1.0}]}
+					}
+				}
+			}
+		}]
+	}`
+	if err := os.WriteFile(cfgPath, []byte(cfgBody), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig must accept base-keyed composite unified close, got: %v", err)
+	}
+	params := cfg.Strategies[0].CloseStrategy.Params
+	if scalar, sl, ok := unifiedRegimeScalarParams(params, "ranging_directional_down"); !ok || sl != 0.7 || len(scalar["tp_tiers"].([]interface{})) != 2 {
+		t.Fatalf("runtime resolve ranging_directional_down = (%v, %g, %v), want 2 tiers/0.7/true", scalar, sl, ok)
 	}
 }
 

--- a/scheduler/regime_window_spec.go
+++ b/scheduler/regime_window_spec.go
@@ -136,6 +136,8 @@ func regimeLabelsForClassifier(classifier string) []string {
 			"ranging_quiet",
 			"ranging_volatile",
 			"ranging_directional",
+			"ranging_directional_up",
+			"ranging_directional_down",
 		}
 	default:
 		return append([]string(nil), canonicalTrendRegimeLabels...)

--- a/scheduler/trailing_tp_ratchet.go
+++ b/scheduler/trailing_tp_ratchet.go
@@ -125,6 +125,8 @@ func ratchetCloseDefaultGroup(label string) (string, bool) {
 	switch l {
 	case "ranging_quiet", "ranging_volatile", "ranging_directional":
 		return l, true
+	case "ranging_directional_up", "ranging_directional_down":
+		return "ranging_directional", true
 	case "ranging":
 		return "ranging_quiet", true
 	}
@@ -264,6 +266,9 @@ func trailingRatchetTiersForRegime(sc StrategyConfig, regime string) []trailingR
 				return nil
 			}
 			block, ok := table[strings.TrimSpace(regime)]
+			if !ok {
+				block, ok = table[regimeLookupLabel(regime)]
+			}
 			if !ok {
 				return nil
 			}
@@ -411,6 +416,9 @@ func validateTrailingTPRatchetClose(sc StrategyConfig, labels []string, regimeEn
 			}
 			for _, key := range labels {
 				block, ok := table[key]
+				if !ok {
+					block, ok = table[regimeLookupLabel(key)]
+				}
 				if !ok {
 					errs = append(errs, fmt.Sprintf("%s.tp_tiers: missing required regime key %q", sub, key))
 					continue

--- a/scheduler/trailing_tp_ratchet_test.go
+++ b/scheduler/trailing_tp_ratchet_test.go
@@ -382,7 +382,7 @@ func TestValidateTrailingTPRatchetClose_RejectsFirstRungLooserThanInitial(t *tes
 }
 
 // TestValidateTrailingTPRatchetClose_CompositeVocabulary proves the regime form
-// validates cleanly against the 7-state composite classifier when the strategy's
+// validates cleanly against the composite classifier when the strategy's
 // regime_atr_window opts into it (and rejects an ADX-only label under composite).
 func TestValidateTrailingTPRatchetClose_CompositeVocabulary(t *testing.T) {
 	tierList := []interface{}{
@@ -398,8 +398,8 @@ func TestValidateTrailingTPRatchetClose_CompositeVocabulary(t *testing.T) {
 		return tbl
 	}
 	composite := regimeLabelsForClassifier(regimeClassifierComposite)
-	if len(composite) != 7 {
-		t.Fatalf("expected 7 composite labels, got %d", len(composite))
+	if len(composite) == 0 {
+		t.Fatalf("expected composite labels, got %d", len(composite))
 	}
 
 	// #870: the regime variant's opening trail / SL owner is the per-regime
@@ -776,6 +776,8 @@ func TestRatchetCloseDefaultGroup(t *testing.T) {
 		{"ranging_quiet", "ranging_quiet", true},
 		{"ranging_volatile", "ranging_volatile", true},
 		{"ranging_directional", "ranging_directional", true},
+		{"ranging_directional_up", "ranging_directional", true},
+		{"ranging_directional_down", "ranging_directional", true},
 		{"ranging", "ranging_quiet", true}, // bare ADX → quiet ladder
 		{"trending_up_clean", "clean", true},
 		{"trending_up_choppy", "choppy", true},

--- a/shared_strategies/close/post_tp_sl.py
+++ b/shared_strategies/close/post_tp_sl.py
@@ -54,7 +54,13 @@ class RegimeFloatBlock:
     trend_regime: Dict[str, float] = field(default_factory=dict)
 
     def resolve(self, regime: str) -> Optional[float]:
-        return self.trend_regime.get((regime or "").strip())
+        key = (regime or "").strip()
+        if key in self.trend_regime:
+            return self.trend_regime[key]
+        fallback = regime_lookup_label(key)
+        if fallback != key:
+            return self.trend_regime.get(fallback)
+        return None
 
 
 @dataclass(frozen=True)
@@ -384,13 +390,17 @@ def _parse_regime_float_block(
         )
         return RegimeFloatBlock(), errs
     valid = set(labels)
+    seen = set(trend_raw)
     unknown = sorted(k for k in trend_raw if k not in valid)
     for label in unknown:
         errs.append(
             f"{ctx_label}.{REGIME_CLASSIFIER_KEY}: unknown regime label {label!r} "
             f"(expected one of: {', '.join(labels)})"
         )
-    missing = [label for label in labels if label not in trend_raw]
+    missing = [
+        label for label in labels
+        if label not in trend_raw and regime_lookup_label(label) not in seen
+    ]
     if missing:
         errs.append(
             f"{ctx_label}.{REGIME_CLASSIFIER_KEY}: missing required regime labels: "

--- a/shared_strategies/close/post_tp_sl.py
+++ b/shared_strategies/close/post_tp_sl.py
@@ -24,6 +24,7 @@ from shared_strategies.close.regime_atr import (
     RegimeATRBlock,
     parse_regime_atr_block,
     parse_regime_tp_tiers,
+    regime_lookup_label,
     resolve_regime_tier,
 )
 from shared_strategies.close._helpers import tier_list_from_params
@@ -872,7 +873,10 @@ def validate_regime_tiered_tp_labels(
                     f"{name}.tiers[{i}].{REGIME_CLASSIFIER_KEY}: unknown regime "
                     f"label {key!r} (expected one of: {', '.join(sorted(expected))})"
                 )
-            missing = [label for label in sorted(expected) if label not in block]
+            missing = [
+                label for label in sorted(expected)
+                if label not in block and regime_lookup_label(label) not in block
+            ]
             if missing:
                 errs.append(
                     f"{name}.tiers[{i}].{REGIME_CLASSIFIER_KEY}: missing required "

--- a/shared_strategies/close/regime_atr.py
+++ b/shared_strategies/close/regime_atr.py
@@ -64,7 +64,12 @@ def unified_regime_scalar_params(params: dict, regime: str):
     trend = params.get(REGIME_CLASSIFIER_KEY)
     if not isinstance(trend, dict):
         return None, 0.0
-    label = trend.get((regime or "").strip())
+    key = (regime or "").strip()
+    label = trend.get(key)
+    if not isinstance(label, dict):
+        fallback = regime_lookup_label(key)
+        if fallback != key:
+            label = trend.get(fallback)
     if not isinstance(label, dict) or "tp_tiers" not in label:
         return None, 0.0
     scalar = {"tp_tiers": label["tp_tiers"]}

--- a/shared_strategies/close/regime_atr.py
+++ b/shared_strategies/close/regime_atr.py
@@ -78,6 +78,16 @@ def unified_regime_scalar_params(params: dict, regime: str):
     return scalar, sl
 
 REGIME_CLASSIFIER_KEY = "trend_regime"
+RANGING_DIRECTIONAL = "ranging_directional"
+RANGING_DIRECTIONAL_UP = "ranging_directional_up"
+RANGING_DIRECTIONAL_DOWN = "ranging_directional_down"
+
+
+def regime_lookup_label(label: str) -> str:
+    label = (label or "").strip()
+    if label in (RANGING_DIRECTIONAL_UP, RANGING_DIRECTIONAL_DOWN):
+        return RANGING_DIRECTIONAL
+    return label
 
 # regimeATRSurface equivalents — kept as string constants so the parser's
 # error messages match Go's surface-specific allowlists.
@@ -107,7 +117,8 @@ class RegimeATRBlock:
     def resolve(self, regime: str) -> Optional[RegimeATREntry]:
         if not self.trend_regime:
             return None
-        return self.trend_regime.get((regime or "").strip())
+        label = (regime or "").strip()
+        return self.trend_regime.get(label) or self.trend_regime.get(regime_lookup_label(label))
 
 
 # Mirrors regimeATRDefaults in scheduler/regime_atr.go — keep values in sync.
@@ -131,6 +142,8 @@ REGIME_ATR_DEFAULTS_TRAILING: Dict[str, RegimeATREntry] = {
     "ranging_quiet": RegimeATREntry(atr=1.0),
     "ranging_volatile": RegimeATREntry(atr=1.0),
     "ranging_directional": RegimeATREntry(atr=1.0),
+    "ranging_directional_up": RegimeATREntry(atr=1.0),
+    "ranging_directional_down": RegimeATREntry(atr=1.0),
 }
 
 # #870: per-quality-group default ATR take-profit ladders. Mirrors
@@ -252,7 +265,10 @@ def parse_regime_atr_block(
             f"(expected one of: {', '.join(labels)})"
         )
 
-    missing_labels = [l for l in labels if l not in trend_raw]
+    missing_labels = [
+        l for l in labels
+        if l not in trend_raw and regime_lookup_label(l) not in trend_raw
+    ]
     if missing_labels:
         errs.append(
             f"{ctx_label}.{REGIME_CLASSIFIER_KEY}: missing required regime labels: "

--- a/shared_strategies/close/test_post_tp_sl.py
+++ b/shared_strategies/close/test_post_tp_sl.py
@@ -54,6 +54,42 @@ def test_scalar_trail_from_here_tp_atr_fraction():
     assert rule.kind == "trail_from_here"
 
 
+def test_composite_tp_atr_fraction_regime_falls_back_to_bare_directional():
+    labels = (
+        "trending_up_clean",
+        "trending_up_choppy",
+        "trending_down_clean",
+        "trending_down_choppy",
+        "ranging_quiet",
+        "ranging_volatile",
+        "ranging_directional",
+        "ranging_directional_up",
+        "ranging_directional_down",
+    )
+    rule = parse_sl_after_rule(
+        {
+            "trail_from_here": {
+                "tp_atr_fraction": {
+                    "trend_regime": {
+                        "trending_up_clean": 0.5,
+                        "trending_up_choppy": 0.5,
+                        "trending_down_clean": 0.5,
+                        "trending_down_choppy": 0.5,
+                        "ranging_quiet": 0.4,
+                        "ranging_volatile": 0.3,
+                        "ranging_directional": 0.25,
+                    }
+                }
+            }
+        },
+        labels=labels,
+    )
+    resolved = rule.resolve_for_regime("ranging_directional_down", tier_multiple=4.0)
+    assert resolved is not None
+    assert resolved.kind == "trail_from_here"
+    assert resolved.trail_atr_mult == 1.0
+
+
 def test_scalar_breakeven_string():
     assert parse_sl_after_rule("breakeven") == SLAfterRule(kind="breakeven")
 

--- a/shared_strategies/close/test_regime_atr.py
+++ b/shared_strategies/close/test_regime_atr.py
@@ -54,6 +54,32 @@ def test_trailing_use_defaults_composite_clean(regime_atr):
         assert regime_atr.resolve_regime_atr(block, label) == 2.0
     assert regime_atr.resolve_regime_atr(block, "trending_up_choppy") == 2.0
     assert regime_atr.resolve_regime_atr(block, "ranging_quiet") == 1.0
+    assert regime_atr.resolve_regime_atr(block, "ranging_directional_up") == 1.0
+    assert regime_atr.resolve_regime_atr(block, "ranging_directional_down") == 1.0
+
+
+def test_ranging_directional_split_falls_back_to_bare_key(regime_atr):
+    labels = (
+        "trending_up_clean", "trending_up_choppy",
+        "trending_down_clean", "trending_down_choppy",
+        "ranging_quiet", "ranging_volatile", "ranging_directional",
+        "ranging_directional_up", "ranging_directional_down",
+    )
+    raw = {regime_atr.REGIME_CLASSIFIER_KEY: {
+        "trending_up_clean": {"atr_multiple": 2.0},
+        "trending_up_choppy": {"atr_multiple": 2.0},
+        "trending_down_clean": {"atr_multiple": 2.0},
+        "trending_down_choppy": {"atr_multiple": 2.0},
+        "ranging_quiet": {"atr_multiple": 1.0},
+        "ranging_volatile": {"atr_multiple": 1.0},
+        "ranging_directional": {"atr_multiple": 1.25},
+    }}
+    block, errs = regime_atr.parse_regime_atr_block(
+        raw, "trailing_stop_atr_regime", regime_atr.SURFACE_TRAILING, labels=labels,
+    )
+    assert errs == []
+    assert regime_atr.resolve_regime_atr(block, "ranging_directional_up") == 1.25
+    assert regime_atr.resolve_regime_atr(block, "ranging_directional_down") == 1.25
 
 
 def test_rejects_bare_label_keys(regime_atr):

--- a/shared_strategies/close/test_regime_atr.py
+++ b/shared_strategies/close/test_regime_atr.py
@@ -82,6 +82,51 @@ def test_ranging_directional_split_falls_back_to_bare_key(regime_atr):
     assert regime_atr.resolve_regime_atr(block, "ranging_directional_down") == 1.25
 
 
+def test_unified_regime_scalar_params_split_falls_back_to_bare_key(regime_atr):
+    tiers = [
+        {"atr_multiple": 1.5, "close_fraction": 0.4},
+        {"atr_multiple": 3.0, "close_fraction": 1.0},
+    ]
+    params = {
+        regime_atr.REGIME_CLASSIFIER_KEY: {
+            "ranging_directional": {
+                "stop_loss_atr": 0.7,
+                "tp_tiers": tiers,
+            }
+        }
+    }
+    scalar, sl = regime_atr.unified_regime_scalar_params(
+        params, "ranging_directional_down"
+    )
+    assert scalar == {"tp_tiers": tiers}
+    assert sl == 0.7
+
+
+def test_unified_regime_evaluate_split_uses_bare_tiers(tiered_regime, regime_atr):
+    position = {
+        "side": "long",
+        "avg_cost": 100.0,
+        "current_quantity": 1.0,
+        "initial_quantity": 1.0,
+        "entry_atr": 2.0,
+        "regime": "ranging_directional_up",
+    }
+    params = {
+        regime_atr.REGIME_CLASSIFIER_KEY: {
+            "ranging_directional": {
+                "stop_loss_atr": 0.7,
+                "tp_tiers": [
+                    {"atr_multiple": 1.5, "close_fraction": 0.4},
+                    {"atr_multiple": 3.0, "close_fraction": 1.0},
+                ],
+            }
+        }
+    }
+    result = tiered_regime.evaluate(position, {"mark_price": 103.0}, params)
+    assert result["close_fraction"] == 0.4
+    assert "ranging_directional_up" in result["reason"]
+
+
 def test_rejects_bare_label_keys(regime_atr):
     raw = {
         "trending_up": {"atr_multiple": 2.0},

--- a/shared_strategies/close/test_trailing_tp_ratchet.py
+++ b/shared_strategies/close/test_trailing_tp_ratchet.py
@@ -176,6 +176,8 @@ def test_ratchet_close_default_group_differentiates_ranging_substates(ratchet):
     assert g("ranging_quiet") == "ranging_quiet"
     assert g("ranging_volatile") == "ranging_volatile"
     assert g("ranging_directional") == "ranging_directional"
+    assert g("ranging_directional_up") == "ranging_directional"
+    assert g("ranging_directional_down") == "ranging_directional"
     # Bare ADX "ranging" (no substate signal) → quiet ladder (pre-#1059 behavior).
     assert g("ranging") == "ranging_quiet"
     # clean/choppy/trend labels delegate to the shared fn, unchanged.
@@ -207,6 +209,12 @@ def test_resolve_tiers_for_regime_ranging_substates(ratchet):
     assert [t[0] for t in directional] == [1.0, 2.0, 3.0, 4.5]
     assert [t[1] for t in directional] == [0.25, 0.50, 0.75, 0.75]
     assert [t[2] for t in directional] == [1.0, 1.0, 0.8, 0.6]  # trail non-increasing
+
+    directional_up, errs = ratchet.resolve_tiers_for_regime(
+        {"use_defaults": True}, "ranging_directional_up", regime_table=True,
+    )
+    assert errs == []
+    assert directional_up == directional
 
     # Bare ADX "ranging" still resolves to the quiet ladder (unchanged pre-#1059).
     adx_ranging, errs = ratchet.resolve_tiers_for_regime(

--- a/shared_strategies/close/trailing_tp_ratchet.py
+++ b/shared_strategies/close/trailing_tp_ratchet.py
@@ -14,7 +14,11 @@ from _helpers import (
     float_from,
     tier_list_from_params,
 )
-from regime_atr import CANONICAL_TREND_REGIME_LABELS, regime_close_default_group
+from regime_atr import (
+    CANONICAL_TREND_REGIME_LABELS,
+    regime_close_default_group,
+    regime_lookup_label,
+)
 
 # DEFAULT_RATCHET_TIERS is the conservative fallback ladder (#866) used when the
 # SCALAR trailing_tp_ratchet omits tp_tiers (or sets use_defaults:true). It
@@ -89,6 +93,8 @@ def ratchet_close_default_group(label: str) -> Optional[str]:
     l = (label or "").strip()
     if l in ("ranging_quiet", "ranging_volatile", "ranging_directional"):
         return l
+    if l in ("ranging_directional_up", "ranging_directional_down"):
+        return "ranging_directional"
     if l == "ranging":
         return "ranging_quiet"
     return regime_close_default_group(l)
@@ -216,6 +222,8 @@ def resolve_tiers_for_regime(
         if not label:
             return [], ["noop:missing_position_regime"]
         block = raw.get(label)
+        if block is None:
+            block = raw.get(regime_lookup_label(label))
         if block is None:
             return [], [f"tp_tiers: missing regime key {label!r}"]
         tiers, terr = _parse_scalar_tiers(block)

--- a/shared_strategies/open/regime_adaptive.py
+++ b/shared_strategies/open/regime_adaptive.py
@@ -28,7 +28,7 @@ classifier uses (ADX period capped at 14, mirroring
     clean    = efficiency >= efficiency_threshold AND adx >= adx_threshold
     big_move & clean        → trending_{up,down}_clean   (breakout mode)
     big_move & !clean       → trending_{up,down}_choppy  (mean-reversion mode)
-    !big_move & high adx    → ranging_directional        (no entries)
+    !big_move & high adx    → ranging_directional_{up,down} / neutral (no entries)
     !big_move & wide range  → ranging_volatile           (mean-reversion mode)
     otherwise               → ranging_quiet              (mean-reversion mode)
 
@@ -36,9 +36,9 @@ The choppy-trend labels take mean-reversion mode because a swing inside a
 broader range *is* a big low-efficiency net move: the z-recovery bar that
 confirms a fade almost definitionally carries a large trailing return, so
 restricting fades to the ``ranging_*`` labels would make them unreachable.
-Only ``ranging_directional`` (high-ADX grind without a decisive move) stays
-entry-free — fading a directional grind is the falling-knife case the #956
-audit showed unfiltered mean reversion dying on.
+Only the ``ranging_directional*`` family (high-ADX grind without a decisive
+move) stays entry-free — fading a directional grind is the falling-knife case
+the #956 audit showed unfiltered mean reversion dying on.
 
 Entries
 -------
@@ -93,6 +93,8 @@ _TREND_DOWN_CHOPPY = -2
 _RANGING_DIRECTIONAL = 3
 _RANGING_VOLATILE = 4
 _RANGING_QUIET = 5
+_RANGING_DIRECTIONAL_UP = 6
+_RANGING_DIRECTIONAL_DOWN = 7
 
 _LABEL_NAMES = {
     _WARMUP: "",
@@ -101,6 +103,8 @@ _LABEL_NAMES = {
     _TREND_DOWN_CLEAN: "trending_down_clean",
     _TREND_DOWN_CHOPPY: "trending_down_choppy",
     _RANGING_DIRECTIONAL: "ranging_directional",
+    _RANGING_DIRECTIONAL_UP: "ranging_directional_up",
+    _RANGING_DIRECTIONAL_DOWN: "ranging_directional_down",
     _RANGING_VOLATILE: "ranging_volatile",
     _RANGING_QUIET: "ranging_quiet",
 }
@@ -127,7 +131,7 @@ def regime_adaptive_core(
     ----------
     df : DataFrame with open, high, low, close, volume columns
     period : composite metric window (return/range/efficiency + ATR normalization)
-    adx_threshold : minimum ADX for the clean-trend / ranging_directional split
+    adx_threshold : minimum ADX for the clean-trend / ranging_directional* split
         (composite classifier default 25; tuned to 20 by walk-forward stability)
     return_eff_threshold : minimum |return_eff| for a decisive net move
         (mirrors composite ``return_pct``, default 0.05)
@@ -221,6 +225,8 @@ def regime_adaptive_core(
             big_move & up,
             big_move & clean,
             big_move,
+            high_adx & up,
+            high_adx & (return_eff < 0),
             high_adx,
             wide,
         ],
@@ -230,6 +236,8 @@ def regime_adaptive_core(
             _TREND_UP_CHOPPY,
             _TREND_DOWN_CLEAN,
             _TREND_DOWN_CHOPPY,
+            _RANGING_DIRECTIONAL_UP,
+            _RANGING_DIRECTIONAL_DOWN,
             _RANGING_DIRECTIONAL,
             _RANGING_VOLATILE,
         ],

--- a/shared_strategies/open/regime_adaptive_htf.py
+++ b/shared_strategies/open/regime_adaptive_htf.py
@@ -201,7 +201,7 @@ def _classify_buckets(
 
 def _confirm_labels(raw: np.ndarray, confirm_buckets: int) -> np.ndarray:
     """Hysteresis over closed buckets: the effective label switches only after
-    ``confirm_buckets`` consecutive buckets carry the same raw label
+    ``confirm_buckets`` consecutive buckets carry the same raw label family
     (the backtest analogue of live ``regime_confirm_cycles``).
 
     Warmup buckets (code 0) neither confirm a new label nor disturb the
@@ -210,23 +210,31 @@ def _confirm_labels(raw: np.ndarray, confirm_buckets: int) -> np.ndarray:
     """
     n = len(raw)
     confirmed = np.zeros(n, dtype=int)
+    def streak_key(label: int) -> int:
+        if label in (_RANGING_DIRECTIONAL_UP, _RANGING_DIRECTIONAL_DOWN):
+            return _RANGING_DIRECTIONAL
+        return label
+
     if confirm_buckets <= 1:
-        return raw.copy()
+        return np.array([streak_key(int(label)) for label in raw], dtype=int)
+
     current = _WARMUP
-    streak_label = _WARMUP
+    streak_family = _WARMUP
     streak = 0
     for i in range(n):
         lab = raw[i]
         if lab == _WARMUP:
-            streak_label = _WARMUP
+            streak_family = _WARMUP
             streak = 0
-        elif lab == streak_label:
-            streak += 1
         else:
-            streak_label = lab
-            streak = 1
-        if streak_label != _WARMUP and streak >= confirm_buckets and streak_label != current:
-            current = streak_label
+            family = streak_key(lab)
+            if family == streak_family:
+                streak += 1
+            else:
+                streak_family = family
+                streak = 1
+        if streak_family != _WARMUP and streak >= confirm_buckets and streak_family != current:
+            current = streak_family
         confirmed[i] = current
     return confirmed
 

--- a/shared_strategies/open/regime_adaptive_htf.py
+++ b/shared_strategies/open/regime_adaptive_htf.py
@@ -61,9 +61,9 @@ bucket label does not flip on one native recovery bar, so fades in true
 ranges stay reachable without that hack (``fade_labels="all_mr"`` restores
 the #967 mapping for comparison).
 
-``ranging_directional`` (high-ADX grind without a decisive move) stays
-entry-free — fading a directional grind is the falling-knife case the #956
-audit showed unfiltered mean reversion dying on. Fades exit at the mean
+The ``ranging_directional*`` family (high-ADX grind without a decisive move)
+stays entry-free — fading a directional grind is the falling-knife case the
+#956 audit showed unfiltered mean reversion dying on. Fades exit at the mean
 (``mr_exit_z``) or when a confirmed *clean* trend ignites against them; the
 slow-trend drift veto from #967 (ATR-normalized net move over
 ``slow_trend_lookback`` native bars opposing the fade side) is retained — it
@@ -101,6 +101,8 @@ _TREND_DOWN_CHOPPY = -2
 _RANGING_DIRECTIONAL = 3
 _RANGING_VOLATILE = 4
 _RANGING_QUIET = 5
+_RANGING_DIRECTIONAL_UP = 6
+_RANGING_DIRECTIONAL_DOWN = 7
 
 _LABEL_NAMES = {
     _WARMUP: "",
@@ -109,6 +111,8 @@ _LABEL_NAMES = {
     _TREND_DOWN_CLEAN: "trending_down_clean",
     _TREND_DOWN_CHOPPY: "trending_down_choppy",
     _RANGING_DIRECTIONAL: "ranging_directional",
+    _RANGING_DIRECTIONAL_UP: "ranging_directional_up",
+    _RANGING_DIRECTIONAL_DOWN: "ranging_directional_down",
     _RANGING_VOLATILE: "ranging_volatile",
     _RANGING_QUIET: "ranging_quiet",
 }
@@ -175,6 +179,8 @@ def _classify_buckets(
             big_move & up,
             big_move & clean,
             big_move,
+            high_adx & up,
+            high_adx & (return_eff < 0),
             high_adx,
             wide,
         ],
@@ -184,6 +190,8 @@ def _classify_buckets(
             _TREND_UP_CHOPPY,
             _TREND_DOWN_CLEAN,
             _TREND_DOWN_CHOPPY,
+            _RANGING_DIRECTIONAL_UP,
+            _RANGING_DIRECTIONAL_DOWN,
             _RANGING_DIRECTIONAL,
             _RANGING_VOLATILE,
         ],

--- a/shared_strategies/open/test_regime_adaptive_htf.py
+++ b/shared_strategies/open/test_regime_adaptive_htf.py
@@ -5,6 +5,9 @@ import pandas as pd
 
 from regime_adaptive_htf import (
     _confirm_labels,
+    _RANGING_DIRECTIONAL,
+    _RANGING_DIRECTIONAL_DOWN,
+    _RANGING_DIRECTIONAL_UP,
     _RANGING_QUIET,
     _RANGING_VOLATILE,
     _TREND_UP_CLEAN,
@@ -140,6 +143,27 @@ def test_confirm_labels_warmup_resets_streak():
 def test_confirm_one_is_identity():
     raw = np.array([_RANGING_QUIET, _TREND_UP_CLEAN, _TREND_DOWN_CLEAN])
     assert _confirm_labels(raw, 1).tolist() == raw.tolist()
+
+
+def test_confirm_labels_folds_directional_ranging_family():
+    raw = np.array([
+        _RANGING_QUIET,
+        _RANGING_QUIET,
+        _RANGING_DIRECTIONAL_UP,
+        _RANGING_DIRECTIONAL_DOWN,
+        _RANGING_DIRECTIONAL_UP,
+    ])
+    conf = _confirm_labels(raw, 2)
+    assert conf.tolist() == [
+        0,
+        _RANGING_QUIET,
+        _RANGING_QUIET,
+        _RANGING_DIRECTIONAL,
+        _RANGING_DIRECTIONAL,
+    ]
+    assert _confirm_labels(
+        np.array([_RANGING_DIRECTIONAL_UP, _RANGING_DIRECTIONAL_DOWN]), 1
+    ).tolist() == [_RANGING_DIRECTIONAL, _RANGING_DIRECTIONAL]
 
 
 # ── Entry / exit semantics ───────────────────────────────────────────────────
@@ -382,4 +406,3 @@ def test_label_lags_not_leads_the_bucket():
     mutated.loc[later, ["open", "high", "low", "close"]] = 1.0
     out_mut = regime_adaptive_htf_core(mutated, **PIN)
     assert out.loc[mid_bucket, "rah_label"] == out_mut.loc[mid_bucket, "rah_label"]
-

--- a/shared_tools/regime.py
+++ b/shared_tools/regime.py
@@ -1,8 +1,8 @@
 """Market regime detection for go-trader check scripts.
 
-Supports per-window classifiers (#795):
+Supports per-window classifiers (#795/#1124):
   adx       — 3-state Wilder ADX + DI (default)
-  composite — 7-state return/ADX/range tuple
+  composite — return/ADX/range tuple with explicit directional ranging labels
 
 Usage in check scripts (after data fetch and before apply_strategy):
 
@@ -56,6 +56,8 @@ VALID_LABELS_COMPOSITE = frozenset({
     "ranging_quiet",
     "ranging_volatile",
     "ranging_directional",
+    "ranging_directional_up",
+    "ranging_directional_down",
 })
 # Back-compat alias for ADX-only callers
 _VALID_LABELS = VALID_LABELS_ADX
@@ -142,7 +144,7 @@ def map_composite_label(
     efficiency: float,
     thresholds: dict[str, float],
 ) -> str:
-    """Map the composite metric tuple to one of seven labels (#795).
+    """Map the composite metric tuple to a composite regime label (#795/#1124).
 
     Inputs are ATR-efficiency normalized so the thresholds are unit-consistent:
       return_eff — window net move / (per-bar ATR * period), signed, ~[-1, 1]
@@ -169,6 +171,10 @@ def map_composite_label(
     # No decisive net move → ranging family.
     if high_adx:
         # Directional pressure without net follow-through.
+        if return_eff > 0:
+            return "ranging_directional_up"
+        if return_eff < 0:
+            return "ranging_directional_down"
         return "ranging_directional"
     if wide:
         return "ranging_volatile"

--- a/shared_tools/test_regime.py
+++ b/shared_tools/test_regime.py
@@ -395,7 +395,9 @@ def test_map_composite_label_states():
     # Ranging family: no decisive net move.
     assert m(0.01, 10, 0.01, 0.0, th) == "ranging_quiet"
     assert m(0.01, 10, 0.10, 0.0, th) == "ranging_volatile"
-    assert m(0.01, 30, 0.10, 0.0, th) == "ranging_directional"
+    assert m(0.01, 30, 0.10, 0.0, th) == "ranging_directional_up"
+    assert m(-0.01, 30, 0.10, 0.0, th) == "ranging_directional_down"
+    assert m(0.0, 30, 0.10, 0.0, th) == "ranging_directional"
 
 
 def test_latest_regime_composite_ranging_not_trending():


### PR DESCRIPTION
## Summary
- Add `ranging_directional_up` and `ranging_directional_down` as explicit composite regime labels
- Treat the new labels as aliases of `ranging_directional` for gating, ATR resolution, profile allocation, divergence bias, unified close, post-TP SL adjustment, and trailing ratchets
- Update backtest and Python regime handling so bare `ranging_directional` config continues to match the split labels

## Testing
- Focused Go review tests passed
- Focused Python close/HTF tests passed
- Broad Go suite passed with only `TestUpdateShellAllDispatchesWithoutBuildToolchain1055` skipped because its stripped test `PATH` omits `bash`

Closes #1124

---
LLM: gpt-5.5 | high effort | Harness: codex
