### PR TITLE
feat(#1133): add user ratchet regime trail defaults

### DIFF
--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -7,6 +7,7 @@ Main entry point for strategy evaluation.
 import sys
 import os
 import argparse
+from copy import deepcopy
 from typing import List, Optional
 
 import numpy as np
@@ -295,13 +296,49 @@ _USER_CLOSE_DEFAULTS_SUPPORTED = {
     "trailing_tp_ratchet_regime",
 }
 
+_STOP_OWNER_KEYS = (
+    "stop_loss_atr_mult",
+    "stop_loss_pct",
+    "stop_loss_margin_pct",
+    "trailing_stop_atr_mult",
+    "trailing_stop_pct",
+    "stop_loss_atr_regime",
+    "trailing_stop_atr_regime",
+)
 
-def _apply_user_close_defaults(close_refs: list, user_defaults: Optional[dict]) -> None:
-    """Inject user_close_defaults tp_tiers into close refs that omit tp_tiers
-    (#866, --defaults user). Mirrors the Go injection at load: an explicit
-    per-ref tp_tiers (the strategy layer) wins, an unsupported evaluator name is
-    skipped, and a ref with no matching entry falls through to the evaluator's
-    built-in system default."""
+
+def _user_close_default_entry(user_defaults: Optional[dict], name: str) -> Optional[dict]:
+    if not isinstance(user_defaults, dict):
+        return None
+    want = str(name or "").strip().lower()
+    entry = user_defaults.get(want)
+    if isinstance(entry, dict):
+        return entry
+    for key in sorted(user_defaults):
+        if str(key or "").strip().lower() == want:
+            entry = user_defaults.get(key)
+            return entry if isinstance(entry, dict) else None
+    return None
+
+
+def _uses_trailing_tp_ratchet_regime(close_refs: list) -> bool:
+    return any(
+        str(ref.get("name", "")).strip().lower() == "trailing_tp_ratchet_regime"
+        for ref in close_refs
+        if isinstance(ref, dict)
+    )
+
+
+def _has_explicit_stop_owner(sc: dict) -> bool:
+    return any(sc.get(k) is not None for k in _STOP_OWNER_KEYS)
+
+
+def _apply_user_close_defaults(close_refs: list, user_defaults: Optional[dict],
+                               sc: Optional[dict] = None) -> None:
+    """Inject user_close_defaults into refs/strategy fields that omit them
+    (#866/#1133, --defaults user). Mirrors the Go loader: explicit per-ref
+    tp_tiers and explicit strategy-level stop owners win, unsupported evaluator
+    names are skipped, and missing entries fall through to system defaults."""
     if not user_defaults:
         return
     for ref in close_refs:
@@ -311,8 +348,8 @@ def _apply_user_close_defaults(close_refs: list, user_defaults: Optional[dict]) 
         params = ref.setdefault("params", {})
         if params.get("tp_tiers") is not None:
             continue  # strategy_close_defaults layer wins
-        entry = user_defaults.get(name)
-        if not isinstance(entry, dict):
+        entry = _user_close_default_entry(user_defaults, name)
+        if entry is None:
             continue
         tp = entry.get("tp_tiers")
         # Mirror the Go loader (validateUserCloseDefaults): an empty or
@@ -322,6 +359,16 @@ def _apply_user_close_defaults(close_refs: list, user_defaults: Optional[dict]) 
         # config outright at load).
         if (isinstance(tp, list) or isinstance(tp, dict)) and tp:
             params["tp_tiers"] = tp
+    if sc is None or not _uses_trailing_tp_ratchet_regime(close_refs):
+        return
+    if _has_explicit_stop_owner(sc):
+        return
+    entry = _user_close_default_entry(user_defaults, "trailing_tp_ratchet_regime")
+    if entry is None:
+        return
+    trail = entry.get("trailing_stop_atr_regime")
+    if isinstance(trail, dict) and trail:
+        sc["trailing_stop_atr_regime"] = deepcopy(trail)
 
 
 def _effective_direction(sc: dict) -> str:
@@ -469,7 +516,7 @@ def load_strategy_config(config_path: str, strategy_id: str,
         # under the operator override). --defaults system leaves them untouched,
         # falling through to the evaluators' built-in defaults.
         if inject_user_defaults:
-            _apply_user_close_defaults(close_refs, cfg.get("user_close_defaults"))
+            _apply_user_close_defaults(close_refs, cfg.get("user_close_defaults"), sc)
         # #942 (D2.1): model the live entry transforms the backtester used to
         # drop silently. ``invert_signal`` flips BUY<->SELL; ``direction`` gates
         # which side may open. Both are applied to the signal in Backtester.run

--- a/backtest/tests/test_strategy_refs_641.py
+++ b/backtest/tests/test_strategy_refs_641.py
@@ -278,6 +278,29 @@ _USER_RATCHET = {
     ]}
 }
 
