### PR TITLE
research(#1152): M6 ranging ratchet/B2-TP geometry retune — incumbents stand

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -311,6 +311,13 @@ def _load_trailing_ratchet():
     global _trailing_ratchet_module
     if _trailing_ratchet_module is not None:
         return _trailing_ratchet_module
+    # trailing_tp_ratchet.py does `from _helpers import …` / `from regime_atr
+    # import …` at module level — both live in shared_strategies/close, so the
+    # dir must be importable BEFORE exec_module. The constructor's own
+    # _ensure_close_strategies_path() call runs after the ratchet load (#1152:
+    # a ratchet close ref in a process that never imported the close registry —
+    # e.g. exit_policy_ab — crashed here on ModuleNotFoundError: _helpers).
+    _ensure_close_strategies_path()
     import importlib.util
     name = "_go_trader_trailing_ratchet"
     path = os.path.abspath(os.path.join(

--- a/backtest/exit_policy_ab.py
+++ b/backtest/exit_policy_ab.py
@@ -544,6 +544,16 @@ _REPLAYABLE_CLOSE_NAMES = {
     "trailing_stop_atr_mult",
     "trailing_stop_atr_regime",
     "stop_loss_atr_mult",
+    # #1152: the ratchet ladders and the frozen-at-open regime TP are
+    # self-contained — they fire off price/ATR/the regime label stamped at open
+    # (a pure function of bar data the replay preserves), never off later
+    # signals, so the single-entry replay isolates them faithfully. The
+    # per-tick re-resolution variants (tiered_tp_atr_live_regime*) stay out:
+    # _dynamic is HL-live-only (load_strategy_config rejects it) and the plain
+    # live_regime variant has no validation run behind it yet.
+    "trailing_tp_ratchet",
+    "trailing_tp_ratchet_regime",
+    "tiered_tp_atr_regime",
 }
 
 

--- a/backtest/research/regime_1152_config_b2.json
+++ b/backtest/research/regime_1152_config_b2.json
@@ -1,0 +1,23 @@
+{
+  "config_version": 16,
+  "regime": {
+    "enabled": true,
+    "period": 20,
+    "windows": {
+      "medium": {"classifier": "composite", "period": 20}
+    }
+  },
+  "strategies": [
+    {
+      "id": "m6-1152-b2",
+      "type": "perps",
+      "direction": "both",
+      "open_strategy": {"name": "squeeze_momentum", "params": {}},
+      "close_strategy": {
+        "name": "tiered_tp_atr_regime",
+        "params": {"use_defaults": true}
+      },
+      "stop_loss_atr_mult": 1.5
+    }
+  ]
+}

--- a/backtest/research/regime_1152_config_b2_mr.json
+++ b/backtest/research/regime_1152_config_b2_mr.json
@@ -1,0 +1,23 @@
+{
+  "config_version": 16,
+  "regime": {
+    "enabled": true,
+    "period": 20,
+    "windows": {
+      "medium": {"classifier": "composite", "period": 20}
+    }
+  },
+  "strategies": [
+    {
+      "id": "m6-1152-b2-mr",
+      "type": "perps",
+      "direction": "both",
+      "open_strategy": {"name": "mean_reversion", "params": {}},
+      "close_strategy": {
+        "name": "tiered_tp_atr_regime",
+        "params": {"use_defaults": true}
+      },
+      "stop_loss_atr_mult": 1.5
+    }
+  ]
+}

--- a/backtest/research/regime_1152_config_ratchet.json
+++ b/backtest/research/regime_1152_config_ratchet.json
@@ -1,0 +1,23 @@
+{
+  "config_version": 16,
+  "regime": {
+    "enabled": true,
+    "period": 20,
+    "windows": {
+      "medium": {"classifier": "composite", "period": 20}
+    }
+  },
+  "strategies": [
+    {
+      "id": "m6-1152-ratchet",
+      "type": "perps",
+      "direction": "both",
+      "open_strategy": {"name": "squeeze_momentum", "params": {}},
+      "close_strategy": {
+        "name": "trailing_tp_ratchet_regime",
+        "params": {"use_defaults": true}
+      },
+      "trailing_stop_atr_regime": {"use_defaults": true}
+    }
+  ]
+}

--- a/backtest/research/regime_1152_config_ratchet_mr.json
+++ b/backtest/research/regime_1152_config_ratchet_mr.json
@@ -1,0 +1,23 @@
+{
+  "config_version": 16,
+  "regime": {
+    "enabled": true,
+    "period": 20,
+    "windows": {
+      "medium": {"classifier": "composite", "period": 20}
+    }
+  },
+  "strategies": [
+    {
+      "id": "m6-1152-ratchet-mr",
+      "type": "perps",
+      "direction": "both",
+      "open_strategy": {"name": "mean_reversion", "params": {}},
+      "close_strategy": {
+        "name": "trailing_tp_ratchet_regime",
+        "params": {"use_defaults": true}
+      },
+      "trailing_stop_atr_regime": {"use_defaults": true}
+    }
+  ]
+}

--- a/backtest/research/regime_1152_exit_retune.json
+++ b/backtest/research/regime_1152_exit_retune.json
@@ -1,0 +1,1337 @@
+{
+  "issue": 1152,
+  "harness": "backtest/exit_policy_ab.py (M6, #1066) \u2014 entry-locked per-entry replay, incumbent-relative, regime-gated",
+  "open_strategies": {
+    "sq": "squeeze_momentum (futures registry, direction both)",
+    "mr": "mean_reversion (futures registry, direction both)"
+  },
+  "classifier": "composite p20 (regime.windows.medium)",
+  "incumbents": {
+    "ratchet.ranging_quiet": [
+      {
+        "atr_multiple": 0.75,
+        "close_fraction": 0.4,
+        "trailing_mult_after": 1.0
+      },
+      {
+        "atr_multiple": 1.5,
+        "close_fraction": 0.8,
+        "trailing_mult_after": 0.75
+      },
+      {
+        "atr_multiple": 2.0,
+        "close_fraction": 1.0,
+        "trailing_mult_after": 0.75
+      }
+    ],
+    "ratchet.ranging_volatile": [
+      {
+        "atr_multiple": 1.0,
+        "close_fraction": 0.4,
+        "trailing_mult_after": 1.0
+      },
+      {
+        "atr_multiple": 2.0,
+        "close_fraction": 0.8,
+        "trailing_mult_after": 0.75
+      },
+      {
+        "atr_multiple": 3.0,
+        "close_fraction": 1.0,
+        "trailing_mult_after": 0.75
+      }
+    ],
+    "ratchet.ranging_directional": [
+      {
+        "atr_multiple": 1.0,
+        "close_fraction": 0.25,
+        "trailing_mult_after": 1.0
+      },
+      {
+        "atr_multiple": 2.0,
+        "close_fraction": 0.5,
+        "trailing_mult_after": 1.0
+      },
+      {
+        "atr_multiple": 3.0,
+        "close_fraction": 0.75,
+        "trailing_mult_after": 0.8
+      },
+      {
+        "atr_multiple": 4.5,
+        "close_fraction": 0.75,
+        "trailing_mult_after": 0.6
+      }
+    ],
+    "b2.ranging (collapsed)": [
+      {
+        "atr_multiple": 0.5,
+        "close_fraction": 0.5
+      },
+      {
+        "atr_multiple": 1.0,
+        "close_fraction": 1.0
+      }
+    ]
+  },
+  "runs": [
+    {
+      "key": "sq.rq_volatile_geometry",
+      "open": "squeeze_momentum",
+      "experiment": "ratchet",
+      "substate": "ranging_quiet",
+      "hypothesis": "quiet's tighter triggers over-harvest; the volatile geometry (wider rungs) does better even in quiet ranges",
+      "candidate_close": [
+        {
+          "name": "trailing_tp_ratchet_regime",
+          "params": {
+            "tp_tiers": {
+              "ranging_quiet": [
+                {
+                  "atr_multiple": 1.0,
+                  "close_fraction": 0.4,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 0.8,
+                  "trailing_mult_after": 0.75
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 1.0,
+                  "trailing_mult_after": 0.75
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 0,
+          "pooled_delta_net_pct_per_entry": null,
+          "datasets_delta_pos": 0,
+          "datasets_delta_neg": 0,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 0,
+          "pooled_delta_net_pct_per_entry": null,
+          "datasets_delta_pos": 0,
+          "datasets_delta_neg": 0,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "inconclusive: insufficient paired entries"
+    },
+    {
+      "key": "sq.rq_lighter_early",
+      "open": "squeeze_momentum",
+      "experiment": "ratchet",
+      "substate": "ranging_quiet",
+      "hypothesis": "same triggers, lighter early scale-out (25/50/100) lets quiet-range winners contribute more",
+      "candidate_close": [
+        {
+          "name": "trailing_tp_ratchet_regime",
+          "params": {
+            "tp_tiers": {
+              "ranging_quiet": [
+                {
+                  "atr_multiple": 0.75,
+                  "close_fraction": 0.25,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 1.5,
+                  "close_fraction": 0.5,
+                  "trailing_mult_after": 0.75
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 1.0,
+                  "trailing_mult_after": 0.75
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 0,
+          "pooled_delta_net_pct_per_entry": null,
+          "datasets_delta_pos": 0,
+          "datasets_delta_neg": 0,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 0,
+          "pooled_delta_net_pct_per_entry": null,
+          "datasets_delta_pos": 0,
+          "datasets_delta_neg": 0,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "inconclusive: insufficient paired entries"
+    },
+    {
+      "key": "sq.rv_wider",
+      "open": "squeeze_momentum",
+      "experiment": "ratchet",
+      "substate": "ranging_volatile",
+      "hypothesis": "volatile ranges still scale out on noise at 1.0/2.0/3.0; widen further (1.5/3.0/4.5)",
+      "candidate_close": [
+        {
+          "name": "trailing_tp_ratchet_regime",
+          "params": {
+            "tp_tiers": {
+              "ranging_volatile": [
+                {
+                  "atr_multiple": 1.5,
+                  "close_fraction": 0.4,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 0.8,
+                  "trailing_mult_after": 0.75
+                },
+                {
+                  "atr_multiple": 4.5,
+                  "close_fraction": 1.0,
+                  "trailing_mult_after": 0.75
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 68,
+          "pooled_delta_net_pct_per_entry": -0.0821,
+          "datasets_delta_pos": 1,
+          "datasets_delta_neg": 5,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 35,
+          "pooled_delta_net_pct_per_entry": 0.0239,
+          "datasets_delta_pos": 2,
+          "datasets_delta_neg": 2,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "incumbent_stands"
+    },
+    {
+      "key": "sq.rv_quiet_geometry",
+      "open": "squeeze_momentum",
+      "experiment": "ratchet",
+      "substate": "ranging_volatile",
+      "hypothesis": "inverse check \u2014 if the quiet geometry wins here too, the #1059 volatile widening never earned its keep",
+      "candidate_close": [
+        {
+          "name": "trailing_tp_ratchet_regime",
+          "params": {
+            "tp_tiers": {
+              "ranging_volatile": [
+                {
+                  "atr_multiple": 0.75,
+                  "close_fraction": 0.4,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 1.5,
+                  "close_fraction": 0.8,
+                  "trailing_mult_after": 0.75
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 1.0,
+                  "trailing_mult_after": 0.75
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 68,
+          "pooled_delta_net_pct_per_entry": 0.0463,
+          "datasets_delta_pos": 4,
+          "datasets_delta_neg": 2,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 35,
+          "pooled_delta_net_pct_per_entry": 0.092,
+          "datasets_delta_pos": 4,
+          "datasets_delta_neg": 1,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "positive_but_not_significant"
+    },
+    {
+      "key": "sq.rd_full_scaleout",
+      "open": "squeeze_momentum",
+      "experiment": "ratchet",
+      "substate": "ranging_directional",
+      "hypothesis": "inverse check \u2014 does the directional let-ride runner (25/50/75 + 4th rung) beat a plain full scale-out?",
+      "candidate_close": [
+        {
+          "name": "trailing_tp_ratchet_regime",
+          "params": {
+            "tp_tiers": {
+              "ranging_directional": [
+                {
+                  "atr_multiple": 1.0,
+                  "close_fraction": 0.4,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 0.8,
+                  "trailing_mult_after": 0.75
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 1.0,
+                  "trailing_mult_after": 0.75
+                }
+              ],
+              "ranging_directional_up": [
+                {
+                  "atr_multiple": 1.0,
+                  "close_fraction": 0.4,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 0.8,
+                  "trailing_mult_after": 0.75
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 1.0,
+                  "trailing_mult_after": 0.75
+                }
+              ],
+              "ranging_directional_down": [
+                {
+                  "atr_multiple": 1.0,
+                  "close_fraction": 0.4,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 0.8,
+                  "trailing_mult_after": 0.75
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 1.0,
+                  "trailing_mult_after": 0.75
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 23,
+          "pooled_delta_net_pct_per_entry": 0.1005,
+          "datasets_delta_pos": 3,
+          "datasets_delta_neg": 0,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 16,
+          "pooled_delta_net_pct_per_entry": 0.1228,
+          "datasets_delta_pos": 5,
+          "datasets_delta_neg": 1,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "positive_but_not_significant"
+    },
+    {
+      "key": "sq.rd_lighter",
+      "open": "squeeze_momentum",
+      "experiment": "ratchet",
+      "substate": "ranging_directional",
+      "hypothesis": "directional drift rewards an even lighter early scale-out (15/35/60) \u2014 more runner",
+      "candidate_close": [
+        {
+          "name": "trailing_tp_ratchet_regime",
+          "params": {
+            "tp_tiers": {
+              "ranging_directional": [
+                {
+                  "atr_multiple": 1.0,
+                  "close_fraction": 0.15,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 0.35,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 0.6,
+                  "trailing_mult_after": 0.8
+                },
+                {
+                  "atr_multiple": 4.5,
+                  "close_fraction": 0.6,
+                  "trailing_mult_after": 0.6
+                }
+              ],
+              "ranging_directional_up": [
+                {
+                  "atr_multiple": 1.0,
+                  "close_fraction": 0.15,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 0.35,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 0.6,
+                  "trailing_mult_after": 0.8
+                },
+                {
+                  "atr_multiple": 4.5,
+                  "close_fraction": 0.6,
+                  "trailing_mult_after": 0.6
+                }
+              ],
+              "ranging_directional_down": [
+                {
+                  "atr_multiple": 1.0,
+                  "close_fraction": 0.15,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 0.35,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 0.6,
+                  "trailing_mult_after": 0.8
+                },
+                {
+                  "atr_multiple": 4.5,
+                  "close_fraction": 0.6,
+                  "trailing_mult_after": 0.6
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 23,
+          "pooled_delta_net_pct_per_entry": -0.0313,
+          "datasets_delta_pos": 1,
+          "datasets_delta_neg": 2,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 16,
+          "pooled_delta_net_pct_per_entry": -0.0628,
+          "datasets_delta_pos": 1,
+          "datasets_delta_neg": 5,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "incumbent_stands"
+    },
+    {
+      "key": "sq.b2_rq_wider",
+      "open": "squeeze_momentum",
+      "experiment": "b2",
+      "substate": "ranging_quiet",
+      "hypothesis": "quiet: is the collapsed fast exit (0.5/1.0) already right, or does a wider 2-rung do better?",
+      "candidate_close": [
+        {
+          "name": "tiered_tp_atr",
+          "params": {
+            "tp_tiers": [
+              {
+                "atr_multiple": 0.75,
+                "close_fraction": 0.5
+              },
+              {
+                "atr_multiple": 1.5,
+                "close_fraction": 1.0
+              }
+            ]
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 0,
+          "pooled_delta_net_pct_per_entry": null,
+          "datasets_delta_pos": 0,
+          "datasets_delta_neg": 0,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 0,
+          "pooled_delta_net_pct_per_entry": null,
+          "datasets_delta_pos": 0,
+          "datasets_delta_neg": 0,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "inconclusive: insufficient paired entries"
+    },
+    {
+      "key": "sq.b2_rv_wider",
+      "open": "squeeze_momentum",
+      "experiment": "b2",
+      "substate": "ranging_volatile",
+      "hypothesis": "volatile: widen the 2 rungs so wide-range noise does not cash the whole position at 0.5 ATR",
+      "candidate_close": [
+        {
+          "name": "tiered_tp_atr",
+          "params": {
+            "tp_tiers": [
+              {
+                "atr_multiple": 0.75,
+                "close_fraction": 0.5
+              },
+              {
+                "atr_multiple": 1.5,
+                "close_fraction": 1.0
+              }
+            ]
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 68,
+          "pooled_delta_net_pct_per_entry": 0.0602,
+          "datasets_delta_pos": 4,
+          "datasets_delta_neg": 2,
+          "datasets_sig_pos_p05": 1,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 34,
+          "pooled_delta_net_pct_per_entry": -0.05,
+          "datasets_delta_pos": 2,
+          "datasets_delta_neg": 3,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "incumbent_stands"
+    },
+    {
+      "key": "sq.b2_rv_patient3",
+      "open": "squeeze_momentum",
+      "experiment": "b2",
+      "substate": "ranging_volatile",
+      "hypothesis": "volatile: a patient 3-rung ladder (ratchet-split analogue) beats the collapsed fast exit",
+      "candidate_close": [
+        {
+          "name": "tiered_tp_atr",
+          "params": {
+            "tp_tiers": [
+              {
+                "atr_multiple": 1.0,
+                "close_fraction": 0.4
+              },
+              {
+                "atr_multiple": 2.0,
+                "close_fraction": 0.8
+              },
+              {
+                "atr_multiple": 3.0,
+                "close_fraction": 1.0
+              }
+            ]
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 68,
+          "pooled_delta_net_pct_per_entry": -0.0619,
+          "datasets_delta_pos": 2,
+          "datasets_delta_neg": 4,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 34,
+          "pooled_delta_net_pct_per_entry": -0.1149,
+          "datasets_delta_pos": 1,
+          "datasets_delta_neg": 4,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "incumbent_stands"
+    },
+    {
+      "key": "sq.b2_rd_patient3",
+      "open": "squeeze_momentum",
+      "experiment": "b2",
+      "substate": "ranging_directional",
+      "hypothesis": "directional: drift rewards patience \u2014 3 rungs mirroring the ratchet's directional split",
+      "candidate_close": [
+        {
+          "name": "tiered_tp_atr",
+          "params": {
+            "tp_tiers": [
+              {
+                "atr_multiple": 1.0,
+                "close_fraction": 0.4
+              },
+              {
+                "atr_multiple": 2.0,
+                "close_fraction": 0.8
+              },
+              {
+                "atr_multiple": 3.0,
+                "close_fraction": 1.0
+              }
+            ]
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 23,
+          "pooled_delta_net_pct_per_entry": 0.0818,
+          "datasets_delta_pos": 2,
+          "datasets_delta_neg": 1,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 16,
+          "pooled_delta_net_pct_per_entry": -0.0367,
+          "datasets_delta_pos": 3,
+          "datasets_delta_neg": 3,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "incumbent_stands"
+    },
+    {
+      "key": "sq.b2_rd_wider2",
+      "open": "squeeze_momentum",
+      "experiment": "b2",
+      "substate": "ranging_directional",
+      "hypothesis": "directional: keep 2 rungs but double the distances",
+      "candidate_close": [
+        {
+          "name": "tiered_tp_atr",
+          "params": {
+            "tp_tiers": [
+              {
+                "atr_multiple": 1.0,
+                "close_fraction": 0.5
+              },
+              {
+                "atr_multiple": 2.0,
+                "close_fraction": 1.0
+              }
+            ]
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 23,
+          "pooled_delta_net_pct_per_entry": 0.0989,
+          "datasets_delta_pos": 2,
+          "datasets_delta_neg": 1,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 16,
+          "pooled_delta_net_pct_per_entry": -0.0528,
+          "datasets_delta_pos": 3,
+          "datasets_delta_neg": 3,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "incumbent_stands"
+    },
+    {
+      "key": "mr.rq_volatile_geometry",
+      "open": "mean_reversion",
+      "experiment": "ratchet",
+      "substate": "ranging_quiet",
+      "hypothesis": "quiet's tighter triggers over-harvest; the volatile geometry (wider rungs) does better even in quiet ranges",
+      "candidate_close": [
+        {
+          "name": "trailing_tp_ratchet_regime",
+          "params": {
+            "tp_tiers": {
+              "ranging_quiet": [
+                {
+                  "atr_multiple": 1.0,
+                  "close_fraction": 0.4,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 0.8,
+                  "trailing_mult_after": 0.75
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 1.0,
+                  "trailing_mult_after": 0.75
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 0,
+          "pooled_delta_net_pct_per_entry": null,
+          "datasets_delta_pos": 0,
+          "datasets_delta_neg": 0,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 0,
+          "pooled_delta_net_pct_per_entry": null,
+          "datasets_delta_pos": 0,
+          "datasets_delta_neg": 0,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "inconclusive: insufficient paired entries"
+    },
+    {
+      "key": "mr.rq_lighter_early",
+      "open": "mean_reversion",
+      "experiment": "ratchet",
+      "substate": "ranging_quiet",
+      "hypothesis": "same triggers, lighter early scale-out (25/50/100) lets quiet-range winners contribute more",
+      "candidate_close": [
+        {
+          "name": "trailing_tp_ratchet_regime",
+          "params": {
+            "tp_tiers": {
+              "ranging_quiet": [
+                {
+                  "atr_multiple": 0.75,
+                  "close_fraction": 0.25,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 1.5,
+                  "close_fraction": 0.5,
+                  "trailing_mult_after": 0.75
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 1.0,
+                  "trailing_mult_after": 0.75
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 0,
+          "pooled_delta_net_pct_per_entry": null,
+          "datasets_delta_pos": 0,
+          "datasets_delta_neg": 0,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 0,
+          "pooled_delta_net_pct_per_entry": null,
+          "datasets_delta_pos": 0,
+          "datasets_delta_neg": 0,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "inconclusive: insufficient paired entries"
+    },
+    {
+      "key": "mr.rv_wider",
+      "open": "mean_reversion",
+      "experiment": "ratchet",
+      "substate": "ranging_volatile",
+      "hypothesis": "volatile ranges still scale out on noise at 1.0/2.0/3.0; widen further (1.5/3.0/4.5)",
+      "candidate_close": [
+        {
+          "name": "trailing_tp_ratchet_regime",
+          "params": {
+            "tp_tiers": {
+              "ranging_volatile": [
+                {
+                  "atr_multiple": 1.5,
+                  "close_fraction": 0.4,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 0.8,
+                  "trailing_mult_after": 0.75
+                },
+                {
+                  "atr_multiple": 4.5,
+                  "close_fraction": 1.0,
+                  "trailing_mult_after": 0.75
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 333,
+          "pooled_delta_net_pct_per_entry": 0.012,
+          "datasets_delta_pos": 3,
+          "datasets_delta_neg": 3,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 233,
+          "pooled_delta_net_pct_per_entry": 0.0233,
+          "datasets_delta_pos": 3,
+          "datasets_delta_neg": 3,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "positive_but_not_significant"
+    },
+    {
+      "key": "mr.rv_quiet_geometry",
+      "open": "mean_reversion",
+      "experiment": "ratchet",
+      "substate": "ranging_volatile",
+      "hypothesis": "inverse check \u2014 if the quiet geometry wins here too, the #1059 volatile widening never earned its keep",
+      "candidate_close": [
+        {
+          "name": "trailing_tp_ratchet_regime",
+          "params": {
+            "tp_tiers": {
+              "ranging_volatile": [
+                {
+                  "atr_multiple": 0.75,
+                  "close_fraction": 0.4,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 1.5,
+                  "close_fraction": 0.8,
+                  "trailing_mult_after": 0.75
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 1.0,
+                  "trailing_mult_after": 0.75
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 333,
+          "pooled_delta_net_pct_per_entry": -0.0116,
+          "datasets_delta_pos": 2,
+          "datasets_delta_neg": 4,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 233,
+          "pooled_delta_net_pct_per_entry": 0.0107,
+          "datasets_delta_pos": 3,
+          "datasets_delta_neg": 3,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "incumbent_stands"
+    },
+    {
+      "key": "mr.rd_full_scaleout",
+      "open": "mean_reversion",
+      "experiment": "ratchet",
+      "substate": "ranging_directional",
+      "hypothesis": "inverse check \u2014 does the directional let-ride runner (25/50/75 + 4th rung) beat a plain full scale-out?",
+      "candidate_close": [
+        {
+          "name": "trailing_tp_ratchet_regime",
+          "params": {
+            "tp_tiers": {
+              "ranging_directional": [
+                {
+                  "atr_multiple": 1.0,
+                  "close_fraction": 0.4,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 0.8,
+                  "trailing_mult_after": 0.75
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 1.0,
+                  "trailing_mult_after": 0.75
+                }
+              ],
+              "ranging_directional_up": [
+                {
+                  "atr_multiple": 1.0,
+                  "close_fraction": 0.4,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 0.8,
+                  "trailing_mult_after": 0.75
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 1.0,
+                  "trailing_mult_after": 0.75
+                }
+              ],
+              "ranging_directional_down": [
+                {
+                  "atr_multiple": 1.0,
+                  "close_fraction": 0.4,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 0.8,
+                  "trailing_mult_after": 0.75
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 1.0,
+                  "trailing_mult_after": 0.75
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 167,
+          "pooled_delta_net_pct_per_entry": -0.0158,
+          "datasets_delta_pos": 3,
+          "datasets_delta_neg": 3,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 3
+        },
+        "oos": {
+          "paired_n": 127,
+          "pooled_delta_net_pct_per_entry": -0.0036,
+          "datasets_delta_pos": 4,
+          "datasets_delta_neg": 2,
+          "datasets_sig_pos_p05": 1,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "incumbent_stands"
+    },
+    {
+      "key": "mr.rd_lighter",
+      "open": "mean_reversion",
+      "experiment": "ratchet",
+      "substate": "ranging_directional",
+      "hypothesis": "directional drift rewards an even lighter early scale-out (15/35/60) \u2014 more runner",
+      "candidate_close": [
+        {
+          "name": "trailing_tp_ratchet_regime",
+          "params": {
+            "tp_tiers": {
+              "ranging_directional": [
+                {
+                  "atr_multiple": 1.0,
+                  "close_fraction": 0.15,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 0.35,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 0.6,
+                  "trailing_mult_after": 0.8
+                },
+                {
+                  "atr_multiple": 4.5,
+                  "close_fraction": 0.6,
+                  "trailing_mult_after": 0.6
+                }
+              ],
+              "ranging_directional_up": [
+                {
+                  "atr_multiple": 1.0,
+                  "close_fraction": 0.15,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 0.35,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 0.6,
+                  "trailing_mult_after": 0.8
+                },
+                {
+                  "atr_multiple": 4.5,
+                  "close_fraction": 0.6,
+                  "trailing_mult_after": 0.6
+                }
+              ],
+              "ranging_directional_down": [
+                {
+                  "atr_multiple": 1.0,
+                  "close_fraction": 0.15,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 2.0,
+                  "close_fraction": 0.35,
+                  "trailing_mult_after": 1.0
+                },
+                {
+                  "atr_multiple": 3.0,
+                  "close_fraction": 0.6,
+                  "trailing_mult_after": 0.8
+                },
+                {
+                  "atr_multiple": 4.5,
+                  "close_fraction": 0.6,
+                  "trailing_mult_after": 0.6
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 167,
+          "pooled_delta_net_pct_per_entry": 0.0026,
+          "datasets_delta_pos": 2,
+          "datasets_delta_neg": 4,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 127,
+          "pooled_delta_net_pct_per_entry": 0.0038,
+          "datasets_delta_pos": 2,
+          "datasets_delta_neg": 4,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "positive_but_not_significant"
+    },
+    {
+      "key": "mr.b2_rq_wider",
+      "open": "mean_reversion",
+      "experiment": "b2",
+      "substate": "ranging_quiet",
+      "hypothesis": "quiet: is the collapsed fast exit (0.5/1.0) already right, or does a wider 2-rung do better?",
+      "candidate_close": [
+        {
+          "name": "tiered_tp_atr",
+          "params": {
+            "tp_tiers": [
+              {
+                "atr_multiple": 0.75,
+                "close_fraction": 0.5
+              },
+              {
+                "atr_multiple": 1.5,
+                "close_fraction": 1.0
+              }
+            ]
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 0,
+          "pooled_delta_net_pct_per_entry": null,
+          "datasets_delta_pos": 0,
+          "datasets_delta_neg": 0,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 0,
+          "pooled_delta_net_pct_per_entry": null,
+          "datasets_delta_pos": 0,
+          "datasets_delta_neg": 0,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "inconclusive: insufficient paired entries"
+    },
+    {
+      "key": "mr.b2_rv_wider",
+      "open": "mean_reversion",
+      "experiment": "b2",
+      "substate": "ranging_volatile",
+      "hypothesis": "volatile: widen the 2 rungs so wide-range noise does not cash the whole position at 0.5 ATR",
+      "candidate_close": [
+        {
+          "name": "tiered_tp_atr",
+          "params": {
+            "tp_tiers": [
+              {
+                "atr_multiple": 0.75,
+                "close_fraction": 0.5
+              },
+              {
+                "atr_multiple": 1.5,
+                "close_fraction": 1.0
+              }
+            ]
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 343,
+          "pooled_delta_net_pct_per_entry": 0.0047,
+          "datasets_delta_pos": 3,
+          "datasets_delta_neg": 3,
+          "datasets_sig_pos_p05": 2,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 241,
+          "pooled_delta_net_pct_per_entry": 0.0496,
+          "datasets_delta_pos": 4,
+          "datasets_delta_neg": 2,
+          "datasets_sig_pos_p05": 2,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "candidate_beats_incumbent"
+    },
+    {
+      "key": "mr.b2_rv_patient3",
+      "open": "mean_reversion",
+      "experiment": "b2",
+      "substate": "ranging_volatile",
+      "hypothesis": "volatile: a patient 3-rung ladder (ratchet-split analogue) beats the collapsed fast exit",
+      "candidate_close": [
+        {
+          "name": "tiered_tp_atr",
+          "params": {
+            "tp_tiers": [
+              {
+                "atr_multiple": 1.0,
+                "close_fraction": 0.4
+              },
+              {
+                "atr_multiple": 2.0,
+                "close_fraction": 0.8
+              },
+              {
+                "atr_multiple": 3.0,
+                "close_fraction": 1.0
+              }
+            ]
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 343,
+          "pooled_delta_net_pct_per_entry": 0.0654,
+          "datasets_delta_pos": 5,
+          "datasets_delta_neg": 1,
+          "datasets_sig_pos_p05": 1,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 241,
+          "pooled_delta_net_pct_per_entry": -0.0017,
+          "datasets_delta_pos": 3,
+          "datasets_delta_neg": 3,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "incumbent_stands"
+    },
+    {
+      "key": "mr.b2_rd_patient3",
+      "open": "mean_reversion",
+      "experiment": "b2",
+      "substate": "ranging_directional",
+      "hypothesis": "directional: drift rewards patience \u2014 3 rungs mirroring the ratchet's directional split",
+      "candidate_close": [
+        {
+          "name": "tiered_tp_atr",
+          "params": {
+            "tp_tiers": [
+              {
+                "atr_multiple": 1.0,
+                "close_fraction": 0.4
+              },
+              {
+                "atr_multiple": 2.0,
+                "close_fraction": 0.8
+              },
+              {
+                "atr_multiple": 3.0,
+                "close_fraction": 1.0
+              }
+            ]
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 176,
+          "pooled_delta_net_pct_per_entry": -0.1363,
+          "datasets_delta_pos": 1,
+          "datasets_delta_neg": 5,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 132,
+          "pooled_delta_net_pct_per_entry": -0.0151,
+          "datasets_delta_pos": 4,
+          "datasets_delta_neg": 2,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "incumbent_stands"
+    },
+    {
+      "key": "mr.b2_rd_wider2",
+      "open": "mean_reversion",
+      "experiment": "b2",
+      "substate": "ranging_directional",
+      "hypothesis": "directional: keep 2 rungs but double the distances",
+      "candidate_close": [
+        {
+          "name": "tiered_tp_atr",
+          "params": {
+            "tp_tiers": [
+              {
+                "atr_multiple": 1.0,
+                "close_fraction": 0.5
+              },
+              {
+                "atr_multiple": 2.0,
+                "close_fraction": 1.0
+              }
+            ]
+          }
+        }
+      ],
+      "status": "ok",
+      "windows": {
+        "is": {
+          "paired_n": 176,
+          "pooled_delta_net_pct_per_entry": -0.1419,
+          "datasets_delta_pos": 1,
+          "datasets_delta_neg": 5,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        },
+        "oos": {
+          "paired_n": 132,
+          "pooled_delta_net_pct_per_entry": -0.0198,
+          "datasets_delta_pos": 4,
+          "datasets_delta_neg": 2,
+          "datasets_sig_pos_p05": 0,
+          "datasets_sig_neg_p05": 0
+        }
+      },
+      "verdict": "incumbent_stands"
+    }
+  ]
+}

--- a/backtest/research/regime_1152_exit_retune.py
+++ b/backtest/research/regime_1152_exit_retune.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""#1152: M6 entry-locked retune of the ranging ratchet ladders + B2 ranging TP group.
+
+#1120 / PR #1149 retuned only the opening-trail table and explicitly deferred the
+per-substate ratchet tier ladders (`ratchetTierGroupDefaults` /
+`DEFAULT_RATCHET_TIERS_BY_GROUP`) and the collapsed B2 ranging TP group
+(`regimeTPTierGroupDefaults["ranging"]` / `REGIME_TP_TIER_GROUP_DEFAULTS`)
+because the bar-level harness cannot isolate per-substate exit geometry — see
+`regime_1120_trail_validation.json:ratchet_tp_note`.
+
+This driver runs the deferred validation with the M6 harness
+(`backtest/exit_policy_ab.py`, #1066): incumbent-relative, entry-locked
+per-entry replay, regime-attributed paired ΔPnL, across the audit datasets and
+walk-forward windows. Each run gates entries to ONE composite ranging substate
+(the gate and the position-regime stamp share the same shifted label series, so
+every paired entry exercises exactly the ladder under test):
+
+- Ratchet runs: incumbent = `trailing_tp_ratchet_regime {use_defaults}` (the
+  shipped per-group ladder) + `trailing_stop_atr_regime {use_defaults}` opening
+  trails; candidate = the same evaluator with an explicit regime-keyed
+  `tp_tiers` carrying only the gated substate's candidate ladder (stops
+  inherited, so the A/B isolates the ladder change).
+- B2 runs: incumbent = `tiered_tp_atr_regime {use_defaults}` (the collapsed
+  2-rung ranging ladder) + a fixed scalar SL; candidate = scalar
+  `tiered_tp_atr` with the substate-differentiated ladder. A scalar candidate
+  is exact here because the run is gated to a single substate — every entry is
+  stamped with that substate, so "regime-keyed ladder for S" ≡ "scalar ladder".
+
+Usage:
+  uv run --no-sync python backtest/research/regime_1152_exit_retune.py \
+      [--jobs 4] [--out-dir /tmp/regime_1152_runs] [--only KEY[,KEY…]] \
+      [--windows is,oos] [--datasets BTC/USDT:1h,…]
+
+Writes per-run harness JSON to --out-dir and the committed aggregate to
+backtest/research/regime_1152_exit_retune.json.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO = os.path.abspath(os.path.join(_THIS_DIR, "..", ".."))
+_HARNESS = os.path.join(_REPO, "backtest", "exit_policy_ab.py")
+_CONFIG_RATCHET = os.path.join(_THIS_DIR, "regime_1152_config_ratchet.json")
+_CONFIG_B2 = os.path.join(_THIS_DIR, "regime_1152_config_b2.json")
+_AGGREGATE_OUT = os.path.join(_THIS_DIR, "regime_1152_exit_retune.json")
+
+# Two entry styles so a ladder verdict is never an artifact of one open
+# strategy's entry timing: squeeze_momentum (breakout/momentum — the #1120
+# lineage) and mean_reversion (band-reversion — the entry style that actually
+# fires inside ranging_quiet, where squeeze_momentum produced ZERO gated
+# entries across all six audit datasets).
+OPENS = {
+    "sq": {
+        "open": "squeeze_momentum",
+        "ratchet": {"config": _CONFIG_RATCHET, "strategy": "m6-1152-ratchet"},
+        "b2": {"config": _CONFIG_B2, "strategy": "m6-1152-b2"},
+    },
+    "mr": {
+        "open": "mean_reversion",
+        "ratchet": {"config": os.path.join(_THIS_DIR, "regime_1152_config_ratchet_mr.json"),
+                    "strategy": "m6-1152-ratchet-mr"},
+        "b2": {"config": os.path.join(_THIS_DIR, "regime_1152_config_b2_mr.json"),
+               "strategy": "m6-1152-b2-mr"},
+    },
+}
+
+
+def _rung(mult: float, frac: float, trail: float) -> dict:
+    return {"atr_multiple": mult, "close_fraction": frac, "trailing_mult_after": trail}
+
+
+def _tp(mult: float, frac: float) -> dict:
+    return {"atr_multiple": mult, "close_fraction": frac}
+
+
+def _ratchet_candidate(labels: list[str], ladder: list[dict]) -> str:
+    """Regime-keyed explicit tp_tiers for trailing_tp_ratchet_regime.
+
+    The evaluator resolves explicit tables by EXACT label match (no #1124 bare
+    fallback in trailing_tp_ratchet.resolve_tiers_for_regime), so the
+    directional family needs the bare label AND both _up/_down keys.
+    """
+    return json.dumps([{
+        "name": "trailing_tp_ratchet_regime",
+        "params": {"tp_tiers": {lab: ladder for lab in labels}},
+    }])
+
+
+def _b2_candidate(ladder: list[dict]) -> str:
+    return json.dumps([{"name": "tiered_tp_atr", "params": {"tp_tiers": ladder}}])
+
+
+_DIRECTIONAL_LABELS = [
+    "ranging_directional", "ranging_directional_up", "ranging_directional_down",
+]
+
+# Incumbent ladders under test (mirrors ratchetTierGroupDefaults /
+# REGIME_TP_TIER_GROUP_DEFAULTS at HEAD; recorded here for the artifact):
+INCUMBENTS = {
+    "ratchet.ranging_quiet": [
+        _rung(0.75, 0.40, 1.0), _rung(1.5, 0.80, 0.75), _rung(2.0, 1.00, 0.75)],
+    "ratchet.ranging_volatile": [
+        _rung(1.0, 0.40, 1.0), _rung(2.0, 0.80, 0.75), _rung(3.0, 1.00, 0.75)],
+    "ratchet.ranging_directional": [
+        _rung(1.0, 0.25, 1.0), _rung(2.0, 0.50, 1.0),
+        _rung(3.0, 0.75, 0.8), _rung(4.5, 0.75, 0.6)],
+    "b2.ranging (collapsed)": [_tp(0.5, 0.50), _tp(1.0, 1.00)],
+}
+
+RUNS: list[dict] = [
+    # --- Ratchet ladders, per substate (#1120 goals 1–2) ------------------
+    {
+        "key": "rq_volatile_geometry",
+        "experiment": "ratchet", "substate": "ranging_quiet",
+        "gate": ["ranging_quiet"],
+        "candidate_close": _ratchet_candidate(["ranging_quiet"], [
+            _rung(1.0, 0.40, 1.0), _rung(2.0, 0.80, 0.75), _rung(3.0, 1.00, 0.75)]),
+        "hypothesis": "quiet's tighter triggers over-harvest; the volatile "
+                      "geometry (wider rungs) does better even in quiet ranges",
+    },
+    {
+        "key": "rq_lighter_early",
+        "experiment": "ratchet", "substate": "ranging_quiet",
+        "gate": ["ranging_quiet"],
+        "candidate_close": _ratchet_candidate(["ranging_quiet"], [
+            _rung(0.75, 0.25, 1.0), _rung(1.5, 0.50, 0.75), _rung(2.0, 1.00, 0.75)]),
+        "hypothesis": "same triggers, lighter early scale-out (25/50/100) lets "
+                      "quiet-range winners contribute more",
+    },
+    {
+        "key": "rv_wider",
+        "experiment": "ratchet", "substate": "ranging_volatile",
+        "gate": ["ranging_volatile"],
+        "candidate_close": _ratchet_candidate(["ranging_volatile"], [
+            _rung(1.5, 0.40, 1.0), _rung(3.0, 0.80, 0.75), _rung(4.5, 1.00, 0.75)]),
+        "hypothesis": "volatile ranges still scale out on noise at 1.0/2.0/3.0; "
+                      "widen further (1.5/3.0/4.5)",
+    },
+    {
+        "key": "rv_quiet_geometry",
+        "experiment": "ratchet", "substate": "ranging_volatile",
+        "gate": ["ranging_volatile"],
+        "candidate_close": _ratchet_candidate(["ranging_volatile"], [
+            _rung(0.75, 0.40, 1.0), _rung(1.5, 0.80, 0.75), _rung(2.0, 1.00, 0.75)]),
+        "hypothesis": "inverse check — if the quiet geometry wins here too, the "
+                      "#1059 volatile widening never earned its keep",
+    },
+    {
+        "key": "rd_full_scaleout",
+        "experiment": "ratchet", "substate": "ranging_directional",
+        "gate": ["ranging_directional"],
+        "candidate_close": _ratchet_candidate(_DIRECTIONAL_LABELS, [
+            _rung(1.0, 0.40, 1.0), _rung(2.0, 0.80, 0.75), _rung(3.0, 1.00, 0.75)]),
+        "hypothesis": "inverse check — does the directional let-ride runner "
+                      "(25/50/75 + 4th rung) beat a plain full scale-out?",
+    },
+    {
+        "key": "rd_lighter",
+        "experiment": "ratchet", "substate": "ranging_directional",
+        "gate": ["ranging_directional"],
+        "candidate_close": _ratchet_candidate(_DIRECTIONAL_LABELS, [
+            _rung(1.0, 0.15, 1.0), _rung(2.0, 0.35, 1.0),
+            _rung(3.0, 0.60, 0.8), _rung(4.5, 0.60, 0.6)]),
+        "hypothesis": "directional drift rewards an even lighter early "
+                      "scale-out (15/35/60) — more runner",
+    },
+    # --- B2 ranging TP group: substate differentiation (#1120 goal 2) -----
+    {
+        "key": "b2_rq_wider",
+        "experiment": "b2", "substate": "ranging_quiet",
+        "gate": ["ranging_quiet"],
+        "candidate_close": _b2_candidate([_tp(0.75, 0.50), _tp(1.5, 1.00)]),
+        "hypothesis": "quiet: is the collapsed fast exit (0.5/1.0) already "
+                      "right, or does a wider 2-rung do better?",
+    },
+    {
+        "key": "b2_rv_wider",
+        "experiment": "b2", "substate": "ranging_volatile",
+        "gate": ["ranging_volatile"],
+        "candidate_close": _b2_candidate([_tp(0.75, 0.50), _tp(1.5, 1.00)]),
+        "hypothesis": "volatile: widen the 2 rungs so wide-range noise does not "
+                      "cash the whole position at 0.5 ATR",
+    },
+    {
+        "key": "b2_rv_patient3",
+        "experiment": "b2", "substate": "ranging_volatile",
+        "gate": ["ranging_volatile"],
+        "candidate_close": _b2_candidate([
+            _tp(1.0, 0.40), _tp(2.0, 0.80), _tp(3.0, 1.00)]),
+        "hypothesis": "volatile: a patient 3-rung ladder (ratchet-split "
+                      "analogue) beats the collapsed fast exit",
+    },
+    {
+        "key": "b2_rd_patient3",
+        "experiment": "b2", "substate": "ranging_directional",
+        "gate": ["ranging_directional"],
+        "candidate_close": _b2_candidate([
+            _tp(1.0, 0.40), _tp(2.0, 0.80), _tp(3.0, 1.00)]),
+        "hypothesis": "directional: drift rewards patience — 3 rungs mirroring "
+                      "the ratchet's directional split",
+    },
+    {
+        "key": "b2_rd_wider2",
+        "experiment": "b2", "substate": "ranging_directional",
+        "gate": ["ranging_directional"],
+        "candidate_close": _b2_candidate([_tp(1.0, 0.50), _tp(2.0, 1.00)]),
+        "hypothesis": "directional: keep 2 rungs but double the distances",
+    },
+]
+
+
+def _run_one(open_key: str, run: dict, out_dir: str, windows: str,
+             datasets: str | None, resamples: int) -> dict:
+    spec = OPENS[open_key][run["experiment"]]
+    full_key = f"{open_key}.{run['key']}"
+    json_path = os.path.join(out_dir, f"{full_key}.json")
+    argv = [
+        sys.executable, _HARNESS,
+        "--baseline-config", spec["config"],
+        "--strategy", spec["strategy"],
+        "--registry", "futures",
+        "--candidate-close", run["candidate_close"],
+        "--windows", windows,
+        "--bootstrap-resamples", str(resamples),
+        "--json", json_path,
+    ]
+    for label in run["gate"]:
+        argv += ["--allowed-regimes", label]
+    if datasets:
+        argv += ["--datasets", datasets]
+    proc = subprocess.run(argv, capture_output=True, text=True)
+    status = "ok" if proc.returncode == 0 and os.path.exists(json_path) else "failed"
+    if status == "failed":
+        sys.stderr.write(f"[{full_key}] FAILED rc={proc.returncode}\n"
+                         f"{proc.stdout[-2000:]}\n{proc.stderr[-2000:]}\n")
+    return {"key": full_key, "status": status, "json": json_path,
+            "report": proc.stdout}
+
+
+def _window_rollup(payload: dict) -> dict:
+    """Per window: paired-N-weighted mean Δnet/e + per-dataset direction votes.
+
+    The harness is the SSoT for per-dataset statistics (Wilcoxon/sign/bootstrap
+    on the raw per-entry deltas); raw deltas are not exported, so the pooled
+    number here is the paired-N-weighted mean of per-dataset means — the same
+    aggregation the harness's own summary table prints — plus a vote count of
+    datasets by delta sign and how many are individually significant.
+    """
+    out = {}
+    for wname, results in (payload.get("results") or {}).items():
+        deltas, votes_pos, votes_neg, sig_pos, sig_neg, n_paired = [], 0, 0, 0, 0, 0
+        for d in results or []:
+            t = d.get("per_regime")
+            if not t or t["all"]["paired_delta"]["mean"] is None:
+                continue
+            mean = t["all"]["paired_delta"]["mean"]
+            n = t["all"]["n"]
+            p = t["all"]["paired_delta"]["signed_rank"]["p_value"]
+            deltas.append((mean, n))
+            n_paired += n
+            if mean > 0:
+                votes_pos += 1
+                sig_pos += 1 if (p is not None and p < 0.05) else 0
+            elif mean < 0:
+                votes_neg += 1
+                sig_neg += 1 if (p is not None and p < 0.05) else 0
+        pooled = (round(sum(m * n for m, n in deltas) / sum(n for _, n in deltas), 4)
+                  if deltas and sum(n for _, n in deltas) else None)
+        out[wname] = {
+            "paired_n": n_paired,
+            "pooled_delta_net_pct_per_entry": pooled,
+            "datasets_delta_pos": votes_pos,
+            "datasets_delta_neg": votes_neg,
+            "datasets_sig_pos_p05": sig_pos,
+            "datasets_sig_neg_p05": sig_neg,
+        }
+    return out
+
+
+def _verdict(rollup: dict) -> str:
+    """Promotion gate: candidate must be positive on BOTH is and oos pooled
+    Δnet/e with at least one individually significant dataset and no
+    significant contradiction; anything else is a negative/inconclusive
+    result for the candidate (the incumbent stands)."""
+    is_w, oos_w = rollup.get("is") or {}, rollup.get("oos") or {}
+    pooled_is = is_w.get("pooled_delta_net_pct_per_entry")
+    pooled_oos = oos_w.get("pooled_delta_net_pct_per_entry")
+    if pooled_is is None or pooled_oos is None:
+        return "inconclusive: insufficient paired entries"
+    if pooled_is > 0 and pooled_oos > 0:
+        sig = (is_w.get("datasets_sig_pos_p05", 0) + oos_w.get("datasets_sig_pos_p05", 0))
+        contra = (is_w.get("datasets_sig_neg_p05", 0) + oos_w.get("datasets_sig_neg_p05", 0))
+        if sig >= 1 and contra == 0:
+            return "candidate_beats_incumbent"
+        return "positive_but_not_significant"
+    return "incumbent_stands"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--jobs", type=int, default=4)
+    ap.add_argument("--out-dir", default=os.path.join(_THIS_DIR, "regime_1152_runs"))
+    ap.add_argument("--only", default=None, help="comma list of run keys")
+    ap.add_argument("--windows", default="is,oos")
+    ap.add_argument("--datasets", default=None,
+                    help="comma list SYMBOL:TIMEFRAME (default: audit six)")
+    ap.add_argument("--bootstrap-resamples", type=int, default=10000)
+    args = ap.parse_args()
+
+    matrix = [(ok, r) for ok in OPENS for r in RUNS]
+    if args.only:
+        keys = {k.strip() for k in args.only.split(",") if k.strip()}
+        unknown = keys - {f"{ok}.{r['key']}" for ok, r in matrix}
+        if unknown:
+            raise SystemExit(f"unknown run keys: {sorted(unknown)}")
+        matrix = [(ok, r) for ok, r in matrix if f"{ok}.{r['key']}" in keys]
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    with ThreadPoolExecutor(max_workers=max(1, args.jobs)) as ex:
+        results = list(ex.map(
+            lambda item: _run_one(item[0], item[1], args.out_dir, args.windows,
+                                  args.datasets, args.bootstrap_resamples),
+            matrix))
+
+    aggregate = {
+        "issue": 1152,
+        "harness": "backtest/exit_policy_ab.py (M6, #1066) — entry-locked "
+                   "per-entry replay, incumbent-relative, regime-gated",
+        "open_strategies": {k: v["open"] + " (futures registry, direction both)"
+                            for k, v in OPENS.items()},
+        "classifier": "composite p20 (regime.windows.medium)",
+        "incumbents": INCUMBENTS,
+        "runs": [],
+    }
+    failed = 0
+    for (open_key, run), res in zip(matrix, results):
+        entry = {
+            "key": res["key"], "open": OPENS[open_key]["open"],
+            "experiment": run["experiment"],
+            "substate": run["substate"], "hypothesis": run["hypothesis"],
+            "candidate_close": json.loads(run["candidate_close"]),
+            "status": res["status"],
+        }
+        if res["status"] == "ok":
+            with open(res["json"]) as fh:
+                payload = json.load(fh)
+            entry["windows"] = _window_rollup(payload)
+            entry["verdict"] = _verdict(entry["windows"])
+        else:
+            failed += 1
+            entry["verdict"] = "run_failed"
+        aggregate["runs"].append(entry)
+        print(f"{entry['key']:<22} {entry['verdict']}")
+
+    with open(_AGGREGATE_OUT, "w") as fh:
+        json.dump(aggregate, fh, indent=2)
+    print(f"\nwrote {_AGGREGATE_OUT}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backtest/research/regime_1152_runs/mr.b2_rd_patient3.json
+++ b/backtest/research/regime_1152_runs/mr.b2_rd_patient3.json
@@ -1,0 +1,1949 @@
+{
+  "open": {
+    "name": "mean_reversion",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "tiered_tp_atr_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "tiered_tp_atr",
+      "params": {
+        "tp_tiers": [
+          {
+            "atr_multiple": 1.0,
+            "close_fraction": 0.4
+          },
+          {
+            "atr_multiple": 2.0,
+            "close_fraction": 0.8
+          },
+          {
+            "atr_multiple": 3.0,
+            "close_fraction": 1.0
+          }
+        ]
+      }
+    }
+  ],
+  "control_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_directional"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 79,
+          "entries": 54,
+          "win_rate": 0.5556,
+          "mean_net_pct": -0.2112,
+          "total_net_pct": -11.4054,
+          "total_return_pct": -10.99,
+          "max_drawdown_pct": -16.9,
+          "sharpe": -1.701,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 106,
+          "entries": 49,
+          "win_rate": 0.3878,
+          "mean_net_pct": -0.2853,
+          "total_net_pct": -13.9789,
+          "total_return_pct": -13.36,
+          "max_drawdown_pct": -17.09,
+          "sharpe": -1.753,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.074073,
+          "lo": -0.471763,
+          "hi": 0.329368,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 54,
+          "paired": 54,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 54,
+            "control_mean_net_pct": -0.2112,
+            "candidate_mean_net_pct": -0.304,
+            "control_total_net_pct": -11.4054,
+            "candidate_total_net_pct": -16.4154,
+            "control_win_rate": 0.5556,
+            "candidate_win_rate": 0.3889,
+            "delta_win_rate": -0.1667,
+            "control_median_mae_pct": -0.6651,
+            "candidate_median_mae_pct": -0.9852,
+            "control_median_mfe_pct": 0.5439,
+            "candidate_median_mfe_pct": 0.8991,
+            "paired_delta": {
+              "n": 54,
+              "mean": -0.092778,
+              "median": 0.0,
+              "sign_test": {
+                "n": 54,
+                "n_pos": 28,
+                "n_neg": 26,
+                "n_zero": 0,
+                "p_value": 0.891923
+              },
+              "signed_rank": {
+                "n": 54,
+                "w": 691.0,
+                "z": -0.4391,
+                "p_value": 0.660574
+              },
+              "bootstrap": {
+                "point": -0.092778,
+                "lo": -0.293725,
+                "hi": 0.106241,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 25,
+              "control_mean_net_pct": -0.2037,
+              "candidate_mean_net_pct": -0.3008,
+              "control_total_net_pct": -5.0925,
+              "candidate_total_net_pct": -7.5205,
+              "control_win_rate": 0.6,
+              "candidate_win_rate": 0.4,
+              "delta_win_rate": -0.2,
+              "control_median_mae_pct": -0.8901,
+              "candidate_median_mae_pct": -1.136,
+              "control_median_mfe_pct": 0.5188,
+              "candidate_median_mfe_pct": 0.6998,
+              "paired_delta": {
+                "n": 25,
+                "mean": -0.09712,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 25,
+                  "n_pos": 11,
+                  "n_neg": 14,
+                  "n_zero": 0,
+                  "p_value": 0.690038
+                },
+                "signed_rank": {
+                  "n": 25,
+                  "w": 134.0,
+                  "z": -0.7534,
+                  "p_value": 0.451213
+                },
+                "bootstrap": {
+                  "point": -0.09712,
+                  "lo": -0.38912,
+                  "hi": 0.199487,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 29,
+              "control_mean_net_pct": -0.2177,
+              "candidate_mean_net_pct": -0.3067,
+              "control_total_net_pct": -6.3129,
+              "candidate_total_net_pct": -8.8949,
+              "control_win_rate": 0.5172,
+              "candidate_win_rate": 0.3793,
+              "delta_win_rate": -0.1379,
+              "control_median_mae_pct": -0.6266,
+              "candidate_median_mae_pct": -0.9112,
+              "control_median_mfe_pct": 0.5893,
+              "candidate_median_mfe_pct": 1.1372,
+              "paired_delta": {
+                "n": 29,
+                "mean": -0.089034,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 29,
+                  "n_pos": 17,
+                  "n_neg": 12,
+                  "n_zero": 0,
+                  "p_value": 0.458258
+                },
+                "signed_rank": {
+                  "n": 29,
+                  "w": 219.0,
+                  "z": 0.0216,
+                  "p_value": 0.982749
+                },
+                "bootstrap": {
+                  "point": -0.089034,
+                  "lo": -0.369181,
+                  "hi": 0.177002,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 11,
+          "entries": 8,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.2164,
+          "total_net_pct": -1.7308,
+          "total_return_pct": -1.83,
+          "max_drawdown_pct": -6.28,
+          "sharpe": -0.399,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 13,
+          "entries": 6,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.9686,
+          "total_net_pct": 5.8114,
+          "total_return_pct": 5.81,
+          "max_drawdown_pct": -3.98,
+          "sharpe": 1.231,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 1.184917,
+          "lo": -0.899269,
+          "hi": 3.137523,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 8,
+          "paired": 8,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 8,
+            "control_mean_net_pct": -0.2164,
+            "candidate_mean_net_pct": 0.0801,
+            "control_total_net_pct": -1.7308,
+            "candidate_total_net_pct": 0.6412,
+            "control_win_rate": 0.5,
+            "candidate_win_rate": 0.5,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.8855,
+            "candidate_median_mae_pct": -1.8855,
+            "control_median_mfe_pct": 1.41,
+            "candidate_median_mfe_pct": 2.932,
+            "paired_delta": {
+              "n": 8,
+              "mean": 0.2965,
+              "median": 0.343,
+              "sign_test": {
+                "n": 8,
+                "n_pos": 6,
+                "n_neg": 2,
+                "n_zero": 0,
+                "p_value": 0.289062
+              },
+              "signed_rank": {
+                "n": 8,
+                "w": 27.0,
+                "z": 1.1902,
+                "p_value": 0.233953
+              },
+              "bootstrap": {
+                "point": 0.2965,
+                "lo": -0.369125,
+                "hi": 0.8635,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 6,
+              "control_mean_net_pct": -0.8418,
+              "candidate_mean_net_pct": -0.7584,
+              "control_total_net_pct": -5.0506,
+              "candidate_total_net_pct": -4.5506,
+              "control_win_rate": 0.3333,
+              "candidate_win_rate": 0.3333,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.1349,
+              "candidate_median_mae_pct": -2.1349,
+              "control_median_mfe_pct": 1.2319,
+              "candidate_median_mfe_pct": 1.2319,
+              "paired_delta": {
+                "n": 6,
+                "mean": 0.083333,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 6,
+                  "n_pos": 4,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 0.6875
+                },
+                "signed_rank": {
+                  "n": 6,
+                  "w": 14.0,
+                  "z": 0.629,
+                  "p_value": 0.529368
+                },
+                "bootstrap": {
+                  "point": 0.083333,
+                  "lo": -0.689833,
+                  "hi": 0.792167,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": 1.6599,
+              "candidate_mean_net_pct": 2.5959,
+              "control_total_net_pct": 3.3198,
+              "candidate_total_net_pct": 5.1918,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.2782,
+              "candidate_median_mae_pct": -0.5131,
+              "control_median_mfe_pct": 2.5149,
+              "candidate_median_mfe_pct": 4.9364,
+              "paired_delta": {
+                "n": 2,
+                "mean": 0.936,
+                "median": 0.936,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 2,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 3.0,
+                  "z": 0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": 0.936,
+                  "lo": 0.686,
+                  "hi": 1.186,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 71,
+          "entries": 48,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.0088,
+          "total_net_pct": 0.4202,
+          "total_return_pct": -0.05,
+          "max_drawdown_pct": -12.18,
+          "sharpe": 0.07,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 108,
+          "entries": 43,
+          "win_rate": 0.4186,
+          "mean_net_pct": -0.1632,
+          "total_net_pct": -7.0163,
+          "total_return_pct": -7.54,
+          "max_drawdown_pct": -14.78,
+          "sharpe": -0.617,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.171924,
+          "lo": -0.871214,
+          "hi": 0.546121,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 48,
+          "paired": 48,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 48,
+            "control_mean_net_pct": 0.0088,
+            "candidate_mean_net_pct": -0.0924,
+            "control_total_net_pct": 0.4202,
+            "candidate_total_net_pct": -4.4368,
+            "control_win_rate": 0.6667,
+            "candidate_win_rate": 0.4583,
+            "delta_win_rate": -0.2084,
+            "control_median_mae_pct": -0.8459,
+            "candidate_median_mae_pct": -1.4491,
+            "control_median_mfe_pct": 1.1557,
+            "candidate_median_mfe_pct": 1.7608,
+            "paired_delta": {
+              "n": 48,
+              "mean": -0.101187,
+              "median": -0.0,
+              "sign_test": {
+                "n": 48,
+                "n_pos": 24,
+                "n_neg": 24,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 48,
+                "w": 563.0,
+                "z": -0.2513,
+                "p_value": 0.801593
+              },
+              "bootstrap": {
+                "point": -0.101187,
+                "lo": -0.449482,
+                "hi": 0.217334,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 25,
+              "control_mean_net_pct": 0.0871,
+              "candidate_mean_net_pct": 0.0166,
+              "control_total_net_pct": 2.1775,
+              "candidate_total_net_pct": 0.4155,
+              "control_win_rate": 0.68,
+              "candidate_win_rate": 0.48,
+              "delta_win_rate": -0.2,
+              "control_median_mae_pct": -0.3802,
+              "candidate_median_mae_pct": -1.3951,
+              "control_median_mfe_pct": 1.3276,
+              "candidate_median_mfe_pct": 1.7,
+              "paired_delta": {
+                "n": 25,
+                "mean": -0.07048,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 25,
+                  "n_pos": 14,
+                  "n_neg": 11,
+                  "n_zero": 0,
+                  "p_value": 0.690038
+                },
+                "signed_rank": {
+                  "n": 25,
+                  "w": 174.0,
+                  "z": 0.296,
+                  "p_value": 0.767248
+                },
+                "bootstrap": {
+                  "point": -0.07048,
+                  "lo": -0.593281,
+                  "hi": 0.403987,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 23,
+              "control_mean_net_pct": -0.0764,
+              "candidate_mean_net_pct": -0.211,
+              "control_total_net_pct": -1.7573,
+              "candidate_total_net_pct": -4.8523,
+              "control_win_rate": 0.6522,
+              "candidate_win_rate": 0.4348,
+              "delta_win_rate": -0.2174,
+              "control_median_mae_pct": -0.9083,
+              "candidate_median_mae_pct": -1.6513,
+              "control_median_mfe_pct": 1.1536,
+              "candidate_median_mfe_pct": 1.9844,
+              "paired_delta": {
+                "n": 23,
+                "mean": -0.134565,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 23,
+                  "n_pos": 10,
+                  "n_neg": 13,
+                  "n_zero": 0,
+                  "p_value": 0.677639
+                },
+                "signed_rank": {
+                  "n": 23,
+                  "w": 117.0,
+                  "z": -0.6235,
+                  "p_value": 0.532952
+                },
+                "bootstrap": {
+                  "point": -0.134565,
+                  "lo": -0.542262,
+                  "hi": 0.283304,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 9,
+          "entries": 7,
+          "win_rate": 0.1429,
+          "mean_net_pct": -2.6858,
+          "total_net_pct": -18.8007,
+          "total_return_pct": -17.51,
+          "max_drawdown_pct": -18.95,
+          "sharpe": -3.014,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 9,
+          "entries": 7,
+          "win_rate": 0.1429,
+          "mean_net_pct": -2.773,
+          "total_net_pct": -19.4107,
+          "total_return_pct": -18.15,
+          "max_drawdown_pct": -19.57,
+          "sharpe": -2.473,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.087143,
+          "lo": -2.840071,
+          "hi": 2.947179,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 7,
+          "paired": 7,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 7,
+            "control_mean_net_pct": -2.6858,
+            "candidate_mean_net_pct": -2.773,
+            "control_total_net_pct": -18.8007,
+            "candidate_total_net_pct": -19.4107,
+            "control_win_rate": 0.1429,
+            "candidate_win_rate": 0.1429,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -3.8226,
+            "candidate_median_mae_pct": -3.8226,
+            "control_median_mfe_pct": 0.6397,
+            "candidate_median_mfe_pct": 0.6397,
+            "paired_delta": {
+              "n": 7,
+              "mean": -0.087143,
+              "median": 0.0,
+              "sign_test": {
+                "n": 6,
+                "n_pos": 3,
+                "n_neg": 3,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 6,
+                "w": 10.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": -0.087143,
+                "lo": -1.311429,
+                "hi": 1.05,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": -4.5101,
+              "candidate_mean_net_pct": -4.5101,
+              "control_total_net_pct": -9.0202,
+              "candidate_total_net_pct": -9.0202,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -5.5887,
+              "candidate_median_mae_pct": -5.5887,
+              "control_median_mfe_pct": 0.9683,
+              "candidate_median_mfe_pct": 0.9683,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.0,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 0,
+                  "n_neg": 1,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.0,
+                  "lo": -0.0,
+                  "hi": 0.0,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 5,
+              "control_mean_net_pct": -1.9561,
+              "candidate_mean_net_pct": -2.0781,
+              "control_total_net_pct": -9.7805,
+              "candidate_total_net_pct": -10.3905,
+              "control_win_rate": 0.2,
+              "candidate_win_rate": 0.2,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -3.5262,
+              "candidate_median_mae_pct": -3.5262,
+              "control_median_mfe_pct": 0.6397,
+              "candidate_median_mfe_pct": 0.6397,
+              "paired_delta": {
+                "n": 5,
+                "mean": -0.122,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 5,
+                  "n_pos": 3,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 5,
+                  "w": 9.0,
+                  "z": 0.2697,
+                  "p_value": 0.787406
+                },
+                "bootstrap": {
+                  "point": -0.122,
+                  "lo": -1.836,
+                  "hi": 1.47,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 68,
+          "entries": 49,
+          "win_rate": 0.449,
+          "mean_net_pct": -0.5095,
+          "total_net_pct": -24.9649,
+          "total_return_pct": -22.69,
+          "max_drawdown_pct": -26.27,
+          "sharpe": -2.152,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 75,
+          "entries": 42,
+          "win_rate": 0.3571,
+          "mean_net_pct": -0.5892,
+          "total_net_pct": -24.7483,
+          "total_return_pct": -22.86,
+          "max_drawdown_pct": -29.36,
+          "sharpe": -2.077,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.079757,
+          "lo": -1.011141,
+          "hi": 0.86768,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 49,
+          "paired": 49,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 49,
+            "control_mean_net_pct": -0.5095,
+            "candidate_mean_net_pct": -0.5482,
+            "control_total_net_pct": -24.9649,
+            "candidate_total_net_pct": -26.861,
+            "control_win_rate": 0.449,
+            "candidate_win_rate": 0.3673,
+            "delta_win_rate": -0.0817,
+            "control_median_mae_pct": -1.2764,
+            "candidate_median_mae_pct": -1.8274,
+            "control_median_mfe_pct": 0.9974,
+            "candidate_median_mfe_pct": 1.2356,
+            "paired_delta": {
+              "n": 49,
+              "mean": -0.038695,
+              "median": 0.0,
+              "sign_test": {
+                "n": 49,
+                "n_pos": 25,
+                "n_neg": 24,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 49,
+                "w": 652.0,
+                "z": 0.3879,
+                "p_value": 0.698057
+              },
+              "bootstrap": {
+                "point": -0.038695,
+                "lo": -0.355561,
+                "hi": 0.268305,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 25,
+              "control_mean_net_pct": -0.6701,
+              "candidate_mean_net_pct": -0.789,
+              "control_total_net_pct": -16.7525,
+              "candidate_total_net_pct": -19.7245,
+              "control_win_rate": 0.44,
+              "candidate_win_rate": 0.32,
+              "delta_win_rate": -0.12,
+              "control_median_mae_pct": -1.3082,
+              "candidate_median_mae_pct": -1.9712,
+              "control_median_mfe_pct": 0.9527,
+              "candidate_median_mfe_pct": 0.9527,
+              "paired_delta": {
+                "n": 25,
+                "mean": -0.11888,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 25,
+                  "n_pos": 14,
+                  "n_neg": 11,
+                  "n_zero": 0,
+                  "p_value": 0.690038
+                },
+                "signed_rank": {
+                  "n": 25,
+                  "w": 168.0,
+                  "z": 0.1345,
+                  "p_value": 0.89298
+                },
+                "bootstrap": {
+                  "point": -0.11888,
+                  "lo": -0.594931,
+                  "hi": 0.343407,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 24,
+              "control_mean_net_pct": -0.3422,
+              "candidate_mean_net_pct": -0.2974,
+              "control_total_net_pct": -8.2124,
+              "candidate_total_net_pct": -7.1365,
+              "control_win_rate": 0.4583,
+              "candidate_win_rate": 0.4167,
+              "delta_win_rate": -0.0416,
+              "control_median_mae_pct": -1.2302,
+              "candidate_median_mae_pct": -1.7578,
+              "control_median_mfe_pct": 1.1165,
+              "candidate_median_mfe_pct": 1.3398,
+              "paired_delta": {
+                "n": 24,
+                "mean": 0.04483,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 24,
+                  "n_pos": 11,
+                  "n_neg": 13,
+                  "n_zero": 0,
+                  "p_value": 0.83882
+                },
+                "signed_rank": {
+                  "n": 24,
+                  "w": 166.0,
+                  "z": 0.4429,
+                  "p_value": 0.657869
+                },
+                "bootstrap": {
+                  "point": 0.04483,
+                  "lo": -0.347669,
+                  "hi": 0.402999,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 12,
+          "entries": 10,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.3326,
+          "total_net_pct": -3.326,
+          "total_return_pct": -3.88,
+          "max_drawdown_pct": -13.5,
+          "sharpe": -0.404,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 14,
+          "entries": 9,
+          "win_rate": 0.1111,
+          "mean_net_pct": -2.6343,
+          "total_net_pct": -23.7089,
+          "total_return_pct": -21.57,
+          "max_drawdown_pct": -22.57,
+          "sharpe": -2.513,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -2.301722,
+          "lo": -4.861117,
+          "hi": 0.394968,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 10,
+          "paired": 10,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 10,
+            "control_mean_net_pct": -0.3326,
+            "candidate_mean_net_pct": -1.7315,
+            "control_total_net_pct": -3.326,
+            "candidate_total_net_pct": -17.315,
+            "control_win_rate": 0.5,
+            "candidate_win_rate": 0.2,
+            "delta_win_rate": -0.3,
+            "control_median_mae_pct": -2.3312,
+            "candidate_median_mae_pct": -4.0431,
+            "control_median_mfe_pct": 2.7535,
+            "candidate_median_mfe_pct": 2.9732,
+            "paired_delta": {
+              "n": 10,
+              "mean": -1.3989,
+              "median": -0.0,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 4,
+                "n_neg": 5,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 14.0,
+                "z": -0.9478,
+                "p_value": 0.343253
+              },
+              "bootstrap": {
+                "point": -1.3989,
+                "lo": -3.3055,
+                "hi": 0.2972,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 5,
+              "control_mean_net_pct": -2.1461,
+              "candidate_mean_net_pct": -1.9953,
+              "control_total_net_pct": -10.7305,
+              "candidate_total_net_pct": -9.9765,
+              "control_win_rate": 0.2,
+              "candidate_win_rate": 0.2,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -3.3332,
+              "candidate_median_mae_pct": -3.3332,
+              "control_median_mfe_pct": 1.5435,
+              "candidate_median_mfe_pct": 1.5435,
+              "paired_delta": {
+                "n": 5,
+                "mean": 0.1508,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 5,
+                  "n_pos": 3,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 5,
+                  "w": 9.0,
+                  "z": 0.2697,
+                  "p_value": 0.787406
+                },
+                "bootstrap": {
+                  "point": 0.1508,
+                  "lo": -1.476,
+                  "hi": 1.9284,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 5,
+              "control_mean_net_pct": 1.4809,
+              "candidate_mean_net_pct": -1.4677,
+              "control_total_net_pct": 7.4045,
+              "candidate_total_net_pct": -7.3385,
+              "control_win_rate": 0.8,
+              "candidate_win_rate": 0.2,
+              "delta_win_rate": -0.6,
+              "control_median_mae_pct": -0.2472,
+              "candidate_median_mae_pct": -4.2082,
+              "control_median_mfe_pct": 3.0589,
+              "candidate_median_mfe_pct": 3.4338,
+              "paired_delta": {
+                "n": 5,
+                "mean": -2.9486,
+                "median": -3.456,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 1,
+                  "n_neg": 3,
+                  "n_zero": 1,
+                  "p_value": 0.625
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 1.0,
+                  "z": -1.278,
+                  "p_value": 0.201243
+                },
+                "bootstrap": {
+                  "point": -2.9486,
+                  "lo": -5.4972,
+                  "hi": -0.4,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 59,
+          "entries": 42,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.4747,
+          "total_net_pct": -19.9392,
+          "total_return_pct": -18.34,
+          "max_drawdown_pct": -21.05,
+          "sharpe": -3.174,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 77,
+          "entries": 41,
+          "win_rate": 0.4146,
+          "mean_net_pct": -0.4058,
+          "total_net_pct": -16.6381,
+          "total_return_pct": -15.72,
+          "max_drawdown_pct": -20.81,
+          "sharpe": -2.331,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.068936,
+          "lo": -0.49823,
+          "hi": 0.63583,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 42,
+          "paired": 42,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 42,
+            "control_mean_net_pct": -0.4747,
+            "candidate_mean_net_pct": -0.4221,
+            "control_total_net_pct": -19.9392,
+            "candidate_total_net_pct": -17.7282,
+            "control_win_rate": 0.5,
+            "candidate_win_rate": 0.4048,
+            "delta_win_rate": -0.0952,
+            "control_median_mae_pct": -0.9445,
+            "candidate_median_mae_pct": -1.3286,
+            "control_median_mfe_pct": 0.6232,
+            "candidate_median_mfe_pct": 0.7043,
+            "paired_delta": {
+              "n": 42,
+              "mean": 0.052643,
+              "median": 0.0,
+              "sign_test": {
+                "n": 42,
+                "n_pos": 23,
+                "n_neg": 19,
+                "n_zero": 0,
+                "p_value": 0.643969
+              },
+              "signed_rank": {
+                "n": 42,
+                "w": 490.0,
+                "z": 0.4751,
+                "p_value": 0.634688
+              },
+              "bootstrap": {
+                "point": 0.052643,
+                "lo": -0.13436,
+                "hi": 0.243313,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 25,
+              "control_mean_net_pct": -0.3383,
+              "candidate_mean_net_pct": -0.2337,
+              "control_total_net_pct": -8.4575,
+              "candidate_total_net_pct": -5.8425,
+              "control_win_rate": 0.56,
+              "candidate_win_rate": 0.48,
+              "delta_win_rate": -0.08,
+              "control_median_mae_pct": -0.6155,
+              "candidate_median_mae_pct": -1.1868,
+              "control_median_mfe_pct": 0.6445,
+              "candidate_median_mfe_pct": 1.4927,
+              "paired_delta": {
+                "n": 25,
+                "mean": 0.1046,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 25,
+                  "n_pos": 15,
+                  "n_neg": 10,
+                  "n_zero": 0,
+                  "p_value": 0.424356
+                },
+                "signed_rank": {
+                  "n": 25,
+                  "w": 197.0,
+                  "z": 0.9148,
+                  "p_value": 0.360278
+                },
+                "bootstrap": {
+                  "point": 0.1046,
+                  "lo": -0.154807,
+                  "hi": 0.353002,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 17,
+              "control_mean_net_pct": -0.6754,
+              "candidate_mean_net_pct": -0.6992,
+              "control_total_net_pct": -11.4817,
+              "candidate_total_net_pct": -11.8857,
+              "control_win_rate": 0.4118,
+              "candidate_win_rate": 0.2941,
+              "delta_win_rate": -0.1177,
+              "control_median_mae_pct": -1.2588,
+              "candidate_median_mae_pct": -1.4563,
+              "control_median_mfe_pct": 0.5041,
+              "candidate_median_mfe_pct": 0.6125,
+              "paired_delta": {
+                "n": 17,
+                "mean": -0.023765,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 17,
+                  "n_pos": 8,
+                  "n_neg": 9,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 17,
+                  "w": 64.0,
+                  "z": -0.5681,
+                  "p_value": 0.569996
+                },
+                "bootstrap": {
+                  "point": -0.023765,
+                  "lo": -0.291474,
+                  "hi": 0.275946,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 8,
+          "entries": 4,
+          "win_rate": 1.0,
+          "mean_net_pct": 1.1674,
+          "total_net_pct": 4.6696,
+          "total_return_pct": 4.75,
+          "max_drawdown_pct": -0.93,
+          "sharpe": 2.208,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 9,
+          "entries": 4,
+          "win_rate": 0.75,
+          "mean_net_pct": 1.6264,
+          "total_net_pct": 6.5056,
+          "total_return_pct": 6.6,
+          "max_drawdown_pct": -3.16,
+          "sharpe": 2.091,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.459,
+          "lo": -1.504,
+          "hi": 2.031156,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 4,
+          "paired": 4,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 4,
+            "control_mean_net_pct": 1.1674,
+            "candidate_mean_net_pct": 1.6264,
+            "control_total_net_pct": 4.6696,
+            "candidate_total_net_pct": 6.5056,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 0.75,
+            "delta_win_rate": -0.25,
+            "control_median_mae_pct": -0.5581,
+            "candidate_median_mae_pct": -1.3171,
+            "control_median_mfe_pct": 2.1468,
+            "candidate_median_mfe_pct": 3.5465,
+            "paired_delta": {
+              "n": 4,
+              "mean": 0.459,
+              "median": 0.9655,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 3,
+                "n_neg": 1,
+                "n_zero": 0,
+                "p_value": 0.625
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 6.0,
+                "z": 0.1826,
+                "p_value": 0.855132
+              },
+              "bootstrap": {
+                "point": 0.459,
+                "lo": -1.299,
+                "hi": 1.7105,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": 1.6399,
+              "candidate_mean_net_pct": 3.6099,
+              "control_total_net_pct": 1.6399,
+              "candidate_total_net_pct": 3.6099,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.511,
+              "candidate_median_mae_pct": -0.511,
+              "control_median_mfe_pct": 2.3552,
+              "candidate_median_mfe_pct": 7.1393,
+              "paired_delta": {
+                "n": 1,
+                "mean": 1.97,
+                "median": 1.97,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 1.97,
+                  "lo": 1.97,
+                  "hi": 1.97,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 3,
+              "control_mean_net_pct": 1.0099,
+              "candidate_mean_net_pct": 0.9652,
+              "control_total_net_pct": 3.0297,
+              "candidate_total_net_pct": 2.8957,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": -0.3333,
+              "control_median_mae_pct": -0.6052,
+              "candidate_median_mae_pct": -1.4972,
+              "control_median_mfe_pct": 1.9385,
+              "candidate_median_mfe_pct": 3.3653,
+              "paired_delta": {
+                "n": 3,
+                "mean": -0.044667,
+                "median": 0.932,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 2,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 3.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.044667,
+                  "lo": -2.065,
+                  "hi": 0.999,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 57,
+          "entries": 43,
+          "win_rate": 0.5349,
+          "mean_net_pct": -0.2973,
+          "total_net_pct": -12.7843,
+          "total_return_pct": -12.59,
+          "max_drawdown_pct": -20.99,
+          "sharpe": -1.312,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 57,
+          "entries": 35,
+          "win_rate": 0.4286,
+          "mean_net_pct": -0.266,
+          "total_net_pct": -9.3115,
+          "total_return_pct": -9.59,
+          "max_drawdown_pct": -17.99,
+          "sharpe": -0.908,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.031266,
+          "lo": -0.859599,
+          "hi": 0.90669,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 43,
+          "paired": 43,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 43,
+            "control_mean_net_pct": -0.2973,
+            "candidate_mean_net_pct": -0.1672,
+            "control_total_net_pct": -12.7843,
+            "candidate_total_net_pct": -7.1903,
+            "control_win_rate": 0.5349,
+            "candidate_win_rate": 0.4419,
+            "delta_win_rate": -0.093,
+            "control_median_mae_pct": -1.2037,
+            "candidate_median_mae_pct": -1.582,
+            "control_median_mfe_pct": 1.3391,
+            "candidate_median_mfe_pct": 1.8135,
+            "paired_delta": {
+              "n": 43,
+              "mean": 0.130093,
+              "median": 0.0,
+              "sign_test": {
+                "n": 42,
+                "n_pos": 23,
+                "n_neg": 19,
+                "n_zero": 1,
+                "p_value": 0.643969
+              },
+              "signed_rank": {
+                "n": 42,
+                "w": 543.0,
+                "z": 1.1378,
+                "p_value": 0.25519
+              },
+              "bootstrap": {
+                "point": 0.130093,
+                "lo": -0.137143,
+                "hi": 0.39061,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 23,
+              "control_mean_net_pct": -0.4944,
+              "candidate_mean_net_pct": -0.4044,
+              "control_total_net_pct": -11.3723,
+              "candidate_total_net_pct": -9.3023,
+              "control_win_rate": 0.4348,
+              "candidate_win_rate": 0.3913,
+              "delta_win_rate": -0.0435,
+              "control_median_mae_pct": -1.3081,
+              "candidate_median_mae_pct": -1.7187,
+              "control_median_mfe_pct": 0.585,
+              "candidate_median_mfe_pct": 0.585,
+              "paired_delta": {
+                "n": 23,
+                "mean": 0.09,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 23,
+                  "n_pos": 11,
+                  "n_neg": 12,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 23,
+                  "w": 150.0,
+                  "z": 0.3498,
+                  "p_value": 0.72651
+                },
+                "bootstrap": {
+                  "point": 0.09,
+                  "lo": -0.225396,
+                  "hi": 0.391699,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 20,
+              "control_mean_net_pct": -0.0706,
+              "candidate_mean_net_pct": 0.1056,
+              "control_total_net_pct": -1.412,
+              "candidate_total_net_pct": 2.112,
+              "control_win_rate": 0.65,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": -0.15,
+              "control_median_mae_pct": -1.192,
+              "candidate_median_mae_pct": -1.4532,
+              "control_median_mfe_pct": 1.4409,
+              "candidate_median_mfe_pct": 2.2588,
+              "paired_delta": {
+                "n": 20,
+                "mean": 0.1762,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 19,
+                  "n_pos": 12,
+                  "n_neg": 7,
+                  "n_zero": 1,
+                  "p_value": 0.359283
+                },
+                "signed_rank": {
+                  "n": 19,
+                  "w": 125.0,
+                  "z": 1.1871,
+                  "p_value": 0.235171
+                },
+                "bootstrap": {
+                  "point": 0.1762,
+                  "lo": -0.267822,
+                  "hi": 0.600574,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 9,
+          "entries": 5,
+          "win_rate": 0.6,
+          "mean_net_pct": 0.0459,
+          "total_net_pct": 0.2295,
+          "total_return_pct": 0.11,
+          "max_drawdown_pct": -6.47,
+          "sharpe": 0.073,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 12,
+          "entries": 5,
+          "win_rate": 0.4,
+          "mean_net_pct": -1.2629,
+          "total_net_pct": -6.3145,
+          "total_return_pct": -6.7,
+          "max_drawdown_pct": -13.59,
+          "sharpe": -1.046,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -1.3088,
+          "lo": -5.842,
+          "hi": 3.520495,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 5,
+          "paired": 5,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 5,
+            "control_mean_net_pct": 0.0459,
+            "candidate_mean_net_pct": -1.2629,
+            "control_total_net_pct": 0.2295,
+            "candidate_total_net_pct": -6.3145,
+            "control_win_rate": 0.6,
+            "candidate_win_rate": 0.4,
+            "delta_win_rate": -0.2,
+            "control_median_mae_pct": -0.7333,
+            "candidate_median_mae_pct": -4.898,
+            "control_median_mfe_pct": 2.7084,
+            "candidate_median_mfe_pct": 3.5365,
+            "paired_delta": {
+              "n": 5,
+              "mean": -1.3088,
+              "median": -2.69,
+              "sign_test": {
+                "n": 5,
+                "n_pos": 2,
+                "n_neg": 3,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 5,
+                "w": 3.0,
+                "z": -1.0787,
+                "p_value": 0.280713
+              },
+              "bootstrap": {
+                "point": -1.3088,
+                "lo": -3.674,
+                "hi": 1.128,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": -1.8001,
+              "candidate_mean_net_pct": -4.4901,
+              "control_total_net_pct": -1.8001,
+              "candidate_total_net_pct": -4.4901,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -4.898,
+              "candidate_median_mae_pct": -4.898,
+              "control_median_mfe_pct": 2.7084,
+              "candidate_median_mfe_pct": 2.7084,
+              "paired_delta": {
+                "n": 1,
+                "mean": -2.69,
+                "median": -2.69,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 0,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -2.69,
+                  "lo": -2.69,
+                  "hi": -2.69,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 4,
+              "control_mean_net_pct": 0.5074,
+              "candidate_mean_net_pct": -0.4561,
+              "control_total_net_pct": 2.0296,
+              "candidate_total_net_pct": -1.8244,
+              "control_win_rate": 0.75,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": -0.25,
+              "control_median_mae_pct": -0.6082,
+              "candidate_median_mae_pct": -4.4347,
+              "control_median_mfe_pct": 2.694,
+              "candidate_median_mfe_pct": 4.6252,
+              "paired_delta": {
+                "n": 4,
+                "mean": -0.9635,
+                "median": -1.053,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 2,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 3.0,
+                  "z": -0.5477,
+                  "p_value": 0.583882
+                },
+                "bootstrap": {
+                  "point": -0.9635,
+                  "lo": -3.9245,
+                  "hi": 1.9975,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 41,
+          "entries": 28,
+          "win_rate": 0.6786,
+          "mean_net_pct": -0.1092,
+          "total_net_pct": -3.0578,
+          "total_return_pct": -3.27,
+          "max_drawdown_pct": -9.16,
+          "sharpe": -0.422,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 53,
+          "entries": 27,
+          "win_rate": 0.4444,
+          "mean_net_pct": -0.024,
+          "total_net_pct": -0.6487,
+          "total_return_pct": -1.12,
+          "max_drawdown_pct": -11.58,
+          "sharpe": -0.06,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.085181,
+          "lo": -0.776208,
+          "hi": 0.964855,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 28,
+          "paired": 28,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 28,
+            "control_mean_net_pct": -0.1092,
+            "candidate_mean_net_pct": 0.0173,
+            "control_total_net_pct": -3.0578,
+            "candidate_total_net_pct": 0.4852,
+            "control_win_rate": 0.6786,
+            "candidate_win_rate": 0.4643,
+            "delta_win_rate": -0.2143,
+            "control_median_mae_pct": -0.8365,
+            "candidate_median_mae_pct": -1.34,
+            "control_median_mfe_pct": 1.0295,
+            "candidate_median_mfe_pct": 2.1886,
+            "paired_delta": {
+              "n": 28,
+              "mean": 0.126536,
+              "median": 0.0,
+              "sign_test": {
+                "n": 27,
+                "n_pos": 15,
+                "n_neg": 12,
+                "n_zero": 1,
+                "p_value": 0.701108
+              },
+              "signed_rank": {
+                "n": 27,
+                "w": 220.0,
+                "z": 0.7328,
+                "p_value": 0.463703
+              },
+              "bootstrap": {
+                "point": 0.126536,
+                "lo": -0.231037,
+                "hi": 0.481118,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 18,
+              "control_mean_net_pct": -0.0204,
+              "candidate_mean_net_pct": -0.0661,
+              "control_total_net_pct": -0.3668,
+              "candidate_total_net_pct": -1.1898,
+              "control_win_rate": 0.7778,
+              "candidate_win_rate": 0.4444,
+              "delta_win_rate": -0.3334,
+              "control_median_mae_pct": -0.6006,
+              "candidate_median_mae_pct": -1.5315,
+              "control_median_mfe_pct": 1.1168,
+              "candidate_median_mfe_pct": 2.1886,
+              "paired_delta": {
+                "n": 18,
+                "mean": -0.045722,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 18,
+                  "n_pos": 9,
+                  "n_neg": 9,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 18,
+                  "w": 82.0,
+                  "z": -0.1307,
+                  "p_value": 0.896051
+                },
+                "bootstrap": {
+                  "point": -0.045722,
+                  "lo": -0.537613,
+                  "hi": 0.412724,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 10,
+              "control_mean_net_pct": -0.2691,
+              "candidate_mean_net_pct": 0.1675,
+              "control_total_net_pct": -2.691,
+              "candidate_total_net_pct": 1.675,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1592,
+              "candidate_median_mae_pct": -1.1592,
+              "control_median_mfe_pct": 0.7911,
+              "candidate_median_mfe_pct": 1.4633,
+              "paired_delta": {
+                "n": 10,
+                "mean": 0.4366,
+                "median": 0.184,
+                "sign_test": {
+                  "n": 9,
+                  "n_pos": 6,
+                  "n_neg": 3,
+                  "n_zero": 1,
+                  "p_value": 0.507812
+                },
+                "signed_rank": {
+                  "n": 9,
+                  "w": 36.0,
+                  "z": 1.5401,
+                  "p_value": 0.123534
+                },
+                "bootstrap": {
+                  "point": 0.4366,
+                  "lo": 0.0182,
+                  "hi": 0.89762,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 13,
+          "entries": 10,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.4501,
+          "total_net_pct": -4.501,
+          "total_return_pct": -4.88,
+          "max_drawdown_pct": -9.46,
+          "sharpe": -0.657,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 18,
+          "entries": 10,
+          "win_rate": 0.3,
+          "mean_net_pct": -1.3133,
+          "total_net_pct": -13.133,
+          "total_return_pct": -12.95,
+          "max_drawdown_pct": -16.5,
+          "sharpe": -1.403,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.8632,
+          "lo": -3.73681,
+          "hi": 2.181988,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 10,
+          "paired": 10,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 10,
+            "control_mean_net_pct": -0.4501,
+            "candidate_mean_net_pct": -1.3133,
+            "control_total_net_pct": -4.501,
+            "candidate_total_net_pct": -13.133,
+            "control_win_rate": 0.5,
+            "candidate_win_rate": 0.3,
+            "delta_win_rate": -0.2,
+            "control_median_mae_pct": -2.2254,
+            "candidate_median_mae_pct": -3.7526,
+            "control_median_mfe_pct": 2.4284,
+            "candidate_median_mfe_pct": 2.9819,
+            "paired_delta": {
+              "n": 10,
+              "mean": -0.8632,
+              "median": 0.0,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 5,
+                "n_neg": 4,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 17.0,
+                "z": -0.5923,
+                "p_value": 0.553617
+              },
+              "bootstrap": {
+                "point": -0.8632,
+                "lo": -2.24676,
+                "hi": 0.428728,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 5,
+              "control_mean_net_pct": 0.7389,
+              "candidate_mean_net_pct": -1.1925,
+              "control_total_net_pct": 3.6945,
+              "candidate_total_net_pct": -5.9625,
+              "control_win_rate": 0.6,
+              "candidate_win_rate": 0.2,
+              "delta_win_rate": -0.4,
+              "control_median_mae_pct": -0.7655,
+              "candidate_median_mae_pct": -3.8059,
+              "control_median_mfe_pct": 2.7496,
+              "candidate_median_mfe_pct": 3.8568,
+              "paired_delta": {
+                "n": 5,
+                "mean": -1.9314,
+                "median": -2.36,
+                "sign_test": {
+                  "n": 5,
+                  "n_pos": 1,
+                  "n_neg": 4,
+                  "n_zero": 0,
+                  "p_value": 0.375
+                },
+                "signed_rank": {
+                  "n": 5,
+                  "w": 3.0,
+                  "z": -1.0787,
+                  "p_value": 0.280713
+                },
+                "bootstrap": {
+                  "point": -1.9314,
+                  "lo": -3.9464,
+                  "hi": 0.6758,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 5,
+              "control_mean_net_pct": -1.6391,
+              "candidate_mean_net_pct": -1.4341,
+              "control_total_net_pct": -8.1955,
+              "candidate_total_net_pct": -7.1705,
+              "control_win_rate": 0.4,
+              "candidate_win_rate": 0.4,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.8324,
+              "candidate_median_mae_pct": -3.6993,
+              "control_median_mfe_pct": 2.1071,
+              "candidate_median_mfe_pct": 2.1071,
+              "paired_delta": {
+                "n": 5,
+                "mean": 0.205,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 4,
+                  "n_neg": 0,
+                  "n_zero": 1,
+                  "p_value": 0.125
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 10.0,
+                  "z": 1.6432,
+                  "p_value": 0.100348
+                },
+                "bootstrap": {
+                  "point": 0.205,
+                  "lo": 0.0,
+                  "hi": 0.5434,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/mr.b2_rd_wider2.json
+++ b/backtest/research/regime_1152_runs/mr.b2_rd_wider2.json
@@ -1,0 +1,1945 @@
+{
+  "open": {
+    "name": "mean_reversion",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "tiered_tp_atr_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "tiered_tp_atr",
+      "params": {
+        "tp_tiers": [
+          {
+            "atr_multiple": 1.0,
+            "close_fraction": 0.5
+          },
+          {
+            "atr_multiple": 2.0,
+            "close_fraction": 1.0
+          }
+        ]
+      }
+    }
+  ],
+  "control_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_directional"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 79,
+          "entries": 54,
+          "win_rate": 0.5556,
+          "mean_net_pct": -0.2112,
+          "total_net_pct": -11.4054,
+          "total_return_pct": -10.99,
+          "max_drawdown_pct": -16.9,
+          "sharpe": -1.701,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 76,
+          "entries": 50,
+          "win_rate": 0.38,
+          "mean_net_pct": -0.3069,
+          "total_net_pct": -15.345,
+          "total_return_pct": -14.51,
+          "max_drawdown_pct": -18.29,
+          "sharpe": -1.96,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.095689,
+          "lo": -0.477021,
+          "hi": 0.28235,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 54,
+          "paired": 54,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 54,
+            "control_mean_net_pct": -0.2112,
+            "candidate_mean_net_pct": -0.2976,
+            "control_total_net_pct": -11.4054,
+            "candidate_total_net_pct": -16.0704,
+            "control_win_rate": 0.5556,
+            "candidate_win_rate": 0.3889,
+            "delta_win_rate": -0.1667,
+            "control_median_mae_pct": -0.6651,
+            "candidate_median_mae_pct": -0.9457,
+            "control_median_mfe_pct": 0.5439,
+            "candidate_median_mfe_pct": 0.8991,
+            "paired_delta": {
+              "n": 54,
+              "mean": -0.086389,
+              "median": 0.0,
+              "sign_test": {
+                "n": 54,
+                "n_pos": 30,
+                "n_neg": 24,
+                "n_zero": 0,
+                "p_value": 0.496617
+              },
+              "signed_rank": {
+                "n": 54,
+                "w": 718.0,
+                "z": -0.2066,
+                "p_value": 0.836287
+              },
+              "bootstrap": {
+                "point": -0.086389,
+                "lo": -0.249363,
+                "hi": 0.076019,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 25,
+              "control_mean_net_pct": -0.2037,
+              "candidate_mean_net_pct": -0.2733,
+              "control_total_net_pct": -5.0925,
+              "candidate_total_net_pct": -6.8325,
+              "control_win_rate": 0.6,
+              "candidate_win_rate": 0.4,
+              "delta_win_rate": -0.2,
+              "control_median_mae_pct": -0.8901,
+              "candidate_median_mae_pct": -1.0059,
+              "control_median_mfe_pct": 0.5188,
+              "candidate_median_mfe_pct": 0.6998,
+              "paired_delta": {
+                "n": 25,
+                "mean": -0.0696,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 25,
+                  "n_pos": 14,
+                  "n_neg": 11,
+                  "n_zero": 0,
+                  "p_value": 0.690038
+                },
+                "signed_rank": {
+                  "n": 25,
+                  "w": 168.0,
+                  "z": 0.1345,
+                  "p_value": 0.89298
+                },
+                "bootstrap": {
+                  "point": -0.0696,
+                  "lo": -0.311205,
+                  "hi": 0.167405,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 29,
+              "control_mean_net_pct": -0.2177,
+              "candidate_mean_net_pct": -0.3185,
+              "control_total_net_pct": -6.3129,
+              "candidate_total_net_pct": -9.2379,
+              "control_win_rate": 0.5172,
+              "candidate_win_rate": 0.3793,
+              "delta_win_rate": -0.1379,
+              "control_median_mae_pct": -0.6266,
+              "candidate_median_mae_pct": -0.9112,
+              "control_median_mfe_pct": 0.5893,
+              "candidate_median_mfe_pct": 1.0745,
+              "paired_delta": {
+                "n": 29,
+                "mean": -0.100862,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 29,
+                  "n_pos": 16,
+                  "n_neg": 13,
+                  "n_zero": 0,
+                  "p_value": 0.711071
+                },
+                "signed_rank": {
+                  "n": 29,
+                  "w": 197.0,
+                  "z": -0.4325,
+                  "p_value": 0.665404
+                },
+                "bootstrap": {
+                  "point": -0.100862,
+                  "lo": -0.326741,
+                  "hi": 0.113103,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 11,
+          "entries": 8,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.2164,
+          "total_net_pct": -1.7308,
+          "total_return_pct": -1.83,
+          "max_drawdown_pct": -6.28,
+          "sharpe": -0.399,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 10,
+          "entries": 7,
+          "win_rate": 0.5714,
+          "mean_net_pct": 0.3135,
+          "total_net_pct": 2.1943,
+          "total_return_pct": 2.06,
+          "max_drawdown_pct": -5.37,
+          "sharpe": 0.457,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.529821,
+          "lo": -1.383944,
+          "hi": 2.427156,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 8,
+          "paired": 8,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 8,
+            "control_mean_net_pct": -0.2164,
+            "candidate_mean_net_pct": -0.0845,
+            "control_total_net_pct": -1.7308,
+            "candidate_total_net_pct": -0.6758,
+            "control_win_rate": 0.5,
+            "candidate_win_rate": 0.5,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.8855,
+            "candidate_median_mae_pct": -1.8855,
+            "control_median_mfe_pct": 1.41,
+            "candidate_median_mfe_pct": 2.0095,
+            "paired_delta": {
+              "n": 8,
+              "mean": 0.131875,
+              "median": 0.19,
+              "sign_test": {
+                "n": 8,
+                "n_pos": 6,
+                "n_neg": 2,
+                "n_zero": 0,
+                "p_value": 0.289062
+              },
+              "signed_rank": {
+                "n": 8,
+                "w": 27.0,
+                "z": 1.1902,
+                "p_value": 0.233953
+              },
+              "bootstrap": {
+                "point": 0.131875,
+                "lo": -0.4525,
+                "hi": 0.5875,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 6,
+              "control_mean_net_pct": -0.8418,
+              "candidate_mean_net_pct": -0.8868,
+              "control_total_net_pct": -5.0506,
+              "candidate_total_net_pct": -5.3206,
+              "control_win_rate": 0.3333,
+              "candidate_win_rate": 0.3333,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.1349,
+              "candidate_median_mae_pct": -2.1349,
+              "control_median_mfe_pct": 1.2319,
+              "candidate_median_mfe_pct": 1.2319,
+              "paired_delta": {
+                "n": 6,
+                "mean": -0.045,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 6,
+                  "n_pos": 4,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 0.6875
+                },
+                "signed_rank": {
+                  "n": 6,
+                  "w": 14.0,
+                  "z": 0.629,
+                  "p_value": 0.529368
+                },
+                "bootstrap": {
+                  "point": -0.045,
+                  "lo": -0.7425,
+                  "hi": 0.5125,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": 1.6599,
+              "candidate_mean_net_pct": 2.3224,
+              "control_total_net_pct": 3.3198,
+              "candidate_total_net_pct": 4.6448,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.2782,
+              "candidate_median_mae_pct": -0.5131,
+              "control_median_mfe_pct": 2.5149,
+              "candidate_median_mfe_pct": 3.4004,
+              "paired_delta": {
+                "n": 2,
+                "mean": 0.6625,
+                "median": 0.6625,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 2,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 3.0,
+                  "z": 0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": 0.6625,
+                  "lo": 0.38,
+                  "hi": 0.945,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 71,
+          "entries": 48,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.0088,
+          "total_net_pct": 0.4202,
+          "total_return_pct": -0.05,
+          "max_drawdown_pct": -12.18,
+          "sharpe": 0.07,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 71,
+          "entries": 44,
+          "win_rate": 0.4318,
+          "mean_net_pct": -0.1516,
+          "total_net_pct": -6.6694,
+          "total_return_pct": -7.11,
+          "max_drawdown_pct": -15.87,
+          "sharpe": -0.594,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.160331,
+          "lo": -0.808106,
+          "hi": 0.494574,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 48,
+          "paired": 48,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 48,
+            "control_mean_net_pct": 0.0088,
+            "candidate_mean_net_pct": -0.0984,
+            "control_total_net_pct": 0.4202,
+            "candidate_total_net_pct": -4.7248,
+            "control_win_rate": 0.6667,
+            "candidate_win_rate": 0.4583,
+            "delta_win_rate": -0.2084,
+            "control_median_mae_pct": -0.8459,
+            "candidate_median_mae_pct": -1.3129,
+            "control_median_mfe_pct": 1.1557,
+            "candidate_median_mfe_pct": 1.6995,
+            "paired_delta": {
+              "n": 48,
+              "mean": -0.107187,
+              "median": 0.0,
+              "sign_test": {
+                "n": 48,
+                "n_pos": 27,
+                "n_neg": 21,
+                "n_zero": 0,
+                "p_value": 0.470879
+              },
+              "signed_rank": {
+                "n": 48,
+                "w": 579.0,
+                "z": -0.0872,
+                "p_value": 0.930528
+              },
+              "bootstrap": {
+                "point": -0.107187,
+                "lo": -0.39251,
+                "hi": 0.148344,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 25,
+              "control_mean_net_pct": 0.0871,
+              "candidate_mean_net_pct": 0.0007,
+              "control_total_net_pct": 2.1775,
+              "candidate_total_net_pct": 0.0175,
+              "control_win_rate": 0.68,
+              "candidate_win_rate": 0.48,
+              "delta_win_rate": -0.2,
+              "control_median_mae_pct": -0.3802,
+              "candidate_median_mae_pct": -1.2648,
+              "control_median_mfe_pct": 1.3276,
+              "candidate_median_mfe_pct": 1.7,
+              "paired_delta": {
+                "n": 25,
+                "mean": -0.0864,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 25,
+                  "n_pos": 15,
+                  "n_neg": 10,
+                  "n_zero": 0,
+                  "p_value": 0.424356
+                },
+                "signed_rank": {
+                  "n": 25,
+                  "w": 174.0,
+                  "z": 0.296,
+                  "p_value": 0.767248
+                },
+                "bootstrap": {
+                  "point": -0.0864,
+                  "lo": -0.50301,
+                  "hi": 0.2938,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 23,
+              "control_mean_net_pct": -0.0764,
+              "candidate_mean_net_pct": -0.2062,
+              "control_total_net_pct": -1.7573,
+              "candidate_total_net_pct": -4.7423,
+              "control_win_rate": 0.6522,
+              "candidate_win_rate": 0.4348,
+              "delta_win_rate": -0.2174,
+              "control_median_mae_pct": -0.9083,
+              "candidate_median_mae_pct": -1.4425,
+              "control_median_mfe_pct": 1.1536,
+              "candidate_median_mfe_pct": 1.2532,
+              "paired_delta": {
+                "n": 23,
+                "mean": -0.129783,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 23,
+                  "n_pos": 12,
+                  "n_neg": 11,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 23,
+                  "w": 125.0,
+                  "z": -0.3802,
+                  "p_value": 0.703807
+                },
+                "bootstrap": {
+                  "point": -0.129783,
+                  "lo": -0.476092,
+                  "hi": 0.210223,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 9,
+          "entries": 7,
+          "win_rate": 0.1429,
+          "mean_net_pct": -2.6858,
+          "total_net_pct": -18.8007,
+          "total_return_pct": -17.51,
+          "max_drawdown_pct": -18.95,
+          "sharpe": -3.014,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 8,
+          "entries": 7,
+          "win_rate": 0.1429,
+          "mean_net_pct": -2.9287,
+          "total_net_pct": -20.5007,
+          "total_return_pct": -19.0,
+          "max_drawdown_pct": -20.41,
+          "sharpe": -2.624,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.242857,
+          "lo": -2.861429,
+          "hi": 2.547143,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 7,
+          "paired": 7,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 7,
+            "control_mean_net_pct": -2.6858,
+            "candidate_mean_net_pct": -2.9287,
+            "control_total_net_pct": -18.8007,
+            "candidate_total_net_pct": -20.5007,
+            "control_win_rate": 0.1429,
+            "candidate_win_rate": 0.1429,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -3.8226,
+            "candidate_median_mae_pct": -3.8226,
+            "control_median_mfe_pct": 0.6397,
+            "candidate_median_mfe_pct": 0.6397,
+            "paired_delta": {
+              "n": 7,
+              "mean": -0.242857,
+              "median": 0.0,
+              "sign_test": {
+                "n": 6,
+                "n_pos": 3,
+                "n_neg": 3,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 6,
+                "w": 10.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": -0.242857,
+                "lo": -1.311429,
+                "hi": 0.582857,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": -4.5101,
+              "candidate_mean_net_pct": -4.5101,
+              "control_total_net_pct": -9.0202,
+              "candidate_total_net_pct": -9.0202,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -5.5887,
+              "candidate_median_mae_pct": -5.5887,
+              "control_median_mfe_pct": 0.9683,
+              "candidate_median_mfe_pct": 0.9683,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.0,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 0,
+                  "n_neg": 1,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.0,
+                  "lo": -0.0,
+                  "hi": 0.0,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 5,
+              "control_mean_net_pct": -1.9561,
+              "candidate_mean_net_pct": -2.2961,
+              "control_total_net_pct": -9.7805,
+              "candidate_total_net_pct": -11.4805,
+              "control_win_rate": 0.2,
+              "candidate_win_rate": 0.2,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -3.5262,
+              "candidate_median_mae_pct": -3.5262,
+              "control_median_mfe_pct": 0.6397,
+              "candidate_median_mfe_pct": 0.6397,
+              "paired_delta": {
+                "n": 5,
+                "mean": -0.34,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 5,
+                  "n_pos": 3,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 5,
+                  "w": 9.0,
+                  "z": 0.2697,
+                  "p_value": 0.787406
+                },
+                "bootstrap": {
+                  "point": -0.34,
+                  "lo": -1.836,
+                  "hi": 0.816,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 68,
+          "entries": 49,
+          "win_rate": 0.449,
+          "mean_net_pct": -0.5095,
+          "total_net_pct": -24.9649,
+          "total_return_pct": -22.69,
+          "max_drawdown_pct": -26.27,
+          "sharpe": -2.152,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 64,
+          "entries": 46,
+          "win_rate": 0.3478,
+          "mean_net_pct": -0.6773,
+          "total_net_pct": -31.1546,
+          "total_return_pct": -27.57,
+          "max_drawdown_pct": -32.86,
+          "sharpe": -2.622,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.167786,
+          "lo": -1.011001,
+          "hi": 0.67736,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 49,
+          "paired": 49,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 49,
+            "control_mean_net_pct": -0.5095,
+            "candidate_mean_net_pct": -0.5471,
+            "control_total_net_pct": -24.9649,
+            "candidate_total_net_pct": -26.8099,
+            "control_win_rate": 0.449,
+            "candidate_win_rate": 0.3673,
+            "delta_win_rate": -0.0817,
+            "control_median_mae_pct": -1.2764,
+            "candidate_median_mae_pct": -1.6822,
+            "control_median_mfe_pct": 0.9974,
+            "candidate_median_mfe_pct": 1.2356,
+            "paired_delta": {
+              "n": 49,
+              "mean": -0.037653,
+              "median": 0.0,
+              "sign_test": {
+                "n": 49,
+                "n_pos": 25,
+                "n_neg": 24,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 49,
+                "w": 638.0,
+                "z": 0.2487,
+                "p_value": 0.803606
+              },
+              "bootstrap": {
+                "point": -0.037653,
+                "lo": -0.322041,
+                "hi": 0.236839,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 25,
+              "control_mean_net_pct": -0.6701,
+              "candidate_mean_net_pct": -0.8543,
+              "control_total_net_pct": -16.7525,
+              "candidate_total_net_pct": -21.3575,
+              "control_win_rate": 0.44,
+              "candidate_win_rate": 0.32,
+              "delta_win_rate": -0.12,
+              "control_median_mae_pct": -1.3082,
+              "candidate_median_mae_pct": -1.7763,
+              "control_median_mfe_pct": 0.9527,
+              "candidate_median_mfe_pct": 0.9527,
+              "paired_delta": {
+                "n": 25,
+                "mean": -0.1842,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 25,
+                  "n_pos": 14,
+                  "n_neg": 11,
+                  "n_zero": 0,
+                  "p_value": 0.690038
+                },
+                "signed_rank": {
+                  "n": 25,
+                  "w": 161.0,
+                  "z": -0.0269,
+                  "p_value": 0.978534
+                },
+                "bootstrap": {
+                  "point": -0.1842,
+                  "lo": -0.566005,
+                  "hi": 0.175815,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 24,
+              "control_mean_net_pct": -0.3422,
+              "candidate_mean_net_pct": -0.2272,
+              "control_total_net_pct": -8.2124,
+              "candidate_total_net_pct": -5.4524,
+              "control_win_rate": 0.4583,
+              "candidate_win_rate": 0.4167,
+              "delta_win_rate": -0.0416,
+              "control_median_mae_pct": -1.2302,
+              "candidate_median_mae_pct": -1.4793,
+              "control_median_mfe_pct": 1.1165,
+              "candidate_median_mfe_pct": 1.3398,
+              "paired_delta": {
+                "n": 24,
+                "mean": 0.115,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 24,
+                  "n_pos": 11,
+                  "n_neg": 13,
+                  "n_zero": 0,
+                  "p_value": 0.83882
+                },
+                "signed_rank": {
+                  "n": 24,
+                  "w": 164.0,
+                  "z": 0.3857,
+                  "p_value": 0.699708
+                },
+                "bootstrap": {
+                  "point": 0.115,
+                  "lo": -0.286042,
+                  "hi": 0.493969,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 12,
+          "entries": 10,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.3326,
+          "total_net_pct": -3.326,
+          "total_return_pct": -3.88,
+          "max_drawdown_pct": -13.5,
+          "sharpe": -0.404,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 13,
+          "entries": 9,
+          "win_rate": 0.1111,
+          "mean_net_pct": -2.384,
+          "total_net_pct": -21.4559,
+          "total_return_pct": -19.73,
+          "max_drawdown_pct": -21.3,
+          "sharpe": -2.358,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -2.051389,
+          "lo": -4.646203,
+          "hi": 0.640386,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 10,
+          "paired": 10,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 10,
+            "control_mean_net_pct": -0.3326,
+            "candidate_mean_net_pct": -1.5996,
+            "control_total_net_pct": -3.326,
+            "candidate_total_net_pct": -15.996,
+            "control_win_rate": 0.5,
+            "candidate_win_rate": 0.2,
+            "delta_win_rate": -0.3,
+            "control_median_mae_pct": -2.3312,
+            "candidate_median_mae_pct": -4.0431,
+            "control_median_mfe_pct": 2.7535,
+            "candidate_median_mfe_pct": 2.9732,
+            "paired_delta": {
+              "n": 10,
+              "mean": -1.267,
+              "median": -0.0,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 4,
+                "n_neg": 5,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 13.0,
+                "z": -1.0662,
+                "p_value": 0.286321
+              },
+              "bootstrap": {
+                "point": -1.267,
+                "lo": -2.815525,
+                "hi": 0.099225,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 5,
+              "control_mean_net_pct": -2.1461,
+              "candidate_mean_net_pct": -2.1821,
+              "control_total_net_pct": -10.7305,
+              "candidate_total_net_pct": -10.9105,
+              "control_win_rate": 0.2,
+              "candidate_win_rate": 0.2,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -3.3332,
+              "candidate_median_mae_pct": -3.3332,
+              "control_median_mfe_pct": 1.5435,
+              "candidate_median_mfe_pct": 1.5435,
+              "paired_delta": {
+                "n": 5,
+                "mean": -0.036,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 5,
+                  "n_pos": 3,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 5,
+                  "w": 8.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.036,
+                  "lo": -1.476,
+                  "hi": 1.368,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 5,
+              "control_mean_net_pct": 1.4809,
+              "candidate_mean_net_pct": -1.0171,
+              "control_total_net_pct": 7.4045,
+              "candidate_total_net_pct": -5.0855,
+              "control_win_rate": 0.8,
+              "candidate_win_rate": 0.2,
+              "delta_win_rate": -0.6,
+              "control_median_mae_pct": -0.2472,
+              "candidate_median_mae_pct": -4.2082,
+              "control_median_mfe_pct": 3.0589,
+              "candidate_median_mfe_pct": 3.4338,
+              "paired_delta": {
+                "n": 5,
+                "mean": -2.498,
+                "median": -2.88,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 1,
+                  "n_neg": 3,
+                  "n_zero": 1,
+                  "p_value": 0.625
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 1.0,
+                  "z": -1.278,
+                  "p_value": 0.201243
+                },
+                "bootstrap": {
+                  "point": -2.498,
+                  "lo": -4.552,
+                  "hi": -0.444,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 59,
+          "entries": 42,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.4747,
+          "total_net_pct": -19.9392,
+          "total_return_pct": -18.34,
+          "max_drawdown_pct": -21.05,
+          "sharpe": -3.174,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 60,
+          "entries": 41,
+          "win_rate": 0.4146,
+          "mean_net_pct": -0.4022,
+          "total_net_pct": -16.4891,
+          "total_return_pct": -15.57,
+          "max_drawdown_pct": -20.52,
+          "sharpe": -2.38,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.07257,
+          "lo": -0.487308,
+          "hi": 0.627148,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 42,
+          "paired": 42,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 42,
+            "control_mean_net_pct": -0.4747,
+            "candidate_mean_net_pct": -0.414,
+            "control_total_net_pct": -19.9392,
+            "candidate_total_net_pct": -17.3892,
+            "control_win_rate": 0.5,
+            "candidate_win_rate": 0.4048,
+            "delta_win_rate": -0.0952,
+            "control_median_mae_pct": -0.9445,
+            "candidate_median_mae_pct": -1.1914,
+            "control_median_mfe_pct": 0.6232,
+            "candidate_median_mfe_pct": 0.7043,
+            "paired_delta": {
+              "n": 42,
+              "mean": 0.060714,
+              "median": 0.0,
+              "sign_test": {
+                "n": 42,
+                "n_pos": 27,
+                "n_neg": 15,
+                "n_zero": 0,
+                "p_value": 0.08843
+              },
+              "signed_rank": {
+                "n": 42,
+                "w": 568.0,
+                "z": 1.4504,
+                "p_value": 0.14694
+              },
+              "bootstrap": {
+                "point": 0.060714,
+                "lo": -0.089524,
+                "hi": 0.207146,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 25,
+              "control_mean_net_pct": -0.3383,
+              "candidate_mean_net_pct": -0.2305,
+              "control_total_net_pct": -8.4575,
+              "candidate_total_net_pct": -5.7625,
+              "control_win_rate": 0.56,
+              "candidate_win_rate": 0.48,
+              "delta_win_rate": -0.08,
+              "control_median_mae_pct": -0.6155,
+              "candidate_median_mae_pct": -1.0814,
+              "control_median_mfe_pct": 0.6445,
+              "candidate_median_mfe_pct": 1.4601,
+              "paired_delta": {
+                "n": 25,
+                "mean": 0.1078,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 25,
+                  "n_pos": 17,
+                  "n_neg": 8,
+                  "n_zero": 0,
+                  "p_value": 0.107752
+                },
+                "signed_rank": {
+                  "n": 25,
+                  "w": 219.0,
+                  "z": 1.5068,
+                  "p_value": 0.131865
+                },
+                "bootstrap": {
+                  "point": 0.1078,
+                  "lo": -0.0974,
+                  "hi": 0.295805,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 17,
+              "control_mean_net_pct": -0.6754,
+              "candidate_mean_net_pct": -0.6839,
+              "control_total_net_pct": -11.4817,
+              "candidate_total_net_pct": -11.6267,
+              "control_win_rate": 0.4118,
+              "candidate_win_rate": 0.2941,
+              "delta_win_rate": -0.1177,
+              "control_median_mae_pct": -1.2588,
+              "candidate_median_mae_pct": -1.2676,
+              "control_median_mfe_pct": 0.5041,
+              "candidate_median_mfe_pct": 0.6125,
+              "paired_delta": {
+                "n": 17,
+                "mean": -0.008529,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 17,
+                  "n_pos": 10,
+                  "n_neg": 7,
+                  "n_zero": 0,
+                  "p_value": 0.629059
+                },
+                "signed_rank": {
+                  "n": 17,
+                  "w": 85.0,
+                  "z": 0.3787,
+                  "p_value": 0.704907
+                },
+                "bootstrap": {
+                  "point": -0.008529,
+                  "lo": -0.234125,
+                  "hi": 0.217654,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 8,
+          "entries": 4,
+          "win_rate": 1.0,
+          "mean_net_pct": 1.1674,
+          "total_net_pct": 4.6696,
+          "total_return_pct": 4.75,
+          "max_drawdown_pct": -0.93,
+          "sharpe": 2.208,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 6,
+          "entries": 4,
+          "win_rate": 0.75,
+          "mean_net_pct": 1.4586,
+          "total_net_pct": 5.8346,
+          "total_return_pct": 5.92,
+          "max_drawdown_pct": -2.65,
+          "sharpe": 1.985,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.29125,
+          "lo": -1.265,
+          "hi": 1.57375,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 4,
+          "paired": 4,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 4,
+            "control_mean_net_pct": 1.1674,
+            "candidate_mean_net_pct": 1.4586,
+            "control_total_net_pct": 4.6696,
+            "candidate_total_net_pct": 5.8346,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 0.75,
+            "delta_win_rate": -0.25,
+            "control_median_mae_pct": -0.5581,
+            "candidate_median_mae_pct": -0.871,
+            "control_median_mfe_pct": 2.1468,
+            "candidate_median_mfe_pct": 2.1993,
+            "paired_delta": {
+              "n": 4,
+              "mean": 0.29125,
+              "median": 0.7475,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 3,
+                "n_neg": 1,
+                "n_zero": 0,
+                "p_value": 0.625
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 6.0,
+                "z": 0.1826,
+                "p_value": 0.855132
+              },
+              "bootstrap": {
+                "point": 0.29125,
+                "lo": -1.05375,
+                "hi": 1.18,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": 1.6399,
+              "candidate_mean_net_pct": 3.0099,
+              "control_total_net_pct": 1.6399,
+              "candidate_total_net_pct": 3.0099,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.511,
+              "candidate_median_mae_pct": -0.511,
+              "control_median_mfe_pct": 2.3552,
+              "candidate_median_mfe_pct": 5.0756,
+              "paired_delta": {
+                "n": 1,
+                "mean": 1.37,
+                "median": 1.37,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 1.37,
+                  "lo": 1.37,
+                  "hi": 1.37,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 3,
+              "control_mean_net_pct": 1.0099,
+              "candidate_mean_net_pct": 0.9416,
+              "control_total_net_pct": 3.0297,
+              "candidate_total_net_pct": 2.8247,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": -0.3333,
+              "control_median_mae_pct": -0.6052,
+              "candidate_median_mae_pct": -1.1369,
+              "control_median_mfe_pct": 1.9385,
+              "candidate_median_mfe_pct": 1.9385,
+              "paired_delta": {
+                "n": 3,
+                "mean": -0.068333,
+                "median": 0.61,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 2,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 3.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.068333,
+                  "lo": -1.7,
+                  "hi": 0.885,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 57,
+          "entries": 43,
+          "win_rate": 0.5349,
+          "mean_net_pct": -0.2973,
+          "total_net_pct": -12.7843,
+          "total_return_pct": -12.59,
+          "max_drawdown_pct": -20.99,
+          "sharpe": -1.312,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 51,
+          "entries": 39,
+          "win_rate": 0.4359,
+          "mean_net_pct": -0.1856,
+          "total_net_pct": -7.2389,
+          "total_return_pct": -7.78,
+          "max_drawdown_pct": -18.89,
+          "sharpe": -0.677,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.111696,
+          "lo": -0.740812,
+          "hi": 0.954669,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 43,
+          "paired": 43,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 43,
+            "control_mean_net_pct": -0.2973,
+            "candidate_mean_net_pct": -0.1493,
+            "control_total_net_pct": -12.7843,
+            "candidate_total_net_pct": -6.4193,
+            "control_win_rate": 0.5349,
+            "candidate_win_rate": 0.4419,
+            "delta_win_rate": -0.093,
+            "control_median_mae_pct": -1.2037,
+            "candidate_median_mae_pct": -1.4707,
+            "control_median_mfe_pct": 1.3391,
+            "candidate_median_mfe_pct": 1.5911,
+            "paired_delta": {
+              "n": 43,
+              "mean": 0.148023,
+              "median": 0.0,
+              "sign_test": {
+                "n": 42,
+                "n_pos": 23,
+                "n_neg": 19,
+                "n_zero": 1,
+                "p_value": 0.643969
+              },
+              "signed_rank": {
+                "n": 42,
+                "w": 565.0,
+                "z": 1.4129,
+                "p_value": 0.157681
+              },
+              "bootstrap": {
+                "point": 0.148023,
+                "lo": -0.064538,
+                "hi": 0.354076,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 23,
+              "control_mean_net_pct": -0.4944,
+              "candidate_mean_net_pct": -0.3773,
+              "control_total_net_pct": -11.3723,
+              "candidate_total_net_pct": -8.6773,
+              "control_win_rate": 0.4348,
+              "candidate_win_rate": 0.3913,
+              "delta_win_rate": -0.0435,
+              "control_median_mae_pct": -1.3081,
+              "candidate_median_mae_pct": -1.582,
+              "control_median_mfe_pct": 0.585,
+              "candidate_median_mfe_pct": 0.585,
+              "paired_delta": {
+                "n": 23,
+                "mean": 0.117174,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 23,
+                  "n_pos": 10,
+                  "n_neg": 13,
+                  "n_zero": 0,
+                  "p_value": 0.677639
+                },
+                "signed_rank": {
+                  "n": 23,
+                  "w": 144.0,
+                  "z": 0.1673,
+                  "p_value": 0.867148
+                },
+                "bootstrap": {
+                  "point": 0.117174,
+                  "lo": -0.111745,
+                  "hi": 0.347391,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 20,
+              "control_mean_net_pct": -0.0706,
+              "candidate_mean_net_pct": 0.1129,
+              "control_total_net_pct": -1.412,
+              "candidate_total_net_pct": 2.258,
+              "control_win_rate": 0.65,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": -0.15,
+              "control_median_mae_pct": -1.192,
+              "candidate_median_mae_pct": -1.3847,
+              "control_median_mfe_pct": 1.4409,
+              "candidate_median_mfe_pct": 1.8116,
+              "paired_delta": {
+                "n": 20,
+                "mean": 0.1835,
+                "median": 0.01,
+                "sign_test": {
+                  "n": 19,
+                  "n_pos": 13,
+                  "n_neg": 6,
+                  "n_zero": 1,
+                  "p_value": 0.167068
+                },
+                "signed_rank": {
+                  "n": 19,
+                  "w": 132.0,
+                  "z": 1.4688,
+                  "p_value": 0.141876
+                },
+                "bootstrap": {
+                  "point": 0.1835,
+                  "lo": -0.192006,
+                  "hi": 0.537506,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 9,
+          "entries": 5,
+          "win_rate": 0.6,
+          "mean_net_pct": 0.0459,
+          "total_net_pct": 0.2295,
+          "total_return_pct": 0.11,
+          "max_drawdown_pct": -6.47,
+          "sharpe": 0.073,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 8,
+          "entries": 5,
+          "win_rate": 0.4,
+          "mean_net_pct": -1.4291,
+          "total_net_pct": -7.1455,
+          "total_return_pct": -7.4,
+          "max_drawdown_pct": -13.59,
+          "sharpe": -1.237,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -1.475,
+          "lo": -5.786,
+          "hi": 2.977,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 5,
+          "paired": 5,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 5,
+            "control_mean_net_pct": 0.0459,
+            "candidate_mean_net_pct": -1.4291,
+            "control_total_net_pct": 0.2295,
+            "candidate_total_net_pct": -7.1455,
+            "control_win_rate": 0.6,
+            "candidate_win_rate": 0.4,
+            "delta_win_rate": -0.2,
+            "control_median_mae_pct": -0.7333,
+            "candidate_median_mae_pct": -4.898,
+            "control_median_mfe_pct": 2.7084,
+            "candidate_median_mfe_pct": 3.5365,
+            "paired_delta": {
+              "n": 5,
+              "mean": -1.475,
+              "median": -2.69,
+              "sign_test": {
+                "n": 5,
+                "n_pos": 2,
+                "n_neg": 3,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 5,
+                "w": 3.0,
+                "z": -1.0787,
+                "p_value": 0.280713
+              },
+              "bootstrap": {
+                "point": -1.475,
+                "lo": -3.422,
+                "hi": 0.513,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": -1.8001,
+              "candidate_mean_net_pct": -4.4901,
+              "control_total_net_pct": -1.8001,
+              "candidate_total_net_pct": -4.4901,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -4.898,
+              "candidate_median_mae_pct": -4.898,
+              "control_median_mfe_pct": 2.7084,
+              "candidate_median_mfe_pct": 2.7084,
+              "paired_delta": {
+                "n": 1,
+                "mean": -2.69,
+                "median": -2.69,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 0,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -2.69,
+                  "lo": -2.69,
+                  "hi": -2.69,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 4,
+              "control_mean_net_pct": 0.5074,
+              "candidate_mean_net_pct": -0.6639,
+              "control_total_net_pct": 2.0296,
+              "candidate_total_net_pct": -2.6554,
+              "control_win_rate": 0.75,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": -0.25,
+              "control_median_mae_pct": -0.6082,
+              "candidate_median_mae_pct": -3.3781,
+              "control_median_mfe_pct": 2.694,
+              "candidate_median_mfe_pct": 3.947,
+              "paired_delta": {
+                "n": 4,
+                "mean": -1.17125,
+                "median": -0.9075,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 2,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 3.0,
+                  "z": -0.5477,
+                  "p_value": 0.583882
+                },
+                "bootstrap": {
+                  "point": -1.17125,
+                  "lo": -3.605,
+                  "hi": 1.2625,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 41,
+          "entries": 28,
+          "win_rate": 0.6786,
+          "mean_net_pct": -0.1092,
+          "total_net_pct": -3.0578,
+          "total_return_pct": -3.27,
+          "max_drawdown_pct": -9.16,
+          "sharpe": -0.422,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 43,
+          "entries": 27,
+          "win_rate": 0.4444,
+          "mean_net_pct": -0.0875,
+          "total_net_pct": -2.3627,
+          "total_return_pct": -2.73,
+          "max_drawdown_pct": -11.05,
+          "sharpe": -0.279,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.0217,
+          "lo": -0.792333,
+          "hi": 0.857092,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 28,
+          "paired": 28,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 28,
+            "control_mean_net_pct": -0.1092,
+            "candidate_mean_net_pct": -0.0508,
+            "control_total_net_pct": -3.0578,
+            "candidate_total_net_pct": -1.4228,
+            "control_win_rate": 0.6786,
+            "candidate_win_rate": 0.4643,
+            "delta_win_rate": -0.2143,
+            "control_median_mae_pct": -0.8365,
+            "candidate_median_mae_pct": -1.34,
+            "control_median_mfe_pct": 1.0295,
+            "candidate_median_mfe_pct": 1.8257,
+            "paired_delta": {
+              "n": 28,
+              "mean": 0.058393,
+              "median": 0.0,
+              "sign_test": {
+                "n": 27,
+                "n_pos": 15,
+                "n_neg": 12,
+                "n_zero": 1,
+                "p_value": 0.701108
+              },
+              "signed_rank": {
+                "n": 27,
+                "w": 214.0,
+                "z": 0.5886,
+                "p_value": 0.556121
+              },
+              "bootstrap": {
+                "point": 0.058393,
+                "lo": -0.228219,
+                "hi": 0.341969,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 18,
+              "control_mean_net_pct": -0.0204,
+              "candidate_mean_net_pct": -0.097,
+              "control_total_net_pct": -0.3668,
+              "candidate_total_net_pct": -1.7468,
+              "control_win_rate": 0.7778,
+              "candidate_win_rate": 0.4444,
+              "delta_win_rate": -0.3334,
+              "control_median_mae_pct": -0.6006,
+              "candidate_median_mae_pct": -1.5315,
+              "control_median_mfe_pct": 1.1168,
+              "candidate_median_mfe_pct": 2.015,
+              "paired_delta": {
+                "n": 18,
+                "mean": -0.076667,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 18,
+                  "n_pos": 9,
+                  "n_neg": 9,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 18,
+                  "w": 81.0,
+                  "z": -0.1742,
+                  "p_value": 0.861707
+                },
+                "bootstrap": {
+                  "point": -0.076667,
+                  "lo": -0.47057,
+                  "hi": 0.289174,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 10,
+              "control_mean_net_pct": -0.2691,
+              "candidate_mean_net_pct": 0.0324,
+              "control_total_net_pct": -2.691,
+              "candidate_total_net_pct": 0.324,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1592,
+              "candidate_median_mae_pct": -1.1592,
+              "control_median_mfe_pct": 0.7911,
+              "candidate_median_mfe_pct": 1.2472,
+              "paired_delta": {
+                "n": 10,
+                "mean": 0.3015,
+                "median": 0.1025,
+                "sign_test": {
+                  "n": 9,
+                  "n_pos": 6,
+                  "n_neg": 3,
+                  "n_zero": 1,
+                  "p_value": 0.507812
+                },
+                "signed_rank": {
+                  "n": 9,
+                  "w": 36.0,
+                  "z": 1.5401,
+                  "p_value": 0.123534
+                },
+                "bootstrap": {
+                  "point": 0.3015,
+                  "lo": -0.045537,
+                  "hi": 0.68,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 13,
+          "entries": 10,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.4501,
+          "total_net_pct": -4.501,
+          "total_return_pct": -4.88,
+          "max_drawdown_pct": -9.46,
+          "sharpe": -0.657,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 15,
+          "entries": 10,
+          "win_rate": 0.3,
+          "mean_net_pct": -1.1461,
+          "total_net_pct": -11.461,
+          "total_return_pct": -11.45,
+          "max_drawdown_pct": -14.62,
+          "sharpe": -1.269,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.696,
+          "lo": -3.567575,
+          "hi": 2.299525,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 10,
+          "paired": 10,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 10,
+            "control_mean_net_pct": -0.4501,
+            "candidate_mean_net_pct": -1.1461,
+            "control_total_net_pct": -4.501,
+            "candidate_total_net_pct": -11.461,
+            "control_win_rate": 0.5,
+            "candidate_win_rate": 0.3,
+            "delta_win_rate": -0.2,
+            "control_median_mae_pct": -2.2254,
+            "candidate_median_mae_pct": -3.3191,
+            "control_median_mfe_pct": 2.4284,
+            "candidate_median_mfe_pct": 2.9819,
+            "paired_delta": {
+              "n": 10,
+              "mean": -0.696,
+              "median": 0.0,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 5,
+                "n_neg": 4,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 17.0,
+                "z": -0.5923,
+                "p_value": 0.553617
+              },
+              "bootstrap": {
+                "point": -0.696,
+                "lo": -1.934,
+                "hi": 0.463525,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 5,
+              "control_mean_net_pct": 0.7389,
+              "candidate_mean_net_pct": -1.0431,
+              "control_total_net_pct": 3.6945,
+              "candidate_total_net_pct": -5.2155,
+              "control_win_rate": 0.6,
+              "candidate_win_rate": 0.2,
+              "delta_win_rate": -0.4,
+              "control_median_mae_pct": -0.7655,
+              "candidate_median_mae_pct": -3.8059,
+              "control_median_mfe_pct": 2.7496,
+              "candidate_median_mfe_pct": 3.8568,
+              "paired_delta": {
+                "n": 5,
+                "mean": -1.782,
+                "median": -2.36,
+                "sign_test": {
+                  "n": 5,
+                  "n_pos": 1,
+                  "n_neg": 4,
+                  "n_zero": 0,
+                  "p_value": 0.375
+                },
+                "signed_rank": {
+                  "n": 5,
+                  "w": 2.0,
+                  "z": -1.3484,
+                  "p_value": 0.17753
+                },
+                "bootstrap": {
+                  "point": -1.782,
+                  "lo": -3.409,
+                  "hi": 0.349925,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 5,
+              "control_mean_net_pct": -1.6391,
+              "candidate_mean_net_pct": -1.2491,
+              "control_total_net_pct": -8.1955,
+              "candidate_total_net_pct": -6.2455,
+              "control_win_rate": 0.4,
+              "candidate_win_rate": 0.4,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.8324,
+              "candidate_median_mae_pct": -2.8324,
+              "control_median_mfe_pct": 2.1071,
+              "candidate_median_mfe_pct": 2.1071,
+              "paired_delta": {
+                "n": 5,
+                "mean": 0.39,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 4,
+                  "n_neg": 0,
+                  "n_zero": 1,
+                  "p_value": 0.125
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 10.0,
+                  "z": 1.6432,
+                  "p_value": 0.100348
+                },
+                "bootstrap": {
+                  "point": 0.39,
+                  "lo": 0.0,
+                  "hi": 1.062,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/mr.b2_rq_wider.json
+++ b/backtest/research/regime_1152_runs/mr.b2_rq_wider.json
@@ -1,0 +1,541 @@
+{
+  "open": {
+    "name": "mean_reversion",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "tiered_tp_atr_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "tiered_tp_atr",
+      "params": {
+        "tp_tiers": [
+          {
+            "atr_multiple": 0.75,
+            "close_fraction": 0.5
+          },
+          {
+            "atr_multiple": 1.5,
+            "close_fraction": 1.0
+          }
+        ]
+      }
+    }
+  ],
+  "control_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_quiet"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/mr.b2_rv_patient3.json
+++ b/backtest/research/regime_1152_runs/mr.b2_rv_patient3.json
@@ -1,0 +1,1493 @@
+{
+  "open": {
+    "name": "mean_reversion",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "tiered_tp_atr_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "tiered_tp_atr",
+      "params": {
+        "tp_tiers": [
+          {
+            "atr_multiple": 1.0,
+            "close_fraction": 0.4
+          },
+          {
+            "atr_multiple": 2.0,
+            "close_fraction": 0.8
+          },
+          {
+            "atr_multiple": 3.0,
+            "close_fraction": 1.0
+          }
+        ]
+      }
+    }
+  ],
+  "control_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_volatile"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 137,
+          "entries": 95,
+          "win_rate": 0.4947,
+          "mean_net_pct": -0.2988,
+          "total_net_pct": -28.3845,
+          "total_return_pct": -24.94,
+          "max_drawdown_pct": -26.31,
+          "sharpe": -3.289,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 132,
+          "entries": 65,
+          "win_rate": 0.4308,
+          "mean_net_pct": -0.2815,
+          "total_net_pct": -18.2966,
+          "total_return_pct": -16.97,
+          "max_drawdown_pct": -18.55,
+          "sharpe": -2.235,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.017298,
+          "lo": -0.314285,
+          "hi": 0.343606,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 95,
+          "paired": 95,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 95,
+            "control_mean_net_pct": -0.2988,
+            "candidate_mean_net_pct": -0.2951,
+            "control_total_net_pct": -28.3845,
+            "candidate_total_net_pct": -28.0316,
+            "control_win_rate": 0.4947,
+            "candidate_win_rate": 0.4,
+            "delta_win_rate": -0.0947,
+            "control_median_mae_pct": -0.595,
+            "candidate_median_mae_pct": -0.8629,
+            "control_median_mfe_pct": 0.5631,
+            "candidate_median_mfe_pct": 0.929,
+            "paired_delta": {
+              "n": 95,
+              "mean": 0.003715,
+              "median": 0.0,
+              "sign_test": {
+                "n": 95,
+                "n_pos": 52,
+                "n_neg": 43,
+                "n_zero": 0,
+                "p_value": 0.41191
+              },
+              "signed_rank": {
+                "n": 95,
+                "w": 2431.0,
+                "z": 0.5586,
+                "p_value": 0.576411
+              },
+              "bootstrap": {
+                "point": 0.003715,
+                "lo": -0.133457,
+                "hi": 0.137968,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 95,
+              "control_mean_net_pct": -0.2988,
+              "candidate_mean_net_pct": -0.2951,
+              "control_total_net_pct": -28.3845,
+              "candidate_total_net_pct": -28.0316,
+              "control_win_rate": 0.4947,
+              "candidate_win_rate": 0.4,
+              "delta_win_rate": -0.0947,
+              "control_median_mae_pct": -0.595,
+              "candidate_median_mae_pct": -0.8629,
+              "control_median_mfe_pct": 0.5631,
+              "candidate_median_mfe_pct": 0.929,
+              "paired_delta": {
+                "n": 95,
+                "mean": 0.003715,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 95,
+                  "n_pos": 52,
+                  "n_neg": 43,
+                  "n_zero": 0,
+                  "p_value": 0.41191
+                },
+                "signed_rank": {
+                  "n": 95,
+                  "w": 2431.0,
+                  "z": 0.5586,
+                  "p_value": 0.576411
+                },
+                "bootstrap": {
+                  "point": 0.003715,
+                  "lo": -0.133457,
+                  "hi": 0.137968,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 33,
+          "entries": 25,
+          "win_rate": 0.44,
+          "mean_net_pct": -0.8159,
+          "total_net_pct": -20.3976,
+          "total_return_pct": -18.98,
+          "max_drawdown_pct": -19.87,
+          "sharpe": -2.438,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 30,
+          "entries": 20,
+          "win_rate": 0.35,
+          "mean_net_pct": -0.6965,
+          "total_net_pct": -13.93,
+          "total_return_pct": -13.51,
+          "max_drawdown_pct": -18.28,
+          "sharpe": -1.573,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.1194,
+          "lo": -1.267408,
+          "hi": 1.576507,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 25,
+          "paired": 25,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 25,
+            "control_mean_net_pct": -0.8159,
+            "candidate_mean_net_pct": -0.7855,
+            "control_total_net_pct": -20.3976,
+            "candidate_total_net_pct": -19.6385,
+            "control_win_rate": 0.44,
+            "candidate_win_rate": 0.36,
+            "delta_win_rate": -0.08,
+            "control_median_mae_pct": -1.3401,
+            "candidate_median_mae_pct": -1.7105,
+            "control_median_mfe_pct": 0.8767,
+            "candidate_median_mfe_pct": 0.8767,
+            "paired_delta": {
+              "n": 25,
+              "mean": 0.03036,
+              "median": -0.0,
+              "sign_test": {
+                "n": 24,
+                "n_pos": 11,
+                "n_neg": 13,
+                "n_zero": 1,
+                "p_value": 0.83882
+              },
+              "signed_rank": {
+                "n": 24,
+                "w": 136.0,
+                "z": -0.3857,
+                "p_value": 0.699708
+              },
+              "bootstrap": {
+                "point": 0.03036,
+                "lo": -0.309489,
+                "hi": 0.365681,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 25,
+              "control_mean_net_pct": -0.8159,
+              "candidate_mean_net_pct": -0.7855,
+              "control_total_net_pct": -20.3976,
+              "candidate_total_net_pct": -19.6385,
+              "control_win_rate": 0.44,
+              "candidate_win_rate": 0.36,
+              "delta_win_rate": -0.08,
+              "control_median_mae_pct": -1.3401,
+              "candidate_median_mae_pct": -1.7105,
+              "control_median_mfe_pct": 0.8767,
+              "candidate_median_mfe_pct": 0.8767,
+              "paired_delta": {
+                "n": 25,
+                "mean": 0.03036,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 24,
+                  "n_pos": 11,
+                  "n_neg": 13,
+                  "n_zero": 1,
+                  "p_value": 0.83882
+                },
+                "signed_rank": {
+                  "n": 24,
+                  "w": 136.0,
+                  "z": -0.3857,
+                  "p_value": 0.699708
+                },
+                "bootstrap": {
+                  "point": 0.03036,
+                  "lo": -0.309489,
+                  "hi": 0.365681,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 142,
+          "entries": 96,
+          "win_rate": 0.625,
+          "mean_net_pct": -0.0395,
+          "total_net_pct": -3.7896,
+          "total_return_pct": -4.59,
+          "max_drawdown_pct": -21.81,
+          "sharpe": -0.215,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 161,
+          "entries": 69,
+          "win_rate": 0.5507,
+          "mean_net_pct": -0.0047,
+          "total_net_pct": -0.3249,
+          "total_return_pct": -1.5,
+          "max_drawdown_pct": -18.73,
+          "sharpe": 0.031,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.034766,
+          "lo": -0.498464,
+          "hi": 0.579733,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 96,
+          "paired": 96,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 96,
+            "control_mean_net_pct": -0.0395,
+            "candidate_mean_net_pct": 0.0385,
+            "control_total_net_pct": -3.7896,
+            "candidate_total_net_pct": 3.6964,
+            "control_win_rate": 0.625,
+            "candidate_win_rate": 0.5312,
+            "delta_win_rate": -0.0938,
+            "control_median_mae_pct": -0.6854,
+            "candidate_median_mae_pct": -1.1612,
+            "control_median_mfe_pct": 1.0829,
+            "candidate_median_mfe_pct": 1.9285,
+            "paired_delta": {
+              "n": 96,
+              "mean": 0.077979,
+              "median": 0.0,
+              "sign_test": {
+                "n": 96,
+                "n_pos": 58,
+                "n_neg": 38,
+                "n_zero": 0,
+                "p_value": 0.051911
+              },
+              "signed_rank": {
+                "n": 96,
+                "w": 2698.0,
+                "z": 1.3503,
+                "p_value": 0.17693
+              },
+              "bootstrap": {
+                "point": 0.077979,
+                "lo": -0.125689,
+                "hi": 0.279207,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 96,
+              "control_mean_net_pct": -0.0395,
+              "candidate_mean_net_pct": 0.0385,
+              "control_total_net_pct": -3.7896,
+              "candidate_total_net_pct": 3.6964,
+              "control_win_rate": 0.625,
+              "candidate_win_rate": 0.5312,
+              "delta_win_rate": -0.0938,
+              "control_median_mae_pct": -0.6854,
+              "candidate_median_mae_pct": -1.1612,
+              "control_median_mfe_pct": 1.0829,
+              "candidate_median_mfe_pct": 1.9285,
+              "paired_delta": {
+                "n": 96,
+                "mean": 0.077979,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 96,
+                  "n_pos": 58,
+                  "n_neg": 38,
+                  "n_zero": 0,
+                  "p_value": 0.051911
+                },
+                "signed_rank": {
+                  "n": 96,
+                  "w": 2698.0,
+                  "z": 1.3503,
+                  "p_value": 0.17693
+                },
+                "bootstrap": {
+                  "point": 0.077979,
+                  "lo": -0.125689,
+                  "hi": 0.279207,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 27,
+          "entries": 20,
+          "win_rate": 0.6,
+          "mean_net_pct": 0.1539,
+          "total_net_pct": 3.078,
+          "total_return_pct": 2.46,
+          "max_drawdown_pct": -14.78,
+          "sharpe": 0.301,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 28,
+          "entries": 15,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.4701,
+          "total_net_pct": -7.0515,
+          "total_return_pct": -7.72,
+          "max_drawdown_pct": -14.8,
+          "sharpe": -0.525,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.624,
+          "lo": -2.870272,
+          "hi": 1.735759,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 20,
+          "paired": 20,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 20,
+            "control_mean_net_pct": 0.1539,
+            "candidate_mean_net_pct": 0.0529,
+            "control_total_net_pct": 3.078,
+            "candidate_total_net_pct": 1.0579,
+            "control_win_rate": 0.6,
+            "candidate_win_rate": 0.45,
+            "delta_win_rate": -0.15,
+            "control_median_mae_pct": -2.5511,
+            "candidate_median_mae_pct": -3.011,
+            "control_median_mfe_pct": 2.5546,
+            "candidate_median_mfe_pct": 3.3478,
+            "paired_delta": {
+              "n": 20,
+              "mean": -0.101004,
+              "median": -0.0,
+              "sign_test": {
+                "n": 20,
+                "n_pos": 8,
+                "n_neg": 12,
+                "n_zero": 0,
+                "p_value": 0.503445
+              },
+              "signed_rank": {
+                "n": 20,
+                "w": 91.0,
+                "z": -0.504,
+                "p_value": 0.614268
+              },
+              "bootstrap": {
+                "point": -0.101004,
+                "lo": -0.988304,
+                "hi": 0.788694,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 20,
+              "control_mean_net_pct": 0.1539,
+              "candidate_mean_net_pct": 0.0529,
+              "control_total_net_pct": 3.078,
+              "candidate_total_net_pct": 1.0579,
+              "control_win_rate": 0.6,
+              "candidate_win_rate": 0.45,
+              "delta_win_rate": -0.15,
+              "control_median_mae_pct": -2.5511,
+              "candidate_median_mae_pct": -3.011,
+              "control_median_mfe_pct": 2.5546,
+              "candidate_median_mfe_pct": 3.3478,
+              "paired_delta": {
+                "n": 20,
+                "mean": -0.101004,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 20,
+                  "n_pos": 8,
+                  "n_neg": 12,
+                  "n_zero": 0,
+                  "p_value": 0.503445
+                },
+                "signed_rank": {
+                  "n": 20,
+                  "w": 91.0,
+                  "z": -0.504,
+                  "p_value": 0.614268
+                },
+                "bootstrap": {
+                  "point": -0.101004,
+                  "lo": -0.988304,
+                  "hi": 0.788694,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 115,
+          "entries": 86,
+          "win_rate": 0.5698,
+          "mean_net_pct": -0.3173,
+          "total_net_pct": -27.2836,
+          "total_return_pct": -24.74,
+          "max_drawdown_pct": -31.6,
+          "sharpe": -2.033,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 133,
+          "entries": 68,
+          "win_rate": 0.4706,
+          "mean_net_pct": -0.1322,
+          "total_net_pct": -8.9868,
+          "total_return_pct": -9.95,
+          "max_drawdown_pct": -23.89,
+          "sharpe": -0.652,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.185092,
+          "lo": -0.407662,
+          "hi": 0.784727,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 86,
+          "paired": 86,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 86,
+            "control_mean_net_pct": -0.3173,
+            "candidate_mean_net_pct": -0.1814,
+            "control_total_net_pct": -27.2836,
+            "candidate_total_net_pct": -15.5986,
+            "control_win_rate": 0.5698,
+            "candidate_win_rate": 0.4651,
+            "delta_win_rate": -0.1047,
+            "control_median_mae_pct": -0.9399,
+            "candidate_median_mae_pct": -1.3291,
+            "control_median_mfe_pct": 1.0633,
+            "candidate_median_mfe_pct": 1.7335,
+            "paired_delta": {
+              "n": 86,
+              "mean": 0.135872,
+              "median": 0.0,
+              "sign_test": {
+                "n": 86,
+                "n_pos": 52,
+                "n_neg": 34,
+                "n_zero": 0,
+                "p_value": 0.066153
+              },
+              "signed_rank": {
+                "n": 86,
+                "w": 2370.0,
+                "z": 2.1487,
+                "p_value": 0.031659
+              },
+              "bootstrap": {
+                "point": 0.135872,
+                "lo": -0.0452,
+                "hi": 0.318507,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 86,
+              "control_mean_net_pct": -0.3173,
+              "candidate_mean_net_pct": -0.1814,
+              "control_total_net_pct": -27.2836,
+              "candidate_total_net_pct": -15.5986,
+              "control_win_rate": 0.5698,
+              "candidate_win_rate": 0.4651,
+              "delta_win_rate": -0.1047,
+              "control_median_mae_pct": -0.9399,
+              "candidate_median_mae_pct": -1.3291,
+              "control_median_mfe_pct": 1.0633,
+              "candidate_median_mfe_pct": 1.7335,
+              "paired_delta": {
+                "n": 86,
+                "mean": 0.135872,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 86,
+                  "n_pos": 52,
+                  "n_neg": 34,
+                  "n_zero": 0,
+                  "p_value": 0.066153
+                },
+                "signed_rank": {
+                  "n": 86,
+                  "w": 2370.0,
+                  "z": 2.1487,
+                  "p_value": 0.031659
+                },
+                "bootstrap": {
+                  "point": 0.135872,
+                  "lo": -0.0452,
+                  "hi": 0.318507,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 31,
+          "entries": 21,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.5351,
+          "total_net_pct": 11.2379,
+          "total_return_pct": 11.03,
+          "max_drawdown_pct": -9.61,
+          "sharpe": 1.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 25,
+          "entries": 12,
+          "win_rate": 0.5,
+          "mean_net_pct": 0.8691,
+          "total_net_pct": 10.4288,
+          "total_return_pct": 10.03,
+          "max_drawdown_pct": -13.28,
+          "sharpe": 0.914,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.333929,
+          "lo": -2.253667,
+          "hi": 2.903754,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 21,
+          "paired": 21,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 21,
+            "control_mean_net_pct": 0.5351,
+            "candidate_mean_net_pct": 0.7344,
+            "control_total_net_pct": 11.2379,
+            "candidate_total_net_pct": 15.4219,
+            "control_win_rate": 0.6667,
+            "candidate_win_rate": 0.4762,
+            "delta_win_rate": -0.1905,
+            "control_median_mae_pct": -1.9909,
+            "candidate_median_mae_pct": -3.1407,
+            "control_median_mfe_pct": 3.055,
+            "candidate_median_mfe_pct": 4.3404,
+            "paired_delta": {
+              "n": 21,
+              "mean": 0.199238,
+              "median": 0.0,
+              "sign_test": {
+                "n": 21,
+                "n_pos": 15,
+                "n_neg": 6,
+                "n_zero": 0,
+                "p_value": 0.078354
+              },
+              "signed_rank": {
+                "n": 21,
+                "w": 147.0,
+                "z": 1.0775,
+                "p_value": 0.281263
+              },
+              "bootstrap": {
+                "point": 0.199238,
+                "lo": -0.76006,
+                "hi": 1.113586,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 21,
+              "control_mean_net_pct": 0.5351,
+              "candidate_mean_net_pct": 0.7344,
+              "control_total_net_pct": 11.2379,
+              "candidate_total_net_pct": 15.4219,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.4762,
+              "delta_win_rate": -0.1905,
+              "control_median_mae_pct": -1.9909,
+              "candidate_median_mae_pct": -3.1407,
+              "control_median_mfe_pct": 3.055,
+              "candidate_median_mfe_pct": 4.3404,
+              "paired_delta": {
+                "n": 21,
+                "mean": 0.199238,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 21,
+                  "n_pos": 15,
+                  "n_neg": 6,
+                  "n_zero": 0,
+                  "p_value": 0.078354
+                },
+                "signed_rank": {
+                  "n": 21,
+                  "w": 147.0,
+                  "z": 1.0775,
+                  "p_value": 0.281263
+                },
+                "bootstrap": {
+                  "point": 0.199238,
+                  "lo": -0.76006,
+                  "hi": 1.113586,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 85,
+          "entries": 62,
+          "win_rate": 0.5968,
+          "mean_net_pct": -0.0385,
+          "total_net_pct": -2.3862,
+          "total_return_pct": -2.65,
+          "max_drawdown_pct": -6.85,
+          "sharpe": -0.322,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 91,
+          "entries": 42,
+          "win_rate": 0.5476,
+          "mean_net_pct": 0.147,
+          "total_net_pct": 6.1758,
+          "total_return_pct": 5.99,
+          "max_drawdown_pct": -7.14,
+          "sharpe": 0.971,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.18553,
+          "lo": -0.278886,
+          "hi": 0.63633,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 62,
+          "paired": 62,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 62,
+            "control_mean_net_pct": -0.0385,
+            "candidate_mean_net_pct": -0.0359,
+            "control_total_net_pct": -2.3862,
+            "candidate_total_net_pct": -2.2262,
+            "control_win_rate": 0.5968,
+            "candidate_win_rate": 0.4839,
+            "delta_win_rate": -0.1129,
+            "control_median_mae_pct": -0.7441,
+            "candidate_median_mae_pct": -0.9555,
+            "control_median_mfe_pct": 0.7634,
+            "candidate_median_mfe_pct": 1.3312,
+            "paired_delta": {
+              "n": 62,
+              "mean": 0.002581,
+              "median": 0.0,
+              "sign_test": {
+                "n": 61,
+                "n_pos": 31,
+                "n_neg": 30,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 61,
+                "w": 976.0,
+                "z": 0.2155,
+                "p_value": 0.829391
+              },
+              "bootstrap": {
+                "point": 0.002581,
+                "lo": -0.179678,
+                "hi": 0.169244,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 62,
+              "control_mean_net_pct": -0.0385,
+              "candidate_mean_net_pct": -0.0359,
+              "control_total_net_pct": -2.3862,
+              "candidate_total_net_pct": -2.2262,
+              "control_win_rate": 0.5968,
+              "candidate_win_rate": 0.4839,
+              "delta_win_rate": -0.1129,
+              "control_median_mae_pct": -0.7441,
+              "candidate_median_mae_pct": -0.9555,
+              "control_median_mfe_pct": 0.7634,
+              "candidate_median_mfe_pct": 1.3312,
+              "paired_delta": {
+                "n": 62,
+                "mean": 0.002581,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 61,
+                  "n_pos": 31,
+                  "n_neg": 30,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 61,
+                  "w": 976.0,
+                  "z": 0.2155,
+                  "p_value": 0.829391
+                },
+                "bootstrap": {
+                  "point": 0.002581,
+                  "lo": -0.179678,
+                  "hi": 0.169244,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 17,
+          "entries": 13,
+          "win_rate": 0.3846,
+          "mean_net_pct": -0.5401,
+          "total_net_pct": -7.0213,
+          "total_return_pct": -7.04,
+          "max_drawdown_pct": -11.73,
+          "sharpe": -1.181,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 16,
+          "entries": 10,
+          "win_rate": 0.5,
+          "mean_net_pct": 0.0545,
+          "total_net_pct": 0.545,
+          "total_return_pct": 0.29,
+          "max_drawdown_pct": -7.29,
+          "sharpe": 0.118,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.5946,
+          "lo": -1.182744,
+          "hi": 2.362917,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 13,
+          "paired": 13,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 13,
+            "control_mean_net_pct": -0.5401,
+            "candidate_mean_net_pct": -0.5604,
+            "control_total_net_pct": -7.0213,
+            "candidate_total_net_pct": -7.2853,
+            "control_win_rate": 0.3846,
+            "candidate_win_rate": 0.3846,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.8036,
+            "candidate_median_mae_pct": -1.8036,
+            "control_median_mfe_pct": 1.2139,
+            "candidate_median_mfe_pct": 1.2139,
+            "paired_delta": {
+              "n": 13,
+              "mean": -0.020308,
+              "median": 0.0,
+              "sign_test": {
+                "n": 12,
+                "n_pos": 6,
+                "n_neg": 6,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 12,
+                "w": 39.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": -0.020308,
+                "lo": -0.427769,
+                "hi": 0.329617,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 13,
+              "control_mean_net_pct": -0.5401,
+              "candidate_mean_net_pct": -0.5604,
+              "control_total_net_pct": -7.0213,
+              "candidate_total_net_pct": -7.2853,
+              "control_win_rate": 0.3846,
+              "candidate_win_rate": 0.3846,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.8036,
+              "candidate_median_mae_pct": -1.8036,
+              "control_median_mfe_pct": 1.2139,
+              "candidate_median_mfe_pct": 1.2139,
+              "paired_delta": {
+                "n": 13,
+                "mean": -0.020308,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 12,
+                  "n_pos": 6,
+                  "n_neg": 6,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 12,
+                  "w": 39.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.020308,
+                  "lo": -0.427769,
+                  "hi": 0.329617,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 99,
+          "entries": 67,
+          "win_rate": 0.5522,
+          "mean_net_pct": -0.0638,
+          "total_net_pct": -4.2718,
+          "total_return_pct": -4.53,
+          "max_drawdown_pct": -10.66,
+          "sharpe": -0.445,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 101,
+          "entries": 54,
+          "win_rate": 0.4815,
+          "mean_net_pct": 0.0749,
+          "total_net_pct": 4.0466,
+          "total_return_pct": 3.69,
+          "max_drawdown_pct": -6.64,
+          "sharpe": 0.513,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.138694,
+          "lo": -0.346555,
+          "hi": 0.635661,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 67,
+          "paired": 67,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 67,
+            "control_mean_net_pct": -0.0638,
+            "candidate_mean_net_pct": -0.0729,
+            "control_total_net_pct": -4.2718,
+            "candidate_total_net_pct": -4.8827,
+            "control_win_rate": 0.5522,
+            "candidate_win_rate": 0.4478,
+            "delta_win_rate": -0.1044,
+            "control_median_mae_pct": -0.9166,
+            "candidate_median_mae_pct": -1.2257,
+            "control_median_mfe_pct": 1.1225,
+            "candidate_median_mfe_pct": 1.4774,
+            "paired_delta": {
+              "n": 67,
+              "mean": -0.009119,
+              "median": 0.0,
+              "sign_test": {
+                "n": 66,
+                "n_pos": 40,
+                "n_neg": 26,
+                "n_zero": 1,
+                "p_value": 0.108857
+              },
+              "signed_rank": {
+                "n": 66,
+                "w": 1281.0,
+                "z": 1.1179,
+                "p_value": 0.263604
+              },
+              "bootstrap": {
+                "point": -0.009119,
+                "lo": -0.25517,
+                "hi": 0.222734,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 67,
+              "control_mean_net_pct": -0.0638,
+              "candidate_mean_net_pct": -0.0729,
+              "control_total_net_pct": -4.2718,
+              "candidate_total_net_pct": -4.8827,
+              "control_win_rate": 0.5522,
+              "candidate_win_rate": 0.4478,
+              "delta_win_rate": -0.1044,
+              "control_median_mae_pct": -0.9166,
+              "candidate_median_mae_pct": -1.2257,
+              "control_median_mfe_pct": 1.1225,
+              "candidate_median_mfe_pct": 1.4774,
+              "paired_delta": {
+                "n": 67,
+                "mean": -0.009119,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 66,
+                  "n_pos": 40,
+                  "n_neg": 26,
+                  "n_zero": 1,
+                  "p_value": 0.108857
+                },
+                "signed_rank": {
+                  "n": 66,
+                  "w": 1281.0,
+                  "z": 1.1179,
+                  "p_value": 0.263604
+                },
+                "bootstrap": {
+                  "point": -0.009119,
+                  "lo": -0.25517,
+                  "hi": 0.222734,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 16,
+          "entries": 12,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.7399,
+          "total_net_pct": 8.8788,
+          "total_return_pct": 8.9,
+          "max_drawdown_pct": -5.17,
+          "sharpe": 1.443,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 26,
+          "entries": 8,
+          "win_rate": 0.75,
+          "mean_net_pct": 1.6801,
+          "total_net_pct": 13.4412,
+          "total_return_pct": 13.91,
+          "max_drawdown_pct": -4.91,
+          "sharpe": 2.386,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.94025,
+          "lo": -1.484269,
+          "hi": 3.202115,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 12,
+          "paired": 12,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 12,
+            "control_mean_net_pct": 0.7399,
+            "candidate_mean_net_pct": 0.8159,
+            "control_total_net_pct": 8.8788,
+            "candidate_total_net_pct": 9.7908,
+            "control_win_rate": 0.6667,
+            "candidate_win_rate": 0.5833,
+            "delta_win_rate": -0.0834,
+            "control_median_mae_pct": -1.5514,
+            "candidate_median_mae_pct": -2.3037,
+            "control_median_mfe_pct": 2.1809,
+            "candidate_median_mfe_pct": 4.2143,
+            "paired_delta": {
+              "n": 12,
+              "mean": 0.076,
+              "median": 0.4,
+              "sign_test": {
+                "n": 12,
+                "n_pos": 8,
+                "n_neg": 4,
+                "n_zero": 0,
+                "p_value": 0.387695
+              },
+              "signed_rank": {
+                "n": 12,
+                "w": 46.0,
+                "z": 0.5099,
+                "p_value": 0.61012
+              },
+              "bootstrap": {
+                "point": 0.076,
+                "lo": -0.794373,
+                "hi": 0.856446,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 12,
+              "control_mean_net_pct": 0.7399,
+              "candidate_mean_net_pct": 0.8159,
+              "control_total_net_pct": 8.8788,
+              "candidate_total_net_pct": 9.7908,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.5833,
+              "delta_win_rate": -0.0834,
+              "control_median_mae_pct": -1.5514,
+              "candidate_median_mae_pct": -2.3037,
+              "control_median_mfe_pct": 2.1809,
+              "candidate_median_mfe_pct": 4.2143,
+              "paired_delta": {
+                "n": 12,
+                "mean": 0.076,
+                "median": 0.4,
+                "sign_test": {
+                  "n": 12,
+                  "n_pos": 8,
+                  "n_neg": 4,
+                  "n_zero": 0,
+                  "p_value": 0.387695
+                },
+                "signed_rank": {
+                  "n": 12,
+                  "w": 46.0,
+                  "z": 0.5099,
+                  "p_value": 0.61012
+                },
+                "bootstrap": {
+                  "point": 0.076,
+                  "lo": -0.794373,
+                  "hi": 0.856446,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 98,
+          "entries": 70,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.3759,
+          "total_net_pct": -26.312,
+          "total_return_pct": -23.69,
+          "max_drawdown_pct": -27.86,
+          "sharpe": -2.776,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 104,
+          "entries": 55,
+          "win_rate": 0.3818,
+          "mean_net_pct": -0.4185,
+          "total_net_pct": -23.0175,
+          "total_return_pct": -21.23,
+          "max_drawdown_pct": -28.32,
+          "sharpe": -2.253,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.042614,
+          "lo": -0.607783,
+          "hi": 0.527758,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 70,
+          "paired": 70,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 70,
+            "control_mean_net_pct": -0.3759,
+            "candidate_mean_net_pct": -0.3686,
+            "control_total_net_pct": -26.312,
+            "candidate_total_net_pct": -25.801,
+            "control_win_rate": 0.5,
+            "candidate_win_rate": 0.4143,
+            "delta_win_rate": -0.0857,
+            "control_median_mae_pct": -1.0865,
+            "candidate_median_mae_pct": -1.4249,
+            "control_median_mfe_pct": 0.8708,
+            "candidate_median_mfe_pct": 1.2421,
+            "paired_delta": {
+              "n": 70,
+              "mean": 0.0073,
+              "median": 0.0,
+              "sign_test": {
+                "n": 69,
+                "n_pos": 38,
+                "n_neg": 31,
+                "n_zero": 1,
+                "p_value": 0.470369
+              },
+              "signed_rank": {
+                "n": 69,
+                "w": 1391.0,
+                "z": 1.0941,
+                "p_value": 0.27389
+              },
+              "bootstrap": {
+                "point": 0.0073,
+                "lo": -0.249453,
+                "hi": 0.233448,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 70,
+              "control_mean_net_pct": -0.3759,
+              "candidate_mean_net_pct": -0.3686,
+              "control_total_net_pct": -26.312,
+              "candidate_total_net_pct": -25.801,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.4143,
+              "delta_win_rate": -0.0857,
+              "control_median_mae_pct": -1.0865,
+              "candidate_median_mae_pct": -1.4249,
+              "control_median_mfe_pct": 0.8708,
+              "candidate_median_mfe_pct": 1.2421,
+              "paired_delta": {
+                "n": 70,
+                "mean": 0.0073,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 69,
+                  "n_pos": 38,
+                  "n_neg": 31,
+                  "n_zero": 1,
+                  "p_value": 0.470369
+                },
+                "signed_rank": {
+                  "n": 69,
+                  "w": 1391.0,
+                  "z": 1.0941,
+                  "p_value": 0.27389
+                },
+                "bootstrap": {
+                  "point": 0.0073,
+                  "lo": -0.249453,
+                  "hi": 0.233448,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 27,
+          "entries": 17,
+          "win_rate": 0.5294,
+          "mean_net_pct": 0.0711,
+          "total_net_pct": 1.2083,
+          "total_return_pct": 0.81,
+          "max_drawdown_pct": -13.8,
+          "sharpe": 0.195,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 25,
+          "entries": 15,
+          "win_rate": 0.4,
+          "mean_net_pct": -0.5952,
+          "total_net_pct": -8.9275,
+          "total_return_pct": -9.61,
+          "max_drawdown_pct": -23.99,
+          "sharpe": -0.756,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.666243,
+          "lo": -2.934199,
+          "hi": 1.617261,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 17,
+          "paired": 17,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 17,
+            "control_mean_net_pct": 0.0711,
+            "candidate_mean_net_pct": 0.0059,
+            "control_total_net_pct": 1.2083,
+            "candidate_total_net_pct": 0.1003,
+            "control_win_rate": 0.5294,
+            "candidate_win_rate": 0.4706,
+            "delta_win_rate": -0.0588,
+            "control_median_mae_pct": -1.9966,
+            "candidate_median_mae_pct": -2.4506,
+            "control_median_mfe_pct": 2.4405,
+            "candidate_median_mfe_pct": 4.0502,
+            "paired_delta": {
+              "n": 17,
+              "mean": -0.065176,
+              "median": 0.0,
+              "sign_test": {
+                "n": 17,
+                "n_pos": 9,
+                "n_neg": 8,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 17,
+                "w": 75.0,
+                "z": -0.0473,
+                "p_value": 0.962244
+              },
+              "bootstrap": {
+                "point": -0.065176,
+                "lo": -1.265299,
+                "hi": 1.088987,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 17,
+              "control_mean_net_pct": 0.0711,
+              "candidate_mean_net_pct": 0.0059,
+              "control_total_net_pct": 1.2083,
+              "candidate_total_net_pct": 0.1003,
+              "control_win_rate": 0.5294,
+              "candidate_win_rate": 0.4706,
+              "delta_win_rate": -0.0588,
+              "control_median_mae_pct": -1.9966,
+              "candidate_median_mae_pct": -2.4506,
+              "control_median_mfe_pct": 2.4405,
+              "candidate_median_mfe_pct": 4.0502,
+              "paired_delta": {
+                "n": 17,
+                "mean": -0.065176,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 17,
+                  "n_pos": 9,
+                  "n_neg": 8,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 17,
+                  "w": 75.0,
+                  "z": -0.0473,
+                  "p_value": 0.962244
+                },
+                "bootstrap": {
+                  "point": -0.065176,
+                  "lo": -1.265299,
+                  "hi": 1.088987,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/mr.b2_rv_wider.json
+++ b/backtest/research/regime_1152_runs/mr.b2_rv_wider.json
@@ -1,0 +1,1489 @@
+{
+  "open": {
+    "name": "mean_reversion",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "tiered_tp_atr_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "tiered_tp_atr",
+      "params": {
+        "tp_tiers": [
+          {
+            "atr_multiple": 0.75,
+            "close_fraction": 0.5
+          },
+          {
+            "atr_multiple": 1.5,
+            "close_fraction": 1.0
+          }
+        ]
+      }
+    }
+  ],
+  "control_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_volatile"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 137,
+          "entries": 95,
+          "win_rate": 0.4947,
+          "mean_net_pct": -0.2988,
+          "total_net_pct": -28.3845,
+          "total_return_pct": -24.94,
+          "max_drawdown_pct": -26.31,
+          "sharpe": -3.289,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 126,
+          "entries": 82,
+          "win_rate": 0.4878,
+          "mean_net_pct": -0.321,
+          "total_net_pct": -26.3182,
+          "total_return_pct": -23.41,
+          "max_drawdown_pct": -24.36,
+          "sharpe": -3.309,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.022169,
+          "lo": -0.288604,
+          "hi": 0.251384,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 95,
+          "paired": 95,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 95,
+            "control_mean_net_pct": -0.2988,
+            "candidate_mean_net_pct": -0.2882,
+            "control_total_net_pct": -28.3845,
+            "candidate_total_net_pct": -27.3745,
+            "control_win_rate": 0.4947,
+            "candidate_win_rate": 0.4842,
+            "delta_win_rate": -0.0105,
+            "control_median_mae_pct": -0.595,
+            "candidate_median_mae_pct": -0.6902,
+            "control_median_mfe_pct": 0.5631,
+            "candidate_median_mfe_pct": 0.7608,
+            "paired_delta": {
+              "n": 95,
+              "mean": 0.010632,
+              "median": 0.0,
+              "sign_test": {
+                "n": 95,
+                "n_pos": 59,
+                "n_neg": 36,
+                "n_zero": 0,
+                "p_value": 0.023488
+              },
+              "signed_rank": {
+                "n": 95,
+                "w": 2807.0,
+                "z": 1.9543,
+                "p_value": 0.050666
+              },
+              "bootstrap": {
+                "point": 0.010632,
+                "lo": -0.077474,
+                "hi": 0.094636,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 95,
+              "control_mean_net_pct": -0.2988,
+              "candidate_mean_net_pct": -0.2882,
+              "control_total_net_pct": -28.3845,
+              "candidate_total_net_pct": -27.3745,
+              "control_win_rate": 0.4947,
+              "candidate_win_rate": 0.4842,
+              "delta_win_rate": -0.0105,
+              "control_median_mae_pct": -0.595,
+              "candidate_median_mae_pct": -0.6902,
+              "control_median_mfe_pct": 0.5631,
+              "candidate_median_mfe_pct": 0.7608,
+              "paired_delta": {
+                "n": 95,
+                "mean": 0.010632,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 95,
+                  "n_pos": 59,
+                  "n_neg": 36,
+                  "n_zero": 0,
+                  "p_value": 0.023488
+                },
+                "signed_rank": {
+                  "n": 95,
+                  "w": 2807.0,
+                  "z": 1.9543,
+                  "p_value": 0.050666
+                },
+                "bootstrap": {
+                  "point": 0.010632,
+                  "lo": -0.077474,
+                  "hi": 0.094636,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 33,
+          "entries": 25,
+          "win_rate": 0.44,
+          "mean_net_pct": -0.8159,
+          "total_net_pct": -20.3976,
+          "total_return_pct": -18.98,
+          "max_drawdown_pct": -19.87,
+          "sharpe": -2.438,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 29,
+          "entries": 23,
+          "win_rate": 0.3913,
+          "mean_net_pct": -0.5914,
+          "total_net_pct": -13.6023,
+          "total_return_pct": -13.17,
+          "max_drawdown_pct": -16.76,
+          "sharpe": -1.593,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.224498,
+          "lo": -1.051351,
+          "hi": 1.548009,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 25,
+          "paired": 25,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 25,
+            "control_mean_net_pct": -0.8159,
+            "candidate_mean_net_pct": -0.8321,
+            "control_total_net_pct": -20.3976,
+            "candidate_total_net_pct": -20.8025,
+            "control_win_rate": 0.44,
+            "candidate_win_rate": 0.36,
+            "delta_win_rate": -0.08,
+            "control_median_mae_pct": -1.3401,
+            "candidate_median_mae_pct": -1.6866,
+            "control_median_mfe_pct": 0.8767,
+            "candidate_median_mfe_pct": 0.8767,
+            "paired_delta": {
+              "n": 25,
+              "mean": -0.016198,
+              "median": 0.0,
+              "sign_test": {
+                "n": 24,
+                "n_pos": 13,
+                "n_neg": 11,
+                "n_zero": 1,
+                "p_value": 0.83882
+              },
+              "signed_rank": {
+                "n": 24,
+                "w": 155.0,
+                "z": 0.1286,
+                "p_value": 0.897697
+              },
+              "bootstrap": {
+                "point": -0.016198,
+                "lo": -0.262208,
+                "hi": 0.198802,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 25,
+              "control_mean_net_pct": -0.8159,
+              "candidate_mean_net_pct": -0.8321,
+              "control_total_net_pct": -20.3976,
+              "candidate_total_net_pct": -20.8025,
+              "control_win_rate": 0.44,
+              "candidate_win_rate": 0.36,
+              "delta_win_rate": -0.08,
+              "control_median_mae_pct": -1.3401,
+              "candidate_median_mae_pct": -1.6866,
+              "control_median_mfe_pct": 0.8767,
+              "candidate_median_mfe_pct": 0.8767,
+              "paired_delta": {
+                "n": 25,
+                "mean": -0.016198,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 24,
+                  "n_pos": 13,
+                  "n_neg": 11,
+                  "n_zero": 1,
+                  "p_value": 0.83882
+                },
+                "signed_rank": {
+                  "n": 24,
+                  "w": 155.0,
+                  "z": 0.1286,
+                  "p_value": 0.897697
+                },
+                "bootstrap": {
+                  "point": -0.016198,
+                  "lo": -0.262208,
+                  "hi": 0.198802,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 142,
+          "entries": 96,
+          "win_rate": 0.625,
+          "mean_net_pct": -0.0395,
+          "total_net_pct": -3.7896,
+          "total_return_pct": -4.59,
+          "max_drawdown_pct": -21.81,
+          "sharpe": -0.215,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 131,
+          "entries": 85,
+          "win_rate": 0.5882,
+          "mean_net_pct": 0.0228,
+          "total_net_pct": 1.9415,
+          "total_return_pct": 0.99,
+          "max_drawdown_pct": -16.5,
+          "sharpe": 0.195,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.062316,
+          "lo": -0.378456,
+          "hi": 0.506104,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 96,
+          "paired": 96,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 96,
+            "control_mean_net_pct": -0.0395,
+            "candidate_mean_net_pct": 0.0342,
+            "control_total_net_pct": -3.7896,
+            "candidate_total_net_pct": 3.2804,
+            "control_win_rate": 0.625,
+            "candidate_win_rate": 0.5833,
+            "delta_win_rate": -0.0417,
+            "control_median_mae_pct": -0.6854,
+            "candidate_median_mae_pct": -0.7639,
+            "control_median_mfe_pct": 1.0829,
+            "candidate_median_mfe_pct": 1.3174,
+            "paired_delta": {
+              "n": 96,
+              "mean": 0.073646,
+              "median": 0.0,
+              "sign_test": {
+                "n": 96,
+                "n_pos": 64,
+                "n_neg": 32,
+                "n_zero": 0,
+                "p_value": 0.001424
+              },
+              "signed_rank": {
+                "n": 96,
+                "w": 3347.0,
+                "z": 3.7219,
+                "p_value": 0.000198
+              },
+              "bootstrap": {
+                "point": 0.073646,
+                "lo": -0.023439,
+                "hi": 0.16016,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 96,
+              "control_mean_net_pct": -0.0395,
+              "candidate_mean_net_pct": 0.0342,
+              "control_total_net_pct": -3.7896,
+              "candidate_total_net_pct": 3.2804,
+              "control_win_rate": 0.625,
+              "candidate_win_rate": 0.5833,
+              "delta_win_rate": -0.0417,
+              "control_median_mae_pct": -0.6854,
+              "candidate_median_mae_pct": -0.7639,
+              "control_median_mfe_pct": 1.0829,
+              "candidate_median_mfe_pct": 1.3174,
+              "paired_delta": {
+                "n": 96,
+                "mean": 0.073646,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 96,
+                  "n_pos": 64,
+                  "n_neg": 32,
+                  "n_zero": 0,
+                  "p_value": 0.001424
+                },
+                "signed_rank": {
+                  "n": 96,
+                  "w": 3347.0,
+                  "z": 3.7219,
+                  "p_value": 0.000198
+                },
+                "bootstrap": {
+                  "point": 0.073646,
+                  "lo": -0.023439,
+                  "hi": 0.16016,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 27,
+          "entries": 20,
+          "win_rate": 0.6,
+          "mean_net_pct": 0.1539,
+          "total_net_pct": 3.078,
+          "total_return_pct": 2.46,
+          "max_drawdown_pct": -14.78,
+          "sharpe": 0.301,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 25,
+          "entries": 17,
+          "win_rate": 0.3529,
+          "mean_net_pct": -0.5527,
+          "total_net_pct": -9.3967,
+          "total_return_pct": -9.67,
+          "max_drawdown_pct": -17.73,
+          "sharpe": -0.697,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.706647,
+          "lo": -2.645838,
+          "hi": 1.290025,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 20,
+          "paired": 20,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 20,
+            "control_mean_net_pct": 0.1539,
+            "candidate_mean_net_pct": -0.1244,
+            "control_total_net_pct": 3.078,
+            "candidate_total_net_pct": -2.487,
+            "control_win_rate": 0.6,
+            "candidate_win_rate": 0.45,
+            "delta_win_rate": -0.15,
+            "control_median_mae_pct": -2.5511,
+            "candidate_median_mae_pct": -2.9325,
+            "control_median_mfe_pct": 2.5546,
+            "candidate_median_mfe_pct": 2.8192,
+            "paired_delta": {
+              "n": 20,
+              "mean": -0.27825,
+              "median": -0.0,
+              "sign_test": {
+                "n": 20,
+                "n_pos": 10,
+                "n_neg": 10,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 20,
+                "w": 109.0,
+                "z": 0.1307,
+                "p_value": 0.896041
+              },
+              "bootstrap": {
+                "point": -0.27825,
+                "lo": -0.862781,
+                "hi": 0.304538,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 20,
+              "control_mean_net_pct": 0.1539,
+              "candidate_mean_net_pct": -0.1244,
+              "control_total_net_pct": 3.078,
+              "candidate_total_net_pct": -2.487,
+              "control_win_rate": 0.6,
+              "candidate_win_rate": 0.45,
+              "delta_win_rate": -0.15,
+              "control_median_mae_pct": -2.5511,
+              "candidate_median_mae_pct": -2.9325,
+              "control_median_mfe_pct": 2.5546,
+              "candidate_median_mfe_pct": 2.8192,
+              "paired_delta": {
+                "n": 20,
+                "mean": -0.27825,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 20,
+                  "n_pos": 10,
+                  "n_neg": 10,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 20,
+                  "w": 109.0,
+                  "z": 0.1307,
+                  "p_value": 0.896041
+                },
+                "bootstrap": {
+                  "point": -0.27825,
+                  "lo": -0.862781,
+                  "hi": 0.304538,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 115,
+          "entries": 86,
+          "win_rate": 0.5698,
+          "mean_net_pct": -0.3173,
+          "total_net_pct": -27.2836,
+          "total_return_pct": -24.74,
+          "max_drawdown_pct": -31.6,
+          "sharpe": -2.033,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 110,
+          "entries": 78,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.2793,
+          "total_net_pct": -21.7878,
+          "total_return_pct": -20.61,
+          "max_drawdown_pct": -29.09,
+          "sharpe": -1.63,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.03792,
+          "lo": -0.494403,
+          "hi": 0.570904,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 86,
+          "paired": 86,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 86,
+            "control_mean_net_pct": -0.3173,
+            "candidate_mean_net_pct": -0.2611,
+            "control_total_net_pct": -27.2836,
+            "candidate_total_net_pct": -22.4536,
+            "control_win_rate": 0.5698,
+            "candidate_win_rate": 0.5233,
+            "delta_win_rate": -0.0465,
+            "control_median_mae_pct": -0.9399,
+            "candidate_median_mae_pct": -1.081,
+            "control_median_mfe_pct": 1.0633,
+            "candidate_median_mfe_pct": 1.3281,
+            "paired_delta": {
+              "n": 86,
+              "mean": 0.056163,
+              "median": 0.0,
+              "sign_test": {
+                "n": 86,
+                "n_pos": 58,
+                "n_neg": 28,
+                "n_zero": 0,
+                "p_value": 0.001606
+              },
+              "signed_rank": {
+                "n": 86,
+                "w": 2735.0,
+                "z": 3.7204,
+                "p_value": 0.000199
+              },
+              "bootstrap": {
+                "point": 0.056163,
+                "lo": -0.053839,
+                "hi": 0.161628,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 86,
+              "control_mean_net_pct": -0.3173,
+              "candidate_mean_net_pct": -0.2611,
+              "control_total_net_pct": -27.2836,
+              "candidate_total_net_pct": -22.4536,
+              "control_win_rate": 0.5698,
+              "candidate_win_rate": 0.5233,
+              "delta_win_rate": -0.0465,
+              "control_median_mae_pct": -0.9399,
+              "candidate_median_mae_pct": -1.081,
+              "control_median_mfe_pct": 1.0633,
+              "candidate_median_mfe_pct": 1.3281,
+              "paired_delta": {
+                "n": 86,
+                "mean": 0.056163,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 86,
+                  "n_pos": 58,
+                  "n_neg": 28,
+                  "n_zero": 0,
+                  "p_value": 0.001606
+                },
+                "signed_rank": {
+                  "n": 86,
+                  "w": 2735.0,
+                  "z": 3.7204,
+                  "p_value": 0.000199
+                },
+                "bootstrap": {
+                  "point": 0.056163,
+                  "lo": -0.053839,
+                  "hi": 0.161628,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 31,
+          "entries": 21,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.5351,
+          "total_net_pct": 11.2379,
+          "total_return_pct": 11.03,
+          "max_drawdown_pct": -9.61,
+          "sharpe": 1.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 25,
+          "entries": 16,
+          "win_rate": 0.5,
+          "mean_net_pct": 0.4496,
+          "total_net_pct": 7.1934,
+          "total_return_pct": 6.71,
+          "max_drawdown_pct": -15.16,
+          "sharpe": 0.645,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.085551,
+          "lo": -2.047914,
+          "hi": 1.887976,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 21,
+          "paired": 21,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 21,
+            "control_mean_net_pct": 0.5351,
+            "candidate_mean_net_pct": 0.2806,
+            "control_total_net_pct": 11.2379,
+            "candidate_total_net_pct": 5.8929,
+            "control_win_rate": 0.6667,
+            "candidate_win_rate": 0.4762,
+            "delta_win_rate": -0.1905,
+            "control_median_mae_pct": -1.9909,
+            "candidate_median_mae_pct": -2.8076,
+            "control_median_mfe_pct": 3.055,
+            "candidate_median_mfe_pct": 3.6063,
+            "paired_delta": {
+              "n": 21,
+              "mean": -0.254524,
+              "median": 0.0,
+              "sign_test": {
+                "n": 21,
+                "n_pos": 13,
+                "n_neg": 8,
+                "n_zero": 0,
+                "p_value": 0.38331
+              },
+              "signed_rank": {
+                "n": 21,
+                "w": 128.0,
+                "z": 0.4171,
+                "p_value": 0.676611
+              },
+              "bootstrap": {
+                "point": -0.254524,
+                "lo": -0.917899,
+                "hi": 0.349304,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 21,
+              "control_mean_net_pct": 0.5351,
+              "candidate_mean_net_pct": 0.2806,
+              "control_total_net_pct": 11.2379,
+              "candidate_total_net_pct": 5.8929,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.4762,
+              "delta_win_rate": -0.1905,
+              "control_median_mae_pct": -1.9909,
+              "candidate_median_mae_pct": -2.8076,
+              "control_median_mfe_pct": 3.055,
+              "candidate_median_mfe_pct": 3.6063,
+              "paired_delta": {
+                "n": 21,
+                "mean": -0.254524,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 21,
+                  "n_pos": 13,
+                  "n_neg": 8,
+                  "n_zero": 0,
+                  "p_value": 0.38331
+                },
+                "signed_rank": {
+                  "n": 21,
+                  "w": 128.0,
+                  "z": 0.4171,
+                  "p_value": 0.676611
+                },
+                "bootstrap": {
+                  "point": -0.254524,
+                  "lo": -0.917899,
+                  "hi": 0.349304,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 85,
+          "entries": 62,
+          "win_rate": 0.5968,
+          "mean_net_pct": -0.0385,
+          "total_net_pct": -2.3862,
+          "total_return_pct": -2.65,
+          "max_drawdown_pct": -6.85,
+          "sharpe": -0.322,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 77,
+          "entries": 53,
+          "win_rate": 0.6226,
+          "mean_net_pct": 0.0446,
+          "total_net_pct": 2.3647,
+          "total_return_pct": 2.07,
+          "max_drawdown_pct": -6.75,
+          "sharpe": 0.382,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.083104,
+          "lo": -0.302613,
+          "hi": 0.47794,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 62,
+          "paired": 62,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 62,
+            "control_mean_net_pct": -0.0385,
+            "candidate_mean_net_pct": -0.0745,
+            "control_total_net_pct": -2.3862,
+            "candidate_total_net_pct": -4.6162,
+            "control_win_rate": 0.5968,
+            "candidate_win_rate": 0.5806,
+            "delta_win_rate": -0.0162,
+            "control_median_mae_pct": -0.7441,
+            "candidate_median_mae_pct": -0.7508,
+            "control_median_mfe_pct": 0.7634,
+            "candidate_median_mfe_pct": 1.0051,
+            "paired_delta": {
+              "n": 62,
+              "mean": -0.035968,
+              "median": 0.0,
+              "sign_test": {
+                "n": 61,
+                "n_pos": 35,
+                "n_neg": 26,
+                "n_zero": 1,
+                "p_value": 0.305677
+              },
+              "signed_rank": {
+                "n": 61,
+                "w": 1126.0,
+                "z": 1.2929,
+                "p_value": 0.196046
+              },
+              "bootstrap": {
+                "point": -0.035968,
+                "lo": -0.135567,
+                "hi": 0.054196,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 62,
+              "control_mean_net_pct": -0.0385,
+              "candidate_mean_net_pct": -0.0745,
+              "control_total_net_pct": -2.3862,
+              "candidate_total_net_pct": -4.6162,
+              "control_win_rate": 0.5968,
+              "candidate_win_rate": 0.5806,
+              "delta_win_rate": -0.0162,
+              "control_median_mae_pct": -0.7441,
+              "candidate_median_mae_pct": -0.7508,
+              "control_median_mfe_pct": 0.7634,
+              "candidate_median_mfe_pct": 1.0051,
+              "paired_delta": {
+                "n": 62,
+                "mean": -0.035968,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 61,
+                  "n_pos": 35,
+                  "n_neg": 26,
+                  "n_zero": 1,
+                  "p_value": 0.305677
+                },
+                "signed_rank": {
+                  "n": 61,
+                  "w": 1126.0,
+                  "z": 1.2929,
+                  "p_value": 0.196046
+                },
+                "bootstrap": {
+                  "point": -0.035968,
+                  "lo": -0.135567,
+                  "hi": 0.054196,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 17,
+          "entries": 13,
+          "win_rate": 0.3846,
+          "mean_net_pct": -0.5401,
+          "total_net_pct": -7.0213,
+          "total_return_pct": -7.04,
+          "max_drawdown_pct": -11.73,
+          "sharpe": -1.181,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 15,
+          "entries": 12,
+          "win_rate": 0.4167,
+          "mean_net_pct": -0.3055,
+          "total_net_pct": -3.6662,
+          "total_return_pct": -3.93,
+          "max_drawdown_pct": -10.25,
+          "sharpe": -0.618,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.234583,
+          "lo": -1.551288,
+          "hi": 1.993812,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 13,
+          "paired": 13,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 13,
+            "control_mean_net_pct": -0.5401,
+            "candidate_mean_net_pct": -0.4105,
+            "control_total_net_pct": -7.0213,
+            "candidate_total_net_pct": -5.3363,
+            "control_win_rate": 0.3846,
+            "candidate_win_rate": 0.3846,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.8036,
+            "candidate_median_mae_pct": -1.8036,
+            "control_median_mfe_pct": 1.2139,
+            "candidate_median_mfe_pct": 1.2139,
+            "paired_delta": {
+              "n": 13,
+              "mean": 0.129615,
+              "median": 0.0,
+              "sign_test": {
+                "n": 12,
+                "n_pos": 6,
+                "n_neg": 6,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 12,
+                "w": 45.0,
+                "z": 0.4315,
+                "p_value": 0.666137
+              },
+              "bootstrap": {
+                "point": 0.129615,
+                "lo": -0.196923,
+                "hi": 0.486154,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 13,
+              "control_mean_net_pct": -0.5401,
+              "candidate_mean_net_pct": -0.4105,
+              "control_total_net_pct": -7.0213,
+              "candidate_total_net_pct": -5.3363,
+              "control_win_rate": 0.3846,
+              "candidate_win_rate": 0.3846,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.8036,
+              "candidate_median_mae_pct": -1.8036,
+              "control_median_mfe_pct": 1.2139,
+              "candidate_median_mfe_pct": 1.2139,
+              "paired_delta": {
+                "n": 13,
+                "mean": 0.129615,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 12,
+                  "n_pos": 6,
+                  "n_neg": 6,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 12,
+                  "w": 45.0,
+                  "z": 0.4315,
+                  "p_value": 0.666137
+                },
+                "bootstrap": {
+                  "point": 0.129615,
+                  "lo": -0.196923,
+                  "hi": 0.486154,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 99,
+          "entries": 67,
+          "win_rate": 0.5522,
+          "mean_net_pct": -0.0638,
+          "total_net_pct": -4.2718,
+          "total_return_pct": -4.53,
+          "max_drawdown_pct": -10.66,
+          "sharpe": -0.445,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 90,
+          "entries": 63,
+          "win_rate": 0.5556,
+          "mean_net_pct": 0.0563,
+          "total_net_pct": 3.5487,
+          "total_return_pct": 3.13,
+          "max_drawdown_pct": -8.24,
+          "sharpe": 0.445,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.120086,
+          "lo": -0.332412,
+          "hi": 0.569846,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 67,
+          "paired": 67,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 67,
+            "control_mean_net_pct": -0.0638,
+            "candidate_mean_net_pct": 0.0321,
+            "control_total_net_pct": -4.2718,
+            "candidate_total_net_pct": 2.1533,
+            "control_win_rate": 0.5522,
+            "candidate_win_rate": 0.5373,
+            "delta_win_rate": -0.0149,
+            "control_median_mae_pct": -0.9166,
+            "candidate_median_mae_pct": -0.9566,
+            "control_median_mfe_pct": 1.1225,
+            "candidate_median_mfe_pct": 1.2975,
+            "paired_delta": {
+              "n": 67,
+              "mean": 0.095896,
+              "median": 0.0,
+              "sign_test": {
+                "n": 66,
+                "n_pos": 46,
+                "n_neg": 20,
+                "n_zero": 1,
+                "p_value": 0.001858
+              },
+              "signed_rank": {
+                "n": 66,
+                "w": 1648.0,
+                "z": 3.4623,
+                "p_value": 0.000536
+              },
+              "bootstrap": {
+                "point": 0.095896,
+                "lo": -0.05015,
+                "hi": 0.225674,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 67,
+              "control_mean_net_pct": -0.0638,
+              "candidate_mean_net_pct": 0.0321,
+              "control_total_net_pct": -4.2718,
+              "candidate_total_net_pct": 2.1533,
+              "control_win_rate": 0.5522,
+              "candidate_win_rate": 0.5373,
+              "delta_win_rate": -0.0149,
+              "control_median_mae_pct": -0.9166,
+              "candidate_median_mae_pct": -0.9566,
+              "control_median_mfe_pct": 1.1225,
+              "candidate_median_mfe_pct": 1.2975,
+              "paired_delta": {
+                "n": 67,
+                "mean": 0.095896,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 66,
+                  "n_pos": 46,
+                  "n_neg": 20,
+                  "n_zero": 1,
+                  "p_value": 0.001858
+                },
+                "signed_rank": {
+                  "n": 66,
+                  "w": 1648.0,
+                  "z": 3.4623,
+                  "p_value": 0.000536
+                },
+                "bootstrap": {
+                  "point": 0.095896,
+                  "lo": -0.05015,
+                  "hi": 0.225674,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 16,
+          "entries": 12,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.7399,
+          "total_net_pct": 8.8788,
+          "total_return_pct": 8.9,
+          "max_drawdown_pct": -5.17,
+          "sharpe": 1.443,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 17,
+          "entries": 11,
+          "win_rate": 0.5455,
+          "mean_net_pct": 0.2481,
+          "total_net_pct": 2.7289,
+          "total_return_pct": 2.48,
+          "max_drawdown_pct": -5.94,
+          "sharpe": 0.492,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.491818,
+          "lo": -2.379748,
+          "hi": 1.400811,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 12,
+          "paired": 12,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 12,
+            "control_mean_net_pct": 0.7399,
+            "candidate_mean_net_pct": 0.5907,
+            "control_total_net_pct": 8.8788,
+            "candidate_total_net_pct": 7.0888,
+            "control_win_rate": 0.6667,
+            "candidate_win_rate": 0.5833,
+            "delta_win_rate": -0.0834,
+            "control_median_mae_pct": -1.5514,
+            "candidate_median_mae_pct": -2.3037,
+            "control_median_mfe_pct": 2.1809,
+            "candidate_median_mfe_pct": 2.4806,
+            "paired_delta": {
+              "n": 12,
+              "mean": -0.149167,
+              "median": 0.0,
+              "sign_test": {
+                "n": 11,
+                "n_pos": 7,
+                "n_neg": 4,
+                "n_zero": 1,
+                "p_value": 0.548828
+              },
+              "signed_rank": {
+                "n": 11,
+                "w": 49.0,
+                "z": 1.3781,
+                "p_value": 0.168167
+              },
+              "bootstrap": {
+                "point": -0.149167,
+                "lo": -0.67875,
+                "hi": 0.178333,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 12,
+              "control_mean_net_pct": 0.7399,
+              "candidate_mean_net_pct": 0.5907,
+              "control_total_net_pct": 8.8788,
+              "candidate_total_net_pct": 7.0888,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.5833,
+              "delta_win_rate": -0.0834,
+              "control_median_mae_pct": -1.5514,
+              "candidate_median_mae_pct": -2.3037,
+              "control_median_mfe_pct": 2.1809,
+              "candidate_median_mfe_pct": 2.4806,
+              "paired_delta": {
+                "n": 12,
+                "mean": -0.149167,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 11,
+                  "n_pos": 7,
+                  "n_neg": 4,
+                  "n_zero": 1,
+                  "p_value": 0.548828
+                },
+                "signed_rank": {
+                  "n": 11,
+                  "w": 49.0,
+                  "z": 1.3781,
+                  "p_value": 0.168167
+                },
+                "bootstrap": {
+                  "point": -0.149167,
+                  "lo": -0.67875,
+                  "hi": 0.178333,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 98,
+          "entries": 70,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.3759,
+          "total_net_pct": -26.312,
+          "total_return_pct": -23.69,
+          "max_drawdown_pct": -27.86,
+          "sharpe": -2.776,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 89,
+          "entries": 61,
+          "win_rate": 0.4426,
+          "mean_net_pct": -0.2777,
+          "total_net_pct": -16.9411,
+          "total_return_pct": -16.15,
+          "max_drawdown_pct": -23.33,
+          "sharpe": -1.778,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.098163,
+          "lo": -0.401617,
+          "hi": 0.60396,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 70,
+          "paired": 70,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 70,
+            "control_mean_net_pct": -0.3759,
+            "candidate_mean_net_pct": -0.307,
+            "control_total_net_pct": -26.312,
+            "candidate_total_net_pct": -21.487,
+            "control_win_rate": 0.5,
+            "candidate_win_rate": 0.4571,
+            "delta_win_rate": -0.0429,
+            "control_median_mae_pct": -1.0865,
+            "candidate_median_mae_pct": -1.2222,
+            "control_median_mfe_pct": 0.8708,
+            "candidate_median_mfe_pct": 1.093,
+            "paired_delta": {
+              "n": 70,
+              "mean": 0.068929,
+              "median": 0.0,
+              "sign_test": {
+                "n": 69,
+                "n_pos": 44,
+                "n_neg": 25,
+                "n_zero": 1,
+                "p_value": 0.029493
+              },
+              "signed_rank": {
+                "n": 69,
+                "w": 1708.0,
+                "z": 2.9895,
+                "p_value": 0.002795
+              },
+              "bootstrap": {
+                "point": 0.068929,
+                "lo": -0.070932,
+                "hi": 0.192214,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 70,
+              "control_mean_net_pct": -0.3759,
+              "candidate_mean_net_pct": -0.307,
+              "control_total_net_pct": -26.312,
+              "candidate_total_net_pct": -21.487,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.4571,
+              "delta_win_rate": -0.0429,
+              "control_median_mae_pct": -1.0865,
+              "candidate_median_mae_pct": -1.2222,
+              "control_median_mfe_pct": 0.8708,
+              "candidate_median_mfe_pct": 1.093,
+              "paired_delta": {
+                "n": 70,
+                "mean": 0.068929,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 69,
+                  "n_pos": 44,
+                  "n_neg": 25,
+                  "n_zero": 1,
+                  "p_value": 0.029493
+                },
+                "signed_rank": {
+                  "n": 69,
+                  "w": 1708.0,
+                  "z": 2.9895,
+                  "p_value": 0.002795
+                },
+                "bootstrap": {
+                  "point": 0.068929,
+                  "lo": -0.070932,
+                  "hi": 0.192214,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 27,
+          "entries": 17,
+          "win_rate": 0.5294,
+          "mean_net_pct": 0.0711,
+          "total_net_pct": 1.2083,
+          "total_return_pct": 0.81,
+          "max_drawdown_pct": -13.8,
+          "sharpe": 0.195,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 27,
+          "entries": 17,
+          "win_rate": 0.5294,
+          "mean_net_pct": 0.2499,
+          "total_net_pct": 4.2483,
+          "total_return_pct": 3.69,
+          "max_drawdown_pct": -15.96,
+          "sharpe": 0.517,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.178824,
+          "lo": -1.501199,
+          "hi": 1.832471,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 17,
+          "paired": 17,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 17,
+            "control_mean_net_pct": 0.0711,
+            "candidate_mean_net_pct": 0.2499,
+            "control_total_net_pct": 1.2083,
+            "candidate_total_net_pct": 4.2483,
+            "control_win_rate": 0.5294,
+            "candidate_win_rate": 0.5294,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.9966,
+            "candidate_median_mae_pct": -1.9966,
+            "control_median_mfe_pct": 2.4405,
+            "candidate_median_mfe_pct": 2.6566,
+            "paired_delta": {
+              "n": 17,
+              "mean": 0.178824,
+              "median": 0.0,
+              "sign_test": {
+                "n": 16,
+                "n_pos": 10,
+                "n_neg": 6,
+                "n_zero": 1,
+                "p_value": 0.454498
+              },
+              "signed_rank": {
+                "n": 16,
+                "w": 93.0,
+                "z": 1.2669,
+                "p_value": 0.205204
+              },
+              "bootstrap": {
+                "point": 0.178824,
+                "lo": -0.32089,
+                "hi": 0.704441,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 17,
+              "control_mean_net_pct": 0.0711,
+              "candidate_mean_net_pct": 0.2499,
+              "control_total_net_pct": 1.2083,
+              "candidate_total_net_pct": 4.2483,
+              "control_win_rate": 0.5294,
+              "candidate_win_rate": 0.5294,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.9966,
+              "candidate_median_mae_pct": -1.9966,
+              "control_median_mfe_pct": 2.4405,
+              "candidate_median_mfe_pct": 2.6566,
+              "paired_delta": {
+                "n": 17,
+                "mean": 0.178824,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 16,
+                  "n_pos": 10,
+                  "n_neg": 6,
+                  "n_zero": 1,
+                  "p_value": 0.454498
+                },
+                "signed_rank": {
+                  "n": 16,
+                  "w": 93.0,
+                  "z": 1.2669,
+                  "p_value": 0.205204
+                },
+                "bootstrap": {
+                  "point": 0.178824,
+                  "lo": -0.32089,
+                  "hi": 0.704441,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/mr.rd_full_scaleout.json
+++ b/backtest/research/regime_1152_runs/mr.rd_full_scaleout.json
@@ -1,0 +1,1992 @@
+{
+  "open": {
+    "name": "mean_reversion",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "tp_tiers": {
+          "ranging_directional": [
+            {
+              "atr_multiple": 1.0,
+              "close_fraction": 0.4,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 0.8,
+              "trailing_mult_after": 0.75
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 1.0,
+              "trailing_mult_after": 0.75
+            }
+          ],
+          "ranging_directional_up": [
+            {
+              "atr_multiple": 1.0,
+              "close_fraction": 0.4,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 0.8,
+              "trailing_mult_after": 0.75
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 1.0,
+              "trailing_mult_after": 0.75
+            }
+          ],
+          "ranging_directional_down": [
+            {
+              "atr_multiple": 1.0,
+              "close_fraction": 0.4,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 0.8,
+              "trailing_mult_after": 0.75
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 1.0,
+              "trailing_mult_after": 0.75
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "control_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_directional"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 98,
+          "entries": 52,
+          "win_rate": 0.3846,
+          "mean_net_pct": -0.248,
+          "total_net_pct": -12.8977,
+          "total_return_pct": -12.43,
+          "max_drawdown_pct": -17.93,
+          "sharpe": -1.698,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 88,
+          "entries": 52,
+          "win_rate": 0.4038,
+          "mean_net_pct": -0.2588,
+          "total_net_pct": -13.4592,
+          "total_return_pct": -12.88,
+          "max_drawdown_pct": -18.66,
+          "sharpe": -1.819,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.010798,
+          "lo": -0.430251,
+          "hi": 0.400546,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 52,
+          "paired": 52,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 52,
+            "control_mean_net_pct": -0.248,
+            "candidate_mean_net_pct": -0.2588,
+            "control_total_net_pct": -12.8977,
+            "candidate_total_net_pct": -13.4592,
+            "control_win_rate": 0.3846,
+            "candidate_win_rate": 0.4038,
+            "delta_win_rate": 0.0192,
+            "control_median_mae_pct": -0.6123,
+            "candidate_median_mae_pct": -0.6123,
+            "control_median_mfe_pct": 0.6738,
+            "candidate_median_mfe_pct": 0.6738,
+            "paired_delta": {
+              "n": 52,
+              "mean": -0.010798,
+              "median": 0.0,
+              "sign_test": {
+                "n": 52,
+                "n_pos": 39,
+                "n_neg": 13,
+                "n_zero": 0,
+                "p_value": 0.00041
+              },
+              "signed_rank": {
+                "n": 52,
+                "w": 1012.0,
+                "z": 2.937,
+                "p_value": 0.003314
+              },
+              "bootstrap": {
+                "point": -0.010798,
+                "lo": -0.08255,
+                "hi": 0.043885,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 23,
+              "control_mean_net_pct": -0.1109,
+              "candidate_mean_net_pct": -0.1551,
+              "control_total_net_pct": -2.5498,
+              "candidate_total_net_pct": -3.5663,
+              "control_win_rate": 0.4348,
+              "candidate_win_rate": 0.4783,
+              "delta_win_rate": 0.0435,
+              "control_median_mae_pct": -0.5046,
+              "candidate_median_mae_pct": -0.5046,
+              "control_median_mfe_pct": 0.5704,
+              "candidate_median_mfe_pct": 0.5704,
+              "paired_delta": {
+                "n": 23,
+                "mean": -0.044196,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 23,
+                  "n_pos": 18,
+                  "n_neg": 5,
+                  "n_zero": 0,
+                  "p_value": 0.010622
+                },
+                "signed_rank": {
+                  "n": 23,
+                  "w": 198.0,
+                  "z": 1.8097,
+                  "p_value": 0.070344
+                },
+                "bootstrap": {
+                  "point": -0.044196,
+                  "lo": -0.191153,
+                  "hi": 0.054522,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 29,
+              "control_mean_net_pct": -0.3568,
+              "candidate_mean_net_pct": -0.3411,
+              "control_total_net_pct": -10.3479,
+              "candidate_total_net_pct": -9.8929,
+              "control_win_rate": 0.3448,
+              "candidate_win_rate": 0.3448,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.6211,
+              "candidate_median_mae_pct": -0.6211,
+              "control_median_mfe_pct": 0.7415,
+              "candidate_median_mfe_pct": 0.7415,
+              "paired_delta": {
+                "n": 29,
+                "mean": 0.01569,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 29,
+                  "n_pos": 21,
+                  "n_neg": 8,
+                  "n_zero": 0,
+                  "p_value": 0.02412
+                },
+                "signed_rank": {
+                  "n": 29,
+                  "w": 322.0,
+                  "z": 2.2488,
+                  "p_value": 0.024524
+                },
+                "bootstrap": {
+                  "point": 0.01569,
+                  "lo": -0.040038,
+                  "hi": 0.064674,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 11,
+          "entries": 6,
+          "win_rate": 0.1667,
+          "mean_net_pct": -0.2743,
+          "total_net_pct": -1.6456,
+          "total_return_pct": -1.71,
+          "max_drawdown_pct": -4.7,
+          "sharpe": -0.417,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 10,
+          "entries": 6,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.2178,
+          "total_net_pct": -1.3066,
+          "total_return_pct": -1.37,
+          "max_drawdown_pct": -4.41,
+          "sharpe": -0.343,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.0565,
+          "lo": -1.796713,
+          "hi": 1.854542,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 6,
+          "paired": 6,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 6,
+            "control_mean_net_pct": -0.2743,
+            "candidate_mean_net_pct": -0.2178,
+            "control_total_net_pct": -1.6456,
+            "candidate_total_net_pct": -1.3066,
+            "control_win_rate": 0.1667,
+            "candidate_win_rate": 0.5,
+            "delta_win_rate": 0.3333,
+            "control_median_mae_pct": -1.2978,
+            "candidate_median_mae_pct": -1.2978,
+            "control_median_mfe_pct": 1.5038,
+            "candidate_median_mfe_pct": 1.5038,
+            "paired_delta": {
+              "n": 6,
+              "mean": 0.0565,
+              "median": 0.0,
+              "sign_test": {
+                "n": 6,
+                "n_pos": 4,
+                "n_neg": 2,
+                "n_zero": 0,
+                "p_value": 0.6875
+              },
+              "signed_rank": {
+                "n": 6,
+                "w": 16.0,
+                "z": 1.0483,
+                "p_value": 0.294507
+              },
+              "bootstrap": {
+                "point": 0.0565,
+                "lo": -0.0605,
+                "hi": 0.18775,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 4,
+              "control_mean_net_pct": -1.1864,
+              "candidate_mean_net_pct": -1.1106,
+              "control_total_net_pct": -4.7454,
+              "candidate_total_net_pct": -4.4424,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.25,
+              "delta_win_rate": 0.25,
+              "control_median_mae_pct": -1.6717,
+              "candidate_median_mae_pct": -1.6717,
+              "control_median_mfe_pct": 0.9892,
+              "candidate_median_mfe_pct": 0.9892,
+              "paired_delta": {
+                "n": 4,
+                "mean": 0.07575,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 3,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 0.625
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 9.0,
+                  "z": 1.278,
+                  "p_value": 0.201243
+                },
+                "bootstrap": {
+                  "point": 0.07575,
+                  "lo": -0.0,
+                  "hi": 0.22725,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": 1.5499,
+              "candidate_mean_net_pct": 1.5679,
+              "control_total_net_pct": 3.0998,
+              "candidate_total_net_pct": 3.1358,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.5,
+              "control_median_mae_pct": -0.2782,
+              "candidate_median_mae_pct": -0.2782,
+              "control_median_mfe_pct": 3.8869,
+              "candidate_median_mfe_pct": 3.8869,
+              "paired_delta": {
+                "n": 2,
+                "mean": 0.018,
+                "median": 0.018,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 2.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.018,
+                  "lo": -0.1815,
+                  "hi": 0.2175,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 118,
+          "entries": 47,
+          "win_rate": 0.4043,
+          "mean_net_pct": -0.1516,
+          "total_net_pct": -7.1247,
+          "total_return_pct": -7.68,
+          "max_drawdown_pct": -15.62,
+          "sharpe": -0.655,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 110,
+          "entries": 47,
+          "win_rate": 0.5106,
+          "mean_net_pct": -0.1596,
+          "total_net_pct": -7.5027,
+          "total_return_pct": -7.89,
+          "max_drawdown_pct": -17.26,
+          "sharpe": -0.71,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.008043,
+          "lo": -0.75767,
+          "hi": 0.731395,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 47,
+          "paired": 47,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 47,
+            "control_mean_net_pct": -0.1516,
+            "candidate_mean_net_pct": -0.1596,
+            "control_total_net_pct": -7.1247,
+            "candidate_total_net_pct": -7.5027,
+            "control_win_rate": 0.4043,
+            "candidate_win_rate": 0.5106,
+            "delta_win_rate": 0.1063,
+            "control_median_mae_pct": -0.8725,
+            "candidate_median_mae_pct": -0.8725,
+            "control_median_mfe_pct": 1.2322,
+            "candidate_median_mfe_pct": 1.2322,
+            "paired_delta": {
+              "n": 47,
+              "mean": -0.008043,
+              "median": 0.0,
+              "sign_test": {
+                "n": 47,
+                "n_pos": 37,
+                "n_neg": 10,
+                "n_zero": 0,
+                "p_value": 9.8e-05
+              },
+              "signed_rank": {
+                "n": 47,
+                "w": 838.0,
+                "z": 2.8942,
+                "p_value": 0.003801
+              },
+              "bootstrap": {
+                "point": -0.008043,
+                "lo": -0.147366,
+                "hi": 0.092426,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 25,
+              "control_mean_net_pct": 0.2461,
+              "candidate_mean_net_pct": 0.1475,
+              "control_total_net_pct": 6.1525,
+              "candidate_total_net_pct": 3.6875,
+              "control_win_rate": 0.52,
+              "candidate_win_rate": 0.6,
+              "delta_win_rate": 0.08,
+              "control_median_mae_pct": -0.6712,
+              "candidate_median_mae_pct": -0.6712,
+              "control_median_mfe_pct": 1.4699,
+              "candidate_median_mfe_pct": 1.4699,
+              "paired_delta": {
+                "n": 25,
+                "mean": -0.0986,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 25,
+                  "n_pos": 17,
+                  "n_neg": 8,
+                  "n_zero": 0,
+                  "p_value": 0.107752
+                },
+                "signed_rank": {
+                  "n": 25,
+                  "w": 197.0,
+                  "z": 0.9148,
+                  "p_value": 0.360278
+                },
+                "bootstrap": {
+                  "point": -0.0986,
+                  "lo": -0.348687,
+                  "hi": 0.063221,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 22,
+              "control_mean_net_pct": -0.6035,
+              "candidate_mean_net_pct": -0.5086,
+              "control_total_net_pct": -13.2772,
+              "candidate_total_net_pct": -11.1902,
+              "control_win_rate": 0.2727,
+              "candidate_win_rate": 0.4091,
+              "delta_win_rate": 0.1364,
+              "control_median_mae_pct": -0.8972,
+              "candidate_median_mae_pct": -0.8972,
+              "control_median_mfe_pct": 1.2036,
+              "candidate_median_mfe_pct": 1.2036,
+              "paired_delta": {
+                "n": 22,
+                "mean": 0.094864,
+                "median": 0.0345,
+                "sign_test": {
+                  "n": 22,
+                  "n_pos": 20,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 0.000121
+                },
+                "signed_rank": {
+                  "n": 22,
+                  "w": 230.0,
+                  "z": 3.344,
+                  "p_value": 0.000826
+                },
+                "bootstrap": {
+                  "point": 0.094864,
+                  "lo": 0.016114,
+                  "hi": 0.180482,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 10,
+          "entries": 7,
+          "win_rate": 0.1429,
+          "mean_net_pct": -3.0855,
+          "total_net_pct": -21.5982,
+          "total_return_pct": -20.3,
+          "max_drawdown_pct": -20.49,
+          "sharpe": -3.077,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 9,
+          "entries": 7,
+          "win_rate": 0.1429,
+          "mean_net_pct": -3.5244,
+          "total_net_pct": -24.6707,
+          "total_return_pct": -22.58,
+          "max_drawdown_pct": -22.77,
+          "sharpe": -3.623,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.438929,
+          "lo": -4.992536,
+          "hi": 3.727143,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 7,
+          "paired": 7,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 7,
+            "control_mean_net_pct": -3.0855,
+            "candidate_mean_net_pct": -3.5244,
+            "control_total_net_pct": -21.5982,
+            "candidate_total_net_pct": -24.6707,
+            "control_win_rate": 0.1429,
+            "candidate_win_rate": 0.1429,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -4.6597,
+            "candidate_median_mae_pct": -4.6597,
+            "control_median_mfe_pct": 0.6397,
+            "candidate_median_mfe_pct": 0.6397,
+            "paired_delta": {
+              "n": 7,
+              "mean": -0.438929,
+              "median": -0.0,
+              "sign_test": {
+                "n": 6,
+                "n_pos": 0,
+                "n_neg": 6,
+                "n_zero": 1,
+                "p_value": 0.03125
+              },
+              "signed_rank": {
+                "n": 6,
+                "w": 0,
+                "z": -2.0966,
+                "p_value": 0.036032
+              },
+              "bootstrap": {
+                "point": -0.438929,
+                "lo": -1.316786,
+                "hi": -0.0,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": -6.1801,
+              "candidate_mean_net_pct": -6.1801,
+              "control_total_net_pct": -12.3602,
+              "candidate_total_net_pct": -12.3602,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -6.8786,
+              "candidate_median_mae_pct": -6.8786,
+              "control_median_mfe_pct": 0.9683,
+              "candidate_median_mfe_pct": 0.9683,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.0,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 0,
+                  "n_neg": 1,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.0,
+                  "lo": -0.0,
+                  "hi": 0.0,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 5,
+              "control_mean_net_pct": -1.8476,
+              "candidate_mean_net_pct": -2.4621,
+              "control_total_net_pct": -9.238,
+              "candidate_total_net_pct": -12.3105,
+              "control_win_rate": 0.2,
+              "candidate_win_rate": 0.2,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -3.5262,
+              "candidate_median_mae_pct": -3.5262,
+              "control_median_mfe_pct": 0.6397,
+              "candidate_median_mfe_pct": 0.6397,
+              "paired_delta": {
+                "n": 5,
+                "mean": -0.6145,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 5,
+                  "n_pos": 0,
+                  "n_neg": 5,
+                  "n_zero": 0,
+                  "p_value": 0.0625
+                },
+                "signed_rank": {
+                  "n": 5,
+                  "w": 0,
+                  "z": -1.8878,
+                  "p_value": 0.059058
+                },
+                "bootstrap": {
+                  "point": -0.6145,
+                  "lo": -1.8435,
+                  "hi": -0.0,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 97,
+          "entries": 46,
+          "win_rate": 0.4348,
+          "mean_net_pct": -0.3263,
+          "total_net_pct": -15.0096,
+          "total_return_pct": -14.72,
+          "max_drawdown_pct": -27.07,
+          "sharpe": -1.223,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 84,
+          "entries": 46,
+          "win_rate": 0.4783,
+          "mean_net_pct": -0.3141,
+          "total_net_pct": -14.4486,
+          "total_return_pct": -14.23,
+          "max_drawdown_pct": -26.9,
+          "sharpe": -1.212,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.012196,
+          "lo": -0.870751,
+          "hi": 0.897645,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 46,
+          "paired": 46,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 46,
+            "control_mean_net_pct": -0.3263,
+            "candidate_mean_net_pct": -0.3141,
+            "control_total_net_pct": -15.0096,
+            "candidate_total_net_pct": -14.4486,
+            "control_win_rate": 0.4348,
+            "candidate_win_rate": 0.4783,
+            "delta_win_rate": 0.0435,
+            "control_median_mae_pct": -1.1858,
+            "candidate_median_mae_pct": -1.1858,
+            "control_median_mfe_pct": 1.1282,
+            "candidate_median_mfe_pct": 1.1282,
+            "paired_delta": {
+              "n": 46,
+              "mean": 0.012196,
+              "median": -0.0,
+              "sign_test": {
+                "n": 46,
+                "n_pos": 20,
+                "n_neg": 26,
+                "n_zero": 0,
+                "p_value": 0.461391
+              },
+              "signed_rank": {
+                "n": 46,
+                "w": 544.0,
+                "z": 0.0328,
+                "p_value": 0.973853
+              },
+              "bootstrap": {
+                "point": 0.012196,
+                "lo": -0.054924,
+                "hi": 0.076228,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 23,
+              "control_mean_net_pct": -0.7991,
+              "candidate_mean_net_pct": -0.7364,
+              "control_total_net_pct": -18.3798,
+              "candidate_total_net_pct": -16.9383,
+              "control_win_rate": 0.3913,
+              "candidate_win_rate": 0.3913,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1875,
+              "candidate_median_mae_pct": -1.1875,
+              "control_median_mfe_pct": 0.9527,
+              "candidate_median_mfe_pct": 0.9527,
+              "paired_delta": {
+                "n": 23,
+                "mean": 0.062674,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 23,
+                  "n_pos": 11,
+                  "n_neg": 12,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 23,
+                  "w": 166.0,
+                  "z": 0.8364,
+                  "p_value": 0.402924
+                },
+                "bootstrap": {
+                  "point": 0.062674,
+                  "lo": -0.004152,
+                  "hi": 0.144047,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 23,
+              "control_mean_net_pct": 0.1465,
+              "candidate_mean_net_pct": 0.1082,
+              "control_total_net_pct": 3.3702,
+              "candidate_total_net_pct": 2.4897,
+              "control_win_rate": 0.4783,
+              "candidate_win_rate": 0.5652,
+              "delta_win_rate": 0.0869,
+              "control_median_mae_pct": -1.184,
+              "candidate_median_mae_pct": -1.184,
+              "control_median_mfe_pct": 1.4441,
+              "candidate_median_mfe_pct": 1.4441,
+              "paired_delta": {
+                "n": 23,
+                "mean": -0.038283,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 23,
+                  "n_pos": 9,
+                  "n_neg": 14,
+                  "n_zero": 0,
+                  "p_value": 0.404873
+                },
+                "signed_rank": {
+                  "n": 23,
+                  "w": 114.0,
+                  "z": -0.7148,
+                  "p_value": 0.474763
+                },
+                "bootstrap": {
+                  "point": -0.038283,
+                  "lo": -0.148263,
+                  "hi": 0.056681,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 21,
+          "entries": 9,
+          "win_rate": 0.4444,
+          "mean_net_pct": -0.5073,
+          "total_net_pct": -4.5659,
+          "total_return_pct": -5.21,
+          "max_drawdown_pct": -17.32,
+          "sharpe": -0.331,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 16,
+          "entries": 9,
+          "win_rate": 0.4444,
+          "mean_net_pct": -0.4552,
+          "total_net_pct": -4.0969,
+          "total_return_pct": -4.73,
+          "max_drawdown_pct": -16.59,
+          "sharpe": -0.319,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.052111,
+          "lo": -3.761079,
+          "hi": 3.81859,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 9,
+          "paired": 9,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 9,
+            "control_mean_net_pct": -0.5073,
+            "candidate_mean_net_pct": -0.4552,
+            "control_total_net_pct": -4.5659,
+            "candidate_total_net_pct": -4.0969,
+            "control_win_rate": 0.4444,
+            "candidate_win_rate": 0.4444,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.5347,
+            "candidate_median_mae_pct": -1.5347,
+            "control_median_mfe_pct": 3.0589,
+            "candidate_median_mfe_pct": 3.0589,
+            "paired_delta": {
+              "n": 9,
+              "mean": 0.052111,
+              "median": 0.0,
+              "sign_test": {
+                "n": 8,
+                "n_pos": 6,
+                "n_neg": 2,
+                "n_zero": 1,
+                "p_value": 0.289062
+              },
+              "signed_rank": {
+                "n": 8,
+                "w": 24.0,
+                "z": 0.7702,
+                "p_value": 0.441209
+              },
+              "bootstrap": {
+                "point": 0.052111,
+                "lo": -0.195722,
+                "hi": 0.288,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 4,
+              "control_mean_net_pct": -2.0132,
+              "candidate_mean_net_pct": -2.1841,
+              "control_total_net_pct": -8.0529,
+              "candidate_total_net_pct": -8.7364,
+              "control_win_rate": 0.25,
+              "candidate_win_rate": 0.25,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -3.779,
+              "candidate_median_mae_pct": -3.779,
+              "control_median_mfe_pct": 1.0669,
+              "candidate_median_mfe_pct": 1.0669,
+              "paired_delta": {
+                "n": 4,
+                "mean": -0.170875,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 3,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 0.625
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 6.0,
+                  "z": 0.1826,
+                  "p_value": 0.855132
+                },
+                "bootstrap": {
+                  "point": -0.170875,
+                  "lo": -0.512625,
+                  "hi": 0.0,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 5,
+              "control_mean_net_pct": 0.6974,
+              "candidate_mean_net_pct": 0.9279,
+              "control_total_net_pct": 3.487,
+              "candidate_total_net_pct": 4.6395,
+              "control_win_rate": 0.6,
+              "candidate_win_rate": 0.6,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.2472,
+              "candidate_median_mae_pct": -0.2472,
+              "control_median_mfe_pct": 3.4338,
+              "candidate_median_mfe_pct": 3.4338,
+              "paired_delta": {
+                "n": 5,
+                "mean": 0.2305,
+                "median": 0.294,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 3,
+                  "n_neg": 1,
+                  "n_zero": 1,
+                  "p_value": 0.625
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 9.0,
+                  "z": 1.278,
+                  "p_value": 0.201243
+                },
+                "bootstrap": {
+                  "point": 0.2305,
+                  "lo": -0.0531,
+                  "hi": 0.51,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 99,
+          "entries": 41,
+          "win_rate": 0.2927,
+          "mean_net_pct": -0.6321,
+          "total_net_pct": -25.9166,
+          "total_return_pct": -23.17,
+          "max_drawdown_pct": -23.87,
+          "sharpe": -3.799,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 66,
+          "entries": 41,
+          "win_rate": 0.3171,
+          "mean_net_pct": -0.6085,
+          "total_net_pct": -24.9501,
+          "total_return_pct": -22.42,
+          "max_drawdown_pct": -23.13,
+          "sharpe": -3.736,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.023573,
+          "lo": -0.548531,
+          "hi": 0.612394,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 41,
+          "paired": 41,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 41,
+            "control_mean_net_pct": -0.6321,
+            "candidate_mean_net_pct": -0.6085,
+            "control_total_net_pct": -25.9166,
+            "candidate_total_net_pct": -24.9501,
+            "control_win_rate": 0.2927,
+            "candidate_win_rate": 0.3171,
+            "delta_win_rate": 0.0244,
+            "control_median_mae_pct": -0.8884,
+            "candidate_median_mae_pct": -0.8884,
+            "control_median_mfe_pct": 0.6125,
+            "candidate_median_mfe_pct": 0.6125,
+            "paired_delta": {
+              "n": 41,
+              "mean": 0.023573,
+              "median": 0.0,
+              "sign_test": {
+                "n": 40,
+                "n_pos": 27,
+                "n_neg": 13,
+                "n_zero": 1,
+                "p_value": 0.038477
+              },
+              "signed_rank": {
+                "n": 40,
+                "w": 581.0,
+                "z": 2.2917,
+                "p_value": 0.021921
+              },
+              "bootstrap": {
+                "point": 0.023573,
+                "lo": -0.010757,
+                "hi": 0.054879,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 25,
+              "control_mean_net_pct": -0.6101,
+              "candidate_mean_net_pct": -0.569,
+              "control_total_net_pct": -15.2525,
+              "candidate_total_net_pct": -14.2245,
+              "control_win_rate": 0.28,
+              "candidate_win_rate": 0.32,
+              "delta_win_rate": 0.04,
+              "control_median_mae_pct": -0.6594,
+              "candidate_median_mae_pct": -0.6594,
+              "control_median_mfe_pct": 0.6339,
+              "candidate_median_mfe_pct": 0.6339,
+              "paired_delta": {
+                "n": 25,
+                "mean": 0.04112,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 25,
+                  "n_pos": 17,
+                  "n_neg": 8,
+                  "n_zero": 0,
+                  "p_value": 0.107752
+                },
+                "signed_rank": {
+                  "n": 25,
+                  "w": 251.0,
+                  "z": 2.3678,
+                  "p_value": 0.017894
+                },
+                "bootstrap": {
+                  "point": 0.04112,
+                  "lo": 0.001959,
+                  "hi": 0.077341,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 16,
+              "control_mean_net_pct": -0.6665,
+              "candidate_mean_net_pct": -0.6704,
+              "control_total_net_pct": -10.6641,
+              "candidate_total_net_pct": -10.7256,
+              "control_win_rate": 0.3125,
+              "candidate_win_rate": 0.3125,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.4901,
+              "candidate_median_mae_pct": -1.4901,
+              "control_median_mfe_pct": 0.5897,
+              "candidate_median_mfe_pct": 0.5897,
+              "paired_delta": {
+                "n": 16,
+                "mean": -0.003844,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 15,
+                  "n_pos": 10,
+                  "n_neg": 5,
+                  "n_zero": 1,
+                  "p_value": 0.301758
+                },
+                "signed_rank": {
+                  "n": 15,
+                  "w": 72.0,
+                  "z": 0.6532,
+                  "p_value": 0.513656
+                },
+                "bootstrap": {
+                  "point": -0.003844,
+                  "lo": -0.064313,
+                  "hi": 0.0475,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 10,
+          "entries": 4,
+          "win_rate": 0.75,
+          "mean_net_pct": 1.5718,
+          "total_net_pct": 6.2871,
+          "total_return_pct": 6.4,
+          "max_drawdown_pct": -2.73,
+          "sharpe": 1.887,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 9,
+          "entries": 4,
+          "win_rate": 0.75,
+          "mean_net_pct": 1.6844,
+          "total_net_pct": 6.7376,
+          "total_return_pct": 6.88,
+          "max_drawdown_pct": -2.21,
+          "sharpe": 2.226,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.112625,
+          "lo": -1.386075,
+          "hi": 1.656,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 4,
+          "paired": 4,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 4,
+            "control_mean_net_pct": 1.5718,
+            "candidate_mean_net_pct": 1.6844,
+            "control_total_net_pct": 6.2871,
+            "candidate_total_net_pct": 6.7376,
+            "control_win_rate": 0.75,
+            "candidate_win_rate": 0.75,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.871,
+            "candidate_median_mae_pct": -0.871,
+            "control_median_mfe_pct": 3.128,
+            "candidate_median_mfe_pct": 3.128,
+            "paired_delta": {
+              "n": 4,
+              "mean": 0.112625,
+              "median": 0.168,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 3,
+                "n_neg": 1,
+                "n_zero": 0,
+                "p_value": 0.625
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 8.0,
+                "z": 0.9129,
+                "p_value": 0.36131
+              },
+              "bootstrap": {
+                "point": 0.112625,
+                "lo": -0.077625,
+                "hi": 0.273,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": 2.8599,
+              "candidate_mean_net_pct": 2.9499,
+              "control_total_net_pct": 2.8599,
+              "candidate_total_net_pct": 2.9499,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.511,
+              "candidate_median_mae_pct": -0.511,
+              "control_median_mfe_pct": 6.2465,
+              "candidate_median_mfe_pct": 6.2465,
+              "paired_delta": {
+                "n": 1,
+                "mean": 0.09,
+                "median": 0.09,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.09,
+                  "lo": 0.09,
+                  "hi": 0.09,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 3,
+              "control_mean_net_pct": 1.1424,
+              "candidate_mean_net_pct": 1.2626,
+              "control_total_net_pct": 3.4272,
+              "candidate_total_net_pct": 3.7877,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1369,
+              "candidate_median_mae_pct": -1.1369,
+              "control_median_mfe_pct": 2.5283,
+              "candidate_median_mfe_pct": 2.5283,
+              "paired_delta": {
+                "n": 3,
+                "mean": 0.120167,
+                "median": 0.246,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 2,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 5.0,
+                  "z": 0.8018,
+                  "p_value": 0.422678
+                },
+                "bootstrap": {
+                  "point": 0.120167,
+                  "lo": -0.1855,
+                  "hi": 0.3,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 79,
+          "entries": 39,
+          "win_rate": 0.4615,
+          "mean_net_pct": -0.4446,
+          "total_net_pct": -17.3389,
+          "total_return_pct": -17.01,
+          "max_drawdown_pct": -21.92,
+          "sharpe": -1.601,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 66,
+          "entries": 40,
+          "win_rate": 0.45,
+          "mean_net_pct": -0.5017,
+          "total_net_pct": -20.068,
+          "total_return_pct": -19.23,
+          "max_drawdown_pct": -24.29,
+          "sharpe": -1.833,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.057113,
+          "lo": -1.197472,
+          "hi": 1.088112,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 39,
+          "paired": 39,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 39,
+            "control_mean_net_pct": -0.4446,
+            "candidate_mean_net_pct": -0.4574,
+            "control_total_net_pct": -17.3389,
+            "candidate_total_net_pct": -17.8379,
+            "control_win_rate": 0.4615,
+            "candidate_win_rate": 0.4615,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.2037,
+            "candidate_median_mae_pct": -1.2037,
+            "control_median_mfe_pct": 1.3734,
+            "candidate_median_mfe_pct": 1.3734,
+            "paired_delta": {
+              "n": 39,
+              "mean": -0.012795,
+              "median": 0.0,
+              "sign_test": {
+                "n": 38,
+                "n_pos": 27,
+                "n_neg": 11,
+                "n_zero": 1,
+                "p_value": 0.013853
+              },
+              "signed_rank": {
+                "n": 38,
+                "w": 500.0,
+                "z": 1.8708,
+                "p_value": 0.061374
+              },
+              "bootstrap": {
+                "point": -0.012795,
+                "lo": -0.144052,
+                "hi": 0.113066,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 20,
+              "control_mean_net_pct": -0.5782,
+              "candidate_mean_net_pct": -0.5795,
+              "control_total_net_pct": -11.5645,
+              "candidate_total_net_pct": -11.59,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.3174,
+              "candidate_median_mae_pct": -1.3174,
+              "control_median_mfe_pct": 1.1992,
+              "candidate_median_mfe_pct": 1.1992,
+              "paired_delta": {
+                "n": 20,
+                "mean": -0.001275,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 20,
+                  "n_pos": 13,
+                  "n_neg": 7,
+                  "n_zero": 0,
+                  "p_value": 0.263176
+                },
+                "signed_rank": {
+                  "n": 20,
+                  "w": 135.0,
+                  "z": 1.1013,
+                  "p_value": 0.27076
+                },
+                "bootstrap": {
+                  "point": -0.001275,
+                  "lo": -0.181652,
+                  "hi": 0.168257,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 19,
+              "control_mean_net_pct": -0.3039,
+              "candidate_mean_net_pct": -0.3288,
+              "control_total_net_pct": -5.7744,
+              "candidate_total_net_pct": -6.2479,
+              "control_win_rate": 0.4211,
+              "candidate_win_rate": 0.4211,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.2037,
+              "candidate_median_mae_pct": -1.2037,
+              "control_median_mfe_pct": 1.3734,
+              "candidate_median_mfe_pct": 1.3734,
+              "paired_delta": {
+                "n": 19,
+                "mean": -0.024921,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 18,
+                  "n_pos": 14,
+                  "n_neg": 4,
+                  "n_zero": 1,
+                  "p_value": 0.030884
+                },
+                "signed_rank": {
+                  "n": 18,
+                  "w": 123.0,
+                  "z": 1.6114,
+                  "p_value": 0.107101
+                },
+                "bootstrap": {
+                  "point": -0.024921,
+                  "lo": -0.222634,
+                  "hi": 0.151767,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 25,
+          "entries": 5,
+          "win_rate": 0.6,
+          "mean_net_pct": 0.0939,
+          "total_net_pct": 0.4695,
+          "total_return_pct": 0.28,
+          "max_drawdown_pct": -12.36,
+          "sharpe": 0.121,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 10,
+          "entries": 5,
+          "win_rate": 0.6,
+          "mean_net_pct": 0.2247,
+          "total_net_pct": 1.1235,
+          "total_return_pct": 0.92,
+          "max_drawdown_pct": -12.36,
+          "sharpe": 0.217,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.1308,
+          "lo": -3.49893,
+          "hi": 3.7282,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 5,
+          "paired": 5,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 5,
+            "control_mean_net_pct": 0.0939,
+            "candidate_mean_net_pct": 0.2247,
+            "control_total_net_pct": 0.4695,
+            "candidate_total_net_pct": 1.1235,
+            "control_win_rate": 0.6,
+            "candidate_win_rate": 0.6,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.7333,
+            "candidate_median_mae_pct": -0.7333,
+            "control_median_mfe_pct": 3.5365,
+            "candidate_median_mfe_pct": 3.5365,
+            "paired_delta": {
+              "n": 5,
+              "mean": 0.1308,
+              "median": 0.138,
+              "sign_test": {
+                "n": 5,
+                "n_pos": 4,
+                "n_neg": 1,
+                "n_zero": 0,
+                "p_value": 0.375
+              },
+              "signed_rank": {
+                "n": 5,
+                "w": 14.0,
+                "z": 1.6181,
+                "p_value": 0.105645
+              },
+              "bootstrap": {
+                "point": 0.1308,
+                "lo": 0.0276,
+                "hi": 0.2508,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": -3.6201,
+              "candidate_mean_net_pct": -3.6201,
+              "control_total_net_pct": -3.6201,
+              "candidate_total_net_pct": -3.6201,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -3.5691,
+              "candidate_median_mae_pct": -3.5691,
+              "control_median_mfe_pct": 2.7084,
+              "candidate_median_mfe_pct": 2.7084,
+              "paired_delta": {
+                "n": 1,
+                "mean": -0.0,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 0,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.0,
+                  "lo": -0.0,
+                  "hi": -0.0,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 4,
+              "control_mean_net_pct": 1.0224,
+              "candidate_mean_net_pct": 1.1859,
+              "control_total_net_pct": 4.0896,
+              "candidate_total_net_pct": 4.7436,
+              "control_win_rate": 0.75,
+              "candidate_win_rate": 0.75,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.6082,
+              "candidate_median_mae_pct": -0.6082,
+              "control_median_mfe_pct": 3.947,
+              "candidate_median_mfe_pct": 3.947,
+              "paired_delta": {
+                "n": 4,
+                "mean": 0.1635,
+                "median": 0.1425,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 4,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 0.125
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 10.0,
+                  "z": 1.6432,
+                  "p_value": 0.100348
+                },
+                "bootstrap": {
+                  "point": 0.1635,
+                  "lo": 0.03675,
+                  "hi": 0.31125,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 69,
+          "entries": 28,
+          "win_rate": 0.4643,
+          "mean_net_pct": -0.0112,
+          "total_net_pct": -0.3128,
+          "total_return_pct": -1.02,
+          "max_drawdown_pct": -14.51,
+          "sharpe": -0.029,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 56,
+          "entries": 28,
+          "win_rate": 0.4643,
+          "mean_net_pct": -0.1315,
+          "total_net_pct": -3.6828,
+          "total_return_pct": -4.16,
+          "max_drawdown_pct": -14.41,
+          "sharpe": -0.426,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.120357,
+          "lo": -1.266217,
+          "hi": 1.016518,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 28,
+          "paired": 28,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 28,
+            "control_mean_net_pct": -0.0112,
+            "candidate_mean_net_pct": -0.1315,
+            "control_total_net_pct": -0.3128,
+            "candidate_total_net_pct": -3.6828,
+            "control_win_rate": 0.4643,
+            "candidate_win_rate": 0.4643,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.8939,
+            "candidate_median_mae_pct": -0.8939,
+            "control_median_mfe_pct": 1.3862,
+            "candidate_median_mfe_pct": 1.3862,
+            "paired_delta": {
+              "n": 28,
+              "mean": -0.120357,
+              "median": 0.0,
+              "sign_test": {
+                "n": 27,
+                "n_pos": 15,
+                "n_neg": 12,
+                "n_zero": 1,
+                "p_value": 0.701108
+              },
+              "signed_rank": {
+                "n": 27,
+                "w": 179.0,
+                "z": -0.2282,
+                "p_value": 0.819462
+              },
+              "bootstrap": {
+                "point": -0.120357,
+                "lo": -0.34702,
+                "hi": 0.031829,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 18,
+              "control_mean_net_pct": -0.2366,
+              "candidate_mean_net_pct": -0.2552,
+              "control_total_net_pct": -4.2593,
+              "candidate_total_net_pct": -4.5938,
+              "control_win_rate": 0.4444,
+              "candidate_win_rate": 0.4444,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.8159,
+              "candidate_median_mae_pct": -0.8159,
+              "control_median_mfe_pct": 1.5573,
+              "candidate_median_mfe_pct": 1.5573,
+              "paired_delta": {
+                "n": 18,
+                "mean": -0.018583,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 18,
+                  "n_pos": 10,
+                  "n_neg": 8,
+                  "n_zero": 0,
+                  "p_value": 0.814529
+                },
+                "signed_rank": {
+                  "n": 18,
+                  "w": 89.0,
+                  "z": 0.1307,
+                  "p_value": 0.896051
+                },
+                "bootstrap": {
+                  "point": -0.018583,
+                  "lo": -0.122417,
+                  "hi": 0.073557,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 10,
+              "control_mean_net_pct": 0.3946,
+              "candidate_mean_net_pct": 0.0911,
+              "control_total_net_pct": 3.9465,
+              "candidate_total_net_pct": 0.911,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.3412,
+              "candidate_median_mae_pct": -1.3412,
+              "control_median_mfe_pct": 1.2472,
+              "candidate_median_mfe_pct": 1.2472,
+              "paired_delta": {
+                "n": 10,
+                "mean": -0.30355,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 9,
+                  "n_pos": 5,
+                  "n_neg": 4,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 9,
+                  "w": 19.0,
+                  "z": -0.3554,
+                  "p_value": 0.722283
+                },
+                "bootstrap": {
+                  "point": -0.30355,
+                  "lo": -0.870651,
+                  "hi": 0.06025,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 27,
+          "entries": 10,
+          "win_rate": 0.6,
+          "mean_net_pct": -0.2056,
+          "total_net_pct": -2.056,
+          "total_return_pct": -2.59,
+          "max_drawdown_pct": -11.04,
+          "sharpe": -0.23,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 18,
+          "entries": 10,
+          "win_rate": 0.6,
+          "mean_net_pct": -0.0711,
+          "total_net_pct": -0.711,
+          "total_return_pct": -1.28,
+          "max_drawdown_pct": -10.27,
+          "sharpe": -0.075,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.1345,
+          "lo": -2.81183,
+          "hi": 3.101751,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 10,
+          "paired": 10,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 10,
+            "control_mean_net_pct": -0.2056,
+            "candidate_mean_net_pct": -0.0711,
+            "control_total_net_pct": -2.056,
+            "candidate_total_net_pct": -0.711,
+            "control_win_rate": 0.6,
+            "candidate_win_rate": 0.6,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -2.2254,
+            "candidate_median_mae_pct": -2.2254,
+            "control_median_mfe_pct": 3.8576,
+            "candidate_median_mfe_pct": 3.8576,
+            "paired_delta": {
+              "n": 10,
+              "mean": 0.1345,
+              "median": 0.06525,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 6,
+                "n_neg": 3,
+                "n_zero": 1,
+                "p_value": 0.507812
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 34.0,
+                "z": 1.3032,
+                "p_value": 0.192518
+              },
+              "bootstrap": {
+                "point": 0.1345,
+                "lo": -0.0629,
+                "hi": 0.361525,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 5,
+              "control_mean_net_pct": 0.5399,
+              "candidate_mean_net_pct": 0.5219,
+              "control_total_net_pct": 2.6995,
+              "candidate_total_net_pct": 2.6095,
+              "control_win_rate": 0.6,
+              "candidate_win_rate": 0.6,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.7655,
+              "candidate_median_mae_pct": -0.7655,
+              "control_median_mfe_pct": 3.8568,
+              "candidate_median_mfe_pct": 3.8568,
+              "paired_delta": {
+                "n": 5,
+                "mean": -0.018,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 5,
+                  "n_pos": 3,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 5,
+                  "w": 9.0,
+                  "z": 0.2697,
+                  "p_value": 0.787406
+                },
+                "bootstrap": {
+                  "point": -0.018,
+                  "lo": -0.2583,
+                  "hi": 0.1536,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 5,
+              "control_mean_net_pct": -0.9511,
+              "candidate_mean_net_pct": -0.6641,
+              "control_total_net_pct": -4.7555,
+              "candidate_total_net_pct": -3.3205,
+              "control_win_rate": 0.6,
+              "candidate_win_rate": 0.6,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.8324,
+              "candidate_median_mae_pct": -2.8324,
+              "control_median_mfe_pct": 3.8584,
+              "candidate_median_mfe_pct": 3.8584,
+              "paired_delta": {
+                "n": 5,
+                "mean": 0.287,
+                "median": 0.1885,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 3,
+                  "n_neg": 1,
+                  "n_zero": 1,
+                  "p_value": 0.625
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 9.0,
+                  "z": 1.278,
+                  "p_value": 0.201243
+                },
+                "bootstrap": {
+                  "point": 0.287,
+                  "lo": 0.0377,
+                  "hi": 0.6321,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/mr.rd_lighter.json
+++ b/backtest/research/regime_1152_runs/mr.rd_lighter.json
@@ -1,0 +1,2007 @@
+{
+  "open": {
+    "name": "mean_reversion",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "tp_tiers": {
+          "ranging_directional": [
+            {
+              "atr_multiple": 1.0,
+              "close_fraction": 0.15,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 0.35,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 0.6,
+              "trailing_mult_after": 0.8
+            },
+            {
+              "atr_multiple": 4.5,
+              "close_fraction": 0.6,
+              "trailing_mult_after": 0.6
+            }
+          ],
+          "ranging_directional_up": [
+            {
+              "atr_multiple": 1.0,
+              "close_fraction": 0.15,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 0.35,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 0.6,
+              "trailing_mult_after": 0.8
+            },
+            {
+              "atr_multiple": 4.5,
+              "close_fraction": 0.6,
+              "trailing_mult_after": 0.6
+            }
+          ],
+          "ranging_directional_down": [
+            {
+              "atr_multiple": 1.0,
+              "close_fraction": 0.15,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 0.35,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 0.6,
+              "trailing_mult_after": 0.8
+            },
+            {
+              "atr_multiple": 4.5,
+              "close_fraction": 0.6,
+              "trailing_mult_after": 0.6
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "control_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_directional"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 98,
+          "entries": 52,
+          "win_rate": 0.3846,
+          "mean_net_pct": -0.248,
+          "total_net_pct": -12.8977,
+          "total_return_pct": -12.43,
+          "max_drawdown_pct": -17.93,
+          "sharpe": -1.698,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 126,
+          "entries": 52,
+          "win_rate": 0.3846,
+          "mean_net_pct": -0.2495,
+          "total_net_pct": -12.9732,
+          "total_return_pct": -12.53,
+          "max_drawdown_pct": -17.77,
+          "sharpe": -1.663,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.001452,
+          "lo": -0.440274,
+          "hi": 0.440796,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 52,
+          "paired": 52,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 52,
+            "control_mean_net_pct": -0.248,
+            "candidate_mean_net_pct": -0.2495,
+            "control_total_net_pct": -12.8977,
+            "candidate_total_net_pct": -12.9732,
+            "control_win_rate": 0.3846,
+            "candidate_win_rate": 0.3846,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.6123,
+            "candidate_median_mae_pct": -0.6123,
+            "control_median_mfe_pct": 0.6738,
+            "candidate_median_mfe_pct": 0.6738,
+            "paired_delta": {
+              "n": 52,
+              "mean": -0.001452,
+              "median": -0.0,
+              "sign_test": {
+                "n": 52,
+                "n_pos": 25,
+                "n_neg": 27,
+                "n_zero": 0,
+                "p_value": 0.889884
+              },
+              "signed_rank": {
+                "n": 52,
+                "w": 540.0,
+                "z": -1.3524,
+                "p_value": 0.176255
+              },
+              "bootstrap": {
+                "point": -0.001452,
+                "lo": -0.029337,
+                "hi": 0.031877,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 23,
+              "control_mean_net_pct": -0.1109,
+              "candidate_mean_net_pct": -0.0969,
+              "control_total_net_pct": -2.5498,
+              "candidate_total_net_pct": -2.2283,
+              "control_win_rate": 0.4348,
+              "candidate_win_rate": 0.4348,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.5046,
+              "candidate_median_mae_pct": -0.5046,
+              "control_median_mfe_pct": 0.5704,
+              "candidate_median_mfe_pct": 0.5704,
+              "paired_delta": {
+                "n": 23,
+                "mean": 0.013978,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 23,
+                  "n_pos": 12,
+                  "n_neg": 11,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 23,
+                  "w": 119.0,
+                  "z": -0.5627,
+                  "p_value": 0.573655
+                },
+                "bootstrap": {
+                  "point": 0.013978,
+                  "lo": -0.03363,
+                  "hi": 0.077483,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 29,
+              "control_mean_net_pct": -0.3568,
+              "candidate_mean_net_pct": -0.3705,
+              "control_total_net_pct": -10.3479,
+              "candidate_total_net_pct": -10.7449,
+              "control_win_rate": 0.3448,
+              "candidate_win_rate": 0.3448,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.6211,
+              "candidate_median_mae_pct": -0.6211,
+              "control_median_mfe_pct": 0.7415,
+              "candidate_median_mfe_pct": 0.7415,
+              "paired_delta": {
+                "n": 29,
+                "mean": -0.01369,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 29,
+                  "n_pos": 13,
+                  "n_neg": 16,
+                  "n_zero": 0,
+                  "p_value": 0.711071
+                },
+                "signed_rank": {
+                  "n": 29,
+                  "w": 156.0,
+                  "z": -1.319,
+                  "p_value": 0.187164
+                },
+                "bootstrap": {
+                  "point": -0.01369,
+                  "lo": -0.042897,
+                  "hi": 0.019173,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 11,
+          "entries": 6,
+          "win_rate": 0.1667,
+          "mean_net_pct": -0.2743,
+          "total_net_pct": -1.6456,
+          "total_return_pct": -1.71,
+          "max_drawdown_pct": -4.7,
+          "sharpe": -0.417,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 11,
+          "entries": 6,
+          "win_rate": 0.1667,
+          "mean_net_pct": -0.3184,
+          "total_net_pct": -1.9106,
+          "total_return_pct": -1.97,
+          "max_drawdown_pct": -4.89,
+          "sharpe": -0.469,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.044167,
+          "lo": -1.905721,
+          "hi": 1.815289,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 6,
+          "paired": 6,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 6,
+            "control_mean_net_pct": -0.2743,
+            "candidate_mean_net_pct": -0.3184,
+            "control_total_net_pct": -1.6456,
+            "candidate_total_net_pct": -1.9106,
+            "control_win_rate": 0.1667,
+            "candidate_win_rate": 0.1667,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.2978,
+            "candidate_median_mae_pct": -1.2978,
+            "control_median_mfe_pct": 1.5038,
+            "candidate_median_mfe_pct": 1.5038,
+            "paired_delta": {
+              "n": 6,
+              "mean": -0.044167,
+              "median": 0.0,
+              "sign_test": {
+                "n": 6,
+                "n_pos": 3,
+                "n_neg": 3,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 6,
+                "w": 9.0,
+                "z": -0.2097,
+                "p_value": 0.833935
+              },
+              "bootstrap": {
+                "point": -0.044167,
+                "lo": -0.125167,
+                "hi": 0.027333,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 4,
+              "control_mean_net_pct": -1.1864,
+              "candidate_mean_net_pct": -1.2369,
+              "control_total_net_pct": -4.7454,
+              "candidate_total_net_pct": -4.9474,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.6717,
+              "candidate_median_mae_pct": -1.6717,
+              "control_median_mfe_pct": 0.9892,
+              "candidate_median_mfe_pct": 0.9892,
+              "paired_delta": {
+                "n": 4,
+                "mean": -0.0505,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 2,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 5.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.0505,
+                  "lo": -0.1515,
+                  "hi": 0.0,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": 1.5499,
+              "candidate_mean_net_pct": 1.5184,
+              "control_total_net_pct": 3.0998,
+              "candidate_total_net_pct": 3.0368,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.2782,
+              "candidate_median_mae_pct": -0.2782,
+              "control_median_mfe_pct": 3.8869,
+              "candidate_median_mfe_pct": 3.8869,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.0315,
+                "median": -0.0315,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.0315,
+                  "lo": -0.145,
+                  "hi": 0.082,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 118,
+          "entries": 47,
+          "win_rate": 0.4043,
+          "mean_net_pct": -0.1516,
+          "total_net_pct": -7.1247,
+          "total_return_pct": -7.68,
+          "max_drawdown_pct": -15.62,
+          "sharpe": -0.655,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 110,
+          "entries": 47,
+          "win_rate": 0.4043,
+          "mean_net_pct": -0.151,
+          "total_net_pct": -7.0967,
+          "total_return_pct": -7.77,
+          "max_drawdown_pct": -14.8,
+          "sharpe": -0.635,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.000596,
+          "lo": -0.801565,
+          "hi": 0.812607,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 47,
+          "paired": 47,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 47,
+            "control_mean_net_pct": -0.1516,
+            "candidate_mean_net_pct": -0.151,
+            "control_total_net_pct": -7.1247,
+            "candidate_total_net_pct": -7.0967,
+            "control_win_rate": 0.4043,
+            "candidate_win_rate": 0.4043,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.8725,
+            "candidate_median_mae_pct": -0.8725,
+            "control_median_mfe_pct": 1.2322,
+            "candidate_median_mfe_pct": 1.2322,
+            "paired_delta": {
+              "n": 47,
+              "mean": 0.000596,
+              "median": -0.0,
+              "sign_test": {
+                "n": 47,
+                "n_pos": 23,
+                "n_neg": 24,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 47,
+                "w": 439.0,
+                "z": -1.3175,
+                "p_value": 0.187678
+              },
+              "bootstrap": {
+                "point": 0.000596,
+                "lo": -0.056247,
+                "hi": 0.078072,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 25,
+              "control_mean_net_pct": 0.2461,
+              "candidate_mean_net_pct": 0.2993,
+              "control_total_net_pct": 6.1525,
+              "candidate_total_net_pct": 7.4825,
+              "control_win_rate": 0.52,
+              "candidate_win_rate": 0.52,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.6712,
+              "candidate_median_mae_pct": -0.6712,
+              "control_median_mfe_pct": 1.4699,
+              "candidate_median_mfe_pct": 1.4699,
+              "paired_delta": {
+                "n": 25,
+                "mean": 0.0532,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 25,
+                  "n_pos": 13,
+                  "n_neg": 12,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 25,
+                  "w": 160.0,
+                  "z": -0.0538,
+                  "p_value": 0.957083
+                },
+                "bootstrap": {
+                  "point": 0.0532,
+                  "lo": -0.040061,
+                  "hi": 0.1927,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 22,
+              "control_mean_net_pct": -0.6035,
+              "candidate_mean_net_pct": -0.6627,
+              "control_total_net_pct": -13.2772,
+              "candidate_total_net_pct": -14.5792,
+              "control_win_rate": 0.2727,
+              "candidate_win_rate": 0.2727,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.8972,
+              "candidate_median_mae_pct": -0.8972,
+              "control_median_mfe_pct": 1.2036,
+              "candidate_median_mfe_pct": 1.2036,
+              "paired_delta": {
+                "n": 22,
+                "mean": -0.059182,
+                "median": -0.023,
+                "sign_test": {
+                  "n": 22,
+                  "n_pos": 10,
+                  "n_neg": 12,
+                  "n_zero": 0,
+                  "p_value": 0.831812
+                },
+                "signed_rank": {
+                  "n": 22,
+                  "w": 71.0,
+                  "z": -1.7856,
+                  "p_value": 0.074162
+                },
+                "bootstrap": {
+                  "point": -0.059182,
+                  "lo": -0.10698,
+                  "hi": -0.015567,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 10,
+          "entries": 7,
+          "win_rate": 0.1429,
+          "mean_net_pct": -3.0855,
+          "total_net_pct": -21.5982,
+          "total_return_pct": -20.3,
+          "max_drawdown_pct": -20.49,
+          "sharpe": -3.077,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 10,
+          "entries": 7,
+          "win_rate": 0.1429,
+          "mean_net_pct": -2.8417,
+          "total_net_pct": -19.8917,
+          "total_return_pct": -19.03,
+          "max_drawdown_pct": -19.23,
+          "sharpe": -2.76,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.243786,
+          "lo": -4.885036,
+          "hi": 5.5025,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 7,
+          "paired": 7,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 7,
+            "control_mean_net_pct": -3.0855,
+            "candidate_mean_net_pct": -2.8417,
+            "control_total_net_pct": -21.5982,
+            "candidate_total_net_pct": -19.8917,
+            "control_win_rate": 0.1429,
+            "candidate_win_rate": 0.1429,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -4.6597,
+            "candidate_median_mae_pct": -4.6597,
+            "control_median_mfe_pct": 0.6397,
+            "candidate_median_mfe_pct": 0.6397,
+            "paired_delta": {
+              "n": 7,
+              "mean": 0.243786,
+              "median": -0.0,
+              "sign_test": {
+                "n": 6,
+                "n_pos": 1,
+                "n_neg": 5,
+                "n_zero": 1,
+                "p_value": 0.21875
+              },
+              "signed_rank": {
+                "n": 6,
+                "w": 6.0,
+                "z": -0.8386,
+                "p_value": 0.401678
+              },
+              "bootstrap": {
+                "point": 0.243786,
+                "lo": -0.0,
+                "hi": 0.731357,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": -6.1801,
+              "candidate_mean_net_pct": -6.1801,
+              "control_total_net_pct": -12.3602,
+              "candidate_total_net_pct": -12.3602,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -6.8786,
+              "candidate_median_mae_pct": -6.8786,
+              "control_median_mfe_pct": 0.9683,
+              "candidate_median_mfe_pct": 0.9683,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.0,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 0,
+                  "n_neg": 1,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.0,
+                  "lo": -0.0,
+                  "hi": 0.0,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 5,
+              "control_mean_net_pct": -1.8476,
+              "candidate_mean_net_pct": -1.5063,
+              "control_total_net_pct": -9.238,
+              "candidate_total_net_pct": -7.5315,
+              "control_win_rate": 0.2,
+              "candidate_win_rate": 0.2,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -3.5262,
+              "candidate_median_mae_pct": -3.5262,
+              "control_median_mfe_pct": 0.6397,
+              "candidate_median_mfe_pct": 0.6397,
+              "paired_delta": {
+                "n": 5,
+                "mean": 0.3413,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 5,
+                  "n_pos": 1,
+                  "n_neg": 4,
+                  "n_zero": 0,
+                  "p_value": 0.375
+                },
+                "signed_rank": {
+                  "n": 5,
+                  "w": 5.0,
+                  "z": -0.5394,
+                  "p_value": 0.589639
+                },
+                "bootstrap": {
+                  "point": 0.3413,
+                  "lo": -0.0,
+                  "hi": 1.0239,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 97,
+          "entries": 46,
+          "win_rate": 0.4348,
+          "mean_net_pct": -0.3263,
+          "total_net_pct": -15.0096,
+          "total_return_pct": -14.72,
+          "max_drawdown_pct": -27.07,
+          "sharpe": -1.223,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 118,
+          "entries": 46,
+          "win_rate": 0.4348,
+          "mean_net_pct": -0.3373,
+          "total_net_pct": -15.5156,
+          "total_return_pct": -15.16,
+          "max_drawdown_pct": -27.23,
+          "sharpe": -1.231,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.011,
+          "lo": -0.899453,
+          "hi": 0.870282,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 46,
+          "paired": 46,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 46,
+            "control_mean_net_pct": -0.3263,
+            "candidate_mean_net_pct": -0.3373,
+            "control_total_net_pct": -15.0096,
+            "candidate_total_net_pct": -15.5156,
+            "control_win_rate": 0.4348,
+            "candidate_win_rate": 0.4348,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.1858,
+            "candidate_median_mae_pct": -1.1858,
+            "control_median_mfe_pct": 1.1282,
+            "candidate_median_mfe_pct": 1.1282,
+            "paired_delta": {
+              "n": 46,
+              "mean": -0.011,
+              "median": -0.0,
+              "sign_test": {
+                "n": 46,
+                "n_pos": 16,
+                "n_neg": 30,
+                "n_zero": 0,
+                "p_value": 0.054076
+              },
+              "signed_rank": {
+                "n": 46,
+                "w": 396.0,
+                "z": -1.5733,
+                "p_value": 0.11566
+              },
+              "bootstrap": {
+                "point": -0.011,
+                "lo": -0.03825,
+                "hi": 0.017805,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 23,
+              "control_mean_net_pct": -0.7991,
+              "candidate_mean_net_pct": -0.8337,
+              "control_total_net_pct": -18.3798,
+              "candidate_total_net_pct": -19.1753,
+              "control_win_rate": 0.3913,
+              "candidate_win_rate": 0.3913,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1875,
+              "candidate_median_mae_pct": -1.1875,
+              "control_median_mfe_pct": 0.9527,
+              "candidate_median_mfe_pct": 0.9527,
+              "paired_delta": {
+                "n": 23,
+                "mean": -0.034587,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 23,
+                  "n_pos": 6,
+                  "n_neg": 17,
+                  "n_zero": 0,
+                  "p_value": 0.03469
+                },
+                "signed_rank": {
+                  "n": 23,
+                  "w": 66.0,
+                  "z": -2.1747,
+                  "p_value": 0.029655
+                },
+                "bootstrap": {
+                  "point": -0.034587,
+                  "lo": -0.069089,
+                  "hi": -0.003956,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 23,
+              "control_mean_net_pct": 0.1465,
+              "candidate_mean_net_pct": 0.1591,
+              "control_total_net_pct": 3.3702,
+              "candidate_total_net_pct": 3.6597,
+              "control_win_rate": 0.4783,
+              "candidate_win_rate": 0.4783,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.184,
+              "candidate_median_mae_pct": -1.184,
+              "control_median_mfe_pct": 1.4441,
+              "candidate_median_mfe_pct": 1.4441,
+              "paired_delta": {
+                "n": 23,
+                "mean": 0.012587,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 23,
+                  "n_pos": 10,
+                  "n_neg": 13,
+                  "n_zero": 0,
+                  "p_value": 0.677639
+                },
+                "signed_rank": {
+                  "n": 23,
+                  "w": 136.0,
+                  "z": -0.0456,
+                  "p_value": 0.963611
+                },
+                "bootstrap": {
+                  "point": 0.012587,
+                  "lo": -0.027177,
+                  "hi": 0.057784,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 21,
+          "entries": 9,
+          "win_rate": 0.4444,
+          "mean_net_pct": -0.5073,
+          "total_net_pct": -4.5659,
+          "total_return_pct": -5.21,
+          "max_drawdown_pct": -17.32,
+          "sharpe": -0.331,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 20,
+          "entries": 9,
+          "win_rate": 0.4444,
+          "mean_net_pct": -0.5568,
+          "total_net_pct": -5.0114,
+          "total_return_pct": -5.66,
+          "max_drawdown_pct": -17.8,
+          "sharpe": -0.344,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.0495,
+          "lo": -3.921489,
+          "hi": 3.856135,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 9,
+          "paired": 9,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 9,
+            "control_mean_net_pct": -0.5073,
+            "candidate_mean_net_pct": -0.5568,
+            "control_total_net_pct": -4.5659,
+            "candidate_total_net_pct": -5.0114,
+            "control_win_rate": 0.4444,
+            "candidate_win_rate": 0.4444,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.5347,
+            "candidate_median_mae_pct": -1.5347,
+            "control_median_mfe_pct": 3.0589,
+            "candidate_median_mfe_pct": 3.0589,
+            "paired_delta": {
+              "n": 9,
+              "mean": -0.0495,
+              "median": 0.0,
+              "sign_test": {
+                "n": 8,
+                "n_pos": 5,
+                "n_neg": 3,
+                "n_zero": 1,
+                "p_value": 0.726562
+              },
+              "signed_rank": {
+                "n": 8,
+                "w": 17.0,
+                "z": -0.07,
+                "p_value": 0.944183
+              },
+              "bootstrap": {
+                "point": -0.0495,
+                "lo": -0.195333,
+                "hi": 0.100944,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 4,
+              "control_mean_net_pct": -2.0132,
+              "candidate_mean_net_pct": -1.9172,
+              "control_total_net_pct": -8.0529,
+              "candidate_total_net_pct": -7.6689,
+              "control_win_rate": 0.25,
+              "candidate_win_rate": 0.25,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -3.779,
+              "candidate_median_mae_pct": -3.779,
+              "control_median_mfe_pct": 1.0669,
+              "candidate_median_mfe_pct": 1.0669,
+              "paired_delta": {
+                "n": 4,
+                "mean": 0.096,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 4,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 0.125
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 10.0,
+                  "z": 1.6432,
+                  "p_value": 0.100348
+                },
+                "bootstrap": {
+                  "point": 0.096,
+                  "lo": 0.0,
+                  "hi": 0.288,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 5,
+              "control_mean_net_pct": 0.6974,
+              "candidate_mean_net_pct": 0.5315,
+              "control_total_net_pct": 3.487,
+              "candidate_total_net_pct": 2.6575,
+              "control_win_rate": 0.6,
+              "candidate_win_rate": 0.6,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.2472,
+              "candidate_median_mae_pct": -0.2472,
+              "control_median_mfe_pct": 3.4338,
+              "candidate_median_mfe_pct": 3.4338,
+              "paired_delta": {
+                "n": 5,
+                "mean": -0.1659,
+                "median": -0.196,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 1,
+                  "n_neg": 3,
+                  "n_zero": 1,
+                  "p_value": 0.625
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 1.0,
+                  "z": -1.278,
+                  "p_value": 0.201243
+                },
+                "bootstrap": {
+                  "point": -0.1659,
+                  "lo": -0.34,
+                  "hi": 0.0082,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 99,
+          "entries": 41,
+          "win_rate": 0.2927,
+          "mean_net_pct": -0.6321,
+          "total_net_pct": -25.9166,
+          "total_return_pct": -23.17,
+          "max_drawdown_pct": -23.87,
+          "sharpe": -3.799,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 92,
+          "entries": 41,
+          "win_rate": 0.2683,
+          "mean_net_pct": -0.6456,
+          "total_net_pct": -26.4706,
+          "total_return_pct": -23.6,
+          "max_drawdown_pct": -24.2,
+          "sharpe": -3.796,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.013512,
+          "lo": -0.587517,
+          "hi": 0.582208,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 41,
+          "paired": 41,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 41,
+            "control_mean_net_pct": -0.6321,
+            "candidate_mean_net_pct": -0.6456,
+            "control_total_net_pct": -25.9166,
+            "candidate_total_net_pct": -26.4706,
+            "control_win_rate": 0.2927,
+            "candidate_win_rate": 0.2683,
+            "delta_win_rate": -0.0244,
+            "control_median_mae_pct": -0.8884,
+            "candidate_median_mae_pct": -0.8884,
+            "control_median_mfe_pct": 0.6125,
+            "candidate_median_mfe_pct": 0.6125,
+            "paired_delta": {
+              "n": 41,
+              "mean": -0.013512,
+              "median": -0.0,
+              "sign_test": {
+                "n": 40,
+                "n_pos": 17,
+                "n_neg": 23,
+                "n_zero": 1,
+                "p_value": 0.429591
+              },
+              "signed_rank": {
+                "n": 40,
+                "w": 279.0,
+                "z": -1.7541,
+                "p_value": 0.079415
+              },
+              "bootstrap": {
+                "point": -0.013512,
+                "lo": -0.029963,
+                "hi": 0.004354,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 25,
+              "control_mean_net_pct": -0.6101,
+              "candidate_mean_net_pct": -0.6306,
+              "control_total_net_pct": -15.2525,
+              "candidate_total_net_pct": -15.7655,
+              "control_win_rate": 0.28,
+              "candidate_win_rate": 0.24,
+              "delta_win_rate": -0.04,
+              "control_median_mae_pct": -0.6594,
+              "candidate_median_mae_pct": -0.6594,
+              "control_median_mfe_pct": 0.6339,
+              "candidate_median_mfe_pct": 0.6339,
+              "paired_delta": {
+                "n": 25,
+                "mean": -0.02052,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 25,
+                  "n_pos": 8,
+                  "n_neg": 17,
+                  "n_zero": 0,
+                  "p_value": 0.107752
+                },
+                "signed_rank": {
+                  "n": 25,
+                  "w": 81.0,
+                  "z": -2.1795,
+                  "p_value": 0.029298
+                },
+                "bootstrap": {
+                  "point": -0.02052,
+                  "lo": -0.04076,
+                  "hi": 0.001421,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 16,
+              "control_mean_net_pct": -0.6665,
+              "candidate_mean_net_pct": -0.6691,
+              "control_total_net_pct": -10.6641,
+              "candidate_total_net_pct": -10.7051,
+              "control_win_rate": 0.3125,
+              "candidate_win_rate": 0.3125,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.4901,
+              "candidate_median_mae_pct": -1.4901,
+              "control_median_mfe_pct": 0.5897,
+              "candidate_median_mfe_pct": 0.5897,
+              "paired_delta": {
+                "n": 16,
+                "mean": -0.002562,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 15,
+                  "n_pos": 9,
+                  "n_neg": 6,
+                  "n_zero": 1,
+                  "p_value": 0.607239
+                },
+                "signed_rank": {
+                  "n": 15,
+                  "w": 60.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.002562,
+                  "lo": -0.028187,
+                  "hi": 0.026875,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 10,
+          "entries": 4,
+          "win_rate": 0.75,
+          "mean_net_pct": 1.5718,
+          "total_net_pct": 6.2871,
+          "total_return_pct": 6.4,
+          "max_drawdown_pct": -2.73,
+          "sharpe": 1.887,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 13,
+          "entries": 4,
+          "win_rate": 0.75,
+          "mean_net_pct": 1.5121,
+          "total_net_pct": 6.0486,
+          "total_return_pct": 6.15,
+          "max_drawdown_pct": -3.39,
+          "sharpe": 1.696,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.059625,
+          "lo": -1.66725,
+          "hi": 1.5445,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 4,
+          "paired": 4,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 4,
+            "control_mean_net_pct": 1.5718,
+            "candidate_mean_net_pct": 1.5121,
+            "control_total_net_pct": 6.2871,
+            "candidate_total_net_pct": 6.0486,
+            "control_win_rate": 0.75,
+            "candidate_win_rate": 0.75,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.871,
+            "candidate_median_mae_pct": -0.871,
+            "control_median_mfe_pct": 3.128,
+            "candidate_median_mfe_pct": 3.128,
+            "paired_delta": {
+              "n": 4,
+              "mean": -0.059625,
+              "median": -0.06875,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 2,
+                "n_neg": 2,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 3.0,
+                "z": -0.5477,
+                "p_value": 0.583882
+              },
+              "bootstrap": {
+                "point": -0.059625,
+                "lo": -0.157,
+                "hi": 0.03775,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": 2.8599,
+              "candidate_mean_net_pct": 2.8724,
+              "control_total_net_pct": 2.8599,
+              "candidate_total_net_pct": 2.8724,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.511,
+              "candidate_median_mae_pct": -0.511,
+              "control_median_mfe_pct": 6.2465,
+              "candidate_median_mfe_pct": 6.2465,
+              "paired_delta": {
+                "n": 1,
+                "mean": 0.0125,
+                "median": 0.0125,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.0125,
+                  "lo": 0.0125,
+                  "hi": 0.0125,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 3,
+              "control_mean_net_pct": 1.1424,
+              "candidate_mean_net_pct": 1.0587,
+              "control_total_net_pct": 3.4272,
+              "candidate_total_net_pct": 3.1762,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1369,
+              "candidate_median_mae_pct": -1.1369,
+              "control_median_mfe_pct": 2.5283,
+              "candidate_median_mfe_pct": 2.5283,
+              "paired_delta": {
+                "n": 3,
+                "mean": -0.083667,
+                "median": -0.15,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 1,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 1.0,
+                  "z": -0.8018,
+                  "p_value": 0.422678
+                },
+                "bootstrap": {
+                  "point": -0.083667,
+                  "lo": -0.164,
+                  "hi": 0.063,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 79,
+          "entries": 39,
+          "win_rate": 0.4615,
+          "mean_net_pct": -0.4446,
+          "total_net_pct": -17.3389,
+          "total_return_pct": -17.01,
+          "max_drawdown_pct": -21.92,
+          "sharpe": -1.601,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 67,
+          "entries": 39,
+          "win_rate": 0.4615,
+          "mean_net_pct": -0.4284,
+          "total_net_pct": -16.7084,
+          "total_return_pct": -16.52,
+          "max_drawdown_pct": -21.56,
+          "sharpe": -1.526,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.016167,
+          "lo": -1.137671,
+          "hi": 1.168963,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 39,
+          "paired": 39,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 39,
+            "control_mean_net_pct": -0.4446,
+            "candidate_mean_net_pct": -0.4284,
+            "control_total_net_pct": -17.3389,
+            "candidate_total_net_pct": -16.7084,
+            "control_win_rate": 0.4615,
+            "candidate_win_rate": 0.4615,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.2037,
+            "candidate_median_mae_pct": -1.2037,
+            "control_median_mfe_pct": 1.3734,
+            "candidate_median_mfe_pct": 1.3734,
+            "paired_delta": {
+              "n": 39,
+              "mean": 0.016167,
+              "median": 0.0,
+              "sign_test": {
+                "n": 38,
+                "n_pos": 23,
+                "n_neg": 15,
+                "n_zero": 1,
+                "p_value": 0.255875
+              },
+              "signed_rank": {
+                "n": 38,
+                "w": 407.0,
+                "z": 0.5221,
+                "p_value": 0.601613
+              },
+              "bootstrap": {
+                "point": 0.016167,
+                "lo": -0.046962,
+                "hi": 0.087154,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 20,
+              "control_mean_net_pct": -0.5782,
+              "candidate_mean_net_pct": -0.5578,
+              "control_total_net_pct": -11.5645,
+              "candidate_total_net_pct": -11.1555,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.3174,
+              "candidate_median_mae_pct": -1.3174,
+              "control_median_mfe_pct": 1.1992,
+              "candidate_median_mfe_pct": 1.1992,
+              "paired_delta": {
+                "n": 20,
+                "mean": 0.02045,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 20,
+                  "n_pos": 11,
+                  "n_neg": 9,
+                  "n_zero": 0,
+                  "p_value": 0.823803
+                },
+                "signed_rank": {
+                  "n": 20,
+                  "w": 115.0,
+                  "z": 0.3547,
+                  "p_value": 0.722844
+                },
+                "bootstrap": {
+                  "point": 0.02045,
+                  "lo": -0.066625,
+                  "hi": 0.118475,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 19,
+              "control_mean_net_pct": -0.3039,
+              "candidate_mean_net_pct": -0.2923,
+              "control_total_net_pct": -5.7744,
+              "candidate_total_net_pct": -5.5529,
+              "control_win_rate": 0.4211,
+              "candidate_win_rate": 0.4211,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.2037,
+              "candidate_median_mae_pct": -1.2037,
+              "control_median_mfe_pct": 1.3734,
+              "candidate_median_mfe_pct": 1.3734,
+              "paired_delta": {
+                "n": 19,
+                "mean": 0.011658,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 18,
+                  "n_pos": 12,
+                  "n_neg": 6,
+                  "n_zero": 1,
+                  "p_value": 0.237885
+                },
+                "signed_rank": {
+                  "n": 18,
+                  "w": 97.0,
+                  "z": 0.4791,
+                  "p_value": 0.6319
+                },
+                "bootstrap": {
+                  "point": 0.011658,
+                  "lo": -0.07153,
+                  "hi": 0.12266,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 25,
+          "entries": 5,
+          "win_rate": 0.6,
+          "mean_net_pct": 0.0939,
+          "total_net_pct": 0.4695,
+          "total_return_pct": 0.28,
+          "max_drawdown_pct": -12.36,
+          "sharpe": 0.121,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 12,
+          "entries": 5,
+          "win_rate": 0.6,
+          "mean_net_pct": 0.0444,
+          "total_net_pct": 0.222,
+          "total_return_pct": 0.04,
+          "max_drawdown_pct": -12.36,
+          "sharpe": 0.087,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.0495,
+          "lo": -3.57129,
+          "hi": 3.4687,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 5,
+          "paired": 5,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 5,
+            "control_mean_net_pct": 0.0939,
+            "candidate_mean_net_pct": 0.0444,
+            "control_total_net_pct": 0.4695,
+            "candidate_total_net_pct": 0.222,
+            "control_win_rate": 0.6,
+            "candidate_win_rate": 0.6,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.7333,
+            "candidate_median_mae_pct": -0.7333,
+            "control_median_mfe_pct": 3.5365,
+            "candidate_median_mfe_pct": 3.5365,
+            "paired_delta": {
+              "n": 5,
+              "mean": -0.0495,
+              "median": -0.0,
+              "sign_test": {
+                "n": 5,
+                "n_pos": 2,
+                "n_neg": 3,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 5,
+                "w": 5.0,
+                "z": -0.5394,
+                "p_value": 0.589639
+              },
+              "bootstrap": {
+                "point": -0.0495,
+                "lo": -0.1117,
+                "hi": 0.0016,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": -3.6201,
+              "candidate_mean_net_pct": -3.6201,
+              "control_total_net_pct": -3.6201,
+              "candidate_total_net_pct": -3.6201,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -3.5691,
+              "candidate_median_mae_pct": -3.5691,
+              "control_median_mfe_pct": 2.7084,
+              "candidate_median_mfe_pct": 2.7084,
+              "paired_delta": {
+                "n": 1,
+                "mean": -0.0,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 0,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.0,
+                  "lo": -0.0,
+                  "hi": -0.0,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 4,
+              "control_mean_net_pct": 1.0224,
+              "candidate_mean_net_pct": 0.9605,
+              "control_total_net_pct": 4.0896,
+              "candidate_total_net_pct": 3.8421,
+              "control_win_rate": 0.75,
+              "candidate_win_rate": 0.75,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.6082,
+              "candidate_median_mae_pct": -0.6082,
+              "control_median_mfe_pct": 3.947,
+              "candidate_median_mfe_pct": 3.947,
+              "paired_delta": {
+                "n": 4,
+                "mean": -0.061875,
+                "median": -0.049,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 2,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 3.0,
+                  "z": -0.5477,
+                  "p_value": 0.583882
+                },
+                "bootstrap": {
+                  "point": -0.061875,
+                  "lo": -0.12575,
+                  "hi": 0.002,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 69,
+          "entries": 28,
+          "win_rate": 0.4643,
+          "mean_net_pct": -0.0112,
+          "total_net_pct": -0.3128,
+          "total_return_pct": -1.02,
+          "max_drawdown_pct": -14.51,
+          "sharpe": -0.029,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 70,
+          "entries": 28,
+          "win_rate": 0.4643,
+          "mean_net_pct": 0.046,
+          "total_net_pct": 1.2892,
+          "total_return_pct": 0.47,
+          "max_drawdown_pct": -14.75,
+          "sharpe": 0.151,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.057214,
+          "lo": -1.171044,
+          "hi": 1.302627,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 28,
+          "paired": 28,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 28,
+            "control_mean_net_pct": -0.0112,
+            "candidate_mean_net_pct": 0.046,
+            "control_total_net_pct": -0.3128,
+            "candidate_total_net_pct": 1.2892,
+            "control_win_rate": 0.4643,
+            "candidate_win_rate": 0.4643,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.8939,
+            "candidate_median_mae_pct": -0.8939,
+            "control_median_mfe_pct": 1.3862,
+            "candidate_median_mfe_pct": 1.3862,
+            "paired_delta": {
+              "n": 28,
+              "mean": 0.057214,
+              "median": -0.0,
+              "sign_test": {
+                "n": 27,
+                "n_pos": 13,
+                "n_neg": 14,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 27,
+                "w": 183.0,
+                "z": -0.1321,
+                "p_value": 0.894876
+              },
+              "bootstrap": {
+                "point": 0.057214,
+                "lo": -0.026269,
+                "hi": 0.182071,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 18,
+              "control_mean_net_pct": -0.2366,
+              "candidate_mean_net_pct": -0.2433,
+              "control_total_net_pct": -4.2593,
+              "candidate_total_net_pct": -4.3798,
+              "control_win_rate": 0.4444,
+              "candidate_win_rate": 0.4444,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.8159,
+              "candidate_median_mae_pct": -0.8159,
+              "control_median_mfe_pct": 1.5573,
+              "candidate_median_mfe_pct": 1.5573,
+              "paired_delta": {
+                "n": 18,
+                "mean": -0.006694,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 18,
+                  "n_pos": 7,
+                  "n_neg": 11,
+                  "n_zero": 0,
+                  "p_value": 0.480682
+                },
+                "signed_rank": {
+                  "n": 18,
+                  "w": 64.0,
+                  "z": -0.9146,
+                  "p_value": 0.360424
+                },
+                "bootstrap": {
+                  "point": -0.006694,
+                  "lo": -0.05239,
+                  "hi": 0.045278,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 10,
+              "control_mean_net_pct": 0.3946,
+              "candidate_mean_net_pct": 0.5669,
+              "control_total_net_pct": 3.9465,
+              "candidate_total_net_pct": 5.669,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.3412,
+              "candidate_median_mae_pct": -1.3412,
+              "control_median_mfe_pct": 1.2472,
+              "candidate_median_mfe_pct": 1.2472,
+              "paired_delta": {
+                "n": 10,
+                "mean": 0.17225,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 9,
+                  "n_pos": 6,
+                  "n_neg": 3,
+                  "n_zero": 1,
+                  "p_value": 0.507812
+                },
+                "signed_rank": {
+                  "n": 9,
+                  "w": 32.0,
+                  "z": 1.0662,
+                  "p_value": 0.286321
+                },
+                "bootstrap": {
+                  "point": 0.17225,
+                  "lo": -0.0329,
+                  "hi": 0.48465,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 27,
+          "entries": 10,
+          "win_rate": 0.6,
+          "mean_net_pct": -0.2056,
+          "total_net_pct": -2.056,
+          "total_return_pct": -2.59,
+          "max_drawdown_pct": -11.04,
+          "sharpe": -0.23,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 33,
+          "entries": 10,
+          "win_rate": 0.6,
+          "mean_net_pct": -0.2768,
+          "total_net_pct": -2.7675,
+          "total_return_pct": -3.28,
+          "max_drawdown_pct": -11.73,
+          "sharpe": -0.303,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.07115,
+          "lo": -2.990707,
+          "hi": 2.893177,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 10,
+          "paired": 10,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 10,
+            "control_mean_net_pct": -0.2056,
+            "candidate_mean_net_pct": -0.2768,
+            "control_total_net_pct": -2.056,
+            "candidate_total_net_pct": -2.7675,
+            "control_win_rate": 0.6,
+            "candidate_win_rate": 0.6,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -2.2254,
+            "candidate_median_mae_pct": -2.2254,
+            "control_median_mfe_pct": 3.8576,
+            "candidate_median_mfe_pct": 3.8576,
+            "paired_delta": {
+              "n": 10,
+              "mean": -0.07115,
+              "median": -0.0435,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 2,
+                "n_neg": 7,
+                "n_zero": 1,
+                "p_value": 0.179688
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 11.0,
+                "z": -1.3032,
+                "p_value": 0.192518
+              },
+              "bootstrap": {
+                "point": -0.07115,
+                "lo": -0.185312,
+                "hi": 0.04055,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 5,
+              "control_mean_net_pct": 0.5399,
+              "candidate_mean_net_pct": 0.5467,
+              "control_total_net_pct": 2.6995,
+              "candidate_total_net_pct": 2.7335,
+              "control_win_rate": 0.6,
+              "candidate_win_rate": 0.6,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.7655,
+              "candidate_median_mae_pct": -0.7655,
+              "control_median_mfe_pct": 3.8568,
+              "candidate_median_mfe_pct": 3.8568,
+              "paired_delta": {
+                "n": 5,
+                "mean": 0.0068,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 5,
+                  "n_pos": 2,
+                  "n_neg": 3,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 5,
+                  "w": 7.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.0068,
+                  "lo": -0.1024,
+                  "hi": 0.1566,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 5,
+              "control_mean_net_pct": -0.9511,
+              "candidate_mean_net_pct": -1.1002,
+              "control_total_net_pct": -4.7555,
+              "candidate_total_net_pct": -5.501,
+              "control_win_rate": 0.6,
+              "candidate_win_rate": 0.6,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.8324,
+              "candidate_median_mae_pct": -2.8324,
+              "control_median_mfe_pct": 3.8584,
+              "candidate_median_mfe_pct": 3.8584,
+              "paired_delta": {
+                "n": 5,
+                "mean": -0.1491,
+                "median": -0.0875,
+                "sign_test": {
+                  "n": 4,
+                  "n_pos": 0,
+                  "n_neg": 4,
+                  "n_zero": 1,
+                  "p_value": 0.125
+                },
+                "signed_rank": {
+                  "n": 4,
+                  "w": 0,
+                  "z": -1.6432,
+                  "p_value": 0.100348
+                },
+                "bootstrap": {
+                  "point": -0.1491,
+                  "lo": -0.3176,
+                  "hi": -0.0175,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/mr.rq_lighter_early.json
+++ b/backtest/research/regime_1152_runs/mr.rq_lighter_early.json
@@ -1,0 +1,554 @@
+{
+  "open": {
+    "name": "mean_reversion",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "tp_tiers": {
+          "ranging_quiet": [
+            {
+              "atr_multiple": 0.75,
+              "close_fraction": 0.25,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 1.5,
+              "close_fraction": 0.5,
+              "trailing_mult_after": 0.75
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 1.0,
+              "trailing_mult_after": 0.75
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "control_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_quiet"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/mr.rq_volatile_geometry.json
+++ b/backtest/research/regime_1152_runs/mr.rq_volatile_geometry.json
@@ -1,0 +1,554 @@
+{
+  "open": {
+    "name": "mean_reversion",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "tp_tiers": {
+          "ranging_quiet": [
+            {
+              "atr_multiple": 1.0,
+              "close_fraction": 0.4,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 0.8,
+              "trailing_mult_after": 0.75
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 1.0,
+              "trailing_mult_after": 0.75
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "control_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_quiet"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/mr.rv_quiet_geometry.json
+++ b/backtest/research/regime_1152_runs/mr.rv_quiet_geometry.json
@@ -1,0 +1,1502 @@
+{
+  "open": {
+    "name": "mean_reversion",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "tp_tiers": {
+          "ranging_volatile": [
+            {
+              "atr_multiple": 0.75,
+              "close_fraction": 0.4,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 1.5,
+              "close_fraction": 0.8,
+              "trailing_mult_after": 0.75
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 1.0,
+              "trailing_mult_after": 0.75
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "control_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_volatile"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 164,
+          "entries": 92,
+          "win_rate": 0.3804,
+          "mean_net_pct": -0.262,
+          "total_net_pct": -24.1012,
+          "total_return_pct": -21.73,
+          "max_drawdown_pct": -24.32,
+          "sharpe": -2.798,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 175,
+          "entries": 94,
+          "win_rate": 0.3936,
+          "mean_net_pct": -0.2442,
+          "total_net_pct": -22.9534,
+          "total_return_pct": -20.81,
+          "max_drawdown_pct": -23.18,
+          "sharpe": -2.713,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.017784,
+          "lo": -0.257172,
+          "hi": 0.287892,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 92,
+          "paired": 92,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 92,
+            "control_mean_net_pct": -0.262,
+            "candidate_mean_net_pct": -0.2486,
+            "control_total_net_pct": -24.1012,
+            "candidate_total_net_pct": -22.8672,
+            "control_win_rate": 0.3804,
+            "candidate_win_rate": 0.3913,
+            "delta_win_rate": 0.0109,
+            "control_median_mae_pct": -0.5137,
+            "candidate_median_mae_pct": -0.5026,
+            "control_median_mfe_pct": 0.607,
+            "candidate_median_mfe_pct": 0.607,
+            "paired_delta": {
+              "n": 92,
+              "mean": 0.013413,
+              "median": -0.0,
+              "sign_test": {
+                "n": 92,
+                "n_pos": 44,
+                "n_neg": 48,
+                "n_zero": 0,
+                "p_value": 0.754652
+              },
+              "signed_rank": {
+                "n": 92,
+                "w": 2215.0,
+                "z": 0.294,
+                "p_value": 0.768766
+              },
+              "bootstrap": {
+                "point": 0.013413,
+                "lo": -0.018001,
+                "hi": 0.046762,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 92,
+              "control_mean_net_pct": -0.262,
+              "candidate_mean_net_pct": -0.2486,
+              "control_total_net_pct": -24.1012,
+              "candidate_total_net_pct": -22.8672,
+              "control_win_rate": 0.3804,
+              "candidate_win_rate": 0.3913,
+              "delta_win_rate": 0.0109,
+              "control_median_mae_pct": -0.5137,
+              "candidate_median_mae_pct": -0.5026,
+              "control_median_mfe_pct": 0.607,
+              "candidate_median_mfe_pct": 0.607,
+              "paired_delta": {
+                "n": 92,
+                "mean": 0.013413,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 92,
+                  "n_pos": 44,
+                  "n_neg": 48,
+                  "n_zero": 0,
+                  "p_value": 0.754652
+                },
+                "signed_rank": {
+                  "n": 92,
+                  "w": 2215.0,
+                  "z": 0.294,
+                  "p_value": 0.768766
+                },
+                "bootstrap": {
+                  "point": 0.013413,
+                  "lo": -0.018001,
+                  "hi": 0.046762,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 44,
+          "entries": 26,
+          "win_rate": 0.4231,
+          "mean_net_pct": -0.6948,
+          "total_net_pct": -18.0646,
+          "total_return_pct": -17.17,
+          "max_drawdown_pct": -18.47,
+          "sharpe": -1.91,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 44,
+          "entries": 26,
+          "win_rate": 0.3846,
+          "mean_net_pct": -0.6676,
+          "total_net_pct": -17.3566,
+          "total_return_pct": -16.57,
+          "max_drawdown_pct": -17.73,
+          "sharpe": -1.907,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.027231,
+          "lo": -1.35124,
+          "hi": 1.409581,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 26,
+          "paired": 26,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 26,
+            "control_mean_net_pct": -0.6948,
+            "candidate_mean_net_pct": -0.6676,
+            "control_total_net_pct": -18.0646,
+            "candidate_total_net_pct": -17.3566,
+            "control_win_rate": 0.4231,
+            "candidate_win_rate": 0.3846,
+            "delta_win_rate": -0.0385,
+            "control_median_mae_pct": -1.3734,
+            "candidate_median_mae_pct": -1.2919,
+            "control_median_mfe_pct": 1.0106,
+            "candidate_median_mfe_pct": 1.0106,
+            "paired_delta": {
+              "n": 26,
+              "mean": 0.027231,
+              "median": -0.0,
+              "sign_test": {
+                "n": 25,
+                "n_pos": 12,
+                "n_neg": 13,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 25,
+                "w": 148.0,
+                "z": -0.3767,
+                "p_value": 0.706399
+              },
+              "bootstrap": {
+                "point": 0.027231,
+                "lo": -0.107925,
+                "hi": 0.189694,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 26,
+              "control_mean_net_pct": -0.6948,
+              "candidate_mean_net_pct": -0.6676,
+              "control_total_net_pct": -18.0646,
+              "candidate_total_net_pct": -17.3566,
+              "control_win_rate": 0.4231,
+              "candidate_win_rate": 0.3846,
+              "delta_win_rate": -0.0385,
+              "control_median_mae_pct": -1.3734,
+              "candidate_median_mae_pct": -1.2919,
+              "control_median_mfe_pct": 1.0106,
+              "candidate_median_mfe_pct": 1.0106,
+              "paired_delta": {
+                "n": 26,
+                "mean": 0.027231,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 25,
+                  "n_pos": 12,
+                  "n_neg": 13,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 25,
+                  "w": 148.0,
+                  "z": -0.3767,
+                  "p_value": 0.706399
+                },
+                "bootstrap": {
+                  "point": 0.027231,
+                  "lo": -0.107925,
+                  "hi": 0.189694,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 185,
+          "entries": 93,
+          "win_rate": 0.5054,
+          "mean_net_pct": -0.0164,
+          "total_net_pct": -1.5273,
+          "total_return_pct": -2.63,
+          "max_drawdown_pct": -17.95,
+          "sharpe": -0.05,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 189,
+          "entries": 95,
+          "win_rate": 0.5053,
+          "mean_net_pct": -0.0464,
+          "total_net_pct": -4.4095,
+          "total_return_pct": -5.27,
+          "max_drawdown_pct": -19.89,
+          "sharpe": -0.246,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.029993,
+          "lo": -0.488498,
+          "hi": 0.432677,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 93,
+          "paired": 93,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 93,
+            "control_mean_net_pct": -0.0164,
+            "candidate_mean_net_pct": -0.0216,
+            "control_total_net_pct": -1.5273,
+            "candidate_total_net_pct": -2.0073,
+            "control_win_rate": 0.5054,
+            "candidate_win_rate": 0.5054,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.673,
+            "candidate_median_mae_pct": -0.673,
+            "control_median_mfe_pct": 1.4908,
+            "candidate_median_mfe_pct": 1.3754,
+            "paired_delta": {
+              "n": 93,
+              "mean": -0.005161,
+              "median": 0.0,
+              "sign_test": {
+                "n": 93,
+                "n_pos": 49,
+                "n_neg": 44,
+                "n_zero": 0,
+                "p_value": 0.678532
+              },
+              "signed_rank": {
+                "n": 93,
+                "w": 2172.0,
+                "z": -0.0498,
+                "p_value": 0.960273
+              },
+              "bootstrap": {
+                "point": -0.005161,
+                "lo": -0.086111,
+                "hi": 0.073205,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 93,
+              "control_mean_net_pct": -0.0164,
+              "candidate_mean_net_pct": -0.0216,
+              "control_total_net_pct": -1.5273,
+              "candidate_total_net_pct": -2.0073,
+              "control_win_rate": 0.5054,
+              "candidate_win_rate": 0.5054,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.673,
+              "candidate_median_mae_pct": -0.673,
+              "control_median_mfe_pct": 1.4908,
+              "candidate_median_mfe_pct": 1.3754,
+              "paired_delta": {
+                "n": 93,
+                "mean": -0.005161,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 93,
+                  "n_pos": 49,
+                  "n_neg": 44,
+                  "n_zero": 0,
+                  "p_value": 0.678532
+                },
+                "signed_rank": {
+                  "n": 93,
+                  "w": 2172.0,
+                  "z": -0.0498,
+                  "p_value": 0.960273
+                },
+                "bootstrap": {
+                  "point": -0.005161,
+                  "lo": -0.086111,
+                  "hi": 0.073205,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 31,
+          "entries": 21,
+          "win_rate": 0.381,
+          "mean_net_pct": -0.7046,
+          "total_net_pct": -14.7961,
+          "total_return_pct": -14.35,
+          "max_drawdown_pct": -22.58,
+          "sharpe": -1.202,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 33,
+          "entries": 21,
+          "win_rate": 0.4286,
+          "mean_net_pct": -0.7697,
+          "total_net_pct": -16.1641,
+          "total_return_pct": -15.39,
+          "max_drawdown_pct": -20.99,
+          "sharpe": -1.411,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.065143,
+          "lo": -1.674674,
+          "hi": 1.485338,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 21,
+          "paired": 21,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 21,
+            "control_mean_net_pct": -0.7046,
+            "candidate_mean_net_pct": -0.7964,
+            "control_total_net_pct": -14.7961,
+            "candidate_total_net_pct": -16.7241,
+            "control_win_rate": 0.381,
+            "candidate_win_rate": 0.4286,
+            "delta_win_rate": 0.0476,
+            "control_median_mae_pct": -2.485,
+            "candidate_median_mae_pct": -2.4229,
+            "control_median_mfe_pct": 2.0347,
+            "candidate_median_mfe_pct": 2.0347,
+            "paired_delta": {
+              "n": 21,
+              "mean": -0.09181,
+              "median": -0.0,
+              "sign_test": {
+                "n": 21,
+                "n_pos": 10,
+                "n_neg": 11,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 21,
+                "w": 130.0,
+                "z": 0.4866,
+                "p_value": 0.626537
+              },
+              "bootstrap": {
+                "point": -0.09181,
+                "lo": -0.717619,
+                "hi": 0.40819,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 21,
+              "control_mean_net_pct": -0.7046,
+              "candidate_mean_net_pct": -0.7964,
+              "control_total_net_pct": -14.7961,
+              "candidate_total_net_pct": -16.7241,
+              "control_win_rate": 0.381,
+              "candidate_win_rate": 0.4286,
+              "delta_win_rate": 0.0476,
+              "control_median_mae_pct": -2.485,
+              "candidate_median_mae_pct": -2.4229,
+              "control_median_mfe_pct": 2.0347,
+              "candidate_median_mfe_pct": 2.0347,
+              "paired_delta": {
+                "n": 21,
+                "mean": -0.09181,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 21,
+                  "n_pos": 10,
+                  "n_neg": 11,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 21,
+                  "w": 130.0,
+                  "z": 0.4866,
+                  "p_value": 0.626537
+                },
+                "bootstrap": {
+                  "point": -0.09181,
+                  "lo": -0.717619,
+                  "hi": 0.40819,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 171,
+          "entries": 83,
+          "win_rate": 0.4458,
+          "mean_net_pct": -0.214,
+          "total_net_pct": -17.7643,
+          "total_return_pct": -17.41,
+          "max_drawdown_pct": -27.98,
+          "sharpe": -1.237,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 150,
+          "entries": 83,
+          "win_rate": 0.4699,
+          "mean_net_pct": -0.2535,
+          "total_net_pct": -21.0423,
+          "total_return_pct": -19.98,
+          "max_drawdown_pct": -28.8,
+          "sharpe": -1.51,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.039494,
+          "lo": -0.587239,
+          "hi": 0.5068,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 83,
+          "paired": 83,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 83,
+            "control_mean_net_pct": -0.214,
+            "candidate_mean_net_pct": -0.2495,
+            "control_total_net_pct": -17.7643,
+            "candidate_total_net_pct": -20.7123,
+            "control_win_rate": 0.4458,
+            "candidate_win_rate": 0.4699,
+            "delta_win_rate": 0.0241,
+            "control_median_mae_pct": -0.7939,
+            "candidate_median_mae_pct": -0.7939,
+            "control_median_mfe_pct": 1.3569,
+            "candidate_median_mfe_pct": 1.3569,
+            "paired_delta": {
+              "n": 83,
+              "mean": -0.035518,
+              "median": -0.0,
+              "sign_test": {
+                "n": 83,
+                "n_pos": 38,
+                "n_neg": 45,
+                "n_zero": 0,
+                "p_value": 0.51041
+              },
+              "signed_rank": {
+                "n": 83,
+                "w": 1525.0,
+                "z": -0.9875,
+                "p_value": 0.323408
+              },
+              "bootstrap": {
+                "point": -0.035518,
+                "lo": -0.103307,
+                "hi": 0.032413,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 83,
+              "control_mean_net_pct": -0.214,
+              "candidate_mean_net_pct": -0.2495,
+              "control_total_net_pct": -17.7643,
+              "candidate_total_net_pct": -20.7123,
+              "control_win_rate": 0.4458,
+              "candidate_win_rate": 0.4699,
+              "delta_win_rate": 0.0241,
+              "control_median_mae_pct": -0.7939,
+              "candidate_median_mae_pct": -0.7939,
+              "control_median_mfe_pct": 1.3569,
+              "candidate_median_mfe_pct": 1.3569,
+              "paired_delta": {
+                "n": 83,
+                "mean": -0.035518,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 83,
+                  "n_pos": 38,
+                  "n_neg": 45,
+                  "n_zero": 0,
+                  "p_value": 0.51041
+                },
+                "signed_rank": {
+                  "n": 83,
+                  "w": 1525.0,
+                  "z": -0.9875,
+                  "p_value": 0.323408
+                },
+                "bootstrap": {
+                  "point": -0.035518,
+                  "lo": -0.103307,
+                  "hi": 0.032413,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 35,
+          "entries": 18,
+          "win_rate": 0.6111,
+          "mean_net_pct": -0.3139,
+          "total_net_pct": -5.6498,
+          "total_return_pct": -6.61,
+          "max_drawdown_pct": -21.34,
+          "sharpe": -0.448,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 34,
+          "entries": 18,
+          "win_rate": 0.6111,
+          "mean_net_pct": -0.338,
+          "total_net_pct": -6.0838,
+          "total_return_pct": -6.99,
+          "max_drawdown_pct": -21.77,
+          "sharpe": -0.489,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.024111,
+          "lo": -2.493408,
+          "hi": 2.467111,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 18,
+          "paired": 18,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 18,
+            "control_mean_net_pct": -0.3139,
+            "candidate_mean_net_pct": -0.338,
+            "control_total_net_pct": -5.6498,
+            "candidate_total_net_pct": -6.0838,
+            "control_win_rate": 0.6111,
+            "candidate_win_rate": 0.6111,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -2.5024,
+            "candidate_median_mae_pct": -2.5024,
+            "control_median_mfe_pct": 2.738,
+            "candidate_median_mfe_pct": 2.738,
+            "paired_delta": {
+              "n": 18,
+              "mean": -0.024111,
+              "median": -0.0,
+              "sign_test": {
+                "n": 17,
+                "n_pos": 8,
+                "n_neg": 9,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 17,
+                "w": 64.0,
+                "z": -0.5681,
+                "p_value": 0.569996
+              },
+              "bootstrap": {
+                "point": -0.024111,
+                "lo": -0.26345,
+                "hi": 0.216781,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 18,
+              "control_mean_net_pct": -0.3139,
+              "candidate_mean_net_pct": -0.338,
+              "control_total_net_pct": -5.6498,
+              "candidate_total_net_pct": -6.0838,
+              "control_win_rate": 0.6111,
+              "candidate_win_rate": 0.6111,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.5024,
+              "candidate_median_mae_pct": -2.5024,
+              "control_median_mfe_pct": 2.738,
+              "candidate_median_mfe_pct": 2.738,
+              "paired_delta": {
+                "n": 18,
+                "mean": -0.024111,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 17,
+                  "n_pos": 8,
+                  "n_neg": 9,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 17,
+                  "w": 64.0,
+                  "z": -0.5681,
+                  "p_value": 0.569996
+                },
+                "bootstrap": {
+                  "point": -0.024111,
+                  "lo": -0.26345,
+                  "hi": 0.216781,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 99,
+          "entries": 58,
+          "win_rate": 0.4828,
+          "mean_net_pct": -0.1178,
+          "total_net_pct": -6.8338,
+          "total_return_pct": -7.0,
+          "max_drawdown_pct": -8.93,
+          "sharpe": -0.855,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 102,
+          "entries": 59,
+          "win_rate": 0.4746,
+          "mean_net_pct": -0.1652,
+          "total_net_pct": -9.7459,
+          "total_return_pct": -9.64,
+          "max_drawdown_pct": -10.14,
+          "sharpe": -1.326,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.047361,
+          "lo": -0.491108,
+          "hi": 0.39439,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 58,
+          "paired": 58,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 58,
+            "control_mean_net_pct": -0.1178,
+            "candidate_mean_net_pct": -0.166,
+            "control_total_net_pct": -6.8338,
+            "candidate_total_net_pct": -9.6298,
+            "control_win_rate": 0.4828,
+            "candidate_win_rate": 0.4828,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.7147,
+            "candidate_median_mae_pct": -0.7147,
+            "control_median_mfe_pct": 0.9142,
+            "candidate_median_mfe_pct": 0.9142,
+            "paired_delta": {
+              "n": 58,
+              "mean": -0.048207,
+              "median": -0.0,
+              "sign_test": {
+                "n": 57,
+                "n_pos": 25,
+                "n_neg": 32,
+                "n_zero": 1,
+                "p_value": 0.427043
+              },
+              "signed_rank": {
+                "n": 57,
+                "w": 651.0,
+                "z": -1.3904,
+                "p_value": 0.164404
+              },
+              "bootstrap": {
+                "point": -0.048207,
+                "lo": -0.147111,
+                "hi": 0.038073,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 58,
+              "control_mean_net_pct": -0.1178,
+              "candidate_mean_net_pct": -0.166,
+              "control_total_net_pct": -6.8338,
+              "candidate_total_net_pct": -9.6298,
+              "control_win_rate": 0.4828,
+              "candidate_win_rate": 0.4828,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.7147,
+              "candidate_median_mae_pct": -0.7147,
+              "control_median_mfe_pct": 0.9142,
+              "candidate_median_mfe_pct": 0.9142,
+              "paired_delta": {
+                "n": 58,
+                "mean": -0.048207,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 57,
+                  "n_pos": 25,
+                  "n_neg": 32,
+                  "n_zero": 1,
+                  "p_value": 0.427043
+                },
+                "signed_rank": {
+                  "n": 57,
+                  "w": 651.0,
+                  "z": -1.3904,
+                  "p_value": 0.164404
+                },
+                "bootstrap": {
+                  "point": -0.048207,
+                  "lo": -0.147111,
+                  "hi": 0.038073,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 15,
+          "entries": 12,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.8083,
+          "total_net_pct": -9.6992,
+          "total_return_pct": -9.56,
+          "max_drawdown_pct": -13.37,
+          "sharpe": -1.63,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 15,
+          "entries": 12,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.7896,
+          "total_net_pct": -9.4752,
+          "total_return_pct": -9.35,
+          "max_drawdown_pct": -12.74,
+          "sharpe": -1.628,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.018667,
+          "lo": -1.837842,
+          "hi": 1.858183,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 12,
+          "paired": 12,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 12,
+            "control_mean_net_pct": -0.8083,
+            "candidate_mean_net_pct": -0.7896,
+            "control_total_net_pct": -9.6992,
+            "candidate_total_net_pct": -9.4752,
+            "control_win_rate": 0.3333,
+            "candidate_win_rate": 0.3333,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.7884,
+            "candidate_median_mae_pct": -1.7884,
+            "control_median_mfe_pct": 1.2321,
+            "candidate_median_mfe_pct": 1.2321,
+            "paired_delta": {
+              "n": 12,
+              "mean": 0.018667,
+              "median": 0.0,
+              "sign_test": {
+                "n": 11,
+                "n_pos": 6,
+                "n_neg": 5,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 11,
+                "w": 33.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 0.018667,
+                "lo": -0.123,
+                "hi": 0.179,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 12,
+              "control_mean_net_pct": -0.8083,
+              "candidate_mean_net_pct": -0.7896,
+              "control_total_net_pct": -9.6992,
+              "candidate_total_net_pct": -9.4752,
+              "control_win_rate": 0.3333,
+              "candidate_win_rate": 0.3333,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.7884,
+              "candidate_median_mae_pct": -1.7884,
+              "control_median_mfe_pct": 1.2321,
+              "candidate_median_mfe_pct": 1.2321,
+              "paired_delta": {
+                "n": 12,
+                "mean": 0.018667,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 11,
+                  "n_pos": 6,
+                  "n_neg": 5,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 11,
+                  "w": 33.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.018667,
+                  "lo": -0.123,
+                  "hi": 0.179,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 126,
+          "entries": 69,
+          "win_rate": 0.4783,
+          "mean_net_pct": -0.0498,
+          "total_net_pct": -3.4369,
+          "total_return_pct": -4.03,
+          "max_drawdown_pct": -9.96,
+          "sharpe": -0.342,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 116,
+          "entries": 70,
+          "win_rate": 0.4571,
+          "mean_net_pct": -0.0794,
+          "total_net_pct": -5.559,
+          "total_return_pct": -6.01,
+          "max_drawdown_pct": -10.2,
+          "sharpe": -0.574,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.029604,
+          "lo": -0.484118,
+          "hi": 0.438835,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 69,
+          "paired": 69,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 69,
+            "control_mean_net_pct": -0.0498,
+            "candidate_mean_net_pct": -0.0796,
+            "control_total_net_pct": -3.4369,
+            "candidate_total_net_pct": -5.4949,
+            "control_win_rate": 0.4783,
+            "candidate_win_rate": 0.4638,
+            "delta_win_rate": -0.0145,
+            "control_median_mae_pct": -0.7792,
+            "candidate_median_mae_pct": -0.7792,
+            "control_median_mfe_pct": 1.1677,
+            "candidate_median_mfe_pct": 1.1119,
+            "paired_delta": {
+              "n": 69,
+              "mean": -0.029826,
+              "median": 0.0,
+              "sign_test": {
+                "n": 68,
+                "n_pos": 38,
+                "n_neg": 30,
+                "n_zero": 1,
+                "p_value": 0.396125
+              },
+              "signed_rank": {
+                "n": 68,
+                "w": 1238.0,
+                "z": 0.3941,
+                "p_value": 0.693494
+              },
+              "bootstrap": {
+                "point": -0.029826,
+                "lo": -0.109189,
+                "hi": 0.044669,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 69,
+              "control_mean_net_pct": -0.0498,
+              "candidate_mean_net_pct": -0.0796,
+              "control_total_net_pct": -3.4369,
+              "candidate_total_net_pct": -5.4949,
+              "control_win_rate": 0.4783,
+              "candidate_win_rate": 0.4638,
+              "delta_win_rate": -0.0145,
+              "control_median_mae_pct": -0.7792,
+              "candidate_median_mae_pct": -0.7792,
+              "control_median_mfe_pct": 1.1677,
+              "candidate_median_mfe_pct": 1.1119,
+              "paired_delta": {
+                "n": 69,
+                "mean": -0.029826,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 68,
+                  "n_pos": 38,
+                  "n_neg": 30,
+                  "n_zero": 1,
+                  "p_value": 0.396125
+                },
+                "signed_rank": {
+                  "n": 68,
+                  "w": 1238.0,
+                  "z": 0.3941,
+                  "p_value": 0.693494
+                },
+                "bootstrap": {
+                  "point": -0.029826,
+                  "lo": -0.109189,
+                  "hi": 0.044669,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 24,
+          "entries": 11,
+          "win_rate": 0.5455,
+          "mean_net_pct": -0.5588,
+          "total_net_pct": -6.1471,
+          "total_return_pct": -6.21,
+          "max_drawdown_pct": -11.74,
+          "sharpe": -1.042,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 20,
+          "entries": 11,
+          "win_rate": 0.5455,
+          "mean_net_pct": -0.2739,
+          "total_net_pct": -3.0131,
+          "total_return_pct": -3.24,
+          "max_drawdown_pct": -10.08,
+          "sharpe": -0.548,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.284909,
+          "lo": -1.514045,
+          "hi": 2.083114,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 11,
+          "paired": 11,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 11,
+            "control_mean_net_pct": -0.5588,
+            "candidate_mean_net_pct": -0.2739,
+            "control_total_net_pct": -6.1471,
+            "candidate_total_net_pct": -3.0131,
+            "control_win_rate": 0.5455,
+            "candidate_win_rate": 0.5455,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.9685,
+            "candidate_median_mae_pct": -0.9685,
+            "control_median_mfe_pct": 1.7748,
+            "candidate_median_mfe_pct": 1.7748,
+            "paired_delta": {
+              "n": 11,
+              "mean": 0.284909,
+              "median": 0.0,
+              "sign_test": {
+                "n": 11,
+                "n_pos": 8,
+                "n_neg": 3,
+                "n_zero": 0,
+                "p_value": 0.226562
+              },
+              "signed_rank": {
+                "n": 11,
+                "w": 51.0,
+                "z": 1.5559,
+                "p_value": 0.119722
+              },
+              "bootstrap": {
+                "point": 0.284909,
+                "lo": -0.031818,
+                "hi": 0.621291,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 11,
+              "control_mean_net_pct": -0.5588,
+              "candidate_mean_net_pct": -0.2739,
+              "control_total_net_pct": -6.1471,
+              "candidate_total_net_pct": -3.0131,
+              "control_win_rate": 0.5455,
+              "candidate_win_rate": 0.5455,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.9685,
+              "candidate_median_mae_pct": -0.9685,
+              "control_median_mfe_pct": 1.7748,
+              "candidate_median_mfe_pct": 1.7748,
+              "paired_delta": {
+                "n": 11,
+                "mean": 0.284909,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 11,
+                  "n_pos": 8,
+                  "n_neg": 3,
+                  "n_zero": 0,
+                  "p_value": 0.226562
+                },
+                "signed_rank": {
+                  "n": 11,
+                  "w": 51.0,
+                  "z": 1.5559,
+                  "p_value": 0.119722
+                },
+                "bootstrap": {
+                  "point": 0.284909,
+                  "lo": -0.031818,
+                  "hi": 0.621291,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 148,
+          "entries": 67,
+          "win_rate": 0.4627,
+          "mean_net_pct": -0.2928,
+          "total_net_pct": -19.6167,
+          "total_return_pct": -18.48,
+          "max_drawdown_pct": -20.72,
+          "sharpe": -1.817,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 111,
+          "entries": 67,
+          "win_rate": 0.4627,
+          "mean_net_pct": -0.2945,
+          "total_net_pct": -19.7287,
+          "total_return_pct": -18.5,
+          "max_drawdown_pct": -21.74,
+          "sharpe": -1.909,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.001672,
+          "lo": -0.562571,
+          "hi": 0.551672,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 67,
+          "paired": 67,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 67,
+            "control_mean_net_pct": -0.2928,
+            "candidate_mean_net_pct": -0.2945,
+            "control_total_net_pct": -19.6167,
+            "candidate_total_net_pct": -19.7287,
+            "control_win_rate": 0.4627,
+            "candidate_win_rate": 0.4627,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.9148,
+            "candidate_median_mae_pct": -0.9148,
+            "control_median_mfe_pct": 1.1801,
+            "candidate_median_mfe_pct": 0.9823,
+            "paired_delta": {
+              "n": 67,
+              "mean": -0.001672,
+              "median": 0.0,
+              "sign_test": {
+                "n": 66,
+                "n_pos": 35,
+                "n_neg": 31,
+                "n_zero": 1,
+                "p_value": 0.712231
+              },
+              "signed_rank": {
+                "n": 66,
+                "w": 1139.0,
+                "z": 0.2108,
+                "p_value": 0.833038
+              },
+              "bootstrap": {
+                "point": -0.001672,
+                "lo": -0.071493,
+                "hi": 0.069375,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 67,
+              "control_mean_net_pct": -0.2928,
+              "candidate_mean_net_pct": -0.2945,
+              "control_total_net_pct": -19.6167,
+              "candidate_total_net_pct": -19.7287,
+              "control_win_rate": 0.4627,
+              "candidate_win_rate": 0.4627,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.9148,
+              "candidate_median_mae_pct": -0.9148,
+              "control_median_mfe_pct": 1.1801,
+              "candidate_median_mfe_pct": 0.9823,
+              "paired_delta": {
+                "n": 67,
+                "mean": -0.001672,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 66,
+                  "n_pos": 35,
+                  "n_neg": 31,
+                  "n_zero": 1,
+                  "p_value": 0.712231
+                },
+                "signed_rank": {
+                  "n": 66,
+                  "w": 1139.0,
+                  "z": 0.2108,
+                  "p_value": 0.833038
+                },
+                "bootstrap": {
+                  "point": -0.001672,
+                  "lo": -0.071493,
+                  "hi": 0.069375,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 26,
+          "entries": 16,
+          "win_rate": 0.4375,
+          "mean_net_pct": -0.1167,
+          "total_net_pct": -1.8676,
+          "total_return_pct": -2.7,
+          "max_drawdown_pct": -16.14,
+          "sharpe": -0.139,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 32,
+          "entries": 16,
+          "win_rate": 0.5625,
+          "mean_net_pct": 0.4385,
+          "total_net_pct": 7.0164,
+          "total_return_pct": 6.7,
+          "max_drawdown_pct": -12.57,
+          "sharpe": 0.884,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.55525,
+          "lo": -1.543641,
+          "hi": 2.618428,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 16,
+          "paired": 16,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 16,
+            "control_mean_net_pct": -0.1167,
+            "candidate_mean_net_pct": 0.1403,
+            "control_total_net_pct": -1.8676,
+            "candidate_total_net_pct": 2.2444,
+            "control_win_rate": 0.4375,
+            "candidate_win_rate": 0.5,
+            "delta_win_rate": 0.0625,
+            "control_median_mae_pct": -1.8061,
+            "candidate_median_mae_pct": -1.8061,
+            "control_median_mfe_pct": 2.4477,
+            "candidate_median_mfe_pct": 2.2951,
+            "paired_delta": {
+              "n": 16,
+              "mean": 0.257,
+              "median": -0.0,
+              "sign_test": {
+                "n": 16,
+                "n_pos": 7,
+                "n_neg": 9,
+                "n_zero": 0,
+                "p_value": 0.803619
+              },
+              "signed_rank": {
+                "n": 16,
+                "w": 66.0,
+                "z": -0.0776,
+                "p_value": 0.938176
+              },
+              "bootstrap": {
+                "point": 0.257,
+                "lo": -0.332506,
+                "hi": 0.935775,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 16,
+              "control_mean_net_pct": -0.1167,
+              "candidate_mean_net_pct": 0.1403,
+              "control_total_net_pct": -1.8676,
+              "candidate_total_net_pct": 2.2444,
+              "control_win_rate": 0.4375,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0625,
+              "control_median_mae_pct": -1.8061,
+              "candidate_median_mae_pct": -1.8061,
+              "control_median_mfe_pct": 2.4477,
+              "candidate_median_mfe_pct": 2.2951,
+              "paired_delta": {
+                "n": 16,
+                "mean": 0.257,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 16,
+                  "n_pos": 7,
+                  "n_neg": 9,
+                  "n_zero": 0,
+                  "p_value": 0.803619
+                },
+                "signed_rank": {
+                  "n": 16,
+                  "w": 66.0,
+                  "z": -0.0776,
+                  "p_value": 0.938176
+                },
+                "bootstrap": {
+                  "point": 0.257,
+                  "lo": -0.332506,
+                  "hi": 0.935775,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/mr.rv_wider.json
+++ b/backtest/research/regime_1152_runs/mr.rv_wider.json
@@ -1,0 +1,1502 @@
+{
+  "open": {
+    "name": "mean_reversion",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "tp_tiers": {
+          "ranging_volatile": [
+            {
+              "atr_multiple": 1.5,
+              "close_fraction": 0.4,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 0.8,
+              "trailing_mult_after": 0.75
+            },
+            {
+              "atr_multiple": 4.5,
+              "close_fraction": 1.0,
+              "trailing_mult_after": 0.75
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "control_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_volatile"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 164,
+          "entries": 92,
+          "win_rate": 0.3804,
+          "mean_net_pct": -0.262,
+          "total_net_pct": -24.1012,
+          "total_return_pct": -21.73,
+          "max_drawdown_pct": -24.32,
+          "sharpe": -2.798,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 149,
+          "entries": 90,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.3067,
+          "total_net_pct": -27.607,
+          "total_return_pct": -24.54,
+          "max_drawdown_pct": -26.81,
+          "sharpe": -2.968,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.044775,
+          "lo": -0.344318,
+          "hi": 0.256701,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 92,
+          "paired": 92,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 92,
+            "control_mean_net_pct": -0.262,
+            "candidate_mean_net_pct": -0.3003,
+            "control_total_net_pct": -24.1012,
+            "candidate_total_net_pct": -27.6292,
+            "control_win_rate": 0.3804,
+            "candidate_win_rate": 0.337,
+            "delta_win_rate": -0.0434,
+            "control_median_mae_pct": -0.5137,
+            "candidate_median_mae_pct": -0.5535,
+            "control_median_mfe_pct": 0.607,
+            "candidate_median_mfe_pct": 0.607,
+            "paired_delta": {
+              "n": 92,
+              "mean": -0.038348,
+              "median": -0.0,
+              "sign_test": {
+                "n": 92,
+                "n_pos": 41,
+                "n_neg": 51,
+                "n_zero": 0,
+                "p_value": 0.348141
+              },
+              "signed_rank": {
+                "n": 92,
+                "w": 1805.0,
+                "z": -1.2986,
+                "p_value": 0.194076
+              },
+              "bootstrap": {
+                "point": -0.038348,
+                "lo": -0.12061,
+                "hi": 0.043761,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 92,
+              "control_mean_net_pct": -0.262,
+              "candidate_mean_net_pct": -0.3003,
+              "control_total_net_pct": -24.1012,
+              "candidate_total_net_pct": -27.6292,
+              "control_win_rate": 0.3804,
+              "candidate_win_rate": 0.337,
+              "delta_win_rate": -0.0434,
+              "control_median_mae_pct": -0.5137,
+              "candidate_median_mae_pct": -0.5535,
+              "control_median_mfe_pct": 0.607,
+              "candidate_median_mfe_pct": 0.607,
+              "paired_delta": {
+                "n": 92,
+                "mean": -0.038348,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 92,
+                  "n_pos": 41,
+                  "n_neg": 51,
+                  "n_zero": 0,
+                  "p_value": 0.348141
+                },
+                "signed_rank": {
+                  "n": 92,
+                  "w": 1805.0,
+                  "z": -1.2986,
+                  "p_value": 0.194076
+                },
+                "bootstrap": {
+                  "point": -0.038348,
+                  "lo": -0.12061,
+                  "hi": 0.043761,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 44,
+          "entries": 26,
+          "win_rate": 0.4231,
+          "mean_net_pct": -0.6948,
+          "total_net_pct": -18.0646,
+          "total_return_pct": -17.17,
+          "max_drawdown_pct": -18.47,
+          "sharpe": -1.91,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 38,
+          "entries": 26,
+          "win_rate": 0.3846,
+          "mean_net_pct": -0.6924,
+          "total_net_pct": -18.0026,
+          "total_return_pct": -17.16,
+          "max_drawdown_pct": -18.27,
+          "sharpe": -1.854,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.002385,
+          "lo": -1.40385,
+          "hi": 1.407854,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 26,
+          "paired": 26,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 26,
+            "control_mean_net_pct": -0.6948,
+            "candidate_mean_net_pct": -0.6924,
+            "control_total_net_pct": -18.0646,
+            "candidate_total_net_pct": -18.0026,
+            "control_win_rate": 0.4231,
+            "candidate_win_rate": 0.3846,
+            "delta_win_rate": -0.0385,
+            "control_median_mae_pct": -1.3734,
+            "candidate_median_mae_pct": -1.3734,
+            "control_median_mfe_pct": 1.0106,
+            "candidate_median_mfe_pct": 1.0106,
+            "paired_delta": {
+              "n": 26,
+              "mean": 0.002385,
+              "median": 0.0,
+              "sign_test": {
+                "n": 25,
+                "n_pos": 13,
+                "n_neg": 12,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 25,
+                "w": 167.0,
+                "z": 0.1076,
+                "p_value": 0.914291
+              },
+              "bootstrap": {
+                "point": 0.002385,
+                "lo": -0.163773,
+                "hi": 0.189771,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 26,
+              "control_mean_net_pct": -0.6948,
+              "candidate_mean_net_pct": -0.6924,
+              "control_total_net_pct": -18.0646,
+              "candidate_total_net_pct": -18.0026,
+              "control_win_rate": 0.4231,
+              "candidate_win_rate": 0.3846,
+              "delta_win_rate": -0.0385,
+              "control_median_mae_pct": -1.3734,
+              "candidate_median_mae_pct": -1.3734,
+              "control_median_mfe_pct": 1.0106,
+              "candidate_median_mfe_pct": 1.0106,
+              "paired_delta": {
+                "n": 26,
+                "mean": 0.002385,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 25,
+                  "n_pos": 13,
+                  "n_neg": 12,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 25,
+                  "w": 167.0,
+                  "z": 0.1076,
+                  "p_value": 0.914291
+                },
+                "bootstrap": {
+                  "point": 0.002385,
+                  "lo": -0.163773,
+                  "hi": 0.189771,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 185,
+          "entries": 93,
+          "win_rate": 0.5054,
+          "mean_net_pct": -0.0164,
+          "total_net_pct": -1.5273,
+          "total_return_pct": -2.63,
+          "max_drawdown_pct": -17.95,
+          "sharpe": -0.05,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 171,
+          "entries": 91,
+          "win_rate": 0.4835,
+          "mean_net_pct": 0.0478,
+          "total_net_pct": 4.3509,
+          "total_return_pct": 3.04,
+          "max_drawdown_pct": -16.28,
+          "sharpe": 0.332,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.064235,
+          "lo": -0.43633,
+          "hi": 0.572679,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 93,
+          "paired": 93,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 93,
+            "control_mean_net_pct": -0.0164,
+            "candidate_mean_net_pct": 0.043,
+            "control_total_net_pct": -1.5273,
+            "candidate_total_net_pct": 3.9967,
+            "control_win_rate": 0.5054,
+            "candidate_win_rate": 0.4839,
+            "delta_win_rate": -0.0215,
+            "control_median_mae_pct": -0.673,
+            "candidate_median_mae_pct": -0.673,
+            "control_median_mfe_pct": 1.4908,
+            "candidate_median_mfe_pct": 1.5181,
+            "paired_delta": {
+              "n": 93,
+              "mean": 0.059398,
+              "median": 0.0,
+              "sign_test": {
+                "n": 93,
+                "n_pos": 49,
+                "n_neg": 44,
+                "n_zero": 0,
+                "p_value": 0.678532
+              },
+              "signed_rank": {
+                "n": 93,
+                "w": 2221.0,
+                "z": 0.1341,
+                "p_value": 0.893319
+              },
+              "bootstrap": {
+                "point": 0.059398,
+                "lo": -0.035206,
+                "hi": 0.169832,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 93,
+              "control_mean_net_pct": -0.0164,
+              "candidate_mean_net_pct": 0.043,
+              "control_total_net_pct": -1.5273,
+              "candidate_total_net_pct": 3.9967,
+              "control_win_rate": 0.5054,
+              "candidate_win_rate": 0.4839,
+              "delta_win_rate": -0.0215,
+              "control_median_mae_pct": -0.673,
+              "candidate_median_mae_pct": -0.673,
+              "control_median_mfe_pct": 1.4908,
+              "candidate_median_mfe_pct": 1.5181,
+              "paired_delta": {
+                "n": 93,
+                "mean": 0.059398,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 93,
+                  "n_pos": 49,
+                  "n_neg": 44,
+                  "n_zero": 0,
+                  "p_value": 0.678532
+                },
+                "signed_rank": {
+                  "n": 93,
+                  "w": 2221.0,
+                  "z": 0.1341,
+                  "p_value": 0.893319
+                },
+                "bootstrap": {
+                  "point": 0.059398,
+                  "lo": -0.035206,
+                  "hi": 0.169832,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 31,
+          "entries": 21,
+          "win_rate": 0.381,
+          "mean_net_pct": -0.7046,
+          "total_net_pct": -14.7961,
+          "total_return_pct": -14.35,
+          "max_drawdown_pct": -22.58,
+          "sharpe": -1.202,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 33,
+          "entries": 22,
+          "win_rate": 0.2727,
+          "mean_net_pct": -0.9896,
+          "total_net_pct": -21.7702,
+          "total_return_pct": -20.36,
+          "max_drawdown_pct": -26.3,
+          "sharpe": -1.633,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.284978,
+          "lo": -1.970978,
+          "hi": 1.484669,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 21,
+          "paired": 21,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 21,
+            "control_mean_net_pct": -0.7046,
+            "candidate_mean_net_pct": -0.7066,
+            "control_total_net_pct": -14.7961,
+            "candidate_total_net_pct": -14.8381,
+            "control_win_rate": 0.381,
+            "candidate_win_rate": 0.3333,
+            "delta_win_rate": -0.0477,
+            "control_median_mae_pct": -2.485,
+            "candidate_median_mae_pct": -2.485,
+            "control_median_mfe_pct": 2.0347,
+            "candidate_median_mfe_pct": 2.0347,
+            "paired_delta": {
+              "n": 21,
+              "mean": -0.002,
+              "median": -0.0,
+              "sign_test": {
+                "n": 21,
+                "n_pos": 8,
+                "n_neg": 13,
+                "n_zero": 0,
+                "p_value": 0.38331
+              },
+              "signed_rank": {
+                "n": 21,
+                "w": 99.0,
+                "z": -0.5561,
+                "p_value": 0.578127
+              },
+              "bootstrap": {
+                "point": -0.002,
+                "lo": -0.398383,
+                "hi": 0.36954,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 21,
+              "control_mean_net_pct": -0.7046,
+              "candidate_mean_net_pct": -0.7066,
+              "control_total_net_pct": -14.7961,
+              "candidate_total_net_pct": -14.8381,
+              "control_win_rate": 0.381,
+              "candidate_win_rate": 0.3333,
+              "delta_win_rate": -0.0477,
+              "control_median_mae_pct": -2.485,
+              "candidate_median_mae_pct": -2.485,
+              "control_median_mfe_pct": 2.0347,
+              "candidate_median_mfe_pct": 2.0347,
+              "paired_delta": {
+                "n": 21,
+                "mean": -0.002,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 21,
+                  "n_pos": 8,
+                  "n_neg": 13,
+                  "n_zero": 0,
+                  "p_value": 0.38331
+                },
+                "signed_rank": {
+                  "n": 21,
+                  "w": 99.0,
+                  "z": -0.5561,
+                  "p_value": 0.578127
+                },
+                "bootstrap": {
+                  "point": -0.002,
+                  "lo": -0.398383,
+                  "hi": 0.36954,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 171,
+          "entries": 83,
+          "win_rate": 0.4458,
+          "mean_net_pct": -0.214,
+          "total_net_pct": -17.7643,
+          "total_return_pct": -17.41,
+          "max_drawdown_pct": -27.98,
+          "sharpe": -1.237,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 140,
+          "entries": 81,
+          "win_rate": 0.4444,
+          "mean_net_pct": -0.1425,
+          "total_net_pct": -11.5401,
+          "total_return_pct": -12.48,
+          "max_drawdown_pct": -25.61,
+          "sharpe": -0.725,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.071557,
+          "lo": -0.538982,
+          "hi": 0.682252,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 83,
+          "paired": 83,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 83,
+            "control_mean_net_pct": -0.214,
+            "candidate_mean_net_pct": -0.1492,
+            "control_total_net_pct": -17.7643,
+            "candidate_total_net_pct": -12.3843,
+            "control_win_rate": 0.4458,
+            "candidate_win_rate": 0.4458,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.7939,
+            "candidate_median_mae_pct": -0.8491,
+            "control_median_mfe_pct": 1.3569,
+            "candidate_median_mfe_pct": 1.3661,
+            "paired_delta": {
+              "n": 83,
+              "mean": 0.064819,
+              "median": 0.0,
+              "sign_test": {
+                "n": 83,
+                "n_pos": 45,
+                "n_neg": 38,
+                "n_zero": 0,
+                "p_value": 0.51041
+              },
+              "signed_rank": {
+                "n": 83,
+                "w": 1918.0,
+                "z": 0.7923,
+                "p_value": 0.428213
+              },
+              "bootstrap": {
+                "point": 0.064819,
+                "lo": -0.082242,
+                "hi": 0.228562,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 83,
+              "control_mean_net_pct": -0.214,
+              "candidate_mean_net_pct": -0.1492,
+              "control_total_net_pct": -17.7643,
+              "candidate_total_net_pct": -12.3843,
+              "control_win_rate": 0.4458,
+              "candidate_win_rate": 0.4458,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.7939,
+              "candidate_median_mae_pct": -0.8491,
+              "control_median_mfe_pct": 1.3569,
+              "candidate_median_mfe_pct": 1.3661,
+              "paired_delta": {
+                "n": 83,
+                "mean": 0.064819,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 83,
+                  "n_pos": 45,
+                  "n_neg": 38,
+                  "n_zero": 0,
+                  "p_value": 0.51041
+                },
+                "signed_rank": {
+                  "n": 83,
+                  "w": 1918.0,
+                  "z": 0.7923,
+                  "p_value": 0.428213
+                },
+                "bootstrap": {
+                  "point": 0.064819,
+                  "lo": -0.082242,
+                  "hi": 0.228562,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 35,
+          "entries": 18,
+          "win_rate": 0.6111,
+          "mean_net_pct": -0.3139,
+          "total_net_pct": -5.6498,
+          "total_return_pct": -6.61,
+          "max_drawdown_pct": -21.34,
+          "sharpe": -0.448,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 26,
+          "entries": 18,
+          "win_rate": 0.3889,
+          "mean_net_pct": -0.5034,
+          "total_net_pct": -9.0618,
+          "total_return_pct": -9.86,
+          "max_drawdown_pct": -25.76,
+          "sharpe": -0.646,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.189556,
+          "lo": -2.730239,
+          "hi": 2.405267,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 18,
+          "paired": 18,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 18,
+            "control_mean_net_pct": -0.3139,
+            "candidate_mean_net_pct": -0.5034,
+            "control_total_net_pct": -5.6498,
+            "candidate_total_net_pct": -9.0618,
+            "control_win_rate": 0.6111,
+            "candidate_win_rate": 0.3889,
+            "delta_win_rate": -0.2222,
+            "control_median_mae_pct": -2.5024,
+            "candidate_median_mae_pct": -2.5024,
+            "control_median_mfe_pct": 2.738,
+            "candidate_median_mfe_pct": 2.738,
+            "paired_delta": {
+              "n": 18,
+              "mean": -0.189556,
+              "median": -0.0,
+              "sign_test": {
+                "n": 18,
+                "n_pos": 7,
+                "n_neg": 11,
+                "n_zero": 0,
+                "p_value": 0.480682
+              },
+              "signed_rank": {
+                "n": 18,
+                "w": 54.0,
+                "z": -1.3501,
+                "p_value": 0.176996
+              },
+              "bootstrap": {
+                "point": -0.189556,
+                "lo": -0.573233,
+                "hi": 0.252686,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 18,
+              "control_mean_net_pct": -0.3139,
+              "candidate_mean_net_pct": -0.5034,
+              "control_total_net_pct": -5.6498,
+              "candidate_total_net_pct": -9.0618,
+              "control_win_rate": 0.6111,
+              "candidate_win_rate": 0.3889,
+              "delta_win_rate": -0.2222,
+              "control_median_mae_pct": -2.5024,
+              "candidate_median_mae_pct": -2.5024,
+              "control_median_mfe_pct": 2.738,
+              "candidate_median_mfe_pct": 2.738,
+              "paired_delta": {
+                "n": 18,
+                "mean": -0.189556,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 18,
+                  "n_pos": 7,
+                  "n_neg": 11,
+                  "n_zero": 0,
+                  "p_value": 0.480682
+                },
+                "signed_rank": {
+                  "n": 18,
+                  "w": 54.0,
+                  "z": -1.3501,
+                  "p_value": 0.176996
+                },
+                "bootstrap": {
+                  "point": -0.189556,
+                  "lo": -0.573233,
+                  "hi": 0.252686,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 99,
+          "entries": 58,
+          "win_rate": 0.4828,
+          "mean_net_pct": -0.1178,
+          "total_net_pct": -6.8338,
+          "total_return_pct": -7.0,
+          "max_drawdown_pct": -8.93,
+          "sharpe": -0.855,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 92,
+          "entries": 56,
+          "win_rate": 0.4286,
+          "mean_net_pct": -0.0931,
+          "total_net_pct": -5.2136,
+          "total_return_pct": -5.53,
+          "max_drawdown_pct": -7.97,
+          "sharpe": -0.61,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.024724,
+          "lo": -0.453411,
+          "hi": 0.509901,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 58,
+          "paired": 58,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 58,
+            "control_mean_net_pct": -0.1178,
+            "candidate_mean_net_pct": -0.1191,
+            "control_total_net_pct": -6.8338,
+            "candidate_total_net_pct": -6.9078,
+            "control_win_rate": 0.4828,
+            "candidate_win_rate": 0.4138,
+            "delta_win_rate": -0.069,
+            "control_median_mae_pct": -0.7147,
+            "candidate_median_mae_pct": -0.7147,
+            "control_median_mfe_pct": 0.9142,
+            "candidate_median_mfe_pct": 0.9535,
+            "paired_delta": {
+              "n": 58,
+              "mean": -0.001276,
+              "median": -0.0,
+              "sign_test": {
+                "n": 57,
+                "n_pos": 28,
+                "n_neg": 29,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 57,
+                "w": 764.0,
+                "z": -0.4926,
+                "p_value": 0.622293
+              },
+              "bootstrap": {
+                "point": -0.001276,
+                "lo": -0.075244,
+                "hi": 0.078622,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 58,
+              "control_mean_net_pct": -0.1178,
+              "candidate_mean_net_pct": -0.1191,
+              "control_total_net_pct": -6.8338,
+              "candidate_total_net_pct": -6.9078,
+              "control_win_rate": 0.4828,
+              "candidate_win_rate": 0.4138,
+              "delta_win_rate": -0.069,
+              "control_median_mae_pct": -0.7147,
+              "candidate_median_mae_pct": -0.7147,
+              "control_median_mfe_pct": 0.9142,
+              "candidate_median_mfe_pct": 0.9535,
+              "paired_delta": {
+                "n": 58,
+                "mean": -0.001276,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 57,
+                  "n_pos": 28,
+                  "n_neg": 29,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 57,
+                  "w": 764.0,
+                  "z": -0.4926,
+                  "p_value": 0.622293
+                },
+                "bootstrap": {
+                  "point": -0.001276,
+                  "lo": -0.075244,
+                  "hi": 0.078622,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 15,
+          "entries": 12,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.8083,
+          "total_net_pct": -9.6992,
+          "total_return_pct": -9.56,
+          "max_drawdown_pct": -13.37,
+          "sharpe": -1.63,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 17,
+          "entries": 12,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.7331,
+          "total_net_pct": -8.7972,
+          "total_return_pct": -8.73,
+          "max_drawdown_pct": -12.95,
+          "sharpe": -1.489,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.075167,
+          "lo": -1.802592,
+          "hi": 1.924513,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 12,
+          "paired": 12,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 12,
+            "control_mean_net_pct": -0.8083,
+            "candidate_mean_net_pct": -0.7689,
+            "control_total_net_pct": -9.6992,
+            "candidate_total_net_pct": -9.2272,
+            "control_win_rate": 0.3333,
+            "candidate_win_rate": 0.3333,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.7884,
+            "candidate_median_mae_pct": -1.7884,
+            "control_median_mfe_pct": 1.2321,
+            "candidate_median_mfe_pct": 1.2321,
+            "paired_delta": {
+              "n": 12,
+              "mean": 0.039333,
+              "median": 0.0,
+              "sign_test": {
+                "n": 11,
+                "n_pos": 7,
+                "n_neg": 4,
+                "n_zero": 1,
+                "p_value": 0.548828
+              },
+              "signed_rank": {
+                "n": 11,
+                "w": 37.0,
+                "z": 0.3112,
+                "p_value": 0.755658
+              },
+              "bootstrap": {
+                "point": 0.039333,
+                "lo": -0.069667,
+                "hi": 0.165333,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 12,
+              "control_mean_net_pct": -0.8083,
+              "candidate_mean_net_pct": -0.7689,
+              "control_total_net_pct": -9.6992,
+              "candidate_total_net_pct": -9.2272,
+              "control_win_rate": 0.3333,
+              "candidate_win_rate": 0.3333,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.7884,
+              "candidate_median_mae_pct": -1.7884,
+              "control_median_mfe_pct": 1.2321,
+              "candidate_median_mfe_pct": 1.2321,
+              "paired_delta": {
+                "n": 12,
+                "mean": 0.039333,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 11,
+                  "n_pos": 7,
+                  "n_neg": 4,
+                  "n_zero": 1,
+                  "p_value": 0.548828
+                },
+                "signed_rank": {
+                  "n": 11,
+                  "w": 37.0,
+                  "z": 0.3112,
+                  "p_value": 0.755658
+                },
+                "bootstrap": {
+                  "point": 0.039333,
+                  "lo": -0.069667,
+                  "hi": 0.165333,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 126,
+          "entries": 69,
+          "win_rate": 0.4783,
+          "mean_net_pct": -0.0498,
+          "total_net_pct": -3.4369,
+          "total_return_pct": -4.03,
+          "max_drawdown_pct": -9.96,
+          "sharpe": -0.342,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 133,
+          "entries": 67,
+          "win_rate": 0.4776,
+          "mean_net_pct": 0.0273,
+          "total_net_pct": 1.8313,
+          "total_return_pct": 1.02,
+          "max_drawdown_pct": -9.97,
+          "sharpe": 0.213,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.077143,
+          "lo": -0.436454,
+          "hi": 0.576893,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 69,
+          "paired": 69,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 69,
+            "control_mean_net_pct": -0.0498,
+            "candidate_mean_net_pct": 0.0103,
+            "control_total_net_pct": -3.4369,
+            "candidate_total_net_pct": 0.7111,
+            "control_win_rate": 0.4783,
+            "candidate_win_rate": 0.4638,
+            "delta_win_rate": -0.0145,
+            "control_median_mae_pct": -0.7792,
+            "candidate_median_mae_pct": -0.7792,
+            "control_median_mfe_pct": 1.1677,
+            "candidate_median_mfe_pct": 1.2871,
+            "paired_delta": {
+              "n": 69,
+              "mean": 0.060116,
+              "median": 0.0,
+              "sign_test": {
+                "n": 68,
+                "n_pos": 40,
+                "n_neg": 28,
+                "n_zero": 1,
+                "p_value": 0.18181
+              },
+              "signed_rank": {
+                "n": 68,
+                "w": 1388.0,
+                "z": 1.3107,
+                "p_value": 0.189969
+              },
+              "bootstrap": {
+                "point": 0.060116,
+                "lo": -0.025132,
+                "hi": 0.154088,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 69,
+              "control_mean_net_pct": -0.0498,
+              "candidate_mean_net_pct": 0.0103,
+              "control_total_net_pct": -3.4369,
+              "candidate_total_net_pct": 0.7111,
+              "control_win_rate": 0.4783,
+              "candidate_win_rate": 0.4638,
+              "delta_win_rate": -0.0145,
+              "control_median_mae_pct": -0.7792,
+              "candidate_median_mae_pct": -0.7792,
+              "control_median_mfe_pct": 1.1677,
+              "candidate_median_mfe_pct": 1.2871,
+              "paired_delta": {
+                "n": 69,
+                "mean": 0.060116,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 68,
+                  "n_pos": 40,
+                  "n_neg": 28,
+                  "n_zero": 1,
+                  "p_value": 0.18181
+                },
+                "signed_rank": {
+                  "n": 68,
+                  "w": 1388.0,
+                  "z": 1.3107,
+                  "p_value": 0.189969
+                },
+                "bootstrap": {
+                  "point": 0.060116,
+                  "lo": -0.025132,
+                  "hi": 0.154088,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 24,
+          "entries": 11,
+          "win_rate": 0.5455,
+          "mean_net_pct": -0.5588,
+          "total_net_pct": -6.1471,
+          "total_return_pct": -6.21,
+          "max_drawdown_pct": -11.74,
+          "sharpe": -1.042,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 18,
+          "entries": 11,
+          "win_rate": 0.4545,
+          "mean_net_pct": -0.5799,
+          "total_net_pct": -6.3791,
+          "total_return_pct": -6.62,
+          "max_drawdown_pct": -16.22,
+          "sharpe": -0.903,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.021091,
+          "lo": -2.074755,
+          "hi": 2.119695,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 11,
+          "paired": 11,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 11,
+            "control_mean_net_pct": -0.5588,
+            "candidate_mean_net_pct": -0.5799,
+            "control_total_net_pct": -6.1471,
+            "candidate_total_net_pct": -6.3791,
+            "control_win_rate": 0.5455,
+            "candidate_win_rate": 0.4545,
+            "delta_win_rate": -0.091,
+            "control_median_mae_pct": -0.9685,
+            "candidate_median_mae_pct": -1.9949,
+            "control_median_mfe_pct": 1.7748,
+            "candidate_median_mfe_pct": 2.1407,
+            "paired_delta": {
+              "n": 11,
+              "mean": -0.021091,
+              "median": 0.0,
+              "sign_test": {
+                "n": 10,
+                "n_pos": 7,
+                "n_neg": 3,
+                "n_zero": 1,
+                "p_value": 0.34375
+              },
+              "signed_rank": {
+                "n": 10,
+                "w": 39.0,
+                "z": 1.1212,
+                "p_value": 0.262193
+              },
+              "bootstrap": {
+                "point": -0.021091,
+                "lo": -1.26,
+                "hi": 0.998727,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 11,
+              "control_mean_net_pct": -0.5588,
+              "candidate_mean_net_pct": -0.5799,
+              "control_total_net_pct": -6.1471,
+              "candidate_total_net_pct": -6.3791,
+              "control_win_rate": 0.5455,
+              "candidate_win_rate": 0.4545,
+              "delta_win_rate": -0.091,
+              "control_median_mae_pct": -0.9685,
+              "candidate_median_mae_pct": -1.9949,
+              "control_median_mfe_pct": 1.7748,
+              "candidate_median_mfe_pct": 2.1407,
+              "paired_delta": {
+                "n": 11,
+                "mean": -0.021091,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 10,
+                  "n_pos": 7,
+                  "n_neg": 3,
+                  "n_zero": 1,
+                  "p_value": 0.34375
+                },
+                "signed_rank": {
+                  "n": 10,
+                  "w": 39.0,
+                  "z": 1.1212,
+                  "p_value": 0.262193
+                },
+                "bootstrap": {
+                  "point": -0.021091,
+                  "lo": -1.26,
+                  "hi": 0.998727,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 148,
+          "entries": 67,
+          "win_rate": 0.4627,
+          "mean_net_pct": -0.2928,
+          "total_net_pct": -19.6167,
+          "total_return_pct": -18.48,
+          "max_drawdown_pct": -20.72,
+          "sharpe": -1.817,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 106,
+          "entries": 67,
+          "win_rate": 0.4179,
+          "mean_net_pct": -0.2623,
+          "total_net_pct": -17.5767,
+          "total_return_pct": -16.93,
+          "max_drawdown_pct": -21.82,
+          "sharpe": -1.539,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.030448,
+          "lo": -0.566581,
+          "hi": 0.63216,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 67,
+          "paired": 67,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 67,
+            "control_mean_net_pct": -0.2928,
+            "candidate_mean_net_pct": -0.2464,
+            "control_total_net_pct": -19.6167,
+            "candidate_total_net_pct": -16.5067,
+            "control_win_rate": 0.4627,
+            "candidate_win_rate": 0.4179,
+            "delta_win_rate": -0.0448,
+            "control_median_mae_pct": -0.9148,
+            "candidate_median_mae_pct": -0.915,
+            "control_median_mfe_pct": 1.1801,
+            "candidate_median_mfe_pct": 1.191,
+            "paired_delta": {
+              "n": 67,
+              "mean": 0.046418,
+              "median": 0.0,
+              "sign_test": {
+                "n": 66,
+                "n_pos": 36,
+                "n_neg": 30,
+                "n_zero": 1,
+                "p_value": 0.538583
+              },
+              "signed_rank": {
+                "n": 66,
+                "w": 1194.0,
+                "z": 0.5622,
+                "p_value": 0.574013
+              },
+              "bootstrap": {
+                "point": 0.046418,
+                "lo": -0.071075,
+                "hi": 0.177493,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 67,
+              "control_mean_net_pct": -0.2928,
+              "candidate_mean_net_pct": -0.2464,
+              "control_total_net_pct": -19.6167,
+              "candidate_total_net_pct": -16.5067,
+              "control_win_rate": 0.4627,
+              "candidate_win_rate": 0.4179,
+              "delta_win_rate": -0.0448,
+              "control_median_mae_pct": -0.9148,
+              "candidate_median_mae_pct": -0.915,
+              "control_median_mfe_pct": 1.1801,
+              "candidate_median_mfe_pct": 1.191,
+              "paired_delta": {
+                "n": 67,
+                "mean": 0.046418,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 66,
+                  "n_pos": 36,
+                  "n_neg": 30,
+                  "n_zero": 1,
+                  "p_value": 0.538583
+                },
+                "signed_rank": {
+                  "n": 66,
+                  "w": 1194.0,
+                  "z": 0.5622,
+                  "p_value": 0.574013
+                },
+                "bootstrap": {
+                  "point": 0.046418,
+                  "lo": -0.071075,
+                  "hi": 0.177493,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 26,
+          "entries": 16,
+          "win_rate": 0.4375,
+          "mean_net_pct": -0.1167,
+          "total_net_pct": -1.8676,
+          "total_return_pct": -2.7,
+          "max_drawdown_pct": -16.14,
+          "sharpe": -0.139,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 23,
+          "entries": 16,
+          "win_rate": 0.4375,
+          "mean_net_pct": -0.2416,
+          "total_net_pct": -3.8656,
+          "total_return_pct": -4.56,
+          "max_drawdown_pct": -18.67,
+          "sharpe": -0.309,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.124875,
+          "lo": -2.416806,
+          "hi": 2.134759,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 16,
+          "paired": 16,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 16,
+            "control_mean_net_pct": -0.1167,
+            "candidate_mean_net_pct": -0.2416,
+            "control_total_net_pct": -1.8676,
+            "candidate_total_net_pct": -3.8656,
+            "control_win_rate": 0.4375,
+            "candidate_win_rate": 0.4375,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.8061,
+            "candidate_median_mae_pct": -1.8061,
+            "control_median_mfe_pct": 2.4477,
+            "candidate_median_mfe_pct": 2.4477,
+            "paired_delta": {
+              "n": 16,
+              "mean": -0.124875,
+              "median": -0.0,
+              "sign_test": {
+                "n": 15,
+                "n_pos": 6,
+                "n_neg": 9,
+                "n_zero": 1,
+                "p_value": 0.607239
+              },
+              "signed_rank": {
+                "n": 15,
+                "w": 42.0,
+                "z": -0.9939,
+                "p_value": 0.320255
+              },
+              "bootstrap": {
+                "point": -0.124875,
+                "lo": -0.33925,
+                "hi": 0.044794,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 16,
+              "control_mean_net_pct": -0.1167,
+              "candidate_mean_net_pct": -0.2416,
+              "control_total_net_pct": -1.8676,
+              "candidate_total_net_pct": -3.8656,
+              "control_win_rate": 0.4375,
+              "candidate_win_rate": 0.4375,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.8061,
+              "candidate_median_mae_pct": -1.8061,
+              "control_median_mfe_pct": 2.4477,
+              "candidate_median_mfe_pct": 2.4477,
+              "paired_delta": {
+                "n": 16,
+                "mean": -0.124875,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 15,
+                  "n_pos": 6,
+                  "n_neg": 9,
+                  "n_zero": 1,
+                  "p_value": 0.607239
+                },
+                "signed_rank": {
+                  "n": 15,
+                  "w": 42.0,
+                  "z": -0.9939,
+                  "p_value": 0.320255
+                },
+                "bootstrap": {
+                  "point": -0.124875,
+                  "lo": -0.33925,
+                  "hi": 0.044794,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/sq.b2_rd_patient3.json
+++ b/backtest/research/regime_1152_runs/sq.b2_rd_patient3.json
@@ -1,0 +1,1563 @@
+{
+  "open": {
+    "name": "squeeze_momentum",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "tiered_tp_atr_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "tiered_tp_atr",
+      "params": {
+        "tp_tiers": [
+          {
+            "atr_multiple": 1.0,
+            "close_fraction": 0.4
+          },
+          {
+            "atr_multiple": 2.0,
+            "close_fraction": 0.8
+          },
+          {
+            "atr_multiple": 3.0,
+            "close_fraction": 1.0
+          }
+        ]
+      }
+    }
+  ],
+  "control_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_directional"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 12,
+          "entries": 8,
+          "win_rate": 0.75,
+          "mean_net_pct": -0.1914,
+          "total_net_pct": -1.5308,
+          "total_return_pct": -1.53,
+          "max_drawdown_pct": -3.09,
+          "sharpe": -0.754,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 18,
+          "entries": 8,
+          "win_rate": 0.625,
+          "mean_net_pct": 0.1251,
+          "total_net_pct": 1.0012,
+          "total_return_pct": 0.95,
+          "max_drawdown_pct": -3.23,
+          "sharpe": 0.395,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.3165,
+          "lo": -0.691281,
+          "hi": 1.350016,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 8,
+          "paired": 8,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 8,
+            "control_mean_net_pct": -0.1914,
+            "candidate_mean_net_pct": 0.1251,
+            "control_total_net_pct": -1.5308,
+            "candidate_total_net_pct": 1.0012,
+            "control_win_rate": 0.75,
+            "candidate_win_rate": 0.625,
+            "delta_win_rate": -0.125,
+            "control_median_mae_pct": -0.5631,
+            "candidate_median_mae_pct": -0.8042,
+            "control_median_mfe_pct": 0.6148,
+            "candidate_median_mfe_pct": 1.492,
+            "paired_delta": {
+              "n": 8,
+              "mean": 0.3165,
+              "median": 0.173,
+              "sign_test": {
+                "n": 8,
+                "n_pos": 5,
+                "n_neg": 3,
+                "n_zero": 0,
+                "p_value": 0.726562
+              },
+              "signed_rank": {
+                "n": 8,
+                "w": 24.0,
+                "z": 0.7702,
+                "p_value": 0.441209
+              },
+              "bootstrap": {
+                "point": 0.3165,
+                "lo": -0.165875,
+                "hi": 0.894284,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 6,
+              "control_mean_net_pct": -0.1134,
+              "candidate_mean_net_pct": 0.2509,
+              "control_total_net_pct": -0.6806,
+              "candidate_total_net_pct": 1.5054,
+              "control_win_rate": 0.8333,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": -0.1666,
+              "control_median_mae_pct": -0.4835,
+              "candidate_median_mae_pct": -0.7702,
+              "control_median_mfe_pct": 0.7231,
+              "candidate_median_mfe_pct": 1.5067,
+              "paired_delta": {
+                "n": 6,
+                "mean": 0.364333,
+                "median": 0.301,
+                "sign_test": {
+                  "n": 6,
+                  "n_pos": 3,
+                  "n_neg": 3,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 6,
+                  "w": 13.0,
+                  "z": 0.4193,
+                  "p_value": 0.674987
+                },
+                "bootstrap": {
+                  "point": 0.364333,
+                  "lo": -0.276333,
+                  "hi": 1.077,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": -0.4251,
+              "candidate_mean_net_pct": -0.2521,
+              "control_total_net_pct": -0.8502,
+              "candidate_total_net_pct": -0.5042,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.6781,
+              "candidate_median_mae_pct": -0.8042,
+              "control_median_mfe_pct": 0.2777,
+              "candidate_median_mfe_pct": 0.9511,
+              "paired_delta": {
+                "n": 2,
+                "mean": 0.173,
+                "median": 0.173,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 2,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 3.0,
+                  "z": 0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": 0.173,
+                  "lo": 0.0,
+                  "hi": 0.346,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 0.0,
+          "mean_net_pct": -2.1301,
+          "total_net_pct": -2.1301,
+          "total_return_pct": -2.12,
+          "max_drawdown_pct": -2.47,
+          "sharpe": -1.869,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 0.0,
+          "mean_net_pct": -2.1301,
+          "total_net_pct": -2.1301,
+          "total_return_pct": -2.12,
+          "max_drawdown_pct": -2.47,
+          "sharpe": -1.869,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.0,
+          "lo": 0.0,
+          "hi": 0.0,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": -2.1301,
+            "candidate_mean_net_pct": -2.1301,
+            "control_total_net_pct": -2.1301,
+            "candidate_total_net_pct": -2.1301,
+            "control_win_rate": 0.0,
+            "candidate_win_rate": 0.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -2.3533,
+            "candidate_median_mae_pct": -2.3533,
+            "control_median_mfe_pct": 0.3097,
+            "candidate_median_mfe_pct": 0.3097,
+            "paired_delta": {
+              "n": 1,
+              "mean": 0.0,
+              "median": 0.0,
+              "sign_test": {
+                "n": 0,
+                "n_pos": 0,
+                "n_neg": 0,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 0,
+                "w": 0.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 0.0,
+                "lo": 0.0,
+                "hi": 0.0,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_up": {
+              "n": 1,
+              "control_mean_net_pct": -2.1301,
+              "candidate_mean_net_pct": -2.1301,
+              "control_total_net_pct": -2.1301,
+              "candidate_total_net_pct": -2.1301,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.3533,
+              "candidate_median_mae_pct": -2.3533,
+              "control_median_mfe_pct": 0.3097,
+              "candidate_median_mfe_pct": 0.3097,
+              "paired_delta": {
+                "n": 1,
+                "mean": 0.0,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 0,
+                  "n_pos": 0,
+                  "n_neg": 0,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 0,
+                  "w": 0.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.0,
+                  "lo": 0.0,
+                  "hi": 0.0,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 16,
+          "entries": 9,
+          "win_rate": 0.5556,
+          "mean_net_pct": 0.046,
+          "total_net_pct": 0.4141,
+          "total_return_pct": 0.38,
+          "max_drawdown_pct": -2.42,
+          "sharpe": 0.151,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 18,
+          "entries": 9,
+          "win_rate": 0.4444,
+          "mean_net_pct": -0.141,
+          "total_net_pct": -1.2689,
+          "total_return_pct": -1.4,
+          "max_drawdown_pct": -4.15,
+          "sharpe": -0.341,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.187,
+          "lo": -1.402444,
+          "hi": 1.057939,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 9,
+          "paired": 9,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 9,
+            "control_mean_net_pct": 0.046,
+            "candidate_mean_net_pct": -0.141,
+            "control_total_net_pct": 0.4141,
+            "candidate_total_net_pct": -1.2689,
+            "control_win_rate": 0.5556,
+            "candidate_win_rate": 0.4444,
+            "delta_win_rate": -0.1112,
+            "control_median_mae_pct": -0.7283,
+            "candidate_median_mae_pct": -1.2115,
+            "control_median_mfe_pct": 0.9856,
+            "candidate_median_mfe_pct": 1.3769,
+            "paired_delta": {
+              "n": 9,
+              "mean": -0.187,
+              "median": -0.385,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 4,
+                "n_neg": 5,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 17.0,
+                "z": -0.5923,
+                "p_value": 0.553617
+              },
+              "bootstrap": {
+                "point": -0.187,
+                "lo": -0.826667,
+                "hi": 0.477014,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 7,
+              "control_mean_net_pct": -0.043,
+              "candidate_mean_net_pct": -0.4052,
+              "control_total_net_pct": -0.3007,
+              "candidate_total_net_pct": -2.8367,
+              "control_win_rate": 0.5714,
+              "candidate_win_rate": 0.4286,
+              "delta_win_rate": -0.1428,
+              "control_median_mae_pct": -1.2115,
+              "candidate_median_mae_pct": -1.2723,
+              "control_median_mfe_pct": 0.9856,
+              "candidate_median_mfe_pct": 1.3769,
+              "paired_delta": {
+                "n": 7,
+                "mean": -0.362286,
+                "median": -0.81,
+                "sign_test": {
+                  "n": 7,
+                  "n_pos": 3,
+                  "n_neg": 4,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 7,
+                  "w": 8.0,
+                  "z": -0.9297,
+                  "p_value": 0.352542
+                },
+                "bootstrap": {
+                  "point": -0.362286,
+                  "lo": -1.061429,
+                  "hi": 0.384571,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": 0.3574,
+              "candidate_mean_net_pct": 0.7839,
+              "control_total_net_pct": 0.7148,
+              "candidate_total_net_pct": 1.5678,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.3932,
+              "candidate_median_mae_pct": -0.3932,
+              "control_median_mfe_pct": 0.8735,
+              "candidate_median_mfe_pct": 2.6631,
+              "paired_delta": {
+                "n": 2,
+                "mean": 0.4265,
+                "median": 0.4265,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 2.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.4265,
+                  "lo": -0.385,
+                  "hi": 1.238,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 7,
+          "entries": 5,
+          "win_rate": 0.6,
+          "mean_net_pct": -0.1651,
+          "total_net_pct": -0.8255,
+          "total_return_pct": -0.91,
+          "max_drawdown_pct": -4.37,
+          "sharpe": -0.223,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 11,
+          "entries": 5,
+          "win_rate": 0.6,
+          "mean_net_pct": 0.0415,
+          "total_net_pct": 0.2075,
+          "total_return_pct": 0.1,
+          "max_drawdown_pct": -4.91,
+          "sharpe": 0.061,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.2066,
+          "lo": -2.08932,
+          "hi": 2.44743,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 5,
+          "paired": 5,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 5,
+            "control_mean_net_pct": -0.1651,
+            "candidate_mean_net_pct": 0.0415,
+            "control_total_net_pct": -0.8255,
+            "candidate_total_net_pct": 0.2075,
+            "control_win_rate": 0.6,
+            "candidate_win_rate": 0.6,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.1631,
+            "candidate_median_mae_pct": -1.7671,
+            "control_median_mfe_pct": 1.6982,
+            "candidate_median_mfe_pct": 2.6688,
+            "paired_delta": {
+              "n": 5,
+              "mean": 0.2066,
+              "median": 0.0,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 3,
+                "n_neg": 1,
+                "n_zero": 1,
+                "p_value": 0.625
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 7.0,
+                "z": 0.5477,
+                "p_value": 0.583882
+              },
+              "bootstrap": {
+                "point": 0.2066,
+                "lo": -0.2206,
+                "hi": 0.8304,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": 0.9099,
+              "candidate_mean_net_pct": 2.2939,
+              "control_total_net_pct": 0.9099,
+              "candidate_total_net_pct": 2.2939,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1631,
+              "candidate_median_mae_pct": -1.1631,
+              "control_median_mfe_pct": 1.6982,
+              "candidate_median_mfe_pct": 4.2616,
+              "paired_delta": {
+                "n": 1,
+                "mean": 1.384,
+                "median": 1.384,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 1.384,
+                  "lo": 1.384,
+                  "hi": 1.384,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 4,
+              "control_mean_net_pct": -0.4339,
+              "candidate_mean_net_pct": -0.5216,
+              "control_total_net_pct": -1.7354,
+              "candidate_total_net_pct": -2.0864,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1443,
+              "candidate_median_mae_pct": -2.2507,
+              "control_median_mfe_pct": 1.5784,
+              "candidate_median_mfe_pct": 2.0032,
+              "paired_delta": {
+                "n": 4,
+                "mean": -0.08775,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 2,
+                  "n_neg": 1,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 3.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.08775,
+                  "lo": -0.282,
+                  "hi": 0.01875,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 6,
+          "entries": 5,
+          "win_rate": 0.4,
+          "mean_net_pct": -0.6011,
+          "total_net_pct": -3.0055,
+          "total_return_pct": -3.0,
+          "max_drawdown_pct": -4.08,
+          "sharpe": -1.362,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 7,
+          "entries": 5,
+          "win_rate": 0.0,
+          "mean_net_pct": -1.4845,
+          "total_net_pct": -7.4225,
+          "total_return_pct": -7.2,
+          "max_drawdown_pct": -7.83,
+          "sharpe": -2.137,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.8834,
+          "lo": -2.1532,
+          "hi": 0.332425,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 5,
+          "paired": 5,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 5,
+            "control_mean_net_pct": -0.6011,
+            "candidate_mean_net_pct": -1.4845,
+            "control_total_net_pct": -3.0055,
+            "candidate_total_net_pct": -7.4225,
+            "control_win_rate": 0.4,
+            "candidate_win_rate": 0.0,
+            "delta_win_rate": -0.4,
+            "control_median_mae_pct": -0.6515,
+            "candidate_median_mae_pct": -2.057,
+            "control_median_mfe_pct": 0.2588,
+            "candidate_median_mfe_pct": 0.2588,
+            "paired_delta": {
+              "n": 5,
+              "mean": -0.8834,
+              "median": -0.0,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 1,
+                "n_neg": 3,
+                "n_zero": 1,
+                "p_value": 0.625
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 1.0,
+                "z": -1.278,
+                "p_value": 0.201243
+              },
+              "bootstrap": {
+                "point": -0.8834,
+                "lo": -2.1146,
+                "hi": -0.0,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": -0.1026,
+              "candidate_mean_net_pct": -0.7721,
+              "control_total_net_pct": -0.2052,
+              "candidate_total_net_pct": -1.5442,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": -0.5,
+              "control_median_mae_pct": -0.5242,
+              "candidate_median_mae_pct": -1.2316,
+              "control_median_mfe_pct": 0.4365,
+              "candidate_median_mfe_pct": 0.7706,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.6695,
+                "median": -0.6695,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 0,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 0,
+                  "z": -0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": -0.6695,
+                  "lo": -1.339,
+                  "hi": -0.0,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 3,
+              "control_mean_net_pct": -0.9334,
+              "candidate_mean_net_pct": -1.9594,
+              "control_total_net_pct": -2.8003,
+              "candidate_total_net_pct": -5.8783,
+              "control_win_rate": 0.3333,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": -0.3333,
+              "control_median_mae_pct": -1.9564,
+              "candidate_median_mae_pct": -2.057,
+              "control_median_mfe_pct": 0.2588,
+              "candidate_median_mfe_pct": 0.2588,
+              "paired_delta": {
+                "n": 3,
+                "mean": -1.026,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -1.026,
+                  "lo": -3.078,
+                  "hi": 0.0,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 2.3199,
+          "total_net_pct": 2.3199,
+          "total_return_pct": 2.32,
+          "max_drawdown_pct": -0.15,
+          "sharpe": 1.441,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 3,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 3.8779,
+          "total_net_pct": 3.8779,
+          "total_return_pct": 3.88,
+          "max_drawdown_pct": -1.44,
+          "sharpe": 1.669,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 1.558,
+          "lo": 1.558,
+          "hi": 1.558,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": 2.3199,
+            "candidate_mean_net_pct": 3.8779,
+            "control_total_net_pct": 2.3199,
+            "candidate_total_net_pct": 3.8779,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.6872,
+            "candidate_median_mae_pct": -3.1233,
+            "control_median_mfe_pct": 3.2513,
+            "candidate_median_mfe_pct": 6.8324,
+            "paired_delta": {
+              "n": 1,
+              "mean": 1.558,
+              "median": 1.558,
+              "sign_test": {
+                "n": 1,
+                "n_pos": 1,
+                "n_neg": 0,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 1,
+                "w": 1.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 1.558,
+                "lo": 1.558,
+                "hi": 1.558,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": 2.3199,
+              "candidate_mean_net_pct": 3.8779,
+              "control_total_net_pct": 2.3199,
+              "candidate_total_net_pct": 3.8779,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.6872,
+              "candidate_median_mae_pct": -3.1233,
+              "control_median_mfe_pct": 3.2513,
+              "candidate_median_mfe_pct": 6.8324,
+              "paired_delta": {
+                "n": 1,
+                "mean": 1.558,
+                "median": 1.558,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 1.558,
+                  "lo": 1.558,
+                  "hi": 1.558,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 4,
+          "entries": 4,
+          "win_rate": 0.75,
+          "mean_net_pct": 0.0724,
+          "total_net_pct": 0.2896,
+          "total_return_pct": 0.24,
+          "max_drawdown_pct": -2.64,
+          "sharpe": 0.134,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 8,
+          "entries": 4,
+          "win_rate": 0.25,
+          "mean_net_pct": -0.3111,
+          "total_net_pct": -1.2444,
+          "total_return_pct": -1.3,
+          "max_drawdown_pct": -2.81,
+          "sharpe": -0.547,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.3835,
+          "lo": -2.608,
+          "hi": 1.989175,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 4,
+          "paired": 4,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 4,
+            "control_mean_net_pct": 0.0724,
+            "candidate_mean_net_pct": -0.3111,
+            "control_total_net_pct": 0.2896,
+            "candidate_total_net_pct": -1.2444,
+            "control_win_rate": 0.75,
+            "candidate_win_rate": 0.25,
+            "delta_win_rate": -0.5,
+            "control_median_mae_pct": -0.1256,
+            "candidate_median_mae_pct": -1.3645,
+            "control_median_mfe_pct": 1.6099,
+            "candidate_median_mfe_pct": 1.7759,
+            "paired_delta": {
+              "n": 4,
+              "mean": -0.3835,
+              "median": -0.495,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 1,
+                "n_neg": 3,
+                "n_zero": 0,
+                "p_value": 0.625
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 2.0,
+                "z": -0.9129,
+                "p_value": 0.36131
+              },
+              "bootstrap": {
+                "point": -0.3835,
+                "lo": -1.161,
+                "hi": 0.394,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": 0.7449,
+              "candidate_mean_net_pct": -0.4161,
+              "control_total_net_pct": 1.4898,
+              "candidate_total_net_pct": -0.8322,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": -1.0,
+              "control_median_mae_pct": -0.1256,
+              "candidate_median_mae_pct": -1.3645,
+              "control_median_mfe_pct": 1.6099,
+              "candidate_median_mfe_pct": 1.7759,
+              "paired_delta": {
+                "n": 2,
+                "mean": -1.161,
+                "median": -1.161,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 0,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 0,
+                  "z": -0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": -1.161,
+                  "lo": -1.332,
+                  "hi": -0.99,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": -0.6001,
+              "candidate_mean_net_pct": -0.2061,
+              "control_total_net_pct": -1.2002,
+              "candidate_total_net_pct": -0.4122,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.3179,
+              "candidate_median_mae_pct": -1.6455,
+              "control_median_mfe_pct": 1.1176,
+              "candidate_median_mfe_pct": 2.5774,
+              "paired_delta": {
+                "n": 2,
+                "mean": 0.394,
+                "median": 0.394,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 2.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.394,
+                  "lo": -0.0,
+                  "hi": 0.788,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 3.3599,
+          "total_net_pct": 3.3599,
+          "total_return_pct": 3.36,
+          "max_drawdown_pct": -0.04,
+          "sharpe": 1.833,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 3,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 6.2139,
+          "total_net_pct": 6.2139,
+          "total_return_pct": 6.22,
+          "max_drawdown_pct": -4.91,
+          "sharpe": 1.405,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 2.854,
+          "lo": 2.854,
+          "hi": 2.854,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": 3.3599,
+            "candidate_mean_net_pct": 6.2139,
+            "control_total_net_pct": 3.3599,
+            "candidate_total_net_pct": 6.2139,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.1653,
+            "candidate_median_mae_pct": -4.2014,
+            "control_median_mfe_pct": 4.1172,
+            "candidate_median_mfe_pct": 10.3839,
+            "paired_delta": {
+              "n": 1,
+              "mean": 2.854,
+              "median": 2.854,
+              "sign_test": {
+                "n": 1,
+                "n_pos": 1,
+                "n_neg": 0,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 1,
+                "w": 1.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 2.854,
+                "lo": 2.854,
+                "hi": 2.854,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_up": {
+              "n": 1,
+              "control_mean_net_pct": 3.3599,
+              "candidate_mean_net_pct": 6.2139,
+              "control_total_net_pct": 3.3599,
+              "candidate_total_net_pct": 6.2139,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1653,
+              "candidate_median_mae_pct": -4.2014,
+              "control_median_mfe_pct": 4.1172,
+              "candidate_median_mfe_pct": 10.3839,
+              "paired_delta": {
+                "n": 1,
+                "mean": 2.854,
+                "median": 2.854,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 2.854,
+                  "lo": 2.854,
+                  "hi": 2.854,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.9284,
+          "total_net_pct": -2.7853,
+          "total_return_pct": -2.77,
+          "max_drawdown_pct": -4.27,
+          "sharpe": -1.107,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 0.3333,
+          "mean_net_pct": -1.4214,
+          "total_net_pct": -4.2643,
+          "total_return_pct": -4.28,
+          "max_drawdown_pct": -7.89,
+          "sharpe": -0.914,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.493,
+          "lo": -3.431667,
+          "hi": 2.506,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": -0.9284,
+            "candidate_mean_net_pct": -1.4214,
+            "control_total_net_pct": -2.7853,
+            "candidate_total_net_pct": -4.2643,
+            "control_win_rate": 0.3333,
+            "candidate_win_rate": 0.3333,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.4988,
+            "candidate_median_mae_pct": -1.4988,
+            "control_median_mfe_pct": 1.3399,
+            "candidate_median_mfe_pct": 2.6995,
+            "paired_delta": {
+              "n": 3,
+              "mean": -0.493,
+              "median": -0.0,
+              "sign_test": {
+                "n": 3,
+                "n_pos": 1,
+                "n_neg": 2,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 3,
+                "w": 2.0,
+                "z": -0.2673,
+                "p_value": 0.789268
+              },
+              "bootstrap": {
+                "point": -0.493,
+                "lo": -2.685,
+                "hi": 1.206,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": -1.5301,
+              "candidate_mean_net_pct": -1.5301,
+              "control_total_net_pct": -1.5301,
+              "candidate_total_net_pct": -1.5301,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.4988,
+              "candidate_median_mae_pct": -1.4988,
+              "control_median_mfe_pct": 0.265,
+              "candidate_median_mfe_pct": 0.265,
+              "paired_delta": {
+                "n": 1,
+                "mean": -0.0,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 0,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.0,
+                  "lo": -0.0,
+                  "hi": -0.0,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": -0.6276,
+              "candidate_mean_net_pct": -1.3671,
+              "control_total_net_pct": -1.2552,
+              "candidate_total_net_pct": -2.7342,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.6784,
+              "candidate_median_mae_pct": -2.6784,
+              "control_median_mfe_pct": 2.0197,
+              "candidate_median_mfe_pct": 3.4634,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.7395,
+                "median": -0.7395,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.7395,
+                  "lo": -2.685,
+                  "hi": 1.206,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 3,
+          "entries": 2,
+          "win_rate": 1.0,
+          "mean_net_pct": 2.3474,
+          "total_net_pct": 4.6948,
+          "total_return_pct": 4.75,
+          "max_drawdown_pct": -2.57,
+          "sharpe": 1.383,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 6,
+          "entries": 2,
+          "win_rate": 1.0,
+          "mean_net_pct": 3.5629,
+          "total_net_pct": 7.1258,
+          "total_return_pct": 7.23,
+          "max_drawdown_pct": -2.75,
+          "sharpe": 1.918,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 1.2155,
+          "lo": -0.467,
+          "hi": 2.898,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 2,
+          "paired": 2,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 2,
+            "control_mean_net_pct": 2.3474,
+            "candidate_mean_net_pct": 3.5629,
+            "control_total_net_pct": 4.6948,
+            "candidate_total_net_pct": 7.1258,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -2.4798,
+            "candidate_median_mae_pct": -2.7143,
+            "control_median_mfe_pct": 3.7418,
+            "candidate_median_mfe_pct": 8.1101,
+            "paired_delta": {
+              "n": 2,
+              "mean": 1.2155,
+              "median": 1.2155,
+              "sign_test": {
+                "n": 2,
+                "n_pos": 1,
+                "n_neg": 1,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 2,
+                "w": 2.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 1.2155,
+                "lo": -0.192,
+                "hi": 2.623,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": 2.3474,
+              "candidate_mean_net_pct": 3.5629,
+              "control_total_net_pct": 4.6948,
+              "candidate_total_net_pct": 7.1258,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.4798,
+              "candidate_median_mae_pct": -2.7143,
+              "control_median_mfe_pct": 3.7418,
+              "candidate_median_mfe_pct": 8.1101,
+              "paired_delta": {
+                "n": 2,
+                "mean": 1.2155,
+                "median": 1.2155,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 2.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 1.2155,
+                  "lo": -0.192,
+                  "hi": 2.623,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/sq.b2_rd_wider2.json
+++ b/backtest/research/regime_1152_runs/sq.b2_rd_wider2.json
@@ -1,0 +1,1559 @@
+{
+  "open": {
+    "name": "squeeze_momentum",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "tiered_tp_atr_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "tiered_tp_atr",
+      "params": {
+        "tp_tiers": [
+          {
+            "atr_multiple": 1.0,
+            "close_fraction": 0.5
+          },
+          {
+            "atr_multiple": 2.0,
+            "close_fraction": 1.0
+          }
+        ]
+      }
+    }
+  ],
+  "control_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_directional"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 12,
+          "entries": 8,
+          "win_rate": 0.75,
+          "mean_net_pct": -0.1914,
+          "total_net_pct": -1.5308,
+          "total_return_pct": -1.53,
+          "max_drawdown_pct": -3.09,
+          "sharpe": -0.754,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 14,
+          "entries": 8,
+          "win_rate": 0.625,
+          "mean_net_pct": 0.0743,
+          "total_net_pct": 0.5942,
+          "total_return_pct": 0.55,
+          "max_drawdown_pct": -3.09,
+          "sharpe": 0.25,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.265625,
+          "lo": -0.69875,
+          "hi": 1.241891,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 8,
+          "paired": 8,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 8,
+            "control_mean_net_pct": -0.1914,
+            "candidate_mean_net_pct": 0.0743,
+            "control_total_net_pct": -1.5308,
+            "candidate_total_net_pct": 0.5942,
+            "control_win_rate": 0.75,
+            "candidate_win_rate": 0.625,
+            "delta_win_rate": -0.125,
+            "control_median_mae_pct": -0.5631,
+            "candidate_median_mae_pct": -0.7235,
+            "control_median_mfe_pct": 0.6148,
+            "candidate_median_mfe_pct": 0.8007,
+            "paired_delta": {
+              "n": 8,
+              "mean": 0.265625,
+              "median": 0.1225,
+              "sign_test": {
+                "n": 8,
+                "n_pos": 6,
+                "n_neg": 2,
+                "n_zero": 0,
+                "p_value": 0.289062
+              },
+              "signed_rank": {
+                "n": 8,
+                "w": 27.0,
+                "z": 1.1902,
+                "p_value": 0.233953
+              },
+              "bootstrap": {
+                "point": 0.265625,
+                "lo": -0.114375,
+                "hi": 0.74125,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 6,
+              "control_mean_net_pct": -0.1134,
+              "candidate_mean_net_pct": 0.2066,
+              "control_total_net_pct": -0.6806,
+              "candidate_total_net_pct": 1.2394,
+              "control_win_rate": 0.8333,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": -0.1666,
+              "control_median_mae_pct": -0.4835,
+              "candidate_median_mae_pct": -0.7609,
+              "control_median_mfe_pct": 0.7231,
+              "candidate_median_mfe_pct": 0.9405,
+              "paired_delta": {
+                "n": 6,
+                "mean": 0.32,
+                "median": 0.2275,
+                "sign_test": {
+                  "n": 6,
+                  "n_pos": 4,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 0.6875
+                },
+                "signed_rank": {
+                  "n": 6,
+                  "w": 15.0,
+                  "z": 0.8386,
+                  "p_value": 0.401678
+                },
+                "bootstrap": {
+                  "point": 0.32,
+                  "lo": -0.194167,
+                  "hi": 0.9175,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": -0.4251,
+              "candidate_mean_net_pct": -0.3226,
+              "control_total_net_pct": -0.8502,
+              "candidate_total_net_pct": -0.6452,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.6781,
+              "candidate_median_mae_pct": -0.6781,
+              "control_median_mfe_pct": 0.2777,
+              "candidate_median_mfe_pct": 0.4901,
+              "paired_delta": {
+                "n": 2,
+                "mean": 0.1025,
+                "median": 0.1025,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 2,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 3.0,
+                  "z": 0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": 0.1025,
+                  "lo": 0.0,
+                  "hi": 0.205,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 0.0,
+          "mean_net_pct": -2.1301,
+          "total_net_pct": -2.1301,
+          "total_return_pct": -2.12,
+          "max_drawdown_pct": -2.47,
+          "sharpe": -1.869,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 0.0,
+          "mean_net_pct": -2.1301,
+          "total_net_pct": -2.1301,
+          "total_return_pct": -2.12,
+          "max_drawdown_pct": -2.47,
+          "sharpe": -1.869,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.0,
+          "lo": 0.0,
+          "hi": 0.0,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": -2.1301,
+            "candidate_mean_net_pct": -2.1301,
+            "control_total_net_pct": -2.1301,
+            "candidate_total_net_pct": -2.1301,
+            "control_win_rate": 0.0,
+            "candidate_win_rate": 0.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -2.3533,
+            "candidate_median_mae_pct": -2.3533,
+            "control_median_mfe_pct": 0.3097,
+            "candidate_median_mfe_pct": 0.3097,
+            "paired_delta": {
+              "n": 1,
+              "mean": 0.0,
+              "median": 0.0,
+              "sign_test": {
+                "n": 0,
+                "n_pos": 0,
+                "n_neg": 0,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 0,
+                "w": 0.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 0.0,
+                "lo": 0.0,
+                "hi": 0.0,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_up": {
+              "n": 1,
+              "control_mean_net_pct": -2.1301,
+              "candidate_mean_net_pct": -2.1301,
+              "control_total_net_pct": -2.1301,
+              "candidate_total_net_pct": -2.1301,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.3533,
+              "candidate_median_mae_pct": -2.3533,
+              "control_median_mfe_pct": 0.3097,
+              "candidate_median_mfe_pct": 0.3097,
+              "paired_delta": {
+                "n": 1,
+                "mean": 0.0,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 0,
+                  "n_pos": 0,
+                  "n_neg": 0,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 0,
+                  "w": 0.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.0,
+                  "lo": 0.0,
+                  "hi": 0.0,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 16,
+          "entries": 9,
+          "win_rate": 0.5556,
+          "mean_net_pct": 0.046,
+          "total_net_pct": 0.4141,
+          "total_return_pct": 0.38,
+          "max_drawdown_pct": -2.42,
+          "sharpe": 0.151,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 13,
+          "entries": 9,
+          "win_rate": 0.4444,
+          "mean_net_pct": -0.2151,
+          "total_net_pct": -1.9359,
+          "total_return_pct": -2.03,
+          "max_drawdown_pct": -4.54,
+          "sharpe": -0.529,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.261111,
+          "lo": -1.412792,
+          "hi": 0.892292,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 9,
+          "paired": 9,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 9,
+            "control_mean_net_pct": 0.046,
+            "candidate_mean_net_pct": -0.2151,
+            "control_total_net_pct": 0.4141,
+            "candidate_total_net_pct": -1.9359,
+            "control_win_rate": 0.5556,
+            "candidate_win_rate": 0.4444,
+            "delta_win_rate": -0.1112,
+            "control_median_mae_pct": -0.7283,
+            "candidate_median_mae_pct": -1.2115,
+            "control_median_mfe_pct": 0.9856,
+            "candidate_median_mfe_pct": 1.3389,
+            "paired_delta": {
+              "n": 9,
+              "mean": -0.261111,
+              "median": -0.385,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 4,
+                "n_neg": 5,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 15.0,
+                "z": -0.8293,
+                "p_value": 0.406941
+              },
+              "bootstrap": {
+                "point": -0.261111,
+                "lo": -0.816125,
+                "hi": 0.291694,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 7,
+              "control_mean_net_pct": -0.043,
+              "candidate_mean_net_pct": -0.4158,
+              "control_total_net_pct": -0.3007,
+              "candidate_total_net_pct": -2.9107,
+              "control_win_rate": 0.5714,
+              "candidate_win_rate": 0.4286,
+              "delta_win_rate": -0.1428,
+              "control_median_mae_pct": -1.2115,
+              "candidate_median_mae_pct": -1.2723,
+              "control_median_mfe_pct": 0.9856,
+              "candidate_median_mfe_pct": 1.3389,
+              "paired_delta": {
+                "n": 7,
+                "mean": -0.372857,
+                "median": -0.81,
+                "sign_test": {
+                  "n": 7,
+                  "n_pos": 3,
+                  "n_neg": 4,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 7,
+                  "w": 7.0,
+                  "z": -1.0987,
+                  "p_value": 0.271899
+                },
+                "bootstrap": {
+                  "point": -0.372857,
+                  "lo": -1.019286,
+                  "hi": 0.294286,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": 0.3574,
+              "candidate_mean_net_pct": 0.4874,
+              "control_total_net_pct": 0.7148,
+              "candidate_total_net_pct": 0.9748,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.3932,
+              "candidate_median_mae_pct": -0.3932,
+              "control_median_mfe_pct": 0.8735,
+              "candidate_median_mfe_pct": 1.4851,
+              "paired_delta": {
+                "n": 2,
+                "mean": 0.13,
+                "median": 0.13,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 2.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.13,
+                  "lo": -0.385,
+                  "hi": 0.645,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 7,
+          "entries": 5,
+          "win_rate": 0.6,
+          "mean_net_pct": -0.1651,
+          "total_net_pct": -0.8255,
+          "total_return_pct": -0.91,
+          "max_drawdown_pct": -4.37,
+          "sharpe": -0.223,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 8,
+          "entries": 5,
+          "win_rate": 0.6,
+          "mean_net_pct": 0.3349,
+          "total_net_pct": 1.6745,
+          "total_return_pct": 1.56,
+          "max_drawdown_pct": -4.03,
+          "sharpe": 0.469,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.5,
+          "lo": -1.974,
+          "hi": 2.885075,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 5,
+          "paired": 5,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 5,
+            "control_mean_net_pct": -0.1651,
+            "candidate_mean_net_pct": 0.3349,
+            "control_total_net_pct": -0.8255,
+            "candidate_total_net_pct": 1.6745,
+            "control_win_rate": 0.6,
+            "candidate_win_rate": 0.6,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.1631,
+            "candidate_median_mae_pct": -1.1631,
+            "control_median_mfe_pct": 1.6982,
+            "candidate_median_mfe_pct": 2.6285,
+            "paired_delta": {
+              "n": 5,
+              "mean": 0.5,
+              "median": 0.335,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 4,
+                "n_neg": 0,
+                "n_zero": 1,
+                "p_value": 0.125
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 10.0,
+                "z": 1.6432,
+                "p_value": 0.100348
+              },
+              "bootstrap": {
+                "point": 0.5,
+                "lo": 0.067,
+                "hi": 0.933,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": 0.9099,
+              "candidate_mean_net_pct": 1.9249,
+              "control_total_net_pct": 0.9099,
+              "candidate_total_net_pct": 1.9249,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1631,
+              "candidate_median_mae_pct": -1.1631,
+              "control_median_mfe_pct": 1.6982,
+              "candidate_median_mfe_pct": 3.4385,
+              "paired_delta": {
+                "n": 1,
+                "mean": 1.015,
+                "median": 1.015,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 1.015,
+                  "lo": 1.015,
+                  "hi": 1.015,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 4,
+              "control_mean_net_pct": -0.4339,
+              "candidate_mean_net_pct": -0.0626,
+              "control_total_net_pct": -1.7354,
+              "candidate_total_net_pct": -0.2504,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1443,
+              "candidate_median_mae_pct": -1.1443,
+              "control_median_mfe_pct": 1.5784,
+              "candidate_median_mfe_pct": 1.9831,
+              "paired_delta": {
+                "n": 4,
+                "mean": 0.37125,
+                "median": 0.1675,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 3,
+                  "n_neg": 0,
+                  "n_zero": 1,
+                  "p_value": 0.25
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 6.0,
+                  "z": 1.3363,
+                  "p_value": 0.181449
+                },
+                "bootstrap": {
+                  "point": 0.37125,
+                  "lo": 0.0,
+                  "hi": 0.8625,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 6,
+          "entries": 5,
+          "win_rate": 0.4,
+          "mean_net_pct": -0.6011,
+          "total_net_pct": -3.0055,
+          "total_return_pct": -3.0,
+          "max_drawdown_pct": -4.08,
+          "sharpe": -1.362,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 7,
+          "entries": 5,
+          "win_rate": 0.0,
+          "mean_net_pct": -1.3321,
+          "total_net_pct": -6.6605,
+          "total_return_pct": -6.48,
+          "max_drawdown_pct": -6.91,
+          "sharpe": -2.099,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.731,
+          "lo": -2.006025,
+          "hi": 0.494,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 5,
+          "paired": 5,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 5,
+            "control_mean_net_pct": -0.6011,
+            "candidate_mean_net_pct": -1.3321,
+            "control_total_net_pct": -3.0055,
+            "candidate_total_net_pct": -6.6605,
+            "control_win_rate": 0.4,
+            "candidate_win_rate": 0.0,
+            "delta_win_rate": -0.4,
+            "control_median_mae_pct": -0.6515,
+            "candidate_median_mae_pct": -2.057,
+            "control_median_mfe_pct": 0.2588,
+            "candidate_median_mfe_pct": 0.2588,
+            "paired_delta": {
+              "n": 5,
+              "mean": -0.731,
+              "median": -0.0,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 1,
+                "n_neg": 3,
+                "n_zero": 1,
+                "p_value": 0.625
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 1.0,
+                "z": -1.278,
+                "p_value": 0.201243
+              },
+              "bootstrap": {
+                "point": -0.731,
+                "lo": -1.757,
+                "hi": -0.0,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": -0.1026,
+              "candidate_mean_net_pct": -0.6476,
+              "control_total_net_pct": -0.2052,
+              "candidate_total_net_pct": -1.2952,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": -0.5,
+              "control_median_mae_pct": -0.5242,
+              "candidate_median_mae_pct": -1.2316,
+              "control_median_mfe_pct": 0.4365,
+              "candidate_median_mfe_pct": 0.7706,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.545,
+                "median": -0.545,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 0,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 0,
+                  "z": -0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": -0.545,
+                  "lo": -1.09,
+                  "hi": -0.0,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 3,
+              "control_mean_net_pct": -0.9334,
+              "candidate_mean_net_pct": -1.7884,
+              "control_total_net_pct": -2.8003,
+              "candidate_total_net_pct": -5.3653,
+              "control_win_rate": 0.3333,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": -0.3333,
+              "control_median_mae_pct": -1.9564,
+              "candidate_median_mae_pct": -2.057,
+              "control_median_mfe_pct": 0.2588,
+              "candidate_median_mfe_pct": 0.2588,
+              "paired_delta": {
+                "n": 3,
+                "mean": -0.855,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.855,
+                  "lo": -2.565,
+                  "hi": 0.0,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 2.3199,
+          "total_net_pct": 2.3199,
+          "total_return_pct": 2.32,
+          "max_drawdown_pct": -0.15,
+          "sharpe": 1.441,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 2,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 3.2599,
+          "total_net_pct": 3.2599,
+          "total_return_pct": 3.26,
+          "max_drawdown_pct": -1.09,
+          "sharpe": 1.659,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.94,
+          "lo": 0.94,
+          "hi": 0.94,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": 2.3199,
+            "candidate_mean_net_pct": 3.2599,
+            "control_total_net_pct": 2.3199,
+            "candidate_total_net_pct": 3.2599,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.6872,
+            "candidate_median_mae_pct": -0.6872,
+            "control_median_mfe_pct": 3.2513,
+            "candidate_median_mfe_pct": 5.3546,
+            "paired_delta": {
+              "n": 1,
+              "mean": 0.94,
+              "median": 0.94,
+              "sign_test": {
+                "n": 1,
+                "n_pos": 1,
+                "n_neg": 0,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 1,
+                "w": 1.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 0.94,
+                "lo": 0.94,
+                "hi": 0.94,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": 2.3199,
+              "candidate_mean_net_pct": 3.2599,
+              "control_total_net_pct": 2.3199,
+              "candidate_total_net_pct": 3.2599,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.6872,
+              "candidate_median_mae_pct": -0.6872,
+              "control_median_mfe_pct": 3.2513,
+              "candidate_median_mfe_pct": 5.3546,
+              "paired_delta": {
+                "n": 1,
+                "mean": 0.94,
+                "median": 0.94,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.94,
+                  "lo": 0.94,
+                  "hi": 0.94,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 4,
+          "entries": 4,
+          "win_rate": 0.75,
+          "mean_net_pct": 0.0724,
+          "total_net_pct": 0.2896,
+          "total_return_pct": 0.24,
+          "max_drawdown_pct": -2.64,
+          "sharpe": 0.134,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 7,
+          "entries": 4,
+          "win_rate": 0.25,
+          "mean_net_pct": -0.3089,
+          "total_net_pct": -1.2354,
+          "total_return_pct": -1.28,
+          "max_drawdown_pct": -2.79,
+          "sharpe": -0.573,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.38125,
+          "lo": -2.510187,
+          "hi": 1.87,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 4,
+          "paired": 4,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 4,
+            "control_mean_net_pct": 0.0724,
+            "candidate_mean_net_pct": -0.3089,
+            "control_total_net_pct": 0.2896,
+            "candidate_total_net_pct": -1.2354,
+            "control_win_rate": 0.75,
+            "candidate_win_rate": 0.25,
+            "delta_win_rate": -0.5,
+            "control_median_mae_pct": -0.1256,
+            "candidate_median_mae_pct": -1.3645,
+            "control_median_mfe_pct": 1.6099,
+            "candidate_median_mfe_pct": 1.7759,
+            "paired_delta": {
+              "n": 4,
+              "mean": -0.38125,
+              "median": -0.4125,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 1,
+                "n_neg": 3,
+                "n_zero": 0,
+                "p_value": 0.625
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 2.0,
+                "z": -0.9129,
+                "p_value": 0.36131
+              },
+              "bootstrap": {
+                "point": -0.38125,
+                "lo": -0.9675,
+                "hi": 0.205,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": 0.7449,
+              "candidate_mean_net_pct": -0.2226,
+              "control_total_net_pct": 1.4898,
+              "candidate_total_net_pct": -0.4452,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": -1.0,
+              "control_median_mae_pct": -0.1256,
+              "candidate_median_mae_pct": -1.3645,
+              "control_median_mfe_pct": 1.6099,
+              "candidate_median_mfe_pct": 1.7759,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.9675,
+                "median": -0.9675,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 0,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 0,
+                  "z": -0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": -0.9675,
+                  "lo": -1.11,
+                  "hi": -0.825,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": -0.6001,
+              "candidate_mean_net_pct": -0.3951,
+              "control_total_net_pct": -1.2002,
+              "candidate_total_net_pct": -0.7902,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.3179,
+              "candidate_median_mae_pct": -1.6455,
+              "control_median_mfe_pct": 1.1176,
+              "candidate_median_mfe_pct": 1.752,
+              "paired_delta": {
+                "n": 2,
+                "mean": 0.205,
+                "median": 0.205,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 2.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.205,
+                  "lo": -0.0,
+                  "hi": 0.41,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 3.3599,
+          "total_net_pct": 3.3599,
+          "total_return_pct": 3.36,
+          "max_drawdown_pct": -0.04,
+          "sharpe": 1.833,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 2,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 5.4799,
+          "total_net_pct": 5.4799,
+          "total_return_pct": 5.48,
+          "max_drawdown_pct": -4.1,
+          "sharpe": 1.432,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 2.12,
+          "lo": 2.12,
+          "hi": 2.12,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": 3.3599,
+            "candidate_mean_net_pct": 5.4799,
+            "control_total_net_pct": 3.3599,
+            "candidate_total_net_pct": 5.4799,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.1653,
+            "candidate_median_mae_pct": -4.2014,
+            "control_median_mfe_pct": 4.1172,
+            "candidate_median_mfe_pct": 8.5995,
+            "paired_delta": {
+              "n": 1,
+              "mean": 2.12,
+              "median": 2.12,
+              "sign_test": {
+                "n": 1,
+                "n_pos": 1,
+                "n_neg": 0,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 1,
+                "w": 1.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 2.12,
+                "lo": 2.12,
+                "hi": 2.12,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_up": {
+              "n": 1,
+              "control_mean_net_pct": 3.3599,
+              "candidate_mean_net_pct": 5.4799,
+              "control_total_net_pct": 3.3599,
+              "candidate_total_net_pct": 5.4799,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1653,
+              "candidate_median_mae_pct": -4.2014,
+              "control_median_mfe_pct": 4.1172,
+              "candidate_median_mfe_pct": 8.5995,
+              "paired_delta": {
+                "n": 1,
+                "mean": 2.12,
+                "median": 2.12,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 2.12,
+                  "lo": 2.12,
+                  "hi": 2.12,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.9284,
+          "total_net_pct": -2.7853,
+          "total_return_pct": -2.77,
+          "max_drawdown_pct": -4.27,
+          "sharpe": -1.107,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 4,
+          "entries": 3,
+          "win_rate": 0.3333,
+          "mean_net_pct": -1.5751,
+          "total_net_pct": -4.7253,
+          "total_return_pct": -4.72,
+          "max_drawdown_pct": -7.89,
+          "sharpe": -1.021,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.646667,
+          "lo": -3.431667,
+          "hi": 2.045,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": -0.9284,
+            "candidate_mean_net_pct": -1.5751,
+            "control_total_net_pct": -2.7853,
+            "candidate_total_net_pct": -4.7253,
+            "control_win_rate": 0.3333,
+            "candidate_win_rate": 0.3333,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.4988,
+            "candidate_median_mae_pct": -1.4988,
+            "control_median_mfe_pct": 1.3399,
+            "candidate_median_mfe_pct": 2.6995,
+            "paired_delta": {
+              "n": 3,
+              "mean": -0.646667,
+              "median": -0.0,
+              "sign_test": {
+                "n": 3,
+                "n_pos": 1,
+                "n_neg": 2,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 3,
+                "w": 2.0,
+                "z": -0.2673,
+                "p_value": 0.789268
+              },
+              "bootstrap": {
+                "point": -0.646667,
+                "lo": -2.685,
+                "hi": 0.745,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": -1.5301,
+              "candidate_mean_net_pct": -1.5301,
+              "control_total_net_pct": -1.5301,
+              "candidate_total_net_pct": -1.5301,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.4988,
+              "candidate_median_mae_pct": -1.4988,
+              "control_median_mfe_pct": 0.265,
+              "candidate_median_mfe_pct": 0.265,
+              "paired_delta": {
+                "n": 1,
+                "mean": -0.0,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 0,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.0,
+                  "lo": -0.0,
+                  "hi": -0.0,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": -0.6276,
+              "candidate_mean_net_pct": -1.5976,
+              "control_total_net_pct": -1.2552,
+              "candidate_total_net_pct": -3.1952,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.6784,
+              "candidate_median_mae_pct": -2.6784,
+              "control_median_mfe_pct": 2.0197,
+              "candidate_median_mfe_pct": 2.7027,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.97,
+                "median": -0.97,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.97,
+                  "lo": -2.685,
+                  "hi": 0.745,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 3,
+          "entries": 2,
+          "win_rate": 1.0,
+          "mean_net_pct": 2.3474,
+          "total_net_pct": 4.6948,
+          "total_return_pct": 4.75,
+          "max_drawdown_pct": -2.57,
+          "sharpe": 1.383,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 4,
+          "entries": 2,
+          "win_rate": 1.0,
+          "mean_net_pct": 3.9549,
+          "total_net_pct": 7.9098,
+          "total_return_pct": 8.07,
+          "max_drawdown_pct": -1.67,
+          "sharpe": 2.243,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 1.6075,
+          "lo": 0.97,
+          "hi": 2.245,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 2,
+          "paired": 2,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 2,
+            "control_mean_net_pct": 2.3474,
+            "candidate_mean_net_pct": 3.9549,
+            "control_total_net_pct": 4.6948,
+            "candidate_total_net_pct": 7.9098,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -2.4798,
+            "candidate_median_mae_pct": -2.4798,
+            "control_median_mfe_pct": 3.7418,
+            "candidate_median_mfe_pct": 6.5786,
+            "paired_delta": {
+              "n": 2,
+              "mean": 1.6075,
+              "median": 1.6075,
+              "sign_test": {
+                "n": 2,
+                "n_pos": 2,
+                "n_neg": 0,
+                "n_zero": 0,
+                "p_value": 0.5
+              },
+              "signed_rank": {
+                "n": 2,
+                "w": 3.0,
+                "z": 0.8944,
+                "p_value": 0.371093
+              },
+              "bootstrap": {
+                "point": 1.6075,
+                "lo": 1.245,
+                "hi": 1.97,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": 2.3474,
+              "candidate_mean_net_pct": 3.9549,
+              "control_total_net_pct": 4.6948,
+              "candidate_total_net_pct": 7.9098,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.4798,
+              "candidate_median_mae_pct": -2.4798,
+              "control_median_mfe_pct": 3.7418,
+              "candidate_median_mfe_pct": 6.5786,
+              "paired_delta": {
+                "n": 2,
+                "mean": 1.6075,
+                "median": 1.6075,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 2,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 3.0,
+                  "z": 0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": 1.6075,
+                  "lo": 1.245,
+                  "hi": 1.97,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/sq.b2_rq_wider.json
+++ b/backtest/research/regime_1152_runs/sq.b2_rq_wider.json
@@ -1,0 +1,541 @@
+{
+  "open": {
+    "name": "squeeze_momentum",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "tiered_tp_atr_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "tiered_tp_atr",
+      "params": {
+        "tp_tiers": [
+          {
+            "atr_multiple": 0.75,
+            "close_fraction": 0.5
+          },
+          {
+            "atr_multiple": 1.5,
+            "close_fraction": 1.0
+          }
+        ]
+      }
+    }
+  ],
+  "control_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_quiet"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/sq.b2_rv_patient3.json
+++ b/backtest/research/regime_1152_runs/sq.b2_rv_patient3.json
@@ -1,0 +1,1414 @@
+{
+  "open": {
+    "name": "squeeze_momentum",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "tiered_tp_atr_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "tiered_tp_atr",
+      "params": {
+        "tp_tiers": [
+          {
+            "atr_multiple": 1.0,
+            "close_fraction": 0.4
+          },
+          {
+            "atr_multiple": 2.0,
+            "close_fraction": 0.8
+          },
+          {
+            "atr_multiple": 3.0,
+            "close_fraction": 1.0
+          }
+        ]
+      }
+    }
+  ],
+  "control_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_volatile"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 28,
+          "entries": 18,
+          "win_rate": 0.5556,
+          "mean_net_pct": -0.249,
+          "total_net_pct": -4.4818,
+          "total_return_pct": -4.48,
+          "max_drawdown_pct": -6.08,
+          "sharpe": -1.27,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 33,
+          "entries": 18,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.1773,
+          "total_net_pct": -3.1918,
+          "total_return_pct": -3.28,
+          "max_drawdown_pct": -4.84,
+          "sharpe": -0.673,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.071667,
+          "lo": -0.681064,
+          "hi": 0.800063,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 18,
+          "paired": 18,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 18,
+            "control_mean_net_pct": -0.249,
+            "candidate_mean_net_pct": -0.1773,
+            "control_total_net_pct": -4.4818,
+            "candidate_total_net_pct": -3.1918,
+            "control_win_rate": 0.5556,
+            "candidate_win_rate": 0.5,
+            "delta_win_rate": -0.0556,
+            "control_median_mae_pct": -0.4224,
+            "candidate_median_mae_pct": -0.7483,
+            "control_median_mfe_pct": 0.5388,
+            "candidate_median_mfe_pct": 0.8427,
+            "paired_delta": {
+              "n": 18,
+              "mean": 0.071667,
+              "median": 0.0,
+              "sign_test": {
+                "n": 18,
+                "n_pos": 10,
+                "n_neg": 8,
+                "n_zero": 0,
+                "p_value": 0.814529
+              },
+              "signed_rank": {
+                "n": 18,
+                "w": 100.0,
+                "z": 0.6097,
+                "p_value": 0.542057
+              },
+              "bootstrap": {
+                "point": 0.071667,
+                "lo": -0.134393,
+                "hi": 0.279944,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 18,
+              "control_mean_net_pct": -0.249,
+              "candidate_mean_net_pct": -0.1773,
+              "control_total_net_pct": -4.4818,
+              "candidate_total_net_pct": -3.1918,
+              "control_win_rate": 0.5556,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": -0.0556,
+              "control_median_mae_pct": -0.4224,
+              "candidate_median_mae_pct": -0.7483,
+              "control_median_mfe_pct": 0.5388,
+              "candidate_median_mfe_pct": 0.8427,
+              "paired_delta": {
+                "n": 18,
+                "mean": 0.071667,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 18,
+                  "n_pos": 10,
+                  "n_neg": 8,
+                  "n_zero": 0,
+                  "p_value": 0.814529
+                },
+                "signed_rank": {
+                  "n": 18,
+                  "w": 100.0,
+                  "z": 0.6097,
+                  "p_value": 0.542057
+                },
+                "bootstrap": {
+                  "point": 0.071667,
+                  "lo": -0.134393,
+                  "hi": 0.279944,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 9,
+          "entries": 7,
+          "win_rate": 0.5714,
+          "mean_net_pct": -0.4558,
+          "total_net_pct": -3.1907,
+          "total_return_pct": -3.27,
+          "max_drawdown_pct": -5.2,
+          "sharpe": -0.779,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 11,
+          "entries": 6,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.3751,
+          "total_net_pct": -2.2506,
+          "total_return_pct": -2.17,
+          "max_drawdown_pct": -6.75,
+          "sharpe": -0.558,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.080708,
+          "lo": -1.750007,
+          "hi": 1.958093,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 7,
+          "paired": 7,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 7,
+            "control_mean_net_pct": -0.4558,
+            "candidate_mean_net_pct": -0.7887,
+            "control_total_net_pct": -3.1907,
+            "candidate_total_net_pct": -5.5207,
+            "control_win_rate": 0.5714,
+            "candidate_win_rate": 0.4286,
+            "delta_win_rate": -0.1428,
+            "control_median_mae_pct": -0.8956,
+            "candidate_median_mae_pct": -1.7168,
+            "control_median_mfe_pct": 1.3514,
+            "candidate_median_mfe_pct": 1.6612,
+            "paired_delta": {
+              "n": 7,
+              "mean": -0.332863,
+              "median": -0.0,
+              "sign_test": {
+                "n": 7,
+                "n_pos": 2,
+                "n_neg": 5,
+                "n_zero": 0,
+                "p_value": 0.453125
+              },
+              "signed_rank": {
+                "n": 7,
+                "w": 7.0,
+                "z": -1.0987,
+                "p_value": 0.271899
+              },
+              "bootstrap": {
+                "point": -0.332863,
+                "lo": -0.776636,
+                "hi": 0.036857,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 7,
+              "control_mean_net_pct": -0.4558,
+              "candidate_mean_net_pct": -0.7887,
+              "control_total_net_pct": -3.1907,
+              "candidate_total_net_pct": -5.5207,
+              "control_win_rate": 0.5714,
+              "candidate_win_rate": 0.4286,
+              "delta_win_rate": -0.1428,
+              "control_median_mae_pct": -0.8956,
+              "candidate_median_mae_pct": -1.7168,
+              "control_median_mfe_pct": 1.3514,
+              "candidate_median_mfe_pct": 1.6612,
+              "paired_delta": {
+                "n": 7,
+                "mean": -0.332863,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 7,
+                  "n_pos": 2,
+                  "n_neg": 5,
+                  "n_zero": 0,
+                  "p_value": 0.453125
+                },
+                "signed_rank": {
+                  "n": 7,
+                  "w": 7.0,
+                  "z": -1.0987,
+                  "p_value": 0.271899
+                },
+                "bootstrap": {
+                  "point": -0.332863,
+                  "lo": -0.776636,
+                  "hi": 0.036857,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 29,
+          "entries": 20,
+          "win_rate": 0.45,
+          "mean_net_pct": -0.3824,
+          "total_net_pct": -7.647,
+          "total_return_pct": -7.48,
+          "max_drawdown_pct": -9.37,
+          "sharpe": -1.289,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 31,
+          "entries": 19,
+          "win_rate": 0.3684,
+          "mean_net_pct": -0.5543,
+          "total_net_pct": -10.5319,
+          "total_return_pct": -10.15,
+          "max_drawdown_pct": -11.59,
+          "sharpe": -1.663,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.171961,
+          "lo": -0.859087,
+          "hi": 0.540275,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 20,
+          "paired": 20,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 20,
+            "control_mean_net_pct": -0.3824,
+            "candidate_mean_net_pct": -0.456,
+            "control_total_net_pct": -7.647,
+            "candidate_total_net_pct": -9.12,
+            "control_win_rate": 0.45,
+            "candidate_win_rate": 0.4,
+            "delta_win_rate": -0.05,
+            "control_median_mae_pct": -1.1531,
+            "candidate_median_mae_pct": -1.3189,
+            "control_median_mfe_pct": 0.8097,
+            "candidate_median_mfe_pct": 0.9582,
+            "paired_delta": {
+              "n": 20,
+              "mean": -0.07365,
+              "median": 0.0,
+              "sign_test": {
+                "n": 20,
+                "n_pos": 11,
+                "n_neg": 9,
+                "n_zero": 0,
+                "p_value": 0.823803
+              },
+              "signed_rank": {
+                "n": 20,
+                "w": 103.0,
+                "z": -0.056,
+                "p_value": 0.955343
+              },
+              "bootstrap": {
+                "point": -0.07365,
+                "lo": -0.387804,
+                "hi": 0.2245,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 20,
+              "control_mean_net_pct": -0.3824,
+              "candidate_mean_net_pct": -0.456,
+              "control_total_net_pct": -7.647,
+              "candidate_total_net_pct": -9.12,
+              "control_win_rate": 0.45,
+              "candidate_win_rate": 0.4,
+              "delta_win_rate": -0.05,
+              "control_median_mae_pct": -1.1531,
+              "candidate_median_mae_pct": -1.3189,
+              "control_median_mfe_pct": 0.8097,
+              "candidate_median_mfe_pct": 0.9582,
+              "paired_delta": {
+                "n": 20,
+                "mean": -0.07365,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 20,
+                  "n_pos": 11,
+                  "n_neg": 9,
+                  "n_zero": 0,
+                  "p_value": 0.823803
+                },
+                "signed_rank": {
+                  "n": 20,
+                  "w": 103.0,
+                  "z": -0.056,
+                  "p_value": 0.955343
+                },
+                "bootstrap": {
+                  "point": -0.07365,
+                  "lo": -0.387804,
+                  "hi": 0.2245,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 4,
+          "entries": 3,
+          "win_rate": 1.0,
+          "mean_net_pct": 2.6332,
+          "total_net_pct": 7.8997,
+          "total_return_pct": 8.04,
+          "max_drawdown_pct": -1.84,
+          "sharpe": 1.566,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 8,
+          "entries": 3,
+          "win_rate": 1.0,
+          "mean_net_pct": 2.9906,
+          "total_net_pct": 8.9717,
+          "total_return_pct": 9.19,
+          "max_drawdown_pct": -2.79,
+          "sharpe": 1.724,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.357333,
+          "lo": -2.499333,
+          "hi": 3.144,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": 2.6332,
+            "candidate_mean_net_pct": 2.9906,
+            "control_total_net_pct": 7.8997,
+            "candidate_total_net_pct": 8.9717,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.4476,
+            "candidate_median_mae_pct": -1.7835,
+            "control_median_mfe_pct": 2.6465,
+            "candidate_median_mfe_pct": 5.3739,
+            "paired_delta": {
+              "n": 3,
+              "mean": 0.357333,
+              "median": 0.21,
+              "sign_test": {
+                "n": 3,
+                "n_pos": 3,
+                "n_neg": 0,
+                "n_zero": 0,
+                "p_value": 0.25
+              },
+              "signed_rank": {
+                "n": 3,
+                "w": 6.0,
+                "z": 1.3363,
+                "p_value": 0.181449
+              },
+              "bootstrap": {
+                "point": 0.357333,
+                "lo": 0.0,
+                "hi": 0.862,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 3,
+              "control_mean_net_pct": 2.6332,
+              "candidate_mean_net_pct": 2.9906,
+              "control_total_net_pct": 7.8997,
+              "candidate_total_net_pct": 8.9717,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.4476,
+              "candidate_median_mae_pct": -1.7835,
+              "control_median_mfe_pct": 2.6465,
+              "candidate_median_mfe_pct": 5.3739,
+              "paired_delta": {
+                "n": 3,
+                "mean": 0.357333,
+                "median": 0.21,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 3,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 0.25
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 6.0,
+                  "z": 1.3363,
+                  "p_value": 0.181449
+                },
+                "bootstrap": {
+                  "point": 0.357333,
+                  "lo": 0.0,
+                  "hi": 0.862,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 28,
+          "entries": 17,
+          "win_rate": 0.5882,
+          "mean_net_pct": -0.1207,
+          "total_net_pct": -2.0517,
+          "total_return_pct": -2.19,
+          "max_drawdown_pct": -8.24,
+          "sharpe": -0.374,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 35,
+          "entries": 17,
+          "win_rate": 0.4706,
+          "mean_net_pct": -0.1275,
+          "total_net_pct": -2.1677,
+          "total_return_pct": -2.5,
+          "max_drawdown_pct": -9.01,
+          "sharpe": -0.307,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.006824,
+          "lo": -1.1804,
+          "hi": 1.210653,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 17,
+          "paired": 17,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 17,
+            "control_mean_net_pct": -0.1207,
+            "candidate_mean_net_pct": -0.1275,
+            "control_total_net_pct": -2.0517,
+            "candidate_total_net_pct": -2.1677,
+            "control_win_rate": 0.5882,
+            "candidate_win_rate": 0.4706,
+            "delta_win_rate": -0.1176,
+            "control_median_mae_pct": -0.9123,
+            "candidate_median_mae_pct": -1.2788,
+            "control_median_mfe_pct": 1.0593,
+            "candidate_median_mfe_pct": 1.4069,
+            "paired_delta": {
+              "n": 17,
+              "mean": -0.006824,
+              "median": 0.0,
+              "sign_test": {
+                "n": 16,
+                "n_pos": 8,
+                "n_neg": 8,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 16,
+                "w": 65.0,
+                "z": -0.1293,
+                "p_value": 0.897142
+              },
+              "bootstrap": {
+                "point": -0.006824,
+                "lo": -0.536362,
+                "hi": 0.550296,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 17,
+              "control_mean_net_pct": -0.1207,
+              "candidate_mean_net_pct": -0.1275,
+              "control_total_net_pct": -2.0517,
+              "candidate_total_net_pct": -2.1677,
+              "control_win_rate": 0.5882,
+              "candidate_win_rate": 0.4706,
+              "delta_win_rate": -0.1176,
+              "control_median_mae_pct": -0.9123,
+              "candidate_median_mae_pct": -1.2788,
+              "control_median_mfe_pct": 1.0593,
+              "candidate_median_mfe_pct": 1.4069,
+              "paired_delta": {
+                "n": 17,
+                "mean": -0.006824,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 16,
+                  "n_pos": 8,
+                  "n_neg": 8,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 16,
+                  "w": 65.0,
+                  "z": -0.1293,
+                  "p_value": 0.897142
+                },
+                "bootstrap": {
+                  "point": -0.006824,
+                  "lo": -0.536362,
+                  "hi": 0.550296,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 1.0,
+          "mean_net_pct": 2.5049,
+          "total_net_pct": 7.5147,
+          "total_return_pct": 7.7,
+          "max_drawdown_pct": -1.72,
+          "sharpe": 1.549,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 5,
+          "entries": 2,
+          "win_rate": 1.0,
+          "mean_net_pct": 3.0929,
+          "total_net_pct": 6.1857,
+          "total_return_pct": 6.39,
+          "max_drawdown_pct": -3.55,
+          "sharpe": 1.218,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.58796,
+          "lo": -0.364747,
+          "hi": 1.540667,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": 2.5049,
+            "candidate_mean_net_pct": 1.6199,
+            "control_total_net_pct": 7.5147,
+            "candidate_total_net_pct": 4.8596,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 0.6667,
+            "delta_win_rate": -0.3333,
+            "control_median_mae_pct": -1.1875,
+            "candidate_median_mae_pct": -4.6487,
+            "control_median_mfe_pct": 4.0774,
+            "candidate_median_mfe_pct": 4.5418,
+            "paired_delta": {
+              "n": 3,
+              "mean": -0.885027,
+              "median": 0.164,
+              "sign_test": {
+                "n": 3,
+                "n_pos": 2,
+                "n_neg": 1,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 3,
+                "w": 3.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": -0.885027,
+                "lo": -3.586,
+                "hi": 0.76692,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 3,
+              "control_mean_net_pct": 2.5049,
+              "candidate_mean_net_pct": 1.6199,
+              "control_total_net_pct": 7.5147,
+              "candidate_total_net_pct": 4.8596,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": -0.3333,
+              "control_median_mae_pct": -1.1875,
+              "candidate_median_mae_pct": -4.6487,
+              "control_median_mfe_pct": 4.0774,
+              "candidate_median_mfe_pct": 4.5418,
+              "paired_delta": {
+                "n": 3,
+                "mean": -0.885027,
+                "median": 0.164,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 2,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 3.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.885027,
+                  "lo": -3.586,
+                  "hi": 0.76692,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 14,
+          "entries": 11,
+          "win_rate": 0.3636,
+          "mean_net_pct": -0.4937,
+          "total_net_pct": -5.4311,
+          "total_return_pct": -5.34,
+          "max_drawdown_pct": -5.34,
+          "sharpe": -1.53,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 14,
+          "entries": 10,
+          "win_rate": 0.3,
+          "mean_net_pct": -0.4739,
+          "total_net_pct": -4.739,
+          "total_return_pct": -4.71,
+          "max_drawdown_pct": -4.71,
+          "sharpe": -1.179,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.019836,
+          "lo": -0.883408,
+          "hi": 0.990794,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 11,
+          "paired": 11,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 11,
+            "control_mean_net_pct": -0.4937,
+            "candidate_mean_net_pct": -0.2941,
+            "control_total_net_pct": -5.4311,
+            "candidate_total_net_pct": -3.2351,
+            "control_win_rate": 0.3636,
+            "candidate_win_rate": 0.3636,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.014,
+            "candidate_median_mae_pct": -1.1272,
+            "control_median_mfe_pct": 0.3961,
+            "candidate_median_mfe_pct": 0.3961,
+            "paired_delta": {
+              "n": 11,
+              "mean": 0.199636,
+              "median": 0.0,
+              "sign_test": {
+                "n": 10,
+                "n_pos": 5,
+                "n_neg": 5,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 10,
+                "w": 32.0,
+                "z": 0.4077,
+                "p_value": 0.683481
+              },
+              "bootstrap": {
+                "point": 0.199636,
+                "lo": -0.128364,
+                "hi": 0.663636,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 11,
+              "control_mean_net_pct": -0.4937,
+              "candidate_mean_net_pct": -0.2941,
+              "control_total_net_pct": -5.4311,
+              "candidate_total_net_pct": -3.2351,
+              "control_win_rate": 0.3636,
+              "candidate_win_rate": 0.3636,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.014,
+              "candidate_median_mae_pct": -1.1272,
+              "control_median_mfe_pct": 0.3961,
+              "candidate_median_mfe_pct": 0.3961,
+              "paired_delta": {
+                "n": 11,
+                "mean": 0.199636,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 10,
+                  "n_pos": 5,
+                  "n_neg": 5,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 10,
+                  "w": 32.0,
+                  "z": 0.4077,
+                  "p_value": 0.683481
+                },
+                "bootstrap": {
+                  "point": 0.199636,
+                  "lo": -0.128364,
+                  "hi": 0.663636,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.0899,
+          "total_net_pct": 0.2697,
+          "total_return_pct": 0.25,
+          "max_drawdown_pct": -4.2,
+          "sharpe": 0.128,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 7,
+          "entries": 3,
+          "win_rate": 0.6667,
+          "mean_net_pct": -0.2708,
+          "total_net_pct": -0.8123,
+          "total_return_pct": -0.94,
+          "max_drawdown_pct": -6.77,
+          "sharpe": -0.189,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.360667,
+          "lo": -4.405,
+          "hi": 2.984333,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": 0.0899,
+            "candidate_mean_net_pct": -0.2708,
+            "control_total_net_pct": 0.2697,
+            "candidate_total_net_pct": -0.8123,
+            "control_win_rate": 0.6667,
+            "candidate_win_rate": 0.6667,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.3427,
+            "candidate_median_mae_pct": -2.2412,
+            "control_median_mfe_pct": 1.6545,
+            "candidate_median_mfe_pct": 3.7548,
+            "paired_delta": {
+              "n": 3,
+              "mean": -0.360667,
+              "median": 0.58,
+              "sign_test": {
+                "n": 3,
+                "n_pos": 2,
+                "n_neg": 1,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 3,
+                "w": 3.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": -0.360667,
+                "lo": -2.645,
+                "hi": 0.983,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 3,
+              "control_mean_net_pct": 0.0899,
+              "candidate_mean_net_pct": -0.2708,
+              "control_total_net_pct": 0.2697,
+              "candidate_total_net_pct": -0.8123,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.3427,
+              "candidate_median_mae_pct": -2.2412,
+              "control_median_mfe_pct": 1.6545,
+              "candidate_median_mfe_pct": 3.7548,
+              "paired_delta": {
+                "n": 3,
+                "mean": -0.360667,
+                "median": 0.58,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 2,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 3.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.360667,
+                  "lo": -2.645,
+                  "hi": 0.983,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 12,
+          "entries": 10,
+          "win_rate": 0.1,
+          "mean_net_pct": -1.2426,
+          "total_net_pct": -12.426,
+          "total_return_pct": -11.78,
+          "max_drawdown_pct": -11.78,
+          "sharpe": -2.984,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 13,
+          "entries": 10,
+          "win_rate": 0.0,
+          "mean_net_pct": -1.5949,
+          "total_net_pct": -15.949,
+          "total_return_pct": -14.87,
+          "max_drawdown_pct": -14.87,
+          "sharpe": -3.525,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.3523,
+          "lo": -1.271312,
+          "hi": 0.539945,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 10,
+          "paired": 10,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 10,
+            "control_mean_net_pct": -1.2426,
+            "candidate_mean_net_pct": -1.5949,
+            "control_total_net_pct": -12.426,
+            "candidate_total_net_pct": -15.949,
+            "control_win_rate": 0.1,
+            "candidate_win_rate": 0.0,
+            "delta_win_rate": -0.1,
+            "control_median_mae_pct": -1.3784,
+            "candidate_median_mae_pct": -1.5074,
+            "control_median_mfe_pct": 0.1102,
+            "candidate_median_mfe_pct": 0.1102,
+            "paired_delta": {
+              "n": 10,
+              "mean": -0.3523,
+              "median": -0.0,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 4,
+                "n_neg": 5,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 19.0,
+                "z": -0.3554,
+                "p_value": 0.722283
+              },
+              "bootstrap": {
+                "point": -0.3523,
+                "lo": -0.8664,
+                "hi": 0.0,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 10,
+              "control_mean_net_pct": -1.2426,
+              "candidate_mean_net_pct": -1.5949,
+              "control_total_net_pct": -12.426,
+              "candidate_total_net_pct": -15.949,
+              "control_win_rate": 0.1,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": -0.1,
+              "control_median_mae_pct": -1.3784,
+              "candidate_median_mae_pct": -1.5074,
+              "control_median_mfe_pct": 0.1102,
+              "candidate_median_mfe_pct": 0.1102,
+              "paired_delta": {
+                "n": 10,
+                "mean": -0.3523,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 9,
+                  "n_pos": 4,
+                  "n_neg": 5,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 9,
+                  "w": 19.0,
+                  "z": -0.3554,
+                  "p_value": 0.722283
+                },
+                "bootstrap": {
+                  "point": -0.3523,
+                  "lo": -0.8664,
+                  "hi": 0.0,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 15,
+          "entries": 9,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.0249,
+          "total_net_pct": 0.2241,
+          "total_return_pct": 0.17,
+          "max_drawdown_pct": -2.38,
+          "sharpe": 0.095,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 16,
+          "entries": 9,
+          "win_rate": 0.4444,
+          "mean_net_pct": 0.0241,
+          "total_net_pct": 0.2171,
+          "total_return_pct": 0.08,
+          "max_drawdown_pct": -3.3,
+          "sharpe": 0.063,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.000778,
+          "lo": -1.238081,
+          "hi": 1.309111,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 9,
+          "paired": 9,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 9,
+            "control_mean_net_pct": 0.0249,
+            "candidate_mean_net_pct": 0.0241,
+            "control_total_net_pct": 0.2241,
+            "candidate_total_net_pct": 0.2171,
+            "control_win_rate": 0.6667,
+            "candidate_win_rate": 0.4444,
+            "delta_win_rate": -0.2223,
+            "control_median_mae_pct": -0.8156,
+            "candidate_median_mae_pct": -1.6316,
+            "control_median_mfe_pct": 1.2719,
+            "candidate_median_mfe_pct": 1.469,
+            "paired_delta": {
+              "n": 9,
+              "mean": -0.000778,
+              "median": -0.0,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 4,
+                "n_neg": 5,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 21.0,
+                "z": -0.1185,
+                "p_value": 0.905695
+              },
+              "bootstrap": {
+                "point": -0.000778,
+                "lo": -0.64835,
+                "hi": 0.593911,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 9,
+              "control_mean_net_pct": 0.0249,
+              "candidate_mean_net_pct": 0.0241,
+              "control_total_net_pct": 0.2241,
+              "candidate_total_net_pct": 0.2171,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.4444,
+              "delta_win_rate": -0.2223,
+              "control_median_mae_pct": -0.8156,
+              "candidate_median_mae_pct": -1.6316,
+              "control_median_mfe_pct": 1.2719,
+              "candidate_median_mfe_pct": 1.469,
+              "paired_delta": {
+                "n": 9,
+                "mean": -0.000778,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 9,
+                  "n_pos": 4,
+                  "n_neg": 5,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 9,
+                  "w": 21.0,
+                  "z": -0.1185,
+                  "p_value": 0.905695
+                },
+                "bootstrap": {
+                  "point": -0.000778,
+                  "lo": -0.64835,
+                  "hi": 0.593911,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 2,
+          "entries": 1,
+          "win_rate": 0.0,
+          "mean_net_pct": -0.7901,
+          "total_net_pct": -0.7901,
+          "total_return_pct": -0.79,
+          "max_drawdown_pct": -1.84,
+          "sharpe": -0.729,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 0.0,
+          "mean_net_pct": -2.2801,
+          "total_net_pct": -2.2801,
+          "total_return_pct": -2.28,
+          "max_drawdown_pct": -3.34,
+          "sharpe": -1.263,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -1.49,
+          "lo": -1.49,
+          "hi": -1.49,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": -0.7901,
+            "candidate_mean_net_pct": -2.2801,
+            "control_total_net_pct": -0.7901,
+            "candidate_total_net_pct": -2.2801,
+            "control_win_rate": 0.0,
+            "candidate_win_rate": 0.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -3.143,
+            "candidate_median_mae_pct": -3.143,
+            "control_median_mfe_pct": 2.3213,
+            "candidate_median_mfe_pct": 2.3213,
+            "paired_delta": {
+              "n": 1,
+              "mean": -1.49,
+              "median": -1.49,
+              "sign_test": {
+                "n": 1,
+                "n_pos": 0,
+                "n_neg": 1,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 1,
+                "w": 0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": -1.49,
+                "lo": -1.49,
+                "hi": -1.49,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 1,
+              "control_mean_net_pct": -0.7901,
+              "candidate_mean_net_pct": -2.2801,
+              "control_total_net_pct": -0.7901,
+              "candidate_total_net_pct": -2.2801,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -3.143,
+              "candidate_median_mae_pct": -3.143,
+              "control_median_mfe_pct": 2.3213,
+              "candidate_median_mfe_pct": 2.3213,
+              "paired_delta": {
+                "n": 1,
+                "mean": -1.49,
+                "median": -1.49,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 0,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -1.49,
+                  "lo": -1.49,
+                  "hi": -1.49,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/sq.b2_rv_wider.json
+++ b/backtest/research/regime_1152_runs/sq.b2_rv_wider.json
@@ -1,0 +1,1410 @@
+{
+  "open": {
+    "name": "squeeze_momentum",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "tiered_tp_atr_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "tiered_tp_atr",
+      "params": {
+        "tp_tiers": [
+          {
+            "atr_multiple": 0.75,
+            "close_fraction": 0.5
+          },
+          {
+            "atr_multiple": 1.5,
+            "close_fraction": 1.0
+          }
+        ]
+      }
+    }
+  ],
+  "control_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops": {
+    "stop_loss_atr_mult": 1.5
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_volatile"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 28,
+          "entries": 18,
+          "win_rate": 0.5556,
+          "mean_net_pct": -0.249,
+          "total_net_pct": -4.4818,
+          "total_return_pct": -4.48,
+          "max_drawdown_pct": -6.08,
+          "sharpe": -1.27,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 28,
+          "entries": 18,
+          "win_rate": 0.5556,
+          "mean_net_pct": -0.2623,
+          "total_net_pct": -4.7218,
+          "total_return_pct": -4.72,
+          "max_drawdown_pct": -5.89,
+          "sharpe": -1.057,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.013333,
+          "lo": -0.721951,
+          "hi": 0.671674,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 18,
+          "paired": 18,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 18,
+            "control_mean_net_pct": -0.249,
+            "candidate_mean_net_pct": -0.2623,
+            "control_total_net_pct": -4.4818,
+            "candidate_total_net_pct": -4.7218,
+            "control_win_rate": 0.5556,
+            "candidate_win_rate": 0.5556,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.4224,
+            "candidate_median_mae_pct": -0.5154,
+            "control_median_mfe_pct": 0.5388,
+            "candidate_median_mfe_pct": 0.8032,
+            "paired_delta": {
+              "n": 18,
+              "mean": -0.013333,
+              "median": 0.0,
+              "sign_test": {
+                "n": 18,
+                "n_pos": 12,
+                "n_neg": 6,
+                "n_zero": 0,
+                "p_value": 0.237885
+              },
+              "signed_rank": {
+                "n": 18,
+                "w": 113.0,
+                "z": 1.1759,
+                "p_value": 0.239651
+              },
+              "bootstrap": {
+                "point": -0.013333,
+                "lo": -0.140278,
+                "hi": 0.088333,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 18,
+              "control_mean_net_pct": -0.249,
+              "candidate_mean_net_pct": -0.2623,
+              "control_total_net_pct": -4.4818,
+              "candidate_total_net_pct": -4.7218,
+              "control_win_rate": 0.5556,
+              "candidate_win_rate": 0.5556,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.4224,
+              "candidate_median_mae_pct": -0.5154,
+              "control_median_mfe_pct": 0.5388,
+              "candidate_median_mfe_pct": 0.8032,
+              "paired_delta": {
+                "n": 18,
+                "mean": -0.013333,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 18,
+                  "n_pos": 12,
+                  "n_neg": 6,
+                  "n_zero": 0,
+                  "p_value": 0.237885
+                },
+                "signed_rank": {
+                  "n": 18,
+                  "w": 113.0,
+                  "z": 1.1759,
+                  "p_value": 0.239651
+                },
+                "bootstrap": {
+                  "point": -0.013333,
+                  "lo": -0.140278,
+                  "hi": 0.088333,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 9,
+          "entries": 7,
+          "win_rate": 0.5714,
+          "mean_net_pct": -0.4558,
+          "total_net_pct": -3.1907,
+          "total_return_pct": -3.27,
+          "max_drawdown_pct": -5.2,
+          "sharpe": -0.779,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 9,
+          "entries": 6,
+          "win_rate": 0.6667,
+          "mean_net_pct": -0.0951,
+          "total_net_pct": -0.5707,
+          "total_return_pct": -0.51,
+          "max_drawdown_pct": -5.22,
+          "sharpe": -0.128,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.360706,
+          "lo": -1.481217,
+          "hi": 2.231426,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 7,
+          "paired": 7,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 7,
+            "control_mean_net_pct": -0.4558,
+            "candidate_mean_net_pct": -0.5487,
+            "control_total_net_pct": -3.1907,
+            "candidate_total_net_pct": -3.8408,
+            "control_win_rate": 0.5714,
+            "candidate_win_rate": 0.5714,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.8956,
+            "candidate_median_mae_pct": -1.6576,
+            "control_median_mfe_pct": 1.3514,
+            "candidate_median_mfe_pct": 1.3514,
+            "paired_delta": {
+              "n": 7,
+              "mean": -0.092864,
+              "median": -0.0,
+              "sign_test": {
+                "n": 6,
+                "n_pos": 2,
+                "n_neg": 4,
+                "n_zero": 1,
+                "p_value": 0.6875
+              },
+              "signed_rank": {
+                "n": 6,
+                "w": 7.0,
+                "z": -0.629,
+                "p_value": 0.529368
+              },
+              "bootstrap": {
+                "point": -0.092864,
+                "lo": -0.342879,
+                "hi": 0.064286,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 7,
+              "control_mean_net_pct": -0.4558,
+              "candidate_mean_net_pct": -0.5487,
+              "control_total_net_pct": -3.1907,
+              "candidate_total_net_pct": -3.8408,
+              "control_win_rate": 0.5714,
+              "candidate_win_rate": 0.5714,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.8956,
+              "candidate_median_mae_pct": -1.6576,
+              "control_median_mfe_pct": 1.3514,
+              "candidate_median_mfe_pct": 1.3514,
+              "paired_delta": {
+                "n": 7,
+                "mean": -0.092864,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 6,
+                  "n_pos": 2,
+                  "n_neg": 4,
+                  "n_zero": 1,
+                  "p_value": 0.6875
+                },
+                "signed_rank": {
+                  "n": 6,
+                  "w": 7.0,
+                  "z": -0.629,
+                  "p_value": 0.529368
+                },
+                "bootstrap": {
+                  "point": -0.092864,
+                  "lo": -0.342879,
+                  "hi": 0.064286,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 29,
+          "entries": 20,
+          "win_rate": 0.45,
+          "mean_net_pct": -0.3824,
+          "total_net_pct": -7.647,
+          "total_return_pct": -7.48,
+          "max_drawdown_pct": -9.37,
+          "sharpe": -1.289,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 29,
+          "entries": 20,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.3344,
+          "total_net_pct": -6.687,
+          "total_return_pct": -6.61,
+          "max_drawdown_pct": -10.06,
+          "sharpe": -1.058,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.048,
+          "lo": -0.608506,
+          "hi": 0.705506,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 20,
+          "paired": 20,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 20,
+            "control_mean_net_pct": -0.3824,
+            "candidate_mean_net_pct": -0.3344,
+            "control_total_net_pct": -7.647,
+            "candidate_total_net_pct": -6.687,
+            "control_win_rate": 0.45,
+            "candidate_win_rate": 0.5,
+            "delta_win_rate": 0.05,
+            "control_median_mae_pct": -1.1531,
+            "candidate_median_mae_pct": -1.1531,
+            "control_median_mfe_pct": 0.8097,
+            "candidate_median_mfe_pct": 0.9582,
+            "paired_delta": {
+              "n": 20,
+              "mean": 0.048,
+              "median": 0.0,
+              "sign_test": {
+                "n": 20,
+                "n_pos": 15,
+                "n_neg": 5,
+                "n_zero": 0,
+                "p_value": 0.041389
+              },
+              "signed_rank": {
+                "n": 20,
+                "w": 167.0,
+                "z": 2.296,
+                "p_value": 0.021678
+              },
+              "bootstrap": {
+                "point": 0.048,
+                "lo": -0.082006,
+                "hi": 0.158513,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 20,
+              "control_mean_net_pct": -0.3824,
+              "candidate_mean_net_pct": -0.3344,
+              "control_total_net_pct": -7.647,
+              "candidate_total_net_pct": -6.687,
+              "control_win_rate": 0.45,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.05,
+              "control_median_mae_pct": -1.1531,
+              "candidate_median_mae_pct": -1.1531,
+              "control_median_mfe_pct": 0.8097,
+              "candidate_median_mfe_pct": 0.9582,
+              "paired_delta": {
+                "n": 20,
+                "mean": 0.048,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 20,
+                  "n_pos": 15,
+                  "n_neg": 5,
+                  "n_zero": 0,
+                  "p_value": 0.041389
+                },
+                "signed_rank": {
+                  "n": 20,
+                  "w": 167.0,
+                  "z": 2.296,
+                  "p_value": 0.021678
+                },
+                "bootstrap": {
+                  "point": 0.048,
+                  "lo": -0.082006,
+                  "hi": 0.158513,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 4,
+          "entries": 3,
+          "win_rate": 1.0,
+          "mean_net_pct": 2.6332,
+          "total_net_pct": 7.8997,
+          "total_return_pct": 8.04,
+          "max_drawdown_pct": -1.84,
+          "sharpe": 1.566,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 1.0,
+          "mean_net_pct": 3.2299,
+          "total_net_pct": 9.6897,
+          "total_return_pct": 9.95,
+          "max_drawdown_pct": -1.84,
+          "sharpe": 1.896,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.596667,
+          "lo": -2.26,
+          "hi": 3.376667,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": 2.6332,
+            "candidate_mean_net_pct": 3.2299,
+            "control_total_net_pct": 7.8997,
+            "candidate_total_net_pct": 9.6897,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.4476,
+            "candidate_median_mae_pct": -1.4476,
+            "control_median_mfe_pct": 2.6465,
+            "candidate_median_mfe_pct": 3.6884,
+            "paired_delta": {
+              "n": 3,
+              "mean": 0.596667,
+              "median": 0.48,
+              "sign_test": {
+                "n": 3,
+                "n_pos": 3,
+                "n_neg": 0,
+                "n_zero": 0,
+                "p_value": 0.25
+              },
+              "signed_rank": {
+                "n": 3,
+                "w": 6.0,
+                "z": 1.3363,
+                "p_value": 0.181449
+              },
+              "bootstrap": {
+                "point": 0.596667,
+                "lo": 0.0,
+                "hi": 1.31,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 3,
+              "control_mean_net_pct": 2.6332,
+              "candidate_mean_net_pct": 3.2299,
+              "control_total_net_pct": 7.8997,
+              "candidate_total_net_pct": 9.6897,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.4476,
+              "candidate_median_mae_pct": -1.4476,
+              "control_median_mfe_pct": 2.6465,
+              "candidate_median_mfe_pct": 3.6884,
+              "paired_delta": {
+                "n": 3,
+                "mean": 0.596667,
+                "median": 0.48,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 3,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 0.25
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 6.0,
+                  "z": 1.3363,
+                  "p_value": 0.181449
+                },
+                "bootstrap": {
+                  "point": 0.596667,
+                  "lo": 0.0,
+                  "hi": 1.31,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 28,
+          "entries": 17,
+          "win_rate": 0.5882,
+          "mean_net_pct": -0.1207,
+          "total_net_pct": -2.0517,
+          "total_return_pct": -2.19,
+          "max_drawdown_pct": -8.24,
+          "sharpe": -0.374,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 27,
+          "entries": 17,
+          "win_rate": 0.5294,
+          "mean_net_pct": -0.0319,
+          "total_net_pct": -0.5417,
+          "total_return_pct": -0.79,
+          "max_drawdown_pct": -8.24,
+          "sharpe": -0.083,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.088824,
+          "lo": -0.964412,
+          "hi": 1.153831,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 17,
+          "paired": 17,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 17,
+            "control_mean_net_pct": -0.1207,
+            "candidate_mean_net_pct": -0.0319,
+            "control_total_net_pct": -2.0517,
+            "candidate_total_net_pct": -0.5417,
+            "control_win_rate": 0.5882,
+            "candidate_win_rate": 0.5294,
+            "delta_win_rate": -0.0588,
+            "control_median_mae_pct": -0.9123,
+            "candidate_median_mae_pct": -0.9405,
+            "control_median_mfe_pct": 1.0593,
+            "candidate_median_mfe_pct": 1.1949,
+            "paired_delta": {
+              "n": 17,
+              "mean": 0.088823,
+              "median": -0.0,
+              "sign_test": {
+                "n": 16,
+                "n_pos": 6,
+                "n_neg": 10,
+                "n_zero": 1,
+                "p_value": 0.454498
+              },
+              "signed_rank": {
+                "n": 16,
+                "w": 64.0,
+                "z": -0.181,
+                "p_value": 0.856383
+              },
+              "bootstrap": {
+                "point": 0.088823,
+                "lo": -0.235,
+                "hi": 0.448529,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 17,
+              "control_mean_net_pct": -0.1207,
+              "candidate_mean_net_pct": -0.0319,
+              "control_total_net_pct": -2.0517,
+              "candidate_total_net_pct": -0.5417,
+              "control_win_rate": 0.5882,
+              "candidate_win_rate": 0.5294,
+              "delta_win_rate": -0.0588,
+              "control_median_mae_pct": -0.9123,
+              "candidate_median_mae_pct": -0.9405,
+              "control_median_mfe_pct": 1.0593,
+              "candidate_median_mfe_pct": 1.1949,
+              "paired_delta": {
+                "n": 17,
+                "mean": 0.088823,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 16,
+                  "n_pos": 6,
+                  "n_neg": 10,
+                  "n_zero": 1,
+                  "p_value": 0.454498
+                },
+                "signed_rank": {
+                  "n": 16,
+                  "w": 64.0,
+                  "z": -0.181,
+                  "p_value": 0.856383
+                },
+                "bootstrap": {
+                  "point": 0.088823,
+                  "lo": -0.235,
+                  "hi": 0.448529,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 1.0,
+          "mean_net_pct": 2.5049,
+          "total_net_pct": 7.5147,
+          "total_return_pct": 7.7,
+          "max_drawdown_pct": -1.72,
+          "sharpe": 1.549,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 0.6667,
+          "mean_net_pct": 2.7466,
+          "total_net_pct": 8.2397,
+          "total_return_pct": 8.35,
+          "max_drawdown_pct": -3.95,
+          "sharpe": 1.568,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.241667,
+          "lo": -3.121667,
+          "hi": 3.141667,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": 2.5049,
+            "candidate_mean_net_pct": 2.7466,
+            "control_total_net_pct": 7.5147,
+            "candidate_total_net_pct": 8.2397,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 0.6667,
+            "delta_win_rate": -0.3333,
+            "control_median_mae_pct": -1.1875,
+            "candidate_median_mae_pct": -2.1063,
+            "control_median_mfe_pct": 4.0774,
+            "candidate_median_mfe_pct": 4.5418,
+            "paired_delta": {
+              "n": 3,
+              "mean": 0.241667,
+              "median": 1.335,
+              "sign_test": {
+                "n": 3,
+                "n_pos": 2,
+                "n_neg": 1,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 3,
+                "w": 3.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 0.241667,
+                "lo": -3.005,
+                "hi": 2.395,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 3,
+              "control_mean_net_pct": 2.5049,
+              "candidate_mean_net_pct": 2.7466,
+              "control_total_net_pct": 7.5147,
+              "candidate_total_net_pct": 8.2397,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": -0.3333,
+              "control_median_mae_pct": -1.1875,
+              "candidate_median_mae_pct": -2.1063,
+              "control_median_mfe_pct": 4.0774,
+              "candidate_median_mfe_pct": 4.5418,
+              "paired_delta": {
+                "n": 3,
+                "mean": 0.241667,
+                "median": 1.335,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 2,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 3.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.241667,
+                  "lo": -3.005,
+                  "hi": 2.395,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 14,
+          "entries": 11,
+          "win_rate": 0.3636,
+          "mean_net_pct": -0.4937,
+          "total_net_pct": -5.4311,
+          "total_return_pct": -5.34,
+          "max_drawdown_pct": -5.34,
+          "sharpe": -1.53,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 15,
+          "entries": 11,
+          "win_rate": 0.3636,
+          "mean_net_pct": -0.4992,
+          "total_net_pct": -5.4911,
+          "total_return_pct": -5.4,
+          "max_drawdown_pct": -5.4,
+          "sharpe": -1.535,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.005455,
+          "lo": -0.773182,
+          "hi": 0.762307,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 11,
+          "paired": 11,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 11,
+            "control_mean_net_pct": -0.4937,
+            "candidate_mean_net_pct": -0.4992,
+            "control_total_net_pct": -5.4311,
+            "candidate_total_net_pct": -5.4911,
+            "control_win_rate": 0.3636,
+            "candidate_win_rate": 0.3636,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.014,
+            "candidate_median_mae_pct": -1.014,
+            "control_median_mfe_pct": 0.3961,
+            "candidate_median_mfe_pct": 0.3961,
+            "paired_delta": {
+              "n": 11,
+              "mean": -0.005455,
+              "median": 0.0,
+              "sign_test": {
+                "n": 10,
+                "n_pos": 6,
+                "n_neg": 4,
+                "n_zero": 1,
+                "p_value": 0.753906
+              },
+              "signed_rank": {
+                "n": 10,
+                "w": 37.0,
+                "z": 0.9174,
+                "p_value": 0.358951
+              },
+              "bootstrap": {
+                "point": -0.005455,
+                "lo": -0.143636,
+                "hi": 0.096364,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 11,
+              "control_mean_net_pct": -0.4937,
+              "candidate_mean_net_pct": -0.4992,
+              "control_total_net_pct": -5.4311,
+              "candidate_total_net_pct": -5.4911,
+              "control_win_rate": 0.3636,
+              "candidate_win_rate": 0.3636,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.014,
+              "candidate_median_mae_pct": -1.014,
+              "control_median_mfe_pct": 0.3961,
+              "candidate_median_mfe_pct": 0.3961,
+              "paired_delta": {
+                "n": 11,
+                "mean": -0.005455,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 10,
+                  "n_pos": 6,
+                  "n_neg": 4,
+                  "n_zero": 1,
+                  "p_value": 0.753906
+                },
+                "signed_rank": {
+                  "n": 10,
+                  "w": 37.0,
+                  "z": 0.9174,
+                  "p_value": 0.358951
+                },
+                "bootstrap": {
+                  "point": -0.005455,
+                  "lo": -0.143636,
+                  "hi": 0.096364,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.0899,
+          "total_net_pct": 0.2697,
+          "total_return_pct": 0.25,
+          "max_drawdown_pct": -4.2,
+          "sharpe": 0.128,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.2249,
+          "total_net_pct": 0.6747,
+          "total_return_pct": 0.65,
+          "max_drawdown_pct": -4.2,
+          "sharpe": 0.279,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.135,
+          "lo": -2.135,
+          "hi": 2.405,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": 0.0899,
+            "candidate_mean_net_pct": 0.2249,
+            "control_total_net_pct": 0.2697,
+            "candidate_total_net_pct": 0.6747,
+            "control_win_rate": 0.6667,
+            "candidate_win_rate": 0.6667,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.3427,
+            "candidate_median_mae_pct": -1.3427,
+            "control_median_mfe_pct": 1.6545,
+            "candidate_median_mfe_pct": 1.7452,
+            "paired_delta": {
+              "n": 3,
+              "mean": 0.135,
+              "median": 0.0,
+              "sign_test": {
+                "n": 2,
+                "n_pos": 2,
+                "n_neg": 0,
+                "n_zero": 1,
+                "p_value": 0.5
+              },
+              "signed_rank": {
+                "n": 2,
+                "w": 3.0,
+                "z": 0.8944,
+                "p_value": 0.371093
+              },
+              "bootstrap": {
+                "point": 0.135,
+                "lo": 0.0,
+                "hi": 0.405,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 3,
+              "control_mean_net_pct": 0.0899,
+              "candidate_mean_net_pct": 0.2249,
+              "control_total_net_pct": 0.2697,
+              "candidate_total_net_pct": 0.6747,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.3427,
+              "candidate_median_mae_pct": -1.3427,
+              "control_median_mfe_pct": 1.6545,
+              "candidate_median_mfe_pct": 1.7452,
+              "paired_delta": {
+                "n": 3,
+                "mean": 0.135,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 2,
+                  "n_neg": 0,
+                  "n_zero": 1,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 3.0,
+                  "z": 0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": 0.135,
+                  "lo": 0.0,
+                  "hi": 0.405,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 12,
+          "entries": 10,
+          "win_rate": 0.1,
+          "mean_net_pct": -1.2426,
+          "total_net_pct": -12.426,
+          "total_return_pct": -11.78,
+          "max_drawdown_pct": -11.78,
+          "sharpe": -2.984,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 12,
+          "entries": 10,
+          "win_rate": 0.0,
+          "mean_net_pct": -1.3481,
+          "total_net_pct": -13.481,
+          "total_return_pct": -12.7,
+          "max_drawdown_pct": -12.7,
+          "sharpe": -3.204,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.1055,
+          "lo": -0.952512,
+          "hi": 0.723,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 10,
+          "paired": 10,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 10,
+            "control_mean_net_pct": -1.2426,
+            "candidate_mean_net_pct": -1.3481,
+            "control_total_net_pct": -12.426,
+            "candidate_total_net_pct": -13.481,
+            "control_win_rate": 0.1,
+            "candidate_win_rate": 0.0,
+            "delta_win_rate": -0.1,
+            "control_median_mae_pct": -1.3784,
+            "candidate_median_mae_pct": -1.5074,
+            "control_median_mfe_pct": 0.1102,
+            "candidate_median_mfe_pct": 0.1102,
+            "paired_delta": {
+              "n": 10,
+              "mean": -0.1055,
+              "median": 0.0,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 5,
+                "n_neg": 4,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 27.0,
+                "z": 0.4739,
+                "p_value": 0.635586
+              },
+              "bootstrap": {
+                "point": -0.1055,
+                "lo": -0.387,
+                "hi": 0.0705,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 10,
+              "control_mean_net_pct": -1.2426,
+              "candidate_mean_net_pct": -1.3481,
+              "control_total_net_pct": -12.426,
+              "candidate_total_net_pct": -13.481,
+              "control_win_rate": 0.1,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": -0.1,
+              "control_median_mae_pct": -1.3784,
+              "candidate_median_mae_pct": -1.5074,
+              "control_median_mfe_pct": 0.1102,
+              "candidate_median_mfe_pct": 0.1102,
+              "paired_delta": {
+                "n": 10,
+                "mean": -0.1055,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 9,
+                  "n_pos": 5,
+                  "n_neg": 4,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 9,
+                  "w": 27.0,
+                  "z": 0.4739,
+                  "p_value": 0.635586
+                },
+                "bootstrap": {
+                  "point": -0.1055,
+                  "lo": -0.387,
+                  "hi": 0.0705,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 15,
+          "entries": 9,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.0249,
+          "total_net_pct": 0.2241,
+          "total_return_pct": 0.17,
+          "max_drawdown_pct": -2.38,
+          "sharpe": 0.095,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 13,
+          "entries": 9,
+          "win_rate": 0.5556,
+          "mean_net_pct": -0.0984,
+          "total_net_pct": -0.8859,
+          "total_return_pct": -0.98,
+          "max_drawdown_pct": -3.35,
+          "sharpe": -0.237,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.123333,
+          "lo": -1.256667,
+          "hi": 1.034,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 9,
+          "paired": 9,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 9,
+            "control_mean_net_pct": 0.0249,
+            "candidate_mean_net_pct": -0.0984,
+            "control_total_net_pct": 0.2241,
+            "candidate_total_net_pct": -0.8859,
+            "control_win_rate": 0.6667,
+            "candidate_win_rate": 0.5556,
+            "delta_win_rate": -0.1111,
+            "control_median_mae_pct": -0.8156,
+            "candidate_median_mae_pct": -1.3651,
+            "control_median_mfe_pct": 1.2719,
+            "candidate_median_mfe_pct": 1.3234,
+            "paired_delta": {
+              "n": 9,
+              "mean": -0.123333,
+              "median": 0.0,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 5,
+                "n_neg": 4,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 23.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": -0.123333,
+                "lo": -0.61,
+                "hi": 0.314444,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 9,
+              "control_mean_net_pct": 0.0249,
+              "candidate_mean_net_pct": -0.0984,
+              "control_total_net_pct": 0.2241,
+              "candidate_total_net_pct": -0.8859,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.5556,
+              "delta_win_rate": -0.1111,
+              "control_median_mae_pct": -0.8156,
+              "candidate_median_mae_pct": -1.3651,
+              "control_median_mfe_pct": 1.2719,
+              "candidate_median_mfe_pct": 1.3234,
+              "paired_delta": {
+                "n": 9,
+                "mean": -0.123333,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 9,
+                  "n_pos": 5,
+                  "n_neg": 4,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 9,
+                  "w": 23.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.123333,
+                  "lo": -0.61,
+                  "hi": 0.314444,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 2,
+          "entries": 1,
+          "win_rate": 0.0,
+          "mean_net_pct": -0.7901,
+          "total_net_pct": -0.7901,
+          "total_return_pct": -0.79,
+          "max_drawdown_pct": -1.84,
+          "sharpe": -0.729,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 2,
+          "entries": 1,
+          "win_rate": 0.0,
+          "mean_net_pct": -0.6701,
+          "total_net_pct": -0.6701,
+          "total_return_pct": -0.67,
+          "max_drawdown_pct": -1.72,
+          "sharpe": -0.619,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.12,
+          "lo": 0.12,
+          "hi": 0.12,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": -0.7901,
+            "candidate_mean_net_pct": -0.6701,
+            "control_total_net_pct": -0.7901,
+            "candidate_total_net_pct": -0.6701,
+            "control_win_rate": 0.0,
+            "candidate_win_rate": 0.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -3.143,
+            "candidate_median_mae_pct": -3.143,
+            "control_median_mfe_pct": 2.3213,
+            "candidate_median_mfe_pct": 2.3213,
+            "paired_delta": {
+              "n": 1,
+              "mean": 0.12,
+              "median": 0.12,
+              "sign_test": {
+                "n": 1,
+                "n_pos": 1,
+                "n_neg": 0,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 1,
+                "w": 1.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 0.12,
+                "lo": 0.12,
+                "hi": 0.12,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 1,
+              "control_mean_net_pct": -0.7901,
+              "candidate_mean_net_pct": -0.6701,
+              "control_total_net_pct": -0.7901,
+              "candidate_total_net_pct": -0.6701,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -3.143,
+              "candidate_median_mae_pct": -3.143,
+              "control_median_mfe_pct": 2.3213,
+              "candidate_median_mfe_pct": 2.3213,
+              "paired_delta": {
+                "n": 1,
+                "mean": 0.12,
+                "median": 0.12,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.12,
+                  "lo": 0.12,
+                  "hi": 0.12,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/sq.rd_full_scaleout.json
+++ b/backtest/research/regime_1152_runs/sq.rd_full_scaleout.json
@@ -1,0 +1,1606 @@
+{
+  "open": {
+    "name": "squeeze_momentum",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "tp_tiers": {
+          "ranging_directional": [
+            {
+              "atr_multiple": 1.0,
+              "close_fraction": 0.4,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 0.8,
+              "trailing_mult_after": 0.75
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 1.0,
+              "trailing_mult_after": 0.75
+            }
+          ],
+          "ranging_directional_up": [
+            {
+              "atr_multiple": 1.0,
+              "close_fraction": 0.4,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 0.8,
+              "trailing_mult_after": 0.75
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 1.0,
+              "trailing_mult_after": 0.75
+            }
+          ],
+          "ranging_directional_down": [
+            {
+              "atr_multiple": 1.0,
+              "close_fraction": 0.4,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 0.8,
+              "trailing_mult_after": 0.75
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 1.0,
+              "trailing_mult_after": 0.75
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "control_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_directional"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 32,
+          "entries": 8,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.0126,
+          "total_net_pct": -0.1008,
+          "total_return_pct": -0.15,
+          "max_drawdown_pct": -3.03,
+          "sharpe": -0.037,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 31,
+          "entries": 8,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.0081,
+          "total_net_pct": -0.0648,
+          "total_return_pct": -0.11,
+          "max_drawdown_pct": -2.7,
+          "sharpe": -0.025,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.0045,
+          "lo": -1.193848,
+          "hi": 1.138386,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 8,
+          "paired": 8,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 8,
+            "control_mean_net_pct": -0.0126,
+            "candidate_mean_net_pct": -0.0081,
+            "control_total_net_pct": -0.1008,
+            "candidate_total_net_pct": -0.0648,
+            "control_win_rate": 0.5,
+            "candidate_win_rate": 0.5,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.4796,
+            "candidate_median_mae_pct": -0.4796,
+            "control_median_mfe_pct": 0.8827,
+            "candidate_median_mfe_pct": 0.8827,
+            "paired_delta": {
+              "n": 8,
+              "mean": 0.0045,
+              "median": 0.01725,
+              "sign_test": {
+                "n": 8,
+                "n_pos": 4,
+                "n_neg": 4,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 8,
+                "w": 22.0,
+                "z": 0.4901,
+                "p_value": 0.624065
+              },
+              "bootstrap": {
+                "point": 0.0045,
+                "lo": -0.121688,
+                "hi": 0.096,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 6,
+              "control_mean_net_pct": 0.2082,
+              "candidate_mean_net_pct": 0.2142,
+              "control_total_net_pct": 1.2494,
+              "candidate_total_net_pct": 1.2854,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.4835,
+              "candidate_median_mae_pct": -0.4835,
+              "control_median_mfe_pct": 1.0325,
+              "candidate_median_mfe_pct": 1.0325,
+              "paired_delta": {
+                "n": 6,
+                "mean": 0.006,
+                "median": 0.05775,
+                "sign_test": {
+                  "n": 6,
+                  "n_pos": 4,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 0.6875
+                },
+                "signed_rank": {
+                  "n": 6,
+                  "w": 14.0,
+                  "z": 0.629,
+                  "p_value": 0.529368
+                },
+                "bootstrap": {
+                  "point": 0.006,
+                  "lo": -0.16025,
+                  "hi": 0.124,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": -0.6751,
+              "candidate_mean_net_pct": -0.6751,
+              "control_total_net_pct": -1.3502,
+              "candidate_total_net_pct": -1.3502,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.4796,
+              "candidate_median_mae_pct": -0.4796,
+              "control_median_mfe_pct": 0.1483,
+              "candidate_median_mfe_pct": 0.1483,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.0,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 0,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 0,
+                  "z": -0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": -0.0,
+                  "lo": -0.0,
+                  "hi": -0.0,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 0.0,
+          "mean_net_pct": -2.8401,
+          "total_net_pct": -2.8401,
+          "total_return_pct": -2.83,
+          "max_drawdown_pct": -2.83,
+          "sharpe": -1.524,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 0.0,
+          "mean_net_pct": -2.8401,
+          "total_net_pct": -2.8401,
+          "total_return_pct": -2.83,
+          "max_drawdown_pct": -2.83,
+          "sharpe": -1.524,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.0,
+          "lo": 0.0,
+          "hi": 0.0,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": -2.8401,
+            "candidate_mean_net_pct": -2.8401,
+            "control_total_net_pct": -2.8401,
+            "candidate_total_net_pct": -2.8401,
+            "control_win_rate": 0.0,
+            "candidate_win_rate": 0.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -3.0899,
+            "candidate_median_mae_pct": -3.0899,
+            "control_median_mfe_pct": 0.3097,
+            "candidate_median_mfe_pct": 0.3097,
+            "paired_delta": {
+              "n": 1,
+              "mean": 0.0,
+              "median": 0.0,
+              "sign_test": {
+                "n": 0,
+                "n_pos": 0,
+                "n_neg": 0,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 0,
+                "w": 0.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 0.0,
+                "lo": 0.0,
+                "hi": 0.0,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_up": {
+              "n": 1,
+              "control_mean_net_pct": -2.8401,
+              "candidate_mean_net_pct": -2.8401,
+              "control_total_net_pct": -2.8401,
+              "candidate_total_net_pct": -2.8401,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -3.0899,
+              "candidate_median_mae_pct": -3.0899,
+              "control_median_mfe_pct": 0.3097,
+              "candidate_median_mfe_pct": 0.3097,
+              "paired_delta": {
+                "n": 1,
+                "mean": 0.0,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 0,
+                  "n_pos": 0,
+                  "n_neg": 0,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 0,
+                  "w": 0.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.0,
+                  "lo": 0.0,
+                  "hi": 0.0,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 19,
+          "entries": 9,
+          "win_rate": 0.4444,
+          "mean_net_pct": -0.0109,
+          "total_net_pct": -0.0984,
+          "total_return_pct": -0.17,
+          "max_drawdown_pct": -3.38,
+          "sharpe": -0.018,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 17,
+          "entries": 9,
+          "win_rate": 0.4444,
+          "mean_net_pct": 0.0948,
+          "total_net_pct": 0.8531,
+          "total_return_pct": 0.77,
+          "max_drawdown_pct": -2.91,
+          "sharpe": 0.257,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.105722,
+          "lo": -1.086113,
+          "hi": 1.268808,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 9,
+          "paired": 9,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 9,
+            "control_mean_net_pct": -0.0109,
+            "candidate_mean_net_pct": 0.0948,
+            "control_total_net_pct": -0.0984,
+            "candidate_total_net_pct": 0.8531,
+            "control_win_rate": 0.4444,
+            "candidate_win_rate": 0.4444,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.7054,
+            "candidate_median_mae_pct": -0.7054,
+            "control_median_mfe_pct": 1.3769,
+            "candidate_median_mfe_pct": 1.3769,
+            "paired_delta": {
+              "n": 9,
+              "mean": 0.105722,
+              "median": 0.0,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 5,
+                "n_neg": 4,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 33.0,
+                "z": 1.1847,
+                "p_value": 0.236137
+              },
+              "bootstrap": {
+                "point": 0.105722,
+                "lo": 0.006278,
+                "hi": 0.216667,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 7,
+              "control_mean_net_pct": -0.0987,
+              "candidate_mean_net_pct": -0.0187,
+              "control_total_net_pct": -0.6907,
+              "candidate_total_net_pct": -0.1307,
+              "control_win_rate": 0.4286,
+              "candidate_win_rate": 0.4286,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.7283,
+              "candidate_median_mae_pct": -0.7283,
+              "control_median_mfe_pct": 1.3769,
+              "candidate_median_mfe_pct": 1.3769,
+              "paired_delta": {
+                "n": 7,
+                "mean": 0.08,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 7,
+                  "n_pos": 4,
+                  "n_neg": 3,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 7,
+                  "w": 20.0,
+                  "z": 0.9297,
+                  "p_value": 0.352542
+                },
+                "bootstrap": {
+                  "point": 0.08,
+                  "lo": -0.008071,
+                  "hi": 0.194571,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": 0.2961,
+              "candidate_mean_net_pct": 0.4919,
+              "control_total_net_pct": 0.5923,
+              "candidate_total_net_pct": 0.9838,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.3589,
+              "candidate_median_mae_pct": -0.3589,
+              "control_median_mfe_pct": 1.717,
+              "candidate_median_mfe_pct": 1.717,
+              "paired_delta": {
+                "n": 2,
+                "mean": 0.19575,
+                "median": 0.19575,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 2.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.19575,
+                  "lo": -0.0,
+                  "hi": 0.3915,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 13,
+          "entries": 5,
+          "win_rate": 0.6,
+          "mean_net_pct": -0.4206,
+          "total_net_pct": -2.103,
+          "total_return_pct": -2.23,
+          "max_drawdown_pct": -4.95,
+          "sharpe": -0.496,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 11,
+          "entries": 5,
+          "win_rate": 0.6,
+          "mean_net_pct": -0.1557,
+          "total_net_pct": -0.7785,
+          "total_return_pct": -0.95,
+          "max_drawdown_pct": -4.95,
+          "sharpe": -0.198,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.2649,
+          "lo": -2.891648,
+          "hi": 3.3232,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 5,
+          "paired": 5,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 5,
+            "control_mean_net_pct": -0.4206,
+            "candidate_mean_net_pct": -0.1557,
+            "control_total_net_pct": -2.103,
+            "candidate_total_net_pct": -0.7785,
+            "control_win_rate": 0.6,
+            "candidate_win_rate": 0.6,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.1631,
+            "candidate_median_mae_pct": -1.1631,
+            "control_median_mfe_pct": 2.6688,
+            "candidate_median_mfe_pct": 2.6464,
+            "paired_delta": {
+              "n": 5,
+              "mean": 0.2649,
+              "median": 0.2595,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 4,
+                "n_neg": 0,
+                "n_zero": 1,
+                "p_value": 0.125
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 10.0,
+                "z": 1.6432,
+                "p_value": 0.100348
+              },
+              "bootstrap": {
+                "point": 0.2649,
+                "lo": 0.0519,
+                "hi": 0.4804,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": 1.4924,
+              "candidate_mean_net_pct": 1.7519,
+              "control_total_net_pct": 1.4924,
+              "candidate_total_net_pct": 1.7519,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1631,
+              "candidate_median_mae_pct": -1.1631,
+              "control_median_mfe_pct": 3.4385,
+              "candidate_median_mfe_pct": 3.4385,
+              "paired_delta": {
+                "n": 1,
+                "mean": 0.2595,
+                "median": 0.2595,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.2595,
+                  "lo": 0.2595,
+                  "hi": 0.2595,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 4,
+              "control_mean_net_pct": -0.8989,
+              "candidate_mean_net_pct": -0.6326,
+              "control_total_net_pct": -3.5954,
+              "candidate_total_net_pct": -2.5304,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.6923,
+              "candidate_median_mae_pct": -1.6923,
+              "control_median_mfe_pct": 2.0032,
+              "candidate_median_mfe_pct": 1.992,
+              "paired_delta": {
+                "n": 4,
+                "mean": 0.26625,
+                "median": 0.19825,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 3,
+                  "n_neg": 0,
+                  "n_zero": 1,
+                  "p_value": 0.25
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 6.0,
+                  "z": 1.3363,
+                  "p_value": 0.181449
+                },
+                "bootstrap": {
+                  "point": 0.26625,
+                  "lo": 0.0,
+                  "hi": 0.5325,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 7,
+          "entries": 5,
+          "win_rate": 0.4,
+          "mean_net_pct": -0.8986,
+          "total_net_pct": -4.493,
+          "total_return_pct": -4.42,
+          "max_drawdown_pct": -4.45,
+          "sharpe": -1.581,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 9,
+          "entries": 5,
+          "win_rate": 0.4,
+          "mean_net_pct": -0.8329,
+          "total_net_pct": -4.1645,
+          "total_return_pct": -4.11,
+          "max_drawdown_pct": -4.24,
+          "sharpe": -1.553,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.0657,
+          "lo": -1.146763,
+          "hi": 1.280903,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 5,
+          "paired": 5,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 5,
+            "control_mean_net_pct": -0.8986,
+            "candidate_mean_net_pct": -0.8329,
+            "control_total_net_pct": -4.493,
+            "candidate_total_net_pct": -4.1645,
+            "control_win_rate": 0.4,
+            "candidate_win_rate": 0.4,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.6515,
+            "candidate_median_mae_pct": -0.6515,
+            "control_median_mfe_pct": 0.2588,
+            "candidate_median_mfe_pct": 0.2588,
+            "paired_delta": {
+              "n": 5,
+              "mean": 0.0657,
+              "median": 0.0,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 3,
+                "n_neg": 1,
+                "n_zero": 1,
+                "p_value": 0.625
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 9.0,
+                "z": 1.278,
+                "p_value": 0.201243
+              },
+              "bootstrap": {
+                "point": 0.0657,
+                "lo": -0.0,
+                "hi": 0.1545,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": -0.2914,
+              "candidate_mean_net_pct": -0.2381,
+              "control_total_net_pct": -0.5827,
+              "candidate_total_net_pct": -0.4762,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.5242,
+              "candidate_median_mae_pct": -0.5242,
+              "control_median_mfe_pct": 0.7706,
+              "candidate_median_mfe_pct": 0.7706,
+              "paired_delta": {
+                "n": 2,
+                "mean": 0.05325,
+                "median": 0.05325,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 2.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.05325,
+                  "lo": -0.0,
+                  "hi": 0.1065,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 3,
+              "control_mean_net_pct": -1.3034,
+              "candidate_mean_net_pct": -1.2294,
+              "control_total_net_pct": -3.9103,
+              "candidate_total_net_pct": -3.6883,
+              "control_win_rate": 0.3333,
+              "candidate_win_rate": 0.3333,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.9564,
+              "candidate_median_mae_pct": -1.9564,
+              "control_median_mfe_pct": 0.2588,
+              "candidate_median_mfe_pct": 0.2588,
+              "paired_delta": {
+                "n": 3,
+                "mean": 0.074,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 2,
+                  "n_neg": 0,
+                  "n_zero": 1,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 3.0,
+                  "z": 0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": 0.074,
+                  "lo": 0.0,
+                  "hi": 0.222,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 6,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 1.2099,
+          "total_net_pct": 1.2099,
+          "total_return_pct": 1.21,
+          "max_drawdown_pct": -1.64,
+          "sharpe": 0.564,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 2,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 1.4319,
+          "total_net_pct": 1.4319,
+          "total_return_pct": 1.43,
+          "max_drawdown_pct": -1.31,
+          "sharpe": 0.724,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.222,
+          "lo": 0.222,
+          "hi": 0.222,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": 1.2099,
+            "candidate_mean_net_pct": 1.4319,
+            "control_total_net_pct": 1.2099,
+            "candidate_total_net_pct": 1.4319,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.6872,
+            "candidate_median_mae_pct": -0.6872,
+            "control_median_mfe_pct": 4.4447,
+            "candidate_median_mfe_pct": 4.4447,
+            "paired_delta": {
+              "n": 1,
+              "mean": 0.222,
+              "median": 0.222,
+              "sign_test": {
+                "n": 1,
+                "n_pos": 1,
+                "n_neg": 0,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 1,
+                "w": 1.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 0.222,
+                "lo": 0.222,
+                "hi": 0.222,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": 1.2099,
+              "candidate_mean_net_pct": 1.4319,
+              "control_total_net_pct": 1.2099,
+              "candidate_total_net_pct": 1.4319,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.6872,
+              "candidate_median_mae_pct": -0.6872,
+              "control_median_mfe_pct": 4.4447,
+              "candidate_median_mfe_pct": 4.4447,
+              "paired_delta": {
+                "n": 1,
+                "mean": 0.222,
+                "median": 0.222,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.222,
+                  "lo": 0.222,
+                  "hi": 0.222,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 7,
+          "entries": 4,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.5239,
+          "total_net_pct": -2.0954,
+          "total_return_pct": -2.11,
+          "max_drawdown_pct": -3.61,
+          "sharpe": -1.152,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 7,
+          "entries": 4,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.4046,
+          "total_net_pct": -1.6184,
+          "total_return_pct": -1.64,
+          "max_drawdown_pct": -3.15,
+          "sharpe": -0.881,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.11925,
+          "lo": -1.72825,
+          "hi": 1.92925,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 4,
+          "paired": 4,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 4,
+            "control_mean_net_pct": -0.5239,
+            "candidate_mean_net_pct": -0.4046,
+            "control_total_net_pct": -2.0954,
+            "candidate_total_net_pct": -1.6184,
+            "control_win_rate": 0.5,
+            "candidate_win_rate": 0.5,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.4455,
+            "candidate_median_mae_pct": -0.4455,
+            "control_median_mfe_pct": 1.6099,
+            "candidate_median_mfe_pct": 1.6099,
+            "paired_delta": {
+              "n": 4,
+              "mean": 0.11925,
+              "median": 0.1335,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 3,
+                "n_neg": 1,
+                "n_zero": 0,
+                "p_value": 0.625
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 9.0,
+                "z": 1.278,
+                "p_value": 0.201243
+              },
+              "bootstrap": {
+                "point": 0.11925,
+                "lo": 0.02925,
+                "hi": 0.20925,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": 0.0774,
+              "candidate_mean_net_pct": 0.2109,
+              "control_total_net_pct": 0.1548,
+              "candidate_total_net_pct": 0.4218,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.4455,
+              "candidate_median_mae_pct": -0.4455,
+              "control_median_mfe_pct": 1.6099,
+              "candidate_median_mfe_pct": 1.6099,
+              "paired_delta": {
+                "n": 2,
+                "mean": 0.1335,
+                "median": 0.1335,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 2,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 3.0,
+                  "z": 0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": 0.1335,
+                  "lo": 0.0585,
+                  "hi": 0.2085,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": -1.1251,
+              "candidate_mean_net_pct": -1.0201,
+              "control_total_net_pct": -2.2502,
+              "candidate_total_net_pct": -2.0402,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.3179,
+              "candidate_median_mae_pct": -1.3179,
+              "control_median_mfe_pct": 1.1176,
+              "candidate_median_mfe_pct": 1.1176,
+              "paired_delta": {
+                "n": 2,
+                "mean": 0.105,
+                "median": 0.105,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 2.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.105,
+                  "lo": -0.0,
+                  "hi": 0.21,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 2,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 1.8824,
+          "total_net_pct": 1.8824,
+          "total_return_pct": 1.88,
+          "max_drawdown_pct": -2.15,
+          "sharpe": 0.749,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 2,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 2.1779,
+          "total_net_pct": 2.1779,
+          "total_return_pct": 2.18,
+          "max_drawdown_pct": -1.72,
+          "sharpe": 0.944,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.2955,
+          "lo": 0.2955,
+          "hi": 0.2955,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": 1.8824,
+            "candidate_mean_net_pct": 2.1779,
+            "control_total_net_pct": 1.8824,
+            "candidate_total_net_pct": 2.1779,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.1653,
+            "candidate_median_mae_pct": -1.1653,
+            "control_median_mfe_pct": 5.7849,
+            "candidate_median_mfe_pct": 5.7849,
+            "paired_delta": {
+              "n": 1,
+              "mean": 0.2955,
+              "median": 0.2955,
+              "sign_test": {
+                "n": 1,
+                "n_pos": 1,
+                "n_neg": 0,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 1,
+                "w": 1.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 0.2955,
+                "lo": 0.2955,
+                "hi": 0.2955,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_up": {
+              "n": 1,
+              "control_mean_net_pct": 1.8824,
+              "candidate_mean_net_pct": 2.1779,
+              "control_total_net_pct": 1.8824,
+              "candidate_total_net_pct": 2.1779,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1653,
+              "candidate_median_mae_pct": -1.1653,
+              "control_median_mfe_pct": 5.7849,
+              "candidate_median_mfe_pct": 5.7849,
+              "paired_delta": {
+                "n": 1,
+                "mean": 0.2955,
+                "median": 0.2955,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.2955,
+                  "lo": 0.2955,
+                  "hi": 0.2955,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.9559,
+          "total_net_pct": -2.8678,
+          "total_return_pct": -2.87,
+          "max_drawdown_pct": -4.6,
+          "sharpe": -0.698,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.9934,
+          "total_net_pct": -2.9803,
+          "total_return_pct": -2.98,
+          "max_drawdown_pct": -4.61,
+          "sharpe": -0.74,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.0375,
+          "lo": -2.695,
+          "hi": 2.62,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": -0.9559,
+            "candidate_mean_net_pct": -0.9934,
+            "control_total_net_pct": -2.8678,
+            "candidate_total_net_pct": -2.9803,
+            "control_win_rate": 0.3333,
+            "candidate_win_rate": 0.3333,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.4988,
+            "candidate_median_mae_pct": -1.4988,
+            "control_median_mfe_pct": 2.6995,
+            "candidate_median_mfe_pct": 2.6995,
+            "paired_delta": {
+              "n": 3,
+              "mean": -0.0375,
+              "median": 0.0,
+              "sign_test": {
+                "n": 2,
+                "n_pos": 1,
+                "n_neg": 1,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 2,
+                "w": 1.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": -0.0375,
+                "lo": -0.1125,
+                "hi": 0.0,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": -1.5301,
+              "candidate_mean_net_pct": -1.5301,
+              "control_total_net_pct": -1.5301,
+              "candidate_total_net_pct": -1.5301,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.4988,
+              "candidate_median_mae_pct": -1.4988,
+              "control_median_mfe_pct": 0.265,
+              "candidate_median_mfe_pct": 0.265,
+              "paired_delta": {
+                "n": 1,
+                "mean": 0.0,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.0,
+                  "lo": 0.0,
+                  "hi": 0.0,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": -0.6689,
+              "candidate_mean_net_pct": -0.7251,
+              "control_total_net_pct": -1.3377,
+              "candidate_total_net_pct": -1.4502,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.8361,
+              "candidate_median_mae_pct": -1.8361,
+              "control_median_mfe_pct": 3.4634,
+              "candidate_median_mfe_pct": 3.4634,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.05625,
+                "median": -0.05625,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 0,
+                  "n_neg": 1,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.05625,
+                  "lo": -0.1125,
+                  "hi": 0.0,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 6,
+          "entries": 2,
+          "win_rate": 1.0,
+          "mean_net_pct": 3.4174,
+          "total_net_pct": 6.8348,
+          "total_return_pct": 6.95,
+          "max_drawdown_pct": -2.59,
+          "sharpe": 1.849,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 6,
+          "entries": 2,
+          "win_rate": 1.0,
+          "mean_net_pct": 3.7949,
+          "total_net_pct": 7.5898,
+          "total_return_pct": 7.74,
+          "max_drawdown_pct": -1.81,
+          "sharpe": 2.14,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.3775,
+          "lo": -0.0915,
+          "hi": 0.8465,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 2,
+          "paired": 2,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 2,
+            "control_mean_net_pct": 3.4174,
+            "candidate_mean_net_pct": 3.7949,
+            "control_total_net_pct": 6.8348,
+            "candidate_total_net_pct": 7.5898,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -2.4798,
+            "candidate_median_mae_pct": -2.4798,
+            "control_median_mfe_pct": 7.5406,
+            "candidate_median_mfe_pct": 7.5406,
+            "paired_delta": {
+              "n": 2,
+              "mean": 0.3775,
+              "median": 0.3775,
+              "sign_test": {
+                "n": 2,
+                "n_pos": 2,
+                "n_neg": 0,
+                "n_zero": 0,
+                "p_value": 0.5
+              },
+              "signed_rank": {
+                "n": 2,
+                "w": 3.0,
+                "z": 0.8944,
+                "p_value": 0.371093
+              },
+              "bootstrap": {
+                "point": 0.3775,
+                "lo": 0.2285,
+                "hi": 0.5265,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": 3.4174,
+              "candidate_mean_net_pct": 3.7949,
+              "control_total_net_pct": 6.8348,
+              "candidate_total_net_pct": 7.5898,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.4798,
+              "candidate_median_mae_pct": -2.4798,
+              "control_median_mfe_pct": 7.5406,
+              "candidate_median_mfe_pct": 7.5406,
+              "paired_delta": {
+                "n": 2,
+                "mean": 0.3775,
+                "median": 0.3775,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 2,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 3.0,
+                  "z": 0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": 0.3775,
+                  "lo": 0.2285,
+                  "hi": 0.5265,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/sq.rd_lighter.json
+++ b/backtest/research/regime_1152_runs/sq.rd_lighter.json
@@ -1,0 +1,1621 @@
+{
+  "open": {
+    "name": "squeeze_momentum",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "tp_tiers": {
+          "ranging_directional": [
+            {
+              "atr_multiple": 1.0,
+              "close_fraction": 0.15,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 0.35,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 0.6,
+              "trailing_mult_after": 0.8
+            },
+            {
+              "atr_multiple": 4.5,
+              "close_fraction": 0.6,
+              "trailing_mult_after": 0.6
+            }
+          ],
+          "ranging_directional_up": [
+            {
+              "atr_multiple": 1.0,
+              "close_fraction": 0.15,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 0.35,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 0.6,
+              "trailing_mult_after": 0.8
+            },
+            {
+              "atr_multiple": 4.5,
+              "close_fraction": 0.6,
+              "trailing_mult_after": 0.6
+            }
+          ],
+          "ranging_directional_down": [
+            {
+              "atr_multiple": 1.0,
+              "close_fraction": 0.15,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 0.35,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 0.6,
+              "trailing_mult_after": 0.8
+            },
+            {
+              "atr_multiple": 4.5,
+              "close_fraction": 0.6,
+              "trailing_mult_after": 0.6
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "control_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_directional"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 32,
+          "entries": 8,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.0126,
+          "total_net_pct": -0.1008,
+          "total_return_pct": -0.15,
+          "max_drawdown_pct": -3.03,
+          "sharpe": -0.037,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 28,
+          "entries": 8,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.0053,
+          "total_net_pct": -0.0423,
+          "total_return_pct": -0.1,
+          "max_drawdown_pct": -3.23,
+          "sharpe": -0.013,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.007313,
+          "lo": -1.226759,
+          "hi": 1.242952,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 8,
+          "paired": 8,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 8,
+            "control_mean_net_pct": -0.0126,
+            "candidate_mean_net_pct": -0.0053,
+            "control_total_net_pct": -0.1008,
+            "candidate_total_net_pct": -0.0423,
+            "control_win_rate": 0.5,
+            "candidate_win_rate": 0.5,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.4796,
+            "candidate_median_mae_pct": -0.4796,
+            "control_median_mfe_pct": 0.8827,
+            "candidate_median_mfe_pct": 0.8827,
+            "paired_delta": {
+              "n": 8,
+              "mean": 0.007312,
+              "median": -0.0115,
+              "sign_test": {
+                "n": 8,
+                "n_pos": 1,
+                "n_neg": 7,
+                "n_zero": 0,
+                "p_value": 0.070312
+              },
+              "signed_rank": {
+                "n": 8,
+                "w": 8.0,
+                "z": -1.3303,
+                "p_value": 0.183431
+              },
+              "bootstrap": {
+                "point": 0.007312,
+                "lo": -0.04325,
+                "hi": 0.085375,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 6,
+              "control_mean_net_pct": 0.2082,
+              "candidate_mean_net_pct": 0.218,
+              "control_total_net_pct": 1.2494,
+              "candidate_total_net_pct": 1.3079,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.4835,
+              "candidate_median_mae_pct": -0.4835,
+              "control_median_mfe_pct": 1.0325,
+              "candidate_median_mfe_pct": 1.0325,
+              "paired_delta": {
+                "n": 6,
+                "mean": 0.00975,
+                "median": -0.03075,
+                "sign_test": {
+                  "n": 6,
+                  "n_pos": 1,
+                  "n_neg": 5,
+                  "n_zero": 0,
+                  "p_value": 0.21875
+                },
+                "signed_rank": {
+                  "n": 6,
+                  "w": 6.0,
+                  "z": -0.8386,
+                  "p_value": 0.401678
+                },
+                "bootstrap": {
+                  "point": 0.00975,
+                  "lo": -0.055917,
+                  "hi": 0.112333,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": -0.6751,
+              "candidate_mean_net_pct": -0.6751,
+              "control_total_net_pct": -1.3502,
+              "candidate_total_net_pct": -1.3502,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.4796,
+              "candidate_median_mae_pct": -0.4796,
+              "control_median_mfe_pct": 0.1483,
+              "candidate_median_mfe_pct": 0.1483,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.0,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 0,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 0,
+                  "z": -0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": -0.0,
+                  "lo": -0.0,
+                  "hi": -0.0,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 0.0,
+          "mean_net_pct": -2.8401,
+          "total_net_pct": -2.8401,
+          "total_return_pct": -2.83,
+          "max_drawdown_pct": -2.83,
+          "sharpe": -1.524,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 0.0,
+          "mean_net_pct": -2.8401,
+          "total_net_pct": -2.8401,
+          "total_return_pct": -2.83,
+          "max_drawdown_pct": -2.83,
+          "sharpe": -1.524,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.0,
+          "lo": 0.0,
+          "hi": 0.0,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": -2.8401,
+            "candidate_mean_net_pct": -2.8401,
+            "control_total_net_pct": -2.8401,
+            "candidate_total_net_pct": -2.8401,
+            "control_win_rate": 0.0,
+            "candidate_win_rate": 0.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -3.0899,
+            "candidate_median_mae_pct": -3.0899,
+            "control_median_mfe_pct": 0.3097,
+            "candidate_median_mfe_pct": 0.3097,
+            "paired_delta": {
+              "n": 1,
+              "mean": 0.0,
+              "median": 0.0,
+              "sign_test": {
+                "n": 0,
+                "n_pos": 0,
+                "n_neg": 0,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 0,
+                "w": 0.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 0.0,
+                "lo": 0.0,
+                "hi": 0.0,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_up": {
+              "n": 1,
+              "control_mean_net_pct": -2.8401,
+              "candidate_mean_net_pct": -2.8401,
+              "control_total_net_pct": -2.8401,
+              "candidate_total_net_pct": -2.8401,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -3.0899,
+              "candidate_median_mae_pct": -3.0899,
+              "control_median_mfe_pct": 0.3097,
+              "candidate_median_mfe_pct": 0.3097,
+              "paired_delta": {
+                "n": 1,
+                "mean": 0.0,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 0,
+                  "n_pos": 0,
+                  "n_neg": 0,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 0,
+                  "w": 0.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.0,
+                  "lo": 0.0,
+                  "hi": 0.0,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 19,
+          "entries": 9,
+          "win_rate": 0.4444,
+          "mean_net_pct": -0.0109,
+          "total_net_pct": -0.0984,
+          "total_return_pct": -0.17,
+          "max_drawdown_pct": -3.38,
+          "sharpe": -0.018,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 19,
+          "entries": 9,
+          "win_rate": 0.4444,
+          "mean_net_pct": -0.0507,
+          "total_net_pct": -0.4559,
+          "total_return_pct": -0.53,
+          "max_drawdown_pct": -3.75,
+          "sharpe": -0.115,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.039722,
+          "lo": -1.196447,
+          "hi": 1.09429,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 9,
+          "paired": 9,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 9,
+            "control_mean_net_pct": -0.0109,
+            "candidate_mean_net_pct": -0.0507,
+            "control_total_net_pct": -0.0984,
+            "candidate_total_net_pct": -0.4559,
+            "control_win_rate": 0.4444,
+            "candidate_win_rate": 0.4444,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.7054,
+            "candidate_median_mae_pct": -0.7054,
+            "control_median_mfe_pct": 1.3769,
+            "candidate_median_mfe_pct": 1.3769,
+            "paired_delta": {
+              "n": 9,
+              "mean": -0.039722,
+              "median": -0.0,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 2,
+                "n_neg": 7,
+                "n_zero": 0,
+                "p_value": 0.179688
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 9.0,
+                "z": -1.5401,
+                "p_value": 0.123534
+              },
+              "bootstrap": {
+                "point": -0.039722,
+                "lo": -0.077111,
+                "hi": -0.005333,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 7,
+              "control_mean_net_pct": -0.0987,
+              "candidate_mean_net_pct": -0.1345,
+              "control_total_net_pct": -0.6907,
+              "candidate_total_net_pct": -0.9417,
+              "control_win_rate": 0.4286,
+              "candidate_win_rate": 0.4286,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.7283,
+              "candidate_median_mae_pct": -0.7283,
+              "control_median_mfe_pct": 1.3769,
+              "candidate_median_mfe_pct": 1.3769,
+              "paired_delta": {
+                "n": 7,
+                "mean": -0.035857,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 7,
+                  "n_pos": 2,
+                  "n_neg": 5,
+                  "n_zero": 0,
+                  "p_value": 0.453125
+                },
+                "signed_rank": {
+                  "n": 7,
+                  "w": 7.0,
+                  "z": -1.0987,
+                  "p_value": 0.271899
+                },
+                "bootstrap": {
+                  "point": -0.035857,
+                  "lo": -0.076,
+                  "hi": -0.001714,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": 0.2961,
+              "candidate_mean_net_pct": 0.2429,
+              "control_total_net_pct": 0.5923,
+              "candidate_total_net_pct": 0.4858,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.3589,
+              "candidate_median_mae_pct": -0.3589,
+              "control_median_mfe_pct": 1.717,
+              "candidate_median_mfe_pct": 1.717,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.05325,
+                "median": -0.05325,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 0,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 0,
+                  "z": -0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": -0.05325,
+                  "lo": -0.1065,
+                  "hi": -0.0,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 13,
+          "entries": 5,
+          "win_rate": 0.6,
+          "mean_net_pct": -0.4206,
+          "total_net_pct": -2.103,
+          "total_return_pct": -2.23,
+          "max_drawdown_pct": -4.95,
+          "sharpe": -0.496,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 17,
+          "entries": 5,
+          "win_rate": 0.6,
+          "mean_net_pct": -0.505,
+          "total_net_pct": -2.525,
+          "total_return_pct": -2.63,
+          "max_drawdown_pct": -4.95,
+          "sharpe": -0.576,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.0844,
+          "lo": -3.067775,
+          "hi": 2.80412,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 5,
+          "paired": 5,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 5,
+            "control_mean_net_pct": -0.4206,
+            "candidate_mean_net_pct": -0.505,
+            "control_total_net_pct": -2.103,
+            "candidate_total_net_pct": -2.525,
+            "control_win_rate": 0.6,
+            "candidate_win_rate": 0.6,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.1631,
+            "candidate_median_mae_pct": -1.1631,
+            "control_median_mfe_pct": 2.6688,
+            "candidate_median_mfe_pct": 2.6688,
+            "paired_delta": {
+              "n": 5,
+              "mean": -0.0844,
+              "median": -0.1005,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 1,
+                "n_neg": 3,
+                "n_zero": 1,
+                "p_value": 0.625
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 1.0,
+                "z": -1.278,
+                "p_value": 0.201243
+              },
+              "bootstrap": {
+                "point": -0.0844,
+                "lo": -0.1487,
+                "hi": -0.0201,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": 1.4924,
+              "candidate_mean_net_pct": 1.3919,
+              "control_total_net_pct": 1.4924,
+              "candidate_total_net_pct": 1.3919,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1631,
+              "candidate_median_mae_pct": -1.1631,
+              "control_median_mfe_pct": 3.4385,
+              "candidate_median_mfe_pct": 3.4385,
+              "paired_delta": {
+                "n": 1,
+                "mean": -0.1005,
+                "median": -0.1005,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 0,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.1005,
+                  "lo": -0.1005,
+                  "hi": -0.1005,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 4,
+              "control_mean_net_pct": -0.8989,
+              "candidate_mean_net_pct": -0.9792,
+              "control_total_net_pct": -3.5954,
+              "candidate_total_net_pct": -3.9169,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.6923,
+              "candidate_median_mae_pct": -1.6923,
+              "control_median_mfe_pct": 2.0032,
+              "candidate_median_mfe_pct": 2.0032,
+              "paired_delta": {
+                "n": 4,
+                "mean": -0.080375,
+                "median": -0.0705,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 1,
+                  "n_neg": 2,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 1.0,
+                  "z": -0.8018,
+                  "p_value": 0.422678
+                },
+                "bootstrap": {
+                  "point": -0.080375,
+                  "lo": -0.16075,
+                  "hi": 0.0,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 7,
+          "entries": 5,
+          "win_rate": 0.4,
+          "mean_net_pct": -0.8986,
+          "total_net_pct": -4.493,
+          "total_return_pct": -4.42,
+          "max_drawdown_pct": -4.45,
+          "sharpe": -1.581,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 10,
+          "entries": 5,
+          "win_rate": 0.0,
+          "mean_net_pct": -0.9424,
+          "total_net_pct": -4.712,
+          "total_return_pct": -4.63,
+          "max_drawdown_pct": -4.63,
+          "sharpe": -1.591,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.0438,
+          "lo": -1.189308,
+          "hi": 1.0974,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 5,
+          "paired": 5,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 5,
+            "control_mean_net_pct": -0.8986,
+            "candidate_mean_net_pct": -0.9424,
+            "control_total_net_pct": -4.493,
+            "candidate_total_net_pct": -4.712,
+            "control_win_rate": 0.4,
+            "candidate_win_rate": 0.0,
+            "delta_win_rate": -0.4,
+            "control_median_mae_pct": -0.6515,
+            "candidate_median_mae_pct": -0.6515,
+            "control_median_mfe_pct": 0.2588,
+            "candidate_median_mfe_pct": 0.2588,
+            "paired_delta": {
+              "n": 5,
+              "mean": -0.0438,
+              "median": -0.0,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 1,
+                "n_neg": 3,
+                "n_zero": 1,
+                "p_value": 0.625
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 2.0,
+                "z": -0.9129,
+                "p_value": 0.36131
+              },
+              "bootstrap": {
+                "point": -0.0438,
+                "lo": -0.103,
+                "hi": 0.0,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": -0.2914,
+              "candidate_mean_net_pct": -0.3269,
+              "control_total_net_pct": -0.5827,
+              "candidate_total_net_pct": -0.6537,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": -0.5,
+              "control_median_mae_pct": -0.5242,
+              "candidate_median_mae_pct": -0.5242,
+              "control_median_mfe_pct": 0.7706,
+              "candidate_median_mfe_pct": 0.7706,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.0355,
+                "median": -0.0355,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 0,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 0,
+                  "z": -0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": -0.0355,
+                  "lo": -0.071,
+                  "hi": -0.0,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 3,
+              "control_mean_net_pct": -1.3034,
+              "candidate_mean_net_pct": -1.3528,
+              "control_total_net_pct": -3.9103,
+              "candidate_total_net_pct": -4.0583,
+              "control_win_rate": 0.3333,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": -0.3333,
+              "control_median_mae_pct": -1.9564,
+              "candidate_median_mae_pct": -1.9564,
+              "control_median_mfe_pct": 0.2588,
+              "candidate_median_mfe_pct": 0.2588,
+              "paired_delta": {
+                "n": 3,
+                "mean": -0.049333,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.049333,
+                  "lo": -0.148,
+                  "hi": 0.0,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 6,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 1.2099,
+          "total_net_pct": 1.2099,
+          "total_return_pct": 1.21,
+          "max_drawdown_pct": -1.64,
+          "sharpe": 0.564,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 2,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 1.0619,
+          "total_net_pct": 1.0619,
+          "total_return_pct": 1.06,
+          "max_drawdown_pct": -1.85,
+          "sharpe": 0.471,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.148,
+          "lo": -0.148,
+          "hi": -0.148,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": 1.2099,
+            "candidate_mean_net_pct": 1.0619,
+            "control_total_net_pct": 1.2099,
+            "candidate_total_net_pct": 1.0619,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.6872,
+            "candidate_median_mae_pct": -0.6872,
+            "control_median_mfe_pct": 4.4447,
+            "candidate_median_mfe_pct": 4.4447,
+            "paired_delta": {
+              "n": 1,
+              "mean": -0.148,
+              "median": -0.148,
+              "sign_test": {
+                "n": 1,
+                "n_pos": 0,
+                "n_neg": 1,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 1,
+                "w": 0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": -0.148,
+                "lo": -0.148,
+                "hi": -0.148,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": 1.2099,
+              "candidate_mean_net_pct": 1.0619,
+              "control_total_net_pct": 1.2099,
+              "candidate_total_net_pct": 1.0619,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.6872,
+              "candidate_median_mae_pct": -0.6872,
+              "control_median_mfe_pct": 4.4447,
+              "candidate_median_mfe_pct": 4.4447,
+              "paired_delta": {
+                "n": 1,
+                "mean": -0.148,
+                "median": -0.148,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 0,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.148,
+                  "lo": -0.148,
+                  "hi": -0.148,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 7,
+          "entries": 4,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.5239,
+          "total_net_pct": -2.0954,
+          "total_return_pct": -2.11,
+          "max_drawdown_pct": -3.61,
+          "sharpe": -1.152,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 7,
+          "entries": 4,
+          "win_rate": 0.5,
+          "mean_net_pct": -0.6034,
+          "total_net_pct": -2.4134,
+          "total_return_pct": -2.42,
+          "max_drawdown_pct": -3.91,
+          "sharpe": -1.326,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.0795,
+          "lo": -1.846,
+          "hi": 1.68025,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 4,
+          "paired": 4,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 4,
+            "control_mean_net_pct": -0.5239,
+            "candidate_mean_net_pct": -0.6034,
+            "control_total_net_pct": -2.0954,
+            "candidate_total_net_pct": -2.4134,
+            "control_win_rate": 0.5,
+            "candidate_win_rate": 0.5,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.4455,
+            "candidate_median_mae_pct": -0.4455,
+            "control_median_mfe_pct": 1.6099,
+            "candidate_median_mfe_pct": 1.6099,
+            "paired_delta": {
+              "n": 4,
+              "mean": -0.0795,
+              "median": -0.089,
+              "sign_test": {
+                "n": 4,
+                "n_pos": 0,
+                "n_neg": 4,
+                "n_zero": 0,
+                "p_value": 0.125
+              },
+              "signed_rank": {
+                "n": 4,
+                "w": 0,
+                "z": -1.6432,
+                "p_value": 0.100348
+              },
+              "bootstrap": {
+                "point": -0.0795,
+                "lo": -0.1395,
+                "hi": -0.0195,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": 0.0774,
+              "candidate_mean_net_pct": -0.0116,
+              "control_total_net_pct": 0.1548,
+              "candidate_total_net_pct": -0.0232,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.4455,
+              "candidate_median_mae_pct": -0.4455,
+              "control_median_mfe_pct": 1.6099,
+              "candidate_median_mfe_pct": 1.6099,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.089,
+                "median": -0.089,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 0,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 0,
+                  "z": -0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": -0.089,
+                  "lo": -0.139,
+                  "hi": -0.039,
+                  "n_resamples": 10000
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": -1.1251,
+              "candidate_mean_net_pct": -1.1951,
+              "control_total_net_pct": -2.2502,
+              "candidate_total_net_pct": -2.3902,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.3179,
+              "candidate_median_mae_pct": -1.3179,
+              "control_median_mfe_pct": 1.1176,
+              "candidate_median_mfe_pct": 1.1176,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.07,
+                "median": -0.07,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 0,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 0.5
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 0,
+                  "z": -0.8944,
+                  "p_value": 0.371093
+                },
+                "bootstrap": {
+                  "point": -0.07,
+                  "lo": -0.14,
+                  "hi": -0.0,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 2,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 1.8824,
+          "total_net_pct": 1.8824,
+          "total_return_pct": 1.88,
+          "max_drawdown_pct": -2.15,
+          "sharpe": 0.749,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 2,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 1.6854,
+          "total_net_pct": 1.6854,
+          "total_return_pct": 1.69,
+          "max_drawdown_pct": -2.44,
+          "sharpe": 0.635,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.197,
+          "lo": -0.197,
+          "hi": -0.197,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": 1.8824,
+            "candidate_mean_net_pct": 1.6854,
+            "control_total_net_pct": 1.8824,
+            "candidate_total_net_pct": 1.6854,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.1653,
+            "candidate_median_mae_pct": -1.1653,
+            "control_median_mfe_pct": 5.7849,
+            "candidate_median_mfe_pct": 5.7849,
+            "paired_delta": {
+              "n": 1,
+              "mean": -0.197,
+              "median": -0.197,
+              "sign_test": {
+                "n": 1,
+                "n_pos": 0,
+                "n_neg": 1,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 1,
+                "w": 0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": -0.197,
+                "lo": -0.197,
+                "hi": -0.197,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_up": {
+              "n": 1,
+              "control_mean_net_pct": 1.8824,
+              "candidate_mean_net_pct": 1.6854,
+              "control_total_net_pct": 1.8824,
+              "candidate_total_net_pct": 1.6854,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1653,
+              "candidate_median_mae_pct": -1.1653,
+              "control_median_mfe_pct": 5.7849,
+              "candidate_median_mfe_pct": 5.7849,
+              "paired_delta": {
+                "n": 1,
+                "mean": -0.197,
+                "median": -0.197,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 0,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.197,
+                  "lo": -0.197,
+                  "hi": -0.197,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.9559,
+          "total_net_pct": -2.8678,
+          "total_return_pct": -2.87,
+          "max_drawdown_pct": -4.6,
+          "sharpe": -0.698,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 6,
+          "entries": 3,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.9233,
+          "total_net_pct": -2.7698,
+          "total_return_pct": -2.78,
+          "max_drawdown_pct": -4.6,
+          "sharpe": -0.663,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.032667,
+          "lo": -2.695,
+          "hi": 2.760333,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": -0.9559,
+            "candidate_mean_net_pct": -0.9233,
+            "control_total_net_pct": -2.8678,
+            "candidate_total_net_pct": -2.7698,
+            "control_win_rate": 0.3333,
+            "candidate_win_rate": 0.3333,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.4988,
+            "candidate_median_mae_pct": -1.4988,
+            "control_median_mfe_pct": 2.6995,
+            "candidate_median_mfe_pct": 2.6995,
+            "paired_delta": {
+              "n": 3,
+              "mean": 0.032667,
+              "median": 0.0,
+              "sign_test": {
+                "n": 2,
+                "n_pos": 2,
+                "n_neg": 0,
+                "n_zero": 1,
+                "p_value": 0.5
+              },
+              "signed_rank": {
+                "n": 2,
+                "w": 3.0,
+                "z": 0.8944,
+                "p_value": 0.371093
+              },
+              "bootstrap": {
+                "point": 0.032667,
+                "lo": 0.0,
+                "hi": 0.098,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 1,
+              "control_mean_net_pct": -1.5301,
+              "candidate_mean_net_pct": -1.5301,
+              "control_total_net_pct": -1.5301,
+              "candidate_total_net_pct": -1.5301,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.4988,
+              "candidate_median_mae_pct": -1.4988,
+              "control_median_mfe_pct": 0.265,
+              "candidate_median_mfe_pct": 0.265,
+              "paired_delta": {
+                "n": 1,
+                "mean": 0.0,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.0,
+                  "lo": 0.0,
+                  "hi": 0.0,
+                  "n_resamples": 0
+                }
+              }
+            },
+            "ranging_directional_up": {
+              "n": 2,
+              "control_mean_net_pct": -0.6689,
+              "candidate_mean_net_pct": -0.6199,
+              "control_total_net_pct": -1.3377,
+              "candidate_total_net_pct": -1.2397,
+              "control_win_rate": 0.5,
+              "candidate_win_rate": 0.5,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.8361,
+              "candidate_median_mae_pct": -1.8361,
+              "control_median_mfe_pct": 3.4634,
+              "candidate_median_mfe_pct": 3.4634,
+              "paired_delta": {
+                "n": 2,
+                "mean": 0.049,
+                "median": 0.049,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.049,
+                  "lo": 0.0,
+                  "hi": 0.098,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 6,
+          "entries": 2,
+          "win_rate": 1.0,
+          "mean_net_pct": 3.4174,
+          "total_net_pct": 6.8348,
+          "total_return_pct": 6.95,
+          "max_drawdown_pct": -2.59,
+          "sharpe": 1.849,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 8,
+          "entries": 2,
+          "win_rate": 1.0,
+          "mean_net_pct": 3.3066,
+          "total_net_pct": 6.6133,
+          "total_return_pct": 6.72,
+          "max_drawdown_pct": -2.99,
+          "sharpe": 1.729,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.11075,
+          "lo": -0.317,
+          "hi": 0.0955,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 2,
+          "paired": 2,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 2,
+            "control_mean_net_pct": 3.4174,
+            "candidate_mean_net_pct": 3.3066,
+            "control_total_net_pct": 6.8348,
+            "candidate_total_net_pct": 6.6133,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -2.4798,
+            "candidate_median_mae_pct": -2.4798,
+            "control_median_mfe_pct": 7.5406,
+            "candidate_median_mfe_pct": 7.5406,
+            "paired_delta": {
+              "n": 2,
+              "mean": -0.11075,
+              "median": -0.11075,
+              "sign_test": {
+                "n": 2,
+                "n_pos": 1,
+                "n_neg": 1,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 2,
+                "w": 1.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": -0.11075,
+                "lo": -0.2245,
+                "hi": 0.003,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_directional_down": {
+              "n": 2,
+              "control_mean_net_pct": 3.4174,
+              "candidate_mean_net_pct": 3.3066,
+              "control_total_net_pct": 6.8348,
+              "candidate_total_net_pct": 6.6133,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.4798,
+              "candidate_median_mae_pct": -2.4798,
+              "control_median_mfe_pct": 7.5406,
+              "candidate_median_mfe_pct": 7.5406,
+              "paired_delta": {
+                "n": 2,
+                "mean": -0.11075,
+                "median": -0.11075,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": -0.11075,
+                  "lo": -0.2245,
+                  "hi": 0.003,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/sq.rq_lighter_early.json
+++ b/backtest/research/regime_1152_runs/sq.rq_lighter_early.json
@@ -1,0 +1,554 @@
+{
+  "open": {
+    "name": "squeeze_momentum",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "tp_tiers": {
+          "ranging_quiet": [
+            {
+              "atr_multiple": 0.75,
+              "close_fraction": 0.25,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 1.5,
+              "close_fraction": 0.5,
+              "trailing_mult_after": 0.75
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 1.0,
+              "trailing_mult_after": 0.75
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "control_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_quiet"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/sq.rq_volatile_geometry.json
+++ b/backtest/research/regime_1152_runs/sq.rq_volatile_geometry.json
@@ -1,0 +1,554 @@
+{
+  "open": {
+    "name": "squeeze_momentum",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "tp_tiers": {
+          "ranging_quiet": [
+            {
+              "atr_multiple": 1.0,
+              "close_fraction": 0.4,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 0.8,
+              "trailing_mult_after": 0.75
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 1.0,
+              "trailing_mult_after": 0.75
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "control_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_quiet"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/sq.rv_quiet_geometry.json
+++ b/backtest/research/regime_1152_runs/sq.rv_quiet_geometry.json
@@ -1,0 +1,1423 @@
+{
+  "open": {
+    "name": "squeeze_momentum",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "tp_tiers": {
+          "ranging_volatile": [
+            {
+              "atr_multiple": 0.75,
+              "close_fraction": 0.4,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 1.5,
+              "close_fraction": 0.8,
+              "trailing_mult_after": 0.75
+            },
+            {
+              "atr_multiple": 2.0,
+              "close_fraction": 1.0,
+              "trailing_mult_after": 0.75
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "control_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_volatile"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 30,
+          "entries": 18,
+          "win_rate": 0.2778,
+          "mean_net_pct": -0.1654,
+          "total_net_pct": -2.9778,
+          "total_return_pct": -3.01,
+          "max_drawdown_pct": -4.14,
+          "sharpe": -0.8,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 32,
+          "entries": 18,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.181,
+          "total_net_pct": -3.2578,
+          "total_return_pct": -3.27,
+          "max_drawdown_pct": -4.88,
+          "sharpe": -0.91,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.015556,
+          "lo": -0.637897,
+          "hi": 0.575364,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 18,
+          "paired": 18,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 18,
+            "control_mean_net_pct": -0.1654,
+            "candidate_mean_net_pct": -0.181,
+            "control_total_net_pct": -2.9778,
+            "candidate_total_net_pct": -3.2578,
+            "control_win_rate": 0.2778,
+            "candidate_win_rate": 0.3333,
+            "delta_win_rate": 0.0555,
+            "control_median_mae_pct": -0.4348,
+            "candidate_median_mae_pct": -0.3946,
+            "control_median_mfe_pct": 0.4703,
+            "candidate_median_mfe_pct": 0.4703,
+            "paired_delta": {
+              "n": 18,
+              "mean": -0.015556,
+              "median": -0.0,
+              "sign_test": {
+                "n": 17,
+                "n_pos": 8,
+                "n_neg": 9,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 17,
+                "w": 67.0,
+                "z": -0.426,
+                "p_value": 0.670077
+              },
+              "bootstrap": {
+                "point": -0.015556,
+                "lo": -0.139783,
+                "hi": 0.123556,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 18,
+              "control_mean_net_pct": -0.1654,
+              "candidate_mean_net_pct": -0.181,
+              "control_total_net_pct": -2.9778,
+              "candidate_total_net_pct": -3.2578,
+              "control_win_rate": 0.2778,
+              "candidate_win_rate": 0.3333,
+              "delta_win_rate": 0.0555,
+              "control_median_mae_pct": -0.4348,
+              "candidate_median_mae_pct": -0.3946,
+              "control_median_mfe_pct": 0.4703,
+              "candidate_median_mfe_pct": 0.4703,
+              "paired_delta": {
+                "n": 18,
+                "mean": -0.015556,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 17,
+                  "n_pos": 8,
+                  "n_neg": 9,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 17,
+                  "w": 67.0,
+                  "z": -0.426,
+                  "p_value": 0.670077
+                },
+                "bootstrap": {
+                  "point": -0.015556,
+                  "lo": -0.139783,
+                  "hi": 0.123556,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 12,
+          "entries": 7,
+          "win_rate": 0.4286,
+          "mean_net_pct": -0.4132,
+          "total_net_pct": -2.8927,
+          "total_return_pct": -2.93,
+          "max_drawdown_pct": -5.52,
+          "sharpe": -0.902,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 11,
+          "entries": 7,
+          "win_rate": 0.4286,
+          "mean_net_pct": -0.4512,
+          "total_net_pct": -3.1587,
+          "total_return_pct": -3.19,
+          "max_drawdown_pct": -5.43,
+          "sharpe": -0.992,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.038,
+          "lo": -1.690321,
+          "hi": 1.592893,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 7,
+          "paired": 7,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 7,
+            "control_mean_net_pct": -0.4132,
+            "candidate_mean_net_pct": -0.4512,
+            "control_total_net_pct": -2.8927,
+            "candidate_total_net_pct": -3.1587,
+            "control_win_rate": 0.4286,
+            "candidate_win_rate": 0.4286,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.8956,
+            "candidate_median_mae_pct": -0.8956,
+            "control_median_mfe_pct": 1.3514,
+            "candidate_median_mfe_pct": 1.3514,
+            "paired_delta": {
+              "n": 7,
+              "mean": -0.038,
+              "median": 0.0,
+              "sign_test": {
+                "n": 7,
+                "n_pos": 4,
+                "n_neg": 3,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 7,
+                "w": 18.0,
+                "z": 0.5916,
+                "p_value": 0.554113
+              },
+              "bootstrap": {
+                "point": -0.038,
+                "lo": -0.122571,
+                "hi": 0.008571,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 7,
+              "control_mean_net_pct": -0.4132,
+              "candidate_mean_net_pct": -0.4512,
+              "control_total_net_pct": -2.8927,
+              "candidate_total_net_pct": -3.1587,
+              "control_win_rate": 0.4286,
+              "candidate_win_rate": 0.4286,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.8956,
+              "candidate_median_mae_pct": -0.8956,
+              "control_median_mfe_pct": 1.3514,
+              "candidate_median_mfe_pct": 1.3514,
+              "paired_delta": {
+                "n": 7,
+                "mean": -0.038,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 7,
+                  "n_pos": 4,
+                  "n_neg": 3,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 7,
+                  "w": 18.0,
+                  "z": 0.5916,
+                  "p_value": 0.554113
+                },
+                "bootstrap": {
+                  "point": -0.038,
+                  "lo": -0.122571,
+                  "hi": 0.008571,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 29,
+          "entries": 20,
+          "win_rate": 0.25,
+          "mean_net_pct": -0.7389,
+          "total_net_pct": -14.778,
+          "total_return_pct": -13.95,
+          "max_drawdown_pct": -14.76,
+          "sharpe": -2.521,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 31,
+          "entries": 20,
+          "win_rate": 0.35,
+          "mean_net_pct": -0.6926,
+          "total_net_pct": -13.852,
+          "total_return_pct": -13.14,
+          "max_drawdown_pct": -13.95,
+          "sharpe": -2.448,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.0463,
+          "lo": -0.830727,
+          "hi": 0.89421,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 20,
+          "paired": 20,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 20,
+            "control_mean_net_pct": -0.7389,
+            "candidate_mean_net_pct": -0.6926,
+            "control_total_net_pct": -14.778,
+            "candidate_total_net_pct": -13.852,
+            "control_win_rate": 0.25,
+            "candidate_win_rate": 0.35,
+            "delta_win_rate": 0.1,
+            "control_median_mae_pct": -1.1531,
+            "candidate_median_mae_pct": -1.1014,
+            "control_median_mfe_pct": 0.6345,
+            "candidate_median_mfe_pct": 0.6345,
+            "paired_delta": {
+              "n": 20,
+              "mean": 0.0463,
+              "median": -0.0,
+              "sign_test": {
+                "n": 20,
+                "n_pos": 9,
+                "n_neg": 11,
+                "n_zero": 0,
+                "p_value": 0.823803
+              },
+              "signed_rank": {
+                "n": 20,
+                "w": 99.0,
+                "z": -0.2053,
+                "p_value": 0.837315
+              },
+              "bootstrap": {
+                "point": 0.0463,
+                "lo": -0.104103,
+                "hi": 0.216805,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 20,
+              "control_mean_net_pct": -0.7389,
+              "candidate_mean_net_pct": -0.6926,
+              "control_total_net_pct": -14.778,
+              "candidate_total_net_pct": -13.852,
+              "control_win_rate": 0.25,
+              "candidate_win_rate": 0.35,
+              "delta_win_rate": 0.1,
+              "control_median_mae_pct": -1.1531,
+              "candidate_median_mae_pct": -1.1014,
+              "control_median_mfe_pct": 0.6345,
+              "candidate_median_mfe_pct": 0.6345,
+              "paired_delta": {
+                "n": 20,
+                "mean": 0.0463,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 20,
+                  "n_pos": 9,
+                  "n_neg": 11,
+                  "n_zero": 0,
+                  "p_value": 0.823803
+                },
+                "signed_rank": {
+                  "n": 20,
+                  "w": 99.0,
+                  "z": -0.2053,
+                  "p_value": 0.837315
+                },
+                "bootstrap": {
+                  "point": 0.0463,
+                  "lo": -0.104103,
+                  "hi": 0.216805,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 6,
+          "entries": 3,
+          "win_rate": 1.0,
+          "mean_net_pct": 2.6959,
+          "total_net_pct": 8.0877,
+          "total_return_pct": 8.23,
+          "max_drawdown_pct": -2.57,
+          "sharpe": 1.59,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 6,
+          "entries": 3,
+          "win_rate": 1.0,
+          "mean_net_pct": 2.7959,
+          "total_net_pct": 8.3877,
+          "total_return_pct": 8.54,
+          "max_drawdown_pct": -2.57,
+          "sharpe": 1.65,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.1,
+          "lo": -3.536,
+          "hi": 3.736,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": 2.6959,
+            "candidate_mean_net_pct": 2.7959,
+            "control_total_net_pct": 8.0877,
+            "candidate_total_net_pct": 8.3877,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.4476,
+            "candidate_median_mae_pct": -1.4476,
+            "control_median_mfe_pct": 5.3739,
+            "candidate_median_mfe_pct": 5.3739,
+            "paired_delta": {
+              "n": 3,
+              "mean": 0.1,
+              "median": -0.0,
+              "sign_test": {
+                "n": 3,
+                "n_pos": 1,
+                "n_neg": 2,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 3,
+                "w": 3.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 0.1,
+                "lo": -0.0,
+                "hi": 0.3,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 3,
+              "control_mean_net_pct": 2.6959,
+              "candidate_mean_net_pct": 2.7959,
+              "control_total_net_pct": 8.0877,
+              "candidate_total_net_pct": 8.3877,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.4476,
+              "candidate_median_mae_pct": -1.4476,
+              "control_median_mfe_pct": 5.3739,
+              "candidate_median_mfe_pct": 5.3739,
+              "paired_delta": {
+                "n": 3,
+                "mean": 0.1,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 1,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 3.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.1,
+                  "lo": -0.0,
+                  "hi": 0.3,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 37,
+          "entries": 17,
+          "win_rate": 0.5294,
+          "mean_net_pct": -0.1574,
+          "total_net_pct": -2.6757,
+          "total_return_pct": -2.96,
+          "max_drawdown_pct": -9.46,
+          "sharpe": -0.426,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 33,
+          "entries": 17,
+          "win_rate": 0.5294,
+          "mean_net_pct": -0.0745,
+          "total_net_pct": -1.2657,
+          "total_return_pct": -1.54,
+          "max_drawdown_pct": -9.46,
+          "sharpe": -0.217,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.082941,
+          "lo": -1.210974,
+          "hi": 1.329321,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 17,
+          "paired": 17,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 17,
+            "control_mean_net_pct": -0.1574,
+            "candidate_mean_net_pct": -0.0745,
+            "control_total_net_pct": -2.6757,
+            "candidate_total_net_pct": -1.2657,
+            "control_win_rate": 0.5294,
+            "candidate_win_rate": 0.5294,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.7668,
+            "candidate_median_mae_pct": -0.7668,
+            "control_median_mfe_pct": 1.1949,
+            "candidate_median_mfe_pct": 1.1949,
+            "paired_delta": {
+              "n": 17,
+              "mean": 0.082941,
+              "median": 0.0,
+              "sign_test": {
+                "n": 16,
+                "n_pos": 10,
+                "n_neg": 6,
+                "n_zero": 1,
+                "p_value": 0.454498
+              },
+              "signed_rank": {
+                "n": 16,
+                "w": 80.0,
+                "z": 0.5947,
+                "p_value": 0.552077
+              },
+              "bootstrap": {
+                "point": 0.082941,
+                "lo": -0.07165,
+                "hi": 0.266241,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 17,
+              "control_mean_net_pct": -0.1574,
+              "candidate_mean_net_pct": -0.0745,
+              "control_total_net_pct": -2.6757,
+              "candidate_total_net_pct": -1.2657,
+              "control_win_rate": 0.5294,
+              "candidate_win_rate": 0.5294,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.7668,
+              "candidate_median_mae_pct": -0.7668,
+              "control_median_mfe_pct": 1.1949,
+              "candidate_median_mfe_pct": 1.1949,
+              "paired_delta": {
+                "n": 17,
+                "mean": 0.082941,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 16,
+                  "n_pos": 10,
+                  "n_neg": 6,
+                  "n_zero": 1,
+                  "p_value": 0.454498
+                },
+                "signed_rank": {
+                  "n": 16,
+                  "w": 80.0,
+                  "z": 0.5947,
+                  "p_value": 0.552077
+                },
+                "bootstrap": {
+                  "point": 0.082941,
+                  "lo": -0.07165,
+                  "hi": 0.266241,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 7,
+          "entries": 3,
+          "win_rate": 0.6667,
+          "mean_net_pct": 2.7046,
+          "total_net_pct": 8.1137,
+          "total_return_pct": 8.24,
+          "max_drawdown_pct": -3.5,
+          "sharpe": 1.512,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 0.6667,
+          "mean_net_pct": 3.0572,
+          "total_net_pct": 9.1717,
+          "total_return_pct": 9.34,
+          "max_drawdown_pct": -3.51,
+          "sharpe": 1.69,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.352667,
+          "lo": -3.835333,
+          "hi": 4.524417,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": 2.7046,
+            "candidate_mean_net_pct": 3.0572,
+            "control_total_net_pct": 8.1137,
+            "candidate_total_net_pct": 9.1717,
+            "control_win_rate": 0.6667,
+            "candidate_win_rate": 0.6667,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.7129,
+            "candidate_median_mae_pct": -1.7129,
+            "control_median_mfe_pct": 4.5418,
+            "candidate_median_mfe_pct": 4.5418,
+            "paired_delta": {
+              "n": 3,
+              "mean": 0.352667,
+              "median": 0.512,
+              "sign_test": {
+                "n": 3,
+                "n_pos": 2,
+                "n_neg": 1,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 3,
+                "w": 5.0,
+                "z": 0.8018,
+                "p_value": 0.422678
+              },
+              "bootstrap": {
+                "point": 0.352667,
+                "lo": -0.016,
+                "hi": 0.562,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 3,
+              "control_mean_net_pct": 2.7046,
+              "candidate_mean_net_pct": 3.0572,
+              "control_total_net_pct": 8.1137,
+              "candidate_total_net_pct": 9.1717,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.7129,
+              "candidate_median_mae_pct": -1.7129,
+              "control_median_mfe_pct": 4.5418,
+              "candidate_median_mfe_pct": 4.5418,
+              "paired_delta": {
+                "n": 3,
+                "mean": 0.352667,
+                "median": 0.512,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 2,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 5.0,
+                  "z": 0.8018,
+                  "p_value": 0.422678
+                },
+                "bootstrap": {
+                  "point": 0.352667,
+                  "lo": -0.016,
+                  "hi": 0.562,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 23,
+          "entries": 12,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.6028,
+          "total_net_pct": -7.2332,
+          "total_return_pct": -7.04,
+          "max_drawdown_pct": -7.04,
+          "sharpe": -1.934,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 19,
+          "entries": 12,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.5333,
+          "total_net_pct": -6.3992,
+          "total_return_pct": -6.26,
+          "max_drawdown_pct": -6.26,
+          "sharpe": -1.73,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.0695,
+          "lo": -0.647013,
+          "hi": 0.795333,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 12,
+          "paired": 12,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 12,
+            "control_mean_net_pct": -0.6028,
+            "candidate_mean_net_pct": -0.5333,
+            "control_total_net_pct": -7.2332,
+            "candidate_total_net_pct": -6.3992,
+            "control_win_rate": 0.3333,
+            "candidate_win_rate": 0.3333,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.0454,
+            "candidate_median_mae_pct": -1.0454,
+            "control_median_mfe_pct": 0.3923,
+            "candidate_median_mfe_pct": 0.3923,
+            "paired_delta": {
+              "n": 12,
+              "mean": 0.0695,
+              "median": 0.0,
+              "sign_test": {
+                "n": 11,
+                "n_pos": 6,
+                "n_neg": 5,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 11,
+                "w": 40.0,
+                "z": 0.5779,
+                "p_value": 0.563318
+              },
+              "bootstrap": {
+                "point": 0.0695,
+                "lo": -0.018833,
+                "hi": 0.174333,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 12,
+              "control_mean_net_pct": -0.6028,
+              "candidate_mean_net_pct": -0.5333,
+              "control_total_net_pct": -7.2332,
+              "candidate_total_net_pct": -6.3992,
+              "control_win_rate": 0.3333,
+              "candidate_win_rate": 0.3333,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.0454,
+              "candidate_median_mae_pct": -1.0454,
+              "control_median_mfe_pct": 0.3923,
+              "candidate_median_mfe_pct": 0.3923,
+              "paired_delta": {
+                "n": 12,
+                "mean": 0.0695,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 11,
+                  "n_pos": 6,
+                  "n_neg": 5,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 11,
+                  "w": 40.0,
+                  "z": 0.5779,
+                  "p_value": 0.563318
+                },
+                "bootstrap": {
+                  "point": 0.0695,
+                  "lo": -0.018833,
+                  "hi": 0.174333,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 6,
+          "entries": 3,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.5252,
+          "total_net_pct": 1.5757,
+          "total_return_pct": 1.57,
+          "max_drawdown_pct": -3.23,
+          "sharpe": 0.695,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 8,
+          "entries": 3,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.8186,
+          "total_net_pct": 2.4557,
+          "total_return_pct": 2.47,
+          "max_drawdown_pct": -2.38,
+          "sharpe": 1.126,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.293333,
+          "lo": -1.028667,
+          "hi": 1.735333,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": 0.5252,
+            "candidate_mean_net_pct": 0.8186,
+            "control_total_net_pct": 1.5757,
+            "candidate_total_net_pct": 2.4557,
+            "control_win_rate": 0.6667,
+            "candidate_win_rate": 0.6667,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.042,
+            "candidate_median_mae_pct": -0.8461,
+            "control_median_mfe_pct": 1.8138,
+            "candidate_median_mfe_pct": 1.8138,
+            "paired_delta": {
+              "n": 3,
+              "mean": 0.293333,
+              "median": 0.47,
+              "sign_test": {
+                "n": 3,
+                "n_pos": 2,
+                "n_neg": 1,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 3,
+                "w": 5.0,
+                "z": 0.8018,
+                "p_value": 0.422678
+              },
+              "bootstrap": {
+                "point": 0.293333,
+                "lo": -0.46,
+                "hi": 0.87,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 3,
+              "control_mean_net_pct": 0.5252,
+              "candidate_mean_net_pct": 0.8186,
+              "control_total_net_pct": 1.5757,
+              "candidate_total_net_pct": 2.4557,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.042,
+              "candidate_median_mae_pct": -0.8461,
+              "control_median_mfe_pct": 1.8138,
+              "candidate_median_mfe_pct": 1.8138,
+              "paired_delta": {
+                "n": 3,
+                "mean": 0.293333,
+                "median": 0.47,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 2,
+                  "n_neg": 1,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 5.0,
+                  "z": 0.8018,
+                  "p_value": 0.422678
+                },
+                "bootstrap": {
+                  "point": 0.293333,
+                  "lo": -0.46,
+                  "hi": 0.87,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 12,
+          "entries": 10,
+          "win_rate": 0.2,
+          "mean_net_pct": -1.0569,
+          "total_net_pct": -10.569,
+          "total_return_pct": -10.12,
+          "max_drawdown_pct": -11.67,
+          "sharpe": -2.123,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 14,
+          "entries": 10,
+          "win_rate": 0.2,
+          "mean_net_pct": -0.9951,
+          "total_net_pct": -9.951,
+          "total_return_pct": -9.56,
+          "max_drawdown_pct": -10.86,
+          "sharpe": -2.13,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.0618,
+          "lo": -0.986425,
+          "hi": 1.0988,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 10,
+          "paired": 10,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 10,
+            "control_mean_net_pct": -1.0569,
+            "candidate_mean_net_pct": -0.9951,
+            "control_total_net_pct": -10.569,
+            "candidate_total_net_pct": -9.951,
+            "control_win_rate": 0.2,
+            "candidate_win_rate": 0.2,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.2887,
+            "candidate_median_mae_pct": -1.2887,
+            "control_median_mfe_pct": 0.208,
+            "candidate_median_mfe_pct": 0.208,
+            "paired_delta": {
+              "n": 10,
+              "mean": 0.0618,
+              "median": 0.0,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 5,
+                "n_neg": 4,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 27.0,
+                "z": 0.4739,
+                "p_value": 0.635586
+              },
+              "bootstrap": {
+                "point": 0.0618,
+                "lo": -0.0846,
+                "hi": 0.27,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 10,
+              "control_mean_net_pct": -1.0569,
+              "candidate_mean_net_pct": -0.9951,
+              "control_total_net_pct": -10.569,
+              "candidate_total_net_pct": -9.951,
+              "control_win_rate": 0.2,
+              "candidate_win_rate": 0.2,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.2887,
+              "candidate_median_mae_pct": -1.2887,
+              "control_median_mfe_pct": 0.208,
+              "candidate_median_mfe_pct": 0.208,
+              "paired_delta": {
+                "n": 10,
+                "mean": 0.0618,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 9,
+                  "n_pos": 5,
+                  "n_neg": 4,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 9,
+                  "w": 27.0,
+                  "z": 0.4739,
+                  "p_value": 0.635586
+                },
+                "bootstrap": {
+                  "point": 0.0618,
+                  "lo": -0.0846,
+                  "hi": 0.27,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 16,
+          "entries": 9,
+          "win_rate": 0.5556,
+          "mean_net_pct": 0.2795,
+          "total_net_pct": 2.5151,
+          "total_return_pct": 2.44,
+          "max_drawdown_pct": -2.84,
+          "sharpe": 0.757,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 15,
+          "entries": 9,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.1523,
+          "total_net_pct": 1.3711,
+          "total_return_pct": 1.3,
+          "max_drawdown_pct": -2.84,
+          "sharpe": 0.414,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.127111,
+          "lo": -1.355117,
+          "hi": 1.12675,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 9,
+          "paired": 9,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 9,
+            "control_mean_net_pct": 0.2795,
+            "candidate_mean_net_pct": 0.1523,
+            "control_total_net_pct": 2.5151,
+            "candidate_total_net_pct": 1.3711,
+            "control_win_rate": 0.5556,
+            "candidate_win_rate": 0.6667,
+            "delta_win_rate": 0.1111,
+            "control_median_mae_pct": -0.8156,
+            "candidate_median_mae_pct": -0.8156,
+            "control_median_mfe_pct": 1.469,
+            "candidate_median_mfe_pct": 1.469,
+            "paired_delta": {
+              "n": 9,
+              "mean": -0.127111,
+              "median": -0.052,
+              "sign_test": {
+                "n": 8,
+                "n_pos": 1,
+                "n_neg": 7,
+                "n_zero": 1,
+                "p_value": 0.070312
+              },
+              "signed_rank": {
+                "n": 8,
+                "w": 6.0,
+                "z": -1.6103,
+                "p_value": 0.107328
+              },
+              "bootstrap": {
+                "point": -0.127111,
+                "lo": -0.344,
+                "hi": 0.094222,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 9,
+              "control_mean_net_pct": 0.2795,
+              "candidate_mean_net_pct": 0.1523,
+              "control_total_net_pct": 2.5151,
+              "candidate_total_net_pct": 1.3711,
+              "control_win_rate": 0.5556,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": 0.1111,
+              "control_median_mae_pct": -0.8156,
+              "candidate_median_mae_pct": -0.8156,
+              "control_median_mfe_pct": 1.469,
+              "candidate_median_mfe_pct": 1.469,
+              "paired_delta": {
+                "n": 9,
+                "mean": -0.127111,
+                "median": -0.052,
+                "sign_test": {
+                  "n": 8,
+                  "n_pos": 1,
+                  "n_neg": 7,
+                  "n_zero": 1,
+                  "p_value": 0.070312
+                },
+                "signed_rank": {
+                  "n": 8,
+                  "w": 6.0,
+                  "z": -1.6103,
+                  "p_value": 0.107328
+                },
+                "bootstrap": {
+                  "point": -0.127111,
+                  "lo": -0.344,
+                  "hi": 0.094222,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 0.0,
+          "mean_net_pct": -2.0101,
+          "total_net_pct": -2.0101,
+          "total_return_pct": -2.0,
+          "max_drawdown_pct": -3.0,
+          "sharpe": -1.453,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 2,
+          "entries": 1,
+          "win_rate": 1.0,
+          "mean_net_pct": 0.0219,
+          "total_net_pct": 0.0219,
+          "total_return_pct": 0.02,
+          "max_drawdown_pct": -1.76,
+          "sharpe": 0.034,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 2.032,
+          "lo": 2.032,
+          "hi": 2.032,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": -2.0101,
+            "candidate_mean_net_pct": 0.0219,
+            "control_total_net_pct": -2.0101,
+            "candidate_total_net_pct": 0.0219,
+            "control_win_rate": 0.0,
+            "candidate_win_rate": 1.0,
+            "delta_win_rate": 1.0,
+            "control_median_mae_pct": -2.0089,
+            "candidate_median_mae_pct": -0.4967,
+            "control_median_mfe_pct": 2.3213,
+            "candidate_median_mfe_pct": 2.3213,
+            "paired_delta": {
+              "n": 1,
+              "mean": 2.032,
+              "median": 2.032,
+              "sign_test": {
+                "n": 1,
+                "n_pos": 1,
+                "n_neg": 0,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 1,
+                "w": 1.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 2.032,
+                "lo": 2.032,
+                "hi": 2.032,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 1,
+              "control_mean_net_pct": -2.0101,
+              "candidate_mean_net_pct": 0.0219,
+              "control_total_net_pct": -2.0101,
+              "candidate_total_net_pct": 0.0219,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 1.0,
+              "delta_win_rate": 1.0,
+              "control_median_mae_pct": -2.0089,
+              "candidate_median_mae_pct": -0.4967,
+              "control_median_mfe_pct": 2.3213,
+              "candidate_median_mfe_pct": 2.3213,
+              "paired_delta": {
+                "n": 1,
+                "mean": 2.032,
+                "median": 2.032,
+                "sign_test": {
+                  "n": 1,
+                  "n_pos": 1,
+                  "n_neg": 0,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 1,
+                  "w": 1.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 2.032,
+                  "lo": 2.032,
+                  "hi": 2.032,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/research/regime_1152_runs/sq.rv_wider.json
+++ b/backtest/research/regime_1152_runs/sq.rv_wider.json
@@ -1,0 +1,1423 @@
+{
+  "open": {
+    "name": "squeeze_momentum",
+    "params": null,
+    "direction": "both"
+  },
+  "incumbent_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "use_defaults": true
+      }
+    }
+  ],
+  "candidate_close": [
+    {
+      "name": "trailing_tp_ratchet_regime",
+      "params": {
+        "tp_tiers": {
+          "ranging_volatile": [
+            {
+              "atr_multiple": 1.5,
+              "close_fraction": 0.4,
+              "trailing_mult_after": 1.0
+            },
+            {
+              "atr_multiple": 3.0,
+              "close_fraction": 0.8,
+              "trailing_mult_after": 0.75
+            },
+            {
+              "atr_multiple": 4.5,
+              "close_fraction": 1.0,
+              "trailing_mult_after": 0.75
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "control_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops": {
+    "trailing_stop_atr_regime": {
+      "use_defaults": true
+    }
+  },
+  "candidate_stops_mode": "inherit",
+  "replayable": true,
+  "regime_cfg": {
+    "period": 14,
+    "adx_threshold": 20.0,
+    "gate_window": "",
+    "classifier": "composite",
+    "windows_spec": {
+      "medium": {
+        "classifier": "composite",
+        "period": 20
+      }
+    }
+  },
+  "gate_allowed_regimes": [
+    "ranging_volatile"
+  ],
+  "registry": "futures",
+  "windows": {
+    "is": [
+      "2025-06-10",
+      "2026-01-01"
+    ],
+    "oos": [
+      "2026-01-01",
+      null
+    ]
+  },
+  "datasets": [
+    "BTC/USDT 1h",
+    "BTC/USDT 4h",
+    "ETH/USDT 1h",
+    "ETH/USDT 4h",
+    "SOL/USDT 1h",
+    "SOL/USDT 4h"
+  ],
+  "bootstrap": {
+    "n_resamples": 10000,
+    "ci": 0.95,
+    "seed": 1066
+  },
+  "results": {
+    "is": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 30,
+          "entries": 18,
+          "win_rate": 0.2778,
+          "mean_net_pct": -0.1654,
+          "total_net_pct": -2.9778,
+          "total_return_pct": -3.01,
+          "max_drawdown_pct": -4.14,
+          "sharpe": -0.8,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 26,
+          "entries": 18,
+          "win_rate": 0.2778,
+          "mean_net_pct": -0.2197,
+          "total_net_pct": -3.9538,
+          "total_return_pct": -3.96,
+          "max_drawdown_pct": -4.91,
+          "sharpe": -1.028,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.054222,
+          "lo": -0.713117,
+          "hi": 0.583889,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 18,
+          "paired": 18,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 18,
+            "control_mean_net_pct": -0.1654,
+            "candidate_mean_net_pct": -0.2197,
+            "control_total_net_pct": -2.9778,
+            "candidate_total_net_pct": -3.9538,
+            "control_win_rate": 0.2778,
+            "candidate_win_rate": 0.2778,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -0.4348,
+            "candidate_median_mae_pct": -0.4348,
+            "control_median_mfe_pct": 0.4703,
+            "candidate_median_mfe_pct": 0.4953,
+            "paired_delta": {
+              "n": 18,
+              "mean": -0.054222,
+              "median": -0.0,
+              "sign_test": {
+                "n": 18,
+                "n_pos": 7,
+                "n_neg": 11,
+                "n_zero": 0,
+                "p_value": 0.480682
+              },
+              "signed_rank": {
+                "n": 18,
+                "w": 47.0,
+                "z": -1.6549,
+                "p_value": 0.097942
+              },
+              "bootstrap": {
+                "point": -0.054222,
+                "lo": -0.110778,
+                "hi": -0.006778,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 18,
+              "control_mean_net_pct": -0.1654,
+              "candidate_mean_net_pct": -0.2197,
+              "control_total_net_pct": -2.9778,
+              "candidate_total_net_pct": -3.9538,
+              "control_win_rate": 0.2778,
+              "candidate_win_rate": 0.2778,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -0.4348,
+              "candidate_median_mae_pct": -0.4348,
+              "control_median_mfe_pct": 0.4703,
+              "candidate_median_mfe_pct": 0.4953,
+              "paired_delta": {
+                "n": 18,
+                "mean": -0.054222,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 18,
+                  "n_pos": 7,
+                  "n_neg": 11,
+                  "n_zero": 0,
+                  "p_value": 0.480682
+                },
+                "signed_rank": {
+                  "n": 18,
+                  "w": 47.0,
+                  "z": -1.6549,
+                  "p_value": 0.097942
+                },
+                "bootstrap": {
+                  "point": -0.054222,
+                  "lo": -0.110778,
+                  "hi": -0.006778,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 12,
+          "entries": 7,
+          "win_rate": 0.4286,
+          "mean_net_pct": -0.4132,
+          "total_net_pct": -2.8927,
+          "total_return_pct": -2.93,
+          "max_drawdown_pct": -5.52,
+          "sharpe": -0.902,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 10,
+          "entries": 7,
+          "win_rate": 0.2857,
+          "mean_net_pct": -0.6704,
+          "total_net_pct": -4.6927,
+          "total_return_pct": -4.66,
+          "max_drawdown_pct": -6.67,
+          "sharpe": -1.286,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.257143,
+          "lo": -1.857221,
+          "hi": 1.368314,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 7,
+          "paired": 7,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 7,
+            "control_mean_net_pct": -0.4132,
+            "candidate_mean_net_pct": -0.6704,
+            "control_total_net_pct": -2.8927,
+            "candidate_total_net_pct": -4.6927,
+            "control_win_rate": 0.4286,
+            "candidate_win_rate": 0.2857,
+            "delta_win_rate": -0.1429,
+            "control_median_mae_pct": -0.8956,
+            "candidate_median_mae_pct": -0.8956,
+            "control_median_mfe_pct": 1.3514,
+            "candidate_median_mfe_pct": 1.3514,
+            "paired_delta": {
+              "n": 7,
+              "mean": -0.257143,
+              "median": -0.0,
+              "sign_test": {
+                "n": 7,
+                "n_pos": 3,
+                "n_neg": 4,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 7,
+                "w": 9.0,
+                "z": -0.7606,
+                "p_value": 0.446873
+              },
+              "bootstrap": {
+                "point": -0.257143,
+                "lo": -0.587143,
+                "hi": 0.039714,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 7,
+              "control_mean_net_pct": -0.4132,
+              "candidate_mean_net_pct": -0.6704,
+              "control_total_net_pct": -2.8927,
+              "candidate_total_net_pct": -4.6927,
+              "control_win_rate": 0.4286,
+              "candidate_win_rate": 0.2857,
+              "delta_win_rate": -0.1429,
+              "control_median_mae_pct": -0.8956,
+              "candidate_median_mae_pct": -0.8956,
+              "control_median_mfe_pct": 1.3514,
+              "candidate_median_mfe_pct": 1.3514,
+              "paired_delta": {
+                "n": 7,
+                "mean": -0.257143,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 7,
+                  "n_pos": 3,
+                  "n_neg": 4,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 7,
+                  "w": 9.0,
+                  "z": -0.7606,
+                  "p_value": 0.446873
+                },
+                "bootstrap": {
+                  "point": -0.257143,
+                  "lo": -0.587143,
+                  "hi": 0.039714,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 29,
+          "entries": 20,
+          "win_rate": 0.25,
+          "mean_net_pct": -0.7389,
+          "total_net_pct": -14.778,
+          "total_return_pct": -13.95,
+          "max_drawdown_pct": -14.76,
+          "sharpe": -2.521,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 30,
+          "entries": 20,
+          "win_rate": 0.25,
+          "mean_net_pct": -0.7614,
+          "total_net_pct": -15.228,
+          "total_return_pct": -14.35,
+          "max_drawdown_pct": -15.41,
+          "sharpe": -2.519,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.0225,
+          "lo": -0.908505,
+          "hi": 0.867125,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 20,
+          "paired": 20,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 20,
+            "control_mean_net_pct": -0.7389,
+            "candidate_mean_net_pct": -0.7614,
+            "control_total_net_pct": -14.778,
+            "candidate_total_net_pct": -15.228,
+            "control_win_rate": 0.25,
+            "candidate_win_rate": 0.25,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.1531,
+            "candidate_median_mae_pct": -1.1531,
+            "control_median_mfe_pct": 0.6345,
+            "candidate_median_mfe_pct": 0.6345,
+            "paired_delta": {
+              "n": 20,
+              "mean": -0.0225,
+              "median": -0.0,
+              "sign_test": {
+                "n": 20,
+                "n_pos": 9,
+                "n_neg": 11,
+                "n_zero": 0,
+                "p_value": 0.823803
+              },
+              "signed_rank": {
+                "n": 20,
+                "w": 89.0,
+                "z": -0.5787,
+                "p_value": 0.562821
+              },
+              "bootstrap": {
+                "point": -0.0225,
+                "lo": -0.1019,
+                "hi": 0.058902,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 20,
+              "control_mean_net_pct": -0.7389,
+              "candidate_mean_net_pct": -0.7614,
+              "control_total_net_pct": -14.778,
+              "candidate_total_net_pct": -15.228,
+              "control_win_rate": 0.25,
+              "candidate_win_rate": 0.25,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.1531,
+              "candidate_median_mae_pct": -1.1531,
+              "control_median_mfe_pct": 0.6345,
+              "candidate_median_mfe_pct": 0.6345,
+              "paired_delta": {
+                "n": 20,
+                "mean": -0.0225,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 20,
+                  "n_pos": 9,
+                  "n_neg": 11,
+                  "n_zero": 0,
+                  "p_value": 0.823803
+                },
+                "signed_rank": {
+                  "n": 20,
+                  "w": 89.0,
+                  "z": -0.5787,
+                  "p_value": 0.562821
+                },
+                "bootstrap": {
+                  "point": -0.0225,
+                  "lo": -0.1019,
+                  "hi": 0.058902,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 6,
+          "entries": 3,
+          "win_rate": 1.0,
+          "mean_net_pct": 2.6959,
+          "total_net_pct": 8.0877,
+          "total_return_pct": 8.23,
+          "max_drawdown_pct": -2.57,
+          "sharpe": 1.59,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 0.6667,
+          "mean_net_pct": 2.5459,
+          "total_net_pct": 7.6377,
+          "total_return_pct": 7.72,
+          "max_drawdown_pct": -3.34,
+          "sharpe": 1.466,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.15,
+          "lo": -4.185333,
+          "hi": 3.885333,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": 2.6959,
+            "candidate_mean_net_pct": 2.5459,
+            "control_total_net_pct": 8.0877,
+            "candidate_total_net_pct": 7.6377,
+            "control_win_rate": 1.0,
+            "candidate_win_rate": 0.6667,
+            "delta_win_rate": -0.3333,
+            "control_median_mae_pct": -1.4476,
+            "candidate_median_mae_pct": -1.4476,
+            "control_median_mfe_pct": 5.3739,
+            "candidate_median_mfe_pct": 5.3739,
+            "paired_delta": {
+              "n": 3,
+              "mean": -0.15,
+              "median": -0.256,
+              "sign_test": {
+                "n": 3,
+                "n_pos": 1,
+                "n_neg": 2,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 3,
+                "w": 2.0,
+                "z": -0.2673,
+                "p_value": 0.789268
+              },
+              "bootstrap": {
+                "point": -0.15,
+                "lo": -0.696,
+                "hi": 0.502,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 3,
+              "control_mean_net_pct": 2.6959,
+              "candidate_mean_net_pct": 2.5459,
+              "control_total_net_pct": 8.0877,
+              "candidate_total_net_pct": 7.6377,
+              "control_win_rate": 1.0,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": -0.3333,
+              "control_median_mae_pct": -1.4476,
+              "candidate_median_mae_pct": -1.4476,
+              "control_median_mfe_pct": 5.3739,
+              "candidate_median_mfe_pct": 5.3739,
+              "paired_delta": {
+                "n": 3,
+                "mean": -0.15,
+                "median": -0.256,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 1,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 2.0,
+                  "z": -0.2673,
+                  "p_value": 0.789268
+                },
+                "bootstrap": {
+                  "point": -0.15,
+                  "lo": -0.696,
+                  "hi": 0.502,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 37,
+          "entries": 17,
+          "win_rate": 0.5294,
+          "mean_net_pct": -0.1574,
+          "total_net_pct": -2.6757,
+          "total_return_pct": -2.96,
+          "max_drawdown_pct": -9.46,
+          "sharpe": -0.426,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 44,
+          "entries": 17,
+          "win_rate": 0.4706,
+          "mean_net_pct": -0.129,
+          "total_net_pct": -2.1937,
+          "total_return_pct": -2.58,
+          "max_drawdown_pct": -9.46,
+          "sharpe": -0.332,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.028353,
+          "lo": -1.371568,
+          "hi": 1.454432,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 17,
+          "paired": 17,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 17,
+            "control_mean_net_pct": -0.1574,
+            "candidate_mean_net_pct": -0.129,
+            "control_total_net_pct": -2.6757,
+            "candidate_total_net_pct": -2.1937,
+            "control_win_rate": 0.5294,
+            "candidate_win_rate": 0.4706,
+            "delta_win_rate": -0.0588,
+            "control_median_mae_pct": -0.7668,
+            "candidate_median_mae_pct": -0.7668,
+            "control_median_mfe_pct": 1.1949,
+            "candidate_median_mfe_pct": 1.1949,
+            "paired_delta": {
+              "n": 17,
+              "mean": 0.028353,
+              "median": -0.0,
+              "sign_test": {
+                "n": 16,
+                "n_pos": 7,
+                "n_neg": 9,
+                "n_zero": 1,
+                "p_value": 0.803619
+              },
+              "signed_rank": {
+                "n": 16,
+                "w": 65.0,
+                "z": -0.1293,
+                "p_value": 0.897142
+              },
+              "bootstrap": {
+                "point": 0.028353,
+                "lo": -0.208241,
+                "hi": 0.294138,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 17,
+              "control_mean_net_pct": -0.1574,
+              "candidate_mean_net_pct": -0.129,
+              "control_total_net_pct": -2.6757,
+              "candidate_total_net_pct": -2.1937,
+              "control_win_rate": 0.5294,
+              "candidate_win_rate": 0.4706,
+              "delta_win_rate": -0.0588,
+              "control_median_mae_pct": -0.7668,
+              "candidate_median_mae_pct": -0.7668,
+              "control_median_mfe_pct": 1.1949,
+              "candidate_median_mfe_pct": 1.1949,
+              "paired_delta": {
+                "n": 17,
+                "mean": 0.028353,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 16,
+                  "n_pos": 7,
+                  "n_neg": 9,
+                  "n_zero": 1,
+                  "p_value": 0.803619
+                },
+                "signed_rank": {
+                  "n": 16,
+                  "w": 65.0,
+                  "z": -0.1293,
+                  "p_value": 0.897142
+                },
+                "bootstrap": {
+                  "point": 0.028353,
+                  "lo": -0.208241,
+                  "hi": 0.294138,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 7,
+          "entries": 3,
+          "win_rate": 0.6667,
+          "mean_net_pct": 2.7046,
+          "total_net_pct": 8.1137,
+          "total_return_pct": 8.24,
+          "max_drawdown_pct": -3.5,
+          "sharpe": 1.512,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 5,
+          "entries": 3,
+          "win_rate": 0.6667,
+          "mean_net_pct": 1.9092,
+          "total_net_pct": 5.7277,
+          "total_return_pct": 5.66,
+          "max_drawdown_pct": -5.15,
+          "sharpe": 0.896,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.795333,
+          "lo": -5.522667,
+          "hi": 3.932,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": 2.7046,
+            "candidate_mean_net_pct": 1.9092,
+            "control_total_net_pct": 8.1137,
+            "candidate_total_net_pct": 5.7277,
+            "control_win_rate": 0.6667,
+            "candidate_win_rate": 0.6667,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.7129,
+            "candidate_median_mae_pct": -1.7129,
+            "control_median_mfe_pct": 4.5418,
+            "candidate_median_mfe_pct": 4.5418,
+            "paired_delta": {
+              "n": 3,
+              "mean": -0.795333,
+              "median": -1.124,
+              "sign_test": {
+                "n": 3,
+                "n_pos": 1,
+                "n_neg": 2,
+                "n_zero": 0,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 3,
+                "w": 1.0,
+                "z": -0.8018,
+                "p_value": 0.422678
+              },
+              "bootstrap": {
+                "point": -0.795333,
+                "lo": -1.704,
+                "hi": 0.442,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 3,
+              "control_mean_net_pct": 2.7046,
+              "candidate_mean_net_pct": 1.9092,
+              "control_total_net_pct": 8.1137,
+              "candidate_total_net_pct": 5.7277,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.7129,
+              "candidate_median_mae_pct": -1.7129,
+              "control_median_mfe_pct": 4.5418,
+              "candidate_median_mfe_pct": 4.5418,
+              "paired_delta": {
+                "n": 3,
+                "mean": -0.795333,
+                "median": -1.124,
+                "sign_test": {
+                  "n": 3,
+                  "n_pos": 1,
+                  "n_neg": 2,
+                  "n_zero": 0,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 3,
+                  "w": 1.0,
+                  "z": -0.8018,
+                  "p_value": 0.422678
+                },
+                "bootstrap": {
+                  "point": -0.795333,
+                  "lo": -1.704,
+                  "hi": 0.442,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "oos": [
+      {
+        "dataset": "BTC/USDT 1h",
+        "control_arm": {
+          "trades": 23,
+          "entries": 12,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.6028,
+          "total_net_pct": -7.2332,
+          "total_return_pct": -7.04,
+          "max_drawdown_pct": -7.04,
+          "sharpe": -1.934,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 21,
+          "entries": 12,
+          "win_rate": 0.3333,
+          "mean_net_pct": -0.6171,
+          "total_net_pct": -7.4052,
+          "total_return_pct": -7.2,
+          "max_drawdown_pct": -7.2,
+          "sharpe": -1.963,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.014333,
+          "lo": -0.695521,
+          "hi": 0.662179,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 12,
+          "paired": 12,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 12,
+            "control_mean_net_pct": -0.6028,
+            "candidate_mean_net_pct": -0.6171,
+            "control_total_net_pct": -7.2332,
+            "candidate_total_net_pct": -7.4052,
+            "control_win_rate": 0.3333,
+            "candidate_win_rate": 0.3333,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.0454,
+            "candidate_median_mae_pct": -1.0454,
+            "control_median_mfe_pct": 0.3923,
+            "candidate_median_mfe_pct": 0.3923,
+            "paired_delta": {
+              "n": 12,
+              "mean": -0.014333,
+              "median": 0.0,
+              "sign_test": {
+                "n": 11,
+                "n_pos": 6,
+                "n_neg": 5,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 11,
+                "w": 34.0,
+                "z": 0.0445,
+                "p_value": 0.964541
+              },
+              "bootstrap": {
+                "point": -0.014333,
+                "lo": -0.112667,
+                "hi": 0.058333,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 12,
+              "control_mean_net_pct": -0.6028,
+              "candidate_mean_net_pct": -0.6171,
+              "control_total_net_pct": -7.2332,
+              "candidate_total_net_pct": -7.4052,
+              "control_win_rate": 0.3333,
+              "candidate_win_rate": 0.3333,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.0454,
+              "candidate_median_mae_pct": -1.0454,
+              "control_median_mfe_pct": 0.3923,
+              "candidate_median_mfe_pct": 0.3923,
+              "paired_delta": {
+                "n": 12,
+                "mean": -0.014333,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 11,
+                  "n_pos": 6,
+                  "n_neg": 5,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 11,
+                  "w": 34.0,
+                  "z": 0.0445,
+                  "p_value": 0.964541
+                },
+                "bootstrap": {
+                  "point": -0.014333,
+                  "lo": -0.112667,
+                  "hi": 0.058333,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "BTC/USDT 4h",
+        "control_arm": {
+          "trades": 6,
+          "entries": 3,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.5252,
+          "total_net_pct": 1.5757,
+          "total_return_pct": 1.57,
+          "max_drawdown_pct": -3.23,
+          "sharpe": 0.695,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 6,
+          "entries": 3,
+          "win_rate": 0.6667,
+          "mean_net_pct": 0.8046,
+          "total_net_pct": 2.4137,
+          "total_return_pct": 2.4,
+          "max_drawdown_pct": -3.23,
+          "sharpe": 0.969,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.279333,
+          "lo": -1.752,
+          "hi": 2.310667,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 3,
+          "paired": 3,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 3,
+            "control_mean_net_pct": 0.5252,
+            "candidate_mean_net_pct": 0.8046,
+            "control_total_net_pct": 1.5757,
+            "candidate_total_net_pct": 2.4137,
+            "control_win_rate": 0.6667,
+            "candidate_win_rate": 0.6667,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -1.042,
+            "candidate_median_mae_pct": -1.042,
+            "control_median_mfe_pct": 1.8138,
+            "candidate_median_mfe_pct": 1.8138,
+            "paired_delta": {
+              "n": 3,
+              "mean": 0.279333,
+              "median": 0.0,
+              "sign_test": {
+                "n": 2,
+                "n_pos": 1,
+                "n_neg": 1,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 2,
+                "w": 2.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 0.279333,
+                "lo": -0.0,
+                "hi": 0.838,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 3,
+              "control_mean_net_pct": 0.5252,
+              "candidate_mean_net_pct": 0.8046,
+              "control_total_net_pct": 1.5757,
+              "candidate_total_net_pct": 2.4137,
+              "control_win_rate": 0.6667,
+              "candidate_win_rate": 0.6667,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -1.042,
+              "candidate_median_mae_pct": -1.042,
+              "control_median_mfe_pct": 1.8138,
+              "candidate_median_mfe_pct": 1.8138,
+              "paired_delta": {
+                "n": 3,
+                "mean": 0.279333,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 2,
+                  "n_pos": 1,
+                  "n_neg": 1,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 2,
+                  "w": 2.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.279333,
+                  "lo": -0.0,
+                  "hi": 0.838,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 1h",
+        "control_arm": {
+          "trades": 12,
+          "entries": 10,
+          "win_rate": 0.2,
+          "mean_net_pct": -1.0569,
+          "total_net_pct": -10.569,
+          "total_return_pct": -10.12,
+          "max_drawdown_pct": -11.67,
+          "sharpe": -2.123,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 11,
+          "entries": 10,
+          "win_rate": 0.1,
+          "mean_net_pct": -1.1205,
+          "total_net_pct": -11.205,
+          "total_return_pct": -10.7,
+          "max_drawdown_pct": -12.72,
+          "sharpe": -2.261,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": -0.0636,
+          "lo": -1.11881,
+          "hi": 1.025805,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 10,
+          "paired": 10,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 10,
+            "control_mean_net_pct": -1.0569,
+            "candidate_mean_net_pct": -1.1205,
+            "control_total_net_pct": -10.569,
+            "candidate_total_net_pct": -11.205,
+            "control_win_rate": 0.2,
+            "candidate_win_rate": 0.1,
+            "delta_win_rate": -0.1,
+            "control_median_mae_pct": -1.2887,
+            "candidate_median_mae_pct": -1.2887,
+            "control_median_mfe_pct": 0.208,
+            "candidate_median_mfe_pct": 0.208,
+            "paired_delta": {
+              "n": 10,
+              "mean": -0.0636,
+              "median": 0.0,
+              "sign_test": {
+                "n": 9,
+                "n_pos": 5,
+                "n_neg": 4,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 9,
+                "w": 24.0,
+                "z": 0.1185,
+                "p_value": 0.905695
+              },
+              "bootstrap": {
+                "point": -0.0636,
+                "lo": -0.36,
+                "hi": 0.1692,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 10,
+              "control_mean_net_pct": -1.0569,
+              "candidate_mean_net_pct": -1.1205,
+              "control_total_net_pct": -10.569,
+              "candidate_total_net_pct": -11.205,
+              "control_win_rate": 0.2,
+              "candidate_win_rate": 0.1,
+              "delta_win_rate": -0.1,
+              "control_median_mae_pct": -1.2887,
+              "candidate_median_mae_pct": -1.2887,
+              "control_median_mfe_pct": 0.208,
+              "candidate_median_mfe_pct": 0.208,
+              "paired_delta": {
+                "n": 10,
+                "mean": -0.0636,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 9,
+                  "n_pos": 5,
+                  "n_neg": 4,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 9,
+                  "w": 24.0,
+                  "z": 0.1185,
+                  "p_value": 0.905695
+                },
+                "bootstrap": {
+                  "point": -0.0636,
+                  "lo": -0.36,
+                  "hi": 0.1692,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "ETH/USDT 4h",
+        "control_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 0,
+          "entries": 0,
+          "win_rate": null,
+          "mean_net_pct": null,
+          "total_net_pct": null,
+          "total_return_pct": 0.0,
+          "max_drawdown_pct": 0.0,
+          "sharpe": 0.0,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": null,
+          "lo": null,
+          "hi": null,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 0,
+          "paired": 0,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": null
+      },
+      {
+        "dataset": "SOL/USDT 1h",
+        "control_arm": {
+          "trades": 16,
+          "entries": 9,
+          "win_rate": 0.5556,
+          "mean_net_pct": 0.2795,
+          "total_net_pct": 2.5151,
+          "total_return_pct": 2.44,
+          "max_drawdown_pct": -2.84,
+          "sharpe": 0.757,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 16,
+          "entries": 9,
+          "win_rate": 0.4444,
+          "mean_net_pct": 0.3692,
+          "total_net_pct": 3.3231,
+          "total_return_pct": 3.24,
+          "max_drawdown_pct": -2.84,
+          "sharpe": 0.93,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.089778,
+          "lo": -1.309778,
+          "hi": 1.569855,
+          "n_resamples": 10000
+        },
+        "paired_diag": {
+          "schedule_entries": 9,
+          "paired": 9,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 9,
+            "control_mean_net_pct": 0.2795,
+            "candidate_mean_net_pct": 0.3692,
+            "control_total_net_pct": 2.5151,
+            "candidate_total_net_pct": 3.3231,
+            "control_win_rate": 0.5556,
+            "candidate_win_rate": 0.4444,
+            "delta_win_rate": -0.1112,
+            "control_median_mae_pct": -0.8156,
+            "candidate_median_mae_pct": -0.8156,
+            "control_median_mfe_pct": 1.469,
+            "candidate_median_mfe_pct": 1.469,
+            "paired_delta": {
+              "n": 9,
+              "mean": 0.089778,
+              "median": -0.0,
+              "sign_test": {
+                "n": 8,
+                "n_pos": 3,
+                "n_neg": 5,
+                "n_zero": 1,
+                "p_value": 0.726562
+              },
+              "signed_rank": {
+                "n": 8,
+                "w": 19.0,
+                "z": 0.07,
+                "p_value": 0.944183
+              },
+              "bootstrap": {
+                "point": 0.089778,
+                "lo": -0.138222,
+                "hi": 0.332222,
+                "n_resamples": 10000
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 9,
+              "control_mean_net_pct": 0.2795,
+              "candidate_mean_net_pct": 0.3692,
+              "control_total_net_pct": 2.5151,
+              "candidate_total_net_pct": 3.3231,
+              "control_win_rate": 0.5556,
+              "candidate_win_rate": 0.4444,
+              "delta_win_rate": -0.1112,
+              "control_median_mae_pct": -0.8156,
+              "candidate_median_mae_pct": -0.8156,
+              "control_median_mfe_pct": 1.469,
+              "candidate_median_mfe_pct": 1.469,
+              "paired_delta": {
+                "n": 9,
+                "mean": 0.089778,
+                "median": -0.0,
+                "sign_test": {
+                  "n": 8,
+                  "n_pos": 3,
+                  "n_neg": 5,
+                  "n_zero": 1,
+                  "p_value": 0.726562
+                },
+                "signed_rank": {
+                  "n": 8,
+                  "w": 19.0,
+                  "z": 0.07,
+                  "p_value": 0.944183
+                },
+                "bootstrap": {
+                  "point": 0.089778,
+                  "lo": -0.138222,
+                  "hi": 0.332222,
+                  "n_resamples": 10000
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "dataset": "SOL/USDT 4h",
+        "control_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 0.0,
+          "mean_net_pct": -2.0101,
+          "total_net_pct": -2.0101,
+          "total_return_pct": -2.0,
+          "max_drawdown_pct": -3.0,
+          "sharpe": -1.453,
+          "liquidated": false
+        },
+        "candidate_arm": {
+          "trades": 1,
+          "entries": 1,
+          "win_rate": 0.0,
+          "mean_net_pct": -2.0101,
+          "total_net_pct": -2.0101,
+          "total_return_pct": -2.0,
+          "max_drawdown_pct": -3.0,
+          "sharpe": -1.453,
+          "liquidated": false
+        },
+        "unpaired_delta_net_pct": {
+          "point": 0.0,
+          "lo": 0.0,
+          "hi": 0.0,
+          "n_resamples": 0
+        },
+        "paired_diag": {
+          "schedule_entries": 1,
+          "paired": 1,
+          "unmatched": 0,
+          "replayable": true
+        },
+        "per_regime": {
+          "all": {
+            "n": 1,
+            "control_mean_net_pct": -2.0101,
+            "candidate_mean_net_pct": -2.0101,
+            "control_total_net_pct": -2.0101,
+            "candidate_total_net_pct": -2.0101,
+            "control_win_rate": 0.0,
+            "candidate_win_rate": 0.0,
+            "delta_win_rate": 0.0,
+            "control_median_mae_pct": -2.0089,
+            "candidate_median_mae_pct": -2.0089,
+            "control_median_mfe_pct": 2.3213,
+            "candidate_median_mfe_pct": 2.3213,
+            "paired_delta": {
+              "n": 1,
+              "mean": 0.0,
+              "median": 0.0,
+              "sign_test": {
+                "n": 0,
+                "n_pos": 0,
+                "n_neg": 0,
+                "n_zero": 1,
+                "p_value": 1.0
+              },
+              "signed_rank": {
+                "n": 0,
+                "w": 0.0,
+                "z": 0.0,
+                "p_value": 1.0
+              },
+              "bootstrap": {
+                "point": 0.0,
+                "lo": 0.0,
+                "hi": 0.0,
+                "n_resamples": 0
+              }
+            }
+          },
+          "by_regime": {
+            "ranging_volatile": {
+              "n": 1,
+              "control_mean_net_pct": -2.0101,
+              "candidate_mean_net_pct": -2.0101,
+              "control_total_net_pct": -2.0101,
+              "candidate_total_net_pct": -2.0101,
+              "control_win_rate": 0.0,
+              "candidate_win_rate": 0.0,
+              "delta_win_rate": 0.0,
+              "control_median_mae_pct": -2.0089,
+              "candidate_median_mae_pct": -2.0089,
+              "control_median_mfe_pct": 2.3213,
+              "candidate_median_mfe_pct": 2.3213,
+              "paired_delta": {
+                "n": 1,
+                "mean": 0.0,
+                "median": 0.0,
+                "sign_test": {
+                  "n": 0,
+                  "n_pos": 0,
+                  "n_neg": 0,
+                  "n_zero": 1,
+                  "p_value": 1.0
+                },
+                "signed_rank": {
+                  "n": 0,
+                  "w": 0.0,
+                  "z": 0.0,
+                  "p_value": 1.0
+                },
+                "bootstrap": {
+                  "point": 0.0,
+                  "lo": 0.0,
+                  "hi": 0.0,
+                  "n_resamples": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backtest/tests/test_exit_policy_ab.py
+++ b/backtest/tests/test_exit_policy_ab.py
@@ -294,6 +294,25 @@ def test_replayable_false_for_open_as_close_and_unknown():
     assert not m.candidate_is_replayable([{"name": "some_signal_reversal_close"}])
 
 
+def test_replayable_true_for_ratchet_and_frozen_regime_tp():
+    # #1152: the ratchet ladders and the frozen-at-open regime TP fire off
+    # price/ATR/the regime stamped at open (bar data), never off later signals,
+    # so the single-entry replay isolates them faithfully.
+    assert m.candidate_is_replayable([{"name": "trailing_tp_ratchet", "params": {}}])
+    assert m.candidate_is_replayable(
+        [{"name": "trailing_tp_ratchet_regime", "params": {"use_defaults": True}}])
+    assert m.candidate_is_replayable([{"name": "tiered_tp_atr_regime", "params": {}}])
+
+
+def test_replayable_false_for_per_tick_regime_variants():
+    # Per-tick re-resolution variants stay out of the set until validated:
+    # tiered_tp_atr_live_regime_dynamic is HL-live-only (load_strategy_config
+    # rejects it), and tiered_tp_atr_live_regime has no #1152 evidence run.
+    assert not m.candidate_is_replayable([{"name": "tiered_tp_atr_live_regime"}])
+    assert not m.candidate_is_replayable(
+        [{"name": "tiered_tp_atr_live_regime_dynamic"}])
+
+
 # --------------------------------------------------------------------------
 # paired_delta_summary structure
 # --------------------------------------------------------------------------

--- a/docs/research/1152-ranging-exit-geometry-m6.md
+++ b/docs/research/1152-ranging-exit-geometry-m6.md
@@ -1,0 +1,159 @@
+# Ranging ratchet-tier ladders + B2 ranging TP group — M6 entry-locked retune (#1152)
+
+**Verdict: every incumbent stands.** No candidate geometry cleared the
+pre-registered promotion gate robustly across both entry styles, so the
+per-substate ratchet ladders (`ratchetTierGroupDefaults` /
+`DEFAULT_RATCHET_TIERS_BY_GROUP`) and the collapsed B2 ranging TP group
+(`regimeTPTierGroupDefaults["ranging"]` = `(0.5, 50%) → (1.0, 100%)`) ship
+unchanged. The `ranging_quiet` ladder is **unevaluable on the audit data**
+(the label occupies 0.2–0.9% of bars; zero gated entries under either entry
+style) — an evidence gap documented below, not a validation. The strongest
+future candidate is a wider B2 volatile ladder (`b2_rv_wider`), which passed
+the gate under mean-reversion entries but failed the out-of-sample window
+under squeeze entries.
+
+This closes the deferral recorded in
+`backtest/research/regime_1120_trail_validation.json:ratchet_tp_note`
+(#1120 / PR #1149 retuned only the opening trails; the bar-level harness
+cannot isolate per-substate exit geometry).
+
+## Method
+
+Harness: `backtest/exit_policy_ab.py` (M6, #1066) — incumbent-relative,
+entry-locked per-entry replay, Wilcoxon signed-rank + sign test on per-entry
+ΔPnL, regime-attributed. Driver + full matrix:
+`backtest/research/regime_1152_exit_retune.py`; aggregate artifact:
+`backtest/research/regime_1152_exit_retune.json`; raw per-run harness JSON:
+`backtest/research/regime_1152_runs/`.
+
+- **Gating = substate isolation.** Each run gates entries to one composite
+  ranging substate (`--allowed-regimes`, composite p20 via
+  `regime.windows.medium`). The entry gate and the position-regime stamp read
+  the same shifted (N-1) label series, so every paired entry exercises exactly
+  the ladder under test. The bare `ranging_directional` gate covers the
+  `_up`/`_down` sub-labels (#1124).
+- **Incumbent arms resolve like live** (`--baseline-config`, #951-parity
+  v16 configs committed next to the driver): ratchet runs =
+  `trailing_tp_ratchet_regime {use_defaults}` +
+  `trailing_stop_atr_regime {use_defaults}` opening trails; B2 runs =
+  `tiered_tp_atr_regime {use_defaults}` + scalar `stop_loss_atr_mult: 1.5`
+  (the ranging SL default). Candidate arms inherit the identical stops
+  (`--candidate-stops inherit`), so each A/B isolates the ladder change alone.
+- **Ratchet candidates** are explicit regime-keyed `tp_tiers` on the same
+  evaluator (exact-match keys, so the directional runs key the bare label AND
+  `_up`/`_down`). **B2 candidates** use scalar `tiered_tp_atr` — exact under a
+  single-substate gate, since every entry is stamped with that substate.
+- **Two entry styles** so a verdict is never an artifact of one open
+  strategy's entry timing: `squeeze_momentum` (`sq.`, breakout — the #1120
+  lineage) and `mean_reversion` (`mr.`, band-reversion — the style that
+  actually trades ranges; 3–15× the paired N). Both `direction: both`,
+  futures registry.
+- Audit datasets (BTC/ETH/SOL × 1h/4h, binanceus fees) and walk-forward
+  windows `is` (2025-06-10 → 2026-01-01) / `oos` (2026-01-01 →) from
+  `eval_windows.py`; capital/bootstrap/seed at harness defaults.
+- **Pre-registered promotion gate** (`_verdict` in the driver): pooled Δnet/e
+  > 0 on BOTH windows, ≥1 individually significant (p<.05) dataset, no
+  significant contradiction — required from **both** entry styles before a
+  fleet default changes.
+
+Two enabling code changes shipped with this study: `trailing_tp_ratchet`,
+`trailing_tp_ratchet_regime`, and `tiered_tp_atr_regime` added to M6's
+`_REPLAYABLE_CLOSE_NAMES` (they fire off price/ATR/the frozen open-stamp —
+self-contained per entry), and `backtester._load_trailing_ratchet` now ensures
+the close-strategies `sys.path` entry before module exec (it crashed with
+`ModuleNotFoundError: _helpers` in any process that hadn't already imported
+the close registry — exactly the M6 CLI path).
+
+## Results — pooled Δnet%/entry (candidate − incumbent; positive favours candidate)
+
+`n` = paired entries; `+/−ds` = datasets by delta sign; `sig` = datasets with
+Wilcoxon p<.05 (signed by direction).
+
+### Ratchet ladders
+
+| run | substate | is | oos | verdict |
+|---|---|---|---|---|
+| `sq.rv_wider` (1.5/3.0/4.5) | volatile | −0.082 (n=68, 1+/5−) | +0.024 (n=35, 2+/2−) | incumbent stands |
+| `mr.rv_wider` | volatile | +0.012 (n=333, 3+/3−) | +0.023 (n=233, 3+/3−) | positive, no sig |
+| `sq.rv_quiet_geometry` (0.75/1.5/2.0) | volatile | +0.046 (n=68, 4+/2−) | +0.092 (n=35, 4+/1−) | positive, no sig |
+| `mr.rv_quiet_geometry` | volatile | −0.012 (n=333, 2+/4−) | +0.011 (n=233, 3+/3−) | incumbent stands |
+| `sq.rd_full_scaleout` (kill the runner) | directional | +0.101 (n=23, 3+/0−) | +0.123 (n=16, 5+/1−) | positive, no sig |
+| `mr.rd_full_scaleout` | directional | −0.016 (n=167, **3 sig−**) | −0.004 (n=127, 1 sig+) | incumbent stands |
+| `sq.rd_lighter` (15/35/60) | directional | −0.031 (n=23) | −0.063 (n=16, 1+/5−) | incumbent stands |
+| `mr.rd_lighter` | directional | +0.003 (n=167, 2+/4−) | +0.004 (n=127, 2+/4−) | positive, no sig |
+| `*.rq_*` (both candidates, both opens) | quiet | n=0 | n=0 | **unevaluable** |
+
+**Volatile:** the two candidates point in opposite directions per entry style
+(squeeze prefers tighter, mean-reversion mildly prefers wider), all
+non-significant — the incumbent middle ladder (1.0/2.0/3.0) is exactly
+between the two candidates and stands.
+
+**Directional:** the higher-power mean-reversion run **rejects removing the
+let-ride runner** (3 significantly-negative datasets in-sample when the 4th
+rung is dropped and scale-out is completed at 75→100%); the squeeze run's
+non-significant preference the other way is 7× smaller in N. Lighter early
+scale-out adds nothing. The #1059 runner ladder survives its inverse check.
+
+### B2 ranging TP group (collapsed incumbent `(0.5, 50%) → (1.0, 100%)`)
+
+| run | substate | is | oos | verdict |
+|---|---|---|---|---|
+| `sq.b2_rv_wider` (0.75/1.5) | volatile | +0.060 (n=68, 1 sig+) | −0.050 (n=34, 2+/3−) | incumbent stands |
+| `mr.b2_rv_wider` | volatile | +0.005 (n=343, **2 sig+**) | +0.050 (n=241, **2 sig+**) | **passes gate** |
+| `sq.b2_rv_patient3` (1.0/2.0/3.0) | volatile | −0.062 (n=68) | −0.115 (n=34) | incumbent stands |
+| `mr.b2_rv_patient3` | volatile | +0.065 (n=343, 1 sig+) | −0.002 (n=241) | incumbent stands |
+| `sq.b2_rd_patient3` | directional | +0.082 (n=23) | −0.037 (n=16) | incumbent stands |
+| `mr.b2_rd_patient3` | directional | −0.136 (n=176, 1+/5−) | −0.015 (n=132) | incumbent stands |
+| `sq.b2_rd_wider2` (1.0/2.0) | directional | +0.099 (n=23) | −0.053 (n=16) | incumbent stands |
+| `mr.b2_rd_wider2` | directional | −0.142 (n=176, 1+/5−) | −0.020 (n=132) | incumbent stands |
+| `*.b2_rq_wider` (both opens) | quiet | n=0 | n=0 | **unevaluable** |
+
+**Directional patience is refuted**, not just unproven: both wider/patient
+directional candidates lose ~0.14%/entry in-sample under mean-reversion
+entries (5 of 6 datasets negative). The collapsed fast exit is right for the
+directional substate.
+
+**`b2_rv_wider` is the one near-miss.** Under mean-reversion entries it passes
+the full gate (positive both windows; ETH 1h and SOL 1h individually
+significant in BOTH windows, p≤0.003; no significant contradiction), but under
+squeeze entries the OOS pooled delta is negative (n=34, non-significant), and
+even in the passing mean-reversion run all three 4h datasets are negative
+in-sample. A fleet-wide on-chain default does not
+change on evidence that one entry style contradicts out-of-sample. **Decision:
+keep the collapsed group; re-run `--only sq.b2_rv_wider,mr.b2_rv_wider` once
+the OOS window has accumulated more squeeze entries — consistent
+cross-entry-style positives would justify a `ranging_volatile` B2 split to
+`(0.75, 50%) → (1.5, 100%)`.**
+
+## The `ranging_quiet` evidence gap
+
+Composite p20 label frequencies over 2025-06-10 → 2026-06-01 (cache snapshot
+`shared_tools/trading_bot.db`, 2026-07-02):
+
+| dataset | ranging_quiet | ranging_volatile | ranging_directional (family) |
+|---|---:|---:|---:|
+| BTC/USDT 1h | 0.2% | 19.3% | 11.3% |
+| ETH/USDT 1h | 0.2% | 18.7% | 8.7% |
+| SOL/USDT 4h | 0.9% | 16.3% | 8.2% |
+
+Quiet ranges essentially do not occur on crypto 1h/4h at these thresholds:
+across all six audit datasets, both windows, and both entry styles, the gated
+runs produced **zero** control entries. This is structural (the label is
+near-absent), not an entry-style power problem. The quiet ladder — which is
+also the bare-ADX `ranging` target and predates #1059 unchanged — therefore
+keeps its long-lived incumbent geometry by default. Any future validation
+needs either a quieter asset class in the audit set or relaxed composite
+thresholds, both out of scope here.
+
+## Reproduction
+
+```
+uv run --no-sync python backtest/research/regime_1152_exit_retune.py --jobs 6
+# single run:
+uv run --no-sync python backtest/research/regime_1152_exit_retune.py --only mr.b2_rv_wider
+```
+
+Deterministic given the cache snapshot (harness seed 1066, fixed windows).
+
+---
+Created with LLM: Fable 5 | high | Harness: Claude Code

--- a/scheduler/regime_atr.go
+++ b/scheduler/regime_atr.go
@@ -328,6 +328,14 @@ func regimeCloseDefaultGroup(label string) (string, bool) {
 // clean lets trends run (4 patient rungs), choppy mirrors the scalar default (3
 // rungs), ranging scales out fast (2 rungs). Cumulative close fractions; the
 // final rung is coerced to 1.0 by finalizeProtectionTiers.
+//
+// #1152 evaluated splitting the collapsed ranging group per composite substate
+// with M6 entry-locked replay (docs/research/1152-ranging-exit-geometry-m6.md)
+// and kept the collapse: directional patience was refuted outright, quiet is
+// unevaluable on the audit data, and the one near-miss (a wider volatile
+// ladder, 0.75/1.5) passed under mean-reversion entries but contradicted
+// out-of-sample under squeeze entries — re-run the b2_rv_wider arms before
+// reconsidering.
 var regimeTPTierGroupDefaults = map[string][]hlProtectionTier{
 	"clean":   {{Multiple: 2.5, Fraction: 0.25}, {Multiple: 4.0, Fraction: 0.50}, {Multiple: 5.5, Fraction: 0.75}, {Multiple: 7.0, Fraction: 1.00}},
 	"choppy":  {{Multiple: 1.5, Fraction: 0.40}, {Multiple: 3.0, Fraction: 0.80}, {Multiple: 5.0, Fraction: 1.00}},

--- a/scheduler/trailing_tp_ratchet.go
+++ b/scheduler/trailing_tp_ratchet.go
@@ -78,10 +78,17 @@ func defaultTrailingRatchetTiers() []trailingRatchetTier {
 // Each group's first-rung trail couples to that group's opening trail in
 // regimeATRDefaults.Trailing (#1120: clean 2.5 / choppy 2.25 / ranging_quiet 1.0
 // / ranging_volatile 1.25 / ranging_directional* 1.5), so
-// every first rung is <= 1.0 for the ranging substates. The split values are
-// starting priors — validate via the #1058 7-state backtester (item 4) before
-// relying on the exact geometry. Mirrors DEFAULT_RATCHET_TIERS_BY_GROUP in
-// shared_strategies/close/trailing_tp_ratchet.py.
+// every first rung is <= 1.0 for the ranging substates.
+//
+// #1152 validated the ranging split with M6 entry-locked replay
+// (docs/research/1152-ranging-exit-geometry-m6.md): volatile candidates
+// (wider AND tighter) were non-significant in both directions — the middle
+// incumbent stands; the directional let-ride runner survived its inverse
+// check (removing rung 4 lost significantly on 3 datasets in-sample under
+// mean-reversion entries). ranging_quiet is UNEVALUABLE on the audit data
+// (label ~0.2-0.9% of bars, zero gated entries) and keeps its pre-#1059
+// geometry on that documented evidence gap. Mirrors
+// DEFAULT_RATCHET_TIERS_BY_GROUP in shared_strategies/close/trailing_tp_ratchet.py.
 var ratchetTierGroupDefaults = map[string][]trailingRatchetTier{
 	"clean": {
 		{ATRMultiple: 3.0, CloseFraction: 0, TrailingMultAfter: 1.5},

--- a/shared_strategies/close/regime_atr.py
+++ b/shared_strategies/close/regime_atr.py
@@ -156,6 +156,9 @@ REGIME_ATR_DEFAULTS_TRAILING: Dict[str, RegimeATREntry] = {
 # cumulative_close_fraction); the final rung is coerced to 1.0 by the consumer.
 # Tier counts are ragged by design: clean lets trends run (4 rungs), choppy
 # mirrors the scalar default (3), ranging scales out fast (2).
+# #1152 evaluated a per-substate split of the collapsed ranging group with M6
+# entry-locked replay and kept the collapse — see
+# docs/research/1152-ranging-exit-geometry-m6.md.
 REGIME_TP_TIER_GROUP_DEFAULTS: Dict[str, List[Tuple[float, float]]] = {
     "clean": [(2.5, 0.25), (4.0, 0.50), (5.5, 0.75), (7.0, 1.00)],
     "choppy": [(1.5, 0.40), (3.0, 0.80), (5.0, 1.00)],

--- a/shared_strategies/close/trailing_tp_ratchet.py
+++ b/shared_strategies/close/trailing_tp_ratchet.py
@@ -46,8 +46,11 @@ DEFAULT_RATCHET_TIERS = [
 # Each group's first rung couples to that group's opening trail in
 # REGIME_ATR_DEFAULTS_TRAILING (#1120: clean 2.5 / choppy 2.25 / ranging_quiet 1.0
 # / ranging_volatile 1.25 / ranging_directional* 1.5).
-# Split values are starting priors — validate via the #1058 7-state backtester
-# before relying on the exact geometry.
+# #1152 validated the ranging split with M6 entry-locked replay (see
+# docs/research/1152-ranging-exit-geometry-m6.md): volatile + directional
+# incumbents stand (directional's let-ride runner survived its inverse check);
+# ranging_quiet is unevaluable on the audit data (label ≈0.2–0.9% of bars) and
+# keeps its pre-#1059 geometry on that documented evidence gap.
 DEFAULT_RATCHET_TIERS_BY_GROUP = {
     "clean": [
         {"atr_multiple": 3.0, "trailing_mult_after": 1.5, "close_fraction": 0.0},


### PR DESCRIPTION
Closes #1152

## What this is

The money-path geometry validation deferred from #1120 / PR #1149 (`regime_1120_trail_validation.json:ratchet_tp_note`): per-substate M6 entry-locked A/Bs of the three composite ranging ratchet ladders (`ratchetTierGroupDefaults`) and a substate split of the collapsed B2 ranging TP group (`regimeTPTierGroupDefaults["ranging"]`).

**Outcome: every incumbent stands — no default-table values change.** This is the issue's documented-negative acceptance path; Go/Python mirrors remain byte-identical and the #1149 pins are untouched, so no `POST_UPDATE_HISTORY.md` entry is needed.

## Method (per the issue's validation gate)

- M6 harness (`backtest/exit_policy_ab.py`, #1066): incumbent-relative, entry-locked per-entry replay, Wilcoxon/sign tests on paired per-entry ΔPnL, regime-attributed.
- 22 runs = {ratchet, B2} candidates × 3 ranging substates × 2 entry styles (`squeeze_momentum`, `mean_reversion`), each across the six audit datasets and `is`/`oos` windows, gated per substate so the entry universe and the position regime stamp isolate exactly the ladder under test.
- Incumbent arms resolve from committed v16 baseline configs via `--baseline-config` (#951 parity); candidate arms inherit identical stops so each A/B isolates the close change alone.
- Pre-registered promotion gate: pooled Δ > 0 on both windows, ≥1 significant dataset, no significant contradiction — required from **both** entry styles before a fleet default changes.

## Findings

- **Ratchet volatile:** wider and tighter candidates non-significant in opposite directions per entry style — the middle incumbent stands.
- **Ratchet directional:** the #1059 let-ride runner survived its inverse check — removing rung 4 lost significantly on 3 datasets in-sample under mean-reversion entries.
- **B2 directional patience refuted outright** (−0.14%/entry in-sample, 5/6 datasets negative).
- **B2 volatile wider ladder (0.75/1.5) is the one near-miss:** passes the full gate under mean-reversion entries (ETH/SOL 1h p≤0.003 in both windows) but contradicts out-of-sample under squeeze entries — documented as the re-run candidate before any future split.
- **`ranging_quiet` is unevaluable:** the label is 0.2–0.9% of bars on the audit datasets; zero gated entries under either entry style. Documented evidence gap; the quiet ladder keeps its long-lived pre-#1059 geometry.

Full writeup: `docs/research/1152-ranging-exit-geometry-m6.md`. Aggregate: `backtest/research/regime_1152_exit_retune.json`; raw per-run harness JSON committed under `backtest/research/regime_1152_runs/`.

## Code changes (enabling fixes, red→green tested)

- `backtest/exit_policy_ab.py`: `trailing_tp_ratchet`, `trailing_tp_ratchet_regime`, `tiered_tp_atr_regime` added to `_REPLAYABLE_CLOSE_NAMES` — they fire off price/ATR/the frozen open-stamp, so the single-entry replay isolates them faithfully. Per-tick regime variants deliberately stay out.
- `backtest/backtester.py`: `_load_trailing_ratchet` now calls `_ensure_close_strategies_path()` before `exec_module` — previously any process that hadn't already imported the close registry (exactly the M6 CLI path) crashed with `ModuleNotFoundError: _helpers` when a ratchet close ref was configured.
- Stale "starting priors — validate via the #1058 backtester" comments on both ladder tables (Go + Python) now cite the #1152 evidence and the quiet-substate gap.
- New tests: replayability of the three added evaluators (asserted red before the change), and per-tick variants asserted excluded.

## Verification

- `go -C scheduler build` + `go -C scheduler test ./...` green.
- Full pytest suite green (2208 passed); `test_regime_default_tables.py` mirror pins green (tables unchanged).
- `gofmt` clean; research driver + configs `py_compile` clean.
- Matrix reproducible: `uv run --no-sync python backtest/research/regime_1152_exit_retune.py --jobs 6` (deterministic given the cache snapshot; harness seed 1066).

## Follow-on (tracked in-doc, unfiled)

- Re-run the `b2_rv_wider` arms once the OOS window accumulates more squeeze entries; consistent cross-style positives would justify a `ranging_volatile` B2 split.
- Quiet-substate validation needs a quieter asset class in the audit set or relaxed composite thresholds — out of scope here.

LLM: Fable 5 | high | Harness: Claude Code

https://claude.ai/code/session_01NXXGT4z7CZPVQScpnJFsZv
