### PR TITLE
fix(ci): grant review job pull-requests:write so @claude PR review can comment

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -242,15 +242,17 @@ jobs:
     needs: classify
     if: needs.classify.outputs.invoked == 'true' && needs.classify.outputs.mode == 'review'
     permissions:
-      # Untrusted-content path: read-only on code AND on the PR. This repo is
-      # PUBLIC, so external fork-PR reviews run here — the agent posts its review
-      # through the issue-comments endpoint (issues: write covers gh pr comment +
-      # the footer PATCH) and only needs to READ PR context, so pull-requests
-      # stays read. Dropping write removes the ability to close, edit, retitle, or
-      # relabel a PR through an allowed interpreter acting on a prompt-injected
-      # diff — contents: read already blocks push/merge.
+      # Untrusted-content path (this repo is PUBLIC, so external fork-PR reviews
+      # run here): read-only on CODE — contents: read blocks push/merge, so a
+      # prompt-injected diff can never ship. pull-requests: write is REQUIRED, not
+      # optional: a review comment targets a PR, and GitHub authorizes
+      # POST /issues/{n}/comments by the target's type — for a pull request that
+      # is pull-requests: write, NOT issues: write (which only covers real
+      # issues). The residual power it grants (close/edit/retitle a PR via an
+      # allowed interpreter on a prompt-injected diff) is the accepted cost of
+      # posting the review at all; merge still requires contents: write.
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
     uses: ./.github/workflows/claude-run.yml
     with:


### PR DESCRIPTION
## Problem

The `@claude` review job runs with `pull-requests: read`, so posting its tracking comment on a PR fails with `Resource not accessible by integration` (403).

Root cause: the least-privilege split (#1178 port) assumed `issues: write` covers PR comments via the shared issues-comments endpoint. GitHub authorizes `POST /issues/{n}/comments` by the **target's type**, so a comment on a pull request requires `pull-requests: write`, not `issues: write`.

## Fix

Change the `review` job's `pull-requests: read` → `write` and correct the rationale comment. `contents: read` is unchanged, so the untrusted-content review path — which on this **public** repo also serves external fork-PR reviews — still can't push or merge (merge requires `contents: write`).

Identical regression found and fixed in job-search and scenecut-front from the same port; scene-cut-ai and the rk-skills template were already correct.

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code

https://claude.ai/code/session_01JxNLCdbEX1wtrnEuPEordZ