### PR TITLE
fix(#1190): give the kill-switch reset DM real context

### DIFF
--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -731,4 +733,45 @@ func formatKillSwitchMessage(hlAddr string, plan KillSwitchClosePlan, portfolioR
 	}
 
 	return fmt.Sprintf("**PORTFOLIO KILL SWITCH (LATCHED, RETRYING)**\n%s\n%s. Virtual state preserved. Next cycle will retry.", portfolioReason, strings.Join(segments, " | "))
+}
+
+// killSwitchInstanceLabel derives a human-readable identifier for this
+// trader process from its config file path, so operator-facing kill-switch
+// messages can distinguish between concurrent deployments (e.g. live vs.
+// paper, or per-asset instances under systemd/go-trader@.service %i, whose
+// out-of-tree config lives at /var/lib/go-trader/<instance>/config.json —
+// see #1056). Falls back to the hostname, then a static default, when the
+// config path itself gives nothing useful (e.g. the repo-relative dev
+// default "scheduler/config.json").
+func killSwitchInstanceLabel(configPath string) string {
+	dir := filepath.Base(filepath.Dir(configPath))
+	if dir != "" && dir != "." && dir != string(filepath.Separator) {
+		return dir
+	}
+	if host, err := os.Hostname(); err == nil && host != "" {
+		return host
+	}
+	return "go-trader"
+}
+
+// formatKillSwitchResetPrompt builds the DM sent to solicit the operator's
+// 'reset' reply (#1190). It reuses the same reason/close-report context
+// already broadcast to all channels via formatKillSwitchMessage
+// (plan.DiscordMessage) — the bare "Kill switch active..." sentence this
+// replaces carried none of that context — and states plainly what 'reset'
+// does and does not do: it only clears the KillSwitchActive latch (see
+// main.go), never itself opening, closing, or protecting a position. When
+// the close plan hasn't confirmed flat (LATCHED, RETRYING), resting
+// stop-losses may already have been cancelled ahead of the flatten attempt,
+// so the prompt must not imply positions are still protected in that state.
+func formatKillSwitchResetPrompt(instanceLabel, hlAddr string, plan KillSwitchClosePlan) string {
+	identity := instanceLabel
+	if hlAddr != "" {
+		identity = fmt.Sprintf("%s (Hyperliquid %s)", identity, hlAddr)
+	}
+	resetNote := "Replying 'reset' only clears the kill switch latch so trading can resume next cycle — it does not itself close or protect any position."
+	if !plan.OnChainConfirmedFlat {
+		resetNote += " On-chain close is still retrying and resting stop-losses may already be cancelled ahead of the flatten attempt — verify positions manually before assuming they're protected."
+	}
+	return fmt.Sprintf("[KILL SWITCH] %s\n%s\n\n%s\nReply 'reset' to proceed.", identity, plan.DiscordMessage, resetNote)
 }

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -2012,3 +2012,90 @@ func TestPlanKillSwitchClose_TSFetcherUnwiredLatches(t *testing.T) {
 		t.Errorf("expected log line mentioning TSFetcher unwired, got: %v", plan.LogLines)
 	}
 }
