### PR TITLE
fix(#1160): make bake-off Bonferroni eligibility achievable by the permutation statistic

### DIFF
--- a/backtest/regime_diagnostics.py
+++ b/backtest/regime_diagnostics.py
@@ -210,7 +210,7 @@ def kmeans_yardstick(features, fwd, k_range=(2, 3, 4, 5, 6, 7), seed=0) -> dict:
 
 
 def score_labels(close, labels, features, horizons=(1, 4, 12), block_mult=3, seed=0,
-                 target="returns") -> dict:
+                 target="returns", n_perm=200) -> dict:
     labels = np.asarray(labels, dtype=object)
     features = np.asarray(features, dtype=float)
     try:
@@ -233,9 +233,11 @@ def score_labels(close, labels, features, horizons=(1, 4, 12), block_mult=3, see
         block_len = max(int(block_mult * mean_dwell), h)
         out["horizons"][f"h{h}"] = {
             "separation": separation(vlabels, fwd),
-            "significance": block_shuffle_pvalue(vlabels, fwd, block_len, seed=seed),
+            "significance": block_shuffle_pvalue(vlabels, fwd, block_len, n_perm=n_perm,
+                                                 seed=seed),
             "yardstick": kmeans_yardstick(features, fwd_full, seed=seed),
-            "per_state_fdr": per_state_significance(vlabels, fwd, block_len, seed=seed),
+            "per_state_fdr": per_state_significance(vlabels, fwd, block_len, n_perm=n_perm,
+                                                    seed=seed),
         }
     # flat aliases for the pre-registered primary (h=4)
     if "h4" in out["horizons"]:
@@ -244,7 +246,7 @@ def score_labels(close, labels, features, horizons=(1, 4, 12), block_mult=3, see
 
 
 def run_window(symbol, timeframe, window, *, model=None, horizons=(1, 4, 12), seed=0,
-               target="returns") -> dict:
+               target="returns", n_perm=200) -> dict:
     from regime import compute_regime_composite, composite_feature_matrix, _DEFAULT_COMPOSITE_THRESHOLDS
     from data_fetcher import load_cached_data
     from eval_windows import WINDOWS, PLATFORM
@@ -260,7 +262,7 @@ def run_window(symbol, timeframe, window, *, model=None, horizons=(1, 4, 12), se
         from regime_hmm import forward_filter_labels
         labels, _conf = forward_filter_labels(features, model)
     return score_labels(df["close"].to_numpy(), labels, features, horizons=horizons,
-                        seed=seed, target=target)
+                        seed=seed, target=target, n_perm=n_perm)
 
 
 def build_parser() -> "argparse.ArgumentParser":

--- a/backtest/research/regime_1080_unsupervised_vol_model.py
+++ b/backtest/research/regime_1080_unsupervised_vol_model.py
@@ -17,6 +17,7 @@ Parameterized by --symbol/--timeframe so #1083 (multi-asset) can reuse it. Read-
 no live or Go path touched. Economic payoff (vs flat-ATR) is #1081, not decided here.
 """
 from __future__ import annotations
+import math
 import os, sys
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 _BACKTEST = os.path.abspath(os.path.join(_THIS_DIR, ".."))
@@ -37,6 +38,11 @@ import regime_vol_model as rvm
 
 DEFAULT_WINDOWS = ("is", "oos", "2023", "2024", "2025H1")
 
+# Auto-resolved permutation-count floor (#1160): the corrected alpha must be ACHIEVABLE by the
+# permutation statistic that is thresholded against it, with headroom — 200 permutations bottom
+# out at p = 1/201 ~ 0.005 > 0.05/18, making the eligibility arm unsatisfiable by construction.
+DEFAULT_BAKEOFF_MIN_N_PERM = 1000
+
 
 def bonferroni_alpha(n_candidates):
     """Family-wise significance threshold for a sweep of n_candidates: SIGNIFICANCE_ALPHA split
@@ -45,18 +51,76 @@ def bonferroni_alpha(n_candidates):
     return SIGNIFICANCE_ALPHA / max(1, int(n_candidates))
 
 
+def min_n_perm_for_alpha(alpha):
+    """Smallest n_perm whose minimum achievable block-shuffle p-value, (0+1)/(n_perm+1),
+    is <= alpha."""
+    return max(1, math.ceil(1.0 / float(alpha)) - 1)
+
+
+def resolve_bakeoff_n_perm(n_candidates, requested=None):
+    """Pick (or validate) the permutation count so the Bonferroni-corrected alpha is achievable
+    by the statistic thresholded against it (#1160). Default: at least
+    DEFAULT_BAKEOFF_MIN_N_PERM and at least 2x resolution headroom below the corrected alpha
+    (min achievable p <= alpha/2). An explicit request below the achievability floor raises —
+    the harness must fail loudly instead of emitting a false honest-negative from a sweep whose
+    eligibility arm no candidate can satisfy."""
+    alpha = bonferroni_alpha(n_candidates)
+    floor = min_n_perm_for_alpha(alpha)
+    if requested is None:
+        return max(DEFAULT_BAKEOFF_MIN_N_PERM, min_n_perm_for_alpha(alpha / 2.0))
+    requested = int(requested)
+    if requested < floor:
+        raise ValueError(
+            f"n_perm={requested} cannot satisfy the Bonferroni-corrected alpha "
+            f"{alpha:.6f} over {n_candidates} candidates: the minimum achievable "
+            f"permutation p-value is 1/{requested + 1} ~ {1.0 / (requested + 1):.6f} "
+            f"> alpha, so no candidate could ever pass. Use n_perm >= {floor}.")
+    return requested
+
+
+def permutation_steps_to_alpha(p_value, n_perm, alpha=SIGNIFICANCE_ALPHA):
+    """How many additional as-or-more-extreme permutations the p-value could absorb before
+    crossing alpha. 0 = knife-edge (one more extreme permutation under a different seed flips
+    the verdict); negative = already above alpha."""
+    scale = int(n_perm) + 1
+    count = int(round(float(p_value) * scale))          # (ge+1) recovered from the reported p
+    limit = int(math.floor(float(alpha) * scale + 1e-9))
+    return limit - count
+
+
+def structurally_ineligible_reason(k, thresholds):
+    """A k-latent candidate emits at most k distinct label names, so below the incumbent-derived
+    min_active_labels floor it can NEVER pass non-degeneracy — it is still scored for evidence,
+    but must not inflate the family-wise denominator (#1160). Returns None when the candidate is
+    structurally eligible."""
+    if int(k) < int(thresholds.min_active_labels):
+        return (f"k={int(k)} can emit at most {int(k)} distinct labels < min_active_labels="
+                f"{int(thresholds.min_active_labels)}: non-degeneracy is unsatisfiable")
+    return None
+
+
+def bonferroni_denominator(candidates):
+    """Number of structurally ELIGIBLE candidates — the family-wise correction divides alpha
+    only across candidates that could actually be selected. Structurally ineligible ones
+    (k below the non-degeneracy floor) contribute zero false-selection probability, so counting
+    them would shrink alpha without bounding anything (#1160)."""
+    return sum(1 for c in candidates if not c.get("structurally_ineligible"))
+
+
 def select_winner(candidates):
-    """Eligible = gate ship AND non-degenerate on every eval window AND the model's forward-vol
-    p-value clears the BONFERRONI-corrected threshold (alpha / number of candidates swept).
-    The gate's own significance arm uses the raw per-candidate alpha; across an 18+ candidate
-    sweep ~1-in-20 clears it by chance, so the family-wise correction is what keeps the
-    SELECTION's false-positive rate bounded. Winner = max held-out model_kruskal_h,
-    stability_gain as tiebreak. Returns None when none are eligible."""
+    """Eligible = structurally eligible AND gate ship AND non-degenerate on every eval window
+    AND the model's forward-vol p-value clears the BONFERRONI-corrected threshold (alpha /
+    number of structurally eligible candidates swept — see bonferroni_denominator). The gate's
+    own significance arm uses the raw per-candidate alpha; across an 18+ candidate sweep
+    ~1-in-20 clears it by chance, so the family-wise correction is what keeps the SELECTION's
+    false-positive rate bounded. Winner = max held-out model_kruskal_h, stability_gain as
+    tiebreak. Returns None when none are eligible."""
     if not candidates:
         return None
-    alpha = bonferroni_alpha(len(candidates))
+    alpha = bonferroni_alpha(bonferroni_denominator(candidates))
     eligible = [c for c in candidates
-                if c.get("verdict", {}).get("ship") and c.get("non_degenerate_all")
+                if not c.get("structurally_ineligible")
+                and c.get("verdict", {}).get("ship") and c.get("non_degenerate_all")
                 and c.get("model_p_value") is not None and c["model_p_value"] <= alpha]
     if not eligible:
         return None
@@ -87,54 +151,91 @@ def _model_label_stream(symbol, timeframe, window, model, period, th):
 
 def run_bakeoff(symbol="BTC/USDT", timeframe="1h", *, in_sample="is", held_out="oos",
                 eval_windows=DEFAULT_WINDOWS, families=("hmm", "gmm", "kmeans"),
-                k_range=range(2, 8), period=48, filter_window=64, seed=0):
+                k_range=range(2, 8), period=48, filter_window=64, seed=0, n_perm=None):
     th = dict(_DEFAULT_COMPOSITE_THRESHOLDS)
     hr_streams = _handrule_streams(symbol, timeframe, eval_windows, period, th)
     thresholds = rvm.derive_thresholds(list(hr_streams.values()))
