### PR TITLE
feat(#1151): move initial capital from summary table to header

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ tailscale serve --bg --https=8444 http://127.0.0.1:8100   # paper instance (8100
 
 Open `https://<node>.tailnet.ts.net:8443/dashboard`. `status_token` still applies.
 
-`inspect` is read-only against live deploys — shows which stop field won, resolved TP tiers, and direction provenance. Discord summaries: columns `Init | Value | PnL | PnL% | DD | Wallet% | Tf | Int | #T | W/L` plus Book Sharpe footer.
+`inspect` is read-only against live deploys — shows which stop field won, resolved TP tiers, and direction provenance. Discord summaries: header shows aggregate initial capital; table columns `Value | PnL | PnL% | DD | Wallet% | Tf | Int | #T | W/L` plus Book Sharpe footer.
 
 ---
 

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -544,7 +544,6 @@ func FormatCategorySummary(
 			timeframe:      tf,
 			interval:       formatInterval(effectiveInterval),
 			value:          pv,
-			initialCap:     initCap,
 			pnl:            pnl,
 			pnlPct:         pnlPct,
 			maxDrawdownPct: sc.MaxDrawdownPct,
@@ -757,7 +756,6 @@ type botInfo struct {
 	timeframe      string // e.g. "1h" or "—" for spot/options
 	interval       string // e.g. "10m", formatted from effective interval seconds
 	value          float64
-	initialCap     float64
 	pnl            float64
 	pnlPct         float64
 	maxDrawdownPct float64

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -412,8 +412,6 @@ func FormatCategorySummary(
 		sb.WriteString(fmt.Sprintf("%s **%s Summary%s**%s\n", icon, title, assetSuffix, verSuffix))
 	}
 
-	sb.WriteString(fmt.Sprintf("Cycle #%d | %.1fs\n", cycle, elapsed.Seconds()))
-
 	// Circuit breaker status — show warning for any strategy with active breaker.
 	var cbActive []string
 	now := time.Now().UTC()
@@ -578,6 +576,8 @@ func FormatCategorySummary(
 	if totalInitCap > 0 {
 		totalPnlPct = (totalPnl / totalInitCap) * 100
 	}
+
+	sb.WriteString(fmt.Sprintf("Cycle #%d | %.1fs | Initial capital: $%s\n", cycle, elapsed.Seconds(), fmtComma(totalInitCap)))
 
 	// Render the strategy table in chunks of catTableMaxRows. The first chunk
 	// is appended to the in-message header; any extra chunks become standalone
@@ -917,20 +917,19 @@ func formatInterval(seconds int) string {
 // this chunk). totalClosed is the sum of closedTrades across the full bot list
 // and is rendered in the #T column of the TOTAL row. totalWins/totalLosses
 // drive the W/L column in the TOTAL row. Used by writeCatTableChunks.
-func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, includeTotals bool, totalInit, totalValue, totalPnl, totalPnlPct float64, totalClosed, totalWins, totalLosses int) {
+func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, includeTotals bool, totalValue, totalPnl, totalPnlPct float64, totalClosed, totalWins, totalLosses int) {
 	if len(bots) == 0 {
 		return
 	}
 	sb.WriteString("\n```\n")
 	if showWalletPct {
-		header := fmt.Sprintf("%-*s%9s %6s %6s %8s%5s %8s%5s %4s %4s %5s", catTableStrategyWidth, "Strategy", "Init", "Value", "PnL", "PnL%", "DD", "Wallet%", "Tf", "Int", "#T", "W/L")
+		header := fmt.Sprintf("%-*s %6s %6s %8s%5s %8s%5s %4s %4s %5s", catTableStrategyWidth, "Strategy", "Value", "PnL", "PnL%", "DD", "Wallet%", "Tf", "Int", "#T", "W/L")
 		sep := strings.Repeat("-", len(header))
 		sb.WriteString(header + "\n")
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {
 			label := summaryStrategyLabel(bot.id)
 			valStr := fmtComma(bot.value)
-			initStr := fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
 			pctStr := fmtPnlPct(bot.pnlPct)
 			maxDDStr := fmtDrawdownPct(bot.maxDrawdownPct)
@@ -939,40 +938,37 @@ func writeCatTablePartial(sb *strings.Builder, bots []botInfo, showWalletPct, in
 				wpStr = fmt.Sprintf("%.1f%%", bot.walletPct)
 			}
 			wlStr := fmtWinLossRatio(bot.winningTrades, bot.losingTrades)
-			sb.WriteString(fmt.Sprintf("%-*s%9s %6s %6s %8s%5s %8s%5s %4s %4d %5s\n", catTableStrategyWidth, label, initStr, valStr, pnlStr, pctStr, maxDDStr, wpStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
+			sb.WriteString(fmt.Sprintf("%-*s %6s %6s %8s%5s %8s%5s %4s %4d %5s\n", catTableStrategyWidth, label, valStr, pnlStr, pctStr, maxDDStr, wpStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
 		}
 		if includeTotals {
 			sb.WriteString(sep + "\n")
 			totValStr := fmtComma(totalValue)
-			totInitStr := fmtComma(totalInit)
 			totPnlStr := fmtPnl(totalPnl)
 			totPctStr := fmtPnlPct(totalPnlPct)
 			totWlStr := fmtWinLossRatio(totalWins, totalLosses)
-			sb.WriteString(fmt.Sprintf("%-*s%9s %6s %6s %8s%5s %8s%5s %4s %4d %5s\n", catTableStrategyWidth, "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", "100.0%", "", "", totalClosed, totWlStr))
+			sb.WriteString(fmt.Sprintf("%-*s %6s %6s %8s%5s %8s%5s %4s %4d %5s\n", catTableStrategyWidth, "TOTAL", totValStr, totPnlStr, totPctStr, "", "100.0%", "", "", totalClosed, totWlStr))
 		}
 	} else {
-		header := fmt.Sprintf("%-*s%9s %6s %6s %8s%5s %5s %4s %4s %5s", catTableStrategyWidth, "Strategy", "Init", "Value", "PnL", "PnL%", "DD", "Tf", "Int", "#T", "W/L")
+		header := fmt.Sprintf("%-*s %6s %6s %8s%5s %5s %4s %4s %5s", catTableStrategyWidth, "Strategy", "Value", "PnL", "PnL%", "DD", "Tf", "Int", "#T", "W/L")
 		sep := strings.Repeat("-", len(header))
 		sb.WriteString(header + "\n")
 		sb.WriteString(sep + "\n")
 		for _, bot := range bots {
 			label := summaryStrategyLabel(bot.id)
 			valStr := fmtComma(bot.value)
-			initStr := fmtComma(bot.initialCap)
 			pnlStr := fmtPnl(bot.pnl)
 			pctStr := fmtPnlPct(bot.pnlPct)
 			wlStr := fmtWinLossRatio(bot.winningTrades, bot.losingTrades)
 			maxDDStr := fmtDrawdownPct(bot.maxDrawdownPct)
-			sb.WriteString(fmt.Sprintf("%-*s%9s %6s %6s %8s%5s %5s %4s %4d %5s\n", catTableStrategyWidth, label, initStr, valStr, pnlStr, pctStr, maxDDStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
+			sb.WriteString(fmt.Sprintf("%-*s %6s %6s %8s%5s %5s %4s %4d %5s\n", catTableStrategyWidth, label, valStr, pnlStr, pctStr, maxDDStr, bot.timeframe, bot.interval, bot.closedTrades, wlStr))
 		}
 		if includeTotals {
 			sb.WriteString(sep + "\n")
 			totValStr := fmtComma(totalValue)
-			totInitStr := fmtComma(totalInit)
 			totPnlStr := fmtPnl(totalPnl)
 			totPctStr := fmtPnlPct(totalPnlPct)
 			totWlStr := fmtWinLossRatio(totalWins, totalLosses)
-			sb.WriteString(fmt.Sprintf("%-*s%9s %6s %6s %8s%5s %5s %4s %4d %5s\n", catTableStrategyWidth, "TOTAL", totInitStr, totValStr, totPnlStr, totPctStr, "", "", "", totalClosed, totWlStr))
+			sb.WriteString(fmt.Sprintf("%-*s %6s %6s %8s%5s %5s %4s %4d %5s\n", catTableStrategyWidth, "TOTAL", totValStr, totPnlStr, totPctStr, "", "", "", totalClosed, totWlStr))
 		}
 	}
 	sb.WriteString("```\n")
@@ -986,10 +982,8 @@ func writeCatTableChunks(bots []botInfo, totalValue, totalPnl, totalPnlPct float
 	if len(bots) == 0 {
 		return nil
 	}
-	var totalInit float64
 	var totalClosed, totalWins, totalLosses int
 	for _, bot := range bots {
-		totalInit += bot.initialCap
 		totalClosed += bot.closedTrades
 		totalWins += bot.winningTrades
 		totalLosses += bot.losingTrades
@@ -1002,7 +996,7 @@ func writeCatTableChunks(bots []botInfo, totalValue, totalPnl, totalPnlPct float
 		}
 		isLast := end == len(bots)
 		var sb strings.Builder
-		writeCatTablePartial(&sb, bots[start:end], showWalletPct, isLast, totalInit, totalValue, totalPnl, totalPnlPct, totalClosed, totalWins, totalLosses)
+		writeCatTablePartial(&sb, bots[start:end], showWalletPct, isLast, totalValue, totalPnl, totalPnlPct, totalClosed, totalWins, totalLosses)
 		chunks = append(chunks, sb.String())
 	}
 	return chunks

--- a/scheduler/discord_test.go
+++ b/scheduler/discord_test.go
@@ -989,9 +989,12 @@ func TestFormatCategorySummary_SharedWallet(t *testing.T) {
 	if !strings.Contains(msg, "Wallet%") {
 		t.Errorf("expected 'Wallet%%' column header, got:\n%s", msg)
 	}
-	// Should contain Init column
-	if !strings.Contains(msg, "Init") {
-		t.Errorf("expected 'Init' column header, got:\n%s", msg)
+	// Aggregate initial capital appears once in the header, not per-row in the table.
+	if !strings.Contains(msg, "Initial capital: $1,000") {
+		t.Errorf("expected aggregate initial capital in header, got:\n%s", msg)
+	}
+	if strings.Contains(msg, " Init ") {
+		t.Errorf("Init column should be removed from table, got:\n%s", msg)
 	}
 	// Should contain 50.0% for each strategy
 	if !strings.Contains(msg, "50.0%") {
@@ -1010,14 +1013,8 @@ func TestFormatCategorySummary_SharedWallet(t *testing.T) {
 		t.Errorf("expected individual value ~542, got:\n%s", msg)
 	}
 	// PnL should use InitialCapital ($500), not runtime Capital ($542.50)
-	if !strings.Contains(msg, "500") {
-		t.Errorf("expected initial capital '500', got:\n%s", msg)
-	}
-	// Column order should be Init | Value (not Value | Init)
-	initIdx := strings.Index(msg, "Init")
-	valueIdx := strings.Index(msg, "Value")
-	if initIdx >= valueIdx {
-		t.Errorf("expected Init column before Value column, got:\n%s", msg)
+	if !strings.Contains(msg, "+42") && !strings.Contains(msg, "+43") {
+		t.Errorf("expected positive PnL from InitialCapital baseline, got:\n%s", msg)
 	}
 }
 
@@ -1069,9 +1066,11 @@ func TestFormatCategorySummary_NoSharedWallet(t *testing.T) {
 	if strings.Contains(msg, "Wallet%") {
 		t.Errorf("should not show Wallet%% column without shared wallet, got:\n%s", msg)
 	}
-	// Should still show Init column even without shared wallet
-	if !strings.Contains(msg, "Init") {
-		t.Errorf("expected 'Init' column header, got:\n%s", msg)
+	if !strings.Contains(msg, "Initial capital: $1,000") {
+		t.Errorf("expected aggregate initial capital in header, got:\n%s", msg)
+	}
+	if strings.Contains(msg, " Init ") {
+		t.Errorf("Init column should be removed from table, got:\n%s", msg)
 	}
 }
 
@@ -2912,9 +2911,9 @@ func TestFormatCategorySummary_AdjustedTotalOverridesNaiveSum(t *testing.T) {
 		t.Fatalf("no TOTAL row found in:\n%s", msg)
 	}
 
-	// TOTAL row value column must show $8,000 (adjusted). The init-capital column
-	// correctly shows $10,000 (sum of both strategies), so we distinguish by
-	// checking the PnL% which is -20.0% only when value=8000 is used.
+	// TOTAL row value column must show $8,000 (adjusted). Aggregate initial
+	// capital ($10,000) lives in the header; distinguish adjusted total via
+	// PnL% which is -20.0% only when value=8000 is used.
 	if !strings.Contains(totalLine, "8,000") {
 		t.Errorf("TOTAL row should show adjusted $8,000; got: %q\nfull msg:\n%s", totalLine, msg)
 	}
@@ -2972,9 +2971,8 @@ func TestFormatCategorySummary_NegativeAdjustedTotalFallsBackToNaiveSum(t *testi
 	}
 
 	// Explicit $0 adjustment (drained shared wallet) → TOTAL Value column shows
-	// $0, NOT the inflated naive sum. The Init column legitimately shows $5,000
-	// (sum of starting capital), so distinguish by PnL%: Value=0 vs Init=5000
-	// gives -100.0%; the naive fallback (Value=5000) would give 0.0%.
+	// $0, NOT the inflated naive sum. Header shows aggregate initial capital
+	// $5,000; PnL% -100.0% distinguishes drained value=0 from naive fallback 0.0%.
 	drainedLine := totalLineOf(FormatCategorySummary(1, 0, 2, 0, 0, prices, nil, strats, state, "spot", "", 600, 0, nil, nil))
 	if drainedLine == "" {
 		t.Fatal("no TOTAL row found for $0-adjustment case")


### PR DESCRIPTION
## Summary

- Remove the per-row and TOTAL `Init` column from Discord category summary tables (`writeCatTablePartial`)
- Show aggregate initial capital once on the `Cycle #N | …` line using existing `totalInitCap` (`FormatCategorySummary`)
- Drop unused `totalInit` accumulation in `writeCatTableChunks`

Closes #1151

## Test plan

- [x] `go test -run TestFormatCategorySummary ./scheduler`
- [x] `go test ./...` in `scheduler`

LLM: Composer | medium | Harness: Cursor
