### PR TITLE
fix(#1228): backtest audit — close 5 simulation-correctness/parity defects

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -982,6 +982,7 @@ class Backtester:
                 parse_regime_atr_block,
                 resolve_regime_atr,
                 unified_regime_scalar_params,
+                validate_unified_regime_close,
             )
 
             # #841 unified per-regime close block: the close ref owns the
@@ -1001,6 +1002,19 @@ class Backtester:
                     self._unified_close_params = dict(_params)
                 break
             if self._unified_close_params is not None:
+                # #1228 review round 3: mirror live's validateUnifiedRegimeClose
+                # — every stampable label must carry a positive stop_loss_atr
+                # (and >=2 valid tp_tiers). Live rejects such a config at load;
+                # simulating it would run a regime with no stop at all.
+                _unified_errs = validate_unified_regime_close(
+                    self._unified_close_params,
+                    labels=self._regime_primary_labels,
+                )
+                if _unified_errs:
+                    raise ValueError(
+                        "Invalid unified per-regime close block: "
+                        + "; ".join(_unified_errs)
+                    )
                 _sole_owner_conflicts = [
                     ("stop_loss_atr_mult", self.stop_loss_atr_mult),
                     ("stop_loss_pct", self.stop_loss_pct),

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -230,6 +230,18 @@ def _gate_directional_policy_by_states(
       - dict  -> keep only the per-state-supported overrides."""
     if not policy:
         return policy
+    # #1124/#1228: live Resolve falls back from a sub-label stamp to the bare
+    # ranging_directional policy entry (exact match wins first). Mirror that by
+    # expanding a bare entry onto its uncovered subs before the per-state gate,
+    # so a cert for e.g. ranging_directional_up honors a bare-only policy the
+    # way live does.
+    from regime import RANGING_DIRECTIONAL_BARE, RANGING_DIRECTIONAL_SUBS
+    bare_entry = policy.get(RANGING_DIRECTIONAL_BARE)
+    if isinstance(bare_entry, dict):
+        expanded = dict(policy)
+        for sub in sorted(RANGING_DIRECTIONAL_SUBS):
+            expanded.setdefault(sub, bare_entry)
+        policy = expanded
     if cert_states is None:
         return policy
     gated = {}
@@ -257,6 +269,12 @@ def _resolve_regime_directional_entry(
     if position_qty > 0 and str(position_regime or "").strip():
         regime = str(position_regime or "").strip()
     entry = policy.get(regime)
+    if not isinstance(entry, dict):
+        # #1124/#1228: mirror live Resolve — a sub-label stamp falls back to
+        # the bare ranging_directional entry (exact match wins first).
+        from regime import RANGING_DIRECTIONAL_BARE, RANGING_DIRECTIONAL_SUBS
+        if regime in RANGING_DIRECTIONAL_SUBS:
+            entry = policy.get(RANGING_DIRECTIONAL_BARE)
     return dict(entry) if isinstance(entry, dict) else None
 
 
@@ -884,6 +902,11 @@ class Backtester:
         self._uses_regime_tiered_close = _close_refs_use_regime_tiered_tp(
             self._close_refs,
         )
+        # #841 unified per-regime close SL ownership; populated below when the
+        # regime-ATR helpers are imported (unified requires a regime tiered
+        # close, which forces that import path).
+        self._unified_close_params: Optional[dict] = None
+        self._unified_scalar_params = None
         self._uses_trailing_ratchet_close = any(
             (r.get("name") or "").strip().lower()
             in ("trailing_tp_ratchet", "trailing_tp_ratchet_regime")
@@ -954,9 +977,51 @@ class Backtester:
             from regime_atr import (  # type: ignore
                 SURFACE_STOP_LOSS,
                 SURFACE_TRAILING,
+                close_params_are_unified_regime,
                 parse_regime_atr_block,
                 resolve_regime_atr,
+                unified_regime_scalar_params,
             )
+
+            # #841 unified per-regime close block: the close ref owns the
+            # per-regime stop loss (stop_loss_atr inside each label entry).
+            # Mirrors Go: unifiedCloseStopLossATR arms the SL, and
+            # validateUnifiedCloseSoleOwner forbids any strategy-level stop
+            # owner alongside the block. Without this, a unified close with
+            # stop_loss_atr backtested with no stop at all (#1228 audit).
+            self._unified_close_params = None
+            self._unified_scalar_params = unified_regime_scalar_params
+            for _ref in self._close_refs:
+                _n = (_ref.get("name") or "").strip().lower()
+                if _n not in ("tiered_tp_atr_regime", "tiered_tp_atr_live_regime"):
+                    continue
+                _params = _ref.get("params") or {}
+                if close_params_are_unified_regime(_params):
+                    self._unified_close_params = dict(_params)
+                break
+            if self._unified_close_params is not None:
+                _sole_owner_conflicts = [
+                    ("stop_loss_atr_mult", self.stop_loss_atr_mult),
+                    ("stop_loss_pct", self.stop_loss_pct),
+                    ("stop_loss_margin_pct", self.stop_loss_margin_pct),
+                    ("trailing_stop_atr_mult", self.trailing_stop_atr_mult),
+                    ("trailing_stop_pct", self.trailing_stop_pct),
+                ]
+                for _field, _val in _sole_owner_conflicts:
+                    if _val is not None and _val > 0:
+                        raise ValueError(
+                            f"{_field} is not allowed alongside a unified "
+                            "per-regime close — the close owns the SL via "
+                            "per-regime stop_loss_atr"
+                        )
+                if self.stop_loss_atr_regime is not None or (
+                    self.trailing_stop_atr_regime is not None
+                ):
+                    raise ValueError(
+                        "stop_loss_atr_regime/trailing_stop_atr_regime are not "
+                        "allowed alongside a unified per-regime close — the "
+                        "close owns the SL via per-regime stop_loss_atr"
+                    )
 
             regime_errs: list[str] = []
             if self.stop_loss_atr_regime is not None:
@@ -1636,6 +1701,20 @@ class Backtester:
                     self._run_trailing_stop_atr_mult = self._resolve_regime_atr(
                         self._trailing_stop_regime_block, lab,
                     )
+            # #841 unified per-regime close: the block owns the SL — resolve
+            # the stamped regime's stop_loss_atr as the run's fixed-SL mult
+            # (mirrors unifiedCloseStopLossATR in scheduler/regime_unified.go).
+            if (
+                self._run_stop_loss_atr_mult is None
+                and self._unified_close_params is not None
+                and self._unified_scalar_params is not None
+                and lab
+            ):
+                _, _usl = self._unified_scalar_params(
+                    self._unified_close_params, lab
+                )
+                if _usl and _usl > 0:
+                    self._run_stop_loss_atr_mult = float(_usl)
             if self._run_stop_loss_atr_mult is None:
                 if (
                     self.stop_loss_atr_mult is not None
@@ -2449,19 +2528,33 @@ class Backtester:
 
     def _stamp_entry_atr(self, atr_series: Optional[pd.Series], idx,
                          entry_price: float) -> float:
-        """Return the ATR at ``idx`` for stamping ``Position.EntryATR``.
+        """Return the ATR to stamp as ``Position.EntryATR`` for a fill at
+        ``idx``.
 
-        Mirrors ``stampEntryATRIfOpened`` in scheduler/main.go: rejects NaN
-        and any value greater than 50% of the entry price as a plausibility
-        guard. Returns 0.0 when no usable ATR is available — close evaluators
-        that require ATR (``tiered_tp_atr``) then fall through with a no-op
-        until a position with a valid ATR is opened.
+        Reads the bar BEFORE ``idx``: the fill happens at ``idx``'s open, when
+        that bar's own high/low/close (and hence its ATR) are still unknown.
+        Live stamps the last closed bar's ATR at order time (signal bar N; the
+        fill bar is N+1), so the closed-bar value is bar N's — reading the
+        fill bar's ATR leaked that bar's own range into the stop/TP geometry
+        (#1228 audit). Mirrors ``stampEntryATRIfOpened`` in scheduler/main.go:
+        rejects NaN and any value greater than 50% of the entry price as a
+        plausibility guard. Returns 0.0 when no usable ATR is available —
+        close evaluators that require ATR (``tiered_tp_atr``) then fall
+        through with a no-op until a position with a valid ATR is opened.
         """
         if atr_series is None or entry_price <= 0:
             return 0.0
         try:
-            value = float(atr_series.loc[idx])
+            pos = int(atr_series.index.get_loc(idx))
         except (KeyError, TypeError, ValueError):
+            # Missing label, or a non-unique index where get_loc returns a
+            # slice/mask — no unambiguous prior bar; treat as no usable ATR.
+            return 0.0
+        if pos < 1:
+            return 0.0
+        try:
+            value = float(atr_series.iloc[pos - 1])
+        except (TypeError, ValueError):
             return 0.0
         if not (value > 0):  # rejects NaN, 0, negative
             return 0.0

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -268,13 +268,14 @@ def _resolve_regime_directional_entry(
     regime = str(current_regime or "").strip()
     if position_qty > 0 and str(position_regime or "").strip():
         regime = str(position_regime or "").strip()
+    # Exact match ONLY — deliberately no bare→sub fallback here. Runtime
+    # always resolves the ALREADY-GATED policy
+    # (_gate_directional_policy_by_states expands a bare ranging_directional
+    # entry onto its subs SUBJECT TO each sub's own per-state certification),
+    # so a bare-certified-but-sub-uncertified stamp must miss and fall back to
+    # base, mirroring live's fail-closed gatedDirectionalEntry (#1085/#1124
+    # exact-match cert, no family fallback).
     entry = policy.get(regime)
-    if not isinstance(entry, dict):
-        # #1124/#1228: mirror live Resolve — a sub-label stamp falls back to
-        # the bare ranging_directional entry (exact match wins first).
-        from regime import RANGING_DIRECTIONAL_BARE, RANGING_DIRECTIONAL_SUBS
-        if regime in RANGING_DIRECTIONAL_SUBS:
-            entry = policy.get(RANGING_DIRECTIONAL_BARE)
     return dict(entry) if isinstance(entry, dict) else None
 
 

--- a/backtest/eval_windows.py
+++ b/backtest/eval_windows.py
@@ -120,20 +120,33 @@ def dd_adjusted_return(return_pct: float, max_dd_pct: float) -> float:
     return return_pct / abs(max_dd_pct)
 
 
+# #1005/#1228: mirrors backtest/backtester.py LIQUIDATED_METRIC_FLOOR (kept in
+# sync by test_eval_windows). A liquidated leg reads return −100% / DD −100%,
+# so raw DDadj is −1.0 — OUTRANKING a surviving losing leg (e.g. −50% return
+# on 25% DD scores −2.0). Floor the axis like Sharpe so a dead account always
+# sorts below any survivor.
+LIQUIDATED_DDADJ_FLOOR = -100.0
+
+
 def leg_from_results(results: dict, bh_return_pct: Optional[float] = None) -> dict:
     """Collapse a Backtester result dict to the per-leg metrics M1 reports."""
     ret = float(results["total_return_pct"])
     dd = float(results["max_drawdown_pct"])
+    liquidated = bool(results.get("liquidated"))
     return {
         "sharpe": float(results["sharpe_ratio"]),
         "return_pct": ret,
         "max_dd_pct": dd,
-        "ddadj": round(dd_adjusted_return(ret, dd), 3),
+        "ddadj": (
+            LIQUIDATED_DDADJ_FLOOR
+            if liquidated
+            else round(dd_adjusted_return(ret, dd), 3)
+        ),
         "trades": int(results["total_trades"]),
         "bh_return_pct": bh_return_pct,
         # #1005: equity hit 0 — metrics are floored at the bust bar (return
         # and DD read −100%); surfaced so blown legs are never silent.
-        "liquidated": bool(results.get("liquidated")),
+        "liquidated": liquidated,
     }
 
 

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -233,8 +233,14 @@ def _result_metric(result: dict, metric: str) -> float:
     ``dd_adjusted_return`` is derived (return / |max DD|, the #963 DDadj
     definition mirrored from eval_windows.dd_adjusted_return — zero-DD legs
     score 0.0 so untraded combos never win); other metrics are read directly.
+
+    #1005/#1228: a liquidated combo is floored to −100 (mirrors
+    eval_windows.LIQUIDATED_DDADJ_FLOOR) — its raw DDadj would be −1.0,
+    letting a blown-up combo outrank a surviving losing one.
     """
     if metric == "dd_adjusted_return":
+        if result.get("liquidated"):
+            return -100.0
         ret = float(result.get("total_return_pct", 0) or 0)
         dd = float(result.get("max_drawdown_pct", 0) or 0)
         return ret / abs(dd) if dd else 0.0

--- a/backtest/parity_diff.py
+++ b/backtest/parity_diff.py
@@ -196,7 +196,12 @@ def config_from_live_config(config_path: str, strategy_id: str,
     timeframe / registry / regime settings the loader doesn't return.
     """
     from run_backtest import load_strategy_config
-    loaded = load_strategy_config(config_path, strategy_id)
+    # #1228: live applies user_defaults.{close,regime_atr,manual}
+    # unconditionally in loadConfig, so a live-parity replay must inject them
+    # too — without this the diff could report CLEAN against effective params
+    # live never runs.
+    loaded = load_strategy_config(config_path, strategy_id,
+                                  inject_user_defaults=True)
     with open(config_path) as fh:
         raw = json.load(fh)
     entry = next(

--- a/backtest/tests/test_backtester_close_strategies.py
+++ b/backtest/tests/test_backtester_close_strategies.py
@@ -796,3 +796,34 @@ def test_unified_regime_close_rejects_second_sl_owner():
             }},
             close_strategies=[_UNIFIED_CLOSE],
         )