-    hr_held = run_window(symbol, timeframe, held_out, model=None, seed=seed, target="volatility")
+    # Denominator policy (#1160): every (family, k) cell is fit and scored for evidence, but the
+    # family-wise correction divides alpha only across STRUCTURALLY ELIGIBLE candidates — a k
+    # below the incumbent-derived min_active_labels floor can never pass non-degeneracy, so it
+    # contributes zero false-selection probability. Never silent: ineligible cells are logged to
+    # stderr and stamped into the report.
+    plan = [(family, k) for family in families for k in k_range]
+    ineligible_reasons = {cell: structurally_ineligible_reason(cell[1], thresholds)
+                          for cell in plan}
+    denominator = sum(1 for cell in plan if not ineligible_reasons[cell])
+    alpha = bonferroni_alpha(denominator)
+    n_perm = resolve_bakeoff_n_perm(denominator, requested=n_perm)
+    ineligible_report = [{"family": f, "k": k, "reason": ineligible_reasons[(f, k)]}
+                         for f, k in plan if ineligible_reasons[(f, k)]]
+    for entry in ineligible_report:
+        print(f"NOTE: candidate {entry['family']}:k={entry['k']} is structurally ineligible "
+              f"and excluded from the Bonferroni denominator — {entry['reason']}",
+              file=sys.stderr)
+    print(f"NOTE: n_perm={n_perm} (min achievable p {1.0 / (n_perm + 1):.6f}) vs "
+          f"Bonferroni-corrected alpha {alpha:.6f} over {denominator} structurally "
+          f"eligible of {len(plan)} swept candidates", file=sys.stderr)
+    hr_held = run_window(symbol, timeframe, held_out, model=None, seed=seed,
+                         target="volatility", n_perm=n_perm)
     hr_tr = hr_held["stability"]["transition_rate"]
