### PR TITLE
fix(#1131): default manual-open ATR fetch to 1h when timeframe unset

### DIFF
--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -348,7 +348,7 @@ func runManualOpen(args []string) int {
 				} else {
 					entryATR = fetched
 					fmt.Fprintf(os.Stderr, "[manual-open] %s %s: --atr omitted; auto-fetched ATR=%.6f (period=14, %s)\n",
-						strategyID, sc.Symbol, fetched, sc.Timeframe)
+						strategyID, sc.Symbol, fetched, resolveManualATRTimeframe(sc))
 				}
 			}
 			if !fetchedOK {

--- a/scheduler/manual_atr.go
+++ b/scheduler/manual_atr.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 )
 
 // HyperliquidFetchATRResult is the JSON output from check_hyperliquid.py
@@ -57,10 +58,19 @@ var runHyperliquidFetchATRFn = RunHyperliquidFetchATR
 // and stamped ATR; if that becomes a problem, plumb a per-strategy ATR period
 // from sc.OpenStrategy.Params here.
 func fetchManualEntryATR(sc StrategyConfig) (float64, string, bool) {
-	if sc.Script == "" || sc.Symbol == "" || sc.Timeframe == "" {
-		return 0, "missing script/symbol/timeframe on strategy config", false
+	if sc.Script == "" || sc.Symbol == "" {
+		return 0, "missing script/symbol on strategy config", false
 	}
-	result, stderr, err := runHyperliquidFetchATRFn(sc.Script, sc.Symbol, sc.Timeframe, 14)
+	// 1h is the canonical default across the manual flow (the init wizard and
+	// generateConfig both default to "1h"), so an unset timeframe falls back to
+	// it rather than failing closed to the coarse heuristic ATR. Only a genuine
+	// fetch failure should drop callers to computeFallbackATR.
+	timeframe := sc.Timeframe
+	if timeframe == "" {
+		timeframe = "1h"
+		fmt.Fprintf(os.Stderr, "[manual-open] defaulting to 1h ATR (strategy timeframe unset)\n")
+	}
+	result, stderr, err := runHyperliquidFetchATRFn(sc.Script, sc.Symbol, timeframe, 14)
 	if err != nil {
 		msg := err.Error()
 		if stderr != "" {

--- a/scheduler/manual_atr.go
+++ b/scheduler/manual_atr.go
@@ -57,17 +57,27 @@ var runHyperliquidFetchATRFn = RunHyperliquidFetchATR
 // Strategies that override ATR period via params will see drift between fetched
 // and stamped ATR; if that becomes a problem, plumb a per-strategy ATR period
 // from sc.OpenStrategy.Params here.
+// resolveManualATRTimeframe returns the timeframe a manual ATR fetch runs
+// against, defaulting an unset strategy timeframe to the manual flow's
+// canonical "1h" (the init wizard and generateConfig both default to "1h").
+// Single source of truth so callers logging the fetch report the timeframe
+// actually used, not the raw (possibly empty) sc.Timeframe.
+func resolveManualATRTimeframe(sc StrategyConfig) string {
+	if sc.Timeframe == "" {
+		return "1h"
+	}
+	return sc.Timeframe
+}
+
 func fetchManualEntryATR(sc StrategyConfig) (float64, string, bool) {
 	if sc.Script == "" || sc.Symbol == "" {
 		return 0, "missing script/symbol on strategy config", false
 	}
-	// 1h is the canonical default across the manual flow (the init wizard and
-	// generateConfig both default to "1h"), so an unset timeframe falls back to
-	// it rather than failing closed to the coarse heuristic ATR. Only a genuine
-	// fetch failure should drop callers to computeFallbackATR.
-	timeframe := sc.Timeframe
-	if timeframe == "" {
-		timeframe = "1h"
+	// An unset timeframe falls back to 1h rather than failing closed to the
+	// coarse heuristic ATR. Only a genuine fetch failure should drop callers to
+	// computeFallbackATR.
+	timeframe := resolveManualATRTimeframe(sc)
+	if sc.Timeframe == "" {
 		fmt.Fprintf(os.Stderr, "[manual-open] defaulting to 1h ATR (strategy timeframe unset)\n")
 	}
 	result, stderr, err := runHyperliquidFetchATRFn(sc.Script, sc.Symbol, timeframe, 14)

--- a/scheduler/manual_atr_test.go
+++ b/scheduler/manual_atr_test.go
@@ -66,7 +66,6 @@ func TestFetchManualEntryATR_MissingFields(t *testing.T) {
 	}{
 		{"no script", StrategyConfig{Symbol: "ETH", Timeframe: "1h"}},
 		{"no symbol", StrategyConfig{Script: "x.py", Timeframe: "1h"}},
-		{"no timeframe", StrategyConfig{Script: "x.py", Symbol: "ETH"}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -100,6 +99,30 @@ func TestFetchManualEntryATR_StubSuccess(t *testing.T) {
 	}
 	if atr != 25.5 {
 		t.Errorf("atr=%v want 25.5", atr)
+	}
+}
+
+// TestFetchManualEntryATR_EmptyTimeframeDefaultsTo1h asserts that an unset
+// timeframe no longer fails closed at the guard but defaults to "1h" and is
+// passed through to the fetch. Stubbed so it never spawns Python.
+func TestFetchManualEntryATR_EmptyTimeframeDefaultsTo1h(t *testing.T) {
+	prev := runHyperliquidFetchATRFn
+	defer func() { runHyperliquidFetchATRFn = prev }()
+	var gotTimeframe string
+	runHyperliquidFetchATRFn = func(script, symbol, timeframe string, period int) (*HyperliquidFetchATRResult, string, error) {
+		gotTimeframe = timeframe
+		return &HyperliquidFetchATRResult{ATR: 18.0, Candles: 200}, "", nil
+	}
+	sc := StrategyConfig{Script: "check.py", Symbol: "ETH"} // Timeframe unset
+	atr, msg, ok := fetchManualEntryATR(sc)
+	if !ok {
+		t.Fatalf("ok=false msg=%s; empty timeframe should default to 1h, not fail closed", msg)
+	}
+	if gotTimeframe != "1h" {
+		t.Errorf("timeframe=%q want 1h", gotTimeframe)
+	}
+	if atr != 18.0 {
+		t.Errorf("atr=%v want 18.0", atr)
 	}
 }
 

--- a/scheduler/manual_atr_test.go
+++ b/scheduler/manual_atr_test.go
@@ -102,6 +102,26 @@ func TestFetchManualEntryATR_StubSuccess(t *testing.T) {
 	}
 }
 
+func TestResolveManualATRTimeframe(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"unset defaults to 1h", "", "1h"},
+		{"explicit 1h", "1h", "1h"},
+		{"explicit non-1h preserved", "4h", "4h"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := resolveManualATRTimeframe(StrategyConfig{Timeframe: c.in})
+			if got != c.want {
+				t.Errorf("resolveManualATRTimeframe(%q)=%q want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
 // TestFetchManualEntryATR_EmptyTimeframeDefaultsTo1h asserts that an unset
 // timeframe no longer fails closed at the guard but defaults to "1h" and is
 // passed through to the fetch. Stubbed so it never spawns Python.


### PR DESCRIPTION
## Summary

`fetchManualEntryATR` (`manual_atr.go`) failed closed when a manual strategy's `timeframe` was unset — its guard rejected empty `sc.Timeframe`, so the manual-open dropped straight to the coarse heuristic ATR (`0.1 × fillPrice / leverage`) instead of attempting the real OHLCV fetch.

`1h` is the canonical default across the rest of the manual flow (the `init` wizard and `generateConfig` both default to `"1h"`). This change defaults an unset timeframe to `"1h"` and keeps the real fetch alive, only falling through to the heuristic on a genuine fetch failure. Guards on `sc.Script` / `sc.Symbol` are unchanged (no sensible default).

The fix is centralized in the shared `fetchManualEntryATR`, so both call sites — `manual.go` and `manual_limit.go` — inherit it with no call-site change.

## Changes

- `manual_atr.go`: drop the empty-timeframe rejection; default to `"1h"` with a stderr line `[manual-open] defaulting to 1h ATR (strategy timeframe unset)` when applied.
- `manual_atr_test.go`: remove the now-invalid `no timeframe` subcase from `TestFetchManualEntryATR_MissingFields`; add `TestFetchManualEntryATR_EmptyTimeframeDefaultsTo1h`, stubbed so it never spawns Python and asserting the fetch receives `timeframe="1h"`.

## Verification

- `gofmt -w` clean
- `go -C scheduler build .` — OK
- `go -C scheduler test .` — full suite passes (30.8s)

Closes #1131

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code
