### PR TITLE
feat(#1196): avwap_stop close evaluator — exit on loss of the anchored VWAP

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -1543,6 +1543,18 @@ class Backtester:
         # current-bar end-of-bar access contract as ATR below; the column is
         # causal (the AVWAP anchor at bar b uses only pivots confirmed by b).
         avwap_series = df["avwap"] if "avwap" in df.columns else None
+        # #1196 review: if avwap_stop is configured but the open strategy never
+        # produces a usable avwap line (no column, or all-NaN/non-positive across
+        # the whole run), the exit can never fire — warn once per run rather than
+        # no-opping silently on every bar. Fails safe either way (engine SL still
+        # protects the position).
+        if self._close_names_include_avwap_stop():
+            avwap_usable = avwap_series is not None and bool(
+                (pd.to_numeric(avwap_series, errors="coerce") > 0).any()
+            )
+            if not avwap_usable:
+                from strategy_composition import warn_avwap_stop_missing_context
+                warn_avwap_stop_missing_context()
 
         atr_series = df["atr"] if "atr" in df.columns else None
         # An ATR-multiple stop/trail needs an `atr` series to stamp entry_atr;
@@ -2449,6 +2461,11 @@ class Backtester:
         if value > 0.5 * entry_price:
             return 0.0
         return value
+
+    def _close_names_include_avwap_stop(self) -> bool:
+        """True when ``avwap_stop`` is among the configured close names (#1196)."""
+        from strategy_composition import close_names_include_avwap_stop
+        return close_names_include_avwap_stop(self.close_strategies)
 
     def _evaluate_close_strategies(self, position: float, avg_cost: float,
                                    initial_quantity: float,

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -1539,6 +1539,11 @@ class Backtester:
             std = roll.std(ddof=0)
             zscore_series = (closes - roll.mean()) / std.replace(0.0, float("nan"))
 
+        # #1196: the open strategy's anchored VWAP line for avwap_stop. Same
+        # current-bar end-of-bar access contract as ATR below; the column is
+        # causal (the AVWAP anchor at bar b uses only pivots confirmed by b).
+        avwap_series = df["avwap"] if "avwap" in df.columns else None
+
         atr_series = df["atr"] if "atr" in df.columns else None
         # An ATR-multiple stop/trail needs an `atr` series to stamp entry_atr;
         # without it the stop silently no-ops (entry_atr stays 0). Strategies that
@@ -2076,6 +2081,7 @@ class Backtester:
                         market_regime=_bar_close_regime(row),
                         bars_held=hold.bars,
                         zscore_series=zscore_series,
+                        avwap_series=avwap_series,
                     )
                     if (
                         trailing_ratchet_active
@@ -2454,7 +2460,8 @@ class Backtester:
                                    position_regime: str = "",
                                    market_regime: str = "",
                                    bars_held: int = 0,
-                                   zscore_series: Optional[pd.Series] = None
+                                   zscore_series: Optional[pd.Series] = None,
+                                   avwap_series: Optional[pd.Series] = None
                                    ) -> Tuple[float, str]:
         """Run every configured close evaluator against the simulated position
         and return ``(max close_fraction, reason of the winning evaluator)``.
@@ -2510,6 +2517,17 @@ class Backtester:
                 z = float("nan")
             if z == z:  # not NaN
                 market_dict["zscore"] = z
+
+        # #1196: live re-anchored AVWAP for avwap_stop. Current-bar (closed)
+        # value, same N-close -> N+1-open fill alignment as ATR above. NaN
+        # warmup rows (pre-anchor) are omitted so the evaluator no-ops on them.
+        if avwap_series is not None:
+            try:
+                avwap_value = float(avwap_series.loc[idx])
+            except (KeyError, TypeError, ValueError):
+                avwap_value = float("nan")
+            if avwap_value == avwap_value and avwap_value > 0:
+                market_dict["avwap"] = avwap_value
 
         best = 0.0
         best_reason = ""

--- a/backtest/tests/test_backtester_close_strategies.py
+++ b/backtest/tests/test_backtester_close_strategies.py
@@ -642,3 +642,64 @@ def test_avwap_stop_short_side_fires_on_reclaim():
     assert result["total_trades"] == 1
     assert result["trades"][0]["side"] == "short"
     assert result["trades"][0]["exit_price"] == 105.0
+
+
+# --------------------------------------------------------------------------
+# #1196 review: warn once per run when avwap_stop is configured but the open
+# strategy never produces a usable avwap line (no column / all-NaN).
+# --------------------------------------------------------------------------
+
+_AVWAP_WARN_MARK = "avwap_stop"
+
+
+def _run_avwap_stop_backtest(df, close_strategies):
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=close_strategies,
+    )
+    return bt.run(df, save=False)
+
+
+def test_avwap_stop_warns_once_when_column_absent(capsys):
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 95, 95],
+        closes=[100, 100, 95, 95, 95],
+        atrs=[2.0] * 5,
+    )
+    _run_avwap_stop_backtest(df, [{"name": "avwap_stop", "params": {"buffer_atr_mult": 0.5}}])
+    err = capsys.readouterr().err
+    assert err.count(_AVWAP_WARN_MARK) == 1
+
+
+def test_avwap_stop_warns_once_when_column_all_nan(capsys):
+    df = _df_avwap_hold(
+        opens=[100, 100, 100, 95, 95],
+        closes=[100, 100, 95, 95, 95],
+        avwaps=[float("nan")] * 5,
+        atrs=[2.0] * 5,
+    )
+    _run_avwap_stop_backtest(df, [{"name": "avwap_stop", "params": {"buffer_atr_mult": 0.5}}])
+    err = capsys.readouterr().err
+    assert err.count(_AVWAP_WARN_MARK) == 1
+
+
+def test_avwap_stop_does_not_warn_when_line_usable(capsys):
+    df = _df_avwap_hold(
+        opens=[100, 100, 100, 95, 95],
+        closes=[100, 100, 95, 95, 95],
+        avwaps=[100.0] * 5,
+        atrs=[2.0] * 5,
+    )
+    _run_avwap_stop_backtest(df, [{"name": "avwap_stop", "params": {"buffer_atr_mult": 0.5}}])
+    err = capsys.readouterr().err
+    assert _AVWAP_WARN_MARK not in err
+
+
+def test_avwap_stop_does_not_warn_when_not_configured(capsys):
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 103, 103],
+        closes=[100, 100, 103, 103, 103],
+    )
+    _run_avwap_stop_backtest(df, [{"name": "tp_at_pct", "params": {"pct": 0.03}}])
+    err = capsys.readouterr().err
+    assert _AVWAP_WARN_MARK not in err

--- a/backtest/tests/test_backtester_close_strategies.py
+++ b/backtest/tests/test_backtester_close_strategies.py
@@ -554,3 +554,91 @@ def test_seeded_position_without_entry_atr_stop_stays_unarmed():
     # Rides to the forced end-of-run close at 95 — exactly one forced close.
     assert result["total_trades"] == 1
     assert result["trades"][0]["exit_date"] == str(idx[-1])
+
+
+# --------------------------------------------------------------------------
+# #1196 avwap_stop — loss-of-line exit against the df's `avwap` column
+# --------------------------------------------------------------------------
+
+def _df_avwap_hold(opens, closes, avwaps, atrs):
+    n = len(closes)
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    return pd.DataFrame({
+        "open": opens, "close": closes,
+        "open_action": ["long"] + ["none"] * (n - 1),
+        "avwap": avwaps, "atr": atrs,
+    }, index=idx)
+
+
+def test_avwap_stop_fires_on_loss_of_line():
+    # Opens at bar 1's open ($100). Bar 2 closes at 95, below
+    # avwap(100) - 0.5*atr(2) = 99 → evaluator fires end of bar 2,
+    # filled at bar 3's open ($95).
+    df = _df_avwap_hold(
+        opens=[100, 100, 100, 95, 95],
+        closes=[100, 100, 95, 95, 95],
+        avwaps=[100.0] * 5,
+        atrs=[2.0] * 5,
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=[{"name": "avwap_stop", "params": {"buffer_atr_mult": 0.5}}],
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["entry_price"] == 100.0
+    assert result["trades"][0]["exit_price"] == 95.0
+
+
+def test_avwap_stop_holds_above_buffered_line():
+    # Close never breaches avwap - buffer → held to the final bar.
+    df = _df_avwap_hold(
+        opens=[100, 100, 100, 100, 100],
+        closes=[100, 100, 99.5, 99.5, 99.5],
+        avwaps=[100.0] * 5,
+        atrs=[2.0] * 5,
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=[{"name": "avwap_stop", "params": {"buffer_atr_mult": 0.5}}],
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] == 99.5
+
+
+def test_avwap_stop_noops_without_avwap_column():
+    # No avwap column → market["avwap"] never injected → evaluator no-ops
+    # (fail-safe) and the position rides to the end.
+    df = _df_open_then_hold(
+        opens=[100, 100, 100, 95, 95],
+        closes=[100, 100, 95, 95, 95],
+        atrs=[2.0] * 5,
+    )
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=[{"name": "avwap_stop", "params": {"buffer_atr_mult": 0.5}}],
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] == 95.0
+    # Exit reason is the end-of-data close, not the evaluator.
+    assert "avwap_stop" not in str(result["trades"][0].get("exit_reason", ""))
+
+
+def test_avwap_stop_short_side_fires_on_reclaim():
+    df = pd.DataFrame({
+        "open": [100, 100, 100, 105, 105],
+        "close": [100, 100, 105, 105, 105],
+        "open_action": ["short"] + ["none"] * 4,
+        "avwap": [100.0] * 5,
+        "atr": [2.0] * 5,
+    }, index=pd.date_range("2024-01-01", periods=5, freq="D"))
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=[{"name": "avwap_stop", "params": {"buffer_atr_mult": 0.5}}],
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["side"] == "short"
+    assert result["trades"][0]["exit_price"] == 105.0

--- a/scheduler/config_migration.go
+++ b/scheduler/config_migration.go
@@ -588,6 +588,11 @@ var closeStrategyOwnedKeys = map[string]map[string]struct{}{
 	"time_stop":     {"max_bars": {}},
 	"atr_stop":      {"atr_mult": {}, "atr_source": {}},
 	"zscore_target": {"lookback": {}, "z_target": {}},
+	// #1196 AVWAP loss-of-line exit. Post-v13 (no legacy migration story);
+	// listed for the Python registry mirror test + unknown-key hints. Virtual
+	// exit only — never added to the on-chain TP sets in
+	// hyperliquid_protection.go (the line moves every bar; no static trigger).
+	"avwap_stop": {"buffer_atr_mult": {}, "atr_source": {}},
 }
 
 // migrateV14Direction translates the legacy boolean `allow_shorts` field on

--- a/shared_strategies/close/avwap_stop.py
+++ b/shared_strategies/close/avwap_stop.py
@@ -1,0 +1,70 @@
+"""AVWAP loss-of-line close evaluator (#1196).
+
+Exits the whole position when the mark breaches the anchored VWAP by
+``buffer_atr_mult`` ATR units on the losing side (long: below the line,
+short: above it). The line is the *live re-anchored* AVWAP — the same
+``avwap`` column the AVWAP-family open strategies compute — injected into
+``market["avwap"]`` by the composition layer (live) and the backtester, both
+reading the open strategy's own result so entry and exit track one line.
+
+Anchor semantics (#1196 spec-gate 1): live re-anchor, not frozen-at-entry.
+A frozen anchor cannot be recomputed once the anchor bar ages out of the
+bounded OHLCV fetch window, and would track a different line than the open
+strategy's own view; re-anchoring keeps exit and entry on the same line.
+
+``buffer_atr_mult == 0`` exits exactly at a line touch and needs no ATR.
+``atr_source`` selects the buffer's ATR: ``live`` (the current bar's
+``market["atr"]``, the default — the buffer scales with current volatility
+like the re-anchored line itself) or ``entry`` (frozen ``Position.EntryATR``).
+Missing avwap/ATR context fails safe (no-op) — the engine stop-loss still
+protects the position.
+"""
+
+from __future__ import annotations
+
+from _helpers import float_from
+
+
+def evaluate(position: dict, market: dict, params: dict) -> dict:
+    avg_cost = float_from(position, "avg_cost")
+    current_quantity = float_from(position, "current_quantity")
+    side = str(position.get("side", "") or "").strip().lower()
+    if avg_cost <= 0 or current_quantity <= 0 or side not in ("long", "short"):
+        return {"close_fraction": 0.0, "reason": "noop:missing_position"}
+    mark_price = float_from(market, "mark_price")
+    if mark_price <= 0:
+        return {"close_fraction": 0.0, "reason": "noop:missing_mark_price"}
+    avwap = float_from(market, "avwap")
+    if avwap <= 0:
+        return {"close_fraction": 0.0, "reason": "noop:missing_avwap"}
+
+    try:
+        buffer_atr_mult = float(params.get("buffer_atr_mult", 0.25) or 0.0)
+    except (TypeError, ValueError):
+        buffer_atr_mult = 0.25
+    if buffer_atr_mult < 0:
+        buffer_atr_mult = 0.0
+
+    buffer = 0.0
+    if buffer_atr_mult > 0:
+        atr_source = str(params.get("atr_source", "live") or "live").strip().lower()
+        if atr_source == "entry":
+            atr_ref = float_from(position, "entry_atr")
+            missing_reason = "noop:missing_entry_atr"
+        else:
+            atr_ref = float_from(market, "atr")
+            missing_reason = "noop:missing_live_atr"
+        if atr_ref <= 0:
+            return {"close_fraction": 0.0, "reason": missing_reason}
+        buffer = buffer_atr_mult * atr_ref
+
+    if side == "long":
+        hit = mark_price <= avwap - buffer
+    else:
+        hit = mark_price >= avwap + buffer
+    if hit:
+        return {
+            "close_fraction": 1.0,
+            "reason": f"avwap_stop:line_lost:{buffer_atr_mult:g}",
+        }
+    return {"close_fraction": 0.0, "reason": "noop:holding_line"}

--- a/shared_strategies/close/registry.py
+++ b/shared_strategies/close/registry.py
@@ -25,6 +25,7 @@ from tiered_tp_pct import evaluate as tiered_tp_pct_evaluate
 from time_stop import evaluate as time_stop_evaluate
 from atr_stop import evaluate as atr_stop_evaluate
 from zscore_target import evaluate as zscore_target_evaluate
+from avwap_stop import evaluate as avwap_stop_evaluate
 
 VALID_PLATFORMS: Tuple[str, ...] = ("spot", "futures", "options")
 
@@ -186,3 +187,12 @@ register(
     "Z-score target exit — full close when price stretches z_target sigma in favour (default-off; needs zscore context)",
     {"lookback": 0, "z_target": 0.0},
 )(zscore_target_evaluate)
+
+# #1196 AVWAP loss-of-line exit. Reads market["avwap"] — the live re-anchored
+# line injected from the AVWAP-family open strategy's own `avwap` column by
+# evaluate_open_close (live) and the backtester; fails safe (no-op) without it.
+register(
+    "avwap_stop",
+    "AVWAP loss-of-line exit — full close when the mark breaches the anchored VWAP by buffer_atr_mult ATR (needs market avwap context; atr_source: live|entry)",
+    {"buffer_atr_mult": 0.25, "atr_source": "live"},
+)(avwap_stop_evaluate)

--- a/shared_strategies/close/test_avwap_stop.py
+++ b/shared_strategies/close/test_avwap_stop.py
@@ -1,0 +1,124 @@
+"""Tests for the #1196 avwap_stop loss-of-line close evaluator."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_close_registry():
+    path = Path(__file__).resolve().parent / "registry.py"
+    spec = importlib.util.spec_from_file_location("_avwap_close_registry", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def reg():
+    return _load_close_registry()
+
+
+def _long_pos(**over):
+    pos = {"side": "long", "current_quantity": 1.0, "avg_cost": 100.0, "entry_atr": 2.0}
+    pos.update(over)
+    return pos
+
+
+def _short_pos(**over):
+    pos = {"side": "short", "current_quantity": 1.0, "avg_cost": 100.0, "entry_atr": 2.0}
+    pos.update(over)
+    return pos
+
+
+# --------------------------------------------------------------------------
+# Long / short hit and boundary (buffer = buffer_atr_mult * live ATR)
+# --------------------------------------------------------------------------
+
+def test_long_hit_and_boundary(reg):
+    params = {"buffer_atr_mult": 0.5, "atr_source": "live"}
+    mkt = {"avwap": 100.0, "atr": 2.0}
+    # buffer = 1.0 → hit at mark <= 99.0
+    out = reg.evaluate("avwap_stop", _long_pos(), {**mkt, "mark_price": 99.0}, params)
+    assert out["close_fraction"] == 1.0
+    assert out["reason"].startswith("avwap_stop:")
+    out = reg.evaluate("avwap_stop", _long_pos(), {**mkt, "mark_price": 99.5}, params)
+    assert out["close_fraction"] == 0.0
+
+
+def test_short_mirrors(reg):
+    params = {"buffer_atr_mult": 0.5, "atr_source": "live"}
+    mkt = {"avwap": 100.0, "atr": 2.0}
+    out = reg.evaluate("avwap_stop", _short_pos(), {**mkt, "mark_price": 101.0}, params)
+    assert out["close_fraction"] == 1.0
+    out = reg.evaluate("avwap_stop", _short_pos(), {**mkt, "mark_price": 100.5}, params)
+    assert out["close_fraction"] == 0.0
+
+
+def test_zero_buffer_exits_at_line_touch_without_atr(reg):
+    # buffer_atr_mult == 0 needs no ATR at all: exit exactly at the line.
+    params = {"buffer_atr_mult": 0.0}
+    out = reg.evaluate("avwap_stop", _long_pos(entry_atr=0.0),
+                       {"mark_price": 100.0, "avwap": 100.0}, params)
+    assert out["close_fraction"] == 1.0
+    out = reg.evaluate("avwap_stop", _long_pos(entry_atr=0.0),
+                       {"mark_price": 100.01, "avwap": 100.0}, params)
+    assert out["close_fraction"] == 0.0
+
+
+# --------------------------------------------------------------------------
+# atr_source: live (market["atr"]) vs entry (position["entry_atr"])
+# --------------------------------------------------------------------------
+
+def test_atr_source_entry_vs_live(reg):
+    # live ATR 4.0 (buffer 2.0 → hit at <= 98), entry ATR 1.0 (buffer 0.5 → hit at <= 99.5)
+    pos = _long_pos(entry_atr=1.0)
+    mkt = {"mark_price": 99.0, "avwap": 100.0, "atr": 4.0}
+    assert reg.evaluate("avwap_stop", pos, mkt,
+                        {"buffer_atr_mult": 0.5, "atr_source": "entry"})["close_fraction"] == 1.0
+    assert reg.evaluate("avwap_stop", pos, mkt,
+                        {"buffer_atr_mult": 0.5, "atr_source": "live"})["close_fraction"] == 0.0
+
+
+def test_missing_atr_fails_safe_when_buffer_positive(reg):
+    out = reg.evaluate("avwap_stop", _long_pos(entry_atr=0.0),
+                       {"mark_price": 50.0, "avwap": 100.0},
+                       {"buffer_atr_mult": 0.5, "atr_source": "live"})
+    assert out["close_fraction"] == 0.0
+    assert out["reason"] == "noop:missing_live_atr"
+    out = reg.evaluate("avwap_stop", _long_pos(entry_atr=0.0),
+                       {"mark_price": 50.0, "avwap": 100.0},
+                       {"buffer_atr_mult": 0.5, "atr_source": "entry"})
+    assert out["close_fraction"] == 0.0
+    assert out["reason"] == "noop:missing_entry_atr"
+
+
+# --------------------------------------------------------------------------
+# Fail-safe on missing context
+# --------------------------------------------------------------------------
+
+def test_missing_avwap_fails_safe(reg):
+    out = reg.evaluate("avwap_stop", _long_pos(), {"mark_price": 50.0, "atr": 2.0}, None)
+    assert out["close_fraction"] == 0.0
+    assert out["reason"] == "noop:missing_avwap"
+
+
+def test_missing_position_or_mark_fails_safe(reg):
+    out = reg.evaluate("avwap_stop", {}, {"mark_price": 50.0, "avwap": 100.0, "atr": 2.0}, None)
+    assert out["close_fraction"] == 0.0
+    assert out["reason"] == "noop:missing_position"
+    out = reg.evaluate("avwap_stop", _long_pos(), {"avwap": 100.0, "atr": 2.0}, None)
+    assert out["close_fraction"] == 0.0
+    assert out["reason"] == "noop:missing_mark_price"
+
+
+# --------------------------------------------------------------------------
+# Registry defaults: buffer 0.25 x live ATR
+# --------------------------------------------------------------------------
+
+def test_registry_defaults_use_live_atr_quarter_buffer(reg):
+    mkt = {"avwap": 100.0, "atr": 2.0}  # buffer = 0.5
+    out = reg.evaluate("avwap_stop", _long_pos(), {**mkt, "mark_price": 99.5}, None)
+    assert out["close_fraction"] == 1.0
+    out = reg.evaluate("avwap_stop", _long_pos(), {**mkt, "mark_price": 99.6}, None)
+    assert out["close_fraction"] == 0.0

--- a/shared_strategies/close/test_close_registry.py
+++ b/shared_strategies/close/test_close_registry.py
@@ -33,6 +33,7 @@ def test_build_close_registry_filters_valid_platforms(registry):
             "time_stop",
             "atr_stop",
             "zscore_target",
+            "avwap_stop",
         }
 
 

--- a/shared_tools/strategy_composition.py
+++ b/shared_tools/strategy_composition.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import inspect
+import sys
 from dataclasses import dataclass
 from typing import Callable, Iterable, Optional
 
@@ -190,6 +191,32 @@ def canonical_close_name(name: str) -> str:
     return _DEPRECATED_CLOSE_NAMES.get(name, name)
 
 
+def close_names_include_avwap_stop(close_names: Iterable[str]) -> bool:
+    """True when ``avwap_stop`` is among the (canonicalized) close names (#1196)."""
+    return any(canonical_close_name(name) == "avwap_stop" for name in close_names)
+
+
+def warn_avwap_stop_missing_context() -> None:
+    """Warn (stderr) that ``avwap_stop`` is configured but has no usable line (#1196 review).
+
+    ``avwap_stop`` no-ops on every bar when the resolved open strategy never
+    emits a positive ``avwap`` value — a misconfiguration such as a typo'd or
+    non-AVWAP open, or an anchor whose warmup never confirms across the run.
+    This fails safe (the engine stop-loss still protects the position) but
+    silently disables the intended exit, so surface it to the operator instead
+    of no-opping in silence. Warn-once is enforced by *call placement* (once per
+    live check subprocess / once per ``Backtester.run``), not by module state —
+    so multiple runs in one process and per-test assertions each see it.
+    """
+    print(
+        "[WARN] close strategy 'avwap_stop' is configured but the open strategy "
+        "produced no usable 'avwap' value; the AVWAP exit can never fire and the "
+        "position is protected only by the engine stop-loss. Verify the open "
+        "strategy is an AVWAP-family strategy that emits an 'avwap' column (#1196).",
+        file=sys.stderr,
+    )
+
+
 def rewrite_deprecated_close_ref(name: str, params: Optional[dict]) -> tuple[str, Optional[dict]]:
     """One-window shim: tp_at_pct → single-tier tiered_tp_pct (#841)."""
     name = (name or "").strip()
@@ -338,6 +365,7 @@ def evaluate_open_close(
     # line the entry was built on. NaN (pre-anchor warmup) and non-positive
     # values are skipped — the evaluator no-ops without the key. Copy-on-write
     # so the caller's market_ctx dict is never mutated.
+    avwap_injected = False
     if not open_result.empty and "avwap" in open_result.columns:
         try:
             avwap_value = float(open_result["avwap"].iloc[-1])
@@ -345,6 +373,13 @@ def evaluate_open_close(
             avwap_value = float("nan")
         if avwap_value == avwap_value and avwap_value > 0:
             market = {**market, "avwap": avwap_value}
+            avwap_injected = True
+    # #1196 review: if avwap_stop is configured but no usable line was injected
+    # (typo'd/non-AVWAP open, or an anchor that never confirmed), the exit can
+    # never fire — warn the operator once per check invocation rather than
+    # no-opping silently. Fails safe either way (engine SL still protects).
+    if not avwap_injected and close_names_include_avwap_stop(close_names):
+        warn_avwap_stop_missing_context()
     for name in close_names:
         resolved, _ = rewrite_deprecated_close_ref(name, None)
         # #640: per-close params arrive via close_params_by_name (carried on the

--- a/shared_tools/strategy_composition.py
+++ b/shared_tools/strategy_composition.py
@@ -333,6 +333,18 @@ def evaluate_open_close(
     open_signal = _last_signal(open_result)
     close_evals: list[CloseEvaluation] = []
     market = market_ctx if market_ctx is not None else _default_market_ctx(df)
+    # #1196: expose the open strategy's anchored VWAP line (last closed bar) to
+    # close evaluators as market["avwap"], so avwap_stop exits against the same
+    # line the entry was built on. NaN (pre-anchor warmup) and non-positive
+    # values are skipped — the evaluator no-ops without the key. Copy-on-write
+    # so the caller's market_ctx dict is never mutated.
+    if not open_result.empty and "avwap" in open_result.columns:
+        try:
+            avwap_value = float(open_result["avwap"].iloc[-1])
+        except (TypeError, ValueError):
+            avwap_value = float("nan")
+        if avwap_value == avwap_value and avwap_value > 0:
+            market = {**market, "avwap": avwap_value}
     for name in close_names:
         resolved, _ = rewrite_deprecated_close_ref(name, None)
         # #640: per-close params arrive via close_params_by_name (carried on the

--- a/shared_tools/test_strategy_composition.py
+++ b/shared_tools/test_strategy_composition.py
@@ -330,3 +330,69 @@ def test_evaluate_open_close_skips_avwap_when_nan_or_absent():
         close_evaluate=close_evaluate, market_ctx={"mark_price": 106},
     )
     assert captured == [{"mark_price": 106}, {"mark_price": 106}]
+
+
+# --------------------------------------------------------------------------
+# #1196 review: warn once when avwap_stop is configured but no usable avwap
+# context is ever produced by the open strategy (the exit can never fire).
+# --------------------------------------------------------------------------
+
+_AVWAP_WARN_MARK = "avwap_stop"
+
+
+def _noop_close_evaluate(name, position, market, params=None):
+    return {"close_fraction": 0.0, "reason": "noop"}
+
+
+def _run_avwap_open_close(apply_strategy, close_strategies):
+    df = pd.DataFrame({"close": [100, 106]})
+    evaluate_open_close(
+        apply_strategy,
+        lambda name: None,
+        df,
+        positional_strategy="legacy",
+        open_strategy="open",
+        close_strategies=close_strategies,
+        position_side="long",
+        close_evaluate=_noop_close_evaluate,
+        market_ctx={"mark_price": 106},
+    )
+
+
+def _apply_with_avwap(values):
+    def _apply(name, data, params=None):
+        result = data.copy()
+        result["signal"] = [0] * len(result)
+        result["avwap"] = values
+        return result
+    return _apply
+
+
+def _apply_without_avwap(name, data, params=None):
+    result = data.copy()
+    result["signal"] = [0] * len(result)
+    return result
+
+
+def test_avwap_stop_warns_once_when_column_absent(capsys):
+    _run_avwap_open_close(_apply_without_avwap, ["avwap_stop"])
+    err = capsys.readouterr().err
+    assert err.count(_AVWAP_WARN_MARK) == 1
+
+
+def test_avwap_stop_warns_once_when_column_all_nan(capsys):
+    _run_avwap_open_close(_apply_with_avwap([float("nan"), float("nan")]), ["avwap_stop"])
+    err = capsys.readouterr().err
+    assert err.count(_AVWAP_WARN_MARK) == 1
+
+
+def test_avwap_stop_does_not_warn_when_avwap_present(capsys):
+    _run_avwap_open_close(_apply_with_avwap([float("nan"), 101.5]), ["avwap_stop"])
+    err = capsys.readouterr().err
+    assert _AVWAP_WARN_MARK not in err
+
+
+def test_avwap_stop_does_not_warn_when_not_configured(capsys):
+    _run_avwap_open_close(_apply_without_avwap, ["tiered_tp_atr_live"])
+    err = capsys.readouterr().err
+    assert _AVWAP_WARN_MARK not in err

--- a/shared_tools/test_strategy_composition.py
+++ b/shared_tools/test_strategy_composition.py
@@ -254,3 +254,79 @@ def test_tp_at_pct_position_aware_close_handles_missing_and_hit():
     )
     assert hit["close_fraction"] == 1.0
     assert hit["reason"] == "tiered_tp_pct:0.05"
+
+
+def test_evaluate_open_close_injects_avwap_from_open_result():
+    # #1196: the open strategy's `avwap` column (last bar) is exposed to close
+    # evaluators as market["avwap"] so avwap_stop exits against the same line
+    # the entry was built on.
+    captured = []
+    df = pd.DataFrame({"close": [100, 106]})
+
+    def get_strategy(name):
+        pass
+
+    def apply_strategy(name, data, params=None):
+        result = data.copy()
+        result["signal"] = [0, 0]
+        result["avwap"] = [float("nan"), 101.5]
+        return result
+
+    def close_evaluate(name, position, market, params=None):
+        captured.append(dict(market))
+        return {"close_fraction": 0.0, "reason": "noop"}
+
+    caller_market = {"mark_price": 106}
+    evaluate_open_close(
+        apply_strategy,
+        get_strategy,
+        df,
+        positional_strategy="legacy",
+        open_strategy="open",
+        close_strategies=["avwap_stop"],
+        position_side="long",
+        position_ctx={"side": "long", "avg_cost": 100, "current_quantity": 1.0},
+        close_evaluate=close_evaluate,
+        market_ctx=caller_market,
+    )
+    assert captured == [{"mark_price": 106, "avwap": 101.5}]
+    # The caller's market_ctx dict is never mutated.
+    assert caller_market == {"mark_price": 106}
+
+
+def test_evaluate_open_close_skips_avwap_when_nan_or_absent():
+    captured = []
+    df = pd.DataFrame({"close": [100, 106]})
+
+    def get_strategy(name):
+        pass
+
+    def close_evaluate(name, position, market, params=None):
+        captured.append(dict(market))
+        return {"close_fraction": 0.0, "reason": "noop"}
+
+    def apply_nan_avwap(name, data, params=None):
+        result = data.copy()
+        result["signal"] = [0, 0]
+        result["avwap"] = [float("nan"), float("nan")]
+        return result
+
+    evaluate_open_close(
+        apply_nan_avwap, get_strategy, df,
+        positional_strategy="legacy", open_strategy="open",
+        close_strategies=["avwap_stop"], position_side="long",
+        close_evaluate=close_evaluate, market_ctx={"mark_price": 106},
+    )
+
+    def apply_no_avwap(name, data, params=None):
+        result = data.copy()
+        result["signal"] = [0, 0]
+        return result
+
+    evaluate_open_close(
+        apply_no_avwap, get_strategy, df,
+        positional_strategy="legacy", open_strategy="open",
+        close_strategies=["avwap_stop"], position_side="long",
+        close_evaluate=close_evaluate, market_ctx={"mark_price": 106},
+    )
+    assert captured == [{"mark_price": 106}, {"mark_price": 106}]


### PR DESCRIPTION
Closes #1196

## What

New close evaluator **`avwap_stop`** — full close when the mark breaches the anchored VWAP by `buffer_atr_mult` ATR on the losing side (long below the line, short above it). Registry defaults `buffer_atr_mult: 0.25`, `atr_source: live`; `buffer_atr_mult: 0` exits at a line touch and needs no ATR; missing avwap/ATR context fails safe (no-op — the engine stop-loss still protects).

## Spec-gate decisions (settled per the issue)

1. **Anchor semantics: live re-anchor.** The evaluator reads `market["avwap"]`, injected from the open strategy's own `avwap` column — entry and exit track the same line, with no Position-carried anchor state. A frozen-at-entry anchor was rejected: it cannot be recomputed once the anchor bar ages out of the bounded OHLCV fetch window, and it would diverge from the line the open strategy itself tracks.
2. **Virtual exit only.** The line re-anchors and moves every bar, so no static on-chain trigger exists; deliberately NOT added to `isTieredTPATRCloseName`/`closeStrategiesSuppressedByOnChainProtection`. The optional tiered-TP-from-AVWAP variant was rejected for now: static tier watermarks over a moving reference break the processed-tier idempotency the existing tiered machinery assumes.
3. **Backtestable with parity.** `evaluate_open_close` (live composition — all 5 check scripts) and `Backtester._evaluate_close_strategies` both inject `market["avwap"]` from the open result's `avwap` column, with the same current-bar end-of-bar access contract as ATR (#730); NaN pre-anchor warmup rows are skipped. No silent backtester no-op when the open strategy is AVWAP-family.

## Changes

- `shared_strategies/close/avwap_stop.py` + registration in `close/registry.py`
- `shared_tools/strategy_composition.py` — copy-on-write `market["avwap"]` injection from the open result's last closed bar
- `backtest/backtester.py` — `avwap_series` threaded into per-bar close evaluation
- `scheduler/config_migration.go` — `closeStrategyOwnedKeys["avwap_stop"] = {buffer_atr_mult, atr_source}`

## Verification

- New tests written first and confirmed red, then green: evaluator units (hit/boundary, short mirror, zero-buffer, `atr_source` entry|live, fail-safe no-ops, registry defaults), composition injection (inject / NaN / absent / caller ctx never mutated), backtester integration (fires on loss of line, holds above buffer, no-ops without an `avwap` column, short reclaim).
- Full suite: `pytest shared_strategies/ shared_tools/ platforms/ backtest/` → 2166 passed.
- `go -C scheduler build` + `go -C scheduler test ./...` → ok, including `TestCloseStrategyOwnedKeysMirrorsPythonRegistry`.

---
LLM: Fable 5 | high | Harness: Claude Code