+    hr_p = hr_held["h4"]["significance"]["p_value"]
     start, end = WINDOWS[in_sample]
     fit_df = load_cached_data(symbol, timeframe, exchange_id=PLATFORM, start_date=start, end_date=end)
     fit_feats = composite_feature_matrix(fit_df, period, th).to_numpy()
 
     candidates = []
-    for family in families:
-        for k in k_range:
-            model = rvm.fit_unsupervised(fit_feats, family=family, k=k,
-                                         filter_window=filter_window, period=period,
-                                         thresholds=th, seed=seed,
-                                         fitted_on={"symbol": symbol, "timeframe": timeframe,
-                                                    "window": in_sample})
-            md = run_window(symbol, timeframe, held_out, model=model, seed=seed, target="volatility")
-            verdict = gate_verdict(hr_held, md)
-            nd = {w: rvm.non_degeneracy(_model_label_stream(symbol, timeframe, w, model, period, th),
-                                        thresholds) for w in eval_windows}
-            candidates.append({
-                "family": family, "k": k, "verdict": verdict,
-                "model_kruskal_h": md["h4"]["separation"]["kruskal_h"],
-                "model_p_value": md["h4"]["significance"]["p_value"],
-                "stability_gain": float(hr_tr - md["stability"]["transition_rate"]),
-                "coverage": md["coverage"],
-                "non_degeneracy": {w: nd[w] for w in eval_windows},
-                "non_degenerate_all": all(nd[w]["ok"] for w in eval_windows),
-                "states": model["states"], "mapping": model["mapping"],
-            })
-    alpha = bonferroni_alpha(len(candidates))
+    for family, k in plan:
+        model = rvm.fit_unsupervised(fit_feats, family=family, k=k,
+                                     filter_window=filter_window, period=period,
+                                     thresholds=th, seed=seed,
+                                     fitted_on={"symbol": symbol, "timeframe": timeframe,
+                                                "window": in_sample})
+        md = run_window(symbol, timeframe, held_out, model=model, seed=seed,
+                        target="volatility", n_perm=n_perm)
+        verdict = gate_verdict(hr_held, md)
+        nd = {w: rvm.non_degeneracy(_model_label_stream(symbol, timeframe, w, model, period, th),
+                                    thresholds) for w in eval_windows}
+        candidates.append({
+            "family": family, "k": k, "verdict": verdict,
+            "model_kruskal_h": md["h4"]["separation"]["kruskal_h"],
+            "model_p_value": md["h4"]["significance"]["p_value"],
+            "stability_gain": float(hr_tr - md["stability"]["transition_rate"]),
+            "coverage": md["coverage"],
+            "non_degeneracy": {w: nd[w] for w in eval_windows},
+            "non_degenerate_all": all(nd[w]["ok"] for w in eval_windows),
+            "structurally_ineligible": bool(ineligible_reasons[(family, k)]),
+            "structural_ineligibility_reason": ineligible_reasons[(family, k)],
+            "states": model["states"], "mapping": model["mapping"],
+        })
     for c in candidates:
