### PR TITLE
feat(#1210): full-options default spec + annotated template; M6 self-contained via incumbent_close

### DIFF
--- a/backtest/auto_suggest.py
+++ b/backtest/auto_suggest.py
@@ -175,6 +175,30 @@ def load_spec(raw: dict, spec_dir: str) -> dict:
                 "live close from a daemon config) or 'incumbent_close' (an "
                 "explicit close-ref ladder); got "
                 + ("both" if m6.get("baseline_config") else "neither"))
+        # strategy_id is embedded unconditionally into every M6 argv
+        # (m6_argv_tail's leading --strategy) on BOTH incumbent paths — the
+        # baseline_config path uses it to select the strategy inside the
+        # config, the incumbent_close path uses it as the open-strategy name.
+        # Resolution is per-variant with an m6-level default
+        # (_exit_ab_entry: variant.get("strategy_id") or m6.get("strategy_id")),
+        # so fail loudly HERE at load time if any variant would resolve to
+        # None rather than surfacing as a broken '--strategy None' subprocess.
+        if not m6.get("strategy_id"):
+            if m6.get("close_stack_specs"):
+                raise ValueError(
+                    "m6 'close_stack_specs' are generated variants that cannot "
+                    "carry a per-variant 'strategy_id'; set an m6-level "
+                    "'strategy_id' (the open-strategy name, or the config's "
+                    "strategy id when using 'baseline_config').")
+            for v in m6.get("candidate_close_variants") or []:
+                if not v.get("strategy_id"):
+                    raise ValueError(
+                        "m6 candidate_close_variant "
+                        + repr(v.get("key") or "<unkeyed>")
+                        + " has no 'strategy_id' and the m6 block sets no "
+                        "default; add an m6-level 'strategy_id' or a per-variant "
+                        "override (the open-strategy name, or the config's "
+                        "strategy id when using 'baseline_config').")
 
     return {
         "study": str(raw.get("study") or "unnamed_study"),

--- a/backtest/auto_suggest.py
+++ b/backtest/auto_suggest.py
@@ -164,6 +164,17 @@ def load_spec(raw: dict, spec_dir: str) -> dict:
         if bc and isinstance(bc, str):
             m6["baseline_config"] = (bc if os.path.isabs(bc)
                                      else os.path.join(spec_dir, bc))
+        # M6 resolves the incumbent from EXACTLY one of a live-daemon
+        # baseline-config (resolve the strategy's live close) or an explicit
+        # incumbent_close ladder — mirroring exit_policy_ab, which rejects both
+        # and neither. The explicit path lets a spec exercise M6 self-contained,
+        # without authoring a v15 config fixture.
+        if bool(m6.get("baseline_config")) == bool(m6.get("incumbent_close")):
+            raise ValueError(
+                "m6 block needs EXACTLY one of 'baseline_config' (resolve the "
+                "live close from a daemon config) or 'incumbent_close' (an "
+                "explicit close-ref ladder); got "
+                + ("both" if m6.get("baseline_config") else "neither"))
 
     return {
         "study": str(raw.get("study") or "unnamed_study"),
@@ -363,15 +374,18 @@ def m5_argv_tail(strategy, registry, direction, windows, datasets, out_json) -> 
 
 
 def m6_argv_tail(m6_candidate, registry, windows, datasets, resamples, seed, out_json) -> list:
-    tail = ["--baseline-config", m6_candidate["baseline_config"],
-            "--strategy", m6_candidate["strategy_id"],
+    tail = ["--strategy", m6_candidate["strategy_id"],
             "--registry", registry,
             "--candidate-close", json.dumps(m6_candidate["candidate_close"]),
             "--candidate-stops", m6_candidate.get("candidate_stops", "inherit"),
             "--windows", _csv(windows),
             "--bootstrap-resamples", str(resamples),
             "--seed", str(seed), "--json", out_json]
-    if m6_candidate.get("incumbent_close"):
+    # Exactly one incumbent source (load_spec enforces this): a live-daemon
+    # config to resolve the strategy's live close, or an explicit ladder.
+    if m6_candidate.get("baseline_config"):
+        tail += ["--baseline-config", m6_candidate["baseline_config"]]
+    elif m6_candidate.get("incumbent_close"):
         tail += ["--incumbent-close", json.dumps(m6_candidate["incumbent_close"])]
     for label in m6_candidate.get("allowed_regimes") or []:
         tail += ["--allowed-regimes", label]

--- a/backtest/candidates/squeeze_momentum_1198/suggest.json
+++ b/backtest/candidates/squeeze_momentum_1198/suggest.json
@@ -1,10 +1,11 @@
 {
   "study": "squeeze_momentum_1198_suggest",
   "registry": "spot",
-  "harnesses": ["m1_noise", "m1", "m3", "m5"],
-  "windows": ["is", "oos"],
+  "harnesses": ["m1_noise", "m1", "m3", "m5", "m6"],
+  "windows": ["is", "oos", "2023", "2024", "2025H1"],
   "datasets": null,
   "correction": {"method": "benjamini_hochberg", "alpha": 0.05},
+  "base": {"name": "squeeze_momentum", "direction": "long"},
   "candidates": [
     {
       "key": "baseline",
@@ -21,5 +22,51 @@
       "candidate": "comp_up_family.json",
       "hypothesis": "gate entries to the composite trending_up family (clean+choppy)"
     }
-  ]
+  ],
+  "sweep": {"kc_mult": [1.0, 1.5], "mom_lookback": [12, 16]},
+  "gate_variants": [
+    {
+      "label": "adx_up",
+      "allowed_regimes": ["trending_up", "ranging"],
+      "regime_windows_spec": {"medium": {"classifier": "adx", "period": 14, "adx_threshold": 20.0}}
+    },
+    {
+      "label": "comp_up",
+      "allowed_regimes": ["trending_up_clean", "trending_up_choppy"],
+      "regime_windows_spec": {"medium": {"classifier": "composite", "period": 14}}
+    }
+  ],
+  "m6": {
+    "strategy_id": "squeeze_momentum",
+    "incumbent_close": [
+      {"name": "tiered_tp_atr", "params": {"tp_tiers": [
+        {"atr_multiple": 0.5, "close_fraction": 0.5},
+        {"atr_multiple": 1.0, "close_fraction": 1.0}
+      ]}}
+    ],
+    "candidate_close_variants": [
+      {
+        "key": "wider_tp",
+        "hypothesis": "widen the 2-rung ranging TP so noise doesn't cash the whole position at 0.5 ATR",
+        "candidate_close": [
+          {"name": "tiered_tp_atr", "params": {"tp_tiers": [
+            {"atr_multiple": 0.75, "close_fraction": 0.5},
+            {"atr_multiple": 1.5, "close_fraction": 1.0}
+          ]}}
+        ],
+        "candidate_stops": "inherit"
+      },
+      {
+        "key": "atr_trail",
+        "hypothesis": "replace the tiered TP with a 3x ATR trailing stop (let winners run)",
+        "candidate_close": [
+          {"name": "trailing_stop_atr_mult", "params": {"atr_mult": 3.0}}
+        ],
+        "candidate_stops": "drop"
+      }
+    ],
+    "close_stack_specs": [
+      {"close": {"name": "atr_stop", "params": {"atr_mult": [2.0, 2.5]}}}
+    ]
+  }
 }

--- a/backtest/candidates/squeeze_momentum_1198/suggest.json
+++ b/backtest/candidates/squeeze_momentum_1198/suggest.json
@@ -62,7 +62,7 @@
         "candidate_close": [
           {"name": "trailing_stop_atr_mult", "params": {"atr_mult": 3.0}}
         ],
-        "candidate_stops": "drop"
+        "candidate_stops": "inherit"
       }
     ],
     "close_stack_specs": [

--- a/backtest/candidates/suggest.template.jsonc
+++ b/backtest/candidates/suggest.template.jsonc
@@ -1,0 +1,146 @@
+// =============================================================================
+// auto_suggest.py — fully-annotated spec template (#1210)
+//
+// This is a REFERENCE, not a runnable file: JSON has no comments, and the tool
+// loads specs with a strict json.load. To turn this into a runnable spec, copy
+// it, strip every `//` comment, and save as strict `.json` (e.g. into
+// backtest/candidates/<your_study>/suggest.json).
+//
+// It documents EVERY option the loader accepts. Only `study` + at least one
+// candidate source (`candidates`, or `base`+`sweep`/`gate_variants`, or `m6`)
+// are required; every other key has the default noted inline, so a minimal
+// real spec is much shorter than this.
+//
+// Run:  uv run --no-sync python backtest/auto_suggest.py --spec <path> [--dry-run]
+// The shipped, all-options-enabled runnable example is:
+//   backtest/candidates/squeeze_momentum_1198/suggest.json
+// =============================================================================
+{
+  // Report/label + the sub-directory tag for default run artifacts. Required.
+  "study": "my_study",
+
+  // "spot" or "futures" only (M6 is spot/futures at the registry level; perps
+  // backtest via the futures registry). Default: "spot".
+  "registry": "spot",
+
+  // Which graders to run against each OPEN-kind candidate. Any subset of:
+  //   "m1_noise" — M1 step-2 gross-edge noise gate (permutation p; runs FIRST;
+  //                a "no_positive_edge" verdict blocks the whole family).
+  //   "m1"       — M1 incumbent-relative multi-window validator (pass/fail; no p).
+  //   "m3"       — M3 exit diagnostics (bleed/fee-churn context; no p).
+  //   "m5"       — M5 fee audit / salvage verdict (context; no p; screens
+  //                registry DEFAULT params only — swept candidates get a
+  //                "m5_params_unaudited" limitation flag, never audited wrong).
+  // (M6 is NOT listed here — it is driven by the "m6" block below, one entry
+  // per close variant.) Default: ["m1_noise", "m1", "m3", "m5"].
+  "harnesses": ["m1_noise", "m1", "m3", "m5", "m6"],
+
+  // Walk-forward windows to score. Any of eval_windows.WINDOWS:
+  //   "is", "oos" (the protocol pair the promotion gate keys off),
+  //   "2023", "2024", "2025H1" (held-out; note they OVERLAP "is").
+  // Default: ["is", "oos"].
+  "windows": ["is", "oos", "2023", "2024", "2025H1"],
+
+  // Datasets as "SYMBOL:TIMEFRAME". null = the six audit datasets
+  // (BTC/ETH/SOL x 1h/4h). Default: null.
+  "datasets": null,
+
+  // Multiple-comparisons correction over the whole candidate family. Only
+  // "benjamini_hochberg" is supported (the family = every M1-step-2 permutation
+  // p + every M6 per-dataset Wilcoxon p in ONE full-spec run; M3/M5 contribute
+  // no p-values). Default: {"method": "benjamini_hochberg", "alpha": 0.05}.
+  "correction": {"method": "benjamini_hochberg", "alpha": 0.05},
+
+  // ---- OPEN-kind candidates -------------------------------------------------
+  // Three ways to produce them; use any combination.
+
+  // (1) Explicit, fully-formed candidates. Each `candidate` is either an inline
+  // eval_windows candidate-json dict, or a filename resolved against THIS spec's
+  // directory. Every candidate is run through validate_candidate at load (a bad
+  // allowed_regimes/direction fails loudly here, not deep in a subprocess).
+  "candidates": [
+    {
+      "key": "baseline",              // unique key (also the artifact/file stem)
+      "candidate": "baseline.json",   // file ref next to the spec, OR an inline dict
+      "hypothesis": "the incumbent bar"   // optional, echoed into the report
+    },
+    {
+      "key": "inline_example",
+      "candidate": {
+        "name": "squeeze_momentum",   // registered open-strategy name (required)
+        "direction": "long",          // long | short | both (both needs close_strategies)
+        "params": {"kc_mult": 1.5},   // optional strategy params
+        "allowed_regimes": ["trending_up_clean"],   // optional entry gate
+        "regime_windows_spec": {"medium": {"classifier": "composite", "period": 14}}
+      }
+    }
+  ],
+
+  // (2) A base candidate + a param SWEEP (cartesian; reuses eval_windows
+  // expand_sweep semantics). Requires "base". Param names must be REAL strategy
+  // params. gate_variants (below) cross-multiply with these sweep rows.
+  "base": {"name": "squeeze_momentum", "direction": "long"},
+  "sweep": {"kc_mult": [1.0, 1.5], "mom_lookback": [12, 16]},
+
+  // (3) Gate VARIANTS crossed with base(+sweep). Each variant overrides the
+  // entry gate; the label becomes part of the candidate key. Applies ONLY to
+  // base/sweep-derived candidates, never to the explicit `candidates` above
+  // (those already carry their own gate). Requires "base".
+  "gate_variants": [
+    {
+      "label": "adx_up",
+      "allowed_regimes": ["trending_up", "ranging"],   // required
+      "regime_windows_spec": {"medium": {"classifier": "adx", "period": 14, "adx_threshold": 20.0}}
+    },
+    {
+      "label": "comp_up",
+      "allowed_regimes": ["trending_up_clean", "trending_up_choppy"],
+      "regime_windows_spec": {"medium": {"classifier": "composite", "period": 14}}
+    }
+  ],
+
+  // ---- M6 exit-A/B block (optional) ----------------------------------------
+  // One entry per close variant; each is graded by the M6 paired per-entry
+  // replay (Wilcoxon p per window/dataset — these p-values join the BH family).
+  // Requires EXACTLY ONE incumbent source:
+  //   "baseline_config" — a v15 live-daemon config path (relative to the spec
+  //       dir); M6 resolves the strategy's live close from it. `strategy_id` is
+  //       then the config's strategy id.
+  //   "incumbent_close" — an explicit close-ref ladder (self-contained; no
+  //       config fixture needed). `strategy_id` is then the OPEN-strategy name
+  //       (a registered strategy, e.g. "squeeze_momentum" — NOT an arbitrary id).
+  // Every candidate_close must be per-entry REPLAYABLE (atr_stop, time_stop,
+  // zscore_target, tiered_tp_atr[_regime], tiered_tp_atr_live, trailing_stop_*,
+  // stop_loss_atr_mult, trailing_tp_ratchet[_regime]); a non-replayable close is
+  // reported "excluded_not_replayable" and never run.
+  "m6": {
+    "strategy_id": "squeeze_momentum",
+    "incumbent_close": [
+      {"name": "tiered_tp_atr", "params": {"tp_tiers": [
+        {"atr_multiple": 0.5, "close_fraction": 0.5},
+        {"atr_multiple": 1.0, "close_fraction": 1.0}
+      ]}}
+    ],
+    "candidate_close_variants": [
+      {
+        "key": "wider_tp",                 // -> candidate key "m6.wider_tp"
+        "hypothesis": "widen the 2-rung TP",
+        "candidate_close": [{"name": "tiered_tp_atr", "params": {"tp_tiers": [
+          {"atr_multiple": 0.75, "close_fraction": 0.5},
+          {"atr_multiple": 1.5, "close_fraction": 1.0}
+        ]}}],
+        "candidate_stops": "inherit",      // "inherit" (keep incumbent stops) | "drop"
+        "allowed_regimes": ["ranging"]     // optional M6 entry gate (ADX labels
+                                           // under the default classifier)
+      }
+    ],
+    // Optional: expand an M2 close-stack grid (optimizer.generate_close_stack_grid)
+    // into extra candidate_close variants keyed "m6.close_stack_<i>". Each spec:
+    //   close: {name, params:{param:[candidate values]}}  (a whole tp_tiers
+    //          ladder is ONE candidate value), and/or stop_loss_atr_mult /
+    //          trailing_stop_atr_mult lists (mutually exclusive).
+    "close_stack_specs": [
+      {"close": {"name": "atr_stop", "params": {"atr_mult": [2.0, 2.5]}}}
+    ]
+  }
+}

--- a/backtest/candidates/suggest.template.jsonc
+++ b/backtest/candidates/suggest.template.jsonc
@@ -6,10 +6,19 @@
 // it, strip every `//` comment, and save as strict `.json` (e.g. into
 // backtest/candidates/<your_study>/suggest.json).
 //
-// It documents EVERY option the loader accepts. Only `study` + at least one
-// candidate source (`candidates`, or `base`+`sweep`/`gate_variants`, or `m6`)
-// are required; every other key has the default noted inline, so a minimal
-// real spec is much shorter than this.
+// It documents every SUGGEST-SPEC WRAPPER option the loader (load_spec /
+// expand_candidates) accepts — study/registry/harnesses/windows/datasets/
+// correction and the candidate sources. The inner candidate-json dicts (the
+// `candidate` field, `base`, gate_variants, m6 close-refs) carry their OWN
+// richer schema, validated by eval_windows.validate_candidate — beyond the
+// name/direction/params/allowed_regimes/regime_windows_spec shown here it also
+// accepts close_strategies (required for direction "both"), type, invert_signal,
+// stop_loss_atr_mult/trailing_stop_atr_mult, profile_allocation, and
+// regime_directional_policy (#1166). See eval_windows.py's validate_candidate
+// for that full candidate-json schema; this template does not re-list it.
+// Only `study` + at least one candidate source (`candidates`, or
+// `base`+`sweep`/`gate_variants`, or `m6`) are required; every other wrapper
+// key has the default noted inline, so a minimal real spec is much shorter.
 //
 // Run:  uv run --no-sync python backtest/auto_suggest.py --spec <path> [--dry-run]
 // The shipped, all-options-enabled runnable example is:

--- a/backtest/candidates/suggest.template.jsonc
+++ b/backtest/candidates/suggest.template.jsonc
@@ -129,7 +129,11 @@
           {"atr_multiple": 0.75, "close_fraction": 0.5},
           {"atr_multiple": 1.5, "close_fraction": 1.0}
         ]}}],
