### PR TITLE
[#1124] Synthesis: Opus minimal base + GLM directional-family rule

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -88,6 +88,7 @@ _close_registry = None
 # Regime helper imported lazily so backtests without regime_enabled=True
 # don't pay the import cost.
 _ensure_regime_fn = None
+_regime_allows_entry_fn = None
 
 # Post-TP SL helpers (#709). Loaded via spec_from_file_location to avoid the
 # same registry-name collision that close_registry_loader works around — this
@@ -98,11 +99,27 @@ _trailing_ratchet_module = None
 
 
 def _load_regime():
-    global _ensure_regime_fn
+    global _ensure_regime_fn, _regime_allows_entry_fn
     if _ensure_regime_fn is None:
         from regime import ensure_regime_columns as _ensure_regime_columns
+        from regime import regime_label_allows_entry as _allows_entry
         _ensure_regime_fn = _ensure_regime_columns
+        _regime_allows_entry_fn = _allows_entry
     return _ensure_regime_fn
+
+
+def _regime_allows_entry(allowed, bar_regime: str) -> bool:
+    """#1124 entry-gate with the one-directional directional family rule.
+
+    A bare ``ranging_directional`` in ``allowed`` matches its ``_up``/``_down``
+    sub-labels, mirroring the Go ``regimeAllowsEntry`` gate for live/backtest
+    parity. Falls back to plain membership if the regime module isn't loaded.
+    """
+    if _regime_allows_entry_fn is None:
+        _load_regime()
+    if _regime_allows_entry_fn is None:
+        return (not allowed) or (not bar_regime) or (bar_regime in allowed)
+    return _regime_allows_entry_fn(allowed, bar_regime)
 
 
 def _regime_primary_labels(spec: Optional[dict]) -> Optional[tuple]:
@@ -1725,7 +1742,7 @@ class Backtester:
             regime_blocked = (
                 self.regime_enabled
                 and bool(self.allowed_regimes)
-                and bar_regime not in self.allowed_regimes
+                and not _regime_allows_entry(self.allowed_regimes, bar_regime)
             )
 
             if uses_open_close:

--- a/backtest/tests/test_backtester_composite_regime.py
+++ b/backtest/tests/test_backtester_composite_regime.py
@@ -74,8 +74,14 @@ def test_composite_label_allows_entry_when_gate_matches(label):
 
 @pytest.mark.parametrize("label", COMPOSITE_LABELS)
 def test_composite_label_blocks_entry_when_gate_mismatches(label):
-    # Pick any distinct label to gate on — the bar is ``label`` so it must block.
-    other = next(l for l in COMPOSITE_LABELS if l != label)
+    # Pick a label that does NOT cover ``label`` under the #1124 family rule.
+    # For the _up/_down sub-labels the bare ranging_directional covers them, so
+    # a gate on bare would (correctly) allow — exclude the bare parent here too.
+    covered_by = {"ranging_directional_up", "ranging_directional_down"}
+    if label in covered_by:
+        other = next(l for l in COMPOSITE_LABELS if l != label and l != "ranging_directional")
+    else:
+        other = next(l for l in COMPOSITE_LABELS if l != label)
     df = _gated_df(label)
     bt = Backtester(
         initial_capital=1000, commission_pct=0, slippage_pct=0,
@@ -160,3 +166,35 @@ def test_composite_regime_flip_does_not_close_open_position():
     result = bt.run(df, save=False)
     assert result["total_trades"] == 1
     assert result["trades"][0]["exit_price"] > 0
+
+
+# ─── #1124: bare ranging_directional covers its _up/_down sub-labels ─────────
+
+
+@pytest.mark.parametrize("sub", ["ranging_directional_up", "ranging_directional_down"])
+def test_bare_ranging_directional_covers_sub_label_entry(sub):
+    """#1124 family rule on the entry gate: an allowed_regimes listing only the
+    bare ``ranging_directional`` must still permit entries on ``_up``/``_down``
+    bars (the producer relabels non-zero drift). Mirrors the Go gate for parity.
+    """
+    df = _gated_df(sub)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_enabled=True, allowed_regimes=["ranging_directional"],
+    )
+    assert bt.run(df, save=False)["total_trades"] >= 1
+
+
+def test_explicit_sub_label_does_not_cover_bare_or_sibling_entry():
+    """#1124: the family expansion is one-directional (bare→subs). An operator
+    listing only ``ranging_directional_up`` gates OUT the bare label and the
+    ``_down`` sibling — never the reverse."""
+    for bar in ["ranging_directional", "ranging_directional_down"]:
+        df = _gated_df(bar)
+        bt = Backtester(
+            initial_capital=1000, commission_pct=0, slippage_pct=0,
+            regime_enabled=True, allowed_regimes=["ranging_directional_up"],
+        )
+        assert bt.run(df, save=False)["total_trades"] == 0, (
+            f"explicit _up must NOT cover bar '{bar}'"
+        )

--- a/backtest/tests/test_backtester_composite_regime_wiring.py
+++ b/backtest/tests/test_backtester_composite_regime_wiring.py
@@ -613,6 +613,8 @@ _COMPOSITE_SL_BLOCK = {"trend_regime": {
     "ranging_quiet": {"atr_multiple": 1.2},
     "ranging_volatile": {"atr_multiple": 1.5},
     "ranging_directional": {"atr_multiple": 1.4},
+    "ranging_directional_up": {"atr_multiple": 1.4},
+    "ranging_directional_down": {"atr_multiple": 1.4},
 }}
 _ADX_SL_BLOCK = {"trend_regime": {
     "trending_up": {"atr_multiple": 2.0},

--- a/scheduler/manual_ratchet_regime_default_test.go
+++ b/scheduler/manual_ratchet_regime_default_test.go
@@ -156,12 +156,13 @@ func TestManualDefault_RegimeComposite_SelectsRatchetRegime(t *testing.T) {
 		t.Fatalf("StopLossATRMult = %v, want nil", *sc.StopLossATRMult)
 	}
 	block := sc.TrailingStopATRRegime
-	if block == nil || len(block.TrendRegime) != 7 {
-		t.Fatalf("trailing_stop_atr_regime must resolve to 7 composite labels, got %#v", block)
+	if block == nil || len(block.TrendRegime) != 9 {
+		t.Fatalf("trailing_stop_atr_regime must resolve to 9 composite labels, got %#v", block)
 	}
 	for _, label := range []string{
 		"trending_up_clean", "trending_up_choppy", "trending_down_clean",
 		"trending_down_choppy", "ranging_quiet", "ranging_volatile", "ranging_directional",
+		"ranging_directional_up", "ranging_directional_down",
 	} {
 		if v, ok := resolveRegimeATR(*block, label); !ok || v <= 0 {
 			t.Fatalf("opening trail for composite label %q = (%g, %v), want positive", label, v, ok)

--- a/scheduler/post_tp_sl.go
+++ b/scheduler/post_tp_sl.go
@@ -76,8 +76,18 @@ func (b *RegimeFloatBlock) Resolve(regime string) (float64, bool) {
 	if b == nil || len(b.TrendRegime) == 0 {
 		return 0, false
 	}
-	v, ok := b.TrendRegime[strings.TrimSpace(regime)]
-	return v, ok
+	r := strings.TrimSpace(regime)
+	if v, ok := b.TrendRegime[r]; ok {
+		return v, true
+	}
+	// #1124: sub-label stamp falls back to the bare ranging_directional entry
+	// (exact match wins first, so an explicit sub key still overrides bare).
+	if regimeDirectionalSubs[r] {
+		if v, ok := b.TrendRegime[regimeDirectionalBare]; ok {
+			return v, true
+		}
+	}
+	return 0, false
 }
 
 func (b *RegimeFloatBlock) EqualForReload(other *RegimeFloatBlock) bool {
@@ -525,10 +535,18 @@ func parseRegimeFloatBlock(raw map[string]interface{}, ctxLabel string, labels [
 			ctxLabel, regimeClassifierKey, label, strings.Join(labels, ", ")))
 	}
 	missing := make([]string, 0)
+	// #1124: bare `ranging_directional` covers its _up/_down sub-labels for
+	// exhaustiveness (back-compat — Resolve resolves the whole family at runtime
+	// via its bare fallback). Sub-labels-only (no bare parent) is still flagged.
+	bareDirectional := trend[regimeDirectionalBare] != nil
 	for _, label := range labels {
-		if _, ok := trend[label]; !ok {
-			missing = append(missing, label)
+		if _, ok := trend[label]; ok {
+			continue
 		}
+		if regimeLabelFamilyCovered(label, bareDirectional) {
+			continue
+		}
+		missing = append(missing, label)
 	}
 	if len(missing) > 0 {
 		errs = append(errs, fmt.Sprintf("%s.%s: missing required regime labels: %s (must be exhaustive — no silent fallback)",

--- a/scheduler/regime.go
+++ b/scheduler/regime.go
@@ -1,5 +1,7 @@
 package main
 
+import "strings"
+
 // regimeAllowsEntry reports whether the current market regime permits a new
 // entry for a strategy. Returns true when:
 //   - allowed is empty (no gate configured), OR
@@ -8,13 +10,29 @@ package main
 //
 // This is the core regime check; callers gate it on "is this an open?" via
 // regimeBlocksOpen so close legs always pass through.
+//
+// #1124: a bare `ranging_directional` in `allowed` matches its `_up`/`_down`
+// sub-labels (the producer relabels non-zero drift). The expansion is
+// one-directional — bare→subs — so an operator listing an explicit `_up`
+// still gates out `_down`. This mirrors the family rule applied to the
+// regime-keyed close blocks so the producer relabeling never silently re-gates
+// a previously-entering strategy.
 func regimeAllowsEntry(allowed []string, current string) bool {
 	if len(allowed) == 0 || current == "" {
 		return true
 	}
+	cur := strings.TrimSpace(current)
 	for _, label := range allowed {
-		if label == current {
+		if label == cur {
 			return true
+		}
+	}
+	// bare ranging_directional covers its #1124 sub-labels.
+	if regimeDirectionalSubs[cur] {
+		for _, label := range allowed {
+			if label == regimeDirectionalBare {
+				return true
+			}
 		}
 	}
 	return false

--- a/scheduler/regime_atr.go
+++ b/scheduler/regime_atr.go
@@ -37,6 +37,35 @@ import (
 // use_defaults, every label here must appear in the trend_regime map.
 var canonicalTrendRegimeLabels = []string{"trending_up", "trending_down", "ranging"}
 
+// regimeDirectionalBare is the bare ranging-directional label, whose
+// `ranging_directional_up`/`_down` sub-labels the producer (#1124) splits out
+// by drift sign. The bare label remains the exact-zero neutral fallback the
+// producer emits at return_eff == 0, so it is the parent of the family.
+const regimeDirectionalBare = "ranging_directional"
+
+// regimeDirectionalSubs is the set of #1124 directional sub-labels that the
+// bare `ranging_directional` label covers for exhaustiveness and runtime
+// resolution. Kept as a helper so every consumer applies the family rule
+// symmetrically (a missed consumer is a silent never-arm of an auto-protective
+// SL/exit — see #1124 review). The rule is one-directional: bare covers its
+// subs, never the reverse, so an explicit `_up`/`_down` key always wins on an
+// exact match and the bare fallback only fires on a miss.
+var regimeDirectionalSubs = map[string]bool{
+	"ranging_directional_up":   true,
+	"ranging_directional_down": true,
+}
+
+// regimeLabelFamilyCovered reports whether an omitted `label` is nevertheless
+// satisfied for exhaustiveness because the bare `ranging_directional` parent
+// is present (`bareDirectionalPresent`). This is the back-compat rule: a
+// 7-label composite block keyed on bare `ranging_directional` still covers
+// the `_up`/`_down` sub-labels, so it must not be rejected as non-exhaustive.
+// Sub-labels-only (no bare parent) is NOT covered — the producer still emits
+// the bare label at return_eff == 0, so omitting it leaves a naked-SL hole.
+func regimeLabelFamilyCovered(label string, bareDirectionalPresent bool) bool {
+	return bareDirectionalPresent && regimeDirectionalSubs[strings.TrimSpace(label)]
+}
+
 // regimeClassifierKey is the wrapper key required around per-label blocks.
 // Reserves space for future classifiers (e.g. "vol_regime") to land as
 // sibling keys without renaming.
@@ -202,12 +231,28 @@ func (b *RegimeATRBlock) IsConfigured() bool {
 // Resolve returns the per-label entry for the given regime. The caller is
 // responsible for validating the block at config-load time so this can
 // assume label presence. Returns (entry, true) on hit, (zero, false) on miss.
+//
+// #1124: a `ranging_directional_up`/`_down` regime stamp falls back to the bare
+// `ranging_directional` entry when the block doesn't carry an explicit sub-label
+// key (the back-compat shape — bare label covers the whole directional family).
+// Exact match wins first, so an explicit sub key always overrides the bare
+// entry. This keeps runtime resolution aligned with the exhaustiveness rule: a
+// bare-only block is exhaustive, so it must also resolve at runtime.
 func (b RegimeATRBlock) Resolve(regime string) (RegimeATREntry, bool) {
 	if b.TrendRegime == nil {
 		return RegimeATREntry{}, false
 	}
-	entry, ok := b.TrendRegime[strings.TrimSpace(regime)]
-	return entry, ok
+	r := strings.TrimSpace(regime)
+	if entry, ok := b.TrendRegime[r]; ok {
+		return entry, true
+	}
+	// #1124: sub-label stamp falls back to the bare ranging_directional entry.
+	if regimeDirectionalSubs[r] {
+		if entry, ok := b.TrendRegime[regimeDirectionalBare]; ok {
+			return entry, true
+		}
+	}
+	return RegimeATREntry{}, false
 }
 
 // regimeATRDefaults holds the per-surface baseline expansions for
@@ -456,10 +501,24 @@ func parseRegimeATRBlock(raw map[string]interface{}, ctxLabel string, surface re
 	}
 
 	missingLabels := []string{}
+	// #1124: the ranging_directional family — bare `ranging_directional` plus
+	// its `ranging_directional_up`/`_down` sub-labels — is satisfied for
+	// exhaustiveness when the bare label is present (it covers all three at
+	// runtime via Resolve's bare fallback, including the return_eff==0 neutral
+	// case the producer still emits). Providing only the sub-labels without the
+	// bare label is NOT exhaustive (the neutral case would resolve to nil →
+	// silent never-arm of an auto-protective exit). So a present bare label
+	// covers its sub-labels, and a missing bare label is flagged even when both
+	// sub-labels exist.
+	bareDirectional := trendMap[regimeDirectionalBare] != nil
 	for _, l := range labels {
-		if _, ok := trendMap[l]; !ok {
-			missingLabels = append(missingLabels, l)
+		if _, ok := trendMap[l]; ok {
+			continue
 		}
+		if regimeLabelFamilyCovered(l, bareDirectional) {
+			continue
+		}
+		missingLabels = append(missingLabels, l)
 	}
 	if len(missingLabels) > 0 {
 		errs = append(errs, fmt.Sprintf("%s.%s: missing required regime labels: %s (must be exhaustive — no silent fallback)", ctxLabel, regimeClassifierKey, strings.Join(missingLabels, ", ")))

--- a/scheduler/regime_atr.go
+++ b/scheduler/regime_atr.go
@@ -236,6 +236,12 @@ var regimeATRDefaults = struct {
 		"ranging_quiet":        {ATR: 1.0},
 		"ranging_volatile":     {ATR: 1.0},
 		"ranging_directional":  {ATR: 1.0},
+		// #1124: directional-drift substates inherit the tight ranging_directional
+		// opening trail (1.0). Explicit entries keep parity with the bare label —
+		// without them mapRegimeToBaselineFamily would fall the _up/_down labels
+		// back to the wider "ranging" family (2.0), silently loosening the trail.
+		"ranging_directional_up":   {ATR: 1.0},
+		"ranging_directional_down": {ATR: 1.0},
 	},
 }
 
@@ -278,7 +284,7 @@ var regimeTPTierGroupDefaults = map[string][]hlProtectionTier{
 var regimeTPFleetDefaultLabelsByGroup = map[string][]string{
 	"clean":   {"trending_up_clean", "trending_down_clean"},
 	"choppy":  {"trending_up", "trending_down", "trending_up_choppy", "trending_down_choppy"},
-	"ranging": {"ranging", "ranging_quiet", "ranging_volatile", "ranging_directional"},
+	"ranging": {"ranging", "ranging_quiet", "ranging_volatile", "ranging_directional", "ranging_directional_up", "ranging_directional_down"},
 }
 
 // defaultRegimeBlockForSurface returns the baseline trend_regime map for a

--- a/scheduler/regime_atr_composite_test.go
+++ b/scheduler/regime_atr_composite_test.go
@@ -59,8 +59,8 @@ func TestValidateRegimeATRConfig_CompositeStopLossExplicit(t *testing.T) {
 		t.Fatalf("composite stop_loss_atr_regime must validate, got: %v", errs)
 	}
 	block := cfg.Strategies[0].StopLossATRRegime
-	if got := len(block.TrendRegime); got != 7 {
-		t.Fatalf("block must be populated with all 7 composite labels, got %d: %v", got, block.TrendRegime)
+	if got := len(block.TrendRegime); got != 9 {
+		t.Fatalf("block must be populated with all 9 composite labels, got %d: %v", got, block.TrendRegime)
 	}
 	// Runtime SL resolution must succeed for a composite label (proves the
 	// authoritative pass populated the composite vocabulary, not ADX).
@@ -116,8 +116,8 @@ func TestValidateRegimeATRConfig_CompositeTrailingExplicit(t *testing.T) {
 	if errs := validateRegimeATRConfig(cfg); len(errs) != 0 {
 		t.Fatalf("composite trailing_stop_atr_regime must validate, got: %v", errs)
 	}
-	if got := len(cfg.Strategies[0].TrailingStopATRRegime.TrendRegime); got != 7 {
-		t.Fatalf("trailing block must hold 7 composite labels, got %d", got)
+	if got := len(cfg.Strategies[0].TrailingStopATRRegime.TrendRegime); got != 9 {
+		t.Fatalf("trailing block must hold 9 composite labels, got %d", got)
 	}
 }
 
@@ -243,6 +243,10 @@ func TestMapRegimeToBaselineFamily(t *testing.T) {
 		{"trending_down_choppy", 2.0, true}, // composite prefix → trending_down
 		{"ranging_quiet", 1.5, true},        // composite prefix → ranging
 		{"ranging_directional", 1.5, true},
+		// #1124: directional-drift substates have no explicit StopLoss entry, so
+		// they fall to the ranging family by prefix — same as bare.
+		{"ranging_directional_up", 1.5, true},
+		{"ranging_directional_down", 1.5, true},
 		{"garbage", 0, false},
 	}
 	for _, tc := range cases {
@@ -251,13 +255,25 @@ func TestMapRegimeToBaselineFamily(t *testing.T) {
 			t.Errorf("mapRegimeToBaselineFamily(%q) = (%g, %v), want (%g, %v)", tc.label, e.ATR, ok, tc.wantATR, tc.wantOK)
 		}
 	}
+
+	// #1124 regression: on the Trailing baseline the directional-drift substates
+	// must resolve to the tight 1.0 ranging_directional trail via their EXPLICIT
+	// entries — NOT the wider 2.0 "ranging" family fallback. Without the explicit
+	// entries a use_defaults trailing block would silently loosen the trail.
+	trailing := regimeATRDefaults.Trailing
+	for _, label := range []string{"ranging_directional_up", "ranging_directional_down"} {
+		e, ok := mapRegimeToBaselineFamily(trailing, label)
+		if !ok || e.ATR != 1.0 {
+			t.Errorf("Trailing[%q] = (%g, %v), want (1.0, true) — explicit tight trail, not the 2.0 ranging family", label, e.ATR, ok)
+		}
+	}
 }
 
 func TestRegimeLabelsFromTierRaw(t *testing.T) {
 	raw := []interface{}{composite7StateTier(2.0, 0.5)}
 	got := regimeLabelsFromTierRaw(raw)
-	if len(got) != 7 {
-		t.Fatalf("expected 7 inferred labels, got %d: %v", len(got), got)
+	if len(got) != 9 {
+		t.Fatalf("expected 9 inferred labels, got %d: %v", len(got), got)
 	}
 	// No per-regime keys → canonical ADX fallback.
 	if got := regimeLabelsFromTierRaw(nil); len(got) != 3 {
@@ -298,7 +314,9 @@ func TestLoadConfig_CompositeStopLossAtrRegime(t *testing.T) {
 					"trending_down_choppy": {"atr_multiple": 1.2},
 					"ranging_quiet": {"atr_multiple": 1.5},
 					"ranging_volatile": {"atr_multiple": 1.0},
-					"ranging_directional": {"atr_multiple": 1.5}
+					"ranging_directional": {"atr_multiple": 1.5},
+					"ranging_directional_up": {"atr_multiple": 1.5},
+					"ranging_directional_down": {"atr_multiple": 1.5}
 				}
 			}
 		}]
@@ -308,11 +326,11 @@ func TestLoadConfig_CompositeStopLossAtrRegime(t *testing.T) {
 	}
 	cfg, err := LoadConfig(cfgPath)
 	if err != nil {
-		t.Fatalf("LoadConfig must accept composite 7-state stop_loss_atr_regime, got: %v", err)
+		t.Fatalf("LoadConfig must accept composite 9-state stop_loss_atr_regime, got: %v", err)
 	}
 	block := cfg.Strategies[0].StopLossATRRegime
-	if block == nil || len(block.TrendRegime) != 7 {
-		t.Fatalf("composite SL block must be populated with 7 labels post-load, got %#v", block)
+	if block == nil || len(block.TrendRegime) != 9 {
+		t.Fatalf("composite SL block must be populated with 9 labels post-load, got %#v", block)
 	}
 	if v, ok := resolveRegimeATR(*block, "trending_down_choppy"); !ok || v != 1.2 {
 		t.Fatalf("runtime resolve trending_down_choppy = (%g, %v), want (1.2, true)", v, ok)

--- a/scheduler/regime_atr_composite_test.go
+++ b/scheduler/regime_atr_composite_test.go
@@ -171,6 +171,102 @@ func TestValidateRegimeATRConfig_CompositeMissingLabelRejected(t *testing.T) {
 	}
 }
 
+// #1124: the ranging_directional family — a present bare ranging_directional
+// covers its _up/_down sub-labels for exhaustiveness, so a legacy block keyed
+// on bare only (no sub-label keys) still validates under the 9-label composite
+// vocabulary (back-compat).
+func TestValidateRegimeATRConfig_CompositeBareDirectionalCoversSubLabels(t *testing.T) {
+	raw := composite7StateATR(2.0)
+	tr := raw["trend_regime"].(map[string]interface{})
+	delete(tr, "ranging_directional_up")
+	delete(tr, "ranging_directional_down")
+	if _, ok := tr["ranging_directional"]; !ok {
+		t.Fatal("test fixture: expected bare ranging_directional key")
+	}
+	sc := StrategyConfig{
+		ID:                "hl-test",
+		Type:              "perps",
+		Platform:          "hyperliquid",
+		RegimeATRWindow:   "daily",
+		StopLossATRRegime: &RegimeATRBlock{raw: raw},
+	}
+	if errs := validateRegimeATRConfig(compositeRegimeCfg(sc)); len(errs) != 0 {
+		t.Fatalf("legacy bare-only directional block must still validate, got: %v", errs)
+	}
+}
+
+// #1124: sub-labels-only (no bare ranging_directional) is NOT exhaustive — the
+// producer still emits the bare label at return_eff==0, so a block missing it
+// would silently never-arm on the neutral case. Must be rejected.
+func TestValidateRegimeATRConfig_CompositeSubLabelsWithoutBareRejected(t *testing.T) {
+	raw := composite7StateATR(2.0)
+	delete(raw["trend_regime"].(map[string]interface{}), "ranging_directional")
+	sc := StrategyConfig{
+		ID:                "hl-test",
+		Type:              "perps",
+		Platform:          "hyperliquid",
+		RegimeATRWindow:   "daily",
+		StopLossATRRegime: &RegimeATRBlock{raw: raw},
+	}
+	errs := validateRegimeATRConfig(compositeRegimeCfg(sc))
+	joined := strings.Join(errs, "\n")
+	if !strings.Contains(joined, "ranging_directional") || !strings.Contains(joined, "missing required regime labels") {
+		t.Fatalf("expected missing bare ranging_directional error, got: %v", errs)
+	}
+}
+
+// #1124: runtime Resolve falls back from a _up/_down stamp to the bare
+// ranging_directional entry when no explicit sub-label key exists, and an
+// explicit sub-label key wins over the bare fallback (one-directional rule).
+func TestRegimeATRBlock_ResolveSubLabelFallsBackToBareAndExplicitWins(t *testing.T) {
+	// Bare-only block: subs resolve via bare fallback.
+	raw := composite7StateATR(1.5)
+	tr := raw["trend_regime"].(map[string]interface{})
+	delete(tr, "ranging_directional_up")
+	delete(tr, "ranging_directional_down")
+	sc := StrategyConfig{
+		ID:                "hl-test",
+		Type:              "perps",
+		Platform:          "hyperliquid",
+		RegimeATRWindow:   "daily",
+		StopLossATRRegime: &RegimeATRBlock{raw: raw},
+	}
+	if errs := validateRegimeATRConfig(compositeRegimeCfg(sc)); len(errs) != 0 {
+		t.Fatalf("fixture must validate, got: %v", errs)
+	}
+	block := *sc.StopLossATRRegime
+	if v, ok := block.Resolve("ranging_directional"); !ok || v.ATR != 1.5 {
+		t.Fatalf("bare resolve: got (%g, %v), want (1.5, true)", v.ATR, ok)
+	}
+	for _, sub := range []string{"ranging_directional_up", "ranging_directional_down"} {
+		v, ok := block.Resolve(sub)
+		if !ok || v.ATR != 1.5 {
+			t.Errorf("Resolve(%q): got (%g, %v), want (1.5, true) via bare fallback", sub, v.ATR, ok)
+		}
+	}
+
+	// Explicit _up key wins over bare; _down still falls back to bare.
+	raw2 := composite7StateATR(1.5)
+	raw2["trend_regime"].(map[string]interface{})["ranging_directional_up"] = map[string]interface{}{"atr_multiple": 0.9}
+	sc2 := StrategyConfig{
+		ID:                "hl-test2",
+		Type:              "perps",
+		Platform:          "hyperliquid",
+		RegimeATRWindow:   "daily",
+		StopLossATRRegime: &RegimeATRBlock{raw: raw2},
+	}
+	if errs := validateRegimeATRConfig(compositeRegimeCfg(sc2)); len(errs) != 0 {
+		t.Fatalf("explicit-sub fixture must validate, got: %v", errs)
+	}
+	block2 := *sc2.StopLossATRRegime
+	if v, ok := block2.Resolve("ranging_directional_up"); !ok || v.ATR != 0.9 {
+		t.Fatalf("explicit _up must win: got (%g, %v), want (0.9, true)", v.ATR, ok)
+	}
+	if v, ok := block2.Resolve("ranging_directional_down"); !ok || v.ATR != 1.5 {
+		t.Fatalf("_down must fall back to bare: got (%g, %v), want (1.5, true)", v.ATR, ok)
+	}
+}
+
 // TestValidateRegimeATRConfig_CompositeTPTiersExplicit covers the tier path:
 // an explicit 7-state tiered_tp_atr_regime close ref must validate under a
 // composite window.

--- a/scheduler/regime_directional_policy.go
+++ b/scheduler/regime_directional_policy.go
@@ -368,6 +368,14 @@ func gatedDirectionalEntry(sc StrategyConfig, regime string, certStates map[stri
 	if sc.RegimeDirectionalPolicy == nil || sc.RegimeDirectionalPolicy.IsZero() {
 		return RegimeDirectionalEntry{}, false
 	}
+	// #1124/#1085: exact match ONLY — deliberately NO bare→sub family fallback
+	// here. The certification artifact carries PER-STATE evidence; a bare
+	// ranging_directional certification must not certify the _up/_down states it
+	// has no per-state evidence for. Borrowing the bare cell would place a
+	// directional bet on unproven evidence, so this evidence gate stays
+	// fail-closed (an uncertified _up/_down resolves to base direction). The
+	// bare→sub fallback in Resolve below only selects the operator's configured
+	// entry; this gate still independently requires per-state certified evidence.
 	certDir, certOK := certStates[strings.TrimSpace(regime)]
 	if !certOK {
 		return RegimeDirectionalEntry{}, false

--- a/scheduler/regime_directional_policy.go
+++ b/scheduler/regime_directional_policy.go
@@ -101,8 +101,18 @@ func (p *RegimeDirectionalPolicy) Resolve(regime string) (RegimeDirectionalEntry
 	if p == nil || len(p.TrendRegime) == 0 {
 		return RegimeDirectionalEntry{}, false
 	}
-	entry, ok := p.TrendRegime[strings.TrimSpace(regime)]
-	return entry, ok
+	r := strings.TrimSpace(regime)
+	if entry, ok := p.TrendRegime[r]; ok {
+		return entry, true
+	}
+	// #1124: sub-label stamp falls back to the bare ranging_directional entry
+	// (exact match wins first, so an explicit sub key still overrides bare).
+	if regimeDirectionalSubs[r] {
+		if entry, ok := p.TrendRegime[regimeDirectionalBare]; ok {
+			return entry, true
+		}
+	}
+	return RegimeDirectionalEntry{}, false
 }
 
 // IsConfigured reports whether the operator supplied any value. Safe to
@@ -258,11 +268,19 @@ func (p *RegimeDirectionalPolicy) ResolveRawWithLabels(label string, labels []st
 	// fallback at runtime. Operators who want the static config to apply
 	// for one regime can spell it out explicitly. Uses `seen` (not `parsed`)
 	// so a label that's present-but-invalid isn't also reported as missing.
+	// #1124: a present bare `ranging_directional` covers its _up/_down
+	// sub-labels (back-compat — Resolve resolves the whole family at runtime
+	// via its bare fallback). Sub-labels-only (no bare) is still flagged.
+	bareDirectional := seen[regimeDirectionalBare]
 	missing := []string{}
 	for _, l := range labels {
-		if !seen[l] {
-			missing = append(missing, l)
+		if seen[l] {
+			continue
 		}
+		if regimeLabelFamilyCovered(l, bareDirectional) {
+			continue
+		}
+		missing = append(missing, l)
 	}
 	if len(missing) > 0 {
 		errs = append(errs, fmt.Sprintf("%s: missing required regime labels: %s", label, strings.Join(missing, ", ")))

--- a/scheduler/regime_divergence.go
+++ b/scheduler/regime_divergence.go
@@ -243,7 +243,16 @@ func regimeLabelBias(label string, snapReturnEff float64) divergenceBias {
 		return biasBullish
 	case "trending_down", "trending_down_clean", "trending_down_choppy":
 		return biasBearish
+	case "ranging_directional_up":
+		// #1124: the label carries the drift direction directly, so the bias is
+		// fixed regardless of snapReturnEff.
+		return biasBullish
+	case "ranging_directional_down":
+		return biasBearish
 	case "ranging_directional":
+		// Bare label: the producer emits it only when return_eff == 0 exactly,
+		// but a stale/legacy snapshot may still carry a nonzero return_eff, so
+		// keep resolving the sign as the tie-break for back-compat.
 		if snapReturnEff > 0 {
 			return biasBullish
 		}

--- a/scheduler/regime_divergence_test.go
+++ b/scheduler/regime_divergence_test.go
@@ -122,6 +122,28 @@ func TestClassifyRegimeDivergence_RangingDirectionalSign(t *testing.T) {
 	}
 }
 
+// TestClassifyRegimeDivergence_RangingDirectionalExplicit covers #1124: the
+// explicit _up/_down labels carry their bias in the name, so the divergence
+// verdict is fixed regardless of the (now redundant) return_eff snapshot.
+func TestClassifyRegimeDivergence_RangingDirectionalExplicit(t *testing.T) {
+	// ranging_directional_up → bullish → hard divergence vs trending_down,
+	// even with a contradicting (stale) return_eff snapshot of 0.
+	up := classifyRegimeDivergence("ranging_directional_up", "trending_down", 0, 0, onDivergenceTrustShort)
+	if up.Kind != DivergenceHard || up.OverrideDir != DirectionLong {
+		t.Fatalf("ranging_directional_up: want hard/long, got %q/%q", up.Kind, up.OverrideDir)
+	}
+	// ranging_directional_down → bearish → same side as trending_down → none.
+	down := classifyRegimeDivergence("ranging_directional_down", "trending_down", 0.99, 0, onDivergenceTrustShort)
+	if down.Kind != DivergenceNone {
+		t.Fatalf("ranging_directional_down vs trending_down: want none, got %q", down.Kind)
+	}
+	// ranging_directional_down → bearish → hard divergence vs trending_up.
+	downVsUp := classifyRegimeDivergence("ranging_directional_down", "trending_up", 0, 0, onDivergenceTrustShort)
+	if downVsUp.Kind != DivergenceHard || downVsUp.OverrideDir != DirectionShort {
+		t.Fatalf("ranging_directional_down vs trending_up: want hard/short, got %q/%q", downVsUp.Kind, downVsUp.OverrideDir)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // RegimeWindowDivergence config + ResolveRaw
 // ---------------------------------------------------------------------------

--- a/scheduler/regime_profile_allocation.go
+++ b/scheduler/regime_profile_allocation.go
@@ -263,10 +263,19 @@ func (a *RegimeProfileAllocation) ResolveRaw(label string, labels []string) []st
 		errs = append(errs, fmt.Sprintf("%s.initial_profile=%q is not a param_sets profile (valid: %s)", label, initialProfile, strings.Join(sortedKeys(paramSets), ", ")))
 	}
 	// Every classifier label must be covered by profiles.
+	// #1124: a present bare `ranging_directional` mapping covers its _up/_down
+	// sub-labels (back-compat — the bare profile resolves the whole family at
+	// runtime via resolveRegimeProfile's bare fallback, including the
+	// return_eff==0 neutral case the producer emits).
+	_, bareDirectional := profiles[regimeDirectionalBare]
 	for _, l := range labels {
-		if _, ok := profiles[l]; !ok {
-			errs = append(errs, fmt.Sprintf("%s.profiles: missing mapping for regime label %q (every label of the window classifier must map to a profile)", label, l))
+		if _, ok := profiles[l]; ok {
+			continue
 		}
+		if regimeLabelFamilyCovered(l, bareDirectional) {
+			continue
+		}
+		errs = append(errs, fmt.Sprintf("%s.profiles: missing mapping for regime label %q (every label of the window classifier must map to a profile)", label, l))
 	}
 
 	if len(errs) > 0 {
@@ -390,6 +399,11 @@ func resolveRegimeProfile(alloc *RegimeProfileAllocation, label, barTime string,
 	desired := ""
 	if label != "" {
 		desired = alloc.Profiles[label]
+		// #1124: sub-label stamp falls back to the bare ranging_directional
+		// mapping when no explicit sub-label profile is configured.
+		if desired == "" && regimeDirectionalSubs[label] {
+			desired = alloc.Profiles[regimeDirectionalBare]
+		}
 	}
 
 	barAdvanced := barTime != "" && barTime != next.LastBarTime

--- a/scheduler/regime_profile_allocation_test.go
+++ b/scheduler/regime_profile_allocation_test.go
@@ -275,7 +275,7 @@ func TestValidateStrategyRegimeVocabulary_RejectsBadProfileWindow(t *testing.T) 
 	var a RegimeProfileAllocation
 	if err := json.Unmarshal([]byte(`{
 		"window": "does_not_exist",
-		"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade"},
+		"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade","ranging_directional_up":"fade","ranging_directional_down":"fade"},
 		"param_sets": {"fade": {"trend_entry":"off"}, "trend": {"trend_entry":"breakout"}},
 		"confirm_bars": 24,
 		"initial_profile": "fade"
@@ -299,7 +299,7 @@ func TestValidateStrategyRegimeVocabulary_AcceptsGoodProfileAllocation(t *testin
 	var a RegimeProfileAllocation
 	if err := json.Unmarshal([]byte(`{
 		"window": "profile_long",
-		"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade"},
+		"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade","ranging_directional_up":"fade","ranging_directional_down":"fade"},
 		"param_sets": {"fade": {"trend_entry":"off"}, "trend": {"trend_entry":"breakout"}},
 		"confirm_bars": 24,
 		"initial_profile": "fade"
@@ -391,7 +391,7 @@ func fullProfileAllocConfig(t *testing.T, palJSON string) Config {
 
 const validPALJSON = `{
 	"window": "profile_long",
-	"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade"},
+	"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade","ranging_directional_up":"fade","ranging_directional_down":"fade"},
 	"param_sets": {"fade": {"trend_entry":"off"}, "trend": {"trend_entry":"breakout"}},
 	"confirm_bars": 24,
 	"initial_profile": "fade"
@@ -466,7 +466,7 @@ func TestLoadConfig_ProfileAllocation_FromFile(t *testing.T) {
 			"direction": "long",
 			"regime_profile_allocation": {
 				"window": "profile_long",
-				"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade"},
+				"profiles": {"trending_up_clean":"trend","trending_up_choppy":"trend","trending_down_clean":"trend","trending_down_choppy":"trend","ranging_quiet":"fade","ranging_volatile":"fade","ranging_directional":"fade","ranging_directional_up":"fade","ranging_directional_down":"fade"},
 				"param_sets": {"fade": {"trend_entry":"off"}, "trend": {"trend_entry":"breakout","trend_drift_confirm":0.1}},
 				"confirm_bars": 24,
 				"initial_profile": "fade"

--- a/scheduler/regime_test.go
+++ b/scheduler/regime_test.go
@@ -129,6 +129,38 @@ func TestRegimeAllowsEntry_NonMatchingLabel(t *testing.T) {
 	}
 }
 
+// TestRegimeAllowsEntry_BareDirectionalCoversSubLabels: #1124 family rule on
+// the entry gate — a bare ranging_directional in allowed matches its _up/_down
+// sub-labels (one-directional bare→subs).
+func TestRegimeAllowsEntry_BareDirectionalCoversSubLabels(t *testing.T) {
+	allowed := []string{"ranging_directional"}
+	if !regimeAllowsEntry(allowed, "ranging_directional_up") {
+		t.Error("bare ranging_directional should allow ranging_directional_up")
+	}
+	if !regimeAllowsEntry(allowed, "ranging_directional_down") {
+		t.Error("bare ranging_directional should allow ranging_directional_down")
+	}
+	if !regimeAllowsEntry(allowed, "ranging_directional") {
+		t.Error("bare ranging_directional should allow itself")
+	}
+}
+
+// TestRegimeAllowsEntry_ExplicitSubLabelDoesNotCoverBareOrSibling: the family
+// expansion is one-directional — an explicit _up does NOT match bare or _down.
+func TestRegimeAllowsEntry_ExplicitSubLabelDoesNotCoverBareOrSibling(t *testing.T) {
+	allowed := []string{"ranging_directional_up"}
+	if regimeAllowsEntry(allowed, "ranging_directional") {
+		t.Error("explicit _up should NOT cover bare ranging_directional")
+	}
+	if regimeAllowsEntry(allowed, "ranging_directional_down") {
+		t.Error("explicit _up should NOT cover ranging_directional_down")
+	}
+	// Still matches itself.
+	if !regimeAllowsEntry(allowed, "ranging_directional_up") {
+		t.Error("explicit _up should match itself")
+	}
+}
+
 func TestRegimeAllowsEntry_EmptyCurrentAllowsWhenListNonEmpty(t *testing.T) {
 	// When regime field is empty (script disabled / not available), allow entry
 	// so existing strategies without regime are unaffected.

--- a/scheduler/regime_unified.go
+++ b/scheduler/regime_unified.go
@@ -54,9 +54,19 @@ func unifiedRegimeScalarParams(params map[string]interface{}, regime string) (sc
 	if !isMap {
 		return nil, 0, false
 	}
-	labelRaw, isMap := trendRaw[strings.TrimSpace(regime)].(map[string]interface{})
+	r := strings.TrimSpace(regime)
+	labelRaw, isMap := trendRaw[r].(map[string]interface{})
 	if !isMap {
-		return nil, 0, false
+		// #1124: sub-label stamp falls back to the bare ranging_directional
+		// entry. The unified close is the sole SL owner, so without this
+		// fallback a bare-only block yields no SL *and* no TPs for an
+		// _up/_down stamp → a naked HL perps position.
+		if regimeDirectionalSubs[r] {
+			labelRaw, isMap = trendRaw[regimeDirectionalBare].(map[string]interface{})
+		}
+		if !isMap {
+			return nil, 0, false
+		}
 	}
 	tiers, hasTiers := labelRaw["tp_tiers"]
 	if !hasTiers {
@@ -200,9 +210,17 @@ func validateUnifiedRegimeClose(params map[string]interface{}, labels []string, 
 			ctxLabel, regimeClassifierKey, l, strings.Join(labels, ", ")))
 	}
 
+	bareDirectional := trendRaw[regimeDirectionalBare] != nil
 	for _, l := range labels {
 		lr, ok := trendRaw[l]
 		if !ok {
+			// #1124 family rule: a present bare ranging_directional covers the
+			// _up/_down sub-labels for exhaustiveness, so a 7-label composite
+			// block (the pre-#1124 shape) still loads and resolves at runtime
+			// via the bare fallback in unifiedRegimeScalarParams.
+			if regimeLabelFamilyCovered(l, bareDirectional) {
+				continue
+			}
 			errs = append(errs, fmt.Sprintf("%s.%s: missing required regime label %q (must be exhaustive — no silent fallback)",
 				ctxLabel, regimeClassifierKey, l))
 			continue

--- a/scheduler/regime_unified_test.go
+++ b/scheduler/regime_unified_test.go
@@ -300,3 +300,114 @@ func TestUnifiedCloseParamsEqualForReload(t *testing.T) {
 		t.Fatal("two non-unified strategies should compare equal")
 	}
 }
+
+// unifiedCompositeBlock is a 9-label composite unified block keyed on bare
+// ranging_directional (no _up/_down keys) — the pre-#1124 shape that the
+// #1124 family rule must keep valid and keep resolving for _up/_down stamps.
+func unifiedCompositeBlock() map[string]interface{} {
+	tiers := func(a, b float64) []interface{} {
+		return []interface{}{
+			map[string]interface{}{"atr_multiple": a, "close_fraction": 0.5},
+			map[string]interface{}{"atr_multiple": b, "close_fraction": 1.0},
+		}
+	}
+	return map[string]interface{}{
+		regimeClassifierKey: map[string]interface{}{
+			"trending_up_clean":    map[string]interface{}{"stop_loss_atr": 1.5, "tp_tiers": tiers(2.0, 4.0)},
+			"trending_up_choppy":   map[string]interface{}{"stop_loss_atr": 1.3, "tp_tiers": tiers(1.8, 3.0)},
+			"trending_down_clean":  map[string]interface{}{"stop_loss_atr": 1.5, "tp_tiers": tiers(2.0, 4.0)},
+			"trending_down_choppy": map[string]interface{}{"stop_loss_atr": 1.3, "tp_tiers": tiers(1.8, 3.0)},
+			"ranging_quiet":        map[string]interface{}{"stop_loss_atr": 1.0, "tp_tiers": tiers(1.2, 2.4)},
+			"ranging_volatile":     map[string]interface{}{"stop_loss_atr": 1.2, "tp_tiers": tiers(1.5, 3.0)},
+			"ranging_directional":  map[string]interface{}{"stop_loss_atr": 1.1, "tp_tiers": tiers(1.3, 2.6)},
+		},
+	}
+}
+
+// TestValidateUnifiedRegimeClose_CompositeBareDirectionalCoversSubLabels:
+// the #1124 family rule — a bare ranging_directional covers its _up/_down
+// sub-labels for exhaustiveness, so the pre-#1124 bare-only shape still loads
+// under the 9-label composite vocabulary.
+func TestValidateUnifiedRegimeClose_CompositeBareDirectionalCoversSubLabels(t *testing.T) {
+	labels := regimeLabelsForClassifier(regimeClassifierComposite)
+	if errs := validateUnifiedRegimeClose(unifiedCompositeBlock(), labels, "close.params"); len(errs) > 0 {
+		t.Fatalf("bare-only composite block keyed on ranging_directional rejected: %v", errs)
+	}
+}
+
+// TestValidateUnifiedRegimeClose_CompositeSubLabelsWithoutBareRejected:
+// sub-labels-only (no bare parent) is still non-exhaustive because the
+// producer emits bare ranging_directional at exactly return_eff == 0. The
+// rule is one-directional: subs never satisfy the bare requirement.
+func TestValidateUnifiedRegimeClose_CompositeSubLabelsWithoutBareRejected(t *testing.T) {
+	labels := regimeLabelsForClassifier(regimeClassifierComposite)
+	m := unifiedCompositeBlock()
+	tr := m[regimeClassifierKey].(map[string]interface{})
+	delete(tr, "ranging_directional")
+	tr["ranging_directional_up"] = map[string]interface{}{"stop_loss_atr": 1.1, "tp_tiers": []interface{}{
+		map[string]interface{}{"atr_multiple": 1.3, "close_fraction": 0.5},
+		map[string]interface{}{"atr_multiple": 2.6, "close_fraction": 1.0},
+	}}
+	tr["ranging_directional_down"] = tr["ranging_directional_up"]
+	errs := validateUnifiedRegimeClose(m, labels, "close.params")
+	joined := strings.Join(errs, " | ")
+	if !strings.Contains(joined, `missing required regime label "ranging_directional"`) {
+		t.Fatalf("sub-labels-only block must be rejected as missing bare ranging_directional, got: %v", errs)
+	}
+}
+
+// TestUnifiedRegimeScalarParams_SubLabelFallsBackToBare: a _up/_down stamp
+// resolves to the bare ranging_directional block at runtime, returning its
+// SL and TP ladder (the sole-owner safety guarantee — no naked position). An
+// explicit sub-label key wins over bare on exact match, while the sibling in
+// the same block still falls back to bare (one-directional rule).
+func TestUnifiedRegimeScalarParams_SubLabelFallsBackToBare(t *testing.T) {
+	for _, stamp := range []string{"ranging_directional_up", "ranging_directional_down"} {
+		scalar, sl, ok := unifiedRegimeScalarParams(unifiedCompositeBlock(), stamp)
+		if !ok {
+			t.Fatalf("%s: expected ok via bare fallback", stamp)
+		}
+		if sl != 1.1 {
+			t.Fatalf("%s: stop_loss_atr = %g, want 1.1 (bare)", stamp, sl)
+		}
+		if tiers, ok := scalar["tp_tiers"].([]interface{}); !ok || len(tiers) != 2 {
+			t.Fatalf("%s: tp_tiers = %v, want bare 2-tier ladder", stamp, scalar["tp_tiers"])
+		}
+	}
+
+	// Explicit _up key wins over bare on exact match; _down still falls back.
+	m := unifiedCompositeBlock()
+	tr := m[regimeClassifierKey].(map[string]interface{})
+	tr["ranging_directional_up"] = map[string]interface{}{"stop_loss_atr": 0.9, "tp_tiers": []interface{}{
+		map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.5},
+		map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
+	}}
+	if _, sl, ok := unifiedRegimeScalarParams(m, "ranging_directional_up"); !ok || sl != 0.9 {
+		t.Fatalf("explicit _up must win: stop_loss_atr = %g, ok = %v, want 0.9/true", sl, ok)
+	}
+	if _, sl, ok := unifiedRegimeScalarParams(m, "ranging_directional_down"); !ok || sl != 1.1 {
+		t.Fatalf("_down must fall back to bare: stop_loss_atr = %g, ok = %v, want 1.1/true", sl, ok)
+	}
+}
+
+// TestUnifiedRegimeSLFolding_SubLabelStampPlacesSL: end-to-end #1124 safety —
+// a composite unified close keyed on bare ranging_directional (the sole SL
+// owner) places an SL via the on-chain protection plan when the producer
+// stamps _up/_down. Without the bare fallback this would be a naked position.
+func TestUnifiedRegimeSLFolding_SubLabelStampPlacesSL(t *testing.T) {
+	sc := StrategyConfig{
+		ID: "hl-unified-sub", Platform: "hyperliquid", Type: "perps",
+		MaxDrawdownPct: 25,
+		CloseStrategy:  &StrategyRef{Name: "tiered_tp_atr_live_regime", Params: unifiedCompositeBlock()},
+	}
+	for _, stamp := range []string{"ranging_directional_up", "ranging_directional_down"} {
+		pos := &Position{Symbol: "ETH", Quantity: 1, AvgCost: 100, EntryATR: 5, Side: "long", Regime: stamp}
+		plan, ok := buildHyperliquidProtectionPlan(sc, pos)
+		if !ok {
+			t.Fatalf("%s: protection plan not built (naked position)", stamp)
+		}
+		if plan.StopLossATRMult != 1.1 {
+			t.Fatalf("%s: plan.StopLossATRMult = %g, want 1.1 (bare fallback)", stamp, plan.StopLossATRMult)
+		}
+	}
+}

--- a/scheduler/regime_window_spec.go
+++ b/scheduler/regime_window_spec.go
@@ -136,6 +136,15 @@ func regimeLabelsForClassifier(classifier string) []string {
 			"ranging_quiet",
 			"ranging_volatile",
 			"ranging_directional",
+			// #1124: directional-drift ranging substates. Adding them to the
+			// classifier vocabulary makes them valid for allowed_regimes gating,
+			// regime_directional_policy and *_atr_regime keys — and, by the same
+			// vocabulary, REQUIRED in explicit (non-use_defaults) trend_regime
+			// blocks under a composite window (exhaustiveness is fail-closed:
+			// a pre-#1124 explicit block missing them errors at load with
+			// "missing required regime labels", never silently no-ops).
+			"ranging_directional_up",
+			"ranging_directional_down",
 		}
 	default:
 		return append([]string(nil), canonicalTrendRegimeLabels...)

--- a/scheduler/regime_window_spec.go
+++ b/scheduler/regime_window_spec.go
@@ -137,12 +137,17 @@ func regimeLabelsForClassifier(classifier string) []string {
 			"ranging_volatile",
 			"ranging_directional",
 			// #1124: directional-drift ranging substates. Adding them to the
-			// classifier vocabulary makes them valid for allowed_regimes gating,
-			// regime_directional_policy and *_atr_regime keys — and, by the same
-			// vocabulary, REQUIRED in explicit (non-use_defaults) trend_regime
-			// blocks under a composite window (exhaustiveness is fail-closed:
-			// a pre-#1124 explicit block missing them errors at load with
-			// "missing required regime labels", never silently no-ops).
+			// classifier vocabulary makes them valid keys for allowed_regimes
+			// gating, regime_directional_policy and *_atr_regime blocks. Under
+			// the #1124 family rule, a present bare ranging_directional covers
+			// its _up/_down subs across every exhaustiveness validator, so a
+			// pre-#1124 explicit (non-use_defaults) trend_regime block that has
+			// the bare label but omits the subs still loads fine (no config
+			// changes required). Exhaustiveness stays fail-closed: a label
+			// errors at load with "missing required regime labels" only when
+			// neither it nor its bare family parent is present — e.g. an
+			// explicit block listing _up/_down but omitting bare is rejected
+			// (the family rule is one-directional: bare→subs, never subs→bare).
 			"ranging_directional_up",
 			"ranging_directional_down",
 		}

--- a/scheduler/trailing_tp_ratchet.go
+++ b/scheduler/trailing_tp_ratchet.go
@@ -272,9 +272,18 @@ func trailingRatchetTiersForRegime(sc StrategyConfig, regime string) []trailingR
 			if !ok || strings.TrimSpace(regime) == "" {
 				return nil
 			}
-			block, ok := table[strings.TrimSpace(regime)]
+			key := strings.TrimSpace(regime)
+			block, ok := table[key]
 			if !ok {
-				return nil
+				// #1124: sub-label stamp falls back to the bare
+				// ranging_directional tier ladder (exact key wins first, so an
+				// explicit sub key still overrides bare).
+				if regimeDirectionalSubs[key] {
+					block, ok = table[regimeDirectionalBare]
+				}
+				if !ok {
+					return nil
+				}
 			}
 			tiers, _ := parseTrailingRatchetTierList(block, ref.Name+".tp_tiers."+regime)
 			return tiers
@@ -418,9 +427,16 @@ func validateTrailingTPRatchetClose(sc StrategyConfig, labels []string, regimeEn
 					errs = append(errs, fmt.Sprintf("%s.tp_tiers: unknown regime key %q (valid: %s)", sub, key, strings.Join(labels, ", ")))
 				}
 			}
+			bareDirectional := table[regimeDirectionalBare] != nil
 			for _, key := range labels {
 				block, ok := table[key]
 				if !ok {
+					// #1124 family rule: bare ranging_directional covers the
+					// _up/_down sub-labels for exhaustiveness (the explicit
+					// tp_tiers resolver falls back bare→sub at runtime).
+					if regimeLabelFamilyCovered(key, bareDirectional) {
+						continue
+					}
 					errs = append(errs, fmt.Sprintf("%s.tp_tiers: missing required regime key %q", sub, key))
 					continue
 				}

--- a/scheduler/trailing_tp_ratchet.go
+++ b/scheduler/trailing_tp_ratchet.go
@@ -125,6 +125,15 @@ func ratchetCloseDefaultGroup(label string) (string, bool) {
 	switch l {
 	case "ranging_quiet", "ranging_volatile", "ranging_directional":
 		return l, true
+	case "ranging_directional_up", "ranging_directional_down":
+		// #1124: the directional-drift substates share the ranging_directional
+		// scale-out ladder (the geometry is direction-agnostic — the SL side
+		// carries direction, the TP scale-out does not). Map them to that group
+		// explicitly; otherwise they fall through to regimeCloseDefaultGroup's
+		// "ranging" key, which has NO ratchet ladder in ratchetTierGroupDefaults
+		// → defaultTrailingRatchetTiersForRegime returns nil → silent never-arm
+		// of the auto-protective ratchet exit (money path).
+		return "ranging_directional", true
 	case "ranging":
 		return "ranging_quiet", true
 	}

--- a/scheduler/trailing_tp_ratchet_test.go
+++ b/scheduler/trailing_tp_ratchet_test.go
@@ -398,8 +398,8 @@ func TestValidateTrailingTPRatchetClose_CompositeVocabulary(t *testing.T) {
 		return tbl
 	}
 	composite := regimeLabelsForClassifier(regimeClassifierComposite)
-	if len(composite) != 7 {
-		t.Fatalf("expected 7 composite labels, got %d", len(composite))
+	if len(composite) != 9 {
+		t.Fatalf("expected 9 composite labels, got %d", len(composite))
 	}
 
 	// #870: the regime variant's opening trail / SL owner is the per-regime
@@ -762,6 +762,21 @@ func TestDefaultTrailingRatchetTiersForRegime(t *testing.T) {
 	if defaultTrailingRatchetTiersForRegime("") != nil {
 		t.Error("empty regime must resolve to nil")
 	}
+	// #1124: the directional-drift substates must resolve to the SAME 4-tier
+	// ranging_directional ladder — never nil. A nil here would mean the ratchet
+	// (auto-protective exit) silently never arms for a ranging_directional_up/
+	// _down position.
+	for _, label := range []string{"ranging_directional_up", "ranging_directional_down"} {
+		got := defaultTrailingRatchetTiersForRegime(label)
+		if len(got) != len(dir) {
+			t.Fatalf("%s want %d tiers (parity with ranging_directional), got %+v", label, len(dir), got)
+		}
+		for i := range dir {
+			if got[i] != dir[i] {
+				t.Fatalf("%s tier[%d] = %+v, want %+v (ranging_directional ladder)", label, i, got[i], dir[i])
+			}
+		}
+	}
 }
 
 // TestRatchetCloseDefaultGroup covers #1059: the ratchet-only resolver
@@ -776,6 +791,9 @@ func TestRatchetCloseDefaultGroup(t *testing.T) {
 		{"ranging_quiet", "ranging_quiet", true},
 		{"ranging_volatile", "ranging_volatile", true},
 		{"ranging_directional", "ranging_directional", true},
+		// #1124: directional-drift substates share the ranging_directional ladder.
+		{"ranging_directional_up", "ranging_directional", true},
+		{"ranging_directional_down", "ranging_directional", true},
 		{"ranging", "ranging_quiet", true}, // bare ADX → quiet ladder
 		{"trending_up_clean", "clean", true},
 		{"trending_up_choppy", "choppy", true},

--- a/shared_strategies/close/post_tp_sl.py
+++ b/shared_strategies/close/post_tp_sl.py
@@ -53,7 +53,15 @@ class RegimeFloatBlock:
     trend_regime: Dict[str, float] = field(default_factory=dict)
 
     def resolve(self, regime: str) -> Optional[float]:
-        return self.trend_regime.get((regime or "").strip())
+        r = (regime or "").strip()
+        v = self.trend_regime.get(r)
+        if v is not None:
+            return v
+        # #1124: sub-label stamp falls back to the bare ranging_directional entry
+        # (exact match wins first, so an explicit sub key still overrides bare).
+        if r in ("ranging_directional_up", "ranging_directional_down"):
+            return self.trend_regime.get("ranging_directional")
+        return None
 
 
 @dataclass(frozen=True)
@@ -389,7 +397,17 @@ def _parse_regime_float_block(
             f"{ctx_label}.{REGIME_CLASSIFIER_KEY}: unknown regime label {label!r} "
             f"(expected one of: {', '.join(labels)})"
         )
-    missing = [label for label in labels if label not in trend_raw]
+    # #1124: bare `ranging_directional` covers its _up/_down sub-labels for
+    # exhaustiveness (back-compat — resolve() resolves the family via its bare
+    # fallback). Sub-labels-only (no bare parent) is still flagged.
+    missing = [
+        label for label in labels
+        if label not in trend_raw
+        and not (
+            label in ("ranging_directional_up", "ranging_directional_down")
+            and "ranging_directional" in trend_raw
+        )
+    ]
     if missing:
         errs.append(
             f"{ctx_label}.{REGIME_CLASSIFIER_KEY}: missing required regime labels: "
@@ -872,7 +890,20 @@ def validate_regime_tiered_tp_labels(
                     f"{name}.tiers[{i}].{REGIME_CLASSIFIER_KEY}: unknown regime "
                     f"label {key!r} (expected one of: {', '.join(sorted(expected))})"
                 )
-            missing = [label for label in sorted(expected) if label not in block]
+            # #1124: a present bare `ranging_directional` covers its _up/_down
+            # sub-labels for exhaustiveness (back-compat — the bare label
+            # resolves the whole family at runtime, including the return_eff==0
+            # neutral case the producer still emits). Providing only the
+            # sub-labels without the bare label is NOT exhaustive.
+            bare_directional_present = "ranging_directional" in block
+            missing = [
+                label for label in sorted(expected)
+                if label not in block
+                and not (
+                    label in ("ranging_directional_up", "ranging_directional_down")
+                    and bare_directional_present
+                )
+            ]
             if missing:
                 errs.append(
                     f"{name}.tiers[{i}].{REGIME_CLASSIFIER_KEY}: missing required "

--- a/shared_strategies/close/regime_atr.py
+++ b/shared_strategies/close/regime_atr.py
@@ -131,6 +131,12 @@ REGIME_ATR_DEFAULTS_TRAILING: Dict[str, RegimeATREntry] = {
     "ranging_quiet": RegimeATREntry(atr=1.0),
     "ranging_volatile": RegimeATREntry(atr=1.0),
     "ranging_directional": RegimeATREntry(atr=1.0),
+    # #1124: directional-drift substates inherit the tight ranging_directional
+    # opening trail (1.0). Explicit entries are required because resolve() is a
+    # strict key lookup — without them a use_defaults block would leave these
+    # labels unresolved.
+    "ranging_directional_up": RegimeATREntry(atr=1.0),
+    "ranging_directional_down": RegimeATREntry(atr=1.0),
 }
 
 # #870: per-quality-group default ATR take-profit ladders. Mirrors

--- a/shared_strategies/close/regime_atr.py
+++ b/shared_strategies/close/regime_atr.py
@@ -107,7 +107,18 @@ class RegimeATRBlock:
     def resolve(self, regime: str) -> Optional[RegimeATREntry]:
         if not self.trend_regime:
             return None
-        return self.trend_regime.get((regime or "").strip())
+        r = (regime or "").strip()
+        entry = self.trend_regime.get(r)
+        if entry is not None:
+            return entry
+        # #1124: a ranging_directional_up/_down stamp falls back to the bare
+        # ranging_directional entry when no explicit sub-label key is present
+        # (the back-compat shape — bare label covers the whole family). Exact
+        # match wins first, so an explicit sub key still overrides bare. Mirrors
+        # RegimeATRBlock.Resolve in scheduler/regime_atr.go.
+        if r in ("ranging_directional_up", "ranging_directional_down"):
+            return self.trend_regime.get("ranging_directional")
+        return None
 
 
 # Mirrors regimeATRDefaults in scheduler/regime_atr.go — keep values in sync.
@@ -258,7 +269,21 @@ def parse_regime_atr_block(
             f"(expected one of: {', '.join(labels)})"
         )
 
-    missing_labels = [l for l in labels if l not in trend_raw]
+    # #1124: a present bare `ranging_directional` covers its _up/_down sub-labels
+    # for exhaustiveness (back-compat — resolve() resolves the whole family at
+    # runtime via its bare fallback, including the return_eff==0 neutral case the
+    # producer still emits). Providing only the sub-labels without the bare label
+    # is NOT exhaustive (the neutral case would resolve to None → silent
+    # never-arm of an auto-protective exit).
+    bare_directional_present = "ranging_directional" in trend_raw
+    missing_labels = [
+        l for l in labels
+        if l not in trend_raw
+        and not (
+            l in ("ranging_directional_up", "ranging_directional_down")
+            and bare_directional_present
+        )
+    ]
     if missing_labels:
         errs.append(
             f"{ctx_label}.{REGIME_CLASSIFIER_KEY}: missing required regime labels: "

--- a/shared_strategies/close/test_regime_atr.py
+++ b/shared_strategies/close/test_regime_atr.py
@@ -195,3 +195,67 @@ def test_atr_multiple_canonical_only(regime_atr):
         both, "stop_loss_atr_regime", regime_atr.SURFACE_STOP_LOSS
     )
     assert errs, "expected error when both atr_multiple and atr are set"
+
+
+# #1124: ranging_directional family — bare label covers _up/_down for
+# exhaustiveness; sub-labels-only is rejected; runtime resolve falls back.
+_COMPOSITE_LABELS_1124 = (
+    "trending_up_clean",
+    "trending_up_choppy",
+    "trending_down_clean",
+    "trending_down_choppy",
+    "ranging_quiet",
+    "ranging_volatile",
+    "ranging_directional",
+    "ranging_directional_up",
+    "ranging_directional_down",
+)
+
+
+def _composite_block_atr(atr, omit=()):
+    return {
+        "trend_regime": {
+            l: {"atr_multiple": atr} for l in _COMPOSITE_LABELS_1124 if l not in omit
+        }
+    }
+
+
+def test_composite_bare_directional_covers_sublabels(regime_atr):
+    # Bare ranging_directional present, no _up/_down keys → the bare label covers
+    # the sub-labels → validates (back-compat).
+    raw = _composite_block_atr(1.5, omit=("ranging_directional_up", "ranging_directional_down"))
+    block, errs = regime_atr.parse_regime_atr_block(
+        raw, "stop_loss_atr_regime", regime_atr.SURFACE_STOP_LOSS,
+        labels=_COMPOSITE_LABELS_1124,
+    )
+    assert errs == [], errs
+    # Runtime: a _up/_down stamp resolves via the bare fallback.
+    assert block.resolve("ranging_directional").atr == 1.5
+    assert block.resolve("ranging_directional_up").atr == 1.5
+    assert block.resolve("ranging_directional_down").atr == 1.5
+
+
+def test_composite_sublabels_without_bare_rejected(regime_atr):
+    # Sub-labels present but bare ranging_directional omitted → NOT exhaustive
+    # (the producer still emits the bare label at return_eff==0).
+    raw = _composite_block_atr(1.5, omit=("ranging_directional",))
+    _, errs = regime_atr.parse_regime_atr_block(
+        raw, "stop_loss_atr_regime", regime_atr.SURFACE_STOP_LOSS,
+        labels=_COMPOSITE_LABELS_1124,
+    )
+    assert any(
+        "missing required regime labels" in e and "ranging_directional" in e for e in errs
+    ), errs
+
+
+def test_composite_explicit_sublabel_wins_over_bare(regime_atr):
+    # When an explicit sub-label key is present, it wins over the bare fallback.
+    raw = _composite_block_atr(1.5)
+    raw[regime_atr.REGIME_CLASSIFIER_KEY]["ranging_directional_up"] = {"atr_multiple": 0.9}
+    block, errs = regime_atr.parse_regime_atr_block(
+        raw, "stop_loss_atr_regime", regime_atr.SURFACE_STOP_LOSS,
+        labels=_COMPOSITE_LABELS_1124,
+    )
+    assert errs == [], errs
+    assert block.resolve("ranging_directional_up").atr == 0.9
+    assert block.resolve("ranging_directional_down").atr == 1.5  # bare fallback

--- a/shared_strategies/close/test_trailing_tp_ratchet.py
+++ b/shared_strategies/close/test_trailing_tp_ratchet.py
@@ -176,6 +176,10 @@ def test_ratchet_close_default_group_differentiates_ranging_substates(ratchet):
     assert g("ranging_quiet") == "ranging_quiet"
     assert g("ranging_volatile") == "ranging_volatile"
     assert g("ranging_directional") == "ranging_directional"
+    # #1124: directional-drift substates share the ranging_directional ladder —
+    # NOT a fall-through to "ranging" (which has no ratchet ladder → never-arm).
+    assert g("ranging_directional_up") == "ranging_directional"
+    assert g("ranging_directional_down") == "ranging_directional"
     # Bare ADX "ranging" (no substate signal) → quiet ladder (pre-#1059 behavior).
     assert g("ranging") == "ranging_quiet"
     # clean/choppy/trend labels delegate to the shared fn, unchanged.
@@ -207,6 +211,16 @@ def test_resolve_tiers_for_regime_ranging_substates(ratchet):
     assert [t[0] for t in directional] == [1.0, 2.0, 3.0, 4.5]
     assert [t[1] for t in directional] == [0.25, 0.50, 0.75, 0.75]
     assert [t[2] for t in directional] == [1.0, 1.0, 0.8, 0.6]  # trail non-increasing
+
+    # #1124: the directional-drift substates resolve to the SAME ladder as the
+    # bare ranging_directional — never an empty ladder (which would silently
+    # leave the auto-protective ratchet exit unarmed).
+    for label in ("ranging_directional_up", "ranging_directional_down"):
+        tiers, errs = ratchet.resolve_tiers_for_regime(
+            {"use_defaults": True}, label, regime_table=True,
+        )
+        assert errs == []
+        assert tiers == directional, f"{label} must mirror the ranging_directional ladder"
 
     # Bare ADX "ranging" still resolves to the quiet ladder (unchanged pre-#1059).
     adx_ranging, errs = ratchet.resolve_tiers_for_regime(

--- a/shared_strategies/close/trailing_tp_ratchet.py
+++ b/shared_strategies/close/trailing_tp_ratchet.py
@@ -89,6 +89,13 @@ def ratchet_close_default_group(label: str) -> Optional[str]:
     l = (label or "").strip()
     if l in ("ranging_quiet", "ranging_volatile", "ranging_directional"):
         return l
+    # #1124: the directional-drift substates share the ranging_directional
+    # scale-out ladder (the geometry is direction-agnostic — the SL side carries
+    # direction, the TP scale-out does not), so map them to that group rather
+    # than fall through to regime_close_default_group's "ranging" (which has no
+    # ratchet ladder → silent never-arm of the protective exit).
+    if l in ("ranging_directional_up", "ranging_directional_down"):
+        return "ranging_directional"
     if l == "ranging":
         return "ranging_quiet"
     return regime_close_default_group(l)

--- a/shared_tools/regime.py
+++ b/shared_tools/regime.py
@@ -56,6 +56,11 @@ VALID_LABELS_COMPOSITE = frozenset({
     "ranging_quiet",
     "ranging_volatile",
     "ranging_directional",
+    # #1124: directional-drift ranging substates. map_composite_label names the
+    # drift via return_eff's sign; bare ranging_directional stays valid for the
+    # exactly-zero case.
+    "ranging_directional_up",
+    "ranging_directional_down",
 })
 # Back-compat alias for ADX-only callers
 _VALID_LABELS = VALID_LABELS_ADX
@@ -168,7 +173,16 @@ def map_composite_label(
         return "trending_down_clean" if clean else "trending_down_choppy"
     # No decisive net move → ranging family.
     if high_adx:
-        # Directional pressure without net follow-through.
+        # Directional pressure without net follow-through (#1124). return_eff's
+        # sign names the drift so the label carries direction, mirroring the
+        # trending family's _up/_down split. Bare ranging_directional is the
+        # producer-side fallback for the exactly-zero case (a common path here,
+        # since big_move is false so return_eff is frequently near zero) — so
+        # back-compat lives in this SSoT, not in each downstream resolver.
+        if return_eff > 0:
+            return "ranging_directional_up"
+        if return_eff < 0:
+            return "ranging_directional_down"
         return "ranging_directional"
     if wide:
         return "ranging_volatile"

--- a/shared_tools/regime.py
+++ b/shared_tools/regime.py
@@ -65,6 +65,35 @@ VALID_LABELS_COMPOSITE = frozenset({
 # Back-compat alias for ADX-only callers
 _VALID_LABELS = VALID_LABELS_ADX
 
+# #1124: the bare `ranging_directional` label is the parent of the directional
+# family — the producer emits the bare label only at exactly return_eff == 0
+# (rare on real price data) and the `_up`/`_down` sub-labels for any non-zero
+# drift. The family rule is one-directional for entry gates and exhaustiveness:
+# a bare `ranging_directional` covers its `_up`/`_down` sub-labels, never the
+# reverse. Mirrors the Go regimeDirectionalBare / regimeDirectionalSubs.
+RANGING_DIRECTIONAL_BARE = "ranging_directional"
+RANGING_DIRECTIONAL_SUBS = frozenset({"ranging_directional_up", "ranging_directional_down"})
+
+
+def regime_label_allows_entry(allowed, current: str) -> bool:
+    """#1124 entry-gate family match.
+
+    True when ``current`` is explicitly in ``allowed`` OR when ``current`` is a
+    directional sub-label (``_up``/``_down``) and the bare ``ranging_directional``
+    parent is in ``allowed``. Expansion is one-directional (bare→subs), so an
+    operator listing an explicit ``_up`` still gates out ``_down``. Empty
+    ``allowed`` (no gate) or empty ``current`` (no regime available) allow entry,
+    matching the Go ``regimeAllowsEntry`` contract for parity.
+    """
+    if not allowed or not current:
+        return True
+    if current in allowed:
+        return True
+    if current in RANGING_DIRECTIONAL_SUBS and RANGING_DIRECTIONAL_BARE in allowed:
+        return True
+    return False
+
+
 _DEFAULT_COMPOSITE_THRESHOLDS = {
     "return_pct": 0.05,
     "range_pct": 0.03,

--- a/shared_tools/test_regime.py
+++ b/shared_tools/test_regime.py
@@ -442,3 +442,27 @@ def test_latest_regime_composite_downtrend():
     snap = _regime_mod.latest_regime_composite(df, period=50, thresholds={"return_pct": 0.02, "range_pct": 0.02, "adx": 15})
     assert snap["regime"] in _regime_mod.VALID_LABELS_COMPOSITE
     assert "trending_down" in snap["regime"]
+
+
+def test_regime_label_allows_entry_bare_covers_subs():
+    """#1124: a bare ranging_directional in allowed covers its _up/_down subs."""
+    allowed = ["ranging_directional"]
+    assert _regime_mod.regime_label_allows_entry(allowed, "ranging_directional_up")
+    assert _regime_mod.regime_label_allows_entry(allowed, "ranging_directional_down")
+    assert _regime_mod.regime_label_allows_entry(allowed, "ranging_directional")
+
+
+def test_regime_label_allows_entry_explicit_sub_does_not_cover_bare_or_sibling():
+    """#1124: family expansion is one-directional (bare→subs), never subs→bare/sibling."""
+    allowed = ["ranging_directional_up"]
+    assert not _regime_mod.regime_label_allows_entry(allowed, "ranging_directional")
+    assert not _regime_mod.regime_label_allows_entry(allowed, "ranging_directional_down")
+    assert _regime_mod.regime_label_allows_entry(allowed, "ranging_directional_up")
+
+
+def test_regime_label_allows_entry_empty_and_exact_match():
+    """#1124: empty allowed / empty current allow entry; exact match wins."""
+    assert _regime_mod.regime_label_allows_entry([], "ranging_directional_up")
+    assert _regime_mod.regime_label_allows_entry(["trending_up"], "")
+    assert _regime_mod.regime_label_allows_entry(["trending_up_clean"], "trending_up_clean")
+    assert not _regime_mod.regime_label_allows_entry(["trending_up_clean"], "ranging_quiet")

--- a/shared_tools/test_regime.py
+++ b/shared_tools/test_regime.py
@@ -395,7 +395,12 @@ def test_map_composite_label_states():
     # Ranging family: no decisive net move.
     assert m(0.01, 10, 0.01, 0.0, th) == "ranging_quiet"
     assert m(0.01, 10, 0.10, 0.0, th) == "ranging_volatile"
-    assert m(0.01, 30, 0.10, 0.0, th) == "ranging_directional"
+    # #1124: high-ADX ranging carries the drift direction in the label. The sign
+    # of return_eff (not its magnitude — big_move is false here) names it.
+    assert m(0.01, 30, 0.10, 0.0, th) == "ranging_directional_up"
+    assert m(-0.01, 30, 0.10, 0.0, th) == "ranging_directional_down"
+    # Exactly-zero drift keeps the bare label as the producer-side fallback.
+    assert m(0.0, 30, 0.10, 0.0, th) == "ranging_directional"
 
 
 def test_latest_regime_composite_ranging_not_trending():


### PR DESCRIPTION
## What this is

A **best-of-N synthesis** for #1124. It starts from the **Opus #1126** solution (the minimal, reuse-first label split) and grafts the **GLM #1125** one-directional *directional-family rule* on top — combining Opus's small correct surface with GLM's future-proof exhaustiveness. The three contestant PRs (#1125 / #1126 / #1127) are left as-is; this is the merge candidate.

## What it adds over the Opus base

The Opus PR's review raised two Recommended Optional findings. Both are resolved here:

1. **`allowed_regimes` silent narrowing (entry/money path).** On the Opus base, a config gating on bare `ranging_directional` quietly stopped allowing entries once the producer relabeled drift to `_up`/`_down` (exact-match gate). Fixed structurally — not with a warning — via the family rule: a bare `ranging_directional` in `allowed_regimes` now matches its `_up`/`_down` bars, in both the live gate (`scheduler/regime.go regimeAllowsEntry`) and the backtest gate (`backtest/backtester.py`), so the match-set never changes.
2. **Incomplete migration coverage.** The family rule makes the migration a no-op for existing bare-keyed composite configs across *every* exhaustiveness-gated surface (see below), so there is no per-surface config edit to enumerate or miss.

## The family rule

A bare `ranging_directional` configured anywhere covers its `_up`/`_down` sub-labels for **entry gating, exhaustiveness validation, and runtime resolution**. It is **one-directional**: an explicit `_up`/`_down` key always wins on exact match, the bare entry is a fallback only on miss, and a config listing only sub-labels *without* the bare parent is still rejected as non-exhaustive (the producer still emits bare at `return_eff == 0`).

Centralized helpers: Go `regimeDirectionalBare` / `regimeDirectionalSubs` / `regimeLabelFamilyCovered` (`scheduler/regime_atr.go`); Python `RANGING_DIRECTIONAL_BARE` / `RANGING_DIRECTIONAL_SUBS` / `regime_label_allows_entry` (`shared_tools/regime.py`).

## Surfaces covered (validator relaxation paired with runtime resolver fallback)

Every exhaustiveness relaxation is paired with the matching runtime resolver fallback on the same surface, so a now-valid bare-only block also resolves at runtime — **no naked-SL hole** (the failure mode GLM's own first pass had and fixed):

- Entry gate — `regimeAllowsEntry` (Go) + backtester bar-regime gate (Python)
- `regime_atr` — `Resolve` + `parseRegimeATRBlock`
- `post_tp_sl` — `RegimeFloatBlock.Resolve` + `parseRegimeFloatBlock` + tiered-TP label validation
- `regime_unified` — `unifiedRegimeScalarParams` + `validateUnifiedRegimeClose` (sole SL owner — the highest-risk site)
- `trailing_tp_ratchet` — explicit `tp_tiers` resolver + `validateTrailingTPRatchetClose`
- `regime_directional_policy` — `Resolve` + `ResolveRawWithLabels`
- `regime_profile_allocation` — `resolveRegimeProfile` + `ResolveRaw`
- Python mirrors in `shared_strategies/close/{regime_atr,post_tp_sl}.py`

## Preserved from the Opus base (unchanged)

The safety-critical ratchet **default-ladder routing** for `_up`/`_down`, the explicit ATR entries, the divergence sign mapping, and the classifier vocabulary — all already correct on the Opus base, left untouched. GLM's dead `regimeLabelWithFamilyFallback` helper (a trap flagged in its own review) was deliberately **not** ported.

## Migration

**No config changes required.** Existing 7-label composite configs keyed on bare `ranging_directional` keep validating and resolving via the family rule. To opt into distinct up/down behavior, add explicit `ranging_directional_up`/`_down` keys — they override the bare entry on exact match.

## Tests

- `go build ./...` / `go vet ./...` clean (run from `scheduler/`, where the module lives).
- `go test ./scheduler/...` green (~31s).
- `pytest shared_tools/test_regime.py shared_strategies/close/ backtest/tests/` — **954 passed**.
- New tests assert each invariant: bare-covers-subs (entry gate, Go + Python + backtest), explicit-sub-wins / one-directional, and sub-labels-only rejected.

Closes #1124

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code
https://claude.ai/code/session_01JX1qCAXvkEaZH7td5xYV9y
