### PR TITLE
feat(#1203): /closing-strategies — Discord catalog of registered close evaluators

### DIFF
--- a/scheduler/closing_strategies.go
+++ b/scheduler/closing_strategies.go
@@ -103,14 +103,33 @@ func formatCloseRegistryEntry(e closeRegistryEntry, userClose CloseDefaultsMap) 
 		keys = append(keys, k)
 	}
 	userEntry, hasUserEntry := closeDefaultsEntry(userClose, e.Name)
-	_, registryHasTPTiers := e.DefaultParams["tp_tiers"]
-	if hasUserEntry && !registryHasTPTiers {
-		// Some override-eligible evaluators (e.g. trailing_tp_ratchet_regime)
-		// ship empty registry default_params — the operator-configured
-		// tp_tiers is the only value that ever runs, so surface it even
-		// though the registry itself has no tp_tiers key to iterate.
-		if tp, ok := userEntry["tp_tiers"]; ok && tp != nil {
-			keys = append(keys, "tp_tiers")
+	// overrideKeys are the user_defaults.close keys whose configured value, if
+	// present, is the effective value shown here (marked as an override). Every
+	// override-eligible evaluator honors tp_tiers; trailing_tp_ratchet_regime
+	// additionally honors the coupled trailing_stop_atr_regime SL owner (the
+	// only evaluator for which close_defaults.go allows that key — see
+	// validateUserCloseDefaults). Both ship absent from the registry
+	// default_params, so surface them even though the registry never lists them.
+	overrideKeys := []string{"tp_tiers"}
+	if strings.ToLower(strings.TrimSpace(e.Name)) == trailingTPRatchetRegimeCloseName {
+		overrideKeys = append(overrideKeys, userCloseDefaultTrailingStopATRRegimeKey)
+	}
+	isOverrideKey := func(k string) bool {
+		for _, ok := range overrideKeys {
+			if k == ok {
+				return true
+			}
+		}
+		return false
+	}
+	if hasUserEntry {
+		for _, ok := range overrideKeys {
+			if _, registryHas := e.DefaultParams[ok]; registryHas {
+				continue // already iterated from the registry default_params
+			}
+			if v, present := userEntry[ok]; present && v != nil {
+				keys = append(keys, ok)
+			}
 		}
 	}
 	sort.Strings(keys)
@@ -118,9 +137,9 @@ func formatCloseRegistryEntry(e closeRegistryEntry, userClose CloseDefaultsMap) 
 		sb.WriteString("  params: (none)\n")
 	}
 	for _, k := range keys {
-		if k == "tp_tiers" && hasUserEntry {
-			if tp, ok := userEntry["tp_tiers"]; ok && tp != nil {
-				fmt.Fprintf(&sb, "  %s=%s (user_defaults.close override)\n", k, jsonInline(tp))
+		if hasUserEntry && isOverrideKey(k) {
+			if v, ok := userEntry[k]; ok && v != nil {
+				fmt.Fprintf(&sb, "  %s=%s (user_defaults.close override)\n", k, jsonInline(v))
 				continue
 			}
 		}

--- a/scheduler/closing_strategies.go
+++ b/scheduler/closing_strategies.go
@@ -98,15 +98,25 @@ func formatCloseRegistryEntry(e closeRegistryEntry, userClose CloseDefaultsMap) 
 	sort.Strings(platforms)
 	fmt.Fprintf(&sb, "  platforms: %s\n", strings.Join(platforms, ", "))
 
-	keys := make([]string, 0, len(e.DefaultParams))
+	keys := make([]string, 0, len(e.DefaultParams)+1)
 	for k := range e.DefaultParams {
 		keys = append(keys, k)
+	}
+	userEntry, hasUserEntry := closeDefaultsEntry(userClose, e.Name)
+	_, registryHasTPTiers := e.DefaultParams["tp_tiers"]
+	if hasUserEntry && !registryHasTPTiers {
+		// Some override-eligible evaluators (e.g. trailing_tp_ratchet_regime)
+		// ship empty registry default_params — the operator-configured
+		// tp_tiers is the only value that ever runs, so surface it even
+		// though the registry itself has no tp_tiers key to iterate.
+		if tp, ok := userEntry["tp_tiers"]; ok && tp != nil {
+			keys = append(keys, "tp_tiers")
+		}
 	}
 	sort.Strings(keys)
 	if len(keys) == 0 {
 		sb.WriteString("  params: (none)\n")
 	}
-	userEntry, hasUserEntry := closeDefaultsEntry(userClose, e.Name)
 	for _, k := range keys {
 		if k == "tp_tiers" && hasUserEntry {
 			if tp, ok := userEntry["tp_tiers"]; ok && tp != nil {

--- a/scheduler/closing_strategies.go
+++ b/scheduler/closing_strategies.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// closing_strategies.go implements the #1203 /closing-strategies Discord
+// command: a read-only catalog of every registered close evaluator (name,
+// description, platforms, config params) sourced from the Python close
+// registry (shared_strategies/close/registry.py) via
+// shared_tools/close_registry_loader.py --list-json.
+
+// closeRegistryEntry mirrors one row of the Python close registry's
+// `--list-json` dump.
+type closeRegistryEntry struct {
+	Name          string                 `json:"name"`
+	Description   string                 `json:"description"`
+	DefaultParams map[string]interface{} `json:"default_params"`
+	Platforms     []string               `json:"platforms"`
+}
+
+var (
+	closeRegistryCatalogMu sync.Mutex
+	closeRegistryCatalog   []closeRegistryEntry // nil until first successful fetch
+)
+
+// fetchCloseRegistryCatalog returns the cached close-evaluator catalog,
+// populating it on first call. The registry is static per deploy (a new
+// evaluator only ships with a rebuild+restart), so the read-only subprocess
+// runs at most once per process lifetime; a failed fetch is never cached, so
+// the next command invocation retries.
+func fetchCloseRegistryCatalog() ([]closeRegistryEntry, error) {
+	closeRegistryCatalogMu.Lock()
+	defer closeRegistryCatalogMu.Unlock()
+	if closeRegistryCatalog != nil {
+		return closeRegistryCatalog, nil
+	}
+	stdout, stderr, err := runPythonReadOnly("shared_tools/close_registry_loader.py", []string{"--list-json"})
+	if err != nil {
+		return nil, fmt.Errorf("close registry dump failed: %w (stderr: %s)", err, strings.TrimSpace(string(stderr)))
+	}
+	var entries []closeRegistryEntry
+	if jsonErr := json.Unmarshal(stdout, &entries); jsonErr != nil {
+		return nil, fmt.Errorf("close registry dump: invalid JSON: %w", jsonErr)
+	}
+	closeRegistryCatalog = entries
+	return entries, nil
+}
+
+// closingStrategiesHeaderBudget reserves room for the per-page header line
+// formatClosingStrategiesResponse prepends after packing, so a page's final
+// length (header + body) never exceeds discordCharLimit.
+const closingStrategiesHeaderBudget = 80
+
+// formatClosingStrategiesResponse renders the close-evaluator catalog as one
+// or more Discord messages, chunked to stay under discordCharLimit (same
+// splitting approach as writeCatTableChunks/FormatCategorySummary). Pure
+// helper — no Python subprocess — so it's fully unit-testable.
+func formatClosingStrategiesResponse(cfg *Config, entries []closeRegistryEntry) []string {
+	sorted := make([]closeRegistryEntry, len(entries))
+	copy(sorted, entries)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+
+	userClose := cfg.userDefaultsClose()
+	blocks := make([]string, 0, len(sorted))
+	for _, e := range sorted {
+		blocks = append(blocks, formatCloseRegistryEntry(e, userClose))
+	}
+	if len(blocks) == 0 {
+		return []string{"No close evaluators registered."}
+	}
+
+	pages := packTextBlocks(blocks, discordCharLimit-closingStrategiesHeaderBudget)
+	for idx := range pages {
+		if idx == 0 {
+			pages[idx] = fmt.Sprintf("**Close evaluators (%d registered)**\n\n%s", len(sorted), pages[idx])
+		} else {
+			pages[idx] = fmt.Sprintf("**Close evaluators (cont'd, page %d/%d)**\n\n%s", idx+1, len(pages), pages[idx])
+		}
+	}
+	return pages
+}
+
+// formatCloseRegistryEntry renders one evaluator's name, description,
+// platforms, and default params (one `key=value` per line, sorted). When
+// user_defaults.close (#866/#1135) overrides a param for this evaluator, the
+// effective value is shown in place of the registry default and marked as an
+// override, since the registry default is not what actually runs.
+func formatCloseRegistryEntry(e closeRegistryEntry, userClose CloseDefaultsMap) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "**%s** — %s\n", e.Name, e.Description)
+
+	platforms := append([]string(nil), e.Platforms...)
+	sort.Strings(platforms)
+	fmt.Fprintf(&sb, "  platforms: %s\n", strings.Join(platforms, ", "))
+
+	keys := make([]string, 0, len(e.DefaultParams))
+	for k := range e.DefaultParams {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if len(keys) == 0 {
+		sb.WriteString("  params: (none)\n")
+	}
+	userEntry, hasUserEntry := closeDefaultsEntry(userClose, e.Name)
+	for _, k := range keys {
+		if k == "tp_tiers" && hasUserEntry {
+			if tp, ok := userEntry["tp_tiers"]; ok && tp != nil {
+				fmt.Fprintf(&sb, "  %s=%s (user_defaults.close override)\n", k, jsonInline(tp))
+				continue
+			}
+		}
+		fmt.Fprintf(&sb, "  %s=%s\n", k, jsonInline(e.DefaultParams[k]))
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// jsonInline compact-encodes a param value for display; falls back to Go's
+// default formatting if the value somehow isn't JSON-marshalable.
+func jsonInline(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}
+
+// packTextBlocks greedily packs blocks into pages, each page's body capped at
+// limit bytes. A single block longer than limit becomes its own oversized
+// page rather than being split mid-block.
+func packTextBlocks(blocks []string, limit int) []string {
+	var pages []string
+	var cur strings.Builder
+	for _, b := range blocks {
+		if cur.Len() > 0 && cur.Len()+len(b) > limit {
+			pages = append(pages, cur.String())
+			cur.Reset()
+		}
+		cur.WriteString(b)
+	}
+	if cur.Len() > 0 {
+		pages = append(pages, cur.String())
+	}
+	return pages
+}

--- a/scheduler/closing_strategies_test.go
+++ b/scheduler/closing_strategies_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatClosingStrategiesResponseSortedOrder(t *testing.T) {
+	entries := []closeRegistryEntry{
+		{Name: "zscore_target", Description: "Z target", DefaultParams: map[string]interface{}{"z_target": 0.0}, Platforms: []string{"spot"}},
+		{Name: "atr_stop", Description: "ATR stop", DefaultParams: map[string]interface{}{"atr_mult": 0.0}, Platforms: []string{"spot"}},
+		{Name: "avwap_stop", Description: "AVWAP stop", DefaultParams: map[string]interface{}{"buffer_atr_mult": 0.25}, Platforms: []string{"spot", "futures"}},
+	}
+	pages := formatClosingStrategiesResponse(&Config{}, entries)
+	if len(pages) != 1 {
+		t.Fatalf("expected 1 page, got %d", len(pages))
+	}
+	body := pages[0]
+	iAtr := strings.Index(body, "**atr_stop**")
+	iAvwap := strings.Index(body, "**avwap_stop**")
+	iZ := strings.Index(body, "**zscore_target**")
+	if iAtr < 0 || iAvwap < 0 || iZ < 0 {
+		t.Fatalf("missing expected entries in output: %s", body)
+	}
+	if !(iAtr < iAvwap && iAvwap < iZ) {
+		t.Fatalf("entries not sorted by name: atr_stop=%d avwap_stop=%d zscore_target=%d", iAtr, iAvwap, iZ)
+	}
+	if !strings.Contains(body, "3 registered") {
+		t.Fatalf("expected header to report 3 registered evaluators, got: %s", body)
+	}
+}
+
+func TestFormatClosingStrategiesResponseParamsAndPlatforms(t *testing.T) {
+	entries := []closeRegistryEntry{
+		{
+			Name:          "avwap_stop",
+			Description:   "AVWAP loss-of-line exit",
+			DefaultParams: map[string]interface{}{"buffer_atr_mult": 0.25, "atr_source": "live"},
+			Platforms:     []string{"futures", "spot"},
+		},
+	}
+	body := formatClosingStrategiesResponse(&Config{}, entries)[0]
+	if !strings.Contains(body, "platforms: futures, spot") {
+		t.Fatalf("expected sorted platform list, got: %s", body)
+	}
+	if !strings.Contains(body, "atr_source=\"live\"") {
+		t.Fatalf("expected atr_source param rendered, got: %s", body)
+	}
+	if !strings.Contains(body, "buffer_atr_mult=0.25") {
+		t.Fatalf("expected buffer_atr_mult param rendered, got: %s", body)
+	}
+}
+
+func TestFormatClosingStrategiesResponseNoParams(t *testing.T) {
+	entries := []closeRegistryEntry{
+		{Name: "trailing_tp_ratchet_regime", Description: "Regime ratchet", DefaultParams: map[string]interface{}{}, Platforms: []string{"spot"}},
+	}
+	body := formatClosingStrategiesResponse(&Config{}, entries)[0]
+	if !strings.Contains(body, "params: (none)") {
+		t.Fatalf("expected explicit (none) marker for empty default_params, got: %s", body)
+	}
+}
+
+func TestFormatClosingStrategiesResponseUserDefaultsOverride(t *testing.T) {
+	cfg := &Config{
+		UserDefaults: &UserDefaultsConfig{
+			Close: CloseDefaultsMap{
+				"tiered_tp_atr_live": {"tp_tiers": []interface{}{
+					map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 1.0},
+				}},
+			},
+		},
+	}
+	entries := []closeRegistryEntry{
+		{
+			Name:        "tiered_tp_atr_live",
+			Description: "Tiered TP",
+			DefaultParams: map[string]interface{}{
+				"tp_tiers":   []interface{}{map[string]interface{}{"atr_multiple": 1.5, "close_fraction": 0.4}},
+				"atr_source": "live",
+			},
+			Platforms: []string{"spot"},
+		},
+	}
+	body := formatClosingStrategiesResponse(cfg, entries)[0]
+	if !strings.Contains(body, "user_defaults.close override") {
+		t.Fatalf("expected override marker, got: %s", body)
+	}
+	if strings.Contains(body, "atr_multiple\":1.5") {
+		t.Fatalf("expected the registry default tp_tiers to be replaced by the override, got: %s", body)
+	}
+	if !strings.Contains(body, "atr_multiple\":1") {
+		t.Fatalf("expected the overriding tp_tiers value to be shown, got: %s", body)
+	}
+	// atr_source has no user_defaults.close story (only tp_tiers can be
+	// overridden) so it must still show the plain registry default.
+	if strings.Contains(body, "atr_source=\"live\" (user_defaults.close override)") {
+		t.Fatalf("atr_source must not be marked as an override, got: %s", body)
+	}
+}
+
+func TestFormatClosingStrategiesResponseNoOverrideWhenUnconfigured(t *testing.T) {
+	entries := []closeRegistryEntry{
+		{
+			Name:          "tiered_tp_atr_live",
+			Description:   "Tiered TP",
+			DefaultParams: map[string]interface{}{"tp_tiers": []interface{}{map[string]interface{}{"atr_multiple": 1.5}}},
+			Platforms:     []string{"spot"},
+		},
+	}
+	body := formatClosingStrategiesResponse(&Config{}, entries)[0]
+	if strings.Contains(body, "override") {
+		t.Fatalf("no user_defaults.close entry exists — must not claim an override: %s", body)
+	}
+}
+
+func TestFormatClosingStrategiesResponseEmptyCatalog(t *testing.T) {
+	pages := formatClosingStrategiesResponse(&Config{}, nil)
+	if len(pages) != 1 || pages[0] != "No close evaluators registered." {
+		t.Fatalf("expected the empty-catalog message, got: %v", pages)
+	}
+}
+
+func TestFormatClosingStrategiesResponseChunksAcrossMessages(t *testing.T) {
+	// Build enough synthetic evaluators with long descriptions to force the
+	// output past discordCharLimit and confirm it splits into multiple pages,
+	// each individually under the limit.
+	var entries []closeRegistryEntry
+	longDesc := strings.Repeat("x", 300)
+	for i := 0; i < 20; i++ {
+		entries = append(entries, closeRegistryEntry{
+			Name:          "evaluator_" + string(rune('a'+i)),
+			Description:   longDesc,
+			DefaultParams: map[string]interface{}{"param": 1.0},
+			Platforms:     []string{"spot"},
+		})
+	}
+	pages := formatClosingStrategiesResponse(&Config{}, entries)
+	if len(pages) < 2 {
+		t.Fatalf("expected multiple pages for oversized catalog, got %d", len(pages))
+	}
+	for idx, p := range pages {
+		if len(p) > discordCharLimit {
+			t.Fatalf("page %d exceeds discordCharLimit (%d): len=%d", idx, discordCharLimit, len(p))
+		}
+	}
+	if !strings.Contains(pages[1], "cont'd") {
+		t.Fatalf("expected continuation header on page 2, got: %s", pages[1])
+	}
+}
+
+func TestPackTextBlocksSingleOversizedBlock(t *testing.T) {
+	block := strings.Repeat("y", 100)
+	pages := packTextBlocks([]string{block}, 10)
+	if len(pages) != 1 || pages[0] != block {
+		t.Fatalf("a lone oversized block should still be returned whole, got: %v", pages)
+	}
+}

--- a/scheduler/closing_strategies_test.go
+++ b/scheduler/closing_strategies_test.go
@@ -86,6 +86,71 @@ func TestFormatClosingStrategiesResponseOverrideSurfacesWhenRegistryDefaultIsEmp
 	}
 }
 
+func TestFormatClosingStrategiesResponseRatchetRegimeSLOverride(t *testing.T) {
+	// trailing_tp_ratchet_regime is the one evaluator whose user_defaults.close
+	// entry may carry a coupled trailing_stop_atr_regime SL owner in addition to
+	// tp_tiers (close_defaults.go validateUserCloseDefaults / applyUserClose
+	// DefaultRatchetRegimeTrail). Both effective override keys must be surfaced
+	// and each marked as an override — the catalog exists so an operator can see
+	// what actually runs without reading source.
+	entries := []closeRegistryEntry{
+		{Name: "trailing_tp_ratchet_regime", Description: "Regime ratchet", DefaultParams: map[string]interface{}{}, Platforms: []string{"spot"}},
+	}
+
+	// Case 1: both tp_tiers and trailing_stop_atr_regime configured — both shown,
+	// both marked as overrides.
+	cfgBoth := &Config{
+		UserDefaults: &UserDefaultsConfig{
+			Close: CloseDefaultsMap{
+				"trailing_tp_ratchet_regime": {
+					"tp_tiers": []interface{}{
+						map[string]interface{}{"atr_multiple": 1.0, "trailing_stop_mult_after": 0.5},
+					},
+					"trailing_stop_atr_regime": map[string]interface{}{
+						"use_defaults": true,
+					},
+				},
+			},
+		},
+	}
+	body := formatClosingStrategiesResponse(cfgBoth, entries)[0]
+	if !strings.Contains(body, "tp_tiers=") || !strings.Contains(body, "trailing_stop_atr_regime=") {
+		t.Fatalf("expected both tp_tiers and trailing_stop_atr_regime surfaced, got: %s", body)
+	}
+	if strings.Count(body, "user_defaults.close override") != 2 {
+		t.Fatalf("expected both override keys marked as overrides, got: %s", body)
+	}
+	if strings.Contains(body, "params: (none)") {
+		t.Fatalf("configured overrides must not be hidden behind the (none) marker, got: %s", body)
+	}
+
+	// Case 2: tp_tiers only — no spurious trailing_stop_atr_regime line.
+	cfgTPOnly := &Config{
+		UserDefaults: &UserDefaultsConfig{
+			Close: CloseDefaultsMap{
+				"trailing_tp_ratchet_regime": {
+					"tp_tiers": []interface{}{
+						map[string]interface{}{"atr_multiple": 1.0, "trailing_stop_mult_after": 0.5},
+					},
+				},
+			},
+		},
+	}
+	body = formatClosingStrategiesResponse(cfgTPOnly, entries)[0]
+	if strings.Contains(body, "trailing_stop_atr_regime") {
+		t.Fatalf("no trailing_stop_atr_regime configured — must not emit a spurious SL line, got: %s", body)
+	}
+	if !strings.Contains(body, "tp_tiers=") || !strings.Contains(body, "user_defaults.close override") {
+		t.Fatalf("expected tp_tiers override surfaced, got: %s", body)
+	}
+
+	// Case 3: no user_defaults.close entry at all — no override note anywhere.
+	body = formatClosingStrategiesResponse(&Config{}, entries)[0]
+	if strings.Contains(body, "override") || strings.Contains(body, "trailing_stop_atr_regime") {
+		t.Fatalf("no user_defaults.close entry exists — must not claim any override, got: %s", body)
+	}
+}
+
 func TestFormatClosingStrategiesResponseUserDefaultsOverride(t *testing.T) {
 	cfg := &Config{
 		UserDefaults: &UserDefaultsConfig{

--- a/scheduler/closing_strategies_test.go
+++ b/scheduler/closing_strategies_test.go
@@ -61,6 +61,31 @@ func TestFormatClosingStrategiesResponseNoParams(t *testing.T) {
 	}
 }
 
+func TestFormatClosingStrategiesResponseOverrideSurfacesWhenRegistryDefaultIsEmpty(t *testing.T) {
+	// trailing_tp_ratchet_regime (and any override-eligible evaluator with
+	// empty registry default_params) must still show the operator's
+	// configured tp_tiers — that's the only value that ever runs for it.
+	cfg := &Config{
+		UserDefaults: &UserDefaultsConfig{
+			Close: CloseDefaultsMap{
+				"trailing_tp_ratchet_regime": {"tp_tiers": []interface{}{
+					map[string]interface{}{"atr_multiple": 1.0, "trailing_stop_mult_after": 0.5},
+				}},
+			},
+		},
+	}
+	entries := []closeRegistryEntry{
+		{Name: "trailing_tp_ratchet_regime", Description: "Regime ratchet", DefaultParams: map[string]interface{}{}, Platforms: []string{"spot"}},
+	}
+	body := formatClosingStrategiesResponse(cfg, entries)[0]
+	if strings.Contains(body, "params: (none)") {
+		t.Fatalf("configured override must not be hidden behind the empty-registry-default (none) marker, got: %s", body)
+	}
+	if !strings.Contains(body, "tp_tiers=") || !strings.Contains(body, "user_defaults.close override") {
+		t.Fatalf("expected tp_tiers override to be surfaced, got: %s", body)
+	}
+}
+
 func TestFormatClosingStrategiesResponseUserDefaultsOverride(t *testing.T) {
 	cfg := &Config{
 		UserDefaults: &UserDefaultsConfig{

--- a/scheduler/discord_commands.go
+++ b/scheduler/discord_commands.go
@@ -764,7 +764,18 @@ func (d *DiscordNotifier) handleClosingStrategies(s *discordgo.Session, i *disco
 		})
 		return
 	}
-	for _, page := range formatClosingStrategiesResponse(d.cfg, entries) {
+	// cfg.UserDefaults is a hot-reloadable field mutated under d.ss.mu.Lock()
+	// on SIGHUP (config_reload.go); hold the read lock across the format call
+	// (not across the subprocess above, which can run up to scriptTimeout).
+	var pages []string
+	if d.ss == nil {
+		pages = formatClosingStrategiesResponse(d.cfg, entries)
+	} else {
+		d.ss.mu.RLock()
+		pages = formatClosingStrategiesResponse(d.cfg, entries)
+		d.ss.mu.RUnlock()
+	}
+	for _, page := range pages {
 		_, _ = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 			Content: truncateForDiscord(page),
 			Flags:   flags,

--- a/scheduler/discord_commands.go
+++ b/scheduler/discord_commands.go
@@ -23,14 +23,15 @@ const commandPrefix = "go-trader-"
 
 // readOnlyCommandNames are usable in a guild or in DMs by anyone.
 var readOnlyCommandNames = map[string]bool{
-	"status":           true,
-	"health":           true,
-	"positions":        true,
-	"pnl":              true,
-	"leaderboard":      true,
-	"circuit-breakers": true,
-	"dead-strategies":  true,
-	"correlation":      true,
+	"status":             true,
+	"health":             true,
+	"positions":          true,
+	"pnl":                true,
+	"leaderboard":        true,
+	"circuit-breakers":   true,
+	"dead-strategies":    true,
+	"correlation":        true,
+	"closing-strategies": true,
 }
 
 // opsCommandNames mutate state, run heavy work, or expose operator-sensitive
@@ -406,6 +407,7 @@ func slashCommands() []*discordgo.ApplicationCommand {
 		{Name: commandPrefix + "circuit-breakers", Description: "Active circuit breakers and kill-switch state"},
 		{Name: commandPrefix + "dead-strategies", Description: "Strategies that have never opened a position"},
 		{Name: commandPrefix + "correlation", Description: "Correlation / concentration warnings"},
+		{Name: commandPrefix + "closing-strategies", Description: "Registered close evaluators and their config params"},
 		{Name: commandPrefix + "logs", Description: "Recent journalctl lines (owner DM only)", Contexts: dmContext(), Options: []*discordgo.ApplicationCommandOption{
 			{Type: discordgo.ApplicationCommandOptionInteger, Name: "n", Description: "Number of lines (default 50, max 200)"},
 		}},
@@ -501,6 +503,8 @@ func (d *DiscordNotifier) interactionCreate(s *discordgo.Session, i *discordgo.I
 		d.respondReadOnlyInline(s, i, d.buildDeadStrategies())
 	case "correlation":
 		d.respondReadOnlyInline(s, i, d.buildCorrelation())
+	case "closing-strategies":
+		d.handleClosingStrategies(s, i)
 	// Ops (owner DM only).
 	case "logs":
 		respondText(s, i, runLogs(optionInt(data.Options, "n", 50)))
@@ -739,6 +743,33 @@ func (d *DiscordNotifier) buildCorrelation() string {
 	d.ss.mu.RLock()
 	defer d.ss.mu.RUnlock()
 	return formatCorrelationResponse(d.ss.state.CorrelationSnapshot)
+}
+
+// handleClosingStrategies answers /closing-strategies (#1203) with the full
+// close-evaluator catalog. Deferred + multi-followup because the first call
+// after startup spawns the close-registry subprocess (cached after that, see
+// fetchCloseRegistryCatalog) and the catalog may span more than one Discord
+// message.
+func (d *DiscordNotifier) handleClosingStrategies(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	flags := d.readOnlyReplyFlags()
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{Flags: flags},
+	})
+	entries, err := fetchCloseRegistryCatalog()
+	if err != nil {
+		_, _ = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+			Content: truncateForDiscord(fmt.Sprintf("closing-strategies: %v", err)),
+			Flags:   flags,
+		})
+		return
+	}
+	for _, page := range formatClosingStrategiesResponse(d.cfg, entries) {
+		_, _ = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+			Content: truncateForDiscord(page),
+			Flags:   flags,
+		})
+	}
 }
 
 // lifetimeStats fetches per-strategy lifetime stats from SQLite (independent of mu).

--- a/shared_tools/close_registry_loader.py
+++ b/shared_tools/close_registry_loader.py
@@ -40,3 +40,34 @@ def get_strategy(name: str) -> dict:
 
 def list_strategies() -> list[str]:
     return list(_load_registry().STRATEGIES.keys())
+
+
+def list_strategies_detailed() -> list[dict]:
+    """Full catalog for operator-facing surfaces (#1203): one dict per
+    registered evaluator with its description, default params, and supported
+    platforms. Sorted by name so output is deterministic across runs."""
+    registry = _load_registry().STRATEGIES
+    return [
+        {
+            "name": name,
+            "description": registry[name]["description"],
+            "default_params": registry[name]["default_params"],
+            "platforms": list(registry[name]["platforms"]),
+        }
+        for name in sorted(registry.keys())
+    ]
+
+
+if __name__ == "__main__":
+    import json
+    import sys
+
+    if "--list-json" in sys.argv:
+        try:
+            print(json.dumps(list_strategies_detailed()))
+        except Exception as exc:  # subprocess contract: JSON to stdout even on error
+            print(json.dumps({"error": str(exc)}))
+            sys.exit(1)
+    else:
+        print(json.dumps({"error": "usage: close_registry_loader.py --list-json"}))
+        sys.exit(1)

--- a/shared_tools/test_close_registry_loader.py
+++ b/shared_tools/test_close_registry_loader.py
@@ -1,0 +1,62 @@
+"""Tests for close_registry_loader.py's --list-json catalog surface (#1203)."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from close_registry_loader import list_strategies, list_strategies_detailed
+
+_LOADER_PATH = Path(__file__).resolve().parent / "close_registry_loader.py"
+
+
+def test_list_strategies_detailed_matches_list_strategies():
+    detailed = list_strategies_detailed()
+    assert {e["name"] for e in detailed} == set(list_strategies())
+
+
+def test_list_strategies_detailed_sorted_by_name():
+    names = [e["name"] for e in list_strategies_detailed()]
+    assert names == sorted(names)
+
+
+def test_list_strategies_detailed_shape():
+    detailed = list_strategies_detailed()
+    assert detailed, "expected at least one registered close evaluator"
+    for entry in detailed:
+        assert set(entry.keys()) == {"name", "description", "default_params", "platforms"}
+        assert isinstance(entry["name"], str) and entry["name"]
+        assert isinstance(entry["description"], str) and entry["description"]
+        assert isinstance(entry["default_params"], dict)
+        assert isinstance(entry["platforms"], list) and entry["platforms"]
+
+
+def test_list_strategies_detailed_spot_check_known_evaluators():
+    by_name = {e["name"]: e for e in list_strategies_detailed()}
+    for name in ("tiered_tp_atr_live", "trailing_tp_ratchet", "avwap_stop"):
+        assert name in by_name
+    assert by_name["avwap_stop"]["default_params"] == {"buffer_atr_mult": 0.25, "atr_source": "live"}
+
+
+def test_cli_list_json_emits_same_shape_as_python_call():
+    """Subprocess contract: --list-json prints JSON to stdout on success."""
+    result = subprocess.run(
+        [sys.executable, str(_LOADER_PATH), "--list-json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    dumped = json.loads(result.stdout)
+    assert dumped == list_strategies_detailed()
+
+
+def test_cli_without_list_json_flag_errors_with_json_on_stdout():
+    """Subprocess contract: scripts emit JSON to stdout even on error, exit 1."""
+    result = subprocess.run(
+        [sys.executable, str(_LOADER_PATH)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert "error" in payload


### PR DESCRIPTION
## Summary

Adds a read-only Discord slash command, `/closing-strategies`, that lists every registered close evaluator (exit rule) with its description, supported platforms, and config parameters (defaults, or the effective `user_defaults.close` override when one applies) — so an operator can pick and configure a `close_strategy` without reading source.

- **Python (SSoT):** `shared_tools/close_registry_loader.py` gains `list_strategies_detailed()` and a `--list-json` CLI mode that dumps the full close registry (`shared_strategies/close/registry.py`) as JSON, following the subprocess contract (JSON to stdout even on error, exit 1 on error).
- **Go:** `scheduler/closing_strategies.go` fetches the catalog once via `runPythonReadOnly` and caches it in-process (never caches a failure); the pure `formatClosingStrategiesResponse` helper sorts evaluators by name, marks `tp_tiers` as a `user_defaults.close` override when one exists (#866/#1135), and chunks output across multiple Discord messages under the 2000-char limit.
- **Command wiring:** `scheduler/discord_commands.go` registers `/closing-strategies` as read-only (available like `/leaderboard`/`/positions` — no owner-DM restriction, absent from `opsCommandNames`; no config writes).

## Test plan

- [x] `uv run --no-sync python -m py_compile shared_tools/close_registry_loader.py`
- [x] `uv run --no-sync python -m pytest shared_tools/test_close_registry_loader.py` — list-json shape, sorted order, CLI subprocess contract, spot-check of `tiered_tp_atr_live`/`trailing_tp_ratchet`/`avwap_stop`
- [x] Full Python suite (`shared_tools/ shared_strategies/ platforms/ backtest/`) — 2198 passed
- [x] `go -C scheduler build .` / `go -C scheduler vet ./...` / `gofmt -l` clean
- [x] `go -C scheduler test ./...` — new `scheduler/closing_strategies_test.go` covers sorted order, param/platform rendering, override-marking (including the no-override and unconfigured-evaluator cases), empty catalog, and multi-message chunking

Closes #1203

---
Created with LLM: Sonnet 5 | high | Harness: Claude Code