+_USER_RATCHET_REGIME = {
+    "trailing_tp_ratchet_regime": {
+        "tp_tiers": {
+            "trending_up": [
+                {"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}
+            ],
+            "trending_down": [
+                {"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}
+            ],
+            "ranging": [
+                {"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}
+            ],
+        },
+        "trailing_stop_atr_regime": {
+            "trend_regime": {
+                "trending_up": {"atr_multiple": 2.75},
+                "trending_down": {"atr_multiple": 2.75},
+                "ranging": {"atr_multiple": 1.5},
+            }
+        },
+    }
+}
+
 
 def _ratchet_cfg(tmp_path, close_params):
     return _write_full_config(tmp_path, {
@@ -331,6 +354,46 @@ def test_defaults_user_strategy_tiers_win(tmp_path):
     kwargs = run_backtest.load_strategy_config(path, "hl-r", inject_user_defaults=True)
     tp = kwargs["close_strategies"][0]["params"]["tp_tiers"]
     assert len(tp) == 1 and tp[0]["atr_multiple"] == 5.0  # not overridden
+
+
+def _ratchet_regime_cfg(tmp_path, extra_strategy=None):
+    strategy = {
+        "id": "hl-rr",
+        "type": "perps",
+        "platform": "hyperliquid",
+        "open_strategy": {"name": "tema_cross_bd"},
+        "close_strategy": {"name": "trailing_tp_ratchet_regime", "params": {"use_defaults": True}},
+    }
+    if extra_strategy:
+        strategy.update(extra_strategy)
+    return _write_full_config(tmp_path, {
+        "config_version": 15,
+        "regime": {"enabled": True, "period": 14, "adx_threshold": 20},
+        "user_close_defaults": _USER_RATCHET_REGIME,
+        "strategies": [strategy],
+    })
+
+
+def test_defaults_user_injects_ratchet_regime_trail(tmp_path):
+    path = _ratchet_regime_cfg(tmp_path)
+    kwargs = run_backtest.load_strategy_config(path, "hl-rr", inject_user_defaults=True)
+    assert kwargs["trailing_stop_atr_regime"]["trend_regime"]["ranging"]["atr_multiple"] == 1.5
+    tp = kwargs["close_strategies"][0]["params"].get("tp_tiers")
+    assert tp["trending_up"][0]["trailing_mult_after"] == 1.0
+
+
+def test_defaults_system_does_not_inject_ratchet_regime_trail(tmp_path):
+    path = _ratchet_regime_cfg(tmp_path)
+    kwargs = run_backtest.load_strategy_config(path, "hl-rr", inject_user_defaults=False)
+    assert kwargs["trailing_stop_atr_regime"] is None
+    assert kwargs["close_strategies"][0]["params"].get("tp_tiers") is None
+
+
+def test_defaults_user_ratchet_regime_trail_does_not_override_stop_owner(tmp_path):
+    path = _ratchet_regime_cfg(tmp_path, {"trailing_stop_atr_mult": 3.0})
+    kwargs = run_backtest.load_strategy_config(path, "hl-rr", inject_user_defaults=True)
+    assert kwargs["trailing_stop_atr_regime"] is None
+    assert kwargs["trailing_stop_atr_mult"] == 3.0
 
 
 def test_load_strategy_config_rejects_multi_legacy_close_array(tmp_path):

--- a/scheduler/close_defaults.go
+++ b/scheduler/close_defaults.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -41,6 +42,8 @@ var closeDefaultsSupported = map[string]struct{}{
 	"trailing_tp_ratchet_regime": {},
 }
 
+const userCloseDefaultTrailingStopATRRegimeKey = "trailing_stop_atr_regime"
+
 // closeDefaultsTierEvaluator reports whether name accepts a user_close_defaults
 // override (see closeDefaultsSupported).
 func closeDefaultsTierEvaluator(name string) bool {
@@ -57,6 +60,27 @@ func closeDefaultsSupportedNames() []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+func closeDefaultsEntry(defaults CloseDefaultsMap, name string) (map[string]interface{}, bool) {
+	if len(defaults) == 0 {
+		return nil, false
+	}
+	want := strings.ToLower(strings.TrimSpace(name))
+	if entry, ok := defaults[want]; ok {
+		return entry, true
+	}
+	keys := make([]string, 0, len(defaults))
+	for k := range defaults {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if strings.ToLower(strings.TrimSpace(k)) == want {
+			return defaults[k], true
+		}
+	}
+	return nil, false
 }
 
 // validateUserCloseDefaults checks the user_close_defaults block shape at load:
@@ -80,8 +104,17 @@ func validateUserCloseDefaults(defaults CloseDefaultsMap) []string {
 			errs = append(errs, fmt.Sprintf("user_close_defaults[%q]: not a tp_tiers close evaluator (allowed: %s)", name, strings.Join(closeDefaultsSupportedNames(), ", ")))
 			continue
 		}
+		normName := strings.ToLower(strings.TrimSpace(name))
 		for k := range entry {
-			if k != "tp_tiers" {
+			if k == "tp_tiers" {
+				continue
+			}
+			if normName == trailingTPRatchetRegimeCloseName && k == userCloseDefaultTrailingStopATRRegimeKey {
+				continue
+			}
+			if normName == trailingTPRatchetRegimeCloseName {
+				errs = append(errs, fmt.Sprintf("user_close_defaults[%q]: unknown key %q (only tp_tiers and trailing_stop_atr_regime are allowed)", name, k))
+			} else {
 				errs = append(errs, fmt.Sprintf("user_close_defaults[%q]: unknown key %q (only tp_tiers is allowed)", name, k))
 			}
 		}
@@ -96,6 +129,11 @@ func validateUserCloseDefaults(defaults CloseDefaultsMap) []string {
 		// empty tp_tiers is rejected loudly: it would otherwise inject `[]` and
 		// silently suppress the system default (runtime resolves to zero tiers).
 		errs = append(errs, validateUserCloseDefaultTiers(name, tp)...)
+		if normName == trailingTPRatchetRegimeCloseName {
+			if raw, ok := entry[userCloseDefaultTrailingStopATRRegimeKey]; ok {
+				errs = append(errs, validateUserCloseDefaultTrailingStopATRRegime(name, raw)...)
+			}
+		}
 	}
 	return errs
 }
@@ -152,6 +190,29 @@ func validateUserCloseDefaultTiers(name string, tp interface{}) []string {
 	}
 }
 
+func validateUserCloseDefaultTrailingStopATRRegime(name string, raw interface{}) []string {
+	ctx := fmt.Sprintf("user_close_defaults[%q].%s", name, userCloseDefaultTrailingStopATRRegimeKey)
+	block, ok := raw.(map[string]interface{})
+	if !ok || block == nil {
+		return []string{ctx + ": must be an object"}
+	}
+	if len(block) == 0 {
+		return []string{ctx + ": must not be empty"}
+	}
+	labels := canonicalTrendRegimeLabels
+	if trendRaw, ok := block[regimeClassifierKey]; ok {
+		if trendMap, ok := trendRaw.(map[string]interface{}); ok && len(trendMap) > 0 {
+			labels = make([]string, 0, len(trendMap))
+			for label := range trendMap {
+				labels = append(labels, label)
+			}
+			sort.Strings(labels)
+		}
+	}
+	_, errs := parseRegimeATRBlock(block, ctx, regimeSurfaceTrailing, labels)
+	return errs
+}
+
 // applyUserCloseDefaultsToRef injects the user_close_defaults tp_tiers for ref's
 // evaluator when the ref omits its own tp_tiers (the strategy layer wins). A
 // no-op when ref is nil, already carries tp_tiers, or has no matching user
@@ -163,7 +224,7 @@ func applyUserCloseDefaultsToRef(ref *StrategyRef, defaults CloseDefaultsMap) bo
 	if _, hasExplicit := closeTierListParam(ref.Params); hasExplicit {
 		return false // strategy_close_defaults layer wins
 	}
-	entry, ok := defaults[strings.ToLower(strings.TrimSpace(ref.Name))]
+	entry, ok := closeDefaultsEntry(defaults, ref.Name)
 	if !ok {
 		return false
 	}
@@ -178,6 +239,85 @@ func applyUserCloseDefaultsToRef(ref *StrategyRef, defaults CloseDefaultsMap) bo
 	return true
 }
 
+func userCloseDefaultTrailingStopATRRegime(defaults CloseDefaultsMap) (*RegimeATRBlock, bool) {
+	entry, ok := closeDefaultsEntry(defaults, trailingTPRatchetRegimeCloseName)
+	if !ok {
+		return nil, false
+	}
+	raw, ok := entry[userCloseDefaultTrailingStopATRRegimeKey]
+	if !ok || raw == nil {
+		return nil, false
+	}
+	blockRaw, ok := raw.(map[string]interface{})
+	if !ok || blockRaw == nil {
+		return nil, false
+	}
+	return &RegimeATRBlock{raw: cloneInterfaceMap(blockRaw)}, true
+}
+
+func cloneInterfaceMap(in map[string]interface{}) map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+	blob, err := json.Marshal(in)
+	if err != nil {
+		out := make(map[string]interface{}, len(in))
+		for k, v := range in {
+			out[k] = v
+		}
+		return out
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(blob, &out); err != nil {
+		out = make(map[string]interface{}, len(in))
+		for k, v := range in {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func strategyUsesTrailingTPRatchetRegimeClose(sc StrategyConfig) bool {
+	for _, ref := range sc.closeRefs() {
+		if strings.ToLower(strings.TrimSpace(ref.Name)) == trailingTPRatchetRegimeCloseName {
+			return true
+		}
+	}
+	return false
+}
+
+func strategyHasExplicitStopOwner(sc StrategyConfig) bool {
+	return sc.StopLossPct != nil ||
+		sc.StopLossMarginPct != nil ||
+		sc.TrailingStopPct != nil ||
+		sc.TrailingStopATRMult != nil ||
+		sc.StopLossATRMult != nil ||
+		sc.StopLossATRRegime.IsConfigured() ||
+		sc.TrailingStopATRRegime.IsConfigured() ||
+		strategyUsesUnifiedRegimeClose(sc)
+}
+
+func applyUserCloseDefaultRatchetRegimeTrail(sc *StrategyConfig, defaults CloseDefaultsMap) bool {
+	if sc == nil || !strategyUsesTrailingTPRatchetRegimeClose(*sc) || strategyHasExplicitStopOwner(*sc) {
+		return false
+	}
+	block, ok := userCloseDefaultTrailingStopATRRegime(defaults)
+	if !ok {
+		return false
+	}
+	sc.TrailingStopATRRegime = block
+	return true
+}
+
+func applyUserCloseDefaultRatchetRegimeTrails(cfg *Config) {
+	if cfg == nil || len(cfg.UserCloseDefaults) == 0 {
+		return
+	}
+	for i := range cfg.Strategies {
+		applyUserCloseDefaultRatchetRegimeTrail(&cfg.Strategies[i], cfg.UserCloseDefaults)
+	}
+}
+
 // applyUserCloseDefaults injects user_close_defaults into every strategy's close
 // ref. Called once per load (and per SIGHUP reload) after close-ref
 // normalization, before validation.
@@ -188,4 +328,19 @@ func applyUserCloseDefaults(cfg *Config) {
 	for i := range cfg.Strategies {
 		applyUserCloseDefaultsToRef(cfg.Strategies[i].CloseStrategy, cfg.UserCloseDefaults)
 	}
+}
+
+func cloneCloseDefaultsMap(defaults CloseDefaultsMap) CloseDefaultsMap {
+	if defaults == nil {
+		return nil
+	}
+	out := make(CloseDefaultsMap, len(defaults))
+	for name, entry := range defaults {
+		if entry == nil {
+			out[name] = nil
+			continue
+		}
+		out[name] = cloneInterfaceMap(entry)
+	}
+	return out
 }

--- a/scheduler/close_defaults_test.go
+++ b/scheduler/close_defaults_test.go
@@ -12,6 +12,30 @@ func ratchetUserTiers() []interface{} {
 	}
 }
 
+func ratchetRegimeUserTiers() map[string]interface{} {
+	tierList := func() []interface{} {
+		return []interface{}{
+			map[string]interface{}{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0},
+			map[string]interface{}{"atr_multiple": 2.0, "trailing_mult_after": 0.75, "close_fraction": 0.0},
+		}
+	}
+	return map[string]interface{}{
+		"trending_up":   tierList(),
+		"trending_down": tierList(),
+		"ranging":       tierList(),
+	}
+}
+
+func ratchetRegimeTrailRaw(up, down, ranging float64) map[string]interface{} {
+	return map[string]interface{}{
+		"trend_regime": map[string]interface{}{
+			"trending_up":   map[string]interface{}{"atr_multiple": up},
+			"trending_down": map[string]interface{}{"atr_multiple": down},
+			"ranging":       map[string]interface{}{"atr_multiple": ranging},
+		},
+	}
+}
+
 func TestApplyUserCloseDefaultsToRef_InjectsWhenAbsent(t *testing.T) {
 	defaults := CloseDefaultsMap{"trailing_tp_ratchet": {"tp_tiers": ratchetUserTiers()}}
 	ref := &StrategyRef{Name: "trailing_tp_ratchet", Params: map[string]interface{}{"use_defaults": true}}
@@ -53,6 +77,12 @@ func TestValidateUserCloseDefaults(t *testing.T) {
 	if errs := validateUserCloseDefaults(CloseDefaultsMap{"tiered_tp_atr": {"tp_tiers": validTiered}}); len(errs) != 0 {
 		t.Fatalf("a non-empty entry should pass, got: %v", errs)
 	}
+	if errs := validateUserCloseDefaults(CloseDefaultsMap{"trailing_tp_ratchet_regime": {
+		"tp_tiers":                 ratchetRegimeUserTiers(),
+		"trailing_stop_atr_regime": ratchetRegimeTrailRaw(2.25, 2.25, 1.25),
+	}}); len(errs) != 0 {
+		t.Fatalf("trailing_tp_ratchet_regime trail default should pass, got: %v", errs)
+	}
 	// Non-monotonic ratchet ladder: trail loosens 1.0 -> 2.0 across rungs.
 	nonMonotonicRatchet := []interface{}{
 		map[string]interface{}{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0},
@@ -66,10 +96,12 @@ func TestValidateUserCloseDefaults(t *testing.T) {
 		{"unknown evaluator", CloseDefaultsMap{"bogus_close": {"tp_tiers": []interface{}{}}}, "not a tp_tiers close evaluator"},
 		{"missing tp_tiers", CloseDefaultsMap{"tiered_tp_atr": {}}, "missing tp_tiers"},
 		{"stray key", CloseDefaultsMap{"tiered_tp_atr": {"tp_tiers": validTiered, "foo": 1}}, "unknown key"},
+		{"trail key on other evaluator", CloseDefaultsMap{"trailing_tp_ratchet": {"tp_tiers": ratchetUserTiers(), "trailing_stop_atr_regime": ratchetRegimeTrailRaw(2.0, 2.0, 1.0)}}, "unknown key"},
 		// empty tp_tiers is rejected (would inject [] and silently suppress the system default).
 		{"empty list", CloseDefaultsMap{"trailing_tp_ratchet": {"tp_tiers": []interface{}{}}}, "must not be empty"},
 		{"empty regime map", CloseDefaultsMap{"trailing_tp_ratchet_regime": {"tp_tiers": map[string]interface{}{}}}, "must not be empty"},
 		{"wrong type", CloseDefaultsMap{"tiered_tp_atr": {"tp_tiers": 42}}, "must be a tier list or regime-keyed object"},
+		{"bad trail shape", CloseDefaultsMap{"trailing_tp_ratchet_regime": {"tp_tiers": ratchetRegimeUserTiers(), "trailing_stop_atr_regime": map[string]interface{}{"trend_regime": map[string]interface{}{"trending_up": map[string]interface{}{"close_fraction": 0.5}}}}}, "close_fraction is only allowed inside close-evaluator tiers"},
 		// non-monotonic ratchet ladder attributed to user_close_defaults, not the strategy.
 		{"non-monotonic ratchet attributed", CloseDefaultsMap{"trailing_tp_ratchet": {"tp_tiers": nonMonotonicRatchet}}, "user_close_defaults[\"trailing_tp_ratchet\"].tp_tiers"},
 		// the dynamic unified-regime evaluator is trend_regime-shaped (no tp_tiers) and excluded.
@@ -166,5 +198,201 @@ func TestUserCloseDefaults_LoadConfigRejectsUnknownEvaluator(t *testing.T) {
 	path := writeTestConfig(t, dir, cfgJSON)
 	if _, err := LoadConfig(path); err == nil || !strings.Contains(err.Error(), "not a tp_tiers close evaluator") {
 		t.Fatalf("expected unknown-evaluator rejection, got: %v", err)
+	}
+}
+
+func TestUserCloseDefaults_LoadConfigInjectsRatchetRegimeTrailBeforeScalarDefault(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"regime": {"enabled": true, "period": 14, "adx_threshold": 20},
+		"user_close_defaults": {
+			"trailing_tp_ratchet_regime": {
+				"tp_tiers": {
+					"trending_up": [
+						{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0},
+						{"atr_multiple": 2.0, "trailing_mult_after": 0.75, "close_fraction": 0.0}
+					],
+					"trending_down": [
+						{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0},
+						{"atr_multiple": 2.0, "trailing_mult_after": 0.75, "close_fraction": 0.0}
+					],
+					"ranging": [
+						{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0},
+						{"atr_multiple": 2.0, "trailing_mult_after": 0.75, "close_fraction": 0.0}
+					]
+				},
+				"trailing_stop_atr_regime": {
+					"trend_regime": {
+						"trending_up": {"atr_multiple": 2.25},
+						"trending_down": {"atr_multiple": 2.25},
+						"ranging": {"atr_multiple": 1.25}
+					}
+				}
+			}
+		},
+		"strategies": [{
+			"id": "hl-eth-ratchet-regime",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000,
+			"close_strategy": {"name": "trailing_tp_ratchet_regime", "params": {"use_defaults": true}}
+		}]
+	}`
+	cfg, err := LoadConfig(writeTestConfig(t, dir, cfgJSON))
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	sc := cfg.Strategies[0]
+	if sc.StopLossATRMult != nil {
+		t.Fatalf("StopLossATRMult = %v, want nil because user regime trail owns the SL", *sc.StopLossATRMult)
+	}
+	if sc.TrailingStopATRRegime == nil || !sc.TrailingStopATRRegime.IsConfigured() {
+		t.Fatal("TrailingStopATRRegime was not injected")
+	}
+	if got, ok := resolveRegimeATR(*sc.TrailingStopATRRegime, "ranging"); !ok || got != 1.25 {
+		t.Fatalf("ranging trail = (%g, %v), want (1.25, true)", got, ok)
+	}
+	tiers := trailingRatchetTiersForRegime(sc, "trending_up")
+	if len(tiers) != 2 || tiers[0].TrailingMultAfter != 1.0 || tiers[1].TrailingMultAfter != 0.75 {
+		t.Fatalf("injected regime tiers = %+v, want user defaults", tiers)
+	}
+}
+
+func TestUserCloseDefaults_RatchetRegimeTrailDoesNotOverrideExplicitStopOwner(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"regime": {"enabled": true, "period": 14, "adx_threshold": 20},
+		"user_close_defaults": {
+			"trailing_tp_ratchet_regime": {
+				"tp_tiers": {
+					"trending_up": [{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}],
+					"trending_down": [{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}],
+					"ranging": [{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}]
+				},
+				"trailing_stop_atr_regime": {
+					"trend_regime": {
+						"trending_up": {"atr_multiple": 2.0},
+						"trending_down": {"atr_multiple": 2.0},
+						"ranging": {"atr_multiple": 1.0}
+					}
+				}
+			}
+		},
+		"strategies": [{
+			"id": "hl-eth-ratchet-regime",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000,
+			"stop_loss_atr_mult": 1.0,
+			"close_strategy": {"name": "trailing_tp_ratchet_regime", "params": {"use_defaults": true}}
+		}]
+	}`
+	_, err := LoadConfig(writeTestConfig(t, dir, cfgJSON))
+	if err == nil {
+		t.Fatal("LoadConfig accepted an explicit scalar stop owner with trailing_tp_ratchet_regime")
+	}
+	if !strings.Contains(err.Error(), "requires trailing_stop_atr_regime") || !strings.Contains(err.Error(), "cannot combine with stop_loss_atr_mult") {
+		t.Fatalf("expected missing-regime-owner plus scalar-conflict errors, got: %v", err)
+	}
+}
+
+func TestUserCloseDefaults_ManualSynthesizedRatchetUsesUserTrail(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"regime": {"enabled": true, "period": 14, "adx_threshold": 20},
+		"user_close_defaults": {
+			"trailing_tp_ratchet_regime": {
+				"tp_tiers": {
+					"trending_up": [{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}],
+					"trending_down": [{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}],
+					"ranging": [{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}]
+				},
+				"trailing_stop_atr_regime": {
+					"trend_regime": {
+						"trending_up": {"atr_multiple": 2.75},
+						"trending_down": {"atr_multiple": 2.75},
+						"ranging": {"atr_multiple": 1.5}
+					}
+				}
+			}
+		},
+		"strategies": [{
+			"id": "hl-manual-eth",
+			"type": "manual",
+			"platform": "hyperliquid",
+			"symbol": "ETH",
+			"timeframe": "1h",
+			"capital": 1000,
+			"leverage": 20,
+			"max_drawdown_pct": 20
+		}]
+	}`
+	cfg, err := LoadConfig(writeTestConfig(t, dir, cfgJSON))
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	sc := cfg.Strategies[0]
+	if sc.CloseStrategy == nil || sc.CloseStrategy.Name != trailingTPRatchetRegimeCloseName {
+		t.Fatalf("CloseStrategy = %v, want %s", sc.CloseStrategy, trailingTPRatchetRegimeCloseName)
+	}
+	if got, ok := resolveRegimeATR(*sc.TrailingStopATRRegime, "trending_up"); !ok || got != 2.75 {
+		t.Fatalf("trending_up trail = (%g, %v), want (2.75, true)", got, ok)
+	}
+	if sc.StopLossATRMult != nil {
+		t.Fatalf("StopLossATRMult = %v, want nil under regime ratchet trail owner", *sc.StopLossATRMult)
+	}
+}
+
+func TestUserCloseDefaults_ManualDefaultsTrailWinsOverUserTrail(t *testing.T) {
+	dir := t.TempDir()
+	cfgJSON := `{
+		"regime": {"enabled": true, "period": 14, "adx_threshold": 20},
+		"manual_defaults": {
+			"trailing_stop_atr_regime": {
+				"trend_regime": {
+					"trending_up": {"atr_multiple": 3.5},
+					"trending_down": {"atr_multiple": 3.5},
+					"ranging": {"atr_multiple": 2.0}
+				}
+			}
+		},
+		"user_close_defaults": {
+			"trailing_tp_ratchet_regime": {
+				"tp_tiers": {
+					"trending_up": [{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}],
+					"trending_down": [{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}],
+					"ranging": [{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}]
+				},
+				"trailing_stop_atr_regime": {
+					"trend_regime": {
+						"trending_up": {"atr_multiple": 2.0},
+						"trending_down": {"atr_multiple": 2.0},
+						"ranging": {"atr_multiple": 1.0}
+					}
+				}
+			}
+		},
+		"strategies": [{
+			"id": "hl-manual-eth",
+			"type": "manual",
+			"platform": "hyperliquid",
+			"symbol": "ETH",
+			"timeframe": "1h",
+			"capital": 1000,
+			"leverage": 20,
+			"max_drawdown_pct": 20
+		}]
+	}`
+	cfg, err := LoadConfig(writeTestConfig(t, dir, cfgJSON))
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	sc := cfg.Strategies[0]
+	if got, ok := resolveRegimeATR(*sc.TrailingStopATRRegime, "trending_up"); !ok || got != 3.5 {
+		t.Fatalf("trending_up trail = (%g, %v), want manual default (3.5, true)", got, ok)
 	}
 }

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -302,6 +302,12 @@ func (c *Config) resolveManualRatchetRegimeTrailBlock(sc StrategyConfig) (*Regim
 			return block, true
 		}
 	}
+	// #1133: the fleet-wide ratchet package can also provide the coupled
+	// per-regime opening trail. Manual-specific defaults still win above; this
+	// user_close_defaults layer wins over the system use_defaults baseline below.
+	if block, ok := userCloseDefaultTrailingStopATRRegime(c.UserCloseDefaults); ok {
+		return block, true
+	}
 	// Default: synthesize a use_defaults block, but only when every active label
 	// maps onto the baseline opening-trail family — else the ratchet would carry
 	// a per-regime hole and we must not silently default into an un-resolvable
@@ -1071,6 +1077,12 @@ func loadConfig(path string, skipLiveCredentialChecks bool) (*Config, error) {
 			fmt.Printf("[INFO] %s: no theta_harvest config, applying defaults (profit=60%%, stop=200%%, dte=3)\n", cfg.Strategies[i].ID)
 		}
 	}
+
+	// #1133: user_close_defaults["trailing_tp_ratchet_regime"] may carry the
+	// coupled strategy-level trailing_stop_atr_regime owner. Apply it before the
+	// generic scalar ATR-stop default below so eligible ratchet-regime perps do not
+	// first acquire stop_loss_atr_mult and then fail the single-owner validation.
+	applyUserCloseDefaultRatchetRegimeTrails(&cfg)
 
 	// #562/#601/#605: Default HL perps strategies with no explicit stop-loss /
 	// trailing-stop fields to the configurable top-level

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -45,6 +45,10 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 		addChange("manual_defaults: %s -> %s", formatManualDefaults(cfg.ManualDefaults), formatManualDefaults(next.ManualDefaults))
 		cfg.ManualDefaults = cloneManualDefaults(next.ManualDefaults)
 	}
+	if !reflect.DeepEqual(cfg.UserCloseDefaults, next.UserCloseDefaults) {
+		addChange("user_close_defaults: updated")
+		cfg.UserCloseDefaults = cloneCloseDefaultsMap(next.UserCloseDefaults)
+	}
 
 	// #1062: regime.display_windows hot-reloads (display-only summary filter).
 	// validateHotReloadCompatible masked it but rejects any other regime change,
@@ -170,6 +174,14 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 			if ns.StopLossATRMult == nil || *ns.StopLossATRMult <= 0 {
 				clearATRMultMissingEntryATRWarningsForStrategy(sc.ID)
 			}
+		}
+		if !sc.StopLossATRRegime.EqualForReload(ns.StopLossATRRegime) {
+			addChange("strategy[%s].stop_loss_atr_regime: shape updated", sc.ID)
+			sc.StopLossATRRegime = cloneRegimeATRBlock(ns.StopLossATRRegime)
+		}
+		if !sc.TrailingStopATRRegime.EqualForReload(ns.TrailingStopATRRegime) {
+			addChange("strategy[%s].trailing_stop_atr_regime: shape updated", sc.ID)
+			sc.TrailingStopATRRegime = cloneRegimeATRBlock(ns.TrailingStopATRRegime)
 		}
 		if !floatPtrEqual(sc.TrailingStopMinMovePct, ns.TrailingStopMinMovePct) {
 			addChange("strategy[%s].trailing_stop_min_move_pct: %s -> %s", sc.ID, formatFloatPtrPct(sc.TrailingStopMinMovePct), formatFloatPtrPct(ns.TrailingStopMinMovePct))

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -475,17 +475,17 @@ func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error 
 			errs = append(errs, fmt.Sprintf("strategy[%s] margin_mode changed with open positions (%q -> %q; flatten first or restart after close)",
 				sc.ID, sc.MarginMode, ns.MarginMode))
 		}
-		if sc.Type == "perps" && sc.Platform == "hyperliquid" && strategyHasOpenPositions(stateStrategy(state, sc.ID)) {
+		if hyperliquidManagedStopReloadGuard(sc) && strategyHasOpenPositions(stateStrategy(state, sc.ID)) {
 			oldTrailing := sc.TrailingStopPct != nil && *sc.TrailingStopPct > 0
 			newTrailing := ns.TrailingStopPct != nil && *ns.TrailingStopPct > 0
 			if oldTrailing != newTrailing {
 				errs = append(errs, fmt.Sprintf("strategy[%s] trailing_stop_pct mode changed with open positions (flatten first or restart after close)",
 					sc.ID))
 			}
-			// #505: ATR-derived trailing stop pct is computed once per
-			// position from the entry ATR; toggling the mode mid-position
-			// would mix two distance regimes against the same on-chain
-			// trigger. Treat exactly like trailing_stop_pct.
+			// #505/#1115: ATR-derived trailing stop pct is computed once per
+			// position from the entry ATR; toggling the mode mid-position would
+			// mix two distance regimes against the same on-chain trigger. Applies
+			// to both HL perps and HL manual protection.
 			oldATR := sc.TrailingStopATRMult != nil && *sc.TrailingStopATRMult > 0
 			newATR := ns.TrailingStopATRMult != nil && *ns.TrailingStopATRMult > 0
 			if oldATR != newATR {
@@ -515,7 +515,7 @@ func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error 
 			if oldFixedRegime != newFixedRegime {
 				errs = append(errs, fmt.Sprintf("strategy[%s] stop_loss_atr_regime mode changed with open positions (flatten first or restart after close)",
 					sc.ID))
-			} else if oldFixedRegime && !sc.StopLossATRRegime.EqualForReload(ns.StopLossATRRegime) {
+			} else if oldFixedRegime && !sc.StopLossATRRegime.EqualEffectiveForReload(ns.StopLossATRRegime) {
 				errs = append(errs, fmt.Sprintf("strategy[%s] stop_loss_atr_regime shape changed with open positions (flatten first or restart after close)",
 					sc.ID))
 			}
@@ -524,7 +524,7 @@ func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error 
 			if oldTrailingRegime != newTrailingRegime {
 				errs = append(errs, fmt.Sprintf("strategy[%s] trailing_stop_atr_regime mode changed with open positions (flatten first or restart after close)",
 					sc.ID))
-			} else if oldTrailingRegime && !sc.TrailingStopATRRegime.EqualForReload(ns.TrailingStopATRRegime) {
+			} else if oldTrailingRegime && !sc.TrailingStopATRRegime.EqualEffectiveForReload(ns.TrailingStopATRRegime) {
 				errs = append(errs, fmt.Sprintf("strategy[%s] trailing_stop_atr_regime shape changed with open positions (flatten first or restart after close)",
 					sc.ID))
 			}
@@ -772,6 +772,10 @@ func stateStrategy(state *AppState, id string) *StrategyState {
 		return nil
 	}
 	return state.Strategies[id]
+}
+
+func hyperliquidManagedStopReloadGuard(sc StrategyConfig) bool {
+	return sc.Platform == "hyperliquid" && (sc.Type == "perps" || sc.Type == "manual")
 }
 
 func strategyHasOpenPositions(s *StrategyState) bool {

--- a/scheduler/config_reload_test.go
+++ b/scheduler/config_reload_test.go
@@ -1382,6 +1382,68 @@ func TestApplyHotReloadConfigPropagatesManualDefaults(t *testing.T) {
 	}
 }
 
+func TestApplyHotReloadConfigCopiesFlatRegimeTrailAndUserCloseDefaults(t *testing.T) {
+	oldTrail := &RegimeATRBlock{TrendRegime: map[string]RegimeATREntry{
+		"trending_up":   {ATR: 2.0},
+		"trending_down": {ATR: 2.0},
+		"ranging":       {ATR: 1.0},
+	}}
+	newTrail := &RegimeATRBlock{TrendRegime: map[string]RegimeATREntry{
+		"trending_up":   {ATR: 2.75},
+		"trending_down": {ATR: 2.75},
+		"ranging":       {ATR: 1.5},
+	}}
+	strategy := func(block *RegimeATRBlock) StrategyConfig {
+		return StrategyConfig{
+			ID: "hl-eth", Type: "perps", Platform: "hyperliquid",
+			Script:                "shared_scripts/check_hyperliquid.py",
+			Args:                  []string{"sma_crossover", "ETH", "1h", "--mode=paper"},
+			CloseStrategy:         &StrategyRef{Name: trailingTPRatchetRegimeCloseName},
+			TrailingStopATRRegime: block,
+			Capital:               1000,
+			MaxDrawdownPct:        10,
+			Leverage:              1,
+		}
+	}
+	cfg := minimalReloadConfig([]StrategyConfig{strategy(oldTrail)})
+	next := minimalReloadConfig([]StrategyConfig{strategy(newTrail)})
+	next.UserCloseDefaults = CloseDefaultsMap{
+		trailingTPRatchetRegimeCloseName: {
+			"tp_tiers":                 ratchetRegimeUserTiers(),
+			"trailing_stop_atr_regime": ratchetRegimeTrailRaw(2.75, 2.75, 1.5),
+		},
+	}
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{}},
+	}}
+
+	changes, err := applyHotReloadConfig(cfg, next, state, nil, nil)
+	if err != nil {
+		t.Fatalf("applyHotReloadConfig: %v", err)
+	}
+	joined := strings.Join(changes, "\n")
+	if !strings.Contains(joined, "trailing_stop_atr_regime") {
+		t.Fatalf("changes missing trailing_stop_atr_regime update: %v", changes)
+	}
+	if !strings.Contains(joined, "user_close_defaults") {
+		t.Fatalf("changes missing user_close_defaults update: %v", changes)
+	}
+	got, ok := resolveRegimeATR(*cfg.Strategies[0].TrailingStopATRRegime, "ranging")
+	if !ok || got != 1.5 {
+		t.Fatalf("reloaded ranging trail = (%g, %v), want (1.5, true)", got, ok)
+	}
+	next.Strategies[0].TrailingStopATRRegime.TrendRegime["ranging"] = RegimeATREntry{ATR: 9.0}
+	got, ok = resolveRegimeATR(*cfg.Strategies[0].TrailingStopATRRegime, "ranging")
+	if !ok || got != 1.5 {
+		t.Fatalf("reloaded trail aliases next after mutation: (%g, %v)", got, ok)
+	}
+	next.UserCloseDefaults[trailingTPRatchetRegimeCloseName]["trailing_stop_atr_regime"] = map[string]interface{}{"use_defaults": true}
+	raw := cfg.UserCloseDefaults[trailingTPRatchetRegimeCloseName]["trailing_stop_atr_regime"].(map[string]interface{})
+	if _, ok := raw["use_defaults"]; ok {
+		t.Fatal("cfg.UserCloseDefaults aliases next after reload")
+	}
+}
+
 // #696: empty tp_tiers array is rejected by validation; LoadConfig surfaces
 // the misuse instead of silently falling back to defaults.
 func TestLoadConfigManualDefaultsRejectsEmptyTPTiersArray(t *testing.T) {

--- a/scheduler/config_reload_test.go
+++ b/scheduler/config_reload_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"sync"
@@ -1442,6 +1443,127 @@ func TestApplyHotReloadConfigCopiesFlatRegimeTrailAndUserCloseDefaults(t *testin
 	if _, ok := raw["use_defaults"]; ok {
 		t.Fatal("cfg.UserCloseDefaults aliases next after reload")
 	}
+}
+
+func TestApplyHotReloadConfigRejectsUserCloseDefaultRegimeTrailChangeWithOpenPosition(t *testing.T) {
+	cases := []struct {
+		name     string
+		id       string
+		strategy string
+	}{
+		{
+			name: "perps",
+			id:   "hl-eth",
+			strategy: `{
+				"id": "hl-eth",
+				"type": "perps",
+				"platform": "hyperliquid",
+				"script": "shared_scripts/check_hyperliquid.py",
+				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+				"capital": 1000,
+				"leverage": 1,
+				"max_drawdown_pct": 20,
+				"close_strategy": {"name": "trailing_tp_ratchet_regime", "params": {"use_defaults": true}}
+			}`,
+		},
+		{
+			name: "manual",
+			id:   "hl-manual-eth",
+			strategy: `{
+				"id": "hl-manual-eth",
+				"type": "manual",
+				"platform": "hyperliquid",
+				"symbol": "ETH",
+				"timeframe": "1h",
+				"capital": 1000,
+				"leverage": 1,
+				"max_drawdown_pct": 20
+			}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := loadUserDefaultRatchetRegimeReloadConfig(t, tc.strategy, explicitUserDefaultTrailJSON(2.5, 2.5, 2.0))
+			next := loadUserDefaultRatchetRegimeReloadConfig(t, tc.strategy, explicitUserDefaultTrailJSON(2.5, 2.5, 1.5))
+
+			_, err := applyHotReloadConfig(cfg, next, openETHReloadState(tc.id), nil, nil)
+			if err == nil {
+				t.Fatal("expected open-position reload to reject changed user_close_defaults trailing_stop_atr_regime")
+			}
+			if !strings.Contains(err.Error(), "trailing_stop_atr_regime shape changed with open positions") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestApplyHotReloadConfigAllowsUserCloseDefaultRegimeTrailEquivalentEditWithOpenPosition(t *testing.T) {
+	strategy := `{
+		"id": "hl-eth",
+		"type": "perps",
+		"platform": "hyperliquid",
+		"script": "shared_scripts/check_hyperliquid.py",
+		"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+		"capital": 1000,
+		"leverage": 1,
+		"max_drawdown_pct": 20,
+		"close_strategy": {"name": "trailing_tp_ratchet_regime", "params": {"use_defaults": true}}
+	}`
+	cfg := loadUserDefaultRatchetRegimeReloadConfig(t, strategy, explicitUserDefaultTrailJSON(2.5, 2.5, 2.0))
+	next := loadUserDefaultRatchetRegimeReloadConfig(t, strategy, `{"use_defaults": true}`)
+
+	changes, err := applyHotReloadConfig(cfg, next, openETHReloadState("hl-eth"), nil, nil)
+	if err != nil {
+		t.Fatalf("applyHotReloadConfig rejected equivalent effective trail: %v", err)
+	}
+	if cfg.Strategies[0].TrailingStopATRRegime == nil || !cfg.Strategies[0].TrailingStopATRRegime.UseDefaults {
+		t.Fatalf("equivalent trail edit was not copied into cfg: %#v", cfg.Strategies[0].TrailingStopATRRegime)
+	}
+	joined := strings.Join(changes, "\n")
+	if !strings.Contains(joined, "trailing_stop_atr_regime") || !strings.Contains(joined, "user_close_defaults") {
+		t.Fatalf("changes=%v, want trailing_stop_atr_regime and user_close_defaults entries", changes)
+	}
+}
+
+func loadUserDefaultRatchetRegimeReloadConfig(t *testing.T, strategyJSON, trailJSON string) *Config {
+	t.Helper()
+	cfgJSON := fmt.Sprintf(`{
+		"regime": {"enabled": true, "period": 14, "adx_threshold": 20},
+		"user_close_defaults": {
+			"trailing_tp_ratchet_regime": {
+				"tp_tiers": {
+					"trending_up": [{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}],
+					"trending_down": [{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}],
+					"ranging": [{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}]
+				},
+				"trailing_stop_atr_regime": %s
+			}
+		},
+		"strategies": [%s]
+	}`, trailJSON, strategyJSON)
+	cfg, err := LoadConfig(writeTestConfig(t, t.TempDir(), cfgJSON))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	return cfg
+}
+
+func explicitUserDefaultTrailJSON(up, down, ranging float64) string {
+	return fmt.Sprintf(`{
+		"trend_regime": {
+			"trending_up": {"atr_multiple": %g},
+			"trending_down": {"atr_multiple": %g},
+			"ranging": {"atr_multiple": %g}
+		}
+	}`, up, down, ranging)
+}
+
+func openETHReloadState(strategyID string) *AppState {
+	return &AppState{Strategies: map[string]*StrategyState{
+		strategyID: {ID: strategyID, Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long"},
+		}},
+	}}
 }
 
 // #696: empty tp_tiers array is rejected by validation; LoadConfig surfaces

--- a/scheduler/regime_atr.go
+++ b/scheduler/regime_atr.go
@@ -169,10 +169,23 @@ func (b *RegimeATRBlock) ResolveSurfaceWithLabels(ctxLabel string, surface regim
 	return nil
 }
 
-// EqualForReload reports whether two blocks have the same shape for
-// hot-reload state-compat purposes. Compares the resolved fields; the raw
-// shape is informational only.
+// EqualForReload reports whether two blocks have the same reload representation.
+// The raw JSON shape is informational only; use_defaults provenance is retained
+// so flat/effectively-safe reloads still copy the operator's latest form.
 func (b *RegimeATRBlock) EqualForReload(other *RegimeATRBlock) bool {
+	if !b.EqualEffectiveForReload(other) {
+		return false
+	}
+	if b == nil || b.IsZero() {
+		return true
+	}
+	return b.UseDefaults == other.UseDefaults
+}
+
+// EqualEffectiveForReload reports whether two blocks resolve to the same runtime
+// ATR map for hot-reload state-compat checks. Representation-only edits such as
+// explicit defaults -> use_defaults do not alter already-armed triggers.
+func (b *RegimeATRBlock) EqualEffectiveForReload(other *RegimeATRBlock) bool {
 	aZero := b == nil || b.IsZero()
 	bZero := other == nil || other.IsZero()
 	if aZero != bZero {
@@ -180,9 +193,6 @@ func (b *RegimeATRBlock) EqualForReload(other *RegimeATRBlock) bool {
 	}
 	if aZero {
 		return true
-	}
-	if b.UseDefaults != other.UseDefaults {
-		return false
 	}
 	if len(b.TrendRegime) != len(other.TrendRegime) {
 		return false


### PR DESCRIPTION
## Summary
- Allow `user_close_defaults.trailing_tp_ratchet_regime` to carry the coupled `trailing_stop_atr_regime` owner and validate that shape only for the regime ratchet evaluator.
- Apply the user trail before scalar ATR stop defaults, including the manual synthesized ratchet-regime path with manual defaults taking precedence.
- Mirror the user-default injection in backtest `--defaults user` and copy regenerated regime stop blocks plus `user_close_defaults` on accepted flat hot reload.

## Tests
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test -run 'Test(UserCloseDefaults|ApplyHotReloadConfigCopiesFlatRegimeTrailAndUserCloseDefaults|ManualDefault_ManualDefaultsTrailBlockOverride|ManualDefault_ManualDefaultsTrailBlockNotAliased)'`
- `uv run --no-sync python -m py_compile backtest/run_backtest.py`
- `uv run --extra test --no-sync python -m pytest backtest/tests/test_strategy_refs_641.py -q`
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler build .`
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go -C scheduler test ./...`
- `uv run --extra test --no-sync python -m pytest shared_strategies/ shared_tools/ platforms/ backtest/`
- `git diff --check`

Closes #1133

LLM: GPT5.5 | xhigh | Harness: Codex
