### PR TITLE
research(#981): mean_reversion_pro M1 — frequency knobs validated, negative result for default change

### DIFF
--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -777,6 +777,9 @@ DEFAULT_PARAM_RANGES = {
         "adx_max": [20.0, 25.0, 30.0],
         "rsi_oversold": [25.0, 30.0, 35.0],
         "rsi_overbought": [65.0, 70.0, 75.0],
+        # #981 default-off extra entry triggers.
+        "touch_entry": [0, 1],
+        "turn_entry": [0, 1],
     },
     "mtf_confluence": {
         "htf_factor": [3, 4, 6],

--- a/docs/research/mean_reversion_pro_981.md
+++ b/docs/research/mean_reversion_pro_981.md
@@ -1,0 +1,230 @@
+# mean_reversion_pro trade frequency M1 application (#981)
+
+Generated: 2026-07-01
+
+Part of the M1 program (#977/#978); audit source #956/#975. The audit ranked
+`mean_reversion_pro` best among strategies that actually traded below the two
+keepers (-0.20 mean Sharpe, +35.8pts vs B&H) but on a starvation sample: 17
+trades in-sample, 2 OOS ("weak (2 trades)"). The regime filter that separates
+it from its deprecated parent (`mean_reversion`, -1.46 / deprecate) is also
+what starves it. This application raises trade frequency **without weakening
+the regime gate**, per the #981 focus: mechanisms as independent default-off
+knobs (M1 step 4), degenerate passes rejected (step 5), plateau-checked
+(step 6).
+
+## Mechanisms (implemented, default-off)
+
+`shared_strategies/open/mean_reversion_pro.py` — two new params (registry
+defaults keep both off; `--list-json` byte-identical, both registries
+verified):
+
+- `touch_entry` (default **0** = off): adds a **band-touch** trigger — the
+  bar the z-score first pierces ±`entry_std` (previous bar inside the band)
+  while RSI shows the extreme.
+- `turn_entry` (default **0** = off): adds a **stretched-turn** trigger — the
+  z-score still beyond ±`entry_std` but turning back toward the mean vs the
+  prior bar, while RSI shows the extreme. Fires earlier than the base
+  reversion cross and also catches stretches whose RSI confirmation window
+  has expired by the time z crosses back.
+
+Both triggers are OR'd with the base reversion-cross trigger (they only ever
+add signal bars — regression-tested) and both sit behind the **same ADX
+no-trend gate and RSI-extreme evidence** — frequency from more setups inside
+the allowed regime, not weaker filtering. RSI evidence for the extra
+triggers = extreme on the current bar OR within the base trigger's
+`confirm_window`. Defaults 0/0 are bit-identical to the pre-#981 strategy
+(regression-tested).
+
+The third mechanism — a **looser ADX gate** — needs no new code:
+`adx_max` is an existing registered param; it is swept as mechanism 3 below.
+
+## Baseline reproduction (M1 step 1)
+
+Audit row (#956, in `scheduler/ui_reports.go`): in-sample mean Sharpe -0.20,
++35.8pts vs B&H, 17 trades over 12 months × 6 datasets; OOS +11.8pts on 2
+trades. On the M1 harness (IS = 2025-06-10→2026-01-01, ~7 months, so lower
+counts are expected; cache populated through 2026-07-01):
+
+| Window | mean Sharpe / bar | mean DDadj / bar | trades (Σ 6 legs) | verdict |
+|--------|-------------------|------------------|--------------------|---------|
+| IS (2025-06-10→2026-01-01) | -0.14 / -0.12 | -0.11 / -0.14 | 9  | FAIL |
+| OOS (2026-01-01→latest)    |  0.41 / -0.63 |  0.45 / -0.46 | 13 | PASS |
+| 2023                        |  1.17 /  1.46 |  6.10 /  3.67 | 20 | FAIL |
+| 2024                        |  1.23 /  0.90 |  2.24 /  1.07 | 23 | PASS |
+| 2025H1                      |  0.07 / -0.42 |  0.06 / -0.37 | 16 | PASS |
+
+Protocol OOS PASS, held-out 2/3 — consistent with the audit's "top tier of
+strategies that traded, sample too thin to trust". The starvation is visible
+per-leg: IS has two zero-trade legs (BTC 4h, ETH 4h; 2025H1 adds SOL 4h),
+and no baseline leg in any window reaches double-digit trades. IS is a
+near-miss FAIL (-0.14 vs bar -0.12) driven by the SOL 4h leg (1 trade,
+-32.3%).
+
+**Diagnosis (M1 step 3):** unlike the M5 fee-churn class, every failure here
+is a *sample-size* failure — the strategy is fee-light (9-23 trades per
+window across 6 legs vs incumbents' hundreds) but one bad leg dominates any
+window mean. More setups inside the same regime is the right lever;
+loosening the regime filter is the wrong one (see mechanism 3).
+
+## Mechanism sweeps (M1 steps 4-6; tuned on IS + held-outs only, per step 5)
+
+### Mechanism 3 — looser ADX gate (`adx_max` sweep, existing param)
+
+Mean candidate Sharpe per tuning window (bar in header; PASS = beats bar on
+Sharpe AND DDadj means; degenerate zero-trade passes auto-rejected):
+
+| adx_max | IS (bar -0.12) | 2023 (bar 1.46) | 2024 (bar 0.90) | 2025H1 (bar -0.42) |
+|---------|----------------|------------------|------------------|---------------------|
+| 20      | 0.18 PASS (3/6 traded) | 0.67 FAIL (3/6) | 0.15 FAIL (3/6) | 0.45 PASS (4/6) |
+| 25 (default) | -0.14 FAIL | 1.17 FAIL | **1.23 PASS** | 0.07 PASS |
+| 30      | -0.78 FAIL | 1.30 FAIL | **1.27 PASS** | -0.11 PASS |
+| 35      | -0.34 FAIL | 1.24 FAIL | 0.79 FAIL | 0.63 PASS |
+| 40      | -0.17 FAIL | 1.16 FAIL | 0.56 FAIL | 0.68 PASS |
+| 50      | 0.01 PASS | 1.42 FAIL | 0.40 FAIL | 0.34 PASS |
+| 100 (≈ no gate) | 0.09 PASS | 1.48 FAIL | 0.31 FAIL | 0.37 PASS |
+
+**Negative result — the gate is not the frequency lever.** No value dominates
+the default across tuning windows: loosening to 35+ bleeds the bull year
+(2024 PASS→FAIL, Sharpe 1.23→0.79→0.31 as the ceiling rises — exactly the
+falling-knife fades the gate exists to block), while tightening to 20 starves
+half the legs to zero trades. The `adx_max=50/100` IS "passes" are the
+audit's core finding replayed in reverse: without the gate the strategy
+converges toward its deprecated parent (2024 at 100 ≈ unfiltered
+mean_reversion behavior). The default `adx_max=25` stays; the issue's
+premise ("the plateau check guards against trading the edge away") is
+confirmed — there is no plateau to move to.
+
+### Mechanisms 1+2 — additional entry triggers (isolated and combined)
+
+Mean candidate Sharpe / DDadj per tuning window; Σ trades across the 6 legs:
+
+| config | IS (bar -0.12/-0.14) | 2023 (bar 1.46/3.67) | 2024 (bar 0.90/1.07) | 2025H1 (bar -0.42/-0.37) |
+|--------|----------------------|-----------------------|-----------------------|---------------------------|
+| base (off/off) | -0.14 / -0.11 · 9 FAIL | 1.17 / 6.10 · 20 FAIL | 1.23 / 2.24 · 23 PASS | 0.07 / 0.06 · 16 PASS |
+| **turn only** | **0.14 / 0.30 · 22 PASS** | 1.32 / 4.09 · 50 FAIL | 0.79 / 1.15 · 54 FAIL | 0.12 / 0.16 · 27 PASS |
+| touch only | -0.59 / -0.48 · 17 FAIL | 0.90 / 3.08 · 46 FAIL | 1.08 / 1.70 · 40 PASS | -0.07 / -0.11 · 23 PASS |
+| both | -0.47 / -0.40 · 25 FAIL | 1.34 / 3.71 · 61 FAIL | 0.61 / 0.59 · 56 FAIL | -0.21 / -0.12 · 31 PASS |
+
+- **`turn_entry=1` is the frequency mechanism that works**: trades 2-2.5×
+  everywhere (9→22, 20→50, 23→54, 16→27), every zero-trade leg fills
+  (6/6 traded in all four windows), and IS flips FAIL→PASS — the ETH 4h leg
+  goes 0 trades → +16.7% (Sharpe 1.88 vs bar 0.30); BTC 1h goes 2→6 trades,
+  Sharpe 0.03 vs bar -1.02.
+- **`touch_entry=1` is a negative result**: it adds nearly as many trades
+  but catches knives (IS Sharpe -0.14→-0.59); stacking it onto turn only
+  dilutes (IS -0.47 vs turn's +0.14). Documented, stays available, not
+  recommended.
+- **2024 is a real regression under turn** (PASS→FAIL, 1.23→0.79 vs bar
+  0.90): in a steady bull the extra fades enter earlier into pullbacks that
+  keep falling; the base cross-back trigger's extra patience was worth more
+  than the extra sample. Same trade-bull-upside-for-chop-coverage shape as
+  #982's HTF gate.
+
+### Plateau checks for the chosen config (`turn_entry=1`, M1 step 6)
+
+- **`adx_max` axis (turn on):** IS passes at 22 and 25 (0.12/0.14), fails at
+  20 (-0.51, 4/6 traded) and 30+ (trend bleed, -0.29/-0.30) — the default 25
+  sits on the two-value plateau, not a cliff edge. 2023 shows a lone spike
+  (adx_max=22 → 2.22 PASS flanked by 1.40/1.32 FAILs) — rejected as an
+  overfit tell per step 6, not chased.
+- **`confirm_window` axis (turn on):** inert — 2,3,4,5 produce identical
+  means on IS and 2024 (the turn trigger's RSI evidence is dominated by the
+  current-bar extreme while stretched). No cliff.
+- **`entry_std` axis (turn on, IS):** flat plateau — 1.75/2.0/2.25/2.5 all
+  PASS (Sharpe 0.11-0.15, DDadj 0.30-0.33, 6/6 traded). The IS pass is not
+  an `entry_std` artifact.
+
+## Final protocol measurement (one OOS look, chosen config `{"turn_entry": 1}`)
+
+| Window | baseline verdict | turn verdict | turn Sharpe / bar | turn DDadj / bar |
+|--------|------------------|--------------|--------------------|-------------------|
+| IS     | FAIL | **PASS** | 0.14 / -0.12 | 0.30 / -0.14 |
+| OOS    | PASS | **FAIL** | -1.32 / -0.63 | -0.68 / -0.46 |
+| 2023   | FAIL | FAIL | 1.32 / 1.46 | 4.09 / 3.67 |
+| 2024   | PASS | **FAIL** | 0.79 / 0.90 | 1.15 / 1.07 |
+| 2025H1 | PASS | PASS | 0.12 / -0.42 | 0.16 / -0.37 |
+
+Windows passed: **2/5 vs baseline 3/5**; protocol OOS **FAIL** (baseline
+PASS); held-out 1/3 vs baseline 2/3. The OOS failure is broad, not one bad
+leg: 1/6 legs beat the bar (baseline: 5-6/6). On the 2026 crash tape the
+stretched-turn trigger enters *before* the reversion is confirmed and
+catches the continuation — SOL 1h flips from +25.3% (baseline, 4 trades) to
+-43.1% (turn, 4 trades); BTC 4h from +9.2% to -19.9%. Slow persistent bleeds
+keep ADX below the ceiling, so the regime gate — correctly — does not save
+an entry trigger that fires too early inside the allowed regime.
+
+## Honest caveats
+
+1. **The frequency mechanism works; the chosen trigger's edge does not
+   survive the protocol window.** Turn delivers exactly the sample the issue
+   asked for (2-2.5× trades, zero-trade legs eliminated, IS FAIL→PASS on a
+   plateau across `adx_max`/`confirm_window`/`entry_std`) but gives back the
+   baseline's OOS pass and the 2024 held-out — the base trigger's patience
+   (wait for the z-score to cross back) *is* the edge the audit measured,
+   not just a sampling handicap.
+2. **The value is regime-conditional** — which is M4's territory (#977 maps
+   mean_reversion_pro to M4 regime-profile allocation): switching
+   `turn_entry` 0↔1 on a slow regime signal (fade harder in grind windows,
+   stand down in trends/crashes) is the natural follow-on the issue itself
+   names. Out of scope here; the default-off knob is the surface M4 needs.
+3. The audit's 2-trade OOS sample is superseded by the current-cache OOS
+   window (6 months, 13 baseline trades) — the baseline's standing is now
+   measured on a real sample, which strengthens, not weakens, the
+   keep-the-default verdict.
+
+## Verdict
+
+**Negative result for any default change — documented, not deleted (M1
+step 4).** All three mechanisms were isolated, swept, and rejected for
+promotion on the M1 bar:
+
+- `adx_max` (mechanism 3): no plateau beats the default across tuning
+  windows; loosening replays the deprecated parent's failure mode.
+- `touch_entry` (mechanism 1): knife-catcher — degrades IS outright.
+- `turn_entry` (mechanism 2): the real candidate — passes IS on a broad
+  plateau with the frequency the issue wanted, but fails the one-look
+  protocol OOS and the bull-year held-outs.
+
+**Registry defaults stay exactly as before** (`--list-json` byte-identical
+on both registries, verified); both new knobs ship **default-off** as
+validated research surface for per-config opt-in and for the M4 follow-on.
+The #981 premise is answered: the regime filter is not what starves the
+strategy — the *reversion-confirmation patience* is, and that patience is
+load-bearing. Live behavior is unchanged.
+
+## Reproduce
+
+```bash
+# Baseline, all 5 windows (M1 steps 1-2)
+uv run --no-sync python backtest/eval_windows.py --strategy mean_reversion_pro
+
+# Mechanism 3 — ADX ceiling sweep per tuning window W ∈ {is,2023,2024,2025H1}
+uv run --no-sync python backtest/eval_windows.py --strategy mean_reversion_pro \
+  --windows W --sweep adx_max=20,25,30,35,40,50,100 --sweep-window W
+
+# Mechanisms 1+2 — trigger isolation/combination per tuning window W
+uv run --no-sync python backtest/eval_windows.py --strategy mean_reversion_pro \
+  --windows W --sweep touch_entry=0,1 --sweep turn_entry=0,1 --sweep-window W
+
+# Plateau axes for the chosen config (IS shown; adx also run on 2023/2024/2025H1)
+uv run --no-sync python backtest/eval_windows.py --strategy mean_reversion_pro \
+  --params '{"turn_entry": 1}' --windows is --sweep adx_max=20,22,25,30,35 --sweep-window is
+uv run --no-sync python backtest/eval_windows.py --strategy mean_reversion_pro \
+  --params '{"turn_entry": 1}' --windows is --sweep confirm_window=2,3,4,5 --sweep-window is
+uv run --no-sync python backtest/eval_windows.py --strategy mean_reversion_pro \
+  --params '{"turn_entry": 1}' --windows is --sweep entry_std=1.75,2.0,2.25,2.5 --sweep-window is
+
+# Final protocol measurement (single OOS look, chosen config)
+uv run --no-sync python backtest/eval_windows.py --strategy mean_reversion_pro \
+  --params '{"turn_entry": 1}'
+```
+
+Runs executed 2026-07-01 on the audit datasets (BTC/ETH/SOL × 1h/4h,
+binanceus fee model, 5 bps slippage, long-leg open-as-close harness);
+`--registry spot` (mean_reversion_pro is byte-identical in both registries).
+Caveat (same class as #980's): a run against a cold or partially-populated
+cache is not reproducible — populate 2023-01-01→now first; with a warm cache
+back-to-back runs reproduce to the digit.
+
+---
+Created with LLM: Fable 5 | high | Harness: Claude Code

--- a/shared_strategies/open/mean_reversion_pro.py
+++ b/shared_strategies/open/mean_reversion_pro.py
@@ -17,6 +17,25 @@ Rules (long; short is the mirror)
 
 Emits ``signal = 1`` (long) / ``-1`` (short) on the reversion bar, else 0.
 When used open-as-close, the opposite signal also exits the position.
+
+Additional entry triggers (#981, default-off)
+---------------------------------------------
+The reversion-cross trigger alone starves the strategy (17 trades in-sample
+in the #956 audit). Two extra triggers add setups *inside the same no-trend
+regime* — frequency from more setups, not weaker filtering. Both stay behind
+the ADX gate and the RSI-extreme evidence, and both are OR'd with the base
+trigger (they never remove a base signal):
+
+- ``touch_entry=1`` — band touch: the bar the z-score first pierces
+  ``±entry_std`` (previous bar inside the band) while RSI shows the extreme.
+- ``turn_entry=1`` — stretched turn: z-score still beyond ``±entry_std`` but
+  turning back toward the mean vs the prior bar, while RSI shows the extreme.
+  Fires earlier than the reversion cross and also catches stretches whose RSI
+  confirmation window has expired by the time z crosses back.
+
+RSI evidence for the extra triggers = RSI at the extreme on the current bar
+OR within the last ``confirm_window`` bars (the base trigger's window).
+Defaults 0/0 are bit-identical to the pre-#981 strategy.
 """
 
 import numpy as np
@@ -35,6 +54,8 @@ def mean_reversion_pro_core(
     rsi_oversold: float = 30.0,
     rsi_overbought: float = 70.0,
     confirm_window: int = 3,
+    touch_entry: int = 0,
+    turn_entry: int = 0,
 ) -> pd.DataFrame:
     """Generate trend-filtered mean-reversion signals (bidirectional).
 
@@ -47,6 +68,8 @@ def mean_reversion_pro_core(
     rsi_period : Wilder RSI lookback
     rsi_oversold / rsi_overbought : RSI extremes the stretch must have reached
     confirm_window : bars to look back for the RSI extreme during the stretch
+    touch_entry : #981 default-off — 1 adds the band-touch trigger
+    turn_entry : #981 default-off — 1 adds the stretched-turn trigger
 
     Returns
     -------
@@ -113,6 +136,26 @@ def mean_reversion_pro_core(
 
     long_mask = no_trend & long_revert & rsi_was_oversold
     short_mask = no_trend & short_revert & rsi_was_overbought
+
+    # #981 additional entry triggers (default-off): more setups inside the
+    # same no-trend regime. OR'd with the base trigger — they only ever add
+    # signal bars, and every extra setup still requires the ADX gate plus
+    # RSI-extreme evidence (current bar or the base trigger's window).
+    if touch_entry or turn_entry:
+        rsi_evidence_long = (result["rsi"] < rsi_oversold) | rsi_was_oversold
+        rsi_evidence_short = (result["rsi"] > rsi_overbought) | rsi_was_overbought
+        if touch_entry:
+            # Band touch: first bar beyond the band (prior bar inside it).
+            long_touch = (z <= -entry_std) & (z.shift(1) > -entry_std)
+            short_touch = (z >= entry_std) & (z.shift(1) < entry_std)
+            long_mask |= no_trend & long_touch & rsi_evidence_long
+            short_mask |= no_trend & short_touch & rsi_evidence_short
+        if turn_entry:
+            # Stretched turn: still beyond the band, turning back to the mean.
+            long_turn = (z <= -entry_std) & (z > z.shift(1))
+            short_turn = (z >= entry_std) & (z < z.shift(1))
+            long_mask |= no_trend & long_turn & rsi_evidence_long
+            short_mask |= no_trend & short_turn & rsi_evidence_short
 
     result.loc[long_mask, "signal"] = 1
     result.loc[short_mask, "signal"] = -1

--- a/shared_strategies/open/registry.py
+++ b/shared_strategies/open/registry.py
@@ -1160,6 +1160,9 @@ def momentum_pro_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
         "adx_period": 14, "adx_max": 25.0,
         "rsi_period": 14, "rsi_oversold": 30.0, "rsi_overbought": 70.0,
         "confirm_window": 3,
+        # #981 additional entry triggers — default-off (1 enables; both stay
+        # behind the ADX no-trend gate + RSI-extreme evidence).
+        "touch_entry": 0, "turn_entry": 0,
     },
 )
 def mean_reversion_pro_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:

--- a/shared_strategies/open/test_mean_reversion_pro.py
+++ b/shared_strategies/open/test_mean_reversion_pro.py
@@ -82,3 +82,113 @@ def test_rsi_confirmation_required():
         rsi_overbought=101.0,
     )
     assert (out["signal"] == 0).all()
+
+
+# ─── #981 additional entry triggers (default-off) ───────────────────────────
+
+
+def test_extra_triggers_default_off_bit_identical():
+    """touch_entry=0, turn_entry=0 must be bit-identical to the pre-#981
+    strategy — the registry default changes nothing."""
+    df = make_ohlcv(make_choppy_with_extremes())
+    base = mean_reversion_pro_core(df, entry_std=1.5)
+    off = mean_reversion_pro_core(df, entry_std=1.5, touch_entry=0, turn_entry=0)
+    assert (base["signal"] == off["signal"]).all()
+    for col in ("z_score", "adx", "rsi"):
+        assert base[col].equals(off[col])
+
+
+def test_touch_entry_adds_setups():
+    """touch_entry=1 must add signal bars the reversion-cross trigger misses
+    (that is the frequency mechanism) without removing any base signal.
+
+    The fixture's V-dips put pierce-bar RSI at ~31-34, so thresholds of
+    35/65 give the touch trigger genuine current-bar RSI evidence there —
+    the same thresholds on both runs keep the comparison apples-to-apples."""
+    df = make_ohlcv(make_choppy_with_extremes())
+    kwargs = dict(entry_std=1.5, rsi_oversold=35.0, rsi_overbought=65.0)
+    base = mean_reversion_pro_core(df, **kwargs)
+    touch = mean_reversion_pro_core(df, touch_entry=1, **kwargs)
+    base_bars = set(np.where(base["signal"].values != 0)[0])
+    touch_bars = set(np.where(touch["signal"].values != 0)[0])
+    assert base_bars <= touch_bars, "touch_entry removed a base signal"
+    assert len(touch_bars) > len(base_bars), "touch_entry added no setups"
+
+
+def test_turn_entry_adds_setups():
+    df = make_ohlcv(make_choppy_with_extremes())
+    base = mean_reversion_pro_core(df, entry_std=1.5)
+    turn = mean_reversion_pro_core(df, entry_std=1.5, turn_entry=1)
+    base_bars = set(np.where(base["signal"].values != 0)[0])
+    turn_bars = set(np.where(turn["signal"].values != 0)[0])
+    assert base_bars <= turn_bars, "turn_entry removed a base signal"
+    assert len(turn_bars) > len(base_bars), "turn_entry added no setups"
+
+
+def test_extra_triggers_preserve_base_signal_values():
+    """On every bar where the base strategy fires, the triggers-on run must
+    emit the same direction (the extra triggers are additive OR, never a
+    rewrite of the base decision)."""
+    df = make_ohlcv(make_choppy_with_extremes())
+    base = mean_reversion_pro_core(df, entry_std=1.5)
+    both = mean_reversion_pro_core(df, entry_std=1.5, touch_entry=1, turn_entry=1)
+    fired = base["signal"].values != 0
+    assert (base["signal"].values[fired] == both["signal"].values[fired]).all()
+
+
+def test_extra_triggers_still_blocked_by_strong_trend():
+    """The regime filter is the strategy's edge (#981's hard requirement):
+    a relentless high-ADX trend must produce zero entries even with both
+    extra triggers enabled."""
+    closes = np.linspace(100, 300, 400)
+    out = mean_reversion_pro_core(
+        make_ohlcv(closes, noise=0.2), touch_entry=1, turn_entry=1
+    )
+    assert (out["signal"] == 0).all()
+
+
+def test_extra_triggers_respect_adx_max_zero():
+    """adx_max=0 closes the no-trend gate for the extra triggers too."""
+    out = mean_reversion_pro_core(
+        make_ohlcv(make_choppy_with_extremes()),
+        adx_max=0.0, touch_entry=1, turn_entry=1,
+    )
+    assert (out["signal"] == 0).all()
+
+
+def test_extra_triggers_require_rsi_evidence():
+    """Impossible RSI thresholds must silence the extra triggers as well —
+    they add setups behind the same oscillator evidence, not around it."""
+    out = mean_reversion_pro_core(
+        make_ohlcv(make_choppy_with_extremes()),
+        rsi_oversold=-1.0, rsi_overbought=101.0,
+        touch_entry=1, turn_entry=1,
+    )
+    assert (out["signal"] == 0).all()
+
+
+def test_extra_triggers_fire_both_sides():
+    """The mirrored short-side triggers must fire on the fixture's spikes,
+    not just the long side on its dips."""
+    out = mean_reversion_pro_core(
+        make_ohlcv(make_choppy_with_extremes()),
+        entry_std=1.5, touch_entry=1, turn_entry=1,
+    )
+    assert (out["signal"] == 1).any()
+    assert (out["signal"] == -1).any()
+
+
+def test_extra_triggers_prefix_stable():
+    """No look-ahead: for every bar where the triggers-on run emits a signal,
+    running on the prefix df[:k+1] must emit the same signal at bar k."""
+    df = make_ohlcv(make_choppy_with_extremes())
+    kwargs = dict(entry_std=1.5, touch_entry=1, turn_entry=1)
+    full = mean_reversion_pro_core(df, **kwargs)
+    signal_bars = list(np.where(full["signal"].values != 0)[0])
+    assert len(signal_bars) >= 1  # fixture sanity
+    for k in signal_bars:
+        partial = mean_reversion_pro_core(df.iloc[: k + 1], **kwargs)
+        assert partial["signal"].iloc[k] == full["signal"].iloc[k], (
+            f"signal at bar {k} flipped under truncation: "
+            f"full={full['signal'].iloc[k]} truncated={partial['signal'].iloc[k]}"
+        )


### PR DESCRIPTION
Closes #981

Full M1 protocol (#977/#995) applied to `mean_reversion_pro`'s trade starvation (#956 audit: 17 trades in-sample, 2 OOS). The issue's three mechanisms land as independent default-off knobs and are validated end-to-end; the headline outcome is an **honest negative result for any default change**, documented per M1 step 4.

## What changed

- `shared_strategies/open/mean_reversion_pro.py` — two default-off params: `touch_entry=1` adds a band-touch trigger (first bar the z-score pierces ±`entry_std` with RSI at the extreme); `turn_entry=1` adds a stretched-turn trigger (z still beyond the band, turning back toward the mean, RSI evidence on the current bar or within `confirm_window`). Both OR onto the base reversion-cross trigger and sit behind the **same ADX no-trend gate** — frequency from more setups inside the allowed regime, not weaker filtering. `0/0` is bit-identical to the pre-#981 strategy (regression-tested).
- `shared_strategies/open/registry.py` — knob defaults on the registration, description untouched; `--list-json` **byte-identical on both registries** (verified against main).
- `backtest/optimizer.py` — `touch_entry`/`turn_entry` in `DEFAULT_PARAM_RANGES`.
- `shared_strategies/open/test_mean_reversion_pro.py` — 9 new tests: default-off parity, additivity (base signals never removed, direction preserved), both-sides firing, ADX gate / `adx_max=0` / RSI evidence still block the extra triggers, prefix stability (no look-ahead).
- `docs/research/mean_reversion_pro_981.md` — baseline reproduction, all sweeps, plateau checks, one-look protocol measurement, verdict.

## M1 result (detail in the research doc)

- **Baseline reproduced**: protocol OOS PASS, held-out 2/3, 9–23 trades per window across 6 legs with zero-trade legs — the audit's starvation confirmed.
- **Mechanism: looser ADX gate (`adx_max` sweep 20–100)** — negative: no ceiling dominates the default 25 across tuning windows; 35+ bleeds the 2024 bull year (1.23→0.31 as the ceiling rises), 20 starves half the legs. The issue's plateau-check guardrail did its job: there is no plateau to move to.
- **Mechanism: `touch_entry`** — negative: knife-catcher (IS Sharpe -0.14→-0.59).
- **Mechanism: `turn_entry`** — delivers the issue's frequency goal (2–2.5× trades everywhere, every zero-trade leg fills, IS FAIL→PASS on a broad plateau across `adx_max`/`confirm_window`/`entry_std`) **but fails the single-look protocol OOS** (-1.32 vs bar -0.63; baseline +0.41 PASS) and the bull-year held-outs (1/3 vs baseline 2/3). The base trigger's reversion-confirmation patience is the audited edge, not a sampling handicap.
- **Disposition**: registry defaults and live behavior unchanged; knobs ship default-off as validated research surface. The regime-conditional value (`turn_entry` 0↔1 on a slow regime signal) is exactly the M4 (#998) follow-on the issue names.

## Verification

- Full pytest suite: **2044 passed**.
- `go -C scheduler build .` + `go test ./...`: ok.
- Spot + futures `--list-json`: byte-identical vs main.
- M1 selection discipline held: tuning on IS + held-outs only; exactly one protocol-OOS measurement (the chosen config's final table).

LLM: Fable 5 | high | Harness: Claude Code

https://claude.ai/code/session_01REhA3VMB6QyqyKwRtcTsA6
