### PR TITLE
research(#1165): breakout regime-gate M4 — positive result; composite trending_up_clean p21 clears the bar

### DIFF
--- a/backtest/candidates/breakout_1165/README.md
+++ b/backtest/candidates/breakout_1165/README.md
@@ -1,0 +1,210 @@
+# breakout (futures) regime-gate work — entry frozen (#1165, M4)
+
+Application of **M4 (regime gating / regime-profile allocation)** to the
+registry's second-ranked entry (#956: +47.5pts vs B&H, -52.2% worst max DD on
+the default open-signal-as-close stack), the follow-on the #984 verdict named:
+the DD is regime exposure, not exit quality, so the sweep is over **when the
+entry may fire**, not how it exits. Entry logic, params, and the close stack
+are frozen throughout (registry defaults, open-signal-as-close, no SL/TP —
+the only protocol IS+OOS pass per #984); same two load-bearing deltas as
+`breakout_984/`: every driver loads the **futures registry** and pins
+**`direction="long"`** (#996).
+
+**Result: positive — the first arm in the #983/#984/#985/#1165 series to
+clear the bar.** The composite `trending_up_clean` gate at classifier period
+21 keeps the protocol IS+OOS pass (the #984 failure point: every close stack
+lost the judged OOS window), flips 2025H1 to PASS (held-out 1/3 vs baseline
+0/3), and on the mandatory stitched audit frame cuts worst DD **-52.2% →
+-23.2%** while *raising* vs-B&H **+43.7 → +56.3pts** — with fee drag down
+14.3pp → 3.8pp on 67 trades vs 260. The #984 inversion (bull-year fixes
+amputate the crash edge) does not bite: the gate skips the bear-tape
+re-entries instead of banking trends early.
+
+**Structural notes (read before comparing rows).**
+
+- The regime gate blocks **entries only** — closes always execute — so the
+  frozen breakdown exit survives under every Arm A candidate
+  (`backtester.py` regime-gate block; the #984 `atr_stop` control showed
+  replacing that exit is strictly harmful).
+- The #998 M4 switch (Arm B) commits **only from flat** (confirm_bars 2), so
+  a position opened under the "on" profile keeps its opening profile's
+  breakdown exit until it closes; the "off" profile
+  (`atr_multiplier: 100.0`) zeroes new entries, not exits.
+- **The naive "block bear entries" hypothesis is refuted** (the caution the
+  issue flagged, in the opposite direction): `adx_not_down` /
+  `comp_not_down` sit at baseline (breakout's TR-expansion entry bars label
+  as *trending/up* even in bear tapes — dead-cat rallies — so "not down"
+  sets block almost nothing; `comp_up_family` blocks literally nothing at
+  period 14, 148/148 trades). What separates the bleed from the edge is
+  trend **quality**: the `clean` vs `choppy` efficiency split, not up vs
+  down direction.
+
+Every committed artifact regenerates from the repo root with the cache DB
+present (`shared_tools/trading_bot.db`) via one of the four committed drivers
+(`sweep_regime_gates.py`, `validate_shortlist.py`, `audit_headline.py`,
+`fee_drag.py`) — each section below states its exact command. Candidate
+regime state (`allowed_regimes` / `regime_windows_spec` /
+`profile_allocation`) is threaded into every leg by
+`driver_common.candidate_leg_kwargs` (unit-tested in
+`backtest/tests/test_breakout_1165_drivers.py`) — unlike the #984 twins, a
+driver here that dropped it would silently score the ungated entry. Protocol
+windows (`is`, `oos`, held-out) are date-pinned; the continuous audit window
+ends at the latest cache by default, so `audit_headline.py` records the
+effective per-dataset data range in its artifact — diff that against the
+committed file before comparing numbers regenerated under a fresher cache
+(committed `effective_range` pins last bars 2026-06-04 → 2026-06-12 per
+dataset, the same cache as `breakout_984/`).
+
+## Step 1 — M4 screen on IS (selection window only)
+
+Both arms, one screen: Arm A gates entries by regime label
+(`allowed_regimes`; legacy ADX and composite 9-state classifiers via
+`regime_windows_spec`, #1058/#1124 — the `comp_not_down` sets use the bare
+`ranging_directional` per bare-covers-subs), Arm B switches the entry's
+param set by regime (#998 two-profile allocation, ADX and composite switch
+windows).
+
+```
+uv run --no-sync python backtest/candidates/breakout_1165/sweep_regime_gates.py \
+    --window is --json backtest/candidates/breakout_1165/sweep_is.json
+```
+
+| IS rank (mean DDadj) | DDadj | Sharpe | ret% | worst DD% | #T |
+|---|---:|---:|---:|---:|---:|
+| `comp_up_clean` (composite p14, `trending_up_clean`) | +0.658 | +0.56 | +11.08 | -32.7 | 45 |
+| `m4_bear_selective` (ADX switch; off = lookback 55 / mult 2.5) | +0.617 | +0.35 | +9.41 | -39.6 | 118 |
+| `m4_bear_off` (ADX switch; off = no entries) | +0.552 | +0.25 | +7.25 | -39.6 | 125 |
+| `m4_trend_only` | +0.391 | +0.41 | +8.99 | -29.1 | 79 |
+| `m4_comp_bear_off` | +0.361 | -0.04 | +2.58 | -52.2 | 147 |
+| `adx_not_down` | +0.335 | +0.04 | +3.61 | -46.0 | 144 |
+| `adx_up` | +0.317 | +0.13 | +5.41 | -37.0 | 112 |
+| `adx_trend_only` | +0.315 | +0.03 | +4.11 | -44.2 | 117 |
+| baseline (ungated) | +0.308 | -0.06 | +1.94 | -52.2 | 148 |
+| `comp_not_down` | +0.308 | -0.06 | +1.94 | -52.2 | 148 |
+| `comp_up_family` / `comp_not_down_calm` / `comp_up_plus_dir_up` | +0.280 | -0.10 | +1.14 | -52.2 | 148 |
+
+The composite `clean`-only gate is the standout screen (3× baseline DDadj on
+30% of the trades); the ADX-window M4 switches beat baseline but keep most of
+the churn; every "block down / not-down" variant is baseline-flat (see
+structural note).
+
+## Step 2 — plateau checks (M1 step 6, IS only)
+
+```
+uv run --no-sync python backtest/candidates/breakout_1165/sweep_regime_gates.py \
+    --window is --grid plateau-only \
+    --comp-plateau-allowed trending_up_clean --plateau-allowed trending_up \
+    --json backtest/candidates/breakout_1165/plateau_is.json
+```
+
+- **Composite classifier period, `trending_up_clean` gate**: p10 +0.272,
+  p14 +0.658, **p21 +1.172**, p28 +0.765 — a 14–28 shelf all above
+  baseline's +0.308 (p10 falls off), not a single-cell spike; p21 is the
+  peak (Sharpe +0.69, ret +13.76%, worst DD -23.2%, 36 trades).
+- **ADX gate threshold, `trending_up`**: t15 +0.259, t20 +0.317, t25 +0.414,
+  t30 -0.084 — weak and non-monotonic everywhere; the ADX arm is not
+  carried past the screen.
+
+## Step 3 — judge through the M1 protocol (#994)
+
+```
+uv run --no-sync python backtest/candidates/breakout_1165/validate_shortlist.py \
+    --json backtest/candidates/breakout_1165/validation.json
+```
+
+(Same functions/harness as `eval_windows.py --candidate-json <c>.json
+--registry futures`, one process so the incumbent bars compute once.)
+
+| Candidate | IS | OOS (judged) | 2023 | 2024 | 2025H1 | held-out |
+|---|---|---|---|---|---|---|
+| baseline | PASS | **PASS** | FAIL | FAIL | FAIL | 0/3 |
+| `comp_up_clean` | PASS | **PASS** | FAIL | FAIL | FAIL | 0/3 |
+| `comp_up_clean_p21` | PASS | **PASS** | FAIL | FAIL | **PASS** | 1/3 |
+| `m4_bear_off` | PASS | **PASS** | FAIL | FAIL | FAIL | 0/3 |
+| `m4_bear_selective` | PASS | **PASS** | FAIL | FAIL | FAIL | 0/3 |
+
+- **Every shortlist member keeps the judged OOS pass** — the exact window
+  where all five #984 close stacks died. The gates trade the 2026 bear tape
+  30 times (p21) vs baseline's 117, skipping the dead-cat re-entries instead
+  of amputating the trend-holds (OOS mean Sharpe: p21 -0.40, m4s -0.03, all
+  vs bar -0.75).
+- `comp_up_clean_p21` flips 2025H1 (+1.1% mean return vs baseline's -23.4%)
+  without the #984 inversion: 2023/2024 stay FAIL against bull-year bars
+  (+74.9% / +18.2% mean return vs baseline's +141.5% / +28.7% — the gate
+  gives up bull-year upside against a long-biased bar, it does not go
+  negative). No liquidated legs anywhere.
+
+## Step 4 — the mandatory stitched continuous-window headline
+
+```
+uv run --no-sync python backtest/candidates/breakout_1165/audit_headline.py \
+    --candidates baseline.json,comp_up_clean.json,comp_up_clean_p21.json,m4_bear_off.json,m4_bear_selective.json \
+    --json backtest/candidates/breakout_1165/audit_window_headline.json
+```
+
+The #983/#984 lesson applied (every prior IS story evaporated here — this
+one doesn't):
+
+| | mean Sharpe | mean ret | vs B&H | worst DD | #T |
+|---|---:|---:|---:|---:|---:|
+| baseline | +0.02 | -1.1% | +43.7pts | -52.2% | 260 |
+| `comp_up_clean` | +0.16 | +3.6% | +48.4pts | -41.2% | 91 |
+| **`comp_up_clean_p21`** | **+0.45** | **+11.4%** | **+56.3pts** | **-23.2%** | **67** |
+| `m4_bear_off` | +0.27 | +7.7% | +52.5pts | -39.6% | 218 |
+| `m4_bear_selective` | +0.32 | +10.1% | +54.9pts | -39.6% | 211 |
+
+The #1165 validation bar was "worst DD materially better than -52.2% with
+vs-B&H within a few points of +47.5" — `comp_up_clean_p21` beats it on both
+sides simultaneously.
+
+## Step 5 — fee-drag gate (breakout is fee-marginal)
+
+```
+uv run --no-sync python backtest/candidates/breakout_1165/fee_drag.py \
+    --candidates baseline.json,comp_up_clean.json,comp_up_clean_p21.json,m4_bear_off.json,m4_bear_selective.json \
+    --json backtest/candidates/breakout_1165/fee_drag_shortlist.json
+```
+
+| | gross ret | net ret | drag | #T | T/yr |
+|---|---:|---:|---:|---:|---:|
+| baseline | +13.3% | -1.1% | 14.3pp | 260 | 43.7 |
+| `comp_up_clean` | +8.7% | +3.6% | 5.1pp | 91 | 15.3 |
+| **`comp_up_clean_p21`** | **+15.2%** | **+11.4%** | **3.8pp** | **67** | **11.3** |
+| `m4_bear_off` | +20.5% | +7.7% | 12.8pp | 218 | 36.6 |
+| `m4_bear_selective` | +22.9% | +10.1% | 12.9pp | 211 | 35.5 |
+
+Opposite of the #984 close stacks (which all *added* legs on a fee-marginal
+entry): the gate removes entries, so drag falls with trade count — and p21's
+gross return is *above* baseline's (+15.2% vs +13.3%): the removed trades
+were net losers before fees, not just fee victims.
+
+## Verdict
+
+1. **The -52.2% DD is regime exposure, and a label set that separates the
+   bleed from the edge exists**: composite `trending_up_clean` (period 21,
+   medium window) — the quality split (clean vs choppy trend efficiency),
+   NOT direction. The #984-conjectured naive bear-block fails exactly as
+   cautioned, but by blocking nothing rather than amputating the edge:
+   breakout's entry bars label directionally "up" even in bear tapes.
+2. `comp_up_clean_p21` meets the full #1165 bar: protocol IS+OOS PASS,
+   held-out 1/3 (2025H1 flipped; bull-years still lose to long-biased bars
+   but stay positive), stitched worst DD -23.2% (vs -52.2%) with vs-B&H
+   +56.3pts (vs +43.7), fee drag 3.8pp on 67 trades. `m4_bear_selective` is
+   the runner-up (stitched +54.9pts / -39.6% DD) if the position-carried
+   response is ever preferred over entry gating.
+3. **Caveats, stated plainly**: period 21 was selected on the IS plateau
+   (the shelf is broad — p14/p21/p28 all clear baseline — but 21 is still
+   the IS peak); the judged OOS window was looked at once per shortlist
+   member (M1 step 5 discipline held: selection was IS-only); all evidence
+   is one asset class (BTC/ETH/SOL × 1h/4h) on the audit frame.
+4. **This changes no live config.** Follow-on (own issue): wire the gate
+   into the live breakout futures strategy via `allowed_regimes:
+   ["trending_up_clean"]` + a composite `regime.windows` medium window at
+   period 21 — a live config change with its own #1074-class classifier
+   evidence requirements — and re-run this directory against
+   `squeeze_momentum` (#983, same DD conclusion, -58.5%): the drivers are
+   strategy-parameterized (`--strategy/--registry/--direction`;
+   `driver_common.py` holds the breakout-specific M4 param sets).
+
+A positive result still ships as evidence, not a config change (#995 step 4
+symmetry: documented, not deployed).

--- a/backtest/candidates/breakout_1165/audit_headline.py
+++ b/backtest/candidates/breakout_1165/audit_headline.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Continuous-audit-window headline for the #1165 shortlist.
+
+Runs candidate JSONs from this directory on the CONTINUOUS #956 audit window
+(2025-06-10 -> latest cache by default) via the M1 harness (eval_windows
+.run_leg, audit-identical fees/slippage) — the mandatory stitched comparison
+(the #983/#984 lesson: IS/held-out wins can evaporate, or worsen the DD, once
+the windows are stitched back together). This window is deliberately NOT in
+eval_windows.WINDOWS: protocol scoring stays segmented (is/oos/held-out);
+this driver exists only for the stitched headline.
+
+Unlike the #984 twin, every leg threads the candidate's regime state
+(allowed_regimes / regime_windows_spec / profile_allocation) via
+driver_common.candidate_leg_kwargs — a gated candidate run without it would
+silently score the UNGATED entry here.
+
+``--end`` defaults to None (latest cache), so headline numbers drift as the
+cache DB gains bars. The artifact therefore records the requested window AND
+the effective per-dataset data range (first/last bar actually loaded) — diff
+``effective_range`` against the committed artifact before comparing numbers.
+
+Run from repo root:
+  uv run --no-sync python backtest/candidates/breakout_1165/audit_headline.py \
+      [--start 2025-06-10] [--end YYYY-MM-DD] \
+      [--candidates baseline.json,...] \
+      [--json backtest/candidates/breakout_1165/audit_window_headline.json]
+"""
+
+import argparse
+import json
+import os
+import statistics
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+sys.path.insert(0, os.path.join(_HERE, "..", ".."))          # backtest/
+sys.path.insert(0, os.path.join(_HERE, "..", "..", "..", "shared_tools"))
+
+from eval_windows import (DATASETS, dataset_key, run_leg,      # noqa: E402
+                          validate_candidate)
+from driver_common import candidate_leg_kwargs                 # noqa: E402
+
+DEFAULT_CANDIDATES = "baseline.json"
+
+
+def effective_range(symbol, timeframe, window):
+    """First/last bar timestamps the cache actually yields for the window."""
+    from data_fetcher import load_cached_data
+    df = load_cached_data(symbol, timeframe,
+                          start_date=window[0], end_date=window[1])
+    if df.empty:
+        return None
+    return {"first_bar": str(df.index[0]), "last_bar": str(df.index[-1]),
+            "bars": int(len(df))}
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument("--start", default="2025-06-10",
+                   help="window start (default: the #956 audit start)")
+    p.add_argument("--end", default=None,
+                   help="window end (default: latest cache — drifts; the "
+                        "artifact records the effective per-dataset range)")
+    p.add_argument("--candidates", default=DEFAULT_CANDIDATES,
+                   help="comma list of candidate JSON files in this dir")
+    p.add_argument("--json", default=None, dest="json_out")
+    args = p.parse_args(argv)
+
+    from registry_loader import load_registry
+    reg = load_registry("futures")
+
+    window = (args.start, args.end)
+    out = {"window": {"start": args.start, "end": args.end},
+           "effective_range": {}, "candidates": {}}
+    for symbol, tf in DATASETS:
+        out["effective_range"][dataset_key(symbol, tf)] = effective_range(
+            symbol, tf, window)
+
+    for fn in [c.strip() for c in args.candidates.split(",") if c.strip()]:
+        with open(os.path.join(_HERE, fn)) as fh:
+            candidate = validate_candidate(json.load(fh))
+        label = fn[:-5] if fn.endswith(".json") else fn
+        legs = {}
+        for symbol, tf in DATASETS:
+            leg = run_leg(reg, candidate["name"], candidate.get("params"),
+                          symbol, tf, window,
+                          **candidate_leg_kwargs(candidate))
+            legs[dataset_key(symbol, tf)] = leg
+            print(f"{label:<18} {symbol} {tf}: sharpe {leg['sharpe']:+.2f}  "
+                  f"ret {leg['return_pct']:+8.2f}%  DD {leg['max_dd_pct']:8.2f}%  "
+                  f"B&H {leg['bh_return_pct']:+8.2f}%  #T {leg['trades']}")
+        ls = list(legs.values())
+        print(f"{label:<18} MEAN sharpe "
+              f"{statistics.mean(l['sharpe'] for l in ls):+.3f}  "
+              f"ret {statistics.mean(l['return_pct'] for l in ls):+7.2f}%  "
+              f"vsB&H {statistics.mean(l['return_pct'] - l['bh_return_pct'] for l in ls):+7.2f}  "
+              f"worstDD {min(l['max_dd_pct'] for l in ls):7.2f}%  "
+              f"#T {sum(l['trades'] for l in ls)}\n")
+        out["candidates"][label] = legs
+
+    if args.json_out:
+        with open(args.json_out, "w") as fh:
+            json.dump(out, fh, indent=2, default=str)
+        print(f"wrote {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backtest/candidates/breakout_1165/audit_window_headline.json
+++ b/backtest/candidates/breakout_1165/audit_window_headline.json
@@ -1,0 +1,350 @@
+{
+  "window": {
+    "start": "2025-06-10",
+    "end": null
+  },
+  "effective_range": {
+    "BTC/USDT 1h": {
+      "first_bar": "2025-06-10 00:00:00",
+      "last_bar": "2026-06-04 00:00:00",
+      "bars": 8617
+    },
+    "BTC/USDT 4h": {
+      "first_bar": "2025-06-10 00:00:00",
+      "last_bar": "2026-06-04 12:00:00",
+      "bars": 2158
+    },
+    "ETH/USDT 1h": {
+      "first_bar": "2025-06-10 00:00:00",
+      "last_bar": "2026-06-12 19:00:00",
+      "bars": 8828
+    },
+    "ETH/USDT 4h": {
+      "first_bar": "2025-06-10 00:00:00",
+      "last_bar": "2026-06-04 12:00:00",
+      "bars": 2158
+    },
+    "SOL/USDT 1h": {
+      "first_bar": "2025-06-10 00:00:00",
+      "last_bar": "2026-06-12 19:00:00",
+      "bars": 8828
+    },
+    "SOL/USDT 4h": {
+      "first_bar": "2025-06-10 00:00:00",
+      "last_bar": "2026-06-04 12:00:00",
+      "bars": 2158
+    }
+  },
+  "candidates": {
+    "baseline": {
+      "BTC/USDT 1h": {
+        "sharpe": -0.67,
+        "return_pct": -20.61,
+        "max_dd_pct": -27.19,
+        "ddadj": -0.758,
+        "trades": 66,
+        "bh_return_pct": -41.47,
+        "liquidated": false,
+        "span_days": 359.0
+      },
+      "BTC/USDT 4h": {
+        "sharpe": -0.633,
+        "return_pct": -17.75,
+        "max_dd_pct": -30.83,
+        "ddadj": -0.576,
+        "trades": 18,
+        "bh_return_pct": -41.68,
+        "liquidated": false,
+        "span_days": 359.5
+      },
+      "ETH/USDT 1h": {
+        "sharpe": 1.05,
+        "return_pct": 44.63,
+        "max_dd_pct": -29.68,
+        "ddadj": 1.504,
+        "trades": 72,
+        "bh_return_pct": -37.91,
+        "liquidated": false,
+        "span_days": 367.7917
+      },
+      "ETH/USDT 4h": {
+        "sharpe": 0.724,
+        "return_pct": 23.65,
+        "max_dd_pct": -35.79,
+        "ddadj": 0.661,
+        "trades": 15,
+        "bh_return_pct": -33.66,
+        "liquidated": false,
+        "span_days": 359.5
+      },
+      "SOL/USDT 1h": {
+        "sharpe": -0.173,
+        "return_pct": -18.9,
+        "max_dd_pct": -47.85,
+        "ddadj": -0.395,
+        "trades": 73,
+        "bh_return_pct": -58.23,
+        "liquidated": false,
+        "span_days": 367.7917
+      },
+      "SOL/USDT 4h": {
+        "sharpe": -0.175,
+        "return_pct": -17.53,
+        "max_dd_pct": -52.17,
+        "ddadj": -0.336,
+        "trades": 16,
+        "bh_return_pct": -56.03,
+        "liquidated": false,
+        "span_days": 359.5
+      }
+    },
+    "comp_up_clean": {
+      "BTC/USDT 1h": {
+        "sharpe": -0.494,
+        "return_pct": -9.52,
+        "max_dd_pct": -14.74,
+        "ddadj": -0.646,
+        "trades": 24,
+        "bh_return_pct": -41.47,
+        "liquidated": false,
+        "span_days": 359.0
+      },
+      "BTC/USDT 4h": {
+        "sharpe": 0.323,
+        "return_pct": 4.25,
+        "max_dd_pct": -14.21,
+        "ddadj": 0.299,
+        "trades": 8,
+        "bh_return_pct": -41.68,
+        "liquidated": false,
+        "span_days": 359.5
+      },
+      "ETH/USDT 1h": {
+        "sharpe": 1.235,
+        "return_pct": 35.27,
+        "max_dd_pct": -21.95,
+        "ddadj": 1.607,
+        "trades": 25,
+        "bh_return_pct": -37.91,
+        "liquidated": false,
+        "span_days": 367.7917
+      },
+      "ETH/USDT 4h": {
+        "sharpe": 0.208,
+        "return_pct": 1.95,
+        "max_dd_pct": -29.66,
+        "ddadj": 0.066,
+        "trades": 7,
+        "bh_return_pct": -33.66,
+        "liquidated": false,
+        "span_days": 359.5
+      },
+      "SOL/USDT 1h": {
+        "sharpe": 0.54,
+        "return_pct": 12.85,
+        "max_dd_pct": -17.86,
+        "ddadj": 0.719,
+        "trades": 20,
+        "bh_return_pct": -58.23,
+        "liquidated": false,
+        "span_days": 367.7917
+      },
+      "SOL/USDT 4h": {
+        "sharpe": -0.87,
+        "return_pct": -23.42,
+        "max_dd_pct": -41.16,
+        "ddadj": -0.569,
+        "trades": 7,
+        "bh_return_pct": -56.03,
+        "liquidated": false,
+        "span_days": 359.5
+      }
+    },
+    "comp_up_clean_p21": {
+      "BTC/USDT 1h": {
+        "sharpe": -0.589,
+        "return_pct": -8.51,
+        "max_dd_pct": -15.83,
+        "ddadj": -0.538,
+        "trades": 17,
+        "bh_return_pct": -41.47,
+        "liquidated": false,
+        "span_days": 359.0
+      },
+      "BTC/USDT 4h": {
+        "sharpe": -0.084,
+        "return_pct": -2.6,
+        "max_dd_pct": -13.53,
+        "ddadj": -0.192,
+        "trades": 7,
+        "bh_return_pct": -41.68,
+        "liquidated": false,
+        "span_days": 359.5
+      },
+      "ETH/USDT 1h": {
+        "sharpe": 1.558,
+        "return_pct": 41.13,
+        "max_dd_pct": -11.67,
+        "ddadj": 3.524,
+        "trades": 18,
+        "bh_return_pct": -37.91,
+        "liquidated": false,
+        "span_days": 367.7917
+      },
+      "ETH/USDT 4h": {
+        "sharpe": 1.229,
+        "return_pct": 30.43,
+        "max_dd_pct": -19.22,
+        "ddadj": 1.583,
+        "trades": 4,
+        "bh_return_pct": -33.66,
+        "liquidated": false,
+        "span_days": 359.5
+      },
+      "SOL/USDT 1h": {
+        "sharpe": 0.226,
+        "return_pct": 2.56,
+        "max_dd_pct": -18.43,
+        "ddadj": 0.139,
+        "trades": 17,
+        "bh_return_pct": -58.23,
+        "liquidated": false,
+        "span_days": 367.7917
+      },
+      "SOL/USDT 4h": {
+        "sharpe": 0.346,
+        "return_pct": 5.51,
+        "max_dd_pct": -23.18,
+        "ddadj": 0.238,
+        "trades": 4,
+        "bh_return_pct": -56.03,
+        "liquidated": false,
+        "span_days": 359.5
+      }
+    },
+    "m4_bear_off": {
+      "BTC/USDT 1h": {
+        "sharpe": -0.375,
+        "return_pct": -12.25,
+        "max_dd_pct": -20.97,
+        "ddadj": -0.584,
+        "trades": 54,
+        "bh_return_pct": -41.47,
+        "liquidated": false,
+        "span_days": 359.0
+      },
+      "BTC/USDT 4h": {
+        "sharpe": -0.266,
+        "return_pct": -8.67,
+        "max_dd_pct": -23.61,
+        "ddadj": -0.367,
+        "trades": 15,
+        "bh_return_pct": -41.68,
+        "liquidated": false,
+        "span_days": 359.5
+      },
+      "ETH/USDT 1h": {
+        "sharpe": 1.184,
+        "return_pct": 47.9,
+        "max_dd_pct": -27.46,
+        "ddadj": 1.744,
+        "trades": 60,
+        "bh_return_pct": -37.91,
+        "liquidated": false,
+        "span_days": 367.7917
+      },
+      "ETH/USDT 4h": {
+        "sharpe": 0.561,
+        "return_pct": 15.54,
+        "max_dd_pct": -39.56,
+        "ddadj": 0.393,
+        "trades": 15,
+        "bh_return_pct": -33.66,
+        "liquidated": false,
+        "span_days": 359.5
+      },
+      "SOL/USDT 1h": {
+        "sharpe": 0.072,
+        "return_pct": -6.74,
+        "max_dd_pct": -37.13,
+        "ddadj": -0.182,
+        "trades": 62,
+        "bh_return_pct": -58.23,
+        "liquidated": false,
+        "span_days": 367.7917
+      },
+      "SOL/USDT 4h": {
+        "sharpe": 0.445,
+        "return_pct": 10.22,
+        "max_dd_pct": -36.73,
+        "ddadj": 0.278,
+        "trades": 12,
+        "bh_return_pct": -56.03,
+        "liquidated": false,
+        "span_days": 359.5
+      }
+    },
+    "m4_bear_selective": {
+      "BTC/USDT 1h": {
+        "sharpe": -0.407,
+        "return_pct": -13.89,
+        "max_dd_pct": -23.19,
+        "ddadj": -0.599,
+        "trades": 51,
+        "bh_return_pct": -41.47,
+        "liquidated": false,
+        "span_days": 359.0
+      },
+      "BTC/USDT 4h": {
+        "sharpe": -0.266,
+        "return_pct": -8.67,
+        "max_dd_pct": -23.61,
+        "ddadj": -0.367,
+        "trades": 15,
+        "bh_return_pct": -41.68,
+        "liquidated": false,
+        "span_days": 359.5
+      },
+      "ETH/USDT 1h": {
+        "sharpe": 1.184,
+        "return_pct": 47.9,
+        "max_dd_pct": -27.46,
+        "ddadj": 1.744,
+        "trades": 60,
+        "bh_return_pct": -37.91,
+        "liquidated": false,
+        "span_days": 367.7917
+      },
+      "ETH/USDT 4h": {
+        "sharpe": 0.561,
+        "return_pct": 15.54,
+        "max_dd_pct": -39.56,
+        "ddadj": 0.393,
+        "trades": 15,
+        "bh_return_pct": -33.66,
+        "liquidated": false,
+        "span_days": 359.5
+      },
+      "SOL/USDT 1h": {
+        "sharpe": 0.421,
+        "return_pct": 9.24,
+        "max_dd_pct": -37.13,
+        "ddadj": 0.249,
+        "trades": 58,
+        "bh_return_pct": -58.23,
+        "liquidated": false,
+        "span_days": 367.7917
+      },
+      "SOL/USDT 4h": {
+        "sharpe": 0.445,
+        "return_pct": 10.22,
+        "max_dd_pct": -36.73,
+        "ddadj": 0.278,
+        "trades": 12,
+        "bh_return_pct": -56.03,
+        "liquidated": false,
+        "span_days": 359.5
+      }
+    }
+  }
+}

--- a/backtest/candidates/breakout_1165/baseline.json
+++ b/backtest/candidates/breakout_1165/baseline.json
@@ -1,0 +1,4 @@
+{
+  "name": "breakout",
+  "direction": "long"
+}

--- a/backtest/candidates/breakout_1165/comp_up_clean.json
+++ b/backtest/candidates/breakout_1165/comp_up_clean.json
@@ -1,0 +1,13 @@
+{
+  "name": "breakout",
+  "direction": "long",
+  "allowed_regimes": [
+    "trending_up_clean"
+  ],
+  "regime_windows_spec": {
+    "medium": {
+      "classifier": "composite",
+      "period": 14
+    }
+  }
+}

--- a/backtest/candidates/breakout_1165/comp_up_clean_p21.json
+++ b/backtest/candidates/breakout_1165/comp_up_clean_p21.json
@@ -1,0 +1,13 @@
+{
+  "name": "breakout",
+  "direction": "long",
+  "allowed_regimes": [
+    "trending_up_clean"
+  ],
+  "regime_windows_spec": {
+    "medium": {
+      "classifier": "composite",
+      "period": 21
+    }
+  }
+}

--- a/backtest/candidates/breakout_1165/driver_common.py
+++ b/backtest/candidates/breakout_1165/driver_common.py
@@ -1,0 +1,155 @@
+"""Shared candidate plumbing for the #1165 regime-gate drivers.
+
+Pure helpers only (no data access) so they are unit-testable
+(backtest/tests/test_breakout_1165_drivers.py) and shared by every driver in
+this directory. The load-bearing one is ``candidate_leg_kwargs``: unlike the
+#984 close-stack shortlist, every #1165 candidate carries regime state
+(``allowed_regimes`` / ``regime_windows_spec`` / ``profile_allocation``), and
+a driver that forgets to thread those into ``run_leg`` silently scores the
+UNGATED entry — a wrong-but-plausible number, not an error. All three
+continuous-window drivers (audit_headline, fee_drag) and the IS sweep build
+their run_leg kwargs here.
+"""
+
+# Sweep grids are versioned HERE so every artifact regenerates from the same
+# candidate specs. The entry stays frozen (registry defaults); only WHEN it
+# may fire varies. Strategy-specific pieces (the M4 "off"/"selective" param
+# sets) are module constants so a re-run against squeeze_momentum (#983, same
+# verdict) only swaps these and --strategy.
+
+# M4 param sets (#998 two-profile model). "on" = frozen registry defaults
+# (empty dict merges under runtime params in reg.apply_strategy). "off" pins
+# atr_multiplier far above any true-range multiple, so the profile emits no
+# entries at all: the regime response is carried by the position (flat-only
+# switch), not the entry list. "selective" raises the breakout bar instead of
+# zeroing it (longer channel, stricter expansion).
+PARAM_SET_ON: dict = {}
+PARAM_SET_OFF: dict = {"atr_multiplier": 100.0}
+PARAM_SET_SELECTIVE: dict = {"lookback": 55, "atr_multiplier": 2.5}
+
+ADX_SPEC = {"medium": {"classifier": "adx", "period": 14, "adx_threshold": 20.0}}
+COMPOSITE_SPEC = {"medium": {"classifier": "composite", "period": 14}}
+
+# Composite 9-state vocabulary (#1058/#1124). The bare `ranging_directional`
+# in an allowed set covers its `_up`/`_down` subs (bare-covers-subs), so the
+# not_down sets list the bare label only.
+COMP_UP_FAMILY = ["trending_up_clean", "trending_up_choppy"]
+COMP_NOT_DOWN = COMP_UP_FAMILY + ["ranging_quiet", "ranging_volatile",
+                                  "ranging_directional"]
+COMP_NOT_DOWN_CALM = COMP_UP_FAMILY + ["ranging_quiet", "ranging_directional"]
+
+
+def adx_spec(threshold: float) -> dict:
+    """ADX windows spec at a non-default gate threshold (plateau sweeps)."""
+    return {"medium": {"classifier": "adx", "period": 14,
+                       "adx_threshold": float(threshold)}}
+
+
+def gate_candidate(label: str, allowed: list, spec: dict) -> dict:
+    """Arm A: entry gate on the frozen entry + frozen default close stack."""
+    return {"label": label, "allowed_regimes": list(allowed),
+            "regime_windows_spec": {k: dict(v) for k, v in spec.items()}}
+
+
+def profile_candidate(label: str, profiles: dict, window_spec: dict,
+                      off_set: dict = PARAM_SET_OFF) -> dict:
+    """Arm B: #998 two-profile allocation (flat-only switch, confirm_bars 2).
+
+    ``profiles`` maps every regime label of the window's classifier to
+    "on"/"off" explicitly — the switcher holds the active profile on unknown
+    labels (fail-open), so an unmapped label would silently mean "no change",
+    not "off".
+    """
+    return {"label": label, "profile_allocation": {
+        "window_spec": dict(window_spec),
+        "profiles": dict(profiles),
+        "param_sets": {"on": dict(PARAM_SET_ON), "off": dict(off_set)},
+        "confirm_bars": 2,
+        "initial_profile": "on",
+    }}
+
+
+def build_gate_grid() -> list:
+    """Arm A screen rows: ADX label subsets + composite label subsets."""
+    rows = [
+        {"label": "baseline"},
+        # ADX (3-label vocabulary), gate threshold 20 = live default.
+        gate_candidate("adx_up", ["trending_up"], ADX_SPEC),
+        gate_candidate("adx_not_down", ["trending_up", "ranging"], ADX_SPEC),
+        gate_candidate("adx_trend_only", ["trending_up", "trending_down"],
+                       ADX_SPEC),
+        # Composite 9-state (#1058/#1124), period 14 medium window.
+        gate_candidate("comp_up_family", COMP_UP_FAMILY, COMPOSITE_SPEC),
+        gate_candidate("comp_up_clean", ["trending_up_clean"], COMPOSITE_SPEC),
+        gate_candidate("comp_not_down", COMP_NOT_DOWN, COMPOSITE_SPEC),
+        gate_candidate("comp_not_down_calm", COMP_NOT_DOWN_CALM,
+                       COMPOSITE_SPEC),
+        gate_candidate("comp_up_plus_dir_up",
+                       COMP_UP_FAMILY + ["ranging_directional_up"],
+                       COMPOSITE_SPEC),
+    ]
+    return rows
+
+
+def build_gate_threshold_plateau(allowed: list,
+                                 thresholds=(15.0, 25.0, 30.0)) -> list:
+    """ADX gate-threshold plateau around the default 20 (M1 step 6: the pick
+    must sit on a shelf, not a spike)."""
+    return [gate_candidate(f"adx_gate_t{t:g}", allowed, adx_spec(t))
+            for t in thresholds]
+
+
+def build_composite_period_plateau(allowed: list,
+                                   periods=(10, 21, 28)) -> list:
+    """Composite classifier-period plateau around the default 14 (M1 step 6
+    for the composite gate arm — the winning label set must hold across
+    neighboring window periods, not spike at one)."""
+    return [gate_candidate(
+        f"comp_gate_p{p}", allowed,
+        {"medium": {"classifier": "composite", "period": int(p)}})
+        for p in periods]
+
+
+def build_profile_grid() -> list:
+    """Arm B screen rows: M4 profile allocation on ADX and composite switch
+    windows."""
+    adx_ws = dict(ADX_SPEC["medium"])
+    comp_ws = dict(COMPOSITE_SPEC["medium"])
+    comp_profiles_bear_off = {
+        "trending_up_clean": "on", "trending_up_choppy": "on",
+        "ranging_quiet": "on", "ranging_volatile": "on",
+        "ranging_directional": "on", "ranging_directional_up": "on",
+        "ranging_directional_down": "on",
+        "trending_down_clean": "off", "trending_down_choppy": "off",
+    }
+    return [
+        profile_candidate("m4_bear_off",
+                          {"trending_up": "on", "ranging": "on",
+                           "trending_down": "off"}, adx_ws),
+        profile_candidate("m4_trend_only",
+                          {"trending_up": "on", "ranging": "off",
+                           "trending_down": "off"}, adx_ws),
+        profile_candidate("m4_bear_selective",
+                          {"trending_up": "on", "ranging": "on",
+                           "trending_down": "off"}, adx_ws,
+                          off_set=PARAM_SET_SELECTIVE),
+        profile_candidate("m4_comp_bear_off", comp_profiles_bear_off, comp_ws),
+    ]
+
+
+def candidate_leg_kwargs(candidate: dict) -> dict:
+    """run_leg kwargs for one candidate — the single place regime state is
+    threaded, so a gated candidate can never silently run ungated on the
+    continuous audit window (the #984 drivers didn't need this; every #1165
+    one does)."""
+    return dict(
+        close_strategies=candidate.get("close_strategies"),
+        direction=candidate.get("direction") or "long",
+        invert_signal=bool(candidate.get("invert_signal")),
+        stop_loss_atr_mult=candidate.get("stop_loss_atr_mult"),
+        trailing_stop_atr_mult=candidate.get("trailing_stop_atr_mult"),
+        profile_allocation=candidate.get("profile_allocation"),
+        allowed_regimes=candidate.get("allowed_regimes"),
+        regime_windows_spec=candidate.get("regime_windows_spec"),
+        regime_directional_policy=candidate.get("regime_directional_policy"),
+    )

--- a/backtest/candidates/breakout_1165/fee_drag.py
+++ b/backtest/candidates/breakout_1165/fee_drag.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Fee-drag screen for the #1165 shortlist (README fee-gate step).
+
+breakout's audit economics are fee-marginal: the M5 screen (#999,
+docs/research/fee-audit-m5.md) measured gross +5.28%/leg vs net -1.54%/leg —
+6.82pp of friction drag over 260 trades (44.3/yr) at ~0.31%/leg. A regime
+gate that only removes losing entries should CUT trades (unlike the #984
+close stacks, which added legs), but a gate that fragments trend-holds into
+re-entries pays the same churn tax. This driver re-runs each candidate twice
+per audit dataset on the continuous audit window — default friction vs zero
+friction (the documented #999 overrides: ``commission_pct=0.0,
+slippage_pct=0.0``) — and reports the gross/net split, drag in percentage
+points, and annualized trade rate, per candidate and vs baseline.
+
+Every leg threads the candidate's regime state via
+driver_common.candidate_leg_kwargs (a gated candidate would otherwise
+silently score ungated). ``summarize_fee_drag`` is imported from the #984
+twin — same aggregation, unit-tested in
+backtest/tests/test_breakout_984_fee_drag.py.
+
+Run from repo root:
+  uv run --no-sync python backtest/candidates/breakout_1165/fee_drag.py \
+      [--start 2025-06-10] [--end YYYY-MM-DD] \
+      [--candidates baseline.json,...] \
+      [--json backtest/candidates/breakout_1165/fee_drag_shortlist.json]
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+sys.path.insert(0, os.path.join(_HERE, "..", ".."))          # backtest/
+sys.path.insert(0, os.path.join(_HERE, "..", "..", "..", "shared_tools"))
+
+from driver_common import candidate_leg_kwargs                 # noqa: E402
+
+DEFAULT_CANDIDATES = "baseline.json"
+
+
+def _load_984_fee_drag():
+    """The #984 twin is a script, not a package module — load it by path."""
+    path = os.path.join(_HERE, "..", "breakout_984", "fee_drag.py")
+    spec = importlib.util.spec_from_file_location("breakout_984_fee_drag", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+summarize_fee_drag = _load_984_fee_drag().summarize_fee_drag
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument("--start", default="2025-06-10",
+                   help="window start (default: the #956 audit start)")
+    p.add_argument("--end", default=None,
+                   help="window end (default: latest cache)")
+    p.add_argument("--candidates", default=DEFAULT_CANDIDATES,
+                   help="comma list of candidate JSON files in this dir")
+    p.add_argument("--json", default=None, dest="json_out")
+    args = p.parse_args(argv)
+
+    from eval_windows import DATASETS, dataset_key, run_leg, validate_candidate
+    from registry_loader import load_registry
+    reg = load_registry("futures")
+
+    window = (args.start, args.end)
+    out = {"window": {"start": args.start, "end": args.end}, "candidates": {}}
+
+    for fn in [c.strip() for c in args.candidates.split(",") if c.strip()]:
+        with open(os.path.join(_HERE, fn)) as fh:
+            candidate = validate_candidate(json.load(fh))
+        label = fn[:-5] if fn.endswith(".json") else fn
+        common = candidate_leg_kwargs(candidate)
+        gross_legs, net_legs, per_dataset = [], [], {}
+        for symbol, tf in DATASETS:
+            net = run_leg(reg, candidate["name"], candidate.get("params"),
+                          symbol, tf, window, **common)
+            gross = run_leg(reg, candidate["name"], candidate.get("params"),
+                            symbol, tf, window, **common,
+                            commission_pct=0.0, slippage_pct=0.0)
+            net_legs.append(net)
+            gross_legs.append(gross)
+            per_dataset[dataset_key(symbol, tf)] = {
+                "gross_return_pct": None if gross is None else gross["return_pct"],
+                "net_return_pct": None if net is None else net["return_pct"],
+                "trades": None if net is None else net["trades"],
+            }
+        summary = summarize_fee_drag(gross_legs, net_legs)
+        out["candidates"][label] = {"summary": summary,
+                                    "per_dataset": per_dataset}
+        s = summary or {}
+        print(f"{label:<22} gross {s.get('mean_gross_return_pct')!s:>8}%  "
+              f"net {s.get('mean_net_return_pct')!s:>8}%  "
+              f"drag {s.get('drag_pp')!s:>6}pp  "
+              f"#T {s.get('trades')!s:>5}  "
+              f"T/yr {s.get('trades_per_year')!s:>6}")
+
+    if args.json_out:
+        with open(args.json_out, "w") as fh:
+            json.dump(out, fh, indent=2, default=str)
+        print(f"\nwrote {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backtest/candidates/breakout_1165/fee_drag_shortlist.json
+++ b/backtest/candidates/breakout_1165/fee_drag_shortlist.json
@@ -1,0 +1,218 @@
+{
+  "window": {
+    "start": "2025-06-10",
+    "end": null
+  },
+  "candidates": {
+    "baseline": {
+      "summary": {
+        "legs": 6,
+        "mean_gross_return_pct": 13.25,
+        "mean_net_return_pct": -1.08,
+        "drag_pp": 14.34,
+        "trades": 260,
+        "trades_per_year": 43.7
+      },
+      "per_dataset": {
+        "BTC/USDT 1h": {
+          "gross_return_pct": -3.21,
+          "net_return_pct": -20.61,
+          "trades": 66
+        },
+        "BTC/USDT 4h": {
+          "gross_return_pct": -13.18,
+          "net_return_pct": -17.75,
+          "trades": 18
+        },
+        "ETH/USDT 1h": {
+          "gross_return_pct": 79.24,
+          "net_return_pct": 44.63,
+          "trades": 72
+        },
+        "ETH/USDT 4h": {
+          "gross_return_pct": 29.34,
+          "net_return_pct": 23.65,
+          "trades": 15
+        },
+        "SOL/USDT 1h": {
+          "gross_return_pct": 0.82,
+          "net_return_pct": -18.9,
+          "trades": 73
+        },
+        "SOL/USDT 4h": {
+          "gross_return_pct": -13.48,
+          "net_return_pct": -17.53,
+          "trades": 16
+        }
+      }
+    },
+    "comp_up_clean": {
+      "summary": {
+        "legs": 6,
+        "mean_gross_return_pct": 8.66,
+        "mean_net_return_pct": 3.56,
+        "drag_pp": 5.1,
+        "trades": 91,
+        "trades_per_year": 15.3
+      },
+      "per_dataset": {
+        "BTC/USDT 1h": {
+          "gross_return_pct": -2.76,
+          "net_return_pct": -9.52,
+          "trades": 24
+        },
+        "BTC/USDT 4h": {
+          "gross_return_pct": 6.78,
+          "net_return_pct": 4.25,
+          "trades": 8
+        },
+        "ETH/USDT 1h": {
+          "gross_return_pct": 45.81,
+          "net_return_pct": 35.27,
+          "trades": 25
+        },
+        "ETH/USDT 4h": {
+          "gross_return_pct": 4.11,
+          "net_return_pct": 1.95,
+          "trades": 7
+        },
+        "SOL/USDT 1h": {
+          "gross_return_pct": 19.83,
+          "net_return_pct": 12.85,
+          "trades": 20
+        },
+        "SOL/USDT 4h": {
+          "gross_return_pct": -21.79,
+          "net_return_pct": -23.42,
+          "trades": 7
+        }
+      }
+    },
+    "comp_up_clean_p21": {
+      "summary": {
+        "legs": 6,
+        "mean_gross_return_pct": 15.23,
+        "mean_net_return_pct": 11.42,
+        "drag_pp": 3.81,
+        "trades": 67,
+        "trades_per_year": 11.3
+      },
+      "per_dataset": {
+        "BTC/USDT 1h": {
+          "gross_return_pct": -3.72,
+          "net_return_pct": -8.51,
+          "trades": 17
+        },
+        "BTC/USDT 4h": {
+          "gross_return_pct": -0.53,
+          "net_return_pct": -2.6,
+          "trades": 7
+        },
+        "ETH/USDT 1h": {
+          "gross_return_pct": 48.96,
+          "net_return_pct": 41.13,
+          "trades": 18
+        },
+        "ETH/USDT 4h": {
+          "gross_return_pct": 32.0,
+          "net_return_pct": 30.43,
+          "trades": 4
+        },
+        "SOL/USDT 1h": {
+          "gross_return_pct": 7.92,
+          "net_return_pct": 2.56,
+          "trades": 17
+        },
+        "SOL/USDT 4h": {
+          "gross_return_pct": 6.78,
+          "net_return_pct": 5.51,
+          "trades": 4
+        }
+      }
+    },
+    "m4_bear_off": {
+      "summary": {
+        "legs": 6,
+        "mean_gross_return_pct": 20.47,
+        "mean_net_return_pct": 7.67,
+        "drag_pp": 12.81,
+        "trades": 218,
+        "trades_per_year": 36.6
+      },
+      "per_dataset": {
+        "BTC/USDT 1h": {
+          "gross_return_pct": 3.19,
+          "net_return_pct": -12.25,
+          "trades": 54
+        },
+        "BTC/USDT 4h": {
+          "gross_return_pct": -4.46,
+          "net_return_pct": -8.67,
+          "trades": 15
+        },
+        "ETH/USDT 1h": {
+          "gross_return_pct": 76.81,
+          "net_return_pct": 47.9,
+          "trades": 60
+        },
+        "ETH/USDT 4h": {
+          "gross_return_pct": 20.86,
+          "net_return_pct": 15.54,
+          "trades": 15
+        },
+        "SOL/USDT 1h": {
+          "gross_return_pct": 12.17,
+          "net_return_pct": -6.74,
+          "trades": 62
+        },
+        "SOL/USDT 4h": {
+          "gross_return_pct": 14.26,
+          "net_return_pct": 10.22,
+          "trades": 12
+        }
+      }
+    },
+    "m4_bear_selective": {
+      "summary": {
+        "legs": 6,
+        "mean_gross_return_pct": 22.94,
+        "mean_net_return_pct": 10.06,
+        "drag_pp": 12.88,
+        "trades": 211,
+        "trades_per_year": 35.5
+      },
+      "per_dataset": {
+        "BTC/USDT 1h": {
+          "gross_return_pct": 0.35,
+          "net_return_pct": -13.89,
+          "trades": 51
+        },
+        "BTC/USDT 4h": {
+          "gross_return_pct": -4.46,
+          "net_return_pct": -8.67,
+          "trades": 15
+        },
+        "ETH/USDT 1h": {
+          "gross_return_pct": 76.81,
+          "net_return_pct": 47.9,
+          "trades": 60
+        },
+        "ETH/USDT 4h": {
+          "gross_return_pct": 20.86,
+          "net_return_pct": 15.54,
+          "trades": 15
+        },
+        "SOL/USDT 1h": {
+          "gross_return_pct": 29.81,
+          "net_return_pct": 9.24,
+          "trades": 58
+        },
+        "SOL/USDT 4h": {
+          "gross_return_pct": 14.26,
+          "net_return_pct": 10.22,
+          "trades": 12
+        }
+      }
+    }
+  }
+}

--- a/backtest/candidates/breakout_1165/m4_bear_off.json
+++ b/backtest/candidates/breakout_1165/m4_bear_off.json
@@ -1,0 +1,24 @@
+{
+  "name": "breakout",
+  "direction": "long",
+  "profile_allocation": {
+    "window_spec": {
+      "classifier": "adx",
+      "period": 14,
+      "adx_threshold": 20.0
+    },
+    "profiles": {
+      "trending_up": "on",
+      "ranging": "on",
+      "trending_down": "off"
+    },
+    "param_sets": {
+      "on": {},
+      "off": {
+        "atr_multiplier": 100.0
+      }
+    },
+    "confirm_bars": 2,
+    "initial_profile": "on"
+  }
+}

--- a/backtest/candidates/breakout_1165/m4_bear_selective.json
+++ b/backtest/candidates/breakout_1165/m4_bear_selective.json
@@ -1,0 +1,25 @@
+{
+  "name": "breakout",
+  "direction": "long",
+  "profile_allocation": {
+    "window_spec": {
+      "classifier": "adx",
+      "period": 14,
+      "adx_threshold": 20.0
+    },
+    "profiles": {
+      "trending_up": "on",
+      "ranging": "on",
+      "trending_down": "off"
+    },
+    "param_sets": {
+      "on": {},
+      "off": {
+        "lookback": 55,
+        "atr_multiplier": 2.5
+      }
+    },
+    "confirm_bars": 2,
+    "initial_profile": "on"
+  }
+}

--- a/backtest/candidates/breakout_1165/plateau_is.json
+++ b/backtest/candidates/breakout_1165/plateau_is.json
@@ -1,0 +1,530 @@
+{
+  "window": "is",
+  "window_range": [
+    "2025-06-10",
+    "2026-01-01"
+  ],
+  "strategy": "breakout",
+  "registry": "futures",
+  "rows": [
+    {
+      "label": "comp_gate_p21",
+      "candidate": {
+        "allowed_regimes": [
+          "trending_up_clean"
+        ],
+        "regime_windows_spec": {
+          "medium": {
+            "classifier": "composite",
+            "period": 21,
+            "thresholds": {
+              "return_eff": 0.05,
+              "range_eff": 0.03,
+              "adx": 25.0,
+              "efficiency": 0.5
+            }
+          }
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -0.687,
+          "return_pct": -5.06,
+          "max_dd_pct": -9.9,
+          "ddadj": -0.511,
+          "trades": 8,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -0.807,
+          "return_pct": -6.81,
+          "max_dd_pct": -10.95,
+          "ddadj": -0.622,
+          "trades": 4,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.461,
+          "return_pct": 41.75,
+          "max_dd_pct": -11.6,
+          "ddadj": 3.599,
+          "trades": 9,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 2.483,
+          "return_pct": 46.03,
+          "max_dd_pct": -10.87,
+          "ddadj": 4.235,
+          "trades": 2,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": 0.266,
+          "return_pct": 1.99,
+          "max_dd_pct": -15.6,
+          "ddadj": 0.128,
+          "trades": 11,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": 0.438,
+          "return_pct": 4.65,
+          "max_dd_pct": -23.18,
+          "ddadj": 0.201,
+          "trades": 2,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 1.172,
+      "mean_sharpe": 0.692,
+      "mean_return_pct": 13.76,
+      "worst_max_dd_pct": -23.18,
+      "total_trades": 36
+    },
+    {
+      "label": "comp_gate_p28",
+      "candidate": {
+        "allowed_regimes": [
+          "trending_up_clean"
+        ],
+        "regime_windows_spec": {
+          "medium": {
+            "classifier": "composite",
+            "period": 28,
+            "thresholds": {
+              "return_eff": 0.05,
+              "range_eff": 0.03,
+              "adx": 25.0,
+              "efficiency": 0.5
+            }
+          }
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": 1.196,
+          "return_pct": 6.56,
+          "max_dd_pct": -7.49,
+          "ddadj": 0.876,
+          "trades": 3,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -1.157,
+          "return_pct": -6.98,
+          "max_dd_pct": -9.7,
+          "ddadj": -0.72,
+          "trades": 3,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.196,
+          "return_pct": 30.7,
+          "max_dd_pct": -10.43,
+          "ddadj": 2.943,
+          "trades": 6,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 1.641,
+          "return_pct": 18.84,
+          "max_dd_pct": -10.32,
+          "ddadj": 1.826,
+          "trades": 1,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": 0.429,
+          "return_pct": 4.18,
+          "max_dd_pct": -11.55,
+          "ddadj": 0.362,
+          "trades": 6,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": -1.56,
+          "return_pct": -16.1,
+          "max_dd_pct": -23.18,
+          "ddadj": -0.695,
+          "trades": 2,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.765,
+      "mean_sharpe": 0.458,
+      "mean_return_pct": 6.2,
+      "worst_max_dd_pct": -23.18,
+      "total_trades": 21
+    },
+    {
+      "label": "adx_gate_t25",
+      "candidate": {
+        "allowed_regimes": [
+          "trending_up"
+        ],
+        "regime_windows_spec": {
+          "medium": {
+            "classifier": "adx",
+            "period": 14,
+            "adx_threshold": 25.0
+          }
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -1.678,
+          "return_pct": -20.03,
+          "max_dd_pct": -23.74,
+          "ddadj": -0.844,
+          "trades": 19,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -1.486,
+          "return_pct": -18.02,
+          "max_dd_pct": -21.83,
+          "ddadj": -0.825,
+          "trades": 9,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.95,
+          "return_pct": 71.9,
+          "max_dd_pct": -18.1,
+          "ddadj": 3.972,
+          "trades": 18,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.994,
+          "return_pct": 18.34,
+          "max_dd_pct": -26.71,
+          "ddadj": 0.687,
+          "trades": 6,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": -0.038,
+          "return_pct": -5.34,
+          "max_dd_pct": -18.44,
+          "ddadj": -0.29,
+          "trades": 21,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": -0.158,
+          "return_pct": -7.56,
+          "max_dd_pct": -34.89,
+          "ddadj": -0.217,
+          "trades": 5,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.414,
+      "mean_sharpe": 0.097,
+      "mean_return_pct": 6.55,
+      "worst_max_dd_pct": -34.89,
+      "total_trades": 78
+    },
+    {
+      "label": "comp_gate_p10",
+      "candidate": {
+        "allowed_regimes": [
+          "trending_up_clean"
+        ],
+        "regime_windows_spec": {
+          "medium": {
+            "classifier": "composite",
+            "period": 10,
+            "thresholds": {
+              "return_eff": 0.05,
+              "range_eff": 0.03,
+              "adx": 25.0,
+              "efficiency": 0.5
+            }
+          }
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -0.883,
+          "return_pct": -9.14,
+          "max_dd_pct": -19.16,
+          "ddadj": -0.477,
+          "trades": 15,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -0.417,
+          "return_pct": -6.28,
+          "max_dd_pct": -13.8,
+          "ddadj": -0.455,
+          "trades": 8,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 1.958,
+          "return_pct": 38.21,
+          "max_dd_pct": -17.11,
+          "ddadj": 2.233,
+          "trades": 17,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.944,
+          "return_pct": 16.95,
+          "max_dd_pct": -26.97,
+          "ddadj": 0.628,
+          "trades": 6,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": -0.574,
+          "return_pct": -15.07,
+          "max_dd_pct": -23.95,
+          "ddadj": -0.629,
+          "trades": 20,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": 0.506,
+          "return_pct": 6.77,
+          "max_dd_pct": -20.48,
+          "ddadj": 0.331,
+          "trades": 4,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.272,
+      "mean_sharpe": 0.256,
+      "mean_return_pct": 5.24,
+      "worst_max_dd_pct": -26.97,
+      "total_trades": 70
+    },
+    {
+      "label": "adx_gate_t15",
+      "candidate": {
+        "allowed_regimes": [
+          "trending_up"
+        ],
+        "regime_windows_spec": {
+          "medium": {
+            "classifier": "adx",
+            "period": 14,
+            "adx_threshold": 15.0
+          }
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -0.949,
+          "return_pct": -15.55,
+          "max_dd_pct": -24.55,
+          "ddadj": -0.633,
+          "trades": 32,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -1.081,
+          "return_pct": -15.37,
+          "max_dd_pct": -20.0,
+          "ddadj": -0.768,
+          "trades": 11,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.195,
+          "return_pct": 63.85,
+          "max_dd_pct": -20.06,
+          "ddadj": 3.183,
+          "trades": 34,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.419,
+          "return_pct": 5.06,
+          "max_dd_pct": -41.07,
+          "ddadj": 0.123,
+          "trades": 11,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": 0.213,
+          "return_pct": -1.18,
+          "max_dd_pct": -34.08,
+          "ddadj": -0.035,
+          "trades": 35,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": -0.289,
+          "return_pct": -14.07,
+          "max_dd_pct": -44.93,
+          "ddadj": -0.313,
+          "trades": 9,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.259,
+      "mean_sharpe": 0.085,
+      "mean_return_pct": 3.79,
+      "worst_max_dd_pct": -44.93,
+      "total_trades": 132
+    },
+    {
+      "label": "adx_gate_t30",
+      "candidate": {
+        "allowed_regimes": [
+          "trending_up"
+        ],
+        "regime_windows_spec": {
+          "medium": {
+            "classifier": "adx",
+            "period": 14,
+            "adx_threshold": 30.0
+          }
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -1.722,
+          "return_pct": -16.9,
+          "max_dd_pct": -18.86,
+          "ddadj": -0.896,
+          "trades": 15,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -1.59,
+          "return_pct": -17.37,
+          "max_dd_pct": -22.33,
+          "ddadj": -0.778,
+          "trades": 8,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.166,
+          "return_pct": 41.64,
+          "max_dd_pct": -18.8,
+          "ddadj": 2.215,
+          "trades": 14,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.484,
+          "return_pct": 6.22,
+          "max_dd_pct": -26.71,
+          "ddadj": 0.233,
+          "trades": 6,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": -1.373,
+          "return_pct": -26.53,
+          "max_dd_pct": -26.53,
+          "ddadj": -1.0,
+          "trades": 16,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": -0.266,
+          "return_pct": -8.22,
+          "max_dd_pct": -29.45,
+          "ddadj": -0.279,
+          "trades": 4,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": -0.084,
+      "mean_sharpe": -0.384,
+      "mean_return_pct": -3.53,
+      "worst_max_dd_pct": -29.45,
+      "total_trades": 63
+    }
+  ]
+}

--- a/backtest/candidates/breakout_1165/sweep_is.json
+++ b/backtest/candidates/breakout_1165/sweep_is.json
@@ -1,0 +1,1176 @@
+{
+  "window": "is",
+  "window_range": [
+    "2025-06-10",
+    "2026-01-01"
+  ],
+  "strategy": "breakout",
+  "registry": "futures",
+  "rows": [
+    {
+      "label": "comp_up_clean",
+      "candidate": {
+        "allowed_regimes": [
+          "trending_up_clean"
+        ],
+        "regime_windows_spec": {
+          "medium": {
+            "classifier": "composite",
+            "period": 14,
+            "thresholds": {
+              "return_eff": 0.05,
+              "range_eff": 0.03,
+              "adx": 25.0,
+              "efficiency": 0.5
+            }
+          }
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -0.48,
+          "return_pct": -4.39,
+          "max_dd_pct": -9.9,
+          "ddadj": -0.443,
+          "trades": 10,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -0.124,
+          "return_pct": -2.4,
+          "max_dd_pct": -14.21,
+          "ddadj": -0.169,
+          "trades": 6,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.768,
+          "return_pct": 57.16,
+          "max_dd_pct": -16.9,
+          "ddadj": 3.382,
+          "trades": 12,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.725,
+          "return_pct": 10.88,
+          "max_dd_pct": -23.5,
+          "ddadj": 0.463,
+          "trades": 5,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": 0.857,
+          "return_pct": 13.54,
+          "max_dd_pct": -14.01,
+          "ddadj": 0.966,
+          "trades": 9,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": -0.384,
+          "return_pct": -8.28,
+          "max_dd_pct": -32.67,
+          "ddadj": -0.253,
+          "trades": 3,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.658,
+      "mean_sharpe": 0.56,
+      "mean_return_pct": 11.08,
+      "worst_max_dd_pct": -32.67,
+      "total_trades": 45
+    },
+    {
+      "label": "m4_bear_selective",
+      "candidate": {
+        "profile_allocation": {
+          "window_spec": {
+            "classifier": "adx",
+            "period": 14,
+            "adx_threshold": 20.0
+          },
+          "profiles": {
+            "trending_up": "on",
+            "ranging": "on",
+            "trending_down": "off"
+          },
+          "param_sets": {
+            "on": {},
+            "off": {
+              "lookback": 55,
+              "atr_multiplier": 2.5
+            }
+          },
+          "confirm_bars": 2,
+          "initial_profile": "on"
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -0.888,
+          "return_pct": -14.64,
+          "max_dd_pct": -23.19,
+          "ddadj": -0.631,
+          "trades": 26,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -0.603,
+          "return_pct": -8.2,
+          "max_dd_pct": -14.44,
+          "ddadj": -0.568,
+          "trades": 10,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.562,
+          "return_pct": 71.32,
+          "max_dd_pct": -15.19,
+          "ddadj": 4.695,
+          "trades": 30,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.493,
+          "return_pct": 6.97,
+          "max_dd_pct": -39.56,
+          "ddadj": 0.176,
+          "trades": 11,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": 0.192,
+          "return_pct": -1.72,
+          "max_dd_pct": -37.13,
+          "ddadj": -0.046,
+          "trades": 33,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": 0.334,
+          "return_pct": 2.75,
+          "max_dd_pct": -36.73,
+          "ddadj": 0.075,
+          "trades": 8,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.617,
+      "mean_sharpe": 0.348,
+      "mean_return_pct": 9.41,
+      "worst_max_dd_pct": -39.56,
+      "total_trades": 118
+    },
+    {
+      "label": "m4_bear_off",
+      "candidate": {
+        "profile_allocation": {
+          "window_spec": {
+            "classifier": "adx",
+            "period": 14,
+            "adx_threshold": 20.0
+          },
+          "profiles": {
+            "trending_up": "on",
+            "ranging": "on",
+            "trending_down": "off"
+          },
+          "param_sets": {
+            "on": {},
+            "off": {
+              "atr_multiplier": 100.0
+            }
+          },
+          "confirm_bars": 2,
+          "initial_profile": "on"
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -0.888,
+          "return_pct": -13.24,
+          "max_dd_pct": -20.97,
+          "ddadj": -0.631,
+          "trades": 29,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -0.603,
+          "return_pct": -8.2,
+          "max_dd_pct": -14.44,
+          "ddadj": -0.568,
+          "trades": 10,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.562,
+          "return_pct": 71.32,
+          "max_dd_pct": -15.19,
+          "ddadj": 4.695,
+          "trades": 30,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.493,
+          "return_pct": 6.97,
+          "max_dd_pct": -39.56,
+          "ddadj": 0.176,
+          "trades": 11,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": -0.407,
+          "return_pct": -16.09,
+          "max_dd_pct": -37.13,
+          "ddadj": -0.433,
+          "trades": 37,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": 0.334,
+          "return_pct": 2.75,
+          "max_dd_pct": -36.73,
+          "ddadj": 0.075,
+          "trades": 8,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.552,
+      "mean_sharpe": 0.248,
+      "mean_return_pct": 7.25,
+      "worst_max_dd_pct": -39.56,
+      "total_trades": 125
+    },
+    {
+      "label": "m4_trend_only",
+      "candidate": {
+        "profile_allocation": {
+          "window_spec": {
+            "classifier": "adx",
+            "period": 14,
+            "adx_threshold": 20.0
+          },
+          "profiles": {
+            "trending_up": "on",
+            "ranging": "off",
+            "trending_down": "off"
+          },
+          "param_sets": {
+            "on": {},
+            "off": {
+              "atr_multiplier": 100.0
+            }
+          },
+          "confirm_bars": 2,
+          "initial_profile": "on"
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -0.639,
+          "return_pct": -7.76,
+          "max_dd_pct": -15.87,
+          "ddadj": -0.489,
+          "trades": 19,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -0.682,
+          "return_pct": -8.21,
+          "max_dd_pct": -15.21,
+          "ddadj": -0.54,
+          "trades": 7,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.005,
+          "return_pct": 42.9,
+          "max_dd_pct": -21.06,
+          "ddadj": 2.037,
+          "trades": 20,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.313,
+          "return_pct": 2.71,
+          "max_dd_pct": -29.13,
+          "ddadj": 0.093,
+          "trades": 7,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": 0.369,
+          "return_pct": 3.87,
+          "max_dd_pct": -23.03,
+          "ddadj": 0.168,
+          "trades": 23,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": 1.126,
+          "return_pct": 20.44,
+          "max_dd_pct": -19.0,
+          "ddadj": 1.076,
+          "trades": 3,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.391,
+      "mean_sharpe": 0.415,
+      "mean_return_pct": 8.99,
+      "worst_max_dd_pct": -29.13,
+      "total_trades": 79
+    },
+    {
+      "label": "m4_comp_bear_off",
+      "candidate": {
+        "profile_allocation": {
+          "window_spec": {
+            "classifier": "composite",
+            "period": 14
+          },
+          "profiles": {
+            "trending_up_clean": "on",
+            "trending_up_choppy": "on",
+            "ranging_quiet": "on",
+            "ranging_volatile": "on",
+            "ranging_directional": "on",
+            "ranging_directional_up": "on",
+            "ranging_directional_down": "on",
+            "trending_down_clean": "off",
+            "trending_down_choppy": "off"
+          },
+          "param_sets": {
+            "on": {},
+            "off": {
+              "atr_multiplier": 100.0
+            }
+          },
+          "confirm_bars": 2,
+          "initial_profile": "on"
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -1.098,
+          "return_pct": -17.69,
+          "max_dd_pct": -25.02,
+          "ddadj": -0.707,
+          "trades": 35,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -1.404,
+          "return_pct": -19.51,
+          "max_dd_pct": -24.56,
+          "ddadj": -0.794,
+          "trades": 13,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.291,
+          "return_pct": 71.99,
+          "max_dd_pct": -18.11,
+          "ddadj": 3.975,
+          "trades": 38,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.76,
+          "return_pct": 14.48,
+          "max_dd_pct": -35.79,
+          "ddadj": 0.405,
+          "trades": 11,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": -0.189,
+          "return_pct": -12.57,
+          "max_dd_pct": -41.19,
+          "ddadj": -0.305,
+          "trades": 39,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": -0.567,
+          "return_pct": -21.21,
+          "max_dd_pct": -52.17,
+          "ddadj": -0.407,
+          "trades": 11,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.361,
+      "mean_sharpe": -0.035,
+      "mean_return_pct": 2.58,
+      "worst_max_dd_pct": -52.17,
+      "total_trades": 147
+    },
+    {
+      "label": "adx_not_down",
+      "candidate": {
+        "allowed_regimes": [
+          "trending_up",
+          "ranging"
+        ],
+        "regime_windows_spec": {
+          "medium": {
+            "classifier": "adx",
+            "period": 14,
+            "adx_threshold": 20.0
+          }
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -0.987,
+          "return_pct": -16.25,
+          "max_dd_pct": -23.71,
+          "ddadj": -0.685,
+          "trades": 34,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -1.404,
+          "return_pct": -19.51,
+          "max_dd_pct": -24.56,
+          "ddadj": -0.794,
+          "trades": 13,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.323,
+          "return_pct": 70.18,
+          "max_dd_pct": -19.01,
+          "ddadj": 3.692,
+          "trades": 36,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.76,
+          "return_pct": 14.48,
+          "max_dd_pct": -35.79,
+          "ddadj": 0.405,
+          "trades": 11,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": -0.326,
+          "return_pct": -16.24,
+          "max_dd_pct": -43.66,
+          "ddadj": -0.372,
+          "trades": 40,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": -0.156,
+          "return_pct": -11.0,
+          "max_dd_pct": -45.97,
+          "ddadj": -0.239,
+          "trades": 10,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.335,
+      "mean_sharpe": 0.035,
+      "mean_return_pct": 3.61,
+      "worst_max_dd_pct": -45.97,
+      "total_trades": 144
+    },
+    {
+      "label": "adx_up",
+      "candidate": {
+        "allowed_regimes": [
+          "trending_up"
+        ],
+        "regime_windows_spec": {
+          "medium": {
+            "classifier": "adx",
+            "period": 14,
+            "adx_threshold": 20.0
+          }
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -1.064,
+          "return_pct": -16.28,
+          "max_dd_pct": -23.47,
+          "ddadj": -0.694,
+          "trades": 28,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -1.305,
+          "return_pct": -17.34,
+          "max_dd_pct": -23.85,
+          "ddadj": -0.727,
+          "trades": 10,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.193,
+          "return_pct": 59.63,
+          "max_dd_pct": -19.47,
+          "ddadj": 3.063,
+          "trades": 30,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.736,
+          "return_pct": 12.85,
+          "max_dd_pct": -30.11,
+          "ddadj": 0.427,
+          "trades": 8,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": 0.278,
+          "return_pct": 1.02,
+          "max_dd_pct": -31.66,
+          "ddadj": 0.032,
+          "trades": 29,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": -0.081,
+          "return_pct": -7.4,
+          "max_dd_pct": -37.01,
+          "ddadj": -0.2,
+          "trades": 7,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.317,
+      "mean_sharpe": 0.126,
+      "mean_return_pct": 5.41,
+      "worst_max_dd_pct": -37.01,
+      "total_trades": 112
+    },
+    {
+      "label": "adx_trend_only",
+      "candidate": {
+        "allowed_regimes": [
+          "trending_up",
+          "trending_down"
+        ],
+        "regime_windows_spec": {
+          "medium": {
+            "classifier": "adx",
+            "period": 14,
+            "adx_threshold": 20.0
+          }
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -1.188,
+          "return_pct": -17.99,
+          "max_dd_pct": -25.03,
+          "ddadj": -0.719,
+          "trades": 29,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -1.305,
+          "return_pct": -17.34,
+          "max_dd_pct": -23.85,
+          "ddadj": -0.727,
+          "trades": 10,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.188,
+          "return_pct": 63.73,
+          "max_dd_pct": -19.47,
+          "ddadj": 3.273,
+          "trades": 32,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.736,
+          "return_pct": 12.85,
+          "max_dd_pct": -30.11,
+          "ddadj": 0.427,
+          "trades": 8,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": 0.3,
+          "return_pct": 1.47,
+          "max_dd_pct": -31.66,
+          "ddadj": 0.046,
+          "trades": 30,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": -0.545,
+          "return_pct": -18.03,
+          "max_dd_pct": -44.24,
+          "ddadj": -0.408,
+          "trades": 8,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.315,
+      "mean_sharpe": 0.031,
+      "mean_return_pct": 4.11,
+      "worst_max_dd_pct": -44.24,
+      "total_trades": 117
+    },
+    {
+      "label": "baseline",
+      "candidate": {
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -1.105,
+          "return_pct": -17.96,
+          "max_dd_pct": -25.27,
+          "ddadj": -0.711,
+          "trades": 35,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -1.404,
+          "return_pct": -19.51,
+          "max_dd_pct": -24.56,
+          "ddadj": -0.794,
+          "trades": 13,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.228,
+          "return_pct": 70.11,
+          "max_dd_pct": -19.01,
+          "ddadj": 3.688,
+          "trades": 38,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.76,
+          "return_pct": 14.48,
+          "max_dd_pct": -35.79,
+          "ddadj": 0.405,
+          "trades": 11,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": -0.244,
+          "return_pct": -14.24,
+          "max_dd_pct": -42.32,
+          "ddadj": -0.336,
+          "trades": 40,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": -0.567,
+          "return_pct": -21.21,
+          "max_dd_pct": -52.17,
+          "ddadj": -0.407,
+          "trades": 11,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.308,
+      "mean_sharpe": -0.055,
+      "mean_return_pct": 1.94,
+      "worst_max_dd_pct": -52.17,
+      "total_trades": 148
+    },
+    {
+      "label": "comp_not_down",
+      "candidate": {
+        "allowed_regimes": [
+          "trending_up_clean",
+          "trending_up_choppy",
+          "ranging_quiet",
+          "ranging_volatile",
+          "ranging_directional"
+        ],
+        "regime_windows_spec": {
+          "medium": {
+            "classifier": "composite",
+            "period": 14,
+            "thresholds": {
+              "return_eff": 0.05,
+              "range_eff": 0.03,
+              "adx": 25.0,
+              "efficiency": 0.5
+            }
+          }
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -1.105,
+          "return_pct": -17.96,
+          "max_dd_pct": -25.27,
+          "ddadj": -0.711,
+          "trades": 35,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -1.404,
+          "return_pct": -19.51,
+          "max_dd_pct": -24.56,
+          "ddadj": -0.794,
+          "trades": 13,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.228,
+          "return_pct": 70.11,
+          "max_dd_pct": -19.01,
+          "ddadj": 3.688,
+          "trades": 38,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.76,
+          "return_pct": 14.48,
+          "max_dd_pct": -35.79,
+          "ddadj": 0.405,
+          "trades": 11,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": -0.244,
+          "return_pct": -14.24,
+          "max_dd_pct": -42.32,
+          "ddadj": -0.336,
+          "trades": 40,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": -0.567,
+          "return_pct": -21.21,
+          "max_dd_pct": -52.17,
+          "ddadj": -0.407,
+          "trades": 11,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.308,
+      "mean_sharpe": -0.055,
+      "mean_return_pct": 1.94,
+      "worst_max_dd_pct": -52.17,
+      "total_trades": 148
+    },
+    {
+      "label": "comp_up_family",
+      "candidate": {
+        "allowed_regimes": [
+          "trending_up_clean",
+          "trending_up_choppy"
+        ],
+        "regime_windows_spec": {
+          "medium": {
+            "classifier": "composite",
+            "period": 14,
+            "thresholds": {
+              "return_eff": 0.05,
+              "range_eff": 0.03,
+              "adx": 25.0,
+              "efficiency": 0.5
+            }
+          }
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -1.284,
+          "return_pct": -20.15,
+          "max_dd_pct": -27.26,
+          "ddadj": -0.739,
+          "trades": 35,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -1.404,
+          "return_pct": -19.51,
+          "max_dd_pct": -24.56,
+          "ddadj": -0.794,
+          "trades": 13,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.169,
+          "return_pct": 67.45,
+          "max_dd_pct": -19.01,
+          "ddadj": 3.548,
+          "trades": 38,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.76,
+          "return_pct": 14.48,
+          "max_dd_pct": -35.79,
+          "ddadj": 0.405,
+          "trades": 11,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": -0.244,
+          "return_pct": -14.24,
+          "max_dd_pct": -42.32,
+          "ddadj": -0.336,
+          "trades": 40,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": -0.567,
+          "return_pct": -21.21,
+          "max_dd_pct": -52.17,
+          "ddadj": -0.407,
+          "trades": 11,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.28,
+      "mean_sharpe": -0.095,
+      "mean_return_pct": 1.14,
+      "worst_max_dd_pct": -52.17,
+      "total_trades": 148
+    },
+    {
+      "label": "comp_not_down_calm",
+      "candidate": {
+        "allowed_regimes": [
+          "trending_up_clean",
+          "trending_up_choppy",
+          "ranging_quiet",
+          "ranging_directional"
+        ],
+        "regime_windows_spec": {
+          "medium": {
+            "classifier": "composite",
+            "period": 14,
+            "thresholds": {
+              "return_eff": 0.05,
+              "range_eff": 0.03,
+              "adx": 25.0,
+              "efficiency": 0.5
+            }
+          }
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -1.284,
+          "return_pct": -20.15,
+          "max_dd_pct": -27.26,
+          "ddadj": -0.739,
+          "trades": 35,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -1.404,
+          "return_pct": -19.51,
+          "max_dd_pct": -24.56,
+          "ddadj": -0.794,
+          "trades": 13,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.169,
+          "return_pct": 67.45,
+          "max_dd_pct": -19.01,
+          "ddadj": 3.548,
+          "trades": 38,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.76,
+          "return_pct": 14.48,
+          "max_dd_pct": -35.79,
+          "ddadj": 0.405,
+          "trades": 11,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": -0.244,
+          "return_pct": -14.24,
+          "max_dd_pct": -42.32,
+          "ddadj": -0.336,
+          "trades": 40,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": -0.567,
+          "return_pct": -21.21,
+          "max_dd_pct": -52.17,
+          "ddadj": -0.407,
+          "trades": 11,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.28,
+      "mean_sharpe": -0.095,
+      "mean_return_pct": 1.14,
+      "worst_max_dd_pct": -52.17,
+      "total_trades": 148
+    },
+    {
+      "label": "comp_up_plus_dir_up",
+      "candidate": {
+        "allowed_regimes": [
+          "trending_up_clean",
+          "trending_up_choppy",
+          "ranging_directional_up"
+        ],
+        "regime_windows_spec": {
+          "medium": {
+            "classifier": "composite",
+            "period": 14,
+            "thresholds": {
+              "return_eff": 0.05,
+              "range_eff": 0.03,
+              "adx": 25.0,
+              "efficiency": 0.5
+            }
+          }
+        },
+        "direction": "long",
+        "name": "breakout"
+      },
+      "legs": {
+        "BTC/USDT 1h": {
+          "sharpe": -1.284,
+          "return_pct": -20.15,
+          "max_dd_pct": -27.26,
+          "ddadj": -0.739,
+          "trades": 35,
+          "bh_return_pct": -20.07,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "BTC/USDT 4h": {
+          "sharpe": -1.404,
+          "return_pct": -19.51,
+          "max_dd_pct": -24.56,
+          "ddadj": -0.794,
+          "trades": 13,
+          "bh_return_pct": -19.54,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 1h": {
+          "sharpe": 2.169,
+          "return_pct": 67.45,
+          "max_dd_pct": -19.01,
+          "ddadj": 3.548,
+          "trades": 38,
+          "bh_return_pct": 10.85,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "ETH/USDT 4h": {
+          "sharpe": 0.76,
+          "return_pct": 14.48,
+          "max_dd_pct": -35.79,
+          "ddadj": 0.405,
+          "trades": 11,
+          "bh_return_pct": 11.35,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 1h": {
+          "sharpe": -0.244,
+          "return_pct": -14.24,
+          "max_dd_pct": -42.32,
+          "ddadj": -0.336,
+          "trades": 40,
+          "bh_return_pct": -21.9,
+          "liquidated": false,
+          "span_days": 205.0
+        },
+        "SOL/USDT 4h": {
+          "sharpe": -0.567,
+          "return_pct": -21.21,
+          "max_dd_pct": -52.17,
+          "ddadj": -0.407,
+          "trades": 11,
+          "bh_return_pct": -21.19,
+          "liquidated": false,
+          "span_days": 205.0
+        }
+      },
+      "mean_ddadj": 0.28,
+      "mean_sharpe": -0.095,
+      "mean_return_pct": 1.14,
+      "worst_max_dd_pct": -52.17,
+      "total_trades": 148
+    }
+  ]
+}

--- a/backtest/candidates/breakout_1165/sweep_regime_gates.py
+++ b/backtest/candidates/breakout_1165/sweep_regime_gates.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""IS-window regime-gate screen for breakout (#1165, M4 on a frozen entry).
+
+Both #1165 arms in one screen, entry AND close stack frozen (registry-default
+params, open-signal-as-close, no SL/TP — the only protocol IS+OOS pass per
+#984): Arm A gates WHEN the entry may fire (`allowed_regimes` over the legacy
+ADX and composite 9-state classifiers via `regime_windows_spec`), Arm B moves
+the regime response into the position (#998 two-profile allocation, flat-only
+switch). Scores every candidate on the six audit datasets over the protocol
+IS window via the M1 harness (eval_windows.run_leg, audit-identical
+fees/slippage), ranked by mean DD-adjusted return — the #1165 headline
+metric. Selection happens HERE (IS only); the shortlist is then judged once
+on protocol OOS + held-out windows through validate_shortlist.py.
+
+`breakout` is futures-registry-only and emits signal=-1 on breakdowns without
+being in bidirectionalPerpsStrategies, so every leg pins direction="long"
+(#996); the -1 stays the (frozen) exit on the plain long/flat path. The
+regime gate blocks entries only — closes always execute — and the M4 switch
+commits only from flat, so an open position keeps its opening profile's
+breakdown exit until it closes.
+
+Strategy-parameterized (--strategy/--registry/--direction) so the
+squeeze_momentum re-run (#983, same DD conclusion) only swaps flags; the M4
+"off"/"selective" param sets live in driver_common.py.
+
+Run from repo root:
+  uv run --no-sync python backtest/candidates/breakout_1165/sweep_regime_gates.py \
+      [--window is] [--plateau-allowed trending_up,ranging] \
+      [--json backtest/candidates/breakout_1165/sweep_is.json]
+"""
+
+import argparse
+import json
+import os
+import statistics
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+sys.path.insert(0, os.path.join(_HERE, "..", ".."))          # backtest/
+sys.path.insert(0, os.path.join(_HERE, "..", "..", "..", "shared_tools"))
+
+from eval_windows import (DATASETS, WINDOWS, dataset_key, run_leg,  # noqa: E402
+                          validate_candidate)
+from driver_common import (build_composite_period_plateau,  # noqa: E402
+                           build_gate_grid, build_gate_threshold_plateau,
+                           build_profile_grid, candidate_leg_kwargs)
+
+
+def score_candidate_row(reg, strategy, candidate, window, capital=1000.0):
+    spec = {k: v for k, v in candidate.items() if k != "label"}
+    spec["name"] = strategy
+    spec.setdefault("direction", "long")
+    validate_candidate(spec)
+    legs = {}
+    for symbol, timeframe in DATASETS:
+        legs[dataset_key(symbol, timeframe)] = run_leg(
+            reg, strategy, spec.get("params"), symbol, timeframe, window,
+            capital=capital, **candidate_leg_kwargs(spec))
+    present = [l for l in legs.values() if l is not None]
+    return {
+        "label": candidate["label"],
+        "candidate": spec,
+        "legs": legs,
+        "mean_ddadj": round(statistics.mean(l["ddadj"] for l in present), 3),
+        "mean_sharpe": round(statistics.mean(l["sharpe"] for l in present), 3),
+        "mean_return_pct": round(statistics.mean(l["return_pct"] for l in present), 2),
+        "worst_max_dd_pct": round(min(l["max_dd_pct"] for l in present), 2),
+        "total_trades": sum(l["trades"] for l in present),
+    }
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument("--strategy", default="breakout")
+    p.add_argument("--registry", choices=["spot", "futures"], default="futures")
+    p.add_argument("--direction", default="long", choices=["long", "short"])
+    p.add_argument("--window", default="is", choices=list(WINDOWS))
+    p.add_argument("--plateau-allowed", default=None,
+                   help="Comma list of ADX labels; adds the gate-threshold "
+                        "plateau rows (15/25/30) for that allowed set")
+    p.add_argument("--comp-plateau-allowed", default=None,
+                   help="Comma list of composite labels; adds the "
+                        "classifier-period plateau rows (10/21/28) for that "
+                        "allowed set")
+    p.add_argument("--grid", default="full", choices=["full", "plateau-only"],
+                   help="'plateau-only' skips the base grid (already "
+                        "committed in sweep_is.json) and runs just the "
+                        "requested plateau rows")
+    p.add_argument("--json", default=None, dest="json_out")
+    args = p.parse_args(argv)
+
+    from registry_loader import load_registry
+    reg = load_registry(args.registry)
+
+    grid = ([] if args.grid == "plateau-only"
+            else build_gate_grid() + build_profile_grid())
+    if args.plateau_allowed:
+        allowed = [s.strip() for s in args.plateau_allowed.split(",") if s.strip()]
+        grid += build_gate_threshold_plateau(allowed)
+    if args.comp_plateau_allowed:
+        allowed = [s.strip() for s in args.comp_plateau_allowed.split(",")
+                   if s.strip()]
+        grid += build_composite_period_plateau(allowed)
+    for c in grid:
+        c["direction"] = args.direction
+
+    window = WINDOWS[args.window]
+    print(f"screening {len(grid)} regime-gate candidates on window "
+          f"{args.window} {window}, entry+close frozen at registry defaults")
+
+    rows = []
+    for i, candidate in enumerate(grid):
+        row = score_candidate_row(reg, args.strategy, candidate, window)
+        rows.append(row)
+        print(f"[{i+1:>2}/{len(grid)}] {row['label']:<24} "
+              f"DDadj {row['mean_ddadj']:>7.3f}  Sharpe {row['mean_sharpe']:>6.2f}  "
+              f"ret {row['mean_return_pct']:>7.2f}%  worstDD {row['worst_max_dd_pct']:>7.2f}%  "
+              f"#T {row['total_trades']}")
+
+    rows.sort(key=lambda r: r["mean_ddadj"], reverse=True)
+    print(f"\n== ranked by mean DDadj (window {args.window}) ==")
+    for r in rows:
+        print(f"{r['label']:<24} DDadj {r['mean_ddadj']:>7.3f}  "
+              f"Sharpe {r['mean_sharpe']:>6.2f}  ret {r['mean_return_pct']:>7.2f}%  "
+              f"worstDD {r['worst_max_dd_pct']:>7.2f}%  #T {r['total_trades']}")
+
+    if args.json_out:
+        with open(args.json_out, "w") as fh:
+            json.dump({"window": args.window, "window_range": list(window),
+                       "strategy": args.strategy, "registry": args.registry,
+                       "rows": rows}, fh, indent=2, default=str)
+        print(f"\nwrote {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backtest/candidates/breakout_1165/validate_shortlist.py
+++ b/backtest/candidates/breakout_1165/validate_shortlist.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Score the #1165 shortlist through the M1 harness, sharing incumbent bars.
+
+Equivalent to running eval_windows.py --candidate-json per candidate across
+all five windows (identical functions, identical harness — evaluate_window
+threads allowed_regimes / regime_windows_spec / profile_allocation natively)
+but in one process so the incumbent-median bars are computed once per window
+instead of once per candidate. Use the per-candidate eval_windows.py command
+from the README (with --registry futures) to reproduce any single table
+independently.
+
+Run from repo root:
+  uv run --no-sync python backtest/candidates/breakout_1165/validate_shortlist.py \
+      [--candidates baseline.json,...] \
+      [--json backtest/candidates/breakout_1165/validation.json]
+"""
+
+import argparse
+import json
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", ".."))          # backtest/
+sys.path.insert(0, os.path.join(_HERE, "..", "..", "..", "shared_tools"))
+
+from eval_windows import (DATASETS, WINDOWS, evaluate_window,   # noqa: E402
+                          format_summary, format_window_report)
+
+CANDIDATES = [
+    "baseline.json",
+    "comp_up_clean.json",
+    "comp_up_clean_p21.json",
+    "m4_bear_off.json",
+    "m4_bear_selective.json",
+]
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument("--json", default=None, dest="json_out")
+    p.add_argument("--candidates", default=None,
+                   help="Comma list of candidate JSON files in this dir "
+                        "(default: the committed shortlist)")
+    p.add_argument("--windows", default=None,
+                   help=f"Comma list (default: all). Known: {', '.join(WINDOWS)}")
+    args = p.parse_args(argv)
+
+    window_names = ([w.strip() for w in args.windows.split(",") if w.strip()]
+                    if args.windows else list(WINDOWS))
+    candidates = ([c.strip() for c in args.candidates.split(",") if c.strip()]
+                  if args.candidates else list(CANDIDATES))
+
+    from registry_loader import load_registry
+    reg = load_registry("futures")
+
+    bars_memo = {}
+    out = {}
+    for fn in candidates:
+        with open(os.path.join(_HERE, fn)) as fh:
+            candidate = json.load(fh)
+        label = fn[:-5]
+        print(f"\n######## candidate: {label} ########")
+        scores = []
+        for wname in window_names:
+            score = evaluate_window(reg, candidate, list(DATASETS), wname,
+                                    1000.0, bars_memo)
+            scores.append(score)
+            print(format_window_report(score))
+        print(format_summary(scores))
+        out[label] = {"candidate": candidate, "window_scores": scores}
+
+    if args.json_out:
+        with open(args.json_out, "w") as fh:
+            json.dump(out, fh, indent=2, default=str)
+        print(f"\nwrote {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backtest/candidates/breakout_1165/validation.json
+++ b/backtest/candidates/breakout_1165/validation.json
@@ -1,0 +1,4413 @@
+{
+  "baseline": {
+    "candidate": {
+      "name": "breakout",
+      "direction": "long"
+    },
+    "window_scores": [
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": -1.105,
+              "return_pct": -17.96,
+              "max_dd_pct": -25.27,
+              "ddadj": -0.711,
+              "trades": 35,
+              "bh_return_pct": -20.07,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -1.02,
+              "ddadj": -0.656,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": -1.404,
+              "return_pct": -19.51,
+              "max_dd_pct": -24.56,
+              "ddadj": -0.794,
+              "trades": 13,
+              "bh_return_pct": -19.54,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -0.325,
+              "ddadj": -0.325,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": 2.228,
+              "return_pct": 70.11,
+              "max_dd_pct": -19.01,
+              "ddadj": 3.688,
+              "trades": 38,
+              "bh_return_pct": 10.85,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": 0.869,
+              "ddadj": 0.593,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 0.76,
+              "return_pct": 14.48,
+              "max_dd_pct": -35.79,
+              "ddadj": 0.405,
+              "trades": 11,
+              "bh_return_pct": 11.35,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": 0.303,
+              "ddadj": 0.112,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": -0.244,
+              "return_pct": -14.24,
+              "max_dd_pct": -42.32,
+              "ddadj": -0.336,
+              "trades": 40,
+              "bh_return_pct": -21.9,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -0.49,
+              "ddadj": -0.45,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": -0.567,
+              "return_pct": -21.21,
+              "max_dd_pct": -52.17,
+              "ddadj": -0.407,
+              "trades": 11,
+              "bh_return_pct": -21.19,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -0.032,
+              "ddadj": -0.119,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": -0.055,
+        "mean_ddadj": 0.308,
+        "mean_bar_sharpe": -0.116,
+        "mean_bar_ddadj": -0.141,
+        "beats_sharpe_count": 3,
+        "beats_ddadj_count": 3,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "pass",
+        "window": "is",
+        "window_range": [
+          "2025-06-10",
+          "2026-01-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": -1.02,
+            "ddadj": -0.656,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": -0.325,
+            "ddadj": -0.325,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": 0.869,
+            "ddadj": 0.593,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": 0.303,
+            "ddadj": 0.112,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": -0.49,
+            "ddadj": -0.45,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": -0.032,
+            "ddadj": -0.119,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": -0.199,
+              "return_pct": -4.22,
+              "max_dd_pct": -15.7,
+              "ddadj": -0.269,
+              "trades": 31,
+              "bh_return_pct": -26.77,
+              "liquidated": false,
+              "span_days": 154.0
+            },
+            "bar": {
+              "sharpe": -1.176,
+              "ddadj": -0.57,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": -0.183,
+              "return_pct": -3.48,
+              "max_dd_pct": -18.03,
+              "ddadj": -0.193,
+              "trades": 6,
+              "bh_return_pct": -27.52,
+              "liquidated": false,
+              "span_days": 154.5
+            },
+            "bar": {
+              "sharpe": -0.301,
+              "ddadj": -0.247,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": -0.805,
+              "return_pct": -16.17,
+              "max_dd_pct": -27.12,
+              "ddadj": -0.596,
+              "trades": 35,
+              "bh_return_pct": -43.99,
+              "liquidated": false,
+              "span_days": 162.7917
+            },
+            "bar": {
+              "sharpe": -0.194,
+              "ddadj": -0.228,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 0.236,
+              "return_pct": 0.81,
+              "max_dd_pct": -15.29,
+              "ddadj": 0.053,
+              "trades": 5,
+              "bh_return_pct": -40.42,
+              "liquidated": false,
+              "span_days": 154.5
+            },
+            "bar": {
+              "sharpe": -0.433,
+              "ddadj": -0.44,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": -0.297,
+              "return_pct": -9.5,
+              "max_dd_pct": -22.8,
+              "ddadj": -0.417,
+              "trades": 34,
+              "bh_return_pct": -46.51,
+              "liquidated": false,
+              "span_days": 162.7917
+            },
+            "bar": {
+              "sharpe": -1.635,
+              "ddadj": -0.795,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": -0.033,
+              "return_pct": -4.03,
+              "max_dd_pct": -14.84,
+              "ddadj": -0.272,
+              "trades": 6,
+              "bh_return_pct": -44.21,
+              "liquidated": false,
+              "span_days": 154.5
+            },
+            "bar": {
+              "sharpe": -0.764,
+              "ddadj": -0.657,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": -0.214,
+        "mean_ddadj": -0.282,
+        "mean_bar_sharpe": -0.75,
+        "mean_bar_ddadj": -0.489,
+        "beats_sharpe_count": 5,
+        "beats_ddadj_count": 5,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "pass",
+        "window": "oos",
+        "window_range": [
+          "2026-01-01",
+          null
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": -1.176,
+            "ddadj": -0.57,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": -0.301,
+            "ddadj": -0.247,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": -0.194,
+            "ddadj": -0.228,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": -0.433,
+            "ddadj": -0.44,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": -1.635,
+            "ddadj": -0.795,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": -0.764,
+            "ddadj": -0.657,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": 0.355,
+              "return_pct": 6.5,
+              "max_dd_pct": -45.69,
+              "ddadj": 0.142,
+              "trades": 87,
+              "bh_return_pct": 157.1,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 1.465,
+              "ddadj": 1.932,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": 2.357,
+              "return_pct": 108.89,
+              "max_dd_pct": -18.77,
+              "ddadj": 5.801,
+              "trades": 19,
+              "bh_return_pct": 156.16,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 1.814,
+              "ddadj": 3.022,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": -0.409,
+              "return_pct": -19.39,
+              "max_dd_pct": -41.82,
+              "ddadj": -0.464,
+              "trades": 86,
+              "bh_return_pct": 92.17,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 0.341,
+              "ddadj": 0.176,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 0.463,
+              "return_pct": 10.62,
+              "max_dd_pct": -33.16,
+              "ddadj": 0.32,
+              "trades": 23,
+              "bh_return_pct": 90.59,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 0.476,
+              "ddadj": 0.341,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 2.273,
+              "return_pct": 325.02,
+              "max_dd_pct": -53.75,
+              "ddadj": 6.047,
+              "trades": 79,
+              "bh_return_pct": 922.79,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 2.564,
+              "ddadj": 9.829,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 2.466,
+              "return_pct": 417.44,
+              "max_dd_pct": -35.2,
+              "ddadj": 11.859,
+              "trades": 18,
+              "bh_return_pct": 931.25,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 2.096,
+              "ddadj": 6.752,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": 1.251,
+        "mean_ddadj": 3.951,
+        "mean_bar_sharpe": 1.459,
+        "mean_bar_ddadj": 3.675,
+        "beats_sharpe_count": 2,
+        "beats_ddadj_count": 2,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "fail",
+        "window": "2023",
+        "window_range": [
+          "2023-01-01",
+          "2024-01-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": 1.465,
+            "ddadj": 1.932,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": 1.814,
+            "ddadj": 3.022,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": 0.341,
+            "ddadj": 0.176,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": 0.476,
+            "ddadj": 0.341,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": 2.564,
+            "ddadj": 9.829,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": 2.096,
+            "ddadj": 6.752,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": 0.827,
+              "return_pct": 26.65,
+              "max_dd_pct": -34.22,
+              "ddadj": 0.779,
+              "trades": 77,
+              "bh_return_pct": 122.08,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.956,
+              "ddadj": 1.123,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": 1.447,
+              "return_pct": 57.9,
+              "max_dd_pct": -29.72,
+              "ddadj": 1.948,
+              "trades": 18,
+              "bh_return_pct": 121.35,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 1.49,
+              "ddadj": 2.325,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": -0.138,
+              "return_pct": -13.55,
+              "max_dd_pct": -50.2,
+              "ddadj": -0.27,
+              "trades": 79,
+              "bh_return_pct": 46.47,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.719,
+              "ddadj": 0.795,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 0.639,
+              "return_pct": 20.28,
+              "max_dd_pct": -47.92,
+              "ddadj": 0.423,
+              "trades": 19,
+              "bh_return_pct": 47.4,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.888,
+              "ddadj": 0.966,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.581,
+              "return_pct": 18.41,
+              "max_dd_pct": -33.06,
+              "ddadj": 0.557,
+              "trades": 76,
+              "bh_return_pct": 88.34,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.591,
+              "ddadj": 0.493,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 1.161,
+              "return_pct": 62.61,
+              "max_dd_pct": -42.71,
+              "ddadj": 1.466,
+              "trades": 15,
+              "bh_return_pct": 85.57,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.781,
+              "ddadj": 0.748,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": 0.753,
+        "mean_ddadj": 0.817,
+        "mean_bar_sharpe": 0.904,
+        "mean_bar_ddadj": 1.075,
+        "beats_sharpe_count": 1,
+        "beats_ddadj_count": 2,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "fail",
+        "window": "2024",
+        "window_range": [
+          "2024-01-01",
+          "2025-01-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": 0.956,
+            "ddadj": 1.123,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": 1.49,
+            "ddadj": 2.325,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": 0.719,
+            "ddadj": 0.795,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": 0.888,
+            "ddadj": 0.966,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": 0.591,
+            "ddadj": 0.493,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": 0.781,
+            "ddadj": 0.748,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": -1.181,
+              "return_pct": -20.88,
+              "max_dd_pct": -31.75,
+              "ddadj": -0.658,
+              "trades": 39,
+              "bh_return_pct": 13.78,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.529,
+              "ddadj": -0.479,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": -0.683,
+              "return_pct": -14.22,
+              "max_dd_pct": -18.91,
+              "ddadj": -0.752,
+              "trades": 11,
+              "bh_return_pct": 14.42,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": 0.11,
+              "ddadj": 0.024,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": -2.096,
+              "return_pct": -45.0,
+              "max_dd_pct": -58.97,
+              "ddadj": -0.763,
+              "trades": 46,
+              "bh_return_pct": -25.89,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.671,
+              "ddadj": -0.54,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": -1.995,
+              "return_pct": -41.88,
+              "max_dd_pct": -55.0,
+              "ddadj": -0.761,
+              "trades": 12,
+              "bh_return_pct": -25.91,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -1.075,
+              "ddadj": -0.634,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.268,
+              "return_pct": -3.36,
+              "max_dd_pct": -46.9,
+              "ddadj": -0.072,
+              "trades": 36,
+              "bh_return_pct": -19.57,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.295,
+              "ddadj": -0.37,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": -0.198,
+              "return_pct": -14.98,
+              "max_dd_pct": -45.98,
+              "ddadj": -0.326,
+              "trades": 10,
+              "bh_return_pct": -19.16,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.085,
+              "ddadj": -0.2,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": -0.981,
+        "mean_ddadj": -0.555,
+        "mean_bar_sharpe": -0.424,
+        "mean_bar_ddadj": -0.366,
+        "beats_sharpe_count": 1,
+        "beats_ddadj_count": 1,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "fail",
+        "window": "2025H1",
+        "window_range": [
+          "2025-01-01",
+          "2025-07-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": -0.529,
+            "ddadj": -0.479,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": 0.11,
+            "ddadj": 0.024,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": -0.671,
+            "ddadj": -0.54,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": -1.075,
+            "ddadj": -0.634,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": -0.295,
+            "ddadj": -0.37,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": -0.085,
+            "ddadj": -0.2,
+            "n": 8
+          }
+        }
+      }
+    ]
+  },
+  "comp_up_clean": {
+    "candidate": {
+      "name": "breakout",
+      "direction": "long",
+      "allowed_regimes": [
+        "trending_up_clean"
+      ],
+      "regime_windows_spec": {
+        "medium": {
+          "classifier": "composite",
+          "period": 14,
+          "thresholds": {
+            "return_eff": 0.05,
+            "range_eff": 0.03,
+            "adx": 25.0,
+            "efficiency": 0.5
+          }
+        }
+      }
+    },
+    "window_scores": [
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": -0.48,
+              "return_pct": -4.39,
+              "max_dd_pct": -9.9,
+              "ddadj": -0.443,
+              "trades": 10,
+              "bh_return_pct": -20.07,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -1.02,
+              "ddadj": -0.656,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": -0.124,
+              "return_pct": -2.4,
+              "max_dd_pct": -14.21,
+              "ddadj": -0.169,
+              "trades": 6,
+              "bh_return_pct": -19.54,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -0.325,
+              "ddadj": -0.325,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": 2.768,
+              "return_pct": 57.16,
+              "max_dd_pct": -16.9,
+              "ddadj": 3.382,
+              "trades": 12,
+              "bh_return_pct": 10.85,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": 0.869,
+              "ddadj": 0.593,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 0.725,
+              "return_pct": 10.88,
+              "max_dd_pct": -23.5,
+              "ddadj": 0.463,
+              "trades": 5,
+              "bh_return_pct": 11.35,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": 0.303,
+              "ddadj": 0.112,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.857,
+              "return_pct": 13.54,
+              "max_dd_pct": -14.01,
+              "ddadj": 0.966,
+              "trades": 9,
+              "bh_return_pct": -21.9,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -0.49,
+              "ddadj": -0.45,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": -0.384,
+              "return_pct": -8.28,
+              "max_dd_pct": -32.67,
+              "ddadj": -0.253,
+              "trades": 3,
+              "bh_return_pct": -21.19,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -0.032,
+              "ddadj": -0.119,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": 0.56,
+        "mean_ddadj": 0.658,
+        "mean_bar_sharpe": -0.116,
+        "mean_bar_ddadj": -0.141,
+        "beats_sharpe_count": 5,
+        "beats_ddadj_count": 5,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "pass",
+        "window": "is",
+        "window_range": [
+          "2025-06-10",
+          "2026-01-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": -1.02,
+            "ddadj": -0.656,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": -0.325,
+            "ddadj": -0.325,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": 0.869,
+            "ddadj": 0.593,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": 0.303,
+            "ddadj": 0.112,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": -0.49,
+            "ddadj": -0.45,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": -0.032,
+            "ddadj": -0.119,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": -0.959,
+              "return_pct": -8.73,
+              "max_dd_pct": -13.77,
+              "ddadj": -0.634,
+              "trades": 14,
+              "bh_return_pct": -26.77,
+              "liquidated": false,
+              "span_days": 154.0
+            },
+            "bar": {
+              "sharpe": -1.176,
+              "ddadj": -0.57,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": 0.826,
+              "return_pct": 5.21,
+              "max_dd_pct": -5.89,
+              "ddadj": 0.885,
+              "trades": 2,
+              "bh_return_pct": -27.52,
+              "liquidated": false,
+              "span_days": 154.5
+            },
+            "bar": {
+              "sharpe": -0.301,
+              "ddadj": -0.247,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": -1.413,
+              "return_pct": -13.93,
+              "max_dd_pct": -21.95,
+              "ddadj": -0.635,
+              "trades": 13,
+              "bh_return_pct": -43.99,
+              "liquidated": false,
+              "span_days": 162.7917
+            },
+            "bar": {
+              "sharpe": -0.194,
+              "ddadj": -0.228,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": -1.059,
+              "return_pct": -8.05,
+              "max_dd_pct": -11.98,
+              "ddadj": -0.672,
+              "trades": 2,
+              "bh_return_pct": -40.42,
+              "liquidated": false,
+              "span_days": 154.5
+            },
+            "bar": {
+              "sharpe": -0.433,
+              "ddadj": -0.44,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.101,
+              "return_pct": -0.61,
+              "max_dd_pct": -12.03,
+              "ddadj": -0.051,
+              "trades": 11,
+              "bh_return_pct": -46.51,
+              "liquidated": false,
+              "span_days": 162.7917
+            },
+            "bar": {
+              "sharpe": -1.635,
+              "ddadj": -0.795,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": -1.665,
+              "return_pct": -16.51,
+              "max_dd_pct": -21.3,
+              "ddadj": -0.775,
+              "trades": 4,
+              "bh_return_pct": -44.21,
+              "liquidated": false,
+              "span_days": 154.5
+            },
+            "bar": {
+              "sharpe": -0.764,
+              "ddadj": -0.657,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": -0.695,
+        "mean_ddadj": -0.314,
+        "mean_bar_sharpe": -0.75,
+        "mean_bar_ddadj": -0.489,
+        "beats_sharpe_count": 3,
+        "beats_ddadj_count": 2,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "pass",
+        "window": "oos",
+        "window_range": [
+          "2026-01-01",
+          null
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": -1.176,
+            "ddadj": -0.57,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": -0.301,
+            "ddadj": -0.247,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": -0.194,
+            "ddadj": -0.228,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": -0.433,
+            "ddadj": -0.44,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": -1.635,
+            "ddadj": -0.795,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": -0.764,
+            "ddadj": -0.657,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": 0.904,
+              "return_pct": 23.16,
+              "max_dd_pct": -33.87,
+              "ddadj": 0.684,
+              "trades": 37,
+              "bh_return_pct": 157.1,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 1.465,
+              "ddadj": 1.932,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": 2.462,
+              "return_pct": 89.39,
+              "max_dd_pct": -12.12,
+              "ddadj": 7.375,
+              "trades": 8,
+              "bh_return_pct": 156.16,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 1.814,
+              "ddadj": 3.022,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": -0.26,
+              "return_pct": -10.32,
+              "max_dd_pct": -29.97,
+              "ddadj": -0.344,
+              "trades": 36,
+              "bh_return_pct": 92.17,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 0.341,
+              "ddadj": 0.176,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 1.092,
+              "return_pct": 30.23,
+              "max_dd_pct": -18.69,
+              "ddadj": 1.617,
+              "trades": 9,
+              "bh_return_pct": 90.59,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 0.476,
+              "ddadj": 0.341,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 2.259,
+              "return_pct": 248.45,
+              "max_dd_pct": -34.39,
+              "ddadj": 7.224,
+              "trades": 32,
+              "bh_return_pct": 922.79,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 2.564,
+              "ddadj": 9.829,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 1.804,
+              "return_pct": 155.52,
+              "max_dd_pct": -21.06,
+              "ddadj": 7.385,
+              "trades": 9,
+              "bh_return_pct": 931.25,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 2.096,
+              "ddadj": 6.752,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": 1.377,
+        "mean_ddadj": 3.99,
+        "mean_bar_sharpe": 1.459,
+        "mean_bar_ddadj": 3.675,
+        "beats_sharpe_count": 2,
+        "beats_ddadj_count": 3,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "fail",
+        "window": "2023",
+        "window_range": [
+          "2023-01-01",
+          "2024-01-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": 1.465,
+            "ddadj": 1.932,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": 1.814,
+            "ddadj": 3.022,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": 0.341,
+            "ddadj": 0.176,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": 0.476,
+            "ddadj": 0.341,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": 2.564,
+            "ddadj": 9.829,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": 2.096,
+            "ddadj": 6.752,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": 0.64,
+              "return_pct": 13.53,
+              "max_dd_pct": -29.66,
+              "ddadj": 0.456,
+              "trades": 29,
+              "bh_return_pct": 122.08,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.956,
+              "ddadj": 1.123,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": 1.084,
+              "return_pct": 29.4,
+              "max_dd_pct": -26.57,
+              "ddadj": 1.107,
+              "trades": 8,
+              "bh_return_pct": 121.35,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 1.49,
+              "ddadj": 2.325,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": 0.395,
+              "return_pct": 7.51,
+              "max_dd_pct": -36.58,
+              "ddadj": 0.205,
+              "trades": 32,
+              "bh_return_pct": 46.47,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.719,
+              "ddadj": 0.795,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 1.682,
+              "return_pct": 69.69,
+              "max_dd_pct": -13.63,
+              "ddadj": 5.113,
+              "trades": 6,
+              "bh_return_pct": 47.4,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.888,
+              "ddadj": 0.966,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.223,
+              "return_pct": 0.34,
+              "max_dd_pct": -36.56,
+              "ddadj": 0.009,
+              "trades": 32,
+              "bh_return_pct": 88.34,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.591,
+              "ddadj": 0.493,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 0.496,
+              "return_pct": 12.73,
+              "max_dd_pct": -31.25,
+              "ddadj": 0.407,
+              "trades": 8,
+              "bh_return_pct": 85.57,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.781,
+              "ddadj": 0.748,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": 0.753,
+        "mean_ddadj": 1.216,
+        "mean_bar_sharpe": 0.904,
+        "mean_bar_ddadj": 1.075,
+        "beats_sharpe_count": 1,
+        "beats_ddadj_count": 1,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "fail",
+        "window": "2024",
+        "window_range": [
+          "2024-01-01",
+          "2025-01-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": 0.956,
+            "ddadj": 1.123,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": 1.49,
+            "ddadj": 2.325,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": 0.719,
+            "ddadj": 0.795,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": 0.888,
+            "ddadj": 0.966,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": 0.591,
+            "ddadj": 0.493,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": 0.781,
+            "ddadj": 0.748,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": -1.003,
+              "return_pct": -9.03,
+              "max_dd_pct": -13.89,
+              "ddadj": -0.65,
+              "trades": 14,
+              "bh_return_pct": 13.78,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.529,
+              "ddadj": -0.479,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": -1.271,
+              "return_pct": -16.61,
+              "max_dd_pct": -16.81,
+              "ddadj": -0.988,
+              "trades": 5,
+              "bh_return_pct": 14.42,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": 0.11,
+              "ddadj": 0.024,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": 0.538,
+              "return_pct": 6.35,
+              "max_dd_pct": -31.14,
+              "ddadj": 0.204,
+              "trades": 13,
+              "bh_return_pct": -25.89,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.671,
+              "ddadj": -0.54,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": -2.218,
+              "return_pct": -26.38,
+              "max_dd_pct": -26.38,
+              "ddadj": -1.0,
+              "trades": 3,
+              "bh_return_pct": -25.91,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -1.075,
+              "ddadj": -0.634,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 1.08,
+              "return_pct": 25.22,
+              "max_dd_pct": -27.15,
+              "ddadj": 0.929,
+              "trades": 13,
+              "bh_return_pct": -19.57,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.295,
+              "ddadj": -0.37,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": -0.071,
+              "return_pct": -5.69,
+              "max_dd_pct": -30.54,
+              "ddadj": -0.186,
+              "trades": 5,
+              "bh_return_pct": -19.16,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.085,
+              "ddadj": -0.2,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": -0.491,
+        "mean_ddadj": -0.282,
+        "mean_bar_sharpe": -0.424,
+        "mean_bar_ddadj": -0.366,
+        "beats_sharpe_count": 3,
+        "beats_ddadj_count": 3,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "fail",
+        "window": "2025H1",
+        "window_range": [
+          "2025-01-01",
+          "2025-07-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": -0.529,
+            "ddadj": -0.479,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": 0.11,
+            "ddadj": 0.024,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": -0.671,
+            "ddadj": -0.54,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": -1.075,
+            "ddadj": -0.634,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": -0.295,
+            "ddadj": -0.37,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": -0.085,
+            "ddadj": -0.2,
+            "n": 8
+          }
+        }
+      }
+    ]
+  },
+  "comp_up_clean_p21": {
+    "candidate": {
+      "name": "breakout",
+      "direction": "long",
+      "allowed_regimes": [
+        "trending_up_clean"
+      ],
+      "regime_windows_spec": {
+        "medium": {
+          "classifier": "composite",
+          "period": 21,
+          "thresholds": {
+            "return_eff": 0.05,
+            "range_eff": 0.03,
+            "adx": 25.0,
+            "efficiency": 0.5
+          }
+        }
+      }
+    },
+    "window_scores": [
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": -0.687,
+              "return_pct": -5.06,
+              "max_dd_pct": -9.9,
+              "ddadj": -0.511,
+              "trades": 8,
+              "bh_return_pct": -20.07,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -1.02,
+              "ddadj": -0.656,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": -0.807,
+              "return_pct": -6.81,
+              "max_dd_pct": -10.95,
+              "ddadj": -0.622,
+              "trades": 4,
+              "bh_return_pct": -19.54,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -0.325,
+              "ddadj": -0.325,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": 2.461,
+              "return_pct": 41.75,
+              "max_dd_pct": -11.6,
+              "ddadj": 3.599,
+              "trades": 9,
+              "bh_return_pct": 10.85,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": 0.869,
+              "ddadj": 0.593,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 2.483,
+              "return_pct": 46.03,
+              "max_dd_pct": -10.87,
+              "ddadj": 4.235,
+              "trades": 2,
+              "bh_return_pct": 11.35,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": 0.303,
+              "ddadj": 0.112,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.266,
+              "return_pct": 1.99,
+              "max_dd_pct": -15.6,
+              "ddadj": 0.128,
+              "trades": 11,
+              "bh_return_pct": -21.9,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -0.49,
+              "ddadj": -0.45,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 0.438,
+              "return_pct": 4.65,
+              "max_dd_pct": -23.18,
+              "ddadj": 0.201,
+              "trades": 2,
+              "bh_return_pct": -21.19,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -0.032,
+              "ddadj": -0.119,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": 0.692,
+        "mean_ddadj": 1.172,
+        "mean_bar_sharpe": -0.116,
+        "mean_bar_ddadj": -0.141,
+        "beats_sharpe_count": 5,
+        "beats_ddadj_count": 5,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "pass",
+        "window": "is",
+        "window_range": [
+          "2025-06-10",
+          "2026-01-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": -1.02,
+            "ddadj": -0.656,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": -0.325,
+            "ddadj": -0.325,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": 0.869,
+            "ddadj": 0.593,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": 0.303,
+            "ddadj": 0.112,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": -0.49,
+            "ddadj": -0.45,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": -0.032,
+            "ddadj": -0.119,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": -1.163,
+              "return_pct": -7.13,
+              "max_dd_pct": -13.27,
+              "ddadj": -0.537,
+              "trades": 8,
+              "bh_return_pct": -26.77,
+              "liquidated": false,
+              "span_days": 154.0
+            },
+            "bar": {
+              "sharpe": -1.176,
+              "ddadj": -0.57,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": 0.468,
+              "return_pct": 2.96,
+              "max_dd_pct": -5.89,
+              "ddadj": 0.503,
+              "trades": 3,
+              "bh_return_pct": -27.52,
+              "liquidated": false,
+              "span_days": 154.5
+            },
+            "bar": {
+              "sharpe": -0.301,
+              "ddadj": -0.247,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": 0.047,
+              "return_pct": -0.44,
+              "max_dd_pct": -11.67,
+              "ddadj": -0.038,
+              "trades": 9,
+              "bh_return_pct": -43.99,
+              "liquidated": false,
+              "span_days": 162.7917
+            },
+            "bar": {
+              "sharpe": -0.194,
+              "ddadj": -0.228,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": -1.696,
+              "return_pct": -11.69,
+              "max_dd_pct": -15.46,
+              "ddadj": -0.756,
+              "trades": 2,
+              "bh_return_pct": -40.42,
+              "liquidated": false,
+              "span_days": 154.5
+            },
+            "bar": {
+              "sharpe": -0.433,
+              "ddadj": -0.44,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.16,
+              "return_pct": 0.56,
+              "max_dd_pct": -9.84,
+              "ddadj": 0.057,
+              "trades": 6,
+              "bh_return_pct": -46.51,
+              "liquidated": false,
+              "span_days": 162.7917
+            },
+            "bar": {
+              "sharpe": -1.635,
+              "ddadj": -0.795,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": -0.234,
+              "return_pct": -2.69,
+              "max_dd_pct": -8.82,
+              "ddadj": -0.305,
+              "trades": 2,
+              "bh_return_pct": -44.21,
+              "liquidated": false,
+              "span_days": 154.5
+            },
+            "bar": {
+              "sharpe": -0.764,
+              "ddadj": -0.657,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": -0.403,
+        "mean_ddadj": -0.179,
+        "mean_bar_sharpe": -0.75,
+        "mean_bar_ddadj": -0.489,
+        "beats_sharpe_count": 5,
+        "beats_ddadj_count": 5,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "pass",
+        "window": "oos",
+        "window_range": [
+          "2026-01-01",
+          null
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": -1.176,
+            "ddadj": -0.57,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": -0.301,
+            "ddadj": -0.247,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": -0.194,
+            "ddadj": -0.228,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": -0.433,
+            "ddadj": -0.44,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": -1.635,
+            "ddadj": -0.795,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": -0.764,
+            "ddadj": -0.657,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": 1.46,
+              "return_pct": 41.74,
+              "max_dd_pct": -26.78,
+              "ddadj": 1.559,
+              "trades": 26,
+              "bh_return_pct": 157.1,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 1.465,
+              "ddadj": 1.932,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": 2.314,
+              "return_pct": 73.68,
+              "max_dd_pct": -12.12,
+              "ddadj": 6.079,
+              "trades": 7,
+              "bh_return_pct": 156.16,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 1.814,
+              "ddadj": 3.022,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": -0.372,
+              "return_pct": -10.93,
+              "max_dd_pct": -26.25,
+              "ddadj": -0.416,
+              "trades": 24,
+              "bh_return_pct": 92.17,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 0.341,
+              "ddadj": 0.176,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 0.957,
+              "return_pct": 24.13,
+              "max_dd_pct": -18.89,
+              "ddadj": 1.277,
+              "trades": 7,
+              "bh_return_pct": 90.59,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 0.476,
+              "ddadj": 0.341,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 1.692,
+              "return_pct": 123.14,
+              "max_dd_pct": -34.52,
+              "ddadj": 3.567,
+              "trades": 24,
+              "bh_return_pct": 922.79,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 2.564,
+              "ddadj": 9.829,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 2.095,
+              "return_pct": 197.36,
+              "max_dd_pct": -21.06,
+              "ddadj": 9.371,
+              "trades": 7,
+              "bh_return_pct": 931.25,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 2.096,
+              "ddadj": 6.752,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": 1.358,
+        "mean_ddadj": 3.573,
+        "mean_bar_sharpe": 1.459,
+        "mean_bar_ddadj": 3.675,
+        "beats_sharpe_count": 2,
+        "beats_ddadj_count": 3,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "fail",
+        "window": "2023",
+        "window_range": [
+          "2023-01-01",
+          "2024-01-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": 1.465,
+            "ddadj": 1.932,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": 1.814,
+            "ddadj": 3.022,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": 0.341,
+            "ddadj": 0.176,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": 0.476,
+            "ddadj": 0.341,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": 2.564,
+            "ddadj": 9.829,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": 2.096,
+            "ddadj": 6.752,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": 0.784,
+              "return_pct": 16.66,
+              "max_dd_pct": -25.28,
+              "ddadj": 0.659,
+              "trades": 24,
+              "bh_return_pct": 122.08,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.956,
+              "ddadj": 1.123,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": 1.07,
+              "return_pct": 26.85,
+              "max_dd_pct": -22.22,
+              "ddadj": 1.208,
+              "trades": 7,
+              "bh_return_pct": 121.35,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 1.49,
+              "ddadj": 2.325,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": 0.123,
+              "return_pct": 0.16,
+              "max_dd_pct": -22.89,
+              "ddadj": 0.007,
+              "trades": 19,
+              "bh_return_pct": 46.47,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.719,
+              "ddadj": 0.795,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 1.171,
+              "return_pct": 42.19,
+              "max_dd_pct": -26.43,
+              "ddadj": 1.596,
+              "trades": 8,
+              "bh_return_pct": 47.4,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.888,
+              "ddadj": 0.966,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.183,
+              "return_pct": 0.19,
+              "max_dd_pct": -24.96,
+              "ddadj": 0.008,
+              "trades": 20,
+              "bh_return_pct": 88.34,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.591,
+              "ddadj": 0.493,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 0.752,
+              "return_pct": 22.98,
+              "max_dd_pct": -17.87,
+              "ddadj": 1.286,
+              "trades": 6,
+              "bh_return_pct": 85.57,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.781,
+              "ddadj": 0.748,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": 0.68,
+        "mean_ddadj": 0.794,
+        "mean_bar_sharpe": 0.904,
+        "mean_bar_ddadj": 1.075,
+        "beats_sharpe_count": 1,
+        "beats_ddadj_count": 2,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "fail",
+        "window": "2024",
+        "window_range": [
+          "2024-01-01",
+          "2025-01-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": 0.956,
+            "ddadj": 1.123,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": 1.49,
+            "ddadj": 2.325,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": 0.719,
+            "ddadj": 0.795,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": 0.888,
+            "ddadj": 0.966,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": 0.591,
+            "ddadj": 0.493,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": 0.781,
+            "ddadj": 0.748,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": 0.146,
+              "return_pct": 0.53,
+              "max_dd_pct": -9.3,
+              "ddadj": 0.057,
+              "trades": 10,
+              "bh_return_pct": 13.78,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.529,
+              "ddadj": -0.479,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": -1.103,
+              "return_pct": -7.46,
+              "max_dd_pct": -11.4,
+              "ddadj": -0.654,
+              "trades": 3,
+              "bh_return_pct": 14.42,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": 0.11,
+              "ddadj": 0.024,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": 1.588,
+              "return_pct": 21.9,
+              "max_dd_pct": -13.81,
+              "ddadj": 1.586,
+              "trades": 8,
+              "bh_return_pct": -25.89,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.671,
+              "ddadj": -0.54,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": -1.424,
+              "return_pct": -17.62,
+              "max_dd_pct": -24.31,
+              "ddadj": -0.725,
+              "trades": 4,
+              "bh_return_pct": -25.91,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -1.075,
+              "ddadj": -0.634,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.598,
+              "return_pct": 9.01,
+              "max_dd_pct": -25.17,
+              "ddadj": 0.358,
+              "trades": 8,
+              "bh_return_pct": -19.57,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.295,
+              "ddadj": -0.37,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 0.187,
+              "return_pct": 0.37,
+              "max_dd_pct": -19.01,
+              "ddadj": 0.019,
+              "trades": 2,
+              "bh_return_pct": -19.16,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.085,
+              "ddadj": -0.2,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": -0.001,
+        "mean_ddadj": 0.107,
+        "mean_bar_sharpe": -0.424,
+        "mean_bar_ddadj": -0.366,
+        "beats_sharpe_count": 4,
+        "beats_ddadj_count": 4,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "pass",
+        "window": "2025H1",
+        "window_range": [
+          "2025-01-01",
+          "2025-07-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": -0.529,
+            "ddadj": -0.479,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": 0.11,
+            "ddadj": 0.024,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": -0.671,
+            "ddadj": -0.54,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": -1.075,
+            "ddadj": -0.634,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": -0.295,
+            "ddadj": -0.37,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": -0.085,
+            "ddadj": -0.2,
+            "n": 8
+          }
+        }
+      }
+    ]
+  },
+  "m4_bear_off": {
+    "candidate": {
+      "name": "breakout",
+      "direction": "long",
+      "profile_allocation": {
+        "window_spec": {
+          "classifier": "adx",
+          "period": 14,
+          "adx_threshold": 20.0
+        },
+        "profiles": {
+          "trending_up": "on",
+          "ranging": "on",
+          "trending_down": "off"
+        },
+        "param_sets": {
+          "on": {},
+          "off": {
+            "atr_multiplier": 100.0
+          }
+        },
+        "confirm_bars": 2,
+        "initial_profile": "on"
+      }
+    },
+    "window_scores": [
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": -0.888,
+              "return_pct": -13.24,
+              "max_dd_pct": -20.97,
+              "ddadj": -0.631,
+              "trades": 29,
+              "bh_return_pct": -20.07,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -1.02,
+              "ddadj": -0.656,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": -0.603,
+              "return_pct": -8.2,
+              "max_dd_pct": -14.44,
+              "ddadj": -0.568,
+              "trades": 10,
+              "bh_return_pct": -19.54,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -0.325,
+              "ddadj": -0.325,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": 2.562,
+              "return_pct": 71.32,
+              "max_dd_pct": -15.19,
+              "ddadj": 4.695,
+              "trades": 30,
+              "bh_return_pct": 10.85,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": 0.869,
+              "ddadj": 0.593,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 0.493,
+              "return_pct": 6.97,
+              "max_dd_pct": -39.56,
+              "ddadj": 0.176,
+              "trades": 11,
+              "bh_return_pct": 11.35,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": 0.303,
+              "ddadj": 0.112,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": -0.407,
+              "return_pct": -16.09,
+              "max_dd_pct": -37.13,
+              "ddadj": -0.433,
+              "trades": 37,
+              "bh_return_pct": -21.9,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -0.49,
+              "ddadj": -0.45,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 0.334,
+              "return_pct": 2.75,
+              "max_dd_pct": -36.73,
+              "ddadj": 0.075,
+              "trades": 8,
+              "bh_return_pct": -21.19,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -0.032,
+              "ddadj": -0.119,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": 0.248,
+        "mean_ddadj": 0.552,
+        "mean_bar_sharpe": -0.116,
+        "mean_bar_ddadj": -0.141,
+        "beats_sharpe_count": 5,
+        "beats_ddadj_count": 5,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "pass",
+        "window": "is",
+        "window_range": [
+          "2025-06-10",
+          "2026-01-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": -1.02,
+            "ddadj": -0.656,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": -0.325,
+            "ddadj": -0.325,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": 0.869,
+            "ddadj": 0.593,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": 0.303,
+            "ddadj": 0.112,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": -0.49,
+            "ddadj": -0.45,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": -0.032,
+            "ddadj": -0.119,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": 0.148,
+              "return_pct": 0.11,
+              "max_dd_pct": -14.86,
+              "ddadj": 0.007,
+              "trades": 25,
+              "bh_return_pct": -26.77,
+              "liquidated": false,
+              "span_days": 154.0
+            },
+            "bar": {
+              "sharpe": -1.176,
+              "ddadj": -0.57,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": -0.424,
+              "return_pct": -6.02,
+              "max_dd_pct": -20.19,
+              "ddadj": -0.298,
+              "trades": 6,
+              "bh_return_pct": -27.52,
+              "liquidated": false,
+              "span_days": 154.5
+            },
+            "bar": {
+              "sharpe": -0.301,
+              "ddadj": -0.247,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": -0.775,
+              "return_pct": -14.88,
+              "max_dd_pct": -27.46,
+              "ddadj": -0.542,
+              "trades": 31,
+              "bh_return_pct": -43.99,
+              "liquidated": false,
+              "span_days": 162.7917
+            },
+            "bar": {
+              "sharpe": -0.194,
+              "ddadj": -0.228,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 0.236,
+              "return_pct": 0.81,
+              "max_dd_pct": -15.29,
+              "ddadj": 0.053,
+              "trades": 5,
+              "bh_return_pct": -40.42,
+              "liquidated": false,
+              "span_days": 154.5
+            },
+            "bar": {
+              "sharpe": -0.433,
+              "ddadj": -0.44,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.543,
+              "return_pct": 6.36,
+              "max_dd_pct": -16.8,
+              "ddadj": 0.379,
+              "trades": 26,
+              "bh_return_pct": -46.51,
+              "liquidated": false,
+              "span_days": 162.7917
+            },
+            "bar": {
+              "sharpe": -1.635,
+              "ddadj": -0.795,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 0.096,
+              "return_pct": -1.65,
+              "max_dd_pct": -18.61,
+              "ddadj": -0.089,
+              "trades": 5,
+              "bh_return_pct": -44.21,
+              "liquidated": false,
+              "span_days": 154.5
+            },
+            "bar": {
+              "sharpe": -0.764,
+              "ddadj": -0.657,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": -0.029,
+        "mean_ddadj": -0.082,
+        "mean_bar_sharpe": -0.75,
+        "mean_bar_ddadj": -0.489,
+        "beats_sharpe_count": 4,
+        "beats_ddadj_count": 4,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "pass",
+        "window": "oos",
+        "window_range": [
+          "2026-01-01",
+          null
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": -1.176,
+            "ddadj": -0.57,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": -0.301,
+            "ddadj": -0.247,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": -0.194,
+            "ddadj": -0.228,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": -0.433,
+            "ddadj": -0.44,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": -1.635,
+            "ddadj": -0.795,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": -0.764,
+            "ddadj": -0.657,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": 0.016,
+              "return_pct": -4.85,
+              "max_dd_pct": -47.65,
+              "ddadj": -0.102,
+              "trades": 81,
+              "bh_return_pct": 157.1,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 1.465,
+              "ddadj": 1.932,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": 2.314,
+              "return_pct": 96.67,
+              "max_dd_pct": -19.72,
+              "ddadj": 4.902,
+              "trades": 19,
+              "bh_return_pct": 156.16,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 1.814,
+              "ddadj": 3.022,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": -0.496,
+              "return_pct": -20.76,
+              "max_dd_pct": -41.78,
+              "ddadj": -0.497,
+              "trades": 76,
+              "bh_return_pct": 92.17,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 0.341,
+              "ddadj": 0.176,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 0.428,
+              "return_pct": 9.15,
+              "max_dd_pct": -34.05,
+              "ddadj": 0.269,
+              "trades": 22,
+              "bh_return_pct": 90.59,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 0.476,
+              "ddadj": 0.341,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 2.659,
+              "return_pct": 454.67,
+              "max_dd_pct": -44.19,
+              "ddadj": 10.289,
+              "trades": 65,
+              "bh_return_pct": 922.79,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 2.564,
+              "ddadj": 9.829,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 2.669,
+              "return_pct": 501.47,
+              "max_dd_pct": -35.2,
+              "ddadj": 14.246,
+              "trades": 16,
+              "bh_return_pct": 931.25,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 2.096,
+              "ddadj": 6.752,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": 1.265,
+        "mean_ddadj": 4.851,
+        "mean_bar_sharpe": 1.459,
+        "mean_bar_ddadj": 3.675,
+        "beats_sharpe_count": 3,
+        "beats_ddadj_count": 3,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "fail",
+        "window": "2023",
+        "window_range": [
+          "2023-01-01",
+          "2024-01-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": 1.465,
+            "ddadj": 1.932,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": 1.814,
+            "ddadj": 3.022,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": 0.341,
+            "ddadj": 0.176,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": 0.476,
+            "ddadj": 0.341,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": 2.564,
+            "ddadj": 9.829,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": 2.096,
+            "ddadj": 6.752,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": 0.934,
+              "return_pct": 29.98,
+              "max_dd_pct": -32.88,
+              "ddadj": 0.912,
+              "trades": 68,
+              "bh_return_pct": 122.08,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.956,
+              "ddadj": 1.123,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": 1.409,
+              "return_pct": 54.73,
+              "max_dd_pct": -30.45,
+              "ddadj": 1.797,
+              "trades": 16,
+              "bh_return_pct": 121.35,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 1.49,
+              "ddadj": 2.325,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": 0.003,
+              "return_pct": -6.93,
+              "max_dd_pct": -46.77,
+              "ddadj": -0.148,
+              "trades": 68,
+              "bh_return_pct": 46.47,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.719,
+              "ddadj": 0.795,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 0.9,
+              "return_pct": 33.38,
+              "max_dd_pct": -37.52,
+              "ddadj": 0.89,
+              "trades": 15,
+              "bh_return_pct": 47.4,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.888,
+              "ddadj": 0.966,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.863,
+              "return_pct": 39.72,
+              "max_dd_pct": -32.3,
+              "ddadj": 1.23,
+              "trades": 67,
+              "bh_return_pct": 88.34,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.591,
+              "ddadj": 0.493,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 1.172,
+              "return_pct": 63.29,
+              "max_dd_pct": -42.71,
+              "ddadj": 1.482,
+              "trades": 14,
+              "bh_return_pct": 85.57,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.781,
+              "ddadj": 0.748,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": 0.88,
+        "mean_ddadj": 1.027,
+        "mean_bar_sharpe": 0.904,
+        "mean_bar_ddadj": 1.075,
+        "beats_sharpe_count": 3,
+        "beats_ddadj_count": 2,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "fail",
+        "window": "2024",
+        "window_range": [
+          "2024-01-01",
+          "2025-01-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": 0.956,
+            "ddadj": 1.123,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": 1.49,
+            "ddadj": 2.325,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": 0.719,
+            "ddadj": 0.795,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": 0.888,
+            "ddadj": 0.966,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": 0.591,
+            "ddadj": 0.493,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": 0.781,
+            "ddadj": 0.748,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": -1.338,
+              "return_pct": -21.88,
+              "max_dd_pct": -33.3,
+              "ddadj": -0.657,
+              "trades": 37,
+              "bh_return_pct": 13.78,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.529,
+              "ddadj": -0.479,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": -1.013,
+              "return_pct": -15.02,
+              "max_dd_pct": -17.43,
+              "ddadj": -0.862,
+              "trades": 10,
+              "bh_return_pct": 14.42,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": 0.11,
+              "ddadj": 0.024,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": -1.001,
+              "return_pct": -24.08,
+              "max_dd_pct": -44.05,
+              "ddadj": -0.547,
+              "trades": 40,
+              "bh_return_pct": -25.89,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.671,
+              "ddadj": -0.54,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": -0.542,
+              "return_pct": -14.24,
+              "max_dd_pct": -33.12,
+              "ddadj": -0.43,
+              "trades": 9,
+              "bh_return_pct": -25.91,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -1.075,
+              "ddadj": -0.634,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.222,
+              "return_pct": -4.34,
+              "max_dd_pct": -46.15,
+              "ddadj": -0.094,
+              "trades": 33,
+              "bh_return_pct": -19.57,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.295,
+              "ddadj": -0.37,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 0.101,
+              "return_pct": -5.74,
+              "max_dd_pct": -37.0,
+              "ddadj": -0.155,
+              "trades": 8,
+              "bh_return_pct": -19.16,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.085,
+              "ddadj": -0.2,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": -0.595,
+        "mean_ddadj": -0.458,
+        "mean_bar_sharpe": -0.424,
+        "mean_bar_ddadj": -0.366,
+        "beats_sharpe_count": 3,
+        "beats_ddadj_count": 3,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "fail",
+        "window": "2025H1",
+        "window_range": [
+          "2025-01-01",
+          "2025-07-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": -0.529,
+            "ddadj": -0.479,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": 0.11,
+            "ddadj": 0.024,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": -0.671,
+            "ddadj": -0.54,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": -1.075,
+            "ddadj": -0.634,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": -0.295,
+            "ddadj": -0.37,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": -0.085,
+            "ddadj": -0.2,
+            "n": 8
+          }
+        }
+      }
+    ]
+  },
+  "m4_bear_selective": {
+    "candidate": {
+      "name": "breakout",
+      "direction": "long",
+      "profile_allocation": {
+        "window_spec": {
+          "classifier": "adx",
+          "period": 14,
+          "adx_threshold": 20.0
+        },
+        "profiles": {
+          "trending_up": "on",
+          "ranging": "on",
+          "trending_down": "off"
+        },
+        "param_sets": {
+          "on": {},
+          "off": {
+            "lookback": 55,
+            "atr_multiplier": 2.5
+          }
+        },
+        "confirm_bars": 2,
+        "initial_profile": "on"
+      }
+    },
+    "window_scores": [
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": -0.888,
+              "return_pct": -14.64,
+              "max_dd_pct": -23.19,
+              "ddadj": -0.631,
+              "trades": 26,
+              "bh_return_pct": -20.07,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -1.02,
+              "ddadj": -0.656,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": -0.603,
+              "return_pct": -8.2,
+              "max_dd_pct": -14.44,
+              "ddadj": -0.568,
+              "trades": 10,
+              "bh_return_pct": -19.54,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -0.325,
+              "ddadj": -0.325,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": 2.562,
+              "return_pct": 71.32,
+              "max_dd_pct": -15.19,
+              "ddadj": 4.695,
+              "trades": 30,
+              "bh_return_pct": 10.85,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": 0.869,
+              "ddadj": 0.593,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 0.493,
+              "return_pct": 6.97,
+              "max_dd_pct": -39.56,
+              "ddadj": 0.176,
+              "trades": 11,
+              "bh_return_pct": 11.35,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": 0.303,
+              "ddadj": 0.112,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.192,
+              "return_pct": -1.72,
+              "max_dd_pct": -37.13,
+              "ddadj": -0.046,
+              "trades": 33,
+              "bh_return_pct": -21.9,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -0.49,
+              "ddadj": -0.45,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 0.334,
+              "return_pct": 2.75,
+              "max_dd_pct": -36.73,
+              "ddadj": 0.075,
+              "trades": 8,
+              "bh_return_pct": -21.19,
+              "liquidated": false,
+              "span_days": 205.0
+            },
+            "bar": {
+              "sharpe": -0.032,
+              "ddadj": -0.119,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": 0.348,
+        "mean_ddadj": 0.617,
+        "mean_bar_sharpe": -0.116,
+        "mean_bar_ddadj": -0.141,
+        "beats_sharpe_count": 5,
+        "beats_ddadj_count": 5,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "pass",
+        "window": "is",
+        "window_range": [
+          "2025-06-10",
+          "2026-01-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": -1.02,
+            "ddadj": -0.656,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": -0.325,
+            "ddadj": -0.325,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": 0.869,
+            "ddadj": 0.593,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": 0.303,
+            "ddadj": 0.112,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": -0.49,
+            "ddadj": -0.45,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": -0.032,
+            "ddadj": -0.119,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": 0.128,
+              "return_pct": -0.16,
+              "max_dd_pct": -15.1,
+              "ddadj": -0.011,
+              "trades": 25,
+              "bh_return_pct": -26.77,
+              "liquidated": false,
+              "span_days": 154.0
+            },
+            "bar": {
+              "sharpe": -1.176,
+              "ddadj": -0.57,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": -0.424,
+              "return_pct": -6.02,
+              "max_dd_pct": -20.19,
+              "ddadj": -0.298,
+              "trades": 6,
+              "bh_return_pct": -27.52,
+              "liquidated": false,
+              "span_days": 154.5
+            },
+            "bar": {
+              "sharpe": -0.301,
+              "ddadj": -0.247,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": -0.775,
+              "return_pct": -14.88,
+              "max_dd_pct": -27.46,
+              "ddadj": -0.542,
+              "trades": 31,
+              "bh_return_pct": -43.99,
+              "liquidated": false,
+              "span_days": 162.7917
+            },
+            "bar": {
+              "sharpe": -0.194,
+              "ddadj": -0.228,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 0.236,
+              "return_pct": 0.81,
+              "max_dd_pct": -15.29,
+              "ddadj": 0.053,
+              "trades": 5,
+              "bh_return_pct": -40.42,
+              "liquidated": false,
+              "span_days": 154.5
+            },
+            "bar": {
+              "sharpe": -0.433,
+              "ddadj": -0.44,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.543,
+              "return_pct": 6.36,
+              "max_dd_pct": -16.8,
+              "ddadj": 0.379,
+              "trades": 26,
+              "bh_return_pct": -46.51,
+              "liquidated": false,
+              "span_days": 162.7917
+            },
+            "bar": {
+              "sharpe": -1.635,
+              "ddadj": -0.795,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 0.096,
+              "return_pct": -1.65,
+              "max_dd_pct": -18.61,
+              "ddadj": -0.089,
+              "trades": 5,
+              "bh_return_pct": -44.21,
+              "liquidated": false,
+              "span_days": 154.5
+            },
+            "bar": {
+              "sharpe": -0.764,
+              "ddadj": -0.657,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": -0.033,
+        "mean_ddadj": -0.085,
+        "mean_bar_sharpe": -0.75,
+        "mean_bar_ddadj": -0.489,
+        "beats_sharpe_count": 4,
+        "beats_ddadj_count": 4,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "pass",
+        "window": "oos",
+        "window_range": [
+          "2026-01-01",
+          null
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": -1.176,
+            "ddadj": -0.57,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": -0.301,
+            "ddadj": -0.247,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": -0.194,
+            "ddadj": -0.228,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": -0.433,
+            "ddadj": -0.44,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": -1.635,
+            "ddadj": -0.795,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": -0.764,
+            "ddadj": -0.657,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": -0.09,
+              "return_pct": -8.17,
+              "max_dd_pct": -49.47,
+              "ddadj": -0.165,
+              "trades": 82,
+              "bh_return_pct": 157.1,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 1.465,
+              "ddadj": 1.932,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": 2.156,
+              "return_pct": 88.34,
+              "max_dd_pct": -23.12,
+              "ddadj": 3.821,
+              "trades": 19,
+              "bh_return_pct": 156.16,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 1.814,
+              "ddadj": 3.022,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": -0.48,
+              "return_pct": -20.51,
+              "max_dd_pct": -41.59,
+              "ddadj": -0.493,
+              "trades": 76,
+              "bh_return_pct": 92.17,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 0.341,
+              "ddadj": 0.176,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 0.428,
+              "return_pct": 9.15,
+              "max_dd_pct": -34.05,
+              "ddadj": 0.269,
+              "trades": 22,
+              "bh_return_pct": 90.59,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 0.476,
+              "ddadj": 0.341,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 2.659,
+              "return_pct": 454.67,
+              "max_dd_pct": -44.19,
+              "ddadj": 10.289,
+              "trades": 65,
+              "bh_return_pct": 922.79,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 2.564,
+              "ddadj": 9.829,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 2.669,
+              "return_pct": 501.47,
+              "max_dd_pct": -35.2,
+              "ddadj": 14.246,
+              "trades": 16,
+              "bh_return_pct": 931.25,
+              "liquidated": false,
+              "span_days": 365.0
+            },
+            "bar": {
+              "sharpe": 2.096,
+              "ddadj": 6.752,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": 1.224,
+        "mean_ddadj": 4.661,
+        "mean_bar_sharpe": 1.459,
+        "mean_bar_ddadj": 3.675,
+        "beats_sharpe_count": 3,
+        "beats_ddadj_count": 3,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "fail",
+        "window": "2023",
+        "window_range": [
+          "2023-01-01",
+          "2024-01-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": 1.465,
+            "ddadj": 1.932,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": 1.814,
+            "ddadj": 3.022,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": 0.341,
+            "ddadj": 0.176,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": 0.476,
+            "ddadj": 0.341,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": 2.564,
+            "ddadj": 9.829,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": 2.096,
+            "ddadj": 6.752,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": 0.796,
+              "return_pct": 25.36,
+              "max_dd_pct": -37.17,
+              "ddadj": 0.682,
+              "trades": 67,
+              "bh_return_pct": 122.08,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.956,
+              "ddadj": 1.123,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": 1.409,
+              "return_pct": 54.73,
+              "max_dd_pct": -30.45,
+              "ddadj": 1.797,
+              "trades": 16,
+              "bh_return_pct": 121.35,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 1.49,
+              "ddadj": 2.325,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": -0.01,
+              "return_pct": -9.58,
+              "max_dd_pct": -54.34,
+              "ddadj": -0.176,
+              "trades": 60,
+              "bh_return_pct": 46.47,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.719,
+              "ddadj": 0.795,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": 0.9,
+              "return_pct": 33.38,
+              "max_dd_pct": -37.52,
+              "ddadj": 0.89,
+              "trades": 15,
+              "bh_return_pct": 47.4,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.888,
+              "ddadj": 0.966,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.85,
+              "return_pct": 38.9,
+              "max_dd_pct": -32.3,
+              "ddadj": 1.204,
+              "trades": 66,
+              "bh_return_pct": 88.34,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.591,
+              "ddadj": 0.493,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 1.172,
+              "return_pct": 63.29,
+              "max_dd_pct": -42.71,
+              "ddadj": 1.482,
+              "trades": 14,
+              "bh_return_pct": 85.57,
+              "liquidated": false,
+              "span_days": 366.0
+            },
+            "bar": {
+              "sharpe": 0.781,
+              "ddadj": 0.748,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": 0.853,
+        "mean_ddadj": 0.98,
+        "mean_bar_sharpe": 0.904,
+        "mean_bar_ddadj": 1.075,
+        "beats_sharpe_count": 3,
+        "beats_ddadj_count": 2,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "fail",
+        "window": "2024",
+        "window_range": [
+          "2024-01-01",
+          "2025-01-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": 0.956,
+            "ddadj": 1.123,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": 1.49,
+            "ddadj": 2.325,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": 0.719,
+            "ddadj": 0.795,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": 0.888,
+            "ddadj": 0.966,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": 0.591,
+            "ddadj": 0.493,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": 0.781,
+            "ddadj": 0.748,
+            "n": 8
+          }
+        }
+      },
+      {
+        "rows": [
+          {
+            "dataset": "BTC/USDT 1h",
+            "leg": {
+              "sharpe": -1.316,
+              "return_pct": -22.69,
+              "max_dd_pct": -33.99,
+              "ddadj": -0.668,
+              "trades": 37,
+              "bh_return_pct": 13.78,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.529,
+              "ddadj": -0.479,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "BTC/USDT 4h",
+            "leg": {
+              "sharpe": -1.013,
+              "return_pct": -15.02,
+              "max_dd_pct": -17.43,
+              "ddadj": -0.862,
+              "trades": 10,
+              "bh_return_pct": 14.42,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": 0.11,
+              "ddadj": 0.024,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 1h",
+            "leg": {
+              "sharpe": -0.988,
+              "return_pct": -25.09,
+              "max_dd_pct": -44.79,
+              "ddadj": -0.56,
+              "trades": 39,
+              "bh_return_pct": -25.89,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.671,
+              "ddadj": -0.54,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "ETH/USDT 4h",
+            "leg": {
+              "sharpe": -1.513,
+              "return_pct": -33.01,
+              "max_dd_pct": -47.76,
+              "ddadj": -0.691,
+              "trades": 10,
+              "bh_return_pct": -25.91,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -1.075,
+              "ddadj": -0.634,
+              "n": 8
+            },
+            "beats_sharpe": false,
+            "beats_ddadj": false
+          },
+          {
+            "dataset": "SOL/USDT 1h",
+            "leg": {
+              "sharpe": 0.222,
+              "return_pct": -4.34,
+              "max_dd_pct": -46.15,
+              "ddadj": -0.094,
+              "trades": 33,
+              "bh_return_pct": -19.57,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.295,
+              "ddadj": -0.37,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          },
+          {
+            "dataset": "SOL/USDT 4h",
+            "leg": {
+              "sharpe": 0.101,
+              "return_pct": -5.74,
+              "max_dd_pct": -37.0,
+              "ddadj": -0.155,
+              "trades": 8,
+              "bh_return_pct": -19.16,
+              "liquidated": false,
+              "span_days": 181.0
+            },
+            "bar": {
+              "sharpe": -0.085,
+              "ddadj": -0.2,
+              "n": 8
+            },
+            "beats_sharpe": true,
+            "beats_ddadj": true
+          }
+        ],
+        "scored_datasets": 6,
+        "traded_datasets": 6,
+        "mean_sharpe": -0.751,
+        "mean_ddadj": -0.505,
+        "mean_bar_sharpe": -0.424,
+        "mean_bar_ddadj": -0.366,
+        "beats_sharpe_count": 2,
+        "beats_ddadj_count": 2,
+        "liquidated_legs": 0,
+        "degenerate": false,
+        "verdict": "fail",
+        "window": "2025H1",
+        "window_range": [
+          "2025-01-01",
+          "2025-07-01"
+        ],
+        "bars": {
+          "BTC/USDT 1h": {
+            "sharpe": -0.529,
+            "ddadj": -0.479,
+            "n": 8
+          },
+          "BTC/USDT 4h": {
+            "sharpe": 0.11,
+            "ddadj": 0.024,
+            "n": 8
+          },
+          "ETH/USDT 1h": {
+            "sharpe": -0.671,
+            "ddadj": -0.54,
+            "n": 8
+          },
+          "ETH/USDT 4h": {
+            "sharpe": -1.075,
+            "ddadj": -0.634,
+            "n": 8
+          },
+          "SOL/USDT 1h": {
+            "sharpe": -0.295,
+            "ddadj": -0.37,
+            "n": 8
+          },
+          "SOL/USDT 4h": {
+            "sharpe": -0.085,
+            "ddadj": -0.2,
+            "n": 8
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/tests/test_breakout_1165_drivers.py
+++ b/backtest/tests/test_breakout_1165_drivers.py
@@ -1,0 +1,97 @@
+"""Tests for the #1165 regime-gate driver plumbing (pure helpers, no data
+access).
+
+The load-bearing property: every #1165 candidate carries regime state, and
+``candidate_leg_kwargs`` is the single place it is threaded into run_leg — a
+driver that dropped ``allowed_regimes`` / ``regime_windows_spec`` /
+``profile_allocation`` would silently score the UNGATED entry on the
+continuous audit window (a plausible wrong number, not an error).
+"""
+
+import importlib.util
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..",
+                                "shared_tools"))
+
+from eval_windows import validate_candidate  # noqa: E402
+
+_COMMON_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "candidates", "breakout_1165",
+    "driver_common.py")
+_spec = importlib.util.spec_from_file_location("breakout_1165_driver_common",
+                                               _COMMON_PATH)
+dc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dc)
+
+
+def test_candidate_leg_kwargs_threads_all_regime_state():
+    candidate = {
+        "name": "breakout",
+        "direction": "long",
+        "allowed_regimes": ["trending_up"],
+        "regime_windows_spec": {"medium": {"classifier": "adx", "period": 14,
+                                           "adx_threshold": 25.0}},
+        "profile_allocation": {"window_spec": {"classifier": "adx",
+                                               "period": 14}},
+    }
+    kw = dc.candidate_leg_kwargs(candidate)
+    assert kw["allowed_regimes"] == ["trending_up"]
+    assert kw["regime_windows_spec"]["medium"]["adx_threshold"] == 25.0
+    assert kw["profile_allocation"]["window_spec"]["period"] == 14
+    assert kw["direction"] == "long"
+    # Frozen close stack: nothing may inject a stop the shortlist doesn't own.
+    assert kw["close_strategies"] is None
+    assert kw["stop_loss_atr_mult"] is None
+    assert kw["trailing_stop_atr_mult"] is None
+
+
+def test_candidate_leg_kwargs_defaults_direction_long():
+    # #996: with direction unset the engine path would open shorts on the
+    # breakout's raw signal=-1 — the default must be the pinned long leg.
+    assert dc.candidate_leg_kwargs({"name": "breakout"})["direction"] == "long"
+
+
+def test_gate_grid_labels_unique_and_specs_validate():
+    grid = dc.build_gate_grid() + dc.build_profile_grid() + \
+        dc.build_gate_threshold_plateau(["trending_up", "ranging"])
+    labels = [c["label"] for c in grid]
+    assert len(labels) == len(set(labels))
+    for c in grid:
+        spec = {k: v for k, v in c.items() if k != "label"}
+        spec["name"] = "breakout"
+        validate_candidate(dict(spec))  # raises on malformed candidates
+
+
+def test_not_down_sets_use_bare_ranging_directional():
+    # #1124 bare-covers-subs: the bare label gates both _up and _down; listing
+    # the subs alongside it would be redundant, listing only one sub would
+    # silently gate out the other.
+    assert "ranging_directional" in dc.COMP_NOT_DOWN
+    assert "ranging_directional_up" not in dc.COMP_NOT_DOWN
+    assert "ranging_directional_down" not in dc.COMP_NOT_DOWN
+
+
+def test_profile_grid_maps_every_composite_label():
+    # _ProfileSwitcher holds the active profile on unknown labels (fail-open),
+    # so the composite M4 candidate must map all nine labels explicitly.
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..",
+                                    "shared_tools"))
+    from regime import VALID_LABELS_COMPOSITE
+    comp = next(c for c in dc.build_profile_grid()
+                if c["label"] == "m4_comp_bear_off")
+    profiles = comp["profile_allocation"]["profiles"]
+    assert set(profiles) == set(VALID_LABELS_COMPOSITE)
+    assert profiles["trending_down_clean"] == "off"
+    assert profiles["trending_down_choppy"] == "off"
+
+
+def test_profile_off_set_emits_no_entries():
+    # The "off" profile zeroes the entry list via an unreachable expansion
+    # multiple; the frozen exit survives because the switch is flat-only.
+    assert dc.PARAM_SET_OFF["atr_multiplier"] >= 100.0
+    # "selective" raises the bar without zeroing it.
+    assert dc.PARAM_SET_SELECTIVE["atr_multiplier"] > 1.5
+    assert dc.PARAM_SET_SELECTIVE["lookback"] > 20


### PR DESCRIPTION
Closes #1165

## What

M4 regime-gate research on `breakout` (futures) — the #984 follow-on. Entry, params, and the default close stack stay frozen (open-signal-as-close, the only protocol IS+OOS pass); the sweep is over **when the entry may fire**:

- **Arm A** — `allowed_regimes` entry gates over the legacy ADX and composite 9-state classifiers (via `regime_windows_spec`, the #985/PR-1173 threading; no harness changes needed).
- **Arm B** — #998 two-profile allocation (flat-only switch): full entries in favorable regimes, zero/selective entries otherwise.

New `backtest/candidates/breakout_1165/` (same shape as `breakout_984/`): four strategy-parameterized drivers, `driver_common.py` (single place candidate regime state threads into `run_leg` — a driver dropping it would silently score the ungated entry on the stitched frame), five shortlist candidate JSONs, committed artifacts, README.

## Result — positive (first in the #983/#984/#985 series)

| | protocol OOS | held-out | stitched worst DD | stitched vs B&H | fee drag | #T |
|---|---|---|---:|---:|---:|---:|
| baseline | PASS | 0/3 | -52.2% | +43.7pts | 14.3pp | 260 |
| **`comp_up_clean_p21`** | **PASS** | **1/3** | **-23.2%** | **+56.3pts** | **3.8pp** | **67** |

- Every shortlist member keeps the judged OOS pass — the exact window where all five #984 close stacks died; the gate skips the bear-tape dead-cat re-entries instead of amputating the trend-holds.
- The issue's cautioned failure mode ("block bear entries" amputates the crash edge) is refuted in the opposite direction: not-down label sets block *nothing* (breakout's TR-expansion entry bars label "up" even in bear tapes). The discriminator is trend **quality** (`clean` vs `choppy` composite efficiency), not direction.
- Composite-period plateau is a 14–28 shelf (p14 +0.658 / p21 +1.172 / p28 +0.765 mean IS DDadj, all above baseline +0.308), not a single-cell spike; caveats (IS-peak selection, one-asset-class evidence) stated in the README verdict.
- **No live config change** — evidence only; the live wiring (composite `regime.windows` + `allowed_regimes` on the breakout futures strategy) is named as follow-on work with its own evidence bar, plus the squeeze_momentum re-run the drivers are parameterized for.

## Verification

- `pytest` full suite passes (incl. new `backtest/tests/test_breakout_1165_drivers.py`); `go -C scheduler test ./...` passes; `py_compile` on all drivers.
- Futures `--list-json` byte-identical before/after; nothing under `shared_strategies/` changes.
- All five artifacts regenerate from the committed drivers (commands in the README); `audit_window_headline.json` pins the effective per-dataset cache range (last bars 2026-06-04 → 2026-06-12).

---
LLM: Fable 5 | high | Harness: Claude Code