+
+// #1190: killSwitchInstanceLabel derives an operator-facing identifier from
+// the deployed config path so concurrent instances (live vs. paper, or
+// per-asset systemd %i deployments) are distinguishable in kill-switch DMs.
+func TestKillSwitchInstanceLabel_UsesConfigDirBasename(t *testing.T) {
+	got := killSwitchInstanceLabel("/var/lib/go-trader/live/config.json")
+	if got != "live" {
+		t.Errorf("killSwitchInstanceLabel(.../live/config.json) = %q, want %q", got, "live")
+	}
+	got = killSwitchInstanceLabel("/var/lib/go-trader/paper-hl-eth/config.json")
+	if got != "paper-hl-eth" {
+		t.Errorf("killSwitchInstanceLabel(.../paper-hl-eth/config.json) = %q, want %q", got, "paper-hl-eth")
+	}
+}
+
+func TestKillSwitchInstanceLabel_FallsBackWhenPathGivesNothingUseful(t *testing.T) {
+	// A bare filename ("config.json") has a "." dir component; must not
+	// surface that as the label — fall back to hostname or the static default.
+	got := killSwitchInstanceLabel("config.json")
+	if got == "." {
+		t.Errorf("killSwitchInstanceLabel(%q) = %q, want a real fallback, not \".\"", "config.json", got)
+	}
+	if got == "" {
+		t.Error("killSwitchInstanceLabel must never return an empty label")
+	}
+}
+
+// #1190: formatKillSwitchResetPrompt replaces the old bare "Kill switch
+// active. Reply 'reset' to resume trading." sentence with a message that
+// carries the same reason/close-report context already broadcast via
+// formatKillSwitchMessage, plus identity and accurate reset semantics.
+func TestFormatKillSwitchResetPrompt_ConfirmedFlatIncludesContextAndIdentity(t *testing.T) {
+	plan := KillSwitchClosePlan{
+		OnChainConfirmedFlat: true,
+		DiscordMessage:       "**PORTFOLIO KILL SWITCH**\nportfolio drawdown 25.0% exceeds limit 20.0%\nHL closes: [ETH]. Virtual state cleared. Manual reset required.",
+	}
+
+	got := formatKillSwitchResetPrompt("live", "0xabc123", plan)
+
+	if !strings.Contains(got, "live") || !strings.Contains(got, "0xabc123") {
+		t.Errorf("expected instance label and HL address in prompt, got: %s", got)
+	}
+	if !strings.Contains(got, "portfolio drawdown 25.0%") {
+		t.Errorf("expected reused drawdown reason in prompt, got: %s", got)
+	}
+	if !strings.Contains(got, "HL closes: [ETH]") {
+		t.Errorf("expected reused close report in prompt, got: %s", got)
+	}
+	if !strings.Contains(got, "does not itself close or protect any position") {
+		t.Errorf("expected explicit reset semantics in prompt, got: %s", got)
+	}
+	if strings.Contains(got, "still retrying") {
+		t.Errorf("confirmed-flat prompt must not claim the close is still retrying, got: %s", got)
+	}
+}
+
+func TestFormatKillSwitchResetPrompt_LatchedRetryingWarnsProtectionMayBeGone(t *testing.T) {
+	plan := KillSwitchClosePlan{
+		OnChainConfirmedFlat: false,
+		DiscordMessage:       "**PORTFOLIO KILL SWITCH (LATCHED, RETRYING)**\nportfolio drawdown 25.0% exceeds limit 20.0%\nHL live close errors — ETH: timeout. Virtual state preserved. Next cycle will retry.",
+	}
+
+	got := formatKillSwitchResetPrompt("live", "0xabc123", plan)
+
+	if !strings.Contains(got, "still retrying") {
+		t.Errorf("expected a not-yet-confirmed-flat warning in prompt, got: %s", got)
+	}
+	if !strings.Contains(got, "stop-losses may already be cancelled") {
+		t.Errorf("expected the naked-stop-loss risk to be called out while retrying, got: %s", got)
+	}
+}
+
+func TestFormatKillSwitchResetPrompt_OmitsAddressWhenHLNotConfigured(t *testing.T) {
+	plan := KillSwitchClosePlan{
+		OnChainConfirmedFlat: true,
+		DiscordMessage:       "**PORTFOLIO KILL SWITCH**\nreason\nHL not configured. Virtual state cleared. Manual reset required.",
+	}
+
+	got := formatKillSwitchResetPrompt("paper-hl-eth", "", plan)
+
+	if strings.Contains(got, "Hyperliquid ") && strings.Contains(got, "()") {
+		t.Errorf("expected no dangling empty-address parenthetical, got: %s", got)
+	}
+	if !strings.Contains(got, "paper-hl-eth") {
+		t.Errorf("expected instance label present regardless of HL address, got: %s", got)
+	}
+}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1349,9 +1349,10 @@ func main() {
 			// Kill switch reset goroutine: prompt owner to reset via DM.
 			if killSwitchFired && notifier.HasOwner() && !resetGoroutineRunning {
 				resetGoroutineRunning = true
+				resetPrompt := formatKillSwitchResetPrompt(killSwitchInstanceLabel(*configPath), hlAddr, plan)
 				go func() {
 					defer func() { resetGoroutineRunning = false }()
-					resp, err := notifier.AskOwnerDM("Kill switch active. Reply 'reset' to resume trading.", 30*time.Minute)
+					resp, err := notifier.AskOwnerDM(resetPrompt, 30*time.Minute)
 					if err != nil {
 						fmt.Printf("[update] Kill switch reset DM timed out or failed: %v\n", err)
 						return


### PR DESCRIPTION
## Summary

- The DM the scheduler sends to ask the owner to reply 'reset' after the portfolio-wide kill switch fires was a bare "Kill switch active. Reply 'reset' to resume trading." — no drawdown reason, no account identity, no trading instance, no explanation of what 'reset' does or doesn't do.
- `formatKillSwitchResetPrompt` (`scheduler/kill_switch_close.go`) now reuses the same reason/close-report context already broadcast to Discord via `formatKillSwitchMessage`, prefixes it with a trader-instance label (`killSwitchInstanceLabel`, derived from the deployed config path, e.g. `/var/lib/go-trader/<instance>/config.json`) and the Hyperliquid wallet address, and states plainly that 'reset' only clears the kill-switch latch — it never itself closes or protects a position.
- When the close plan hasn't confirmed flat (LATCHED, RETRYING), the prompt also warns that resting stop-losses may already be cancelled ahead of the flatten attempt, so the owner doesn't assume protection is still in place.
- This kill switch is account/process-wide (a single `PortfolioRisk.KillSwitchActive` flag) — there is no per-strategy variant, so the message intentionally does not attribute the trigger to a strategy.

## Test plan

- [x] `go build ./...` from `scheduler/`
- [x] `go vet ./...`
- [x] `gofmt -l` on changed files (clean)
- [x] `go test ./...` (full suite passes)
- [x] New regression tests (`TestKillSwitchInstanceLabel_*`, `TestFormatKillSwitchResetPrompt_*`) proven red on the unfixed code (compile failure without the new functions), green after the fix

Closes #1190

---
Created with LLM: Sonnet 5 | high | Harness: Claude Code
