### PR TITLE
fix(#1128): lazy-init HL Exchange and exempt transient 429 script failures

### DIFF
--- a/platforms/hyperliquid/adapter.py
+++ b/platforms/hyperliquid/adapter.py
@@ -16,6 +16,7 @@ import math
 import os
 import sys
 import tempfile
+import threading
 import time
 from decimal import Decimal, ROUND_DOWN
 
@@ -30,6 +31,10 @@ TESTNET_URL = "https://api.hyperliquid-testnet.xyz"
 # call entirely (#768).
 META_CACHE_PATH = "/tmp/hl_meta.json"
 META_CACHE_TTL_S = 3600  # 60 minutes
+
+# After a lazy Exchange init failure (429, network), suppress re-attempts briefly
+# so trading calls in the same subprocess fast-fail without re-hitting CloudFront.
+_EXCHANGE_INIT_BACKOFF_S = 30
 
 # OHLCV candles are re-fetched from /info by every strategy subprocess. With
 # ~20 strategies per instance sharing a handful of asset+timeframe combos, the
@@ -416,28 +421,27 @@ class HyperliquidExchangeAdapter:
         base_url = TESTNET_URL if testnet else MAINNET_URL
         self._base_url = base_url
 
-        self._info = self._build_info(base_url, allow_cache=True)
-        self._account_address = addr
+        self._wallet = None
         self._exchange = None
+        self._exchange_lock = threading.Lock()
+        self._exchange_init_error = None
+        self._exchange_backoff_until = 0.0
+        self._cached_spot_meta = None
+        self._cached_meta = None
         # Symbols we've already refreshed meta for and still couldn't find —
         # capped at one /info refresh per missing symbol per subprocess
         # lifetime, otherwise a typo or delisted asset would re-fetch meta
         # on every order operation. (PR #769 review point 2.)
         self._sz_decimals_misses: set[str] = set()
 
+        self._info = self._build_info(base_url, allow_cache=True)
+        self._account_address = addr
+
         if secret:
-            try:
-                import eth_account
-                wallet = eth_account.Account.from_key(secret)
-                account_addr = addr or wallet.address
-                self._account_address = account_addr
-                self._exchange = _HLExchange(
-                    wallet, base_url=base_url, account_address=account_addr
-                )
-            except Exception as e:
-                raise RuntimeError(
-                    f"Failed to initialize Hyperliquid Exchange client: {e}"
-                )
+            import eth_account
+            wallet = eth_account.Account.from_key(secret)
+            self._wallet = wallet
+            self._account_address = addr or wallet.address
 
     def _build_info(self, base_url: str, allow_cache: bool):
         """Construct an SDK Info instance, using the /tmp/hl_meta.json cache
@@ -454,19 +458,70 @@ class HyperliquidExchangeAdapter:
         cached = _load_meta_cache() if allow_cache else None
         if cached is not None:
             spot_meta, meta = cached
+            self._cached_spot_meta, self._cached_meta = spot_meta, meta
             return _HLInfo(base_url=base_url, skip_ws=True, meta=meta,
                            spot_meta=_normalize_spot_meta(spot_meta))
         try:
             spot_meta, meta = _fetch_raw_meta(base_url)
             _save_meta_cache(spot_meta, meta)
+            self._cached_spot_meta, self._cached_meta = spot_meta, meta
             return _HLInfo(base_url=base_url, skip_ws=True, meta=meta,
                            spot_meta=_normalize_spot_meta(spot_meta))
         except Exception as exc:
             # Last-resort fallback: let the SDK's constructor fetch fresh.
             # Costs the same 2 /info as before this change; cache write failed
             # but trading must continue.
+            self._cached_spot_meta, self._cached_meta = None, None
             print(f"[WARN] hl meta fetch failed ({exc}); falling back to SDK init", file=sys.stderr)
             return _HLInfo(base_url=base_url, skip_ws=True)
+
+    def _ensure_exchange(self):
+        """Lazily construct the SDK Exchange client (#1128).
+
+        Regime/signal subprocesses only need ``self._info`` for OHLCV; deferring
+        ``Exchange`` skips its embedded ``Info`` spotMeta/meta /info storm. When
+        trading eventually needs Exchange, pass the same cached meta blobs.
+        """
+        if self._exchange is not None:
+            return self._exchange
+        if self._wallet is None:
+            return None
+        now = time.time()
+        with self._exchange_lock:
+            if self._exchange is not None:
+                return self._exchange
+            if (self._exchange_init_error is not None
+                    and now < self._exchange_backoff_until):
+                raise RuntimeError(
+                    "Failed to initialize Hyperliquid Exchange client: "
+                    f"{self._exchange_init_error}"
+                )
+            try:
+                kwargs = {
+                    "base_url": self._base_url,
+                    "account_address": self._account_address,
+                }
+                if self._cached_meta is not None and self._cached_spot_meta is not None:
+                    kwargs["meta"] = self._cached_meta
+                    kwargs["spot_meta"] = _normalize_spot_meta(self._cached_spot_meta)
+                self._exchange = _HLExchange(self._wallet, **kwargs)
+                self._exchange_init_error = None
+                self._exchange_backoff_until = 0.0
+                return self._exchange
+            except Exception as e:
+                self._exchange_init_error = e
+                self._exchange_backoff_until = time.time() + _EXCHANGE_INIT_BACKOFF_S
+                raise RuntimeError(
+                    f"Failed to initialize Hyperliquid Exchange client: {e}"
+                ) from e
+
+    def _require_exchange(self, caller: str = "live trading"):
+        """Return the live Exchange client or raise if unavailable."""
+        if self._wallet is None:
+            raise RuntimeError(
+                f"{caller} requires live mode (set HYPERLIQUID_SECRET_KEY)"
+            )
+        return self._ensure_exchange()
 
     def _sz_decimals(self, symbol: str) -> int:
         """Look up sz_decimals for ``symbol``, force-refreshing the cached
@@ -502,8 +557,8 @@ class HyperliquidExchangeAdapter:
 
     @property
     def is_live(self) -> bool:
-        """True if Exchange client is initialized (live mode)."""
-        return self._exchange is not None
+        """True when live credentials are configured (Exchange may be lazy)."""
+        return self._wallet is not None
 
     @property
     def mode(self) -> str:
@@ -748,16 +803,13 @@ class HyperliquidExchangeAdapter:
         Only available in live mode; raises RuntimeError in paper mode.
         Returns raw SDK response dict.
         """
-        if not self._exchange:
-            raise RuntimeError(
-                "market_open requires live mode (set HYPERLIQUID_SECRET_KEY)"
-            )
+        exchange = self._require_exchange("market_open")
         # Round to asset's tick precision to avoid float_to_wire rounding error
         sz_decimals = self._sz_decimals(symbol)
         size = round(size, sz_decimals)
         if size <= 0:
             raise ValueError(f"Size rounded to zero for {symbol} (sz_decimals={sz_decimals})")
-        return self._exchange.market_open(symbol, is_buy, size, None, 0.01)
+        return exchange.market_open(symbol, is_buy, size, None, 0.01)
 
     def limit_open(
         self,
@@ -782,10 +834,7 @@ class HyperliquidExchangeAdapter:
         live mode; raises RuntimeError in paper mode.
         Returns the raw SDK response dict.
         """
-        if not self._exchange:
-            raise RuntimeError(
-                "limit_open requires live mode (set HYPERLIQUID_SECRET_KEY)"
-            )
+        exchange = self._require_exchange("limit_open")
         sz_decimals = self._sz_decimals(symbol)
         size = round(size, sz_decimals)
         if size <= 0:
@@ -796,7 +845,7 @@ class HyperliquidExchangeAdapter:
             raise ValueError(f"unsupported tif {tif!r}, expected 'Alo', 'Gtc' or 'Ioc'")
         limit_px = _round_perps_px(limit_px, sz_decimals)
         order_type = {"limit": {"tif": tif}}
-        return self._exchange.order(
+        return exchange.order(
             symbol, is_buy, size, limit_px, order_type, reduce_only=False
         )
 
@@ -812,17 +861,14 @@ class HyperliquidExchangeAdapter:
         Only available in live mode; raises RuntimeError in paper mode.
         Returns raw SDK response dict.
         """
-        if not self._exchange:
-            raise RuntimeError(
-                "market_close requires live mode (set HYPERLIQUID_SECRET_KEY)"
-            )
+        exchange = self._require_exchange("market_close")
         if sz is not None:
             # Round to asset's tick precision to avoid float_to_wire rounding error (#425)
             sz_decimals = self._sz_decimals(symbol)
             sz = round(sz, sz_decimals)
             if sz <= 0:
                 raise ValueError(f"Size rounded to zero for {symbol} (sz_decimals={sz_decimals})")
-        return self._exchange.market_close(symbol, sz)
+        return exchange.market_close(symbol, sz)
 
     def lookup_fill_fee_by_oid(
         self,
@@ -989,10 +1035,7 @@ class HyperliquidExchangeAdapter:
         The scheduler detects this via isHLOpenOrderCapRejection and escalates
         to CRITICAL + notifier — no proactive client-side counter is required.
         """
-        if not self._exchange:
-            raise RuntimeError(
-                "place_stop_loss requires live mode (set HYPERLIQUID_SECRET_KEY)"
-            )
+        exchange = self._require_exchange("place_stop_loss")
         sz_decimals = self._sz_decimals(symbol)
         sz = round(sz, sz_decimals)
         if sz <= 0:
@@ -1014,7 +1057,7 @@ class HyperliquidExchangeAdapter:
         trigger_px = _round_perps_px(trigger_px, sz_decimals)
 
         order_type = {"trigger": {"triggerPx": trigger_px, "isMarket": True, "tpsl": "sl"}}
-        return self._exchange.order(
+        return exchange.order(
             symbol, is_buy, sz, limit_px, order_type, reduce_only=True
         )
 
@@ -1026,10 +1069,7 @@ class HyperliquidExchangeAdapter:
         is_buy: bool,
     ) -> dict:
         """Place a reduce-only take-profit limit order (#601)."""
-        if not self._exchange:
-            raise RuntimeError(
-                "place_take_profit_limit requires live mode (set HYPERLIQUID_SECRET_KEY)"
-            )
+        exchange = self._require_exchange("place_take_profit_limit")
         sz_decimals = self._sz_decimals(symbol)
         sz = _floor_size(sz, sz_decimals)
         if sz <= 0:
@@ -1038,7 +1078,7 @@ class HyperliquidExchangeAdapter:
             raise ValueError(f"limit_px must be > 0, got {limit_px}")
         limit_px = _round_perps_px(limit_px, sz_decimals)
         order_type = {"limit": {"tif": "Gtc"}}
-        return self._exchange.order(
+        return exchange.order(
             symbol, is_buy, sz, limit_px, order_type, reduce_only=True
         )
 
@@ -1092,11 +1132,8 @@ class HyperliquidExchangeAdapter:
         limits placed via place_take_profit_limit) are both cancellable
         through this single primitive (#604 review #4).
         """
-        if not self._exchange:
-            raise RuntimeError(
-                "cancel_order_by_oid requires live mode (set HYPERLIQUID_SECRET_KEY)"
-            )
-        return self._exchange.cancel(symbol, int(oid))
+        exchange = self._require_exchange("cancel_order_by_oid")
+        return exchange.cancel(symbol, int(oid))
 
     # Backwards-compatible alias. The original name implied only trigger
     # orders were supported; in practice HL's cancel works for any order
@@ -1114,13 +1151,10 @@ class HyperliquidExchangeAdapter:
         or when ``get_position_leverage`` confirms the on-chain state already
         matches the desired (mode, leverage) pair (#491).
         """
-        if not self._exchange:
-            raise RuntimeError(
-                "update_leverage requires live mode (set HYPERLIQUID_SECRET_KEY)"
-            )
+        exchange = self._require_exchange("update_leverage")
         if leverage < 1:
             raise ValueError(f"leverage must be >= 1, got {leverage}")
-        return self._exchange.update_leverage(int(leverage), symbol, bool(is_cross))
+        return exchange.update_leverage(int(leverage), symbol, bool(is_cross))
 
     def get_position_leverage(self, symbol: str) -> dict | None:
         """Return ``{"margin_mode": "isolated"|"cross", "leverage": int}`` for the

--- a/platforms/hyperliquid/test_adapter.py
+++ b/platforms/hyperliquid/test_adapter.py
@@ -385,6 +385,7 @@ class TestOrderExecution:
         mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
         adapter = mod.HyperliquidExchangeAdapter()
         # Simulate live mode
+        adapter._wallet = MagicMock()
         adapter._exchange = mock_exchange
         adapter._info = mock_info
 
@@ -399,6 +400,7 @@ class TestOrderExecution:
         mock_exchange = MagicMock()
         mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
         adapter = mod.HyperliquidExchangeAdapter()
+        adapter._wallet = MagicMock()
         adapter._exchange = mock_exchange
         adapter._info = mock_info
 
@@ -412,6 +414,7 @@ class TestOrderExecution:
         mock_exchange.market_close.return_value = {"status": "closed"}
         mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
         adapter = mod.HyperliquidExchangeAdapter()
+        adapter._wallet = MagicMock()
         adapter._exchange = mock_exchange
 
         result = adapter.market_close("BTC")
@@ -430,6 +433,7 @@ class TestOrderExecution:
         mock_exchange.market_close.return_value = {"status": "closed"}
         mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
         adapter = mod.HyperliquidExchangeAdapter()
+        adapter._wallet = MagicMock()
         adapter._exchange = mock_exchange
         adapter._info = mock_info
 
@@ -446,6 +450,7 @@ class TestOrderExecution:
         mock_exchange.market_close.return_value = {"status": "closed"}
         mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
         adapter = mod.HyperliquidExchangeAdapter()
+        adapter._wallet = MagicMock()
         adapter._exchange = mock_exchange
         adapter._info = mock_info
 
@@ -459,6 +464,7 @@ class TestOrderExecution:
         mock_exchange = MagicMock()
         mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
         adapter = mod.HyperliquidExchangeAdapter()
+        adapter._wallet = MagicMock()
         adapter._exchange = mock_exchange
         adapter._info = mock_info
 
@@ -480,6 +486,7 @@ class TestStopLossPlacement:
         mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
         adapter = mod.HyperliquidExchangeAdapter()
         mock_exchange = MagicMock()
+        adapter._wallet = MagicMock()
         adapter._exchange = mock_exchange
         adapter._info = mock_info
         return adapter, mock_exchange, mod
@@ -694,6 +701,7 @@ class TestLimitOpen:
         mock_exchange.order.return_value = {"status": "ok"}
         mod = _load_hl_adapter(mock_info_cls=mock_info_cls)
         adapter = mod.HyperliquidExchangeAdapter()
+        adapter._wallet = MagicMock()
         adapter._exchange = mock_exchange
         adapter._info = mock_info
         return adapter, mock_exchange
@@ -847,3 +855,98 @@ class TestFundingHistoryRange:
         adapter = self._adapter(mock_info)
         out = adapter.get_funding_history_range("BTC", base, base + 100 * self._HOUR)
         assert len(out) == 5
+
+
+# ─── Lazy Exchange init (#1128) ───────────────────
+
+class TestLazyExchangeInit:
+    def _sample_meta(self):
+        return (
+            {"universe": [{"index": 0, "name": "USDC/USDC", "tokens": [0, 0]}],
+             "tokens": [{"name": "USDC", "szDecimals": 0}]},
+            {"universe": [{"name": "BTC", "szDecimals": 5}]},
+        )
+
+    def _live_adapter_mod(self, monkeypatch, mock_exchange_cls=None):
+        spot_meta, meta = self._sample_meta()
+        mock_info = MagicMock()
+        mock_info.asset_to_sz_decimals = {"BTC": 5}
+        mock_info.candles_snapshot.return_value = []
+        mock_info_cls = MagicMock(return_value=mock_info)
+        exchange_calls = {"n": 0}
+        mock_exchange = MagicMock()
+        mock_exchange.market_open.return_value = {"status": "ok"}
+
+        def exchange_factory(*args, **kwargs):
+            exchange_calls["n"] += 1
+            exchange_calls["kwargs"] = kwargs
+            return mock_exchange
+
+        mock_exchange_cls = mock_exchange_cls or MagicMock(side_effect=exchange_factory)
+        mod = _load_hl_adapter(mock_info_cls=mock_info_cls, mock_exchange_cls=mock_exchange_cls)
+        monkeypatch.setenv("HYPERLIQUID_SECRET_KEY", "0x" + "11" * 32)
+        monkeypatch.setattr(mod, "_load_meta_cache", lambda *a, **kw: (spot_meta, meta))
+
+        fake_wallet = MagicMock()
+        fake_account_mod = MagicMock()
+        fake_account_mod.Account.from_key.return_value = fake_wallet
+        monkeypatch.setitem(sys.modules, "eth_account", fake_account_mod)
+
+        adapter = mod.HyperliquidExchangeAdapter()
+        return mod, adapter, mock_info, mock_exchange, exchange_calls
+
+    def test_init_defers_exchange_when_secret_set(self, monkeypatch):
+        mod, adapter, _, _, exchange_calls = self._live_adapter_mod(monkeypatch)
+        assert adapter._exchange is None
+        assert adapter.is_live is True
+        assert exchange_calls["n"] == 0
+
+    def test_get_ohlcv_works_without_exchange(self, monkeypatch):
+        _, adapter, mock_info, _, exchange_calls = self._live_adapter_mod(monkeypatch)
+        adapter.get_ohlcv("BTC", interval="1h", limit=10)
+        mock_info.candles_snapshot.assert_called()
+        assert exchange_calls["n"] == 0
+
+    def test_market_open_lazy_inits_exchange_with_cached_meta(self, monkeypatch):
+        _, adapter, mock_info, mock_exchange, exchange_calls = self._live_adapter_mod(monkeypatch)
+        assert adapter._cached_meta is not None
+        adapter._info = mock_info
+        adapter.market_open("BTC", True, 0.5)
+        assert exchange_calls["n"] == 1
+        assert exchange_calls["kwargs"].get("meta", {})["universe"][0]["name"] == "BTC"
+        mock_exchange.market_open.assert_called_once()
+
+    def test_exchange_init_429_does_not_fail_adapter_init(self, monkeypatch):
+        err = RuntimeError("(429, None, 'null', None)")
+        mod, adapter, mock_info, _, _ = self._live_adapter_mod(
+            monkeypatch,
+            mock_exchange_cls=MagicMock(side_effect=err),
+        )
+        adapter._info = mock_info
+        assert adapter._exchange is None
+        with pytest.raises(RuntimeError, match="Failed to initialize Hyperliquid Exchange client"):
+            adapter.market_open("BTC", True, 0.5)
+
+    def test_concurrent_lazy_init_calls_exchange_once(self, monkeypatch):
+        import threading
+
+        _, adapter, mock_info, _, exchange_calls = self._live_adapter_mod(monkeypatch)
+        adapter._info = mock_info
+        barrier = threading.Barrier(2)
+        errors = []
+
+        def worker():
+            try:
+                barrier.wait(timeout=5)
+                adapter.market_open("BTC", True, 0.5)
+            except Exception as exc:  # noqa: BLE001 - collect for assertion
+                errors.append(exc)
+
+        t1 = threading.Thread(target=worker)
+        t2 = threading.Thread(target=worker)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+        assert not errors
+        assert exchange_calls["n"] == 1

--- a/platforms/hyperliquid/test_adapter.py
+++ b/platforms/hyperliquid/test_adapter.py
@@ -927,6 +927,83 @@ class TestLazyExchangeInit:
         with pytest.raises(RuntimeError, match="Failed to initialize Hyperliquid Exchange client"):
             adapter.market_open("BTC", True, 0.5)
 
+    def test_exchange_init_backoff_suppresses_rapid_retries(self, monkeypatch):
+        err = RuntimeError("(429, None, 'null', None)")
+        mod, adapter, mock_info, _, exchange_calls = self._live_adapter_mod(monkeypatch)
+
+        def exchange_factory(*args, **kwargs):
+            exchange_calls["n"] += 1
+            raise err
+
+        monkeypatch.setattr(mod, "_HLExchange", MagicMock(side_effect=exchange_factory))
+        now = [1_700_000_000.0]
+        monkeypatch.setattr(mod.time, "time", lambda: now[0])
+        adapter._info = mock_info
+
+        with pytest.raises(RuntimeError, match="Failed to initialize Hyperliquid Exchange client"):
+            adapter.market_open("BTC", True, 0.5)
+        assert exchange_calls["n"] == 1
+
+        now[0] += 5
+        with pytest.raises(RuntimeError, match="Failed to initialize Hyperliquid Exchange client"):
+            adapter.market_open("BTC", True, 0.5)
+        assert exchange_calls["n"] == 1, "backoff must suppress SDK constructor within 30s"
+
+    def test_exchange_init_retries_after_backoff_expires(self, monkeypatch):
+        err = RuntimeError("(429, None, 'null', None)")
+        mod, adapter, mock_info, _, exchange_calls = self._live_adapter_mod(monkeypatch)
+
+        def exchange_factory(*args, **kwargs):
+            exchange_calls["n"] += 1
+            raise err
+
+        monkeypatch.setattr(mod, "_HLExchange", MagicMock(side_effect=exchange_factory))
+        now = [1_700_000_000.0]
+        monkeypatch.setattr(mod.time, "time", lambda: now[0])
+        adapter._info = mock_info
+
+        with pytest.raises(RuntimeError, match="Failed to initialize Hyperliquid Exchange client"):
+            adapter.market_open("BTC", True, 0.5)
+        assert exchange_calls["n"] == 1
+
+        now[0] += mod._EXCHANGE_INIT_BACKOFF_S + 1
+        with pytest.raises(RuntimeError, match="Failed to initialize Hyperliquid Exchange client"):
+            adapter.market_open("BTC", True, 0.5)
+        assert exchange_calls["n"] == 2, "constructor must retry after backoff window"
+
+    def test_exchange_init_success_after_backoff_uses_cached_exchange(self, monkeypatch):
+        mod, adapter, mock_info, mock_exchange, exchange_calls = self._live_adapter_mod(monkeypatch)
+        err = RuntimeError("(429, None, 'null', None)")
+
+        def exchange_factory(*args, **kwargs):
+            exchange_calls["n"] += 1
+            if exchange_calls["n"] == 1:
+                raise err
+            return mock_exchange
+
+        adapter._exchange = None
+        monkeypatch.setattr(
+            mod,
+            "_HLExchange",
+            MagicMock(side_effect=exchange_factory),
+        )
+        now = [1_700_000_000.0]
+        monkeypatch.setattr(mod.time, "time", lambda: now[0])
+        adapter._info = mock_info
+
+        with pytest.raises(RuntimeError, match="Failed to initialize Hyperliquid Exchange client"):
+            adapter.market_open("BTC", True, 0.5)
+        assert exchange_calls["n"] == 1
+
+        now[0] += mod._EXCHANGE_INIT_BACKOFF_S + 1
+        adapter.market_open("BTC", True, 0.5)
+        assert exchange_calls["n"] == 2
+        assert adapter._exchange is mock_exchange
+
+        adapter.market_open("BTC", True, 0.5)
+        assert exchange_calls["n"] == 2, "cached exchange must not re-init"
+        assert mock_exchange.market_open.call_count == 2
+
     def test_concurrent_lazy_init_calls_exchange_once(self, monkeypatch):
         import threading
 

--- a/scheduler/script_failure_alerts.go
+++ b/scheduler/script_failure_alerts.go
@@ -23,6 +23,12 @@ const scriptFailureAlertThreshold = 3
 // still surfaces the #829 dead-strategy signal.
 const scriptFailureTransientAlertThreshold = 15
 
+// scriptFailureTransientAlertMaxDuration is the wall-clock cap on sustained
+// throttle before operator alert. Calibrated to scriptFailureTransientAlertThreshold
+// at a 5-minute check interval (~75 min) so slow-interval strategies escalate
+// in the same window without waiting for 15 sparse cycles.
+const scriptFailureTransientAlertMaxDuration = 75 * time.Minute
+
 // scriptFailureTransientRE matches operator-visible upstream throttle errors.
 // Deliberately excludes bare "429" substrings (prices, OIDs, counts).
 var scriptFailureTransientRE = regexp.MustCompile(`(?i)(\(429[,\)]|(?:http|status)[\s_]?429|status_code[=:]\s*429|rate.?limit|error from cloudfront)`)
@@ -61,6 +67,7 @@ func scriptFailureModeLabel(mode scriptFailureMode) string {
 type scriptFailureEntry struct {
 	count          int
 	lastErrSig     string // first ~120 bytes of the most recent error
+	firstSeenAt    time.Time
 	lastNotifiedAt time.Time
 	alerted        bool // an alert has fired for the current failure streak
 }
@@ -81,7 +88,7 @@ type ScriptFailureTracker struct {
 // hour) while the streak persists. A change in error signature after the
 // threshold re-alerts immediately so operators see a shifting failure mode.
 func (t *ScriptFailureTracker) Record(strategyID, errSig string, now time.Time) (bool, int) {
-	return recordScriptFailureAtThreshold(t, strategyID, errSig, now, scriptFailureAlertThreshold)
+	return recordScriptFailureAtThreshold(t, strategyID, errSig, now, scriptFailureAlertThreshold, 0)
 }
 
 // Clear resets the failure streak for strategyID after a clean script run and
@@ -136,8 +143,9 @@ func formatScriptFailureTransientAlert(sc StrategyConfig, mode scriptFailureMode
 }
 
 // recordScriptFailureAtThreshold is the shared increment/notify logic for both
-// the primary and transient-only trackers.
-func recordScriptFailureAtThreshold(t *ScriptFailureTracker, strategyID, errSig string, now time.Time, threshold int) (bool, int) {
+// the primary and transient-only trackers. maxDuration>0 allows wall-clock
+// escalation before count reaches threshold (transient tracker only).
+func recordScriptFailureAtThreshold(t *ScriptFailureTracker, strategyID, errSig string, now time.Time, threshold int, maxDuration time.Duration) (bool, int) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.entries == nil {
@@ -151,9 +159,16 @@ func recordScriptFailureAtThreshold(t *ScriptFailureTracker, strategyID, errSig 
 	sig := truncErrSig(errSig)
 	sigChanged := sig != e.lastErrSig
 	e.count++
+	if e.count == 1 {
+		e.firstSeenAt = now
+	}
 	e.lastErrSig = sig
 
-	if e.count < threshold {
+	crossed := e.count >= threshold
+	if !crossed && maxDuration > 0 && !e.firstSeenAt.IsZero() {
+		crossed = now.Sub(e.firstSeenAt) >= maxDuration
+	}
+	if !crossed {
 		return false, e.count
 	}
 
@@ -186,7 +201,8 @@ func notifyScriptFailure(notifier *MultiNotifier, sc StrategyConfig, mode script
 	if scriptFailureErrorIsTransient(errMsg) {
 		fmt.Printf("[WARN] transient script failure [%s]: %s\n", sc.ID, errMsg)
 		shouldNotify, count := recordScriptFailureAtThreshold(
-			scriptFailureTransientTracker, sc.ID, errMsg, now, scriptFailureTransientAlertThreshold)
+			scriptFailureTransientTracker, sc.ID, errMsg, now,
+			scriptFailureTransientAlertThreshold, scriptFailureTransientAlertMaxDuration)
 		if !shouldNotify || notifier == nil || !notifier.HasBackends() {
 			return
 		}

--- a/scheduler/script_failure_alerts.go
+++ b/scheduler/script_failure_alerts.go
@@ -17,10 +17,15 @@ import (
 // blip that clears on the next cycle.
 const scriptFailureAlertThreshold = 3
 
-// scriptFailureTransientRE matches operator-visible errors from transient HL /
-// CDN throttling (#1128). These must not advance the consecutive-failure
-// streak — a 429 storm is not a dead strategy.
-var scriptFailureTransientRE = regexp.MustCompile(`(?i)(\(429[,\)]|\b429\b|rate.?limit|error from cloudfront)`)
+// scriptFailureTransientAlertThreshold is the consecutive transient-only failure
+// count before operator alert (#1128). Higher than scriptFailureAlertThreshold
+// so brief 429 storms stay journald-only, while a sustained IP-level throttle
+// still surfaces the #829 dead-strategy signal.
+const scriptFailureTransientAlertThreshold = 15
+
+// scriptFailureTransientRE matches operator-visible upstream throttle errors.
+// Deliberately excludes bare "429" substrings (prices, OIDs, counts).
+var scriptFailureTransientRE = regexp.MustCompile(`(?i)(\(429[,\)]|(?:http|status)[\s_]?429|status_code[=:]\s*429|rate.?limit|error from cloudfront)`)
 
 // scriptFailureErrorIsTransient reports whether errMsg is a short-lived
 // upstream throttle that should not count toward the 3-strike alert.
@@ -135,6 +140,10 @@ func (t *ScriptFailureTracker) Clear(strategyID string) (bool, int) {
 // scriptFailureTracker is the package-level singleton; resets on restart.
 var scriptFailureTracker = &ScriptFailureTracker{}
 
+// scriptFailureTransientTracker counts consecutive throttle-only failures per
+// strategy; cleared on recovery alongside scriptFailureTracker.
+var scriptFailureTransientTracker = &ScriptFailureTracker{}
+
 // formatScriptFailureAlert builds the operator message for a failing signal
 // script. count is the consecutive-failure count after incrementing. The
 // scheduler PID is included so operators can tell which process is producing
@@ -153,6 +162,53 @@ func formatScriptRecoveredAlert(sc StrategyConfig, priorCount int) string {
 		sc.ID, sc.Platform, sc.Script, os.Getpid(), priorCount)
 }
 
+// formatScriptFailureTransientAlert builds the operator message when a strategy
+// has been failing with upstream throttle errors long enough to escalate.
+func formatScriptFailureTransientAlert(sc StrategyConfig, mode scriptFailureMode, errMsg string, count int) string {
+	return fmt.Sprintf("**SIGNAL SCRIPT FAILING (sustained upstream throttle)** [%s] %s %s (pid=%d, %s, %d consecutive transient failures): %s",
+		sc.ID, sc.Platform, sc.Script, os.Getpid(), scriptFailureModeLabel(mode), count, errMsg)
+}
+
+// recordScriptFailureAtThreshold is the shared increment/notify logic for both
+// the primary and transient-only trackers.
+func recordScriptFailureAtThreshold(t *ScriptFailureTracker, strategyID, errSig string, now time.Time, threshold int) (bool, int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.entries == nil {
+		t.entries = make(map[string]*scriptFailureEntry)
+	}
+	e := t.entries[strategyID]
+	if e == nil {
+		e = &scriptFailureEntry{}
+		t.entries[strategyID] = e
+	}
+	sig := truncErrSig(errSig)
+	sigChanged := sig != e.lastErrSig
+	e.count++
+	e.lastErrSig = sig
+
+	if e.count < threshold {
+		return false, e.count
+	}
+
+	shouldNotify := false
+	switch {
+	case !e.alerted:
+		shouldNotify = true
+	case sigChanged:
+		shouldNotify = true
+	case e.count%10 == 0:
+		shouldNotify = true
+	case !e.lastNotifiedAt.IsZero() && now.Sub(e.lastNotifiedAt) >= time.Hour:
+		shouldNotify = true
+	}
+	if shouldNotify {
+		e.alerted = true
+		e.lastNotifiedAt = now
+	}
+	return shouldNotify, e.count
+}
+
 // notifyScriptFailure records a signal-script failure for sc and fires a
 // throttled operator alert once the consecutive-failure streak crosses
 // scriptFailureAlertThreshold. mode distinguishes a hard crash (no JSON) from a
@@ -160,12 +216,20 @@ func formatScriptRecoveredAlert(sc StrategyConfig, priorCount int) string {
 // always recorded — even with no notifier backends — so the count and recovery
 // state stay accurate; nil/empty notifier just suppresses the send.
 func notifyScriptFailure(notifier *MultiNotifier, sc StrategyConfig, mode scriptFailureMode, errMsg string) {
+	now := time.Now().UTC()
 	if scriptFailureErrorIsTransient(errMsg) {
-		fmt.Printf("[WARN] transient script failure (streak not incremented) [%s]: %s\n",
-			sc.ID, errMsg)
+		fmt.Printf("[WARN] transient script failure [%s]: %s\n", sc.ID, errMsg)
+		shouldNotify, count := recordScriptFailureAtThreshold(
+			scriptFailureTransientTracker, sc.ID, errMsg, now, scriptFailureTransientAlertThreshold)
+		if !shouldNotify || notifier == nil || !notifier.HasBackends() {
+			return
+		}
+		msg := formatScriptFailureTransientAlert(sc, mode, errMsg, count)
+		notifier.SendToAllChannels(msg)
+		notifier.SendOwnerDM(msg)
 		return
 	}
-	shouldNotify, count := scriptFailureTracker.Record(sc.ID, errMsg, time.Now().UTC())
+	shouldNotify, count := scriptFailureTracker.Record(sc.ID, errMsg, now)
 	if !shouldNotify || notifier == nil || !notifier.HasBackends() {
 		return
 	}
@@ -179,10 +243,18 @@ func notifyScriptFailure(notifier *MultiNotifier, sc StrategyConfig, mode script
 // notice. Safe to call every cycle: it no-ops when no streak is active.
 func clearScriptFailure(notifier *MultiNotifier, sc StrategyConfig) {
 	recovered, priorCount := scriptFailureTracker.Clear(sc.ID)
-	if !recovered || notifier == nil || !notifier.HasBackends() {
+	transientRecovered, transientPrior := scriptFailureTransientTracker.Clear(sc.ID)
+	if !recovered && !transientRecovered {
 		return
 	}
-	msg := formatScriptRecoveredAlert(sc, priorCount)
+	if notifier == nil || !notifier.HasBackends() {
+		return
+	}
+	prior := priorCount
+	if transientPrior > prior {
+		prior = transientPrior
+	}
+	msg := formatScriptRecoveredAlert(sc, prior)
 	notifier.SendToAllChannels(msg)
 	notifier.SendOwnerDM(msg)
 }

--- a/scheduler/script_failure_alerts.go
+++ b/scheduler/script_failure_alerts.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"sync"
 	"time"
 )
@@ -15,6 +16,17 @@ import (
 // strikes balances detection latency against noise from a transient indexer
 // blip that clears on the next cycle.
 const scriptFailureAlertThreshold = 3
+
+// scriptFailureTransientRE matches operator-visible errors from transient HL /
+// CDN throttling (#1128). These must not advance the consecutive-failure
+// streak — a 429 storm is not a dead strategy.
+var scriptFailureTransientRE = regexp.MustCompile(`(?i)(\(429[,\)]|\b429\b|rate.?limit|error from cloudfront)`)
+
+// scriptFailureErrorIsTransient reports whether errMsg is a short-lived
+// upstream throttle that should not count toward the 3-strike alert.
+func scriptFailureErrorIsTransient(errMsg string) bool {
+	return scriptFailureTransientRE.MatchString(errMsg)
+}
 
 // scriptFailureMode distinguishes the two ways a signal-check subprocess can
 // fail. Both count toward the same per-strategy consecutive-failure tally —
@@ -148,6 +160,11 @@ func formatScriptRecoveredAlert(sc StrategyConfig, priorCount int) string {
 // always recorded — even with no notifier backends — so the count and recovery
 // state stay accurate; nil/empty notifier just suppresses the send.
 func notifyScriptFailure(notifier *MultiNotifier, sc StrategyConfig, mode scriptFailureMode, errMsg string) {
+	if scriptFailureErrorIsTransient(errMsg) {
+		fmt.Printf("[WARN] transient script failure (streak not incremented) [%s]: %s\n",
+			sc.ID, errMsg)
+		return
+	}
 	shouldNotify, count := scriptFailureTracker.Record(sc.ID, errMsg, time.Now().UTC())
 	if !shouldNotify || notifier == nil || !notifier.HasBackends() {
 		return

--- a/scheduler/script_failure_alerts.go
+++ b/scheduler/script_failure_alerts.go
@@ -81,41 +81,7 @@ type ScriptFailureTracker struct {
 // hour) while the streak persists. A change in error signature after the
 // threshold re-alerts immediately so operators see a shifting failure mode.
 func (t *ScriptFailureTracker) Record(strategyID, errSig string, now time.Time) (bool, int) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.entries == nil {
-		t.entries = make(map[string]*scriptFailureEntry)
-	}
-	e := t.entries[strategyID]
-	if e == nil {
-		e = &scriptFailureEntry{}
-		t.entries[strategyID] = e
-	}
-	sig := truncErrSig(errSig)
-	sigChanged := sig != e.lastErrSig
-	e.count++
-	e.lastErrSig = sig
-
-	if e.count < scriptFailureAlertThreshold {
-		return false, e.count
-	}
-
-	shouldNotify := false
-	switch {
-	case !e.alerted:
-		shouldNotify = true // first alert for this streak (threshold crossed)
-	case sigChanged:
-		shouldNotify = true // failure character changed mid-streak
-	case e.count%10 == 0:
-		shouldNotify = true
-	case !e.lastNotifiedAt.IsZero() && now.Sub(e.lastNotifiedAt) >= time.Hour:
-		shouldNotify = true
-	}
-	if shouldNotify {
-		e.alerted = true
-		e.lastNotifiedAt = now
-	}
-	return shouldNotify, e.count
+	return recordScriptFailureAtThreshold(t, strategyID, errSig, now, scriptFailureAlertThreshold)
 }
 
 // Clear resets the failure streak for strategyID after a clean script run and

--- a/scheduler/script_failure_alerts_test.go
+++ b/scheduler/script_failure_alerts_test.go
@@ -167,6 +167,10 @@ func TestScriptFailureErrorIsTransient(t *testing.T) {
 		{"Failed to initialize Hyperliquid Exchange client: (429, None, 'null', None)", true},
 		{"hl rate limited", true},
 		{"X-Cache: Error from cloudfront", true},
+		{"HTTP 429 Too Many Requests", true},
+		{"status_code=429 from HL", true},
+		{"order oid 429 rejected by exchange", false},
+		{"price crossed 42900.5", false},
 		{"list index out of range", false},
 		{"connection refused", false},
 	}
@@ -177,9 +181,12 @@ func TestScriptFailureErrorIsTransient(t *testing.T) {
 	}
 }
 
-func TestNotifyScriptFailure_Transient429SkipsStreak(t *testing.T) {
-	id := "transient-skip-1128"
-	defer scriptFailureTracker.Clear(id)
+func TestNotifyScriptFailure_BriefTransientSkipsPrimaryStreak(t *testing.T) {
+	id := "transient-brief-1128"
+	defer func() {
+		scriptFailureTracker.Clear(id)
+		scriptFailureTransientTracker.Clear(id)
+	}()
 	sc := StrategyConfig{ID: id, Platform: "hyperliquid", Script: "check_regime.py"}
 	err429 := "Failed to initialize Hyperliquid Exchange client: (429, None)"
 	for i := 0; i < scriptFailureAlertThreshold+2; i++ {
@@ -187,6 +194,57 @@ func TestNotifyScriptFailure_Transient429SkipsStreak(t *testing.T) {
 	}
 	shouldNotify, count := scriptFailureTracker.Record(id, "connection refused", time.Now().UTC())
 	if shouldNotify || count != 1 {
-		t.Fatalf("transient-only notify must not advance streak: notify=%v count=%d, want false/1", shouldNotify, count)
+		t.Fatalf("brief transient must not advance primary streak: notify=%v count=%d, want false/1", shouldNotify, count)
+	}
+}
+
+func TestNotifyScriptFailure_SustainedTransientAlerts(t *testing.T) {
+	id := "transient-sustained-1128"
+	defer func() {
+		scriptFailureTracker.Clear(id)
+		scriptFailureTransientTracker.Clear(id)
+	}()
+	sc := StrategyConfig{ID: id, Platform: "hyperliquid", Script: "check_regime.py"}
+	err429 := "Failed to initialize Hyperliquid Exchange client: (429, None)"
+	for i := 0; i < scriptFailureTransientAlertThreshold; i++ {
+		notifyScriptFailure(nil, sc, scriptFailureError, err429)
+	}
+	recovered, prior := scriptFailureTransientTracker.Clear(id)
+	if !recovered || prior != scriptFailureTransientAlertThreshold {
+		t.Fatalf("sustained transient: recovered=%v prior=%d, want true/%d", recovered, prior, scriptFailureTransientAlertThreshold)
+	}
+}
+
+func TestNotifyScriptFailure_AlternatingTransientAndRealStillAlerts(t *testing.T) {
+	id := "transient-alternate-1128"
+	defer func() {
+		scriptFailureTracker.Clear(id)
+		scriptFailureTransientTracker.Clear(id)
+	}()
+	sc := StrategyConfig{ID: id, Platform: "hyperliquid", Script: "check_hyperliquid.py"}
+	err429 := "Failed to initialize Hyperliquid Exchange client: (429, None)"
+	for i := 0; i < scriptFailureAlertThreshold; i++ {
+		notifyScriptFailure(nil, sc, scriptFailureError, err429)
+		notifyScriptFailure(nil, sc, scriptFailureError, "connection refused")
+	}
+	recovered, prior := scriptFailureTracker.Clear(id)
+	if !recovered || prior != scriptFailureAlertThreshold {
+		t.Fatalf("alternating real errors must alert primary tracker: recovered=%v prior=%d", recovered, prior)
+	}
+}
+
+func TestClearScriptFailure_ClearsTransientTracker(t *testing.T) {
+	id := "transient-clear-1128"
+	defer func() {
+		scriptFailureTracker.Clear(id)
+		scriptFailureTransientTracker.Clear(id)
+	}()
+	now := time.Now().UTC()
+	for i := 0; i < scriptFailureTransientAlertThreshold; i++ {
+		recordScriptFailureAtThreshold(scriptFailureTransientTracker, id, "HTTP 429", now, scriptFailureTransientAlertThreshold)
+	}
+	recovered, prior := scriptFailureTransientTracker.Clear(id)
+	if !recovered || prior != scriptFailureTransientAlertThreshold {
+		t.Fatalf("transient clear: recovered=%v prior=%d", recovered, prior)
 	}
 }

--- a/scheduler/script_failure_alerts_test.go
+++ b/scheduler/script_failure_alerts_test.go
@@ -241,10 +241,54 @@ func TestClearScriptFailure_ClearsTransientTracker(t *testing.T) {
 	}()
 	now := time.Now().UTC()
 	for i := 0; i < scriptFailureTransientAlertThreshold; i++ {
-		recordScriptFailureAtThreshold(scriptFailureTransientTracker, id, "HTTP 429", now, scriptFailureTransientAlertThreshold)
+		recordScriptFailureAtThreshold(scriptFailureTransientTracker, id, "HTTP 429", now, scriptFailureTransientAlertThreshold, scriptFailureTransientAlertMaxDuration)
 	}
 	recovered, prior := scriptFailureTransientTracker.Clear(id)
 	if !recovered || prior != scriptFailureTransientAlertThreshold {
 		t.Fatalf("transient clear: recovered=%v prior=%d", recovered, prior)
+	}
+}
+
+func TestScriptFailureTransientTracker_WallClockEscalation(t *testing.T) {
+	tr := &ScriptFailureTracker{}
+	t0 := time.Unix(1700000000, 0).UTC()
+	err429 := "HTTP 429"
+	id := "slow-interval-wallclock-1128"
+
+	if notify, count := recordScriptFailureAtThreshold(tr, id, err429, t0, scriptFailureTransientAlertThreshold, scriptFailureTransientAlertMaxDuration); notify || count != 1 {
+		t.Fatalf("first failure: notify=%v count=%d, want false/1", notify, count)
+	}
+	// Two sparse 1h-interval failures: count stays below 15 but wall-clock bound fires.
+	tLate := t0.Add(scriptFailureTransientAlertMaxDuration + time.Minute)
+	if notify, count := recordScriptFailureAtThreshold(tr, id, err429, tLate, scriptFailureTransientAlertThreshold, scriptFailureTransientAlertMaxDuration); !notify || count != 2 {
+		t.Fatalf("wall-clock escalation: notify=%v count=%d, want true/2", notify, count)
+	}
+}
+
+func TestScriptFailureTransientTracker_BriefStormStaysSilent(t *testing.T) {
+	tr := &ScriptFailureTracker{}
+	t0 := time.Unix(1700000000, 0).UTC()
+	err429 := "HTTP 429"
+	id := "brief-storm-wallclock-1128"
+
+	for i := 1; i < scriptFailureTransientAlertThreshold; i++ {
+		if notify, count := recordScriptFailureAtThreshold(tr, id, err429, t0.Add(time.Duration(i)*time.Second), scriptFailureTransientAlertThreshold, scriptFailureTransientAlertMaxDuration); notify {
+			t.Fatalf("failure %d: unexpected alert during brief storm under count and duration bounds", i)
+		} else if count != i {
+			t.Fatalf("failure %d: count=%d, want %d", i, count, i)
+		}
+	}
+}
+
+func TestScriptFailureTransientTracker_RecoveryResetsWallClock(t *testing.T) {
+	tr := &ScriptFailureTracker{}
+	t0 := time.Unix(1700000000, 0).UTC()
+	err429 := "HTTP 429"
+	id := "wallclock-recovery-1128"
+
+	recordScriptFailureAtThreshold(tr, id, err429, t0, scriptFailureTransientAlertThreshold, scriptFailureTransientAlertMaxDuration)
+	tr.Clear(id)
+	if notify, count := recordScriptFailureAtThreshold(tr, id, err429, t0.Add(scriptFailureTransientAlertMaxDuration+time.Minute), scriptFailureTransientAlertThreshold, scriptFailureTransientAlertMaxDuration); notify || count != 1 {
+		t.Fatalf("post-recovery streak must restart: notify=%v count=%d, want false/1", notify, count)
 	}
 }

--- a/scheduler/script_failure_alerts_test.go
+++ b/scheduler/script_failure_alerts_test.go
@@ -158,3 +158,35 @@ func TestFormatScriptRecoveredAlert(t *testing.T) {
 		t.Fatalf("recovery alert missing fields: %q", msg)
 	}
 }
+
+func TestScriptFailureErrorIsTransient(t *testing.T) {
+	cases := []struct {
+		msg   string
+		want  bool
+	}{
+		{"Failed to initialize Hyperliquid Exchange client: (429, None, 'null', None)", true},
+		{"hl rate limited", true},
+		{"X-Cache: Error from cloudfront", true},
+		{"list index out of range", false},
+		{"connection refused", false},
+	}
+	for _, tc := range cases {
+		if got := scriptFailureErrorIsTransient(tc.msg); got != tc.want {
+			t.Fatalf("transient(%q) = %v, want %v", tc.msg, got, tc.want)
+		}
+	}
+}
+
+func TestNotifyScriptFailure_Transient429SkipsStreak(t *testing.T) {
+	id := "transient-skip-1128"
+	defer scriptFailureTracker.Clear(id)
+	sc := StrategyConfig{ID: id, Platform: "hyperliquid", Script: "check_regime.py"}
+	err429 := "Failed to initialize Hyperliquid Exchange client: (429, None)"
+	for i := 0; i < scriptFailureAlertThreshold+2; i++ {
+		notifyScriptFailure(nil, sc, scriptFailureError, err429)
+	}
+	shouldNotify, count := scriptFailureTracker.Record(id, "connection refused", time.Now().UTC())
+	if shouldNotify || count != 1 {
+		t.Fatalf("transient-only notify must not advance streak: notify=%v count=%d, want false/1", shouldNotify, count)
+	}
+}

--- a/scheduler/script_failure_alerts_test.go
+++ b/scheduler/script_failure_alerts_test.go
@@ -161,8 +161,8 @@ func TestFormatScriptRecoveredAlert(t *testing.T) {
 
 func TestScriptFailureErrorIsTransient(t *testing.T) {
 	cases := []struct {
-		msg   string
-		want  bool
+		msg  string
+		want bool
 	}{
 		{"Failed to initialize Hyperliquid Exchange client: (429, None, 'null', None)", true},
 		{"hl rate limited", true},


### PR DESCRIPTION
## Summary
- Defer Hyperliquid SDK `Exchange` construction until the first trading call; regime/signal subprocesses keep using eager cached `Info` for OHLCV only (#1128).
- Pass cached `meta`/`spot_meta` into lazy `Exchange` init to avoid a second uncached embedded `Info`.
- Add 30s in-process backoff after Exchange init failure; OHLCV paths stay usable.
- Exempt HL 429 / rate-limit / CloudFront throttle errors from `scriptFailureTracker` streak increments (still WARN-logged).

## Test plan
- [x] `pytest platforms/hyperliquid/test_adapter.py platforms/hyperliquid/test_meta_cache.py` (92 passed)
- [x] `go test -run 'TestScriptFailure|TestNotifyScriptFailure|TestFormatScript' ./scheduler`

Closes #1128

LLM: Composer | high | Harness: Cursor