-        c["passes_bonferroni"] = (c["model_p_value"] is not None and c["model_p_value"] <= alpha)
+        c["passes_bonferroni"] = (not c["structurally_ineligible"]
+                                  and c["model_p_value"] is not None
+                                  and c["model_p_value"] <= alpha)
     winner = select_winner(candidates)
+    incumbent_steps = permutation_steps_to_alpha(hr_p, n_perm)
     return {
         "symbol": symbol, "timeframe": timeframe, "in_sample": in_sample,
         "held_out": held_out, "target": "volatility",
         "candidate_count": len(candidates),
         "significance_alpha": SIGNIFICANCE_ALPHA,
         "bonferroni_alpha": alpha,
+        "bonferroni_denominator": denominator,
+        "bonferroni_denominator_policy": (
+            "structurally ineligible candidates (k < incumbent-derived min_active_labels) are "
+            "scored for evidence but excluded from the family-wise denominator"),
+        "structurally_ineligible": ineligible_report,
+        "n_perm": int(n_perm),
+        "min_achievable_p_value": 1.0 / (n_perm + 1),
         "non_degeneracy_thresholds": vars(thresholds),
         "handrule_held_out": {"kruskal_h": hr_held["h4"]["separation"]["kruskal_h"],
-                              "p_value": hr_held["h4"]["significance"]["p_value"],
+                              "p_value": hr_p,
                               "transition_rate": hr_tr,
-                              "abstained": bool(hr_held["h4"]["significance"]["p_value"]
-                                                > SIGNIFICANCE_ALPHA)},
+                              "abstained": bool(hr_p > SIGNIFICANCE_ALPHA),
+                              # Knife-edge visibility (#1160): additional as-or-more-extreme
+                              # permutations the incumbent p could absorb before the
+                              # trustworthy/abstain verdict flips (0 = next one flips it).
+                              "permutation_steps_to_alpha": int(incumbent_steps),
+                              "knife_edge": bool(0 <= incumbent_steps <= 1)},
         "candidates": candidates,
         "winner": ({"family": winner["family"], "k": winner["k"]} if winner else None),
     }
@@ -150,6 +251,10 @@ def build_parser():
     p.add_argument("--period", type=int, default=48)
     p.add_argument("--filter-window", type=int, default=64)
     p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--n-perm", type=int, default=None,
