### PR TITLE
feat(#1170): anchored_vwap_reversion — fade ATR-measured stretches beyond the anchored VWAP

### DIFF
--- a/backtest/fee_audit.py
+++ b/backtest/fee_audit.py
@@ -95,7 +95,7 @@ LIVE_BIDIRECTIONAL_STRATEGIES = frozenset({
     "chart_pattern", "liquidity_sweeps", "bear_pullback_st", "vwap_rejection_st",
     "momentum_pro", "mean_reversion_pro", "consolidation_range", "mtf_confluence",
     "vol_momentum", "funding_skew", "regime_adaptive", "anchored_vwap",
-    "anchored_vwap_channel", "atr_band_revert",
+    "anchored_vwap_channel", "anchored_vwap_reversion", "atr_band_revert",
 })
 
 # The #956/#963 protocol windows; held-out windows overlap `is` and would

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -734,6 +734,12 @@ DEFAULT_PARAM_RANGES = {
         "confirm_bars": [1, 2, 3],
         "min_width_atr_mult": [1.0, 1.5, 2.5],
     },
+    "anchored_vwap_reversion": {
+        "pivot_strength": [3, 5, 8],
+        "entry_atr_mult": [1.0, 1.5, 2.0],
+        "buffer_atr_mult": [0.1, 0.25, 0.5],
+        "confirm_bars": [1, 2, 3],
+    },
     "chart_pattern": {
         "pivot_lookback": [3, 5, 7],
         "tolerance": [0.02, 0.03, 0.05],

--- a/backtest/tests/test_backtester_lookahead.py
+++ b/backtest/tests/test_backtester_lookahead.py
@@ -493,3 +493,88 @@ def test_anchored_vwap_channel_no_lookahead():
     assert not np.array_equal(bf[:cut], bt), (
         "forward-peeking variant should break truncation-invariance — the test "
         "is not sensitive to look-ahead")
+
+
+# ─── anchored_vwap_reversion: signals at bars <= cut don't depend on future bars (#1170) ─
+from anchored_vwap_reversion import anchored_vwap_reversion_core  # noqa: E402
+
+
+_AVWAP_REVERSION_PARAMS = dict(pivot_strength=2, entry_atr_mult=1.0,
+                               buffer_atr_mult=0.0, confirm_bars=2, atr_period=3)
+
+
+def _avwap_reversion_mixed_fixture() -> pd.DataFrame:
+    """OHLCV forming a swing LOW (idx 5), a downside stretch, then a swing
+    HIGH (idx 13) and an upside stretch.
+
+    Bar 9 wicks through the lower ATR band and closes back inside — below the
+    line — so +1 fires at bar 10; the rally re-anchors (bar 9's wick low is
+    itself a strict swing low, confirming at 11; the bar-13 swing high
+    confirms at 15) and bar 16's hand-set up-wick through the upper band with
+    a held in-zone close fires -1 at bar 17. A smooth fixture is NOT usable:
+    equal lows/highs at a monotonic turn tie under the strict pivot rule and
+    nothing confirms (see the anchored_vwap fixture note above).
+    """
+    closes = np.array([110, 108, 106, 104, 102, 100, 101, 102, 101, 100.2,
+                       100.6, 103, 105, 107, 106, 105, 106.5, 106.3],
+                      dtype=float)
+    lows = closes - 0.5
+    lows[9] = 99.0
+    highs = closes + 0.5
+    highs[16] = 108.5
+    idx = pd.date_range("2026-01-01", periods=len(closes), freq="1h")
+    return pd.DataFrame(
+        {"open": closes, "high": highs, "low": lows, "close": closes,
+         "volume": np.full(len(closes), 10.0)},
+        index=idx,
+    )
+
+
+def test_anchored_vwap_reversion_no_lookahead():
+    """Truncating future bars must not change any signal at bars <= cut.
+
+    anchored_vwap_reversion_core anchors to *confirmed* pivots (pivot_strength
+    bars on each side), derives AVWAP/ATR from prefix sums, and evaluates every
+    trigger clause (stretch touch, snap-back, zone hold, freshness) on bars at
+    or before the current bar, so appending future bars cannot change an
+    earlier signal.
+
+    Mirrors test_anchored_vwap_no_lookahead's non-vacuity and sensitivity
+    checks (#1019 review) and the #1169 full prefix sweep: the fixture must
+    emit both signal directions, and a deliberately forward-peeking variant
+    must make the invariance assertion FAIL, proving the test can actually
+    detect look-ahead.
+    """
+    df = _avwap_reversion_mixed_fixture()
+    cut = 17  # straddles the confirm_bars window [16, 17]; bar 17 fires -1
+
+    def real(d):
+        return anchored_vwap_reversion_core(d, **_AVWAP_REVERSION_PARAMS)["signal"].to_numpy()
+
+    def forward_peeking(d):
+        # bar n adopts bar n+1's signal — a canonical look-ahead contamination.
+        s = anchored_vwap_reversion_core(d, **_AVWAP_REVERSION_PARAMS)["signal"].to_numpy().copy()
+        if len(s) > 1:
+            s[:-1] = s[1:]
+        return s
+
+    full = real(df)
+    # Non-vacuity: the fixture must actually produce signals (both directions).
+    assert (full != 0).any(), "fixture is vacuous — no signal to guard"
+    assert (full == 1).any() and (full == -1).any(), "expected a +1 and a -1"
+
+    # Invariant: signals at bars < cut are unchanged when future bars are
+    # dropped — at the single cut straddling the firing window, and at every
+    # earlier cut (the re-anchors at 11 and 15 sit inside the sweep).
+    trunc = real(df.iloc[:cut])
+    assert np.array_equal(full[:cut], trunc), "signals < cut must not depend on future bars"
+    for c in range(3, len(df)):
+        assert np.array_equal(full[:c], real(df.iloc[:c])), f"prefix changed at cut {c}"
+
+    # Sensitivity: a forward-peeking core variant must NOT be truncation-invariant,
+    # else the assertion above proves nothing.
+    bf = forward_peeking(df)
+    bt = forward_peeking(df.iloc[:cut])
+    assert not np.array_equal(bf[:cut], bt), (
+        "forward-peeking variant should break truncation-invariance — the test "
+        "is not sensitive to look-ahead")

--- a/docs/superpowers/specs/2026-07-02-anchored-vwap-reversion-strategy-design.md
+++ b/docs/superpowers/specs/2026-07-02-anchored-vwap-reversion-strategy-design.md
@@ -1,0 +1,167 @@
+# Anchored VWAP Reversion (`anchored_vwap_reversion`) — Strategy Design
+
+**Issue:** [#1170](https://github.com/richkuo/go-trader/issues/1170)
+**Umbrella:** [#1017](https://github.com/richkuo/go-trader/issues/1017)
+**Design parent:** [#1016](https://github.com/richkuo/go-trader/issues/1016) (`docs/superpowers/specs/2026-06-15-anchored-vwap-strategy-design.md`)
+**Sibling:** [#1169](https://github.com/richkuo/go-trader/issues/1169) (`docs/superpowers/specs/2026-07-01-anchored-vwap-channel-strategy-design.md`)
+**Date:** 2026-07-02
+**Status:** Approved design — implemented alongside this spec.
+
+## 1. Goal
+
+Add the third AVWAP open strategy: mean-reversion **to** the single
+pivot-anchored VWAP line. When price stretches at least `entry_atr_mult × ATR`
+beyond the line and then snaps back inside that band without reclaiming the
+line itself, enter toward the line: **long a downside stretch, short an upside
+stretch**. The session-reset `vwap_reversion` trades the same idea against a
+daily VWAP; this measures the stretch from a structural anchor (the most
+recent confirmed swing pivot, #1016 §3) instead of a calendar reset.
+
+## 2. Core design decisions (locked)
+
+These are the decisions #1170 deferred to spec time, recorded per its
+acceptance criteria:
+
+| Decision | Choice |
+|---|---|
+| Band type | **ATR bands** — `entry_atr_mult × ATR` around the AVWAP, not `vwap_reversion`-style std-dev bands. Rationale: (1) family consistency — #1016 and #1169 both scale line distances by the inline ATR; (2) a std-dev band computed within the anchor window is degenerate right after a re-anchor (1–3 samples → zero/hair-trigger bands), while the rolling ATR is anchor-independent and always well-formed past warmup |
+| Short leg | **Yes, symmetric** — a stretch `entry_atr_mult × ATR` ABOVE the line shorts back toward it. Joins `bidirectionalPerpsStrategies` and `LIVE_BIDIRECTIONAL_STRATEGIES` (`backtest/fee_audit.py`), same as both siblings |
+| Trigger shape | **Stretch touch + buffered snap-back + zone hold** (not `vwap_reversion`'s raw band-cross): the trigger bar's extreme must reach the band, its close must recover back inside by `buffer_atr_mult × ATR`, and every window bar must close **between the band and the line** — the falling-knife guard the raw cross lacks, reusing #1016/#1169 clause vocabulary |
+| Differentiation vs `anchored_vwap` (#1016) | Mutually exclusive per bar by construction: the flip strategy requires the close **beyond** the line (breach through); this strategy requires every window close strictly on the stretched side of the line (`close < avwap` for longs). A reclaim of the line during the hold kills the reversion fire — that regime belongs to the flip |
+| Differentiation vs `anchored_vwap_channel` (#1169) | The channel fades touches of its **two** anchored lines (support/resistance = the AVWAPs themselves) from inside the channel; this fades an **ATR-measured stretch away from the one type-agnostic line**, entering beyond it. Same portfolio class (ranging mean reversion), disjoint trigger geometry; both ship pre-gated to composite ranging and operators tune overlap per asset |
+| Regime gate default | **Pre-gated to composite ranging** `{ranging_quiet, ranging_volatile}` via `strategiesDefaultingToCompositeRangingGate` — stretch-fading is run over when the stretch is the start of a trend leg, the exact `atr_band_revert`/#1169 rationale; `ranging_directional` stays excluded |
+| Exit | No custom close evaluator — SL/TP come from config close defaults; the opposite stretch signal flips/flattens (family posture, #1016 §2). The AVWAP-targeting close evaluator stays out of scope in #1017 |
+
+## 3. Anchor and line
+
+Identical to #1016 §3–4, reused verbatim: strict unique swing pivots
+(`pivot_strength` bars each side), a pivot at *p* knowable only at `p + k`,
+single type-agnostic anchor = most recent confirmed pivot, AVWAP via global
+prefix sums (exact across re-anchors), zero-volume fallback to the bar's
+typical price. Emitted columns `avwap`, `anchor_index`, `atr` match #1016.
+
+## 4. Bands
+
+```
+lower_band[i] = avwap[i] − entry_atr_mult × ATR[i]
+upper_band[i] = avwap[i] + entry_atr_mult × ATR[i]
+```
+
+Bands are per-bar (live AVWAP, live ATR) — not frozen at the trigger bar —
+matching how #1169's hold clause tracks its live lines.
+
+## 5. Trigger: stretch touch + buffered snap-back + zone hold
+
+Notation mirrors #1016 §5: window `W = [b..n]` with `b = n − confirm_bars + 1`,
+`buf = buffer_atr_mult × ATR[b]`.
+
+**Validity at `b`:** anchor confirmed at `b` AND `b−1` (the freshness
+reference needs a defined band too); `ATR[b]` not NaN.
+
+**Long (+1) fires at bar `n`** iff all hold:
+1. **Stretch touch:** `low[b] ≤ lower_band[b]` — the trigger bar reached at
+   least `entry_atr_mult × ATR` below the line.
+2. **Buffered snap-back:** `close[b] ≥ lower_band[b] + buf` — it closed
+   decisively back inside the band.
+3. **Zone hold:** `lower_band[k] ≤ close[k] < avwap[k]` for every `k ∈ W` —
+   held inside the stretch zone: recovering, but the line (the target) not yet
+   reached. A close back through the band (knife resumes) or above the line
+   (move already over / flip territory) kills the fire.
+4. **Fresh touch:** `low[b−1] > lower_band[b−1]` — the prior bar did not
+   touch the band, so the fire is local and unique (#1016 §5 clause-3
+   rationale: the signal column must be deterministic on its own, +1 only on
+   the completing bar).
+
+**Short (−1)** mirrors on the upper band: `high[b] ≥ upper_band[b]`,
+`close[b] ≤ upper_band[b] − buf`, hold `avwap[k] < close[k] ≤ upper_band[k]`,
+fresh `high[b−1] < upper_band[b−1]`. The two zone holds are disjoint
+(`close < avwap` vs `close > avwap`), so a bar can never satisfy both; long is
+evaluated first regardless — deterministic, documented.
+
+NaN band values (ATR warmup inside the window) make every comparison false —
+fail quiet, same posture as the siblings.
+
+## 6. Parameters
+
+| Param | Default | Range (optimizer) |
+|---|---|---|
+| `pivot_strength` | 5 | [3, 5, 8] |
+| `entry_atr_mult` | 1.5 | [1.0, 1.5, 2.0] |
+| `buffer_atr_mult` | 0.25 | [0.1, 0.25, 0.5] |
+| `confirm_bars` | 2 | [1, 2, 3] |
+| `atr_period` | 14 | (fixed; not swept) |
+
+`entry_atr_mult` defaults to 1.5 by analogy with `vwap_reversion`'s
+`entry_std = 1.5` (same "how stretched before fading" role, ATR-scaled).
+
+## 7. Look-ahead safety
+
+Identical guarantees to #1016 §7 (pivots knowable at `p + k`; prefix sums,
+ATR, and every trigger clause read bars ≤ n; signal at N fills at N+1 open).
+A dedicated `anchored_vwap_reversion` case joins
+`backtest/tests/test_backtester_lookahead.py` with the same **non-vacuity**
+(fixture must emit a +1 and a −1) and **sensitivity** (a forward-peeking
+variant must fail the invariance assertion) checks the #1019 review demanded,
+plus the #1169 full prefix sweep.
+
+## 8. File-by-file wiring
+
+1. **`shared_strategies/open/anchored_vwap_reversion.py`** (new) —
+   `anchored_vwap_reversion_core(df, pivot_strength=5, entry_atr_mult=1.5,
+   buffer_atr_mult=0.25, confirm_bars=2, atr_period=14)` returning the df plus
+   `signal`, `avwap`, `anchor_index`, `atr`. ATR inlined byte-identical to
+   `standard_atr` (same `shared_tools`-off-sys.path constraint as #1016).
+2. **`shared_strategies/open/registry.py`** — import, `@register`
+   (default platforms → spot + futures), and `PLATFORM_ORDER` entries directly
+   after `anchored_vwap_channel` in both lists.
+3. **`scheduler/init.go`** — `knownShortNames["anchored_vwap_reversion"] = "avwaprev"`;
+   `bidirectionalPerpsStrategies` entry (shorts the upside stretch);
+   `defaultSpotStrategies` / `defaultPerpsStrategies` / `defaultFuturesStrategies`
+   entries after `anchored_vwap_channel`; `strategiesDefaultingToCompositeRangingGate`
+   entry per §2.
+4. **`backtest/optimizer.py`** — `DEFAULT_PARAM_RANGES["anchored_vwap_reversion"]` per §6.
+5. **`backtest/fee_audit.py`** — `LIVE_BIDIRECTIONAL_STRATEGIES` entry (short leg).
+
+## 9. Test plan
+
+- **`shared_strategies/open/test_anchored_vwap_reversion.py`** (new),
+  mirroring the sibling suites: empty/short-df guards; anchor confirmation
+  indices; hand-computed AVWAP; zero-volume fallback; long stretch-snap-back
+  fires exactly once on the completing bar; short mirrors; no signal before
+  the first anchor; **no snap-back (close still beyond the band) → 0** (the
+  falling-knife guard, non-vacuous); **line reclaimed during hold → 0** (the
+  flip-territory guard, non-vacuous); buffer blocks a shallow snap-back;
+  NaN-ATR warmup → 0; registry registration for spot + futures.
+- **Look-ahead:** §7 case in `test_backtester_lookahead.py`.
+- **Go:** `init_anchored_vwap_reversion_test.go` — wiring (short name,
+  bidirectional membership, presence in all three default lists) and
+  `generateConfig` composite-ranging-gate tests mirroring
+  `init_anchored_vwap_channel_test.go`.
+- **Registry parity:** `--list-json` snapshotted before the change for spot
+  and futures; the post-change diff must be exactly the one new entry.
+
+## 10. Backtest validation
+
+Same two-leg protocol as #1016 §11 / #1169 §11 (the backtester measures one
+direction per run; no `--config`, which would demand a close evaluator this
+design doesn't have):
+
+```
+uv run --no-sync python backtest/run_backtest.py \
+  --strategy anchored_vwap_reversion --symbol BTC/USDT --timeframe 1h --mode single
+
+uv run --no-sync python backtest/run_backtest.py \
+  --strategy anchored_vwap_reversion --symbol BTC/USDT --timeframe 1h --mode single \
+  --direction short
+```
+
+Sanity-check trade counts on each run (a stretch-fading strategy on trending
+BTC should trade sparsely; zero trades across both legs would indicate a
+wiring or gate bug, not selectivity).
+
+## 11. Out of scope (still tracked in #1017)
+
+- Optional momentum/regime gate on `anchored_vwap` itself.
+- AVWAP-anchored close evaluator (`close/registry.py`) — including
+  take-profit **at** the line, which this strategy approximates today via the
+  opposite-signal flip and config close defaults.

--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -35,54 +35,55 @@ type stratDef struct {
 
 // knownShortNames maps strategy IDs to abbreviated config ID prefixes.
 var knownShortNames = map[string]string{
-	"sma_crossover":         "sma",
-	"ema_crossover":         "ema",
-	"momentum":              "momentum",
-	"rsi":                   "rsi",
-	"bollinger_bands":       "bb",
-	"macd":                  "macd",
-	"mean_reversion":        "mr",
-	"volume_weighted":       "vw",
-	"triple_ema":            "tema",
-	"triple_ema_bidir":      "temab",
-	"tema_cross":            "temac",
-	"tema_cross_bd":         "temacb",
-	"rsi_macd_combo":        "rmc",
-	"vol_mean_reversion":    "vol",
-	"momentum_options":      "mom",
-	"protective_puts":       "pput",
-	"covered_calls":         "ccall",
-	"breakout":              "bo",
-	"atr_breakout":          "atrbo",
-	"stoch_rsi":             "stochrsi",
-	"ichimoku_cloud":        "ichi",
-	"order_blocks":          "ob",
-	"vwap_reversion":        "vwap",
-	"anchored_vwap":         "avwap",
-	"anchored_vwap_channel": "avwapch",
-	"chart_pattern":         "cpat",
-	"liquidity_sweeps":      "liqsw",
-	"parabolic_sar":         "psar",
-	"delta_neutral_funding": "dnf",
-	"funding_skew":          "fskew",
-	"supertrend":            "st",
-	"squeeze_momentum":      "sqm",
-	"heikin_ashi_ema":       "hae",
-	"range_scalper":         "rs",
-	"sweep_squeeze_combo":   "ssc",
-	"adx_trend":             "adxt",
-	"donchian_breakout":     "dbo",
-	"session_breakout":      "sbo",
-	"bear_pullback_st":      "bps",
-	"vwap_rejection_st":     "vrs",
-	"momentum_pro":          "mompro",
-	"mean_reversion_pro":    "mrpro",
-	"consolidation_range":   "cr",
-	"atr_band_revert":       "abr",
-	"mtf_confluence":        "mtfc",
-	"vol_momentum":          "volmom",
-	"regime_adaptive":       "regad",
-	"regime_adaptive_htf":   "rahtf",
+	"sma_crossover":           "sma",
+	"ema_crossover":           "ema",
+	"momentum":                "momentum",
+	"rsi":                     "rsi",
+	"bollinger_bands":         "bb",
+	"macd":                    "macd",
+	"mean_reversion":          "mr",
+	"volume_weighted":         "vw",
+	"triple_ema":              "tema",
+	"triple_ema_bidir":        "temab",
+	"tema_cross":              "temac",
+	"tema_cross_bd":           "temacb",
+	"rsi_macd_combo":          "rmc",
+	"vol_mean_reversion":      "vol",
+	"momentum_options":        "mom",
+	"protective_puts":         "pput",
+	"covered_calls":           "ccall",
+	"breakout":                "bo",
+	"atr_breakout":            "atrbo",
+	"stoch_rsi":               "stochrsi",
+	"ichimoku_cloud":          "ichi",
+	"order_blocks":            "ob",
+	"vwap_reversion":          "vwap",
+	"anchored_vwap":           "avwap",
+	"anchored_vwap_channel":   "avwapch",
+	"anchored_vwap_reversion": "avwaprev",
+	"chart_pattern":           "cpat",
+	"liquidity_sweeps":        "liqsw",
+	"parabolic_sar":           "psar",
+	"delta_neutral_funding":   "dnf",
+	"funding_skew":            "fskew",
+	"supertrend":              "st",
+	"squeeze_momentum":        "sqm",
+	"heikin_ashi_ema":         "hae",
+	"range_scalper":           "rs",
+	"sweep_squeeze_combo":     "ssc",
+	"adx_trend":               "adxt",
+	"donchian_breakout":       "dbo",
+	"session_breakout":        "sbo",
+	"bear_pullback_st":        "bps",
+	"vwap_rejection_st":       "vrs",
+	"momentum_pro":            "mompro",
+	"mean_reversion_pro":      "mrpro",
+	"consolidation_range":     "cr",
+	"atr_band_revert":         "abr",
+	"mtf_confluence":          "mtfc",
+	"vol_momentum":            "volmom",
+	"regime_adaptive":         "regad",
+	"regime_adaptive_htf":     "rahtf",
 }
 
 // bidirectionalPerpsStrategies lists strategy IDs that emit signal=-1 as a
@@ -90,24 +91,25 @@ var knownShortNames = map[string]string{
 // set AllowShorts=true so ExecutePerpsSignal opens shorts from flat instead
 // of skipping the signal (#328).
 var bidirectionalPerpsStrategies = map[string]bool{
-	"triple_ema_bidir":      true,
-	"tema_cross_bd":         true,
-	"session_breakout":      true,
-	"donchian_breakout":     true, // emits short on lower-channel breakdown (#649)
-	"chart_pattern":         true, // emits short on bearish patterns (double top, H&S, bear flag) (#649)
-	"liquidity_sweeps":      true, // emits short on stop-hunt wicks above swing highs (#649)
-	"bear_pullback_st":      true, // dedicated short-only strategy for bear-market rally rejections (#651)
-	"vwap_rejection_st":     true, // dedicated short-only strategy for VWAP/EMA rally rejections in bearish regime (#652)
-	"anchored_vwap":         true, // single-AVWAP S/R flip; emits short on a buffered breakdown below the line (#1016)
-	"anchored_vwap_channel": true, // dual-AVWAP channel; emits short on a buffered rejection off the resistance line (#1169)
-	"momentum_pro":          true, // emits short on stacked-bearish-EMA trend-pullback breakdowns
-	"mean_reversion_pro":    true, // emits short on overbought reversion in no-trend regimes
-	"consolidation_range":   true, // emits short at the top edge of a consolidation box (range-edge mean-reversion)
-	"atr_band_revert":       true, // futures variant (allow_short) shorts the upper ATR band in ranging conditions
-	"mtf_confluence":        true, // futures variant (allow_short) shorts LTF pullback rallies in HTF downtrends (#957)
-	"vol_momentum":          true, // emits short on ATR-normalized negative momentum with efficiency confirmation (#959)
-	"funding_skew":          true, // shorts crowded-long funding extremes on EMA breakdown (#960)
-	"regime_adaptive":       true, // futures variant (allow_short) shorts clean downtrend breakouts and fades range tops (#958)
+	"triple_ema_bidir":        true,
+	"tema_cross_bd":           true,
+	"session_breakout":        true,
+	"donchian_breakout":       true, // emits short on lower-channel breakdown (#649)
+	"chart_pattern":           true, // emits short on bearish patterns (double top, H&S, bear flag) (#649)
+	"liquidity_sweeps":        true, // emits short on stop-hunt wicks above swing highs (#649)
+	"bear_pullback_st":        true, // dedicated short-only strategy for bear-market rally rejections (#651)
+	"vwap_rejection_st":       true, // dedicated short-only strategy for VWAP/EMA rally rejections in bearish regime (#652)
+	"anchored_vwap":           true, // single-AVWAP S/R flip; emits short on a buffered breakdown below the line (#1016)
+	"anchored_vwap_channel":   true, // dual-AVWAP channel; emits short on a buffered rejection off the resistance line (#1169)
+	"anchored_vwap_reversion": true, // single-AVWAP stretch fade; emits short on a buffered snap-back from above the band (#1170)
+	"momentum_pro":            true, // emits short on stacked-bearish-EMA trend-pullback breakdowns
+	"mean_reversion_pro":      true, // emits short on overbought reversion in no-trend regimes
+	"consolidation_range":     true, // emits short at the top edge of a consolidation box (range-edge mean-reversion)
+	"atr_band_revert":         true, // futures variant (allow_short) shorts the upper ATR band in ranging conditions
+	"mtf_confluence":          true, // futures variant (allow_short) shorts LTF pullback rallies in HTF downtrends (#957)
+	"vol_momentum":            true, // emits short on ATR-normalized negative momentum with efficiency confirmation (#959)
+	"funding_skew":            true, // shorts crowded-long funding extremes on EMA breakdown (#960)
+	"regime_adaptive":         true, // futures variant (allow_short) shorts clean downtrend breakouts and fades range tops (#958)
 }
 
 func isBidirectionalPerpsStrategy(id string) bool {
@@ -127,6 +129,9 @@ var strategiesDefaultingToCompositeRangingGate = map[string][]string{
 	// anchored_vwap_channel fades both edges of an AVWAP channel — the same
 	// range-edge mean-reversion class, gated for the same reason (#1169).
 	"anchored_vwap_channel": {"ranging_quiet", "ranging_volatile"},
+	// anchored_vwap_reversion fades ATR-measured stretches beyond the anchored
+	// line — same mean-reversion class, gated for the same reason (#1170).
+	"anchored_vwap_reversion": {"ranging_quiet", "ranging_volatile"},
 }
 
 // defaultCompositeRangingGate returns a fresh copy of the default composite
@@ -175,6 +180,7 @@ var defaultSpotStrategies = []stratDef{
 	{ID: "vwap_reversion", ShortName: "vwap"},
 	{ID: "anchored_vwap", ShortName: "avwap"},
 	{ID: "anchored_vwap_channel", ShortName: "avwapch"},
+	{ID: "anchored_vwap_reversion", ShortName: "avwaprev"},
 	{ID: "chart_pattern", ShortName: "cpat"},
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 	{ID: "parabolic_sar", ShortName: "psar"},
@@ -204,6 +210,7 @@ var defaultPerpsStrategies = []stratDef{
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 	{ID: "anchored_vwap", ShortName: "avwap"},
 	{ID: "anchored_vwap_channel", ShortName: "avwapch"},
+	{ID: "anchored_vwap_reversion", ShortName: "avwaprev"},
 	{ID: "delta_neutral_funding", ShortName: "dnf"},
 	{ID: "funding_skew", ShortName: "fskew"},
 	{ID: "sweep_squeeze_combo", ShortName: "ssc"},
@@ -229,6 +236,7 @@ var defaultFuturesStrategies = []stratDef{
 	{ID: "vwap_reversion", ShortName: "vwap"},
 	{ID: "anchored_vwap", ShortName: "avwap"},
 	{ID: "anchored_vwap_channel", ShortName: "avwapch"},
+	{ID: "anchored_vwap_reversion", ShortName: "avwaprev"},
 	{ID: "chart_pattern", ShortName: "cpat"},
 	{ID: "liquidity_sweeps", ShortName: "liqsw"},
 	{ID: "parabolic_sar", ShortName: "psar"},

--- a/scheduler/init_anchored_vwap_reversion_test.go
+++ b/scheduler/init_anchored_vwap_reversion_test.go
@@ -1,0 +1,102 @@
+package main
+
+import "testing"
+
+func TestAnchoredVWAPReversionWiring(t *testing.T) {
+	if got := deriveShortName("anchored_vwap_reversion"); got != "avwaprev" {
+		t.Fatalf("deriveShortName(anchored_vwap_reversion) = %q, want avwaprev", got)
+	}
+	if !isBidirectionalPerpsStrategy("anchored_vwap_reversion") {
+		t.Fatal("anchored_vwap_reversion must be a bidirectional perps strategy (it shorts the upside stretch)")
+	}
+	lists := map[string][]stratDef{
+		"spot":    defaultSpotStrategies,
+		"perps":   defaultPerpsStrategies,
+		"futures": defaultFuturesStrategies,
+	}
+	for name, list := range lists {
+		found := false
+		for _, s := range list {
+			if s.ID == "anchored_vwap_reversion" {
+				found = true
+				if s.ShortName != "avwaprev" {
+					t.Fatalf("%s list: anchored_vwap_reversion short name = %q, want avwaprev", name, s.ShortName)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("anchored_vwap_reversion missing from default %s list", name)
+		}
+	}
+}
+
+// anchored_vwap_reversion fades ATR-measured stretches beyond the anchored
+// VWAP — mean reversion whose edge depends on ranging conditions, so init
+// pre-gates it to the composite quiet/volatile ranging substates exactly like
+// atr_band_revert and anchored_vwap_channel (ranging_directional stays
+// excluded: directional pressure inside a range is the breakout precursor,
+// mean reversion's worst case).
+
+func TestGenerateConfig_AnchoredVWAPReversion_DefaultsToCompositeRangingGate(t *testing.T) {
+	opts := baseOpts()
+	opts.Assets = []string{"BTC"}
+	opts.SpotStrategies = []string{"anchored_vwap_reversion"}
+
+	cfg := generateConfig(opts)
+
+	sc, ok := findStrategy(cfg, "avwaprev-btc")
+	if !ok {
+		t.Fatalf("expected strategy avwaprev-btc, got %v", cfg.Strategies)
+	}
+	want := []string{"ranging_quiet", "ranging_volatile"}
+	if len(sc.AllowedRegimes) != len(want) {
+		t.Fatalf("allowed_regimes = %v, want %v", sc.AllowedRegimes, want)
+	}
+	for i, l := range want {
+		if sc.AllowedRegimes[i] != l {
+			t.Fatalf("allowed_regimes[%d] = %q, want %q", i, sc.AllowedRegimes[i], l)
+		}
+	}
+
+	if cfg.Regime == nil || !cfg.Regime.Enabled {
+		t.Fatalf("expected cfg.Regime enabled, got %+v", cfg.Regime)
+	}
+	win, ok := cfg.Regime.Windows["medium"]
+	if !ok {
+		t.Fatalf("expected a composite 'medium' window, got windows %+v", cfg.Regime.Windows)
+	}
+	if win.effectiveClassifier() != regimeClassifierComposite {
+		t.Fatalf("medium window classifier = %q, want composite", win.effectiveClassifier())
+	}
+
+	if vErrs := validateStrategyRegimeVocabulary(cfg); len(vErrs) != 0 {
+		t.Fatalf("regime vocabulary errors: %v", vErrs)
+	}
+	if err := validateConfig(cfg, true); err != nil {
+		t.Fatalf("generated config failed validation: %v", err)
+	}
+}
+
+func TestGenerateConfig_AnchoredVWAPReversion_Perps_DefaultsToCompositeRangingGate(t *testing.T) {
+	opts := baseOpts()
+	opts.Assets = []string{"BTC"}
+	opts.EnableSpot = false
+	opts.EnablePerps = true
+	opts.PerpsStrategies = []string{"anchored_vwap_reversion"}
+
+	cfg := generateConfig(opts)
+
+	sc, ok := findStrategy(cfg, "hl-avwaprev-btc")
+	if !ok {
+		t.Fatalf("expected strategy hl-avwaprev-btc, got %v", cfg.Strategies)
+	}
+	if len(sc.AllowedRegimes) == 0 {
+		t.Fatalf("perps anchored_vwap_reversion should be regime-gated, got none")
+	}
+	if cfg.Regime == nil || !cfg.Regime.Enabled {
+		t.Fatalf("expected cfg.Regime enabled for perps anchored_vwap_reversion")
+	}
+	if err := validateConfig(cfg, true); err != nil {
+		t.Fatalf("generated perps config failed validation: %v", err)
+	}
+}

--- a/shared_strategies/open/anchored_vwap_reversion.py
+++ b/shared_strategies/open/anchored_vwap_reversion.py
@@ -1,0 +1,162 @@
+"""Anchored VWAP Reversion (AVWAP reversion) — mean-reversion TO the single
+pivot-anchored VWAP line: long a buffered snap-back from an ATR-measured
+stretch below the line, short the mirror stretch above it.
+
+Design: docs/superpowers/specs/2026-07-02-anchored-vwap-reversion-strategy-design.md
+
+Complementary to anchored_vwap (#1016), which trades a buffered breach
+*through* the same line — here every window bar must close strictly on the
+stretched side of the line (a reclaim kills the fire; that regime belongs to
+the flip strategy) — and to anchored_vwap_channel (#1169), which fades touches
+of its two anchored lines from inside the channel rather than an ATR-measured
+stretch beyond the one type-agnostic line.
+
+ATR is inlined (rolling-mean True Range, integer-round only when atr >= 100) to
+match standard_atr WITHOUT importing shared_tools — open strategies cannot
+assume shared_tools is on sys.path at module-load time (the registry parity test
+loads registry.py via importlib without it, so a top-level import would raise
+ModuleNotFoundError). The inline copy is byte-identical to standard_atr.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def _inline_atr(df: pd.DataFrame, period: int) -> pd.Series:
+    """ATR via simple rolling mean of True Range (standard_atr convention)."""
+    high = df["high"].astype(float)
+    low = df["low"].astype(float)
+    prev_close = df["close"].astype(float).shift(1)
+    tr = pd.concat(
+        [high - low, (high - prev_close).abs(), (low - prev_close).abs()],
+        axis=1,
+    ).max(axis=1)
+    atr = tr.rolling(window=period).mean()
+    return atr.where(atr < 100, atr.round(0))
+
+
+def anchored_vwap_reversion_core(
+    df: pd.DataFrame,
+    pivot_strength: int = 5,
+    entry_atr_mult: float = 1.5,
+    buffer_atr_mult: float = 0.25,
+    confirm_bars: int = 2,
+    atr_period: int = 14,
+) -> pd.DataFrame:
+    """Single-AVWAP stretch-and-snap-back reversion signals.
+
+    Parameters
+    ----------
+    df : OHLCV DataFrame (open, high, low, close, volume).
+    pivot_strength : bars required on EACH side of a swing pivot to confirm it
+        (strict max high / strict min low). A pivot at bar p is only knowable at
+        bar p + pivot_strength — the look-ahead guarantee.
+    entry_atr_mult : band distance — the trigger bar's extreme must reach
+        entry_atr_mult * ATR beyond the AVWAP before a fade is considered.
+    buffer_atr_mult : the trigger bar's close must recover back inside the band
+        by buffer_atr_mult * ATR (the snap-back confirmation).
+    confirm_bars : bars the close must hold inside the stretch zone — between
+        the band and the line — (inclusive of the trigger bar) before a signal
+        fires.
+    atr_period : lookback for the inline ATR.
+
+    Returns
+    -------
+    DataFrame with added columns:
+        signal       : +1 (downside stretch fading long), -1 (upside stretch
+                       fading short), 0 otherwise
+        avwap        : anchored VWAP (NaN before the first confirmed anchor)
+        anchor_index : bar index of the active anchor (-1 before the first one)
+        atr          : inline ATR
+    """
+    result = df.copy()
+    n = len(result)
+    result["signal"] = 0
+    result["avwap"] = np.nan
+    result["anchor_index"] = -1
+    result["atr"] = _inline_atr(result, atr_period)
+    if n < 2 * pivot_strength + 1 + confirm_bars:
+        return result
+
+    high = result["high"].astype(float).to_numpy()
+    low = result["low"].astype(float).to_numpy()
+
+    # --- strict swing pivots (unique max high / unique min low in window) ---
+    k = int(pivot_strength)
+    is_pivot = np.zeros(n, dtype=bool)
+    for i in range(k, n - k):
+        wh = high[i - k:i + k + 1]
+        wl = low[i - k:i + k + 1]
+        wmax = wh.max()
+        wmin = wl.min()
+        is_high = high[i] == wmax and int((wh == wmax).sum()) == 1
+        is_low = low[i] == wmin and int((wl == wmin).sum()) == 1
+        if is_high or is_low:
+            is_pivot[i] = True
+
+    # --- anchor in effect at each bar: most recent pivot confirmed by then.
+    # A pivot at p becomes knowable at bar p + k.
+    anchor = np.full(n, -1, dtype=int)
+    last = -1
+    for b in range(n):
+        p = b - k
+        if p >= 0 and is_pivot[p]:
+            last = p
+        anchor[b] = last
+    result["anchor_index"] = anchor
+
+    # --- AVWAP via global prefix sums (exact across re-anchors) ---
+    tp = ((result["high"] + result["low"] + result["close"]) / 3.0).to_numpy()
+    vol = result["volume"].astype(float).to_numpy()
+    pref_tpvol = np.concatenate([[0.0], np.cumsum(tp * vol)])  # pref[i] = sum first i
+    pref_vol = np.concatenate([[0.0], np.cumsum(vol)])
+    avwap = np.full(n, np.nan)
+    for b in range(n):
+        a = anchor[b]
+        if a < 0:
+            continue
+        num = pref_tpvol[b + 1] - pref_tpvol[a]
+        den = pref_vol[b + 1] - pref_vol[a]
+        avwap[b] = tp[b] if den <= 0 else num / den
+    result["avwap"] = avwap
+
+    # --- per-bar ATR bands around the live line ---
+    close = result["close"].astype(float).to_numpy()
+    atr_arr = result["atr"].to_numpy()
+    lower_band = avwap - entry_atr_mult * atr_arr
+    upper_band = avwap + entry_atr_mult * atr_arr
+
+    # --- trigger: stretch touch + buffered snap-back + zone hold, fire-once
+    # via fresh-touch clause. NaN bands (ATR warmup / no anchor) make every
+    # comparison false — fail quiet.
+    cb = int(confirm_bars)
+    sig = np.zeros(n, dtype=int)
+    for nbar in range(n):
+        b = nbar - cb + 1                       # window start (trigger bar)
+        if b - 1 < 0 or anchor[b] < 0 or anchor[b - 1] < 0:
+            continue                            # freshness reference needs a band too
+        if np.isnan(atr_arr[b]):
+            continue
+        buf = buffer_atr_mult * atr_arr[b]
+        win_c = close[b:nbar + 1]
+        # LONG: stretch touch below the lower band, buffered snap-back, every
+        # window close held between the band and the line (target not reached).
+        if (low[b] <= lower_band[b]
+                and close[b] >= lower_band[b] + buf
+                and np.all(win_c >= lower_band[b:nbar + 1])
+                and np.all(win_c < avwap[b:nbar + 1])
+                and low[b - 1] > lower_band[b - 1]):
+            sig[nbar] = 1
+            continue
+        # SHORT: mirror on the upper band.
+        if (high[b] >= upper_band[b]
+                and close[b] <= upper_band[b] - buf
+                and np.all(win_c <= upper_band[b:nbar + 1])
+                and np.all(win_c > avwap[b:nbar + 1])
+                and high[b - 1] < upper_band[b - 1]):
+            sig[nbar] = -1
+    result["signal"] = sig
+
+    return result

--- a/shared_strategies/open/registry.py
+++ b/shared_strategies/open/registry.py
@@ -56,6 +56,7 @@ from vwap_rejection_st import vwap_rejection_st_core
 from vol_momentum import vol_momentum_core
 from anchored_vwap import anchored_vwap_core
 from anchored_vwap_channel import anchored_vwap_channel_core
+from anchored_vwap_reversion import anchored_vwap_reversion_core
 
 
 VALID_PLATFORMS: Tuple[str, ...] = ("spot", "futures")
@@ -1156,6 +1157,21 @@ def anchored_vwap_channel_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
 
 
 @register(
+    "anchored_vwap_reversion",
+    "Anchored VWAP Reversion — fades an ATR-measured stretch beyond the pivot-anchored VWAP; long a buffered snap-back from below the band, short the mirror above",
+    {
+        "pivot_strength": 5,
+        "entry_atr_mult": 1.5,
+        "buffer_atr_mult": 0.25,
+        "confirm_bars": 2,
+        "atr_period": 14,
+    },
+)
+def anchored_vwap_reversion_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
+    return anchored_vwap_reversion_core(df, **params)
+
+
+@register(
     "momentum_pro",
     "Momentum Pro — trend-pullback entries in a stacked-EMA trend, ADX-confirmed, on a volume-backed resumption",
     {
@@ -1333,7 +1349,7 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "rsi_macd_combo", "stoch_rsi", "supertrend", "ichimoku_cloud",
         "pairs_spread", "squeeze_momentum", "atr_breakout", "amd_ifvg",
         "heikin_ashi_ema", "order_blocks", "vwap_reversion", "anchored_vwap",
-        "anchored_vwap_channel", "chart_pattern",
+        "anchored_vwap_channel", "anchored_vwap_reversion", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
         "sweep_squeeze_combo", "adx_trend", "donchian_breakout", "tema_cross",
         "momentum_pro", "mean_reversion_pro", "atr_band_revert", "mtf_confluence",
@@ -1346,7 +1362,7 @@ PLATFORM_ORDER: Dict[str, List[str]] = {
         "mean_reversion", "rsi", "macd", "breakout", "stoch_rsi", "supertrend",
         "squeeze_momentum", "ichimoku_cloud", "atr_breakout", "amd_ifvg",
         "heikin_ashi_ema", "order_blocks", "vwap_reversion", "anchored_vwap",
-        "anchored_vwap_channel", "chart_pattern",
+        "anchored_vwap_channel", "anchored_vwap_reversion", "chart_pattern",
         "liquidity_sweeps", "parabolic_sar", "range_scalper",
         "sweep_squeeze_combo", "adx_trend", "delta_neutral_funding",
         "funding_skew", "donchian_breakout", "session_breakout", "bear_pullback_st",

--- a/shared_strategies/open/test_anchored_vwap_reversion.py
+++ b/shared_strategies/open/test_anchored_vwap_reversion.py
@@ -1,0 +1,232 @@
+"""Tests for anchored_vwap_reversion.py — single-AVWAP stretch-fade strategy."""
+
+import importlib.util
+import os
+
+import numpy as np
+import pandas as pd
+
+from anchored_vwap_reversion import anchored_vwap_reversion_core
+
+
+def _hourly_index(n, start="2026-01-01 00:00:00"):
+    return pd.date_range(start, periods=n, freq="1h")
+
+
+def _ohlcv(closes, highs=None, lows=None, opens=None, volume=100.0):
+    closes = np.asarray(closes, dtype=float)
+    n = len(closes)
+    highs = closes + 0.5 if highs is None else np.asarray(highs, dtype=float)
+    lows = closes - 0.5 if lows is None else np.asarray(lows, dtype=float)
+    opens = closes if opens is None else np.asarray(opens, dtype=float)
+    vol = np.full(n, float(volume)) if np.isscalar(volume) else np.asarray(volume, dtype=float)
+    return pd.DataFrame(
+        {"open": opens, "high": highs, "low": lows, "close": closes, "volume": vol},
+        index=_hourly_index(n),
+    )
+
+
+_PARAMS = dict(pivot_strength=2, entry_atr_mult=1.0, buffer_atr_mult=0.0,
+               confirm_bars=2, atr_period=3)
+
+
+def _long_stretch_df():
+    """Swing low at 5 (conf. 7); bar 9 wicks through the lower ATR band and
+    closes back inside it — below the line; bar 10 holds in the zone -> +1 at 10."""
+    closes = [110, 108, 106, 104, 102, 100, 101, 102, 101, 100.2, 100.6]
+    lows = np.asarray(closes) - 0.5
+    lows[9] = 99.0
+    return _ohlcv(closes, lows=lows, volume=10.0)
+
+
+def _short_stretch_df():
+    """Swing high at 5 (conf. 7); bar 9 wicks through the upper ATR band and
+    closes back inside it — above the line; bar 10 holds in the zone -> -1 at 10."""
+    closes = [90, 92, 94, 96, 98, 100, 99, 98, 99, 99.8, 99.4]
+    highs = np.asarray(closes) + 0.5
+    highs[9] = 102.0
+    return _ohlcv(closes, highs=highs, volume=10.0)
+
+
+# --- scaffold + guards -----------------------------------------------------------
+
+def test_empty_and_short_df_return_zero_signal():
+    empty = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+    out = anchored_vwap_reversion_core(empty)
+    assert list(out["signal"]) == []
+    for col in ("avwap", "anchor_index", "atr"):
+        assert col in out.columns, col
+
+    short = _ohlcv(np.linspace(100, 101, 6))  # < 2*5+1+2
+    out = anchored_vwap_reversion_core(short)
+    assert (out["signal"] == 0).all()
+    assert (out["anchor_index"] == -1).all()
+
+
+# --- anchor index ----------------------------------------------------------------
+
+def test_anchor_confirms_at_pivot_plus_strength():
+    df = _long_stretch_df()
+    out = anchored_vwap_reversion_core(df, **_PARAMS)
+    anchor = out["anchor_index"].to_numpy()
+    # Low pivot at 5 confirms at 7; the bar-7 swing high (strict max of highs
+    # 5..9) re-anchors from its confirmation at 9. Bar 9's hand-set wick low
+    # would need bar 11 to confirm and the fixture ends at 10.
+    assert (anchor[:7] == -1).all()
+    assert anchor[7] == 5 and anchor[8] == 5
+    assert (anchor[9:] == 7).all()
+
+
+def test_no_signal_before_first_anchor():
+    # Monotonic decline: equal-step lows tie under the strict pivot rule, so
+    # nothing confirms and no stretch may fire however deep price falls.
+    closes = [110, 108, 106, 104, 102, 100, 98, 96, 94, 92, 90, 88]
+    out = anchored_vwap_reversion_core(_ohlcv(closes, volume=10.0), **_PARAMS)
+    assert (out["anchor_index"] == -1).all()
+    assert (out["signal"] == 0).all()
+
+
+# --- AVWAP -----------------------------------------------------------------------
+
+def test_avwap_matches_hand_computed_prefix_sum():
+    closes = [104, 106, 108, 106, 104, 102, 100, 102, 104, 106, 108, 110]
+    flat = np.asarray(closes, dtype=float)   # tp == close when high==low==close
+    df = _ohlcv(closes, highs=flat, lows=flat, volume=10.0)
+    out = anchored_vwap_reversion_core(df, pivot_strength=2, confirm_bars=2, atr_period=3)
+    avwap = out["avwap"].to_numpy()
+    # High pivot at 2 confirms at 4; low pivot at 6 re-anchors from bar 8.
+    assert np.isnan(avwap[:4]).all()
+    for nbar in (4, 5, 6, 7):
+        expected = np.mean(closes[2:nbar + 1])
+        assert abs(avwap[nbar] - expected) < 1e-9, (nbar, avwap[nbar], expected)
+    for nbar in (8, 9, 10, 11):
+        expected = np.mean(closes[6:nbar + 1])
+        assert abs(avwap[nbar] - expected) < 1e-9, (nbar, avwap[nbar], expected)
+
+
+def test_avwap_zero_volume_window_falls_back_to_typical():
+    closes = [104, 106, 108, 106, 104, 102, 100, 102, 104, 106, 108, 110]
+    df = _ohlcv(closes, volume=0.0)
+    out = anchored_vwap_reversion_core(df, pivot_strength=2, confirm_bars=2, atr_period=3)
+    tp = (df["high"] + df["low"] + df["close"]).to_numpy() / 3.0
+    avwap = out["avwap"].to_numpy()
+    for nbar in range(4, 12):
+        assert abs(avwap[nbar] - tp[nbar]) < 1e-9
+
+
+# --- triggers --------------------------------------------------------------------
+
+def test_long_stretch_fires_once_on_completing_bar():
+    out = anchored_vwap_reversion_core(_long_stretch_df(), **_PARAMS)
+    sig = out["signal"].to_numpy()
+    assert sig[10] == 1
+    assert (sig == 1).sum() == 1
+    assert (sig == -1).sum() == 0
+    # The trigger bar (9) wicked through the band the prior bar (8) did not touch,
+    # and both window closes held below the line (the target not yet reached).
+    avwap = out["avwap"].to_numpy()
+    atr = out["atr"].to_numpy()
+    low = out["low"].to_numpy()
+    close = out["close"].to_numpy()
+    lower_band = avwap - _PARAMS["entry_atr_mult"] * atr
+    assert low[9] <= lower_band[9]
+    assert low[8] > lower_band[8]
+    assert close[9] < avwap[9] and close[10] < avwap[10]
+
+
+def test_short_stretch_mirrors():
+    out = anchored_vwap_reversion_core(_short_stretch_df(), **_PARAMS)
+    sig = out["signal"].to_numpy()
+    assert sig[10] == -1
+    assert (sig == -1).sum() == 1
+    assert (sig == 1).sum() == 0
+    avwap = out["avwap"].to_numpy()
+    atr = out["atr"].to_numpy()
+    high = out["high"].to_numpy()
+    close = out["close"].to_numpy()
+    upper_band = avwap + _PARAMS["entry_atr_mult"] * atr
+    assert high[9] >= upper_band[9]
+    assert high[8] < upper_band[8]
+    assert close[9] > avwap[9] and close[10] > avwap[10]
+
+
+def test_no_snap_back_keeps_falling_knife_unfaded():
+    """The trigger bar closes BELOW the band (stretch without recovery): the
+    snap-back clause alone must hold the signal at 0 — the falling-knife guard."""
+    closes = [110, 108, 106, 104, 102, 100, 101, 102, 101, 97.5, 97.9]
+    lows = np.asarray(closes) - 0.5
+    lows[9] = 97.0
+    df = _ohlcv(closes, lows=lows, volume=10.0)
+    out = anchored_vwap_reversion_core(df, **_PARAMS)
+    # Non-vacuity: the touch clause genuinely holds at the would-be trigger bar...
+    avwap = out["avwap"].to_numpy()
+    atr = out["atr"].to_numpy()
+    lower_band = avwap - _PARAMS["entry_atr_mult"] * atr
+    assert df["low"].to_numpy()[9] <= lower_band[9]
+    # ...but the close never recovered back inside the band.
+    assert df["close"].to_numpy()[9] < lower_band[9]
+    assert (out["signal"] == 0).all()
+
+
+def test_line_reclaim_during_hold_kills_the_fire():
+    """The hold bar closes back ABOVE the line: the reversion opportunity is
+    gone (flip territory), so the zone-hold clause must hold the signal at 0."""
+    closes = [110, 108, 106, 104, 102, 100, 101, 102, 101, 100.2, 101.5]
+    lows = np.asarray(closes) - 0.5
+    lows[9] = 99.0
+    df = _ohlcv(closes, lows=lows, volume=10.0)
+    out = anchored_vwap_reversion_core(df, **_PARAMS)
+    # Non-vacuity: identical trigger-bar geometry to the firing fixture...
+    avwap = out["avwap"].to_numpy()
+    atr = out["atr"].to_numpy()
+    lower_band = avwap - _PARAMS["entry_atr_mult"] * atr
+    close = df["close"].to_numpy()
+    assert df["low"].to_numpy()[9] <= lower_band[9]
+    assert close[9] >= lower_band[9]
+    assert close[9] < avwap[9]
+    # ...but bar 10 closed above the live line.
+    assert close[10] >= avwap[10]
+    assert (out["signal"] == 0).all()
+
+
+def test_buffer_blocks_shallow_snap_back():
+    # Same stretch geometry, but demand a recovery margin the trigger bar's
+    # close cannot meet -> no signal anywhere.
+    out = anchored_vwap_reversion_core(
+        _long_stretch_df(), pivot_strength=2, entry_atr_mult=1.0,
+        buffer_atr_mult=5.0, confirm_bars=2, atr_period=3)
+    assert (out["signal"] == 0).all()
+
+
+def test_nan_atr_warmup_yields_no_signal():
+    out = anchored_vwap_reversion_core(
+        _long_stretch_df(), pivot_strength=2, entry_atr_mult=1.0,
+        buffer_atr_mult=0.0, confirm_bars=2, atr_period=99)
+    assert (out["signal"] == 0).all()
+
+
+# --- registry --------------------------------------------------------------------
+
+def _load_registry():
+    here = os.path.dirname(os.path.abspath(__file__))
+    spec = importlib.util.spec_from_file_location(
+        "_reg_under_test_avwap_reversion", os.path.join(here, "registry.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_registered_for_spot_and_futures():
+    reg = _load_registry()
+    for platform in ("spot", "futures"):
+        assert "anchored_vwap_reversion" in reg.build_registry(platform), platform
+        assert "anchored_vwap_reversion" in reg.PLATFORM_ORDER[platform], platform
+
+
+def test_registered_fn_applies_via_registry():
+    reg = _load_registry()
+    entry = reg.STRATEGIES["anchored_vwap_reversion"]
+    df = _long_stretch_df()
+    out = entry["fn"](df, **entry["default_params"])
+    assert "signal" in out.columns


### PR DESCRIPTION
Closes #1170

## What

Registers `anchored_vwap_reversion` — the third AVWAP open strategy (umbrella #1017): mean-reversion **to** the single pivot-anchored VWAP line. When price stretches at least `entry_atr_mult × ATR` beyond the line and snaps back inside the band without reclaiming the line, it enters toward the line: long a downside stretch, short the mirror.

Trigger = **stretch touch + buffered snap-back + zone hold** (every window close held between the band and the line), reusing the #1016/#1169 clause vocabulary. The zone hold makes it per-bar disjoint from `anchored_vwap`'s breach trade and adds the falling-knife guard `vwap_reversion`'s raw band-cross lacks.

## Spec-time decisions (recorded in `docs/superpowers/specs/2026-07-02-anchored-vwap-reversion-strategy-design.md`)

- **Band type: ATR** (not std-dev) — family consistency; anchor-window std-dev is degenerate right after a re-anchor (1–3 samples).
- **Short leg: yes, symmetric** — joins `bidirectionalPerpsStrategies` and `LIVE_BIDIRECTIONAL_STRATEGIES` (`backtest/fee_audit.py`).
- **Channel differentiation (#1169):** channel fades touches of its two anchored lines from inside; this fades an ATR-measured stretch beyond the one type-agnostic line — disjoint trigger geometry, same portfolio class.
- **Ranging gate: yes** — joins `strategiesDefaultingToCompositeRangingGate` with `{ranging_quiet, ranging_volatile}`.

## Wiring

- `shared_strategies/open/anchored_vwap_reversion.py` (new core), registry `register()` + `PLATFORM_ORDER` (spot + futures)
- `scheduler/init.go`: `knownShortNames` (`avwaprev`), `bidirectionalPerpsStrategies`, `strategiesDefaultingToCompositeRangingGate`, all three default lists
- `backtest/optimizer.py` `DEFAULT_PARAM_RANGES`; `backtest/fee_audit.py` bidirectional set (Go↔Python parity test covers it)

## Verification

- Python: full suite `shared_strategies/ shared_tools/ platforms/ backtest/` — **2139 passed**
- Go: `go -C scheduler test ./... -count=1` — **ok** (new wiring + generateConfig ranging-gate tests mirroring the #1169 ones)
- Look-ahead: new `test_anchored_vwap_reversion_no_lookahead` with non-vacuity (+1 and −1 in fixture), sensitivity (forward-peeking variant must fail), and the full prefix sweep
- Guard tests are non-vacuous: the falling-knife fixture genuinely satisfies the touch clause and originally fired without the snap-back clause; the line-reclaim fixture shares the firing geometry
- `--list-json` snapshot diff (spot + futures): exactly the one new entry, rest byte-identical
- Backtest sanity (spec §10): long leg 254+ trades, short leg 260 trades on BTC/USDT 1h — both legs wired and trading

---
Created with LLM: Fable 5 | high | Harness: Claude Code
