### PR TITLE
feat(#1197): live-label fidelity evidence + config-shape tests for the comp_up_clean_p21 breakout gate

### DIFF
--- a/backtest/candidates/breakout_1165/README.md
+++ b/backtest/candidates/breakout_1165/README.md
@@ -273,11 +273,11 @@ guards, tested in the same file):
    (Step 6 above): the live-label fidelity bar passed on all 12 rows, the
    operator config shape + gate semantics are pinned by
    `scheduler/regime_comp_up_clean_gate_test.go`, and the config edit itself
-   is operator-side (out-of-tree, #1056). Remaining follow-on (own issue):
-   re-run this directory against `squeeze_momentum` (#983, same DD
-   conclusion, -58.5%): the drivers are strategy-parameterized
-   (`--strategy/--registry/--direction`; `driver_common.py` holds the
-   breakout-specific M4 param sets).
+   is operator-side (out-of-tree, #1056). The other named follow-on — the
+   `squeeze_momentum` re-run of this directory (#983, same DD conclusion,
+   -58.5%) — ran as **#1198** via the strategy-parameterized drivers
+   (`backtest/candidates/squeeze_momentum_1198/`, PR 1201): **negative**;
+   the gate does not transfer to that entry.
 
 A positive result still ships as evidence, not a config change (#995 step 4
 symmetry: documented, not deployed).

--- a/backtest/candidates/breakout_1165/README.md
+++ b/backtest/candidates/breakout_1165/README.md
@@ -178,6 +178,78 @@ entry): the gate removes entries, so drag falls with trade count — and p21's
 gross return is *above* baseline's (+15.2% vs +13.3%): the removed trades
 were net losers before fees, not just fee victims.
 
+## Step 6 — live-label fidelity gate (#1197 wiring evidence)
+
+Everything above scored `trending_up_clean` labels computed over the **full
+cached history**; the live gate reads them from `check_regime.py`, which
+recomputes the composite over a **bounded 200-bar fetch** each cycle — the
+ADX sub-recursion seeds differently, so the same calendar bar can label
+differently live vs in this evidence (#1082). Before wiring, this step
+measures that drift with the same hand-rule arm the #1074 promotion gate
+uses (`regime_bounded_window_validate.validate`, `model=None` — no fitted
+model, so `gate_verdict`/provenance don't apply), applied fail-closed
+(#1082 bar: agreement ≥ 0.95 on ≥ 30 comparable bars, per dataset × window;
+a short/missing row blocks, never vacuously passes):
+
+```
+uv run --no-sync python backtest/candidates/breakout_1165/live_label_fidelity.py \
+    --json backtest/candidates/breakout_1165/live_label_fidelity.json
+```
+
+**Result: PASS on all 12 rows** (6 datasets × is/oos). Worst all-label
+agreement 0.98678 (BTC/4h is); worst gate-membership agreement — the exact
+`trending_up_clean` bit `allowed_regimes` consumes — 0.99338 (ETH/4h oos,
+6 flips on 907 bars). 8 of 12 rows have zero gate flips; the bounded window
+the live scheduler sees reproduces the labels this evidence scored.
+
+| | 1h is | 1h oos | 4h is | 4h oos |
+|---|---:|---:|---:|---:|
+| BTC/USDT | 0.99735 / 0 | 0.99837 / 2 | 0.98678 / 0 | 0.99890 / 1 |
+| ETH/USDT | 0.99796 / 0 | 0.99897 / 0 | 0.99504 / 0 | 0.99228 / 6 |
+| SOL/USDT | 1.00000 / 0 | 0.99820 / 0 | 0.99835 / 0 | 0.99338 / 2 |
+
+(all-label agreement / gate-membership flips; n per row: 1h is 4900,
+1h oos 3676–3887, 4h is 1210, 4h oos 907)
+
+### The wiring itself (operator config, out-of-tree per #1056)
+
+The live config lives at `/var/lib/go-trader[/<instance>]/config.json`, not
+in the repo, so the deployment is an operator edit. The exact shape — pinned
+by `scheduler/regime_comp_up_clean_gate_test.go` so it can never silently
+drift from what was validated:
+
+```jsonc
+"regime": {
+  "enabled": true,
+  "windows": {
+    "comp_p21": { "classifier": "composite", "period": 21 }
+    // …existing windows (e.g. an ADX "medium") stay as they are
+  }
+},
+// on the breakout futures strategy:
+"regime_gate_window": "comp_p21",
+"allowed_regimes": ["trending_up_clean"]
+```
+
+Deployment constraints (all enforced by config validation / hot-reload
+guards, tested in the same file):
+
+- **Set `regime_gate_window` explicitly.** Without it the gate reads the
+  PRIMARY window ("medium" when present) — if that's an existing ADX window,
+  its 3-label vocabulary lacks `trending_up_clean` and config load rejects;
+  if the composite window itself happens to be named "medium" it works, but
+  only by deployment-order luck. The explicit key makes the wiring
+  independent of what other windows exist.
+- Composite thresholds stay the shared defaults (this evidence ran them);
+  the label pairing is validated against the gate window's classifier
+  (`validateStrategyRegimeVocabulary`).
+- **Apply while the strategy is flat**: SIGHUP hot-reload blocks
+  `regime_gate_window`/classifier changes on a referenced window while a
+  position is open (`config_reload.go`).
+- Gate semantics live: entries blocked when the medium-window label ≠
+  `trending_up_clean`, **closes and position management always execute** —
+  the same asymmetry every backtest row above relied on.
+
 ## Verdict
 
 1. **The -52.2% DD is regime exposure, and a label set that separates the
@@ -197,14 +269,15 @@ were net losers before fees, not just fee victims.
    the IS peak); the judged OOS window was looked at once per shortlist
    member (M1 step 5 discipline held: selection was IS-only); all evidence
    is one asset class (BTC/ETH/SOL × 1h/4h) on the audit frame.
-4. **This changes no live config.** Follow-on (own issue): wire the gate
-   into the live breakout futures strategy via `allowed_regimes:
-   ["trending_up_clean"]` + a composite `regime.windows` medium window at
-   period 21 — a live config change with its own #1074-class classifier
-   evidence requirements — and re-run this directory against
-   `squeeze_momentum` (#983, same DD conclusion, -58.5%): the drivers are
-   strategy-parameterized (`--strategy/--registry/--direction`;
-   `driver_common.py` holds the breakout-specific M4 param sets).
+4. **Steps 1–5 changed no live config.** The wiring follow-on is **#1197**
+   (Step 6 above): the live-label fidelity bar passed on all 12 rows, the
+   operator config shape + gate semantics are pinned by
+   `scheduler/regime_comp_up_clean_gate_test.go`, and the config edit itself
+   is operator-side (out-of-tree, #1056). Remaining follow-on (own issue):
+   re-run this directory against `squeeze_momentum` (#983, same DD
+   conclusion, -58.5%): the drivers are strategy-parameterized
+   (`--strategy/--registry/--direction`; `driver_common.py` holds the
+   breakout-specific M4 param sets).
 
 A positive result still ships as evidence, not a config change (#995 step 4
 symmetry: documented, not deployed).

--- a/backtest/candidates/breakout_1165/live_label_fidelity.json
+++ b/backtest/candidates/breakout_1165/live_label_fidelity.json
@@ -1,0 +1,415 @@
+{
+  "gate": {
+    "label": "trending_up_clean",
+    "period": 21,
+    "lookback": 200,
+    "agreement_threshold": 0.95,
+    "min_agreement_bars": 30
+  },
+  "windows": [
+    "is",
+    "oos"
+  ],
+  "rows": [
+    {
+      "symbol": "BTC/USDT",
+      "timeframe": "1h",
+      "window": "is",
+      "n_eval_bars": 4921,
+      "label_drift": {
+        "n": 4900,
+        "agreement": 0.9973469387755102,
+        "disagreements": 13,
+        "transitions": {
+          "ranging_volatile->ranging_directional_down": 3,
+          "ranging_volatile->ranging_directional_up": 10
+        }
+      },
+      "adx_drift": {
+        "n": 4900,
+        "mean_abs": 0.07381901106768288,
+        "median_abs": 8.695312613582473e-05,
+        "p95_abs": 0.0005100248961111831,
+        "max_abs": 29.72670461130841,
+        "mean_rel": 0.001989849569357033,
+        "p95_rel": 1.981357542333142e-05,
+        "corr": 0.9948852404400537
+      },
+      "verdict": {
+        "n": 4900,
+        "agreement": 0.9973469387755102,
+        "gate_membership_flips": 0,
+        "gate_membership_agreement": 1.0,
+        "passes": true,
+        "blocking_reasons": []
+      }
+    },
+    {
+      "symbol": "BTC/USDT",
+      "timeframe": "1h",
+      "window": "oos",
+      "n_eval_bars": 3697,
+      "label_drift": {
+        "n": 3676,
+        "agreement": 0.9983677910772579,
+        "disagreements": 6,
+        "transitions": {
+          "ranging_directional_down->ranging_volatile": 3,
+          "ranging_directional_up->ranging_volatile": 1,
+          "trending_up_choppy->trending_up_clean": 2
+        }
+      },
+      "adx_drift": {
+        "n": 3676,
+        "mean_abs": 0.14515886533535077,
+        "median_abs": 8.642605192399344e-05,
+        "p95_abs": 0.0006675609518449477,
+        "max_abs": 33.59277732033872,
+        "mean_rel": 0.002291142941145596,
+        "p95_rel": 3.261641272208983e-05,
+        "corr": 0.9921550444668995
+      },
+      "verdict": {
+        "n": 3676,
+        "agreement": 0.9983677910772579,
+        "gate_membership_flips": 2,
+        "gate_membership_agreement": 0.999455930359086,
+        "passes": true,
+        "blocking_reasons": []
+      }
+    },
+    {
+      "symbol": "BTC/USDT",
+      "timeframe": "4h",
+      "window": "is",
+      "n_eval_bars": 1231,
+      "label_drift": {
+        "n": 1210,
+        "agreement": 0.9867768595041322,
+        "disagreements": 16,
+        "transitions": {
+          "ranging_directional_down->ranging_volatile": 12,
+          "ranging_directional_up->ranging_volatile": 3,
+          "trending_down_choppy->trending_down_clean": 1
+        }
+      },
+      "adx_drift": {
+        "n": 1210,
+        "mean_abs": 0.4488869550772479,
+        "median_abs": 8.303581788204895e-05,
+        "p95_abs": 0.9561764996343088,
+        "max_abs": 29.114470339063104,
+        "mean_rel": 0.008886290734341818,
+        "p95_rel": 0.02396733600551699,
+        "corr": 0.9736511898591835
+      },
+      "verdict": {
+        "n": 1210,
+        "agreement": 0.9867768595041322,
+        "gate_membership_flips": 0,
+        "gate_membership_agreement": 1.0,
+        "passes": true,
+        "blocking_reasons": []
+      }
+    },
+    {
+      "symbol": "BTC/USDT",
+      "timeframe": "4h",
+      "window": "oos",
+      "n_eval_bars": 928,
+      "label_drift": {
+        "n": 907,
+        "agreement": 0.9988974641675854,
+        "disagreements": 1,
+        "transitions": {
+          "trending_up_choppy->trending_up_clean": 1
+        }
+      },
+      "adx_drift": {
+        "n": 907,
+        "mean_abs": 0.7850529694738908,
+        "median_abs": 9.125559227030067e-05,
+        "p95_abs": 1.337693091587515,
+        "max_abs": 43.438435753686186,
+        "mean_rel": 0.010907164609939433,
+        "p95_rel": 0.06638612701499635,
+        "corr": 0.9423794053585218
+      },
+      "verdict": {
+        "n": 907,
+        "agreement": 0.9988974641675854,
+        "gate_membership_flips": 1,
+        "gate_membership_agreement": 0.9988974641675854,
+        "passes": true,
+        "blocking_reasons": []
+      }
+    },
+    {
+      "symbol": "ETH/USDT",
+      "timeframe": "1h",
+      "window": "is",
+      "n_eval_bars": 4921,
+      "label_drift": {
+        "n": 4900,
+        "agreement": 0.9979591836734694,
+        "disagreements": 10,
+        "transitions": {
+          "ranging_volatile->ranging_directional_down": 5,
+          "ranging_volatile->ranging_directional_up": 4,
+          "trending_down_choppy->trending_down_clean": 1
+        }
+      },
+      "adx_drift": {
+        "n": 4900,
+        "mean_abs": 0.10988275565502045,
+        "median_abs": 7.467307016106872e-05,
+        "p95_abs": 0.0004220452338493886,
+        "max_abs": 41.25642477693557,
+        "mean_rel": 0.00267838691808798,
+        "p95_rel": 2.1305443735506625e-05,
+        "corr": 0.9900817182683903
+      },
+      "verdict": {
+        "n": 4900,
+        "agreement": 0.9979591836734694,
+        "gate_membership_flips": 0,
+        "gate_membership_agreement": 1.0,
+        "passes": true,
+        "blocking_reasons": []
+      }
+    },
+    {
+      "symbol": "ETH/USDT",
+      "timeframe": "1h",
+      "window": "oos",
+      "n_eval_bars": 3908,
+      "label_drift": {
+        "n": 3887,
+        "agreement": 0.998970928736815,
+        "disagreements": 4,
+        "transitions": {
+          "ranging_directional_down->ranging_volatile": 3,
+          "ranging_directional_up->ranging_volatile": 1
+        }
+      },
+      "adx_drift": {
+        "n": 3887,
+        "mean_abs": 0.11045137354298959,
+        "median_abs": 8.451907905637768e-05,
+        "p95_abs": 0.0004971992205032193,
+        "max_abs": 24.366347423004164,
+        "mean_rel": 0.0016368629402478245,
+        "p95_rel": 2.4021255700349687e-05,
+        "corr": 0.9957470660827097
+      },
+      "verdict": {
+        "n": 3887,
+        "agreement": 0.998970928736815,
+        "gate_membership_flips": 0,
+        "gate_membership_agreement": 1.0,
+        "passes": true,
+        "blocking_reasons": []
+      }
+    },
+    {
+      "symbol": "ETH/USDT",
+      "timeframe": "4h",
+      "window": "is",
+      "n_eval_bars": 1231,
+      "label_drift": {
+        "n": 1210,
+        "agreement": 0.9950413223140496,
+        "disagreements": 6,
+        "transitions": {
+          "ranging_volatile->ranging_directional_down": 2,
+          "trending_down_choppy->trending_down_clean": 4
+        }
+      },
+      "adx_drift": {
+        "n": 1210,
+        "mean_abs": 0.2796405492712268,
+        "median_abs": 7.630417681170343e-05,
+        "p95_abs": 0.40710608411610133,
+        "max_abs": 34.89673118163211,
+        "mean_rel": 0.0050123994928374625,
+        "p95_rel": 0.006947481241562653,
+        "corr": 0.9809927580256937
+      },
+      "verdict": {
+        "n": 1210,
+        "agreement": 0.9950413223140496,
+        "gate_membership_flips": 0,
+        "gate_membership_agreement": 1.0,
+        "passes": true,
+        "blocking_reasons": []
+      }
+    },
+    {
+      "symbol": "ETH/USDT",
+      "timeframe": "4h",
+      "window": "oos",
+      "n_eval_bars": 928,
+      "label_drift": {
+        "n": 907,
+        "agreement": 0.9922822491730982,
+        "disagreements": 7,
+        "transitions": {
+          "trending_down_clean->trending_down_choppy": 1,
+          "trending_up_choppy->trending_up_clean": 6
+        }
+      },
+      "adx_drift": {
+        "n": 907,
+        "mean_abs": 0.5830784755609477,
+        "median_abs": 9.278051771133278e-05,
+        "p95_abs": 0.6869318378736444,
+        "max_abs": 47.184703954865526,
+        "mean_rel": 0.006029858857140124,
+        "p95_rel": 0.027029641286732593,
+        "corr": 0.9499237925158283
+      },
+      "verdict": {
+        "n": 907,
+        "agreement": 0.9922822491730982,
+        "gate_membership_flips": 6,
+        "gate_membership_agreement": 0.9933847850055126,
+        "passes": true,
+        "blocking_reasons": []
+      }
+    },
+    {
+      "symbol": "SOL/USDT",
+      "timeframe": "1h",
+      "window": "is",
+      "n_eval_bars": 4921,
+      "label_drift": {
+        "n": 4900,
+        "agreement": 1.0,
+        "disagreements": 0,
+        "transitions": {}
+      },
+      "adx_drift": {
+        "n": 4900,
+        "mean_abs": 0.05176447773317934,
+        "median_abs": 7.08778162881174e-05,
+        "p95_abs": 0.0004068593084560317,
+        "max_abs": 32.605804610759265,
+        "mean_rel": 0.00045353110845757204,
+        "p95_rel": 1.9071303437680558e-05,
+        "corr": 0.9952166004930632
+      },
+      "verdict": {
+        "n": 4900,
+        "agreement": 1.0,
+        "gate_membership_flips": 0,
+        "gate_membership_agreement": 1.0,
+        "passes": true,
+        "blocking_reasons": []
+      }
+    },
+    {
+      "symbol": "SOL/USDT",
+      "timeframe": "1h",
+      "window": "oos",
+      "n_eval_bars": 3908,
+      "label_drift": {
+        "n": 3887,
+        "agreement": 0.9981991252894263,
+        "disagreements": 7,
+        "transitions": {
+          "ranging_directional_down->ranging_volatile": 1,
+          "ranging_directional_up->ranging_volatile": 1,
+          "ranging_volatile->ranging_directional_up": 5
+        }
+      },
+      "adx_drift": {
+        "n": 3887,
+        "mean_abs": 0.16463606632778158,
+        "median_abs": 7.804836586444708e-05,
+        "p95_abs": 0.0005099555279322478,
+        "max_abs": 57.51548078646959,
+        "mean_rel": 0.0014978197557275082,
+        "p95_rel": 2.6439110881360282e-05,
+        "corr": 0.9794402927145861
+      },
+      "verdict": {
+        "n": 3887,
+        "agreement": 0.9981991252894263,
+        "gate_membership_flips": 0,
+        "gate_membership_agreement": 1.0,
+        "passes": true,
+        "blocking_reasons": []
+      }
+    },
+    {
+      "symbol": "SOL/USDT",
+      "timeframe": "4h",
+      "window": "is",
+      "n_eval_bars": 1231,
+      "label_drift": {
+        "n": 1210,
+        "agreement": 0.9983471074380166,
+        "disagreements": 2,
+        "transitions": {
+          "ranging_directional_up->ranging_volatile": 1,
+          "trending_down_choppy->trending_down_clean": 1
+        }
+      },
+      "adx_drift": {
+        "n": 1210,
+        "mean_abs": 0.18711592151190093,
+        "median_abs": 7.841291173349418e-05,
+        "p95_abs": 0.16834707738619403,
+        "max_abs": 30.908796749659068,
+        "mean_rel": 0.0012255172956640078,
+        "p95_rel": 0.002849356835881268,
+        "corr": 0.9775564961434633
+      },
+      "verdict": {
+        "n": 1210,
+        "agreement": 0.9983471074380166,
+        "gate_membership_flips": 0,
+        "gate_membership_agreement": 1.0,
+        "passes": true,
+        "blocking_reasons": []
+      }
+    },
+    {
+      "symbol": "SOL/USDT",
+      "timeframe": "4h",
+      "window": "oos",
+      "n_eval_bars": 928,
+      "label_drift": {
+        "n": 907,
+        "agreement": 0.9933847850055126,
+        "disagreements": 6,
+        "transitions": {
+          "ranging_directional_up->ranging_volatile": 4,
+          "trending_up_choppy->trending_up_clean": 2
+        }
+      },
+      "adx_drift": {
+        "n": 907,
+        "mean_abs": 0.5424899169016445,
+        "median_abs": 8.619717824132067e-05,
+        "p95_abs": 1.3880936079386428,
+        "max_abs": 39.2552359806205,
+        "mean_rel": 0.008687900722925659,
+        "p95_rel": 0.042342147647588216,
+        "corr": 0.9648711565195103
+      },
+      "verdict": {
+        "n": 907,
+        "agreement": 0.9933847850055126,
+        "gate_membership_flips": 2,
+        "gate_membership_agreement": 0.9977949283351709,
+        "passes": true,
+        "blocking_reasons": []
+      }
+    }
+  ],
+  "verdict": {
+    "promote": true,
+    "blocking_reasons": []
+  }
+}

--- a/backtest/candidates/breakout_1165/live_label_fidelity.py
+++ b/backtest/candidates/breakout_1165/live_label_fidelity.py
@@ -1,0 +1,184 @@
+"""Live-label fidelity gate for wiring `comp_up_clean_p21` live (#1197).
+
+The #1165 evidence scored composite `trending_up_clean` labels (period 21)
+computed over the FULL cached history of each dataset. The live gate reads
+labels from `shared_scripts/check_regime.py`, which recomputes the composite
+over a BOUNDED fetch (`--ohlcv-limit`, default 200 bars) each cycle — the
+composite's ADX sub-recursion is seeded only ~200 bars back, so the same
+calendar bar can label differently live vs in the evidence (#1082). Before the
+gate goes live, this driver measures that drift: per-bar hand-rule composite
+labels, full-window vs bounded-window, via the same
+`regime_bounded_window_validate` arms the #1074 promotion gate uses (we call
+the same functions live calls; nothing is re-implemented here).
+
+Promotion criterion (the #1082 bar applied to a hand-rule gate — there is no
+fitted model, so `gate_verdict`/provenance don't apply): for EVERY dataset the
+live strategy could trade (the same six the evidence covered) and every
+protocol window, full-vs-bounded label agreement >= 0.95 measured on >= 30
+bars both views scored. Fail closed: a missing/short window blocks, it never
+vacuously passes. The artifact also reports the binary agreement on
+`trending_up_clean` membership — the exact bit `allowed_regimes` consumes —
+which can never be lower than the all-label agreement it is gated on.
+
+Run from the repo root with the cache DB present:
+
+    uv run --no-sync python backtest/candidates/breakout_1165/live_label_fidelity.py \
+        --json backtest/candidates/breakout_1165/live_label_fidelity.json
+
+Exit code is non-zero when ANY row blocks, so the #1197 wiring decision can
+never ride a partially-failed run.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_BACKTEST = os.path.abspath(os.path.join(_THIS_DIR, "..", ".."))
+_ROOT = os.path.abspath(os.path.join(_BACKTEST, ".."))
+for _p in (_BACKTEST, os.path.join(_ROOT, "shared_tools")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# The gate under promotion: composite `trending_up_clean` at period 21
+# (comp_up_clean_p21, README step 2 plateau peak). The thresholds stay the
+# shared defaults — the evidence ran them and the live window spec will too.
+GATE_PERIOD = 21
+GATE_LABEL = "trending_up_clean"
+PROTOCOL_WINDOWS = ("is", "oos")
+
+
+def gate_membership_flips(label_drift: dict, gate_label: str = GATE_LABEL) -> int:
+    """Count of disagreeing bars where the two views differ ON THE GATE BIT
+    (exactly one side labels `gate_label`). `label_drift` is a
+    `label_drift_stats` dict; its `transitions` maps "full->bounded" pairs to
+    counts for every disagreeing bar, so the gate-relevant subset is the pairs
+    where membership differs. A "clean->choppy" flip blocks an entry the
+    evidence took; "choppy->clean" admits one it never scored — both count.
+    """
+    flips = 0
+    for key, count in (label_drift.get("transitions") or {}).items():
+        full_label, _, bounded_label = key.partition("->")
+        if (full_label == gate_label) != (bounded_label == gate_label):
+            flips += int(count)
+    return flips
+
+
+def row_verdict(label_drift: dict, *, agreement_threshold: float,
+                min_agreement_bars: int) -> dict:
+    """Fail-closed pass/block for one (dataset, window) row, mirroring the
+    #1082 `go_no_go` agreement arm: enough comparable bars first (a short
+    window yields a vacuous agreement=1.0 on ~0 bars and must BLOCK), then the
+    all-label agreement threshold. The binary gate-membership agreement is
+    derived and reported but not separately gated — disagreements on the gate
+    bit are a subset of all-label disagreements, so it can never be lower.
+    """
+    n = int(label_drift.get("n", 0))
+    agreement = float(label_drift.get("agreement", 0.0))
+    flips = gate_membership_flips(label_drift)
+    gate_agreement = 1.0 if n == 0 else 1.0 - flips / n
+    reasons: list[str] = []
+    if n < min_agreement_bars:
+        reasons.append(
+            f"insufficient comparable bars: {n} < {min_agreement_bars} "
+            "(agreement not measurable -> fail closed)")
+    elif agreement < agreement_threshold:
+        reasons.append(
+            f"full-vs-bounded label agreement {agreement:.4f} "
+            f"< threshold {agreement_threshold:.4f}")
+    return {
+        "n": n,
+        "agreement": agreement,
+        "gate_membership_flips": flips,
+        "gate_membership_agreement": gate_agreement,
+        "passes": not reasons,
+        "blocking_reasons": reasons,
+    }
+
+
+def overall_verdict(rows: list, expected_rows: int) -> dict:
+    """Promote iff every expected row exists and passes. A run that produced
+    fewer rows than the dataset x window matrix (loader error, empty cache)
+    blocks — silence is not evidence."""
+    reasons: list[str] = []
+    if len(rows) < expected_rows:
+        reasons.append(
+            f"only {len(rows)}/{expected_rows} dataset-window rows produced "
+            "(missing rows fail closed)")
+    for row in rows:
+        if not row["verdict"]["passes"]:
+            reasons.append(
+                f"{row['symbol']} {row['timeframe']} {row['window']}: "
+                + "; ".join(row["verdict"]["blocking_reasons"]))
+    return {"promote": not reasons, "blocking_reasons": reasons}
+
+
+def main(argv=None) -> int:
+    import argparse
+    import json
+
+    from eval_windows import DATASETS
+    from regime_bounded_window_validate import (
+        DEFAULT_AGREEMENT_THRESHOLD,
+        DEFAULT_LOOKBACK,
+        DEFAULT_MIN_AGREEMENT_BARS,
+        validate,
+    )
+
+    parser = argparse.ArgumentParser(
+        description="Full-vs-bounded composite label fidelity at the gate "
+                    "period (#1197 wiring gate for comp_up_clean_p21)")
+    parser.add_argument("--period", type=int, default=GATE_PERIOD)
+    parser.add_argument("--lookback", type=int, default=DEFAULT_LOOKBACK,
+                        help=f"live bounded fetch size (default {DEFAULT_LOOKBACK}, "
+                             "mirrors check_regime --ohlcv-limit)")
+    parser.add_argument("--windows", default=",".join(PROTOCOL_WINDOWS),
+                        help="comma list of eval_windows keys "
+                             f"(default {','.join(PROTOCOL_WINDOWS)})")
+    parser.add_argument("--agreement-threshold", type=float,
+                        default=DEFAULT_AGREEMENT_THRESHOLD)
+    parser.add_argument("--min-agreement-bars", type=int,
+                        default=DEFAULT_MIN_AGREEMENT_BARS)
+    parser.add_argument("--json", default=None,
+                        help="write the full report JSON to this path")
+    args = parser.parse_args(argv)
+
+    windows = [w.strip() for w in args.windows.split(",") if w.strip()]
+    rows = []
+    for symbol, timeframe in DATASETS:
+        for window in windows:
+            rep = validate(symbol, timeframe, window, None,
+                           lookback=args.lookback,
+                           incumbent_period=args.period)
+            hr = rep["handrule"]
+            rows.append({
+                "symbol": symbol,
+                "timeframe": timeframe,
+                "window": window,
+                "n_eval_bars": rep["n_eval_bars"],
+                "label_drift": hr["label_drift"],
+                "adx_drift": rep["adx_drift"],
+                "verdict": row_verdict(
+                    hr["label_drift"],
+                    agreement_threshold=args.agreement_threshold,
+                    min_agreement_bars=args.min_agreement_bars),
+            })
+    payload = {
+        "gate": {"label": GATE_LABEL, "period": int(args.period),
+                 "lookback": int(args.lookback),
+                 "agreement_threshold": float(args.agreement_threshold),
+                 "min_agreement_bars": int(args.min_agreement_bars)},
+        "windows": windows,
+        "rows": rows,
+        "verdict": overall_verdict(rows, len(DATASETS) * len(windows)),
+    }
+    text = json.dumps(payload, indent=2, default=float)
+    if args.json:
+        with open(args.json, "w") as fh:
+            fh.write(text)
+    print(text)
+    return 0 if payload["verdict"]["promote"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backtest/tests/test_breakout_1165_live_label_fidelity.py
+++ b/backtest/tests/test_breakout_1165_live_label_fidelity.py
@@ -1,0 +1,97 @@
+"""Tests for the #1197 live-label fidelity gate (pure helpers, no data
+access).
+
+The load-bearing properties: the per-row verdict fails CLOSED (a window too
+short to measure agreement blocks — it never rides a vacuous agreement=1.0 on
+~0 bars), the overall verdict blocks when any expected dataset-window row is
+missing (silence is not evidence), and the gate-membership flip count keys on
+`trending_up_clean` membership CHANGING — not on any disagreement touching the
+label pair.
+"""
+
+import importlib.util
+import os
+
+_DRIVER_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "candidates", "breakout_1165",
+    "live_label_fidelity.py")
+_spec = importlib.util.spec_from_file_location(
+    "breakout_1165_live_label_fidelity", _DRIVER_PATH)
+llf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(llf)
+
+
+def _drift(n, agreement, transitions=None):
+    return {"n": n, "agreement": agreement,
+            "disagreements": sum((transitions or {}).values()),
+            "transitions": dict(transitions or {})}
+
+
+def test_gate_membership_flips_counts_both_directions():
+    drift = _drift(100, 0.97, {
+        "trending_up_clean->trending_up_choppy": 2,   # gate loses an entry bar
+        "trending_up_choppy->trending_up_clean": 1,   # gate admits an unscored bar
+        "ranging_quiet->ranging_volatile": 4,          # gate bit unchanged
+    })
+    assert llf.gate_membership_flips(drift) == 3
+
+
+def test_gate_membership_flips_ignores_non_gate_disagreements():
+    drift = _drift(50, 0.9, {"trending_down_clean->ranging_quiet": 5})
+    assert llf.gate_membership_flips(drift) == 0
+
+
+def test_row_verdict_fails_closed_below_min_bars():
+    # A vacuous agreement=1.0 on too few comparable bars must BLOCK.
+    v = llf.row_verdict(_drift(3, 1.0), agreement_threshold=0.95,
+                        min_agreement_bars=30)
+    assert not v["passes"]
+    assert any("insufficient comparable bars" in r for r in v["blocking_reasons"])
+
+
+def test_row_verdict_blocks_below_agreement_threshold():
+    v = llf.row_verdict(
+        _drift(100, 0.90, {"trending_up_clean->ranging_quiet": 10}),
+        agreement_threshold=0.95, min_agreement_bars=30)
+    assert not v["passes"]
+    assert any("label agreement" in r for r in v["blocking_reasons"])
+
+
+def test_row_verdict_passes_and_derives_gate_agreement():
+    v = llf.row_verdict(
+        _drift(100, 0.98, {"trending_up_clean->trending_up_choppy": 1,
+                           "ranging_quiet->ranging_volatile": 1}),
+        agreement_threshold=0.95, min_agreement_bars=30)
+    assert v["passes"]
+    assert v["gate_membership_flips"] == 1
+    assert v["gate_membership_agreement"] == 0.99
+    # The gate bit can never disagree more often than labels overall.
+    assert v["gate_membership_agreement"] >= v["agreement"]
+
+
+def test_overall_verdict_blocks_on_missing_rows():
+    row = {"symbol": "BTC/USDT", "timeframe": "1h", "window": "oos",
+           "verdict": {"passes": True, "blocking_reasons": []}}
+    v = llf.overall_verdict([row], expected_rows=12)
+    assert not v["promote"]
+    assert any("1/12" in r for r in v["blocking_reasons"])
+
+
+def test_overall_verdict_blocks_when_any_row_blocks():
+    ok = {"symbol": "BTC/USDT", "timeframe": "1h", "window": "is",
+          "verdict": {"passes": True, "blocking_reasons": []}}
+    bad = {"symbol": "SOL/USDT", "timeframe": "4h", "window": "oos",
+           "verdict": {"passes": False,
+                       "blocking_reasons": ["label agreement 0.9000 < threshold"]}}
+    v = llf.overall_verdict([ok, bad], expected_rows=2)
+    assert not v["promote"]
+    assert any("SOL/USDT 4h oos" in r for r in v["blocking_reasons"])
+
+
+def test_overall_verdict_promotes_when_all_rows_pass():
+    rows = [{"symbol": s, "timeframe": tf, "window": w,
+             "verdict": {"passes": True, "blocking_reasons": []}}
+            for s in ("BTC/USDT",) for tf in ("1h", "4h") for w in ("is", "oos")]
+    v = llf.overall_verdict(rows, expected_rows=4)
+    assert v["promote"]
+    assert v["blocking_reasons"] == []

--- a/scheduler/regime_comp_up_clean_gate_test.go
+++ b/scheduler/regime_comp_up_clean_gate_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// ─── #1197: comp_up_clean_p21 live wiring for the breakout futures strategy ──
+//
+// The #1165 evidence (backtest/candidates/breakout_1165/) validated gating
+// breakout futures entries on composite `trending_up_clean` at classifier
+// period 21. These tests pin the exact operator config that wiring uses and
+// the gate semantics the evidence relied on (entries blocked, closes always
+// execute), so the deployed shape can never silently drift from what was
+// validated.
+
+func compUpCleanP21FuturesConfig() Config {
+	return Config{
+		IntervalSeconds: 60,
+		Regime: &RegimeConfig{
+			Enabled:      true,
+			Period:       14, // loadConfig default; the gate reads the p21 window below
+			ADXThreshold: 20,
+			Windows: RegimeWindowsMap{
+				"medium": {Classifier: "composite", Period: 21},
+			},
+		},
+		Strategies: []StrategyConfig{
+			{
+				ID:               "ts-breakout-btc",
+				Type:             "futures",
+				Platform:         "topstep",
+				Script:           "shared_scripts/check_topstep.py",
+				Args:             []string{"breakout", "BTC", "1h"},
+				Capital:          5000,
+				MaxDrawdownPct:   10,
+				RegimeGateWindow: "medium",
+				AllowedRegimes:   []string{"trending_up_clean"},
+			},
+		},
+	}
+}
+
+// The full wiring from the issue — composite medium window at period 21,
+// regime_gate_window pointing at it, allowed_regimes carrying the composite
+// label — must validate as one piece.
+func TestValidateConfig_CompUpCleanP21Wiring_Accepts(t *testing.T) {
+	cfg := compUpCleanP21FuturesConfig()
+	if err := ValidateConfig(&cfg); err != nil {
+		t.Fatalf("comp_up_clean_p21 wiring should validate, got: %v", err)
+	}
+}
+
+// The realistic deployment shape: a live config that already carries an ADX
+// "medium" window for other strategies adds the p21 composite window under its
+// own key. With regime_gate_window pointing at it the pairing validates…
+func TestValidateConfig_CompUpCleanP21Wiring_AcceptsAlongsideExistingADXWindow(t *testing.T) {
+	cfg := compUpCleanP21FuturesConfig()
+	cfg.Regime.Windows = RegimeWindowsMap{
+		"medium":   {Classifier: "adx", Period: 14, ADXThreshold: 20},
+		"comp_p21": {Classifier: "composite", Period: 21},
+	}
+	cfg.Strategies[0].RegimeGateWindow = "comp_p21"
+	if err := ValidateConfig(&cfg); err != nil {
+		t.Fatalf("comp_p21 gate window alongside an ADX medium window should validate, got: %v", err)
+	}
+}
+
+// …and the touch-set trap: omit regime_gate_window in that same config and the
+// gate resolves the PRIMARY window ("medium" when present — here the ADX one),
+// whose 3-label vocabulary lacks `trending_up_clean`. Config load must reject
+// loudly, never half-apply. (With the composite window itself named "medium"
+// and no ADX sibling, primary resolution happens to land on it — the explicit
+// regime_gate_window is what makes the wiring deployment-order independent.)
+func TestValidateConfig_CompUpCleanP21Wiring_RejectsWithoutGateWindow(t *testing.T) {
+	cfg := compUpCleanP21FuturesConfig()
+	cfg.Regime.Windows = RegimeWindowsMap{
+		"medium":   {Classifier: "adx", Period: 14, ADXThreshold: 20},
+		"comp_p21": {Classifier: "composite", Period: 21},
+	}
+	cfg.Strategies[0].RegimeGateWindow = ""
+	err := ValidateConfig(&cfg)
+	if err == nil {
+		t.Fatal("trending_up_clean against the primary ADX window should fail validation")
+	}
+	if !strings.Contains(err.Error(), "trending_up_clean") {
+		t.Fatalf("error should name the invalid label, got: %v", err)
+	}
+}
+
+// A composite label on an ADX window spec must also reject when the gate
+// window is named but carries the wrong classifier — the pairing is
+// (label, window classifier), not just window existence.
+func TestValidateConfig_CompUpCleanP21Wiring_RejectsADXClassifierWindow(t *testing.T) {
+	cfg := compUpCleanP21FuturesConfig()
+	cfg.Regime.Windows = RegimeWindowsMap{
+		"medium": {Classifier: "adx", Period: 21},
+	}
+	if err := ValidateConfig(&cfg); err == nil {
+		t.Fatal("trending_up_clean against an adx-classifier gate window should fail validation")
+	}
+}
+
+// Gate semantics the #1165 evidence relied on (README structural note: the
+// regime gate blocks ENTRIES only; closes always execute). Flat + label
+// outside the allowed set blocks; flat + trending_up_clean passes; an open
+// position is never blocked, whatever the label, so close/manage paths run.
+func TestApplyRegimeGate_CompUpCleanP21_EntriesBlockedClosesPass(t *testing.T) {
+	cfg := compUpCleanP21FuturesConfig()
+	sc := cfg.Strategies[0]
+	rc := cfg.Regime
+
+	payloadFor := func(label string) RegimePayload {
+		var p RegimePayload
+		raw := `{"medium":{"regime":"` + label + `"}}`
+		if err := json.Unmarshal([]byte(raw), &p); err != nil {
+			t.Fatalf("payload unmarshal: %v", err)
+		}
+		return p
+	}
+
+	// Every non-clean composite label blocks a flat entry.
+	for _, label := range []string{
+		"trending_up_choppy", "trending_down_clean", "trending_down_choppy",
+		"ranging_quiet", "ranging_volatile", "ranging_directional",
+		"ranging_directional_up", "ranging_directional_down",
+	} {
+		gateLabel, blocked := applyRegimeGate(sc, payloadFor(label), rc, 0)
+		if !blocked {
+			t.Errorf("flat entry under %q should be blocked, gateLabel=%q", label, gateLabel)
+		}
+	}
+
+	// The validated label admits the entry.
+	if gateLabel, blocked := applyRegimeGate(sc, payloadFor("trending_up_clean"), rc, 0); blocked {
+		t.Fatalf("flat entry under trending_up_clean should pass, gateLabel=%q", gateLabel)
+	}
+
+	// Closes always execute: with a position open the gate never blocks, even
+	// under a label the entry side would reject.
+	if _, blocked := applyRegimeGate(sc, payloadFor("trending_down_choppy"), rc, 1.5); blocked {
+		t.Fatal("open position must never be gate-blocked (closes always execute)")
+	}
+}


### PR DESCRIPTION
Closes #1197

## What this ships

The #1165 evidence validated gating the breakout futures strategy's entries on composite `trending_up_clean` at classifier period 21 (`comp_up_clean_p21`: stitched worst DD -52.2% → -23.2%, vs-B&H +43.7 → +56.3pts, fee drag 14.3pp → 3.8pp). The live config is out-of-tree (#1056), so the actual config edit is operator-side; this PR ships everything that edit depends on:

- **Live-label fidelity evidence (the #1082-class bar).** `backtest/candidates/breakout_1165/live_label_fidelity.py` measures whether the live scheduler's bounded 200-bar `check_regime.py` fetch reproduces the composite p21 labels the full-history evidence scored, via the same `regime_bounded_window_validate` hand-rule arm the #1074 promotion gate uses. Fail-closed per dataset × window (agreement ≥ 0.95 on ≥ 30 bars; missing/short rows block; non-zero exit on any block). **Result: PASS on all 12 rows** — worst all-label agreement 0.98678, worst `trending_up_clean`-membership agreement 0.99338 (ETH/4h oos, 6 flips on 907 bars). Artifact committed.
- **Config-shape + gate-semantics tests.** `scheduler/regime_comp_up_clean_gate_test.go` pins the exact operator wiring through `ValidateConfig` — including the touch-set trap: omitting `regime_gate_window` when an ADX window is the primary rejects loudly (its vocabulary lacks the composite label), which is why the wiring sets the gate window explicitly. Gate semantics pinned: all 8 non-clean composite labels block a flat entry, `trending_up_clean` passes, and an open position is never gate-blocked (closes/management always execute).
- **Driver unit tests** for the fail-closed verdict logic and gate-membership flip counting.
- **README Step 6** — fidelity results, the operator config snippet, and deployment constraints (explicit `regime_gate_window`, `regime.enabled: true`, apply while flat — hot-reload blocks gate-window/classifier changes with a position open).

## Verification

- `go -C scheduler test ./...` and the full pytest suite green; `gofmt` clean.
- One-cycle paper smoke with the gate config: the live composite p21 label computed (`trending_up_choppy` on current tape) and the scheduler logged "Regime gate: open signal blocked" — the acceptance criterion (entries suppressed under non-`trending_up_clean` labels) demonstrated end-to-end.
- Fidelity sweep regenerates from the repo root with the cache DB present (command in README Step 6 / module docstring).

## Follow-on named in the deliverables

README verdict item 4 names the `squeeze_momentum` re-run of this directory (#983, -58.5% DD) as its own issue — not filed in this PR.

LLM: Fable 5 | high | Harness: Claude Code
