### PR TITLE
feat(#1017): default-off RSI/EMA momentum gate on anchored_vwap (rider B)

### DIFF
--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -727,6 +727,8 @@ DEFAULT_PARAM_RANGES = {
         "pivot_strength": [3, 5, 8],
         "buffer_atr_mult": [0.1, 0.25, 0.5],
         "confirm_bars": [1, 2, 3],
+        "gate_rsi_period": [0, 14, 21],
+        "gate_ema_period": [0, 100, 200],
     },
     "anchored_vwap_channel": {
         "pivot_strength": [3, 5, 8],

--- a/shared_strategies/open/anchored_vwap.py
+++ b/shared_strategies/open/anchored_vwap.py
@@ -33,12 +33,28 @@ def _inline_atr(df: pd.DataFrame, period: int) -> pd.Series:
     return atr.where(atr < 100, atr.round(0))
 
 
+def _inline_rsi(close: pd.Series, period: int) -> pd.Series:
+    """Wilder RSI, same convention as the registry's rsi strategy
+    (``ewm(alpha=1/period, min_periods=period, adjust=False)``): NaN through
+    the warmup window, 100 when the window has no losses."""
+    delta = close.diff()
+    gain = delta.clip(lower=0)
+    loss = (-delta).clip(lower=0)
+    avg_gain = gain.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
+    avg_loss = loss.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
+    rs = avg_gain / avg_loss
+    return 100 - (100 / (1 + rs))
+
+
 def anchored_vwap_core(
     df: pd.DataFrame,
     pivot_strength: int = 5,
     buffer_atr_mult: float = 0.25,
     confirm_bars: int = 2,
     atr_period: int = 14,
+    gate_rsi_period: int = 0,
+    gate_rsi_level: float = 50.0,
+    gate_ema_period: int = 0,
 ) -> pd.DataFrame:
     """Single-AVWAP support/resistance-flip signals.
 
@@ -53,6 +69,18 @@ def anchored_vwap_core(
     confirm_bars : bars the close must hold on the correct side of the AVWAP
         (inclusive of the breach bar) before a signal fires.
     atr_period : lookback for the inline ATR.
+    gate_rsi_period : momentum gate (#1017, default-off): when > 0, a long
+        only fires with RSI(gate_rsi_period) >= gate_rsi_level on the signal
+        bar and a short only with RSI <= gate_rsi_level (equality passes both
+        ways). NaN warmup bars pass — the same fail-open semantics as the
+        #982 ``htf_gate_mode="veto"`` neutral state. 0 disables the gate and
+        the output is bit-identical to the pre-gate strategy.
+    gate_rsi_level : RSI midline the gate compares against.
+    gate_ema_period : trend gate (#1017, default-off): when > 0, a long only
+        fires with the signal-bar close >= EMA(gate_ema_period) and a short
+        only with close <= it (equality passes). Bars before the EMA has
+        accrued ``gate_ema_period`` inputs are warmup and pass (mirrors the
+        #982 EMA-warmup convention). 0 disables the gate.
 
     Returns
     -------
@@ -61,6 +89,8 @@ def anchored_vwap_core(
         avwap        : anchored VWAP (NaN before the first confirmed anchor)
         anchor_index : bar index of the active anchor (-1 before the first one)
         atr          : inline ATR
+        gate_rsi     : gate RSI series (only when gate_rsi_period > 0)
+        gate_ema     : gate EMA series (only when gate_ema_period > 0)
     """
     result = df.copy()
     n = len(result)
@@ -138,6 +168,27 @@ def anchored_vwap_core(
                 and close[b] <= avwap[b] - buf
                 and close[b - 1] > avwap[b - 1]):
             sig[nbar] = -1
+
+    # --- momentum/trend gate (#1017 rider B, default-off) ---
+    # Applied after the flip trigger so the gates see exactly the signals the
+    # strategy would otherwise emit (same layering as the #982 chart_pattern
+    # HTF gate). Warmup bars fail open: a gate with no data never blocks.
+    if gate_rsi_period and int(gate_rsi_period) > 0:
+        rsi = _inline_rsi(result["close"].astype(float), int(gate_rsi_period))
+        result["gate_rsi"] = rsi
+        r = rsi.to_numpy()
+        level = float(gate_rsi_level)
+        blocked = ((sig == 1) & (r < level)) | ((sig == -1) & (r > level))
+        blocked &= ~np.isnan(r)
+        sig[blocked] = 0
+    if gate_ema_period and int(gate_ema_period) > 0:
+        p = int(gate_ema_period)
+        ema = result["close"].astype(float).ewm(span=p, adjust=False).mean()
+        result["gate_ema"] = ema
+        e = ema.to_numpy()
+        warm = np.arange(n) >= p
+        blocked = warm & (((sig == 1) & (close < e)) | ((sig == -1) & (close > e)))
+        sig[blocked] = 0
     result["signal"] = sig
 
     return result

--- a/shared_strategies/open/registry.py
+++ b/shared_strategies/open/registry.py
@@ -1135,6 +1135,8 @@ def vwap_rejection_st_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:
         "buffer_atr_mult": 0.25,
         "confirm_bars": 2,
         "atr_period": 14,
+        "gate_rsi_period": 0, "gate_rsi_level": 50.0,
+        "gate_ema_period": 0,
     },
 )
 def anchored_vwap_strategy(df: pd.DataFrame, **params) -> pd.DataFrame:

--- a/shared_strategies/open/test_anchored_vwap.py
+++ b/shared_strategies/open/test_anchored_vwap.py
@@ -6,7 +6,7 @@ import os
 import numpy as np
 import pandas as pd
 
-from anchored_vwap import anchored_vwap_core
+from anchored_vwap import _inline_rsi, anchored_vwap_core
 
 
 def _hourly_index(n, start="2026-01-01 00:00:00"):
@@ -127,6 +127,133 @@ def test_nan_atr_warmup_yields_no_signal():
     df = _long_reclaim_df()
     out = anchored_vwap_core(df, pivot_strength=2, buffer_atr_mult=0.25, confirm_bars=2, atr_period=99)
     assert (out["signal"] == 0).all()
+
+
+# --- Momentum/trend gate (#1017 rider B) ----------------------------------------
+
+_GATE_BASE_KW = dict(pivot_strength=2, buffer_atr_mult=0.0, confirm_bars=2, atr_period=3)
+
+
+def _high_prior_long_reclaim_df():
+    """Long reclaim identical in shape to _long_reclaim_df but preceded by a
+    much higher regime, so a long EMA still sits far above the signal-bar
+    close — the counter-trend case the EMA gate must block."""
+    closes = [140, 138, 136, 134, 132, 100,
+              100.5, 100.2, 99.8, 99.5,
+              103.5, 104.0, 104.5, 105.0]
+    return _ohlcv(closes, volume=10.0)
+
+
+def test_inline_rsi_extremes_and_warmup():
+    rising = pd.Series(np.linspace(100, 113, 14))
+    rsi = _inline_rsi(rising, 3)
+    assert rsi.iloc[:3].isna().all()          # min_periods warmup
+    assert (rsi.iloc[3:] == 100.0).all()      # no losses -> 100
+    falling = pd.Series(np.linspace(113, 100, 14))
+    assert (_inline_rsi(falling, 3).iloc[3:] == 0.0).all()
+
+
+def test_gate_default_off_is_bit_identical():
+    df = _long_reclaim_df()
+    base = anchored_vwap_core(df, **_GATE_BASE_KW)
+    off = anchored_vwap_core(df, **_GATE_BASE_KW, gate_rsi_period=0, gate_ema_period=0)
+    assert (base["signal"] == off["signal"]).all()
+    assert "gate_rsi" not in off.columns and "gate_ema" not in off.columns
+
+
+def test_rsi_gate_blocks_long_below_level_and_passes_above():
+    df = _long_reclaim_df()
+    base = anchored_vwap_core(df, **_GATE_BASE_KW)
+    b = int(np.where(base["signal"].to_numpy() == 1)[0][0])
+    probe = anchored_vwap_core(df, **_GATE_BASE_KW, gate_rsi_period=6, gate_rsi_level=0.0)
+    assert probe["signal"].iloc[b] == 1       # level 0 never blocks a long
+    rsi_b = float(probe["gate_rsi"].iloc[b])
+    assert not np.isnan(rsi_b)
+    blocked = anchored_vwap_core(
+        df, **_GATE_BASE_KW, gate_rsi_period=6, gate_rsi_level=rsi_b + 1.0)
+    assert blocked["signal"].iloc[b] == 0
+    assert (blocked["signal"] == 0).all()     # nothing else fires either
+    passed = anchored_vwap_core(
+        df, **_GATE_BASE_KW, gate_rsi_period=6, gate_rsi_level=rsi_b - 1.0)
+    assert passed["signal"].iloc[b] == 1
+
+
+def test_rsi_gate_blocks_short_above_level_mirror():
+    closes = [90, 92, 94, 96, 98, 100,
+              99.5, 99.8, 100.2, 100.5,
+              96.5, 96.0, 95.5, 95.0]
+    df = _ohlcv(closes, volume=10.0)
+    base = anchored_vwap_core(df, **_GATE_BASE_KW)
+    b = int(np.where(base["signal"].to_numpy() == -1)[0][0])
+    probe = anchored_vwap_core(df, **_GATE_BASE_KW, gate_rsi_period=6, gate_rsi_level=100.0)
+    assert probe["signal"].iloc[b] == -1      # level 100 never blocks a short
+    rsi_b = float(probe["gate_rsi"].iloc[b])
+    blocked = anchored_vwap_core(
+        df, **_GATE_BASE_KW, gate_rsi_period=6, gate_rsi_level=rsi_b - 1.0)
+    assert blocked["signal"].iloc[b] == 0
+    passed = anchored_vwap_core(
+        df, **_GATE_BASE_KW, gate_rsi_period=6, gate_rsi_level=rsi_b + 1.0)
+    assert passed["signal"].iloc[b] == -1
+
+
+def test_rsi_gate_warmup_nan_fails_open():
+    df = _long_reclaim_df()
+    base = anchored_vwap_core(df, **_GATE_BASE_KW)
+    b = int(np.where(base["signal"].to_numpy() == 1)[0][0])
+    gated = anchored_vwap_core(
+        df, **_GATE_BASE_KW, gate_rsi_period=13, gate_rsi_level=100.0)
+    assert np.isnan(gated["gate_rsi"].iloc[b])
+    assert (gated["signal"] == base["signal"]).all()
+
+
+def test_ema_gate_blocks_counter_trend_long():
+    df = _high_prior_long_reclaim_df()
+    base = anchored_vwap_core(df, **_GATE_BASE_KW)
+    longs = np.where(base["signal"].to_numpy() == 1)[0]
+    assert len(longs) == 1
+    b = int(longs[0])
+    gated = anchored_vwap_core(df, **_GATE_BASE_KW, gate_ema_period=10)
+    assert b >= 10                            # past EMA warmup
+    assert float(gated["gate_ema"].iloc[b]) > float(df["close"].iloc[b])
+    assert (gated["signal"] == 0).all()
+
+
+def test_ema_gate_passes_aligned_long_and_short():
+    long_df = _high_prior_long_reclaim_df()
+    base = anchored_vwap_core(long_df, **_GATE_BASE_KW)
+    b = int(np.where(base["signal"].to_numpy() == 1)[0][0])
+    gated = anchored_vwap_core(long_df, **_GATE_BASE_KW, gate_ema_period=3)
+    assert float(gated["gate_ema"].iloc[b]) < float(long_df["close"].iloc[b])
+    assert gated["signal"].iloc[b] == 1
+    short_df = _ohlcv([90, 92, 94, 96, 98, 100,
+                       99.5, 99.8, 100.2, 100.5,
+                       96.5, 96.0, 95.5, 95.0], volume=10.0)
+    sbase = anchored_vwap_core(short_df, **_GATE_BASE_KW)
+    sb = int(np.where(sbase["signal"].to_numpy() == -1)[0][0])
+    sgated = anchored_vwap_core(short_df, **_GATE_BASE_KW, gate_ema_period=3)
+    assert float(sgated["gate_ema"].iloc[sb]) > float(short_df["close"].iloc[sb])
+    assert sgated["signal"].iloc[sb] == -1
+
+
+def test_ema_gate_warmup_fails_open():
+    df = _high_prior_long_reclaim_df()
+    base = anchored_vwap_core(df, **_GATE_BASE_KW)
+    b = int(np.where(base["signal"].to_numpy() == 1)[0][0])
+    gated = anchored_vwap_core(df, **_GATE_BASE_KW, gate_ema_period=12)
+    assert b < 12                             # signal bar inside the warmup window
+    assert (gated["signal"] == base["signal"]).all()
+
+
+def test_gated_signal_independent_of_future_bars():
+    df = _high_prior_long_reclaim_df()
+    kw = dict(_GATE_BASE_KW, gate_rsi_period=6, gate_rsi_level=50.0, gate_ema_period=3)
+    full = anchored_vwap_core(df, **kw)
+    for k in range(8, len(df)):
+        partial = anchored_vwap_core(df.iloc[:k + 1], **kw)
+        assert (
+            partial["signal"].to_numpy()
+            == full["signal"].to_numpy()[:k + 1]
+        ).all(), k
 
 
 # --- Task 5: registry ----------------------------------------------------------


