### PR TITLE
fix(#1157): surface uncertified directional policy beyond boot stdout

### DIFF
--- a/scheduler/discord_commands.go
+++ b/scheduler/discord_commands.go
@@ -484,7 +484,7 @@ func (d *DiscordNotifier) interactionCreate(s *discordgo.Session, i *discordgo.I
 	// subprocess + venue HTTP, which can exceed Discord's 3s deadline — so ACK
 	// first (deferred), then deliver the built response via a follow-up.
 	case "status":
-		d.respondReadOnlyDeferred(s, i, func() string { return d.buildReadOnly(formatStatusResponse) })
+		d.respondReadOnlyDeferred(s, i, d.buildDiscordStatus)
 	case "positions":
 		d.respondReadOnlyDeferred(s, i, func() string { return d.buildReadOnly(formatPositionsResponse) })
 	case "pnl":
@@ -646,6 +646,22 @@ func (d *DiscordNotifier) buildReadOnly(fn func(*AppState, map[string]float64) s
 	d.ss.mu.RLock()
 	defer d.ss.mu.RUnlock()
 	return fn(d.ss.state, prices)
+}
+
+// buildDiscordStatus is the /status slash-command builder: portfolio summary plus
+// any uncertified/expired regime_directional_policy notes (#1157).
+func (d *DiscordNotifier) buildDiscordStatus() string {
+	if d.ss == nil || d.cfg == nil {
+		return "status server not wired"
+	}
+	prices := d.ss.fetchLiveMarkPrices()
+	d.ss.mu.RLock()
+	defer d.ss.mu.RUnlock()
+	base := formatStatusResponse(d.ss.state, prices)
+	if note := directionalCertOperatorNotes(d.cfg.Strategies, d.cfg.Regime); note != "" {
+		return base + note
+	}
+	return base
 }
 
 func (d *DiscordNotifier) buildHealth() string {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -116,7 +116,8 @@ func main() {
 	setDirectionalCertStore(LoadDirectionalCertSetFailClosed(directionalCertPath(), func(f string, a ...interface{}) {
 		fmt.Fprintf(os.Stderr, f+"\n", a...)
 	}))
-	for _, line := range directionalCertStartupSummary(cfg) {
+	directionalCertSummaryLines := directionalCertStartupSummary(cfg)
+	for _, line := range directionalCertSummaryLines {
 		fmt.Println(line)
 	}
 
@@ -384,6 +385,9 @@ func main() {
 		}
 	}
 
+	// #1157: surface uncertified/expired directional policy to owner DM at startup.
+	notifyDirectionalCertStartupSummary(notifier, directionalCertSummaryLines)
+
 	// #339: Forward the missing-state-DB warning to the owner. Captured before
 	// OpenStateDB ran (which would have created an empty DB), surfaced here
 	// once the notifier is available.
@@ -551,9 +555,11 @@ func main() {
 		setDirectionalCertStore(LoadDirectionalCertSetFailClosed(directionalCertPath(), func(f string, a ...interface{}) {
 			fmt.Fprintf(os.Stderr, "[reload] "+f+"\n", a...)
 		}))
-		for _, line := range directionalCertStartupSummary(cfg) {
+		reloadCertLines := directionalCertStartupSummary(cfg)
+		for _, line := range reloadCertLines {
 			fmt.Printf("[reload] %s\n", line)
 		}
+		notifyDirectionalCertStartupSummary(notifier, reloadCertLines)
 
 		if len(changes) == 0 {
 			fmt.Println("[reload] Config reload applied: no hot-reloadable changes")

--- a/scheduler/regime_directional_certification.go
+++ b/scheduler/regime_directional_certification.go
@@ -429,3 +429,61 @@ func directionalCertSignMismatches(sc StrategyConfig, certStates map[string]stri
 	sort.Strings(out)
 	return out
 }
+
+// directionalCertStartupLinesNeedingOwnerDM filters startup-summary lines that
+// should reach the owner DM (#1157): DEFAULT-OFF, EXPIRED, or unresolvable
+// policy cells. Active certification lines are informational stdout only.
+func directionalCertStartupLinesNeedingOwnerDM(lines []string) []string {
+	var out []string
+	for _, line := range lines {
+		if strings.Contains(line, "DEFAULT-OFF") ||
+			strings.Contains(line, "EXPIRED") ||
+			strings.Contains(line, "policy inert") {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// notifyDirectionalCertStartupSummary forwards filtered #1085 startup-summary
+// lines to the owner DM so uncertified policy is visible outside boot stdout.
+func notifyDirectionalCertStartupSummary(notifier *MultiNotifier, lines []string) {
+	if notifier == nil || !notifier.HasOwner() {
+		return
+	}
+	for _, line := range directionalCertStartupLinesNeedingOwnerDM(lines) {
+		notifier.SendOwnerDM("[state] " + line)
+	}
+}
+
+// directionalCertOperatorNotes returns a compact operator suffix for status
+// surfaces (Discord /status) listing strategies whose directional policy is not
+// actively certified. Empty when every configured policy is CertActive.
+func directionalCertOperatorNotes(strategies []StrategyConfig, rc *RegimeConfig) string {
+	if len(strategies) == 0 {
+		return ""
+	}
+	now := time.Now().UTC()
+	cfg := &Config{Regime: rc}
+	var parts []string
+	for _, sc := range strategies {
+		if !sc.RegimeDirectionalPolicy.IsConfigured() {
+			continue
+		}
+		switch strategyDirectionalCertStatus(sc, rc, now) {
+		case CertActive:
+			continue
+		case CertExpired:
+			_, cell := directionalCertInspectStatus(sc, cfg)
+			parts = append(parts, fmt.Sprintf("%s=EXPIRED %s", sc.ID, cell))
+		default:
+			_, cell := directionalCertInspectStatus(sc, cfg)
+			parts = append(parts, fmt.Sprintf("%s=DEFAULT-OFF %s", sc.ID, cell))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	sort.Strings(parts)
+	return " | directional_policy: " + strings.Join(parts, "; ")
+}

--- a/scheduler/regime_directional_certification.go
+++ b/scheduler/regime_directional_certification.go
@@ -445,13 +445,61 @@ func directionalCertStartupLinesNeedingOwnerDM(lines []string) []string {
 	return out
 }
 
+// directionalCertOwnerDMSnapshot canonicalizes the filtered owner-DM payload so
+// unchanged certification state can be deduped across startup/SIGHUP (#1157).
+func directionalCertOwnerDMSnapshot(lines []string) string {
+	filtered := directionalCertStartupLinesNeedingOwnerDM(lines)
+	if len(filtered) == 0 {
+		return ""
+	}
+	cp := append([]string(nil), filtered...)
+	sort.Strings(cp)
+	return strings.Join(cp, "\n")
+}
+
+var (
+	directionalCertOwnerDMMu       sync.Mutex
+	directionalCertOwnerDMLastSnap string
+)
+
 // notifyDirectionalCertStartupSummary forwards filtered #1085 startup-summary
 // lines to the owner DM so uncertified policy is visible outside boot stdout.
+// Identical filtered snapshots are deduped so repeated SIGHUPs (e.g. after
+// Discord config edits) do not spam the owner. When the snapshot changes,
+// only lines absent from the prior snapshot are DM'd, except on a fresh
+// degradation (prior snapshot empty → all filtered lines).
 func notifyDirectionalCertStartupSummary(notifier *MultiNotifier, lines []string) {
 	if notifier == nil || !notifier.HasOwner() {
 		return
 	}
-	for _, line := range directionalCertStartupLinesNeedingOwnerDM(lines) {
+	filtered := directionalCertStartupLinesNeedingOwnerDM(lines)
+	snap := directionalCertOwnerDMSnapshot(lines)
+	directionalCertOwnerDMMu.Lock()
+	if snap == directionalCertOwnerDMLastSnap {
+		directionalCertOwnerDMMu.Unlock()
+		return
+	}
+	prevSnap := directionalCertOwnerDMLastSnap
+	directionalCertOwnerDMLastSnap = snap
+	directionalCertOwnerDMMu.Unlock()
+
+	if snap == "" {
+		return
+	}
+	toSend := filtered
+	if prevSnap != "" {
+		prevSet := make(map[string]struct{}, strings.Count(prevSnap, "\n")+1)
+		for _, line := range strings.Split(prevSnap, "\n") {
+			prevSet[line] = struct{}{}
+		}
+		toSend = nil
+		for _, line := range filtered {
+			if _, seen := prevSet[line]; !seen {
+				toSend = append(toSend, line)
+			}
+		}
+	}
+	for _, line := range toSend {
 		notifier.SendOwnerDM("[state] " + line)
 	}
 }

--- a/scheduler/regime_directional_certification_test.go
+++ b/scheduler/regime_directional_certification_test.go
@@ -233,6 +233,56 @@ func TestDirectionalCertStartupSummary(t *testing.T) {
 	}
 }
 
+func TestDirectionalCertStartupLinesNeedingOwnerDM(t *testing.T) {
+	lines := []string{
+		"[#1085] active: regime_directional_policy CERTIFIED for (BTC,1h,adx) — directional selection ACTIVE",
+		"[#1085] dir: regime_directional_policy DEFAULT-OFF — no certified directional edge for (BTC,1h,adx)",
+		"[#1085] dir: regime_directional_policy certification EXPIRED for (ETH,1h,adx)",
+		"[#1085] dir: regime_directional_policy configured but symbol/timeframe unresolvable — policy inert (base direction)",
+	}
+	got := directionalCertStartupLinesNeedingOwnerDM(lines)
+	if len(got) != 3 {
+		t.Fatalf("want 3 owner-DM lines, got %d: %v", len(got), got)
+	}
+}
+
+func TestNotifyDirectionalCertStartupSummary(t *testing.T) {
+	mock := &mockNotifier{}
+	mn := NewMultiNotifier(notifierBackend{notifier: mock, ownerID: "owner1"})
+	lines := []string{
+		"[#1085] ok: regime_directional_policy CERTIFIED for (BTC,1h,adx) — directional selection ACTIVE",
+		"[#1085] dir: regime_directional_policy DEFAULT-OFF — no certified directional edge for (BTC,1h,adx)",
+	}
+	notifyDirectionalCertStartupSummary(mn, lines)
+	if len(mock.dms) != 1 {
+		t.Fatalf("want 1 owner DM, got %d: %v", len(mock.dms), mock.dms)
+	}
+	if !strings.Contains(mock.dms[0].content, "DEFAULT-OFF") {
+		t.Fatalf("DM should carry DEFAULT-OFF line, got: %q", mock.dms[0].content)
+	}
+}
+
+func TestDirectionalCertOperatorNotes(t *testing.T) {
+	prev := getDirectionalCertStore()
+	setDirectionalCertStore(emptyDirectionalCertSet())
+	defer setDirectionalCertStore(prev)
+
+	rc := &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20}
+	strategies := []StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Args: []string{"vwap", "ETH", "1h"},
+		RegimeDirectionalPolicy: &RegimeDirectionalPolicy{
+			TrendRegime: map[string]RegimeDirectionalEntry{"trending_down": {Direction: DirectionShort}},
+		},
+	}}
+	note := directionalCertOperatorNotes(strategies, rc)
+	if !strings.Contains(note, "hl-eth=DEFAULT-OFF") {
+		t.Fatalf("expected DEFAULT-OFF note, got: %q", note)
+	}
+	if directionalCertOperatorNotes(nil, rc) != "" {
+		t.Fatal("nil strategies should yield empty note")
+	}
+}
+
 // Review finding 1: DirectionCertifiedAtOpen must survive a daemon restart
 // (SQLite round-trip). Without persistence a CERTIFIED-at-open position reloads
 // as false and is migrated to base direction (req-2 violation). Covers both

--- a/scheduler/regime_directional_certification_test.go
+++ b/scheduler/regime_directional_certification_test.go
@@ -247,6 +247,7 @@ func TestDirectionalCertStartupLinesNeedingOwnerDM(t *testing.T) {
 }
 
 func TestNotifyDirectionalCertStartupSummary(t *testing.T) {
+	resetDirectionalCertOwnerDMDedupForTest()
 	mock := &mockNotifier{}
 	mn := NewMultiNotifier(notifierBackend{notifier: mock, ownerID: "owner1"})
 	lines := []string{
@@ -260,6 +261,36 @@ func TestNotifyDirectionalCertStartupSummary(t *testing.T) {
 	if !strings.Contains(mock.dms[0].content, "DEFAULT-OFF") {
 		t.Fatalf("DM should carry DEFAULT-OFF line, got: %q", mock.dms[0].content)
 	}
+
+	notifyDirectionalCertStartupSummary(mn, lines)
+	if len(mock.dms) != 1 {
+		t.Fatalf("identical snapshot should not re-DM, got %d DMs: %v", len(mock.dms), mock.dms)
+	}
+
+	changed := append([]string(nil), lines...)
+	changed = append(changed, "[#1085] eth: regime_directional_policy DEFAULT-OFF — no certified directional edge for (ETH,1h,adx)")
+	notifyDirectionalCertStartupSummary(mn, changed)
+	if len(mock.dms) != 2 {
+		t.Fatalf("changed snapshot should DM again, got %d DMs: %v", len(mock.dms), mock.dms)
+	}
+
+	certifiedOnly := []string{
+		"[#1085] dir: regime_directional_policy CERTIFIED for (BTC,1h,adx) — directional selection ACTIVE",
+	}
+	notifyDirectionalCertStartupSummary(mn, certifiedOnly)
+	if len(mock.dms) != 2 {
+		t.Fatalf("certified-only snapshot should not DM, got %d DMs", len(mock.dms))
+	}
+	notifyDirectionalCertStartupSummary(mn, lines)
+	if len(mock.dms) != 3 {
+		t.Fatalf("re-degradation after certified should DM again, got %d DMs", len(mock.dms))
+	}
+}
+
+func resetDirectionalCertOwnerDMDedupForTest() {
+	directionalCertOwnerDMMu.Lock()
+	directionalCertOwnerDMLastSnap = ""
+	directionalCertOwnerDMMu.Unlock()
 }
 
 func TestDirectionalCertOperatorNotes(t *testing.T) {

--- a/scheduler/regime_directional_policy.go
+++ b/scheduler/regime_directional_policy.go
@@ -427,6 +427,16 @@ func EffectiveDirectionForPositionGated(sc StrategyConfig, currentRegime, posReg
 	return EffectiveDirectionForRegimeGated(sc, regime, certStates)
 }
 
+// EffectiveInvertSignalForPositionGated is the invert-signal sibling of
+// EffectiveDirectionForPositionGated (#1157 /status parity).
+func EffectiveInvertSignalForPositionGated(sc StrategyConfig, currentRegime, posRegime string, posQty float64, certStates map[string]string) bool {
+	regime := effectiveRegimeForPolicy(currentRegime, posRegime, posQty)
+	if entry, honored := gatedDirectionalEntry(sc, regime, certStates); honored {
+		return entry.InvertSignal
+	}
+	return sc.InvertSignal
+}
+
 // policyAllowsPositionSide reports whether posSide is permitted under at least
 // one entry in regime_directional_policy. Used when pos.Regime is empty
 // (legacy / pre-#741) so validation does not false-positive a side that some

--- a/scheduler/regime_directional_policy_test.go
+++ b/scheduler/regime_directional_policy_test.go
@@ -208,6 +208,20 @@ func TestEffectiveDirectionForPositionGated(t *testing.T) {
 	}
 }
 
+func TestEffectiveInvertSignalForPositionGated(t *testing.T) {
+	policy := &RegimeDirectionalPolicy{TrendRegime: map[string]RegimeDirectionalEntry{
+		"trending_down": {Direction: DirectionShort, InvertSignal: true},
+	}}
+	sc := StrategyConfig{Direction: DirectionLong, InvertSignal: false, RegimeDirectionalPolicy: policy}
+	certAll := map[string]string{"trending_down": DirectionShort}
+	if got := EffectiveInvertSignalForPositionGated(sc, "trending_down", "", 0, certAll); !got {
+		t.Error("certified flat should honor policy invert")
+	}
+	if got := EffectiveInvertSignalForPositionGated(sc, "trending_down", "", 0, nil); got {
+		t.Error("uncertified flat should fall back to base invert=false")
+	}
+}
+
 func TestPolicyAllowsPositionSide(t *testing.T) {
 	policy := &RegimeDirectionalPolicy{TrendRegime: map[string]RegimeDirectionalEntry{
 		"trending_up":   {Direction: DirectionLong},

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -286,26 +286,28 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 	defer ss.mu.RUnlock()
 
 	type StratStatus struct {
-		ID                      string                     `json:"id"`
-		Type                    string                     `json:"type"`
-		Cash                    float64                    `json:"cash"`
-		InitialCapital          float64                    `json:"initial_capital"`
-		Positions               map[string]*Position       `json:"positions"`
-		OptionPositions         map[string]*OptionPosition `json:"option_positions"`
-		TradeCount              int                        `json:"trade_count"`
-		PortfolioValue          float64                    `json:"portfolio_value"`
-		PnL                     float64                    `json:"pnl"`
-		PnLPct                  float64                    `json:"pnl_pct"`
-		RiskState               RiskState                  `json:"risk_state"`
-		Regime                  string                     `json:"regime,omitempty"`
-		BaseDirection           string                     `json:"base_direction,omitempty"`            // #779: base direction from config (pre-policy resolution)
-		BaseInvertSignal        bool                       `json:"base_invert_signal,omitempty"`        // #779: base invert from config (pre-policy resolution)
-		EffectiveDirection      string                     `json:"effective_direction,omitempty"`       // #779: resolved direction for the active regime (policy override or base)
-		EffectiveInvertSignal   bool                       `json:"effective_invert_signal,omitempty"`   // #779: resolved invert for the active regime
-		RegimeDirectionalPolicy bool                       `json:"regime_directional_policy,omitempty"` // #779: true when strategy has a policy block configured
-		EffectivePolicyRegime   string                     `json:"effective_policy_regime,omitempty"`   // #779: regime key the resolver used (pos.Regime while open, current regime when flat); shown only when policy is configured
-		RegimeDivergence        *RegimeDivergenceState     `json:"regime_divergence,omitempty"`         // #907: active window-divergence state; nil when none
-		RegimeProfile           *RegimeProfileState        `json:"regime_profile,omitempty"`            // #998: active regime-profile allocation switch state; nil when none
+		ID                             string                     `json:"id"`
+		Type                           string                     `json:"type"`
+		Cash                           float64                    `json:"cash"`
+		InitialCapital                 float64                    `json:"initial_capital"`
+		Positions                      map[string]*Position       `json:"positions"`
+		OptionPositions                map[string]*OptionPosition `json:"option_positions"`
+		TradeCount                     int                        `json:"trade_count"`
+		PortfolioValue                 float64                    `json:"portfolio_value"`
+		PnL                            float64                    `json:"pnl"`
+		PnLPct                         float64                    `json:"pnl_pct"`
+		RiskState                      RiskState                  `json:"risk_state"`
+		Regime                         string                     `json:"regime,omitempty"`
+		BaseDirection                  string                     `json:"base_direction,omitempty"`                   // #779: base direction from config (pre-policy resolution)
+		BaseInvertSignal               bool                       `json:"base_invert_signal,omitempty"`               // #779: base invert from config (pre-policy resolution)
+		EffectiveDirection             string                     `json:"effective_direction,omitempty"`              // #779: resolved direction for the active regime (policy override or base)
+		EffectiveInvertSignal          bool                       `json:"effective_invert_signal,omitempty"`          // #779: resolved invert for the active regime
+		RegimeDirectionalPolicy        bool                       `json:"regime_directional_policy,omitempty"`        // #779: true when strategy has a policy block configured
+		EffectivePolicyRegime          string                     `json:"effective_policy_regime,omitempty"`          // #779: regime key the resolver used (pos.Regime while open, current regime when flat); shown only when policy is configured
+		DirectionalCertificationStatus string                     `json:"directional_certification_status,omitempty"` // #1157: certified|expired|uncertified for the strategy's (asset,tf,classifier) cell
+		DirectionalCertificationCell   string                     `json:"directional_certification_cell,omitempty"`   // #1157: (asset,timeframe,classifier) certification key
+		RegimeDivergence               *RegimeDivergenceState     `json:"regime_divergence,omitempty"`                // #907: active window-divergence state; nil when none
+		RegimeProfile                  *RegimeProfileState        `json:"regime_profile,omitempty"`                   // #998: active regime-profile allocation switch state; nil when none
 	}
 
 	type StatusResp struct {
@@ -363,46 +365,54 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 		effDir := baseDir
 		effInvert := baseInvert
 		var effRegimeKey string
+		var certStatusStr, certCell string
 		policyConfigured := sc.RegimeDirectionalPolicy.IsConfigured()
 		if policyConfigured {
 			posQty := 0.0
 			posRegime := ""
+			var certStates map[string]string
 			for _, p := range s.Positions {
 				if p != nil && p.Quantity > 0 {
 					posQty = p.Quantity
 					posRegime = positionDirectionalRegimeLabel(p, sc)
+					certStates = p.DirectionCertifiedStatesAtOpen
 					break
 				}
 			}
 			currentDirRegime := strategyCurrentDirectionalRegime(s, sc)
 			effRegimeKey = effectiveRegimeForPolicy(currentDirRegime, posRegime, posQty)
-			if entry, ok := sc.RegimeDirectionalPolicy.Resolve(effRegimeKey); ok {
-				effDir = entry.Direction
-				effInvert = entry.InvertSignal
+			if posQty <= 0 {
+				certStates, _ = strategyDirectionalCertified(sc, ss.regime, time.Now().UTC())
 			}
+			effDir = EffectiveDirectionForPositionGated(sc, currentDirRegime, posRegime, posQty, certStates)
+			effInvert = EffectiveInvertSignalForPositionGated(sc, currentDirRegime, posRegime, posQty, certStates)
+			certStatusStr = strategyDirectionalCertStatus(sc, ss.regime, time.Now().UTC()).String()
+			_, certCell = directionalCertInspectStatus(sc, &Config{Regime: ss.regime})
 		}
 
 		resp.Strategies[id] = StratStatus{
-			ID:                      s.ID,
-			Type:                    s.Type,
-			Cash:                    s.Cash,
-			InitialCapital:          initCap,
-			Positions:               s.Positions,
-			OptionPositions:         s.OptionPositions,
-			TradeCount:              len(s.TradeHistory),
-			PortfolioValue:          pv,
-			PnL:                     pnl,
-			PnLPct:                  pnlPct,
-			RiskState:               s.RiskState,
-			Regime:                  s.Regime,
-			BaseDirection:           baseDir,
-			BaseInvertSignal:        baseInvert,
-			EffectiveDirection:      effDir,
-			EffectiveInvertSignal:   effInvert,
-			RegimeDirectionalPolicy: policyConfigured,
-			EffectivePolicyRegime:   effRegimeKey,
-			RegimeDivergence:        s.RegimeDivergence,
-			RegimeProfile:           s.RegimeProfile,
+			ID:                             s.ID,
+			Type:                           s.Type,
+			Cash:                           s.Cash,
+			InitialCapital:                 initCap,
+			Positions:                      s.Positions,
+			OptionPositions:                s.OptionPositions,
+			TradeCount:                     len(s.TradeHistory),
+			PortfolioValue:                 pv,
+			PnL:                            pnl,
+			PnLPct:                         pnlPct,
+			RiskState:                      s.RiskState,
+			Regime:                         s.Regime,
+			BaseDirection:                  baseDir,
+			BaseInvertSignal:               baseInvert,
+			EffectiveDirection:             effDir,
+			EffectiveInvertSignal:          effInvert,
+			RegimeDirectionalPolicy:        policyConfigured,
+			EffectivePolicyRegime:          effRegimeKey,
+			DirectionalCertificationStatus: certStatusStr,
+			DirectionalCertificationCell:   certCell,
+			RegimeDivergence:               s.RegimeDivergence,
+			RegimeProfile:                  s.RegimeProfile,
 		}
 	}
 

--- a/scheduler/server_test.go
+++ b/scheduler/server_test.go
@@ -182,6 +182,62 @@ func TestHandleStatusWithBearerToken(t *testing.T) {
 	}
 }
 
+func TestHandleStatusUncertifiedPolicyGatedDirection(t *testing.T) {
+	prev := getDirectionalCertStore()
+	setDirectionalCertStore(emptyDirectionalCertSet())
+	defer setDirectionalCertStore(prev)
+
+	policy := &RegimeDirectionalPolicy{
+		TrendRegime: map[string]RegimeDirectionalEntry{
+			"trending_down": {Direction: DirectionShort},
+		},
+	}
+	strategies := []StrategyConfig{{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid",
+		Direction: DirectionLong, Args: []string{"vwap", "ETH", "1h"},
+		RegimeDirectionalPolicy: policy,
+	}}
+	state := NewAppState()
+	state.Strategies["hl-eth"] = &StrategyState{
+		ID:              "hl-eth",
+		Type:            "perps",
+		Regime:          "trending_down",
+		Positions:       map[string]*Position{},
+		OptionPositions: map[string]*OptionPosition{},
+	}
+	var mu sync.RWMutex
+	ss := NewStatusServer(state, &mu, "", strategies, nil)
+	ss.SetConfigContext("", &RegimeConfig{Enabled: true, Period: 14, ADXThreshold: 20})
+
+	req := httptest.NewRequest("GET", "/status", nil)
+	w := httptest.NewRecorder()
+	ss.handleStatus(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp struct {
+		Strategies map[string]struct {
+			EffectiveDirection             string `json:"effective_direction"`
+			DirectionalCertificationStatus string `json:"directional_certification_status"`
+			DirectionalCertificationCell   string `json:"directional_certification_cell"`
+		} `json:"strategies"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	st := resp.Strategies["hl-eth"]
+	if st.EffectiveDirection != DirectionLong {
+		t.Errorf("effective_direction = %q, want %q (gated to base when uncertified)", st.EffectiveDirection, DirectionLong)
+	}
+	if st.DirectionalCertificationStatus != "uncertified" {
+		t.Errorf("directional_certification_status = %q, want uncertified", st.DirectionalCertificationStatus)
+	}
+	if st.DirectionalCertificationCell == "" {
+		t.Error("expected directional_certification_cell to be set")
+	}
+}
+
 func TestNewStatusServerExtractsSymbols(t *testing.T) {
 	strategies := []StrategyConfig{
 		{Type: "spot", Args: []string{"sma", "BTC/USDT", "1h"}},


### PR DESCRIPTION
## Summary

- Owner DM on `directionalCertStartupSummary` DEFAULT-OFF/EXPIRED/inert lines at daemon startup and SIGHUP cert reload (reuses existing summary text; no loader duplication).
- HTTP `/status` now reports `directional_certification_status` + `directional_certification_cell` and computes `effective_direction` / `effective_invert_signal` through the #1085 cert gate (`EffectiveDirectionForPositionGated`).
- Discord `/status` appends a `directional_policy:` suffix when any configured policy is uncertified or expired.

Closes #1157

## Test plan

- [x] `go -C scheduler test ./...` (all pass)
- [x] `TestHandleStatusUncertifiedPolicyGatedDirection` — uncertified policy shows base direction + `uncertified` cert status
- [x] `TestNotifyDirectionalCertStartupSummary` — owner DM only for DEFAULT-OFF lines
- [x] `TestDirectionalCertOperatorNotes` — Discord note suffix

LLM: Composer | medium | Harness: Cursor