### PR TITLE
feat(#980): momentum_pro M1 — short-leg measurement + volatility-targeted entry sizing

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -17,6 +17,11 @@ closed data:
                          at row N+1's open in the per-bar entry block.
   • ``_open_action``   — shift(1) in the open/close-split normalization block.
   • ``_close_fraction`` (column-based) — shift(1) in the same block.
+  • ``_entry_fraction`` (column-based, #980) — shift(1) alongside the signal;
+                         scales the notional committed at open (1.0 = full
+                         notional; remainder stays as a cash reserve).
+                         Backtest-research surface only: live order sizing is
+                         config-driven and ignores the column entirely.
   • ``regime``         — shift(1) in the regime-shift block (post-injection,
                          #730) so entries gate on bar N's regime, not N+1's.
 
@@ -541,6 +546,26 @@ def _max_close_fraction_series(df: pd.DataFrame) -> pd.Series:
         values = sorted(set(fractions[bad].stack().tolist()))
         raise ValueError(f"close_fraction values must be in [0, 1] — got {values}")
     return fractions.max(axis=1)
+
+
+def _validated_entry_fraction_series(df: pd.DataFrame) -> pd.Series:
+    """Validate the strategy-emitted ``entry_fraction`` column (#980).
+
+    Values must be in (0, 1]: 1.0 = full notional (today's behavior), a
+    fraction commits that share of flat-state cash at the open and leaves the
+    remainder as a cash reserve. NaN means "no opinion" and resolves to full
+    notional downstream. 0 is rejected rather than treated as "skip the
+    entry" — suppressing an entry is the signal's job, and a 0-fraction open
+    would book a zero-share phantom trade.
+    """
+    vals = df["entry_fraction"].astype(float)
+    bad = vals[vals.notna() & ((vals <= 0) | (vals > 1))]
+    if not bad.empty:
+        values = sorted(set(bad.tolist()))
+        raise ValueError(
+            f"entry_fraction values must be in (0, 1] — got {values}"
+        )
+    return vals
 
 
 class Trade:
@@ -1396,6 +1421,17 @@ class Backtester:
             df["_open_action"] = open_actions.shift(1).fillna("none")
             df["_close_fraction"] = _max_close_fraction_series(df).shift(1).fillna(0.0)
 
+        # #980: per-bar entry sizing. ``entry_fraction`` is a decision input
+        # computed from bar N's closed data, so it shifts forward with the
+        # signal; the shift hole and NaN (warmup / no opinion) resolve to
+        # 1.0 = full notional, today's behavior. Applies to every open path
+        # (plain long/short, open/close engine, profile allocation — the
+        # column is profile-independent, like ``_close_fraction``).
+        if "entry_fraction" in df.columns:
+            df["_entry_fraction"] = (
+                _validated_entry_fraction_series(df).shift(1).fillna(1.0)
+            )
+
         # Regime: inject vectorized labels before the per-bar loop so each bar
         # can gate new entries. Mirrors the live path: latest_regime(df) on the
         # same OHLCV window → identical label by construction (same algorithm).
@@ -1671,10 +1707,18 @@ class Backtester:
         book_funding = "funding_accrual" in df.columns
         total_funding_pnl = 0.0
 
+        has_entry_fraction = "_entry_fraction" in df.columns
+
         for i, (idx, row) in enumerate(df.iterrows()):
             fill_price = row["open"] if has_open else row["close"]
             mark_price = row["close"]
             signal = row["signal"]
+            # #980: fraction of flat-state cash committed if an entry fills at
+            # this bar's open. Normalized/validated pre-loop; 1.0 = full
+            # notional (the only value when no ``entry_fraction`` column).
+            entry_fraction = (
+                float(row["_entry_fraction"]) if has_entry_fraction else 1.0
+            )
             # #998: regime-profile allocation — advance the flat-only, confirm_bars
             # hysteresis switch and read the active profile's signal for this bar.
             # ``flat`` is the position carried into the bar (= the position state at
@@ -1905,11 +1949,15 @@ class Backtester:
                 # included: it would book a zero-share phantom trade.
                 if open_action == "long" and position == 0 and cash > 0 and not regime_blocked:
                     effective_price = fill_price * (1 + self.slippage_pct)
-                    commission = cash * self.commission_pct
-                    available = cash - commission
+                    # #980: commit entry_fraction of flat-state cash; the
+                    # remainder stays as a reserve (fraction 1.0 = full
+                    # notional, today's math exactly).
+                    invest = cash * entry_fraction
+                    commission = invest * self.commission_pct
+                    available = invest - commission
                     shares = available / effective_price
                     position = shares
-                    cash = 0.0
+                    cash -= invest
 
                     current_trade = Trade(idx, effective_price, "long")
                     current_trade.shares = shares
@@ -1956,10 +2004,15 @@ class Backtester:
                         sl_high_water_px = mark_price
                 elif open_action == "short" and position == 0 and cash > 0 and not regime_blocked:
                     effective_price = fill_price * (1 - self.slippage_pct)
-                    commission = cash * self.commission_pct
-                    notional = cash - commission
+                    # #980: entry_fraction of flat-state cash is the committed
+                    # margin; pay commission from it, receive the short-sale
+                    # proceeds on top of the untouched reserve (fraction 1.0
+                    # reduces to cash = 2 * notional, today's math exactly).
+                    margin = cash * entry_fraction
+                    commission = margin * self.commission_pct
+                    notional = margin - commission
                     shares = notional / effective_price
-                    cash = 2 * notional  # pay commission, receive short-sale proceeds
+                    cash += 2 * notional - margin
                     position = -shares
 
                     current_trade = Trade(idx, effective_price, "short")
@@ -2098,7 +2151,10 @@ class Backtester:
                 effective_price = fill_price * (1 - self.slippage_pct)
                 proceeds = position * effective_price
                 commission = proceeds * self.commission_pct
-                cash = proceeds - commission
+                # #980: additive — a fractional entry leaves a cash reserve
+                # (and funding accrual lands in cash) that an overwrite here
+                # would silently destroy. Identical when cash == 0.
+                cash += proceeds - commission
                 position = 0.0
                 if current_trade:
                     current_trade.close(idx, effective_price)
@@ -2150,14 +2206,16 @@ class Backtester:
             # long/flat path can't reach negative cash today, but carries the
             # same guard so the invariant holds by construction.
             if plain_short_for_bar and signal == -1 and position == 0 and cash > 0 and not regime_blocked:
-                # SELL — open short with full notional. Mirrors the engine
-                # path's short-open mechanics: pay commission, receive the
-                # short-sale proceeds (cash = 2 * notional).
+                # SELL — open short. Mirrors the engine path's short-open
+                # mechanics: pay commission from the committed margin, receive
+                # the short-sale proceeds (#980: entry_fraction scales the
+                # committed margin; 1.0 reduces to cash = 2 * notional).
                 effective_price = fill_price * (1 - self.slippage_pct)
-                commission = cash * self.commission_pct
-                notional = cash - commission
+                margin = cash * entry_fraction
+                commission = margin * self.commission_pct
+                notional = margin - commission
                 shares = notional / effective_price
-                cash = 2 * notional
+                cash += 2 * notional - margin
                 position = -shares
 
                 current_trade = Trade(idx, effective_price, "short")
@@ -2208,13 +2266,15 @@ class Backtester:
                 self._run_position_regime = ""
 
             elif not plain_short_for_bar and signal == 1 and position == 0 and cash > 0 and not regime_blocked:
-                # BUY — go long with all available cash
+                # BUY — go long (#980: entry_fraction of flat-state cash;
+                # 1.0 = all available cash, today's math exactly)
                 effective_price = fill_price * (1 + self.slippage_pct)
-                commission = cash * self.commission_pct
-                available = cash - commission
+                invest = cash * entry_fraction
+                commission = invest * self.commission_pct
+                available = invest - commission
                 shares = available / effective_price
                 position = shares
-                cash = 0.0
+                cash -= invest
 
                 current_trade = Trade(idx, effective_price, "long")
                 current_trade.shares = shares
@@ -2249,7 +2309,9 @@ class Backtester:
                 effective_price = fill_price * (1 - self.slippage_pct)
                 proceeds = position * effective_price
                 commission = proceeds * self.commission_pct
-                cash = proceeds - commission
+                # #980: additive — preserve any fractional-entry cash reserve
+                # (identical when cash == 0, the full-notional case).
+                cash += proceeds - commission
                 position = 0.0
 
                 if current_trade:

--- a/backtest/tests/test_backtester_entry_fraction.py
+++ b/backtest/tests/test_backtester_entry_fraction.py
@@ -1,0 +1,206 @@
+"""#980: per-bar ``entry_fraction`` entry sizing.
+
+A strategy-emitted ``entry_fraction`` column in (0, 1] scales the notional
+committed at open; the remainder stays as a cash reserve. The column is a
+decision input, so it shifts forward one bar with the signal. Absent column,
+NaN values, and fraction 1.0 are all byte-identical to today's full-notional
+behavior. These tests pin: long/short plain-path math, the open/close engine
+path, next-bar-open shift alignment, validation, NaN semantics, and the
+reserve-preserving (additive) close/SL fills.
+"""
+import sys
+import pathlib
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / "shared_tools"))
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from backtester import Backtester
+
+
+def _df(closes, signals, entry_fraction=None, opens=None):
+    closes = np.asarray(closes, dtype=float)
+    n = len(closes)
+    opens = closes if opens is None else np.asarray(opens, dtype=float)
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pd.DataFrame(
+        {
+            "open": opens,
+            "high": np.maximum(opens, closes) + 0.5,
+            "low": np.minimum(opens, closes) - 0.5,
+            "close": closes,
+            "volume": np.full(n, 1000.0),
+            "signal": np.asarray(signals, dtype=float),
+        },
+        index=idx,
+    )
+    if entry_fraction is not None:
+        df["entry_fraction"] = np.asarray(entry_fraction, dtype=float)
+    return df
+
+
+def _run(df, **kw):
+    kw.setdefault("commission_pct", 0.0)
+    kw.setdefault("slippage_pct", 0.0)
+    bt = Backtester(initial_capital=10000.0, **kw)
+    return bt.run(df.copy(), strategy_name="x", symbol="BTC/USDT",
+                  timeframe="1d", save=False)
+
+
+# ─── Plain-path mechanics ─────────────────────────────────────────────────────
+
+
+def test_long_fractional_entry_commits_fraction_and_keeps_reserve():
+    # Signal bar 0 fills bar 1 open (100) at fraction 0.5: 5000 invested,
+    # 50 shares, 5000 reserve. Close signal bar 2 fills bar 3 open (120):
+    # proceeds 6000 land ON TOP of the reserve.
+    closes = [100, 100, 120, 120, 120]
+    signals = [1, 0, -1, 0, 0]
+    res = _run(_df(closes, signals, entry_fraction=[0.5] * 5))
+    assert res["total_trades"] == 1
+    assert res["trades"][0]["shares"] == pytest.approx(50.0)
+    assert res["final_capital"] == pytest.approx(11000.0)
+
+
+def test_short_fractional_entry_commits_fraction_and_keeps_reserve():
+    # direction="short": margin 5000 → 50 shares short at 100, cash
+    # 10000 - 5000 + 2*5000 = 15000; cover at 80 costs 4000 → 11000.
+    closes = [100, 100, 80, 80, 80]
+    signals = [-1, 0, 1, 0, 0]
+    res = _run(_df(closes, signals, entry_fraction=[0.5] * 5),
+               direction="short")
+    assert res["total_trades"] == 1
+    assert res["trades"][0]["side"] == "short"
+    assert res["trades"][0]["shares"] == pytest.approx(50.0)
+    assert res["final_capital"] == pytest.approx(11000.0)
+
+
+def test_entry_fraction_uses_signal_bar_value_not_fill_bar():
+    # The column shifts with the signal: the bar-0 signal fills at bar 1's
+    # open using bar 0's fraction (0.25 → 25 shares), never bar 1's (0.75).
+    closes = [100, 100, 100, 100]
+    signals = [1, 0, -1, 0]
+    res = _run(_df(closes, signals, entry_fraction=[0.25, 0.75, 0.75, 0.75]))
+    assert res["total_trades"] == 1
+    assert res["trades"][0]["shares"] == pytest.approx(25.0)
+
+
+def test_fraction_one_column_matches_no_column_exactly():
+    closes = [100, 105, 98, 110, 104, 120, 115, 108]
+    signals = [1, 0, -1, 1, 0, 0, -1, 0]
+    base = _run(_df(closes, signals),
+                commission_pct=0.001, slippage_pct=0.0005)
+    scaled = _run(_df(closes, signals, entry_fraction=[1.0] * 8),
+                  commission_pct=0.001, slippage_pct=0.0005)
+    assert scaled["final_capital"] == pytest.approx(base["final_capital"])
+    assert scaled["total_trades"] == base["total_trades"]
+
+
+def test_nan_entry_fraction_means_full_notional():
+    closes = [100, 100, 120, 120]
+    signals = [1, 0, -1, 0]
+    base = _run(_df(closes, signals))
+    nan_col = _run(_df(closes, signals, entry_fraction=[np.nan] * 4))
+    assert nan_col["final_capital"] == pytest.approx(base["final_capital"])
+    assert nan_col["trades"][0]["shares"] == pytest.approx(
+        base["trades"][0]["shares"])
+
+
+def test_compounding_reuses_reserve_plus_proceeds():
+    # Round trip 1 at fraction 0.5 (flat price): cash back to 10000. Round
+    # trip 2 re-commits half of the FULL 10000 — the reserve rejoined the pool.
+    closes = [100, 100, 100, 100, 100, 100, 100]
+    signals = [1, 0, -1, 1, 0, -1, 0]
+    res = _run(_df(closes, signals, entry_fraction=[0.5] * 7))
+    assert res["total_trades"] == 2
+    assert res["trades"][1]["shares"] == pytest.approx(50.0)
+    assert res["final_capital"] == pytest.approx(10000.0)
+
+
+# ─── Reserve-preserving close fills ───────────────────────────────────────────
+
+
+def test_signal_close_preserves_reserve():
+    # Regression for the historical ``cash = proceeds - commission``
+    # overwrite on the plain-path long close: with a 0.5 entry the 5000
+    # reserve must survive the close, not be replaced by the proceeds.
+    closes = [100, 100, 90, 90, 90]
+    signals = [1, 0, -1, 0, 0]
+    res = _run(_df(closes, signals, entry_fraction=[0.5] * 5))
+    # 50 shares closed at 90 → 4500 proceeds + 5000 reserve.
+    assert res["final_capital"] == pytest.approx(9500.0)
+
+
+def test_standalone_stop_fill_preserves_reserve():
+    # Same regression on the standalone-stop fill: SL at -10% from 100
+    # triggers on bar 3's close (85) and fills bar 4's open (85);
+    # 50 * 85 = 4250 proceeds + 5000 reserve.
+    closes = [100, 100, 95, 85, 85, 85]
+    signals = [1, 0, 0, 0, 0, 0]
+    res = _run(_df(closes, signals, entry_fraction=[0.5] * 6),
+               stop_loss_pct=0.10)
+    assert res["total_trades"] == 1
+    assert res["final_capital"] == pytest.approx(9250.0)
+
+
+# ─── Open/close engine path ───────────────────────────────────────────────────
+
+
+def test_engine_path_long_fractional_entry():
+    idx = pd.date_range("2024-01-01", periods=5, freq="D")
+    df = pd.DataFrame({
+        "open": [100.0] * 5,
+        "high": [101.0] * 5,
+        "low": [99.0] * 5,
+        "close": [100.0] * 5,
+        "volume": [1000.0] * 5,
+        "open_action": ["none", "long", "none", "none", "none"],
+        "close_fraction": [0, 0, 1, 0, 0],
+        "entry_fraction": [np.nan, 0.5, np.nan, np.nan, np.nan],
+    }, index=idx)
+    bt = Backtester(initial_capital=1000, commission_pct=0, slippage_pct=0)
+    res = bt.run(df, save=False)
+    assert res["total_trades"] == 1
+    assert res["trades"][0]["shares"] == pytest.approx(5.0)
+    assert res["final_capital"] == pytest.approx(1000.0)
+
+
+def test_engine_path_short_fractional_entry():
+    idx = pd.date_range("2024-01-01", periods=5, freq="D")
+    df = pd.DataFrame({
+        "open": [100.0, 100.0, 100.0, 80.0, 80.0],
+        "high": [101.0] * 5,
+        "low": [79.0] * 5,
+        "close": [100.0, 100.0, 80.0, 80.0, 80.0],
+        "volume": [1000.0] * 5,
+        "open_action": ["none", "short", "none", "none", "none"],
+        "close_fraction": [0, 0, 1, 0, 0],
+        "entry_fraction": [np.nan, 0.5, np.nan, np.nan, np.nan],
+    }, index=idx)
+    bt = Backtester(initial_capital=1000, commission_pct=0, slippage_pct=0)
+    res = bt.run(df, save=False)
+    assert res["total_trades"] == 1
+    assert res["trades"][0]["side"] == "short"
+    assert res["trades"][0]["shares"] == pytest.approx(5.0)
+    # 1000 - 500 margin + 2*500 proceeds = 1500; cover at 80 costs 400.
+    assert res["final_capital"] == pytest.approx(1100.0)
+
+
+# ─── Validation ───────────────────────────────────────────────────────────────
+
+
+def test_zero_entry_fraction_rejected():
+    closes = [100, 100, 100]
+    signals = [1, 0, 0]
+    with pytest.raises(ValueError, match=r"entry_fraction .* \(0, 1\]"):
+        _run(_df(closes, signals, entry_fraction=[0.0, 1.0, 1.0]))
+
+
+def test_out_of_range_entry_fraction_rejected():
+    closes = [100, 100, 100]
+    signals = [1, 0, 0]
+    with pytest.raises(ValueError, match=r"entry_fraction .* \(0, 1\]"):
+        _run(_df(closes, signals, entry_fraction=[1.5, 1.0, 1.0]))

--- a/docs/research/momentum_pro_980.md
+++ b/docs/research/momentum_pro_980.md
@@ -1,0 +1,158 @@
+# momentum_pro short-leg measurement + volatility-targeted sizing (#980)
+
+Generated: 2026-07-01
+
+Full M1 protocol (#995) on `momentum_pro`, the #956 audit's best OOS-checked
+strategy. Two mechanisms per M1 step 4, each isolated and combined:
+
+1. **Short-leg measurement** — `momentum_pro_core` already emits `signal=-1`
+   shorts unconditionally; the audit's compare runs measured the long/flat
+   path only (on that path a bearish `-1` acts as the long *exit*). The short
+   leg is measured here via the #989 `--direction short` harness. No strategy
+   code change.
+2. **ATR-normalized (volatility-targeted) entry sizing** — new unregistered
+   kwargs on `momentum_pro_core` (`vol_target_atr_pct`, default **0.0 = OFF**;
+   `vol_target_atr_period=14`; `vol_target_min_fraction=0.10`) emit an
+   `entry_fraction` column, consumed by a new Backtester surface (#980,
+   `close_fraction`-precedent column, shift(1) with the signal) that scales
+   the notional committed at open: `clip(target / (ATR/close), 0.10, 1.0)`.
+   Signals and trade counts are never changed — exposure only. Not a
+   registered default param, so `--list-json` stays byte-identical (verified);
+   live order sizing is config-driven and ignores the column (backtest-research
+   surface only).
+
+## Reproduce
+
+Data: binanceus OHLCV cache populated 2026-07-01 (fetched since 2023-01-01;
+`oos` end = latest cached bar 2026-07-01). All runs `--registry spot`
+(momentum_pro is byte-identical in both registries).
+
+```bash
+# Baseline long leg (M1 steps 1-2)
+uv run --no-sync python backtest/eval_windows.py --strategy momentum_pro --registry spot --json /tmp/mp980/base_long.json
+
+# Short leg (mechanism 1)
+uv run --no-sync python backtest/eval_windows.py --strategy momentum_pro --registry spot --direction short --json /tmp/mp980/short.json
+
+# Sizing sweeps (mechanism 2; tuned on IS + held-outs per M1 step 5, never OOS)
+uv run --no-sync python backtest/eval_windows.py --strategy momentum_pro --registry spot --sweep vol_target_atr_pct=0.005,0.0075,0.01,0.015,0.02,0.03 --sweep-window is
+uv run --no-sync python backtest/eval_windows.py --strategy momentum_pro --registry spot --sweep vol_target_atr_pct=0.005,0.0075,0.01,0.015,0.02,0.03 --sweep-window 2023
+uv run --no-sync python backtest/eval_windows.py --strategy momentum_pro --registry spot --sweep vol_target_atr_pct=0.005,0.0075,0.01,0.015,0.02,0.03 --sweep-window 2024
+uv run --no-sync python backtest/eval_windows.py --strategy momentum_pro --registry spot --sweep vol_target_atr_pct=0.005,0.0075,0.01,0.015,0.02,0.03 --sweep-window 2025H1
+
+# Final protocol measurement of the chosen sizing config (one OOS look) + combo
+uv run --no-sync python backtest/eval_windows.py --strategy momentum_pro --registry spot --params '{"vol_target_atr_pct": 0.015}' --json /tmp/mp980/final_sized_long.json
+uv run --no-sync python backtest/eval_windows.py --strategy momentum_pro --registry spot --direction short --params '{"vol_target_atr_pct": 0.015}' --json /tmp/mp980/final_sized_short.json
+```
+
+Caveat (same class as #1021's): a run against a **cold or partially-populated
+cache is not reproducible** — `load_cached_data` only falls back to fetching
+when the requested range is completely empty, so a partial cache silently
+truncates a window. Populate the full 2023-01-01→now range first (any
+all-windows run does it); with a warm cache, back-to-back runs reproduce to
+the digit (verified across three invocations).
+
+## Baseline reproduction (M1 step 1)
+
+The audit snapshot (`scheduler/ui_reports.go`, generated 2026-06-10) is not
+digit-reproducible on the current cache: its OOS row (+27.3pts vs B&H, 5
+trades) was **BTC/USDT 1h only** and ended 2026-06-10, while the harness OOS
+now runs to 2026-07-01. The current-cache BTC/USDT 1h OOS leg is consistent
+with it: -6.87% vs B&H -30.77% = **+23.9pts on 6 trades**, and it still beats
+the incumbent bar on both Sharpe and DDadj.
+
+The 6-dataset harness baseline (registry defaults, long leg):
+
+| window | mean Sharpe | bar | mean DDadj | bar | verdict |
+|---|---:|---:|---:|---:|---|
+| is | 0.02 | -0.12 | 0.17 | -0.14 | PASS |
+| oos | -1.34 | -0.63 | -0.70 | -0.46 | **FAIL** |
+| 2023 | 1.88 | 1.46 | 6.95 | 3.67 | PASS |
+| 2024 | 0.78 | 0.90 | 0.95 | 1.07 | FAIL |
+| 2025H1 | -0.34 | -0.42 | -0.06 | -0.37 | PASS |
+
+Diagnosis: the audit's "best OOS" edge is **BTC-concentrated**. On the
+current OOS window BTC 1h still clears the bar decisively (SD), but all four
+ETH/SOL legs and BTC 4h fail it (1/6), dragging the mean below the bar. The
+long leg remains selective (2-9 trades per leg) — the failure is where the
+edge lives (BTC), not churn.
+
+## Mechanism 1 — short leg
+
+| config | IS | OOS | 2023 | 2024 | 2025H1 | held-out |
+|---|---|---|---|---|---|---|
+| long (baseline) | PASS | FAIL | PASS | FAIL | PASS | 2/3 |
+| short | PASS | **PASS** | FAIL | FAIL | PASS | 1/3 |
+
+Protocol OOS for the short leg is emphatic: **6/6 datasets beat the bar on
+both Sharpe and DDadj** (mean Sharpe +1.52 vs bar -0.63; every leg posts a
+positive return — BTC 4h +38.2%, ETH 4h +44.2%, SOL 4h +37.8% — against
+B&H -30..-45%). The IS window also passes (0.32 vs -0.12).
+
+The held-outs expose the regime dependency: **0/6 legs beat the bar in both
+2023 and 2024** (bull years; e.g. 2024 mean return -37.5% across legs while
+B&H is +46..+122%). Same failure shape as `session_breakout`'s short leg
+(#1031) and `vol_momentum`'s (#1021): a real bear-window short edge that
+cannot survive an uptrend.
+
+**Verdict: negative result for an unconditional standalone short config —
+documented, not deleted.** The stacked-bearish-EMA + ADX gate is not
+sufficient regime protection across bull years. Live behavior is unchanged
+(momentum_pro stays in `bidirectionalPerpsStrategies`; live perps positions
+get the SL/TP protection stack the plain harness deliberately omits).
+Follow-on direction if pursued: regime-gate the short side (the
+`regime_directional_policy` machinery is the existing surface for exactly
+this), which is out of scope here.
+
+## Mechanism 2 — volatility-targeted sizing
+
+Sweep of `vol_target_atr_pct` on the tuning windows (IS + held-outs; mean
+Sharpe / mean DDadj vs the baseline row):
+
+| config | is | 2023 | 2024 | 2025H1 |
+|---|---|---|---|---|
+| baseline (off) | 0.02 / 0.17 | 1.88 / 6.95 | 0.78 / 0.95 | -0.34 / -0.06 |
+| 0.005 | -0.02 / 0.12 | 2.10 / 5.77 | 0.78 / 0.95 | -0.47 / -0.12 |
+| 0.0075 | -0.01 / 0.15 | 2.09 / 6.52 | 0.77 / 0.93 | -0.39 / -0.09 |
+| 0.01 | -0.02 / 0.14 | 2.07 / 6.87 | 0.80 / 0.98 | -0.30 / -0.05 |
+| **0.015** | 0.01 / 0.15 | 2.01 / 7.35 | 0.77 / 0.95 | **-0.24 / -0.03** |
+| 0.02 | 0.02 / 0.17 | 1.95 / 7.26 | 0.75 / 0.93 | -0.25 / -0.03 |
+| 0.03 | 0.02 / 0.17 | 1.91 / 7.18 | 0.78 / 0.95 | -0.29 / -0.04 |
+
+Chosen: **0.015** — the center of a broad plateau (0.01-0.02 all move the
+same windows the same way; M1 step 6 satisfied, no single-param spike).
+Mechanically it binds mostly on the 4h / high-vol legs (1h ATR/close rarely
+exceeds 1.5%): e.g. 2025H1 SOL 4h Sharpe -1.23 → -0.55 with maxDD -39.1% →
+-24.7%; 2023 DDadj 6.95 → 7.35. Trade counts are identical everywhere by
+construction.
+
+Final protocol measurement (one OOS look, chosen config):
+
+| config | IS | OOS | 2023 | 2024 | 2025H1 | held-out |
+|---|---|---|---|---|---|---|
+| long + sizing 0.015 | PASS | FAIL | PASS | FAIL | PASS | 2/3 |
+| short + sizing 0.015 | PASS | PASS | FAIL | FAIL | PASS | 1/3 |
+
+**Verdict: mild, consistent risk-adjusted improvement — but it flips no
+window verdict on either leg.** OOS is nearly untouched (the 1h legs, where
+the OOS failure lives, rarely bind the clip). Per M1 selection discipline
+that is not promotion evidence: the knob stays **default-off and
+unregistered** (`--list-json` byte-identical), available to future
+applications via `--params`.
+
+## Verdict table
+
+| mechanism | protocol OOS | held-out | disposition |
+|---|---|---|---|
+| long baseline | FAIL (BTC-concentrated edge) | 2/3 | remains the shipped default |
+| short leg (unconditional) | PASS 6/6 | 1/3 (fails both bull years) | negative result — documented, not shipped standalone; regime-gating is the follow-on surface |
+| sizing 0.015 (long) | FAIL (no flip) | 2/3 | keep default-off, unregistered |
+| sizing 0.015 (short combo) | PASS (short's own edge) | 1/3 | no interaction — sizing neither rescues nor harms the short leg |
+
+No registry defaults change; `--list-json` verified byte-identical against
+`main` for both registries. The engine gains the `entry_fraction` surface
+(+ tests) and momentum_pro gains the default-off sizing kwargs (+ tests);
+both are inert unless explicitly enabled.
+
+---
+Created with LLM: Fable 5 | high | Harness: Claude Code

--- a/shared_strategies/open/momentum_pro.py
+++ b/shared_strategies/open/momentum_pro.py
@@ -18,6 +18,10 @@ Rules (long; short is the mirror)
                   ``vol_mult`` <= 0.
 
 Emits ``signal = 1`` (long) / ``-1`` (short) on the trigger bar, else 0.
+
+Optional volatility-targeted entry sizing (#980, default OFF): when
+``vol_target_atr_pct > 0`` an ``entry_fraction`` column scales the notional
+committed at open inversely with ATR/close. Signals are never affected.
 """
 
 import numpy as np
@@ -37,6 +41,9 @@ def momentum_pro_core(
     pullback_touch_buffer_pct: float = 0.0,
     vol_period: int = 20,
     vol_mult: float = 1.2,
+    vol_target_atr_pct: float = 0.0,
+    vol_target_atr_period: int = 14,
+    vol_target_min_fraction: float = 0.10,
 ) -> pd.DataFrame:
     """Generate trend-pullback momentum signals (bidirectional).
 
@@ -50,6 +57,17 @@ def momentum_pro_core(
         as a pullback tag (0 = a plain touch qualifies)
     vol_period : SMA lookback for the volume baseline
     vol_mult : entry-bar volume must exceed vol_mult × SMA(volume); <= 0 disables
+    vol_target_atr_pct : volatility-targeted entry sizing (#980, default OFF).
+        When > 0, emit an ``entry_fraction`` column scaling the notional
+        committed at open inversely with realized vol:
+        ``clip(vol_target_atr_pct / (ATR / close), vol_target_min_fraction, 1.0)``
+        — full size when ATR/close <= the target, proportionally smaller when
+        the market is more volatile. Signals are NEVER changed by this knob;
+        <= 0 (the default) emits no column and is byte-identical to today.
+        Deliberately NOT a registered default param (``--list-json`` stays
+        byte-identical); reach it via ``--params``.
+    vol_target_atr_period : rolling True-Range mean lookback for the sizing ATR
+    vol_target_min_fraction : floor on the emitted fraction (avoids dust entries)
 
     Returns
     -------
@@ -58,6 +76,8 @@ def momentum_pro_core(
         ema_fast / ema_mid / ema_long : the regime EMAs
         adx        : Wilder ADX (0 during warmup)
         vol_sma    : SMA(volume, vol_period)
+        entry_fraction : only when ``vol_target_atr_pct > 0`` — per-bar entry
+            size fraction in (0, 1] (NaN during ATR warmup = full notional)
     """
     result = df.copy()
     result["signal"] = 0
@@ -123,4 +143,25 @@ def momentum_pro_core(
 
     result.loc[long_mask, "signal"] = 1
     result.loc[short_mask, "signal"] = -1
+
+    # #980: volatility-targeted entry sizing (default OFF — no column, and no
+    # effect on signals either way). ATR follows the standard_atr convention
+    # (rolling-mean True Range, integer-round only when ATR >= 100 — keep in
+    # sync with shared_tools/atr.py and the other inline copies).
+    if vol_target_atr_pct > 0:
+        prev_close = close.shift(1)
+        tr = pd.concat(
+            [high - low, (high - prev_close).abs(), (low - prev_close).abs()],
+            axis=1,
+        ).max(axis=1)
+        atr = tr.rolling(window=vol_target_atr_period).mean()
+        atr = atr.where(atr < 100, atr.round(0))
+        atr_pct = atr / close
+        fraction = (vol_target_atr_pct / atr_pct).clip(
+            lower=vol_target_min_fraction, upper=1.0,
+        )
+        # Warmup / degenerate ATR (NaN or <= 0) → NaN = "no opinion"; the
+        # engine resolves NaN to full notional, today's behavior.
+        result["entry_fraction"] = fraction.where(atr_pct > 0)
+
     return result

--- a/shared_strategies/open/test_momentum_pro.py
+++ b/shared_strategies/open/test_momentum_pro.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from momentum_pro import momentum_pro_core
 
@@ -102,3 +103,62 @@ def test_downtrend_pullback_fires_short():
     df = make_ohlcv(opens, highs, lows, closes, vol)
     out = momentum_pro_core(df, vol_mult=1.2)
     assert (out["signal"] == -1).any(), "expected a short entry on the breakdown bar"
+
+
+# ─── #980: volatility-targeted entry sizing (default OFF) ────────────────────
+
+
+def test_vol_target_off_by_default_no_entry_fraction_column():
+    df = build_uptrend_with_pullback()
+    out = momentum_pro_core(df)
+    assert "entry_fraction" not in out.columns
+
+
+def test_vol_target_zero_is_byte_identical_to_default():
+    df = build_uptrend_with_pullback()
+    base = momentum_pro_core(df)
+    off = momentum_pro_core(df, vol_target_atr_pct=0.0)
+    pd.testing.assert_frame_equal(base, off)
+
+
+def test_vol_target_never_changes_signals():
+    df = build_uptrend_with_pullback()
+    base = momentum_pro_core(df)
+    sized = momentum_pro_core(df, vol_target_atr_pct=0.01)
+    pd.testing.assert_series_equal(base["signal"], sized["signal"])
+
+
+def test_vol_target_emits_fraction_scaled_by_atr():
+    # Flat bars: high-low = 2 around close 100 → TR 2, ATR 2, ATR/close 0.02.
+    # Target 0.01 → fraction 0.5 once the ATR window is warm.
+    n = 260
+    closes = np.full(n, 100.0)
+    df = make_ohlcv(closes, closes + 1.0, closes - 1.0, closes,
+                    np.full(n, 100.0))
+    out = momentum_pro_core(df, vol_target_atr_pct=0.01)
+    assert "entry_fraction" in out.columns
+    warm = out["entry_fraction"].iloc[50:]
+    assert warm.notna().all()
+    assert warm.iloc[-1] == pytest.approx(0.5)
+    assert ((warm > 0) & (warm <= 1)).all()
+
+
+def test_vol_target_fraction_floors_at_min_fraction():
+    n = 260
+    closes = np.full(n, 100.0)
+    df = make_ohlcv(closes, closes + 1.0, closes - 1.0, closes,
+                    np.full(n, 100.0))
+    out = momentum_pro_core(df, vol_target_atr_pct=0.0001,
+                            vol_target_min_fraction=0.10)
+    warm = out["entry_fraction"].iloc[50:]
+    assert np.allclose(warm, 0.10)
+
+
+def test_vol_target_caps_fraction_at_one_in_quiet_markets():
+    n = 260
+    closes = np.full(n, 100.0)
+    df = make_ohlcv(closes, closes + 1.0, closes - 1.0, closes,
+                    np.full(n, 100.0))
+    out = momentum_pro_core(df, vol_target_atr_pct=0.50)
+    warm = out["entry_fraction"].iloc[50:]
+    assert np.allclose(warm, 1.0)


### PR DESCRIPTION
Closes #980

## What

Full M1 application on `momentum_pro` (the #956 audit's best OOS-checked strategy): measure the already-emitted short leg, and add volatility-targeted entry sizing behind a new backtester surface. Both mechanisms are independent and default-off per M1 step 4.

**Engine (`backtest/backtester.py`):** new `entry_fraction` column surface following the `close_fraction` precedent — strategy-emitted, validated to (0, 1], `shift(1)`'d with the signal, scales the notional committed at all four open paths; remainder stays as a cash reserve. The plain-path long close and SL fills become **additive** (`cash += proceeds`) so a fractional-entry reserve (or funding accrual) survives the close — identical arithmetic when cash is 0, i.e. every existing run. Backtest-research surface only; live sizing is config-driven and ignores the column.

**Strategy (`shared_strategies/open/momentum_pro.py`):** default-off, deliberately **unregistered** kwargs (`vol_target_atr_pct`, `vol_target_atr_period`, `vol_target_min_fraction`) emitting `entry_fraction = clip(target / (ATR/close), floor, 1.0)` — reachable via `--params`, never in `default_params`. Signals and trade counts are never affected.

## M1 results (`docs/research/momentum_pro_980.md`)

| config | IS | OOS | 2023 | 2024 | 2025H1 | held-out |
|---|---|---|---|---|---|---|
| long baseline | PASS | FAIL | PASS | FAIL | PASS | 2/3 |
| short leg | PASS | **PASS 6/6** | FAIL 0/6 | FAIL 0/6 | PASS | 1/3 |
| long + sizing 0.015 | PASS | FAIL | PASS | FAIL | PASS | 2/3 |
| short + sizing 0.015 | PASS | PASS | FAIL | FAIL | PASS | 1/3 |

- **Short leg:** emphatic protocol-OOS pass (mean Sharpe +1.52 vs bar -0.63, every dataset positive while B&H is -30..-45%) but 0/6 in both bull held-outs — the #1031/#1021 failure shape. Negative result for an unconditional standalone short: documented, not shipped; regime-gating the short side is the named follow-on surface. Live behavior unchanged.
- **Sizing:** chosen 0.015 sits on a broad 0.01–0.02 plateau (tuned on IS + held-outs only, one final OOS look). Mild consistent risk-adjusted improvement (2025H1 mean Sharpe -0.34 → -0.24; SOL 4h maxDD -39.1% → -24.7%; 2023 DDadj 6.95 → 7.35), flips no verdict → stays default-off/unregistered.
- **Baseline note:** the audit's "+27.3pts best OOS" row was BTC/USDT 1h only; current-cache BTC 1h OOS reproduces it directionally (+23.9pts, 6 trades, beats bar) while the 6-dataset OOS mean fails — the long edge is BTC-concentrated.

## Verification

- `uv run --no-sync python -m pytest shared_strategies/ shared_tools/ platforms/ backtest/` — **2014 passed** (incl. 14 new engine cases + 6 new strategy cases).
- `--list-json` **byte-identical** vs `main` for both registries (diffed).
- No Go changes.

LLM: Fable 5 | high | Harness: Claude Code