-        "candidate_stops": "inherit",      // "inherit" (keep incumbent stops) | "drop"
+        // "inherit" keeps the incumbent's stops; "drop" measures the candidate
+        // stop alone. NOTE: "drop" is a NO-OP that prints a [WARN] on the
+        // incumbent_close path this template uses (no strategy-level stops
+        // resolve without baseline_config) — only meaningful with baseline_config.
+        "candidate_stops": "inherit",
         "allowed_regimes": ["ranging"]     // optional M6 entry gate (ADX labels
                                            // under the default classifier)
       }

--- a/backtest/candidates/suggest.template.jsonc
+++ b/backtest/candidates/suggest.template.jsonc
@@ -66,6 +66,9 @@
     },
     {
       "key": "inline_example",
+      // optional per-candidate harness override; defaults to the spec-wide
+      // "harnesses" above. Narrow it for e.g. an M1-only smoke candidate.
+      "harnesses": ["m1_noise", "m1"],
       "candidate": {
         "name": "squeeze_momentum",   // registered open-strategy name (required)
         "direction": "long",          // long | short | both (both needs close_strategies)
@@ -115,6 +118,11 @@
   // reported "excluded_not_replayable" and never run.
   "m6": {
     "strategy_id": "squeeze_momentum",
+    // Optional m6-level entry gate applied to close_stack_specs-generated
+    // variants (which have no per-variant allowed_regimes of their own); the
+    // ONLY way to gate them. Explicit candidate_close_variants use their own
+    // allowed_regimes (below) instead. ADX labels under the default classifier.
+    "allowed_regimes": ["ranging"],
     "incumbent_close": [
       {"name": "tiered_tp_atr", "params": {"tp_tiers": [
         {"atr_multiple": 0.5, "close_fraction": 0.5},

--- a/backtest/candidates/suggest.template.jsonc
+++ b/backtest/candidates/suggest.template.jsonc
@@ -133,6 +133,11 @@
       {
         "key": "wider_tp",                 // -> candidate key "m6.wider_tp"
         "hypothesis": "widen the 2-rung TP",
+        // optional per-variant strategy_id override; falls back to the m6-level
+        // strategy_id above. Lets one variant target a different open-strategy
+        // (or config strategy id under baseline_config). close_stack-generated
+        // variants cannot set this — they always use the m6-level default.
+        "strategy_id": "squeeze_momentum",
         "candidate_close": [{"name": "tiered_tp_atr", "params": {"tp_tiers": [
           {"atr_multiple": 0.75, "close_fraction": 0.5},
           {"atr_multiple": 1.5, "close_fraction": 1.0}

--- a/backtest/candidates/suggest.template.jsonc
+++ b/backtest/candidates/suggest.template.jsonc
@@ -8,14 +8,20 @@
 //
 // It documents every SUGGEST-SPEC WRAPPER option the loader (load_spec /
 // expand_candidates) accepts — study/registry/harnesses/windows/datasets/
-// correction and the candidate sources. The inner candidate-json dicts (the
-// `candidate` field, `base`, gate_variants, m6 close-refs) carry their OWN
-// richer schema, validated by eval_windows.validate_candidate — beyond the
+// correction and the candidate sources. The inner OPEN-candidate dicts (the
+// `candidate` field, and `base`/gate_variants which expand into open
+// candidates) carry their OWN richer schema, validated at load by
+// eval_windows.validate_candidate — beyond the
 // name/direction/params/allowed_regimes/regime_windows_spec shown here it also
 // accepts close_strategies (required for direction "both"), type, invert_signal,
 // stop_loss_atr_mult/trailing_stop_atr_mult, profile_allocation, and
 // regime_directional_policy (#1166). See eval_windows.py's validate_candidate
 // for that full candidate-json schema; this template does not re-list it.
+// The m6 close-refs (incumbent_close / candidate_close) are a DIFFERENT shape
+// — close-strategy references like {name, params} — and get NO shape validation
+// at load: the only load-time check is a name whitelist (candidate_is_replayable
+// in exit_policy_ab.py); a malformed close-ref params shape fails later inside
+// the exit_policy_ab.py subprocess, not here.
 // Only `study` + at least one candidate source (`candidates`, or
 // `base`+`sweep`/`gate_variants`, or `m6`) are required; every other wrapper
 // key has the default noted inline, so a minimal real spec is much shorter.

--- a/backtest/tests/test_auto_suggest.py
+++ b/backtest/tests/test_auto_suggest.py
@@ -179,6 +179,50 @@ def test_m6_incumbent_close_only_spec_loads():
     assert ab[0]["candidate"]["baseline_config"] is None
 
 
+def test_m6_missing_strategy_id_everywhere_fails_at_load():
+    # (a) incumbent_close set, no strategy_id at m6 OR variant level -> must
+    # raise at load, not surface as a broken '--strategy None' subprocess.
+    bad = _base_spec(candidates=[], m6={
+        "incumbent_close": [{"name": "tiered_tp_atr", "params": {}}],
+        "candidate_close_variants": [
+            {"key": "v", "candidate_close": [{"name": "atr_stop", "params": {"atr_mult": 2}}]}]})
+    with pytest.raises(ValueError, match="strategy_id"):
+        asug.load_spec(bad, _STUDY_DIR)
+
+
+def test_m6_per_variant_strategy_id_override_loads_without_m6_default():
+    # (b) m6 block omits strategy_id but each variant supplies its own -> legit.
+    spec = asug.load_spec(_base_spec(candidates=[], m6={
+        "incumbent_close": [{"name": "tiered_tp_atr", "params": {}}],
+        "candidate_close_variants": [
+            {"key": "v", "strategy_id": "squeeze_momentum",
+             "candidate_close": [{"name": "atr_stop", "params": {"atr_mult": 2}}]}]},
+    ), _STUDY_DIR)
+    ab = [e for e in asug.expand_candidates(spec) if e["kind"] == "exit_ab"]
+    assert len(ab) == 1 and ab[0]["candidate"]["strategy_id"] == "squeeze_momentum"
+
+
+def test_m6_close_stack_specs_require_m6_level_strategy_id():
+    # close_stack variants are generated and cannot carry a per-variant
+    # strategy_id, so an m6-level default is mandatory when they are present.
+    bad = _base_spec(candidates=[], m6={
+        "incumbent_close": [{"name": "tiered_tp_atr", "params": {}}],
+        "candidate_close_variants": [],
+        "close_stack_specs": [{"close": {"name": "atr_stop", "params": {"atr_mult": [2.0]}}}]})
+    with pytest.raises(ValueError, match="close_stack_specs"):
+        asug.load_spec(bad, _STUDY_DIR)
+
+
+def test_m6_baseline_config_path_also_requires_strategy_id():
+    # (c) the baseline_config path embeds --strategy too; same missing-value guard.
+    bad = _base_spec(candidates=[], m6={
+        "baseline_config": "cfg.json",
+        "candidate_close_variants": [
+            {"key": "v", "candidate_close": [{"name": "atr_stop", "params": {"atr_mult": 2}}]}]})
+    with pytest.raises(ValueError, match="strategy_id"):
+        asug.load_spec(bad, _STUDY_DIR)
+
+
 def test_shipped_full_options_spec_loads_and_expands():
     # The committed all-options default must load and expand cleanly (guards the
     # demo from silently rotting — every generator + M6 exercised).

--- a/backtest/tests/test_auto_suggest.py
+++ b/backtest/tests/test_auto_suggest.py
@@ -223,6 +223,29 @@ def test_m6_baseline_config_path_also_requires_strategy_id():
         asug.load_spec(bad, _STUDY_DIR)
 
 
+_TEMPLATE = os.path.join(os.path.dirname(_STUDY_DIR), "suggest.template.jsonc")
+
+
+def _load_template_json():
+    import re
+    return json.loads(re.sub(r"//.*", "", open(_TEMPLATE).read()))
+
+
+def test_template_documents_every_variant_and_candidate_option():
+    # The template header asserts it "documents EVERY option the loader accepts";
+    # three prior review rounds each found one omitted key. Lock in the fixes so
+    # a future edit can't silently regress the completeness claim.
+    raw = _load_template_json()
+    # per-candidate harness override (auto_suggest.py: c.get("harnesses"))
+    assert any("harnesses" in c for c in raw["candidates"]), "template omits per-candidate harnesses"
+    m6 = raw["m6"]
+    # m6-level allowed_regimes default (seeds close_stack variants)
+    assert "allowed_regimes" in m6, "template omits m6-level allowed_regimes"
+    # per-variant strategy_id override (variant.get("strategy_id"))
+    assert any("strategy_id" in v for v in m6["candidate_close_variants"]), \
+        "template omits per-variant strategy_id override"
+
+
 def test_shipped_full_options_spec_loads_and_expands():
     # The committed all-options default must load and expand cleanly (guards the
     # demo from silently rotting — every generator + M6 exercised).

--- a/backtest/tests/test_auto_suggest.py
+++ b/backtest/tests/test_auto_suggest.py
@@ -153,6 +153,46 @@ def test_non_replayable_m6_close_excluded():
     assert entries["m6.good"]["precondition_errors"] == []
 
 
+def test_m6_requires_exactly_one_incumbent_source():
+    base = dict(candidates=[])
+    both = _base_spec(**base, m6={"strategy_id": "s", "baseline_config": "cfg.json",
+                                  "incumbent_close": [{"name": "tiered_tp_atr"}],
+                                  "candidate_close_variants": []})
+    with pytest.raises(ValueError, match="EXACTLY one"):
+        asug.load_spec(both, _STUDY_DIR)
+    neither = _base_spec(**base, m6={"strategy_id": "s",
+                                     "candidate_close_variants": []})
+    with pytest.raises(ValueError, match="EXACTLY one"):
+        asug.load_spec(neither, _STUDY_DIR)
+
+
+def test_m6_incumbent_close_only_spec_loads():
+    spec = asug.load_spec(_base_spec(candidates=[], m6={
+        "strategy_id": "squeeze_momentum",
+        "incumbent_close": [{"name": "tiered_tp_atr", "params": {}}],
+        "candidate_close_variants": [
+            {"key": "v", "candidate_close": [{"name": "atr_stop", "params": {"atr_mult": 2}}]}]},
+    ), _STUDY_DIR)
+    entries = asug.expand_candidates(spec)
+    ab = [e for e in entries if e["kind"] == "exit_ab"]
+    assert len(ab) == 1 and ab[0]["precondition_errors"] == []
+    assert ab[0]["candidate"]["baseline_config"] is None
+
+
+def test_shipped_full_options_spec_loads_and_expands():
+    # The committed all-options default must load and expand cleanly (guards the
+    # demo from silently rotting — every generator + M6 exercised).
+    with open(os.path.join(_STUDY_DIR, "suggest.json")) as fh:
+        raw = json.load(fh)
+    spec = asug.load_spec(raw, _STUDY_DIR)
+    entries = asug.expand_candidates(spec)
+    kinds = {e["kind"] for e in entries}
+    assert kinds == {"open", "exit_ab"}          # both harness families present
+    ab = [e for e in entries if e["kind"] == "exit_ab"]
+    assert all(e["precondition_errors"] == [] for e in ab)   # all M6 closes replayable
+    assert len({e["key"] for e in entries}) == len(entries)  # keys unique
+
+
 def test_m5_params_limitation_flagged():
     spec = asug.load_spec(_base_spec(
         harnesses=["m5"],
@@ -197,6 +237,25 @@ def test_m6_argv_tail_repeats_allowed_regimes():
     assert tail.count("--allowed-regimes") == 2
     assert "--bootstrap-resamples" in tail and "10000" in tail
     assert "--candidate-stops" in tail and "inherit" in tail
+
+
+def test_m6_argv_tail_baseline_config_path():
+    m6c = {"baseline_config": "/cfg.json", "strategy_id": "s",
+           "candidate_close": [{"name": "atr_stop"}]}
+    tail = asug.m6_argv_tail(m6c, "spot", ["oos"], None, 100, 1066, "/t/m6.json")
+    assert "--baseline-config" in tail and "/cfg.json" in tail
+    assert "--incumbent-close" not in tail  # exactly one incumbent source
+
+
+def test_m6_argv_tail_incumbent_close_path_omits_baseline():
+    # The self-contained path: no baseline_config, an explicit incumbent ladder.
+    m6c = {"strategy_id": "squeeze_momentum",
+           "incumbent_close": [{"name": "tiered_tp_atr", "params": {}}],
+           "candidate_close": [{"name": "atr_stop", "params": {"atr_mult": 2}}]}
+    tail = asug.m6_argv_tail(m6c, "spot", ["oos"], None, 100, 1066, "/t/m6.json")
+    assert "--baseline-config" not in tail
+    assert "--incumbent-close" in tail
+    assert "--strategy" in tail and "squeeze_momentum" in tail
 
 
 def test_m5_argv_tail():


### PR DESCRIPTION
## Summary

Follow-up to #1212 (merged). Makes the auto-suggester's shipped default a **full run with every option enabled**, and adds a **fully-annotated template** documenting every spec field — both requested after using the tool.

## Changes

- **`backtest/candidates/suggest.template.jsonc`** (new) — reference template with an inline comment on every option: harnesses, windows, datasets, correction, explicit candidates, the `base`+`sweep`+`gate_variants` grid, and the full `m6` block. It's a reference (JSON has no comments — strip them to run) and points at the runnable example.
- **`backtest/candidates/squeeze_momentum_1198/suggest.json`** — the shipped default now exercises everything: all five harnesses including M6, all five windows, the six audit datasets, explicit candidates **plus** a `kc_mult`/`mom_lookback` sweep crossed with two `gate_variants`, and an M6 exit-A/B block (two close variants + an M2 close-stack grid).
- **`backtest/auto_suggest.py`** — enabler: M6 now resolves its incumbent from **exactly one** of a live-daemon `baseline_config` **or** an explicit `incumbent_close` ladder (mirrors `exit_policy_ab`, which rejects both/neither). The explicit path lets a spec run M6 self-contained, with no v15 config fixture — `strategy_id` is then the open-strategy name. `load_spec` enforces the exactly-one rule; `m6_argv_tail` emits whichever source is set.

## Why a code change was needed

The prior default was open-kind only because M6 required a `--baseline-config` daemon-config fixture. Rather than author a fixture, this uses M6's supported `--incumbent-close` path so the "all options" default is self-contained and runnable.

## Verification

- Full-spec `--dry-run` expands to 26 harness commands across 11 open candidates + 4 M6 arms; all candidate keys unique, all M6 closes replayable.
- A tiny real M6 incumbent-close run executes end-to-end (`m6.wider_tp` → real paired Δ, survives BH → `survivor`).
- A swept+gated grid candidate runs and correctly carries the `m5_params_unaudited` limitation flag.
- 47 unit tests pass (added: both M6 argv paths, the exactly-one-incumbent validation, incumbent-close load, and a guard that the shipped full-options spec loads and expands).

Closes #1214.
Relates to #1210.

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code
https://claude.ai/code/session_01QS9j5Ure4nDCdMqjiPDTpB
