### PR TITLE
feat(#1169): anchored_vwap_channel — dual-anchor AVWAP channel (long lower line, short upper)

### DIFF
--- a/backtest/fee_audit.py
+++ b/backtest/fee_audit.py
@@ -95,7 +95,7 @@ LIVE_BIDIRECTIONAL_STRATEGIES = frozenset({
     "chart_pattern", "liquidity_sweeps", "bear_pullback_st", "vwap_rejection_st",
     "momentum_pro", "mean_reversion_pro", "consolidation_range", "mtf_confluence",
     "vol_momentum", "funding_skew", "regime_adaptive", "anchored_vwap",
-    "atr_band_revert",
+    "anchored_vwap_channel", "atr_band_revert",
 })
 
 # The #956/#963 protocol windows; held-out windows overlap `is` and would

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -728,6 +728,12 @@ DEFAULT_PARAM_RANGES = {
         "buffer_atr_mult": [0.1, 0.25, 0.5],
         "confirm_bars": [1, 2, 3],
     },
+    "anchored_vwap_channel": {
+        "pivot_strength": [3, 5, 8],
+        "buffer_atr_mult": [0.1, 0.25, 0.5],
+        "confirm_bars": [1, 2, 3],
+        "min_width_atr_mult": [1.0, 1.5, 2.5],
+    },
     "chart_pattern": {
         "pivot_lookback": [3, 5, 7],
         "tolerance": [0.02, 0.03, 0.05],

--- a/backtest/tests/test_backtester_lookahead.py
+++ b/backtest/tests/test_backtester_lookahead.py
@@ -410,3 +410,86 @@ def test_anchored_vwap_no_lookahead():
     assert not np.array_equal(bf[:cut], bt), (
         "forward-peeking variant should break truncation-invariance — the test "
         "is not sensitive to look-ahead")
+
+
+# ─── anchored_vwap_channel: signals at bars <= cut don't depend on future bars (#1169) ─
+from anchored_vwap_channel import anchored_vwap_channel_core  # noqa: E402
+
+
+_AVWAP_CHANNEL_PARAMS = dict(pivot_strength=2, buffer_atr_mult=0.0, confirm_bars=2,
+                             min_width_atr_mult=0.0, atr_period=3)
+
+
+def _avwap_channel_mixed_fixture() -> pd.DataFrame:
+    """OHLCV forming a swing HIGH (idx 2), a swing LOW (idx 6), then a channel.
+
+    Bar 10 wicks through the support line and reclaims (+1 fires at bar 11 —
+    and bar 10's hand-set wick low is itself a strict swing low, re-anchoring
+    support at bar 12). A later swing HIGH (idx 13) re-anchors resistance; the
+    bar-15 dip to the risen support fires +1 at 16, and bar 16's hand-set
+    up-wick through resistance with a held rejection fires -1 at bar 17. A
+    smooth fixture is NOT usable: equal highs/lows at a monotonic turn tie
+    under the strict pivot rule and nothing confirms (see the anchored_vwap
+    fixture note above).
+    """
+    closes = np.array([104, 106, 108, 106, 104, 102, 100, 102, 104, 103,
+                       102.5, 103.5, 104.5, 106.0, 104.8, 104.2, 104.6, 104.0],
+                      dtype=float)
+    lows = closes - 0.5
+    lows[10] = 101.0
+    highs = closes + 0.5
+    highs[16] = 105.8
+    idx = pd.date_range("2026-01-01", periods=len(closes), freq="1h")
+    return pd.DataFrame(
+        {"open": closes, "high": highs, "low": lows, "close": closes,
+         "volume": np.full(len(closes), 10.0)},
+        index=idx,
+    )
+
+
+def test_anchored_vwap_channel_no_lookahead():
+    """Truncating future bars must not change any signal at bars <= cut.
+
+    anchored_vwap_channel_core confirms typed pivots (pivot_strength bars on
+    each side), derives both AVWAP lines from prefix sums, and evaluates every
+    trigger/validity clause on bars at or before the current bar, so appending
+    future bars cannot change an earlier signal.
+
+    Mirrors test_anchored_vwap_no_lookahead's non-vacuity and sensitivity
+    checks (#1019 review): the fixture must emit both signal directions, and a
+    deliberately forward-peeking variant must make the invariance assertion
+    FAIL, proving the test can actually detect look-ahead.
+    """
+    df = _avwap_channel_mixed_fixture()
+    cut = 17  # straddles the confirm_bars window [16, 17]; bar 17 fires -1
+
+    def real(d):
+        return anchored_vwap_channel_core(d, **_AVWAP_CHANNEL_PARAMS)["signal"].to_numpy()
+
+    def forward_peeking(d):
+        # bar n adopts bar n+1's signal — a canonical look-ahead contamination.
+        s = anchored_vwap_channel_core(d, **_AVWAP_CHANNEL_PARAMS)["signal"].to_numpy().copy()
+        if len(s) > 1:
+            s[:-1] = s[1:]
+        return s
+
+    full = real(df)
+    # Non-vacuity: the fixture must actually produce signals (both directions).
+    assert (full != 0).any(), "fixture is vacuous — no signal to guard"
+    assert (full == 1).any() and (full == -1).any(), "expected a +1 and a -1"
+
+    # Invariant: signals at bars < cut are unchanged when future bars are
+    # dropped — at the single cut straddling the firing window, and at every
+    # earlier cut (re-anchors at 12 and 15 sit inside the sweep).
+    trunc = real(df.iloc[:cut])
+    assert np.array_equal(full[:cut], trunc), "signals < cut must not depend on future bars"
+    for c in range(3, len(df)):
+        assert np.array_equal(full[:c], real(df.iloc[:c])), f"prefix changed at cut {c}"
+
+    # Sensitivity: a forward-peeking core variant must NOT be truncation-invariant,
+    # else the assertion above proves nothing.
+    bf = forward_peeking(df)
+    bt = forward_peeking(df.iloc[:cut])
+    assert not np.array_equal(bf[:cut], bt), (
+        "forward-peeking variant should break truncation-invariance — the test "
+        "is not sensitive to look-ahead")

--- a/docs/superpowers/specs/2026-07-01-anchored-vwap-channel-strategy-design.md
+++ b/docs/superpowers/specs/2026-07-01-anchored-vwap-channel-strategy-design.md
@@ -1,0 +1,194 @@
+# Anchored VWAP Channel (`anchored_vwap_channel`) — Strategy Design
+
+**Issue:** [#1169](https://github.com/richkuo/go-trader/issues/1169)
+**Umbrella:** [#1017](https://github.com/richkuo/go-trader/issues/1017)
+**Design parent:** [#1016](https://github.com/richkuo/go-trader/issues/1016) (`docs/superpowers/specs/2026-06-15-anchored-vwap-strategy-design.md`)
+**Date:** 2026-07-01
+**Status:** Approved design — implemented alongside this spec.
+
+## 1. Goal
+
+Add a second AVWAP open strategy that maintains **two** anchored VWAPs — one
+anchored at the most recent **confirmed swing LOW** (the support line), one at
+the most recent **confirmed swing HIGH** (the resistance line) — and trades the
+channel between them: **long a buffered bounce off the lower line, short a
+buffered rejection off the upper line**. This is range-edge mean reversion on
+volume-weighted structure, deliberately complementary to `anchored_vwap`
+(#1016), which trades a **breach through** its single line: the channel
+strategy only ever fades a touch that *holds*; a close beyond either line
+simply produces no signal here (that regime belongs to the flip strategy).
+
+## 2. Core design decisions (locked)
+
+These are the decisions #1169 deferred to spec time, recorded per its
+acceptance criteria:
+
+| Decision | Choice |
+|---|---|
+| Line trigger | **Touch + buffered reclaim** — the trigger bar's extreme (low/high) must touch or penetrate the line, and its close must recover past the line by `buffer_atr_mult × ATR`; then an N-bar bare-line hold (reusing `buffer_atr_mult` and `confirm_bars` semantics from #1016, re-aimed at bounces instead of breaches) |
+| Fire-once clause | **Fresh touch** — the bar before the trigger bar must NOT have touched the line (the multi-bar analogue of #1016's fresh-crossing clause, keyed on the touch extreme rather than the close) |
+| Line inversion | **No-trade** — when `support ≥ resistance` (the low-anchored line has climbed above the high-anchored line) the channel is structurally meaningless; emit 0. No re-labeling, no swap: fail quiet until pivots re-establish order |
+| Minimum channel width | **ATR-mult gate** — require `(resistance − support) ≥ min_width_atr_mult × ATR` on the trigger bar (default **1.5**); thinner channels leave no room between entry and the opposite edge |
+| Channel-validity evaluation bar | The **trigger bar** `b` (window start). Hold bars only re-check their own line |
+| Direction / platform | **Bidirectional perps live** + spot + backtest (same as #1016); the short leg joins `bidirectionalPerpsStrategies` |
+| Exit | No custom close evaluator — SL/TP come from config close defaults, and the opposite edge's signal flips/flattens (same posture as #1016 §2) |
+| Regime gate default | **Pre-gated to composite ranging** `{ranging_quiet, ranging_volatile}` via `strategiesDefaultingToCompositeRangingGate` — see §7 |
+
+## 3. Anchors: typed swing pivots
+
+`anchored_vwap` tracks the most recent confirmed pivot **type-agnostically**
+(§3 of the parent spec). The channel variant tracks the two types
+**separately**, with identical strictness and the identical look-ahead
+guarantee:
+
+- A swing high at bar *p* requires `high[p]` to be the **strict, unique**
+  maximum of `high[p−k : p+k+1]`; a swing low mirrors on `low` (strict, unique
+  minimum). Flat-top/flat-bottom plateaus confirm nothing (parent §3).
+- A pivot at *p* is knowable only at bar `p + k` (`k = pivot_strength`).
+- `anchor_high_index[n]` = bar index of the most recent swing HIGH whose
+  confirmation bar ≤ n; `anchor_low_index[n]` mirrors for swing LOWs. Each is
+  −1 until its first pivot confirms.
+- **Both** anchors must exist before any signal can fire. Until then: 0.
+
+## 4. The two AVWAPs
+
+Same global-prefix-sum computation as parent §4, evaluated twice:
+
+```
+support[n]    = (Σ tp·vol [anchor_low..n])  / (Σ vol [anchor_low..n])
+resistance[n] = (Σ tp·vol [anchor_high..n]) / (Σ vol [anchor_high..n])
+```
+
+with `tp = (high + low + close) / 3` and the same zero-volume fallback to
+`tp[n]`. Emitted as `avwap_support` / `avwap_resistance` columns (NaN before
+the respective anchor confirms), alongside `anchor_low_index`,
+`anchor_high_index`, and `atr`.
+
+## 5. Trigger: touch + buffered reclaim + N-bar hold
+
+All notation mirrors parent §5: window `W = [b..n]` with `b = n − confirm_bars + 1`,
+`buf = buffer_atr_mult × ATR[b]`.
+
+**Channel validity at `b`** (both signals require it):
+1. Both anchors confirmed at `b` and at `b−1` (the freshness reference needs
+   defined lines too).
+2. `ATR[b]` is not NaN.
+3. Not inverted: `support[b] < resistance[b]`.
+4. Wide enough: `resistance[b] − support[b] ≥ min_width_atr_mult × ATR[b]`.
+
+**Long (+1) fires at bar `n`** iff all hold:
+1. **Touch:** `low[b] ≤ support[b]` — the trigger bar dipped to/through the
+   support line.
+2. **Buffered reclaim:** `close[b] ≥ support[b] + buf` — it closed decisively
+   back above.
+3. **Hold (bare line):** `close[k] ≥ support[k]` for every `k ∈ W`.
+4. **Fresh touch:** `low[b−1] > support[b−1]` — the prior bar did not touch,
+   so the fire is local and unique (parent §5 clause-3 rationale: the signal
+   column must be deterministic on its own, +1 only on the completing bar).
+
+**Short (−1)** mirrors on the resistance line: `high[b] ≥ resistance[b]`,
+`close[b] ≤ resistance[b] − buf`, hold `close[k] ≤ resistance[k]`, fresh
+`high[b−1] < resistance[b−1]`. Long is evaluated first; a bar satisfying both
+(possible only in a degenerate wide-bar case that the width gate makes rare)
+resolves long — deterministic, documented.
+
+Notes:
+- A close **through** a line fails the hold clause here by construction —
+  breaches are `anchored_vwap`'s trade, not this one's (§1).
+- Re-anchors inside a window behave exactly as parent §5: each bar compares
+  against its own live lines.
+
+## 6. Parameters
+
+| Param | Default | Range (optimizer) |
+|---|---|---|
+| `pivot_strength` | 5 | [3, 5, 8] |
+| `buffer_atr_mult` | 0.25 | [0.1, 0.25, 0.5] |
+| `confirm_bars` | 2 | [1, 2, 3] |
+| `min_width_atr_mult` | 1.5 | [1.0, 1.5, 2.5] |
+| `atr_period` | 14 | (fixed; not swept) |
+
+## 7. Regime gate default (composite ranging)
+
+The channel trade is definitionally ranging-structure: it fades both edges and
+is run over when the range resolves into a trend. That is the exact rationale
+`strategiesDefaultingToCompositeRangingGate` encodes for `atr_band_revert`
+(`scheduler/init.go:115`), so `anchored_vwap_channel` joins that map with the
+same labels `{ranging_quiet, ranging_volatile}` — `ranging_directional` stays
+excluded (directional pressure inside a range is the breakout precursor,
+mean reversion's worst case). This is a **wizard default** only: it stamps
+`allowed_regimes` on generated configs (plus the global composite "medium"
+window when absent); operators widen/narrow post-init. `anchored_vwap` itself
+stays ungated — its S/R-flip leg is breakout-following, not range-fading.
+
+## 8. Look-ahead safety
+
+Identical guarantees to parent §7 (pivots knowable at `p + k`; prefix sums,
+ATR, and every trigger clause read bars ≤ n; signal at N fills at N+1 open).
+A dedicated `anchored_vwap_channel` case joins
+`backtest/tests/test_backtester_lookahead.py` with the same **non-vacuity**
+(fixture must emit a +1 and a −1) and **sensitivity** (a forward-peeking
+variant must fail the invariance assertion) checks the #1019 review demanded
+of the parent's test.
+
+## 9. File-by-file wiring
+
+1. **`shared_strategies/open/anchored_vwap_channel.py`** (new) —
+   `anchored_vwap_channel_core(df, pivot_strength=5, buffer_atr_mult=0.25,
+   confirm_bars=2, min_width_atr_mult=1.5, atr_period=14)` returning the df
+   plus `signal`, `avwap_support`, `avwap_resistance`, `anchor_low_index`,
+   `anchor_high_index`, `atr`. ATR inlined byte-identical to `standard_atr`
+   (same `shared_tools`-off-sys.path constraint as parent §5).
+2. **`shared_strategies/open/registry.py`** — import, `@register`
+   (default platforms → spot + futures), and `PLATFORM_ORDER` entries directly
+   after `anchored_vwap` in both lists.
+3. **`scheduler/init.go`** — `knownShortNames["anchored_vwap_channel"] = "avwapch"`;
+   `bidirectionalPerpsStrategies` entry (shorts the upper line);
+   `defaultSpotStrategies` / `defaultPerpsStrategies` / `defaultFuturesStrategies`
+   entries after `anchored_vwap`; `strategiesDefaultingToCompositeRangingGate`
+   entry per §7.
+4. **`backtest/optimizer.py`** — `DEFAULT_PARAM_RANGES["anchored_vwap_channel"]` per §6.
+
+## 10. Test plan
+
+- **`shared_strategies/open/test_anchored_vwap_channel.py`** (new), mirroring
+  the parent suite: empty/short-df guards; typed-anchor confirmation indices;
+  hand-computed support AND resistance AVWAPs; zero-volume fallback; long
+  bounce fires exactly once on the completing bar; short rejection mirrors;
+  no signal before both anchors; **inversion → 0** (with a non-vacuous
+  would-be touch inside the inverted region); **width gate → 0**; registry
+  registration for spot + futures.
+- **Look-ahead:** §8 case in `test_backtester_lookahead.py`.
+- **Go:** `init_anchored_vwap_channel_test.go` — wiring (short name,
+  bidirectional membership, presence in all three default lists) and
+  `generateConfig` composite-ranging-gate tests mirroring
+  `init_atr_band_revert_test.go`.
+- **Registry parity:** `--list-json` snapshotted before the change for spot
+  and futures; the post-change diff must be exactly the one new entry.
+
+## 11. Backtest validation
+
+Same two-leg protocol as parent §11 (the backtester measures one direction per
+run; no `--config`, which would demand a close evaluator this design doesn't
+have):
+
+```
+uv run --no-sync python backtest/run_backtest.py \
+  --strategy anchored_vwap_channel --symbol BTC/USDT --timeframe 1h --mode single
+
+uv run --no-sync python backtest/run_backtest.py \
+  --strategy anchored_vwap_channel --symbol BTC/USDT --timeframe 1h --mode single \
+  --direction short
+```
+
+Sanity-check trade counts on each run (a range-edge strategy on trending BTC
+should trade sparsely; zero trades across both legs would indicate a wiring or
+gate bug, not selectivity).
+
+## 12. Out of scope (still tracked in #1017)
+
+- Mean-reversion-to-line strategy (`anchored_vwap_reversion`).
+- Optional momentum/regime gate on `anchored_vwap` itself.
+- AVWAP-anchored close evaluator (`close/registry.py`).
+- Channel-interior targets (e.g. take-profit at mid-channel) — close-evaluator
+  territory, not open-signal territory.

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -59,6 +59,7 @@ var knownShortNames = map[string]string{
 	"order_blocks":          "ob",
 	"vwap_reversion":        "vwap",
 	"anchored_vwap":         "avwap",
+	"anchored_vwap_channel": "avwapch",
 	"chart_pattern":         "cpat",
 	"liquidity_sweeps":      "liqsw",
 	"parabolic_sar":         "psar",
@@ -89,23 +90,24 @@ var knownShortNames = map[string]string{
 // set AllowShorts=true so ExecutePerpsSignal opens shorts from flat instead
 // of skipping the signal (#328).
 var bidirectionalPerpsStrategies = map[string]bool{
-	"triple_ema_bidir":    true,
-	"tema_cross_bd":       true,
-	"session_breakout":    true,
-	"donchian_breakout":   true, // emits short on lower-channel breakdown (#649)
-	"chart_pattern":       true, // emits short on bearish patterns (double top, H&S, bear flag) (#649)
-	"liquidity_sweeps":    true, // emits short on stop-hunt wicks above swing highs (#649)
-	"bear_pullback_st":    true, // dedicated short-only strategy for bear-market rally rejections (#651)
-	"vwap_rejection_st":   true, // dedicated short-only strategy for VWAP/EMA rally rejections in bearish regime (#652)
-	"anchored_vwap":       true, // single-AVWAP S/R flip; emits short on a buffered breakdown below the line (#1016)
-	"momentum_pro":        true, // emits short on stacked-bearish-EMA trend-pullback breakdowns
-	"mean_reversion_pro":  true, // emits short on overbought reversion in no-trend regimes
-	"consolidation_range": true, // emits short at the top edge of a consolidation box (range-edge mean-reversion)
-	"atr_band_revert":     true, // futures variant (allow_short) shorts the upper ATR band in ranging conditions
-	"mtf_confluence":      true, // futures variant (allow_short) shorts LTF pullback rallies in HTF downtrends (#957)
-	"vol_momentum":        true, // emits short on ATR-normalized negative momentum with efficiency confirmation (#959)
-	"funding_skew":        true, // shorts crowded-long funding extremes on EMA breakdown (#960)
-	"regime_adaptive":     true, // futures variant (allow_short) shorts clean downtrend breakouts and fades range tops (#958)
+	"triple_ema_bidir":      true,
+	"tema_cross_bd":         true,
+	"session_breakout":      true,
+	"donchian_breakout":     true, // emits short on lower-channel breakdown (#649)
+	"chart_pattern":         true, // emits short on bearish patterns (double top, H&S, bear flag) (#649)
+	"liquidity_sweeps":      true, // emits short on stop-hunt wicks above swing highs (#649)
+	"bear_pullback_st":      true, // dedicated short-only strategy for bear-market rally rejections (#651)
+	"vwap_rejection_st":     true, // dedicated short-only strategy for VWAP/EMA rally rejections in bearish regime (#652)
+	"anchored_vwap":         true, // single-AVWAP S/R flip; emits short on a buffered breakdown below the line (#1016)
+	"anchored_vwap_channel": true, // dual-AVWAP channel; emits short on a buffered rejection off the resistance line (#1169)
+	"momentum_pro":          true, // emits short on stacked-bearish-EMA trend-pullback breakdowns
+	"mean_reversion_pro":    true, // emits short on overbought reversion in no-trend regimes
+	"consolidation_range":   true, // emits short at the top edge of a consolidation box (range-edge mean-reversion)
+	"atr_band_revert":       true, // futures variant (allow_short) shorts the upper ATR band in ranging conditions
+	"mtf_confluence":        true, // futures variant (allow_short) shorts LTF pullback rallies in HTF downtrends (#957)
+	"vol_momentum":          true, // emits short on ATR-normalized negative momentum with efficiency confirmation (#959)
+	"funding_skew":          true, // shorts crowded-long funding extremes on EMA breakdown (#960)
+	"regime_adaptive":       true, // futures variant (allow_short) shorts clean downtrend breakouts and fades range tops (#958)
 }
 
 func isBidirectionalPerpsStrategy(id string) bool {
@@ -122,6 +124,9 @@ func isBidirectionalPerpsStrategy(id string) bool {
 // case). Operators can widen/narrow allowed_regimes post-init.
 var strategiesDefaultingToCompositeRangingGate = map[string][]string{
 	"atr_band_revert": {"ranging_quiet", "ranging_volatile"},
+	// anchored_vwap_channel fades both edges of an AVWAP channel — the same
+	// range-edge mean-reversion class, gated for the same reason (#1169).
+	"anchored_vwap_channel": {"ranging_quiet", "ranging_volatile"},
 }
 
 // defaultCompositeRangingGate returns a fresh copy of the default composite
@@ -169,6 +174,7 @@ var defaultSpotStrategies = []stratDef{
 	{ID: "order_blocks", ShortName: "ob"},
 	{ID: "vwap_reversion", ShortName: "vwap"},
 	{ID: "anchored_vwap", ShortName: "avwap"},
+	{ID: "anchored_vwap_channel", ShortName: "avwapch"},
 	{ID: "chart_pattern", ShortName: "cpat"},
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 	{ID: "parabolic_sar", ShortName: "psar"},
@@ -198,6 +204,7 @@ var defaultPerpsStrategies = []stratDef{
 	{ID: "chart_pattern", ShortName: "cpat"},
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 	{ID: "anchored_vwap", ShortName: "avwap"},
+	{ID: "anchored_vwap_channel", ShortName: "avwapch"},
 	{ID: "delta_neutral_funding", ShortName: "dnf"},
 	{ID: "funding_skew", ShortName: "fskew"},
 	{ID: "sweep_squeeze_combo", ShortName: "ssc"},
@@ -223,6 +230,7 @@ var defaultFuturesStrategies = []stratDef{
 	{ID: "order_blocks", ShortName: "ob"},
 	{ID: "vwap_reversion", ShortName: "vwap"},
 	{ID: "anchored_vwap", ShortName: "avwap"},
+	{ID: "anchored_vwap_channel", ShortName: "avwapch"},
 	{ID: "chart_pattern", ShortName: "cpat"},
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 	{ID: "parabolic_sar", ShortName: "psar"},

--- a/scheduler/init_anchored_vwap_channel_test.go
+++ b/scheduler/init_anchored_vwap_channel_test.go
@@ -1,0 +1,101 @@
+package main
+
+import "testing"
+
+func TestAnchoredVWAPChannelWiring(t *testing.T) {
+	if got := deriveShortName("anchored_vwap_channel"); got != "avwapch" {
+		t.Fatalf("deriveShortName(anchored_vwap_channel) = %q, want avwapch", got)
+	}
+	if !isBidirectionalPerpsStrategy("anchored_vwap_channel") {
+		t.Fatal("anchored_vwap_channel must be a bidirectional perps strategy (it shorts the upper line)")
+	}
+	lists := map[string][]stratDef{
+		"spot":    defaultSpotStrategies,
+		"perps":   defaultPerpsStrategies,
+		"futures": defaultFuturesStrategies,
+	}
+	for name, list := range lists {
+		found := false
+		for _, s := range list {
+			if s.ID == "anchored_vwap_channel" {
+				found = true
+				if s.ShortName != "avwapch" {
+					t.Fatalf("%s list: anchored_vwap_channel short name = %q, want avwapch", name, s.ShortName)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("anchored_vwap_channel missing from default %s list", name)
+		}
+	}
+}
+
+// anchored_vwap_channel fades both edges of an AVWAP channel — range-edge mean
+// reversion whose edge depends on ranging conditions, so init pre-gates it to
+// the composite quiet/volatile ranging substates exactly like atr_band_revert
+// (ranging_directional stays excluded: directional pressure inside a range is
+// the breakout precursor, mean reversion's worst case).
+
+func TestGenerateConfig_AnchoredVWAPChannel_DefaultsToCompositeRangingGate(t *testing.T) {
+	opts := baseOpts()
+	opts.Assets = []string{"BTC"}
+	opts.SpotStrategies = []string{"anchored_vwap_channel"}
+
+	cfg := generateConfig(opts)
+
+	sc, ok := findStrategy(cfg, "avwapch-btc")
+	if !ok {
+		t.Fatalf("expected strategy avwapch-btc, got %v", cfg.Strategies)
+	}
+	want := []string{"ranging_quiet", "ranging_volatile"}
+	if len(sc.AllowedRegimes) != len(want) {
+		t.Fatalf("allowed_regimes = %v, want %v", sc.AllowedRegimes, want)
+	}
+	for i, l := range want {
+		if sc.AllowedRegimes[i] != l {
+			t.Fatalf("allowed_regimes[%d] = %q, want %q", i, sc.AllowedRegimes[i], l)
+		}
+	}
+
+	if cfg.Regime == nil || !cfg.Regime.Enabled {
+		t.Fatalf("expected cfg.Regime enabled, got %+v", cfg.Regime)
+	}
+	win, ok := cfg.Regime.Windows["medium"]
+	if !ok {
+		t.Fatalf("expected a composite 'medium' window, got windows %+v", cfg.Regime.Windows)
+	}
+	if win.effectiveClassifier() != regimeClassifierComposite {
+		t.Fatalf("medium window classifier = %q, want composite", win.effectiveClassifier())
+	}
+
+	if vErrs := validateStrategyRegimeVocabulary(cfg); len(vErrs) != 0 {
+		t.Fatalf("regime vocabulary errors: %v", vErrs)
+	}
+	if err := validateConfig(cfg, true); err != nil {
+		t.Fatalf("generated config failed validation: %v", err)
+	}
+}
+
+func TestGenerateConfig_AnchoredVWAPChannel_Perps_DefaultsToCompositeRangingGate(t *testing.T) {
+	opts := baseOpts()
+	opts.Assets = []string{"BTC"}
+	opts.EnableSpot = false
+	opts.EnablePerps = true
+	opts.PerpsStrategies = []string{"anchored_vwap_channel"}
+
+	cfg := generateConfig(opts)
+
+	sc, ok := findStrategy(cfg, "hl-avwapch-btc")
+	if !ok {
+		t.Fatalf("expected strategy hl-avwapch-btc, got %v", cfg.Strategies)
+	}
+	if len(sc.AllowedRegimes) == 0 {
+		t.Fatalf("perps anchored_vwap_channel should be regime-gated, got none")
+	}
+	if cfg.Regime == nil || !cfg.Regime.Enabled {
+		t.Fatalf("expected cfg.Regime enabled for perps anchored_vwap_channel")
+	}
+	if err := validateConfig(cfg, true); err != nil {
+		t.Fatalf("generated perps config failed validation: %v", err)
+	}
+}

--- a/shared_strategies/open/anchored_vwap_channel.py
+++ b/shared_strategies/open/anchored_vwap_channel.py
@@ -1,0 +1,179 @@
+"""Anchored VWAP Channel (AVWAP channel) — dual VWAPs anchored to the most
+recent *confirmed* swing low (support line) and swing high (resistance line),
+traded as range-edge mean reversion: long a buffered bounce off the lower
+line, short a buffered rejection off the upper line.
+
+Design: docs/superpowers/specs/2026-07-01-anchored-vwap-channel-strategy-design.md
+
+Complementary to anchored_vwap (#1016), which trades a buffered breach
+*through* its single type-agnostic line: here a close beyond either line fails
+the hold clause by construction — the channel strategy only fades touches that
+hold inside the channel. No trading while the lines are inverted
+(support >= resistance) or the channel is thinner than
+min_width_atr_mult * ATR on the trigger bar.
+
+ATR is inlined (rolling-mean True Range, integer-round only when atr >= 100) to
+match standard_atr WITHOUT importing shared_tools — open strategies cannot
+assume shared_tools is on sys.path at module-load time (the registry parity test
+loads registry.py via importlib without it, so a top-level import would raise
+ModuleNotFoundError). The inline copy is byte-identical to standard_atr.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def _inline_atr(df: pd.DataFrame, period: int) -> pd.Series:
+    """ATR via simple rolling mean of True Range (standard_atr convention)."""
+    high = df["high"].astype(float)
+    low = df["low"].astype(float)
+    prev_close = df["close"].astype(float).shift(1)
+    tr = pd.concat(
+        [high - low, (high - prev_close).abs(), (low - prev_close).abs()],
+        axis=1,
+    ).max(axis=1)
+    atr = tr.rolling(window=period).mean()
+    return atr.where(atr < 100, atr.round(0))
+
+
+def anchored_vwap_channel_core(
+    df: pd.DataFrame,
+    pivot_strength: int = 5,
+    buffer_atr_mult: float = 0.25,
+    confirm_bars: int = 2,
+    min_width_atr_mult: float = 1.5,
+    atr_period: int = 14,
+) -> pd.DataFrame:
+    """Dual-AVWAP channel bounce/rejection signals.
+
+    Parameters
+    ----------
+    df : OHLCV DataFrame (open, high, low, close, volume).
+    pivot_strength : bars required on EACH side of a swing pivot to confirm it
+        (strict max high / strict min low). A pivot at bar p is only knowable at
+        bar p + pivot_strength — the look-ahead guarantee.
+    buffer_atr_mult : the trigger bar's close must recover past its line by
+        buffer_atr_mult * ATR (reclaim above support / rejection below
+        resistance).
+    confirm_bars : bars the close must hold on the channel side of the touched
+        line (inclusive of the touch bar) before a signal fires.
+    min_width_atr_mult : minimum channel width, in ATR multiples on the trigger
+        bar; a thinner (or inverted) channel emits no signal.
+    atr_period : lookback for the inline ATR.
+
+    Returns
+    -------
+    DataFrame with added columns:
+        signal           : +1 (support bounce), -1 (resistance rejection), 0 otherwise
+        avwap_support    : AVWAP anchored at the last confirmed swing LOW (NaN before it)
+        avwap_resistance : AVWAP anchored at the last confirmed swing HIGH (NaN before it)
+        anchor_low_index : bar index of the active swing-low anchor (-1 before the first one)
+        anchor_high_index: bar index of the active swing-high anchor (-1 before the first one)
+        atr              : inline ATR
+    """
+    result = df.copy()
+    n = len(result)
+    result["signal"] = 0
+    result["avwap_support"] = np.nan
+    result["avwap_resistance"] = np.nan
+    result["anchor_low_index"] = -1
+    result["anchor_high_index"] = -1
+    result["atr"] = _inline_atr(result, atr_period)
+    if n < 2 * pivot_strength + 1 + confirm_bars:
+        return result
+
+    high = result["high"].astype(float).to_numpy()
+    low = result["low"].astype(float).to_numpy()
+
+    # --- strict swing pivots, tracked by type (unique max high / unique min low) ---
+    k = int(pivot_strength)
+    is_pivot_high = np.zeros(n, dtype=bool)
+    is_pivot_low = np.zeros(n, dtype=bool)
+    for i in range(k, n - k):
+        wh = high[i - k:i + k + 1]
+        wl = low[i - k:i + k + 1]
+        wmax = wh.max()
+        wmin = wl.min()
+        if high[i] == wmax and int((wh == wmax).sum()) == 1:
+            is_pivot_high[i] = True
+        if low[i] == wmin and int((wl == wmin).sum()) == 1:
+            is_pivot_low[i] = True
+
+    # --- per-type anchor in effect at each bar: most recent pivot of that type
+    # confirmed by then. A pivot at p becomes knowable at bar p + k.
+    anchor_high = np.full(n, -1, dtype=int)
+    anchor_low = np.full(n, -1, dtype=int)
+    last_high = -1
+    last_low = -1
+    for b in range(n):
+        p = b - k
+        if p >= 0:
+            if is_pivot_high[p]:
+                last_high = p
+            if is_pivot_low[p]:
+                last_low = p
+        anchor_high[b] = last_high
+        anchor_low[b] = last_low
+    result["anchor_high_index"] = anchor_high
+    result["anchor_low_index"] = anchor_low
+
+    # --- both AVWAPs via global prefix sums (exact across re-anchors) ---
+    tp = ((result["high"] + result["low"] + result["close"]) / 3.0).to_numpy()
+    vol = result["volume"].astype(float).to_numpy()
+    pref_tpvol = np.concatenate([[0.0], np.cumsum(tp * vol)])  # pref[i] = sum first i
+    pref_vol = np.concatenate([[0.0], np.cumsum(vol)])
+
+    def _avwap_from(anchor: np.ndarray) -> np.ndarray:
+        line = np.full(n, np.nan)
+        for b in range(n):
+            a = anchor[b]
+            if a < 0:
+                continue
+            num = pref_tpvol[b + 1] - pref_tpvol[a]
+            den = pref_vol[b + 1] - pref_vol[a]
+            line[b] = tp[b] if den <= 0 else num / den
+        return line
+
+    support = _avwap_from(anchor_low)
+    resistance = _avwap_from(anchor_high)
+    result["avwap_support"] = support
+    result["avwap_resistance"] = resistance
+
+    # --- trigger: touch + buffered reclaim + N-bar hold, fire-once via fresh
+    # touch. Channel validity (both lines defined, not inverted, wide enough)
+    # is evaluated on the trigger bar b.
+    close = result["close"].astype(float).to_numpy()
+    atr_arr = result["atr"].to_numpy()
+    cb = int(confirm_bars)
+    sig = np.zeros(n, dtype=int)
+    for nbar in range(n):
+        b = nbar - cb + 1                       # window start (touch bar)
+        if b - 1 < 0 or anchor_low[b] < 0 or anchor_high[b] < 0:
+            continue
+        if anchor_low[b - 1] < 0 or anchor_high[b - 1] < 0:
+            continue                            # freshness reference needs lines too
+        if np.isnan(atr_arr[b]):
+            continue
+        if support[b] >= resistance[b]:
+            continue                            # inverted channel: fail quiet
+        if resistance[b] - support[b] < min_width_atr_mult * atr_arr[b]:
+            continue                            # channel too thin to fade
+        buf = buffer_atr_mult * atr_arr[b]
+        # LONG: fresh touch of support, buffered reclaim, held above the line.
+        if (low[b] <= support[b]
+                and close[b] >= support[b] + buf
+                and np.all(close[b:nbar + 1] >= support[b:nbar + 1])
+                and low[b - 1] > support[b - 1]):
+            sig[nbar] = 1
+            continue
+        # SHORT: mirror on the resistance line.
+        if (high[b] >= resistance[b]
+                and close[b] <= resistance[b] - buf
+                and np.all(close[b:nbar + 1] <= resistance[b:nbar + 1])
+                and high[b - 1] < resistance[b - 1]):
+            sig[nbar] = -1
+    result["signal"] = sig
+
+    return result

--- a/shared_strategies/open/registry.py
+++ b/shared_strategies/open/registry.py
@@ -55,6 +55,7 @@ from session_breakout import session_breakout_core
 from vwap_rejection_st import vwap_rejection_st_core
 from vol_momentum import vol_momentum_core
 from anchored_vwap import anchored_vwap_core
+from anchored_vwap_channel import anchored_vwap_channel_core
 
 
 VALID_PLATFORMS: Tuple[str, ...] = ("spot", "futures")
@@ -1139,6 +1140,21 @@ def anchored_vwap_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
 
 
 @register(
+    "anchored_vwap_channel",
+    "Anchored VWAP Channel — dual VWAPs anchored to the last confirmed swing low (support) and swing high (resistance); long a buffered bounce off the lower line, short a buffered rejection off the upper",
+    {
+        "pivot_strength": 5,
+        "buffer_atr_mult": 0.25,
+        "confirm_bars": 2,
+        "min_width_atr_mult": 1.5,
+        "atr_period": 14,
+    },
+)
+def anchored_vwap_channel_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return anchored_vwap_channel_core(df, **params)
+
+
+@register(
     "momentum_pro",
     "Momentum Pro — trend-pullback entries in a stacked-EMA trend, ADX-confirmed, on a volume-backed resumption",
     {
@@ -1312,7 +1328,8 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "mean_reversion", "momentum", "volume_weighted", "triple_ema",
         "rsi_macd_combo", "stoch_rsi", "supertrend", "ichimoku_cloud",
         "pairs_spread", "squeeze_momentum", "atr_breakout", "amd_ifvg",
-        "heikin_ashi_ema", "order_blocks", "vwap_reversion", "anchored_vwap", "chart_pattern",
+        "heikin_ashi_ema", "order_blocks", "vwap_reversion", "anchored_vwap",
+        "anchored_vwap_channel", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
         "sweep_squeeze_combo", "adx_trend", "donchian_breakout", "tema_cross",
         "momentum_pro", "mean_reversion_pro", "atr_band_revert", "mtf_confluence",
@@ -1324,7 +1341,8 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "triple_ema", "triple_ema_bidir", "tema_cross", "tema_cross_bd", "rsi_macd_combo", "momentum",
         "mean_reversion", "rsi", "macd", "breakout", "stoch_rsi", "supertrend",
         "squeeze_momentum", "ichimoku_cloud", "atr_breakout", "amd_ifvg",
-        "heikin_ashi_ema", "order_blocks", "vwap_reversion", "anchored_vwap", "chart_pattern",
+        "heikin_ashi_ema", "order_blocks", "vwap_reversion", "anchored_vwap",
+        "anchored_vwap_channel", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
         "sweep_squeeze_combo", "adx_trend", "delta_neutral_funding",
         "funding_skew", "donchian_breakout", "session_breakout", "bear_pullback_st",

--- a/shared_strategies/open/test_anchored_vwap_channel.py
+++ b/shared_strategies/open/test_anchored_vwap_channel.py
@@ -1,0 +1,226 @@
+"""Tests for anchored_vwap_channel.py — dual-AVWAP channel bounce strategy."""
+
+import importlib.util
+import os
+
+import numpy as np
+import pandas as pd
+
+from anchored_vwap_channel import anchored_vwap_channel_core
+
+
+def _hourly_index(n, start="2026-01-01 00:00:00"):
+    return pd.date_range(start, periods=n, freq="1h")
+
+
+def _ohlcv(closes, highs=None, lows=None, opens=None, volume=100.0):
+    closes = np.asarray(closes, dtype=float)
+    n = len(closes)
+    highs = closes + 0.5 if highs is None else np.asarray(highs, dtype=float)
+    lows = closes - 0.5 if lows is None else np.asarray(lows, dtype=float)
+    opens = closes if opens is None else np.asarray(opens, dtype=float)
+    vol = np.full(n, float(volume)) if np.isscalar(volume) else np.asarray(volume, dtype=float)
+    return pd.DataFrame(
+        {"open": opens, "high": highs, "low": lows, "close": closes, "volume": vol},
+        index=_hourly_index(n),
+    )
+
+
+_PARAMS = dict(pivot_strength=2, buffer_atr_mult=0.0, confirm_bars=2,
+               min_width_atr_mult=0.0, atr_period=3)
+
+
+def _long_bounce_df():
+    """High pivot at 2 (conf. 4), low pivot at 6 (conf. 8); bar 10 wicks
+    through the support line and closes back above; bar 11 holds -> +1 at 11."""
+    closes = [104, 106, 108, 106, 104, 102, 100, 102, 104, 103, 102.5, 103.5]
+    lows = np.asarray(closes) - 0.5
+    lows[10] = 101.0
+    return _ohlcv(closes, lows=lows, volume=10.0)
+
+
+def _short_rejection_df():
+    """Low pivot at 2 (conf. 4), high pivot at 6 (conf. 8); bar 10 wicks
+    through the resistance line and closes back below; bar 11 holds -> -1 at 11."""
+    closes = [100, 98, 96, 98, 100, 102, 104, 102, 100, 101, 101.5, 100.5]
+    highs = np.asarray(closes) + 0.5
+    highs[10] = 103.0
+    return _ohlcv(closes, highs=highs, volume=10.0)
+
+
+# --- scaffold + guards -----------------------------------------------------------
+
+def test_empty_and_short_df_return_zero_signal():
+    empty = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+    out = anchored_vwap_channel_core(empty)
+    assert list(out["signal"]) == []
+    for col in ("avwap_support", "avwap_resistance", "anchor_low_index",
+                "anchor_high_index", "atr"):
+        assert col in out.columns, col
+
+    short = _ohlcv(np.linspace(100, 101, 6))  # < 2*5+1+2
+    out = anchored_vwap_channel_core(short)
+    assert (out["signal"] == 0).all()
+    assert (out["anchor_low_index"] == -1).all()
+    assert (out["anchor_high_index"] == -1).all()
+
+
+# --- typed pivots + per-type anchor indices --------------------------------------
+
+def test_typed_anchors_confirm_independently():
+    df = _long_bounce_df()
+    out = anchored_vwap_channel_core(df, **_PARAMS)
+    ah = out["anchor_high_index"].to_numpy()
+    al = out["anchor_low_index"].to_numpy()
+    # High pivot at 2 confirms at 4; low pivot at 6 confirms at 8.
+    assert (ah[:4] == -1).all()
+    assert (ah[4:10] == 2).all()
+    assert (al[:8] == -1).all()
+    assert (al[8:] == 6).all()
+
+
+def test_no_signal_before_both_anchors():
+    # Only a swing high forms (monotonic decline afterwards): support never
+    # exists, so no signal can fire even on deep touches of the single line.
+    closes = [104, 106, 108, 106, 104, 102, 100, 98, 96, 94, 92, 90]
+    out = anchored_vwap_channel_core(_ohlcv(closes, volume=10.0), **_PARAMS)
+    assert (out["anchor_low_index"] == -1).all()
+    assert (out["signal"] == 0).all()
+
+
+# --- both AVWAPs -----------------------------------------------------------------
+
+def test_avwaps_match_hand_computed_prefix_sums():
+    closes = [104, 106, 108, 106, 104, 102, 100, 102, 104, 106, 108, 110]
+    flat = np.asarray(closes, dtype=float)   # tp == close when high==low==close
+    df = _ohlcv(closes, highs=flat, lows=flat, volume=10.0)
+    out = anchored_vwap_channel_core(df, pivot_strength=2, confirm_bars=2, atr_period=3)
+    support = out["avwap_support"].to_numpy()
+    resistance = out["avwap_resistance"].to_numpy()
+    # Resistance anchored at the high pivot (bar 2) from its confirmation (bar 4);
+    # support anchored at the low pivot (bar 6) from bar 8.
+    assert np.isnan(resistance[:4]).all()
+    assert np.isnan(support[:8]).all()
+    for nbar in (4, 6, 8, 10, 11):
+        expected = np.mean(closes[2:nbar + 1])
+        assert abs(resistance[nbar] - expected) < 1e-9, (nbar, resistance[nbar], expected)
+    for nbar in (8, 9, 10, 11):
+        expected = np.mean(closes[6:nbar + 1])
+        assert abs(support[nbar] - expected) < 1e-9, (nbar, support[nbar], expected)
+
+
+def test_zero_volume_window_falls_back_to_typical():
+    closes = [104, 106, 108, 106, 104, 102, 100, 102, 104, 106, 108, 110]
+    df = _ohlcv(closes, volume=0.0)
+    out = anchored_vwap_channel_core(df, pivot_strength=2, confirm_bars=2, atr_period=3)
+    tp = (df["high"] + df["low"] + df["close"]).to_numpy() / 3.0
+    support = out["avwap_support"].to_numpy()
+    resistance = out["avwap_resistance"].to_numpy()
+    for nbar in range(8, 12):
+        assert abs(support[nbar] - tp[nbar]) < 1e-9
+        assert abs(resistance[nbar] - tp[nbar]) < 1e-9
+
+
+# --- triggers --------------------------------------------------------------------
+
+def test_long_bounce_fires_once_on_completing_bar():
+    out = anchored_vwap_channel_core(_long_bounce_df(), **_PARAMS)
+    sig = out["signal"].to_numpy()
+    assert sig[11] == 1
+    assert (sig == 1).sum() == 1
+    assert (sig == -1).sum() == 0
+    # The touch bar (10) dipped through the line the prior bar (9) did not touch.
+    support = out["avwap_support"].to_numpy()
+    low = out["low"].to_numpy()
+    assert low[10] <= support[10]
+    assert low[9] > support[9]
+
+
+def test_short_rejection_mirrors():
+    out = anchored_vwap_channel_core(_short_rejection_df(), **_PARAMS)
+    sig = out["signal"].to_numpy()
+    assert sig[11] == -1
+    assert (sig == -1).sum() == 1
+    assert (sig == 1).sum() == 0
+    resistance = out["avwap_resistance"].to_numpy()
+    high = out["high"].to_numpy()
+    assert high[10] >= resistance[10]
+    assert high[9] < resistance[9]
+
+
+def test_buffer_blocks_shallow_reclaim():
+    # Same bounce geometry, but demand a reclaim margin the touch bar's close
+    # cannot meet -> no signal anywhere.
+    out = anchored_vwap_channel_core(
+        _long_bounce_df(), pivot_strength=2, buffer_atr_mult=5.0,
+        confirm_bars=2, min_width_atr_mult=0.0, atr_period=3)
+    assert (out["signal"] == 0).all()
+
+
+def test_nan_atr_warmup_yields_no_signal():
+    out = anchored_vwap_channel_core(
+        _long_bounce_df(), pivot_strength=2, buffer_atr_mult=0.0,
+        confirm_bars=2, min_width_atr_mult=0.0, atr_period=99)
+    assert (out["signal"] == 0).all()
+
+
+# --- channel-validity gates ------------------------------------------------------
+
+def test_inverted_channel_blocks_would_be_bounce():
+    """Rally after the V: the low-anchored line climbs above the high-anchored
+    line. A deep wick then satisfies every LONG clause except channel order —
+    the inversion gate alone must hold the signal at 0."""
+    closes = [104, 106, 108, 106, 104, 102, 100, 104, 108, 112, 116, 120, 118, 119]
+    lows = np.asarray(closes) - 0.5
+    lows[12] = 108.0  # would-be touch of the support line
+    df = _ohlcv(closes, lows=lows, volume=10.0)
+    out = anchored_vwap_channel_core(df, **_PARAMS)
+    support = out["avwap_support"].to_numpy()
+    resistance = out["avwap_resistance"].to_numpy()
+    close = out["close"].to_numpy()
+    low = out["low"].to_numpy()
+    b = 12  # trigger bar for a window completing at 13
+    # Non-vacuity: the long clauses genuinely hold at b...
+    assert low[b] <= support[b]
+    assert close[b] >= support[b]
+    assert close[13] >= support[13]
+    assert low[b - 1] > support[b - 1]
+    # ...but the channel is inverted there, so nothing may fire.
+    assert support[b] >= resistance[b]
+    assert (out["signal"] == 0).all()
+
+
+def test_min_width_gate_blocks_thin_channel():
+    # The exact fixture that fires +1 under min_width_atr_mult=0 stays silent
+    # when the required width exceeds what the channel offers.
+    out = anchored_vwap_channel_core(
+        _long_bounce_df(), pivot_strength=2, buffer_atr_mult=0.0,
+        confirm_bars=2, min_width_atr_mult=50.0, atr_period=3)
+    assert (out["signal"] == 0).all()
+
+
+# --- registry --------------------------------------------------------------------
+
+def _load_registry():
+    here = os.path.dirname(os.path.abspath(__file__))
+    spec = importlib.util.spec_from_file_location(
+        "_reg_under_test_avwap_channel", os.path.join(here, "registry.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_registered_for_spot_and_futures():
+    reg = _load_registry()
+    for platform in ("spot", "futures"):
+        assert "anchored_vwap_channel" in reg.build_registry(platform), platform
+        assert "anchored_vwap_channel" in reg.PLATFORM_ORDER[platform], platform
+
+
+def test_registered_fn_applies_via_registry():
+    reg = _load_registry()
+    entry = reg.STRATEGIES["anchored_vwap_channel"]
+    df = _long_bounce_df()
+    out = entry["fn"](df, **entry["default_params"])
+    assert "signal" in out.columns


### PR DESCRIPTION
Closes #1169

## What

Registers `anchored_vwap_channel`, a new open strategy maintaining TWO anchored VWAPs — support anchored at the most recent confirmed swing LOW, resistance at the most recent confirmed swing HIGH — and trading the channel between them: long a buffered bounce off the lower line, short a buffered rejection off the upper. Distinct entry logic from `anchored_vwap`'s single-line S/R flip (a close *through* a line fails this strategy's hold clause by construction — breaches remain the flip strategy's trade).

## Spec-time decisions (per the issue's acceptance criteria)

Recorded in `docs/superpowers/specs/2026-07-01-anchored-vwap-channel-strategy-design.md`:

1. **Line trigger** — touch + buffered reclaim: the trigger bar's extreme must reach the line, its close must recover past it by `buffer_atr_mult × ATR` (param reused from #1016, re-aimed at bounces), then a `confirm_bars` bare-line hold; fire-once via a fresh-touch clause.
2. **Inversion** (`support ≥ resistance`) — no-trade, fail quiet until pivots re-establish order.
3. **Minimum channel width** — `(resistance − support) ≥ min_width_atr_mult × ATR` on the trigger bar (default 1.5, swept [1.0, 1.5, 2.5]).
4. **Regime gate default** — pre-gated to composite `{ranging_quiet, ranging_volatile}` via `strategiesDefaultingToCompositeRangingGate` (same rationale and labels as `atr_band_revert`; flagged during issue validation as an unrecorded decision). Wizard default only; operators widen post-init.

## Wiring (issue checklist)

- `shared_strategies/open/anchored_vwap_channel.py` — core, inheriting #1016's mechanics: strict typed pivots knowable only at `p + pivot_strength`, both AVWAPs via global prefix sums, inline ATR.
- `shared_strategies/open/registry.py` — `register()` + `PLATFORM_ORDER` (spot + futures).
- `scheduler/init.go` — `knownShortNames` (`avwapch`), `bidirectionalPerpsStrategies` (short leg), all three default strategy lists, composite ranging gate.
- `backtest/optimizer.py` — `DEFAULT_PARAM_RANGES`.
- `backtest/fee_audit.py` — `LIVE_BIDIRECTIONAL_STRATEGIES` mirror (its Go-source parity test caught the omission; kept in sync).

## Verification

- `--list-json` snapshotted before/after: diff is exactly the new entry, existing order byte-preserved (spot + futures).
- Full pytest suite: **2049 passed** (includes the new unit suite and the look-ahead case with non-vacuity + forward-peeking sensitivity checks and a full truncation prefix sweep across re-anchors).
- `go -C scheduler build .` + full `go -C scheduler test ./...`: pass (includes new wiring + `generateConfig` gate tests mirroring `atr_band_revert`'s).
- Backtest sanity (per parent spec §11 two-leg protocol, BTC/USDT 1h): long leg 21 trades, short leg 20 trades — sparse range-edge cadence as expected; nothing goes live until configured.

---
Created with LLM: Fable 5 | high | Harness: Claude Code
