### PR TITLE
docs(#1220): enumerate candidate-study drivers + harden registry completeness test

### DIFF
--- a/backtest/tests/test_backtesting_registry.py
+++ b/backtest/tests/test_backtesting_registry.py
@@ -1,17 +1,27 @@
-"""Registry completeness regression (#1216).
+"""Registry completeness regression (#1216, hardened #1220).
 
 Enforces the invariant docs/backtesting-registry.md and the CLAUDE.md upkeep
 rule both promise: every non-test harness script under backtest/ and
-backtest/research/ has exactly one entry in the registry, and the registry
-references no file that does not exist. This is what keeps the doc from silently
-drifting out of sync with the code as harnesses are added or removed.
+backtest/research/ has exactly one table row in the registry, every candidate
+study directory is listed, and the registry references no file or study that
+does not exist. This is what keeps the doc from silently drifting out of sync
+with the code as harnesses are added or removed.
+
+Matching is row-anchored and exact — a filename that is merely a *substring* of
+an already-listed one (e.g. `run.py` inside `run_backtest.py`) does NOT satisfy
+its own requirement, and an accidental duplicate row fails the "exactly one"
+check.
 """
 import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BACKTEST = REPO_ROOT / "backtest"
+CANDIDATES = BACKTEST / "candidates"
 REGISTRY = REPO_ROOT / "docs" / "backtesting-registry.md"
+
+# First-cell token of a Markdown table row: `| `<token>` | ...`
+_ROW_TOKEN = re.compile(r"(?m)^\|\s*`([^`]+)`\s*\|")
 
 
 def _is_test(name: str) -> bool:
@@ -23,40 +33,69 @@ def _harness_files():
     files = []
     for d in (BACKTEST, BACKTEST / "research"):
         for p in sorted(d.glob("*.py")):
-            if _is_test(p.name):
-                continue
-            files.append(p)
+            if not _is_test(p.name):
+                files.append(p)
     return files
+
+
+def _token_for(p: Path) -> str:
+    """The exact backtick token the registry uses: bare name, or `research/<name>`."""
+    return p.relative_to(BACKTEST).as_posix()
 
 
 def _registry_text() -> str:
     return REGISTRY.read_text()
 
 
-def test_every_harness_has_a_registry_row():
-    text = _registry_text()
-    missing = [
-        p.relative_to(BACKTEST).as_posix()
-        for p in _harness_files()
-        if p.name not in text
-    ]
-    assert not missing, (
-        "backtest/ scripts missing a row in docs/backtesting-registry.md "
-        f"(add one per the CLAUDE.md upkeep rule): {missing}"
+def _row_tokens():
+    """Every first-cell backtick token that appears as a table row, with counts."""
+    counts = {}
+    for t in _ROW_TOKEN.findall(_registry_text()):
+        counts[t] = counts.get(t, 0) + 1
+    return counts
+
+
+def test_every_harness_has_exactly_one_row():
+    rows = _row_tokens()
+    problems = []
+    for p in _harness_files():
+        tok = _token_for(p)
+        n = rows.get(tok, 0)
+        if n != 1:
+            problems.append(f"{tok}: {n} rows (want exactly 1)")
+    assert not problems, (
+        "backtest/ harness scripts must each have exactly one registry row in "
+        f"docs/backtesting-registry.md (add one per the CLAUDE.md upkeep rule): {problems}"
     )
 
 
-def test_registry_references_no_nonexistent_file():
-    """Inverse invariant: no phantom rows — every .py the doc names exists."""
-    text = _registry_text()
-    # backtick-quoted tokens ending in .py, e.g. `backtester.py`, `research/regime_1073_x.py`
-    tokens = set(re.findall(r"`([\w./-]+\.py)`", text))
+def test_every_candidate_study_has_exactly_one_row():
+    rows = _row_tokens()
+    problems = []
+    for d in sorted(CANDIDATES.iterdir()):
+        if not d.is_dir():
+            continue
+        n = rows.get(d.name, 0)
+        if n != 1:
+            problems.append(f"{d.name}: {n} rows (want exactly 1)")
+    assert not problems, (
+        "every backtest/candidates/<study>/ directory must have exactly one row "
+        f"in the candidate-studies table: {problems}"
+    )
+
+
+def test_registry_rows_reference_no_nonexistent_target():
+    """Inverse: no phantom rows — every table-row token maps to a real file or study."""
     phantom = []
-    for tok in sorted(tokens):
-        # every harness token in the doc is rooted at backtest/
-        if not (BACKTEST / tok).exists():
-            phantom.append(tok)
+    for tok in sorted(_row_tokens()):
+        if tok.endswith(".py"):
+            if not (BACKTEST / tok).exists():
+                phantom.append(f"{tok} (no such file)")
+        elif "." not in tok:
+            # bare token → a candidate study directory
+            if not (CANDIDATES / tok).is_dir():
+                phantom.append(f"{tok} (no such candidate study)")
     assert not phantom, (
-        "docs/backtesting-registry.md references files that do not exist under "
-        f"backtest/: {phantom}"
+        "docs/backtesting-registry.md has rows pointing at things that do not exist: "
+        f"{phantom}"
     )

--- a/backtest/tests/test_backtesting_registry.py
+++ b/backtest/tests/test_backtesting_registry.py
@@ -85,17 +85,17 @@ def test_every_candidate_study_has_exactly_one_row():
 
 
 def test_registry_rows_reference_no_nonexistent_target():
-    """Inverse: no phantom rows — every table-row token maps to a real file or study."""
+    """Inverse: no phantom rows — EVERY table-row token must resolve to a real
+    target (a file under backtest/ or a candidates/<study>/ directory). No token
+    shape is exempt: a dotted non-.py row (e.g. a `.jsonc` spec, or a study dir
+    whose name contains a dot) is existence-checked like any other.
+    """
     phantom = []
     for tok in sorted(_row_tokens()):
-        if tok.endswith(".py"):
-            if not (BACKTEST / tok).exists():
-                phantom.append(f"{tok} (no such file)")
-        elif "." not in tok:
-            # bare token → a candidate study directory
-            if not (CANDIDATES / tok).is_dir():
-                phantom.append(f"{tok} (no such candidate study)")
+        if (BACKTEST / tok).exists() or (CANDIDATES / tok).is_dir():
+            continue
+        phantom.append(tok)
     assert not phantom, (
-        "docs/backtesting-registry.md has rows pointing at things that do not exist: "
-        f"{phantom}"
+        "docs/backtesting-registry.md has rows pointing at things that do not exist "
+        f"(no matching file under backtest/ or candidates/<study>/ dir): {phantom}"
     )

--- a/docs/backtesting-registry.md
+++ b/docs/backtesting-registry.md
@@ -1,10 +1,13 @@
 # Backtesting & Research Harness Registry
 
-Single map of every backtesting and offline-research tool in `backtest/`. The
-sprawl (core simulators, the M1–M6 validation series, the regime-promotion
-pipeline, and a long tail of one-shot research scripts) is otherwise untracked
-and undiscoverable. This file is the source of truth; the per-subsystem
-mechanics live in [`docs/ARCHITECTURE.md` § Backtest harnesses](ARCHITECTURE.md).
+Map of the backtesting and offline-research harnesses in `backtest/`. The
+reusable tools — core simulators, the M1–M6 validation series, the
+regime-promotion pipeline, and the one-shot research scripts — are listed
+individually below; the per-study candidate suites under `backtest/candidates/`
+(each a self-contained set of executable driver scripts plus specs) are indexed
+by study rather than enumerated script-by-script. This file is the source of
+truth; the per-subsystem mechanics live in
+[`docs/ARCHITECTURE.md` § Backtest harnesses](ARCHITECTURE.md).
 
 **Upkeep rule:** any PR that adds, deprecates, or repurposes a harness updates
 its row here in the same PR. A new row is part of the change, not a follow-up.
@@ -16,6 +19,7 @@ its row here in the same PR. A new row is part of the change, not a follow-up.
 - **Regime-promotion pipeline** — the offline machinery (#1065–#1097) that decides whether a market-regime *classifier* may replace the incumbent hand-rule.
 - **Support library** — shared, non-executable infrastructure imported by the above.
 - **Research one-shot** — reproducible evidence for a single closed issue; run to regenerate a documented result, not a maintained tool.
+- **Candidate study** — a per-strategy directory under `backtest/candidates/<study>/` bundling that study's own executable driver scripts (screens/gates) and specs; indexed by study below.
 
 ## Core simulators
 
@@ -85,12 +89,27 @@ its row here in the same PR. A new row is part of the change, not a follow-up.
 
 ## Candidate studies (`backtest/candidates/`)
 
-Declarative candidate specs consumed by `eval_windows.py` / `auto_suggest.py`
-(`--candidate-json`), not harnesses themselves. Add a `<study>/suggest.json` (or
-`--candidate-json`) per study; `suggest.template.jsonc` is the annotated template.
+Each `backtest/candidates/<study>/` is a self-contained study for one strategy.
+Most bundle **executable driver scripts** — per-study screens and gates that
+shell out to the M-series harnesses above (M1 shortlist scoring, M2 close-stack
+sweeps, M4 regime-gate sweeps, walk-forward fold stability, fee-drag screens,
+continuous-audit headlines, live-label fidelity) — alongside JSON specs (fed to
+`eval_windows.py` / `auto_suggest.py` via `--candidate-json`) and a `README.md`
+recording the study's steps. Two studies share a `driver_common.py` library. A
+study may also be spec-only (e.g. `ichimoku_997`: JSON configs + README, no
+drivers). The drivers are study-local and largely parallel across studies, so
+they are indexed by study here, not enumerated script-by-script.
 
-Current studies: `breakout_984`, `breakout_1165`, `ichimoku_997`, `rahtf_1054`,
-`squeeze_983`, `squeeze_momentum_1198`.
+| Study | What it screens | Drivers | Origin |
+|-------|-----------------|---------|--------|
+| `breakout_984` | `breakout` close-stack (M2) sweeps, walk-forward, fee-drag, M1 shortlist, audit headline. | 6 | #984 |
+| `breakout_1165` | `breakout` regime-gate (M4) sweep, fee-drag, M1 shortlist, audit headline, live-label fidelity (+`driver_common.py`). | 5 + lib | #1165 |
+| `squeeze_983` | `squeeze_momentum` close-stack (M2) sweeps, walk-forward, M1 shortlist, audit headline. | 5 | #983 |
+| `squeeze_momentum_1198` | `squeeze_momentum` regime-gate (M4) sweep, fee-drag, M1 shortlist, audit headline (+`driver_common.py`). | 4 + lib | #1198 |
+| `rahtf_1054` | `regime_adaptive_htf` entry-condition split behind the M1 noise verdict. | 1 | #1054 |
+| `ichimoku_997` | Spec-only — `atr_stop`/`time_stop`/`zscore` close-config candidates + README, no drivers. | 0 | #997 |
+
+`suggest.template.jsonc` is the annotated spec template for a new study.
 
 ## Where results are recorded
 


### PR DESCRIPTION
## What & why

Follow-up to the two `Recommended Optional` findings from the PR #1217 review of `docs/backtesting-registry.md`. Both were real: the doc overstated its coverage, and the completeness test used a substring match.

`Closes #1220`

## Changes

1. **Coverage honesty (finding 1).** The intro no longer claims to map "every tool in `backtest/`" while excluding a class of harnesses. The candidate-studies section now describes `backtest/candidates/<study>/` accurately — self-contained executable driver suites (21 `__main__` drivers across 5 studies: M1 shortlist scoring, M2 close-stack sweeps, M4 regime-gate sweeps, walk-forward, fee-drag, audit headlines, live-label fidelity; 2 share a `driver_common.py` lib) — with a per-study table. Studies are indexed by study, not enumerated script-by-script (the drivers are study-local and largely parallel across studies); a spec-only study (`ichimoku_997`) is shown as 0 drivers. Added a **Candidate study** category.
2. **Test hardening (finding 2).** `test_backtesting_registry.py` now matches a **row-anchored exact backtick token** and asserts **exactly one** row per target — a filename that is a substring of a listed one (e.g. `run.py` in `run_backtest.py`) no longer passes, and a duplicate row fails. Added a check that **every candidate study directory is listed**, and a phantom-row inverse covering both files and studies.

## Must-survive cases (verified)

- Substring name (`run.py` vs `run_backtest.py`): both independently required — proven `run.py`/`backtest.py` have 0 rows.
- A new candidate study directory (with or without drivers) must be listed — forward study check.
- A spec-only study dir does not force per-spec rows — `ichimoku_997` passes with 0 drivers.
- A driver moved up into `backtest/research/` is caught by the top-level harness check.
- Duplicate row → fails the exactly-one check.

## Safety / blast radius

Documentation + test only — no code, no runtime, no money path.

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code
