### PR TITLE
feat(#982): chart_pattern HTF trend gate — default-off knobs + M1 validation

### DIFF
--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -732,6 +732,8 @@ DEFAULT_PARAM_RANGES = {
         "pivot_lookback": [3, 5, 7],
         "tolerance": [0.02, 0.03, 0.05],
         "vol_multiplier": [1.2, 1.5, 2.0],
+        # #982 HTF trend gate (0 = off; nonzero values from the M1 plateau).
+        "htf_gate_factor": [0, 6, 10],
     },
     "liquidity_sweeps": {
         "swing_lookback": [10, 20, 30],

--- a/docs/research/982-chart-pattern-htf-gate-m1.md
+++ b/docs/research/982-chart-pattern-htf-gate-m1.md
@@ -1,0 +1,168 @@
+# chart_pattern HTF trend gate M1 application (#982)
+
+Part of the M1 program (#977/#978); audit source #956/#975. The audit's
+highest-conviction CONFIRM candidate was multi-timeframe confluence — "an HTF
+trend gate over an LTF entry attacks exactly" the registry-wide failure mode of
+high-frequency long entries fighting the higher-timeframe trend. This
+application adds that gate over `chart_pattern`'s existing pattern entries as
+**default-off knobs** and validates it on the full M1 protocol.
+
+## Mechanism (implemented, default-off)
+
+`shared_strategies/open/chart_patterns.py` — four new `chart_pattern` params
+(registry defaults keep the gate off; `--list-json` byte-identical, both
+registries verified):
+
+- `htf_gate_factor` (default **0** = off; >1 enables): native bars per HTF
+  bucket, resampled in-frame via the `mtf_confluence` (#963)
+  `_resample_htf`/`_project_to_native` machinery — no extra data fetch, and the
+  same anti-look-ahead contract (an HTF bucket is only readable from the native
+  bar at which it has fully closed).
+- `htf_gate_mode` (default `"veto"`): `veto` blocks only counter-trend signals
+  (+1 in an HTF downtrend, -1 in an HTF uptrend; neutral/warmup passes) — the
+  live DSL `htf_filter` semantics. `align` requires agreement (neutral blocks).
+- `htf_gate_ema_fast` / `htf_gate_ema_slow` (defaults 20/40): EMAs over HTF
+  bucket closes; trend is the fast/slow relation, neutral until `ema_slow`
+  buckets have accrued.
+
+The gate filters signals **after** volume confirmation, so it sees exactly what
+the strategy would otherwise emit. `htf_gate_factor<=1` is bit-identical to the
+pre-#982 strategy (regression-tested).
+
+Why not reuse the DSL-level `HTFFilter` (`config.go` `htf_filter`,
+`shared_tools/htf_filter.py`): it is a binary flag with a fixed default-HTF map
+and a fixed 50-EMA — no sweepable surface, so an M1 plateau check (step 6) is
+impossible against it, and the M1 bar (`eval_windows.run_leg`) does not apply
+it. The strategy-param form follows the #976 (`regime_adaptive_htf`) reference
+pattern, backtests through `apply_strategy` on every harness unchanged, and
+remains available to live configs via `params`.
+
+## Baseline reproduction (M1 step 1)
+
+Audit row (#956, in `scheduler/ui_reports.go`): in-sample mean Sharpe -0.27,
+mean return -11.5%, 185 trades; OOS +24.0pt edge vs B&H on 23 trades, verdict
+"yes". Reproduced on the M1 harness 2026-07-01 (data has accrued ~3 weeks since
+the audit): BTC/USDT 1h OOS leg -2.20% vs B&H -26.77% (+24.6pt edge, 21
+trades) — consistent. Full baseline (registry defaults, 8-incumbent median bar
+recomputed per window × dataset, 6 audit datasets):
+
+| Window | mean Sharpe / bar | mean DDadj / bar | verdict |
+|--------|-------------------|------------------|---------|
+| IS (2025-06-10→2026-01-01) | -0.42 / -0.12 | -0.12 / -0.14 | FAIL |
+| OOS (2026-01-01→latest)    | -0.61 / -0.75 | -0.37 / -0.49 | PASS |
+| 2023                        | +1.33 / +1.46 | +4.85 / +3.67 | FAIL |
+| 2024                        | +1.25 / +0.90 | +1.96 / +1.07 | PASS |
+| 2025H1                      | -0.53 / -0.42 | -0.29 / -0.37 | FAIL |
+
+Baseline: protocol OOS PASS, held-out 1/3 — the entry edge is real but the
+strategy bleeds in chop/bear windows, exactly the audit's diagnosis.
+
+**Trade-count / fee diagnosis (M1 step 3):** chart_pattern is mid-frequency
+(24–109 trades per window across the 6 legs; 250 in 2023) — not the M5
+fee-churn class; the bleed is directional (counter-trend entries), not fee
+drag. The mechanism to test is a trend gate, not selectivity-by-cost.
+
+## Plateau sweeps (M1 step 6) — `htf_gate_factor` 0,4,5,6,8,10,12, veto mode
+
+Mean candidate Sharpe per window (bar in header; PASS = beats bar on Sharpe AND
+DDadj means):
+
+| factor | IS (bar -0.12) | OOS (bar -0.75) | 2023 (bar 1.46) | 2024 (bar 0.90) | 2025H1 (bar -0.42) |
+|--------|----------------|-----------------|------------------|------------------|---------------------|
+| 0      | -0.42 FAIL | -0.61 PASS | 1.33 FAIL | **1.25 PASS** | -0.53 FAIL |
+| 4      | **0.15 PASS** | **-0.67 PASS** | **1.67 PASS** | 0.65 FAIL | **0.59 PASS** |
+| 5      | 0.23 PASS | -0.87 FAIL | 1.70 PASS | 0.85 FAIL | 0.30 PASS |
+| 6      | 0.48 PASS | -1.02 FAIL | 1.81 PASS | 0.74 FAIL | -0.01 PASS |
+| 8      | -0.03 PASS | -1.34 FAIL | 1.66 PASS | 0.72 FAIL | -0.04 PASS |
+| 10     | -0.08 PASS | -1.09 FAIL | 1.51 PASS | 0.87 FAIL | 0.02 PASS |
+| 12     | -0.22 FAIL | -0.97 FAIL | 1.57 FAIL | 1.02 PASS | 0.03 PASS |
+
+- **IS, 2023, 2025H1: broad plateau.** IS and 2023 flip FAIL→PASS at factors
+  4–10; 2025H1 flips FAIL→PASS at every gated factor (4–12). Not a spike.
+- **EMA axis is also a plateau:** at factor 4 on IS, all 9 combos of
+  `ema_fast`∈{15,20,25} × `ema_slow`∈{30,40,50} PASS (Sharpe 0.09–0.31).
+- **Mode isolation:** `align` is dominated by `veto` everywhere (e.g. IS f6
+  -0.02 vs +0.48; OOS strictly worse, with legs going zero-trade at f≥8) —
+  requiring agreement starves entries without adding selectivity value. The
+  shipped default mode is `veto`.
+- **Selectivity:** the gate cuts trades ~70% (IS 109→29, 2023 250→58,
+  2024 191→58 summed across the 6 legs) — blocking counter-trend entries AND
+  suppressing bearish closes during HTF uptrends (longer holds in bulls, which
+  is where the 2023 DDadj gain comes from).
+
+## Recommended opt-in config and its full M1 table
+
+`{"htf_gate_factor": 4}` (veto, EMAs 20/40) — the lightest gate on the
+plateau, and the only one that keeps the protocol-OOS pass:
+
+| Window | baseline verdict | f4 verdict | f4 Sharpe / bar |
+|--------|------------------|------------|------------------|
+| IS     | FAIL | **PASS** | 0.15 / -0.12 |
+| OOS    | PASS | **PASS** | -0.67 / -0.75 |
+| 2023   | FAIL | **PASS** | 1.67 / 1.46 |
+| 2024   | PASS | FAIL | 0.65 / 0.90 |
+| 2025H1 | FAIL | **PASS** | 0.59 / -0.42 |
+
+Windows passed: **4/5 vs baseline 2/5**; protocol (IS+OOS) both PASS (baseline
+failed IS); held-out 2/3 vs baseline 1/3.
+
+## Honest caveats
+
+1. **2024 is a real regression** (PASS→FAIL, Sharpe 1.25→0.65). In a steady
+   bull with shallow HTF pullbacks, the gate blocks recovering dip-buys while
+   the ungated strategy monetizes them. 2023 (also a bull) still improves
+   because its H1 bear-continuation phases were where ungated entries bled.
+   The mechanism trades bull-year upside for chop/bear protection.
+2. **OOS is factor-fragile.** Only f4 keeps the OOS pass; f≥5 fails it. The
+   2026 crash tape rewards the mean-reversion dip-buys the gate suppresses.
+   The f4 OOS margin over the bar is thin (-0.67 vs -0.75) and its mean is
+   slightly below the ungated -0.61.
+3. Both caveats point the same way: the gate's value is **regime-conditional**.
+   That is M4's (#998 regime-profile allocation) territory — switching
+   `htf_gate_factor` 0↔4 on a slow regime signal is the natural follow-on
+   experiment, out of scope here.
+
+## Verdict
+
+Mechanism validated per the #982 decision frame: default-off knobs shipped, the
+gate clears the #955/#977 bar on the protocol window (IS+OOS PASS at f4,
+baseline failed IS), sits on a broad plateau on IS/2023/2025H1 across both the
+factor and EMA axes, and the held-out table improves 1/3 → 2/3. **Registry
+default stays off** (`htf_gate_factor=0`): the 2024 regression and the OOS
+factor-fragility do not support changing live behavior wholesale, and the
+issue scoped the deliverable as default-off knobs. Operators wanting the gate
+opt in per-config with `{"htf_gate_factor": 4}`.
+
+The audit's optional fold-in (untested-level confluence, from the
+volume-profile CUT verdict) was **not implemented**: M1 isolates one mechanism
+at a time, and the HTF gate alone already changes the trade universe ~70%;
+level-confluence stacking is a separate candidate to run against this new
+baseline if pursued.
+
+## Reproduce
+
+```
+# Baseline, all 5 windows
+uv run --no-sync python backtest/eval_windows.py --strategy chart_pattern
+
+# Recommended opt-in, all 5 windows
+uv run --no-sync python backtest/eval_windows.py --strategy chart_pattern \
+  --params '{"htf_gate_factor": 4}'
+
+# Factor plateau on any window W ∈ {is,oos,2023,2024,2025H1}
+uv run --no-sync python backtest/eval_windows.py --strategy chart_pattern \
+  --windows W --sweep htf_gate_factor=0,4,5,6,8,10,12 --sweep-window W
+
+# EMA plateau at f4 (IS)
+uv run --no-sync python backtest/eval_windows.py --strategy chart_pattern \
+  --params '{"htf_gate_factor":4}' --windows is \
+  --sweep htf_gate_ema_fast=15,20,25 --sweep htf_gate_ema_slow=30,40,50 \
+  --sweep-window is
+```
+
+Runs executed 2026-07-01 on the audit datasets (BTC/ETH/SOL × 1h/4h,
+binanceus fee model, 5 bps slippage, long-leg open-as-close harness).
+
+Generated: 2026-07-01
+
+LLM: Fable 5 | high | Harness: Claude Code + live M1 runs

--- a/shared_strategies/open/chart_patterns.py
+++ b/shared_strategies/open/chart_patterns.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 
+from mtf_confluence import _project_to_native, _resample_htf
+
 
 @dataclass
 class PatternMatch:
@@ -720,6 +722,47 @@ def detect_cup_and_handle(
 
 
 # ─────────────────────────────────────────────
+# HTF Trend Gate (#982)
+# ─────────────────────────────────────────────
+
+_HTF_GATE_MODES = ("veto", "align")
+
+
+def _htf_gate_trend(
+    df: pd.DataFrame,
+    htf_factor: int,
+    ema_fast: int = 20,
+    ema_slow: int = 40,
+) -> pd.Series:
+    """Higher-timeframe trend visible at each native bar (1 up, -1 down, 0).
+
+    Reuses the ``mtf_confluence`` (#963) resample machinery and its
+    anti-look-ahead contract: an HTF bucket is only readable from the native
+    bar at which the bucket has fully closed, so the trend at bar N never
+    depends on bars after N. Trend is up when the HTF EMA(fast) of bucket
+    closes sits above EMA(slow), down when below; neutral (0) until
+    ``ema_slow`` buckets have accrued (EMA warmup) and before the first
+    bucket close is visible.
+    """
+    htf, visible_at = _resample_htf(df, htf_factor)
+    if len(htf) == 0:
+        return pd.Series(0, index=df.index, dtype=int)
+    htf_close = htf["close"]
+    fast = htf_close.ewm(span=ema_fast, adjust=False).mean()
+    slow = htf_close.ewm(span=ema_slow, adjust=False).mean()
+    warm = np.arange(len(htf)) >= ema_slow
+    trend_htf = pd.Series(
+        np.where(warm & (fast > slow), 1, np.where(warm & (fast < slow), -1, 0)),
+        index=htf.index,
+    )
+    return (
+        _project_to_native(trend_htf, visible_at, df.index)
+        .fillna(0)
+        .astype(int)
+    )
+
+
+# ─────────────────────────────────────────────
 # Orchestrator
 # ─────────────────────────────────────────────
 
@@ -748,11 +791,34 @@ def chart_pattern_core(
     tolerance: float = 0.03,
     vol_multiplier: float = 1.5,
     vol_period: int = 20,
+    htf_gate_factor: int = 0,
+    htf_gate_mode: str = "veto",
+    htf_gate_ema_fast: int = 20,
+    htf_gate_ema_slow: int = 40,
 ) -> pd.DataFrame:
     """
     Run all pattern detectors on OHLCV data. Produces a 'signal' column:
     1 = bullish pattern confirmed, -1 = bearish, 0 = no pattern.
+
+    HTF trend gate (#982, default-off): when ``htf_gate_factor`` > 1 the
+    native frame is resampled to ``htf_gate_factor`` × the native bar (no
+    extra data fetch; closed buckets only, same anti-look-ahead contract as
+    ``mtf_confluence``) and pattern signals are filtered against the HTF
+    EMA(fast)/EMA(slow) trend:
+
+    - ``htf_gate_mode="veto"``: block only counter-trend signals (+1 in an
+      HTF downtrend, -1 in an HTF uptrend); a neutral/warmup trend passes
+      everything — the same semantics as the live DSL ``htf_filter``.
+    - ``htf_gate_mode="align"``: require agreement (+1 only in an uptrend,
+      -1 only in a downtrend); neutral blocks.
+
+    ``htf_gate_factor`` <= 1 disables the gate entirely and the output is
+    bit-identical to the pre-#982 strategy.
     """
+    if htf_gate_mode not in _HTF_GATE_MODES:
+        raise ValueError(
+            f"htf_gate_mode must be one of {_HTF_GATE_MODES}, got {htf_gate_mode!r}"
+        )
     result = df.copy()
     result["signal"] = 0
     n = len(result)
@@ -787,6 +853,21 @@ def chart_pattern_core(
         idx = match.bar_index
         if 0 <= idx < n and volume_confirmed(result["volume"], idx, vol_period, vol_multiplier):
             result.iloc[idx, result.columns.get_loc("signal")] = match.signal
+
+    # HTF trend gate (#982): filter confirmed pattern signals against the
+    # higher-timeframe trend. Applied after volume confirmation so the gate
+    # sees exactly the signals the strategy would otherwise emit.
+    if htf_gate_factor and int(htf_gate_factor) > 1:
+        trend = _htf_gate_trend(
+            result, int(htf_gate_factor), htf_gate_ema_fast, htf_gate_ema_slow
+        )
+        result["htf_gate_trend"] = trend
+        sig = result["signal"]
+        if htf_gate_mode == "align":
+            blocked = ((sig == 1) & (trend != 1)) | ((sig == -1) & (trend != -1))
+        else:  # veto
+            blocked = ((sig == 1) & (trend == -1)) | ((sig == -1) & (trend == 1))
+        result.loc[blocked, "signal"] = 0
 
     result["swing_high"] = swing_highs
     result["swing_low"] = swing_lows

--- a/shared_strategies/open/registry.py
+++ b/shared_strategies/open/registry.py
@@ -845,7 +845,14 @@ def vwap_reversion_strategy(df: pd.DataFrame, entry_std: float = 1.5, exit_std: 
 @register(
     "chart_pattern",
     "Chart Pattern \u2014 detects Double Top/Bottom, H&S, Flags, Triangles with volume confirmation",
-    {"pivot_lookback": 5, "tolerance": 0.03, "vol_multiplier": 1.5, "vol_period": 20},
+    {
+        "pivot_lookback": 5, "tolerance": 0.03, "vol_multiplier": 1.5,
+        "vol_period": 20,
+        # #982 HTF trend gate \u2014 default-off (0 disables; >1 gates pattern
+        # signals against the resampled-in-frame HTF EMA trend).
+        "htf_gate_factor": 0, "htf_gate_mode": "veto",
+        "htf_gate_ema_fast": 20, "htf_gate_ema_slow": 40,
+    },
 )
 def chart_pattern_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
     return chart_pattern_core(df, **params)

--- a/shared_strategies/open/test_chart_patterns.py
+++ b/shared_strategies/open/test_chart_patterns.py
@@ -21,6 +21,7 @@ from chart_patterns import (
     detect_cup_and_handle,
     chart_pattern_core,
     _get_swing_indices,
+    _htf_gate_trend,
 )
 
 
@@ -558,3 +559,130 @@ class TestChartPatternCore:
         # With vol_multiplier=3.0 and low breakout volume, signals should be filtered
         sell_signals = result[result["signal"] == -1]
         assert len(sell_signals) == 0
+
+
+# ─── HTF Trend Gate (#982) ──────────────────
+
+def _double_top_fixture(prefix=None):
+    """The orchestrator double-top fixture (emits -1 sell signals), optionally
+    preceded by a price prefix that sets the HTF trend context."""
+    prices = (
+        list(np.linspace(80, 100, 20)) +
+        list(np.linspace(100, 90, 15)) +
+        list(np.linspace(90, 99, 15)) +
+        list(np.linspace(99, 85, 20)) +
+        [85] * 30
+    )
+    if prefix is not None:
+        prices = list(prefix) + prices
+    vol = [100.0] * len(prices)
+    # High volume across the double-top breakout region so the volume filter
+    # passes there (region sits after the prefix).
+    off = len(prefix) if prefix is not None else 0
+    for i in range(off + 50, off + 70):
+        vol[i] = 200.0
+    return make_ohlcv(prices, volume=vol)
+
+
+class TestHTFGate:
+    def test_default_off_is_bit_identical(self):
+        df = _double_top_fixture()
+        base = chart_pattern_core(df, pivot_lookback=3, tolerance=0.03, vol_multiplier=1.0)
+        off = chart_pattern_core(
+            df, pivot_lookback=3, tolerance=0.03, vol_multiplier=1.0,
+            htf_gate_factor=0,
+        )
+        assert "htf_gate_trend" not in base.columns
+        assert "htf_gate_trend" not in off.columns
+        assert (base["signal"] == off["signal"]).all()
+
+    def test_htf_gate_trend_direction_and_warmup(self):
+        up = make_ohlcv(np.linspace(50, 200, 600))
+        trend_up = _htf_gate_trend(up, 4, ema_fast=10, ema_slow=20)
+        down = make_ohlcv(np.linspace(200, 50, 600))
+        trend_down = _htf_gate_trend(down, 4, ema_fast=10, ema_slow=20)
+        # Neutral through EMA warmup (slow span in buckets), then directional.
+        assert trend_up.iloc[0] == 0 and trend_down.iloc[0] == 0
+        assert trend_up.iloc[-1] == 1
+        assert trend_down.iloc[-1] == -1
+
+    def test_veto_blocks_counter_trend_sell_in_uptrend(self):
+        # Long rising prefix puts the HTF trend firmly up when the double-top
+        # breakdown (-1) fires; veto mode must gate those sells to 0.
+        df = _double_top_fixture(prefix=np.linspace(20, 80, 400))
+        base = chart_pattern_core(df, pivot_lookback=3, tolerance=0.03, vol_multiplier=1.0)
+        gated = chart_pattern_core(
+            df, pivot_lookback=3, tolerance=0.03, vol_multiplier=1.0,
+            htf_gate_factor=4, htf_gate_ema_fast=10, htf_gate_ema_slow=20,
+        )
+        sell_bars = np.where(base["signal"].values == -1)[0]
+        assert len(sell_bars) >= 1  # fixture sanity
+        blocked = 0
+        for k in sell_bars:
+            trend_k = int(gated["htf_gate_trend"].iloc[k])
+            if trend_k == 1:
+                assert gated["signal"].iloc[k] == 0, (
+                    f"veto left a -1 signal at bar {k} despite HTF uptrend"
+                )
+                blocked += 1
+            else:
+                assert gated["signal"].iloc[k] == base["signal"].iloc[k]
+        # Fixture sanity: the uptrend prefix must actually make the gate bite
+        # on at least one sell signal, else this test is vacuous.
+        assert blocked >= 1
+
+    def test_veto_passes_neutral_and_align_blocks_it(self):
+        # factor=30 with slow=40 needs 1200 bars of warmup; the 100-bar fixture
+        # keeps the HTF trend neutral throughout. Veto passes everything
+        # through unchanged; align (requires agreement) blocks everything.
+        df = _double_top_fixture()
+        base = chart_pattern_core(df, pivot_lookback=3, tolerance=0.03, vol_multiplier=1.0)
+        assert base["signal"].abs().sum() >= 1  # fixture sanity
+        veto = chart_pattern_core(
+            df, pivot_lookback=3, tolerance=0.03, vol_multiplier=1.0,
+            htf_gate_factor=30,
+        )
+        align = chart_pattern_core(
+            df, pivot_lookback=3, tolerance=0.03, vol_multiplier=1.0,
+            htf_gate_factor=30, htf_gate_mode="align",
+        )
+        assert (veto["htf_gate_trend"] == 0).all()
+        assert (veto["signal"] == base["signal"]).all()
+        assert (align["signal"] == 0).all()
+
+    def test_invalid_mode_raises(self):
+        df = _double_top_fixture()
+        with pytest.raises(ValueError, match="htf_gate_mode"):
+            chart_pattern_core(df, htf_gate_mode="bogus")
+
+    def test_gated_signal_independent_of_future_bars(self):
+        # Same prefix-stability contract as the ungated orchestrator test,
+        # with the gate active on a DatetimeIndex (exercises the wall-clock
+        # resample path): the projected HTF trend must never read a bucket
+        # that has not closed by bar K.
+        df = _double_top_fixture(prefix=np.linspace(20, 80, 400))
+        df.index = pd.date_range("2024-01-01", periods=len(df), freq="1h")
+        kwargs = dict(
+            pivot_lookback=3, tolerance=0.03, vol_multiplier=1.0,
+            htf_gate_factor=4, htf_gate_ema_fast=10, htf_gate_ema_slow=20,
+        )
+        full = chart_pattern_core(df, **kwargs)
+        base = chart_pattern_core(df, pivot_lookback=3, tolerance=0.03,
+                                  vol_multiplier=1.0)
+        # Check every bar where the UNGATED strategy fires: the gated verdict
+        # there (pass or block) must be identical under truncation — a
+        # look-ahead in the projected trend would flip it either way.
+        signal_bars = list(np.where(base["signal"].values != 0)[0])
+        assert len(signal_bars) >= 1  # fixture sanity
+        for k in signal_bars:
+            partial = chart_pattern_core(df.iloc[: k + 1], **kwargs)
+            assert partial["signal"].iloc[k] == full["signal"].iloc[k], (
+                f"gated signal at bar {k} flipped under truncation"
+            )
+        # The visible trend series itself must also be prefix-stable.
+        k = signal_bars[-1]
+        partial = chart_pattern_core(df.iloc[: k + 1], **kwargs)
+        assert (
+            partial["htf_gate_trend"].values
+            == full["htf_gate_trend"].values[: k + 1]
+        ).all()


### PR DESCRIPTION
Closes #982. Part of the M1 program (#977/#978); audit source #956/#975.

## What

Adds a **default-off HTF trend gate** over `chart_pattern`'s pattern entries — the audit's highest-conviction CONFIRM candidate (multi-timeframe confluence) applied to the strategy the diagnosis fit best — and validates it on the full M1 protocol.

**New `chart_pattern` params** (`shared_strategies/open/chart_patterns.py`, registry defaults keep the gate off):

- `htf_gate_factor` (default **0** = off): native bars per HTF bucket, resampled in-frame via the `mtf_confluence` (#963) `_resample_htf`/`_project_to_native` machinery — no extra data fetch, closed-buckets-only anti-look-ahead contract.
- `htf_gate_mode` (default `veto`): `veto` blocks only counter-trend signals (live DSL `htf_filter` semantics); `align` requires trend agreement.
- `htf_gate_ema_fast`/`htf_gate_ema_slow` (20/40): HTF-bucket EMAs defining the trend, neutral through warmup.

Why not the DSL-level `HTFFilter` (evaluated per the issue): binary, fixed default-HTF map + fixed 50-EMA — no sweepable surface for the M1 plateau check, and `eval_windows.run_leg` doesn't apply it. The strategy-param form follows the #976 reference pattern and flows through every harness via `apply_strategy` unchanged.

## M1 result (full protocol, 6 audit datasets, 8-incumbent median bar)

Baseline reproduced first (matches the #956 audit row; BTC 1h OOS +24.6pt edge vs B&H). Recommended opt-in `{"htf_gate_factor": 4}`:

| Window | baseline | f4 (veto) |
|--------|----------|-----------|
| IS | FAIL (-0.42) | **PASS** (0.15) |
| OOS | PASS (-0.61) | **PASS** (-0.67) |
| 2023 | FAIL (1.33) | **PASS** (1.67) |
| 2024 | PASS (1.25) | FAIL (0.65) |
| 2025H1 | FAIL (-0.53) | **PASS** (0.59) |

Windows passed 4/5 vs baseline 2/5; protocol IS+OOS both PASS; held-out 1/3 → 2/3. Plateau: IS/2023 pass at factors 4–10, 2025H1 at 4–12; all 9 EMA fast×slow combos pass IS at f4. `align` mode is dominated by `veto` everywhere.

**Registry default stays OFF.** Honest caveats (full detail in `docs/research/982-chart-pattern-htf-gate-m1.md`): 2024 regresses PASS→FAIL and OOS passes only at f4 — the gate trades bull-year upside for chop/bear protection, so it ships as a validated opt-in, not a default flip. The regime-conditional follow-on (switching the gate via #998 M4 profile allocation) is noted as future work. The issue's optional untested-level-confluence fold-in was not implemented (M1 isolates one mechanism; the gate alone changes the trade universe ~70%).

## Verification

- Full pytest suite: **2002 passed** (includes 6 new gate tests: default-off bit-parity, trend direction/warmup, veto blocks counter-trend sells in an HTF uptrend, veto-passes-neutral vs align-blocks, invalid-mode raises, gated prefix-stability/no-look-ahead on the datetime resample path).
- `--list-json` **byte-identical** vs main on both spot and futures registries (description untouched; params don't surface in discovery output).
- `go -C scheduler build` + `go -C scheduler test .` pass (no Go changes).
- All sweep/verdict runs executed live 2026-07-01; reproduce commands in the research doc.

LLM: Fable 5 | high | Harness: Claude Code

https://claude.ai/code/session_01PQRybtyYkVrf6ZLQ8kKaom
