### PR TITLE
fix(#1189): show a strategy's gate-window regime in status/dashboard, not the shared default

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2489,7 +2489,7 @@ func main() {
 					pv = displayStrategyValue(stratState, prices)
 					posCount := len(stratState.Positions) + len(stratState.OptionPositions)
 					cash := stratState.Cash
-					regimeLabel := stratState.Regime
+					regimeLabel := strategyDisplayRegimeLabel(stratState, sc, cfg.Regime)
 					mu.RUnlock()
 
 					logger.Info("%s", formatStatusLine(cash, posCount, pv, trades, regimeLabel))

--- a/scheduler/regime_multi_window.go
+++ b/scheduler/regime_multi_window.go
@@ -502,6 +502,32 @@ func strategyCurrentDirectionalRegime(stratState *StrategyState, sc StrategyConf
 	return strings.TrimSpace(stratState.Regime)
 }
 
+// strategyDisplayRegimeLabel resolves the regime label for operator-facing
+// status surfaces (Phase 6 status log, /status API, dashboard) using the
+// strategy's configured gate window (regime_gate_window) instead of the
+// shared-default window, so the displayed label matches what the strategy's
+// entry gate is actually evaluating (#1189).
+//
+// Display-only: stratState.Regime itself must stay untouched. It is also the
+// live fallback consulted by strategyCurrentDirectionalRegime/
+// strategyCurrentATRRegime whenever regime_directional_window/regime_atr_window
+// is left unset, which feeds the #822 orphan auto-close and dynamic-regime
+// close SL/TP tier resolution — repointing the shared field itself (rather
+// than adding this separate resolver) would silently change those live
+// trading decisions for any strategy overriding only regime_gate_window.
+func strategyDisplayRegimeLabel(stratState *StrategyState, sc StrategyConfig, rc *RegimeConfig) string {
+	if stratState == nil {
+		return ""
+	}
+	key := normalizeRegimeWindowKey(sc.RegimeGateWindow)
+	if key != "" && key != regimeWindowDefaultKey && len(stratState.RegimeWindows) > 0 {
+		if label, ok := stratState.RegimeWindows[key]; ok && strings.TrimSpace(label) != "" {
+			return strings.TrimSpace(label)
+		}
+	}
+	return strings.TrimSpace(stratState.Regime)
+}
+
 func positionCtxForCheck(sc StrategyConfig, pos *Position, regime *RegimeConfig) PositionCtx {
 	ctx := positionCtxFromPosition(pos)
 	if pos == nil {

--- a/scheduler/regime_multi_window_test.go
+++ b/scheduler/regime_multi_window_test.go
@@ -200,3 +200,74 @@ func TestValidateRegimeWindowsConfig_RejectsReservedWindowName(t *testing.T) {
 		t.Fatalf("errs = %v", errs)
 	}
 }
+
+// #1189: the operator-facing display label must match the strategy's
+// configured gate window, not the shared-default window used for
+// stratState.Regime.
+func TestStrategyDisplayRegimeLabel_UsesGateWindowOverride(t *testing.T) {
+	sc := StrategyConfig{RegimeGateWindow: "composite_long"}
+	st := &StrategyState{
+		Regime: "ranging", // shared-default ("medium") window label
+		RegimeWindows: map[string]string{
+			"medium":         "ranging",
+			"composite_long": "trending_down_choppy",
+		},
+	}
+	if got := strategyDisplayRegimeLabel(st, sc, nil); got != "trending_down_choppy" {
+		t.Fatalf("strategyDisplayRegimeLabel = %q, want trending_down_choppy", got)
+	}
+}
+
+func TestStrategyDisplayRegimeLabel_FallsBackWhenGateWindowUnset(t *testing.T) {
+	sc := StrategyConfig{} // no regime_gate_window override
+	st := &StrategyState{
+		Regime:        "ranging",
+		RegimeWindows: map[string]string{"medium": "ranging", "composite_long": "trending_down_choppy"},
+	}
+	if got := strategyDisplayRegimeLabel(st, sc, nil); got != "ranging" {
+		t.Fatalf("strategyDisplayRegimeLabel = %q, want ranging (fallback to shared default)", got)
+	}
+}
+
+func TestStrategyDisplayRegimeLabel_FallsBackWhenWindowLabelMissing(t *testing.T) {
+	sc := StrategyConfig{RegimeGateWindow: "composite_long"}
+	st := &StrategyState{
+		Regime:        "ranging",
+		RegimeWindows: map[string]string{"medium": "ranging"}, // composite_long not populated yet
+	}
+	if got := strategyDisplayRegimeLabel(st, sc, nil); got != "ranging" {
+		t.Fatalf("strategyDisplayRegimeLabel = %q, want ranging (fallback, gate label not yet captured)", got)
+	}
+}
+
+func TestStrategyDisplayRegimeLabel_NilStratState(t *testing.T) {
+	sc := StrategyConfig{RegimeGateWindow: "composite_long"}
+	if got := strategyDisplayRegimeLabel(nil, sc, nil); got != "" {
+		t.Fatalf("strategyDisplayRegimeLabel = %q, want empty", got)
+	}
+}
+
+// #1189 regression: a strategy that overrides ONLY regime_gate_window must
+// keep resolving its ATR/directional fallbacks (and therefore the #822
+// orphan-close and dynamic-regime-close tier resolution) from the shared
+// stratState.Regime — strategyDisplayRegimeLabel must never be substituted
+// into those call sites.
+func TestStrategyDisplayRegimeLabel_DoesNotAffectATRDirectionalFallbacks(t *testing.T) {
+	sc := StrategyConfig{RegimeGateWindow: "composite_long"} // ATR/directional windows left unset
+	st := &StrategyState{
+		Regime: "ranging",
+		RegimeWindows: map[string]string{
+			"medium":         "ranging",
+			"composite_long": "trending_down_choppy",
+		},
+	}
+	if got := strategyDisplayRegimeLabel(st, sc, nil); got != "trending_down_choppy" {
+		t.Fatalf("display label = %q, want trending_down_choppy", got)
+	}
+	if got := strategyCurrentATRRegime(st, sc); got != "ranging" {
+		t.Fatalf("strategyCurrentATRRegime = %q, want ranging (unaffected shared-default fallback)", got)
+	}
+	if got := strategyCurrentDirectionalRegime(st, sc); got != "ranging" {
+		t.Fatalf("strategyCurrentDirectionalRegime = %q, want ranging (unaffected shared-default fallback)", got)
+	}
+}

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -403,7 +403,7 @@ func (ss *StatusServer) handleStatus(w http.ResponseWriter, r *http.Request) {
 			PnL:                            pnl,
 			PnLPct:                         pnlPct,
 			RiskState:                      s.RiskState,
-			Regime:                         s.Regime,
+			Regime:                         strategyDisplayRegimeLabel(s, sc, ss.regime),
 			BaseDirection:                  baseDir,
 			BaseInvertSignal:               baseInvert,
 			EffectiveDirection:             effDir,

--- a/scheduler/ui_server.go
+++ b/scheduler/ui_server.go
@@ -459,7 +459,7 @@ func (ss *StatusServer) uiStrategyOverview(id string) (UIStrategyOverview, Lifet
 		PnLPct:           pnlPct,
 		WinRate:          winRate,
 		Sharpe:           sharpe,
-		Regime:           snapshot.Regime,
+		Regime:           strategyDisplayRegimeLabel(&snapshot, sc, ss.regime),
 		Direction:        strategyDisplayDirection(sc),
 		PnL:              pnl,
 		PortfolioValue:   pv,


### PR DESCRIPTION
## Summary

Fixes the mismatch between a strategy's displayed regime (status log, `/status` API, dashboard) and the regime its entry gate actually evaluates when `regime_gate_window` is overridden.

- `stratState.Regime` always carried the shared-default window's label (`primaryRegimeWindowKey`, "medium" when configured), regardless of a strategy's `regime_gate_window` override — so the operator-facing display could show a stale/wrong regime while the strategy correctly traded on its configured window.
- The original issue's suggested fix (repoint `stratState.Regime` itself) is unsafe: that field is also the live fallback used by `strategyCurrentDirectionalRegime`/`strategyCurrentATRRegime` whenever `regime_directional_window`/`regime_atr_window` is left unset — which feeds the `#822` orphan auto-close and the dynamic-regime-close SL/TP tier resolution. Repointing it would silently change those trading decisions for any strategy overriding only `regime_gate_window`.
- Instead, this adds `strategyDisplayRegimeLabel` — a display-only resolver (same pattern as the existing per-field fallbacks) that reads the strategy's gate-window label from `stratState.RegimeWindows` (already populated with every window's label) and falls back to `stratState.Regime` when unset — and wires it into the three operator-facing surfaces only: the Phase 6 status log (`main.go`), `StratStatus.Regime` (`/status` API, `server.go`), and `UIStrategyOverview.Regime` (dashboard, `ui_server.go`). `stratState.Regime` itself is untouched.

## Test plan

- [x] `go build .` (from `scheduler/`)
- [x] `go test ./...` (scheduler package, full suite) — passing
- [x] New regression tests in `regime_multi_window_test.go` cover: gate-window override resolves correctly, fallback when unset, fallback when the gate window's label hasn't been captured yet, nil state, and — critically — that `strategyCurrentATRRegime`/`strategyCurrentDirectionalRegime` (the #822/dynamic-tier fallbacks) are unaffected by the new resolver

Closes #1189

---
Created with LLM: Sonnet 5 | high | Harness: Claude Code
