### PR TITLE
docs(#1216): backtesting & research harness registry + upkeep rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ Before implementing `@claude review` findings: restate each item as an invariant
 
 ## Backtest
 **Mechanics, harness flags, and #951/#983/#989/#1005 detail → `docs/ARCHITECTURE.md` § Backtest harnesses. Guardrails + run commands below.**
+- **Harness registry SSoT → `docs/backtesting-registry.md`** — the map of every `backtest/` tool (core simulators, M1–M6 validators, regime-promotion pipeline, research one-shots). **Any PR that adds/deprecates/repurposes a harness updates its row there in the same PR** (a new row is part of the change, not a follow-up).
 - Run: `uv run --no-sync python backtest/run_backtest.py --strategy <n> --symbol BTC/USDT --timeframe 1h --mode single`; `backtest_options.py`/`backtest_theta.py --underlying BTC --since YYYY-MM-DD --capital 10000`; `backtest_pairs.py` (beta-hedged z-score, no live path).
 - `--config <path> --strategy <id>` reads the single `close_strategy`. **#951: `--config` gates on `config_version>=15`** (pre-v15 legacy close keys silently no-op vs live → reject with migrate text). Entry ATR guard 50%-of-AvgCost; bar-level only.
 - Regime: entries blocked when `bar_regime ∉ allowed_regimes`; closes always execute; options unsupported. **#1025** `--config` threads `allowed_regimes` (CLI flag rejected); named `regime_gate_window` rejected at load when gate active. **#1058** composite 9-state via `regime.windows` (#1124 `ranging_directional_up`/`_down`, bare-covers-subs in the bar-regime gate); **#1067** open name falls back to `args[0]`. **Regime parity detail → ARCHITECTURE.md.**

--- a/backtest/tests/test_backtesting_registry.py
+++ b/backtest/tests/test_backtesting_registry.py
@@ -1,0 +1,62 @@
+"""Registry completeness regression (#1216).
+
+Enforces the invariant docs/backtesting-registry.md and the CLAUDE.md upkeep
+rule both promise: every non-test harness script under backtest/ and
+backtest/research/ has exactly one entry in the registry, and the registry
+references no file that does not exist. This is what keeps the doc from silently
+drifting out of sync with the code as harnesses are added or removed.
+"""
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKTEST = REPO_ROOT / "backtest"
+REGISTRY = REPO_ROOT / "docs" / "backtesting-registry.md"
+
+
+def _is_test(name: str) -> bool:
+    return name.startswith("test_") or name.endswith("_test.py")
+
+
+def _harness_files():
+    """Non-test .py directly under backtest/ and backtest/research/ (non-recursive)."""
+    files = []
+    for d in (BACKTEST, BACKTEST / "research"):
+        for p in sorted(d.glob("*.py")):
+            if _is_test(p.name):
+                continue
+            files.append(p)
+    return files
+
+
+def _registry_text() -> str:
+    return REGISTRY.read_text()
+
+
+def test_every_harness_has_a_registry_row():
+    text = _registry_text()
+    missing = [
+        p.relative_to(BACKTEST).as_posix()
+        for p in _harness_files()
+        if p.name not in text
+    ]
+    assert not missing, (
+        "backtest/ scripts missing a row in docs/backtesting-registry.md "
+        f"(add one per the CLAUDE.md upkeep rule): {missing}"
+    )
+
+
+def test_registry_references_no_nonexistent_file():
+    """Inverse invariant: no phantom rows — every .py the doc names exists."""
+    text = _registry_text()
+    # backtick-quoted tokens ending in .py, e.g. `backtester.py`, `research/regime_1073_x.py`
+    tokens = set(re.findall(r"`([\w./-]+\.py)`", text))
+    phantom = []
+    for tok in sorted(tokens):
+        # every harness token in the doc is rooted at backtest/
+        if not (BACKTEST / tok).exists():
+            phantom.append(tok)
+    assert not phantom, (
+        "docs/backtesting-registry.md references files that do not exist under "
+        f"backtest/: {phantom}"
+    )

--- a/docs/backtesting-registry.md
+++ b/docs/backtesting-registry.md
@@ -69,6 +69,7 @@ its row here in the same PR. A new row is part of the change, not a follow-up.
 | `research/regime_1095_enriched_vol_model.py` | Evidence run extending the bake-off to the enriched feature matrix. | one-shot | #1095 |
 | `research/regime_1120_trail_validation.py` | Incumbent vs proposed regime opening-trail defaults. | one-shot | #1120 |
 | `research/regime_1152_exit_retune.py` | M6 entry-locked retune of ranging ratchet ladders + B2 ranging TP group. | one-shot | #1152 |
+| `research/regime_1211_incumbent_baseline.py` | Re-measures whether the promotion gate's incumbent baseline is trustworthy, or whether the shipping rule must be redesigned. | one-shot | #1211 |
 | `consolidation_research.py` | Consolidation characterization study — segments consolidation regions in history. | one-shot | consolidation |
 | `consolidation_strategy_sim.py` | `consolidation_range` entry/exit rules over history, look-ahead safe. | one-shot | consolidation |
 | `consolidation_strategy_sweep.py` | Parameter sweep for `consolidation_range` with in-sample/out-of-sample split. | one-shot | consolidation |

--- a/docs/backtesting-registry.md
+++ b/docs/backtesting-registry.md
@@ -1,0 +1,98 @@
+# Backtesting & Research Harness Registry
+
+Single map of every backtesting and offline-research tool in `backtest/`. The
+sprawl (core simulators, the M1–M6 validation series, the regime-promotion
+pipeline, and a long tail of one-shot research scripts) is otherwise untracked
+and undiscoverable. This file is the source of truth; the per-subsystem
+mechanics live in [`docs/ARCHITECTURE.md` § Backtest harnesses](ARCHITECTURE.md).
+
+**Upkeep rule:** any PR that adds, deprecates, or repurposes a harness updates
+its row here in the same PR. A new row is part of the change, not a follow-up.
+
+## Categories
+
+- **Core simulator** — the trade-simulating engine and its entry points / reporting / optimization; produce equity curves and metrics.
+- **M-series validator** — the M1–M6 incumbent-relative research methodology (audit slices via `eval_windows.py`); grade a candidate change you hand them.
+- **Regime-promotion pipeline** — the offline machinery (#1065–#1097) that decides whether a market-regime *classifier* may replace the incumbent hand-rule.
+- **Support library** — shared, non-executable infrastructure imported by the above.
+- **Research one-shot** — reproducible evidence for a single closed issue; run to regenerate a documented result, not a maintained tool.
+
+## Core simulators
+
+| File | Purpose | Status | Origin |
+|------|---------|--------|--------|
+| `backtester.py` | Trade-simulating engine; replays a strategy on historical bars and computes metrics. | active | core |
+| `run_backtest.py` | Main CLI entry — run strategies across assets/timeframes/modes; threads `--config`, regime gate, HTF. | active | core |
+| `optimizer.py` | Walk-forward rolling in-sample/out-of-sample parameter optimization (anti-overfit). | active | core |
+| `reporter.py` | Text performance reports — single, comparison, multi-asset. | active | core |
+| `backtest_options.py` | Options-strategy backtester (e.g. `vol_mean_reversion`) against historical spot. | active | core |
+| `backtest_theta.py` | Theta-harvesting A/B (conservative vs aggressive vs hold-to-expiry). | active | core |
+| `backtest_pairs.py` | Two-leg beta-hedged pairs (z-score) simulator; no live path. | active | core |
+| `parity_diff.py` | Backtest-vs-live parity diff — enforces the simulator↔scheduler contract. | active | #906 |
+
+## M-series validators (M1–M6)
+
+| File | Purpose | Status | Origin |
+|------|---------|--------|--------|
+| `eval_windows.py` | **M1** multi-window incumbent-relative validator — one command per application issue. | active | #977 |
+| `gross_edge_noise.py` | **M1 step-2** sample-noise adjudicator for `graduate_m1` fee-audit verdicts; run before any selectivity work. | active | #1054 |
+| `exit_diagnostics.py` | **M3** holding-time / excursion diagnostics — where a strategy's PnL dies. | active | #997 |
+| `fee_audit.py` | **M5** registry-wide trade-count × fee-drag selectivity triage. | active | #999 |
+| `exit_policy_ab.py` | **M6** regime-conditioned incumbent-relative exit-policy A/B. | active | #1066 |
+| `auto_suggest.py` | Reusable cross-harness driver that sweeps candidates and ranks gate-survivors under one BH correction. **Suggest-only — never writes a live default/config/PR.** | active | #1210 |
+
+## Regime-promotion pipeline (#1065–#1097)
+
+| File | Purpose | Status | Origin |
+|------|---------|--------|--------|
+| `regime_calibrate.py` | Fit + walk-forward validate the label-anchored regime HMM; hosts `gate_verdict` (candidate-self-v2 promotion gate). | active | #1065, #1211 |
+| `regime_hmm.py` | Label-anchored Gaussian HMM: closed-form fit + causal forward-filter decoder. | active | #1065 |
+| `regime_vol_model.py` | Unsupervised vol-state candidates (HMM/GMM/k-means) behind one model-dict schema. Offline only. | active | #1080 |
+| `regime_enriched_features.py` | Enriched feature matrix (canonical four + ignored signals) for the #1095 bake-off. | active | #1095 |
+| `regime_diagnostics.py` | 7-state regime quality diagnostics (pure scorers + CLI). | active | #1065 |
+| `regime_stats.py` | Dependency-free statistics (permutation, BH, Kruskal–Wallis) for regime diagnostics. | active | #1065 |
+| `regime_bounded_window_validate.py` | Bounded-window ADX re-validation reflecting the live fetch path. | active | #1082 |
+| `directional_certification.py` | Evidence-gated directional-certification backtest consumer — parity mirror of the Go path. | active | #1085 |
+| `research/regime_1081_economic_gate.py` | Economic walk-forward gate for regime-conditioned ATR sizing (money-side complement to separation gates). | active | #1081 |
+| `research/regime_1083_multi_asset_gate.py` | Multi-asset breadth gate orchestrating the single-cell separation/economic gates. | active | #1083 |
+| `research/regime_1076_certify.py` | Producer for the directional-certification artifact (SSoT for the regime→direction gate). | active | #1085 |
+
+## Research one-shots (reproducible evidence, tied to a closed issue)
+
+| File | Purpose | Status | Origin |
+|------|---------|--------|--------|
+| `research/regime_1073_directional_negative_result.py` | Evidence the 7-state composite has no real forward-*return* separation (but strong forward-vol). | one-shot | #1073 |
+| `research/regime_1076_directional_premise.py` | Scope-1: does the regime label predict forward *direction*? | one-shot | #1076 |
+| `research/regime_1076_economic_sim.py` | Scope-2: does picking trade side by regime label earn risk-adjusted PnL over base? | one-shot | #1076 |
+| `research/regime_1076_aggregate.py` | Aggregates the #1076 battery under one global multiple-comparisons correction. | one-shot | #1076 |
+| `research/regime_1080_unsupervised_vol_model.py` | Evidence run for the unsupervised vol-state bake-off. | one-shot | #1080 |
+| `research/regime_1095_enriched_vol_model.py` | Evidence run extending the bake-off to the enriched feature matrix. | one-shot | #1095 |
+| `research/regime_1120_trail_validation.py` | Incumbent vs proposed regime opening-trail defaults. | one-shot | #1120 |
+| `research/regime_1152_exit_retune.py` | M6 entry-locked retune of ranging ratchet ladders + B2 ranging TP group. | one-shot | #1152 |
+| `consolidation_research.py` | Consolidation characterization study — segments consolidation regions in history. | one-shot | consolidation |
+| `consolidation_strategy_sim.py` | `consolidation_range` entry/exit rules over history, look-ahead safe. | one-shot | consolidation |
+| `consolidation_strategy_sweep.py` | Parameter sweep for `consolidation_range` with in-sample/out-of-sample split. | one-shot | consolidation |
+| `consolidation_sweep.py` | Fetch-once in-process consolidation parameter-grid runner. | one-shot | consolidation |
+
+## Support libraries
+
+| File | Purpose | Status | Origin |
+|------|---------|--------|--------|
+| `registry_loader.py` | Loads the spot/futures strategy registry by platform for backtest use. | active | core |
+
+(`regime_stats.py` is listed under the regime-promotion pipeline; it is also imported by `auto_suggest.py`.)
+
+## Candidate studies (`backtest/candidates/`)
+
+Declarative candidate specs consumed by `eval_windows.py` / `auto_suggest.py`
+(`--candidate-json`), not harnesses themselves. Add a `<study>/suggest.json` (or
+`--candidate-json`) per study; `suggest.template.jsonc` is the annotated template.
+
+Current studies: `breakout_984`, `breakout_1165`, `ichimoku_997`, `rahtf_1054`,
+`squeeze_983`, `squeeze_momentum_1198`.
+
+## Where results are recorded
+
+- Committed run artifacts: `backtest/research/*.json` (e.g. `regime_1211_baseline_remeasure.json`).
+- Narrative writeups: `docs/research/*.md`.
+- Cross-cutting mechanics and negative results: `docs/ARCHITECTURE.md` § Backtest harnesses.


### PR DESCRIPTION
## What & why

`backtest/` grew to ~28 top-level scripts + 11 `research/regime_*` one-shots with no index — core simulators, the M1–M6 validation series, the regime-promotion pipeline (#1065–#1097), the #1210 auto-suggester, 6 candidate studies, and a long tail of issue-specific research. You could not tell at a glance what existed, what was active vs a one-shot evidence run, or where it came from.

`Closes #1216`

## Change

1. **`docs/backtesting-registry.md`** — one table row per tool: file, one-line purpose (taken from the tool's own module docstring, not paraphrased), category (core simulator / M-series validator / regime-promotion pipeline / support library / research one-shot), status, and origin issue. Grouped by category with a taxonomy and a "where results are recorded" pointer. Covers every `.py` under `backtest/` and `backtest/research/` (excluding tests) plus the `backtest/candidates/` studies.
2. **`CLAUDE.md` § Backtest** — names the registry as SSoT and requires any PR that adds/deprecates/repurposes a harness to update its row in the same PR (the existing "new X → update Y" pattern).

## Why a doc, not the issue body

Issue bodies are not code-reviewed, do not diff against the code, and rot the day after they are written. The issue tracks the work; the versioned doc is the living artifact, kept honest by the same-PR upkeep rule.

## Safety / blast radius

Documentation only — no code, no runtime, no money path.

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code