+                   help="block-shuffle permutation count for the significance arm (default: "
+                        "auto-resolved so the Bonferroni-corrected alpha is achievable with "
+                        "headroom; explicit values below the achievability floor are rejected)")
     p.add_argument("--json", default=None, help="write the bake-off report JSON here")
     return p
 
@@ -159,7 +264,8 @@ def main(argv=None):
     args = build_parser().parse_args(argv)
     report = run_bakeoff(args.symbol, args.timeframe, in_sample=args.in_sample,
                          held_out=args.held_out, period=args.period,
-                         filter_window=args.filter_window, seed=args.seed)
+                         filter_window=args.filter_window, seed=args.seed,
+                         n_perm=args.n_perm)
     text = json.dumps(report, indent=2, default=float)
     if args.json:
         with open(args.json, "w") as fh:

--- a/backtest/research/regime_1080_unsupervised_vol_model.py
+++ b/backtest/research/regime_1080_unsupervised_vol_model.py
@@ -88,6 +88,15 @@ def permutation_steps_to_alpha(p_value, n_perm, alpha=SIGNIFICANCE_ALPHA):
     return limit - count
 
 
+def verdict_knife_edge(steps):
+    """True when the trustworthy/abstain verdict sits within one permutation step of alpha on
+    EITHER side: steps 0 / -1 flip on a single as-or-more-extreme permutation (one added /
+    one removed under a different seed), steps 1 is a single step from the boundary itself.
+    A one-sided check would report an abstain-by-one incumbent as a comfortable abstain —
+    understating exactly the fragility this flag exists to surface."""
+    return abs(int(steps)) <= 1
+
+
 def structurally_ineligible_reason(k, thresholds):
     """A k-latent candidate emits at most k distinct label names, so below the incumbent-derived
     min_active_labels floor it can NEVER pass non-degeneracy — it is still scored for evidence,
@@ -233,9 +242,10 @@ def run_bakeoff(symbol="BTC/USDT", timeframe="1h", *, in_sample="is", held_out="
                               "abstained": bool(hr_p > SIGNIFICANCE_ALPHA),
                               # Knife-edge visibility (#1160): additional as-or-more-extreme
                               # permutations the incumbent p could absorb before the
-                              # trustworthy/abstain verdict flips (0 = next one flips it).
+                              # trustworthy/abstain verdict flips (0 = next one flips it;
+                              # negative = already abstained, -1 by a single permutation).
                               "permutation_steps_to_alpha": int(incumbent_steps),
-                              "knife_edge": bool(0 <= incumbent_steps <= 1)},
+                              "knife_edge": bool(verdict_knife_edge(incumbent_steps))},
         "candidates": candidates,
         "winner": ({"family": winner["family"], "k": winner["k"]} if winner else None),
     }

--- a/backtest/research/regime_1083_multi_asset_gate.py
+++ b/backtest/research/regime_1083_multi_asset_gate.py
@@ -110,6 +110,10 @@ def _summarize_bakeoff(report: dict) -> dict:
         "handrule_held_out": report.get("handrule_held_out"),
         "significance_alpha": report.get("significance_alpha"),
         "bonferroni_alpha": report.get("bonferroni_alpha"),
+        "bonferroni_denominator": report.get("bonferroni_denominator"),
+        "n_perm": report.get("n_perm"),
+        "min_achievable_p_value": report.get("min_achievable_p_value"),
+        "structurally_ineligible": report.get("structurally_ineligible"),
     }
 
 

--- a/backtest/tests/test_regime_vol_model.py
+++ b/backtest/tests/test_regime_vol_model.py
@@ -373,13 +373,24 @@ def test_bakeoff_smoke_on_cached_data_if_available():
         # module load is inside the guard: a missing transitive dep / unparseable
         # eval_windows config must SKIP, not FAIL.
         mod = _load_research_module("smoke")
+        # narrowed sweep at an explicit n_perm=200 — the #1160 achievability guard must
+        # NOT spuriously trip when 200 permutations DO resolve the corrected alpha.
         report = mod.run_bakeoff("BTC/USDT", "1h", families=("kmeans",),
-                                 k_range=range(3, 4), eval_windows=("is", "oos"))
+                                 k_range=range(3, 4), eval_windows=("is", "oos"),
+                                 n_perm=200)
     except Exception as e:  # noqa: BLE001 — no cached OHLCV in CI -> skip, not fail
         pytest.skip(f"no cached OHLCV / data path unavailable: {e}")
     assert "candidates" in report and len(report["candidates"]) == 1
     assert "non_degeneracy_thresholds" in report
     assert "handrule_held_out" in report and "abstained" in report["handrule_held_out"]
+    # #1160 poweredness audit fields
+    assert report["n_perm"] == 200
+    assert report["min_achievable_p_value"] == pytest.approx(1.0 / 201.0)
+    assert "bonferroni_denominator" in report and "bonferroni_denominator_policy" in report
+    assert "structurally_ineligible" in report
+    assert "permutation_steps_to_alpha" in report["handrule_held_out"]
+    assert "knife_edge" in report["handrule_held_out"]
+    assert report["min_achievable_p_value"] <= report["bonferroni_alpha"]
 
 
 def test_non_degeneracy_flags_high_occupancy():
@@ -403,3 +414,108 @@ def test_non_degeneracy_flags_low_transition_rate():
     rep = non_degeneracy(stream, thr)
     assert rep["ok"] is False
     assert "min_transition_rate" in " ".join(rep["reasons"])
+
+
+# --- #1160: the Bonferroni eligibility arm must be achievable by the permutation statistic ---
+
+
+def test_resolve_bakeoff_n_perm_default_achieves_corrected_alpha_with_headroom():
+    mod = _load_research_module("nperm_default")
+    n = mod.resolve_bakeoff_n_perm(18)
+    assert n >= mod.DEFAULT_BAKEOFF_MIN_N_PERM
+    # minimum achievable p clears the 18-candidate corrected alpha with >= 2x headroom
+    assert 1.0 / (n + 1) <= mod.bonferroni_alpha(18) / 2.0
+
+
+def test_resolve_bakeoff_n_perm_rejects_underpowered_explicit_request():
+    mod = _load_research_module("nperm_reject")
+    # the merged default: 200 permutations bottom out at 1/201 ~ 0.00498 > 0.05/18 ~ 0.00278
+    with pytest.raises(ValueError, match="cannot satisfy the Bonferroni-corrected alpha"):
+        mod.resolve_bakeoff_n_perm(18, requested=200)
+
+
+def test_resolve_bakeoff_n_perm_narrowed_sweep_accepts_200():
+    mod = _load_research_module("nperm_narrow")
+    # kmeans-only sweep: 6 candidates -> alpha = 0.05/6 ~ 0.00833 > 1/201, guard must not trip
+    assert mod.resolve_bakeoff_n_perm(6, requested=200) == 200
+
+
+def test_real_pipeline_p_value_can_be_crowned_at_default_sweep_resolution():
+    # Regression at the REAL statistic's resolution (#1160), not synthetic p-values: a candidate
+    # with genuinely strong forward separation, scored by block_shuffle_pvalue at the
+    # auto-resolved n_perm, must clear the 18-candidate Bonferroni threshold and be crowned.
+    # At the merged n_perm=200 this was impossible by construction (min p 1/201 > 0.05/18).
+    from regime_diagnostics import block_shuffle_pvalue
+    mod = _load_research_module("crown")
+    n_perm = mod.resolve_bakeoff_n_perm(18)
+    rng = np.random.default_rng(0)
+    labels = np.array((["low"] * 8 + ["high"] * 8) * 25, dtype=object)   # 400 bars, 50 blocks
+    fwd = np.where(labels == "high", 1.0, 0.001) + rng.normal(0, 1e-4, len(labels))
+    sig = block_shuffle_pvalue(labels, fwd, block_len=8, n_perm=n_perm, seed=0)
+    alpha = mod.bonferroni_alpha(18)
+    assert sig["p_value"] <= alpha
+    strong = {"family": "kmeans", "k": 4, "verdict": {"ship": True},
+              "model_p_value": sig["p_value"], "non_degenerate_all": True,
+              "model_kruskal_h": 999.0, "stability_gain": 0.9}
+    fillers = [{"family": "hmm", "k": 5, "verdict": {"ship": False}, "model_p_value": 0.9,
+                "non_degenerate_all": False, "model_kruskal_h": 1.0, "stability_gain": 0.0}
+               for _ in range(17)]
+    win = mod.select_winner([strong] + fillers)
+    assert win is not None and win["family"] == "kmeans" and win["k"] == 4
+
+
+def test_structurally_ineligible_reason_keys_off_min_active_labels():
+    mod = _load_research_module("inelig_reason")
+    thr = rvm.NonDegeneracyThresholds(min_active_labels=4, max_occupancy=0.9,
+                                      min_transition_rate=0.0)
+    assert mod.structurally_ineligible_reason(2, thr) is not None
+    assert mod.structurally_ineligible_reason(3, thr) is not None
+    assert mod.structurally_ineligible_reason(4, thr) is None
+    assert mod.structurally_ineligible_reason(7, thr) is None
+
+
+def test_bonferroni_denominator_excludes_structurally_ineligible():
+    mod = _load_research_module("denom")
+    cands = ([{"structurally_ineligible": True} for _ in range(6)]
+             + [{} for _ in range(12)])
+    assert mod.bonferroni_denominator(cands) == 12
+    assert mod.bonferroni_alpha(mod.bonferroni_denominator(cands)) == pytest.approx(0.05 / 12)
+
+
+def test_select_winner_ignores_structurally_ineligible_candidates():
+    # An ineligible candidate must neither win nor shrink alpha for the eligible one:
+    # 1 eligible + 19 ineligible -> denominator 1 -> alpha = 0.05, so p=0.03 is crownable.
+    mod = _load_research_module("inelig_select")
+    eligible = {"family": "gmm", "k": 4, "verdict": {"ship": True}, "model_p_value": 0.03,
+                "non_degenerate_all": True, "model_kruskal_h": 10.0, "stability_gain": 0.1}
+    ineligible = [{"family": "kmeans", "k": 2, "verdict": {"ship": True},
+                   "model_p_value": 0.0001, "non_degenerate_all": True,
+                   "model_kruskal_h": 999.0, "stability_gain": 0.9,
+                   "structurally_ineligible": True}
+                  for _ in range(19)]
+    win = mod.select_winner([eligible] + ineligible)
+    assert win is not None and win["family"] == "gmm" and win["k"] == 4
+
+
+def test_permutation_steps_to_alpha_flags_merged_run_knife_edge():
+    mod = _load_research_module("steps")
+    # the merged evidence run: incumbent OOS p = 10/201 ~ 0.0498 at n_perm=200 -> zero headroom
+    # (the very next as-or-more-extreme permutation under another seed flips the verdict)
+    assert mod.permutation_steps_to_alpha(10.0 / 201.0, 200) == 0
+    assert mod.permutation_steps_to_alpha(15.0 / 201.0, 200) < 0   # already abstained
+    assert mod.permutation_steps_to_alpha(2.0 / 201.0, 200) > 0    # comfortable margin
+
+
+def test_score_labels_default_n_perm_is_byte_identical():
+    # #1160 acceptance: existing callers that pass no n_perm must produce byte-identical
+    # output to an explicit n_perm=200 (regime_calibrate / regime_bounded_window_validate).
+    import json
+    from regime_diagnostics import score_labels
+    feats = _feature_blob_matrix()
+    rng = np.random.default_rng(1)
+    labels = rng.choice(["a", "b", "c"], size=len(feats)).astype(object)
+    close = 100.0 + np.cumsum(rng.normal(0.0, 0.5, len(feats)))
+    base = score_labels(close, labels, feats, target="volatility")
+    explicit = score_labels(close, labels, feats, target="volatility", n_perm=200)
+    assert (json.dumps(base, default=float, sort_keys=True)
+            == json.dumps(explicit, default=float, sort_keys=True))

--- a/backtest/tests/test_regime_vol_model.py
+++ b/backtest/tests/test_regime_vol_model.py
@@ -506,6 +506,23 @@ def test_permutation_steps_to_alpha_flags_merged_run_knife_edge():
     assert mod.permutation_steps_to_alpha(2.0 / 201.0, 200) > 0    # comfortable margin
 
 
+def test_verdict_knife_edge_is_symmetric_around_alpha():
+    # knife_edge must fire whenever a single as-or-more-extreme permutation (added on the
+    # proceed side, removed on the abstain side) would flip trustworthy/abstain — one-sided
+    # 0..1 would read an abstain-by-one incumbent as a comfortable abstain.
+    mod = _load_research_module("knife")
+    # proceed-edge regression guard: merged-run p = 10/201 -> steps 0, flagged
+    assert mod.permutation_steps_to_alpha(10.0 / 201.0, 200) == 0
+    assert mod.verdict_knife_edge(0) is True
+    # abstain-by-one: p = 11/201 -> steps -1, must flag
+    assert mod.permutation_steps_to_alpha(11.0 / 201.0, 200) == -1
+    assert mod.verdict_knife_edge(-1) is True
+    # one step inside the boundary still flags; two steps either side must not
+    assert mod.verdict_knife_edge(1) is True
+    assert mod.verdict_knife_edge(-2) is False
+    assert mod.verdict_knife_edge(2) is False
+
+
 def test_score_labels_default_n_perm_is_byte_identical():
     # #1160 acceptance: existing callers that pass no n_perm must produce byte-identical
     # output to an explicit n_perm=200 (regime_calibrate / regime_bounded_window_validate).


### PR DESCRIPTION
Closes #1160

## Problem

The #1080 bake-off's Bonferroni eligibility arm was structurally unsatisfiable at the default sweep: `block_shuffle_pvalue`'s `n_perm=200` bottoms out at p = 1/201 ≈ 0.00498, above the 18-candidate corrected alpha 0.05/18 ≈ 0.00278 — `passes_bonferroni` was false for every candidate on every run, and the impossibility read as an honest `WINNER: none eligible`. The #1083 multi-asset gate (merged since the issue was filed) calls `run_bakeoff` and silently inherited the same impossibility.

## Changes

- **`n_perm` threading:** `run_window` → `score_labels` → `block_shuffle_pvalue` + `per_state_significance` accept an explicit `n_perm`, defaulting to 200 — `regime_calibrate` and `regime_bounded_window_validate` output stays byte-identical (regression-tested).
- **Auto-resolved permutation count:** `run_bakeoff` resolves `n_perm` via `resolve_bakeoff_n_perm` — at least 1000, and minimum achievable p ≤ corrected alpha / 2 (2× resolution headroom). An explicit `--n-perm` below the achievability floor **raises** with the exact floor in the message; narrowed sweeps where 200 suffices (e.g. kmeans-only) are accepted unchanged.
- **Bonferroni denominator policy (logged, never silent):** candidates with `k <` the incumbent-derived `min_active_labels` floor can never pass non-degeneracy; they are still fit and scored for evidence but excluded from the family-wise denominator and from `select_winner`, stamped `structurally_ineligible` in the report and noted on stderr.
- **Knife-edge visibility:** `handrule_held_out` now carries `permutation_steps_to_alpha` (additional as-or-more-extreme permutations the incumbent p can absorb before the trustworthy/abstain verdict flips) and a `knife_edge` flag — the merged evidence run's 10/201 sits at exactly 0 steps.
- **Report audit fields:** `n_perm`, `min_achievable_p_value`, `bonferroni_denominator`, `bonferroni_denominator_policy`, `structurally_ineligible`; the #1083 gate's `_summarize_bakeoff` forwards them into each cell's audit trail.

## Verification

- Full Python suite: **2005 passed** (`uv run --no-sync python -m pytest shared_strategies/ shared_tools/ platforms/ backtest/`), zero skips — the cache-guarded bake-off smoke ran against real cached OHLCV with the new fields at an explicit narrowed-sweep `n_perm=200` (guard correctly does not trip).
- New regression tests exercise the acceptance criteria at the **real pipeline's resolution**, not synthetic p-values: a strongly-separated candidate scored by `block_shuffle_pvalue` at the resolved `n_perm` clears the 18-candidate corrected alpha and is crowned by `select_winner` (impossible at 200 permutations); the underpowered-request guard rejects `n_perm=200` at 18 candidates and accepts it at 6; denominator exclusion, knife-edge arithmetic (merged run = 0 steps), and byte-identical default `score_labels` output are each pinned.

---
LLM: Fable 5 | high | Harness: Claude Code
