### PR TITLE
fix: skip #1211 incumbent-baseline smoke test before any live-data fallback fires

### DIFF
--- a/backtest/tests/test_regime_1211_incumbent_baseline.py
+++ b/backtest/tests/test_regime_1211_incumbent_baseline.py
@@ -290,7 +290,21 @@ def test_load_cell_rejects_non_monotonic_index(monkeypatch):
 
 def test_load_cell_on_cached_data_if_available():
     """If the BTC/USDT 1h OOS cache exists, load_cell returns a scoreable cell whose kruskal_h
-    matches run_window's h4 (proving the harness mirrors the incumbent measurement exactly)."""
+    matches run_window's h4 (proving the harness mirrors the incumbent measurement exactly).
+
+    Both load_cell and run_window fall back to a *live* exchange fetch when the local cache is
+    empty (data_fetcher.load_cached_data). Two independent live fetches issued a few seconds
+    apart race the market and can disagree by more than pytest.approx's tolerance, so this must
+    check the cache directly and skip BEFORE calling either -- never let the live-fetch fallback
+    fire here (that's what made this test flaky in CI, which has no pre-populated cache)."""
+    import pandas as pd
+    import storage
+    from eval_windows import WINDOWS, PLATFORM
+    start, end = WINDOWS["oos"]
+    start_ts = int(pd.Timestamp(start).timestamp() * 1000) if start else None
+    end_ts = int(pd.Timestamp(end).timestamp() * 1000) if end else None
+    if storage.load_ohlcv(PLATFORM, "BTC/USDT", "1h", start_ts, end_ts).empty:
+        pytest.skip("no cached data: BTC/USDT 1h oos not pre-populated locally")
     cell = M.load_cell("BTC/USDT", "1h", "oos")
     if cell["status"] != "available":
         pytest.skip(f"no cached data: {cell.get('reason')}")


### PR DESCRIPTION
## Summary
- `test_load_cell_on_cached_data_if_available` (backtest/tests/test_regime_1211_incumbent_baseline.py) was flaky in CI: https://github.com/richkuo/go-trader/actions/runs/28640038779/job/84934073421
- Its skip guard only checked `load_cell()`'s returned status, but `load_cell()` and `run_window()` both call `data_fetcher.load_cached_data()`, which silently falls back to a **live** exchange fetch when the local OHLCV cache is empty (true on a fresh CI checkout).
- The test then issued two independent live BTC/USDT fetches a few seconds apart; market movement between them shifted the computed `kruskal_h` values outside `pytest.approx`'s tolerance (79.3134 vs 79.3116), failing CI on an unrelated push.
- Fix: check the cache directly via `storage.load_ohlcv()` (same start/end window resolution) *before* calling `load_cell` or `run_window`, and skip immediately if empty — neither live-fetch fallback can fire anymore.

## Test plan
- [x] `python -m py_compile` on the changed file
- [x] Targeted run: `pytest backtest/tests/test_regime_1211_incumbent_baseline.py -v` — 25 passed (test executes and asserts correctly against the locally populated cache, confirming the fix doesn't change behavior when cache is present)
- [x] Full `pytest backtest/tests/` — 1070 passed, 0 failed

---
Created with LLM: Sonnet 5 | high | Harness: Claude Code