### PR DESCRIPTION
Closes #1017

Implements rider B — the last remaining deliverable on the umbrella (children #1169/#1170 landed; the AVWAP close evaluator split out to #1196).

## What

Default-off momentum/trend gate params on `anchored_vwap`, following the #982 `chart_pattern` HTF-gate shape (gate layered after the base trigger so it sees exactly the signals the strategy would otherwise emit; no check-script changes — params flow through the opaque `--params` JSON):

- `gate_rsi_period` / `gate_rsi_level` (defaults `0` / `50.0`): when enabled, a long only fires with signal-bar RSI ≥ level, a short only with RSI ≤ level. NaN warmup fails open (veto semantics, mirrors #982 neutral).
- `gate_ema_period` (default `0`): when enabled, a long only fires with signal-bar close ≥ EMA(period), a short only with close ≤ it. Bars before the EMA has accrued `period` inputs fail open (#982 warmup convention).
- Wilder RSI inlined in `anchored_vwap.py` (same `ewm(alpha=1/period, min_periods=period, adjust=False)` convention as the registry `rsi` strategy) — open strategies cannot import `shared_tools` at module load.
- Registry defaults + `optimizer.py` ranges (`gate_rsi_period: [0, 14, 21]`, `gate_ema_period: [0, 100, 200]`). No registry default changed from off — per the issue, M1 validation gates any future default flip.

## Verification

- 9 new tests: default-off bit-identical (no gate columns); RSI gate blocks counter-momentum longs/shorts and passes aligned ones (levels probed ±1 around the computed signal-bar RSI); EMA gate blocks a counter-trend long under a high prior regime and passes aligned entries; warmup fail-open for both gates; gated signal prefix-independent of future bars; inline-RSI extremes/warmup.
- Full suite: `pytest shared_strategies/ shared_tools/ platforms/ backtest/` → 2155 passed.
- `--list-json` diffed byte-identical before/after (Go `discoverStrategies` unaffected).
- `go -C scheduler build` + `go -C scheduler test ./...` → ok.

---
Created with LLM: Fable 5 | high | Harness: Claude Code