+
+
+def test_unified_regime_close_bare_block_arms_sl_for_directional_sub_stamp():
+    # #1124/#1228 review: a bare-only ranging_directional unified block must
+    # arm its stop for a position stamped with the _up/_down sub-label, like
+    # live's unifiedRegimeScalarParams bare fallback.
+    close_ref = {
+        "name": "tiered_tp_atr_regime",
+        "params": {"trend_regime": {
+            "ranging_directional": {
+                "tp_tiers": [{"atr_multiple": 99.0, "close_fraction": 1.0}],
+                "stop_loss_atr": 1.0,
+            },
+        }},
+    }
+    idx = pd.date_range("2024-01-01", periods=6, freq="D")
+    df = pd.DataFrame({
+        "open": [100, 100, 100, 95, 95, 95],
+        "close": [100, 100, 96, 95, 95, 95],
+        "atr": [2, 2, 2, 2, 2, 2],
+        "regime": ["ranging_directional_up"] * 6,
+        "open_action": ["long", "none", "none", "none", "none", "none"],
+    }, index=idx)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=[close_ref],
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] == 95.0
+    assert result["trades"][0]["exit_date"] == str(idx[3])

--- a/backtest/tests/test_backtester_close_strategies.py
+++ b/backtest/tests/test_backtester_close_strategies.py
@@ -7,6 +7,7 @@ applied at the next bar's open (same fill alignment as the column-based
 close_fraction path).
 """
 import pandas as pd
+import pytest
 
 from backtester import Backtester
 
@@ -703,3 +704,95 @@ def test_avwap_stop_does_not_warn_when_not_configured(capsys):
     _run_avwap_stop_backtest(df, [{"name": "tp_at_pct", "params": {"pct": 0.03}}])
     err = capsys.readouterr().err
     assert _AVWAP_WARN_MARK not in err
+
+
+# ---------------------------------------------------------------------------
+# #841/#1228: unified per-regime close block — the close ref owns the
+# per-regime stop loss. Pre-fix the backtester dropped it entirely (a unified
+# close with stop_loss_atr simulated with NO stop), inflating results vs live.
+# ---------------------------------------------------------------------------
+
+_UNIFIED_CLOSE = {
+    "name": "tiered_tp_atr_regime",
+    # #841 unified shape: one trend_regime block holding each label's whole
+    # exit plan (tp_tiers + stop_loss_atr).
+    "params": {"trend_regime": {
+        "ranging": {
+            "tp_tiers": [{"atr_multiple": 99.0, "close_fraction": 1.0}],
+            "stop_loss_atr": 1.0,
+        },
+        "trending_up": {
+            "tp_tiers": [{"atr_multiple": 99.0, "close_fraction": 1.0}],
+            "stop_loss_atr": 2.0,
+        },
+        "trending_down": {
+            "tp_tiers": [{"atr_multiple": 99.0, "close_fraction": 1.0}],
+            "stop_loss_atr": 2.0,
+        },
+    }},
+}
+
+
+def _df_unified():
+    # Bar 0 emits long + regime "ranging" -> fill at bar 1 open ($100) with
+    # stamped regime ranging (shifted read of bar 0). Entry ATR = bar 0's
+    # closed ATR = 2. ranging stop_loss_atr 1.0 -> trigger 98. Bar 2 close 96
+    # breaches -> SL fill at bar 3 OPEN ($95).
+    idx = pd.date_range("2024-01-01", periods=6, freq="D")
+    return pd.DataFrame({
+        "open": [100, 100, 100, 95, 95, 95],
+        "close": [100, 100, 96, 95, 95, 95],
+        "atr": [2, 2, 2, 2, 2, 2],
+        "regime": ["ranging"] * 6,
+        "open_action": ["long", "none", "none", "none", "none", "none"],
+    }, index=idx)
+
+
+def test_unified_regime_close_arms_per_regime_stop_loss():
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=[_UNIFIED_CLOSE],
+    )
+    result = bt.run(_df_unified(), save=False)
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] == 95.0
+    assert result["trades"][0]["exit_date"] == str(_df_unified().index[3])
+
+
+def test_unified_regime_close_no_stop_without_breach():
+    # Same config, price never reaches the 98 trigger -> holds to end of data.
+    idx = pd.date_range("2024-01-01", periods=5, freq="D")
+    df = pd.DataFrame({
+        "open": [100, 100, 100, 99, 99],
+        "close": [100, 100, 99, 99, 99],
+        "atr": [2, 2, 2, 2, 2],
+        "regime": ["ranging"] * 5,
+        "open_action": ["long", "none", "none", "none", "none"],
+    }, index=idx)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=[_UNIFIED_CLOSE],
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_date"] == str(idx[4])
+
+
+def test_unified_regime_close_rejects_second_sl_owner():
+    # Mirrors Go validateUnifiedCloseSoleOwner: the unified block owns the SL.
+    with pytest.raises(ValueError, match="unified per-regime close"):
+        Backtester(
+            initial_capital=1000, commission_pct=0, slippage_pct=0,
+            stop_loss_atr_mult=1.5,
+            close_strategies=[_UNIFIED_CLOSE],
+        )
+    with pytest.raises(ValueError, match="unified per-regime close"):
+        Backtester(
+            initial_capital=1000, commission_pct=0, slippage_pct=0,
+            stop_loss_atr_regime={"trend_regime": {
+                "ranging": {"atr_multiple": 1.0},
+                "trending_up": {"atr_multiple": 1.0},
+                "trending_down": {"atr_multiple": 1.0},
+            }},
+            close_strategies=[_UNIFIED_CLOSE],
+        )

--- a/backtest/tests/test_backtester_close_strategies.py
+++ b/backtest/tests/test_backtester_close_strategies.py
@@ -718,15 +718,18 @@ _UNIFIED_CLOSE = {
     # exit plan (tp_tiers + stop_loss_atr).
     "params": {"trend_regime": {
         "ranging": {
-            "tp_tiers": [{"atr_multiple": 99.0, "close_fraction": 1.0}],
+            "tp_tiers": [{"atr_multiple": 98.0, "close_fraction": 0.5},
+                         {"atr_multiple": 99.0, "close_fraction": 1.0}],
             "stop_loss_atr": 1.0,
         },
         "trending_up": {
-            "tp_tiers": [{"atr_multiple": 99.0, "close_fraction": 1.0}],
+            "tp_tiers": [{"atr_multiple": 98.0, "close_fraction": 0.5},
+                         {"atr_multiple": 99.0, "close_fraction": 1.0}],
             "stop_loss_atr": 2.0,
         },
         "trending_down": {
-            "tp_tiers": [{"atr_multiple": 99.0, "close_fraction": 1.0}],
+            "tp_tiers": [{"atr_multiple": 98.0, "close_fraction": 0.5},
+                         {"atr_multiple": 99.0, "close_fraction": 1.0}],
             "stop_loss_atr": 2.0,
         },
     }},
@@ -798,18 +801,33 @@ def test_unified_regime_close_rejects_second_sl_owner():
         )
 
 
+_COMPOSITE_SPEC_1228 = {"medium": {"classifier": "composite", "period": 21}}
+
+
+def _unified_composite_block(bare_sl=1.0, include_bare_sl=True):
+    """Exhaustive 7-key composite unified block (bare ranging_directional
+    covers _up/_down per #1124); never-firing far TPs; stop_loss_atr 99 on
+    non-directional labels so only the bare SL is exercised."""
+    far = [{"atr_multiple": 98.0, "close_fraction": 0.5},
+           {"atr_multiple": 99.0, "close_fraction": 1.0}]
+    bare = {"tp_tiers": [dict(t) for t in far]}
+    if include_bare_sl:
+        bare["stop_loss_atr"] = bare_sl
+    block = {"ranging_directional": bare}
+    for lab in ("ranging_quiet", "ranging_volatile", "trending_up_clean",
+                "trending_up_choppy", "trending_down_clean",
+                "trending_down_choppy"):
+        block[lab] = {"tp_tiers": [dict(t) for t in far], "stop_loss_atr": 99.0}
+    return block
+
+
 def test_unified_regime_close_bare_block_arms_sl_for_directional_sub_stamp():
     # #1124/#1228 review: a bare-only ranging_directional unified block must
     # arm its stop for a position stamped with the _up/_down sub-label, like
     # live's unifiedRegimeScalarParams bare fallback.
     close_ref = {
         "name": "tiered_tp_atr_regime",
-        "params": {"trend_regime": {
-            "ranging_directional": {
-                "tp_tiers": [{"atr_multiple": 99.0, "close_fraction": 1.0}],
-                "stop_loss_atr": 1.0,
-            },
-        }},
+        "params": {"trend_regime": _unified_composite_block(bare_sl=1.0)},
     }
     idx = pd.date_range("2024-01-01", periods=6, freq="D")
     df = pd.DataFrame({
@@ -821,9 +839,76 @@ def test_unified_regime_close_bare_block_arms_sl_for_directional_sub_stamp():
     }, index=idx)
     bt = Backtester(
         initial_capital=1000, commission_pct=0, slippage_pct=0,
+        regime_windows_spec=_COMPOSITE_SPEC_1228,
         close_strategies=[close_ref],
     )
     result = bt.run(df, save=False)
     assert result["total_trades"] == 1
     assert result["trades"][0]["exit_price"] == 95.0
     assert result["trades"][0]["exit_date"] == str(idx[3])
+
+
+# ---------------------------------------------------------------------------
+# #1228 review round 3: mirror live validateUnifiedRegimeClose — a unified
+# label with tp_tiers but no positive stop_loss_atr must be REJECTED at load
+# (live refuses to start on it), never simulated stopless.
+# ---------------------------------------------------------------------------
+
+def _unified_adx_block(sl_overrides=None, drop_sl_for=()):
+    far = [{"atr_multiple": 98.0, "close_fraction": 0.5},
+           {"atr_multiple": 99.0, "close_fraction": 1.0}]
+    block = {}
+    for lab in ("ranging", "trending_up", "trending_down"):
+        entry = {"tp_tiers": [dict(t) for t in far]}
+        if lab not in drop_sl_for:
+            entry["stop_loss_atr"] = (sl_overrides or {}).get(lab, 1.0)
+        block[lab] = entry
+    return {"name": "tiered_tp_atr_regime", "params": {"trend_regime": block}}
+
+
+def test_unified_close_missing_stop_loss_atr_rejected_at_load():
+    with pytest.raises(ValueError, match="stop_loss_atr"):
+        Backtester(
+            initial_capital=1000, commission_pct=0, slippage_pct=0,
+            close_strategies=[_unified_adx_block(drop_sl_for=("trending_up",))],
+        )
+
+
+def test_unified_close_nonpositive_stop_loss_atr_rejected_at_load():
+    with pytest.raises(ValueError, match="must be > 0"):
+        Backtester(
+            initial_capital=1000, commission_pct=0, slippage_pct=0,
+            close_strategies=[_unified_adx_block(sl_overrides={"ranging": 0})],
+        )
+    with pytest.raises(ValueError, match="must be > 0"):
+        Backtester(
+            initial_capital=1000, commission_pct=0, slippage_pct=0,
+            close_strategies=[_unified_adx_block(sl_overrides={"ranging": -1.5})],
+        )
+
+
+def test_unified_close_bare_block_without_sl_rejected_at_load():
+    # Compound of round 1 + round 3: the bare entry serving _up/_down through
+    # the #1124 fallback must itself carry the SL, or the config is rejected.
+    close_ref = {
+        "name": "tiered_tp_atr_regime",
+        "params": {"trend_regime": _unified_composite_block(
+            include_bare_sl=False)},
+    }
+    with pytest.raises(ValueError, match="stop_loss_atr"):
+        Backtester(
+            initial_capital=1000, commission_pct=0, slippage_pct=0,
+            regime_windows_spec=_COMPOSITE_SPEC_1228,
+            close_strategies=[close_ref],
+        )
+
+
+def test_unified_close_single_tier_rejected_at_load():
+    ref = _unified_adx_block()
+    ref["params"]["trend_regime"]["ranging"]["tp_tiers"] = [
+        {"atr_multiple": 2.0, "close_fraction": 1.0}]
+    with pytest.raises(ValueError, match="at least 2 tiers"):
+        Backtester(
+            initial_capital=1000, commission_pct=0, slippage_pct=0,
+            close_strategies=[ref],
+        )

--- a/backtest/tests/test_backtester_lookahead.py
+++ b/backtest/tests/test_backtester_lookahead.py
@@ -578,3 +578,44 @@ def test_anchored_vwap_reversion_no_lookahead():
     assert not np.array_equal(bf[:cut], bt), (
         "forward-peeking variant should break truncation-invariance — the test "
         "is not sensitive to look-ahead")
+
+
+# ---------------------------------------------------------------------------
+# #1228: EntryATR stamp must read the last CLOSED bar before the fill bar.
+# The fill happens at bar N+1's open, when that bar's own high/low/close (and
+# hence its ATR) are still unknown — stamping the fill bar's ATR leaked its
+# own range into the stop/TP geometry.
+# ---------------------------------------------------------------------------
+
+def test_entry_atr_stamped_from_bar_before_fill():
+    # Bar 0 emits long -> fill at bar 1 open. Closed-bar ATR at order time is
+    # bar 0's (5); the fill bar's ATR (20) must NOT be stamped. With a 1xATR
+    # tier, bar 2 close 110 (=100+2x5) fires only under the closed-bar stamp
+    # (a 20-ATR stamp would need 120).
+    idx = pd.date_range("2024-01-01", periods=5, freq="D")
+    df = pd.DataFrame({
+        "open": [100, 100, 100, 110, 110],
+        "close": [100, 100, 110, 110, 110],
+        "atr": [5, 20, 20, 20, 20],
+        "open_action": ["long", "none", "none", "none", "none"],
+    }, index=idx)
+    bt = Backtester(
+        initial_capital=1000, commission_pct=0, slippage_pct=0,
+        close_strategies=[{"name": "tiered_tp_atr", "params": {"tp_tiers": [
+            {"atr_multiple": 1.0, "close_fraction": 1.0},
+        ]}}],
+    )
+    result = bt.run(df, save=False)
+    assert result["total_trades"] == 1
+    assert result["trades"][0]["exit_price"] == 110.0
+    assert result["trades"][0]["exit_date"] == str(idx[3])
+
+
+def test_entry_atr_stamp_no_prior_bar_returns_zero():
+    # A fill on the very first bar has no closed prior bar -> no usable ATR
+    # (evaluators that need it no-op), never the fill bar's own value.
+    bt = Backtester(initial_capital=1000, commission_pct=0, slippage_pct=0)
+    idx = pd.date_range("2024-01-01", periods=3, freq="D")
+    atr = pd.Series([5.0, 6.0, 7.0], index=idx)
+    assert bt._stamp_entry_atr(atr, idx[0], 100.0) == 0.0
+    assert bt._stamp_entry_atr(atr, idx[2], 100.0) == 6.0

--- a/backtest/tests/test_directional_certification.py
+++ b/backtest/tests/test_directional_certification.py
@@ -188,10 +188,45 @@ def test_gate_expands_bare_policy_onto_certified_subs():
     assert gated == {"ranging_directional_up": {"direction": "both"}}
 
 
-def test_resolve_directional_entry_bare_fallback_for_subs():
+def test_resolve_directional_entry_is_exact_match_only():
+    # #1228 review round 2: runtime resolution runs against the ALREADY-GATED
+    # policy, whose gate expands bare->subs subject to each sub's own cert. A
+    # resolve-level bare fallback would resurrect the override for a sub the
+    # gate dropped as uncertified — diverging from live's fail-closed
+    # gatedDirectionalEntry. So resolution is exact-match only.
     from backtester import _resolve_regime_directional_entry
-    policy = {"ranging_directional": {"direction": "short"}}
+    bare_only = {"ranging_directional": {"direction": "short"}}
     assert _resolve_regime_directional_entry(
-        policy, "ranging_directional_down") == {"direction": "short"}
-    # Exact sub key still wins; bare never covers non-family labels.
-    assert _resolve_regime_directional_entry(policy, "trending_up") is None
+        bare_only, "ranging_directional_down") is None
+    assert _resolve_regime_directional_entry(bare_only, "trending_up") is None
+    assert _resolve_regime_directional_entry(
+        bare_only, "ranging_directional") == {"direction": "short"}
+
+
+def test_gate_then_resolve_matches_live_cert_semantics():
+    # End-to-end gate+resolve composition, the three review must-survive cases.
+    from backtester import (
+        _gate_directional_policy_by_states,
+        _resolve_regime_directional_entry,
+    )
+    bare_policy = {"ranging_directional": {"direction": "long"}}
+    # (1) bare policy + bare-only cert + stamped _down -> BASE (live
+    # fails-closed: cert lookup is exact on the stamped sub).
+    gated = _gate_directional_policy_by_states(
+        bare_policy, {"ranging_directional": "long"})
+    assert _resolve_regime_directional_entry(
+        gated, "ranging_directional_down") is None
+    # ...while a bare stamp still honors the bare override.
+    assert _resolve_regime_directional_entry(
+        gated, "ranging_directional") == {"direction": "long"}
+    # (2) bare policy + sub cert + stamped _up -> bare override honored via
+    # the gate's cert-aware expansion.
+    gated = _gate_directional_policy_by_states(
+        bare_policy, {"ranging_directional_up": "long"})
+    assert _resolve_regime_directional_entry(
+        gated, "ranging_directional_up") == {"direction": "long"}
+    # (3) bare direction contradicts the sub's certified sign -> base.
+    gated = _gate_directional_policy_by_states(
+        bare_policy, {"ranging_directional_up": "short"})
+    assert _resolve_regime_directional_entry(
+        gated, "ranging_directional_up") is None

--- a/backtest/tests/test_directional_certification.py
+++ b/backtest/tests/test_directional_certification.py
@@ -164,3 +164,34 @@ def test_repo_artifact_is_empty_and_valid():
                             "regime_directional_certifications.json")
     certs = load_certifications(artifact)
     assert certs == {}, "the shipped artifact must certify nothing (#1076)"
+
+
+def test_gate_expands_bare_policy_onto_certified_subs():
+    # #1124/#1228: live Resolve falls back from a sub-label stamp to the bare
+    # ranging_directional policy entry. A cert for ranging_directional_up must
+    # therefore honor a bare-only policy the way live does.
+    from backtester import _gate_directional_policy_by_states
+    bare_only = {"ranging_directional": {"direction": "long"}}
+    gated = _gate_directional_policy_by_states(
+        bare_only, {"ranging_directional_up": "long"})
+    assert gated == {"ranging_directional_up": {"direction": "long"}}
+    # Contradicting cert still drops the expanded entry.
+    assert _gate_directional_policy_by_states(
+        bare_only, {"ranging_directional_up": "short"}) == {}
+    # An explicit sub key wins over the bare expansion (exact match first).
+    mixed = {
+        "ranging_directional": {"direction": "long"},
+        "ranging_directional_up": {"direction": "both"},
+    }
+    gated = _gate_directional_policy_by_states(
+        mixed, {"ranging_directional_up": "short"})
+    assert gated == {"ranging_directional_up": {"direction": "both"}}
+
+
+def test_resolve_directional_entry_bare_fallback_for_subs():
+    from backtester import _resolve_regime_directional_entry
+    policy = {"ranging_directional": {"direction": "short"}}
+    assert _resolve_regime_directional_entry(
+        policy, "ranging_directional_down") == {"direction": "short"}
+    # Exact sub key still wins; bare never covers non-family labels.
+    assert _resolve_regime_directional_entry(policy, "trending_up") is None

--- a/backtest/tests/test_metrics_liquidation.py
+++ b/backtest/tests/test_metrics_liquidation.py
@@ -287,3 +287,29 @@ def test_render_markdown_liquidated_section_only_when_present():
     clean = fa.aggregate_strategy("ok", "spot", [_fa_leg(False)])
     md_clean = fa.render_markdown(fa.rank_rows([clean]), meta)
     assert "## Liquidated legs" not in md_clean
+
+
+# ---------------------------------------------------------------------------
+# #1228: DDadj liquidation floor — a dead account must never outrank a
+# surviving losing leg on the ddadj axis (raw DDadj of a blown leg is
+# −100/|−100| = −1.0, better than a −50%/25%-DD survivor's −2.0).
+# ---------------------------------------------------------------------------
+
+def test_liquidated_ddadj_floor_constant_mirrors_backtester():
+    from backtester import LIQUIDATED_METRIC_FLOOR
+    assert ew.LIQUIDATED_DDADJ_FLOOR == -LIQUIDATED_METRIC_FLOOR
+
+
+def test_leg_from_results_floors_ddadj_when_liquidated():
+    blown = ew.leg_from_results(_results())
+    assert blown["ddadj"] == ew.LIQUIDATED_DDADJ_FLOOR
+    survivor = ew.leg_from_results(
+        _results(ret=-50.0, dd=-25.0, sharpe=-1.0, liquidated=False))
+    assert survivor["ddadj"] == pytest.approx(-2.0)
+    # The whole point: the survivor must outrank the blown leg.
+    assert survivor["ddadj"] > blown["ddadj"]
+
+
+def test_leg_from_results_ddadj_unfloored_when_not_liquidated():
+    leg = ew.leg_from_results(_results(ret=30.0, dd=-15.0, liquidated=False))
+    assert leg["ddadj"] == pytest.approx(2.0)

--- a/backtest/tests/test_optimizer_close_stacks.py
+++ b/backtest/tests/test_optimizer_close_stacks.py
@@ -390,3 +390,18 @@ def test_optimize_long_direction_with_no_close_ref_runs():
     sides = {t["side"] for w in result["window_results"]
              for t in w["test_result"]["trades"]}
     assert sides <= {"long"}, sides
+
+
+def test_result_metric_dd_adjusted_return_floors_liquidated():
+    # #1228: a blown-up combo's raw DDadj (−100/|−100| = −1.0) would outrank a
+    # surviving loser (−60%/30% DD = −2.0); the floor keeps dead combos last.
+    blown = _result_metric(
+        {"total_return_pct": -100.0, "max_drawdown_pct": -100.0,
+         "liquidated": True},
+        "dd_adjusted_return")
+    survivor = _result_metric(
+        {"total_return_pct": -60.0, "max_drawdown_pct": -30.0,
+         "liquidated": False},
+        "dd_adjusted_return")
+    assert blown == -100.0
+    assert survivor > blown

--- a/backtest/tests/test_parity_diff.py
+++ b/backtest/tests/test_parity_diff.py
@@ -636,3 +636,30 @@ def test_registry_close_advances_quantity_ladder():
     assert fracs[40] == pytest.approx(2.0 / 3.0)
     assert contexts[41]["current_quantity"] == pytest.approx(0.2)
     assert fracs[41] == pytest.approx(0.0)
+
+
+def test_config_mode_injects_user_close_defaults(tmp_path):
+    """#1228: live applies user_defaults unconditionally at loadConfig, so the
+    parity replay must inject them too — otherwise the diff replays params
+    live never runs and can report CLEAN against the wrong effective config."""
+    import json as _json
+    cfg_path = tmp_path / "config.json"
+    ladder = [
+        {"atr_multiple": 1.0, "close_fraction": 0.5},
+        {"atr_multiple": 2.0, "close_fraction": 1.0},
+    ]
+    cfg_path.write_text(_json.dumps({
+        "config_version": 16,
+        "user_defaults": {"close": {"tiered_tp_atr": {"tp_tiers": ladder}}},
+        "strategies": [{
+            "id": "hl-sma-btc",
+            "type": "perps",
+            "script": "shared_scripts/check_hyperliquid.py",
+            "args": ["sma_crossover", "BTC/USDT", "4h"],
+            "open_strategy": {"name": "sma_crossover", "params": {}},
+            "close_strategy": {"name": "tiered_tp_atr",
+                               "params": {"use_defaults": True}},
+        }],
+    }))
+    cfg = config_from_live_config(str(cfg_path), "hl-sma-btc")
+    assert cfg.close_refs[0]["params"].get("tp_tiers") == ladder

--- a/docs/research/1228-backtest-audit.md
+++ b/docs/research/1228-backtest-audit.md
@@ -69,7 +69,12 @@ input assembly and parsing mirrors:
   entry cover `_up`/`_down` stamps, exact match winning first; cert gating stays exact
   per #1124). Inert while the cert artifact is empty, but a real mirror gap once any cert
   lands. The backtest gate now expands a bare entry onto uncovered subs before the
-  per-state cert check, and runtime resolution falls back bare→sub like live.
+  per-state cert check — so a sub honors the bare override only when that sub's OWN
+  certification passes; runtime resolution against the gated policy stays exact-match,
+  matching live's fail-closed `gatedDirectionalEntry` (a bare cert never certifies an
+  uncertified sub). The shared `unified_regime_scalar_params` helper also gained the
+  live bare→sub fallback (review round 1) so a bare-only unified close block arms its
+  SL/TPs for a directional sub-label stamp.
 - Verified PARITY: regime gating (#1025/#1124 one-directional family rule), #1085
   evidence gate (default-off, fail-closed, exact cert lookup), reject list otherwise
   exhaustive against `closeStrategyOwnedKeys` (mirror-enforced by Go test), default

--- a/docs/research/1228-backtest-audit.md
+++ b/docs/research/1228-backtest-audit.md
@@ -1,0 +1,131 @@
+# #1228 — End-to-end audit of the backtest system (look-ahead, live parity, fee/metric fidelity)
+
+Audit of the backtest engine and harnesses at HEAD `d5840bd` (2026-07-05), per issue #1228.
+Six parallel audit passes (look-ahead, fill/accounting, live-vs-backtest parity, metrics
+math, M-series statistics, registry conformance); every finding re-verified against code
+before any fix landed. Baseline before changes: `backtest/tests/` 1069 passed / 1 skipped;
+remaining pytest suite 1234 passed.
+
+## Per-subsystem verdicts
+
+### 1. Look-ahead — CLEAN except one leak (fixed)
+
+- The three #1153/#1154 HTF `.shift(1)`-before-`reindex` fixes (`_htf_trend_series`,
+  `_aligned_regime_columns`, `_profile_label_series`) are intact and test-pinned.
+- Signal shift, regime-gate N−1 read, close-evaluator closed-bar context (ATR/zscore/avwap),
+  funding `merge_asof(direction="backward")` + `searchsorted(side="right")` accrual,
+  `mtf_confluence`/`regime_adaptive_htf` in-frame resample visibility, and
+  `analog_retrieval` eligibility windows: all verified SAFE with existing regression tests.
+- **FIXED — EntryATR stamped from the fill bar's still-forming ATR** (`_stamp_entry_atr`
+  read `atr_series.loc[fill_bar]`, whose value incorporates that bar's own high/low/close,
+  unknown at the open where the entry fills). Live stamps the last closed bar's ATR at
+  order time. One-bar, geometry-only leak (never creates/blocks a signal) that
+  systematically flattered ATR-stop/TP stacks on volatile entry bars. Now reads the bar
+  before the fill; a first-bar fill has no closed prior bar and stamps 0 (evaluators
+  no-op, matching the existing no-usable-ATR convention). Regression:
+  `test_backtester_lookahead.py::test_entry_atr_stamped_from_bar_before_fill`.
+  Constant-ATR scenarios (most tests, and any run where ATR moves slowly) are unaffected;
+  results with fast-moving ATR at entry may shift slightly, in the conservative direction.
+- Not changed (documented conventions): trailing-trigger HWM seeded from the fill bar's
+  close is self-cancelling (the same bar's end-of-bar walker would raise the HWM to that
+  close anyway); the `_regime_bar_close` fallback branch when `regime_enabled` is false is
+  unreachable via the shipped `--config` wiring.
+
+### 2. Fill/accounting model — CLEAN (no fixes)
+
+- Signal-at-N-fills-at-N+1-open verified on every entry/exit/flip/partial path; fees per
+  leg mirror `fees.go` (parity-scraped test); funding sign/lag pinned; partial-close
+  quantity/avg-cost/`initial_quantity`/dust math correct; #1005 sticky liquidation floor
+  and its propagation through `eval_windows.py`/`fee_audit.py` fully verified and
+  test-pinned. Leverage is explicitly not modeled (fail-loud at load), not a silent gap.
+- Documented conventions, left as-is: funding books at loop-top (exit-bar charged,
+  entry-bar skipped — pinned as intended); short-entry commission based on committed
+  margin (~fee² divergence); per-trade `pnl` is gross of the entry fee (win-rate /
+  profit-factor classification only; cash/equity accounting is exact) — follow-up filed.
+
+### 3. Live-vs-backtest parity — two drifts (fixed), two latent gaps (fixed), one design gap (follow-up)
+
+Close-evaluator math is shared (the backtester dispatches through the same
+`shared_strategies/close/registry.py` the live check scripts use), so drift lives in
+input assembly and parsing mirrors:
+
+- **FIXED — unified #841 per-regime close block lost its stop-loss in backtest.** Live,
+  the block is the sole SL owner (`validateUnifiedCloseSoleOwner`) and
+  `unifiedCloseStopLossATR` arms the per-regime stop; the backtester discarded the SL the
+  shared helper returns and no other owner could exist — a unified close with
+  `stop_loss_atr` backtested with **no stop at all**, inflating results. The backtester
+  now resolves the stamped regime's `stop_loss_atr` as the run's fixed-SL mult and
+  rejects any second strategy-level SL owner, mirroring both Go behaviors.
+- **FIXED — `parse_regime_tp_tiers` didn't strip `sl_after`** before the ATR-block
+  allowlist parse (Go strips `close_fraction` AND `sl_after`; the CLAUDE.md guardrail was
+  never ported to the Python mirror). A per-tier `sl_after` on a regime tiered close
+  loaded in Go but errored in Python — failing backtest load AND silently never arming on
+  the live Python fire path, which re-parses through the same helper.
+- **FIXED — `parity_diff.py` never injected `user_defaults`** (live applies them
+  unconditionally at loadConfig), so it could report CLEAN against effective params live
+  never runs. Now loads with `inject_user_defaults=True`.
+- **FIXED — backtest directional-policy lookup missed the live bare→sub fallback**
+  (`Resolve` in `regime_directional_policy.go` lets a bare `ranging_directional` policy
+  entry cover `_up`/`_down` stamps, exact match winning first; cert gating stays exact
+  per #1124). Inert while the cert artifact is empty, but a real mirror gap once any cert
+  lands. The backtest gate now expands a bare entry onto uncovered subs before the
+  per-state cert check, and runtime resolution falls back bare→sub like live.
+- Verified PARITY: regime gating (#1025/#1124 one-directional family rule), #1085
+  evidence gate (default-off, fail-closed, exact cert lookup), reject list otherwise
+  exhaustive against `closeStrategyOwnedKeys` (mirror-enforced by Go test), default
+  ladders vs `defaultHLProtectionTiers`/`ratchetTierGroupDefaults`, #1135 user-defaults
+  injector mirror itself.
+- **Follow-up (design decision):** backtest `--defaults` defaults to `system` while live
+  applies `user_defaults` unconditionally — a default `--config` run can silently use
+  different effective tiers than live. Flipping the default changes existing baselines,
+  so it needs its own decision. Documented reverse drift (unchanged): `time_stop` /
+  `zscore_target` fire in backtest but live check scripts don't pass their inputs yet.
+
+### 4. Metrics — one ranking bug (fixed), two degenerate-input follow-ups
+
+- Sharpe/Sortino annualization, max-drawdown, #1005 sticky floor + sentinel overrides,
+  Calmar/annual-return guards: verified correct and test-pinned.
+- **FIXED — DDadj not floored for liquidated legs.** A blown leg reads return −100% /
+  DD −100%, so raw DDadj = −1.0 — outranking a surviving losing leg (−50%/25% DD =
+  −2.0) in M1 `ddadj`/`beats_ddadj` and in the optimizer's `dd_adjusted_return` metric.
+  Both consumers now floor liquidated legs to −100 (mirroring the #1005 Sharpe
+  sentinel), with a constant-sync test against `LIQUIDATED_METRIC_FLOOR`.
+- **Follow-ups:** Sortino uses sample-std of negative returns about their own mean and
+  needs ≥2 losing bars (a near-perfect leg scores a neutral 0.0) — changing the
+  definition re-baselines every documented study, so it needs its own pass;
+  `profit_factor = inf` on all-win legs would emit nonstandard JSON `Infinity` if ever
+  serialized (currently not forwarded to any JSON artifact).
+
+### 5. M-series validators + auto_suggest statistics — CLEAN (no fixes)
+
+- Benjamini–Hochberg: pooled once over the whole candidate family, correct step-up
+  formula, noise-family dedup keyed by family (siblings can't skip the downgrade),
+  `--only` runs stamped EXPLORATORY. Verified with existing tests.
+- `gross_edge_noise` sign-flip permutation (one-sided, add-one smoothing), the #1054
+  noise-before-selectivity ordering (enforced in `auto_suggest`), M6 exactly-one rule
+  (enforced at both spec load and `exit_policy_ab`), bootstrap/Wilcoxon/sign-test
+  implementations, and determinism (seeded stdlib `Random`): all correct.
+- Minor noted, not a defect: adjacent M1 windows share their boundary bar because
+  `load_ohlcv` uses an inclusive end bound while `gross_edge_noise` documents
+  `[start, end)` — one bar of equity per boundary, nil trade-level effect by the
+  N→N+1 fill construction. Tracked as a follow-up alongside the loader convention.
+
+### 6. Registry/doc conformance — CLEAN (no code changes)
+
+- Every executable `backtest/` script (25 root + 10 research) has a current registry
+  row; no orphan or materially stale rows; documented run commands match argparse.
+- Minor notes: `backtest/test_consolidation_research.py` sits at `backtest/` root
+  outside `tests/`; `backtest/AUDIT.md`, `backtest/THETA_HARVEST_RESULTS.md`, and two
+  in-tree `research/README_*.md` writeups fall outside the registry's declared
+  results locations; `auto_suggest.py` is listed under the M-series table though it's a
+  cross-harness driver. None affect correctness.
+
+## Baseline impact
+
+The EntryATR fix (and the unified-SL fix, for any config using a unified block) can shift
+historical results where ATR moved sharply between the signal bar and the fill bar; the
+DDadj floor changes rankings only for runs containing liquidated legs. Whether any
+documented study verdict (#983/#984/#1054/#1152/#1211, #1181 baselines) moves under the
+corrected geometry has NOT been re-measured here — re-running those studies is tracked as
+a follow-up. Any future re-run will reflect the corrected (closed-bar, generally more
+conservative) stop geometry.

--- a/shared_strategies/close/regime_atr.py
+++ b/shared_strategies/close/regime_atr.py
@@ -498,8 +498,14 @@ def parse_regime_tp_tiers(
         )
         # Strip non-classifier keys we recognize at the tier level before
         # parsing so the inner allowlist check focuses on the trend_regime
-        # block shape.
-        tier_subset = {k: v for k, v in item.items() if k != "close_fraction"}
+        # block shape. Mirrors Go (scheduler/regime_atr.go): close_fraction is
+        # handled by the tier-fraction logic below and sl_after by
+        # parse_strategy_tp_sl_after_rules — without stripping sl_after, a
+        # per-tier sl_after on a regime close failed the parse AND silently
+        # never armed at fire time, since the fire path re-parses through here.
+        tier_subset = {
+            k: v for k, v in item.items() if k not in ("close_fraction", "sl_after")
+        }
         sub_label = f"{ctx_label}.tiers[{idx}]"
         block, sub_errs = parse_regime_atr_block(
             tier_subset,

--- a/shared_strategies/close/regime_atr.py
+++ b/shared_strategies/close/regime_atr.py
@@ -64,7 +64,16 @@ def unified_regime_scalar_params(params: dict, regime: str):
     trend = params.get(REGIME_CLASSIFIER_KEY)
     if not isinstance(trend, dict):
         return None, 0.0
-    label = trend.get((regime or "").strip())
+    r = (regime or "").strip()
+    label = trend.get(r)
+    if not isinstance(label, dict):
+        # #1124: a ranging_directional_up/_down stamp falls back to the bare
+        # ranging_directional entry (exact match wins first). The unified close
+        # is the sole SL owner, so without this fallback a bare-only block
+        # yields no SL *and* no TPs for a sub-label stamp. Mirrors
+        # unifiedRegimeScalarParams in scheduler/regime_unified.go.
+        if r in ("ranging_directional_up", "ranging_directional_down"):
+            label = trend.get("ranging_directional")
     if not isinstance(label, dict) or "tp_tiers" not in label:
         return None, 0.0
     scalar = {"tp_tiers": label["tp_tiers"]}

--- a/shared_strategies/close/regime_atr.py
+++ b/shared_strategies/close/regime_atr.py
@@ -88,6 +88,148 @@ def unified_regime_scalar_params(params: dict, regime: str):
 
 REGIME_CLASSIFIER_KEY = "trend_regime"
 
+# Mirrors canonicalTrendRegimeLabels in scheduler/regime_atr.go.
+CANONICAL_TREND_REGIME_LABELS = ("trending_up", "trending_down", "ranging")
+
+_RANGING_DIRECTIONAL_BARE = "ranging_directional"
+_RANGING_DIRECTIONAL_SUBS = ("ranging_directional_up", "ranging_directional_down")
+
+
+def validate_unified_regime_close(params: dict, labels=None) -> List[str]:
+    """Validate a #841 unified per-regime close block. Mirrors Go's
+    validateUnifiedRegimeClose (scheduler/regime_unified.go): the label set
+    must be exhaustive against the vocabulary (bare ``ranging_directional``
+    covers its ``_up``/``_down`` subs, #1124), every label must be an object
+    carrying ``tp_tiers`` (>=2 valid tiers) AND a positive ``stop_loss_atr``
+    — the unified close owns the SL, so a label omitting it would simulate
+    (or run) that regime with no stop loss at all. Returns a list of error
+    strings (#1228 review round 3: the backtester must reject what live
+    rejects at load, never simulate a stopless regime silently)."""
+    errs: List[str] = []
+    for k in params or {}:
+        if k not in (REGIME_CLASSIFIER_KEY, "atr_source"):
+            errs.append(
+                f"unified close: unknown param {k!r} (allowed: trend_regime, atr_source)"
+            )
+    trend = (params or {}).get(REGIME_CLASSIFIER_KEY)
+    if not isinstance(trend, dict):
+        errs.append(f"unified close.{REGIME_CLASSIFIER_KEY}: must be an object")
+        return errs
+    label_vocab = list(labels) if labels else list(CANONICAL_TREND_REGIME_LABELS)
+    valid = set(label_vocab)
+    for l in sorted(set(trend) - valid):
+        errs.append(
+            f"unified close.{REGIME_CLASSIFIER_KEY}: unknown regime label {l!r} "
+            f"(expected one of: {', '.join(label_vocab)})"
+        )
+    bare_directional = trend.get(_RANGING_DIRECTIONAL_BARE) is not None
+    for l in label_vocab:
+        if l not in trend:
+            # #1124 family rule: a present bare ranging_directional covers the
+            # _up/_down sub-labels (runtime resolves via the bare fallback in
+            # unified_regime_scalar_params).
+            if bare_directional and l in _RANGING_DIRECTIONAL_SUBS:
+                continue
+            errs.append(
+                f"unified close.{REGIME_CLASSIFIER_KEY}: missing required regime "
+                f"label {l!r} (must be exhaustive — no silent fallback)"
+            )
+            continue
+        lm = trend[l]
+        if not isinstance(lm, dict):
+            errs.append(
+                f"unified close.{REGIME_CLASSIFIER_KEY}.{l}: must be an object"
+            )
+            continue
+        for k in lm:
+            if k not in ("stop_loss_atr", "tp_tiers"):
+                errs.append(
+                    f"unified close.{REGIME_CLASSIFIER_KEY}.{l}: unknown key {k!r} "
+                    "(allowed: stop_loss_atr, tp_tiers)"
+                )
+        # stop_loss_atr is required per label: the unified close owns the SL
+        # (sole-owner rejects strategy-level stops), so a regime omitting it
+        # would run/simulate a position with no stop loss at all. #841 review.
+        if "stop_loss_atr" not in lm:
+            errs.append(
+                f"unified close.{REGIME_CLASSIFIER_KEY}.{l}: missing required "
+                "'stop_loss_atr' (the unified close owns the per-regime SL)"
+            )
+        else:
+            try:
+                sl = float(lm["stop_loss_atr"])
+            except (TypeError, ValueError):
+                sl = -1.0
+            if not sl > 0:
+                errs.append(
+                    f"unified close.{REGIME_CLASSIFIER_KEY}.{l}.stop_loss_atr: "
+                    "must be > 0"
+                )
+        if "tp_tiers" not in lm:
+            errs.append(
+                f"unified close.{REGIME_CLASSIFIER_KEY}.{l}: missing required 'tp_tiers'"
+            )
+            continue
+        errs.extend(
+            _validate_unified_tier_list(
+                lm["tp_tiers"], f"unified close.{REGIME_CLASSIFIER_KEY}.{l}"
+            )
+        )
+    return errs
+
+
+def _validate_unified_tier_list(raw, ctx_label: str) -> List[str]:
+    """Mirrors validateUnifiedTierList in scheduler/regime_unified.go."""
+    if not isinstance(raw, list):
+        return [f"{ctx_label}.tp_tiers: must be a list, got {type(raw).__name__}"]
+    # >=2 tiers matches the on-chain resolver (strategyTPTiersForRegime returns
+    # nil for <2) — on HL-live a single-tier regime would emit no TP exit.
+    if len(raw) < 2:
+        return [f"{ctx_label}.tp_tiers: must have at least 2 tiers, got {len(raw)}"]
+    errs: List[str] = []
+    for i, item in enumerate(raw):
+        if not isinstance(item, dict):
+            errs.append(
+                f"{ctx_label}.tp_tiers[{i}]: must be an object, got {type(item).__name__}"
+            )
+            continue
+        try:
+            mult = float(item.get("atr_multiple"))
+        except (TypeError, ValueError):
+            mult = -1.0
+        if not mult > 0:
+            errs.append(f"{ctx_label}.tp_tiers[{i}].atr_multiple: must be > 0")
+        try:
+            frac = float(item.get("close_fraction"))
+        except (TypeError, ValueError):
+            frac = -1.0
+        if not (0 < frac <= 1):
+            errs.append(f"{ctx_label}.tp_tiers[{i}].close_fraction: must be in (0, 1]")
+        if "sl_after" in item:
+            try:
+                from post_tp_sl import parse_sl_after_rule, validate_sl_after_rule
+            except ImportError:  # direct-module import contexts
+                from .post_tp_sl import parse_sl_after_rule, validate_sl_after_rule
+            try:
+                rule = parse_sl_after_rule(item["sl_after"])
+                validate_sl_after_rule(rule)
+            except ValueError as e:
+                errs.append(f"{ctx_label}.tp_tiers[{i}].sl_after: {e}")
+            else:
+                if rule.has_regime():
+                    errs.append(
+                        f"{ctx_label}.tp_tiers[{i}].sl_after: must be scalar in a "
+                        "unified per-regime block (the regime is resolved at the "
+                        "top level; drop the trend_regime sub-block)"
+                    )
+        for k in item:
+            if k not in ("atr_multiple", "close_fraction", "sl_after"):
+                errs.append(
+                    f"{ctx_label}.tp_tiers[{i}]: unknown key {k!r} "
+                    "(allowed: atr_multiple, close_fraction, sl_after)"
+                )
+    return errs
+
 # regimeATRSurface equivalents — kept as string constants so the parser's
 # error messages match Go's surface-specific allowlists.
 SURFACE_STOP_LOSS = "stop_loss"

--- a/shared_strategies/close/test_post_tp_sl.py
+++ b/shared_strategies/close/test_post_tp_sl.py
@@ -376,3 +376,39 @@ def test_validate_breakeven_rejects_regime_block():
     rule = SLAfterRule(kind="breakeven", atr_regime=object())  # type: ignore[arg-type]
     with pytest.raises(ValueError):
         validate_sl_after_rule(rule)
+
+
+def test_parse_strategy_tp_sl_after_rules_regime_close_per_tier_sl_after():
+    # #1228 parity: a per-tier sl_after on a tiered_tp_atr_regime close loads
+    # in Go but errored in the Python mirror (parse_regime_tp_tiers rejected
+    # the sl_after sibling key), so the rule silently never armed at fire
+    # time. The regime-resolved parse must succeed and align the rule.
+    close_refs = [
+        {
+            "name": "tiered_tp_atr_regime",
+            "params": {
+                "tp_tiers": [
+                    {
+                        "trend_regime": {
+                            "trending_up": {"atr_multiple": 2.0, "close_fraction": 0.5},
+                            "trending_down": {"atr_multiple": 2.0, "close_fraction": 0.5},
+                            "ranging": {"atr_multiple": 1.5, "close_fraction": 0.5},
+                        },
+                        "sl_after": "breakeven",
+                    },
+                    {
+                        "trend_regime": {
+                            "trending_up": {"atr_multiple": 4.0, "close_fraction": 1.0},
+                            "trending_down": {"atr_multiple": 4.0, "close_fraction": 1.0},
+                            "ranging": {"atr_multiple": 3.0, "close_fraction": 1.0},
+                        },
+                    },
+                ],
+            },
+        }
+    ]
+    rules, errs = parse_strategy_tp_sl_after_rules(close_refs, regime="ranging")
+    assert errs == [], errs
+    assert len(rules.per_tier) == 2
+    assert rules.per_tier[0].kind == "breakeven"
+    assert rules.per_tier[1].kind == ""

--- a/shared_strategies/close/test_regime_atr.py
+++ b/shared_strategies/close/test_regime_atr.py
@@ -347,3 +347,59 @@ def test_unified_scalar_params_no_bare_no_sub_misses(regime_atr):
         {"trend_regime": {"ranging_directional": {
             "tp_tiers": [], "stop_loss_atr": 1.0}}}, "trending_down")
     assert scalar is None and sl == 0.0
+
+
+def _unified_params_1228(**overrides):
+    far = [{"atr_multiple": 2.0, "close_fraction": 0.5},
+           {"atr_multiple": 3.0, "close_fraction": 1.0}]
+    block = {}
+    for lab in ("ranging", "trending_up", "trending_down"):
+        block[lab] = {"tp_tiers": [dict(t) for t in far], "stop_loss_atr": 1.0}
+    for lab, entry in overrides.items():
+        block[lab] = entry
+    return {"trend_regime": block}
+
+
+def test_validate_unified_regime_close_accepts_valid_block(regime_atr):
+    assert regime_atr.validate_unified_regime_close(_unified_params_1228()) == []
+
+
+def test_validate_unified_regime_close_requires_positive_sl(regime_atr):
+    # #1228 round 3 — mirrors scheduler/regime_unified.go: stop_loss_atr is
+    # required per label and must be > 0 (the unified close owns the SL).
+    p = _unified_params_1228()
+    del p["trend_regime"]["trending_up"]["stop_loss_atr"]
+    errs = regime_atr.validate_unified_regime_close(p)
+    assert any("missing required 'stop_loss_atr'" in e for e in errs)
+    p = _unified_params_1228()
+    p["trend_regime"]["ranging"]["stop_loss_atr"] = 0
+    errs = regime_atr.validate_unified_regime_close(p)
+    assert any("must be > 0" in e for e in errs)
+
+
+def test_validate_unified_regime_close_exhaustive_and_tiers(regime_atr):
+    p = _unified_params_1228()
+    del p["trend_regime"]["ranging"]
+    errs = regime_atr.validate_unified_regime_close(p)
+    assert any("missing required regime label 'ranging'" in e for e in errs)
+    p = _unified_params_1228()
+    p["trend_regime"]["ranging"]["tp_tiers"] = [
+        {"atr_multiple": 2.0, "close_fraction": 1.0}]
+    errs = regime_atr.validate_unified_regime_close(p)
+    assert any("at least 2 tiers" in e for e in errs)
+
+
+def test_validate_unified_regime_close_bare_covers_subs(regime_atr):
+    labels = ("ranging_directional", "ranging_directional_up",
+              "ranging_directional_down", "ranging_quiet")
+    far = [{"atr_multiple": 2.0, "close_fraction": 0.5},
+           {"atr_multiple": 3.0, "close_fraction": 1.0}]
+    p = {"trend_regime": {
+        "ranging_directional": {"tp_tiers": far, "stop_loss_atr": 1.0},
+        "ranging_quiet": {"tp_tiers": far, "stop_loss_atr": 1.0},
+    }}
+    assert regime_atr.validate_unified_regime_close(p, labels=labels) == []
+    # Without the bare entry the subs are genuinely missing.
+    del p["trend_regime"]["ranging_directional"]
+    errs = regime_atr.validate_unified_regime_close(p, labels=labels)
+    assert any("ranging_directional_up" in e for e in errs)

--- a/shared_strategies/close/test_regime_atr.py
+++ b/shared_strategies/close/test_regime_atr.py
@@ -291,3 +291,59 @@ def test_tier_sl_after_sibling_stripped_before_atr_parse(regime_atr):
     )
     assert errs == [], errs
     assert len(specs) == 2
+
+
+def test_unified_scalar_params_bare_covers_directional_subs(regime_atr):
+    # #1124/#1228 review: a bare-only unified block must resolve for a
+    # ranging_directional_up/_down stamp (mirrors Go unifiedRegimeScalarParams
+    # — the unified close is the sole SL owner, so a miss means no SL AND no
+    # TPs for the sub-label stamp).
+    params = {
+        "trend_regime": {
+            "ranging_directional": {
+                "tp_tiers": [{"atr_multiple": 2.0, "close_fraction": 1.0}],
+                "stop_loss_atr": 1.5,
+            },
+        },
+    }
+    for sub in ("ranging_directional_up", "ranging_directional_down"):
+        scalar, sl = regime_atr.unified_regime_scalar_params(params, sub)
+        assert scalar == {"tp_tiers": [{"atr_multiple": 2.0, "close_fraction": 1.0}]}
+        assert sl == 1.5
+
+
+def test_unified_scalar_params_explicit_sub_wins_over_bare(regime_atr):
+    params = {
+        "trend_regime": {
+            "ranging_directional": {
+                "tp_tiers": [{"atr_multiple": 2.0, "close_fraction": 1.0}],
+                "stop_loss_atr": 1.5,
+            },
+            "ranging_directional_up": {
+                "tp_tiers": [{"atr_multiple": 4.0, "close_fraction": 1.0}],
+                "stop_loss_atr": 0.9,
+            },
+        },
+    }
+    scalar, sl = regime_atr.unified_regime_scalar_params(
+        params, "ranging_directional_up")
+    assert scalar["tp_tiers"][0]["atr_multiple"] == 4.0
+    assert sl == 0.9
+    # The sibling sub still rides the bare entry.
+    _, sl_down = regime_atr.unified_regime_scalar_params(
+        params, "ranging_directional_down")
+    assert sl_down == 1.5
+
+
+def test_unified_scalar_params_no_bare_no_sub_misses(regime_atr):
+    params = {"trend_regime": {
+        "trending_up": {"tp_tiers": [], "stop_loss_atr": 1.0},
+    }}
+    scalar, sl = regime_atr.unified_regime_scalar_params(
+        params, "ranging_directional_up")
+    assert scalar is None and sl == 0.0
+    # Bare never covers non-family labels either.
+    scalar, sl = regime_atr.unified_regime_scalar_params(
+        {"trend_regime": {"ranging_directional": {
+            "tp_tiers": [], "stop_loss_atr": 1.0}}}, "trending_down")
+    assert scalar is None and sl == 0.0

--- a/shared_strategies/close/test_regime_atr.py
+++ b/shared_strategies/close/test_regime_atr.py
@@ -263,3 +263,31 @@ def test_composite_explicit_sublabel_wins_over_bare(regime_atr):
     assert errs == [], errs
     assert block.resolve("ranging_directional_up").atr == 0.9
     assert block.resolve("ranging_directional_down").atr == 1.5  # bare fallback
+
+
+def test_tier_sl_after_sibling_stripped_before_atr_parse(regime_atr):
+    # #1228 parity: Go strips both close_fraction AND sl_after before the
+    # ATR-block allowlist parse (scheduler/regime_atr.go). A per-tier
+    # sl_after on a regime TP tier must not trip the unknown-key check.
+    raw_tiers = [
+        {
+            regime_atr.REGIME_CLASSIFIER_KEY: {
+                "trending_up": {"atr_multiple": 3.0, "close_fraction": 0.4},
+                "trending_down": {"atr_multiple": 3.0, "close_fraction": 0.4},
+                "ranging": {"atr_multiple": 1.5, "close_fraction": 0.6},
+            },
+            "sl_after": "breakeven",
+        },
+        {
+            regime_atr.REGIME_CLASSIFIER_KEY: {
+                "trending_up": {"atr_multiple": 5.0, "close_fraction": 1.0},
+                "trending_down": {"atr_multiple": 5.0, "close_fraction": 1.0},
+                "ranging": {"atr_multiple": 3.0, "close_fraction": 1.0},
+            },
+        },
+    ]
+    specs, errs = regime_atr.parse_regime_tp_tiers(
+        raw_tiers, "tiered_tp_atr_regime", False
+    )
+    assert errs == [], errs
+    assert len(specs) == 2


### PR DESCRIPTION
Closes #1228

End-to-end audit of the backtest system per the issue's six subsystems, with every confirmed verdict-affecting defect fixed and regression-tested red→green against origin/main. Full per-subsystem report: `docs/research/1228-backtest-audit.md`.

## Fixed (5 defects)

1. **EntryATR look-ahead** — `_stamp_entry_atr` read the fill bar's still-forming ATR; stop/TP geometry leaked that bar's own range. Now reads the last closed bar before the fill, matching live's order-time stamp (`backtest/backtester.py`).
2. **Unified #841 per-regime close backtested with no stop-loss** — the block's per-regime `stop_loss_atr` was discarded in simulation while live validation guarantees no other SL owner exists. The backtester now arms it as the run's fixed SL for the stamped regime and rejects a second strategy-level SL owner (mirrors `unifiedCloseStopLossATR` + `validateUnifiedCloseSoleOwner`).
3. **`parse_regime_tp_tiers` missing the `sl_after` strip** (shared live+backtest helper) — a per-tier `sl_after` on a regime tiered close failed config load AND silently never armed on the Python fire path; Go has stripped it since the original guardrail (`shared_strategies/close/regime_atr.py`).
4. **DDadj not floored for liquidated legs** — a blown-up leg raw-scored −1.0 and outranked surviving losers in M1 rankings and the optimizer's `dd_adjusted_return`; both now floor to −100, mirroring the #1005 Sharpe sentinel (`backtest/eval_windows.py`, `backtest/optimizer.py`).
5. **Parity blind spots** — `parity_diff.py` now injects `user_defaults` like live's loadConfig, and the backtest directional-policy gate/resolution mirrors live's #1124 bare→sub fallback (`backtest/parity_diff.py`, `backtest/backtester.py`).

## Audited clean (no change needed)

Fill model (N→N+1), fees/funding/partial-close/flip accounting, #1005 floor propagation, Sharpe/Sortino/DD math, BH correction + noise gate + M6 exactly-one rule, regime-gate and #1085 evidence-gate parity, backtesting-registry rows and commands.

## Follow-ups (named in the audit doc, to be filed)

`--defaults system` vs live's unconditional user_defaults; entry-fee-gross per-trade PnL classification; nonstandard Sortino degenerate; window boundary-bar inclusivity; re-measuring documented study baselines under the corrected geometry.

## Verification

- Baseline before changes: backtest/tests 1069 passed / 1 skipped; remaining suite 1234 passed.
- Every fix proven red on origin/main code, green after (16 new regression tests).
- Full suite after: 2318 passed. `go -C scheduler build .` clean; smoke `run_backtest.py --mode single` runs end-to-end.

---
Created with LLM: Fable 5 | high | Harness: Claude Code
