### PR TITLE
research(#1166): momentum_pro directional-gate M1 — negative result; thread regime_directional_policy through eval_windows

### DIFF
--- a/backtest/eval_windows.py
+++ b/backtest/eval_windows.py
@@ -282,6 +282,7 @@ def run_leg(reg, name: str, params: Optional[dict], symbol: str, timeframe: str,
             profile_allocation: Optional[dict] = None,
             allowed_regimes: Optional[list[str]] = None,
             regime_windows_spec: Optional[dict] = None,
+            regime_directional_policy: Optional[dict] = None,
             regime_enabled: bool = False,
             regime_period: int = 14,
             regime_adx_threshold: float = 20.0,
@@ -309,6 +310,15 @@ def run_leg(reg, name: str, params: Optional[dict], symbol: str, timeframe: str,
     #1058 path classifies the PRIMARY (medium-first) window instead — composite
     (9-state) or ADX per the spec — so composite labels can gate entries on the
     M1 bar.
+
+    regime_directional_policy (#1166, #1025 shape {trend_regime: {label:
+    {direction, invert_signal?}}}) resolves the entry direction per bar
+    regime so directional-gated candidates can be scored on the M1 bar. It is
+    a RESEARCH-MODE surface: the leg passes the Backtester's #1085 certified
+    input explicitly (True), deliberately bypassing the default-off live
+    evidence gate for measurement — never wire a shipped certification
+    artifact through here. regime_enabled is forced true when a policy is
+    present (the Backtester rejects a policy without regime compute).
     """
     from atr import ensure_atr_indicator
     from data_fetcher import load_cached_data
@@ -354,7 +364,9 @@ def run_leg(reg, name: str, params: Optional[dict], symbol: str, timeframe: str,
     # spec alone also enables it (the spec exists only to pick the gate's
     # classifier, so threading it without computing the column would be a
     # silent no-op).
-    use_regime = regime_enabled or bool(allowed_regimes) or bool(regime_windows_spec)
+    use_regime = (regime_enabled or bool(allowed_regimes)
+                  or bool(regime_windows_spec)
+                  or bool(regime_directional_policy))
     bt_kwargs = dict(
         initial_capital=capital, platform=PLATFORM,
         open_strategy={"name": name, "params": dict(strat_params or {})},
@@ -376,6 +388,14 @@ def run_leg(reg, name: str, params: Optional[dict], symbol: str, timeframe: str,
     # default stands (passing None would zero it out via the constructor).
     if slippage_pct is not None:
         bt_kwargs["slippage_pct"] = slippage_pct
+    # #1166: keys added ONLY when a policy is present so legs without one
+    # build byte-identical Backtester kwargs. The certified override is
+    # explicit research mode — without it the #1085 evidence gate nulls the
+    # policy to base direction (matching live default-off) and the run would
+    # silently score the ungated config.
+    if regime_directional_policy:
+        bt_kwargs["regime_directional_policy"] = regime_directional_policy
+        bt_kwargs["regime_directional_certified"] = True
     bt = Backtester(**bt_kwargs)
     results = bt.run(df_signals, strategy_name=name, symbol=symbol,
                      timeframe=timeframe, params=strat_params, save=False)
@@ -500,6 +520,47 @@ def validate_candidate(candidate: dict) -> dict:
             except (ValueError, TypeError) as exc:
                 raise ValueError(f"candidate.regime_windows_spec: {exc}")
             candidate["regime_windows_spec"] = normalized
+
+    # #1166: regime_directional_policy (per-regime entry direction, #1025
+    # shape) is threadable so directional-gated candidates can be scored on
+    # the M1 bar. Normalize with the Backtester's own parser so a malformed
+    # policy fails loudly at the gate instead of deep in the leg run. Any
+    # state resolving direction='both' opens a two-sided book for that
+    # regime, which the plain signal path cannot model (the Backtester
+    # rejects it at run) — require close refs up front, mirroring the
+    # candidate-level direction='both' guard.
+    rdp = candidate.get("regime_directional_policy")
+    if rdp is not None:
+        if not isinstance(rdp, dict):
+            raise ValueError(
+                "candidate.regime_directional_policy must be an object "
+                "{trend_regime: {label: {direction, invert_signal?}}} "
+                "(or omitted for no directional gate)")
+        if not rdp:
+            candidate.pop("regime_directional_policy", None)
+        else:
+            from backtester import _normalize_regime_directional_policy
+            try:
+                normalized_rdp = _normalize_regime_directional_policy(rdp)
+            except (ValueError, TypeError) as exc:
+                raise ValueError(
+                    f"candidate.regime_directional_policy: {exc}")
+            both_labels = sorted(
+                label for label, entry in (normalized_rdp or {}).items()
+                if entry.get("direction") == "both")
+            if both_labels and not close_refs:
+                raise ValueError(
+                    "candidate.regime_directional_policy resolves "
+                    f"direction='both' for {both_labels} but the candidate "
+                    "has no close_strategies. The plain signal path runs one "
+                    "leg at a time, so a both-sided regime would be rejected "
+                    "by the Backtester (or silently mis-scored). Add "
+                    "close_strategies (the open/close engine models both "
+                    "sides) or drop the both-states.")
+            # Keep the full {trend_regime: ...} shape the Backtester
+            # constructor takes, with the compacted per-label entries.
+            candidate["regime_directional_policy"] = {
+                "trend_regime": normalized_rdp}
     return candidate
 
 
@@ -532,6 +593,8 @@ def evaluate_window(reg, candidate: dict, datasets: List[tuple],
             profile_allocation=candidate.get("profile_allocation"),
             allowed_regimes=candidate.get("allowed_regimes"),
             regime_windows_spec=candidate.get("regime_windows_spec"),
+            regime_directional_policy=candidate.get(
+                "regime_directional_policy"),
         )
     score = score_candidate(candidate_legs, bars)
     score["window"] = window_name
@@ -654,7 +717,7 @@ def build_parser() -> argparse.ArgumentParser:
                         "close_strategies?, direction?, invert_signal?, "
                         "stop_loss_atr_mult?, trailing_stop_atr_mult?, "
                         "allowed_regimes?, regime_windows_spec?, "
-                        "profile_allocation?}. "
+                        "regime_directional_policy?, profile_allocation?}. "
                         "Overrides --strategy/--params. allowed_regimes enables "
                         "the entry gate on the M1 bar (legacy lookback unless "
                         "regime_windows_spec picks another classifier).")
@@ -681,6 +744,14 @@ def build_parser() -> argparse.ArgumentParser:
                         "PRIMARY (medium-first) window (#1058) so composite "
                         "labels work in --allowed-regimes. Omit for the "
                         "legacy ADX gate.")
+    p.add_argument("--regime-directional-policy", default=None, metavar="JSON",
+                   help="#1166 directional-policy JSON (#1025 shape: "
+                        "{trend_regime: {label: {direction: long|short|both, "
+                        "invert_signal?}}}) resolving the entry direction per "
+                        "bar regime. RESEARCH MODE: the leg passes the #1085 "
+                        "certified input explicitly, so the default-off live "
+                        "gate is bypassed deliberately for measurement. "
+                        "both-states require close_strategies.")
     p.add_argument("--windows", default=None,
                    help=f"Comma list of windows (default: all). "
                         f"Known: {', '.join(WINDOWS)}")
@@ -728,6 +799,10 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     if args.regime_windows_spec:
         candidate["regime_windows_spec"] = json.loads(args.regime_windows_spec)
+
+    if args.regime_directional_policy:
+        candidate["regime_directional_policy"] = json.loads(
+            args.regime_directional_policy)
 
     try:
         validate_candidate(candidate)

--- a/backtest/tests/test_eval_windows.py
+++ b/backtest/tests/test_eval_windows.py
@@ -457,3 +457,162 @@ def test_evaluate_window_validates_before_any_work():
     with pytest.raises(ValueError, match="silently dropped"):
         ew.evaluate_window(None, {"name": "x", "direction": "both"},
                            [("BTC/USDT", "1h")], "oos", 1000.0, {})
+
+
+# ---------------------------------------------------------------------------
+# #1166: regime_directional_policy threading (M1 directional-gate candidates)
+# ---------------------------------------------------------------------------
+
+def test_validate_candidate_accepts_regime_directional_policy():
+    # Valid #1025-shaped policy: normalized through the Backtester's own
+    # parser (invert_signal defaulted, unknown keys rejected there) and kept
+    # on the candidate in the full {trend_regime: ...} shape the Backtester
+    # constructor takes.
+    c = {"name": "x", "direction": "both",
+         "close_strategies": [{"name": "atr_stop",
+                               "params": {"atr_mult": 2.0}}],
+         "regime_directional_policy": {"trend_regime": {
+             "trending_up": {"direction": "long"},
+             "trending_down": {"direction": "both"}}}}
+    assert ew.validate_candidate(c) is c
+    assert c["regime_directional_policy"]["trend_regime"]["trending_up"] == {
+        "direction": "long", "invert_signal": False}
+
+    # Empty dict = no policy (normalized away, like allowed_regimes/spec).
+    c2 = {"name": "x", "regime_directional_policy": {}}
+    assert ew.validate_candidate(c2) is c2
+    assert "regime_directional_policy" not in c2
+
+
+def test_validate_candidate_rejects_malformed_regime_directional_policy():
+    # Non-dict shapes fail loudly.
+    with pytest.raises(ValueError, match="regime_directional_policy"):
+        ew.validate_candidate(
+            {"name": "x", "regime_directional_policy": "trending_up"})
+    # Missing trend_regime wrapper (the #1025 shape) surfaces the parser error.
+    with pytest.raises(ValueError, match="trend_regime"):
+        ew.validate_candidate(
+            {"name": "x", "regime_directional_policy": {
+                "trending_up": {"direction": "long"}}})
+    # Bad direction value rejected by the parser.
+    with pytest.raises(ValueError, match="regime_directional_policy"):
+        ew.validate_candidate(
+            {"name": "x", "regime_directional_policy": {"trend_regime": {
+                "trending_up": {"direction": "flat"}}}})
+
+
+def test_validate_candidate_rejects_both_state_policy_without_close_refs():
+    # A both-state resolves a two-sided book for that regime; the plain
+    # signal path cannot model it (Backtester rejects at run) — fail at the
+    # gate, mirroring the direction='both' guard.
+    with pytest.raises(ValueError, match="close_strategies"):
+        ew.validate_candidate(
+            {"name": "x", "regime_directional_policy": {"trend_regime": {
+                "trending_down": {"direction": "both"}}}})
+
+
+def test_run_leg_omits_policy_kwargs_without_policy(monkeypatch):
+    """#1166 regression: legs without a directional policy must build
+    byte-identical Backtester kwargs — the new keys are only ever added when
+    a policy is present, so existing candidates cannot change behavior."""
+    df = _synthetic_df()
+    import data_fetcher
+    monkeypatch.setattr(data_fetcher, "load_cached_data",
+                        lambda *a, **k: df, raising=True)
+    import backtester as bt_mod
+    real = bt_mod.Backtester
+    calls = []
+
+    def _spy(**kwargs):
+        calls.append(kwargs)
+        return real(**kwargs)
+
+    monkeypatch.setattr(bt_mod, "Backtester", _spy, raising=True)
+    leg = ew.run_leg(_FakeRegistry(), "alternator", None, "BTC/USDT", "1h",
+                     ("2026-01-01", None))
+    assert leg is not None and calls
+    assert "regime_directional_policy" not in calls[0]
+    assert "regime_directional_certified" not in calls[0]
+
+
+def test_run_leg_threads_regime_directional_policy_research_certified(monkeypatch):
+    """#1166: the policy must reach the Backtester with the EXPLICIT
+    research-mode certified override (else the #1085 evidence gate nulls it
+    to base direction — matching live default-off — and the measurement
+    silently scores the ungated config), and regime compute must be forced
+    on (the Backtester rejects a policy with regime_enabled=False)."""
+    df = _synthetic_df()
+    df = df.copy()
+    df["regime"] = "trending_up"
+    import data_fetcher
+    monkeypatch.setattr(data_fetcher, "load_cached_data",
+                        lambda *a, **k: df, raising=True)
+    import backtester as bt_mod
+    real = bt_mod.Backtester
+    calls = []
+
+    def _spy(**kwargs):
+        calls.append(kwargs)
+        return real(**kwargs)
+
+    monkeypatch.setattr(bt_mod, "Backtester", _spy, raising=True)
+    policy = {"trend_regime": {"trending_up": {"direction": "short"}}}
+    leg = ew.run_leg(_FakeRegistry(), "alternator", None, "BTC/USDT", "1h",
+                     ("2026-01-01", None),
+                     regime_directional_policy=policy)
+    assert leg is not None and calls
+    kw = calls[0]
+    assert kw["regime_directional_policy"] == policy
+    assert kw["regime_directional_certified"] is True
+    assert kw["regime_enabled"] is True
+
+
+def test_run_leg_policy_switches_plain_path_side(monkeypatch):
+    """#1166 behavioral: with every bar classified trending_up and a
+    trending_up→short policy, the plain path runs the short/flat mirror for
+    those bars instead of long/flat — the leg must differ from the ungated
+    long run. Identical legs mean the policy never reached the engine (or
+    the #1085 gate nulled it because the certified override was dropped)."""
+    df = _synthetic_df(n=240)
+    df = df.copy()
+    df["regime"] = "trending_up"
+    import data_fetcher
+    monkeypatch.setattr(data_fetcher, "load_cached_data",
+                        lambda *a, **k: df, raising=True)
+    plain = ew.run_leg(_FakeRegistry(), "alternator", None, "BTC/USDT", "1h",
+                       ("2026-01-01", None))
+    gated = ew.run_leg(_FakeRegistry(), "alternator", None, "BTC/USDT", "1h",
+                       ("2026-01-01", None),
+                       regime_directional_policy={"trend_regime": {
+                           "trending_up": {"direction": "short"}}})
+    assert plain is not None and plain.get("trades", 0) > 0
+    assert gated is not None and gated.get("trades", 0) > 0
+    assert (gated["return_pct"], gated["max_dd_pct"]) != \
+        (plain["return_pct"], plain["max_dd_pct"]), (
+        "trending_up→short policy produced a leg identical to the ungated "
+        "long run — the policy never reached the Backtester")
+
+
+def test_evaluate_window_threads_regime_directional_policy(monkeypatch):
+    """#1166: the candidate key must flow evaluate_window → run_leg."""
+    seen = {}
+
+    def _fake_run_leg(reg, name, params, symbol, timeframe, window, **kwargs):
+        seen.update(kwargs)
+        return {"sharpe": 1.0, "return_pct": 1.0, "max_dd_pct": 1.0,
+                "ddadj": 1.0, "trades": 1, "bh_return_pct": 0.0,
+                "span_days": 30.0}
+
+    monkeypatch.setattr(ew, "run_leg", _fake_run_leg, raising=True)
+    monkeypatch.setattr(ew, "incumbent_bars", lambda legs: {}, raising=True)
+    monkeypatch.setattr(ew, "compute_incumbent_legs",
+                        lambda *a, **k: {}, raising=True)
+    policy = {"trend_regime": {"trending_up": {"direction": "long"}}}
+    cand = {"name": "x", "direction": "both",
+            "close_strategies": [{"name": "atr_stop",
+                                  "params": {"atr_mult": 2.0}}],
+            "regime_directional_policy": policy}
+    ew.evaluate_window(None, cand, [("BTC/USDT", "1h")], "oos", 1000.0, {})
+    # validate_candidate normalizes (invert_signal defaulted) and re-wraps.
+    assert seen.get("regime_directional_policy") == {"trend_regime": {
+        "trending_up": {"direction": "long", "invert_signal": False}}}

--- a/docs/research/1166-momentum-pro-directional-gate.md
+++ b/docs/research/1166-momentum-pro-directional-gate.md
@@ -1,0 +1,217 @@
+# momentum_pro: regime-gating the short side via regime_directional_policy (#1166)
+
+Generated: 2026-07-02
+
+Follow-up to #980 (`docs/research/momentum_pro_980.md`), which found a real
+but regime-dependent short edge: protocol OOS PASS 6/6, yet 0/6 legs beat the
+bar in either bull held-out (2023, 2024). This measurement asks whether gating
+the short side by regime state — coarse ADX 3-label first, composite 9-state
+second, and the combined long+gated-short shape through the
+`regime_directional_policy` machinery — recovers the bear-window edge without
+bleeding it away in bull years. Full M1 protocol (#995); sibling of
+`session_breakout` #1031 and `vol_momentum` #1021.
+
+**Verdict: negative result across every gate shape measured.** The bull-year
+failure is not separable by regime label for this entry style: momentum_pro's
+own stacked-bearish-EMA + ADX entry gate is already a local-downtrend
+detector, so every downtrend-shaped regime gate is nearly redundant with it
+(≤3 of 45–60 bull-year shorts suppressed), and the one gate that does cut
+exposure (composite clean-only, ~half the trades) leaves survivors that lose
+at the same rate. The combined long+gated-short config improves held-outs to
+2/3 — but an ungated same-engine control scores identically to the third
+decimal, attributing the entire improvement to the long side riding bull
+years. Nothing here is promotion evidence; no certification artifact ships;
+live behavior is untouched.
+
+## Harness change (the PR's code deliverable)
+
+`eval_windows.py` now threads a `regime_directional_policy` candidate key
+(#1025 shape `{trend_regime: {label: {direction, invert_signal?}}}`) through
+`validate_candidate` → `evaluate_window` → `run_leg` → `Backtester`, mirroring
+the `allowed_regimes` plumbing, plus a `--regime-directional-policy` JSON
+flag:
+
+- **Research-mode certified override.** The #1085 evidence gate defaults the
+  policy OFF unless certified. A measurement leg passes the Backtester's
+  `regime_directional_certified=True` input explicitly — bypassing the
+  default-off live gate deliberately and visibly, never via a shipped
+  certification artifact.
+- **Engine-path guard.** Any policy state resolving `direction='both'` opens
+  a two-sided book for that regime, which the plain signal path cannot model
+  (the Backtester rejects both-states there) — `validate_candidate` requires
+  `close_strategies` up front, mirroring the candidate-level
+  `direction='both'` guard.
+- **Byte-identical regression.** The new Backtester kwargs are added only
+  when a policy is present; legs without one build identical kwargs
+  (regression-tested by capturing constructor kwargs). `--list-json` verified
+  byte-identical against `main` for both registries.
+- Tests: accept/normalize (invert_signal defaulted), malformed-policy loud
+  reject, both-state-without-close-refs reject, kwargs threading + certified
+  override, plain-path behavioral side-switch, evaluate_window threading.
+
+The isolated gated-short leg needs none of this: `allowed_regimes` +
+`--direction short` (existing #1031 plumbing) already expresses
+"short entries only in bear states, flat elsewhere". The policy threading is
+what the combined shape requires (the policy vocabulary is
+`long`/`short`/`both` — there is no flat state, so a bull-state `long` entry
+admits longs rather than going flat).
+
+## Reproduce
+
+Data: the checkout's `shared_tools/trading_bot.db` OHLCV cache. **This cache
+is NOT the one the #980 rows were produced on**: its 1h/4h series end
+2026-06-04..2026-06-12 per dataset (vs #980's 2026-07-01), so the open-ended
+`oos` window is shorter here and #980's published OOS rows are not
+digit-comparable. Every comparison in this doc is against baselines re-run on
+THIS cache (rows G and D below); the #980 rows match in shape (identical
+window verdicts). Fixed windows (`is`, `2023`, `2024`, `2025H1`) verified
+full-span via each leg's `span_days` — no silent truncation (#980's
+cold-cache caveat). All runs `--registry spot`, the six audit datasets,
+incumbent bar recomputed per (window, dataset).
+
+```bash
+# G — ungated short baseline (re-run of #980 mechanism 1 on this cache)
+uv run --no-sync python backtest/eval_windows.py --strategy momentum_pro --registry spot \
+  --direction short --windows is,oos,2023,2024,2025H1
+
+# A/B — isolated gated short, legacy ADX 3-label (B adds ranging; identical result)
+uv run --no-sync python backtest/eval_windows.py --strategy momentum_pro --registry spot \
+  --direction short --allowed-regimes trending_down --windows is,2023,2024,2025H1
+uv run --no-sync python backtest/eval_windows.py --strategy momentum_pro --registry spot \
+  --direction short --allowed-regimes trending_down --allowed-regimes ranging --windows is,2023,2024,2025H1
+
+# E/F — isolated gated short, composite 9-state (#1058)
+SPEC='{"medium": {"classifier": "composite", "period": 14}}'
+uv run --no-sync python backtest/eval_windows.py --strategy momentum_pro --registry spot \
+  --direction short --allowed-regimes trending_down_clean --allowed-regimes trending_down_choppy \
+  --regime-windows-spec "$SPEC" --windows is,2023,2024,2025H1
+uv run --no-sync python backtest/eval_windows.py --strategy momentum_pro --registry spot \
+  --direction short --allowed-regimes trending_down_clean \
+  --regime-windows-spec "$SPEC" --windows is,2023,2024,2025H1
+
+# C — combined long+gated-short via the new policy threading (engine path)
+cat > /tmp/mp1166-combined.json <<'J'
+{
+  "name": "momentum_pro",
+  "direction": "both",
+  "close_strategies": [{"name": "atr_stop", "params": {"atr_mult": 2.0, "atr_source": "entry"}}],
+  "regime_directional_policy": {"trend_regime": {
+      "trending_up": {"direction": "long"},
+      "trending_down": {"direction": "both"}}}
+}
+J
+uv run --no-sync python backtest/eval_windows.py --registry spot \
+  --candidate-json /tmp/mp1166-combined.json --windows is,2023,2024,2025H1
+
+# D — ungated same-engine control (identical minus the policy block)
+# Final protocol-OOS look (after tuning-window selection): --windows oos on A and C.
+```
+
+The combined shape needs the open/close engine (`direction='both'` +
+`close_strategies`), so C is compared against D — the same engine path, same
+`atr_stop` close — never against the plain-path #980 rows. The M1 incumbent
+bar itself stays the harness's fixed plain-path construct for all rows.
+
+## Isolated gated short (plain path, `allowed_regimes` + `--direction short`)
+
+Window mean Sharpe / mean DDadj (bar in parentheses), verdict per M1 #955:
+
+| config | is | 2023 | 2024 | 2025H1 | oos |
+|---|---|---|---|---|---|
+| G ungated (#980 re-run) | 0.32 / 0.24 PASS | -1.01 / -0.74 FAIL | -0.97 / -0.73 FAIL | -0.08 / 0.20 PASS | 2.11 / 2.11 PASS |
+| A adx `trending_down` | 0.29 / 0.22 PASS | -0.95 / -0.73 FAIL 0/6 | -1.01 / -0.74 FAIL 0/6 | -0.08 / 0.20 PASS | 2.03 / 2.00 PASS |
+| B adx `trending_down`+`ranging` | identical to A in every leg | | | | not run |
+| E comp `trending_down_clean`+`_choppy` | 0.25 / 0.16 PASS | -1.02 / -0.76 FAIL 0/6 | -1.08 / -0.77 FAIL 0/6 | -0.16 / 0.23 PASS | not run |
+| F comp `trending_down_clean` | 0.59 / 0.70 PASS | -0.98 / -0.65 FAIL 0/6 | -1.04 / -0.57 FAIL 0/6 | -0.01 / 0.32 PASS | not run |
+
+(bars: is -0.12 / -0.14 · 2023 1.46 / 3.67 · 2024 0.90 / 1.07 ·
+2025H1 -0.42 / -0.37 · oos -0.75 / -0.49)
+
+Suppressed-entry counts (total short entries across the six datasets;
+suppression = G minus config — the gate produced the reduction, not data
+absence; every window traded 6/6, no degenerate verdicts anywhere):
+
+| window | G ungated | A adx | E comp family | F comp clean-only |
+|---|---:|---:|---:|---:|
+| is | 32 | 32 (−0) | 31 (−1) | 18 (−14) |
+| 2023 | 47 | 45 (−2) | 44 (−3) | 24 (−23) |
+| 2024 | 60 | 59 (−1) | 57 (−3) | 30 (−30) |
+| 2025H1 | 29 | 29 (−0) | 28 (−1) | 10 (−19) |
+| oos | 24 | 24 (−0) | — | — |
+
+Two mechanisms, both fatal to the gating idea:
+
+1. **Downtrend-family gates are redundant with the strategy's own entry
+   gate.** momentum_pro shorts only fire from a stacked-bearish-EMA
+   (20<50<200) regime with ADX>20 — by construction the bar-level regime
+   classifier (ADX or composite trending_down family) labels those same bars
+   trending-down. A/E suppress ≤3 of 45–60 bull-year entries; B (adding
+   `ranging`) changes nothing at all because a ranging-labeled short never
+   passes the internal ADX gate in the first place.
+2. **The selective gate cuts exposure, not the loss rate.** F
+   (`trending_down_clean` only) suppresses ~half the bull-year shorts
+   (47→24, 60→30) yet 2023/2024 means barely move (-1.01→-0.98,
+   -0.97→-1.04): the surviving "clean downtrend" entries lose exactly like
+   the rejected ones. At entry time a bull-market correction is
+   indistinguishable from a bear-market downtrend in these label vocabularies
+   — the information that would separate them (what happens next) isn't in
+   the regime state.
+
+The gate is also costless where the edge lives (A keeps OOS PASS 6/6, zero
+suppression) — it is simply inert: momentum_pro already self-gates.
+
+## Combined long+gated-short (engine path, policy vs ungated control)
+
+C = `direction both` + `atr_stop` 2.0 (entry-ATR) + policy
+`{trending_up: long, trending_down: both}` (ranging → base `both` fallback).
+D = identical minus the policy — the control that isolates the gate's
+contribution.
+
+| config | is | 2023 | 2024 | 2025H1 | oos |
+|---|---|---|---|---|---|
+| D ungated control | 0.10 / -0.07 PASS | 2.25 / 8.72 PASS | 0.67 / 1.26 FAIL | -0.13 / -0.20 PASS | 1.73 / 1.75 PASS |
+| C policy-gated | 0.08 / -0.11 PASS | 2.25 / 8.72 PASS | 0.69 / 1.32 FAIL (4/6 S, 3/6 D) | -0.14 / -0.21 PASS | 1.73 / 1.75 PASS |
+
+- **C ≡ D everywhere that matters.** 2023 rows identical to the digit (six
+  legs, 1 trade each — the long entry; both configs took zero 2023 shorts
+  because the internal gate already suppressed them). OOS legs identical to
+  the third decimal on all six datasets (both 17 trades). Total entries
+  differ by ≤2 per window (2024: 48 vs 46).
+- Adjacent policy shapes converge to the same rows: `{trending_up: long}`
+  alone (trending_down→both via base fallback — semantically identical,
+  confirms the resolver) and the tighter `{trending_up: long, ranging: long,
+  trending_down: both}` (ranging shorts already blocked internally). The
+  "plateau" (M1 step 6) is real but degenerate — it is the plateau of a
+  no-op.
+- The held-out improvement over #980's short row (1/3 → 2/3) and the 2024
+  0/6 → 4/6-Sharpe movement are therefore **entirely the long side riding
+  bull years** (2023: +79..+815% per leg from the long entries), not the
+  directional gate. Against the issue's pass bar — "the GATED config must
+  keep protocol-OOS PASS and stop losing to the bar 0/6 in 2023/2024" — the
+  literal clauses are met by C, but the D control shows the gate contributed
+  none of it; crediting the policy would be attributing the control's result
+  to the treatment. 2024's window verdict also remains FAIL on means.
+
+## Verdict table
+
+| config | protocol OOS | held-out | disposition |
+|---|---|---|---|
+| G short ungated (#980 re-run) | PASS | 1/3 (0/6 both bull years) | baseline reproduced on this cache |
+| A/B short + ADX bear gate | PASS (A) | 1/3 (0/6 both bull years) | negative — gate suppresses ≤2 bull-year entries |
+| E short + composite bear family | not taken | 1/3 tuning shape (0/6 both bull years) | negative — same redundancy |
+| F short + composite clean-only | not taken | 1/3 tuning shape (0/6 both bull years) | negative — halves trades, survivors lose identically |
+| C combined via policy | PASS | 2/3 | attribution fails: D control identical — improvement is the long side |
+| D combined ungated control | PASS | 2/3 | the same result with no directional machinery at all |
+
+**Disposition: negative result — documented, not deleted; close #1166.**
+No regime state in either vocabulary separates momentum_pro's bear short
+edge from its bull failure, because the strategy's entry condition already
+conditions on the same information. No certification evidence is generated,
+`regime_directional_policy` remains default-off/uncertified for momentum_pro
+(#1085), no registry defaults change, and live behavior is untouched. The
+harness threading stays: it is strategy-agnostic and lets the next
+directional-gate candidate (one whose entries do NOT already self-select for
+local downtrends) be measured on the M1 bar without new plumbing.
+
+---
+Created with LLM: Fable 5 | high | Harness: Claude Code


### PR DESCRIPTION
Closes #1166

## What this PR does

**Harness (code deliverable):** `eval_windows.py` accepts a `regime_directional_policy` candidate key (#1025 shape) and a `--regime-directional-policy` JSON flag, threaded `validate_candidate` → `evaluate_window` → `run_leg` → `Backtester`, mirroring the `allowed_regimes` plumbing:

- Research-mode legs drive the Backtester's `regime_directional_certified` input explicitly (`True`) — the #1085 default-off live gate is bypassed deliberately and visibly for measurement, never via a shipped certification artifact.
- Policy states resolving `direction='both'` require `close_strategies` at the validation gate (the plain signal path cannot model a two-sided regime; the Backtester rejects it at run).
- Legs without a policy build **byte-identical Backtester kwargs** — regression-tested by capturing constructor kwargs. `--list-json` verified byte-identical against `main` for both registries.
- 7 new tests in `backtest/tests/test_eval_windows.py` (accept/normalize, malformed reject, both-state reject, kwargs threading + certified override, plain-path behavioral side-switch, evaluate_window threading), written red → green.

**Measurement (research deliverable):** full M1 (#995) on momentum_pro's short side, six audit datasets × five windows — **negative result across every gate shape**; full write-up with verdict tables and suppressed-entry counts in `docs/research/1166-momentum-pro-directional-gate.md`:

| config | protocol OOS | 2023 | 2024 | held-out |
|---|---|---|---|---|
| short ungated (#980 re-run, this cache) | PASS | FAIL 0/6 | FAIL 0/6 | 1/3 |
| short + ADX `trending_down` gate | PASS | FAIL 0/6 | FAIL 0/6 | 1/3 |
| short + composite bear-family / clean-only | — | FAIL 0/6 | FAIL 0/6 | 1/3 |
| combined long+gated-short (policy, engine path) | PASS | PASS | FAIL (4/6 Sharpe) | 2/3 |
| combined ungated control (no policy) | PASS | PASS | FAIL | 2/3 |

Why negative: momentum_pro's own stacked-bearish-EMA + ADX entry gate already conditions on the same information as any downtrend-shaped regime label — the ADX/composite-family gates suppress ≤3 of 45–60 bull-year shorts; the selective clean-only gate halves exposure but survivors lose at the same rate. The combined config's held-out gain is attributed by the ungated control (identical rows to the third decimal) to the long side riding bull years, not the gate.

Disposition per M1 step 4: documented, not deleted. No certification evidence, no registry default changes, live behavior untouched. The threading stays — it is strategy-agnostic and serves the next directional-gate candidate whose entries don't already self-select for local downtrends.

## Verification

- Full pytest suite: **2132 passed** (includes the 7 new tests; new tests verified red before implementation).
- `py_compile` clean; no Go changes.
- `--list-json` diffed byte-identical vs `main` (spot + futures registries).
- All fixed measurement windows verified full-span via per-leg `span_days` (no silent cache truncation); the open-ended OOS window's per-dataset cache-end drift vs #980 is documented in the research doc, with same-cache baselines re-run for every comparison.

LLM: Fable 5 | high | Harness: Claude Code
